### PR TITLE
Skip compressible content type check with null strings.

### DIFF
--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -204,7 +204,10 @@ HostConfiguration::is_content_type_compressible(const char *content_type, int co
 
   for (StringContainer::iterator it = compressible_content_types_.begin(); it != compressible_content_types_.end(); ++it) {
     const char *match_string = it->c_str();
-    bool exclude             = match_string[0] == '!';
+    if (match_string == nullptr) {
+      continue;
+    }
+    bool exclude = match_string[0] == '!';
 
     if (exclude) {
       ++match_string; // skip '!'


### PR DESCRIPTION
I still don't know how I managed to bump into this, but I got TrafficServer to crash using the compress plugin because in some cases `match_string` in null.

I've changed the logic to ignore the element in the iterator in those cases, so it doesn't crash.