### PR TITLE
Add basic SystemTap markers support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2070,6 +2070,25 @@ AC_CHECK_TYPE([struct tcp_info],
   ]]
 )
 
+AC_MSG_CHECKING([whether to include systemtap tracing support])
+AC_ARG_ENABLE([systemtap],
+              [AS_HELP_STRING([--enable-systemtap],
+                              [Enable inclusion of systemtap trace support])],
+              [ENABLE_SYSTEMTAP="${enableval}"], [ENABLE_SYSTEMTAP='no'])
+AM_CONDITIONAL([ENABLE_SYSTEMTAP], [test x$ENABLE_SYSTEMTAP = xyes])
+AC_MSG_RESULT(${ENABLE_SYSTEMTAP})
+
+if test "x${ENABLE_SYSTEMTAP}" = xyes; then
+  AC_CHECK_PROGS(DTRACE, dtrace)
+  if test -z "$DTRACE"; then
+    AC_MSG_ERROR([dtrace not found])
+  fi
+  AC_CHECK_HEADER([sys/sdt.h], [SDT_H_FOUND='yes'],
+                  [SDT_H_FOUND='no';
+                     AC_MSG_ERROR([systemtap support needs sys/sdt.h header])])
+  AC_DEFINE([HAVE_SYSTEMTAP], [1], [Define to 1 if using probes.])
+fi
+
 # See if we can build the remap_stats plugin
 AS_IF([test "x$enable_experimental_plugins" = "xyes"],
   [

--- a/doc/developer-guide/debugging/debug-builds.en.rst
+++ b/doc/developer-guide/debugging/debug-builds.en.rst
@@ -41,3 +41,22 @@ Debugging Tips:
 -  Use assertions in your plugin (:c:func:`TSAssert` and :c:func:`TSReleaseAssert`).
 
 
+SystemTap and DTrace support
+****************************
+
+Traffic Server can be instrumented with **SystemTap** on Linux systems, or
+**DTrace** on *BSDs and macOS. In order to use such tools, Traffic Server needs
+to be built with ``-g``, or the debug symbols need to be installed. On Debian
+systems, install the ``trafficserver-dbgsym`` package to install the debug
+symbols.
+
+In addition to the normal probe points that can be used with SystemTap and
+DTrace, such as function calls and specific statements, Traffic Server does
+provide SDT markers at various interesting code paths.
+
+Pass the ``--enable-systemtap`` flag to ``./configure`` in order to build
+Traffic Server with dtrace style markers (SDT). On Traffic Server builds with
+SDT markers enabled, you can list the available markers with ``stap -L
+'process("/path/to/traffic_server").mark("*")``.
+
+See the `SystemTap documentation <https://sourceware.org/systemtap/wiki/AddingUserSpaceProbingToApps>`_ and the `DTrace guide <http://dtrace.org/guide/chp-sdt.html>`_ for more information.

--- a/doc/release-notes/whats-new.en.rst
+++ b/doc/release-notes/whats-new.en.rst
@@ -30,6 +30,7 @@ have participated in this development cycle.
 
 New Features
 ------------
+- Add support for dtrace style markers (SDT) and include a few markers at locations of interest to users of SystemTap, dtrace, and gdb. See :ref:`developer-debug-builds`.
 
 New or modifed Configurations
 -----------------------------

--- a/include/ts/sdt.h
+++ b/include/ts/sdt.h
@@ -1,0 +1,40 @@
+/** @file
+
+    A brief file description
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#ifdef HAVE_SYSTEMTAP
+
+#include <sys/sdt.h>
+
+#define ATS_PROBE(probe) DTRACE_PROBE(trafficserver, probe)
+#define ATS_PROBE1(probe, param1) DTRACE_PROBE1(trafficserver, probe, param1)
+#define ATS_PROBE2(probe, param1, param2) DTRACE_PROBE2(trafficserver, probe, param1, param2)
+
+#else
+
+#define ATS_PROBE(...)
+#define ATS_PROBE1(...)
+#define ATS_PROBE2(...)
+
+#endif

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -44,6 +44,7 @@
 #include "IPAllow.h"
 #include "tscore/I_Layout.h"
 #include "tscore/bwf_std_format.h"
+#include "ts/sdt.h"
 
 #include <openssl/ossl_typ.h>
 #include <openssl/ssl.h>
@@ -1764,6 +1765,8 @@ HttpSM::state_http_server_open(int event, void *data)
     pending_action = nullptr;
 
     session->new_connection(vc);
+
+    ATS_PROBE1(new_origin_server_connection, t_state.current.server->name);
 
     session->state = HSS_ACTIVE;
     ats_ip_copy(&t_state.server_info.src_addr, netvc->get_local_addr());


### PR DESCRIPTION
Introduce a new ./configure flag, --enable-systemtap, to build
traffic_server with SystemTap markers support. Also include a marker
called "new_origin_server_connection" under the "trafficserver"
provider.

See https://sourceware.org/systemtap/wiki/AddingUserSpaceProbingToApps