### PR TITLE
Refactor the NextHopSelectionStrategy interface to simplify it.

### DIFF
--- a/include/ts/nexthop.h
+++ b/include/ts/nexthop.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Implementation of various round robin nexthop selections strategies.
+  Traffic Server SDK API header file
 
   @section license License
 
@@ -19,26 +19,30 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
+
+  @section developers Developers
+
+  NextHop plugin interface.
+
  */
 
 #pragma once
 
-#include <mutex>
-#include "NextHopSelectionStrategy.h"
+#include <ts/apidefs.h>
 
-class NextHopRoundRobin : public NextHopSelectionStrategy
-{
-  std::mutex _mutex;
-  uint32_t latched_index = 0;
+// plugin callback commands.
+enum NHCmd { NH_MARK_UP, NH_MARK_DOWN };
 
-public:
-  NextHopRoundRobin() = delete;
-  NextHopRoundRobin(const std::string_view &name, const NHPolicyType &policy) : NextHopSelectionStrategy(name, policy) {}
-  ~NextHopRoundRobin();
-  bool
-  Init(const YAML::Node &n)
-  {
-    return NextHopSelectionStrategy::Init(n);
-  }
-  void findNextHop(TSHttpTxn txnp, void *ih = nullptr, time_t now = 0) override;
+struct NHHealthStatus {
+  virtual bool isNextHopAvailable(TSHttpTxn txn, const char *hostname, void *ih = nullptr)                                    = 0;
+  virtual void markNextHop(TSHttpTxn txn, const char *hostname, const NHCmd status, void *ih = nullptr, const time_t now = 0) = 0;
+  virtual ~NHHealthStatus() {}
+};
+
+struct NHPluginStrategy {
+  virtual void findNextHop(TSHttpTxn txnp, void *ih = nullptr)   = 0;
+  virtual bool nextHopExists(TSHttpTxn txnp, void *ih = nullptr) = 0;
+  virtual ~NHPluginStrategy() {}
+
+  NHHealthStatus *healthStatus;
 };

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#include "ts/nexthop.h"
 #include "tscore/ink_platform.h"
 
 #include <strings.h>
@@ -207,8 +208,7 @@ findParent(HttpTransact::State *s)
   url_mapping *mp = s->url_map.getMapping();
 
   if (mp && mp->strategy) {
-    return mp->strategy->findNextHop(s->state_machine->sm_id, s->parent_result, s->request_data, s->txn_conf->parent_fail_threshold,
-                                     s->txn_conf->parent_retry_time);
+    return mp->strategy->findNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine));
   } else if (s->parent_params) {
     return s->parent_params->findParent(&s->request_data, &s->parent_result, s->txn_conf->parent_fail_threshold,
                                         s->txn_conf->parent_retry_time);
@@ -223,8 +223,7 @@ markParentDown(HttpTransact::State *s)
   url_mapping *mp = s->url_map.getMapping();
 
   if (mp && mp->strategy) {
-    return mp->strategy->markNextHopDown(s->state_machine->sm_id, s->parent_result, s->txn_conf->parent_fail_threshold,
-                                         s->txn_conf->parent_retry_time);
+    return mp->strategy->markNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine), s->parent_result.hostname, NH_MARK_DOWN);
   } else if (s->parent_params) {
     return s->parent_params->markParentDown(&s->parent_result, s->txn_conf->parent_fail_threshold, s->txn_conf->parent_retry_time);
   }
@@ -237,7 +236,7 @@ markParentUp(HttpTransact::State *s)
 {
   url_mapping *mp = s->url_map.getMapping();
   if (mp && mp->strategy) {
-    return mp->strategy->markNextHopUp(s->state_machine->sm_id, s->parent_result);
+    return mp->strategy->markNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine), s->parent_result.hostname, NH_MARK_UP);
   } else if (s->parent_params) {
     return s->parent_params->markParentUp(&s->parent_result);
   }
