### PR TITLE
microserver error handling: SSLError check and debug.

### DIFF
--- a/tests/gold_tests/autest-site/microserver.test.ext
+++ b/tests/gold_tests/autest-site/microserver.test.ext
@@ -21,6 +21,7 @@ import socket
 import ssl
 
 from autest.api import AddWhenFunction
+import hosts.output as host
 from ports import get_port
 
 import trlib.ipconstants as IPConstants
@@ -132,6 +133,16 @@ def uServerUpAndRunning(serverHost, port, isSsl, isIPv6, request, clientcert='',
     try:
         sock.connect((serverHost, port))
     except ConnectionRefusedError:
+        host.WriteDebug(
+            ['uServerUpAndRunning', 'when'],
+            "Connection refused: {0}:{1}".format(
+                serverHost, port))
+        return False
+    except ssl.SSLError:
+        host.WriteDebug(
+            ['uServerUpAndRunning', 'when'],
+            "SSL connection error: {0}:{1}".format(
+                serverHost, port))
         return False
 
     sock.sendall(request.encode())


### PR DESCRIPTION
This is a result of investigating flakyness in the tls_verify_base AuTest: https://github.com/apache/trafficserver/issues/6840.

This adds SSL error handling. This will at least clean up the error logging. Further, if the issue connecting to the server is a temporary timing related problem, then this may address the issue altogether because it will allow the When retry logic to give further series of attempts rather than abruptly terminating via the uncaught exception. If, on the other hand, the issue is persistent, then a timeout will occur.