### PR TITLE
listen on all the net threads

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -317,11 +317,25 @@ Thread Variables
    The number of threads |TS| will create if `proxy.config.exec_thread.autoconfig`
    is set to ``0``, otherwise this option is ignored.
 
+.. ts:cv:: CONFIG proxy.config.exec_thread.listen INT 0
+
+   If enabled (``1``) all the exex_threads listen for incoming connections. `proxy.config.accept_threads`
+   should be disabled to enable this variable.
+
 .. ts:cv:: CONFIG proxy.config.accept_threads INT 1
 
    The number of accept threads. If disabled (``0``), then accepts will be done
    in each of the worker threads.
 
+   ==============  ==================   ===================
+   accept_threads  exec_thread.listen   Effect
+   ==============  ==================   ===================
+   ``0``                 ``0``          All worker threads accept new connections and share listen fd.
+   ``1``                 ``0``          New conections are accepted on a dedicated accept thread and distributed to worker threads in round robin fashion.
+   ``0``                 ``1``          All worker threads listen on the same port using SO_REUSEPORT.
+                                        Each thread has its own listen and new connections are accepted on all the threads.
+
+  By default, `proxy.config.accept_threads` is set to 1 and `proxy.config.exec_thread.listen` is set to 0. 
 .. ts:cv:: CONFIG proxy.config.thread.default.stacksize INT 1048576
 
    Default thread stack size, in bytes, for all threads (default is 1 MB).

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -107,6 +107,7 @@ struct NetAccept : public Continuation {
 
   virtual int acceptEvent(int event, void *e);
   virtual int acceptFastEvent(int event, void *e);
+  virtual int accept_per_thread(int event, void *e);
   int acceptLoopEvent(int event, Event *e);
   void cancel();
 

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -38,6 +38,9 @@
 #define EVENTIO_ASYNC_SIGNAL 5
 
 #if TS_USE_EPOLL
+#ifndef EPOLLEXCLUSIVE
+#define EPOLLEXCLUSIVE 0
+#endif
 #ifdef USE_EDGE_TRIGGER_EPOLL
 #define USE_EDGE_TRIGGER 1
 #define EVENTIO_READ (EPOLLIN | EPOLLET)
@@ -592,7 +595,7 @@ EventIO::start(EventLoop l, int afd, Continuation *c, int e)
 #if TS_USE_EPOLL
   struct epoll_event ev;
   memset(&ev, 0, sizeof(ev));
-  ev.events   = e;
+  ev.events   = e | EPOLLEXCLUSIVE;
   ev.data.ptr = this;
 #ifndef USE_EDGE_TRIGGER
   events = e;

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -524,6 +524,8 @@ NetHandler::waitForActivity(ink_hrtime timeout)
       }
     } else if (epd->type == EVENTIO_ASYNC_SIGNAL) {
       net_signal_hook_callback(this->thread);
+    } else if (epd->type == EVENTIO_NETACCEPT) {
+      this->thread->schedule_imm(epd->data.c);
     }
     ev_next_event(pd, x);
   }

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -201,15 +201,17 @@ NetAccept::init_accept(EThread *t)
   t->schedule_every(this, period);
 }
 
