### PR TITLE
traffic_manager should not retry on disk failure

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -729,6 +729,8 @@ CacheProcessor::start_internal(int flags)
     }
     Emergency("Cache initialization failed - only %d out of %d disks were valid and all were required.", gndisks,
               theCacheStore.n_disks_in_config);
+  } else if (this->waitForCache() == 2 && static_cast<unsigned int>(gndisks) < theCacheStore.n_disks_in_config) {
+    Warning("Cache initialization incomplete - only %d out of %d disks were valid.", gndisks, theCacheStore.n_disks_in_config);
   }
 
   // If we got here, we have enough disks to proceed
@@ -784,7 +786,9 @@ CacheProcessor::diskInitialized()
       if (cb_after_init) {
         cb_after_init();
       }
-      Fatal("Cache initialization failed - only %d of %d disks were available.", gndisks, theCacheStore.n_disks_in_config);
+      Emergency("Cache initialization failed - only %d of %d disks were available.", gndisks, theCacheStore.n_disks_in_config);
+    } else if (this->waitForCache() == 2) {
+      Warning("Cache initialization incomplete - only %d of %d disks were available.", gndisks, theCacheStore.n_disks_in_config);
     }
   }
 
@@ -1052,7 +1056,7 @@ CacheProcessor::cacheInitialized()
 
   // TS-3848
   if (CACHE_INIT_FAILED == CacheProcessor::initialized && cacheProcessor.waitForCache() > 1) {
-    Fatal("Cache initialization failed with cache required, exiting.");
+    Emergency("Cache initialization failed with cache required, exiting.");
   }
 }
 
@@ -2062,7 +2066,7 @@ Cache::open_done()
 
   // TS-3848
   if (ready == CACHE_INIT_FAILED && cacheProcessor.waitForCache() >= 2) {
-    Fatal("Failed to initialize cache host table");
+    Emergency("Failed to initialize cache host table");
   }
 
   cacheProcessor.cacheInitialized();

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -833,7 +833,7 @@ main(int argc, const char **argv)
         just_started++;
       }
     } else {
-      // Even if we shouldn't try the start the proxy again, leave manager around to
+      // Even if we shouldn't try to start the proxy again, leave manager around to
       // avoid external automated restarts
       if (!lmgmt->proxy_recoverable && !printed_unrecoverable) {
         mgmt_log("[main] Proxy is un-recoverable. Proxy will not be relaunched.\n");

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -492,7 +492,8 @@ main(int argc, const char **argv)
   char *tsArgs       = nullptr;
   int disable_syslog = false;
   char userToRunAs[MAX_LOGIN + 1];
-  RecInt fds_throttle = -1;
+  RecInt fds_throttle        = -1;
+  bool printed_unrecoverable = false;
 
   ArgumentDescription argument_descriptions[] = {
     {"proxyOff", '-', "Disable proxy", "F", &proxy_off, nullptr, nullptr},
@@ -831,9 +832,12 @@ main(int argc, const char **argv)
       } else {
         just_started++;
       }
-    } else { /* Give the proxy a chance to fire up */
-      if (!lmgmt->proxy_recoverable) {
+    } else {
+      // Even if we shouldn't try the start the proxy again, leave manager around to
+      // avoid external automated restarts
+      if (!lmgmt->proxy_recoverable && !printed_unrecoverable) {
         mgmt_log("[main] Proxy is un-recoverable. Proxy will not be relaunched.\n");
+        printed_unrecoverable = true;
       }
 
       just_started++;


### PR DESCRIPTION
Replaces calls to Fatal with calls to Emergency so traffic_manager does not keep retrying in this case.  Adjusted traffic_manager so it does not bombard manager.log with warnings if traffic_server should not be restarted.  Also added uniform warning messages in the case of disk failure and wait_for_cache is set to 2 to simplify log monitoring.

This closes #7396