### PR TITLE
Promote netvc to ProxySession

### DIFF
--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -63,33 +63,21 @@ public:
   void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true) override;
 
   // Implement VConnection interface.
-  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
-  VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
-                   bool owner = false) override;
-
   void do_io_close(int lerrno = -1) override;
-  void do_io_shutdown(ShutdownHowTo_t howto) override;
-  void reenable(VIO *vio) override;
 
   // Accessor Methods
   bool allow_half_open() const;
   void set_half_close_flag(bool flag) override;
   bool get_half_close_flag() const override;
   bool is_chunked_encoding_supported() const override;
-  NetVConnection *get_netvc() const override;
   int get_transact_count() const override;
   virtual bool is_outbound_transparent() const;
 
   Http1ServerSession *get_server_session() const override;
-  void set_active_timeout(ink_hrtime timeout_in) override;
-  void set_inactivity_timeout(ink_hrtime timeout_in) override;
-  void cancel_inactivity_timeout() override;
   const char *get_protocol_string() const override;
 
   void increment_current_active_client_connections_stat() override;
   void decrement_current_active_client_connections_stat() override;
-
-  bool support_sni() const override;
 
 private:
   Http1ClientSession(Http1ClientSession &);

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -90,11 +90,7 @@ public:
   // Methods
 
   // Implement VConnection interface
-  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
-  VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
   void do_io_close(int lerrno = -1) override;
-  void do_io_shutdown(ShutdownHowTo_t howto) override;
-  void reenable(VIO *vio) override;
 
   // Implement ProxySession interface
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override;
@@ -109,7 +105,6 @@ public:
 
   ////////////////////
   // Accessors
-  NetVConnection *get_netvc() const override;
   sockaddr const *get_client_addr() override;
   sockaddr const *get_local_addr() override;
   int get_transact_count() const override;
@@ -144,8 +139,6 @@ public:
   // Variables
   Http2ConnectionState connection_state;
 
-  bool support_sni() const override;
-
 private:
   int main_event_handler(int, void *);
 
@@ -163,7 +156,6 @@ private:
 
   int64_t total_write_len        = 0;
   SessionHandler session_handler = nullptr;
-  NetVConnection *client_vc      = nullptr;
   MIOBuffer *read_buffer         = nullptr;
   IOBufferReader *_reader        = nullptr;
   MIOBuffer *write_buffer        = nullptr;

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -118,22 +118,10 @@ HQSession::release(ProxyTransaction *trans)
   return;
 }
 
-NetVConnection *
-HQSession::get_netvc() const
-{
-  return this->_client_vc;
-}
-
 int
 HQSession::get_transact_count() const
 {
   return 0;
-}
-
-bool
-HQSession::support_sni() const
-{
-  return this->_client_vc ? this->_client_vc->support_sni() : false;
 }
 
 //
@@ -149,7 +137,7 @@ Http3Session::Http3Session(NetVConnection *vc) : HQSession(vc)
 
 Http3Session::~Http3Session()
 {
-  this->_client_vc = nullptr;
+  this->_vc = nullptr;
   delete this->_local_qpack;
   delete this->_remote_qpack;
 }
@@ -202,7 +190,7 @@ Http3Session::remote_qpack()
 //
 Http09Session::~Http09Session()
 {
-  this->_client_vc = nullptr;
+  this->_vc = nullptr;
 }
 
 const char *

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -32,7 +32,7 @@ class HQSession : public ProxySession
 public:
   using super = ProxySession; ///< Parent type
 
-  HQSession(NetVConnection *vc) : _client_vc(vc){};
+  HQSession(NetVConnection *vc) : ProxySession(vc){};
   virtual ~HQSession();
 
   // Implement VConnection interface
@@ -47,16 +47,11 @@ public:
   void start() override;
   void destroy() override;
   void release(ProxyTransaction *trans) override;
-  NetVConnection *get_netvc() const override;
   int get_transact_count() const override;
-  bool support_sni() const override;
 
   // HQSession
   void add_transaction(HQTransaction *);
   HQTransaction *get_transaction(QUICStreamId);
-
-protected:
-  NetVConnection *_client_vc = nullptr;
 
 private:
   // this should be unordered map?


### PR DESCRIPTION
A refactoring to prepare for more protocols to protocol.  All of the client side Session classes have their own client_vc NetVConnection entry.  The server side will also have a netvc.  Moving the NetVConnection entry and related pass through methods to the ProxySession super class seems like a good preparation.  

This probably won't pass autest until PR #6758 is committed.  Found that flaw while testing this branch.