### PR TITLE
Convert PluginVC Regression Test to an Au Test.

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -23,6 +23,7 @@
 
 #include "P_DNS.h"
 #include "tscore/ink_inet.h"
+#include "tscore/Regression.h"
 
 #include "I_SplitDNS.h"
 

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -28,6 +28,7 @@
 #include "Show.h"
 #include "tscore/Tokenizer.h"
 #include "tscore/ink_apidefs.h"
+#include "tscore/Regression.h"
 
 #include <utility>
 #include <vector>

--- a/iocore/net/P_Net.h
+++ b/iocore/net/P_Net.h
@@ -104,7 +104,6 @@ extern RecRawStatBlock *net_rsb;
 #include "P_UnixPollDescriptor.h"
 #include "P_Socks.h"
 #include "P_CompletionUtil.h"
-#include "P_NetVCTest.h"
 
 #include "P_SSLNetVConnection.h"
 #include "P_SSLNetProcessor.h"

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -31,6 +31,7 @@
 #include "HttpTransact.h"
 #include "I_Machine.h"
 #include "tscore/Filenames.h"
+#include "tscore/Regression.h"
 
 #define MAX_SIMPLE_RETRIES 5
 #define MAX_UNAVAILABLE_SERVER_RETRIES 5

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -74,7 +74,6 @@
 #include "PluginVC.h"
 #include "P_EventSystem.h"
 #include "P_Net.h"
-#include "tscore/Regression.h"
 
 #define PVC_LOCK_RETRY_TIME HRTIME_MSECONDS(10)
 #define PVC_DEFAULT_MAX_BYTES 32768
@@ -1276,13 +1275,23 @@ PluginVCCore::set_plugin_tag(const char *tag)
   passive_vc.plugin_tag = active_vc.plugin_tag = tag;
 }
 
+#if !defined(INCLUDE_CONVERTED_TO_AU_TEST)
+#define INCLUDE_CONVERTED_TO_AU_TEST 1
+#endif
+
 /*************************************************************
  *
  *   REGRESSION TEST STUFF
  *
  **************************************************************/
 
