### PR TITLE
Add extra state for allow_half_open setting

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4202,8 +4202,12 @@ Sockets
    :reloadable:
    :overridable:
 
-   Turn on or off support for connection half open for client side. Default is on, so
-   after client sends FIN, the connection is still there.
+   Controls whether ATS will continue to send data over a connection when the client side
+   closes (operating in a half open state).  The client would have to be be written to 
+   expect this to process the extra data.  A value of 0 disables the half open connection from 
+   consideration. A value of 1 cause |TS| to send data after receiving a FIN on non TLS connections.
+   A value of 2 will cause |TS| to also send data over TLS connections after the client sends a
+   FIN.
 
 .. ts:cv:: CONFIG proxy.config.http.wait_for_cache INT 0
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -303,7 +303,7 @@ static const RecordElement RecordsConfig[] =
   //        # basics #
   //        ##########
   //       #
-  {RECT_CONFIG, "proxy.config.http.allow_half_open", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.allow_half_open", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http.enabled", RECD_INT, "1", RECU_RESTART_TM, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -523,10 +523,14 @@ Http1ClientSession::start()
 }
 
 bool
-Http1ClientSession::allow_half_open() const
+Http1ClientSession::allow_half_open(bool allow_half_open_tls) const
 {
-  // Only allow half open connections if the not over TLS
-  return (client_vc && dynamic_cast<SSLNetVConnection *>(client_vc) == nullptr);
+  if (allow_half_open_tls) {
+    return true;
+  } else {
+    // Only allow half open connections if the not over TLS
+    return (client_vc && dynamic_cast<SSLNetVConnection *>(client_vc) == nullptr);
+  }
 }
 
 void

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -72,7 +72,7 @@ public:
   void reenable(VIO *vio) override;
 
   // Accessor Methods
-  bool allow_half_open() const;
+  bool allow_half_open(bool half_open_tls) const;
   void set_half_close_flag(bool flag) override;
   bool get_half_close_flag() const override;
   bool is_chunked_encoding_supported() const override;

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -68,10 +68,11 @@ Http1Transaction::reenable(VIO *vio)
 bool
 Http1Transaction::allow_half_open() const
 {
-  bool config_allows_it = (_sm) ? _sm->t_state.txn_conf->allow_half_open > 0 : true;
+  bool config_allows_it            = (_sm) ? _sm->t_state.txn_conf->allow_half_open > 0 : false;
+  bool config_allows_tls_half_open = (_sm) ? _sm->t_state.txn_conf->allow_half_open > 1 : false;
   if (config_allows_it) {
     // Check with the session to make sure the underlying transport allows the half open scenario
-    return static_cast<Http1ClientSession *>(_proxy_ssn)->allow_half_open();
+    return static_cast<Http1ClientSession *>(_proxy_ssn)->allow_half_open(config_allows_tls_half_open);
   }
   return false;
 }


### PR DESCRIPTION
Updates proxy.config.http.allow_half_open  to have three values: 0 disabled, 1 enabled for non-tls, 2 enabled for tls and non-tls.