### PR TITLE
Fixed chunked_encoding test to work with OpenSSL 1.0.2

### DIFF
--- a/tests/gold_tests/chunked_encoding/smuggle-client.c
+++ b/tests/gold_tests/chunked_encoding/smuggle-client.c
@@ -93,7 +93,7 @@ main(int argc, char *argv[])
     exit(EXIT_FAILURE);
   }
 
-  SSL_CTX *client_ctx = SSL_CTX_new(TLS_method());
+  SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
   SSL *ssl            = SSL_new(client_ctx);
 
   SSL_set_fd(ssl, sfd);


### PR DESCRIPTION
This is a fix for the autests that have been hanging for over a week now.

The Godaddy boxes are running OpenSSL 1.0.2 and the chunked_encoding test requires OpenSSL 1.1.1 APIs in smuggle-client.c.

This was broken by #6397