### PR TITLE
Removes copypasta curl text from tests and removes checks for curl

### DIFF
--- a/tests/gold_tests/cache/cache-generation-disjoint.test.py
+++ b/tests/gold_tests/cache/cache-generation-disjoint.test.py
@@ -21,7 +21,7 @@ import uuid
 Test.Summary = '''
 Test that the same URL path in different cache generations creates disjoint objects
 '''
-# need Curl
+
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts")

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -19,7 +19,7 @@
 Test.Summary = '''
 Test chunked encoding processing
 '''
-# need Curl with HTTP/2
+
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
@@ -20,11 +20,9 @@ import os
 Test.Summary = '''
 Test interaction of H2 and chunked encoding
 '''
-# need Curl
+
 Test.SkipUnless(
     Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
-    Condition.HasProgram("nc", "Nc needs to be installed on this system for this test to work"),
-    Condition.HasProgram("curl", "Curl need to be installed on system for this test to work"),
     Condition.HasCurlFeature('http2')
 )
 Test.ContinueOnFail = True

--- a/tests/gold_tests/h2/h2disable.test.py
+++ b/tests/gold_tests/h2/h2disable.test.py
@@ -20,7 +20,6 @@ Test.Summary = '''
 Test disabling H2 on a per domain basis
 '''
 
-# need Curl
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
@@ -20,7 +20,6 @@ Test.Summary = '''
 Test disabling H2 on a per domain basis
 '''
 
-# need Curl
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/h2/h2enable.test.py
+++ b/tests/gold_tests/h2/h2enable.test.py
@@ -20,7 +20,6 @@ Test.Summary = '''
 Test enabling H2 on a per domain basis
 '''
 
-# need Curl
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
@@ -20,7 +20,6 @@ Test.Summary = '''
 Test enabling H2 on a per domain basis
 '''
 
-# need Curl
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -20,7 +20,7 @@ import os
 Test.Summary = '''
 Test a basic remap of a http/2 connection
 '''
-# need Curl
+
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/h2/http2_priority.test.py
+++ b/tests/gold_tests/h2/http2_priority.test.py
@@ -20,7 +20,6 @@ Test.Summary = '''
 Test a basic remap of a http connection with Stream Priority Feature
 '''
 
-# need Curl
 Test.SkipUnless(
     Condition.HasCurlFeature('http2'),
     Condition.HasProgram("shasum", "shasum need to be installed on system for this test to work"),

--- a/tests/gold_tests/h2/nghttp.test.py
+++ b/tests/gold_tests/h2/nghttp.test.py
@@ -20,7 +20,7 @@ import os
 Test.Summary = '''
 Test with nghttp
 '''
-# need Curl
+
 Test.SkipUnless(
     Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
 )

--- a/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
+++ b/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
@@ -19,7 +19,7 @@
 Test.Summary = '''
 Test experimental/multiplexer.
 '''
-# need Curl
+
 Test.SkipUnless(
     Condition.PluginExists('multiplexer.so')
 )

--- a/tests/gold_tests/timeout/active_timeout.test.py
+++ b/tests/gold_tests/timeout/active_timeout.test.py
@@ -18,7 +18,6 @@
 
 Test.Summary = 'Testing ATS active timeout'
 
-# need Curl
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/timeout/inactive_timeout.test.py
+++ b/tests/gold_tests/timeout/inactive_timeout.test.py
@@ -18,7 +18,6 @@
 
 Test.Summary = 'Testing ATS inactivity timeout'
 
-# need Curl
 Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -23,7 +23,6 @@ Test TLS protocol offering  based on SNI
 # By default only offer TLSv1_2
 # for special doman foo.com only offer TLSv1 and TLSv1_1
 
-# need Curl
 Test.SkipUnless(
     Condition.HasOpenSSLVersion("1.1.1")
 )


### PR DESCRIPTION
It was decided that curl is a base requirement for autest back in
6c1a90f4f209a02cf1345ac4c20e2e67c4c58db1