### PR TITLE
Fix failures to h2spec test and make h2spec test more resilient

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -436,7 +436,7 @@ Http2Stream::initiating_close()
     bool sent_write_complete = false;
     if (_sm) {
       // Push out any last IO events
-      if (write_vio.cont) {
+      if (write_vio.cont && write_vio.nbytes > 0) {
         SCOPED_MUTEX_LOCK(lock, write_vio.mutex, this_ethread());
         // Are we done?
         if (write_vio.nbytes == write_vio.ndone) {

--- a/tests/gold_tests/h2/h2spec.test.py
+++ b/tests/gold_tests/h2/h2spec.test.py
@@ -53,8 +53,8 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.client.verify.server':  0,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http2',
+    'proxy.config.diags.debug.enabled': 0,
+    'proxy.config.diags.debug.tags': 'http',
 })
 
 # ----
@@ -65,7 +65,7 @@ ts.Disk.records_config.update({
 h2spec_targets = "http2/1 http2/2 http2/3 http2/4 http2/5 http2/6.1 http2/6.2 http2/6.3 http2/6.5 http2/6.6 http2/6.7 http2/6.8 http2/7 http2/8 hpack"
 
 test_run = Test.AddTestRun()
-test_run.Processes.Default.Command = 'h2spec {0} -t -k -p {1}'.format(h2spec_targets, ts.Variables.ssl_port)
+test_run.Processes.Default.Command = 'h2spec {0} -t -k --timeout 10 -p {1}'.format(h2spec_targets, ts.Variables.ssl_port)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
 test_run.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))


### PR DESCRIPTION
Another solution to PR #6879 

Adjusts a change in #6732 to ensure that the error frame is emitted.

Also adjusts the timeout for h2spec from the default of 2 seconds to 10.  I was seeing failures in the concurrent stream overflow test (5.1.2) where sometimes it would succeed and sometimes timeout.  This was with and without the changes in #6732.