### PR TITLE
Export YAML CPP library headers for plugin use.

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -34,3 +34,6 @@ all-local:	$(LOCAL)
 
 clean-local:
 	$(MAKE) -C yamlcpp clean
+
+install-data-local:
+	$(MAKE) -C yamlcpp install

--- a/lib/yamlcpp/Makefile.am
+++ b/lib/yamlcpp/Makefile.am
@@ -17,8 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-AM_CPPFLAGS += \
-	-I$(abs_top_srcdir)/lib/yamlcpp/include
+AM_CPPFLAGS += -I$(abs_top_srcdir)/lib/yamlcpp/include
 
 noinst_LTLIBRARIES = libyamlcpp.la
 
@@ -50,3 +49,17 @@ src/simplekey.cpp \
 src/singledocparser.cpp \
 src/stream.cpp \
 src/tag.cpp
+
+
+yamlcpp_includedir=$(includedir)/yaml-cpp
+yamlcpp_include_HEADERS = \
+        $(srcdir)/include/yaml-cpp/*.h
+
+yamlcpp_node_includedir=$(includedir)/yaml-cpp/node
+yamlcpp_node_include_HEADERS = \
+	$(srcdir)/include/yaml-cpp/node/*.h
+
+yamlcpp_node_detail_includedir=$(includedir)/yaml-cpp/node/detail
+yamlcpp_node_detail_include_HEADERS = \
+	$(srcdir)/include/yaml-cpp/node/detail/*.h
+	


### PR DESCRIPTION
A fix for that is in progress.

This puts the YAML CPP headers in the SDK during install, parallel to the "ts" and "tscpp" headers. This way plugins can use the YAML-CPP library without

*  Downloading and installing separately

*  Crashing due to slight different versions of YAML-CPP

If we want to encourage plugins to use YAML, this will lower the barrier.