### PR TITLE
Remove unused MAYBE_ABORT state

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5374,7 +5374,6 @@ HttpSM::set_ua_abort(HttpTransact::AbortState_t ua_abort, int event)
 
   switch (ua_abort) {
   case HttpTransact::ABORTED:
-  case HttpTransact::MAYBE_ABORTED:
     // More detailed client side abort logging based on event
     switch (event) {
     case VC_EVENT_ERROR:

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -8340,8 +8340,6 @@ HttpTransact::client_result_stat(State *s, ink_hrtime total_time, ink_hrtime req
   //////////////////////////////////////////
   if (s->client_info.abort == ABORTED) {
     client_transaction_result = CLIENT_TRANSACTION_RESULT_ERROR_ABORT;
-  } else if (s->client_info.abort == MAYBE_ABORTED) {
-    client_transaction_result = CLIENT_TRANSACTION_RESULT_ERROR_POSSIBLE_ABORT;
   }
   // Count the status codes, assuming the client didn't abort (i.e. there is an m_http)
   if ((s->source != SOURCE_NONE) && (s->client_info.abort == DIDNOT_ABORT)) {

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -219,7 +219,6 @@ public:
   enum AbortState_t {
     ABORT_UNDEFINED = 0,
     DIDNOT_ABORT,
-    MAYBE_ABORTED,
     ABORTED,
   };
 


### PR DESCRIPTION
Noticed that HttpTransact::MAYBE_ABORT is never set, so might as well tidy it up..