### PR TITLE
Issue #6864 - Fix crash due to invalid iterator

### DIFF
--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -155,11 +155,11 @@ ServerSessionPool::acquireSession(sockaddr const *addr, CryptoHash const &hostna
     // Not fixed on FreeBSD as of llvm 6.0.1.
     std::tie(first, last) = static_cast<const decltype(m_fqdn_pool)::range::super_type &>(m_fqdn_pool.equal_range(hostname_hash));
     while (last != first) {
-      --last;
-      if (port == ats_ip_port_cast(last->get_server_ip()) &&
-          (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_SNI) || validate_sni(sm, last->get_netvc())) &&
-          (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTSNISYNC) || validate_host_sni(sm, last->get_netvc())) &&
-          (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_CERT) || validate_cert(sm, last->get_netvc()))) {
+      Http1ServerSession *curr = --last;
+      if (curr && (port == ats_ip_port_cast(curr->get_server_ip())) &&
+          (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_SNI) || validate_sni(sm, curr->get_netvc())) &&
+          (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTSNISYNC) || validate_host_sni(sm, curr->get_netvc())) &&
+          (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_CERT) || validate_cert(sm, curr->get_netvc()))) {
         zret = HSM_DONE;
         break;
       }
@@ -179,11 +179,11 @@ ServerSessionPool::acquireSession(sockaddr const *addr, CryptoHash const &hostna
     // Note the port is matched as part of the address key so it doesn't need to be checked again.
     if (match_style & (~TS_SERVER_SESSION_SHARING_MATCH_MASK_IP)) {
       while (last != first) {
-        --last;
-        if ((!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTONLY) || last->hostname_hash == hostname_hash) &&
-            (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_SNI) || validate_sni(sm, last->get_netvc())) &&
-            (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTSNISYNC) || validate_host_sni(sm, last->get_netvc())) &&
-            (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_CERT) || validate_cert(sm, last->get_netvc()))) {
+        Http1ServerSession *curr = --last;
+        if (curr && (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTONLY) || curr->hostname_hash == hostname_hash) &&
+            (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_SNI) || validate_sni(sm, curr->get_netvc())) &&
+            (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTSNISYNC) || validate_host_sni(sm, curr->get_netvc())) &&
+            (!(match_style & TS_SERVER_SESSION_SHARING_MATCH_MASK_CERT) || validate_cert(sm, curr->get_netvc()))) {
           zret = HSM_DONE;
           break;
         }


### PR DESCRIPTION
Fix for https://github.com/apache/trafficserver/issues/6864

