### PR TITLE
Allow disabling SO_MARK and IP_TOS usage

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4273,6 +4273,8 @@ Sockets
         SO_KEEPALIVE (2)
         SO_LINGER (4) - with a timeout of 0 seconds
         TCP_FASTOPEN (8)
+        PACKET_MARK (16)
+        PACKET_TOS (32)
 
 .. note::
 
@@ -4305,6 +4307,8 @@ Sockets
         SO_KEEPALIVE (2)
         SO_LINGER (4) - with a timeout of 0 seconds
         TCP_FASTOPEN (8)
+        PACKET_MARK (16)
+        PACKET_TOS (32)
 
 .. note::
 

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -174,6 +174,10 @@ struct NetVCOptions {
   static uint32_t const SOCK_OPT_LINGER_ON = 4;
   /// Value for TCP Fast open @c sockopt_flags
   static uint32_t const SOCK_OPT_TCP_FAST_OPEN = 8;
+  /// Value for SO_MARK @c sockopt_flags
+  static uint32_t const SOCK_OPT_PACKET_MARK = 16;
+  /// Value for IP_TOS @c sockopt_flags
+  static uint32_t const SOCK_OPT_PACKET_TOS = 32;
 
   uint32_t packet_mark;
   uint32_t packet_tos;

--- a/iocore/net/UnixConnection.cc
+++ b/iocore/net/UnixConnection.cc
@@ -414,16 +414,20 @@ Connection::apply_options(NetVCOptions const &opt)
   }
 
 #if TS_HAS_SO_MARK
-  uint32_t mark = opt.packet_mark;
-  safe_setsockopt(fd, SOL_SOCKET, SO_MARK, reinterpret_cast<char *>(&mark), sizeof(uint32_t));
+  if (opt.sockopt_flags & NetVCOptions::SOCK_OPT_PACKET_MARK) {
+    uint32_t mark = opt.packet_mark;
+    safe_setsockopt(fd, SOL_SOCKET, SO_MARK, reinterpret_cast<char *>(&mark), sizeof(uint32_t));
+  }
 #endif
 
 #if TS_HAS_IP_TOS
-  uint32_t tos = opt.packet_tos;
-  if (addr.isIp4()) {
-    safe_setsockopt(fd, IPPROTO_IP, IP_TOS, reinterpret_cast<char *>(&tos), sizeof(uint32_t));
-  } else if (addr.isIp6()) {
-    safe_setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, reinterpret_cast<char *>(&tos), sizeof(uint32_t));
+  if (opt.sockopt_flags & NetVCOptions::SOCK_OPT_PACKET_TOS) {
+    uint32_t tos = opt.packet_tos;
+    if (addr.isIp4()) {
+      safe_setsockopt(fd, IPPROTO_IP, IP_TOS, reinterpret_cast<char *>(&tos), sizeof(uint32_t));
+    } else if (addr.isIp6()) {
+      safe_setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, reinterpret_cast<char *>(&tos), sizeof(uint32_t));
+    }
   }
 #endif
 }


### PR DESCRIPTION
Add two socket option flags to allow disabling SO_MARK and IP_TOS usage on configuration time. This is pretty handy on environments where you don't wish to grant CAP_NET_ADMIN to TS.