### PR TITLE
Adjust to actually try a server address more than once

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3789,7 +3789,7 @@ HttpTransact::handle_response_from_server(State *s)
         return CallOSDNSLookup(s);
       } else if ((s->dns_info.srv_lookup_success || s->host_db_info.is_rr_elt()) &&
                  (s->txn_conf->connect_attempts_rr_retries > 0) &&
-                 (s->current.attempts % s->txn_conf->connect_attempts_rr_retries == 0)) {
+                 ((s->current.attempts + 1) % s->txn_conf->connect_attempts_rr_retries == 0)) {
         delete_server_rr_entry(s, max_connect_retries);
         return;
       } else {


### PR DESCRIPTION
Noticed this while testing connection retries across a server name with multiple addresses.  I had the following settings

```
CONFIG proxy.config.http.connect_attempts_max_retries INT 6
CONFIG proxy.config.http.connect_attempts_rr_retries INT 3
```

And I had microdns set up to replay with addresses 192.168.1.10 and 192.168.1.13 for the name "foo".

I had a server listening on port 8888 on 192.168.1.10 but a iptables DROP rule on port 8888 for 192.168.1.13.

For my query that maps to http://foo:8888, it was being sent to 192.168.1.13 first.  In the original code, it would fail 192.168.1.13, mark it down, and then successfully connect to 192.168.1.10.  So it ignored the connect_attempts_rr_retries count of 3.

With this code change, the same query would try and fail connections to 192.168.1.13 three times before marking it down and moving onto  192.168.1.10.

All of the retries were verified by looking at Debug output.

A note about the name "connect_attempts_rr_retries" implies this is the number of additional tries beyond the first try, but that is not how it is coded.  And reviewing the documentation, that is not what is described either.

Related to issue #7290 