### PR TITLE
NextHop Strategy Refactor and Fixes

### DIFF
--- a/include/ts/nexthop.h
+++ b/include/ts/nexthop.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Implementation of various round robin nexthop selections strategies.
+  Traffic Server SDK API header file
 
   @section license License
 
@@ -19,26 +19,31 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
+
+  @section developers Developers
+
+  NextHop plugin interface.
+
  */
 
 #pragma once
 
-#include <mutex>
-#include "NextHopSelectionStrategy.h"
+#include <ts/apidefs.h>
 
-class NextHopRoundRobin : public NextHopSelectionStrategy
-{
-  std::mutex _mutex;
-  uint32_t latched_index = 0;
+// plugin callback commands.
+enum NHCmd { NH_MARK_UP, NH_MARK_DOWN };
 
-public:
-  NextHopRoundRobin() = delete;
-  NextHopRoundRobin(const std::string_view &name, const NHPolicyType &policy) : NextHopSelectionStrategy(name, policy) {}
-  ~NextHopRoundRobin();
-  bool
-  Init(const YAML::Node &n)
-  {
-    return NextHopSelectionStrategy::Init(n);
-  }
-  void findNextHop(TSHttpTxn txnp, void *ih = nullptr, time_t now = 0) override;
+struct NHHealthStatus {
+  virtual bool isNextHopAvailable(TSHttpTxn txn, const char *hostname, const int port, void *ih = nullptr) = 0;
+  virtual void markNextHop(TSHttpTxn txn, const char *hostname, const int port, const NHCmd status, void *ih = nullptr,
+                           const time_t now = 0)                                                           = 0;
+  virtual ~NHHealthStatus() {}
+};
+
+struct NHPluginStrategy {
+  virtual void findNextHop(TSHttpTxn txnp, void *ih = nullptr)   = 0;
+  virtual bool nextHopExists(TSHttpTxn txnp, void *ih = nullptr) = 0;
+  virtual ~NHPluginStrategy() {}
+
+  NHHealthStatus *healthStatus;
 };

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -41,6 +41,7 @@ libhttp_remap_a_SOURCES = \
 	NextHopSelectionStrategy.cc \
 	NextHopConsistentHash.h \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	NextHopRoundRobin.h \
 	NextHopRoundRobin.cc \
 	NextHopStrategyFactory.h \
@@ -148,6 +149,7 @@ test_NextHopStrategyFactory_SOURCES = \
 	NextHopStrategyFactory.cc \
 	NextHopRoundRobin.cc \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	unit-tests/test_NextHopStrategyFactory.cc \
 	unit-tests/nexthop_test_stubs.cc
 
@@ -178,6 +180,7 @@ test_NextHopRoundRobin_SOURCES = \
 	NextHopStrategyFactory.cc \
 	NextHopRoundRobin.cc \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	unit-tests/test_NextHopRoundRobin.cc \
 	unit-tests/nexthop_test_stubs.cc
 
@@ -207,6 +210,7 @@ test_NextHopConsistentHash_SOURCES = \
 	NextHopSelectionStrategy.cc \
 	NextHopStrategyFactory.cc \
 	NextHopConsistentHash.cc \
+	NextHopHealthStatus.cc \
 	NextHopRoundRobin.cc \
 	unit-tests/test_NextHopConsistentHash.cc \
 	unit-tests/nexthop_test_stubs.cc

--- a/proxy/http/remap/NextHopConsistentHash.cc
+++ b/proxy/http/remap/NextHopConsistentHash.cc
@@ -24,6 +24,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include "tscore/HashSip.h"
+#include "HttpSM.h"
 #include "NextHopConsistentHash.h"
 
 // hash_key strings.
@@ -207,81 +208,84 @@ NextHopConsistentHash::getHashKey(uint64_t sm_id, HttpRequestData *hrdata, ATSHa
 }
 
 void
-NextHopConsistentHash::findNextHop(const uint64_t sm_id, ParentResult &result, RequestData &rdata, const uint64_t fail_threshold,
-                                   const uint64_t retry_time, time_t now)
+NextHopConsistentHash::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
 {
-  time_t _now       = now;
-  bool firstcall    = false;
-  bool nextHopRetry = false;
-  bool wrapped      = false;
+  HttpSM *sm                   = reinterpret_cast<HttpSM *>(txnp);
+  ParentResult *result         = &sm->t_state.parent_result;
+  HttpRequestData request_info = sm->t_state.request_data;
+  int64_t sm_id                = sm->sm_id;
+  int64_t retry_time           = sm->t_state.txn_conf->parent_retry_time;
+  time_t _now                  = now;
+  bool firstcall               = false;
+  bool nextHopRetry            = false;
+  bool wrapped                 = false;
   std::vector<bool> wrap_around(groups, false);
   uint32_t cur_ring = 0; // there is a hash ring for each host group
   uint64_t hash_key = 0;
   uint32_t lookups  = 0;
   ATSHash64Sip24 hash;
-  HttpRequestData *request_info    = static_cast<HttpRequestData *>(&rdata);
   HostRecord *hostRec              = nullptr;
   std::shared_ptr<HostRecord> pRec = nullptr;
   HostStatus &pStatus              = HostStatus::instance();
   HostStatus_t host_stat           = HostStatus_t::HOST_STATUS_INIT;
   HostStatRec *hst                 = nullptr;
 
-  if (result.line_number == -1 && result.result == PARENT_UNDEFINED) {
+  if (result->line_number == -1 && result->result == PARENT_UNDEFINED) {
     firstcall = true;
   }
 
   if (firstcall) {
-    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] firstcall, line_number: %d, result: %s", sm_id, result.line_number,
-             ParentResultStr[result.result]);
-    result.line_number = distance;
-    cur_ring           = 0;
+    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] firstcall, line_number: %d, result: %s", sm_id, result->line_number,
+             ParentResultStr[result->result]);
+    result->line_number = distance;
+    cur_ring            = 0;
     for (uint32_t i = 0; i < groups; i++) {
-      result.chash_init[i] = false;
-      wrap_around[i]       = false;
+      result->chash_init[i] = false;
+      wrap_around[i]        = false;
     }
   } else {
-    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] not firstcall, line_number: %d, result: %s", sm_id, result.line_number,
-             ParentResultStr[result.result]);
+    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] not firstcall, line_number: %d, result: %s", sm_id, result->line_number,
+             ParentResultStr[result->result]);
     switch (ring_mode) {
     case NH_ALTERNATE_RING:
       if (groups > 1) {
-        cur_ring = (result.last_group + 1) % groups;
+        cur_ring = (result->last_group + 1) % groups;
       } else {
-        cur_ring = result.last_group;
+        cur_ring = result->last_group;
       }
       break;
     case NH_EXHAUST_RING:
     default:
       if (!wrapped) {
-        cur_ring = result.last_group;
+        cur_ring = result->last_group;
       } else if (groups > 1) {
-        cur_ring = (result.last_group + 1) % groups;
+        cur_ring = (result->last_group + 1) % groups;
       }
       break;
     }
   }
 
   // Do the initial parent look-up.
