### PR TITLE
Make sure time is consistent between calculations

### DIFF
--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -132,11 +132,7 @@ EThread::process_event(Event *e, int calling_code)
         if (e->period < 0) {
           e->timeout_at = e->period;
         } else {
-          this->get_hrtime_updated();
-          e->timeout_at = cur_time + e->period;
-          if (e->timeout_at < cur_time) {
-            e->timeout_at = cur_time;
-          }
+          e->timeout_at = Thread::get_hrtime_updated() + e->period;
         }
         EventQueueExternal.enqueue_local(e);
       }
@@ -228,7 +224,7 @@ EThread::execute_regular()
     do {
       done_one = false;
       // execute all the eligible internal events
-      EventQueue.check_ready(cur_time, this);
+      EventQueue.check_ready(loop_start_time, this);
       while ((e = EventQueue.dequeue_ready(cur_time))) {
         ink_assert(e);
         ink_assert(e->timeout_at > 0);
@@ -263,7 +259,7 @@ EThread::execute_regular()
     tail_cb->waitForActivity(sleep_time);
 
     // loop cleanup
-    loop_finish_time = this->get_hrtime_updated();
+    loop_finish_time = Thread::get_hrtime_updated();
     delta            = loop_finish_time - loop_start_time;
 
     // This can happen due to time of day adjustments (which apparently happen quite frequently). I


### PR DESCRIPTION
Make sure the time is consistent when we're doing calculations for scheduling events.