### PR TITLE
HostDB - change HostResPreferenceOrder type to std::array.

### DIFF
--- a/include/tscore/ink_resolver.h
+++ b/include/tscore/ink_resolver.h
@@ -74,6 +74,8 @@
 #include <resolv.h>
 #include <arpa/nameser.h>
 
+#include <array>
+
 #if defined(openbsd)
 #define NS_INT16SZ INT16SZ
 #define NS_INT32SZ INT32SZ
@@ -157,10 +159,8 @@ enum HostResPreference {
 };
 /// # of preference values.
 static int const N_HOST_RES_PREFERENCE = HOST_RES_PREFER_IPV6 + 1;
-/// # of entries in a preference ordering.
-static int const N_HOST_RES_PREFERENCE_ORDER = 3;
 /// Storage for preference ordering.
-typedef HostResPreference HostResPreferenceOrder[N_HOST_RES_PREFERENCE_ORDER];
+using HostResPreferenceOrder = std::array<HostResPreference, 3>;
 /// Global, hard wired default value for preference ordering.
 extern HostResPreferenceOrder const HOST_RES_DEFAULT_PREFERENCE_ORDER;
 /// Global (configurable) default.
@@ -188,8 +188,8 @@ extern HostResStyle ats_host_res_from(int family,                    ///< Connec
 
 /** Parse a host resolution configuration string.
  */
-extern void parse_host_res_preference(const char *value,           ///< [in] Configuration string.
-                                      HostResPreferenceOrder order /// [out] Order to update.
+extern void parse_host_res_preference(const char *value,            ///< [in] Configuration string.
+                                      HostResPreferenceOrder &order /// [out] Order to update.
 );
 
 /// Configure the preference order to hold only what's from the client address.

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -208,7 +208,7 @@ HttpProxyPort::Group &HttpProxyPort::m_global = GLOBAL_DATA;
 HttpProxyPort::HttpProxyPort() : m_fd(ts::NO_FD)
 
 {
-  memcpy(m_host_res_preference, host_res_default_preference_order, sizeof(m_host_res_preference));
+  m_host_res_preference = host_res_default_preference_order;
 }
 
 bool
@@ -633,8 +633,7 @@ HttpProxyPort::print(char *out, size_t n)
    * transparent (which means the preference order is forced) or if
    * the order is the same as the default.
    */
-  if (!m_outbound_transparent_p &&
-      0 != memcmp(m_host_res_preference, host_res_default_preference_order, sizeof(m_host_res_preference))) {
+  if (!m_outbound_transparent_p && m_host_res_preference != host_res_default_preference_order) {
     zret += snprintf(out + zret, n - zret, ":%s=", OPT_HOST_RES_PREFIX);
     zret += ts_host_res_order_to_string(m_host_res_preference, out + zret, n - zret);
   }
@@ -689,9 +688,8 @@ void
 ts_host_res_global_init()
 {
   // Global configuration values.
-  memcpy(host_res_default_preference_order, HOST_RES_DEFAULT_PREFERENCE_ORDER, sizeof(host_res_default_preference_order));
-
-  char *ip_resolve = REC_ConfigReadString("proxy.config.hostdb.ip_resolve");
+  host_res_default_preference_order = HOST_RES_DEFAULT_PREFERENCE_ORDER;
+  char *ip_resolve                  = REC_ConfigReadString("proxy.config.hostdb.ip_resolve");
   if (ip_resolve) {
     parse_host_res_preference(ip_resolve, host_res_default_preference_order);
   }

--- a/lib/records/unit_tests/unit_test_main.cc
+++ b/lib/records/unit_tests/unit_test_main.cc
@@ -38,9 +38,8 @@ main(int argc, char *argv[])
   // Global data initialization needed for the unit tests.
   ts_session_protocol_well_known_name_indices_init();
   // Cheat for ts_host_res_global_init as there's no records.config to check for non-default.
-  memcpy(host_res_default_preference_order, HOST_RES_DEFAULT_PREFERENCE_ORDER, sizeof(host_res_default_preference_order));
-
-  int result = Catch::Session().run(argc, argv);
+  host_res_default_preference_order = HOST_RES_DEFAULT_PREFERENCE_ORDER;
+  int result                        = Catch::Session().run(argc, argv);
 
   // global clean-up...
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -550,9 +550,7 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
   ink_assert(ua_txn->get_proxy_ssn()->accept_options);
 
   // default the upstream IP style host resolution order from inbound
-  std::copy(std::begin(ua_txn->get_proxy_ssn()->accept_options->host_res_preference),
-            std::end(ua_txn->get_proxy_ssn()->accept_options->host_res_preference),
-            std::begin(t_state.my_txn_conf().host_res_data.order));
+  t_state.my_txn_conf().host_res_data.order = ua_txn->get_proxy_ssn()->accept_options->host_res_preference;
 
   start_sub_sm();
 

--- a/proxy/http/HttpSessionAccept.h
+++ b/proxy/http/HttpSessionAccept.h
@@ -84,7 +84,7 @@ public:
   /// Host address resolution preference order.
   HostResPreferenceOrder host_res_preference;
   /// Set the host query preference.
-  self &setHostResPreference(HostResPreferenceOrder const);
+  self &setHostResPreference(HostResPreferenceOrder const &);
   /// Acceptable session protocols.
   SessionProtocolSet session_protocol_preference;
   /// Set the session protocol preference.
@@ -94,7 +94,7 @@ public:
 inline HttpSessionAcceptOptions::HttpSessionAcceptOptions()
 
 {
-  memcpy(host_res_preference, host_res_default_preference_order, sizeof(host_res_preference));
+  host_res_preference = host_res_default_preference_order;
 }
 
 inline HttpSessionAcceptOptions &
@@ -146,9 +146,9 @@ HttpSessionAcceptOptions::setTransparentPassthrough(bool flag)
 }
 
 inline HttpSessionAcceptOptions &
-HttpSessionAcceptOptions::setHostResPreference(HostResPreferenceOrder const order)
+HttpSessionAcceptOptions::setHostResPreference(HostResPreferenceOrder const &order)
 {
-  memcpy(host_res_preference, order, sizeof(host_res_preference));
+  host_res_preference = order;
   return *this;
 }
 

--- a/src/tscore/ink_res_init.cc
+++ b/src/tscore/ink_res_init.cc
@@ -586,7 +586,7 @@ ink_res_init(ink_res_state statp,         ///< State object to update.
 }
 
 void
-parse_host_res_preference(const char *value, HostResPreferenceOrder order)
+parse_host_res_preference(const char *value, HostResPreferenceOrder &order)
 {
   Tokenizer tokens(";/|");
   // preference from the config string.
@@ -601,7 +601,8 @@ parse_host_res_preference(const char *value, HostResPreferenceOrder order)
     found[i] = false;
   }
 
-  for (i = 0; i < n && np < N_HOST_RES_PREFERENCE_ORDER; ++i) {
+  const int order_size = static_cast<int>(order.size());
+  for (i = 0; i < n && np < order_size; ++i) {
     const char *elt = tokens[i];
     // special case none/only because that terminates the sequence.
     if (0 == strcasecmp(elt, HOST_RES_PREFERENCE_STRING[HOST_RES_PREFER_NONE])) {
@@ -632,7 +633,7 @@ parse_host_res_preference(const char *value, HostResPreferenceOrder order)
     if (!found[HOST_RES_PREFER_IPV6]) {
       order[np++] = HOST_RES_PREFER_IPV6;
     }
-    if (np < N_HOST_RES_PREFERENCE_ORDER) { // was N_HOST_RES_PREFERENCE)
+    if (np < order_size) { // was N_HOST_RES_PREFERENCE)
       order[np] = HOST_RES_PREFER_NONE;
     }
   }

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -516,8 +516,7 @@ ats_host_res_from(int family, HostResPreferenceOrder const &order)
   bool v4 = false, v6 = false;
   HostResPreference client = AF_INET6 == family ? HOST_RES_PREFER_IPV6 : HOST_RES_PREFER_IPV4;
 
-  for (int i = 0; i < N_HOST_RES_PREFERENCE_ORDER; ++i) {
-    HostResPreference p = order[i];
+  for (auto p : order) {
     if (HOST_RES_PREFER_CLIENT == p) {
       p = client; // CLIENT -> actual value
     }
@@ -548,13 +547,13 @@ ats_host_res_from(int family, HostResPreferenceOrder const &order)
 void
 ats_force_order_by_family(sockaddr const *addr, HostResPreferenceOrder order)
 {
-  int pos{0};
+  HostResPreferenceOrder::size_type pos{0};
   if (ats_is_ip6(addr)) {
     order[pos++] = HOST_RES_PREFER_IPV6;
   } else if (ats_is_ip4(addr)) {
     order[pos++] = HOST_RES_PREFER_IPV4;
   }
-  for (; pos < N_HOST_RES_PREFERENCE_ORDER; pos++) {
+  for (; pos < order.size(); pos++) {
     order[pos] = HOST_RES_PREFER_NONE;
   }
 }


### PR DESCRIPTION
Using `std::array` instead of c style array. 
This change make easy and less verbose dealing with the host resolution type, better value semantics in that sense.