### PR TITLE
Remove a special treatment for SSLNetVC in migrateToCurrentThread()

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -484,6 +484,8 @@ private:
   std::string_view map_tls_protocol_to_tag(const char *proto_string) const;
   bool update_rbio(bool move_to_socket);
   void increment_ssl_version_metric(int version) const;
+  NetProcessor *_getNetProcessor() override;
+  void *_prepareForMigration() override;
 
   enum SSLHandshakeStatus sslHandshakeStatus = SSL_HANDSHAKE_ONGOING;
   bool sslClientRenegotiationAbort           = false;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -291,6 +291,10 @@ public:
   void apply_options() override;
 
   friend void write_to_net_io(NetHandler *, UnixNetVConnection *, EThread *);
+
+private:
+  virtual void *_prepareForMigration();
+  virtual NetProcessor *_getNetProcessor();
 };
 
 extern ClassAllocator<UnixNetVConnection> netVCAllocator;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1705,14 +1705,12 @@ void
 SSLNetVCAttach(SSL *ssl, SSLNetVConnection *vc)
 {
   SSL_set_ex_data(ssl, ssl_vc_index, vc);
-  TLSSessionResumptionSupport::bind(ssl, vc);
 }
 
 void
 SSLNetVCDetach(SSL *ssl)
 {
   SSL_set_ex_data(ssl, ssl_vc_index, nullptr);
-  TLSSessionResumptionSupport::unbind(ssl);
 }
 
 SSLNetVConnection *


### PR DESCRIPTION
`UnixNetVC::migrateToCurrentThread` has code related to SSL and also duplicate code. This PR moves the SSL related code into SSLNetVC and simplify the duplicated part.

Another small change is moving out calls for `TLSSessionResumptionSupport::bind/unbind` from `SSLNetVCAttach/Detach`. They were integrated on #7278, but I don't think it's a right direction. The calls were intentionally separated from `SSLNetVCAttach/Detach` because I'm trying to delete `SSLNetVCAttach/Detach` which is not applicable forQUICNetVC. I'm going to add these functions below on another PR once this is merged.

```cpp
void
SSLNetVConnection::_bindSSLObject()
{
  SSLNetVCAttach(this->ssl, this);
  TLSSessionResumptionSupport::bind(this->ssl, this);
}

void
SSLNetVConnection::_unbindSSLObject()
{
  SSLNetVCDetach(this->ssl);
  TLSSessionResumptionSupport::unbind(this->ssl);
}
```

