### PR TITLE
Skip running autests for ci builds that don't have relevant changed files

### DIFF
--- a/ci/jenkins/bin/autest.sh
+++ b/ci/jenkins/bin/autest.sh
@@ -18,6 +18,14 @@
 
 set +x
 
+if [ ! -z "$ghprbActualCommit" ]; then
+    git diff ${ghprbActualCommit}^...${ghprbActualCommit} --name-only | egrep -E '^(build|iocore|proxy|tests|include|mgmt|plugins|proxy|src)/' > /dev/null
+    if [ $? = 1 ]; then
+        echo "No relevant files changed, skipping run"
+        exit 0
+    fi
+fi
+
 # Set default encoding UTF-8 for AuTest
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8

--- a/tests/autest.sh
+++ b/tests/autest.sh
@@ -16,14 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-if [ ! -z "$ghprbActualCommit" ]; then
-    git diff ${ghprbActualCommit}^...${ghprbActualCommit} --name-only | egrep -E '^(build|iocore|proxy|tests|include|mgmt|plugins|proxy|src)/' > /dev/null
-    if [ $? = 1 ]; then
-        echo "No relevant files changed, skipping autest run"
-        exit 0
-    fi
-fi
-
 pushd $(dirname $0) > /dev/null
 export PYTHONPATH=$(pwd):$PYTHONPATH
 ./test-env-check.sh;


### PR DESCRIPTION
Removed from tests/autest.sh and put into the toplevel ci script