### PR TITLE
Fix stringstream crash during shutdown

### DIFF
--- a/plugins/experimental/ssl_session_reuse/src/common.cc
+++ b/plugins/experimental/ssl_session_reuse/src/common.cc
@@ -30,18 +30,21 @@
 
 #include "common.h"
 
-const unsigned char salt[] = {115, 97, 108, 117, 0, 85, 137, 229};
+const unsigned char salt[]      = {115, 97, 108, 117, 0, 85, 137, 229};
+const unsigned char hex_chars[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
 std::string
-hex_str(std::string str)
+hex_str(std::string const &str)
 {
-  std::string hex_str = "";
-  for (char &c : str) {
-    std::stringstream stream;
-    stream << std::hex << std::setfill('0') << std::setw(2) << (0xFF & static_cast<unsigned int>(c));
-    hex_str += stream.str();
+  size_t len = str.size() * 2 + 1;
+  char hex_str[len];
+  for (unsigned long int i = 0; i < str.size(); ++i) {
+    unsigned char c    = str.at(i);
+    hex_str[i * 2]     = hex_chars[(c & 0xF0) >> 4];
+    hex_str[i * 2 + 1] = hex_chars[(c & 0x0F)];
   }
-  return hex_str;
+  hex_str[len] = '\0';
+  return std::string(hex_str, len);
 }
 
 int

--- a/plugins/experimental/ssl_session_reuse/src/common.h
+++ b/plugins/experimental/ssl_session_reuse/src/common.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <iostream>
-#include <sstream>
 #include <iomanip>
 #include <string>
 #include <cstring>
@@ -70,7 +69,7 @@ private:
   std::mutex threads_mutex;
 };
 
-std::string hex_str(std::string str);
+std::string hex_str(std::string const &str);
 
 int encrypt_encode64(const unsigned char *key, int key_length, const unsigned char *in_data, int in_data_len, char *out_data,
                      size_t out_data_size, size_t *out_data_len);


### PR DESCRIPTION
Seeing crashes during shutdown with this stack, removing stringstream looks like the only choice.
```
[ 00 ] libc-2.17.so                  raise                                     
[ 01 ] libc-2.17.so                  __GI_abort                                
[ 02 ] libstdc++.so.6.0.19           __gnu_cxx::__verbose_terminate_handler()  
[ 03 ] libstdc++.so.6.0.19                                                     
[ 04 ] libstdc++.so.6.0.19           std::terminate()                          
[ 05 ] libstdc++.so.6.0.19           __gxx_personality_v0                      
[ 06 ] libgcc_s-4.8.5-20150702.so.1                                            
[ 07 ] libgcc_s-4.8.5-20150702.so.1  _Unwind_ForcedUnwind                      
[ 08 ] libpthread-2.17.so            __GI___pthread_unwind                     
[ 09 ] libpthread-2.17.so            sigcancel_handler                         
[ 10 ] libpthread-2.17.so                                                      
[ 11 ] libstdc++.so.6.0.19           std::locale::~locale()                    
[ 12 ] asf_ssl_session_reuse.so      hex_str(std::string)                      ( basic_ios.h:282 )
[ 13 ] asf_ssl_session_reuse.so      RedisSubscriber::run()                    ( subscriber.cc:182 )
[ 14 ] asf_ssl_session_reuse.so      setup_subscriber(void*)                   ( subscriber.cc:47 )
[ 15 ] traffic_server                ink_thread_trampoline                     ( InkIOCoreAPI.cc:128 )
[ 16 ] libpthread-2.17.so            start_thread                              
```