### PR TITLE
Create an explicit runroot.yaml for AuTests

### DIFF
--- a/tests/gold_tests/autest-site/autest_runroot_layout.yml
+++ b/tests/gold_tests/autest-site/autest_runroot_layout.yml
@@ -1,0 +1,28 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+prefix: .
+exec_prefix: .
+bindir: ./bin
+sbindir: ./bin
+sysconfdir: ./etc/trafficserver
+datadir: ./share/trafficserver
+includedir: ./include
+libdir: ./lib
+libexecdir: ./libexec/trafficserver
+localstatedir: ./var
+runtimedir: ./runtime
+logdir: ./log

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -75,6 +75,18 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
 
     # set root for this test
     p.Env['TS_ROOT'] = ts_dir
+
+    # Explicitly create a runroot.yaml in the sandbox so that any other
+    # runroot.yaml files don't confuse the test Traffic Server processes as to
+    # where their Runroot should be. For the test, the user specified a sandbox
+    # so that should be used as the Runroot.
+    traffic_layout = os.path.join(p.Variables.BINDIR, 'traffic_layout')
+    autest_runroot_yaml = os.path.join(AUTEST_SITE_PATH, 'autest_runroot_layout.yml')
+    p.Setup.RunCommand(
+        'TS_ROOT={} {} init --force --copy-style soft --path {} '
+        '--layout={}'.format(
+            p.Variables.PREFIX, traffic_layout, ts_dir, autest_runroot_yaml))
+
     p.Setup.MakeDir(ts_dir)
 
     # set bin location
@@ -82,7 +94,6 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     p.Env['PROXY_CONFIG_BIN_PATH'] = bin_dir
     bin_path = os.path.join(ts_dir, bin_dir)
     p.Env['PATH'] = bin_path + os.pathsep + p.ComposeEnv()['PATH']
-    p.Setup.Copy(p.Variables.BINDIR, bin_path, CopyLogic.SoftFiles)
 
     # setup config directory
 
@@ -125,7 +136,6 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     #########################################################
     # create subdirectories that need to exist (but are empty)
     # log directory has to be created with correct permissions
-    p.Setup.MakeDir(log_dir)  # log directory has to be created
     p.Setup.Chown(log_dir, "nobody", "nobody", ignore=True)
     # covers ubuntu's unprivileged group
     p.Setup.Chown(log_dir, "nobody", "nogroup", ignore=True)
@@ -142,7 +152,6 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     p.Variables.RUNTIMEDIR = runtime_dir
     p.Variables.LOCALSTATEDIR = runtime_dir
 
-    p.Setup.MakeDir(runtime_dir)
     p.Setup.Chown(runtime_dir, "nobody", "nobody", ignore=True)
     # covers ubuntu's unprivileged group
     p.Setup.Chown(runtime_dir, "nobody", "nogroup", ignore=True)


### PR DESCRIPTION
The ATS install directory may have its own runroot.yaml, but we don't
want AuTest to use that. The user specified a sandbox via autest and we
want the tests to use that location as the runroot. To ensure this, this
patch has the trafficserver extension create its own runroot.yaml in the
sandbox directory which the Traffic Server process will find via the
TS_ROOT environment variable.