### PR TITLE
AuTest: Pipfile update to use microserver 1.0.5

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -32,7 +32,7 @@ dnslib = "*"
 requests = "*"
 gunicorn = "*"
 httpbin = "*"
-microserver = ">=1.0.4"
+microserver = ">=1.0.5"
 jsonschema = "*"
 python-jose = "*"
 


### PR DESCRIPTION
The latest version of microserver applies SO_REUSEADDR on the socket it
binds to. This will hopefully address the flaky behavior we've seen with
the tls tests.

This update to microserver is another attempt to address:
https://github.com/apache/trafficserver/issues/6842