### PR TITLE
Disable remap-stats test until we can reliably wait for metrics

### DIFF
--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
@@ -19,6 +19,7 @@ Test remap_stats plugin
 '''
 # Skip if plugins not present.
 Test.SkipUnless(Condition.PluginExists('remap_stats.so'))
+Test.SkipIf(Condition.true("Test cannot deterministically wait until the stats appear"))
 
 server = Test.MakeOriginServer("server")
 


### PR DESCRIPTION
We should disable the remap-stats test until we have a means to deterministically wait until the metrics are available.

I tried adding a test that delayed until some metrics appeared.  This worked much of the time, but sometimes that returned all 0's.  The metrics had been created but the values had not been updated.

The current version just waits 15 seconds.  That is not always long enough on the CI machines.