### PR TITLE
Fix 8.1.x build with old openssl

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -407,6 +407,7 @@ ssl_verify_client_callback(int preverify_ok, X509_STORE_CTX *ctx)
   return SSL_TLSEXT_ERR_OK;
 }
 
+#if TS_USE_CERT_CB || TS_USE_HELLO_CB
 static int
 PerformAction(Continuation *cont, const char *servername)
 {
@@ -424,6 +425,7 @@ PerformAction(Continuation *cont, const char *servername)
   }
   return SSL_TLSEXT_ERR_OK;
 }
+#endif
 
 #if TS_USE_HELLO_CB
 // Pausable callback


### PR DESCRIPTION
Fix unused-function warnings on ubuntu 14.04 & centos 6
```
../../../iocore/net/SSLUtils.cc:411:1: error: 'int PerformAction(Continuation*, const char*)' defined but not used [-Werror=unused-function]
 PerformAction(Continuation *cont, const char *servername)
 ^~~~~~~~~~~~~
```
https://ci.trafficserver.apache.org/view/8.1.x/job/ubuntu_14_04-8.1.x/compiler=gcc,label=ubuntu_14_04,type=debug/171/console
https://ci.trafficserver.apache.org/view/8.1.x/job/centos_6-8.1.x/compiler=gcc,label=centos_6,type=debug/173/console