### PR TITLE
Make double Au test more reliable.

### DIFF
--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -26,7 +26,6 @@ Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, command="traffic_manager")
 server = Test.MakeOriginServer("server")
-server2 = Test.MakeOriginServer("server2")
 
 Test.testName = ""
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: double_h2.test\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -45,13 +44,6 @@ ts.Disk.remap_config.AddLine(
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'continuations_verify.*',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http.cache.http': 0,  # disable cache to simply the test.
-    'proxy.config.cache.enable_read_while_writer': 0,
-    'proxy.config.ssl.client.verify.server': 0,
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
-    'proxy.config.http2.max_concurrent_streams_in': 65535
 })
 
 # add plugin to assist with test metrics
@@ -88,33 +80,28 @@ ts.StartAfter(*ps)
 server.StartAfter(*ps)
 tr.StillRunningAfter = ts
 
-# Signal that all the curl processes have completed
+# Signal that all the curl processes have completed and poll for done metric
 tr = Test.AddTestRun("Curl Done")
-tr.Processes.Default.Command = "traffic_ctl plugin msg done done"
+tr.Processes.Default.Command = (
+    "traffic_ctl plugin msg done done ; "
+    "N=60 ; "
+    "while (( N > 0 )) ; "
+    "do "
+    "sleep 1 ; "
+    'if [[ "$$( traffic_ctl metric get continuations_verify.test.done )" = '
+    '"continuations_verify.test.done 1" ]] ; then exit 0 ; '
+    "fi ; "
+    "let N=N-1 ; "
+    "done ; "
+    "echo TIMEOUT ; "
+    "exit 1"
+)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Env = ts.Env
 tr.StillRunningAfter = ts
 
-# Parking this as a ready tester on a meaningless process
-# To stall the test runs that check for the stats until the
-# stats have propagated and are ready to read.
-
-
-def make_done_stat_ready(tsenv):
-    def done_stat_ready(process, hasRunFor, **kw):
-        retval = subprocess.run("traffic_ctl metric get continuations_verify.test.done > done  2> /dev/null", shell=True, env=tsenv)
-        if retval.returncode == 0:
-            retval = subprocess.run("grep 1 done > /dev/null", shell=True, env=tsenv)
-        return retval.returncode == 0
-
-    return done_stat_ready
-
-
 # number of sessions/transactions opened and closed are equal
 tr = Test.AddTestRun("Check Ssn")
-server2.StartupTimeout = 60
-# Again, here the imporant thing is the ready function not the server2 process
-tr.Processes.Default.StartBefore(server2, ready=make_done_stat_ready(ts.Env))
 tr.Processes.Default.Command = comparator_command.format('ssn')
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Env = ts.Env
@@ -129,7 +116,6 @@ tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
 tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
     "continuations_verify.txn.close.2 {}".format(numberOfRequests), 'should be the number of transactions we made')
 tr.StillRunningAfter = ts
-tr.StillRunningAfter = server2
 
 tr = Test.AddTestRun("Check Txn")
 tr.Processes.Default.Command = comparator_command.format('txn')
@@ -137,4 +123,3 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("yes", 'should verify contents')
 tr.StillRunningAfter = ts
-tr.StillRunningAfter = server2


### PR DESCRIPTION
This is a cherry-pick of the following PR to 9.x:
https://github.com/apache/trafficserver/pull/7216

---

In my test environment, the double test fails at least 1% of the time.  I changed an Au test ready condition
to polling in a bash while loop.  I ran the changed test 500 times, and there were 0 failures.  I also
eliminated the "done" temp file, which the current version of the test writes in whatever directory
autest was run from (and doesn't delete it at the end of the test).

(cherry picked from commit cdc06465de9efe50f5bc2a4f1d8395214fa35d3a)