### PR TITLE
Doc: clean up build errors.

### DIFF
--- a/doc/admin-guide/files/logging.yaml.en.rst
+++ b/doc/admin-guide/files/logging.yaml.en.rst
@@ -325,7 +325,7 @@ common fields:
 
    formats:
    - name: minimalfmt
-     format: '%<chi> : %<cqu> : %<pssc>'
+     format: '%<chi> , %<cqu> , %<pssc>'
 
 The following is an example of a format that uses aggregate operators to
 produce a summary log:
@@ -334,7 +334,7 @@ produce a summary log:
 
    formats:
    - name: summaryfmt
-     format: '%<LAST(cqts)> : %<COUNT(*)> : %<SUM(psql)>'
+     format: '%<LAST(cqts)>:%<COUNT(*)>:%<SUM(psql)>'
      interval: 10
 
 The following is an example of a filter that will cause only REFRESH_HIT events

--- a/doc/admin-guide/logging/examples.en.rst
+++ b/doc/admin-guide/logging/examples.en.rst
@@ -247,7 +247,7 @@ to clients:
 
    formats:
    - name: mysummary
-     format: '%<LAST(cqts)> : %<COUNT(*)> : %<SUM(psql)>'
+     format: '%<LAST(cqts)>:%<COUNT(*)>:%<SUM(psql)>'
      interval: 10
 
 Dual Output to Compact Binary Logs and ASCII Pipes

--- a/doc/admin-guide/logging/understanding.en.rst
+++ b/doc/admin-guide/logging/understanding.en.rst
@@ -151,7 +151,7 @@ aforementioned aggregate functions and the specification of an interval, as so:
 
    formats:
    - name: mysummary
-     format: '%<operator(field)> : %<operator(field)>'
+     format: '%<operator(field)> , %<operator(field)>'
      interval: n
 
 The interval itself is given with *n* as the number of seconds for each period

--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -977,7 +977,7 @@ Here is an example:
     end
 
 
-`TOP <#lua-plugin>`_
+:ref:`TOP <admin-plugins-ts-lua>`
 
 ts.client_request.get_ssl_protocol
 -----------------------------------------------
@@ -997,7 +997,7 @@ Here is an example:
     end
 
 
-`TOP <#lua-plugin>`_
+:ref:`TOP <admin-plugins-ts-lua>`
 
 ts.client_request.get_ssl_cipher
 -----------------------------------------------
@@ -1017,7 +1017,7 @@ Here is an example:
     end
 
 
-`TOP <#lua-plugin>`_
+:ref:`TOP <admin-plugins-ts-lua>`
 
 ts.client_request.get_ssl_curve
 -----------------------------------------------
@@ -1037,7 +1037,7 @@ Here is an example:
     end
 
 
-`TOP <#lua-plugin>`_
+:ref:`TOP <admin-plugins-ts-lua>`
 
 ts.http.set_cache_url
 ---------------------


### PR DESCRIPTION
The worst one was in logging - for some reason the YAML Pygment lexer doesn't like ": %" in the text - that breaks. Eliding the space, or using something other than a colon (like a comma) fixes the problem. I tested this on the Pygments website and it works fine there, not sure why it doesn't work locally.