### PR TITLE
Updating the autest version pin to 1.7.4.

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -22,7 +22,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-autest = "==1.7.3"
+autest = "==1.7.4"
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"
 dnslib = "*"


### PR DESCRIPTION
This newer version of autest is required for the new tests/gold_tests/logging/log_retention.test.py which was just merged in. 1.7.4 has a fix for handling addition of testers to stderr.