### PR TITLE
Generalize KA check logic

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7003,10 +7003,8 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
     // unless we are going to use chunked encoding on HTTP/1.1 or the client issued a PUSH request
     if (s->client_info.keep_alive != HTTP_KEEPALIVE) {
       ka_action = KA_DISABLED;
-    } else if (s->state_machine->client_protocol && (IP_PROTO_TAG_HTTP_3.compare(s->state_machine->client_protocol) == 0 ||
-                                                     strncmp(s->state_machine->client_protocol, "http/2", 6) == 0)) {
-      ka_action = KA_CONNECTION;
-    } else if (s->hdr_info.trust_response_cl == false &&
+    } else if (s->hdr_info.trust_response_cl == false && s->state_machine->ua_txn &&
+               s->state_machine->ua_txn->is_chunked_encoding_supported() &&
                !(s->client_info.receive_chunked_response == true ||
                  (s->method == HTTP_WKSIDX_PUSH && s->client_info.keep_alive == HTTP_KEEPALIVE))) {
       ka_action = KA_CLOSE;


### PR DESCRIPTION
Since the logic is for chunked encoding, we should be able to check the availability instead of protocol names. This enables us to not maintain the protocol list here that don't use chunked encoding.

Without this change, we'd need to check every protocol names that don't support chunked encoding such as http/2, h3, h3-27, h3-28, etc. by costly string comparison.