### PR TITLE
Re-order READ_REQUEST_ HDR_HOOK and PRE_REMAP_HOOK

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -880,7 +880,7 @@ one forces the beginning of a new ruleset.
      node[shape=record];
 
      Client[height=4, label="{ Client|{<p1>|<p2>} }"];
-     ATS[height=4, fontsize=10,label="{ {{<clientside0>Global:\nREAD_REQUEST_PRE_REMAP_HOOK|<clientside01>Global:\nREAD_REQUEST_HDR_HOOK\nRemap rule:\nREMAP_PSEUDO_HOOK}|<clientside1>SEND_RESPONSE_HDR_HOOK}|ATS |{<originside0>SEND_REQUEST_HDR_HOOK|<originside1>READ_RESPONSE_HDR_HOOK} }",xlabel="ATS"];
+     ATS[height=4, fontsize=10,label="{ {{<clientside0>Global:\nREAD_REQUEST_HDR_HOOK\nREAD_REQUEST_PRE_REMAP_HOOK|<clientside01>Remap rule:\nREMAP_PSEUDO_HOOK}|<clientside1>SEND_RESPONSE_HDR_HOOK}|ATS |{<originside0>SEND_REQUEST_HDR_HOOK|<originside1>READ_RESPONSE_HDR_HOOK} }",xlabel="ATS"];
      Origin[height=4, label="{ {<request>|<response>}|Origin }"];
 
      Client:p1 -> ATS:clientside0 [ label = "Request" ];


### PR DESCRIPTION
#5795 notes that READ_REQUEST_HDR_HOOK and READ_REQUEST_PRE_REMAP_HOOK
in the diagram are reversed from actual.
The state diagram in
https://docs.trafficserver.apache.org/en/8.0.x/developer-guide/plugins/hooks-and-transactions/index.en.html#http-transaction-state-diagram
show that READ_REQUEST is before
PRE_REMAP.