### PR TITLE
Removing always true/false comparisons

### DIFF
--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -116,7 +116,7 @@ MIOBuffer::write(IOBufferBlock const *b, int64_t alen, int64_t offset)
       continue;
     }
     int64_t bytes;
-    if (len < 0 || len >= max_bytes) {
+    if (len >= max_bytes) {
       bytes = max_bytes;
     } else {
       bytes = len;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -409,7 +409,7 @@ ssl_client_hello_callback(SSL *s, int *al, void *arg)
        * The list in practice only has a single element, so we only consider
        * the first one.
        */
-      if (remaining != 0 && *p++ == TLSEXT_NAMETYPE_host_name) {
+      if (*p++ == TLSEXT_NAMETYPE_host_name) {
         remaining--;
         /* Now we can finally pull out the byte array with the actual hostname. */
         if (remaining > 2) {

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -1628,7 +1628,7 @@ TSPluginInit(int argc, const char *argv[])
   if (argc < 2) {
     TSError("[tsmemcache] Usage: tsmemcache.so [accept_port]\n");
     goto error;
-  } else if (argc > 1) {
+  } else {
     int port = atoi(argv[1]);
     if (!port) {
       TSError("[tsmemcache] bad accept_port '%s'\n", argv[1]);

--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -188,9 +188,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   TSHandleMLocRelease(mbuf, TS_NULL_MLOC, ul);
 
   PluginDebug("Processing request for %.*s.", url_ct, url);
-  if (cpi < max_cpi) {
-    checkpoints[cpi++] = mark_timer(&t);
-  }
+  checkpoints[cpi++] = mark_timer(&t);
 
   int strip_size = url_ct + 1;
   strip_uri      = (char *)TSmalloc(strip_size);
@@ -199,9 +197,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   size_t strip_ct;
   cjose_jws_t *jws = get_jws_from_uri(url, url_ct, package, strip_uri, strip_size, &strip_ct);
 
-  if (cpi < max_cpi) {
-    checkpoints[cpi++] = mark_timer(&t);
-  }
+  checkpoints[cpi++] = mark_timer(&t);
+
   int checked_cookies = 0;
   if (!jws) {
   check_cookies:

--- a/proxy/hdrs/HdrTest.cc
+++ b/proxy/hdrs/HdrTest.cc
@@ -541,8 +541,6 @@ HdrTest::test_http_aux(const char *request, const char *response)
   const char *start;
   const char *end;
 
-  int status = 1;
-
   printf("   <<< MUST BE HAND-VERIFIED FOR FULL BENEFIT >>>\n\n");
 
   /*** (1) parse the request string into req_hdr ***/
@@ -1520,8 +1518,6 @@ HdrTest::test_http()
 int
 HdrTest::test_http_mutation()
 {
-  int status = 1;
-
   bri_box("test_http_mutation");
 
   printf("   <<< MUST BE HAND-VERIFIED FOR FULL BENEFIT>>>\n\n");

--- a/proxy/hdrs/HdrTest.cc
+++ b/proxy/hdrs/HdrTest.cc
@@ -565,7 +565,7 @@ HdrTest::test_http_aux(const char *request, const char *response)
   if (err == PARSE_RESULT_ERROR) {
     req_hdr.destroy();
     rsp_hdr.destroy();
-    return (failures_to_status("test_http_aux", (status == 0)));
+    return (failures_to_status("test_http_aux", false));
   }
 
   /*** useless copy to exercise copy function ***/
@@ -606,7 +606,7 @@ HdrTest::test_http_aux(const char *request, const char *response)
   if (err == PARSE_RESULT_ERROR) {
     req_hdr.destroy();
     rsp_hdr.destroy();
-    return (failures_to_status("test_http_aux", (status == 0)));
+    return (failures_to_status("test_http_aux", false));
   }
 
   http_parser_clear(&parser);
@@ -655,7 +655,7 @@ HdrTest::test_http_aux(const char *request, const char *response)
   req_hdr.destroy();
   rsp_hdr.destroy();
 
-  return (failures_to_status("test_http_aux", (status == 0)));
+  return (failures_to_status("test_http_aux", false));
 }
 
 int
@@ -1599,7 +1599,7 @@ HdrTest::test_http_mutation()
 
   resp_hdr.destroy();
 
-  return (failures_to_status("test_http_mutation", (status == 0)));
+  return (failures_to_status("test_http_mutation", false));
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4305,7 +4305,7 @@ HttpSM::parse_range_and_compare(MIMEField *field, int64_t content_length)
         ;
       }
 
-      if (s < e || start < 0) {
+      if (s < e) {
         t_state.range_setup = HttpTransact::RANGE_NONE;
         goto Lfaild;
       }
@@ -4345,7 +4345,7 @@ HttpSM::parse_range_and_compare(MIMEField *field, int64_t content_length)
         ;
       }
 
-      if (s < e || end < 0) {
+      if (s < e) {
         t_state.range_setup = HttpTransact::RANGE_NONE;
         goto Lfaild;
       }

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -845,7 +845,6 @@ process_regex_mapping_config(const char *from_host_lower, url_mapping *new_mappi
   const char *to_host;
   int to_host_len;
   int substitution_id;
-  int substitution_count = 0;
   int captures;
 
   reg_map->to_url_host_template     = nullptr;

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -875,10 +875,6 @@ process_regex_mapping_config(const char *from_host_lower, url_mapping *new_mappi
   to_host = new_mapping->toURL.host_get(&to_host_len);
   for (int i = 0; i < (to_host_len - 1); ++i) {
     if (to_host[i] == '$') {
-      if (substitution_count > UrlRewrite::MAX_REGEX_SUBS) {
-        Warning("Cannot have more than %d substitutions in mapping with host [%s]", UrlRewrite::MAX_REGEX_SUBS, from_host_lower);
-        goto lFail;
-      }
       substitution_id = to_host[i + 1] - '0';
       if ((substitution_id < 0) || (substitution_id > captures)) {
         Warning("Substitution id [%c] has no corresponding capture pattern in regex [%s]", to_host[i + 1], from_host_lower);


### PR DESCRIPTION
To me these are the ones that made the most sense to remove.  There are some others reported that:

1) Seem to be false positives due to enum usages for some reason

2) Seemed to me that they should be left in for readability purposes. These ones were constant comparisons but when viewed in the code they were in it made sense to leave them because
it fit the code scheme and helped readability

Addresses issue #6354 