### PR TITLE
Use EVP MAC API if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1298,6 +1298,9 @@ TS_CHECK_CRYPTO_SET_CIPHERSUITES
 # Check for openssl early data support
 TS_CHECK_EARLY_DATA
 
+# Check for openssl session ticket support
+TS_CHECK_SESSION_TICKET
+
 saved_LIBS="$LIBS"
 TS_ADDTO([LIBS], ["$OPENSSL_LIBS"])
 

--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -79,6 +79,7 @@
 #define TS_USE_REMOTE_UNWINDING @use_remote_unwinding@
 #define TS_USE_TLS_OCSP @use_tls_ocsp@
 #define TS_HAS_TLS_EARLY_DATA @has_tls_early_data@
+#define TS_HAS_TLS_SESSION_TICKET @has_tls_session_ticket@
 
 #define TS_HAS_SO_PEERCRED @has_so_peercred@
 

--- a/iocore/net/SSLCertLookup.cc
+++ b/iocore/net/SSLCertLookup.cc
@@ -28,6 +28,7 @@
 #include "tscore/MatcherUtils.h"
 #include "tscore/Regex.h"
 #include "tscore/Trie.h"
+#include "tscore/ink_config.h"
 #include "tscore/BufferWriter.h"
 #include "tscore/bwf_std_format.h"
 #include "tscore/TestBox.h"
@@ -216,7 +217,7 @@ fail:
 ssl_ticket_key_block *
 ssl_create_ticket_keyblock(const char *ticket_key_path)
 {
-#if TS_HAVE_OPENSSL_SESSION_TICKETS
+#if TS_HAS_TLS_SESSION_TICKET
   ats_scoped_str ticket_key_data;
   int ticket_key_len;
   ssl_ticket_key_block *keyblock = nullptr;
@@ -241,10 +242,10 @@ fail:
   ticket_block_free(keyblock);
   return nullptr;
 
-#else  /* !TS_HAVE_OPENSSL_SESSION_TICKETS */
+#else  /* !TS_HAS_TLS_SESSION_TICKET */
   (void)ticket_key_path;
   return nullptr;
-#endif /* TS_HAVE_OPENSSL_SESSION_TICKETS */
+#endif /* TS_HAS_TLS_SESSION_TICKET */
 }
 
 SSLCertContext::SSLCertContext(SSLCertContext const &other)

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -34,6 +34,7 @@
 #include <cstring>
 #include <cmath>
 
+#include "tscore/ink_config.h"
 #include "tscore/ink_platform.h"
 #include "tscore/I_Layout.h"
 #include "records/I_RecHttp.h"
@@ -533,7 +534,7 @@ SSLTicketParams::LoadTicket(bool &nochange)
   cleanup();
   nochange = true;
 
-#if TS_HAVE_OPENSSL_SESSION_TICKETS
+#if TS_HAS_TLS_SESSION_TICKET
   ssl_ticket_key_block *keyblock = nullptr;
 
   SSLConfig::scoped_config params;
@@ -581,15 +582,15 @@ SSLTicketParams::LoadTicket(bool &nochange)
   load_time               = time(nullptr);
 
   Debug("ssl", "ticket key reloaded from %s", ticket_key_filename);
-  return true;
 #endif
