### PR TITLE
traffic_dump: Fixing content:size collection.

### DIFF
--- a/tests/gold_tests/pluginTest/traffic_dump/gold/post_with_body.gold
+++ b/tests/gold_tests/pluginTest/traffic_dump/gold/post_with_body.gold
@@ -1,0 +1,8 @@
+``
+> POST http://localhost:``/post_with_body HTTP/1.1
+> Host: www.example.com``
+> User-Agent: curl/``
+> Accept: */*
+``
+< Server: ATS/``
+``

--- a/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
@@ -67,7 +67,27 @@ def verify_request_target(replay_json, request_target):
         print("The replay file did not have a first transaction with a url element.")
         return False
 
-    return url == request_target
+    if url != request_target:
+        print("Mismatched request target. Expected: {}, received: {}".format(request_target, url))
+        return False
+    return True
+
+
+def verify_client_request_size(replay_json, client_request_size):
+    """
+    Verify that the 'url' element of the first transaction contains the request target.
+    """
+    try:
+        size = int(replay_json['sessions'][0]['transactions'][0]['client-request']['content']['size'])
+    except KeyError:
+        print("The replay file did not have content size element in the first client-request.")
+        return False
+
+    if size != client_request_size:
+        print("Mismatched client-request request size. Expected: {}, received: {}".format(
+            client_request_size, size))
+        return False
+    return True
 
 
 def parse_args():
@@ -80,6 +100,9 @@ def parse_args():
                         help="The replay file to validate.")
     parser.add_argument("--request-target",
                         help="The request target ('url' element) to expect in the replay file.")
+    parser.add_argument("--client-request-size",
+                        type=int,
+                        help="The expected size value in the client-request node.")
     return parser.parse_args()
 
 
@@ -105,6 +128,9 @@ def main():
         return 1
 
     if args.request_target and not verify_request_target(replay_json, args.request_target):
+        return 1
+
+    if args.client_request_size and not verify_client_request_size(replay_json, args.client_request_size):
         return 1
 
     return 0


### PR DESCRIPTION
traffic_dump was collecting the client-request body information too
early, resulting in an incorrect content:size value (it was always
zero). This holds off on collecting the body size until later so the
value is accurate. A traffic_dump AuTest is being added to verify
correct behavior with requests containing bodies.

Also, this updates the Traffic Dump post_process.py script to add
proxy-request and server-response nodes to transactions without them
because the proxy replied locally to the request. This is useful in
replay scenarios in which the test version of Traffic Server likely
won't have the cached responses.