### PR TITLE
Prevent buffer overflow during log filter actions

### DIFF
--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1144,7 +1144,7 @@ void
 LogAccess::set_client_req_url(char *buf, int len)
 {
   if (buf) {
-    m_client_req_url_len = len;
+    m_client_req_url_len = std::min(len, m_client_req_url_len);
     ink_strlcpy(m_client_req_url_str, buf, m_client_req_url_len + 1);
   }
 }
@@ -1153,7 +1153,7 @@ void
 LogAccess::set_client_req_url_canon(char *buf, int len)
 {
   if (buf) {
-    m_client_req_url_canon_len = len;
+    m_client_req_url_canon_len = std::min(len, m_client_req_url_canon_len);
     ink_strlcpy(m_client_req_url_canon_str, buf, m_client_req_url_canon_len + 1);
   }
 }
@@ -1162,7 +1162,7 @@ void
 LogAccess::set_client_req_unmapped_url_canon(char *buf, int len)
 {
   if (buf && m_client_req_unmapped_url_canon_str) {
-    m_client_req_unmapped_url_canon_len = len;
+    m_client_req_unmapped_url_canon_len = std::min(len, m_client_req_unmapped_url_canon_len);
     ink_strlcpy(m_client_req_unmapped_url_canon_str, buf, m_client_req_unmapped_url_canon_len + 1);
   }
 }
@@ -1171,7 +1171,7 @@ void
 LogAccess::set_client_req_unmapped_url_path(char *buf, int len)
 {
   if (buf && m_client_req_unmapped_url_path_str) {
-    m_client_req_unmapped_url_path_len = len;
+    m_client_req_unmapped_url_path_len = std::min(len, m_client_req_unmapped_url_path_len);
     ink_strlcpy(m_client_req_unmapped_url_path_str, buf, m_client_req_unmapped_url_path_len + 1);
   }
 }
@@ -1180,7 +1180,7 @@ void
 LogAccess::set_client_req_unmapped_url_host(char *buf, int len)
 {
   if (buf && m_client_req_unmapped_url_host_str) {
-    m_client_req_unmapped_url_host_len = len;
+    m_client_req_unmapped_url_host_len = std::min(len, m_client_req_unmapped_url_host_len);
     ink_strlcpy(m_client_req_unmapped_url_host_str, buf, m_client_req_unmapped_url_host_len + 1);
   }
 }
@@ -1190,7 +1190,7 @@ LogAccess::set_client_req_url_path(char *buf, int len)
 {
   //?? use m_client_req_unmapped_url_path_str for now..may need to enhance later..
   if (buf && m_client_req_unmapped_url_path_str) {
-    m_client_req_url_path_len = len;
+    m_client_req_url_path_len = std::min(len, m_client_req_url_path_len);
     ink_strlcpy(m_client_req_unmapped_url_path_str, buf, m_client_req_url_path_len + 1);
   }
 }


### PR DESCRIPTION
Buffer overflow resulting in corrupting global variables when the
unmapped URL is pointing to the global INVALID_STR (default initial value).

This fixes #6946 


ASAN report

