### PR TITLE
Fixes garbled logs when using %<vbn> log tag

### DIFF
--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1220,7 +1220,7 @@ LogAccess::marshal_cache_lookup_url_canon(char *buf)
 int
 LogAccess::marshal_version_build_number(char *buf)
 {
-  int len = sizeof(appVersionInfo.BldNumStr);
+  int len = LogAccess::strlen(appVersionInfo.BldNumStr);
   if (buf) {
     marshal_str(buf, appVersionInfo.BldNumStr, len);
   }


### PR DESCRIPTION
(cherry picked from commit 1674ce260e55bfc8e781f26c11244686ee78034c)