### PR TITLE
Fix host type in host matcher.

### DIFF
--- a/src/tscore/HostLookup.cc
+++ b/src/tscore/HostLookup.cc
@@ -785,15 +785,15 @@ HostLookup::TableInsert(string_view match_data, int index, bool domain_record)
   //         leaf node to make sure we have a match
   if (domain_record == false) {
     if (match.empty()) {
-      leaf_array[index].type = HostLeaf::HOST_PARTIAL;
-    } else {
       leaf_array[index].type = HostLeaf::HOST_COMPLETE;
+    } else {
+      leaf_array[index].type = HostLeaf::HOST_PARTIAL;
     }
   } else {
     if (match.empty()) {
-      leaf_array[index].type = HostLeaf::DOMAIN_PARTIAL;
-    } else {
       leaf_array[index].type = HostLeaf::DOMAIN_COMPLETE;
+    } else {
+      leaf_array[index].type = HostLeaf::DOMAIN_PARTIAL;
     }
   }
 


### PR DESCRIPTION
Host type is partial when the number of subdomains in a hostname is more than default table depth; otherwise, it is complete.