### PR TITLE
Fix support for openssl async engine

### DIFF
--- a/contrib/openssl/README.md
+++ b/contrib/openssl/README.md
@@ -5,6 +5,6 @@ It should be built as follows.  It must be build against openssl 1.1 or better f
 
 gcc -fPIC -shared -g -o async-test.so -I<path to openssl headers> -L<path to openssl library> -lssl -lcrypto -lpthread async_engine.c
 
-load_engine.cnf is an example openssl config file that can be passed to Traffic Server via the proxy.config.ssl.engine_cnf_file setting.
+load_engine.cnf is an example openssl config file that can be passed to Traffic Server via the proxy.config.ssl.engine.conf_file setting.
 It describes which crypto engines should be loaded and how they should be used.  In the case of our async-test crypto engine it will be used for
 RSA operations

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -893,7 +893,12 @@ SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams *params, const std::str
 #ifndef OPENSSL_IS_BORINGSSL
   ENGINE *e = ENGINE_get_default_RSA();
   if (e != nullptr) {
-    const char *argkey = (keyPath == nullptr || keyPath[0] == '\0') ? completeServerCertPath.c_str() : keyPath;
+    ats_scoped_str argkey;
+    if (keyPath == nullptr || keyPath[0] == '\0') {
+      argkey = completeServerCertPath.c_str();
+    } else {
+      argkey = Layout::get()->relative_to(params->serverKeyPathOnly, keyPath);
+    }
     if (!SSL_CTX_use_PrivateKey(ctx, ENGINE_load_private_key(e, argkey, nullptr, nullptr))) {
       SSLError("failed to load server private key from engine");
     }

--- a/tests/gold_tests/tls/tls_engine.test.py
+++ b/tests/gold_tests/tls/tls_engine.test.py
@@ -1,0 +1,98 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import os
+
+
+# Someday should add client cert to origin to exercise the
+# engine interface on the other side
+
+Test.Summary = '''
+Test tls via the async interface with the sample async_engine
+'''
+
+Test.SkipUnless(Condition.HasOpenSSLVersion('1.1.1'))
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
+server = Test.MakeOriginServer("server")
+
+# Compile with tsxs.  That should bring in the consisten versions of openssl
+ts.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir, '../../contrib/openssl', 'async_engine.c'), Test.RunDirectory)
+ts.Setup.RunCommand("tsxs -o async_engine.so async_engine.c")
+
+# Add info the origin server responses
+server.addResponse("sessionlog.json",
+                   {"headers": "GET / HTTP/1.1\r\nuuid: basic\r\n\r\n", "timestamp": "1469733493.993", "body": ""},
+                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 2\r\n\r\n", "timestamp": "1469733493.993", "body": "ok"})
+
+# add ssl materials like key, certificates for the server
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+
+ts.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+ts.Disk.records_config.update({
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.client.verify.server':  0,
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
+    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.ssl.engine.conf_file': '{0}/ts/config/load_engine.cnf'.format(Test.RunDirectory),
+    'proxy.config.ssl.async.handshake.enabled': 1,
+    'proxy.config.diags.debug.enabled': 0,
+    'proxy.config.diags.debug.tags': 'ssl'
+})
+
+ts.Disk.MakeConfigFile('load_engine.cnf').AddLines([
+    'openssl_conf = openssl_init',
+    '',
+    '[openssl_init]',
+    '',
+    'engines = engine_section',
+    '',
+    '[engine_section]',
+    '',
+    'async = async_section',
+    '',
+    '[async_section]',
+    '',
+    'dynamic_path = {0}/async_engine.so'.format(Test.RunDirectory),
+    '',
+    'engine_id = async-test',
+    '',
+    'default_algorithms = RSA',
+    '',
+    'init = 1'])
+
+# Make a basic request.  Hopefully it goes through
+tr = Test.AddTestRun("Run-Test")
+tr.Processes.Default.Command = "curl -k -v -H uuid:basic -H host:example.com  https://127.0.0.1:{0}/".format(ts.Variables.ssl_port)
+tr.ReturnCode = 0
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/(2|1\.1) 200", "Request succeeds")
+tr.StillRunningAfter = server
+
+ts.Streams.All += Testers.ContainsExpression("Send signal to ", "The Async engine triggers")


### PR DESCRIPTION
Maciej Oleksy tried to use the openssl async engine support provided in ATS and noticed it was broken.  There were a few issues, but the main issue was due to changes in casting and class hierarchy with the NetEvent refactor (PR #6287).  Due to the casting problem the signaling event that indicated the async job was ready to move on never got delivered.

I added an autest that exercises the example async_engine.so, so we catch problems in this area sooner in the future.

I would like to pull this in since it is a fix to a break in a released feature.