### PR TITLE
Traffic Dump: dump server-side protocol stack

### DIFF
--- a/doc/developer-guide/api/functions/TSClientProtocolStack.en.rst
+++ b/doc/developer-guide/api/functions/TSClientProtocolStack.en.rst
@@ -31,9 +31,13 @@ Synopsis
 
 .. function:: TSReturnCode TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, char const** result, int* actual)
 
+.. function:: TSReturnCode TSHttpTxnServerProtocolStackGet(TSHttpTxn txnp, int n, const char** result, int* actual)
+
 .. function:: TSReturnCode TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, char const** result, int* actual)
 
 .. function:: char const* TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp)
+
+.. function:: const char* TSHttpTxnServerProtocolStackContains(TSHttpTxn txnp, char const* tag)
 
 .. function:: char const* TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp)
 
@@ -44,12 +48,15 @@ Synopsis
 Description
 ===========
 
-These functions are used to explore the protocol stack of the client (user agent) connection to
+These functions are used to explore the protocol stack of either the client (user agent) or origin server connection to
 |TS|. The functions :func:`TSHttpTxnClientProtocolStackGet` and
 :func:`TSHttpSsnClientProtocolStackGet` can be used to retrieve the entire protocol stack for the
-user agent connection. :func:`TSHttpTxnClientProtocolStackContains` and
-:func:`TSHttpSsnClientProtocolStackContains` will check for a specific protocol :arg:`tag` being
-present in the stack.
+user agent connection. The :func:`TSHttpTxnServerProtocolStackGet` can be used
+to retrieve the entire protocol stack for
+the origin server connection. :func:`TSHttpTxnClientProtocolStackContains`,
+:func:`TSHttpSsnClientProtocolStackContains`, and
+:func:`TSHttpTxnServerProtocolStackContains`  will check for a specific
+protocol :arg:`tag` being present in the stack.
 
 Each protocol is represented by tag which is a null terminated string. A particular tag will always
 be returned as the same character pointer and so protocols can be reliably checked with pointer
@@ -60,18 +67,18 @@ normalized value. This is useful for plugins that provide custom protocols for u
 
 The protocols are ordered from higher level protocols to the lower level ones on which the higher
 operate. For instance a stack might look like "http/1.1,tls/1.2,tcp,ipv4". For
-:func:`TSHttpTxnClientProtocolStackGet` and :func:`TSHttpSsnClientProtocolStackGet` these values
+:func:`TSHttpTxnClientProtocolStackGet`, :func:`TSHttpSsnClientProtocolStackGet`, and :func:`TSHttpTxnServerProtocolStackGet` these values
 are placed in the array :arg:`result`. :arg:`count` is the maximum number of elements of
 :arg:`result` that may be modified by the function call. If :arg:`actual` is not :const:`NULL` then
 the actual number of elements in the protocol stack will be returned. If this is equal or less than
 :arg:`count` then all elements were returned. If it is larger then some layers were omitted from
 :arg:`result`. If the full stack is required :arg:`actual` can be used to resize :arg:`result` to
 be sufficient to hold all of the elements and the function called again with updated :arg:`count`
-and :arg:`result`. In practice the maximum number of elements will is almost certain to be less
+and :arg:`result`. In practice the maximum number of elements is almost certain to be less
 than 10 which therefore should suffice. These functions return :const:`TS_SUCCESS` on success and
 :const:`TS_ERROR` on failure which should only occurr if :arg:`txnp` or :arg:`ssnp` are invalid.
 
-The :func:`TSHttpTxnClientProtocolStackContains` and :func:`TSHttpSsnClientProtocolStackContains`
+The :func:`TSHttpTxnClientProtocolStackContains`, :func:`TSHttpSsnClientProtocolStackContains`, and :func:`TSHttpTxnServerProtocolStackContains`
 functions are provided for the convenience when only the presence of a protocol is of interest, not
 its location or the presence of other protocols. These functions return :const:`NULL` if the protocol
 :arg:`tag` is not present, and a pointer to the normalized tag if it is present. The strings are

--- a/doc/developer-guide/api/functions/TSVConn.en.rst
+++ b/doc/developer-guide/api/functions/TSVConn.en.rst
@@ -21,7 +21,7 @@
 TSVConn
 *******
 
-Traffic Server APIs to get :type:`TSVConn` from :type:`TSHttpSsn` object
+Traffic Server APIs to get :type:`TSVConn` from :type:`TSHttpSsn` or :type:`TSHttpTxn` object.
 
 Synopsis
 ========
@@ -32,11 +32,13 @@ Synopsis
 
 .. function:: TSVConn TSHttpSsnClientVConnGet(TSHttpSsn ssnp)
 .. function:: TSVConn TSHttpSsnServerVConnGet(TSHttpSsn ssnp)
+.. function:: TSVConn TSHttpTxnServerVConnGet(TSHttpTxn txnp)
 
 Description
 ===========
 
-These APIs allow the developer to get the NetVconnection (represented by :type:`TSVConn`) from the Http session (:type:`TSHttpSsn`) object.
+These APIs allow the developer to get the NetVconnection (represented by :type:`TSVConn`) from the Http session (:type:`TSHttpSsn`) or transaction (:type:`TSHttpTxn`) object.
 
 :func:`TSHttpSsnClientVConnGet` returns the :type:`TSVConn` associated with the client side :type:`TSHttpSsn` object.
 :func:`TSHttpSsnServerVConnGet` returns the same associated with the server side :type:`TSHttpSsn`.
