### PR TITLE
Set wrap around after checking all the parents

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -108,7 +108,7 @@ ParentConsistentHash::getPathHash(HttpRequestData *hrdata, ATSHash64 *h)
 // Helper function to abstract calling ATSConsistentHash lookup_by_hashval() vs lookup().
 static pRecord *
 chash_lookup(ATSConsistentHash *fhash, uint64_t path_hash, ATSConsistentHashIter *chashIter, bool *wrap_around,
-             ATSHash64Sip24 *hash, bool *chash_init)
+             ATSHash64Sip24 *hash, bool *chash_init, bool *mapWrapped)
 {
   pRecord *prtmp;
 
@@ -118,6 +118,11 @@ chash_lookup(ATSConsistentHash *fhash, uint64_t path_hash, ATSConsistentHashIter
   } else {
     prtmp = (pRecord *)fhash->lookup(nullptr, chashIter, wrap_around, hash);
   }
+  // Do not set wrap_around to true until we try all the parents atleast once.
+  bool wrapped = *wrap_around;
+  *wrap_around = (*mapWrapped && *wrap_around) ? true : false;
+  if (!*mapWrapped && wrapped)
+    *mapWrapped = true;
   return prtmp;
 }
 
@@ -188,7 +193,7 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
   fhash     = chash[last_lookup];
   do { // search until we've selected a different parent if !firstCall
     prtmp = chash_lookup(fhash, path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash,
-                         &result->chash_init[last_lookup]);
+                         &result->chash_init[last_lookup], &result->mapWrapped[last_lookup]);
     lookups++;
     if (prtmp) {
       pRec = (parents[last_lookup] + prtmp->idx);
@@ -219,10 +224,6 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
     }
   }
   if (!pRec || (pRec && !pRec->available) || host_stat == HOST_STATUS_DOWN) {
-    if (firstCall) {
-      result->chash_init[PRIMARY]   = false;
-      result->chash_init[SECONDARY] = false;
-    }
     do {
       // check if the host is retryable.  It's retryable if the retry window has elapsed
       // and the global host status is HOST_STATUS_UP
@@ -276,7 +277,7 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
         }
         fhash = chash[last_lookup];
         prtmp = chash_lookup(fhash, path_hash, &result->chashIter[last_lookup], &wrap_around[last_lookup], &hash,
-                             &result->chash_init[last_lookup]);
+                             &result->chash_init[last_lookup], &result->mapWrapped[last_lookup]);
         lookups++;
         if (prtmp) {
           pRec = (parents[last_lookup] + prtmp->idx);

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -177,8 +177,10 @@ struct ParentResult {
   reset()
   {
     ink_zero(*this);
-    line_number = -1;
-    result      = PARENT_UNDEFINED;
+    line_number   = -1;
+    result        = PARENT_UNDEFINED;
+    mapWrapped[0] = false;
+    mapWrapped[1] = false;
   }
 
   bool
@@ -274,6 +276,7 @@ private:
   uint32_t start_parent;
   uint32_t last_group;
   bool wrap_around;
+  bool mapWrapped[2];
   // state for consistent hash.
   int last_lookup;
   ATSConsistentHashIter chashIter[MAX_GROUP_RINGS];


### PR DESCRIPTION
lookup/lookup_by_hashval sets wrap_around when it reaches the end of the map, but that doesn't indicate all the parents are checked for availability.