### PR TITLE
Fix build error in QUICTypes.cc

### DIFF
--- a/iocore/net/quic/QUICTypes.h
+++ b/iocore/net/quic/QUICTypes.h
@@ -225,9 +225,9 @@ class QUICConnectionId
 public:
   static uint8_t SCID_LEN;
 
-  static const int MIN_LENGTH_FOR_INITIAL = 8;
-  static const int MAX_LENGTH             = 20;
-  static const size_t MAX_HEX_STR_LENGTH  = MAX_LENGTH * 2 + 1;
+  static constexpr int MIN_LENGTH_FOR_INITIAL = 8;
+  static constexpr int MAX_LENGTH             = 20;
+  static constexpr size_t MAX_HEX_STR_LENGTH  = MAX_LENGTH * 2 + 1;
   static QUICConnectionId ZERO();
   QUICConnectionId();
   QUICConnectionId(const uint8_t *buf, uint8_t len);


### PR DESCRIPTION
Don't know why it happen, but `constepr` fix this error.

```
  CXXLD    traffic_server/traffic_server
  CXXLD    traffic_quic/traffic_quic
../iocore/net/quic/libquic.a(QUICTypes.o): In function `QUICConnectionId::QUICConnectionId(unsigned char const*, unsigned char)':
/home/scw00/trafficserver/iocore/net/quic/QUICTypes.cc:591: undefined reference to `QUICConnectionId::MAX_LENGTH'

```