### PR TITLE
WIP - MgmtConverter - extend load/store API to pass HttpSM.

### DIFF
--- a/mgmt/MgmtDefs.h
+++ b/mgmt/MgmtDefs.h
@@ -33,6 +33,7 @@
 #include "tscpp/util/MemSpan.h"
 #include "tscpp/util/TextView.h"
 
+class HttpSM;
 typedef int64_t MgmtIntCounter;
 typedef int64_t MgmtInt;
 typedef int8_t MgmtByte;
@@ -72,71 +73,77 @@ struct MgmtConverter {
    * This is passed a @c void* which is a pointer to the member in the configuration instance.
    * This function must return a @c MgmtInt converted from that value.
    */
-  MgmtInt (*load_int)(const void *) = nullptr;
+  MgmtInt (*load_int)(const HttpSM *, const void *) = nullptr;
 
   /** Store a @c MgmtInt into a native type.
    *
    * This function is passed a @c void* which is a pointer to the member in the configuration
    * instance and a @c MgmtInt. The member should be updated to correspond to the @c MgmtInt value.
    */
-  void (*store_int)(void *, MgmtInt) = nullptr;
+  void (*store_int)(const HttpSM *, void *, MgmtInt) = nullptr;
 
   /** Load a @c MgmtFloat from a native type.
    *
    * This is passed a @c void* which is a pointer to the member in the configuration instance.
    * This function must return a @c MgmtFloat converted from that value.
    */
-  MgmtFloat (*load_float)(const void *) = nullptr;
+  MgmtFloat (*load_float)(const HttpSM *, const void *) = nullptr;
 
   /** Store a @c MgmtFloat into a native type.
    *
    * This function is passed a @c void* which is a pointer to the member in the configuration
    * instance and a @c MgmtFloat. The member should be updated to correspond to the @c MgmtFloat value.
    */
-  void (*store_float)(void *, MgmtFloat) = nullptr;
+  void (*store_float)(const HttpSM *, void *, MgmtFloat) = nullptr;
 
   /** Load a native type into view.
    *
    * This is passed a @c void* which is a pointer to the member in the configuration instance.
    * This function must return a @c string_view which contains the text for the member.
    */
-  std::string_view (*load_string)(const void *) = nullptr;
+  std::string_view (*load_string)(const HttpSM *, const void *) = nullptr;
 
   /** Store a view in a native type.
    *
    * This is passed a @c void* which is a pointer to the member in the configuration instance.
    * This function must return a @c string_view which contains the text for the member.
    */
-  void (*store_string)(void *, std::string_view) = nullptr;
+  void (*store_string)(const HttpSM *, void *, std::string_view) = nullptr;
 
   // Convenience constructors because generally only one pair is valid.
-  MgmtConverter(MgmtInt (*load)(const void *), void (*store)(void *, MgmtInt));
-  MgmtConverter(MgmtFloat (*load)(const void *), void (*store)(void *, MgmtFloat));
-  MgmtConverter(std::string_view (*load)(const void *), void (*store)(void *, std::string_view));
+  MgmtConverter(MgmtInt (*load)(const HttpSM *, const void *), void (*store)(const HttpSM *, void *, MgmtInt));
+  MgmtConverter(MgmtFloat (*load)(const HttpSM *, const void *), void (*store)(const HttpSM *, void *, MgmtFloat));
+  MgmtConverter(std::string_view (*load)(const HttpSM *, const void *), void (*store)(const HttpSM *, void *, std::string_view));
 
-  MgmtConverter(MgmtInt (*_load_int)(const void *), void (*_store_int)(void *, MgmtInt), MgmtFloat (*_load_float)(const void *),
-                void (*_store_float)(void *, MgmtFloat), std::string_view (*_load_string)(const void *),
-                void (*_store_string)(void *, std::string_view));
+  MgmtConverter(MgmtInt (*_load_int)(const HttpSM *, const void *), void (*_store_int)(const HttpSM *, void *, MgmtInt),
+                MgmtFloat (*_load_float)(const HttpSM *, const void *), void (*_store_float)(const HttpSM *, void *, MgmtFloat),
+                std::string_view (*_load_string)(const HttpSM *, const void *),
+                void (*_store_string)(const HttpSM *, void *, std::string_view));
 };
 
-inline MgmtConverter::MgmtConverter(MgmtInt (*load)(const void *), void (*store)(void *, MgmtInt))
+inline MgmtConverter::MgmtConverter(MgmtInt (*load)(const HttpSM *, const void *), void (*store)(const HttpSM *, void *, MgmtInt))
   : load_int(load), store_int(store)
 {
 }
 
-inline MgmtConverter::MgmtConverter(MgmtFloat (*load)(const void *), void (*store)(void *, MgmtFloat))
+inline MgmtConverter::MgmtConverter(MgmtFloat (*load)(const HttpSM *, const void *),
+                                    void (*store)(const HttpSM *, void *, MgmtFloat))
   : load_float(load), store_float(store)
 {
 }
 
