### PR TITLE
Fix TS_USE_DIAGS usage for --disable-diags option

### DIFF
--- a/include/tscore/Diags.h
+++ b/include/tscore/Diags.h
@@ -312,7 +312,7 @@ extern inkcoreapi Diags *diags;
 #define AlertV(fmt, ap) DiagsErrorV(DL_Alert, fmt, ap)
 #define EmergencyV(fmt, ap) DiagsErrorV(DL_Emergency, fmt, ap)
 
-#ifdef TS_USE_DIAGS
+#if TS_USE_DIAGS
 
 #define Diag(tag, ...)                                 \
   do {                                                 \


### PR DESCRIPTION
Another miss-usage of TS_USE_* macro. It's DEFINED regardless of `enable`/`disable` configure option.  