### PR TITLE
Add Metrics to track SSL Handshake attempts

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1107,6 +1107,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
 
   // Go do the preaccept hooks
   if (sslHandshakeHookState == HANDSHAKE_HOOKS_PRE) {
+    SSL_INCREMENT_DYN_STAT(ssl_total_attempts_handshake_count_in_stat);
     if (!curHook) {
       Debug("ssl", "Initialize preaccept curHook from NULL");
       curHook = ssl_hooks->get(TSSslHookInternalID(TS_VCONN_START_HOOK));
@@ -1352,6 +1353,7 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
 
   // Go do the preaccept hooks
   if (sslHandshakeHookState == HANDSHAKE_HOOKS_OUTBOUND_PRE) {
+    SSL_INCREMENT_DYN_STAT(ssl_total_attempts_handshake_count_out_stat);
     if (!curHook) {
       Debug("ssl", "Initialize outbound connect curHook from NULL");
       curHook = ssl_hooks->get(TSSslHookInternalID(TS_VCONN_OUTBOUND_START_HOOK));

--- a/iocore/net/SSLStats.cc
+++ b/iocore/net/SSLStats.cc
@@ -132,8 +132,12 @@ SSLInitializeStatistics()
   // SSL handshake time
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_handshake_time", RECD_COUNTER, RECP_PERSISTENT,
                      (int)ssl_total_handshake_time_stat, RecRawStatSyncSum);
+  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_attempts_handshake_count_in", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)ssl_total_attempts_handshake_count_in_stat, RecRawStatSyncCount);
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_success_handshake_count_in", RECD_COUNTER, RECP_PERSISTENT,
                      (int)ssl_total_success_handshake_count_in_stat, RecRawStatSyncCount);
+  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_attempts_handshake_count_out", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)ssl_total_attempts_handshake_count_out_stat, RecRawStatSyncCount);
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.total_success_handshake_count_out", RECD_COUNTER, RECP_PERSISTENT,
                      (int)ssl_total_success_handshake_count_out_stat, RecRawStatSyncCount);
 

--- a/iocore/net/SSLStats.h
+++ b/iocore/net/SSLStats.h
@@ -68,6 +68,7 @@ enum SSL_Stats {
   ssl_user_agent_session_miss_stat,
   ssl_user_agent_session_timeout_stat,
   ssl_total_handshake_time_stat,
+  ssl_total_attempts_handshake_count_in_stat,
   ssl_total_success_handshake_count_in_stat,
   ssl_total_tickets_created_stat,
   ssl_total_tickets_verified_stat,
@@ -89,6 +90,7 @@ enum SSL_Stats {
   ssl_error_read_eos,
   ssl_error_ssl,
   ssl_sni_name_set_failure,
+  ssl_total_attempts_handshake_count_out_stat,
   ssl_total_success_handshake_count_out_stat,
 
   /* ocsp stapling stats */


### PR DESCRIPTION
ATS currently has metrics to track SSL Handshake success, but, that metric isn't very useful without knowing the total handshake attempts made. This is needed for troubleshooting SSL handshake failures etc.