### PR TITLE
Protect against nullptr access during SSL Callback

### DIFF
--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -53,7 +53,7 @@ verify_callback(int signature_ok, X509_STORE_CTX *ctx)
   // No enforcing, go away
   if (netvc == nullptr) {
     // No netvc, very bad.  Go away.  Things are not good.
-    Warning("Netvc gone by in verify_callback");
+    SSLDebug("WARN, Netvc gone by in verify_callback");
     return false;
   } else if (netvc->options.verifyServerPolicy == YamlSNIConfig::Policy::DISABLED) {
     return true; // Tell them that all is well

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1019,7 +1019,7 @@ ssl_callback_info(const SSL *ssl, int where, int ret)
 
   SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
 
-  if ((where & SSL_CB_ACCEPT_LOOP) && netvc->getSSLHandShakeComplete() == true &&
+  if (netvc && (where & SSL_CB_ACCEPT_LOOP) && netvc->getSSLHandShakeComplete() == true &&
       SSLConfigParams::ssl_allow_client_renegotiation == false) {
     int state = SSL_get_state(ssl);
 


### PR DESCRIPTION

```
(gdb) thr 14
[Switching to thread 14 (Thread 0x2b52c6305700 (LWP 19308))]
#0  0x00002b52bf77106f in _Unwind_IteratePhdrCallback (info=<optimized out>, size=<optimized out>, ptr=0x2b52c6302e00) at ../.././libgcc/unwind-dw2-fde-dip.c:398
398     ../.././libgcc/unwind-dw2-fde-dip.c: No such file or directory.

(gdb) bt
#0  0x00002b52bf77106f in _Unwind_IteratePhdrCallback (info=<optimized out>, size=<optimized out>, ptr=0x2b52c6302e00) at ../.././libgcc/unwind-dw2-fde-dip.c:398
#1  0x00002b52bfab242c in dl_iterate_phdr () from /lib64/libc.so.6
#2  0x00002b52bf771501 in _Unwind_Find_FDE (pc=0x2b52be040700 <state_machine+2128>, bases=bases@entry=0x2b52c6302f88) at ../.././libgcc/unwind-dw2-fde-dip.c:469
#3  0x00002b52bf76da43 in uw_frame_state_for (context=context@entry=0x2b52c6302ee0, fs=fs@entry=0x2b52c6302fd0) at ../.././libgcc/unwind-dw2.c:1249
#4  0x00002b52bf76f988 in _Unwind_Backtrace (trace=0x2b52bfa89da0 <backtrace_helper>, trace_argument=0x2b52c6303190) at ../.././libgcc/unwind.inc:290
#5  0x00002b52bfa89f16 in backtrace () from /lib64/libc.so.6
#6  0x00002b52bd074a43 in ink_stack_trace_dump () at ink_stack_trace.cc:63
#7  0x00002b52bd0898b3 in signal_crash_handler (signo=signo@entry=11) at signals.cc:180
#8  0x00000000004c3dde in crash_logger_invoke (signo=11, info=0x2b52c6303730, ctx=0x2b52c6303600) at traffic_server/Crash.cc:173
#9  <signal handler called>
#10 ssl_callback_info (ssl=0x2b5375fe3000, where=8193, ret=<optimized out>) at SSLUtils.cc:1073
#11 0x00002b52be040701 in state_machine () from /lib/libssl.so.1.1
#12 0x00002b52be02b878 in SSL_do_handshake () from /lib/libssl.so.1.1
#13 0x00000000007518ad in SSLAccept (ssl=0x2b5375fe3000) at SSLUtils.cc:1889
#14 0x000000000073eb46 in SSLNetVConnection::sslServerHandShakeEvent (this=this@entry=0x2b5359351100, err=@0x2b52c6304a90: 0) at SSLNetVConnection.cc:1238
#15 0x0000000000740e41 in SSLNetVConnection::sslStartHandShake (this=0x2b5359351100, event=<optimized out>, err=@0x2b52c6304a90: 0) at SSLNetVConnection.cc:1052
#16 0x000000000073f993 in SSLNetVConnection::net_read_io (this=0x2b5359351100, nh=0x2b52c2223d80, lthread=0x2b52c2220000) at SSLNetVConnection.cc:564
#17 0x000000000075ec38 in NetHandler::process_ready_list (this=this@entry=0x2b52c2223d80) at UnixNet.cc:412
#18 0x000000000075ef2d in NetHandler::waitForActivity (this=0x2b52c2223d80, timeout=<optimized out>) at UnixNet.cc:547
#19 0x00000000007bc9da in EThread::execute_regular (this=this@entry=0x2b52c2220000) at UnixEThread.cc:266
#20 0x00000000007bcc62 in EThread::execute (this=0x2b52c2220000) at UnixEThread.cc:327
#21 0x00000000007bafb9 in spawn_thread_internal (a=0x2b52c0d63800) at Thread.cc:92
#22 0x00002b52becc2dd5 in start_thread () from /lib64/libpthread.so.0
#23 0x00002b52bfa73ead in clone () from /lib64/libc.so.6
(gdb) f 10
#10 ssl_callback_info (ssl=0x2b5375fe3000, where=8193, ret=<optimized out>) at SSLUtils.cc:1073
1073    SSLUtils.cc: No such file or directory.
(gdb) p netvc
$54 = <optimized out>
(gdb) p ret
$55 = <optimized out>
(gdb) p where
$56 = 8193
```

```
(gdb) thr 85
[Switching to thread 85 (Thread 0x2b3cc4d05700 (LWP 30971))]
#0  0x00002b3cb77dc660 in _dl_addr () from /lib64/libc.so.6
(gdb) bt
#0  0x00002b3cb77dc660 in _dl_addr () from /lib64/libc.so.6
#1  0x00002b3cb77b4585 in backtrace_symbols_fd () from /lib64/libc.so.6
#2  0x00002b3cb4d9ea59 in ink_stack_trace_dump () at ink_stack_trace.cc:65
#3  0x00002b3cb4db38b3 in signal_crash_handler (signo=signo@entry=11) at signals.cc:180
#4  0x00000000004c3f6e in crash_logger_invoke (signo=11, info=0x2b3cc4d02230, ctx=0x2b3cc4d02100) at traffic_server/Crash.cc:173
#5  <signal handler called>
#6  0x00002b3cb4d7c5b1 in write (sv=..., this=<optimized out>) at ../../include/tscore/BufferWriter.h:92
#7  operator() (__closure=<optimized out>) at BufferWriterFormat.cc:479
#8  Write_Aligned<ts::bw_fmt::Format_Integer(ts::BufferWriter&, const ts::BWFSpec&, uintmax_t, bool)::<lambda()> > (neg=<optimized out>, fill=<optimized out>, width=<optimized out>, align=<optimized out>, f=..., w=...) at BufferWriterFormat.cc:396
#9  ts::bw_fmt::Format_Integer (w=..., spec=..., i=<optimized out>, neg_p=<optimized out>) at BufferWriterFormat.cc:470
#10 0x00002b3cb4d7ed32 in printv<long&> (args=..., fmt=..., this=0x2b3cc4d02f80) at ../../include/tscore/BufferWriter.h:649
#11 print<long> (fmt=..., this=0x2b3cc4d02f80) at ../../include/tscore/BufferWriter.h:884
#12 (anonymous namespace)::BWF_Timestamp (w=..., spec=...) at BufferWriterFormat.cc:987
#13 0x00002b3cb4d82fd8 in printv<> (args=..., fmt=..., this=0x2b3cc4d03130) at ../../include/tscore/BufferWriter.h:657
#14 print<> (fmt=..., this=0x2b3cc4d03130) at ../../include/tscore/BufferWriter.h:884
#15 Diags::print_va (this=this@entry=0x2b3cb88bb780, debug_tag=<optimized out>, debug_tag@entry=0x0, diags_level=diags_level@entry=DL_Warning, loc=0x2b3cc4d03f10, format_string=<optimized out>, format_string@entry=0x822a40 "Netvc gone by in verify_callback", ap=ap@entry=0x2b3cc4d03de8) at Diags.cc:224
#16 0x00002b3cb4d83677 in Diags::error_va (this=0x2b3cb88bb780, level=DL_Warning, loc=<optimized out>, format_string=0x822a40 "Netvc gone by in verify_callback", ap=0x2b3cc4d03de8) at Diags.cc:463
#17 0x00000000004c413e in Diags::error (this=<optimized out>, level=level@entry=DL_Warning, loc=loc@entry=0x2b3cc4d03f10, fmt=fmt@entry=0x822a40 "Netvc gone by in verify_callback") at ../include/tscore/Diags.h:207
#18 0x00000000007331ad in verify_callback (signature_ok=1, ctx=0x2b3cc70b4900) at SSLClientUtils.cc:56
#19 0x00002b3cb61b7b28 in internal_verify () from /lib/libcrypto.so.1.1
#20 0x00002b3cb61b99ec in verify_chain () from /lib/libcrypto.so.1.1
#21 0x00002b3cb61ba158 in X509_verify_cert () from /lib/libcrypto.so.1.1
#22 0x00002b3cb5d4b2f8 in ssl_verify_cert_chain () from /lib/libssl.so.1.1
#23 0x00002b3cb5d6e1b6 in tls_process_server_certificate () from /lib/libssl.so.1.1
#24 0x00002b3cb5d707f5 in ossl_statem_client_process_message () from /lib/libssl.so.1.1
#25 0x00002b3cb5d6a685 in state_machine () from /lib/libssl.so.1.1
#26 0x00002b3cb5d55878 in SSL_do_handshake () from /lib/libssl.so.1.1
#27 0x0000000000751dad in SSLConnect (ssl=0x2b3d18264000) at SSLUtils.cc:1910
#28 0x000000000073e31b in SSLNetVConnection::sslClientHandShakeEvent (this=this@entry=0x2b3d37174f10, err=@0x2b3cc4d04a90: 0) at SSLNetVConnection.cc:1425
#29 0x00000000007414ed in SSLNetVConnection::sslStartHandShake (this=0x2b3d37174f10, event=<optimized out>, err=@0x2b3cc4d04a90: 0) at SSLNetVConnection.cc:1145
#30 0x0000000000740294 in SSLNetVConnection::net_read_io (this=0x2b3d37174f10, nh=0x2b3cbbc09d80, lthread=0x2b3cbbc06000) at SSLNetVConnection.cc:562
#31 0x000000000075f008 in NetHandler::process_ready_list (this=this@entry=0x2b3cbbc09d80) at UnixNet.cc:412
#32 0x000000000075f2fd in NetHandler::waitForActivity (this=0x2b3cbbc09d80, timeout=<optimized out>) at UnixNet.cc:547
#33 0x00000000007c285a in EThread::execute_regular (this=this@entry=0x2b3cbbc06000) at UnixEThread.cc:266
#34 0x00000000007c2ac2 in EThread::execute (this=0x2b3cbbc06000) at UnixEThread.cc:327
#35 0x00000000007c0e49 in spawn_thread_internal (a=0x2b3cb8d63d80) at Thread.cc:92
#36 0x00002b3cb69ecdd5 in start_thread () from /lib64/libpthread.so.0
#37 0x00002b3cb779dead in clone () from /lib64/libc.so.6

```