### PR TITLE
Limit this check to Linux, where ldd always works

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,7 +104,9 @@ if BUILD_DOCS
 	@cd doc && $(MAKE) $(AM_MAKEFLAGS) install-man
 endif
 
-TESTS = tools/check-unused-dependencies
+if OS_LINUX
+    TESTS = tools/check-unused-dependencies
+endif
 
 rat:
 	java -jar $(top_srcdir)/ci/apache-rat-0.13-SNAPSHOT.jar -E $(top_srcdir)/ci/rat-regex.txt  -d $(top_srcdir)

--- a/configure.ac
+++ b/configure.ac
@@ -738,6 +738,7 @@ case $host_os in
 esac
 
 TS_ADDTO(AM_CPPFLAGS, [-D$host_os_def])
+AM_CONDITIONAL([OS_LINUX], [test "x$host_os_def" = "xlinux"])
 
 dnl AM_PROG_AR is not always available, but it doesn't seem to be needed in older versions.
 ifdef([AM_PROG_AR],


### PR DESCRIPTION
This is likely a candidate for 9.x and 8.x as well, I don't see how this can work, at least not on Catalina.