### PR TITLE
Do not reload configs periodically

### DIFF
--- a/mgmt/ConfigManager.cc
+++ b/mgmt/ConfigManager.cc
@@ -95,12 +95,12 @@ ConfigManager::statFile(struct stat *buf)
   return statResult;
 }
 
-// bool ConfigManager::checkForUserUpdate()
+// bool ConfigManager::checkForUserUpdate(RollBackCheckType how)
 //
 //  Called to check if the file has been changed  by the user.
 //  Timestamps are compared to see if a change occurred
 bool
-ConfigManager::checkForUserUpdate()
+ConfigManager::checkForUserUpdate(RollBackCheckType how)
 {
   struct stat fileInfo;
   bool result;
@@ -113,10 +113,11 @@ ConfigManager::checkForUserUpdate()
   }
 
   if (fileLastModified < TS_ARCHIVE_STAT_MTIME(fileInfo)) {
-    fileLastModified = TS_ARCHIVE_STAT_MTIME(fileInfo);
-    configFiles->fileChanged(fileName, configName);
-    mgmt_log("User has changed config file %s\n", fileName);
-
+    if (how == ROLLBACK_CHECK_AND_UPDATE) {
+      fileLastModified = TS_ARCHIVE_STAT_MTIME(fileInfo);
+      configFiles->fileChanged(fileName, configName);
+      mgmt_log("User has changed config file %s\n", fileName);
+    }
     result = true;
   } else {
     result = false;

--- a/mgmt/ConfigManager.h
+++ b/mgmt/ConfigManager.h
@@ -31,6 +31,11 @@ class TextBuffer;
 
 class ExpandingArray;
 
+enum RollBackCheckType {
+  ROLLBACK_CHECK_AND_UPDATE,
+  ROLLBACK_CHECK_ONLY,
+};
+
 //
 //  class ConfigManager
 //
@@ -66,7 +71,7 @@ public:
   };
 
   // Check if a file has changed, automatically holds the lock. Used by FileManager.
-  bool checkForUserUpdate();
+  bool checkForUserUpdate(RollBackCheckType);
 
   // These are getters, for FileManager to get info about a particular configuration.
   const char *

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -177,7 +177,7 @@ FileManager::rereadConfig()
     rb = it.second;
     // ToDo: rb->isVersions() was always true before, because numberBackups was always >= 1. So ROLLBACK_CHECK_ONLY could not
     // happen at all...
-    if (rb->checkForUserUpdate()) {
+    if (rb->checkForUserUpdate(ROLLBACK_CHECK_AND_UPDATE)) {
       changedFiles.push_back(rb);
       if (rb->isChildManaged()) {
         if (std::find(parentFileNeedChange.begin(), parentFileNeedChange.end(), rb->getParentConfig()) ==
@@ -237,7 +237,7 @@ FileManager::isConfigStale()
   ink_mutex_acquire(&accessLock);
   for (auto &&it : bindings) {
     rb = it.second;
-    if (rb->checkForUserUpdate()) {
+    if (rb->checkForUserUpdate(ROLLBACK_CHECK_ONLY)) {
       stale = true;
       break;
     }


### PR DESCRIPTION
This partially reverts the changes made in #5603, it'll fix the behaviour where `remap.config` and some other configs files are being reloaded periodically right now.