### PR TITLE
Add QUIC draft-29 support

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4092,13 +4092,13 @@ removed in the future without prior notice.
    This is just for debugging. Do not change it from the default value unless
    you really understand what this is.
 
-.. ts:cv:: CONFIG proxy.config.quic.congestion_control.initial_window_scale INT 10
+.. ts:cv:: CONFIG proxy.config.quic.congestion_control.initial_window INT 12000
    :reloadable:
 
    This is just for debugging. Do not change it from the default value unless
    you really understand what this is.
 
-.. ts:cv:: CONFIG proxy.config.quic.congestion_control.minimum_window_scale INT 2
+.. ts:cv:: CONFIG proxy.config.quic.congestion_control.minimum_window INT 2400
    :reloadable:
 
    This is just for debugging. Do not change it from the default value unless

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -1232,7 +1232,9 @@ extern tsapi const char *const TS_ALPN_PROTOCOL_HTTP_1_0;
 extern tsapi const char *const TS_ALPN_PROTOCOL_HTTP_1_1;
 extern tsapi const char *const TS_ALPN_PROTOCOL_HTTP_2_0;
 extern tsapi const char *const TS_ALPN_PROTOCOL_HTTP_3;
+extern tsapi const char *const TS_ALPN_PROTOCOL_HTTP_3_D27;
 extern tsapi const char *const TS_ALPN_PROTOCOL_HTTP_QUIC;
+extern tsapi const char *const TS_ALPN_PROTOCOL_HTTP_QUIC_D27;
 
 extern tsapi int TS_ALPN_PROTOCOL_INDEX_HTTP_0_9;
 extern tsapi int TS_ALPN_PROTOCOL_INDEX_HTTP_1_0;

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -72,6 +72,8 @@ extern const std::string_view IP_PROTO_TAG_HTTP_1_1;
 extern const std::string_view IP_PROTO_TAG_HTTP_2_0;
 extern const std::string_view IP_PROTO_TAG_HTTP_QUIC;
 extern const std::string_view IP_PROTO_TAG_HTTP_3;
+extern const std::string_view IP_PROTO_TAG_HTTP_QUIC_D27;
+extern const std::string_view IP_PROTO_TAG_HTTP_3_D27;
 
 struct IpAddr; // forward declare.
 

