### PR TITLE
Removes the records.config.shadow alternative config file

### DIFF
--- a/include/tscore/Filenames.h
+++ b/include/tscore/Filenames.h
@@ -24,3 +24,8 @@
 ///////////////////////////////////////////////////////////////////
 // Configuration file names
 extern const char *STORAGE_CONF_FILENAME;
+extern const char *RECORDS_CONF_FILENAME;
+
+///////////////////////////////////////////////////////////////////
+// Various other file names
+extern const char *RECORDS_STATS_FILE;

--- a/lib/records/P_RecDefs.h
+++ b/lib/records/P_RecDefs.h
@@ -25,10 +25,6 @@
 
 #include "I_RecDefs.h"
 
-#define REC_CONFIG_FILE "records.config"
-#define REC_SHADOW_EXT ".shadow"
-#define REC_RAW_STATS_FILE "records.snap"
-
 #define REC_MESSAGE_ELE_MAGIC 0xF00DF00D
 
 // We need at least this many internal record entries for our configurations and metrics. Any

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -24,6 +24,7 @@
 #include "tscore/ink_platform.h"
 #include "tscore/ink_memory.h"
 #include "tscore/ink_string.h"
+#include "tscore/Filenames.h"
 
 #include "RecordsConfig.h"
 #include "P_RecFile.h"
@@ -218,14 +219,10 @@ RecCoreInit(RecModeT mode_type, Diags *_diags)
 
     ink_mutex_init(&g_rec_config_lock);
 
-    g_rec_config_fpath = ats_stringdup(RecConfigReadConfigPath(nullptr, REC_CONFIG_FILE REC_SHADOW_EXT));
+    g_rec_config_fpath = ats_stringdup(RecConfigReadConfigPath(nullptr, RECORDS_CONF_FILENAME));
     if (RecFileExists(g_rec_config_fpath) == REC_ERR_FAIL) {
-      ats_free(const_cast<char *>(g_rec_config_fpath));
-      g_rec_config_fpath = ats_stringdup(RecConfigReadConfigPath(nullptr, REC_CONFIG_FILE));
-      if (RecFileExists(g_rec_config_fpath) == REC_ERR_FAIL) {
-        RecLog(DL_Warning, "Could not find '%s', system will run with defaults\n", REC_CONFIG_FILE);
-        file_exists = false;
-      }
+      RecLog(DL_Warning, "Could not find '%s', system will run with defaults\n", RECORDS_CONF_FILENAME);
+      file_exists = false;
     }
 
     if (file_exists) {
@@ -1260,7 +1257,7 @@ std::string
 RecConfigReadPersistentStatsPath()
 {
   std::string rundir(RecConfigReadRuntimeDir());
-  return Layout::relative_to(rundir, REC_RAW_STATS_FILE);
+  return Layout::relative_to(rundir, RECORDS_STATS_FILE);
 }
 
 void

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -38,6 +38,7 @@
 #include "tscpp/util/TextView.h"
 #include "tscore/BufferWriter.h"
 #include "tscore/bwf_std_format.h"
+#include "tscore/Filenames.h"
 
 #if TS_USE_POSIX_CAP
 #include <sys/capability.h>
@@ -749,7 +750,7 @@ LocalManager::processEventQueue()
     // check if we have a local file update
     if (mh->msg_id == MGMT_EVENT_CONFIG_FILE_UPDATE) {
       // records.config
-      if (!(strcmp(payload.begin(), REC_CONFIG_FILE))) {
+      if (!(strcmp(payload.begin(), RECORDS_CONF_FILENAME))) {
         if (RecReadConfigFile() != REC_ERR_OKAY) {
           mgmt_elog(errno, "[fileUpdated] Config update failed for records.config\n");
         } else {

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -155,7 +155,7 @@ produce_layout(bool json)
   print_var("PLUGINDIR", RecConfigReadPluginDir(), json);
   print_var("INCLUDEDIR", Layout::get()->includedir, json);
 
-  print_var("records.config", RecConfigReadConfigPath(nullptr, REC_CONFIG_FILE), json);
+  print_var(RECORDS_CONF_FILENAME, RecConfigReadConfigPath(nullptr, RECORDS_CONF_FILENAME), json);
   print_var("remap.config", RecConfigReadConfigPath("proxy.config.url_remap.filename"), json);
   print_var("plugin.config", RecConfigReadConfigPath(nullptr, "plugin.config"), json);
   print_var("ssl_multicert.config", RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename"), json);

--- a/src/traffic_manager/AddConfigFilesHere.cc
+++ b/src/traffic_manager/AddConfigFilesHere.cc
@@ -76,7 +76,7 @@ initializeRegistry()
   registerFile("proxy.config.log.config.filename", "logging.yaml");
   registerFile("", STORAGE_CONF_FILENAME);
   registerFile("proxy.config.socks.socks_config_file", "socks.config");
-  registerFile("records.config", "records.config");
+  registerFile(RECORDS_CONF_FILENAME, RECORDS_CONF_FILENAME);
   registerFile("proxy.config.cache.control.filename", "cache.config");
   registerFile("proxy.config.cache.ip_allow.filename", "ip_allow.yaml");
   registerFile("proxy.config.http.parent_proxy.file", "parent.config");

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -28,6 +28,7 @@
 #include "tscore/ink_args.h"
 #include "tscore/ink_syslog.h"
 #include "tscore/runroot.h"
+#include "tscore/Filenames.h"
 
 #include "WebMgmtUtils.h"
 #include "MgmtUtils.h"
@@ -90,7 +91,7 @@ static char bind_stderr[512]  = "";
 static const char *mgmt_path  = nullptr;
 
 // By default, set the current directory as base
-static const char *recs_conf = "records.config";
+static const char *recs_conf = RECORDS_CONF_FILENAME;
 
 static int fds_limit;
 

--- a/src/tscore/Filenames.cc
+++ b/src/tscore/Filenames.cc
@@ -22,3 +22,8 @@
 ///////////////////////////////////////////////////////////////////
 // Configuration file names
 const char *STORAGE_CONF_FILENAME = "storage.config";
+const char *RECORDS_CONF_FILENAME = "records.config";
+
+///////////////////////////////////////////////////////////////////
+// Various other file names
+const char *RECORDS_STATS_FILE = "records.snap";

--- a/src/tscore/unit_tests/test_layout.cc
+++ b/src/tscore/unit_tests/test_layout.cc
@@ -23,6 +23,7 @@
 
 #include "tscore/I_Layout.h"
 #include "tscore/ink_platform.h"
+#include "tscore/Filenames.h"
 
 std::string
 append_slash(const char *path)
@@ -79,8 +80,8 @@ TEST_CASE("relative to test", "[relative_to]")
 
   // relative to (4 parameters)
   char config_file[PATH_NAME_MAX];
-  Layout::relative_to(config_file, sizeof(config_file), Layout::get()->sysconfdir, "records.config");
-  std::string a = Layout::relative_to(Layout::get()->sysconfdir, "records.config");
+  Layout::relative_to(config_file, sizeof(config_file), Layout::get()->sysconfdir, RECORDS_CONF_FILENAME);
+  std::string a = Layout::relative_to(Layout::get()->sysconfdir, RECORDS_CONF_FILENAME);
   std::string b = config_file;
   REQUIRE(a == b);
 }


### PR DESCRIPTION
In addition, cleans up the usage and definitions of "records.config".