### PR TITLE
Traffic Dump: Record HTTP/2 priority.

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnClientStreamIdGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientStreamIdGet.en.rst
@@ -1,0 +1,49 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSHttpTxnClientStreamIdGet
+**************************
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: TSReturnCode TSHttpTxnClientStreamIdGet(TSHttpTxn txnp, uint64_t* stream_id)
+
+Description
+===========
+
+Retrieve the stream identification for the HTTP stream of which the provided
+transaction is a part. The resultant stream identifier is populated in the
+``stream_id`` output parameter.
+
+This interface currently only supports HTTP/2 streams. See RFC 7540 section
+5.1.1 for details concerning HTTP/2 stream identifiers.
+
+This API returns an error if the provided transaction is not an HTTP/2
+transaction.
+
+See Also
+========
+
+:doc:`TSHttpTxnClientStreamPriorityGet.en`

--- a/doc/developer-guide/api/functions/TSHttpTxnClientStreamPriorityGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientStreamPriorityGet.en.rst
@@ -1,0 +1,67 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSHttpTxnClientStreamPriorityGet
+********************************
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: TSReturnCode TSHttpTxnClientStreamPriorityGet(TSHttpTxn txnp, TSHttpPriority* priority)
+
+Description
+===========
+
+Retrieve the priority information for the HTTP stream associated with the
+provided transaction.  The resultant priority information is populated in the
+``priority`` output variable. The ``TSHttpPriority`` type is designed to be
+agnostic of the various HTTP protocol versions that support HTTP streams. The
+user should pass a pointer casted to ``TSHttpPriority`` from a previously
+allocated ``TSHttp2Priority`` structure. This design anticipates future support
+for HTTP versions that support streams, such as HTTP/3.
+
+The ``TSHttp2Priority`` structure has the following declaration:
+
+.. code-block:: cpp
+
+  typedef struct {
+    uint8_t priority_type; /** HTTP_PROTOCOL_TYPE_HTTP_2 */
+    int32_t stream_dependency;
+    uint8_t weight;
+  } TSHttp2Priority;
+
+In a call to ``TSHttpTxnClientStreamPriorityGet``, the dependency and weight
+will be populated in the ``stream_dependency`` and ``weight`` members,
+respectively.  If the stream associated with the given transaction has no
+dependency, then the ``stream_dependency`` output parameter will be populated
+with ``-1`` and the value of ``weight`` will be meaningless. See RFC 7540
+section 5.3 for details concerning HTTP/2 stream priority.
+
+This API returns an error if the provided transaction is not an HTTP/2
+transaction.
+
+See Also
+========
+
+:doc:`TSHttpTxnClientStreamIdGet.en`

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -873,6 +873,44 @@ typedef enum {
   TS_USER_ARGS_COUNT  ///< Fake enum, # of valid entries.
 } TSUserArgType;
 
+/** An enumeration of HTTP version types for the priority functions that behave
+ * differently across HTTP protocols. */
+typedef enum {
+  HTTP_PRIORITY_TYPE_HTTP_UNSPECIFIED = 1,
+  HTTP_PRIORITY_TYPE_HTTP_2,
+  HTTP_PRIORITY_TYPE_HTTP_3,
+} TSHttpPriorityType;
+
+/** The abstract type of the various HTTP priority implementations. */
+typedef struct {
+  /** The reference to the concrete HTTP priority implementation. This will be
+   * a value from TSHttpPriorityType. */
+  uint8_t priority_type;
+  /** The space allocated for the concrete priority implementation.
+   *
+   * Note that this has to take padding into account. There is a static_assert
+   * in InkAPI.cc to verify that TSHttpPriority is at least as large as
+   * TSHttp2Priority. As other structures are added that are represented by
+   * TSHttpPriority add more static_asserts to verify that TSHttpPriority is as
+   * large as it needs to be.
+   */
+  uint8_t data[7];
+} TSHttpPriority;
+
+/** A structure for HTTP/2 priority.
+ *
+ * For an explanation of these terms with respect to HTTP/2, see RFC 7540,
+ * section 5.3.
+ */
+typedef struct {
+  uint8_t priority_type; /** HTTP_PROTOCOL_TYPE_HTTP_2 */
+  uint8_t weight;
+  /** The stream dependency. Per spec, see RFC 7540 section 6.2, this is 31
+   * bits. We use a signed 32 bit stucture to store either a valid dependency
+   * or -1 if the stream has no dependency. */
+  int32_t stream_dependency;
+} TSHttp2Priority;
+
 typedef struct tsapi_file *TSFile;
 
 typedef struct tsapi_mloc *TSMLoc;

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2574,6 +2574,32 @@ tsapi TSIOBufferReader TSHttpTxnPostBufferReaderGet(TSHttpTxn txnp);
  */
 tsapi TSReturnCode TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len);
 
