### PR TITLE
cachekey plugin: add cache_range_requests compatibility

### DIFF
--- a/doc/admin-guide/plugins/cache_range_requests.en.rst
+++ b/doc/admin-guide/plugins/cache_range_requests.en.rst
@@ -161,6 +161,10 @@ incorrectly *WILL* result in cache poisoning.
 generated in the logs and the cache_range_requests plugin will disable
 transaction caching in order to avoid cache poisoning.
 
+*NOTE* Since the ATS plugin api only allows the cache key to be set once
+per transaction it is preferred to use the cachekey.so plugin in conjunction
+with the cache_range_requests plugin.
+
 Configuration examples
 ======================
 

--- a/doc/admin-guide/plugins/cachekey.en.rst
+++ b/doc/admin-guide/plugins/cachekey.en.rst
@@ -201,6 +201,27 @@ Cache key elements separator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * ``--separator=<string>`` - the `cache key` is constructed by extracting elements from HTTP URI and headers or by using the UA classifiers and they are appended during the key construction and separated by ``/`` (by default). This options allows to override the default separator to any string (including an empty string).
 
+percent encoding
+^^^^^^^^^^^^^^^^
+* ``--percent-encode=`` (default: true) - by default the cachekey percent encodes the cache key as it is built.  This disables that encoding.  Useful only for the cache_range_requests plugin compatibility.
+
+cache_range_requests plugin cachekey compatibility
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* ``--crr-compat-range`` (default: don't apply) - if a range header exists this appends the range header in way that is compatible with the cache_range_requests plugin.  This option should be used if the cache_range_requests plugin is already deployed without cachekey and a new remap rule needs to share cache keys with it. The following lines produce equivalent cache keys:
+
+::
+
+  $ cat remap.config
+  map http://crr/ http://parent/ \
+    @plugin=cache_range_requests.so
+  map http://cachekey_crr/ http://parent/ \
+    @plugin=cachekey.so \
+      @pparam=--canonical-prefix \
+      @pparam=--static-prefix=http://parent \
+      @pparam=--crr-compat-range \
+      @pparam=--percent-encode=false \
+    @plugin=cache_range_requests.so \
+      @pparam=--no-modify-cachekey
 
 How to run the plugin
 =====================

--- a/plugins/cachekey/cachekey.h
+++ b/plugins/cachekey/cachekey.h
@@ -50,7 +50,7 @@
 class CacheKey
 {
 public:
-  CacheKey(TSHttpTxn txn, String separator, CacheKeyUriType urlType, CacheKeyKeyType targetUrlType,
+  CacheKey(TSHttpTxn txn, String separator, CacheKeyUriType urlType, CacheKeyKeyType targetUrlType, bool percentEncode,
            TSRemapRequestInfo *rri = nullptr);
   ~CacheKey();
 
@@ -66,6 +66,7 @@ public:
   void appendCookies(const ConfigCookies &config);
   void appendUaCaptures(Pattern &config);
   bool appendUaClass(Classifier &classifier);
+  bool setCompatRangeHeader();
   bool finalize() const;
 
   // noncopyable
@@ -91,4 +92,5 @@ private:
   String _separator;                    /**< @brief a separator used to separate the cache key elements extracted from the URI */
   CacheKeyUriType _uriType = REMAP;     /**< @brief the URI type used as a cachekey base: pristine, remap, etc. */
   CacheKeyKeyType _keyType = CACHE_KEY; /**< @brief the target URI type: cache key, parent selection, etc. */
+  bool _percentEncode      = true;      /**< @brief percent encode the cache key? */
 };

--- a/plugins/cachekey/configs.cc
+++ b/plugins/cachekey/configs.cc
@@ -399,6 +399,8 @@ Configs::init(int argc, const char *argv[], bool perRemapConfig)
     {const_cast<char *>("key-type"), optional_argument, nullptr, 'u'},
     {const_cast<char *>("capture-header"), optional_argument, nullptr, 'v'},
     {const_cast<char *>("canonical-prefix"), optional_argument, nullptr, 'w'},
+    {const_cast<char *>("crr-compat-range"), optional_argument, nullptr, 'x'},
+    {const_cast<char *>("percent-encode"), optional_argument, nullptr, 'y'},
     /* reserve 'z' for 'config' files */
     {nullptr, 0, nullptr, 0},
   };
@@ -513,6 +515,16 @@ Configs::init(int argc, const char *argv[], bool perRemapConfig)
     case 'w': /* canonical-prefix */
       _canonicalPrefix = isTrue(optarg);
       break;
+    case 'x': /* crr-range */
+      _crrCompatRange = isTrue(optarg);
+      if (_crrCompatRange) {
+        CacheKeyDebug("Adding cache_range_requests compatible range header to key");
+      }
+      break;
+    case 'y': /* percent-encode */
+      _percentEncode = isTrue(optarg);
+    default:
+      break;
     }
   }
 
@@ -537,21 +549,33 @@ Configs::finalize()
 }
 
 bool
-Configs::prefixToBeRemoved()
+Configs::prefixToBeRemoved() const
 {
   return _prefixToBeRemoved;
 }
 
 bool
