### PR TITLE
Fix sni.yaml fqdn to match complete name string

### DIFF
--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -108,10 +108,13 @@ SNIConfigParams::SNIConfigParams() {}
 const actionVector *
 SNIConfigParams::get(const std::string &servername) const
 {
+  int ovector[2];
   for (const auto &retval : sni_action_list) {
-    if (retval.match == nullptr && servername.length() == 0) {
+    int length = servername.length();
+    if (retval.match == nullptr && length == 0) {
       return &retval.actions;
-    } else if (pcre_exec(retval.match, nullptr, servername.c_str(), servername.length(), 0, 0, nullptr, 0) >= 0) {
+    } else if (pcre_exec(retval.match, nullptr, servername.c_str(), length, 0, 0, ovector, 2) == 1 && ovector[0] == 0 &&
+               ovector[1] == length) {
       return &retval.actions;
     }
   }

--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -63,6 +63,8 @@ ts.Disk.sni_yaml.AddLines([
     'sni:',
     '- fqdn: bob.bar.com',
     '  verify_client: NONE',
+    '- fqdn: "bob.com"',
+    '  verify_client: STRICT',
     '- fqdn: bob.*.com',
     '  verify_client: NONE',
     '- fqdn: "*bar.com"',
@@ -168,3 +170,17 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
+
+
+# Test that the fqdn's match completely.  bob.com should require client certificate. bob.com.com should not
+tr = Test.AddTestRun("Connect to bob.com without cert, should fail")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.com:{0}:127.0.0.1' https://bob.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 35
+
+tr = Test.AddTestRun("Connect to bob.com.com without cert, should succeed")
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = "curl --tls-max 1.2 -k --resolve 'bob.com.com:{0}:127.0.0.1' https://bob.com.com:{0}/case1".format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
Noticed this while adding a test for another PR.  The fqdn name match will succeed on a prefix match.  Should completely match the server name.  Augmented a test to catch the regression.