### PR TITLE
Fix HPACK Dynamic Table Cleanup

### DIFF
--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -327,10 +327,10 @@ HpackIndexingTable::size() const
   return _dynamic_table->size();
 }
 
-bool
+void
 HpackIndexingTable::update_maximum_size(uint32_t new_size)
 {
-  return _dynamic_table->update_maximum_size(new_size);
+  _dynamic_table->update_maximum_size(new_size);
 }
 
 //
@@ -403,11 +403,11 @@ HpackDynamicTable::size() const
 // are evicted from the end of the header table until the size of the
 // header table is less than or equal to the maximum size.
 //
-bool
+void
 HpackDynamicTable::update_maximum_size(uint32_t new_size)
 {
   this->_maximum_size = new_size;
-  return this->_evict_overflowed_entries();
+  this->_evict_overflowed_entries();
 }
 
 uint32_t
@@ -416,12 +416,12 @@ HpackDynamicTable::length() const
   return this->_headers.size();
 }
 
-bool
+void
 HpackDynamicTable::_evict_overflowed_entries()
 {
   if (this->_current_size <= this->_maximum_size) {
     // Do nothing
-    return true;
+    return;
   }
 
   for (auto h = this->_headers.rbegin(); h != this->_headers.rend(); ++h) {
@@ -438,13 +438,7 @@ HpackDynamicTable::_evict_overflowed_entries()
     }
   }
 
-  if (this->_headers.size() == 0) {
-    return false;
-  }
-
   this->_mime_hdr_gc();
-
-  return true;
 }
 
 /**
@@ -772,9 +766,7 @@ update_dynamic_table_size(const uint8_t *buf_start, const uint8_t *buf_end, Hpac
     return HPACK_ERROR_COMPRESSION_ERROR;
   }
 
-  if (indexing_table.update_maximum_size(size) == false) {
-    return HPACK_ERROR_COMPRESSION_ERROR;
-  }
+  indexing_table.update_maximum_size(size);
 
   return len;
 }

--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -123,12 +123,12 @@ public:
 
   uint32_t maximum_size() const;
   uint32_t size() const;
-  bool update_maximum_size(uint32_t new_size);
+  void update_maximum_size(uint32_t new_size);
 
   uint32_t length() const;
 
 private:
-  bool _evict_overflowed_entries();
+  void _evict_overflowed_entries();
   void _mime_hdr_gc();
 
   uint32_t _current_size = 0;
@@ -157,7 +157,7 @@ public:
   void add_header_field(const MIMEField *field);
   uint32_t maximum_size() const;
   uint32_t size() const;
-  bool update_maximum_size(uint32_t new_size);
+  void update_maximum_size(uint32_t new_size);
 
 private:
   HpackDynamicTable *_dynamic_table;


### PR DESCRIPTION
Fix #6748. This is introduced by TS-3719, it was trying to fix a bug.

> The table size is reduced by the by max size - new size instead of current size - new size. This causes the table to try to delete items that don't exist.

We don't need to worry about this with the current code, because we're using a for loop now.

https://github.com/apache/trafficserver/blob/4638ddcc2848da53b94f8678d22057d8efda8df3/proxy/http2/HPACK.cc#L427
