### PR TITLE
Rename ratelimiting configs to reflect requests and not connections

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -409,20 +409,21 @@ Network
    handled. This should be tuned according to your memory size, and expected
    work load.  If this is set to 0, the throttling logic is disabled.
 
-.. ts:cv:: CONFIG proxy.config.net.max_connections_in INT 30000
+.. ts:cv:: CONFIG proxy.config.net.max_requests_in INT 30000
 
-   The total number of client connections that the :program:`traffic_server`
-   can handle simultaneously. This should be tuned according to your memory size,
-   and expected work load (network, cpu etc). This limit includes both keepalive
-   and active client connections that :program:`traffic_server` can handle at
-   any given instant.
+   The total number of client requests that |TS| can handle simultaneously.
+   This should be tuned according to your memory size, and expected work load
+   (network, cpu etc). This limit includes both idle (keep alive) connections
+   and active requests that |TS| can handle at any given instant. The delta
+   between `proxy.config.net.max_requests_in` and `proxy.config.net.max_active_requests_in`
+   is the amount of maximum idle connections |TS| will maintain.
 
-.. ts:cv:: CONFIG proxy.config.net.max_active_connections_in INT 10000
+.. ts:cv:: CONFIG proxy.config.net.max_active_requests_in INT 10000
 
    The total number of active client connections that the |TS| can handle
    simultaneously. This should be tuned according to your memory size,
    and expected work load (network, cpu etc). If this is set to 0, active
-   connection tracking is disabled and active connections have no separate
+   request tracking is disabled and max active requests has no separate
    limit and the total connections follow `proxy.config.net.connections_throttle`
 
 .. ts:cv:: CONFIG proxy.config.net.default_inactivity_timeout INT 86400

--- a/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
@@ -66,7 +66,7 @@ Network I/O
 .. ts:stat:: global proxy.process.net.connections_throttled_out integer
    :type: counter
 
-.. ts:stat:: global proxy.process.net.max.active.connections_throttled_in integer
+.. ts:stat:: global proxy.process.net.max.active.requests_throttled_in integer
    :type: counter
 
 .. ts:stat:: global proxy.process.net.default_inactivity_timeout_applied integer

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -142,8 +142,8 @@ register_net_stats()
                      (int)net_connections_throttled_in_stat, RecRawStatSyncSum);
   RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.connections_throttled_out", RECD_INT, RECP_PERSISTENT,
                      (int)net_connections_throttled_out_stat, RecRawStatSyncSum);
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.max.active.connections_throttled_in", RECD_INT, RECP_PERSISTENT,
-                     (int)net_connections_max_active_throttled_in_stat, RecRawStatSyncSum);
+  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.max.active.requests_throttled_in", RECD_INT, RECP_PERSISTENT,
+                     (int)net_requests_max_active_throttled_in_stat, RecRawStatSyncSum);
 }
 
 void

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -58,7 +58,7 @@ enum Net_Stats {
   net_tcp_accept_stat,
   net_connections_throttled_in_stat,
   net_connections_throttled_out_stat,
-  net_connections_max_active_throttled_in_stat,
+  net_requests_max_active_throttled_in_stat,
   Net_Stat_Count
 };
 

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -272,8 +272,8 @@ public:
 
   /// configuration settings for managing the active and keep-alive queues
   struct Config {
-    uint32_t max_connections_in                 = 0;
-    uint32_t max_connections_active_in          = 0;
+    uint32_t max_requests_in                    = 0;
+    uint32_t max_requests_active_in             = 0;
     uint32_t inactive_threshold_in              = 0;
     uint32_t transaction_no_activity_timeout_in = 0;
     uint32_t keep_alive_no_activity_timeout_in  = 0;
@@ -288,7 +288,7 @@ public:
     uint32_t &
     operator[](int n)
     {
-      return *(&max_connections_in + n);
+      return *(&max_requests_in + n);
     }
   };
   /** Static global config, set and updated per process.
@@ -302,8 +302,8 @@ public:
   Config config; ///< Per thread copy of the @c global_config
   // Active and keep alive queue values that depend on other configuration values.
   // These are never updated directly, they are computed from other config values.
-  uint32_t max_connections_per_thread_in        = 0;
-  uint32_t max_connections_active_per_thread_in = 0;
+  uint32_t max_requests_per_thread_in        = 0;
+  uint32_t max_requests_active_per_thread_in = 0;
   /// Number of configuration items in @c Config.
   static constexpr int CONFIG_ITEM_COUNT = sizeof(Config) / sizeof(uint32_t);
   /// Which members of @c Config the per thread values depend on.

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -398,9 +398,9 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.attach_server_session_to_client", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.max_connections_in", RECD_INT, "30000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.max_requests_in", RECD_INT, "30000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.max_connections_active_in", RECD_INT, "10000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.max_requests_active_in", RECD_INT, "10000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
 
   //       ###########################


### PR DESCRIPTION
email to dev/users@

```
On Tuesday, May 12, 2020, 05:17:36 PM PDT, Sudheer Vinukonda <sudheervinukonda@yahoo.com> wrote:


9.x (re)introduces a feature (it was accidentally "lost" during some unrelated refactoring) that will allow to configure limits on max "active" connections that can be allowed at any given time (https://github.com/apache/trafficserver/pull/6754)

Given that this feature is based on tracking "active connections", it should work very well with HTTP/1.1 traffic (where, 1 active connection = 1 request). However, with HTTP/2 and stream multiplexing, this is no longer true and it isn't nearly as effective. One can still use an average number of concurrent streams/connection to configure the limits, but, ideally, what would work for both HTTP/1.1 and HTTP/2 (and going forward with QUIC/HTTP/3) would be to track and (rate) limit request level concurrency. There is some ongoing work on this and to align better with that work, we are proposing to make the below changes to existing configs with 9.x


1) Rename "proxy.config.net.max_connections_in" to "proxy.config.net.max_requests_in"

2) Rename "proxy.config.net.max_active_connections_in" to "proxy.config.net.max_active_requests_in"

3) proxy.config.net.connections_throttle - This config will stay put to limit the max number of open connections (FD, rlimits etc) 


More context on the new changes - 

The idea is to tune active connections that can be handled (based on the available resources/capacity (CPU, Memory, Network bandwidth) and minimize/remove dependency on having to tune connection timeouts (active/inactive/keep-alive etc) which are very hard to tune.

The primary goal is to limit the max active connections allowed at any given instant. The resource requirement for an idle/inactive vs active connections are completely different - For e.g an idle connection really only consumes memory resource, while an active connection consumes CPU, network besides memory. And allowing to tune/cap the max active connections based on the deployed capacity for the resources available, would make timeout tuning almost redundant and no op. Otherwise, we'd have to tune the timeouts to estimate throughput which is very hard as it's hard to justify how large or small we want the active timeout to be or keep alive timeout to be. For e.g in a non-peak hour, we could let the active timeout be much higher than the default, while during peak hour, we'd want to limit it to ensure we are not starving resources on one connection.

Note: there's one little TODO item here. PluginVC's connections are not tracked in the NetVC's active queue because these are bogus internal connections. However, for some users, internal traffic is significant (e.g sideways calls, or background fetches etc) and does consume plenty of resources. Since these internal requests don't impact ingress network, and have a slightly different resource requirements than client originated requests, it might be better to track these using a separate config for internal requests. Will follow that part up with a separate PR.



```