### PR TITLE
[Doc][DevGuide][TSStatSync] Fixing documentation for SUM and COUNT types

### DIFF
--- a/doc/developer-guide/api/types/TSStatSync.en.rst
+++ b/doc/developer-guide/api/types/TSStatSync.en.rst
@@ -35,11 +35,11 @@ Enumeration Members
 
 .. c:member:: TSStatSync TS_STAT_SYNC_SUM
 
-   Values should add be summed.
+   This stat sync type should be used for gauge metrics (i.e can increase or decrease with time). It may be manipulated using TSStatIntIncrement, TSStatIntDecrement, TSStatIntSet. E.g for counting number of available origin-servers or number of active threads.
 
 .. c:member:: TSStatSync TS_STAT_SYNC_COUNT
 
-   Values should be added together.
+   This stat sync type should be used for counter metrics (i.e it should only increase with time). It should only be manipulated using TSStatIntIncrement. E.g for tracking call counts or uptime.
 
 .. c:member:: TSStatSync TS_STAT_SYNC_AVG
 


### PR DESCRIPTION
JIRA: [TST-264](https://issues.apache.org/jira/browse/TST-264) (couldn't find Traffic Server project, so created in Test project)

The current [documentation](https://docs.trafficserver.apache.org/en/latest/developer-guide/api/types/TSStatSync.en.html) for TSStatSync is non informative and unclear as to how and when they should be used. Although TSStatIntGet API is able to get the correct count, but it does not sync correctly and doesnot get reflected on call to `/_stats` endpoint. Correcting the documentation to reflect when and how these should be used.