### PR TITLE
Do not fail multicert load if line does not create entry

### DIFF
--- a/iocore/net/QUICMultiCertConfigLoader.cc
+++ b/iocore/net/QUICMultiCertConfigLoader.cc
@@ -190,8 +190,13 @@ QUICMultiCertConfigLoader::_store_ssl_ctx(SSLCertLookup *lookup, const shared_SS
   shared_ssl_ticket_key_block keyblock = nullptr;
 
   if (!ctx || !multi_cert_params || !this->_store_single_ssl_ctx(lookup, multi_cert_params, ctx, common_names)) {
-    lookup->is_valid = false;
-    retval           = false;
+    retval = false;
+    std::string names;
+    for (auto name : data.cert_names_list) {
+      names.append(name);
+      names.append(" ");
+    }
+    Warning("QUIC: Failed to insert SSL_CTX for certificate %s entries for names already made", names.c_str());
   }
 
   for (auto iter = unique_names.begin(); retval && iter != unique_names.end(); ++iter) {
@@ -205,8 +210,7 @@ QUICMultiCertConfigLoader::_store_ssl_ctx(SSLCertLookup *lookup, const shared_SS
 
     shared_SSL_CTX unique_ctx(this->init_server_ssl_ctx(single_data, multi_cert_params.get(), iter->second), SSL_CTX_free);
     if (!unique_ctx || !this->_store_single_ssl_ctx(lookup, multi_cert_params, unique_ctx, iter->second)) {
-      lookup->is_valid = false;
-      retval           = false;
+      retval = false;
     }
   }
 

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1420,8 +1420,13 @@ SSLMultiCertConfigLoader::_store_ssl_ctx(SSLCertLookup *lookup, const shared_SSL
   shared_SSL_CTX ctx(this->init_server_ssl_ctx(data, sslMultCertSettings.get(), common_names), SSL_CTX_free);
 
   if (!ctx || !sslMultCertSettings || !this->_store_single_ssl_ctx(lookup, sslMultCertSettings, ctx, common_names)) {
-    lookup->is_valid = false;
-    retval           = false;
+    retval = false;
+    std::string names;
+    for (auto name : data.cert_names_list) {
+      names.append(name);
+      names.append(" ");
+    }
+    Warning("Failed to insert SSL_CTX for certificate %s entries for names already made", names.c_str());
   }
 
   for (auto iter = unique_names.begin(); retval && iter != unique_names.end(); ++iter) {
@@ -1435,8 +1440,7 @@ SSLMultiCertConfigLoader::_store_ssl_ctx(SSLCertLookup *lookup, const shared_SSL
 
     shared_SSL_CTX unique_ctx(this->init_server_ssl_ctx(single_data, sslMultCertSettings.get(), iter->second), SSL_CTX_free);
     if (!unique_ctx || !this->_store_single_ssl_ctx(lookup, sslMultCertSettings, unique_ctx, iter->second)) {
-      lookup->is_valid = false;
-      retval           = false;
+      retval = false;
     }
   }
 


### PR DESCRIPTION
Another issue introduced in the refactor of f729c9dc41ff1635132f4bdc6331ce826f3bc2fe.

@djcarlin found this while deploying our version of ATS9 which includes the refactoring commit. Do to cert restructuring, certA.pem included all the names that were in certB.pem.  So when 
Due to new certs. all the names in transparency.oath.com*.pem are also in careers.oath.com*.pem which is processed first.

This means that _store_single_ssl_ctx will fail since no new entries were created in the lookup structure. The changes in the refactor were marking the lookup structure as invalid which will cause the ssl_multicert load to fail.

But this is an innocuous failure, since processing succeeded, but names in the certs had already been represented, so we should not fail the multicert load.