### PR TITLE
slice plugin VIO cleanup

### DIFF
--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -138,9 +138,9 @@ Under normal logging these slice block errors tend to show up as::
 By default more detailed stitching errors are written to ``diags.log``.
 Examples are as follows::
 
-    ERROR: [slice.cc: 288] logSliceError(): 1555705573.639 reason="Non 206 internal block response" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1000000-" norm_range="bytes 1000000-52428799/52428800" etag_exp="%221603934496%22" lm_exp="Fri, 19 Apr 2019 18:53:20 GMT" blk_range="21000000-21999999" status_got="206" cr_got="" etag_got="%221603934496%22" lm_got="" cc="no-store" via=""
+ERROR: [slice.cc: 288] logSliceError(): 1555705573.639 reason="Non 206 internal block response" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1000000-" norm_range="bytes 1000000-52428799/52428800" etag_exp="%221603934496%22" lm_exp="Fri, 19 Apr 2019 18:53:20 GMT" blk_range="21000000-21999999" status_got="206" cr_got="" etag_got="%221603934496%22" lm_got="" cc="no-store" via=""
 
-    ERROR: [server.cc: 288] logSliceError(): 1572370000.219 reason="Mismatch block Etag" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1092779033-1096299354" norm_range="bytes 1092779033-1096299354/2147483648" etag_exp="%223719843648%22" lm_exp="Tue, 29 Oct 2019 14:40:00 GMT" blk_range="1095000000-1095999999" status_got="206" cr_got="bytes 1095000000-1095999999/2147483648" etag_got="%223719853648%22" lm_got="Tue, 29 Oct 2019 17:26:40 GMT" cc="max-age=10000" via=""
+ERROR: [server.cc: 288] logSliceError(): 1572370000.219 reason="Mismatch block Etag" uri="http://ats_ep/someasset.mp4" uas="curl" req_range="bytes=1092779033-1096299354" norm_range="bytes 1092779033-1096299354/2147483648" etag_exp="%223719843648%22" lm_exp="Tue, 29 Oct 2019 14:40:00 GMT" blk_range="1095000000-1095999999" status_got="206" cr_got="bytes 1095000000-1095999999/2147483648" etag_got="%223719853648%22" lm_got="Tue, 29 Oct 2019 17:26:40 GMT" cc="max-age=10000" via=""
 
 Whether or how often these detailed log entries are written are
 configurable plugin options.

--- a/plugins/experimental/slice/Config.cc
+++ b/plugins/experimental/slice/Config.cc
@@ -98,13 +98,14 @@ Config::fromArgs(int const argc, char const *const argv[])
     {const_cast<char *>("remap-host"), required_argument, nullptr, 'r'},
     {const_cast<char *>("pace-errorlog"), required_argument, nullptr, 'p'},
     {const_cast<char *>("disable-errorlog"), no_argument, nullptr, 'd'},
+    {const_cast<char *>("throttle"), no_argument, nullptr, 'o'},
     {nullptr, 0, nullptr, 0},
   };
 
   // getopt assumes args start at '1' so this hack is needed
   char *const *argvp = (const_cast<char *const *>(argv) - 1);
   for (;;) {
-    int const opt = getopt_long(argc + 1, argvp, "b:t:r:p:d", longopts, nullptr);
+    int const opt = getopt_long(argc + 1, argvp, "b:t:r:p:do", longopts, nullptr);
     if (-1 == opt) {
       break;
     }
@@ -148,6 +149,10 @@ Config::fromArgs(int const argc, char const *const argv[])
     } break;
     case 'd':
       m_paceerrsecs = -1;
+      break;
+    case 'o':
+      m_throttle = true;
+      DEBUG_LOG("Enabling internal block throttling");
       break;
     default:
       break;

