### PR TITLE
Fix closed flag from #6287

### DIFF
--- a/iocore/net/NetEvent.h
+++ b/iocore/net/NetEvent.h
@@ -62,7 +62,7 @@ public:
   NetState read{};
   NetState write{};
 
-  bool closed    = false;
+  int closed     = 0;
   NetHandler *nh = nullptr;
 
   ink_hrtime inactivity_timeout_in      = 0;


### PR DESCRIPTION
`closed` flag should be int since `do_io_close(-1)` is valid.

introduce in #6287