### PR TITLE
Fix vc close migration race condition

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -652,11 +652,11 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
   // FIXME: the nh must not nullptr.
   ink_assert(nh);
 
+  // The vio continuations will be cleared in ::clear called from ::free
   read.enabled    = 0;
   write.enabled   = 0;
   read.vio.nbytes = 0;
   read.vio.op     = VIO::NONE;
-  read.vio.cont   = nullptr;
 
   if (netvc_context == NET_VCONNECTION_OUT) {
     // do not clear the iobufs yet to guard
@@ -670,7 +670,6 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
 
   write.vio.nbytes = 0;
   write.vio.op     = VIO::NONE;
-  write.vio.cont   = nullptr;
 
   EThread *t        = this_ethread();
   bool close_inline = !recursion && (!nh || nh->mutex->thread_holding == t);

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -652,12 +652,6 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
   // FIXME: the nh must not nullptr.
   ink_assert(nh);
 
-  // mark it closed first
-  if (alerrno == -1) {
-    closed = 1;
-  } else {
-    closed = -1;
-  }
   read.enabled    = 0;
   write.enabled   = 0;
   read.vio.nbytes = 0;
@@ -684,6 +678,14 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
   INK_WRITE_MEMORY_BARRIER;
   if (alerrno && alerrno != -1) {
     this->lerrno = alerrno;
+  }
+
+  // Must mark for closed last in case this is a
+  // cross thread migration scenario.
+  if (alerrno == -1) {
+    closed = 1;
+  } else {
+    closed = -1;
   }
 
   if (close_inline) {


### PR DESCRIPTION
The issue contains the details.  This problem came in with PR #7278.  Once we added that commit, our canary production box would crash at least once an hour with corrupted memory stacks (examples in issue).  We ran an ASAN version of the build in our prod sim and came up with a use-after-free and a very similar double free failure (again stacks in the issue).

The use after free issue was do to the close flag being set early in UnixNetVConnection::do_io_close, but having accesses to the object later.  The other thread would see the close flag set when walking the event look and delete the netvc object from underneath the first thread.

We have been running a build with this patch on a production box for over 3 hours now.  We will expand our testing of this, but it seems likely that this is addressing the crash we were seeing.

This closes #7333