### PR TITLE
Make custom xdebug HTTP header name available to other plugins.

### DIFF
--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -706,6 +706,13 @@ TSPluginInit(int argc, const char *argv[])
   }
   xDebugHeader.len = strlen(xDebugHeader.str);
 
+  // Make xDebugHeader available to other plugins, as a C-style string.
+  //
+  int idx = -1;
+  TSReleaseAssert(TSUserArgIndexReserve(TS_USER_ARGS_GLB, "XDebugHeader", "XDebug header name", &idx) == TS_SUCCESS);
+  TSReleaseAssert(idx >= 0);
+  TSUserArgSet(nullptr, idx, const_cast<char *>(xDebugHeader.str));
+
   AuxDataMgr::init("xdebug");
 
   // Setup the global hook


### PR DESCRIPTION
The custom header name is passed to the xdebug plugin as plugin parameter.  This change makes it available
as a global TS API user parameter.