### PR TITLE
Fix crash when following redirect

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7850,10 +7850,9 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
   // will do that in handle_api_return under the
   // HttpTransact::SM_ACTION_REDIRECT_READ state
   t_state.parent_result.reset();
-  t_state.request_sent_time           = 0;
-  t_state.response_received_time      = 0;
-  t_state.cache_info.write_lock_state = HttpTransact::CACHE_WL_INIT;
-  t_state.next_action                 = HttpTransact::SM_ACTION_REDIRECT_READ;
+  t_state.request_sent_time      = 0;
+  t_state.response_received_time = 0;
+  t_state.next_action            = HttpTransact::SM_ACTION_REDIRECT_READ;
   // we have a new OS and need to have DNS lookup the new OS
   t_state.dns_info.lookup_success = false;
   t_state.force_dns               = false;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2091,7 +2091,12 @@ HttpTransact::DecideCacheLookup(State *s)
     if (s->redirect_info.redirect_in_process) {
       // without calling out the CACHE_LOOKUP_COMPLETE_HOOK
       if (s->txn_conf->cache_http) {
-        s->cache_info.action = CACHE_DO_WRITE;
+        if (s->cache_info.write_lock_state == CACHE_WL_FAIL) {
+          s->cache_info.action           = CACHE_PREPARE_TO_WRITE;
+          s->cache_info.write_lock_state = HttpTransact::CACHE_WL_INIT;
+        } else if (s->cache_info.write_lock_state == CACHE_WL_SUCCESS) {
+          s->cache_info.action = CACHE_DO_WRITE;
+        }
       }
       LookupSkipOpenServer(s);
     } else {


### PR DESCRIPTION
I got ats crashed in the step below:
1.  Writting  a arbitrary rule into parent.config and set `proxy.config.http.number_of_redirections INT 3`,      `proxy.config.http.redirect.actions STRING default:follow` .
2.  Performing a http request and  get cache read miss , cache write lock miss; and the os returned 302 with url `http://ip/path` (no domain in it), and ats get cache read miss for the url os returned.
3. When following redirect and performing cache write action  for the  URL step 2 returned , ATS get crashed.


Here is the call stack
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff65e9801 in __GI_abort () at abort.c:79
#2  0x00007ffff7affbd1 in ink_abort (message_format=0x7ffff7b6c408 "%s:%d: failed assertion `%s`") at ink_error.cc:99
#3  0x00007ffff7afd001 in _ink_assert (expression=0x555555b51948 "c_sm->cache_write_vc != nullptr", file=0x555555b4e2c2 "HttpSM.cc", line=6242) at ink_assert.cc:37
#4  0x00005555558a4aa0 in HttpSM::setup_cache_write_transfer (this=0x7ffff0b00700, c_sm=0x7ffff0b024b0, source_vc=0x7fffec23bc10, store_info=0x7ffff0b00860, skip_bytes=304, 
    name=0x555555b514e4 "cache write") at HttpSM.cc:6242
