### PR TITLE
Remove tls_versions from host sni policy check

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1851,6 +1851,8 @@ Security
 
    You can override this global setting on a per domain basis in the :file:`sni.yaml` file using the :ref:`host_sni_policy attribute<override-host-sni-policy>` action.
 
+   Currently, only the verify_client policy is checked for host name and SNI matching.
+
 Cache Control
 =============
 

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -262,11 +262,6 @@ public:
     }
     return SSL_TLSEXT_ERR_OK;
   }
-  bool
-  TestClientSNIAction(const char *servername, const IpEndpoint &ep, int &policy) const override
-  {
-    return !unset;
-  }
 };
 
 class SNI_IpAllow : public ActionItem


### PR DESCRIPTION
The current logic will apply the host name and SNI name match check of the host name would have triggered a SNI policy for verify_client or tls_versions.

After working with this in production @djcarlin ran into issues with the tls_versions.  If the original connection negotiated TLS v1.3 but the SNI policy corresponding to the current host name would have only offered TLS 1.2, should we deny it?  Or only deny of the version was lower than the specified policy.

Ultimately we probably need a properties control here too.  In the short term, I suggest leaving the enforcement only for the client certificate policies.  As we gain experience, we can augment this configuration control or maybe go to something completely different.