### PR TITLE
Fix ip-allow reloads for 8x

### DIFF
--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -287,7 +287,7 @@ public:
   }
 
   /// acl record - cache IpAllow::match() call
-  
+
   const AclRecord *
   get_acl_record()
   {
@@ -303,7 +303,7 @@ public:
   {
     this->acl_record = acl_record;
   }
-  
+
   /// Local address for outbound connection.
   IpAddr outbound_ip4;
   /// Local address for outbound connection.
@@ -325,7 +325,7 @@ protected:
   // XXX Consider using a bitwise flags variable for the following flags, so
   // that we can make the best use of internal alignment padding.
   const AclRecord *acl_record = nullptr;
-  
+
   // Session specific debug flag.
   bool debug_on   = false;
   bool hooks_on   = true;

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -147,7 +147,7 @@ public:
   const AclRecord *
   get_acl_record() const
   {
-    return parent ? parent->acl_record : nullptr;
+    return parent ? parent->get_acl_record() : nullptr;
   }
 
   // Indicate we are done with this transaction

--- a/proxy/http/HttpSessionAccept.cc
+++ b/proxy/http/HttpSessionAccept.cc
@@ -67,7 +67,7 @@ HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReade
   new_session->outbound_ip6              = outbound_ip6;
   new_session->outbound_port             = outbound_port;
   new_session->host_res_style            = ats_host_res_from(client_ip->sa_family, host_res_preference);
-  new_session->acl_record                = acl_record;
+  new_session->set_acl_record(acl_record);
 
   new_session->new_connection(netvc, iobuf, reader, backdoor);
 

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -54,7 +54,7 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
   }
 
   Http2ClientSession *new_session = THREAD_ALLOC_INIT(http2ClientSessionAllocator, this_ethread());
-  new_session->acl_record         = session_acl_record;
+  new_session->set_acl_record(session_acl_record);
   new_session->host_res_style     = ats_host_res_from(client_ip->sa_family, options.host_res_preference);
   new_session->outbound_ip4       = options.outbound_ip4;
   new_session->outbound_ip6       = options.outbound_ip6;

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -55,10 +55,10 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
 
   Http2ClientSession *new_session = THREAD_ALLOC_INIT(http2ClientSessionAllocator, this_ethread());
   new_session->set_acl_record(session_acl_record);
-  new_session->host_res_style     = ats_host_res_from(client_ip->sa_family, options.host_res_preference);
-  new_session->outbound_ip4       = options.outbound_ip4;
-  new_session->outbound_ip6       = options.outbound_ip6;
-  new_session->outbound_port      = options.outbound_port;
+  new_session->host_res_style = ats_host_res_from(client_ip->sa_family, options.host_res_preference);
+  new_session->outbound_ip4   = options.outbound_ip4;
+  new_session->outbound_ip6   = options.outbound_ip6;
+  new_session->outbound_port  = options.outbound_port;
   new_session->new_connection(netvc, iobuf, reader, false /* backdoor */);
 
   return true;


### PR DESCRIPTION
From what I can tell the issue that causes ipallow reloading to have
problems is related to stale acl_records. As found by @elsloo , you
can produce the issue when testing with KA sessions since they will keep
stale acl_records around, so after a reload is done and the timeout to
free them has expired you end up with an invalid reference to an
ipallow/acl object.

It looks like what was happening is that the httpsession's acl_record is
set only once while creating a new session, so that is what becomes
stale.  I added a get function for the session's acl record which then
fetches the parent acl record which then uses the ipallow scoped config
to get a new acl based on the current client IP. In testing this seems
to have alleviated the issue that I can see