### PR TITLE
Fixes to hostDB to avoid event and memory leaks

### DIFF
--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -37,7 +37,6 @@
 extern int hostdb_enable;
 extern int hostdb_migrate_on_demand;
 extern int hostdb_lookup_timeout;
-extern int hostdb_insert_timeout;
 extern int hostdb_re_dns_on_reload;
 
 // 0 = obey, 1 = ignore, 2 = min(X,ttl), 3 = max(X,ttl)


### PR DESCRIPTION
@randall found memory leaks in a previous hostDB fix I pushed 153c08166ed3ba83f92064e607b37210fa34c297.

I spent quite a bit of time last winter tracking down HostDB events that would trigger after the original continuations had long died.  This was particularly bad in our forward proxy deployments where we didn't have control over the DNS servers.

We got our internal 7 version stable in terms of eliminating the stale hostdb events and the major hostdb leak.  This PR is the functional changes between the two.  The event leak fixes involve better tracking the the scheduled events and making sure to cancel them before cleaning things up.

Our internal version has been running with the asserts ensuring that the action->mutex == action.continuation->mutex.  So in this PR, I left the asserts but got rid of the odd second lock logic.  After staring at enough cores, I am convinced that those occurred in cases where the continuation had been deleted and reassigned. 

I also removed the hostdb_insert_timeout.  That appeared to be remnants of obsolete logic.