### PR TITLE
Supporting out of source builds for AuTests.

### DIFF
--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -31,3 +31,7 @@ if AuTestVersion() < autest_version:
 Settings.path_argument(["--ats-bin"],
                        required=True,
                        help="A user provided directory to ATS bin")
+
+Settings.path_argument(["--build-root"],
+                       required=False,
+                       help="The location of the build root for out of source builds")

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -17,12 +17,22 @@
 #  limitations under the License.
 
 import json
-import subprocess
+import os
+from os.path import dirname
 import pprint
+import subprocess
 
 if Arguments.ats_bin is not None:
     # Add environment variables
     ENV['ATS_BIN'] = Arguments.ats_bin
+
+if Arguments.build_root is not None:
+    ENV['BUILD_ROOT'] = Arguments.build_root
+else:
+    # Assume the build root is the same directory tree as the test location.
+    ENV['BUILD_ROOT'] = dirname(dirname(dirname(AutestSitePath)))
+
+host.WriteVerbose(['ats'], "Test build root: {}:".format(ENV['BUILD_ROOT']))
 
 if ENV['ATS_BIN'] is not None:
     # Add variables for Tests
@@ -78,9 +88,12 @@ if ENV['ATS_BIN'] is not None:
                 host.WriteError("tsxs is broken. Aborting tests", show_stack=False)
     host.WriteVerbose(['ats'], "Traffic server build flags:\n", pprint.pformat(out))
     Variables.update(out)
-Variables.AtsExampleDir = os.path.join(AutestSitePath, '../../../example')
-Variables.AtsTestToolsDir = os.path.join(AutestSitePath, '../../tools')
-Variables.AtsTestPluginsDir = os.path.join(AutestSitePath, '../../tools/plugins/.libs')
+
+Variables.AtsExampleDir = os.path.join(AutestSitePath, '..', '..', '..', 'example')
+Variables.AtsTestToolsDir = os.path.join(AutestSitePath, '..', '..', 'tools')
+Variables.BuildRoot = ENV['BUILD_ROOT']
+Variables.AtsTestPluginsDir = os.path.join(Variables.BuildRoot, 'tests', 'tools', 'plugins', '.libs')
+Variables.AtsBuildGoldTestsDir = os.path.join(Variables.BuildRoot, 'tests', 'gold_tests')
 
 # modify delay times as we always have to kill Trafficserver
 # no need to wait

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+
 Test.Summary = '''
 Test chunked encoding processing
 '''
@@ -94,7 +96,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 
 # smuggle-client is built via `make`. Here we copy the built binary down to the
 # test directory so that the test runs in this file can use it.
-Test.Setup.Copy('smuggle-client')
+Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'chunked_encoding', 'smuggle-client'))
 
 # HTTP1.1 GET: www.example.com
 tr = Test.AddTestRun()

--- a/tests/gold_tests/continuations/session_id.test.py
+++ b/tests/gold_tests/continuations/session_id.test.py
@@ -39,7 +39,8 @@ ts = Test.MakeATSProcess("ts", command="traffic_manager", enable_tls=True, enabl
 ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
-Test.PrepareTestPlugin(os.path.join(Test.TestDirectory, 'plugins', '.libs', 'session_id_verify.so'), ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsBuildGoldTestsDir,
+                                    'continuations', 'plugins', '.libs', 'session_id_verify.so'), ts)
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,

--- a/tests/gold_tests/timeout/tls_conn_timeout.test.py
+++ b/tests/gold_tests/timeout/tls_conn_timeout.test.py
@@ -16,11 +16,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+
 Test.Summary = 'Testing ATS TLS handshake timeout'
 
 ts = Test.MakeATSProcess("ts")
 
-Test.Setup.Copy('ssl-delay-server')
+Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'timeout', 'ssl-delay-server'))
 
 Test.ContinueOnFail = True
 Test.GetTcpPort("block_connect_port")

--- a/tests/gold_tests/tls/tls.test.py
+++ b/tests/gold_tests/tls/tls.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+
 Test.Summary = '''
 Test tls
 '''
@@ -26,7 +28,7 @@ server = Test.MakeOriginServer("server")
 
 # ssl-post is built via `make`. Here we copy the built binary down to the test
 # directory so that the test runs in this file can use it.
-Test.Setup.Copy('ssl-post')
+Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'tls', 'ssl-post'))
 
 requestLocation = "test2"
 reHost = "www.example.com"


### PR DESCRIPTION
This adds the --build-root autest option to support running AuTest for out of
source builds where the built binaries reside in a directory tree
outside of where the Traffic Server AuTests themselves are located.