### PR TITLE
Fix pointer overflow in XPACK (8.0.x)

### DIFF
--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -704,7 +704,7 @@ decode_string(Arena &arena, char **str, uint32_t &str_length, const uint8_t *buf
   }
   p += len;
 
-  if ((p + encoded_string_len) > buf_end) {
+  if (buf_end < p || static_cast<uint64_t>(buf_end - p) < encoded_string_len) {
     return HPACK_ERROR_COMPRESSION_ERROR;
   }
 


### PR DESCRIPTION
Backport #6854 to 8.0.x branch. ( Unlike 8.1.x, 9.0.x, and master branch, XPACK.cc doesn't exist on this branch yet. )

----

(cherry picked from commit c20125eba5594fcc18305ee14e25e7ce4eb2d4d2)

Conflicts:
	proxy/hdrs/XPACK.cc