### PR TITLE
Reverse debug specific check.

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -7452,7 +7452,7 @@ TSIsDebugTagSet(const char *t)
 void
 TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...)
 {
-  if (is_debug_tag_set(tag) || (debug_flag && diags->on())) {
+  if ((debug_flag && diags->on()) || is_debug_tag_set(tag)) {
     va_list ap;
 
     va_start(ap, format_str);


### PR DESCRIPTION
debug_flag && diags->on() is almost an atomic operation,
while is_debug_tag_set requires Diags to run a regular expression.

When debug_flag is set to 1, we always want to print the debug log,
regardless of whether the tag is set or not, which makes the
is_debug_tag_set check useless, and expensive.

This change flips the conditional to check if debug_flag is 1 first,
skipping the tag check if it is.