### PR TITLE
Fixed build issues with hwloc 2.x API changes

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -192,8 +192,13 @@ struct AIOThreadInfo : public Continuation {
     (void)event;
     (void)e;
 #if TS_USE_HWLOC
+#if HWLOC_API_VERSION >= 0x20000
+    hwloc_set_membind(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_INTERLEAVE,
+                      HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_BYNODESET);
+#else
     hwloc_set_membind_nodeset(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_INTERLEAVE,
                               HWLOC_MEMBIND_THREAD);
+#endif
 #endif
     aio_thread_main(this);
     delete this;

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -230,7 +230,11 @@ ThreadAffinityInitializer::alloc_numa_stack(EThread *t, size_t stacksize)
 
   if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
     // Let's temporarily set the memory binding to our destination NUMA node
+#if HWLOC_API_VERSION >= 0x20000
+    hwloc_set_membind(ink_get_topology(), nodeset, mem_policy, HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_BYNODESET);
+#else
     hwloc_set_membind_nodeset(ink_get_topology(), nodeset, mem_policy, HWLOC_MEMBIND_THREAD);
+#endif
   }
 
   // Alloc our stack
@@ -238,8 +242,13 @@ ThreadAffinityInitializer::alloc_numa_stack(EThread *t, size_t stacksize)
 
   if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
     // Now let's set it back to default for this thread.
+#if HWLOC_API_VERSION >= 0x20000
+    hwloc_set_membind(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_DEFAULT,
+                      HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_BYNODESET);
+#else
     hwloc_set_membind_nodeset(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_DEFAULT,
                               HWLOC_MEMBIND_THREAD);
+#endif
   }
 
   hwloc_bitmap_free(nodeset);


### PR DESCRIPTION
Fix for Fedora 31 that uses hwloc 2.0.4

Documentation for hwloc 2.0.4: https://www.open-mpi.org/projects/hwloc/doc/hwloc-v2.0.4-letter.pdf