### PR TITLE
Make compress test more resilient

### DIFF
--- a/tests/gold_tests/pluginTest/compress/compress.gold
+++ b/tests/gold_tests/pluginTest/compress/compress.gold
@@ -6,7 +6,7 @@
 < Content-Encoding: br
 < Vary: Accept-Encoding
 < Content-Length: 46
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip
 > Accept-Encoding: gzip
@@ -15,7 +15,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/br
 > Accept-Encoding: br
@@ -24,14 +24,14 @@
 < Content-Encoding: br
 < Vary: Accept-Encoding
 < Content-Length: 46
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/deflate
 > Accept-Encoding: deflate
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
-
+``
 > GET http://ae-1/obj1 HTTP/1.1
 > X-Ats-Compress-Test: 1/gzip, deflate, sdch, br
 > Accept-Encoding: gzip, deflate, sdch, br
@@ -40,7 +40,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-1/obj1 HTTP/1.1
 > X-Ats-Compress-Test: 1/gzip
 > Accept-Encoding: gzip
@@ -49,21 +49,21 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-1/obj1 HTTP/1.1
 > X-Ats-Compress-Test: 1/br
 > Accept-Encoding: br
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
-
+``
 > GET http://ae-1/obj1 HTTP/1.1
 > X-Ats-Compress-Test: 1/deflate
 > Accept-Encoding: deflate
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
-
+``
 > GET http://ae-2/obj2 HTTP/1.1
 > X-Ats-Compress-Test: 2/gzip, deflate, sdch, br
 > Accept-Encoding: gzip, deflate, sdch, br
@@ -72,7 +72,7 @@
 < Content-Encoding: br
 < Vary: Accept-Encoding
 < Content-Length: 46
-
+``
 > GET http://ae-2/obj2 HTTP/1.1
 > X-Ats-Compress-Test: 2/gzip
 > Accept-Encoding: gzip
@@ -81,7 +81,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-2/obj2 HTTP/1.1
 > X-Ats-Compress-Test: 2/br
 > Accept-Encoding: br
@@ -90,14 +90,14 @@
 < Content-Encoding: br
 < Vary: Accept-Encoding
 < Content-Length: 46
-
+``
 > GET http://ae-2/obj2 HTTP/1.1
 > X-Ats-Compress-Test: 2/deflate
 > Accept-Encoding: deflate
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=0.666
 > Accept-Encoding: gzip;q=0.666
@@ -106,7 +106,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=0.666x
 > Accept-Encoding: gzip;q=0.666x
@@ -115,7 +115,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=#0.666
 > Accept-Encoding: gzip;q=#0.666
@@ -124,7 +124,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip; Q = 0.666
 > Accept-Encoding: gzip; Q = 0.666
@@ -133,14 +133,14 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=0.0
 > Accept-Encoding: gzip;q=0.0
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
 < Content-Length: 1049
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=-0.1
 > Accept-Encoding: gzip;q=-0.1
@@ -149,7 +149,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/aaa, gzip;q=0.666, bbb
 > Accept-Encoding: aaa, gzip;q=0.666, bbb
@@ -158,7 +158,7 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/ br ; q=0.666, bbb
 > Accept-Encoding:  br ; q=0.666, bbb
@@ -167,7 +167,7 @@
 < Content-Encoding: br
 < Vary: Accept-Encoding
 < Content-Length: 46
-
+``
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/aaa, gzip;q=0.666 , 
 > Accept-Encoding: aaa, gzip;q=0.666 , 
@@ -176,4 +176,5 @@
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
 < Content-Length: 71
+``
 


### PR DESCRIPTION
compress test was failing for me locally because the number of spaces between blocks in the gold file differed.