### PR TITLE
Fixing include synopsis rendering for API docs.

### DIFF
--- a/doc/developer-guide/api/functions/TSAPI.en.rst
+++ b/doc/developer-guide/api/functions/TSAPI.en.rst
@@ -28,8 +28,10 @@ Introduction to the Apache Traffic Server API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
-`#include <ts/remap.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+    #include <ts/remap.h>
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSAcceptor.en.rst
+++ b/doc/developer-guide/api/functions/TSAcceptor.en.rst
@@ -26,7 +26,9 @@ Traffic Server API's related to Accept objects
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAcceptor TSAcceptorGet(TSVConn sslp)
 .. function:: TSAcceptor TSAcceptorGetbyID(int id)

--- a/doc/developer-guide/api/functions/TSActionCancel.en.rst
+++ b/doc/developer-guide/api/functions/TSActionCancel.en.rst
@@ -24,7 +24,9 @@ TSActionCancel
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSActionCancel(TSAction actionp)
 

--- a/doc/developer-guide/api/functions/TSActionDone.en.rst
+++ b/doc/developer-guide/api/functions/TSActionDone.en.rst
@@ -24,7 +24,9 @@ TSActionDone
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSActionDone(TSAction actionp)
 

--- a/doc/developer-guide/api/functions/TSCacheRead.en.rst
+++ b/doc/developer-guide/api/functions/TSCacheRead.en.rst
@@ -24,7 +24,9 @@ TSCacheRead
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSCacheRead(TSCont contp, TSCacheKey key)
 

--- a/doc/developer-guide/api/functions/TSCacheRemove.en.rst
+++ b/doc/developer-guide/api/functions/TSCacheRemove.en.rst
@@ -24,7 +24,9 @@ TSCacheRemove
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSCacheRemove(TSCont contp, TSCacheKey key)
 

--- a/doc/developer-guide/api/functions/TSCacheWrite.en.rst
+++ b/doc/developer-guide/api/functions/TSCacheWrite.en.rst
@@ -24,7 +24,9 @@ TSCacheWrite
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSCacheWrite(TSCont contp, TSCacheKey key)
 

--- a/doc/developer-guide/api/functions/TSClientProtocolStack.en.rst
+++ b/doc/developer-guide/api/functions/TSClientProtocolStack.en.rst
@@ -25,7 +25,9 @@ TSClientProtocolStack
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const** result, int* actual)
 

--- a/doc/developer-guide/api/functions/TSConfig.en.rst
+++ b/doc/developer-guide/api/functions/TSConfig.en.rst
@@ -24,7 +24,9 @@ TSConfig Functions
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. type:: void (*TSConfigDestroyFunc)(void*)
 .. function:: unsigned int TSConfigSet(unsigned int id, void * data, TSConfigDestroyFunc funcp)

--- a/doc/developer-guide/api/functions/TSContCall.en.rst
+++ b/doc/developer-guide/api/functions/TSContCall.en.rst
@@ -24,7 +24,9 @@ TSContCall
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSContCall(TSCont contp, TSEvent event, void * edata)
 

--- a/doc/developer-guide/api/functions/TSContCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSContCreate.en.rst
@@ -24,7 +24,9 @@ TSContCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSCont TSContCreate(TSEventFunc funcp, TSMutex mutexp)
 

--- a/doc/developer-guide/api/functions/TSContDataGet.en.rst
+++ b/doc/developer-guide/api/functions/TSContDataGet.en.rst
@@ -24,7 +24,9 @@ TSContDataGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void* TSContDataGet(TSCont contp)
 

--- a/doc/developer-guide/api/functions/TSContDataSet.en.rst
+++ b/doc/developer-guide/api/functions/TSContDataSet.en.rst
@@ -24,7 +24,9 @@ TSContDataSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSContDataSet(TSCont contp, void * data)
 

--- a/doc/developer-guide/api/functions/TSContDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSContDestroy.en.rst
@@ -24,7 +24,9 @@ TSContDestroy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSContDestroy(TSCont contp)
 

--- a/doc/developer-guide/api/functions/TSContMutexGet.en.rst
+++ b/doc/developer-guide/api/functions/TSContMutexGet.en.rst
@@ -24,7 +24,9 @@ TSContMutexGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMutex TSContMutexGet(TSCont contp)
 

--- a/doc/developer-guide/api/functions/TSContSchedule.en.rst
+++ b/doc/developer-guide/api/functions/TSContSchedule.en.rst
@@ -24,7 +24,9 @@ TSContSchedule
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSContSchedule(TSCont contp, TSHRTime timeout)
 

--- a/doc/developer-guide/api/functions/TSContScheduleOnPool.en.rst
+++ b/doc/developer-guide/api/functions/TSContScheduleOnPool.en.rst
@@ -24,7 +24,9 @@ TSContScheduleOnPool
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSContScheduleOnPool(TSCont contp, TSHRTime timeout, TSThreadPool tp)
 

--- a/doc/developer-guide/api/functions/TSContScheduleOnThread.en.rst
+++ b/doc/developer-guide/api/functions/TSContScheduleOnThread.en.rst
@@ -24,7 +24,9 @@ TSContScheduleOnThread
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSContScheduleOnThread(TSCont contp, TSHRTime timeout, TSEventThread ethread)
 

--- a/doc/developer-guide/api/functions/TSContThreadAffinityClear.en.rst
+++ b/doc/developer-guide/api/functions/TSContThreadAffinityClear.en.rst
@@ -24,7 +24,9 @@ TSContThreadAffinityClear
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSContThreadAffinityClear(TSCont contp)
 

--- a/doc/developer-guide/api/functions/TSContThreadAffinityGet.en.rst
+++ b/doc/developer-guide/api/functions/TSContThreadAffinityGet.en.rst
@@ -24,7 +24,9 @@ TSContThreadAffinityGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSEventThread TSContThreadAffinityGet(TSCont contp)
 

--- a/doc/developer-guide/api/functions/TSContThreadAffinitySet.en.rst
+++ b/doc/developer-guide/api/functions/TSContThreadAffinitySet.en.rst
@@ -24,7 +24,9 @@ TSContThreadAffinitySet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSContThreadAffinitySet(TSCont contp, TSEventThread ethread)
 

--- a/doc/developer-guide/api/functions/TSDebug.en.rst
+++ b/doc/developer-guide/api/functions/TSDebug.en.rst
@@ -26,7 +26,9 @@ Traffic Server Debugging APIs.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSError(const char * format, ...)
 .. function:: void TSFatal(const char * format, ...)

--- a/doc/developer-guide/api/functions/TSEventThreadSelf.en.rst
+++ b/doc/developer-guide/api/functions/TSEventThreadSelf.en.rst
@@ -24,7 +24,9 @@ TSEventThreadSelf
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSEventThread TSEventThreadSelf(void)
 

--- a/doc/developer-guide/api/functions/TSHostLookup.en.rst
+++ b/doc/developer-guide/api/functions/TSHostLookup.en.rst
@@ -24,7 +24,9 @@ TSHostLookup
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSHostLookup(TSCont contp, const char * hostname, size_t namelen)
 

--- a/doc/developer-guide/api/functions/TSHostLookupResultAddrGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHostLookupResultAddrGet.en.rst
@@ -24,7 +24,9 @@ TSHostLookupResultAddrGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: sockaddr const* TSHostLookupResultAddrGet(TSHostLookupResult lookup_result)
 

--- a/doc/developer-guide/api/functions/TSHttpArgs.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpArgs.en.rst
@@ -23,7 +23,9 @@ TSHttpArgs
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnArgIndexReserve(const char * name, const char * description, int * arg_idx)
 .. function:: TSReturnCode TSHttpTxnArgIndexNameLookup(const char * name, int * arg__idx, const char ** description)

--- a/doc/developer-guide/api/functions/TSHttpConnect.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpConnect.en.rst
@@ -24,7 +24,9 @@ TSHttpConnect
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVConn TSHttpConnect(sockaddr const * addr)
 

--- a/doc/developer-guide/api/functions/TSHttpConnectWithPluginId.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpConnectWithPluginId.en.rst
@@ -29,7 +29,9 @@ as if it came from a client.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVConn TSHttpConnectWithPluginId(sockaddr const * addr, char const * tag, int64_t id)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrClone.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrClone.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrClone
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc * locp)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrCopy.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrCopy.en.rst
@@ -28,7 +28,9 @@ Copies the contents of the HTTP header located at :arg:`src_loc` within
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_offset, TSMBuffer src_bufp, TSMLoc src_offset)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrCreate.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMLoc TSHttpHdrCreate(TSMBuffer bufp)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrDestroy.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrDestroy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpHdrDestroy(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrHostGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrHostGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrHostGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char* TSHttpHdrHostGet(TSMBuffer bufp, TSMLoc offset, int * length)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrLengthGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrLengthGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrLengthGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSHttpHdrLengthGet(TSMBuffer bufp, TSMLoc mloc)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrMethodGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrMethodGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrMethodGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char* TSHttpHdrMethodGet(TSMBuffer bufp, TSMLoc offset, int * length)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrMethodSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrMethodSet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrMethodSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrMethodSet(TSMBuffer bufp, TSMLoc offset, const char * value, int length)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrPrint.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrPrint.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrPrint
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpHdrPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrReasonGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrReasonGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrReasonGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char* TSHttpHdrReasonGet(TSMBuffer bufp, TSMLoc offset, int * length)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrReasonLookup.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrReasonLookup.en.rst
@@ -21,7 +21,9 @@ TSHttpHdrReasonLookup
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: const char* TSHttpHdrReasonLookup(TSHttpStatus status)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrReasonSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrReasonSet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrReasonSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrReasonSet(TSMBuffer bufp, TSMLoc offset, const char * value, int length)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrStatusGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrStatusGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrStatusGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSHttpStatus TSHttpHdrStatusGet(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrStatusSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrStatusSet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrStatusSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrStatusSet(TSMBuffer bufp, TSMLoc offset, TSHttpStatus status)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrTypeGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrTypeGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrTypeGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSHttpType TSHttpHdrTypeGet(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrTypeSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrTypeSet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrTypeSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrTypeSet(TSMBuffer bufp, TSMLoc offset, TSHttpType type)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrUrlGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrUrlGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrUrlGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrUrlGet(TSMBuffer bufp, TSMLoc offset, TSMLoc * locp)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrUrlSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrUrlSet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrUrlSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrUrlSet(TSMBuffer bufp, TSMLoc offset, TSMLoc url)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrVersionGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrVersionGet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrVersionGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSHttpHdrVersionGet(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSHttpHdrVersionSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHdrVersionSet.en.rst
@@ -24,7 +24,9 @@ TSHttpHdrVersionSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpHdrVersionSet(TSMBuffer bufp, TSMLoc offset, int ver)
 

--- a/doc/developer-guide/api/functions/TSHttpHookAdd.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpHookAdd.en.rst
@@ -27,7 +27,9 @@ Intercept Traffic Server events.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpHookAdd(TSHttpHookID id, TSCont contp)
 .. function:: void TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp)

--- a/doc/developer-guide/api/functions/TSHttpOverridableConfig.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpOverridableConfig.en.rst
@@ -27,7 +27,9 @@ TSHttpOverridableConfig
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 
 .. function:: TSReturnCode TSHttpTxnConfigIntSet(TSHttpTxn txnp, TSOverridableConfigKey key, TSMgmtInt value)

--- a/doc/developer-guide/api/functions/TSHttpParserCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpParserCreate.en.rst
@@ -27,7 +27,9 @@ Parse HTTP headers from memory buffers.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSHttpParser TSHttpParserCreate(void)
 .. function:: void TSHttpParserClear(TSHttpParser parser)

--- a/doc/developer-guide/api/functions/TSHttpSsnClientFdGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpSsnClientFdGet.en.rst
@@ -21,7 +21,9 @@ TSHttpSsnClientFdGet
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: TSReturnCode TSHttpSsnClientFdGet(TSHttpTxn txnp, int *fdp)
 

--- a/doc/developer-guide/api/functions/TSHttpSsnIdGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpSsnIdGet.en.rst
@@ -24,7 +24,9 @@ Returns the unique identifier for client session.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int64_t TSHttpSsnIdGet(TSHttpSsn ssnp)
 

--- a/doc/developer-guide/api/functions/TSHttpSsnReenable.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpSsnReenable.en.rst
@@ -24,7 +24,9 @@ TSHttpSsnReenable
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpSsnReenable(TSHttpSsn ssnp, TSEvent event)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnAborted.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnAborted.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnAborted
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: TSReturnCode TSHttpTxnAborted(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnCacheLookupStatusGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnCacheLookupStatusGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnCacheLookupStatusGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnCacheLookupStatusGet(TSHttpTxn txnp, int * lookup_status)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnCacheLookupUrlGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnCacheLookupUrlGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnCacheLookupUrlGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnCacheLookupUrlGet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc offset)
 
@@ -41,7 +43,9 @@ TSHttpTxnCacheLookupUrlSet
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: TSReturnCode TSHttpTxnCacheLookupUrlSet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnCachedReqGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnCachedReqGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnCachedReqGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnCachedReqGet(TSHttpTxn txnp, TSMBuffer * bufp, TSMLoc * offset)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnCachedRespGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnCachedRespGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnCachedRespGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnCachedRespGet(TSHttpTxn txnp, TSMBuffer * bufp, TSMLoc * offset)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnClientFdGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientFdGet.en.rst
@@ -21,7 +21,9 @@ TSHttpTxnClientFdGet
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: TSReturnCode TSHttpTxnClientFdGet(TSHttpTxn txnp, int *fdp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnClientPacketDscpSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientPacketDscpSet.en.rst
@@ -23,7 +23,9 @@ TSHttpTxnClientPacketDscpSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnClientPacketDscpSet(TSHttpTxn txnp, int dscp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnClientPacketMarkSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientPacketMarkSet.en.rst
@@ -23,7 +23,9 @@ TSHttpTxnClientPacketMarkSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnClientPacketTosSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientPacketTosSet.en.rst
@@ -23,7 +23,9 @@ TSHttpTxnClientPacketTosSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnClientPacketTosSet(TSHttpTxn txnp, int tos)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnClientReqGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientReqGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnClientReqGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnClientReqGet(TSHttpTxn txnp, TSMBuffer * bufp, TSMLoc * offset)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnClientRespGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientRespGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnClientRespGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnClientRespGet(TSHttpTxn txnp, TSMBuffer * bufp, TSMLoc * offset)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnErrorBodySet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnErrorBodySet.en.rst
@@ -26,7 +26,9 @@ Sets an error type body to a transaction.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnErrorBodySet(TSHttpTxn txnp, char * buf, size_t buflength, char * mimetype)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnIncomingAddrGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnIncomingAddrGet.en.rst
@@ -24,7 +24,9 @@ Get the incoming proxy address on which a client's connection is accepted.
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: sockaddr const* TSHttpTxnIncomingAddrGet(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnInfoIntGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnInfoIntGet.en.rst
@@ -21,7 +21,9 @@ TSHttpTxnInfoIntGet
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: TSReturnCode TSHttpTxnInfoIntGet(TSHttpTxn txnp, TSHttpTxnInfoKey key, TSMgmtInt * value)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnIntercept.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnIntercept.en.rst
@@ -27,7 +27,9 @@ origin server.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnIntercept(TSCont contp, TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnIsCacheable.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnIsCacheable.en.rst
@@ -21,7 +21,9 @@ TSHttpTxnIsCacheable
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnIsCacheable(TSHttpTxn txnp, TSMBuffer request, TSMBuffer response)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnIsInternal.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnIsInternal.en.rst
@@ -24,7 +24,9 @@ Test whether a request is internally-generated.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSHttpTxnIsInternal(TSHttpTxn txnp)
 .. function:: int TSHttpSsnIsInternal(TSHttpSsn ssnp)

--- a/doc/developer-guide/api/functions/TSHttpTxnIsWebsocket.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnIsWebsocket.en.rst
@@ -24,7 +24,9 @@ Test whether a request is attempting to initiate Websocket connection.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSHttpTxnIsWebsocket(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnMilestoneGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnMilestoneGet.en.rst
@@ -27,7 +27,9 @@ Get a specified :arg:`milestone` timer value for the current transaction.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnMilestoneGet(TSHttpTxn txnp, TSMilestonesType milestone, TSHRTime * time)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopAddrGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopAddrGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnNextHopAddrGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: sockaddr const * TSHttpTxnNextHopAddrGet(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopNameGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopNameGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnNextHopNameGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char *TSHttpTxnNextHopNameGet(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnOutgoingAddrGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnOutgoingAddrGet.en.rst
@@ -26,7 +26,9 @@ Get or set the local IP address for outbound connections.
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: sockaddr const* TSHttpTxnOutgoingAddrGet(TSHttpTxn txnp)
 .. c:function:: TSReturnCode TSHttpTxnOutgoingAddrSet(TSHttpTxn txnp, sockaddr const* addr)

--- a/doc/developer-guide/api/functions/TSHttpTxnParentProxySet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnParentProxySet.en.rst
@@ -26,7 +26,9 @@ Sets the parent proxy :arg:`hostname` and :arg:`port`.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnParentProxySet(TSHttpTxn txnp, const char * hostname, int port)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnParentSelectionUrlGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnParentSelectionUrlGet.en.rst
@@ -27,7 +27,9 @@ Traffic Server Parent Selection consistent hash URL manipulation API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnParentSelectionUrlSet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc offset)
 .. function:: TSReturnCode TSHttpTxnParentSelectionUrlGet(TSHttpTxn txnp, TSMBuffer bufp, TSMLoc offset)

--- a/doc/developer-guide/api/functions/TSHttpTxnPluginTagGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnPluginTagGet.en.rst
@@ -24,7 +24,9 @@ Fetch the tag of the plugin that created this transaction.
 
 Synopsis
 ========
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char * TSHttpTxnPluginTagGet(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnRedoCacheLookup.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnRedoCacheLookup.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnRedoCacheLookup
 Synopsis
 ========
 
-`#include <ts/experimental.h>`
+.. code-block:: cpp
+
+    #include <ts/experimental.h>
 
 .. function:: TSReturnCode TSHttpTxnRedoCacheLookup(TSHttpTxn txnp, const char *url, int length)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnReenable.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnReenable.en.rst
