### PR TITLE
Reduce the number of write operation on H2

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3901,11 +3901,11 @@ HTTP/2 Configuration
    Clients that send smaller window increments lower than this limit will be immediately disconnected with an error
    code of ENHANCE_YOUR_CALM.
 
-.. ts:cv:: CONFIG proxy.config.http2.write_buffer_block_size_index INT 11
+.. ts:cv:: CONFIG proxy.config.http2.write_buffer_block_size INT 262144
    :reloadable:
 
    Specifies the size of a buffer block that is used for buffering outgoing
-   HTTP/2 frames. The default value is 11 which maps to 256KB.
+   HTTP/2 frames. The size will be rounded up based on power of 2.
 
 .. ts:cv:: CONFIG proxy.config.http2.write_threshold FLOAT `0.5
    :reloadable:

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3901,6 +3901,19 @@ HTTP/2 Configuration
    Clients that send smaller window increments lower than this limit will be immediately disconnected with an error
    code of ENHANCE_YOUR_CALM.
 
+.. ts:cv:: CONFIG proxy.config.http2.write_buffer_block_size_index INT 11
+   :reloadable:
+
+   Specifies the size of a buffer block that is used for buffering outgoing
+   HTTP/2 frames. The default value is 11 which maps to 256KB.
+
+.. ts:cv:: CONFIG proxy.config.http2.write_threshold FLOAT `0.5
+   :reloadable:
+
+   Specifies the threshold for triggering write operation for sending HTTP/2
+   frames. The default value is 0.5 and it measn write operation is going to be
+   triggered when half or more of the buffer is occupied.
+
 HTTP/3 Configuration
 ====================
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3907,12 +3907,20 @@ HTTP/2 Configuration
    Specifies the size of a buffer block that is used for buffering outgoing
    HTTP/2 frames. The size will be rounded up based on power of 2.
 
