### PR TITLE
Improve config_describe logs to print a better output format.

### DIFF
--- a/src/traffic_ctl/config.cc
+++ b/src/traffic_ctl/config.cc
@@ -25,6 +25,7 @@
 #include <ctime>
 #include "records/I_RecDefs.h"
 #include "records/P_RecUtils.h"
+#include <tscore/BufferWriter.h>
 
 struct RecordDescriptionPolicy {
   using entry_type = TSConfigRecordDescription *;
@@ -223,24 +224,26 @@ CtrlEngine::config_describe()
       return;
     }
 
-    std::cout << "Name: " << desc.rec_name << std::endl;
-    std::cout << "Current Value: " << CtrlMgmtRecordValue(desc.rec_type, desc.rec_value).c_str() << std::endl;
-    std::cout << "Default Value: " << CtrlMgmtRecordValue(desc.rec_type, desc.rec_default).c_str() << std::endl;
-    std::cout << "Record Type: " << rec_classof(desc.rec_class) << std::endl;
-    std::cout << "Data Type: " << rec_typeof(desc.rec_type) << std::endl;
-    std::cout << "Access Control: " << rec_accessof(desc.rec_access) << std::endl;
-    std::cout << "Update Type: " << rec_updateof(desc.rec_updatetype) << std::endl;
-    std::cout << "Update Status: " << desc.rec_update << std::endl;
-    std::cout << "Source: " << rec_sourceof(desc.rec_source) << std::endl;
+    std::string text;
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Name", desc.rec_name);
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Current Value ", CtrlMgmtRecordValue(desc.rec_type, desc.rec_value).c_str());
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Default Value ", CtrlMgmtRecordValue(desc.rec_type, desc.rec_default).c_str());
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Record Type ", rec_classof(desc.rec_class));
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Data Type ", rec_typeof(desc.rec_type));
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Access Control ", rec_accessof(desc.rec_access));
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Update Type ", rec_updateof(desc.rec_updatetype));
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Update Status ", desc.rec_update);
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Source ", rec_sourceof(desc.rec_source));
 
     if (strlen(desc.rec_checkexpr)) {
-      std::cout << "Syntax Check: " << rec_checkof(desc.rec_checktype) << desc.rec_checkexpr << std::endl;
+      std::cout << ts::bwprint(text, "{:16s}: {}\n", "Syntax Check ", rec_checkof(desc.rec_checktype), desc.rec_checkexpr);
     } else {
-      std::cout << "Syntax Check: " << rec_checkof(desc.rec_checktype) << std::endl;
+      std::cout << ts::bwprint(text, "{:16s}: {}\n", "Syntax Check ", rec_checkof(desc.rec_checktype));
     }
-    std::cout << "Version: " << desc.rec_version << std::endl;
-    std::cout << "Order: " << desc.rec_order << std::endl;
-    std::cout << "Raw Stat Block: " << desc.rec_rsb << std::endl;
+
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Version ", desc.rec_version);
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Order ", desc.rec_order);
+    std::cout << ts::bwprint(text, "{:16s}: {}\n", "Raw Stat Block ", desc.rec_rsb);
 
     TSConfigRecordDescriptionFree(&desc);
   }


### PR DESCRIPTION
Improve  `CtrlEngine::config_describe` output logs to display a better formatted output.
Previous output:

```
Name: proxy.config.http.per_server.connection.match
Current Value: ip
Default Value: ip
Record Type: standard config
Data Type: STRING
Access Control: default
Update Type: dynamic, no restart
Update Status: 0
Source: built in default
Syntax Check: string matching a regular expression^(?:ip|host|both|none)$
Version: 0
Order: 945
Raw Stat Block: 0
```
With the change:

```
Name            : proxy.config.http.per_server.connection.match
Current Value   : ip
Default Value   : ip
Record Type     : standard config
Data Type       : STRING
Access Control  : default
Update Type     : dynamic, no restart
Update Status   : 0
Source          : built in default
Syntax Check    : string matching a regular expression
Version         : 0
Order           : 528
Raw Stat Block  : 0
```
