### PR TITLE
Add log pipe buffer size configuration to ATS 7

### DIFF
--- a/doc/admin-guide/files/logging.config.en.rst
+++ b/doc/admin-guide/files/logging.config.en.rst
@@ -293,6 +293,11 @@ RollingOffsetHr     number      Specifies an hour (from 0 to 23) at which log
                                 :ts:cv:`proxy.config.log.rolling_offset_hr`.
 RollingSizeMb       number      Size, in megabytes, at which log files are
                                 rolled.
+PipeBufferSize      number      The minimum size, in bytes, to set as the
+                                capacity of the FIFO. This only applies to
+                                ``log.pipe`` logging objects. The default value
+                                is 0 which indicates that the system default
+                                size will be used.
 Filters             array of    The optional list of filter objects which
                     filters     restrict the individual events logged.
 CollationHosts      array of    If present, one or more strings specifying the

--- a/doc/admin-guide/logging/examples.en.rst
+++ b/doc/admin-guide/logging/examples.en.rst
@@ -283,7 +283,8 @@ Dual Output to Compact Binary Logs and ASCII Pipes
 This example demonstrates logging the same event data to multiple locations, in
 a hypothetical scenario where we may wish to keep a compact form of our logs
 available for archival purposes, while performing live log analysis on a stream
-of the event data.
+of the event data. By setting ``PipeBufferSize`` to 1048576 we request |TS| to
+set the buffer capacity for the pipe to 1 MB.
 
 .. code:: lua
 
@@ -298,6 +299,7 @@ of the event data.
    log.pipe {
      Format = ourformat,
      Filename = 'streaming_log'
+     PipeBufferSize = 1048576
    }
 
 Filtering Events to ASCII Pipe for Alerting

--- a/proxy/config/logging.config.default
+++ b/proxy/config/logging.config.default
@@ -33,6 +33,7 @@
 --    RollingIntervalSec (number, optional):
 --    RollingOffsetHr (number, optional):
 --    RollingSizeMb (number, optional):
+--    PipeBufferSize (number, optional):
 --    Filters (array of filter objects, optional):
 --    CollationHosts (array of strings, optional):
 --      This parameter may be either a single string or an array of entries.

--- a/proxy/logging/LogFile.h
+++ b/proxy/logging/LogFile.h
@@ -44,7 +44,7 @@ class LogFile : public LogBufferSink, public RefCountObj
 {
 public:
   LogFile(const char *name, const char *header, LogFileFormat format, uint64_t signature, size_t ascii_buffer_size = 4 * 9216,
-          size_t max_line_size = 9216);
+          size_t max_line_size = 9216, int pipe_buffer_size = 0);
   LogFile(const LogFile &);
   ~LogFile();
 
@@ -127,6 +127,7 @@ public:
   uint64_t m_signature;       // signature of log object stored
   size_t m_ascii_buffer_size; // size of ascii buffer
   size_t m_max_line_size;     // size of longest log line (record)
+  int m_pipe_buffer_size;     // this is the size of the pipe buffer set by fcntl
   int m_fd;                   // this could back m_log or a pipe, depending on the situation
 
 public:

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -88,7 +88,7 @@ LogBufferManager::preproc_buffers(LogBufferSink *sink)
 
 LogObject::LogObject(const LogFormat *format, const char *log_dir, const char *basename, LogFileFormat file_format,
                      const char *header, Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec,
-                     int rolling_offset_hr, int rolling_size_mb, bool auto_created)
+                     int rolling_offset_hr, int rolling_size_mb, bool auto_created, int pipe_buffer_size)
   : m_auto_created(auto_created),
     m_alt_filename(nullptr),
     m_flags(0),
