### PR TITLE
URI Sig Null Check for Clang Warning

### DIFF
--- a/plugins/experimental/uri_signing/normalize.c
+++ b/plugins/experimental/uri_signing/normalize.c
@@ -218,7 +218,7 @@ normalize_uri(const char *uri, int uri_ct, char *normal_uri, int normal_ct)
   const char *uri_end  = uri + uri_ct;
   const char *buff_end = normal_uri + normal_ct;
 
-  if (normal_uri && normal_ct < uri_ct + 1) {
+  if ((normal_uri == null) || (normal_uri && normal_ct < uri_ct + 1)) {
     PluginDebug("Buffer to Normalize URI not large enough.");
     return -1;
   }


### PR DESCRIPTION
This commit adds a missing null check in the uri normalization function.
This was caught by the clang analyzer.