### PR TITLE
TLS Session Reuse: Downgrade noisy log to debug

### DIFF
--- a/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/openssl_utils.cc
@@ -56,7 +56,7 @@ ssl_new_session(TSSslSessionID &sid)
   char session_data[SSL_SESSION_MAX_DER];
   const auto buffer_length = TSSslSessionGetBuffer(&sid, session_data, &session_ret_len);
   if (buffer_length == 0) {
-    TSError("Failed to find a session buffer.");
+    TSDebug(PLUGIN, "Failed to find a session buffer.");
     return 0;
   } else if (buffer_length > session_ret_len) {
     TSError("Session data is too large. Its size is: %d but our max buffer size is: %d.", buffer_length, SSL_SESSION_MAX_DER);


### PR DESCRIPTION
In the ssl_session_reuse plugin, not finding a TLS session for reuse via
TSSslSessionGetBuffer is simply an indication that there is no available
TSL session to reuse. This is a normal case and should not be logged as
an error.  Downgrading it to debug status.