### PR TITLE
Check sni against SSL object

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -649,6 +649,12 @@ public:
     return false;
   }
 
+  virtual const char *
+  get_sni_servername() const
+  {
+    return nullptr;
+  }
+
   /** Structure holding user options. */
   NetVCOptions options;
 

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -454,6 +454,12 @@ public:
     verify_cert = ctx;
   }
 
+  const char *
+  get_sni_servername() const override
+  {
+    return SSL_get_servername(this->ssl, TLSEXT_NAMETYPE_host_name);
+  }
+
 private:
   std::string_view map_tls_protocol_to_tag(const char *proto_string) const;
   bool update_rbio(bool move_to_socket);

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -85,7 +85,7 @@ ServerSessionPool::validate_host_sni(HttpSM *sm, NetVConnection *netvc)
     // by fetching the hostname from the server request.  So the connection should only
     // be reused if the hostname in the new request is the same as the host name in the
     // original request
-    const char *session_sni = netvc->options.sni_servername;
+    const char *session_sni = netvc->get_sni_servername();
     if (session_sni) {
       // TS-4468: If the connection matches, make sure the SNI server
       // name (if present) matches the request hostname
@@ -106,7 +106,7 @@ ServerSessionPool::validate_sni(HttpSM *sm, NetVConnection *netvc)
   // a new connection.
   //
   if (sm->t_state.scheme == URL_WKSIDX_HTTPS) {
-    const char *session_sni       = netvc->options.sni_servername;
+    const char *session_sni       = netvc->get_sni_servername();
     std::string_view proposed_sni = sm->get_outbound_sni();
     Debug("http_ss", "validate_sni proposed_sni=%s, sni=%s", proposed_sni.data(), session_sni);
     if (!session_sni || proposed_sni.length() == 0) {


### PR DESCRIPTION
This fix is needed to make PR https://github.com/apache/trafficserver/pull/6566 fully functional when working with global session pools.

If the netvc's are migrated, the options data structure is lost.  This change just uses the SSL object to fetch the sni name directly.