### PR TITLE
Remove obsolete pipeline_max variable

### DIFF
--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -97,9 +97,6 @@ union HostDBApplicationInfo {
   // http server attributes in the host database          //
   //                                                      //
   // http_version       - one of HttpVersion_t            //
-  // pipeline_max       - max pipeline.     (up to 127).  //
-  //                      0 - no keep alive               //
-  //                      1 - no pipeline, only keepalive //
   // keep_alive_timeout - in seconds. (up to 63 seconds). //
   // last_failure       - UNIX time for the last time     //
   //                      we tried the server & failed    //
@@ -108,7 +105,6 @@ union HostDBApplicationInfo {
   //////////////////////////////////////////////////////////
   struct http_server_attr {
     unsigned int http_version : 3;
-    unsigned int pipeline_max : 7;
     unsigned int keepalive_timeout : 6;
     unsigned int fail_count : 8;
     unsigned int unused1 : 8;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1332,7 +1332,6 @@ HttpTransact::setup_plugin_request_intercept(State *s)
   s->server_info.http_version.set(1, 0);
   s->server_info.keep_alive                  = HTTP_NO_KEEPALIVE;
   s->host_db_info.app.http_data.http_version = HostDBApplicationInfo::HTTP_VERSION_10;
-  s->host_db_info.app.http_data.pipeline_max = 1;
   s->server_info.dst_addr.setToAnyAddr(AF_INET);                                 // must set an address or we can't set the port.
   s->server_info.dst_addr.port() = htons(s->hdr_info.client_request.port_get()); // this is the info that matters.
 


### PR DESCRIPTION
While looking at pipeline logic, ran across this member variable that appears to be obsolete.