### PR TITLE
Use EVP API instead of MD5_Init/Update/Final (secure_link plugin)

### DIFF
--- a/example/plugins/c-api/secure_link/secure_link.c
+++ b/example/plugins/c-api/secure_link/secure_link.c
@@ -111,6 +111,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
   EVP_DigestUpdate(ctx, sli->secret, strlen(sli->secret));
   EVP_DigestUpdate(ctx, ip, strlen(ip));
+
   if (path) {
     EVP_DigestUpdate(ctx, path, strlen(path));
   }
@@ -118,6 +119,11 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     EVP_DigestUpdate(ctx, expire, strlen(expire));
   }
   EVP_DigestFinal_ex(ctx, md, NULL);
+#ifdef HAVE_EVP_MD_CTX_FREE
+  EVP_MD_CTX_free(ctx);
+#else
+  EVP_MD_CTX_destroy(ctx);
+#endif
   for (i = 0; i < MD5_DIGEST_LENGTH; i++) {
     sprintf(&hash[i * 2], "%02x", md[i]);
   }

--- a/example/plugins/c-api/secure_link/secure_link.c
+++ b/example/plugins/c-api/secure_link/secure_link.c
@@ -103,7 +103,11 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     /* this is just example, so set fake params to prevent plugin crash */
     path = TSstrdup("example/");
   }
+#ifdef HAVE_EVP_MD_CTX_NEW
   ctx = EVP_MD_CTX_new();
+#else
+  ctx = EVP_MD_CTX_create();
+#endif
   EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
   EVP_DigestUpdate(ctx, sli->secret, strlen(sli->secret));
   EVP_DigestUpdate(ctx, ip, strlen(ip));

--- a/example/plugins/c-api/secure_link/secure_link.c
+++ b/example/plugins/c-api/secure_link/secure_link.c
@@ -28,7 +28,8 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <openssl/md5.h>
+#include <openssl/md5.h> // For MD5_DIGEST_LENGTH
+#include <openssl/evp.h>
 
 #include "ts/ts.h"
 #include "ts/remap.h"
@@ -45,7 +46,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 {
   int i, len;
   time_t t, e;
-  MD5_CTX ctx;
+  EVP_MD_CTX *ctx;
   struct sockaddr_in *in;
   const char *qh, *ph, *ip;
   unsigned char md[MD5_DIGEST_LENGTH];
@@ -102,16 +103,17 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     /* this is just example, so set fake params to prevent plugin crash */
     path = TSstrdup("example/");
   }
-  MD5_Init(&ctx);
-  MD5_Update(&ctx, sli->secret, strlen(sli->secret));
-  MD5_Update(&ctx, ip, strlen(ip));
+  ctx = EVP_MD_CTX_new();
+  EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
+  EVP_DigestUpdate(ctx, sli->secret, strlen(sli->secret));
+  EVP_DigestUpdate(ctx, ip, strlen(ip));
   if (path) {
-    MD5_Update(&ctx, path, strlen(path));
+    EVP_DigestUpdate(ctx, path, strlen(path));
   }
   if (expire) {
-    MD5_Update(&ctx, expire, strlen(expire));
+    EVP_DigestUpdate(ctx, expire, strlen(expire));
   }
-  MD5_Final(md, &ctx);
+  EVP_DigestFinal_ex(ctx, md, NULL);
   for (i = 0; i < MD5_DIGEST_LENGTH; i++) {
     sprintf(&hash[i * 2], "%02x", md[i]);
   }


### PR DESCRIPTION
MD5_Init/Update/Final are going to be deprecated since OpenSSL 3.0.
https://www.openssl.org/docs/manmaster/man3/MD5_Init.html