### PR TITLE
set host name in TLS extension for SNI Host check in service side with sni policy verify_with_name_source.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3451,7 +3451,21 @@ Client-Related Configuration
 
    Indicate how the SNI value for the TLS connection to the origin is selected.  By default it is
    `host` which means the host header field value is used for the SNI.  If `remap` is specified, the
-   remapped origin name is used for the SNI value.
+   remapped origin name is used for the SNI value.  If `verify_with_name_source` is specified, the 
+   SNI will be the host header value and the name to check in the server certificate will be the 
+   remap header value.
+   We have two names that could be used in the transaction host header and the SNI value to the 
+   origin. These could be the host header from the client or the remap host name. Unless you have 
+   pristine host header enabled, these are likely the same values.
+   If sni_policy = host, both the sni and the host header to origin will be the same.
+   If sni_policy = remap, the sni value with be the remap host name and the host header will be the 
+   host header from the client.
+   In addition, We may want to set the SNI and host headers the same (makes some common web servers 
+   happy), but the certificate served by the origin may have a name that corresponds to the remap 
+   name. So instead of using the SNI name for the name check, we may want to use the remap name. 
+   So if sni_policy = verify_with_name_source, the sni will be the host header value and the name to 
+   check in the server certificate will be the remap header value.
+   
 
 .. ts:cv:: CONFIG proxy.config.ssl.client.TLSv1 INT 0
 

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -68,6 +68,7 @@ NetVCOptions::reset()
 
   sni_servername              = nullptr;
   ssl_servername              = nullptr;
+  sni_hostname                = nullptr;
   ssl_client_cert_name        = nullptr;
   ssl_client_private_key_name = nullptr;
   ssl_client_ca_cert_name     = nullptr;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1078,11 +1078,12 @@ SSLNetVConnection::sslStartHandShake(int event, int &err)
 
       SSL_set_verify(this->ssl, SSL_VERIFY_PEER, verify_callback);
 
-      if (this->options.sni_servername) {
-        if (SSL_set_tlsext_host_name(this->ssl, this->options.sni_servername)) {
-          Debug("ssl", "using SNI name '%s' for client handshake", this->options.sni_servername.get());
+      ats_scoped_str &tlsext_host_name = this->options.sni_hostname ? this->options.sni_hostname : this->options.sni_servername;
+      if (tlsext_host_name) {
+        if (SSL_set_tlsext_host_name(this->ssl, tlsext_host_name)) {
+          Debug("ssl", "using SNI name '%s' for client handshake", tlsext_host_name.get());
         } else {
-          Debug("ssl.error", "failed to set SNI name '%s' for client handshake", this->options.sni_servername.get());
+          Debug("ssl.error", "failed to set SNI name '%s' for client handshake", tlsext_host_name.get());
           SSL_INCREMENT_DYN_STAT(ssl_sni_name_set_failure);
         }
       }

--- a/iocore/net/quic/QUICTLS_openssl.cc
+++ b/iocore/net/quic/QUICTLS_openssl.cc
@@ -405,7 +405,8 @@ QUICTLS::QUICTLS(QUICPacketProtectionKeyInfo &pp_key_info, SSL_CTX *ssl_ctx, Net
 
     SSL_set_alpn_protos(this->_ssl, reinterpret_cast<const unsigned char *>(netvc_options.alpn_protos.data()),
                         netvc_options.alpn_protos.size());
-    SSL_set_tlsext_host_name(this->_ssl, netvc_options.sni_servername.get());
+    const ats_scoped_str &tlsext_host_name = netvc_options.sni_hostname ? netvc_options.sni_hostname : netvc_options.sni_servername;
+    SSL_set_tlsext_host_name(this->_ssl, tlsext_host_name.get());
   } else {
     SSL_set_accept_state(this->_ssl);
   }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5049,6 +5049,17 @@ HttpSM::do_http_server_open(bool raw)
     if (t_state.txn_conf->ssl_client_sni_policy != nullptr && !strcmp(t_state.txn_conf->ssl_client_sni_policy, "remap")) {
       len = strlen(t_state.server_info.name);
       opt.set_sni_servername(t_state.server_info.name, len);
+    } else if (t_state.txn_conf->ssl_client_sni_policy != nullptr &&
+               !strcmp(t_state.txn_conf->ssl_client_sni_policy, "verify_with_name_source")) {
+      // the same with "remap" policy to set sni_servername
+      len = strlen(t_state.server_info.name);
+      opt.set_sni_servername(t_state.server_info.name, len);
+
+      // also set sni_hostname with host header from server request in this policy
+      const char *host = t_state.hdr_info.server_request.host_get(&len);
+      if (host && len > 0) {
+        opt.set_sni_hostname(host, len);
+      }
     } else { // Do the default of host header for SNI
       const char *host = t_state.hdr_info.server_request.host_get(&len);
       if (host && len > 0) {


### PR DESCRIPTION
We had discussion about this issue with @shinrich @sudheerv @zizhong in the ATS Fall Summit. To clear the context, take an example as below, because the remap, client sent "foo" to ATS and ATS sent "bar" to front-end.
client: https://foo/ -> proxy(ATS): https://bar/ -> Font-end

During TLS handshake sni_servername("bar") is used to select the certificate by Jetty. After successful handshake, when proxy requests for server's resources, the server validates each request by using HOST request header ("foo") which mismatches certificate that it selected during handshake using sni_servername ("bar").

To fix this problem in our case, we add sni policy "verify_with_name_source". In this policy, in proxy/http/HttpSM.cc, compared with current "remap" policy, we set sni_servername ("bar") which is same as "remap" policy, and also set new option sni_hostname("foo") with the Host from pristine URL.
In iocore/net/SSLNetVConnection.cc, when we call SSL_set_tlsext_host_name, we check sni_hostname ("bar") firstly, if it's empty then check sni_servername("foo"). It can ensure the sni host verification pass in server side in our case.