### PR TITLE
Backport 7.1.x: Add range check of Http2SettingsIdentifier

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -70,7 +70,7 @@ public:
   unsigned
   get(Http2SettingsIdentifier id) const
   {
-    if (id < HTTP2_SETTINGS_MAX) {
+    if (0 < id && id < HTTP2_SETTINGS_MAX) {
       return this->settings[indexof(id)];
     } else {
       ink_assert(!"Bad Settings Identifier");
@@ -96,7 +96,7 @@ private:
   static unsigned
   indexof(Http2SettingsIdentifier id)
   {
-    ink_assert(id < HTTP2_SETTINGS_MAX);
+    ink_assert(0 < id && id < HTTP2_SETTINGS_MAX);
 
     return id - 1;
   }

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -82,7 +82,7 @@ public:
   unsigned
   set(Http2SettingsIdentifier id, unsigned value)
   {
-    if (id < HTTP2_SETTINGS_MAX) {
+    if (0 < id && id < HTTP2_SETTINGS_MAX) {
       return this->settings[indexof(id)] = value;
     } else {
       // Do nothing - 6.5.2 Unsupported parameters MUST be ignored


### PR DESCRIPTION
(cherry picked from commit c2bc17d665ccd70e7e33ca3c456f2e4146ea20a6, f45e2574d6a298a962e1f032f5855179ee1295c3)

Fixes: #6965

In #6965,  the trafficserver ignores unsupported Http2SettingsIdentifier.
So, identifier should be checked correctly to avoid zero.