### PR TITLE
Add virtual destructors for Http2TxFrame, Http2FrequencyCounter

### DIFF
--- a/proxy/http2/Http2Frame.h
+++ b/proxy/http2/Http2Frame.h
@@ -53,6 +53,7 @@ class Http2TxFrame
 {
 public:
   Http2TxFrame(const Http2FrameHeader &h) : _hdr(h) {}
+  virtual ~Http2TxFrame() {}
 
   // Don't allocate on heap
   void *operator new(std::size_t)   = delete;

--- a/proxy/http2/Http2FrequencyCounter.h
+++ b/proxy/http2/Http2FrequencyCounter.h
@@ -31,6 +31,7 @@ class Http2FrequencyCounter
 public:
   void increment(uint16_t amount = 1);
   uint32_t get_count();
+  virtual ~Http2FrequencyCounter() {}
 
 protected:
   uint16_t _count[2]      = {0};


### PR DESCRIPTION
This will prevent potential future issues by following the rule of any class that needs virtual methods must have a virtual destructor.