### PR TITLE
[CPPAPI] Provide access to TSRemapRequestInfo in RemapPlugins.

### DIFF
--- a/include/tscpp/api/RemapPlugin.h
+++ b/include/tscpp/api/RemapPlugin.h
@@ -25,6 +25,7 @@
 #include "tscpp/api/Transaction.h"
 #include "tscpp/api/Url.h"
 #include "tscpp/api/utils.h"
+#include "ts/remap.h"
 
 namespace atscppapi
 {
@@ -48,6 +49,25 @@ public:
     RESULT_NO_REMAP_STOP,
     RESULT_DID_REMAP_STOP,
   };
+
+  /**
+   * Invoked when a request matches the remap.config line - it gives you access to the remap information
+   * if you want to have more control over how the remap happens.
+   *
+   * @param transaction Transaction
+   * @param rri The remap information in the remap.config line.
+   *
+   * @return Result of the remap - will dictate further processing by the system.
+   */
+  virtual Result
+  remapTransaction(Transaction &transaction, TSRemapRequestInfo *rri)
+  {
+    Url map_from_url(rri->requestBufp, rri->mapFromUrl), map_to_url(rri->requestBufp, rri->mapToUrl);
+    bool redirect              = false;
+    RemapPlugin::Result result = doRemap(map_from_url, map_to_url, transaction, redirect);
+    rri->redirect              = redirect ? 1 : 0;
+    return result;
+  }
 
   /**
    * Invoked when a request matches the remap.config line - implementation should perform the

--- a/src/tscpp/api/RemapPlugin.cc
+++ b/src/tscpp/api/RemapPlugin.cc
@@ -30,12 +30,9 @@ using namespace atscppapi;
 TSRemapStatus
 TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 {
-  RemapPlugin *remap_plugin = static_cast<RemapPlugin *>(ih);
-  Url map_from_url(rri->requestBufp, rri->mapFromUrl), map_to_url(rri->requestBufp, rri->mapToUrl);
+  RemapPlugin *remap_plugin  = static_cast<RemapPlugin *>(ih);
   Transaction &transaction   = utils::internal::getTransaction(rh);
-  bool redirect              = false;
-  RemapPlugin::Result result = remap_plugin->doRemap(map_from_url, map_to_url, transaction, redirect);
-  rri->redirect              = redirect ? 1 : 0;
+  RemapPlugin::Result result = remap_plugin->remapTransaction(transaction, rri);
   switch (result) {
   case RemapPlugin::RESULT_ERROR:
     return TSREMAP_ERROR;


### PR DESCRIPTION
While plugins can modify a remap behavior by overloading the `doRemap` method, they cannot modify the origin URL directly, they have to change the client URL using `transaction.getClientRequest().getUrl()`, which is not very intuitive.

This change adds a new public method to the CPP API that gives plugins access to the original `TSRemapRequestInfo` structure. This new method doesn't change any current behavior, and all existent plugins work as expected. If you look at the diff, you can see that I only moved 4 lines of private code to this new virtual method.

I sent a message to the dev mailing list to discuss this change, but I didn't get any response. I'm guessing not many people use these APIs, which is understandable if you have more experience with the low level API.

Signed-off-by: David Calavera <david.calavera@gmail.com>