### PR TITLE
Make tls_hooks tests more likely to pass particularly for 9.0.x branch

### DIFF
--- a/tests/gold_tests/tls_hooks/tls_hooks.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks.test.py
@@ -74,5 +74,5 @@ ts.Streams.All = Testers.ContainsExpression(
     "Pre accept message appears only once or twice",
     reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks10.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks10.test.py
@@ -62,5 +62,5 @@ tr.Processes.Default.ReturnCode = 0
 
 ts.Streams.stderr = "gold/ts-cert-1-im-2.gold"
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks11.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks11.test.py
@@ -69,5 +69,5 @@ ts.Streams.All = Testers.ContainsExpression(
     r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(preacceptstring),
     "Pre accept message appears only once or twice",
     reflags=re.S | re.M)
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks12.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks12.test.py
@@ -62,5 +62,5 @@ tr.Processes.Default.ReturnCode = 0
 
 ts.Streams.stderr = "gold/ts-preaccept-delayed-1-immdate-2.gold"
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks13.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks13.test.py
@@ -62,5 +62,5 @@ tr.Processes.Default.ReturnCode = 0
 
 ts.Streams.stderr = "gold/ts-out-start-close-2.gold"
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks14.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks14.test.py
@@ -62,5 +62,5 @@ tr.Processes.Default.ReturnCode = 0
 
 ts.Streams.stderr = "gold/ts-out-delay-start-2.gold"
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks15.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks15.test.py
@@ -62,5 +62,5 @@ tr.Processes.Default.ReturnCode = 0
 
 ts.Streams.stderr = "gold/ts-close-out-close.gold"
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks16.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks16.test.py
@@ -71,5 +71,5 @@ snistring = "Client Hello callback 0"
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -71,5 +71,5 @@ snistring = "Client Hello callback 0"
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -75,5 +75,5 @@ ts.Streams.All = Testers.ContainsExpression(
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks2.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks2.test.py
@@ -68,5 +68,5 @@ snistring = "SNI callback 0"
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks3.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks3.test.py
@@ -68,5 +68,5 @@ certstring = "Cert callback 0"
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring), "Cert message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks4.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks4.test.py
@@ -74,5 +74,5 @@ ts.Streams.All += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}
 ts.Streams.All += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring),
                                              "Cert message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks6.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks6.test.py
@@ -76,5 +76,5 @@ ts.Streams.All = Testers.ContainsExpression(
     "Pre accept message appears only once or twice",
     reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks7.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks7.test.py
@@ -71,5 +71,5 @@ ts.Streams.All = Testers.ContainsExpression(
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring1), "SNI message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks8.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks8.test.py
@@ -71,5 +71,5 @@ ts.Streams.All = Testers.ContainsExpression(
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks9.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks9.test.py
@@ -67,5 +67,5 @@ ts.Streams.stderr = "gold/ts-cert-im-1.gold"
 certstring0 = "Cert callback 0"
 ts.Streams.All = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
-tr.Processes.Default.TimeOut = 5
-tr.TimeOut = 5
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15


### PR DESCRIPTION
The autest 9.0.x build has been failing reliably on tls_hooks14.  Looking at the output, all looks good.  If I increase the test timeout from 5 to 6 it stops failing for me locally.  On master if I decrease the test timeout to 4, it fails reliably for me too.   I am guessing that these test are running close to the timeout point.  The ATS9 branch does not have all the optimizations that @bneradt has been adding, so perhaps that branch is just getting unlikely.

There is no compelling reason the timeout needs to be so short.  I'd like to keep a timeout because I think the default timeout is 30 minutes which seems way too long. So I bumped them all up to 15 seconds.
