### PR TITLE
Fix session reuse plugin shutdown crashes and cleanups

### DIFF
--- a/plugins/experimental/ssl_session_reuse/src/Config.h
+++ b/plugins/experimental/ssl_session_reuse/src/Config.h
@@ -31,7 +31,6 @@
 
 struct fromstring {
   fromstring(const std::string &string) : _string(string) {}
-
   template <typename _T> operator _T() const
   {
     _T t;

--- a/plugins/experimental/ssl_session_reuse/src/common.cc
+++ b/plugins/experimental/ssl_session_reuse/src/common.cc
@@ -69,11 +69,14 @@ encrypt_encode64(const unsigned char *key, int key_length, const unsigned char *
   // generate key and iv
   if (EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), salt, key, key_length, 1, gen_key, iv) <= 0) {
     TSDebug(PLUGIN, "Error generating key.");
+    ret = -2;
+    goto Cleanup;
   }
 
   // Set context AES128 with the generated key and iv
   if (1 != EVP_EncryptInit_ex(context, EVP_aes_256_cbc(), nullptr, gen_key, iv)) {
     TSDebug(PLUGIN, "EVP_EncryptInit_ex failed.");
+    ret = -3;
     goto Cleanup;
   }
 
@@ -84,11 +87,13 @@ encrypt_encode64(const unsigned char *key, int key_length, const unsigned char *
   encrypted         = new unsigned char[in_data_len + cipher_block_size * 2];
   if (1 != EVP_EncryptUpdate(context, encrypted, &encrypted_len, in_data, in_data_len)) {
     TSDebug(PLUGIN, "EVP_EncryptUpdate failed.");
+    ret = -4;
     goto Cleanup;
   }
 
   if (1 != EVP_EncryptFinal_ex(context, encrypted + encrypted_len, &encrypted_len_extra)) {
     TSDebug(PLUGIN, "EVP_EncryptFinal_ex failed.");
+    ret = -5;
     goto Cleanup;
   }
 
@@ -98,6 +103,7 @@ encrypt_encode64(const unsigned char *key, int key_length, const unsigned char *
   if (TSBase64Encode(reinterpret_cast<char *>(encrypted), encrypted_len + encrypted_len_extra, out_data, out_data_size,
                      out_data_len) != 0) {
     TSDebug(PLUGIN, "Base 64 encoding failed.");
+    ret = -6;
     goto Cleanup;
   }
 
@@ -141,16 +147,20 @@ decrypt_decode64(const unsigned char *key, int key_length, const char *in_data, 
   std::memset(decoded, 0, decoded_size);
   if (TSBase64Decode(in_data, in_data_len, decoded, decoded_size, &decoded_len) != 0) {
     TSDebug(PLUGIN, "Base 64 decoding failed.");
+    ret = -2;
     goto Cleanup;
   }
 
   // generate key and iv
   if (EVP_BytesToKey(EVP_aes_256_cbc(), EVP_md5(), salt, key, key_length, 1, gen_key, iv) <= 0) {
     TSDebug(PLUGIN, "Error generating key.");
+    ret = -3;
+    goto Cleanup;
   }
   // set context with the generated key and iv
   if (1 != EVP_DecryptInit_ex(context, EVP_aes_256_cbc(), nullptr, gen_key, iv)) {
     TSDebug(PLUGIN, "EVP_DecryptInit_ex failed.");
+    ret = -4;
     goto Cleanup;
   }
 
@@ -158,11 +168,13 @@ decrypt_decode64(const unsigned char *key, int key_length, const char *in_data, 
   // EVP_DecryptUpdate() and EVP_DecryptFinal_ex() have the exact same requirements as their encrypt counterparts.
   if (1 != EVP_DecryptUpdate(context, out_data, &decrypted_len, decoded, decoded_len)) {
     TSDebug(PLUGIN, "EVP_DecryptUpdate failed.");
+    ret = -5;
     goto Cleanup;
   }
 
   if (1 != EVP_DecryptFinal_ex(context, out_data + decrypted_len, &decrypted_len_extra)) {
     TSDebug(PLUGIN, "EVP_DecryptFinal_ex failed.");
+    ret = -6;
     goto Cleanup;
   }
 

--- a/plugins/experimental/ssl_session_reuse/src/common.h
+++ b/plugins/experimental/ssl_session_reuse/src/common.h
@@ -43,6 +43,8 @@
 class PluginThreads
 {
 public:
+  bool shutdown = false;
+
   void
   store(const pthread_t &th)
   {
@@ -53,10 +55,9 @@ public:
   void
   terminate()
   {
+    shutdown = true;
+
     std::lock_guard<std::mutex> lock(threads_mutex);
-    for (pthread_t th : threads_queue) {
-      ::pthread_cancel(th);
-    }
     while (!threads_queue.empty()) {
       pthread_t th = threads_queue.front();
       ::pthread_join(th, nullptr);

--- a/plugins/experimental/ssl_session_reuse/src/message.h
+++ b/plugins/experimental/ssl_session_reuse/src/message.h
@@ -35,7 +35,7 @@ typedef struct message {
   std::set<RedisEndpoint, RedisEndpointCompare> hosts_tried;
 
   message() {}
+  message(const struct message &m) : channel(m.channel), data(m.data), cleanup(m.cleanup), hosts_tried(m.hosts_tried) {}
   message(const std::string &c, const std::string &d, bool quit = false) : channel(c), data(d), cleanup(quit) {}
   virtual ~message() {}
-
 } Message;

--- a/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
@@ -50,6 +50,7 @@ ssl_new_session(TSSslSessionID &sid)
     TSError("Encoded id failed.");
     return 0;
   }
+  std::string redis_channel = ssl_param.cluster_name + "." + encoded_id;
 
   int session_ret_len = SSL_SESSION_MAX_DER;
   char session_data[SSL_SESSION_MAX_DER];
@@ -65,7 +66,6 @@ ssl_new_session(TSSslSessionID &sid)
     return 0;
   }
 
-  std::string redis_channel = ssl_param.cluster_name + "." + encoded_id;
   ssl_param.pub->publish(redis_channel, encrypted_data);
 
   TSDebug(PLUGIN, "Create new session id: %s encoded: %s channel: %s", encoded_id.c_str(), encrypted_data.c_str(),

--- a/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
@@ -48,14 +48,14 @@ static char channel_key[MAX_REDIS_KEYSIZE] = {
 };
 static int channel_key_length = 0;
 
-static int stek_master_setter_running = 0; /* stek master setter thread running */
+static std::atomic<bool> stek_master_setter_running(false); /* stek master setter thread running */
 
-static bool stek_initialized = false;
+static std::atomic<bool> stek_initialized(false);
 
 bool
 isSTEKMaster()
 {
-  return stek_master_setter_running != 0;
+  return stek_master_setter_running;
 }
 
 /*****************************************************************************
@@ -165,43 +165,47 @@ STEK_encrypt(struct ssl_ticket_key_t *stek, const char *key, int key_length, cha
   int stek_len          = sizeof(struct ssl_ticket_key_t);
   size_t encrypted_size = *ret_len;
   size_t encrypted_len  = 0;
+  int ret               = -1;
 
-  if (encrypt_encode64(reinterpret_cast<const unsigned char *>(key), key_length, reinterpret_cast<unsigned char *>(stek), stek_len,
-                       ret_encrypted, encrypted_size, &encrypted_len) == 0) {
+  if ((ret = encrypt_encode64(reinterpret_cast<const unsigned char *>(key), key_length, reinterpret_cast<unsigned char *>(stek),
+                              stek_len, ret_encrypted, encrypted_size, &encrypted_len)) == 0) {
     *ret_len = encrypted_len;
-    return 1; // success
   } else {
-    TSDebug(PLUGIN, "STEK encryption failed.");
-    return 0;
+    TSDebug(PLUGIN, "STEK_encrypt calling encrypt_encode64 failed, error: %d", ret);
   }
+  return ret;
 }
 
 static int
 STEK_decrypt(const std::string &encrypted_data, const char *key, int key_length, struct ssl_ticket_key_t *ret_STEK)
 {
   if (!ret_STEK) {
-    return 0;
+    return -1;
   }
 
   TSDebug(PLUGIN, "STEK_decrypt: requested to decrypt %lu bytes", encrypted_data.length());
 
-  int ret                  = 0;
+  int ret                  = -1;
   size_t decrypted_size    = DECODED_LEN(encrypted_data.length()) + EVP_MAX_BLOCK_LENGTH * 2;
   size_t decrypted_len     = 0;
   unsigned char *decrypted = new unsigned char[decrypted_size];
 
   std::memset(decrypted, 0, decrypted_size);
-  decrypt_decode64(reinterpret_cast<const unsigned char *>(key), key_length, encrypted_data.c_str(), encrypted_data.length(),
-                   decrypted, decrypted_size, &decrypted_len);
+  if ((ret = decrypt_decode64(reinterpret_cast<const unsigned char *>(key), key_length, encrypted_data.c_str(),
+                              encrypted_data.length(), decrypted, decrypted_size, &decrypted_len)) != 0) {
+    TSDebug(PLUGIN, "STEK_decrypt calling decrypt_decode64 failed, error: %d", ret);
+    goto Cleanup;
+  }
 
   if (sizeof(struct ssl_ticket_key_t) != decrypted_len) {
     TSError("STEK data length mismatch, got %lu, should be %lu", decrypted_len, sizeof(struct ssl_ticket_key_t));
+    ret = -1;
     goto Cleanup;
   }
 
   memcpy(ret_STEK, decrypted, sizeof(struct ssl_ticket_key_t));
   memset(decrypted, 0, decrypted_size); // warm fuzzies
-  ret = 1;
+  ret = 0;
 
 Cleanup:
 
@@ -227,7 +231,7 @@ STEK_Send_To_Network(struct ssl_ticket_key_t *stekToSend)
 
   // encrypt the STEK before sending
   encryptedDataLength = sizeof(encryptedData);
-  if (!STEK_encrypt(stekToSend, get_key_ptr(), get_key_length(), encryptedData, &encryptedDataLength)) {
+  if (STEK_encrypt(stekToSend, get_key_ptr(), get_key_length(), encryptedData, &encryptedDataLength) != 0) {
     TSError("STEK_encrypt failed, not sending.");
     return 0; // failure
   }
@@ -262,46 +266,50 @@ STEK_Update_Setter_Thread(void *arg)
     return nullptr;
   }
 
-  stek_master_setter_running = 1;
+  stek_master_setter_running = true;
   TSDebug(PLUGIN, "Will now act as the STEK rotator for POD.");
 
-  while (true) {
-    // Create new STEK, set it for me, and then send it to the POD.
-    if ((!STEK_CreateNew(&newKey, 0, 1 /* entropy ensured */)) || (!STEK_Send_To_Network(&newKey))) {
-      // Error occurred. We will retry after a short interval.
-      // perhaps publishig isn't up yet.
-      startProblem++;     // count how many times we have this problem.
-      sleepInterval = 60; // short sleep for error retry
-      TSError("Could not create/send new STEK for key rotation... Try again in %d seconds.", sleepInterval);
-    } else {
-      //  Everything good. will sleep for normal rotation time period and then repeat
-      startProblem = 0;
-      TSDebug(PLUGIN, "New POD STEK created and sent to network.");
+  while (!plugin_threads.shutdown) {
+    try {
+      // Create new STEK, set it for me, and then send it to the POD.
+      if ((!STEK_CreateNew(&newKey, 0, 1 /* entropy ensured */)) || (!STEK_Send_To_Network(&newKey))) {
+        // Error occurred. We will retry after a short interval.
+        // perhaps publishig isn't up yet.
+        startProblem++;     // count how many times we have this problem.
+        sleepInterval = 60; // short sleep for error retry
+        TSError("Could not create/send new STEK for key rotation... Try again in %d seconds.", sleepInterval);
+      } else {
+        //  Everything good. will sleep for normal rotation time period and then repeat
+        startProblem = 0;
+        TSDebug(PLUGIN, "New POD STEK created and sent to network.");
 
-      sleepInterval = ssl_param.key_update_interval;
-    }
+        sleepInterval = ssl_param.key_update_interval;
+      }
 
-    ::sleep(sleepInterval);
+      ::sleep(sleepInterval);
 
-    if ((!startProblem) && (memcmp(&newKey, &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t)))) {
-      /* I am not using the key I set before sleeping.  This means node (and POD) has
-       * sync'd onto a more recent master,  which we will now yield to by exiting
-       * out of this thread. */
+      if ((!startProblem) && (memcmp(&newKey, &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t)))) {
+        /* I am not using the key I set before sleeping.  This means node (and POD) has
+         * sync'd onto a more recent master,  which we will now yield to by exiting
+         * out of this thread. */
+        goto done_master_setter;
+      }
+
+      if (startProblem > 60) {
+        /* We've been trying every minute for more than an hour. Time to give up and move on..*/
+        /* Another node in pod will notice and pick up responsibility, else we'll try again later */
+        goto done_master_setter;
+      }
+    } catch (...) {
+      TSDebug(PLUGIN, "STEK_Update_Setter_Thread exception");
       goto done_master_setter;
     }
-
-    if (startProblem > 60) {
-      /* We've been trying every minute for more than an hour. Time to give up and move on..*/
-      /* Another node in pod will notice and pick up responsibility, else we'll try again later */
-      goto done_master_setter;
-    }
-
   } // while(forever)
 
 done_master_setter:
   TSDebug(PLUGIN, "Yielding STEK-Master rotation responsibility to another node in POD.");
   memset(&newKey, 0, sizeof(struct ssl_ticket_key_t));
-  stek_master_setter_running = 0;
+  stek_master_setter_running = false;
   return nullptr;
 }
 
@@ -311,8 +319,8 @@ void
 STEK_update(const std::string &encrypted_stek)
 {
   struct ssl_ticket_key_t newSTEK;
-  if (STEK_decrypt(encrypted_stek, get_key_ptr(), get_key_length(), &newSTEK)) {
-    if (memcmp(&newSTEK, &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t))) {
+  if (STEK_decrypt(encrypted_stek, get_key_ptr(), get_key_length(), &newSTEK) == 0) {
+    if (memcmp(&newSTEK, &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t)) != 0) {
       /* ... and it's a new one,  so we will now set and use it. */
       ssl_key_lock.lock();
       memcpy(&ssl_param.ticket_keys[1], &ssl_param.ticket_keys[0], sizeof(struct ssl_ticket_key_t));
@@ -346,46 +354,61 @@ STEK_Update_Checker_Thread(void *arg)
   TSDebug(PLUGIN, "Starting STEK_Update_Checker_Thread.");
 
   lastChangeTime = lastWarningTime = time(&currentTime); // init to current to supress a startup warning.
+  int check_count                  = 0;                  // Keep track of how many times we've checked whether we got a new STEK.
 
-  while (true) {
-    if (!stek_initialized && ssl_param.pub) {
-      // Launch a request for the master to resend you the ticket key
-      std::string redis_channel = ssl_param.cluster_name + "." + STEK_ID_RESEND;
-      ssl_param.pub->publish(redis_channel, ""); // send it
-      TSDebug(PLUGIN, "Request for ticket.");
-    }
-    time(&currentTime);
-    time_t sleepUntil;
-    if (stek_initialized) {
-      // Sleep until we are overdue for a key update
-      sleepUntil = 2 * STEK_MAX_LIFETIME - (currentTime - lastChangeTime);
-    } else {
-      // Wait for a while in hopes that the server gets back to us
-      sleepUntil = 30;
-    }
-    ::sleep(sleepUntil);
+  while (!plugin_threads.shutdown) {
+    try {
+      if (!stek_initialized && ssl_param.pub) {
+        // Launch a request for the master to resend you the ticket key
+        std::string redis_channel = ssl_param.cluster_name + "." + STEK_ID_RESEND;
+        ssl_param.pub->publish(redis_channel, ""); // send it
+        TSDebug(PLUGIN, "Request for ticket.");
+      }
+      time(&currentTime);
+      time_t sleepUntil;
+      if (stek_initialized) {
+        // Sleep until we are overdue for a key update
+        sleepUntil       = 2 * STEK_MAX_LIFETIME - (currentTime - lastChangeTime);
+        stek_initialized = false;
+        check_count      = 0;
+      } else {
+        // Wait for a while in hopes that the server gets back to us
+        sleepUntil = 30;
+        ++check_count;
+      }
+      ::sleep(sleepUntil);
 
-    /* We track last time STEK changed. If we haven't gotten a new STEK in twice the max,
-     * then we figure something is wrong with the POD STEK master and nominate a new master.
-     * STEK master may have been misconfigured, disconnected, died or who-knows.
-     * ...no problem we will will recover POD STEK rotation now */
-
-    time(&currentTime);
-    if ((currentTime - lastChangeTime) > (2 * STEK_MAX_LIFETIME)) {
-      // Yes we were way past due for a new STEK, and haven't received it.
-      if ((currentTime - lastWarningTime) > STEK_NOT_CHANGED_WARNING_INTERVAL) {
-        // Yes it's time to put another warning in log file.
-        TSError("Session Ticket Encryption Key not syncd in past %d hours.",
-                static_cast<int>(((currentTime - lastChangeTime) / 3600)));
-
-        lastWarningTime = currentTime;
+      if (check_count == 0) {
+        continue;
       }
 
-      /* Time to nominate a new stek master for pod key rotation... */
-      if (!stek_master_setter_running) {
-        TSDebug(PLUGIN, "Will nominate a new STEK-master thread now for pod key rotation.");
-        TSThreadCreate(STEK_Update_Setter_Thread, nullptr);
+      /* We track last time STEK changed. If we haven't gotten a new STEK in twice the max,
+       * then we figure something is wrong with the POD STEK master and nominate a new master.
+       * STEK master may have been misconfigured, disconnected, died or who-knows.
+       * If we're have been checking in the past five minutes and still haven't got a new
+       * STEK, we believe that the master has died, so "now, I am the master".
+       * ...no problem we will recover POD STEK rotation now */
+
+      time(&currentTime);
+      if ((currentTime - lastChangeTime) > (2 * STEK_MAX_LIFETIME) || check_count > 10) {
+        // Yes we were way past due for a new STEK, and haven't received it.
+        if ((currentTime - lastWarningTime) > STEK_NOT_CHANGED_WARNING_INTERVAL) {
+          // Yes it's time to put another warning in log file.
+          TSError("Session Ticket Encryption Key not syncd in past %d hours.",
+                  static_cast<int>(((currentTime - lastChangeTime) / 3600)));
+
+          lastWarningTime = currentTime;
+        }
+
+        /* Time to nominate a new stek master for pod key rotation... */
+        if (!stek_master_setter_running) {
+          TSDebug(PLUGIN, "Will nominate a new STEK-master thread now for pod key rotation.");
+          TSThreadCreate(STEK_Update_Setter_Thread, nullptr);
+        }
       }
+    } catch (...) {
+      TSDebug(PLUGIN, "STEK_Update_Checker_Thread exception");
+      break;
     }
   } // while(forever)
 

--- a/plugins/experimental/ssl_session_reuse/src/stek.h
+++ b/plugins/experimental/ssl_session_reuse/src/stek.h
@@ -25,8 +25,8 @@
 
 /* STEK - Session Ticket Encryption Key stuff */
 
-#define STEK_ID_NAME "stek" // ACTUALLY it is redis channel minus cluster_name prefix, aka mdbm keyname
-#define STEK_ID_RESEND "resendstek"
+#define STEK_ID_NAME "@stek@" // ACTUALLY it is redis channel minus cluster_name prefix, aka mdbm keyname
+#define STEK_ID_RESEND "@resendstek@"
 #define STEK_MAX_LIFETIME 86400 // 24 hours max - should rotate STEK
 
 #define STEK_NOT_CHANGED_WARNING_INTERVAL (2 * STEK_MAX_LIFETIME) // warn on non-stek rotate every X secs.

--- a/plugins/experimental/ssl_session_reuse/src/subscriber.cc
+++ b/plugins/experimental/ssl_session_reuse/src/subscriber.cc
@@ -96,8 +96,7 @@ RedisSubscriber::is_good()
 int
 RedisSubscriber::get_endpoint_index()
 {
-  int retval = m_redisEndpointsIndex++;
-  return retval;
+  return m_redisEndpointsIndex++;
 }
 
 ::redisContext *
@@ -150,67 +149,72 @@ RedisSubscriber::setup_connection(int index)
 void
 RedisSubscriber::run()
 {
-  TSDebug(PLUGIN, "RedisSubscriber::runMaster: Called.");
+  TSDebug(PLUGIN, "RedisSubscriber::run: Called.");
   int my_endpoint_index = get_endpoint_index();
   ::redisContext *my_context(setup_connection(my_endpoint_index));
   ::redisReply *current_reply(nullptr);
 
-  while (true) {
-    while ((!my_context) || (my_context->err)) {
-      ::usleep(m_redisRetryDelay);
-      my_context = setup_connection(my_endpoint_index);
-    }
-
-    TSDebug(PLUGIN, "RedisSubscriber::runMaster: Issuing command: PSUBSCRIBE %s", m_channel.c_str());
-    current_reply = static_cast<redisReply *>(::redisCommand(my_context, "PSUBSCRIBE %s", m_channel.c_str()));
-
-    if (!current_reply || (REDIS_REPLY_ERROR == current_reply->type)) {
-      TSError("RedisSubscriber::runMaster: Subscribe to redis server on channel: %s failed.", m_channel.c_str());
-      ::usleep(1000 * 1000);
-      continue;
-    } else {
-      TSDebug(PLUGIN, "RedisSubscriber::runMaster: Successfully subscribed to channel: %s", m_channel.c_str());
-      TSDebug(PLUGIN, "RedisSubscriber::runMaster: Waiting for messages to appear on the channel!");
-      ::freeReplyObject(current_reply);
-    }
-
-    // Blocking read
-    while (REDIS_OK == ::redisGetReply(my_context, reinterpret_cast<void **>(&current_reply))) {
-      // Process Message
-      std::string channel(current_reply->element[2]->str, current_reply->element[2]->len);
-      std::string data(current_reply->element[3]->str, current_reply->element[3]->len);
-      TSDebug(PLUGIN, "RedisSubscriber::runMaster: Redis request channel: %s message: %s", channel.c_str(), hex_str(data).c_str());
-
-      std::string key = "";
-      // Strip the channel name to get the key
-      if (channel.compare(0, m_channel_prefix.length(), m_channel_prefix) == 0) {
-        key = channel.substr(m_channel_prefix.length());
+  while (!plugin_threads.shutdown) {
+    try {
+      while ((!my_context) || (my_context->err)) {
+        ::usleep(m_redisRetryDelay);
+        my_context = setup_connection(my_endpoint_index);
       }
 
-      // If this is new keys, go do the ticket key updates
-      if (strncmp(key.c_str(), STEK_ID_NAME, strlen(STEK_ID_NAME)) == 0) {
-        STEK_update(data);
-        // Requesting last ticket to be resent
-      } else if (strncmp(key.c_str(), STEK_ID_RESEND, strlen(STEK_ID_RESEND)) == 0) {
-        if (isSTEKMaster()) {
-          TSDebug(PLUGIN, "RedisSubscriber::runMaster: Resend ticket.");
-          STEK_Send_To_Network(ssl_param.ticket_keys);
-        }
-      } else { // Otherwise this is a new session.  Let ATS core know about it
-        char session_id[SSL_MAX_SSL_SESSION_ID_LENGTH * 2];
-        int session_id_len = sizeof(session_id);
-        if (decode_id(key, session_id, session_id_len) == 0) { // Decrypt the data
-          TSDebug(PLUGIN, "RedisSubscriber::runMaster: Add session encoded_id: %s decoded_id: %.*s %d", key.c_str(), session_id_len,
-                  hex_str(std::string(session_id, session_id_len)).c_str(), session_id_len);
-          add_session(session_id, session_id_len, data);
-        } else {
-          TSDebug(PLUGIN, "RedisSubscriber::runMaster: Failed to decode key: %s", key.c_str());
-        }
+      TSDebug(PLUGIN, "RedisSubscriber::run: Issuing command: PSUBSCRIBE %s", m_channel.c_str());
+      current_reply = static_cast<redisReply *>(::redisCommand(my_context, "PSUBSCRIBE %s", m_channel.c_str()));
+
+      if (!current_reply || (REDIS_REPLY_ERROR == current_reply->type)) {
+        TSError("RedisSubscriber::run: Subscribe to redis server on channel: %s failed.", m_channel.c_str());
+        ::usleep(1000 * 1000);
+        continue;
+      } else {
+        TSDebug(PLUGIN, "RedisSubscriber::run: Successfully subscribed to channel: %s", m_channel.c_str());
+        TSDebug(PLUGIN, "RedisSubscriber::run: Waiting for messages to appear on the channel!");
+        ::freeReplyObject(current_reply);
       }
 
-      ::freeReplyObject(current_reply);
+      // Blocking read
+      while (!plugin_threads.shutdown && REDIS_OK == ::redisGetReply(my_context, reinterpret_cast<void **>(&current_reply))) {
+        // Process Message
+        std::string channel(current_reply->element[2]->str, current_reply->element[2]->len);
+        std::string data(current_reply->element[3]->str, current_reply->element[3]->len);
+        TSDebug(PLUGIN, "RedisSubscriber::run: Redis request channel: %s message: %s", channel.c_str(), hex_str(data).c_str());
 
-      TSDebug(PLUGIN, "RedisSubscriber::runMaster: Got message: %s channel: %s", hex_str(data).c_str(), channel.c_str());
+        std::string key = "";
+        // Strip the channel name to get the key
+        if (channel.compare(0, m_channel_prefix.length(), m_channel_prefix) == 0) {
+          key = channel.substr(m_channel_prefix.length());
+        }
+
+        // If this is new keys, go do the ticket key updates
+        if (strncmp(key.c_str(), STEK_ID_NAME, strlen(STEK_ID_NAME)) == 0) {
+          STEK_update(data);
+          // Requesting last ticket to be resent
+        } else if (strncmp(key.c_str(), STEK_ID_RESEND, strlen(STEK_ID_RESEND)) == 0) {
+          if (isSTEKMaster()) {
+            TSDebug(PLUGIN, "RedisSubscriber::run: Resend ticket.");
+            STEK_Send_To_Network(ssl_param.ticket_keys);
+          }
+        } else { // Otherwise this is a new session.  Let ATS core know about it
+          char session_id[SSL_MAX_SSL_SESSION_ID_LENGTH * 2];
+          int session_id_len = sizeof(session_id);
+          if (decode_id(key, session_id, session_id_len) == 0) { // Decrypt the data
+            TSDebug(PLUGIN, "RedisSubscriber::run: Add session encoded_id: %s decoded_id: %.*s %d", key.c_str(), session_id_len,
+                    hex_str(std::string(session_id, session_id_len)).c_str(), session_id_len);
+            add_session(session_id, session_id_len, data);
+          } else {
+            TSDebug(PLUGIN, "RedisSubscriber::run: Failed to decode key: %s", key.c_str());
+          }
+        }
+
+        ::freeReplyObject(current_reply);
+
+        TSDebug(PLUGIN, "RedisSubscriber::run: Got message: %s channel: %s", hex_str(data).c_str(), channel.c_str());
+      }
+    } catch (...) {
+      TSDebug(PLUGIN, "RedisSubscriber::run exception");
+      break;
     }
   }
 }

--- a/plugins/experimental/ssl_session_reuse/src/subscriber.h
+++ b/plugins/experimental/ssl_session_reuse/src/subscriber.h
@@ -25,6 +25,7 @@
 
 #include <vector>
 #include <string>
+#include <atomic>
 
 #include "message.h"
 #include "globals.h"
@@ -36,7 +37,7 @@ private:
   std::string redis_passwd;
 
   std::vector<RedisEndpoint> m_redisEndpoints;
-  int m_redisEndpointsIndex;
+  std::atomic<int> m_redisEndpointsIndex;
   std::string m_channel;
   std::string m_channel_prefix;
 


### PR DESCRIPTION
Remove `pthread_cancel`, use atomic flags to ensure cross thread safety, and some other cleanups.