--- a/iocore/net/P_QUICPacketHandler.h
+++ b/iocore/net/P_QUICPacketHandler.h
@@ -87,7 +87,7 @@ protected:
 private:
   void _recv_packet(int event, UDPPacket *udp_packet) override;
   int _stateless_retry(const uint8_t *buf, uint64_t buf_len, UDPConnection *connection, IpEndpoint from, QUICConnectionId dcid,
-                       QUICConnectionId scid, QUICConnectionId *original_cid);
+                       QUICConnectionId scid, QUICConnectionId *original_cid, QUICConnectionId *retry_cid, QUICVersion version);
   bool _send_stateless_reset(QUICConnectionId dcid, uint32_t instance_id, UDPConnection *udp_con, IpEndpoint &addr,
                              size_t maximum_size);
   void _send_invalid_token_error(const uint8_t *initial_packet, uint64_t initial_packet_len, UDPConnection *connection,

--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -150,7 +150,7 @@ QUICNetProcessor::connect_re(Continuation *cont, sockaddr const *remote_addr, Ne
   QUICConnectionId client_dst_cid;
   client_dst_cid.randomize();
   // vc->init set handler of vc `QUICNetVConnection::startEvent`
-  vc->init(client_dst_cid, client_dst_cid, con, packet_handler, this->_rtable);
+  vc->init(QUIC_SUPPORTED_VERSIONS[0], client_dst_cid, client_dst_cid, con, packet_handler, this->_rtable);
   packet_handler->init(vc);
 
   // Connection ID will be changed

--- a/iocore/net/QUICPacketHandler.cc
+++ b/iocore/net/QUICPacketHandler.cc
@@ -37,14 +37,17 @@
 #include "QUICMultiCertConfigLoader.h"
 #include "QUICTLS.h"
 
-static constexpr char debug_tag[] = "quic_sec";
+static constexpr char debug_tag[]   = "quic_sec";
+static constexpr char v_debug_tag[] = "v_quic_sec";
 
 #define QUICDebug(fmt, ...) Debug(debug_tag, fmt, ##__VA_ARGS__)
-#define QUICDebugQC(qc, fmt, ...) Debug(debug_tag, "[%s] " fmt, qc->cids().data(), ##__VA_ARGS__)
+#define QUICQCDebug(qc, fmt, ...) Debug(debug_tag, "[%s] " fmt, qc->cids().data(), ##__VA_ARGS__)
 
 // ["local dcid" - "local scid"]
-#define QUICDebugDS(dcid, scid, fmt, ...) \
+#define QUICPHDebug(dcid, scid, fmt, ...) \
   Debug(debug_tag, "[%08" PRIx32 "-%08" PRIx32 "] " fmt, dcid.h32(), scid.h32(), ##__VA_ARGS__)
+#define QUICVPHDebug(dcid, scid, fmt, ...) \
+  Debug(v_debug_tag, "[%08" PRIx32 "-%08" PRIx32 "] " fmt, dcid.h32(), scid.h32(), ##__VA_ARGS__)
 
 //
 // QUICPacketHandler
@@ -99,7 +102,7 @@ QUICPacketHandler::_send_packet(UDPConnection *udp_con, IpEndpoint &addr, Ptr<IO
 {
   UDPPacket *udp_packet = new_UDPPacket(addr, 0, udp_payload);
 
-  if (is_debug_tag_set(debug_tag)) {
+  if (is_debug_tag_set(v_debug_tag)) {
     ip_port_text_buffer ipb;
     QUICConnectionId dcid = QUICConnectionId::ZERO();
     QUICConnectionId scid = QUICConnectionId::ZERO();
@@ -117,8 +120,8 @@ QUICPacketHandler::_send_packet(UDPConnection *udp_con, IpEndpoint &addr, Ptr<IO
       }
     }
 
-    QUICDebugDS(dcid, scid, "send %s packet to %s from port %u size=%" PRId64, (QUICInvariants::is_long_header(buf) ? "LH" : "SH"),
-                ats_ip_nptop(&addr, ipb, sizeof(ipb)), udp_con->getPortNum(), buf_len);
+    QUICVPHDebug(dcid, scid, "send %s packet to %s from port %u size=%" PRId64, (QUICInvariants::is_long_header(buf) ? "LH" : "SH"),
+                 ats_ip_nptop(&addr, ipb, sizeof(ipb)), udp_con->getPortNum(), buf_len);
   }
 
   udp_con->send(this->_get_continuation(), udp_packet);
@@ -215,6 +218,7 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
   IOBufferBlock *block = udp_packet->getIOBlockChain();
   const uint8_t *buf   = reinterpret_cast<uint8_t *>(block->buf());
   uint64_t buf_len     = block->size();
+  QUICVersion version;
 
   if (buf_len == 0) {
     QUICDebug("Ignore packet - payload is too small");
@@ -238,25 +242,24 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
       return;
     }
 
-    if (is_debug_tag_set(debug_tag)) {
+    if (is_debug_tag_set(v_debug_tag)) {
       ip_port_text_buffer ipb_from;
       ip_port_text_buffer ipb_to;
-      QUICDebugDS(scid, dcid, "recv LH packet from %s to %s size=%" PRId64,
-                  ats_ip_nptop(&udp_packet->from.sa, ipb_from, sizeof(ipb_from)),
-                  ats_ip_nptop(&udp_packet->to.sa, ipb_to, sizeof(ipb_to)), udp_packet->getPktLength());
+      QUICVPHDebug(scid, dcid, "recv LH packet from %s to %s size=%" PRId64,
+                   ats_ip_nptop(&udp_packet->from.sa, ipb_from, sizeof(ipb_from)),
+                   ats_ip_nptop(&udp_packet->to.sa, ipb_to, sizeof(ipb_to)), udp_packet->getPktLength());
     }
 
-    QUICVersion v;
-    if (unlikely(!QUICInvariants::version(v, buf, buf_len))) {
+    if (unlikely(!QUICInvariants::version(version, buf, buf_len))) {
       QUICDebug("Ignore packet - payload is too small");
       udp_packet->free();
       return;
     }
 
-    if (!QUICInvariants::is_version_negotiation(v) && !QUICTypeUtil::is_supported_version(v)) {
-      QUICDebugDS(scid, dcid, "Unsupported version: 0x%x", v);
+    if (!QUICInvariants::is_version_negotiation(version) && !QUICTypeUtil::is_supported_version(version)) {
+      QUICPHDebug(scid, dcid, "Unsupported version: 0x%x", version);
 
-      QUICPacketUPtr vn = QUICPacketFactory::create_version_negotiation_packet(scid, dcid);
+      QUICPacketUPtr vn = QUICPacketFactory::create_version_negotiation_packet(scid, dcid, version);
       this->_send_packet(*vn, udp_packet->getConnection(), udp_packet->from, 1200, nullptr, 0);
       udp_packet->free();
       return;
@@ -281,12 +284,12 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     }
   } else {
     // TODO: lookup DCID by 5-tuple when ATS omits SCID
-    if (is_debug_tag_set(debug_tag)) {
+    if (is_debug_tag_set(v_debug_tag)) {
       ip_port_text_buffer ipb_from;
       ip_port_text_buffer ipb_to;
-      QUICDebugDS(scid, dcid, "recv SH packet from %s to %s size=%" PRId64,
-                  ats_ip_nptop(&udp_packet->from.sa, ipb_from, sizeof(ipb_from)),
-                  ats_ip_nptop(&udp_packet->to.sa, ipb_to, sizeof(ipb_to)), udp_packet->getPktLength());
+      QUICVPHDebug(scid, dcid, "recv SH packet from %s to %s size=%" PRId64,
+                   ats_ip_nptop(&udp_packet->from.sa, ipb_from, sizeof(ipb_from)),
+                   ats_ip_nptop(&udp_packet->to.sa, ipb_to, sizeof(ipb_to)), udp_packet->getPktLength());
     }
   }
 
@@ -295,9 +298,11 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
 
   // Server Stateless Retry
   QUICConfig::scoped_config params;
-  QUICConnectionId cid_in_retry_token = QUICConnectionId::ZERO();
+  QUICConnectionId ocid_in_retry_token = QUICConnectionId::ZERO();
+  QUICConnectionId rcid_in_retry_token = QUICConnectionId::ZERO();
   if (!vc && params->stateless_retry() && QUICInvariants::is_long_header(buf)) {
-    int ret = this->_stateless_retry(buf, buf_len, udp_packet->getConnection(), udp_packet->from, dcid, scid, &cid_in_retry_token);
+    int ret = this->_stateless_retry(buf, buf_len, udp_packet->getConnection(), udp_packet->from, dcid, scid, &ocid_in_retry_token,
+                                     &rcid_in_retry_token, version);
     if (ret < 0) {
       udp_packet->free();
       return;
@@ -320,7 +325,7 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     udp_packet->free();
 
     if (is_debug_tag_set(debug_tag) && sent) {
-      QUICDebugDS(scid, dcid, "sent Stateless Reset : connection not found, dcid=%s", dcid.hex().c_str());
+      QUICPHDebug(scid, dcid, "sent Stateless Reset : connection not found, dcid=%s", dcid.hex().c_str());
     }
 
     return;
@@ -331,7 +336,7 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     udp_packet->free();
 
     if (is_debug_tag_set(debug_tag) && sent) {
-      QUICDebugDS(scid, dcid, "sent Stateless Reset : connection is already closed, dcid=%s", dcid.hex().c_str());
+      QUICPHDebug(scid, dcid, "sent Stateless Reset : connection is already closed, dcid=%s", dcid.hex().c_str());
     }
 
     return;
@@ -348,11 +353,12 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     QUICConnectionId peer_cid     = scid;
 
     if (is_debug_tag_set("quic_sec")) {
-      QUICDebugDS(peer_cid, original_cid, "client initial dcid=%s", original_cid.hex().c_str());
+      QUICPHDebug(peer_cid, original_cid, "client initial dcid=%s", original_cid.hex().c_str());
     }
 
     vc = static_cast<QUICNetVConnection *>(getNetProcessor()->allocate_vc(nullptr));
-    vc->init(peer_cid, original_cid, cid_in_retry_token, udp_packet->getConnection(), this, &this->_rtable, &this->_ctable);
+    vc->init(version, peer_cid, original_cid, ocid_in_retry_token, rcid_in_retry_token, udp_packet->getConnection(), this,
+             &this->_rtable, &this->_ctable);
     vc->id = net_next_connection_number();
     vc->con.move(con);
     vc->submit_time = Thread::get_hrtime();
@@ -393,7 +399,8 @@ QUICPacketHandler::send_packet(QUICNetVConnection *vc, const Ptr<IOBufferBlock> 
 
 int
 QUICPacketHandlerIn::_stateless_retry(const uint8_t *buf, uint64_t buf_len, UDPConnection *connection, IpEndpoint from,
-                                      QUICConnectionId dcid, QUICConnectionId scid, QUICConnectionId *original_cid)
+                                      QUICConnectionId dcid, QUICConnectionId scid, QUICConnectionId *original_cid,
+                                      QUICConnectionId *retry_cid, QUICVersion version)
 {
   QUICPacketType type = QUICPacketType::UNINITIALIZED;
   QUICPacketR::type(type, buf, buf_len);
@@ -411,14 +418,14 @@ QUICPacketHandlerIn::_stateless_retry(const uint8_t *buf, uint64_t buf_len, UDPC
   }
 
   if (token_length == 0) {
-    QUICRetryToken token(from, dcid);
     QUICConnectionId local_cid;
     local_cid.randomize();
-    QUICPacketUPtr retry_packet = QUICPacketFactory::create_retry_packet(scid, local_cid, token);
+    QUICRetryToken token(from, dcid, local_cid);
+    QUICPacketUPtr retry_packet = QUICPacketFactory::create_retry_packet(version, scid, local_cid, token);
 
-    QUICDebug("[TX] %s packet ODCID=%" PRIx64 " token_length=%u token=%02x%02x%02x%02x...",
-              QUICDebugNames::packet_type(retry_packet->type()), static_cast<uint64_t>(token.original_dcid()), token.length(),
-              token.buf()[0], token.buf()[1], token.buf()[2], token.buf()[3]);
+    QUICDebug("[TX] %s packet ODCID=%" PRIx64 " RCID=%" PRIx64 " token_length=%u token=%02x%02x%02x%02x...",
+              QUICDebugNames::packet_type(retry_packet->type()), static_cast<uint64_t>(token.original_dcid()),
+              static_cast<uint64_t>(token.scid()), token.length(), token.buf()[0], token.buf()[1], token.buf()[2], token.buf()[3]);
     this->_send_packet(*retry_packet, connection, from, 1200, nullptr, 0);
 
     return -2;
@@ -429,12 +436,14 @@ QUICPacketHandlerIn::_stateless_retry(const uint8_t *buf, uint64_t buf_len, UDPC
       QUICRetryToken token(buf + token_offset, token_length);
       if (token.is_valid(from)) {
         *original_cid = token.original_dcid();
-        QUICDebug("Retry Token is valid. ODCID=%" PRIx64, static_cast<uint64_t>(*original_cid));
+        *retry_cid    = token.scid();
+        QUICDebug("Retry Token is valid. ODCID=%" PRIx64 " RCID=%" PRIx64, static_cast<uint64_t>(*original_cid),
+                  static_cast<uint64_t>(*retry_cid));
         return 0;
       } else {
-        QUICDebug("Retry token is invalid: ODCID=%" PRIx64 "token_length=%u token=%02x%02x%02x%02x...",
-                  static_cast<uint64_t>(token.original_dcid()), token.length(), token.buf()[0], token.buf()[1], token.buf()[2],
-                  token.buf()[3]);
+        QUICDebug("Retry token is invalid: ODCID=%" PRIx64 " RCID=%" PRIx64 " token_length=%u token=%02x%02x%02x%02x...",
+                  static_cast<uint64_t>(token.original_dcid()), static_cast<uint64_t>(*retry_cid), token.length(), token.buf()[0],
+                  token.buf()[1], token.buf()[2], token.buf()[3]);
         this->_send_invalid_token_error(buf, buf_len, connection, from);
         return -3;
       }
@@ -468,6 +477,8 @@ QUICPacketHandlerIn::_send_invalid_token_error(const uint8_t *initial_packet, ui
   QUICConnectionId dcid_in_initial;
   QUICInvariants::scid(scid_in_initial, initial_packet, initial_packet_len);
   QUICInvariants::dcid(dcid_in_initial, initial_packet, initial_packet_len);
+  QUICVersion version_in_initial;
+  QUICLongHeaderPacketR::version(version_in_initial, initial_packet, initial_packet_len);
 
   // Create CONNECTION_CLOSE frame
   auto error = std::make_unique<QUICConnectionError>(QUICTransErrorCode::INVALID_TOKEN);
@@ -487,7 +498,7 @@ QUICPacketHandlerIn::_send_invalid_token_error(const uint8_t *initial_packet, ui
   QUICPacketHeaderProtector php(ppki);
   QUICCertConfig::scoped_config server_cert;
   QUICTLS tls(ppki, server_cert->ssl_default.get(), NET_VCONNECTION_IN, {}, "", "");
-  tls.initialize_key_materials(dcid_in_initial);
+  tls.initialize_key_materials(dcid_in_initial, version_in_initial);
 
   // Create INITIAL packet
   QUICConnectionId scid;
@@ -553,7 +564,7 @@ QUICPacketHandlerOut::_recv_packet(int event, UDPPacket *udp_packet)
   if (is_debug_tag_set(debug_tag)) {
     ip_port_text_buffer ipb_from;
     ip_port_text_buffer ipb_to;
-    QUICDebugQC(this->_vc, "recv %s packet from %s to %s size=%" PRId64, (QUICInvariants::is_long_header(buf) ? "LH" : "SH"),
+    QUICQCDebug(this->_vc, "recv %s packet from %s to %s size=%" PRId64, (QUICInvariants::is_long_header(buf) ? "LH" : "SH"),
                 ats_ip_nptop(&udp_packet->from.sa, ipb_from, sizeof(ipb_from)),
                 ats_ip_nptop(&udp_packet->to.sa, ipb_to, sizeof(ipb_to)), udp_packet->getPktLength());
   }

--- a/iocore/net/quic/Makefile.am
+++ b/iocore/net/quic/Makefile.am
@@ -142,7 +142,7 @@ TESTS = $(check_PROGRAMS)
 
 test_CPPFLAGS = \
   $(AM_CPPFLAGS) \
-  -I$(abs_top_srcdir)/tests/include
+  -I$(abs_top_srcdir)/tests/include -O0
 
 test_LDADD = \
   libquic.a \

--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -28,7 +28,7 @@
 
 QUICAckFrameManager::QUICAckFrameManager()
 {
-  for (auto i = 0; i < kPacketNumberSpace; i++) {
+  for (auto i = 0; i < QUIC_N_PACKET_SPACES; i++) {
     this->_ack_creator[i] = std::make_unique<QUICAckFrameCreator>(static_cast<QUICPacketNumberSpace>(i), this);
   }
 }
@@ -132,7 +132,7 @@ QUICAckFrameManager::ack_delay_exponent() const
 void
 QUICAckFrameManager::set_max_ack_delay(uint16_t delay)
 {
-  for (auto i = 0; i < kPacketNumberSpace; i++) {
+  for (auto i = 0; i < QUIC_N_PACKET_SPACES; i++) {
     this->_ack_creator[i]->set_max_ack_delay(delay);
   }
 }
@@ -193,7 +193,7 @@ QUICAckFrameManager::QUICAckFrameCreator::push_back(QUICPacketNumber packet_numb
   }
 
   // can not delay handshake packet
-  if ((this->_pn_space == QUICPacketNumberSpace::Initial || this->_pn_space == QUICPacketNumberSpace::Handshake) && !ack_only) {
+  if ((this->_pn_space == QUICPacketNumberSpace::INITIAL || this->_pn_space == QUICPacketNumberSpace::HANDSHAKE) && !ack_only) {
     this->_should_send = true;
   }
 
@@ -335,7 +335,7 @@ QUICAckFrameManager::QUICAckFrameCreator::_calculate_delay()
   ink_hrtime now             = Thread::get_hrtime();
   uint64_t delay             = (now - this->_largest_ack_received_time) / 1000;
   uint8_t ack_delay_exponent = 3;
-  if (this->_pn_space != QUICPacketNumberSpace::Initial && this->_pn_space != QUICPacketNumberSpace::Handshake) {
+  if (this->_pn_space != QUICPacketNumberSpace::INITIAL && this->_pn_space != QUICPacketNumberSpace::HANDSHAKE) {
     ack_delay_exponent = this->_ack_manager->ack_delay_exponent();
   }
   return delay >> ack_delay_exponent;

--- a/iocore/net/quic/QUICAckFrameCreator.h
+++ b/iocore/net/quic/QUICAckFrameCreator.h
@@ -78,7 +78,7 @@ public:
 
     QUICAckFrameManager *_ack_manager = nullptr;
 
-    QUICPacketNumberSpace _pn_space = QUICPacketNumberSpace::Initial;
+    QUICPacketNumberSpace _pn_space = QUICPacketNumberSpace::INITIAL;
   };
 
   static constexpr int MAXIMUM_PACKET_COUNT = 256;

--- a/iocore/net/quic/QUICAddrVerifyState.cc
+++ b/iocore/net/quic/QUICAddrVerifyState.cc
@@ -48,7 +48,7 @@ QUICAddrVerifyState::consume(uint32_t windows)
 }
 
 uint32_t
-QUICAddrVerifyState::windows()
+QUICAddrVerifyState::windows() const
 {
   return this->_windows;
 }

--- a/iocore/net/quic/QUICAddrVerifyState.h
+++ b/iocore/net/quic/QUICAddrVerifyState.h
@@ -34,7 +34,7 @@ public:
   void fill(uint32_t windows);
   void consume(uint32_t windows);
   void set_addr_verifed();
-  uint32_t windows();
+  uint32_t windows() const;
   bool is_verified() const;
 
 private:

--- a/iocore/net/quic/QUICBidirectionalStream.cc
+++ b/iocore/net/quic/QUICBidirectionalStream.cc
@@ -469,8 +469,8 @@ QUICBidirectionalStream::generate_frame(uint8_t *buf, QUICEncryptionLevel level,
     // Calling update always success, because len is always less than stream_credit
     ink_assert(ret == 0);
 
-    QUICStreamFCDebug("[REMOTE] %" PRIu64 "/%" PRIu64, this->_remote_flow_controller.current_offset(),
-                      this->_remote_flow_controller.current_limit());
+    QUICVStreamFCDebug("[REMOTE] %" PRIu64 "/%" PRIu64, this->_remote_flow_controller.current_offset(),
+                       this->_remote_flow_controller.current_limit());
     if (this->_remote_flow_controller.current_offset() == this->_remote_flow_controller.current_limit()) {
       QUICStreamDebug("Flow Controller will block sending a STREAM frame");
     }

--- a/iocore/net/quic/QUICConfig.cc
+++ b/iocore/net/quic/QUICConfig.cc
@@ -179,9 +179,8 @@ QUICConfigParams::initialize()
   this->_ld_initial_rtt = HRTIME_MSECONDS(timeout);
 
   // Congestion Control
-  REC_EstablishStaticConfigInt32U(this->_cc_max_datagram_size, "proxy.config.quic.congestion_control.max_datagram_size");
-  REC_EstablishStaticConfigInt32U(this->_cc_initial_window_scale, "proxy.config.quic.congestion_control.initial_window_scale");
-  REC_EstablishStaticConfigInt32U(this->_cc_minimum_window_scale, "proxy.config.quic.congestion_control.minimum_window_scale");
+  REC_EstablishStaticConfigInt32U(this->_cc_initial_window, "proxy.config.quic.congestion_control.initial_window");
+  REC_EstablishStaticConfigInt32U(this->_cc_minimum_window, "proxy.config.quic.congestion_control.minimum_window");
   REC_EstablishStaticConfigFloat(this->_cc_loss_reduction_factor, "proxy.config.quic.congestion_control.loss_reduction_factor");
   REC_EstablishStaticConfigInt32U(this->_cc_persistent_congestion_threshold,
                                   "proxy.config.quic.congestion_control.persistent_congestion_threshold");
@@ -420,26 +419,15 @@ QUICConfigParams::ld_initial_rtt() const
 }
 
 uint32_t
-QUICConfigParams::cc_max_datagram_size() const
-{
-  return _cc_max_datagram_size;
-}
-
-uint32_t
 QUICConfigParams::cc_initial_window() const
 {
-  // kInitialWindow:  Default limit on the initial amount of data in
-  // flight, in bytes.  Taken from [RFC6928].  The RECOMMENDED value is
-  // the minimum of 10 * kMaxDatagramSize and max(2* kMaxDatagramSize,
-  // 14600)).
-  return std::min(_cc_initial_window_scale * _cc_max_datagram_size,
-                  std::max(2 * _cc_max_datagram_size, static_cast<uint32_t>(14600)));
+  return _cc_initial_window;
 }
 
 uint32_t
 QUICConfigParams::cc_minimum_window() const
 {
-  return _cc_minimum_window_scale * _cc_max_datagram_size;
+  return _cc_minimum_window;
 }
 
 float

--- a/iocore/net/quic/QUICConfig.h
+++ b/iocore/net/quic/QUICConfig.h
@@ -146,9 +146,8 @@ private:
   ink_hrtime _ld_initial_rtt    = HRTIME_MSECONDS(500);
 
   // [draft-11 recovery] 4.7.1.  Constants of interest
-  uint32_t _cc_max_datagram_size               = 1200;
-  uint32_t _cc_initial_window_scale            = 10; // Actual initial window size is this value multiplied by the _cc_default_mss
-  uint32_t _cc_minimum_window_scale            = 2;  // Actual minimum window size is this value multiplied by the _cc_default_mss
+  uint32_t _cc_initial_window                  = 1200 * 10;
+  uint32_t _cc_minimum_window                  = 1200 * 2;
   float _cc_loss_reduction_factor              = 0.5;
   uint32_t _cc_persistent_congestion_threshold = 3;
 };

--- a/iocore/net/quic/QUICCongestionController.h
+++ b/iocore/net/quic/QUICCongestionController.h
@@ -25,22 +25,6 @@
 
 #include "QUICFrame.h"
 
-struct QUICPacketInfo {
-  // 6.3.1.  Sent Packet Fields
-  QUICPacketNumber packet_number;
-  ink_hrtime time_sent;
-  bool ack_eliciting;
-  bool is_crypto_packet;
-  bool in_flight;
-  size_t sent_bytes;
-
-  // addition
-  QUICPacketType type;
-  std::vector<QUICFrameInfo> frames;
-  QUICPacketNumberSpace pn_space;
-  // end
-};
-
 class QUICCongestionController
 {
 public:
@@ -52,15 +36,21 @@ public:
   };
 
   virtual ~QUICCongestionController() {}
-  virtual void on_packet_sent(size_t bytes_sent)                                                                    = 0;
-  virtual void on_packet_acked(const QUICPacketInfo &acked_packet)                                                  = 0;
-  virtual void process_ecn(const QUICPacketInfo &acked_largest_packet, const QUICAckFrame::EcnSection *ecn_section) = 0;
-  virtual void on_packets_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &packets)                         = 0;
-  virtual void add_extra_credit()                                                                                   = 0;
-  virtual void reset()                                                                                              = 0;
-  virtual uint32_t credit() const                                                                                   = 0;
+  // Appendix B.  Congestion Control Pseudocode
+  virtual void on_packet_sent(size_t bytes_sent)                                                                               = 0;
+  virtual void on_packets_acked(const std::vector<QUICSentPacketInfoUPtr> &packets)                                            = 0;
+  virtual void process_ecn(const QUICAckFrame &ack, QUICPacketNumberSpace pn_space, ink_hrtime largest_acked_packet_time_sent) = 0;
+  virtual void on_packets_lost(const std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> &packets)                              = 0;
+  // The function signature is different from the pseudo code because LD takes care of most of the processes
+  virtual void on_packet_number_space_discarded(size_t bytes_in_flight) = 0;
+
+  // These are additional and not on the spec
+  virtual void add_extra_credit()          = 0;
+  virtual void reset()                     = 0;
+  virtual uint32_t credit() const          = 0;
+  virtual uint32_t bytes_in_flight() const = 0;
+
   // Debug
-  virtual uint32_t bytes_in_flight() const   = 0;
   virtual uint32_t congestion_window() const = 0;
   virtual uint32_t current_ssthresh() const  = 0;
 };

--- a/iocore/net/quic/QUICConnection.h
+++ b/iocore/net/quic/QUICConnection.h
@@ -37,16 +37,32 @@ public:
   virtual ~QUICConnectionInfoProvider() {}
   virtual QUICConnectionId peer_connection_id() const     = 0;
   virtual QUICConnectionId original_connection_id() const = 0;
-  virtual QUICConnectionId first_connection_id() const    = 0;
-  virtual QUICConnectionId connection_id() const          = 0;
-  virtual std::string_view cids() const                   = 0;
-  virtual const QUICFiveTuple five_tuple() const          = 0;
+  /**
+   * This is S1 on 7.3.Authenticating Connection IDs
+   */
+  virtual QUICConnectionId first_connection_id() const = 0;
+  /**
+   * This is S2 on 7.3.Authenticating Connection IDs
+   */
+  virtual QUICConnectionId retry_source_connection_id() const = 0;
+  /**
+   * This is C1 or S3 on 7.3.Authenticating Connection IDs
+   */
+  virtual QUICConnectionId initial_source_connection_id() const = 0;
+  virtual QUICConnectionId connection_id() const                = 0;
+  virtual std::string_view cids() const                         = 0;
+  virtual const QUICFiveTuple five_tuple() const                = 0;
 
   virtual uint32_t pmtu() const                                = 0;
   virtual NetVConnectionContext_t direction() const            = 0;
   virtual int select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
                                    unsigned inlen) const       = 0;
   virtual bool is_closed() const                               = 0;
+  virtual bool is_at_anti_amplification_limit() const          = 0;
+  virtual bool is_address_validation_completed() const         = 0;
+  virtual bool is_handshake_completed() const                  = 0;
+  virtual bool has_keys_for(QUICPacketNumberSpace space) const = 0;
+  virtual QUICVersion negotiated_version() const               = 0;
   virtual std::string_view negotiated_application_name() const = 0;
 };
 

--- a/iocore/net/quic/QUICContext.cc
+++ b/iocore/net/quic/QUICContext.cc
@@ -33,12 +33,6 @@ public:
   QUICCCConfigQCP(const QUICConfigParams *params) : _params(params) {}
 
   uint32_t
-  max_datagram_size() const override
-  {
-    return this->_params->cc_max_datagram_size();
-  }
-
-  uint32_t
   initial_window() const override
   {
     return this->_params->cc_initial_window();

--- a/iocore/net/quic/QUICContext.h
+++ b/iocore/net/quic/QUICContext.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "QUICTypes.h"
 #include "QUICConnection.h"
 #include "QUICConfig.h"
 #include "QUICEvents.h"
@@ -54,7 +55,7 @@ public:
   // callback on packet send event
   virtual void packet_send_callback(QUICCallbackContext &, const QUICPacket &p){};
   // callback on packet lost event
-  virtual void packet_lost_callback(QUICCallbackContext &, const QUICPacketInfo &p){};
+  virtual void packet_lost_callback(QUICCallbackContext &, const QUICSentPacketInfo &p){};
   // callback on packet receive event
   virtual void packet_recv_callback(QUICCallbackContext &, const QUICPacket &p){};
   // callback on packet acked event
@@ -128,7 +129,7 @@ public:
   }
 
   void
-  trigger(CallbackEvent e, const QUICPacketInfo &p)
+  trigger(CallbackEvent e, const QUICSentPacketInfo &p)
   {
     QUICCallbackContext ctx;
     for (auto &&it : this->_callbacks) {

--- a/iocore/net/quic/QUICDebugNames.cc
+++ b/iocore/net/quic/QUICDebugNames.cc
@@ -121,6 +121,8 @@ QUICDebugNames::error_code(uint16_t code)
     return "NO_ERROR";
   case static_cast<uint16_t>(QUICTransErrorCode::INTERNAL_ERROR):
     return "INTERNAL_ERROR";
+  case static_cast<uint16_t>(QUICTransErrorCode::CONNECTION_REFUSED):
+    return "CONNECTION_REFUSED";
   case static_cast<uint16_t>(QUICTransErrorCode::FLOW_CONTROL_ERROR):
     return "FLOW_CONTROL_ERROR";
   case static_cast<uint16_t>(QUICTransErrorCode::STREAM_LIMIT_ERROR):
@@ -139,6 +141,8 @@ QUICDebugNames::error_code(uint16_t code)
     return "PROTOCOL_VIOLATION";
   case static_cast<uint16_t>(QUICTransErrorCode::INVALID_TOKEN):
     return "INVALID_TOKEN";
+  case static_cast<uint16_t>(QUICTransErrorCode::APPLICATION_ERROR):
+    return "APPLICATION_ERROR";
   case static_cast<uint16_t>(QUICTransErrorCode::CRYPTO_BUFFER_EXCEEDED):
     return "CRYPTO_BUFFER_EXCEEDED";
   default:
@@ -189,8 +193,8 @@ QUICDebugNames::transport_parameter_id(QUICTransportParameterId id)
     return "MAX_IDLE_TIMEOUT";
   case QUICTransportParameterId::PREFERRED_ADDRESS:
     return "PREFERRED_ADDRESS";
-  case QUICTransportParameterId::MAX_PACKET_SIZE:
-    return "MAX_PACKET_SIZE";
+  case QUICTransportParameterId::MAX_UDP_PAYLOAD_SIZE:
+    return "MAX_UDP_PAYLOAD_SIZE";
   case QUICTransportParameterId::STATELESS_RESET_TOKEN:
     return "STATELESS_RESET_TOKEN";
   case QUICTransportParameterId::ACK_DELAY_EXPONENT:
@@ -205,10 +209,14 @@ QUICDebugNames::transport_parameter_id(QUICTransportParameterId id)
     return "INITIAL_MAX_STREAM_DATA_UNI";
   case QUICTransportParameterId::MAX_ACK_DELAY:
     return "INITIAL_MAX_ACK_DELAY";
-  case QUICTransportParameterId::ORIGINAL_CONNECTION_ID:
-    return "INITIAL_ORIGINAL_CONNECTION_ID";
+  case QUICTransportParameterId::ORIGINAL_DESTINATION_CONNECTION_ID:
+    return "INITIAL_ORIGINAL_DESTINATION_CONNECTION_ID";
   case QUICTransportParameterId::ACTIVE_CONNECTION_ID_LIMIT:
     return "ACTIVE_CONNECTION_ID_LIMIT";
+  case QUICTransportParameterId::INITIAL_SOURCE_CONNECTION_ID:
+    return "INITIAL_SOURCE_CONNECTION_ID";
+  case QUICTransportParameterId::RETRY_SOURCE_CONNECTION_ID:
+    return "RETRY_SOURCE_CONNECTION_ID";
   default:
     return "UNKNOWN";
   }
@@ -323,12 +331,12 @@ const char *
 QUICDebugNames::pn_space(QUICPacketNumberSpace pn_space)
 {
   switch (pn_space) {
-  case QUICPacketNumberSpace::Initial:
-    return "QUICPacketNumberSpace::Initial";
-  case QUICPacketNumberSpace::Handshake:
-    return "QUICPacketNumberSpace::Handshake";
-  case QUICPacketNumberSpace::ApplicationData:
-    return "QUICPacketNumberSpace::ApplicationData";
+  case QUICPacketNumberSpace::INITIAL:
+    return "INITIAL";
+  case QUICPacketNumberSpace::HANDSHAKE:
+    return "HANDSHAKE";
+  case QUICPacketNumberSpace::APPLICATION_DATA:
+    return "APPLCIATION_DATA";
   default:
     return "UNKNOWN";
   }

--- a/iocore/net/quic/QUICFrame.cc
+++ b/iocore/net/quic/QUICFrame.cc
@@ -3104,15 +3104,3 @@ QUICFrameFactory::create_handshake_done_frame(uint8_t *buf, QUICFrameId id, QUIC
   new (buf) QUICHandshakeDoneFrame(id, owner);
   return reinterpret_cast<QUICHandshakeDoneFrame *>(buf);
 }
-
-QUICFrameId
-QUICFrameInfo::id() const
-{
-  return this->_id;
-}
-
-QUICFrameGenerator *
-QUICFrameInfo::generated_by() const
-{
-  return this->_generator;
-}

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -40,8 +40,6 @@ class QUICCryptoFrame;
 class QUICPacketR;
 class QUICFrameGenerator;
 
-using QUICFrameId = uint64_t;
-
 class QUICFrame
 {
 public:
@@ -907,16 +905,4 @@ private:
   QUICFrame *_reusable_frames[256] = {nullptr};
   uint8_t _buf_for_fast_create[256 * QUICFrame::MAX_INSTANCE_SIZE];
   QUICUnknownFrame _unknown_frame;
-};
-
-class QUICFrameInfo
-{
-public:
-  QUICFrameInfo(QUICFrameId id, QUICFrameGenerator *generator) : _id(id), _generator(generator) {}
-  QUICFrameId id() const;
-  QUICFrameGenerator *generated_by() const;
-
-private:
-  QUICFrameId _id = 0;
-  QUICFrameGenerator *_generator;
 };

--- a/iocore/net/quic/QUICFrameDispatcher.cc
+++ b/iocore/net/quic/QUICFrameDispatcher.cc
@@ -24,9 +24,11 @@
 #include "QUICFrameDispatcher.h"
 #include "QUICDebugNames.h"
 
-static constexpr char tag[] = "quic_net";
+static constexpr char tag[]   = "quic_net";
+static constexpr char v_tag[] = "v_quic_net";
 
 #define QUICDebug(fmt, ...) Debug(tag, "[%s] " fmt, this->_info->cids().data(), ##__VA_ARGS__)
+#define QUICVDebug(fmt, ...) Debug(v_tag, "[%s] " fmt, this->_info->cids().data(), ##__VA_ARGS__)
 
 //
 // Frame Dispatcher
@@ -70,10 +72,10 @@ QUICFrameDispatcher::receive_frames(QUICContext &ctx, QUICEncryptionLevel level,
       is_flow_controlled = true;
     }
 
-    if (is_debug_tag_set(tag) && type != QUICFrameType::PADDING) {
+    if (is_debug_tag_set(v_tag) && type != QUICFrameType::PADDING) {
       char msg[1024];
       frame.debug_msg(msg, sizeof(msg));
-      QUICDebug("[RX] | %s", msg);
+      QUICVDebug("[RX] | %s", msg);
     }
 
     if (type != QUICFrameType::PADDING && type != QUICFrameType::ACK) {

--- a/iocore/net/quic/QUICHandshake.h
+++ b/iocore/net/quic/QUICHandshake.h
@@ -42,9 +42,10 @@ class QUICHandshake : public QUICFrameHandler, public QUICFrameGenerator
 {
 public:
   // Constructor for client side
-  QUICHandshake(QUICConnection *qc, QUICHandshakeProtocol *hsp);
+  QUICHandshake(QUICVersion version, QUICConnection *qc, QUICHandshakeProtocol *hsp);
   // Constructor for server side
-  QUICHandshake(QUICConnection *qc, QUICHandshakeProtocol *hsp, QUICStatelessResetToken token, bool stateless_retry);
+  QUICHandshake(QUICVersion version, QUICConnection *qc, QUICHandshakeProtocol *hsp, QUICStatelessResetToken token,
+                bool stateless_retry);
   ~QUICHandshake();
 
   // QUICFrameHandler
@@ -60,6 +61,8 @@ public:
   QUICConnectionErrorUPtr start(const QUICTPConfig &tp_config, QUICPacketFactory *packet_factory, bool vn_exercise_enabled);
   QUICConnectionErrorUPtr negotiate_version(const QUICVersionNegotiationPacketR &packet, QUICPacketFactory *packet_factory);
   void reset();
+  void update(const QUICInitialPacketR &initial_packet);
+  void update(const QUICRetryPacketR &retry_packet);
 
   // for server side
   QUICConnectionErrorUPtr start(const QUICTPConfig &tp_config, const QUICInitialPacketR &initial_packet,
@@ -91,8 +94,10 @@ private:
 
   QUICVersionNegotiator *_version_negotiator = nullptr;
   QUICStatelessResetToken _reset_token;
-  bool _client_initial  = false;
-  bool _stateless_retry = false;
+  bool _client_initial                          = false;
+  bool _stateless_retry                         = false;
+  QUICConnectionId _initial_source_cid_received = QUICConnectionId::ZERO();
+  QUICConnectionId _retry_source_cid_received   = QUICConnectionId::ZERO();
 
   QUICCryptoStream _crypto_streams[4];
 

--- a/iocore/net/quic/QUICHandshakeProtocol.h
+++ b/iocore/net/quic/QUICHandshakeProtocol.h
@@ -47,7 +47,7 @@ public:
   virtual void reset()                                                                    = 0;
   virtual bool is_handshake_finished() const                                              = 0;
   virtual bool is_ready_to_derive() const                                                 = 0;
-  virtual int initialize_key_materials(QUICConnectionId cid)                              = 0;
+  virtual int initialize_key_materials(QUICConnectionId cid, QUICVersion)                 = 0;
   virtual const char *negotiated_cipher_suite() const                                     = 0;
   virtual void negotiated_application_name(const uint8_t **name, unsigned int *len) const = 0;
 

--- a/iocore/net/quic/QUICKeyGenerator.h
+++ b/iocore/net/quic/QUICKeyGenerator.h
@@ -43,7 +43,7 @@ public:
    * Generate keys for Initial encryption level
    * The keys for the remaining encryption level are derived by TLS stack with "quic " prefix
    */
-  void generate(uint8_t *hp_key, uint8_t *pp_key, uint8_t *iv, size_t *iv_len, QUICConnectionId cid);
+  void generate(QUICVersion version, uint8_t *hp_key, uint8_t *pp_key, uint8_t *iv, size_t *iv_len, QUICConnectionId cid);
 
   void regenerate(uint8_t *hp_key, uint8_t *pp_key, uint8_t *iv, size_t *iv_len, const uint8_t *secret, size_t secret_len,
                   const EVP_CIPHER *cipher, QUICHKDF &hkdf);
@@ -56,8 +56,8 @@ private:
 
   int _generate(uint8_t *hp_key, uint8_t *pp_key, uint8_t *iv, size_t *iv_len, QUICHKDF &hkdf, const uint8_t *secret,
                 size_t secret_len, const EVP_CIPHER *cipher);
-  int _generate_initial_secret(uint8_t *out, size_t *out_len, QUICHKDF &hkdf, QUICConnectionId cid, const char *label,
-                               size_t label_len, size_t length);
+  int _generate_initial_secret(QUICVersion version, uint8_t *out, size_t *out_len, QUICHKDF &hkdf, QUICConnectionId cid,
+                               const char *label, size_t label_len, size_t length);
   int _generate_key(uint8_t *out, size_t *out_len, QUICHKDF &hkdf, const uint8_t *secret, size_t secret_len,
                     size_t key_length) const;
   int _generate_iv(uint8_t *out, size_t *out_len, QUICHKDF &hkdf, const uint8_t *secret, size_t secret_len, size_t iv_length) const;

--- a/iocore/net/quic/QUICLossDetector.cc
+++ b/iocore/net/quic/QUICLossDetector.cc
@@ -61,7 +61,7 @@ QUICLossDetector::~QUICLossDetector()
     this->_loss_detection_timer = nullptr;
   }
 
-  for (auto i = 0; i < kPacketNumberSpace; i++) {
+  for (auto i = 0; i < QUIC_N_PACKET_SPACES; i++) {
     this->_sent_packets[i].clear();
   }
 }
@@ -125,32 +125,30 @@ QUICLossDetector::largest_acked_packet_number(QUICPacketNumberSpace pn_space) co
 }
 
 void
-QUICLossDetector::on_packet_sent(QUICPacketInfoUPtr packet_info, bool in_flight)
+QUICLossDetector::on_packet_sent(QUICSentPacketInfoUPtr packet_info, bool in_flight)
 {
+  // ADDITIONAL CODE
   if (packet_info->type == QUICPacketType::VERSION_NEGOTIATION) {
     return;
   }
+  // END OF ADDITIONAL CODE
 
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
 
   QUICPacketNumber packet_number = packet_info->packet_number;
   bool ack_eliciting             = packet_info->ack_eliciting;
-  bool is_crypto_packet          = packet_info->is_crypto_packet;
   ink_hrtime now                 = packet_info->time_sent;
   size_t sent_bytes              = packet_info->sent_bytes;
+  QUICPacketNumberSpace pn_space = packet_info->pn_space;
 
-  QUICLDDebug("%s packet sent : %" PRIu64 " bytes: %lu ack_eliciting: %d", QUICDebugNames::pn_space(packet_info->pn_space),
-              packet_number, sent_bytes, ack_eliciting);
+  QUICLDVDebug("%s packet sent : %" PRIu64 " bytes: %lu ack_eliciting: %d", QUICDebugNames::pn_space(packet_info->pn_space),
+               packet_number, sent_bytes, ack_eliciting);
 
   this->_add_to_sent_packet_list(packet_number, std::move(packet_info));
 
   if (in_flight) {
-    if (is_crypto_packet) {
-      this->_time_of_last_sent_crypto_packet = now;
-    }
-
     if (ack_eliciting) {
-      this->_time_of_last_sent_ack_eliciting_packet = now;
+      this->_time_of_last_ack_eliciting_packet[static_cast<int>(pn_space)] = now;
     }
     this->_cc->on_packet_sent(sent_bytes);
     this->_set_loss_detection_timer();
@@ -158,27 +156,60 @@ QUICLossDetector::on_packet_sent(QUICPacketInfoUPtr packet_info, bool in_flight)
 }
 
 void
+QUICLossDetector::on_datagram_received()
+{
+  if (this->_context.connection_info()->is_at_anti_amplification_limit()) {
+    this->_set_loss_detection_timer();
+  }
+}
+
+void
+QUICLossDetector::on_packet_number_space_discarded(QUICPacketNumberSpace pn_space)
+{
+  ink_assert(pn_space != QUICPacketNumberSpace::APPLICATION_DATA);
+  size_t bytes_in_flight = 0;
+  for (auto it = this->_sent_packets[static_cast<int>(pn_space)].begin();
+       it != this->_sent_packets[static_cast<int>(pn_space)].end();) {
+    auto ret = this->_remove_from_sent_packet_list(it, pn_space);
+    auto &pi = ret.first;
+    if (pi->in_flight) {
+      bytes_in_flight += pi->sent_bytes;
+    }
+    it = ret.second;
+  }
+  this->_cc->on_packet_number_space_discarded(bytes_in_flight);
+  // Reset the loss detection and PTO timer
+  this->_time_of_last_ack_eliciting_packet[static_cast<int>(pn_space)] = 0;
+  this->_loss_time[static_cast<int>(pn_space)]                         = 0;
+  this->_rtt_measure->set_pto_count(0);
+  this->_set_loss_detection_timer();
+  QUICLDDebug("[%s] Packets have been discarded because keys for the space are discarded", QUICDebugNames::pn_space(pn_space));
+}
+
+void
 QUICLossDetector::reset()
 {
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
+
+  // A.4.  Initialization
   if (this->_loss_detection_timer) {
     this->_loss_detection_timer->cancel();
     this->_loss_detection_timer = nullptr;
   }
-
-  this->_ack_eliciting_outstanding = 0;
-  this->_crypto_outstanding        = 0;
-
-  // [draft-17 recovery] 6.4.3.  Initialization
-  this->_time_of_last_sent_ack_eliciting_packet = 0;
-  this->_time_of_last_sent_crypto_packet        = 0;
-  for (auto i = 0; i < kPacketNumberSpace; i++) {
-    this->_largest_acked_packet[i] = 0;
-    this->_loss_time[i]            = 0;
+  this->_rtt_measure->reset();
+  for (auto i = 0; i < QUIC_N_PACKET_SPACES; i++) {
+    this->_largest_acked_packet[i]              = UINT64_MAX;
+    this->_time_of_last_ack_eliciting_packet[i] = 0;
+    this->_loss_time[i]                         = 0;
     this->_sent_packets[i].clear();
+    //  ADDITIONAL CODE
+    this->_num_packets_in_flight[i] = 0;
+    // END OF ADDITIONAL CODE
   }
 
-  this->_rtt_measure->reset();
+  //  ADDITIONAL CODE
+  this->_ack_eliciting_outstanding = 0;
+  // END OF ADDITIONAL CODE
 }
 
 void
@@ -188,12 +219,12 @@ QUICLossDetector::update_ack_delay_exponent(uint8_t ack_delay_exponent)
 }
 
 bool
-QUICLossDetector::_include_ack_eliciting(const std::vector<QUICPacketInfo *> &acked_packets, int index) const
+QUICLossDetector::_include_ack_eliciting(const std::vector<QUICSentPacketInfoUPtr> &acked_packets) const
 {
   // Find out ack_elicting packet.
   // FIXME: this loop is the same as _on_ack_received's loop it would better
   // to combine it.
-  for (auto packet : acked_packets) {
+  for (const auto &packet : acked_packets) {
     if (packet->ack_eliciting) {
       return true;
     }
@@ -207,65 +238,68 @@ QUICLossDetector::_on_ack_received(const QUICAckFrame &ack_frame, QUICPacketNumb
 {
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
 
-  int index                          = static_cast<int>(pn_space);
-  this->_largest_acked_packet[index] = std::max(this->_largest_acked_packet[index], ack_frame.largest_acknowledged());
+  int index = static_cast<int>(pn_space);
+  if (this->_largest_acked_packet[index] == UINT64_MAX) {
+    this->_largest_acked_packet[index] = ack_frame.largest_acknowledged();
+  } else {
+    this->_largest_acked_packet[index] = std::max(this->_largest_acked_packet[index], ack_frame.largest_acknowledged());
+  }
 
-  auto newly_acked_packets = this->_determine_newly_acked_packets(ack_frame, index);
+  auto newly_acked_packets = this->_detect_and_remove_acked_packets(ack_frame, pn_space);
   if (newly_acked_packets.empty()) {
     return;
   }
 
   // If the largest acknowledged is newly acked and
   //  ack-eliciting, update the RTT.
-  auto pi = this->_sent_packets[index].find(ack_frame.largest_acknowledged());
-  if (pi != this->_sent_packets[index].end() &&
-      (pi->second->ack_eliciting || this->_include_ack_eliciting(newly_acked_packets, index))) {
-    ink_hrtime latest_rtt = Thread::get_hrtime() - pi->second->time_sent;
+  const auto &largest_acked = newly_acked_packets[0];
+  if (largest_acked->packet_number == ack_frame.largest_acknowledged() && this->_include_ack_eliciting(newly_acked_packets)) {
+    ink_hrtime latest_rtt = Thread::get_hrtime() - largest_acked->time_sent;
     // _latest_rtt is nanosecond but ack_frame.ack_delay is microsecond and scaled
-    ink_hrtime delay = HRTIME_USECONDS(ack_frame.ack_delay() << this->_ack_delay_exponent);
-    this->_rtt_measure->update_rtt(latest_rtt, delay);
+    ink_hrtime ack_delay = 0;
+    if (pn_space == QUICPacketNumberSpace::APPLICATION_DATA) {
+      ack_delay = HRTIME_USECONDS(ack_frame.ack_delay() << this->_ack_delay_exponent);
+    }
+    this->_rtt_measure->update_rtt(latest_rtt, ack_delay);
   }
-
-  QUICLDVDebug("[%s] Unacked packets %lu (retransmittable %u, includes %u handshake packets)", QUICDebugNames::pn_space(pn_space),
-               this->_sent_packets[index].size(), this->_ack_eliciting_outstanding.load(), this->_crypto_outstanding.load());
 
   // if (ACK frame contains ECN information):
   //   ProcessECN(ack)
-  if (ack_frame.ecn_section() != nullptr && pi != this->_sent_packets[index].end()) {
-    this->_cc->process_ecn(*pi->second, ack_frame.ecn_section());
+  if (ack_frame.ecn_section() != nullptr) {
+    this->_cc->process_ecn(ack_frame, pn_space, largest_acked->time_sent);
   }
 
+  // ADDITIONAL CODE
   // Find all newly acked packets.
-  for (auto info : newly_acked_packets) {
+  for (const auto &info : newly_acked_packets) {
     this->_on_packet_acked(*info);
   }
+  // END OF ADDITIONAL CODE
 
-  QUICLDVDebug("[%s] Unacked packets %lu (retransmittable %u, includes %u handshake packets)", QUICDebugNames::pn_space(pn_space),
-               this->_sent_packets[index].size(), this->_ack_eliciting_outstanding.load(), this->_crypto_outstanding.load());
+  auto lost_packets = this->_detect_and_remove_lost_packets(pn_space);
+  if (!lost_packets.empty()) {
+    this->_cc->on_packets_lost(lost_packets);
+  }
+  this->_cc->on_packets_acked(newly_acked_packets);
 
-  this->_detect_lost_packets(pn_space);
+  QUICLDVDebug("[%s] Newly acked:%lu Lost:%lu Unacked packets:%lu (%u ack eliciting)", QUICDebugNames::pn_space(pn_space),
+               newly_acked_packets.size(), lost_packets.size(), this->_sent_packets[index].size(),
+               this->_ack_eliciting_outstanding.load());
 
-  this->_rtt_measure->set_crypto_count(0);
-  this->_rtt_measure->set_pto_count(0);
-
-  QUICLDDebug("[%s] Unacked packets %lu (retransmittable %u, includes %u handshake packets)", QUICDebugNames::pn_space(pn_space),
-              this->_sent_packets[index].size(), this->_ack_eliciting_outstanding.load(), this->_crypto_outstanding.load());
-
+  if (this->_peer_completed_address_validation()) {
+    this->_rtt_measure->set_pto_count(0);
+  }
   this->_set_loss_detection_timer();
 }
 
 void
-QUICLossDetector::_on_packet_acked(const QUICPacketInfo &acked_packet)
+QUICLossDetector::_on_packet_acked(const QUICSentPacketInfo &acked_packet)
 {
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
-  QUICLDDebug("[%s] Packet number %" PRIu64 " has been acked", QUICDebugNames::pn_space(acked_packet.pn_space),
-              acked_packet.packet_number);
+  QUICLDVDebug("[%s] Packet number %" PRIu64 " has been acked", QUICDebugNames::pn_space(acked_packet.pn_space),
+               acked_packet.packet_number);
 
-  if (acked_packet.in_flight) {
-    this->_cc->on_packet_acked(acked_packet);
-  }
-
-  for (const QUICFrameInfo &frame_info : acked_packet.frames) {
+  for (const QUICSentPacketInfo::FrameInfo &frame_info : acked_packet.frames) {
     auto reactor = frame_info.generated_by();
     if (reactor == nullptr) {
       continue;
@@ -273,23 +307,74 @@ QUICLossDetector::_on_packet_acked(const QUICPacketInfo &acked_packet)
 
     reactor->on_frame_acked(frame_info.id());
   }
-
-  this->_remove_from_sent_packet_list(acked_packet.packet_number, acked_packet.pn_space);
 }
 
 ink_hrtime
-QUICLossDetector::_get_earliest_loss_time(QUICPacketNumberSpace &pn_space)
+QUICLossDetector::_get_loss_time_and_space(QUICPacketNumberSpace &pn_space)
 {
-  ink_hrtime time = this->_loss_time[static_cast<int>(QUICPacketNumberSpace::Initial)];
-  pn_space        = QUICPacketNumberSpace::Initial;
-  for (auto i = 1; i < kPacketNumberSpace; i++) {
-    if (this->_loss_time[i] != 0 && (time != 0 || this->_loss_time[i] < time)) {
+  ink_hrtime time = this->_loss_time[static_cast<int>(QUICPacketNumberSpace::INITIAL)];
+  pn_space        = QUICPacketNumberSpace::INITIAL;
+  for (auto i = 1; i < QUIC_N_PACKET_SPACES; i++) {
+    if (time == 0 || this->_loss_time[i] < time) {
       time     = this->_loss_time[i];
       pn_space = static_cast<QUICPacketNumberSpace>(i);
     }
   }
 
   return time;
+}
+
+ink_hrtime
+QUICLossDetector::_get_pto_time_and_space(QUICPacketNumberSpace &space)
+{
+  ink_hrtime duration =
+    (this->_rtt_measure->smoothed_rtt() + std::max(4 * this->_rtt_measure->rttvar(), this->_rtt_measure->k_granularity())) *
+    (1 << this->_rtt_measure->pto_count());
+
+  // Arm PTO from now when there are no inflight packets.
+  if (this->_num_packets_in_flight[static_cast<int>(QUICPacketNumberSpace::INITIAL)].load() == 0 &&
+      this->_num_packets_in_flight[static_cast<int>(QUICPacketNumberSpace::HANDSHAKE)].load() == 0 &&
+      this->_num_packets_in_flight[static_cast<int>(QUICPacketNumberSpace::APPLICATION_DATA)].load() == 0) {
+    ink_assert(!this->_peer_completed_address_validation());
+    if (this->_context.connection_info()->has_keys_for(QUICPacketNumberSpace::HANDSHAKE)) {
+      space = QUICPacketNumberSpace::HANDSHAKE;
+      return Thread::get_hrtime() + duration;
+    } else {
+      space = QUICPacketNumberSpace::INITIAL;
+      return Thread::get_hrtime() + duration;
+    }
+  }
+  ink_hrtime pto_timeout          = INT64_MAX;
+  QUICPacketNumberSpace pto_space = QUICPacketNumberSpace::INITIAL;
+  for (int i = 0; i < QUIC_N_PACKET_SPACES; ++i) {
+    if (this->_num_packets_in_flight[i].load() == 0) {
+      continue;
+    }
+    if (i == static_cast<int>(QUICPacketNumberSpace::APPLICATION_DATA)) {
+      // Skip ApplicationData until handshake complete.
+      if (!this->_context.connection_info()->is_address_validation_completed()) {
+        space = pto_space;
+        return pto_timeout;
+      }
+      // Include max_ack_delay and backoff for ApplicationData.
+      // FIXME should be set by transport parameters
+      duration += this->_rtt_measure->max_ack_delay() * (1 << this->_rtt_measure->pto_count());
+    }
+
+    ink_hrtime t = this->_time_of_last_ack_eliciting_packet[i] + duration;
+    if (t < pto_timeout) {
+      pto_timeout = t;
+      pto_space   = QUICPacketNumberSpace(i);
+    }
+  }
+  space = pto_space;
+  return pto_timeout;
+}
+
+bool
+QUICLossDetector::_peer_completed_address_validation() const
+{
+  return this->_context.connection_info()->is_address_validation_completed();
 }
 
 void
@@ -302,112 +387,115 @@ QUICLossDetector::_set_loss_detection_timer()
     }
   };
 
+  std::function<void(void)> cancel_timer = [this]() {
+    this->_loss_detection_alarm_at = 0;
+    this->_loss_detection_timer->cancel();
+    this->_loss_detection_timer = nullptr;
+  };
+
   QUICPacketNumberSpace pn_space;
-  ink_hrtime alarm = this->_get_earliest_loss_time(pn_space);
-  if (alarm != 0) {
-    update_timer(alarm);
+  ink_hrtime earliest_loss_time = this->_get_loss_time_and_space(pn_space);
+  if (earliest_loss_time != 0) {
+    update_timer(earliest_loss_time);
     QUICLDDebug("[%s] time threshold loss detection timer: %" PRId64 "ms", QUICDebugNames::pn_space(pn_space),
                 (this->_loss_detection_alarm_at - Thread::get_hrtime()) / HRTIME_MSECOND);
     return;
   }
 
-  if (this->_crypto_outstanding > 0 || this->_is_client_without_one_rtt_key()) {
-    // Crypto retransmission timer.
-    alarm = this->_time_of_last_sent_crypto_packet + this->_rtt_measure->handshake_retransmit_timeout();
-    update_timer(alarm);
-    QUICLDDebug("%s crypto packet alarm will be set: %" PRId64 "ms", QUICDebugNames::pn_space(pn_space),
-                (alarm - this->_time_of_last_sent_crypto_packet) / HRTIME_MSECOND);
-    return;
+  if (this->_context.connection_info()->is_at_anti_amplification_limit()) {
+    if (this->_loss_detection_timer) {
+      cancel_timer();
+      QUICLDDebug("Loss detection alarm has been unset because of anti-amplification limit");
+      return;
+    }
   }
 
   // Don't arm the alarm if there are no packets with retransmittable data in flight.
-  // -- MODIFIED CODE --
-  // In pseudocode, `bytes_in_flight` is used, but we're tracking "retransmittable data in flight" by `_ack_eliciting_outstanding`
-  if (this->_ack_eliciting_outstanding == 0) {
+  if (this->_ack_eliciting_outstanding == 0 && this->_peer_completed_address_validation()) {
     if (this->_loss_detection_timer) {
-      this->_loss_detection_alarm_at = 0;
-      this->_loss_detection_timer->cancel();
-      this->_loss_detection_timer = nullptr;
-      QUICLDDebug("Loss detection alarm has been unset");
+      cancel_timer();
+      QUICLDDebug("Loss detection alarm has been unset because of no ack eliciting packets outstanding");
     }
-
     return;
   }
-  // -- END OF MODIFIED CODE --
 
   // PTO Duration
-  alarm = this->_time_of_last_sent_ack_eliciting_packet + this->_rtt_measure->current_pto_period();
-  update_timer(alarm);
-  QUICLDDebug("[%s] PTO timeout will be set: %" PRId64 "ms", QUICDebugNames::pn_space(pn_space),
-              (alarm - this->_time_of_last_sent_ack_eliciting_packet) / HRTIME_MSECOND);
+  ink_hrtime timeout = this->_get_pto_time_and_space(pn_space);
+  update_timer(timeout);
+  QUICLDVDebug("[%s] PTO timeout has been set: %" PRId64 "ms", QUICDebugNames::pn_space(pn_space),
+               (timeout - this->_time_of_last_ack_eliciting_packet[static_cast<int>(pn_space)]) / HRTIME_MSECOND);
 }
 
 void
 QUICLossDetector::_on_loss_detection_timeout()
 {
   QUICPacketNumberSpace pn_space;
-  ink_hrtime loss_time = this->_get_earliest_loss_time(pn_space);
-  if (loss_time != 0) {
+  ink_hrtime earliest_loss_time = this->_get_loss_time_and_space(pn_space);
+  if (earliest_loss_time != 0) {
     // Time threshold loss Detection
-    this->_detect_lost_packets(pn_space);
-  } else if (this->_crypto_outstanding) {
-    // Handshake retransmission alarm.
-    QUICLDVDebug("Crypto Retranmission");
-    this->_retransmit_all_unacked_crypto_data();
-    this->_rtt_measure->set_crypto_count(this->_rtt_measure->crypto_count() + 1);
-  } else if (this->_is_client_without_one_rtt_key()) {
+    auto lost_packets = this->_detect_and_remove_lost_packets(pn_space);
+    ink_assert(!lost_packets.empty());
+    this->_cc->on_packets_lost(lost_packets);
+    this->_set_loss_detection_timer();
+    return;
+  }
+
+  if (this->_cc->bytes_in_flight() > 0) {
+    // PTO. Send new data if available, else retransmit old data.
+    // If neither is available, send a single PING frame.
+    QUICPacketNumberSpace pns;
+    this->_get_pto_time_and_space(pns);
+    this->_send_one_or_two_ack_eliciting_packet(pns);
+  } else {
+    ink_assert(this->_is_client_without_one_rtt_key());
     // Client sends an anti-deadlock packet: Initial is padded
     // to earn more anti-amplification credit,
     // a Handshake packet proves address ownership.
     if (this->_context.key_info()->is_encryption_key_available(QUICKeyPhase::HANDSHAKE)) {
-      this->_send_one_handshake_packets();
+      this->_send_one_ack_eliciting_handshake_packet();
     } else {
-      this->_send_one_padded_packets();
+      this->_send_one_ack_eliciting_padded_initial_packet();
     }
-
-    this->_rtt_measure->set_crypto_count(this->_rtt_measure->crypto_count() + 1);
-  } else {
-    QUICLDVDebug("PTO");
-    this->_send_one_or_two_packet();
-    this->_rtt_measure->set_pto_count(this->_rtt_measure->pto_count() + 1);
   }
 
-  QUICLDDebug("[%s] Unacked packets %lu (retransmittable %u, includes %u handshake packets)", QUICDebugNames::pn_space(pn_space),
-              this->_sent_packets[static_cast<int>(pn_space)].size(), this->_ack_eliciting_outstanding.load(),
-              this->_crypto_outstanding.load());
+  this->_rtt_measure->set_pto_count(this->_rtt_measure->pto_count() + 1);
+  this->_set_loss_detection_timer();
+
+  QUICLDDebug("[%s] Unacked packets %lu (ack_eliciting %u)", QUICDebugNames::pn_space(pn_space),
+              this->_sent_packets[static_cast<int>(pn_space)].size(), this->_ack_eliciting_outstanding.load());
 
   if (is_debug_tag_set("v_quic_loss_detector")) {
     for (auto i = 0; i < 3; i++) {
       for (auto &unacked : this->_sent_packets[i]) {
-        QUICLDVDebug("[%s] #%" PRIu64 " is_crypto=%i ack_eliciting=%i size=%zu %u %u",
-                     QUICDebugNames::pn_space(static_cast<QUICPacketNumberSpace>(i)), unacked.first,
-                     unacked.second->is_crypto_packet, unacked.second->ack_eliciting, unacked.second->sent_bytes,
-                     this->_ack_eliciting_outstanding.load(), this->_crypto_outstanding.load());
+        QUICLDVDebug("[%s] #%" PRIu64 " ack_eliciting=%i size=%zu %u",
+                     QUICDebugNames::pn_space(static_cast<QUICPacketNumberSpace>(i)), unacked.first, unacked.second->ack_eliciting,
+                     unacked.second->sent_bytes, this->_ack_eliciting_outstanding.load());
       }
     }
   }
-
-  this->_set_loss_detection_timer();
 }
 
-void
-QUICLossDetector::_detect_lost_packets(QUICPacketNumberSpace pn_space)
+std::map<QUICPacketNumber, QUICSentPacketInfoUPtr>
+QUICLossDetector::_detect_and_remove_lost_packets(QUICPacketNumberSpace pn_space)
 {
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
-  this->_loss_time[static_cast<int>(pn_space)] = 0;
-  ink_hrtime loss_delay = this->_k_time_threshold * std::max(this->_rtt_measure->latest_rtt(), this->_rtt_measure->smoothed_rtt());
-  loss_delay            = std::min(loss_delay, this->_rtt_measure->k_granularity());
+  ink_assert(this->_largest_acked_packet[static_cast<int>(pn_space)] != UINT64_MAX);
 
-  std::map<QUICPacketNumber, QUICPacketInfo *> lost_packets;
+  this->_loss_time[static_cast<int>(pn_space)] = 0;
+  std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> lost_packets;
+  ink_hrtime loss_delay = this->_k_time_threshold * std::max(this->_rtt_measure->latest_rtt(), this->_rtt_measure->smoothed_rtt());
+
+  // Minimum time of kGranularity before packets are deemed lost.
+  loss_delay = std::max(loss_delay, this->_rtt_measure->k_granularity());
 
   // Packets sent before this time are deemed lost.
   ink_hrtime lost_send_time = Thread::get_hrtime() - loss_delay;
 
   // Packets with packet numbers before this are deemed lost.
-  QUICPacketNumber lost_pn = this->_largest_acked_packet[static_cast<int>(pn_space)] - this->_k_packet_threshold;
+  //  QUICPacketNumber lost_pn = this->_largest_acked_packet[static_cast<int>(pn_space)] - this->_k_packet_threshold;
 
   for (auto it = this->_sent_packets[static_cast<int>(pn_space)].begin();
-       it != this->_sent_packets[static_cast<int>(pn_space)].end(); ++it) {
+       it != this->_sent_packets[static_cast<int>(pn_space)].end();) {
     if (it->first > this->_largest_acked_packet[static_cast<int>(pn_space)]) {
       // the spec uses continue but we can break here because the _sent_packets is sorted by packet_number.
       break;
@@ -416,8 +504,9 @@ QUICLossDetector::_detect_lost_packets(QUICPacketNumberSpace pn_space)
     auto &unacked = it->second;
 
     // Mark packet as lost, or set time when it should be marked.
-    if (unacked->time_sent < lost_send_time || unacked->packet_number < lost_pn) {
-      if (unacked->time_sent < lost_send_time) {
+    if (unacked->time_sent <= lost_send_time ||
+        this->_largest_acked_packet[static_cast<int>(pn_space)] >= unacked->packet_number + this->_k_packet_threshold) {
+      if (unacked->time_sent <= lost_send_time) {
         QUICLDDebug("[%s] Lost: time since sent is too long (#%" PRId64 " sent=%" PRId64 ", delay=%" PRId64
                     ", fraction=%lf, lrtt=%" PRId64 ", srtt=%" PRId64 ")",
                     QUICDebugNames::pn_space(pn_space), it->first, unacked->time_sent, lost_send_time, this->_k_time_threshold,
@@ -428,59 +517,40 @@ QUICLossDetector::_detect_lost_packets(QUICPacketNumberSpace pn_space)
                     this->_k_packet_threshold);
       }
 
-      if (unacked->in_flight) {
-        lost_packets.insert({it->first, it->second.get()});
+      auto ret = this->_remove_from_sent_packet_list(it, pn_space);
+      auto pi  = std::move(ret.first);
+      it       = ret.second;
+      if (pi->in_flight) {
+        this->_context.trigger(QUICContext::CallbackEvent::PACKET_LOST, *pi);
+        lost_packets.emplace(pi->packet_number, std::move(pi));
       }
-    } else if (this->_loss_time[static_cast<int>(pn_space)] == 0) {
-      this->_loss_time[static_cast<int>(pn_space)] = unacked->time_sent + loss_delay;
+
     } else {
-      this->_loss_time[static_cast<int>(pn_space)] =
-        std::min(this->_loss_time[static_cast<int>(pn_space)], unacked->time_sent + loss_delay);
+      if (this->_loss_time[static_cast<int>(pn_space)] == 0) {
+        this->_loss_time[static_cast<int>(pn_space)] = unacked->time_sent + loss_delay;
+      } else {
+        this->_loss_time[static_cast<int>(pn_space)] =
+          std::min(this->_loss_time[static_cast<int>(pn_space)], unacked->time_sent + loss_delay);
+      }
+      ++it;
     }
   }
 
-  // Inform the congestion controller of lost packets and
-  // lets it decide whether to retransmit immediately.
+  // -- ADDITIONAL CODE --
+  // Not sure how we can get feedback from congestion control and when we should retransmit the lost packets but we need to send
+  // them somewhere.
+  // I couldn't find the place so just send them here for now.
   if (!lost_packets.empty()) {
-    this->_cc->on_packets_lost(lost_packets);
-    for (auto lost_packet : lost_packets) {
-      this->_context.trigger(QUICContext::CallbackEvent::PACKET_LOST, *lost_packet.second);
-      // -- ADDITIONAL CODE --
-      // Not sure how we can get feedback from congestion control and when we should retransmit the lost packets but we need to send
-      // them somewhere.
-      // I couldn't find the place so just send them here for now.
+    for (const auto &lost_packet : lost_packets) {
       this->_retransmit_lost_packet(*lost_packet.second);
-      // -- END OF ADDITIONAL CODE --
-      // -- ADDITIONAL CODE --
-      this->_remove_from_sent_packet_list(lost_packet.first, pn_space);
-      // -- END OF ADDITIONAL CODE --
     }
   }
+  // -- END OF ADDITIONAL CODE --
+
+  return lost_packets;
 }
 
 // ===== Functions below are used on the spec but there're no pseudo code  =====
-
-void
-QUICLossDetector::_retransmit_all_unacked_crypto_data()
-{
-  SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
-  for (auto i = 0; i < kPacketNumberSpace; i++) {
-    std::set<QUICPacketNumber> retransmitted_crypto_packets;
-    std::map<QUICPacketNumber, QUICPacketInfo *> lost_packets;
-    for (auto &info : this->_sent_packets[i]) {
-      if (info.second->is_crypto_packet) {
-        retransmitted_crypto_packets.insert(info.first);
-        this->_retransmit_lost_packet(*info.second);
-        lost_packets.insert({info.first, info.second.get()});
-      }
-    }
-
-    this->_cc->on_packets_lost(lost_packets);
-    for (auto packet_number : retransmitted_crypto_packets) {
-      this->_remove_from_sent_packet_list(packet_number, static_cast<QUICPacketNumberSpace>(i));
-    }
-  }
-}
 
 void
 QUICLossDetector::_send_packet(QUICEncryptionLevel level, bool padded)
@@ -494,7 +564,7 @@ QUICLossDetector::_send_packet(QUICEncryptionLevel level, bool padded)
 }
 
 void
-QUICLossDetector::_send_one_or_two_packet()
+QUICLossDetector::_send_one_or_two_ack_eliciting_packet(QUICPacketNumberSpace pn_space)
 {
   this->_send_packet(QUICEncryptionLevel::ONE_RTT);
   this->_send_packet(QUICEncryptionLevel::ONE_RTT);
@@ -504,7 +574,7 @@ QUICLossDetector::_send_one_or_two_packet()
 }
 
 void
-QUICLossDetector::_send_one_handshake_packets()
+QUICLossDetector::_send_one_ack_eliciting_handshake_packet()
 {
   this->_send_packet(QUICEncryptionLevel::HANDSHAKE);
   QUICLDDebug("[%s] send handshake packet: ping count=%" PRIu64, QUICDebugNames::encryption_level(QUICEncryptionLevel::HANDSHAKE),
@@ -512,7 +582,7 @@ QUICLossDetector::_send_one_handshake_packets()
 }
 
 void
-QUICLossDetector::_send_one_padded_packets()
+QUICLossDetector::_send_one_ack_eliciting_padded_initial_packet()
 {
   this->_send_packet(QUICEncryptionLevel::INITIAL, true);
   QUICLDDebug("[%s] send PADDING frame: ping count=%" PRIu64, QUICDebugNames::encryption_level(QUICEncryptionLevel::INITIAL),
@@ -522,12 +592,12 @@ QUICLossDetector::_send_one_padded_packets()
 // ===== Functions below are helper functions =====
 
 void
-QUICLossDetector::_retransmit_lost_packet(const QUICPacketInfo &packet_info)
+QUICLossDetector::_retransmit_lost_packet(const QUICSentPacketInfo &packet_info)
 {
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
 
   QUICLDDebug("Retransmit %s packet #%" PRIu64, QUICDebugNames::packet_type(packet_info.type), packet_info.packet_number);
-  for (const QUICFrameInfo &frame_info : packet_info.frames) {
+  for (const QUICSentPacketInfo::FrameInfo &frame_info : packet_info.frames) {
     auto reactor = frame_info.generated_by();
     if (reactor == nullptr) {
       continue;
@@ -537,11 +607,13 @@ QUICLossDetector::_retransmit_lost_packet(const QUICPacketInfo &packet_info)
   }
 }
 
-std::vector<QUICPacketInfo *>
-QUICLossDetector::_determine_newly_acked_packets(const QUICAckFrame &ack_frame, int pn_space)
+std::vector<QUICSentPacketInfoUPtr>
+QUICLossDetector::_detect_and_remove_acked_packets(const QUICAckFrame &ack_frame, QUICPacketNumberSpace pn_space)
 {
-  std::vector<QUICPacketInfo *> packets;
+  std::vector<QUICSentPacketInfoUPtr> packets;
   std::set<QUICAckFrame::PacketNumberRange> numbers;
+  int index = static_cast<int>(pn_space);
+
   QUICPacketNumber x = ack_frame.largest_acknowledged();
   numbers.insert({x, static_cast<uint64_t>(x) - ack_frame.ack_block_section()->first_ack_block()});
   x -= ack_frame.ack_block_section()->first_ack_block() + 1;
@@ -552,9 +624,13 @@ QUICLossDetector::_determine_newly_acked_packets(const QUICAckFrame &ack_frame, 
   }
 
   for (auto &&range : numbers) {
-    for (auto ite = this->_sent_packets[pn_space].rbegin(); ite != this->_sent_packets[pn_space].rend(); ite++) {
+    for (auto ite = this->_sent_packets[index].begin(); ite != this->_sent_packets[index].end();) {
       if (range.contains(ite->first)) {
-        packets.push_back(ite->second.get());
+        auto ret = this->_remove_from_sent_packet_list(ite, pn_space);
+        packets.push_back(std::move(ret.first));
+        ite = ret.second;
+      } else {
+        ++ite;
       }
     }
   }
@@ -563,62 +639,48 @@ QUICLossDetector::_determine_newly_acked_packets(const QUICAckFrame &ack_frame, 
 }
 
 void
-QUICLossDetector::_add_to_sent_packet_list(QUICPacketNumber packet_number, QUICPacketInfoUPtr packet_info)
+QUICLossDetector::_add_to_sent_packet_list(QUICPacketNumber packet_number, QUICSentPacketInfoUPtr packet_info)
 {
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
 
   // Add to the list
   int index = static_cast<int>(packet_info->pn_space);
-  this->_sent_packets[index].insert(std::pair<QUICPacketNumber, QUICPacketInfoUPtr>(packet_number, std::move(packet_info)));
+  this->_sent_packets[index].insert(std::pair<QUICPacketNumber, QUICSentPacketInfoUPtr>(packet_number, std::move(packet_info)));
 
   // Increment counters
   auto ite = this->_sent_packets[index].find(packet_number);
   if (ite != this->_sent_packets[index].end()) {
-    if (ite->second->is_crypto_packet) {
-      ++this->_crypto_outstanding;
-      ink_assert(this->_crypto_outstanding.load() > 0);
-    }
     if (ite->second->ack_eliciting) {
       ++this->_ack_eliciting_outstanding;
       ink_assert(this->_ack_eliciting_outstanding.load() > 0);
     }
+    if (ite->second->in_flight) {
+      ++this->_num_packets_in_flight[index];
+    }
   }
 }
 
-void
-QUICLossDetector::_remove_from_sent_packet_list(QUICPacketNumber packet_number, QUICPacketNumberSpace pn_space)
-{
-  SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
-
-  auto ite = this->_sent_packets[static_cast<int>(pn_space)].find(packet_number);
-  this->_decrement_outstanding_counters(ite, pn_space);
-  this->_sent_packets[static_cast<int>(pn_space)].erase(packet_number);
-}
-
-std::map<QUICPacketNumber, QUICPacketInfoUPtr>::iterator
-QUICLossDetector::_remove_from_sent_packet_list(std::map<QUICPacketNumber, QUICPacketInfoUPtr>::iterator it,
+std::pair<QUICSentPacketInfoUPtr, std::map<QUICPacketNumber, QUICSentPacketInfoUPtr>::iterator>
+QUICLossDetector::_remove_from_sent_packet_list(std::map<QUICPacketNumber, QUICSentPacketInfoUPtr>::iterator it,
                                                 QUICPacketNumberSpace pn_space)
 {
   SCOPED_MUTEX_LOCK(lock, this->_loss_detection_mutex, this_ethread());
 
-  this->_decrement_outstanding_counters(it, pn_space);
-  return this->_sent_packets[static_cast<int>(pn_space)].erase(it);
+  this->_decrement_counters(it, pn_space);
+  auto pi = std::move(it->second);
+  return {std::move(pi), this->_sent_packets[static_cast<int>(pn_space)].erase(it)};
 }
 
 void
-QUICLossDetector::_decrement_outstanding_counters(std::map<QUICPacketNumber, QUICPacketInfoUPtr>::iterator it,
-                                                  QUICPacketNumberSpace pn_space)
+QUICLossDetector::_decrement_counters(std::map<QUICPacketNumber, QUICSentPacketInfoUPtr>::iterator it,
+                                      QUICPacketNumberSpace pn_space)
 {
   if (it != this->_sent_packets[static_cast<int>(pn_space)].end()) {
-    // Decrement counters
-    if (it->second->is_crypto_packet) {
-      ink_assert(this->_crypto_outstanding.load() > 0);
-      --this->_crypto_outstanding;
-    }
     if (it->second->ack_eliciting) {
       ink_assert(this->_ack_eliciting_outstanding.load() > 0);
       --this->_ack_eliciting_outstanding;
     }
+    --this->_num_packets_in_flight[static_cast<int>(pn_space)];
   }
 }
 
@@ -658,10 +720,11 @@ QUICRTTMeasure::update_rtt(ink_hrtime latest_rtt, ink_hrtime ack_delay)
 {
   this->_latest_rtt = latest_rtt;
 
-  if (this->_smoothed_rtt == 0) {
-    this->_min_rtt      = 0;
-    this->_smoothed_rtt = this->_latest_rtt;
-    this->_rttvar       = this->_latest_rtt / 2;
+  if (this->_is_first_sample) {
+    this->_min_rtt         = this->_latest_rtt;
+    this->_smoothed_rtt    = this->_latest_rtt;
+    this->_rttvar          = this->_latest_rtt / 2;
+    this->_is_first_sample = false;
     return;
   }
 
@@ -698,32 +761,16 @@ QUICRTTMeasure::congestion_period(uint32_t threshold) const
   return pto * threshold;
 }
 
-ink_hrtime
-QUICRTTMeasure::handshake_retransmit_timeout() const
-{
-  // Handshake retransmission alarm.
-  ink_hrtime timeout = 0;
-  if (this->_smoothed_rtt == 0) {
-    timeout = 2 * this->_k_initial_rtt;
-  } else {
-    timeout = 2 * this->_smoothed_rtt;
-  }
-  timeout = std::max(timeout, this->_k_granularity);
-  timeout = timeout * (1 << this->_crypto_count);
-
-  return timeout;
-}
-
-void
-QUICRTTMeasure::set_crypto_count(uint32_t count)
-{
-  this->_crypto_count = count;
-}
-
 void
 QUICRTTMeasure::set_pto_count(uint32_t count)
 {
   this->_pto_count = count;
+}
+
+void
+QUICRTTMeasure::set_max_ack_delay(ink_hrtime max_ack_delay)
+{
+  this->_max_ack_delay = max_ack_delay;
 }
 
 ink_hrtime
@@ -739,15 +786,15 @@ QUICRTTMeasure::latest_rtt() const
 }
 
 uint32_t
-QUICRTTMeasure::crypto_count() const
-{
-  return this->_crypto_count;
-}
-
-uint32_t
 QUICRTTMeasure::pto_count() const
 {
   return this->_pto_count;
+}
+
+ink_hrtime
+QUICRTTMeasure::max_ack_delay() const
+{
+  return this->_max_ack_delay;
 }
 
 ink_hrtime
@@ -759,10 +806,10 @@ QUICRTTMeasure::k_granularity() const
 void
 QUICRTTMeasure::reset()
 {
-  this->_crypto_count = 0;
+  // A.4.  Initialization
   this->_pto_count    = 0;
-  this->_smoothed_rtt = 0;
-  this->_rttvar       = 0;
-  this->_min_rtt      = 0;
   this->_latest_rtt   = 0;
+  this->_smoothed_rtt = this->_k_initial_rtt;
+  this->_rttvar       = this->_k_initial_rtt / 2.0;
+  this->_min_rtt      = 0;
 }

--- a/iocore/net/quic/QUICLossDetector.h
+++ b/iocore/net/quic/QUICLossDetector.h
@@ -44,70 +44,6 @@ class QUICPinger;
 class QUICLossDetector;
 class QUICRTTMeasure;
 
-using QUICPacketInfoUPtr = std::unique_ptr<QUICPacketInfo>;
-
-class QUICRTTProvider
-{
-public:
-  virtual ink_hrtime smoothed_rtt() const = 0;
-  virtual ink_hrtime rttvar() const       = 0;
-  virtual ink_hrtime latest_rtt() const   = 0;
-
-  virtual ink_hrtime congestion_period(uint32_t threshold) const = 0;
-};
-
-class QUICNewRenoCongestionController : public QUICCongestionController
-{
-public:
-  QUICNewRenoCongestionController(QUICContext &context);
-  virtual ~QUICNewRenoCongestionController() {}
-  void on_packet_sent(size_t bytes_sent) override;
-  void on_packet_acked(const QUICPacketInfo &acked_packet) override;
-  virtual void on_packets_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &packets) override;
-  void process_ecn(const QUICPacketInfo &acked_largest_packet, const QUICAckFrame::EcnSection *ecn_section) override;
-  bool check_credit() const;
-  uint32_t credit() const override;
-  void reset() override;
-  bool is_app_limited();
-
-  // Debug
-  uint32_t bytes_in_flight() const override;
-  uint32_t congestion_window() const override;
-  uint32_t current_ssthresh() const override;
-
-  void add_extra_credit() override;
-
-private:
-  Ptr<ProxyMutex> _cc_mutex;
-
-  void _congestion_event(ink_hrtime sent_time);
-  bool _in_persistent_congestion(const std::map<QUICPacketNumber, QUICPacketInfo *> &lost_packets,
-                                 QUICPacketInfo *largest_lost_packet);
-  bool _in_window_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &lost_packets, QUICPacketInfo *largest_lost_packet,
-                       ink_hrtime period) const;
-
-  uint32_t _extra_packets_count = 0;
-
-  // [draft-17 recovery] 7.9.1. Constants of interest
-  // Values will be loaded from records.config via QUICConfig at constructor
-  uint32_t _k_max_datagram_size               = 0;
-  uint32_t _k_initial_window                  = 0;
-  uint32_t _k_minimum_window                  = 0;
-  float _k_loss_reduction_factor              = 0.0;
-  uint32_t _k_persistent_congestion_threshold = 3;
-
-  // [draft-17 recovery] 7.9.2. Variables of interest
-  uint32_t _ecn_ce_counter                   = 0;
-  uint32_t _bytes_in_flight                  = 0;
-  uint32_t _congestion_window                = 0;
-  ink_hrtime _congestion_recovery_start_time = 0;
-  uint32_t _ssthresh                         = UINT32_MAX;
-
-  bool _in_congestion_recovery(ink_hrtime sent_time) const;
-
-  QUICContext &_context;
-};
-
 class QUICLossDetector : public Continuation, public QUICFrameHandler
 {
 public:
@@ -117,9 +53,15 @@ public:
 
   int event_handler(int event, Event *edata);
 
+  // QUICFrameHandler interface
   std::vector<QUICFrameType> interests() override;
   virtual QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
-  void on_packet_sent(QUICPacketInfoUPtr packet_info, bool in_flight = true);
+
+  void on_packet_sent(QUICSentPacketInfoUPtr packet_info, bool in_flight = true);
+  void on_datagram_received();
+  // OnPacketNumberSpaceDiscarded is on Congestion Control section but having it here makes more sense because most processes are
+  // for LD.
+  void on_packet_number_space_discarded(QUICPacketNumberSpace pn_space);
   QUICPacketNumber largest_acked_packet_number(QUICPacketNumberSpace pn_space) const;
   void update_ack_delay_exponent(uint8_t ack_delay_exponent);
   void reset();
@@ -129,29 +71,32 @@ private:
 
   uint8_t _ack_delay_exponent = 3;
 
-  // [draft-17 recovery] 6.4.1.  Constants of interest
+  // Recovery A.2. Constants of Interest
   // Values will be loaded from records.config via QUICConfig at constructor
   uint32_t _k_packet_threshold = 0;
   float _k_time_threshold      = 0.0;
+  // kGranularity, kInitialRtt are defined in QUICRTTMeasure
+  QUICRTTMeasure *_rtt_measure = nullptr;
+  // kPacketNumberSpace is defined as QUICPacketNumberSpace on QUICTypes.h
 
-  // [draft-11 recovery] 3.5.2.  Variables of interest
+  // Recovery A.3. Variables of interest
   // Keep the order as the same as the spec so that we can see the difference easily.
-  Action *_loss_detection_timer                              = nullptr;
-  ink_hrtime _time_of_last_sent_ack_eliciting_packet         = 0;
-  ink_hrtime _time_of_last_sent_crypto_packet                = 0;
-  ink_hrtime _loss_time[kPacketNumberSpace]                  = {0};
-  QUICPacketNumber _largest_acked_packet[kPacketNumberSpace] = {0};
-  std::map<QUICPacketNumber, QUICPacketInfoUPtr> _sent_packets[kPacketNumberSpace];
+  // latest_rtt, smoothed_rtt, rttvar, min_rtt and max_ack_delay are defined in QUICRttMeasure
+  Action *_loss_detection_timer = nullptr;
+  // pto_count is defined in QUICRttMeasure
+  ink_hrtime _time_of_last_ack_eliciting_packet[QUIC_N_PACKET_SPACES] = {0};
+  QUICPacketNumber _largest_acked_packet[QUIC_N_PACKET_SPACES]        = {0};
+  ink_hrtime _loss_time[QUIC_N_PACKET_SPACES]                         = {0};
+  std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> _sent_packets[QUIC_N_PACKET_SPACES];
 
   // These are not defined on the spec but expected to be count
   // These counter have to be updated when inserting / erasing packets from _sent_packets with following functions.
-  std::atomic<uint32_t> _crypto_outstanding;
   std::atomic<uint32_t> _ack_eliciting_outstanding;
-  void _add_to_sent_packet_list(QUICPacketNumber packet_number, std::unique_ptr<QUICPacketInfo> packet_info);
-  void _remove_from_sent_packet_list(QUICPacketNumber packet_number, QUICPacketNumberSpace pn_space);
-  std::map<QUICPacketNumber, QUICPacketInfoUPtr>::iterator _remove_from_sent_packet_list(
-    std::map<QUICPacketNumber, QUICPacketInfoUPtr>::iterator it, QUICPacketNumberSpace pn_space);
-  void _decrement_outstanding_counters(std::map<QUICPacketNumber, QUICPacketInfoUPtr>::iterator it, QUICPacketNumberSpace pn_space);
+  std::atomic<uint32_t> _num_packets_in_flight[QUIC_N_PACKET_SPACES];
+  void _add_to_sent_packet_list(QUICPacketNumber packet_number, std::unique_ptr<QUICSentPacketInfo> packet_info);
+  std::pair<QUICSentPacketInfoUPtr, std::map<QUICPacketNumber, QUICSentPacketInfoUPtr>::iterator> _remove_from_sent_packet_list(
+    std::map<QUICPacketNumber, QUICSentPacketInfoUPtr>::iterator it, QUICPacketNumberSpace pn_space);
+  void _decrement_counters(std::map<QUICPacketNumber, QUICSentPacketInfoUPtr>::iterator it, QUICPacketNumberSpace pn_space);
 
   /*
    * Because this alarm will be reset on every packet transmission, to reduce number of events,
@@ -160,27 +105,28 @@ private:
   ink_hrtime _loss_detection_alarm_at = 0;
 
   void _on_ack_received(const QUICAckFrame &ack_frame, QUICPacketNumberSpace pn_space);
-  void _on_packet_acked(const QUICPacketInfo &acked_packet);
-  void _detect_lost_packets(QUICPacketNumberSpace pn_space);
+  void _on_packet_acked(const QUICSentPacketInfo &acked_packet);
+  std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> _detect_and_remove_lost_packets(QUICPacketNumberSpace pn_space);
   void _set_loss_detection_timer();
   void _on_loss_detection_timeout();
-  void _retransmit_lost_packet(const QUICPacketInfo &packet_info);
+  void _retransmit_lost_packet(const QUICSentPacketInfo &packet_info);
 
-  ink_hrtime _get_earliest_loss_time(QUICPacketNumberSpace &pn_space);
+  ink_hrtime _get_loss_time_and_space(QUICPacketNumberSpace &space);
+  ink_hrtime _get_pto_time_and_space(QUICPacketNumberSpace &space);
+  bool _peer_completed_address_validation() const;
 
-  std::vector<QUICPacketInfo *> _determine_newly_acked_packets(const QUICAckFrame &ack_frame, int pn_space);
-  bool _include_ack_eliciting(const std::vector<QUICPacketInfo *> &acked_packets, int index) const;
+  std::vector<QUICSentPacketInfoUPtr> _detect_and_remove_acked_packets(const QUICAckFrame &ack_frame,
+                                                                       QUICPacketNumberSpace pn_space);
+  bool _include_ack_eliciting(const std::vector<QUICSentPacketInfoUPtr> &acked_packets) const;
 
-  void _retransmit_all_unacked_crypto_data();
-  void _send_one_or_two_packet();
-  void _send_one_handshake_packets();
-  void _send_one_padded_packets();
+  void _send_one_or_two_ack_eliciting_packet(QUICPacketNumberSpace pn_space);
+  void _send_one_ack_eliciting_handshake_packet();
+  void _send_one_ack_eliciting_padded_initial_packet();
 
   void _send_packet(QUICEncryptionLevel level, bool padded = false);
 
   bool _is_client_without_one_rtt_key() const;
 
-  QUICRTTMeasure *_rtt_measure  = nullptr;
   QUICPinger *_pinger           = nullptr;
   QUICPadder *_padder           = nullptr;
   QUICCongestionController *_cc = nullptr;
@@ -200,7 +146,6 @@ public:
   void init(const QUICLDConfig &ld_config);
 
   // period
-  ink_hrtime handshake_retransmit_timeout() const;
   ink_hrtime current_pto_period() const;
   ink_hrtime congestion_period(uint32_t threshold) const override;
 
@@ -210,10 +155,10 @@ public:
   ink_hrtime latest_rtt() const override;
 
   uint32_t pto_count() const;
-  uint32_t crypto_count() const;
+  ink_hrtime max_ack_delay() const;
 
-  void set_crypto_count(uint32_t count);
   void set_pto_count(uint32_t count);
+  void set_max_ack_delay(ink_hrtime max_ack_delay);
 
   void update_rtt(ink_hrtime latest_rtt, ink_hrtime ack_delay);
   void reset();
@@ -221,19 +166,18 @@ public:
   ink_hrtime k_granularity() const;
 
 private:
-  // related to rtt calculate
-  uint32_t _crypto_count = 0;
-  uint32_t _pto_count    = 0;
-  // FIXME should be set by transport parameters
-  ink_hrtime _max_ack_delay = HRTIME_MSECONDS(25);
+  bool _is_first_sample = false;
 
-  // rtt vars
+  // A.3. Variables of interest
   ink_hrtime _latest_rtt   = 0;
   ink_hrtime _smoothed_rtt = 0;
   ink_hrtime _rttvar       = 0;
   ink_hrtime _min_rtt      = INT64_MAX;
+  // FIXME should be set by transport parameters
+  ink_hrtime _max_ack_delay = HRTIME_MSECONDS(25);
+  uint32_t _pto_count       = 0;
 
-  // config
+  // Recovery A.2.  Constants of Interest
   ink_hrtime _k_granularity = 0;
   ink_hrtime _k_initial_rtt = HRTIME_MSECONDS(500);
 };

--- a/iocore/net/quic/QUICNewRenoCongestionController.cc
+++ b/iocore/net/quic/QUICNewRenoCongestionController.cc
@@ -22,19 +22,26 @@
  */
 
 #include <tscore/Diags.h>
-#include <QUICLossDetector.h>
+#include <QUICCongestionController.h>
+#include <QUICNewRenoCongestionController.h>
 
 #define QUICCCDebug(fmt, ...)                                                                                               \
   Debug("quic_cc",                                                                                                          \
         "[%s] "                                                                                                             \
-        "window: %" PRIu32 " bytes: %" PRIu32 " ssthresh: %" PRIu32 " extra: %" PRIu32 " " fmt,                             \
+        "window:%" PRIu32 " in-flight:%" PRIu32 " ssthresh:%" PRIu32 " extra:%" PRIu32 " " fmt,                             \
+        this->_context.connection_info()->cids().data(), this->_congestion_window, this->_bytes_in_flight, this->_ssthresh, \
+        this->_extra_packets_count, ##__VA_ARGS__)
+#define QUICCCVDebug(fmt, ...)                                                                                              \
+  Debug("v_quic_cc",                                                                                                        \
+        "[%s] "                                                                                                             \
+        "window:%" PRIu32 " in-flight:%" PRIu32 " ssthresh:%" PRIu32 " extra:%" PRIu32 " " fmt,                             \
         this->_context.connection_info()->cids().data(), this->_congestion_window, this->_bytes_in_flight, this->_ssthresh, \
         this->_extra_packets_count, ##__VA_ARGS__)
 
 #define QUICCCError(fmt, ...)                                                                                               \
   Error("quic_cc",                                                                                                          \
         "[%s] "                                                                                                             \
-        "window: %" PRIu32 " bytes: %" PRIu32 " ssthresh: %" PRIu32 " extra %" PRIu32 " " fmt,                              \
+        "window:%" PRIu32 " in-flight:%" PRIu32 " ssthresh:%" PRIu32 " extra:%" PRIu32 " " fmt,                             \
         this->_context.connection_info()->cids().data(), this->_congestion_window, this->_bytes_in_flight, this->_ssthresh, \
         this->_extra_packets_count, ##__VA_ARGS__)
 
@@ -42,7 +49,6 @@ QUICNewRenoCongestionController::QUICNewRenoCongestionController(QUICContext &co
   : _cc_mutex(new_ProxyMutex()), _context(context)
 {
   auto &cc_config                          = context.cc_config();
-  this->_k_max_datagram_size               = cc_config.max_datagram_size();
   this->_k_initial_window                  = cc_config.initial_window();
   this->_k_minimum_window                  = cc_config.minimum_window();
   this->_k_loss_reduction_factor           = cc_config.loss_reduction_factor();
@@ -69,46 +75,42 @@ QUICNewRenoCongestionController::_in_congestion_recovery(ink_hrtime sent_time) c
 }
 
 bool
-QUICNewRenoCongestionController::is_app_limited()
+QUICNewRenoCongestionController::_is_app_or_flow_control_limited()
 {
   // FIXME : don't known how does app worked here
   return false;
 }
 
 void
-QUICNewRenoCongestionController::on_packet_acked(const QUICPacketInfo &acked_packet)
+QUICNewRenoCongestionController::_maybe_send_one_packet()
 {
-  // Remove from bytes_in_flight.
-  SCOPED_MUTEX_LOCK(lock, this->_cc_mutex, this_ethread());
-  this->_bytes_in_flight -= acked_packet.sent_bytes;
-  if (this->_in_congestion_recovery(acked_packet.time_sent)) {
-    // Do not increase congestion window in recovery period.
-    return;
-  }
-
-  if (this->is_app_limited()) {
-    // Do not increase congestion_window if application
-    // limited.
-    return;
-  }
-
-  if (this->_congestion_window < this->_ssthresh) {
-    // Slow start.
-    this->_context.trigger(QUICContext::CallbackEvent::CONGESTION_STATE_CHANGED, QUICCongestionController::State::SLOW_START);
-    this->_congestion_window += acked_packet.sent_bytes;
-    QUICCCDebug("slow start window changed");
-  } else {
-    // Congestion avoidance.
-    this->_context.trigger(QUICContext::CallbackEvent::CONGESTION_STATE_CHANGED,
-                           QUICCongestionController::State::CONGESTION_AVOIDANCE);
-    this->_congestion_window += this->_k_max_datagram_size * acked_packet.sent_bytes / this->_congestion_window;
-    QUICCCDebug("Congestion avoidance window changed");
-  }
+  // TODO Implement _maybe_send_one_packet
 }
 
-// additional code
-// the original one is:
-//   CongestionEvent(sent_time):
+bool
+QUICNewRenoCongestionController::_are_all_packets_lost(const std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> &lost_packets,
+                                                       const QUICSentPacketInfoUPtr &largest_lost_packet, ink_hrtime period) const
+{
+  // check whether packets are continuous. return true if all continuous packets are in period
+  QUICPacketNumber next_expected = UINT64_MAX;
+  for (auto &it : lost_packets) {
+    if (it.second->time_sent >= largest_lost_packet->time_sent - period) {
+      if (next_expected == UINT64_MAX) {
+        next_expected = it.second->packet_number + 1;
+        continue;
+      }
+
+      if (next_expected != it.second->packet_number) {
+        return false;
+      }
+
+      next_expected = it.second->packet_number + 1;
+    }
+  }
+
+  return next_expected == UINT64_MAX ? false : true;
+}
+
 void
 QUICNewRenoCongestionController::_congestion_event(ink_hrtime sent_time)
 {
@@ -122,54 +124,82 @@ QUICNewRenoCongestionController::_congestion_event(ink_hrtime sent_time)
     this->_context.trigger(QUICContext::CallbackEvent::CONGESTION_STATE_CHANGED, QUICCongestionController::State::RECOVERY);
     this->_context.trigger(QUICContext::CallbackEvent::METRICS_UPDATE, this->_congestion_window, this->_bytes_in_flight,
                            this->_ssthresh);
+    // A packet can be sent to speed up loss recovery.
+    this->_maybe_send_one_packet();
   }
 }
 
-// additional code
-// the original one is:
-//   ProcessECN(ack):
 void
-QUICNewRenoCongestionController::process_ecn(const QUICPacketInfo &acked_largest_packet,
-                                             const QUICAckFrame::EcnSection *ecn_section)
+QUICNewRenoCongestionController::process_ecn(const QUICAckFrame &ack_frame, QUICPacketNumberSpace pn_space,
+                                             ink_hrtime largest_acked_time_sent)
 {
   // If the ECN-CE counter reported by the peer has increased,
   // this could be a new congestion event.
-  if (ecn_section->ecn_ce_count() > this->_ecn_ce_counter) {
-    this->_ecn_ce_counter = ecn_section->ecn_ce_count();
+  if (ack_frame.ecn_section()->ecn_ce_count() > this->_ecn_ce_counters[static_cast<int>(pn_space)]) {
+    this->_ecn_ce_counters[static_cast<int>(pn_space)] = ack_frame.ecn_section()->ecn_ce_count();
     // Start a new congestion event if the last acknowledged
     // packet was sent after the start of the previous
     // recovery epoch.
-    this->_congestion_event(acked_largest_packet.time_sent);
+    this->_congestion_event(largest_acked_time_sent);
   }
 }
 
 bool
-QUICNewRenoCongestionController::_in_persistent_congestion(const std::map<QUICPacketNumber, QUICPacketInfo *> &lost_packets,
-                                                           QUICPacketInfo *largest_lost_packet)
+QUICNewRenoCongestionController::_in_persistent_congestion(const std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> &lost_packets,
+                                                           const QUICSentPacketInfoUPtr &largest_lost_packet)
 {
-  ink_hrtime period = this->_context.rtt_provider()->congestion_period(this->_k_persistent_congestion_threshold);
-  // Determine if all packets in the window before the
-  // newest lost packet, including the edges, are marked
-  // lost
-  return this->_in_window_lost(lost_packets, largest_lost_packet, period);
+  ink_hrtime congestion_period = this->_context.rtt_provider()->congestion_period(this->_k_persistent_congestion_threshold);
+  // Determine if all packets in the time period before the
+  // largest newly lost packet, including the edges, are
+  // marked lost
+  return this->_are_all_packets_lost(lost_packets, largest_lost_packet, congestion_period);
+}
+
+void
+QUICNewRenoCongestionController::on_packets_acked(const std::vector<QUICSentPacketInfoUPtr> &packets)
+{
+  SCOPED_MUTEX_LOCK(lock, this->_cc_mutex, this_ethread());
+
+  for (auto &packet : packets) {
+    // Remove from bytes_in_flight.
+    this->_bytes_in_flight -= packet->sent_bytes;
+    if (this->_in_congestion_recovery(packet->time_sent)) {
+      // Do not increase congestion window in recovery period.
+      continue;
+    }
+    if (this->_is_app_or_flow_control_limited()) {
+      // Do not increase congestion_window if application
+      // limited or flow control limited.
+      continue;
+    }
+    if (this->_congestion_window < this->_ssthresh) {
+      // Slow start.
+      this->_context.trigger(QUICContext::CallbackEvent::CONGESTION_STATE_CHANGED, QUICCongestionController::State::SLOW_START);
+      this->_congestion_window += packet->sent_bytes;
+      QUICCCVDebug("slow start window changed");
+      continue;
+    }
+    // Congestion avoidance.
+    this->_context.trigger(QUICContext::CallbackEvent::CONGESTION_STATE_CHANGED,
+                           QUICCongestionController::State::CONGESTION_AVOIDANCE);
+    this->_congestion_window += this->_max_datagram_size * static_cast<double>(packet->sent_bytes) / this->_congestion_window;
+    QUICCCVDebug("Congestion avoidance window changed");
+  }
 }
 
 // additional code
 // the original one is:
 //   OnPacketsLost(lost_packets):
 void
-QUICNewRenoCongestionController::on_packets_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &lost_packets)
+QUICNewRenoCongestionController::on_packets_lost(const std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> &lost_packets)
 {
-  if (lost_packets.empty()) {
-    return;
-  }
-
   SCOPED_MUTEX_LOCK(lock, this->_cc_mutex, this_ethread());
+
   // Remove lost packets from bytes_in_flight.
   for (auto &lost_packet : lost_packets) {
     this->_bytes_in_flight -= lost_packet.second->sent_bytes;
   }
-  QUICPacketInfo *largest_lost_packet = lost_packets.rbegin()->second;
+  const auto &largest_lost_packet = lost_packets.rbegin()->second;
   this->_congestion_event(largest_lost_packet->time_sent);
 
   // Collapse congestion window if persistent congestion
@@ -178,8 +208,14 @@ QUICNewRenoCongestionController::on_packets_lost(const std::map<QUICPacketNumber
   }
 }
 
+void
+QUICNewRenoCongestionController::on_packet_number_space_discarded(size_t bytes_in_flight)
+{
+  this->_bytes_in_flight -= bytes_in_flight;
+}
+
 bool
-QUICNewRenoCongestionController::check_credit() const
+QUICNewRenoCongestionController::_check_credit() const
 {
   if (this->_bytes_in_flight >= this->_congestion_window) {
     QUICCCDebug("Congestion control pending");
@@ -195,7 +231,7 @@ QUICNewRenoCongestionController::credit() const
     return UINT32_MAX;
   }
 
-  if (this->check_credit()) {
+  if (this->_check_credit()) {
     return this->_congestion_window - this->_bytes_in_flight;
   } else {
     return 0;
@@ -226,34 +262,13 @@ QUICNewRenoCongestionController::reset()
 {
   SCOPED_MUTEX_LOCK(lock, this->_cc_mutex, this_ethread());
 
-  this->_bytes_in_flight                = 0;
   this->_congestion_window              = this->_k_initial_window;
+  this->_bytes_in_flight                = 0;
   this->_congestion_recovery_start_time = 0;
   this->_ssthresh                       = UINT32_MAX;
-}
-
-bool
-QUICNewRenoCongestionController::_in_window_lost(const std::map<QUICPacketNumber, QUICPacketInfo *> &lost_packets,
-                                                 QUICPacketInfo *largest_lost_packet, ink_hrtime period) const
-{
-  // check whether packets are continuous. return true if all continuous packets are in period
-  QUICPacketNumber next_expected = UINT64_MAX;
-  for (auto &it : lost_packets) {
-    if (it.second->time_sent >= largest_lost_packet->time_sent - period) {
-      if (next_expected == UINT64_MAX) {
-        next_expected = it.second->packet_number + 1;
-        continue;
-      }
-
-      if (next_expected != it.second->packet_number) {
-        return false;
-      }
-
-      next_expected = it.second->packet_number + 1;
-    }
+  for (int i = 0; i < QUIC_N_PACKET_SPACES; ++i) {
+    this->_ecn_ce_counters[i] = 0;
   }
-
-  return next_expected == UINT64_MAX ? false : true;
 }
 
 void

--- a/iocore/net/quic/QUICNewRenoCongestionController.h
+++ b/iocore/net/quic/QUICNewRenoCongestionController.h
@@ -1,0 +1,81 @@
+/** @file
+ *
+ *  A brief file description
+ *
+ *  @section license License
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include "QUICTypes.h"
+#include "QUICContext.h"
+#include "QUICCongestionController.h"
+
+class QUICNewRenoCongestionController : public QUICCongestionController
+{
+public:
+  QUICNewRenoCongestionController(QUICContext &context);
+  virtual ~QUICNewRenoCongestionController() {}
+
+  void on_packet_sent(size_t bytes_sent) override;
+  void on_packets_acked(const std::vector<QUICSentPacketInfoUPtr> &packets) override;
+  virtual void on_packets_lost(const std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> &packets) override;
+  void on_packet_number_space_discarded(size_t bytes_in_flight) override;
+  void process_ecn(const QUICAckFrame &ack, QUICPacketNumberSpace pn_space, ink_hrtime largest_acked_packet_time_sent) override;
+  uint32_t credit() const override;
+  void reset() override;
+
+  // Debug
+  uint32_t bytes_in_flight() const override;
+  uint32_t congestion_window() const override;
+  uint32_t current_ssthresh() const override;
+
+  void add_extra_credit() override;
+
+private:
+  Ptr<ProxyMutex> _cc_mutex;
+  uint32_t _extra_packets_count = 0;
+  QUICContext &_context;
+  bool _check_credit() const;
+
+  // Appendix B.  Congestion Control Pseudocode
+  bool _in_congestion_recovery(ink_hrtime sent_time) const;
+  void _congestion_event(ink_hrtime sent_time);
+  bool _in_persistent_congestion(const std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> &lost_packets,
+                                 const QUICSentPacketInfoUPtr &largest_lost_packet);
+  bool _is_app_or_flow_control_limited();
+  void _maybe_send_one_packet();
+  bool _are_all_packets_lost(const std::map<QUICPacketNumber, QUICSentPacketInfoUPtr> &lost_packets,
+                             const QUICSentPacketInfoUPtr &largest_lost_packet, ink_hrtime period) const;
+
+  // Recovery B.1. Constants of interest
+  // Values will be loaded from records.config via QUICConfig at constructor
+  uint32_t _k_initial_window                  = 0;
+  uint32_t _k_minimum_window                  = 0;
+  float _k_loss_reduction_factor              = 0.0;
+  uint32_t _k_persistent_congestion_threshold = 0;
+
+  // B.2. Variables of interest
+  uint32_t _max_datagram_size                     = 0;
+  uint32_t _ecn_ce_counters[QUIC_N_PACKET_SPACES] = {0};
+  uint32_t _bytes_in_flight                       = 0;
+  uint32_t _congestion_window                     = 0;
+  ink_hrtime _congestion_recovery_start_time      = 0;
+  uint32_t _ssthresh                              = UINT32_MAX;
+};

--- a/iocore/net/quic/QUICPacket.h
+++ b/iocore/net/quic/QUICPacket.h
@@ -319,7 +319,8 @@ public:
   /**
    * For sending packet
    */
-  QUICVersionNegotiationPacket(QUICConnectionId dcid, QUICConnectionId scid, const QUICVersion versions[], int nversions);
+  QUICVersionNegotiationPacket(const QUICConnectionId &dcid, const QUICConnectionId &scid, const QUICVersion versions[],
+                               int nversions, QUICVersion version_in_initial);
 
   QUICPacketType type() const override;
   QUICVersion version() const override;
@@ -335,6 +336,7 @@ public:
 private:
   const QUICVersion *_versions;
   int _nversions;
+  const QUICVersion _version_in_initial;
 };
 
 class QUICVersionNegotiationPacketR : public QUICLongHeaderPacketR

--- a/iocore/net/quic/QUICPacketFactory.cc
+++ b/iocore/net/quic/QUICPacketFactory.cc
@@ -197,10 +197,11 @@ QUICPacketFactory::create(uint8_t *packet_buf, UDPConnection *udp_con, IpEndpoin
 }
 
 QUICPacketUPtr
-QUICPacketFactory::create_version_negotiation_packet(QUICConnectionId dcid, QUICConnectionId scid)
+QUICPacketFactory::create_version_negotiation_packet(QUICConnectionId dcid, QUICConnectionId scid, QUICVersion version_in_initial)
 {
-  return QUICPacketUPtr(new QUICVersionNegotiationPacket(dcid, scid, QUIC_SUPPORTED_VERSIONS, countof(QUIC_SUPPORTED_VERSIONS)),
-                        &QUICPacketDeleter::delete_packet_new);
+  return QUICPacketUPtr(
+    new QUICVersionNegotiationPacket(dcid, scid, QUIC_SUPPORTED_VERSIONS, countof(QUIC_SUPPORTED_VERSIONS), version_in_initial),
+    &QUICPacketDeleter::delete_packet_new);
 }
 
 QUICPacketUPtr
@@ -228,10 +229,10 @@ QUICPacketFactory::create_initial_packet(uint8_t *packet_buf, QUICConnectionId d
 }
 
 QUICPacketUPtr
-QUICPacketFactory::create_retry_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid, QUICRetryToken &token)
+QUICPacketFactory::create_retry_packet(QUICVersion version, QUICConnectionId destination_cid, QUICConnectionId source_cid,
+                                       QUICRetryToken &token)
 {
-  return QUICPacketUPtr(new QUICRetryPacket(QUIC_SUPPORTED_VERSIONS[0], destination_cid, source_cid, token),
-                        &QUICPacketDeleter::delete_packet_new);
+  return QUICPacketUPtr(new QUICRetryPacket(version, destination_cid, source_cid, token), &QUICPacketDeleter::delete_packet_new);
 }
 
 QUICPacketUPtr
@@ -329,7 +330,7 @@ QUICPacketFactory::is_ready_to_create_protected_packet()
 void
 QUICPacketFactory::reset()
 {
-  for (auto i = 0; i < kPacketNumberSpace; i++) {
+  for (auto i = 0; i < QUIC_N_PACKET_SPACES; i++) {
     this->_packet_number_generator[i].reset();
   }
 }

--- a/iocore/net/quic/QUICPacketFactory.h
+++ b/iocore/net/quic/QUICPacketFactory.h
@@ -44,9 +44,11 @@ class QUICPacketFactory
 {
 public:
   static QUICPacketUPtr create_null_packet();
-  static QUICPacketUPtr create_version_negotiation_packet(QUICConnectionId dcid, QUICConnectionId scid);
+  static QUICPacketUPtr create_version_negotiation_packet(QUICConnectionId dcid, QUICConnectionId scid,
+                                                          QUICVersion version_in_version);
   static QUICPacketUPtr create_stateless_reset_packet(QUICStatelessResetToken stateless_reset_token, size_t maximum_size);
-  static QUICPacketUPtr create_retry_packet(QUICConnectionId destination_cid, QUICConnectionId source_cid, QUICRetryToken &token);
+  static QUICPacketUPtr create_retry_packet(QUICVersion version, QUICConnectionId destination_cid, QUICConnectionId source_cid,
+                                            QUICRetryToken &token);
 
   QUICPacketFactory(const QUICPacketProtectionKeyInfo &pp_key_info) : _pp_key_info(pp_key_info), _pp_protector(pp_key_info) {}
 

--- a/iocore/net/quic/QUICRetryIntegrityTag.h
+++ b/iocore/net/quic/QUICRetryIntegrityTag.h
@@ -29,11 +29,17 @@ class QUICRetryIntegrityTag
 {
 public:
   static constexpr int LEN = 16;
-  static bool compute(uint8_t *out, QUICConnectionId odcid, Ptr<IOBufferBlock> header, Ptr<IOBufferBlock> payload);
+  static bool compute(uint8_t *out, QUICVersion version, QUICConnectionId odcid, Ptr<IOBufferBlock> header,
+                      Ptr<IOBufferBlock> payload);
 
 private:
-  static constexpr uint8_t KEY_FOR_RETRY_INTEGRITY_TAG[]   = {0x4d, 0x32, 0xec, 0xdb, 0x2a, 0x21, 0x33, 0xc8,
-                                                            0x41, 0xe4, 0x04, 0x3d, 0xf2, 0x7d, 0x44, 0x30};
-  static constexpr uint8_t NONCE_FOR_RETRY_INTEGRITY_TAG[] = {0x4d, 0x16, 0x11, 0xd0, 0x55, 0x13,
-                                                              0xa5, 0x52, 0xc5, 0x87, 0xd5, 0x75};
+  static constexpr uint8_t KEY_FOR_RETRY_INTEGRITY_TAG[]   = {0xcc, 0xce, 0x18, 0x7e, 0xd0, 0x9a, 0x09, 0xd0,
+                                                            0x57, 0x28, 0x15, 0x5a, 0x6c, 0xb9, 0x6b, 0xe1};
+  static constexpr uint8_t NONCE_FOR_RETRY_INTEGRITY_TAG[] = {0xe5, 0x49, 0x30, 0xf9, 0x7f, 0x21,
+                                                              0x36, 0xf0, 0x53, 0x0a, 0x8c, 0x1c};
+  // For draft 27
+  static constexpr uint8_t KEY_FOR_RETRY_INTEGRITY_TAG_D27[]   = {0x4d, 0x32, 0xec, 0xdb, 0x2a, 0x21, 0x33, 0xc8,
+                                                                0x41, 0xe4, 0x04, 0x3d, 0xf2, 0x7d, 0x44, 0x30};
+  static constexpr uint8_t NONCE_FOR_RETRY_INTEGRITY_TAG_D27[] = {0x4d, 0x16, 0x11, 0xd0, 0x55, 0x13,
+                                                                  0xa5, 0x52, 0xc5, 0x87, 0xd5, 0x75};
 };

--- a/iocore/net/quic/QUICStream.h
+++ b/iocore/net/quic/QUICStream.h
@@ -130,5 +130,8 @@ protected:
 #define QUICStreamFCDebug(fmt, ...)                                                                         \
   Debug("quic_flow_ctrl", "[%s] [%" PRIu64 "] [%s] " fmt, this->_connection_info->cids().data(), this->_id, \
         QUICDebugNames::stream_state(this->_state.get()), ##__VA_ARGS__)
+#define QUICVStreamFCDebug(fmt, ...)                                                                          \
+  Debug("v_quic_flow_ctrl", "[%s] [%" PRIu64 "] [%s] " fmt, this->_connection_info->cids().data(), this->_id, \
+        QUICDebugNames::stream_state(this->_state.get()), ##__VA_ARGS__)
 
 extern const uint32_t MAX_STREAM_FRAME_OVERHEAD;

--- a/iocore/net/quic/QUICTLS.cc
+++ b/iocore/net/quic/QUICTLS.cc
@@ -165,7 +165,7 @@ QUICTLS::is_ready_to_derive() const
 }
 
 int
-QUICTLS::initialize_key_materials(QUICConnectionId cid)
+QUICTLS::initialize_key_materials(QUICConnectionId cid, QUICVersion version)
 {
   this->_pp_key_info.set_cipher_initial(EVP_aes_128_gcm());
   this->_pp_key_info.set_cipher_for_hp_initial(EVP_aes_128_ecb());
@@ -217,8 +217,8 @@ QUICTLS::initialize_key_materials(QUICConnectionId cid)
     server_iv_len         = this->_pp_key_info.decryption_iv_len(QUICKeyPhase::INITIAL);
   }
 
-  this->_keygen_for_client.generate(client_key_for_hp, client_key, client_iv, client_iv_len, cid);
-  this->_keygen_for_server.generate(server_key_for_hp, server_key, server_iv, server_iv_len, cid);
+  this->_keygen_for_client.generate(version, client_key_for_hp, client_key, client_iv, client_iv_len, cid);
+  this->_keygen_for_server.generate(version, server_key_for_hp, server_key, server_iv, server_iv_len, cid);
 
   this->_pp_key_info.set_decryption_key_available(QUICKeyPhase::INITIAL);
   this->_pp_key_info.set_encryption_key_available(QUICKeyPhase::INITIAL);

--- a/iocore/net/quic/QUICTLS.h
+++ b/iocore/net/quic/QUICTLS.h
@@ -71,7 +71,7 @@ public:
   void reset() override;
   bool is_handshake_finished() const override;
   bool is_ready_to_derive() const override;
-  int initialize_key_materials(QUICConnectionId cid) override;
+  int initialize_key_materials(QUICConnectionId cid, QUICVersion version) override;
   void update_negotiated_cipher();
   void update_key_materials_for_read(QUICEncryptionLevel level, const uint8_t *secret, size_t secret_len);
   void update_key_materials_for_write(QUICEncryptionLevel level, const uint8_t *secret, size_t secret_len);

--- a/iocore/net/quic/QUICTLS_boringssl.cc
+++ b/iocore/net/quic/QUICTLS_boringssl.cc
@@ -30,6 +30,7 @@
 #include <openssl/aead.h>
 
 #include "QUICGlobals.h"
+#include "QUICConnection.h"
 #include "QUICPacketProtectionKeyInfo.h"
 
 static constexpr char tag[] = "quic_tls";
@@ -80,10 +81,13 @@ set_write_secret(SSL *ssl, enum ssl_encryption_level_t level, const SSL_CIPHER *
     const uint8_t *tp_buf;
     size_t tp_buf_len;
     SSL_get_peer_quic_transport_params(ssl, &tp_buf, &tp_buf_len);
+    const QUICConnection *qc = static_cast<const QUICConnection *>(SSL_get_ex_data(ssl, QUIC::ssl_quic_qc_index));
+    QUICVersion version      = qc->negotiated_version();
     if (SSL_is_server(ssl)) {
-      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(tp_buf, tp_buf_len));
+      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(tp_buf, tp_buf_len, version));
     } else {
-      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInEncryptedExtensions>(tp_buf, tp_buf_len));
+      qtls->set_remote_transport_parameters(
+        std::make_shared<QUICTransportParametersInEncryptedExtensions>(tp_buf, tp_buf_len, version));
     }
   }
 
@@ -111,10 +115,13 @@ set_encryption_secrets(SSL *ssl, enum ssl_encryption_level_t level, const uint8_
     const uint8_t *tp_buf;
     size_t tp_buf_len;
     SSL_get_peer_quic_transport_params(ssl, &tp_buf, &tp_buf_len);
+    const QUICConnection *qc = static_cast<const QUICConnection *>(SSL_get_ex_data(ssl, QUIC::ssl_quic_qc_index));
+    QUICVersion version      = qc->negotiated_version();
     if (SSL_is_server(ssl)) {
-      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(tp_buf, tp_buf_len));
+      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(tp_buf, tp_buf_len, version));
     } else {
-      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInEncryptedExtensions>(tp_buf, tp_buf_len));
+      qtls->set_remote_transport_parameters(
+        std::make_shared<QUICTransportParametersInEncryptedExtensions>(tp_buf, tp_buf_len, version));
     }
   }
 

--- a/iocore/net/quic/QUICTLS_openssl.cc
+++ b/iocore/net/quic/QUICTLS_openssl.cc
@@ -29,6 +29,7 @@
 #include <openssl/evp.h>
 
 #include "QUICGlobals.h"
+#include "QUICConnection.h"
 #include "QUICPacketProtectionKeyInfo.h"
 
 static constexpr char tag[] = "quic_tls";
@@ -71,10 +72,13 @@ set_encryption_secrets(SSL *ssl, enum ssl_encryption_level_t level, const uint8_
     const uint8_t *tp_buf;
     size_t tp_buf_len;
     SSL_get_peer_quic_transport_params(ssl, &tp_buf, &tp_buf_len);
+    const QUICConnection *qc = static_cast<const QUICConnection *>(SSL_get_ex_data(ssl, QUIC::ssl_quic_qc_index));
+    QUICVersion version      = qc->negotiated_version();
     if (SSL_is_server(ssl)) {
-      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(tp_buf, tp_buf_len));
+      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(tp_buf, tp_buf_len, version));
     } else {
-      qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInEncryptedExtensions>(tp_buf, tp_buf_len));
+      qtls->set_remote_transport_parameters(
+        std::make_shared<QUICTransportParametersInEncryptedExtensions>(tp_buf, tp_buf_len, version));
     }
   }
 

--- a/iocore/net/quic/QUICTransportParameters.cc
+++ b/iocore/net/quic/QUICTransportParameters.cc
@@ -35,9 +35,9 @@ static constexpr char tag[] = "quic_handshake";
 
 static constexpr int TRANSPORT_PARAMETERS_MAXIMUM_SIZE = 65535;
 
-static constexpr uint32_t TP_ERROR_LENGTH = 0x010000;
-static constexpr uint32_t TP_ERROR_VALUE  = 0x020000;
-// static constexpr uint32_t TP_ERROR_MUST_EXIST     = 0x030000;
+static constexpr uint32_t TP_ERROR_LENGTH         = 0x010000;
+static constexpr uint32_t TP_ERROR_VALUE          = 0x020000;
+static constexpr uint32_t TP_ERROR_MUST_EXIST     = 0x030000;
 static constexpr uint32_t TP_ERROR_MUST_NOT_EXIST = 0x040000;
 
 QUICTransportParameters::Value::Value(const uint8_t *data, uint16_t len) : _len(len)
@@ -70,6 +70,14 @@ QUICTransportParameters::Value::len() const
   return this->_len;
 }
 
+QUICTransportParameters::QUICTransportParameters(const uint8_t *buf, size_t len, QUICVersion version)
+{
+  this->_load(buf, len, version);
+  if (is_debug_tag_set(tag)) {
+    this->_print();
+  }
+}
+
 QUICTransportParameters::~QUICTransportParameters()
 {
   for (auto p : this->_parameters) {
@@ -78,7 +86,7 @@ QUICTransportParameters::~QUICTransportParameters()
 }
 
 void
-QUICTransportParameters::_load(const uint8_t *buf, size_t len)
+QUICTransportParameters::_load(const uint8_t *buf, size_t len, QUICVersion version)
 {
   bool has_error   = false;
   const uint8_t *p = buf;
@@ -130,7 +138,7 @@ QUICTransportParameters::_load(const uint8_t *buf, size_t len)
   }
 
   // Validate parameters
-  int res = this->_validate_parameters();
+  int res = this->_validate_parameters(version);
   if (res < 0) {
     Debug(tag, "Transport parameter is not valid (err=%d)", res);
     this->_valid = false;
@@ -140,7 +148,7 @@ QUICTransportParameters::_load(const uint8_t *buf, size_t len)
 }
 
 int
-QUICTransportParameters::_validate_parameters() const
+QUICTransportParameters::_validate_parameters(QUICVersion version) const
 {
   decltype(this->_parameters)::const_iterator ite;
 
@@ -159,9 +167,9 @@ QUICTransportParameters::_validate_parameters() const
   if ((ite = this->_parameters.find(QUICTransportParameterId::MAX_IDLE_TIMEOUT)) != this->_parameters.end()) {
   }
 
-  if ((ite = this->_parameters.find(QUICTransportParameterId::MAX_PACKET_SIZE)) != this->_parameters.end()) {
+  if ((ite = this->_parameters.find(QUICTransportParameterId::MAX_UDP_PAYLOAD_SIZE)) != this->_parameters.end()) {
     if (QUICIntUtil::read_nbytes_as_uint(ite->second->data(), ite->second->len()) < 1200) {
-      return -(TP_ERROR_VALUE | QUICTransportParameterId::MAX_PACKET_SIZE);
+      return -(TP_ERROR_VALUE | QUICTransportParameterId::MAX_UDP_PAYLOAD_SIZE);
     }
   }
 
@@ -262,6 +270,10 @@ QUICTransportParameters::store(uint8_t *buf, uint16_t *len) const
   }
 
   *len = (p - buf);
+
+  if (is_debug_tag_set(tag)) {
+    this->_print();
+  }
 }
 
 void
@@ -301,12 +313,9 @@ QUICTransportParameters::_print() const
 // QUICTransportParametersInClientHello
 //
 
-QUICTransportParametersInClientHello::QUICTransportParametersInClientHello(const uint8_t *buf, size_t len)
+QUICTransportParametersInClientHello::QUICTransportParametersInClientHello(const uint8_t *buf, size_t len, QUICVersion version)
+  : QUICTransportParameters(buf, len, version)
 {
-  this->_load(buf, len);
-  if (is_debug_tag_set(tag)) {
-    this->_print();
-  }
 }
 
 std::ptrdiff_t
@@ -316,9 +325,9 @@ QUICTransportParametersInClientHello::_parameters_offset(const uint8_t *) const
 }
 
 int
-QUICTransportParametersInClientHello::_validate_parameters() const
+QUICTransportParametersInClientHello::_validate_parameters(QUICVersion version) const
 {
-  int res = QUICTransportParameters::_validate_parameters();
+  int res = QUICTransportParameters::_validate_parameters(version);
   if (res < 0) {
     return res;
   }
@@ -326,12 +335,20 @@ QUICTransportParametersInClientHello::_validate_parameters() const
   decltype(this->_parameters)::const_iterator ite;
 
   // MUST NOTs
-  if ((ite = this->_parameters.find(QUICTransportParameterId::STATELESS_RESET_TOKEN)) != this->_parameters.end()) {
-    return -(TP_ERROR_MUST_NOT_EXIST | QUICTransportParameterId::STATELESS_RESET_TOKEN);
+  if ((ite = this->_parameters.find(QUICTransportParameterId::ORIGINAL_DESTINATION_CONNECTION_ID)) != this->_parameters.end()) {
+    return -(TP_ERROR_MUST_NOT_EXIST | QUICTransportParameterId::ORIGINAL_DESTINATION_CONNECTION_ID);
   }
 
   if ((ite = this->_parameters.find(QUICTransportParameterId::PREFERRED_ADDRESS)) != this->_parameters.end()) {
     return -(TP_ERROR_MUST_NOT_EXIST | QUICTransportParameterId::PREFERRED_ADDRESS);
+  }
+
+  if ((ite = this->_parameters.find(QUICTransportParameterId::RETRY_SOURCE_CONNECTION_ID)) != this->_parameters.end()) {
+    return -(TP_ERROR_MUST_NOT_EXIST | QUICTransportParameterId::RETRY_SOURCE_CONNECTION_ID);
+  }
+
+  if ((ite = this->_parameters.find(QUICTransportParameterId::STATELESS_RESET_TOKEN)) != this->_parameters.end()) {
+    return -(TP_ERROR_MUST_NOT_EXIST | QUICTransportParameterId::STATELESS_RESET_TOKEN);
   }
 
   return 0;
@@ -341,18 +358,10 @@ QUICTransportParametersInClientHello::_validate_parameters() const
 // QUICTransportParametersInEncryptedExtensions
 //
 
-QUICTransportParametersInEncryptedExtensions::QUICTransportParametersInEncryptedExtensions(const uint8_t *buf, size_t len)
+QUICTransportParametersInEncryptedExtensions::QUICTransportParametersInEncryptedExtensions(const uint8_t *buf, size_t len,
+                                                                                           QUICVersion version)
+  : QUICTransportParameters(buf, len, version)
 {
-  this->_load(buf, len);
-  if (is_debug_tag_set(tag)) {
-    this->_print();
-  }
-}
-
-void
-QUICTransportParametersInEncryptedExtensions::add_version(QUICVersion version)
-{
-  this->_versions[this->_n_versions++] = version;
 }
 
 std::ptrdiff_t
@@ -362,21 +371,36 @@ QUICTransportParametersInEncryptedExtensions::_parameters_offset(const uint8_t *
 }
 
 int
-QUICTransportParametersInEncryptedExtensions::_validate_parameters() const
+QUICTransportParametersInEncryptedExtensions::_validate_parameters(QUICVersion version) const
 {
-  int res = QUICTransportParameters::_validate_parameters();
+  int res = QUICTransportParameters::_validate_parameters(version);
   if (res < 0) {
     return res;
   }
 
   decltype(this->_parameters)::const_iterator ite;
 
-  // MUSTs if the server sent a Retry packet
-  if ((ite = this->_parameters.find(QUICTransportParameterId::ORIGINAL_CONNECTION_ID)) != this->_parameters.end()) {
-    // We cannot check the length because it's not a fixed length.
-  } else {
-    // TODO Need a way that checks if we received a Retry from the server
-    // return -(TP_ERROR_MUST_EXIST | QUICTransportParameterId::ORIGINAL_CONNECTION_ID);
+  // MUSTs
+  if (version == QUIC_SUPPORTED_VERSIONS[0]) { // draft-28
+    if ((ite = this->_parameters.find(QUICTransportParameterId::INITIAL_SOURCE_CONNECTION_ID)) != this->_parameters.end()) {
+      // We cannot check the length because it's not a fixed length.
+    } else {
+      return -(TP_ERROR_MUST_EXIST | QUICTransportParameterId::INITIAL_SOURCE_CONNECTION_ID);
+    }
+
+    if ((ite = this->_parameters.find(QUICTransportParameterId::ORIGINAL_DESTINATION_CONNECTION_ID)) != this->_parameters.end()) {
+      // We cannot check the length because it's not a fixed length.
+    } else {
+      return -(TP_ERROR_MUST_EXIST | QUICTransportParameterId::ORIGINAL_DESTINATION_CONNECTION_ID);
+    }
+
+    // MUSTs if the server sent a Retry packet, but MUST NOT if the server did not send a Retry packet
+    // TODO Check if the server sent Retry packet
+    if ((ite = this->_parameters.find(QUICTransportParameterId::RETRY_SOURCE_CONNECTION_ID)) != this->_parameters.end()) {
+      // return -(TP_ERROR_MUST_NOT_EXIST | QUICTransportParameterId::RETRY_SOURCE_CONNECTION_ID);
+    } else {
+      // return -(TP_ERROR_MUST_EXIST | QUICTransportParameterId::RETRY_SOURCE_CONNECTION_ID);
+    }
   }
 
   // MAYs
@@ -422,14 +446,15 @@ int
 QUICTransportParametersHandler::parse(SSL *s, unsigned int ext_type, unsigned int context, const unsigned char *in, size_t inlen,
                                       X509 *x, size_t chainidx, int *al, void *parse_arg)
 {
-  QUICTLS *qtls = static_cast<QUICTLS *>(SSL_get_ex_data(s, QUIC::ssl_quic_tls_index));
-
+  QUICTLS *qtls            = static_cast<QUICTLS *>(SSL_get_ex_data(s, QUIC::ssl_quic_tls_index));
+  const QUICConnection *qc = static_cast<const QUICConnection *>(SSL_get_ex_data(s, QUIC::ssl_quic_qc_index));
+  QUICVersion version      = qc->negotiated_version();
   switch (context) {
   case SSL_EXT_CLIENT_HELLO:
-    qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(in, inlen));
+    qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInClientHello>(in, inlen, version));
     break;
   case SSL_EXT_TLS1_3_ENCRYPTED_EXTENSIONS:
-    qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInEncryptedExtensions>(in, inlen));
+    qtls->set_remote_transport_parameters(std::make_shared<QUICTransportParametersInEncryptedExtensions>(in, inlen, version));
     break;
   default:
     // Do nothing

--- a/iocore/net/quic/QUICTypes.cc
+++ b/iocore/net/quic/QUICTypes.cc
@@ -153,13 +153,14 @@ QUICTypeUtil::key_phase(QUICPacketType type)
 QUICPacketNumberSpace
 QUICTypeUtil::pn_space(QUICEncryptionLevel level)
 {
+  // TODO Optimize the case order
   switch (level) {
   case QUICEncryptionLevel::HANDSHAKE:
-    return QUICPacketNumberSpace::Handshake;
+    return QUICPacketNumberSpace::HANDSHAKE;
   case QUICEncryptionLevel::INITIAL:
-    return QUICPacketNumberSpace::Initial;
+    return QUICPacketNumberSpace::INITIAL;
   default:
-    return QUICPacketNumberSpace::ApplicationData;
+    return QUICPacketNumberSpace::APPLICATION_DATA;
   }
 }
 
@@ -360,7 +361,7 @@ QUICResumptionToken::expire_time() const
   return QUICIntUtil::read_nbytes_as_uint(this->_token + (1 + 20), 4);
 }
 
-QUICRetryToken::QUICRetryToken(const IpEndpoint &src, QUICConnectionId original_dcid)
+QUICRetryToken::QUICRetryToken(const IpEndpoint &src, QUICConnectionId original_dcid, QUICConnectionId scid)
 {
   // TODO: read cookie secret from file like SSLTicketKeyConfig
   static constexpr char stateless_retry_token_secret[] = "stateless_cookie_secret";
@@ -371,7 +372,13 @@ QUICRetryToken::QUICRetryToken(const IpEndpoint &src, QUICConnectionId original_
   data_len = strlen(reinterpret_cast<char *>(data));
 
   size_t cid_len;
+  *(data + data_len) = original_dcid.length();
+  data_len += 1;
   QUICTypeUtil::write_QUICConnectionId(original_dcid, data + data_len, &cid_len);
+  data_len += cid_len;
+  *(data + data_len) = scid.length();
+  data_len += 1;
+  QUICTypeUtil::write_QUICConnectionId(scid, data + data_len, &cid_len);
   data_len += cid_len;
 
   this->_token[0] = static_cast<uint8_t>(Type::RETRY);
@@ -380,21 +387,38 @@ QUICRetryToken::QUICRetryToken(const IpEndpoint &src, QUICConnectionId original_
   ink_assert(this->_token_len == 20);
   this->_token_len += 1;
 
+  *(this->_token + this->_token_len) = original_dcid.length();
+  this->_token_len += 1;
   QUICTypeUtil::write_QUICConnectionId(original_dcid, this->_token + this->_token_len, &cid_len);
+  this->_token_len += cid_len;
+  *(this->_token + this->_token_len) = scid.length();
+  this->_token_len += 1;
+  QUICTypeUtil::write_QUICConnectionId(scid, this->_token + this->_token_len, &cid_len);
   this->_token_len += cid_len;
 }
 
 bool
 QUICRetryToken::is_valid(const IpEndpoint &src) const
 {
-  return *this == QUICRetryToken(src, this->original_dcid());
+  return *this == QUICRetryToken(src, this->original_dcid(), this->scid());
 }
 
 const QUICConnectionId
 QUICRetryToken::original_dcid() const
 {
   // Type uses 1 byte and output of EVP_sha1() should be 160 bits
-  return QUICTypeUtil::read_QUICConnectionId(this->_token + (1 + 20), this->_token_len - (1 + 20));
+  auto len   = *(this->_token + (1 + 20));
+  auto start = this->_token + (1 + 20 + 1);
+  return QUICTypeUtil::read_QUICConnectionId(start, len);
+}
+
+const QUICConnectionId
+QUICRetryToken::scid() const
+{
+  auto len   = *(this->_token + (1 + 20));
+  auto start = this->_token + (1 + 20 + 1 + len + 1);
+  len        = *(this->_token + (1 + 20 + 1 + len));
+  return QUICTypeUtil::read_QUICConnectionId(start, len);
 }
 
 QUICFrameType
@@ -672,6 +696,18 @@ QUICConnectionId::hex() const
     stream << std::hex << static_cast<int>(this->_id[i]);
   }
   return stream.str();
+}
+
+QUICFrameId
+QUICSentPacketInfo::FrameInfo::id() const
+{
+  return this->_id;
+}
+
+QUICFrameGenerator *
+QUICSentPacketInfo::FrameInfo::generated_by() const
+{
+  return this->_generator;
 }
 
 //

--- a/iocore/net/quic/qlog/QLogListener.h
+++ b/iocore/net/quic/qlog/QLogListener.h
@@ -73,7 +73,7 @@ public:
   };
 
   void
-  packet_lost_callback(QUICCallbackContext &, const QUICPacketInfo &packet) override
+  packet_lost_callback(QUICCallbackContext &, const QUICSentPacketInfo &packet) override
   {
     auto qe = std::make_unique<Recovery::PacketLost>(PacketTypeToName(packet.type), packet.packet_number);
     this->_log.last_trace().push_event(std::move(qe));

--- a/iocore/net/quic/test/test_QUICAckFrameCreator.cc
+++ b/iocore/net/quic/test/test_QUICAckFrameCreator.cc
@@ -283,7 +283,7 @@ TEST_CASE("QUICAckFrameManager_loss_recover", "[quic]")
 TEST_CASE("QUICAckFrameManager_QUICAckFrameCreator", "[quic]")
 {
   QUICAckFrameManager ack_manager;
-  QUICAckFrameManager::QUICAckFrameCreator packet_numbers(QUICPacketNumberSpace::Initial, &ack_manager);
+  QUICAckFrameManager::QUICAckFrameCreator packet_numbers(QUICPacketNumberSpace::INITIAL, &ack_manager);
 
   CHECK(packet_numbers.size() == 0);
   CHECK(packet_numbers.largest_ack_number() == 0);

--- a/iocore/net/quic/test/test_QUICKeyGenerator.cc
+++ b/iocore/net/quic/test/test_QUICKeyGenerator.cc
@@ -35,8 +35,8 @@
 #include "QUICKeyGenerator.h"
 #include "QUICPacketProtectionKeyInfo.h"
 
-// https://github.com/quicwg/base-drafts/wiki/Test-Vector-for-the-Clear-Text-AEAD-key-derivation
-TEST_CASE("draft-23 Test Vectors", "[quic]")
+// https://github.com/quicwg/base-drafts/wiki/Test-Vector-for-the-Initial-AEAD-key-derivation
+TEST_CASE("draft-23~27 Test Vectors", "[quic]")
 {
   SECTION("CLIENT Initial")
   {
@@ -51,8 +51,9 @@ TEST_CASE("draft-23 Test Vectors", "[quic]")
     QUICPacketProtectionKeyInfo pp_key_info;
     pp_key_info.set_cipher_initial(EVP_aes_128_gcm());
     pp_key_info.set_cipher_for_hp_initial(EVP_aes_128_ecb());
-    keygen.generate(pp_key_info.encryption_key_for_hp(QUICKeyPhase::INITIAL), pp_key_info.encryption_key(QUICKeyPhase::INITIAL),
-                    pp_key_info.encryption_iv(QUICKeyPhase::INITIAL), pp_key_info.encryption_iv_len(QUICKeyPhase::INITIAL), cid);
+    keygen.generate(0xff00001b, pp_key_info.encryption_key_for_hp(QUICKeyPhase::INITIAL),
+                    pp_key_info.encryption_key(QUICKeyPhase::INITIAL), pp_key_info.encryption_iv(QUICKeyPhase::INITIAL),
+                    pp_key_info.encryption_iv_len(QUICKeyPhase::INITIAL), cid);
 
     CHECK(pp_key_info.encryption_key_len(QUICKeyPhase::INITIAL) == sizeof(expected_client_key));
     CHECK(memcmp(pp_key_info.encryption_key(QUICKeyPhase::INITIAL), expected_client_key, sizeof(expected_client_key)) == 0);
@@ -76,8 +77,9 @@ TEST_CASE("draft-23 Test Vectors", "[quic]")
     QUICPacketProtectionKeyInfo pp_key_info;
     pp_key_info.set_cipher_initial(EVP_aes_128_gcm());
     pp_key_info.set_cipher_for_hp_initial(EVP_aes_128_ecb());
-    keygen.generate(pp_key_info.encryption_key_for_hp(QUICKeyPhase::INITIAL), pp_key_info.encryption_key(QUICKeyPhase::INITIAL),
-                    pp_key_info.encryption_iv(QUICKeyPhase::INITIAL), pp_key_info.encryption_iv_len(QUICKeyPhase::INITIAL), cid);
+    keygen.generate(0xff00001b, pp_key_info.encryption_key_for_hp(QUICKeyPhase::INITIAL),
+                    pp_key_info.encryption_key(QUICKeyPhase::INITIAL), pp_key_info.encryption_iv(QUICKeyPhase::INITIAL),
+                    pp_key_info.encryption_iv_len(QUICKeyPhase::INITIAL), cid);
 
     CHECK(pp_key_info.encryption_key_len(QUICKeyPhase::INITIAL) == sizeof(expected_server_key));
     CHECK(memcmp(pp_key_info.encryption_key(QUICKeyPhase::INITIAL), expected_server_key, sizeof(expected_server_key)) == 0);

--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -27,6 +27,8 @@
 #include "QUICPacketFactory.h"
 #include "QUICAckFrameCreator.h"
 #include "QUICEvents.h"
+#include "QUICPacketFactory.h"
+#include "QUICAckFrameCreator.h"
 #include "Mock.h"
 #include "tscore/ink_hrtime.h"
 
@@ -79,16 +81,15 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
       {reinterpret_cast<const uint8_t *>("\x11\x12\x13\x14\x15\x16\x17\x18"), 8}, sizeof(raw), 0, true, true, false);
     handshake_packet->attach_payload(payload, true);
     QUICPacketUPtr packet = QUICPacketUPtr(handshake_packet, [](QUICPacket *p) { delete p; });
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{
       packet->packet_number(),
-      Thread::get_hrtime(),
       packet->is_ack_eliciting(),
-      static_cast<QUICLongHeaderPacket &>(*packet).is_crypto_packet(),
       true,
       packet->size(),
+      Thread::get_hrtime(),
       packet->type(),
       {},
-      QUICPacketNumberSpace::Handshake,
+      QUICPacketNumberSpace::HANDSHAKE,
     }));
     ink_hrtime_sleep(HRTIME_MSECONDS(1000));
     CHECK(g.lost_frame_count >= 0);
@@ -106,7 +107,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
   SECTION("1-RTT")
   {
     // Send packet (1) to (7)
-    QUICPacketNumberSpace pn_space = QUICPacketNumberSpace::ApplicationData;
+    QUICPacketNumberSpace pn_space = QUICPacketNumberSpace::APPLICATION_DATA;
     QUICEncryptionLevel level      = QUICEncryptionLevel::ONE_RTT;
     payload                        = make_ptr<IOBufferBlock>(new_IOBufferBlock());
     payload->alloc(iobuffer_size_to_index(payload_len, BUFFER_SIZE_INDEX_32K));
@@ -181,97 +182,87 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
     QUICPacketNumber pn9  = packet9->packet_number();
     QUICPacketNumber pn10 = packet10->packet_number();
 
-    QUICPacketInfoUPtr packet_info = nullptr;
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet1->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet1->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet1->size(),
-                                                                  packet1->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet2->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet2->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet2->size(),
-                                                                  packet2->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet3->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet3->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet3->size(),
-                                                                  packet3->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet4->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet4->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet4->size(),
-                                                                  packet4->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet5->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet5->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet5->size(),
-                                                                  packet5->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet6->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet6->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet6->size(),
-                                                                  packet6->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet7->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet6->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet7->size(),
-                                                                  packet7->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet8->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet6->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet8->size(),
-                                                                  packet8->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet9->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet6->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet9->size(),
-                                                                  packet9->type(),
-                                                                  {},
-                                                                  pn_space}));
-    detector.on_packet_sent(QUICPacketInfoUPtr(new QUICPacketInfo{packet10->packet_number(),
-                                                                  Thread::get_hrtime(),
-                                                                  packet10->is_ack_eliciting(),
-                                                                  false,
-                                                                  true,
-                                                                  packet10->size(),
-                                                                  packet10->type(),
-                                                                  {},
-                                                                  pn_space}));
+    QUICSentPacketInfoUPtr packet_info = nullptr;
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet1->packet_number(),
+                                                                          packet1->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet1->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet1->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet2->packet_number(),
+                                                                          packet2->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet2->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet2->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet3->packet_number(),
+                                                                          packet3->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet3->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet3->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet4->packet_number(),
+                                                                          packet4->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet4->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet4->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet5->packet_number(),
+                                                                          packet5->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet5->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet5->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet6->packet_number(),
+                                                                          packet6->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet6->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet6->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet7->packet_number(),
+                                                                          packet6->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet7->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet7->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet8->packet_number(),
+                                                                          packet6->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet8->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet8->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet9->packet_number(),
+                                                                          packet6->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet9->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet9->type(),
+                                                                          {},
+                                                                          pn_space}));
+    detector.on_packet_sent(QUICSentPacketInfoUPtr(new QUICSentPacketInfo{packet10->packet_number(),
+                                                                          packet10->is_ack_eliciting(),
+                                                                          true,
+                                                                          packet10->size(),
+                                                                          Thread::get_hrtime(),
+                                                                          packet10->type(),
+                                                                          {},
+                                                                          pn_space}));
 
     ink_hrtime_sleep(HRTIME_MSECONDS(2000));
     // Receive an ACK for (1) (4) (5) (7) (8) (9)

--- a/iocore/net/quic/test/test_QUICPacketFactory.cc
+++ b/iocore/net/quic/test/test_QUICPacketFactory.cc
@@ -37,7 +37,7 @@ TEST_CASE("QUICPacketFactory_Create_VersionNegotiationPacket", "[quic]")
   QUICConnectionId dcid(raw_dcid, 8);
   QUICConnectionId scid(raw_scid, 8);
 
-  QUICPacketUPtr packet = factory.create_version_negotiation_packet(scid, dcid);
+  QUICPacketUPtr packet = factory.create_version_negotiation_packet(scid, dcid, QUIC_EXERCISE_VERSION1);
   REQUIRE(packet != nullptr);
 
   QUICVersionNegotiationPacket &vn_packet = static_cast<QUICVersionNegotiationPacket &>(*packet);
@@ -56,8 +56,9 @@ TEST_CASE("QUICPacketFactory_Create_VersionNegotiationPacket", "[quic]")
     0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, // Destination Connection ID
     0x08,                                           // SCID Len
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // Source Connection ID
+    0xff, 0x00, 0x00, 0x1d,                         // Supported Version
     0xff, 0x00, 0x00, 0x1b,                         // Supported Version
-    0x1a, 0x2a, 0x3a, 0x4a,                         // Exercise Version
+    0x5a, 0x6a, 0x7a, 0x8a,                         // Exercise Version
   };
   uint8_t buf[1024] = {0};
   size_t buf_len;
@@ -75,9 +76,9 @@ TEST_CASE("QUICPacketFactory_Create_Retry", "[quic]")
   uint8_t raw[] = {0xaa, 0xbb, 0xcc, 0xdd};
   QUICRetryToken token(raw, 4);
 
-  QUICPacketUPtr packet =
-    factory.create_retry_packet(QUICConnectionId(reinterpret_cast<const uint8_t *>("\x01\x02\x03\x04"), 4),
-                                QUICConnectionId(reinterpret_cast<const uint8_t *>("\x11\x12\x13\x14"), 4), token);
+  QUICPacketUPtr packet = factory.create_retry_packet(
+    QUIC_SUPPORTED_VERSIONS[0], QUICConnectionId(reinterpret_cast<const uint8_t *>("\x01\x02\x03\x04"), 4),
+    QUICConnectionId(reinterpret_cast<const uint8_t *>("\x11\x12\x13\x14"), 4), token);
 
   REQUIRE(packet != nullptr);
 

--- a/iocore/net/quic/test/test_QUICPacketHeaderProtector.cc
+++ b/iocore/net/quic/test/test_QUICPacketHeaderProtector.cc
@@ -26,6 +26,8 @@
 #include "QUICPacketProtectionKeyInfo.h"
 #include "QUICPacketHeaderProtector.h"
 #include "QUICTLS.h"
+#include "QUICGlobals.h"
+#include "Mock.h"
 
 struct PollCont;
 #include "P_UDPConnection.h"
@@ -87,8 +89,10 @@ TEST_CASE("QUICPacketHeaderProtector")
     QUICHandshakeProtocol *client = new QUICTLS(pp_key_info_client, client_ssl_ctx, NET_VCONNECTION_OUT, netvc_options);
     QUICHandshakeProtocol *server = new QUICTLS(pp_key_info_server, server_ssl_ctx, NET_VCONNECTION_IN, netvc_options);
 
-    CHECK(client->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8}));
-    CHECK(server->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8}));
+    CHECK(client->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8},
+                                           QUIC_SUPPORTED_VERSIONS[0]));
+    CHECK(server->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8},
+                                           QUIC_SUPPORTED_VERSIONS[0]));
 
     QUICPacketHeaderProtector client_ph_protector(pp_key_info_client);
     QUICPacketHeaderProtector server_ph_protector(pp_key_info_server);
@@ -121,8 +125,12 @@ TEST_CASE("QUICPacketHeaderProtector")
     QUICPacketProtectionKeyInfo pp_key_info_client;
     QUICPacketProtectionKeyInfo pp_key_info_server;
     NetVCOptions netvc_options;
+    MockQUICConnection mock_client_connection;
+    MockQUICConnection mock_server_connection;
     QUICHandshakeProtocol *client = new QUICTLS(pp_key_info_client, client_ssl_ctx, NET_VCONNECTION_OUT, netvc_options);
     QUICHandshakeProtocol *server = new QUICTLS(pp_key_info_server, server_ssl_ctx, NET_VCONNECTION_IN, netvc_options);
+    SSL_set_ex_data(static_cast<QUICTLS *>(client)->ssl_handle(), QUIC::ssl_quic_qc_index, &mock_client_connection);
+    SSL_set_ex_data(static_cast<QUICTLS *>(server)->ssl_handle(), QUIC::ssl_quic_qc_index, &mock_server_connection);
 
     auto client_tp = std::make_shared<QUICTransportParametersInClientHello>();
     auto server_tp = std::make_shared<QUICTransportParametersInEncryptedExtensions>();
@@ -131,8 +139,10 @@ TEST_CASE("QUICPacketHeaderProtector")
     client->set_local_transport_parameters(client_tp);
     server->set_local_transport_parameters(server_tp);
 
-    CHECK(client->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8}));
-    CHECK(server->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8}));
+    CHECK(client->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8},
+                                           QUIC_SUPPORTED_VERSIONS[0]));
+    CHECK(server->initialize_key_materials({reinterpret_cast<const uint8_t *>("\x83\x94\xc8\xf0\x3e\x51\x57\x00"), 8},
+                                           QUIC_SUPPORTED_VERSIONS[0]));
 
     QUICPacketHeaderProtector client_ph_protector(pp_key_info_client);
     QUICPacketHeaderProtector server_ph_protector(pp_key_info_server);

--- a/iocore/net/quic/test/test_QUICStreamManager.cc
+++ b/iocore/net/quic/test/test_QUICStreamManager.cc
@@ -47,7 +47,7 @@ TEST_CASE("QUICStreamManager_NewStream", "[quic]")
     0x40, 0x10 // value
   };
   std::shared_ptr<QUICTransportParameters> local_tp =
-    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf));
+    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   uint8_t remote_tp_buf[] = {
     0x08,      // parameter id - initial_max_streams_bidi
@@ -55,7 +55,7 @@ TEST_CASE("QUICStreamManager_NewStream", "[quic]")
     0x40, 0x10 // value
   };
   std::shared_ptr<QUICTransportParameters> remote_tp =
-    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf));
+    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   sm.init_flow_control_params(local_tp, remote_tp);
 
@@ -139,7 +139,7 @@ TEST_CASE("QUICStreamManager_total_offset_received", "[quic]")
     0xbf, 0xff, 0xff, 0xff // value
   };
   std::shared_ptr<QUICTransportParameters> local_tp =
-    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf));
+    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   uint8_t remote_tp_buf[] = {
     0x08,                  // parameter id - initial_max_streams_bidi
@@ -150,7 +150,7 @@ TEST_CASE("QUICStreamManager_total_offset_received", "[quic]")
     0xbf, 0xff, 0xff, 0xff // value
   };
   std::shared_ptr<QUICTransportParameters> remote_tp =
-    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf));
+    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   sm.init_flow_control_params(local_tp, remote_tp);
 
@@ -194,7 +194,7 @@ TEST_CASE("QUICStreamManager_total_offset_sent", "[quic]")
     0xbf, 0xff, 0xff, 0xff // value
   };
   std::shared_ptr<QUICTransportParameters> local_tp =
-    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf));
+    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   uint8_t remote_tp_buf[] = {
     0x08,                  // parameter id - initial_max_streams_bidi
@@ -205,7 +205,7 @@ TEST_CASE("QUICStreamManager_total_offset_sent", "[quic]")
     0xbf, 0xff, 0xff, 0xff // value
   };
   std::shared_ptr<QUICTransportParameters> remote_tp =
-    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf));
+    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   sm.init_flow_control_params(local_tp, remote_tp);
 
@@ -262,7 +262,7 @@ TEST_CASE("QUICStreamManager_max_streams", "[quic]")
     0x03, // value
   };
   std::shared_ptr<QUICTransportParameters> local_tp =
-    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf));
+    std::make_shared<QUICTransportParametersInEncryptedExtensions>(local_tp_buf, sizeof(local_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   uint8_t remote_tp_buf[] = {
     0x08, // parameter id - initial_max_streams_bidi
@@ -273,7 +273,7 @@ TEST_CASE("QUICStreamManager_max_streams", "[quic]")
     0x03, // value
   };
   std::shared_ptr<QUICTransportParameters> remote_tp =
-    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf));
+    std::make_shared<QUICTransportParametersInClientHello>(remote_tp_buf, sizeof(remote_tp_buf), QUIC_SUPPORTED_VERSIONS[0]);
 
   sm.init_flow_control_params(local_tp, remote_tp);
 

--- a/iocore/net/quic/test/test_QUICTransportParameters.cc
+++ b/iocore/net/quic/test/test_QUICTransportParameters.cc
@@ -44,13 +44,13 @@ TEST_CASE("QUICTransportParametersInClientHello_read", "[quic]")
       0x05, 0x67,             // value
     };
 
-    QUICTransportParametersInClientHello params_in_ch(buf, sizeof(buf));
+    QUICTransportParametersInClientHello params_in_ch(buf, sizeof(buf), QUIC_SUPPORTED_VERSIONS[0]);
     CHECK(params_in_ch.is_valid());
 
     uint16_t len        = 0;
     const uint8_t *data = nullptr;
 
-    data = params_in_ch.getAsBytes(QUICTransportParameterId::ORIGINAL_CONNECTION_ID, len);
+    data = params_in_ch.getAsBytes(QUICTransportParameterId::ORIGINAL_DESTINATION_CONNECTION_ID, len);
     CHECK(len == 4);
     CHECK(memcmp(data, "\x11\x22\x33\x44", 4) == 0);
 
@@ -62,7 +62,7 @@ TEST_CASE("QUICTransportParametersInClientHello_read", "[quic]")
     CHECK(len == 2);
     CHECK(memcmp(data, "\x0a\x0b", 2) == 0);
 
-    data = params_in_ch.getAsBytes(QUICTransportParameterId::MAX_PACKET_SIZE, len);
+    data = params_in_ch.getAsBytes(QUICTransportParameterId::MAX_UDP_PAYLOAD_SIZE, len);
     CHECK(len == 2);
     CHECK(memcmp(data, "\x05\x67", 2) == 0);
 
@@ -82,7 +82,7 @@ TEST_CASE("QUICTransportParametersInClientHello_read", "[quic]")
       0x12, 0x34, 0x56, 0x78, // value
     };
 
-    QUICTransportParametersInClientHello params_in_ch(buf, sizeof(buf));
+    QUICTransportParametersInClientHello params_in_ch(buf, sizeof(buf), QUIC_SUPPORTED_VERSIONS[0]);
     CHECK(!params_in_ch.is_valid());
   }
 }
