### PR TITLE
Use default rwlock attributes on initialize

### DIFF
--- a/src/tscore/ink_rwlock.cc
+++ b/src/tscore/ink_rwlock.cc
@@ -24,8 +24,6 @@
 #include "tscore/ink_config.h"
 #include "tscore/ink_rwlock.h"
 
-static pthread_rwlockattr_t attr;
-
 //-------------------------------------------------------------------------
 // ink_rwlock_init
 //
@@ -34,7 +32,7 @@ static pthread_rwlockattr_t attr;
 void
 ink_rwlock_init(ink_rwlock *rw)
 {
-  int error = pthread_rwlock_init(rw, &attr);
+  int error = pthread_rwlock_init(rw, nullptr);
   if (unlikely(error != 0)) {
     ink_abort("pthread_rwlock_init(%p) failed: %s (%d)", rw, strerror(error), error);
   }


### PR DESCRIPTION
After 3aeb0db4cd93197c4dd1dca734c9262555975d55, TS failed a assert on start up on macOS.

```
traffic_server: using root directory '/opt/ats-master'
Fatal: pthread_rwlock_init(0x100731160) failed: Invalid argument (22)
```

`man pthread_rwlock_init` says below. We can use the default value by setting `nullptr`.
> If attr is NULL, the default read-write lock attributes shall be used