-  hash_key = getHashKey(sm_id, request_info, &hash);
+  hash_key = getHashKey(sm_id, &request_info, &hash);
 
   do { // search until we've selected a different parent if !firstcall
     std::shared_ptr<ATSConsistentHash> r = rings[cur_ring];
-    hostRec               = chash_lookup(r, hash_key, &result.chashIter[cur_ring], &wrapped, &hash, &result.chash_init[cur_ring],
-                           &result.mapWrapped[cur_ring], sm_id);
+    hostRec               = chash_lookup(r, hash_key, &result->chashIter[cur_ring], &wrapped, &hash, &result->chash_init[cur_ring],
+                           &result->mapWrapped[cur_ring], sm_id);
     wrap_around[cur_ring] = wrapped;
     lookups++;
     // the 'available' flag is maintained in 'host_groups' and not the hash ring.
     if (hostRec) {
       pRec = host_groups[hostRec->group_index][hostRec->host_index];
       if (firstcall) {
-        hst                        = (pRec) ? pStatus.getHostStatus(pRec->hostname.c_str()) : nullptr;
-        result.first_choice_status = (hst) ? hst->status : HostStatus_t::HOST_STATUS_UP;
+        hst                         = (pRec) ? pStatus.getHostStatus(pRec->hostname.c_str()) : nullptr;
+        result->first_choice_status = (hst) ? hst->status : HostStatus_t::HOST_STATUS_UP;
         break;
       }
     } else {
       pRec = nullptr;
     }
-  } while (pRec && result.hostname && strcmp(pRec->hostname.c_str(), result.hostname) == 0);
+  } while (pRec && result->hostname && strcmp(pRec->hostname.c_str(), result->hostname) == 0);
 
   NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] Initial parent lookups: %d", sm_id, lookups);
 
@@ -305,11 +309,11 @@ NextHopConsistentHash::findNextHop(const uint64_t sm_id, ParentResult &result, R
         _now == 0 ? _now = time(nullptr) : _now = now;
         // check if the host is retryable.  It's retryable if the retry window has elapsed
         if ((pRec->failedAt + retry_time) < static_cast<unsigned>(_now)) {
-          nextHopRetry       = true;
-          result.last_parent = pRec->host_index;
-          result.last_lookup = pRec->group_index;
-          result.retry       = nextHopRetry;
-          result.result      = PARENT_SPECIFIED;
+          nextHopRetry        = true;
+          result->last_parent = pRec->host_index;
+          result->last_lookup = pRec->group_index;
+          result->retry       = nextHopRetry;
+          result->result      = PARENT_SPECIFIED;
           NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] next hop %s is now retryable, marked it available.", sm_id, pRec->hostname.c_str());
           break;
         }
@@ -328,8 +332,8 @@ NextHopConsistentHash::findNextHop(const uint64_t sm_id, ParentResult &result, R
         break;
       }
       std::shared_ptr<ATSConsistentHash> r = rings[cur_ring];