-Configs::pathToBeRemoved()
+Configs::pathToBeRemoved() const
 {
   return _pathToBeRemoved;
 }
 
 bool
-Configs::canonicalPrefix()
+Configs::canonicalPrefix() const
 {
   return _canonicalPrefix;
+}
+
+bool
+Configs::useCompatRangeHeader() const
+{
+  return _crrCompatRange;
+}
+
+bool
+Configs::percentEncode() const
+{
+  return _percentEncode;
 }
 
 void
@@ -563,7 +587,7 @@ Configs::setSeparator(const char *arg)
 }
 
 const String &
-Configs::getSeparator()
+Configs::getSeparator() const
 {
   return _separator;
 }
@@ -610,13 +634,13 @@ Configs::setKeyType(const char *arg)
 }
 
 CacheKeyUriType
-Configs::getUriType()
+Configs::getUriType() const
 {
   return _uriType;
 }
 
-CacheKeyKeyTypeSet &
-Configs::getKeyType()
+const CacheKeyKeyTypeSet &
+Configs::getKeyType() const
 {
   return _keyTypes;
 }

--- a/plugins/cachekey/configs.h
+++ b/plugins/cachekey/configs.h
@@ -165,17 +165,27 @@ public:
   /**
    * @brief Tells the caller if the prefix is to be removed (not processed at all).
    */
-  bool prefixToBeRemoved();
+  bool prefixToBeRemoved() const;
 
   /**
    * @brief Tells the caller if the path is to be removed (not processed at all).
    */
-  bool pathToBeRemoved();
+  bool pathToBeRemoved() const;
 
   /**
    * @brief keep URI scheme and authority elements.
    */
-  bool canonicalPrefix();
+  bool canonicalPrefix() const;
+
+  /**
+   * @brief Cache_range_requests compatible Range header key.
+   */
+  bool useCompatRangeHeader() const;
+
+  /**
+   * @brief Percent encode the cache key?
+   */
+  bool percentEncode() const;
 
   /**
    * @brief set the cache key elements separator string.
@@ -185,7 +195,7 @@ public:
   /**
    * @brief get the cache key elements separator string.
    */
-  const String &getSeparator();
+  const String &getSeparator() const;
 
   /**
    * @brief sets the URI Type.
@@ -200,12 +210,12 @@ public:
   /**
    * @brief get URI type.
    */
-  CacheKeyUriType getUriType();
+  CacheKeyUriType getUriType() const;
 
   /**
    * @brief get target URI type.
    */
-  CacheKeyKeyTypeSet &getKeyType();
+  const CacheKeyKeyTypeSet &getKeyType() const;
 
   /* Make the following members public to avoid unnecessary accessors */
   ConfigQuery _query;        /**< @brief query parameter related configuration */
@@ -231,6 +241,8 @@ private:
   bool _prefixToBeRemoved  = false; /**< @brief instructs the prefix (i.e. host:port) not to added to the cache key */
   bool _pathToBeRemoved    = false; /**< @brief instructs the path not to added to the cache key */
   bool _canonicalPrefix    = false; /**< @brief keep the URI scheme and authority element used as input to transforming into key */
+  bool _crrCompatRange     = false; /**< @brief add cache_range_requests compatible range header */
+  bool _percentEncode      = true;  /**< @brief percent encode key (true by default) */
   String _separator        = "/";   /**< @brief a separator used to separate the cache key elements extracted from the URI */
   CacheKeyUriType _uriType = REMAP; /**< @brief shows which URI the cache key will be based on */
   CacheKeyKeyTypeSet _keyTypes;     /**< @brief target URI to be modified, cache key or paren selection */

