### PR TITLE
Set thread mutex to the DNSHandler mutex of SplitDNS

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -237,6 +237,7 @@ DNSProcessor::start(int, size_t stacksize)
   dns_failover_try_period = dns_timeout + 1; // Modify the "default" accordingly
 
   if (SplitDNSConfig::gsplit_dns_enabled) {
+    SplitDNSConfig::dnsHandler_mutex = thread->mutex;
     // reconfigure after threads start
     SplitDNSConfig::reconfigure();
   }

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -112,8 +112,6 @@ SplitDNSConfig::release(SplitDNS *params)
 void
 SplitDNSConfig::startup()
 {
-  dnsHandler_mutex = new_ProxyMutex();
-
   // startup just check gsplit_dns_enabled
   REC_ReadConfigInt32(gsplit_dns_enabled, "proxy.config.dns.splitDNS.enabled");
   SplitDNSConfig::splitDNSUpdate = new ConfigUpdateHandler<SplitDNSConfig>();


### PR DESCRIPTION
An alternative approach of #7316 to fix #7315.

The `thread->mutex` is used as the DNSHandler mutex of DNSProcessor. Do the same things to the SplitDNS.

https://github.com/apache/trafficserver/blob/ef18164093454f44384c5d5c8de2937a9edd6675/iocore/dns/DNS.cc#L251-L256