-      hostRec               = chash_lookup(r, hash_key, &result.chashIter[cur_ring], &wrapped, &hash, &result.chash_init[cur_ring],
-                             &result.mapWrapped[cur_ring], sm_id);
+      hostRec = chash_lookup(r, hash_key, &result->chashIter[cur_ring], &wrapped, &hash, &result->chash_init[cur_ring],
+                             &result->mapWrapped[cur_ring], sm_id);
       wrap_around[cur_ring] = wrapped;
       lookups++;
       if (hostRec) {
@@ -372,37 +376,36 @@ NextHopConsistentHash::findNextHop(const uint64_t sm_id, ParentResult &result, R
   // Validate and return the final result.
   // ----------------------------------------------------------------------------------------------------
 
-  // use the available or marked for retry parent.
-  hst       = (pRec) ? pStatus.getHostStatus(pRec->hostname.c_str()) : nullptr;
-  host_stat = (hst) ? hst->status : HostStatus_t::HOST_STATUS_UP;
-
-  if (pRec && host_stat == HOST_STATUS_UP && (pRec->available || result.retry)) {
-    result.result      = PARENT_SPECIFIED;
-    result.hostname    = pRec->hostname.c_str();
-    result.last_parent = pRec->host_index;
-    result.last_lookup = result.last_group = cur_ring;
+  if (pRec && host_stat == HOST_STATUS_UP && (pRec->available || result->retry)) {
+    result->result      = PARENT_SPECIFIED;
+    result->hostname    = pRec->hostname.c_str();
+    result->last_parent = pRec->host_index;
+    result->last_lookup = result->last_group = cur_ring;
     switch (scheme) {
     case NH_SCHEME_NONE:
     case NH_SCHEME_HTTP:
-      result.port = pRec->getPort(scheme);
+      result->port = pRec->getPort(scheme);
       break;
     case NH_SCHEME_HTTPS:
-      result.port = pRec->getPort(scheme);
+      result->port = pRec->getPort(scheme);
       break;
     }
-    result.retry = nextHopRetry;
-    ink_assert(result.hostname != nullptr);
-    ink_assert(result.port != 0);
-    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] Chosen parent: %s.%d", sm_id, result.hostname, result.port);
+    result->retry = nextHopRetry;
+    ink_assert(result->hostname != nullptr);
+    ink_assert(result->port != 0);
+    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] result->result: %s Chosen parent: %s.%d", sm_id, ParentResultStr[result->result],
+             result->hostname, result->port);
   } else {
     if (go_direct == true) {
-      result.result = PARENT_DIRECT;
+      result->result = PARENT_DIRECT;
     } else {
-      result.result = PARENT_FAIL;
+      result->result = PARENT_FAIL;
     }
-    result.hostname = nullptr;
-    result.port     = 0;
-    result.retry    = false;
+    result->hostname = nullptr;
+    result->port     = 0;
+    result->retry    = false;
+    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] result->result: %s set hostname null port 0 retry false", sm_id,
+             ParentResultStr[result->result]);
   }
 
   return;

--- a/proxy/http/remap/NextHopConsistentHash.h
+++ b/proxy/http/remap/NextHopConsistentHash.h
@@ -49,6 +49,5 @@ public:
   NextHopConsistentHash(const std::string_view name, const NHPolicyType &policy) : NextHopSelectionStrategy(name, policy) {}
   ~NextHopConsistentHash();
   bool Init(const YAML::Node &n);
-  void findNextHop(const uint64_t sm_id, ParentResult &result, RequestData &rdata, const uint64_t fail_threshold,
-                   const uint64_t retry_time, time_t now = 0) override;
+  void findNextHop(TSHttpTxn txnp, void *ih = nullptr, time_t now = 0) override;
 };

