### PR TITLE
Script to find mutexes/futexes that are contending

### DIFF
--- a/tools/gdb_mutex_contention.pl
+++ b/tools/gdb_mutex_contention.pl
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script requires that you run futexes.stp system tap script first
+# https://sourceware.org/systemtap/examples/#process/futexes.stp
+
+use strict;
+use warnings;
+use Getopt::Std;
+
+sub usage() {
+  print "gdb_mutex_contention.pl -f futexes_output [-s symbols] [-m mutexes]\n";
+  print "Example:\n";
+  print "\tsudo timeout 30 ./futexes.stp > futexes.out\n";
+  print "\tsudo ./gdb_mutex_contention.pl -f futexes.out\n";
+
+  exit 1;
+}
+
+{
+  my %opts;
+  getopts('m:f:s:', \%opts);
+  usage() if (! defined$opts{f});
+
+  my $pid = 0;
+  my $file = $opts{f};
+  my $symbols = $opts{s} || 20;
+  my $mutexes = $opts{m} || 10;
+  my %locks;
+
+  # Read output from futexes.stp
+  open(INPUT, $file) || die $!;
+  while(<INPUT>) {
+    chomp;
+    if (m/(ET_NET|traffic_server).+\[(\d+)\] lock (\S+) contended (\d+) times, (\d+) avg us/) {
+      $pid = $2;
+      my $lock = $3;
+      my $frequency = $4;
+      my $wait = $5;
+      $locks{$lock}->{frequency} = $frequency;
+      $locks{$lock}->{line} = $_;
+      $locks{$lock}->{wait} = $wait * $frequency;
+    }
+  }
+
+  # Grab the binary from the running pid
+  my $binary = `ps --pid $pid -o command -h`;
+  chomp $binary;
+
+  # Print out what we are going to run gdb on
+  print "Running gdb over binary: $binary and pid: $pid\n";
+
+  # Loop over the futexes that had the highest total wait time
+  my $count = 0;
+  foreach my $lock (sort { $locks{$b}->{wait} <=> $locks{$a}->{wait} } keys %locks) {
+    print "lock: $locks{$lock}->{line} - total wait: $locks{$lock}->{wait}\n";
+
+    open(MACRO, "> gdb.auto.mutex.macro") || die $!;
+    print MACRO "handle SIGPIPE nostop\n";
+    print MACRO "handle SIGPIPE noprint\n\n";
+    print MACRO "rwatch *$lock\n\n";
+    print MACRO "cont\n";
+    print MACRO "bt 40\n";
+    close(MACRO);
+
+    system("gdb -x gdb.auto.mutex.macro --batch $binary $pid >& gdb.out");
+
+    open(GDB_OUT, "gdb.out") || die $!;
+    my $gdb_out_lines = 1;
+    while (<GDB_OUT>) {
+      chomp;
+      if (m|\#\d+ (.+)|) {
+        print "\t$_\n";
+        last if ++$gdb_out_lines > $symbols;
+      }
+
+    }
+    close(GDB_OUT);
+    last if ++$count > $mutexes;
+    print "\n";
+  }
+
+  unlink("gdb.auto.mutex.macro");
+  unlink("gdb.out");
+  close(INPUT);
+}


### PR DESCRIPTION
Sample truncated output:
```
12:39:45 bart:(futex_script)~/dev/apache/trafficserver/tools$ sudo ./gdb_mutex_contention.pl -f ~/futexes.out
Running gdb over binary: /usr/local/bin/traffic_server and pid: 274016
lock: [ET_NET 3][274016] lock 0xf4dbe0 contended 2390 times, 22365 avg us - total wait: 53452350
	#0  0x00007fadae90dea3 in __GI___pthread_mutex_lock (mutex=0xf4dbe0) at ../nptl/pthread_mutex_lock.c:80
	#1  0x00007fadaef14e77 in ink_mutex_acquire (m=0xf4dbe0) at ../../include/tscore/ink_mutex.h:48
	#2  0x00007fadaef14fdc in Diags::lock (this=0xf4db40) at ../../include/tscore/Diags.h:256
	#3  0x00007fadaef139d2 in Diags::print_va (this=0xf4db40, debug_tag=0x0, diags_level=DL_Error, loc=0x51a9390, format_string=0x9b8078 "HTTP/2 connection error code=0x%02x client_ip=%s session_id=%ld stream_id=%u %s", ap=0x51a91d8) at Diags.cc:250
	#4  0x00007fadaef141a7 in Diags::error_va (this=0xf4db40, level=DL_Error, loc=0x51a9390, format_string=0x9b8078 "HTTP/2 connection error code=0x%02x client_ip=%s session_id=%ld stream_id=%u %s", ap=0x51a91d8) at Diags.cc:469
	#5  0x00000000006682eb in Diags::error (this=0xf4db40, level=DL_Error, loc=0x51a9390, fmt=0x9b8078 "HTTP/2 connection error code=0x%02x client_ip=%s session_id=%ld stream_id=%u %s") at ../include/tscore/Diags.h:207
	#6  0x00000000007bdb48 in Http2ConnectionState::main_event_handler (this=0x7fad540ed0e8, event=2253, edata=0x51a9680) at Http2ConnectionState.cc:1070
	#7  0x000000000066c7ef in Continuation::handleEvent (this=0x7fad540ed0e8, event=2253, data=0x51a9680) at /home/bcall/dev/apache/trafficserver/iocore/eventsystem/I_Continuation.h:190
	#8  0x00000000007b043e in send_connection_event (cont=0x7fad540ed0e8, event=2253, edata=0x51a9680) at Http2ClientSession.cc:65
	#9  0x00000000007b3925 in Http2ClientSession::do_complete_frame_read (this=0x7fad540ecde0) at Http2ClientSession.cc:577
	#10 0x00000000007b3ef0 in Http2ClientSession::state_process_frame_read
...
```
