### PR TITLE
Cleanup incoming PROXY Protocol v1

### DIFF
--- a/iocore/net/P_NetVConnection.h
+++ b/iocore/net/P_NetVConnection.h
@@ -22,12 +22,13 @@
  */
 
 #include "I_NetVConnection.h"
+#include "ProxyProtocol.h"
 
 inline sockaddr const *
 NetVConnection::get_remote_addr()
 {
   if (!got_remote_addr) {
-    if (pp_info.proxy_protocol_version != ProxyProtocolVersion::UNDEFINED) {
+    if (pp_info.version != ProxyProtocolVersion::UNDEFINED) {
       set_remote_addr(get_proxy_protocol_src_addr());
     } else {
       set_remote_addr();

--- a/iocore/net/ProxyProtocol.h
+++ b/iocore/net/ProxyProtocol.h
@@ -25,28 +25,29 @@
 
 #pragma once
 
-#include "tscore/ink_defs.h"
-#include "tscore/ink_memory.h"
-#include <tscore/ink_resolver.h>
-#include <tscore/ink_platform.h>
-#include "I_VConnection.h"
-#include "I_NetVConnection.h"
-#include "I_IOBuffer.h"
+#include <tscore/ink_inet.h>
+#include <tscpp/util/TextView.h>
 
-// http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+enum class ProxyProtocolVersion {
+  UNDEFINED,
+  V1,
+  V2,
+};
 
-extern bool proxy_protov1_parse(NetVConnection *, ts::TextView hdr);
-extern bool ssl_has_proxy_v1(NetVConnection *, char *, int64_t *);
-extern bool http_has_proxy_v1(IOBufferReader *, NetVConnection *);
+enum class ProxyProtocolData {
+  UNDEFINED,
+  SRC,
+  DST,
+};
 
-const char *const PROXY_V1_CONNECTION_PREFACE = R"(PROXY)";
-const char *const PROXY_V2_CONNECTION_PREFACE = "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A\x02";
+struct ProxyProtocol {
+  ProxyProtocolVersion version = ProxyProtocolVersion::UNDEFINED;
+  uint16_t ip_family           = AF_UNSPEC;
+  IpEndpoint src_addr          = {};
+  IpEndpoint dst_addr          = {};
+};
 
-const size_t PROXY_V1_CONNECTION_PREFACE_LEN = strlen(PROXY_V1_CONNECTION_PREFACE); // 5
-const size_t PROXY_V2_CONNECTION_PREFACE_LEN = 13;
+const size_t PPv1_CONNECTION_HEADER_LEN_MAX = 108;
+const size_t PPv2_CONNECTION_HEADER_LEN_MAX = 16;
 
-const size_t PROXY_V1_CONNECTION_HEADER_LEN_MIN = 15;
-const size_t PROXY_V2_CONNECTION_HEADER_LEN_MIN = 16;
-
-const size_t PROXY_V1_CONNECTION_HEADER_LEN_MAX = 108;
-const size_t PROXY_V2_CONNECTION_HEADER_LEN_MAX = 16;
+extern size_t proxy_protocol_parse(ProxyProtocol *pp_info, ts::TextView tv);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -405,7 +405,7 @@ SSLNetVConnection::read_raw_data()
   IpMap *pp_ipmap;
   pp_ipmap = SSLConfigParams::proxy_protocol_ipmap;
 
-  if (this->get_is_proxy_protocol()) {
+  if (this->get_is_proxy_protocol() && this->get_proxy_protocol_version() == ProxyProtocolVersion::UNDEFINED) {
     Debug("proxyprotocol", "proxy protocol is enabled on this port");
     if (pp_ipmap->count() > 0) {
       Debug("proxyprotocol", "proxy protocol has a configured allowlist of trusted IPs - checking");
@@ -430,8 +430,8 @@ SSLNetVConnection::read_raw_data()
                              "proxy protocol is enabled on this port - processing all connections");
     }
 
-    if (ssl_has_proxy_v1(this, buffer, &r)) {
-      Debug("proxyprotocol", "ssl has proxy_v1 header");
+    if (this->has_proxy_protocol(buffer, &r)) {
+      Debug("proxyprotocol", "ssl has proxy protocol header");
       set_remote_addr(get_proxy_protocol_src_addr());
     } else {
       Debug("proxyprotocol", "proxy protocol was enabled, but required header was not present in the "

--- a/proxy/ProtocolProbeSessionAccept.cc
+++ b/proxy/ProtocolProbeSessionAccept.cc
@@ -100,7 +100,7 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
     IpMap *pp_ipmap;
     pp_ipmap = probeParent->proxy_protocol_ipmap;
 
-    if (netvc->get_is_proxy_protocol()) {
+    if (netvc->get_is_proxy_protocol() && netvc->get_proxy_protocol_version() == ProxyProtocolVersion::UNDEFINED) {
       Debug("proxyprotocol", "ioCompletionEvent: proxy protocol is enabled on this port");
       if (pp_ipmap->count() > 0) {
         Debug("proxyprotocol", "ioCompletionEvent: proxy protocol has a configured allowlist of trusted IPs - checking");
@@ -120,8 +120,8 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
               "ernabled on this port - processing all connections");
       }
 
-      if (http_has_proxy_v1(reader, netvc)) {
-        Debug("proxyprotocol", "ioCompletionEvent: http has proxy_v1 header");
+      if (netvc->has_proxy_protocol(reader)) {
+        Debug("proxyprotocol", "ioCompletionEvent: http has proxy protocol header");
         netvc->set_remote_addr(netvc->get_proxy_protocol_src_addr());
       } else {
         Debug("proxyprotocol",

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5771,11 +5771,11 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
   ats_ip_copy(&s->request_data.src_ip, &s->client_info.src_addr);
   memset(&s->request_data.dest_ip, 0, sizeof(s->request_data.dest_ip));
   if (vc) {
-    s->request_data.incoming_port     = vc->get_local_port();
-    s->pp_info.proxy_protocol_version = vc->get_proxy_protocol_version();
-    if (s->pp_info.proxy_protocol_version != NetVConnection::ProxyProtocolVersion::UNDEFINED) {
-      ats_ip_copy(s->pp_info.src_addr, vc->pp_info.src_addr);
-      ats_ip_copy(s->pp_info.dst_addr, vc->pp_info.dst_addr);
+    s->request_data.incoming_port = vc->get_local_port();
+    s->pp_info.version            = vc->get_proxy_protocol_version();
+    if (s->pp_info.version != ProxyProtocolVersion::UNDEFINED) {
+      ats_ip_copy(s->pp_info.src_addr, vc->get_proxy_protocol_src_addr());
+      ats_ip_copy(s->pp_info.dst_addr, vc->get_proxy_protocol_dst_addr());
     }
   }
   s->request_data.xact_start                      = s->client_request_time;

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -910,7 +910,7 @@ public:
       internal_msg_buffer_size = 0;
     }
 
-    NetVConnection::ProxyProtocol pp_info;
+    ProxyProtocol pp_info;
 
   private:
     // Make this a raw byte array, so it will be accessed through the my_txn_conf() member function.

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1359,15 +1359,15 @@ LogAccess::marshal_proxy_protocol_version(char *buf)
   int len                 = INK_MIN_ALIGN;
 
   if (m_http_sm) {
-    NetVConnection::ProxyProtocolVersion ver = m_http_sm->t_state.pp_info.proxy_protocol_version;
+    ProxyProtocolVersion ver = m_http_sm->t_state.pp_info.version;
     switch (ver) {
-    case NetVConnection::ProxyProtocolVersion::V1:
+    case ProxyProtocolVersion::V1:
       version_str = "V1";
       break;
-    case NetVConnection::ProxyProtocolVersion::V2:
+    case ProxyProtocolVersion::V2:
       version_str = "V2";
       break;
-    case NetVConnection::ProxyProtocolVersion::UNDEFINED:
+    case ProxyProtocolVersion::UNDEFINED:
     default:
       version_str = "-";
       break;
@@ -1387,7 +1387,7 @@ int
 LogAccess::marshal_proxy_protocol_src_ip(char *buf)
 {
   sockaddr const *ip = nullptr;
-  if (m_http_sm && m_http_sm->t_state.pp_info.proxy_protocol_version != NetVConnection::ProxyProtocolVersion::UNDEFINED) {
+  if (m_http_sm && m_http_sm->t_state.pp_info.version != ProxyProtocolVersion::UNDEFINED) {
     ip = &m_http_sm->t_state.pp_info.src_addr.sa;
   }
   return marshal_ip(buf, ip);
@@ -1399,7 +1399,7 @@ int
 LogAccess::marshal_proxy_protocol_dst_ip(char *buf)
 {
   sockaddr const *ip = nullptr;
-  if (m_http_sm && m_http_sm->t_state.pp_info.proxy_protocol_version != NetVConnection::ProxyProtocolVersion::UNDEFINED) {
+  if (m_http_sm && m_http_sm->t_state.pp_info.version != ProxyProtocolVersion::UNDEFINED) {
     ip = &m_http_sm->t_state.pp_info.dst_addr.sa;
   }
   return marshal_ip(buf, ip);


### PR DESCRIPTION
This is a preparation for PROXY Protocol v2 support.

1). Make parser interface version-neutral
  - the public function is named `proxy_protocol_parse()` and it switches parsers based on the preface.

2). Cleanup NetVConnection & ProxyProtocol
  - `NetVConnection::ProxyProtocol` -> `ProxyProtocol`
  -  `bool http_has_proxy_v1(IOBufferReader *, NetVConnection *)` 
    -> `bool NetVConnection::has_proxy_protocol(IOBufferReader *reader)`
  - `bool ssl_has_proxy_v1(NetVConnection *sslvc, char *buffer, int64_t *bytes_r)` 
    -> `bool NetVConnection::has_proxy_protocol(char *buffer, int64_t *bytes_r)`
  - Make `NetVConnection::pp_info` private

## Links

- AuTest is #7326 
- Unit Test is ~~coming in another PR.~~ #7332