### PR TITLE
LGTM: Fix comparing int8_t with wider type

### DIFF
--- a/src/tscpp/util/TextView.cc
+++ b/src/tscpp/util/TextView.cc
@@ -134,7 +134,7 @@ ts::svtoi(TextView src, TextView *out, int base)
       zret = svto_radix<16>(src);
       break;
     default:
-      while (src.size() && (0 <= (v = svtoi_convert[static_cast<unsigned char>(*src)])) && v < base) {
+      while (src.size() && (0 <= (v = svtoi_convert[static_cast<unsigned char>(*src)])) && static_cast<int>(v) < base) {
         auto n = zret * base + v;
         if (n < zret) {
           zret = std::numeric_limits<uintmax_t>::max();


### PR DESCRIPTION
Fix #6353 