### PR TITLE
Only decrement log_stat_log_files_open_stat when the file is closed.

### DIFF
--- a/include/tscore/BaseLogFile.h
+++ b/include/tscore/BaseLogFile.h
@@ -177,7 +177,7 @@ public:
   static bool rolled_logfile(char *path);
   static bool exists(const char *pathname);
   int open_file(int perm = -1);
-  void close_file();
+  int close_file();
   void change_name(const char *new_name);
   void display(FILE *fd = stdout);
   const char *

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -258,18 +258,24 @@ LogFile::close_file()
 {
   if (is_open()) {
     if (m_file_format == LOG_FILE_PIPE) {
-      ::close(m_fd);
-      Debug("log-file", "LogFile %s (fd=%d) is closed", m_name, m_fd);
+      if (::close(m_fd)) {
+        Error("Error closing LogFile %s: %s.", m_name, strerror(errno));
+      } else {
+        Debug("log-file", "LogFile %s (fd=%d) is closed", m_name, m_fd);
+        RecIncrRawStat(log_rsb, this_thread()->mutex->thread_holding, log_stat_log_files_open_stat, -1);
+      }
       m_fd = -1;
     } else if (m_log) {
-      m_log->close_file();
-      Debug("log-file", "LogFile %s is closed", m_log->get_name());
+      if (m_log->close_file()) {
+        Error("Error closing LogFile %s: %s.", m_log->get_name(), strerror(errno));
+      } else {
+        Debug("log-file", "LogFile %s is closed", m_log->get_name());
+        RecIncrRawStat(log_rsb, this_thread()->mutex->thread_holding, log_stat_log_files_open_stat, -1);
+      }
     } else {
       Warning("LogFile %s is open but was not closed", m_name);
     }
   }
-
-  RecIncrRawStat(log_rsb, this_thread()->mutex->thread_holding, log_stat_log_files_open_stat, -1);
 }
 
 struct RolledFile {
@@ -369,7 +375,9 @@ LogFile::roll(long interval_start, long interval_end, bool reopen_after_rolling)
     // Since these two methods of using BaseLogFile are not compatible, we perform the logging log file specific
     // close file operation here within the containing LogFile object.
     if (m_log->roll(interval_start, interval_end)) {
-      m_log->close_file();
+      if (m_log->close_file()) {
+        Error("Error closing LogFile %s: %s.", m_log->get_name(), strerror(errno));
+      }
 
       if (reopen_after_rolling) {
         /* If we re-open now log file will be created even if there is nothing being logged */

--- a/src/tscore/BaseLogFile.cc
+++ b/src/tscore/BaseLogFile.cc
@@ -339,18 +339,30 @@ BaseLogFile::open_file(int perm)
   return LOG_FILE_NO_ERROR;
 }
 
-/*
- * Closes actual log file, not metainfo
+/**
+ * @brief Close the managed log file.
+ *
+ * @note This closes the actual log file, not its metainfo.
+ *
+ * @return The result of calling fclose on the file descriptor or 0 if the file
+ * was not open. If the result is non-zero, fclose failed and errno is set
+ * appropriately.
  */
-void
+int
 BaseLogFile::close_file()
 {
+  int ret = 0;
   if (is_open()) {
-    fclose(m_fp);
     log_log_trace("BaseLogFile %s is closed\n", m_name.get());
+
+    // Both log_log_trace and fclose may set errno. Thus, keep fclose after
+    // log_log_trace so that by the time this function completes if errno was
+    // set by fclose it will remain upon function return.
+    ret       = fclose(m_fp);
     m_fp      = nullptr;
     m_is_init = false;
   }
+  return ret;
 }
 
 /*


### PR DESCRIPTION
I noticed via code inspection that our log_stat_log_files_open_stat could be off: we only increment the stat when opening succeeds, but we always decremented the stat every time close_file() was called regardless of whether a file descriptor was actually closed. This patch addresses this.