### PR TITLE
remap_stats: Fix BufferWriter usage error.

### DIFF
--- a/plugins/experimental/remap_stats/remap_stats.cc
+++ b/plugins/experimental/remap_stats/remap_stats.cc
@@ -143,9 +143,9 @@ handle_post_remap(TSCont cont, TSEvent event ATS_UNUSED, void *edata)
 }
 
 static void
-create_stat_name(ts::LocalBufferWriter<MAX_STAT_LENGTH> &stat_name, std::string_view h, std::string_view b)
+create_stat_name(ts::FixedBufferWriter &stat_name, std::string_view h, std::string_view b)
 {
-  stat_name.reset().reduce(1);
+  stat_name.reset().clip(1);
   stat_name.print("plugin.{}.{}.{}", PLUGIN_NAME, h, b);
   stat_name.extend(1).write('\0');
 }


### PR DESCRIPTION
This is a usage error from the C++ upgrade of `remap_stats` in #6006. I misremembered the approriate method and the one used was asserting. This changes to use the correct method to restrict the size of the output buffer. It also cleans up the parameter declaration a bit. This should fix a crash in use.