### PR TITLE
Fix AuTest (httpbin) againt 8.0.x

### DIFF
--- a/tests/gold_tests/h2/gold/httpbin_0_stdout.gold
+++ b/tests/gold_tests/h2/gold/httpbin_0_stdout.gold
@@ -1,10 +1,5 @@
 {
-  "args": {}, ``
-  "headers": {
-    "Accept": "*/*", ``
-    "Host": ``
-    "User-Agent": "curl/``
-  }, ``
-  "origin": ``
+  ``
   "url": "http://``/get"
+  ``
 }

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -66,21 +66,23 @@ ts.Disk.records_config.update({
 
 })
 ts.Disk.logging_yaml.AddLines(
-    '''
+'''
 formats:
-  # Extended Log Format.
   - name: access
-    format: |-
-[%<cqtn>] %<cqtx> %<cqpv> %<cqssv> %<cqssc> %<crc> %<pssc> %<pscl>
+    format: '[%<cqtn>] %<cqtx> %<cqpv> %<cqssv> %<cqssc> %<crc> %<pssc> %<pscl>'
 
 logs:
   - filename: access
     format: access
-}
 '''.split("\n")
 )
 
 Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'access.log'), exists=True, content='gold/httpbin_access.gold')
+
+# TODO: when httpbin 0.8.0 or later is released, remove below json pretty print hack
+json_printer = '''
+python -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2, separators=(',', ': ')))"
+'''
 
 # ----
 # Test Cases
@@ -88,7 +90,7 @@ Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'access.log'), exists=True, con
 
 # Test Case 0: Basic request and resposne
 test_run = Test.AddTestRun()
-test_run.Processes.Default.Command = 'curl -vs -k --http2 https://127.0.0.1:{0}/get'.format(ts.Variables.ssl_port)
+test_run.Processes.Default.Command = 'curl -vs -k --http2 https://127.0.0.1:{0}/get | {1}'.format(ts.Variables.ssl_port, json_printer)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
 test_run.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))


### PR DESCRIPTION
This have some part of below commits.

1. Add 100-continue expectation support on H2 connection

(cherry picked from commit c0fe598af5ad41a73c44d8f10fc5bae6baa555f7)

2. Remove trailing white space from json formatter

(cherry picked from commit 9836b0bbb4c36e2c1c70a57a7cfe66276ac9c0ba)

3. Fix AuTest for HTTP/2 using httpbin

(cherry picked from commit 2e15c6541e973ad6e45e1daf92549f7b5c47eccb)