### PR TITLE
Document proxy.config.http.cache.post_method.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1945,6 +1945,12 @@ Cache Control
 
    Enables (``1``) or disables (``0``) caching of HTTP requests.
 
+.. ts:cv:: CONFIG proxy.config.http.cache.post_method INT 0
+   :reloadable:
+   :overridable:
+
+   Enables (``1``) or disables (``0``) caching of HTTP POST requests.
+
 .. ts:cv:: CONFIG proxy.config.http.cache.generation INT -1
    :reloadable:
    :overridable:


### PR DESCRIPTION
This option allows people to cache responses to POST requests.

Signed-off-by: David Calavera <david.calavera@gmail.com>