### PR TITLE
Removes SSLNetVConnection::sslContextSet

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -177,10 +177,6 @@ public:
   /// Reenable the VC after a pre-accept or SNI hook is called.
   virtual void reenable(NetHandler *nh, int event = TS_EVENT_CONTINUE);
 
-  /// Set the SSL context.
-  /// @note This must be called after the SSL endpoint has been created.
-  virtual bool sslContextSet(void *ctx);
-
   int64_t read_raw_data();
 
   void

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1652,18 +1652,6 @@ SSLNetVConnection::reenable(NetHandler *nh, int event)
 }
 
 bool
-SSLNetVConnection::sslContextSet(void *ctx)
-{
-  bool zret = true;
-  if (ssl) {
-    SSL_set_SSL_CTX(ssl, static_cast<SSL_CTX *>(ctx));
-  } else {
-    zret = false;
-  }
-  return zret;
-}
-
-bool
 SSLNetVConnection::callHooks(TSEvent eventId)
 {
   // Only dealing with the SNI/CERT hook so far.


### PR DESCRIPTION
This was introduced in 044da6999442449434b282d8b537d8858505bbfc but was
never used