### PR TITLE
Disable client inactivity timeout while server is processing POST request

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2008,28 +2008,13 @@ HttpSM::state_read_server_response_header(int event, void *data)
 
     // Now that we know that we have all of the origin server
     // response headers, we can reset the client inactivity
-    // timeout.  This is unlikely to cause a recurrence of
-    // old bug because there will be no more retries now that
-    // the connection has been established.  It is possible
-    // however.  We do not need to reset the inactivity timeout
-    // if the request contains a body (noted by the
-    // request_content_length field) because it was never
-    // canceled.
-    //
-
+    // timeout.
     // we now reset the client inactivity timeout only
     // when we are ready to send the response headers. In the
     // case of transform plugin, this is after the transform
     // outputs the 1st byte, which can take a long time if the
     // plugin buffers the whole response.
-    // Also, if the request contains a body, we cancel the timeout
-    // when we read the 1st byte of the origin server response.
-    /*
-       if (ua_txn && !t_state.hdr_info.request_content_length) {
-       ua_txn->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(
-       HttpConfig::m_master.accept_no_activity_timeout));
-       }
-     */
+    ua_txn->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->transaction_no_activity_timeout_in));
 
     t_state.current.state         = HttpTransact::CONNECTION_ALIVE;
     t_state.transact_return_point = HttpTransact::HandleResponse;
@@ -3578,7 +3563,13 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
       }
     }
 
-    // Initiate another read to catch aborts and timeouts.
+    // Now that we have communicated the post body, turn off the inactivity timeout
+    // until the server starts sending data back
+    if (ua_txn && t_state.hdr_info.request_content_length) {
+      ua_txn->cancel_inactivity_timeout();
+    }
+
+    // Initiate another read to catch aborts
     ua_entry->vc_handler = &HttpSM::state_watch_for_client_abort;
     ua_entry->read_vio   = p->vc->do_io_read(this, INT64_MAX, ua_buffer_reader->mbuf);
     break;

--- a/tests/gold_tests/timeout/case-inactive1.sh
+++ b/tests/gold_tests/timeout/case-inactive1.sh
@@ -1,0 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+nc -4 -l ${2} -c "sh ./delay-inactive-server.sh" &
+sleep 1
+curl -i http://127.0.0.1:${1}/${3}

--- a/tests/gold_tests/timeout/case-inactive2.sh
+++ b/tests/gold_tests/timeout/case-inactive2.sh
@@ -1,0 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+nc -4 -l ${2} -c  "sh ./delay-inactive-server.sh" &
+sleep 1
+curl -k -i --http1.1 https://127.0.0.1:${1}/${3}

--- a/tests/gold_tests/timeout/case-inactive3.sh
+++ b/tests/gold_tests/timeout/case-inactive3.sh
@@ -1,0 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+nc -4 -l ${2} -c  "sh ./delay-inactive-server.sh" &
+sleep 1
+curl -k -i --http2 https://127.0.0.1:${1}/${3}

--- a/tests/gold_tests/timeout/case-inactive4.sh
+++ b/tests/gold_tests/timeout/case-inactive4.sh
@@ -1,0 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+nc -4 -l ${2} -c  "sh ./delay-inactive-server.sh" &
+sleep 1
+curl -d "post body" -k -i --http2 https://127.0.0.1:${1}/${3}

--- a/tests/gold_tests/timeout/case-inactive5.sh
+++ b/tests/gold_tests/timeout/case-inactive5.sh
@@ -1,0 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+nc -4 -l ${2} -c  "sh ./delay-inactive-server.sh" &
+sleep 1
+curl -d "post body" -i  http://127.0.0.1:${1}/${3}

--- a/tests/gold_tests/timeout/case-inactive6.sh
+++ b/tests/gold_tests/timeout/case-inactive6.sh
@@ -1,0 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+nc -4 -l ${2} -c  "sh ./delay-inactive-server.sh" &
+sleep 1
+curl -d "post body" -k -i --http1.1 https://127.0.0.1:${1}/${3}

--- a/tests/gold_tests/timeout/delay-inactive-server.sh
+++ b/tests/gold_tests/timeout/delay-inactive-server.sh
@@ -1,0 +1,20 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+sleep 4
+printf "HTTP/1.1 200\r\nTransfer-encoding: chunked\r\n\r\n"
+printf "F\r\n123456789012345\r\n"
+printf "0\r\n\r\n"