@@ -250,7 +249,7 @@ parentExists(HttpTransact::State *s)
 {
   url_mapping *mp = s->url_map.getMapping();
   if (mp && mp->strategy) {
-    return mp->strategy->nextHopExists(s->state_machine->sm_id);
+    return mp->strategy->nextHopExists(reinterpret_cast<TSHttpTxn>(s->state_machine));
   } else if (s->parent_params) {
     return s->parent_params->parentExists(&s->request_data);
   }
@@ -265,8 +264,7 @@ nextParent(HttpTransact::State *s)
   url_mapping *mp = s->url_map.getMapping();
   if (mp && mp->strategy) {
     // NextHop only has a findNextHop() function.
-    return mp->strategy->findNextHop(s->state_machine->sm_id, s->parent_result, s->request_data, s->txn_conf->parent_fail_threshold,
-                                     s->txn_conf->parent_retry_time);
+    return mp->strategy->findNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine));
   } else if (s->parent_params) {
     return s->parent_params->nextParent(&s->request_data, &s->parent_result, s->txn_conf->parent_fail_threshold,
                                         s->txn_conf->parent_retry_time);

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -41,6 +41,7 @@ libhttp_remap_a_SOURCES = \
 	NextHopSelectionStrategy.cc \
 	NextHopConsistentHash.h \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	NextHopRoundRobin.h \
 	NextHopRoundRobin.cc \
 	NextHopStrategyFactory.h \
@@ -149,6 +150,7 @@ test_NextHopStrategyFactory_SOURCES = \
 	NextHopStrategyFactory.cc \
 	NextHopRoundRobin.cc \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	unit-tests/test_NextHopStrategyFactory.cc \
 	unit-tests/nexthop_test_stubs.cc
 
@@ -179,6 +181,7 @@ test_NextHopRoundRobin_SOURCES = \
 	NextHopStrategyFactory.cc \
 	NextHopRoundRobin.cc \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	unit-tests/test_NextHopRoundRobin.cc \
 	unit-tests/nexthop_test_stubs.cc
 
@@ -208,6 +211,7 @@ test_NextHopConsistentHash_SOURCES = \
 	NextHopSelectionStrategy.cc \
 	NextHopStrategyFactory.cc \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	NextHopRoundRobin.cc \
 	unit-tests/test_NextHopConsistentHash.cc \
 	unit-tests/nexthop_test_stubs.cc

--- a/proxy/http/remap/NextHopConsistentHash.h
+++ b/proxy/http/remap/NextHopConsistentHash.h
@@ -49,6 +49,5 @@ public:
   NextHopConsistentHash(const std::string_view name, const NHPolicyType &policy) : NextHopSelectionStrategy(name, policy) {}
   ~NextHopConsistentHash();
   bool Init(const YAML::Node &n);
-  void findNextHop(const uint64_t sm_id, ParentResult &result, RequestData &rdata, const uint64_t fail_threshold,
-                   const uint64_t retry_time, time_t now = 0) override;
+  void findNextHop(TSHttpTxn txnp, void *ih = nullptr, time_t now = 0) override;
 };