@@ -98,7 +98,8 @@ LogObject::LogObject(const LogFormat *format, const char *log_dir, const char *b
     m_rolling_offset_hr(rolling_offset_hr),
     m_rolling_size_mb(rolling_size_mb),
     m_last_roll_time(0),
-    m_buffer_manager_idx(0)
+    m_buffer_manager_idx(0),
+    m_pipe_buffer_size(pipe_buffer_size)
 {
   ink_release_assert(format);
   m_format         = new LogFormat(*format);
@@ -118,7 +119,8 @@ LogObject::LogObject(const LogFormat *format, const char *log_dir, const char *b
   // by default, create a LogFile for this object, if a loghost is
   // later specified, then we will delete the LogFile object
   //
-  m_logFile = new LogFile(m_filename, header, file_format, m_signature, Log::config->ascii_buffer_size, Log::config->max_line_size);
+  m_logFile = new LogFile(m_filename, header, file_format, m_signature, Log::config->ascii_buffer_size, Log::config->max_line_size,
+                          m_pipe_buffer_size);
 
   LogBuffer *b = new LogBuffer(this, Log::config->log_buffer_size);
   ink_assert(b);
@@ -138,7 +140,8 @@ LogObject::LogObject(LogObject &rhs)
     m_signature(rhs.m_signature),
     m_flush_threads(rhs.m_flush_threads),
     m_rolling_interval_sec(rhs.m_rolling_interval_sec),
-    m_last_roll_time(rhs.m_last_roll_time)
+    m_last_roll_time(rhs.m_last_roll_time),
+    m_pipe_buffer_size(rhs.m_pipe_buffer_size)
 {
   m_format         = new LogFormat(*(rhs.m_format));
   m_buffer_manager = new LogBufferManager[m_flush_threads];

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -99,7 +99,7 @@ public:
 
   LogObject(const LogFormat *format, const char *log_dir, const char *basename, LogFileFormat file_format, const char *header,
             Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec = 0, int rolling_offset_hr = 0,
-            int rolling_size_mb = 0, bool auto_created = false);
+            int rolling_size_mb = 0, bool auto_created = false, int pipe_buffer_size = 0);
   LogObject(LogObject &);
   virtual ~LogObject();
 
@@ -297,6 +297,8 @@ private:
   volatile head_p m_log_buffer; // current work buffer
   unsigned m_buffer_manager_idx;
   LogBufferManager *m_buffer_manager;
+
+  int m_pipe_buffer_size;
 
   void generate_filenames(const char *log_dir, const char *basename, LogFileFormat file_format);
   void _setup_rolling(Log::RollingEnabledValues rolling_enabled, int rolling_interval_sec, int rolling_offset_hr,

--- a/tests/gold_tests/autest-site/when.test.ext
+++ b/tests/gold_tests/autest-site/when.test.ext
@@ -1,0 +1,36 @@
+'''
+When extensions.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from autest.api import AddWhenFunction
+import hosts.output as host
+
+
+def FileContains(haystack, needle):
+    with open(haystack) as f:
+        result = needle in f.read()
+
+        host.WriteDebug(
+            ['FileExists', 'when'],
+            "Testing for file content '{0}' in '{1}' : {2}".format(
+                needle, haystack, result))
+
+        return result
+
+
+AddWhenFunction(FileContains)

--- a/tests/gold_tests/logging/log_pipe.test.py
+++ b/tests/gold_tests/logging/log_pipe.test.py
@@ -1,0 +1,184 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Test custom log file format
+'''
+# This test requires Curl and is Linux specific.
+Test.SkipUnless(
+    Condition.HasProgram(
+        "curl", "Curl need to be installed on system for this test to work"),
+    Condition.IsPlatform("linux")
+)
+
+ts_counter = 1
+
+
+def get_ts(logging_config):
+    """
+    Create a Traffic Server process.
+    """
+    global ts_counter
+    ts = Test.MakeATSProcess("ts{}".format(ts_counter))
+    ts_counter += 1
+
+    ts.Disk.records_config.update({
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'log-file',
+        })
+
+    # Since we're only verifying logs and not traffic, we don't need an origin
+    # server. The following will simply deny the requests and emit a log
+    # message.
+    ts.Disk.remap_config.AddLine(
+        'map / http://www.linkedin.com/ @action=deny'
+    )
+
+    ts.Disk.logging_config.AddLines(logging_config)
+
+    return ts
+
+
+#
+# Test 1: Default configured log pipe size.
+#
+tr = Test.AddTestRun()
+pipe_name = "default_pipe_size.pipe"
+ts = get_ts(
+        '''custom = format {{
+      Format = "%<hii> %<hiih>"
+    }}
+
+    log.pipe {{
+      Format = custom,
+      Filename = '{}'
+    }}'''.format(pipe_name).split("\n")
+    )
+pipe_path = os.path.join(ts.Variables.LOGDIR, pipe_name)
+
+ts.Streams.All += Testers.ContainsExpression(
+    "Created named pipe .*{}".format(pipe_name),
+    "Verify that the named pipe was created")
+
+ts.Streams.All += Testers.ContainsExpression(
+    "no readers for pipe .*{}".format(pipe_name),
+    "Verify that no readers for the pipe was detected.")
+
+ts.Streams.All += Testers.ExcludesExpression(
+    "New buffer size for pipe".format(pipe_name),
+    "Verify that the default pipe size was used.")
+
+curl = tr.Processes.Process("client_request", 'curl "http://127.0.0.1:{0}" --verbose'.format(
+    ts.Variables.port))
+
+reader_output = os.path.join(ts.Variables.LOGDIR, "reader_output")
+pipe_reader = tr.Processes.Process("pipe_reader", 'cat {} | tee {}'.format(pipe_path, reader_output))
+curl_ready = tr.Processes.Process("curl_ready", 'sleep 30')
+# In the AuTest environment, it can take more than 10 seconds for the log file
+# to be created.
+curl_ready.StartupTimeout = 30
+curl_ready.Ready = When.FileContains(reader_output, '127.0.0.1')
+
+tr.Processes.Default.Command = "sleep 10"
+tr.Processes.Default.Return = 0
+
+# Process ordering.
+tr.Processes.Default.StartBefore(curl_ready)
+curl_ready.StartBefore(curl)
+curl.StartBefore(pipe_reader)
+pipe_reader.StartBefore(ts)
+
+
+#
+# Test 2: Change the log's buffer size.
+#
+tr = Test.AddTestRun()
+pipe_name = "change_pipe_size.pipe"
+# 64 KB is the default, so set the size larger than that to verify we can
+# increase the size.
+pipe_size = 75000
+ts = get_ts(
+        '''custom = format {{
+      Format = "%<hii> %<hiih>"
+    }}
+
+    log.pipe {{
+      Format = custom,
+      Filename = '{}',
+      PipeBufferSize = {}
+    }}'''.format(pipe_name, pipe_size).split("\n")
+    )
+
+pipe_path = os.path.join(ts.Variables.LOGDIR, pipe_name)
+
+ts.Streams.All += Testers.ContainsExpression(
+    "Created named pipe .*{}".format(pipe_name),
+    "Verify that the named pipe was created")
+
+ts.Streams.All += Testers.ContainsExpression(
+    "no readers for pipe .*{}".format(pipe_name),
+    "Verify that no readers for the pipe was detected.")
+
+ts.Streams.All += Testers.ContainsExpression(
+    "Previous buffer size for pipe .*{}".format(pipe_name),
+    "Verify that the named pipe's size was adjusted")
+
+# See fcntl:
+#   "Attempts to set the pipe capacity below the page size
+#    are silently rounded up to the page size."
+#
+# As a result of this, we cannot check that the pipe size is the exact size we
+# requested, but it should be at least that big. We use the
+# pipe_buffer_is_larger_than.py helper script to verify that the pipe grew in
+# size.
+ts.Streams.All += Testers.ContainsExpression(
+    "New buffer size for pipe.*{}".format(pipe_name),
+    "Verify that the named pipe's size was adjusted")
+buffer_verifier = "pipe_buffer_is_larger_than.py"
+tr.Setup.Copy(buffer_verifier)
+verify_buffer_size = tr.Processes.Process(
+        "verify_buffer_size",
+        "python3 {} {} {}".format(buffer_verifier, pipe_path, pipe_size))
+verify_buffer_size.Return = 0
+verify_buffer_size.Streams.All += Testers.ContainsExpression(
+    "Success",
+    "The buffer size verifier should report success.")
+
+curl = tr.Processes.Process("client_request", 'curl "http://127.0.0.1:{0}" --verbose'.format(
+    ts.Variables.port))
+
+reader_output = os.path.join(ts.Variables.LOGDIR, "reader_output")
+pipe_reader = tr.Processes.Process("pipe_reader", 'cat {} | tee {}'.format(pipe_path, reader_output))
+curl_ready = tr.Processes.Process("curl_ready", 'sleep 30')
+# In the AuTest environment, it can take more than 10 seconds for the log file
+# to be created.
+curl_ready.StartupTimeout = 30
+curl_ready.Ready = When.FileContains(reader_output, '127.0.0.1')
+
+tr.Processes.Default.Command = "sleep 10"
+tr.Processes.Default.Return = 0
+
+
+# Process ordering.
+tr.Processes.Default.StartBefore(verify_buffer_size)
+verify_buffer_size.StartBefore(curl_ready)
+curl_ready.StartBefore(curl)
+curl.StartBefore(pipe_reader)
+pipe_reader.StartBefore(ts)

--- a/tests/gold_tests/logging/pipe_buffer_is_larger_than.py
+++ b/tests/gold_tests/logging/pipe_buffer_is_larger_than.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import fcntl
+import sys
+
+F_SETPIPE_SZ = 1031  # Linux 2.6.35+
+F_GETPIPE_SZ = 1032  # Linux 2.6.35+
+
+
+def parse_args():
+    parser = parser = argparse.ArgumentParser(
+            description='Verify that a FIFO has a buffer of at least a certain size')
+
+    parser.add_argument(
+            'pipe_name',
+            help='The pipe name upon which to verify the size is large enough.')
+
+    parser.add_argument(
+            'minimum_buffer_size',
+            help='The minimu buffer size for the pipe to expect.')
+
+    return parser.parse_args()
+
+
+def test_fifo(fifo, minimum_buffer_size):
+    try:
+        fifo_fd = open(fifo, "rb+", buffering=0)
+        buffer_size = fcntl.fcntl(fifo_fd, F_GETPIPE_SZ)
+
+        if buffer_size >= int(minimum_buffer_size):
+            print("Success. Size is: {} which is larger than: {}".format(
+                buffer_size,
+                minimum_buffer_size))
+            return 0
+        else:
+            print("Fail. Size is: {} which is smaller than: {}".format(
+                buffer_size,
+                minimum_buffer_size))
+            return 1
+    except Exception as e:
+        print("Unable to open fifo, error: {}".format(str(e)))
+        return 2
+
+
+def main():
+    args = parse_args()
+    return test_fifo(args.pipe_name, args.minimum_buffer_size)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This configuration for the FIFO pipe buffer size exists in ATS 9 but it has never been backported to 7. It's not a trivial backport since the configuration is via the Lua logging.config rather than the logging.yaml file which is why it was never pulled back.

**This should not be merged forward.** I intend to create a separate PR for ATS 9 to add the test there.