### PR TITLE
Add mechanism to enforce SNI policy

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1844,6 +1844,24 @@ Security
    ``2`` Similar to 0, except return a 416 error code and no response body.
    ===== ======================================================================
 
+.. ts:cv:: CONFIG proxy.config.http.host_sni_policy INT 2
+
+   This option controls how host header and SNI name mismatches are handled.  Mismatches
+   may result in SNI-based policies defined in :file:`sni.yaml` being avoided.  For example, ``foo.com``
+   may be the fqdn value in :file:`sni.yaml` which defines that client certificates are required.
+   The user could specify ``bar.com`` as the SNI to avoid the policy requiring the client certificate
+   but specify ``foo.com`` as the HTTP host header to still access the same object.
+
+   Therefore, if a host header would have triggered a SNI policy, it is possible that the user is
+   trying to bypass a SNI policy if the host header and SNI values do not match.
+
+   If this setting is 0, no checking is performed.  If this setting is 1 or 2, the host header and SNI values
+   are compared if the host header value would have triggered a SNI policy.  If there is a mismatch and the value
+   is 1, a warning is generated but the transaction is allowed to proceed.  If the value is 2 and there is a
+   mismatch, a warning is generated and a status 403 is returned.
+
+   You can override this global setting on a per domain basis in the :file:`sni.yaml` file using the :ref:`host_sni_policy attribute<override-host-sni-policy>` action.
+
 Cache Control
 =============
 

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -457,6 +457,15 @@ public:
   virtual Action *send_OOB(Continuation *cont, char *buf, int len);
 
   /**
+    Return the server name that is appropriate for the network VC type
+  */
+  virtual const char *
+  get_server_name() const
+  {
+    return nullptr;
+  }
+
+  /**
     Cancels a scheduled send_OOB. Part of the message could have
     been sent already. Not callbacks to the cont are made after
     this call. The Action returned by send_OOB should not be accessed
@@ -626,6 +635,16 @@ public:
   get_context() const
   {
     return netvc_context;
+  }
+
+  /**
+   * Returns true if the network protocol
+   * supports a client provided SNI value
+   */
+  virtual bool
+  support_sni()
+  {
+    return false;
   }
 
   /** Structure holding user options. */

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -642,7 +642,7 @@ public:
    * supports a client provided SNI value
    */
   virtual bool
-  support_sni()
+  support_sni() const
   {
     return false;
   }

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -399,12 +399,18 @@ public:
   // The serverName is either a pointer to the (null-terminated) name fetched from the
   // SSL object or the empty string.
   const char *
-  get_server_name() const
+  get_server_name() const override
   {
     return _serverName.get() ? _serverName.get() : "";
   }
 
   void set_server_name(std::string_view name);
+
+  bool
+  support_sni() override
+  {
+    return true;
+  }
 
   /// Set by asynchronous hooks to request a specific operation.
   SslVConnOp hookOpRequested = SSL_HOOK_OP_DEFAULT;
@@ -430,6 +436,8 @@ public:
   {
     verify_cert = ctx;
   }
+
+  static bool TestClientAction(const char *servername, const IpEndpoint &ep, int &enforcement_policy);
 
 private:
   std::string_view map_tls_protocol_to_tag(const char *proto_string) const;

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -407,7 +407,7 @@ public:
   void set_server_name(std::string_view name);
 
   bool
-  support_sni() override
+  support_sni() const override
   {
     return true;
   }
@@ -436,8 +436,6 @@ public:
   {
     verify_cert = ctx;
   }
-
-  static bool TestClientAction(const char *servername, const IpEndpoint &ep, int &enforcement_policy);
 
 private:
   std::string_view map_tls_protocol_to_tag(const char *proto_string) const;

--- a/iocore/net/P_SSLSNI.h
+++ b/iocore/net/P_SSLSNI.h
@@ -122,6 +122,8 @@ struct SNIConfig {
 
   typedef ConfigProcessor::scoped_config<SNIConfig, SNIConfigParams> scoped_config;
 
+  static bool TestClientAction(const char *servername, const IpEndpoint &ep, int &enforcement_policy);
+
 private:
   static int configid;
 };

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -138,6 +138,12 @@ public:
     return false;
   }
 
