### PR TITLE
Adjust the refcounts to avoid Mutex leak

### DIFF
--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -256,7 +256,7 @@ Mutex_trylock(
 #ifdef DEBUG
   const SourceLocation &location, const char *ahandler,
 #endif
-  Ptr<ProxyMutex> &m, EThread *t)
+  ProxyMutex *m, EThread *t)
 {
   ink_assert(t != nullptr);
   ink_assert(t == reinterpret_cast<EThread *>(this_thread()));
@@ -295,12 +295,26 @@ Mutex_trylock(
   return true;
 }
 
+inline bool
+Mutex_trylock(
+#ifdef DEBUG
+  const SourceLocation &location, const char *ahandler,
+#endif
+  Ptr<ProxyMutex> &m, EThread *t)
+{
+  return Mutex_trylock(
+#ifdef DEBUG
+    location, ahandler,
+#endif
+    m.get(), t);
+}
+
 inline int
 Mutex_lock(
 #ifdef DEBUG
   const SourceLocation &location, const char *ahandler,
 #endif
-  Ptr<ProxyMutex> &m, EThread *t)
+  ProxyMutex *m, EThread *t)
 {
   ink_assert(t != nullptr);
   if (m->thread_holding != t) {
@@ -327,8 +341,22 @@ Mutex_lock(
   return true;
 }
 
+inline int
+Mutex_lock(
+#ifdef DEBUG
+  const SourceLocation &location, const char *ahandler,
+#endif
+  Ptr<ProxyMutex> &m, EThread *t)
+{
+  return Mutex_lock(
+#ifdef DEBUG
+    location, ahandler,
+#endif
+    m.get(), t);
+}
+
 inline void
-Mutex_unlock(Ptr<ProxyMutex> &m, EThread *t)
+Mutex_unlock(ProxyMutex *m, EThread *t)
 {
   if (m->nthread_holding) {
     ink_assert(t == m->thread_holding);
@@ -349,6 +377,12 @@ Mutex_unlock(Ptr<ProxyMutex> &m, EThread *t)
       ink_mutex_release(&m->the_mutex);
     }
   }
+}
+
+inline void
+Mutex_unlock(Ptr<ProxyMutex> &m, EThread *t)
+{
+  Mutex_unlock(m.get(), t);
 }
 
 class WeakMutexLock


### PR DESCRIPTION
This PR addresses issue #5777.  

After talking with @traeak a few days ago, staring at the code for a day, and talking with @SolidWallOfCode, I think I understand what is going on.  The problem is that we are treating ProxyMutex objects as referenced counted smart pointers from within the INKContInternal objects, but we are also treating them as not-smart pointers via the C Plugin interface TSMutexCreate, TSMutexLock, TSMutexUnlock, and TSMutexDestroy.

@traeak identified the commit from PR #4926 as the cause of the leak.  That PR was cleaning up the various mutex lock/unlock methods and added refcount increment decrement to TSMutexCreate/Destroy to try to make things uniformly reference counted.  However, with that change, the ProxyMutex's created by TSMutexCreate and passed to TSContCreate would never be deleted, because the stand-alone TSMutexDestroy was never called to decrement the last reference count.

This PR 
* Removes the reference count increment/decrement from TSMutexCreate/Destroy.  Returning to the behavior from before PR #4926
* Adds non-smart pointer versions of Mutex_lock, Mutex_unlock, and Mutex_trylock, which also reverts some of the cleanup from PR #4926.  Without this change calls to TSMutexLock/Unlock from the plugin would delete the ProxyMutex on return from the mutex call because the smart pointer reference count would go to 0.  These crashes would exhibit in autests for traffic_dump and lua_watermark.

This is not the optimal solution, but good enough for release 9.  A more consistent solution would likely require more changes in plugin code.  I will leave discussion for that to another thread.