### PR TITLE
Strip whitespaces after field-name and before the colon in headers from the origin

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2572,12 +2572,14 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
     // whitespace between a header field-name and colon with a response code
     // of 400 (Bad Request).
     // A proxy MUST remove any such whitespace from a response message before
-    // fowarding the message downstream.
+    // forwarding the message downstream.
+    bool raw_print_field = true;
     if (is_ws(field_name.back())) {
       if (!remove_ws_from_field_name) {
         return PARSE_RESULT_ERROR;
       }
       field_name.rtrim_if(&ParseRules::is_ws);
+      raw_print_field = false;
     }
 
     // find value first
@@ -2613,7 +2615,7 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
 
     MIMEField *field = mime_field_create(heap, mh);
     mime_field_name_value_set(heap, mh, field, field_name_wks_idx, field_name.data(), field_name.size(), field_value.data(),
-                              field_value.size(), true, parsed.size(), false);
+                              field_value.size(), raw_print_field, parsed.size(), false);
     mime_hdr_field_attach(mh, field, 1, nullptr);
   }
 }

--- a/tests/gold_tests/headers/field_name_space.test.py
+++ b/tests/gold_tests/headers/field_name_space.test.py
@@ -33,7 +33,7 @@ request_header = {
     "timestamp": "1469733493.993",
     "body": ""}
 response_header = {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nX-Foo : 123\r\nX-Foo: 456\r\n",
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nFoo : 123\r\nFoo: 456\r\n",
     "timestamp": "1469733493.993",
     "body": "xxx"}
 server.addResponse("sessionlog.json", request_header, response_header)

--- a/tests/gold_tests/headers/field_name_space.test.py
+++ b/tests/gold_tests/headers/field_name_space.test.py
@@ -1,0 +1,53 @@
+'''
+Test on handeling spaces after the field name and before the colon
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Checking  on handeling spaces after the field name and before the colon
+'''
+
+Test.ContinueOnFail = True
+
+# Define default ATS
+ts = Test.MakeATSProcess("ts")
+server = Test.MakeOriginServer("server")
+
+testName = "field_name_space"
+request_header = {
+    "headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""}
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nX-Foo : 123\r\nX-Foo: 456\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"}
+server.addResponse("sessionlog.json", request_header, response_header)
+
+ts.Disk.remap_config.AddLine(
+    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+
+# Test spaces at the end of the field name and before the :
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.Command = 'curl -s -D - -v --ipv4 --http1.1 -H "Host: www.example.com" http://localhost:{0}/'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stderr = "gold/field_name_space.gold"
+tr.StillRunningAfter = ts

--- a/tests/gold_tests/headers/gold/field_name_space.gold
+++ b/tests/gold_tests/headers/gold/field_name_space.gold
@@ -4,7 +4,8 @@
 > User-Agent: curl/``
 ``
 < HTTP/1.1 200 OK
-< X-Foo: 123, 456
+< Foo: 123
+< Foo: 456
 < Content-Length: 3
 < Date: ``
 < Age: ``

--- a/tests/gold_tests/headers/gold/field_name_space.gold
+++ b/tests/gold_tests/headers/gold/field_name_space.gold
@@ -1,0 +1,13 @@
+``
+> GET /``
+> Host: www.example.com``
+> User-Agent: curl/``
+``
+< HTTP/1.1 200 OK
+< X-Foo: 123, 456
+< Content-Length: 3
+< Date: ``
+< Age: ``
+< Connection: keep-alive
+< Server: ATS/``
+``


### PR DESCRIPTION
This fixes #7176 