### PR TITLE
Turn on debug for the bash script test_logstats_summary

### DIFF
--- a/src/traffic_logstats/tests/test_logstats_summary
+++ b/src/traffic_logstats/tests/test_logstats_summary
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 set -e # exit on error
+set -x # turn on debug
 
 TMPDIR=${TMPDIR:-/tmp}
 tmpfile=$(mktemp "$TMPDIR/logstats.XXXXXX")


### PR DESCRIPTION
I am seeing this randomly on CI and I am hoping that turning on debug for the bash script will give some insight.  I ran the test > 2,000 times and I couldn't get it to fail on my dev box.

```
======================================================
   Apache Traffic Server 10.0.0: src/test-suite.log
======================================================

# TOTAL: 3
# PASS:  2
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: traffic_logstats/tests/test_logstats_summary
==================================================

./traffic_logstats/traffic_logstats: line 117: /var/jenkins/workspace/fedora_31-master/compiler/gcc/label/fedora_31/type/debug/build/BUILDS/src/traffic_logstats/.libs/lt-traffic_logstats: Invalid argument
./traffic_logstats/traffic_logstats: line 117: /var/jenkins/workspace/fedora_31-master/compiler/gcc/label/fedora_31/type/debug/build/BUILDS/src/traffic_logstats/.libs/lt-traffic_logstats: Success
```