### PR TITLE
Adding connection close headers to regex_remap test.

### DIFF
--- a/tests/gold_tests/pluginTest/regex_remap/replay/yts-2819.replay.json
+++ b/tests/gold_tests/pluginTest/regex_remap/replay/yts-2819.replay.json
@@ -62,6 +62,10 @@
                 [
                   "Content-Length",
                   "6128"
+                ],
+                [
+                  "Connection",
+                  "close"
                 ]
               ]
             }
@@ -132,6 +136,10 @@
                 [
                   "Content-Length",
                   "6128"
+                ],
+                [
+                  "Connection",
+                  "close"
                 ]
               ]
             }


### PR DESCRIPTION
The new microserver 1.0.4 has the ability to keep the connection to the client open. This is to support connection reuse tests. Most tests request microserver to reply with a "Connection: close" header which causes the connection to be closed after the response, but regex_remap didn't. This adds those Connection: close headers to the regex_remap response.

Without this change, the regex_remap test failed with the following output:

```
 Test: regex_remap: Failed
    File: regex_remap.test.py
    Directory: /home/bneradt/work/trafficserver_2910/tests/gold_tests/pluginTest/regex_remap
   Starting Test regex_remap : No issues found - Passed
      Reason: Started!
   Process: server: Failed
     Setting up : Lamda - Passed
     Setting up : MakeDir - Passed
     Setting up : Copy - Passed
     Test : Checking that any test passes - Failed
        Reason: None of the tests passed
     
       Test : Checking that ReturnCode == None - Failed
          Reason: Returned Value -9 != None
       
     
       Test : Checking that ReturnCode == 0 - Failed
          Reason: Returned Value -9 != 0

```