### PR TITLE
Cleanup: Remove SSL Wire Trace releated code in UnixNetVConnection

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -268,11 +268,6 @@ public:
   bool from_accept_thread  = false;
   NetAccept *accept_object = nullptr;
 
-  // es - origin_trace associated connections
-  bool origin_trace;
-  const sockaddr *origin_trace_addr;
-  int origin_trace_port;
-
   int startEvent(int event, Event *e);
   int acceptEvent(int event, Event *e);
   int mainEvent(int event, Event *e);
@@ -296,24 +291,6 @@ public:
   void apply_options() override;
 
   friend void write_to_net_io(NetHandler *, UnixNetVConnection *, EThread *);
-
-  void
-  setOriginTrace(bool t)
-  {
-    origin_trace = t;
-  }
-
-  void
-  setOriginTraceAddr(const sockaddr *addr)
-  {
-    origin_trace_addr = addr;
-  }
-
-  void
-  setOriginTracePort(int port)
-  {
-    origin_trace_port = port;
-  }
 };
 
 extern ClassAllocator<UnixNetVConnection> netVCAllocator;


### PR DESCRIPTION
These `origin_trace` code are introduced as part of SSL Wire Trace feature by 6e3ce5022d67a9c4098595d3d45e24a3c697c80c. But the feature is removed by 6ee5c616d165b969b42a86c4eb2ca0b1be86b881 and these remaining code is not used anywhere.

Part of #4652.