### PR TITLE
Updated to clang-format v9.0.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,42 +2,48 @@
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: All
 AlwaysBreakAfterReturnType: AllDefinitions
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
+  AfterCaseLabel:  false
   AfterClass:      true
-  AfterControlStatement: true
-  AfterEnum:       true
+  AfterControlStatement: false
+  AfterEnum:       false
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: false
-  AfterStruct:     true
-  AfterUnion:      true
-  AfterExternBlock: true
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
-  SplitEmptyFunction: false
-  SplitEmptyRecord: false
-  SplitEmptyNamespace: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Linux
 BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
@@ -81,6 +87,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: false
@@ -89,20 +96,22 @@ PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 30000
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    Mozilla
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
@@ -111,6 +120,9 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
 TabWidth:        8
 UseTab:          Never
 ...

--- a/example/plugins/c-api/cache_scan/cache_scan.cc
+++ b/example/plugins/c-api/cache_scan/cache_scan.cc
@@ -491,7 +491,7 @@ cache_print_plugin(TSCont contp, TSEvent event, void *edata)
 
 //----------------------------------------------------------------------------
 void
-TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
+TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */[])
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/c-api/intercept/intercept.cc
+++ b/example/plugins/c-api/intercept/intercept.cc
@@ -534,7 +534,7 @@ InterceptTxnHook(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int /* argc */, const char * /* argv */ [])
+TSPluginInit(int /* argc */, const char * /* argv */[])
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/c-api/passthru/passthru.cc
+++ b/example/plugins/c-api/passthru/passthru.cc
@@ -315,7 +315,7 @@ PassthruListen()
 }
 
 void
-TSPluginInit(int /* argc */, const char * /* argv */ [])
+TSPluginInit(int /* argc */, const char * /* argv */[])
 {
   TSPluginRegistrationInfo info = {PLUGIN_NAME, "Apache Software Foundation", "dev@trafficserver.apache.org"};
 

--- a/example/plugins/c-api/statistic/statistic.cc
+++ b/example/plugins/c-api/statistic/statistic.cc
@@ -36,7 +36,7 @@
 #define PLUGIN_NAME "statistics"
 
 void
-TSPluginInit(int /* argc */, const char * /* argv */ [])
+TSPluginInit(int /* argc */, const char * /* argv */[])
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/cpp-api/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
+++ b/example/plugins/cpp-api/async_http_fetch_streaming/AsyncHttpFetchStreaming.cc
@@ -80,7 +80,7 @@ public:
 };
 
 void
-TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
+TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */[])
 {
   if (!RegisterGlobalPlugin("CPP_Example_AsyncHttpFetchStreaming", "apache", "dev@trafficserver.apache.org")) {
     return;

--- a/example/plugins/cpp-api/intercept/intercept.cc
+++ b/example/plugins/cpp-api/intercept/intercept.cc
@@ -58,7 +58,7 @@ public:
 };
 
 void
-TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
+TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */[])
 {
   if (!RegisterGlobalPlugin("CPP_Example_Intercept", "apache", "dev@trafficserver.apache.org")) {
     return;

--- a/include/tscore/BufferWriter.h
+++ b/include/tscore/BufferWriter.h
@@ -529,9 +529,7 @@ namespace bw_fmt
   /// @a TUPLE.  Due to language limitations it cannot be done directly. The formatters can be
   /// accessed via standard array access in contrast to templated tuple access. The actual array is
   /// static and therefore at run time the only operation is loading the address of the array.
-  template <typename TUPLE, size_t... N>
-  ArgFormatterSignature<TUPLE> *
-  Get_Arg_Formatter_Array(std::index_sequence<N...>)
+  template <typename TUPLE, size_t... N> ArgFormatterSignature<TUPLE> *Get_Arg_Formatter_Array(std::index_sequence<N...>)
   {
     static ArgFormatterSignature<TUPLE> fa[sizeof...(N)] = {&bw_fmt::Arg_Formatter<TUPLE, N>...};
     return fa;

--- a/include/tscore/Errata.h
+++ b/include/tscore/Errata.h
@@ -336,7 +336,7 @@ public:
                       int indent,        ///< Additional indention per line for messages.
                       int shift,         ///< Additional @a indent for nested @c Errata.
                       char const *lead   ///< Leading text for nested @c Errata.
-                      ) const;
+  ) const;
   /// Simple formatted output to fixed sized buffer.
   /// @return Number of characters written to @a buffer.
   size_t write(char *buffer,    ///< Output buffer.
@@ -345,7 +345,7 @@ public:
                int indent,      ///< Additional indention per line for messages.
                int shift,       ///< Additional @a indent for nested @c Errata.
                char const *lead ///< Leading text for nested @c Errata.
-               ) const;
+  ) const;
 
 protected:
   /// Construct from implementation pointer.

