### PR TITLE
Supporting out of source builds for AuTests.

### DIFF
--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -35,3 +35,7 @@ if AuTestVersion() < autest_version:
 Settings.path_argument(["--ats-bin"],
                        required=True,
                        help="A user provided directory to ATS bin")
+
+Settings.path_argument(["--build-root"],
+                       required=False,
+                       help="The location of the build root for out of source builds")

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -17,12 +17,22 @@
 #  limitations under the License.
 
 import json
-import subprocess
+import os
+from os.path import dirname
 import pprint
+import subprocess
 
 if Arguments.ats_bin is not None:
     # Add environment variables
     ENV['ATS_BIN'] = Arguments.ats_bin
+
+if Arguments.build_root is not None:
+    ENV['BUILD_ROOT'] = Arguments.build_root
+else:
+    # Assume the build root is the same directory tree as the test location.
+    ENV['BUILD_ROOT'] = dirname(dirname(dirname(AutestSitePath)))
+
+host.WriteVerbose(['ats'], "Test build root: {}:".format(ENV['BUILD_ROOT']))
 
 if ENV['ATS_BIN'] is not None:
     # Add variables for Tests
@@ -78,9 +88,12 @@ if ENV['ATS_BIN'] is not None:
                 host.WriteError("tsxs is broken. Aborting tests", show_stack=False)
     host.WriteVerbose(['ats'], "Traffic server build flags:\n", pprint.pformat(out))
     Variables.update(out)
-Variables.AtsExampleDir = os.path.join(AutestSitePath, '../../../example')
-Variables.AtsTestToolsDir = os.path.join(AutestSitePath, '../../tools')
-Variables.AtsTestPluginsDir = os.path.join(AutestSitePath, '../../tools/plugins/.libs')
+
+Variables.AtsExampleDir = os.path.join(AutestSitePath, '..', '..', '..', 'example')
+Variables.AtsTestToolsDir = os.path.join(AutestSitePath, '..', '..', 'tools')
+Variables.BuildRoot = ENV['BUILD_ROOT']
+Variables.AtsTestPluginsDir = os.path.join(Variables.BuildRoot, 'tests', 'tools', 'plugins', '.libs')
+Variables.AtsBuildGoldTestsDir = os.path.join(Variables.BuildRoot, 'tests', 'gold_tests')
 
 # modify delay times as we always have to kill Trafficserver
 # no need to wait

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+
 Test.Summary = '''
 Test chunked encoding processing
 '''
@@ -94,7 +96,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 
 # smuggle-client is built via `make`. Here we copy the built binary down to the
 # test directory so that the test runs in this file can use it.
-Test.Setup.Copy('smuggle-client')
+Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'chunked_encoding', 'smuggle-client'))
 
 # HTTP1.1 GET: www.example.com
 tr = Test.AddTestRun()

--- a/tests/gold_tests/tls/tls.test.py
+++ b/tests/gold_tests/tls/tls.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+
 Test.Summary = '''
 Test tls
 '''
@@ -26,7 +28,7 @@ server = Test.MakeOriginServer("server")
 
 # ssl-post is built via `make`. Here we copy the built binary down to the test
 # directory so that the test runs in this file can use it.
-Test.Setup.Copy('ssl-post')
+Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'tls', 'ssl-post'))
 
 requestLocation = "test2"
 reHost = "www.example.com"


### PR DESCRIPTION
This is a cherry-pick back to 9.0.x of the following PR:
https://github.com/apache/trafficserver/pull/7109

---

This adds the --build-root autest option to support running AuTest for
out of source builds where the built binaries reside in a directory tree
outside of where the Traffic Server AuTests themselves are located.

(cherry picked from commit c5e25a2ade51af4bf8ff595957058acdfbc590ff)