### PR TITLE
Expose remap config file callback

### DIFF
--- a/include/ts/experimental.h
+++ b/include/ts/experimental.h
@@ -346,6 +346,7 @@ tsapi char *TSMatcherLineValue(TSMatcherLine ml, int element);
  ****************************************************************************/
 tsapi TSReturnCode TSMgmtConfigIntSet(const char *var_name, TSMgmtInt value);
 
+tsapi TSReturnCode TSMgmtConfigFileAdd(const char *parent, const char *fileName);
 /* ----------------------------------------------------------------------
  * Interfaces used by Wireless group
  * ---------------------------------------------------------------------- */

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1187,6 +1187,7 @@ tsapi TSReturnCode TSMgmtCounterGet(const char *var_name, TSMgmtCounter *result)
 tsapi TSReturnCode TSMgmtFloatGet(const char *var_name, TSMgmtFloat *result);
 tsapi TSReturnCode TSMgmtStringGet(const char *var_name, TSMgmtString *result);
 tsapi TSReturnCode TSMgmtSourceGet(const char *var_name, TSMgmtSource *source);
+tsapi TSReturnCode TSMgmtConfigFileAdd(const char *parent, const char *fileName);
 /* --------------------------------------------------------------------------
    Continuations */
 tsapi TSCont TSContCreate(TSEventFunc funcp, TSMutex mutexp);

--- a/mgmt/utils/MgmtUtils.h
+++ b/mgmt/utils/MgmtUtils.h
@@ -58,3 +58,5 @@ void mgmt_fatal(const int lerrno, const char *message_format, ...) TS_NORETURN;
 
 void mgmt_sleep_sec(int);
 void mgmt_sleep_msec(int);
+
+void load_config_file_callback(const char *parent_file, const char *remap_file);

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -25,11 +25,12 @@
 bool
 Acl::init(char const *filename)
 {
-  std::string configloc;
   struct stat s;
   bool status = false;
 
   YAML::Node maxmind;
+
+  configloc.clear();
 
   if (filename[0] != '/') {
     // relative file
@@ -71,6 +72,12 @@ Acl::init(char const *filename)
     TSError("YAML::Exception %s when parsing YAML config file %s for maxmind", e.what(), configloc.c_str());
     return status;
   }
+
+  // Associate our config file with remap.config to be able to initiate reloads
+  TSMgmtString result;
+  const char *var_name = "proxy.config.url_remap.filename";
+  TSMgmtStringGet(var_name, &result);
+  TSMgmtConfigFileAdd(result, configloc.c_str());
 
   // Find our database name and convert to full path as needed
   status = loaddb(maxmind["database"]);

--- a/plugins/experimental/maxmind_acl/mmdb.h
+++ b/plugins/experimental/maxmind_acl/mmdb.h
@@ -82,6 +82,7 @@ public:
 
 protected:
   // Class members
+  std::string configloc;
   YAML::Node _config;
   MMDB_s _mmdb;
   std::string _html;

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -32,6 +32,7 @@
 #include "tscore/ink_file.h"
 #include "tscore/Tokenizer.h"
 #include "tscore/ts_file.h"
+#include "tscore/Filenames.h"
 #include "IPAllow.h"
 #include "PluginFactory.h"
 
@@ -299,7 +300,7 @@ parse_remap_fragment(const char *path, BUILD_TABLE_INFO *bti, char *errbuf, size
   if (success) {
     // register the included file with the management subsystem so that we can correctly
     // reload them when they change
-    load_remap_file_cb(path);
+    load_remap_file_cb(ts::filename::REMAP, path);
   } else {
     snprintf(errbuf, errbufsize, "failed to parse included file %s", path);
     return (const char *)errbuf;

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -76,6 +76,6 @@ unsigned long remap_check_option(const char **argv, int argc, unsigned long find
 
 bool remap_parse_config(const char *path, UrlRewrite *rewrite);
 
-typedef void (*load_remap_file_func)(const char *);
+typedef void (*load_remap_file_func)(const char *, const char *);
 
 extern load_remap_file_func load_remap_file_cb;

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -7763,6 +7763,16 @@ TSMgmtConfigIntSet(const char *var_name, TSMgmtInt value)
   return TS_SUCCESS;
 }
 
+extern void load_config_file_callback(const char *parent, const char *remap_file);
+
+/* Config file name setting */
+TSReturnCode
+TSMgmtConfigFileAdd(const char *parent, const char *fileName)
+{
+  load_config_file_callback(parent, fileName);
+  return TS_SUCCESS;
+}
+
 TSReturnCode
 TSCacheUrlSet(TSHttpTxn txnp, const char *url, int length)
 {

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -131,7 +131,6 @@ static void mgmt_storage_device_cmd_callback(int cmd, std::string_view const &ar
 static void mgmt_lifecycle_msg_callback(ts::MemSpan<void>);
 static void init_ssl_ctx_callback(void *ctx, bool server);
 static void load_ssl_file_callback(const char *ssl_file);
-static void load_remap_file_callback(const char *remap_file);
 static void task_threads_started_callback();
 
 // We need these two to be accessible somewhere else now
@@ -1897,7 +1896,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 #endif
 
   // setup callback for tracking remap included files
-  load_remap_file_cb = load_remap_file_callback;
+  load_remap_file_cb = load_config_file_callback;
 
   // We need to do this early so we can initialize the Machine
   // singleton, which depends on configuration values loaded in this.
@@ -2272,10 +2271,10 @@ load_ssl_file_callback(const char *ssl_file)
   pmgmt->signalConfigFileChild(ts::filename::SSL_MULTICERT, ssl_file);
 }
 
-static void
-load_remap_file_callback(const char *remap_file)
+void
+load_config_file_callback(const char *parent_file, const char *remap_file)
 {
-  pmgmt->signalConfigFileChild(ts::filename::REMAP, remap_file);
+  pmgmt->signalConfigFileChild(parent_file, remap_file);
 }
 
 static void


### PR DESCRIPTION
This extends the load_remap_file_callback to be load_config_file_callback.  It now takes 2 parameters so that you can specify both the parent and child file to tie to any tracked file. Also added as an API call for plugins that wish to use the functionality

For plugins this only particularly makes sense to tie to remap.config.  The child/parent setup will remove all children on reload of the parent file, so a plugin would have to manually track any files other than remap (since a remap reload will cause the plugin itself to reload and re-register its config file). However this functionality may be useful in the future or as a template for when we get to more yaml rewrites and having multiple files included