### PR TITLE
HTTP/2 backports for 8.1.x (part 2)

### DIFF
--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -169,22 +169,13 @@ private:
 class Http2ClientSession : public ProxyClientSession
 {
 public:
-  typedef ProxyClientSession super; ///< Parent type.
-  typedef int (Http2ClientSession::*SessionHandler)(int, void *);
+  using super          = ProxyClientSession; ///< Parent type.
+  using SessionHandler = int (Http2ClientSession::*)(int, void *);
 
   Http2ClientSession();
 
-  // Implement ProxyClientSession interface.
-  void start() override;
-  void destroy() override;
-  void free() override;
-  void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) override;
-
-  bool
-  ready_to_free() const
-  {
-    return kill_me;
-  }
+  /////////////////////
+  // Methods
 
   // Implement VConnection interface.
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
@@ -194,129 +185,38 @@ public:
   void do_io_shutdown(ShutdownHowTo_t howto) override;
   void reenable(VIO *vio) override;
 
-  NetVConnection *
-  get_netvc() const override
-  {
-    return client_vc;
-  }
+  // Implement ProxyClientSession interface.
+  void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader, bool backdoor) override;
+  void start() override;
+  void destroy() override;
+  void release(ProxyClientTransaction *trans) override;
+  void free() override;
 
-  sockaddr const *
-  get_client_addr() override
-  {
-    return client_vc ? client_vc->get_remote_addr() : &cached_client_addr.sa;
-  }
+  // more methods
+  void write_reenable();
 
-  sockaddr const *
-  get_local_addr() override
-  {
-    return client_vc ? client_vc->get_local_addr() : &cached_local_addr.sa;
-  }
-
-  void
-  write_reenable()
-  {
-    write_vio->reenable();
-  }
-
-  void set_upgrade_context(HTTPHdr *h);
-
-  const Http2UpgradeContext &
-  get_upgrade_context() const
-  {
-    return upgrade_context;
-  }
-
-  int
-  get_transact_count() const override
-  {
-    return connection_state.get_stream_requests();
-  }
-
-  void
-  release(ProxyClientTransaction *trans) override
-  {
-  }
-
-  Http2ConnectionState connection_state;
-  void
-  set_dying_event(int event)
-  {
-    dying_event = event;
-  }
-
-  int
-  get_dying_event() const
-  {
-    return dying_event;
-  }
-
-  bool
-  is_recursing() const
-  {
-    return recursion > 0;
-  }
-
-  const char *
-  get_protocol_string() const override
-  {
-    return "http/2";
-  }
-
-  int
-  populate_protocol(std::string_view *result, int size) const override
-  {
-    int retval = 0;
-    if (size > retval) {
-      result[retval++] = IP_PROTO_TAG_HTTP_2_0;
-      if (size > retval) {
-        retval += super::populate_protocol(result + retval, size - retval);
-      }
-    }
-    return retval;
-  }
-
-  const char *
-  protocol_contains(std::string_view prefix) const override
-  {
-    const char *retval = nullptr;
-
-    if (prefix.size() <= IP_PROTO_TAG_HTTP_2_0.size() && strncmp(IP_PROTO_TAG_HTTP_2_0.data(), prefix.data(), prefix.size()) == 0) {
-      retval = IP_PROTO_TAG_HTTP_2_0.data();
-    } else {
-      retval = super::protocol_contains(prefix);
-    }
-    return retval;
-  }
-
+  ////////////////////
+  // Accessors
+  NetVConnection *get_netvc() const override;
+  sockaddr const *get_client_addr() override;
+  sockaddr const *get_local_addr() override;
+  int get_transact_count() const override;
+  const char *get_protocol_string() const override;
+  int populate_protocol(std::string_view *result, int size) const override;
+  const char *protocol_contains(std::string_view prefix) const override;
   void increment_current_active_client_connections_stat() override;
   void decrement_current_active_client_connections_stat() override;
 
