### PR TITLE
Promote 'Enable_Config_Var' from HttpConnectionCount to HttpConfig.

### DIFF
--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -851,3 +851,28 @@ inline HttpConfigParams::~HttpConfigParams()
   delete connect_ports;
   delete redirect_actions_map;
 }
+
+/** Enable a dynamic configuration variable.
+ *
+ * @param name Configuration var name.
+ * @param cb Callback to do the actual update of the master record.
+ * @param cookie Extra data for @a cb
+ *
+ * The purpose of this is to unite the different ways and times a configuration variable needs
+ * to be loaded. These are
+ * - Process start.
+ * - Dynamic update.
+ * - Plugin API update.
+ *
+ * @a cb is expected to perform the update. It must return a @c bool which is
+ * - @c true if the value was changed.
+ * - @c false if the value was not changed.
+ *
+ * Based on that, a run time configuration update is triggered or not.
+ *
+ * In addition, this invokes @a cb and passes it the information in the configuration variable
+ * global table in order to perform the initial loading of the value. No update is triggered for
+ * that call as it is not needed.
+ *
+ */
+extern void Enable_Config_Var(std::string_view const &name, bool (*cb)(const char *, RecDataT, RecData, void *), void *cookie);


### PR DESCRIPTION
This is part of the "config inversion" work. This function ended up working well in the HTTP connection count logic, therefore I'd like to promote it to the general HTTP config logic so it is available for other uses.

The main benefit of this is it unifies conversion, process start loading, and update callbacks to use the same code instead of, as is generally done, having cut and paste logic initial loading and update callbacks.

Added Issue #6048. 