### PR TITLE
Set default encoding UTF-8 for AuTest on Linux

### DIFF
--- a/ci/jenkins/bin/autest.sh
+++ b/ci/jenkins/bin/autest.sh
@@ -18,6 +18,17 @@
 
 set +x
 
+# Set default encoding UTF-8 for AuTest
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+echo "LC_ALL: $LC_ALL"
+echo "LANG: $LANG"
+
+# Check python version & encoding
+python3 --version
+echo "python default encoding: "
+python3 -c "import sys; print(sys.getdefaultencoding())"
+
 INSTALL="${ATS_BUILD_BASEDIR}/install"
 URL="https://ci.trafficserver.apache.org/autest"
 JOB_ID=${ghprbPullId:-${ATS_BRANCH:-master}}


### PR DESCRIPTION
Fix h2spec failure of AuTest. Based on @dragon512 's suggestion.
```
     Process: Default: Exception
       Test : Checking that ReturnCode == 0 - Passed
          Reason: Returned Value: 0 == 0
       file /var/tmp/ausb-6378.12193/h2spec/_output/0-tr-Default/stream.stdout.txt : Checking that /var/tmp/ausb-6378.12193/h2spec/_output/0-tr-Default/stream.stdout.txt matches gold/h2spec_stdout.gold - Exception
          Reason: Traceback (most recent call last):
             File "/usr/local/lib/python3.6/site-packages/autest/testers/tester.py", line 184, in __call__
               self.test(eventinfo, **kw)
             File "/usr/local/lib/python3.6/site-packages/autest/testers/gold_file.py", line 49, in test
               val_content = val_file.read()
             File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
               return codecs.ascii_decode(input, self.errors)[0]
           UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 152: ordinal not in range(128)
```