### PR TITLE
Cleanup: Fixes for a more stringent g++ compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,6 @@ add_executable(ats
         src/wccp/WccpMsg.cc
         src/wccp/WccpStatic.cc
         src/wccp/WccpUtil.h
-        lib/ink_autoconf.h
         mgmt/api/include/mgmtapi.h
         mgmt/api/APITestCliRemote.cc
         mgmt/api/CoreAPI.cc
@@ -814,7 +813,6 @@ add_executable(ats
         proxy/http2/HuffmanCodec.h
         proxy/http2/RegressionHPACK.cc
         proxy/http2/test_HPACK.cc
-        proxy/http2/test_Http2DependencyTree.cc
         proxy/http2/test_Huffmancode.cc
         proxy/logging/Log.cc
         proxy/logging/Log.h
@@ -893,7 +891,6 @@ add_executable(ats
         proxy/Show.h
         proxy/StatPages.cc
         proxy/StatPages.h
-        proxy/TimeTrace.h
         proxy/Transform.cc
         proxy/Transform.h
         proxy/TransformInternal.h
@@ -916,8 +913,6 @@ add_library(libtscore SHARED
         include/tscore/Arena.h
         src/tscore/BaseLogFile.cc
         include/tscore/BaseLogFile.h
-        src/tscore/Bitops.cc
-        include/tscore/Bitops.h
         include/tscore/bwf_std_format.h
         include/tscore/BufferWriter.h
         include/tscore/BufferWriterForward.h
@@ -1065,17 +1060,13 @@ add_library(libtscore SHARED
         include/tscore/SimpleTokenizer.h
         src/tscore/SourceLocation.cc
         include/tscore/SourceLocation.h
-        src/tscore/test_arena.cc
         src/tscore/test_atomic.cc
         src/tscore/test_freelist.cc
         src/tscore/test_geometry.cc
         src/tscore/test_History.cc
-        src/tscore/test_List.cc
-        src/tscore/test_Map.cc
         src/tscore/test_PriorityQueue.cc
         src/tscore/test_Ptr.cc
         src/tscore/test_Regex.cc
-        src/tscore/test_Vec.cc
         src/tscore/test_X509HostnameValidator.cc
         include/tscore/TestBox.h
         src/tscore/TestHttpHeader.cc
@@ -1190,7 +1181,6 @@ add_library(plugin_escalate SHARED
 
 # CacheTool
 add_executable(traffic_cache_tool
-	src/traffic_cache_tool/CacheStore.h
 	src/traffic_cache_tool/CacheDefs.h
 	src/traffic_cache_tool/CacheDefs.cc
 	src/traffic_cache_tool/CacheTool.cc

--- a/include/tscore/BufferWriter.h
+++ b/include/tscore/BufferWriter.h
@@ -207,6 +207,9 @@ public:
 };
 
 /** A @c BufferWrite concrete subclass to write to a fixed size buffer.
+ *
+ * Copies and moves are forbidden because that leaves the original in a potentially bad state. An
+ * instance is cheap to construct and should be done explicitly when needed.
  */
 class FixedBufferWriter : public BufferWriter
 {
@@ -231,10 +234,8 @@ public:
 
   FixedBufferWriter(const FixedBufferWriter &) = delete;
   FixedBufferWriter &operator=(const FixedBufferWriter &) = delete;
-  /// Move constructor.
-  FixedBufferWriter(FixedBufferWriter &&) = default;
-  /// Move assignment.
-  FixedBufferWriter &operator=(FixedBufferWriter &&) = default;
+  FixedBufferWriter(FixedBufferWriter &&)                 = delete;
+  FixedBufferWriter &operator=(FixedBufferWriter &&) = delete;
 
   FixedBufferWriter(MemSpan &span) : _buf(span.begin()), _capacity(static_cast<size_t>(span.size())) {}
 

--- a/include/tscore/ContFlags.h
+++ b/include/tscore/ContFlags.h
@@ -41,8 +41,9 @@ class ContFlags
 public:
   enum flags { DEBUG_OVERRIDE = 0, DISABLE_PLUGINS = 1, LAST_FLAG };
 
-  ContFlags() {}
-  ContFlags(uint32_t in_flags) : raw_flags(in_flags) {}
+  constexpr ContFlags() {}
+  constexpr ContFlags(ContFlags const &that) = default;
+  constexpr ContFlags(uint32_t in_flags) : raw_flags(in_flags) {}
   void
   set_flags(uint32_t new_flags)
   {

--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -47,6 +47,7 @@ union CryptoHash {
 
   /// Default constructor - init to zero.
   CryptoHash() { memset(this, 0, sizeof(*this)); }
+  CryptoHash(CryptoHash const &that) = default;
 
   /// Assignment - bitwise copy.
   CryptoHash &

--- a/include/tscore/Map.h
+++ b/include/tscore/Map.h
@@ -1150,6 +1150,7 @@ public:
   MapElem(K const &akey, C const &avalue) : key(akey), value(avalue) {}
   MapElem(MapElem const &e) : key(e.key), value(e.value) {}
   MapElem() : key(), value() {}
+  MapElem &operator=(MapElem const &that) = default;
 };
 
 template <class K, class C, class A = DefaultAlloc> class Map : public Vec<MapElem<K, C>, A>

--- a/include/tscore/MemSpan.h
+++ b/include/tscore/MemSpan.h
@@ -53,6 +53,8 @@ public:
   /// Default constructor (empty buffer).
   constexpr MemSpan();
 
+  constexpr MemSpan(self_type const &that) = default;
+
   /** Construct explicitly with a pointer and size.
    */
   constexpr MemSpan(void *ptr,  ///< Pointer to buffer.

--- a/include/tscore/ink_uuid.h
+++ b/include/tscore/ink_uuid.h
@@ -33,8 +33,9 @@ class ATSUuid
 {
 public:
   // Constructors
-  ATSUuid() : _version(TS_UUID_UNDEFINED) {}
-  ATSUuid &operator=(const ATSUuid other);
+  ATSUuid()                    = default;
+  ATSUuid(ATSUuid const &that) = default;
+  ATSUuid &operator            =(const ATSUuid other);
 
   // Initialize the UUID from a string
   bool parseString(const char *str);
@@ -122,7 +123,7 @@ private:
   } _uuid;
 
   // This is the typically used visible portion of the UUID
-  TSUuidVersion _version;
+  TSUuidVersion _version = TS_UUID_UNDEFINED;
   char _string[TS_UUID_STRING_LEN + 1];
 
   bool

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -174,7 +174,7 @@ public:
   /// at every call site. We also need this because we have ats_scoped_str members.
   Span(Span const &that)
   {
-    memcpy(this, &that, reinterpret_cast<intptr_t>(&(static_cast<Span *>(nullptr)->pathname)));
+    memcpy(static_cast<void *>(this), &that, reinterpret_cast<intptr_t>(&(static_cast<Span *>(nullptr)->pathname)));
     if (that.pathname) {
       pathname = ats_strdup(that.pathname);
     }

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -132,6 +132,7 @@ struct Connection {
 
   virtual ~Connection();
   Connection();
+  Connection(Connection const &) = delete;
 
   /// Default options.
   static NetVCOptions const DEFAULT_OPTIONS;
@@ -140,11 +141,6 @@ struct Connection {
    * Move control of the socket from the argument object orig to the current object.
    */
   void move(Connection &);
-
-private:
-  // Don't want copy constructors to avoid having the deconstructor on
-  // temporarly copies close the file descriptor too soon. Use move instead
-  Connection(Connection const &);
 
 protected:
   void _cleanup();

--- a/lib/tsconfig/NumericType.h
+++ b/lib/tsconfig/NumericType.h
@@ -1,6 +1,3 @@
-# if !defined(TS_NUMERIC_TYPE_HEADER)
-# define TS_NUMERIC_TYPE_HEADER
-
 /** @file
 
     Create a distinct type from a builtin numeric type.
@@ -41,12 +38,14 @@
     limitations under the License.
  */
 
-# include <limits>
+#pragma once
 
-namespace ts {
+#include <limits>
 
+namespace ts
+{
 // Forward declare.
-template < typename T, typename X > class NumericType;
+template <typename T, typename X> class NumericType;
 
 /// @cond NOT_DOCUMENTED
 /** Support template for resolving operator ambiguity.
@@ -65,26 +64,25 @@ template < typename T, typename X > class NumericType;
     @internal Note that we don't have to provide an actual implementation
     for these operators. Funky, isn't it?
 */
-template <
-  typename T, ///< Base numeric type.
-  typename X ///< Distinguishing tag type.
-> class NumericTypeIntOperators {
+template <typename T, ///< Base numeric type.
+          typename X  ///< Distinguishing tag type.
+          >
+class NumericTypeIntOperators
+{
 public:
-    NumericType<T,X>& operator += ( int t );
-    NumericType<T,X>& operator -= ( int t );
+  NumericType<T, X> &operator+=(int t);
+  NumericType<T, X> &operator-=(int t);
 
-    // Must have const and non-const versions.
-    NumericType<T,X> operator +  ( int t );
-    NumericType<T,X> operator -  ( int t );
-    NumericType<T,X> operator +  ( int t ) const;
-    NumericType<T,X> operator -  ( int t ) const;
+  // Must have const and non-const versions.
+  NumericType<T, X> operator+(int t);
+  NumericType<T, X> operator-(int t);
+  NumericType<T, X> operator+(int t) const;
+  NumericType<T, X> operator-(int t) const;
 };
 
-template < typename T, typename X > NumericType<T,X>
-operator + ( int t, NumericTypeIntOperators<T,X> const& );
+template <typename T, typename X> NumericType<T, X> operator+(int t, NumericTypeIntOperators<T, X> const &);
 
-template < typename T, typename X > NumericType<T,X>
-operator - ( int t, NumericTypeIntOperators<T,X> const& );
+template <typename T, typename X> NumericType<T, X> operator-(int t, NumericTypeIntOperators<T, X> const &);
 
 /// @endcond
 
@@ -93,91 +91,189 @@ operator - ( int t, NumericTypeIntOperators<T,X> const& );
     @internal One issue is that this is not a POD and so doesn't work
     with @c printf. I will need to investigate what that would take.
  */
-template <
-  typename T, ///< Base numeric type.
-  typename X ///< Distinguishing tag type.
-> class NumericType : public NumericTypeIntOperators<T,X> {
+template <typename T, ///< Base numeric type.
+          typename X  ///< Distinguishing tag type.
+          >
+class NumericType : public NumericTypeIntOperators<T, X>
+{
 public:
-    typedef T raw_type; //!< Base builtin type.
-    typedef NumericType self; //!< Self reference type.
+  using raw_type  = T;           ///< Base type.
+  using self_type = NumericType; ///< Self reference type.
 
-    /// @cond NOT_DOCUMENTED
-    // Need to import these to avoid compiler problems.
-    using NumericTypeIntOperators<T,X>::operator +=;
-    using NumericTypeIntOperators<T,X>::operator -=;
-    using NumericTypeIntOperators<T,X>::operator +;
-    using NumericTypeIntOperators<T,X>::operator -;
-    /// @endcond
+  /// @cond NOT_DOCUMENTED
+  // Need to import these to avoid compiler problems.
+  using NumericTypeIntOperators<T, X>::operator+=;
+  using NumericTypeIntOperators<T, X>::operator-=;
+  using NumericTypeIntOperators<T, X>::operator+;
+  using NumericTypeIntOperators<T, X>::operator-;
+  /// @endcond
 
-    /// Default constructor, uninitialized.
-    NumericType();
-    //! Construct from implementation type.
-    NumericType(
-      raw_type const t ///< Initialized value.
-    );
-    //! Assignment from implementation type.
-    NumericType & operator = (raw_type const t);
-    //! Self assignment.
-    NumericType & operator = (self const& that);
+  /// Default constructor, uninitialized.
+  NumericType();
+  //! Construct from implementation type.
+  constexpr NumericType(raw_type const t ///< Initialized value.
+  );
+  /// Copy constructor.
+  constexpr NumericType(self_type const &that) = default;
 
-    /// User conversion to implementation type.
-    /// @internal If we have just a single const method conversion to a copy
-    /// of the @c raw_type then the stream operators don't work. Only a CR
-    /// conversion operator satisifies the argument matching.
-    operator raw_type const& () const { return _t; }
-    /// User conversion to implementation type.
-    operator raw_type& () { return _t; }
-    /// Explicit conversion to host type
-    raw_type raw() const { return _t; }
+  //! Assignment from implementation type.
+  NumericType &operator=(raw_type const t);
+  //! Self assignment.
+  NumericType &operator=(self_type const &that);
 
-    // User conversions to raw type provide the standard comparison operators.
-    self& operator += ( self const& that );
-    self& operator -= ( self const& that );
+  /// User conversion to implementation type.
+  /// @internal If we have just a single const method conversion to a copy
+  /// of the @c raw_type then the stream operators don't work. Only a CR
+  /// conversion operator satisifies the argument matching.
+  operator raw_type const &() const { return _t; }
+  /// User conversion to implementation type.
+  operator raw_type &() { return _t; }
+  /// Explicit conversion to host type
+  raw_type
+  raw() const
+  {
+    return _t;
+  }
 
-    self& operator += ( raw_type t );
-    self& operator -= ( raw_type t );
+  // User conversions to raw type provide the standard comparison operators.
+  self_type &operator+=(self_type const &that);
+  self_type &operator-=(self_type const &that);
 
-    self operator +  ( self const& that );
-    self operator -  ( self const& that );
+  self_type &operator+=(raw_type t);
+  self_type &operator-=(raw_type t);
 
-    self operator +  ( raw_type t );
-    self operator -  ( raw_type t );
+  self_type operator+(self_type const &that);
+  self_type operator-(self_type const &that);
 
-    self& operator ++();
-    self operator ++(int);
-    self& operator --();
-    self operator --(int);
+  self_type operator+(raw_type t);
+  self_type operator-(raw_type t);
+
+  self_type &operator++();
+  self_type operator++(int);
+  self_type &operator--();
+  self_type operator--(int);
 
 private:
-    raw_type   _t;
+  raw_type _t;
 };
 
 // Method definitions.
 // coverity[uninit_ctor]
-template < typename T, typename X > NumericType<T,X>::NumericType() { }
-template < typename T, typename X > NumericType<T,X>::NumericType(raw_type const t) : _t(t) { }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator = (raw_type const t) { _t = t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator = (self const& that) { _t = that._t; return *this; }
+template <typename T, typename X> NumericType<T, X>::NumericType() {}
+template <typename T, typename X> constexpr NumericType<T, X>::NumericType(raw_type const t) : _t(t) {}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator=(raw_type const t)
+{
+  _t = t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator=(self_type const &that)
+{
+  _t = that._t;
+  return *this;
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator += ( self const& that ) { _t += that._t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator -= ( self const& that ) { _t -= that._t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator +  ( self const& that ) { return self(_t + that._t); }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator -  ( self const& that ) { return self(_t - that._t); }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator+=(self_type const &that)
+{
+  _t += that._t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator-=(self_type const &that)
+{
+  _t -= that._t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator+(self_type const &that)
+{
+  return self_type(_t + that._t);
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator-(self_type const &that)
+{
+  return self_type(_t - that._t);
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator += ( raw_type t ) { _t += t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator -= ( raw_type t ) { _t -= t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator +  ( raw_type t ) { return self(_t + t); }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator -  ( raw_type t ) { return self(_t - t); }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator+=(raw_type t)
+{
+  _t += t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator-=(raw_type t)
+{
+  _t -= t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator+(raw_type t)
+{
+  return self_type(_t + t);
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator-(raw_type t)
+{
+  return self_type(_t - t);
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator ++() { ++_t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator --() { --_t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator ++(int) { self tmp(*this); ++_t; return tmp; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator --(int) { self tmp(*this); --_t; return tmp; }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator++()
+{
+  ++_t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator--()
+{
+  --_t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator++(int)
+{
+  self_type tmp(*this);
+  ++_t;
+  return tmp;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator--(int)
+{
+  self_type tmp(*this);
+  --_t;
+  return tmp;
+}
 
-template < typename T, typename X > NumericType<T,X> operator +  ( T const& lhs, NumericType<T,X> const& rhs ) { return rhs + lhs; }
-template < typename T, typename X > NumericType<T,X> operator -  ( T const& lhs, NumericType<T,X> const& rhs ) { return NumericType<T,X>(lhs - rhs.raw()); }
+template <typename T, typename X>
+NumericType<T, X>
+operator+(T const &lhs, NumericType<T, X> const &rhs)
+{
+  return rhs + lhs;
+}
+template <typename T, typename X>
+NumericType<T, X>
+operator-(T const &lhs, NumericType<T, X> const &rhs)
+{
+  return NumericType<T, X>(lhs - rhs.raw());
+}
 
 /* ----------------------------------------------------------------------- */
-} /* end namespace ts */
+} // namespace ts
 /* ----------------------------------------------------------------------- */
-# endif // TS_NUMERIC_TYPE_HEADER

--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -184,7 +184,7 @@ struct EVPKey {
   EVPKey(void) : key(EVP_PKEY_new()) { assert(nullptr != key); }
 
   bool
-  assign(const char *const k) const
+  assign(char *k) const
   {
     assert(nullptr != k);
     const int rc = EVP_PKEY_assign_RSA(key, k);
@@ -196,7 +196,7 @@ struct EVPKey {
   bool
   assign(T &t)
   {
-    return assign(reinterpret_cast<const char *>(t));
+    return assign(reinterpret_cast<char *>(t));
   }
 };
 

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -468,14 +468,15 @@ HTTPValTE *http_parse_te(const char *buf, int len, Arena *arena);
 class HTTPVersion
 {
 public:
-  HTTPVersion();
-  explicit HTTPVersion(int32_t version);
-  HTTPVersion(int ver_major, int ver_minor);
+  constexpr HTTPVersion() = default;
+  explicit constexpr HTTPVersion(int32_t version);
+  constexpr HTTPVersion(int ver_major, int ver_minor);
+  constexpr HTTPVersion(HTTPVersion const &that) = default;
 
   void set(HTTPVersion ver);
   void set(int ver_major, int ver_minor);
 
-  HTTPVersion &operator=(const HTTPVersion &hv);
+  constexpr HTTPVersion &operator=(const HTTPVersion &hv);
   int operator==(const HTTPVersion &hv) const;
   int operator!=(const HTTPVersion &hv) const;
   int operator>(const HTTPVersion &hv) const;
@@ -484,7 +485,7 @@ public:
   int operator<=(const HTTPVersion &hv) const;
 
 public:
-  int32_t m_version;
+  int32_t m_version = HTTP_VERSION(1, 0);
 };
 
 class IOBufferReader;
@@ -661,17 +662,12 @@ private:
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline HTTPVersion::HTTPVersion() : m_version(HTTP_VERSION(1, 0)) {}
+inline constexpr HTTPVersion::HTTPVersion(int32_t version) : m_version(version) {}
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline HTTPVersion::HTTPVersion(int32_t version) : m_version(version) {}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline HTTPVersion::HTTPVersion(int ver_major, int ver_minor) : m_version(HTTP_VERSION(ver_major, ver_minor)) {}
+inline constexpr HTTPVersion::HTTPVersion(int ver_major, int ver_minor) : m_version(HTTP_VERSION(ver_major, ver_minor)) {}
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
@@ -694,7 +690,7 @@ HTTPVersion::set(int ver_major, int ver_minor)
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline HTTPVersion &
+inline constexpr HTTPVersion &
 HTTPVersion::operator=(const HTTPVersion &hv)
 {
   m_version = hv.m_version;


### PR DESCRIPTION
It appears to me the problem is a more stringent g++ compiler. Many (if not most) of these issues are in code that hasn't been touched for years (e.g., "Map.h"). I also think many of these were done for ATS 9, but those PRs weren't pulled back. The fixes were simple enough it was easier to just do them again, or just copy from master.