### PR TITLE
Remove -j from lgtm build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -29,4 +29,4 @@ extraction:
     configure:
       command: "./configure --enable-experimental-plugins"
     index:
-      build_command: "make -j"
+      build_command: "make"


### PR DESCRIPTION
The lgtm build seems to be hanging some times for an hour or two, which can then lead to the build timing out when it keeps going. Removing the -j option thinking this might be causing resource contention with the builds. Have done a successful test build using this config