### PR TITLE
HostDB: remove unused field in HostDBApplicationInfo

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -64,6 +64,10 @@ int hostdb_sync_frequency                          = 0;
 int hostdb_disable_reverse_lookup                  = 0;
 int hostdb_max_iobuf_index                         = BUFFER_SIZE_INDEX_32K;
 
+// Verify the generic storage is sufficient to cover all alternate members.
+static_assert(sizeof(HostDBApplicationInfo::allotment) == sizeof(HostDBApplicationInfo),
+              "Generic storage for HostDBApplicationInfo is smaller than the union storage.");
+
 ClassAllocator<HostDBContinuation> hostDBContAllocator("hostDBContAllocator");
 
 // Static configuration information

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -682,10 +682,10 @@ public:
     DNSLookupInfo dns_info;
     RedirectInfo redirect_info;
     OutboundConnTrack::TxnState outbound_conn_track_state;
-    unsigned int updated_server_version   = HostDBApplicationInfo::HTTP_VERSION_UNDEFINED;
-    bool force_dns                        = false;
-    MgmtByte cache_open_write_fail_action = 0;
-    bool is_revalidation_necessary        = false; // Added to check if revalidation is necessary - YTS Team, yamsat
+    HostDBApplicationInfo::HttpVersion updated_server_version = HostDBApplicationInfo::HTTP_VERSION_UNDEFINED;
+    bool force_dns                                            = false;
+    MgmtByte cache_open_write_fail_action                     = 0;
+    bool is_revalidation_necessary = false; // Added to check if revalidation is necessary - YTS Team, yamsat
     ConnectionAttributes client_info;
     ConnectionAttributes parent_info;
     ConnectionAttributes server_info;


### PR DESCRIPTION
* Remove `HostDBApplicationInfo::http_data::keep_alive_timeout`.
* Change `HostDBApplicationInfo::HttpVersion` to be an 8 bit enum.
* Move the 32 bit value in `HostDBApplicationInfo::http_data` to be first for better packing.
* Add a `static_assert` to make sure the `allotment` member is sufficiently sized.
* Bump the HostDB object version to 1.1.

Ultimately this is about the first point, the others are collateral changes.