### PR TITLE
Fix tunnel crash

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -906,6 +906,11 @@ HttpTunnel::producer_run(HttpTunnelProducer *p)
   for (c = p->consumer_list.head; c; c = c->link.next) {
     int64_t c_write = consumer_n;
 
+    // Don't bother to set up the consumer if it is dead
+    if (!c->alive) {
+      continue;
+    }
+
     if (!p->alive) {
       // Adjust the amount of chunked data to write if the only data was in the initial read
       // The amount to write in some cases is dependent on the type of the consumer, so this


### PR DESCRIPTION
This may address issue #6572.  It is an issue we found when running ATS9, but neglected to get pushed up. Looking through the code, it sees that this is vulnerable in ATS7 as well.  Presumably 8.x as well.

In producer_run, an EOS was processed from the producer.  This shuts down the consumer before it has a chance to set up the consumer write.

The fix is to check whether the consumer is still alive before setting up the consumer write.

```
#0  0x0000000000000000 in ?? ()
#1  0x000000000058a7e6 in HttpTunnel::producer_run (this=this@entry=0x2b8c14947238, p=p@entry=0x2b8c14947440) at ../../../../../../_vcs/trafficserver9/proxy/http/HttpTunnel.cc:956
#2  0x000000000058aff9 in HttpTunnel::tunnel_run (this=this@entry=0x2b8c14947238, p_arg=p_arg@entry=0x2b8c14947440) at ../../../../../../_vcs/trafficserver9/proxy/http/HttpTunnel.cc:699
#3  0x000000000053ef19 in HttpSM::do_setup_post_tunnel (this=0x2b8c14946330, to_vc_type=<optimized out>) at ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:5689
#4  0x0000000000541f5d in HttpSM::state_send_server_request_header (this=0x2b8c14946330, event=103, data=0x2b826353dc40) at ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:2002
#5  0x0000000000543513 in main_handler (data=0x2b826353dc40, event=103, this=0x2b8c14946330) at ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:2571
#6  HttpSM::main_handler (this=0x2b8c14946330, event=103, data=0x2b826353dc40) at ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:2541nixEThread.cc:274
#7  0x0000000000701471 in handleEvent (data=0x2b826353dc40, event=103, this=0x2b8c14946330)rver9/iocore/eventsystem/UnixET    at /sd/workspace/src/git.ouroath.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
#8  handleEvent (data=0x2b826353dc40, event=103, this=0x2b8c14946330) ../../../../../../_vcs/trafficserver9/iocore/eventsy    at /sd/workspace/src/git.ouroath.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163ad.so.0
#9  write_signal_and_update (vc=0x2b826353da00, event=103) at ../../../../../../_vcs/trafficserver9/iocore/net/UnixNetVConnection.cc:114
#10 write_signal_done (vc=0x2b826353da00, nh=0x2b7ec82e0f50, event=103) at ../../../../../../_vcs/trafficserver9/iocore/net/UnixNetVConnection.cc:156
#11 write_to_net_io(NetHandler*, UnixNetVConnection*, EThread*) () at ../../../../../../_vcs/trafficserver9/iocore/net/UnixNetVConnection.cc:497
#12 0x0000000000701554 in write_to_net (nh=nh@entry=0x2b7ec82e0f50, vc=vc@entry=0x2b826353da00, thread=<optimized out>) at ../../../../../../_vcs/trafficserver9/iocore/net/UnixNetVConnection.cc:341
#13 0x00000000006eeb9f in NetHandler::process_ready_list (this=this@entry=0x2b7ec82e0f50) at ../../../../../../_vcs/trafficserver9/iocore/net/UnixNet.cc:418
#14 0x00000000006eef80 in NetHandler::waitForActivity(long) () at ../../../../../../_vcs/trafficserver9/iocore/net/UnixNet.cc:536
#15 0x000000000073d133 in EThread::execute_regular (this=this@entry=0x2b7ec82dd240) at ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEThread.cc:274
#16 0x000000000073d386 in execute (this=0x2b7ec82dd240) at ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEThread.cc:338
#17 EThread::execute (this=0x2b7ec82dd240) at ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEThread.cc:316
#18 0x000000000073b669 in spawn_thread_internal (a=0x2b7ec47c5a40) at ../../../../../../_vcs/trafficserver9/iocore/eventsystem/Thread.cc:92
#19 0x00002b7ec2adcdd5 in start_thread () from /lib64/libpthread.so.0
#20 0x00002b7ec3811ead in clone () from /lib64/libc.so.6
```