### PR TITLE
Remove remnants of obsolete remap thread.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3970,15 +3970,6 @@ Plug-in Configuration
 
    Specifies the location of |TS| plugins.
 
-.. ts:cv:: CONFIG proxy.config.remap.num_remap_threads INT 0
-
-   When this variable is set to ``0``, plugin remap callbacks are
-   executed in line on network threads. If remap processing takes
-   significant time, this can be cause additional request latency.
-   Setting this variable to causes remap processing to take place
-   on a dedicated thread pool, freeing the network threads to service
-   additional requests.
-
 SOCKS Processor
 ===============
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1446,14 +1446,6 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.allocator.dontdump_iobuffers", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
   ,
 
-  //############
-  //#
-  //# Eric's super cool remap processor
-  //#
-  //############
-  {RECT_CONFIG, "proxy.config.remap.num_remap_threads", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
-
   // Controls for TLS ASYN_JOBS and engine loading
   {RECT_CONFIG, "proxy.config.ssl.async.handshake.enabled", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL},
   {RECT_CONFIG, "proxy.config.ssl.engine.conf_file", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL},

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7207,21 +7207,16 @@ HttpSM::set_next_state()
   }
 
   case HttpTransact::SM_ACTION_REMAP_REQUEST: {
-    if (!remapProcessor.using_separate_thread()) {
-      do_remap_request(true); /* run inline */
-      SMDebug("url_rewrite", "completed inline remapping request for [%" PRId64 "]", sm_id);
-      t_state.url_remap_success = remapProcessor.finish_remap(&t_state, m_remap);
-      if (t_state.next_action == HttpTransact::SM_ACTION_SEND_ERROR_CACHE_NOOP && t_state.transact_return_point == nullptr) {
-        // It appears that we can now set the next_action to error and transact_return_point to nullptr when
-        // going through do_remap_request presumably due to a plugin setting an error.  In that case, it seems
-        // that the error message has already been setup, so we can just return and avoid the further
-        // call_transact_and_set_next_state
-      } else {
-        call_transact_and_set_next_state(nullptr);
-      }
+    do_remap_request(true); /* run inline */
+    SMDebug("url_rewrite", "completed inline remapping request for [%" PRId64 "]", sm_id);
+    t_state.url_remap_success = remapProcessor.finish_remap(&t_state, m_remap);
+    if (t_state.next_action == HttpTransact::SM_ACTION_SEND_ERROR_CACHE_NOOP && t_state.transact_return_point == nullptr) {
+      // It appears that we can now set the next_action to error and transact_return_point to nullptr when
+      // going through do_remap_request presumably due to a plugin setting an error.  In that case, it seems
+      // that the error message has already been setup, so we can just return and avoid the further
+      // call_transact_and_set_next_state
     } else {
-      HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_remap_request);
-      do_remap_request(false); /* dont run inline (iow on another thread) */
+      call_transact_and_set_next_state(nullptr);
     }
     break;
   }

--- a/proxy/http/remap/RemapProcessor.h
+++ b/proxy/http/remap/RemapProcessor.h
@@ -35,31 +35,16 @@
 #define EVENT_REMAP_ERROR (REMAP_EVENT_EVENTS_START + 1)
 #define EVENT_REMAP_COMPLETE (REMAP_EVENT_EVENTS_START + 2)
 
-class RemapProcessor : public Processor
+class RemapProcessor
 {
 public:
   RemapProcessor() {}
-  ~RemapProcessor() override {}
+  ~RemapProcessor() {}
   bool setup_for_remap(HttpTransact::State *s, UrlRewrite *table);
   bool finish_remap(HttpTransact::State *s, UrlRewrite *table);
 
   Action *perform_remap(Continuation *cont, HttpTransact::State *s);
-  int start(int num_threads, size_t stacksize) override;
   bool LessThan(HttpTransact::State *, HttpTransact::State *);
-  void
-  setUseSeparateThread()
-  {
-    _use_separate_remap_thread = true;
-  }
-  bool
-  using_separate_thread()
-  {
-    return _use_separate_remap_thread == true;
-  }
-
-private:
-  EventType ET_REMAP              = 0;
-  bool _use_separate_remap_thread = false;
 };
 
 /**

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1830,17 +1830,6 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // This means any spawn scheduling must be done before this point.
   eventProcessor.start(num_of_net_threads, stacksize);
 
-  int num_remap_threads = 0;
-  REC_ReadConfigInteger(num_remap_threads, "proxy.config.remap.num_remap_threads");
-  if (num_remap_threads < 1) {
-    num_remap_threads = 0;
-  }
-
-  if (num_remap_threads > 0) {
-    Note("using the new remap processor system with %d threads", num_remap_threads);
-    remapProcessor.setUseSeparateThread();
-  }
-
   eventProcessor.schedule_every(new SignalContinuation, HRTIME_MSECOND * 500, ET_CALL);
   eventProcessor.schedule_every(new DiagsLogContinuation, HRTIME_SECOND, ET_TASK);
   eventProcessor.schedule_every(new MemoryLimit, HRTIME_SECOND * 10, ET_TASK);
@@ -1873,7 +1862,6 @@ main(int /* argc ATS_UNUSED */, const char **argv)
       }
     }
   } else {
-    remapProcessor.start(num_remap_threads, stacksize);
     RecProcessStart();
     initCacheControl();
     IpAllow::startup();


### PR DESCRIPTION
While wandering through the remap code, noticed what seemed to be obsolete references to a remap thread.  Cleaning up the unused logic and variables.

However, as I removed the last little bits, I did find it in the documentation, and it seems that traffic_server will dutifully launch the threads.  Since I was most of the way along, I finished the removal on this branch.  

If this is a feature we want to keep, we should probably add a few autests to ensure that the feature works on some basic level.