### PR TITLE
Fix rst errors for collapsed forwarding plugin

### DIFF
--- a/doc/admin-guide/plugins/collapsed_forwarding.en.rst
+++ b/doc/admin-guide/plugins/collapsed_forwarding.en.rst
@@ -79,14 +79,14 @@ on the error by using an internal redirect follow back to itself, essentially
 blocking the request until a response arrives, at which point, relies on
 read-while-writer feature to start downloading the object to all waiting
 clients. The following config parameters are assumed to be set for this
-plugin to work::
+plugin to work:
 
-:ts:cv:`proxy.config.http.cache.open_write_fail_action`        1
-:ts:cv:`proxy.config.cache.enable_read_while_writer`           1
-:ts:cv:`proxy.config.http.number_of_redirections`             10
-:ts:cv:`proxy.config.http.redirect_use_orig_cache_key`         1
-:ts:cv:`proxy.config.http.background_fill_active_timeout`      0
-:ts:cv:`proxy.config.http.background_fill_completed_threshold` 0
+- :ts:cv:`proxy.config.http.cache.open_write_fail_action`        ``1``
+- :ts:cv:`proxy.config.cache.enable_read_while_writer`           ``1``
+- :ts:cv:`proxy.config.http.number_of_redirections`             ``10``
+- :ts:cv:`proxy.config.http.redirect_use_orig_cache_key`         ``1``
+- :ts:cv:`proxy.config.http.background_fill_active_timeout`      ``0``
+- :ts:cv:`proxy.config.http.background_fill_completed_threshold` ``0``
 
 Additionally, given that collapsed forwarding works based on cache write
 lock failure detection, the plugin requires cache to be enabled and ready.
@@ -119,7 +119,7 @@ For a large scale Video Streaming scenario, there’s a combination of a
 large number of revalidations (e.g. media playlists) and cache misses
 (e.g. media segments) that occur for the same file. Traffic Server’s
 RWW works great in collapsing the concurrent requests in such a scenario,
-however, as described in ``_admin-configuration-reducing-origin-requests``,
+however, as described in :ref:`admin-configuration-reducing-origin-requests`,
 Traffic Server’s implementation of RWW has a significant limitation, which
 restricts its ability to invoke RWW only when the response headers are
 already received. This means that any number of concurrent requests for
@@ -185,6 +185,4 @@ retries, allowing to be able to initiate RWW, whenever the response headers
 are received for the request that was allowed to go to the Origin.
 
 
-More details are available at
-
-https://docs.trafficserver.apache.org/en/6.0.x/admin/http-proxy-caching.en.html#reducing-origin-server-requests-avoiding-the-thundering-herd
+More details are available at :ref:`admin-configuration-reducing-origin-requests`


### PR DESCRIPTION
- The table of configs was printing the  rst reference tags
- the link to the thundering herd section wasn't a link
- the hard coded anchor link is better as a reference that stays with
the docs.