### PR TITLE
Fixing rolled log cleanup parsing for <something>.log.<something> files.

### DIFF
--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -616,15 +616,9 @@ LogConfig::update_space_used()
         //
         // then check if the candidate belongs to any given log type
         //
-        ts::TextView type_name(entry->d_name, strlen(entry->d_name));
-        // A rolled log will look something like:
-        // squid.log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.old
-        //
-        // The following logic cuts things back to original unrolled file which
-        // is the key into the deleting_info map (squid.log in the above example).
-        auto suffix = type_name;
-        type_name.remove_suffix(suffix.remove_prefix(suffix.find('.') + 1).remove_prefix(suffix.find('_')).size());
-        auto iter = deleting_info.find(type_name);
+        ts::TextView rolled_filename(entry->d_name, strlen(entry->d_name));
+        auto type_name = LogUtils::get_unrolled_filename(rolled_filename);
+        auto iter      = deleting_info.find(type_name);
         if (iter == deleting_info.end()) {
           // We won't delete the log if its name doesn't match any give type.
           continue;

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -616,8 +616,7 @@ LogConfig::update_space_used()
         //
         // then check if the candidate belongs to any given log type
         //
-        std::string_view rolled_filename(entry->d_name, strlen(entry->d_name));
-        auto iter = deleting_info.find(LogUtils::get_unrolled_filename(rolled_filename));
+        auto iter = deleting_info.find(LogUtils::get_unrolled_filename(entry->d_name));
         if (iter == deleting_info.end()) {
           // We won't delete the log if its name doesn't match any give type.
           continue;

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -616,9 +616,8 @@ LogConfig::update_space_used()
         //
         // then check if the candidate belongs to any given log type
         //
-        ts::TextView rolled_filename(entry->d_name, strlen(entry->d_name));
-        auto type_name = LogUtils::get_unrolled_filename(rolled_filename);
-        auto iter      = deleting_info.find(type_name);
+        std::string_view rolled_filename(entry->d_name, strlen(entry->d_name));
+        auto iter = deleting_info.find(LogUtils::get_unrolled_filename(rolled_filename));
         if (iter == deleting_info.end()) {
           // We won't delete the log if its name doesn't match any give type.
           continue;

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -489,28 +489,21 @@ LogUtils::get_unrolled_filename(ts::TextView rolled_filename)
 
   suffix.remove_prefix_at('.');
   // Using the above squid.log example, suffix now looks like:
-  //   log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.ol
+  //   log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.old
 
-  if (suffix.find('_') != std::string::npos) {
-    suffix.remove_prefix_at('_');
-    // suffix now looks like:
-    //   some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.ol
-  } else if (suffix.find('.') != std::string::npos) {
-    // There was no underscore in the file after the first '.'.
-    // Some logs have the following format (without the hostname):
-    // diags.log.20191114.21h43m16s-20191114.21h43m17s.old
-
-    suffix.remove_prefix_at('.');
-    // Using the diags.log from our above example, suffix now looks like:
-    //   log.20191114.21h43m16s-20191114.21h43m17s.old
-  } else {
-    // If there isn't a '.' or an '_' after the first '.', then this
-    // doesn't look like a rolled file.
-    return rolled_filename;
+  // Some suffixes do not have the hostname.  Rolled diags.log files will look
+  // something like this, for example:
+  //   diags.log.20191114.21h43m16s-20191114.21h43m17s.old
+  //
+  // For these, the second delimeter will be a period. For this reason, we also
+  // split_prefix_at with a period as well.
+  if (suffix.split_prefix_at('_') || suffix.split_prefix_at('.')) {
+    // ' + 1' to remove the '_' or second '.':
+    return unrolled_name.remove_suffix(suffix.size() + 1);
   }
-
-  // ' + 1' to remove the '_' or second '.':
-  return unrolled_name.remove_suffix(suffix.size() + 1);
+  // If there isn't a '.' or an '_' after the first '.', then this
+  // doesn't look like a rolled file.
+  return rolled_filename;
 }
 
 // Checks if the file pointed to by full_filename either is a regular

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -478,6 +478,41 @@ LogUtils::seconds_to_next_roll(time_t time_now, int rolling_offset, int rolling_
   return ((tr >= sidl ? (tr - sidl) % rolling_interval : (86400 - (sidl - tr)) % rolling_interval));
 }
 
+ts::TextView
+LogUtils::get_unrolled_filename(ts::TextView rolled_filename)
+{
+  auto unrolled_name = rolled_filename;
+
+  // A rolled log will look something like:
+  //   squid.log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.old
+  auto suffix = rolled_filename;
+
+  suffix.remove_prefix_at('.');
+  // Using the above squid.log example, suffix now looks like:
+  //   log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.ol
+
+  if (suffix.find('_') != std::string::npos) {
+    suffix.remove_prefix_at('_');
+    // suffix now looks like:
+    //   some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.ol
+  } else if (suffix.find('.') != std::string::npos) {
+    // There was no underscore in the file after the first '.'.
+    // Some logs have the following format (without the hostname):
+    // diags.log.20191114.21h43m16s-20191114.21h43m17s.old
+
+    suffix.remove_prefix_at('.');
+    // Using the diags.log from our above example, suffix now looks like:
+    //   log.20191114.21h43m16s-20191114.21h43m17s.old
+  } else {
+    // If there isn't a '.' or an '_' after the first '.', then this
+    // doesn't look like a rolled file.
+    return rolled_filename;
+  }
+
+  // ' + 1' to remove the '_' or second '.':
+  return unrolled_name.remove_suffix(suffix.size() + 1);
+}
+
 // Checks if the file pointed to by full_filename either is a regular
 // file or a pipe and has write permission, or, if the file does not
 // exist, if the path prefix of full_filename names a directory that

--- a/proxy/logging/LogUtils.h
+++ b/proxy/logging/LogUtils.h
@@ -26,6 +26,7 @@
 
 #include "tscore/ink_platform.h"
 #include "tscore/Arena.h"
+#include <tscpp/util/TextView.h>
 
 class MIMEHdr;
 
@@ -61,6 +62,22 @@ int timestamp_to_hex_str(unsigned timestamp, char *str, size_t len, size_t *n_ch
 int seconds_to_next_roll(time_t time_now, int rolling_offset, int rolling_interval);
 int file_is_writeable(const char *full_filename, off_t *size_bytes = nullptr, bool *has_size_limit = nullptr,
                       uint64_t *current_size_limit_bytes = nullptr);
+
+/** Given a rolled file, determine the unrolled filename.
+ *
+ * For example, given this:
+ *   diags.log.20191114.21h43m16s-20191114.21h43m17s.old
+ *
+ * Return this:
+ *   diags.log
+ *
+ * @param[in] rolled_filename The rolled filename from which to derive the
+ * unrolled filename.
+ *
+ * @return The unrolled filename if it looked like a rolled log file or the
+ * input filename if it didn't.
+ */
+ts::TextView get_unrolled_filename(ts::TextView rolled_filename);
 
 // Marshals header tags and values together, with a single terminating nul character.  Returns buffer space required.  'buf' points
 // to where to put the marshaled data.  If 'buf' is null, no data is marshaled, but the function returns the amount of space that

--- a/proxy/logging/unit-tests/test_LogUtils2.cc
+++ b/proxy/logging/unit-tests/test_LogUtils2.cc
@@ -130,3 +130,26 @@ void
 RecSignalManager(int, char const *, std::size_t)
 {
 }
+
+TEST_CASE("LogUtilsUnrolled", "get_unrolled_filename")
+{
+  // Rolled log inputs.
+  constexpr ts::TextView with_underscore = "squid.log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.old";
+  REQUIRE(get_unrolled_filename(with_underscore) == "squid.log");
+
+  constexpr ts::TextView without_underscore = "diags.log.20191114.21h43m16s-20191114.21h43m17s.old";
+  REQUIRE(get_unrolled_filename(without_underscore) == "diags.log");
+
+  constexpr ts::TextView dot_file = ".log.20191114.21h43m16s-20191114.21h43m17s.old";
+  // Maybe strange, but why not?
+  REQUIRE(get_unrolled_filename(dot_file) == ".log");
+
+  // Non-rolled log inputs.
+  REQUIRE(get_unrolled_filename("") == "");
+
+  constexpr ts::TextView not_a_log = "logging.yaml";
+  REQUIRE(get_unrolled_filename(not_a_log) == not_a_log);
+
+  constexpr ts::TextView no_dot = "logging_yaml";
+  REQUIRE(get_unrolled_filename(no_dot) == no_dot);
+}

--- a/proxy/logging/unit-tests/test_LogUtils2.cc
+++ b/proxy/logging/unit-tests/test_LogUtils2.cc
@@ -131,7 +131,7 @@ RecSignalManager(int, char const *, std::size_t)
 {
 }
 
-TEST_CASE("LogUtilsUnrolled", "get_unrolled_filename")
+TEST_CASE("get_unrolled_filename parses possible log files as expected", "[get_unrolled_filename]")
 {
   // Rolled log inputs.
   constexpr ts::TextView with_underscore = "squid.log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.old";


### PR DESCRIPTION
With the following PR:
https://github.com/apache/trafficserver/pull/6096

we addressed log cleanup candidate selection for log filenames of the following form:
<base_name>.log_some.hostname.com.<begin_timestamp>-<end_timestamp>.old

Such as:
squid.log_some.hostname.com.20191029.18h15m02s-20191029.18h30m02s.old

That did fix log cleanup for rolled logs like squid logs. Looking at a production box however, and doing some code inspection, I noticed that now things don't work for logs of the following form:

diags.log.20191114.21h43m16s-20191114.21h43m17s.old

Notice it doesn't have the '_<hostname>' in it. I didn't notice that logs could have that form when I did the above PR. The change in this PR fixes things so that both types are now recognized and made candidates for rolled log cleanup removal.

There's a different logging issue as well: in 7.x, any file with a '.old' suffix was a candidate for log removal. Now, in 9.x, candidates have to belong to a list of configured types to be removed. diags.log and traffic.out are hard-coded in this list and any log file in logging.yaml should make it in the list too. But other logs generated by Traffic Server (such as error.log) and logs generated by plugins are not recognized as candidates and therefore never get cleaned up. I intend to address this by adding a mechanism for generic log recognition for unrecognized options. That will be a separate PR.