### PR TITLE
Traffic Dump: Add server response HTTP version

### DIFF
--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -157,7 +157,7 @@
         "version": {
           "description": "HTTP version",
           "type": "string",
-          "enum": ["0.9", "1.0", "1.1"]
+          "enum": ["0.9", "1.0", "1.1", "2.0"]
         },
         "scheme": {
           "description": "HTTP scheme (request).",
@@ -187,6 +187,11 @@
       "type": "object",
       "required": ["status"],
       "properties": {
+        "version": {
+          "description": "HTTP version",
+          "type": "string",
+          "enum": ["0.9", "1.0", "1.1", "2.0"]
+        },
         "status": {
           "description": "Status code.",
           "type": "number"


### PR DESCRIPTION
@shinrich pointed out that it would be helpful to print the server response HTTP version like we do for requests.