### PR TITLE
Remove unnecesary HttpSM handler call with VC_EVENT_ERROR

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -460,7 +460,6 @@ Http2Stream::initiating_close()
 
     // This should result in do_io_close or release being called.  That will schedule the final
     // kill yourself signal
-    // Send the SM the EOS signal if there are no active VIO's to signal
     // We are sending signals rather than calling the handlers directly to avoid the case where
     // the HttpTunnel handler causes the HttpSM to be deleted on the stack.
     bool sent_write_complete = false;
@@ -487,9 +486,6 @@ Http2Stream::initiating_close()
         Http2StreamDebug("send EOS to read cont");
         read_event = send_tracked_event(read_event, VC_EVENT_EOS, &read_vio);
       }
-    } else if (_sm) {
-      SCOPED_MUTEX_LOCK(lock, _sm->mutex, this_ethread());
-      _sm->handleEvent(VC_EVENT_ERROR);
     } else if (!sent_write_complete) {
       // Transaction is already gone or not started. Kill yourself
       do_io_close();


### PR DESCRIPTION
Fix the second issue of #6368.

IIUC, when `Http2Stream` as a `VConnection` signal `VC_EVENT_ERROR` event to the upper layer,  a `vio` should be also given as a second argument.

In the #6368 case, 1) `read_vio.cont` is nullptr and 2) `write_vio.cont` is nullptr or `VC_EVENT_WRITE_COMPLETE` or `VC_EVENT_EOS` is already sent. Thus, this `VC_EVENT_ERROR` looks unnecessary.
