### PR TITLE
Increase the default max_record_entries to match the original value

### DIFF
--- a/lib/records/P_RecDefs.h
+++ b/lib/records/P_RecDefs.h
@@ -31,7 +31,7 @@
 // additional slots in librecords will be allocated to the plugin metrics. These should be
 // updated if we change the internal librecords size significantly.
 #define REC_INTERNAL_RECORDS 1100
-#define REC_MIN_API_RECORDS 500
+#define REC_DEFAULT_API_RECORDS 1400
 
 #define REC_CONFIG_UPDATE_INTERVAL_MS 3000
 #define REC_REMOTE_SYNC_INTERVAL_MS 5000

--- a/lib/records/RecCore.cc
+++ b/lib/records/RecCore.cc
@@ -34,7 +34,7 @@
 
 // This is needed to manage the size of the librecords record. It can't be static, because it needs to be modified
 // and used (read) from several binaries / modules.
-int max_records_entries = REC_INTERNAL_RECORDS + REC_MIN_API_RECORDS;
+int max_records_entries = REC_INTERNAL_RECORDS + REC_DEFAULT_API_RECORDS;
 
 static bool g_initialized = false;
 

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -170,7 +170,8 @@ ProxyStateSet(TSProxyStateT state, TSCacheClearT clear)
 
     // Start with the default options from records.config.
     if (RecGetRecordString_Xmalloc("proxy.config.proxy_binary_opts", &proxy_options) == REC_ERR_OKAY) {
-      if (max_records_entries == (REC_INTERNAL_RECORDS + REC_MIN_API_RECORDS)) { // Default size, don't need to pass down to _server
+      if (max_records_entries ==
+          (REC_INTERNAL_RECORDS + REC_DEFAULT_API_RECORDS)) { // Default size, don't need to pass down to _server
         snprintf(tsArgs, sizeof(tsArgs), "%s", proxy_options);
       } else {
         snprintf(tsArgs, sizeof(tsArgs), "%s --maxRecords %d", proxy_options, max_records_entries);


### PR DESCRIPTION
Addresses issue #6472.  We've updated our /etc/sysconfig/trafficserver to pass in the 2500 (the previous compiled in value).  But if you start traffic_server without that value in our environment you get a mysterious core dump.  Better for the upgrade to keep the default value the same as the previous compiled in value.  From my reading there was no real meaning to the min_api value.  It was really just the default.  So this PR increases the default.