### PR TITLE
option to disable compression for range request's response

### DIFF
--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -107,7 +107,7 @@ range-request
 -----
 
 When set to ``true``, causes |TS| to compress responses to Range Requests.
-Disabled by default.
+Disabled by default. Setting this to true while setting cache to false leads to delivering corrupted content.
 
 compressible-content-type
 -------------------------

--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -103,6 +103,12 @@ versions of the content as :term:`alternates <alternate>`. When set to
 ``false``, |TS| will cache only the compressed or decompressed variant returned
 by the origin. Enabled by default.
 
+range-request
+-----
+
+When set to ``true``, causes |TS| to compress responses to Range Requests.
+Disabled by default.
+
 compressible-content-type
 -------------------------
 

--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -105,6 +105,7 @@ enum ParserState {
   kParseRemoveAcceptEncoding,
   kParseEnable,
   kParseCache,
+  kParseRangeRequest,
   kParseFlush,
   kParseAllow,
   kParseMinimumContentLength
@@ -347,6 +348,8 @@ Configuration::Parse(const char *path)
           state = kParseEnable;
         } else if (token == "cache") {
           state = kParseCache;
+        } else if (token == "range-request") {
+          state = kParseRangeRequest;
         } else if (token == "flush") {
           state = kParseFlush;
         } else if (token == "supported-algorithms") {
@@ -377,6 +380,10 @@ Configuration::Parse(const char *path)
         break;
       case kParseCache:
         current_host_configuration->set_cache(token == "true");
+        state = kParseStart;
+        break;
+      case kParseRangeRequest:
+        current_host_configuration->set_range_request(token == "true");
         state = kParseStart;
         break;
       case kParseFlush:

--- a/plugins/compress/configuration.h
+++ b/plugins/compress/configuration.h
@@ -48,6 +48,7 @@ public:
     : host_(host),
       enabled_(true),
       cache_(true),
+      range_request_(false),
       remove_accept_encoding_(false),
       flush_(false),
       compression_algorithms_(ALGORITHM_GZIP),
@@ -64,6 +65,16 @@ public:
   set_enabled(bool x)
   {
     enabled_ = x;
+  }
+  bool
+  range_request()
+  {
+    return range_request_;
+  }
+  void
+  set_range_request(bool x)
+  {
+    range_request_ = x;
   }
   bool
   cache()
@@ -131,6 +142,7 @@ private:
   std::string host_;
   bool enabled_;
   bool cache_;
+  bool range_request_;
   bool remove_accept_encoding_;
   bool flush_;
   int compression_algorithms_;


### PR DESCRIPTION
Provide an option to disable compression for a request with Range header.