### PR TITLE
Rename ambiguous log variable

### DIFF
--- a/example/plugins/cpp-api/logger_example/LoggerExample.cc
+++ b/example/plugins/cpp-api/logger_example/LoggerExample.cc
@@ -33,7 +33,7 @@ using std::string;
 
 namespace
 {
-Logger log;
+Logger logger;
 GlobalPlugin *plugin;
 } // namespace
 
@@ -61,7 +61,7 @@ public:
   void
   handleReadRequestHeadersPostRemap(Transaction &transaction) override
   {
-    LOG_DEBUG(log,
+    LOG_DEBUG(logger,
               "handleReadRequestHeadersPostRemap.\n"
               "\tRequest URL: %s\n"
               "\tRequest Path: %s\n"
@@ -74,23 +74,23 @@ public:
     // Next, to demonstrate how you can change logging levels:
     if (transaction.getClientRequest().getUrl().getPath() == "change_log_level") {
       if (transaction.getClientRequest().getUrl().getQuery().find("level=debug") != string::npos) {
-        log.setLogLevel(Logger::LOG_LEVEL_DEBUG);
-        LOG_DEBUG(log, "Changed log level to DEBUG");
+        logger.setLogLevel(Logger::LOG_LEVEL_DEBUG);
+        LOG_DEBUG(logger, "Changed log level to DEBUG");
       } else if (transaction.getClientRequest().getUrl().getQuery().find("level=info") != string::npos) {
-        log.setLogLevel(Logger::LOG_LEVEL_INFO);
-        LOG_INFO(log, "Changed log level to INFO");
+        logger.setLogLevel(Logger::LOG_LEVEL_INFO);
+        LOG_INFO(logger, "Changed log level to INFO");
       } else if (transaction.getClientRequest().getUrl().getQuery().find("level=error") != string::npos) {
-        log.setLogLevel(Logger::LOG_LEVEL_ERROR);
-        LOG_ERROR(log, "Changed log level to ERROR");
+        logger.setLogLevel(Logger::LOG_LEVEL_ERROR);
+        LOG_ERROR(logger, "Changed log level to ERROR");
       }
     }
 
     // One drawback to using the Traffic Server Text Loggers is that you're limited in the size of the log
     // lines, this limit is now set at 8kb for atscppapi, but this limit might be removed in the future.
-    LOG_INFO(log, "This message will be dropped (see error.log) because it's just too big: %s", big_buffer_14kb_);
+    LOG_INFO(logger, "This message will be dropped (see error.log) because it's just too big: %s", big_buffer_14kb_);
 
     // This should work though:
-    LOG_INFO(log, "%s", big_buffer_6kb_);
+    LOG_INFO(logger, "%s", big_buffer_6kb_);
 
     transaction.resume();
   }
@@ -119,24 +119,24 @@ TSPluginInit(int argc ATSCPPAPI_UNUSED, const char *argv[] ATSCPPAPI_UNUSED)
   // The fifth argument is to enable log rolling, this is enabled by default.
   // The sixth argument is the frequency in which we will roll the logs, 300 seconds is very low,
   //  the default for this argument is 3600.
-  log.init("logger_example", true, true, Logger::LOG_LEVEL_DEBUG, true, 300);
+  logger.init("logger_example", true, true, Logger::LOG_LEVEL_DEBUG, true, 300);
 
   // Now that we've initialized a logger we can do all kinds of fun things on it:
-  log.setRollingEnabled(true);        // already done via log.init, just an example.
-  log.setRollingIntervalSeconds(300); // already done via log.init
+  logger.setRollingEnabled(true);        // already done via log.init, just an example.
+  logger.setRollingIntervalSeconds(300); // already done via log.init
 
   // You have two ways to log to a logger, you can log directly on the object itself:
-  log.logInfo("Hello World from: %s", argv[0]);
+  logger.logInfo("Hello World from: %s", argv[0]);
 
   // Alternatively you can take advantage of the super helper macros for logging
   // that will include the file, function, and line number automatically as part
   // of the log message:
-  LOG_INFO(log, "Hello World with more info from: %s", argv[0]);
+  LOG_INFO(logger, "Hello World with more info from: %s", argv[0]);
 
   // This will hurt performance, but it's an option that's always available to you
   // to force flush the logs. Otherwise TrafficServer will flush the logs around
   // once every second. You should really avoid flushing the log unless it's really necessary.
-  log.flush();
+  logger.flush();
 
   plugin = new GlobalHookPlugin();
 }


### PR DESCRIPTION
I got a compile error after updating Xcode.

```
Making all in cpp-api
  CXX      logger_example/LoggerExample.lo
logger_example/LoggerExample.cc:64:15: error: reference to 'log' is ambiguous
    LOG_DEBUG(log,
              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/math.h:1003:1: note: candidate found by name lookup is 'log'
log(_A1 __lcpp_x) _NOEXCEPT {return ::log((double)__lcpp_x);}
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/math.h:997:46: note: candidate found by name lookup is 'log'
inline _LIBCPP_INLINE_VISIBILITY long double log(long double __lcpp_x) _NOEXCEPT {return ::logl(__lcpp_x);}
                                             ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/math.h:996:46: note: candidate found by name lookup is 'log'
inline _LIBCPP_INLINE_VISIBILITY float       log(float __lcpp_x) _NOEXCEPT       {return ::logf(__lcpp_x);}
                                             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/math.h:373:15: note: candidate found by name lookup is 'log'
extern double log(double);
              ^
logger_example/LoggerExample.cc:36:8: note: candidate found by name lookup is '(anonymous namespace)::log'
Logger log;
       ^
logger_example/LoggerExample.cc:64:15: error: unknown type name 'log'; did you mean 'long'?
    LOG_DEBUG(log,
              ^~~
              long
```

```
$ clang --version
Apple clang version 12.0.0 (clang-1200.0.32.2)
```