### PR TITLE
Make the number of default lua states configurable via records.config

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3970,6 +3970,12 @@ Plug-in Configuration
 
    Specifies the location of |TS| plugins.
 
+.. ts:cv:: CONFIG proxy.config.plugin.lua.max_states INT 256
+
+   Maximum number of lua states at startup.  Applies to both remap and global plugins (each type is allocated this number of states).  The lua plugin --states overrides this but MUST be less than or equal to this value.
+
+	 This setting is not reloadable since it is must be applied when all the lua states are first initialized.
+
 SOCKS Processor
 ===============
 

--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -128,6 +128,17 @@ If it is used as remap plugin, we can write the following in remap.config to def
 
     map http://a.tbcdn.cn/ http://inner.tbcdn.cn/ @plugin=/XXX/tslua.so @pparam=--states=64 @pparam=/XXX/test_hdr.lua
 
+The maximum number of allowed states is set to 256 which is also the
+default states value.  The default value can be globally changed by
+adding a configuration option to records.config.
+
+::
+
+    CONFIG proxy.config.plugin.lua.max_states INT 64
+
+Any per plugin --states value overrides this default value but must be less than or equal to this value.  This setting is not reloadable since it is must be applied when all the lua states are first initialized.
+
+
 TS API for Lua
 ==============
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1201,6 +1201,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.plugin.load_elevated", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
   ,
+  {RECT_CONFIG, "proxy.config.plugin.lua.max_states", RECD_INT, "256", RECU_RESTART_TS, RR_NULL, RECC_INT, "^[1-9][0-9]*$", RECA_READ_ONLY}
+	,
 
   // Interim configuration setting for obeying keepalive requests on internal
   // (PluginVC) sessions. See TS-4960 and friends.


### PR DESCRIPTION
In order to limit the number of LUA VM states (set to 256 at compile time) every single remap rule must specify --states=<somevalue>.  This new records.config option

```
CONFIG proxy.config.plugin.lua.max_states INT 64
```

can be used to globally set this value to something lower than the default 256.  This sets the number of VM slots when the first lua plugin loads.
The --states=<value> option for the tslua.so plugin will still be used to override this value but must be lte to this value.