### PR TITLE
Add a null check to avoid crashing

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4811,6 +4811,9 @@ std::string_view
 HttpSM::get_outbound_cert() const
 {
   const char *cert_name = t_state.txn_conf->ssl_client_cert_filename;
+  if (cert_name == nullptr) {
+    cert_name = "";
+  }
   return std::string_view(cert_name);
 }
 


### PR DESCRIPTION
This fixes a crash described in #7033.