### PR TITLE
Mark EOS on Http/2 Header for responses without body

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1584,7 +1584,9 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   if (header_blocks_size <= static_cast<uint32_t>(BUFFER_SIZE_FOR_INDEX(buffer_size_index[HTTP2_FRAME_TYPE_HEADERS]))) {
     payload_length = header_blocks_size;
     flags |= HTTP2_FLAGS_HEADERS_END_HEADERS;
-    if (h2_hdr.presence(MIME_PRESENCE_CONTENT_LENGTH) && h2_hdr.get_content_length() == 0) {
+
+    if (is_response_body_precluded(resp_header->status_get(), stream->get_method_wksidx()) ||
+        (h2_hdr.presence(MIME_PRESENCE_CONTENT_LENGTH) && h2_hdr.get_content_length() == 0)) {
       flags |= HTTP2_FLAGS_HEADERS_END_STREAM;
       stream->send_end_stream = true;
     }

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -120,6 +120,7 @@ public:
   void update_initial_rwnd(Http2WindowSize new_size);
   bool has_trailing_header() const;
   void set_request_headers(HTTPHdr &h2_headers);
+  int get_method_wksidx();
 
   //////////////////
   // Variables
@@ -315,4 +316,10 @@ inline bool
 Http2Stream::is_first_transaction() const
 {
   return is_first_transaction_flag;
+}
+
+inline int
+Http2Stream::get_method_wksidx()
+{
+  return _req_header.method_get_wksidx();
 }


### PR DESCRIPTION
I think this addresses the performance issue reported in Issue #6178 

As noted there, a new commit from @masaori335 cleaned up the chunked data processing.  The HTTP/2 implementation was relying on that to send empty DATA frames with the EOS bit set to finish the transaction instead of setting the EOS bit on the response header.

This PR detects methods and return codes that will not send a response body, so the HEADER frame can have the EOS bit set directly, and avoid the inactivity timeout.