@@ -111,7 +111,7 @@ TEST_CASE("QUICTransportParametersInClientHello_write", "[quic]")
   params_in_ch.set(QUICTransportParameterId::INITIAL_MAX_STREAM_DATA_BIDI_LOCAL, max_stream_data);
 
   uint16_t max_packet_size = 0x1bcd;
-  params_in_ch.set(QUICTransportParameterId::MAX_PACKET_SIZE, max_packet_size);
+  params_in_ch.set(QUICTransportParameterId::MAX_UDP_PAYLOAD_SIZE, max_packet_size);
 
   uint8_t stateless_reset_token[16] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
@@ -142,7 +142,7 @@ TEST_CASE("QUICTransportParametersInEncryptedExtensions_read", "[quic]")
       0x91, 0x22, 0x33, 0x44, // value
     };
 
-    QUICTransportParametersInEncryptedExtensions params_in_ee(buf, sizeof(buf));
+    QUICTransportParametersInEncryptedExtensions params_in_ee(buf, sizeof(buf), QUIC_SUPPORTED_VERSIONS[0]);
     CHECK(params_in_ee.is_valid());
 
     uint16_t len        = 0;
@@ -183,7 +183,7 @@ TEST_CASE("QUICTransportParametersInEncryptedExtensions_read", "[quic]")
       0x00,                   // length of value
     };
 
