### PR TITLE
Add lua stats for lua plugin resource tracking

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3970,6 +3970,12 @@ Plug-in Configuration
 
    Specifies the location of |TS| plugins.
 
+.. ts:cv:: CONFIG proxy.config.plugin.lua.max_states INT 256
+
+   Maximum number of lua states at startup.  Applies to both remap and global plugins (each type is allocated this number of states).  The lua plugin --states overrides this but MUST be less than or equal to this value.
+
+	 This setting is not reloadable since it is must be applied when all the lua states are first initialized.
+
 SOCKS Processor
 ===============
 

--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -128,6 +128,17 @@ If it is used as remap plugin, we can write the following in remap.config to def
 
     map http://a.tbcdn.cn/ http://inner.tbcdn.cn/ @plugin=/XXX/tslua.so @pparam=--states=64 @pparam=/XXX/test_hdr.lua
 
+The maximum number of allowed states is set to 256 which is also the
+default states value.  The default value can be globally changed by
+adding a configuration option to records.config.
+
+::
+
+    CONFIG proxy.config.plugin.lua.max_states INT 64
+
+Any per plugin --states value overrides this default value but must be less than or equal to this value.  This setting is not reloadable since it is must be applied when all the lua states are first initialized.
+
+
 TS API for Lua
 ==============
 

--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -138,6 +138,50 @@ adding a configuration option to records.config.
 
 Any per plugin --states value overrides this default value but must be less than or equal to this value.  This setting is not reloadable since it is must be applied when all the lua states are first initialized.
 
+Profiling
+=========
+
+The lua module collects runtime statistics about the lua states, for remap
+and global instances.  Per state stats are constantly maintained and are
+made available through a lifecycle hook.  These may be accessed through:
+
+::
+
+    traffic_ctl plugin msg ts_lua stats_print
+
+Sample output:
+
+::
+
+    [Feb  5 19:00:15.072] ts_lua (remap) id:    0 gc_kb:   2508 gc_kb_max:   3491 threads:  417 threads_max:  438
+    [Feb  5 19:00:15.072] ts_lua (remap) id:    1 gc_kb:   1896 gc_kb_max:   3646 threads:  417 threads_max:  446
+    [Feb  5 19:00:15.072] ts_lua (remap) id:    2 gc_kb:   3376 gc_kb_max:   3740 threads:  417 threads_max:  442
+
+Max values may be reset at any time by running:
+
+::
+
+    traffic_ctl plugin msg ts_lua stats_reset
+
+
+Summary statistics are aggregated every 5s and are available as metrics.
+
+::
+
+    traffic_ctl metric match lua
+
+Sample output:
+
+::
+
+    plugin.lua.global.states 8
+    plugin.lua.remap.gc_bytes_min 4804608
+    plugin.lua.remap.gc_bytes_mean 5552537
+    plugin.lua.remap.gc_bytes_max 5779456
+    plugin.lua.remap.threads_min 31
+    plugin.lua.remap.threads_mean 44
+    plugin.lua.remap.threads_max 146
+
 
 TS API for Lua
 ==============

--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -164,7 +164,7 @@ Max values may be reset at any time by running:
     traffic_ctl plugin msg ts_lua stats_reset
 
 
-Summary statistics are aggregated every 5s and are available as metrics.
+Snapstho statistics are aggregated every 1s and are available as metrics.
 
 ::
 
@@ -175,12 +175,8 @@ Sample output:
 ::
 
     plugin.lua.global.states 8
-    plugin.lua.remap.gc_bytes_min 4804608
-    plugin.lua.remap.gc_bytes_mean 5552537
-    plugin.lua.remap.gc_bytes_max 5779456
-    plugin.lua.remap.threads_min 31
-    plugin.lua.remap.threads_mean 44
-    plugin.lua.remap.threads_max 146
+    plugin.lua.remap.gc_bytes 5552537
+    plugin.lua.remap.threads 44
 
 
 TS API for Lua

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1201,6 +1201,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.plugin.load_elevated", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
   ,
+  {RECT_CONFIG, "proxy.config.plugin.lua.max_states", RECD_INT, "256", RECU_RESTART_TS, RR_NULL, RECC_INT, "^[1-9][0-9]*$", RECA_READ_ONLY}
+	,
 
   // Interim configuration setting for obeying keepalive requests on internal
   // (PluginVC) sessions. See TS-4960 and friends.

--- a/plugins/lua/ts_lua_coroutine.h
+++ b/plugins/lua/ts_lua_coroutine.h
@@ -28,11 +28,21 @@
 struct async_item;
 typedef int (*async_clean)(struct async_item *item);
 
