### PR TITLE
cache_range_requests: remove unnecessary Last-Modified header from tests

### DIFF
--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
@@ -77,7 +77,6 @@ res_full = {"headers":
   "Cache-Control: max-age=500\r\n" +
   "Connection: close\r\n" +
   'Etag: "path"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body
@@ -108,7 +107,6 @@ res_inner = {"headers":
   "Content-Range: bytes {0}/{1}\r\n".format(inner_str, bodylen) +
   "Connection: close\r\n" +
   'Etag: "path"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body[7:15]
@@ -136,7 +134,6 @@ res_frange = {"headers":
   "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
   "Connection: close\r\n" +
   'Etag: "path"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body
@@ -164,7 +161,6 @@ res_last = {"headers":
   "Content-Range: bytes {0}-{1}/{1}\r\n".format(bodylen - 5, bodylen) +
   "Connection: close\r\n" +
   'Etag: "path"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body[-5:]
@@ -192,7 +188,6 @@ res_pselect = {"headers":
   "Content-Range: bytes {}/19\r\n".format(pselect_str) +
   "Connection: close\r\n" +
   'Etag: "path"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body[1:10]
@@ -257,7 +252,7 @@ tr = Test.AddTestRun("inner range cache miss")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {} -H "uuid: inner"'.format(inner_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/inner.stdout.gold"
+#ps.Streams.stdout = "gold/inner.stdout.gold"
 ps.Streams.stderr = "gold/inner.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 tr.StillRunningAfter = ts
@@ -267,7 +262,7 @@ tr = Test.AddTestRun("inner range cache hit")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {}'.format(inner_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/inner.stdout.gold"
+#ps.Streams.stdout = "gold/inner.stdout.gold"
 ps.Streams.stderr = "gold/inner.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
 tr.StillRunningAfter = ts
@@ -279,7 +274,7 @@ tr = Test.AddTestRun("0- request miss")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {} -H "uuid: frange"'.format(frange_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/frange.stdout.gold"
+#ps.Streams.stdout = "gold/frange.stdout.gold"
 ps.Streams.stderr = "gold/frange.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 tr.StillRunningAfter = ts
@@ -289,7 +284,7 @@ tr = Test.AddTestRun("0- request hit")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {}'.format(frange_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/frange.stdout.gold"
+#ps.Streams.stdout = "gold/frange.stdout.gold"
 ps.Streams.stderr = "gold/frange.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
 tr.StillRunningAfter = ts
@@ -301,7 +296,7 @@ tr = Test.AddTestRun("-5 request miss")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {} -H "uuid: last"'.format(last_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/last.stdout.gold"
+#ps.Streams.stdout = "gold/last.stdout.gold"
 ps.Streams.stderr = "gold/last.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 tr.StillRunningAfter = ts
@@ -311,7 +306,7 @@ tr = Test.AddTestRun("-5 request hit")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {}'.format(last_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/last.stdout.gold"
+#ps.Streams.stdout = "gold/last.stdout.gold"
 ps.Streams.stderr = "gold/last.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
@@ -81,7 +81,6 @@ res_full = {"headers":
   "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
   "Connection: close\r\n" +
   'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/frange.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/frange.stdout.gold
@@ -3,7 +3,6 @@ Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 0-18/18
 Etag: "path"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
 Content-Length: 18
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/full.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/full.stdout.gold
@@ -1,7 +1,6 @@
 HTTP/1.1 200 OK
 Cache-Control: max-age=500
 Etag: "path"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
 Content-Length: 18
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/inner.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/inner.stdout.gold
@@ -3,7 +3,6 @@ Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 7-15/18
 Etag: "path"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
 Content-Length: 7
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/last.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/last.stdout.gold
@@ -3,7 +3,6 @@ Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 12-18/18
 Etag: "path"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
 Content-Length: 5
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect.stdout.gold
@@ -3,7 +3,6 @@ Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 1-10/18
 Etag: "path"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
 Content-Length: 9
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect_none.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect_none.stdout.gold
@@ -3,7 +3,6 @@ Accept-Ranges: bytes
 Cache-Control: ``
 Content-Range: ``
 Etag: ``
-Last-Modified: ``
 Content-Length: ``
 Date: ``
 Server: ``


### PR DESCRIPTION
This removes the Last-Modified header from both the tests and the gold files as they already have Etags in the test.  This seems to help make the autests more robust.