### PR TITLE
Add some stats collections to cache_promote.

### DIFF
--- a/doc/admin-guide/plugins/cache_promote.en.rst
+++ b/doc/admin-guide/plugins/cache_promote.en.rst
@@ -49,6 +49,21 @@ If :option:`--policy` is set to ``lru`` the following options are also available
 
    The size (number of entries) of the LRU.
 
+.. option:: --stats-enable-with-id
+
+   Enables collecting statistics.  The option requires an argument, the
+   remap-identifier.  The remap-identifier is a string that is concatenated
+   to the stat name.  The following stats are collected.
+
+*  **plugin.cache_promote.${remap-identifier}.cache_hits** - Cache hit total, available for all policies.
+*  **plugin.cache_promote.${remap-identifier}.freelist_size** - Size of the freelist when using the LRU policy.
+*  **plugin.cache_promote.${remap-identifier}.lru_size** - Size of the LRU when using the LRU policy.
+*  **plugin.cache_promote.${remap-identifier}.lru_hit** - LRU hit count when using the LRU policy.
+*  **plugin.cache_promote.${remap-identifier}.lru_miss** - LRU miss count when using the LRU policy.
+*  **plugin.cache_promote.${remap-identifier}.lru_vacated** - count of LRU entries removed to make room for a new request.
+*  **plugin.cache_promote.${remap-identifier}.promoted** - count requests promoted, available in all policies.
+*  **plugin.cache_promote.${remap-identifier}.total_requests** - count of all requests.
+
 These two options combined with your usage patterns will control how likely a
 URL is to become promoted to enter the cache.
 


### PR DESCRIPTION
Adds optional stats collections to the cache_promote plugin.  The stats may be useful in tuning the plugin.

To enable the stats, use the --stats-enable-with-id=${remap-identifier}

For example with `--stats-enable-with-id=foo.com`

The following stats are collected for the remap entry using cache_promote:

`"plugin.cache_promote.foo.com.cache_hits": "335508",
"plugin.cache_promote.foo.com.freelist_size": "7",
"plugin.cache_promote.foo.com.lru_size": "1066128",
"plugin.cache_promote.foo.com.lru_hit": "1900723",
"plugin.cache_promote.foo.com.lru_miss": "3025836",
"plugin.cache_promote.foo.com.lru_vacated": "58985",
"plugin.cache_promote.foo.com.promoted": "1900723",
"plugin.cache_promote.foo.com.total_requests": "5262067",`

The documentation explains each of the stats.
