### PR TITLE
Traffic Dump: Fix stream-id printing after first transaction.

### DIFF
--- a/plugins/experimental/traffic_dump/session_data.h
+++ b/plugins/experimental/traffic_dump/session_data.h
@@ -192,6 +192,7 @@ private:
 
   using get_protocol_stack_f  = std::function<TSReturnCode(int, const char **, int *)>;
   using get_tls_description_f = std::function<std::string()>;
+  using handle_http_version_f = std::function<void(std::string_view)>;
 
   /** Create the protocol stack for a session.
    *
@@ -201,10 +202,16 @@ private:
    * @param[in] get_protocol_stack The function to use to populate a protocol
    * stack.
    *
+   * @param[in] get_tls_node The function to use to populate the tls node.
+   *
+   * @param[in] handle_http_version A function that performs arbitrary logic
+   * given the HTTP/2 protocol version.
+   *
    * @return The description of the protocol stack and True if the stack
    * contained an HTTP description, false otherwise.
    */
-  std::string get_protocol_stack_helper(const get_protocol_stack_f &get_protocol_stack, const get_tls_description_f &get_tls_node);
+  std::string get_protocol_stack_helper(const get_protocol_stack_f &get_protocol_stack, const get_tls_description_f &get_tls_node,
+                                        const handle_http_version_f &handle_http_version);
 
   /** Get the JSON string that describes the client session stack.
    *

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -80,7 +80,11 @@ request_header = {"headers": "GET /tls HTTP/1.1\r\n"
                   "Host: www.tls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionfile.log", request_header, response_200)
-request_header = {"headers": "GET /h2 HTTP/1.1\r\n"
+request_header = {"headers": "GET /h2_first HTTP/2\r\n"
+                  "Host: www.tls.com\r\nContent-Length: 0\r\n\r\n",
+                  "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_200)
+request_header = {"headers": "GET /h2_second HTTP/2\r\n"
                   "Host: www.tls.com\r\nContent-Length: 0\r\n\r\n",
                   "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionfile.log", request_header, response_200)
@@ -409,10 +413,12 @@ tr.StillRunningAfter = ts
 #
 # Test 7: Verify correct protcol dumping of TLS and HTTP/2 connections.
 #
-tr = Test.AddTestRun("Conduct an HTTP/2 transaction over a TLS connection.")
+tr = Test.AddTestRun("Conduct two HTTP/2 transactions over a TLS connection.")
 tr.Processes.Default.Command = \
     ('curl --http2 -k -H"Host: www.tls.com" --resolve "www.tls.com:{0}:127.0.0.1" '
-     '--cert ./signed-foo.pem --key ./signed-foo.key --verbose https://www.tls.com:{0}/h2'.format(
+     '--cert ./signed-foo.pem --key ./signed-foo.key --verbose https://www.tls.com:{0}/h2_first '
+     '--next --http2 -k -H"Host: www.tls.com" --resolve "www.tls.com:{0}:127.0.0.1" '
+     '--cert ./signed-foo.pem --key ./signed-foo.key --verbose https://www.tls.com:{0}/h2_second'.format(
          ts.Variables.ssl_port))
 
 tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
This fixes a Traffic Dump bug in which only the first HTTP/2 stream-id
for a transaction in an HTTP/2 session was printed.