### PR TITLE
Fix our doc build system to handle non-sourcedir configure locations

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -51,7 +51,7 @@ I18NSPHINXOPTS  = $(SPHINXOPTS)
 # The PAPER setting variables requires recursive make variable expansion, which automake
 # detects as non-portable. We bounce this through a shell script and do the expansion there.
 SBUILD = PAPEROPT_a4="$(PAPEROPT_a4)" PAPEROPT_letter="$(PAPEROPT_letter)" PAPER="$(PAPER)" \
-	PLANTUML_JAR="$(shell ext/plantuml_fetch.sh | tail -1)" \
+	PLANTUML_JAR="$(shell $(srcdir)/ext/plantuml_fetch.sh | tail -1)" \
 	$(srcdir)/sbuild "$(SPHINXBUILD)" \
 	-c $(srcdir) \
 	$(ALLSPHINXOPTS)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,6 @@ from sphinx import version_info
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('ext'))
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -57,7 +56,7 @@ extensions = [
 ]
 
 # Contains values that are dependent on configure.ac.
-LOCAL_CONFIG = 'ext/local-config.py'
+LOCAL_CONFIG = os.path.join(os.environ['PWD'], "ext", "local-config.py")
 with open(LOCAL_CONFIG) as f :
     exec(compile(f.read(), LOCAL_CONFIG, 'exec'))
 

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -31,9 +31,10 @@ from docutils.parsers import rst
 from docutils.parsers.rst import directives
 from sphinx.domains import Domain, ObjType, std
 from sphinx.roles import XRefRole
-from sphinx.locale import l_, _
+from sphinx.locale import  _
 import sphinx
 
+import os
 import subprocess
 import re
 
@@ -374,13 +375,18 @@ class TrafficServerDomain(Domain):
 
 
 # get the branch this documentation is building for in X.X.x form
-with open('../configure.ac', 'r') as f:
+REPO_ROOT = os.path.join(os.path.dirname(os.path.dirname(
+        os.environ['DOCUTILSCONFIG'])))
+CONFIGURE_AC = os.path.join(REPO_ROOT, 'configure.ac')
+with open(CONFIGURE_AC, 'r') as f:
     contents = f.read()
     match = re.compile(r'm4_define\(\[TS_VERSION_S],\[(.*?)]\)').search(contents)
     autoconf_version = '.'.join(match.group(1).split('.', 2)[:2] + ['x'])
 
 # get the current branch the local repository is on
-git_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+REPO_GIT_DIR = os.path.join(REPO_ROOT, ".git")
+git_branch = subprocess.check_output(['git', '--git-dir', REPO_GIT_DIR,
+                                      'rev-parse', '--abbrev-ref', 'HEAD'])
 
 
 def make_github_link(name, rawtext, text, lineno, inliner, options={}, content=[]):

--- a/doc/uml/Makefile.am
+++ b/doc/uml/Makefile.am
@@ -19,7 +19,7 @@
 if BUILD_DOCS
 images := $(patsubst %.uml,images/%.svg,$(wildcard *.uml))
 images += $(patsubst %.plantuml,images/%.svg,$(wildcard *.plantuml))
-PLANTUML_JAR := $(shell ../ext/plantuml_fetch.sh | tail -1)
+PLANTUML_JAR := $(shell $(srcdir)/../ext/plantuml_fetch.sh | tail -1)
 
 all-am: jar-check $(images)
 endif


### PR DESCRIPTION
I generally configure from a directory outside of source so my built object files don't pollute my source tree. I noticed that ATS generally supports this but had problems if --enable-docs was passed to configure because our doc make and config files had a hard-coded expectation of being run from the source tree. This addresses the issues I found.

To test this, I built the install and html targets from both a tree configured in source (to make sure I didn't break anything for that situation) and outside of source and both ran successfully.