### PR TITLE
avoid dynamic_cast for non_internal requests

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -43,10 +43,13 @@ ProxyTransaction::new_transaction(bool from_early_data)
   HttpTxnDebug("[%" PRId64 "] Starting transaction %d using sm [%" PRId64 "]", _proxy_ssn->connection_id(),
                _proxy_ssn->get_transact_count(), _sm->sm_id);
 
-  PluginIdentity *pi = dynamic_cast<PluginIdentity *>(this->get_netvc());
-  if (pi) {
-    _sm->plugin_tag = pi->getPluginTag();
-    _sm->plugin_id  = pi->getPluginId();
+  // PI tag valid only for internal requests
+  if (this->get_netvc()->get_is_internal_request()) {
+    PluginIdentity *pi = dynamic_cast<PluginIdentity *>(this->get_netvc());
+    if (pi) {
+      _sm->plugin_tag = pi->getPluginTag();
+      _sm->plugin_id  = pi->getPluginId();
+    }
   }
 
   this->increment_client_transactions_stat();


### PR DESCRIPTION
…ests

See lots of stack traces spending cycles on dynamic_cast for every request, when in reality, it's no longer needed as `Http2ClientSession` which used to inherit `PluginIdentity` in the past is no longer doing that and the client access protocol for access logs is being extracted directly from the HttpSM context.