--- a/proxy/http/remap/NextHopHealthStatus.cc
+++ b/proxy/http/remap/NextHopHealthStatus.cc
@@ -1,0 +1,152 @@
+/** @file
+
+  Implementation of nexthop consistent hash selections strategies.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "NextHopSelectionStrategy.h"
+#include "HttpSM.h"
+
+/**
+ * initialize the host_map
+ */
+void
+NextHopHealthStatus::insert(std::vector<std::shared_ptr<HostRecord>> &hosts)
+{
+  for (uint32_t ii = 0; ii < hosts.size(); ii++) {
+    std::shared_ptr<HostRecord> h = hosts[ii];
+    for (auto protocol = h->protocols.begin(); protocol != h->protocols.end(); ++protocol) {
+      const std::string host_port = h->getHostPort((*protocol)->port);
+      host_map.emplace(std::make_pair(host_port, h));
+      NH_Debug(NH_DEBUG_TAG, "inserting %s into host_map", host_port.c_str());
+    }
+  }
+}
+
+/**
+ * check that hostname is available for use.
+ */
+bool
+NextHopHealthStatus::isNextHopAvailable(TSHttpTxn txn, const char *hostname, const int port, void *ih)
+{
+  HttpSM *sm    = reinterpret_cast<HttpSM *>(txn);
+  int64_t sm_id = sm->sm_id;
+
+  const std::string host_port = HostRecord::makeHostPort(hostname, port);
+  auto iter                   = host_map.find(host_port);
+
+  if (iter == host_map.end()) {
+    NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] no host named %s found in host_map", sm_id, host_port.c_str());
+    return false;
+  }
+
+  std::shared_ptr p = iter->second;
+  return p->available;
+}
+
+/**
+ * mark up or down the indicated host
+ */
+void
+NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int port, const NHCmd status, void *ih,
+                                 const time_t now)
+{
+  time_t _now;
+  now == 0 ? _now = time(nullptr) : _now = now;
+
+  HttpSM *sm              = reinterpret_cast<HttpSM *>(txn);
+  ParentResult result     = sm->t_state.parent_result;
+  int64_t sm_id           = sm->sm_id;
+  int64_t fail_threshold  = sm->t_state.txn_conf->parent_fail_threshold;
+  int64_t retry_time      = sm->t_state.txn_conf->parent_retry_time;
+  uint32_t new_fail_count = 0;
+
+  // make sure we're called back with a result structure for a parent
+  // that is being retried.
+  if (status == NH_MARK_UP) {
+    ink_assert(result.retry == true);
+  }
+  if (result.result != PARENT_SPECIFIED) {
+    return;
+  }
+
+  // No failover exists when the result is set through the API.
+  if (result.is_api_result()) {
+    return;
+  }
+
+  const std::string host_port = HostRecord::makeHostPort(hostname, port);
+  auto iter                   = host_map.find(host_port);
+  if (iter == host_map.end()) {
+    NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] no host named %s found in host_map", sm_id, host_port.c_str());
+    return;
+  }
+
+  std::shared_ptr h = iter->second;
+
+  switch (status) {
+  // Mark the host up.
+  case NH_MARK_UP:
+    if (!h->available) {
+      h->set_available();
+      NH_Note("[%" PRId64 "] http parent proxy %s restored", sm_id, hostname);
+    }
+    break;
+  // Mark the host down.
+  case NH_MARK_DOWN:
+    if (h->failedAt == 0 || result.retry == true) {
+      { // lock guard
+        std::lock_guard<std::mutex> guard(h->_mutex);
+        if (h->failedAt == 0) {
+          h->failedAt = _now;
+          if (result.retry == false) {
+            new_fail_count = h->failCount = 1;
+          }
+        } else if (result.retry == true) {
+          h->failedAt = _now;
+        }
+      } // end lock guard
+      NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", h->hostname.c_str());
+    } else {
+      int old_count = 0;
+      // if the last failure was outside the retry window, set the failcount to 1 and failedAt to now.
+      { // lock guard
+        std::lock_guard<std::mutex> lock(h->_mutex);
+        if ((h->failedAt + retry_time) < static_cast<unsigned>(_now)) {
+          h->failCount = 1;
+          h->failedAt  = _now;
+        } else {
+          old_count = h->failCount = 1;
+        }
+        new_fail_count = old_count + 1;
+      } // end of lock_guard
+      NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] Parent fail count increased to %d for %s", sm_id, new_fail_count, h->hostname.c_str());
+    }
+
+    if (new_fail_count >= fail_threshold) {
+      h->set_unavailable();
+      NH_Note("[%" PRId64 "] Failure threshold met failcount:%d >= threshold:%" PRId64 ", http parent proxy %s marked down", sm_id,
+              new_fail_count, fail_threshold, h->hostname.c_str());
+      NH_Debug(NH_DEBUG_TAG, "[%" PRId64 "] NextHop %s marked unavailable, h->available=%s", sm_id, h->hostname.c_str(),
+               (h->available) ? "true" : "false");
+    }
+    break;
+  }
+}

--- a/proxy/http/remap/NextHopSelectionStrategy.cc
+++ b/proxy/http/remap/NextHopSelectionStrategy.cc
@@ -23,6 +23,7 @@
 
 #include <yaml-cpp/yaml.h>
 #include "I_Machine.h"
+#include "HttpSM.h"
 #include "NextHopSelectionStrategy.h"
 
 // ring mode strings
@@ -179,6 +180,7 @@ NextHopSelectionStrategy::Init(const YAML::Node &n)
               hosts_inner.push_back(std::move(host_rec));
               num_parents++;
             }
+            passive_health.insert(hosts_inner);
             host_groups.push_back(std::move(hosts_inner));
           }
         }
@@ -193,105 +195,18 @@ NextHopSelectionStrategy::Init(const YAML::Node &n)
 }
 
 void