+/* context stats */
+typedef struct {
+  TSMutex mutexp;  // mutex for the following stats
+  int gc_kb;       // last recorded gc kbytes
+  int gc_kb_max;   // maximum recorded gc kbytes
+  int threads;     // associated coroutines
+  int threads_max; // max coroutines
+} ts_lua_ctx_stats;
+
 /* main context*/
 typedef struct {
-  lua_State *lua; // basic lua vm, injected
-  TSMutex mutexp; // mutex for lua vm
-  int gref;       // reference for lua vm self, in reg table
+  lua_State *lua;          // basic lua vm, injected
+  TSMutex mutexp;          // mutex for lua vm
+  int gref;                // reference for lua vm self, in reg table
+  ts_lua_ctx_stats *stats; // per vm stats
 } ts_lua_main_ctx;
 
 /* coroutine */

--- a/plugins/lua/ts_lua_util.c
+++ b/plugins/lua/ts_lua_util.c
@@ -40,6 +40,8 @@ static lua_State *ts_lua_new_state();
 static void ts_lua_init_registry(lua_State *L);
 static void ts_lua_init_globals(lua_State *L);
 static void ts_lua_inject_ts_api(lua_State *L);
+static ts_lua_ctx_stats *ts_lua_create_ctx_stats();
+static void ts_lua_destroy_ctx_stats(ts_lua_ctx_stats *stats);
 
 int
 ts_lua_create_vm(ts_lua_main_ctx *arr, int n)
@@ -58,6 +60,7 @@ ts_lua_create_vm(ts_lua_main_ctx *arr, int n)
     arr[i].gref   = luaL_ref(L, LUA_REGISTRYINDEX); /* L[REG][gref] = L[GLOBAL] */
     arr[i].lua    = L;
     arr[i].mutexp = TSMutexCreate();
+    arr[i].stats  = ts_lua_create_ctx_stats();
   }
 
   return 0;
@@ -68,11 +71,26 @@ ts_lua_destroy_vm(ts_lua_main_ctx *arr, int n)
 {
   int i;
   lua_State *L;
+  TSMutex mutexp;
+  ts_lua_ctx_stats *stats;
 
   for (i = 0; i < n; i++) {
     L = arr[i].lua;
-    if (L)
+    if (L) {
       lua_close(L);
+      arr[i].lua = NULL;
+    }
+    mutexp = arr[i].mutexp;
+    if (mutexp) {
+      TSMutexDestroy(mutexp);
+      arr[i].mutexp = NULL;
+    }
+
+    stats = arr[i].stats;
+    if (stats) {
+      ts_lua_destroy_ctx_stats(stats);
+      arr[i].stats = NULL;
+    }
   }
 
   return;
@@ -96,6 +114,29 @@ ts_lua_new_state()
   ts_lua_init_globals(L);
 
   return L;
+}
+
+ts_lua_ctx_stats *
+ts_lua_create_ctx_stats()
+{
+  ts_lua_ctx_stats *stats = NULL;
+
+  stats = TSmalloc(sizeof(ts_lua_ctx_stats));
+  memset(stats, 0, sizeof(ts_lua_ctx_stats));
+
+  stats->mutexp = TSMutexCreate();
+
+  return stats;
+}
+
+void
+ts_lua_destroy_ctx_stats(ts_lua_ctx_stats *stats)
+{
+  if (stats) {
+    TSMutexDestroy(stats->mutexp);
+    stats->mutexp = NULL;
+    TSfree(stats);
+  }
 }
 
 ts_lua_instance_conf *
@@ -501,6 +542,17 @@ ts_lua_create_async_ctx(lua_State *L, ts_lua_cont_info *hci, int n)
   crt->lua  = l;
   crt->ref  = luaL_ref(L, LUA_REGISTRYINDEX);
 
