### PR TITLE
Spacing tweaks to acl_filter_rule::print

### DIFF
--- a/proxy/http/remap/AclFiltering.cc
+++ b/proxy/http/remap/AclFiltering.cc
@@ -102,6 +102,7 @@ acl_filter_rule::print()
       printf("0x%x ", HTTP_WKSIDX_CONNECT + i);
     }
   }
+  printf("\n");
   printf("nonstandard methods=");
   for (const auto &nonstandard_method : nonstandard_methods) {
     printf("%s ", nonstandard_method.c_str());
@@ -110,13 +111,13 @@ acl_filter_rule::print()
   printf("src_ip_cnt=%d\n", src_ip_cnt);
   for (i = 0; i < src_ip_cnt; i++) {
     ip_text_buffer b1, b2;
-    printf("%s - %s", src_ip_array[i].start.toString(b1, sizeof(b1)), src_ip_array[i].end.toString(b2, sizeof(b2)));
+    printf("%s - %s, ", src_ip_array[i].start.toString(b1, sizeof(b1)), src_ip_array[i].end.toString(b2, sizeof(b2)));
   }
   printf("\n");
   printf("in_ip_cnt=%d\n", in_ip_cnt);
   for (i = 0; i < in_ip_cnt; i++) {
     ip_text_buffer b1, b2;
-    printf("%s - %s", in_ip_array[i].start.toString(b1, sizeof(b1)), in_ip_array[i].end.toString(b2, sizeof(b2)));
+    printf("%s - %s, ", in_ip_array[i].start.toString(b1, sizeof(b1)), in_ip_array[i].end.toString(b2, sizeof(b2)));
   }
   printf("\n");
   for (i = 0; i < argc; i++) {


### PR DESCRIPTION
Makes the ip lists actually discernible as IPs

eg:
127.0.0.1 - 127.0.0.1, ::1 - ::1, 10.0.0.0 - 10.255.255.255, 8.0.0.0 - 8.255.255.255,