--- a/proxy/http/remap/NextHopHealthStatus.cc
+++ b/proxy/http/remap/NextHopHealthStatus.cc
@@ -1,0 +1,146 @@
+/** @file
+
+  Implementation of nexthop consistent hash selections strategies.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "NextHopSelectionStrategy.h"
+#include "HttpSM.h"
+
+/**
+ * initialize the host_map
+ */
+void
+NextHopHealthStatus::insert(std::vector<std::shared_ptr<HostRecord>> &hosts)
+{
+  for (uint32_t ii = 0; ii < hosts.size(); ii++) {
+    std::shared_ptr<HostRecord> h = hosts[ii];
+    host_map.emplace(std::make_pair(h->hostname, h));
+    NH_Debug(NH_DEBUG_TAG, "inserting %s into host_map", h->hostname.c_str());
+  }
+}
+
+/**
+ * check that hostname is available for use.
+ */
+bool
+NextHopHealthStatus::isNextHopAvailable(TSHttpTxn txn, const char *hostname, void *ih)
+{
+  HttpSM *sm    = reinterpret_cast<HttpSM *>(txn);
+  int64_t sm_id = sm->sm_id;
+
+  auto iter = host_map.find(hostname);
+
+  if (iter == host_map.end()) {
+    NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] no host named %s found in host_map", sm_id, hostname);
+    return false;
+  }
+
+  std::shared_ptr p = iter->second;
+  return p->available;
+}
+
+/**
+ * mark up or down the indicated host
+ */
+void
+NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const NHCmd status, void *ih, const time_t now)
+{
+  time_t _now;
+  now == 0 ? _now = time(nullptr) : _now = now;
+
+  HttpSM *sm              = reinterpret_cast<HttpSM *>(txn);
+  ParentResult result     = sm->t_state.parent_result;
+  int64_t sm_id           = sm->sm_id;
+  int64_t fail_threshold  = sm->t_state.txn_conf->parent_fail_threshold;
+  int64_t retry_time      = sm->t_state.txn_conf->parent_retry_time;
+  uint32_t new_fail_count = 0;
+
+  // make sure we're called back with a result structure for a parent
+  // that is being retried.
+  if (status == NH_MARK_UP) {
+    ink_assert(result.retry == true);
+  }
+  if (result.result != PARENT_SPECIFIED) {
+    return;
+  }
+
+  // No failover exists when the result is set through the API.
+  if (result.is_api_result()) {
+    return;
+  }
+
+  auto iter = host_map.find(hostname);
+  if (iter == host_map.end()) {
+    NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] no host named %s found in host_map", sm_id, hostname);
+    return;
+  }
+
+  std::shared_ptr h = iter->second;
+
+  switch (status) {
+  // Mark the host up.
+  case NH_MARK_UP:
+    if (!h->available) {
+      h->set_available();
+      NH_Note("[%" PRId64 "] http parent proxy %s restored", sm_id, hostname);
+    }
+    break;
+  // Mark the host down.
+  case NH_MARK_DOWN:
+    if (h->failedAt == 0 || result.retry == true) {
+      { // lock guard
+        std::lock_guard<std::mutex> guard(h->_mutex);
+        if (h->failedAt == 0) {
+          h->failedAt = _now;
+          if (result.retry == false) {
+            new_fail_count = h->failCount = 1;
+          }
+        } else if (result.retry == true) {
+          h->failedAt = _now;
+        }
+      } // end lock guard
+      NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", h->hostname.c_str());
+    } else {
+      int old_count = 0;
+      // if the last failure was outside the retry window, set the failcount to 1 and failedAt to now.
+      { // lock guard
+        std::lock_guard<std::mutex> lock(h->_mutex);
+        if ((h->failedAt + retry_time) < static_cast<unsigned>(_now)) {
+          h->failCount = 1;
+          h->failedAt  = _now;
+        } else {
+          old_count = h->failCount = 1;
+        }
+        new_fail_count = old_count + 1;
+      } // end of lock_guard
+      NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] Parent fail count increased to %d for %s", sm_id, new_fail_count, h->hostname.c_str());
+    }
+
+    if (new_fail_count >= fail_threshold) {
+      h->set_unavailable();
+      NH_Note("[%" PRId64 "] Failure threshold met failcount:%d >= threshold:%" PRId64 ", http parent proxy %s marked down", sm_id,
+              new_fail_count, fail_threshold, h->hostname.c_str());
+      NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] NextHop %s marked unavailable, h->available=%s", sm_id, h->hostname.c_str(),
+               (h->available) ? "true" : "false");
+    }
+    break;
+  }
+}

--- a/proxy/http/remap/unit-tests/nexthop_test_stubs.h
+++ b/proxy/http/remap/unit-tests/nexthop_test_stubs.h
@@ -52,34 +52,21 @@ void PrintToStdErr(const char *fmt, ...);
 #endif /* __cplusplus */
 
 #include "ControlMatcher.h"