--- a/include/tscore/IpMap.h
+++ b/include/tscore/IpMap.h
@@ -306,7 +306,7 @@ public:
   */
   bool contains(sockaddr const *target, ///< Search target (network order).
                 void **ptr = nullptr    ///< Client data return.
-                ) const;
+  ) const;
 
   /** Test for membership.
 
@@ -318,7 +318,7 @@ public:
   */
   bool contains(in_addr_t target,    ///< Search target (network order).
                 void **ptr = nullptr ///< Client data return.
-                ) const;
+  ) const;
 
   /** Test for membership.
 
@@ -330,7 +330,7 @@ public:
   */
   bool contains(IpEndpoint const *target, ///< Search target (network order).
                 void **ptr = nullptr      ///< Client data return.
-                ) const;
+  ) const;
 
   /** Test for membership.
 
@@ -342,7 +342,7 @@ public:
   */
   bool contains(IpAddr const &target, ///< Search target (network order).
                 void **ptr = nullptr  ///< Client data return.
-                ) const;
+  ) const;
 
   /** Remove all addresses from the map.
 

--- a/include/tscore/RbTree.h
+++ b/include/tscore/RbTree.h
@@ -52,7 +52,7 @@ namespace detail
     /// @return The child in the direction @a d if it exists,
     /// @c NULL if not.
     self *getChild(Direction d //!< The direction of the desired child
-                   ) const;
+    ) const;
 
     /** Determine which child a node is
         @return @c LEFT if @a n is the left child,
@@ -61,7 +61,7 @@ namespace detail
     */
     Direction
     getChildDirection(self *const &n //!< The presumed child node
-                      ) const
+    ) const
     {
       return (n == _left) ? LEFT : (n == _right) ? RIGHT : NONE;
     }

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1214,7 +1214,7 @@ struct IpAddr {
   */
   char *toString(char *dest, ///< [out] Destination string buffer.
                  size_t len  ///< [in] Size of buffer.
-                 ) const;
+  ) const;
 
   /// Equality.
   bool