+/** Retrieve the client side stream id for the stream of which the
+ * provided transaction is a part.
+ *
+ * @param[in] txnp The Transaction for which the stream id should be retrieved.
+ * @param[out] stream_id The stream id for this transaction.
+ *
+ * @return TS_ERROR if a stream id cannot be retrieved for the given
+ * transaction given its protocol. For instance, if txnp is an HTTP/1.1
+ * transaction, then a TS_ERROR will be returned because HTTP/1.1 does not
+ * implement streams.
+ */
+tsapi TSReturnCode TSHttpTxnClientStreamIdGet(TSHttpTxn txnp, uint64_t *stream_id);
+
+/** Retrieve the client side priority for the stream of which the
+ * provided transaction is a part.
+ *
+ * @param[in] txnp The Transaction for which the stream id should be retrieved.
+ * @param[out] priority The priority for the stream in this transaction.
+ *
+ * @return TS_ERROR if a priority cannot be retrieved for the given
+ * transaction given its protocol. For instance, if txnp is an HTTP/1.1
+ * transaction, then a TS_ERROR will be returned because HTTP/1.1 does not
+ * implement stream priorities.
+ */
+tsapi TSReturnCode TSHttpTxnClientStreamPriorityGet(TSHttpTxn txnp, TSHttpPriority *priority);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/plugins/experimental/traffic_dump/transaction_data.h
+++ b/plugins/experimental/traffic_dump/transaction_data.h
@@ -39,11 +39,18 @@ namespace traffic_dump
 class TransactionData
 {
 private:
+  /// The TSHttpTxn of the associated HTTP transaction.
+  TSHttpTxn _txnp = nullptr;
+
+  /// The HTTP version in the client-side protocol stack or empty string
+  /// if it was not specified there.
+  std::string _http_version_from_client_stack;
+
   /** The string for the JSON content of this transaction. */
-  std::string txn_json;
+  std::string _txn_json;
 
   /** The '"protocol" node for this transaction's server-side connection. */
-  std::string server_protocol_description;
+  std::string _server_protocol_description;
 
   // The index to be used for the TS API for storing this TransactionData on a
   // per-transaction basis.
@@ -65,13 +72,21 @@ public:
    */
   static bool init();
 
-  /// Read the txn information from TSMBuffer and write the header information.
-  /// This function does not write the content node.
-  std::string write_message_node_no_content(TSMBuffer &buffer, TSMLoc &hdr_loc);
+  /** Read the txn information from TSMBuffer and write the header information.
+   * This function does not write the content node.
+   *
+   * @param[in] http_version An optional specification for the HTTP "version"
+   * node.
+   */
+  std::string write_message_node_no_content(TSMBuffer &buffer, TSMLoc &hdr_loc, std::string_view http_version = "");
 
-  /// Read the txn information from TSMBuffer and write the header information including
-  /// the content node describing the body characteristics.
-  std::string write_message_node(TSMBuffer &buffer, TSMLoc &hdr_loc, int64_t num_body_bytes);
+  /** Read the txn information from TSMBuffer and write the header information including
+   * the content node describing the body characteristics.
+   *
+   * @param[in] http_version An optional specification for the HTTP "version"
+   * node.
+   */
+  std::string write_message_node(TSMBuffer &buffer, TSMLoc &hdr_loc, int64_t num_body_bytes, std::string_view http_version = "");
 
   /// The handler callback for transaction events.
   static int global_transaction_handler(TSCont contp, TSEvent event, void *edata);
@@ -90,6 +105,18 @@ private:
    * @return A comma-separated string representing the sensitive HTTP fields.
    */
   static std::string get_sensitive_field_description();
+
+  /** Construct a TransactionData object.
+   *
+   * Note that this constructor is private since only the global handler
+   * creates these at the moment.
+   *
+   * @param[in] txnp The TSHttpTxn for the associated HTTP transaction.
+   *
+   * @param[in] http_version_from_client_stack The HTTP version as specified in
+   *    the protocol stack, or empty string if no so specified.
+   */
+  TransactionData(TSHttpTxn txnp, std::string_view http_version_from_client_stack);
 
   /** Inspect the field to see whether it is sensitive and return a generic value
    * of equal size to the original if it is.
@@ -113,6 +140,22 @@ private:
    * @return The view without the scheme prefix.
    */
   std::string_view remove_scheme_prefix(std::string_view url);
+
+  /** Write the "client-request" node to _txn_json.
+   *
+   * Note that the "content" node is not written with this function, so it will
+   * have to be written later.
+   */
+  void write_client_request_node_no_content(TSMBuffer &buffer, TSMLoc &hdr_loc);
+
+  /// Write the "proxy-request" node to _txn_json.
+  void write_proxy_request_node(TSMBuffer &buffer, TSMLoc &hdr_loc);
+
+  /// Write the "server-response" node to _txn_json.
+  void write_server_response_node(TSMBuffer &buffer, TSMLoc &hdr_loc);
+
+  /// Write the "proxy-response" node to _txn_json.
+  void write_proxy_response_node(TSMBuffer &buffer, TSMLoc &hdr_loc);
 };
 
 } // namespace traffic_dump

