### PR TITLE
Fix origin scheme selection with partial-blind addition

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5130,7 +5130,7 @@ HttpSM::do_http_server_open(bool raw)
     if (new_scheme_to_use >= 0) { // found a new scheme, use it
       scheme_to_use = new_scheme_to_use;
     }
-    if (!tls_upstream) {
+    if (!raw || !tls_upstream) {
       tls_upstream = scheme_to_use == URL_WKSIDX_HTTPS;
     }
   }


### PR DESCRIPTION
Found this issue while trying to deploy the most recent ATS9 updates in our environment.  The partial_blind tunnel additions caused our CARP plugin to break.  The plugin uses TSHttpTxnServerAddrSet and TSUrlSchemeSet to adjust some transactions to communicate with another peer in the colo using HTTP instead of HTTPS as the original transaction came in on.

Without this change the logic to downgrade a transaction from HTTPS to HTTP to origin was not triggering.  So ATS would send a client-hello to a peer expecting no TLS.  It would sending back a HTTP 400 error which confused the TLS processing on the sending ATS side resulting in a 502 connection error.

This adjustment fixed our plugin logic, but @randall needs to verify that this does not break the partial_blind_tunnel logic.