### PR TITLE
Graduate TSHttpTxnServerPush to the stable API interface

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
+.. function:: TSReturnCode TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
 
 Description
 ===========
@@ -39,6 +39,9 @@ This API works only if the protocol of a transaction supports Server Push and it
 is not disabled by the client. You can call this API without checking whether
 Server Push is available on the transaction and it does nothing if Server Push
 is not available.
+
+This API returns an error if the URL to push is not valid, the client has Server Push disabled,
+or there is an error creating the H/2 PUSH_PROMISE frame.
 
 See Also
 ========

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
@@ -26,7 +26,7 @@ Synopsis
 
 .. code-block:: cpp
 
-    #include <ts/experimental.h>
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
 
@@ -39,12 +39,6 @@ This API works only if the protocol of a transaction supports Server Push and it
 is not disabled by the client. You can call this API without checking whether
 Server Push is available on the transaction and it does nothing if Server Push
 is not available.
-
-
-Notes
-=====
-
-This API may be changed in the future version since it is experimental.
 
 See Also
 ========

--- a/example/plugins/c-api/server_push/server_push.c
+++ b/example/plugins/c-api/server_push/server_push.c
@@ -36,7 +36,6 @@
 #include <ctype.h>
 
 #include "ts/ts.h"
-#include "ts/experimental.h"
 #include "tscore/ink_defs.h"
 
 const char *PLUGIN_NAME = "server_push";

--- a/include/ts/experimental.h
+++ b/include/ts/experimental.h
@@ -244,8 +244,6 @@ tsapi TSReturnCode TSHttpTxnUpdateCachedObject(TSHttpTxn txnp);
  ****************************************************************************/
 tsapi int TSHttpTxnLookingUpTypeGet(TSHttpTxn txnp);
 
-tsapi void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len);
-
 /* ip addr parsing */
 tsapi TSReturnCode TSIpStringToAddr(const char *str, size_t str_len, struct sockaddr *addr);
 

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2535,6 +2535,15 @@ tsapi TSReturnCode TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp);
  */
 tsapi TSIOBufferReader TSHttpTxnPostBufferReaderGet(TSHttpTxn txnp);
 
+/**
+ * Initiate an HTTP/2 Server Push preload request.
+ * Use this api to register a URL that you want to preload with HTTP/2 Server Push.
+ *
+ * @param url the URL string to preload.
+ * @param url_len the length of the URL string.
+ */
+tsapi void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2542,7 +2542,7 @@ tsapi TSIOBufferReader TSHttpTxnPostBufferReaderGet(TSHttpTxn txnp);
  * @param url the URL string to preload.
  * @param url_len the length of the URL string.
  */
-tsapi void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len);
+tsapi TSReturnCode TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len);
 
 #ifdef __cplusplus
 }

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -50,6 +50,7 @@ include regex_remap/Makefile.inc
 include regex_revalidate/Makefile.inc
 include remap_purge/Makefile.inc
 include s3_auth/Makefile.inc
+include server_push_preload/Makefile.inc
 include stats_over_http/Makefile.inc
 include tcpinfo/Makefile.inc
 include xdebug/Makefile.inc
@@ -73,7 +74,6 @@ include experimental/money_trace/Makefile.inc
 include experimental/mp4/Makefile.inc
 include experimental/redo_cache_lookup/Makefile.inc
 include experimental/remap_stats/Makefile.inc
-include experimental/server_push_preload/Makefile.inc
 include experimental/slice/Makefile.inc
 include experimental/sslheaders/Makefile.inc
 include experimental/stream_editor/Makefile.inc

--- a/plugins/experimental/server_push_preload/README.md
+++ b/plugins/experimental/server_push_preload/README.md
@@ -1,3 +1,0 @@
-Parse origin response Link headers and use H2 Server Push to initiate push requests of assets that have the preload keyword.
-
-https://www.w3.org/TR/preload/

--- a/plugins/server_push_preload/Makefile.inc
+++ b/plugins/server_push_preload/Makefile.inc
@@ -14,14 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-pkglib_LTLIBRARIES += experimental/server_push_preload/server_push_preload.la
+pkglib_LTLIBRARIES += server_push_preload/server_push_preload.la
 
-experimental_server_push_preload_server_push_preload_la_SOURCES = \
-  experimental/server_push_preload/server_push_preload.cc
+server_push_preload_server_push_preload_la_SOURCES = \
+  server_push_preload/server_push_preload.cc
 
-experimental_server_push_preload_server_push_preload_la_LDFLAGS = \
+server_push_preload_server_push_preload_la_LDFLAGS = \
   $(AM_LDFLAGS)
 
-experimental_server_push_preload_server_push_preload_la_LIBADD = \
+server_push_preload_server_push_preload_la_LIBADD = \
   $(top_builddir)/src/tscpp/api/libtscppapi.la
 

--- a/plugins/server_push_preload/README.md
+++ b/plugins/server_push_preload/README.md
@@ -1,0 +1,17 @@
+Parse origin response Link headers and use H2 Server Push to initiate push requests of assets that have the preload keyword.
+
+https://www.w3.org/TR/preload/
+
+This plugin can be used as a global plugin or a remap plugin.
+
+To use it as a global plugin for all your remaps, add this line to your `plugins.config` file:
+
+```
+server_push_preload.so
+```
+
+To use it as a remap plugin add it to one of your remaps in the `remap.config` file:
+
+```
+map https://foo.cow.com/ https://bar.cow.com @plugin=server_push_preload.so
+```

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1639,7 +1639,7 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   ats_free(buf);
 }
 
