### PR TITLE
Fix stale pointer due to SSL config reload

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -72,7 +72,6 @@ NetVCOptions::reset()
   sni_hostname                = nullptr;
   ssl_client_cert_name        = nullptr;
   ssl_client_private_key_name = nullptr;
-  ssl_client_ca_cert_name     = nullptr;
 }
 
 inline void

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1068,7 +1068,7 @@ SSLNetVConnection::sslStartHandShake(int event, int &err)
 
       // First Look to see if there are override parameters
       if (options.ssl_client_cert_name) {
-        std::string certFilePath = Layout::get()->relative_to(params->clientCertPathOnly, options.ssl_client_cert_name);
+        std::string certFilePath = Layout::get()->relative_to(params->clientCertPathOnly, options.ssl_client_cert_name.get());
         std::string keyFilePath;
         if (options.ssl_client_private_key_name) {
           keyFilePath = Layout::get()->relative_to(params->clientKeyPathOnly, options.ssl_client_private_key_name);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5182,7 +5182,7 @@ HttpSM::do_http_server_open(bool raw)
     opt.f_tcp_fastopen = (t_state.txn_conf->sock_option_flag_out & NetVCOptions::SOCK_OPT_TCP_FAST_OPEN);
   }
 
-  opt.ssl_client_cert_name        = t_state.txn_conf->ssl_client_cert_filename;
+  opt.set_ssl_client_cert_name(t_state.txn_conf->ssl_client_cert_filename);
   opt.ssl_client_private_key_name = t_state.txn_conf->ssl_client_private_key_filename;
   opt.ssl_client_ca_cert_name     = t_state.txn_conf->ssl_client_ca_cert_filename;
 

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -127,7 +127,7 @@ ServerSessionPool::validate_cert(HttpSM *sm, NetVConnection *netvc)
   // a new connection.
   //
   if (sm->t_state.scheme == URL_WKSIDX_HTTPS) {
-    const char *session_cert       = netvc->options.ssl_client_cert_name;
+    const char *session_cert       = netvc->options.ssl_client_cert_name.get();
     std::string_view proposed_cert = sm->get_outbound_cert();
     Debug("http_ss", "validate_cert proposed_cert=%.*s, cert=%s", static_cast<int>(proposed_cert.size()), proposed_cert.data(),
           session_cert);


### PR DESCRIPTION
This issue was identified in an ASAN by @bneradt using proxy_verifier to replay production traffic during config reloads.  One of the failures was the following heap overflow.

```
=================================================================
==39991==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6060003b7440 at pc 0x0000005e264d bp 0x2ae02c75cd30 sp 0x2ae02c75c4d8
READ of size 2 at 0x6060003b7440 thread T4 ([ET_NET 2])
    #0 0x5e264c in __interceptor_strlen.part.31 (/opt/oath/trafficserver/9.0/bin/traffic_server+0x5e264c)
    #1 0x862c47 in std::char_traits<char>::length(char const*) /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/char_traits.h:322
    #2 0x862c47 in std::basic_string_view<char, std::char_traits<char> >::basic_string_view(char const*) /opt/rh/devtoolset-8/root/usr/include/c++/8/string_view:100
    #3 0x862c47 in std::basic_string_view<char, std::char_traits<char> >::compare(char const*) const /opt/rh/devtoolset-8/root/usr/include/c++/8/string_view:275
    #4 0x862c47 in ServerSessionPool::validate_cert(HttpSM*, NetVConnection*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSessionManager.cc:136
    #5 0x86468e in ServerSessionPool::acquireSession(sockaddr const*, ats::CryptoHash const&, TSServerSessionSharingMatchMask, HttpSM*, Http1ServerSession*&) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSessionManager.cc:158
    #6 0x86531f in HttpSessionManager::acquire_session(sockaddr const*, ats::CryptoHash const&, HttpSM*, TSServerSessionSharingMatchMask, TSServerSessionSharingPoolType) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSessionManager.
cc:410
    #7 0x8668cf in HttpSessionManager::acquire_session(Continuation*, sockaddr const*, char const*, ProxyTransaction*, HttpSM*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSessionManager.cc:381
    #8 0x834a11 in HttpSM::do_http_server_open(bool) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:4952
    #9 0x840825 in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7500
    #10 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #11 0x8296c9 in HttpSM::handle_api_return() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1611
    #12 0x81a6b5 in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1543
    #13 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #14 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #15 0x2ae0304a5a5c in cb _vcs/quick_filter-9/quick_filter/quick_filter.cc:637
    #16 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #17 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #18 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #19 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #20 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #21 0x840f3a in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7337
    #22 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #23 0x7f3741 in HttpSM::do_hostdb_lookup() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:4163
    #24 0x840ae8 in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7653
    #25 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #26 0x8296c9 in HttpSM::handle_api_return() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1611
    #27 0x81a6b5 in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1543
    #28 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #29 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #30 0x2ae037e2b01c in main_handler ../../../../../_vcs/trafficserver9/plugins/regex_revalidate/regex_revalidate.c:453
    #31 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #32 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #33 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #34 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #35 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #36 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #37 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #38 0x2ae03718326c in carpLookup(tsapi_cont*, TSEvent, void*) _vcs/carp-9/carp/carp.cc:767
    #39 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #40 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #41 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #42 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #43 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #44 0x8216ee in HttpSM::setup_cache_lookup_complete_api() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:2522
    #45 0x8216ee in HttpSM::state_cache_open_read(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:2584
    #46 0x823d48 in HttpSM::main_handler(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:2626
    #47 0x94c1f9 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #48 0x94c1f9 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #49 0x94c1f9 in HttpCacheSM::state_cache_open_read(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpCacheSM.cc:133
    #50 0xcb3f48 in Cache::open_read(Continuation*, ats::CryptoHash const*, HTTPHdr*, OverridableHttpConfigParams const*, CacheFragType, char const*, int) ../../../../../../_vcs/trafficserver9/iocore/cache/CacheRead.cc:149
    #51 0xc2ebdb in CacheProcessor::open_read(Continuation*, HttpCacheKey const*, HTTPHdr*, OverridableHttpConfigParams const*, long, CacheFragType) ../../../../../../_vcs/trafficserver9/iocore/cache/Cache.cc:3221
    #52 0x94b81b in HttpCacheSM::do_cache_open_read(HttpCacheKey const&) ../../../../../../_vcs/trafficserver9/proxy/http/HttpCacheSM.cc:273
    #53 0x94cc16 in HttpCacheSM::open_read(HttpCacheKey const*, URL*, HTTPHdr*, OverridableHttpConfigParams const*, long) ../../../../../../_vcs/trafficserver9/proxy/http/HttpCacheSM.cc:307
    #54 0x7e1073 in HttpSM::do_cache_lookup_and_read() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:4594
    #55 0x840197 in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7468
    #56 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #57 0x8296c9 in HttpSM::handle_api_return() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1611
    #58 0x81a6b5 in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1543
    #59 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #60 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #61 0x2ae0304a5a5c in cb _vcs/quick_filter-9/quick_filter/quick_filter.cc:637
    #62 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #63 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #64 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #65 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #66 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #67 0x840f3a in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7337
    #68 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #69 0x83fbf1 in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7719
    #70 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #71 0x8296c9 in HttpSM::handle_api_return() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1611
    #72 0x81a6b5 in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1543
    #73 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #74 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #75 0x2ae035c760a4 in http_hook _vcs/yahoo_connection-9/yahoo_connection/INKPluginInit.cc:441
    #76 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #77 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #78 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #79 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #80 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #81 0x840f3a in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7337
    #82 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #83 0x8296c9 in HttpSM::handle_api_return() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1611
    #84 0x81a6b5 in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1543
    #85 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #86 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #87 0x2ae03810e48c in Context::ts_callback(tsapi_cont*, TSEvent, void*) _vcs/txn_box-9/plugin/src/Context.cc:279
    #88 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #89 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #90 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #91 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #92 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #93 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #94 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #95 0x2ae037903b31 in health_check_origin ../../../../../_vcs/trafficserver9/plugins/healthchecks/healthchecks.c:541
    #96 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #97 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #98 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #99 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #100 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #101 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #102 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #103 0x2ae0376a63b8 in cont_rewrite_headers ../../../../../_vcs/trafficserver9/plugins/header_rewrite/header_rewrite.cc:308
    #104 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #105 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #106 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #107 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #108 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #109 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #110 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #111 0x2ae0371853dc in onReadRequest(tsapi_cont*, TSEvent, void*) _vcs/carp-9/carp/carp.cc:375
    #112 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #113 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #114 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #115 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #116 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #117 0x827852 in HttpSM::state_api_callback(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1347
    #118 0x6e8eb4 in TSHttpTxnReenable ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:6123
    #119 0x2ae035c760a4 in http_hook _vcs/yahoo_connection-9/yahoo_connection/INKPluginInit.cc:441
    #120 0x6a5a8e in INKContInternal::handle_event(int, void*) ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1096
    #121 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #122 0x6e1022 in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #123 0x6e1022 in APIHook::invoke(int, void*) const ../../../../../_vcs/trafficserver9/src/traffic_server/InkAPI.cc:1333
    #124 0x81a2db in HttpSM::state_api_callout(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:1476
    #125 0x840f3a in HttpSM::set_next_state() ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7337
    #126 0x7ea6af in HttpSM::call_transact_and_set_next_state(void (*)(HttpTransact::State*)) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:7303
    #127 0x80aa9b in HttpSM::state_read_client_request_header(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:833
    #128 0x824035 in HttpSM::main_handler(int, void*) ../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc:2623
    #129 0xefd99f in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:167
    #130 0xefd99f in Continuation::handleEvent(int, void*) /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/iocore/eventsystem/I_Continuation.h:163
    #131 0xefd99f in read_signal_and_update ../../../../../../_vcs/trafficserver9/iocore/net/UnixNetVConnection.cc:83
    #132 0xefd99f in UnixNetVConnection::readSignalAndUpdate(int) ../../../../../../_vcs/trafficserver9/iocore/net/UnixNetVConnection.cc:1014
    #133 0xe669f0 in SSLNetVConnection::net_read_io(NetHandler*, EThread*) ../../../../../../_vcs/trafficserver9/iocore/net/SSLNetVConnection.cc:672
    #134 0xed0b74 in NetHandler::process_ready_list() ../../../../../../_vcs/trafficserver9/iocore/net/UnixNet.cc:413
    #135 0xed1a76 in NetHandler::waitForActivity(long) ../../../../../../_vcs/trafficserver9/iocore/net/UnixNet.cc:548
    #136 0xff0d9e in EThread::execute_regular() ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEThread.cc:271
    #137 0xff15f5 in EThread::execute() ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEThread.cc:332
    #138 0xff15f5 in EThread::execute() ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEThread.cc:310
    #139 0xfeb0da in spawn_thread_internal ../../../../../../_vcs/trafficserver9/iocore/eventsystem/Thread.cc:92
    #140 0x2ae023feddd4 in start_thread (/lib64/libpthread.so.0+0x7dd4)
    #141 0x2ae024f2b02c in __clone (/lib64/libc.so.6+0xfe02c)

Address 0x6060003b7440 is a wild pointer.
SUMMARY: AddressSanitizer: heap-buffer-overflow (/opt/oath/trafficserver/9.0/bin/traffic_server+0x5e264c) in __interceptor_strlen.part.31
Shadow bytes around the buggy address:
  0x0c0c8006ee30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0c8006ee40: 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
  0x0c0c8006ee50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0c8006ee60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c0c8006ee70: 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
=>0x0c0c8006ee80: fa fa fa fa fa fa fa fa[fa]fa fa fa fa fa fa fa
  0x0c0c8006ee90: fa fa fa fa 00 00 00 00 00 00 00 fa fa fa fa fa
  0x0c0c8006eea0: 00 00 00 00 00 00 00 fa fa fa fa fa 00 00 00 00
  0x0c0c8006eeb0: 00 00 00 fa fa fa fa fa fd fd fd fd fd fd fd fa
  0x0c0c8006eec0: fa fa fa fa 00 00 00 00 00 00 00 fa fa fa fa fa
  0x0c0c8006eed0: 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Thread T4 ([ET_NET 2]) created by T0 ([TS_MAIN]) here:
    #0 0x5887ef in __interceptor_pthread_create (/opt/oath/trafficserver/9.0/bin/traffic_server+0x5887ef)
    #1 0xfec26e in ink_thread_create /home/bneradt/repos/build_ts_9_asan/_build/build_release_posix-x86_64/trafficserver9/build/../../../../_vcs/trafficserver9/include/tscore/ink_thread.h:159
    #2 0xfec26e in Thread::start(char const*, void*, unsigned long, std::function<void ()> const&) ../../../../../../_vcs/trafficserver9/iocore/eventsystem/Thread.cc:109
    #3 0xff92cb in EventProcessor::spawn_event_threads(int, int, unsigned long) ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEventProcessor.cc:392
    #4 0xffa079 in EventProcessor::start(int, unsigned long) ../../../../../../_vcs/trafficserver9/iocore/eventsystem/UnixEventProcessor.cc:455
    #5 0x50c557 in main ../../../../../_vcs/trafficserver9/src/traffic_server/traffic_server.cc:1977
    #6 0x2ae024e4f494 in __libc_start_main (/lib64/libc.so.6+0x22494)

==39991==ABORTING
```
Digging into the code, this appears to be the issue

```
opt.ssl_client_cert_name        = t_state.txn_conf->ssl_client_cert_filename;
```

The t_state.txn_conf has a lifetime of the transaction. However, we are saving aside the reference to the ssl_client_cert_file_name for the lifetime of the origin connection so we can perform the cert match on session reuse. With origin session reuse, this can be longer than the lifetime of the transaction.

If we are unlucky with a remap.config reload, the old string can get freed.

It seems that the safe thing to do here is to copy the string and free it when the netvc goes away. @bneradt tested this patch in his replay, reload environment and the heap overflow went away.
