### PR TITLE
traffic_dump: debug_tag and lock improvements

### DIFF
--- a/plugins/experimental/traffic_dump/global_variables.h
+++ b/plugins/experimental/traffic_dump/global_variables.h
@@ -20,6 +20,6 @@
 
 namespace traffic_dump
 {
-char const constexpr *const debug_tag = "traffic_dump";
+constexpr char debug_tag[] = "traffic_dump";
 
 } // namespace traffic_dump

--- a/plugins/experimental/traffic_dump/session_data.h
+++ b/plugins/experimental/traffic_dump/session_data.h
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <mutex>
 #include <string_view>
 
 #include "ts/ts.h"
@@ -61,9 +62,12 @@ private:
   /// Whether the first transaction in this session has been written.
   bool has_written_first_transaction = false;
 
-  TSCont aio_cont       = nullptr; /// AIO continuation callback
-  TSCont txn_cont       = nullptr; /// Transaction continuation callback
-  TSMutex disk_io_mutex = nullptr; /// AIO mutex
+  TSCont aio_cont = nullptr; /// AIO continuation callback
+  TSCont txn_cont = nullptr; /// Transaction continuation callback
+
+  // The following has to be recursive because the stack does not unwind
+  // between event invocations.
+  std::recursive_mutex disk_io_mutex; /// The mutex for guarding IO calls.
 
   //
   // Static Variables


### PR DESCRIPTION
These are changes from a set of suggestions that Walt Karas made
internally. Incidentally, these changes to disk_io_mutex likely
addresses a crash we saw for the mutex when it was acccidentally double
freed.