### PR TITLE
Add cross references between server session sharing match and upstream connection tracking match.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -975,8 +975,14 @@ mptcp
 
 .. note::
 
-   Server sessions to different ports never match even if the FQDN and IP
+   Server sessions to different upstream ports never match even if the FQDN and IP
    address match.
+
+.. note::
+
+   :ts:cv:`Upstream session tracking <proxy.config.http.per_server.connection.max>` uses a similar
+   set of options for matching sessions, but is :ts:cv:`set independently
+   <proxy.config.http.per_server.connection.match>` from session sharing.
 
 .. ts:cv:: CONFIG proxy.config.http.server_session_sharing.pool STRING thread
 
@@ -1503,6 +1509,11 @@ Origin Server Connect Attempts
       Group by IP address, port, and host name. Each distinct combination is a group.
 
    To disable upstream server grouping, set :ts:cv:`proxy.config.http.per_server.connection.max` to ``0``.
+
+.. note::
+
+   This setting is independent of the :ts:cv:`setting for upstream session sharing matching
+   <proxy.config.http.server_session_sharing.match>`.
 
 .. ts:cv:: CONFIG proxy.config.http.per_server.connection.queue_size INT 0
    :reloadable:

--- a/doc/admin-guide/plugins/icap.en.rst
+++ b/doc/admin-guide/plugins/icap.en.rst
@@ -1,4 +1,5 @@
 .. _icap-plugin:
+.. include:: ../../common.defs
 
 ICAP Plugin
 ***********

--- a/doc/admin-guide/plugins/memory_profile.en.rst
+++ b/doc/admin-guide/plugins/memory_profile.en.rst
@@ -1,3 +1,5 @@
+.. include:: ../../common.defs
+
 Memory_profile Plugin
 *********************
 


### PR DESCRIPTION
* Fix various documentation build errors.
* Add the cross referencing.