### PR TITLE
Remove obsolete cdn_ HttpTransact vars

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -762,9 +762,7 @@ how_to_open_connection(HttpTransact::State *s)
   // Setting up a direct CONNECT tunnel enters OriginServerRawOpen. We always do that if we
   // are not forwarding CONNECT and are not going to a parent proxy.
   if (s->method == HTTP_WKSIDX_CONNECT) {
-    if (s->txn_conf->forward_connect_method == 1 || s->parent_result.result == PARENT_SPECIFIED) {
-      connect_next_action = HttpTransact::SM_ACTION_ORIGIN_SERVER_OPEN;
-    } else {
+    if (s->txn_conf->forward_connect_method != 1 && s->parent_result.result != PARENT_SPECIFIED) {
       connect_next_action = HttpTransact::SM_ACTION_ORIGIN_SERVER_RAW_OPEN;
     }
   }

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -702,12 +702,6 @@ public:
     //  able to defer some work in building the request
     TransactFunc_t pending_work = nullptr;
 
-    // Sandbox of Variables
-    StateMachineAction_t cdn_saved_next_action        = SM_ACTION_UNDEFINED;
-    void (*cdn_saved_transact_return_point)(State *s) = nullptr;
-    bool cdn_remap_complete                           = false;
-    bool first_dns_lookup                             = true;
-
     HttpRequestData request_data;
     ParentConfigParams *parent_params                           = nullptr;
     std::shared_ptr<NextHopSelectionStrategy> next_hop_strategy = nullptr;


### PR DESCRIPTION
Noticed this while working through the origin connect code to restructure it for multiple protocols.

First I observed that cdn_remap_complete is only set to true, so the true check clause in HttpTransact::OSDNSLookup is obsolete.  Once that clause removed, cdn_saved_next_action is only set in how_to_open_connection and used as a return value.  So it is easy enough to replace the member variable with a local variable.

Finally cdn_saved_transact_return_point and first_dns_lookup are only ever initialized and never used.