### PR TITLE
Disable max_connections_active_in default and fix close logic

### DIFF
--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -319,7 +319,7 @@ public:
   void process_enabled_list();
   void process_ready_list();
   void manage_keep_alive_queue();
-  bool manage_active_queue(bool ignore_queue_size);
+  bool manage_active_queue(NetEvent *ne, bool ignore_queue_size);
   void add_to_keep_alive_queue(NetEvent *ne);
   void remove_from_keep_alive_queue(NetEvent *ne);
   bool add_to_active_queue(NetEvent *ne);

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -400,7 +400,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.net.max_connections_in", RECD_INT, "30000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.max_connections_active_in", RECD_INT, "10000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.max_connections_active_in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
 
   //       ###########################

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -346,6 +346,7 @@ Http2ClientSession::main_event_handler(int event, void *edata)
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_ERROR:
   case VC_EVENT_EOS:
+    Http2SsnDebug("Closing event %d", event);
     this->set_dying_event(event);
     this->do_io_close();
     if (_vc != nullptr) {

--- a/tests/gold_tests/h2/h2active_timeout.py
+++ b/tests/gold_tests/h2/h2active_timeout.py
@@ -22,23 +22,25 @@ import argparse
 import time
 
 
-def makerequest(port):
+def makerequest(port, active_timeout):
     hyper.tls._context = hyper.tls.init_context()
     hyper.tls._context.check_hostname = False
     hyper.tls._context.verify_mode = hyper.compat.ssl.CERT_NONE
 
     conn = HTTPConnection('localhost:{0}'.format(port), secure=True)
 
-    active_timeout = 3
-    request_interval = 0.1
-    loop_cnt = int((active_timeout + 2) / request_interval)
-    for _ in range(loop_cnt):
-        try:
-            conn.request('GET', '/')
-            time.sleep(request_interval)
-        except:
-            print('CONNECTION_TIMEOUT')
-            return
+    try:
+        # delay after sending the first request
+        # so the H2 session active timeout triggers
+        # Then the next request should fail
+        req_id = conn.request('GET', '/')
+        time.sleep(active_timeout)
+        response = conn.get_response(req_id)
+        req_id = conn.request('GET', '/')
+        response = conn.get_response(req_id)
+    except:
+        print('CONNECTION_TIMEOUT')
+        return
 
     print('NO_TIMEOUT')
 
@@ -48,8 +50,11 @@ def main():
     parser.add_argument("--port", "-p",
                         type=int,
                         help="Port to use")
+    parser.add_argument("--delay", "-d",
+                        type=int,
+                        help="Time to delay in seconds")
     args = parser.parse_args()
-    makerequest(args.port)
+    makerequest(args.port, args.delay)
 
 
 if __name__ == '__main__':

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -152,7 +152,7 @@ tr.StillRunningAfter = server
 
 # Test Case 5: h2_active_timeout
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 h2active_timeout.py -p {0}'.format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = 'python3 h2active_timeout.py -p {0} -d 4'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/active_timeout.gold"
 tr.StillRunningAfter = server


### PR DESCRIPTION
Now that @sudheerv fixed the active connection enforcement with PR#6754 the max_connection_in which has been set to 10,000 forever suddenly starts doing something.

I got surprised by this when testing ATS9 on a production box and suddenly losing client connections.  I would suggest that we change the default setting to 0 to disable the feature, so folks can select the appropriate value for their environment.