### PR TITLE
Remove dependencies on include/tscore

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <getopt.h>
+#include <inttypes.h>
 
 #include "ts_lua_util.h"
 

--- a/plugins/lua/ts_lua_client_request.c
+++ b/plugins/lua/ts_lua_client_request.c
@@ -16,8 +16,8 @@
   limitations under the License.
 */
 
-#include "tscore/ink_platform.h"
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include "ts_lua_util.h"
 
 static void ts_lua_inject_client_request_client_addr_api(lua_State *L);

--- a/plugins/lua/ts_lua_common.h
+++ b/plugins/lua/ts_lua_common.h
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "lua.h"
 #include "lualib.h"
@@ -29,7 +30,6 @@
 #include <ts/ts.h>
 #include <ts/experimental.h>
 #include <ts/remap.h>
-#include "tscore/ink_defs.h"
 #include "ts_lua_coroutine.h"
 
 #define TS_LUA_FUNCTION_REMAP "do_remap"
@@ -177,3 +177,7 @@ typedef struct {
       ih->buffer = NULL;                \
     }                                   \
   } while (0)
+
+#ifndef ATS_UNUSED
+#define ATS_UNUSED __attribute__((unused))
+#endif

--- a/plugins/lua/ts_lua_misc.c
+++ b/plugins/lua/ts_lua_misc.c
@@ -16,8 +16,8 @@
   limitations under the License.
 */
 
-#include "tscore/ink_platform.h"
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include "ts_lua_util.h"
 
 static int ts_lua_get_process_id(lua_State *L);

--- a/plugins/lua/ts_lua_server_request.c
+++ b/plugins/lua/ts_lua_server_request.c
@@ -16,8 +16,8 @@
   limitations under the License.
 */
 
-#include "tscore/ink_platform.h"
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include "ts_lua_util.h"
 
 #define TS_LUA_CHECK_SERVER_REQUEST_HDR(http_ctx)                                                                                \


### PR DESCRIPTION
Plugins shouldn't have dependencies on internal header files.