### PR TITLE
Detect bogus jemalloc version

### DIFF
--- a/build/jemalloc.m4
+++ b/build/jemalloc.m4
@@ -68,7 +68,18 @@ if test "$enable_jemalloc" != "no"; then
     AC_CHECK_HEADERS(jemalloc/jemalloc.h, [jemalloc_have_headers=1])
   fi
   if test "$jemalloc_have_headers" != "0"; then
-    jemalloch=1
+    AC_RUN_IFELSE([
+      AC_LANG_PROGRAM(
+        [#include <jemalloc/jemalloc.h>],
+        [
+          #if (JEMALLOC_VERSION_MAJOR == 0)
+          exit(1);
+          #endif
+        ]
+      )],
+      [jemalloch=1],
+      [AC_MSG_ERROR(jemalloc has bogus version)]
+    )
   else
     AC_MSG_WARN([jemalloc not found])
     CPPFLAGS=$saved_cppflags

--- a/include/tscore/JeAllocator.h
+++ b/include/tscore/JeAllocator.h
@@ -26,6 +26,9 @@
 
 #if TS_HAS_JEMALLOC
 #include <jemalloc/jemalloc.h>
+#if (JEMALLOC_VERSION_MAJOR == 0)
+#error jemalloc has bogus version
+#endif
 #if (JEMALLOC_VERSION_MAJOR == 5) && defined(MADV_DONTDUMP)
 #define JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED 1
 #endif /* MADV_DONTDUMP */


### PR DESCRIPTION
When compiling with jemalloc, we need to check jemalloc has the correct versions defined in their header file. Adding some checks to do that and spit out error if bogus version is detected.

The following is quoted from jemalloc's `INSTALL.md` file:
> --with-version=(<major>.<minor>.<bugfix>-<nrev>-g<gid>|VERSION)
> 
> The VERSION file is mandatory for successful configuration, and the following steps are taken to assure its presence:
> 
> If --with-version=..--g is specified, generate VERSION using the specified value.
> If --with-version is not specified in either form and the source directory is inside a git repository, try to generate VERSION via 'git describe' invocations that pattern-match release tags.
> If VERSION is missing, generate it with a bogus version: 0.0.0-0-g0000000000000000000000000000000000000000
> Note that --with-version=VERSION bypasses (1) and (2), which simplifies VERSION configuration when embedding a jemalloc release into another project's git repository.