### PR TITLE
Fix test_error_page_selection memory leaks and logic errors

### DIFF
--- a/proxy/http/unit_tests/test_error_page_selection.cc
+++ b/proxy/http/unit_tests/test_error_page_selection.cc
@@ -33,15 +33,16 @@ TEST_CASE("error page selection test", "[http]")
     const char *content_charset;
   };
 
-  std::array<Sets, 9> sets = {{{"default", "en", "iso-8859-1"},
-                               {"en-cockney", "en-cockney", "iso-8859-1"},
-                               {"en0", "en", "iso-8859-1"},
-                               {"en-us", "en-us", "us-ascii"},
-                               {"en1", "en", "unicode"},
-                               {"en-cockney-slang", "en-cockney-slang", "iso-8859-1"},
-                               {"ko0", "ko", "iso-8859-1"},
-                               {"ko1", "ko", "iso-2022-kr"},
-                               {"jp", "jp", "shift-jis"}}};
+  std::array<Sets, 10> sets = {{{"default", "en", "iso-8859-1"},
+                                {"en-cockney", "en-cockney", "iso-8859-1"},
+                                {"en0", "en", "iso-8859-1"},
+                                {"en-us", "en-us", "us-ascii"},
+                                {"en1", "en", "unicode"},
+                                {"en-cockney-slang", "en-cockney-slang", "iso-8859-1"},
+                                {"ko0", "ko", "iso-8859-1"},
+                                {"ko1", "ko", "iso-2022-kr"},
+                                {"jp", "jp", "shift-jis"},
+                                {"es", "es", "unicode"}}};
 
   struct Tests {
     const char *accept_language;
@@ -52,31 +53,33 @@ TEST_CASE("error page selection test", "[http]")
     int expected_I;
   };
 
