### PR TITLE
slice: clean up 502 header/body generation.

### DIFF
--- a/plugins/experimental/slice/Data.h
+++ b/plugins/experimental/slice/Data.h
@@ -48,6 +48,9 @@ struct Data {
 
   sockaddr_storage m_client_ip;
 
+  // transaction pointer
+  TSHttpTxn m_txnp{nullptr};
+
   // for pristine/effective url coming in
   TSMBuffer m_urlbuf{nullptr};
   TSMLoc m_urlloc{nullptr};
@@ -96,16 +99,10 @@ struct Data {
     m_hostname[0]     = '\0';
     m_etag[0]         = '\0';
     m_lastmodified[0] = '\0';
-#if defined(COLLECT_STATS)
-    TSStatIntIncrement(stats::DataCreate, 1);
-#endif
   }
 
   ~Data()
   {
-#if defined(COLLECT_STATS)
-    TSStatIntIncrement(stats::DataDestroy, 1);
-#endif
     if (nullptr != m_urlbuf) {
       if (nullptr != m_urlloc) {
         TSHandleMLocRelease(m_urlbuf, TS_NULL_MLOC, m_urlloc);

--- a/plugins/experimental/slice/Stage.h
+++ b/plugins/experimental/slice/Stage.h
@@ -34,9 +34,6 @@ struct Channel {
   {
     if (nullptr != m_reader) {
       TSIOBufferReaderFree(m_reader);
-#if defined(COLLECT_STATS)
-      TSStatIntDecrement(stats::Reader, 1);
-#endif
     }
     if (nullptr != m_iobuf) {
       TSIOBufferDestroy(m_iobuf);
@@ -65,9 +62,6 @@ struct Channel {
     if (nullptr == m_iobuf) {
       m_iobuf  = TSIOBufferCreate();
       m_reader = TSIOBufferReaderAlloc(m_iobuf);
-#if defined(COLLECT_STATS)
-      TSStatIntIncrement(stats::Reader, 1);
-#endif
     } else {
       int64_t const drained = drainReader();
       if (0 < drained) {
@@ -85,9 +79,6 @@ struct Channel {
     if (nullptr == m_iobuf) {
       m_iobuf  = TSIOBufferCreate();
       m_reader = TSIOBufferReaderAlloc(m_iobuf);
-#if defined(COLLECT_STATS)
-      TSStatIntIncrement(stats::Reader, 1);
-#endif
     } else {
       int64_t const drained = drainReader();
       if (0 < drained) {

--- a/plugins/experimental/slice/client.cc
+++ b/plugins/experimental/slice/client.cc
@@ -27,9 +27,6 @@
 bool
 handle_client_req(TSCont contp, TSEvent event, Data *const data)
 {
-#if defined(COLLECT_STATS)
-  stats::StatsRAI const rai(stats::ClientTime);
-#endif
   switch (event) {
   case TS_EVENT_VCONN_READ_READY:
   case TS_EVENT_VCONN_READ_COMPLETE: {
@@ -126,11 +123,6 @@ handle_client_req(TSCont contp, TSEvent event, Data *const data)
 void
 handle_client_resp(TSCont contp, TSEvent event, Data *const data)
 {
-#if defined(COLLECT_STATS)
-  TSStatIntIncrement(stats::Client, 1);
-  stats::StatsRAI const rai(stats::ClientTime);
-#endif
-
   switch (event) {
   case TS_EVENT_VCONN_WRITE_READY: {
     switch (data->m_blockstate) {

--- a/plugins/experimental/slice/response.cc
+++ b/plugins/experimental/slice/response.cc
@@ -48,8 +48,8 @@ bodyString416()
 }
 
 // Form a 502 response, preliminary
-std::string const &
-string502()
+std::string
+string502(int const httpver)
 {
   static std::string msg;
   static std::mutex mutex;
@@ -68,10 +68,13 @@ string502()
     bodystr.append("</body>\n");
     bodystr.append("</html>\n");
 
+    char hverstr[64];
+    int const hlen =
+      snprintf(hverstr, sizeof(hverstr), "HTTP/%d.%d 502 Bad Gateway\r\n", TS_HTTP_MAJOR(httpver), TS_HTTP_MINOR(httpver));
+    msg.append(hverstr, hlen);
+
     char clenstr[1024];
     int const clen = snprintf(clenstr, sizeof(clenstr), "%lu", bodystr.size());
-
-    msg.append("HTTP/1.1 502 Bad Gateway\r\n");
     msg.append("Content-Length: ");
     msg.append(clenstr, clen);
     msg.append("\r\n");
@@ -87,6 +90,7 @@ void
 form416HeaderAndBody(HttpHeader &header, int64_t const contentlen, std::string const &bodystr)
 {
   header.removeKey(TS_MIME_FIELD_LAST_MODIFIED, TS_MIME_LEN_LAST_MODIFIED);
+  header.removeKey(TS_MIME_FIELD_EXPIRES, TS_MIME_LEN_EXPIRES);
   header.removeKey(TS_MIME_FIELD_ETAG, TS_MIME_LEN_ETAG);
   header.removeKey(TS_MIME_FIELD_ACCEPT_RANGES, TS_MIME_LEN_ACCEPT_RANGES);
 

--- a/plugins/experimental/slice/response.h
+++ b/plugins/experimental/slice/response.h
@@ -21,7 +21,7 @@
 #include "HttpHeader.h"
 #include <string>
 
-std::string const &string502();
+std::string string502(int const httpver);
 
 std::string const &bodyString416();
 

--- a/plugins/experimental/slice/slice.h
+++ b/plugins/experimental/slice/slice.h
@@ -32,23 +32,12 @@
 #define PLUGIN_NAME "slice"
 #endif
 
-#ifndef COLLECT_STATS
-#define COLLECT_STATS
-#endif
-
 constexpr std::string_view X_CRR_IMS_HEADER = {"X-Crr-Ims"};
 
 #if !defined(UNITTEST)
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define DEBUG_LOG(fmt, ...)                                                      \
-  TSDebug(PLUGIN_NAME, "[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, \
-          ##__VA_ARGS__) /*                                                      \
-                                 ; fprintf(stderr, "[%s:%04d]: " fmt "\n"        \
-                                         , __FILENAME__                          \
-                                         , __LINE__                              \
-                                         , ##__VA_ARGS__)                        \
-                         */
+#define DEBUG_LOG(fmt, ...) TSDebug(PLUGIN_NAME, "[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__)
 
 #define ERROR_LOG(fmt, ...)                                                         \
   TSError("[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__); \
@@ -60,33 +49,3 @@ constexpr std::string_view X_CRR_IMS_HEADER = {"X-Crr-Ims"};
 #define ERROR_LOG(fmt, ...)
 
 #endif
-
-#if defined(COLLECT_STATS)
-namespace stats
-{
-extern int DataCreate;
-extern int DataDestroy;
-extern int Reader;
-extern int Server;
-extern int Client;
-extern int RequestTime;
-extern int FirstHeaderTime;
-extern int NextHeaderTime;
-extern int ServerTime;
-extern int ClientTime;
-
-struct StatsRAI {
-  int m_statid;
-  TSHRTime m_timebeg;
-
-  StatsRAI(int statid) : m_statid(statid), m_timebeg(TShrtime()) {}
-
-  ~StatsRAI()
-  {
-    TSHRTime const timeend = TShrtime();
-    TSStatIntIncrement(m_statid, timeend - m_timebeg);
-  }
-};
-
-} // namespace stats
-#endif // COLLECT_STATS

--- a/plugins/experimental/slice/util.cc
+++ b/plugins/experimental/slice/util.cc
@@ -25,6 +25,8 @@ void
 shutdown(TSCont const contp, Data *const data)
 {
   DEBUG_LOG("shutting down transaction");
+  data->m_upstream.close();
+  data->m_dnstream.close();
   TSContDataSet(contp, nullptr);
   delete data;
   TSContDestroy(contp);
@@ -34,9 +36,9 @@ void
 abort(TSCont const contp, Data *const data)
 {
   DEBUG_LOG("aborting transaction");
-  TSContDataSet(contp, nullptr);
   data->m_upstream.abort();
   data->m_dnstream.abort();
+  TSContDataSet(contp, nullptr);
   delete data;
   TSContDestroy(contp);
 }


### PR DESCRIPTION
Small change in how corner case 502 is generated.
Also change the header debug to use TSHttpHdrPrint and pull the string off the TSIOBuffer blocks instead of building it through iteration.