### PR TITLE
detect and fix stms log field having epoch time ms for intercept plugins.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2976,7 +2976,13 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
 {
   STATE_ENTER(&HttpSM::tunnel_handler_server, event);
 
-  milestones[TS_MILESTONE_SERVER_CLOSE] = Thread::get_hrtime();
+  // An intercept handler may not set TS_MILESTONE_SERVER_CONNECT
+  // by default. Therefore we only set TS_MILESTONE_SERVER_CLOSE if
+  // TS_MILESTONE_SERVER_CONNECT is set (non-zero), lest certain time
+  // statistics are calculated from epoch time.
+  if (0 != milestones[TS_MILESTONE_SERVER_CONNECT]) {
+    milestones[TS_MILESTONE_SERVER_CLOSE] = Thread::get_hrtime();
+  }
 
   bool close_connection = false;
 


### PR DESCRIPTION
For intercept plugins like stats_over_http and slice the stms logging field may end up being set to epoch time in ms.
This fix detects that condition inside HttpSM by only allowing TS_MILESTONE_SERVER_CLOSE to be set if 
TS_MILESTONE_SERVER_CONNECT was already set.

LogAccess::marshal_server_resp_time_ms uses this code to calculate this stms field.
```
m_http_sm->milestones.difference_msec(TS_MILESTONE_SERVER_CONNECT, TS_MILESTONE_SERVER_CLOSE)
```

This is a mitigation in the code.

resolves #7196