+  const char *
+  get_server_name() const override
+  {
+    return nullptr;
+  }
+
   void do_io_close(int lerrno = -1) override;
   void do_io_shutdown(ShutdownHowTo_t howto) override;
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1891,3 +1891,22 @@ SSLNetVConnection::set_server_name(std::string_view name)
     _serverName.reset(n);
   }
 }
+
+// See if any of the client-side actions would trigger for this combination of servername and
+// client IP
+// host_sni_policy is an in/out paramter.  It starts with the global policy from the records.config
+// setting proxy.config.http.host_sni_policy and is possibly overridden if the sni policy
+// contains a host_sni_policy entry
+bool
+SSLNetVConnection::TestClientAction(const char *servername, const IpEndpoint &ep, int &host_sni_policy)
+{
+  bool retval = false;
+  SNIConfig::scoped_config params;
+  const actionVector *actionvec = params->get(servername);
+  if (actionvec) {
+    for (auto &&item : *actionvec) {
+      retval |= item->TestClientSNIAction(servername, ep, host_sni_policy);
+    }
+  }
+  return retval;
+}

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1891,22 +1891,3 @@ SSLNetVConnection::set_server_name(std::string_view name)
     _serverName.reset(n);
   }
 }
-
-// See if any of the client-side actions would trigger for this combination of servername and
-// client IP
-// host_sni_policy is an in/out paramter.  It starts with the global policy from the records.config
-// setting proxy.config.http.host_sni_policy and is possibly overridden if the sni policy
-// contains a host_sni_policy entry
-bool
-SSLNetVConnection::TestClientAction(const char *servername, const IpEndpoint &ep, int &host_sni_policy)
-{
-  bool retval = false;
-  SNIConfig::scoped_config params;
-  const actionVector *actionvec = params->get(servername);
-  if (actionvec) {
-    for (auto &&item : *actionvec) {
-      retval |= item->TestClientSNIAction(servername, ep, host_sni_policy);
-    }
-  }
-  return retval;
-}

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -186,3 +186,22 @@ SNIConfig::release(SNIConfigParams *params)
 {
   configProcessor.release(configid, params);
 }
+
+// See if any of the client-side actions would trigger for this combination of servername and
+// client IP
+// host_sni_policy is an in/out paramter.  It starts with the global policy from the records.config
+// setting proxy.config.http.host_sni_policy and is possibly overridden if the sni policy
+// contains a host_sni_policy entry
+bool
+SNIConfig::TestClientAction(const char *servername, const IpEndpoint &ep, int &host_sni_policy)
+{
+  bool retval = false;
+  SNIConfig::scoped_config params;
+  const actionVector *actionvec = params->get(servername);
+  if (actionvec) {
+    for (auto &&item : *actionvec) {
+      retval |= item->TestClientSNIAction(servername, ep, host_sni_policy);
+    }
+  }
+  return retval;
+}

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -70,6 +70,9 @@ SNIConfigParams::loadSNIConfig()
     if (item.verify_client_level != 255) {
       ai->actions.push_back(std::make_unique<VerifyClient>(item.verify_client_level));
     }
