### PR TITLE
close the file after use

### DIFF
--- a/proxy/http3/test/test_QPACK.cc
+++ b/proxy/http3/test/test_QPACK.cc
@@ -342,6 +342,7 @@ test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int am
   FILE *fd_out = fopen(out_file, "w");
   if (!fd_out) {
     std::cerr << "couldn't open file: " << out_file << std::endl;
+    fclose(fd_in);
     REQUIRE(false);
     return -1;
   }
@@ -399,7 +400,7 @@ test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int am
   fflush(fd_in);
   fclose(fd_in);
   fflush(fd_out);
-  fclose(fd_out);  
+  fclose(fd_out);
   return ret;
 }
 

--- a/proxy/http3/test/test_QPACK.cc
+++ b/proxy/http3/test/test_QPACK.cc
@@ -380,6 +380,7 @@ test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int am
   }
 
   if (!feof(fd_in)) {
+    REQUIRE(false)
     return -1;
   }
 

--- a/proxy/http3/test/test_QPACK.cc
+++ b/proxy/http3/test/test_QPACK.cc
@@ -395,7 +395,10 @@ test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int am
       delete header_sets[i];
     }
   }
-
+  fflush(fd_in);
+  fclose(fd_in);
+  fflush(fd_out);
+  fclose(fd_out);  
   return ret;
 }
 

--- a/proxy/http3/test/test_QPACK.cc
+++ b/proxy/http3/test/test_QPACK.cc
@@ -380,7 +380,7 @@ test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int am
   }
 
   if (!feof(fd_in)) {
-    REQUIRE(false)
+    REQUIRE(false);
     return -1;
   }
 


### PR DESCRIPTION
Hi Peeps,

I found an opportunity for improvement this code. The test_decode function opens two files, but it never closes those files. In this case, we have 2 types of weaknesses: CWE 399 (Resource Management Errors) and CWE 772 (Missing Release of Resource after Effective Lifetime).

According to CWE 772: "When a resource is not released after use, it can allow attackers to cause a denial of service by causing the allocation of resources without triggering their release. Frequently-affected resources include memory, CPU, disk space, power or battery, etc."

Thus, I suggest following the pattern of the test_encode function and closing both files after use.

CWE 339: https://cwe.mitre.org/data/definitions/399.html
CWE 772: https://cwe.mitre.org/data/definitions/772.html

Regards