### PR TITLE
SSLConfig mem leak fix

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -367,6 +367,7 @@ SSLConfigParams::initialize()
             verify_server);
     verifyServerPolicy = YamlSNIConfig::Policy::DISABLED;
   }
+  ats_free(verify_server);
 
   REC_ReadConfigStringAlloc(verify_server, "proxy.config.ssl.client.verify.server.properties");
   if (strcmp(verify_server, "SIGNATURE") == 0) {


### PR DESCRIPTION
ASAN found this leak when doing a config reload.