### PR TITLE
RateLimiting and Connection Config changes

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -414,19 +414,20 @@ Network
 
 .. ts:cv:: CONFIG proxy.config.net.max_connections_in INT 30000
 
-   The total number of client connections that the :program:`traffic_server`
-   can handle simultaneously. This should be tuned according to your memory size,
-   and expected work load (network, cpu etc). This limit includes both keepalive
-   and active client connections that :program:`traffic_server` can handle at
-   any given instant.
+   The total number of client requests that |TS| can handle simultaneously.
+   This should be tuned according to your memory size, and expected work load
+   (network, cpu etc). This limit includes both idle (keep alive) connections
+   and active requests that |TS| can handle at any given instant. The delta
+   between `proxy.config.net.max_connections_in` and `proxy.config.net.max_requests_in`
+   is the amount of maximum idle (keepalive) connections |TS| will maintain.
 
-.. ts:cv:: CONFIG proxy.config.net.max_active_connections_in INT 10000
+.. ts:cv:: CONFIG proxy.config.net.max_requests_in INT 0
 
-   The total number of active client connections that the |TS| can handle
-   simultaneously. This should be tuned according to your memory size,
-   and expected work load (network, cpu etc). If this is set to 0, active
-   connection tracking is disabled and active connections have no separate
-   limit and the total connections follow `proxy.config.net.connections_throttle`
+   The total number of concurrent requests or active client connections
+   that the |TS| can handle simultaneously. This should be tuned according
+   to your memory size, and expected work load (network, cpu etc). When
+   set to 0, active request tracking is disabled and max requests has no
+   separate limit and the total connections follow `proxy.config.net.connections_throttle`
 
 .. ts:cv:: CONFIG proxy.config.net.default_inactivity_timeout INT 86400
    :reloadable:

--- a/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
@@ -66,7 +66,7 @@ Network I/O
 .. ts:stat:: global proxy.process.net.connections_throttled_out integer
    :type: counter
 
-.. ts:stat:: global proxy.process.net.max.active.connections_throttled_in integer
+.. ts:stat:: global proxy.process.net.max.requests_throttled_in integer
    :type: counter
 
 .. ts:stat:: global proxy.process.net.default_inactivity_timeout_applied integer

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -142,8 +142,8 @@ register_net_stats()
                      (int)net_connections_throttled_in_stat, RecRawStatSyncSum);
   RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.connections_throttled_out", RECD_INT, RECP_PERSISTENT,
                      (int)net_connections_throttled_out_stat, RecRawStatSyncSum);