+    if (item.host_sni_policy != 255) {
+      ai->actions.push_back(std::make_unique<HostSniPolicy>(item.host_sni_policy));
+    }
     if (!item.protocol_unset) {
       ai->actions.push_back(std::make_unique<TLSValidProtocols>(item.protocol_mask));
     }

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -104,12 +104,11 @@ std::set<std::string> valid_sni_config_keys = {TS_fqdn,
                                                TS_client_cert,
                                                TS_client_key,
                                                TS_http2,
-                                               TS_ip_allow
+                                               TS_ip_allow,
 #if TS_USE_HELLO_CB
-                                               ,
-                                               TS_valid_tls_versions_in
+                                               TS_valid_tls_versions_in,
 #endif
-};
+                                               TS_host_sni_policy};
 
 namespace YAML
 {
@@ -144,6 +143,12 @@ template <> struct convert<YamlSNIConfig::Item> {
         throw YAML::ParserException(node[TS_verify_client].Mark(), "unknown value \"" + value + "\"");
       }
       item.verify_client_level = static_cast<uint8_t>(level);
+    }
+
+    if (node[TS_host_sni_policy]) {
+      auto value           = node[TS_host_sni_policy].as<std::string>();
+      int policy           = POLICY_DESCRIPTOR.get(value);
+      item.host_sni_policy = static_cast<uint8_t>(policy);
     }
 
     if (node[TS_tunnel_route]) {

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -41,6 +41,7 @@ TSDECL(client_key);
 TSDECL(ip_allow);
 TSDECL(valid_tls_versions_in);
 TSDECL(http2);
+TSDECL(host_sni_policy);
 #undef TSDECL
 
 const int start = 0;
@@ -53,7 +54,8 @@ struct YamlSNIConfig {
     verify_server_policy,     // this applies to server side vc only
     verify_server_properties, // this applies to server side vc only
     client_cert,
-    h2 // this applies to client side only
+    h2,             // this applies to client side only
+    host_sni_policy // Applies to client side only
   };
   enum class Level { NONE = 0, MODERATE, STRICT };
   enum class Policy : uint8_t { DISABLED = 0, PERMISSIVE, ENFORCED, UNSET };
@@ -67,6 +69,7 @@ struct YamlSNIConfig {
     std::string fqdn;
     std::optional<bool> offer_h2; // Has no value by default, so do not initialize!
     uint8_t verify_client_level = 255;
+    uint8_t host_sni_policy     = 255;
     std::string tunnel_destination;
     bool tunnel_decrypt               = false;
     Policy verify_server_policy       = Policy::UNSET;

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1459,6 +1459,14 @@ static const RecordElement RecordsConfig[] =
   // Controls for TLS ASYN_JOBS and engine loading
   {RECT_CONFIG, "proxy.config.ssl.async.handshake.enabled", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL},
   {RECT_CONFIG, "proxy.config.ssl.engine.conf_file", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL},
+
+  //###########
+  //#
+  //# Control how the host/sni name mismatches are handled
+  //# 0 - no checking. 1 - log in mismatch. 2 - enforcing
+  //#
+  //###########
+  {RECT_CONFIG, "proxy.config.http.host_sni_policy", RECD_INT, "2", RECU_NULL, RR_NULL, RECC_NULL, "[0-2]", RECA_NULL},
 };
 // clang-format on
 

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -141,6 +141,8 @@ public:
   TSHttpHookID get_hookid() const;
   bool has_hooks() const;
 
+  virtual bool support_sni() const = 0;
+
   APIHook *hook_get(TSHttpHookID id) const;
   HttpAPIHooks const *feature_hooks() const;
   ////////////////////

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -107,6 +107,8 @@ public:
   void set_rx_error_code(ProxyError e);
   void set_tx_error_code(ProxyError e);
 
+  bool support_sni() const;
+
   /// Variables
   //
   HttpSessionAccept::Options upstream_outbound_options; // overwritable copy of options
@@ -212,4 +214,10 @@ inline const char *
 ProxyTransaction::protocol_contains(std::string_view tag_prefix) const
 {
   return _proxy_ssn ? _proxy_ssn->protocol_contains(tag_prefix) : nullptr;
+}
+
+inline bool
+ProxyTransaction::support_sni() const
+{
+  return _proxy_ssn ? _proxy_ssn->support_sni() : false;
 }

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -597,3 +597,9 @@ Http1ClientSession::get_protocol_string() const
 {
   return "http";
 }
+
+bool
+Http1ClientSession::support_sni() const
+{
+  return client_vc ? client_vc->support_sni() : false;
+}

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -89,6 +89,8 @@ public:
   void increment_current_active_client_connections_stat() override;
   void decrement_current_active_client_connections_stat() override;
 
+  bool support_sni() const override;
+
 private:
   Http1ClientSession(Http1ClientSession &);
 

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1,4 +1,5 @@
 /** @file
+ *
 
   A brief file description
 
@@ -1250,6 +1251,7 @@ HttpConfig::startup()
   HttpEstablishStaticConfigLongLong(c.oride.number_of_redirections, "proxy.config.http.number_of_redirections");
   HttpEstablishStaticConfigLongLong(c.post_copy_size, "proxy.config.http.post_copy_size");
   HttpEstablishStaticConfigStringAlloc(c.redirect_actions_string, "proxy.config.http.redirect.actions");
+  HttpEstablishStaticConfigByte(c.http_host_sni_policy, "proxy.config.http.host_sni_policy");
 
   HttpEstablishStaticConfigStringAlloc(c.oride.ssl_client_sni_policy, "proxy.config.ssl.client.sni_policy");
 
@@ -1521,6 +1523,7 @@ HttpConfig::reconfigure()
   params->post_copy_size                    = m_master.post_copy_size;
   params->redirect_actions_string           = ats_strdup(m_master.redirect_actions_string);
   params->redirect_actions_map = parse_redirect_actions(params->redirect_actions_string, params->redirect_actions_self_action);
+  params->http_host_sni_policy = m_master.http_host_sni_policy;
 
   params->oride.ssl_client_sni_policy = ats_strdup(m_master.oride.ssl_client_sni_policy);
 

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -787,6 +787,8 @@ public:
   MgmtInt http_request_line_max_size = 65535;
   MgmtInt http_hdr_field_max_size    = 131070;
 
+  MgmtByte http_host_sni_policy = 0;
+
   // noncopyable
   /////////////////////////////////////
   // operator = and copy constructor //

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3965,12 +3965,58 @@ HttpSM::state_remap_request(int event, void * /* data ATS_UNUSED */)
   return 0;
 }
 
