### PR TITLE
Backport 7.1.x: HTTP/2: ignore unknown settings

### DIFF
--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -152,7 +152,8 @@ http2_settings_parameter_is_valid(const Http2SettingsParameter &param)
   };
 
   if (param.id == 0 || param.id >= HTTP2_SETTINGS_MAX) {
-    return false;
+    // Do nothing - 6.5.2 Unsupported parameters MUST be ignored
+    return true;
   }
 
   if (param.value > settings_max[param.id]) {

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -85,7 +85,7 @@ public:
     if (id < HTTP2_SETTINGS_MAX) {
       return this->settings[indexof(id)] = value;
     } else {
-      ink_assert(!"Bad Settings Identifier");
+      // Do nothing - 6.5.2 Unsupported parameters MUST be ignored
     }
 
     return 0;


### PR DESCRIPTION
(cherry picked from commit 74d65887625fe9a291a27520598dc93326d800b0)

Fixes https://github.com/apache/trafficserver/issues/6964

Netlify has been running with this patch for a week and it fixes the problem described in the Chromium issue.