### PR TITLE
Fix FreeBSD 12 link issue in test_libhttp2.

### DIFF
--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -66,11 +66,12 @@ TESTS = $(check_PROGRAMS)
 # Be careful if you change the order. Details in GitHub #6666
 test_libhttp2_LDADD = \
 	libhttp2.a \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
-	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
 	@HWLOC_LIBS@


### PR DESCRIPTION
This is not a nice fix, but seems to work around some linking issues we have when building with `--enable-debug` in some of the platforms. This was previusly discussed here -> #6666  but some recent changes had some effects on the build. With this 'hacky' change it works on freebsd, also tested locally with fedora and ubuntu 19.10.
I did try different approaches and also some different order and the only one that seems to work is making `libinkevent` duplicated in the list. 