### PR TITLE
Add virtual destructor to QUICTPConfig.

### DIFF
--- a/iocore/net/quic/QUICTypes.h
+++ b/iocore/net/quic/QUICTypes.h
@@ -520,6 +520,7 @@ private:
 class QUICTPConfig
 {
 public:
+  virtual ~QUICTPConfig()                                                                          = default; // required
   virtual uint32_t no_activity_timeout() const                                                     = 0;
   virtual const IpEndpoint *preferred_address_ipv4() const                                         = 0;
   virtual const IpEndpoint *preferred_address_ipv6() const                                         = 0;


### PR DESCRIPTION
Required because `QUICTPConfig` has virtual methods.

This should be backported to ATS 9.