### PR TITLE
Correctly track H2 post vio bytes

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1385,10 +1385,10 @@ HttpTunnel::chain_abort_all(HttpTunnelProducer *p)
     if (c->alive) {
       c->alive     = false;
       c->write_vio = nullptr;
-      c->vc->do_io_close(EHTTP_ERROR);
       update_stats_after_abort(c->vc_type);
+      c->vc->do_io_close(EHTTP_ERROR);
+      c->vc = nullptr;
     }
-
     if (c->self_producer) {
       // Must snip the link before recursively
       // freeing to avoid looks introduced by
@@ -1410,8 +1410,9 @@ HttpTunnel::chain_abort_all(HttpTunnelProducer *p)
       p->self_consumer->alive = false;
     }
     p->read_vio = nullptr;
-    p->vc->do_io_close(EHTTP_ERROR);
     update_stats_after_abort(p->vc_type);
+    p->vc->do_io_close(EHTTP_ERROR);
+    p->vc = nullptr;
   }
 }
 
@@ -1480,6 +1481,7 @@ HttpTunnel::finish_all_internal(HttpTunnelProducer *p, bool chain)
       }
     }
   }
+  // p->vc = nullptr;
 
   while (c) {
     if (c->alive) {

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -213,7 +213,7 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     return;
   }
 
-  if (this->recv_end_stream) {
+  if (this->recv_end_stream || this->read_vio.ntodo() == 0) {
     this->read_vio.nbytes = bufindex;
     this->signal_read_event(VC_EVENT_READ_COMPLETE);
   } else {

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -124,6 +124,8 @@ public:
   bool has_trailing_header() const;
   void set_request_headers(HTTPHdr &h2_headers);
   MIOBuffer *read_vio_writer() const;
+  bool read_vio_done() const;
+  void update_read(int num_written);
 
   //////////////////
   // Variables
@@ -325,4 +327,16 @@ inline MIOBuffer *
 Http2Stream::read_vio_writer() const
 {
   return this->read_vio.get_writer();
+}
+
+inline void
+Http2Stream::update_read(int num_written)
+{
+  read_vio.ndone += num_written;
+}
+
+inline bool
+Http2Stream::read_vio_done() const
+{
+  return read_vio.ntodo() == 0;
 }

--- a/tests/gold_tests/slow_post/slow_post.test.py
+++ b/tests/gold_tests/slow_post/slow_post.test.py
@@ -41,7 +41,7 @@ class SlowPostAttack:
         self._server.addResponse("sessionlog.json", request_header2, response_header2)
 
     def setupTS(self):
-        self._ts = Test.MakeATSProcess("ts", select_ports=False)
+        self._ts = Test.MakeATSProcess("ts", select_ports=True)
         self._ts.Disk.remap_config.AddLine(
             'map / http://127.0.0.1:{0}'.format(self._server.Variables.Port)
         )


### PR DESCRIPTION
This should address issue #6313.  Or at least it seems to be addressing the crash we were seeing after introducing the commit with the H2 post processing optimization.  The key thing this commit addresses is updating the vio ndone on the read_vio in the Http2Stream.  We would see WRITE_COMPLETE on the tunnel server side for the post body, but would not see the READ_COMPLETE for the user agent post side.  In this post case, the client request is specifying a content-length.  Eventually the inactivity timeout would trigger on the user agent and the read_vio on the server side would be left open.

This PR updates the ndone on the H2 vio and it does some other cleanup to ensure that sessions not in the tunnel are marked as such so they can be correctly cleaned up before the SM is deleted.

I ran a precursor version of this patch on a production box overnight without crash.  This PR has most of the asserts I added removed.  I'm running this patch now.