### PR TITLE
Fixes an assertion failure when proxy.config.http.no_dns_just_forward_to_parent is enabled

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -538,6 +538,13 @@ find_server_and_update_current_info(HttpTransact::State *s)
     return HttpTransact::HOST_NONE;
 
   case PARENT_DIRECT:
+    // if the configuration does not allow the origin to be dns'd
+    // we're unable to go direct to the origin.
+    if (s->http_config_param->no_dns_forward_to_parent) {
+      Warning("no available parents and the config proxy.config.http.no_dns_just_forward_to_parent, prevents origin lookups.");
+      s->parent_result.result = PARENT_FAIL;
+      return HttpTransact::HOST_NONE;
+    }
   /* fall through */
   default:
     update_current_info(&s->current, &s->server_info, HttpTransact::ORIGIN_SERVER, (s->current.attempts)++);


### PR DESCRIPTION
When proxy.config.http.no_dns_just_forward_to_parent is enabled and there are no parent.config or strategy entries to configure nexthop forwarding, ATS fails the assertion in HttpTransact::handle_parent_died() and crashes on test/debug builds.  For release builds, a 502 is returned to the client.  

This PR fixes the issue for debug/test builds so that a 502 is also sent to the client by modifying the parent_result.result to be PARENT_FAIL when proxy.config.http.no_dns_just_forward_to_parent is enabled and there is no parent.config or strategy entry to handle the request.

This PR also provides a Warning message to alert of the configuration issue that results in the 502's.