### PR TITLE
Copy the Client SNI Server Name out of the openssl SSL object.

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -31,6 +31,8 @@
  ****************************************************************************/
 #pragma once
 
+#include <memory>
+
 #include "tscore/ink_platform.h"
 #include "ts/apidefs.h"
 #include <string_view>
@@ -393,11 +395,16 @@ public:
   ink_hrtime sslHandshakeEndTime   = 0;
   ink_hrtime sslLastWriteTime      = 0;
   int64_t sslTotalBytesSent        = 0;
-  // The serverName is either a pointer to the name fetched from the
-  // SSL object or the empty string.  Therefore, we do not allocate
-  // extra memory for this value.  If plugins in the future can set the
-  // serverName value, this strategy will have to change.
-  const char *serverName = nullptr;
+
+  // The serverName is either a pointer to the (null-terminated) name fetched from the
+  // SSL object or the empty string.
+  const char *
+  get_server_name() const
+  {
+    return _serverName.get() ? _serverName.get() : "";
+  }
+
+  void set_server_name(std::string_view name);
 
   /// Set by asynchronous hooks to request a specific operation.
   SslVConnOp hookOpRequested = SSL_HOOK_OP_DEFAULT;
@@ -466,6 +473,8 @@ private:
   in_port_t tunnel_port       = 0;
   bool tunnel_decrypt         = false;
   X509_STORE_CTX *verify_cert = nullptr;
+
+  std::unique_ptr<char[]> _serverName;
 };
 
 typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -44,6 +44,7 @@
 
 #include <climits>
 #include <string>
+#include <cstring>
 
 using namespace std::literals;
 
@@ -889,6 +890,8 @@ SSLNetVConnection::do_io_close(int lerrno)
 void
 SSLNetVConnection::clear()
 {
+  _serverName.reset();
+
   if (ssl != nullptr) {
     SSL_free(ssl);
     ssl = nullptr;
@@ -1876,4 +1879,15 @@ SSLNetVConnection::protocol_contains(std::string_view prefix) const
     retval = super::protocol_contains(prefix);
   }
   return retval;
+}
+
+void
+SSLNetVConnection::set_server_name(std::string_view name)
+{
+  if (name.size()) {
+    char *n = new char[name.size() + 1];
+    std::memcpy(n, name.data(), name.size());
+    n[name.size()] = '\0';
+    _serverName.reset(n);
+  }
 }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -627,7 +627,7 @@ HttpSM::setup_blind_tunnel_port()
           t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
         }
       } else {
-        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->serverName, strlen(ssl_vc->serverName));
+        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->get_server_name(), strlen(ssl_vc->get_server_name()));
         t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
       }
     }
@@ -1439,7 +1439,7 @@ plugins required to work with sni_routing.
           t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
         }
       } else if (ssl_vc) {
-        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->serverName, strlen(ssl_vc->serverName));
+        t_state.hdr_info.client_request.url_get()->host_set(ssl_vc->get_server_name(), strlen(ssl_vc->get_server_name()));
         t_state.hdr_info.client_request.url_get()->port_set(t_state.state_machine->ua_txn->get_netvc()->get_local_port());
       }
     }


### PR DESCRIPTION
And ensure it is null-terminated.

This should go into 9.0.  The risk of putting it in is less than the risk of leaving it out.