### PR TITLE
Skipping log_retention.test.py because it is flaky in CI

### DIFF
--- a/tests/gold_tests/logging/log_retention.test.py
+++ b/tests/gold_tests/logging/log_retention.test.py
@@ -23,6 +23,12 @@ Test.Summary = '''
 Test the enforcment of proxy.config.log.max_space_mb_for_logs.
 '''
 
+# This test is sensitive to timing issues, especially in the OS CI for some
+# reason. We'll leave the test here because it is helpful for when doing
+# development on the log rotate code, but make it generally skipped when the
+# suite of AuTests are run so it doesn't generate annoying false negatives.
+Test.SkipIf(Condition.true("This test is sensitive to timing issues which makes it flaky."))
+
 
 class TestLogRetention:
     __base_records_config = {


### PR DESCRIPTION
```
$ ./autest.sh --ats-bin ~/build/ts_os_7x_disable_log_test/bin/ --sandbox /tmp/sbskip -f log_retention
...
Environment config finished. Running AuTest...
Running Test log_retention: Skipped
Warning: Skipping test log_retention because:
 This test is sensitive to timing issues which makes it flaky.

Generating Report: --------------
1 Tests were skipped:
--------------------------------------------------------------------------------
 Test "log_retention" Skipped
    File: log_retention.test.py
    Directory: /home/bneradt/repos/ts_os_7x_disable_log_test/tests/gold_tests/logging
  Reason: This test is sensitive to timing issues which makes it flaky.

Total of 1 test
  Unknown: 0
  Exception: 0
  Failed: 0
  Warning: 0
  Skipped: 1
  Passed: 0

```