### PR TITLE
PluginFactory - Remove unused code.

### DIFF
--- a/proxy/http/remap/PluginFactory.h
+++ b/proxy/http/remap/PluginFactory.h
@@ -118,12 +118,5 @@ protected:
   std::error_code _ec;
   bool _preventiveCleaning = true;
 
-  // Hold the full path for global plugins not taking part of the dynamic reloading.
-  struct DisableReloadPluginInfo {
-    fs::path fullPath;
-  };
-
-  std::forward_list<DisableReloadPluginInfo> optoutPlugins;
-
   static constexpr const char *const _tag = "plugin_factory"; /** @brief log tag used by this class */
 };


### PR DESCRIPTION
Removing code that it's a leftover of the first `TSPluginDSOReloadEnable()` approach(#6880 ). This code was unused and does not belong to this class.