### PR TITLE
Updated ink_rwlock to be a real reader writer lock

### DIFF
--- a/src/tscore/ink_rwlock.cc
+++ b/src/tscore/ink_rwlock.cc
@@ -24,131 +24,30 @@
 #include "tscore/ink_config.h"
 #include "tscore/ink_rwlock.h"
 
+static pthread_rwlockattr_t attr;
+
 //-------------------------------------------------------------------------
 // ink_rwlock_init
 //
 // Note: This should be called only once.
 //-------------------------------------------------------------------------
-int
+void
 ink_rwlock_init(ink_rwlock *rw)
 {
-  ink_mutex_init(&rw->rw_mutex);
-
-  ink_cond_init(&rw->rw_condreaders);
-  ink_cond_init(&rw->rw_condwriters);
-  rw->rw_nwaitreaders = 0;
-  rw->rw_nwaitwriters = 0;
-  // coverity[missing_lock]
-  rw->rw_refcount = 0;
-  rw->rw_magic    = RW_MAGIC;
-
-  return 0;
+  int error = pthread_rwlock_init(rw, &attr);
+  if (unlikely(error != 0)) {
+    ink_abort("pthread_rwlock_init(%p) failed: %s (%d)", rw, strerror(error), error);
+  }
 }
 
 //-------------------------------------------------------------------------
 // ink_rwlock_destroy
 //-------------------------------------------------------------------------
-
-int
+void
 ink_rwlock_destroy(ink_rwlock *rw)
 {
-  if (rw->rw_magic != RW_MAGIC) {
-    return EINVAL;
+  int error = pthread_rwlock_destroy(rw);
+  if (unlikely(error != 0)) {
+    ink_abort("pthread_rwlock_destroy(%p) failed: %s (%d)", rw, strerror(error), error);
   }
-  if (rw->rw_refcount != 0 || rw->rw_nwaitreaders != 0 || rw->rw_nwaitwriters != 0) {
-    return EBUSY;
-  }
-
-  ink_mutex_destroy(&rw->rw_mutex);
-  ink_cond_destroy(&rw->rw_condreaders);
-  ink_cond_destroy(&rw->rw_condwriters);
-  rw->rw_magic = 0;
-
-  return 0;
-}
-
-//-------------------------------------------------------------------------
-// ink_rwlock_rdlock
-//-------------------------------------------------------------------------
-
-int
-ink_rwlock_rdlock(ink_rwlock *rw)
-{
-  if (rw->rw_magic != RW_MAGIC) {
-    return EINVAL;
-  }
-
-  ink_mutex_acquire(&rw->rw_mutex);
-
-  /* give preference to waiting writers */
-  while (rw->rw_refcount < 0 || rw->rw_nwaitwriters > 0) {
-    rw->rw_nwaitreaders++;
-    ink_cond_wait(&rw->rw_condreaders, &rw->rw_mutex);
-    rw->rw_nwaitreaders--;
-  }
-  rw->rw_refcount++; /* another reader has a read lock */
-
-  ink_mutex_release(&rw->rw_mutex);
-
-  return 0;
-}
-
-//-------------------------------------------------------------------------
-// ink_rwlock_wrlock
-//-------------------------------------------------------------------------
-
-int
-ink_rwlock_wrlock(ink_rwlock *rw)
-{
-  if (rw->rw_magic != RW_MAGIC) {
-    return EINVAL;
-  }
-
-  ink_mutex_acquire(&rw->rw_mutex);
-
-  while (rw->rw_refcount != 0) {
-    rw->rw_nwaitwriters++;
-    ink_cond_wait(&rw->rw_condwriters, &rw->rw_mutex);
-    rw->rw_nwaitwriters--;
-  }
-  rw->rw_refcount = -1;
-
-  ink_mutex_release(&rw->rw_mutex);
-
-  return 0;
-}
-
-//-------------------------------------------------------------------------
-// ink_rwlock_unlock
-//-------------------------------------------------------------------------
-
-int
-ink_rwlock_unlock(ink_rwlock *rw)
-{
-  if (rw->rw_magic != RW_MAGIC) {
-    return EINVAL;
-  }
-
-  ink_mutex_acquire(&rw->rw_mutex);
-
-  if (rw->rw_refcount > 0) {
-    rw->rw_refcount--; /* releasing a reader */
-  } else if (rw->rw_refcount == -1) {
-    rw->rw_refcount = 0; /* releasing a reader */
-  } else {
-    ink_abort("invalid refcount %d on ink_rwlock %p", rw->rw_refcount, rw);
-  }
-
-  /* give preference to waiting writers over waiting readers */
-  if (rw->rw_nwaitwriters > 0) {
-    if (rw->rw_refcount == 0) {
-      ink_cond_signal(&rw->rw_condwriters);
-    }
-  } else if (rw->rw_nwaitreaders > 0) {
-    ink_cond_broadcast(&rw->rw_condreaders);
-  }
-
-  ink_mutex_release(&rw->rw_mutex);
-
-  return 0;
 }


### PR DESCRIPTION
This change updates `ink_rwlock` to be a `pthread_rwlock`.  I used `ink_mutex` as a model for the implementation.

I was seeing lock contention on `HostStatus::host_status_rwlock` which is a `ink_rwlock`.  `ink_rwlock` is implemented with a `pthread_mutex` instead of a `pthread_rwlock`.  I was seeing it contending at a rate of 1.3K per seconds while benchmarking:

For a 30 second period of time:
`[ET_NET 3][1877820] lock 0x891ff8 contended 38393 times, 2 avg us`

The performance didn't increase with the change while benchmarking ATS, but it does simplify the code and gets rid of lock contention which will make it easier to identify other contending locks.  I believe performance didn't increase because the time we are contending on the lock is only 2us.


