### PR TITLE
Fix #7167, make pep8 failure

### DIFF
--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -50,7 +50,7 @@ function main() {
   pip install -q "pycodestyle==${PYCODESTYLE_TAG}"
   pip install -q "autopep8==${AUTOPEP8_VERSION}"
 
-  ver=$(autopep8 --version)
+  ver=$(autopep8 --version 2>&1)
   if [ "$ver" != "$VERSION" ]
   then
       echo "Wrong version of autopep8!"


### PR DESCRIPTION
On a rhel7 box, `autopep8 --version` writes to stderr instead of stdout. That caused the issue in #7167 

```
zizhang@zizhang-ld1 :) ~/source/zzzats
$ ver=`autopep8 --version 2>&1`; echo "VERSION="$ver
VERSION=autopep8 1.5.4 (pycodestyle: 2.6.0)
zizhang@zizhang-ld1 :) ~/source/zzzats
$ ver=`autopep8 --version`; echo "VERSION="$ver
autopep8 1.5.4 (pycodestyle: 2.6.0)
VERSION=
```