### PR TITLE
Issue 4635: Address pipe reuse after configuration reload issues

### DIFF
--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -118,6 +118,12 @@ LogFile::LogFile(const LogFile &copy)
 LogFile::~LogFile()
 {
   Debug("log-file", "entering LogFile destructor, this=%p", this);
+
+  // close_file() checks whether a file is open before attempting to close, so
+  // this is safe to call even if a file had not been opened. Further, calling
+  // close_file() here ensures that we do not leak file descriptors.
+  close_file();
+
   delete m_log;
   ats_free(m_header);
   ats_free(m_name);


### PR DESCRIPTION
This addresses the issue described by @ema :

https://github.com/apache/trafficserver/issues/4635

I reproduced the inability to read from the pipe after trafficserver responded to the HUP signal and unlinked the pipe. I next removed the unlink and reproduced the leaked file descriptor Emanuele describes. I then added the close call in the LogFile destructor and the pipe is no longer leaked.

Notice further that I changed the wording in the code comments concerning the meta file for a pipe. Meta files are used only for log rotation and pipes are never rotated since that concept doesn't apply to a pipe. Thus we never associate a meta file with log pipes. This can be seen in the LogFile constructor:

https://github.com/apache/trafficserver/blob/92d4ef1/proxy/logging/LogFile.cc#L74

Notice that BaseLogFile is only created if the LogFile is not a pipe. BaseLogFile is the object that manages the meta file, thus meta files are (correctly) not created for pipes.