### PR TITLE
Updates clang-format to LLVM v10.0.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortLambdasOnASingleLine: All
@@ -56,6 +56,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
@@ -71,12 +72,17 @@ IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
+    SortPriority:    0
   - Regex:           '^(<|"(gtest|isl|json)/)'
     Priority:        3
+    SortPriority:    0
   - Regex:           '.*'
     Priority:        1
+    SortPriority:    0
 IncludeIsMainRegex: '$'
+IncludeIsMainSourceRegex: ''
 IndentCaseLabels: false
+IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
@@ -112,18 +118,22 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
+SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
+UseCRLF:         false
 UseTab:          Never
 ...
 

--- a/include/tscore/ArgParser.h
+++ b/include/tscore/ArgParser.h
@@ -48,7 +48,11 @@ public:
   // bool to check if certain command/option is called
   operator bool() const noexcept { return _is_called; }
   // index accessing []
-  std::string const &operator[](int x) const { return _values.at(x); }
+  std::string const &
+  operator[](int x) const
+  {
+    return _values.at(x);
+  }
   // return the Environment variable
   std::string const &env() const noexcept;
   // iterator for arguments

--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -84,7 +84,11 @@ union CryptoHash {
   }
 
   /// Access 64 bit slice.
-  uint64_t operator[](int i) const { return u64[i]; }
+  uint64_t
+  operator[](int i) const
+  {
+    return u64[i];
+  }
   /// Access 64 bit slice.
   /// @note Identical to @ operator[] but included for symmetry.
   uint64_t

--- a/include/tscore/History.h
+++ b/include/tscore/History.h
@@ -67,7 +67,11 @@ public:
     return history_pos > Count ? Count : history_pos;
   }
 
-  const HistoryEntry &operator[](unsigned int i) const { return history[i]; }
+  const HistoryEntry &
+  operator[](unsigned int i) const
+  {
+    return history[i];
+  }
 
 private:
   HistoryEntry history[Count];

--- a/include/tscore/IntrusivePtr.h
+++ b/include/tscore/IntrusivePtr.h
@@ -472,13 +472,17 @@ IntrusivePtr<T>::operator=(IntrusivePtr<U> &&that)
   return *this;
 }
 
-template <typename T> T *IntrusivePtr<T>::operator->() const
+template <typename T>
+T *
+IntrusivePtr<T>::operator->() const
 {
   IntrusivePtrPolicy<T>::dereferenceCheck(m_obj);
   return m_obj;
 }
 
-template <typename T> T &IntrusivePtr<T>::operator*() const
+template <typename T>
+T &
+IntrusivePtr<T>::operator*() const
 {
   IntrusivePtrPolicy<T>::dereferenceCheck(m_obj);
   return *m_obj;

--- a/include/tscore/IpMap.h
+++ b/include/tscore/IpMap.h
@@ -482,12 +482,14 @@ IpMap::iterator::operator==(iterator const &that) const
   return _tree == that._tree && _node == that._node;
 }
 
-inline IpMap::iterator::reference IpMap::iterator::operator*() const
+inline IpMap::iterator::reference
+IpMap::iterator::operator*() const
 {
   return *_node;
 }
 
-inline IpMap::iterator::pointer IpMap::iterator::operator->() const
+inline IpMap::iterator::pointer
+IpMap::iterator::operator->() const
 {
   return _node;
 }

--- a/include/tscore/Ptr.h
+++ b/include/tscore/Ptr.h
@@ -105,8 +105,16 @@ public:
   Ptr<T> &operator=(const Ptr<T> &);
   Ptr<T> &operator=(T *);
 
-  T *operator->() const { return (m_ptr); }
-  T &operator*() const { return (*m_ptr); }
+  T *
+  operator->() const
+  {
+    return (m_ptr);
+  }
+  T &
+  operator*() const
+  {
+    return (*m_ptr);
+  }
 
   // Making this explicit avoids unwanted conversions.  See https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Safe_bool .
   explicit operator bool() const { return m_ptr != nullptr; }

