### PR TITLE
Improve client_vc tracking

### DIFF
--- a/doc/developer-guide/plugins/hooks-and-transactions/http-sessions.en.rst
+++ b/doc/developer-guide/plugins/hooks-and-transactions/http-sessions.en.rst
@@ -40,7 +40,10 @@ The HTTP session hooks are:
 
 -  ``TS_HTTP_SSN_CLOSE_HOOK`` Called when an HTTP session ends (a
    session ends when the client connection is closed). This hook must be
-   added as a global hook.
+   added as a global hook.  The relative order of invocation between the
+   ``TS_VCONN_CLOSE_HOOK`` and ``TS_HTTP_SSN_CLOSE_HOOK`` is undefined.  In
+   most cases the ``TS_VCONN_CLOSE_HOOK`` will execute first, but that is
+   not guaranteed.
 
 Use the session hooks to get a handle to a session (an ``TSHttpSsn``
 object). If you want your plugin to be called back for each transaction

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -88,6 +88,7 @@ read_signal_and_update(int event, UnixNetVConnection *vc)
     case VC_EVENT_ACTIVE_TIMEOUT:
     case VC_EVENT_INACTIVITY_TIMEOUT:
       Debug("inactivity_cop", "event %d: null read.vio cont, closing vc %p", event, vc);
+      Warning("read: Closing orphaned vc %p", vc);
       vc->closed = 1;
       break;
     default:
@@ -119,6 +120,7 @@ write_signal_and_update(int event, UnixNetVConnection *vc)
     case VC_EVENT_ACTIVE_TIMEOUT:
     case VC_EVENT_INACTIVITY_TIMEOUT:
       Debug("inactivity_cop", "event %d: null write.vio cont, closing vc %p", event, vc);
+      Warning("write: Closing orphaned vc %p", vc);
       vc->closed = 1;
       break;
     default:

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -87,7 +87,6 @@ private:
   int state_keep_alive(int event, void *data);
   int state_slave_keep_alive(int event, void *data);
   int state_wait_for_close(int event, void *data);
-  int state_wait_for_sm_shutdown(int event, void *data);
 
   enum C_Read_State {
     HCS_INIT,

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -586,7 +586,8 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
   //  this hook maybe asynchronous, we need to disable IO on
   //  client but set the continuation to be the state machine
   //  so if we get an timeout events the sm handles them
-  ua_entry->read_vio = client_vc->do_io_read(this, 0, buffer_reader->mbuf);
+  ua_entry->read_vio  = client_vc->do_io_read(this, 0, buffer_reader->mbuf);
+  ua_entry->write_vio = client_vc->do_io_write(this, 0, nullptr);
 
   /////////////////////////
   // set up timeouts     //
@@ -2768,7 +2769,6 @@ HttpSM::tunnel_handler_post(int event, void *data)
     if (ua_entry->write_buffer) {
       free_MIOBuffer(ua_entry->write_buffer);
       ua_entry->write_buffer = nullptr;
-      ua_entry->vc->do_io_write(nullptr, 0, nullptr);
     }
     if (!p->handler_state) {
       p->handler_state = HTTP_SM_POST_UA_FAIL;
@@ -3529,9 +3529,6 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
       // if it is active timeout case, we need to give another chance to send 408 response;
       ua_txn->set_active_timeout(HRTIME_SECONDS(t_state.txn_conf->transaction_active_timeout_in));
 
-      p->vc->do_io_write(nullptr, 0, nullptr);
-      p->vc->do_io_shutdown(IO_SHUTDOWN_READ);
-
       return 0;
     }
   // fall through
@@ -3543,8 +3540,6 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
     //   server and close the ua
     p->handler_state = HTTP_SM_POST_UA_FAIL;
     set_ua_abort(HttpTransact::ABORTED, event);
-    p->vc->do_io_write(nullptr, 0, nullptr);
-    p->vc->do_io_shutdown(IO_SHUTDOWN_READ);
     tunnel.chain_abort_all(p);
     server_session = nullptr;
     // the in_tunnel status on both the ua & and
@@ -3555,6 +3550,11 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
     if (p->consumer_list.head && p->consumer_list.head->vc_type == HT_TRANSFORM) {
       hsm_release_assert(post_transform_info.entry->in_tunnel == true);
     } // server side may have completed before the user agent side, so it may no longer be in tunnel
+
+    // In the error case, start to take down the client session. There should
+    // be no reuse here
+    vc_table.remove_entry(this->ua_entry);
+    ua_txn->do_io_close();
     break;
 
   case VC_EVENT_READ_COMPLETE:
@@ -3571,8 +3571,7 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
       }
     }
 
-    // Initiate another read to watch catch aborts and
-    //   timeouts
+    // Initiate another read to catch aborts and timeouts.
     ua_entry->vc_handler = &HttpSM::state_watch_for_client_abort;
     ua_entry->read_vio   = p->vc->do_io_read(this, INT64_MAX, ua_buffer_reader->mbuf);
     break;

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -286,7 +286,7 @@ Http2ClientSession::do_io_close(int alerrno)
   this->clear_session_active();
 
   // Clean up the write VIO in case of inactivity timeout
