### PR TITLE
Doc: traffic_manager - Add documentation for exp backoff and config.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -543,7 +543,23 @@ Local Manager
    root processes.
 
    This setting is not reloadable, since it is must be applied when
-   program:`traffic_manager` initializes.
+   :program:`traffic_manager` initializes.
+
+.. ts:cv:: CONFIG proxy.node.config.manager_exponential_sleep_ceiling INT 60
+
+   In case of :program:`traffic_manager` is unable to start :program:`traffic_server`,
+   this setting specifies the maximum amount of seconds that the :program:`traffic_manager`
+   process should wait until it tries again to restart :program:`traffic_server`.
+   In case of :program:`traffic_manager` failing to start :program:`traffic_server`, it will
+   retry exponentially until it reaches the ceiling time.
+
+.. ts:cv:: CONFIG proxy.node.config.manager_retry_cap INT 5
+
+   This setting specifies the number of times that :program:`traffic_manager` will retry
+   to restart :program:`traffic_server` once the  maximum ceiling time is reached.
+
+.. note::
+   If set to ``0``, no cap will take place.
 
 Alarm Configuration
 ===================

--- a/doc/appendices/command-line/traffic_manager.en.rst
+++ b/doc/appendices/command-line/traffic_manager.en.rst
@@ -52,6 +52,20 @@ SIGHUP
 SIGINT, SIGTERM
   These signals cause :program:`traffic_manager` to exit after also shutting down :program:`traffic_server`.
 
+Exponential Back-off Delay
+==========================
+
+  If :program:`traffic_server` has issues communicating with  :program:`traffic_manager` after a crash,
+  :program:`traffic_manager` will retry to start  :program:`traffic_server` using an exponential back-off delay,
+  which will make :program:`traffic_manager` to retry starting :program:`traffic_server` from ``1s`` until it
+  reaches the max ceiling time. The ceiling time is configurable  as well as the number of times that
+  :program:`traffic_manager` will keep trying to start :program:`traffic_server`.
+
+.. note::
+  For more information about this configuration please check :file:`records.config`
+
+
+
 See also
 ========
 


### PR DESCRIPTION
Adding documentation for
- exponential backoff delay
- exponential backoff notes for `traffic_manager` program.

Logic change: [PR6481](https://github.com/apache/trafficserver/pull/6481)