### PR TITLE
Remove header conversion functions for HTTP/0.9

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5223,11 +5223,6 @@ HttpTransact::check_response_validity(State *s, HTTPHdr *incoming_hdr)
   if (incoming_hdr->type_get() != HTTP_TYPE_RESPONSE) {
     return NOT_A_RESPONSE_HEADER;
   }
-  // If the response is 0.9 then there is no status
-  //   code or date
-  if (did_forward_server_send_0_9_response(s) == true) {
-    return NO_RESPONSE_HEADER_ERROR;
-  }
 
   HTTPStatus incoming_status = incoming_hdr->status_get();
   if (!incoming_status) {
@@ -5257,16 +5252,6 @@ HttpTransact::check_response_validity(State *s, HTTPHdr *incoming_hdr)
 #endif
 
   return NO_RESPONSE_HEADER_ERROR;
-}
-
-bool
-HttpTransact::did_forward_server_send_0_9_response(State *s)
-{
-  if (s->hdr_info.server_response.version_get() == HTTPVersion(0, 9)) {
-    s->current.server->http_version.set(0, 9);
-    return true;
-  }
-  return false;
 }
 
 bool

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1002,7 +1002,6 @@ public:
   static RequestError_t check_request_validity(State *s, HTTPHdr *incoming_hdr);
   static ResponseError_t check_response_validity(State *s, HTTPHdr *incoming_hdr);
   static bool delete_all_document_alternates_and_return(State *s, bool cache_hit);
-  static bool did_forward_server_send_0_9_response(State *s);
   static bool does_client_request_permit_cached_response(const OverridableHttpConfigParams *p, CacheControlResult *c, HTTPHdr *h,
                                                          char *via_string);
   static bool does_client_request_permit_dns_caching(CacheControlResult *c, HTTPHdr *h);

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -253,10 +253,6 @@ HttpTransactHeaders::convert_request(HTTPVersion outgoing_ver, HTTPHdr *outgoing
     convert_to_1_0_request_header(outgoing_request);
   } else if (outgoing_ver == HTTPVersion(1, 1)) {
     convert_to_1_1_request_header(outgoing_request);
-  } else if (outgoing_ver == HTTPVersion(0, 9)) {
-    // Http 0.9 is a special case - do not bother copying over fields,
-    // because they will all need to be removed anyway.
-    convert_to_0_9_request_header(outgoing_request);
   } else {
     Debug("http_trans", "[HttpTransactHeaders::convert_request]"
                         "Unsupported Version - passing through");
@@ -272,29 +268,10 @@ HttpTransactHeaders::convert_response(HTTPVersion outgoing_ver, HTTPHdr *outgoin
     convert_to_1_0_response_header(outgoing_response);
   } else if (outgoing_ver == HTTPVersion(1, 1)) {
     convert_to_1_1_response_header(outgoing_response);
-  } else if (outgoing_ver == HTTPVersion(0, 9)) {
-    // Http 0.9 is a special case - do not bother copying over fields,
-    // because they will all need to be removed anyway.
-    convert_to_0_9_response_header(outgoing_response);
   } else {
     Debug("http_trans", "[HttpTransactHeaders::convert_response]"
                         "Unsupported Version - passing through");
   }
-}
-
-////////////////////////////////////////////////////////////////////////
-// Take an existing outgoing request header and make it HTTP/0.9
-void
-HttpTransactHeaders::convert_to_0_9_request_header(HTTPHdr *outgoing_request)
-{
-  // These are required
-  ink_assert(outgoing_request->method_get_wksidx() == HTTP_WKSIDX_GET);
-  ink_assert(outgoing_request->url_get()->valid());
-
-  outgoing_request->version_set(HTTPVersion(0, 9));
-
-  // HTTP/0.9 has no headers: nuke them all
-  outgoing_request->fields_clear();
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -336,20 +313,6 @@ HttpTransactHeaders::convert_to_1_1_request_header(HTTPHdr *outgoing_request)
   // so specify that response should use identity transfer coding.
   // outgoing_request->value_insert(MIME_FIELD_TE, "identity;q=1.0");
   // outgoing_request->value_insert(MIME_FIELD_TE, "chunked;q=0.0");
-}
-
-////////////////////////////////////////////////////////////////////////
-// Take an existing outgoing response header and make it HTTP/0.9
-void
-HttpTransactHeaders::convert_to_0_9_response_header(HTTPHdr * /* outgoing_response ATS_UNUSED */)
-{
-  // Http 0.9 does not require a response header.
-
-  // There used to be clear header here, but the state machine
-  // does not write down the response header if the client is
-  // 0.9. We need the header fields to make decisions about
-  // the size of the response body, however.
-  // There is therefore no need to clear the header.
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -475,12 +438,6 @@ HttpTransactHeaders::downgrade_request(bool *origin_server_keep_alive, HTTPHdr *
   if (outgoing_request->version_get() == HTTPVersion(1, 1)) {
     // ver.set (HTTPVersion (1, 0));
     convert_to_1_0_request_header(outgoing_request);
-
-    // bz48199: only GET requests can be downgraded to HTTP/0.9
-  } else if (outgoing_request->version_get() == HTTPVersion(1, 0) && outgoing_request->method_get_wksidx() == HTTP_WKSIDX_GET) {
-    // ver.set (HTTPVersion (0, 9));
-    convert_to_0_9_request_header(outgoing_request);
-
   } else {
     return false;
   }

--- a/proxy/http/HttpTransactHeaders.h
+++ b/proxy/http/HttpTransactHeaders.h
@@ -45,10 +45,8 @@ public:
 
   static void convert_request(HTTPVersion outgoing_ver, HTTPHdr *outgoing_request);
   static void convert_response(HTTPVersion outgoing_ver, HTTPHdr *outgoing_response);
-  static void convert_to_0_9_request_header(HTTPHdr *outgoing_request);
   static void convert_to_1_0_request_header(HTTPHdr *outgoing_request);
   static void convert_to_1_1_request_header(HTTPHdr *outgoing_request);
-  static void convert_to_0_9_response_header(HTTPHdr *outgoing_response);
   static void convert_to_1_0_response_header(HTTPHdr *outgoing_response);
   static void convert_to_1_1_response_header(HTTPHdr *outgoing_response);
 


### PR DESCRIPTION
Since we dropped HTTP/0.9 support, we don't need these header conversion functions.