### PR TITLE
Fix bad HTTP/2 post client causing stuck HttpSM

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3663,7 +3663,7 @@ HttpSM::tunnel_handler_post_server(int event, HttpTunnelConsumer *c)
     // do not shut down the client read
     if (enable_redirection) {
       if (ua_producer->vc_type == HT_STATIC && event != VC_EVENT_ERROR && event != VC_EVENT_EOS) {
-        ua_entry->read_vio = ua_producer->vc->do_io_read(this, INT64_MAX, c->producer->read_buffer);
+        ua_entry->read_vio = ua_producer->vc->do_io_read(this, INT64_MAX, ua_buffer_reader->mbuf);
         // ua_producer->vc->do_io_shutdown(IO_SHUTDOWN_READ);
       } else {
         if (ua_producer->vc_type == HT_STATIC && t_state.redirect_info.redirect_in_process) {
@@ -3671,7 +3671,7 @@ HttpSM::tunnel_handler_post_server(int event, HttpTunnelConsumer *c)
         }
       }
     } else {
-      ua_entry->read_vio = ua_producer->vc->do_io_read(this, INT64_MAX, c->producer->read_buffer);
+      ua_entry->read_vio = ua_producer->vc->do_io_read(this, INT64_MAX, ua_buffer_reader->mbuf);
       // we should not shutdown read side of the client here to prevent sending a reset
       // ua_producer->vc->do_io_shutdown(IO_SHUTDOWN_READ);
     } // end of added logic

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2717,7 +2717,7 @@ HttpSM::tunnel_handler_post_or_put(HttpTunnelProducer *p)
     tunnel.reset();
     // When the ua completed sending it's data we must have
     //  removed it from the tunnel
-    ink_release_assert(ua_entry->in_tunnel == false);
+    ua_entry->in_tunnel     = false;
     server_entry->in_tunnel = false;
 
     break;

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1612,6 +1612,7 @@ HttpTunnel::main_handler(int event, void *data)
       ink_assert(c->write_vio == (VIO *)data || c->vc == ((VIO *)data)->vc_server);
       sm_callback = consumer_handler(event, c);
     } else {
+      // Presumably a delayed event we can ignore now
       internal_error(); // do nothing
     }
   }

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1332,6 +1332,9 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
     if (c->producer && c->producer->handler_state == 0) {
       if (event == VC_EVENT_WRITE_COMPLETE) {
         c->producer->handler_state = HTTP_SM_POST_SUCCESS;
+        // If the consumer completed, presumably the producer successfully read and is done
+        c->producer->read_success = true;
+        c->producer->alive        = false;
       } else if (c->vc_type == HT_HTTP_SERVER) {
         c->producer->handler_state = HTTP_SM_POST_UA_FAIL;
       } else if (c->vc_type == HT_HTTP_CLIENT) {

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -396,8 +396,11 @@ HttpTunnel::is_tunnel_alive() const
 {
   bool tunnel_alive = false;
 
+  // Really a tunnel is only alive as long as there are consumers
+  // to consume.  Or if there are no consumer (e.g. tunneling into a buffer)
+  // an alive producer may count
   for (const auto &producer : producers) {
-    if (producer.alive == true) {
+    if (producer.alive == true && producer.consumer_list.head == nullptr) {
       tunnel_alive = true;
       break;
     }
@@ -483,7 +486,7 @@ HttpTunnel::get_consumer(VIO *vio)
 {
   if (vio) {
     for (int i = 0; i < MAX_CONSUMERS; i++) {
-      if (consumers[i].alive && (consumers[i].write_vio == vio || consumers[i].vc == vio->vc_server)) {
+      if (consumers[i].alive && consumers[i].write_vio == vio) {
         return consumers + i;
       }
     }

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -396,11 +396,8 @@ HttpTunnel::is_tunnel_alive() const
 {
   bool tunnel_alive = false;
 
-  // Really a tunnel is only alive as long as there are consumers
-  // to consume.  Or if there are no consumer (e.g. tunneling into a buffer)
-  // an alive producer may count
   for (const auto &producer : producers) {
-    if (producer.alive == true && producer.consumer_list.head == nullptr) {
+    if (producer.alive == true) {
       tunnel_alive = true;
       break;
     }


### PR DESCRIPTION
We first noticed this problem because we were using the per origin conntrack mechanism.  And one of the origins we had set for a limit of 3000 was getting stuck with the limit permanently set, so all requests for that origin were returning 502. Looking more closely, there were 3000 connections to that origin in the CLOSE-WAIT state (i.e. the peer had sent the FIN but ATS had not responded.

We took one of the machines in this state out of rotation, created a core file, and looked at the cop_list on the net handler object on one of the threads.  Eventually found a netvc that was HTTP and pointing at our problem origin.  Looking at the history for the associated state machine, we see that it had been iterating on 

```
{location = {file = 0x78acc0 "../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc", 
        func = 0x78ee20 <HttpSM::state_send_server_request_header(int, void*)::__FUNCTION__> "state_send_server_request_header", line = 2026}, event = 105, reentrancy = 1}, 
{location = {
        file = 0x78acc0 "../../../../../../_vcs/trafficserver9/proxy/http/HttpSM.cc", func = 0x78e830 <HttpSM::handle_server_setup_error(int, void*)::__FUNCTION__> "handle_server_setup_error", line = 5573}, 
      event = 105, reentrancy = 1},
```
For the whole history.   So presumably the inactivity_cop was sending the inactivity timeout event every 5 minutes (our setting for the default inactivity timeout), but the HttpSM was never getting killed.  So I created a one-off build that added a bool to the HttpSM and an assert to detected with the same state machine passed through state_send_server_request_header with the inactivity timeout twice.  Once we got a core from that, we could see that the client had been using HTTP2 and was sending a POST.  The tunnel is still alive in this case. It is set up as the post tunnel. The consumer side is finished (alive = false). It has written 2822 of 2822. The producer side is not finished (alive = true). It has read 0 of 2822.  In the ua_txn recv_end_stream is false.  So the HTTP/2 client has sent all the expected data (content-length had been set to 2822) but it did not send a DATA frame with the EOS bit set.  A bad client, but it should not have caused this zombie state.

This PR fixes this issue in our production.  We see no CLOSE-WAIT connections for the origin in question.

The key change is adjusting the logic for HttpTunnel::is_tunnel_alive. The original logic will return true (alive) if any producer or any consumer is alive. This was causing the problem in handle_server_setup_error. The tunnel had 1 alive producer the (the HTTP/2 post user agent) but the consumer had completed. All the post data had been passed to the server, but the HTTP/2 user agent had not received the EOS bit, so it would be stuck in this state forever.

Since the tunnel was alive handle_server_setup_error assumed there was at least one active consumer left, so it would defer sending the error message until the consumer (which does not exist) completed.

I changed the is_tunnel_alive logic logic to only check for active consumers (or an active producer with not consumers which occurs if post buffering is enabled). This causes the handle_server_setup_error to complete and set up an error response even if the tunnel producer is still active.

I had to adjust a few other asserts/checks to deal with slow EOS READ_COMPLETES. My branch passes autest and regression tests and has been running merrily on one of our boxes in the problem colo today..