-void
-NetAccept::init_accept_per_thread()
+int
+NetAccept::accept_per_thread(int event, void *ep)
 {
-  int i, n;
+  int listen_per_thread = 0;
+  REC_ReadConfigInteger(listen_per_thread, "proxy.config.exec_thread.listen");
 
-  ink_assert(opt.etype >= 0);
-
-  if (do_listen(NON_BLOCKING)) {
-    return;
+  if (listen_per_thread == 1) {
+    if (do_listen(NON_BLOCKING)) {
+      Fatal("[NetAccept::accept_per_thread]:error listenting on ports");
+      return -1;
+    }
   }
 
   if (accept_fn == net_accept) {
@@ -217,21 +219,38 @@ NetAccept::init_accept_per_thread()
   } else {
     SET_HANDLER((NetAcceptHandler)&NetAccept::acceptEvent);
   }
+  PollDescriptor *pd = get_PollDescriptor(this_ethread());
+  if (this->ep.start(pd, this, EVENTIO_READ) < 0) {
+    Fatal("[NetAccept::accept_per_thread]:error starting EventIO");
+    return -1;
+  }
+  return 0;
+}
 
-  period = -HRTIME_MSECONDS(net_accept_period);
-  n      = eventProcessor.thread_group[opt.etype]._count;
+void
+NetAccept::init_accept_per_thread()
+{
+  int i, n;
+  int listen_per_thread = 0;
+
+  ink_assert(opt.etype >= 0);
+  REC_ReadConfigInteger(listen_per_thread, "proxy.config.exec_thread.listen");
+
+  if (listen_per_thread == 0) {
+    if (do_listen(NON_BLOCKING)) {
+      Fatal("[NetAccept::accept_per_thread]:error listenting on ports");
+      return;
+    }
+  }
+
+  SET_HANDLER((NetAcceptHandler)&NetAccept::accept_per_thread);
+  n = eventProcessor.thread_group[opt.etype]._count;
 
   for (i = 0; i < n; i++) {
-    NetAccept *a       = (i < n - 1) ? clone() : this;
-    EThread *t         = eventProcessor.thread_group[opt.etype]._thread[i];
-    PollDescriptor *pd = get_PollDescriptor(t);
-
-    if (a->ep.start(pd, a, EVENTIO_READ) < 0) {
-      Warning("[NetAccept::init_accept_per_thread]:error starting EventIO");
-    }
-
-    a->mutex = get_NetHandler(t)->mutex;
-    t->schedule_every(a, period);
+    NetAccept *a = (i < n - 1) ? clone() : this;
+    EThread *t   = eventProcessor.thread_group[opt.etype]._thread[i];
+    a->mutex     = get_NetHandler(t)->mutex;
+    t->schedule_imm(a);
   }
 }
 
@@ -401,16 +420,18 @@ NetAccept::acceptFastEvent(int event, void *ep)
   int loop               = accept_till_done;
 
   do {
-    if (!opt.backdoor && check_net_throttle(ACCEPT)) {
-      ifd = NO_FD;
-      return EVENT_CONT;
-    }
-
     socklen_t sz = sizeof(con.addr);
     int fd       = socketManager.accept4(server.fd, &con.addr.sa, &sz, SOCK_NONBLOCK | SOCK_CLOEXEC);
     con.fd       = fd;
 
     if (likely(fd >= 0)) {
+      // check for throttle
+      if (!opt.backdoor && check_net_throttle(ACCEPT)) {
+        // close the connection as we are in throttle state
+        con.close();
+        NET_SUM_DYN_STAT(net_connections_throttled_in_stat, 1);
+        continue;
+      }
       Debug("iocore_net", "accepted a new socket: %d", fd);
       NET_SUM_GLOBAL_DYN_STAT(net_tcp_accept_stat, 1);
       if (opt.send_bufsize > 0) {
@@ -440,6 +461,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     }
     // check return value from accept()
     if (res < 0) {
+      Debug("iocore_net", "received : %s", strerror(errno));
       res = -errno;
       if (res == -EAGAIN || res == -ECONNABORTED
 #if defined(linux)
@@ -458,9 +480,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     }
 
     vc = (UnixNetVConnection *)this->getNetProcessor()->allocate_vc(e->ethread);
-    if (!vc) {
-      goto Ldone;
-    }
+    ink_release_assert(vc);
 
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
     vc->id = net_next_connection_number();

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -116,6 +116,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.exec_thread.affinity", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-4]", RECA_READ_ONLY}
   ,
+  {RECT_CONFIG, "proxy.config.exec_thread.listen", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
+  ,
   {RECT_CONFIG, "proxy.config.accept_threads", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-" TS_STR(TS_MAX_NUMBER_EVENT_THREADS) "]", RECA_READ_ONLY}
   ,
   {RECT_CONFIG, "proxy.config.task_threads", RECD_INT, "2", RECU_RESTART_TS, RR_NULL, RECC_INT, "[1-" TS_STR(TS_MAX_NUMBER_EVENT_THREADS) "]", RECA_READ_ONLY}

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -557,6 +557,11 @@ main(int argc, const char **argv)
   }
 
   RecGetRecordInt("proxy.config.net.connections_throttle", &fds_throttle);
+  RecInt listen_per_thread = 0;
+  RecGetRecordInt("proxy.config.exec_thread.listen", &listen_per_thread);
+  if (listen_per_thread > 0) { // Turn off listening. Traffic server is going to listen on all the threads.
+    listen_off = true;
+  }
 
   set_process_limits(fds_throttle); // as root
 


### PR DESCRIPTION
This commit does the following.
1) Removes periodic scheduling of accept on net threads.
2) Schedules accept based on epoll notification.
3) Adds epollexclusive flag to epoll_ctl flags. Epollexclusive flag wakes up only one net thread
4) Uses so_reuseport on Linux to listen on all the threads.
5) Uses so_reuseport_lb on FreeBSD to listen on all the threads.

Do we need an option to disable epoll exclusive wakeup mechanism?