-struct TestData : public HttpRequestData {
-  std::string hostname;
-  sockaddr client_ip;
-  sockaddr server_ip;
+#include "ParentSelection.h"
 
-  TestData()
-  {
-    client_ip.sa_family = AF_INET;
-    memset(client_ip.sa_data, 0, sizeof(client_ip.sa_data));
-  }
-  const char *
-  get_host()
-  {
-    return hostname.c_str();
-  }
-  sockaddr const *
-  get_ip()
-  {
-    return &server_ip;
-  }
-  sockaddr const *
-  get_client_ip()
-  {
-    return &client_ip;
-  }
-  char *
-  get_string()
-  {
-    return nullptr;
-  }
+struct trans_config {
+  int64_t parent_retry_time     = 0;
+  int64_t parent_fail_threshold = 0;
+  trans_config() {}
 };
+
+struct trans_state {
+  ParentResult parent_result;
+  HttpRequestData request_data;
+  trans_config txn_conf;
+  trans_state() {}
+};
+
+class HttpSM;
+
+void build_request(int64_t sm_id, HttpSM *sm, sockaddr_in *ip, const char *os_hostname, sockaddr const *dest_ip);

--- a/proxy/http/remap/unit-tests/test_NextHopConsistentHash.cc
+++ b/proxy/http/remap/unit-tests/test_NextHopConsistentHash.cc
@@ -31,6 +31,7 @@
 #include <catch.hpp> /* catch unit-test framework */
 #include <yaml-cpp/yaml.h>
 
+#include "HttpSM.h"
 #include "nexthop_test_stubs.h"
 #include "NextHopSelectionStrategy.h"
 #include "NextHopStrategyFactory.h"
@@ -41,7 +42,7 @@ extern int cmd_disable_pfreelist;
 
 SCENARIO("Testing NextHopConsistentHash class, using policy 'consistent_hash'", "[NextHopConsistentHash]")
 {
-  // We need this to build a HdrHeap object in br();
+  // We need this to build a HdrHeap object in build_request();
   // No thread setup, forbid use of thread local allocators.
   cmd_disable_pfreelist = true;
   // Get all of the HTTP WKS items populated.
@@ -66,18 +67,11 @@ SCENARIO("Testing NextHopConsistentHash class, using policy 'consistent_hash'", 
 
     WHEN("requests are received.")
     {
-      HttpRequestData request;
-      ParentResult result;
-      TestData rdata;
-      rdata.xact_start        = time(nullptr);
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-
       // need to run these checks in succession so there
       // are no host status state changes.
       //
       // These tests simulate failed requests using a selected host.
-      // markNextHopDown() is called by the state machine when
+      // markNextHop() is called by the state machine when
       // there is a request failure due to a connection error or
       // timeout.  the 'result' struct has the information on the
       // host used in the failed request and when called, marks the
@@ -88,92 +82,96 @@ SCENARIO("Testing NextHopConsistentHash class, using policy 'consistent_hash'", 
       //
       THEN("when making requests and taking nodes down.")
       {
+        HttpSM sm;
+        ParentResult *result = &sm.t_state.parent_result;
+        TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
+
         REQUIRE(nhf.strategies_loaded == true);
         REQUIRE(strategy != nullptr);
 
         // first request.
-        br(&request, "rabbit.net");
-        result.reset();
-        strategy->findNextHop(10001, result, request, fail_threshold, retry_time);
+        build_request(10001, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
 
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
-        // mark down p1.foo.com.  markNextHopDown looks at the 'result'
+        // mark down p1.foo.com.  markNextHop looks at the 'result'
         // and uses the host index there mark down the host selected
         // from a
-        strategy->markNextHopDown(10001, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // second request - reusing the ParentResult from the last request
         // simulating a failure triggers a search for another parent, not firstcall.
-        br(&request, "rabbit.net");
-        strategy->findNextHop(10002, result, request, fail_threshold, retry_time);
+        build_request(10002, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
 
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // mark down p2.foo.com
-        strategy->markNextHopDown(10002, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // third request - reusing the ParentResult from the last request
         // simulating a failure triggers a search for another parent, not firstcall.
-        br(&request, "rabbit.net");
-        strategy->findNextHop(10003, result, request, fail_threshold, retry_time);
+        build_request(10003, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
 
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "s2.bar.com") == 0);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "s2.bar.com") == 0);
 
         // mark down s2.bar.com
-        strategy->markNextHopDown(10003, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // fourth request - reusing the ParentResult from the last request
         // simulating a failure triggers a search for another parent, not firstcall.
-        br(&request, "rabbit.net");
-        strategy->findNextHop(10004, result, request, fail_threshold, retry_time);
+        build_request(10004, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
 
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "s1.bar.com") == 0);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "s1.bar.com") == 0);
 
         // mark down s1.bar.com.
-        strategy->markNextHopDown(10004, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // fifth request - reusing the ParentResult from the last request
         // simulating a failure triggers a search for another parent, not firstcall.
-        br(&request, "rabbit.net");
-        strategy->findNextHop(10005, result, request, fail_threshold, retry_time);
+        build_request(10005, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
 
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "q1.bar.com") == 0);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "q1.bar.com") == 0);
 
         // mark down q1.bar.com
-        strategy->markNextHopDown(10005, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
         // sixth request - reusing the ParentResult from the last request
         // simulating a failure triggers a search for another parent, not firstcall.
-        br(&request, "rabbit.net");
-        strategy->findNextHop(10006, result, request, fail_threshold, retry_time);
+        build_request(10006, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
 
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "q2.bar.com") == 0);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "q2.bar.com") == 0);
 
         // mark down q2.bar.com
-        strategy->markNextHopDown(10006, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
         // seventh request - reusing the ParentResult from the last request
         // simulating a failure triggers a search for another parent, not firstcall.
-        br(&request, "rabbit.net");
-        strategy->findNextHop(10007, result, request, fail_threshold, retry_time);
+        build_request(10007, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
 
-        CHECK(result.result == ParentResultType::PARENT_DIRECT);
-        CHECK(result.hostname == nullptr);
+        CHECK(result->result == ParentResultType::PARENT_DIRECT);
+        CHECK(result->hostname == nullptr);
 
         // sleep and test that q2 is becomes retryable;
         time_t now = time(nullptr) + 5;
 
         // eighth request - reusing the ParentResult from the last request
         // simulating a failure triggers a search for another parent, not firstcall.
-        br(&request, "rabbit.net");
-        strategy->findNextHop(10008, result, request, fail_threshold, retry_time, now);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "q2.bar.com") == 0);
+        build_request(10008, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp, nullptr, now);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "q2.bar.com") == 0);
       }
     }
   }
