### PR TITLE
Remove session use-after free

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -87,6 +87,7 @@ read_signal_and_update(int event, UnixNetVConnection *vc)
     case VC_EVENT_ERROR:
     case VC_EVENT_ACTIVE_TIMEOUT:
     case VC_EVENT_INACTIVITY_TIMEOUT:
+      Warning("Closing orphaned vc %p", vc);
       Debug("inactivity_cop", "event %d: null read.vio cont, closing vc %p", event, vc);
       vc->closed = 1;
       break;

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -316,10 +316,6 @@ Http1ClientSession::state_wait_for_close(int event, void *data)
   case VC_EVENT_INACTIVITY_TIMEOUT:
     half_close = false;
     this->do_io_close();
-    if (client_vc != nullptr) {
-      client_vc->do_io_close();
-      client_vc = nullptr;
-    }
     break;
   case VC_EVENT_READ_READY:
     // Drain any data read
@@ -396,10 +392,6 @@ Http1ClientSession::state_keep_alive(int event, void *data)
 
   case VC_EVENT_EOS:
     this->do_io_close();
-    if (client_vc != nullptr) {
-      client_vc->do_io_close();
-      client_vc = nullptr;
-    }
     break;
 
   case VC_EVENT_READ_COMPLETE:

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -185,9 +185,7 @@ Http1ServerSession::release()
     return;
   }
 
-  // Make sure the vios for the current SM are cleared
-  server_vc->do_io_read(nullptr, 0, nullptr);
-  server_vc->do_io_write(nullptr, 0, nullptr);
+  // release_session or do_io_close will clear the IO operations from the SM
 
   HSMresult_t r = httpSessionManager.release_session(this);
 


### PR DESCRIPTION
I had added these client_vc checks to try and address stale references to client_vc pointers that we were seeing.  However referencing the session object after calling do_io_close is dangerous because the session object may have been freed on return.  @bneradt caught this as a use-after-free when working with an ASAN build and the traffic-dump plugin in our prod sym environment.

My current theory on the stale client_vc is that the netvc is closing due to EOS or an error while the read/write_vio's have the continuation set to 0.  In that case the SM/tunnel/session will not be notified that the netvc has been deleted.  I added a Warning message so we can look for that case in our logs.  Thought about adding an assert, but I figured the Warning would be less invasive.  It may be ok to have an unattached netvc in some cases.

I also removed one set of do_io_read null's that I don't think are necessary.