### PR TITLE
Updated release notes for 9.0.0 to have new QUIC 27 version

### DIFF
--- a/doc/release-notes/whats-new.en.rst
+++ b/doc/release-notes/whats-new.en.rst
@@ -33,7 +33,7 @@ New Features
 
 This version of ATS has a number of new features (details below), but we're particularly excited about the following features:
 
-* Experimental QUIC support (draft 23).
+* Experimental QUIC support (draft 27).
 * TLS v1.3 0RTT support.
 
 PROXY protocol


### PR DESCRIPTION
QUIC version we support on 9.0.0 is 27.