### PR TITLE
Return TSFetchSM from TSFetchUrl so TSFetchFlagSet can set fetch flags

### DIFF
--- a/doc/developer-guide/api/functions/TSFetchCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSFetchCreate.en.rst
@@ -32,9 +32,9 @@ Synopsis
     #include <ts/ts.h>
 
 .. function:: void TSFetchPages(TSFetchUrlParams_t *)
-.. function:: void TSFetchUrl(const char *, int, sockaddr const *, TSCont, TSFetchWakeUpOptions, TSFetchEvent)
+.. function:: TSFetchSM TSFetchUrl(const char *, int, sockaddr const *, TSCont, TSFetchWakeUpOptions, TSFetchEvent)
 .. function:: void TSFetchFlagSet(TSFetchSM, int)
-.. function:: TSFetch TSFetchCreate(TSCont, const char *, const char *, const char *, struct sockaddr const *, int)
+.. function:: TSFetchSM TSFetchCreate(TSCont, const char *, const char *, const char *, struct sockaddr const *, int)
 .. function:: void TSFetchHeaderAdd(TSFetchSM, const char *, int, const char *, int)
 .. function:: void TSFetchWriteData(TSFetchSM, const void *, size_t)
 .. function:: ssize_t TSFetchReadData(TSFetchSM, void *, size_t)

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -922,6 +922,8 @@ typedef struct tsapi_hostlookupresult *TSHostLookupResult;
 typedef struct tsapi_aiocallback *TSAIOCallback;
 typedef struct tsapi_net_accept *TSAcceptor;
 
+typedef struct tsapi_fetchsm *TSFetchSM;
+
 typedef void *(*TSThreadFunc)(void *data);
 typedef int (*TSEventFunc)(TSCont contp, TSEvent event, void *edata);
 typedef void (*TSConfigDestroyFunc)(void *data);

--- a/include/ts/experimental.h
+++ b/include/ts/experimental.h
@@ -50,8 +50,6 @@ typedef enum {
   TS_FETCH_FLAGS_NOT_INTERNAL_REQUEST = 1 << 4  // Allow this fetch to be created as a non-internal request.
 } TSFetchFlags;
 
-typedef struct tsapi_fetchsm *TSFetchSM;
-
 /* Forward declaration of in_addr, any user of these APIs should probably
    include net/netinet.h or whatever is appropriate on the platform. */
 struct in_addr;

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1722,8 +1722,8 @@ tsapi TSVConn TSHttpConnect(struct sockaddr const *addr);
  */
 tsapi TSVConn TSHttpConnectTransparent(struct sockaddr const *client_addr, struct sockaddr const *server_addr);
 
-tsapi void TSFetchUrl(const char *request, int request_len, struct sockaddr const *addr, TSCont contp,
-                      TSFetchWakeUpOptions callback_options, TSFetchEvent event);
+tsapi TSFetchSM TSFetchUrl(const char *request, int request_len, struct sockaddr const *addr, TSCont contp,
+                           TSFetchWakeUpOptions callback_options, TSFetchEvent event);
 tsapi void TSFetchPages(TSFetchUrlParams_t *params);
 
 /* Check if HTTP State machine is internal or not */

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -7916,7 +7916,7 @@ TSFetchPages(TSFetchUrlParams_t *params)
   }
 }
 
-void
+TSFetchSM
 TSFetchUrl(const char *headers, int request_len, sockaddr const *ip, TSCont contp, TSFetchWakeUpOptions callback_options,
            TSFetchEvent events)
 {
@@ -7928,6 +7928,8 @@ TSFetchUrl(const char *headers, int request_len, sockaddr const *ip, TSCont cont
 
   fetch_sm->init((Continuation *)contp, callback_options, events, headers, request_len, ip);
   fetch_sm->httpConnect();
+
+  return reinterpret_cast<TSFetchSM>(fetch_sm);
 }
 
 void


### PR DESCRIPTION
This is a miss in the commit 7675d0b8082247de35146cedbce6875cb2d39f03. Sorry for the miss, it was discussed in the email to dev that the TSFetchUrl()'s default fetch flags will be changed and TSFetchFlagSet() API will be added to set them explicitly, but I missed changing the return type for TSFetchUrl() which is needed to be able to use TSFetchFlagSet()