### PR TITLE
Reduce doc build errors

### DIFF
--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -138,9 +138,9 @@ Under normal logging these slice block errors tend to show up as::
 By default more detailed stitching errors are written to ``diags.log``.
 Examples are as follows::
 
-ERROR: [slice.cc: 288] logSliceError(): 1555705573.639 reason="Non 206 internal block response" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1000000-" norm_range="bytes 1000000-52428799/52428800" etag_exp="%221603934496%22" lm_exp="Fri, 19 Apr 2019 18:53:20 GMT" blk_range="21000000-21999999" status_got="206" cr_got="" etag_got="%221603934496%22" lm_got="" cc="no-store" via=""
+    ERROR: [slice.cc: 288] logSliceError(): 1555705573.639 reason="Non 206 internal block response" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1000000-" norm_range="bytes 1000000-52428799/52428800" etag_exp="%221603934496%22" lm_exp="Fri, 19 Apr 2019 18:53:20 GMT" blk_range="21000000-21999999" status_got="206" cr_got="" etag_got="%221603934496%22" lm_got="" cc="no-store" via=""
 
-ERROR: [server.cc: 288] logSliceError(): 1572370000.219 reason="Mismatch block Etag" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1092779033-1096299354" norm_range="bytes 1092779033-1096299354/2147483648" etag_exp="%223719843648%22" lm_exp="Tue, 29 Oct 2019 14:40:00 GMT" blk_range="1095000000-1095999999" status_got="206" cr_got="bytes 1095000000-1095999999/2147483648" etag_got="%223719853648%22" lm_got="Tue, 29 Oct 2019 17:26:40 GMT" cc="max-age=10000" via=""
+    ERROR: [server.cc: 288] logSliceError(): 1572370000.219 reason="Mismatch block Etag" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1092779033-1096299354" norm_range="bytes 1092779033-1096299354/2147483648" etag_exp="%223719843648%22" lm_exp="Tue, 29 Oct 2019 14:40:00 GMT" blk_range="1095000000-1095999999" status_got="206" cr_got="bytes 1095000000-1095999999/2147483648" etag_got="%223719853648%22" lm_got="Tue, 29 Oct 2019 17:26:40 GMT" cc="max-age=10000" via=""
 
 Whether or how often these detailed log entries are written are
 configurable plugin options.

--- a/doc/developer-guide/debugging/debug-builds.en.rst
+++ b/doc/developer-guide/debugging/debug-builds.en.rst
@@ -45,7 +45,7 @@ SystemTap and DTrace support
 ****************************
 
 Traffic Server can be instrumented with **SystemTap** on Linux systems, or
-**DTrace** on *BSDs and macOS. In order to use such tools, Traffic Server needs
+**DTrace** on \*BSDs and macOS. In order to use such tools, Traffic Server needs
 to be built with ``-g``, or the debug symbols need to be installed. On Debian
 systems, install the ``trafficserver-dbgsym`` package to install the debug
 symbols.

--- a/doc/release-notes/whats-new.en.rst
+++ b/doc/release-notes/whats-new.en.rst
@@ -33,7 +33,7 @@ New Features
 - Add support for dtrace style markers (SDT) and include a few markers at locations of interest to users of SystemTap, dtrace, and gdb. See :ref:`developer-debug-builds`.
 
 New or modified Configurations
------------------------------
+------------------------------
 
 Logging and Metrics
 -------------------


### PR DESCRIPTION
Had these build errors
trafficserver/doc/admin-guide/plugins/slice.en.rst:141: WARNING: Literal block expected; none found.
trafficserver/doc/developer-guide/debugging/debug-builds.en.rst:47: WARNING: Inline emphasis start-string without end-string.
trafficserver/doc/release-notes/whats-new.en.rst:36: WARNING: Title underline too short.

Fixes were
- Added indentation to slice code block
- The * in *BSD needed escaping
- Added and extra underline