### PR TITLE
Disable the most expensive "make check" tests by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -284,6 +284,20 @@ TS_ARG_ENABLE_VAR([has], [tests])
 AM_CONDITIONAL([BUILD_TESTS], [test 0 -ne $has_tests])
 
 #
+# Build expensive unit tests ?
+#
+
+AC_MSG_CHECKING([whether to enable expensive unit tests])
+AC_ARG_ENABLE([expensive-tests],
+  [AS_HELP_STRING([--enable-expensive-tests],[turn on expensive unit tests])],
+  [],
+  [enable_expensive_tests=no]
+)
+AC_MSG_RESULT([$enable_expensive_tests])
+TS_ARG_ENABLE_VAR([has], [expensive_tests])
+AM_CONDITIONAL([EXPENSIVE_TESTS], [test 0 -ne $has_expensive_tests])
+
+#
 # Build documentation?
 #
 

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -116,6 +116,7 @@ test_LDADD = \
 	@YAMLCPP_LIBS@ \
 	-lm
 
+if EXPENSIVE_TESTS
 check_PROGRAMS = \
   test_Cache \
   test_RWW \
@@ -128,6 +129,7 @@ check_PROGRAMS = \
   test_Update_L_to_S \
   test_Update_S_to_L \
   test_Update_header
+endif
 
 test_main_SOURCES = \
   ./test/main.cc \

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -19,7 +19,11 @@
 include $(top_srcdir)/build/tidy.mk
 
 noinst_PROGRAMS = mkdfa CompileParseRules
-check_PROGRAMS = test_atomic test_freelist test_geometry test_X509HostnameValidator test_tscore
+check_PROGRAMS = test_geometry test_X509HostnameValidator test_tscore
+
+if EXPENSIVE_TESTS
+check_PROGRAMS += test_atomic test_freelist
+endif
 
 TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=$(abs_top_srcdir)/ci/asan_leak_suppression/unit_tests.txt
 


### PR DESCRIPTION
This is at least a 2x improvement in runtime, which will help on the
CI. Also, worth noting is that the cache tests are insanely disk write
and storage heavy, it essentially builds ~23 traffic_server binaries.