### PR TITLE
Make chunked_encoding test more reliable by killing nc process

### DIFF
--- a/tests/gold_tests/chunked_encoding/case4.sh
+++ b/tests/gold_tests/chunked_encoding/case4.sh
@@ -17,3 +17,4 @@
 nc -l 8888 -o outserver4 -c "sh ./server4.sh" &
 sleep 1
 ./smuggle-client 127.0.0.1 ${1}
+kill %1


### PR DESCRIPTION
chunked_encoding test has been intermittently failing on CI.  In the failure case I saw today, the output file from the last test running nc is empty.  This PR adds a line to kill the background nc process which will hopefully flush the output to disk before the case4.sh script returns.