### PR TITLE
Don't be overly aggressive on stream failures and closing

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -610,8 +610,8 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
       ip_port_text_buffer ipb;
       const char *client_ip = ats_ip_ntop(get_client_addr(), ipb, sizeof(ipb));
       Warning("HTTP/2 session error client_ip=%s session_id=%" PRId64
-              " closing a connection, because its stream error rate (%f) is too high",
-              client_ip, connection_id(), this->connection_state.get_stream_error_rate());
+              " closing a connection, because its stream error rate (%f) exceeded the threshold (%f)",
+              client_ip, connection_id(), this->connection_state.get_stream_error_rate(), Http2::stream_error_rate_threshold);
       err = Http2ErrorCode::HTTP2_ERROR_ENHANCE_YOUR_CALM;
     }
 

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -250,7 +250,8 @@ public:
   get_stream_error_rate() const
   {
     int total = get_stream_requests();
-    if (total > 0) {
+
+    if (total >= (1 / Http2::stream_error_rate_threshold)) {
       return (double)stream_error_count / (double)total;
     } else {
       return 0;


### PR DESCRIPTION
Randall found this in our production. I'm thinking 1/threshold is a good limit here, such that you can at least calculate a reasonable percentage based on a large enough sample.