### PR TITLE
Perf: replace dynamic_cast with static_cast in this_thread()

### DIFF
--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -177,7 +177,7 @@ EThread::schedule_spawn(Continuation *c, int ev, void *cookie)
 TS_INLINE EThread *
 this_ethread()
 {
-  return dynamic_cast<EThread *>(this_thread());
+  return static_cast<EThread *>(this_thread());
 }
 
 TS_INLINE EThread *


### PR DESCRIPTION
During the investigation of HTTP/2 performance regression, I realized that this `dynamic_cast` has a significant impact (~6%).
We never initialize `Thread` directly, so we don't need to use `dynamic_cast` here.
