### PR TITLE
Remove remnants of http/1.1 pipeline logic.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3296,8 +3296,7 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
     // only external POSTs should be subject to this logic; ruling out internal POSTs here
     bool is_eligible_post_request = ((t_state.method == HTTP_WKSIDX_POST) && !is_internal);
 
-    if ((is_eligible_post_request || t_state.client_info.pipeline_possible == true) && c->producer->vc_type != HT_STATIC &&
-        event == VC_EVENT_WRITE_COMPLETE) {
+    if (is_eligible_post_request && c->producer->vc_type != HT_STATIC && event == VC_EVENT_WRITE_COMPLETE) {
       ua_txn->set_half_close_flag(true);
     }
 
@@ -3606,7 +3605,6 @@ HttpSM::tunnel_handler_post_server(int event, HttpTunnelConsumer *c)
       if (ua_producer->vc_type == HT_STATIC && event != VC_EVENT_ERROR && event != VC_EVENT_EOS) {
         ua_entry->read_vio = ua_producer->vc->do_io_read(this, INT64_MAX, c->producer->read_buffer);
         // ua_producer->vc->do_io_shutdown(IO_SHUTDOWN_READ);
-        t_state.client_info.pipeline_possible = false;
       } else {
         if (ua_producer->vc_type == HT_STATIC && t_state.redirect_info.redirect_in_process) {
           post_failed = true;
@@ -3616,7 +3614,6 @@ HttpSM::tunnel_handler_post_server(int event, HttpTunnelConsumer *c)
       ua_entry->read_vio = ua_producer->vc->do_io_read(this, INT64_MAX, c->producer->read_buffer);
       // we should not shutdown read side of the client here to prevent sending a reset
       // ua_producer->vc->do_io_shutdown(IO_SHUTDOWN_READ);
-      t_state.client_info.pipeline_possible = false;
     } // end of added logic
 
     // We want to shutdown the tunnel here and see if there

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5438,10 +5438,6 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
     s->client_info.keep_alive = incoming_request->keep_alive_get();
   }
 
-  if (s->client_info.keep_alive == HTTP_KEEPALIVE && s->client_info.http_version == HTTPVersion(1, 1)) {
-    s->client_info.pipeline_possible = true;
-  }
-
   if (!s->server_info.name || s->redirect_info.redirect_in_process) {
     s->server_info.name = s->arena.str_store(host_name, host_len);
   }

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -541,7 +541,6 @@ public:
     // The following variable is true if the client expects to
     // received a chunked response.
     bool receive_chunked_response = false;
-    bool pipeline_possible        = false;
     bool proxy_connect_hdr        = false;
     /// @c errno from the most recent attempt to connect.
     /// zero means no failure (not attempted, succeeded).


### PR DESCRIPTION
There is only one place that enforces on the pipeline_possible flag which is in HttpSM::tunnel_handler_ua.  In the logic that would otherwise close the client connection (i.e. it is Http/1.1 with the connection header set to close), the pipeline_possible flag is checked and the half_open flag is set to delay the client connection close.  Which seems like a bad idea.

Beyond that, the logic that sets the pipeline_possible flag in HttpTransact::initialize_state_variables_from_request would not set it in that case.  So I don't think that half close logic would ever get invoked purely based on the pipeline_possible flag.

I don't think ATS currently supports HTTP/1.1 pipelining as described in the wikipedia article in that we never send out HTTP/1.1 requests from the same connection in parallel.  ATS does process them in series, but it does that just by virtual of the keep-alive logic.  The parallel requests are amply supported by HTTP/2 and moving forward HTTP/3, so no need to go back and fix up HTTP/1.1 pipelining support.

https://en.wikipedia.org/wiki/HTTP_pipelining

I would like to clean up the remnants of the pipelining logic to reduce confusion moving forward.