### PR TITLE
AuTest: Log and When condition for ATS initialized

### DIFF
--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -281,10 +281,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True, enabl
     get_port(p, "manager_port")
     get_port(p, "admin_port")
 
-    if enable_tls:
-        p.Ready = When.PortsOpen([p.Variables.port, p.Variables.ssl_port])
-    else:
-        p.Ready = When.PortOpen(p.Variables.port)
+    # The following message was added so that tests and users can know when
+    # Traffic Server is ready to both receive and optimize traffic.
+    p.Ready = When.FileContains(p.Disk.diags_log.AbsPath, "NOTE: traffic server initialized")
 
     if select_ports:
         # default config

--- a/tests/gold_tests/autest-site/when.test.ext
+++ b/tests/gold_tests/autest-site/when.test.ext
@@ -19,14 +19,33 @@ When extensions.
 
 from autest.api import AddWhenFunction
 import hosts.output as host
+import os
 
 
 def FileContains(haystack, needle):
+    """
+    Return whether the file haystack contains the string needle.
+
+    Args:
+        haystack (str): The path to the file to be inspected.
+        needle (str): The content to look for in haystack.
+
+    Returns:
+        True if the haystack exists as a file and contains needle, False
+        otherwise.
+    """
+    if not os.path.exists(haystack):
+        host.WriteDebug(
+            ['FileContains', 'when'],
+            "Testing for file content '{0}' in file '{1}': file does not exist".format(
+                needle, haystack))
+        return False
+
     with open(haystack) as f:
         result = needle in f.read()
 
         host.WriteDebug(
-            ['FileExists', 'when'],
+            ['FileContains', 'when'],
             "Testing for file content '{0}' in '{1}' : {2}".format(
                 needle, haystack, result))
 


### PR DESCRIPTION
This aims to make the AuTests more reliable by providing a log message
from traffic server that the AutTests can use as a ready condition
before the tests are started. Without this, there were issues with the
tests starting either when the cache was initialized and the ports were
not, or vice versa.