-    QUICTransportParametersInEncryptedExtensions params_in_ee(buf, sizeof(buf));
+    QUICTransportParametersInEncryptedExtensions params_in_ee(buf, sizeof(buf), QUIC_SUPPORTED_VERSIONS[0]);
     CHECK(params_in_ee.is_valid());
 
     uint16_t len        = 0;
@@ -215,7 +215,7 @@ TEST_CASE("QUICTransportParametersInEncryptedExtensions_read", "[quic]")
       0x12, 0x34, 0x56, 0x78, // value
     };
 
-    QUICTransportParametersInEncryptedExtensions params_in_ee(buf, sizeof(buf));
+    QUICTransportParametersInEncryptedExtensions params_in_ee(buf, sizeof(buf), QUIC_SUPPORTED_VERSIONS[0]);
     CHECK(!params_in_ee.is_valid());
   }
 }
@@ -242,10 +242,8 @@ TEST_CASE("QUICTransportParametersEncryptedExtensions_write", "[quic]")
     params_in_ee.set(QUICTransportParameterId::INITIAL_MAX_STREAM_DATA_BIDI_REMOTE, max_stream_data);
 
     uint16_t max_packet_size = 0x1bcd;
-    params_in_ee.set(QUICTransportParameterId::MAX_PACKET_SIZE, max_packet_size);
+    params_in_ee.set(QUICTransportParameterId::MAX_UDP_PAYLOAD_SIZE, max_packet_size);
 
