### PR TITLE
Fix brotli plugin

### DIFF
--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -24,6 +24,8 @@
 #include <cstring>
 #include <zlib.h>
 
+#include "ink_autoconf.h"
+
 #if HAVE_BROTLI_ENCODE_H
 #include <brotli/encode.h>
 #endif

--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#include "ink_autoconf.h"
 #include "configuration.h"
 #include <fstream>
 #include <algorithm>


### PR DESCRIPTION
Seems that HAVE_BROTLI_ENCODE_H was not available to the compress plugin even when brotli was compiled in causing compress autest failure.