### PR TITLE
Making client session id unique across HTTP/1 and 2 sessions

### DIFF
--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -194,7 +194,7 @@ private:
 ///////////////////
 // INLINE
 
-static inline int64_t next_cs_id = 0;
+inline int64_t next_cs_id = 0;
 
 inline int64_t
 ProxySession::next_connection_id()


### PR DESCRIPTION
Making client session id unique across HTTP/1 and 2 sessions
    
I noticed that calls to TSHttpSsnIdGet were not unique for sessions across HTTP/1 and HTTP/2 sessions: they each counted from 0 independently. This makes them share the same counter.

The static applied to next_cs_id made the variable independent between the translation units that used it (Http1ClientSession.cc and Http2ClientSession.cc via ProxySession::next_connection_id in this case). By removing this and maintaining inline, the object is the same across the compilation units.