### PR TITLE
Optimize data structure for client SSL_CTX objects.

### DIFF
--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -30,10 +30,18 @@
  ****************************************************************************/
 #pragma once
 
+#include <cstdint>
+#include <new>
+#include <type_traits>
+#include <cstring>
+#include <string_view>
+#include <unordered_map>
+
 #include <openssl/rand.h>
 
 #include "tscore/ink_inet.h"
 #include "tscore/IpMap.h"
+#include <tscore/HashFNV.h>
 
 #include "ProxyConfig.h"
 
@@ -41,6 +49,214 @@
 #include "YamlSNIConfig.h"
 
 #include "P_SSLUtils.h"
+
+namespace SSLUtilsImpl
+{
+// An array of const instances of T.  T must be copyable.  The length of the array is fixed at the time of instance
+// creation.  The array associated with an instance will have the same value as the array passed to the make()
+// static member function.
+template <typename T, bool THasEq = false> class DurableConstArray
+{
+public:
+  // Lifetime of array associated with an instance of this class.
+  enum Duration {
+    PERMANENT,         // Longer than this instance or instance this instance is copied or moved to.
+    UNOWNED_TRANSIENT, // Only guaranteed to be as long as this instance.
+    OWNED_IN_HEAP      // Dynamically allocated and deleted when this instance is destroyed.
+  };
+
+  DurableConstArray() {}
+
+  ~DurableConstArray()
+  {
+    if (OWNED_IN_HEAP == _duration) {
+      for (std::size_t i = 0; i < _size; ++i) {
+        _ptr[i].~T();
+      }
+      delete[] reinterpret_cast<const char *>(_ptr);
+    }
+  }
+
+  // Use this member function for construction.
+  static DurableConstArray
+  make(Duration d, T const *ptr, std::size_t size)
+  {
+    DurableConstArray dc;
+    dc._ptr      = size ? ptr : nullptr;
+    dc._size     = ptr ? size : 0;
+    dc._duration = dc._size ? d : PERMANENT;
+    return dc;
+  }
+
+  DurableConstArray(const DurableConstArray &that)
+  {
+    _size = that._size;
+    if (PERMANENT == that._duration) {
+      _duration = PERMANENT;
+      _ptr      = that._ptr;
+    } else {
+      _duration     = OWNED_IN_HEAP;
+      char *p       = new char[sizeof(T) * _size];
+      _ptr          = reinterpret_cast<T *>(p);
+      std::size_t i = 0;
+      try {
+        for (; i < _size; ++i, p += sizeof(T)) {
+          ::new (p) T(that._ptr[i]);
+        }
+      } catch (...) {
+        while (i) {
+          _ptr[--i].~T();
+        }
+        throw;
+      }
+    }
+  }
+
+  DurableConstArray(DurableConstArray &&that)
+  {
+    _duration = that._duration;
+    _ptr      = that._ptr;
+    _size     = that._size;
+
+    ::new (&that) DurableConstArray();
+  }
+
+  DurableConstArray &
+  operator=(const DurableConstArray &that)
+  {
+    if (this != &that) {
+      this->~DurableConstArray();
+
+      ::new (this) DurableConstArray(that);
+    }
+    return *this;
+  }
+
+  DurableConstArray &
+  operator=(DurableConstArray &&that)
+  {
+    this->~DurableConstArray();
+
+    _duration = that._duration;
+    _ptr      = that._ptr;
+    _size     = that._size;
+
+    ::new (&that) DurableConstArray();
+
+    return *this;
+  }
+
+  Duration
+  duration() const
+  {
+    return _duration;
+  }
+  T const *
+  data() const
+  {
+    return _ptr;
+  }
+  std::size_t
+  size() const
+  {
+    return _size;
+  }
+
+  friend typename std::enable_if<THasEq, bool>::type
+  operator==(DurableConstArray const &a, DurableConstArray const &b)
+  {
+    if (a._size != b._size) {
+      return false;
+    }
+    if (a._ptr == b._ptr) {
+      return true;
+    }
+    if (!(a._ptr && b._ptr)) {
+      return false;
+    }
+    for (std::size_t i = 0; i < a._size; ++i) {
+      if (a._ptr[i] != b._ptr[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  friend typename std::enable_if<THasEq, bool>::type
+  operator!=(DurableConstArray const &a, DurableConstArray const &b)
+  {
+    return !(a == b);
+  }
+
+private:
+  Duration _duration{PERMANENT};
+  T const *_ptr{nullptr}; // Array associated with this instance.
+  std::size_t _size{0};   // Dimenstion of array.
+};
+
+// A Key class for the unordered_map instances below that avoids unnecessary heap use.
+class TwoCStrKey
+{
+public:
+  TwoCStrKey() {}
+
+  TwoCStrKey(char const *major, char const *minor) : _major(_make(major)), _minor(_make(minor)) {}
+
+  friend bool
+  operator==(TwoCStrKey const &a, TwoCStrKey const &b)
+  {
+    if (a._major != b._major) {
+      return false;
+    }
+    return a._minor == b._minor;
+  }
+
+  std::string_view
+  major() const
+  {
+    return std::string_view(_major.data(), _major.size());
+  }
+  std::string_view
+  minor() const
+  {
+    return std::string_view(_minor.data(), _minor.size());
+  }
+
+  friend struct TwoCStrKeyHash;
+
+private:
+  using Comp = DurableConstArray<char, true>;
+
+  Comp _major, _minor;
+
+  Comp
+  _make(char const *cStr)
+  {
+    if (!cStr || !*cStr) {
+      return Comp();
+    }
+    return Comp::make(Comp::UNOWNED_TRANSIENT, cStr, std::strlen(cStr));
+  }
+};
+
+struct TwoCStrKeyHash {
+  std::size_t
+  operator()(TwoCStrKey const &k) const
+  {
+    ATSHash32FNV1a h;
+
+    h.update(k._major.data(), k._major.size());
+    h.update(k._minor.data(), k._minor.size());
+
+    // ATSHash32FNV1a::final() does nothing, no need to call.
+
+    return h.get();
+  }
+};
+
+} // end namespace SSLUtilsImpl
+
+using SSLUtilsTwoCStrKey = SSLUtilsImpl::TwoCStrKey;
 
 struct SSLCertLookup;
 struct ssl_ticket_key_block;
@@ -134,8 +350,8 @@ struct SSLConfigParams : public ConfigInfo {
   // The first level maps from CA bundle file&path to next level map;
   // The second level maps from cert&key to actual SSL_CTX;
   // The second level map owns the client SSL_CTX objects and is responsible for cleaning them up
-  using CTX_MAP = std::unordered_map<std::string, shared_SSL_CTX>;
-  mutable std::unordered_map<std::string, CTX_MAP> top_level_ctx_map;
+  using CTX_MAP = std::unordered_map<SSLUtilsTwoCStrKey, shared_SSL_CTX, SSLUtilsImpl::TwoCStrKeyHash>;
+  mutable std::unordered_map<SSLUtilsTwoCStrKey, CTX_MAP, SSLUtilsImpl::TwoCStrKeyHash> top_level_ctx_map;
   mutable ink_mutex ctxMapLock;
 
   shared_SSL_CTX getClientSSL_CTX() const;

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -688,9 +688,8 @@ shared_SSL_CTX
 SSLConfigParams::getCTX(const char *client_cert, const char *key_file, const char *ca_bundle_file, const char *ca_bundle_path) const
 {
   shared_SSL_CTX client_ctx = nullptr;
-  std::string top_level_key, ctx_key;
-  ts::bwprint(top_level_key, "{}:{}", ca_bundle_file, ca_bundle_path);
-  ts::bwprint(ctx_key, "{}:{}", client_cert, key_file);
+  SSLUtilsImpl::TwoCStrKey top_level_key(ca_bundle_file, ca_bundle_path);
+  SSLUtilsImpl::TwoCStrKey ctx_key(client_cert, key_file);
 
   auto ctx_map_iter = top_level_ctx_map.find(top_level_key);
   if (ctx_map_iter != top_level_ctx_map.end()) {


### PR DESCRIPTION
The purpose is to eliminate heap allocations/deallocations currently necessary simply to look up a context object.