### PR TITLE
Fixes the 'traffic_ctl host status' for trafficserver 8.1.x

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -439,6 +439,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
   char *tmp = nullptr, *tmp2 = nullptr, *tmp3 = nullptr;
   const char *errPtr = nullptr;
   float weight       = 1.0;
+  HostStatus &hs     = HostStatus::instance();
 
   if (parents != nullptr && isPrimary == true) {
     return "Can not specify more than one set of parents";
@@ -531,6 +532,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
       this->parents[i].name                    = this->parents[i].hostname;
       this->parents[i].available               = true;
       this->parents[i].weight                  = weight;
+      hs.createHostStat(this->parents[i].hostname);
       if (tmp3) {
         memcpy(this->parents[i].hash_string, tmp3 + 1, strlen(tmp3));
         this->parents[i].name = this->parents[i].hash_string;
@@ -546,6 +548,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
       this->secondary_parents[i].name                    = this->secondary_parents[i].hostname;
       this->secondary_parents[i].available               = true;
       this->secondary_parents[i].weight                  = weight;
+      hs.createHostStat(this->secondary_parents[i].hostname);
       if (tmp3) {
         memcpy(this->secondary_parents[i].hash_string, tmp3 + 1, strlen(tmp3));
         this->secondary_parents[i].name = this->secondary_parents[i].hash_string;

--- a/src/traffic_ctl/host.cc
+++ b/src/traffic_ctl/host.cc
@@ -35,19 +35,14 @@ status_get(unsigned argc, const char **argv)
   for (unsigned i = 0; i < n_file_arguments; ++i) {
     CtrlMgmtRecord record;
     TSMgmtError error;
-    std::string str = stat_prefix + file_arguments[i];
-
-    for (const char *_reason_tag : Reason::reasons) {
-      std::string _stat = str + "_" + _reason_tag;
-      error             = record.fetch(_stat.c_str());
-      if (error != TS_ERR_OKAY) {
-        CtrlMgmtError(error, "failed to fetch %s", file_arguments[i]);
-        return CTRL_EX_ERROR;
-      }
-
-      if (REC_TYPE_IS_STAT(record.rclass())) {
-        printf("%s %s\n", record.name(), CtrlMgmtRecordValue(record).c_str());
-      }
+    std::string _stat = stat_prefix + file_arguments[i];
+    error             = record.fetch(_stat.c_str());
+    if (error != TS_ERR_OKAY) {
+      fprintf(stderr, "failed to fetch %s, no record found\n", file_arguments[i]);
+      return CTRL_EX_ERROR;
+    }
+    if (REC_TYPE_IS_STAT(record.rclass())) {
+      printf("%s %s\n", record.name(), CtrlMgmtRecordValue(record).c_str());
     }
   }
 


### PR DESCRIPTION
Fixes the 'traffic_ctl host status' command to correctly lookup next hop metrics and adds back the
automatic creation of parent host metrics when parent.config is read at startup.