### PR TITLE
Make the setting of the continuation handler safer.

### DIFF
--- a/iocore/net/NetTimeout.h
+++ b/iocore/net/NetTimeout.h
@@ -69,7 +69,7 @@ private:
   };
   ```
  */
-template <class T, class List = DLL<T>> class ActivityCop : Continuation
+template <class T, class List = DLL<T>> class ActivityCop : public Continuation
 {
 public:
   ActivityCop(){};

--- a/iocore/net/test_I_UDPNet.cc
+++ b/iocore/net/test_I_UDPNet.cc
@@ -47,12 +47,12 @@ class EchoServer : public Continuation
 {
 public:
   EchoServer() : Continuation(new_ProxyMutex()) { SET_HANDLER(&EchoServer::start); };
-  bool start();
+  int start(int, void *);
   int handle_packet(int event, void *data);
 };
 
-bool
-EchoServer::start()
+int
+EchoServer::start(int, void *)
 {
   SET_HANDLER(&EchoServer::handle_packet);
 


### PR DESCRIPTION
These three code examples only differ in the first two lines:
https://godbolt.org/z/Gq38j7
https://godbolt.org/z/hGb9PT
https://godbolt.org/z/6MdKjn

They illustrate how using a C-style cast to convert a derived
class member function pointer to a base class member function
pointer bypasses a compile time check that is derived class is
actually derived from the base class.