### PR TITLE
LGTM: Add header guards

### DIFF
--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <ts/ts.h>
 #include <netinet/in.h>
 #include <memory>

--- a/plugins/experimental/geoip_acl/acl.h
+++ b/plugins/experimental/geoip_acl/acl.h
@@ -15,6 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+
+#pragma once
+
 #include <cstdio>
 #include <cstring>
 #include <arpa/inet.h>

--- a/plugins/experimental/sslheaders/sslheaders.h
+++ b/plugins/experimental/sslheaders/sslheaders.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <ts/ts.h>
 #include <ts/remap.h>
 #include <cstring>

--- a/plugins/experimental/uri_signing/config.h
+++ b/plugins/experimental/uri_signing/config.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/plugins/experimental/uri_signing/cookie.h
+++ b/plugins/experimental/uri_signing/cookie.h
@@ -16,5 +16,7 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <stddef.h>
 const char *get_cookie_value(const char **cookie, size_t *cookie_ct, const char *key, size_t *ct);

--- a/plugins/experimental/uri_signing/jwt.h
+++ b/plugins/experimental/uri_signing/jwt.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <stdbool.h>
 #include <jansson.h>
 

--- a/plugins/experimental/uri_signing/normalize.h
+++ b/plugins/experimental/uri_signing/normalize.h
@@ -16,5 +16,7 @@
  * limitations under the License.
  */
 
+#pragma once
+
 int normalize_uri(const char *uri, int uri_ct, char *uri_normal, int buffer_size);
 int remove_dot_segments(const char *path, int path_ct, char *ret_buffer, int buff_ct);

--- a/plugins/experimental/uri_signing/parse.h
+++ b/plugins/experimental/uri_signing/parse.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <stdlib.h>
 
 struct _cjose_jws_int;

--- a/plugins/experimental/uri_signing/timing.h
+++ b/plugins/experimental/uri_signing/timing.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <stdint.h>
 #include <time.h>
 

--- a/src/traffic_layout/info.h
+++ b/src/traffic_layout/info.h
@@ -21,6 +21,8 @@
   limitations under the License.
  */
 
+#pragma once
+
 // the original traffic_layout
 
 void produce_features(bool json);


### PR DESCRIPTION
Fix "Missing header guard" on lgtm.
https://lgtm.com/projects/g/apache/trafficserver/alerts/?mode=tree&ruleFocus=2163210746