### PR TITLE
Fix format string for int64_t

### DIFF
--- a/tests/gold_tests/continuations/plugins/session_id_verify.cc
+++ b/tests/gold_tests/continuations/plugins/session_id_verify.cc
@@ -20,9 +20,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-#include <ts/ts.h>    // for debug
-#include <cstdlib>    // for abort
-#include <inttypes.h> // for PRIu64
+#include <ts/ts.h>   // for debug
+#include <cstdlib>   // for abort
+#include <cinttypes> // for PRId64
 #include <unordered_set>
 
 // plugin registration info
@@ -43,11 +43,11 @@ global_handler(TSCont continuation, TSEvent event, void *data)
 
     static std::unordered_set<int64_t> seen_ids;
     if (seen_ids.find(id) != seen_ids.end()) {
-      TSError("[%s] Plugin encountered a duplicate session id: %ld", PLUGIN_NAME, id);
+      TSError("[%s] Plugin encountered a duplicate session id: %" PRId64, PLUGIN_NAME, id);
     } else {
       seen_ids.insert(id);
     }
-    TSDebug(PLUGIN_NAME, "session id: %ld", id);
+    TSDebug(PLUGIN_NAME, "session id: %" PRId64, id);
   } break;
 
   default:


### PR DESCRIPTION
Fix warnings on macOS after #6945.
```
  CXX      gold_tests/continuations/plugins/session_id_verify.lo
gold_tests/continuations/plugins/session_id_verify.cc:46:83: error: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
      TSError("[%s] Plugin encountered a duplicate session id: %ld", PLUGIN_NAME, id);
                                                               ~~~                ^~
                                                               %lld
gold_tests/continuations/plugins/session_id_verify.cc:50:45: error: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
    TSDebug(PLUGIN_NAME, "session id: %ld", id);
                                      ~~~   ^~
                                      %lld
2 errors generated.
```