### PR TITLE
Fix for lua plugin coredump problem during reload

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -131,7 +131,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
     TSDebug(TS_LUA_DEBUG_TAG, "[%s] checking if script has been registered", __FUNCTION__);
 
     // we only need to check the first lua VM for script registration
+    TSMutexLock(ts_lua_main_ctx_array[0].mutexp);
     conf = ts_lua_script_registered(ts_lua_main_ctx_array[0].lua, script);
+    TSMutexUnlock(ts_lua_main_ctx_array[0].mutexp);
   }
 
   if (!conf) {
@@ -166,7 +168,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
     // register the script only if it is from a file and has no __init__ function
     if (fn && !conf->init_func) {
       // we only need to register the script for the first lua VM
+      TSMutexLock(ts_lua_main_ctx_array[0].mutexp);
       ts_lua_script_register(ts_lua_main_ctx_array[0].lua, conf->script, conf);
+      TSMutexUnlock(ts_lua_main_ctx_array[0].mutexp);
     }
   }
 

--- a/plugins/lua/ts_lua_util.c
+++ b/plugins/lua/ts_lua_util.c
@@ -264,8 +264,6 @@ ts_lua_add_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n, int a
     lua_newtable(L);
     lua_replace(L, LUA_GLOBALSINDEX); /* L[GLOBAL] = EMPTY */
 
-    lua_gc(L, LUA_GCCOLLECT, 0);
-
     TSMutexUnlock(arr[i].mutexp);
   }
 
@@ -305,8 +303,6 @@ ts_lua_del_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n)
 
     lua_newtable(L);
     lua_replace(L, LUA_GLOBALSINDEX); /* L[GLOBAL] = EMPTY  */
-
-    lua_gc(L, LUA_GCCOLLECT, 0);
 
     TSMutexUnlock(arr[i].mutexp);
   }
@@ -368,8 +364,6 @@ ts_lua_reload_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n)
 
     lua_newtable(L);
     lua_replace(L, LUA_GLOBALSINDEX); /* L[GLOBAL] = EMPTY */
-
-    lua_gc(L, LUA_GCCOLLECT, 0);
 
     TSMutexUnlock(arr[i].mutexp);
   }


### PR DESCRIPTION
In production we are seeing some coredumps from lua plugin during reload. 
It turns out that the lua plugin is using the first lua VM to store script related information. And during reload, that VM can be used simultaneous being used to serve requests. And thus we should  use a mutex when using the first lua VM during reload.

Also we are doing lua_gc() during reload and we think it can be quite slow sometimes. So we are removing these calls. 

We have been testing these fixes for over a week in production and it eliminates the coredump situation we previously saw. 