### PR TITLE
url_sig: fix memory leak with urlParse and pristine flag (8.1.x)

### DIFF
--- a/plugins/experimental/url_sig/url_sig.c
+++ b/plugins/experimental/url_sig/url_sig.c
@@ -165,11 +165,11 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
       return TS_ERROR;
     }
     if (strncmp(line, "key", 3) == 0) {
-      if (strncmp((char *)(line + 3), "0", 1) == 0) {
+      if (strncmp(line + 3, "0", 1) == 0) {
         keynum = 0;
       } else {
         TSDebug(PLUGIN_NAME, ">>> %s <<<", line + 3);
-        keynum = atoi((char *)(line + 3));
+        keynum = atoi(line + 3);
         if (keynum == 0) {
           keynum = -1; // Not a Number
         }
@@ -349,13 +349,17 @@ fixedBufferWrite(char **dest_end, int *dest_len, const char *src, int src_len)
 }
 
 static char *
-urlParse(char *url, char *anchor, char *new_path_seg, int new_path_seg_len, char *signed_seg, unsigned int signed_seg_len)
+urlParse(char const *const url_in, char *anchor, char *new_path_seg, int new_path_seg_len, char *signed_seg,
+         unsigned int signed_seg_len)
 {
   char *segment[MAX_SEGMENTS];
+  char url[8192]                     = {'\0'};
   unsigned char decoded_string[2048] = {'\0'};
   char new_url[8192]; /* new_url is not null_terminated */
   char *p = NULL, *sig_anchor = NULL, *saveptr = NULL;
   int i = 0, numtoks = 0, decoded_len = 0, sig_anchor_seg = 0;
+
+  strncat(url, url_in, sizeof(url) - strlen(url) - 1);
 
   char *new_url_end    = new_url;
   int new_url_len_left = sizeof(new_url);
@@ -373,7 +377,7 @@ urlParse(char *url, char *anchor, char *new_path_seg, int new_path_seg_len, char
     TSError("insufficient space to copy schema into new_path_seg buffer.");
     return NULL;
   }
-  TSDebug(PLUGIN_NAME, "%s:%d - new_url: %*s\n", __FILE__, __LINE__, (int)(new_url_end - new_url), new_url);
+  TSDebug(PLUGIN_NAME, "%s:%d - new_url: %.*s\n", __FILE__, __LINE__, (int)(new_url_end - new_url), new_url);
 
   // parse the url.
   if ((p = strtok_r(skip, "/", &saveptr)) != NULL) {
@@ -582,19 +586,25 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   // check for path params.
   if (query == NULL || strstr(query, "E=") == NULL) {
     char *const parsed = urlParse(url, cfg->sig_anchor, new_path, 8192, path_params, 8192);
-    if (NULL == parsed) {
-      err_log(url, "Has no signing query string or signing path parameters.");
+    if (parsed == NULL) {
+      err_log(url, "Unable to parse/decode new url path parameters");
       goto deny;
     }
 
-    url             = parsed;
     has_path_params = true;
-    query           = strstr(url, ";");
+    query           = strstr(parsed, ";");
 
     if (query == NULL) {
       err_log(url, "Has no signing query string or signing path parameters.");
+      TSfree(parsed);
       goto deny;
     }
+
+    if (url != current_url) {
+      TSfree(url);
+    }
+
+    url = parsed;
   }
 
   /* first, parse the query string */

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
@@ -251,10 +251,12 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --http1.1 --insecure --header 'Host: one.two.three' 'https://127.0.0.1:{}/".format(ts.Variables.ssl_port) +
+    "curl --verbose --insecure --header 'Host: one.two.three' 'https://127.0.0.1:{}/".format(ts.Variables.ssl_port) +
     "foo/abcde/qrstuvwxyz?E=33046618506&A=1&K=7&P=1&S=acae22b0e1ba6ea6fbb5d26018dbf152558e98cb'" +
     LogTee + " ; grep -F -e '< HTTP' -e Authorization {0}/url_sig_long.log > {0}/url_sig_short.log ".format(ts.RunDirectory)
 )
+tr.Processes.Default.TimeOut = 5
+tr.TimeOut = 5
 
 # Overriding the built in ERROR check since we expect some ERROR messages
 ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "Some tests are failure tests")


### PR DESCRIPTION
This is a back port of:

https://github.com/apache/trafficserver/pull/5973 (url_sig: fix memory leak with urlParse and pristine flag)