### PR TITLE
Removes use of SPLIT_DNS macro

### DIFF
--- a/doc/developer-guide/testing/blackbox-testing.en.rst
+++ b/doc/developer-guide/testing/blackbox-testing.en.rst
@@ -258,7 +258,6 @@ Condition Testing
         - TS_HAS_128BIT_CAS
         - TS_HAS_TESTS
         - TS_HAS_WCCP
-        - SPLIT_DNS
 
 
 Examples:

--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -95,8 +95,6 @@
 
 #define TS_MAX_HOST_NAME_LEN @max_host_name_len@
 
-#define SPLIT_DNS 1
-
 /* Defaults for user / group */
 #define TS_PKGSYSUSER "@pkgsysuser@"
 #define TS_PKGSYSGROUP "@pkgsysgroup@"

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -24,9 +24,7 @@
 #include "P_DNS.h"
 #include "tscore/ink_inet.h"
 
-#ifdef SPLIT_DNS
 #include "I_SplitDNS.h"
-#endif
 
 #define SRV_COST (RRFIXEDSZ + 0)
 #define SRV_WEIGHT (RRFIXEDSZ + 2)
@@ -411,15 +409,11 @@ DNSEntry::init(const char *x, int len, int qtype_arg, Continuation *acont, DNSPr
   action        = acont;
   submit_thread = acont->mutex->thread_holding;
 
-#ifdef SPLIT_DNS
   if (SplitDNSConfig::gsplit_dns_enabled) {
     dnsH = opt.handler ? opt.handler : dnsProcessor.handler;
   } else {
     dnsH = dnsProcessor.handler;
   }
-#else
-  dnsH = dnsProcessor.handler;
-#endif // SPLIT_DNS
 
   dnsH->txn_lookup_timeout = opt.timeout;
 

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -32,7 +32,6 @@
 #include "tscore/Tokenizer.h"
 #include "tscore/Filenames.h"
 
-#ifdef SPLIT_DNS
 #include <sys/types.h>
 #include "P_SplitDNS.h"
 #include "tscore/MatcherUtils.h"
@@ -552,5 +551,3 @@ ink_split_dns_init(ts::ModuleVersion v)
 
   init_called = 1;
 }
-
-#endif // SPLIT_DNS

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -169,7 +169,7 @@ HostDBHash::set_host(const char *name, int len)
 {
   host_name = name;
   host_len  = len;
-#ifdef SPLIT_DNS
+
   if (host_name && SplitDNSConfig::isSplitDNSEnabled()) {
     const char *scan;
     // I think this is checking for a hostname that is just an address.
@@ -189,7 +189,7 @@ HostDBHash::set_host(const char *name, int len)
       dns_server = nullptr;
     }
   }
-#endif // SPLIT_DNS
+
   return *this;
 }
 

--- a/iocore/hostdb/P_HostDB.h
+++ b/iocore/hostdb/P_HostDB.h
@@ -32,10 +32,7 @@
 
 #include "tscore/ink_platform.h"
 
-#ifdef SPLIT_DNS
 #include "P_SplitDNS.h"
-#endif
-
 #include "P_EventSystem.h"
 
 #include "I_HostDB.h"

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -123,7 +123,6 @@ produce_features(bool json)
   print_feature("TS_MAX_THREADS_IN_EACH_THREAD_TYPE", TS_MAX_THREADS_IN_EACH_THREAD_TYPE, json);
   print_feature("TS_MAX_NUMBER_EVENT_THREADS", TS_MAX_NUMBER_EVENT_THREADS, json);
   print_feature("TS_MAX_HOST_NAME_LEN", TS_MAX_HOST_NAME_LEN, json);
-  print_feature("SPLIT_DNS", SPLIT_DNS, json);
   print_feature("TS_PKGSYSUSER", TS_PKGSYSUSER, json);
   print_feature("TS_PKGSYSGROUP", TS_PKGSYSGROUP, json, true);
   if (json) {

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2049,9 +2049,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     HostStatus::instance().loadHostStatusFromStats();
     netProcessor.init_socks();
     ParentConfig::startup();
-#ifdef SPLIT_DNS
     SplitDNSConfig::startup();
-#endif
 
     // Initialize HTTP/2
     Http2::init();

--- a/tests/README.md
+++ b/tests/README.md
@@ -317,7 +317,6 @@ ts.Disk.remap_config.AddLine(
  * TS_HAS_128BIT_CAS
  * TS_HAS_TESTS
  * TS_HAS_WCCP
- * SPLIT_DNS
 
 ### Example
 ```python


### PR DESCRIPTION
This was never exposed in autoconf and has always been enabled.