### PR TITLE
Fix HttpTunnel flow_control to work with http2

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -748,7 +748,7 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
     // we have to keep reading until we give the user all the
     // bytes it wanted or we hit the watermark.
-    if (vio.ntodo() > 0 && !vio.buffer.writer()->high_water()) {
+    if (vio.ntodo() > 0 && !vio.buffer.writer()->high_water() && !vio.is_disabled()) {
       goto Lread;
     }
     return EVENT_CONT;

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -102,6 +102,16 @@ public:
   Http1ServerSession *get_server_session() const;
   HttpSM *get_sm() const;
 
+  /** Compute the backlog.  This is the amount of data ready to read
+      for each element of the chain.  If @a limit is non-negative then
+      the method will return as soon as the computed backlog is at
+      least that large. This provides for more efficient checking if
+      the caller is interested only in whether the backlog is at least
+      @a limit. The default is to accurately compute the backlog.
+  */
+  virtual uint64_t backlog(uint64_t limit = UINT64_MAX ///< Maximum value of interest
+                           ) = 0;
+
   // This function must return a non-negative number that is different for two in-progress transactions with the same proxy_ssn
   // session.
   //

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -97,7 +97,8 @@ Http1Transaction::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 VIO *
 Http1Transaction::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
 {
-  return _proxy_ssn->do_io_write(c, nbytes, buf, owner);
+  write_vio = _proxy_ssn->do_io_write(c, nbytes, buf, owner);
+  return write_vio;
 }
 
 void
@@ -146,4 +147,17 @@ Http1Transaction::get_transaction_id() const
   // identifier.
   //
   return _proxy_ssn->get_transact_count();
+}
+
+uint64_t
+Http1Transaction::backlog(uint64_t limit)
+{
+  uint64_t retval = 0;
+  if (write_vio) {
+    IOBufferReader *r = this->write_vio->get_reader();
+    if (r) {
+      retval = static_cast<uint64_t>(r->read_avail());
+    }
+  }
+  return retval;
 }

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -58,9 +58,12 @@ public:
 
   void set_reader(IOBufferReader *reader);
 
+  uint64_t backlog(uint64_t limit = UINT64_MAX) override;
+
   ////////////////////
   // Variables
 
 protected:
   bool outbound_transparent{false};
+  VIO *write_vio = nullptr;
 };

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -563,6 +563,7 @@ HttpTunnelProducer::is_throttled() const
 inline void
 HttpTunnelProducer::throttle()
 {
+  this->read_vio->disable();
   if (!this->is_throttled()) {
     this->set_throttle_src(this);
   }

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -369,17 +369,20 @@ Http2ClientSession::main_event_handler(int event, void *edata)
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_ERROR:
   case VC_EVENT_EOS:
+    Http2SsnDebug("%s (%d)", get_vc_event_name(event), event);
+
     this->set_dying_event(event);
     this->do_io_close();
     retval = 0;
     break;
 
   case VC_EVENT_WRITE_READY:
-    retval = 0;
-    break;
-
   case VC_EVENT_WRITE_COMPLETE:
-    // Seems as this is being closed already
+    Http2SsnDebug("%s (%d)", get_vc_event_name(event), event);
+
+    this->connection_state.restart_streams();
+    this->write_vio->reenable();
+
     retval = 0;
     break;
 
@@ -770,4 +773,10 @@ int64_t
 Http2ClientSession::write_buffer_size()
 {
   return write_buffer->max_read_avail();
+}
+
+int64_t
+Http2ClientSession::write_avail()
+{
+  return this->write_buffer->write_avail();
 }

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -212,6 +212,8 @@ public:
   // Record history from Http2ConnectionState
   void remember(const SourceLocation &location, int event, int reentrant = NO_REENTRANT);
 
+  int64_t write_avail();
+
   // noncopyable
   Http2ClientSession(Http2ClientSession &) = delete;
   Http2ClientSession &operator=(const Http2ClientSession &) = delete;
@@ -219,6 +221,12 @@ public:
   ///////////////////
   // Variables
   Http2ConnectionState connection_state;
+
+  IOBufferReader *
+  get_write_reader()
+  {
+    return sm_writer;
+  }
 
 private:
   int main_event_handler(int, void *);

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -74,7 +74,7 @@ public:
   void terminate_if_possible();
   void update_read_request(int64_t read_len, bool send_update, bool check_eos = false);
   void update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
-  void signal_write_event(bool call_update);
+  bool signal_write_event(bool call_update);
   void restart_sending();
   void push_promise(URL &url, const MIMEField *accept_encoding);
 
@@ -121,6 +121,7 @@ public:
   void update_initial_rwnd(Http2WindowSize new_size);
   bool has_trailing_header() const;
   void set_request_headers(HTTPHdr &h2_headers);
+  uint64_t backlog(uint64_t limit = UINT64_MAX) override;
 
   //////////////////
   // Variables


### PR DESCRIPTION
Changes I made a while back to enable the HttpTunnel flow control to work with Http/2 and from cache.

Had to fix the cache to not serve if the vio was disabled.

Also added a backlog virtual method to compute the total amount of buffer used by the Http2 client.