### PR TITLE
Add HttpTransact::get_max_age and TSHttpTxnGetMaxAge

### DIFF
--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2453,6 +2453,18 @@ tsapi TSReturnCode TSHttpTxnMilestoneGet(TSHttpTxn txnp, TSMilestonesType milest
 tsapi int TSHttpTxnIsCacheable(TSHttpTxn txnp, TSMBuffer request, TSMBuffer response);
 
 /**
+  Get the maximum age in seconds as indicated by the origin server.
+  This would typically be used in TS_HTTP_READ_RESPONSE_HDR_HOOK, when you have
+  the server response ready.
+
+  @param txnp the transaction pointer
+  @param response the server response header. If NULL, use the transactions origin response.
+
+  @return the age in seconds if specified by Cache-Control, -1 otherwise
+*/
+tsapi int TSHttpTxnGetMaxAge(TSHttpTxn txnp, TSMBuffer response);
+
+/**
    Return a string representation for a TSServerState value. This is useful for plugin debugging.
 
    @param state the value of this TSServerState

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1037,6 +1037,7 @@ public:
 
   static void handle_request_keep_alive_headers(State *s, HTTPVersion ver, HTTPHdr *heads);
   static void handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTPHdr *heads);
+  static int get_max_age(HTTPHdr *response);
   static int calculate_document_freshness_limit(State *s, HTTPHdr *response, time_t response_date, bool *heuristic);
   static Freshness_t what_is_document_freshness(State *s, HTTPHdr *client_request, HTTPHdr *cached_obj_response);
   static Authentication_t AuthenticationNeeded(const OverridableHttpConfigParams *p, HTTPHdr *client_request,

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -8950,6 +8950,30 @@ TSHttpTxnIsCacheable(TSHttpTxn txnp, TSMBuffer request, TSMBuffer response)
   return (req->valid() && resp->valid() && HttpTransact::is_response_cacheable(&(sm->t_state), req, resp)) ? 1 : 0;
 }
 
+int
+TSHttpTxnGetMaxAge(TSHttpTxn txnp, TSMBuffer response)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  HttpSM *sm = (HttpSM *)txnp;
+  HTTPHdr *resp;
+
+  if (response) {
+    // Make sure the response we got as a parameter is valid
+    sdk_assert(sdk_sanity_check_mbuffer(response) == TS_SUCCESS);
+    resp = reinterpret_cast<HTTPHdr *>(response);
+  } else {
+    // Use the transactions origin response if the user passed NULL
+    resp = &(sm->t_state.hdr_info.server_response);
+  }
+
+  if (!resp || !resp->valid()) {
+    return -1;
+  }
+
+  // We have a valid response, return max_age
+  return HttpTransact::get_max_age(resp);
+}
+
 // Lookup various debug names for common HTTP types.
 const char *
 TSHttpServerStateNameLookup(TSServerState state)


### PR DESCRIPTION
Add a new function called HttpTransact::get_max_age based on the logic
in HttpTransact::calculate_document_freshness_limit that extracts
max_age depending on s-maxage and max-age. Expose the function as
TSHttpTxnGetMaxAge.