+:func:`TSHttpTxnServerVConnGet` returns the same associated with a :type:`TSHttpTxn`.

--- a/doc/developer-guide/api/functions/TSVConnProvidedSslCert.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnProvidedSslCert.en.rst
@@ -1,0 +1,38 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSVConnProvidedSslCert
+********************************
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: int TSVConnProvidedSslCert(TSVConn svc)
+
+Description
+===========
+
+Determines whether the connection associated with :arg:`svc` was an SSL
+connection on which a server certificate was provided in the SSL handshake.
+Returns :literal:`1` if it was and :literal:`0` otherwise.

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1216,9 +1216,11 @@ tsapi void TSHttpHookAdd(TSHttpHookID id, TSCont contp);
 tsapi void TSHttpSsnHookAdd(TSHttpSsn ssnp, TSHttpHookID id, TSCont contp);
 tsapi void TSHttpSsnReenable(TSHttpSsn ssnp, TSEvent event);
 tsapi int TSHttpSsnTransactionCount(TSHttpSsn ssnp);
-/* get TSVConn from session */
+/* Get the TSVConn from a session. */
 tsapi TSVConn TSHttpSsnClientVConnGet(TSHttpSsn ssnp);
 tsapi TSVConn TSHttpSsnServerVConnGet(TSHttpSsn ssnp);
+/* Get the TSVConn from a transaction. */
+tsapi TSVConn TSHttpTxnServerVConnGet(TSHttpTxn txnp);
 
 /* --------------------------------------------------------------------------
    SSL connections */
@@ -1258,6 +1260,10 @@ TSReturnCode TSVConnProtocolEnable(TSVConn connp, const char *protocol_name);
 
 /*  Returns 1 if the sslp argument refers to a SSL connection */
 tsapi int TSVConnIsSsl(TSVConn sslp);
+/* Returns 1 if a certificate was provided in the TLS handshake, 0 otherwise.
+ */
+tsapi int TSVConnProvidedSslCert(TSVConn sslp);
+
 tsapi TSSslSession TSSslSessionGet(const TSSslSessionID *session_id);
 tsapi int TSSslSessionGetBuffer(const TSSslSessionID *session_id, char *buffer, int *len_ptr);
 tsapi TSReturnCode TSSslSessionInsert(const TSSslSessionID *session_id, TSSslSession add_session, TSSslConnection ssl_conn);
@@ -2512,7 +2518,7 @@ tsapi TSUuid TSProcessUuidGet(void);
 tsapi const char *TSHttpTxnPluginTagGet(TSHttpTxn txnp);
 
 /*
- * Return information about the client protocols
+ * Return information about the client protocols.
  */
 tsapi TSReturnCode TSHttpTxnClientProtocolStackGet(TSHttpTxn txnp, int n, const char **result, int *actual);
 tsapi TSReturnCode TSHttpSsnClientProtocolStackGet(TSHttpSsn ssnp, int n, const char **result, int *actual);
@@ -2520,6 +2526,12 @@ tsapi const char *TSHttpTxnClientProtocolStackContains(TSHttpTxn txnp, char cons
 tsapi const char *TSHttpSsnClientProtocolStackContains(TSHttpSsn ssnp, char const *tag);
 tsapi const char *TSNormalizedProtocolTag(char const *tag);
 tsapi const char *TSRegisterProtocolTag(char const *tag);
+
+/*
+ * Return information about the server protocols.
+ */
+tsapi TSReturnCode TSHttpTxnServerProtocolStackGet(TSHttpTxn txnp, int n, const char **result, int *actual);
+tsapi const char *TSHttpTxnServerProtocolStackContains(TSHttpTxn txnp, char const *tag);
 
 // If, for the given transaction, the URL has been remapped, this function puts the memory location of the "from" URL object in
 // the variable pointed to by urlLocp, and returns TS_SUCCESS.  (The URL object will be within memory allocated to the

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -45,7 +45,18 @@ IN6_IS_ADDR_UNSPECIFIED(in6_addr const *addr)
 }
 #endif
 
-// IP protocol stack tags.
+/*
+ * IP protocol stack tags.
+ *
+ * When adding support for an additional protocol, the following minimum steps
+ * should be done:
+ *
+ * 1. This set of string_views should be updated with the new tag.
+ * 2. A populate_protocol function overload should be implemented for the
+ *    appropriate VConnection or ProxySession virtual function.
+ * 3. Traffic Dump should be updated to handle the new tag in:
+ *    plugins/experimental/traffic_dump/session_data.cc
+ */
 extern const std::string_view IP_PROTO_TAG_IPV4;
 extern const std::string_view IP_PROTO_TAG_IPV6;
 extern const std::string_view IP_PROTO_TAG_UDP;

