### PR TITLE
Fix a bug that current_active_client_connections doesn't decrease

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1409,6 +1409,7 @@ Http2ConnectionState::release_stream()
         // or we can use a local variable to do it.
         // ua_session = nullptr;
       } else if (shutdown_state == HTTP2_SHUTDOWN_IN_PROGRESS && fini_event == nullptr) {
+        ua_session->clear_session_active();
         fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
       } else if (ua_session->is_active()) {
         // If the number of clients is 0, HTTP2_SESSION_EVENT_FINI is not received or sent, and ua_session is active,


### PR DESCRIPTION
`current_active_client_connections` was not decremented when a connection is closed with graceful shutdown (GOAWAY frame with stream ID 2^31-1).

This bug was perhaps introduced by #4936 since `clear_session_active` was originally always called regardless of graceful shutdown.

This fix would fix a part of #6671 but maybe not completely. There's no fix for *leak* on this PR.