### PR TITLE
Disables "virtual host not used with AWS auth v4" error in s3_auth

### DIFF
--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -203,9 +203,7 @@ public:
       }
     } else {
       /* 4 == _version */
-      if (_virt_host_modified) {
-        TSError("[%s] virtual host not used with AWS auth v4, parameter ignored", PLUGIN_NAME);
-      }
+      // NOTE: virtual host not used with AWS auth v4, parameter ignored
     }
     return true;
   }


### PR DESCRIPTION
This would error on every request