### PR TITLE
Add TXN_CLOSE hook to CPPAPI TransactionPlugin

### DIFF
--- a/include/tscpp/api/Plugin.h
+++ b/include/tscpp/api/Plugin.h
@@ -58,8 +58,8 @@ public:
     HOOK_READ_REQUEST_HEADERS,  /**< This hook will be fired after the request is read. */
     HOOK_READ_CACHE_HEADERS,    /**< This hook will be fired after the CACHE hdrs. */
     HOOK_CACHE_LOOKUP_COMPLETE, /**< This hook will be fired after cache lookup complete. */
-    HOOK_TXN_CLOSE,             /**< This hook will be fired after send response headers. */
-    HOOK_SELECT_ALT             /**< This hook will be fired after select alt. */
+    HOOK_TXN_CLOSE, /**< This hook will be fired after send response headers, only for TransactionPlugins::registerHook()!. */
+    HOOK_SELECT_ALT /**< This hook will be fired after select alt. */
   };
 
   /**

--- a/include/tscpp/api/Plugin.h
+++ b/include/tscpp/api/Plugin.h
@@ -58,6 +58,7 @@ public:
     HOOK_READ_REQUEST_HEADERS,  /**< This hook will be fired after the request is read. */
     HOOK_READ_CACHE_HEADERS,    /**< This hook will be fired after the CACHE hdrs. */
     HOOK_CACHE_LOOKUP_COMPLETE, /**< This hook will be fired after cache lookup complete. */
+    HOOK_TXN_CLOSE,             /**< This hook will be fired after send response headers. */
     HOOK_SELECT_ALT             /**< This hook will be fired after select alt. */
   };
 
@@ -138,6 +139,15 @@ public:
    */
   virtual void
   handleReadCacheLookupComplete(Transaction &transaction)
+  {
+    transaction.resume();
+  };
+
+  /**
+   * This method must be implemented when you hook HOOK_TXN_CLOSE
+   */
+  virtual void
+  handleTxnClose(Transaction &transaction)
   {
     transaction.resume();
   };

--- a/include/tscpp/api/TransactionPlugin.h
+++ b/include/tscpp/api/TransactionPlugin.h
@@ -93,6 +93,10 @@ public:
    *  see HookType and Plugin for the correspond HookTypes and callback methods. If you fail to implement the
    *  callback, a default implementation will be used that will only resume the Transaction.
    *
+   * \note For automatic destruction, you must either register dynamically allocated instances of
+   *  classes derived from this class with the the corresponding Transaction object (using
+   *  Transaction::addPlugin()), or register HOOK_TXN_CLOSE (but not both).
+   *
    * @param HookType the type of hook you wish to register
    * @see HookType
    * @see Plugin

