### PR TITLE
Fix sni ip_allow and host_sni_policy

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1896,7 +1896,7 @@ Security
 
    You can override this global setting on a per domain basis in the :file:`sni.yaml` file using the :ref:`host_sni_policy attribute<override-host-sni-policy>` action.
 
-   Currently, only the verify_client policy is checked for host name and SNI matching.
+   Currently, only the verify_client and ip_allow policies are checked for host name and SNI matching.
 
 Cache Control
 =============

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -325,8 +325,9 @@ public:
   TestClientSNIAction(const char *servrername, const IpEndpoint &ep, int &policy) const override
   {
     bool retval = false;
-    if (ip_map.contains(ep)) {
-      retval = true;
+    if (ip_map.count() > 0) {
+      // Only triggers if the map didn't contain the address
+      retval = !ip_map.contains(ep);
     }
     return retval;
   }


### PR DESCRIPTION
Fixes logic error causing issue described in #7348.  Also updates the documentation.

I would have liked to include an autest for this case.  There are  no autests for the sni ip_allow feature.  Unfortunately, since we are running unprivileged, there is no way to specify multiple client IP addresses to exercise the feature.

This closes #7348