### PR TITLE
Weird characters in debug message

### DIFF
--- a/proxy/http/remap/PluginDso.cc
+++ b/proxy/http/remap/PluginDso.cc
@@ -87,7 +87,7 @@ PluginDso::load(std::string &error)
       std::error_code ec;
       fs::file_status fs = fs::status(_effectivePath, ec);
       _mtime             = fs::modification_time(fs);
-      PluginDebug(_tag, "plugin '%s' mоdification time %ld", _configPath.c_str(), _mtime);
+      PluginDebug(_tag, "plugin '%s' modification time %ld", _configPath.c_str(), _mtime);
 
       /* Now attemt to load the plugin DSO */
       if ((_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW | RTLD_LOCAL)) == nullptr) {


### PR DESCRIPTION
old text:
11:40:15 bart:(master)~/dev/apache/trafficserver$ echo mоdification | hexdump -C
00000000  6d d0 be 64 69 66 69 63  61 74 69 6f 6e 0a        |m..dification.|
0000000e

new text:
11:40:09 bart:(master)~/dev/apache/trafficserver$ echo modification | hexdump -C
00000000  6d 6f 64 69 66 69 63 61  74 69 6f 6e 0a           |modification.|
0000000d