### PR TITLE
Update TSStatFindName to check that sync callback is set on the stat

### DIFF
--- a/lib/records/I_RecCore.h
+++ b/lib/records/I_RecCore.h
@@ -166,7 +166,7 @@ RecErrT RecLookupMatchingRecords(unsigned rec_type, const char *match, RecLookup
 RecErrT RecGetRecordType(const char *name, RecT *rec_type, bool lock = true);
 RecErrT RecGetRecordDataType(const char *name, RecDataT *data_type, bool lock = true);
 RecErrT RecGetRecordPersistenceType(const char *name, RecPersistT *persist_type, bool lock = true);
-RecErrT RecGetRecordOrderAndId(const char *name, int *order, int *id, bool lock = true);
+RecErrT RecGetRecordOrderAndId(const char *name, int *order, int *id, bool lock = true, bool check_sync_cb = false);
 RecErrT RecGetRecordUpdateType(const char *name, RecUpdateT *update_type, bool lock = true);
 RecErrT RecGetRecordCheckType(const char *name, RecCheckT *check_type, bool lock = true);
 RecErrT RecGetRecordCheckExpr(const char *name, char **check_expr, bool lock = true);

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -607,7 +607,7 @@ RecGetRecordPersistenceType(const char *name, RecPersistT *persist_type, bool lo
 }
 
 RecErrT
-RecGetRecordOrderAndId(const char *name, int *order, int *id, bool lock)
+RecGetRecordOrderAndId(const char *name, int *order, int *id, bool lock, bool check_sync_cb)
 {
   RecErrT err = REC_ERR_FAIL;
 
@@ -619,15 +619,17 @@ RecGetRecordOrderAndId(const char *name, int *order, int *id, bool lock)
     RecRecord *r = it->second;
 
     if (r->registered) {
-      rec_mutex_acquire(&(r->lock));
-      if (order) {
-        *order = r->order;
+      if (!check_sync_cb || r->stat_meta.sync_cb) {
+        rec_mutex_acquire(&(r->lock));
+        if (order) {
+          *order = r->order;
+        }
+        if (id) {
+          *id = r->rsb_id;
+        }
+        err = REC_ERR_OKAY;
+        rec_mutex_release(&(r->lock));
       }
-      if (id) {
-        *id = r->rsb_id;
-      }
-      err = REC_ERR_OKAY;
-      rec_mutex_release(&(r->lock));
     }
   }
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -7451,7 +7451,7 @@ TSStatFindName(const char *name, int *idp)
 
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
 
-  if (RecGetRecordOrderAndId(name, nullptr, &id) != REC_ERR_OKAY) {
+  if (RecGetRecordOrderAndId(name, nullptr, &id, true, true) != REC_ERR_OKAY) {
     return TS_ERROR;
   }
 


### PR DESCRIPTION
This PR corrects the behavior of the API `TSStatFindName()` to return success only when the stat already has a `sync_cb` set (which is only true if the stat was originally created via a call to `TSStatCreate()` - needed to ensure the `api_rsb_index` is correctly incremented/reserved)


```
Yeah, that sounds fair! I'll change the existing `TSStatFindName()` API to only return success if the found stat also has a sync callback already set. Sync Callback (e.g a Counter/Guage/Average etc) is set by calling TSStatCreate() ) and this change will ensure that `TSStatFindName()` will not return success when a stat is loaded from disk upon a restart but no TSStatCreate() is called on it yet. 

Here's the PR 
https://github.com/apache/trafficserver/pull/6658

If anyone has concerns or need the old behavior, pls let me know :)


Thanks,

Sudheer
On Tuesday, April 14, 2020, 03:24:33 PM PDT, Leif Hedstrom <zwoop@apache.org> wrote:
> On Apr 14, 2020, at 1:23 PM, Sudheer Vinukonda <sudheervinukonda@yahoo.com> wrote:
> 
> The existing TS API `TSStaFindName()` returns success if it's able to find the stat in the stats hash table. This automatically becomes true for persistent stats that get loaded from the stats snapshot, even when a `TSStatCreate()` hasn't been called yet on that stat after a server restart.
> 
> There are certain use cases, which check if `TSStatFindName()` returns not found and only then create the stat (call `TSStatCreate()`)  - for example, header-rewrite plugin. The intention there is to not call `TSStatCreate` duplicate on a given counter that's potentially created via multiple rules. 
> 
> However, this results in not setting the Sync CB for the counter while also not updating the api_rsb_index. This can potentially affect subsequent API stats as they end up getting stat ids that are already in use by previously used stats that did not end up calling `TSStatCreate`
> 
> To address this, I'm proposing to add a new TS API `TSSyncStatFindName()` which returns found only if the stat is in the hash table and it's sync_cb is set. This API will replace the usage of `TSStatFindName` in header-rewrite and other plugins that we internally have which have similar use cases.
> 
> Let me know any concerns/comments/feedback.



Hmmm, why not just “fix” the existing API for 9.0.0, and be done with it? Or, alternatively, if both functionalities needs to be available, add another option to the existing API(s)? I’m hesitant to add more complexity with difficult to chose from APIs, particularly since we’re right in the middle of a major (9.0.0) release right now.

— Leif
```