### PR TITLE
free(map); -> delete map;

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -74,7 +74,7 @@ certinfo_map_free(void * /*parent*/, void *ptr, CRYPTO_EX_DATA * /*ad*/, int /*i
     ink_mutex_destroy(&iter->second->stapling_mutex);
     OPENSSL_free(iter->second);
   }
-  free(map);
+  delete map;
 }
 
 static int ssl_stapling_index = -1;


### PR DESCRIPTION
Fixing an ASan reported alloc-dealloc-mismatch in which `map` was
constructed with new but destructed with free instead of delete
in `certinfo_map_free`.