### PR TITLE
Be explicit about RTLD_LOCAL, defaults varies on platforms

### DIFF
--- a/proxy/http/remap/PluginDso.cc
+++ b/proxy/http/remap/PluginDso.cc
@@ -90,7 +90,7 @@ PluginDso::load(std::string &error)
       PluginDebug(_tag, "plugin '%s' mоdification time %ld", _configPath.c_str(), _mtime);
 
       /* Now attemt to load the plugin DSO */
-      if ((_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW)) == nullptr) {
+      if ((_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW | RTLD_LOCAL)) == nullptr) {
 #if defined(freebsd) || defined(openbsd)
         char *err = (char *)dlerror();
 #else

--- a/proxy/http/remap/unit-tests/test_PluginFactory.cc
+++ b/proxy/http/remap/unit-tests/test_PluginFactory.cc
@@ -136,7 +136,7 @@ public:
   {
     CHECK(fs::exists(configPath));
 
-    void *handle = dlopen(configPath.c_str(), RTLD_NOW);
+    void *handle = dlopen(configPath.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (!handle) {
       return false;
     }


### PR DESCRIPTION
At least on macOS, the default (according to the manual) is RTLD_GLOBAL. I think we should be explicit here, just to be safe. I ran into this before, where we ended up having name space collisions between plugins when I was testing things.