-    params_in_ee.add_version(0x01020304);
-    params_in_ee.add_version(0x05060708);
     params_in_ee.store(buf, &len);
     CHECK(len == 10);
     CHECK(memcmp(buf, expected, len) == 0);
@@ -273,11 +271,9 @@ TEST_CASE("QUICTransportParametersEncryptedExtensions_write", "[quic]")
     params_in_ee.set(QUICTransportParameterId::INITIAL_MAX_STREAM_DATA_BIDI_REMOTE, max_stream_data);
 
     uint16_t max_packet_size = 0x1bcd;
-    params_in_ee.set(QUICTransportParameterId::MAX_PACKET_SIZE, max_packet_size);
+    params_in_ee.set(QUICTransportParameterId::MAX_UDP_PAYLOAD_SIZE, max_packet_size);
     params_in_ee.set(QUICTransportParameterId::DISABLE_ACTIVE_MIGRATION, nullptr, 0);
 
-    params_in_ee.add_version(0x01020304);
-    params_in_ee.add_version(0x05060708);
     params_in_ee.store(buf, &len);
     CHECK(len == 12);
     CHECK(memcmp(buf, expected, len) == 0);

--- a/iocore/net/quic/test/test_QUICType.cc
+++ b/iocore/net/quic/test/test_QUICType.cc
@@ -103,11 +103,14 @@ TEST_CASE("QUICType", "[quic]")
     IpEndpoint ep;
     ats_ip4_set(&ep, 0x04030201, 0x2211);
 
