### PR TITLE
Avoid unnecessary copying of STL map for QUICTPConfigQCP class.

### DIFF
--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -204,7 +204,7 @@ public:
     }
   }
 
-  std::unordered_map<uint16_t, std::pair<const uint8_t *, uint16_t>>
+  const std::unordered_map<uint16_t, std::pair<const uint8_t *, uint16_t>> &
   additional_tp() const override
   {
     return this->_additional_tp;

--- a/iocore/net/quic/QUICTypes.h
+++ b/iocore/net/quic/QUICTypes.h
@@ -520,21 +520,21 @@ private:
 class QUICTPConfig
 {
 public:
-  virtual ~QUICTPConfig()                                                                          = default; // required
-  virtual uint32_t no_activity_timeout() const                                                     = 0;
-  virtual const IpEndpoint *preferred_address_ipv4() const                                         = 0;
-  virtual const IpEndpoint *preferred_address_ipv6() const                                         = 0;
-  virtual uint32_t initial_max_data() const                                                        = 0;
-  virtual uint32_t initial_max_stream_data_bidi_local() const                                      = 0;
-  virtual uint32_t initial_max_stream_data_bidi_remote() const                                     = 0;
-  virtual uint32_t initial_max_stream_data_uni() const                                             = 0;
-  virtual uint64_t initial_max_streams_bidi() const                                                = 0;
-  virtual uint64_t initial_max_streams_uni() const                                                 = 0;
-  virtual uint8_t ack_delay_exponent() const                                                       = 0;
-  virtual uint8_t max_ack_delay() const                                                            = 0;
-  virtual uint8_t active_cid_limit() const                                                         = 0;
-  virtual bool disable_active_migration() const                                                    = 0;
-  virtual std::unordered_map<uint16_t, std::pair<const uint8_t *, uint16_t>> additional_tp() const = 0;
+  virtual ~QUICTPConfig()                                                                                 = default; // required
+  virtual uint32_t no_activity_timeout() const                                                            = 0;
+  virtual const IpEndpoint *preferred_address_ipv4() const                                                = 0;
+  virtual const IpEndpoint *preferred_address_ipv6() const                                                = 0;
+  virtual uint32_t initial_max_data() const                                                               = 0;
+  virtual uint32_t initial_max_stream_data_bidi_local() const                                             = 0;
+  virtual uint32_t initial_max_stream_data_bidi_remote() const                                            = 0;
+  virtual uint32_t initial_max_stream_data_uni() const                                                    = 0;
+  virtual uint64_t initial_max_streams_bidi() const                                                       = 0;
+  virtual uint64_t initial_max_streams_uni() const                                                        = 0;
+  virtual uint8_t ack_delay_exponent() const                                                              = 0;
+  virtual uint8_t max_ack_delay() const                                                                   = 0;
+  virtual uint8_t active_cid_limit() const                                                                = 0;
+  virtual bool disable_active_migration() const                                                           = 0;
+  virtual const std::unordered_map<uint16_t, std::pair<const uint8_t *, uint16_t>> &additional_tp() const = 0;
 };
 
 class QUICLDConfig


### PR DESCRIPTION
The optimizer may elide the copying but best not to count on it.