### PR TITLE
Assure no SM survives plugin factory deactivation (9.0.x)

### DIFF
--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -141,7 +141,7 @@ reloadUrlRewrite()
   Debug("url_rewrite", "%s updated, reloading...", ts::filename::REMAP);
   newTable = new UrlRewrite();
   if (newTable->load()) {
-    static const char *msg = "%s finished loading";
+    static const char *msg_format = "%s finished loading";
 
     // Hold at least one lease, until we reload the configuration
     newTable->acquire();
@@ -152,18 +152,17 @@ reloadUrlRewrite()
     ink_assert(oldTable != nullptr);
 
     // Release the old one
-    oldTable->pluginFactory.deactivate();
     oldTable->release();
 
-    Debug("url_rewrite", msg, ts::filename::REMAP);
-    Note("%s", msg);
+    Debug("url_rewrite", msg_format, ts::filename::REMAP);
+    Note(msg_format, ts::filename::REMAP);
     return true;
   } else {
-    static const char *msg = "%s failed to load";
+    static const char *msg_format = "%s failed to load";
 
     delete newTable;
-    Debug("url_rewrite", msg, ts::filename::REMAP);
-    Error(msg, ts::filename::REMAP);
+    Debug("url_rewrite", msg_format, ts::filename::REMAP);
+    Error(msg_format, ts::filename::REMAP);
     return false;
   }
 }

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -106,6 +106,9 @@ UrlRewrite::~UrlRewrite()
   DestroyStore(temporary_redirects);
   DestroyStore(forward_mappings_with_recv_port);
   _valid = false;
+
+  /* Deactivate the factory when all SM are gone for sure. */
+  pluginFactory.deactivate();
 }
 
 /** Sets the reverse proxy flag. */


### PR DESCRIPTION
Currently plugins sometimes destroy continuations used for hooks
in `TSRemapDeleteInstance`. To make sure no SM is still alive when
TSRemapDeleteInstance is called "deactivating" the remap plugin
factory as late as possible right before its destruction.

Fixed minor memory leak when a corrupted DSO file loading is
attempted during config reload, added few extra debug messages.

(9.0.x specific PR, cherry-pick of commit e6cf1bf / PR #6280)