### PR TITLE
Reduce case sensitivity of chunked_encoding test

### DIFF
--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -138,7 +138,7 @@ tr.StillRunningAfter = server
 
 server4_out = Test.Disk.File("outserver4")
 server4_out.Content = Testers.ExcludesExpression("sneaky", "Extra body bytes should not be delivered")
-server4_out.Content += Testers.ContainsExpression("Transfer-Encoding: chunked", "Request should be chunked encoded")
+server4_out.Content += Testers.ContainsExpression("Transfer-[Ee]ncoding: chunked", "Request should be chunked encoded")
 
 # HTTP/1.1 Try to smuggle another request to the origin
 tr = Test.AddTestRun()


### PR DESCRIPTION
Noticed PR #6908 and PR #6935 are getting blocked by the chunked_encoding test.  Looks like there was a change in case of Transfer-Encoding -> Transfer-encoding

This PR at least eliminates caring about the case of the E