### PR TITLE
Add FetchSM support to dechunking in non-streaming mode with new TS API TSFetchFlagSet

### DIFF
--- a/doc/developer-guide/api/functions/TSFetchCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSFetchCreate.en.rst
@@ -1,0 +1,55 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSFetchCreate
+*************
+
+Traffic Server asynchronous Fetch API.
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: void TSFetchPages(TSFetchUrlParams_t *)
+.. function:: void TSFetchUrl(const char *, int, sockaddr const *, TSCont, TSFetchWakeUpOptions, TSFetchEvent)
+.. function:: void TSFetchFlagSet(TSFetchSM, int)
+.. function:: TSFetch TSFetchCreate(TSCont, const char *, const char *, const char *, struct sockaddr const *, int)
+.. function:: void TSFetchHeaderAdd(TSFetchSM, const char *, int, const char *, int)
+.. function:: void TSFetchWriteData(TSFetchSM, const void *, size_t)
+.. function:: ssize_t TSFetchReadData(TSFetchSM, void *, size_t)
+.. function:: void TSFetchLaunch(TSFetchSM)
+.. function:: void TSFetchDestroy(TSFetchSM)
+.. function:: void TSFetchUserDataSet(TSFetchSM, void *)
+.. function:: void* TSFetchUserDataGet(TSFetchSM)
+.. function:: TSMBuffer TSFetchRespHdrMBufGet(TSFetchSM)
+.. function:: TSMLoc TSFetchRespHdrMLocGet(TSFetchSM)
+
+Description
+===========
+
+Traffic Server provides a number of routines for fetching resources asynchronously.
+These API are useful to support a number of use cases that may involve sideways
+calls, while handling the client request. Some typical examples include centralized
+rate limiting framework, database lookups for login/authentication, refreshing configs
+in the background asynchronously, ESI etc.

--- a/include/ts/experimental.h
+++ b/include/ts/experimental.h
@@ -380,6 +380,16 @@ tsapi TSFetchSM TSFetchCreate(TSCont contp, const char *method, const char *url,
                               struct sockaddr const *client_addr, int flags);
 
 /*
+ * Set fetch flags to FetchSM Context
+ *
+ * @param fetch_sm: returned value of TSFetchCreate().
+ * @param flags: can be bitwise OR of several TSFetchFlags.
+ *
+ * return void
+ */
+tsapi void TSFetchFlagSet(TSFetchSM fetch_sm, int flags);
+
+/*
  * Create FetchSM, this API will enable stream IO automatically.
  *
  * @param fetch_sm: returned value of TSFetchCreate().

--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -359,6 +359,7 @@ void
 FetchSM::get_info_from_buffer(IOBufferReader *reader)
 {
   char *buf, *info;
+  IOBufferBlock *blk;
   int64_t read_avail, read_done;
 
   if (!reader) {
@@ -376,15 +377,42 @@ FetchSM::get_info_from_buffer(IOBufferReader *reader)
   info            = (char *)ats_malloc(sizeof(char) * (read_avail + 1));
   client_response = info;
 
-  // To maintain backwards compatibility we don't allow chunking when it's not streaming.
-  if (!(fetch_flags & TS_FETCH_FLAGS_STREAM) || !check_chunked()) {
+  /* Read the data out of the reader */
+  if (reader->block != NULL)
+    reader->skip_empty_blocks();
+
+  blk = reader->block.get();
+
+  // This is the equivalent of TSIOBufferBlockReadStart()
+  buf       = blk->start() + reader->start_offset;
+  read_done = blk->read_avail() - reader->start_offset;
+
+  if (header_done == 0 && read_done > 0) {
+    int bytes_used = 0;
+    header_done    = 1;
+    if (client_response_hdr.parse_resp(&http_parser, reader, &bytes_used, 0) == PARSE_RESULT_DONE) {
+      if (bytes_used > 0) {
+        memcpy(info, buf, bytes_used);
+        info += bytes_used;
+        client_bytes += bytes_used;
+      }
+    } else {
+      Error("Failed to parse headers in FetchSM buffer");
+    }
+    // adjust the read_avail
+    read_avail -= bytes_used;
+  }
+
+  // Send the body without dechunk when neither streaming nor dechunk flag is set
+  // Or when the body is not chunked
+  if (!((fetch_flags & TS_FETCH_FLAGS_STREAM) || (fetch_flags & TS_FETCH_FLAGS_DECHUNK)) || !check_chunked()) {
     /* Read the data out of the reader */
     while (read_avail > 0) {
       if (reader->block) {
         reader->skip_empty_blocks();
       }
 
-      IOBufferBlock *blk = reader->block.get();
+      blk = reader->block.get();
 
       // This is the equivalent of TSIOBufferBlockReadStart()
       buf       = blk->start() + reader->start_offset;

--- a/src/traffic_server/FetchSM.h
+++ b/src/traffic_server/FetchSM.h
@@ -61,7 +61,6 @@ public:
     callback_events  = events;
     callback_options = options;
     _addr.assign(addr);
-    fetch_flags = TS_FETCH_FLAGS_DECHUNK;
     writeRequest(headers, length);
     mutex = new_ProxyMutex();
 
@@ -74,6 +73,12 @@ public:
     // So we should set the water_mark of resp_buffer with a large value,
     // INT64_MAX would be reasonable.
     resp_buffer->water_mark = INT64_MAX;
+  }
+
+  void
+  set_fetch_flags(int flags)
+  {
+    fetch_flags = flags;
   }
 
   int fetch_handler(int event, void *data);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -7916,6 +7916,13 @@ TSFetchUrl(const char *headers, int request_len, sockaddr const *ip, TSCont cont
   fetch_sm->httpConnect();
 }
 
+void
+TSFetchFlagSet(TSFetchSM fetch_sm, int flags)
+{
+  sdk_assert(sdk_sanity_check_fetch_sm(fetch_sm) == TS_SUCCESS);
+  (reinterpret_cast<FetchSM *>(fetch_sm))->set_fetch_flags(flags);
+}
+
 TSFetchSM
 TSFetchCreate(TSCont contp, const char *method, const char *url, const char *version, struct sockaddr const *client_addr, int flags)
 {


### PR DESCRIPTION



to enable TSFetchUrl to use HTTP/1.1

FetchSM supports dechunking of chunked response but only in
STREAM mode (ie headers first and body in stream). However,
we may need to use FetchSM for sideways calls with dechunked
body and non-stream mode ie headers and body together. Without
this, TSFetchUrl can only work with HTTP/1.0 which is limiting
as it doesn't allow us to enable keep alive and all 1.1 goodness
This PR fixes the problem by allowing to dechunk response even
when stream mode isn't specified