### PR TITLE
Fix deprecated-copy warning in cache tool

### DIFF
--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -255,6 +255,8 @@ class VolumeAllocator
       : _config(config), _size(size), _deficit(deficit), _shares(shares)
     {
     }
+    V(const V &v) = default;
+
     V &
     operator=(V const &that)
     {


### PR DESCRIPTION
I saw below `-Wdeprecated-copy` warning with llvm-10 on macOS.
```
  CXX      traffic_cache_tool/traffic_cache_tool-CacheTool.o
traffic_cache_tool/CacheTool.cc:259:5: error: definition of implicit copy constructor for 'V' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
    operator=(V const &that)
    ^
/usr/local/opt/llvm/include/c++/v1/memory:1876:31: note: in implicit copy constructor for 'ct::VolumeAllocator::V' first required here
            ::new((void*)__p) _Up(_VSTD::forward<_Args>(__args)...);
                              ^
/usr/local/opt/llvm/include/c++/v1/memory:1768:18: note: in instantiation of function template specialization 'std::__1::allocator<ct::VolumeAllocator::V>::construct<ct::VolumeAllocator::V, ct::VolumeAllocator::V>' requested
here
            {__a.construct(__p, _VSTD::forward<_Args>(__args)...);}
                 ^
/usr/local/opt/llvm/include/c++/v1/memory:1595:14: note: in instantiation of function template specialization 'std::__1::allocator_traits<std::__1::allocator<ct::VolumeAllocator::V> >::__construct<ct::VolumeAllocator::V, ct::
VolumeAllocator::V>' requested here
            {__construct(__has_construct<allocator_type, _Tp*, _Args...>(),
             ^
/usr/local/opt/llvm/include/c++/v1/vector:924:21: note: in instantiation of function template specialization 'std::__1::allocator_traits<std::__1::allocator<ct::VolumeAllocator::V> >::construct<ct::VolumeAllocator::V, ct::Vol
umeAllocator::V>' requested here
    __alloc_traits::construct(this->__alloc(), _VSTD::__to_address(__tx.__pos_),
                    ^
/usr/local/opt/llvm/include/c++/v1/vector:1652:9: note: in instantiation of function template specialization 'std::__1::vector<ct::VolumeAllocator::V, std::__1::allocator<ct::VolumeAllocator::V> >::__construct_one_at_end<ct::
VolumeAllocator::V>' requested here
        __construct_one_at_end(_VSTD::move(__x));
        ^
traffic_cache_tool/CacheTool.cc:313:15: note: in instantiation of member function 'std::__1::vector<ct::VolumeAllocator::V, std::__1::allocator<ct::VolumeAllocator::V> >::push_back' requested here
          _av.push_back({vol, size, 0, 0});
              ^
1 error generated.
make[2]: *** [traffic_cache_tool/traffic_cache_tool-CacheTool.o] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all-recursive] Error 1
```