### PR TITLE
Change HTTP/2 error rate log to warning

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -402,9 +402,9 @@ Http2ClientSession::main_event_handler(int event, void *edata)
                Http2::stream_error_rate_threshold) { // For a case many stream errors happened
       ip_port_text_buffer ipb;
       const char *client_ip = ats_ip_ntop(get_client_addr(), ipb, sizeof(ipb));
-      Error("HTTP/2 session error client_ip=%s session_id=%" PRId64
-            " closing a connection, because its stream error rate (%f) exceeded the threshold (%f)",
-            client_ip, connection_id(), this->connection_state.get_stream_error_rate(), Http2::stream_error_rate_threshold);
+      Warning("HTTP/2 session error client_ip=%s session_id=%" PRId64
+              " closing a connection, because its stream error rate (%f) exceeded the threshold (%f)",
+              client_ip, connection_id(), this->connection_state.get_stream_error_rate(), Http2::stream_error_rate_threshold);
       Http2SsnDebug("Preparing for graceful shutdown because of a high stream error rate");
       cause_of_death = Http2SessionCod::HIGH_ERROR_RATE;
       this->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED, Http2ErrorCode::HTTP2_ERROR_ENHANCE_YOUR_CALM);
@@ -582,9 +582,9 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
     if (this->connection_state.get_stream_error_rate() > std::min(1.0, Http2::stream_error_rate_threshold * 2.0)) {
       ip_port_text_buffer ipb;
       const char *client_ip = ats_ip_ntop(get_client_addr(), ipb, sizeof(ipb));
-      Error("HTTP/2 session error client_ip=%s session_id=%" PRId64
-            " closing a connection, because its stream error rate (%f) is too high",
-            client_ip, connection_id(), this->connection_state.get_stream_error_rate());
+      Warning("HTTP/2 session error client_ip=%s session_id=%" PRId64
+              " closing a connection, because its stream error rate (%f) is too high",
+              client_ip, connection_id(), this->connection_state.get_stream_error_rate());
       err = Http2ErrorCode::HTTP2_ERROR_ENHANCE_YOUR_CALM;
     }
 


### PR DESCRIPTION
We're facing a bunch of this error log on production, but we have nothing to do on the ATS side.

/cc @sekimura