### PR TITLE
Update autest python version to 36

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -24,7 +24,7 @@ autopep8 = "*"
 pyflakes = "*"
 
 [packages]
-autest = "==1.7.4"
+autest = "==1.8.0"
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"
 dnslib = "*"

--- a/tests/autest.sh
+++ b/tests/autest.sh
@@ -27,7 +27,7 @@ if [ ! -f ./env-test/bin/autest ]; then\
         echo -e "${GREEN}Done!${NC}";\
 	fi
 # this is for rhel or centos systems
-test -r /opt/rh/rh-python35/enable && . /opt/rh/rh-python35/enable
+test -r /opt/rh/rh-python36/enable && . /opt/rh/rh-python36/enable
 . env-test/bin/activate
 ./env-test/bin/autest -D gold_tests "$@"
 ret=$?

--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -26,7 +26,7 @@ import platform
 import sys
 
 pip_packages = [
-    "autest==1.7.3",
+    "autest==1.8.0",
     "hyper",
     "requests",
     "dnslib",
@@ -39,8 +39,8 @@ pip_packages = [
 distro_packages = {
     "RHEL": [
         "install epel-release",
-        "install python35",
-        "install rh-python35-python-virtualenv"
+        "install python36",
+        "install rh-python36-python-virtualenv"
     ],
     "Fedora": [
         "install python3",
@@ -55,7 +55,7 @@ distro_packages = {
     ],
     "CentOS": [
         "install epel-release",
-        "install rh-python35-python-virtualenv"
+        "install rh-python36-python-virtualenv"
     ]
 }
 
@@ -169,7 +169,7 @@ def gen_package_cmds(packages):
 
 extra = ''
 if distro() == 'RHEL' or distro() == 'CentOS':
-    extra = ". /opt/rh/rh-python35/enable ;"
+    extra = ". /opt/rh/rh-python36/enable ;"
 
 
 def venv_cmds(path):
@@ -181,7 +181,7 @@ def venv_cmds(path):
     return [
         # first command only needed for rhel and centos systems at this time
         extra + " virtualenv --python=python3 {0}".format(path),
-        extra + " {0}/bin/pip install pip --upgrade".format(path)
+        extra + " {0}/bin/pip install pip setuptools --upgrade".format(path)
     ]
 
 


### PR DESCRIPTION
Update autest python version to 36

This updates the needed version to 36 since it appears some dependencies require it.  It also adds setuptools to be upgraded along with pip to resolve a build requirements issues.  Finally it sets the bootstrap autest version to match what is in the pipfile since they are off currently