```
(gdb) p hostdb_max_iobuf_index
$12 = 1769172816
(gdb) p http_global_hooks
$13 = (HttpAPIHooks *) 0x2b2ee301e000
(gdb) p invalid_str
No symbol "invalid_str" in current context.
(gdb) p INVALID_STR
$14 = 0xaa2c10 <INVALID_STR> "https://www.link\005"
================================================================
==3885==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00000142ccce at pc 0x2b30bb9d5a65 bp 0x2b30c6a53370 sp 0x2b30c6a53368
WRITE of size 1 at 0x00000142ccce thread T21 ([ET_NET 19])
    #0 0x2b30bb9d5a64 in ink_strlcpy(char*, char const*, unsigned long) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/src/tscore/ink_string.cc:183
    #1 0x9d3268 in LogFilterString::wipe_this_entry(LogAccess*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/logging/LogFilter.cc:370
    #2 0x9e3c5f in LogFilterList::wipe_this_entry(LogAccess*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/logging/LogFilter.cc:1016
    #3 0x9ffe0e in LogObject::log(LogAccess*, std::basic_string_view<char, std::char_traits<char> >) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/logging/LogObject.cc:546
    #4 0x9ffe0e in LogObject::log(LogAccess*, char const*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/logging/LogObject.cc:517
    #5 0x9ffe0e in LogObjectManager::log(LogAccess*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/logging/LogObject.cc:1277
    #6 0x981a0a in Log::access(LogAccess*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/logging/Log.cc:1157
    #7 0x6f91b5 in HttpSM::kill_this() /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/http/HttpSM.cc:7083
    #8 0x6fa12f in HttpSM::main_handler(int, void*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/http/HttpSM.cc:2723
    #9 0x81051b in Continuation::handleEvent(int, void*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/eventsystem/I_Continuation.h:190
    #10 0x81051b in HttpTunnel::main_handler(int, void*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/proxy/http/HttpTunnel.cc:1629
    #11 0xeb62b1 in Continuation::handleEvent(int, void*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/eventsystem/I_Continuation.h:190
    #12 0xeb62b1 in write_signal_and_update /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/net/UnixNetVConnection.cc:115
    #13 0xeb62b1 in write_signal_done /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/net/UnixNetVConnection.cc:161
    #14 0xed0d2a in write_to_net_io(NetHandler*, UnixNetVConnection*, EThread*) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/net/UnixNetVConnection.cc:494
    #15 0xe6f793 in NetHandler::process_ready_list() /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/net/UnixNet.cc:429
    #16 0xe703d8 in NetHandler::waitForActivity(long) /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/net/UnixNet.cc:547
    #17 0xfe515e in EThread::execute_regular() /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/eventsystem/UnixEThread.cc:266
    #18 0xfe5ab1 in EThread::execute() /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/eventsystem/UnixEThread.cc:327
    #19 0xfdff1a in spawn_thread_internal /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/iocore/eventsystem/Thread.cc:92
    #20 0x2b30bd7bfdd4 in start_thread (/lib64/libpthread.so.0+0x7dd4)
    #21 0x2b30be570eac in __clone (/lib64/libc.so.6+0xfdeac)

0x00000142ccce is located 0 bytes to the right of global variable 'INVALID_STR' defined in 'LogAccess.cc:35:6' (0x142ccc0) of size 14
SUMMARY: AddressSanitizer: global-buffer-overflow /home/xinli1/work/prj/ats9/core/ats-core_BR_HF_ats9/ats9/src/src/tscore/ink_string.cc:183 in ink_strlcpy(char*, char const*, unsigned long)
Shadow bytes around the buggy address:
  0x00008027d940: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d950: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d960: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d970: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x00008027d990: 00 00 00 00 00 00 00 00 00[06]f9 f9 f9 f9 f9 f9
  0x00008027d9a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d9b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d9c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d9d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x00008027d9e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
```

Other stack traces showing the global variable corruption affecting UserArgTable

