### PR TITLE
doc + unittest TSRemap(Init|NewInstance) failures

### DIFF
--- a/doc/developer-guide/plugins/remap-plugins.en.rst
+++ b/doc/developer-guide/plugins/remap-plugins.en.rst
@@ -50,6 +50,9 @@ should be placed in :arg:`errbuff`, taking note of the maximum size of the buffe
 :arg:`errbuff_size`. The message is checked if the function returns a value other than
 :macro:`TS_SUCCESS`.
 
+If :func:`TSRemapInit` returns :macro:`TS_ERROR` then the remap configuration loading
+is aborted immediatelly.
+
 This function should perform any plugin global initialization, such as setting up static data
 tables. It only be called immediately after the dynamic library is loaded from disk.
 
@@ -87,6 +90,9 @@ completed before any calls to :func:`TSRemapDoRemap`.
 If there is an error then the callback should return :macro:`TS_ERROR` and fill in the
 :arg:`errbuff` with a C-string describing the error. Otherwise the function must return
 :macro:`TS_SUCCESS`.
+
+If :func:`TSRemapNewInstance` returns :macro:`TS_ERROR` then the remap configuration loading
+is aborted immediatelly.
 
 
 Configuration reload notifications

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -82,7 +82,10 @@ test_PluginDso_SOURCES = \
 
 test_PluginFactory_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DPLUGIN_DSO_TESTS
 test_PluginFactory_LIBTOOLFLAGS = --preserve-dup-deps
-EXTRA_test_PluginFactory_DEPENDENCIES = unit-tests/plugin_v1.la
+EXTRA_test_PluginFactory_DEPENDENCIES = \
+	unit-tests/plugin_v1.la \
+	unit-tests/plugin_init_fail.la
+	unit-tests/plugin_instinit_fail.la
 test_PluginFactory_LDADD = $(COMMON_PLUGINDSO_LDADDS)
 test_PluginFactory_LDFLAGS = $(AM_LDFLAGS)
 test_PluginFactory_SOURCES = \
@@ -121,6 +124,8 @@ DSO_LDFLAGS = \
 pkglib_LTLIBRARIES = \
 	unit-tests/plugin_v1.la \
 	unit-tests/plugin_v2.la \
+	unit-tests/plugin_init_fail.la \
+	unit-tests/plugin_instinit_fail.la \
 	unit-tests/plugin_required_cb.la \
 	unit-tests/plugin_missing_deleteinstance.la \
 	unit-tests/plugin_missing_doremap.la \
@@ -133,6 +138,12 @@ unit_tests_plugin_v1_la_CPPFLAGS = -DPLUGINDSOVER=1 $(AM_CPPFLAGS)
 unit_tests_plugin_v2_la_SOURCES = unit-tests/plugin_misc_cb.cc
 unit_tests_plugin_v2_la_LDFLAGS = $(DSO_LDFLAGS)
 unit_tests_plugin_v2_la_CPPFLAGS = -DPLUGINDSOVER=2 $(AM_CPPFLAGS)
+unit_tests_plugin_init_fail_la_SOURCES = unit-tests/plugin_init_fail.cc
+unit_tests_plugin_init_fail_la_LDFLAGS = $(DSO_LDFLAGS)
+unit_tests_plugin_init_fail_la_CPPFLAGS = $(AM_CPPFLAGS)
+unit_tests_plugin_instinit_fail_la_SOURCES = unit-tests/plugin_instinit_fail.cc
+unit_tests_plugin_instinit_fail_la_LDFLAGS = $(DSO_LDFLAGS)
+unit_tests_plugin_instinit_fail_la_CPPFLAGS = $(AM_CPPFLAGS)
 unit_tests_plugin_required_cb_la_SOURCES = unit-tests/plugin_required_cb.cc
 unit_tests_plugin_required_cb_la_LDFLAGS = $(DSO_LDFLAGS)
 unit_tests_plugin_required_cb_la_CPPFLAGS = -DPLUGINDSOVER=1 $(AM_CPPFLAGS)