-    uint8_t cid_buf[] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
-                         0x19, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27};
-    QUICConnectionId cid(cid_buf, sizeof(cid_buf));
+    uint8_t cid1_buf[] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+                          0x19, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27};
+    QUICConnectionId cid1(cid1_buf, sizeof(cid1_buf));
+    uint8_t cid2_buf[] = {0xA0, 0xA1, 0x12, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8,
+                          0xA9, 0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7};
+    QUICConnectionId cid2(cid2_buf, sizeof(cid2_buf));
 
-    QUICRetryToken token1(ep, cid);
+    QUICRetryToken token1(ep, cid1, cid2);
     QUICRetryToken token2(token1.buf(), token1.length());
 
     CHECK(token1.is_valid(ep));
@@ -118,6 +121,7 @@ TEST_CASE("QUICType", "[quic]")
     CHECK(token1.length() == token2.length());
     CHECK(memcmp(token1.buf(), token2.buf(), token1.length()) == 0);
     CHECK(token1.original_dcid() == token2.original_dcid());
+    CHECK(token1.scid() == token2.scid());
   }
 
   SECTION("QUICResumptionToken")

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -38,39 +38,45 @@ SessionProtocolNameRegistry globalSessionProtocolNameRegistry;
    These are also used for NPN setup.
 */
 
