### PR TITLE
Fixed fallthrough compiler error with Centos 6

### DIFF
--- a/lib/tsconfig/TsConfigGrammar.c
+++ b/lib/tsconfig/TsConfigGrammar.c
@@ -892,6 +892,7 @@ yytnamerr (char *yyres, const char *yystr)
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
             /* Fall through.  */
+            __attribute__ ((fallthrough));
           default:
             if (yyres)
               yyres[yyn] = *yyp;


### PR DESCRIPTION
ccache on centos 6 doesn't like the fall through comment for some odd
reason