### PR TITLE
Make traffic_manager be flexible when opening config files.

### DIFF
--- a/mgmt/ConfigManager.cc
+++ b/mgmt/ConfigManager.cc
@@ -42,8 +42,9 @@
 #define TS_ARCHIVE_STAT_MTIME(t) ((t).st_mtime * 1000000000)
 #endif
 
-ConfigManager::ConfigManager(const char *fileName_, const char *configName_, bool root_access_needed_, bool isRequired_, ConfigManager *parentConfig_)
-  : root_access_needed(root_access_needed_),  isRequired(isRequired_), parentConfig(parentConfig_)
+ConfigManager::ConfigManager(const char *fileName_, const char *configName_, bool root_access_needed_, bool isRequired_,
+                             ConfigManager *parentConfig_)
+  : root_access_needed(root_access_needed_), isRequired(isRequired_), parentConfig(parentConfig_)
 {
   ExpandingArray existVer(25, true); // Existing versions
   struct stat fileInfo;

--- a/mgmt/ConfigManager.h
+++ b/mgmt/ConfigManager.h
@@ -54,7 +54,7 @@ class ConfigManager
 {
 public:
   // fileName_ should be rooted or a base file name.
-  ConfigManager(const char *fileName_, const char *configName_, bool root_access_needed, ConfigManager *parentConfig_);
+  ConfigManager(const char *fileName_, const char *configName_, bool root_access_needed, bool isRequired_, ConfigManager *parentConfig_);
   ~ConfigManager();
 
   // Manual take out of lock required
@@ -104,6 +104,12 @@ public:
     return root_access_needed;
   }
 
+  bool
+  getIsRequired() const
+  {
+    return isRequired;
+  }
+
   FileManager *configFiles = nullptr; // Manager to notify on an update.
 
   // noncopyable
@@ -117,6 +123,7 @@ private:
   char *fileName;
   char *configName;
   bool root_access_needed;
+  bool isRequired;
   ConfigManager *parentConfig;
   time_t fileLastModified = 0;
 };

