### PR TITLE
Cleanup the eventloop

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -475,9 +475,9 @@ aio_thread_main(void *arg)
         SCOPED_MUTEX_LOCK(lock, op->mutex, thr_info->mutex->thread_holding);
         op->handleEvent(EVENT_NONE, nullptr);
       } else if (op->thread == AIO_CALLBACK_THREAD_ANY) {
-        eventProcessor.schedule_imm_signal(op);
+        eventProcessor.schedule_imm(op);
       } else {
-        op->thread->schedule_imm_signal(op);
+        op->thread->schedule_imm(op);
       }
       ink_mutex_acquire(&my_aio_req->aio_mutex);
     } while (true);

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -358,7 +358,7 @@ Vol::aggWriteDone(int event, Event *e)
   CacheVC *c = nullptr;
   while ((c = sync.dequeue())) {
     if (UINT_WRAP_LTE(c->write_serial + 2, header->write_serial)) {
-      eventProcessor.schedule_imm_signal(c, ET_CALL, AIO_EVENT_DONE);
+      eventProcessor.schedule_imm(c, ET_CALL, AIO_EVENT_DONE);
     } else {
       sync.push(c); // put it back on the front
       break;
@@ -1026,7 +1026,7 @@ Lagain:
       ink_assert(false);
       while ((c = agg.dequeue())) {
         agg_todo_size -= c->agg_len;
-        eventProcessor.schedule_imm_signal(c, ET_CALL, AIO_EVENT_DONE);
+        eventProcessor.schedule_imm(c, ET_CALL, AIO_EVENT_DONE);
       }
       return EVENT_CONT;
     }
@@ -1090,7 +1090,7 @@ Lwait:
     if (event == EVENT_CALL && c->mutex->thread_holding == mutex->thread_holding) {
       ret = EVENT_RETURN;
     } else {
-      eventProcessor.schedule_imm_signal(c, ET_CALL, AIO_EVENT_DONE);
+      eventProcessor.schedule_imm(c, ET_CALL, AIO_EVENT_DONE);
     }
   }
   return ret;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1437,7 +1437,7 @@ DNSEntry::post(DNSHandler *h, HostEnt *ent)
   } else {
     mutex = action.mutex;
     SET_HANDLER(&DNSEntry::postOneEvent);
-    submit_thread->schedule_imm_signal(this);
+    submit_thread->schedule_imm(this);
   }
   return 0;
 }

--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -126,7 +126,6 @@ public:
 
   */
   Event *schedule_imm(Continuation *c, int callback_event = EVENT_IMMEDIATE, void *cookie = nullptr);
-  Event *schedule_imm_signal(Continuation *c, int callback_event = EVENT_IMMEDIATE, void *cookie = nullptr);
 
   /**
     Schedules the continuation on this EThread to receive an event
@@ -300,7 +299,7 @@ public:
   EThread &operator=(const EThread &) = delete;
   ~EThread() override;
 
-  Event *schedule(Event *e, bool fast_signal = false);
+  Event *schedule(Event *e);
 
   /** Block of memory to allocate thread specific data e.g. stat system arrays. */
   char thread_private[PER_THREAD_DATA];
@@ -313,9 +312,6 @@ public:
 
   ProtectedQueue EventQueueExternal;
   PriorityEventQueue EventQueue;
-
-  EThread **ethreads_to_be_signalled = nullptr;
-  int n_ethreads_to_be_signalled     = 0;
 
   static constexpr int NO_ETHREAD_ID = -1;
   int id                             = NO_ETHREAD_ID;

--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -151,11 +151,7 @@ public:
   */
   Event *schedule_imm(Continuation *c, EventType event_type = ET_CALL, int callback_event = EVENT_IMMEDIATE,
                       void *cookie = nullptr);
-  /*
-    provides the same functionality as schedule_imm and also signals the thread immediately
-  */
-  Event *schedule_imm_signal(Continuation *c, EventType event_type = ET_CALL, int callback_event = EVENT_IMMEDIATE,
-                             void *cookie = nullptr);
+
   /**
     Schedules the continuation on a specific thread group to receive an
     event at the given timeout. Requests the EventProcessor to schedule
@@ -329,7 +325,7 @@ public:
   | Unix & non NT Interface                                |
   \*------------------------------------------------------*/
 
-  Event *schedule(Event *e, EventType etype, bool fast_signal = false);
+  Event *schedule(Event *e, EventType etype);
   EThread *assign_thread(EventType etype);
   EThread *assign_affinity_by_type(Continuation *cont, EventType etype);
 

--- a/iocore/eventsystem/I_ProtectedQueue.h
+++ b/iocore/eventsystem/I_ProtectedQueue.h
@@ -37,7 +37,7 @@
 #include "tscore/ink_platform.h"
 #include "I_Event.h"
 struct ProtectedQueue {
-  void enqueue(Event *e, bool fast_signal = false);
+  void enqueue(Event *e);
   void signal();
   int try_signal();             // Use non blocking lock and if acquired, signal
   void enqueue_local(Event *e); // Safe when called from the same thread
@@ -54,5 +54,3 @@ struct ProtectedQueue {
 
   ProtectedQueue();
 };
-
-void flush_signals(EThread *t);

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -45,15 +45,6 @@ EThread::schedule_imm(Continuation *cont, int callback_event, void *cookie)
 }
 
 TS_INLINE Event *
