### PR TITLE
Docker builds do not need build numbers in workspace

### DIFF
--- a/ci/jenkins/bin/autest.sh
+++ b/ci/jenkins/bin/autest.sh
@@ -18,7 +18,7 @@
 
 set +x
 
-INSTALL="${WORKSPACE}/${BUILD_NUMBER}/install"
+INSTALL="${ATS_BUILD_BASEDIR}/install"
 URL="https://ci.trafficserver.apache.org/autest"
 JOB_ID=${ghprbPullId:-${ATS_BRANCH:-master}}
 AUSB="ausb-${JOB_ID}.${BUILD_NUMBER}"

--- a/ci/jenkins/bin/build.sh
+++ b/ci/jenkins/bin/build.sh
@@ -33,14 +33,14 @@ echo "CCACHE: $CCACHE"
 echo "WERROR: $WERROR"
 
 # Change to the build area (this is previously setup in extract.sh)
-cd "${WORKSPACE}/${BUILD_NUMBER}/build"
+cd "${ATS_BUILD_BASEDIR}/build"
 mkdir -p BUILDS && cd BUILDS
 
 # Restore verbose shell output
 set -x
 
 ../configure \
-    --prefix="${WORKSPACE}/${BUILD_NUMBER}/install" \
+    --prefix="${ATS_BUILD_BASEDIR}/install" \
     --enable-experimental-plugins \
     --enable-example-plugins \
     --with-user=jenkins \

--- a/ci/jenkins/bin/cache-tests.sh
+++ b/ci/jenkins/bin/cache-tests.sh
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-PREFIX="${WORKSPACE}/${BUILD_NUMBER}/install"
+PREFIX="${ATS_BUILD_BASEDIR}/install"
 REMAP="${PREFIX}/etc/trafficserver/remap.config"
 RECORDS="${PREFIX}/etc/trafficserver/records.config"
 
@@ -25,7 +25,7 @@ TWEAK=""
 
 # Change to the build area (this is previously setup in extract.sh)
 set +x
-cd "${WORKSPACE}/${BUILD_NUMBER}/build"
+cd "${ATS_BUILD_BASEDIR}/build"
 
 ./configure \
     --prefix=${PREFIX} \

--- a/ci/jenkins/bin/clang-format.sh
+++ b/ci/jenkins/bin/clang-format.sh
@@ -16,6 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+set +x
 cd "${WORKSPACE}/src"
 
 # First, make sure there are no trailing WS!!!
@@ -25,6 +26,17 @@ if [ "1" != "$?" ]; then
     echo "Error: Please run: git grep -IE ' +$'"
     exit 1
 fi
+echo "Success! No trailing whitespace"
+
+# Make sure there are no DOS shit here.
+git grep -IE $'\r$' | fgrep -v 'lib/yamlcpp'
+if [ "1" != "$?" ]; then
+    echo "Error: Please make sure to run dos2unix on the above file(s)"
+    exit 1
+fi
+echo "Success! No DOS carriage return"
+
+set -x
 
 autoreconf -if && ./configure
 [ "0" != "$?" ] && exit 1

--- a/ci/jenkins/bin/cleanup.sh
+++ b/ci/jenkins/bin/cleanup.sh
@@ -17,11 +17,10 @@
 #  limitations under the License.
 
 # Do a distclean, to verify that we can actually satisfy this (common) build target
-cd "${WORKSPACE}/${BUILD_NUMBER}/build"
+cd "${ATS_BUILD_BASEDIR}/build"
 [ -d BUILDS ] && cd BUILDS
 
 ${ATS_MAKE} distclean
 
-# Final cleanup, this removes the build and install areas
-cd "${WORKSPACE}"
-rm -rf ${BUILD_NUMBER}
+# Final cleanup, this removes the build and install areas, not really needed nor right for docker builds
+cd "${WORKSPACE}" && rm -rf ${BUILD_NUMBER}

--- a/ci/jenkins/bin/extract.sh
+++ b/ci/jenkins/bin/extract.sh
@@ -18,16 +18,16 @@
 
 set +x
 # Setup the build and install area for this build
-mkdir -p "${WORKSPACE}/${BUILD_NUMBER}/build"
-mkdir -p "${WORKSPACE}/${BUILD_NUMBER}/install"
+mkdir -p "${ATS_BUILD_BASEDIR}/build"
+mkdir -p "${ATS_BUILD_BASEDIR}/install"
 
-cd "${WORKSPACE}/${BUILD_NUMBER}/build"
+cd "${ATS_BUILD_BASEDIR}/build"
 echo "Artifact: ${ATS_SRC_HOME}/trafficserver-${ATS_BRANCH}.tar.bz2"
 tar xf ${ATS_SRC_HOME}/trafficserver-${ATS_BRANCH}.tar.bz2
 mv trafficserver-*/* .
 
-echo "build: ${WORKSPACE}/${BUILD_NUMBER}/build"
-echo "install: ${WORKSPACE}/${BUILD_NUMBER}/install"
+echo "build: ${ATS_BUILD_BASEDIR}/build"
+echo "install: ${ATS_BUILD_BASEDIR}/install"
 
 # Restore verbose shell output
 set -x

--- a/ci/jenkins/bin/github.sh
+++ b/ci/jenkins/bin/github.sh
@@ -18,7 +18,7 @@
 
 set +x
 
-INSTALL="${WORKSPACE}/${BUILD_NUMBER}/install"
+INSTALL="${ATS_BUILD_BASEDIR}/install"
 
 # Optional settings
 CCACHE=""

--- a/ci/jenkins/bin/regression.sh
+++ b/ci/jenkins/bin/regression.sh
@@ -16,7 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-cd "${WORKSPACE}/${BUILD_NUMBER}/build"
+cd "${ATS_BUILD_BASEDIR}/build"
 [ -d BUILDS ] && cd BUILDS
 
 echo
@@ -27,5 +27,5 @@ ${ATS_MAKE} install || exit 1
 
 echo
 echo -n "Regression tests started at " && date
-"${WORKSPACE}/${BUILD_NUMBER}/install/bin/traffic_server" -k -K -R 1
+"${ATS_BUILD_BASEDIR}/install/bin/traffic_server" -k -K -R 1
 echo -n "Regression tests finished at " && date


### PR DESCRIPTION
Eliminating the build number helps improve the ccache
cache hit ratio dramatically, since our command line
options to e.g. -I would bust the cache.