### PR TITLE
New option to dead server to not retry during dead period

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1452,7 +1452,7 @@ Origin Server Connect Attempts
    :reloadable:
    :overridable:
 
-   Maximum number of connection retries |TS| can make while an origin is marked dead.  Typically this value is smaller than
+   Maximum number of connection attempts |TS| can make while an origin is marked dead per request.  Typically this value is smaller than
    `proxy.config.http.connect_attempts_max_retries`_ so an error is returned to the client faster and also to reduce the load on the dead origin.
    The timeout interval `proxy.config.http.connect_attempts_timeout`_ in seconds is used with this setting.
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4936,6 +4936,12 @@ HttpSM::do_http_server_open(bool raw)
       call_transact_and_set_next_state(HttpTransact::Forbidden);
       return;
     }
+
+    if (HttpTransact::is_server_negative_cached(&t_state) == true &&
+        t_state.txn_conf->connect_attempts_max_retries_dead_server < 0) {
+      call_transact_and_set_next_state(HttpTransact::OriginDead);
+      return;
+    }
   }
 
   // Check for self loop.

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4938,7 +4938,7 @@ HttpSM::do_http_server_open(bool raw)
     }
 
     if (HttpTransact::is_server_negative_cached(&t_state) == true &&
-        t_state.txn_conf->connect_attempts_max_retries_dead_server < 0) {
+        t_state.txn_conf->connect_attempts_max_retries_dead_server <= 0) {
       call_transact_and_set_next_state(HttpTransact::OriginDead);
       return;
     }

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3779,7 +3779,7 @@ HttpTransact::handle_response_from_server(State *s)
     }
 
     if (is_server_negative_cached(s)) {
-      max_connect_retries = s->txn_conf->connect_attempts_max_retries_dead_server;
+      max_connect_retries = s->txn_conf->connect_attempts_max_retries_dead_server - 1;
     } else {
       // server not yet negative cached - use default number of retries
       max_connect_retries = s->txn_conf->connect_attempts_max_retries;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -451,7 +451,7 @@ update_cache_control_information_from_config(HttpTransact::State *s)
   }
 }
 
-inline bool
+bool
 HttpTransact::is_server_negative_cached(State *s)
 {
   if (s->host_db_info.app.http_data.last_failure != 0 &&

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -937,8 +937,9 @@ public:
   static void HandleRequestAuthorized(State *s);
   static void BadRequest(State *s);
   static void Forbidden(State *s);
-  static void TooEarly(State *s);
   static void SelfLoop(State *s);
+  static void TooEarly(State *s);
+  static void OriginDead(State *s);
   static void PostActiveTimeoutResponse(State *s);
   static void PostInactiveTimeoutResponse(State *s);
   static void DecideCacheLookup(State *s);


### PR DESCRIPTION
Currently ATS retries 2 times with the current configuration of `proxy.config.http.connect_attempts_max_retries_dead_server` set to 1 and 1 time with it set to 0.

With a setting of -1 (added in this patch) ATS won't retry at all during the dead server timeout period.  We need to revisit the dead server design, since it doesn't make much sense as it is currently implemented.

