### PR TITLE
stop individual threads using signals

### DIFF
--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1145,6 +1145,7 @@ tsapi const char *TSHttpHdrReasonLookup(TSHttpStatus status);
 /* --------------------------------------------------------------------------
    Threads */
 tsapi TSThread TSThreadCreate(TSThreadFunc func, void *data);
+tsapi TSThread TSThreadCreateWithSignalling(TSThreadFunc func, void *data, bool term_by_signal);
 tsapi TSThread TSThreadInit(void);
 tsapi void TSThreadDestroy(TSThread thread);
 tsapi void TSThreadWait(TSThread thread);

--- a/tests/gold_tests/term_by_signal/term_by_signal.test.py
+++ b/tests/gold_tests/term_by_signal/term_by_signal.test.py
@@ -1,0 +1,49 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import os
+
+Test.Summary = 'Test TSThreadCreateWithSignalling API'
+Test.ContinueOnFail = True
+
+# Define default ATS
+ts = Test.MakeATSProcess('ts')
+
+Test.testName = 'Test TSThreadCreateWithSignalling API'
+
+ts.Disk.records_config.update({
+    'proxy.config.exec_thread.autoconfig': 0,
+    'proxy.config.exec_thread.autoconfig.scale': 1.5,
+    'proxy.config.exec_thread.limit': 8,
+    'proxy.config.accept_threads': 1,
+    'proxy.config.task_threads': 2,
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'proxy_signal_handler|TSThreadCreateWithSignalling_test'
+})
+
+# Load plugin
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'term_by_signal.so'), ts)
+
+# www.example.com Host
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'printf "Test TSThreadCreateWithSignalling API" && sleep 1'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(ts)
+ts.Ready = 0
+ts.Streams.All = Testers.IncludesExpression('stopping thread with signal', '')

--- a/tests/tools/plugins/Makefile.inc
+++ b/tests/tools/plugins/Makefile.inc
@@ -59,6 +59,9 @@ tools_plugins_ssl_verify_test_la_SOURCES = tools/plugins/ssl_verify_test.cc
 noinst_LTLIBRARIES += tools/plugins/ssntxnorder_verify.la
 tools_plugins_ssntxnorder_verify_la_SOURCES = tools/plugins/ssntxnorder_verify.cc
 
+noinst_LTLIBRARIES += tools/plugins/term_by_signal.la
+tools_plugins_term_by_signal_la_SOURCES = tools/plugins/term_by_signal.cc
+
 noinst_LTLIBRARIES += tools/plugins/test_cppapi.la
 tools_plugins_test_cppapi_la_SOURCES = tools/plugins/test_cppapi.cc
 tools_plugins_test_cppapi_la_LDFLAGS = \

--- a/tests/tools/plugins/term_by_signal.cc
+++ b/tests/tools/plugins/term_by_signal.cc
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+#include <stdlib.h> // for abort
+#include <ts/ts.h>  // for debug
+#include <unistd.h>
+#include <thread>
+
+// debug messages viewable by setting 'proxy.config.diags.debug.tags'
+// in 'records.config'
+
+// plugin registration info
+static char plugin_name[]   = "TSThreadCreateWithSignalling_test";
+static char vendor_name[]   = "apache";
+static char support_email[] = "duke8253@apache.org";
+
+void *
+worker_thread(void *arg)
+{
+  TSDebug(plugin_name, "Thread Started: %lx", reinterpret_cast<unsigned long>(pthread_self()));
+  while (true) {
+    usleep(100000);
+  }
+}
+
+static int
+LifecycleHookTracer(TSCont contp, TSEvent event, void *edata)
+{
+  if (event == TS_EVENT_LIFECYCLE_TASK_THREADS_READY) {
+    for (int i = 0; i < 5; ++i) {
+      TSThreadCreateWithSignalling(worker_thread, nullptr, true);
+    }
+  }
+
+  usleep(10000000);
+
+  return 0;
+}
+
+void
+TSPluginInit(int argc, const char *argv[])
+{
+  TSDebug(plugin_name, "initializing plugin for testing TSThreadCreateWithSignalling");
+
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = plugin_name;
+  info.vendor_name   = vendor_name;
+  info.support_email = support_email;
+
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+    TSDebug(plugin_name, "[%s] plugin registration failed", plugin_name);
+    abort();
+  }
+
+  TSLifecycleHookAdd(TS_LIFECYCLE_TASK_THREADS_READY_HOOK, TSContCreate(LifecycleHookTracer, TSMutexCreate()));
+
+  return;
+}


### PR DESCRIPTION
Like proposed in the mailing list, this should be used by plugins to create threads that want to be stopped when the traffic server process receives an terminating signal (SIGINT, SIGTERM).