### PR TITLE
Perf: Fix mis-usage of Arena in HPACK

### DIFF
--- a/proxy/hdrs/XPACK.h
+++ b/proxy/hdrs/XPACK.h
@@ -32,6 +32,10 @@ const static int XPACK_ERROR_SIZE_EXCEEDED_ERROR = -2;
 // These primitives are shared with HPACK and QPACK.
 int64_t xpack_encode_integer(uint8_t *buf_start, const uint8_t *buf_end, uint64_t value, uint8_t n);
 int64_t xpack_decode_integer(uint64_t &dst, const uint8_t *buf_start, const uint8_t *buf_end, uint8_t n);
+
+// TODO: replace all xpack_encode_string() (without Arena) calls in QPACK
 int64_t xpack_encode_string(uint8_t *buf_start, const uint8_t *buf_end, const char *value, uint64_t value_len, uint8_t n = 7);
+int64_t xpack_encode_string(Arena &arena, uint8_t *buf_start, const uint8_t *buf_end, const char *value, uint64_t value_len,
+                            uint8_t n = 7);
 int64_t xpack_decode_string(Arena &arena, char **str, uint64_t &str_length, const uint8_t *buf_start, const uint8_t *buf_end,
                             uint8_t n = 7);

--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -159,7 +159,10 @@ public:
   uint32_t size() const;
   bool update_maximum_size(uint32_t new_size);
 
+  Arena &arena();
+
 private:
+  Arena _arena;
   HpackDynamicTable *_dynamic_table;
 };
 


### PR DESCRIPTION
`Arena` is used for temporally buffer in some functions of HAPCK, but they are destroyed immediately. This is making some overhead of memory allocation. The arena should be reused.