### PR TITLE
hostdb: don't use next_sync_time - now() as TTL (it can be negative)

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1655,8 +1655,7 @@ HostDBContinuation::do_dns()
     if (find_result != current_host_file_map->hosts_file_map.end()) {
       if (action.continuation) {
         // Set the TTL based on how often we stat() the host file
-        HostDBInfo *r = lookup_done(IpAddr(find_result->second), hash.host_name, false,
-                                    hostdb_hostfile_check_interval, nullptr);
+        HostDBInfo *r = lookup_done(IpAddr(find_result->second), hash.host_name, false, hostdb_hostfile_check_interval, nullptr);
         reply_to_cont(action.continuation, r);
       }
       hostdb_cont_free(this);
@@ -2240,8 +2239,8 @@ ParseHostFile(const char *path, unsigned int hostdb_hostfile_check_interval_pars
         // +1 in case no terminating newline
         int64_t size = info.st_size + 1;
 
-        parsed_hosts_file_ptr                 = new RefCountedHostsFileMap;
-        parsed_hosts_file_ptr->HostFileText   = static_cast<char *>(ats_malloc(size));
+        parsed_hosts_file_ptr               = new RefCountedHostsFileMap;
+        parsed_hosts_file_ptr->HostFileText = static_cast<char *>(ats_malloc(size));
         if (parsed_hosts_file_ptr->HostFileText) {
           char *base = parsed_hosts_file_ptr->HostFileText;
           char *limit;

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1654,9 +1654,9 @@ HostDBContinuation::do_dns()
     HostsFileMap::iterator find_result                = current_host_file_map->hosts_file_map.find(hname);
     if (find_result != current_host_file_map->hosts_file_map.end()) {
       if (action.continuation) {
-        // Set the TTL based on how much time remains until the next sync
+        // Set the TTL based on how often we stat() the host file
         HostDBInfo *r = lookup_done(IpAddr(find_result->second), hash.host_name, false,
-                                    current_host_file_map->next_sync_time - ink_time(), nullptr);
+                                    hostdb_hostfile_check_interval, nullptr);
         reply_to_cont(action.continuation, r);
       }
       hostdb_cont_free(this);
@@ -2241,7 +2241,6 @@ ParseHostFile(const char *path, unsigned int hostdb_hostfile_check_interval_pars
         int64_t size = info.st_size + 1;
 
         parsed_hosts_file_ptr                 = new RefCountedHostsFileMap;
-        parsed_hosts_file_ptr->next_sync_time = ink_time() + hostdb_hostfile_check_interval_parse;
         parsed_hosts_file_ptr->HostFileText   = static_cast<char *>(ats_malloc(size));
         if (parsed_hosts_file_ptr->HostFileText) {
           char *base = parsed_hosts_file_ptr->HostFileText;

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -182,7 +182,6 @@ typedef std::map<ts::ConstBuffer, IpAddr, CmpConstBuffferCaseInsensitive> HostsF
 struct RefCountedHostsFileMap : public RefCountObj {
   HostsFileMap hosts_file_map;
   ats_scoped_str HostFileText;
-  ink_time_t next_sync_time; // time of the next sync
 };
 
 //


### PR DESCRIPTION
`next_sync_time` gets set to `ink_time() + hostdb_hostfile_check_interval` when a host file is actually loaded and parsed.

The host file is `stat()`ed every `hostdb_hostfile_check_interval`, and *only if has been updated* is it loaded and parsed.

So, if the host file is untouched for a while, `next_sync_time` is actually in the past.

It's only actually used here:
```cpp
        HostDBInfo *r = lookup_done(IpAddr(find_result->second), hash.host_name, false,
                                    current_host_file_map->next_sync_time - ink_time(), nullptr);
```
where it's inserting something into the HostDB with a potentially negative TTL. (but actually the TTL is treated as unsigned, so I was seeing a quite large TTL.)

I think you probably want to replace that TTL with something like `hostdb_hostfile_check_interval` or maybe something fancier involving the last update time.

But I've had a lot of coffee so please correct me if I'm wrong :)
I was definitely seeing debug lines like:
```
[Jul  7 21:20:15.191] Server {0x2b3aa8614700} DEBUG: <HostDB.cc:1122 (lookup_done)> (hostdb) done 127.0.0.1 TTL -6
```
(that line number is from a different branch)

Related question: is there a way to do something like a config reload signal for all the hosts in the host file?
I'm going to try to work around that by setting some small timeouts in the following:
```
CONFIG proxy.config.hostdb.host_file.interval INT 10  # stat() the host file to see if it's been touched
CONFIG proxy.config.cache.hostdb.sync_frequency INT 0  # don't persist hostdb to disk between restarts
CONFIG proxy.config.hostdb.verify_after INT 10  #  refresh the cache from the last-read host file contents after this long
```

Thank you!
[ed: force pushing to fix my commit message]