### PR TITLE
 Do not cache Transfer-Encoding header

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5005,9 +5005,9 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
       continue;
     }
     /////////////////////////////////////
-    // dont cache content-length field //
+    // dont cache content-length field  and transfer encoding //
     /////////////////////////////////////
-    if (name == MIME_FIELD_CONTENT_LENGTH) {
+    if (name == MIME_FIELD_CONTENT_LENGTH || name == MIME_FIELD_TRANSFER_ENCODING) {
       continue;
     }
     /////////////////////////////////////


### PR DESCRIPTION
Caching Transfer Encoding can cause protocol violation( sending both Transfer Encoding and Content Length) to client. This solves #7230 

