### PR TITLE
Remove unfinished h2c support

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -167,11 +167,6 @@ ProxyTransaction::set_outbound_transparent(bool flag)
   upstream_outbound_options.f_outbound_transparent = flag;
 }
 
-void
-ProxyTransaction::set_h2c_upgrade_flag()
-{
-}
-
 int
 ProxyTransaction::get_transaction_priority_weight() const
 {

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -73,7 +73,6 @@ public:
   virtual bool is_chunked_encoding_supported() const;
 
   virtual void set_proxy_ssn(ProxySession *set_proxy_ssn);
-  virtual void set_h2c_upgrade_flag();
 
   /// Non-Virtual Methods
   //

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1230,9 +1230,12 @@ HttpTransact::handle_upgrade_request(State *s)
       } else {
         TxnDebug("http_trans_upgrade", "Unable to upgrade connection to websockets, invalid headers (RFC 6455).");
       }
+    } else if (s->upgrade_token_wks == MIME_VALUE_H2C) {
+      // We need to recognize h2c to not handle it as an error.
+      // We just ignore the Upgrade header and respond to the request as though the Upgrade header field were absent.
+      s->is_upgrade_request = false;
+      return false;
     }
-
-    // TODO accept h2c token to start HTTP/2 session after TS-3498 is fixed
   } else {
     TxnDebug("http_trans_upgrade", "Transaction requested upgrade for unknown protocol: %s", upgrade_hdr_val);
   }

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -60,24 +60,6 @@ enum class Http2SsnMilestone {
 
 size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ_BUFFER_SIZE_INDEX;
 
-// To support Upgrade: h2c
-struct Http2UpgradeContext {
-  Http2UpgradeContext() {}
-  ~Http2UpgradeContext()
-  {
-    if (req_header) {
-      req_header->clear();
-      delete req_header;
-    }
-  }
-
-  // Modified request header
-  HTTPHdr *req_header = nullptr;
-
-  // Decoded HTTP2-Settings Header Field
-  Http2ConnectionSettings client_settings;
-};
-
 class Http2ClientSession : public ProxySession
 {
 public:
@@ -115,7 +97,6 @@ public:
   void decrement_current_active_client_connections_stat() override;
 
   void set_upgrade_context(HTTPHdr *h);
-  const Http2UpgradeContext &get_upgrade_context() const;
   void set_dying_event(int event);
   int get_dying_event() const;
   bool ready_to_free() const;
@@ -168,9 +149,6 @@ private:
   History<HISTORY_DEFAULT_SIZE> _history;
   Milestones<Http2SsnMilestone, static_cast<size_t>(Http2SsnMilestone::LAST_ENTRY)> _milestones;
 
-  // For Upgrade: h2c
-  Http2UpgradeContext upgrade_context;
-
   VIO *write_vio                 = nullptr;
   int dying_event                = 0;
   bool kill_me                   = false;
@@ -191,12 +169,6 @@ extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;
 
 ///////////////////////////////////////////////
 // INLINE
-
-inline const Http2UpgradeContext &
-Http2ClientSession::get_upgrade_context() const
-{
-  return upgrade_context;
-}
 
 inline bool
 Http2ClientSession::ready_to_free() const


### PR DESCRIPTION
This removes code for h2c support except the upgrade token. The token is needed to recognize h2c and handle it as a normal request without Upgrade header.

With this change, a request with `Upgrade: h2c` does not cause "400 Invalid Upgrade Request", unless the request is really a bad request. The behavior for `Upgrade: websocket` is not changed (it returns 400 if the request doesn't follow requirements on RFC6455).

This closes #3813