### PR TITLE
Add duplicate header field processing when creating outgoing response

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7861,6 +7861,14 @@ HttpTransact::build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing
               ink_assert(field != nullptr);
               value = field->value_get(&len);
               outgoing_response->value_append(fields[i].name, fields[i].len, value, len, false);
+              if (field->has_dups()) {
+                field = field->m_next_dup;
+                while (field) {
+                  value = field->value_get(&len);
+                  outgoing_response->value_append(fields[i].name, fields[i].len, value, len, true);
+                  field = field->m_next_dup;
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Currently when we are copying fields from a generated base response over
to our outgoing response we ignore duplicate fields.  This can remove
entries from headers such as Cache-Control if they come in on multiple
header fields

Resolves #5679 