--- a/mgmt/ConfigManager.h
+++ b/mgmt/ConfigManager.h
@@ -54,7 +54,8 @@ class ConfigManager
 {
 public:
   // fileName_ should be rooted or a base file name.
-  ConfigManager(const char *fileName_, const char *configName_, bool root_access_needed, bool isRequired_, ConfigManager *parentConfig_);
+  ConfigManager(const char *fileName_, const char *configName_, bool root_access_needed, bool isRequired_,
+                ConfigManager *parentConfig_);
   ~ConfigManager();
 
   // Manual take out of lock required

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -92,20 +92,21 @@ FileManager::registerCallback(FileCallbackFunc func)
 //  Pointers to the new objects are stored in the bindings hashtable
 //
 void
-FileManager::addFile(const char *fileName, const char *configName, bool root_access_needed, ConfigManager *parentConfig)
+FileManager::addFile(const char *fileName, const char *configName, bool root_access_needed, bool isRequired,
+                     ConfigManager *parentConfig)
 {
   ink_mutex_acquire(&accessLock);
-  addFileHelper(fileName, configName, root_access_needed, parentConfig);
+  addFileHelper(fileName, configName, root_access_needed, isRequired, parentConfig);
   ink_mutex_release(&accessLock);
 }
 
 // caller must hold the lock
 void
-FileManager::addFileHelper(const char *fileName, const char *configName, bool root_access_needed, ConfigManager *parentConfig)
+FileManager::addFileHelper(const char *fileName, const char *configName, bool root_access_needed, bool isRequired, ConfigManager *parentConfig)
 {
   ink_assert(fileName != nullptr);
 
-  ConfigManager *rb = new ConfigManager(fileName, configName, root_access_needed, parentConfig);
+  ConfigManager *rb = new ConfigManager(fileName, configName, root_access_needed, isRequired, parentConfig);
   rb->configFiles   = this;
 
   bindings.emplace(rb->getFileName(), rb);
@@ -257,7 +258,7 @@ FileManager::configFileChild(const char *parent, const char *child)
   ink_mutex_acquire(&accessLock);
   if (auto it = bindings.find(parent); it != bindings.end()) {
     parentConfig = it->second;
-    addFileHelper(child, "", parentConfig->rootAccessNeeded(), parentConfig);
+    addFileHelper(child, "", parentConfig->rootAccessNeeded(), parentConfig->getIsRequired(), parentConfig);
   }
   ink_mutex_release(&accessLock);
 }

--- a/mgmt/FileManager.cc
+++ b/mgmt/FileManager.cc
@@ -102,7 +102,8 @@ FileManager::addFile(const char *fileName, const char *configName, bool root_acc
 
 // caller must hold the lock
 void
-FileManager::addFileHelper(const char *fileName, const char *configName, bool root_access_needed, bool isRequired, ConfigManager *parentConfig)
+FileManager::addFileHelper(const char *fileName, const char *configName, bool root_access_needed, bool isRequired,
+                           ConfigManager *parentConfig)
 {
   ink_assert(fileName != nullptr);
 

--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -48,7 +48,7 @@ enum lockAction_t {
 //
 //  public functions:
 //
-//  addFile(char*, char *, configFileInfo*) - adds a new config file to be
+//  addFile(char*, char *, bool, configFileInfo*) - adds a new config file to be
 //       managed.  A ConfigManager object is created for the file.
 //       if the file_info ptr is not NULL, a WebFileEdit object
 //       is also created
@@ -80,7 +80,8 @@ class FileManager
 public:
   FileManager();
   ~FileManager();
-  void addFile(const char *fileName, const char *configName, bool root_access_needed, ConfigManager *parentConfig = nullptr);
+  void addFile(const char *fileName, const char *configName, bool root_access_needed, bool isRequired,
+               ConfigManager *parentConfig = nullptr);
   bool getConfigObj(const char *fileName, ConfigManager **rbPtr);
   void registerCallback(FileCallbackFunc func);
   void fileChanged(const char *fileName, const char *configName);
@@ -93,7 +94,7 @@ private:
   ink_mutex cbListLock; // Protects the CallBack List
   DLL<callbackListable> cblist;
   std::unordered_map<std::string_view, ConfigManager *> bindings;
-  void addFileHelper(const char *fileName, const char *configName, bool root_access_needed, ConfigManager *parentConfig);
+  void addFileHelper(const char *fileName, const char *configName, bool root_access_needed, bool isRequired, ConfigManager *parentConfig);
 };
 
 void initializeRegistry(); // implemented in AddConfigFilesHere.cc

--- a/mgmt/FileManager.h
+++ b/mgmt/FileManager.h
@@ -94,7 +94,8 @@ private:
   ink_mutex cbListLock; // Protects the CallBack List
   DLL<callbackListable> cblist;
   std::unordered_map<std::string_view, ConfigManager *> bindings;
-  void addFileHelper(const char *fileName, const char *configName, bool root_access_needed, bool isRequired, ConfigManager *parentConfig);
+  void addFileHelper(const char *fileName, const char *configName, bool root_access_needed, bool isRequired,
+                     ConfigManager *parentConfig);
 };
 
 void initializeRegistry(); // implemented in AddConfigFilesHere.cc

--- a/src/traffic_manager/AddConfigFilesHere.cc
+++ b/src/traffic_manager/AddConfigFilesHere.cc
@@ -29,6 +29,9 @@
 
 extern FileManager *configFiles;
 
+
+static constexpr bool REQUIRED { true };
+static constexpr bool NOT_REQUIRED { false };
 /****************************************************************************
  *
  *  AddConfigFilesHere.cc - Structs for config files and
@@ -43,14 +46,14 @@ testcall(char *foo, char * /*configName */)
 }
 
 void
