### PR TITLE
Assert on valid boundaries for UserArgTable access

### DIFF
--- a/include/tscore/PluginUserArgs.h
+++ b/include/tscore/PluginUserArgs.h
@@ -53,14 +53,14 @@ public:
   void *
   get_user_arg(size_t ix) const
   {
-    ink_assert(ix < user_args.size());
+    ink_release_assert(ix < user_args.size());
     return this->user_args[ix];
   };
 
   void
   set_user_arg(size_t ix, void *arg)
   {
-    ink_assert(ix < user_args.size());
+    ink_release_assert(ix < user_args.size());
     user_args[ix] = arg;
   };
 


### PR DESCRIPTION
We've run into quite a bit of pain dealing with global variable corruption while testing ATS9 in our prod. The root cause turned out to be #6950 , however, as part of that one of the suspicions we had was on the User Arg Table, which also creates a huge global data and looked corrupted in all the crashes we ran into. It's critical to ensure we are not running over/under the array boundaries when updating User Arg tables as otherwise the symptoms (global var corruption) would not be easy to troubleshoot.  

Note also that the older TxnArgSet and TxnArgGet API did have similar boundary checks as well, so, it seems reasonable to add release asserts even for User Arg table access.