### PR TITLE
Make Http2ClientSession inactive on EOS event

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -103,6 +103,9 @@ Http2ClientSession::free()
   REMEMBER(NO_EVENT, this->recursion)
   Http2SsnDebug("session free");
 
+  // Don't free active ProxySession
+  ink_release_assert(is_active() == false);
+
   this->_milestones.mark(Http2SsnMilestone::CLOSE);
   ink_hrtime total_time = this->_milestones.elapsed(Http2SsnMilestone::OPEN, Http2SsnMilestone::CLOSE);
 

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1406,6 +1406,8 @@ Http2ConnectionState::release_stream()
 
     if (total_client_streams_count == 0) {
       if (fini_received) {
+        ua_session->clear_session_active();
+
         // We were shutting down, go ahead and terminate the session
         // this is a member of Http2ConnectionState and will be freed
         // when ua_session is destroyed


### PR DESCRIPTION
Fix #6671 & add a release assert to make sure any active session is not freed.

I could reproduce the issue in my local box with h2spec. It looks like ATS jump in `Http2ConnectionState::release_stream()` with `fini_received = true` & `ua_session->is_active() = true` in error cases. 

As @maskit pointed out on #6729, the issue is introduced by #4936 which was released by 8.0.3. 
It looks like what we should have was moving only the problematic `vc->add_to_keep_alive_queue();` at that time.

## How to reproduce 
```
$ h2spec -h localhost -p 4443 -t -k http2/5.1/7
```

## Backtrace
```
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2ConnectionState.cc:864 (rcv_continuation_frame)> (http2_con) [18] [1] Received CONTINUATION frame
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2ConnectionState.cc:1874 (send_goaway_frame)> (http2_con) [18] Send GOAWAY frame, last_stream_id: 1
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2ClientSession.cc:324 (set_half_close_local_flag)> (http2_cs) [18] session half-close local
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2ConnectionState.cc:1336 (delete_stream)> (http2_con) [18] [1] Delete stream
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2ConnectionState.cc:1803 (send_rst_stream_frame)> (http2_con) [18] [1] Send RST_STREAM frame
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2Stream.cc:301 (change_state)> (http2_stream) [18] [1] Http2StreamState::HTTP2_STREAM_STATE_CLOSED
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2Stream.cc:425 (initiating_close)> (http2_stream) [18] [1] initiating_close
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2Stream.cc:466 (initiating_close)> (http2_stream) [18] [1] send EOS to read cont
[Jun  9 11:25:06.343] [ET_NET 6] DEBUG: <Http2Stream.cc:765 (destroy)> (http2_stream) [18] [1] Destroy stream, sent 0 bytes
Process 29730 stopped
* thread #8, name = '[ET_NET 6]', stop reason = breakpoint 1.1
    frame #0: 0x000000010012bf43 traffic_server`Http2ConnectionState::release_stream(this=0x00000000090edd48, stream=0x00000000091cf3e0) at Http2ConnectionState.cc:1396:9
   1393         // We were shutting down, go ahead and terminate the session
   1394         // this is a member of Http2ConnectionState and will be freed
   1395         // when ua_session is destroyed
-> 1396         ua_session->destroy();
   1397
   1398         // Can't do this because we just destroyed right here ^,
   1399         // or we can use a local variable to do it.
(lldb) bt
* thread #8, name = '[ET_NET 6]', stop reason = breakpoint 1.1
  * frame #0: 0x000000010012bf43 traffic_server`Http2ConnectionState::release_stream(this=0x00000000090edd48, stream=0x00000000091cf3e0) at Http2ConnectionState.cc:1396:9
    frame #1: 0x000000010013f9e6 traffic_server`Http2Stream::destroy(this=0x00000000091cf3e0) at Http2Stream.cc:784:36
    frame #2: 0x000000010013cb94 traffic_server`Http2Stream::terminate_if_possible(this=0x00000000091cf3e0) at Http2Stream.cc:414:5
    frame #3: 0x000000010013b4cd traffic_server`Http2Stream::main_event_handler(this=0x00000000091cf3e0, event=104, edata=0x0000000009815f00) at Http2Stream.cc:149:3
    frame #4: 0x0000000100008286 traffic_server`Continuation::handleEvent(this=0x00000000091cf3e0, event=104, data=0x0000000009815f00) at I_Continuation.h:160:12
    frame #5: 0x0000000100319b0f traffic_server`EThread::process_event(this=0x0000000002c34000, e=0x0000000009815f00, calling_code=104) at UnixEThread.cc:131:22
    frame #6: 0x0000000100319e7d traffic_server`EThread::process_queue(this=0x0000000002c34000, NegativeQueue=0x0000000004a26f10, ev_count=0x0000000004a26ee0, nq_count=0x0000000004a26ee4) at UnixEThread.cc:170:7
    frame #7: 0x000000010031a386 traffic_server`EThread::execute_regular(this=0x0000000002c34000) at UnixEThread.cc:230:5
    frame #8: 0x000000010031aa65 traffic_server`EThread::execute(this=0x0000000002c34000) at UnixEThread.cc:331:11
    frame #9: 0x0000000100318ce8 traffic_server`spawn_thread_internal(a=0x00000000008220a0) at Thread.cc:85:12
    frame #10: 0x00007fff7198f109 libsystem_pthread.dylib`_pthread_start + 148
    frame #11: 0x00007fff7198ab8b libsystem_pthread.dylib`thread_start + 15
(lldb) p ua_session->is_active()
(bool) $0 = true
```