### PR TITLE
Don't sleep if ProtectedQueue.localQueue is not empty. (#6234)

### DIFF
--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -33,7 +33,7 @@
 #include "I_EThread.h"
 #include "I_EventProcessor.h"
 
-const int DELAY_FOR_RETRY = HRTIME_MSECONDS(10);
+const ink_hrtime DELAY_FOR_RETRY = HRTIME_MSECONDS(10);
 
 TS_INLINE Event *
 EThread::schedule_imm(Continuation *cont, int callback_event, void *cookie)

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -254,7 +254,13 @@ EThread::execute_regular()
     next_time             = EventQueue.earliest_timeout();
     ink_hrtime sleep_time = next_time - Thread::get_hrtime_updated();
     if (sleep_time > 0) {
-      sleep_time = std::min(sleep_time, HRTIME_MSECONDS(thread_max_heartbeat_mseconds));
+      if (EventQueueExternal.localQueue.empty()) {
+        sleep_time = std::min(sleep_time, HRTIME_MSECONDS(thread_max_heartbeat_mseconds));
+      } else {
+        // Because of a missed lock, Timed-Event and Negative-Event have been pushed into localQueue for retry in awhile.
+        // Therefore, we have to set the limitation of sleep time in order to handle the next retry in time.
+        sleep_time = std::min(sleep_time, DELAY_FOR_RETRY);
+      }
       ++(current_metric->_wait);
     } else {
       sleep_time = 0;


### PR DESCRIPTION
Within `process_event()`, if the `Event` can not be locked , it will be pushed into `ProtectedQueue.localQueue` for retry in awhile.

We missed the checked on `ProtectedQueue.localQueue` before to calculate the sleep time.

As a result, these retrying `Event` may wait up to 60 ms before they can be processed.