-registerFile(const char *configName, const char *defaultName)
+registerFile(const char *configName, const char *defaultName, bool isRequired)
 {
   bool found        = false;
   const char *fname = REC_readString(configName, &found);
   if (!found) {
     fname = defaultName;
   }
-  configFiles->addFile(fname, configName, false);
+  configFiles->addFile(fname, configName, false, isRequired);
 }
 
 //
@@ -73,20 +76,20 @@ initializeRegistry()
     ink_assert(!"Configuration Object Registry Initialized More than Once");
   }
 
-  registerFile("proxy.config.log.config.filename", ts::filename::LOGGING);
-  registerFile("", ts::filename::STORAGE);
-  registerFile("proxy.config.socks.socks_config_file", ts::filename::SOCKS);
-  registerFile(ts::filename::RECORDS, ts::filename::RECORDS);
-  registerFile("proxy.config.cache.control.filename", ts::filename::CACHE);
-  registerFile("proxy.config.cache.ip_allow.filename", ts::filename::IP_ALLOW);
-  registerFile("proxy.config.http.parent_proxy.file", ts::filename::PARENT);
-  registerFile("proxy.config.url_remap.filename", ts::filename::REMAP);
-  registerFile("", ts::filename::VOLUME);
-  registerFile("proxy.config.cache.hosting_filename", ts::filename::HOSTING);
-  registerFile("", ts::filename::PLUGIN);
-  registerFile("proxy.config.dns.splitdns.filename", ts::filename::SPLITDNS);
-  registerFile("proxy.config.ssl.server.multicert.filename", ts::filename::SSL_MULTICERT);
-  registerFile("proxy.config.ssl.servername.filename", ts::filename::SNI);
+  registerFile("proxy.config.log.config.filename", ts::filename::LOGGING, NOT_REQUIRED);
+  registerFile("", ts::filename::STORAGE, REQUIRED);
+  registerFile("proxy.config.socks.socks_config_file", ts::filename::SOCKS, NOT_REQUIRED);
+  registerFile(ts::filename::RECORDS, ts::filename::RECORDS, NOT_REQUIRED);
+  registerFile("proxy.config.cache.control.filename", ts::filename::CACHE, NOT_REQUIRED);
+  registerFile("proxy.config.cache.ip_allow.filename", ts::filename::IP_ALLOW, NOT_REQUIRED);
+  registerFile("proxy.config.http.parent_proxy.file", ts::filename::PARENT, NOT_REQUIRED);
+  registerFile("proxy.config.url_remap.filename", ts::filename::REMAP, NOT_REQUIRED);
+  registerFile("", ts::filename::VOLUME, NOT_REQUIRED);
+  registerFile("proxy.config.cache.hosting_filename", ts::filename::HOSTING, NOT_REQUIRED);
+  registerFile("", ts::filename::PLUGIN, NOT_REQUIRED);
+  registerFile("proxy.config.dns.splitdns.filename", ts::filename::SPLITDNS, NOT_REQUIRED);
+  registerFile("proxy.config.ssl.server.multicert.filename", ts::filename::SSL_MULTICERT, NOT_REQUIRED);
+  registerFile("proxy.config.ssl.servername.filename", ts::filename::SNI, NOT_REQUIRED);
 
   configFiles->registerCallback(testcall);
 }

--- a/src/traffic_manager/AddConfigFilesHere.cc
+++ b/src/traffic_manager/AddConfigFilesHere.cc
@@ -29,9 +29,8 @@
 
 extern FileManager *configFiles;
 
-
-static constexpr bool REQUIRED { true };
-static constexpr bool NOT_REQUIRED { false };
+static constexpr bool REQUIRED{true};
+static constexpr bool NOT_REQUIRED{false};
 /****************************************************************************
  *
  *  AddConfigFilesHere.cc - Structs for config files and


### PR DESCRIPTION
In order to make TM and TS more flexible about configuration files this PR allow `traffic_manager` to start if the configuration file is not marked as `required`. Only `storage.config` is marked as required for now.
This is a second part [6459](https://github.com/apache/trafficserver/pull/6459)