+  void set_upgrade_context(HTTPHdr *h);
+  const Http2UpgradeContext &get_upgrade_context() const;
+  void set_dying_event(int event);
+  int get_dying_event() const;
+  bool ready_to_free() const;
+  bool is_recursing() const;
   void set_half_close_local_flag(bool flag);
-  bool
-  get_half_close_local_flag() const
-  {
-    return half_close_local;
-  }
-
-  bool
-  is_url_pushed(const char *url, int url_len)
-  {
-    char *dup_url            = ats_strndup(url, url_len);
-    InkHashTableEntry *entry = ink_hash_table_lookup_entry(h2_pushed_urls, dup_url);
-    ats_free(dup_url);
-    return entry != nullptr;
-  }
-
-  void
-  add_url_to_pushed_table(const char *url, int url_len)
-  {
-    if (h2_pushed_urls_size < Http2::push_diary_size) {
-      char *dup_url = ats_strndup(url, url_len);
-      ink_hash_table_insert(h2_pushed_urls, dup_url, nullptr);
-      h2_pushed_urls_size++;
-      ats_free(dup_url);
-    }
-  }
+  bool get_half_close_local_flag() const;
+  bool is_url_pushed(const char *url, int url_len);
+  void add_url_to_pushed_table(const char *url, int url_len);
 
   // Record history from Http2ConnectionState
   void remember(const SourceLocation &location, int event, int reentrant = NO_REENTRANT);
@@ -324,6 +224,10 @@ public:
   // noncopyable
   Http2ClientSession(Http2ClientSession &) = delete;
   Http2ClientSession &operator=(const Http2ClientSession &) = delete;
+
+  ///////////////////
+  // Variables
+  Http2ConnectionState connection_state;
 
 private:
   int main_event_handler(int, void *);
@@ -373,3 +277,51 @@ private:
 };
 
 extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;
+
+///////////////////////////////////////////////
+// INLINE
+
+inline const Http2UpgradeContext &
+Http2ClientSession::get_upgrade_context() const
+{
+  return upgrade_context;
+}
+
+inline bool
+Http2ClientSession::ready_to_free() const
+{
+  return kill_me;
+}
+
+inline void
+Http2ClientSession::set_dying_event(int event)
+{
+  dying_event = event;
+}
+
+inline int
+Http2ClientSession::get_dying_event() const
+{
+  return dying_event;
+}
+
+inline bool
+Http2ClientSession::is_recursing() const
+{
+  return recursion > 0;
+}
+
+inline bool
+Http2ClientSession::get_half_close_local_flag() const
+{
+  return half_close_local;
+}
+
+inline bool
+Http2ClientSession::is_url_pushed(const char *url, int url_len)
+{
+  char *dup_url            = ats_strndup(url, url_len);
+  InkHashTableEntry *entry = ink_hash_table_lookup_entry(h2_pushed_urls, dup_url);
+  ats_free(dup_url);
+  return entry != nullptr;
+}


### PR DESCRIPTION
This is the second part of HTTP/2 backports to 8.1.x.

This is a tricky one. To reduce conflicts with future backports of HTTP/2, cherry-pick only HTTP/2 changes of below commits. Mainly moving functions. With this change, we'll still see some conflicts, but `git` can easily find the correct function to change.

#5880 - ProxySsn Refactor move code to cc
#5908 - ProxySession cleanup: moving inline functions to .h

(cherry picked from commit c8ca9f69a777eab01953b6cb16c91e8d6ddcbca2)
(cherry picked from commit 3a44862d203571443672f089c7f294ba81f18e6b)

Conflicts:
	proxy/ProxySession.cc
	proxy/ProxySession.h
	proxy/ProxyTransaction.cc
	proxy/ProxyTransaction.h
	proxy/http/Http1ClientSession.cc
	proxy/http/Http1ClientSession.h
	proxy/http/Http1ServerSession.cc
	proxy/http/Http1ServerSession.h
	proxy/http/Http1Transaction.cc
	proxy/http/Http1Transaction.h
	proxy/http2/Http2ClientSession.cc
	proxy/http2/Http2ClientSession.h
	proxy/http2/Http2Stream.cc
	proxy/http2/Http2Stream.h