### PR TITLE
Add memory_profile plugin

### DIFF
--- a/doc/admin-guide/plugins/index.en.rst
+++ b/doc/admin-guide/plugins/index.en.rst
@@ -158,6 +158,7 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
    JA3 Fingerprint <ja3_fingerprint.en>
    Maxmind ACL <maxmind_acl.en>
    Memcache <memcache.en>
+   Memory Profile <memory_profile.en>
    Metalink <metalink.en>
    Money Trace <money_trace.en>
    MP4 <mp4.en>

--- a/doc/admin-guide/plugins/memory_profile.en.rst
+++ b/doc/admin-guide/plugins/memory_profile.en.rst
@@ -1,0 +1,68 @@
+Memory_profile Plugin
+*********************
+
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+
+
+This plugin listens for plugin msgs and invokes jemalloc control
+operations.
+
+Installation
+============
+
+Add the following line to :file:`plugin.config`::
+
+    memory_profile.so
+
+In addition, |TS| must be able to read jemalloc configuration
+information either through the ``JEMALLOC_CONF`` environment variable
+or via the string sym linked to ``/etc/malloc.conf``.
+
+For example, if the string below is in ``JEMALLOC_CONF`` or in the sym link string, it
+enables profiling and indicates that the memory dump prefix is ``/tmp/jeprof``.::
+
+    prof:true,prof_prefix:/tmp/jeprof
+
+Details on configuration jemalloc options at `<http://jemalloc.net/jemalloc.3.html>`.
+
+Plugin Messages
+===============
+
+The plugin responds to the following mesages sent via traffic_ctl.
+
+Message    Action
+========== ===================================================================================
+activate   Start jemalloc profiling. Useful if prof_active:false was in the configure string.
+
+deactivate Stop jemalloc profiling.
+
+dump       If profiling is enabled and active, it will generate a profile dump file.
+
+stats      Print jemalloc statistics in traffic.out
+
+The command below sends the stats message to the plugin causing the current statistics to be written to traffic.out::
+
+    traffic_ctl plugin msg memory_profile stats
+
+Limitations
+===========
+
+Currently the plugin only functions for systems compiled against jemalloc.
+Perhaps in the future, it can be augmented to interact with other memory
+allocation systems.
+

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -75,6 +75,7 @@ include experimental/maxmind_acl/Makefile.inc
 endif
 
 include experimental/memcache/Makefile.inc
+include experimental/memory_profile/Makefile.inc
 include experimental/metalink/Makefile.inc
 include experimental/money_trace/Makefile.inc
 include experimental/mp4/Makefile.inc

--- a/plugins/experimental/memory_profile/Makefile.inc
+++ b/plugins/experimental/memory_profile/Makefile.inc
@@ -15,7 +15,7 @@
 #  limitations under the License.
 
 experimental_memory_profile_memory_profile_la_CPPFLAGS = \
-  $(AM_CPPFLAGS) 
+  $(AM_CPPFLAGS)
 
 pkglib_LTLIBRARIES += experimental/memory_profile/memory_profile.la
 

--- a/plugins/experimental/memory_profile/Makefile.inc
+++ b/plugins/experimental/memory_profile/Makefile.inc
@@ -1,0 +1,23 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+experimental_memory_profile_memory_profile_la_CPPFLAGS = \
+  $(AM_CPPFLAGS) 
+
+pkglib_LTLIBRARIES += experimental/memory_profile/memory_profile.la
+
+experimental_memory_profile_memory_profile_la_SOURCES = \
+  experimental/memory_profile/memory_profile.cc

--- a/plugins/experimental/memory_profile/memory_profile.cc
+++ b/plugins/experimental/memory_profile/memory_profile.cc
@@ -1,0 +1,109 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/* memory_profile.cc
+ *   Responds to plugin messages to dump and activate memory profiling
+ *   System must be built with jemalloc to be useful
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <ts/ts.h>
+#include <string.h>
+#include <errno.h>
+#include <tscore/ink_config.h>
+#if TS_HAS_JEMALLOC
+#include <jemalloc/jemalloc.h>
+#endif
+
+#define PLUGIN_NAME "memory_profile"
+
+int
+CallbackHandler(TSCont cont, TSEvent id, void *data)
+{
+  (void)cont; // make compiler shut up about unused variable.
+
+  if (id == TS_EVENT_LIFECYCLE_MSG) {
+    TSPluginMsg *msg = (TSPluginMsg *)data;
+    TSDebug(PLUGIN_NAME, "Message to '%s' - %zu bytes of data", msg->tag, msg->data_size);
+    if (strcmp(PLUGIN_NAME, msg->tag) == 0) { // Message is for us
+#if TS_HAS_JEMALLOC
+      int retval = 0;
+      if (strncmp((char *)msg->data, "dump", msg->data_size) == 0) {
+        if ((retval = mallctl("prof.dump", nullptr, nullptr, nullptr, 0)) != 0) {
+          TSError("mallct(prof.dump) failed retval=%d errno=%d", retval, errno);
+        }
+      } else if (strncmp((char *)msg->data, "activate", msg->data_size) == 0) {
+        bool active = true;
+
+        if ((retval = mallctl("prof.active", nullptr, nullptr, &active, sizeof(active))) != 0) {
+          TSError("mallct(prof.activate) on failed retval=%d errno=%d", retval, errno);
+        }
+      } else if (strncmp((char *)msg->data, "deactivate", msg->data_size) == 0) {
+        bool active = false;
+        if ((retval = mallctl("prof.active", nullptr, nullptr, &active, sizeof(active))) != 0) {
+          TSError("mallct(prof.activate) off failed retval=%d errno=%d", retval, errno);
+        }
+      } else if (strncmp((char *)msg->data, "stats", msg->data_size) == 0) {
+        malloc_stats_print(nullptr, nullptr, nullptr);
+      } else {
+        TSError("Unexpected msg %*.s", (int)msg->data_size, (char *)msg->data);
+      }
+#else
+      TSError("Not built with jemalloc");
+#endif
+    }
+  } else {
+    TSError("Unexpected event %d", id);
+  }
+  return TS_EVENT_NONE;
+}
+
+void
+TSPluginInit(int argc, const char *argv[])
+{
+  TSPluginRegistrationInfo info;
+  TSCont cb;
+
+  info.plugin_name   = PLUGIN_NAME;
+  info.vendor_name   = "Apache Software Foundation";
+  info.support_email = "dev@trafficserver.apache.org";
+
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+    TSError("[%s] Plugin registration failed", PLUGIN_NAME);
+
+    goto Lerror;
+  }
+
+  cb = TSContCreate(CallbackHandler, NULL);
+
+  TSLifecycleHookAdd(TS_LIFECYCLE_MSG_HOOK, cb);
+
+  TSDebug(PLUGIN_NAME, "online");
+
+  return;
+
+Lerror:
+  TSError("[%s] Unable to initialize plugin (disabled)", PLUGIN_NAME);
+}


### PR DESCRIPTION
A simple plugin to perform jemalloc ctl operations on the traffic_server running with jemalloc.  I found it really useful to control when I wanted to make profile dumps.