### PR TITLE
Update inactive_timeout_at in Http2Stream::signal_read_event()

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -670,6 +670,7 @@ Http2Stream::signal_read_event(int event)
 
   MUTEX_TRY_LOCK(lock, read_vio.cont->mutex, this_ethread());
   if (lock.is_locked()) {
+    inactive_timeout_at = Thread::get_hrtime() + inactive_timeout;
     this->read_vio.cont->handleEvent(event, &this->read_vio);
   } else {
     if (this->_read_vio_event) {


### PR DESCRIPTION
Fix part of #6368

c55001bec19d4db63f58b484186b942fbec5ae2a replaced some `Http2Stream::update_read_request()` calls with `Http2Stream::signal_read_event()`. 
In these cases, `inactive_timeout_at` needs to be updated.