-NextHopSelectionStrategy::markNextHopDown(const uint64_t sm_id, ParentResult &result, const uint64_t fail_threshold,
-                                          const uint64_t retry_time, time_t now)
+NextHopSelectionStrategy::markNextHop(TSHttpTxn txnp, const char *hostname, const int port, const NHCmd status, void *ih,
+                                      const time_t now)
 {
-  time_t _now;
-  now == 0 ? _now = time(nullptr) : _now = now;
-  uint32_t new_fail_count                = 0;
-
-  //  Make sure that we are being called back with with a
-  //  result structure with a selected parent.
-  if (result.result != PARENT_SPECIFIED) {
-    return;
-  }
-  // If we were set through the API we currently have not failover
-  //   so just return fail
-  if (result.is_api_result()) {
-    ink_assert(0);
-    return;
-  }
-  uint32_t hst_size = host_groups[result.last_group].size();
-  ink_assert(result.last_parent < hst_size);
-  std::shared_ptr<HostRecord> h = host_groups[result.last_group][result.last_parent];
-
-  // If the parent has already been marked down, just increment
-  //   the failure count.  If this is the first mark down on a
-  //   parent we need to both set the failure time and set
-  //   count to one. If this was the result of a retry, we
-  //   must update move the failedAt timestamp to now so that we
-  //   continue negative cache the parent
-  if (h->failedAt == 0 || result.retry == true) {
-    { // start of lock_guard scope.
-      std::lock_guard<std::mutex> lock(h->_mutex);
-      if (h->failedAt == 0) {
-        // Mark the parent failure time.
-        h->failedAt = _now;
-        if (result.retry == false) {
-          new_fail_count = h->failCount = 1;
-        }
-      } else if (result.retry == true) {
-        h->failedAt = _now;
-      }
-    } // end of lock_guard scope
-    NH_Note("[%" PRIu64 "] NextHop %s marked as down %s:%d", sm_id, (result.retry) ? "retry" : "initially", h->hostname.c_str(),
-            h->getPort(scheme));
-
-  } else {
-    int old_count = 0;
-
-    // if the last failure was outside the retry window, set the failcount to 1 and failedAt to now.
-    { // start of lock_guard_scope
-      std::lock_guard<std::mutex> lock(h->_mutex);
-      if ((h->failedAt + retry_time) < static_cast<unsigned>(_now)) {
-        h->failCount = 1;
-        h->failedAt  = _now;
-      } else {
-        old_count = h->failCount = 1;
-      }
-      new_fail_count = old_count + 1;
-    } // end of lock_guard
-    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] Parent fail count increased to %d for %s:%d", sm_id, new_fail_count, h->hostname.c_str(),
-             h->getPort(scheme));
-  }
-
-  if (new_fail_count >= fail_threshold) {
-    h->set_unavailable();
-    NH_Note("[%" PRIu64 "] Failure threshold met failcount:%d >= threshold:%" PRIu64 ", http parent proxy %s:%d marked down", sm_id,
-            new_fail_count, fail_threshold, h->hostname.c_str(), h->getPort(scheme));
-    NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] NextHop %s:%d marked unavailable, h->available=%s", sm_id, h->hostname.c_str(),
-             h->getPort(scheme), (h->available) ? "true" : "false");
-  }
-}
-
-void
-NextHopSelectionStrategy::markNextHopUp(const uint64_t sm_id, ParentResult &result)
-{
-  //  Make sure that we are being called back with with a
-  //   result structure with a parent that is being retried
-  ink_assert(result.retry == true);
-  if (result.result != PARENT_SPECIFIED) {
-    return;
-  }
-  // If we were set through the API we currently have not failover
-  //   so just return fail
-  if (result.is_api_result()) {
-    ink_assert(0);
-    return;
-  }
-  uint32_t hst_size = host_groups[result.last_group].size();
-  ink_assert(result.last_parent < hst_size);
-  std::shared_ptr<HostRecord> h = host_groups[result.last_group][result.last_parent];
-
-  if (!h->available) {
-    h->set_available();
-    NH_Note("[%" PRIu64 "] http parent proxy %s:%d restored", sm_id, h->hostname.c_str(), h->getPort(scheme));
-  }
+  return passive_health.markNextHop(txnp, hostname, port, status, ih, now);
 }
 
 bool
-NextHopSelectionStrategy::nextHopExists(const uint64_t sm_id)
+NextHopSelectionStrategy::nextHopExists(TSHttpTxn txnp, void *ih)
 {
+  HttpSM *sm    = reinterpret_cast<HttpSM *>(txnp);
+  int64_t sm_id = sm->sm_id;
+
   for (uint32_t gg = 0; gg < groups; gg++) {
     for (uint32_t hh = 0; hh < host_groups[gg].size(); hh++) {
       HostRecord *p = host_groups[gg][hh].get();
@@ -302,6 +217,19 @@ NextHopSelectionStrategy::nextHopExists(const uint64_t sm_id)
     }
   }
   return false;
+}
+
+bool
+NextHopSelectionStrategy::responseIsRetryable(unsigned int current_retry_attempts, HTTPStatus response_code)
+{
+  return this->resp_codes.contains(response_code) && current_retry_attempts < this->max_simple_retries &&
+         current_retry_attempts < this->num_parents;
+}
+
+bool
+NextHopSelectionStrategy::onFailureMarkParentDown(HTTPStatus response_code)
+{
+  return static_cast<int>(response_code) >= 500 && static_cast<int>(response_code) <= 599;
 }
 
 namespace YAML

--- a/proxy/http/remap/unit-tests/consistent-hash-tests.yaml
+++ b/proxy/http/remap/unit-tests/consistent-hash-tests.yaml
@@ -169,3 +169,198 @@ strategies:
       health_check:
         - passive
         - active
