### PR TITLE
Remove usage of stored ACL record, fix ipallow reload

### DIFF
--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -36,7 +36,6 @@
 #define SsnDebug(ssn, tag, ...) SpecificDebug((ssn)->debug(), tag, __VA_ARGS__)
 
 class ProxyClientTransaction;
-struct AclRecord;
 
 enum class ProxyErrorClass {
   NONE,
@@ -284,9 +283,6 @@ public:
     NetVConnection *netvc = get_netvc();
     return netvc ? netvc->get_local_addr() : nullptr;
   }
-
-  /// acl record - cache IpAllow::match() call
-  const AclRecord *acl_record = nullptr;
 
   /// Local address for outbound connection.
   IpAddr outbound_ip4;

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -144,12 +144,6 @@ public:
     host_res_style = style;
   }
 
-  const AclRecord *
-  get_acl_record() const
-  {
-    return parent ? parent->acl_record : nullptr;
-  }
-
   // Indicate we are done with this transaction
   virtual void release(IOBufferReader *r);
 

--- a/proxy/http/HttpSessionAccept.cc
+++ b/proxy/http/HttpSessionAccept.cc
@@ -67,7 +67,6 @@ HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReade
   new_session->outbound_ip6              = outbound_ip6;
   new_session->outbound_port             = outbound_port;
   new_session->host_res_style            = ats_host_res_from(client_ip->sa_family, host_res_preference);
-  new_session->acl_record                = acl_record;
 
   new_session->new_connection(netvc, iobuf, reader, backdoor);
 

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -54,7 +54,6 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
   }
 
   Http2ClientSession *new_session = THREAD_ALLOC_INIT(http2ClientSessionAllocator, this_ethread());
-  new_session->acl_record         = session_acl_record;
   new_session->host_res_style     = ats_host_res_from(client_ip->sa_family, options.host_res_preference);
   new_session->outbound_ip4       = options.outbound_ip4;
   new_session->outbound_ip6       = options.outbound_ip6;


### PR DESCRIPTION
Currently the parentclientsession stores a cached pointer of the ACL record pulled from ipallow. When doing a reload of ipallow, after it hits the 60sec cleanup timeout, that structure is deleted and this reference becomes invalid which then leads to any keep alived sessions to start returning 403 on requests since it no longer has any valid ACL records. This only happens with KA since it's cached and never gets refreshed until the session is completely done.

This change removes all usages of that cached record and instead calls the session's ipallow test function which uses a scoped ipallow instance, so that it gets updated on each call to pull the most recent record.