### PR TITLE
Increment ssl_error_syscall only if not EOF

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/ssl.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/ssl.en.rst
@@ -74,9 +74,6 @@ SSL/TLS
    The number of SSL connections to origin servers which were terminated due to
    unsupported SSL/TLS protocol versions, since statistics collection began.
 
-.. ts:stat:: global proxy.process.ssl.ssl_error_read_eos integer
-   :type: counter
-
 .. ts:stat:: global proxy.process.ssl.ssl_error_ssl integer
    :type: counter
 
@@ -229,4 +226,3 @@ SSL/TLS
 
    Incoming client SSL connections terminated due to an unsupported or disabled
    version of SSL/TLS, since statistics collection began.
-

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -306,15 +306,14 @@ ssl_read_from_net(SSLNetVConnection *sslvc, EThread *lthread, int64_t &ret)
       Debug("ssl.error", "SSL_ERROR_WOULD_BLOCK(read/x509 lookup)");
       break;
     case SSL_ERROR_SYSCALL:
-      SSL_INCREMENT_DYN_STAT(ssl_error_syscall);
       if (nread != 0) {
         // not EOF
+        SSL_INCREMENT_DYN_STAT(ssl_error_syscall);
         event = SSL_READ_ERROR;
         ret   = errno;
         Debug("ssl.error", "SSL_ERROR_SYSCALL, underlying IO error: %s", strerror(errno));
       } else {
         // then EOF observed, treat it as EOS
-        // Error("[SSL_NetVConnection::ssl_read_from_net] SSL_ERROR_SYSCALL, EOF observed violating SSL protocol");
         event = SSL_READ_EOS;
       }
       break;

--- a/iocore/net/SSLStats.cc
+++ b/iocore/net/SSLStats.cc
@@ -184,8 +184,6 @@ SSLInitializeStatistics()
   // error stats
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.ssl_error_syscall", RECD_COUNTER, RECP_PERSISTENT,
                      (int)ssl_error_syscall, RecRawStatSyncCount);
-  RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.ssl_error_read_eos", RECD_COUNTER, RECP_PERSISTENT,
-                     (int)ssl_error_read_eos, RecRawStatSyncCount);
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.ssl_error_ssl", RECD_COUNTER, RECP_PERSISTENT, (int)ssl_error_ssl,
                      RecRawStatSyncCount);
   RecRegisterRawStat(ssl_rsb, RECT_PROCESS, "proxy.process.ssl.ssl_error_async", RECD_COUNTER, RECP_PERSISTENT,

--- a/iocore/net/SSLStats.h
+++ b/iocore/net/SSLStats.h
@@ -88,7 +88,6 @@ enum SSL_Stats {
 
   /* error stats */
   ssl_error_syscall,
-  ssl_error_read_eos,
   ssl_error_ssl,
   ssl_error_async,
   ssl_sni_name_set_failure,


### PR DESCRIPTION
Similar to #5389, below 2 SSL metrics are confusing / misleading.

1. `proxy.process.ssl.ssl_error_syscall` 

I observed this counter is incremented, but almost all cases are EOF. It'd be useful that this is incremented only if it's not EOF.

2. `proxy.process.ssl.ssl_error_read_eos`

This is not incremented anywhere. 
