### PR TITLE
Adding logging fields for collapsed forwarding metrics

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -151,6 +151,9 @@ Cache Details
 .. _chm:
 .. _cwr:
 .. _cwtr:
+.. _crra:
+.. _cwra:
+.. _cccs:
 
 These log fields reveal details of the |TS| proxy interaction with its own
 cache while attempting to service incoming client requests.
@@ -173,6 +176,14 @@ cwr   Proxy Cache    Cache Write Result. Specifies the result of attempting to
                      (``WL_MISS``), write interrupted (``INTR``), error while
                      writing (``ERR``), or cache write successful (``FIN``).
 cwt   Proxy Cache    Cache Write Transform Result.
+crra  Proxy Cache    Cache read retry attempts to read the object from cache.
+cwra  Proxy Cache    Cache write retry attempts to write a fresh or updated
+                     object to cache.
+cccs  Proxy Cache    Cache collapsed connection success; true or false if the
+                     cache lookup failed, a write was attempt but failed due to
+                     being blocked on the write by another request. Will be true
+                     if the subsequent lookup succeeded after the write failure or
+                     false if the request had to go upstream.
 ===== ============== ==========================================================
 
 .. _admin-logging-fields-txn:

--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -179,11 +179,10 @@ cwt   Proxy Cache    Cache Write Transform Result.
 crra  Proxy Cache    Cache read retry attempts to read the object from cache.
 cwra  Proxy Cache    Cache write retry attempts to write a fresh or updated
                      object to cache.
-cccs  Proxy Cache    Cache collapsed connection success; true or false if the
-                     cache lookup failed, a write was attempt but failed due to
-                     being blocked on the write by another request. Will be true
-                     if the subsequent lookup succeeded after the write failure or
-                     false if the request had to go upstream.
+cccs  Proxy Cache    Cache collapsed connection success;
+                     -1: collapsing was attempted but failed, request went upstream
+                     0: collapsing was unnecessary
+                     1: attempted to collapse and got a cache hit on subsequent read attempts
 ===== ============== ==========================================================
 
 .. _admin-logging-fields-txn:

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -892,6 +892,21 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("ctid", field);
 
+  field = new LogField("cache_read_retry_attempts", "crra", LogField::dINT, &LogAccess::marshal_cache_read_retries,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("crra", field);
+
+  field = new LogField("cache_write_retry_attempts", "cwra", LogField::dINT, &LogAccess::marshal_cache_write_retries,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("cwra", field);
+
+  field = new LogField("cache_collapsed_connection_success", "cccs", LogField::dINT,
+                       &LogAccess::marshal_cache_collapsed_connection_success, &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("cccs", field);
+
   field = new LogField("client_transaction_priority_weight", "ctpw", LogField::sINT,
                        &LogAccess::marshal_client_http_transaction_priority_weight, &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -2640,8 +2640,7 @@ LogAccess::marshal_cache_read_retries(char *buf)
   if (buf) {
     int64_t id = 0;
     if (m_http_sm) {
-      HttpCacheSM csm = m_http_sm->get_cache_sm();
-      id              = csm.get_open_read_tries();
+      id = m_http_sm->get_cache_sm().get_open_read_tries();
     }
     marshal_int(buf, id);
   }
@@ -2657,8 +2656,7 @@ LogAccess::marshal_cache_write_retries(char *buf)
   if (buf) {
     int64_t id = 0;
     if (m_http_sm) {
-      HttpCacheSM csm = m_http_sm->get_cache_sm();
-      id              = csm.get_open_write_tries();
+      id = m_http_sm->get_cache_sm().get_open_write_tries();
     }
     marshal_int(buf, id);
   }
@@ -2671,9 +2669,8 @@ LogAccess::marshal_cache_collapsed_connection_success(char *buf)
   if (buf) {
     int64_t id = 0;
     if (m_http_sm) {
-      HttpCacheSM csm   = m_http_sm->get_cache_sm();
       SquidLogCode code = m_http_sm->t_state.squid_codes.log_code;
-      if ((csm.get_open_write_tries() == (m_http_sm->t_state.txn_conf->max_cache_open_write_retries + 1)) &&
+      if ((m_http_sm->get_cache_sm().get_open_write_tries() == (m_http_sm->t_state.txn_conf->max_cache_open_write_retries + 1)) &&
           ((code == SQUID_LOG_TCP_HIT) || (code == SQUID_LOG_TCP_MEM_HIT) || (code == SQUID_LOG_TCP_DISK_HIT))) {
         id = 1;
       }

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -2635,6 +2635,58 @@ LogAccess::marshal_client_http_transaction_priority_dependence(char *buf)
   -------------------------------------------------------------------------*/
 
 int
+LogAccess::marshal_cache_read_retries(char *buf)
+{
+  if (buf) {
+    int64_t id = 0;
+    if (m_http_sm) {
+      HttpCacheSM csm = m_http_sm->get_cache_sm();
+      id              = csm.get_open_read_tries();
+    }
+    marshal_int(buf, id);
+  }
+  return INK_MIN_ALIGN;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
+LogAccess::marshal_cache_write_retries(char *buf)
+{
+  if (buf) {
+    int64_t id = 0;
+    if (m_http_sm) {
+      HttpCacheSM csm = m_http_sm->get_cache_sm();
+      id              = csm.get_open_write_tries();
+    }
+    marshal_int(buf, id);
+  }
+  return INK_MIN_ALIGN;
+}
+
+int
+LogAccess::marshal_cache_collapsed_connection_success(char *buf)
+{
+  if (buf) {
+    int64_t id = 0;
+    if (m_http_sm) {
+      HttpCacheSM csm   = m_http_sm->get_cache_sm();
+      SquidLogCode code = m_http_sm->t_state.squid_codes.log_code;
+      if ((csm.get_open_write_tries() == (m_http_sm->t_state.txn_conf->max_cache_open_write_retries + 1)) &&
+          ((code == SQUID_LOG_TCP_HIT) || (code == SQUID_LOG_TCP_MEM_HIT) || (code == SQUID_LOG_TCP_DISK_HIT))) {
+        id = 1;
+      }
+    }
+
+    marshal_int(buf, id);
+  }
+  return INK_MIN_ALIGN;
+}
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
 LogAccess::marshal_http_header_field(LogField::Container container, char *field, char *buf)
 {
   char *str        = nullptr;

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -252,6 +252,9 @@ public:
   inkcoreapi int marshal_cache_lookup_url_canon(char *);                      // STR
   inkcoreapi int marshal_client_sni_server_name(char *);                      // STR
   inkcoreapi int marshal_version_build_number(char *);                        // STR
+  inkcoreapi int marshal_cache_read_retries(char *);                          // INT
+  inkcoreapi int marshal_cache_write_retries(char *);                         // INT
+  inkcoreapi int marshal_cache_collapsed_connection_success(char *);          // INT
 
   // named fields from within a http header
   //


### PR DESCRIPTION
This adds 3 new log fields for transaction output (since collapsed forwarding is transaction based)
* crra - The number of read retry attempts for this transaction. If no CF has been done (it has not attempted a write) then this is just the read lock contention.  If a write has been attempted then this value gets reset to 0 as it attempts more reads post-write-fail.
* cwra - The number of write retry attempts. This will be either the number based on write lock contention, or it can be the max-write-retries+1. If it is max+1 that means that we have hit the max attempts because the lock was being held by another writer and so this transaction fell back to read retries and attempted to be collapsed
* cccs - Collapsed connection success. 
-1: Collapsing attempted but failed, went upstream
0: collapsing unnecessary
1: collapsing attempted and subsequent read was a cache hit