--- a/include/tscore/Scalar.h
+++ b/include/tscore/Scalar.h
@@ -826,27 +826,39 @@ Scalar<N, C, T>::operator*=(C n) -> self &
   return *this;
 }
 
-template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(Scalar<N, C, T> const &lhs, C n)
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator*(Scalar<N, C, T> const &lhs, C n)
 {
   return Scalar<N, C, T>(lhs) *= n;
 }
-template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(C n, Scalar<N, C, T> const &rhs)
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator*(C n, Scalar<N, C, T> const &rhs)
 {
   return Scalar<N, C, T>(rhs) *= n;
 }
-template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(Scalar<N, C, T> const &lhs, int n)
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator*(Scalar<N, C, T> const &lhs, int n)
 {
   return Scalar<N, C, T>(lhs) *= n;
 }
-template <intmax_t N, typename C, typename T> Scalar<N, C, T> operator*(int n, Scalar<N, C, T> const &rhs)
+template <intmax_t N, typename C, typename T>
+Scalar<N, C, T>
+operator*(int n, Scalar<N, C, T> const &rhs)
 {
   return Scalar<N, C, T>(rhs) *= n;
 }
-template <intmax_t N> Scalar<N, int> operator*(Scalar<N, int> const &lhs, int n)
+template <intmax_t N>
+Scalar<N, int>
+operator*(Scalar<N, int> const &lhs, int n)
 {
   return Scalar<N, int>(lhs) *= n;
 }
-template <intmax_t N> Scalar<N, int> operator*(int n, Scalar<N, int> const &rhs)
+template <intmax_t N>
+Scalar<N, int>
+operator*(int n, Scalar<N, int> const &rhs)
 {
   return Scalar<N, int>(rhs) *= n;
 }

--- a/include/tscore/TsBuffer.h
+++ b/include/tscore/TsBuffer.h
@@ -323,7 +323,8 @@ Buffer::operator==(ConstBuffer const &that) const
 {
   return _size == that._size && _ptr == that._ptr;
 }
-inline bool Buffer::operator!() const
+inline bool
+Buffer::operator!() const
 {
   return !(_ptr && _size);
 }
@@ -331,7 +332,8 @@ inline Buffer::operator pseudo_bool() const
 {
   return _ptr && _size ? &self::operator! : nullptr;
 }
-inline char Buffer::operator*() const
+inline char
+Buffer::operator*() const
 {
   return *_ptr;
 }
@@ -407,7 +409,8 @@ ConstBuffer::operator==(Buffer const &that) const
 {
   return _size == that._size && 0 == memcmp(_ptr, that._ptr, _size);
 }
-inline bool ConstBuffer::operator!() const
+inline bool
+ConstBuffer::operator!() const
 {
   return !(_ptr && _size);
 }
@@ -415,7 +418,8 @@ inline ConstBuffer::operator pseudo_bool() const
 {
   return _ptr && _size ? &self::operator! : nullptr;
 }
-inline char ConstBuffer::operator*() const
+inline char
+ConstBuffer::operator*() const
 {
   return *_ptr;
 }
@@ -438,7 +442,8 @@ ConstBuffer::data() const
 {
   return _ptr;
 }
-inline char ConstBuffer::operator[](int n) const
+inline char
+ConstBuffer::operator[](int n) const
 {
   return _ptr[n];
 }

--- a/include/tscore/ink_memory.h
+++ b/include/tscore/ink_memory.h
@@ -591,7 +591,11 @@ public:
     return *this;
   }
 
