### PR TITLE
Fixed build issue with Ubuntu 16 debug

### DIFF
--- a/include/tscore/PluginUserArgs.h
+++ b/include/tscore/PluginUserArgs.h
@@ -28,12 +28,12 @@
 #include "tscore/ink_assert.h"
 #include "tscore/PluginUserArgs.h"
 
-static constexpr std::array<size_t, TS_USER_ARGS_COUNT> MAX_USER_ARGS = {
+static constexpr std::array<size_t, TS_USER_ARGS_COUNT> MAX_USER_ARGS = {{
   16, /* max number of user arguments for TXN */
   8,  /* max number of user arguments for SSN */
   4,  /* max number of user arguments for VCONN */
   128 /* max number of user arguments for GLB */
-};
+}};
 
 /**
   This is a mixin class (sort of), implementing the appropriate APIs and data storage for


### PR DESCRIPTION
Seeing this on CI:
```
../../../include/tscore/PluginUserArgs.h:32:3: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
  16, /* max number of user arguments for TXN */
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  {
1 error generated.
```