### PR TITLE
Fix null pointer dereference reported by clang-analyzer

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1182,8 +1182,12 @@ HttpTunnel::producer_handler(int event, HttpTunnelProducer *p)
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case HTTP_TUNNEL_EVENT_CONSUMER_DETACH:
     if (p->alive) {
-      p->alive      = false;
-      p->bytes_read = p->read_vio->ndone;
+      p->alive = false;
+      if (p->read_vio) {
+        p->bytes_read = p->read_vio->ndone;
+      } else {
+        p->bytes_read = 0;
+      }
       // Clear any outstanding reads so they don't
       // collide with future tunnel IO's
       p->vc->do_io_read(nullptr, 0, nullptr);


### PR DESCRIPTION
The clang-analyzer reported this null pointer dereference on the build of #6118.
It looks like this is not related to #6118, but adding a nullptr check looks reasonable.