### PR TITLE
Add AuTest for HTTP/2 Graceful Shutdown

### DIFF
--- a/tests/gold_tests/h2/gold/nghttp_1_stdout.gold
+++ b/tests/gold_tests/h2/gold/nghttp_1_stdout.gold
@@ -1,0 +1,12 @@
+``
+[``] recv HEADERS frame <length=``, flags=0x04, stream_id=1>
+``
+[``] recv GOAWAY frame <length=8, flags=0x00, stream_id=0>
+          (last_stream_id=2147483647, error_code=NO_ERROR(0x00), opaque_data(0)=[])
+``
+[``] recv GOAWAY frame <length=8, flags=0x00, stream_id=0>
+          (last_stream_id=1, error_code=NO_ERROR(0x00), opaque_data(0)=[])
+``
+[``] recv DATA frame <length=0, flags=0x01, stream_id=1>
+          ; END_STREAM
+``

--- a/tests/gold_tests/h2/gold/nghttp_ts_stderr.gold
+++ b/tests/gold_tests/h2/gold/nghttp_ts_stderr.gold
@@ -1,0 +1,5 @@
+``
+``session free
+``
+``session free
+``

--- a/tests/gold_tests/h2/nghttp.test.py
+++ b/tests/gold_tests/h2/nghttp.test.py
@@ -30,6 +30,7 @@ Test.ContinueOnFail = True
 # Setup Origin Server
 # ----
 microserver = Test.MakeOriginServer("microserver")
+httpbin = Test.MakeHttpBinServer("httpbin")
 
 # 128KB
 post_body = "0123456789abcdef" * 8192
@@ -49,15 +50,20 @@ microserver.addResponse("sessionlog.json",
 # ----
 # Setup ATS
 # ----
-ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_cache=False)
+ts = Test.MakeATSProcess("ts", select_ports=True,
+                         enable_tls=True, enable_cache=False)
 
 # add ssl materials like key, certificates for the server
 ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
-ts.Disk.remap_config.AddLine(
-    'map /post http://127.0.0.1:{0}/post'.format(microserver.Variables.Port)
-)
+ts.Setup.CopyAs('rules/graceful_shutdown.conf', Test.RunDirectory)
+
+ts.Disk.remap_config.AddLines([
+    'map /post http://127.0.0.1:{0}/post'.format(microserver.Variables.Port),
+    'map /httpbin/ http://127.0.0.1:{0}/ @plugin=header_rewrite.so @pparam={1}/graceful_shutdown.conf'.format(
+        httpbin.Variables.Port, Test.RunDirectory)
+])
 
 ts.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
@@ -65,18 +71,18 @@ ts.Disk.ssl_multicert_config.AddLine(
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
+    'proxy.config.diags.debug.tags': 'http2_cs',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http2.active_timeout_in': 3,
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir)
 })
 
 # ----
 # Test Cases
 # ----
 
-# Test Case 0:  Trailer
+# Test Case 0: Trailer
 tr = Test.AddTestRun()
+tr.TimeOut = 10
 tr.Processes.Default.Command = "nghttp -v --no-dep 'https://127.0.0.1:{0}/post' --trailer 'foo: bar' -d 'post_body'".format(
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
@@ -84,3 +90,18 @@ tr.Processes.Default.StartBefore(microserver, ready=When.PortOpen(microserver.Va
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stdout = "gold/nghttp_0_stdout.gold"
 tr.StillRunningAfter = microserver
+tr.StillRunningAfter = ts
+
+# Test Case 1: Graceful Shutdown
+#   - This test takes 3 seconds to make sure receiving 2 GOAWAY frames
+#   - TODO: add a test case of a client keeps the connection open ( -e.g. keep sending PING frame)
+tr = Test.AddTestRun()
+tr.TimeOut = 10
+tr.Processes.Default.Command = f"nghttp -vn --no-dep 'https://127.0.0.1:{ts.Variables.ssl_port}/httpbin/drip?duration=3'"
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+tr.Processes.Default.Streams.stdout = "gold/nghttp_1_stdout.gold"
+tr.StillRunningAfter = httpbin
+tr.StillRunningAfter = ts
+
+ts.Streams.stderr = "gold/nghttp_ts_stderr.gold"

--- a/tests/gold_tests/h2/rules/graceful_shutdown.conf
+++ b/tests/gold_tests/h2/rules/graceful_shutdown.conf
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cond %{SEND_RESPONSE_HDR_HOOK}
+  set-header Connection "close"


### PR DESCRIPTION
Add a basic test case of HTTP/2 Graceful Shutdown. Please note that this doesn't cover the issues we discussed in #7267.