### PR TITLE
Fix the relative path for template_sets_dir to be install directory

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -668,7 +668,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.body_factory.enable_logging", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.body_factory.template_sets_dir", RECD_STRING, "body_factory", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[^[:space:]]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.body_factory.template_sets_dir", RECD_STRING, TS_BUILD_SYSCONFDIR "/body_factory", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[^[:space:]]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.body_factory.response_max_size", RECD_INT, "8192", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,


### PR DESCRIPTION
In our current production version, the base path applied to a relative path specified in the setting proxy.config.body_factory.template_sets_dir is the install root path (/home/y/ in our case).

In ATS9, the base path for this setting became <install_dir>/<conf_dir> (/home/y/conf/trafficserver in our case).  So unless we change the value of this setting from conf/trafficserver/body_factory to body_factory, the body factory templates won't load.  However, traffic_server will continue to run.  It issues the following message in diags.log
```
[Nov 19 16:32:59.926] traffic_server WARNING: Unable to access() directory '/home/y/conf/trafficserver/conf/trafficserver/body_factory': 2, No such file or directory
[Nov 19 16:32:59.926] traffic_server WARNING:  Please set 'proxy.config.body_factory.template_sets_dir'
[Nov 19 16:32:59.926] traffic_server WARNING: can't open response template directory '/home/y/conf/trafficserver/conf/trafficserver/body_factory' (No such file or directory)
[Nov 19 16:32:59.926] traffic_server WARNING: no response templates --- using default error pages
```
But it doesn't load any default pages.  Rather instead of returning error responses built from templates it just closes the connection to the client with no response.  The causes an increase in the number of "invalid" responses.

Other settings do not seem to have their base directory changed.  For example, the proxy.config.ssl*path settings all  still assume a base directory of the install directory.

Looks like the culprit was ba420782. I think this was an unintentional side effect of the change. By using a cleaner API to fetch the templates_sets_dir, it is loading relative to the conf directory instead of relative to the install directory.  This PR backs out some of those changes so that the value of proxy.config.body_factory.template_sets_dir is applied to the install directory.

If we feel that we want to make the base directory change, it should be made to all similar config entries, and the documentation should be updated (was not in this case).