### PR TITLE
Add transparent access for internal buffer in LocalBuffer

### DIFF
--- a/include/tscpp/util/LocalBuffer.h
+++ b/include/tscpp/util/LocalBuffer.h
@@ -42,6 +42,11 @@ public:
   T *data() const;
   std::size_t size() const;
 
+  T &operator[](std::size_t index);
+  const T &operator[](std::size_t index) const;
+
+  operator T *();
+
 private:
   T _buf[EstSizeBound];
   T *const _ptr;
@@ -67,6 +72,21 @@ inline std::size_t
 LocalBuffer<T, S>::size() const
 {
   return _size;
+}
+
+template <class T, std::size_t S> inline T &LocalBuffer<T, S>::operator[](std::size_t index)
+{
+  return data()[index];
+}
+
+template <class T, std::size_t S> inline const T &LocalBuffer<T, S>::operator[](std::size_t index) const
+{
+  return data()[index];
+}
+
+template <class T, std::size_t S> inline LocalBuffer<T, S>::operator T *()
+{
+  return data();
 }
 
 } // namespace ts

--- a/src/tscpp/util/unit_tests/test_LocalBuffer.cc
+++ b/src/tscpp/util/unit_tests/test_LocalBuffer.cc
@@ -108,4 +108,24 @@ TEST_CASE("LocalBuffer", "[libts][LocalBuffer]")
       CHECK(local_buffer.size() == 4096);
     }
   }
+
+  SECTION("Transparent access")
+  {
+    const size_t len = 1024;
+    ts::LocalBuffer local_buffer1(len);
+    ts::LocalBuffer local_buffer2(len);
+
+    memset(local_buffer1, 0xAA, len);
+    local_buffer1[len - 1] = 0xBB;
+
+    CHECK(local_buffer1[0] == 0xAA);
+    CHECK(local_buffer1[len - 1] == 0xBB);
+    CHECK(local_buffer1.size() == 1024);
+
+    memcpy(local_buffer2, local_buffer1, local_buffer2.size());
+
+    CHECK(local_buffer2[0] == 0xAA);
+    CHECK(local_buffer2[len - 1] == 0xBB);
+    CHECK(local_buffer2.size() == 1024);
+  }
 }


### PR DESCRIPTION
#6536 looks ok, but use of LocalBuffer requires additional variable just for type conversion. This PR adds transparent access for the internal buffer in LocalBuffer and it allows accessing LocalBuffer like a pure array.