+  - strategy: "ignore-self-detect-false"
+    policy: consistent_hash
+    ignore_self_detect: false
+    hash_key: path
+    groups:
+      - &g1
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8000
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8001
+          weight: 1.0
+      - &g2
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8002
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8003
+          weight: 1.0
+    scheme: http
+    failover:
+      ring_mode: exhaust_ring
+      response_codes:
+        - 404
+        - 503
+      health_check:
+        - passive
+        - active
+  - strategy: "ignore-self-detect-true"
+    policy: consistent_hash
+    ignore_self_detect: true
+    hash_key: path
+    groups:
+      - &g1
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8000
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8001
+          weight: 1.0
+      - &g2
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8002
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8003
+          weight: 1.0
+    scheme: http
+    failover:
+      ring_mode: exhaust_ring
+      response_codes:
+        - 404
+        - 503
+      health_check:
+        - passive
+        - active
+  - strategy: "ignore-self-detect-true"
+    policy: consistent_hash
+    ignore_self_detect: true
+    hash_key: path
+    groups:
+      - &g1
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8000
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8001
+          weight: 1.0
+      - &g2
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8002
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8003
+          weight: 1.0
+    scheme: http
+    failover:
+      ring_mode: exhaust_ring
+      response_codes:
+        - 404
+        - 503
+      health_check:
+        - passive
+        - active
+  - strategy: "same-host-different-port"
+    policy: consistent_hash
+    ignore_self_detect: true
+    hash_key: path
+    groups:
+      - &g1
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8000
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8001
+          weight: 1.0
+      - &g2
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8002
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8003
+          weight: 1.0
+      - &g3
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8004
+          weight: 1.0
+        - host: localhost
+          protocol:
+            - scheme: http
+              port: 8005
+          weight: 1.0
+    scheme: http
+    failover:
+      ring_mode: exhaust_ring
+      response_codes:
+        - 404
+        - 503
+      health_check:
+        - passive
+        - active
+  - strategy: "hash-string-override"
+    policy: consistent_hash
+    ignore_self_detect: true
+    hash_key: path
+    groups:
+      - &hso0
+        - host: foo.test
+          hash_string: one
+          protocol:
+            - scheme: http
+              port: 80
+          weight: 1.0
+        - host: bar.test
+          hash_string: two
+          protocol:
+            - scheme: http
+              port: 80
+          weight: 1.0
+      - &hso1
+        - host: baz.test
+          hash_string: three
+          protocol:
+            - scheme: http
+              port: 80
+          weight: 1.0
+        - host: bat.test
+          hash_string: four
+          protocol:
+            - scheme: http
+              port: 80
+          weight: 1.0
+    scheme: http
+    failover:
+      ring_mode: exhaust_ring
+      response_codes:
+        - 404
+        - 503
+      health_check:
+        - passive
+        - active

