### PR TITLE
Fixed logging docs typos

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -273,30 +273,6 @@ System Variables
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
    output logs as much as possible. See :doc:`../logging/rotation.en` for guidance.
 
-.. ts:cv:: CONFIG proxy.config.output.logfile.rolling_max_count INT 0
-   :reloadable:
-
-   Specifies the maximum count of rolled output logs to keep. This value will be used by the
-   auto-deletion (if enabled) to trim the number of rolled log files every time the log is rolled.
-   A default value of 0 means auto-deletion will not try to limit the number of output logs.
-   See :doc:`../logging/rotation.en` for an use-case for this option.
-
-.. ts:cv:: CONFIG proxy.config.output.logfile.rolling_allow_empty INT 0
-   :reloadable:
-
-   While rolling default behavior is to rename, close and re-open the log file *only* when/if there is
-   something to log to the log file. This option opens a new log file right after rolling even if there
-   is nothing to log (i.e. nothing to be logged due to lack of requests to the server)
-   which may lead to 0-sized log files while rolling. See :doc:`../logging/rotation.en` for an use-case
-   for this option.
-
-   ===== ======================================================================
-   Value Description
-   ===== ======================================================================
-   ``0`` No empty log files created and rolled if there was nothing to log
-   ``1`` Allow empty log files to be created and  rolled even if there was nothing to log
-   ===== ======================================================================
-
 
 Thread Variables
 ----------------
@@ -2871,6 +2847,30 @@ Logging Configuration
    Specifies the minimum count of rolled (event) logs to keep. This value will be used to decide the
    order of auto-deletion (if enabled). A default value of 0 means auto-deletion will try to keep
    logs as much as possible. This value can be and should be overridden in logging.yaml. See :doc:`../logging/rotation.en` for guidance.
+
+.. ts:cv:: CONFIG proxy.config.log.rolling_max_count INT 0
+   :reloadable:
+
+   Specifies the maximum count of rolled output logs to keep. This value will be used by the
+   auto-deletion (if enabled) to trim the number of rolled log files every time the log is rolled.
+   A default value of 0 means auto-deletion will not try to limit the number of output logs.
+   See :doc:`../logging/rotation.en` for an use-case for this option.
+
+.. ts:cv:: CONFIG proxy.config.log.rolling_allow_empty INT 0
+   :reloadable:
+
+   While rolling default behavior is to rename, close and re-open the log file *only* when/if there is
+   something to log to the log file. This option opens a new log file right after rolling even if there
+   is nothing to log (i.e. nothing to be logged due to lack of requests to the server)
+   which may lead to 0-sized log files while rolling. See :doc:`../logging/rotation.en` for an use-case
+   for this option.
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``0`` No empty log files created and rolled if there was nothing to log
+   ``1`` Allow empty log files to be created and  rolled even if there was nothing to log
+   ===== ======================================================================
 
 .. ts:cv:: CONFIG proxy.config.log.auto_delete_rolled_files INT 1
    :reloadable:

--- a/doc/admin-guide/logging/rotation.en.rst
+++ b/doc/admin-guide/logging/rotation.en.rst
@@ -255,13 +255,13 @@ the maximum number of rolled log files, and forcing |TS| to roll even when there
 
 Let us say we wanted the oldest log entry to be kept on the box to be no older than 2-hour old.
 
-Set :ts:cv:`proxy.config.output.logfile.rolling_interval_sec` (yaml: `rolling_interval_sec`) to 3600 (1h)
+Set :ts:cv:`proxy.config.log.rolling_interval_sec` (yaml: `rolling_interval_sec`) to 3600 (1h)
 which will lead to rolling every 1h.
 
-Set :ts:cv:`proxy.config.output.logfile.rolling_max_count` (yaml: `rolling_max_count`) to 1
+Set :ts:cv:`proxy.config.log.rolling_max_count` (yaml: `rolling_max_count`) to 1
 which will lead to keeping only one rolled log file at any moment (rolled will be trimmed on every roll).
 
-Set :ts:cv:`proxy.config.output.logfile.rolling_allow_empty` (yaml: `rolling_allow_empty`) to 1 (default: 0)
+Set :ts:cv:`proxy.config.log.rolling_allow_empty` (yaml: `rolling_allow_empty`) to 1 (default: 0)
 which will allow logs to be open and rolled even if there was nothing to be logged during the previous period
 (i.e. no requests to |TS|).
 


### PR DESCRIPTION
Renamed the following references (bug):
-`proxy.config.output.logfile.rolling_max_count`
+`proxy.config.log.rolling_max_count`
-`proxy.config.output.logfile.rolling_allow_empty`
+`proxy.config.log.rolling_allow_empty`