```
Program terminated with signal 11, Segmentation fault.
#0  head (this=0x2541302541302589) at traffic_server/InkAPI.cc:1339
1339	traffic_server/InkAPI.cc: No such file or directory.
(gdb) bt
#0  head (this=0x2541302541302589) at traffic_server/InkAPI.cc:1339
#1  init (id=TS_HTTP_READ_RESPONSE_HDR_HOOK, feature_hooks=<optimized out>, this=0x2ae24e773ae8) at traffic_server/InkAPI.cc:1427
#2  HttpHookState::init (this=0x2ae24e773ae0, id=TS_HTTP_READ_RESPONSE_HDR_HOOK, global=<optimized out>, ssn=0x2ae20d377600, txn=0x2ae24e773b50) at traffic_server/InkAPI.cc:1370
#3  0x000000000054f3cd in HttpSM::do_api_callout_internal (this=0x2ae24e771920) at HttpSM.cc:5332
#4  0x000000000055d605 in HttpSM::do_api_callout (this=this@entry=0x2ae24e771920) at HttpSM.cc:365
#5  0x000000000054fcab in HttpSM::state_read_server_response_header (this=0x2ae24e771920, event=100, data=0x2ae2ae30c2c0) at HttpSM.cc:2006
#6  0x0000000000551f68 in HttpSM::main_handler (this=0x2ae24e771920, event=100, data=0x2ae2ae30c2c0) at HttpSM.cc:2710
#7  0x0000000000776a03 in handleEvent (data=0x2ae2ae30c2c0, event=100, this=0x2ae24e771920) at /home/svinukon/Traffic/ATS/ats9/ats-core_trunk/ats9/src/iocore/eventsystem/I_Continuation.h:190
#8  read_signal_and_update (event=100, vc=0x2ae2ae30c0e0) at UnixNetVConnection.cc:83
#9  0x000000000077d1ee in read_from_net (nh=0x2ae18a009dd0, vc=0x2ae2ae30c0e0, thread=0x2ae18a006000) at UnixNetVConnection.cc:314
#10 0x0000000000762ee8 in NetHandler::process_ready_list (this=this@entry=0x2ae18a009dd0) at UnixNet.cc:412
#11 0x00000000007631dd in NetHandler::waitForActivity (this=0x2ae18a009dd0, timeout=<optimized out>) at UnixNet.cc:547
#12 0x00000000007c6eba in EThread::execute_regular (this=this@entry=0x2ae18a006000) at UnixEThread.cc:266
#13 0x00000000007c7182 in EThread::execute (this=0x2ae18a006000) at UnixEThread.cc:327
#14 0x00000000007c5529 in spawn_thread_internal (a=0x2ae188569e40) at Thread.cc:92
#15 0x00002ae18652add5 in start_thread () from /lib64/libpthread.so.0
#16 0x00002ae1872dbead in clone () from /lib64/libc.so.6
(gdb) p hostdb_max_iobuf_index
$1 = 808592688
(gdb) p sizeof9hostdb_max_iobuf_index)
p sizeof(No symbol "sizeof9hostdb_max_iobuf_index" in current context.
(gdb) p sizeof(hostdb_max_iobuf_index)
$2 = 4
(gdb) p (int)0x2541302541302589
$3 = 1093674377
(gdb) p http_global_hooks
$4 = (HttpAPIHooks *) 0x2541302541302541
(gdb) p ssl_hooks
$5 = (SslAPIHooks *) 0x3025413025413025
(gdb) p lifecycle_hoooks
No symbol "lifecycle_hoooks" in current context.
(gdb) p lifecycle_hooks
$6 = (LifecycleAPIHooks *) 0x4130254130254130
(gdb) p TS_HTTP_LEN_PUSH
$7 = 807747888
(gdb) p TS_HTTP_LEN_CONNECT
$8 = 807747888
(gdb) p TS_HTTP_METHOD_CONNECT
$9 = 0x2541302541302541 <Address 0x2541302541302541 out of bounds>
(gdb) p TS_HTTP_VALUE_BYTES
$10 = 0x3025413025413025 <Address 0x3025413025413025 out of bounds>
(gdb) p TS_MIME_LEN_ACCEPT
$11 = 1093674305
(gdb) p MIME_LEN_ACCEPT
$12 = 6
(gdb) p TS_MIME_FIELD_ACCEPT
$13 = 0x4130254130254130 <Address 0x4130254130254130 out of bounds>
(gdb) p TS_URL_SCHEME_FILE
$14 = 0x4130254130254130 <Address 0x4130254130254130 out of bounds>
(gdb) p TS_USER_ARGS_COUNT
$15 = TS_USER_ARGS_COUNT
(gdb) p TS_USER_ARGS_GLB
$16 = TS_USER_ARGS_GLB
(gdb) p UserArgTable
$17 = {{{type = 1818585446, name = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x676e6e6576303425 <Address 0x676e6e6576303425 out of bounds>}, _M_string_length = 7885630523655417714, {
          _M_local_buf = "%0A%0A%23contrac", _M_allocated_capacity = 3613365951073955877}}, description = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, 
          _M_p = 0x6833322530322574 <Address 0x6833322530322574 out of bounds>}, _M_string_length = 8241978093345726821, {_M_local_buf = "e%20%23%20dynami", _M_allocated_capacity = 2680541338519348581}}}, {type = 841315171, name = {static npos = 18446744073709551615, 
        _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x6c657665646d7263 <Address 0x6c657665646d7263 out of bounds>}, _M_string_length = 2756537384318627951, {_M_local_buf = "includeFollowed=", _M_allocated_capacity = 5072571010795138665}}, 
      description = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x6572702665757274 <Address 0x6572702665757274 out of bounds>}, _M_string_length = 6365935209299863910, {_M_local_buf = "XXXXXXXX&q=hasht", 
          _M_allocated_capacity = 6365935209750747224}}}, {type = 7563105, name = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab0868 <UserArgTable+168> ""}, _M_string_length = 0, {
          _M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}, description = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab0888 <UserArgTable+200> ""}, _M_string_length = 0, {
          _M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}}, {type = TS_USER_ARGS_TXN, name = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab08b0 <UserArgTable+240> ""}, 
        _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}, description = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab08d0 <UserArgTable+272> ""}, 
        _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}}, {type = TS_USER_ARGS_TXN, name = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, 
          _M_p = 0xab08f8 <UserArgTable+312> ""}, _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}, description = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, 
          _M_p = 0xab0918 <UserArgTable+344> ""}, _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}}, {type = TS_USER_ARGS_TXN, name = {static npos = 18446744073709551615, 
        _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab0940 <UserArgTable+384> ""}, _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}, description = {static npos = 18446744073709551615, 
        _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab0960 <UserArgTable+416> ""}, _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}}, {type = TS_USER_ARGS_TXN, name = {
        static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab0988 <UserArgTable+456> ""}, _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}, description = {
        static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab09a8 <UserArgTable+488> ""}, _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}}, {type = TS_USER_ARGS_TXN, 
      name = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0xab09d0 <UserArgTable+528> ""}, _M_string_length = 0, {_M_local_buf = '\000' <repeats 15 times>, _M_allocated_capacity = 0}}, description = {

```

