### PR TITLE
Follow the comments in I_Thread.h, add an independent ink_thread_key for EThread

### DIFF
--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -282,6 +282,8 @@ public:
   // Set the tail handler.
   void set_tail_handler(LoopTailHandler *handler);
 
+  void set_specific() override;
+
   /* private */
 
   Event *schedule_local(Event *e);

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -110,7 +110,7 @@ public:
   */
   Ptr<ProxyMutex> mutex;
 
-  void set_specific();
+  virtual void set_specific();
 
   inkcoreapi static ink_thread_key thread_data_key;
 

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -34,6 +34,7 @@
 #include "I_EventProcessor.h"
 
 const ink_hrtime DELAY_FOR_RETRY = HRTIME_MSECONDS(10);
+extern ink_thread_key ethread_key;
 
 TS_INLINE Event *
 EThread::schedule_imm(Continuation *cont, int callback_event, void *cookie)
@@ -186,7 +187,9 @@ EThread::schedule_spawn(Continuation *c, int ev, void *cookie)
 TS_INLINE EThread *
 this_ethread()
 {
-  return static_cast<EThread *>(this_thread());
+  // The `dynamic_cast` has a significant performace impact (~6%).
+  // Reported by masaori and create PR #6281 to fix it.
+  return static_cast<EThread *>(ink_thread_getspecific(ethread_key));
 }
 
 TS_INLINE EThread *

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -66,10 +66,10 @@ TESTS = $(check_PROGRAMS)
 # Be careful if you change the order. Details in GitHub #6666
 test_libhttp2_LDADD = \
 	libhttp2.a \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a \
-	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/proxy/hdrs/libhdrs.a \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/lib/records/librecords_p.a \
 	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \


### PR DESCRIPTION
By discussing in slack with @maskit  and @masaori335 ,

The below comments in I_Thread:
https://github.com/apache/trafficserver/blob/25806af21159f7996835d8ce2bf47b449d77c5b4/iocore/eventsystem/I_Thread.h#L43-L47

1. The `Thread` class maintains a thread_key[1].
2. The threads registered by the thread_key[1].
3. We can obtain the `Thread` object by the thread_key[1].

The below comments in I_Thread:
https://github.com/apache/trafficserver/blob/25806af21159f7996835d8ce2bf47b449d77c5b4/iocore/eventsystem/I_Thread.h#L47-L50

4. The `EThread` class maintains a different thread_key[2] than the `Thread`.
5. These `EThread`s registered by the thread_key[2].
6. We can obtain the `EThread` object by the thread_key[2].

In my understand, the item 1 to 3 also applied to `EThread` because the `EThread` is derived class of `Thread`.

According to the code, this part of the logic is simplified and only one thread_key is maintained.
This is not a problem until a new Thread derived class is introduced. But the simplified logic makes us confused about the original design. This PR is try to meet the design which described in I_Thread.h.

@maskit has a different understanding of the comments and thinks there should be some checks in `this_ethread()`. My suggestion is "do as little as possible in `this_ethread ()`" because,
- The `this_ethread ()` is called frequently.
- And @masaori335 found a performance issue with `dynamic_cast` in `this_ethread()` (PR #6281).

