### PR TITLE
Backing out my update of our jenkin's autest file.

### DIFF
--- a/ci/jenkins/bin/autest.sh
+++ b/ci/jenkins/bin/autest.sh
@@ -105,7 +105,11 @@ set +x
 echo -n "=======>>>>  Started on "
 date
 
-./tests/autest.sh --sandbox "$SANDBOX" --ats-bin "${INSTALL}/bin" $AUTEST_DEBUG $AUTEST_VERBOSE
+AUTEST="/usr/bin/autest"
+[ ! -x ${AUTEST} ] && AUTEST="/usr/local/bin/autest"
+set -x
+
+${AUTEST} -D ./tests/gold_tests --sandbox "$SANDBOX" --ats-bin "${INSTALL}/bin" $AUTEST_DEBUG $AUTEST_VERBOSE
 status=$?
 
 set +x


### PR DESCRIPTION
In a PR updating versions for autest I initially proposed using pipenv
to get autest:

https://github.com/apache/trafficserver/pull/7113

But, talking with Leif, we agreed that this adds too much
overhead to test runs. He updated autest on the machine fo rme. However
I forgot to pull out the jenkins/bin/autest.sh change in that PR after
that conversation and it got pulled in. This PR reverts back
jenkins/bin/autest.sh to the correct version which uses autest on the
machine.