```
Program terminated with signal 11, Segmentation fault.
#0  0x000000000072c715 in printv<ts::bwf::detail::MemDump&> (args=..., fmt=..., this=0x2b17f32046c0) at ../../include/tscore/BufferWriter.h:649
649	../../include/tscore/BufferWriter.h: No such file or directory.
(gdb) bt
#0  0x000000000072c715 in printv<ts::bwf::detail::MemDump&> (args=..., fmt=..., this=0x2b17f32046c0) at ../../include/tscore/BufferWriter.h:649
#1  print<ts::bwf::detail::MemDump> (fmt=..., this=0x2b17f32046c0) at ../../include/tscore/BufferWriter.h:884
#2  SSLAddressLookupKey (ip=..., this=0x2b17f3204700) at SSLCertLookup.cc:54
#3  SSLCertLookup::find (this=this@entry=0x2b17edbdf0a0, address=...) at SSLCertLookup.cc:303
#4  0x000000000073dc8f in SSLNetVConnection::sslStartHandShake (this=0x2b182dfc1000, event=0, err=@0x2b17f3204ac0: 0) at SSLNetVConnection.cc:1009
#5  0x000000000073c2d3 in SSLNetVConnection::net_read_io (this=0x2b182dfc1000, nh=0x2b17ed623dd0, lthread=0x2b17ed620000) at SSLNetVConnection.cc:562
#6  0x000000000075c938 in NetHandler::process_ready_list (this=this@entry=0x2b17ed623dd0) at UnixNet.cc:412
#7  0x000000000075cc2d in NetHandler::waitForActivity (this=0x2b17ed623dd0, timeout=<optimized out>) at UnixNet.cc:547
#8  0x00000000007c04ea in EThread::execute_regular (this=this@entry=0x2b17ed620000) at UnixEThread.cc:266
#9  0x00000000007c07b2 in EThread::execute (this=0x2b17ed620000) at UnixEThread.cc:327
#10 0x00000000007beb59 in spawn_thread_internal (a=0x2b17ea96d2c0) at Thread.cc:92
#11 0x00002b17e866edd5 in start_thread () from /lib64/libpthread.so.0
#12 0x00002b17e941fead in clone () from /lib64/libc.so.6
(gdb) p hostdb_max_iobuf_index
$1 = 1482184792
(gdb) p INVALID_STR
$2 = 0xaa2c10 <INVALID_STR> "https://www.linkedin.com/voyager/api/typeahead/hits?q=federated&query=", 'X' <repeats 130 times>...
(gdb) 

```