### PR TITLE
RBTree - fix potential nullptr dereference

### DIFF
--- a/src/tscore/RbTree.cc
+++ b/src/tscore/RbTree.cc
@@ -301,7 +301,7 @@ namespace detail
             parent    = n->_parent;
             d         = NONE; // Cancel any leaf node logic
           } else {
-            if (wfc->_color == BLACK) {
+            if (wfc == BLACK) {
               w->getChild(near)->_color = BLACK;
               w->_color                 = RED;
               w->rotate(far);


### PR DESCRIPTION
This fixes a potential `nullptr` dereference. The node color comparison handles that by treating a `nullptr` as a `BLACK` node. Most of the code was converted to use that, but this line wasn't. Not sure why we haven't seen this in production, but it was breaking things for me while testing `TxnBox`. As long as I fixed it there, I might as well get it fixed here.