### PR TITLE
Avoid cross-thread mutex conflicts

### DIFF
--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -115,8 +115,6 @@ EventProcessor::schedule(Event *e, EventType etype)
 
   if (e->continuation->mutex) {
     e->mutex = e->continuation->mutex;
-  } else {
-    e->mutex = e->continuation->mutex = e->ethread->mutex;
   }
   e->ethread->EventQueueExternal.enqueue(e);
   return e;

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -34,6 +34,8 @@
 #include <sys/eventfd.h>
 #endif
 
+#include <typeinfo>
+
 struct AIOCallback;
 
 #define NO_HEARTBEAT -1
@@ -108,7 +110,7 @@ void
 EThread::process_event(Event *e, int calling_code)
 {
   ink_assert((!e->in_the_prot_queue && !e->in_the_priority_queue));
-  MUTEX_TRY_LOCK(lock, e->mutex, this);
+  WEAK_MUTEX_TRY_LOCK(lock, e->mutex, this);
   if (!lock.is_locked()) {
     e->timeout_at = cur_time + DELAY_FOR_RETRY;
     EventQueueExternal.enqueue_local(e);
@@ -119,6 +121,11 @@ EThread::process_event(Event *e, int calling_code)
     }
     Continuation *c_temp = e->continuation;
     // Make sure that the continuation is locked before calling the handler
+
+    // Give a heads up if we are processing through a continuation without a mutex
+    if (!e->mutex) {
+      Warning("event processing for continuation %s without a mutex", typeid(*c_temp).name());
+    }
 
     // Restore the client IP debugging flags
     set_cont_flags(e->continuation->control_flags);


### PR DESCRIPTION
If a continuation does not have a mutex and it is being scheduled, the original logic will assign the mutex associated with current net handler thread.  If this is a long-lived, global continuation, assigning a thread's net handler mutex will cause lock contention blocking other threads.  It will also mean that it is probable that the nethandler lock will not be immediately acquired as in the scenario described in PR #5950.

This PR changes the logic to allow the continuation mutex to be null during scheduling, with the assumption that the plugin writer is dealing with locking directly in the plugin.  It does issue a warning so the operations team can review logs for surprising unlocked, scheduled plugins.  It also changes the lock acquisition in process_event to a weak lock to allow for the possibility of a null mutex.

We have been running with this change since after the Christmas break and it eliminated crashes due to the assert I added that was detecting high contention continuation locks (presumably due to use of nethandler mutexes on the continuation).