### PR TITLE
Issue #6400 - Add config option to enable/disable dynamic plugin reload feature 

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3988,6 +3988,11 @@ Plug-in Configuration
 
    Specifies the location of |TS| plugins.
 
+.. ts:cv:: CONFIG proxy.config.plugin.dynamic_reload_mode INT 1
+
+   Enables (``1``) or disables (``0``) the dynamic reload feature for remap
+   plugins (`remap.config`). Global plugins (`plugin.config`) do not have dynamic reload feature yet.
+
 SOCKS Processor
 ===============
 

--- a/doc/developer-guide/design-documents/reloading-plugins.en.rst
+++ b/doc/developer-guide/design-documents/reloading-plugins.en.rst
@@ -30,6 +30,8 @@ configuration reload, i.e.::
 
   traffic_ctl config reload
 
+This feature is enabled by default. It can be turned off by setting the configuration variable :ts:cv:`proxy.config.plugin.dynamic_reload_mode` to ``0`` in :file:`records.config`. When the feature is turned off, once ATS is started one will be able load only one version of a plugin, and re-loading the same plugin would do nothing.
+
 Although plugin reloading should be transparent to plugin developers, the following are some design considerations
 and implementation details for this feature.
 
@@ -175,3 +177,7 @@ be reused by 'global' plugins in the future.
 To make sure plugins are still loaded while their code is still in use there is reference counting done around ``PluginDso``
 which inherits ``RefCountObj`` and implements ``acquire()`` and ``release()`` methods which are called by ``TSCreateCont``,
 ``TSVConnCreate`` and ``TSDestroyCont``.
+
+Other notes
+-----------
+When this feature for dynamic plugin reload is turned on (:ts:cv:`proxy.config.plugin.dynamic_reload_mode` is set to ``1``), there is one pitfall users should be aware of. Since "global" plugins do not support this feature while the "remap" plugins do, if a plugin is used as a global plugin as well as a remap plugin, there will be two different copies of the plugin loaded in memory with no state shared between them.

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1050,6 +1050,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.url_remap.pristine_host_hdr", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.plugin.dynamic_reload_mode", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  ,
 
   //##############################################################################
   //#

--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -34,6 +34,33 @@
 
 #define MAX_PLUGIN_ARGS 64
 
+static PluginDynamicReloadMode plugin_dynamic_reload_mode = REMAP_PLUGIN_DYNAMIC_RELOAD_ON;
+
+bool
+isPluginDynamicReloadEnabled()
+{
+  return plugin_dynamic_reload_mode == REMAP_PLUGIN_DYNAMIC_RELOAD_ON;
+}
+
+void
+parsePluginDynamicReloadConfig()
+{
+  int int_plugin_dynamic_reload_mode;
+  REC_ReadConfigInteger(int_plugin_dynamic_reload_mode, "proxy.config.plugin.dynamic_reload_mode");
+  plugin_dynamic_reload_mode = (PluginDynamicReloadMode)int_plugin_dynamic_reload_mode;
+  if (plugin_dynamic_reload_mode < PLUGIN_DYNAMIC_RELOAD_MODE_MIN || plugin_dynamic_reload_mode > PLUGIN_DYNAMIC_RELOAD_MODE_MAX) {
+    Warning("proxy.config.plugin.dynamic_reload_mode out of range. using default value.");
+    plugin_dynamic_reload_mode = REMAP_PLUGIN_DYNAMIC_RELOAD_ON;
+  }
+  Note("Initialized plugin_dynamic_reload_mode: %d", plugin_dynamic_reload_mode);
+}
+
+void
+parsePluginConfig()
+{
+  parsePluginDynamicReloadConfig();
+}
+
 static const char *plugin_dir = ".";
 
 using init_func_t = void (*)(int, char **);

--- a/proxy/Plugin.h
+++ b/proxy/Plugin.h
@@ -26,6 +26,18 @@
 #include <string>
 #include "tscore/List.h"
 
