### PR TITLE
Sticky server does not work with H2 client

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -996,7 +996,9 @@ mptcp
 .. ts:cv:: CONFIG proxy.config.http.attach_server_session_to_client INT 0
    :overridable:
 
-   Control the re-use of an server session by a user agent (client) session.
+   Control the re-use of an server session by a user agent (client) session. Currently only applies to user
+   agents using HTTP/1.0 or HTTP/1.1. For other HTTP versions, the origin connection is always returned to the
+   session sharing pool or closed.
 
    If a user agent performs more than one HTTP transaction on its connection to Traffic Server a server session must be
    obtained for the second (and subsequent) transaction as for the first. This settings affects how that server session

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -212,9 +212,10 @@ public:
     return con_id;
   }
 
-  virtual void
+  virtual bool
   attach_server_session(HttpServerSession *ssession, bool transaction_done = true)
   {
+    return false;
   }
 
   virtual HttpServerSession *

--- a/proxy/ProxyClientTransaction.cc
+++ b/proxy/ProxyClientTransaction.cc
@@ -72,10 +72,10 @@ ProxyClientTransaction::release(IOBufferReader *r)
   }
 }
 
-void
+bool
 ProxyClientTransaction::attach_server_session(HttpServerSession *ssession, bool transaction_done)
 {
-  parent->attach_server_session(ssession, transaction_done);
+  return parent->attach_server_session(ssession, transaction_done);
 }
 
 void

--- a/proxy/ProxyClientTransaction.h
+++ b/proxy/ProxyClientTransaction.h
@@ -47,7 +47,7 @@ public:
   virtual void set_inactivity_timeout(ink_hrtime timeout_in) = 0;
   virtual void cancel_inactivity_timeout()                   = 0;
 
-  virtual void attach_server_session(HttpServerSession *ssession, bool transaction_done = true);
+  virtual bool attach_server_session(HttpServerSession *ssession, bool transaction_done = true);
 
   // See if we need to schedule on the primary thread for the transaction or change the thread that is associated with the VC.
   // If we reschedule, the scheduled action is returned.  Otherwise, NULL is returned

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -508,7 +508,7 @@ Http1ClientSession::new_transaction()
   trans.new_transaction();
 }
 
-void
+bool
 Http1ClientSession::attach_server_session(HttpServerSession *ssession, bool transaction_done)
 {
   if (ssession) {
@@ -546,6 +546,7 @@ Http1ClientSession::attach_server_session(HttpServerSession *ssession, bool tran
     bound_ss     = nullptr;
     slave_ka_vio = nullptr;
   }
+  return true;
 }
 
 void

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -122,7 +122,7 @@ public:
   // Indicate we are done with a transaction
   void release(ProxyClientTransaction *trans) override;
 
-  void attach_server_session(HttpServerSession *ssession, bool transaction_done = true) override;
+  bool attach_server_session(HttpServerSession *ssession, bool transaction_done = true) override;
 
   HttpServerSession *
   get_server_session() const override

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3032,10 +3032,14 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
     // server session to so the next ka request can use it.  Server sessions will
     // be placed into the shared pool if the next incoming request is for a different
     // origin server
+    bool release_origin_connection = true;
     if (t_state.txn_conf->attach_server_session_to_client == 1 && ua_txn && t_state.client_info.keep_alive == HTTP_KEEPALIVE) {
       Debug("http", "attaching server session to the client");
-      ua_txn->attach_server_session(server_session);
-    } else {
+      if (ua_txn->attach_server_session(server_session)) {
+        release_origin_connection = false;
+      }
+    }
+    if (release_origin_connection) {
       // Release the session back into the shared session pool
       server_session->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->keep_alive_no_activity_timeout_out));
       server_session->release();


### PR DESCRIPTION
Backport #7261 to 8.1.x branch

----

(cherry picked from commit d285211b72c3db636623575ce5a69b2f3d74d4a0)

Conflicts:
	proxy/ProxySession.cc
	proxy/ProxySession.h
	proxy/ProxyTransaction.cc
	proxy/ProxyTransaction.h
	proxy/http/Http1ClientSession.cc
	proxy/http/Http1ClientSession.h