### PR TITLE
Sticky server does not work with H2 client

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -999,7 +999,9 @@ mptcp
 .. ts:cv:: CONFIG proxy.config.http.attach_server_session_to_client INT 0
    :overridable:
 
-   Control the re-use of an server session by a user agent (client) session.
+   Control the re-use of an server session by a user agent (client) session. Currently only applies to user
+   agents using HTTP/1.0 or HTTP/1.1. For other HTTP versions, the origin connection is always returned to the
+   session sharing pool or closed.
 
    If a user agent performs more than one HTTP transaction on its connection to |TS| a server session must be
    obtained for the second (and subsequent) transaction as for the first. This settings affects how that server session

--- a/proxy/ProxySession.cc
+++ b/proxy/ProxySession.cc
@@ -200,9 +200,10 @@ ProxySession::connection_id() const
   return con_id;
 }
 
-void
+bool
 ProxySession::attach_server_session(Http1ServerSession *ssession, bool transaction_done)
 {
+  return false;
 }
 
 Http1ServerSession *

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -89,7 +89,7 @@ public:
   // Virtual Methods
   virtual void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) = 0;
   virtual void start()                                                                          = 0;
-  virtual void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true);
+  virtual bool attach_server_session(Http1ServerSession *ssession, bool transaction_done = true);
 
   virtual void release(ProxyTransaction *trans) = 0;
 

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -56,10 +56,10 @@ ProxyTransaction::new_transaction(bool from_early_data)
   _sm->attach_client_session(this, _reader);
 }
 
-void
+bool
 ProxyTransaction::attach_server_session(Http1ServerSession *ssession, bool transaction_done)
 {
-  _proxy_ssn->attach_server_session(ssession, transaction_done);
+  return _proxy_ssn->attach_server_session(ssession, transaction_done);
 }
 
 void

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -38,7 +38,7 @@ public:
   /// Virtual Methods
   //
   virtual void new_transaction(bool from_early_data = false);
-  virtual void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true);
+  virtual bool attach_server_session(Http1ServerSession *ssession, bool transaction_done = true);
   Action *adjust_thread(Continuation *cont, int event, void *data);
   virtual void release(IOBufferReader *r) = 0;
   virtual void transaction_done();

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -460,7 +460,7 @@ Http1ClientSession::new_transaction()
   trans.new_transaction(read_from_early_data > 0 ? true : false);
 }
 
-void
+bool
 Http1ClientSession::attach_server_session(Http1ServerSession *ssession, bool transaction_done)
 {
   if (ssession) {
@@ -499,6 +499,7 @@ Http1ClientSession::attach_server_session(Http1ServerSession *ssession, bool tra
     bound_ss     = nullptr;
     slave_ka_vio = nullptr;
   }
+  return true;
 }
 
 void

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -60,7 +60,7 @@ public:
   void destroy() override;
   void free() override;
 
-  void attach_server_session(Http1ServerSession *ssession, bool transaction_done = true) override;
+  bool attach_server_session(Http1ServerSession *ssession, bool transaction_done = true) override;
 
   // Implement VConnection interface.
   void do_io_close(int lerrno = -1) override;


### PR DESCRIPTION
[Step to Reproduce crash]

1. Set the following configurations in records.config.
   CONFIG proxy.config.http.attach_server_session_to_client INT 1
   CONFIG proxy.config.net.default_inactivity_timeout INT 10
2. Restart ATS
3. Send a GET request with HTTP/2 to ATS that will communicate with an origin server
4. Wait for inactivity timeout, 10 seconds, that was specified by the config of default_inactivity_timeout.
5. Crash

The problem was that the 
proxy.config.http.attach_server_session_to_client setting  only currently makes sense for HTTP/1. x user agents.  As we make our origin connections both HTTP/2 and HTTP/1.x it may make sense to add this sticky session support between HTTP/2 user agent and server sessions.

This fix avoids setting the sticky server session if the user agent is HTTP2.  It will instead just close the server session.  So the server session so not left floating around with a reference to the deleted HttpSM..