### PR TITLE
Add simple uri_signing autest and subsequent fixes

### DIFF
--- a/plugins/experimental/uri_signing/common.h
+++ b/plugins/experimental/uri_signing/common.h
@@ -33,7 +33,10 @@ void PrintToStdErr(const char *fmt, ...);
 #else
 
 #include "ts/ts.h"
-#define PluginDebug(...) TSDebug("uri_signing", PLUGIN_NAME " " __VA_ARGS__)
-#define PluginError(...) PluginDebug(__VA_ARGS__), TSError(PLUGIN_NAME " " __VA_ARGS__)
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#define PluginDebug(fmt, ...) TSDebug(PLUGIN_NAME, "[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__);
+#define PluginError(fmt, ...)      \
+  PluginDebug(fmt, ##__VA_ARGS__); \
+  TSError("[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__);
 
 #endif

--- a/plugins/experimental/uri_signing/config.c
+++ b/plugins/experimental/uri_signing/config.c
@@ -289,7 +289,6 @@ read_config(const char *path)
         PluginDebug("Found Id in the config: %s", cfg->id);
       }
     }
-    json_decref(id_json);
 
     json_t *strip_json = json_object_get(jwks, "strip_token");
     if (strip_json) {

--- a/plugins/experimental/uri_signing/parse.c
+++ b/plugins/experimental/uri_signing/parse.c
@@ -31,8 +31,8 @@ cjose_jws_t *
 get_jws_from_uri(const char *uri, size_t uri_ct, const char *paramName, char *strip_uri, size_t buff_ct, size_t *strip_ct)
 {
   /* Reserved characters as defined by the URI Generic Syntax RFC: https://tools.ietf.org/html/rfc3986#section-2.2 */
-  static const char *reserved_string  = ":/?#[]@!$&\'()*+,;=";
-  static const char *sub_delim_string = "!$&\'()*+,;=";
+  static char const *const reserved_string  = ":/?#[]@!$&\'()*+,;=";
+  static char const *const sub_delim_string = "!$&\'()*+,;=";
 
   /* If param name ends in reserved character this will be treated as the termination symbol when parsing for package. Default is
    * '='. */

--- a/plugins/experimental/uri_signing/parse.h
+++ b/plugins/experimental/uri_signing/parse.h
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 
 struct _cjose_jws_int;
+
+/* For now strip_ct returns size of string *including* the null terminator */
 struct _cjose_jws_int *get_jws_from_uri(const char *uri, size_t uri_ct, const char *paramName, char *strip_uri, size_t buff_ct,
                                         size_t *strip_ct);
 struct _cjose_jws_int *get_jws_from_cookie(const char **cookie, size_t *cookie_ct, const char *paramName);

--- a/plugins/experimental/uri_signing/python_signer/uri_signer.py
+++ b/plugins/experimental/uri_signing/python_signer/uri_signer.py
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,49 +26,107 @@ import os
 from jose import jwk, jwt
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config',
-                        help="Configuration File",
-                        required=True)
-    parser.add_argument('-u', '--uri',
-                        help="URI to sign",
-                        required=True)
-    args = parser.parse_args()
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-c', '--config',
+            help="Configuration File",
+            required=True)
+  parser.add_argument('-u', '--uri',
+            help="URI to sign",
+            required=True)
 
-    with open(args.config, 'r') as f:
-        config = json.load(f)
+  # helpers
+  parser.add_argument('--key_index', type=int, nargs=1)
+  parser.add_argument('--token_lifetime', type=int, nargs=1)
 
-    keys = config["keys"]
+  # override arguments -- claims
+  parser.add_argument('--aud', nargs=1)
+  parser.add_argument('--cdniets', type=int, nargs=1)
+  parser.add_argument('--cdnistd', type=int, nargs=1)
+  parser.add_argument('--cdnistt', type=int, nargs=1)
+  parser.add_argument('--exp', type=int, nargs=1)
+  parser.add_argument('--iss', nargs=1)
 
-    # Randomly select a key
+  # override arguments -- key
+  parser.add_argument('--alg', nargs=1)
+  parser.add_argument('--k', nargs=1)
+  parser.add_argument('--kid', nargs=1)
+  parser.add_argument('--kty', nargs=1)
+
+  args = parser.parse_args()
+
+  with open(args.config, 'r') as f:
+    config = json.load(f)
+
+  keys = config["keys"]
+
+  # Select a key, either explicitly or randomly
+  key_index = 0
+  if args.key_index:
+    key_index = args.key_index[0]
+    print("args key_index " + str(key_index))
+  else:
     key_index = random.randint(0,len(keys)-1)
-    print("Using Key: " + str(keys[key_index]["kid"]) + " to sign URI.")
-    key = keys[key_index]
+    print("randomizing key index")
 