--- a/include/wccp/Wccp.h
+++ b/include/wccp/Wccp.h
@@ -187,7 +187,7 @@ public:
 
   /// Get a port value.
   uint16_t getPort(int idx ///< Index of target port.
-                   ) const;
+  ) const;
   /// Set a port value.
   self &setPort(int idx,      ///< Index of port.
                 uint16_t port ///< Value for port.

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -1191,7 +1191,8 @@ compare_ushort(void const *a, void const *b)
 // Check
 //
 
-int Vol::dir_check(bool /* fix ATS_UNUSED */) // TODO: we should eliminate this parameter ?
+int
+Vol::dir_check(bool /* fix ATS_UNUSED */) // TODO: we should eliminate this parameter ?
 {
   static int const SEGMENT_HISTOGRAM_WIDTH = 16;
   int hist[SEGMENT_HISTOGRAM_WIDTH + 1]    = {0};

--- a/iocore/cache/CacheTest.cc
+++ b/iocore/cache/CacheTest.cc
@@ -333,13 +333,14 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   remove_fail_test.expect_event = CACHE_EVENT_REMOVE_FAILED;
   rand_CacheKey(&remove_fail_test.key, thread->mutex);
 
-  CACHE_SM(t, replace_write_test,
-           { cacheProcessor.open_write(this, &key, CACHE_FRAG_TYPE_NONE, 100, CACHE_WRITE_OPT_SYNC); } int open_write_callout() {
-             header.serial = 10;
-             cache_vc->set_header(&header, sizeof(header));
-             cvio = cache_vc->do_io_write(this, nbytes, buffer_reader);
-             return 1;
-           });
+  CACHE_SM(
+    t, replace_write_test,
+    { cacheProcessor.open_write(this, &key, CACHE_FRAG_TYPE_NONE, 100, CACHE_WRITE_OPT_SYNC); } int open_write_callout() {
+      header.serial = 10;
+      cache_vc->set_header(&header, sizeof(header));
+      cvio = cache_vc->do_io_write(this, nbytes, buffer_reader);
+      return 1;
+    });
   replace_write_test.expect_initial_event = CACHE_EVENT_OPEN_WRITE;
   replace_write_test.expect_event         = VC_EVENT_WRITE_COMPLETE;
   replace_write_test.nbytes               = 100;
@@ -365,16 +366,17 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   replace_test.key                  = replace_write_test.key;
   replace_test.content_salt         = 1;
 
-  CACHE_SM(t, replace_read_test, { cacheProcessor.open_read(this, &key); } int open_read_callout() {
-    CacheTestHeader *h = nullptr;
-    int hlen           = 0;
-    if (cache_vc->get_header((void **)&h, &hlen) < 0)
-      return -1;
-    if (h->serial != 11)
-      return -1;
-    cvio = cache_vc->do_io_read(this, nbytes, buffer);
-    return 1;
-  });
+  CACHE_SM(
+    t, replace_read_test, { cacheProcessor.open_read(this, &key); } int open_read_callout() {
+      CacheTestHeader *h = nullptr;
+      int hlen           = 0;
+      if (cache_vc->get_header((void **)&h, &hlen) < 0)
+        return -1;
+      if (h->serial != 11)
+        return -1;
+      cvio = cache_vc->do_io_read(this, nbytes, buffer);
+      return 1;
+    });
   replace_read_test.expect_initial_event = CACHE_EVENT_OPEN_READ;
   replace_read_test.expect_event         = VC_EVENT_READ_COMPLETE;
   replace_read_test.nbytes               = 100;
@@ -387,10 +389,11 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   large_write_test.nbytes               = 10000000;
   rand_CacheKey(&large_write_test.key, thread->mutex);
 
-  CACHE_SM(t, pread_test, { cacheProcessor.open_read(this, &key); } int open_read_callout() {
-    cvio = cache_vc->do_io_pread(this, nbytes, buffer, 7000000);
-    return 1;
-  });
+  CACHE_SM(
+    t, pread_test, { cacheProcessor.open_read(this, &key); } int open_read_callout() {
+      cvio = cache_vc->do_io_pread(this, nbytes, buffer, 7000000);
+      return 1;
+    });
   pread_test.expect_initial_event = CACHE_EVENT_OPEN_READ;
   pread_test.expect_event         = VC_EVENT_READ_COMPLETE;
   pread_test.nbytes               = 100;

--- a/iocore/net/quic/Mock.h
+++ b/iocore/net/quic/Mock.h
@@ -560,10 +560,7 @@ public:
       _padder(NetVConnectionContext_t::NET_VCONNECTION_UNSET)
   {
   }
-  void
-  rcv_frame(std::shared_ptr<const QUICFrame>)
-  {
-  }
+  void rcv_frame(std::shared_ptr<const QUICFrame>) {}
 
   void
   on_packet_sent(QUICPacketUPtr packet)

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -1286,11 +1286,12 @@ RecSignalWarning(int sig, const char *fmt, ...)
 void
 RecConfigWarnIfUnregistered()
 {
-  RecDumpRecords(RECT_CONFIG,
-                 [](RecT, void *, int registered_p, const char *name, int, RecData *) -> void {
-                   if (!registered_p) {
-                     Warning("Unrecognized configuration value '%s'", name);
-                   }
-                 },
-                 nullptr);
+  RecDumpRecords(
+    RECT_CONFIG,
+    [](RecT, void *, int registered_p, const char *name, int, RecData *) -> void {
+      if (!registered_p) {
+        Warning("Unrecognized configuration value '%s'", name);
+      }
+    },
+    nullptr);
 }

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -1065,9 +1065,8 @@ recordIPCheck(const char *pattern, const char *value)
   //  regex_t regex;
   //  int result;
   bool check;
-  const char *range_pattern =
-    R"(\[[0-9]+\-[0-9]+\]\\\.\[[0-9]+\-[0-9]+\]\\\.\[[0-9]+\-[0-9]+\]\\\.\[[0-9]+\-[0-9]+\])";
-  const char *ip_pattern = "[0-9]*[0-9]*[0-9].[0-9]*[0-9]*[0-9].[0-9]*[0-9]*[0-9].[0-9]*[0-9]*[0-9]";
+  const char *range_pattern = R"(\[[0-9]+\-[0-9]+\]\\\.\[[0-9]+\-[0-9]+\]\\\.\[[0-9]+\-[0-9]+\]\\\.\[[0-9]+\-[0-9]+\])";
+  const char *ip_pattern    = "[0-9]*[0-9]*[0-9].[0-9]*[0-9]*[0-9].[0-9]*[0-9]*[0-9].[0-9]*[0-9]*[0-9]";
 
   Tokenizer dotTok1(".");
   Tokenizer dotTok2(".");

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -688,7 +688,7 @@ TSTerminate()
 
 /*--- plugin initialization -----------------------------------------------*/
 inkexp extern void
-TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
+TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */[])
 {
 }
 

--- a/plugins/experimental/metalink/metalink.cc
+++ b/plugins/experimental/metalink/metalink.cc
@@ -888,7 +888,7 @@ handler(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
+TSPluginInit(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */[])
 {
   TSPluginRegistrationInfo info;
 

--- a/plugins/experimental/slice/HttpHeader.h
+++ b/plugins/experimental/slice/HttpHeader.h
@@ -106,7 +106,7 @@ struct HttpHeader {
                    char *const valstr,  // <-- return string value
                    int *const vallen,   // <-- pass in capacity, returns len of string
                    int const index = -1 // retrieves all values
-                   ) const;
+  ) const;
 
   /**
     Sets or adds a key/value

--- a/plugins/experimental/slice/Range.cc
+++ b/plugins/experimental/slice/Range.cc
@@ -121,7 +121,7 @@ Range::fromStringClosed(char const *const rangestr)
 bool
 Range::toStringClosed(char *const bufstr,
                       int *const buflen // returns actual bytes used
-                      ) const
+) const
 {
   if (!isValid()) {
     if (0 < *buflen) {

--- a/plugins/experimental/slice/transfer.cc
+++ b/plugins/experimental/slice/transfer.cc
@@ -18,7 +18,8 @@
 
 #include "transfer.h"
 
-int64_t transfer_content_bytes(Data *const data) // , char const * const fstr)
+int64_t
+transfer_content_bytes(Data *const data) // , char const * const fstr)
 {
   int64_t consumed(0);
 

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -642,7 +642,7 @@ GeneratorInitialize()
 }
 
 void
-TSPluginInit(int /* argc */, const char * /* argv */ [])
+TSPluginInit(int /* argc */, const char * /* argv */[])
 {
   TSPluginRegistrationInfo info;
 
@@ -676,8 +676,7 @@ TSRemapDoRemap(void * /* ih */, TSHttpTxn txn, TSRemapRequestInfo * /* rri ATS_U
 }
 
 TSReturnCode
-TSRemapNewInstance(int /* argc */, char * /* argv */ [], void **ih, char * /* errbuf ATS_UNUSED */,
-                   int /* errbuf_size ATS_UNUSED */)
+TSRemapNewInstance(int /* argc */, char * /* argv */[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   *ih = nullptr;
   return TS_SUCCESS;

--- a/proxy/ControlBase.h
+++ b/proxy/ControlBase.h
@@ -65,10 +65,10 @@ public:
         @return @c true if the request is matched, @c false if not.
     */
     virtual bool check(HttpRequestData *req ///< Request to check.
-                       ) const = 0;
+    ) const = 0;
     /// Print the mod information.
     virtual void print(FILE *f ///< Output stream.
-                       ) const = 0;
+    ) const = 0;
   };
 
   ControlBase();

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -46,7 +46,8 @@ Http1Transaction::release(IOBufferReader *r)
   }
 }
 
