### PR TITLE
Add more flexible error handling when open a config file.

### DIFF
--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -610,7 +610,7 @@ ConfigVolumes::read_config_file()
       Warning("Cannot open the config file: %s - %s", (const char *)config_path, strerror(ec.value()));
       break;
     default:
-      Error("%s failed to load: %s", ts::filename::VOLUME, strerror(ec.value()));
+      Error("%s failed to load: %s", (const char *)config_path, strerror(ec.value()));
       return;
     }
   }

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -139,8 +139,7 @@ SplitDNSConfig::reconfigure()
   params->m_DNSSrvrTable    = new DNS_table("proxy.config.dns.splitdns.filename", modulePrefix, &sdns_dest_tags);
 
   if (nullptr == params->m_DNSSrvrTable || (0 == params->m_DNSSrvrTable->getEntryCount())) {
-    Error("%s failed to load", ts::filename::SPLITDNS);
-    Warning("No NAMEDs provided! Disabling SplitDNS");
+    Warning("Failed to load %s - No NAMEDs provided! Disabling SplitDNS", ts::filename::SPLITDNS);
     gsplit_dns_enabled = 0;
     delete params;
     return;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1592,8 +1592,8 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup)
 {
   const SSLConfigParams *params = this->_params;
 
-  char *tok_state = nullptr;
-  char *line      = nullptr;
+  char *tok_state   = nullptr;
+  char *line        = nullptr;
   unsigned line_num = 0;
   matcher_line line_info;
 


### PR DESCRIPTION
Currently `traffic_manager` wont start `traffic_server` if some configuration files aren't present in the config folder, this should not be a blocker for TS to start. This PR is the first of a series that will allow TM and TS to start without non required configurations files.

This particular PR cleans up old legacy code and use a more modern approach that provides more flexible error handling when opening a configuration file. `ENOENT` is whitelisted now and cases like `EACCESS` will end  up on an Error being logged.

In the past `traffic_manager` would have created a 0 byte file if the files wasn't there, letting `traffic_server` work as normal, this follows the same principle but without the need of the config file.