#5  0x00005555558a30a4 in HttpSM::perform_cache_write_action (this=0x7ffff0b00700) at HttpSM.cc:5915
#6  0x000055555589061f in HttpSM::handle_api_return (this=0x7ffff0b00700) at HttpSM.cc:1718
#7  0x00005555558a9f12 in HttpSM::set_next_state (this=0x7ffff0b00700) at HttpSM.cc:7478
#8  0x00005555558a8eab in HttpSM::call_transact_and_set_next_state (this=0x7ffff0b00700, f=0x0) at HttpSM.cc:7249
#9  0x0000555555890044 in HttpSM::handle_api_return (this=0x7ffff0b00700) at HttpSM.cc:1651
#10 0x00005555558b19bc in HttpSM::do_api_callout (this=0x7ffff0b00700) at HttpSM.cc:402
#11 0x0000555555891cdc in HttpSM::state_read_server_response_header (this=0x7ffff0b00700, event=100, data=0x7fffe401cba8) at HttpSM.cc:2035
#12 0x0000555555894cb5 in HttpSM::main_handler (this=0x7ffff0b00700, event=100, data=0x7fffe401cba8) at HttpSM.cc:2649
#13 0x00005555557f2c7f in Continuation::handleEvent (this=0x7ffff0b00700, event=100, data=0x7fffe401cba8) at /root/code/traffic_master/trafficserver_back/iocore/eventsystem/I_Continuation.h:190
#14 0x0000555555af13ef in read_signal_and_update (event=100, vc=0x7fffe401c9c0) at UnixNetVConnection.cc:83
#15 0x0000555555af223e in read_from_net (nh=0x55555634f760, vc=0x7fffe401c9c0, thread=0x55555634ba50) at UnixNetVConnection.cc:309
#16 0x0000555555af46f7 in UnixNetVConnection::net_read_io (this=0x7fffe401c9c0, nh=0x55555634f760, lthread=0x55555634ba50) at UnixNetVConnection.cc:890
#17 0x0000555555ae74e8 in NetHandler::process_ready_list (this=0x55555634f760) at UnixNet.cc:400
#18 0x0000555555ae7ce0 in NetHandler::waitForActivity (this=0x55555634f760, timeout=60000000) at UnixNet.cc:535
#19 0x0000555555b288e8 in EThread::execute_regular (this=0x55555634ba50) at UnixEThread.cc:266
#20 0x0000555555b28b32 in EThread::execute (this=0x55555634ba50) at UnixEThread.cc:327
#21 0x0000555555b2746b in spawn_thread_internal (a=0x555556767010) at Thread.cc:92
#22 0x00007ffff70b76db in start_thread (arg=0x555556766700) at pthread_create.c:463
#23 0x00007ffff66ca88f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
history
```
{history = {{location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52cc0 <HttpSM::state_read_client_request_header(int, void*)::__FUNCTION__> "state_read_client_request_header", 
        line = 661}, event = 100, reentrancy = 2}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7373}, 
      event = 34463, reentrancy = 2}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52fb0 <HttpSM::state_hostdb_lookup(int, void*)::__FUNCTION__> "state_hostdb_lookup", line = 2284}, 
      event = 500, reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7407}, event = 34463, 
      reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52fd0 <HttpSM::state_hostdb_reverse_lookup(int, void*)::__FUNCTION__> "state_hostdb_reverse_lookup", line = 2332}, 
      event = 500, reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7413}, event = 34463, 
      reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b53430 <HttpSM::do_cache_lookup_and_read()::__FUNCTION__> "do_cache_lookup_and_read", line = 4627}, event = 9504, 
      reentrancy = 1}, {location = {file = 0x555555b62940 "HttpCacheSM.cc", func = 0x555555b63020 <HttpCacheSM::state_cache_open_read(int, void*)::__FUNCTION__> "state_cache_open_read", line = 100}, 
      event = 1103, reentrancy = -31073}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b53050 <HttpSM::state_cache_open_read(int, void*)::__FUNCTION__> "state_cache_open_read", 
        line = 2563}, event = 1103, reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7522}, 
      event = 34463, reentrancy = 1}, {location = {file = 0x555555b62940 "HttpCacheSM.cc", func = 0x555555b63040 <HttpCacheSM::state_cache_open_write(int, void*)::__FUNCTION__> "state_cache_open_write", 
        line = 160}, event = 1109, reentrancy = -31073}, {location = {file = 0x555555b62940 "HttpCacheSM.cc", 
        func = 0x555555b63040 <HttpCacheSM::state_cache_open_write(int, void*)::__FUNCTION__> "state_cache_open_write", line = 160}, event = 2, reentrancy = -31073}, {location = {
        file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b53030 <HttpSM::state_cache_open_write(int, void*)::__FUNCTION__> "state_cache_open_write", line = 2445}, event = 1109, reentrancy = 1}, {
      location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7419}, event = 34463, reentrancy = 1}, {location = {
        file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52eb0 <HttpSM::state_http_server_open(int, void*)::__FUNCTION__> "state_http_server_open", line = 1772}, event = 200, reentrancy = 2}, {
      location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52eb0 <HttpSM::state_http_server_open(int, void*)::__FUNCTION__> "state_http_server_open", line = 1772}, event = 101, 
      reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52f20 <HttpSM::state_send_server_request_header(int, void*)::__FUNCTION__> "state_send_server_request_header", 
        line = 2052}, event = 103, reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", 
        func = 0x555555b52ee0 <HttpSM::state_read_server_response_header(int, void*)::__FUNCTION__> "state_read_server_response_header", line = 1898}, event = 100, reentrancy = 1}, {location = {
        file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7413}, event = 34463, reentrancy = 1}, {location = {
        file = 0x555555b62940 "HttpCacheSM.cc", func = 0x555555b63020 <HttpCacheSM::state_cache_open_read(int, void*)::__FUNCTION__> "state_cache_open_read", line = 100}, event = 1103, 
      reentrancy = -31073}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b53050 <HttpSM::state_cache_open_read(int, void*)::__FUNCTION__> "state_cache_open_read", line = 2563}, 
      event = 1103, reentrancy = 2}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7373}, event = 34463, 
      reentrancy = 2}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7407}, event = 34463, reentrancy = 2}, {
      location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b53430 <HttpSM::do_cache_lookup_and_read()::__FUNCTION__> "do_cache_lookup_and_read", line = 4627}, event = 48408, reentrancy = 1}, {
      location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52fd0 <HttpSM::state_hostdb_reverse_lookup(int, void*)::__FUNCTION__> "state_hostdb_reverse_lookup", line = 2332}, event = 500, 
      reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b538c8 <HttpSM::set_next_state()::__FUNCTION__> "set_next_state", line = 7419}, event = 34463, reentrancy = 1}, {
      location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52eb0 <HttpSM::state_http_server_open(int, void*)::__FUNCTION__> "state_http_server_open", line = 1772}, event = 200, 
      reentrancy = 2}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52eb0 <HttpSM::state_http_server_open(int, void*)::__FUNCTION__> "state_http_server_open", line = 1772}, 
      event = 101, reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", 
        func = 0x555555b52f20 <HttpSM::state_send_server_request_header(int, void*)::__FUNCTION__> "state_send_server_request_header", line = 2052}, event = 103, reentrancy = 1}, {location = {
        file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b52ee0 <HttpSM::state_read_server_response_header(int, void*)::__FUNCTION__> "state_read_server_response_header", line = 1898}, event = 100, 
      reentrancy = 1}, {location = {file = 0x555555b4e2c2 "HttpSM.cc", func = 0x555555b537f0 <HttpSM::setup_server_transfer()::__FUNCTION__> "setup_server_transfer", line = 6663}, event = 34463, 
      reentrancy = 1}, {location = {file = 0x0, func = 0x0, line = 0}, event = 0, reentrancy = 0} <repeats 34 times>}, history_pos = 31}
```

I think is the reason is in   `HttpTransact::OSDNSLookup`
https://github.com/apache/trafficserver/blob/134fb609351c16656089d68a550f41c280d05c2d/proxy/http/HttpTransact.cc#L1960-L1965

And   `HttpTransact::DecideCacheLookup`
https://github.com/apache/trafficserver/blob/134fb609351c16656089d68a550f41c280d05c2d/proxy/http/HttpTransact.cc#L2091-L2097
which decide directly dong cache write without geting cache write lock that caused the crash.
Squash for pr https://github.com/apache/trafficserver/pull/6561