-#if TS_HAS_TESTS
+#if TS_HAS_TESTS && INCLUDE_CONVERTED_TO_AU_TEST
+
+#include "P_NetVCTest.h"
+#include "tscore/Regression.h"
+
+// Note that, if this test is deleted, then P_NetVCTest.h and NetVCTest.cc in iocore/net can also be removed.
+
 class PVCTestDriver : public NetTestDriver
 {
 public:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,6 +24,16 @@ SUBDIRS =
 
 AM_LDFLAGS += $(TS_PLUGIN_LD_FLAGS)
 
+AM_CPPFLAGS += \
+  -I$(abs_top_srcdir)/iocore/dns \
+  -I$(abs_top_srcdir)/iocore/eventsystem \
+  -I$(abs_top_srcdir)/iocore/hostdb \
+  -I$(abs_top_srcdir)/iocore/net \
+  -I$(abs_top_srcdir)/mgmt \
+  -I$(abs_top_srcdir)/mgmt/utils \
+  -I$(abs_top_srcdir)/proxy \
+  -I$(abs_top_srcdir)/proxy/hdrs
+
 # Automake is pretty draconian about not creating shared object (.so) files for
 # non-installed files. However we do not want to install our test plugins so
 # we prefix them with noinst_.  The following -rpath argument coerces the
@@ -34,6 +44,7 @@ include gold_tests/continuations/plugins/Makefile.inc
 include gold_tests/chunked_encoding/Makefile.inc
 include gold_tests/timeout/Makefile.inc
 include gold_tests/tls/Makefile.inc
+include gold_tests/unit_testing/Makefile.inc
 include tools/plugins/Makefile.inc
 
 TESTS = $(check_PROGRAMS)

--- a/tests/gold_tests/unit_testing/Makefile.inc
+++ b/tests/gold_tests/unit_testing/Makefile.inc
@@ -1,0 +1,25 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# This file is included in test/Makefile.am under repo root directory.
+
+noinst_LTLIBRARIES += gold_tests/unit_testing/unit_testing.la
+gold_tests_unit_testing_unit_testing_la_SOURCES = \
+  gold_tests/unit_testing/unit_testing.cc \
+  gold_tests/unit_testing/unit_testing.h \
+  gold_tests/unit_testing/PluginVC/NetVCTest.h \
+  gold_tests/unit_testing/PluginVC/NetVCTest.cc \
+  gold_tests/unit_testing/PluginVC/PluginVC_UT.cc

--- a/tests/gold_tests/unit_testing/PluginVC/NetVCTest.h
+++ b/tests/gold_tests/unit_testing/PluginVC/NetVCTest.h
@@ -1,0 +1,132 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/****************************************************************************
+
+   NetVCTest.h
+
+   Description:
+       Unit test for infrastructure for VConnections implementing the
+         NetVConnection interface
+
+ ****************************************************************************/
+
+#pragma once
+
+#include <tscore/ink_platform.h>
+
+class VIO;
+class MIOBuffer;
+class IOBufferReader;
+
+namespace Au_UT
+{
+enum NetVcTestType_t {
+  NET_VC_TEST_ACTIVE,
+  NET_VC_TEST_PASSIVE,
+};
+
+struct NVC_test_def {
+  const char *test_name;
+
+  int bytes_to_send;
+  int nbytes_write;
+
+  int bytes_to_read;
+  int nbytes_read;
+
+  int write_bytes_per;
+  int timeout;
+
+  int expected_read_term;
+  int expected_write_term;
+};
+
+extern NVC_test_def netvc_tests_def[];
+extern const unsigned num_netvc_tests;
+
+struct NetTestDriver : public Continuation {
+  int errors = 0;
+};
+
+class NetVCTest : public Continuation
+{
+public:
+  NetVCTest();
+  ~NetVCTest() override;
+  NetVcTestType_t test_cont_type = NET_VC_TEST_ACTIVE;
+
+  int main_handler(int event, void *data);
+  void read_handler(int event);
+  void write_handler(int event);
+  void cleanup();
+
+  void init_test(NetVcTestType_t n_type, NetTestDriver *driver, NetVConnection *nvc, NVC_test_def *my_def,
+                 const char *module_name_arg);
+  void start_test();
+  int fill_buffer(MIOBuffer *buf, uint8_t *seed, int bytes);
+  int consume_and_check_bytes(IOBufferReader *r, uint8_t *seed);
+
+  void write_finished();
+  void read_finished();
+  void finished();
+  void record_error(const char *msg);
+
+  NetVConnection *test_vc = nullptr;
+  NetTestDriver *driver   = nullptr;
+
+  VIO *read_vio  = nullptr;
+  VIO *write_vio = nullptr;
+
+  MIOBuffer *read_buffer  = nullptr;
+  MIOBuffer *write_buffer = nullptr;
+
+  IOBufferReader *reader_for_rbuf = nullptr;
+  IOBufferReader *reader_for_wbuf = nullptr;
+
+  int write_bytes_to_add_per = 0;
+  int timeout                = 0;
+
+  int actual_bytes_read = 0;
+  int actual_bytes_sent = 0;
+
+  bool write_done = false;
+  bool read_done  = false;
+
+  uint8_t read_seed  = 0;
+  uint8_t write_seed = 0;
+
+  int bytes_to_send = 0;
+  int bytes_to_read = 0;
+
+  int nbytes_read  = 0;
+  int nbytes_write = 0;
+
+  int expected_read_term  = 0;
+  int expected_write_term = 0;
+
+  const char *test_name   = nullptr;
+  const char *module_name = nullptr;
+};
+
+} // end namespace Au_UT

--- a/tests/gold_tests/unit_testing/PluginVC/PluginVC_UT.cc
+++ b/tests/gold_tests/unit_testing/PluginVC/PluginVC_UT.cc
@@ -1,0 +1,121 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/****************************************************************************
+
+   Description: Unit testing for proxy/PluginVC.cc.
+
+ ****************************************************************************/
+
+#include <PluginVC.h>
+#include <P_EventSystem.h>
+#include <P_Net.h>
+#include "NetVCTest.h"
+
+#include "../unit_testing.h"
+
+namespace
+{
+class PVCTestDriver : public NetTestDriver
+{
+public:
+  PVCTestDriver(InProgress const &ip);
+  ~PVCTestDriver() override;
+
+  void start_tests();
+  void run_next_test();
+  int main_handler(int event, void *data);
+
+private:
+  unsigned i                    = 0;
+  unsigned completions_received = 0;
+  InProgress _ip;
+};
+
+PVCTestDriver::PVCTestDriver(InProgress const &ip) : _ip(ip) {}
+
+PVCTestDriver::~PVCTestDriver()
+{
+  mutex = nullptr;
+}
+
+void
+PVCTestDriver::start_tests()
+{
+  mutex = new_ProxyMutex();
+  MUTEX_TRY_LOCK(lock, mutex, this_ethread());
+
+  SET_HANDLER(&PVCTestDriver::main_handler);
+
+  run_next_test();
+}
+
+void
+PVCTestDriver::run_next_test()
+{
+  unsigned a_index = i * 2;
+  unsigned p_index = a_index + 1;
+
+  if (p_index >= num_netvc_tests) {
+    // We are done - PASS or FAIL?
+    ink_release_assert(errors == 0);
+    delete this;
+    return;
+  }
+  completions_received = 0;
+  i++;
+
+  TSDebug(Debug_tag, "PVCTestDriver: Starting test %s", netvc_tests_def[a_index].test_name);
+
+  NetVCTest *p       = new NetVCTest;
+  NetVCTest *a       = new NetVCTest;
+  PluginVCCore *core = PluginVCCore::alloc(p);
+
+  p->init_test(NET_VC_TEST_PASSIVE, this, nullptr, &netvc_tests_def[p_index], "PluginVC");
+  PluginVC *a_vc = core->connect();
+
+  a->init_test(NET_VC_TEST_ACTIVE, this, a_vc, &netvc_tests_def[a_index], "PluginVC");
+}
+
+int
+PVCTestDriver::main_handler(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
+{
+  completions_received++;
+
+  if (completions_received == 2) {
+    run_next_test();
+  }
+
+  return 0;
+}
+
+void
+test(InProgress ip)
+{
+  PVCTestDriver *driver = new PVCTestDriver(ip);
+  driver->start_tests();
+}
+
+Test t(test);
+
+} // end anonymous namespace

--- a/tests/gold_tests/unit_testing/unit_testing.cc
+++ b/tests/gold_tests/unit_testing/unit_testing.cc
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <deque>
+#include <atomic>
+#include <memory>
+
+#include <unistd.h>
+
+#include <tscore/ink_assert.h>
+
+#include "unit_testing.h"
+
+namespace
+{
+std::deque<void (*)(InProgress)> testList;
+}
+
+namespace Au_UT
+{
+char const Debug_tag[] = "Au_UT";
+
+FileDeleter::FileDeleter(std::string_view pathspec) : _pathspec(pathspec) {}
+FileDeleter::~FileDeleter()
+{
+  unlink(_pathspec.c_str());
+}
+
+Test::Test(void (*test_func)(InProgress))
+{
+  testList.push_back(test_func);
+}
+
+} // end namespace Au_UT
+
+namespace
+{
+// A copy of this is passed to each test function.  If the test creates any self-deleting objects in the heap,
+// each such object should contain a copy of this object.  When all the copies are destroyed (or reset), the
+// corresponding file will be deleted (and the Au test can detect the deletion).
+//
+InProgress delete_on_completion;
+
+std::atomic<unsigned> lifecycle_event_count;
+
+int
+contFunc(TSCont cont, TSEvent event, void *eventData)
+{
+  ink_release_assert((TS_EVENT_LIFECYCLE_PORTS_READY == event) || (TS_EVENT_LIFECYCLE_TASK_THREADS_READY == event));
+
+  ++lifecycle_event_count;
+
+  ink_release_assert(lifecycle_event_count <= 2);
+
+  if (2 == lifecycle_event_count) {
+    // Run all of the tests in the list.
+    //
+    for (auto fp : testList) {
+      fp(delete_on_completion);
+    }
+
+    // Reset the shared pointer.  From now on, the file to be deleted on completion will only continue to exist
+    // as long as previously-made copies of this object exist.
+    //
+    delete_on_completion.reset();
+
+    TSContDestroy(cont);
+  }
+
+  return 0;
+}
+
+} // end anonymous namespace
+
+// argv[1] - Pathspec of file to delete when all activity triggered by ports ready lifecycle hook completes.
+//
+void
+TSPluginInit(int argc, const char *argv[])
+{
+  TSDebug(Debug_tag, "unit_testing: TSPluginInit()");
+
+  TSReleaseAssert(2 == argc);
+
+  TSPluginRegistrationInfo info;
+
+  info.plugin_name   = "unit_testing";
+  info.vendor_name   = "Apache Software Foundation";
+  info.support_email = "dev@trafficserver.apache.org";
+
+  if (TSPluginRegister(&info) != TS_SUCCESS) {
+    TSError("unit_testing: Plugin registration failed");
+
+    return;
+  }
+
+  delete_on_completion = std::make_shared<FileDeleter>(argv[1]);
+
+  auto cont = TSContCreate(contFunc, nullptr);
+  TSLifecycleHookAdd(TS_LIFECYCLE_PORTS_READY_HOOK, cont);
+  TSLifecycleHookAdd(TS_LIFECYCLE_TASK_THREADS_READY_HOOK, cont);
+}

--- a/tests/gold_tests/unit_testing/unit_testing.h
+++ b/tests/gold_tests/unit_testing/unit_testing.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include <ts/ts.h>
+
+namespace Au_UT
+{
+extern char const Debug_tag[];
+
+// Delete file whose path is specified in the constructor when the instance is destroyed.
+//
+class FileDeleter
+{
+public:
+  FileDeleter(std::string_view pathspec);
+
+  ~FileDeleter();
+
+private:
+  std::string _pathspec;
+};
+
+using InProgress = std::shared_ptr<FileDeleter>;
+
+// Create a statically-allocated object of this class to register a test function.  The function starts but may
+// not finish the test.  To indicate that the test has finished, it should destroy the InProgress object that
+// it is passed, plus all the copies that it makes of the object.  A test must cause traffic_server to exit
+// with a non-zero exit value if it fails.
+//
+struct Test {
+  Test(void (*test_func)(InProgress));
+};
+
+} // end namespace Au_UT
+
+using namespace Au_UT;

--- a/tests/gold_tests/unit_testing/unit_testing.test.py
+++ b/tests/gold_tests/unit_testing/unit_testing.test.py
@@ -1,0 +1,60 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Some TS code has very complex dependencies.  This make it impractical to unit test it with Catch, because it's
+# too complicated to link a Catch executable.  Such code should be unit tested in the plugin for this Au test.
+
+import os
+
+
+Test.Summary = '''
+Unit testing for code with complex dependencies.
+'''
+
+ts = Test.MakeATSProcess("ts")
+
+ts.Disk.records_config.update({
+    # NOTE: The PluginVC "overflow" test seems to get into an infinite loop when debug out is enabled.
+    'proxy.config.diags.debug.enabled': 0,
+    'proxy.config.diags.debug.tags': 'pvc|pvc_event|Au_UT',
+})
+
+# File to be deleted when tests are fully completed.
+#
+InProgressFilePathspec = os.path.join(Test.RunDirectory, "in_progress")
+
+Test.PrepareTestPlugin(
+    os.path.join(os.path.join(Test.TestDirectory, ".libs"), "unit_testing.so"), ts,
+    plugin_args=InProgressFilePathspec
+)
+
+# Create file to be deleted when tests are fully completed.
+#
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "touch " + InProgressFilePathspec
+tr.Processes.Default.ReturnCode = 0
+
+# Give tests up to 60 seconds to complete.
+#
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(ts)
+tr.Processes.Default.Command = (
+    "N=60 ; while ((N > 0 )) ; do " +
+    "if [[ ! -f " + InProgressFilePathspec + " ]] ; then exit 0 ; fi ; sleep 1 ; let N=N-1 ; " +
+    "done ; echo 'TIMEOUT' ; exit 1"
+)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts


### PR DESCRIPTION
I converted this to an Au test rather than a Catch test, because linking the Catch test executable was too difficult.