### PR TITLE
Updating the autest version pin to 1.7.4.

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -24,7 +24,7 @@ autopep8 = "*"
 pyflakes = "*"
 
 [packages]
-autest = "==1.7.3"
+autest = "==1.7.4"
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"
 dnslib = "*"


### PR DESCRIPTION
(cherry picked from commit 60e6ace5c4c6908a0081bcbb2d5af197ab8a30c0)

I was seeing the issue locally during our autest runs of comparison tests on stderr being checked against stdout. This has been fixed in 1.7.4