### PR TITLE
Avoid a weird name collision between HRW and tscore

### DIFF
--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -69,10 +69,10 @@ public:
   bool res;
 };
 
-class SimpleTokenizerTest : public SimpleTokenizer
+class SimpleTokenizerTest : public HRWSimpleTokenizer
 {
 public:
-  SimpleTokenizerTest(const std::string &line) : SimpleTokenizer(line), res(true)
+  SimpleTokenizerTest(const std::string &line) : HRWSimpleTokenizer(line), res(true)
   {
     std::cout << "Finished tokenizer test: " << line << std::endl;
   }

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -248,7 +248,7 @@ Parser::cond_is_hook(TSHttpHookID &hook) const
   return false;
 }
 
-SimpleTokenizer::SimpleTokenizer(const std::string &original_line)
+HRWSimpleTokenizer::HRWSimpleTokenizer(const std::string &original_line)
 {
   std::string line        = original_line;
   ParserState state       = PARSER_DEFAULT;

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -99,14 +99,14 @@ protected:
   std::vector<std::string> _tokens;
 };
 
-class SimpleTokenizer
+class HRWSimpleTokenizer
 {
 public:
-  explicit SimpleTokenizer(const std::string &line);
+  explicit HRWSimpleTokenizer(const std::string &line);
 
   // noncopyable
-  SimpleTokenizer(const SimpleTokenizer &) = delete;
-  void operator=(const SimpleTokenizer &) = delete;
+  HRWSimpleTokenizer(const HRWSimpleTokenizer &) = delete;
+  void operator=(const HRWSimpleTokenizer &) = delete;
 
   const std::vector<std::string> &
   get_tokens() const

--- a/plugins/header_rewrite/value.cc
+++ b/plugins/header_rewrite/value.cc
@@ -44,7 +44,7 @@ Value::set_value(const std::string &val)
   _value = val;
 
   if (_value.find("%{") != std::string::npos) {
-    SimpleTokenizer tokenizer(_value);
+    HRWSimpleTokenizer tokenizer(_value);
     auto tokens = tokenizer.get_tokens();
 
     for (auto token : tokens) {


### PR DESCRIPTION
There's weird interactions here, a better solution (as discussed and proposed by @bryancall and @randall) is to change parameters to dlopen(). However, I'm running into different issues with that, and it's late in the game to make a change to the core that could break a lot of plugins (maybe).

See also #6445  