-  this->do_io_write(nullptr, 0, nullptr);
+  this->do_io_write(this, 0, nullptr);
 }
 
 void
@@ -349,10 +349,6 @@ Http2ClientSession::main_event_handler(int event, void *edata)
     Http2SsnDebug("Closing event %d", event);
     this->set_dying_event(event);
     this->do_io_close();
-    if (_vc != nullptr) {
-      _vc->do_io_close();
-      _vc = nullptr;
-    }
     retval = 0;
     break;
 
@@ -594,7 +590,6 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
         if (!this->connection_state.is_state_closed()) {
           this->connection_state.send_goaway_frame(this->connection_state.get_latest_stream_id_in(), err);
           this->set_half_close_local_flag(true);
-          this->do_io_close();
         }
       }
       return 0;

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -242,7 +242,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
   if (cstate.is_valid_streamid(stream_id)) {
     stream = cstate.find_stream(stream_id);
     if (stream == nullptr || !stream->has_trailing_header()) {
-      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED,
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv headers cannot find existing stream_id");
     }
   } else {

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -241,7 +241,10 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
 
   if (cstate.is_valid_streamid(stream_id)) {
     stream = cstate.find_stream(stream_id);
-    if (stream == nullptr || !stream->has_trailing_header()) {
+    if (stream == nullptr) {
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED,
+                        "recv headers cannot find existing stream_id");
+    } else if (!stream->has_trailing_header()) {
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv headers cannot find existing stream_id");
     }

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -652,7 +652,9 @@ Http2Stream::signal_read_event(int event)
 void
 Http2Stream::signal_write_event(int event)
 {
-  if (this->write_vio.cont == nullptr || this->write_vio.cont->mutex == nullptr || this->write_vio.op == VIO::NONE) {
+  // Don't signal a write event if in fact nothing was written
+  if (this->write_vio.cont == nullptr || this->write_vio.cont->mutex == nullptr || this->write_vio.op == VIO::NONE ||
+      this->write_vio.nbytes == 0) {
     return;
   }
 

--- a/tests/gold_tests/pluginTest/test_hooks/log.gold
+++ b/tests/gold_tests/pluginTest/test_hooks/log.gold
@@ -24,10 +24,10 @@ Transaction: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 Global: event=TS_EVENT_HTTP_TXN_CLOSE
 Session: event=TS_EVENT_HTTP_TXN_CLOSE
 Transaction: event=TS_EVENT_HTTP_TXN_CLOSE
+``
 Global: event=TS_EVENT_HTTP_SSN_CLOSE
 Session: event=TS_EVENT_HTTP_SSN_CLOSE
-Global: event=TS_EVENT_VCONN_CLOSE
-Global: ssl flag=1
+``
 Global: event=TS_EVENT_VCONN_START
 Global: ssl flag=1
 Global: event=TS_EVENT_SSL_SERVERNAME
@@ -43,7 +43,7 @@ Transaction: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 Global: event=TS_EVENT_HTTP_TXN_CLOSE
 Session: event=TS_EVENT_HTTP_TXN_CLOSE
 Transaction: event=TS_EVENT_HTTP_TXN_CLOSE
+``
 Global: event=TS_EVENT_HTTP_SSN_CLOSE
 Session: event=TS_EVENT_HTTP_SSN_CLOSE
-Global: event=TS_EVENT_VCONN_CLOSE
-Global: ssl flag=1
+``

--- a/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
@@ -99,3 +99,4 @@ tr.Processes.Default.Command = "echo check log"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File("log.txt")
 f.Content = "log.gold"
+f.Content += Testers.ContainsExpression("Global: event=TS_EVENT_VCONN_CLOSE", "VCONN_CLOSE should trigger 2 times")


### PR DESCRIPTION
A replacement for PR #6732 plus some additional fixes suggested by @masaori335. 

The issue we have been tracking down for the last few months on ATS9 is dealing with "stale" client_vc pointers.  The first approach taken in PR #6469 was to just look for still set client_vc's after the client session do_io_close and then close it.  However that approach would sometimes touch a client_vc object that had already been freed.  With ASAN builds @bneradt found a number of use-after-free cases.

Then we took this approach of making sure that while a HttpSM or client session is still alive and referencing the client_vc, the read and write vio's should reference either the HttpSM, session or some other layer 7 object.  The theory being that we were getting stale client_vc references because net events like error, eos, timeout would occur while the write/read vio was pointing to a null continuation.  We have been running this logic in our ATS9 deployments since late April and our number of crashes has been minimal and due to other issues.

@masaori335 pointed out that we should be able to close the netvc object at the point where the session do_io_close occurs.  Making that change and running double*/openclose* with 100's of transactions shows that this is safe.

Also extended the h2spec timeout from the default 2 seconds.  Given the timing vagaries of the CI environment, giving more timeout slack seemed better.  With all the debugging on, I was seeing intermittent failures in a variety of cases.