### PR TITLE
Schedule `INKContInternal` destruction on local queue

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1099,7 +1099,7 @@ INKContInternal::destroy()
     // action is needed.
     //
     if (p) {
-      p->schedule_imm(this);
+      p->schedule_imm_local(this);
     }
   }
 }


### PR DESCRIPTION
This event is scheduled on the current `EThread`, so the signalling `schedule` call should be unnecessary. Use the non-signalling `schedule_imm_local` function instead.