-.. ts:cv:: CONFIG proxy.config.http2.write_threshold FLOAT `0.5
+.. ts:cv:: CONFIG proxy.config.http2.write_size_threshold FLOAT 0.5
    :reloadable:
 
-   Specifies the threshold for triggering write operation for sending HTTP/2
+   Specifies the size threshold for triggering write operation for sending HTTP/2
    frames. The default value is 0.5 and it measn write operation is going to be
    triggered when half or more of the buffer is occupied.
+
+.. ts:cv:: CONFIG proxy.config.http2.write_time_threshold INT 100
+   :reloadable:
+   :units: milliseconds
+
+   Specifies the time threshold for triggering write operation for sending HTTP/2
+   frames. Write operation will be triggered at least once every this configured
+   number of millisecond regardless of pending data size.
 
 HTTP/3 Configuration
 ====================

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1333,6 +1333,10 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http2.header_table_size_limit", RECD_INT, "65536", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http2.write_buffer_block_size_index", RECD_INT, "11", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.http2.write_threshold", RECD_FLOAT, "0.5",  RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
 
   //############
   //#

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1333,9 +1333,11 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http2.header_table_size_limit", RECD_INT, "65536", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http2.write_buffer_block_size", RECD_INT, "262144", RECU_DYNAMIC, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http2.write_buffer_block_size", RECD_INT, "262144", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http2.write_threshold", RECD_FLOAT, "0.5",  RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http2.write_size_threshold", RECD_FLOAT, "0.5",  RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.http2.write_time_threshold", RECD_INT, "100", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
 
   //############

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1333,7 +1333,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http2.header_table_size_limit", RECD_INT, "65536", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http2.write_buffer_block_size_index", RECD_INT, "11", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http2.write_buffer_block_size", RECD_INT, "262144", RECU_DYNAMIC, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http2.write_threshold", RECD_FLOAT, "0.5",  RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -805,6 +805,8 @@ float Http2::min_avg_window_update             = 2560.0;
 uint32_t Http2::con_slow_log_threshold         = 0;
 uint32_t Http2::stream_slow_log_threshold      = 0;
 uint32_t Http2::header_table_size_limit        = 65536;
+uint32_t Http2::write_buffer_block_size_index  = 11;
+float Http2::write_threshold                   = 0.5;
 
 void
 Http2::init()
@@ -832,6 +834,8 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(con_slow_log_threshold, "proxy.config.http2.connection.slow.log.threshold");
   REC_EstablishStaticConfigInt32U(stream_slow_log_threshold, "proxy.config.http2.stream.slow.log.threshold");
   REC_EstablishStaticConfigInt32U(header_table_size_limit, "proxy.config.http2.header_table_size_limit");
+  REC_EstablishStaticConfigInt32U(write_buffer_block_size_index, "proxy.config.http2.write_buffer_block_size_index");
+  REC_EstablishStaticConfigFloat(write_threshold, "proxy.config.http2.write_threshold");
 
   // If any settings is broken, ATS should not start
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, max_concurrent_streams_in}));

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -806,7 +806,8 @@ uint32_t Http2::con_slow_log_threshold         = 0;
 uint32_t Http2::stream_slow_log_threshold      = 0;
 uint32_t Http2::header_table_size_limit        = 65536;
 uint32_t Http2::write_buffer_block_size        = 262144;
-float Http2::write_threshold                   = 0.5;
+float Http2::write_size_threshold              = 0.5;
+uint32_t Http2::write_time_threshold           = 100;
 
 void
 Http2::init()
@@ -835,7 +836,8 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(stream_slow_log_threshold, "proxy.config.http2.stream.slow.log.threshold");
   REC_EstablishStaticConfigInt32U(header_table_size_limit, "proxy.config.http2.header_table_size_limit");
   REC_EstablishStaticConfigInt32U(write_buffer_block_size, "proxy.config.http2.write_buffer_block_size");
-  REC_EstablishStaticConfigFloat(write_threshold, "proxy.config.http2.write_threshold");
+  REC_EstablishStaticConfigFloat(write_size_threshold, "proxy.config.http2.write_size_threshold");
+  REC_EstablishStaticConfigInt32U(write_time_threshold, "proxy.config.http2.write_time_threshold");
 
   // If any settings is broken, ATS should not start
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, max_concurrent_streams_in}));

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -805,7 +805,7 @@ float Http2::min_avg_window_update             = 2560.0;
 uint32_t Http2::con_slow_log_threshold         = 0;
 uint32_t Http2::stream_slow_log_threshold      = 0;
 uint32_t Http2::header_table_size_limit        = 65536;
-uint32_t Http2::write_buffer_block_size_index  = 11;
+uint32_t Http2::write_buffer_block_size        = 262144;
 float Http2::write_threshold                   = 0.5;
 
 void
@@ -834,7 +834,7 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(con_slow_log_threshold, "proxy.config.http2.connection.slow.log.threshold");
   REC_EstablishStaticConfigInt32U(stream_slow_log_threshold, "proxy.config.http2.stream.slow.log.threshold");
   REC_EstablishStaticConfigInt32U(header_table_size_limit, "proxy.config.http2.header_table_size_limit");
-  REC_EstablishStaticConfigInt32U(write_buffer_block_size_index, "proxy.config.http2.write_buffer_block_size_index");
+  REC_EstablishStaticConfigInt32U(write_buffer_block_size, "proxy.config.http2.write_buffer_block_size");
   REC_EstablishStaticConfigFloat(write_threshold, "proxy.config.http2.write_threshold");
 
   // If any settings is broken, ATS should not start

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -403,6 +403,8 @@ public:
   static uint32_t con_slow_log_threshold;
   static uint32_t stream_slow_log_threshold;
   static uint32_t header_table_size_limit;
+  static uint32_t write_buffer_block_size_index;
+  static float write_threshold;
 
   static void init();
 };

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -403,7 +403,7 @@ public:
   static uint32_t con_slow_log_threshold;
   static uint32_t stream_slow_log_threshold;
   static uint32_t header_table_size_limit;
-  static uint32_t write_buffer_block_size_index;
+  static uint32_t write_buffer_block_size;
   static float write_threshold;
 
   static void init();

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -404,7 +404,8 @@ public:
   static uint32_t stream_slow_log_threshold;
   static uint32_t header_table_size_limit;
   static uint32_t write_buffer_block_size;
-  static float write_threshold;
+  static float write_size_threshold;
+  static uint32_t write_time_threshold;
 
   static void init();
 };

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -327,7 +327,7 @@ Http2ClientSession::flush()
   if (this->_pending_sending_data_size > 0) {
     total_write_len += this->_pending_sending_data_size;
     this->_pending_sending_data_size = 0;
-    this->_write_buffer_last_flash   = Thread::get_hrtime();
+    this->_write_buffer_last_flush   = Thread::get_hrtime();
     write_reenable();
   }
 }
@@ -376,7 +376,7 @@ Http2ClientSession::main_event_handler(int event, void *edata)
   case VC_EVENT_WRITE_READY:
   case VC_EVENT_WRITE_COMPLETE:
     this->connection_state.restart_streams();
-    if ((Thread::get_hrtime() >= this->_write_buffer_last_flash + HRTIME_MSECONDS(this->_write_time_threshold))) {
+    if ((Thread::get_hrtime() >= this->_write_buffer_last_flush + HRTIME_MSECONDS(this->_write_time_threshold))) {
       this->flush();
     }
     retval = 0;

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -315,14 +315,20 @@ Http2ClientSession::xmit(const Http2TxFrame &frame, bool flush)
   }
 
   if (flush) {
-    if (this->_pending_sending_data_size > 0) {
-      total_write_len += this->_pending_sending_data_size;
-      this->_pending_sending_data_size = 0;
-      write_reenable();
-    }
+    this->flush();
   }
 
   return len;
+}
+
+void
+Http2ClientSession::flush()
+{
+  if (this->_pending_sending_data_size > 0) {
+    total_write_len += this->_pending_sending_data_size;
+    this->_pending_sending_data_size = 0;
+    write_reenable();
+  }
 }
 
 int

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -218,9 +218,10 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   this->_reader                 = reader ? reader : this->read_buffer->alloc_reader();
 
   // This block size is the buffer size that we pass to SSLWriteBuffer
-  this->write_buffer     = new_MIOBuffer(Http2::write_buffer_block_size_index);
-  this->sm_writer        = this->write_buffer->alloc_reader();
-  this->_write_threshold = index_to_buffer_size(Http2::write_buffer_block_size_index) * Http2::write_threshold;
+  auto buffer_block_size_index = iobuffer_size_to_index(Http2::write_buffer_block_size, MAX_BUFFER_SIZE_INDEX);
+  this->write_buffer           = new_MIOBuffer(buffer_block_size_index);
+  this->sm_writer              = this->write_buffer->alloc_reader();
+  this->_write_threshold       = index_to_buffer_size(buffer_block_size_index) * Http2::write_threshold;
 
   this->_handle_if_ssl(new_vc);
 

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -101,7 +101,7 @@ public:
 
   // more methods
   void write_reenable();
-  int64_t xmit(const Http2TxFrame &frame);
+  int64_t xmit(const Http2TxFrame &frame, bool flush = true);
 
   ////////////////////
   // Accessors
@@ -182,6 +182,10 @@ private:
 
   Event *_reenable_event = nullptr;
   int _n_frame_read      = 0;
+
+  MIOBuffer *_send_frame_buffer             = nullptr;
+  IOBufferReader *_send_frame_buffer_reader = nullptr;
+  uint32_t _send_frame_buffer_used_size     = 0;
 
   int64_t read_from_early_data   = 0;
   bool cur_frame_from_early_data = false;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -164,7 +164,7 @@ private:
   Http2FrameHeader current_hdr        = {0, 0, 0, 0};
   uint32_t _write_size_threshold      = 0;
   uint32_t _write_time_threshold      = 100;
-  ink_hrtime _write_buffer_last_flash = 0;
+  ink_hrtime _write_buffer_last_flush = 0;
 
   IpEndpoint cached_client_addr;
   IpEndpoint cached_local_addr;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -162,6 +162,7 @@ private:
   MIOBuffer *write_buffer        = nullptr;
   IOBufferReader *sm_writer      = nullptr;
   Http2FrameHeader current_hdr   = {0, 0, 0, 0};
+  uint32_t _write_threshold      = 0;
 
   IpEndpoint cached_client_addr;
   IpEndpoint cached_local_addr;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -183,9 +183,7 @@ private:
   Event *_reenable_event = nullptr;
   int _n_frame_read      = 0;
 
-  MIOBuffer *_send_frame_buffer             = nullptr;
-  IOBufferReader *_send_frame_buffer_reader = nullptr;
-  uint32_t _send_frame_buffer_used_size     = 0;
+  uint32_t _pending_sending_data_size = 0;
 
   int64_t read_from_early_data   = 0;
   bool cur_frame_from_early_data = false;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -155,14 +155,16 @@ private:
 
   bool _should_do_something_else();
 
-  int64_t total_write_len        = 0;
-  SessionHandler session_handler = nullptr;
-  MIOBuffer *read_buffer         = nullptr;
-  IOBufferReader *_reader        = nullptr;
-  MIOBuffer *write_buffer        = nullptr;
-  IOBufferReader *sm_writer      = nullptr;
-  Http2FrameHeader current_hdr   = {0, 0, 0, 0};
-  uint32_t _write_threshold      = 0;
+  int64_t total_write_len             = 0;
+  SessionHandler session_handler      = nullptr;
+  MIOBuffer *read_buffer              = nullptr;
+  IOBufferReader *_reader             = nullptr;
+  MIOBuffer *write_buffer             = nullptr;
+  IOBufferReader *sm_writer           = nullptr;
+  Http2FrameHeader current_hdr        = {0, 0, 0, 0};
+  uint32_t _write_size_threshold      = 0;
+  uint32_t _write_time_threshold      = 100;
+  ink_hrtime _write_buffer_last_flash = 0;
 
   IpEndpoint cached_client_addr;
   IpEndpoint cached_local_addr;

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -102,6 +102,7 @@ public:
   // more methods
   void write_reenable();
   int64_t xmit(const Http2TxFrame &frame, bool flush = true);
+  void flush();
 
   ////////////////////
   // Accessors

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1580,7 +1580,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
                    _client_rwnd, stream->client_rwnd(), payload_length);
 
   Http2DataFrame data(stream->get_id(), flags, resp_reader, payload_length);
-  this->ua_session->xmit(data);
+  this->ua_session->xmit(data, flags & HTTP2_FLAGS_DATA_END_STREAM);
 
   stream->update_sent_count(payload_length);
 

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1547,6 +1547,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
     // We only need to check for window size when there is a payload
     if (window_size <= 0) {
       Http2StreamDebug(this->ua_session, stream->get_id(), "No window");
+      this->ua_session->flush();
       return Http2SendDataFrameResult::NO_WINDOW;
     }
 
@@ -1564,6 +1565,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
   // OK if there is no body yet. Otherwise continue on to send a DATA frame and delete the stream
   if (!stream->is_write_vio_done() && payload_length == 0) {
     Http2StreamDebug(this->ua_session, stream->get_id(), "No payload");
+    this->ua_session->flush();
     return Http2SendDataFrameResult::NO_PAYLOAD;
   }
 


### PR DESCRIPTION
H1ClientSession can simply pass large (1MB) buffers that come from Cache to `SSLWriteBuffer` (== `SSL_write`), because there's no framing on H1. On the other hand, H2ClientSession can't do the same, because data has to be split into DATA frames (frame headers have to be inserted). During the framing, small (16KB) buffers are made on each DATA frame and H2ClientSession passes those to `SSLWriteBuffers`. This means that we call `SSLWriteBuffer` 64 times more on H2.

This change reduces the number of write operation (`SSLWriteBuffer`) on H2 by increasing the buffer (block) size and storing multiple DATA frames into the single large buffer.

Here's benchmark result on my laptop:

`$ time h2load -n10000 -c10 -m10 https://localhost:8443/8m`