@@ -181,7 +179,7 @@ SCENARIO("Testing NextHopConsistentHash class, using policy 'consistent_hash'", 
 
 SCENARIO("Testing NextHopConsistentHash class (all firstcalls), using policy 'consistent_hash'", "[NextHopConsistentHash]")
 {
-  // We need this to build a HdrHeap object in br();
+  // We need this to build a HdrHeap object in build_request();
   // No thread setup, forbid use of thread local allocators.
   cmd_disable_pfreelist = true;
   // Get all of the HTTP WKS items populated.
@@ -211,12 +209,9 @@ SCENARIO("Testing NextHopConsistentHash class (all firstcalls), using policy 'co
     // state changes induced by using multiple WHEN() and THEN()
     WHEN("initial requests are made and hosts are unavailable .")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
-      rdata.xact_start = time(nullptr);
-      HttpRequestData request;
-      ParentResult result;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("when making requests and taking nodes down.")
       {
@@ -224,58 +219,58 @@ SCENARIO("Testing NextHopConsistentHash class (all firstcalls), using policy 'co
         REQUIRE(strategy != nullptr);
 
         // first request.
-        br(&request, "rabbit.net");
-        result.reset();
-        strategy->findNextHop(20001, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(20001, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // mark down p1.foo.com
-        strategy->markNextHopDown(20001, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
         // second request
-        br(&request, "rabbit.net");
-        result.reset();
-        strategy->findNextHop(20002, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(20002, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // mark down p2.foo.com
-        strategy->markNextHopDown(20002, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // third request
-        br(&request, "rabbit.net");
-        result.reset();
-        strategy->findNextHop(20003, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "s2.bar.com") == 0);
+        result->reset();
+        build_request(20003, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "s2.bar.com") == 0);
 
         // mark down s2.bar.com
-        strategy->markNextHopDown(20003, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // fourth request
-        br(&request, "rabbit.net");
-        result.reset();
-        strategy->findNextHop(20004, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "s1.bar.com") == 0);
+        result->reset();
+        build_request(20004, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "s1.bar.com") == 0);
 
         // mark down s1.bar.com
-        strategy->markNextHopDown(20004, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // fifth request
-        br(&request, "rabbit.net/asset1");
-        result.reset();
-        strategy->findNextHop(20005, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "q1.bar.com") == 0);
+        result->reset();
+        build_request(20005, &sm, nullptr, "rabbit.net/asset1", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "q1.bar.com") == 0);
 
         // sixth request - wait and p1 should now become available
         time_t now = time(nullptr) + 5;
-        br(&request, "rabbit.net");
-        result.reset();
-        strategy->findNextHop(20006, result, request, fail_threshold, retry_time, now);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        result->reset();
+        build_request(20006, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp, nullptr, now);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
       }
     }
   }
@@ -283,7 +278,7 @@ SCENARIO("Testing NextHopConsistentHash class (all firstcalls), using policy 'co
 
 SCENARIO("Testing NextHopConsistentHash class (alternating rings), using policy 'consistent_hash'", "[NextHopConsistentHash]")
 {
-  // We need this to build a HdrHeap object in br();
+  // We need this to build a HdrHeap object in build_request();
   // No thread setup, forbid use of thread local allocators.
   cmd_disable_pfreelist = true;
   // Get all of the HTTP WKS items populated.
@@ -308,12 +303,9 @@ SCENARIO("Testing NextHopConsistentHash class (alternating rings), using policy 
     // makeing requests and marking down hosts with a config set for alternating ring mode.
     WHEN("requests are made in a config set for alternating rings and hosts are marked down.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
-      rdata.xact_start = time(nullptr);
-      HttpRequestData request;
-      ParentResult result;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("expect the following results when making requests and marking hosts down.")
       {
@@ -321,73 +313,74 @@ SCENARIO("Testing NextHopConsistentHash class (alternating rings), using policy 
         REQUIRE(strategy != nullptr);
 
         // first request.
-        br(&request, "bunny.net/asset1");
-        result.reset();
-        strategy->findNextHop(30001, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "c2.foo.com") == 0);
+        result->reset();
+        build_request(30001, &sm, nullptr, "bunny.net/asset1", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "c2.foo.com") == 0);
 
         // simulated failure, mark c2 down and retry request
-        strategy->markNextHopDown(30001, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // second request
-        br(&request, "bunny.net.net/asset1");
-        strategy->findNextHop(30002, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "c3.bar.com") == 0);
+        build_request(30002, &sm, nullptr, "bunny.net.net/asset1", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "c3.bar.com") == 0);
 
         // mark down c3.bar.com
-        strategy->markNextHopDown(30002, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // third request
-        br(&request, "bunny.net/asset2");
-        result.reset();
-        strategy->findNextHop(30003, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "c6.bar.com") == 0);
+        build_request(30003, &sm, nullptr, "bunny.net/asset2", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "c6.bar.com") == 0);
 
         // just mark it down and retry request
-        strategy->markNextHopDown(30003, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
         // fourth request
-        br(&request, "bunny.net/asset2");
-        strategy->findNextHop(30004, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "c1.foo.com") == 0);
+        build_request(30004, &sm, nullptr, "bunny.net/asset2", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "c1.foo.com") == 0);
 
         // mark it down
-        strategy->markNextHopDown(30004, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
         // fifth request - new request
-        br(&request, "bunny.net/asset3");
-        result.reset();
-        strategy->findNextHop(30005, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "c4.bar.com") == 0);
+        build_request(30005, &sm, nullptr, "bunny.net/asset3", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "c4.bar.com") == 0);
 
         // mark it down and retry
-        strategy->markNextHopDown(30005, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
         // sixth request
-        br(&request, "bunny.net/asset3");
-        result.reset();
-        strategy->findNextHop(30006, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "c5.bar.com") == 0);
+        result->reset();
+        build_request(30006, &sm, nullptr, "bunny.net/asset3", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "c5.bar.com") == 0);
 
         // mark it down
-        strategy->markNextHopDown(30006, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
         // seventh request - new request with all hosts down and go_direct is false.
-        br(&request, "bunny.net/asset4");
-        result.reset();
-        strategy->findNextHop(30007, result, request, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_FAIL);
-        CHECK(result.hostname == nullptr);
+        result->reset();
+        build_request(30007, &sm, nullptr, "bunny.net/asset4", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_FAIL);
+        CHECK(result->hostname == nullptr);
 
         // eighth request - retry after waiting for the retry window to expire.
         time_t now = time(nullptr) + 5;
-        br(&request, "bunny.net/asset4");
-        result.reset();
-        strategy->findNextHop(30008, result, request, fail_threshold, retry_time, now);
-        CHECK(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "c2.foo.com") == 0);
+        result->reset();
+        build_request(30008, &sm, nullptr, "bunny.net/asset4", nullptr);
+        strategy->findNextHop(txnp, nullptr, now);
+        CHECK(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "c2.foo.com") == 0);
       }
     }
   }