-void Http1Transaction::destroy() // todo make ~Http1Transaction()
+void
+Http1Transaction::destroy() // todo make ~Http1Transaction()
 {
   _sm = nullptr;
 }

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -163,24 +163,26 @@ Enable_Config_Var(std::string_view const &name, bool (*cb)(const char *, RecData
 
   Context &ctx = storage.emplace_back(cb, cookie);
   // Register the call back - this handles external updates.
-  RecRegisterConfigUpdateCb(name.data(),
-                            [](const char *name, RecDataT dtype, RecData data, void *ctx) -> int {
-                              auto &&[cb, cookie] = *static_cast<Context *>(ctx);
-                              if ((*cb)(name, dtype, data, cookie)) {
-                                http_config_cb(name, dtype, data, cookie); // signal runtime config update.
-                              }
-                              return REC_ERR_OKAY;
-                            },
-                            &ctx);
+  RecRegisterConfigUpdateCb(
+    name.data(),
+    [](const char *name, RecDataT dtype, RecData data, void *ctx) -> int {
+      auto &&[cb, cookie] = *static_cast<Context *>(ctx);
+      if ((*cb)(name, dtype, data, cookie)) {
+        http_config_cb(name, dtype, data, cookie); // signal runtime config update.
+      }
+      return REC_ERR_OKAY;
+    },
+    &ctx);
 
   // Use the record to do the initial data load.
   // Look it up and call the updater @a cb on that data.
-  RecLookupRecord(name.data(),
-                  [](RecRecord const *r, void *ctx) -> void {
-                    auto &&[cb, cookie] = *static_cast<Context *>(ctx);
-                    (*cb)(r->name, r->data_type, r->data, cookie);
-                  },
-                  &ctx);
+  RecLookupRecord(
+    name.data(),
+    [](RecRecord const *r, void *ctx) -> void {
+      auto &&[cb, cookie] = *static_cast<Context *>(ctx);
+      (*cb)(r->name, r->data_type, r->data, cookie);
+    },
+    &ctx);
 }
 
 // [amc] Not sure which is uglier, this switch or having a micro-function for each var.

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -98,8 +98,7 @@ LogConfig::setup_default_values()
   max_line_size     = 9216; // size of pipe buffer for SunOS 5.6
 }
 
