### PR TITLE
Fix #7116, skip the insertion of the same continuation to pending dns

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1586,6 +1586,10 @@ HostDBContinuation::set_check_pending_dns()
 {
   Queue<HostDBContinuation> &q = hostDB.pending_dns_for_hash(hash.hash);
   this->setThreadAffinity(this_ethread());
+  if (q.in(this)) {
+    Warning("Skip the insertion of the same continuation to pending dns");
+    return false;
+  }
   HostDBContinuation *c = q.head;
   for (; c; c = static_cast<HostDBContinuation *>(c->link.next)) {
     if (hash.hash == c->hash.hash) {


### PR DESCRIPTION
GDB showed the dead loop is because the next field of an element pointing to itself.
```
#1  HostDBCache::is_pending_dns_for_hash (this=this@entry=0xbd3e20 <hostDB>, hash=...) at HostDB.cc:247
247 HostDB.cc: No such file or directory.
(gdb) info locals
c = 0x2b63897745e0
q = @0x2b638704bdc0: {<DLL<HostDBContinuation, Continuation::Link_link>> = {head = 0x2b63897745e0}, tail = 0x2b63897745e0}
(gdb) p q->head->link->next
$7 = (Continuation *) 0x2b63897745e0
(gdb) p q->head->link->next->link->next
$8 = (Continuation *) 0x2b63897745e0
```

Tried a test build and found the incorrect next field was caused by enqueuing the same element.

There is the logic that if HostDB Continuation timeout is applied, we retry the same continuation which causes the enqueuing the same element.

`pending_dns` is basically an entry of hash map implemented with a linked list. Not checking the same element is the wrong implementation of a hashmap.

