### PR TITLE
A couple doc tweaks

### DIFF
--- a/doc/developer-guide/plugins/hooks-and-transactions/http-transactions.en.rst
+++ b/doc/developer-guide/plugins/hooks-and-transactions/http-transactions.en.rst
@@ -28,7 +28,7 @@ transactions.
 
 As described in the section on HTTP sessions, an **HTTP transaction** is
 an object defined for the lifetime of a single request from a client and
-the corresponding response from Traffic Server. The **``TSHttpTxn``**
+the corresponding response from Traffic Server. The ``TSHttpTxn``
 structure is the main handle given to a plugin for manipulating a
 transaction's internal state. Additionally, an HTTP transaction has a
 reference back to the HTTP session that created it.

--- a/doc/developer-guide/plugins/introduction.en.rst
+++ b/doc/developer-guide/plugins/introduction.en.rst
@@ -90,7 +90,7 @@ Below are some guidelines for creating a plugin:
    These examples are discussed in the following chapters.
 
 #. Determine where your plugin needs to hook on to Traffic Server's HTTP
-   processing (view the :ref:`http-txn-state-diagram`.
+   processing (view the :ref:`http-txn-state-diagram`).
 
 #. Read :ref:`developer-plugins-header-based-examples` to learn the basics of
    writing plugins: creating continuations and setting up hooks. If you
@@ -101,7 +101,7 @@ Below are some guidelines for creating a plugin:
    then read about the details of those APIs in this manual's reference
    chapters.
 
-#. Compile and load your plugin (see :ref:`developer-plugins-getting-started`.
+#. Compile and load your plugin (see :ref:`developer-plugins-getting-started`).
 
 #. Depending on your plugin's functionality, you might start testing it
    by issuing requests by hand and checking for the desired behavior in


### PR DESCRIPTION
The http-transactions.en.rst change is to address this:

https://docs.trafficserver.apache.org/en/latest/developer-guide/plugins/hooks-and-transactions/http-transactions.en.html

Notice that the attempt to wrap `` with ** is simply resulting in a bolded literal ``, which is surely not the intention. Simply removing the ** results in what I think was desired.

The introduction.en.rst change simply closes parens.