Before:
```
finished in 58.30s, 171.54 req/s, 1.34GB/s
requests: 10000 total, 10000 started, 10000 done, 10000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 10000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 78.17GB (83932534571) total, 101.64KB (104077) headers (space savings 96.71%), 78.13GB (83886080000) data
                     min         max         mean         sd        +/- sd
time for request:    18.00ms       5.53s    483.43ms    516.19ms    93.72%
time for connect:     2.92ms      8.21ms      5.14ms      1.68ms    70.00%
time to 1st byte:    44.94ms    164.22ms    116.20ms     33.34ms    70.00%
req/s           :      17.15       29.08       20.61        3.75    80.00%

real    0m58.313s
user    0m40.274s
sys     0m17.108s
```

After:
```
finished in 50.54s, 197.86 req/s, 1.55GB/s
requests: 10000 total, 10000 started, 10000 done, 10000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 10000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 78.17GB (83932534054) total, 101.14KB (103564) headers (space savings 96.72%), 78.13GB (83886080000) data
                     min         max         mean         sd        +/- sd
time for request:    14.06ms       6.96s    416.36ms    559.53ms    95.08%
time for connect:     2.75ms      7.41ms      4.89ms      1.48ms    60.00%
time to 1st byte:    30.32ms    115.90ms     79.89ms     31.21ms    50.00%
req/s           :      19.79       28.42       23.34        3.79    60.00%

real    0m50.556s
user    0m36.718s
sys     0m13.533s
```

For reference, this is H1 result on the same condition:
```
finished in 50.20s, 199.18 req/s, 1.56GB/s
requests: 10000 total, 10000 started, 10000 done, 10000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 10000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 78.13GB (83889917615) total, 3.10MB (3247615) headers (space savings 0.00%), 78.13GB (83886080000) data
                     min         max         mean         sd        +/- sd
time for request:    15.03ms      18.19s    416.14ms    803.15ms    98.16%
time for connect:     3.57ms     10.81ms      6.10ms      2.10ms    80.00%
time to 1st byte:     6.88ms     27.72ms     13.49ms      6.91ms    80.00%
req/s           :      19.92       26.83       24.18        2.27    70.00%

real    0m50.226s
user    0m36.963s
sys     0m12.938s
```