### PR TITLE
Prevent use-after-free of TransactionPlugin

### DIFF
--- a/include/tscpp/api/TransactionPlugin.h
+++ b/include/tscpp/api/TransactionPlugin.h
@@ -118,6 +118,8 @@ protected:
    */
   std::shared_ptr<Mutex> getMutex();
 
+  std::shared_ptr<Mutex> getMutex(TSHttpTxn);
+
 private:
   TransactionPluginState *state_; /**< The internal state for a TransactionPlugin */
   friend class utils::internal;

--- a/src/tscpp/api/TransactionPlugin.cc
+++ b/src/tscpp/api/TransactionPlugin.cc
@@ -71,6 +71,12 @@ TransactionPlugin::getMutex()
   return state_->mutex_;
 }
 
+std::shared_ptr<Mutex>
+TransactionPlugin::getMutex(TSHttpTxn txnp)
+{
+  return state_->ats_txn_handle_ == txnp ? state_->mutex_ : nullptr;
+}
+
 bool
 TransactionPlugin::isWebsocket() const
 {

--- a/src/tscpp/api/utils_internal.h
+++ b/src/tscpp/api/utils_internal.h
@@ -55,7 +55,7 @@ namespace utils
     static HttpVersion getHttpVersion(TSMBuffer hdr_buf, TSMLoc hdr_loc);
     static void initTransactionManagement();
     static std::string consumeFromTSIOBufferReader(TSIOBufferReader);
-    static std::shared_ptr<Mutex> getTransactionPluginMutex(TransactionPlugin &);
+    static std::shared_ptr<Mutex> getTransactionPluginMutex(TransactionPlugin &, TSHttpTxn);
     static Transaction &getTransaction(TSHttpTxn);
 
     static AsyncHttpFetchState *


### PR DESCRIPTION
A fix that we are running in prod to prevent the below crashes

```
(gdb) bt
#0  __atomic_add (__val=1, __mem=0x64006469756767) at /usr/include/c++/4.8.2/ext/atomicity.h:53
#1  __atomic_add_dispatch (__val=1, __mem=0x64006469756767) at /usr/include/c++/4.8.2/ext/atomicity.h:96
#2  _M_add_ref_copy (this=0x6400646975675f) at /usr/include/c++/4.8.2/bits/shared_ptr_base.h:131
#3  __shared_count (__r=..., this=0x2adb99107a58) at /usr/include/c++/4.8.2/bits/shared_ptr_base.h:553
#4  __shared_ptr (this=this@entry=0x2adb99107a50) at /usr/include/c++/4.8.2/bits/shared_ptr_base.h:779
#5  shared_ptr (this=this@entry=0x2adb99107a50) at /usr/include/c++/4.8.2/bits/shared_ptr.h:103
#6  atscppapi::TransactionPlugin::getMutex (this=this@entry=0x2adc02a8c240) at TransactionPlugin.cc:75
#7  0x00002adbb0a24d79 in atscppapi::utils::internal::getTransactionPluginMutex (transaction_plugin=...) at utils_internal.cc:192
#8  0x00002adbb0a24d96 in (anonymous namespace)::cleanupTransactionPlugin (plugin=0x2adc02a8c240) at utils_internal.cc:56
#9  0x00002adbb0a25021 in (anonymous namespace)::handleTransactionEvents (cont=<optimized out>, event=<optimized out>, edata=0x2adc33b3d4b0) at utils_internal.cc:101
#10 0x00000000004c4a03 in INKContInternal::handle_event (this=0x2adbb0588f40, event=60012, edata=0x2adc33b3d4b0) at InkAPI.cc:1012
#11 0x00000000005b5c8f in HttpSM::state_api_callout (this=0x2adc33b3d4b0, event=<optimized out>, data=<optimized out>) at HttpSM.cc:1640
#12 0x00000000005bc02a in HttpSM::kill_this (this=this@entry=0x2adc33b3d4b0) at HttpSM.cc:7041
#13 0x00000000005bcef0 in HttpSM::main_handler (this=0x2adc33b3d4b0, event=2301, data=0x2adc33b3e840) at HttpSM.cc:2960
#14 0x00000000005ff1dd in handleEvent (data=0x2adc33b3e840, event=2301, this=<optimized out>) at ../../iocore/eventsystem/I_Continuation.h:153
#15 HttpTunnel::main_handler (this=0x2adc33b3e840, event=<optimized out>, data=<optimized out>) at HttpTunnel.cc:1642
#16 0x000000000076e10e in handleEvent (data=0x2adc4e83a5d8, event=103, this=<optimized out>) at ../../iocore/eventsystem/I_Continuation.h:153
#17 write_signal_and_update (vc=0x2adc4e83a440, event=103) at UnixNetVConnection.cc:179
#18 write_signal_done (vc=0x2adc4e83a440, nh=0x2adb9550af20, event=103) at UnixNetVConnection.cc:224
#19 write_to_net_io (nh=nh@entry=0x2adb9550af20, vc=0x2adc4e83a440, thread=<optimized out>) at UnixNetVConnection.cc:564
#20 0x000000000076e468 in write_to_net (nh=nh@entry=0x2adb9550af20, vc=vc@entry=0x2adc4e83a440, thread=<optimized out>) at UnixNetVConnection.cc:421
#21 0x000000000075df74 in NetHandler::mainNetEvent (this=0x2adb9550af20, event=<optimized out>, e=<optimized out>) at UnixNet.cc:535
#22 0x000000000078fa7f in handleEvent (data=0x2adb94bfe4c0, event=5, this=<optimized out>) at I_Continuation.h:153
#23 process_event (calling_code=5, e=0x2adb94bfe4c0, this=0x2adb95507000) at UnixEThread.cc:152
#24 EThread::execute (this=0x2adb95507000) at UnixEThread.cc:279
#25 0x000000000078e68a in spawn_thread_internal (a=0x2adb939a9130) at Thread.cc:86
#26 0x00002adb91387dc5 in start_thread () from /lib64/libpthread.so.0
#27 0x00002adb9242176d in clone () from /lib64/libc.so.6
(gdb) f 7
#7  0x00002adbb0a24d79 in atscppapi::utils::internal::getTransactionPluginMutex (transaction_plugin=...) at utils_internal.cc:192
192 utils_internal.cc: No such file or directory.
(gdb) p *transaction_plugin.state_.cont_
$1 = <incomplete type>
(gdb) p *(INKContInternal*)transaction_plugin.state_.cont_
Cannot access memory at address 0x0
(gdb) p *(INKContInternal*)transaction_plugin.state_      
$2 = {<DummyVConnection> = {<VConnection> = {<Continuation> = {<force_VFPT_to_top> = {_vptr.force_VFPT_to_top = 0x0}, handler = NULL, mutex = {m_ptr = 0x31313a}, link = {<SLink<Continuation>> = {next = 0x0}, prev = 0x20000000}, control_flags = {raw_flags = 301989888}}, lerrno = 496274542}, <No data fields>}, 
  mdata = 0x5ab7f2e0263b5896, m_event_func = 0x7126c1efbc02ad50, m_event_count = -820720873, m_closed = 1447507213, m_deletable = -1059571869, m_deleted = -597350145, m_free_magic = 2566914090}
(gdb) p *(INKContInternal*)transaction_plugin       
Cannot access memory at address 0x7673652d646f7270
(gdb) p *transaction_plugin.state_
$3 = {<atscppapi::noncopyable> = {<No data fields>}, cont_ = 0x0, ats_txn_handle_ = 0x0, mutex_ = <error reading variable: Cannot access memory at address 0x313142>}
(gdb) p *transaction_plugin       
No symbol "operator*" in current context.
(gdb) p transaction_plugin
$4 = (atscppapi::TransactionPlugin &) @0x2adc02a8c240: {<atscppapi::Plugin> = {<atscppapi::noncopyable> = {<No data fields>}, _vptr.Plugin = 0x7673652d646f7270}, state_ = 0x2adbe3790035}
(gdb) p transaction_plugin.state_
$5 = (atscppapi::TransactionPluginState *) 0x2adbe3790035
(gdb) p *transaction_plugin.state_
$6 = {<atscppapi::noncopyable> = {<No data fields>}, cont_ = 0x0, ats_txn_handle_ = 0x0, mutex_ = <error reading variable: Cannot access memory at address 0x313142>}
(gdb) f
#7  0x00002adbb0a24d79 in atscppapi::utils::internal::getTransactionPluginMutex (transaction_plugin=...) at utils_internal.cc:192
192 in utils_internal.cc
(gdb) up
#8  0x00002adbb0a24d96 in (anonymous namespace)::cleanupTransactionPlugin (plugin=0x2adc02a8c240) at utils_internal.cc:56
56  in utils_internal.cc
(gdb) p *(TransactionPlugin*)0x2adc02a8c240
$7 = {<atscppapi::Plugin> = {<atscppapi::noncopyable> = {<No data fields>}, _vptr.Plugin = 0x7673652d646f7270}, state_ = 0x2adbe3790035}
(gdb) p *(TransactionPlugin*)0x2adc02a8c240.state_
Invalid number "0x2adc02a8c240.state".
(gdb) p *((TransactionPlugin*)0x2adc02a8c240).state_
$8 = {<atscppapi::noncopyable> = {<No data fields>}, cont_ = 0x0, ats_txn_handle_ = 0x0, mutex_ = <error reading variable: Cannot access memory at address 0x313142>}
(gdb) up
#9  0x00002adbb0a25021 in (anonymous namespace)::handleTransactionEvents (cont=<optimized out>, event=<optimized out>, edata=0x2adc33b3d4b0) at utils_internal.cc:101
101 in utils_internal.cc
(gdb) p *transaction
No symbol "operator*" in current context.
(gdb) p transaction.state_
$9 = (atscppapi::TransactionState *) 0x2adb9f459cc0
(gdb) p *transaction.state_
$10 = {<atscppapi::noncopyable> = {<No data fields>}, txn_ = 0x2adc33b3d4b0, plugins_ = std::list = {[0] = 0x2adc02a8c240, [1] = 0x2adbe092f630}, client_request_hdr_buf_ = 0x2adc33b3dc38, client_request_hdr_loc_ = 0x2adbf9432088, client_request_ = {<atscppapi::Request> = {<atscppapi::noncopyable> = {<No data fields>}, 
      state_ = 0x2adb9f7f8080}, state_ = 0x2adbf7d62c60}, server_request_hdr_buf_ = 0x2adc33b3dcb8, server_request_hdr_loc_ = 0x2adbd2a5b888, server_request_ = {<atscppapi::noncopyable> = {<No data fields>}, state_ = 0x2adba2320680}, server_response_hdr_buf_ = 0x2adc33b3dcf8, server_response_hdr_loc_ = 0x2adbce275088, 
  server_response_ = {<atscppapi::noncopyable> = {<No data fields>}, state_ = 0x2adb9f42fb80}, client_response_hdr_buf_ = 0x2adc33b3dc78, client_response_hdr_loc_ = 0x2adbcd8e2088, client_response_ = {<atscppapi::noncopyable> = {<No data fields>}, state_ = 0x2adbf7d789a0}, cached_response_hdr_buf_ = 0x0, 
  cached_response_hdr_loc_ = 0x0, cached_response_ = {<atscppapi::noncopyable> = {<No data fields>}, state_ = 0x2adbf7d78f20}, cached_request_hdr_buf_ = 0x0, cached_request_hdr_loc_ = 0x0, cached_request_ = {<atscppapi::noncopyable> = {<No data fields>}, state_ = 0x2adb9f7bfdc0}, context_values_ = std::map with 0 elements}
(gdb) p *(TransactionPlugin*)0x2adc02a8c240
$11 = {<atscppapi::Plugin> = {<atscppapi::noncopyable> = {<No data fields>}, _vptr.Plugin = 0x7673652d646f7270}, state_ = 0x2adbe3790035}
(gdb) p *((TransactionPlugin*)0x2adc02a8c240).state_
$12 = {<atscppapi::noncopyable> = {<No data fields>}, cont_ = 0x0, ats_txn_handle_ = 0x0, mutex_ = <error reading variable: Cannot access memory at address 0x313142>}
(gdb) p *((TransactionPlugin*)0x2adc02a8c240)       
$13 = {<atscppapi::Plugin> = {<atscppapi::noncopyable> = {<No data fields>}, _vptr.Plugin = 0x7673652d646f7270}, state_ = 0x2adbe3790035}
```