### PR TITLE
Prevent stale netvc access on SSL Callbacks

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1505,7 +1505,7 @@ SSLNetVConnection::advertise_next_protocol(SSL *ssl, const unsigned char **out, 
 {
   SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
 
-  ink_release_assert(netvc != nullptr);
+  ink_release_assert(netvc && netvc->ssl == ssl);
 
   if (netvc->getNPN(out, outlen)) {
     // Successful return tells OpenSSL to advertise.
@@ -1522,7 +1522,7 @@ SSLNetVConnection::select_next_protocol(SSL *ssl, const unsigned char **out, uns
 {
   SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
 
-  ink_release_assert(netvc != nullptr);
+  ink_release_assert(netvc && netvc->ssl == ssl);
   const unsigned char *npnptr = nullptr;
   unsigned int npnsize        = 0;
   if (netvc->getNPN(&npnptr, &npnsize)) {


### PR DESCRIPTION
Since SSL Callbacks are asynchronous in nature, it's possible the
associated NetVC is already freed causing a potential use-after-free
problem.

This fixes https://github.com/apache/trafficserver/issues/6886 

Here's an example stack trace

```
#0  ssl_callback_session_ticket (ssl=0x2b588f91e000, keyname=0x2b57d2f043f0 "\260D\360\322W+", iv=0x2b57d2f043e0 "", cipher_ctx=0x2b585887cd40, hctx=0x2b582398e700, enc=1) at SSLSessionTicket.cc:67
67	SSLSessionTicket.cc: No such file or directory.
(gdb) bt 
#0  ssl_callback_session_ticket (ssl=0x2b588f91e000, keyname=0x2b57d2f043f0 "\260D\360\322W+", iv=0x2b57d2f043e0 "", cipher_ctx=0x2b585887cd40, hctx=0x2b582398e700, enc=1) at SSLSessionTicket.cc:67
#1  0x00002b57c96a1718 in tls_construct_new_session_ticket () from /lib/libssl.so.1.1
#2  0x00002b57c96933f7 in state_machine () from /lib/libssl.so.1.1
#3  0x00002b57c9668dea in ssl3_read_bytes () from /lib/libssl.so.1.1
#4  0x00002b57c96708fa in ssl3_read () from /lib/libssl.so.1.1
#5  0x00002b57c967c07d in ssl_read_internal () from /lib/libssl.so.1.1
#6  0x00002b57c967c253 in SSL_read () from /lib/libssl.so.1.1
#7  0x0000000000754315 in SSLReadBuffer (ssl=0x2b588f91e000, buf=0x2b589ce95000, nbytes=nbytes@entry=4096, nread=@0x2b57d2f04968: 0) at SSLUtils.cc:1851
#8  0x00000000007439fa in ssl_read_from_net (ret=<synthetic pointer>, lthread=<optimized out>, sslvc=0x2b58dcf86330) at SSLNetVConnection.cc:275
#9  SSLNetVConnection::net_read_io (this=0x2b58dcf86330, nh=0x2b57ce223d80, lthread=<optimized out>) at SSLNetVConnection.cc:665
#10 0x0000000000762498 in NetHandler::process_ready_list (this=this@entry=0x2b57ce223d80) at UnixNet.cc:412
#11 0x000000000076278d in NetHandler::waitForActivity (this=0x2b57ce223d80, timeout=<optimized out>) at UnixNet.cc:547
#12 0x00000000007c6a9a in EThread::execute_regular (this=this@entry=0x2b57ce220000) at UnixEThread.cc:266
#13 0x00000000007c6d62 in EThread::execute (this=0x2b57ce220000) at UnixEThread.cc:327
#14 0x00000000007c5109 in spawn_thread_internal (a=0x2b57cc56de80) at Thread.cc:92
#15 0x00002b57ca315dd5 in start_thread () from /lib64/libpthread.so.0
#16 0x00002b57cb0c6ead in clone () from /lib64/libc.so.6
(gdb) p ssl   
$1 = (SSL *) 0x2b588f91e000
(gdb) p netvc
$2 = (SSLNetVConnection &) @0x0: <error reading variable>
```