### PR TITLE
Do not lose original inactivity timeout on disable

### DIFF
--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -548,7 +548,8 @@ static inline void
 read_disable(NetHandler *nh, NetEvent *ne)
 {
   if (!ne->write.enabled) {
-    ne->set_inactivity_timeout(0);
+    // Don't reset the inactivity_timeout_in, so it we be there next time we reset
+    ne->next_inactivity_timeout_at = 0;
     Debug("socket", "read_disable updating inactivity_at %" PRId64 ", NetEvent=%p", ne->next_inactivity_timeout_at, ne);
   }
   ne->read.enabled = 0;
@@ -569,7 +570,8 @@ static inline void
 write_disable(NetHandler *nh, NetEvent *ne)
 {
   if (!ne->read.enabled) {
-    ne->set_inactivity_timeout(0);
+    // Don't reset the inactivity_timeout_in, so it we be there next time we reset
+    ne->next_inactivity_timeout_at = 0;
     Debug("socket", "write_disable updating inactivity_at %" PRId64 ", NetEvent=%p", ne->next_inactivity_timeout_at, ne);
   }
   ne->write.enabled = 0;

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -548,7 +548,8 @@ static inline void
 read_disable(NetHandler *nh, NetEvent *ne)
 {
   if (!ne->write.enabled) {
-    // Don't reset the inactivity_timeout_in, so it we be there next time we reset
+    // Clear the next scheduled inactivity time, but don't clear inactivity_timeout_in,
+    // so the current timeout is used when the NetEvent is reenabled and not the default inactivity timeout
     ne->next_inactivity_timeout_at = 0;
     Debug("socket", "read_disable updating inactivity_at %" PRId64 ", NetEvent=%p", ne->next_inactivity_timeout_at, ne);
   }
@@ -570,7 +571,8 @@ static inline void
 write_disable(NetHandler *nh, NetEvent *ne)
 {
   if (!ne->read.enabled) {
-    // Don't reset the inactivity_timeout_in, so it we be there next time we reset
+    // Clear the next scheduled inactivity time, but don't clear inactivity_timeout_in,
+    // so the current timeout is used when the NetEvent is reenabled and not the default inactivity timeout
     ne->next_inactivity_timeout_at = 0;
     Debug("socket", "write_disable updating inactivity_at %" PRId64 ", NetEvent=%p", ne->next_inactivity_timeout_at, ne);
   }


### PR DESCRIPTION
Saw this when trying to override the inactivity timeouts for a tunnel_route.  We could override the proxy.config.http.transaction_no_activity_timeout_in and proxy.config.http.transaction_no_activity_timeout_out to 600 seconds (from our default of 30 and 90).  But our test stalled tunnel timed out at 300 seconds because our proxy.config.net.default_inactivity_timeout was set to 300, and the inactivity cop resets the timeout to proxy.config.net.default_inactivity_timeout if the next_inactivity_timeout is set to 0.

However, for the tunnel case, there is not an opportunity to reset the timeout to the original value.  With this code change, the tunnel timeout works as expected without tripping up on the default_inactivity_timeout.  This chance also does not seem to impact regular traffic.

I am not sure why we are clearing the inactivity timeout if the netvc is both read and write disabled. Looking through the git blames it seems that this logic has been present since the code moved into github in 2009.  