### PR TITLE
Fix the thread ready check

### DIFF
--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -321,6 +321,8 @@ public:
   */
   int n_ethreads = 0;
 
+  bool has_tg_started(int etype);
+
   /*------------------------------------------------------*\
   | Unix & non NT Interface                                |
   \*------------------------------------------------------*/
@@ -406,3 +408,5 @@ private:
 };
 
 extern inkcoreapi class EventProcessor eventProcessor;
+
+void thread_started(EThread *);

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -371,6 +371,7 @@ EventProcessor::spawn_event_threads(EventType ev_type, int n_threads, size_t sta
   }
   tg->_count = n_threads;
   n_ethreads += n_threads;
+  schedule_spawn(&thread_started, ev_type);
 
   // Separate loop to avoid race conditions between spawn events and updating the thread table for
   // the group. Some thread set up depends on knowing the total number of threads but that can't be
@@ -394,10 +395,7 @@ EventProcessor::initThreadState(EThread *t)
 {
   // Run all thread type initialization continuations that match the event types for this thread.
   for (int i = 0; i < MAX_EVENT_TYPES; ++i) {
-    if (t->is_event_type(i)) { // that event type done here, roll thread start events of that type.
-      if (++thread_group[i]._started == thread_group[i]._count && thread_group[i]._afterStartCallback != nullptr) {
-        thread_group[i]._afterStartCallback();
-      }
+    if (t->is_event_type(i)) {
       // To avoid race conditions on the event in the spawn queue, create a local one to actually send.
       // Use the spawn queue event as a read only model.
       Event *nev = eventAllocator.alloc();
@@ -490,4 +488,25 @@ EventProcessor::spawn_thread(Continuation *cont, const char *thr_name, size_t st
   e->ethread->start(thr_name, nullptr, stacksize);
 
   return e;
+}
+
+bool
+EventProcessor::has_tg_started(int etype)
+{
+  return thread_group[etype]._started == thread_group[etype]._count;
+}
+
+void
+thread_started(EThread *t)
+{
+  // Find what type of thread this is, and increment the "_started" counter of that thread type.
+  for (int i = 0; i < MAX_EVENT_TYPES; ++i) {
+    if (t->is_event_type(i)) {
+      if (++eventProcessor.thread_group[i]._started == eventProcessor.thread_group[i]._count &&
+          eventProcessor.thread_group[i]._afterStartCallback != nullptr) {
+        eventProcessor.thread_group[i]._afterStartCallback();
+      }
+      break;
+    }
+  }
 }

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -308,9 +308,9 @@ init_accept_HttpProxyServer(int n_accept_threads)
  *  start_HttpProxyServer().
  */
 void
-init_HttpProxyServer(EThread *)
+init_HttpProxyServer()
 {
-  if (eventProcessor.thread_group[ET_NET]._started == num_of_net_threads) {
+  if (eventProcessor.has_tg_started(ET_NET)) {
     std::unique_lock<std::mutex> lock(proxyServerMutex);
     et_net_threads_ready = true;
     lock.unlock();

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -38,7 +38,7 @@ void init_accept_HttpProxyServer(int n_accept_threads = 0);
 
 /** Checkes whether we can call start_HttpProxyServer().
  */
-void init_HttpProxyServer(EThread *);
+void init_HttpProxyServer();
 
 /** Start the proxy server.
     The port data should have been created by @c prep_HttpProxyServer().


### PR DESCRIPTION
#3821 unintentionally broke the logic for thread start check:
The intention of the thread check was to let the last `ET_NET` thread that's started to notify it is ok to call `start_HttpProxyServer`, but with the change in #3821 it is not done correctly. Instead of the last `ET_NET` thread doing the notification, all `ET_NET` are initiating the notification, the reason being we increment the `_started` counter before we execute the `_spawnQueue`. 

This PR restores the original logic of the thread check, and also fixes an issue where ATS crashes if run in command mode.

```
(gdb) thread 1
[Switching to thread 1 (Thread 0x7ffff7fdf880 (LWP 20848))]
#0  0x00007ffff577b1a0 in _int_free () from /lib64/libc.so.6
(gdb) bt
#0  0x00007ffff577b1a0 in _int_free () from /lib64/libc.so.6
#1  0x0000000000610c60 in deallocate (this=<optimized out>, __p=<optimized out>) at ../../include/tscore/EnumDescriptor.h:36
#2  deallocate (__a=..., __n=1, __p=<optimized out>) at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/alloc_traits.h:462
#3  _M_deallocate_node (this=<optimized out>, __n=<optimized out>) at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/hashtable_policy.h:2102
#4  _M_deallocate_nodes (this=<optimized out>, __n=0xc43ee0) at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/hashtable_policy.h:2113
#5  clear (this=0xbd4400 <TLS_PROTOCOLS_DESCRIPTOR+64>) at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/hashtable.h:2050
#6  ~_Hashtable (this=0xbd4400 <TLS_PROTOCOLS_DESCRIPTOR+64>, __in_chrg=<optimized out>) at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/hashtable.h:1374
#7  ~unordered_map (this=0xbd4400 <TLS_PROTOCOLS_DESCRIPTOR+64>, __in_chrg=<optimized out>) at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/unordered_map.h:102
#8  TsEnumDescriptor::~TsEnumDescriptor (this=0xbd43c0 <TLS_PROTOCOLS_DESCRIPTOR>, __in_chrg=<optimized out>) at ../../include/tscore/EnumDescriptor.h:36
#9  0x00007ffff5733cd9 in __run_exit_handlers () from /lib64/libc.so.6
#10 0x00007ffff5733d27 in exit () from /lib64/libc.so.6.    <<<<<<<<<<<<<<<<<<<<
#11 0x00000000004aea95 in main () at traffic_server/traffic_server.cc:1713
#12 0x00007ffff571c545 in __libc_start_main () from /lib64/libc.so.6
#13 0x00000000004cf08f in _start () at ../include/tscore/ink_inet.h:1477
```