-  std::array<Tests, 24> tests = {{
+  std::array<Tests, 26> tests = {{
     {nullptr, nullptr, "default", 1, 0, INT_MAX},
-    {"en", nullptr, "en1", 1, 2, 1},
-    {"ko", nullptr, "ko0", 1, 2, 1},
+    {"en", "iso-8859-1", "en0", 1, 2, 1},
+    {"en", "unicode", "en1", 1, 2, 1},
+    {"ko", "iso-8859-1", "ko0", 1, 2, 1},
+    {"ko", "iso-2022-kr", "ko1", 1, 2, 1},
     {"en-us", nullptr, "en-us", 1, 5, 1},
     {"en-US", nullptr, "en-us", 1, 5, 1},
-    {"en,ko", nullptr, "en1", 1, 2, 1},
-    {"ko,en", nullptr, "ko0", 1, 2, 1},
-    {"en;q=0.7,ko", nullptr, "ko0", 1, 2, 2},
-    {"en;q=.7,ko", nullptr, "ko0", 1, 2, 2},
-    {"en;q=.7,ko;q=.7", nullptr, "en1", 0.7, 2, 1},
-    {"en;q=.7,ko;q=.701", nullptr, "ko0", 0.701, 2, 2},
-    {"en;q=.7  ,  ko;q=.701", nullptr, "ko0", 0.701, 2, 2},
-    {"en  ;  q=.7  ,  ko  ;  ;  ;  ; q=.701", nullptr, "ko0", 0.701, 2, 2},
-    {"en,ko;q=.7", nullptr, "en1", 1, 2, 1},
-    {"en;q=1,ko;q=.7", nullptr, "en1", 1, 2, 1},
-    {"en;;;q=1,ko;q=.7", nullptr, "en1", 1, 2, 1},
-    {"en;;;q=1,,,,ko;q=.7", nullptr, "en1", 1, 2, 1},
-    {"en;;;q=.7,,,,ko;q=.7", nullptr, "en1", 0.7, 2, 1},
-    {"en;;;q=.699,,,,ko;q=.7", nullptr, "ko0", 0.7, 2, 5},
-    {"en;q=0,ko;q=1", nullptr, "ko0", 1, 2, 2},
-    {"en;q=0, ko;q=1", nullptr, "ko0", 1, 2, 2},
-    {"en;q=0,ko;q=.5", nullptr, "ko0", 0.5, 2, 2},
-    {"en;q=0, ko;q=.5", nullptr, "ko0", 0.5, 2, 2},
-    {"en;q=000000000.00000000000000000000,ko;q=1.0000000000000000000", nullptr, "ko0", 1, 2, 2},
+    {"jp,es", nullptr, "jp", 1, 2, 1},
+    {"es,jp", nullptr, "es", 1, 2, 1},
+    {"jp;q=0.7,es", nullptr, "es", 1, 2, 2},
+    {"jp;q=.7,es", nullptr, "es", 1, 2, 2},
+    {"jp;q=.7,es;q=.7", nullptr, "jp", 0.7, 2, 1},
+    {"jp;q=.7,es;q=.701", nullptr, "es", 0.701, 2, 2},
+    {"jp;q=.7  ,  es;q=.701", nullptr, "es", 0.701, 2, 2},
+    {"jp  ;  q=.7  ,  es  ;  ;  ;  ; q=.701", nullptr, "es", 0.701, 2, 2},
+    {"jp,es;q=.7", nullptr, "jp", 1, 2, 1},
+    {"jp;q=1,es;q=.7", nullptr, "jp", 1, 2, 1},
+    {"jp;;;q=1,es;q=.7", nullptr, "jp", 1, 2, 1},
+    {"jp;;;q=1,,,,es;q=.7", nullptr, "jp", 1, 2, 1},
+    {"jp;;;q=.7,,,,es;q=.7", nullptr, "jp", 0.7, 2, 1},
+    {"jp;;;q=.699,,,,es;q=.7", nullptr, "es", 0.7, 2, 5},
+    {"jp;q=0,es;q=1", nullptr, "es", 1, 2, 2},
+    {"jp;q=0, es;q=1", nullptr, "es", 1, 2, 2},
+    {"jp;q=0,es;q=.5", nullptr, "es", 0.5, 2, 2},
+    {"jp;q=0, es;q=.5", nullptr, "es", 0.5, 2, 2},
+    {"jp;q=000000000.00000000000000000000,es;q=1.0000000000000000000", nullptr, "es", 1, 2, 2},
   }};
 
   // (1) build fake hash table of sets

--- a/proxy/http/unit_tests/test_error_page_selection.cc
+++ b/proxy/http/unit_tests/test_error_page_selection.cc
@@ -22,88 +22,97 @@
  */
 
 #include "catch.hpp"
-
 #include "HttpBodyFactory.h"
+#include <array>
 
 TEST_CASE("error page selection test", "[http]")
 {
-  static struct {
+  struct Sets {
     const char *set_name;
     const char *content_language;
     const char *content_charset;
-  } sets[] = {{"default", "en", "iso-8859-1"}, {"en-cockney", "en-cockney", "iso-8859-1"},
-              {"en", "en", "iso-8859-1"},      {"en-us", "en-us", "us-ascii"},
-              {"en", "en", "unicode"},         {"en-cockney-slang", "en-cockney-slang", "iso-8859-1"},
-              {"ko", "ko", "iso-8859-1"},      {"ko", "ko", "iso-2022-kr"},
-              {"jp", "jp", "shift-jis"}};
-  static struct {
+  };
+
+  std::array<Sets, 9> sets = {{{"default", "en", "iso-8859-1"},
+                               {"en-cockney", "en-cockney", "iso-8859-1"},
+                               {"en0", "en", "iso-8859-1"},
+                               {"en-us", "en-us", "us-ascii"},
+                               {"en1", "en", "unicode"},
+                               {"en-cockney-slang", "en-cockney-slang", "iso-8859-1"},
+                               {"ko0", "ko", "iso-8859-1"},
+                               {"ko1", "ko", "iso-2022-kr"},
+                               {"jp", "jp", "shift-jis"}}};
+
+  struct Tests {
     const char *accept_language;
     const char *accept_charset;
     const char *expected_set;
     float expected_Q;
     int expected_La;
     int expected_I;
-  } tests[] = {
-    {nullptr, nullptr, "default", 1, 0, INT_MAX},
-    {"en", nullptr, "en", 1, 2, 1},
-    {"ko", nullptr, "ko", 1, 2, 1},
-    {"en-us", nullptr, "en-us", 1, 5, 1},
-    {"en-US", nullptr, "en-us", 1, 5, 1},
-    {"en,ko", nullptr, "en", 1, 2, 1},
-    {"ko,en", nullptr, "ko", 1, 2, 1},
-    {"en;q=0.7,ko", nullptr, "ko", 1, 2, 2},
-    {"en;q=.7,ko", nullptr, "ko", 1, 2, 2},
-    {"en;q=.7,ko;q=.7", nullptr, "en", 0.7, 2, 1},
-    {"en;q=.7,ko;q=.701", nullptr, "ko", 0.701, 2, 2},
-    {"en;q=.7  ,  ko;q=.701", nullptr, "ko", 0.701, 2, 2},
-    {"en  ;  q=.7  ,  ko  ;  ;  ;  ; q=.701", nullptr, "ko", 0.701, 2, 2},
-    {"en,ko;q=.7", nullptr, "en", 1, 2, 1},
-    {"en;q=1,ko;q=.7", nullptr, "en", 1, 2, 1},
-    {"en;;;q=1,ko;q=.7", nullptr, "en", 1, 2, 1},
-    {"en;;;q=1,,,,ko;q=.7", nullptr, "en", 1, 2, 1},
-    {"en;;;q=.7,,,,ko;q=.7", nullptr, "en", 0.7, 2, 1},
-    {"en;;;q=.699,,,,ko;q=.7", nullptr, "ko", 0.7, 2, 5},
-    {"en;q=0,ko;q=1", nullptr, "ko", 1, 2, 2},
-    {"en;q=0, ko;q=1", nullptr, "ko", 1, 2, 2},
-    {"en;q=0,ko;q=.5", nullptr, "ko", 0.5, 2, 2},
-    {"en;q=0, ko;q=.5", nullptr, "ko", 0.5, 2, 2},
-    {"en;q=000000000.00000000000000000000,ko;q=1.0000000000000000000", nullptr, "ko", 1, 2, 2},
   };
 
-  int i;
-  int nsets  = sizeof(sets) / sizeof(sets[0]);
-  int ntests = sizeof(tests) / sizeof(tests[0]);
+  std::array<Tests, 24> tests = {{
+    {nullptr, nullptr, "default", 1, 0, INT_MAX},
+    {"en", nullptr, "en1", 1, 2, 1},
+    {"ko", nullptr, "ko0", 1, 2, 1},
+    {"en-us", nullptr, "en-us", 1, 5, 1},
+    {"en-US", nullptr, "en-us", 1, 5, 1},
+    {"en,ko", nullptr, "en1", 1, 2, 1},
+    {"ko,en", nullptr, "ko0", 1, 2, 1},
+    {"en;q=0.7,ko", nullptr, "ko0", 1, 2, 2},
+    {"en;q=.7,ko", nullptr, "ko0", 1, 2, 2},
+    {"en;q=.7,ko;q=.7", nullptr, "en1", 0.7, 2, 1},
+    {"en;q=.7,ko;q=.701", nullptr, "ko0", 0.701, 2, 2},
+    {"en;q=.7  ,  ko;q=.701", nullptr, "ko0", 0.701, 2, 2},
+    {"en  ;  q=.7  ,  ko  ;  ;  ;  ; q=.701", nullptr, "ko0", 0.701, 2, 2},
+    {"en,ko;q=.7", nullptr, "en1", 1, 2, 1},
+    {"en;q=1,ko;q=.7", nullptr, "en1", 1, 2, 1},
+    {"en;;;q=1,ko;q=.7", nullptr, "en1", 1, 2, 1},
+    {"en;;;q=1,,,,ko;q=.7", nullptr, "en1", 1, 2, 1},
+    {"en;;;q=.7,,,,ko;q=.7", nullptr, "en1", 0.7, 2, 1},
+    {"en;;;q=.699,,,,ko;q=.7", nullptr, "ko0", 0.7, 2, 5},
+    {"en;q=0,ko;q=1", nullptr, "ko0", 1, 2, 2},
+    {"en;q=0, ko;q=1", nullptr, "ko0", 1, 2, 2},
+    {"en;q=0,ko;q=.5", nullptr, "ko0", 0.5, 2, 2},
+    {"en;q=0, ko;q=.5", nullptr, "ko0", 0.5, 2, 2},
+    {"en;q=000000000.00000000000000000000,ko;q=1.0000000000000000000", nullptr, "ko0", 1, 2, 2},
+  }};
+
   // (1) build fake hash table of sets
   std::unique_ptr<HttpBodyFactory::BodySetTable> table_of_sets;
   table_of_sets.reset(new HttpBodyFactory::BodySetTable);
-  for (i = 0; i < nsets; i++) {
+  for (const auto &set : sets) {
     HttpBodySetRawData *body_set = new HttpBodySetRawData;
     body_set->magic              = 0;
-    body_set->set_name           = strdup(sets[i].set_name);
-    body_set->content_language   = strdup(sets[i].content_language);
-    body_set->content_charset    = strdup(sets[i].content_charset);
+    body_set->set_name           = strdup(set.set_name);
+    body_set->content_language   = strdup(set.content_language);
+    body_set->content_charset    = strdup(set.content_charset);
     body_set->table_of_pages.reset(new HttpBodySetRawData::TemplateTable);
+    REQUIRE(table_of_sets->find(body_set->set_name) == table_of_sets->end());
     table_of_sets->emplace(body_set->set_name, body_set);
   }
+
   // (2) for each test, parse accept headers into lists, and test matching
-  for (i = 0; i < ntests; i++) {
+  int count = 0;
+  for (const auto &test : tests) {
     float Q_best;
     int La_best, Lc_best, I_best;
     const char *set_best;
     StrList accept_language_list;
     StrList accept_charset_list;
-    HttpCompat::parse_comma_list(&accept_language_list, tests[i].accept_language);
-    HttpCompat::parse_comma_list(&accept_charset_list, tests[i].accept_charset);
-    printf("         test #%d: (Accept-Language='%s', Accept-Charset='%s')\n", i + 1,
-           (tests[i].accept_language ? tests[i].accept_language : "<null>"),
-           (tests[i].accept_charset ? tests[i].accept_charset : "<null>"));
+    HttpCompat::parse_comma_list(&accept_language_list, test.accept_language);
+    HttpCompat::parse_comma_list(&accept_charset_list, test.accept_charset);
+    printf("         test #%d: (Accept-Language='%s', Accept-Charset='%s')\n", ++count,
+           (test.accept_language ? test.accept_language : "<null>"), (test.accept_charset ? test.accept_charset : "<null>"));
     set_best = HttpBodyFactory::determine_set_by_language(table_of_sets, &(accept_language_list), &(accept_charset_list), &Q_best,
                                                           &La_best, &Lc_best, &I_best);
-    REQUIRE(strcmp(set_best, tests[i].expected_set) == 0);
-    REQUIRE(Q_best == tests[i].expected_Q);
-    REQUIRE(La_best == tests[i].expected_La);
-    REQUIRE(I_best == tests[i].expected_I);
+    REQUIRE(strcmp(set_best, test.expected_set) == 0);
+    REQUIRE(Q_best == test.expected_Q);
+    REQUIRE(La_best == test.expected_La);
+    REQUIRE(I_best == test.expected_I);
   }
+
   for (const auto &it : *table_of_sets.get()) {
     ats_free(it.second->set_name);
     ats_free(it.second->content_language);


### PR DESCRIPTION
This fixes #7245

The leak was that the same key name was used multiple times on insert after it newed the value.  This caused the old entry to leak.  I changed the names to be unique and test to see if the name is in the hash map before inserting it.
