### PR TITLE
Fix building Catch on macOS

### DIFF
--- a/tests/include/catch.hpp
+++ b/tests/include/catch.hpp
@@ -7093,6 +7093,10 @@ namespace Catch {
 #  include <stdbool.h>
 #  include <sys/types.h>
 #  include <unistd.h>
+
+// ink_autoconf.h is required to use HAVE_SYS_SYSCTL_H
+#include "ink_autoconf.h"
+
 #if defined(darwin) || defined(freebsd)
 #ifdef HAVE_SYS_SYSCTL_H
 #  include <sys/sysctl.h>
@@ -13051,4 +13055,3 @@ using Catch::Detail::Approx;
 // end catch_reenable_warnings.h
 // end catch.hpp
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-


### PR DESCRIPTION
Checking `HAVE_SYS_SYSCTL_H` in `catch.hpp` is introduced by #6145 (3ea8301d1572073072063233b6974244d1827e81).
However, it requires including `ink_autoconf.h` before the check.

```
+ make test
Making check in src/tscpp/util
/Applications/Xcode.app/Contents/Developer/usr/bin/make  test_tscpputil
  CXX      unit_tests/test_tscpputil-unit_test_main.o
In file included from ../../../../src/tscpp/util/unit_tests/unit_test_main.cc:25:
/Users/jenkins/workspace/macOS-master/compiler/clang/label/macOS/type/release/src/BUILDS/../tests/include/catch.hpp:7114:33: error: variable has incomplete type 'struct kinfo_proc'
            struct kinfo_proc   info;
                                ^
/Users/jenkins/workspace/macOS-master/compiler/clang/label/macOS/type/release/src/BUILDS/../tests/include/catch.hpp:7114:20: note: forward declaration of 'kinfo_proc'
            struct kinfo_proc   info;
                   ^
/Users/jenkins/workspace/macOS-master/compiler/clang/label/macOS/type/release/src/BUILDS/../tests/include/catch.hpp:7125:22: error: use of undeclared identifier 'CTL_KERN'
            mib[0] = CTL_KERN;
                     ^
/Users/jenkins/workspace/macOS-master/compiler/clang/label/macOS/type/release/src/BUILDS/../tests/include/catch.hpp:7126:22: error: use of undeclared identifier 'KERN_PROC'
            mib[1] = KERN_PROC;
                     ^
/Users/jenkins/workspace/macOS-master/compiler/clang/label/macOS/type/release/src/BUILDS/../tests/include/catch.hpp:7127:22: error: use of undeclared identifier 'KERN_PROC_PID'
            mib[2] = KERN_PROC_PID;
                     ^
/Users/jenkins/workspace/macOS-master/compiler/clang/label/macOS/type/release/src/BUILDS/../tests/include/catch.hpp:7140:45: error: use of undeclared identifier 'P_TRACED'
            return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
                                            ^
5 errors generated.
make[2]: *** [unit_tests/test_tscpputil-unit_test_main.o] Error 1
make[1]: *** [check-am] Error 2
make: *** [check-recursive] Error 1
```

