### PR TITLE
lua plugin: fix for incorrectly injecting global plugin stats

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -76,7 +76,7 @@ typedef struct {
 } ts_lua_plugin_stats;
 
 ts_lua_plugin_stats *
-create_plugin_stats(ts_lua_main_ctx *const main_ctx_array)
+create_plugin_stats(ts_lua_main_ctx *const main_ctx_array, char const *const *stat_strs)
 {
   ts_lua_plugin_stats *const stats = TSmalloc(sizeof(ts_lua_plugin_stats));
   memset(stats, 0, sizeof(ts_lua_plugin_stats));
@@ -87,15 +87,7 @@ create_plugin_stats(ts_lua_main_ctx *const main_ctx_array)
   stats->gc_kb   = 0;
   stats->threads = 0;
 
-  char const *const *stat_strs = NULL;
-  int max_state_count          = 0;
-  if (main_ctx_array == ts_lua_main_ctx_array) { // remap
-    stat_strs       = ts_lua_stat_strs;
-    max_state_count = ts_lua_max_state_count;
-  } else { // global
-    stat_strs       = ts_lua_g_stat_strs;
-    max_state_count = ts_lua_max_state_count;
-  }
+  int const max_state_count = ts_lua_max_state_count;
 
   for (int ind = 0; ind < TS_LUA_IND_SIZE; ++ind) {
     stats->stat_inds[ind] = TSStatCreate(stat_strs[ind], TS_RECORDDATATYPE_INT, TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_SUM);
@@ -319,7 +311,7 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
       TSContDataSet(lcontp, ts_lua_main_ctx_array);
       TSLifecycleHookAdd(TS_LIFECYCLE_MSG_HOOK, lcontp);
 
-      ts_lua_plugin_stats *const plugin_stats = create_plugin_stats(ts_lua_main_ctx_array);
+      ts_lua_plugin_stats *const plugin_stats = create_plugin_stats(ts_lua_main_ctx_array, ts_lua_stat_strs);
 
       // start the stats management
       if (NULL != plugin_stats) {
@@ -752,7 +744,7 @@ TSPluginInit(int argc, const char *argv[])
       TSContDataSet(contp, ts_lua_g_main_ctx_array);
       TSLifecycleHookAdd(TS_LIFECYCLE_MSG_HOOK, contp);
 
-      ts_lua_plugin_stats *const plugin_stats = create_plugin_stats(ts_lua_main_ctx_array);
+      ts_lua_plugin_stats *const plugin_stats = create_plugin_stats(ts_lua_g_main_ctx_array, ts_lua_g_stat_strs);
 
       if (NULL != plugin_stats) {
         TSCont const scontp = TSContCreate(statsHandler, TSMutexCreate());

--- a/tests/gold_tests/pluginTest/lua/global.lua
+++ b/tests/gold_tests/pluginTest/lua/global.lua
@@ -1,0 +1,23 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+--  regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"); you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+
+function do_global_read_request()
+  if 'GET' == ts.client_request.get_method() then
+		if '/noop' == ts.client_request.get_uri() then
+			ts.http.set_resp(200, "noop")
+		end
+  end
+end

--- a/tests/gold_tests/pluginTest/lua/gold/metrics.stdout.gold
+++ b/tests/gold_tests/pluginTest/lua/gold/metrics.stdout.gold
@@ -1,3 +1,6 @@
+plugin.lua.global.states ``
+plugin.lua.global.gc_bytes ``
+plugin.lua.global.threads ``
 plugin.lua.remap.states ``
 plugin.lua.remap.gc_bytes ``
 plugin.lua.remap.threads ``

--- a/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
@@ -47,6 +47,8 @@ ts.Disk.remap_config.AddLines({
     ' @plugin=tslua.so @pparam={}/hello.lua'.format(Test.TestDirectory)
 })
 
+ts.Disk.plugin_config.AddLine('tslua.so {}/global.lua'.format(Test.TestDirectory))
+
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'ts_lua',
@@ -80,12 +82,13 @@ tr.StillRunningAfter = ts
 # 2 Test - Check for metrics
 tr = Test.AddTestRun("Check for metrics")
 tr.DelayStart = 15 # 5s lag on metrics to update
+tr.TimeOut = 5
 ps = tr.Processes.Default # alias
+ps.Env = ts.Env
 ps.Command = "traffic_ctl metric match lua"
 ps.Env = ts.Env
 ps.ReturnCode = 0
 ps.Streams.stdout = "gold/metrics.stdout.gold"
-tr.TimeOut = 5
 tr.StillRunningAfter = ts
 
 # 3 Test - Check for developer lifecycle stats


### PR DESCRIPTION
Fixes a bug where the global lua plugin stats are incorrectly assigned causing a collision with remap plugins.