### PR TITLE
Fixes an issue where NextHopSelectionStrategy did not implement a parent check.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -245,6 +245,20 @@ markParentUp(HttpTransact::State *s)
 
 // wrapper to choose between a remap next hop strategy or use parent.config
 // remap next hop strategy is preferred
+inline static bool
+parentExists(HttpTransact::State *s)
+{
+  url_mapping *mp = s->url_map.getMapping();
+  if (mp && mp->strategy) {
+    return mp->strategy->nextHopExists(s->state_machine->sm_id);
+  } else if (s->parent_params) {
+    return s->parent_params->parentExists(&s->request_data);
+  }
+  return false;
+}
+
+// wrapper to choose between a remap next hop strategy or use parent.config
+// remap next hop strategy is preferred
 inline static void
 nextParent(HttpTransact::State *s)
 {
@@ -1444,7 +1458,7 @@ HttpTransact::HandleRequest(State *s)
       ats_ip_copy(&s->request_data.dest_ip, &addr);
     }
 
-    if (s->parent_params->parentExists(&s->request_data)) {
+    if (parentExists(s)) {
       // If the proxy is behind and firewall and there is no
       //  DNS service available, we just want to forward the request
       //  the parent proxy.  In this case, we never find out the

--- a/proxy/http/remap/NextHopSelectionStrategy.cc
+++ b/proxy/http/remap/NextHopSelectionStrategy.cc
@@ -251,15 +251,15 @@ NextHopSelectionStrategy::markNextHopDown(const uint64_t sm_id, ParentResult &re
       }
       new_fail_count = old_count + 1;
     } // end of lock_guard
-    NH_Debug("parent_select", "[%" PRIu64 "] Parent fail count increased to %d for %s:%d", sm_id, new_fail_count,
-             h->hostname.c_str(), h->getPort(scheme));
+    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] Parent fail count increased to %d for %s:%d", sm_id, new_fail_count, h->hostname.c_str(),
+             h->getPort(scheme));
   }
 
   if (new_fail_count >= fail_threshold) {
     h->set_unavailable();
     NH_Note("[%" PRIu64 "] Failure threshold met failcount:%d >= threshold:%" PRIu64 ", http parent proxy %s:%d marked down", sm_id,
             new_fail_count, fail_threshold, h->hostname.c_str(), h->getPort(scheme));
-    NH_Debug("parent_select", "[%" PRIu64 "] NextHop %s:%d marked unavailable, h->available=%s", sm_id, h->hostname.c_str(),
+    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] NextHop %s:%d marked unavailable, h->available=%s", sm_id, h->hostname.c_str(),
              h->getPort(scheme), (h->available) ? "true" : "false");
   }
 }
@@ -287,6 +287,21 @@ NextHopSelectionStrategy::markNextHopUp(const uint64_t sm_id, ParentResult &resu
     h->set_available();
     NH_Note("[%" PRIu64 "] http parent proxy %s:%d restored", sm_id, h->hostname.c_str(), h->getPort(scheme));
   }
+}
+
+bool
+NextHopSelectionStrategy::nextHopExists(const uint64_t sm_id)
+{
+  for (uint32_t gg = 0; gg < groups; gg++) {
+    for (uint32_t hh = 0; hh < host_groups[gg].size(); hh++) {
+      HostRecord *p = host_groups[gg][hh].get();
+      if (p->available) {
+        NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] found available next hop %s", sm_id, p->hostname.c_str());
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 namespace YAML

--- a/proxy/http/remap/NextHopSelectionStrategy.h
+++ b/proxy/http/remap/NextHopSelectionStrategy.h
@@ -195,6 +195,7 @@ public:
   void markNextHopDown(const uint64_t sm_id, ParentResult &result, const uint64_t fail_threshold, const uint64_t retry_time,
                        time_t now = 0);
   void markNextHopUp(const uint64_t sm_id, ParentResult &result);
+  bool nextHopExists(const uint64_t sm_id);
 
   std::string strategy_name;
   bool go_direct           = true;


### PR DESCRIPTION
Fixes an issue where NextHopSelectionStrategy did not implement a parent check function required when `proxy.config.http.no_dns_just_forward_to_parent` is enabled.