### PR TITLE
Fail on missing body factory

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2361,7 +2361,7 @@ Customizable User Response Pages
 
    The customizable response page default directory. If this is a
    relative path, |TS| resolves it relative to the
-   ``PREFIX`` directory.
+   ``SYSCONFDIR`` directory.
 
 .. ts:cv:: CONFIG proxy.config.body_factory.template_base STRING ""
     :reloadable:

--- a/doc/admin-guide/monitoring/error-messages.en.rst
+++ b/doc/admin-guide/monitoring/error-messages.en.rst
@@ -136,7 +136,7 @@ is provided in :ref:`appendix-http-status-codes`.
 
 The error messages can be customized. The actual response is generated from a template. These
 templates are stored in files which means the errors responses can be customized by modifying these
-files. The default directory for the template files is ``PREFIX/body_factory/default`` but this can
+files. The default directory for the template files is ``SYSCONFDIR/body_factory/default`` but this can
 be changed by the configuration variable :ts:cv:`proxy.config.body_factory.template_sets_dir`. All
 files in this directory are added to a lookup table which is consulted when the error message is
 generated. The name used for lookup is by default that listed in the :ref:`following table

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -279,8 +279,8 @@ HttpBodyFactory::reconfigure()
   ats_scoped_str directory_of_template_sets(RecConfigReadConfigPath("proxy.config.body_factory.template_sets_dir", "body_factory"));
 
   if (access(directory_of_template_sets, R_OK) < 0) {
-    Warning("Unable to access() directory '%s': %d, %s", (const char *)directory_of_template_sets, errno, strerror(errno));
-    Warning(" Please set 'proxy.config.body_factory.template_sets_dir' ");
+    Fatal("Unable to access() directory '%s': %d, %s.  Please set 'proxy.config.body_factory.template_sets_dir' ",
+          (const char *)directory_of_template_sets, errno, strerror(errno));
   }
 
   Debug("body_factory", "directory_of_template_sets = '%s' ", (const char *)directory_of_template_sets);


### PR DESCRIPTION
This is an alternative fix to issue #5102.  My preferred fix is in PR #6203.  But if we do want to keep the template_sets_dir relative to the configuration directory rather than the install directory, this PR will fail if the body_factory cannot be loaded and the PR updates the documentation for the setting to reflect the new relative base path.