### PR TITLE
Correctly track H2 post vio bytes

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -213,7 +213,7 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     return;
   }
 
-  if (this->recv_end_stream) {
+  if (this->recv_end_stream || this->read_vio.ntodo() == 0) {
     this->read_vio.nbytes = bufindex;
     this->signal_read_event(VC_EVENT_READ_COMPLETE);
   } else {

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -124,6 +124,8 @@ public:
   bool has_trailing_header() const;
   void set_request_headers(HTTPHdr &h2_headers);
   MIOBuffer *read_vio_writer() const;
+  bool read_vio_done() const;
+  void update_read(int num_written);
 
   //////////////////
   // Variables
@@ -325,4 +327,16 @@ inline MIOBuffer *
 Http2Stream::read_vio_writer() const
 {
   return this->read_vio.get_writer();
+}
+
+inline void
+Http2Stream::update_read(int num_written)
+{
+  read_vio.ndone += num_written;
+}
+
+inline bool
+Http2Stream::read_vio_done() const
+{
+  return read_vio.ntodo() == 0;
 }


### PR DESCRIPTION
Breaking apart the PR in #6401.

This PR concentrates on fixing the read_vio.ndone tracking so the read_complete is sent to the HttpTunnel in a timely manner.  Needs to be applied with PR #6408 to address the crashing issue.