### PR TITLE
Clear handling tracked events of Http2Stream (9.0.x)

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -75,9 +75,11 @@ Http2Stream::main_event_handler(int event, void *edata)
   Event *e = static_cast<Event *>(edata);
   reentrancy_count++;
   if (e == _read_vio_event) {
+    _read_vio_event = nullptr;
     this->signal_read_event(e->callback_event);
     return 0;
   } else if (e == _write_vio_event) {
+    _write_vio_event = nullptr;
     this->signal_write_event(e->callback_event);
     return 0;
   } else if (e == cross_thread_event) {
@@ -86,6 +88,7 @@ Http2Stream::main_event_handler(int event, void *edata)
     event        = VC_EVENT_ACTIVE_TIMEOUT;
     active_event = nullptr;
   } else if (e == inactive_event) {
+    inactive_event = nullptr;
     if (inactive_timeout_at && inactive_timeout_at < Thread::get_hrtime()) {
       event = VC_EVENT_INACTIVITY_TIMEOUT;
       clear_inactive_timer();
@@ -899,12 +902,13 @@ Http2Stream::clear_io_events()
 {
   if (read_event) {
     read_event->cancel();
+    read_event = nullptr;
   }
-  read_event = nullptr;
+
   if (write_event) {
     write_event->cancel();
+    write_event = nullptr;
   }
-  write_event = nullptr;
 
   if (buffer_full_write_event) {
     buffer_full_write_event->cancel();


### PR DESCRIPTION
Backport #6825 to 9.0.x

----

(cherry picked from commit 0b92e7cc3a6df779c4d527e0915adfb7ed936487)

With 9.0.x branch specific change
	modified:   proxy/http2/Http2Stream.cc