### PR TITLE
Fix a crash on TLS resumption

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -302,7 +302,12 @@ public:
     if (!ssl) {
       return nullptr;
     }
-    ssl_curve_id curve = getSSLCurveNID();
+    ssl_curve_id curve;
+    if (getSSLSessionCacheHit()) {
+      curve = getSSLCurveNID();
+    } else {
+      curve = SSLGetCurveNID(ssl);
+    }
 #ifndef OPENSSL_IS_BORINGSSL
     if (curve == NID_undef) {
       return nullptr;

--- a/iocore/net/TLSSessionResumptionSupport.cc
+++ b/iocore/net/TLSSessionResumptionSupport.cc
@@ -199,7 +199,6 @@ TLSSessionResumptionSupport::_getSessionInformation(ssl_ticket_key_block *keyblo
       }
 
       this->_setSSLSessionCacheHit(true);
-      this->_setSSLCurveNID(SSLGetCurveNID(ssl));
 
 #ifdef TLS1_3_VERSION
       if (SSL_version(ssl) >= TLS1_3_VERSION) {


### PR DESCRIPTION
A possible fix for the crash on TLS resumption.

The crash seems to be caused by a small change made on ##6736. On the PR, I added `this->_setSSLCurveNID(SSLGetCurveNID(ssl));` after a call for `_setSSLSessionCacheHit` for consistency, but I realized it doesn't make sense in `_getSessionInformation`.

So I removed the line and added a code similar to `fetch_ssl_curve`, which was removed on #6736.

 I couldn't reproduce the crash by myself and CI tests don't catch the crash somehow, so please ran this locally if you can reproduce the crash.