### PR TITLE
Reduce process duration of test_Http2FrequencyCounter

### DIFF
--- a/proxy/http2/Http2FrequencyCounter.cc
+++ b/proxy/http2/Http2FrequencyCounter.cc
@@ -26,7 +26,7 @@
 void
 Http2FrequencyCounter::increment(uint16_t amount)
 {
-  ink_hrtime hrtime_sec = ink_hrtime_to_sec(Thread::get_hrtime());
+  ink_hrtime hrtime_sec = this->_get_hrtime();
   uint8_t counter_index = ((hrtime_sec % 60) >= 30);
   uint8_t last_index    = ((this->_last_update % 60) >= 30);
 
@@ -52,4 +52,10 @@ uint32_t
 Http2FrequencyCounter::get_count()
 {
   return this->_count[0] + this->_count[1];
+}
+
+ink_hrtime
+Http2FrequencyCounter::_get_hrtime()
+{
+  return ink_hrtime_to_sec(Thread::get_hrtime());
 }

--- a/proxy/http2/Http2FrequencyCounter.h
+++ b/proxy/http2/Http2FrequencyCounter.h
@@ -35,4 +35,7 @@ public:
 protected:
   uint16_t _count[2]      = {0};
   ink_hrtime _last_update = 0;
+
+private:
+  virtual ink_hrtime _get_hrtime();
 };

--- a/proxy/http2/unit_tests/test_Http2FrequencyCounter.cc
+++ b/proxy/http2/unit_tests/test_Http2FrequencyCounter.cc
@@ -29,12 +29,22 @@ class TestHttp2FrequencyCounter : public Http2FrequencyCounter
 {
 public:
   void
-  set_internal_state(ink_hrtime last_update_sec, uint16_t count_0, uint16_t count_1)
+  set_internal_state(ink_hrtime now, ink_hrtime last_update_sec, uint16_t count_0, uint16_t count_1)
   {
+    this->_now         = now;
     this->_last_update = last_update_sec;
     this->_count[0]    = count_0;
     this->_count[1]    = count_1;
   }
+
+private:
+  ink_hrtime
+  _get_hrtime() override
+  {
+    return this->_now;
+  }
+
+  ink_hrtime _now = 0;
 };
 
 TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
@@ -49,47 +59,45 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
     counter.increment(2);
     REQUIRE(counter.get_count() == 3);
 
-    counter.set_internal_state(ink_hrtime_to_sec(Thread::get_hrtime()) - 10, 1, 2);
+    ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
+    counter.set_internal_state(now, now - 10, 1, 2);
     REQUIRE(counter.get_count() == 3);
   }
 
   SECTION("Update at 0")
   {
     ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    while (now % 60 != 0) {
-      sleep(1);
-      now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    }
+    now -= now % 60;
 
-    counter.set_internal_state(now - 5, 1, 2);
+    counter.set_internal_state(now, now - 5, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 3);
 
-    counter.set_internal_state(now - 10, 1, 2);
+    counter.set_internal_state(now, now - 10, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 3);
 
-    counter.set_internal_state(now - 20, 1, 2);
+    counter.set_internal_state(now, now - 20, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 3);
 
-    counter.set_internal_state(now - 30, 1, 2);
+    counter.set_internal_state(now, now - 30, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 3);
 
-    counter.set_internal_state(now - 40, 1, 2);
+    counter.set_internal_state(now, now - 40, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 50, 1, 2);
+    counter.set_internal_state(now, now - 50, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 60, 1, 2);
+    counter.set_internal_state(now, now - 60, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 70, 1, 2);
+    counter.set_internal_state(now, now - 70, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
   }
@@ -97,40 +105,38 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
   SECTION("Update at 10")
   {
     ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    while (now % 60 != 10) {
-      sleep(1);
-      now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    }
+    now -= now % 60;
+    now += 10;
 
-    counter.set_internal_state(now - 5, 1, 2);
+    counter.set_internal_state(now, now - 5, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 4);
 
-    counter.set_internal_state(now - 10, 1, 2);
+    counter.set_internal_state(now, now - 10, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 4);
 
-    counter.set_internal_state(now - 20, 1, 2);
+    counter.set_internal_state(now, now - 20, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 3);
 
-    counter.set_internal_state(now - 30, 1, 2);
+    counter.set_internal_state(now, now - 30, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 3);
 
-    counter.set_internal_state(now - 40, 1, 2);
+    counter.set_internal_state(now, now - 40, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 3);
 
-    counter.set_internal_state(now - 50, 1, 2);
+    counter.set_internal_state(now, now - 50, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 60, 1, 2);
+    counter.set_internal_state(now, now - 60, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 70, 1, 2);
+    counter.set_internal_state(now, now - 70, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
   }
@@ -138,40 +144,38 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
   SECTION("Update at 30")
   {
     ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    while (now % 60 != 30) {
-      sleep(1);
-      now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    }
+    now -= now % 60;
+    now += 30;
 
-    counter.set_internal_state(now - 5, 1, 2);
+    counter.set_internal_state(now, now - 5, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 2);
 
-    counter.set_internal_state(now - 10, 1, 2);
+    counter.set_internal_state(now, now - 10, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 2);
 
-    counter.set_internal_state(now - 20, 1, 2);
+    counter.set_internal_state(now, now - 20, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 2);
 
-    counter.set_internal_state(now - 30, 1, 2);
+    counter.set_internal_state(now, now - 30, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 2);
 
-    counter.set_internal_state(now - 40, 1, 2);
+    counter.set_internal_state(now, now - 40, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 50, 1, 2);
+    counter.set_internal_state(now, now - 50, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 60, 1, 2);
+    counter.set_internal_state(now, now - 60, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 70, 1, 2);
+    counter.set_internal_state(now, now - 70, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
   }
@@ -179,40 +183,38 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
   SECTION("Update at 40")
   {
     ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    while (now % 60 != 40) {
-      sleep(1);
-      now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
-    }
+    now -= now % 60;
+    now += 40;
 
-    counter.set_internal_state(now - 5, 1, 2);
+    counter.set_internal_state(now, now - 5, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 4);
 
-    counter.set_internal_state(now - 10, 1, 2);
+    counter.set_internal_state(now, now - 10, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 4);
 
-    counter.set_internal_state(now - 20, 1, 2);
+    counter.set_internal_state(now, now - 20, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 2);
 
-    counter.set_internal_state(now - 30, 1, 2);
+    counter.set_internal_state(now, now - 30, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 2);
 
-    counter.set_internal_state(now - 40, 1, 2);
+    counter.set_internal_state(now, now - 40, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 2);
 
-    counter.set_internal_state(now - 50, 1, 2);
+    counter.set_internal_state(now, now - 50, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 60, 1, 2);
+    counter.set_internal_state(now, now - 60, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
 
-    counter.set_internal_state(now - 70, 1, 2);
+    counter.set_internal_state(now, now - 70, 1, 2);
     counter.increment();
     CHECK(counter.get_count() == 1);
   }


### PR DESCRIPTION
Prior to this change, `test_Http2FrequencyCounter` took almost 2 mins to run. Because there were 4 loops like below. ( the expected value of each loop is 29.5 sec ).
```
 while (now % 60 != 0) {
	 sleep(1);		
	 now = ink_hrtime_to_sec(Thread::get_hrtime_updated());		
}
```