### PR TITLE
Reset stale read.triggered when migrating thread contexts

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1188,6 +1188,9 @@ UnixNetVConnection::populate(Connection &con_in, Continuation *c, void *arg)
     return EVENT_ERROR;
   }
 
+  // reset stale read triggered on keep alive connection to prevent getting into read ready list
+  this->read.triggered = 0;
+
   if (h->startIO(this) < 0) {
     Debug("iocore_net", "populate : Failed to add to epoll list");
     return EVENT_ERROR;


### PR DESCRIPTION
This fixes issue #7096.

The stale triggered results in adding the idle VC to read-ready list
which ends up in a quagmire of odd looking corruption and openSSL crashes

This is applicable to Server Session reuse with Global share mode.

This is a regression caused by PR https://github.com/apache/trafficserver/pull/2440

 