### PR TITLE
Fixes various crashers loading/reloading parent.config

### DIFF
--- a/src/tscore/HostLookup.cc
+++ b/src/tscore/HostLookup.cc
@@ -277,8 +277,8 @@ CharIndex::~CharIndex()
 {
   // clean up the illegal key table.
   if (illegalKey) {
-    for (auto spot = illegalKey->begin(), limit = illegalKey->end(); spot != limit; delete &*(spot++)) {
-      ; // empty
+    for (auto &item : *illegalKey) {
+      delete item.second;
     }
   }
 }
@@ -428,9 +428,14 @@ CharIndex::iterator::advance() -> self_type &
       break;
     } else if (state.block->array[state.index].block != nullptr) {
       // There is a lower level block to iterate over, store our current state and descend
-      q[cur_level++] = state;
-      state.block    = state.block->array[state.index].block.get();
-      state.index    = 0;
+      if (static_cast<int>(q.size()) <= cur_level) {
+        q.push_back(state);
+      } else {
+        q[cur_level] = state;
+      }
+      cur_level++;
+      state.block = state.block->array[state.index].block.get();
+      state.index = 0;
     } else {
       ++state.index;
     }
@@ -556,8 +561,9 @@ HostBranch::~HostBranch()
     break;
   case HOST_HASH: {
     HostTable *ht = next_level._table;
-    for (auto spot = ht->begin(), limit = ht->end(); spot != limit; delete &*(spot++)) {
-    } // empty
+    for (auto &item : *ht) {
+      delete item.second;
+    }
     delete ht;
   } break;
   case HOST_INDEX: {


### PR DESCRIPTION
and another on reload:
```
=================================================================
==86844==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x60400d2d9be0 in thread T13
    #0 0x10ba47b02 in wrap__ZdlPv (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x6eb02)
    #1 0x10afd50b1 in HostBranch::~HostBranch() HostLookup.cc:564
    #2 0x10afd5cb4 in HostBranch::~HostBranch() HostLookup.cc:558
    #3 0x10afd52c7 in HostBranch::~HostBranch() HostLookup.cc:571
    #4 0x10afd5cb4 in HostBranch::~HostBranch() HostLookup.cc:558
    #5 0x10972308b in HostLookup::~HostLookup() HostLookup.h:119
    #6 0x109715104 in HostLookup::~HostLookup() HostLookup.h:119
    #7 0x10984b974 in HostMatcher<ParentRecord, ParentResult>::~HostMatcher() ControlMatcher.cc:96
    #8 0x109840264 in HostMatcher<ParentRecord, ParentResult>::~HostMatcher() ControlMatcher.cc:95
    #9 0x10984013f in ControlMatcher<ParentRecord, ParentResult>::~ControlMatcher() ControlMatcher.cc:709
    #10 0x1098402c4 in ControlMatcher<ParentRecord, ParentResult>::~ControlMatcher() ControlMatcher.cc:706
    #11 0x1098db109 in ParentConfigParams::~ParentConfigParams() ParentSelection.cc:94
    #12 0x1098db254 in ParentConfigParams::~ParentConfigParams() ParentSelection.cc:90
    #13 0x1098db278 in ParentConfigParams::~ParentConfigParams() ParentSelection.cc:90
    #14 0x1095e7b6d in ConfigProcessor::release(unsigned int, RefCountObj*) ProxyConfig.cc:194
    #15 0x1095e7f14 in ConfigInfoReleaser::handle_event(int, void*) ProxyConfig.cc:104
    #16 0x108e991b2 in Continuation::handleEvent(int, void*) I_Continuation.h:190
    #17 0x109b87391 in EThread::process_event(Event*, int) UnixEThread.cc:136
    #18 0x109b88eb6 in EThread::execute_regular() UnixEThread.cc:249
    #19 0x109b8a5a0 in EThread::execute() UnixEThread.cc:338
    #20 0x109b84792 in spawn_thread_internal(void*) Thread.cc:92
    #21 0x7fff6d1c1d35 in _pthread_start (libsystem_pthread.dylib:x86_64+0x5d35)
    #22 0x7fff6d1be58e in thread_start (libsystem_pthread.dylib:x86_64+0x258e)

0x60400d2d9be0 is located 16 bytes inside of 48-byte region [0x60400d2d9bd0,0x60400d2d9c00)
allocated by thread T0 here:
    #0 0x10ba47502 in wrap__Znwm (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x6e502)
    #1 0x10afe082c in std::__1::__libcpp_allocate(unsigned long, unsigned long) new:239
    #2 0x10aff7891 in std::__1::allocator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*> >::allocate(unsigned long, void const*) memory:1814
    #3 0x10aff7520 in std::__1::allocator_traits<std::__1::allocator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*> > >::allocate(std::__1::allocator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*> >&, unsigned long) memory:1547
    #4 0x10aff6d6a in std::__1::unique_ptr<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*>, std::__1::__hash_node_destructor<std::__1::allocator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*> > > > std::__1::__hash_table<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::__unordered_map_hasher<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::__unordered_map_equal<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*> > >::__construct_node<std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&>(std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&) __hash_table:2524
    #5 0x10aff6932 in std::__1::pair<std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*>*>, bool> std::__1::__hash_table<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::__unordered_map_hasher<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::__unordered_map_equal<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*> > >::__emplace_unique_impl<std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&>(std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&) __hash_table:2175
    #6 0x10aff6613 in std::__1::pair<std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*>*>, bool> std::__1::__hash_table<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::__unordered_map_hasher<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::__unordered_map_equal<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*> > >::__emplace_unique<std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&>(std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&) __hash_table:1097
    #7 0x10afd8c2b in std::__1::pair<std::__1::__hash_map_iterator<std::__1::__hash_iterator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*>, void*>*> >, bool> std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, HostBranch*, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, HostBranch*> > >::emplace<std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&>(std::__1::basic_string_view<char, std::__1::char_traits<char> >&, HostBranch*&) unordered_map:1080
    #8 0x10afd82db in HostLookup::InsertBranch(HostBranch*, std::__1::basic_string_view<char, std::__1::char_traits<char> >) HostLookup.cc:683
    #9 0x10afda2c3 in HostLookup::TableInsert(std::__1::basic_string_view<char, std::__1::char_traits<char> >, int, bool) HostLookup.cc:768
    #10 0x10afdeb09 in HostLookup::NewEntry(std::__1::basic_string_view<char, std::__1::char_traits<char> >, bool, void*) HostLookup.cc:944
    #11 0x10984457b in HostMatcher<ParentRecord, ParentResult>::NewEntry(matcher_line*) ControlMatcher.cc:220
    #12 0x109841acd in ControlMatcher<ParentRecord, ParentResult>::BuildTableFromString(char*) ControlMatcher.cc:898
    #13 0x10983ffc7 in ControlMatcher<ParentRecord, ParentResult>::BuildTable() ControlMatcher.cc:948
    #14 0x10983fb69 in ControlMatcher<ParentRecord, ParentResult>::ControlMatcher(char const*, char const*, matcher_tags const*, int) ControlMatcher.cc:699
    #15 0x109840024 in ControlMatcher<ParentRecord, ParentResult>::ControlMatcher(char const*, char const*, matcher_tags const*, int) ControlMatcher.cc:675
    #16 0x1098deeca in ParentConfig::reconfigure() ParentSelection.cc:273
    #17 0x1098dec7c in ParentConfig::startup() ParentSelection.cc:252
    #18 0x108f8f95e in main traffic_server.cc:1882
    #19 0x7fff6cfb52e4 in start (libdyld.dylib:x86_64+0x112e4)

Thread T13 created by T0 here:
    #0 0x10ba3278d in wrap_pthread_create (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x5978d)
    #1 0x109b84558 in ink_thread_create(_opaque_pthread_t**, void* (*)(void*), void*, int, unsigned long, void*) ink_thread.h:159
    #2 0x109b842d4 in Thread::start(char const*, void*, unsigned long, std::__1::function<void ()> const&) Thread.cc:109
    #3 0x109b8fad9 in EventProcessor::spawn_event_threads(int, int, unsigned long) UnixEventProcessor.cc:392
    #4 0x109b90d58 in EventProcessor::start(int, unsigned long) UnixEventProcessor.cc:455
    #5 0x108f8f12c in main traffic_server.cc:1831
    #6 0x7fff6cfb52e4 in start (libdyld.dylib:x86_64+0x112e4)
```