### PR TITLE
Cleanup: Get rid of NetVConnection::outstanding()

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -357,14 +357,6 @@ struct NetVCOptions {
 class NetVConnection : public VConnection, public PluginUserArgs<TS_USER_ARGS_VCONN>
 {
 public:
-  // How many bytes have been queued to the OS for sending by haven't been sent yet
-  // Not all platforms support this, and if they don't we'll return -1 for them
-  virtual int64_t
-  outstanding()
-  {
-    return -1;
-  };
-
   /**
      Initiates read. Thread safe, may be called when not handling
      an event from the NetVConnection, or the NetVConnection creation

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -107,7 +107,6 @@ enum tcp_congestion_control_t { CLIENT_SIDE, SERVER_SIDE };
 class UnixNetVConnection : public NetVConnection, public NetEvent
 {
 public:
-  int64_t outstanding() override;
   VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false) override;
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -571,19 +571,6 @@ UnixNetVConnection::get_data(int id, void *data)
   }
 }
 
-int64_t
-UnixNetVConnection::outstanding()
-{
-  int n;
-  int ret = ioctl(this->get_socket(), TIOCOUTQ, &n);
-  // if there was an error (such as ioctl doesn't support this call on this platform) then
-  // we return -1
-  if (ret == -1) {
-    return ret;
-  }
-  return n;
-}
-
 VIO *
 UnixNetVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {


### PR DESCRIPTION
It's added by 3c7d1b1f341c3cd28275774eeb994c3d4883277e. But 784ba4383db72892ba794a7b83904af370b6f35a removed using it. It looks like dead code now.