### PR TITLE
Fix localstatedir and runtimedir for Debian layout

### DIFF
--- a/config.layout
+++ b/config.layout
@@ -192,8 +192,8 @@
     docdir:        ${prefix}/share/doc+
     installbuilddir: ${prefix}/share/trafficserver/build
     includedir:    ${prefix}/include
-    localstatedir: /var/run
-    runtimedir:    /var/run+
+    localstatedir: /run
+    runtimedir:    /run+
     logdir:        /var/log+
     cachedir: /var/cache+
 </Layout>


### PR DESCRIPTION
Starting with Debian Buster, trafficserver gets a warning on start from systemd if the pidfile is on /var/run instead of /run:
```
traffic-cache-atsupload-buster systemd[1]: /lib/systemd/system/trafficserver.service:8: PIDFile= references path below legacy directory /var/run/, updating /var/run/trafficserver/manager.lock → /run/trafficserver/manager.lock; please update the unit file accordingly.
```

while debian "fixed (https://salsa.debian.org/debian/trafficserver/commit/bee57ba9249b6bdb6cd3e33729f4a2a7f0b10ec1) the issue merely changing their PIDFile path from /var/run to /run (it's currently symlinked), TS should also write into /run instead of /var/run.