### PR TITLE
Perf: Optimize sending HTTP/2 frame

### DIFF
--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -244,24 +244,6 @@ http2_write_frame_header(const Http2FrameHeader &hdr, IOVec iov)
 }
 
 bool
-http2_write_data(const uint8_t *src, size_t length, const IOVec &iov)
-{
-  byte_pointer ptr(iov.iov_base);
-  write_and_advance(ptr, src, length);
-
-  return true;
-}
-
-bool
-http2_write_headers(const uint8_t *src, size_t length, const IOVec &iov)
-{
-  byte_pointer ptr(iov.iov_base);
-  write_and_advance(ptr, src, length);
-
-  return true;
-}
-
-bool
 http2_write_rst_stream(uint32_t error_code, IOVec iov)
 {
   byte_pointer ptr(iov.iov_base);

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -33,6 +33,9 @@ class HTTPHdr;
 
 typedef unsigned Http2StreamId;
 
+constexpr Http2StreamId HTTP2_CONNECTION_CONTROL_STRTEAM = 0;
+constexpr uint8_t HTTP2_FRAME_NO_FLAG                    = 0;
+
 // [RFC 7540] 6.9.2. Initial Flow Control Window Size
 // the flow control window can be come negative so we need to track it with a signed type.
 typedef int32_t Http2WindowSize;
@@ -319,10 +322,6 @@ http2_is_server_streamid(Http2StreamId streamid)
 bool http2_parse_frame_header(IOVec, Http2FrameHeader &);
 
 bool http2_write_frame_header(const Http2FrameHeader &, IOVec);
-
-bool http2_write_data(const uint8_t *, size_t, const IOVec &);
-
-bool http2_write_headers(const uint8_t *, size_t, const IOVec &);
 
 bool http2_write_rst_stream(uint32_t, IOVec);
 

--- a/proxy/http2/Http2Frame.cc
+++ b/proxy/http2/Http2Frame.cc
@@ -1,0 +1,253 @@
+/** @file
+
+  Http2Frame
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "Http2Frame.h"
+
+//
+// Http2Frame
+//
+IOBufferReader *
+Http2Frame::reader() const
+{
+  return this->_ioreader;
+}
+
+const Http2FrameHeader &
+Http2Frame::header() const
+{
+  return this->_hdr;
+}
+
+bool
+Http2Frame::is_from_early_data() const
+{
+  return this->_from_early_data;
+}
+
+//
+// DATA Frame
+//
+int64_t
+Http2DataFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  if (this->_reader && this->_payload_len > 0) {
+    int64_t written = 0;
+    // Fill current IOBufferBlock as much as possible to reduce SSL_write() calls
+    while (written < this->_payload_len) {
+      int64_t read_len = std::min(this->_payload_len - written, this->_reader->block_read_avail());
+      written += iobuffer->write(this->_reader->start(), read_len);
+      this->_reader->consume(read_len);
+    }
+    len += written;
+  }
+
+  return len;
+}
+
+//
+// HEADERS Frame
+//
+int64_t
+Http2HeadersFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Validation
+  if (this->_hdr_block_len > Http2::max_frame_size) {
+    return -1;
+  }
+
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  if (this->_hdr_block && this->_hdr_block_len > 0) {
+    len += iobuffer->write(this->_hdr_block, this->_hdr_block_len);
+  }
+
+  return len;
+}
+
+//
+// PRIORITY Frame
+//
+int64_t
+Http2PriorityFrame::write_to(MIOBuffer *iobuffer) const
+{
+  ink_abort("not supported yet");
+
+  return 0;
+}
+
+//
+// RST_STREM Frame
+//
+int64_t
+Http2RstStreamFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  uint8_t payload[HTTP2_RST_STREAM_LEN];
+  http2_write_rst_stream(this->_error_code, make_iovec(payload));
+  len += iobuffer->write(payload, sizeof(payload));
+
+  return len;
+}
+
+//
+// SETTINGS Frame
+//
+int64_t
+Http2SettingsFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  for (uint32_t i = 0; i < this->_psize; ++i) {
+    Http2SettingsParameter *p = this->_params + i;
+
+    uint8_t p_buf[HTTP2_SETTINGS_PARAMETER_LEN];
+    http2_write_settings(*p, make_iovec(p_buf));
+    len += iobuffer->write(p_buf, sizeof(p_buf));
+  }
+
+  return len;
+}
+
+//
+// PUSH_PROMISE Frame
+//
+int64_t
+Http2PushPromiseFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Validation
+  if (this->_hdr_block_len > Http2::max_frame_size) {
+    return -1;
+  }
+
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  uint8_t p_buf[HTTP2_MAX_FRAME_SIZE];
+  http2_write_push_promise(this->_params, this->_hdr_block, this->_hdr_block_len, make_iovec(p_buf));
+  len += iobuffer->write(p_buf, sizeof(Http2StreamId) + this->_hdr_block_len);
+
+  return len;
+}
+
+//
+// PING Frame
+//
+int64_t
+Http2PingFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  uint8_t payload[HTTP2_PING_LEN] = {0};
+  http2_write_ping(this->_opaque_data, make_iovec(payload));
+  len += iobuffer->write(payload, sizeof(payload));
+
+  return len;
+}
+
+//
+// GOAWAY Frame
+//
+int64_t
+Http2GoawayFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  uint8_t payload[HTTP2_GOAWAY_LEN];
+  http2_write_goaway(this->_params, make_iovec(payload));
+  len += iobuffer->write(payload, sizeof(payload));
+
+  return len;
+}
+
+//
+// WINDOW_UPDATE Frame
+//
+int64_t
+Http2WindowUpdateFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  uint8_t payload[HTTP2_WINDOW_UPDATE_LEN];
+  http2_write_window_update(this->_window, make_iovec(payload));
+  len += iobuffer->write(payload, sizeof(payload));
+
+  return len;
+}
+
+//
+// CONTINUATION Frame
+//
+int64_t
+Http2ContinuationFrame::write_to(MIOBuffer *iobuffer) const
+{
+  // Validation
+  if (this->_hdr_block_len > Http2::max_frame_size) {
+    return -1;
+  }
+
+  // Write frame header
+  uint8_t buf[HTTP2_FRAME_HEADER_LEN];
+  http2_write_frame_header(this->_hdr, make_iovec(buf));
+  int64_t len = iobuffer->write(buf, sizeof(buf));
+
+  // Write frame payload
+  if (this->_hdr_block && this->_hdr_block_len > 0) {
+    len += iobuffer->write(this->_hdr_block, this->_hdr_block_len);
+  }
+
+  return len;
+}

--- a/proxy/http2/Http2Frame.h
+++ b/proxy/http2/Http2Frame.h
@@ -1,0 +1,252 @@
+/** @file
+
+  Http2Frame
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "P_Net.h"
+
+#include "HTTP2.h"
+
+/**
+   Incoming HTTP/2 Frame
+ */
+class Http2Frame
+{
+public:
+  Http2Frame(const Http2FrameHeader &h, IOBufferReader *r, bool e = false) : _hdr(h), _ioreader(r), _from_early_data(e) {}
+
+  // Accessor
+  IOBufferReader *reader() const;
+  const Http2FrameHeader &header() const;
+  bool is_from_early_data() const;
+
+private:
+  Http2FrameHeader _hdr;
+  IOBufferReader *_ioreader = nullptr;
+  bool _from_early_data     = false;
+};
+
+/**
+   Outgoing HTTP/2 Frame
+ */
+class Http2TxFrame
+{
+public:
+  Http2TxFrame(const Http2FrameHeader &h) : _hdr(h) {}
+
+  // Don't allocate on heap
+  void *operator new(std::size_t)   = delete;
+  void *operator new[](std::size_t) = delete;
+
+  virtual int64_t write_to(MIOBuffer *iobuffer) const = 0;
+
+protected:
+  Http2FrameHeader _hdr;
+};
+
+/**
+   DATA Frame
+ */
+class Http2DataFrame : public Http2TxFrame
+{
+public:
+  Http2DataFrame(Http2StreamId stream_id, uint8_t flags, IOBufferReader *r, uint32_t l)
+    : Http2TxFrame({l, HTTP2_FRAME_TYPE_DATA, flags, stream_id}), _reader(r), _payload_len(l)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  IOBufferReader *_reader = nullptr;
+  uint32_t _payload_len   = 0;
+};
+
+/**
+   HEADERS Frame
+
+   TODO: support priority info & padding using Http2HeadersParameter
+ */
+class Http2HeadersFrame : public Http2TxFrame
+{
+public:
+  Http2HeadersFrame(Http2StreamId stream_id, uint8_t flags, uint8_t *h, uint32_t l)
+    : Http2TxFrame({l, HTTP2_FRAME_TYPE_HEADERS, flags, stream_id}), _hdr_block(h), _hdr_block_len(l)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  uint8_t *_hdr_block     = nullptr;
+  uint32_t _hdr_block_len = 0;
+};
+
+/**
+   PRIORITY Frame
+
+   TODO: implement xmit function
+ */
+class Http2PriorityFrame : public Http2TxFrame
+{
+public:
+  Http2PriorityFrame(Http2StreamId stream_id, uint8_t flags, Http2Priority p)
+    : Http2TxFrame({HTTP2_PRIORITY_LEN, HTTP2_FRAME_TYPE_PRIORITY, flags, stream_id}), _params(p)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  Http2Priority _params;
+};
+
+/**
+   RST_STREAM Frame
+ */
+class Http2RstStreamFrame : public Http2TxFrame
+{
+public:
+  Http2RstStreamFrame(Http2StreamId stream_id, uint32_t e)
+    : Http2TxFrame({HTTP2_RST_STREAM_LEN, HTTP2_FRAME_TYPE_RST_STREAM, HTTP2_FRAME_NO_FLAG, stream_id}), _error_code(e)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  uint32_t _error_code;
+};
+
+/**
+   SETTINGS Frame
+ */
+class Http2SettingsFrame : public Http2TxFrame
+{
+public:
+  Http2SettingsFrame(Http2StreamId stream_id, uint8_t flags) : Http2TxFrame({0, HTTP2_FRAME_TYPE_SETTINGS, flags, stream_id}) {}
+  Http2SettingsFrame(Http2StreamId stream_id, uint8_t flags, Http2SettingsParameter *p, uint32_t s)
+    : Http2TxFrame({static_cast<uint32_t>(HTTP2_SETTINGS_PARAMETER_LEN) * s, HTTP2_FRAME_TYPE_SETTINGS, flags, stream_id}),
+      _params(p),
+      _psize(s)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  Http2SettingsParameter *_params = nullptr;
+  uint32_t _psize                 = 0;
+};
+
+/**
+   PUSH_PROMISE Frame
+
+   TODO: support padding
+ */
+class Http2PushPromiseFrame : public Http2TxFrame
+{
+public:
+  Http2PushPromiseFrame(Http2StreamId stream_id, uint8_t flags, Http2PushPromise p, uint8_t *h, uint32_t l)
+    : Http2TxFrame({l, HTTP2_FRAME_TYPE_PUSH_PROMISE, flags, stream_id}), _params(p), _hdr_block(h), _hdr_block_len(l)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  Http2PushPromise _params;
+  uint8_t *_hdr_block     = nullptr;
+  uint32_t _hdr_block_len = 0;
+};
+
+/**
+   PING Frame
+ */
+class Http2PingFrame : public Http2TxFrame
+{
+public:
+  Http2PingFrame(Http2StreamId stream_id, uint8_t flags, const uint8_t *data)
+    : Http2TxFrame({HTTP2_PING_LEN, HTTP2_FRAME_TYPE_PING, flags, stream_id}), _opaque_data(data)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  const uint8_t *_opaque_data;
+};
+
+/**
+   GOAWAY Frame
+
+   TODO: support Additional Debug Data
+ */
+class Http2GoawayFrame : public Http2TxFrame
+{
+public:
+  Http2GoawayFrame(Http2Goaway p)
+    : Http2TxFrame({HTTP2_GOAWAY_LEN, HTTP2_FRAME_TYPE_GOAWAY, HTTP2_FRAME_NO_FLAG, HTTP2_CONNECTION_CONTROL_STRTEAM}), _params(p)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  Http2Goaway _params;
+};
+
+/**
+   WINDOW_UPDATE Frame
+ */
+class Http2WindowUpdateFrame : public Http2TxFrame
+{
+public:
+  Http2WindowUpdateFrame(Http2StreamId stream_id, uint32_t w)
+    : Http2TxFrame({HTTP2_WINDOW_UPDATE_LEN, HTTP2_FRAME_TYPE_WINDOW_UPDATE, HTTP2_FRAME_NO_FLAG, stream_id}), _window(w)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  uint32_t _window = 0;
+};
+
+/**
+   CONTINUATION Frame
+ */
+class Http2ContinuationFrame : public Http2TxFrame
+{
+public:
+  Http2ContinuationFrame(Http2StreamId stream_id, uint8_t flags, uint8_t *h, uint32_t l)
+    : Http2TxFrame({l, HTTP2_FRAME_TYPE_CONTINUATION, flags, stream_id}), _hdr_block(h), _hdr_block_len(l)
+  {
+  }
+
+  int64_t write_to(MIOBuffer *iobuffer) const override;
+
+private:
+  uint8_t *_hdr_block     = nullptr;
+  uint32_t _hdr_block_len = 0;
+};

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -384,7 +384,9 @@ Http2Stream::do_io_close(int /* flags */)
     if (_proxy_ssn && this->is_client_state_writeable()) {
       // Make sure any trailing end of stream frames are sent
       // Wee will be removed at send_data_frames or closing connection phase
-      static_cast<Http2ClientSession *>(_proxy_ssn)->connection_state.send_data_frames(this);
+      Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
+      SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+      h2_proxy_ssn->connection_state.send_data_frames(this);
     }
 
     clear_timers();

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -38,6 +38,8 @@ libhttp2_a_SOURCES = \
 	HPACK.h \
 	HTTP2.cc \
 	HTTP2.h \
+	Http2Frame.cc \
+	Http2Frame.h \
 	Http2ClientSession.cc \
 	Http2ClientSession.h \
 	Http2ConnectionState.cc \


### PR DESCRIPTION
Prior to this change, HTTP/2 was almost 30% slower than HTTP/1.1 (over TLS) on downloading a huge file (over 1GB).

Improvements:
- Avoid unnecessary IOBufferBlock allocation for all type of frame
- Avoid unnecessary copy on sending DATA frame
- Adjust IOBufferBlock size of Http2ClientSession::write_buffer

Cleanups:
- Decouple receiving & sending HTTP/2 Frame
- Remove unnecessary SCOPED_MUTEX_LOCK

----

Another approach of #5916.
Some features like adding padding are unimplemented as is.