### PR TITLE
Make post_slow_server Au test work in Docker container.

### DIFF
--- a/tests/gold_tests/post_slow_server/check.sh
+++ b/tests/gold_tests/post_slow_server/check.sh
@@ -16,4 +16,12 @@
 
 # Check that curl command received 200 KBytes of data (in 8-byte lines).
 
-(( $( grep '^1234567$' curl.log | wc -l ) == ((200 * 1024) / 8) ))
+RECEIVED=$( grep '^[0-9][0-9][0-9][0-9][0-9][0-9][0-9]$' curl.log | wc -l )
+let RECEIVED=8*RECEIVED
+
+EXPECTED=$((200 * 1024))
+
+echo "Exepcted=$EXPECTED"
+echo "Recieved=$RECEIVED"
+
+(( RECEIVED == EXPECTED ))

--- a/tests/gold_tests/post_slow_server/post_slow_server.test.py
+++ b/tests/gold_tests/post_slow_server/post_slow_server.test.py
@@ -61,8 +61,7 @@ server = Test.Processes.Process(
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl --request POST --verbose --ipv4 --http2 --insecure --header "Content-Length: 0"' +
-    r" --header 'Host: localhost' https://localhost:{}/xyz 2>&1 | tr '\r' '\n' ".format(ts.Variables.ssl_port) +
-    ' > curl.log'
+    " --header 'Host: localhost' https://localhost:{}/xyz >curl.log 2>curl.err".format(ts.Variables.ssl_port)
 )
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/post_slow_server/server.sh
+++ b/tests/gold_tests/post_slow_server/server.sh
@@ -24,14 +24,16 @@ response ()
   #
   while (( 1 == 1 ))
   do
-    if tr '\r' '=' < rcv_file | grep '^=$' > /dev/null
-    then
-      break;
+    if [[ -f rcv_file ]] ; then
+      if tr '\r' '=' < rcv_file | grep '^=$' > /dev/null
+      then
+        break;
+      fi
     fi
     sleep 1
   done
 
-  sleep 2m
+  date >&2 ; sleep 2m ; date >&2
 
   # Send back 200 KBytes of data
 
@@ -42,8 +44,8 @@ response ()
   let I=0
   while (( I < ((200 * 1024) / 8) ))
   do
-    printf "1234567\n"
     let I=I+1
+    printf "%07.7u\n" $((I * 8))
   done
 }
 


### PR DESCRIPTION
For some reason, redirecting standard error into standard output for a curl command causes a line of standard output to be lost when running in my Linux Docker container on MacOS.  Also made a few other small tweaks to the test.