### PR TITLE
Signal VC_EVENT_READ_COMPLETE when ATS received END_STREAM flag

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -139,11 +139,17 @@ rcv_data_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv data bad payload length");
     }
-  }
 
-  // If Data length is 0, do nothing.
-  if (payload_length == 0) {
-    return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
+    // Pure END_STREAM
+    if (payload_length == 0) {
+      stream->signal_read_event(VC_EVENT_READ_COMPLETE);
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
+    }
+  } else {
+    // If payload length is 0 without END_STREAM flag, do nothing
+    if (payload_length == 0) {
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
+    }
   }
 
   // Check whether Window Size is acceptable
@@ -373,6 +379,9 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       stream->new_transaction(frame.is_from_early_data());
       // Send request header to SM
       stream->send_request(cstate);
+    } else {
+      // Signal VC_EVENT_READ_COMPLETE becasue received trailing header fields with END_STREAM flag
+      stream->signal_read_event(VC_EVENT_READ_COMPLETE);
     }
   } else {
     // NOTE: Expect CONTINUATION Frame. Do NOT change state of stream or decode

--- a/tests/gold_tests/h2/gold/nghttp_0_stdout.gold
+++ b/tests/gold_tests/h2/gold/nghttp_0_stdout.gold
@@ -1,0 +1,17 @@
+``
+[``] send HEADERS frame <length=``, flags=0x04, stream_id=1>
+``
+``trailer: foo
+``
+[``] send DATA frame <length=``, flags=0x00, stream_id=1>
+``
+[``] send HEADERS frame <length=8, flags=0x05, stream_id=1>
+``; END_STREAM | END_HEADERS
+``
+``foo: bar
+``
+[``] recv (stream_id=1) :status: 200
+``
+[``] recv RST_STREAM frame <length=4, flags=0x00, stream_id=1>
+``(error_code=NO_ERROR(0x00))
+``

--- a/tests/gold_tests/h2/nghttp.test.py
+++ b/tests/gold_tests/h2/nghttp.test.py
@@ -1,0 +1,84 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Test with nghttp
+'''
+# need Curl
+Test.SkipUnless(
+    Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
+)
+Test.ContinueOnFail = True
+
+# ----
+# Setup Origin Server
+# ----
+microserver = Test.MakeOriginServer("microserver")
+
+# 128KB
+post_body = "0123456789abcdef" * 8192
+post_body_file = open(os.path.join(Test.RunDirectory, "post_body"), "w")
+post_body_file.write(post_body)
+post_body_file.close()
+
+# For Test Case 0
+microserver.addResponse("sessionlog.json",
+                        {"headers": "POST /post HTTP/1.1\r\nHost: www.example.com\r\nTrailer: foo\r\n\r\n",
+                            "timestamp": "1469733493.993", "body": post_body},
+                        {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""})
+
+# ----
+# Setup ATS
+# ----
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
+
+# add ssl materials like key, certificates for the server
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+
+ts.Disk.remap_config.AddLine(
+    'map /post http://127.0.0.1:{0}/post'.format(microserver.Variables.Port)
+)
+
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http',
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.http.cache.http': 0,
+    'proxy.config.http2.active_timeout_in': 3,
+})
+
+# ----
+# Test Cases
+# ----
+
+# Test Case 0:  Trailer
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "nghttp -v --no-dep 'https://127.0.0.1:{0}/post' --trailer 'foo: bar' -d 'post_body'".format(
+    ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(microserver)
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.Streams.stdout = "gold/nghttp_0_stdout.gold"
+tr.StillRunningAfter = microserver


### PR DESCRIPTION
One of the fixes for #6313. As @maskit pointed out on #6401, the VC_EVENT_READ_COMPLETE event was not sent when ATS received trailing header fields after c55001b. It uncovered an issue of  HttpTunnel ( this should be fixed in another PR ).

Update:
Pure END_STREAM DATA frame case could also trigger the crash. Prior to this change, it was ignored like the trailing header with the END_STREAM flag.

TODO: 
- [x] Add AuTest to cover this trailer case. 
I used `nghttp` with `--trailer` option in local tests. But I'm wondering we can use `curl` to avoid increasing dependencies of AuTest.