-  T *operator->() const { return *this; }
+  T *
+  operator->() const
+  {
+    return *this;
+  }
 };
 
 /** Combine two strings as file paths.

--- a/include/tscpp/util/IntrusiveDList.h
+++ b/include/tscpp/util/IntrusiveDList.h
@@ -493,12 +493,16 @@ ts::IntrusiveDList<L>::iterator::operator--(int) -> self_type
   return tmp;
 }
 
-template <typename L> auto ts::IntrusiveDList<L>::const_iterator::operator-> () const -> value_type *
+template <typename L>
+auto
+ts::IntrusiveDList<L>::const_iterator::operator->() const -> value_type *
 {
   return _v;
 }
 
-template <typename L> auto ts::IntrusiveDList<L>::iterator::operator-> () const -> value_type *
+template <typename L>
+auto
+ts::IntrusiveDList<L>::iterator::operator->() const -> value_type *
 {
   return super_type::_v;
 }
@@ -508,12 +512,16 @@ template <typename L> ts::IntrusiveDList<L>::const_iterator::operator value_type
   return _v;
 }
 
-template <typename L> auto ts::IntrusiveDList<L>::const_iterator::operator*() const -> value_type &
+template <typename L>
+auto
+ts::IntrusiveDList<L>::const_iterator::operator*() const -> value_type &
 {
   return *_v;
 }
 
-template <typename L> auto ts::IntrusiveDList<L>::iterator::operator*() const -> value_type &
+template <typename L>
+auto
+ts::IntrusiveDList<L>::iterator::operator*() const -> value_type &
 {
   return *super_type::_v;
 }

--- a/include/tscpp/util/MemSpan.h
+++ b/include/tscpp/util/MemSpan.h
@@ -603,7 +603,9 @@ MemSpan<T>::operator!=(self_type const &that) const
   return !(*this == that);
 }
 
-template <typename T> bool MemSpan<T>::operator!() const
+template <typename T>
+bool
+MemSpan<T>::operator!() const
 {
   return _count == 0;
 }
@@ -641,7 +643,9 @@ MemSpan<T>::end() const
   return _ptr + _count;
 }
 
-template <typename T> T &MemSpan<T>::operator[](size_t idx) const
+template <typename T>
+T &
+MemSpan<T>::operator[](size_t idx) const
 {
   return _ptr[idx];
 }
@@ -769,7 +773,8 @@ MemSpan<void>::operator!=(self_type const &that) const
   return !(*this == that);
 }
 
-inline bool MemSpan<void>::operator!() const
+inline bool
+MemSpan<void>::operator!() const
 {
   return _size == 0;
 }

--- a/include/tscpp/util/TextView.h
+++ b/include/tscpp/util/TextView.h
@@ -624,12 +624,14 @@ TextView::clear()
   return *this;
 }
 
-inline char TextView::operator*() const
+inline char
+TextView::operator*() const
 {
   return this->empty() ? 0 : *(this->data());
 }
 
-inline bool TextView::operator!() const
+inline bool
+TextView::operator!() const
 {
   return this->empty();
 }

--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -875,7 +875,7 @@ create_config(RegressionTest *t, int num)
     }
 
     // make sure we have at least 1280 M bytes
-    if (total_space<(10 << 27)>> STORE_BLOCK_SHIFT) {
+    if (total_space < ((10 << 27) >> STORE_BLOCK_SHIFT)) {
       rprintf(t, "Not enough space for 10 volume\n");
       return 0;
     }

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -62,7 +62,11 @@ struct span_diskid_t {
     return id[0] == rhs.id[0] && id[1] == rhs.id[1];
   }
 
-  int64_t &operator[](unsigned i) { return id[i]; }
+  int64_t &
+  operator[](unsigned i)
+  {
+    return id[i];
+  }
 };
 
 //

--- a/iocore/cache/P_CacheArray.h
+++ b/iocore/cache/P_CacheArray.h
@@ -81,12 +81,16 @@ template <class T> TS_INLINE CacheArray<T>::operator const T *() const
   return data;
 }
 
-template <class T> TS_INLINE CacheArray<T>::operator T *()
+template <class T>
+TS_INLINE
+CacheArray<T>::operator T *()
 {
   return data;
 }
 
-template <class T> TS_INLINE T &CacheArray<T>::operator[](int idx)
+template <class T>
+TS_INLINE T &
+CacheArray<T>::operator[](int idx)
 {
   return data[idx];
 }

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -1469,12 +1469,14 @@ IOBufferChain::const_iterator::operator!=(self_type const &that) const
   return _b != that._b;
 }
 
-inline IOBufferChain::const_iterator::value_type &IOBufferChain::const_iterator::operator*() const
+inline IOBufferChain::const_iterator::value_type &
+IOBufferChain::const_iterator::operator*() const
 {
   return *_b;
 }
 
-inline IOBufferChain::const_iterator::value_type *IOBufferChain::const_iterator::operator->() const
+inline IOBufferChain::const_iterator::value_type *
+IOBufferChain::const_iterator::operator->() const
 {
   return _b;
 }
@@ -1494,12 +1496,14 @@ IOBufferChain::const_iterator::operator++(int)
   return pre;
 }
 
-inline IOBufferChain::iterator::value_type &IOBufferChain::iterator::operator*() const
+inline IOBufferChain::iterator::value_type &
+IOBufferChain::iterator::operator*() const
 {
   return *_b;
 }
 
-inline IOBufferChain::iterator::value_type *IOBufferChain::iterator::operator->() const
+inline IOBufferChain::iterator::value_type *
+IOBufferChain::iterator::operator->() const
 {
   return _b;
 }

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -577,7 +577,8 @@ IOBufferReader::consume(int64_t n)
   }
 }
 
-TS_INLINE char &IOBufferReader::operator[](int64_t i)
+TS_INLINE char &
+IOBufferReader::operator[](int64_t i)
 {
   static char default_ret = '\0'; // This is just to avoid compiler warnings...
   IOBufferBlock *b        = block.get();

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -285,7 +285,11 @@ public:
         Making it a method means the knowledge of which member is the first one
         is localized to this struct, not scattered about.
      */
