### PR TITLE
Add failed state to hostdb to better track failing origins

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4261,6 +4261,7 @@ HttpSM::do_hostdb_update_if_necessary()
   } else {
     if (t_state.host_db_info.app.http_data.last_failure != 0) {
       t_state.host_db_info.app.http_data.last_failure = 0;
+      t_state.host_db_info.app.http_data.fail_count   = 0;
       issue_update |= 1;
       char addrbuf[INET6_ADDRPORTSTRLEN];
       SMDebug("http", "[%" PRId64 "] hostdb update marking IP: %s as up", sm_id,
@@ -5336,30 +5337,40 @@ HttpSM::mark_host_failure(HostDBInfo *info, time_t time_down)
 {
   char addrbuf[INET6_ADDRPORTSTRLEN];
 
-  if (info->app.http_data.last_failure == 0) {
-    char *url_str = t_state.hdr_info.client_request.url_string_get(&t_state.arena, nullptr);
-    Log::error("%s", lbw()
-                       .clip(1)
-                       .print("CONNECT Error: {} connecting to {} for '{}' (setting last failure time)",
-                              ts::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr,
-                              ts::bwf::FirstOf(url_str, "<none>"))
-                       .extend(1)
-                       .write('\0')
-                       .data());
+  if (time_down) {
+    // Increment the fail_count
+    ++info->app.http_data.fail_count;
+    if (info->app.http_data.fail_count >= t_state.txn_conf->connect_attempts_rr_retries) {
+      if (info->app.http_data.last_failure == 0) {
+        char *url_str = t_state.hdr_info.client_request.url_string_get(&t_state.arena, nullptr);
+        Log::error("%s", lbw()
+                           .clip(1)
+                           .print("CONNECT Error: {} connecting to {} for '{}' (setting last failure time)",
+                                  ts::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr,
+                                  ts::bwf::FirstOf(url_str, "<none>"))
+                           .extend(1)
+                           .write('\0')
+                           .data());
 
-    if (url_str) {
-      t_state.arena.str_free(url_str);
+        if (url_str) {
+          t_state.arena.str_free(url_str);
+        }
+      }
+      info->app.http_data.last_failure = time_down;
+      SMDebug("http", "[%" PRId64 "] hostdb update marking IP: %s as down", sm_id,
+              ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
+    } else {
+      SMDebug("http", "[%" PRId64 "] hostdb increment IP failcount %s to %d", sm_id,
+              ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)), info->app.http_data.fail_count);
     }
+  } else { // Clear the failure
+    info->app.http_data.fail_count   = 0;
+    info->app.http_data.last_failure = time_down;
   }
-
-  info->app.http_data.last_failure = time_down;
 
 #ifdef DEBUG
   ink_assert(ink_local_time() + t_state.txn_conf->down_server_timeout > time_down);
 #endif
-
-  SMDebug("http", "[%" PRId64 "] hostdb update marking IP: %s as down", sm_id,
-          ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
 }
 
 void

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -465,6 +465,7 @@ HttpTransact::is_server_negative_cached(State *s)
     //   down to 2*down_server_timeout
     if (s->client_request_time + s->txn_conf->down_server_timeout < s->host_db_info.app.http_data.last_failure) {
       s->host_db_info.app.http_data.last_failure = 0;
+      s->host_db_info.app.http_data.fail_count   = 0;
       ink_assert(!"extreme clock skew");
       return true;
     }


### PR DESCRIPTION
This is one possible solution to the immediate dead/down server on post failure problem described in issue #7290 

This PR uses the previously unused fail_count field in the set of hostdb structures to track how many times in a row an address for a name has failed.  In the case where transaction is not retryable (e.g. in the case of a post failure where data has been sent to the server), this code change updates the app.http_data.fail_count and updates the app.http_data.last_failure field only if the fail_count is greater than or equal to the value of the proxy.config.http.connect_attempts_rr_retries.  So if that was set to 3.  Three consecutive failures would need to occur before that address for the server name would be marked down.

I tested this in an environment with microdns set up to reply with addresses 192.168.1.10 and 192.168.1.13 for the name "foo".

I had servers listening on port 8888 on 192.168.1.10 and 192.168.1.13, but the version running on 192.168.1.13 would wait for 40 seconds before replying to a POST.  The other server responded immediately.  The transaction_no_activity_timeout_out was set to 10 seconds.

Without this code change, the POST request would hit 192.168.1.13 first and timeout.  Then subsequent requests would be sent to 192.168.1.10 until the interval specified in proxy.config.http.down_server.cache_time had passed.

With this code change, the POST requests would be sent to 192.168.1.13 for the number of times specified in proxy.config.http.connect_attempts_rr_retries before marking that address down for "foo" and moving onto 192.168.1.10 exclusively until the time specified in proxy.config.http.down_server.cache_time had passed.

This is not going to perfectly ensure that the bad address is tried exactly proxy.config.http.connect_attempts_rr_retries times.  Since the HostDBInfo is copied into the HttpSM area and then updates are copied back to the main HostDB store, it is quite possible that concurrent threads will cancel out each others updates.  But this should get reasonably close to matching the retry count.