### PR TITLE
traffic_ctl - plugin msg  now require only the tag as mandatory field data field is now optional.

### DIFF
--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -235,7 +235,9 @@ traffic_ctl plugin
    :cpp:enumerator:`TSLifecycleHookID::TS_LIFECYCLE_MSG_HOOK` will receive a callback for that hook.
    The :arg:`TAG` and :arg:`DATA` will be available to the plugin hook processing. It is expected
    that plugins will use :arg:`TAG` to select relevant messages and determine the format of the
-   :arg:`DATA`.
+   :arg:`DATA`. The :arg:`DATA` is optional and may not be available to consume, if not available then size will be 0
+   and the data will be NULL. Any extra passed value beside the tag and the optional data will be ignored.
+   Check :c:type:`TSPluginMsg` for more info.
 
 traffic_ctl host
 ----------------

--- a/example/plugins/c-api/lifecycle_plugin/lifecycle_plugin.c
+++ b/example/plugins/c-api/lifecycle_plugin/lifecycle_plugin.c
@@ -49,6 +49,10 @@ CallbackHandler(TSCont this, TSEvent id, void *data)
   case TS_EVENT_LIFECYCLE_MSG: {
     TSPluginMsg *msg = (TSPluginMsg *)data;
     TSDebug(PLUGIN_NAME, "Message to '%s' - %zu bytes of data", msg->tag, msg->data_size);
+    if (msg->data_size == 0) {
+      TSDebug(PLUGIN_NAME, "Message data is not available");
+    }
+
     break;
   }
   default:

--- a/plugins/experimental/header_freq/header_freq.cc
+++ b/plugins/experimental/header_freq/header_freq.cc
@@ -195,6 +195,8 @@ handle_hook(TSCont contp, TSEvent event, void *edata)
         TSCont c = TSContCreate(CB_Command_Log, TSMutexCreate());
         TSContDataSet(c, new std::string(static_cast<const char *>(msgp->data), msgp->data_size));
         TSContScheduleOnPool(c, 0, TS_THREAD_POOL_TASK);
+      } else if (msgp->data_size == 0) {
+        TSError("[%s] No command provided.", PLUGIN_NAME);
       } else {
         TSError("[%s] Unknown command '%.*s'", PLUGIN_NAME, static_cast<int>(msgp->data_size),
                 static_cast<const char *>(msgp->data));

--- a/plugins/experimental/traffic_dump/traffic_dump.cc
+++ b/plugins/experimental/traffic_dump/traffic_dump.cc
@@ -43,14 +43,14 @@ global_message_handler(TSCont contp, TSEvent event, void *edata)
     std::string_view tag(msg->tag, strlen(msg->tag));
     if (tag.substr(0, PLUGIN_PREFIX.size()) == PLUGIN_PREFIX) {
       tag.remove_prefix(PLUGIN_PREFIX.size());
-      if (tag == "sample") {
+      if (tag == "sample" && msg->data_size) {
         const auto new_sample_size = static_cast<int64_t>(strtol(static_cast<char const *>(msg->data), nullptr, 0));
         TSDebug(debug_tag, "TS_EVENT_LIFECYCLE_MSG: Received Msg to change sample size to %" PRId64 "bytes", new_sample_size);
         SessionData::set_sample_pool_size(new_sample_size);
       } else if (tag == "reset") {
         TSDebug(debug_tag, "TS_EVENT_LIFECYCLE_MSG: Received Msg to reset disk usage counter");
         SessionData::reset_disk_usage();
-      } else if (tag == "limit") {
+      } else if (tag == "limit" && msg->data_size) {
         const auto new_max_disk_usage = static_cast<int64_t>(strtol(static_cast<char const *>(msg->data), nullptr, 0));
         TSDebug(debug_tag, "TS_EVENT_LIFECYCLE_MSG: Received Msg to change max disk usage to %" PRId64 "bytes", new_max_disk_usage);
         SessionData::set_max_disk_usage(new_max_disk_usage);

--- a/src/traffic_ctl/plugin.cc
+++ b/src/traffic_ctl/plugin.cc
@@ -29,7 +29,12 @@ CtrlEngine::plugin_msg()
   TSMgmtError error;
   auto msg_data = arguments.get("msg");
 
-  error = TSLifecycleMessage(msg_data[0].c_str(), msg_data[1].c_str(), msg_data[1].size() + 1);
+  if (msg_data.size() == 1) { // no data provided, just the tag
+    error = TSLifecycleMessage(msg_data[0].c_str(), nullptr, 0);
+  } else {
+    error = TSLifecycleMessage(msg_data[0].c_str(), msg_data[1].c_str(), msg_data[1].size() + 1);
+  }
+
   if (error != TS_ERR_OKAY) {
     CtrlMgmtError(error, "message '%s' not sent", msg_data[0].c_str());
     status_code = CTRL_EX_ERROR;

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -229,7 +229,9 @@ main(int argc, const char **argv)
   metric_command.add_command("zero", "Clear one or more metric values", "", MORE_THAN_ONE_ARG_N, [&]() { engine.metric_zero(); });
 
   // plugin command
-  plugin_command.add_command("msg", "Send message to plugins - a TAG and the message DATA", "", 2, [&]() { engine.plugin_msg(); })
+  plugin_command
+    .add_command("msg", "Send message to plugins - a TAG and the message DATA(optional)", "", MORE_THAN_ONE_ARG_N,
+                 [&]() { engine.plugin_msg(); })
     .add_example_usage("traffic_ctl plugin msg TAG DATA");
 
   // server commands


### PR DESCRIPTION
`traffic_ctl` can send a plugin message, which has a tag and a body. The CLI requires a tag and a body, but in some cases the body is irrelevant. However the CLI will fail if there’s no body. This change make the body/data optional, if not passed then the message handler will get data size as 0 and the data as NULL.
