### PR TITLE
Remove using namespace std

### DIFF
--- a/iocore/cache/CacheTest.cc
+++ b/iocore/cache/CacheTest.cc
@@ -28,8 +28,6 @@
 #include <cmath>
 #include <cstdlib>
 
-using namespace std;
-
 CacheTestSM::CacheTestSM(RegressionTest *t, const char *name) : RegressionSM(t), cache_test_name(name)
 {
   SET_HANDLER(&CacheTestSM::event_handler);
@@ -550,7 +548,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
   bool pass = true;
   CacheKey key;
   Vol *vol = theCache->key_to_vol(&key, "example.com", sizeof("example.com") - 1);
-  vector<Ptr<IOBufferData>> data;
+  std::vector<Ptr<IOBufferData>> data;
 
   cache->init(cache_size, vol);
 

--- a/src/traffic_top/stats.h
+++ b/src/traffic_top/stats.h
@@ -32,8 +32,6 @@
 #include <sys/time.h>
 #include "mgmtapi.h"
 
-using namespace std;
-
 struct LookupItem {
   LookupItem(const char *s, const char *n, const int t) : pretty(s), name(n), numerator(""), denominator(""), type(t) {}
   LookupItem(const char *s, const char *n, const char *d, const int t) : pretty(s), name(n), numerator(n), denominator(d), type(t)
@@ -49,7 +47,7 @@ extern size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream);
 #if HAS_CURL
 extern char curl_error[CURL_ERROR_SIZE];
 #endif
-extern string response;
+extern std::string response;
 
 namespace constant
 {
@@ -62,6 +60,9 @@ const char end[]       = "\",\n";
 //----------------------------------------------------------------------------
 class Stats
 {
+  using string                            = std::string;
+  template <class Key, class T> using map = std::map<Key, T>;
+
 public:
   Stats(const string &url) : _url(url)
   {
@@ -524,6 +525,12 @@ public:
   }
 
 private:
+  std::pair<std::string, LookupItem>
+  make_pair(std::string s, LookupItem i)
+  {
+    return std::make_pair(s, i);
+  }
+
   map<string, string> *_stats;
   map<string, string> *_old_stats;
   map<string, LookupItem> lookup_table;


### PR DESCRIPTION
To fix build issue on FreeBSD 12.1 & LLVM-9 on macOS.

It looks like using `namespace std` & including `I_EThread.h` makes below build error.

```
CacheTest.cc:559:55: error: reference to 'this_thread' is ambiguous
      IOBufferData *d = THREAD_ALLOC(ioDataAllocator, this_thread());
                                                      ^
/var/jenkins/workspace/freebsd-github/src/iocore/eventsystem/P_Thread.h:46:1: note: candidate found by name lookup is 'this_thread'
this_thread()
^
/usr/include/c++/v1/__threading_support:465:11: note: candidate found by name lookup is 'std::__1::this_thread'
namespace this_thread
          ^
```