--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -30,6 +30,7 @@ struct Config {
 
   int64_t m_blockbytes{blockbytesdefault};
   std::string m_remaphost; // remap host to use for loopback slice GET
+  bool m_throttle{false};  // internal block throttling
   int m_paceerrsecs{0};    // -1 disable logging, 0 no pacing, max 60s
 
   // Convert optarg to bytes

--- a/plugins/experimental/slice/HttpHeader.h
+++ b/plugins/experimental/slice/HttpHeader.h
@@ -53,6 +53,16 @@ struct HttpHeader {
     return nullptr != m_buffer && nullptr != m_lochdr;
   }
 
+  int
+  byteSize() const
+  {
+    if (isValid()) {
+      return TSHttpHdrLengthGet(m_buffer, m_lochdr);
+    } else {
+      return 0;
+    }
+  }
+
   // TS_HTTP_TYPE_UNKNOWN, TS_HTTP_TYPE_REQUEST, TS_HTTP_TYPE_RESPONSE
   TSHttpType type() const;
 
@@ -205,7 +215,8 @@ struct HdrMgr {
      TSHttpHdrParseResp
     Call this multiple times if necessary.
   */
-  TSParseResult populateFrom(TSHttpParser const http_parser, TSIOBufferReader const reader, HeaderParseFunc const parsefunc);
+  TSParseResult populateFrom(TSHttpParser const http_parser, TSIOBufferReader const reader, HeaderParseFunc const parsefunc,
+                             int64_t *const consumed);
 
   bool
   isValid() const

--- a/plugins/experimental/slice/Makefile.inc
+++ b/plugins/experimental/slice/Makefile.inc
@@ -23,7 +23,6 @@ experimental_slice_slice_la_SOURCES = \
   experimental/slice/Config.h \
   experimental/slice/ContentRange.cc \
   experimental/slice/ContentRange.h \
-  experimental/slice/Data.cc \
   experimental/slice/Data.h \
   experimental/slice/HttpHeader.cc \
   experimental/slice/HttpHeader.h \
@@ -39,7 +38,9 @@ experimental_slice_slice_la_SOURCES = \
   experimental/slice/slice.h \
   experimental/slice/Stage.h \
   experimental/slice/transfer.cc \
-  experimental/slice/transfer.h
+  experimental/slice/transfer.h \
+  experimental/slice/util.cc \
+  experimental/slice/util.h
 
 check_PROGRAMS += experimental/slice/test_content_range
 

--- a/plugins/experimental/slice/Makefile.tsxs
+++ b/plugins/experimental/slice/Makefile.tsxs
@@ -22,7 +22,6 @@ all: $(PLUGIN).so
 SOURCES = \
 	Config.cc \
 	ContentRange.cc \
-	Data.cc \
 	HttpHeader.cc \
 	Range.cc \
 	client.cc \

--- a/plugins/experimental/slice/Range.cc
+++ b/plugins/experimental/slice/Range.cc
@@ -152,6 +152,16 @@ Range::firstBlockFor(int64_t const blocksize) const
   }
 }
 
