### PR TITLE
Cancel active/inactive timeout on closing Http2Stream

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -365,6 +365,7 @@ Http2Stream::do_io_close(int /* flags */)
       h2_proxy_ssn->connection_state.send_data_frames(this);
     }
 
+    _clear_timers();
     clear_io_events();
 
     // Wait until transaction_done is called from HttpSM to signal that the TXN_CLOSE hook has been executed
@@ -430,6 +431,7 @@ Http2Stream::initiating_close()
     // TXN_CLOSE has been sent
     // _proxy_ssn = NULL;
 
+    _clear_timers();
     clear_io_events();
 
     // This should result in do_io_close or release being called.  That will schedule the final
@@ -813,6 +815,7 @@ Http2Stream::destroy()
   if (header_blocks) {
     ats_free(header_blocks);
   }
+  _clear_timers();
   clear_io_events();
   http_parser_clear(&http_parser);
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -150,6 +150,7 @@ private:
   bool response_is_data_available() const;
   Event *send_tracked_event(Event *event, int send_event, VIO *vio);
   void send_response_body(bool call_update);
+  void _clear_timers();
 
   /**
    * Check if this thread is the right thread to process events for this
@@ -320,4 +321,11 @@ inline MIOBuffer *
 Http2Stream::read_vio_writer() const
 {
   return this->read_vio.get_writer();
+}
+
+inline void
+Http2Stream::_clear_timers()
+{
+  _timeout.cancel_active_timeout();
+  _timeout.cancel_inactive_timeout();
 }


### PR DESCRIPTION
Fix #7102. 

On #6494, I dropped `Http2Stream::clear_timers()` function, but active/inactive timeouts of Http2Stream needs to be canceled (at least in `Http2Stream::do_io_close()`)