### PR TITLE
Fixed gcc7 issue with yaml-cpp 0.6.3

### DIFF
--- a/plugins/experimental/cookie_remap/cookie_remap.cc
+++ b/plugins/experimental/cookie_remap/cookie_remap.cc
@@ -873,10 +873,10 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
       }
 
       for (YAML::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
-        const YAML::Node &first  = it2->first;
-        const YAML::Node &second = it2->second;
+        const YAML::Node first  = it2->first;
+        const YAML::Node second = it2->second;
 
-        if (second.Type() != YAML::NodeType::Scalar) {
+        if (second.IsScalar() == false) {
           const string reason = "All op nodes must be of type scalar";
           TSError("Invalid YAML Configuration format for cookie_remap: %s, reason: %s", filename.c_str(), reason.c_str());
           return TS_ERROR;


### PR DESCRIPTION
gcc7 has an issue with doing a return in the middle of iterating over the yaml map.  Changed to be a copy of the Node instead of a reference.

PR #6163 caused this issue when upgrading to yaml-cup 0.6.3

Trying different optimization levels. it only fails to compile if using -O1 or higher.