### PR TITLE
Fix the active_timeout test to work without quic enabled

### DIFF
--- a/tests/gold_tests/timeout/active_timeout.test.py
+++ b/tests/gold_tests/timeout/active_timeout.test.py
@@ -22,7 +22,10 @@ Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )
 
-ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_quic=True)
+if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
+    ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_quic=True)
+else:
+    ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server", delay=8)
 
 request_header = {"headers": "GET /file HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
@@ -62,6 +65,6 @@ tr3.Processes.Default.Command = 'curl -k -i --http2 https://127.0.0.1:{0}/file'.
 tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")
 
 if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
-    tr4= Test.AddTestRun("tr")
+    tr4 = Test.AddTestRun("tr")
     tr4.Processes.Default.Command = 'curl -k -i --http3 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port)
     tr4.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")


### PR DESCRIPTION
The master autest job has been failing on active_timeout.  It also failed on my local build with the standard openssl library (no quic enabled).

Looking in diags.log we see

```
[Sep 16 16:12:33.112] traffic_server WARNING: Invalid option 'quic' in proxy port descriptor '2003:quic'
[Sep 16 16:12:33.112] traffic_server WARNING: Invalid option 'quic' in proxy port descriptor '2004:quic:ipv6'
```

and 

```
[Sep 16 16:12:33.151] [ET_NET 10] ERROR: Could not bind or listen to port 2003 (error: -1)
[Sep 16 16:12:33.151] [ET_NET 10] WARNING: unable to listen on port 2003: -1 98, Address already in use
[Sep 16 16:12:33.151] [ET_NET 10] ERROR: Could not bind or listen to port 2004 (error: -1)
[Sep 16 16:12:33.151] [ET_NET 10] WARNING: unable to listen on port 2004: -1 98, Address already in use
[Sep 16 16:12:33.151] [ET_NET 10] NOTE: Traffic Server is fully initialized.
```

By protecting the enable_quic option to the ts creation with the QUIC feature test, the errors go away and the test passes.  A search shows that this is the only test exercising the enable_quic option so far.