### PR TITLE
slice: check if vio is still valid before calling TSVIODone* on shutdown

### DIFF
--- a/plugins/experimental/slice/Stage.h
+++ b/plugins/experimental/slice/Stage.h
@@ -49,7 +49,9 @@ struct Channel {
       int64_t const avail = TSIOBufferReaderAvail(m_reader);
       TSIOBufferReaderConsume(m_reader, avail);
       consumed = avail;
-      TSVIONDoneSet(m_vio, TSVIONDoneGet(m_vio) + consumed);
+      if (nullptr != m_vio) {
+        TSVIONDoneSet(m_vio, TSVIONDoneGet(m_vio) + consumed);
+      }
     }
 
     return consumed;


### PR DESCRIPTION
During upstream shutdown ensure the upstream VIO from the server is not nullptr before calling TSVIONDoneGet/Set 

relevant part of the crash trace:

Fatal: traffic_server/InkIOCoreAPI.cc:357: failed assertion `sdk_sanity_check_iocore_structure(viop) == TS_SUCCESS`
Traffic Server 8.1.0253.f882f4b.el7 Aug  5 2020 19:01:30 33d6c8656de7
traffic_server: using root directory '/opt/trafficserver'
traffic_server: received signal 6 (Aborted)
traffic_server - STACK TRACE: 
...
/opt/trafficserver/libexec/trafficserver/slice.so(_Z8shutdownP10tsapi_contP4Data+0x32a)[0x2b23965e771a]
/opt/trafficserver/libexec/trafficserver/slice.so(_Z18handle_server_respP10tsapi_cont7TSEventP4Data+0x558)[0x2b23965e5b58]
/opt/trafficserver/libexec/trafficserver/slice.so(_Z14intercept_hookP10tsapi_cont7TSEventPv+0x40d)[0x2b23965e2c2d]
