### PR TITLE
Race condition between Server session release and Net read

### DIFF
--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -346,7 +346,8 @@ public:
   */
   Event *start_event = nullptr;
 
-  ServerSessionPool *server_session_pool = nullptr;
+  ServerSessionPool *server_session_pool    = nullptr;
+  ServerSessionPool *server_session_pool_gc = nullptr;
 
   /** Default handler used until it is overridden.
 

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -908,6 +908,14 @@ public:
     return ats_ip_port_host_order(this->get_proxy_protocol_addr(ProxyProtocolData::DST));
   };
 
+  Ptr<ProxyMutex> &
+  get_server_idle_pool_mutex()
+  {
+    return server_idle_pool_mutex;
+  }
+
+  Ptr<ProxyMutex> server_idle_pool_mutex;
+
   struct ProxyProtocol {
     ProxyProtocolVersion proxy_protocol_version = ProxyProtocolVersion::UNDEFINED;
     uint16_t ip_family;

--- a/iocore/net/SSLNetProcessor.cc
+++ b/iocore/net/SSLNetProcessor.cc
@@ -111,6 +111,8 @@ SSLNetProcessor::allocate_vc(EThread *t)
     }
   }
 
+  vc->server_idle_pool_mutex = new_ProxyMutex();
+
   return vc;
 }
 

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -338,6 +338,8 @@ UnixNetProcessor::allocate_vc(EThread *t)
     }
   }
 
+  vc->server_idle_pool_mutex = new_ProxyMutex();
+
   return vc;
 }
 

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -37,6 +37,8 @@
 #include "HttpConnectionCount.h"
 #include "HttpProxyAPIEnums.h"
 
+#define EHTTPSESSIONCLOSE 1111
+
 class HttpSM;
 class MIOBuffer;
 class IOBufferReader;
@@ -66,7 +68,7 @@ public:
   ////////////////////
   // Methods
   void new_connection(NetVConnection *new_vc);
-  void release();
+  void release(bool to_pool = true);
   void destroy();
 
   // VConnection Methods
@@ -109,6 +111,8 @@ public:
   // Sessions become if authentication headers
   //  are sent over them
   bool private_session = false;
+
+  bool close_received = false;
 
   // Copy of the owning SM's server session sharing settings
   TSServerSessionSharingMatchMask sharing_match = TS_SERVER_SESSION_SHARING_MATCH_MASK_NONE;

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -67,6 +67,7 @@ public:
   static bool validate_host_sni(HttpSM *sm, NetVConnection *netvc);
   static bool validate_sni(HttpSM *sm, NetVConnection *netvc);
   static bool validate_cert(HttpSM *sm, NetVConnection *netvc);
+  void cleanupSession(Http1ServerSession *s, int event, bool from_shared_pool = true);
 
 protected:
   using IPTable   = IntrusiveHashMap<Http1ServerSession::IPLinkage>;
@@ -89,7 +90,7 @@ public:
                              HttpSM *sm, Http1ServerSession *&server_session);
   /** Release a session to to pool.
    */
-  void releaseSession(Http1ServerSession *ss);
+  void releaseSession(Http1ServerSession *ss, bool to_pool = true);
 
   /// Close all sessions and then clear the table.
   void purge();
@@ -98,6 +99,7 @@ public:
   // Note that each server session is stored in both pools.
   IPTable m_ip_pool;
   FQDNTable m_fqdn_pool;
+  IPTable m_ip_pool_gc;
 };
 
 class HttpSessionManager
@@ -106,7 +108,7 @@ public:
   HttpSessionManager() {}
   ~HttpSessionManager() {}
   HSMresult_t acquire_session(Continuation *cont, sockaddr const *addr, const char *hostname, ProxyTransaction *ua_txn, HttpSM *sm);
-  HSMresult_t release_session(Http1ServerSession *to_release);
+  HSMresult_t release_session(Http1ServerSession *to_release, bool to_pool = true);
   void purge_keepalives();
   void init();
   int main_handler(int event, void *data);


### PR DESCRIPTION
This fixes #7284 

Defer Http1ServerSession destroying to prevent read buffer
corruption due to race with network i/o

PR #7278 fixed the crash due to race condition during server session acquisition but the fix did not actually solve the problem for the same race during server session closing.

It turns out the root cause is that the read buffer attached to the Server NetVC is actually "owned" by Http1ServerSession object which destroys itself along with the mutex associated when calling do_io_close(). The actual NetVC may be doing a read in a different thread at the same time and is now using the read buffer that is freed by Http1ServerSession. This seems to happen more again with Transform plugins at play. I tried to switch the ownership of the read buffer to the Server NetVC, but, could not get it working correctly as it seems to expose even more race conditions and asserts all over the place.

Instead, the solution I implemented is to not destroy the Server Session during do_io_close(), but add it to a separate unshared/gc session pool, which will eventually clean up these sessions on a subsequent event from either inactivity cop or a stray read that was racing with it. Moving them to a separate gc session pool allows to also guard the event handling with a dedicated mutex against the read. This mutex guard can not be easily added within an SM call back since that'd mean handling a lock failure etc which introduces complexity into the state machine.