--- a/proxy/http/remap/unit-tests/nexthop_test_stubs.h
+++ b/proxy/http/remap/unit-tests/nexthop_test_stubs.h
@@ -48,7 +48,6 @@ extern "C" {
 class HttpRequestData;
 
 void PrintToStdErr(const char *fmt, ...);
-void br_destroy(HttpRequestData &h);
 void build_request(HttpRequestData &h, const char *os_hostname);
 
 #ifdef __cplusplus
@@ -56,34 +55,23 @@ void build_request(HttpRequestData &h, const char *os_hostname);
 #endif /* __cplusplus */
 
 #include "ControlMatcher.h"
-struct TestData : public HttpRequestData {
-  std::string hostname;
-  sockaddr client_ip;
-  sockaddr server_ip;
+#include "ParentSelection.h"
 
-  TestData()
-  {
-    client_ip.sa_family = AF_INET;
-    memset(client_ip.sa_data, 0, sizeof(client_ip.sa_data));
-  }
-  const char *
-  get_host()
-  {
-    return hostname.c_str();
-  }
-  sockaddr const *
-  get_ip()
-  {
-    return &server_ip;
-  }
-  sockaddr const *
-  get_client_ip()
-  {
-    return &client_ip;
-  }
-  char *
-  get_string()
-  {
-    return nullptr;
-  }
+struct trans_config {
+  int64_t parent_retry_time     = 0;
+  int64_t parent_fail_threshold = 0;
+  trans_config() {}
 };
+
+struct trans_state {
+  ParentResult parent_result;
+  HttpRequestData request_data;
+  trans_config txn_conf;
+  trans_state() {}
+};
+
+class HttpSM;
+
+void br_destroy(HttpSM &sm);
+
+void build_request(int64_t sm_id, HttpSM *sm, sockaddr_in *ip, const char *os_hostname, sockaddr const *dest_ip);

--- a/proxy/http/remap/unit-tests/test_NextHopRoundRobin.cc
+++ b/proxy/http/remap/unit-tests/test_NextHopRoundRobin.cc
@@ -31,6 +31,7 @@
 #include <catch.hpp> /* catch unit-test framework */
 #include <yaml-cpp/yaml.h>
 
+#include "HttpSM.h"
 #include "nexthop_test_stubs.h"
 #include "NextHopSelectionStrategy.h"
 #include "NextHopStrategyFactory.h"
@@ -38,6 +39,12 @@
 
 SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-strict'", "[NextHopRoundRobin]")
 {
+  // We need this to build a HdrHeap object in build_request();
+  // No thread setup, forbid use of thread local allocators.
+  cmd_disable_pfreelist = true;
+  // Get all of the HTTP WKS items populated.
+  http_init();
+
   GIVEN("Loading the round-robin-tests.yaml config for round robin 'rr-strict' tests.")
   {
     std::shared_ptr<NextHopSelectionStrategy> strategy;
@@ -56,9 +63,9 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-strict'", "[NextHopR
 
     WHEN("making requests using a 'rr-strict' policy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("then testing rr-strict.")
       {
@@ -66,86 +73,103 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-strict'", "[NextHopR
         REQUIRE(strategy != nullptr);
 
         // first request.
-        ParentResult result;
-        strategy->findNextHop(10000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10001, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // second request.
-        result.reset();
-        strategy->findNextHop(10001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10002, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // third request.
-        result.reset();
-        strategy->findNextHop(10002, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10003, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // did not reset result, kept it as last parent selected was p1.fo.com, mark it down and we should only select p2.foo.com
-        strategy->markNextHopDown(10003, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, result->port, NH_MARK_DOWN);
 
         // fourth request, p1 is down should select p2.
-        result.reset();
-        strategy->findNextHop(10004, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10004, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // fifth request, p1 is down should still select p2.
-        result.reset();
-        strategy->findNextHop(10005, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10005, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // mark down p2.
-        strategy->markNextHopDown(10006, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, result->port, NH_MARK_DOWN);
 
         // fifth request, p1 and p2 are both down, should get s1.bar.com from failover ring.
-        result.reset();
-        strategy->findNextHop(10007, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "s1.bar.com") == 0);
+        build_request(10006, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "s1.bar.com") == 0);
 
         // sixth request, p1 and p2 are still down, should get s1.bar.com from failover ring.
-        result.reset();
-        strategy->findNextHop(10008, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "s1.bar.com") == 0);
+        build_request(10007, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "s1.bar.com") == 0);
 
         // mark down s1.
-        strategy->markNextHopDown(10009, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, result->port, NH_MARK_DOWN);
 
         // seventh request, p1, p2, s1 are down, should get s2.bar.com from failover ring.
-        result.reset();
-        strategy->findNextHop(10010, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "s2.bar.com") == 0);
+        build_request(10008, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "s2.bar.com") == 0);
 
         // mark down s2.
-        strategy->markNextHopDown(10011, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, result->port, NH_MARK_DOWN);
 
         // eighth request, p1, p2, s1, s2 are down, should get PARENT_DIRECT as go_direct is true
-        result.reset();
-        strategy->findNextHop(10012, result, rdata, fail_threshold, retry_time);
-        CHECK(result.result == ParentResultType::PARENT_DIRECT);
+        build_request(10009, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(result->result == ParentResultType::PARENT_DIRECT);
 
         // check that nextHopExists() returns false when all parents are down.
-        CHECK(strategy->nextHopExists(10012) == false);
+        CHECK(strategy->nextHopExists(txnp) == false);
 
         // change the request time to trigger a retry.
         time_t now = (time(nullptr) + 5);
 
         // ninth request, p1 and p2 are still down, should get p2.foo.com as it will be retried
-        result.reset();
-        strategy->findNextHop(10013, result, rdata, fail_threshold, retry_time, now);
-        REQUIRE(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10010, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp, nullptr, now);
+        REQUIRE(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // tenth request, p1 should now be retried.
-        result.reset();
-        strategy->findNextHop(10014, result, rdata, fail_threshold, retry_time, now);
-        REQUIRE(result.result == ParentResultType::PARENT_SPECIFIED);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10011, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp, nullptr, now);
+        REQUIRE(result->result == ParentResultType::PARENT_SPECIFIED);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
       }
+      br_destroy(sm);
     }
   }
 }
 
 SCENARIO("Testing NextHopRoundRobin class, using policy 'first-live'", "[NextHopRoundRobin]")
 {
+  // We need this to build a HdrHeap object in build_request();
+  // No thread setup, forbid use of thread local allocators.
+  cmd_disable_pfreelist = true;
+  // Get all of the HTTP WKS items populated.
+  http_init();
+
   GIVEN("Loading the round-robin-tests.yaml config for round robin 'first-live' tests.")
   {
     std::shared_ptr<NextHopSelectionStrategy> strategy;
@@ -164,9 +188,9 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'first-live'", "[NextHop
 
     WHEN("when using a strategy with a 'first-live' policy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("when making requests and marking down hosts.")
       {
@@ -174,37 +198,47 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'first-live'", "[NextHop
         REQUIRE(strategy != nullptr);
 
         // first request.
-        ParentResult result;
-        strategy->findNextHop(20000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10012, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // second request.
-        result.reset();
-        strategy->findNextHop(20001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10013, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
 
         // mark down p1.
-        strategy->markNextHopDown(20002, result, 1, fail_threshold);
+        strategy->markNextHop(txnp, result->hostname, result->port, NH_MARK_DOWN);
 
         // third request.
-        result.reset();
-        strategy->findNextHop(20003, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p2.foo.com") == 0);
+        build_request(10014, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p2.foo.com") == 0);
 
         // change the request time to trigger a retry.
         time_t now = (time(nullptr) + 5);
 
         // fourth request, p1 should be marked for retry
-        result.reset();
-        strategy->findNextHop(20004, result, rdata, fail_threshold, retry_time, now);
-        CHECK(strcmp(result.hostname, "p1.foo.com") == 0);
+        build_request(10015, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp, nullptr, now);
+        CHECK(strcmp(result->hostname, "p1.foo.com") == 0);
       }
+      br_destroy(sm);
     }
   }
 }
 
 SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-ip'", "[NextHopRoundRobin]")
 {
+  // We need this to build a HdrHeap object in build_request();
+  // No thread setup, forbid use of thread local allocators.
+  cmd_disable_pfreelist = true;
+  // Get all of the HTTP WKS items populated.
+  http_init();
+
   GIVEN("Loading the round-robin-tests.yaml config for round robin 'rr-ip' tests.")
   {
     std::shared_ptr<NextHopSelectionStrategy> strategy;
@@ -217,6 +251,10 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-ip'", "[NextHopRound
     sa2.sin_port   = 10001;
     sa2.sin_family = AF_INET;
     inet_pton(AF_INET, "192.168.1.2", &(sa2.sin_addr));
+    HttpSM sm;
+    ParentResult *result = &sm.t_state.parent_result;
+    TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
+
     WHEN("the config is loaded.")
     {
       THEN("then the 'rr-strict' strategy is ready.")
@@ -229,10 +267,6 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-ip'", "[NextHopRound
 
     WHEN("using the 'rr-strict' strategy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
-
       THEN("when making requests and marking down hosts.")
       {
         REQUIRE(nhf.strategies_loaded == true);
@@ -240,48 +274,58 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'rr-ip'", "[NextHopRound
 
         // call and test parentExists(), this call should not affect
         // findNextHop() round robin strict results
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // first request.
-        memcpy(&rdata.client_ip, &sa1, sizeof(sa1));
-        ParentResult result;
-        strategy->findNextHop(30000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        // memcpy(&rdata.client_ip, &sa1, sizeof(sa1));
+        build_request(10016, &sm, &sa1, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
 
         // call and test parentExists(), this call should not affect
         // findNextHop round robin strict results.
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // second request.
-        memcpy(&rdata.client_ip, &sa2, sizeof(sa2));
-        result.reset();
-        strategy->findNextHop(30001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        // memcpy(&rdata.client_ip, &sa2, sizeof(sa2));
+        build_request(10017, &sm, &sa2, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // call and test parentExists(), this call should not affect
         // findNextHop() round robin strict results
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // third  request with same client ip, result should still be p3
-        result.reset();
-        strategy->findNextHop(30002, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10018, &sm, &sa2, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // call and test parentExists(), this call should not affect
         // findNextHop() round robin strict results.
-        CHECK(strategy->nextHopExists(29000) == true);
+        CHECK(strategy->nextHopExists(txnp) == true);
 
         // fourth  request with same client ip and same result indicating a failure should result in p4
         // being selected.
-        strategy->findNextHop(30003, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        build_request(10019, &sm, &sa2, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
       }
     }
+    br_destroy(sm);
   }
 }
 
 SCENARIO("Testing NextHopRoundRobin class, using policy 'latched'", "[NextHopRoundRobin]")
 {
+  // We need this to build a HdrHeap object in build_request();
+  // No thread setup, forbid use of thread local allocators.
+  cmd_disable_pfreelist = true;
+  // Get all of the HTTP WKS items populated.
+  http_init();
+
   GIVEN("Loading the round-robin-tests.yaml config for round robin 'latched' tests.")
   {
     std::shared_ptr<NextHopSelectionStrategy> strategy;
@@ -300,9 +344,9 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'latched'", "[NextHopRou
 
     WHEN("using a strategy having a 'latched' policy.")
     {
-      uint64_t fail_threshold = 1;
-      uint64_t retry_time     = 1;
-      TestData rdata;
+      HttpSM sm;
+      ParentResult *result = &sm.t_state.parent_result;
+      TSHttpTxn txnp       = reinterpret_cast<TSHttpTxn>(&sm);
 
       THEN("when making requests and marking down hosts.")
       {
@@ -310,28 +354,33 @@ SCENARIO("Testing NextHopRoundRobin class, using policy 'latched'", "[NextHopRou
         REQUIRE(strategy != nullptr);
 
         // first request should select p3
-        ParentResult result;
-        strategy->findNextHop(40000, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10020, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // second request should select p3
-        result.reset();
-        strategy->findNextHop(40001, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10021, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
 
         // third request, use previous result to simulate a failure, we should now select p4.
-        strategy->findNextHop(40002, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        build_request(10022, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
 
         // fourth request we should be latched on p4
-        result.reset();
-        strategy->findNextHop(40003, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p4.foo.com") == 0);
+        build_request(10023, &sm, nullptr, "rabbit.net", nullptr);
+        result->reset();
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p4.foo.com") == 0);
 
         // fifth request, use previous result to simulate a failure, we should now select p3.
-        strategy->findNextHop(40004, result, rdata, fail_threshold, retry_time);
-        CHECK(strcmp(result.hostname, "p3.foo.com") == 0);
+        build_request(10024, &sm, nullptr, "rabbit.net", nullptr);
+        strategy->findNextHop(txnp);
+        CHECK(strcmp(result->hostname, "p3.foo.com") == 0);
       }
+      br_destroy(sm);
     }
   }
 }


### PR DESCRIPTION
This is a collaboration between @jrushford and me. This:
- Refactors the NextHopSelectionStrategy interface to simplify and prepare for Plugins (John's work)
- Refactors Strategy Markdown logic, to simplify, encapsulate, and also prepare for Plugin usage
- Fixes strategies.yaml parent errors with 4xx to not mark down and 5xx to mark down, matching parent.config behavior
- Fixes strategies.yaml markdown to include the port, to not mark down parents with the same hostname and different ports, matching parent.config behavior
- Fixes strategies.yaml ignore_self_detect 
- Fixes  strategies.yaml hash_string override

Includes unit tests for the above fixes.