### PR TITLE
Add log line length configuration to records.config.en.rst

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2916,6 +2916,43 @@ Logging Configuration
    :file:`logging.yaml` configuration file. If this is a relative
    path, |TS| loads it relative to the ``SYSCONFDIR`` directory.
 
+.. ts:cv:: CONFIG proxy.config.log.max_line_size INT 9216
+   :units: bytes
+
+   This controls the maximum line length for ``ASCII`` formatted log entries.
+   This applies to ``ASCII_PIPE`` and ``ASCII`` file logs, *unless*
+   :ts:cv:`proxy.config.log.ascii_buffer_size` is also specified and the value
+   of ``ascii_buffer_size`` is larger than ``max_line_size``: in that case,
+   ``max_line_size`` only applies to ``ASCII_PIPE`` logs while
+   ``ascii_buffer_size`` will apply to ``ASCII`` (non-pipe) log files.
+
+.. ts:cv:: CONFIG proxy.config.log.ascii_buffer_size INT 36864
+   :units: bytes
+
+   This controls the maximum line length for ``ASCII`` formatted log entries
+   that are non-pipe log files. If this value is smaller than
+   :ts:cv:`proxy.config.log.max_line_size`, then the latter will be used for
+   both ``ASCII`` and ``ASCII_PIPE`` log files. If both ``max_line_size`` and
+   ``ascii_buffer_size`` are set, then ``max_line_size`` will be used for
+   ``ASCII_PIPE`` logs while ``ascii_buffer_size`` will be used for ``ASCII``
+   (non-pipe) log files.  This all might seem complicated, but just keep in
+   mind that the intention of ``ascii_buffer_size`` is to simply provide a way
+   for the user to configure different ``ASCII`` and ``ASCII_PIPE`` maximum
+   line lengths.
+
+.. ts:cv:: CONFIG proxy.config.log.log_buffer_size INT 9216
+   :reloadable:
+   :units: bytes
+
+   This is an orthogonal mechanism from :ts:cv:`proxy.config.log.max_line_size`
+   and :ts:cv:`proxy.config.log.ascii_buffer_size` for limiting line length
+   size by constraining the log entry buffer to a particular amount of memory.
+   Unlike the above two configurations, ``log_buffer_size`` applies to both
+   binary and ``ASCII`` log file entries.  For ``ASCII`` log files, if a maximum
+   log size is set via both the above mechanisms and by ``log_buffer_size``,
+   then the smaller of the two configurations will be applied to the line
+   length.
+
 Diagnostic Logging Configuration
 ================================
 

--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -800,34 +800,13 @@ cquuh Client Request Unmapped URL host from the client request.
 Line Length
 ===========
 
-The maximum line size for a log entry can be configured via the following parameters:
+The maximum line size for a log entry can be configured via the following
+parameters, the details of which are documented in the linked
+:file:`records.config` descriptions:
 
-- :ts:cv:`proxy.config.log.max_line_size`: This controls the maximum line
-  length for ASCII formatted log entries. This applies to ``ASCII_PIPE`` and
-  ``ASCII`` file logs, *unless* :ts:cv:`proxy.config.log.ascii_buffer_size` is
-  also specified and the value of :ts:cv:`ascii_buffer_size` is larger than
-  :ts:cv:`max_line_size`: in that case, :ts:cv:`max_line_size` only applies to
-  ``ASCII_PIPE`` logs while :ts:cv:`ascii_buffer_size` will apply to ``ASCII``
-  (non-pipe) log files.
-
-- :ts:cv:`proxy.config.log.ascii_buffer_size`: This controls the maximum line
-  length for ASCII formatted log entries that are non-pipe log files. If this
-  value is smaller than :ts:cv:`proxy.config.log.max_line_size`, then the
-  latter will be used for both ``ASCII`` and ``ASCII_PIPE`` log files. If both
-  :ts:cv:`max_line_size` and :ts:cv:`ascii_buffer_size` are set, then
-  :ts:cv:`max_line_size` will be used for ``ASCII_PIPE`` logs while
-  :ts:cv:`ascii_buffer_size` will be used for ``ASCII`` (non-pipe) log files.
-  This all might seem complicated, but just keep in mind that the intention of
-  :ts:cv:`ascii_buffer_size` is to simply provide a way for the user to
-  configure different ``ASCII`` and ``ASCII_PIPE`` maximum line lengths.
-
-- :ts:cv:`proxy.config.log.log_buffer_size`: This is an orthogonal mechanism
-  for limiting line length size by constraining the log entry buffer to a
-  particular amount of memory. Unlike the above two configurations,
-  :ts:cv:`log_buffer_size` applies to both binary and ASCII log file entries.
-  For ASCII log files, if a maximum log size is set via the above mechanisms
-  and by :ts:cv:`log_buffer_size`, then the smaller of the two configurations
-  will be applied to the line length.
+- :ts:cv:`proxy.config.log.max_line_size`
+- :ts:cv:`proxy.config.log.ascii_buffer_size`
+- :ts:cv:`proxy.config.log.log_buffer_size`
 
 Log Field Slicing
 =================


### PR DESCRIPTION
I added documentation for logging configuration parameters here:
https://github.com/apache/trafficserver/pull/6305

@SolidWallOfCode pointed out that this introduced warnings in the build of the docs that I didn't notice in my builds. I thought I was using formatting directives, but instead I was adding undefined references. This fixes that by adding the definitions for the references to records.config.en.rst. While doing this, however, it doesn't make sense to duplicate this documentation in formatting.en.rst and in records.config.en.rst. Instead I'm adding references to the latter in the former.

Notice that this is mostly a cut and paste of the text from one location to the other.