### PR TITLE
Destroy threads after job done

### DIFF
--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -28,6 +28,8 @@
 #include <functional>
 #include <string_view>
 
+#include <ts/apidefs.h>
+
 #include "MgmtUtils.h"
 #include "BaseManager.h"
 #include "tscore/ink_sock.h"
@@ -49,7 +51,8 @@ public:
   // Start a thread for the process manager. If @a cb is set then it
   // is called after the thread is started and before any messages are
   // processed.
-  void start(std::function<void()> const &cb = std::function<void()>());
+  void start(std::function<TSThread()> const &cb_init        = std::function<TSThread()>(),
+             std::function<void(TSThread)> const &cb_destroy = std::function<void(TSThread)>());
 
   // Stop the process manager, dropping any unprocessed messages.
   void stop();
@@ -94,7 +97,9 @@ private:
 
   /// Thread initialization callback.
   /// This allows @c traffic_server and @c traffic_manager to perform different initialization in the thread.
-  std::function<void()> init;
+  std::function<TSThread()> init;
+  std::function<void(TSThread)> destroy;
+  TSThread managerThread = nullptr;
 
   int local_manager_sockfd;
 #if HAVE_EVENTFD

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -662,8 +662,8 @@ initialize_process_manager()
   pmgmt = new ProcessManager(remote_management_flag);
 
   // Lifecycle callbacks can potentially be invoked from this thread, so force thread initialization
-  // to make the TS API work. Use a lambda to avoid dealing with compiler dependent casting issues.
-  pmgmt->start([]() -> void { TSThreadInit(); });
+  // to make the TS API work.
+  pmgmt->start(TSThreadInit, TSThreadDestroy);
 
   RecProcessInitMessage(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE);
   pmgmt->reconfigure();


### PR DESCRIPTION
This fixes the memory leak described in issue #7082. 