### PR TITLE
Add null check to fix error tunnel crash

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1473,7 +1473,7 @@ HttpTunnel::finish_all_internal(HttpTunnelProducer *p, bool chain)
 
   if (action == TCA_PASSTHRU_CHUNKED_CONTENT) {
     // if the only chunked data was in the initial read, make sure we don't consume too much
-    if (p->bytes_read == 0) {
+    if (p->bytes_read == 0 && p->buffer_start != nullptr) {
       int num_read = p->buffer_start->read_avail() - p->chunked_handler.chunked_reader->read_avail();
       if (num_read < p->init_bytes_done) {
         p->init_bytes_done = num_read;


### PR DESCRIPTION
This error was introduced with recent changes to correctly compute the data sent in a chunk in various edge cases.

Over the weekend, we saw many of the following stacks.  I assume network connectivity to one of our origins was flakey.

```
#0  0x0000000000617ce6 in read_avail (this=0x0) at /sd/workspace/src/git.ouroath.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver7/build/../../../../_vcs/trafficserver7/iocore/eventsystem/P_IOBuffer.h:629
#1  HttpTunnel::finish_all_internal (this=this@entry=0x2ab325d493a8, p=p@entry=0x2ab325d495b0, chain=chain@entry=false) at ../../../../../../_vcs/trafficserver7/proxy/http/HttpTunnel.cc:1571
#2  0x00000000005bcd1e in local_finish_all (p=0x2ab325d495b0, this=0x2ab325d493a8) at ../../../../../../_vcs/trafficserver7/proxy/http/HttpTunnel.h:401
#3  HttpSM::tunnel_handler_server (this=0x2ab325d48000, event=3, p=0x2ab325d495b0) at ../../../../../../_vcs/trafficserver7/proxy/http/HttpSM.cc:3132
#4  0x0000000000616e29 in HttpTunnel::producer_handler (this=this@entry=0x2ab325d493a8, event=3, p=0x2ab325d495b0) at ../../../../../../_vcs/trafficserver7/proxy/http/HttpTunnel.cc:1295
#5  0x0000000000617a0f in HttpTunnel::main_handler (this=0x2ab325d493a8, event=<optimized out>, data=<optimized out>) at ../../../../../../_vcs/trafficserver7/proxy/http/HttpTunnel.cc:1696
#6  0x0000000000794c3f in handleEvent (data=0x2ab309256d80, event=3, this=0x2ab325d493a8)
    at /sd/workspace/src/git.ouroath.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver7/build/../../../../_vcs/trafficserver7/iocore/eventsystem/I_Continuation.h:182
#7  read_signal_and_update (vc=0x2ab309256c00, event=3) at ../../../../../../_vcs/trafficserver7/iocore/net/UnixNetVConnection.cc:144
#8  read_signal_done (vc=0x2ab309256c00, nh=0x2ab25f5996a0, event=3) at ../../../../../../_vcs/trafficserver7/iocore/net/UnixNetVConnection.cc:205
#9  read_signal_error (lerrno=518752, vc=0x2ab309256c00, nh=0x2ab25f5996a0) at ../../../../../../_vcs/trafficserver7/iocore/net/UnixNetVConnection.cc:229
#10 UnixNetVConnection::readSignalError (this=this@entry=0x2ab309256c00, nh=nh@entry=0x2ab25f5996a0, err=err@entry=0) at ../../../../../../_vcs/trafficserver7/iocore/net/UnixNetVConnection.cc:1091
#11 0x0000000000773e01 in SSLNetVConnection::net_read_io(NetHandler*, EThread*) () at ../../../../../../_vcs/trafficserver7/iocore/net/SSLNetVConnection.cc:674
#12 0x0000000000787709 in NetHandler::waitForActivity(long) () at ../../../../../../_vcs/trafficserver7/iocore/net/UnixNet.cc:497
#13 0x00000000007cf2c7 in EThread::execute_regular (this=0x2ab25f5959c0) at ../../../../../../_vcs/trafficserver7/iocore/eventsystem/I_PriorityEventQueue.h:116
#14 0x00000000007cd9e2 in spawn_thread_internal (a=0x2ab25cfadd80) at ../../../../../../_vcs/trafficserver7/iocore/eventsystem/Thread.cc:85
#15 0x00002ab25b379dd5 in start_thread () from /lib64/libpthread.so.0
#16 0x00002ab25c0aeead in clone () from /lib64/libc.so.6
```

The issue was that p->buffer_start was null.  This member variable gets set to null at the end of HttpTunnel::producer_run.  So if finish_all_internal gets called from a function invoked from producer_run all is well.  But if the error occurs later, then we need to check that buffer_start is still set before using it to compute the correct value for init_bytes_read.
