### PR TITLE
READ_RESPONSE_HDR_HOOK is not invoked from Cache.

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -913,7 +913,7 @@ READ_RESPONSE_HDR_HOOK
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Rulesets evaluated within this context will process only once the origin server
-response (or cached response) has been read, but prior to |TS| sending that
+response has been read, but prior to |TS| sending that
 response to the client.
 
 This is the default hook condition for all globally-configured rulesets.

--- a/doc/locale/ja/LC_MESSAGES/admin-guide/plugins/header_rewrite.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/plugins/header_rewrite.en.po
@@ -1135,7 +1135,7 @@ msgstr ""
 #: ../../../admin-guide/plugins/header_rewrite.en.rst:792
 msgid ""
 "Rulesets evaluated within this context will process only once the origin "
-"server response (or cached response) has been read, but prior to |TS| "
+"server response has been read, but prior to |TS| "
 "sending that response to the client."
 msgstr ""
 


### PR DESCRIPTION
READ_RESPONSE_HDR_HOOK is invoked only when the response is from the Origin Server.