--- a/plugins/experimental/traffic_dump/session_data.cc
+++ b/plugins/experimental/traffic_dump/session_data.cc
@@ -61,7 +61,7 @@ std::unordered_map<std::string, std::string> tag_to_node = {
   {std::string(IP_PROTO_TAG_HTTP_2_0), R"("name":"http","version":"2")"},
 
   {std::string(IP_PROTO_TAG_HTTP_QUIC), R"("name":"http","version":"0.9")"},
-  {std::string(IP_PROTO_TAG_HTTP_QUIC), R"("name":"http","version":"3")"},
+  {std::string(IP_PROTO_TAG_HTTP_3), R"("name":"http","version":"3")"},
 };
 
 /** Create a TLS characteristics node.

--- a/plugins/experimental/traffic_dump/session_data.h
+++ b/plugins/experimental/traffic_dump/session_data.h
@@ -124,19 +124,19 @@ public:
    */
   static void set_max_disk_usage(int64_t new_max_disk_usage);
 
-#if 0
-  // TODO: This will eventually be used by TransactionData to dump
-  // the server protocol description in the "server-response" node,
-  // but the TS API does not yet support this.
-
   /** Get the JSON string that describes the server session stack.
    *
-   * @param[in] ssnp The reference to the server session.
+   * The server side protocol description may change on a per-transaction
+   * basis. Therefore we print this for each transaction and take an TSHttpTxn
+   * instead of a TSHttpSsn that the analogous get_client_protocol_description
+   * receives.
    *
-   * @return A JSON description of the server protocol stack.
+   * @param[in] txnp The reference to the transaction.
+   *
+   * @return A JSON description of the server protocol stack for the
+   * transaction.
    */
-  static std::string get_server_protocol_description(TSHttpSsn ssnp);
-#endif
+  static std::string get_server_protocol_description(TSHttpTxn txnp);
 
   /** Write the string to the session's dump file.
    *

--- a/plugins/experimental/traffic_dump/transaction_data.h
+++ b/plugins/experimental/traffic_dump/transaction_data.h
@@ -37,6 +37,9 @@ private:
   /** The string for the JSON content of this transaction. */
   std::string txn_json;
 
+  /** The '"protocol" node for this transaction's server-side conection. */
+  std::string server_protocol_description;
+
   // The index to be used for the TS API for storing this TransactionData on a
   // per-transaction basis.
   static int transaction_arg_index;

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -303,6 +303,13 @@ public:
   /// @arg n [in] Size of the array @a result.
   int populate_client_protocol(std::string_view *result, int n) const;
   const char *client_protocol_contains(std::string_view tag_prefix) const;
+
+  /// Get the protocol stack for the outbound (origin server) connection.
+  /// @arg result [out] Array to store the results
+  /// @arg n [in] Size of the array @a result.
+  int populate_server_protocol(std::string_view *result, int n) const;
+  const char *server_protocol_contains(std::string_view tag_prefix) const;
+
   std::string_view find_proto_string(HTTPVersion version) const;
 
   int64_t sm_id      = -1;

--- a/tests/gold_tests/pluginTest/traffic_dump/gold/200.gold
+++ b/tests/gold_tests/pluginTest/traffic_dump/gold/200.gold
@@ -1,6 +1,6 @@
 ``
 > GET /`` HTTP/1.1
-> Host: www.example.com``
+> Host: www.notls.com``
 > User-Agent: curl/``
 > Accept: */*
 ``

--- a/tests/gold_tests/pluginTest/traffic_dump/gold/explicit_target.gold
+++ b/tests/gold_tests/pluginTest/traffic_dump/gold/explicit_target.gold
@@ -1,6 +1,6 @@
 ``
 > GET http://localhost:``/candy HTTP/1.1
-> Host: www.example.com``
+> Host: www.notls.com``
 > User-Agent: curl/``
 > Accept: */*
 ``

--- a/tests/gold_tests/pluginTest/traffic_dump/gold/post_with_body.gold
+++ b/tests/gold_tests/pluginTest/traffic_dump/gold/post_with_body.gold
@@ -1,6 +1,6 @@
 ``
 > POST http://localhost:``/post_with_body HTTP/1.1
