### PR TITLE
Fix memory leaks in multiplexer plugin

### DIFF
--- a/plugins/multiplexer/ats-multiplexer.cc
+++ b/plugins/multiplexer/ats-multiplexer.cc
@@ -118,6 +118,8 @@ DoRemap(const Instance &i, TSHttpTxn t)
     CHECK(TSMimeHdrFieldValueStringSet(buffer, location, field, -1, "original", 8));
 
     CHECK(TSMimeHdrFieldAppend(buffer, location, field));
+
+    CHECK(TSHandleMLocRelease(buffer, location, field));
   }
 
   Requests requests;


### PR DESCRIPTION
We were running jemalloc/jeprof against the multiplexer plugin, and we have identified a memory leak. 

Attached is the jeprof graph illustrating the issue - 

<img width="411" alt="Screen Shot 2020-09-02 at 2 08 34 PM" src="https://user-images.githubusercontent.com/830308/92036907-cc934d80-ed25-11ea-85b9-a11bf309fa06.png">

Please review!