### PR TITLE
Local 8.0.x change for gcc9 - Map.h, MemSpan.h, ink_uuid.h

### DIFF
--- a/include/tscore/Map.h
+++ b/include/tscore/Map.h
@@ -1150,6 +1150,7 @@ public:
   MapElem(K const &akey, C const &avalue) : key(akey), value(avalue) {}
   MapElem(MapElem const &e) : key(e.key), value(e.value) {}
   MapElem() : key(), value() {}
+  MapElem &operator=(MapElem const &that) = default;
 };
 
 template <class K, class C, class A = DefaultAlloc> class Map : public Vec<MapElem<K, C>, A>

--- a/include/tscore/MemSpan.h
+++ b/include/tscore/MemSpan.h
@@ -53,6 +53,8 @@ public:
   /// Default constructor (empty buffer).
   constexpr MemSpan();
 
+  constexpr MemSpan(self_type const &that) = default;
+
   /** Construct explicitly with a pointer and size.
    */
   constexpr MemSpan(void *ptr,  ///< Pointer to buffer.

--- a/include/tscore/ink_uuid.h
+++ b/include/tscore/ink_uuid.h
@@ -36,6 +36,8 @@ public:
   ATSUuid() : _version(TS_UUID_UNDEFINED) {}
   ATSUuid &operator=(const ATSUuid other);
 
+  ATSUuid(ATSUuid const &that) = default;
+
   // Initialize the UUID from a string
   bool parseString(const char *str);
 


### PR DESCRIPTION
I was able to cherry pick the majority of the changes from master to 8.0.x for gcc9 support.  I wasn't able to find commits for these 3 lines and made these changes local to the 8.0.x branch.