### PR TITLE
Add support for a simple_server_retry_responses list

### DIFF
--- a/doc/admin-guide/files/parent.config.en.rst
+++ b/doc/admin-guide/files/parent.config.en.rst
@@ -207,7 +207,8 @@ The following list shows the possible actions and their allowed values.
 .. _parent-config-format-parent-retry:
 
 ``parent_retry``
-    - ``simple_retry`` - If the parent origin server returns a 404 response on a request
+    - ``simple_retry`` - If the parent returns a 404 response or if the response matches
+      a list of http 4xx responses defined in ``simple_server_retry_responses`` on a request
       a new parent is selected and the request is retried.  The number of retries is controlled
       by ``max_simple_retries`` which is set to 1 by default.
     - ``unavailable_server_retry`` - If the parent returns a 503 response or if the response matches
@@ -215,6 +216,13 @@ The following list shows the possible actions and their allowed values.
       parent is marked down and a new parent is selected to retry the request.  The number of
       retries is controlled by ``max_unavailable_server_retries`` which is set to 1 by default.
     - ``both`` - This enables both ``simple_retry`` and ``unavailable_server_retry`` as described above.
+
+.. _parent-config-format-simple-server-retry-responses:
+
+``simple_server_retry_responses``
+   If ``parent_retry`` is set to either ``simple_retry`` or ``both``, this parameter is a comma separated list of
+   http 4xx response codes that will invoke the ``simple_retry`` described in the ``parent_retry`` section. By
+   default, ``simple_server_retry_responses`` is set to 404.
 
 .. _parent-config-format-unavailable-server-retry-responses:
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -283,7 +283,7 @@ is_localhost(const char *name, int len)
 inline static bool
 is_response_simple_code(HTTPStatus response_code)
 {
-  if (response_code < 399 || response_code > 499) {
+  if (response_code < 400 || response_code > 499) {
     return false;
   }
 
@@ -293,7 +293,7 @@ is_response_simple_code(HTTPStatus response_code)
 inline static bool
 is_response_unavailable_code(HTTPStatus response_code)
 {
-  if (response_code < 499 || response_code > 599) {
+  if (response_code < 500 || response_code > 599) {
     return false;
   }
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -280,6 +280,26 @@ is_localhost(const char *name, int len)
   return (len == (sizeof(local) - 1)) && (memcmp(name, local, len) == 0);
 }
 
+inline static bool
+is_response_simple_code(HTTPStatus response_code)
+{
+  if (response_code < 399 || response_code > 499) {
+    return false;
+  }
+
+  return true;
+}
+
+inline static bool
+is_response_unavailable_code(HTTPStatus response_code)
+{
+  if (response_code < 499 || response_code > 599) {
+    return false;
+  }
+
+  return true;
+}
+
 inline static void
 simple_or_unavailable_server_retry(HttpTransact::State *s)
 {
@@ -288,11 +308,10 @@ simple_or_unavailable_server_retry(HttpTransact::State *s)
 
   TxnDebug("http_trans", "[simple_or_unavailabe_server_retry] server_response = %d, simple_retry_attempts: %d, numParents:%d ",
            server_response, s->current.simple_retry_attempts, numParents(s));
-
   // simple retry is enabled, 0x1
-  if ((retry_type(s) & PARENT_RETRY_SIMPLE) && s->current.simple_retry_attempts < max_retries(s, PARENT_RETRY_SIMPLE) &&
-      server_response == HTTP_STATUS_NOT_FOUND) {
-    TxnDebug("http_trans", "RECEIVED A SIMPLE RETRY RESPONSE");
+  if ((retry_type(s) & PARENT_RETRY_SIMPLE) && is_response_simple_code(server_response) &&
+      s->current.simple_retry_attempts < max_retries(s, PARENT_RETRY_SIMPLE) && response_is_retryable(s, server_response)) {
+    TxnDebug("parent_select", "RECEIVED A SIMPLE RETRY RESPONSE");
     if (s->current.simple_retry_attempts < numParents(s)) {
       s->current.state      = HttpTransact::PARENT_RETRY;
       s->current.retry_type = PARENT_RETRY_SIMPLE;
@@ -303,7 +322,7 @@ simple_or_unavailable_server_retry(HttpTransact::State *s)
     }
   }
   // unavailable server retry is enabled 0x2
-  else if ((retry_type(s) & PARENT_RETRY_UNAVAILABLE_SERVER) &&
+  else if ((retry_type(s) & PARENT_RETRY_UNAVAILABLE_SERVER) && is_response_unavailable_code(server_response) &&
            s->current.unavailable_server_retry_attempts < max_retries(s, PARENT_RETRY_UNAVAILABLE_SERVER) &&
            response_is_retryable(s, server_response)) {
     TxnDebug("parent_select", "RECEIVED A PARENT_RETRY_UNAVAILABLE_SERVER RESPONSE");

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -283,7 +283,7 @@ is_localhost(const char *name, int len)
 inline static bool
 is_response_simple_code(HTTPStatus response_code)
 {
-  if (response_code < 400 || response_code > 499) {
+  if (static_cast<unsigned int>(response_code) < 400 || static_cast<unsigned int>(response_code) > 499) {
     return false;
   }
 
@@ -293,7 +293,7 @@ is_response_simple_code(HTTPStatus response_code)
 inline static bool
 is_response_unavailable_code(HTTPStatus response_code)
 {
-  if (response_code < 500 || response_code > 599) {
+  if (static_cast<unsigned int>(response_code) < 500 || static_cast<unsigned int>(response_code) > 599) {
     return false;
   }
 


### PR DESCRIPTION
This allows the user to set a list of 4xx response codes which trigger a simple retry, instead of the current functionality which will only trigger on a 404.  This mimics the unavailable responses list in the same manner except for the 4xx simple retry case