+  // update thread stats
+  ts_lua_main_ctx *const main_ctx = crt->mctx;
+  ts_lua_ctx_stats *const stats   = main_ctx->stats;
+
+  TSMutexLock(stats->mutexp);
+  ++stats->threads;
+  if (stats->threads_max < stats->threads) {
+    stats->threads_max = stats->threads;
+  }
+  TSMutexUnlock(stats->mutexp);
+
   // replace the param; start with 2 because first two params are not needed
   for (i = 2; i < n; i++) {
     lua_pushvalue(L, i + 1);
@@ -517,6 +569,14 @@ ts_lua_destroy_async_ctx(ts_lua_http_ctx *http_ctx)
   ts_lua_cont_info *ci;
 
   ci = &http_ctx->cinfo;
+
+  // update thread stats
+  ts_lua_main_ctx *const main_ctx = ci->routine.mctx;
+  ts_lua_ctx_stats *const stats   = main_ctx->stats;
+
+  TSMutexLock(stats->mutexp);
+  --stats->threads;
+  TSMutexUnlock(stats->mutexp);
 
   ts_lua_release_cont_info(ci);
   TSfree(http_ctx);
@@ -580,6 +640,16 @@ ts_lua_create_http_ctx(ts_lua_main_ctx *main_ctx, ts_lua_instance_conf *conf)
   crt->lua  = l;
   crt->mctx = main_ctx;
 
+  // update thread stats
+  ts_lua_ctx_stats *const stats = main_ctx->stats;
+
+  TSMutexLock(stats->mutexp);
+  ++stats->threads;
+  if (stats->threads_max < stats->threads) {
+    stats->threads_max = stats->threads;
+  }
+  TSMutexUnlock(stats->mutexp);
+
   http_ctx->instance_conf = conf;
 
   ts_lua_set_http_ctx(l, http_ctx);
@@ -622,6 +692,14 @@ ts_lua_destroy_http_ctx(ts_lua_http_ctx *http_ctx)
     TSHandleMLocRelease(http_ctx->cached_response_bufp, TS_NULL_MLOC, http_ctx->cached_response_hdrp);
     TSMBufferDestroy(http_ctx->cached_response_bufp);
   }
+
+  // update thread stats
+  ts_lua_main_ctx *const main_ctx = ci->routine.mctx;
+  ts_lua_ctx_stats *const stats   = main_ctx->stats;
+
+  TSMutexLock(stats->mutexp);
+  --stats->threads;
+  TSMutexUnlock(stats->mutexp);
 
   ts_lua_release_cont_info(ci);
   TSfree(http_ctx);
@@ -806,6 +884,7 @@ ts_lua_http_cont_handler(TSCont contp, TSEvent ev, void *edata)
   rc = ret = 0;
 
   TSMutexLock(main_ctx->mutexp);
+
   ts_lua_set_cont_info(L, ci);
 
   switch (event) {
@@ -951,7 +1030,22 @@ ts_lua_http_cont_handler(TSCont contp, TSEvent ev, void *edata)
     break;
   }
 
+  // current memory in use by this state
+  int const gc_kb = lua_getgccount(L);
+
   TSMutexUnlock(main_ctx->mutexp);
+
+  // collect state memory stats
+  ts_lua_ctx_stats *const stats = main_ctx->stats;
+
+  TSMutexLock(stats->mutexp);
+  if (gc_kb != stats->gc_kb) {
+    stats->gc_kb = gc_kb;
+    if (stats->gc_kb_max < stats->gc_kb) {
+      stats->gc_kb_max = stats->gc_kb;
+    }
+  }
+  TSMutexUnlock(stats->mutexp);
 
   if (rc == 0) {
     TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);


### PR DESCRIPTION
This adds resource stats for the lua plugin.  For each "lua state" current lua memory, max lua memory, threads and threads_max are recorded.  This applies to both "remap" and "global" stats depending on what type of lua plugins are in use.

```
# traffic_ctl metric match lua
plugin.lua.remap.states 8
plugin.lua.remap.gc_bytes 6400409
plugin.lua.remap.threads 36
```

For detailed debugging purposes a lifecycle hook has been added to dump detailed stats per "lua state".

```
# traffic_ctl plugin msg ts_lua stats_print
```
in traffic.out:
```
[Feb  5 19:27:15.089] ts_lua (remap) id:   0 gc_kb:    676 gc_kb_max:   2515 threads:    4 threads_max:  258  
[Feb  5 19:27:15.089] ts_lua (remap) id:   1 gc_kb:    599 gc_kb_max:   2493 threads:    7 threads_max:  252  
[Feb  5 19:27:15.089] ts_lua (remap) id:   2 gc_kb:    655 gc_kb_max:   2364 threads:    5 threads_max:  255  
[Feb  5 19:27:15.089] ts_lua (remap) id:   3 gc_kb:   1112 gc_kb_max:   2294 threads:    3 threads_max:  259  
[Feb  5 19:27:15.089] ts_lua (remap) id:   4 gc_kb:    818 gc_kb_max:   2271 threads:    3 threads_max:  254  
...
```
The _gc_kb_max_ and _threads_max_ values recorded are "all time" values.

Reset these _gc_kb_max_ and _threads_max_ by:
```
# traffic_ctl plugin msg ts_lua stats_reset
```