### PR TITLE
Add note to background fetch about include/exclude

### DIFF
--- a/doc/admin-guide/plugins/background_fetch.en.rst
+++ b/doc/admin-guide/plugins/background_fetch.en.rst
@@ -74,6 +74,16 @@ The contents of the config-file could be as below::
    exclude X-Foo-Bar text
    exclude Content-Length <1000
 
+.. important::
+
+   The ``include`` configuration directive is only used when there is a corresponding ``exclude`` to exempt.
+   For example, a single line directive, ``include Host example.com`` would not make the plugin
+   *only* act on example.com. To acheive classic allow (only) lists, one would need to have a broad
+   exclude line, such as::
+
+      exclude Host *
+      include Host example.com
+
 The plugin also now supports per remap activation. To activate the plugin for a given remap, add the
 below on the remap line::
 


### PR DESCRIPTION
The include configuraton directive for background fetch is a bit
confusing, in that it requires a corresponding exclude directive.
That is, its used as an exemption mechanism to an exclude
directive.