### PR TITLE
Check the exit value of the regression test

### DIFF
--- a/ci/jenkins/bin/github.sh
+++ b/ci/jenkins/bin/github.sh
@@ -76,7 +76,6 @@ echo -n "Unit tests finished at " && date
 echo
 echo -n "Regression tests started at " && date
 ${INSTALL}/bin/traffic_server -K -k -R 1
+rval=$?
 echo -n "Regression tests finished at " && date
-[ "0" != "$?" ] && exit 1
-
-exit 0
+exit $rval

--- a/ci/jenkins/bin/regression.sh
+++ b/ci/jenkins/bin/regression.sh
@@ -28,4 +28,6 @@ ${ATS_MAKE} install || exit 1
 echo
 echo -n "Regression tests started at " && date
 "${ATS_BUILD_BASEDIR}/install/bin/traffic_server" -k -K -R 1
+rval=$?
 echo -n "Regression tests finished at " && date
+exit $rval


### PR DESCRIPTION
Looks like this has been happening since 11/20/19:
```
bd69a108d1 (Leif Hedstrom 2019-08-27 09:35:57 -0600 74) [ -x ${INSTALL}/bin/traffic_server ] || exit 1
54b7bace25 (Leif Hedstrom 2017-05-19 16:13:48 -0600 75)
ed7add8ce0 (Leif Hedstrom 2019-11-20 16:32:35 +0800 76) echo
ed7add8ce0 (Leif Hedstrom 2019-11-20 16:32:35 +0800 77) echo -n "Regression tests started at " && date
54b7bace25 (Leif Hedstrom 2017-05-19 16:13:48 -0600 78) ${INSTALL}/bin/traffic_server -K -k -R 1
ed7add8ce0 (Leif Hedstrom 2019-11-20 16:32:35 +0800 79) echo -n "Regression tests finished at " && date
bd69a108d1 (Leif Hedstrom 2019-08-27 09:35:57 -0600 80) [ "0" != "$?" ] && exit 1
```