### PR TITLE
HostDB: Fix cache data version checking to use full version, not only major version.

### DIFF
--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -373,8 +373,8 @@ public:
   ts::VersionNumber object_version; // version passed in of whatever it is we are caching
 
   RefCountCacheHeader(ts::VersionNumber object_version = ts::VersionNumber());
-  bool operator==(const RefCountCacheHeader other) const;
-  bool compatible(RefCountCacheHeader *other) const;
+  bool operator==(RefCountCacheHeader const &that) const;
+  bool compatible(RefCountCacheHeader *that) const;
 };
 
 // RefCountCache is a ref-counted key->value map to store classes that inherit from RefCountObj.

--- a/iocore/hostdb/RefCountCache.cc
+++ b/iocore/hostdb/RefCountCache.cc
@@ -41,14 +41,13 @@ RefCountCacheHashEntry::dealloc(RefCountCacheHashEntry *e)
 RefCountCacheHeader::RefCountCacheHeader(ts::VersionNumber object_version) : object_version(object_version){};
 
 bool
-RefCountCacheHeader::operator==(const RefCountCacheHeader other) const
+RefCountCacheHeader::operator==(RefCountCacheHeader const &that) const
 {
-  return this->magic == other.magic && this->version == other.version;
+  return this->magic == that.magic && this->version == that.version;
 }
 
 bool
-RefCountCacheHeader::compatible(RefCountCacheHeader *other) const
+RefCountCacheHeader::compatible(RefCountCacheHeader *that) const
 {
-  return (this->magic == other->magic && this->version._major == other->version._major &&
-          this->object_version._major == other->version._major);
+  return this->magic == that->magic && this->version == that->version && this->object_version == that->version;
 };


### PR DESCRIPTION
This also fixes the parameter type from a non-reference to a reference.