### PR TITLE
SSL: Always renew TLS Session Tickets iff TLSv1.3 is being used

### DIFF
--- a/iocore/net/SSLSessionTicket.cc
+++ b/iocore/net/SSLSessionTicket.cc
@@ -102,8 +102,8 @@ ssl_callback_session_ticket(SSL *ssl, unsigned char *keyname, unsigned char *iv,
 
         netvc.setSSLSessionCacheHit(true);
 
-#if TS_HAS_TLS_EARLY_DATA
-        if (SSL_version(ssl) >= TLS1_3_VERSION && config->server_max_early_data > 0) {
+#ifdef TLS1_3_VERSION
+        if (SSL_version(ssl) >= TLS1_3_VERSION) {
           Debug("ssl_session_ticket", "make sure tickets are only used once.");
           return 2;
         }


### PR DESCRIPTION
Always renew TLS Session Tickets when TLSv1.3 is being used. This mimics the default OpenSSL behaviour as described in [SSL_CTX_set_session_ticket_cb(3)](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_session_ticket_cb.html):
> By default, in TLSv1.2 and below, a new session ticket is not issued on a successful resumption and therefore gen_cb will not be called. In TLSv1.3 the default behaviour is to always issue a new ticket on resumption

This also gets rid of the following behavior differences:
* If `proxy.config.ssl.session_cache` is enabled and `proxy.config.ssl.server.session_ticket.enable` is disabled TS issues TLSv1.3 session tickets for new and reused TLS sessions.
* If `proxy.config.ssl.session_cache` and `proxy.config.ssl.server.session_ticket.enable` are both enabled TS issues TLSv1.3 session tickets for new TLS sessions.
