### PR TITLE
set sni_name with remapped origin name if sni_policy is not the default value

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4800,11 +4800,13 @@ HttpSM::get_outbound_sni() const
 {
   const char *sni_name = nullptr;
   size_t len           = 0;
-  if (t_state.txn_conf->ssl_client_sni_policy != nullptr && !strcmp(t_state.txn_conf->ssl_client_sni_policy, "remap")) {
+  if (t_state.txn_conf->ssl_client_sni_policy == nullptr || !strcmp(t_state.txn_conf->ssl_client_sni_policy, "host")) {
+    // By default the host header field value is used for the SNI.
+    sni_name = t_state.hdr_info.server_request.host_get(reinterpret_cast<int *>(&len));
+  } else {
+    // If other is specified, like "remap" and "verify_with_name_source", the remapped origin name is used for the SNI value
     len      = strlen(t_state.server_info.name);
     sni_name = t_state.server_info.name;
-  } else { // Do the default of host header for SNI
-    sni_name = t_state.hdr_info.server_request.host_get(reinterpret_cast<int *>(&len));
   }
   return std::string_view(sni_name, len);
 }


### PR DESCRIPTION
proxy.config.ssl.client.sni_policy can be NULL, "host", "remap", and "verify_with_name_source" now. By default policy (the setting is NULL or "host"), the host header field value is used for the SNI, and for other settings, we need the remapped origin name used for the SNI value.
BTW, the difference of "verify_with_name_source" and "remap" is: host header filed value is used to set ssl_tlext_host_name in "verify_with_name_source", but remapped origin name used to set ssl_tlext_host_name in "remap". 
