### PR TITLE
Ensure TSStatCreate is called at least once per counter

### DIFF
--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -268,7 +268,8 @@ protected:
 
 private:
   std::string _counter_name;
-  int _counter = TS_ERROR;
+  int _counter  = TS_ERROR;
+  bool _created = false;
 };
 
 class OperatorRMCookie : public OperatorCookies


### PR DESCRIPTION
Oddly, TSStatFindName() seems to return success sometimes (especially on
a traffic_server restart (but, not a traffic_manager restart) following a core dump) , yet the counter was never created and
api_rsb_index is not updated. This causes issues with this counter as well
as subsequent counters that end up grabbing the previously allocated stat_id