### PR TITLE
Support body factory template suppression for internal requests

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2395,7 +2395,7 @@ Customizable User Response Pages
    ===== ======================================================================
    ``0`` Never suppress generated response pages.
    ``1`` Always suppress generated response pages.
-   ``2`` Suppress response pages only for intercepted traffic.
+   ``2`` Suppress response pages only for internal traffic.
    ===== ======================================================================
 
 .. ts:cv:: CONFIG proxy.config.http_ui_enabled INT 0

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -674,7 +674,7 @@ static const RecordElement RecordsConfig[] =
   ,
   //# 0 - never suppress generated responses
   //# 1 - always suppress generated responses
-  //# 2 - suppress responses for intercepted traffic
+  //# 2 - suppress responses for internal traffic
   {RECT_CONFIG, "proxy.config.body_factory.response_suppression_mode", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.body_factory.template_base", RECD_STRING, "NONE", RECU_DYNAMIC, RR_NULL, RECC_STR, ".*", RECA_NULL}


### PR DESCRIPTION
Repurpose unused config proxy.config.body_factory.response_suppression_mode (2)

Email to dev/users@

```Sudheer Vinukonda <sudheervinukonda@yahoo.com>
To:
users
,
dev@trafficserver.apache.org
Cc:
mmahto@linkedin.com

Mon, Mar 9 at 1:47 PM

After discussing with Bryan and Alan, I'm going to go ahead with the change to repurpose the currently dead setting `2` to mean  ``2`` = suppress response pages only for *internal* traffic

> .. ts:cv:: CONFIG proxy.config.body_factory.response_suppression_mode INT 0
>    Specifies when Traffic Server suppresses generated response pages:
>    -  ``0`` = never suppress generated response pages
>    -  ``1`` = always suppress generated response pages
>    -  ``2`` = suppress response pages only for *internal* traffic



Thanks,

Sudheer

On Friday, March 6, 2020, 11:48:18 AM PST, Bryan Call <bcall@apache.org> wrote:


+1 - Looks good to me.

-Bryan


> On Mar 6, 2020, at 9:49 AM, Sudheer Vinukonda <sudheervinukonda@yahoo.com> wrote:
>
> We've a lot of use cases, that trigger internal requests via TSFetchUrl. We've body_factory enabled (0) for our response error templates which is nice, but we'd like to suppress the error template responses for internal requests (note that body factory code is quite a bit of an overhead due to mallocs/locks etc in request path -- we need to improve that, but that's a bit outside the scope of this email).
> Looking at the configs, we have proxy.config.body_factory.response_suppression_mode which can take the below values today. It looks like
> 2 (`2`` = suppress response pages only for intercepted traffic) is not used at all looking through the code. Discussed with Bryan over slack and we think it's reasonable to repurpose `2` as `2`` = suppress response pages only for internal traffic.
> Let me know if there are any concerns.
> https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.config.en.html#proxy-config-body-factory-response-suppression-mode <https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.config.en.html#proxy-config-body-factory-response-suppression-mode>
>
> .. ts:cv:: CONFIG proxy.config.body_factory.response_suppression_mode INT 0
>    Specifies when Traffic Server suppresses generated response pages:
>    -  ``0`` = never suppress generated response pages
>    -  ``1`` = always suppress generated response pages
>    -  ``2`` = suppress response pages only for intercepted traffic
>
> -- Sudheer
>```