### PR TITLE
Fix session pool to add and fetch to beginning of hash chain instead of end

### DIFF
--- a/include/tscore/IntrusiveHashMap.h
+++ b/include/tscore/IntrusiveHashMap.h
@@ -539,16 +539,6 @@ IntrusiveHashMap<H>::insert(value_type *v)
     if (spot != bucket->_v) {
       mixed_p = true; // found some other key, it's going to be mixed.
     }
-    if (spot != limit) {
-      // If an equal key was found, walk past those to insert at the upper end of the range.
-      do {
-        spot = H::next_ptr(spot);
-      } while (spot != limit && H::equal(key, H::key_of(spot)));
-      if (spot != limit) { // something not equal past last equivalent, it's going to be mixed.
-        mixed_p = true;
-      }
-    }
-
     _list.insert_before(spot, v);
     if (spot == bucket->_v) { // added before the bucket start, update the start.
       bucket->_v = v;

--- a/src/tscore/unit_tests/test_IntrusiveHashMap.cc
+++ b/src/tscore/unit_tests/test_IntrusiveHashMap.cc
@@ -123,7 +123,7 @@ TEST_CASE("IntrusiveHashMap", "[libts][IntrusiveHashMap]")
   auto r = map.equal_range("dup"sv);
   REQUIRE(r.first != r.second);
   REQUIRE(r.first->_payload == "dup"sv);
-  REQUIRE(r.first->_n == 79);
+  REQUIRE(r.first->_n == 81);
 
   Map::iterator idx;
 
@@ -138,13 +138,13 @@ TEST_CASE("IntrusiveHashMap", "[libts][IntrusiveHashMap]")
   REQUIRE(r.first != r.second);
   idx = r.first;
   REQUIRE(idx->_payload == "dup"sv);
+  REQUIRE(idx->_n == 81);
+  REQUIRE((++idx)->_payload == "dup"sv);
+  REQUIRE(idx->_n != r.first->_n);
   REQUIRE(idx->_n == 79);
   REQUIRE((++idx)->_payload == "dup"sv);
   REQUIRE(idx->_n != r.first->_n);
   REQUIRE(idx->_n == 80);
-  REQUIRE((++idx)->_payload == "dup"sv);
-  REQUIRE(idx->_n != r.first->_n);
-  REQUIRE(idx->_n == 81);
   REQUIRE(++idx == map.end());
   // Verify only the "dup" items are left.
   for (auto &&elt : map) {
@@ -200,7 +200,7 @@ TEST_CASE("IntrusiveHashMapManyStrings", "[IntrusiveHashMap]")
   }
   for (int idx = 23; idx < N; idx += 23) {
     auto spot = ihm.find(strings[idx]);
-    if (spot == ihm.end() || spot->_n != idx || ++spot == ihm.end() || spot->_n != 2000 + idx) {
+    if (spot == ihm.end() || spot->_n != 2000 + idx || ++spot == ihm.end() || spot->_n != idx) {
       miss_p = true;
     }
   }
@@ -213,7 +213,7 @@ TEST_CASE("IntrusiveHashMapManyStrings", "[IntrusiveHashMap]")
   }
   for (int idx = 31; idx < N; idx += 31) {
     auto spot = ihm.find(strings[idx]);
-    if (spot == ihm.end() || spot->_n != idx || ++spot == ihm.end() || (idx != (23 * 31) && spot->_n != 3000 + idx) ||
+    if (spot == ihm.end() || spot->_n != 3000 + idx || ++spot == ihm.end() || (idx != (23 * 31) && spot->_n != idx) ||
         (idx == (23 * 31) && spot->_n != 2000 + idx)) {
       miss_p = true;
     }


### PR DESCRIPTION
When comparing our ATS9 performance against our ATS7 builds, we noticed that the origin session reuse rates were lower.  Looking more closely with @SolidWallOfCode we found that the ATS7 version picked against the head of the hash chain and added back to the head.  But the ATS9 version both added to the tail and picked from the tail (walking the chain 2 times).

This PR returns the code to the ATS7 version.  Add to head and remove from head (LIFO).  With this code change, our session reuse performance matches peer machines running our ATS7.

Did a brief experiment with FIFO (add to head and remove from tail) and that did not work well with our workload where our goal is to minimize number of connections to origin.  Actually more recently, we had another customer that wanted a smoother distribution of traffic to origins and a FIFO version of our ATS7 worked best for them.  So making FIFO vs LIFO a configurable option will be another PR at some point.