### PR TITLE
8.1.x backport: header_rewrite: this fixes parsing where the [ ] section gets merged into values

### DIFF
--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -185,8 +185,10 @@ RulesConfig::parse_config(const std::string &fname, TSHttpHookID default_hook)
       continue;
     }
 
-    Parser p(line); // Tokenize and parse this line
-    if (p.empty()) {
+    Parser p;
+
+    // Tokenize and parse this line
+    if (!p.parse_line(line) || p.empty()) {
       continue;
     }
 

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -44,7 +44,12 @@ TSError(const char *fmt, ...)
 class ParserTest : public Parser
 {
 public:
-  ParserTest(const std::string &line) : Parser(line), res(true) { std::cout << "Finished parser test: " << line << std::endl; }
+  ParserTest(const std::string &line) : res(true)
+  {
+    Parser::parse_line(line);
+    std::cout << "Finished parser test: " << line << std::endl;
+  }
+
   std::vector<std::string>
   getTokens() const
   {
@@ -364,12 +369,13 @@ test_parsing()
   }
 
   {
-    ParserTest p(R"(set-header Alt-Svc "quic=\":443\"; v=\"35\"")");
+    ParserTest p(R"(set-header Alt-Svc "quic=\":443\"; v=\"35\"" [L])");
 
-    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.getTokens().size(), 4UL);
     CHECK_EQ(p.getTokens()[0], "set-header");
     CHECK_EQ(p.getTokens()[1], "Alt-Svc");
     CHECK_EQ(p.getTokens()[2], R"(quic=":443"; v="35")");
+    CHECK_EQ(p.get_value(), R"(quic=":443"; v="35")");
 
     END_TEST();
   }
@@ -472,12 +478,16 @@ test_tokenizer()
     SimpleTokenizerTest p("a simple test");
     CHECK_EQ(p.get_tokens().size(), 1UL);
     CHECK_EQ(p.get_tokens()[0], "a simple test");
+
+    END_TEST();
   }
 
   {
     SimpleTokenizerTest p(R"(quic=":443"; v="35")");
     CHECK_EQ(p.get_tokens().size(), 1UL);
     CHECK_EQ(p.get_tokens()[0], R"(quic=":443"; v="35")");
+
+    END_TEST();
   }
 
   {
@@ -485,6 +495,8 @@ test_tokenizer()
     CHECK_EQ(p.get_tokens().size(), 2UL);
     CHECK_EQ(p.get_tokens()[0], "let's party like it's  ");
     CHECK_EQ(p.get_tokens()[1], "%{NOW:YEAR}");
+
+    END_TEST();
   }
   {
     SimpleTokenizerTest p("A racoon's favorite tag is %<cqhm> in %{NOW:YEAR}!");
@@ -494,6 +506,8 @@ test_tokenizer()
     CHECK_EQ(p.get_tokens()[2], " in ");
     CHECK_EQ(p.get_tokens()[3], "%{NOW:YEAR}");
     CHECK_EQ(p.get_tokens()[4], "!");
+
+    END_TEST();
   }
 
   {
@@ -503,6 +517,8 @@ test_tokenizer()
     CHECK_EQ(p.get_tokens()[1], "%{IP:SERVER}");
     CHECK_EQ(p.get_tokens()[2], ":");
     CHECK_EQ(p.get_tokens()[3], "%{INBOUND:LOCAL-PORT}");
+
+    END_TEST();
   }
 
   return errors;

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -33,7 +33,7 @@
 class Parser
 {
 public:
-  explicit Parser(const std::string &line);
+  Parser(){};
 
   bool
   empty() const
@@ -72,14 +72,20 @@ public:
   }
 
   bool cond_is_hook(TSHttpHookID &hook) const;
-  const std::vector<std::string> &get_tokens() const;
+
+  const std::vector<std::string> &
+  get_tokens() const
+  {
+    return _tokens;
+  }
+
+  bool parse_line(const std::string &original_line);
 
 private:
-  void preprocess(std::vector<std::string> tokens);
-  DISALLOW_COPY_AND_ASSIGN(Parser);
+  bool preprocess(std::vector<std::string> tokens);
 
-  bool _cond;
-  bool _empty;
+  bool _cond  = false;
+  bool _empty = false;
   std::vector<std::string> _mods;
   std::string _op;
   std::string _arg;
@@ -94,10 +100,15 @@ class SimpleTokenizer
 public:
   explicit SimpleTokenizer(const std::string &line);
 
-  const std::vector<std::string> &get_tokens() const;
+  // noncopyable
+  SimpleTokenizer(const SimpleTokenizer &) = delete;
+  void operator=(const SimpleTokenizer &) = delete;
 
-private:
-  DISALLOW_COPY_AND_ASSIGN(SimpleTokenizer);
+  const std::vector<std::string> &
+  get_tokens() const
+  {
+    return _tokens;
+  }
 
 protected:
   std::vector<std::string> _tokens;

--- a/plugins/header_rewrite/ruleset.cc
+++ b/plugins/header_rewrite/ruleset.cc
@@ -76,8 +76,7 @@ RuleSet::add_operator(Parser &p, const char *filename, int lineno)
   Operator *o = operator_factory(p.get_op());
 
   if (nullptr != o) {
-    // TODO: This should be extended to show both the "argument" and the "value" (if both are used)
-    TSDebug(PLUGIN_NAME, "   Adding operator: %s(%s)", p.get_op().c_str(), p.get_arg().c_str());
+    TSDebug(PLUGIN_NAME, "   Adding operator: %s(%s)=\"%s\"", p.get_op().c_str(), p.get_arg().c_str(), p.get_value().c_str());
     o->initialize(p);
     if (!o->set_hook(_hook)) {
       delete o;

--- a/plugins/header_rewrite/value.cc
+++ b/plugins/header_rewrite/value.cc
@@ -47,24 +47,30 @@ Value::set_value(const std::string &val)
     SimpleTokenizer tokenizer(_value);
 
     auto tokens = tokenizer.get_tokens();
-    for (auto it = tokens.begin(); it != tokens.end(); it++) {
-      std::string token = *it;
-
+    for (auto token : tokens) {
       Condition *tcond_val = nullptr;
+
       if (token.substr(0, 2) == "%<") {
-        tcond_val = new ConditionExpandableString(*it);
+        tcond_val = new ConditionExpandableString(token);
       } else if (token.substr(0, 2) == "%{") {
         std::string cond_token = token.substr(2, token.size() - 3);
-        tcond_val              = condition_factory(cond_token);
-      }
 
-      if (tcond_val) {
-        Parser parser(_value);
-        tcond_val->initialize(parser);
+        if ((tcond_val = condition_factory(cond_token))) {
+          Parser parser;
+
+          if (parser.parse_line(_value)) {
+            tcond_val->initialize(parser);
+          } else {
+            // TODO: should we produce error here?
+          }
+        }
       } else {
         tcond_val = new ConditionStringLiteral(token);
       }
-      _cond_vals.push_back(tcond_val);
+
+      if (tcond_val) {
+        _cond_vals.push_back(tcond_val);
+      }
     }
   } else {
     _int_value   = strtol(_value.c_str(), nullptr, 10);


### PR DESCRIPTION
For example:

    cond %{SEND_RESPONSE_HDR_HOOK}
     set-header X-First "First"
     set-header X-Last "Last" [L]

would set the header X-Last: Last [L].

In addition, it also fixes a typo (I think?) in an unrelated test,
however, it's unclear as to why it's not failing that test.

    CHECK_EQ(p.get_tokens()[1], "%{METHOD}c”);

(cherry picked from commit 6eb82a932daa97668432681d34f4d603180b8d83)