```
gdb) bt
#0  0x00002b56037ac06f in _Unwind_IteratePhdrCallback (info=<optimized out>, size=<optimized out>, ptr=0x2b560a0fe380) at ../.././libgcc/unwind-dw2-fde-dip.c:398
#1  0x00002b5603aed42c in dl_iterate_phdr () from /lib64/libc.so.6
#2  0x00002b56037ac501 in _Unwind_Find_FDE (pc=0x2b562b119c90 <HostOverridePostRemapPlugin::handleReadRequestHeadersPostRemap(atscppapi::Transaction&)+124>, bases=bases@entry=0x2b560a0fe508) at ../.././libgcc/unwind-dw2-fde-dip.c:469
#3  0x00002b56037a8a43 in uw_frame_state_for (context=context@entry=0x2b560a0fe460, fs=fs@entry=0x2b560a0fe550) at ../.././libgcc/unwind-dw2.c:1249
#4  0x00002b56037aa988 in _Unwind_Backtrace (trace=0x2b5603ac4da0 <backtrace_helper>, trace_argument=0x2b560a0fe710) at ../.././libgcc/unwind.inc:290
#5  0x00002b5603ac4f16 in backtrace () from /lib64/libc.so.6
#6  0x00002b56010afa43 in ink_stack_trace_dump () at ink_stack_trace.cc:63
#7  0x00002b56010c48b3 in signal_crash_handler (signo=signo@entry=11) at signals.cc:180
#8  0x00000000004c3dde in crash_logger_invoke (signo=11, info=0x2b560a0fecb0, ctx=0x2b560a0feb80) at traffic_server/Crash.cc:173
#9  <signal handler called>
#10 Http1ServerSession::get_server_ip (this=this@entry=0x0) at Http1ServerSession.cc:223
#11 0x000000000056108c in ServerSessionPool::acquireSession (this=0x2b56048ac900, addr=addr@entry=0x2b56a6912410, hostname_hash=..., match_style=match_style@entry=TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTONLY, sm=sm@entry=0x2b56a6911ce0, to_return=@0x2b560a0ff910: 0x0) at HttpSessionManager.cc:159
#12 0x00000000005618d1 in HttpSessionManager::acquire_session (this=0xacdee0 <httpSessionManager>, ip=0x2b56a6912410, hostname=0x2b5614a03019 "lva1-app52756.prod.linkedin.com", ua_txn=<optimized out>, sm=sm@entry=0x2b56a6911ce0) at HttpSessionManager.cc:398
#13 0x00000000005540cc in HttpSM::do_http_server_open (this=this@entry=0x2b56a6911ce0, raw=raw@entry=false) at HttpSM.cc:5029
#14 0x0000000000556d60 in HttpSM::set_next_state (this=0x2b56a6911ce0) at HttpSM.cc:7559
#15 0x0000000000541302 in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2b56a6911ce0, f=f@entry=0x0) at HttpSM.cc:7362
#16 0x0000000000551c9a in HttpSM::handle_api_return (this=0x2b56a6911ce0) at HttpSM.cc:1634
#17 0x000000000054d7ee in HttpSM::state_api_callout (this=0x2b56a6911ce0, event=<optimized out>, data=<optimized out>) at HttpSM.cc:1566
#18 0x0000000000556d73 in HttpSM::set_next_state (this=0x2b56a6911ce0) at HttpSM.cc:7396
#19 0x0000000000541302 in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2b56a6911ce0, f=f@entry=0x0) at HttpSM.cc:7362
#20 0x0000000000551c9a in HttpSM::handle_api_return (this=0x2b56a6911ce0) at HttpSM.cc:1634
#21 0x000000000054d7ee in HttpSM::state_api_callout (this=0x2b56a6911ce0, event=<optimized out>, data=<optimized out>) at HttpSM.cc:1566
#22 0x0000000000556d73 in HttpSM::set_next_state (this=0x2b56a6911ce0) at HttpSM.cc:7396
#23 0x0000000000541302 in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2b56a6911ce0, f=f@entry=0x0) at HttpSM.cc:7362
#24 0x0000000000543d3a in HttpSM::do_hostdb_lookup (this=this@entry=0x2b56a6911ce0) at HttpSM.cc:4252
#25 0x0000000000556e1a in HttpSM::set_next_state (this=0x2b56a6911ce0) at HttpSM.cc:7712
#26 0x0000000000541302 in HttpSM::call_transact_and_set_next_state (this=this@entry=0x2b56a6911ce0, f=f@entry=0x0) at HttpSM.cc:7362
#27 0x0000000000551c9a in HttpSM::handle_api_return (this=0x2b56a6911ce0) at HttpSM.cc:1634
#28 0x000000000054d7ee in HttpSM::state_api_callout (this=this@entry=0x2b56a6911ce0, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1566
#29 0x0000000000550a34 in HttpSM::state_api_callback (this=this@entry=0x2b56a6911ce0, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1366
#30 0x00000000004eba3a in TSHttpTxnReenable (txnp=0x2b56a6911ce0, event=TS_EVENT_HTTP_CONTINUE) at traffic_server/InkAPI.cc:6096
#31 0x00002b562b119c91 in HostOverridePostRemapPlugin::handleReadRequestHeadersPostRemap (this=0x2b56193fffd0, transaction=...) at host_override.cpp:189
#32 0x00002b561ac22ea8 in invokePluginForEvent (event=TS_EVENT_HTTP_POST_REMAP, ats_txn_handle=0x2b56a6911ce0, plugin=0x2b56193fffd0) at utils_internal.cc:156
#33 atscppapi::utils::internal::invokePluginForEvent (plugin=plugin@entry=0x2b56193fffd0, ats_txn_handle=ats_txn_handle@entry=0x2b56a6911ce0, event=event@entry=TS_EVENT_HTTP_POST_REMAP) at utils_internal.cc:247
#34 0x00002b561ac1f2f5 in (anonymous namespace)::handleTransactionPluginEvents (cont=0x2b56bf5d13c0, event=TS_EVENT_HTTP_POST_REMAP, edata=0x2b56a6911ce0) at TransactionPlugin.cc:53
#35 0x00000000004d7231 in INKContInternal::handle_event (this=0x2b56bf5d13c0, event=60017, edata=0x2b56a6911ce0) at traffic_server/InkAPI.cc:1096
#36 0x00000000004ef7e6 in Continuation::handleEvent (this=0x2b56bf5d13c0, event=event@entry=60017, data=data@entry=0x2b56a6911ce0) at /home/svinukon/Traffic/ATS/ats9/ats-core_trunk/ats9/src/iocore/eventsystem/I_Continuation.h:193
#37 0x00000000004e9517 in APIHook::invoke (this=this@entry=0x2b560c2179a0, event=60017, edata=edata@entry=0x2b56a6911ce0) at traffic_server/InkAPI.cc:1333
#38 0x000000000054d2b7 in HttpSM::state_api_callout (this=this@entry=0x2b56a6911ce0, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1499
#39 0x0000000000550a34 in HttpSM::state_api_callback (this=this@entry=0x2b56a6911ce0, event=event@entry=60000, data=data@entry=0x0) at HttpSM.cc:1366
#40 0x00000000004eba3a in TSHttpTxnReenable (txnp=txnp@entry=0x2b56a6911ce0, event=event@entry=TS_EVENT_HTTP_CONTINUE) at traffic_server/InkAPI.cc:6096
#41 0x00002b563cca6cd9 in TxnOpenCloseHandler (contp=<optimized out>, event=<optimized out>, edata=0x2b56a6911ce0) at adaptor.cc:1697
#42 0x00000000004d7231 in INKContInternal::handle_event (this=0x2b5636fc9840, event=60017, edata=0x2b56a6911ce0) at traffic_server/InkAPI.cc:1096
#43 0x00000000004ef7e6 in Continuation::handleEvent (this=0x2b5636fc9840, event=event@entry=60017, data=data@entry=0x2b56a6911ce0) at /home/svinukon/Traffic/ATS/ats9/ats-core_trunk/ats9/src/iocore/eventsystem/I_Continuation.h:193
#44 0x00000000004e9517 in APIHook::invoke (this=this@entry=0x2b5604d75ae0, event=60017, edata=edata@entry=0x2b56a6911ce0) at traffic_server/InkAPI.cc:1333

(gdb) f 11
#11 0x000000000056108c in ServerSessionPool::acquireSession (this=0x2b56048ac900, addr=addr@entry=0x2b56a6912410, hostname_hash=..., match_style=match_style@entry=TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTONLY, sm=sm@entry=0x2b56a6911ce0, to_return=@0x2b560a0ff910: 0x0) at HttpSessionManager.cc:159
159     HttpSessionManager.cc: No such file or directory.
(gdb) up
#12 0x00000000005618d1 in HttpSessionManager::acquire_session (this=0xacdee0 <httpSessionManager>, ip=0x2b56a6912410, hostname=0x2b5614a03019 "lva1-app52756.prod.linkedin.com", ua_txn=<optimized out>, sm=sm@entry=0x2b56a6911ce0) at HttpSessionManager.cc:398
398     in HttpSessionManager.cc
(gdb) p last
No symbol "last" in current context.
(gdb) down
#11 0x000000000056108c in ServerSessionPool::acquireSession (this=0x2b56048ac900, addr=addr@entry=0x2b56a6912410, hostname_hash=..., match_style=match_style@entry=TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTONLY, sm=sm@entry=0x2b56a6911ce0, to_return=@0x2b560a0ff910: 0x0) at HttpSessionManager.cc:159
159     in HttpSessionManager.cc
(gdb) p last
$1 = {<ts::IntrusiveDList<Http1ServerSession::FQDNLinkage>::const_iterator> = {_list = 0x2b56048ac998, _v = 0x0}, <No data fields>}
(gdb) p first


```