+  return true;
 }
 
 void
 SSLTicketParams::LoadTicketData(char *ticket_data, int ticket_data_len)
 {
   cleanup();
-#if TS_HAVE_OPENSSL_SESSION_TICKETS
+#if TS_HAS_TLS_SESSION_TICKET
   if (ticket_data != nullptr && ticket_data_len > 0) {
     default_global_keyblock = ticket_block_create(ticket_data, ticket_data_len);
   } else {

--- a/iocore/net/SSLSessionTicket.cc
+++ b/iocore/net/SSLSessionTicket.cc
@@ -23,7 +23,7 @@
 
 #include "SSLSessionTicket.h"
 
-#if TS_HAVE_OPENSSL_SESSION_TICKETS
+#if TS_HAS_TLS_SESSION_TICKET
 
 #include "P_SSLCertLookup.h"
 #include "TLSSessionResumptionSupport.h"
@@ -40,8 +40,13 @@ ssl_session_ticket_free(void * /*parent*/, void *ptr, CRYPTO_EX_DATA * /*ad*/, i
  * a mechanism to present the ticket back to the server.
  * */
 int
+#ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
+ssl_callback_session_ticket(SSL *ssl, unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx,
+                            int enc)
+#else
 ssl_callback_session_ticket(SSL *ssl, unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx,
                             int enc)
+#endif
 {
   TLSSessionResumptionSupport *srs = TLSSessionResumptionSupport::getInstance(ssl);
 
@@ -57,4 +62,4 @@ ssl_callback_session_ticket(SSL *ssl, unsigned char *keyname, unsigned char *iv,
   }
 }
 
-#endif /* TS_HAVE_OPENSSL_SESSION_TICKETS */
+#endif /* TS_HAS_TLS_SESSION_TICKET */

--- a/iocore/net/SSLSessionTicket.h
+++ b/iocore/net/SSLSessionTicket.h
@@ -23,21 +23,21 @@
 
 #pragma once
 
+#include "tscore/ink_config.h"
 #include <openssl/safestack.h>
 #include <openssl/tls1.h>
 #include <openssl/ssl.h>
 
-// Check if the ticket_key callback #define is available, and if so, enable session tickets.
-#ifdef SSL_CTX_set_tlsext_ticket_key_cb
-#define TS_HAVE_OPENSSL_SESSION_TICKETS 1
-#endif
-
-#ifdef TS_HAVE_OPENSSL_SESSION_TICKETS
+#if TS_HAS_TLS_SESSION_TICKET
 
 #include <openssl/crypto.h>
 #include <openssl/hmac.h>
 
 void ssl_session_ticket_free(void *, void *, CRYPTO_EX_DATA *, int, long, void *);
+#ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
+int ssl_callback_session_ticket(SSL *, unsigned char *, unsigned char *, EVP_CIPHER_CTX *, EVP_MAC_CTX *, int);
+#else
 int ssl_callback_session_ticket(SSL *, unsigned char *, unsigned char *, EVP_CIPHER_CTX *, HMAC_CTX *, int);
+#endif
 
-#endif /* TS_HAVE_OPENSSL_SESSION_TICKETS */
+#endif /* TS_HAS_TLS_SESSION_TICKET */

--- a/iocore/net/TLSSessionResumptionSupport.h
+++ b/iocore/net/TLSSessionResumptionSupport.h
@@ -40,8 +40,13 @@ public:
   static void bind(SSL *ssl, TLSSessionResumptionSupport *srs);
   static void unbind(SSL *ssl);
 
+#ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
+  int processSessionTicket(SSL *ssl, unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx,
+                           int enc);
+#else
   int processSessionTicket(SSL *ssl, unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx,
                            int enc);
+#endif
   bool getSSLSessionCacheHit() const;
   ssl_curve_id getSSLCurveNID() const;
 
@@ -57,10 +62,17 @@ private:
   bool _sslSessionCacheHit = false;
   int _sslCurveNID         = NID_undef;
 
+#ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
+  int _setSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
+                             EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx);
+  int _getSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
+                             EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx);
+#else
   int _setSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
                              EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx);
   int _getSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
                              EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx);
+#endif
 
   void _setSSLSessionCacheHit(bool state);
   void _setSSLCurveNID(ssl_curve_id curve_nid);


### PR DESCRIPTION
HMAC_Init_ex is going to be deprecated since OpenSSL 3.0

https://www.openssl.org/docs/manmaster/man3/HMAC_Init_ex.html
https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_tlsext_ticket_key_cb.html
https://www.openssl.org/docs/manmaster/man3/EVP_MAC_CTX_set_params.html