-    # Build Out claimset
-    claimset = {}
-    if ("iss" in config.keys()):
-        claimset["iss"] = config["iss"]
+  print("Using key_index " + str(key_index))
 
-    if ("token_lifetime" in config.keys()):
-        claimset["exp"] = int(time.time()) + config["token_lifetime"]
-    else:
-        claimset["exp"] = int(time.time()) + 30
+  print("Using Key: " + str(keys[key_index]["kid"]) + " to sign URI.")
+  key = keys[key_index]
 
-    if("aud" in config.keys()):
-        claimset["aud"] = config["aud"]
+  # Build Out claimset
+  claimset = {}
+  if "iss" in config.keys():
+    claimset["iss"] = config["iss"]
 
-    if("cdnistt"  in config.keys()):
-        if config["cdnistt"]:
-            claimset["cdnistt"] = 1
-            if("cdniets" in config.keys()):
-                claimset["cdniets"] = config["cdniets"]
-            else:
-                claimset["cdniets"] = 30
+  if "token_lifetime" in config.keys():
+    claimset["exp"] = int(time.time()) + config["token_lifetime"]
+  else:
+    claimset["exp"] = int(time.time()) + 30
 
-    Token = jwt.encode(claimset,key,algorithm=key["alg"])
+  if "aud" in config.keys():
+    claimset["aud"] = config["aud"]
 
-    print("Signed URL: " + args.uri + "?urisigning=" + Token)
+  if "cdnistt" in config.keys():
+    if config["cdnistt"]:
+      claimset["cdnistt"] = 1
+      if "cdniets" in config.keys():
+        claimset["cdniets"] = config["cdniets"]
+      else:
+        claimset["cdniets"] = 30
+
+
+  # process override args - simple
+  if args.iss:
+    claimset["iss"] = args.iss[0]
+  if args.exp:
+    claimset["exp"] = args.exp[0]
+  if args.aud:
+    claimset["aud"] = args.aud[0]
+
+  # process override args - complex
+  if args.cdnistt:
+    claimset["cdnistt"] = args.cdnistt[0]
+
+  if "cdnistt" in config.keys():
+    if args.cdniets:
+      claimset["cdniets"] = arg.cdniets[0]
+
+  # specific key overrides
+  if args.alg:
+    key["alg"] = args.alg[0]
+  if args.kid:
+    key["kid"] = args.kid[0]
+  if args.kty:
+    key["kty"] = args.kty[0]
+  if args.k:
+    key["k"] = args.k[0]
+
+  print(claimset)
+  print(key)
+
+  Token = jwt.encode(claimset,key,algorithm=key["alg"])
+
+  print("Signed URL: " + args.uri + "?URISigningPackage=" + Token)
 
 if __name__ == "__main__":
-     main()
+   main()

--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -34,6 +34,7 @@ gunicorn = "*"
 httpbin = "*"
 microserver = ">=1.0.4"
 jsonschema = "*"
+python-jose = "*"
 
 [requires]
 python_version = "3"

--- a/tests/gold_tests/pluginTest/uri_signing/config.json
+++ b/tests/gold_tests/pluginTest/uri_signing/config.json
@@ -1,0 +1,27 @@
+{
+ "issuer": {
+  "id": "issuer",
+  "renewal_kid": "1",
+  "strip_token": true,
+  "auth_directives": [
+   {
+    "auth": "allow",
+    "uri": "regex:.*crossdomain.xml"
+   }
+  ],
+  "keys": [
+   {
+    "alg": "HS256",
+    "k": "SECRET00",
+    "kid": "0",
+    "kty": "oct"
+   },
+   {
+    "alg": "HS256",
+    "k": "SECRET01",
+    "kid": "1",
+    "kty": "oct"
+   }
+  ]
+ }
+}

--- a/tests/gold_tests/pluginTest/uri_signing/gold/200.gold
+++ b/tests/gold_tests/pluginTest/uri_signing/gold/200.gold
@@ -1,0 +1,13 @@
+``
+> GET `` HTTP/1.1
+> User-Agent: curl/``
+> Host: somehost``
+> Accept: */*
+> Proxy-Connection: ``
+``
+< HTTP/1.1 200 OK
+< Content-Length: ``
+< Date: ``
+< Proxy-Connection: ``
+< Server: ATS/``
+``

--- a/tests/gold_tests/pluginTest/uri_signing/gold/403.gold
+++ b/tests/gold_tests/pluginTest/uri_signing/gold/403.gold
@@ -1,0 +1,16 @@
+``
+> GET `` HTTP/1.1
+> User-Agent: curl/``
+> Host: somehost``
+> Accept: */*
+> Proxy-Connection: ``
+``
+< HTTP/1.1 403 Forbidden
+< Date: ``
+< Proxy-Connection: ``
+< Server: ATS/``
+< Cache-Control: no-store
+< Content-Type: text/html
+< Content-Language: en
+< Content-Length: ``
+``

