### PR TITLE
Do not create Host Status stats for Origin servers.

### DIFF
--- a/src/traffic_server/HostStatus.cc
+++ b/src/traffic_server/HostStatus.cc
@@ -406,10 +406,6 @@ HostStatus::getHostStatus(const char *name)
     }
     _status->reasons = reasons;
   }
-  // didn't find this host in host status db, create the record
-  if (!lookup) {
-    createHostStat(name);
-  }
 
   return _status;
 }


### PR DESCRIPTION
Creating a host status stat for each origin server can blowup the stat system. 