-void
-LogConfig::reconfigure_mgmt_variables(ts::MemSpan<void>)
+void LogConfig::reconfigure_mgmt_variables(ts::MemSpan<void>)
 {
   Note("received log reconfiguration event, rolling now");
   Log::config->roll_log_files_now = true;

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2029,8 +2029,7 @@ REGRESSION_TEST(Hdrs)(RegressionTest *t, int atype, int *pstatus)
 }
 #endif
 
-static void
-mgmt_restart_shutdown_callback(ts::MemSpan<void>)
+static void mgmt_restart_shutdown_callback(ts::MemSpan<void>)
 {
   sync_cache_dir_on_shutdown();
 }

--- a/src/tscore/BufferWriterFormat.cc
+++ b/src/tscore/BufferWriterFormat.cc
@@ -467,17 +467,18 @@ namespace bw_fmt
       }
       w.write(digits);
     } else { // use generic Write_Aligned
-      Write_Aligned(w,
-                    [&]() {
-                      if (prefix1) {
-                        w.write(prefix1);
-                        if (prefix2) {
-                          w.write(prefix2);
-                        }
-                      }
-                      w.write(digits);
-                    },
-                    spec._align, width, spec._fill, neg);
+      Write_Aligned(
+        w,
+        [&]() {
+          if (prefix1) {
+            w.write(prefix1);
+            if (prefix2) {
+              w.write(prefix2);
+            }
+          }
+          w.write(digits);
+        },
+        spec._align, width, spec._fill, neg);
     }
     return w;
   }