-void
+bool
 Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding)
 {
   HTTPHdr h1_hdr, h2_hdr;
@@ -1651,7 +1651,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   uint8_t flags               = 0x00;
 
   if (client_settings.get(HTTP2_SETTINGS_ENABLE_PUSH) == 0) {
-    return;
+    return false;
   }
 
   Http2StreamDebug(ua_session, stream->get_id(), "Send PUSH_PROMISE frame");
@@ -1681,14 +1681,14 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   buf = static_cast<uint8_t *>(ats_malloc(buf_len));
   if (buf == nullptr) {
     h2_hdr.destroy();
-    return;
+    return false;
   }
   Http2ErrorCode result = http2_encode_header_blocks(&h2_hdr, buf, buf_len, &header_blocks_size, *(this->remote_hpack_handle),
                                                      client_settings.get(HTTP2_SETTINGS_HEADER_TABLE_SIZE));
   if (result != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
     h2_hdr.destroy();
     ats_free(buf);
-    return;
+    return false;
   }
 
   // Send a PUSH_PROMISE frame
@@ -1736,7 +1736,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   stream = this->create_stream(id, error);
   if (!stream) {
     h2_hdr.destroy();
-    return;
+    return false;
   }
 
   SCOPED_MUTEX_LOCK(stream_lock, stream->mutex, this_ethread());
@@ -1759,6 +1759,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   stream->send_request(*this);
 
   h2_hdr.destroy();
+  return true;
 }
 
 void

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -247,7 +247,7 @@ public:
   void send_data_frames(Http2Stream *stream);
   Http2SendDataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
   void send_headers_frame(Http2Stream *stream);
-  void send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding);
+  bool send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding);
   void send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec);
   void send_settings_frame(const Http2ConnectionSettings &new_settings);
   void send_ping_frame(Http2StreamId id, uint8_t flag, const uint8_t *opaque_data);

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -683,12 +683,12 @@ Http2Stream::signal_write_event(bool call_update)
   }
 }
 
-void
+bool
 Http2Stream::push_promise(URL &url, const MIMEField *accept_encoding)
 {
   Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
   SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
-  h2_proxy_ssn->connection_state.send_push_promise_frame(this, url, accept_encoding);
+  return h2_proxy_ssn->connection_state.send_push_promise_frame(this, url, accept_encoding);
 }
 
 void

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -75,7 +75,7 @@ public:
   void update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
   void signal_write_event(bool call_update);
   void restart_sending();
-  void push_promise(URL &url, const MIMEField *accept_encoding);
+  bool push_promise(URL &url, const MIMEField *accept_encoding);
 
   // Stream level window size
   ssize_t client_rwnd() const;

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -8031,7 +8031,7 @@ TSHttpTxnIsInternal(TSHttpTxn txnp)
   return TSHttpSsnIsInternal(TSHttpTxnSsnGet(txnp));
 }
 
-void
+TSReturnCode
 TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
@@ -8040,26 +8040,37 @@ TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
   url_obj.create(nullptr);
   if (url_obj.parse(url, url_len) == PARSE_RESULT_ERROR) {
     url_obj.destroy();
-    return;
+    return TS_ERROR;
   }
 
   HttpSM *sm          = reinterpret_cast<HttpSM *>(txnp);
   Http2Stream *stream = dynamic_cast<Http2Stream *>(sm->ua_txn);
-  if (stream) {
-    Http2ClientSession *ua_session = static_cast<Http2ClientSession *>(stream->get_proxy_ssn());
-    SCOPED_MUTEX_LOCK(lock, ua_session->mutex, this_ethread());
-    if (!ua_session->connection_state.is_state_closed() && !ua_session->is_url_pushed(url, url_len)) {
-      HTTPHdr *hptr = &(sm->t_state.hdr_info.client_request);
-      TSMLoc obj    = reinterpret_cast<TSMLoc>(hptr->m_http);
-
-      MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(obj);
-      MIMEField *f    = mime_hdr_field_find(mh, MIME_FIELD_ACCEPT_ENCODING, MIME_LEN_ACCEPT_ENCODING);
-      stream->push_promise(url_obj, f);
-
-      ua_session->add_url_to_pushed_table(url, url_len);
-    }
+  if (stream == nullptr) {
+    url_obj.destroy();
+    return TS_ERROR;
   }
+
+  Http2ClientSession *ua_session = static_cast<Http2ClientSession *>(stream->get_proxy_ssn());
+  SCOPED_MUTEX_LOCK(lock, ua_session->mutex, this_ethread());
+  if (ua_session->connection_state.is_state_closed() || ua_session->is_url_pushed(url, url_len)) {
+    url_obj.destroy();
+    return TS_ERROR;
+  }
+
+  HTTPHdr *hptr = &(sm->t_state.hdr_info.client_request);
+  TSMLoc obj    = reinterpret_cast<TSMLoc>(hptr->m_http);
+
+  MIMEHdrImpl *mh = _hdr_mloc_to_mime_hdr_impl(obj);
+  MIMEField *f    = mime_hdr_field_find(mh, MIME_FIELD_ACCEPT_ENCODING, MIME_LEN_ACCEPT_ENCODING);
+  if (!stream->push_promise(url_obj, f)) {
+    url_obj.destroy();
+    return TS_ERROR;
+  }
+
+  ua_session->add_url_to_pushed_table(url, url_len);
+
   url_obj.destroy();
+  return TS_SUCCESS;
 }
 
 TSReturnCode


### PR DESCRIPTION
We learned in the Fall Summit 2019 that this API is being used in production quite heavily in certain fruit company.

It would make sense to move this API and the plugin that's in experimental to the stable API section in ts.h.

In this change, I also modified the server_push_preload plugin to be able to load it as a RemapPlugin, since it was only a global plugin until now.