### PR TITLE
Revert "Disable the chunked_encoding test"

### DIFF
--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -21,8 +21,7 @@ Test chunked encoding processing
 '''
 # need Curl with HTTP/2
 Test.SkipUnless(
-    Condition.HasCurlFeature('http2'),
-    Condition.HasProgram("xxxZZZxxx", "disable the test until it is working")
+    Condition.HasCurlFeature('http2')
 )
 Test.ContinueOnFail = True
 


### PR DESCRIPTION
This reverts commit a558db594f54f4b706fe319b587eab5d6ed33fd8.

This will reenable the chunked_encoding/chunked_encoding.test.py test.  Hopefully it will work on CI now, it did on the command line on the GoDaddy box.