### PR TITLE
Fix missing virtual destructor in TLSSessionResumptionSupport.

### DIFF
--- a/iocore/net/TLSSessionResumptionSupport.h
+++ b/iocore/net/TLSSessionResumptionSupport.h
@@ -33,6 +33,8 @@
 class TLSSessionResumptionSupport
 {
 public:
+  virtual ~TLSSessionResumptionSupport() = default;
+
   static void initialize();
   static TLSSessionResumptionSupport *getInstance(SSL *ssl);
   static void bind(SSL *ssl, TLSSessionResumptionSupport *srs);


### PR DESCRIPTION
The class has a virtual method and so requires a virtual destructor.