### PR TITLE
Allow lo interface in list of system stats

### DIFF
--- a/plugins/experimental/system_stats/system_stats.c
+++ b/plugins/experimental/system_stats/system_stats.c
@@ -160,7 +160,7 @@ netStatsInfo(TSMutex stat_creation_mutex)
   }
 
   while ((dent = readdir(srcdir)) != NULL) {
-    if (strcmp(dent->d_name, ".") == 0 || strcmp(dent->d_name, "..") == 0 || strcmp(dent->d_name, "lo") == 0) {
+    if (strcmp(dent->d_name, ".") == 0 || strcmp(dent->d_name, "..") == 0) {
       continue;
     }
 


### PR DESCRIPTION
We (and others) may have a use case for needing lo in the list of system stats, removing the restriction