### PR TITLE
Improve logic to cleanup server-session exactly once

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1385,10 +1385,10 @@ HttpTunnel::chain_abort_all(HttpTunnelProducer *p)
     if (c->alive) {
       c->alive     = false;
       c->write_vio = nullptr;
-      c->vc->do_io_close(EHTTP_ERROR);
       update_stats_after_abort(c->vc_type);
+      c->vc->do_io_close(EHTTP_ERROR);
+      c->vc = nullptr;
     }
-
     if (c->self_producer) {
       // Must snip the link before recursively
       // freeing to avoid looks introduced by
@@ -1410,8 +1410,9 @@ HttpTunnel::chain_abort_all(HttpTunnelProducer *p)
       p->self_consumer->alive = false;
     }
     p->read_vio = nullptr;
-    p->vc->do_io_close(EHTTP_ERROR);
     update_stats_after_abort(p->vc_type);
+    p->vc->do_io_close(EHTTP_ERROR);
+    p->vc = nullptr;
   }
 }
 


### PR DESCRIPTION
Breaking apart the PR in #6401.  This one includes the logic to better ensure that the server_session is closed and deleted in a timely manner.  The crash we were seeing was due to a server_session staying around after the HttpSM had been deleted.  The inactivity cop would execute the handleEvent on the deleted HttpSM continuation.