### PR TITLE
Lua plugin fix: Account for null in output from TSUrlPercentDecode.

### DIFF
--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -1952,8 +1952,8 @@ ts.server_request_get_version
 
 **description:** Return the http version string of the server request.
 
-Current possible values are 1.0, 1.1, and 0.9.
-::
+Current possible values are 1.0, 1.1, and 0.9. ::
+
     function send_request()
         local version = ts.server_request.get_version()
         ts.debug(version)

--- a/doc/developer-guide/api/functions/TSUrlPercentEncode.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlPercentEncode.en.rst
@@ -51,16 +51,28 @@ failed.  :func:`TSStringPercentEncode` is similar but operates on a string. If
 the optional :arg:`map` parameter is provided (not :literal:`NULL`) , it should
 be a map of characters to encode.
 
-:func:`TSStringPercentDecode` perform percent-decoding of the string in the
-:arg:`str` buffer, writing to the :arg:`dst` buffer. The source and
-destination can be the same, in which case they overwrite. The decoded string
-is always guaranteed to be no longer than the source string.
+:func:`TSStringPercentDecode` perform percent-decoding of the string in the :arg:`str` buffer,
+writing to the :arg:`dst` buffer. The source and destination can be the same, in which case the
+decoded string is written on top of the source string. The decoded string is guaranteed to be
+no longer than the source string, but will include a terminating null which, if there are no
+escapes, makes the destination one longer than the source. In practice this means the destination
+length needs to be bumped up by one to account for the null, and a string can't be decoded in place
+if it's not already null terminated with the length of the destination including the null, but the
+length of the source *not* including the null. E.g. ::
+
+   static char const ORIGINAL[] = "A string without escapes, but null terminated";
+   char * source = TSstrdup(ORIGINAL); // make it writeable.
+   size_t length; // return value.
+   // sizeof(ORIGINAL) includes the null, so don't include that in the input.
+   static const size_t N_CHARS = sizeof(ORIGINAL) - 1;
+   TSReturnCode result = TSUrlPercentDecode(source, N_CHARS, source, N_CHARS + 1, &length);
+   ink_assert(length == N_CHARS);
 
 Return Values
 =============
 
-All these APIs returns a :type:`TSReturnCode`, indicating success
-(:data:`TS_SUCCESS`) or failure (:data:`TS_ERROR`) of the operation.
+All these APIs returns a :type:`TSReturnCode`, indicating success (:data:`TS_SUCCESS`) or failure
+(:data:`TS_ERROR`) of the operation.
 
 See Also
 ========

--- a/plugins/lua/ts_lua_crypto.c
+++ b/plugins/lua/ts_lua_crypto.c
@@ -316,8 +316,8 @@ ts_lua_unescape_uri(lua_State *L)
     return 1;
   }
 
-  /* the unescaped string can only be smaller */
-  dlen = len;
+  /* the unescaped string can not be larger, but need to account for terminating null. */
+  dlen = len + 1;
   dst  = lua_newuserdata(L, dlen);
 
   if (TS_SUCCESS == TSStringPercentDecode((const char *)src, len, (char *)dst, dlen, &length)) {


### PR DESCRIPTION
The behavior of `TSUrlPercentDecode` is not fully described in the documentation. This patches fixes two issues related to that.

*  For the Lua plugin, the URI decoding logic drops the last character if there are no escapes in the string. The logic there is adjusted to account for the API behavior.

*  The documentation is updated to describe this non-obvious behavior to avoid future problems of a similar nature.