### PR TITLE
Change localtime/gmtime usages to use the threadsafe versions with local storage

### DIFF
--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -1057,7 +1057,8 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
             resp_header_fields.append("Expires: 0\r\n");
           } else {
             char line_buf[128];
-            int line_size = strftime(line_buf, 128, "Expires: %a, %d %b %Y %T GMT\r\n", gmtime(&expires_time));
+            struct tm gm_expires_time;
+            int line_size = strftime(line_buf, 128, "Expires: %a, %d %b %Y %T GMT\r\n", gmtime_r(&expires_time, &gm_expires_time));
             resp_header_fields.append(line_buf, line_size);
           }
         }
@@ -1188,7 +1189,9 @@ writeStandardHeaderFields(InterceptData &int_data, int &n_bytes_written)
   if (find(HEADER_WHITELIST.begin(), HEADER_WHITELIST.end(), TS_MIME_FIELD_LAST_MODIFIED) == HEADER_WHITELIST.end()) {
     time_t time_now = static_cast<time_t>(TShrtime() / 1000000000); // it returns nanoseconds!
     char last_modified_line[128];
-    int last_modified_line_size = strftime(last_modified_line, 128, "Last-Modified: %a, %d %b %Y %T GMT\r\n", gmtime(&time_now));
+    struct tm gmnow;
+    int last_modified_line_size =
+      strftime(last_modified_line, 128, "Last-Modified: %a, %d %b %Y %T GMT\r\n", gmtime_r(&time_now, &gmnow));
     if (TSIOBufferWrite(int_data.output.buffer, last_modified_line, last_modified_line_size) == TS_ERROR) {
       LOG_ERROR("Error while writing last-modified fields");
       return false;

--- a/src/traffic_top/traffic_top.cc
+++ b/src/traffic_top/traffic_top.cc
@@ -228,10 +228,11 @@ help(const string &host, const string &version)
 
   while (true) {
     clear();
-    time_t now       = time(nullptr);
-    struct tm *nowtm = localtime(&now);
+    time_t now = time(nullptr);
+    struct tm nowtm;
     char timeBuf[32];
-    strftime(timeBuf, sizeof(timeBuf), "%H:%M:%S", nowtm);
+    localtime_r(&now, &nowtm);
+    strftime(timeBuf, sizeof(timeBuf), "%H:%M:%S", &nowtm);
 
     // clear();
     attron(A_BOLD);
@@ -467,10 +468,11 @@ main(int argc, const char **argv)
     attron(A_BOLD);
 
     string version;
-    time_t now       = time(nullptr);
-    struct tm *nowtm = localtime(&now);
+    time_t now = time(nullptr);
+    struct tm nowtm;
     char timeBuf[32];
-    strftime(timeBuf, sizeof(timeBuf), "%H:%M:%S", nowtm);
+    localtime_r(&now, &nowtm);
+    strftime(timeBuf, sizeof(timeBuf), "%H:%M:%S", &nowtm);
     stats.getStat("version", version);
 
     mvprintw(23, 0, "%-20.20s   %30s (q)uit (h)elp (%c)bsolute  ", host.c_str(), page_alt.c_str(), absolute ? 'A' : 'a');

--- a/tools/http_load/http_load.c
+++ b/tools/http_load/http_load.c
@@ -2760,9 +2760,9 @@ idle_connection(ClientData client_data, struct timeval *nowP __attribute__((unus
   int cnum;
   struct timeval tv;
   char strTime[32];
-
+  struct tm localtv;
   gettimeofday(&tv, NULL);
-  strftime(strTime, 32, "%T", localtime(&tv.tv_sec));
+  strftime(strTime, 32, "%T", localtime_r(&tv.tv_sec, &localtv));
 
   cnum                         = client_data.i;
   connections[cnum].idle_timer = (Timer *)0;


### PR DESCRIPTION
Addresses issue #6355 , changing to suggested usages of gmtime_r and localtime_r which use local storage to be thread safe