### PR TITLE
Updating our autest suite to require Python3.6

### DIFF
--- a/ci/jenkins/bin/autest.sh
+++ b/ci/jenkins/bin/autest.sh
@@ -105,11 +105,7 @@ set +x
 echo -n "=======>>>>  Started on "
 date
 
-AUTEST="/usr/bin/autest"
-[ ! -x ${AUTEST} ] && AUTEST="/usr/local/bin/autest"
-set -x
-
-${AUTEST} -D ./tests/gold_tests --sandbox "$SANDBOX" --ats-bin "${INSTALL}/bin" $AUTEST_DEBUG $AUTEST_VERBOSE
+./tests/autest.sh --sandbox "$SANDBOX" --ats-bin "${INSTALL}/bin" $AUTEST_DEBUG $AUTEST_VERBOSE
 status=$?
 
 set +x

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ To run autest manually, the recommended way is to follow these steps:
 
 AuTest and the relevant tools can be install manually instead of using the wrapper script. By doing this, it is often easier to debug issues with the testing system, or the tests. There are two ways this can be done.
 1. Run the bootstrap script then source the path with a "source ./env-test/bin/activate" command. At this point autest command should run without the wrapper script
-2. Make sure you install python 3.5 or better on your system. From there install these python packages ( ie pip install ):
+2. Make sure you install python 3.6 or better on your system. From there install these python packages ( ie pip install ):
   - hyper
   - git+https://bitbucket.org/autestsuite/reusable-gold-testing-system.git
   - [traffic-replay](https://bitbucket.org/autestsuite/trafficreplay/src/master/) (This will automatically install [MicroDNS](https://bitbucket.org/autestsuite/microdns/src/master/), [MicroServer](https://bitbucket.org/autestsuite/microserver/src/master/), [TrafficReplayLibrary](https://bitbucket.org/autestsuite/trafficreplaylibrary/src/master/), and dnslib as part of the dependencies.)
@@ -53,7 +53,7 @@ AuTest and the relevant tools can be install manually instead of using the wrapp
 When writing for the AuTest system please refer to the current [Online Documentation](https://autestsuite.bitbucket.io/) for general use of the system. To use CurlHeader tester for testing output of curl, please refer to [CurlHeader README](gold_tests/autest-site/readme.md)
 
 ## Documentation of AuTest extension for ATS.
-Autest allows for the creation of extensions to help specialize and simplify test writing for a given application domain. Minus API addition the extension code will check that python 3.5 or better is used. There is also a new command line argumented added specifically for Trafficserver:
+Autest allows for the creation of extensions to help specialize and simplify test writing for a given application domain. Minus API addition the extension code will check that python 3.6 or better is used. There is also a new command line argumented added specifically for Trafficserver:
 
 --ats-bin < path to bin directory >
 

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -18,14 +18,18 @@
 
 import sys
 
-if sys.version_info < (3, 5, 0):
+if sys.version_info < (3, 6, 0):
     host.WriteError(
-        "You need python 3.5 or later to run these tests\n", show_stack=False)
+        "You need python 3.6 or later to run these tests\n", show_stack=False)
 
-autest_version = "1.7.2"
+autest_version = "1.8.1"
 if AuTestVersion() < autest_version:
     host.WriteError(
-        "Tests need AuTest version {ver} or better\n Please update AuTest:\n  pip install --upgrade autest\n".format(ver=autest_version), show_stack=False)
+        "Tests need AuTest version {needed_version} or better, found version {found_version}\n"
+            "Please update AuTest:\n  pip install --upgrade autest\n".format(
+            needed_version=autest_version,
+            found_version=AuTestVersion()),
+        show_stack=False)
 
 
 Settings.path_argument(["--ats-bin"],

--- a/tests/test-env-check.sh
+++ b/tests/test-env-check.sh
@@ -20,15 +20,15 @@
 python3 - << _END_
 import sys
 
-if sys.version_info.major < 3 or sys.version_info.minor < 5:
+if sys.version_info.major < 3 or sys.version_info.minor < 6:
     exit(1)
 _END_
 
 if [ $? = 1 ]; then
-    echo "Python 3.5 or newer is not installed/enabled."
+    echo "Python 3.6 or newer is not installed/enabled."
     return
 else
-    echo "Python 3.5 or newer detected!"
+    echo "Python 3.6 or newer detected!"
 fi
 
 # check for python development header -- for autest


### PR DESCRIPTION
AuTest 1.8.1, which we require (see tests/Pipfile), uses features new to
Python 3.6 such as type hints. We therefore already have required 3.6 
for a few weeks. This just updates our scripts to enforce this.