### PR TITLE
CacheRead: catch and invalidate an asset with invalid negative cache_seek bytes value.

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -717,8 +717,46 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     bytes     = doc->len - doc_pos;
     if (is_debug_tag_set("cache_seek")) {
       char target_key_str[CRYPTO_HEX_SIZE];
-      key.toHexStr(target_key_str);
-      Debug("cache_seek", "Read # %d @ %" PRId64 "/%d for %" PRId64, fragment, doc_pos, doc->len, bytes);
+      Debug("cache_seek", "Read # %d @ %" PRId64 "/%d for %" PRId64 " %s", fragment, doc_pos, doc->len, bytes,
+            key.toHexStr(target_key_str));
+    }
+
+    // This shouldn't happen for HTTP assets but it does
+    // occasionally in production. This is a temporary fix
+    // to clean up broken objects until the root cause can
+    // be found. It must be the case that either the fragment
+    // offsets are incorrect or a fragment table isn't being
+    // created when it should be.
+    if (frag_type == CACHE_FRAG_TYPE_HTTP && bytes < 0) {
+      char xt[CRYPTO_HEX_SIZE];
+      char yt[CRYPTO_HEX_SIZE];
+
+      int url_length       = 0;
+      char const *url_text = nullptr;
+      if (request.valid()) {
+        url_text = request.url_get()->string_get_ref(&url_length);
+      }
+
+      int64_t prev_frag_size = 0;
+      if (fragment && frags) {
+        prev_frag_size = static_cast<int64_t>(frags[fragment - 1]);
+      }
+
+      Warning("cache_seek range request bug: read %s targ %s - %s frag # %d (prev_frag %" PRId64 ") @ %" PRId64 "/%d for %" PRId64
+              " tot %" PRId64 " url '%.*s'",
+              doc->key.toHexStr(xt), key.toHexStr(yt), f.single_fragment ? "single" : "multi", fragment, prev_frag_size, doc_pos,
+              doc->len, bytes, doc->total_len, url_length, url_text);
+
+      doc->magic = DOC_CORRUPT;
+
+      CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+      if (!lock.is_locked()) {
+        SET_HANDLER(&CacheVC::openReadDirDelete);
+        VC_SCHED_LOCK_RETRY();
+      }
+
+      dir_delete(&earliest_key, vol, &earliest_dir);
+      goto Lerror;
     }
   }
   if (ntodo <= 0) {
@@ -1217,4 +1255,19 @@ Learliest:
   last_collision = nullptr;
   SET_HANDLER(&CacheVC::openReadStartEarliest);
   return openReadStartEarliest(event, e);
+}
+
+/*
+   Handle a directory delete event in case of some detected corruption.
+*/
+int
+CacheVC::openReadDirDelete(int event, Event *e)
+{
+  MUTEX_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+  if (!lock.is_locked()) {
+    VC_SCHED_LOCK_RETRY();
+  }
+
+  dir_delete(&earliest_key, vol, &earliest_dir);
+  return calluser(VC_EVENT_ERROR);
 }

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -326,6 +326,7 @@ struct CacheVC : public CacheVConnection {
   int openReadFromWriterMain(int event, Event *e);
   int openReadFromWriterFailure(int event, Event *);
   int openReadChooseWriter(int event, Event *e);
+  int openReadDirDelete(int event, Event *e);
 
   int openWriteCloseDir(int event, Event *e);
   int openWriteCloseHeadDone(int event, Event *e);


### PR DESCRIPTION
One of our delivery services has all of its assets under 2.7MB.  Some clients range request into the asset and we use the background_fetch plugin to handle these.  While 
testing a different way of handling these assets we found occasional oversized single fragment assets that returned bad data ONLY when the range request start is beyond normal 1048576 byte sized fragment would be. Invalidating and repulling the asset would fix it for range request use.

This patch detects that condition, tags the cache entry as corrupt and deletes it from the cache directory, resulting in a TCP_SWAPFAIL_MISS then a refetch of the asset.

I tested this by simulating a thundering herd against a single asset, then forcing the fail condition when a range request is made.  Each range request resulted in a swapfail and any normal requests threads in process of fetching cache blocks would swapfail as well.  A TCP_MISS would follow by continued TCP_(MEM)_HITs.

This only checks for a condition that should never happen and is of limited impact.