### PR TITLE
Cleanup: Remove unnecessary member from Http2Stream

### DIFF
--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -144,7 +144,6 @@ public:
   bool is_first_transaction_flag = false;
 
   HTTPHdr response_header;
-  IOBufferReader *response_reader          = nullptr;
   Http2DependencyTree::Node *priority_node = nullptr;
 
 private:


### PR DESCRIPTION
We needed `Http2Stream::response_reader` for `ChunkedHandler` in `Http2Stream`, but we removed it completely by #5901.