### PR TITLE
For remap_stats, removes configure time dependency on search.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2080,8 +2080,6 @@ AS_IF([test "x$enable_experimental_plugins" = "xyes"],
         AC_CHECK_FUNCS([hcreate_r hsearch_r])
       ])
   ])
-AM_CONDITIONAL([BUILD_REMAP_STATS_PLUGIN],
-  [ test "x$enable_experimental_plugins" = "xyes" -a "x$ac_cv_header_search_h" = "xyes" -a "x$ac_cv_type_struct_hsearch_data" = "xyes" -a "x$ac_cv_func_hcreate_r" = "xyes" -a "x$ac_cv_func_hsearch_r" = "xyes" ])
 
 AC_ARG_WITH([default-stack-size],
   [AS_HELP_STRING([--with-default-stack-size],[specify the default stack size in bytes [default=1048576]])],

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -72,6 +72,7 @@ include experimental/metalink/Makefile.inc
 include experimental/money_trace/Makefile.inc
 include experimental/mp4/Makefile.inc
 include experimental/redo_cache_lookup/Makefile.inc
+include experimental/remap_stats/Makefile.inc
 include experimental/server_push_preload/Makefile.inc
 include experimental/slice/Makefile.inc
 include experimental/sslheaders/Makefile.inc
@@ -91,10 +92,6 @@ endif
 
 if BUILD_SSL_SESSION_REUSE_PLUGIN
 include experimental/ssl_session_reuse/Makefile.inc
-endif
-
-if BUILD_REMAP_STATS_PLUGIN
-include experimental/remap_stats/Makefile.inc
 endif
 
 if HAS_KYOTOCABINET


### PR DESCRIPTION
The plugin no longer depends on this header since moving to C++