--- a/proxy/http/remap/PluginFactory.cc
+++ b/proxy/http/remap/PluginFactory.cc
@@ -171,13 +171,15 @@ PluginFactory::getRemapPlugin(const fs::path &configPath, int argc, char **argv,
     plugin = new RemapPluginInfo(configPath, effectivePath, runtimePath);
     if (nullptr != plugin) {
       if (plugin->load(error)) {
-        PluginDso::loadedPlugins()->add(plugin);
-
         if (plugin->init(error)) {
+          PluginDso::loadedPlugins()->add(plugin);
           inst = RemapPluginInst::init(plugin, argc, argv, error);
           if (nullptr != inst) {
             _instList.append(inst);
           }
+        } else {
+          plugin->unload(error);
+          delete plugin;
         }
 
         if (_preventiveCleaning) {

--- a/proxy/http/remap/unit-tests/plugin_init_fail.cc
+++ b/proxy/http/remap/unit-tests/plugin_init_fail.cc
@@ -1,0 +1,58 @@
+/** @file
+
+  A test plugin for testing Plugin's Dynamic Shared Objects (DSO)
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  @section details Details
+
+  Implements code necessary for Reverse Proxy which mostly consists of
+  general purpose hostname substitution in URLs.
+
+ */
+
+#include "plugin_testing_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include "ts/ts.h"
+#include "ts/remap.h"
+
+TSReturnCode
+TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+{
+  return TS_ERROR;
+}
+
+void
+TSRemapDone(void)
+{
+}
+
+TSRemapStatus
+TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
+{
+  return TSREMAP_NO_REMAP;
+}
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */

--- a/proxy/http/remap/unit-tests/plugin_instinit_fail.cc
+++ b/proxy/http/remap/unit-tests/plugin_instinit_fail.cc
@@ -1,0 +1,69 @@
+/** @file
+
+  A test plugin for testing Plugin's Dynamic Shared Objects (DSO)
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  @section details Details
+
+  Implements code necessary for Reverse Proxy which mostly consists of
+  general purpose hostname substitution in URLs.
+
+ */
+
+#include "plugin_testing_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include "ts/ts.h"
+#include "ts/remap.h"
+
+TSReturnCode
+TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+{
+  return TS_SUCCESS;
+}
+
+void
+TSRemapDone(void)
+{
+}
+
+TSReturnCode
+TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size)
+{
+  return TS_ERROR;
+}
+
+void
+TSRemapDeleteInstance(void *)
+{
+}
+
+TSRemapStatus
+TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
+{
+  return TSREMAP_NO_REMAP;
+}
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */

--- a/proxy/http/remap/unit-tests/test_PluginFactory.cc
+++ b/proxy/http/remap/unit-tests/test_PluginFactory.cc
@@ -190,7 +190,11 @@ SCENARIO("loading plugins", "[plugin][core]")
       PluginFactoryUnitTest *factory = getFactory(tempComponent);
       RemapPluginInst *plugin        = factory->getRemapPlugin(configPath, 0, nullptr, error);
 
-      THEN("expect it to successfully load") { validateSuccessfulConfigPathTest(plugin, error, effectivePath, runtimePath); }
+      THEN("expect it to successfully load")
+      {
+        validateSuccessfulConfigPathTest(plugin, error, effectivePath, runtimePath);
+        CHECK(nullptr != PluginDso::loadedPlugins()->findByEffectivePath(effectivePath));
+      }
 
       teardownConfigPathTest(factory);
     }
@@ -204,7 +208,11 @@ SCENARIO("loading plugins", "[plugin][core]")
       PluginFactoryUnitTest *factory = getFactory(tempComponent);
       RemapPluginInst *plugin        = factory->getRemapPlugin(configPath, 0, nullptr, error);
 
-      THEN("expect it to successfully load") { validateSuccessfulConfigPathTest(plugin, error, effectivePath, runtimePath); }
+      THEN("expect it to successfully load")
+      {
+        validateSuccessfulConfigPathTest(plugin, error, effectivePath, runtimePath);
+        CHECK(nullptr != PluginDso::loadedPlugins()->findByEffectivePath(effectivePath));
+      }
 
       teardownConfigPathTest(factory);
     }
@@ -218,7 +226,11 @@ SCENARIO("loading plugins", "[plugin][core]")
       PluginFactoryUnitTest *factory = getFactory(tempComponent);
       RemapPluginInst *plugin        = factory->getRemapPlugin(configPath, 0, nullptr, error);
 
-      THEN("expect it to successfully load") { validateSuccessfulConfigPathTest(plugin, error, effectivePath, runtimePath); }
+      THEN("expect it to successfully load")
+      {
+        validateSuccessfulConfigPathTest(plugin, error, effectivePath, runtimePath);
+        CHECK(nullptr != PluginDso::loadedPlugins()->findByEffectivePath(effectivePath));
+      }
 
       teardownConfigPathTest(factory);
     }
@@ -263,6 +275,40 @@ SCENARIO("loading plugins", "[plugin][core]")
         expectedError.append("failed to find plugin '").append(absoluteNonexistingPath.string()).append("'");
         CHECK(nullptr == plugin);
         CHECK(expectedError == error);
+      }
+
+      teardownConfigPathTest(factory);
+    }
+
+    WHEN("plugin initialization fails")
+    {
+      fs::path configPath = fs::path("plugin_init_fail.so");
+      fs::path buildPath  = pluginBuildDir / configPath;
+      setupConfigPathTest(configPath, buildPath, tempComponent, effectivePath, runtimePath);
+      PluginFactoryUnitTest *factory = getFactory(tempComponent);
+      RemapPluginInst *plugin        = factory->getRemapPlugin(configPath, 0, nullptr, error);
+
+      THEN("expect it to unload the plugin dso")
+      {
+        CHECK(nullptr == plugin);
+        CHECK(nullptr == PluginDso::loadedPlugins()->findByEffectivePath(effectivePath));
+      }
+
+      teardownConfigPathTest(factory);
+    }
+
+    WHEN("instance initialization fails")
+    {
+      fs::path configPath = fs::path("plugin_instinit_fail.so");
+      fs::path buildPath  = pluginBuildDir / configPath;
+      setupConfigPathTest(configPath, buildPath, tempComponent, effectivePath, runtimePath);
+      PluginFactoryUnitTest *factory = getFactory(tempComponent);
+      RemapPluginInst *plugin        = factory->getRemapPlugin(configPath, 0, nullptr, error);
+
+      THEN("expect it to unload the plugin dso")
+      {
+        CHECK(nullptr == plugin);
+        CHECK(nullptr == PluginDso::loadedPlugins()->findByEffectivePath(effectivePath));
       }
 
       teardownConfigPathTest(factory);


### PR DESCRIPTION
Documented configuration reload behavior when `TSRemapIniti()` and `TSRemapNewInstance()` return `TS_ERROR` aborting the reload.

Verified that `TSRemapInit()` and `TSRemapNewInstance()` actually abort the configuration reload if any of them return `TS_ERROR`. Discovered and fixed a discrepency with not unloading the DSO if the initial `TSRemapInit()` call returns `TS_ERROR`.  Added unit tests to validate the DSO actuall unloading.