@@ -27,7 +27,9 @@ processing the current hook.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnReenable(TSHttpTxn txnp, TSEvent event)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerAddrGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerAddrGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnServerAddrGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: sockaddr const* TSHttpTxnServerAddrGet(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerAddrSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerAddrSet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnServerAddrSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnServerAddrSet(TSHttpTxn txnp, struct sockaddr const* addr)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerFdGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerFdGet.en.rst
@@ -21,7 +21,9 @@ TSHttpTxnServerFdGet
 Synopsis
 --------
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:function:: TSReturnCode TSHttpTxnServerFdGet(TSHttpTxn txnp, int *fdp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerIntercept.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerIntercept.en.rst
@@ -27,7 +27,9 @@ Intercept origin server requests.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnServerIntercept(TSCont contp, TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPacketDscpSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPacketDscpSet.en.rst
@@ -25,7 +25,9 @@ Change packet DSCP for the server side connection.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnServerPacketDscpSet(TSHttpTxn txnp, int dscp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPacketMarkSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPacketMarkSet.en.rst
@@ -25,7 +25,9 @@ Change packet firewall mark for the server side connection.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPacketTosSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPacketTosSet.en.rst
@@ -25,7 +25,9 @@ Change packet TOS for the server side connection.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnServerPacketTosSet(TSHttpTxn txnp, int tos)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPush.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnServerPush
 Synopsis
 ========
 
-`#include <ts/experimental.h>`
+.. code-block:: cpp
+
+    #include <ts/experimental.h>
 
 .. function:: void TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerReqGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerReqGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnServerReqGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnServerReqGet(TSHttpTxn txnp, TSMBuffer * bufp, TSMLoc * obj)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnServerRespGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerRespGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnServerRespGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnServerRespGet(TSHttpTxn txnp, TSMBuffer * bufp, TSMLoc * offset)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnSsnGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnSsnGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnSsnGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSHttpSsn TSHttpTxnSsnGet(TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnTransformRespGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnTransformRespGet.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnTransformRespGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnTransformRespGet(TSHttpTxn txnp, TSMBuffer * bufp, TSMLoc * offset)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnTransformedRespCache.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnTransformedRespCache.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnTransformedRespCache
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnTransformedRespCache(TSHttpTxn txnp, int on)
 

--- a/doc/developer-guide/api/functions/TSHttpTxnUntransformedRespCache.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnUntransformedRespCache.en.rst
@@ -24,7 +24,9 @@ TSHttpTxnUntransformedRespCache
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSHttpTxnUntransformedRespCache(TSHttpTxn txnp, int on)
 

--- a/doc/developer-guide/api/functions/TSIOBufferBlockReadStart.en.rst
+++ b/doc/developer-guide/api/functions/TSIOBufferBlockReadStart.en.rst
@@ -24,7 +24,9 @@ TSIOBufferBlockReadStart
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char * TSIOBufferBlockReadStart(TSIOBufferBlock blockp, TSIOBufferReader readerp, int64_t * avail)
 

--- a/doc/developer-guide/api/functions/TSIOBufferCopy.en.rst
+++ b/doc/developer-guide/api/functions/TSIOBufferCopy.en.rst
@@ -24,7 +24,9 @@ TSIOBufferCopy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int64_t TSIOBufferCopy(TSIOBuffer bufp, TSIOBufferReader readerp, int64_t length, int64_t offset)
 

--- a/doc/developer-guide/api/functions/TSIOBufferCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSIOBufferCreate.en.rst
@@ -27,7 +27,9 @@ Traffic Server IO buffer API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSIOBuffer TSIOBufferCreate(void)
 .. function:: TSIOBuffer TSIOBufferSizedCreate(TSIOBufferSizeIndex index)

--- a/doc/developer-guide/api/functions/TSIOBufferReader.en.rst
+++ b/doc/developer-guide/api/functions/TSIOBufferReader.en.rst
@@ -25,7 +25,10 @@ Traffic Server IO buffer reader API.
 
 Synopsis
 ========
-`#include <ts/ts.h>`
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSIOBufferReader TSIOBufferReaderAlloc(TSIOBuffer bufp)
 .. function:: TSIOBufferReader TSIOBufferReaderClone(TSIOBufferReader readerp)

--- a/doc/developer-guide/api/functions/TSInstallDirGet.en.rst
+++ b/doc/developer-guide/api/functions/TSInstallDirGet.en.rst
@@ -27,7 +27,9 @@ Return Traffic Server installation directories.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char * TSInstallDirGet(void)
 .. function:: const char * TSConfigDirGet(void)

--- a/doc/developer-guide/api/functions/TSIpStringToAddr.en.rst
+++ b/doc/developer-guide/api/functions/TSIpStringToAddr.en.rst
@@ -24,7 +24,9 @@ TSIpStringToAddr
 Synopsis
 ========
 
-`#include <ts/experimental.h>`
+.. code-block:: cpp
+
+    #include <ts/experimental.h>
 
 .. function:: TSReturnCode TSIpStringToAddr(const char * str, int str_len, sockaddr* addr)
 

--- a/doc/developer-guide/api/functions/TSLifecycleHookAdd.en.rst
+++ b/doc/developer-guide/api/functions/TSLifecycleHookAdd.en.rst
@@ -26,7 +26,9 @@ TSLifecycleHookAdd
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSLifecycleHookAdd(TSLifecycleHookID id, TSCont contp)
 

--- a/doc/developer-guide/api/functions/TSMBufferCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSMBufferCreate.en.rst
@@ -25,7 +25,9 @@ Traffic Server marshall buffer API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMBuffer TSMBufferCreate(void)
 .. function:: TSReturnCode TSMBufferDestroy(TSMBuffer bufp)

--- a/doc/developer-guide/api/functions/TSMgmtCounterGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtCounterGet.en.rst
@@ -24,7 +24,9 @@ TSMgmtCounterGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMgmtCounterGet(const char * var_name, TSMgmtCounter * result)
 

--- a/doc/developer-guide/api/functions/TSMgmtFloatGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtFloatGet.en.rst
@@ -24,7 +24,9 @@ TSMgmtFloatGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMgmtFloatGet(const char * var_name, TSMgmtFloat * result)
 

--- a/doc/developer-guide/api/functions/TSMgmtIntGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtIntGet.en.rst
@@ -24,7 +24,9 @@ TSMgmtIntGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMgmtIntGet(const char * var_name, TSMgmtInt * result)
 

--- a/doc/developer-guide/api/functions/TSMgmtSourceGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtSourceGet.en.rst
@@ -24,7 +24,9 @@ TSMgmtSourceGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMgmtSourceGet(const char * var_name, TSMgmtSource * result)
 

--- a/doc/developer-guide/api/functions/TSMgmtStringGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtStringGet.en.rst
@@ -24,7 +24,9 @@ TSMgmtStringGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMgmtStringGet(const char * var_name, TSMgmtString * result)
 

--- a/doc/developer-guide/api/functions/TSMgmtUpdateRegister.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtUpdateRegister.en.rst
@@ -24,7 +24,9 @@ TSMgmtUpdateRegister
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSMgmtUpdateRegister(TSCont contp, const char * plugin_name)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrClone.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrClone.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrClone
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc * locp)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrCopy.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrCopy.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrCopy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_offset, TSMBuffer src_bufp, TSMLoc src_offset)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrCreate.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrCreate(TSMBuffer bufp, TSMLoc * locp)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrDestroy.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrDestroy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrDestroy(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldAppend.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldAppend.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldAppend
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldAppend(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldClone.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldClone.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldClone
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldClone(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc src_field, TSMLoc * locp)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldCopy.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldCopy.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldCopy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldCopy(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMLoc dest_field, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc src_field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldCopyValues.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldCopyValues.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldCopyValues
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldCopyValues(TSMBuffer dest_bufp, TSMLoc dest_hdr, TSMLoc dest_field, TSMBuffer src_bufp, TSMLoc src_hdr, TSMLoc src_field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldCreate.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldCreate(TSMBuffer bufp, TSMLoc hdr, TSMLoc * out)
 .. function:: TSReturnCode TSMimeHdrFieldCreateNamed(TSMBuffer bufp, TSMLoc hdr, const char * name, int name_len, TSMLoc * out)

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldDestroy.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldDestroy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldDestroy(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldFind.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldFind.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldFind
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMLoc TSMimeHdrFieldFind(TSMBuffer bufp, TSMLoc hdr, const char * name, int length)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldGet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMLoc TSMimeHdrFieldGet(TSMBuffer bufp, TSMLoc hdr, int idx)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldLengthGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldLengthGet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldLengthGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSMimeHdrFieldLengthGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldNameGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldNameGet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldNameGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char * TSMimeHdrFieldNameGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int * length)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldNameSet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldNameSet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldNameSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldNameSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, const char * name, int length)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldNext.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldNext.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldNext
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMLoc TSMimeHdrFieldNext(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldNextDup.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldNextDup.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldNextDup
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMLoc TSMimeHdrFieldNextDup(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldRemove.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldRemove.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldRemove
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldRemove(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueAppend.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueAppend.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueAppend
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueAppend(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, const char * value, int length)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueDateInsert.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueDateInsert.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueDateInsert
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueDateInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, time_t value)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueDateSet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueDateSet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueDateSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueDateSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, time_t value)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueIntSet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueIntSet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueIntSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueIntSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, int value)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueStringGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueStringGet.en.rst
@@ -26,7 +26,9 @@ Get HTTP MIME header values.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function::  const char * TSMimeHdrFieldValueStringGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, int * value_len_ptr)
 .. function::  int TSMimeHdrFieldValueIntGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx)

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueStringInsert.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueStringInsert.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueStringInsert
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueStringInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, const char * value, int length)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueStringSet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueStringSet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueStringSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueStringSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, const char * value, int length)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueUintInsert.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueUintInsert.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueUintInsert
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueUintInsert(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, unsigned int value)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValueUintSet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValueUintSet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValueUintSet
 Synopsis
 =========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValueUintSet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx, unsigned int value)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValuesClear.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValuesClear.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValuesClear
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldValuesClear(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldValuesCount.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldValuesCount.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldValuesCount
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSMimeHdrFieldValuesCount(TSMBuffer bufp, TSMLoc hdr, TSMLoc field)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldsClear.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldsClear.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldsClear
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMimeHdrFieldsClear(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrFieldsCount.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrFieldsCount.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrFieldsCount
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSMimeHdrFieldsCount(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrLengthGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrLengthGet.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrLengthGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSMimeHdrLengthGet(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrParse.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrParse.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrParse
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSParseResult TSMimeHdrParse(TSMimeParser parser, TSMBuffer bufp, TSMLoc offset, const char ** start, const char * end)
 

--- a/doc/developer-guide/api/functions/TSMimeHdrPrint.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrPrint.en.rst
@@ -24,7 +24,9 @@ TSMimeHdrPrint
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSMimeHdrPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
 

--- a/doc/developer-guide/api/functions/TSMimeParserClear.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeParserClear.en.rst
@@ -24,7 +24,9 @@ TSMimeParserClear
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSMimeParserClear(TSMimeParser parser)
 

--- a/doc/developer-guide/api/functions/TSMimeParserCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeParserCreate.en.rst
@@ -24,7 +24,9 @@ TSMimeParserCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMimeParser TSMimeParserCreate(void)
 

--- a/doc/developer-guide/api/functions/TSMimeParserDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeParserDestroy.en.rst
@@ -24,7 +24,9 @@ TSMimeParserDestroy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSMimeParserDestroy(TSMimeParser parser)
 

--- a/doc/developer-guide/api/functions/TSMutexCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSMutexCreate.en.rst
@@ -24,7 +24,9 @@ TSMutexCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMutex TSMutexCreate(void)
 

--- a/doc/developer-guide/api/functions/TSMutexDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSMutexDestroy.en.rst
@@ -24,7 +24,9 @@ TSMutexDestroy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSMutexDestroy(TSMutex mutexp)
 

--- a/doc/developer-guide/api/functions/TSMutexLock.en.rst
+++ b/doc/developer-guide/api/functions/TSMutexLock.en.rst
@@ -24,7 +24,9 @@ TSMutexLock
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSMutexLock(TSMutex mutexp)
 

--- a/doc/developer-guide/api/functions/TSMutexLockTry.en.rst
+++ b/doc/developer-guide/api/functions/TSMutexLockTry.en.rst
@@ -24,7 +24,9 @@ TSMutexLockTry
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMutexLockTry(TSMutex mutexp)
 

--- a/doc/developer-guide/api/functions/TSMutexUnlock.en.rst
+++ b/doc/developer-guide/api/functions/TSMutexUnlock.en.rst
@@ -24,7 +24,9 @@ TSMutexUnlock
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSMutexUnlock(TSMutex mutexp)
 

--- a/doc/developer-guide/api/functions/TSNetAccept.en.rst
+++ b/doc/developer-guide/api/functions/TSNetAccept.en.rst
@@ -24,7 +24,9 @@ TSNetAccept
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSNetAccept(TSCont contp, int port, int domain, int accept_threads)
 

--- a/doc/developer-guide/api/functions/TSNetAcceptNamedProtocol.en.rst
+++ b/doc/developer-guide/api/functions/TSNetAcceptNamedProtocol.en.rst
@@ -26,7 +26,9 @@ Listen on all SSL ports for connections for the specified protocol name.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSNetAcceptNamedProtocol(TSCont contp, const char * protocol)
 

--- a/doc/developer-guide/api/functions/TSNetConnect.en.rst
+++ b/doc/developer-guide/api/functions/TSNetConnect.en.rst
@@ -24,7 +24,9 @@ TSNetConnect
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSAction TSNetConnect(TSCont contp, sockaddr const * addr)
 

--- a/doc/developer-guide/api/functions/TSNetInvokingGet.en.rst
+++ b/doc/developer-guide/api/functions/TSNetInvokingGet.en.rst
@@ -24,7 +24,9 @@ TSNetInvokingContGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSCont TSNetInvokingContGet(TSVConn conn)
 

--- a/doc/developer-guide/api/functions/TSPluginInit.en.rst
+++ b/doc/developer-guide/api/functions/TSPluginInit.en.rst
@@ -26,7 +26,9 @@ Traffic Server plugin loading and registration.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSPluginInit(int argc, const char* argv[])
 .. function:: TSReturnCode TSPluginRegister(TSPluginRegistrationInfo* plugin_info)

--- a/doc/developer-guide/api/functions/TSRecords.en.rst
+++ b/doc/developer-guide/api/functions/TSRecords.en.rst
@@ -26,7 +26,9 @@ Traffic Server Records
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSMgmtStringCreate(TSRecordType rec_type, const char* name, \
                                               const TSMgmtString data_default, TSRecordUpdateType update_type, \

--- a/doc/developer-guide/api/functions/TSRemap.en.rst
+++ b/doc/developer-guide/api/functions/TSRemap.en.rst
@@ -26,8 +26,10 @@ Traffic Server remap plugin entry points.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
-`#include <ts/remap.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+    #include <ts/remap.h>
 
 .. function:: TSReturnCode TSRemapInit(TSRemapInterface * api_info, char * errbuff, int errbuff_size)
 .. function:: void TSRemapPreConfigReload(void)

--- a/doc/developer-guide/api/functions/TSRemapFromToUrlGet.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapFromToUrlGet.en.rst
@@ -24,7 +24,9 @@ TSRemapFrom/ToUrlGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSRemapFromUrlGet(TSHttpTxn txnp, TSMLoc * urlLocp)
 .. function:: TSReturnCode TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc * urlLocp)

--- a/doc/developer-guide/api/functions/TSSslClientCertUpdate.en.rst
+++ b/doc/developer-guide/api/functions/TSSslClientCertUpdate.en.rst
@@ -26,7 +26,9 @@ Traffic Server TLS client cert update
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSSslClientCertUpdate(const char *cert_path, const char *key_path)
 

--- a/doc/developer-guide/api/functions/TSSslClientContext.en.rst
+++ b/doc/developer-guide/api/functions/TSSslClientContext.en.rst
@@ -23,7 +23,9 @@ TSSslClientContext
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSSslClientContextsNamesGet(int n, const char **result, int *actual)
 

--- a/doc/developer-guide/api/functions/TSSslContext.en.rst
+++ b/doc/developer-guide/api/functions/TSSslContext.en.rst
@@ -26,7 +26,9 @@ Traffic Server TLS server context.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSSslContext TSSslContextFindByName(const char * name)
 

--- a/doc/developer-guide/api/functions/TSSslServerCertUpdate.en.rst
+++ b/doc/developer-guide/api/functions/TSSslServerCertUpdate.en.rst
@@ -26,7 +26,9 @@ Traffic Server TLS server cert update
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSSslServerCertUpdate(const char *cert_path, const char *key_path)
 

--- a/doc/developer-guide/api/functions/TSSslServerContextCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSSslServerContextCreate.en.rst
@@ -26,7 +26,9 @@ Traffic Server TLS server context creation.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSSslContext TSSslServerContextCreate(TSSslX509 *cert, char *certname)
 .. function:: void TSSslContextDestroy(TSSslContext ctx)

--- a/doc/developer-guide/api/functions/TSSslSession.en.rst
+++ b/doc/developer-guide/api/functions/TSSslSession.en.rst
@@ -24,7 +24,9 @@ TSSslSession
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSSslSession TSSslSessionGet(const TSSslSessionID * sessionid)
 .. function:: int TSSslSessionGetBuffer(const TSSslSessionID * sessionid, char * buffer, int * len_ptr)

--- a/doc/developer-guide/api/functions/TSStat.en.rst
+++ b/doc/developer-guide/api/functions/TSStat.en.rst
@@ -28,7 +28,9 @@ in contrast to processing log files.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSStatCreate(const char * name, TSRecordDataType type, TSStatPersistence persistence, TSStatSync sync_style)
 .. function:: TSReturnCode TSStatFindName(const char * name, int * idx_ptr)

--- a/doc/developer-guide/api/functions/TSTextLogObjectCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSTextLogObjectCreate.en.rst
@@ -27,7 +27,9 @@ Traffic Server text logging API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSTextLogObjectCreate(const char * filename, int mode, TSTextLogObject * new_log_obj)
 .. function:: TSReturnCode TSTextLogObjectWrite(TSTextLogObject the_object, const char * format, ...)

--- a/doc/developer-guide/api/functions/TSThreadCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSThreadCreate.en.rst
@@ -24,7 +24,9 @@ TSThreadCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSThread TSThreadCreate(TSThreadFunc func, void * data)
 

--- a/doc/developer-guide/api/functions/TSThreadDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSThreadDestroy.en.rst
@@ -24,7 +24,9 @@ TSThreadDestroy
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSThreadDestroy(TSThread thread)
 

--- a/doc/developer-guide/api/functions/TSThreadInit.en.rst
+++ b/doc/developer-guide/api/functions/TSThreadInit.en.rst
@@ -24,7 +24,9 @@ TSThreadInit
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSThread TSThreadInit(void)
 

--- a/doc/developer-guide/api/functions/TSThreadSelf.en.rst
+++ b/doc/developer-guide/api/functions/TSThreadSelf.en.rst
@@ -24,7 +24,9 @@ TSThreadSelf
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSThread TSThreadSelf(void)
 

--- a/doc/developer-guide/api/functions/TSTrafficServerVersionGet.en.rst
+++ b/doc/developer-guide/api/functions/TSTrafficServerVersionGet.en.rst
@@ -26,7 +26,9 @@ Return Traffic Server version information.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char * TSTrafficServerVersionGet(void)
 .. function:: int TSTrafficServerVersionGetMajor(void)

--- a/doc/developer-guide/api/functions/TSTransformCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSTransformCreate.en.rst
@@ -24,7 +24,9 @@ TSTransformCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVConn TSTransformCreate(TSEventFunc event_funcp, TSHttpTxn txnp)
 

--- a/doc/developer-guide/api/functions/TSTransformOutputVConnGet.en.rst
+++ b/doc/developer-guide/api/functions/TSTransformOutputVConnGet.en.rst
@@ -24,7 +24,9 @@ TSTransformOutputVConnGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVConn TSTransformOutputVConnGet(TSVConn connp)
 

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -28,8 +28,10 @@ TSAPI Types
 Synopsis
 ========
 
-`#include <ts/ts.h>`
-`#include <ts/remap.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+    #include <ts/remap.h>
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSUrlCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlCreate.en.rst
@@ -27,7 +27,9 @@ Traffic Server URL object construction API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSUrlCreate(TSMBuffer bufp, TSMLoc * locp)
 .. function:: TSReturnCode TSUrlClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_url, TSMLoc * locp)

--- a/doc/developer-guide/api/functions/TSUrlFtpTypeGet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlFtpTypeGet.en.rst
@@ -24,7 +24,9 @@ TSUrlFtpTypeGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSUrlFtpTypeGet(TSMBuffer bufp, TSMLoc offset)
 

--- a/doc/developer-guide/api/functions/TSUrlFtpTypeSet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlFtpTypeSet.en.rst
@@ -24,7 +24,9 @@ TSUrlFtpTypeSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSUrlFtpTypeSet(TSMBuffer bufp, TSMLoc offset, int type)
 

--- a/doc/developer-guide/api/functions/TSUrlHostGet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlHostGet.en.rst
@@ -27,7 +27,9 @@ Traffic Server URL component retrieval API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: const char * TSUrlHostGet(TSMBuffer bufp, TSMLoc offset, int * length)
 .. function:: const char * TSUrlSchemeGet(TSMBuffer bufp, TSMLoc offset, int * length)

--- a/doc/developer-guide/api/functions/TSUrlHostSet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlHostSet.en.rst
@@ -27,7 +27,9 @@ Traffic Server URL component manipulation API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSUrlHostSet(TSMBuffer bufp, TSMLoc offset, const char * value, int length)
 .. function:: TSReturnCode TSUrlSchemeSet(TSMBuffer bufp, TSMLoc offset, const char * value, int length)

--- a/doc/developer-guide/api/functions/TSUrlPercentEncode.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlPercentEncode.en.rst
@@ -27,7 +27,9 @@ Traffic Server URL percent encoding API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSUrlPercentEncode(TSMBuffer bufp, TSMLoc offset, char * dst, size_t dst_size, size_t * length, const unsigned char * map)
 .. function:: TSReturnCode TSStringPercentEncode(const char * str, int str_len, char * dst, size_t dst_size, size_t * length, const unsigned char * map)

--- a/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlStringGet.en.rst
@@ -27,7 +27,9 @@ Traffic Server URL string representations API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: char * TSUrlStringGet(TSMBuffer bufp, TSMLoc offset, int * length)
 .. function:: char * TSHttpTxnEffectiveUrlStringGet(TSHttpTxn txn, int * length)

--- a/doc/developer-guide/api/functions/TSUuidCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSUuidCreate.en.rst
@@ -26,7 +26,9 @@ Traffic Server UUID construction APIs.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSUuid TSUuidCreate(void)
 .. function:: TSReturnCode TSUuidInitialize(TSUuid uuid, TSUuidVersion v)

--- a/doc/developer-guide/api/functions/TSVConn.en.rst
+++ b/doc/developer-guide/api/functions/TSVConn.en.rst
@@ -26,7 +26,9 @@ Traffic Server APIs to get :type:`TSVConn` from :type:`TSHttpSsn` object
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVConn TSHttpSsnClientVConnGet(TSHttpSsn ssnp)
 .. function:: TSVConn TSHttpSsnServerVConnGet(TSHttpSsn ssnp)

--- a/doc/developer-guide/api/functions/TSVConnAbort.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnAbort.en.rst
@@ -24,7 +24,9 @@ TSVConnAbort
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSVConnAbort(TSVConn connp, int error)
 

--- a/doc/developer-guide/api/functions/TSVConnArgs.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnArgs.en.rst
@@ -25,7 +25,9 @@ TSVConnArgs
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSVConnArgIndexReserve(const char * name, const char * description, int * arg_idx)
 .. function:: TSReturnCode TSVConnArgIndexNameLookup(const char * name, int * arg_idx, const char ** description)

--- a/doc/developer-guide/api/functions/TSVConnCacheObjectSizeGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnCacheObjectSizeGet.en.rst
@@ -24,7 +24,9 @@ TSVConnCacheObjectSizeGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int64_t TSVConnCacheObjectSizeGet(TSVConn connp)
 

--- a/doc/developer-guide/api/functions/TSVConnClose.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnClose.en.rst
@@ -24,7 +24,9 @@ TSVConnClose
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSVConnClose(TSVConn connp)
 

--- a/doc/developer-guide/api/functions/TSVConnClosedGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnClosedGet.en.rst
@@ -24,7 +24,9 @@ TSVConnClosedGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSVConnClosedGet(TSVConn connp)
 

--- a/doc/developer-guide/api/functions/TSVConnCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnCreate.en.rst
@@ -24,7 +24,9 @@ TSVConnCreate
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSCont TSVConnCreate(TSEventFunc funcp, TSMutex mutexp)
 

--- a/doc/developer-guide/api/functions/TSVConnFdCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnFdCreate.en.rst
@@ -26,7 +26,9 @@ Create a TSVConn from a socket.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVConn TSVConnFdCreate(int fd)
 

--- a/doc/developer-guide/api/functions/TSVConnIsSsl.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnIsSsl.en.rst
@@ -24,7 +24,9 @@ TSVConnIsSsl
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int TSVConnIsSsl(TSVConn svc)
 

--- a/doc/developer-guide/api/functions/TSVConnProtocol.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnProtocol.en.rst
@@ -24,7 +24,9 @@ TSVConnProtocolEnable/Disable
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSVConnProtocolEnable(TSVConn vconn, const char* protocol)
 .. function:: TSReturnCode TSVConnProtocolDisable(TSVConn vconn, const char* protocol)

--- a/doc/developer-guide/api/functions/TSVConnRead.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnRead.en.rst
@@ -24,7 +24,9 @@ TSVConnRead
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVIO TSVConnRead(TSVConn connp, TSCont contp, TSIOBuffer bufp, int64_t nbytes)
 

--- a/doc/developer-guide/api/functions/TSVConnReadVIOGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnReadVIOGet.en.rst
@@ -24,7 +24,9 @@ TSVConnReadVIOGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVIO TSVConnReadVIOGet(TSVConn connp)
 

--- a/doc/developer-guide/api/functions/TSVConnReenable.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnReenable.en.rst
@@ -24,7 +24,9 @@ TSVConnReenable
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSVConnReenable(TSVConn svc)
 

--- a/doc/developer-guide/api/functions/TSVConnShutdown.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnShutdown.en.rst
@@ -24,7 +24,9 @@ TSVConnShutdown
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSVConnShutdown(TSVConn connp, int read, int write)
 

--- a/doc/developer-guide/api/functions/TSVConnSslConnectionGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnSslConnectionGet.en.rst
@@ -24,7 +24,9 @@ TSVConnSslConnectionGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSSslConnection TSVConnSslConnectionGet(TSVConn svc)
 

--- a/doc/developer-guide/api/functions/TSVConnSslVerifyCTXGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnSslVerifyCTXGet.en.rst
@@ -24,7 +24,9 @@ TSVConnSslVerifyCTXGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSSslVerifyCTX TSVConnSslVerifyCTXGet(TSVConn svc)
 

--- a/doc/developer-guide/api/functions/TSVConnTunnel.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnTunnel.en.rst
@@ -24,7 +24,9 @@ TSVConnTunnel
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSReturnCode TSVConnTunnel(TSVConn svc)
 

--- a/doc/developer-guide/api/functions/TSVConnWrite.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnWrite.en.rst
@@ -24,7 +24,9 @@ TSVConnWrite
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVIO TSVConnWrite(TSVConn connp, TSCont contp, TSIOBufferReader readerp, int64_t nbytes)
 

--- a/doc/developer-guide/api/functions/TSVConnWriteVIOGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnWriteVIOGet.en.rst
@@ -24,7 +24,9 @@ TSVConnWriteVIOGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVIO TSVConnWriteVIOGet(TSVConn connp)
 

--- a/doc/developer-guide/api/functions/TSVIOBufferGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIOBufferGet.en.rst
@@ -24,7 +24,9 @@ TSVIOBufferGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSIOBuffer TSVIOBufferGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIOContGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIOContGet.en.rst
@@ -24,7 +24,9 @@ TSVIOContGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSCont TSVIOContGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIOMutexGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIOMutexGet.en.rst
@@ -24,7 +24,9 @@ TSVIOMutexGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSMutex TSVIOMutexGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIONBytesGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIONBytesGet.en.rst
@@ -24,7 +24,9 @@ TSVIONBytesGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int64_t TSVIONBytesGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIONBytesSet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIONBytesSet.en.rst
@@ -24,7 +24,9 @@ TSVIONBytesSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSVIONBytesSet(TSVIO viop, int64_t nbytes)
 

--- a/doc/developer-guide/api/functions/TSVIONDoneGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIONDoneGet.en.rst
@@ -24,7 +24,9 @@ TSVIONDoneGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int64_t TSVIONDoneGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIONDoneSet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIONDoneSet.en.rst
@@ -24,7 +24,9 @@ TSVIONDoneSet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSVIONDoneSet(TSVIO viop, int64_t ndone)
 

--- a/doc/developer-guide/api/functions/TSVIONTodoGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIONTodoGet.en.rst
@@ -24,7 +24,9 @@ TSVIONTodoGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: int64_t TSVIONTodoGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIOReaderGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIOReaderGet.en.rst
@@ -24,7 +24,9 @@ TSVIOReaderGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSIOBufferReader TSVIOReaderGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIOReenable.en.rst
+++ b/doc/developer-guide/api/functions/TSVIOReenable.en.rst
@@ -24,7 +24,9 @@ TSVIOReenable
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSVIOReenable(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSVIOVConnGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVIOVConnGet.en.rst
@@ -24,7 +24,9 @@ TSVIOVConnGet
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSVConn TSVIOVConnGet(TSVIO viop)
 

--- a/doc/developer-guide/api/functions/TSfclose.en.rst
+++ b/doc/developer-guide/api/functions/TSfclose.en.rst
@@ -24,7 +24,9 @@ TSfclose
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSfclose(TSFile filep)
 

--- a/doc/developer-guide/api/functions/TSfflush.en.rst
+++ b/doc/developer-guide/api/functions/TSfflush.en.rst
@@ -24,7 +24,9 @@ TSfflush
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void TSfflush(TSFile filep)
 

--- a/doc/developer-guide/api/functions/TSfgets.en.rst
+++ b/doc/developer-guide/api/functions/TSfgets.en.rst
@@ -24,7 +24,9 @@ TSfgets
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: char* TSfgets(TSFile filep, char * buf, size_t length)
 

--- a/doc/developer-guide/api/functions/TSfopen.en.rst
+++ b/doc/developer-guide/api/functions/TSfopen.en.rst
@@ -24,7 +24,9 @@ TSfopen
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: TSFile TSfopen(const char * filename, const char * mode)
 

--- a/doc/developer-guide/api/functions/TSfread.en.rst
+++ b/doc/developer-guide/api/functions/TSfread.en.rst
@@ -24,7 +24,9 @@ TSfread
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: ssize_t TSfread(TSFile filep, void * buf, size_t length)
 

--- a/doc/developer-guide/api/functions/TSfwrite.en.rst
+++ b/doc/developer-guide/api/functions/TSfwrite.en.rst
@@ -24,7 +24,9 @@ TSfwrite
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: ssize_t TSfwrite(TSFile filep, const void * buf, size_t length)
 

--- a/doc/developer-guide/api/functions/TSmalloc.en.rst
+++ b/doc/developer-guide/api/functions/TSmalloc.en.rst
@@ -27,7 +27,9 @@ Traffic Server memory allocation API.
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. function:: void * TSmalloc(size_t size)
 .. function:: void * TSrealloc(void * ptr , size_t size)

--- a/doc/developer-guide/api/types/TSCacheDataType.en.rst
+++ b/doc/developer-guide/api/types/TSCacheDataType.en.rst
@@ -22,7 +22,9 @@ TSCacheDataType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSCacheDataType
 

--- a/doc/developer-guide/api/types/TSCacheError.en.rst
+++ b/doc/developer-guide/api/types/TSCacheError.en.rst
@@ -22,7 +22,9 @@ TSCacheError
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSCacheError
 

--- a/doc/developer-guide/api/types/TSCacheLookupResult.en.rst
+++ b/doc/developer-guide/api/types/TSCacheLookupResult.en.rst
@@ -22,7 +22,9 @@ TSCacheLookupResult
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSCacheLookupResult
 

--- a/doc/developer-guide/api/types/TSCacheScanResult.en.rst
+++ b/doc/developer-guide/api/types/TSCacheScanResult.en.rst
@@ -22,7 +22,9 @@ TSCacheScanResult
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSCacheScanResult
 

--- a/doc/developer-guide/api/types/TSEvent.en.rst
+++ b/doc/developer-guide/api/types/TSEvent.en.rst
@@ -23,7 +23,9 @@ TSEvent
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSEvent
 

--- a/doc/developer-guide/api/types/TSFetchWakeUpOptions.en.rst
+++ b/doc/developer-guide/api/types/TSFetchWakeUpOptions.en.rst
@@ -22,7 +22,9 @@ TSFetchWakeUpOptions
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSFetchWakeUpOptions
 

--- a/doc/developer-guide/api/types/TSHttpHookID.en.rst
+++ b/doc/developer-guide/api/types/TSHttpHookID.en.rst
@@ -24,7 +24,9 @@ TSHttpHookID
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSHttpHookID
 

--- a/doc/developer-guide/api/types/TSHttpStatus.en.rst
+++ b/doc/developer-guide/api/types/TSHttpStatus.en.rst
@@ -24,7 +24,9 @@ TSHttpStatus
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSHttpStatus
 

--- a/doc/developer-guide/api/types/TSHttpType.en.rst
+++ b/doc/developer-guide/api/types/TSHttpType.en.rst
@@ -22,7 +22,9 @@ TSHttpType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSHttpType
 

--- a/doc/developer-guide/api/types/TSIOBuffersSizeIndex.en.rst
+++ b/doc/developer-guide/api/types/TSIOBuffersSizeIndex.en.rst
@@ -22,7 +22,9 @@ TSIOBuffersSizeIndex
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSIOBuffersSizeIndex
 

--- a/doc/developer-guide/api/types/TSLookingUpType.en.rst
+++ b/doc/developer-guide/api/types/TSLookingUpType.en.rst
@@ -22,7 +22,9 @@ TSLookingUpType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSLookingUpType
 

--- a/doc/developer-guide/api/types/TSOverridableConfigKey.en.rst
+++ b/doc/developer-guide/api/types/TSOverridableConfigKey.en.rst
@@ -22,7 +22,9 @@ TSOverridableConfigKey
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSOverridableConfigKey
 

--- a/doc/developer-guide/api/types/TSParseResult.en.rst
+++ b/doc/developer-guide/api/types/TSParseResult.en.rst
@@ -22,7 +22,9 @@ TSParseResult
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSParseResult
 

--- a/doc/developer-guide/api/types/TSRecordAccessType.en.rst
+++ b/doc/developer-guide/api/types/TSRecordAccessType.en.rst
@@ -22,7 +22,9 @@ TSRecordAccessType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSRecordAccessType
 

--- a/doc/developer-guide/api/types/TSRecordCheckType.en.rst
+++ b/doc/developer-guide/api/types/TSRecordCheckType.en.rst
@@ -22,7 +22,9 @@ TSRecordCheckType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSRecordCheckType
 

--- a/doc/developer-guide/api/types/TSRecordDataType.en.rst
+++ b/doc/developer-guide/api/types/TSRecordDataType.en.rst
@@ -22,7 +22,9 @@ TSRecordDataType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSRecordDataType
 

--- a/doc/developer-guide/api/types/TSRecordModeType.en.rst
+++ b/doc/developer-guide/api/types/TSRecordModeType.en.rst
@@ -22,7 +22,9 @@ TSRecordModeType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSRecordModeType
 

--- a/doc/developer-guide/api/types/TSRecordPersistType.en.rst
+++ b/doc/developer-guide/api/types/TSRecordPersistType.en.rst
@@ -22,7 +22,9 @@ TSRecordPersistType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSRecordPersistType
 

--- a/doc/developer-guide/api/types/TSRecordType.en.rst
+++ b/doc/developer-guide/api/types/TSRecordType.en.rst
@@ -22,7 +22,9 @@ TSRecordType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSRecordType
 

--- a/doc/developer-guide/api/types/TSRecordUpdateType.en.rst
+++ b/doc/developer-guide/api/types/TSRecordUpdateType.en.rst
@@ -22,7 +22,9 @@ TSRecordUpdateType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSRecordUpdateType
 

--- a/doc/developer-guide/api/types/TSReturnCode.en.rst
+++ b/doc/developer-guide/api/types/TSReturnCode.en.rst
@@ -22,7 +22,9 @@ TSReturnCode
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSReturnCode
 

--- a/doc/developer-guide/api/types/TSSDKVersion.en.rst
+++ b/doc/developer-guide/api/types/TSSDKVersion.en.rst
@@ -22,7 +22,9 @@ TSSDKVersion
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSSDKVersion
 

--- a/doc/developer-guide/api/types/TSServerSessionSharingMatchType.en.rst
+++ b/doc/developer-guide/api/types/TSServerSessionSharingMatchType.en.rst
@@ -22,7 +22,9 @@ TSServerSessionSharingMatchType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSServerSessionSharingMatchType
 

--- a/doc/developer-guide/api/types/TSServerSessionSharingPoolType.en.rst
+++ b/doc/developer-guide/api/types/TSServerSessionSharingPoolType.en.rst
@@ -22,7 +22,9 @@ TSServerSessionSharingPoolType
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSServerSessionSharingPoolType
 

--- a/doc/developer-guide/api/types/TSServerState.en.rst
+++ b/doc/developer-guide/api/types/TSServerState.en.rst
@@ -22,7 +22,9 @@ TSServerState
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSServerState
 

--- a/doc/developer-guide/api/types/TSSslSession.en.rst
+++ b/doc/developer-guide/api/types/TSSslSession.en.rst
@@ -24,7 +24,9 @@ TSSslSession
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. type:: TSSslSessionID
 

--- a/doc/developer-guide/api/types/TSStatPeristence.en.rst
+++ b/doc/developer-guide/api/types/TSStatPeristence.en.rst
@@ -22,7 +22,9 @@ TSStatPersistence
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:type:: TSStatPersistence
 

--- a/doc/developer-guide/api/types/TSStatSync.en.rst
+++ b/doc/developer-guide/api/types/TSStatSync.en.rst
@@ -22,7 +22,9 @@ TSStatSync
 Synopsis
 ========
 
-`#include <ts/ts.h>`
+.. code-block:: cpp
+
+    #include <ts/ts.h>
 
 .. c:type:: TSStatSync
 

--- a/doc/developer-guide/api/types/TSThreadPool.en.rst
+++ b/doc/developer-guide/api/types/TSThreadPool.en.rst
@@ -22,7 +22,9 @@ TSThreadPool
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSThreadPool
 

--- a/doc/developer-guide/api/types/TSUuid.en.rst
+++ b/doc/developer-guide/api/types/TSUuid.en.rst
@@ -22,7 +22,9 @@ TSUuid
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSUuid
 

--- a/doc/developer-guide/api/types/TSVConnCloseFlags.en.rst
+++ b/doc/developer-guide/api/types/TSVConnCloseFlags.en.rst
@@ -22,7 +22,9 @@ TSVConnCloseFlags
 Synopsis
 ========
 
-`#include <ts/apidefs.h>`
+.. code-block:: cpp
+
+    #include <ts/apidefs.h>
 
 .. c:type:: TSVConnCloseFlags
 

--- a/doc/developer-guide/internal-libraries/MemSpan.en.rst
+++ b/doc/developer-guide/internal-libraries/MemSpan.en.rst
@@ -25,7 +25,9 @@ MemSpan
 Synopsis
 ========
 
-:code:`#include <ts/MemSpan.h>`
+.. code-block:: cpp
+
+    #include <ts/MemSpan.h>
 
 :class:`MemSpan` is a view on a contiguous section of writeable memory. A view does not own the memory
 and neither allocates nor de-allocates. The memory in the view is always owned by some other container

--- a/doc/developer-guide/internal-libraries/TextView.en.rst
+++ b/doc/developer-guide/internal-libraries/TextView.en.rst
@@ -25,7 +25,9 @@ TextView
 Synopsis
 ========
 
-:code:`#include <ts/TextView.h>`
+.. code-block:: cpp
+
+    #include <ts/TextView.h>`
 
 .. class:: TextView
 


### PR DESCRIPTION
I noticed the include synopsis renders incorrectly when there are multiple includes. The method we're using for them is incorrect, even for a single include, but demonstrates itself as incorrect when there are multiple includes. The problem can currently be seen here:

https://docs.trafficserver.apache.org/en/latest/developer-guide/api/functions/TSAPI.en.html

Notice that since the includes are not rendered as code, they are placed side by side.

I'm applying the solution which was already implemented in the following file to the other synopsis statements:
 https://raw.githubusercontent.com/apache/trafficserver/fa10c20b8ed43072fd7e214c62b195b525f24d8e/doc/developer-guide/internal-libraries/buffer-writer.en.rst

The diff is large, but it is pretty much the same change for each file. The original included file names are preserved after the diff, of course.