### PR TITLE
Make format specifier for time_t portable

### DIFF
--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -479,7 +479,8 @@ handle_cache_lookup_complete(TSHttpTxn txnp, txndata *const txn_state)
   if (TS_SUCCESS == TSHttpTxnCacheLookupStatusGet(txnp, &cachestat)) {
     if (TS_CACHE_LOOKUP_HIT_FRESH == cachestat) {
       time_t const ch_time = get_date_from_cached_hdr(txnp);
-      DEBUG_LOG("IMS Cached header time %" PRId64 " vs IMS %" PRId64, ch_time, txn_state->ims_time);
+      DEBUG_LOG("IMS Cached header time %jd vs IMS %jd", static_cast<intmax_t>(ch_time),
+                static_cast<intmax_t>(txn_state->ims_time));
       if (ch_time < txn_state->ims_time) {
         TSHttpTxnCacheLookupStatusSet(txnp, TS_CACHE_LOOKUP_HIT_STALE);
         if (TSIsDebugTagSet(PLUGIN_NAME)) {

--- a/plugins/experimental/slice/HttpHeader.cc
+++ b/plugins/experimental/slice/HttpHeader.cc
@@ -276,7 +276,7 @@ HttpHeader::setKeyTime(char const *const keystr, int const keylen, time_t const 
     if (TS_SUCCESS == TSMimeHdrFieldValueDateSet(m_buffer, m_lochdr, locfield, timeval)) {
       if (TS_SUCCESS == TSMimeHdrFieldAppend(m_buffer, m_lochdr, locfield)) {
         status = true;
-        DEBUG_LOG("Set header %.*s to %" PRId64, keylen, keystr, timeval);
+        DEBUG_LOG("Set header %.*s to %jd", keylen, keystr, static_cast<intmax_t>(timeval));
       }
     }
     TSHandleMLocRelease(m_buffer, m_lochdr, locfield);

--- a/plugins/experimental/slice/server.cc
+++ b/plugins/experimental/slice/server.cc
@@ -332,12 +332,12 @@ logSliceError(char const *const message, Data const *const data, HttpHeader cons
             " status_got=\"%d\""
             " cr_got=\"%.*s\""
             " etag_got=\"%.*s\""
-            " lm_got=\"%" PRId64 "\""
+            " lm_got=\"%jd\""
             " cc=\"%.*s\""
             " via=\"%.*s\"  - attempting to recover",
             secs, ms, message, (int)urlplen, urlpstr, uaslen, uasstr, rangelen, rangestr, normlen, normstr, (int)etagexplen,
             etagexpstr, data->m_lastmodifiedlen, data->m_lastmodified, blockbeg, blockend - 1, statusgot, crlen, crstr,
-            (int)etaggotlen, etaggotstr, lmgot, cclen, ccstr, vialen, viastr);
+            (int)etaggotlen, etaggotstr, static_cast<intmax_t>(lmgot), cclen, ccstr, vialen, viastr);
 }
 
 bool
@@ -426,7 +426,7 @@ handleNextServerHeader(Data *const data, TSCont const contp)
       // Ask for any slice newer than the cached one
       time_t const dateims = date + 1;
 
-      DEBUG_LOG("Attempting to reissue interior slice block request with IMS header time: %" PRId64, dateims);
+      DEBUG_LOG("Attempting to reissue interior slice block request with IMS header time: %jd", static_cast<intmax_t>(dateims));
 
       // add special CRR IMS header to the request
       HttpHeader headerreq(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);
@@ -448,7 +448,7 @@ handleNextServerHeader(Data *const data, TSCont const contp)
       // Ask for any slice newer than the cached one
       time_t const dateims = date + 1;
 
-      DEBUG_LOG("Attempting to reissue reference slice block request with IMS header time: %" PRId64, dateims);
+      DEBUG_LOG("Attempting to reissue reference slice block request with IMS header time: %jd", static_cast<intmax_t>(dateims));
 
       // add special CRR IMS header to the request
       HttpHeader headerreq(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);


### PR DESCRIPTION
PRId64 doesn't work for time_t on macOS.

This page uses "%jd", and it works for me.
https://en.cppreference.com/w/c/chrono/time_t