### PR TITLE
TextView: add constructor size values to enable strlen even for null pointers

### DIFF
--- a/src/tscpp/util/TextView.cc
+++ b/src/tscpp/util/TextView.cc
@@ -27,6 +27,8 @@
 #include <cctype>
 #include <sstream>
 
+static_assert(size_t(-1) == std::string_view::npos, "TextView assumes -1 is the same as npos");
+
 int
 memcmp(std::string_view const &lhs, std::string_view const &rhs)
 {


### PR DESCRIPTION
Some minor cleanup
*  Better comments (remove some inline argument comments)
*  Tweak constructors to enable invoking `strlen` on the string pointer in a way that's safe even if the string is a null pointer.
*  Tweak `assign` as above.
*  Add the `_tv` literal extension in parallel to `_sv`.

The `strlen` support for size is handy, as it corresponds to how this is handled in the plugin API where "-1" means "compute the length". While this could be done at the call site, having to handle null pointers on top of that becomes annoying and error prone. This makes it self to do `TextView v{ptr, TextView::npos};` without having to worry if `ptr` is `nullptr`. In the latter case the view will be safely initialized to an empty state.