### PR TITLE
Ensure TSContSchedule API family are called from an EThread.

### DIFF
--- a/doc/developer-guide/api/functions/TSContSchedule.en.rst
+++ b/doc/developer-guide/api/functions/TSContSchedule.en.rst
@@ -44,6 +44,9 @@ another thread this can be problematic to be correctly timed. The return value c
 :func:`TSActionDone` to see if the continuation ran before the return, which is possible if
 :arg:`timeout` is `0`. Returns ``nullptr`` if thread affinity was cleared.
 
+Note that the TSContSchedule() family of API shall only be called from an ATS EThread.
+Calling it from raw non-EThreads can result in unpredictable behavior.
+
 See Also
 ========
 

--- a/doc/developer-guide/api/functions/TSContScheduleOnPool.en.rst
+++ b/doc/developer-guide/api/functions/TSContScheduleOnPool.en.rst
@@ -54,6 +54,9 @@ called and continuations that use them have the same restrictions. ``TS_THREAD_P
 are threads that exist to perform long or blocking actions, although sufficiently long operation can
 impact system performance by blocking other continuations on the threads.
 
+Note that the TSContSchedule() family of API shall only be called from an ATS EThread.
+Calling it from raw non-EThreads can result in unpredictable behavior.
+
 Example Scenarios
 =================
 

--- a/doc/developer-guide/api/functions/TSContScheduleOnThread.en.rst
+++ b/doc/developer-guide/api/functions/TSContScheduleOnThread.en.rst
@@ -35,6 +35,9 @@ Description
 
 Mostly the same as :func:`TSContSchedule`. Schedules :arg:`contp` on :arg:`ethread`.
 
+Note that the TSContSchedule() family of API shall only be called from an ATS EThread.
+Calling it from raw non-EThreads can result in unpredictable behavior.
+
 See Also
 ========
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -4517,6 +4517,9 @@ TSContSchedule(TSCont contp, TSHRTime timeout)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(contp) == TS_SUCCESS);
 
+  /* ensure we are on a EThread */
+  sdk_assert(sdk_sanity_check_null_ptr((void *)this_ethread()) == TS_SUCCESS);
+
   FORCE_PLUGIN_SCOPED_MUTEX(contp);
 
   INKContInternal *i = reinterpret_cast<INKContInternal *>(contp);
@@ -4546,6 +4549,9 @@ TSAction
 TSContScheduleOnPool(TSCont contp, TSHRTime timeout, TSThreadPool tp)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(contp) == TS_SUCCESS);
+
+  /* ensure we are on a EThread */
+  sdk_assert(sdk_sanity_check_null_ptr((void *)this_ethread()) == TS_SUCCESS);
 
   FORCE_PLUGIN_SCOPED_MUTEX(contp);
 
@@ -4624,6 +4630,9 @@ TSContScheduleEvery(TSCont contp, TSHRTime every /* millisecs */)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(contp) == TS_SUCCESS);
 
+  /* ensure we are on a EThread */
+  sdk_assert(sdk_sanity_check_null_ptr((void *)this_ethread()) == TS_SUCCESS);
+
   FORCE_PLUGIN_SCOPED_MUTEX(contp);
 
   INKContInternal *i = reinterpret_cast<INKContInternal *>(contp);
@@ -4648,6 +4657,9 @@ TSAction
 TSContScheduleEveryOnPool(TSCont contp, TSHRTime every, TSThreadPool tp)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(contp) == TS_SUCCESS);
+
+  /* ensure we are on a EThread */
+  sdk_assert(sdk_sanity_check_null_ptr((void *)this_ethread()) == TS_SUCCESS);
 
   FORCE_PLUGIN_SCOPED_MUTEX(contp);
 


### PR DESCRIPTION
If called from a non-EThread, the Mutex_Lock ends up not acquiring
the lock but still releasing it causing weird behavior much later

Here's a core dump we ran into because of the above

```
#0  0x00007ffff4419207 in raise () from /lib64/libc.so.6
#1  0x00007ffff441a8f8 in abort () from /lib64/libc.so.6
#2  0x00007ffff6d5654b in ink_abort (message_format=message_format@entry=0x7ffff6dd4268 "pthread_mutex_destroy(%p) failed: %s (%d)") at ink_error.cc:99
#3  0x00007ffff6d5aecf in ink_mutex_destroy (m=m@entry=0x7ffff36a07d0) at ink_mutex.cc:72
#4  0x00000000007a838d in free (this=0x7ffff36a07c0) at I_Lock.h:595
#5  ~Ptr (this=<optimized out>, __in_chrg=<optimized out>) at ../../include/tscore/Ptr.h:207
#6  ~WeakMutexTryLock (this=<optimized out>, __in_chrg=<optimized out>) at I_Lock.h:486
#7  EThread::process_event (this=this@entry=0x7ffff3220000, e=e@entry=0x7ffff370b560, calling_code=<optimized out>) at UnixEThread.cc:130
#8  0x00000000007a8b2e in EThread::process_queue (this=this@entry=0x7ffff3220000, NegativeQueue=NegativeQueue@entry=0x7fffeaf04e00, ev_count=ev_count@entry=0x7fffeaf04dfc,
    nq_count=nq_count@entry=0x7fffeaf04df8) at UnixEThread.cc:176
#9  0x00000000007a90c8 in EThread::execute_regular (this=this@entry=0x7ffff3220000) at UnixEThread.cc:236
#10 0x00000000007a98a2 in EThread::execute (this=0x7ffff3220000) at UnixEThread.cc:345
#11 0x00000000007a7be9 in spawn_thread_internal (a=0x7ffff36fb440) at Thread.cc:92
#12 0x00007ffff5257dd5 in start_thread () from /lib64/libpthread.so.0
#13 0x00007ffff44e1b3d in clone () from /lib64/libc.so.6
```