-> Host: www.example.com``
+> Host: www.notls.com``
 > User-Agent: curl/``
 > Accept: */*
 ``

--- a/tests/gold_tests/pluginTest/traffic_dump/gold/two_transactions.gold
+++ b/tests/gold_tests/pluginTest/traffic_dump/gold/two_transactions.gold
@@ -1,11 +1,11 @@
 ``
 > GET /first HTTP/1.1
-> Host: www.example.com
+> Host: www.notls.com
 ``
 < HTTP/1.1 200 OK
 ``
 > GET /second HTTP/1.1
-> Host: www.example.com
+> Host: www.notls.com
 ``
 < HTTP/1.1 200 OK
 ``

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -199,7 +199,7 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/200.gold"
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-http_protocols = "tcp,ipv4"
+http_protocols = "tcp,ip"
 
 # Execute the second transaction.
 tr = Test.AddTestRun("Second transaction")
@@ -375,7 +375,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Verify the client protocol stack.")
-https_protocols = "tcp,ipv4,tls"
+https_protocols = "tls,tcp,ip"
 client_tls_features = "sni:www.tls.com,proxy-verify-mode:0,proxy-provided-cert:true"
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
 tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}" --client-tls-features "{4}"'.format(
@@ -389,7 +389,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Verify the server protocol stack.")
-https_server_stack = "http/1.1,tcp,ipv4,tls"
+https_server_stack = "http,tls,tcp,ip"
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
 server_tls_features = 'proxy-provided-cert:false,sni:www.tls.com,proxy-verify-mode:1'
 tr.Processes.Default.Command = 'python3 {0} {1} {2} --server-protocols "{3}" --server-tls-features "{4}"'.format(
@@ -416,7 +416,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Verify the client protocol stack.")
-h2_protocols = "h2,tcp,ipv4,tls"
+h2_protocols = "http,tls,tcp,ip"
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
 tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}" --client-tls-features "{4}"'.format(
         verify_replay,
@@ -468,7 +468,7 @@ tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Verify the server protocol stack.")
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
-http_server_stack = "http/1.1,tcp,ipv4"
+http_server_stack = "http,tcp,ip"
 tr.Processes.Default.Command = 'python3 {0} {1} {2} --server-protocols "{3}"'.format(
         verify_replay,
         os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -27,10 +27,10 @@ Test.SkipUnless(
 )
 
 # Configure the origin server.
-server = Test.MakeOriginServer("server")
+server = Test.MakeOriginServer("server", both=True)
 
 request_header = {"headers": "GET /one HTTP/1.1\r\n"
-                  "Host: www.example.com\r\nContent-Length: 0\r\n\r\n",
+                  "Host: www.notls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK"
                    "\r\nConnection: close\r\nContent-Length: 0"
@@ -38,7 +38,7 @@ response_header = {"headers": "HTTP/1.1 200 OK"
                    "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionfile.log", request_header, response_header)
 request_header = {"headers": "GET /two HTTP/1.1\r\n"
-                  "Host: www.example.com\r\nContent-Length: 0\r\n\r\n",
+                  "Host: www.notls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK"
                    "\r\nConnection: close\r\nContent-Length: 0"
@@ -46,7 +46,7 @@ response_header = {"headers": "HTTP/1.1 200 OK"
                    "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionfile.log", request_header, response_header)
 request_header = {"headers": "GET /three HTTP/1.1\r\n"
-                  "Host: www.example.com\r\nContent-Length: 0\r\n\r\n",
+                  "Host: www.notls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK"
                    "\r\nConnection: close\r\nContent-Length: 0"
@@ -54,14 +54,14 @@ response_header = {"headers": "HTTP/1.1 200 OK"
                    "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionfile.log", request_header, response_header)
 request_header = {"headers": "GET /post_with_body HTTP/1.1\r\n"
-                  "Host: www.example.com\r\nContent-Length: 0\r\n\r\n",
+                  "Host: www.notls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK"
-                   "\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionfile.log", request_header, response_header)
+response_200 = {"headers": "HTTP/1.1 200 OK"
+                "\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+                "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_200)
 request_header = {"headers": "GET /cache_test HTTP/1.1\r\n"
-                  "Host: www.example.com\r\nContent-Length: 0\r\n\r\n",
+                  "Host: www.notls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK"
                    "\r\nConnection: close\r\nCache-Control: max-age=300\r\n"
@@ -69,31 +69,66 @@ response_header = {"headers": "HTTP/1.1 200 OK"
                    "timestamp": "1469733493.993", "body": "1234"}
 server.addResponse("sessionfile.log", request_header, response_header)
 request_header = {"headers": "GET /first HTTP/1.1\r\n"
-                  "Host: www.example.com\r\nContent-Length: 0\r\n\r\n",
+                  "Host: www.notls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK"
-                   "\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionfile.log", request_header, response_header)
+server.addResponse("sessionfile.log", request_header, response_200)
 request_header = {"headers": "GET /second HTTP/1.1\r\n"
-                  "Host: www.example.com\r\nContent-Length: 0\r\n\r\n",
+                  "Host: www.notls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK"
-                   "\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionfile.log", request_header, response_header)
+server.addResponse("sessionfile.log", request_header, response_200)
+request_header = {"headers": "GET /tls HTTP/1.1\r\n"
+                  "Host: www.tls.com\r\nContent-Length: 0\r\n\r\n",
+                  "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_200)
+request_header = {"headers": "GET /h2 HTTP/1.1\r\n"
+                  "Host: www.tls.com\r\nContent-Length: 0\r\n\r\n",
+                  "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_200)
+request_header = {"headers": "GET /client_only_tls HTTP/1.1\r\n"
+                  "Host: www.client_only_tls.com\r\nContent-Length: 0\r\n\r\n",
+                  "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_200)
 
 # Define ATS and configure it.
-ts = Test.MakeATSProcess("ts")
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 replay_dir = os.path.join(ts.RunDirectory, "ts", "log")
+
+ts.addSSLfile("ssl/server.pem")
+ts.addSSLfile("ssl/server.key")
+ts.addSSLfile("ssl/signer.pem")
+
+ts.Setup.Copy("ssl/signed-foo.pem")
+ts.Setup.Copy("ssl/signed-foo.key")
+
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'traffic_dump',
     'proxy.config.http.insert_age_in_response': 0,
+
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.client.verify.server':  0,
+    'proxy.config.url_remap.pristine_host_hdr': 1,
+    'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
+    'proxy.config.exec_thread.autoconfig.scale': 1.0,
+    'proxy.config.http.host_sni_policy': 2,
+    'proxy.config.ssl.TLSv1_3': 0,
 })
+
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+
+ts.Disk.remap_config.AddLine(
+    'map https://www.client_only_tls.com/ http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+ts.Disk.remap_config.AddLine(
+    'map https://www.tls.com/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port)
+)
 ts.Disk.remap_config.AddLine(
     'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
 )
+
 # Configure traffic_dump.
 ts.Disk.plugin_config.AddLine(
     'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 '
@@ -140,6 +175,12 @@ replay_file_session_6 = os.path.join(replay_dir, "127", "0000000000000005")
 ts.Disk.File(replay_file_session_6, exists=True)
 replay_file_session_7 = os.path.join(replay_dir, "127", "0000000000000006")
 ts.Disk.File(replay_file_session_7, exists=True)
+replay_file_session_8 = os.path.join(replay_dir, "127", "0000000000000007")
+ts.Disk.File(replay_file_session_8, exists=True)
+replay_file_session_9 = os.path.join(replay_dir, "127", "0000000000000008")
+ts.Disk.File(replay_file_session_9, exists=True)
+replay_file_session_10 = os.path.join(replay_dir, "127", "0000000000000009")
+ts.Disk.File(replay_file_session_10, exists=True)
 
 #
 # Test 1: Verify the correct behavior of two transactions across two sessions.
@@ -152,7 +193,7 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Command = \
         ('curl --http1.1 http://127.0.0.1:{0}/one -H"Cookie: donotlogthis" '
-         '-H"Host: www.example.com" -H"X-Request-1: ultra_sensitive" --verbose'.format(
+         '-H"Host: www.notls.com" -H"X-Request-1: ultra_sensitive" --verbose'.format(
              ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/200.gold"
@@ -163,7 +204,7 @@ http_protocols = "tcp,ipv4"
 # Execute the second transaction.
 tr = Test.AddTestRun("Second transaction")
 tr.Processes.Default.Command = \
-        ('curl http://127.0.0.1:{0}/two -H"Host: www.example.com" '
+        ('curl http://127.0.0.1:{0}/two -H"Host: www.notls.com" '
          '-H"X-Request-2: also_very_sensitive" --verbose'.format(
             ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
@@ -211,7 +252,7 @@ tr = Test.AddTestRun("Make a request with an explicit target.")
 request_target = "http://localhost:{0}/candy".format(ts.Variables.port)
 tr.Processes.Default.Command = (
         'curl --request-target "{0}" '
-        'http://127.0.0.1:{1}/three -H"Host: www.example.com" --verbose'.format(
+        'http://127.0.0.1:{1}/three -H"Host: www.notls.com" --verbose'.format(
             request_target, ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/explicit_target.gold"
@@ -242,7 +283,7 @@ request_target = "http://localhost:{0}/post_with_body".format(ts.Variables.port)
 # in the test run directory.
 tr.Processes.Default.Command = (
         'curl --data-binary @{0} --request-target "{1}" '
-        'http://127.0.0.1:{2} -H"Host: www.example.com" --verbose'.format(
+        'http://127.0.0.1:{2} -H"Host: www.notls.com" --verbose'.format(
             verify_replay, request_target, ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/post_with_body.gold"
@@ -269,7 +310,7 @@ tr.StillRunningAfter = ts
 #
 tr = Test.AddTestRun("Make a request for an uncached object.")
 tr.Processes.Default.Command = \
-        ('curl --http1.1 http://127.0.0.1:{0}/cache_test -H"Host: www.example.com" --verbose'.format(
+        ('curl --http1.1 http://127.0.0.1:{0}/cache_test -H"Host: www.notls.com" --verbose'.format(
              ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/4_byte_response_body.gold"
@@ -278,7 +319,7 @@ tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Repeat the previous request: should be cached now.")
 tr.Processes.Default.Command = \
-        ('curl --http1.1 http://127.0.0.1:{0}/cache_test -H"Host: www.example.com" --verbose'.format(
+        ('curl --http1.1 http://127.0.0.1:{0}/cache_test -H"Host: www.notls.com" --verbose'.format(
              ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/4_byte_response_body.gold"
@@ -301,8 +342,8 @@ tr.StillRunningAfter = ts
 #
 tr = Test.AddTestRun("Conduct two transactions in the same session.")
 tr.Processes.Default.Command = \
-        ('curl --http1.1 http://127.0.0.1:{0}/first -H"Host: www.example.com" --verbose --next '
-            'curl --http1.1 http://127.0.0.1:{0}/second -H"Host: www.example.com" --verbose'
+        ('curl --http1.1 http://127.0.0.1:{0}/first -H"Host: www.notls.com" --verbose --next '
+            'curl --http1.1 http://127.0.0.1:{0}/second -H"Host: www.notls.com" --verbose'
             .format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/two_transactions.gold"
@@ -316,6 +357,123 @@ tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}"'.fo
         os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
         replay_file_session_7,
         http_protocols)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+#
+# Test 6: Verify correct protcol dumping of a TLS connection.
+#
+tr = Test.AddTestRun("Perform an HTTP/1 transaction over a TLS connection.")
+tr.Processes.Default.Command = \
+        ('curl --http1.1 -k -H"Host: www.tls.com" --resolve "www.tls.com:{0}:127.0.0.1" '
+         '--cert ./signed-foo.pem --key ./signed-foo.key --verbose https://www.tls.com:{0}/tls'.format(
+             ts.Variables.ssl_port))
+
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Verify the client protocol stack.")
+https_protocols = "tcp,ipv4,tls"
+client_tls_features = "sni:www.tls.com,proxy-verify-mode:0,proxy-provided-cert:true"
+tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
+tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}" --client-tls-features "{4}"'.format(
+        verify_replay,
+        os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+        replay_file_session_8,
+        https_protocols,
+        client_tls_features)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Verify the server protocol stack.")
+https_server_stack = "http/1.1,tcp,ipv4,tls"
+tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
+server_tls_features = 'proxy-provided-cert:false,sni:www.tls.com,proxy-verify-mode:1'
+tr.Processes.Default.Command = 'python3 {0} {1} {2} --server-protocols "{3}" --server-tls-features "{4}"'.format(
+        verify_replay,
+        os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+        replay_file_session_8,
+        https_server_stack,
+        server_tls_features)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+#
+# Test 7: Verify correct protcol dumping of TLS and HTTP/2 connections.
+#
+tr = Test.AddTestRun("Conduct an HTTP/2 transaction over a TLS connection.")
+tr.Processes.Default.Command = \
+        ('curl --http2 -k -H"Host: www.tls.com" --resolve "www.tls.com:{0}:127.0.0.1" '
+         '--cert ./signed-foo.pem --key ./signed-foo.key --verbose https://www.tls.com:{0}/h2'.format(
+             ts.Variables.ssl_port))
+
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Verify the client protocol stack.")
+h2_protocols = "h2,tcp,ipv4,tls"
+tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
+tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}" --client-tls-features "{4}"'.format(
+        verify_replay,
+        os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+        replay_file_session_9,
+        h2_protocols,
+        client_tls_features)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Verify the server protocol stack.")
+tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
+tr.Processes.Default.Command = 'python3 {0} {1} {2} --server-protocols "{3}" --server-tls-features "{4}"'.format(
+        verify_replay,
+        os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+        replay_file_session_9,
+        https_server_stack,
+        server_tls_features)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+#
+# Test 8: Verify correct protcol dumping of client-side TLS and server-side HTTP.
+#
+tr = Test.AddTestRun("Conduct a client-side TLS connection with an HTTP server-side connection.")
+tr.Processes.Default.Command = \
+        ('curl --http1.1 -k -H"Host: www.client_only_tls.com" '
+         '--resolve "www.client_only_tls.com:{0}:127.0.0.1" '
+         '--cert ./signed-foo.pem --key ./signed-foo.key '
+         '--verbose https://www.client_only_tls.com:{0}/client_only_tls'.format(
+             ts.Variables.ssl_port))
+
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Verify the client protocol stack.")
+tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
+tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}"'.format(
+        verify_replay,
+        os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+        replay_file_session_10,
+        https_protocols)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Verify the server protocol stack.")
+tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
+http_server_stack = "http/1.1,tcp,ipv4"
+tr.Processes.Default.Command = 'python3 {0} {1} {2} --server-protocols "{3}"'.format(
+        verify_replay,
+        os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+        replay_file_session_10,
+        http_server_stack)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
@@ -126,7 +126,7 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/200_sni_bob.gold"
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-session_1_protocols = "h2,tls,tcp,ipv4"
+session_1_protocols = "http,tls,tcp,ip"
 # Observe that the sni.yaml config dictates STRICT as the verify_client
 # attribute.
 session_1_tls_features = 'sni:bob,proxy-verify-mode:7,proxy-provided-cert:true'

--- a/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
@@ -139,38 +139,105 @@ def verify_sensitive_fields_not_dumped(replay_json, sensitive_fields):
     return True
 
 
-def verify_client_protocols(replay_json, expected_protocol_features):
+def verify_protocols_helper(replay_json, expected_protocol_features, is_client):
     expected_protocols_list = expected_protocol_features.split(',')
     expected_protocols_list.sort()
     try:
-        protocol_node = replay_json['sessions'][0]['protocol']
-        protocol_list = protocol_node.copy()
+        if is_client:
+            protocol_node = replay_json['sessions'][0]['protocol']
+        else:
+            protocol_node = replay_json['sessions'][0]['transactions'][0]['proxy-request']['protocol']
+
+        protocol_list = list(protocol_node.keys())
         protocol_list.sort()
         if protocol_list == expected_protocols_list:
             return True
         else:
-            print('Unexpected protocol stack. Expected: "{}", found: "{}".'.format(
-                ','.join(expected_protocols_list), ','.join(protocol_list)))
+            host_name = "client" if is_client else "server"
+            print('Unexpected protocol {} stack. Expected: "{}", found: "{}".'.format(
+                host_name, ','.join(expected_protocols_list), ','.join(protocol_list)))
             return False
     except KeyError:
-        print("Could not find client protocol stack node in the replay file.")
+        print("Could not find {} protocol stack node in the replay file.".format(host_name))
         return False
+
+
+def verify_client_protocols(replay_json, expected_protocol_features):
+    return verify_protocols_helper(replay_json, expected_protocol_features, is_client=True)
+
+
+def verify_server_protocols(replay_json, expected_protocol_features):
+    return verify_protocols_helper(replay_json, expected_protocol_features, is_client=False)
+
+
+def get_tls_features(replay_json, is_client):
+    session = replay_json['sessions'][0]
+    if is_client:
+        protocol_parent = session['protocol']
+    else:
+        protocol_parent = session['transactions'][0]['proxy-request']['protocol']
+    return protocol_parent['tls']
+
+
+def verify_tls_features(expected_tls_features, found_tls_features):
+    for expected_tls_feature in expected_tls_features.split(','):
+        expected_key, expected_value = expected_tls_feature.split(':')
+        try:
+            found_value = found_tls_features[expected_key]
+        except KeyError:
+            print("Could not find tls feature in the replay file: {}".format(expected_key))
+            return False
+        value_matches = False
+        if type(found_value) == str:
+            value_matches = found_value == expected_value
+        elif type(found_value) == int:
+            value_matches = found_value == int(expected_value)
+        elif type(found_value) == bool:
+            if expected_value.lower() == "false":
+                expected_value = False
+            elif expected_value.lower() == "true":
+                expected_value = True
+            else:
+                raise ValueError("Cannot convert expected value to a boolean: {}, found: {}".format(
+                    expected_value, found_value))
+            value_matches = found_value == bool(expected_value)
+        else:
+            raise ValueError("Cannot determine type of found value: {}".format(
+                found_value))
+
+        if not value_matches:
+            print('Mismatched value for "{}", expected "{}", received "{}"'.format(
+                expected_key, expected_value, found_value))
+            return False
+    return True
 
 
 def verify_client_tls_features(replay_json, expected_tls_features):
     try:
-        session = replay_json['sessions'][0]
-        for expected_tls_feature in expected_tls_features.split(','):
-            expected_key, expected_value = expected_tls_feature.split(':')
-            tls_features = session['tls']
-            try:
-                return tls_features[expected_key] == expected_value
-            except KeyError:
-                print("Could not find client tls feature in the replay file: {}".format(expected_key))
-                return False
+        tls_features = get_tls_features(replay_json, is_client=True)
     except KeyError:
         print("Could not find client tls node in the replay file.")
         return False
+
+    if not verify_tls_features(expected_tls_features, tls_features):
+        print('Failed to verify client tls features in "{}"'.format(
+            expected_tls_features))
+        return False
+    return True
+
+
+def verify_server_tls_features(replay_json, expected_tls_features):
+    try:
+        tls_features = get_tls_features(replay_json, is_client=False)
+    except KeyError:
+        print("Could not find server tls node in the replay file.")
+        return False
+
+    if not verify_tls_features(expected_tls_features, tls_features):
+        print('Failed to verify server tls features in "{}"'.format(
+            expected_tls_features))
+        return False
+    return True
 
 
 def parse_args():
@@ -191,8 +258,12 @@ def parse_args():
                         help="The fields that are considered sensitive and replaced with insensitive values.")
     parser.add_argument("--client-protocols",
                         help="The comma-separated protocol features to expect for the client connection.")
+    parser.add_argument("--server-protocols",
+                        help="The comma-separated protocol features to expect for the server connection.")
     parser.add_argument("--client-tls-features",
                         help="The TLS values to expect for the client connection.")
+    parser.add_argument("--server-tls-features",
+                        help="The TLS values to expect for the server connection.")
     return parser.parse_args()
 
 
@@ -229,7 +300,13 @@ def main():
     if args.client_protocols and not verify_client_protocols(replay_json, args.client_protocols):
         return 1
 
+    if args.server_protocols and not verify_server_protocols(replay_json, args.server_protocols):
+        return 1
+
     if args.client_tls_features and not verify_client_tls_features(replay_json, args.client_tls_features):
+        return 1
+
+    if args.server_tls_features and not verify_server_tls_features(replay_json, args.server_tls_features):
         return 1
 
     return 0

--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -24,12 +24,9 @@
         "required": [ "transactions" ],
         "properties": {
           "protocol": {
-            "description": "The network protocol stack of the inbound connection.",
-            "type": "array",
-            "items": {
-              "description": "Protocol tag",
-              "type": "string"
-            }
+            "description": "The network protocol description of the inbound connection.",
+            "type": "object",
+            "$ref": "#/definitions/protocol"
           },
           "connect-time": {
             "description": "User Agent connection time.",
@@ -120,6 +117,58 @@
         }
       ]
     },
+    "protocol": {
+      "description": "The characteristics of the lower level protocols.",
+      "type": "object",
+      "properties": {
+        "ip": {
+          "desciption": "A description of the IP layer of the connection.",
+          "type": "object"
+        },
+        "ipv6": {
+          "desciption": "A description of the IP layer of the connection.",
+          "type": "object"
+        },
+        "tcp": {
+          "desciption": "A description of the TCP layer of the connection.",
+          "type": "object"
+        },
+        "tls": {
+          "description": "The description of the TLS details.",
+          "type": "object",
+          "properties": {
+            "version": {
+              "desciption": "The TLS version.",
+              "type": "string"
+            },
+            "sni": {
+              "desciption": "The SNI in the client hello.",
+              "type": "string"
+            },
+            "request-certificate": {
+              "desciption": "Whether a certificate should be requested from the proxy.",
+              "type": "boolean"
+            },
+            "verify-mode": {
+              "desciption": "The server or client's OpenSSL verify mode against the proxy.",
+              "type": "boolean"
+            },
+            "proxy-verify-mode": {
+              "desciption": "The proxy's OpenSSL verify mode against the peer.",
+              "type": "integer"
+            },
+            "proxy-provided-cert": {
+              "desciption": "Whether the proxy provided a cert in the handshake.",
+              "type": "boolean"
+            }
+          }
+        },
+        "h2": {
+          "desciption": "A description of the HTTP/2 protocol for the connection.",
+          "type": "object"
+        }
+      }
+    },
     "header-fields": {
       "description": "HTTP header fields.",
       "type": "object",
@@ -178,6 +227,11 @@
         "headers": {
           "description": "HTTP header fields.",
           "$ref": "#/definitions/header-fields"
+        },
+        "protocol": {
+          "description": "The network protocol description of the connection.",
+          "type": "object",
+          "$ref": "#/definitions/protocol"
         }
       }
     },

--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -25,7 +25,6 @@
         "properties": {
           "protocol": {
             "description": "The network protocol description of the inbound connection.",
-            "type": "object",
             "$ref": "#/definitions/protocol"
           },
           "connect-time": {
@@ -119,53 +118,16 @@
     },
     "protocol": {
       "description": "The characteristics of the lower level protocols.",
-      "type": "object",
+      "type": "array",
+      "required": ["name"],
       "properties": {
-        "ip": {
-          "desciption": "A description of the IP layer of the connection.",
-          "type": "object"
+        "name": {
+          "desciption": "The name of the protocol.",
+          "type": "string"
         },
-        "ipv6": {
-          "desciption": "A description of the IP layer of the connection.",
-          "type": "object"
-        },
-        "tcp": {
-          "desciption": "A description of the TCP layer of the connection.",
-          "type": "object"
-        },
-        "tls": {
-          "description": "The description of the TLS details.",
-          "type": "object",
-          "properties": {
-            "version": {
-              "desciption": "The TLS version.",
-              "type": "string"
-            },
-            "sni": {
-              "desciption": "The SNI in the client hello.",
-              "type": "string"
-            },
-            "request-certificate": {
-              "desciption": "Whether a certificate should be requested from the proxy.",
-              "type": "boolean"
-            },
-            "verify-mode": {
-              "desciption": "The server or client's OpenSSL verify mode against the proxy.",
-              "type": "boolean"
-            },
-            "proxy-verify-mode": {
-              "desciption": "The proxy's OpenSSL verify mode against the peer.",
-              "type": "integer"
-            },
-            "proxy-provided-cert": {
-              "desciption": "Whether the proxy provided a cert in the handshake.",
-              "type": "boolean"
-            }
-          }
-        },
-        "h2": {
-          "desciption": "A description of the HTTP/2 protocol for the connection.",
-          "type": "object"
+        "version": {
+          "desciption": "The version of the protocol.",
+          "type": "string"
         }
       }
     },
@@ -230,7 +192,6 @@
         },
         "protocol": {
           "description": "The network protocol description of the connection.",
-          "type": "object",
           "$ref": "#/definitions/protocol"
         }
       }

--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -128,6 +128,26 @@
         "version": {
           "desciption": "The version of the protocol.",
           "type": "string"
+        },
+        "sni": {
+          "desciption": "The SNI in the client hello.",
+          "type": "string"
+        },
+        "request-certificate": {
+          "desciption": "Whether a certificate should be requested from the proxy.",
+          "type": "boolean"
+        },
+        "verify-mode": {
+          "desciption": "The server or client's OpenSSL verify mode against the proxy.",
+          "type": "boolean"
+        },
+        "proxy-verify-mode": {
+          "desciption": "The proxy's OpenSSL verify mode against the peer.",
+          "type": "integer"
+        },
+        "proxy-provided-cert": {
+          "desciption": "Whether the proxy provided a cert in the handshake.",
+          "type": "boolean"
         }
       }
     },

--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -145,7 +145,7 @@
           "desciption": "The proxy's OpenSSL verify mode against the peer.",
           "type": "integer"
         },
-        "proxy-provided-cert": {
+        "proxy-provided-certificate": {
           "desciption": "Whether the proxy provided a cert in the handshake.",
           "type": "boolean"
         }


### PR DESCRIPTION
This also adds some TLS information in the protocol stack, such as the
verify_mode applied to the SSL session and whether the server requested
a client certificate.

With this change, there are now two kinds of protocol stacks that are 
dumped. There is a session-level one that describes the client-side
protocol stack. It can look something like this:

```
    "sessions": [
        {
            "protocol": [
                {
                    "name": "http",
                    "version": "2"
                },
                {
                    "name": "tls",
                    "version": "TLSv1.2",
                    "sni": "www.tls.com",
                    "proxy-verify-mode": 0,
                    "proxy-provided-cert": true
                },
                {
                    "name": "tcp"
                },
                {
                    "name": "ip",
                    "version": "4"
                }
            ],
```

In addition, there is now a server-side protocol stack that will be printed in
every proxy-request node. It can look something like this:

```
                    "proxy-request": {
                        "protocol": [
                            {
                                "name": "http",
                                "version": "1.1"
                            },
                            {
                                "name": "tls",
                                "version": "TLSv1.2",
                                "sni": "www.tls.com",
                                "proxy-verify-mode": 1,
                                "proxy-provided-cert": false
                            },
                            {
                                "name": "tcp"
                            },
                            {
                                "name": "ip",
                                "version": "4"
                            }
                        ],
```
Note that the dump provides TLS information from the perspective of the proxy,
therefore the TLS nodes are prefixed by "proxy-". The schema is also updated to
anticipate verifier directives that dictate client and server TLS behavior
("verify-mode" and "request-certificate").
