### PR TITLE
Add Incoming PROXY Protocol v2 Support 

### DIFF
--- a/doc/admin-guide/configuration/proxy-protocol.en.rst
+++ b/doc/admin-guide/configuration/proxy-protocol.en.rst
@@ -31,7 +31,7 @@ TLS connections.
 
 .. note::
 
-    The current version only supports transforming client IP from PROXY Version 1
+    The current version only supports transforming client IP from PROXY Version 1/2
     header to the Forwarded: header.
 
 In the current implementation, the client IP address in the PROXY protocol header
@@ -41,7 +41,7 @@ is passed to the origin server via an HTTP `Forwarded:
 The Proxy Protocol must be enabled on each port.  See
 :ts:cv:`proxy.config.http.server_ports` for information on how to enable the
 Proxy Protocol on a port.  Once enabled, all incoming requests must be prefaced
-with the PROXY v1 header.  Any request not preface by this header will be
+with the PROXY v1/v2 header.  Any request not preface by this header will be
 dropped.
 
 As a security measure, an optional list of trusted IP addresses may be
@@ -50,7 +50,7 @@ configured with :ts:cv:`proxy.config.http.proxy_protocol_allowlist`.
    .. important::
 
        If the allowlist is configured, requests will only be accepted from these
-       IP addresses and must be prefaced with the PROXY v1 header.
+       IP addresses and must be prefaced with the PROXY v1/v2 header.
 
 See :ts:cv:`proxy.config.http.insert_forwarded` for configuration information.
 Detection of the PROXY protocol header is automatic.  If the PROXY header

--- a/iocore/net/ProxyProtocol.h
+++ b/iocore/net/ProxyProtocol.h
@@ -48,6 +48,6 @@ struct ProxyProtocol {
 };
 
 const size_t PPv1_CONNECTION_HEADER_LEN_MAX = 108;
-const size_t PPv2_CONNECTION_HEADER_LEN_MAX = 16;
+const size_t PPv2_CONNECTION_HEADER_LEN     = 16;
 
 extern size_t proxy_protocol_parse(ProxyProtocol *pp_info, ts::TextView tv);

--- a/iocore/net/unit_tests/test_ProxyProtocol.cc
+++ b/iocore/net/unit_tests/test_ProxyProtocol.cc
@@ -124,13 +124,16 @@ TEST_CASE("PROXY Protocol v1 Parser", "[ProxyProtocol][ProxyProtocolv1]")
 
 TEST_CASE("PROXY Protocol v2 Parser", "[ProxyProtocol][ProxyProtocolv2]")
 {
-  SECTION("TCP over IPv4")
+  IpEndpoint src_addr;
+  IpEndpoint dst_addr;
+
+  SECTION("TCP over IPv4 without TLVs")
   {
     uint8_t raw_data[] = {
-      0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< sig
+      0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
       0x55, 0x49, 0x54, 0x0A,                         ///<
-      0x02,                                           ///< ver_vmd
-      0x11,                                           ///< fam
+      0x21,                                           ///< version & command
+      0x11,                                           ///< protocol & family
       0x00, 0x0C,                                     ///< len
       0xC0, 0x00, 0x02, 0x01,                         ///< src_addr
       0xC6, 0x33, 0x64, 0x01,                         ///< dst_addr
@@ -141,7 +144,286 @@ TEST_CASE("PROXY Protocol v2 Parser", "[ProxyProtocol][ProxyProtocolv2]")
     ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
 
     ProxyProtocol pp_info;
-    // TODO: add test when implemented. Just checking this doesn't crash for now
+    REQUIRE(proxy_protocol_parse(&pp_info, tv) == tv.size());
+
+    REQUIRE(ats_ip_pton("192.0.2.1:50000", src_addr) == 0);
+    REQUIRE(ats_ip_pton("198.51.100.1:443", dst_addr) == 0);
+
+    CHECK(pp_info.version == ProxyProtocolVersion::V2);
+    CHECK(pp_info.ip_family == AF_INET);
+    CHECK(pp_info.src_addr == src_addr);
+    CHECK(pp_info.dst_addr == dst_addr);
+  }
+
+  SECTION("TCP over IPv6 without TLVs")
+  {
+    uint8_t raw_data[] = {
+      0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+      0x55, 0x49, 0x54, 0x0A,                         ///<
+      0x21,                                           ///< version & command
+      0x21,                                           ///< protocol & family
+      0x00, 0x24,                                     ///< len
+      0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+      0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+      0xC3, 0x50,                                     ///< src_port
+      0x01, 0xBB,                                     ///< dst_port
+    };
+
+    ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+    ProxyProtocol pp_info;
+    REQUIRE(proxy_protocol_parse(&pp_info, tv) == tv.size());
+
+    REQUIRE(ats_ip_pton("[2001:db8:0:1::]:50000", src_addr) == 0);
+    REQUIRE(ats_ip_pton("[2001:db8:0:2::]:443", dst_addr) == 0);
+
+    CHECK(pp_info.version == ProxyProtocolVersion::V2);
+    CHECK(pp_info.ip_family == AF_INET6);
+    CHECK(pp_info.src_addr == src_addr);
+    CHECK(pp_info.dst_addr == dst_addr);
+  }
+
+  SECTION("LOCAL command - health check")
+  {
+    uint8_t raw_data[] = {
+      0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+      0x55, 0x49, 0x54, 0x0A,                         ///<
+      0x20,                                           ///< version & command
+      0x00,                                           ///< protocol & family
+      0x00, 0x24,                                     ///< len
+      0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+      0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+      0xC3, 0x50,                                     ///< src_port
+      0x01, 0xBB,                                     ///< dst_port
+    };
+
+    ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+    ProxyProtocol pp_info;
+    REQUIRE(proxy_protocol_parse(&pp_info, tv) == tv.size());
+
+    CHECK(pp_info.version == ProxyProtocolVersion::V2);
+    CHECK(pp_info.ip_family == AF_UNSPEC);
+  }
+
+  SECTION("UNSPEC - unknownun/specified/unsupported transport protocol & address family")
+  {
+    uint8_t raw_data[] = {
+      0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+      0x55, 0x49, 0x54, 0x0A,                         ///<
+      0x21,                                           ///< version & command
+      0x00,                                           ///< protocol & family
+      0x00, 0x24,                                     ///< len
+      0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+      0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+      0xC3, 0x50,                                     ///< src_port
+      0x01, 0xBB,                                     ///< dst_port
+    };
+
+    ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+    ProxyProtocol pp_info;
     REQUIRE(proxy_protocol_parse(&pp_info, tv) == 0);
+
+    CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+    CHECK(pp_info.ip_family == AF_UNSPEC);
+  }
+
+  // TLVs are not supported yet. Checking TLVs are skipped as expected for now.
+  SECTION("TLVs")
+  {
+    uint8_t raw_data[] = {
+      0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+      0x55, 0x49, 0x54, 0x0A,                         ///<
+      0x21,                                           ///< version & command
+      0x11,                                           ///< protocol & family
+      0x00, 0x11,                                     ///< len
+      0xC0, 0x00, 0x02, 0x01,                         ///< src_addr
+      0xC6, 0x33, 0x64, 0x01,                         ///< dst_addr
+      0xC3, 0x50,                                     ///< src_port
+      0x01, 0xBB,                                     ///< dst_port
+      0x01, 0x00, 0x02, 0x68, 0x32,                   /// PP2_TYPE_ALPN (h2)
+    };
+
+    ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+    ProxyProtocol pp_info;
+    REQUIRE(proxy_protocol_parse(&pp_info, tv) == tv.size());
+
+    REQUIRE(ats_ip_pton("192.0.2.1:50000", src_addr) == 0);
+    REQUIRE(ats_ip_pton("198.51.100.1:443", dst_addr) == 0);
+
+    CHECK(pp_info.version == ProxyProtocolVersion::V2);
+    CHECK(pp_info.ip_family == AF_INET);
+    CHECK(pp_info.src_addr == src_addr);
+    CHECK(pp_info.dst_addr == dst_addr);
+  }
+
+  SECTION("Malformed Headers")
+  {
+    ProxyProtocol pp_info;
+
+    SECTION("invalid preface")
+    {
+      uint8_t raw_data[] = {
+        0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, ///< preface
+        0xDE, 0xAD, 0xBE, 0xEF,                         ///<
+        0x21,                                           ///< version & command
+        0x21,                                           ///< protocol & family
+        0x00, 0x24,                                     ///< len
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0xC3, 0x50,                                     ///< src_port
+        0x01, 0xBB,                                     ///< dst_port
+      };
+
+      ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+      CHECK(proxy_protocol_parse(&pp_info, tv) == 0);
+      CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+      CHECK(pp_info.ip_family == AF_UNSPEC);
+    }
+
+    SECTION("unsupported version & command")
+    {
+      uint8_t raw_data[] = {
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+        0x55, 0x49, 0x54, 0x0A,                         ///<
+        0xFF,                                           ///< version & command
+        0x21,                                           ///< protocol & family
+        0x00, 0x24,                                     ///< len
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0xC3, 0x50,                                     ///< src_port
+        0x01, 0xBB,                                     ///< dst_port
+      };
+
+      ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+      CHECK(proxy_protocol_parse(&pp_info, tv) == 0);
+      CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+      CHECK(pp_info.ip_family == AF_UNSPEC);
+    }
+
+    SECTION("unsupported protocol & family")
+    {
+      uint8_t raw_data[] = {
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+        0x55, 0x49, 0x54, 0x0A,                         ///<
+        0x21,                                           ///< version & command
+        0xFF,                                           ///< protocol & family
+        0x00, 0x24,                                     ///< len
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0xC3, 0x50,                                     ///< src_port
+        0x01, 0xBB,                                     ///< dst_port
+      };
+
+      ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+      CHECK(proxy_protocol_parse(&pp_info, tv) == 0);
+      CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+      CHECK(pp_info.ip_family == AF_UNSPEC);
+    }
+
+    SECTION("invalid len value - too long")
+    {
+      uint8_t raw_data[] = {
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+        0x55, 0x49, 0x54, 0x0A,                         ///<
+        0x21,                                           ///< version & command
+        0x21,                                           ///< protocol & family
+        0x00, 0x25,                                     ///< len
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0xC3, 0x50,                                     ///< src_port
+        0x01, 0xBB,                                     ///< dst_port
+      };
+
+      ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+      CHECK(proxy_protocol_parse(&pp_info, tv) == 0);
+      CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+      CHECK(pp_info.ip_family == AF_UNSPEC);
+    }
+
+    SECTION("invalid len - actual buffer is shorter than the value")
+    {
+      uint8_t raw_data[] = {
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+        0x55, 0x49, 0x54, 0x0A,                         ///<
+        0x21,                                           ///< version & command
+        0x21,                                           ///< protocol & family
+        0x00, 0x24,                                     ///< len
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, ///<
+        0xC3, 0x50,                                     ///< src_port
+        0x01,                                           ///< dst_port
+      };
+
+      ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+      CHECK(proxy_protocol_parse(&pp_info, tv) == 0);
+      CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+      CHECK(pp_info.ip_family == AF_UNSPEC);
+    }
+
+    SECTION("invalid len - too short for INET")
+    {
+      uint8_t raw_data[] = {
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+        0x55, 0x49, 0x54, 0x0A,                         ///<
+        0x21,                                           ///< version & command
+        0x11,                                           ///< protocol & family
+        0x00, 0x0C,                                     ///< len
+        0xC0, 0x00,                                     ///< src_addr
+        0xC6, 0x33,                                     ///< dst_addr
+        0xC3, 0x50,                                     ///< src_port
+        0x01, 0xBB,                                     ///< dst_port
+      };
+
+      ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+      CHECK(proxy_protocol_parse(&pp_info, tv) == 0);
+      CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+      CHECK(pp_info.ip_family == AF_UNSPEC);
+    }
+
+    SECTION("invalid len - too short for INET6")
+    {
+      uint8_t raw_data[] = {
+        0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+        0x55, 0x49, 0x54, 0x0A,                         ///<
+        0x21,                                           ///< version & command
+        0x21,                                           ///< protocol & family
+        0x00, 0x24,                                     ///< len
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x01, ///< src_addr
+        0x20, 0x01, 0x0D, 0xB8, 0x00, 0x00, 0x00, 0x02, ///< dst_addr
+        0xC3, 0x50,                                     ///< src_port
+        0x01, 0xBB,                                     ///< dst_port
+      };
+
+      ts::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+      CHECK(proxy_protocol_parse(&pp_info, tv) == 0);
+      CHECK(pp_info.version == ProxyProtocolVersion::UNDEFINED);
+      CHECK(pp_info.ip_family == AF_UNSPEC);
+    }
   }
 }


### PR DESCRIPTION
Address #7339. UDP, UNIX Domain Socket, and TLVs support are out of scope.

~~Mark as a draft until depending PRs (#7331, #7332) are merged.~~ All set