### PR TITLE
rc: fixes systemd unit file stopping

### DIFF
--- a/rc/trafficserver.service.in
+++ b/rc/trafficserver.service.in
@@ -27,8 +27,8 @@ Restart=on-failure
 RestartSec=5s
 LimitNOFILE=1000000
 ExecStopPost=/bin/sh -c ' \
-        export TM_PIDFILE=$(@exp_bindir@/traffic_layout} 2>/dev/null | grep RUNTIMEDIR | cut -d: -f2)/manager.lock ; \
-        /bin/rm -f $TM_PIDFILE ; \
+        export TM_PIDFILE=$(@exp_bindir@/traffic_layout 2>/dev/null | grep RUNTIMEDIR | cut -d: -f2)/manager.lock ; \
+        /bin/rm $TM_PIDFILE ; \
         if [[ $? -ne 0 ]]; then echo "ERROR: Unable to delete PID"; exit 1; fi'
 TimeoutStopSec=5s
 ExecReload=@exp_bindir@/traffic_ctl config reload


### PR DESCRIPTION
In the ExecStopPost stanza of the unit file, an errant "}" made the lock
file never be deleted. Also the "-f" flag to rm always makes the
returncode 0 whether or not the file exists making the return code check
always return success.