### PR TITLE
Disable lua_stats autest until we can reliably wait for stats

### DIFF
--- a/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
@@ -23,6 +23,7 @@ Test lua states and stats functionality
 Test.SkipUnless(
     Condition.PluginExists('tslua.so'),
 )
+Test.SkipIf(Condition.true("Test cannot deterministically wait until the stats appear"))
 
 Test.ContinueOnFail = True
 # Define default ATS


### PR DESCRIPTION
Discussed in issue #6486 

Had the same issue with remap_stats test.  At the moment we do not have the means to wait for a metric to show up and know that it has the "final" value.  The best we can do is poll until the metric shows up (but not necessarily with the final value), or delay which is not always sufficient in the CI environment.