### PR TITLE
Respecting default rolling_enabled value in plugins.

### DIFF
--- a/plugins/regex_revalidate/regex_revalidate.c
+++ b/plugins/regex_revalidate/regex_revalidate.c
@@ -481,7 +481,6 @@ TSPluginInit(int argc, const char *argv[])
       break;
     case 'l':
       if (TS_SUCCESS == TSTextLogObjectCreate(optarg, TS_LOG_MODE_ADD_TIMESTAMP, &pstate->log)) {
-        TSTextLogObjectRollingEnabledSet(pstate->log, 1);
         TSTextLogObjectRollingIntervalSecSet(pstate->log, LOG_ROLL_INTERVAL);
         TSTextLogObjectRollingOffsetHrSet(pstate->log, LOG_ROLL_OFFSET);
       }


### PR DESCRIPTION
We're using logrotate(3) via SIGUSR2. As such we're no longer using ATS log rotate and are disabling proxy.config.log.rolling_enabled. We noticed that some plugins indiscriminately enable log rolling without consideration of the system value. This looks like it is just a mistake that went unnoticed because we've always had this enabled. I'm changing a couple plugins to respect the proxy.config.log.rolling_enabled value by not overwriting it with TSTextLogObjectRollingEnabledSet unless explicitly configured to do so.

---

The tcpinfo change is easier to read if you configure the diff view to hide whitespace changes.