### PR TITLE
For per-transaction config override, crossing the const-correctness event horizon.

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -3254,8 +3254,8 @@ ink_cache_init(ts::ModuleVersion v)
 
 //----------------------------------------------------------------------------
 Action *
-CacheProcessor::open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request, OverridableHttpConfigParams *params,
-                          time_t pin_in_cache, CacheFragType type)
+CacheProcessor::open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request,
+                          const OverridableHttpConfigParams *params, time_t pin_in_cache, CacheFragType type)
 {
   return caches[type]->open_read(cont, &key->hash, request, params, type, key->hostname, key->hostlen);
 }

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -91,7 +91,7 @@ Lcallreturn:
 }
 
 Action *
-Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, OverridableHttpConfigParams *params,
+Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, const OverridableHttpConfigParams *params,
                  CacheFragType type, const char *hostname, int host_len)
 {
   if (!CacheProcessor::IsCacheReady(type)) {

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -86,7 +86,7 @@ struct CacheProcessor : public Processor {
   Action *scan(Continuation *cont, char *hostname = nullptr, int host_len = 0, int KB_per_second = SCAN_KB_PER_SECOND);
   Action *lookup(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   inkcoreapi Action *open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request,
-                               OverridableHttpConfigParams *params, time_t pin_in_cache = (time_t)0,
+                               const OverridableHttpConfigParams *params, time_t pin_in_cache = (time_t)0,
                                CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   Action *open_write(Continuation *cont, int expected_size, const HttpCacheKey *key, CacheHTTPHdr *request, CacheHTTPInfo *old_info,
                      time_t pin_in_cache = (time_t)0, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -441,7 +441,7 @@ struct CacheVC : public CacheVConnection {
   CacheFragType frag_type;
   CacheHTTPInfo *info;
   CacheHTTPInfoVector *write_vector;
-  OverridableHttpConfigParams *params;
+  const OverridableHttpConfigParams *params;
   int header_len;        // for communicating with agg_copy
   int frag_len;          // for communicating with agg_copy
   uint32_t write_len;    // for communicating with agg_copy
@@ -988,7 +988,7 @@ struct Cache {
                             const char *hostname = nullptr, int host_len = 0);
   Action *scan(Continuation *cont, const char *hostname = nullptr, int host_len = 0, int KB_per_second = 2500);
 
-  Action *open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, OverridableHttpConfigParams *params,
+  Action *open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, const OverridableHttpConfigParams *params,
                     CacheFragType type, const char *hostname, int host_len);
   Action *open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *old_info, time_t pin_in_cache = (time_t)0,
                      const CacheKey *key1 = nullptr, CacheFragType type = CACHE_FRAG_TYPE_HTTP, const char *hostname = nullptr,

--- a/mgmt/MgmtDefs.h
+++ b/mgmt/MgmtDefs.h
@@ -72,7 +72,7 @@ struct MgmtConverter {
    * This is passed a @c void* which is a pointer to the member in the configuration instance.
    * This function must return a @c MgmtInt converted from that value.
    */
-  MgmtInt (*load_int)(void *) = nullptr;
+  MgmtInt (*load_int)(const void *) = nullptr;
 
   /** Store a @c MgmtInt into a native type.
    *
@@ -86,7 +86,7 @@ struct MgmtConverter {
    * This is passed a @c void* which is a pointer to the member in the configuration instance.
    * This function must return a @c MgmtFloat converted from that value.
    */
-  MgmtFloat (*load_float)(void *) = nullptr;
+  MgmtFloat (*load_float)(const void *) = nullptr;
 
   /** Store a @c MgmtFloat into a native type.
    *
@@ -100,7 +100,7 @@ struct MgmtConverter {
    * This is passed a @c void* which is a pointer to the member in the configuration instance.
    * This function must return a @c string_view which contains the text for the member.
    */
-  std::string_view (*load_string)(void *) = nullptr;
+  std::string_view (*load_string)(const void *) = nullptr;
 
   /** Store a view in a native type.
    *
@@ -110,30 +110,33 @@ struct MgmtConverter {
   void (*store_string)(void *, std::string_view) = nullptr;
 
   // Convenience constructors because generally only one pair is valid.
-  MgmtConverter(MgmtInt (*load)(void *), void (*store)(void *, MgmtInt));
-  MgmtConverter(MgmtFloat (*load)(void *), void (*store)(void *, MgmtFloat));
-  MgmtConverter(std::string_view (*load)(void *), void (*store)(void *, std::string_view));
+  MgmtConverter(MgmtInt (*load)(const void *), void (*store)(void *, MgmtInt));
+  MgmtConverter(MgmtFloat (*load)(const void *), void (*store)(void *, MgmtFloat));
+  MgmtConverter(std::string_view (*load)(const void *), void (*store)(void *, std::string_view));
 
-  MgmtConverter(MgmtInt (*_load_int)(void *), void (*_store_int)(void *, MgmtInt), MgmtFloat (*_load_float)(void *),
-                void (*_store_float)(void *, MgmtFloat), std::string_view (*_load_string)(void *),
+  MgmtConverter(MgmtInt (*_load_int)(const void *), void (*_store_int)(void *, MgmtInt), MgmtFloat (*_load_float)(const void *),
+                void (*_store_float)(void *, MgmtFloat), std::string_view (*_load_string)(const void *),
                 void (*_store_string)(void *, std::string_view));
 };
 
-inline MgmtConverter::MgmtConverter(MgmtInt (*load)(void *), void (*store)(void *, MgmtInt)) : load_int(load), store_int(store) {}
+inline MgmtConverter::MgmtConverter(MgmtInt (*load)(const void *), void (*store)(void *, MgmtInt))
+  : load_int(load), store_int(store)
+{
+}
 
-inline MgmtConverter::MgmtConverter(MgmtFloat (*load)(void *), void (*store)(void *, MgmtFloat))
+inline MgmtConverter::MgmtConverter(MgmtFloat (*load)(const void *), void (*store)(void *, MgmtFloat))
   : load_float(load), store_float(store)
 {
 }
 
-inline MgmtConverter::MgmtConverter(std::string_view (*load)(void *), void (*store)(void *, std::string_view))
+inline MgmtConverter::MgmtConverter(std::string_view (*load)(const void *), void (*store)(void *, std::string_view))
   : load_string(load), store_string(store)
 {
 }
 
-inline MgmtConverter::MgmtConverter(MgmtInt (*_load_int)(void *), void (*_store_int)(void *, MgmtInt),
-                                    MgmtFloat (*_load_float)(void *), void (*_store_float)(void *, MgmtFloat),
-                                    std::string_view (*_load_string)(void *), void (*_store_string)(void *, std::string_view))
+inline MgmtConverter::MgmtConverter(MgmtInt (*_load_int)(const void *), void (*_store_int)(void *, MgmtInt),
+                                    MgmtFloat (*_load_float)(const void *), void (*_store_float)(void *, MgmtFloat),
+                                    std::string_view (*_load_string)(const void *), void (*_store_string)(void *, std::string_view))
   : load_int(_load_int),
     store_int(_store_int),
     load_float(_load_float),

--- a/proxy/CacheControl.cc
+++ b/proxy/CacheControl.cc
@@ -156,7 +156,7 @@ reloadCacheControl()
 }
 
 void
-getCacheControl(CacheControlResult *result, HttpRequestData *rdata, OverridableHttpConfigParams *h_txn_conf, char *tag)
+getCacheControl(CacheControlResult *result, HttpRequestData *rdata, const OverridableHttpConfigParams *h_txn_conf, char *tag)
 {
   rdata->tag = tag;
   CacheControlTable->Match(rdata, result);

--- a/proxy/CacheControl.h
+++ b/proxy/CacheControl.h
@@ -121,7 +121,7 @@ class URL;
 struct HttpConfigParams;
 struct OverridableHttpConfigParams;
 
-inkcoreapi void getCacheControl(CacheControlResult *result, HttpRequestData *rdata, OverridableHttpConfigParams *h_txn_conf,
+inkcoreapi void getCacheControl(CacheControlResult *result, HttpRequestData *rdata, const OverridableHttpConfigParams *h_txn_conf,
                                 char *tag = nullptr);
 inkcoreapi bool host_rule_in_CacheControlTable();
 inkcoreapi bool ip_rule_in_CacheControlTable();

--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -280,7 +280,8 @@ HttpCacheSM::do_cache_open_read(const HttpCacheKey &key)
 }
 
 Action *
-HttpCacheSM::open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, OverridableHttpConfigParams *params, time_t pin_in_cache)
+HttpCacheSM::open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, const OverridableHttpConfigParams *params,
+                       time_t pin_in_cache)
 {
   Action *act_return;
 

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -65,7 +65,8 @@ public:
     captive_action.init(this);
   }
 
-  Action *open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, OverridableHttpConfigParams *params, time_t pin_in_cache);
+  Action *open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, const OverridableHttpConfigParams *params,
+                    time_t pin_in_cache);
 
   Action *open_write(const HttpCacheKey *key, URL *url, HTTPHdr *request, CacheHTTPInfo *old_info, time_t pin_in_cache, bool retry,
                      bool allow_multiple);
@@ -194,10 +195,10 @@ private:
   bool open_write_cb = false;
 
   // Open read parameters
-  int open_read_tries                      = 0;
-  HTTPHdr *read_request_hdr                = nullptr;
-  OverridableHttpConfigParams *http_params = nullptr;
-  time_t read_pin_in_cache                 = 0;
+  int open_read_tries                            = 0;
+  HTTPHdr *read_request_hdr                      = nullptr;
+  const OverridableHttpConfigParams *http_params = nullptr;
+  time_t read_pin_in_cache                       = 0;
 
   // Open write parameters
   bool retry_write     = true;

--- a/proxy/http/HttpConnectionCount.cc
+++ b/proxy/http/HttpConnectionCount.cc
@@ -38,16 +38,16 @@ OutboundConnTrack::Imp OutboundConnTrack::_imp;
 OutboundConnTrack::GlobalConfig *OutboundConnTrack::_global_config{nullptr};
 
 const MgmtConverter OutboundConnTrack::MAX_CONV(
-  [](void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<decltype(TxnConfig::max) *>(data)); },
+  [](const void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::max) *>(data)); },
   [](void *data, MgmtInt i) -> void { *static_cast<decltype(TxnConfig::max) *>(data) = static_cast<decltype(TxnConfig::max)>(i); });
 
 const MgmtConverter OutboundConnTrack::MIN_CONV(
-  [](void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<decltype(TxnConfig::min) *>(data)); },
+  [](const void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::min) *>(data)); },
   [](void *data, MgmtInt i) -> void { *static_cast<decltype(TxnConfig::min) *>(data) = static_cast<decltype(TxnConfig::min)>(i); });
 
 // Do integer and string conversions.
 const MgmtConverter OutboundConnTrack::MATCH_CONV{
-  [](void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<decltype(TxnConfig::match) *>(data)); },
+  [](const void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::match) *>(data)); },
   [](void *data, MgmtInt i) -> void {
     // Problem - the InkAPITest requires being able to set an arbitrary value, so this can either
     // correctly clamp or pass the regression tests. Currently it passes the tests.
@@ -57,8 +57,8 @@ const MgmtConverter OutboundConnTrack::MATCH_CONV{
   },
   nullptr,
   nullptr,
-  [](void *data) -> std::string_view {
-    auto t = *static_cast<OutboundConnTrack::MatchType *>(data);
+  [](const void *data) -> std::string_view {
+    auto t = *static_cast<const OutboundConnTrack::MatchType *>(data);
     return t < 0 || t > OutboundConnTrack::MATCH_BOTH ? "Invalid"sv : OutboundConnTrack::MATCH_TYPE_NAME[t];
   },
   [](void *data, std::string_view src) -> void {
@@ -372,7 +372,7 @@ OutboundConnTrack::Warning_Bad_Match_Type(std::string_view tag)
 }
 
 void
-OutboundConnTrack::TxnState::Note_Unblocked(TxnConfig *config, int count, sockaddr const *addr)
+OutboundConnTrack::TxnState::Note_Unblocked(const TxnConfig *config, int count, sockaddr const *addr)
 {
   time_t lat; // last alert time (epoch seconds)
 
@@ -388,7 +388,8 @@ OutboundConnTrack::TxnState::Note_Unblocked(TxnConfig *config, int count, sockad
 }
 
 void
-OutboundConnTrack::TxnState::Warn_Blocked(TxnConfig *config, int64_t sm_id, int count, sockaddr const *addr, char const *debug_tag)
+OutboundConnTrack::TxnState::Warn_Blocked(const TxnConfig *config, int64_t sm_id, int count, sockaddr const *addr,
+                                          char const *debug_tag)
 {
   bool alert_p     = _g->should_alert();
   auto blocked     = alert_p ? _g->_blocked.exchange(0) : _g->_blocked.load();

--- a/proxy/http/HttpConnectionCount.h
+++ b/proxy/http/HttpConnectionCount.h
@@ -184,7 +184,7 @@ public:
      * @param count Current connection count for display in message.
      * @param addr IP address of the upstream.
      */
-    void Note_Unblocked(TxnConfig *config, int count, const sockaddr *addr);
+    void Note_Unblocked(const TxnConfig *config, int count, const sockaddr *addr);
 
     /** Generate a Warning that a connection was blocked.
      *
@@ -194,7 +194,7 @@ public:
      * @param addr IP address of the upstream.
      * @param debug_tag Tag to use for the debug message. If no debug message should be generated set this to @c nullptr.
      */
-    void Warn_Blocked(TxnConfig *config, int64_t sm_id, int count, const sockaddr *addr, const char *debug_tag = nullptr);
+    void Warn_Blocked(const TxnConfig *config, int64_t sm_id, int count, const sockaddr *addr, const char *debug_tag = nullptr);
   };
 
   /** Get or create the @c Group for the specified session properties.

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2121,7 +2121,7 @@ HttpSM::process_srv_info(HostDBInfo *r)
   if (!r || !r->is_srv || !r->round_robin) {
     t_state.dns_info.srv_hostname[0]    = '\0';
     t_state.dns_info.srv_lookup_success = false;
-    t_state.txn_conf->srv_enabled       = false;
+    t_state.my_txn_conf().srv_enabled   = false;
     SMDebug("dns_srv", "No SRV records were available, continuing to lookup %s", t_state.dns_info.lookup_name);
   } else {
     HostDBRoundRobin *rr = r->rr();
@@ -2133,7 +2133,7 @@ HttpSM::process_srv_info(HostDBInfo *r)
     if (!srv) {
       t_state.dns_info.srv_lookup_success = false;
       t_state.dns_info.srv_hostname[0]    = '\0';
-      t_state.txn_conf->srv_enabled       = false;
+      t_state.my_txn_conf().srv_enabled   = false;
       SMDebug("dns_srv", "SRV records empty for %s", t_state.dns_info.lookup_name);
     } else {
       t_state.dns_info.srv_lookup_success = true;
@@ -4677,7 +4677,7 @@ HttpSM::send_origin_throttled_response()
 }
 
 static void
-set_tls_options(NetVCOptions &opt, OverridableHttpConfigParams *txn_conf)
+set_tls_options(NetVCOptions &opt, const OverridableHttpConfigParams *txn_conf)
 {
   char *verify_server = nullptr;
   if (txn_conf->ssl_client_verify_server_policy == nullptr) {

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -172,7 +172,7 @@ update_cache_control_information_from_config(HttpTransact::State *s)
 
   // Less than 0 means it wasn't overridden, so leave it alone.
   if (s->cache_control.cache_responses_to_cookies >= 0) {
-    s->txn_conf->cache_responses_to_cookies = s->cache_control.cache_responses_to_cookies;
+    s->my_txn_conf().cache_responses_to_cookies = s->cache_control.cache_responses_to_cookies;
   }
 }
 
@@ -1230,7 +1230,7 @@ HttpTransact::HandleRequest(State *s)
   if (s->txn_conf->srv_enabled) {
     IpEndpoint addr;
     ats_ip_pton(s->server_info.name, &addr);
-    s->txn_conf->srv_enabled = !ats_is_ip(&addr);
+    s->my_txn_conf().srv_enabled = !ats_is_ip(&addr);
   }
 
   // if the request is a trace or options request, decrement the

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "tscore/ink_assert.h"
 #include "tscore/ink_platform.h"
 #include "P_HostDB.h"
 #include "P_Net.h"
@@ -819,8 +820,16 @@ public:
     int64_t range_output_cl  = 0;
     RangeRecord *ranges      = nullptr;
 
-    OverridableHttpConfigParams *txn_conf = nullptr;
-    OverridableHttpConfigParams my_txn_conf; // Storage for plugins, to avoid malloc
+    OverridableHttpConfigParams const *txn_conf = nullptr;
+    OverridableHttpConfigParams &
+    my_txn_conf() // Storage for plugins, to avoid malloc
+    {
+      auto p = reinterpret_cast<OverridableHttpConfigParams *>(_my_txn_conf);
+
+      ink_assert(p == txn_conf);
+
+      return *p;
+    }
 
     bool transparent_passthrough = false;
     bool range_in_cache          = false;
@@ -900,10 +909,9 @@ public:
     void
     setup_per_txn_configs()
     {
-      if (txn_conf != &my_txn_conf) {
-        // Make sure we copy it first.
-        memcpy(&my_txn_conf, &http_config_param->oride, sizeof(my_txn_conf));
-        txn_conf = &my_txn_conf;
+      if (txn_conf != reinterpret_cast<OverridableHttpConfigParams *>(_my_txn_conf)) {
+        txn_conf = reinterpret_cast<OverridableHttpConfigParams *>(_my_txn_conf);
+        memcpy(_my_txn_conf, &http_config_param->oride, sizeof(_my_txn_conf));
       }
     }
 
@@ -922,6 +930,10 @@ public:
     }
 
     NetVConnection::ProxyProtocol pp_info;
+
+  private:
+    // Make this a raw byte array, so it will be accessed through the my_txn_conf() member function.
+    alignas(OverridableHttpConfigParams) char _my_txn_conf[sizeof(OverridableHttpConfigParams)];
 
   }; // End of State struct.
 

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -164,7 +164,7 @@ is_empty(char *s)
 */
 int
 HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPHdr *client_request,
-                                        OverridableHttpConfigParams *http_config_params)
+                                        const OverridableHttpConfigParams *http_config_params)
 {
   time_t current_age, best_age = CacheHighAgeWatermark;
   time_t t_now         = 0;
@@ -284,7 +284,7 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
 
 */
 float
-HttpTransactCache::calculate_quality_of_match(OverridableHttpConfigParams *http_config_param, HTTPHdr *client_request,
+HttpTransactCache::calculate_quality_of_match(const OverridableHttpConfigParams *http_config_param, HTTPHdr *client_request,
                                               HTTPHdr *obj_client_request, HTTPHdr *obj_origin_server_response)
 {
   // For PURGE requests, any alternate is good really.
@@ -1124,7 +1124,7 @@ language_wildcard:
 
 */
 Variability_t
-HttpTransactCache::CalcVariability(OverridableHttpConfigParams *http_config_params, HTTPHdr *client_request,
+HttpTransactCache::CalcVariability(const OverridableHttpConfigParams *http_config_params, HTTPHdr *client_request,
                                    HTTPHdr *obj_client_request, HTTPHdr *obj_origin_server_response)
 {
   ink_assert(http_config_params != nullptr);

--- a/proxy/http/HttpTransactCache.h
+++ b/proxy/http/HttpTransactCache.h
@@ -52,9 +52,9 @@ public:
   /////////////////////////////////
 
   static int SelectFromAlternates(CacheHTTPInfoVector *cache_vector_data, HTTPHdr *client_request,
-                                  OverridableHttpConfigParams *cache_lookup_http_config_params);
+                                  const OverridableHttpConfigParams *cache_lookup_http_config_params);
 
-  static float calculate_quality_of_match(OverridableHttpConfigParams *http_config_params, HTTPHdr *client_request,
+  static float calculate_quality_of_match(const OverridableHttpConfigParams *http_config_params, HTTPHdr *client_request,
                                           HTTPHdr *obj_client_request, HTTPHdr *obj_origin_server_response);
 
   static float calculate_quality_of_accept_match(MIMEField *accept_field, MIMEField *content_field);
@@ -75,7 +75,7 @@ public:
   // variability & server negotiation routines //
   ///////////////////////////////////////////////
 
-  static Variability_t CalcVariability(OverridableHttpConfigParams *http_config_params, HTTPHdr *client_request,
+  static Variability_t CalcVariability(const OverridableHttpConfigParams *http_config_params, HTTPHdr *client_request,
                                        HTTPHdr *obj_client_request, HTTPHdr *obj_origin_server_response);
 
   static HTTPStatus match_response_to_request_conditionals(HTTPHdr *ua_request, HTTPHdr *c_response,

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -961,7 +961,7 @@ HttpTransactHeaders::remove_host_name_from_url(HTTPHdr *outgoing_request)
 }
 
 void
-HttpTransactHeaders::add_global_user_agent_header_to_request(OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header)
+HttpTransactHeaders::add_global_user_agent_header_to_request(const OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header)
 {
   if (http_txn_conf->global_user_agent_header) {
     MIMEField *ua_field;
@@ -1160,7 +1160,7 @@ HttpTransactHeaders::add_forwarded_field_to_request(HttpTransact::State *s, HTTP
 } // end HttpTransact::add_forwarded_field_to_outgoing_request()
 
 void
-HttpTransactHeaders::add_server_header_to_response(OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header)
+HttpTransactHeaders::add_server_header_to_response(const OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header)
 {
   if (http_txn_conf->proxy_response_server_enabled && http_txn_conf->proxy_response_server_string) {
     MIMEField *ua_field;
@@ -1186,7 +1186,7 @@ HttpTransactHeaders::add_server_header_to_response(OverridableHttpConfigParams *
 
 void
 HttpTransactHeaders::remove_privacy_headers_from_request(HttpConfigParams *http_config_param,
-                                                         OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header)
+                                                         const OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header)
 {
   if (!header) {
     return;

--- a/proxy/http/HttpTransactHeaders.h
+++ b/proxy/http/HttpTransactHeaders.h
@@ -87,10 +87,10 @@ public:
   static void remove_conditional_headers(HTTPHdr *outgoing);
   static void remove_100_continue_headers(HttpTransact::State *s, HTTPHdr *outgoing);
   static void remove_host_name_from_url(HTTPHdr *outgoing_request);
-  static void add_global_user_agent_header_to_request(OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header);
-  static void add_server_header_to_response(OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header);
-  static void remove_privacy_headers_from_request(HttpConfigParams *http_config_param, OverridableHttpConfigParams *http_txn_conf,
-                                                  HTTPHdr *header);
+  static void add_global_user_agent_header_to_request(const OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header);
+  static void add_server_header_to_response(const OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header);
+  static void remove_privacy_headers_from_request(HttpConfigParams *http_config_param,
+                                                  const OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header);
   static void add_connection_close(HTTPHdr *header);
 
   static int nstrcpy(char *d, const char *as);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -7806,11 +7806,11 @@ TSHttpTxnFollowRedirect(TSHttpTxn txnp, int on)
     sm->enable_redirection = true;
     // Make sure we allow for at least one redirection.
     if (sm->t_state.txn_conf->number_of_redirections <= 0) {
-      sm->t_state.txn_conf->number_of_redirections = 1;
+      sm->t_state.my_txn_conf().number_of_redirections = 1;
     }
   } else {
-    sm->enable_redirection                       = false;
-    sm->t_state.txn_conf->number_of_redirections = 0;
+    sm->enable_redirection                           = false;
+    sm->t_state.my_txn_conf().number_of_redirections = 0;
   }
 
   return TS_SUCCESS;
@@ -7839,7 +7839,7 @@ TSHttpTxnRedirectUrlSet(TSHttpTxn txnp, const char *url, const int url_len)
   // Make sure we allow for at least one redirection.
   if (sm->t_state.txn_conf->number_of_redirections <= 0) {
     sm->t_state.setup_per_txn_configs();
-    sm->t_state.txn_conf->number_of_redirections = 1;
+    sm->t_state.my_txn_conf().number_of_redirections = 1;
   }
 }
 
@@ -8189,7 +8189,7 @@ _memberp_to_generic(T *ptr, MgmtConverter const *&conv)
 inline void *
 _memberp_to_generic(MgmtInt *ptr, MgmtConverter const *&conv)
 {
-  static const MgmtConverter converter([](void *data) -> MgmtInt { return *static_cast<MgmtInt *>(data); },
+  static const MgmtConverter converter([](const void *data) -> MgmtInt { return *static_cast<const MgmtInt *>(data); },
                                        [](void *data, MgmtInt i) -> void { *static_cast<MgmtInt *>(data) = i; });
 
   conv = &converter;
@@ -8200,7 +8200,7 @@ _memberp_to_generic(MgmtInt *ptr, MgmtConverter const *&conv)
 inline void *
 _memberp_to_generic(MgmtByte *ptr, MgmtConverter const *&conv)
 {
-  static const MgmtConverter converter{[](void *data) -> MgmtInt { return *static_cast<MgmtByte *>(data); },
+  static const MgmtConverter converter{[](const void *data) -> MgmtInt { return *static_cast<const MgmtByte *>(data); },
                                        [](void *data, MgmtInt i) -> void { *static_cast<MgmtByte *>(data) = i; }};
 
   conv = &converter;
@@ -8211,7 +8211,7 @@ _memberp_to_generic(MgmtByte *ptr, MgmtConverter const *&conv)
 inline void *
 _memberp_to_generic(MgmtFloat *ptr, MgmtConverter const *&conv)
 {
-  static const MgmtConverter converter{[](void *data) -> MgmtFloat { return *static_cast<MgmtFloat *>(data); },
+  static const MgmtConverter converter{[](const void *data) -> MgmtFloat { return *static_cast<const MgmtFloat *>(data); },
                                        [](void *data, MgmtFloat f) -> void { *static_cast<MgmtFloat *>(data) = f; }};
 
   conv = &converter;
@@ -8224,8 +8224,9 @@ template <typename E>
 inline auto
 _memberp_to_generic(MgmtFloat *ptr, MgmtConverter const *&conv) -> typename std::enable_if<std::is_enum<E>::value, void *>::type
 {
-  static const MgmtConverter converter{[](void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<E *>(data)); },
-                                       [](void *data, MgmtInt i) -> void { *static_cast<E *>(data) = static_cast<E>(i); }};
+  static const MgmtConverter converter{
+    [](const void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<const E *>(data)); },
+    [](void *data, MgmtInt i) -> void { *static_cast<E *>(data) = static_cast<E>(i); }};
 
   conv = &converter;
   return ptr;
@@ -8590,6 +8591,13 @@ _conf_to_memberp(TSOverridableConfigKey conf, OverridableHttpConfigParams *overr
   return ret;
 }
 
+// 2nd little helper function to find the struct member for getting.
+static const void *
+_conf_to_memberp(TSOverridableConfigKey conf, const OverridableHttpConfigParams *overridableHttpConfig, MgmtConverter const *&conv)
+{
+  return _conf_to_memberp(conf, const_cast<OverridableHttpConfigParams *>(overridableHttpConfig), conv);
+}
+
 /* APIs to manipulate the overridable configuration options.
  */
 TSReturnCode
@@ -8602,7 +8610,7 @@ TSHttpTxnConfigIntSet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtInt val
 
   s->t_state.setup_per_txn_configs();
 
-  void *dest = _conf_to_memberp(conf, s->t_state.txn_conf, conv);
+  void *dest = _conf_to_memberp(conf, &(s->t_state.my_txn_conf()), conv);
 
   if (!dest || !conv->store_int) {
     return TS_ERROR;
@@ -8621,7 +8629,7 @@ TSHttpTxnConfigIntGet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtInt *va
 
   HttpSM *s = reinterpret_cast<HttpSM *>(txnp);
   MgmtConverter const *conv;
-  void *src = _conf_to_memberp(conf, s->t_state.txn_conf, conv);
+  const void *src = _conf_to_memberp(conf, s->t_state.txn_conf, conv);
 
   if (!src || !conv->load_int) {
     return TS_ERROR;
@@ -8642,7 +8650,7 @@ TSHttpTxnConfigFloatSet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtFloat
 
   s->t_state.setup_per_txn_configs();
 
-  void *dest = _conf_to_memberp(conf, s->t_state.txn_conf, conv);
+  void *dest = _conf_to_memberp(conf, &(s->t_state.my_txn_conf()), conv);
 
   if (!dest || !conv->store_float) {
     return TS_ERROR;
@@ -8660,7 +8668,7 @@ TSHttpTxnConfigFloatGet(TSHttpTxn txnp, TSOverridableConfigKey conf, TSMgmtFloat
   sdk_assert(sdk_sanity_check_null_ptr(static_cast<void *>(value)) == TS_SUCCESS);
 
   MgmtConverter const *conv;
-  void *src = _conf_to_memberp(conf, reinterpret_cast<HttpSM *>(txnp)->t_state.txn_conf, conv);
+  const void *src = _conf_to_memberp(conf, reinterpret_cast<HttpSM *>(txnp)->t_state.txn_conf, conv);
 
   if (!src || !conv->load_float) {
     return TS_ERROR;
@@ -8686,29 +8694,29 @@ TSHttpTxnConfigStringSet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
   switch (conf) {
   case TS_CONFIG_HTTP_RESPONSE_SERVER_STR:
     if (value && length > 0) {
-      s->t_state.txn_conf->proxy_response_server_string     = const_cast<char *>(value); // The "core" likes non-const char*
-      s->t_state.txn_conf->proxy_response_server_string_len = length;
+      s->t_state.my_txn_conf().proxy_response_server_string     = const_cast<char *>(value); // The "core" likes non-const char*
+      s->t_state.my_txn_conf().proxy_response_server_string_len = length;
     } else {
-      s->t_state.txn_conf->proxy_response_server_string     = nullptr;
-      s->t_state.txn_conf->proxy_response_server_string_len = 0;
+      s->t_state.my_txn_conf().proxy_response_server_string     = nullptr;
+      s->t_state.my_txn_conf().proxy_response_server_string_len = 0;
     }
     break;
   case TS_CONFIG_HTTP_GLOBAL_USER_AGENT_HEADER:
     if (value && length > 0) {
-      s->t_state.txn_conf->global_user_agent_header      = const_cast<char *>(value); // The "core" likes non-const char*
-      s->t_state.txn_conf->global_user_agent_header_size = length;
+      s->t_state.my_txn_conf().global_user_agent_header      = const_cast<char *>(value); // The "core" likes non-const char*
+      s->t_state.my_txn_conf().global_user_agent_header_size = length;
     } else {
-      s->t_state.txn_conf->global_user_agent_header      = nullptr;
-      s->t_state.txn_conf->global_user_agent_header_size = 0;
+      s->t_state.my_txn_conf().global_user_agent_header      = nullptr;
+      s->t_state.my_txn_conf().global_user_agent_header_size = 0;
     }
     break;
   case TS_CONFIG_BODY_FACTORY_TEMPLATE_BASE:
     if (value && length > 0) {
-      s->t_state.txn_conf->body_factory_template_base     = const_cast<char *>(value);
-      s->t_state.txn_conf->body_factory_template_base_len = length;
+      s->t_state.my_txn_conf().body_factory_template_base     = const_cast<char *>(value);
+      s->t_state.my_txn_conf().body_factory_template_base_len = length;
     } else {
-      s->t_state.txn_conf->body_factory_template_base     = nullptr;
-      s->t_state.txn_conf->body_factory_template_base_len = 0;
+      s->t_state.my_txn_conf().body_factory_template_base     = nullptr;
+      s->t_state.my_txn_conf().body_factory_template_base_len = 0;
     }
     break;
   case TS_CONFIG_HTTP_INSERT_FORWARDED:
@@ -8716,7 +8724,7 @@ TSHttpTxnConfigStringSet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
       ts::LocalBufferWriter<1024> error;
       HttpForwarded::OptionBitSet bs = HttpForwarded::optStrToBitset(std::string_view(value, length), error);
       if (!error.size()) {
-        s->t_state.txn_conf->insert_forwarded = bs;
+        s->t_state.my_txn_conf().insert_forwarded = bs;
       } else {
         Error("HTTP %.*s", static_cast<int>(error.size()), error.data());
       }
@@ -8724,32 +8732,32 @@ TSHttpTxnConfigStringSet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
     break;
   case TS_CONFIG_SSL_CLIENT_VERIFY_SERVER_POLICY:
     if (value && length > 0) {
-      s->t_state.txn_conf->ssl_client_verify_server_policy = const_cast<char *>(value);
+      s->t_state.my_txn_conf().ssl_client_verify_server_policy = const_cast<char *>(value);
     }
     break;
   case TS_CONFIG_SSL_CLIENT_VERIFY_SERVER_PROPERTIES:
     if (value && length > 0) {
-      s->t_state.txn_conf->ssl_client_verify_server_properties = const_cast<char *>(value);
+      s->t_state.my_txn_conf().ssl_client_verify_server_properties = const_cast<char *>(value);
     }
     break;
   case TS_CONFIG_SSL_CLIENT_SNI_POLICY:
     if (value && length > 0) {
-      s->t_state.txn_conf->ssl_client_sni_policy = const_cast<char *>(value);
+      s->t_state.my_txn_conf().ssl_client_sni_policy = const_cast<char *>(value);
     }
     break;
   case TS_CONFIG_SSL_CLIENT_CERT_FILENAME:
     if (value && length > 0) {
-      s->t_state.txn_conf->ssl_client_cert_filename = const_cast<char *>(value);
+      s->t_state.my_txn_conf().ssl_client_cert_filename = const_cast<char *>(value);
     }
     break;
   case TS_CONFIG_SSL_CLIENT_PRIVATE_KEY_FILENAME:
     if (value && length > 0) {
-      s->t_state.txn_conf->ssl_client_private_key_filename = const_cast<char *>(value);
+      s->t_state.my_txn_conf().ssl_client_private_key_filename = const_cast<char *>(value);
     }
     break;
   case TS_CONFIG_SSL_CLIENT_CA_CERT_FILENAME:
     if (value && length > 0) {
-      s->t_state.txn_conf->ssl_client_ca_cert_filename = const_cast<char *>(value);
+      s->t_state.my_txn_conf().ssl_client_ca_cert_filename = const_cast<char *>(value);
     }
     break;
   case TS_CONFIG_SSL_CERT_FILEPATH:
@@ -8757,7 +8765,7 @@ TSHttpTxnConfigStringSet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
     break;
   default: {
     MgmtConverter const *conv;
-    void *dest = _conf_to_memberp(conf, s->t_state.txn_conf, conv);
+    void *dest = _conf_to_memberp(conf, &(s->t_state.my_txn_conf()), conv);
     if (dest != nullptr && conv != nullptr && conv->store_string) {
       conv->store_string(dest, std::string_view(value, length));
     } else {
@@ -8794,7 +8802,7 @@ TSHttpTxnConfigStringGet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
     break;
   default: {
     MgmtConverter const *conv;
-    void *src = _conf_to_memberp(conf, sm->t_state.txn_conf, conv);
+    const void *src = _conf_to_memberp(conf, sm->t_state.txn_conf, conv);
     if (src != nullptr && conv != nullptr && conv->load_string) {
       auto sv = conv->load_string(src);
       *value  = sv.data();


### PR DESCRIPTION
And falling into the black hole.

This will protect against inadvertently stomping on the baseline values for overridable configuration variables.