### PR TITLE
Doc: Remove local path to MathJax.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -501,7 +501,7 @@ epub_copyright = u'2013, dev@trafficserver.apache.org'
 
 # Allow duplicate toc entries.
 #epub_tocdup = True
-mathjax_path = 'https://docs.trafficserver.apache.org/__RTD/MathJax.js'
+#mathjax_path = 'https://docs.trafficserver.apache.org/__RTD/MathJax.js'
 
 # Enabling marking bit fields as 'bitfield_N`.
 # Currently parameterized fields don't work. When they do, we should change to


### PR DESCRIPTION
Remove the local path for mathjax - this was apparently added while the docs were served from ReadTheDocs, which had it installed locally. Because our current docs server doesn't, and we don't use the mathematical typesetting either, it's better to just comment it out and use the default (which would be served from a CDN if used).

This primarily makes @zwoop happy by making the docs server logs cleaner.