### PR TITLE
Introduce NetEvent to split UnixNetVConnection and NetHandler

### DIFF
--- a/iocore/net/NetEvent.h
+++ b/iocore/net/NetEvent.h
@@ -1,0 +1,92 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "I_EventSystem.h"
+
+class NetHandler;
+
+// this class is used to NetHandler to hide some detail of NetEvent.
+// To combine the `UDPConenction` and `NetEvent`. NetHandler should
+// callback to net_read_io or net_write_io when net event happen.
+class NetEvent
+{
+public:
+  NetEvent() = default;
+  virtual ~NetEvent() {}
+  virtual void net_read_io(NetHandler *nh, EThread *lthread)  = 0;
+  virtual void net_write_io(NetHandler *nh, EThread *lthread) = 0;
+  virtual void free(EThread *t)                               = 0;
+
+  // since we want this class to be independent from VConnection, Continutaion. There should be
+  // a pure virtual function which connect sub class and NetHandler.
+  virtual int callback(int event = CONTINUATION_EVENT_NONE, void *data = nullptr) = 0;
+
+  // Duplicate with `NetVConnection::set_inactivity_timeout`
+  // TODO: more abstraction.
+  virtual void set_inactivity_timeout(ink_hrtime timeout_in) = 0;
+
+  // get this vc's thread
+  virtual EThread *get_thread() = 0;
+
+  // Close when EventIO close;
+  virtual int close() = 0;
+
+  // get fd
+  virtual int get_fd()                   = 0;
+  virtual Ptr<ProxyMutex> &get_mutex()   = 0;
+  virtual ContFlags &get_control_flags() = 0;
+
+  EventIO ep{};
+  NetState read{};
+  NetState write{};
+
+  bool closed    = false;
+  NetHandler *nh = nullptr;
+
+  ink_hrtime inactivity_timeout_in      = 0;
+  ink_hrtime active_timeout_in          = 0;
+  ink_hrtime next_inactivity_timeout_at = 0;
+  ink_hrtime next_activity_timeout_at   = 0;
+  ink_hrtime submit_time                = 0;
+
+  LINK(NetEvent, open_link);
+  LINK(NetEvent, cop_link);
+  LINKM(NetEvent, read, ready_link)
+  SLINKM(NetEvent, read, enable_link)
+  LINKM(NetEvent, write, ready_link)
+  SLINKM(NetEvent, write, enable_link)
+  LINK(NetEvent, keep_alive_queue_link);
+  LINK(NetEvent, active_queue_link);
+
+  union {
+    unsigned int flags = 0;
+#define NET_VC_SHUTDOWN_READ 1
+#define NET_VC_SHUTDOWN_WRITE 2
+    struct {
+      unsigned int got_local_addr : 1;
+      unsigned int shutdown : 2;
+    } f;
+  };
+};

--- a/iocore/net/P_UnixNetState.h
+++ b/iocore/net/P_UnixNetState.h
@@ -40,13 +40,13 @@
 #include "I_VIO.h"
 
 class Event;
-class UnixNetVConnection;
+class NetEvent;
 
 struct NetState {
   int enabled = 0;
   VIO vio;
-  Link<UnixNetVConnection> ready_link;
-  SLink<UnixNetVConnection> enable_link;
+  Link<NetEvent> ready_link;
+  SLink<NetEvent> enable_link;
   int in_enabled_list = 0;
   int triggered       = 0;
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -905,7 +905,7 @@ QUICNetVConnection::state_connection_closed(int event, Event *data)
     // FIXME I'm not sure whether we can block here, but it's needed to not crash.
     SCOPED_MUTEX_LOCK(lock, this->nh->mutex, this_ethread());
     if (this->nh) {
-      this->nh->free_netvc(this);
+      this->nh->free_netevent(this);
     } else {
       this->free(this->mutex->thread_holding);
     }

--- a/iocore/net/UnixNetPages.cc
+++ b/iocore/net/UnixNetPages.cc
@@ -61,10 +61,11 @@ struct ShowNet : public ShowCont {
     }
 
     ink_hrtime now = Thread::get_hrtime();
-    forl_LL(UnixNetVConnection, vc, nh->open_list)
+    forl_LL(NetEvent, ne, nh->open_list)
     {
+      auto vc = dynamic_cast<UnixNetVConnection *>(ne);
       //      uint16_t port = ats_ip_port_host_order(&addr.sa);
-      if (ats_is_ip(&addr) && !ats_ip_addr_port_eq(&addr.sa, vc->get_remote_addr())) {
+      if (vc == nullptr || (ats_is_ip(&addr) && !ats_ip_addr_port_eq(&addr.sa, vc->get_remote_addr()))) {
         continue;
       }
       //      if (port && port != ats_ip_port_host_order(&vc->server_addr.sa) && port != vc->accept_port)
@@ -158,7 +159,12 @@ struct ShowNet : public ShowCont {
     CHECK_SHOW(show("<H3>Thread: %d</H3>\n", ithread));
     CHECK_SHOW(show("<table border=1>\n"));
     int connections = 0;
-    forl_LL(UnixNetVConnection, vc, nh->open_list) connections++;
+    forl_LL(NetEvent, ne, nh->open_list)
+    {
+      if (dynamic_cast<UnixNetVConnection *>(ne) != nullptr) {
+        ++connections;
+      }
+    }
     CHECK_SHOW(show("<tr><td>%s</td><td>%d</td></tr>\n", "Connections", connections));
     // CHECK_SHOW(show("<tr><td>%s</td><td>%d</td></tr>\n", "Last Poll Size", pollDescriptor->nfds));
     CHECK_SHOW(show("<tr><td>%s</td><td>%d</td></tr>\n", "Last Poll Ready", pollDescriptor->result));


### PR DESCRIPTION
One of #6229 , Split UnixNetVConnection and NetHandler

Introduce new class NetEvent to Split NetHandler and UnixNetVConnection.

In current implementation. The NetHandler is bond to UnixNetVConnection. So if someone wants to use NetHandler to implement their own nets events handler (like udp), it should create a class which is derived from UnixNetVConnection and it will make the object too large.

So abstract necessary api to hide more detail of implementation.

PS: This PR try to combine UDPConnection and UnixNetVConnection and other XXXXConnection as one and these connections are manage by NetHandler through NetEvent apis. 

Currently UDP implementation is consist of pacing, timer, packets cancelling. And most of these features are not used in QUIC. To support #5352 The UDP implementation might  have to  be managed by NetHandler. That is the reason why we re-implement it.