@@ -574,13 +575,14 @@ namespace bw_fmt
     std::string_view whole_digits{whole + sizeof(whole) - l, l};
     std::string_view frac_digits{fraction + sizeof(fraction) - r, r};
 
-    Write_Aligned(w,
-                  [&]() {
-                    w.write(whole_digits);
-                    w.write(dec);
-                    w.write(frac_digits);
-                  },
-                  spec._align, width, spec._fill, neg);
+    Write_Aligned(
+      w,
+      [&]() {
+        w.write(whole_digits);
+        w.write(dec);
+        w.write(frac_digits);
+      },
+      spec._align, width, spec._fill, neg);
 
     return w;
   }
@@ -611,7 +613,8 @@ bwformat(BufferWriter &w, BWFSpec const &spec, std::string_view sv)
     return bwformat(w, spec, bwf::detail::MemDump(sv.data(), sv.size()));
   } else {
     width -= sv.size();
-    bw_fmt::Write_Aligned(w, [&w, &sv]() { w.write(sv); }, spec._align, width, spec._fill, 0);
+    bw_fmt::Write_Aligned(
+      w, [&w, &sv]() { w.write(sv); }, spec._align, width, spec._fill, 0);
   }
   return w;
 }
@@ -963,8 +966,8 @@ bwformat(BufferWriter &w, BWFSpec const &spec, bwf::detail::MemDump const &hex)
     w.write(fmt_type);
     width -= 2;
   }
-  bw_fmt::Write_Aligned(w, [&w, &hex, digits]() { bw_fmt::Format_As_Hex(w, hex._view, digits); }, spec._align, width, spec._fill,
-                        0);
+  bw_fmt::Write_Aligned(
+    w, [&w, &hex, digits]() { bw_fmt::Format_As_Hex(w, hex._view, digits); }, spec._align, width, spec._fill, 0);
   return w;
 }
 

--- a/src/tscore/EventNotify.cc
+++ b/src/tscore/EventNotify.cc
@@ -104,7 +104,8 @@ EventNotify::wait()
 #endif
 }
 
-int EventNotify::timedwait(int timeout) // milliseconds
+int
+EventNotify::timedwait(int timeout) // milliseconds
 {
 #ifdef HAVE_EVENTFD
   ssize_t nr, nr_fd = 0;

--- a/src/tscore/IpMap.cc
+++ b/src/tscore/IpMap.cc
@@ -180,7 +180,7 @@ namespace detail
     */
     bool contains(ArgType target,      ///< Search target value.
                   void **ptr = nullptr ///< Client data return.
-                  ) const;
+    ) const;
 
     /** Remove all addresses in the map.
 

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -88,14 +88,15 @@
  * Form all types of queries.
  * Returns the size of the result or -1.
  */
-int ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of query  */
-                    const char *dname,                         /*!< domain name  */
-                    int _class, int type,                      /*!< _class and type of query  */
-                    const u_char *data,                        /*!< resource record data  */
-                    int datalen,                               /*!< length of data  */
-                    const u_char * /* newrr_in  ATS_UNUSED */, /*!< new rr for modify or append  */
-                    u_char *buf,                               /*!< buffer to put query  */
-                    int buflen)                                /*!< size of buffer  */
+int
+ink_res_mkquery(ink_res_state statp, int op,               /*!< opcode of query  */
+                const char *dname,                         /*!< domain name  */
+                int _class, int type,                      /*!< _class and type of query  */
+                const u_char *data,                        /*!< resource record data  */
+                int datalen,                               /*!< length of data  */
+                const u_char * /* newrr_in  ATS_UNUSED */, /*!< new rr for modify or append  */
+                u_char *buf,                               /*!< buffer to put query  */
+                int buflen)                                /*!< size of buffer  */
 {
   HEADER *hp;
   u_char *cp, *ep;

--- a/src/tscore/test_atomic.cc
+++ b/src/tscore/test_atomic.cc
@@ -139,7 +139,7 @@ cycle_data(void *d)
 #endif // LONG_ATOMICLIST_TEST
 
 int
-main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */ [])
+main(int /* argc ATS_UNUSED */, const char * /* argv ATS_UNUSED */[])
 {
 #ifndef LONG_ATOMICLIST_TEST
   int32_t m = 1, n = 100;

--- a/src/tscore/test_freelist.cc
+++ b/src/tscore/test_freelist.cc
@@ -66,7 +66,7 @@ test(void *d)
 }
 
 int
