### PR TITLE
Add new API / TSPluginDSOReloadEnable to override  DSO remap dynamic reload.

### DIFF
--- a/doc/developer-guide/api/functions/TSPluginDSOReloadEnable.en.rst
+++ b/doc/developer-guide/api/functions/TSPluginDSOReloadEnable.en.rst
@@ -1,0 +1,51 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSPluginDSOReloadEnable
+*************************
+
+Control whether this plugin will take part in the remap dynamic reload preocess (remap.config)
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: TSReturnCode TSPluginDSOReloadEnable(int enabled)
+
+Description
+===========
+
+This function provides the ability to enable/disable programmatically the plugin
+dynamic reloading when the same Dynamic Shared Object (DSO) is also used as a remap plugin.
+This overrides :ts:cv:`proxy.config.plugin.dynamic_reload_mode`.
+
+.. warning::  This function should be called from within :func:`TSPluginInit`
+
+The function will return :type:`TS_ERROR`  in any of the following cases:
+    - The function was not called from within :func:`TSPluginInit`
+    - TS is unable to get the canonical path from the plugin's path.
+
+See Also
+========
+
+:manpage:`TSAPI(3ts)`

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -162,6 +162,20 @@ int TSTrafficServerVersionGetPatch(void);
  */
 tsapi TSReturnCode TSPluginRegister(const TSPluginRegistrationInfo *plugin_info);
 
+/**
+   This function provides the ability to enable/disable programmatically
+   the plugin dynamic reloading when the same Dynamic Shared Object (DSO)
+   is also used as a remap plugin. This overrides `proxy.config.plugin.dynamic_reload_mode`
+   configuration variable.
+
+   @param enabled boolean flag. 0/false will disable the reload on the caller plugin.
+   @return TS_ERROR if the function is not called from within TSPluginInit or if TS is
+           unable to get the canonical path from the plugin's path. TS_SUCCESS otherwise.
+
+   @note This function should be called from within TSPluginInit
+ */
+tsapi TSReturnCode TSPluginDSOReloadEnable(int enabled);
+
 /* --------------------------------------------------------------------------
    Files */
 /**

--- a/proxy/http/remap/PluginFactory.cc
+++ b/proxy/http/remap/PluginFactory.cc
@@ -152,6 +152,13 @@ PluginFactory::getRemapPlugin(const fs::path &configPath, int argc, char **argv,
     return nullptr;
   }
 
+  // The plugin may have opt out by `TSPluginDSOReloadEnable`, let's check and overwrite
+  if (dynamicReloadEnabled && PluginDso::loadedPlugins()->isPluginInDsoOptOutTable(effectivePath)) {
+    // plugin not interested to be reload.
+    PluginDebug(_tag, "Plugin %s not interested in taking part of the reload.", effectivePath.c_str());
+    dynamicReloadEnabled = false;
+  }
+
   /* Only one plugin with this effective path can be loaded by a plugin factory */
   RemapPluginInfo *plugin = dynamic_cast<RemapPluginInfo *>(findByEffectivePath(effectivePath, dynamicReloadEnabled));
   RemapPluginInst *inst   = nullptr;

--- a/proxy/http/remap/PluginFactory.h
+++ b/proxy/http/remap/PluginFactory.h
@@ -82,6 +82,8 @@ public:
  * filesystem links and different dl library implementations.
  *
  * @note This is meant to unify the way global and remap plugins are (re)loaded (global plugin support is not implemented yet).
+ * @note In the case of a mixed plugin, getRemapPlugin/dynamicReloadEnabled can be internally overwritten if the plugin opt out to
+ * take part in the dynamic reload process.
  */
 class PluginFactory
 {
@@ -115,6 +117,13 @@ protected:
   ATSUuid *_uuid = nullptr;
   std::error_code _ec;
   bool _preventiveCleaning = true;
+
+  // Hold the full path for global plugins not taking part of the dynamic reloading.
+  struct DisableReloadPluginInfo {
+    fs::path fullPath;
+  };
+
+  std::forward_list<DisableReloadPluginInfo> optoutPlugins;
 
   static constexpr const char *const _tag = "plugin_factory"; /** @brief log tag used by this class */
 };

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1966,6 +1966,23 @@ TSPluginRegister(const TSPluginRegistrationInfo *plugin_info)
   return TS_SUCCESS;
 }
 
+TSReturnCode
+TSPluginDSOReloadEnable(int enabled)
+{
+  TSReturnCode ret = TS_SUCCESS;
+  if (!plugin_reg_current) {
+    return TS_ERROR;
+  }
+
+  if (!enabled) {
+    if (!PluginDso::loadedPlugins()->addPluginPathToDsoOptOutTable(plugin_reg_current->plugin_path)) {
+      ret = TS_ERROR;
+    }
+  }
+
+  return ret;
+}
+
 ////////////////////////////////////////////////////////////////////
 //
 // API file management


### PR DESCRIPTION
This PR adds a new TS API that let a particular Global and Remap plugin to override the configuration   `proxy.config.plugin.dynamic_reload_mode` to control whether this plugin will take part on the DSO dynamic remap plugin reload process or not.