### PR TITLE
Fix truncated reponse on HTTP/2 graceful shutdown

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1427,9 +1427,6 @@ Http2ConnectionState::release_stream()
         // Can't do this because we just destroyed right here ^,
         // or we can use a local variable to do it.
         // ua_session = nullptr;
-      } else if (shutdown_state == HTTP2_SHUTDOWN_IN_PROGRESS && fini_event == nullptr) {
-        ua_session->clear_session_active();
-        fini_event = this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
       } else if (ua_session->is_active()) {
         // If the number of clients is 0, HTTP2_SESSION_EVENT_FINI is not received or sent, and ua_session is active,
         // then mark the connection as inactive


### PR DESCRIPTION
# Issue
We intermittently faced that clients get truncated response from ATS (v8.1.0). This happens only if ATS is in graceful shutdown mode, response takes time, and 2 GOAWAY frames are sent. We found that ATS races A). writing data to the socket and B). closing connection.

A sequence of the issue is below.

1). ATS starts sending response on the stream (id=1) and sends GOAWAY (stream_id=2^31-1) to indicate ATS is in graceful shutdown mode
2). After 2 seconds, ATS sends another GOAWAY (stream_id=1) and `shutdown_state` becomes `HTTP2_SHUTDOWN_IN_PROGRESS`
3). ATS try to complete sending the response and close the stream (ATS write a DATA frame with the END_STREAM flag to the buffer of VConnection)
4). ATS schedule `HTTP2_SESSION_EVENT_FINI` event
5). ATS try to write (SSL_write) data in the buffer but can't for some reasons ( - e.g., MBIO or socket buffer is full )
6). Scheduled `HTTP2_SESSION_EVENT_FINI` closes VConnection regardless of the status

# Fix
This change removes step 4). in the above. The HTTP/2 connection becomes inactive and follows the close sequence in regular mode.

# Future work
In the graceful shutdown mode, ATS can close the inactive connections aggressively ( an idea is closing the connection from `VC_EVENT_WRITE_COMPLETE` event ). But it seems not necessary. I'd like to do it as a part of #6877 (Refactoring closing HTTP/2 session).

---- 
(update)

# Trade-Off
This fix has a trade-off of losing the ability to close lingering inactive connections ( - e.g. a client keeps sending PING frame ).
As I wrote above, I'll restore this feature with #6877 or another PR. Because the size of the change seems big.
