### PR TITLE
Clear handling tracked events of Http2Stream

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -79,9 +79,11 @@ Http2Stream::main_event_handler(int event, void *edata)
   Event *e = static_cast<Event *>(edata);
   reentrancy_count++;
   if (e == _read_vio_event) {
+    _read_vio_event = nullptr;
     this->signal_read_event(e->callback_event);
     return 0;
   } else if (e == _write_vio_event) {
+    _write_vio_event = nullptr;
     this->signal_write_event(e->callback_event);
     return 0;
   } else if (e == cross_thread_event) {
@@ -874,12 +876,13 @@ Http2Stream::clear_io_events()
 {
   if (read_event) {
     read_event->cancel();
+    read_event = nullptr;
   }
-  read_event = nullptr;
+
   if (write_event) {
     write_event->cancel();
+    write_event = nullptr;
   }
-  write_event = nullptr;
 
   if (buffer_full_write_event) {
     buffer_full_write_event->cancel();


### PR DESCRIPTION
We faced some crashes on canceling events of Http2Stream on 8.1.x branch.

## crash 1
```
(gdb) bt
#0  0x00007f70fd4d2199 in waitpid () from /lib64/libpthread.so.0
#1  0x000055f06daffe74 in crash_logger_invoke(int, siginfo_t*, void*) (signo=11, info=0x7f70f250aa70, ctx=0x7f70f250a940) at traffic_server/Crash.cc:165
#2  <signal handler called>
#3  0x00007f70d6a13a00 in ?? ()
#4  0x000055f06dbc791c in clear_inactive_timer (this=0x7f68464d68a0) at Http2Stream.cc:878
#5  clear_timers (this=0x7f68464d68a0) at Http2Stream.cc:895
#6  Http2Stream::initiating_close() (this=0x7f68464d68a0) at Http2Stream.cc:436
#7  0x000055f06dbbd972 in Http2ConnectionState::delete_stream(Http2Stream*) (this=0x7f49eab7d7d0, stream=0x7f68464d68a0) at Http2ConnectionState.cc:1371
#8  0x000055f06dbbea72 in Http2ConnectionState::send_data_frames(Http2Stream*) (this=0x7f49eab7d7d0, stream=0x7f68464d68a0) at Http2ConnectionState.cc:1580 (<- stream state: closed)
...
(gdb) frame 4
#4  0x000055f06dbc791c in clear_inactive_timer (this=0x7f68464d68a0) at Http2Stream.cc:878
878         inactive_event->cancel();
```

## crash 2
```
(gdb) bt
#0  0x00007f10ca1f4199 in waitpid () from /lib64/libpthread.so.0
#1  0x000055950ad4fe74 in crash_logger_invoke(int, siginfo_t, void) (signo=11, info=0x7f10bfb099b0, ctx=0x7f10bfb09880) at traffic_server/Crash.cc:165
#2  <signal handler called>
#3  0x00007f0f88544c60 in ?? ()
#4  0x000055950ae179b2 in clear_io_events (this=0x7f0e297a5670) at Http2Stream.cc:917
#5  Http2Stream::initiating_close() (this=0x7f0e297a5670) at Http2Stream.cc:437
#6  0x000055950ae0d972 in Http2ConnectionState::delete_stream(Http2Stream) (this=0x7f0fd51062d0, stream=0x7f0e297a5670) at Http2ConnectionState.cc:1371
#7  0x000055950ae0ea72 in Http2ConnectionState::send_data_frames(Http2Stream) (this=0x7f0fd51062d0, stream=0x7f0e297a5670) at Http2ConnectionState.cc:1580
...
(gdb) frame 4
#4  0x000055950ae179b2 in clear_io_events (this=0x7f0e297a5670) at Http2Stream.cc:917
917         this->_read_vio_event->cancel();
```

Some tracked events are not set `nullptr` when Http2Stream handles them. This leads Http2Stream to cancel invalid events on shutdown.

We did some refactorings for these tracked events, so we need to modify this patch for 9.0.x, 8.1.x, and 8.0.x branch.