-main(int /* argc ATS_UNUSED */, char * /*argv ATS_UNUSED */ [])
+main(int /* argc ATS_UNUSED */, char * /*argv ATS_UNUSED */[])
 {
   int i;
 

--- a/src/wccp/WccpLocal.h
+++ b/src/wccp/WccpLocal.h
@@ -296,7 +296,7 @@ public:
   );
   /// Access const element.
   RouterAssignElt const &elt(int idx ///< Index of target element.
-                             ) const;
+  ) const;
   /// Get the number of elements.
   uint32_t getCount() const;
   //@}
@@ -537,7 +537,7 @@ public:
   uint32_t getCount() const;
   /// Get a cache address.
   uint32_t getAddr(int idx ///< Index of target address.
-                   ) const;
+  ) const;
   /// Set a cache address.
   self &setAddr(int idx,      ///< Index of target address.
                 uint32_t addr ///< Address value to set.
@@ -547,7 +547,7 @@ public:
   );
   /// Access a const bucket.
   Bucket const &operator[](size_t idx ///< Bucket index (0..N_BUCKETS-1)
-                           ) const;
+  ) const;
   //@}
 
   /** Do a round robin assignment.
@@ -1046,7 +1046,7 @@ public:
   );
 
   bool validate(MsgBuffer const &msg ///< Message data.
-                ) const;
+  ) const;
 
 protected:
   /// Local to this message shared key / password.
@@ -1105,7 +1105,7 @@ public:
 
   /// Get a port value.
   uint16_t getPort(int idx ///< Index of target port.
-                   ) const;
+  ) const;
   /// Set a port value.
   self &setPort(int idx,      ///< Index of port.
                 uint16_t port ///< Value for port.
@@ -1195,7 +1195,7 @@ public:
   uint32_t getFromCount() const;
   /// Get received from address.
   uint32_t getFromAddr(int idx ///< Index of address.
-                       ) const;
+  ) const;
   /// Set received from address.
   self &setFromAddr(int idx,      ///< Index of address.
                     uint32_t addr ///< Address value.
@@ -1335,14 +1335,14 @@ public:
   );
   /// Access cache element.
   CacheIdBox const &cacheId(int idx ///< Index of target element.
-                            ) const;
+  ) const;
   /// Get router count field.
   /// @note No @c setf method because this cannot be changed independently.
   /// @see fill
   uint32_t getRouterCount() const;
   /// Get router address.
   uint32_t getRouterAddr(int idx ///< Index of router.
-                         ) const;
+  ) const;
   /// Set router address.
   self &setRouterAddr(int idx,      ///< Index of router.
                       uint32_t addr ///< Address value.
@@ -1418,7 +1418,7 @@ public:
   uint32_t getCacheCount() const;
   /// Get a cache address.
   uint32_t getCacheAddr(int idx ///< Index of target address.
-                        ) const;
+  ) const;
   /// Set a cache address.
   self &setCacheAddr(int idx,      ///< Index of target address.
                      uint32_t addr ///< Address value to set.
@@ -1499,7 +1499,7 @@ public:
   uint32_t getCacheCount() const;
   /// Get a cache address.
   uint32_t getCacheAddr(int idx ///< Index of target address.
-                        ) const;
+  ) const;
   /// Set a cache address.
   self &setCacheAddr(int idx,      ///< Index of target address.
                      uint32_t addr ///< Address value to set.
@@ -1509,7 +1509,7 @@ public:
   );
   /// Access a bucket.
   Bucket const &bucket(int idx ///< Index of target bucket.
-                       ) const;
+  ) const;
   //@}
 
   /// Fill out the component from an @c Assignment.
@@ -1560,7 +1560,7 @@ public:
   CapabilityElt &elt(int idx ///< Index of target element.
   );
   CapabilityElt const &elt(int idx ///< Index of target element.
-                           ) const;
+  ) const;
   /// Get the element count.
   /// @note No corresponding @c setf_ because that cannot be changed once set.
   /// @see fill
@@ -2268,7 +2268,7 @@ protected:
   /// @return Security option to use during message fill.
   SecurityOption setSecurity(BaseMsg &msg,          ///< Message.
                              GroupData const &group ///< Group data used to control fill.
-                             ) const;
+  ) const;
   /// Validate a security component.
   bool validateSecurity(BaseMsg &msg,          ///< Message data (including security component).
                         GroupData const &group ///< Group data for message.
@@ -2301,11 +2301,11 @@ namespace detail
       /// Time until next packet.
       /// @return Seconds until a packet should be sent.
       time_t waitTime(time_t now ///< Current time.
-                      ) const;
+      ) const;
       /// Time till next ping.
       /// @return Seconds until a HERE_I_AM should be sent.
       time_t pingTime(time_t now ///< Current time.
-                      ) const;
+      ) const;
 
       uint32_t m_addr;       ///< Router identifying IP address.
       uint32_t m_generation; ///< Router's view change number.
@@ -2406,7 +2406,7 @@ namespace detail
       /// Time until next event.
       /// @return The number of seconds until the next event of interest.
       time_t waitTime(time_t now ///< Current time.
-                      ) const;
+      ) const;
 
       /** Cull routers.
           Routers that have not replied recently are moved from the
@@ -2503,7 +2503,7 @@ public:
   */
   virtual ts::Errata checkRouterAssignment(GroupData const &group,    ///< Group with assignment.
                                            RouterViewComp const &comp ///< Assignment reported by router.
-                                           ) const;
+  ) const;
 
 protected:
   /// Generate contents in HERE_I_AM @a msg for seed router.

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -19,7 +19,7 @@
 #  limitations under the License.
 
 # Update the PKGDATE with the new version date when making a new clang-format binary package.
