### PR TITLE
Adjust flags to ensure tunnel producer is cleaned up

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1335,15 +1335,17 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
         // If the consumer completed, presumably the producer successfully read
         c->producer->read_success = true;
         // Go ahead and clean up the producer side
-        p->alive = false;
-        if (p->read_vio) {
-          p->bytes_read = p->read_vio->ndone;
-        } else {
-          p->bytes_read = 0;
-        }
-        if (p->vc != HTTP_TUNNEL_STATIC_PRODUCER) {
-          // Clear any outstanding reads
-          p->vc->do_io_read(nullptr, 0, nullptr);
+        if (p->alive) {
+          p->alive = false;
+          if (p->read_vio) {
+            p->bytes_read = p->read_vio->ndone;
+          } else {
+            p->bytes_read = 0;
+          }
+          if (p->vc != HTTP_TUNNEL_STATIC_PRODUCER) {
+            // Clear any outstanding reads
+            p->vc->do_io_read(nullptr, 0, nullptr);
+          }
         }
       } else if (c->vc_type == HT_HTTP_SERVER) {
         c->producer->handler_state = HTTP_SM_POST_UA_FAIL;

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1333,8 +1333,18 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
       if (event == VC_EVENT_WRITE_COMPLETE) {
         c->producer->handler_state = HTTP_SM_POST_SUCCESS;
         // If the consumer completed, presumably the producer successfully read
-        // Not marking the producer not alive, so the regular cleanup logic will be triggered
         c->producer->read_success = true;
+        // Go ahead and clean up the producer side
+        p->alive = false;
+        if (p->read_vio) {
+          p->bytes_read = p->read_vio->ndone;
+        } else {
+          p->bytes_read = 0;
+        }
+        if (p->vc != HTTP_TUNNEL_STATIC_PRODUCER) {
+          // Clear any outstanding reads
+          p->vc->do_io_read(nullptr, 0, nullptr);
+        }
       } else if (c->vc_type == HT_HTTP_SERVER) {
         c->producer->handler_state = HTTP_SM_POST_UA_FAIL;
       } else if (c->vc_type == HT_HTTP_CLIENT) {

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1332,9 +1332,9 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
     if (c->producer && c->producer->handler_state == 0) {
       if (event == VC_EVENT_WRITE_COMPLETE) {
         c->producer->handler_state = HTTP_SM_POST_SUCCESS;
-        // If the consumer completed, presumably the producer successfully read and is done
+        // If the consumer completed, presumably the producer successfully read
+        // Not marking the producer not alive, so the regular cleanup logic will be triggered
         c->producer->read_success = true;
-        c->producer->alive        = false;
       } else if (c->vc_type == HT_HTTP_SERVER) {
         c->producer->handler_state = HTTP_SM_POST_UA_FAIL;
       } else if (c->vc_type == HT_HTTP_CLIENT) {

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -396,11 +396,8 @@ HttpTunnel::is_tunnel_alive() const
 {
   bool tunnel_alive = false;
 
-  // Really a tunnel is only alive as long as there are consumers
-  // to consume.  Or if there are no consumer (e.g. tunneling into a buffer)
-  // an alive producer may count
   for (const auto &producer : producers) {
-    if (producer.alive == true && producer.consumer_list.head == nullptr) {
+    if (producer.alive == true) {
       tunnel_alive = true;
       break;
     }

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -396,8 +396,11 @@ HttpTunnel::is_tunnel_alive() const
 {
   bool tunnel_alive = false;
 
+  // Really a tunnel is only alive as long as there are consumers
+  // to consume.  Or if there are no consumer (e.g. tunneling into a buffer)
+  // an alive producer may count
   for (const auto &producer : producers) {
-    if (producer.alive == true) {
+    if (producer.alive == true && producer.consumer_list.head == nullptr) {
       tunnel_alive = true;
       break;
     }


### PR DESCRIPTION
The issue describes most of the issue.  This error came in with PR #7237.  We were internally running the first version of that PR, but in reviewing the PR @masaori335 found a ink_assert being triggered.  I over fixed the change, so when we upgraded our build to run the final version of the PR, we started seeing many crashes due to lingering continuations being associated with VC vio's.   

This PR fixed the issue by not proactivity marking the producer dead.   So the normal cleanup paths will still be executed.

This closes #7338