+// This check must be called before remap.  Otherwise, the client_request host
+// name may be changed.
+void
+HttpSM::check_sni_host()
+{
+  // Check that the SNI and host name fields match, if it matters
+  // Issue warning or mark the transaction to be terminated as necessary
+  int host_len;
+  const char *host_name = t_state.hdr_info.client_request.host_get(&host_len);
+  if (host_name && host_len) {
+    if (ua_txn->support_sni()) {
+      int host_sni_policy   = t_state.http_config_param->http_host_sni_policy;
+      NetVConnection *netvc = ua_txn->get_netvc();
+      if (netvc) {
+        IpEndpoint ip = netvc->get_remote_endpoint();
+        if (SSLNetVConnection::TestClientAction(std::string{host_name, static_cast<size_t>(host_len)}.c_str(), ip,
+                                                host_sni_policy) &&
+            host_sni_policy > 0) {
+          // In a SNI/Host mismatch where the Host would have triggered SNI policy, mark the transaction
+          // to be considered for rejection after the remap phase passes.  Gives the opportunity to conf_remap
+          // override the policy.:w
+          //
+          //
+          // to be rejected
+          // in the end_remap logic
+          const char *sni_value    = netvc->get_server_name();
+          const char *action_value = host_sni_policy == 2 ? "terminate" : "continue";
+          if (!sni_value || sni_value[0] == '\0') { // No SNI
+            Warning("No SNI for TLS request with hostname %.*s action=%s", host_len, host_name, action_value);
+            if (host_sni_policy == 2) {
+              this->t_state.client_connection_enabled = false;
+            }
+          } else if (strncmp(host_name, sni_value, host_len) != 0) { // Name mismatch
+            Warning("SNI/hostname mismatch sni=%s host=%.*s action=%s", sni_value, host_len, host_name, action_value);
+            if (host_sni_policy == 2) {
+              this->t_state.client_connection_enabled = false;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 void
 HttpSM::do_remap_request(bool run_inline)
 {
   SMDebug("http_seq", "[HttpSM::do_remap_request] Remapping request");
   SMDebug("url_rewrite", "Starting a possible remapping for request [%" PRId64 "]", sm_id);
   bool ret = remapProcessor.setup_for_remap(&t_state, m_remap);
+
+  check_sni_host();
 
   // Preserve effective url before remap
   t_state.unmapped_url.create(t_state.hdr_info.client_request.url_get()->m_heap);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -40,6 +40,7 @@
 #include "RemapProcessor.h"
 #include "Transform.h"
 #include "P_SSLConfig.h"
+#include "P_SSLSNI.h"
 #include "HttpPages.h"
 #include "IPAllow.h"
 #include "tscore/I_Layout.h"
@@ -3980,8 +3981,7 @@ HttpSM::check_sni_host()
       NetVConnection *netvc = ua_txn->get_netvc();
       if (netvc) {
         IpEndpoint ip = netvc->get_remote_endpoint();
-        if (SSLNetVConnection::TestClientAction(std::string{host_name, static_cast<size_t>(host_len)}.c_str(), ip,
-                                                host_sni_policy) &&
+        if (SNIConfig::TestClientAction(std::string{host_name, static_cast<size_t>(host_len)}.c_str(), ip, host_sni_policy) &&
             host_sni_policy > 0) {
           // In a SNI/Host mismatch where the Host would have triggered SNI policy, mark the transaction
           // to be considered for rejection after the remap phase passes.  Gives the opportunity to conf_remap

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -339,6 +339,10 @@ public:
   bool get_postbuf_done();
   bool is_postbuf_valid();
 
+  // See if we should allow the transaction
+  // based on sni and host name header values
+  void check_sni_host();
+
 protected:
   int reentrancy_count = 0;
 

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -723,3 +723,9 @@ Http2ClientSession::add_url_to_pushed_table(const char *url, int url_len)
     h2_pushed_urls.emplace(url);
   }
 }
+
+bool
+Http2ClientSession::support_sni() const
+{
+  return client_vc ? client_vc->support_sni() : false;
+}

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -220,6 +220,8 @@ public:
   // Variables
   Http2ConnectionState connection_state;
 
+  bool support_sni() const override;
+
 private:
   int main_event_handler(int, void *);
 

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -130,6 +130,12 @@ HQSession::get_transact_count() const
   return 0;
 }
 
+bool
+HQSession::support_sni() const
+{
+  return this->_client_vc;
+}
+
 //
 // Http3Session
 //

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -133,7 +133,7 @@ HQSession::get_transact_count() const
 bool
 HQSession::support_sni() const
 {
-  return this->_client_vc;
+  return this->_client_vc ? this->_client_vc->support_sni() : false;
 }
 
 //

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -49,6 +49,7 @@ public:
   void release(ProxyTransaction *trans) override;
   NetVConnection *get_netvc() const override;
   int get_transact_count() const override;
+  bool support_sni() override;
 
   // HQSession
   void add_transaction(HQTransaction *);

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -49,7 +49,7 @@ public:
   void release(ProxyTransaction *trans) override;
   NetVConnection *get_netvc() const override;
   int get_transact_count() const override;
-  bool support_sni() override;
+  bool support_sni() const override;
 
   // HQSession
   void add_transaction(HQTransaction *);

--- a/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
+++ b/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
@@ -58,35 +58,35 @@ tr.Processes.Default.Streams.All = "gold/miss_default-1.gold"
 
 # Same URL in generation 1 is a MISS.
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation1/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose'.format(
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation1/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose -o /dev/null'.format(
     ts.Variables.port, objectid)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/miss_gen1.gold"
 
 # Same URL in generation 2 is still a MISS.
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation2/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose'.format(
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation2/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose -o /dev/null'.format(
     ts.Variables.port, objectid)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/miss_gen2.gold"
 
 # Second touch is a HIT for default.
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/default/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose'.format(
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/default/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose -o /dev/null'.format(
     ts.Variables.port, objectid)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/hit_default-1.gold"
 
 # Second touch is a HIT for generation1.
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation1/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose'.format(
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation1/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose -o /dev/null'.format(
     ts.Variables.port, objectid)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/hit_gen1.gold"
 
 # Second touch is a HIT for generation2.
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation2/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose'.format(
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}/generation2/cache/10/{1}" -H "x-debug: x-cache,x-cache-key,via,x-cache-generation" --verbose -o /dev/null'.format(
     ts.Variables.port, objectid)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/hit_gen2.gold"

--- a/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
+++ b/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
@@ -69,12 +69,6 @@ ts.Disk.remap_config.AddLine(
     'map https://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port)
 )
 
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: "*bar.com"',
-    '  verify_client: STRICT',
-])
-
 ts.Disk.plugin_config.AddLine(
     'sslheaders.so SSL-Client-ID=client.subject'
 )