-    uint32_t &operator[](int n) { return *(&max_connections_in + n); }
+    uint32_t &
+    operator[](int n)
+    {
+      return *(&max_connections_in + n);
+    }
   };
   /** Static global config, set and updated per process.
 

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -210,8 +210,16 @@ public:
     public:
       const_iterator(uint8_t index, const std::vector<QUICAckFrame::AckBlock> *ack_blocks);
 
-      const QUICAckFrame::AckBlock &operator*() const { return this->_current_block; };
-      const QUICAckFrame::AckBlock *operator->() const { return &this->_current_block; };
+      const QUICAckFrame::AckBlock &
+      operator*() const
+      {
+        return this->_current_block;
+      };
+      const QUICAckFrame::AckBlock *
+      operator->() const
+      {
+        return &this->_current_block;
+      };
       const QUICAckFrame::AckBlock &operator++();
       const bool operator!=(const const_iterator &ite) const;
       const bool operator==(const const_iterator &ite) const;

--- a/mgmt/ProxyConfig.h
+++ b/mgmt/ProxyConfig.h
@@ -68,7 +68,11 @@ public:
     ~scoped_config() { ClassType::release(ptr); }
     operator bool() const { return ptr != nullptr; }
     operator const ConfigType *() const { return ptr; }
-    const ConfigType *operator->() const { return ptr; }
+    const ConfigType *
+    operator->() const
+    {
+      return ptr;
+    }
 
   private:
     ConfigType *ptr;

--- a/mgmt/utils/ExpandingArray.cc
+++ b/mgmt/utils/ExpandingArray.cc
@@ -48,7 +48,8 @@ ExpandingArray::~ExpandingArray()
   ats_free(internalArray);
 }
 
-void *ExpandingArray::operator[](int index)
+void *
+ExpandingArray::operator[](int index)
 {
   if (index < numValidValues) {
     return internalArray[index];

--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -352,7 +352,9 @@ struct QueryMap {
 
   QueryMap(std::string &&s) : content_(s) { parse(); }
 
-  template <typename T> const Vector &operator[](T &&k) const
+  template <typename T>
+  const Vector &
+  operator[](T &&k) const
   {
     const auto iterator = map_.find(k);
     if (iterator != map_.end()) {

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -224,7 +224,9 @@ FeatureAPIHooks<ID, N>::get(ID id) const
   return likely(is_valid(id)) ? m_hooks[id].head() : nullptr;
 }
 
-template <typename ID, int N> APIHooks const *FeatureAPIHooks<ID, N>::operator[](ID id) const
+template <typename ID, int N>
+APIHooks const *
+FeatureAPIHooks<ID, N>::operator[](ID id) const
 {
   return likely(is_valid(id)) ? &(m_hooks[id]) : nullptr;
 }

--- a/proxy/Milestones.h
+++ b/proxy/Milestones.h
@@ -33,8 +33,16 @@
 template <class T, size_t entries> class Milestones
 {
 public:
-  ink_hrtime &operator[](T ms) { return this->_milestones[static_cast<size_t>(ms)]; }
-  ink_hrtime operator[](T ms) const { return this->_milestones[static_cast<size_t>(ms)]; }
+  ink_hrtime &
+  operator[](T ms)
+  {
+    return this->_milestones[static_cast<size_t>(ms)];
+  }
+  ink_hrtime
+  operator[](T ms) const
+  {
+    return this->_milestones[static_cast<size_t>(ms)];
+  }
 
   /**
    * Mark given milestone with timestamp if it's not marked yet

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -133,7 +133,8 @@ public:
   LogBuffer(LogObject *owner, LogBufferHeader *header);
   ~LogBuffer();
 
-  char &operator[](int idx)
+  char &
+  operator[](int idx)
   {
     ink_assert(idx >= 0);
     ink_assert((size_t)idx < m_size);

--- a/src/tscore/HostLookup.cc
+++ b/src/tscore/HostLookup.cc
@@ -388,13 +388,15 @@ CharIndex::end() -> iterator
   return {};
 }
 
-auto CharIndex::iterator::operator-> () -> value_type *
+auto
+CharIndex::iterator::operator->() -> value_type *
 {
   ink_assert(state.block != nullptr); // clang!
   return state.block->array[state.index].branch;
 }
 
-auto CharIndex::iterator::operator*() -> value_type &
+auto
+CharIndex::iterator::operator*() -> value_type &
 {
   ink_assert(state.block != nullptr); // clang!
   return *(state.block->array[state.index].branch);

--- a/src/tscore/Tokenizer.cc
+++ b/src/tscore/Tokenizer.cc
@@ -275,7 +275,8 @@ Tokenizer::addToken(char *startAddr, int length)
   }
 }
 
-const char *Tokenizer::operator[](unsigned index) const
+const char *
+Tokenizer::operator[](unsigned index) const
 {
   const tok_node *cur_node = &start_node;
   unsigned cur_start       = 0;

--- a/src/tscore/unit_tests/test_Extendible.cc
+++ b/src/tscore/unit_tests/test_Extendible.cc
@@ -90,8 +90,18 @@ public:
   uint16_t c = {3};
 
   // operator[]
-  template <typename F> decltype(auto) operator[](F field) const { return ext::get(*this, field); }
-  template <typename F> decltype(auto) operator[](F field) { return ext::set(*this, field); }
+  template <typename F>
+  decltype(auto)
+  operator[](F field) const
+  {
+    return ext::get(*this, field);
+  }
+  template <typename F>
+  decltype(auto)
+  operator[](F field)
+  {
+    return ext::set(*this, field);
+  }
 };
 
 ext::FieldId<C, std::atomic<uint16_t>> ext_c_1;
@@ -220,8 +230,18 @@ struct Derived : Extendible<Derived> {
   string m_str;
 
   // operator[] for shorthand
-  template <typename F> decltype(auto) operator[](F field) const { return ext::get(*this, field); }
-  template <typename F> decltype(auto) operator[](F field) { return ext::set(*this, field); }
+  template <typename F>
+  decltype(auto)
+  operator[](F field) const
+  {
+    return ext::get(*this, field);
+  }
+  template <typename F>
+  decltype(auto)
+  operator[](F field)
+  {
+    return ext::set(*this, field);
+  }
 
   static const string
   testFormat()

--- a/src/tscpp/api/Headers.cc
+++ b/src/tscpp/api/Headers.cc
@@ -133,7 +133,8 @@ header_field_value_iterator::~header_field_value_iterator()
   delete state_;
 }
 
-std::string header_field_value_iterator::operator*()
+std::string
+header_field_value_iterator::operator*()
 {
   if (state_->index_ >= 0) {
     int length      = 0;
@@ -363,7 +364,8 @@ HeaderField::operator=(const char *field_value)
   return append(field_value);
 }
 
-std::string HeaderField::operator[](const int index)
+std::string
+HeaderField::operator[](const int index)
 {
   return *header_field_value_iterator(iter_.state_->mloc_container_->hdr_buf_, iter_.state_->mloc_container_->hdr_loc_,
                                       iter_.state_->mloc_container_->field_loc_, index);
@@ -464,7 +466,8 @@ header_field_iterator::operator!=(const header_field_iterator &rhs) const
   return !operator==(rhs);
 }
 
-HeaderField header_field_iterator::operator*()
+HeaderField
+header_field_iterator::operator*()
 {
   return HeaderField(*this);
 }
@@ -670,7 +673,8 @@ Headers::set(const std::string &key, const std::string &value)
   return append(key, value);
 }
 
-HeaderField Headers::operator[](const std::string &key)
+HeaderField
+Headers::operator[](const std::string &key)
 {
   // In STL fashion if the key doesn't exist it will be added with an empty value.
   header_field_iterator it = find(key);

--- a/src/wccp/WccpLocal.h
+++ b/src/wccp/WccpLocal.h
@@ -3369,11 +3369,13 @@ HashAssignElt::getBucketBase()
   // coverity[ptr_arith]
   return reinterpret_cast<Bucket *>((&m_count + 1 + this->getCount()));
 }
-inline HashAssignElt::Bucket &HashAssignElt::operator[](size_t idx)
+inline HashAssignElt::Bucket &
+HashAssignElt::operator[](size_t idx)
 {
   return this->getBucketBase()[idx];
 }
-inline HashAssignElt::Bucket const &HashAssignElt::operator[](size_t idx) const
+inline HashAssignElt::Bucket const &
+HashAssignElt::operator[](size_t idx) const
 {
   return (*(const_cast<self *>(this)))[idx];
 }
@@ -3386,7 +3388,8 @@ MaskAssignElt::getCount() const
 {
   return ntohl(m_count);
 }
-inline MaskValueSetElt *MaskAssignElt::appender::operator->()
+inline MaskValueSetElt *
+MaskAssignElt::appender::operator->()
 {
   return m_set;
 }

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -19,7 +19,7 @@
 #  limitations under the License.
 
 # Update the PKGDATE with the new version date when making a new clang-format binary package.
-PKGDATE="20191031"
+PKGDATE="20200514"
 
 function main() {
   set -e # exit on error
@@ -27,7 +27,7 @@ function main() {
 
   DIR=${1:-.}
   PACKAGE="clang-format-${PKGDATE}.tar.bz2"
-  VERSION="clang-format version 9.0.0 (https://github.com/llvm/llvm-project.git 0399d5a9682b3cef71c653373e38890c63c4c365)"
+  VERSION="clang-format version 10.0.0 (https://github.com/llvm/llvm-project.git d32170dbd5b0d54436537b6b75beaf44324e0c28)"
 
   URL=${URL:-https://ci.trafficserver.apache.org/bintray/${PACKAGE}}
 
@@ -62,7 +62,7 @@ function main() {
     ${CURL} -L --progress-bar -o ${ARCHIVE} ${URL}
     ${TAR} -x -C ${ROOT} -f ${ARCHIVE}
     cat > ${ROOT}/sha1 << EOF
-c1b7ae57bfc80507ee155779a1ab8cf919b3e062  ${ARCHIVE}
+5eec43e5c7f3010d6e6f37639491cabe51de0ab2  ${ARCHIVE}
 EOF
     ${SHASUM} -c ${ROOT}/sha1
     chmod +x ${FORMAT}


### PR DESCRIPTION
There are two commits here, please don't squash, such that I can cherry pick (to 9.x) the one updating the scripts, but not the actual reformatting.