### PR TITLE
Fix use-after free

### DIFF
--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -315,11 +315,11 @@ Http1ClientSession::state_wait_for_close(int event, void *data)
   case VC_EVENT_ACTIVE_TIMEOUT:
   case VC_EVENT_INACTIVITY_TIMEOUT:
     half_close = false;
-    this->do_io_close();
     if (client_vc != nullptr) {
       client_vc->do_io_close();
       client_vc = nullptr;
     }
+    this->do_io_close();
     break;
   case VC_EVENT_READ_READY:
     // Drain any data read
@@ -395,11 +395,11 @@ Http1ClientSession::state_keep_alive(int event, void *data)
     break;
 
   case VC_EVENT_EOS:
-    this->do_io_close();
     if (client_vc != nullptr) {
       client_vc->do_io_close();
       client_vc = nullptr;
     }
+    this->do_io_close();
     break;
 
   case VC_EVENT_READ_COMPLETE:

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -376,11 +376,11 @@ Http2ClientSession::main_event_handler(int event, void *edata)
   case VC_EVENT_ERROR:
   case VC_EVENT_EOS:
     this->set_dying_event(event);
-    this->do_io_close();
     if (client_vc != nullptr) {
       client_vc->do_io_close();
       client_vc = nullptr;
     }
+    this->do_io_close();
     retval = 0;
     break;
 


### PR DESCRIPTION
@bneradt found this use-after free when running prod sim.

The problem was introduced with https://github.com/apache/trafficserver/pull/6469

The do_io_close may close the session object.