### PR TITLE
MicroDNS Extension: handle different 'default' types

### DIFF
--- a/tests/gold_tests/autest-site/microDNS.test.ext
+++ b/tests/gold_tests/autest-site/microDNS.test.ext
@@ -82,7 +82,10 @@ def MakeDNServer(obj, name, filename="dns_file.json", port=False, ip='INADDR_LOO
         jsondata = {'mappings': []}
 
         if default:
-            jsondata['otherwise'] = [default]
+            if isinstance(default, str):
+                # MicroDNS expects 'otherwise' to be a sequence.
+                default = [default]
+            jsondata['otherwise'] = default
 
         with open(filepath, 'w') as f:
             f.write(json.dumps(jsondata))


### PR DESCRIPTION
The MicroDNS extension supports populating the 'otherwise' node with a
list of hosts via the default parameter.  The Traffic Server tests only
pass a string to default, but tests could also pass a list. This makes
the extension deal with either of these input types. As it is, without
this change, tests cannot pass a list because the list itself would be
wrapped as a list.
    
This change fixes the use of MicroDNS for plugins that use the
Traffic Server extensions, such as txn_box.so.
