### PR TITLE
Add checks to catch tunnel memory leaks

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -28,7 +28,6 @@
 
 #include "InkAPIInternal.h" // Added to include the ssl_hook definitions
 #include "Log.h"
-#include "HttpTunnel.h"
 #include "ProxyProtocol.h"
 #include "HttpConfig.h"
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6334,6 +6334,7 @@ HttpSM::setup_100_continue_transfer()
 
   // Clear the decks before we set up new producers.  As things stand, we cannot have two static operators
   // at once
+  tunnel.deallocate_buffers();
   tunnel.reset();
 
   // Setup the tunnel to the client
@@ -6466,6 +6467,7 @@ HttpSM::setup_internal_transfer(HttpSMHandler handler_arg)
   // Clear the decks before we setup the new producers
   // As things stand, we cannot have two static producers operating at
   // once
+  tunnel.deallocate_buffers();
   tunnel.reset();
 
   // Setup the tunnel to the client

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -97,9 +97,11 @@ ChunkedHandler::clear()
   switch (action) {
   case ACTION_DOCHUNK:
     free_MIOBuffer(chunked_buffer);
+    chunked_buffer = nullptr;
     break;
   case ACTION_DECHUNK:
     free_MIOBuffer(dechunked_buffer);
+    dechunked_buffer = nullptr;
     break;
   case ACTION_PASSTHRU:
   default:
@@ -477,6 +479,8 @@ HttpTunnel::reset()
   }
 #endif
 
+  assert_freed_buffers();
+
   num_producers = 0;
   num_consumers = 0;
   ink_zero(consumers);
@@ -523,6 +527,16 @@ HttpTunnel::alloc_consumer()
   }
   ink_release_assert(0);
   return nullptr;
+}
+
+void
+HttpTunnel::assert_freed_buffers()
+{
+  for (auto &producer : producers) {
+    ink_release_assert(producer.read_buffer == nullptr);
+    ink_release_assert(producer.chunked_handler.chunked_buffer == nullptr);
+    ink_release_assert(producer.chunked_handler.dechunked_buffer == nullptr);
+  }
 }
 
 int

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -333,6 +333,7 @@ private:
   void finish_all_internal(HttpTunnelProducer *p, bool chain);
   void update_stats_after_abort(HttpTunnelType_t t);
   void producer_run(HttpTunnelProducer *p);
+  void assert_freed_buffers();
 
   HttpTunnelProducer *get_producer(VIO *vio);
   HttpTunnelConsumer *get_consumer(VIO *vio);


### PR DESCRIPTION
Attempt to debug issue #6783 

Not clear anything here will fix that issue, but the added asserts should trigger if the state machine shuts down without freeing the chunked_buffer.

In our production with jemalloc profiling I was not able to catch any allocation stacks that included generate_chunked_content.