### PR TITLE
change overridable var type for proxy.config.http.server_session_sharing.match from int to string

### DIFF
--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1107,6 +1107,7 @@ HttpConfig::startup()
   // [amc] This is a bit of a mess, need to figure out to make this cleaner.
   RecRegisterConfigUpdateCb("proxy.config.http.server_session_sharing.match", &http_server_session_sharing_cb, &c);
   http_config_enum_mask_read("proxy.config.http.server_session_sharing.match", c.oride.server_session_sharing_match);
+  HttpEstablishStaticConfigStringAlloc(c.oride.server_session_sharing_match_str, "proxy.config.http.server_session_sharing.match");
   http_config_enum_read("proxy.config.http.server_session_sharing.pool", SessionSharingPoolStrings, c.server_session_sharing_pool);
 
   RecRegisterConfigUpdateCb("proxy.config.http.insert_forwarded", &http_insert_forwarded_cb, &c);
@@ -1403,10 +1404,11 @@ HttpConfig::reconfigure()
     params->oride.flow_high_water_mark = params->oride.flow_low_water_mark = 0;
   }
 
-  params->oride.server_session_sharing_match = m_master.oride.server_session_sharing_match;
-  params->oride.server_min_keep_alive_conns  = m_master.oride.server_min_keep_alive_conns;
-  params->server_session_sharing_pool        = m_master.server_session_sharing_pool;
-  params->oride.keep_alive_post_out          = m_master.oride.keep_alive_post_out;
+  params->oride.server_session_sharing_match     = m_master.oride.server_session_sharing_match;
+  params->oride.server_session_sharing_match_str = ats_strdup(m_master.oride.server_session_sharing_match_str);
+  params->oride.server_min_keep_alive_conns      = m_master.oride.server_min_keep_alive_conns;
+  params->server_session_sharing_pool            = m_master.server_session_sharing_pool;
+  params->oride.keep_alive_post_out              = m_master.oride.keep_alive_post_out;
 
   params->oride.keep_alive_no_activity_timeout_in   = m_master.oride.keep_alive_no_activity_timeout_in;
   params->oride.keep_alive_no_activity_timeout_out  = m_master.oride.keep_alive_no_activity_timeout_out;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -467,6 +467,7 @@ struct OverridableHttpConfigParams {
 
   MgmtInt server_min_keep_alive_conns         = 0;
   MgmtByte server_session_sharing_match       = 0;
+  char *server_session_sharing_match_str      = nullptr;
   MgmtByte auth_server_session_private        = 1;
   MgmtByte fwd_proxy_auth_to_parent           = 0;
   MgmtByte uncacheable_requests_bypass_parent = 1;
@@ -854,6 +855,7 @@ inline HttpConfigParams::~HttpConfigParams()
   ats_free(proxy_response_via_string);
   ats_free(anonymize_other_header_list);
   ats_free(oride.body_factory_template_base);
+  ats_free(oride.server_session_sharing_match_str);
   ats_free(oride.proxy_response_server_string);
   ats_free(oride.global_user_agent_header);
   ats_free(oride.ssl_client_cert_filename);

--- a/src/shared/overridable_txn_vars.cc
+++ b/src/shared/overridable_txn_vars.cc
@@ -101,7 +101,7 @@ const std::unordered_map<std::string_view, std::tuple<const TSOverridableConfigK
      {"proxy.config.http.cache.ignore_server_no_cache", {TS_CONFIG_HTTP_CACHE_IGNORE_SERVER_NO_CACHE, TS_RECORDDATATYPE_INT}},
      {"proxy.config.http.cache.heuristic_min_lifetime", {TS_CONFIG_HTTP_CACHE_HEURISTIC_MIN_LIFETIME, TS_RECORDDATATYPE_INT}},
      {"proxy.config.http.cache.heuristic_max_lifetime", {TS_CONFIG_HTTP_CACHE_HEURISTIC_MAX_LIFETIME, TS_RECORDDATATYPE_INT}},
-     {"proxy.config.http.server_session_sharing.match", {TS_CONFIG_HTTP_SERVER_SESSION_SHARING_MATCH, TS_RECORDDATATYPE_INT}},
+     {"proxy.config.http.server_session_sharing.match", {TS_CONFIG_HTTP_SERVER_SESSION_SHARING_MATCH, TS_RECORDDATATYPE_STRING}},
      {"proxy.config.http.cache.ignore_accept_mismatch", {TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_MISMATCH, TS_RECORDDATATYPE_INT}},
      {"proxy.config.http.cache.open_write_fail_action", {TS_CONFIG_HTTP_CACHE_OPEN_WRITE_FAIL_ACTION, TS_RECORDDATATYPE_INT}},
      {"proxy.config.http.insert_squid_x_forwarded_for", {TS_CONFIG_HTTP_INSERT_SQUID_X_FORWARDED_FOR, TS_RECORDDATATYPE_INT}},

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -8702,6 +8702,7 @@ TSHttpTxnConfigStringSet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
   case TS_CONFIG_HTTP_SERVER_SESSION_SHARING_MATCH:
     if (value && length > 0) {
       HttpConfig::load_server_session_sharing_match(value, s->t_state.my_txn_conf().server_session_sharing_match);
+      s->t_state.my_txn_conf().server_session_sharing_match_str = const_cast<char *>(value);
     }
     break;
   case TS_CONFIG_SSL_CLIENT_VERIFY_SERVER_POLICY:
@@ -8778,6 +8779,10 @@ TSHttpTxnConfigStringGet(TSHttpTxn txnp, TSOverridableConfigKey conf, const char
   case TS_CONFIG_BODY_FACTORY_TEMPLATE_BASE:
     *value  = sm->t_state.txn_conf->body_factory_template_base;
     *length = sm->t_state.txn_conf->body_factory_template_base_len;
+    break;
+  case TS_CONFIG_HTTP_SERVER_SESSION_SHARING_MATCH:
+    *value  = sm->t_state.txn_conf->server_session_sharing_match_str;
+    *length = *value ? strlen(*value) : 0;
     break;
   default: {
     MgmtConverter const *conv;


### PR DESCRIPTION
We find a problem when we set overridable config proxy.config.http.server_session_sharing.match in the remap rule. This config type is defined as string (https://github.com/apache/trafficserver/blob/master/mgmt/RecordsConfig.cc#L375), which is same with ATS manual, but it’s also defined as integer if we override it from remap rule(https://github.com/apache/trafficserver/blob/master/src/shared/overridable_txn_vars.cc#L104), and only integer format is supported in the remap plugin due to this code (https://github.com/apache/trafficserver/blob/master/plugins/conf_remap/conf_remap.cc#L98).

We discussed it in the slack channel, to make things consistency, we’re planning changing the override type for this config to string, and only string format would be used in remap rule.