--- a/plugins/cachekey/plugin.cc
+++ b/plugins/cachekey/plugin.cc
@@ -42,7 +42,7 @@ setCacheKey(TSHttpTxn txn, Configs *config, TSRemapRequestInfo *rri = nullptr)
 
   for (auto type : keyTypes) {
     /* Initial cache key facility from the requested URL. */
-    CacheKey cachekey(txn, config->getSeparator(), config->getUriType(), type, rri);
+    CacheKey cachekey(txn, config->getSeparator(), config->getUriType(), type, config->percentEncode(), rri);
 
     /* Append custom prefix or the host:port */
     if (!config->prefixToBeRemoved()) {
@@ -66,6 +66,12 @@ setCacheKey(TSHttpTxn txn, Configs *config, TSRemapRequestInfo *rri = nullptr)
     }
     /* Append query parameters to the cache key. */
     cachekey.appendQuery(config->_query);
+
+    /* Append cache_range_requests compatible range request. */
+    CacheKeyDebug("Setting the compat range header");
+    if (config->useCompatRangeHeader()) {
+      cachekey.setCompatRangeHeader();
+    }
 
     /* Set the cache key */
     cachekey.finalize();

--- a/tests/gold_tests/pluginTest/cachekey/cachekey_crr.test.py
+++ b/tests/gold_tests/pluginTest/cachekey/cachekey_crr.test.py
@@ -1,0 +1,133 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Basic cache_range_requests plugin test
+'''
+
+# Test description:
+# Preload the cache with the entire asset to be range requested.
+# Reload remap rule with cache_range_requests plugin
+# Request content through the cache_range_requests plugin
+
+Test.SkipUnless(
+    Condition.PluginExists('cache_range_requests.so'),
+    Condition.PluginExists('xdebug.so'),
+)
+Test.ContinueOnFail = False
+Test.testName = "cache_range_requests"
+
+# Define and configure ATS
+ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+
+# Define and configure origin server
+server = Test.MakeOriginServer("server", lookup_key="{%uuid}")
+
+# default root
+req_chk = {"headers":
+           "GET / HTTP/1.1\r\n" +
+           "Host: www.example.com\r\n" +
+           "uuid: none\r\n" +
+           "\r\n",
+           "timestamp": "1469733493.993",
+           "body": ""
+           }
+
+res_chk = {"headers":
+           "HTTP/1.1 200 OK\r\n" +
+           "Connection: close\r\n" +
+           "\r\n",
+           "timestamp": "1469733493.993",
+           "body": ""
+           }
+
+server.addResponse("sessionlog.json", req_chk, res_chk)
+
+body = "lets go surfin now"
+bodylen = len(body)
+frange_str = "0-"
+
+req_frange = {"headers":
+              "GET /path~foo HTTP/1.1\r\n" +
+              "Host: www.example.com\r\n" +
+              "Accept: */*\r\n" +
+              "Range: bytes={}\r\n".format(frange_str) +
+              "uuid: frange\r\n" +
+              "\r\n",
+              "timestamp": "1469733493.993",
+              "body": ""
+              }
+
+res_frange = {"headers":
+              "HTTP/1.1 206 Partial Content\r\n" +
+              "Accept-Ranges: bytes\r\n" +
+              "Cache-Control: max-age=500\r\n" +
+              "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
+              "Connection: close\r\n" +
+              'Etag: "path"\r\n' +
+              "\r\n",
+              "timestamp": "1469733493.993",
+              "body": body
+              }
+
+server.addResponse("sessionlog.json", req_frange, res_frange)
+
+# cache range requests plugin remap
+ts.Disk.remap_config.AddLines([
+    'map http://crr/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
+    ' @plugin=cache_range_requests.so',
+
+    'map http://cachekey_crr/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
+    ' @plugin=cachekey.so @pparam=--canonical-prefix @pparam=--static-prefix=http://127.0.0.1:{}'.format(server.Variables.Port)
+    + ' @pparam=--crr-compat-range @pparam=--percent-encode=false @plugin=cache_range_requests.so @pparam=--no-modify-cachekey'
+])
+
+# cache debug
+ts.Disk.plugin_config.AddLine('xdebug.so')
+
+# minimal configuration
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 0,
+    'proxy.config.diags.debug.tags': 'cache_range_requests',
+})
+
+curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} -H "x-debug: X-Cache-Key"'.format(ts.Variables.port)
+
+cachekey_exp = 'http://127.0.0.1:{}/path~foo-bytes=0-'.format(server.Variables.Port)
+
+# 0 Test - 0- request cache_range_requests
+tr = Test.AddTestRun("0- request miss")
+ps = tr.Processes.Default
+ps.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+ps.StartBefore(Test.Processes.ts)
+ps.Command = curl_and_args + ' "http://crr/path~foo" -r {} -H "uuid: frange"'.format(frange_str)
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache-Key: " + cachekey_exp, "expected cache miss")
+ps.Streams.stdout.Content += Testers.ContainsExpression("Content-Range: bytes 0-18/18", "expected content-range header")
+tr.StillRunningAfter = ts
+
+# 4 Test - 0- request using cachekey
+tr = Test.AddTestRun("0- request hit")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' "http://cachekey_crr/path~foo" -r {} -H "uuid: frange"'.format(frange_str)
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache-Key: " + cachekey_exp, "expected cache miss")
+ps.Streams.stdout.Content += Testers.ContainsExpression("Content-Range: bytes 0-18/18", "expected content-range header")
+tr.StillRunningAfter = ts
+
+# end range


### PR DESCRIPTION
This adds functionality to cachekey to allow it to generate compatible cache keys with the cache_range_requests plugin.
This should only be used if a remap rule was originally written to rely on the cache_range_requests plugin only.

Use case is to allow alternate remap rules (dev,qa,test) to use cached content from a production remap rule.

This required adding the following options:
* --crr-compat-range  (default false)
* --percent-encode=false (default true)

The following example allows another remap rule to share the cache key with the original:
```
  map http://crr/ http://parent/ \
    @plugin=cache_range_requests.so
  map http://cachekey_crr/ http://parent/ \
    @plugin=cachekey.so \
      @pparam=--canonical-prefix \
      @pparam=--static-prefix=http://parent \
      @pparam=--crr-compat-range \
      @pparam=--percent-encode=false \
    @plugin=cache_range_requests.so \
      @pparam=--no-modify-cachekey
```

This is low impact, opt in only.