### PR TITLE
slice: default to throttling, fixes to manufactured 416 responses.

### DIFF
--- a/plugins/experimental/slice/Config.cc
+++ b/plugins/experimental/slice/Config.cc
@@ -112,7 +112,6 @@ Config::fromArgs(int const argc, char const *const argv[])
     {const_cast<char *>("exclude-regex"), required_argument, nullptr, 'e'},
     {const_cast<char *>("include-regex"), required_argument, nullptr, 'i'},
     {const_cast<char *>("ref-relative"), no_argument, nullptr, 'l'},
-    {const_cast<char *>("throttle"), no_argument, nullptr, 'o'},
     {const_cast<char *>("pace-errorlog"), required_argument, nullptr, 'p'},
     {const_cast<char *>("remap-host"), required_argument, nullptr, 'r'},
     {const_cast<char *>("blockbytes-test"), required_argument, nullptr, 't'},
@@ -181,10 +180,6 @@ Config::fromArgs(int const argc, char const *const argv[])
     case 'l': {
       m_reftype = RefType::Relative;
       DEBUG_LOG("Reference slice relative to request (not slice block 0)");
-    } break;
-    case 'o': {
-      m_throttle = true;
-      DEBUG_LOG("Enabling internal block throttling");
     } break;
     case 'p': {
       int const secsread = atoi(optarg);

--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -41,8 +41,7 @@ struct Config {
   RegexType m_regex_type{None};
   pcre *m_regex{nullptr};
   pcre_extra *m_regex_extra{nullptr};
-  bool m_throttle{false}; // internal block throttling
-  int m_paceerrsecs{0};   // -1 disable logging, 0 no pacing, max 60s
+  int m_paceerrsecs{0}; // -1 disable logging, 0 no pacing, max 60s
   enum RefType { First, Relative };
   RefType m_reftype{First}; // reference slice is relative to request
 

--- a/plugins/experimental/slice/slice.h
+++ b/plugins/experimental/slice/slice.h
@@ -39,8 +39,8 @@ constexpr std::string_view X_CRR_IMS_HEADER = {"X-Crr-Ims"};
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 #define DEBUG_LOG(fmt, ...) TSDebug(PLUGIN_NAME, "[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__)
 
-#define ERROR_LOG(fmt, ...)                                                         \
-  TSError("[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__); \
+#define ERROR_LOG(fmt, ...)                                                                         \
+  TSError("[%s/%s:% 4d] %s(): " fmt, PLUGIN_NAME, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__); \
   TSDebug(PLUGIN_NAME, "[%s:%04d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__)
 
 #else

--- a/plugins/experimental/slice/util.cc
+++ b/plugins/experimental/slice/util.cc
@@ -128,6 +128,7 @@ request_block(TSCont contp, Data *const data)
     break;
   default:
     ERROR_LOG("Invalid blockstate");
+    return false;
     break;
   }
 


### PR DESCRIPTION
The slice plugin has a problem when consecutive slice blocks are held in ram cache and are shoved into the slice plugin without performing any throttling (which is done for other cases like TCP_HIT, etc).  This PR makes throttling the default and restores the data hand off to using TSIOBufferReaderAvail and TSIOBufferCopy instead of iterating through the TSIOBuffer blocks.

Also a bug was found with slice's 416 response creator, a bug exposed by the addition of slice self healing.

closes #7256 
resolves #7179