### PR TITLE
Fix missing virtual destructor for PluginUserArgsMixin.

### DIFF
--- a/include/tscore/PluginUserArgs.h
+++ b/include/tscore/PluginUserArgs.h
@@ -42,6 +42,7 @@ static constexpr std::array<size_t, TS_USER_ARGS_COUNT> MAX_USER_ARGS = {{
 class PluginUserArgsMixin
 {
 public:
+  virtual ~PluginUserArgsMixin()                  = default;
   virtual void *get_user_arg(size_t ix) const     = 0;
   virtual void set_user_arg(size_t ix, void *arg) = 0;
 };


### PR DESCRIPTION
Mostly cleanliness - it's good to build with `-Wnon-virutal-dtor` to detect more important errors and so this needs to be fixed. As the class don't have any contents it's not really a direct problem, but even
there best to be safe as adding the virtual destructor has no marginal cost for classes that already have
virtual methods.