### PR TITLE
Reduce minimum config files needed for golden_tests.

### DIFF
--- a/tests/gold_tests/autest-site/min_cfg/cache.config
+++ b/tests/gold_tests/autest-site/min_cfg/cache.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/hosting.config
+++ b/tests/gold_tests/autest-site/min_cfg/hosting.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/logging.yaml
+++ b/tests/gold_tests/autest-site/min_cfg/logging.yaml
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/parent.config
+++ b/tests/gold_tests/autest-site/min_cfg/parent.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/plugin.config
+++ b/tests/gold_tests/autest-site/min_cfg/plugin.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/readme.txt
+++ b/tests/gold_tests/autest-site/min_cfg/readme.txt
@@ -1,3 +1,4 @@
-Contains the miniumn set of config file and setting to allow trafficserver to start in a usable way.
+Contains the minimum set of config file and setting to allow trafficserver to start in a usable way.
 The goal is to remove the need for any of these files to exist.
-Each of these files should provide an understanding of what we need to fix in the code
+ip_allow.yaml is needed to allow tests the minimum access to traffic_server.
+storage.config needs to exist for now.

--- a/tests/gold_tests/autest-site/min_cfg/records.config
+++ b/tests/gold_tests/autest-site/min_cfg/records.config
@@ -1,1 +1,0 @@
-# some stuff

--- a/tests/gold_tests/autest-site/min_cfg/remap.config
+++ b/tests/gold_tests/autest-site/min_cfg/remap.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/sni.yaml
+++ b/tests/gold_tests/autest-site/min_cfg/sni.yaml
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/socks.config
+++ b/tests/gold_tests/autest-site/min_cfg/socks.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/splitdns.config
+++ b/tests/gold_tests/autest-site/min_cfg/splitdns.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/ssl_multicert.config
+++ b/tests/gold_tests/autest-site/min_cfg/ssl_multicert.config
@@ -1,1 +1,0 @@
-# this files just needs to exist

--- a/tests/gold_tests/autest-site/min_cfg/volume.config
+++ b/tests/gold_tests/autest-site/min_cfg/volume.config
@@ -1,1 +1,0 @@
-# this files just needs to exist


### PR DESCRIPTION
Update golden tests to reduce the number of required configuration files. This should be merge after [6459](https://github.com/apache/trafficserver/pull/6459) and [6460](https://github.com/apache/trafficserver/pull/6460)

We remove all the non fundamental config files and just let the minimum to let the tests to run.