### PR TITLE
Fix FetchSM to support non-streaming dechunking mode

### DIFF
--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -191,7 +191,7 @@ FetchSM::check_chunked()
   static const char CHUNKED_TEXT[] = "chunked";
   static size_t const CHUNKED_LEN  = sizeof(CHUNKED_TEXT) - 1;
 
-  if (resp_is_chunked < 0) {
+  if ((resp_is_chunked < 0) && !(client_response_hdr.version_get() < HTTPVersion(1, 1))) {
     resp_is_chunked = static_cast<int>(
       this->check_for_field_value(MIME_FIELD_TRANSFER_ENCODING, MIME_LEN_TRANSFER_ENCODING, CHUNKED_TEXT, CHUNKED_LEN));
 
@@ -377,8 +377,7 @@ FetchSM::get_info_from_buffer(IOBufferReader *reader)
   client_response = info;
 
   // To maintain backwards compatibility we don't allow chunking when it's not streaming
-  if ((!(fetch_flags & TS_FETCH_FLAGS_STREAM) && (!(fetch_flags & TS_FETCH_FLAGS_DECHUNK) || (callback_options == NO_CALLBACK))) ||
-      !check_chunked()) {
+  if ((!(fetch_flags & TS_FETCH_FLAGS_STREAM) && (!(fetch_flags & TS_FETCH_FLAGS_DECHUNK))) || !check_chunked()) {
     /* Read the data out of the reader */
     while (read_avail > 0) {
       if (reader->block) {

--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -376,8 +376,9 @@ FetchSM::get_info_from_buffer(IOBufferReader *reader)
   info            = (char *)ats_malloc(sizeof(char) * (read_avail + 1));
   client_response = info;
 
-  // To maintain backwards compatibility we don't allow chunking when it's not streaming.
-  if ((!(fetch_flags & TS_FETCH_FLAGS_STREAM) && !(fetch_flags & TS_FETCH_FLAGS_DECHUNK)) || !check_chunked()) {
+  // To maintain backwards compatibility we don't allow chunking when it's not streaming
+  if ((!(fetch_flags & TS_FETCH_FLAGS_STREAM) && (!(fetch_flags & TS_FETCH_FLAGS_DECHUNK) || (callback_options == NO_CALLBACK))) ||
+      !check_chunked()) {
     /* Read the data out of the reader */
     while (read_avail > 0) {
       if (reader->block) {


### PR DESCRIPTION
to enable TSFetchUrl to use HTTP/1.1

FetchSM supports dechunking of chunked response but only in
STREAM mode (ie headers first and body in stream). However,
we may need to use FetchSM for sideways calls with dechunked
body and non-stream mode ie headers and body together. Without
this, TSFetchUrl can only work with HTTP/1.0 which is limiting
as it doesn't allow us to enable keep alive and all 1.1 goodness
This PR fixes the problem by allowing to dechunk response even
when stream mode isn't specified.