--- a/proxy/http/remap/unit-tests/test_NextHopRoundRobin.cc
+++ b/proxy/http/remap/unit-tests/test_NextHopRoundRobin.cc
@@ -31,6 +31,7 @@
 #include <catch.hpp> /* catch unit-test framework */
 #include <yaml-cpp/yaml.h>
 
+#include "HttpSM.h"
 #include "nexthop_test_stubs.h"
 #include "NextHopSelectionStrategy.h"
 #include "NextHopStrategyFactory.h"
@@ -56,9 +57,9 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-strict'", "[NextHopR
 
     WHEN("making requests using a 'rr-strict' policy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("then testing rr-strict.")
       {
@@ -66,79 +67,89 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-strict'", "[NextHopR
         REQUIRE(strategy != nullptr);
 
         // first request.
-        ParentResult result;
-        strategy->findNextHop(10000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10001, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // second request.
-        result.reset();
-        strategy->findNextHop(10001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10002, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // third request.
-        result.reset();
-        strategy->findNextHop(10002, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10003, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // did not reset result, kept it as last parent selected was p1.fo.com, mark it down and we should only select p2.foo.com
-        strategy->markNextHopDown(10003, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // fourth request, p1 is down should select p2.
-        result.reset();
-        strategy->findNextHop(10004, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10004, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // fifth request, p1 is down should still select p2.
-        result.reset();
-        strategy->findNextHop(10005, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10005, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // mark down p2.
-        strategy->markNextHopDown(10006, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // fifth request, p1 and p2 are both down, should get s1.bar.com from failover ring.
-        result.reset();
-        strategy->findNextHop(10007, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "s1.bar.com") == 0);
+        build_request(10006, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "s1.bar.com") == 0);
 
         // sixth request, p1 and p2 are still down, should get s1.bar.com from failover ring.
-        result.reset();
-        strategy->findNextHop(10008, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "s1.bar.com") == 0);
+        build_request(10007, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "s1.bar.com") == 0);
 
         // mark down s1.
-        strategy->markNextHopDown(10009, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // seventh request, p1, p2, s1 are down, should get s2.bar.com from failover ring.
-        result.reset();
-        strategy->findNextHop(10010, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "s2.bar.com") == 0);
+        build_request(10008, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "s2.bar.com") == 0);
 
         // mark down s2.
-        strategy->markNextHopDown(10011, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // eighth request, p1, p2, s1, s2 are down, should get PARENT_DIRECT as go_direct is true
-        result.reset();
-        strategy->findNextHop(10012, result, rdata, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_DIRECT);
+        build_request(10009, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_DIRECT);
 
         // check that nextHopExists() returns false when all parents are down.
-        CHECK(strategy->nextHopExists(10012) == false);
+        CHECK(strategy->nextHopExists(txnp) == false);
 
         // change the request time to trigger a retry.
         time_t now = (time(nullptr) + 5);
 
         // ninth request, p1 and p2 are still down, should get p2.foo.com as it will be retried
-        result.reset();
-        strategy->findNextHop(10013, result, rdata, fail_threshold, retry_time, now);
-        REQUIRE(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10010, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp, nullptr, now);
+        REQUIRE(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // tenth request, p1 should now be retried.
-        result.reset();
-        strategy->findNextHop(10014, result, rdata, fail_threshold, retry_time, now);
-        REQUIRE(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10011, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp, nullptr, now);
+        REQUIRE(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
       }
     }
   }
@@ -164,9 +175,9 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'first-live'", "[NextHop
 
     WHEN("when using a strategy with a 'first-live' policy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("when making requests and marking down hosts.")
       {
@@ -174,30 +185,33 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'first-live'", "[NextHop
         REQUIRE(strategy != nullptr);
 
         // first request.
-        ParentResult result;
-        strategy->findNextHop(20000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10012, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // second request.
-        result.reset();
-        strategy->findNextHop(20001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10013, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // mark down p1.
-        strategy->markNextHopDown(20002, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, NH_MARK_DOWN);
 
         // third request.
-        result.reset();
-        strategy->findNextHop(20003, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10014, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // change the request time to trigger a retry.
         time_t now = (time(nullptr) + 5);
 
         // fourth request, p1 should be marked for retry
-        result.reset();
-        strategy->findNextHop(20004, result, rdata, fail_threshold, retry_time, now);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10015, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp, nullptr, now);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
       }
     }
   }
@@ -217,6 +231,10 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-ip'", "[NextHopRound
     sa2.sin_port   = 10001;
     sa2.sin_family = AF_INET;
     inet_pton(AF_INET, "192.168.1.2", &(sa2.sin_addr));
+    HttpSM sm;
+    ParentResult *result = &sm.t_state.parent_result;
+    TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
+
     WHEN("the config is loaded.")
     {
       THEN("then the 'rr-strict' strategy is ready.")
@@ -229,10 +247,6 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-ip'", "[NextHopRound
 
     WHEN("using the 'rr-strict' strategy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
-
       THEN("when making requests and marking down hosts.")
       {
         REQUIRE(nhf.strategies_loaded == true);
@@ -240,41 +254,44 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-ip'", "[NextHopRound
 
         // call and test parentExists(), this call should not affect
         // findNextHop() round robin strict results
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // first request.
-        memcpy(&rdata.client_ip, &sa1, sizeof(sa1));
-        ParentResult result;
-        strategy->findNextHop(30000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        // memcpy(&rdata.client_ip, &sa1, sizeof(sa1));
+        build_request(10016, &sm, &sa1, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
 
         // call and test parentExists(), this call should not affect
         // findNextHop round robin strict results.
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // second request.
-        memcpy(&rdata.client_ip, &sa2, sizeof(sa2));
-        result.reset();
-        strategy->findNextHop(30001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        // memcpy(&rdata.client_ip, &sa2, sizeof(sa2));
+        build_request(10017, &sm, &sa2, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // call and test parentExists(), this call should not affect
         // findNextHop() round robin strict results
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // third  request with same client ip, result should still be p3
-        result.reset();
-        strategy->findNextHop(30002, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10018, &sm, &sa2, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // call and test parentExists(), this call should not affect
         // findNextHop() round robin strict results.
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // fourth  request with same client ip and same result indicating a failure should result in p4
         // being selected.
-        strategy->findNextHop(30003, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        build_request(10019, &sm, &sa2, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
       }
     }
   }
@@ -300,9 +317,9 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'latched'", "[NextHopRou
 
     WHEN("using a strategy having a 'latched' policy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("when making requests and marking down hosts.")
       {
@@ -310,27 +327,31 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'latched'", "[NextHopRou
         REQUIRE(strategy != nullptr);
 
         // first request should select p3
-        ParentResult result;
-        strategy->findNextHop(40000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10020, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // second request should select p3
-        result.reset();
-        strategy->findNextHop(40001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10021, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // third request, use previous result to simulate a failure, we should now select p4.
-        strategy->findNextHop(40002, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        build_request(10022, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
 
         // fourth request we should be latched on p4
-        result.reset();
-        strategy->findNextHop(40003, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        build_request(10023, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
 
         // fifth request, use previous result to simulate a failure, we should now select p3.
-        strategy->findNextHop(40004, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10024, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
       }
     }
   }


### PR DESCRIPTION
This is part of a project to add support into Trafficserver for loading and using plugins that may be used for next hop and parent selection.  This PR simplifies the interface that the state machine uses in calling the Next hop selection strategy functionality.  The old interface required many parameters that could be found by looking an the HttpSM object.  So the new interface now gets an opaque pointer to the HttpSM object and can use that to derive all other information required from the state machine.  Nexthop plugins will be able to use this interface and all other API calls as well.   

Refactoring here is the first step in adding in support for Next hop plugins.