### PR TITLE
Revert "Disable the HttpSM half open logic if the underlying transpor…

### DIFF
--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -76,13 +76,6 @@ public:
   void do_io_shutdown(ShutdownHowTo_t howto) override;
   void reenable(VIO *vio) override;
 
-  bool
-  allow_half_open()
-  {
-    // Only allow half open connections if the not over TLS
-    return (client_vc && dynamic_cast<SSLNetVConnection *>(client_vc) == nullptr);
-  }
-
   void
   set_half_close_flag(bool flag) override
   {

--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -71,10 +71,5 @@ Http1ClientTransaction::transaction_done()
 bool
 Http1ClientTransaction::allow_half_open() const
 {
-  bool config_allows_it = (current_reader) ? current_reader->t_state.txn_conf->allow_half_open > 0 : true;
-  if (config_allows_it) {
-    // Check with the session to make sure the underlying transport allows the half open scenario
-    return static_cast<Http1ClientSession *>(parent)->allow_half_open();
-  }
-  return false;
+  return current_reader ? current_reader->t_state.txn_conf->allow_half_open > 0 : true;
 }


### PR DESCRIPTION
…t is TLS"

This reverts commit 422e81057070d405a1aa24575d36383e8a7c8d2e.

This is an attempt to stabilize the issues after #4213, and also to verify that eliminating this code path is indeed a fix.