### PR TITLE
Fix strict round robin cur_index increment

### DIFF
--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -99,8 +99,8 @@ ParentRoundRobin::selectParent(bool first_call, ParentResult *result, RequestDat
         }
         break;
       case P_STRICT_ROUND_ROBIN:
-        cur_index = ink_atomic_increment(reinterpret_cast<int32_t *>(&result->rec->rr_next), 1);
-        cur_index = result->start_parent = cur_index % num_parents;
+        cur_index = result->start_parent =
+          ink_atomic_increment(reinterpret_cast<uint32_t *>(&result->rec->rr_next), 1) % num_parents;
         break;
       case P_NO_ROUND_ROBIN:
         cur_index = result->start_parent = 0;


### PR DESCRIPTION
rr_next was wrongly casted as an int32_t instead of as an uint32_t. As shown on #6321, on long-lived ATS instances the value of rr_next would be interpreted as a negative value, it would be incremented till the value reaches 0, hence all the traffic hits the first parent