### PR TITLE
Adds support for configure option --enable-yaml-headers

### DIFF
--- a/build/yaml-cpp.m4
+++ b/build/yaml-cpp.m4
@@ -84,3 +84,14 @@ AC_SUBST([YAMLCPP_LIBS])
 AC_SUBST([YAMLCPP_LDFLAGS])
 
 ])
+
+dnl TS_CHECK_YAML_HEADERS_EXPORT: check if we want to export yaml-cpp headers from trafficserver. default: not exported
+AC_DEFUN([TS_CHECK_YAML_HEADERS_EXPORT], [
+AC_MSG_CHECKING([whether to export yaml-cpp headers])
+AC_ARG_ENABLE([yaml-headers],
+  [AS_HELP_STRING([--enable-yaml-headers],[Export yaml-cpp headers])],
+  [],
+  [enable_yaml_headers=no]
+)
+AC_MSG_RESULT([$enable_yaml_headers])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1432,6 +1432,9 @@ AC_SUBST([LIBJANSSON])
 TS_CHECK_YAML_CPP
 AM_CONDITIONAL([BUILD_YAML_CPP], [test x"$has_yaml_cpp" = x"no"])
 
+TS_CHECK_YAML_HEADERS_EXPORT
+AM_CONDITIONAL([EXPORT_YAML_HEADERS], [test x"$enable_yaml_headers" = x"yes"])
+
 # Check for optional hiredis library
 TS_CHECK_HIREDIS
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -35,5 +35,7 @@ all-local:	$(LOCAL)
 clean-local:
 	$(MAKE) -C yamlcpp clean
 
+if EXPORT_YAML_HEADERS
 install-data-local:
 	$(MAKE) -C yamlcpp install
+endif


### PR DESCRIPTION
=> Gives build-time control for exporting yaml-cpp headers from
trafficserver. By default, headers won't be exported.
=> Enhances support added in following commit:
a71a815dacea967b3e02a1f103b7ae199d993913 (Export headers for internal
YAML-CPP library)
=> Allows client-code to keep using their own yaml-cpp headers without
any interference from yam-cpp headers in trafficserver