### PR TITLE
Make next_cs_id a private member variable.

### DIFF
--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -189,12 +189,11 @@ private:
   bool m_active = false;
 
   std::unique_ptr<SSLProxySession> _ssl;
+  static inline int64_t next_cs_id = 0;
 };
 
 ///////////////////
 // INLINE
-
-inline int64_t next_cs_id = 0;
 
 inline int64_t
 ProxySession::next_connection_id()

--- a/tests/gold_tests/continuations/plugins/session_id_verify.cc
+++ b/tests/gold_tests/continuations/plugins/session_id_verify.cc
@@ -1,0 +1,91 @@
+/**
+  @file
+  @brief A plugin to print session id values.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#include <ts/ts.h>    // for debug
+#include <inttypes.h> // for PRIu64
+#include <unordered_set>
+
+// plugin registration info
+#define PLUGIN_NAME "session_id_verify"
+static char plugin_name[]   = PLUGIN_NAME;
+static char vendor_name[]   = "Apache";
+static char support_email[] = "bneradt@apache.org";
+
+int
+global_handler(TSCont continuation, TSEvent event, void *data)
+{
+  TSHttpSsn session = static_cast<TSHttpSsn>(data);
+
+  switch (event) {
+  case TS_EVENT_HTTP_SSN_START: {
+    TSDebug(PLUGIN_NAME, " -- global_handler :: TS_EVENT_HTTP_SSN_START");
+    int64_t id = TSHttpSsnIdGet(session);
+
+    static std::unordered_set<int64_t> seen_ids;
+    if (seen_ids.find(id) != seen_ids.end()) {
+      TSError("[%s] Plugin encountered a duplicate session id: %ld", PLUGIN_NAME, id);
+    } else {
+      seen_ids.insert(id);
+    }
+    TSDebug(PLUGIN_NAME, "session id: %ld", id);
+  } break;
+
+  default:
+    return 0;
+  }
+
+  TSHttpSsnReenable(session, TS_EVENT_HTTP_CONTINUE);
+
+  return 0;
+}
+
+void
+TSPluginInit(int argc, const char *argv[])
+{
+  TSDebug(PLUGIN_NAME, "initializing plugin");
+
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = plugin_name;
+  info.vendor_name   = vendor_name;
+  info.support_email = support_email;
+
+#if (TS_VERSION_MAJOR < 3)
+  if (TSPluginRegister(TS_SDK_VERSION_2_0, &info) != TS_SUCCESS) {
+#elif (TS_VERSION_MAJOR < 6)
+  if (TSPluginRegister(TS_SDK_VERSION_3_0, &info) != TS_SUCCESS) {
+#else
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+#endif
+    TSError("[%s] Plugin registration failed.", PLUGIN_NAME);
+  }
+
+  TSCont contp = TSContCreate(global_handler, TSMutexCreate());
+  if (contp == nullptr) {
+    // Continuation initialization failed. Unrecoverable, report and exit.
+    TSError("[%s] could not create continuation.", PLUGIN_NAME);
+    abort();
+  } else {
+    // Add all hooks.
+    TSHttpHookAdd(TS_HTTP_SSN_START_HOOK, contp);
+  }
+}

--- a/tests/gold_tests/continuations/session_id.test.py
+++ b/tests/gold_tests/continuations/session_id.test.py
@@ -1,0 +1,101 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Verify session ID properties.
+'''
+
+Test.SkipUnless(
+    Condition.HasCurlFeature('http2')
+)
+
+# Configure the server.
+server = Test.MakeOriginServer("server")
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+                  "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length:0\r\n\r\n",
+                   "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_header)
+
+# Configure ATS.
+ts = Test.MakeATSProcess("ts", command="traffic_manager", enable_tls=True)
+
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+
+Test.PreparePlugin(os.path.join(Test.TestDirectory, 'plugins', 'session_id_verify.cc'), ts)
+
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'session_id_verify',
+    'proxy.config.http.cache.http': 0,  # disable cache to simplify the test.
+    'proxy.config.cache.enable_read_while_writer': 0,
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+})
+
+ts.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+
+#
+# Run some HTTP/1 traffic.
+#
+tr = Test.AddTestRun("Perform HTTP/1 transactions")
+cmd = 'curl -v -H "host:example.com" http://127.0.0.1:{0}'.format(ts.Variables.port)
+numberOfRequests = 100
+# Create a bunch of curl commands to be executed in parallel. Default.Process
+# is set in SpawnCommands.  On Fedora 28/29, it seems that curl will
+# occaisionally timeout after a couple seconds and return exitcode 2 Examinig
+# the packet capture shows that Traffic Server dutifully sends the response
+ps = tr.SpawnCommands(cmdstr=cmd,  count=numberOfRequests, retcode=Any(0, 2))
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = Any(0, 2)
+tr.Processes.Default.StartBefore(
+    server, ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.port))
+ts.StartAfter(*ps)
+server.StartAfter(*ps)
+
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+
+#
+# Run some HTTP/2 traffic.
+#
+tr = Test.AddTestRun("Perform HTTP/2 transactions")
+cmd = 'curl -v -k --http2 -H "host:example.com" https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
+ps = tr.SpawnCommands(cmdstr=cmd,  count=numberOfRequests, retcode=Any(0, 2))
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = Any(0, 2)
+
+#
+# Verify that the session ids are unique.
+#
+
+# AuTest already searches for errors in diags.log and fails if it encounters
+# them. The test plugin prints an error to this log if it sees duplicate ids.
+# The following is to verify that we encountered the expected ids.
+ts.Streams.stderr += Testers.ContainsExpression(
+        "session id: 199",
+        "Verify the various session ids were found.")


### PR DESCRIPTION
This implements @maskit 's suggestion here:
https://github.com/apache/trafficserver/pull/6606#issuecomment-607541204

This also adds a test verifying that session ids are unique across HTTP/1 and HTTP/2 transactions.