### PR TITLE
traffic_manager - Exponential backoff - Make values configurable

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1257,6 +1257,11 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_NODE, "proxy.node.version.manager.build_person", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  //# manager: backoff configuration.
+  {RECT_CONFIG, "proxy.node.config.manager_exponential_sleep_ceiling", RECD_INT, "60", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.node.config.manager_retry_cap", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
 
   //#
   //# SSL parent proxying info


### PR DESCRIPTION
Make traffic_manager a bit more flexible when the exponential backoff is kick off.
- Add configuration field that let us set the max sleep time
`proxy.node.config.manager_exponential_sleep_ceiling`
- Add a configuration field that let us set the maximum number of retries after we reach the max sleep time.
`proxy.node.config.manager_retry_cap`
- Add a random variance between retries