### PR TITLE
Change AM_LDFLAGS to be an addition, not an overwrite, in the plugin makefile

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -25,7 +25,7 @@ pkglib_LTLIBRARIES =
 
 SUBDIRS =
 
-AM_LDFLAGS = $(TS_PLUGIN_LD_FLAGS)
+AM_LDFLAGS += $(TS_PLUGIN_LD_FLAGS)
 
 include authproxy/Makefile.inc
 include background_fetch/Makefile.inc


### PR DESCRIPTION
This allows the various libpaths, and specifically the rpath, to be transferred over to plugins when used for tests.  Currently separate test applications will build properly against things like a custom openssl installation, however when they run they do not know the correct location unless you have set the LD path on the system to include that directory.  Passing this information around allows the ATS library rpath to also be used for the test applications so they can determine at runtime where to look for libraries

Closes #5757 