-const char *const TS_ALPN_PROTOCOL_HTTP_0_9  = IP_PROTO_TAG_HTTP_0_9.data();
-const char *const TS_ALPN_PROTOCOL_HTTP_1_0  = IP_PROTO_TAG_HTTP_1_0.data();
-const char *const TS_ALPN_PROTOCOL_HTTP_1_1  = IP_PROTO_TAG_HTTP_1_1.data();
-const char *const TS_ALPN_PROTOCOL_HTTP_2_0  = IP_PROTO_TAG_HTTP_2_0.data();
-const char *const TS_ALPN_PROTOCOL_HTTP_3    = IP_PROTO_TAG_HTTP_3.data();
-const char *const TS_ALPN_PROTOCOL_HTTP_QUIC = IP_PROTO_TAG_HTTP_QUIC.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_0_9      = IP_PROTO_TAG_HTTP_0_9.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_0      = IP_PROTO_TAG_HTTP_1_0.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_1_1      = IP_PROTO_TAG_HTTP_1_1.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_2_0      = IP_PROTO_TAG_HTTP_2_0.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_3        = IP_PROTO_TAG_HTTP_3.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_QUIC     = IP_PROTO_TAG_HTTP_QUIC.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_3_D27    = IP_PROTO_TAG_HTTP_3_D27.data();
+const char *const TS_ALPN_PROTOCOL_HTTP_QUIC_D27 = IP_PROTO_TAG_HTTP_QUIC_D27.data();
 
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP  = "http";
 const char *const TS_ALPN_PROTOCOL_GROUP_HTTP2 = "http2";
 
-const char *const TS_PROTO_TAG_HTTP_1_0  = TS_ALPN_PROTOCOL_HTTP_1_0;
-const char *const TS_PROTO_TAG_HTTP_1_1  = TS_ALPN_PROTOCOL_HTTP_1_1;
-const char *const TS_PROTO_TAG_HTTP_2_0  = TS_ALPN_PROTOCOL_HTTP_2_0;
-const char *const TS_PROTO_TAG_HTTP_3    = TS_ALPN_PROTOCOL_HTTP_3;
-const char *const TS_PROTO_TAG_HTTP_QUIC = TS_ALPN_PROTOCOL_HTTP_QUIC;
-const char *const TS_PROTO_TAG_TLS_1_3   = IP_PROTO_TAG_TLS_1_3.data();
-const char *const TS_PROTO_TAG_TLS_1_2   = IP_PROTO_TAG_TLS_1_2.data();
-const char *const TS_PROTO_TAG_TLS_1_1   = IP_PROTO_TAG_TLS_1_1.data();
-const char *const TS_PROTO_TAG_TLS_1_0   = IP_PROTO_TAG_TLS_1_0.data();
-const char *const TS_PROTO_TAG_TCP       = IP_PROTO_TAG_TCP.data();
-const char *const TS_PROTO_TAG_UDP       = IP_PROTO_TAG_UDP.data();
-const char *const TS_PROTO_TAG_IPV4      = IP_PROTO_TAG_IPV4.data();
-const char *const TS_PROTO_TAG_IPV6      = IP_PROTO_TAG_IPV6.data();
+const char *const TS_PROTO_TAG_HTTP_1_0      = TS_ALPN_PROTOCOL_HTTP_1_0;
+const char *const TS_PROTO_TAG_HTTP_1_1      = TS_ALPN_PROTOCOL_HTTP_1_1;
+const char *const TS_PROTO_TAG_HTTP_2_0      = TS_ALPN_PROTOCOL_HTTP_2_0;
+const char *const TS_PROTO_TAG_HTTP_3        = TS_ALPN_PROTOCOL_HTTP_3;
+const char *const TS_PROTO_TAG_HTTP_QUIC     = TS_ALPN_PROTOCOL_HTTP_QUIC;
+const char *const TS_PROTO_TAG_HTTP_3_D27    = TS_ALPN_PROTOCOL_HTTP_3_D27;
+const char *const TS_PROTO_TAG_HTTP_QUIC_D27 = TS_ALPN_PROTOCOL_HTTP_QUIC_D27;
+const char *const TS_PROTO_TAG_TLS_1_3       = IP_PROTO_TAG_TLS_1_3.data();
+const char *const TS_PROTO_TAG_TLS_1_2       = IP_PROTO_TAG_TLS_1_2.data();
+const char *const TS_PROTO_TAG_TLS_1_1       = IP_PROTO_TAG_TLS_1_1.data();
+const char *const TS_PROTO_TAG_TLS_1_0       = IP_PROTO_TAG_TLS_1_0.data();
+const char *const TS_PROTO_TAG_TCP           = IP_PROTO_TAG_TCP.data();
+const char *const TS_PROTO_TAG_UDP           = IP_PROTO_TAG_UDP.data();
+const char *const TS_PROTO_TAG_IPV4          = IP_PROTO_TAG_IPV4.data();
+const char *const TS_PROTO_TAG_IPV6          = IP_PROTO_TAG_IPV6.data();
 
 std::unordered_set<std::string_view> TSProtoTags;
 
 // Precomputed indices for ease of use.