-PKGDATE="20180413"
+PKGDATE="20191031"
 
 function main() {
   set -e # exit on error
@@ -27,7 +27,7 @@ function main() {
 
   DIR=${1:-.}
   PACKAGE="clang-format-${PKGDATE}.tar.bz2"
-  VERSION="clang-format version 6.0.1 (http://llvm.org/git/clang.git d5f48a217f404c3462537527f4169bb45eed3904) (http://llvm.org/git/llvm.git aa0c91ae818e0b9e7981a42236dededc85997568)"
+  VERSION="clang-format version 9.0.0 (https://github.com/llvm/llvm-project.git 0399d5a9682b3cef71c653373e38890c63c4c365)"
 
   URL=${URL:-https://ci.trafficserver.apache.org/bintray/${PACKAGE}}
 
@@ -62,7 +62,7 @@ function main() {
     ${CURL} -L --progress-bar -o ${ARCHIVE} ${URL}
     ${TAR} -x -C ${ROOT} -f ${ARCHIVE}
     cat > ${ROOT}/sha1 << EOF
-26aff1bc6dc315c695c62cadde38c934acd22d06  ${ARCHIVE}
+c1b7ae57bfc80507ee155779a1ab8cf919b3e062  ${ARCHIVE}
 EOF
     ${SHASUM} -c ${ROOT}/sha1
     chmod +x ${FORMAT}


### PR DESCRIPTION
I've not tweaked any of the new features etc. in clang-format, we can do this in a separate PR. I'll also make a separate PR for ATS v9.0.0, with the same changes.