--- a/tests/gold_tests/pluginTest/uri_signing/run_sign.sh
+++ b/tests/gold_tests/pluginTest/uri_signing/run_sign.sh
@@ -1,0 +1,104 @@
+# Script to run sign.pl script.  Single parameter is number 1 or greater selecting a set of script parameters.
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Preset arguments for generating tests
+#
+cmd_args ()
+{
+SELECT="$1"
+
+FUTURE="1923056084" #  Monday, December 9, 2030 14:14:44
+
+case "$SELECT" in
+0) # future signing
+  echo "-c signer.json"
+  echo "-u http://somehost/someasset.ts"
+	echo "--exp=${FUTURE}"
+	echo "--key_index=0"
+  ;;
+1) # expired signing (~1970)
+  echo "-c signer.json"
+  echo "-u http://somehost/someasset.ts"
+	echo "--key_index=0"
+	echo "--exp=1"
+  ;;
+2) # future, second key
+  echo "-c signer.json"
+  echo "-u http://somehost/someasset.ts"
+	echo "--exp=${FUTURE}"
+	echo "--key_index=1"
+  ;;
+3)
+  ;;
+*)
+  echo "run_sign.sh: bad parameter" 1>&2
+  exit 1
+  ;;
+esac
+}
+
+# Find the path to the sign.pl script in the url_sig (source) directory.
+#
+find_cmd ()
+{
+local D T='..'
+while [[ ! -d $T/.git ]]
+do
+  if [[ ! -d $T/.. ]] ; then
+    echo "Working directory not in a git repo" 1>&2
+    exit 1
+  fi
+  T="$T/.."
+done
+
+for D in $( find $T -name uri_signing -type d )
+do
+    if [[ -x $D/python_signer/uri_signer.py ]] ; then
+        echo "$D/python_signer/uri_signer.py"
+        return 0
+    fi
+done
+
+echo "cannot find uri_signer.py" 1>&2
+exit 1
+}
+
+# check for python-jose module
+pip list | grep python-jose > /dev/null
+status=$?
+if [[ "$status" != 0 ]] ; then
+    echo "cannot find python-jose" 1>&2
+    exit 1
+fi
+
+CMD=$( find_cmd )
+status=$?
+if [[ "$status" != 0 ]] ; then
+    exit 1
+fi
+
+
+ARGS=$( cmd_args "$1" )
+status=$?
+if [[ "$status" != 0 ]] ; then
+    exit 1
+fi
+
+echo $CMD $ARGS
+
+$CMD $ARGS | tr ' ' '\n' | tail -1

--- a/tests/gold_tests/pluginTest/uri_signing/signer.json
+++ b/tests/gold_tests/pluginTest/uri_signing/signer.json
@@ -1,0 +1,18 @@
+{
+ "iss": "issuer",
+ "token_lifetime": 90,
+ "keys": [
+  {
+   "alg": "HS256",
+   "k": "SECRET00",
+   "kid": "0",
+   "kty": "oct"
+  },
+  {
+   "alg": "HS256",
+   "k": "SECRET01",
+   "kid": "1",
+   "kty": "oct"
+  }
+ ]
+}

