### PR TITLE
Clear call_sm on tunnel reset

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -477,6 +477,7 @@ HttpTunnel::reset()
   }
 #endif
 
+  call_sm       = false;
   num_producers = 0;
   num_consumers = 0;
   ink_zero(consumers);


### PR DESCRIPTION
I ran across this while debugging gRPC on my HTTP/2 to origin branch.

One case was terminating early, and looking at the HttpSM history, the response tunnel sm handler and executed but neither the producer nor consumer handlers handlers had executed.  After an hour or so of staring, I realized that the tunnel.call_sm had been set from processing the post body, but had not been cleared before executing the response body.  So after the first event to the HttpTunnel, the final HttpSM handler would be called.

I'm breaking this out to integrate into ATS sooner.  This logic has been present since April 2016.  For most transactions there is either a complex post body or a complex response body but not both so this is hopefully not a frequent issue.  gRPC breaks that assumption.  But I assume we had a certain amount of background failures due to this.  They will appear as early terminations, and for most traffic should not occur that often.  Or I would assume that we would have noticed this before now.