### PR TITLE
Remove method that does nothing.

### DIFF
--- a/include/tscpp/api/Url.h
+++ b/include/tscpp/api/Url.h
@@ -124,14 +124,6 @@ public:
    */
   void setPort(const uint16_t);
 
-  /**
-   * This method allows you to reset the url, this will force the Url to fully re-read all cached values.
-   * If this method is used on a Detached Requests' Url object it will completely destroy the values.
-   *
-   * \note This method should rarely be used.
-   */
-  void reset();
-
 private:
   bool isInitialized() const;
   void init(void *hdr_buf, void *url_loc);

--- a/src/tscpp/api/Url.cc
+++ b/src/tscpp/api/Url.cc
@@ -63,11 +63,6 @@ bool inline Url::isInitialized() const
   return state_->hdr_buf_ && state_->url_loc_;
 }
 
-void
-Url::reset()
-{
-}
-
 std::string
 Url::getUrlString() const
 {

--- a/src/tscpp/api/utils_internal.cc
+++ b/src/tscpp/api/utils_internal.cc
@@ -61,7 +61,6 @@ handleTransactionEvents(TSCont cont, TSEvent event, void *edata)
   utils::internal::setTransactionEvent(transaction, event);
   switch (event) {
   case TS_EVENT_HTTP_POST_REMAP:
-    transaction.getClientRequest().getUrl().reset();
     // This is here to force a refresh of the cached client request url
     TSMBuffer hdr_buf;
     TSMLoc hdr_loc;


### PR DESCRIPTION
Long time ago, this method used to do something, but not anymore.