### PR TITLE
Compatibility fixes for gcc 9.2, Fedora 31 on ATS 7.1.x.

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -190,8 +190,13 @@ struct AIOThreadInfo : public Continuation {
     (void)event;
     (void)e;
 #if TS_USE_HWLOC
+#if HWLOC_API_VERSION >= 0x20000
+    hwloc_set_membind(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_INTERLEAVE,
+                      HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_BYNODESET);
+#else
     hwloc_set_membind_nodeset(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_INTERLEAVE,
                               HWLOC_MEMBIND_THREAD);
+#endif
 #endif
     aio_thread_main(this);
     delete this;

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -170,7 +170,7 @@ public:
   /// at every call site. We also need this because we have ats_scoped_str members.
   Span(Span const &that)
   {
-    memcpy(this, &that, reinterpret_cast<intptr_t>(&(static_cast<Span *>(0)->pathname)));
+    memcpy(static_cast<void *>(this), &that, reinterpret_cast<intptr_t>(&(static_cast<Span *>(0)->pathname)));
     if (that.pathname)
       pathname = ats_strdup(that.pathname);
     if (that.hash_base_string)

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -104,17 +104,26 @@ alloc_numa_stack(hwloc_cpuset_t cpuset, size_t stacksize)
   }
 
   if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
-    // Let's temporarily set the memory binding to our destination NUMA node
+// Let's temporarily set the memory binding to our destination NUMA node
+#if HWLOC_API_VERSION >= 0x20000
+    hwloc_set_membind(ink_get_topology(), nodeset, mem_policy, HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_BYNODESET);
+#else
     hwloc_set_membind_nodeset(ink_get_topology(), nodeset, mem_policy, HWLOC_MEMBIND_THREAD);
+#endif
   }
 
   // Alloc our stack
   stack = alloc_stack(stacksize);
 
   if (mem_policy != HWLOC_MEMBIND_DEFAULT) {
-    // Now let's set it back to default for this thread.
+// Now let's set it back to default for this thread.
+#if HWLOC_API_VERSION >= 0x20000
+    hwloc_set_membind(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_DEFAULT,
+                      HWLOC_MEMBIND_THREAD | HWLOC_MEMBIND_BYNODESET);
+#else
     hwloc_set_membind_nodeset(ink_get_topology(), hwloc_topology_get_topology_nodeset(ink_get_topology()), HWLOC_MEMBIND_DEFAULT,
                               HWLOC_MEMBIND_THREAD);
+#endif
   }
 
   hwloc_bitmap_free(nodeset);

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -133,6 +133,7 @@ struct Connection {
 
   virtual ~Connection();
   Connection();
+  Connection(Connection const &that) = delete;
 
   /// Default options.
   static NetVCOptions const DEFAULT_OPTIONS;
@@ -142,12 +143,17 @@ struct Connection {
    */
   void move(Connection &);
 
-private:
-  // Don't want copy constructors to avoid having the deconstructor on
-  // temporarly copies close the file descriptor too soon. Use move instead
-  Connection(Connection const &);
-
 protected:
+  /** Assignment operator.
+   *
+   * @param that Source object.
+   * @return @a this
+   *
+   * This is protected because it is not safe in the general case, but is valid for
+   * certain subclasses. Those provide a public assignemnt that depends on this method.
+   */
+  Connection &operator=(Connection const &that) = default;
+
   void _cleanup();
 };
 

--- a/lib/ts/ContFlags.h
+++ b/lib/ts/ContFlags.h
@@ -41,7 +41,8 @@ class ContFlags
 public:
   enum flags { DEBUG_OVERRIDE = 0, DISABLE_PLUGINS = 1, LAST_FLAG };
 
-  ContFlags() : raw_flags(0) {}
+  ContFlags() {}
+  ContFlags(ContFlags const &that) = default;
   ContFlags(uint32_t in_flags) : raw_flags(in_flags) {}
   void
   set_flags(uint32_t new_flags)

--- a/lib/ts/CryptoHash.h
+++ b/lib/ts/CryptoHash.h
@@ -41,6 +41,7 @@ union CryptoHash {
     u64[0] = 0;
     u64[1] = 0;
   }
+  constexpr CryptoHash(CryptoHash const &that) = default;
 
   /// Assignment - bitwise copy.
   CryptoHash &

--- a/lib/ts/MemView.h
+++ b/lib/ts/MemView.h
@@ -107,6 +107,7 @@ protected:
 public:
   /// Default constructor (empty buffer).
   constexpr MemView();
+  constexpr MemView(self const &that) = default;
 
   /** Construct explicitly with a pointer and size.
    */
@@ -322,6 +323,7 @@ protected:
 public:
   /// Default constructor (empty buffer).
   constexpr StringView();
+  constexpr StringView(self const &that) = default;
 
   /** Construct explicitly with a pointer and size.
    */

--- a/lib/ts/ink_defs.cc
+++ b/lib/ts/ink_defs.cc
@@ -33,7 +33,6 @@
 #if defined(linux) || defined(freebsd) || defined(darwin)
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #endif
 #if defined(linux)
 #include <sys/utsname.h>

--- a/lib/ts/ink_platform.h
+++ b/lib/ts/ink_platform.h
@@ -174,8 +174,10 @@ typedef unsigned int in_addr_t;
 #include <sys/sysinfo.h>
 #endif
 
-#ifdef HAVE_SYS_SYSCTL_H
+#if defined(darwin) || defined(freebsd)
+#if HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
+#endif
 #endif
 
 #ifdef HAVE_SYS_SYSTEMINFO_H

--- a/lib/ts/ink_uuid.h
+++ b/lib/ts/ink_uuid.h
@@ -33,8 +33,9 @@ class ATSUuid
 {
 public:
   // Constructors
-  ATSUuid() : _version(TS_UUID_UNDEFINED) {}
-  ATSUuid &operator=(const ATSUuid other);
+  ATSUuid()                              = default;
+  constexpr ATSUuid(ATSUuid const &that) = default;
+  ATSUuid &operator                      =(const ATSUuid other);
 
   // Initialize the UUID from a string
   bool parseString(const char *str);
@@ -122,7 +123,7 @@ private:
   } _uuid;
 
   // This is the typically used visible portion of the UUID
-  TSUuidVersion _version;
+  TSUuidVersion _version = TS_UUID_UNDEFINED;
   char _string[TS_UUID_STRING_LEN + 1];
 
   bool

--- a/lib/tsconfig/NumericType.h
+++ b/lib/tsconfig/NumericType.h
@@ -1,6 +1,3 @@
-# if !defined(TS_NUMERIC_TYPE_HEADER)
-# define TS_NUMERIC_TYPE_HEADER
-
 /** @file
 
     Create a distinct type from a builtin numeric type.
@@ -41,12 +38,14 @@
     limitations under the License.
  */
 
-# include <limits>
+#pragma once
 
-namespace ts {
+#include <limits>
 
+namespace ts
+{
 // Forward declare.
-template < typename T, typename X > class NumericType;
+template <typename T, typename X> class NumericType;
 
 /// @cond NOT_DOCUMENTED
 /** Support template for resolving operator ambiguity.
@@ -65,26 +64,25 @@ template < typename T, typename X > class NumericType;
     @internal Note that we don't have to provide an actual implementation
     for these operators. Funky, isn't it?
 */
-template <
-  typename T, ///< Base numeric type.
-  typename X ///< Distinguishing tag type.
-> class NumericTypeIntOperators {
+template <typename T, ///< Base numeric type.
+          typename X  ///< Distinguishing tag type.
+          >
+class NumericTypeIntOperators
+{
 public:
-    NumericType<T,X>& operator += ( int t );
-    NumericType<T,X>& operator -= ( int t );
+  NumericType<T, X> &operator+=(int t);
+  NumericType<T, X> &operator-=(int t);
 
-    // Must have const and non-const versions.
-    NumericType<T,X> operator +  ( int t );
-    NumericType<T,X> operator -  ( int t );
-    NumericType<T,X> operator +  ( int t ) const;
-    NumericType<T,X> operator -  ( int t ) const;
+  // Must have const and non-const versions.
+  NumericType<T, X> operator+(int t);
+  NumericType<T, X> operator-(int t);
+  NumericType<T, X> operator+(int t) const;
+  NumericType<T, X> operator-(int t) const;
 };
 
-template < typename T, typename X > NumericType<T,X>
-operator + ( int t, NumericTypeIntOperators<T,X> const& );
+template <typename T, typename X> NumericType<T, X> operator+(int t, NumericTypeIntOperators<T, X> const &);
 
-template < typename T, typename X > NumericType<T,X>
-operator - ( int t, NumericTypeIntOperators<T,X> const& );
+template <typename T, typename X> NumericType<T, X> operator-(int t, NumericTypeIntOperators<T, X> const &);
 
 /// @endcond
 
@@ -93,91 +91,189 @@ operator - ( int t, NumericTypeIntOperators<T,X> const& );
     @internal One issue is that this is not a POD and so doesn't work
     with @c printf. I will need to investigate what that would take.
  */
-template <
-  typename T, ///< Base numeric type.
-  typename X ///< Distinguishing tag type.
-> class NumericType : public NumericTypeIntOperators<T,X> {
+template <typename T, ///< Base numeric type.
+          typename X  ///< Distinguishing tag type.
+          >
+class NumericType : public NumericTypeIntOperators<T, X>
+{
 public:
-    typedef T raw_type; //!< Base builtin type.
-    typedef NumericType self; //!< Self reference type.
+  using raw_type  = T;           ///< Base type.
+  using self_type = NumericType; ///< Self reference type.
 
-    /// @cond NOT_DOCUMENTED
-    // Need to import these to avoid compiler problems.
-    using NumericTypeIntOperators<T,X>::operator +=;
-    using NumericTypeIntOperators<T,X>::operator -=;
-    using NumericTypeIntOperators<T,X>::operator +;
-    using NumericTypeIntOperators<T,X>::operator -;
-    /// @endcond
+  /// @cond NOT_DOCUMENTED
+  // Need to import these to avoid compiler problems.
+  using NumericTypeIntOperators<T, X>::operator+=;
+  using NumericTypeIntOperators<T, X>::operator-=;
+  using NumericTypeIntOperators<T, X>::operator+;
+  using NumericTypeIntOperators<T, X>::operator-;
+  /// @endcond
 
-    /// Default constructor, uninitialized.
-    NumericType();
-    //! Construct from implementation type.
-    NumericType(
-      raw_type const t ///< Initialized value.
-    );
-    //! Assignment from implementation type.
-    NumericType & operator = (raw_type const t);
-    //! Self assignment.
-    NumericType & operator = (self const& that);
+  /// Default constructor, uninitialized.
+  NumericType();
+  //! Construct from implementation type.
+  constexpr NumericType(raw_type const t ///< Initialized value.
+  );
+  /// Copy constructor.
+  constexpr NumericType(self_type const &that) = default;
 
-    /// User conversion to implementation type.
-    /// @internal If we have just a single const method conversion to a copy
-    /// of the @c raw_type then the stream operators don't work. Only a CR
-    /// conversion operator satisifies the argument matching.
-    operator raw_type const& () const { return _t; }
-    /// User conversion to implementation type.
-    operator raw_type& () { return _t; }
-    /// Explicit conversion to host type
-    raw_type raw() const { return _t; }
+  //! Assignment from implementation type.
+  NumericType &operator=(raw_type const t);
+  //! Self assignment.
+  NumericType &operator=(self_type const &that);
 
-    // User conversions to raw type provide the standard comparison operators.
-    self& operator += ( self const& that );
-    self& operator -= ( self const& that );
+  /// User conversion to implementation type.
+  /// @internal If we have just a single const method conversion to a copy
+  /// of the @c raw_type then the stream operators don't work. Only a CR
+  /// conversion operator satisifies the argument matching.
+  operator raw_type const &() const { return _t; }
+  /// User conversion to implementation type.
+  operator raw_type &() { return _t; }
+  /// Explicit conversion to host type
+  raw_type
+  raw() const
+  {
+    return _t;
+  }
 
-    self& operator += ( raw_type t );
-    self& operator -= ( raw_type t );
+  // User conversions to raw type provide the standard comparison operators.
+  self_type &operator+=(self_type const &that);
+  self_type &operator-=(self_type const &that);
 
-    self operator +  ( self const& that );
-    self operator -  ( self const& that );
+  self_type &operator+=(raw_type t);
+  self_type &operator-=(raw_type t);
 
-    self operator +  ( raw_type t );
-    self operator -  ( raw_type t );
+  self_type operator+(self_type const &that);
+  self_type operator-(self_type const &that);
 
-    self& operator ++();
-    self operator ++(int);
-    self& operator --();
-    self operator --(int);
+  self_type operator+(raw_type t);
+  self_type operator-(raw_type t);
+
+  self_type &operator++();
+  self_type operator++(int);
+  self_type &operator--();
+  self_type operator--(int);
 
 private:
-    // coverity[uninit_member]
-    raw_type   _t;
+  raw_type _t;
 };
 
 // Method definitions.
-template < typename T, typename X > NumericType<T,X>::NumericType() { }
-template < typename T, typename X > NumericType<T,X>::NumericType(raw_type const t) : _t(t) { }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator = (raw_type const t) { _t = t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator = (self const& that) { _t = that._t; return *this; }
+// coverity[uninit_ctor]
+template <typename T, typename X> NumericType<T, X>::NumericType() {}
+template <typename T, typename X> constexpr NumericType<T, X>::NumericType(raw_type const t) : _t(t) {}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator=(raw_type const t)
+{
+  _t = t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator=(self_type const &that)
+{
+  _t = that._t;
+  return *this;
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator += ( self const& that ) { _t += that._t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator -= ( self const& that ) { _t -= that._t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator +  ( self const& that ) { return self(_t + that._t); }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator -  ( self const& that ) { return self(_t - that._t); }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator+=(self_type const &that)
+{
+  _t += that._t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator-=(self_type const &that)
+{
+  _t -= that._t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator+(self_type const &that)
+{
+  return self_type(_t + that._t);
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator-(self_type const &that)
+{
+  return self_type(_t - that._t);
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator += ( raw_type t ) { _t += t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator -= ( raw_type t ) { _t -= t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator +  ( raw_type t ) { return self(_t + t); }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator -  ( raw_type t ) { return self(_t - t); }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator+=(raw_type t)
+{
+  _t += t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator-=(raw_type t)
+{
+  _t -= t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator+(raw_type t)
+{
+  return self_type(_t + t);
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator-(raw_type t)
+{
+  return self_type(_t - t);
+}
 
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator ++() { ++_t; return *this; }
-template < typename T, typename X > NumericType<T,X>& NumericType<T,X>::operator --() { --_t; return *this; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator ++(int) { self tmp(*this); ++_t; return tmp; }
-template < typename T, typename X > NumericType<T,X> NumericType<T,X>::operator --(int) { self tmp(*this); --_t; return tmp; }
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator++()
+{
+  ++_t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X> &
+NumericType<T, X>::operator--()
+{
+  --_t;
+  return *this;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator++(int)
+{
+  self_type tmp(*this);
+  ++_t;
+  return tmp;
+}
+template <typename T, typename X>
+NumericType<T, X>
+NumericType<T, X>::operator--(int)
+{
+  self_type tmp(*this);
+  --_t;
+  return tmp;
+}
 
-template < typename T, typename X > NumericType<T,X> operator +  ( T const& lhs, NumericType<T,X> const& rhs ) { return rhs + lhs; }
-template < typename T, typename X > NumericType<T,X> operator -  ( T const& lhs, NumericType<T,X> const& rhs ) { return NumericType<T,X>(lhs - rhs.raw()); }
+template <typename T, typename X>
+NumericType<T, X>
+operator+(T const &lhs, NumericType<T, X> const &rhs)
+{
+  return rhs + lhs;
+}
+template <typename T, typename X>
+NumericType<T, X>
+operator-(T const &lhs, NumericType<T, X> const &rhs)
+{
+  return NumericType<T, X>(lhs - rhs.raw());
+}
 
 /* ----------------------------------------------------------------------- */
-} /* end namespace ts */
+} // namespace ts
 /* ----------------------------------------------------------------------- */
-# endif // TS_NUMERIC_TYPE_HEADER

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -465,14 +465,15 @@ HTTPValTE *http_parse_te(const char *buf, int len, Arena *arena);
 class HTTPVersion
 {
 public:
-  HTTPVersion();
+  HTTPVersion()                        = default;
+  HTTPVersion(HTTPVersion const &that) = default;
   explicit HTTPVersion(int32_t version);
   HTTPVersion(int ver_major, int ver_minor);
 
   void set(HTTPVersion ver);
   void set(int ver_major, int ver_minor);
 
-  HTTPVersion &operator=(const HTTPVersion &hv);
+  HTTPVersion &operator=(const HTTPVersion &hv) = default;
   int operator==(const HTTPVersion &hv) const;
   int operator!=(const HTTPVersion &hv) const;
   int operator>(const HTTPVersion &hv) const;
@@ -481,7 +482,7 @@ public:
   int operator<=(const HTTPVersion &hv) const;
 
 public:
-  int32_t m_version;
+  int32_t m_version{HTTP_VERSION(1, 0)};
 };
 
 class IOBufferReader;
@@ -659,13 +660,6 @@ private:
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline HTTPVersion::HTTPVersion() : m_version(HTTP_VERSION(1, 0))
-{
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
 inline HTTPVersion::HTTPVersion(int32_t version) : m_version(version)
 {
 }
@@ -693,17 +687,6 @@ inline void
 HTTPVersion::set(int ver_major, int ver_minor)
 {
   m_version = HTTP_VERSION(ver_major, ver_minor);
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline HTTPVersion &
-HTTPVersion::operator=(const HTTPVersion &hv)
-{
-  m_version = hv.m_version;
-
-  return *this;
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
While building on Fedora 31, with g++ 9.2.1, I ran in to a number of compile time issues. All of them have been fixed in ATS 9, this is essentially a back port of those fixes to 7.1.x.

The fix for `NumericType.h` was a bit more involved so I copied the ATS 9 version then ran `clang-format` on it.