+enum PluginDynamicReloadMode {
+  PLUGIN_DYNAMIC_RELOAD_MODE_MIN = 0,
+  PLUGIN_DYNAMIC_RELOAD_OFF      = 0,
+  REMAP_PLUGIN_DYNAMIC_RELOAD_ON = 1,
+  PLUGIN_DYNAMIC_RELOAD_MODE_MAX = 1
+};
+
+// read records.config to parse plugin related configs
+void parsePluginConfig();
+
+bool isPluginDynamicReloadEnabled();
+
 struct PluginRegInfo {
   PluginRegInfo();
   ~PluginRegInfo();

--- a/proxy/http/remap/PluginDso.h
+++ b/proxy/http/remap/PluginDso.h
@@ -43,6 +43,8 @@ namespace fs = ts::file;
 #include "I_EventSystem.h"
 #include "tscpp/util/IntrusiveDList.h"
 
+#include "Plugin.h"
+
 class PluginThreadContext : public RefCountObj
 {
 public:
@@ -69,6 +71,7 @@ public:
   const fs::path &effectivePath() const;
   const fs::path &runtimePath() const;
   time_t modTime() const;
+  void *dlOpenHandle() const;
 
   /* List used by the plugin factory */
   using self_type  = PluginDso; ///< Self reference type.
@@ -89,6 +92,7 @@ public:
   void incInstanceCount();
   void decInstanceCount();
   int instanceCount();
+  bool isDynamicReloadEnabled() const;
 
   class LoadedPlugins : public RefCountObj
   {
@@ -96,7 +100,7 @@ public:
     LoadedPlugins() : _mutex(new_ProxyMutex()) {}
     void add(PluginDso *plugin);
     void remove(PluginDso *plugin);
-    PluginDso *findByEffectivePath(const fs::path &path);
+    PluginDso *findByEffectivePath(const fs::path &path, bool dynamicReloadEnabled);
     void indicatePreReload(const char *factoryId);
     void indicatePostReload(bool reloadSuccessful, const std::unordered_map<PluginDso *, int> &pluginUsed, const char *factoryId);
 

--- a/proxy/http/remap/PluginFactory.h
+++ b/proxy/http/remap/PluginFactory.h
@@ -94,7 +94,7 @@ public:
   PluginFactory &setRuntimeDir(const fs::path &runtimeDir);
   PluginFactory &addSearchDir(const fs::path &searchDir);
 
-  RemapPluginInst *getRemapPlugin(const fs::path &configPath, int argc, char **argv, std::string &error);
+  RemapPluginInst *getRemapPlugin(const fs::path &configPath, int argc, char **argv, std::string &error, bool dynamicReloadEnabled);
 
   virtual const char *getUuid();
   void clean(std::string &error);
@@ -104,7 +104,7 @@ public:
   void indicatePostReload(bool reloadSuccessful);
 
 protected:
-  PluginDso *findByEffectivePath(const fs::path &path);
+  PluginDso *findByEffectivePath(const fs::path &path, bool dynamicReloadEnabled);
   fs::path getEffectivePath(const fs::path &configPath);
 
   std::vector<fs::path> _searchDirs; /** @brief ordered list of search paths where we look for plugins */

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -817,7 +817,8 @@ remap_load_plugin(const char **argv, int argc, url_mapping *mp, char *errbuf, in
     REC_ReadConfigInteger(elevate_access, "proxy.config.plugin.load_elevated");
     ElevateAccess access(elevate_access ? ElevateAccess::FILE_PRIVILEGE : 0);
 
-    pi = rewrite->pluginFactory.getRemapPlugin(ts::file::path(const_cast<const char *>(c)), parc, pargv, error);
+    pi = rewrite->pluginFactory.getRemapPlugin(ts::file::path(const_cast<const char *>(c)), parc, pargv, error,
+                                               isPluginDynamicReloadEnabled());
   } // done elevating access
 
   bool result = true;

--- a/proxy/http/remap/unit-tests/plugin_testing_common.cc
+++ b/proxy/http/remap/unit-tests/plugin_testing_common.cc
@@ -50,3 +50,24 @@ getTemporaryDir()
 
   return fs::path(mkdtemp(dirNameTemplate));
 }
+
+// implement functions to support unit-testing of option to enable/disable dynamic reload of plugins
+static PluginDynamicReloadMode plugin_dynamic_reload_mode = REMAP_PLUGIN_DYNAMIC_RELOAD_ON;
+
+bool
+isPluginDynamicReloadEnabled()
+{
+  return plugin_dynamic_reload_mode == REMAP_PLUGIN_DYNAMIC_RELOAD_ON;
+}
+
+void
+enablePluginDynamicReload()
+{
+  plugin_dynamic_reload_mode = REMAP_PLUGIN_DYNAMIC_RELOAD_ON;
+}
+
+void
+disablePluginDynamicReload()
+{
+  plugin_dynamic_reload_mode = PLUGIN_DYNAMIC_RELOAD_OFF;
+}

--- a/proxy/http/remap/unit-tests/plugin_testing_common.h
+++ b/proxy/http/remap/unit-tests/plugin_testing_common.h
@@ -101,3 +101,7 @@ void PrintToStdErr(const char *fmt, ...);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+// functions to support unit-testing of option to enable/disable dynamic reload of plugins
+void enablePluginDynamicReload();
+void disablePluginDynamicReload();

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2042,6 +2042,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     // initialize logging (after event and net processor)
     Log::init(remote_management_flag ? 0 : Log::NO_REMOTE_MANAGEMENT);
 
+    (void)parsePluginConfig();
+
     // Init plugins as soon as logging is ready.
     (void)plugin_init(); // plugin.config
 


### PR DESCRIPTION
Adds config option "proxy.config.plugin.dynamic_reload_mode" which can take values 0 (disable) or 1 (enable). The default value will be 0.
This will be applicable only for remap plugins (global plugins do not yet support dynamic reload).
The assumption is that if dynamic reload is disabled, it will be disabled for all plugins specified in remap.config.
This is applicable for ATS 9 (branch 9.0.x)