### PR TITLE
Ensure that ca override does not get lost

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -467,6 +467,19 @@ public:
     sent_cert = send_the_cert;
   }
 
+  void set_ca_cert_file(std::string_view file, std::string_view dir);
+
+  const char *
+  get_ca_cert_file()
+  {
+    return _ca_cert_file.get();
+  }
+  const char *
+  get_ca_cert_dir()
+  {
+    return _ca_cert_dir.get();
+  }
+
 protected:
   const IpEndpoint &
   _getLocalEndpoint() override
@@ -519,6 +532,8 @@ private:
 
   // Null-terminated string, or nullptr if there is no SNI server name.
   std::unique_ptr<char[]> _serverName;
+  std::unique_ptr<char[]> _ca_cert_file;
+  std::unique_ptr<char[]> _ca_cert_dir;
 
   EventIO async_ep{};
 };

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -126,7 +126,7 @@ void SSLNetVCDetach(SSL *ssl);
 SSLNetVConnection *SSLNetVCAccess(const SSL *ssl);
 
 void setClientCertLevel(SSL *ssl, uint8_t certLevel);
-void setClientCertCACerts(SSL *ssl, X509_STORE *ca_certs);
+void setClientCertCACerts(SSL *ssl, const char *file, const char *dir);
 void setTLSValidProtocols(SSL *ssl, unsigned long proto_mask, unsigned long max_mask);
 
 namespace ssl

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -925,6 +925,7 @@ SSLNetVConnection::clear()
 {
   _serverName.reset();
   _ca_cert_file.reset();
+  _ca_cert_dir.reset();
 
   if (ssl != nullptr) {
     SSL_free(ssl);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -924,6 +924,7 @@ void
 SSLNetVConnection::clear()
 {
   _serverName.reset();
+  _ca_cert_file.reset();
 
   if (ssl != nullptr) {
     SSL_free(ssl);
@@ -1919,5 +1920,22 @@ SSLNetVConnection::set_server_name(std::string_view name)
     std::memcpy(n, name.data(), name.size());
     n[name.size()] = '\0';
     _serverName.reset(n);
+  }
+}
+
+void
+SSLNetVConnection::set_ca_cert_file(std::string_view file, std::string_view dir)
+{
+  if (file.size()) {
+    char *n = new char[file.size() + 1];
+    std::memcpy(n, file.data(), file.size());
+    n[file.size()] = '\0';
+    _ca_cert_file.reset(n);
+  }
+  if (dir.size()) {
+    char *n = new char[dir.size() + 1];
+    std::memcpy(n, dir.data(), dir.size());
+    n[dir.size()] = '\0';
+    _ca_cert_dir.reset(n);
   }
 }

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -69,7 +69,8 @@ SNIConfigParams::loadSNIConfig()
       ai->actions.push_back(std::make_unique<ControlH2>(item.offer_h2.value()));
     }
     if (item.verify_client_level != 255) {
-      ai->actions.push_back(std::make_unique<VerifyClient>(item.verify_client_level, item.verify_client_ca_certs.release()));
+      ai->actions.push_back(
+        std::make_unique<VerifyClient>(item.verify_client_level, item.verify_client_ca_file, item.verify_client_ca_dir));
     }
     if (item.host_sni_policy != 255) {
       ai->actions.push_back(std::make_unique<HostSniPolicy>(item.host_sni_policy));

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -64,14 +64,6 @@ YamlSNIConfig::loader(const char *cfgFilename)
 }
 
 void
-YamlSNIConfig::X509StoreDeleter::operator()(X509_STORE *store)
-{
-  if (store) {
-    X509_STORE_free(store);
-  }
-}
-
-void
 YamlSNIConfig::Item::EnableProtocol(YamlSNIConfig::TLSProtocol proto)
 {
   if (proto <= YamlSNIConfig::TLSProtocol::TLS_MAX) {
@@ -98,12 +90,7 @@ YamlSNIConfig::Item::EnableProtocol(YamlSNIConfig::TLSProtocol proto)
   }
 }
 
-VerifyClient::~VerifyClient()
-{
-  if (ca_certs) {
-    X509_STORE_free(ca_certs);
-  }
-}
+VerifyClient::~VerifyClient() {}
 
 TsEnumDescriptor LEVEL_DESCRIPTOR         = {{{"NONE", 0}, {"MODERATE", 1}, {"STRICT", 2}}};
 TsEnumDescriptor POLICY_DESCRIPTOR        = {{{"DISABLED", 0}, {"PERMISSIVE", 1}, {"ENFORCED", 2}}};
@@ -207,11 +194,8 @@ template <> struct convert<YamlSNIConfig::Item> {
       if (!dir.empty() && (dir[0] != '/')) {
         dir = RecConfigReadConfigDir() + '/' + dir;
       }
-      YamlSNIConfig::X509UniqPtr ctx{X509_STORE_new()};
-      if (!X509_STORE_load_locations(ctx.get(), file.empty() ? nullptr : file.c_str(), dir.empty() ? nullptr : dir.c_str())) {
-        throw YAML::ParserException(n.Mark(), "cannot load CA certs in file=" + file + " dir=" + dir);
-      }
-      item.verify_client_ca_certs.reset(ctx.release());
+      item.verify_client_ca_file = file;
+      item.verify_client_ca_dir  = dir;
 #endif
     }
 

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -47,9 +47,6 @@ TSDECL(http2);
 TSDECL(host_sni_policy);
 #undef TSDECL
 
-// Predeclare OpenSSL X509 store struct.
-struct x509_store_st;
-
 const int start = 0;
 struct YamlSNIConfig {
   enum class Action {
@@ -73,17 +70,12 @@ struct YamlSNIConfig {
 
   YamlSNIConfig() {}
 
-  struct X509StoreDeleter {
-    void operator()(x509_store_st *);
-  };
-
-  using X509UniqPtr = std::unique_ptr<x509_store_st, X509StoreDeleter>;
-
   struct Item {
     std::string fqdn;
     std::optional<bool> offer_h2; // Has no value by default, so do not initialize!
     uint8_t verify_client_level = 255;
-    X509UniqPtr verify_client_ca_certs;
+    std::string verify_client_ca_file;
+    std::string verify_client_ca_dir;
     uint8_t host_sni_policy = 255;
     std::string tunnel_destination;
     bool tunnel_decrypt               = false;

--- a/tests/gold_tests/tls/tls_client_verify3.test.py
+++ b/tests/gold_tests/tls/tls_client_verify3.test.py
@@ -48,6 +48,9 @@ ts.Disk.records_config.update({
 })
 
 ts.Disk.ssl_multicert_config.AddLine(
+    'ssl_cert_name={0}/bbb-signed.pem ssl_key_name={0}/bbb-signed.key'.format(Test.TestDirectory + "/ssl")
+)
+ts.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
 )
 
@@ -59,6 +62,9 @@ ts.Disk.remap_config.AddLine(
 ts.Disk.sni_yaml.AddLines([
     'sni:',
     '- fqdn: bbb.com',
+    '  verify_client: STRICT',
+    '  verify_client_ca_certs: bbb-ca.pem',
+    '- fqdn: bbb-signed',
     '  verify_client: STRICT',
     '  verify_client_ca_certs: bbb-ca.pem',
     '- fqdn: ccc.com',
@@ -85,8 +91,8 @@ tr = Test.AddTestRun()
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = (
-    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'bbb.com:{0}:127.0.0.1'" +
-    " https://bbb.com:{0}/xyz"
+    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'bbb-signed:{0}:127.0.0.1'" +
+    " https://bbb-signed:{0}/xyz"
 ).format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/bbb-signed")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")


### PR DESCRIPTION
This is a fix on the feature added in PR #7130 

If the client request had a SNI name that both matched a server cert from ssl_multicert.config and the ca override feature in sni.yaml, the ca override data would be set first and then cleared by the openssl call SSL_set_SSL_CTX.

This PR augments the test to cover this case (select a non-default cert from ssl_multicert.config).  It also reapplies the ca override data after calling SSL_set_SSL_CTX.

Since this feature is in 9.0.x, the fix should go there as well.