### PR TITLE
Update autest to version 1.8.0

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -24,7 +24,7 @@ autopep8 = "*"
 pyflakes = "*"
 
 [packages]
-autest = "==1.7.4"
+autest = "==1.8.0"
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"
 dnslib = "*"


### PR DESCRIPTION
    This updated autest version contains a fix for cleanup logic so that the
    port selection mechanism in ports.py works better. Without this update,
    the port recycling logic never gets called and we run out of the
    optimally selected ports and fallback to the old port selection logic
    which has a race condition with another server grabbing the lock before
    the test process does, resulting in an address in use error.
