### PR TITLE
Fix link issue of test_libhttp2 on FreeBSD 12 with --enable-debug

### DIFF
--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -62,12 +62,14 @@ check_PROGRAMS = \
 
 TESTS = $(check_PROGRAMS)
 
+# The order of libinkevent.a and libhdrs.a is sensitive for LLD on debug build.
+# Be careful if you change the order. Details in GitHub #6666
 test_libhttp2_LDADD = \
 	libhttp2.a \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/lib/records/librecords_p.a \
 	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \


### PR DESCRIPTION
Fix FreeBSD 12 debug jobs on ci.
```
libtool: link: ccache clang++ -std=c++17 -ggdb3 -pipe -Wall -Wno-deprecated-declarations -Qunused-arguments -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -Werror -Wno-invalid-offsetof -mcx16 -Qunused-arguments -rdynamic -Wl,-R/usr/local/lib -Wl,-R/usr/local/lib -o .libs/test_libhttp2 unit_tests/test_libhttp2-test_Http2Frame.o unit_tests/test_libhttp2-main.o  -L/usr/local/lib -L/usr/lib libhttp2.a ../../proxy/hdrs/libhdrs.a ../../src/tscore/.libs/libtscore.so -L/var/jenkins/workspace/freebsd_12-9.0.x/compiler/clang/label/freebsd_12/type/debug/111/build/BUILDS/lib/yamlcpp /var/jenkins/workspace/freebsd_12-9.0.x/compiler/clang/label/freebsd_12/type/debug/111/build/BUILDS/src/tscpp/util/.libs/libtscpputil.so -lpcre -lssl -lcrypto ../../src/tscpp/util/.libs/libtscpputil.so ../../iocore/eventsystem/libinkevent.a ../../lib/records/librecords_p.a ../../mgmt/.libs/libmgmt_p.a ../../proxy/shared/libUglyLogStubs.a -lexecinfo -lpthread -Wl,-rpath -Wl,/var/jenkins/workspace/freebsd_12-9.0.x/compiler/clang/label/freebsd_12/type/debug/111/install/lib -Wl,-rpath -Wl,/usr/lib -Wl,-rpath -Wl,/usr/local/lib
ld: error: undefined symbol: ProxySession::ProxySession()
>>> referenced by Http2ClientSession.cc:68 (../../../proxy/http2/Http2ClientSession.cc:68)
>>>               Http2ClientSession.o:(Http2ClientSession::Http2ClientSession()) in archive libhttp2.a

ld: error: undefined symbol: ProxySession::ProxySession()
>>> referenced by Http2ClientSession.cc:68 (../../../proxy/http2/Http2ClientSession.cc:68)
>>>               Http2ClientSession.o:(Http2ClientSession::Http2ClientSession()) in archive libhttp2.a
...
```
https://ci.trafficserver.apache.org/job/freebsd_12-master/compiler=clang,label=freebsd_12,type=debug/1334/console

Both of 9.0.x and 8.1.x branch need this. The unit test is introduced by 582df40711b07cf01b25c65c7fddf27288e0a8bd and it was cherry picked to 9.0.x and 8.1.x.