### PR TITLE
Set thread mutex to the DNSHandler mutex of SplitDNS (#7321)

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -239,6 +239,7 @@ DNSProcessor::start(int, size_t stacksize)
   dns_failover_try_period = dns_timeout + 1; // Modify the "default" accordingly
 
   if (SplitDNSConfig::gsplit_dns_enabled) {
+    SplitDNSConfig::dnsHandler_mutex = thread->mutex;
     // reconfigure after threads start
     SplitDNSConfig::reconfigure();
   }

--- a/iocore/dns/SplitDNS.cc
+++ b/iocore/dns/SplitDNS.cc
@@ -114,8 +114,6 @@ SplitDNSConfig::release(SplitDNS *params)
 void
 SplitDNSConfig::startup()
 {
-  dnsHandler_mutex = new_ProxyMutex();
-
   // startup just check gsplit_dns_enabled
   REC_ReadConfigInt32(gsplit_dns_enabled, "proxy.config.dns.splitDNS.enabled");
   SplitDNSConfig::splitDNSUpdate = new ConfigUpdateHandler<SplitDNSConfig>();


### PR DESCRIPTION
Backport #7321 against the 8.1.x branch.

----

(cherry picked from commit 3f11f151db24ec92ea0af61197401e5b10144e27)
