### PR TITLE
Update check for min versions when running AuTest

### DIFF
--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -18,11 +18,11 @@
 
 import sys
 
-if sys.version_info < (3, 5, 0):
+if sys.version_info < (3, 6, 0):
     host.WriteError(
-        "You need python 3.5 or later to run these tests\n", show_stack=False)
+        "You need python 3.6 or later to run these tests\n", show_stack=False)
 
-autest_version = "1.7.2"
+autest_version = "1.8.1"
 if AuTestVersion() < autest_version:
     host.WriteError(
         "Tests need AuTest version {ver} or better\n Please update AuTest:\n  pip install --upgrade autest\n".format(ver=autest_version), show_stack=False)


### PR DESCRIPTION
The current check will fail to enforce python 3.6. If running with python 3.5 there will be a syntax error with the parser