-  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.max.active.connections_throttled_in", RECD_INT, RECP_PERSISTENT,
-                     (int)net_connections_max_active_throttled_in_stat, RecRawStatSyncSum);
+  RecRegisterRawStat(net_rsb, RECT_PROCESS, "proxy.process.net.max.requests_throttled_in", RECD_INT, RECP_PERSISTENT,
+                     (int)net_requests_max_throttled_in_stat, RecRawStatSyncSum);
 }
 
 void

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -58,7 +58,7 @@ enum Net_Stats {
   net_tcp_accept_stat,
   net_connections_throttled_in_stat,
   net_connections_throttled_out_stat,
-  net_connections_max_active_throttled_in_stat,
+  net_requests_max_throttled_in_stat,
   Net_Stat_Count
 };
 

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -273,7 +273,7 @@ public:
   /// configuration settings for managing the active and keep-alive queues
   struct Config {
     uint32_t max_connections_in                 = 0;
-    uint32_t max_connections_active_in          = 0;
+    uint32_t max_requests_in                    = 0;
     uint32_t inactive_threshold_in              = 0;
     uint32_t transaction_no_activity_timeout_in = 0;
     uint32_t keep_alive_no_activity_timeout_in  = 0;
@@ -302,8 +302,8 @@ public:
   Config config; ///< Per thread copy of the @c global_config
   // Active and keep alive queue values that depend on other configuration values.
   // These are never updated directly, they are computed from other config values.
-  uint32_t max_connections_per_thread_in        = 0;
-  uint32_t max_connections_active_per_thread_in = 0;
+  uint32_t max_connections_per_thread_in = 0;
+  uint32_t max_requests_per_thread_in    = 0;
   /// Number of configuration items in @c Config.
   static constexpr int CONFIG_ITEM_COUNT = sizeof(Config) / sizeof(uint32_t);
   /// Which members of @c Config the per thread values depend on.

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -400,7 +400,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.net.max_connections_in", RECD_INT, "30000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.max_connections_active_in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.max_requests_active_in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
 
   //       ###########################


### PR DESCRIPTION
Conn config renaming to support a protocol agnostic
rate limiter (using request concurrency as opposed to
active connections)

Link to related talk during ATS Spring'20 Summit 

https://cwiki.apache.org/confluence/download/attachments/158863592/ATS%20Concurrency%20Limiter.pdf?version=1&modificationDate=1592327600000&api=v2

Email to dev/users@

```
Re: Connection and Timeout Tuning, config name changes in 9.x
Yahoo
/
Sent



Sudheer Vinukonda <sudheervinukonda@yahoo.com>
To:
dev@trafficserver.apache.org
Cc:
Users
,
Leif Hedstrom
,
SUSAN HINRICHS

Sat, May 16 at 10:41 AM

Thanks, Bryan! Based on the discussion with Bryan on slack, below is the newer proposed config changes: 

1) Rename "proxy.config.net.max_active_connections_in" to "proxy.config.net.max_requests_in"

2) Rename "proxy.config.http.server_max_connections" to "proxy.config.net.max_connections_out"

3) "proxy.config.net.max_connections_in" - This config will stay put to limit the max number of in-flight requests (concurrency) + idle (socket) connections 

4) "proxy.config.net.connections_throttle" - This config will stay put to limit the max number of open connections (FD, rlimits etc), but eventually will be deprecated and replaced with {{ "proxy.config.net.max_connections_in" + "proxy.config.net.max_connections_out" }}


Please provide any feedback/comments/concerns.


Thanks,

Sudheer


On Friday, May 15, 2020, 11:11:53 AM PDT, Bryan Call <bcall@apache.org> wrote:


After seeing the GitHub PR I think we should keep proxy.config.net.max_connections_in since it is the number of socket connections (active + idle) and then rename proxy.config.net.max_active_connections_in, as you suggested in your email, to proxy.config.net.max_active_requests_in or proxy.config.net.max_requests_in (as Sudheer suggested on Slack).

I would like to see us get rid of proxy.config.net.connections_throttle in the long term and use max_connections_in/out if possible.

-Bryan


> On May 12, 2020, at 5:17 PM, Sudheer Vinukonda <sudheervinukonda@yahoo.com.INVALID> wrote:
>
> 9.x (re)introduces a feature (it was accidentally "lost" during some unrelated refactoring) that will allow to configure limits on max "active" connections that can be allowed at any given time (https://github.com/apache/trafficserver/pull/6754)
> Given that this feature is based on tracking "active connections", it should work very well with HTTP/1.1 traffic (where, 1 active connection = 1 request). However, with HTTP/2 and stream multiplexing, this is no longer true and it isn't nearly as effective. One can still use an average number of concurrent streams/connection to configure the limits, but, ideally, what would work for both HTTP/1.1 and HTTP/2 (and going forward with QUIC/HTTP/3) would be to track and (rate) limit request level concurrency. There is some ongoing work on this and to align better with that work, we are proposing to make the below changes to existing configs with 9.x
>
> 1) Rename "proxy.config.net.max_connections_in" to "proxy.config.net.max_requests_in"
> 2) Rename "proxy.config.net.max_active_connections_in" to "proxy.config.net.max_active_requests_in"
> 3) proxy.config.net.connections_throttle - This config will stay put to limit the max number of open connections (FD, rlimits etc)
>
> More context on the new changes -
>
>
> The idea is to tune active connections that can be handled (based on the available resources/capacity (CPU, Memory, Network bandwidth) and minimize/remove dependency on having to tune connection timeouts (active/inactive/keep-alive etc) which are very hard to tune.
>
> The primary goal is to limit the max active connections allowed at any given instant. The resource requirement for an idle/inactive vs active connections are completely different - For e.g an idle connection really only consumes memory resource, while an active connection consumes CPU, network besides memory. And allowing to tune/cap the max active connections based on the deployed capacity for the resources available, would make timeout tuning almost redundant and no op. Otherwise, we'd have to tune the timeouts to estimate throughput which is very hard as it's hard to justify how large or small we want the active timeout to be or keep alive timeout to be. For e.g in a non-peak hour, we could let the active timeout be much higher than the default, while during peak hour, we'd want to limit it to ensure we are not starving resources on one connection.
> Note: there's one little TODO item here. PluginVC's connections are not tracked in the NetVC's active queue because these are bogus internal connections. However, for some users, internal traffic is significant (e.g sideways calls, or background fetches etc) and does consume plenty of resources. Since these internal requests don't impact ingress network, and have a slightly different resource requirements than client originated requests, it might be better to track these using a separate config for internal requests. Will follow that part up with a separate PR.
>
>


```