--- a/src/tscpp/api/GlobalPlugin.cc
+++ b/src/tscpp/api/GlobalPlugin.cc
@@ -87,6 +87,7 @@ GlobalPlugin::~GlobalPlugin()
 void
 GlobalPlugin::registerHook(Plugin::HookType hook_type)
 {
+  assert(hook_type != Plugin::HOOK_TXN_CLOSE);
   TSHttpHookID hook_id = utils::internal::convertInternalHookToTsHook(hook_type);
   TSHttpHookAdd(hook_id, state_->cont_);
   LOG_DEBUG("Registered global plugin %p for hook %s", this, HOOK_TYPE_STRINGS[hook_type].c_str());

--- a/src/tscpp/api/utils_internal.cc
+++ b/src/tscpp/api/utils_internal.cc
@@ -141,6 +141,13 @@ void inline invokePluginForEvent(Plugin *plugin, TSHttpTxn ats_txn_handle, TSEve
   case TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE:
     plugin->handleReadCacheLookupComplete(transaction);
     break;
+  case TS_EVENT_HTTP_TXN_CLOSE:
+    if (plugin) {
+      plugin->handleTxnClose(transaction);
+    } else {
+      LOG_ERROR("stray event TS_EVENT_HTTP_TXN_CLOSE, no transaction plugin to handle it!");
+    }
+    break;
   default:
     assert(false); /* we should never get here */
     break;
@@ -191,6 +198,8 @@ utils::internal::convertInternalHookToTsHook(Plugin::HookType hooktype)
     return TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK;
   case Plugin::HOOK_SELECT_ALT:
     return TS_HTTP_SELECT_ALT_HOOK;
+  case Plugin::HOOK_TXN_CLOSE:
+    return TS_HTTP_TXN_CLOSE_HOOK;
   default:
     assert(false); // shouldn't happen, let's catch it early
     break;


### PR DESCRIPTION
Email to dev@

```
We recently ran into a core dump issue due to one of our TransactionPlugin's continuations being called back with TXN_CLOSE event.

The current CPPAPI's TransactionPlugin does not expect a call back on TXN_CLOSE, and asserts on it. This is because the expectation seems to be that all the continuations for TransactionPlugins attached to the Transaction are destroyed in the global TXN_CLOSE hook. However, this only works based on the plugin table in the Transaction object, which gets populated based on `Transaction::addPlugin()`. Turns out, some of our plugins do not call `Transaction::addPlugin()` and just create a `TransactionPlugin()` and register hooks to it resulting in them getting called back for TXN_CLOSE event as well.

Long story short, it didn't particularly seem unreasonable to add support to TXN_CLOSE event in TransactionPlugin, since the current API does not seem to mandate calling `Transaction.addPlugin()`. 


https://github.com/apache/trafficserver/pull/6800


Please let me know if there are any concerns/comments.
  ````

Here's the stack trace

```(gdb) bt
#0  0x00002aabdd0cc1d7 in raise () from /lib64/libc.so.6
#1  0x00002aabdd0cda08 in abort () from /lib64/libc.so.6
#2  0x00002aabdd0c5146 in __assert_fail_base () from /lib64/libc.so.6
#3  0x00002aabdd0c51f2 in __assert_fail () from /lib64/libc.so.6
#4  0x00002aabfb6223cf in invokePluginForEvent (event=468845984, ats_txn_handle=0x2aac6e63a070, plugin=0x2aac92d6d4e0) at utils_internal.cc:148
#5  atscppapi::utils::internal::invokePluginForEvent (plugin=plugin@entry=0x2aac92d6d4e0, ats_txn_handle=ats_txn_handle@entry=0x2aac6e63a070, event=event@entry=TS_EVENT_HTTP_TXN_CLOSE) at utils_internal.cc:222
#6  0x00002aabfb624310 in (anonymous namespace)::handleTransactionPluginEvents (cont=0x2aad52c4ce00, event=TS_EVENT_HTTP_TXN_CLOSE, edata=0x2aac6e63a070) at TransactionPlugin.cc:57
#7  0x00000000004c4833 in INKContInternal::handle_event (this=0x2aad52c4ce00, event=60012, edata=0x2aac6e63a070) at InkAPI.cc:1012
#8  0x00000000005b5b1f in HttpSM::state_api_callout (this=this@entry=0x2aac6e63a070, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1638
#9  0x00000000005bca82 in HttpSM::state_api_callback (this=this@entry=0x2aac6e63a070, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1507
#10 0x00000000004d9a69 in TSHttpTxnReenable (txnp=0x2aac6e63a070, event=TS_EVENT_HTTP_CONTINUE) at InkAPI.cc:5714
#11 0x00002aabfbea9e41 in AtsPluginUtils::creqCleanup (cont=0x2aabfb2fc3a0, event=TS_EVENT_HTTP_TXN_CLOSE, edata=0x2aac6e63a070) at ClientRequest.cc:76
#12 0x00000000004c4833 in INKContInternal::handle_event (this=0x2aabfb2fc3a0, event=60012, edata=0x2aac6e63a070) at InkAPI.cc:1012
#13 0x00000000005b5b1f in HttpSM::state_api_callout (this=this@entry=0x2aac6e63a070, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1638
#14 0x00000000005bca82 in HttpSM::state_api_callback (this=this@entry=0x2aac6e63a070, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1507
#15 0x00000000004d9a69 in TSHttpTxnReenable (txnp=0x2aac6e63a070, event=TS_EVENT_HTTP_CONTINUE) at InkAPI.cc:5714
#16 0x00002aabfb621e25 in (anonymous namespace)::handleTransactionEvents (cont=<optimized out>, event=<optimized out>, edata=0x2aac6e63a070) at utils_internal.cc:95
#17 0x00000000004c4833 in INKContInternal::handle_event (this=0x2aabfb2fcf40, event=60012, edata=0x2aac6e63a070) at InkAPI.cc:1012
#18 0x00000000005b5b1f in HttpSM::state_api_callout (this=0x2aac6e63a070, event=<optimized out>, data=<optimized out>) at HttpSM.cc:1638
#19 0x00000000005bbeba in HttpSM::kill_this (this=this@entry=0x2aac6e63a070) at HttpSM.cc:7039
#20 0x00000000005bcd80 in HttpSM::main_handler (this=0x2aac6e63a070, event=2301, data=0x2aac6e63b400) at HttpSM.cc:2958
#21 0x00000000005fee8d in handleEvent (data=0x2aac6e63b400, event=2301, this=<optimized out>) at ../../iocore/eventsystem/I_Continuation.h:153
#22 HttpTunnel::main_handler (this=0x2aac6e63b400, event=<optimized out>, data=<optimized out>) at HttpTunnel.cc:1642
#23 0x000000000076da7e in handleEvent (data=0x2aac0aed7e98, event=103, this=<optimized out>) at ../../iocore/eventsystem/I_Continuation.h:153
#24 write_signal_and_update (vc=0x2aac0aed7d00, event=103) at UnixNetVConnection.cc:179
#25 write_signal_done (vc=0x2aac0aed7d00, nh=0x2aabe160be00, event=103) at UnixNetVConnection.cc:224
#26 write_to_net_io (nh=nh@entry=0x2aabe160be00, vc=0x2aac0aed7d00, thread=<optimized out>) at UnixNetVConnection.cc:564
#27 0x000000000076ddd8 in write_to_net (nh=nh@entry=0x2aabe160be00, vc=vc@entry=0x2aac0aed7d00, thread=<optimized out>) at UnixNetVConnection.cc:421
#28 0x000000000075dba4 in NetHandler::mainNetEvent (this=0x2aabe160be00, event=<optimized out>, e=<optimized out>) at UnixNet.cc:530
#29 0x000000000078f3ef in handleEvent (data=0x2aabdf7fd8c0, event=5, this=<optimized out>) at I_Continuation.h:153
#30 process_event (calling_code=5, e=0x2aabdf7fd8c0, this=0x2aabe1608000) at UnixEThread.cc:152
#31 EThread::execute (this=0x2aabe1608000) at UnixEThread.cc:279
#32 0x000000000078dffa in spawn_thread_internal (a=0x2aabde99d6d0) at Thread.cc:86
#33 0x00002aabdc0f4dc5 in start_thread () from /lib64/libpthread.so.0
#34 0x00002aabdd18e76d in clone () from /lib64/libc.so.6
```