### PR TITLE
Add support for a new (TSMgmtDataTypeGet) mgmt API to retrieve the record data type.

### DIFF
--- a/doc/developer-guide/api/functions/TSMgmtDataTypeGet.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtDataTypeGet.en.rst
@@ -1,0 +1,50 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSMgmtDataTypeGet
+*************
+
+Synopsis
+========
+
+.. code-block:: c
+
+    #include <ts/ts.h>
+
+.. function:: TSReturnCode TSMgmtDataTypeGet(const char * var_name, TSRecordDataType * result)
+
+Description
+===========
+
+Get the type of a value for a configuration variable. :arg:`var_name` is the name of the variable
+as a null terminated string. The type value is stored in :arg:`result`. The function can return
+:c:data:`TS_ERROR` if :arg:`var_name` is not found.
+
+Types
+=====
+
+Check :type:`TSRecordDataType` for a detailed description.
+
+
+
+Return Values
+=============
+
+:data:`TS_SUCCESS` if the :arg:`var_name` was found, :data:`TS_ERROR` if not.

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1209,6 +1209,8 @@ tsapi TSReturnCode TSMgmtFloatGet(const char *var_name, TSMgmtFloat *result);
 tsapi TSReturnCode TSMgmtStringGet(const char *var_name, TSMgmtString *result);
 tsapi TSReturnCode TSMgmtSourceGet(const char *var_name, TSMgmtSource *source);
 tsapi TSReturnCode TSMgmtConfigFileAdd(const char *parent, const char *fileName);
+tsapi TSReturnCode TSMgmtDataTypeGet(const char *var_name, TSRecordDataType *result);
+
 /* --------------------------------------------------------------------------
    Continuations */
 tsapi TSCont TSContCreate(TSEventFunc funcp, TSMutex mutexp);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -4536,6 +4536,12 @@ TSMgmtSourceGet(const char *var_name, TSMgmtSource *source)
   return REC_ERR_OKAY == RecGetRecordSource(var_name, reinterpret_cast<RecSourceT *>(source)) ? TS_SUCCESS : TS_ERROR;
 }
 
+TSReturnCode
+TSMgmtDataTypeGet(const char *var_name, TSRecordDataType *result)
+{
+  return REC_ERR_OKAY == RecGetRecordDataType(var_name, reinterpret_cast<RecDataT *>(result)) ? TS_SUCCESS : TS_ERROR;
+}
+
 ////////////////////////////////////////////////////////////////////
 //
 // Continuations

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -6441,6 +6441,7 @@ REGRESSION_TEST(SDK_API_TSTextLog)(RegressionTest *test, int /* atype ATS_UNUSED
 //                     TSMgmtFloatGet
 //                     TSMgmtIntGet
 //                     TSMgmtStringGet
+//                     TSMgmtDataTypeGet
 //////////////////////////////////////////////
 
 REGRESSION_TEST(SDK_API_TSMgmtGet)(RegressionTest *test, int /* atype ATS_UNUSED */, int *pstatus)
@@ -6500,6 +6501,21 @@ REGRESSION_TEST(SDK_API_TSMgmtGet)(RegressionTest *test, int /* atype ATS_UNUSED
     err = 1;
   } else {
     SDK_RPRINT(test, "TSMgmtStringGet", "TestCase1.4", TC_PASS, "ok");
+  }
+
+  {
+    TSRecordDataType result;
+    auto ret = TSMgmtDataTypeGet(CONFIG_PARAM_STRING_NAME, &result);
+    if (ret != TS_SUCCESS) {
+      SDK_RPRINT(test, "TSMgmtDataTypeGet", "TestCase1.5", TC_FAIL, "can not get value of param %s", CONFIG_PARAM_STRING_NAME);
+      err = 1;
+    } else if (result != TSRecordDataType::TS_RECORDDATATYPE_STRING) {
+      SDK_RPRINT(test, "TSMgmtDataTypeGet", "TestCase1.5", TC_FAIL, "can not get right type for %s - %d", CONFIG_PARAM_STRING_NAME,
+                 result);
+      err = 1;
+    } else {
+      SDK_RPRINT(test, "TSMgmtDataTypeGet", "TestCase1.5", TC_PASS, "ok");
+    }
   }
 
   if (err) {


### PR DESCRIPTION
Implements new management API that brings the record data type from a particular record. `TSMgmtDataTypeGet`