### PR TITLE
Fix proxy.process.http.current_client_connections

### DIFF
--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -261,12 +261,8 @@ Http1ClientSession::do_io_close(int alerrno)
   } else {
     HttpSsnDebug("[%" PRId64 "] session closed", con_id);
     HTTP_SUM_DYN_STAT(http_transactions_per_client_con, transact_count);
-    if (read_state != HCS_ACTIVE_READER) {
-      // donot double decrement
-      HTTP_DECREMENT_DYN_STAT(http_current_client_connections_stat);
-    }
-    read_state    = HCS_CLOSED;
-    conn_decrease = false;
+    read_state = HCS_CLOSED;
+
     // Can go ahead and close the netvc now, but keeping around the session object
     // until all the transactions are closed
     if (_vc) {


### PR DESCRIPTION
On ats 9.0.x (and presumably master) proxy.process.http.current_client_connections is not being correctly decremented.

The error was introduced in ASF PR #7012.  I think the test whether to decrement was backwards.  This code change seems to address the issue.

This closes issue #7054 