--- a/tests/gold_tests/pluginTest/traffic_dump/gold/200_http10.gold
+++ b/tests/gold_tests/pluginTest/traffic_dump/gold/200_http10.gold
@@ -1,0 +1,11 @@
+``
+> GET /`` HTTP/1.0
+> Host: www.notls.com``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.0 200 OK
+< Content-Length: 0
+< Set-Cookie: classified_not_for_logging
+< Date: ``
+``

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -204,11 +204,11 @@ http_protocols = "tcp,ip"
 # Execute the second transaction.
 tr = Test.AddTestRun("Second transaction")
 tr.Processes.Default.Command = \
-    ('curl http://127.0.0.1:{0}/two -H"Host: www.notls.com" '
+    ('curl --http1.0 http://127.0.0.1:{0}/two -H"Host: www.notls.com" '
      '-H"X-Request-2: also_very_sensitive" --verbose'.format(
          ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.Streams.stderr = "gold/200.gold"
+tr.Processes.Default.Streams.stderr = "gold/200_http10.gold"
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
@@ -221,12 +221,14 @@ sensitive_fields_arg = (
     "--sensitive-fields x-request-1 "
     "--sensitive-fields x-request-2 ")
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
-tr.Processes.Default.Command = 'python3 {0} {1} {2} {3} --client-protocols "{4}"'.format(
-    verify_replay,
-    os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
-    replay_file_session_1,
-    sensitive_fields_arg,
-    http_protocols)
+tr.Processes.Default.Command = \
+    ('python3 {0} {1} {2} {3} --client-http-version "1.1" '
+     '--client-protocols "{4}"'.format(
+         verify_replay,
+         os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+         replay_file_session_1,
+         sensitive_fields_arg,
+         http_protocols))
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -234,11 +236,13 @@ tr.StillRunningAfter = ts
 # Verify the properties of the replay file for the second transaction.
 tr = Test.AddTestRun("Verify the json content of the second session")
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
-tr.Processes.Default.Command = "python3 {0} {1} {2} {3} --request-target '/two'".format(
-    verify_replay,
-    os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
-    replay_file_session_2,
-    sensitive_fields_arg)
+tr.Processes.Default.Command = \
+    ('python3 {0} {1} {2} {3} --client-http-version "1.0" '
+     '--request-target "/two"'.format(
+         verify_replay,
+         os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+         replay_file_session_2,
+         sensitive_fields_arg))
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -418,12 +422,14 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("Verify the client protocol stack.")
 h2_protocols = "http,tls,tcp,ip"
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
-tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}" --client-tls-features "{4}"'.format(
-    verify_replay,
-    os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
-    replay_file_session_9,
-    h2_protocols,
-    client_tls_features)
+tr.Processes.Default.Command = \
+    ('python3 {0} {1} {2} --client-http-version "2" '
+     '--client-protocols "{3}" --client-tls-features "{4}"'.format(
+         verify_replay,
+         os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
+         replay_file_session_9,
+         h2_protocols,
+         client_tls_features))
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -457,7 +463,7 @@ tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Verify the client protocol stack.")
 tr.Setup.CopyAs(verify_replay, Test.RunDirectory)
-tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-protocols "{3}"'.format(
+tr.Processes.Default.Command = 'python3 {0} {1} {2} --client-http-version "1.1" --client-protocols "{3}"'.format(
     verify_replay,
     os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json'),
     replay_file_session_10,

--- a/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
@@ -254,6 +254,20 @@ def verify_server_tls_features(replay_json, expected_tls_features):
     return True
 
 
+def verify_client_http_version(replay_json, expected_client_http_version):
+    try:
+        found_version = replay_json['sessions'][0]['transactions'][0]['client-request']['version']
+    except KeyError:
+        print("Could not find client-request:version node in the replay file.")
+        return False
+
+    if expected_client_http_version != found_version:
+        print('Expected client version of "{}", but found "{}"'.format(
+            expected_client_http_version, found_version))
+        return False
+    return True
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("schema_file",
@@ -278,6 +292,8 @@ def parse_args():
                         help="The TLS values to expect for the client connection.")
     parser.add_argument("--server-tls-features",
                         help="The TLS values to expect for the server connection.")
+    parser.add_argument("--client-http-version",
+                        help="The client HTTP version to expect")
     return parser.parse_args()
 
 
@@ -321,6 +337,9 @@ def main():
         return 1
 
     if args.server_tls_features and not verify_server_tls_features(replay_json, args.server_tls_features):
+        return 1
+
+    if args.client_http_version and not verify_client_http_version(replay_json, args.client_http_version):
         return 1
 
     return 0

--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -188,7 +188,33 @@
         "version": {
           "description": "HTTP version",
           "type": "string",
-          "enum": ["0.9", "1.0", "1.1", "2.0"]
+          "enum": ["0.9", "1.0", "1.1", "2", "3"]
+        },
+        "http2": {
+          "description": "A description of the HTTP/2 properties",
+          "type": "object",
+          "required": [ "stream-id" ],
+          "properties": {
+            "stream-id": {
+              "description": "The HTTP/2 stream identifier.",
+              "type": "integer"
+            },
+            "priority": {
+              "description": "A description of the HTTP/2 properties",
+              "type": "object",
+              "required": [ "stream-dependency", "weight" ],
+              "properties": {
+                "stream-dependency": {
+                  "description": "The stream this stream depends upon.",
+                  "type": "integer"
+                },
+                "weight": {
+                  "description": "The priority weight assigned to the stream dependency.",
+                  "type": "integer"
+                }
+              }
+            }
+          }
         },
         "scheme": {
           "description": "HTTP scheme (request).",
@@ -225,7 +251,7 @@
         "version": {
           "description": "HTTP version",
           "type": "string",
-          "enum": ["0.9", "1.0", "1.1", "2.0"]
+          "enum": ["0.9", "1.0", "1.1", "2", "3"]
         },
         "status": {
           "description": "Status code.",


### PR DESCRIPTION
This updates the Traffic Dump plugin to record HTTP/2 stream id and
priority informatin. To support this, this adds the following TS API
getters:

  TSHttpTxnClientHttp2StreamIdGet
  TSHttpTxnClientHttp2PriorityGet

This also fixes the "version" Traffic Dump node for HTTP/2 which,
previously, had always displayed 1.1 instead of 2 for HTTP/2
connections.