### PR TITLE
Remove trailing white space from json formatter

### DIFF
--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -80,7 +80,7 @@ Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'access.log'), exists=True, con
 
 # TODO: when httpbin 0.8.0 or later is released, remove below json pretty print hack
 json_printer = '''
-python -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2))"
+python -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2, separators=(',', ': ')))"
 '''
 
 # ----


### PR DESCRIPTION
Fix httpbin autest.

```
       file /var/tmp/ausb-6370.12163/httpbin/_output/3-tr-Default/stream.stdout.txt : Checking that /var/tmp/ausb-6370.12163/httpbin/_output/3-tr-Default/stream.stdout.txt matches gold/httpbin_3_stdout.gold - Failed
          Reason: File differences
           Gold File : /var/jenkins/workspace/autest-github/src/tests/gold_tests/h2/gold/httpbin_3_stdout.gold
           Data File : /var/tmp/ausb-6370.12163/httpbin/_output/3-tr-Default/stream.stdout.txt
             {
               "files": {}, 
               "origin": "127.0.0.1", 
               "form": {
                 "key": "value"
           -   },
           +   }, 
           ?     +
           
               "url": "http://127.0.0.1:61743/post", 
               "args": {}, 
               "headers": {
                 "Content-Length": "9", 
                 "Client-Ip": "127.0.0.1", 
                 "Accept": "*/*", 
                 "User-Agent": "curl/7.65.0-DEV", 
                 "Host": "127.0.0.1:61743", 
                 "Expect": "100-continue", 
                 "Content-Type": "application/x-www-form-urlencoded"
               }, 
               "json": null, 
               "data": ""
             }
```