--- a/tests/gold_tests/tls/tls_sni_host_policy.test.py
+++ b/tests/gold_tests/tls/tls_sni_host_policy.test.py
@@ -1,0 +1,147 @@
+'''
+Test exercising host and SNI mismatch controls
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test exercising host and SNI mismatch controls
+'''
+
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
+cafile = "{0}/signer.pem".format(Test.RunDirectory)
+cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
+server = Test.MakeOriginServer("server")
+
+request_header = {"headers": "GET /case1 HTTP/1.1\r\nHost: example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+request_header = {"headers": "GET /  HTTP/1.1\r\nHost: bar.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+ts.addSSLfile("ssl/signer.pem")
+
+ts.Disk.records_config.update({
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.client.verify.server':  0,
+    'proxy.config.url_remap.pristine_host_hdr' : 1,
+    'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
+    'proxy.config.http.host_sni_policy': 2,
+    'proxy.config.ssl.TLSv1_3': 0
+})
+
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+
+# Just map everything through to origin.  This test is concentratign on the user-agent side
+ts.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}/'.format(server.Variables.Port)
+)
+
+# Scenario 1:  Default no client cert required.  cert required for bar.com
+ts.Disk.sni_yaml.AddLines([
+    'sni:',
+    '- fqdn: boblite',
+    '  verify_client: STRICT',
+    '  host_sni_policy: PERMISSIVE',
+    '- fqdn: bob',
+    '  verify_client: STRICT',
+])
+
+# case 1
+# sni=bob and host=dave.  Do not provide client cert.  Should fail
+tr = Test.AddTestRun("Connect to bob without cert")
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.StartBefore(server)
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k -H 'host:dave' --resolve 'bob:{0}:127.0.0.1' https://bob:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 35
+
+# case 2
+# sni=bob and host=dave.  Do provide client cert.  Should succeed
+tr = Test.AddTestRun("Connect to bob with good cert")
+tr.Setup.Copy("ssl/signed-foo.pem")
+tr.Setup.Copy("ssl/signed-foo.key")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:dave' --resolve 'bob:{0}:127.0.0.1' https://bob:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+
+# case 3
+# sni=dave and host=bob.  Do not provide client cert.  Should fail due to sni-host mismatch
+tr = Test.AddTestRun("Connect to dave without cert")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k -H 'host:bob' --resolve 'dave:{0}:127.0.0.1' https://dave:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Access Denied", "Check response")
+
+# case 4
+# sni=dave and host=bob.  Do provide client cert.  Should fail due to sni-host mismatch
+tr = Test.AddTestRun("Connect to dave with cert")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:bob' --resolve 'dave:{0}:127.0.0.1' https://dave:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("Access Denied", "Check response")
+
+# case 5
+# sni=ellen and host=boblite.  Do not provide client cert.  Should warn due to sni-host mismatch
+tr = Test.AddTestRun("Connect to ellen without cert")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k -H 'host:boblite' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
+
+# case 6
+# sni=ellen and host=boblite.  Do provide client cert.  Should warn due to sni-host mismatch
+tr = Test.AddTestRun("Connect to ellen with cert")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:boblite' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
+
+# case 7
+# sni=ellen and host=fran.  Do not provide client cert.  No warning since neither name is mentioned in sni.yaml
+tr = Test.AddTestRun("Connect to ellen without cert")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k -H 'host:fran' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
+
+# case 8
+# sni=ellen and host=fran.  Do provide client cert.  No warning since neither name is mentioned in sni.yaml
+tr = Test.AddTestRun("Connect to ellen with cert")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:fran' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
+
+
+ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI/hostname mismatch sni=dave host=bob action=terminate", "Should have warning on mismatch")
+ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI/hostname mismatch sni=ellen host=boblite action=continue", "Should have warning on mismatch")
+ts.Disk.diags_log.Content += Testers.ExcludesExpression("WARNING: SNI/hostname mismatch sni=ellen host=fran", "Should not have warning on mismatch with non-policy host")


### PR DESCRIPTION
This mechanism prevents a malicious user from avoiding a SNI-based policy but still accessing the protected resource.  Some examples are enumerated in the documentation updates of this PR.

We have been running this mechanism internally.