### PR TITLE
Fix potential stall on HTTP/2 connection

### DIFF
--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -148,7 +148,7 @@ private:
   bool response_is_data_available() const;
   Event *send_tracked_event(Event *event, int send_event, VIO *vio);
   void send_response_body(bool call_update);
-
+  void _signal_event(VIO &vio, int event);
   /**
    * Check if this thread is the right thread to process events for this
    * continuation.
@@ -216,10 +216,8 @@ private:
   ink_hrtime inactive_timeout_at = 0;
   Event *inactive_event          = nullptr;
 
-  Event *read_event       = nullptr;
-  Event *write_event      = nullptr;
-  Event *_read_vio_event  = nullptr;
-  Event *_write_vio_event = nullptr;
+  Event *read_event  = nullptr;
+  Event *write_event = nullptr;
 };
 
 extern ClassAllocator<Http2Stream> http2StreamAllocator;


### PR DESCRIPTION
In Http2Stream.cc, below (bit simplified) code appear 5 times. However, this doesn't work as expected when the try lock is not locked.
```
MUTEX_TRY_LOCK(lock, read_vio.mutex, this_ethread());
if (lock.is_locked()) {
    read_vio.cont->handleEvent(event, &read_vio);
} else {
    this_ethread()->schedule_imm(read_vio.cont, event, &read_vio);
}
```

The third argument of `schedule_imm()` is `void *cookie` and it is assigned to `Event::cookie`. When the event is processed, the second argument of `handleEvent()` is `Event *`.
OTOH, the event handler of the `read_vio.cont` (HttpTunnel or HttpSM) assume the second `void *` is `VIO *`. 
This means if we want to pass `VIO *`, we need to call `handleEvent()` directly.

https://github.com/apache/trafficserver/blob/baf9d4b8363039a192be14ba0a7137ebbc0c5450/proxy/http/HttpTunnel.cc#L1559
https://github.com/apache/trafficserver/blob/baf9d4b8363039a192be14ba0a7137ebbc0c5450/proxy/http/HttpSM.cc#L2629

When ATS falls into the case, the event is ignored and the stream might be stalled.