-EThread::schedule_imm_signal(Continuation *cont, int callback_event, void *cookie)
-{
-  Event *e          = ::eventAllocator.alloc();
-  e->callback_event = callback_event;
-  e->cookie         = cookie;
-  return schedule(e->init(cont, 0, 0), true);
-}
-
-TS_INLINE Event *
 EThread::schedule_at(Continuation *cont, ink_hrtime t, int callback_event, void *cookie)
 {
   Event *e          = ::eventAllocator.alloc();
@@ -85,7 +76,7 @@ EThread::schedule_every(Continuation *cont, ink_hrtime t, int callback_event, vo
 }
 
 TS_INLINE Event *
-EThread::schedule(Event *e, bool fast_signal)
+EThread::schedule(Event *e)
 {
   e->ethread = this;
   ink_assert(tt == REGULAR);
@@ -100,7 +91,7 @@ EThread::schedule(Event *e, bool fast_signal)
   // The continuation that gets scheduled later is not always the
   // client VC, it can be HttpCacheSM etc. so save the flags
   e->continuation->control_flags.set_flags(get_cont_flags().get_flags());
-  EventQueueExternal.enqueue(e, fast_signal);
+  EventQueueExternal.enqueue(e);
   return e;
 }
 

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -89,7 +89,7 @@ EventProcessor::assign_affinity_by_type(Continuation *cont, EventType etype)
 }
 
 TS_INLINE Event *
-EventProcessor::schedule(Event *e, EventType etype, bool fast_signal)
+EventProcessor::schedule(Event *e, EventType etype)
 {
   ink_assert(etype < MAX_EVENT_TYPES);
 
@@ -118,22 +118,8 @@ EventProcessor::schedule(Event *e, EventType etype, bool fast_signal)
   } else {
     e->mutex = e->continuation->mutex = e->ethread->mutex;
   }
-  e->ethread->EventQueueExternal.enqueue(e, fast_signal);
+  e->ethread->EventQueueExternal.enqueue(e);
   return e;
-}
-
-TS_INLINE Event *
-EventProcessor::schedule_imm_signal(Continuation *cont, EventType et, int callback_event, void *cookie)
-{
-  Event *e = eventAllocator.alloc();
-
-  ink_assert(et < MAX_EVENT_TYPES);
-#ifdef ENABLE_TIME_TRACE
-  e->start_time = Thread::get_hrtime();
-#endif
-  e->callback_event = callback_event;
-  e->cookie         = cookie;
-  return schedule(e->init(cont, 0, 0), et, true);
 }
 
 TS_INLINE Event *

--- a/iocore/eventsystem/ProtectedQueue.cc
+++ b/iocore/eventsystem/ProtectedQueue.cc
@@ -44,7 +44,7 @@
 extern ClassAllocator<Event> eventAllocator;
 
 void
-ProtectedQueue::enqueue(Event *e, bool fast_signal)
+ProtectedQueue::enqueue(Event *e)
 {
   ink_assert(!e->in_the_prot_queue && !e->in_the_priority_queue);
   EThread *e_ethread   = e->ethread;
@@ -59,25 +59,6 @@ ProtectedQueue::enqueue(Event *e, bool fast_signal)
       e_ethread->tail_cb->signalActivity();
     }
   }
-}
-
-void
-flush_signals(EThread *thr)
-{
-  ink_assert(this_ethread() == thr);
-  int n = thr->n_ethreads_to_be_signalled;
-  if (n > eventProcessor.n_ethreads) {
-    n = eventProcessor.n_ethreads; // MAX
-  }
-  int i;
-
-  for (i = 0; i < n; i++) {
-    if (thr->ethreads_to_be_signalled[i]) {
-      thr->ethreads_to_be_signalled[i]->tail_cb->signalActivity();
-      thr->ethreads_to_be_signalled[i] = nullptr;
-    }
-  }
-  thr->n_ethreads_to_be_signalled = 0;
 }
 
 void

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -56,8 +56,6 @@ EThread::EThread()
 
 EThread::EThread(ThreadType att, int anid) : id(anid), tt(att)
 {
-  ethreads_to_be_signalled = static_cast<EThread **>(ats_malloc(MAX_EVENT_THREADS * sizeof(EThread *)));
-  memset(ethreads_to_be_signalled, 0, MAX_EVENT_THREADS * sizeof(EThread *));
   memset(thread_private, 0, PER_THREAD_DATA);
 #if HAVE_EVENTFD
   evfd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
@@ -92,15 +90,7 @@ EThread::EThread(ThreadType att, Event *e) : tt(att), start_event(e)
 
 // Provide a destructor so that SDK functions which create and destroy
 // threads won't have to deal with EThread memory deallocation.
-EThread::~EThread()
-{
-  if (n_ethreads_to_be_signalled > 0) {
-    flush_signals(this);
-  }
-  ats_free(ethreads_to_be_signalled);
-  // TODO: This can't be deleted ....
-  // delete[]l1_hash;
-}
+EThread::~EThread() {}
 
 bool
 EThread::is_event_type(EventType et)
@@ -268,10 +258,6 @@ EThread::execute_regular()
       ++(current_metric->_wait);
     } else {
       sleep_time = 0;
-    }
-
-    if (n_ethreads_to_be_signalled) {
-      flush_signals(this);
     }
 
     tail_cb->waitForActivity(sleep_time);

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -360,7 +360,7 @@ NetAccept::do_blocking_accept(EThread *t)
     NetHandler *h = get_NetHandler(t);
     // Assign NetHandler->mutex to NetVC
     vc->mutex = h->mutex;
-    t->schedule_imm_signal(vc);
+    t->schedule_imm(vc);
   } while (loop);
 
   return 1;


### PR DESCRIPTION
This is a cleanup for the eventloop, removed `schedule_imm_signal`, `fast_signal` and their related code since those are not used anymore.