### PR TITLE
Fix some long lines and reduntant plugin_config SO additions.

### DIFF
--- a/tests/gold_tests/headers/syntax.test.py
+++ b/tests/gold_tests/headers/syntax.test.py
@@ -38,7 +38,7 @@ ts.Disk.remap_config.AddLine(
     'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
 )
 
-# Test 1 - 200 Response
+# Test 0 - 200 Response
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.port))
@@ -47,21 +47,21 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "syntax.200.gold"
 tr.StillRunningAfter = ts
 
-# Test 2 - 400 Response - Single space after field name
+# Test 1 - 400 Response - Single space after field name
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl -s -D - -v --ipv4 --http1.1 -H "foo : bar" -H "Host: www.example.com" http://localhost:{0}/'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "syntax.400.gold"
 tr.StillRunningAfter = ts
 
-# Test 3 - 400 Response - Double space after field name
+# Test 2 - 400 Response - Double space after field name
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl -s -D - -v --ipv4 --http1.1 -H "foo  : bar" -H "Host: www.example.com" http://localhost:{0}/'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "syntax.400.gold"
 tr.StillRunningAfter = ts
 
-# Test 4 - 400 Response - Three different Content-Length headers
+# Test 3 - 400 Response - Three different Content-Length headers
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl -s -D - -v --ipv4 --http1.1 -d "hello world" -H "Content-Length: 11" -H "Content-Length: 10" -H "Content-Length: 9" -H "Host: www.example.com" http://localhost:{0}/'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
@@ -75,7 +75,7 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "syntax.200.gold"
 tr.StillRunningAfter = ts
 
-# Test 4 - 200 Response - Three different Content-Length headers with a Transfer ecoding header
+# Test 5 - 200 Response - Three different Content-Length headers with a Transfer encoding header
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl -s -D - -v --ipv4 --http1.1 -d "hello world" -H "Transfer-Encoding: chunked" -H "Content-Length: 11" -H "Content-Length: 10" -H "Content-Length: 9" -H "Host: www.example.com" http://localhost:{0}/'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -75,10 +75,6 @@ ts.Disk.sni_yaml.AddLines([
 # Set up plugin
 Test.PreparePlugin(Test.Variables.AtsExampleDir + '/plugins/c-api/cert_update/cert_update.cc', ts)
 
-ts.Disk.plugin_config.AddLine(
-    'cert_update.so'
-)
-
 # Server-Cert-Pre
 # curl should see that Traffic Server presents bar.com cert from alice
 tr = Test.AddTestRun("Server-Cert-Pre")

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
@@ -21,8 +21,9 @@ Test xdebug plugin X-Remap and fwd headers
 server = Test.MakeOriginServer("server", options={'--load': (Test.TestDirectory + '/x_remap-observer.py')})
 
 request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": "" }
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "" }
+    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+                   "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts")

--- a/tests/gold_tests/remap/remap_http.test.py
+++ b/tests/gold_tests/remap/remap_http.test.py
@@ -29,13 +29,17 @@ server2 = Test.MakeOriginServer("server2",lookup_key="{%Host}{PATH}")
 dns = Test.MakeDNServer("dns")
 
 Test.testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+                  "timestamp": "1469733493.993", "body": ""}
 # expected response from the origin server
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+                   "timestamp": "1469733493.993", "body": ""}
 
-request_header2 = {"headers": "GET /test HTTP/1.1\r\nHost: www.testexample.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header2 = {"headers": "GET /test HTTP/1.1\r\nHost: www.testexample.com\r\n\r\n",
+                   "timestamp": "1469733493.993", "body": ""}
 # expected response from the origin server
-response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+                    "timestamp": "1469733493.993", "body": ""}
 
 # add response to the server dictionary
 server.addResponse("sessionfile.log", request_header, response_header)

--- a/tests/gold_tests/remap/remap_https.test.py
+++ b/tests/gold_tests/remap/remap_https.test.py
@@ -29,9 +29,11 @@ server2 = Test.MakeOriginServer("server2", ssl=True)
 
 #**testname is required**
 testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+                  "timestamp": "1469733493.993", "body": ""}
 # desired response form the origin server
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+                   "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 server2.addResponse("sessionlog.json", request_header, response_header)
 

--- a/tests/gold_tests/slow_post/slow_post.test.py
+++ b/tests/gold_tests/slow_post/slow_post.test.py
@@ -46,9 +46,6 @@ class SlowPostAttack:
             'map / http://127.0.0.1:{0}'.format(self._server.Variables.Port)
         )
         # This plugin can enable request buffer for POST.
-        self._ts.Disk.plugin_config.AddLine(
-            'request_buffer.so'
-        )
         Test.PreparePlugin(os.path.join(Test.Variables.AtsTestToolsDir, 'plugins', 'request_buffer.c'), self._ts)
         self._ts.Disk.records_config.update({
             'proxy.config.diags.debug.enabled': 1,


### PR DESCRIPTION
While working on the PR for session id matching:
https://github.com/apache/trafficserver/pull/6066

I noticed that some tests call Test.PreparePlugin and then follow that up with:

ts.Disk.plugin_config.AddLine(
    'cert_update.so'
)

Those AddLine calls are redundant because PreparePlugin already does that for the caller.

This also addresses some long lines and fixes the test numbering comments in the syntax.test.py.