### PR TITLE
Remove dup code in QUICMultiCertConfigLoader

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -89,7 +89,8 @@ protected:
                              std::set<std::string> &names);
 
 private:
-  virtual bool _store_ssl_ctx(SSLCertLookup *lookup, shared_SSLMultiCertConfigParams ssl_multi_cert_params);
+  virtual const char *_debug_tag() const;
+  bool _store_ssl_ctx(SSLCertLookup *lookup, shared_SSLMultiCertConfigParams ssl_multi_cert_params);
   virtual void _set_handshake_callbacks(SSL_CTX *ctx);
 };
 

--- a/iocore/net/QUICMultiCertConfigLoader.h
+++ b/iocore/net/QUICMultiCertConfigLoader.h
@@ -51,7 +51,7 @@ public:
                                const SSLMultiCertConfigParams *sslMultCertSettings, std::set<std::string> &names) override;
 
 private:
-  bool _store_ssl_ctx(SSLCertLookup *lookup, shared_SSLMultiCertConfigParams ssl_multi_cert_params) override;
+  const char *_debug_tag() const override;
   virtual void _set_handshake_callbacks(SSL_CTX *ssl_ctx) override;
   static int ssl_select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
                                       unsigned inlen, void *);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1406,7 +1406,7 @@ SSLMultiCertConfigLoader::_store_ssl_ctx(SSLCertLookup *lookup, const shared_SSL
     if (0 > SSLMultiCertConfigLoader::check_server_cert_now(cert, current_cert_name)) {
       /* At this point, we know cert is bad, and we've already printed a
          descriptive reason as to why cert is bad to the log file */
-      Debug("ssl", "Marking certificate as NOT VALID: %s", current_cert_name);
+      Debug(this->_debug_tag(), "Marking certificate as NOT VALID: %s", current_cert_name);
       lookup->is_valid = false;
     }
     i++;
@@ -1421,7 +1421,7 @@ SSLMultiCertConfigLoader::_store_ssl_ctx(SSLCertLookup *lookup, const shared_SSL
       names.append(name);
       names.append(" ");
     }
-    Warning("Failed to insert SSL_CTX for certificate %s entries for names already made", names.c_str());
+    Warning("(%s) Failed to insert SSL_CTX for certificate %s entries for names already made", this->_debug_tag(), names.c_str());
   }
 
   for (auto iter = unique_names.begin(); retval && iter != unique_names.end(); ++iter) {
@@ -2236,6 +2236,12 @@ fail:
   EVP_MD_CTX_free(digest);
 
   return result;
+}
+
+const char *
+SSLMultiCertConfigLoader::_debug_tag() const
+{
+  return "ssl";
 }
 
 /**


### PR DESCRIPTION
The only difference between `SSLMultiCertConfigLoader::_store_ssl_ctx` and `QUICMultiCertConfigLoader::_store_ssl_ctx` was whether it says "QUIC" on log outputs.

This commit removes the long dup code and introduces `_debug_tag()` so that derived classes can override the debug tag.

Also, this is actually for #6933. I could request or make the same change for QUICMultiCertConfigLoader but unifying the code would make more sense.