-inline MgmtConverter::MgmtConverter(std::string_view (*load)(const void *), void (*store)(void *, std::string_view))
+inline MgmtConverter::MgmtConverter(std::string_view (*load)(const HttpSM *, const void *),
+                                    void (*store)(const HttpSM *, void *, std::string_view))
   : load_string(load), store_string(store)
 {
 }
 
-inline MgmtConverter::MgmtConverter(MgmtInt (*_load_int)(const void *), void (*_store_int)(void *, MgmtInt),
-                                    MgmtFloat (*_load_float)(const void *), void (*_store_float)(void *, MgmtFloat),
-                                    std::string_view (*_load_string)(const void *), void (*_store_string)(void *, std::string_view))
+inline MgmtConverter::MgmtConverter(MgmtInt (*_load_int)(const HttpSM *, const void *),
+                                    void (*_store_int)(const HttpSM *, void *, MgmtInt),
+                                    MgmtFloat (*_load_float)(const HttpSM *, const void *),
+                                    void (*_store_float)(const HttpSM *, void *, MgmtFloat),
+                                    std::string_view (*_load_string)(const HttpSM *, const void *),
+                                    void (*_store_string)(const HttpSM *, void *, std::string_view))
   : load_int(_load_int),
     store_int(_store_int),
     load_float(_load_float),

--- a/proxy/http/HttpConnectionCount.cc
+++ b/proxy/http/HttpConnectionCount.cc
@@ -38,17 +38,27 @@ OutboundConnTrack::Imp OutboundConnTrack::_imp;
 OutboundConnTrack::GlobalConfig *OutboundConnTrack::_global_config{nullptr};
 
 const MgmtConverter OutboundConnTrack::MAX_CONV(
-  [](const void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::max) *>(data)); },
-  [](void *data, MgmtInt i) -> void { *static_cast<decltype(TxnConfig::max) *>(data) = static_cast<decltype(TxnConfig::max)>(i); });
+  [](const HttpSM *, const void *data) -> MgmtInt {
+    return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::max) *>(data));
+  },
+  [](const HttpSM *, void *data, MgmtInt i) -> void {
+    *static_cast<decltype(TxnConfig::max) *>(data) = static_cast<decltype(TxnConfig::max)>(i);
+  });
 
 const MgmtConverter OutboundConnTrack::MIN_CONV(
-  [](const void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::min) *>(data)); },
-  [](void *data, MgmtInt i) -> void { *static_cast<decltype(TxnConfig::min) *>(data) = static_cast<decltype(TxnConfig::min)>(i); });
+  [](const HttpSM *, const void *data) -> MgmtInt {
+    return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::min) *>(data));
+  },
+  [](const HttpSM *, void *data, MgmtInt i) -> void {
+    *static_cast<decltype(TxnConfig::min) *>(data) = static_cast<decltype(TxnConfig::min)>(i);
+  });
 
 // Do integer and string conversions.
 const MgmtConverter OutboundConnTrack::MATCH_CONV{
-  [](const void *data) -> MgmtInt { return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::match) *>(data)); },
-  [](void *data, MgmtInt i) -> void {
+  [](const HttpSM *, const void *data) -> MgmtInt {
+    return static_cast<MgmtInt>(*static_cast<const decltype(TxnConfig::match) *>(data));
+  },
+  [](const HttpSM *, void *data, MgmtInt i) -> void {
     // Problem - the InkAPITest requires being able to set an arbitrary value, so this can either
     // correctly clamp or pass the regression tests. Currently it passes the tests.
     //    *static_cast<decltype(TxnConfig::match) *>(data) = std::clamp(static_cast<decltype(TxnConfig::match)>(i), MATCH_IP,
@@ -57,11 +67,11 @@ const MgmtConverter OutboundConnTrack::MATCH_CONV{
   },
   nullptr,
   nullptr,
-  [](const void *data) -> std::string_view {
+  [](const HttpSM *, const void *data) -> std::string_view {
     auto t = *static_cast<const OutboundConnTrack::MatchType *>(data);
     return t < 0 || t > OutboundConnTrack::MATCH_BOTH ? "Invalid"sv : OutboundConnTrack::MATCH_TYPE_NAME[t];
   },
-  [](void *data, std::string_view src) -> void {
+  [](const HttpSM *, void *data, std::string_view src) -> void {
     OutboundConnTrack::MatchType t;
     if (OutboundConnTrack::lookup_match_type(src, t)) {
       *static_cast<OutboundConnTrack::MatchType *>(data) = t;


### PR DESCRIPTION
Include HTTP Txn pointer to converters API. We need to extend the converter API in case that a particular converter needs to use some data from the current transaction. 