### PR TITLE
Perf: Use LocalBuffer in HTTP/2

### DIFF
--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -22,7 +22,8 @@
  */
 
 #include "HPACK.h"
-#include "HuffmanCodec.h"
+
+#include "tscpp/util/LocalBuffer.h"
 
 // [RFC 7541] 4.1. Calculating Table Size
 // The size of an entry is the sum of its name's length in octets (as defined in Section 5.2),
@@ -581,12 +582,14 @@ encode_literal_header_field_with_new_name(uint8_t *buf_start, const uint8_t *buf
 
   // Convert field name to lower case to follow HTTP2 spec.
   // This conversion is needed because WKSs in MIMEFields is old fashioned
-  Arena arena;
   int name_len;
-  const char *name = header.name_get(&name_len);
-  char *lower_name = arena.str_store(name, name_len);
+  const char *original_name = header.name_get(&name_len);
+
+  ts::LocalBuffer<char> local_buffer(name_len);
+  char *lower_name = local_buffer.data();
+
   for (int i = 0; i < name_len; i++) {
-    lower_name[i] = ParseRules::ink_tolower(lower_name[i]);
+    lower_name[i] = ParseRules::ink_tolower(original_name[i]);
   }
 
   // Name String
@@ -606,7 +609,7 @@ encode_literal_header_field_with_new_name(uint8_t *buf_start, const uint8_t *buf
 
   p += len;
 
-  Debug("hpack_encode", "Encoded field: %.*s: %.*s", name_len, name, value_len, value);
+  Debug("hpack_encode", "Encoded field: %.*s: %.*s", name_len, lower_name, value_len, value);
   return p - buf_start;
 }
 

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -30,6 +30,7 @@
 #include "HttpDebugNames.h"
 
 #include "tscpp/util/PostScript.h"
+#include "tscpp/util/LocalBuffer.h"
 
 #include <sstream>
 #include <numeric>
@@ -1587,8 +1588,6 @@ Http2ConnectionState::send_data_frames(Http2Stream *stream)
 void
 Http2ConnectionState::send_headers_frame(Http2Stream *stream)
 {
-  uint8_t *buf                = nullptr;
-  uint32_t buf_len            = 0;
   uint32_t header_blocks_size = 0;
   int payload_length          = 0;
   uint8_t flags               = 0x00;
@@ -1598,17 +1597,14 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
   HTTPHdr *resp_hdr = &stream->response_header;
   http2_convert_header_from_1_1_to_2(resp_hdr);
 
-  buf_len = resp_hdr->length_get() * 2; // Make it double just in case
-  buf     = static_cast<uint8_t *>(ats_malloc(buf_len));
-  if (buf == nullptr) {
-    return;
-  }
+  uint32_t buf_len = resp_hdr->length_get() * 2; // Make it double just in case
+  ts::LocalBuffer local_buffer(buf_len);
+  uint8_t *buf = local_buffer.data();
 
   stream->mark_milestone(Http2StreamMilestone::START_ENCODE_HEADERS);
   Http2ErrorCode result = http2_encode_header_blocks(resp_hdr, buf, buf_len, &header_blocks_size, *(this->remote_hpack_handle),
                                                      client_settings.get(HTTP2_SETTINGS_HEADER_TABLE_SIZE));
   if (result != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
-    ats_free(buf);
     return;
   }
 
@@ -1635,7 +1631,6 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
       fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
     }
 
-    ats_free(buf);
     return;
   }
 
@@ -1658,15 +1653,11 @@ Http2ConnectionState::send_headers_frame(Http2Stream *stream)
     this->ua_session->xmit(continuation_frame);
     sent += payload_length;
   }
-
-  ats_free(buf);
 }
 
 bool
 Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding)
 {
-  uint8_t *buf                = nullptr;
-  uint32_t buf_len            = 0;
   uint32_t header_blocks_size = 0;
   int payload_length          = 0;
   uint8_t flags               = 0x00;
@@ -1698,15 +1689,13 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
 
   http2_convert_header_from_1_1_to_2(&hdr);
 
-  buf_len = hdr.length_get() * 2; // Make it double just in case
-  buf     = static_cast<uint8_t *>(ats_malloc(buf_len));
-  if (buf == nullptr) {
-    return false;
-  }
+  uint32_t buf_len = hdr.length_get() * 2; // Make it double just in case
+  ts::LocalBuffer local_buffer(buf_len);
+  uint8_t *buf = local_buffer.data();
+
   Http2ErrorCode result = http2_encode_header_blocks(&hdr, buf, buf_len, &header_blocks_size, *(this->remote_hpack_handle),
                                                      client_settings.get(HTTP2_SETTINGS_HEADER_TABLE_SIZE));
   if (result != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
-    ats_free(buf);
     return false;
   }
 
@@ -1742,7 +1731,6 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
     this->ua_session->xmit(continuation);
     sent += payload_length;
   }
-  ats_free(buf);
 
   Http2Error error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
   stream = this->create_stream(id, error);


### PR DESCRIPTION
Replace Arena and ats_malloc/free with LocalBuffer as much as possible. This is another approach of #6495.

I left `xpack_decode_string()` with Arena because it's a tricky one.

Mark as draft PR until #6528 is merged.