### PR TITLE
8.1.x backport cache_range_requests autests: remove last-modified

### DIFF
--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
@@ -76,8 +76,7 @@ res_full = {"headers":
   "HTTP/1.1 200 OK\r\n" +
   "Cache-Control: max-age=500\r\n" +
   "Connection: close\r\n" +
-  'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
+  'Etag: "path"\r\n' +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body
@@ -107,8 +106,7 @@ res_inner = {"headers":
   "Cache-Control: max-age=500\r\n" +
   "Content-Range: bytes {0}/{1}\r\n".format(inner_str, bodylen) +
   "Connection: close\r\n" +
-  'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
+  'Etag: "path"\r\n' +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body[7:15]
@@ -135,8 +133,7 @@ res_frange = {"headers":
   "Cache-Control: max-age=500\r\n" +
   "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
   "Connection: close\r\n" +
-  'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
+  'Etag: "path"\r\n' +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body
@@ -163,8 +160,7 @@ res_last = {"headers":
   "Cache-Control: max-age=200\r\n" +
   "Content-Range: bytes {0}-{1}/{1}\r\n".format(bodylen - 5, bodylen) +
   "Connection: close\r\n" +
-  'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
+  'Etag: "path"\r\n' +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body[-5:]
@@ -191,8 +187,7 @@ res_pselect = {"headers":
   "Cache-Control: max-age=200\r\n" +
   "Content-Range: bytes {}/19\r\n".format(pselect_str) +
   "Connection: close\r\n" +
-  'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-  "Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT\r\n" +
+  'Etag: "path"\r\n' +
   "\r\n",
   "timestamp": "1469733493.993",
   "body": body[1:10]
@@ -238,7 +233,7 @@ tr = Test.AddTestRun("inner range cache miss")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {} -H "uuid: inner"'.format(inner_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/inner.stdout.gold"
+#ps.Streams.stdout = "gold/inner.stdout.gold"
 ps.Streams.stderr = "gold/inner.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 tr.StillRunningAfter = ts
@@ -248,7 +243,7 @@ tr = Test.AddTestRun("inner range cache hit")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {}'.format(inner_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/inner.stdout.gold"
+#ps.Streams.stdout = "gold/inner.stdout.gold"
 ps.Streams.stderr = "gold/inner.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
 tr.StillRunningAfter = ts
@@ -260,7 +255,7 @@ tr = Test.AddTestRun("0- request miss")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {} -H "uuid: frange"'.format(frange_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/frange.stdout.gold"
+#ps.Streams.stdout = "gold/frange.stdout.gold"
 ps.Streams.stderr = "gold/frange.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 tr.StillRunningAfter = ts
@@ -270,7 +265,7 @@ tr = Test.AddTestRun("0- request hit")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {}'.format(frange_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/frange.stdout.gold"
+#ps.Streams.stdout = "gold/frange.stdout.gold"
 ps.Streams.stderr = "gold/frange.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
 tr.StillRunningAfter = ts
@@ -282,7 +277,7 @@ tr = Test.AddTestRun("-5 request miss")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {} -H "uuid: last"'.format(last_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/last.stdout.gold"
+#ps.Streams.stdout = "gold/last.stdout.gold"
 ps.Streams.stderr = "gold/last.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 tr.StillRunningAfter = ts
@@ -292,7 +287,7 @@ tr = Test.AddTestRun("-5 request hit")
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://www.example.com/path -r {}'.format(last_str)
 ps.ReturnCode = 0
-ps.Streams.stdout = "gold/last.stdout.gold"
+#ps.Streams.stdout = "gold/last.stdout.gold"
 ps.Streams.stderr = "gold/last.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/frange.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/frange.stdout.gold
@@ -2,8 +2,7 @@ HTTP/1.1 206 Partial Content
 Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 0-18/18
-Etag: "772102f4-56f4bc1e6d417"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
+Etag: "path"
 Content-Length: 18
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/full.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/full.stdout.gold
@@ -1,7 +1,6 @@
 HTTP/1.1 200 OK
 Cache-Control: max-age=500
-Etag: "772102f4-56f4bc1e6d417"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
+Etag: "path"
 Content-Length: 18
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/inner.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/inner.stdout.gold
@@ -2,8 +2,7 @@ HTTP/1.1 206 Partial Content
 Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 7-15/18
-Etag: "772102f4-56f4bc1e6d417"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
+Etag: "path"
 Content-Length: 7
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/last.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/last.stdout.gold
@@ -2,8 +2,7 @@ HTTP/1.1 206 Partial Content
 Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 12-18/18
-Etag: "772102f4-56f4bc1e6d417"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
+Etag: "path"
 Content-Length: 5
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect.stdout.gold
@@ -2,8 +2,7 @@ HTTP/1.1 206 Partial Content
 Accept-Ranges: bytes
 Cache-Control: max-age=500
 Content-Range: bytes 1-10/18
-Etag: "772102f4-56f4bc1e6d417"
-Last-Modified: Sat, 23 Jun 2018 09:27:29 GMT
+Etag: "path"
 Content-Length: 9
 Date: ``
 Server: ``

--- a/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect_none.stdout.gold
+++ b/tests/gold_tests/pluginTest/cache_range_requests/gold/pselect_none.stdout.gold
@@ -3,7 +3,6 @@ Accept-Ranges: bytes
 Cache-Control: ``
 Content-Range: ``
 Etag: ``
-Last-Modified: ``
 Content-Length: ``
 Date: ``
 Server: ``


### PR DESCRIPTION
Backport PR to make the autests simpler and more resilient.