--- a/tests/gold_tests/timeout/inactive_client_post_timeout.test.py
+++ b/tests/gold_tests/timeout/inactive_client_post_timeout.test.py
@@ -1,0 +1,108 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = 'Testing ATS client inactivity timeout'
+
+Test.SkipUnless(
+    Condition.HasCurlFeature('http2')
+)
+
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
+
+Test.ContinueOnFail = True
+
+Test.GetTcpPort("upstream_port1")
+Test.GetTcpPort("upstream_port2")
+Test.GetTcpPort("upstream_port3")
+Test.GetTcpPort("upstream_port4")
+Test.GetTcpPort("upstream_port5")
+Test.GetTcpPort("upstream_port6")
+
+ts.addSSLfile("../tls/ssl/server.pem")
+ts.addSSLfile("../tls/ssl/server.key")
+
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http',
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.url_remap.remap_required': 1,
+    'proxy.config.http.transaction_no_activity_timeout_in': 2,
+})
+
+ts.Disk.remap_config.AddLines([
+    'map /case1 http://127.0.0.1:{0}'.format(Test.Variables.upstream_port1),
+    'map /case2 http://127.0.0.1:{0}'.format(Test.Variables.upstream_port2),
+    'map /case3 http://127.0.0.1:{0}'.format(Test.Variables.upstream_port3),
+    'map /case4 http://127.0.0.1:{0}'.format(Test.Variables.upstream_port4),
+    'map /case5 http://127.0.0.1:{0}'.format(Test.Variables.upstream_port5),
+    'map /case6 http://127.0.0.1:{0}'.format(Test.Variables.upstream_port6),
+])
+
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+
+# Using netcat with explicit delays instead of the delay option with microserver because it appears
+# that microserver will not delay responses to POST requests
+# The delay-inactive-server.sh will deplay for 4 seconds before returning a response. This is more
+# than the 2 second proxy.config.http.transaction_no_activity_timeout_in
+# These tests exercise that the client inactivity timeout is disabled after the request and post body
+# are sent.  So a slow to respond server will not trigger the client inactivity timeout.
+
+tr4 = Test.AddTestRun("tr")
+tr4.Processes.Default.StartBefore(ts, ready=When.PortOpen(ts.Variables.ssl_port))
+tr4.Setup.Copy('delay-inactive-server.sh')
+tr4.Setup.Copy('case-inactive4.sh')
+tr4.Processes.Default.ReturnCode = 0
+tr4.Processes.Default.Command = 'sh -x ./case-inactive4.sh {0} {1} case4'.format(
+    ts.Variables.ssl_port, Test.Variables.upstream_port4)
+tr4.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 200", "Should get successful response")
+
+tr = Test.AddTestRun("tr")
+tr.Setup.Copy('case-inactive1.sh')
+tr.Processes.Default.Command = 'sh -x ./case-inactive1.sh {0} {1} case1'.format(ts.Variables.port, Test.Variables.upstream_port1)
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    "HTTP/1.1 200", "Client inactivity should not trigger during server stall")
+
+tr2 = Test.AddTestRun("tr")
+tr2.Setup.Copy('case-inactive2.sh')
+tr2.Processes.Default.Command = 'sh -x ./case-inactive2.sh {0} {1} case2'.format(
+    ts.Variables.ssl_port, Test.Variables.upstream_port2)
+tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    "HTTP/1.1 200", "Client inactivity should not trigger during server stall")
+
+tr3 = Test.AddTestRun("tr")
+tr3.Setup.Copy('case-inactive3.sh')
+tr3.Processes.Default.Command = 'sh -x ./case-inactive3.sh {0} {1} case3'.format(
+    ts.Variables.ssl_port, Test.Variables.upstream_port3)
+tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    "HTTP/2 200", "Client inactivity should not trigger during server stall")
+
+tr5 = Test.AddTestRun("tr")
+tr5.Setup.Copy('case-inactive5.sh')
+tr5.Processes.Default.Command = 'sh -x ./case-inactive5.sh {0} {1} case5'.format(ts.Variables.port, Test.Variables.upstream_port5)
+tr5.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    "HTTP/1.1 200", "Client inactivity timeout should not apply during server stall")
+
+tr6 = Test.AddTestRun("tr")
+tr6.Setup.Copy('case-inactive6.sh')
+tr6.Processes.Default.Command = 'sh -x ./case-inactive6.sh {0} {1} case6'.format(
+    ts.Variables.ssl_port, Test.Variables.upstream_port6)
+tr6.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    "HTTP/1.1 200", "Client inactivity timeout should not apply during server stall")


### PR DESCRIPTION
This PR makes changes to HttpSM.cc to disable the client inactivity timeout at the end of the POST tunnel, and it reenables the client inactivity timeout upon receiving a server response header.

It also adds an autest to exercise different cases of GET and POST against a origin that will delay for 4 seconds before returning a response.  In the autest the client inactivity timeout is set to 2.  When run against the current origin/master, the GET cases will succeed and the POST cases will fail.  With this code change, all cases should succeed.

This closes #7308