--- a/tests/gold_tests/pluginTest/uri_signing/uri_signing.test.py
+++ b/tests/gold_tests/pluginTest/uri_signing/uri_signing.test.py
@@ -1,0 +1,208 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import subprocess
+Test.Summary = '''
+Test uri_signing plugin
+'''
+
+Test.ContinueOnFail = False
+
+# Skip if plugins not present.
+Test.SkipUnless(Condition.PluginExists('uri_signing.so'))
+
+server = Test.MakeOriginServer("server")
+
+# Default origin test
+req_header = { "headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+	"timestamp": "1469733493.993",
+	"body": "",
+}
+res_header = { "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+	"timestamp": "1469733493.993",
+	"body": "",
+}
+server.addResponse("sessionfile.log", req_header, res_header)
+
+# Test case for normal
+req_header = { "headers":
+	"GET /someasset.ts HTTP/1.1\r\nHost: somehost\r\n\r\n",
+	"timestamp": "1469733493.993",
+	"body": "",
+}
+
+res_header = { "headers":
+	"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+	"timestamp": "1469733493.993",
+	"body": "somebody",
+}
+
+server.addResponse("sessionfile.log", req_header, res_header)
+
+# Test case for crossdomain
+req_header = { "headers":
+	"GET /crossdomain.xml HTTP/1.1\r\nHost: somehost\r\n\r\n",
+	"timestamp": "1469733493.993",
+	"body": "",
+}
+
+res_header = { "headers":
+	"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+	"timestamp": "1469733493.993",
+	"body": "<crossdomain></crossdomain>",
+}
+
+server.addResponse("sessionfile.log", req_header, res_header)
+
+# http://user:password@host:port/path;params?query#fragment
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts")
+#ts = Test.MakeATSProcess("ts", "traffic_server_valgrind.sh")
+
+ts.Disk.records_config.update({
+  'proxy.config.diags.debug.enabled': 1,
+  'proxy.config.diags.debug.tags': 'uri_signing|http',
+#  'proxy.config.diags.debug.tags': 'uri_signing',
+  'proxy.config.http.cache.http': 0,  # No cache
+})
+
+# Use unchanged incoming URL.
+ts.Disk.remap_config.AddLine(
+    'map http://somehost/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
+    ' @plugin=uri_signing.so @pparam={}/config.json'.format(Test.RunDirectory)
+)
+
+# Install configuration
+ts.Setup.CopyAs('config.json', Test.RunDirectory)
+ts.Setup.CopyAs('run_sign.sh', Test.RunDirectory)
+ts.Setup.CopyAs('signer.json', Test.RunDirectory)
+#ts.Setup.CopyAs('traffic_server_valgrind.sh', Test.RunDirectory)
+
+curl_and_args = 'curl -q -v -x localhost:{} '.format(ts.Variables.port)
+
+# 0 - reject unsigned request
+tr = Test.AddTestRun("unsigned request")
+ps = tr.Processes.Default
+ps.StartBefore(ts)
+ps.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+ps.Command = curl_and_args + 'http://somehost/someasset.ts'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/403.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 1 - accept a passthru request
+tr = Test.AddTestRun("passthru request")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + 'http://somehost/crossdomain.xml'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/200.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 2 - good token, signed "forever" (run_sign.sh 0)
+tr = Test.AddTestRun("good signed")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts?URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjE5MjMwNTYwODR9.zw_wFQ-wvrWmfPLGj3hAUWn-GOHkiJZi2but4KV0paY"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/200.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 3 - expired token (run_sign.sh 1)
+tr = Test.AddTestRun("expired signed")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts?URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjF9.GkdlOPHQc6BqS4Q6x79GeYuVFO2zuGbaPZZsJfD6ir8"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/403.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 4 - good token, different key (run_sign.sh 2)
+tr = Test.AddTestRun("good token, second key")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts?URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjE5MjMwNTYwODR9.ozH4sNwgcOlTZT0l4RQlVCH_osxz9yI1HCBesEv-jYg"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/200.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 5 - good token, inline
+tr = Test.AddTestRun("good signed")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjE5MjMwNTYwODR9.zw_wFQ-wvrWmfPLGj3hAUWn-GOHkiJZi2but4KV0paY/someasset.ts"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/200.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 6 - expired token, inline
+tr = Test.AddTestRun("expired signed")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjF9.GkdlOPHQc6BqS4Q6x79GeYuVFO2zuGbaPZZsJfD6ir8/someasset.ts"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/403.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 7 - good token, param
+tr = Test.AddTestRun("good signed, param")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts;URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjE5MjMwNTYwODR9.zw_wFQ-wvrWmfPLGj3hAUWn-GOHkiJZi2but4KV0paY"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/200.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 8 - expired token, param
+tr = Test.AddTestRun("expired signed, param")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts;URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjF9.GkdlOPHQc6BqS4Q6x79GeYuVFO2zuGbaPZZsJfD6ir8"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/403.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 9 - let's cookie this
+tr = Test.AddTestRun("good signed cookie")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts" -H "Cookie: URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjE5MjMwNTYwODR9.zw_wFQ-wvrWmfPLGj3hAUWn-GOHkiJZi2but4KV0paY"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/200.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 10 - expired cookie token
+tr = Test.AddTestRun("expired signed cooked")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts" -H "Cookie: URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjF9.GkdlOPHQc6BqS4Q6x79GeYuVFO2zuGbaPZZsJfD6ir8"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/403.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# 9 - multiple cookies
+tr = Test.AddTestRun("multiple cookies, expired then good")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + '"http://somehost/someasset.ts" -H "Cookie: URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjF9.GkdlOPHQc6BqS4Q6x79GeYuVFO2zuGbaPZZsJfD6ir8;URISigningPackage=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJleHAiOjE5MjMwNTYwODR9.zw_wFQ-wvrWmfPLGj3hAUWn-GOHkiJZi2but4KV0paY"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/200.gold"
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts


### PR DESCRIPTION
Add autest for uri_signing plugin.

Code mods/fixes:
- Add override options to sample python signer.

Plugin
- update config file loading (absolute or relative from TSConfigDir)
- crash fix from extraneous jwt cleanup call
- fix token stripping from uri