### PR TITLE
Free TSMgmtString after using it.

### DIFF
--- a/plugins/compress/misc.cc
+++ b/plugins/compress/misc.cc
@@ -172,6 +172,7 @@ init_hidden_header_name()
     hidden_header_name                         = static_cast<char *>(TSmalloc(hidden_header_name_len + 1));
     hidden_header_name[hidden_header_name_len] = 0;
     sprintf(hidden_header_name, "x-accept-encoding-%s", result);
+    TSfree(result);
   }
   return hidden_header_name;
 }


### PR DESCRIPTION
The leak detector told me that this is a memory leak:

```
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7f7f76293b90 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb90)
    #1 0x7f7f75de31da in ats_malloc ../../../../src/tscore/ink_memory.cc:59
    #2 0x7f7f75de391c in _xstrdup ../../../../src/tscore/ink_memory.cc:274
    #3 0xd503d2 in RecDataSet(RecDataT, RecData*, RecData*) ../../../../lib/records/RecUtils.cc:136
    #4 0xd33f8d in RecGetRecord_Xmalloc(char const*, RecDataT, RecData*, bool) ../../../../lib/records/RecCore.cc:936
    #5 0xd2f391 in RecGetRecordString_Xmalloc(char const*, char**, bool) ../../../../lib/records/RecCore.cc:425
    #6 0x68e253 in TSMgmtStringGet ../../../src/traffic_server/InkAPI.cc:4444
    #7 0x7f7f68069561 in init_hidden_header_name() ../../../plugins/compress/misc.cc:138
    #8 0x7f7f68058808 in TSPluginInit ../../../plugins/compress/compress.cc:1007
    #9 0xc10fd5 in single_plugin_init ../../../proxy/Plugin.cc:152
    #10 0xc1255c in plugin_init(bool) ../../../proxy/Plugin.cc:322
    #11 0x6e0fd9 in main ../../../src/traffic_server/traffic_server.cc:2058
    #12 0x7f7f7382a82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
```