### PR TITLE
Fix ink_endian.h to include an appropriate header file

### DIFF
--- a/include/tscore/ink_endian.h
+++ b/include/tscore/ink_endian.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "tscore/ink_config.h"
+
 #ifdef HAVE_SYS_ENDIAN_H
 #include <sys/endian.h>
 #endif


### PR DESCRIPTION
HAVE_XXX_H was not defined on this file because it did not include ink_config.h