### PR TITLE
Change gold files to be less restrictive 

### DIFF
--- a/tests/gold_tests/pluginTest/uri_signing/gold/200.gold
+++ b/tests/gold_tests/pluginTest/uri_signing/gold/200.gold
@@ -1,13 +1,3 @@
 ``
-> GET `` HTTP/1.1
-> User-Agent: curl/``
-> Host: somehost``
-> Accept: */*
-> Proxy-Connection: ``
-``
 < HTTP/1.1 200 OK
-< Content-Length: ``
-< Date: ``
-< Proxy-Connection: ``
-< Server: ATS/``
 ``

--- a/tests/gold_tests/pluginTest/uri_signing/gold/403.gold
+++ b/tests/gold_tests/pluginTest/uri_signing/gold/403.gold
@@ -1,16 +1,3 @@
 ``
-> GET `` HTTP/1.1
-> User-Agent: curl/``
-> Host: somehost``
-> Accept: */*
-> Proxy-Connection: ``
-``
 < HTTP/1.1 403 Forbidden
-< Date: ``
-< Proxy-Connection: ``
-< Server: ATS/``
-< Cache-Control: no-store
-< Content-Type: text/html
-< Content-Language: en
-< Content-Length: ``
 ``


### PR DESCRIPTION
Some of the headers the gold files use in the tests can be in a different order