### PR TITLE
Make QPACK.h self-contained

### DIFF
--- a/proxy/http3/QPACK.h
+++ b/proxy/http3/QPACK.h
@@ -23,11 +23,17 @@
 
 #pragma once
 
+#include <map>
+
 #include "I_EventSystem.h"
 #include "I_Event.h"
+#include "I_IOBuffer.h"
+#include "tscore/Arena.h"
 #include "tscpp/util/IntrusiveDList.h"
 #include "MIME.h"
+#include "HTTP.h"
 #include "QUICApplication.h"
+#include "QUICConnection.h"
 
 class HTTPHdr;
 


### PR DESCRIPTION
#6905 revealed QPACK.h is not self-contained. This change will fix the compile error on #6905.