-int TS_ALPN_PROTOCOL_INDEX_HTTP_0_9  = SessionProtocolNameRegistry::INVALID;
-int TS_ALPN_PROTOCOL_INDEX_HTTP_1_0  = SessionProtocolNameRegistry::INVALID;
-int TS_ALPN_PROTOCOL_INDEX_HTTP_1_1  = SessionProtocolNameRegistry::INVALID;
-int TS_ALPN_PROTOCOL_INDEX_HTTP_2_0  = SessionProtocolNameRegistry::INVALID;
-int TS_ALPN_PROTOCOL_INDEX_HTTP_3    = SessionProtocolNameRegistry::INVALID;
-int TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_0_9      = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_1_0      = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_1_1      = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_2_0      = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_3        = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC     = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_3_D27    = SessionProtocolNameRegistry::INVALID;
+int TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC_D27 = SessionProtocolNameRegistry::INVALID;
 
 // Predefined protocol sets for ease of use.
 SessionProtocolSet HTTP_PROTOCOL_SET;
@@ -703,12 +709,15 @@ void
 ts_session_protocol_well_known_name_indices_init()
 {
   // register all the well known protocols and get the indices set.
-  TS_ALPN_PROTOCOL_INDEX_HTTP_0_9  = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_0_9});
-  TS_ALPN_PROTOCOL_INDEX_HTTP_1_0  = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_1_0});
-  TS_ALPN_PROTOCOL_INDEX_HTTP_1_1  = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_1_1});
-  TS_ALPN_PROTOCOL_INDEX_HTTP_2_0  = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_2_0});
-  TS_ALPN_PROTOCOL_INDEX_HTTP_3    = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_3});
-  TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_QUIC});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_0_9   = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_0_9});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_1_0   = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_1_0});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_1_1   = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_1_1});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_2_0   = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_2_0});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_3     = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_3});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_3_D27 = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_3_D27});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC  = globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_QUIC});
+  TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC_D27 =
+    globalSessionProtocolNameRegistry.toIndexConst(std::string_view{TS_ALPN_PROTOCOL_HTTP_QUIC_D27});
 
   // Now do the predefined protocol sets.
   HTTP_PROTOCOL_SET.markIn(TS_ALPN_PROTOCOL_INDEX_HTTP_0_9);
@@ -722,6 +731,8 @@ ts_session_protocol_well_known_name_indices_init()
 
   DEFAULT_QUIC_SESSION_PROTOCOL_SET.markIn(TS_ALPN_PROTOCOL_INDEX_HTTP_3);
   DEFAULT_QUIC_SESSION_PROTOCOL_SET.markIn(TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC);
+  DEFAULT_QUIC_SESSION_PROTOCOL_SET.markIn(TS_ALPN_PROTOCOL_INDEX_HTTP_3_D27);
+  DEFAULT_QUIC_SESSION_PROTOCOL_SET.markIn(TS_ALPN_PROTOCOL_INDEX_HTTP_QUIC_D27);
 
   DEFAULT_NON_TLS_SESSION_PROTOCOL_SET = HTTP_PROTOCOL_SET;
 
@@ -730,6 +741,8 @@ ts_session_protocol_well_known_name_indices_init()
   TSProtoTags.insert(TS_PROTO_TAG_HTTP_2_0);
   TSProtoTags.insert(TS_PROTO_TAG_HTTP_3);
   TSProtoTags.insert(TS_PROTO_TAG_HTTP_QUIC);
+  TSProtoTags.insert(TS_PROTO_TAG_HTTP_3_D27);
+  TSProtoTags.insert(TS_PROTO_TAG_HTTP_QUIC_D27);
   TSProtoTags.insert(TS_PROTO_TAG_TLS_1_3);
   TSProtoTags.insert(TS_PROTO_TAG_TLS_1_2);
   TSProtoTags.insert(TS_PROTO_TAG_TLS_1_1);

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1442,9 +1442,9 @@ static const RecordElement RecordsConfig[] =
   // Constatns of Congestion Control
   {RECT_CONFIG, "proxy.config.quic.congestion_control.max_datagram_size", RECD_INT, "1200", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.quic.congestion_control.initial_window_scale", RECD_INT, "10", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.quic.congestion_control.initial_window", RECD_INT, "12000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.quic.congestion_control.minimum_window_scale", RECD_INT, "2", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.quic.congestion_control.minimum_window", RECD_INT, "2400", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.quic.congestion_control.loss_reduction_factor", RECD_FLOAT, "0.5", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[\\.0-9]+$", RECA_NULL}
   ,

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -238,6 +238,12 @@ MakeHttpProxyAcceptor(HttpProxyAcceptor &acceptor, HttpProxyPort &port, unsigned
 
     quic->enableProtocols(port.m_session_protocol_preference);
 
+    // HTTP/0.9 over QUIC draft-27 (for interop only, will be removed)
+    quic->registerEndpoint(TS_ALPN_PROTOCOL_HTTP_QUIC_D27, new Http3SessionAccept(accept_opt));
+
+    // HTTP/3 draft-27
+    quic->registerEndpoint(TS_ALPN_PROTOCOL_HTTP_3_D27, new Http3SessionAccept(accept_opt));
+
     // HTTP/0.9 over QUIC (for interop only, will be removed)
     quic->registerEndpoint(TS_ALPN_PROTOCOL_HTTP_QUIC, new Http3SessionAccept(accept_opt));
 

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -32,7 +32,7 @@ class HQSession : public ProxySession
 public:
   using super = ProxySession; ///< Parent type
 
-  HQSession(NetVConnection *vc) : ProxySession(vc){};
+  HQSession(NetVConnection *vc);
   virtual ~HQSession();
 
   // Implement VConnection interface
@@ -43,6 +43,8 @@ public:
   void reenable(VIO *vio) override;
 
   // Implement ProxySession interface
+  const char *get_protocol_string() const override;
+  int populate_protocol(std::string_view *result, int size) const override;
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override;
   void start() override;
   void destroy() override;
@@ -56,6 +58,8 @@ public:
 private:
   // this should be unordered map?
   Queue<HQTransaction> _transaction_list;
+
+  char _protocol_string[16];
 };
 
 class Http3Session : public HQSession
@@ -67,8 +71,6 @@ public:
   ~Http3Session();
 
   // ProxySession interface
-  const char *get_protocol_string() const override;
-  int populate_protocol(std::string_view *result, int size) const override;
   void increment_current_active_client_connections_stat() override;
   void decrement_current_active_client_connections_stat() override;
 
@@ -92,8 +94,6 @@ public:
   ~Http09Session();
 
   // ProxySession interface
-  const char *get_protocol_string() const override;
-  int populate_protocol(std::string_view *result, int size) const override;
   void increment_current_active_client_connections_stat() override;
   void decrement_current_active_client_connections_stat() override;
 

--- a/proxy/http3/Http3SessionAccept.cc
+++ b/proxy/http3/Http3SessionAccept.cc
@@ -62,16 +62,16 @@ Http3SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
 
   std::string_view alpn = qvc->negotiated_application_name();
 
-  if (alpn.empty() || IP_PROTO_TAG_HTTP_QUIC.compare(alpn) == 0) {
+  if (alpn.empty() || IP_PROTO_TAG_HTTP_QUIC.compare(alpn) == 0 || IP_PROTO_TAG_HTTP_QUIC_D27.compare(alpn) == 0) {
     if (alpn.empty()) {
       Debug("http3", "[%s] start HTTP/0.9 app (ALPN=null)", qvc->cids().data());
     } else {
-      Debug("http3", "[%s] start HTTP/0.9 app (ALPN=%s)", qvc->cids().data(), IP_PROTO_TAG_HTTP_QUIC.data());
+      Debug("http3", "[%s] start HTTP/0.9 app (ALPN=%.*s)", qvc->cids().data(), static_cast<int>(alpn.length()), alpn.data());
     }
 
     new Http09App(qvc, std::move(session_acl), this->options);
-  } else if (IP_PROTO_TAG_HTTP_3.compare(alpn) == 0) {
-    Debug("http3", "[%s] start HTTP/3 app (ALPN=%s)", qvc->cids().data(), IP_PROTO_TAG_HTTP_3.data());
+  } else if (IP_PROTO_TAG_HTTP_3.compare(alpn) == 0 || IP_PROTO_TAG_HTTP_3_D27.compare(alpn) == 0) {
+    Debug("http3", "[%s] start HTTP/3 app (ALPN=%.*s)", qvc->cids().data(), static_cast<int>(alpn.length()), alpn.data());
 
     Http3App *app = new Http3App(qvc, std::move(session_acl), this->options);
     app->start();

--- a/src/traffic_quic/quic_client.cc
+++ b/src/traffic_quic/quic_client.cc
@@ -34,8 +34,8 @@
 // https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_alpn_protos.html
 // Should be integrate with IP_PROTO_TAG_HTTP_QUIC in ts/ink_inet.h ?
 using namespace std::literals;
-static constexpr std::string_view HQ_ALPN_PROTO_LIST("\5hq-27"sv);
-static constexpr std::string_view H3_ALPN_PROTO_LIST("\5h3-27"sv);
+static constexpr std::string_view HQ_ALPN_PROTO_LIST("\5hq-29\5hq-27"sv);
+static constexpr std::string_view H3_ALPN_PROTO_LIST("\5h3-29\5h3-27"sv);
 
 QUICClient::QUICClient(const QUICClientConfig *config) : Continuation(new_ProxyMutex()), _config(config)
 {

--- a/src/tscore/ink_inet.cc
+++ b/src/tscore/ink_inet.cc
@@ -49,9 +49,11 @@ const std::string_view IP_PROTO_TAG_TLS_1_3("tls/1.3"sv);
 const std::string_view IP_PROTO_TAG_HTTP_0_9("http/0.9"sv);
 const std::string_view IP_PROTO_TAG_HTTP_1_0("http/1.0"sv);
 const std::string_view IP_PROTO_TAG_HTTP_1_1("http/1.1"sv);
-const std::string_view IP_PROTO_TAG_HTTP_2_0("h2"sv);     // HTTP/2 over TLS
-const std::string_view IP_PROTO_TAG_HTTP_QUIC("hq-27"sv); // HTTP/0.9 over QUIC
-const std::string_view IP_PROTO_TAG_HTTP_3("h3-27"sv);    // HTTP/3 over QUIC
+const std::string_view IP_PROTO_TAG_HTTP_2_0("h2"sv);         // HTTP/2 over TLS
+const std::string_view IP_PROTO_TAG_HTTP_QUIC("hq-29"sv);     // HTTP/0.9 over QUIC
+const std::string_view IP_PROTO_TAG_HTTP_3("h3-29"sv);        // HTTP/3 over QUIC
+const std::string_view IP_PROTO_TAG_HTTP_QUIC_D27("hq-27"sv); // HTTP/0.9 over QUIC (draft-27)
+const std::string_view IP_PROTO_TAG_HTTP_3_D27("h3-27"sv);    // HTTP/3 over QUIC (draft-27)
 
 const std::string_view UNIX_PROTO_TAG{"unix"sv};
 


### PR DESCRIPTION
About 2 months ago I said draft-29 would be available on 9.1.0, but we haven't had any RC for 9.0 yet so we may want to add draft-29 support to 9.0.

Supporting only draft-27 on 9.0 would make less sense in a few months because the latest is draft-29 and it's a kind of LTS version. Clients would drop draft-27 support and have draft-29 and above in near future.

Our draft-29 support has not been tested as much as draft-27 support in terms of interop, but it would probably be worth to take the small risk rather than completely losing compatible clients.

This PR literally adds draft-29 support, so both 27 and 29 would be supported. And it's an important change because it enables ATS to support 29 plus a later (or the final) version in the future.


Squashed commit of the following:

commit 4d579f49a21ca5ab5389d2edd3d225883c69743a
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Aug 13 08:32:58 2020 +0900

    Fix docs

commit 8c114c0eeb1096859228f6272a214d92d41f3c73
Merge: f39e3977f b52746404
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Aug 13 07:31:56 2020 +0900

    Merge branch 'master' into quic-latest

    * master:
      Adding autopep8 as a pre-commit hook. (#7071)
      Refresh proxy protocol diagram (#7095)
      Skip docs builds if there are no changes in the doc dir and files it includes (#7088)
      Remove more deadcode (#7098)
      destroy threads after job done (#7083)
      Fix compilation error - missing '&' operator (#7093)
      Adds description for ssl_ticket_number in ssl_multicert docs (#7091)
      Ran clang-tidy over the source tree (#7077)
      Move the direct self loop check later to HttpSM::do_http_server_open just before connection upstream. (#7069)

commit f39e3977f05b1432c93d427f3f516e1d2febe423
Merge: d09a75792 2219cee51
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Aug 6 09:08:46 2020 +0900

    Merge branch 'master' into quic-latest

    * master:
      Signal WRITE_COMPLETE regardless of transmission progress (#7062)
      Converts files to #pragma once (#7089)
      Fix eval_ip compile - missing const. (#7087)
      Fix a crash on connection migration to the advertised preferred address (#7080)
      Update and run the autopep8 make target (#7070)
      Fixes no_content_length status code description in docs (#7086)
      const-ify quic/http3 code (#7084)
      Fixes build warnings in maxmind_acl (#7085)
      Add TS_USE_QUIC to traffic_layout info (#7074)
      Added support for out of tree builds with vscode (#7072)
      constify Print() methods and other low hanging fruit (#7068)
      Updating to AuTest 1.8.1. (#7065)
      Use system include-style for STL and OpenSSL headers (#7066)
      tests: gitignore ssl-delay-server binary (#7067)

     Conflicts:
    	iocore/net/quic/QUICLossDetector.cc
    	iocore/net/quic/QUICLossDetector.h

commit d09a757926f28b0af5a6be89b09f4e965e0ee963
Author: Randall Meyer <rrm@apache.org>
Date:   Tue Aug 4 13:52:53 2020 -0700

    const-ify quic/http3 code (#7079)

commit 84e4c8eb0b6d2e410b85c8c0eece2ffe83f8068b
Merge: 50937c097 3087f1642
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Fri Jul 31 10:24:13 2020 +0900

    Merge branch 'master' into quic-latest

    * master:
      Fix a crash on active timeout on QUIC connections (#7059)
      Don't make an error on receiving retransmitted handshake data (#7061)
      Document proxy.config.http.cache.post_method. (#7060)
      Quote out lists of servers and domains in splitdns.config example (#7057)
      Fix proxy.process.http.current_client_connections (#7056)
      Fixed CLIENT-URL to use the pristine client URL (#7050)
      Removes FIXME that is unlikely to be fixed at this point in the project history (#7058)
      Move to denylists and allowlists (#7034)
      Avoid unnecessary copying of STL map for QUICTPConfigQCP class. (#7039)

commit 50937c0976476f4f643181ab882e7e5ab7b5e7bd
Merge: f6e174414 9467a2c1c
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Tue Jul 28 10:08:26 2020 +0900

    Merge branch 'master' into quic-latest

    * master:
      Fixes spelling/license formatting in traffic_dump plugin (#7047)
      Fixes spelling in docs (#7048)
      Fixes spelling H3-related code (#7046)
      Cleans up various versions checks (#7049)
      Fix a typo (#7043)

     Conflicts:
    	iocore/net/quic/QUICHandshake.cc
    	iocore/net/quic/QUICLossDetector.cc
    	iocore/net/quic/QUICNewRenoCongestionController.cc
    	iocore/net/quic/test/test_QUICPacketFactory.cc

commit f6e17441438c9161a15ff913630363bdcc62ae85
Merge: 83e1da7ec 549c62605
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Mon Jul 27 11:11:58 2020 +0900

    Merge branch 'master' into quic-latest

    * master:
      Make tls_conn_timeout test more reliable in CI (#7018)
      Remove deprecated verify.server for 9.0 (#7040)
      Updated GitHub description and homepage URL to be https (#7019)
      Add virtual destructor to QUICTPConfig. (#7036)
      Fix code to eliminate warning and enable feature (#7031)
      add a null check to avoid crashing (#7035)
      Squashed commit of the following: (#7000)
      Fixed problem with all "forced" volumes cache (#7028)
      Spacing tweaks to acl_filter_rule::print (#7026)
      Removes dead code from iocore/dns (#7025)
      Removes TODO (#7027)
      Add logic to resolve content-length transfer-encoding conflicts on response (#6992)
      Add memory_profile plugin (#7014)
      Fix typos relating to tls_bridge (#7011)
      slice: clean up of created 502 response header (#6919)
      Add new API / TSPluginDSOReloadEnable that overrides the configuration variable `proxy.config.plugin.dynamic_reload_mode` for a particular plugin. (#6880)
      Remove incorrect assert in inactivity timeout handling (#7012)
      Removes use of SPLIT_DNS macro (#7010)
      Fixed core when sending back a redirect and having an invalid server response (#7004)
      slice: fix throttle not work (#7008)
      Updates to thread scale factor (#7007)
      Added tasks and launch files for vscode, to configure, build and debug (#7005)
      NextHop Strategy Refactor and Fixes (#6782)
      Make the setting of the continuation handler safer. (#6996)
      ProtocolStack n -> count (#7006)
      Fix volume/stripe calcs when using forced volumes (#6995)
      Cleanup: Write error message on diags output instead of stderr (#6997)

     Conflicts:
    	iocore/net/P_QUICNetVConnection.h
    	iocore/net/P_QUICPacketHandler.h
    	iocore/net/QUICNetProcessor.cc
    	iocore/net/QUICNetVConnection.cc
    	iocore/net/QUICPacketHandler.cc
    	iocore/net/quic/Mock.h
    	iocore/net/quic/QUICCongestionController.h
    	iocore/net/quic/QUICContext.cc
    	iocore/net/quic/QUICContext.h
    	iocore/net/quic/QUICDebugNames.cc
    	iocore/net/quic/QUICFrame.cc
    	iocore/net/quic/QUICHandshake.cc
    	iocore/net/quic/QUICKeyGenerator.h
    	iocore/net/quic/QUICLossDetector.cc
    	iocore/net/quic/QUICLossDetector.h
    	iocore/net/quic/QUICNewRenoCongestionController.cc
    	iocore/net/quic/QUICPacket.cc
    	iocore/net/quic/QUICPacket.h
    	iocore/net/quic/QUICPacketFactory.cc
    	iocore/net/quic/QUICPacketFactory.h
    	iocore/net/quic/QUICRetryIntegrityTag.cc
    	iocore/net/quic/QUICRetryIntegrityTag.h
    	iocore/net/quic/QUICTLS.h
    	iocore/net/quic/QUICTLS_boringssl.cc
    	iocore/net/quic/QUICTLS_openssl.cc
    	iocore/net/quic/QUICTransportParameters.cc
    	iocore/net/quic/QUICTransportParameters.h
    	iocore/net/quic/QUICTypes.cc
    	iocore/net/quic/QUICTypes.h
    	iocore/net/quic/qlog/QLogListener.h
    	iocore/net/quic/test/test_QUICHandshakeProtocol.cc
    	iocore/net/quic/test/test_QUICLossDetector.cc
    	iocore/net/quic/test/test_QUICPacket.cc
    	iocore/net/quic/test/test_QUICPacketFactory.cc
    	iocore/net/quic/test/test_QUICPacketHeaderProtector.cc
    	iocore/net/quic/test/test_QUICStreamManager.cc
    	iocore/net/quic/test/test_QUICVersionNegotiator.cc
    	proxy/http/HttpProxyServerMain.cc
    	src/traffic_quic/quic_client.cc
    	src/tscore/ink_inet.cc

commit 83e1da7ecca7979d6fbfe498804363e478733941
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Wed Jul 22 23:26:56 2020 +0900

    Fix a crash on path validation

commit c74bd89603739bb4f3ac07e462293c4f96f65506
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Wed Jul 22 23:19:05 2020 +0900

    Fix a crash on traffic_quic

commit b4a0c8cdb6762c38831135c702f975cdf0836db7
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Wed Jul 22 16:37:02 2020 +0900

    Update Congestion Control logic to draft-29

commit 53da24017791e12f3a5c400f2c5058645e336b0d
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Wed Jul 22 11:40:18 2020 +0900

    Adjust debug log verbosity

commit 92a34b0186535292408ba40b1db0eac3069bfa2a
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Tue Jul 21 12:04:00 2020 +0900

    Fix infinite PING

commit 42c4054b9280618ba5d8a6b90b5eb16aa194003a
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Jul 9 10:16:04 2020 +0900

    Update Loss Detection logic to draft-29

commit e8109c0ba6bd643d9efd11acf617e4234dd784df
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Fri Jun 26 10:57:42 2020 +0900

    Update tests

commit 3a8cb4ac985a3745e565a3824c37d2b437af2abe
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Jun 25 14:58:47 2020 +0900

    Use different keys and nonces for Draft-27 and Draft-29

commit 37af6254f67633c59a46770b78d599195647b657
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Jun 25 14:14:57 2020 +0900

    Use different salts for Draft-27 and Draft-29

commit 52e57fe283308dcb3979a900c06f2afe02f97314
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Mon Jun 22 11:53:43 2020 +0900

    Rename SERVER_BUSY to CONNECTION_REFUSED

commit e5fb638c56005e4a0f9951b8518280a7f7df18c5
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Mon Jun 22 11:50:38 2020 +0900

    Update QUIC draft version numbers to 29

commit a9ef9b0a4142e5d37d1d0736e8dce1faed0c39e1
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Fri Jul 10 17:21:46 2020 +0900

    Update code for BoringSSL

commit 58cac989ffbbf9e9422a1ecb88ec761821399794
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Jun 4 11:24:16 2020 +0900

    Don't include exercise version number provided by a client into VN packet

commit 47e1eb749119dcbc409435153fc473152200df4d
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu Jun 4 10:45:14 2020 +0900

    Updates tests and fixes a couple of typoes

commit f41ca7b22221fa4d8319de8b97c17337e1fcc1c3
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Mon Jun 1 12:46:32 2020 +0900

    Support both QUIC draft-27 and draft-28

commit 3a5b3c70331078c3701d33e91c2e0414aa689cdd
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu May 28 13:57:57 2020 +0900

    Add QUIC APPLICATION_ERROR error code

commit 0457e747a86b4a80ccc0acd017d21a581cb5ca3b
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Thu May 28 13:33:02 2020 +0900

    Add support for new Transport Parameters on draft-28

commit 2717ecc632a613f4808b24765d302d5c5bc8d100
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Mon May 25 11:46:49 2020 +0900

    Rename QUIC Transport Parameters

    ORIGINAL_CONNECTION_ID -> ORIGINAL_DESTINATION_CONNECTION_ID
    MAX_PACKET_SIZE -> MAX_UDP_PAYLOAD_SIZE

commit 9ef2167e32aab96dbd89cf304d74ee0121cdb601
Author: Masakazu Kitajo <maskit@apache.org>
Date:   Mon May 25 10:34:54 2020 +0900

    Update QUIC draft version numbers to 28