### PR TITLE
Bugfix: set a default inactivity timeout only if a read or write I/O operation was set

### DIFF
--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -70,7 +70,10 @@ public:
       }
 
       // set a default inactivity timeout if one is not set
-      if (ne->next_inactivity_timeout_at == 0 && nh.config.default_inactivity_timeout > 0) {
+      // The event `EVENT_INACTIVITY_TIMEOUT` only be triggered if a read
+      // or write I/O operation was set by `do_io_read()` or `do_io_write()`.
+      if (ne->next_inactivity_timeout_at == 0 && nh.config.default_inactivity_timeout > 0 &&
+          (ne->read.enabled || ne->write.enabled)) {
         Debug("inactivity_cop", "vc: %p inactivity timeout not set, setting a default of %d", ne,
               nh.config.default_inactivity_timeout);
         ne->set_default_inactivity_timeout(HRTIME_SECONDS(nh.config.default_inactivity_timeout));


### PR DESCRIPTION
In order to resolve the leaks of UnixNetVConnection, from v5.0.0-rc0,
the feature "Setting default inactivity timeout" was added by TS-1375
(commit 6397b161).

The event `EVENT_INACTIVITY_TIMEOUT` is used to limit the maximum time
for the transaction. It can reclaim NetVC if the transaction stalls.
For example, HttpSM read the request from client and only received
part of content, or HttpSM send the request to origin server and only
sent part of content.

The event `EVENT_ACTIVE_TIMEOUT` is used to limit the maximum life time
for the session. It can avoid long live idle sessions.
For example, HttpSM received a HTTP/1.0 request and shutdown read for
ClientVC, and then it requests an OS DNS lookup. Since I/O operation is
not set, only the event "EVENT_ACTIVE_TIMEOUT" is valid for HttpSM.

HttpSM as the processor of HTTP transaction, it should handle the event
"EVENT_INACTIVITY_TIMEOUT" and the event "EVENT_ACTIVE_TIMEOUT" and
perform the same operation. But if it disabled both read and write, it
will only handle the event "EVENT_ACTIVE_TIMEOUT".