### PR TITLE
Add new test and fix for float configuration failure in conf_remap

### DIFF
--- a/plugins/conf_remap/conf_remap.cc
+++ b/plugins/conf_remap/conf_remap.cc
@@ -63,6 +63,8 @@ str_to_datatype(const char *str)
     type = TS_RECORDDATATYPE_INT;
   } else if (!strcmp(str, "STRING")) {
     type = TS_RECORDDATATYPE_STRING;
+  } else if (!strcmp(str, "FLOAT")) {
+    type = TS_RECORDDATATYPE_FLOAT;
   }
 
   return type;
@@ -105,6 +107,9 @@ RemapConfigs::parse_inline(const char *arg)
       _items[_current]._data.rec_string = TSstrdup(value.c_str());
       _items[_current]._data_len        = value.size();
     }
+    break;
+  case TS_RECORDDATATYPE_FLOAT:
+    _items[_current]._data.rec_float = strtof(value.c_str(), nullptr);
     break;
   default:
     TSError("[%s] Configuration variable '%s' is of an unsupported type", PLUGIN_NAME, key.c_str());
@@ -181,7 +186,7 @@ RemapConfigs::parse_file(const char *filename)
     // Find the type (INT or STRING only)
     tok = strtok_r(nullptr, " \t", &ln);
     if (TS_RECORDDATATYPE_NULL == (type = str_to_datatype(tok))) {
-      TSError("[%s] file %s, line %d: only INT and STRING types supported", PLUGIN_NAME, path.c_str(), line_num);
+      TSError("[%s] file %s, line %d: only INT, STRING, and FLOAT types supported", PLUGIN_NAME, path.c_str(), line_num);
       continue;
     }
 
@@ -230,6 +235,9 @@ RemapConfigs::parse_file(const char *filename)
         _items[_current]._data.rec_string = TSstrdup(tok);
         _items[_current]._data_len        = strlen(tok);
       }
+      break;
+    case TS_RECORDDATATYPE_FLOAT:
+      _items[_current]._data.rec_float = strtof(tok, nullptr);
       break;
     default:
       TSError("[%s] file %s, line %d: type not support (unheard of)", PLUGIN_NAME, path.c_str(), line_num);
@@ -329,6 +337,10 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo * /* rri ATS_UNUSED */
       case TS_RECORDDATATYPE_STRING:
         TSHttpTxnConfigStringSet(txnp, conf->_items[ix]._name, conf->_items[ix]._data.rec_string, conf->_items[ix]._data_len);
         TSDebug(PLUGIN_NAME, "Setting config id %d to %s", conf->_items[ix]._name, conf->_items[ix]._data.rec_string);
+        break;
+      case TS_RECORDDATATYPE_FLOAT:
+        TSHttpTxnConfigFloatSet(txnp, conf->_items[ix]._name, conf->_items[ix]._data.rec_int);
+        TSDebug(PLUGIN_NAME, "Setting config id %d to %f", conf->_items[ix]._name, conf->_items[ix]._data.rec_float);
         break;
       default:
         break; // Error ?

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -208,6 +208,11 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True, enabl
     tmpname = os.path.join(config_dir, fname)
     p.Disk.File(tmpname, id=make_id(fname), typename="ats:config")
 
+    # for conf_remap_float, used by conf_remap plugin
+    fname = "delain.config"
+    tmpname = os.path.join(config_dir, fname)
+    p.Disk.File(tmpname, id=make_id(fname), typename="ats:config")
+
     fname = "hosting.config"
     tmpname = os.path.join(config_dir, fname)
     p.Disk.File(tmpname, id=make_id(fname), typename="ats:config")

--- a/tests/gold_tests/remap/conf_remap_float.py
+++ b/tests/gold_tests/remap/conf_remap_float.py
@@ -1,0 +1,51 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import os
+
+Test.Summary = '''
+Test command: traffic_ctl config describe proxy.config.http.background_fill_completed_threshold (YTSATS-3309)
+'''
+Test.testName = 'Float in conf_remap Config Test'
+
+ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True)
+
+# Add dummy remap rule
+ts.Disk.remap_config.AddLine(
+    'map http://cdn.example.com/ http://origin.example.com/ @plugin=conf_remap.so @pparam={file}'.format(file=os.path.join(ts.RunDirectory, 'ts/config/delain.config'))
+)
+
+ts.Disk.delain_config.AddLine(
+    'CONFIG proxy.config.http.background_fill_completed_threshold FLOAT 0.500000'
+)
+
+#
+# Test body
+#
+
+# First reload
+tr = Test.AddTestRun("traffic_ctl command")
+tr.Env = ts.Env
+tr.TimeOut = 5
+tr.StillRunningAfter = ts
+
+p = tr.Processes.Default
+p.Command = "traffic_ctl config describe proxy.config.http.background_fill_completed_threshold"
+p.ReturnCode = 0
+p.StartBefore(Test.Processes.ts, ready=When.FileExists(os.path.join(tr.RunDirectory, 'ts/log/diags.log')))


### PR DESCRIPTION
Test that conf_remap can override float settings (e.g. proxy.config.http.background_fill_completed_threshold) successfully.