### PR TITLE
Issue 6838 Fixing the comparison in waited_enough (drain functionality)

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -381,8 +381,11 @@ Thread Variables
    :reloadable:
 
    The shutdown timeout(in seconds) to apply when stopping Traffic
-   Server, in which ATS can initiate graceful shutdowns. It only supports
-   HTTP/2 graceful shutdown for now. Stopping |TS| here means sending
+   Server, in which ATS can initiate graceful shutdowns. In order
+   to effect graceful shutdown, the value specified should be greater
+   than 0. Value of 0 will not effect an abrupt shutdown. Abrupt
+   shutdowns can be achieved with out specifying --drain;
+   (traffic_ctl server stop /restart). Stopping |TS| here means sending
    `traffic_server` a signal either by `bin/trafficserver stop` or `kill`.
 
 .. ts:cv:: CONFIG proxy.config.thread.max_heartbeat_mseconds INT 60

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -198,7 +198,7 @@ waited_enough()
     return false;
   }
 
-  return (lmgmt->mgmt_shutdown_triggered_at + timeout >= time(nullptr));
+  return (timeout ? (lmgmt->mgmt_shutdown_triggered_at + timeout <= time(nullptr)) : false);
 }
 
 static void


### PR DESCRIPTION
@sudheerv 
[Issue](https://github.com/apache/trafficserver/issues/6838)
Test cases:
1. Noticed drain works when CONFIG proxy.config.stop.shutdown_timeout is set to 0 and with values greater than zero