+int64_t
+Range::lastBlockFor(int64_t const blocksize) const
+{
+  if (0 < blocksize && isValid()) {
+    return std::max((int64_t)0, (m_end - 1) / blocksize);
+  } else {
+    return -1;
+  }
+}
+
 Range
 Range::intersectedWith(Range const &other) const
 {
@@ -162,7 +172,6 @@ bool
 Range::blockIsInside(int64_t const blocksize, int64_t const blocknum) const
 {
   Range const blockrange(blocksize * blocknum, blocksize * (blocknum + 1));
-
   Range const isec(blockrange.intersectedWith(*this));
 
   return isec.isValid();

--- a/plugins/experimental/slice/Range.h
+++ b/plugins/experimental/slice/Range.h
@@ -56,6 +56,10 @@ public:
    */
   int64_t firstBlockFor(int64_t const blockbytes) const;
 
+  /** block number of last (inclusive) range block
+   */
+  int64_t lastBlockFor(int64_t const blockbytes) const;
+
   /** block intersection
    */
   Range intersectedWith(Range const &other) const;

--- a/plugins/experimental/slice/client.h
+++ b/plugins/experimental/slice/client.h
@@ -27,6 +27,8 @@
  * New block requests are also initiated by the client.
  */
 
+bool requestBlock(TSCont contp, Data *const data);
+
 /** returns true if the incoming vio can be turned off
  */
 bool handle_client_req(TSCont contp, TSEvent event, Data *const data);

--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -27,6 +27,19 @@
 #include "ts/ts.h"
 
 #include <netinet/in.h>
+#include <cassert>
+#include <mutex>
+
+#if defined(COLLECT_STATS)
+namespace stats
+{
+int DataCreate  = -1;
+int DataDestroy = -1;
+int Reader      = -1;
+int Server      = -1;
+int Client      = -1;
+} // namespace stats
+#endif // COLLECT_STATS
 
 namespace
 {
@@ -143,7 +156,9 @@ read_request(TSHttpTxn txnp, Config *const config)
       }
 
       // we'll intercept this GET and do it ourselves
-      TSCont const icontp(TSContCreate(intercept_hook, TSMutexCreate()));
+      TSMutex const mutex = TSContMutexGet(reinterpret_cast<TSCont>(txnp));
+      // TSMutex const mutex = TSMutexCreate();
+      TSCont const icontp(TSContCreate(intercept_hook, mutex));
       TSContDataSet(icontp, (void *)data);
       TSHttpTxnIntercept(icontp, txnp);
       return true;
@@ -218,7 +233,44 @@ SLICE_EXPORT
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbug, int errbuf_size)
 {
-  DEBUG_LOG("slice remap is successfully initialized.");
+  DEBUG_LOG("slice remap initializing.");
+
+#if defined(COLLECT_STATS)
+  static bool init = false;
+  static std::mutex mutex;
+
+  std::lock_guard<std::mutex> lock(mutex);
+
+  if (!init) {
+    init = true;
+
+    std::string const namedatacreate = std::string(PLUGIN_NAME) + ".DataCreate";
+    stats::DataCreate = TSStatCreate(namedatacreate.c_str(), TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+
+    assert(0 <= stats::DataCreate);
+
+    std::string const namedatadestroy = std::string(PLUGIN_NAME) + ".DataDestroy";
+    stats::DataDestroy = TSStatCreate(namedatadestroy.c_str(), TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+
+    assert(0 <= stats::DataDestroy);
+
+    std::string const namereader = std::string(PLUGIN_NAME) + ".Reader";
+    stats::Reader = TSStatCreate(namereader.c_str(), TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+
+    assert(0 <= stats::Reader);
+
+    std::string const nameserver = std::string(PLUGIN_NAME) + ".Server";
+    stats::Server = TSStatCreate(nameserver.c_str(), TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+
+    assert(0 <= stats::Server);
+
+    std::string const nameclient = std::string(PLUGIN_NAME) + ".Client";
+    stats::Client = TSStatCreate(nameclient.c_str(), TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
+
+    assert(0 <= stats::Client);
+  }
+#endif // COLLECT_STATS
+
   return TS_SUCCESS;
 }
 

--- a/plugins/experimental/slice/slice.h
+++ b/plugins/experimental/slice/slice.h
@@ -52,3 +52,14 @@
 #define ERROR_LOG(fmt, ...)
 
 #endif
+
+#if defined(COLLECT_STATS)
+namespace stats
+{
+extern int DataCreate;
+extern int DataDestroy;
+extern int Reader;
+extern int Server;
+extern int Client;
+} // namespace stats
+#endif // COLLECT_STATS

--- a/plugins/experimental/slice/util.cc
+++ b/plugins/experimental/slice/util.cc
@@ -1,0 +1,134 @@
+/** @file
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "util.h"
+
+#include "Config.h"
+#include "Data.h"
+
+void
+shutdown(TSCont const contp, Data *const data)
+{
+  DEBUG_LOG("shutting down transaction");
+  TSContDataSet(contp, nullptr);
+  delete data;
+  TSContDestroy(contp);
+}
+
+void
+abort(TSCont const contp, Data *const data)
+{
+  DEBUG_LOG("aborting transaction");
+  TSContDataSet(contp, nullptr);
+  data->m_upstream.abort();
+  data->m_dnstream.abort();
+  delete data;
+  TSContDestroy(contp);
+}
+
+// create and issue a block request
+bool
+request_block(TSCont contp, Data *const data)
+{
+  // ensure no upstream connection
+  if (data->m_upstream.m_read.isOpen()) {
+    ERROR_LOG("Block request already in flight!");
+    return false;
+  }
+
+  if (Data::BlockState::Pending != data->m_blockstate) {
+    ERROR_LOG("request_block called with non Pending state!");
+    return false;
+  }
+
+  int64_t const blockbeg = (data->m_config->m_blockbytes * data->m_blocknum);
+  Range blockbe(blockbeg, blockbeg + data->m_config->m_blockbytes);
+
+  char rangestr[1024];
+  int rangelen      = sizeof(rangestr);
+  bool const rpstat = blockbe.toStringClosed(rangestr, &rangelen);
+  TSAssert(rpstat);
+
+  DEBUG_LOG("requestBlock: %s", rangestr);
+
+  // reuse the incoming client header, just change the range
+  HttpHeader header(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);
+
+  // add/set sub range key and add slicer tag
+  bool const rangestat = header.setKeyVal(TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE, rangestr, rangelen);
+
+  if (!rangestat) {
+    ERROR_LOG("Error trying to set range request header %s", rangestr);
+    return false;
+  }
+
+  // create virtual connection back into ATS
+  TSVConn const upvc = TSHttpConnectWithPluginId((sockaddr *)&data->m_client_ip, PLUGIN_NAME, 0);
+
+  int const hlen = TSHttpHdrLengthGet(header.m_buffer, header.m_lochdr);
+
+  // set up connection with the HttpConnect server
+  data->m_upstream.setupConnection(upvc);
+  data->m_upstream.setupVioWrite(contp, hlen);
+
+  // Send full request
+  TSHttpHdrPrint(header.m_buffer, header.m_lochdr, data->m_upstream.m_write.m_iobuf);
+  TSVIOReenable(data->m_upstream.m_write.m_vio);
+
+  /*
+          std::string const headerstr(header.toString());
+          DEBUG_LOG("Headers\n%s", headerstr.c_str());
+  */
+
+  // get ready for data back from the server
+  data->m_upstream.setupVioRead(contp, INT64_MAX);
+
+  // anticipate the next server response header
+  TSHttpParserClear(data->m_http_parser);
+  data->m_resp_hdrmgr.resetHeader();
+
+  data->m_blockexpected              = 0;
+  data->m_blockconsumed              = 0;
+  data->m_blockstate                 = Data::BlockState::Active;
+  data->m_server_block_header_parsed = false;
+
+  return true;
+}
+
+bool
+reader_avail_more_than(TSIOBufferReader const reader, int64_t bytes)
+{
+  TSIOBufferBlock block = TSIOBufferReaderStart(reader);
+
+  if (nullptr == block) {
+    return false;
+  }
+
+  while (nullptr != block) {
+    int64_t const blockbytes = TSIOBufferBlockReadAvail(block, reader);
+    if (bytes < blockbytes) {
+      return true;
+    } else {
+      bytes -= blockbytes;
+    }
+
+    block = TSIOBufferBlockNext(block);
+  }
+
+  return false;
+}

--- a/plugins/experimental/slice/util.h
+++ b/plugins/experimental/slice/util.h
@@ -18,20 +18,19 @@
 
 #pragma once
 
-#include "Data.h"
+#include "ts/ts.h"
+
+struct Data;
 
 /** Functions to deal with the connection to the client.
  * Body content transfers are handled by the client.
  * New block requests are also initiated by the client.
  */
 
-/* transfer bytes from the server to the client
- * Returns amount of bytes consumed from the reader (<= bytes written to client)
- */
-int64_t transfer_content_bytes(Data *const data); // , char const * const fstr);
+void shutdown(TSCont const contp, Data *const data);
 
-// transfer all bytes from the server (error condition)
-int64_t transfer_all_bytes(Data *const data);
+void abort(TSCont const contp, Data *const data);
 
-// Signal the input about write state
-void signal_input(TSVIO const input_vio, int64_t const consumed);
+bool request_block(TSCont contp, Data *const data);
+
+bool reader_avail_more_than(TSIOBufferReader const reader, int64_t bytes);


### PR DESCRIPTION
This cleans up the slice plugin making better use of the TSVION* functions for better control of the handlers.

This also adds optional internal throttling to limit false in memory cache hits.  Any number of contiguous slice blocks that are in memory cache (TCP_MEM_HIT) will be stacked up downstream of this plugin waiting for a client to download.  This often happens with video players (browser based, mplayer, etc) which at times may request multiple huge ranges and then dump the transactions after consuming very little data.