### PR TITLE
Fix error in cert lookup

### DIFF
--- a/iocore/net/P_SSLCertLookup.h
+++ b/iocore/net/P_SSLCertLookup.h
@@ -98,7 +98,7 @@ public:
   {
   }
   SSLCertContext(shared_SSL_CTX sc, shared_SSLMultiCertConfigParams u)
-    : ctx_mutex(), ctx(sc), opt(u->opt), userconfig(nullptr), keyblock(nullptr)
+    : ctx_mutex(), ctx(sc), opt(u->opt), userconfig(u), keyblock(nullptr)
   {
   }
   SSLCertContext(shared_SSL_CTX sc, shared_SSLMultiCertConfigParams u, shared_ssl_ticket_key_block kb)


### PR DESCRIPTION
Noticed while writing the tests for PR #6483.  Originally had the fix there, but @maskit suggested pulled out the obvious error into a separate PR from the original, involved PR, which seemed quite reasonable.