### PR TITLE
Let Dedicated EThreads use `EThread::schedule`

### DIFF
--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -79,7 +79,10 @@ TS_INLINE Event *
 EThread::schedule(Event *e)
 {
   e->ethread = this;
-  ink_assert(tt == REGULAR);
+  if (tt != REGULAR) {
+    ink_assert(tt == DEDICATED);
+    return eventProcessor.schedule(e, ET_CALL);
+  }
   if (e->continuation->mutex) {
     e->mutex = e->continuation->mutex;
   } else {


### PR DESCRIPTION
`EThread::schedule_local` allows calls from `Dedicated` `EThreads` by scheduling events on the `ET_CALL` pool. This change brings the same behavior to the `EThread::schedule` function.