### PR TITLE
Fix unnecessary addition of Expires header

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3055,7 +3055,7 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
       // the reason string being written to the client and a bad CL when reading from cache.
       // I didn't find anywhere this appended reason is being used, so commenting it out.
       /*
-        if (t_state.is_cacheable_and_negative_caching_is_enabled && p->bytes_read == 0) {
+        if (t_state.is_cacheable_due_to_negative_caching_configuration && p->bytes_read == 0) {
         int reason_len;
         const char *reason = t_state.hdr_info.server_response.reason_get(&reason_len);
         if (reason == NULL)
@@ -3111,8 +3111,8 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
   }
 
   // turn off negative caching in case there are multiple server contacts
-  if (t_state.is_cacheable_and_negative_caching_is_enabled) {
-    t_state.is_cacheable_and_negative_caching_is_enabled = false;
+  if (t_state.is_cacheable_due_to_negative_caching_configuration) {
+    t_state.is_cacheable_due_to_negative_caching_configuration = false;
   }
 
   // If we had a ground fill, check update our status
@@ -6735,7 +6735,7 @@ HttpSM::setup_server_transfer()
 
   nbytes = server_transfer_init(buf, hdr_size);
 
-  if (t_state.is_cacheable_and_negative_caching_is_enabled &&
+  if (t_state.is_cacheable_due_to_negative_caching_configuration &&
       t_state.hdr_info.server_response.status_get() == HTTP_STATUS_NO_CONTENT) {
     int s = sizeof("No Content") - 1;
     buf->write("No Content", s);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -4402,7 +4402,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
     client_response_code = server_response_code;
     base_response        = &s->hdr_info.server_response;
 
-    s->is_cacheable_and_negative_caching_is_enabled = cacheable && s->txn_conf->negative_caching_enabled;
+    s->is_cacheable_due_to_negative_caching_configuration = cacheable && is_negative_caching_appropriate(s);
 
     // determine the correct cache action given the original cache action,
     // cacheability of server response, and request method
@@ -4464,7 +4464,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
     //   before issuing a 304
     if (s->cache_info.action == CACHE_DO_WRITE || s->cache_info.action == CACHE_DO_NO_ACTION ||
         s->cache_info.action == CACHE_DO_REPLACE) {
-      if (s->is_cacheable_and_negative_caching_is_enabled) {
+      if (s->is_cacheable_due_to_negative_caching_configuration) {
         HTTPHdr *resp;
         s->cache_info.object_store.create();
         s->cache_info.object_store.request_set(&s->hdr_info.client_request);
@@ -4500,8 +4500,8 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
           SET_VIA_STRING(VIA_PROXY_RESULT, VIA_PROXY_SERVER_REVALIDATED);
         }
       }
-    } else if (s->is_cacheable_and_negative_caching_is_enabled) {
-      s->is_cacheable_and_negative_caching_is_enabled = false;
+    } else if (s->is_cacheable_due_to_negative_caching_configuration) {
+      s->is_cacheable_due_to_negative_caching_configuration = false;
     }
 
     break;
@@ -4911,7 +4911,7 @@ HttpTransact::set_headers_for_cache_write(State *s, HTTPInfo *cache_info, HTTPHd
      sites yields no insight. So the assert is removed and we keep the behavior that if the response
      in @a cache_info is already set, we don't override it.
   */
-  if (!s->is_cacheable_and_negative_caching_is_enabled || !cache_info->response_get()->valid()) {
+  if (!s->is_cacheable_due_to_negative_caching_configuration || !cache_info->response_get()->valid()) {
     cache_info->response_set(response);
   }
 

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -737,23 +737,15 @@ public:
     bool client_connection_enabled = true;
     bool acl_filtering_performed   = false;
 
-    /// True if negative caching is enabled and the response is cacheable.
+    /// True if the response is cacheable because of negative caching configuration.
     ///
-    /// Note carefully that this being true does not necessarily imply that the
-    /// response code was negative. It means that (a) the response was
-    /// cacheable apart from response code considerations, and (b) concerning
-    /// the response code one of the following was true:
+    /// This being true implies the following:
     ///
-    ///   * The response was a negative response code configured cacheable
-    ///   by the user via negative response caching configuration, or ...
-    ///
-    ///   * The response code was an otherwise cacheable positive repsonse
-    ///   value (such as a 200 response, for example).
-    ///
-    /// TODO: We should consider refactoring this variable and its use. For now
-    /// I'm giving it an awkwardly long name to make sure the meaning of it is
-    /// clear in its various contexts.
-    bool is_cacheable_and_negative_caching_is_enabled = false;
+    /// * The response code was negative.
+    /// * Negative caching is enabled.
+    /// * The response is considered cacheable because of negative caching
+    ///   configuration.
+    bool is_cacheable_due_to_negative_caching_configuration = false;
     // for authenticated content caching
     CacheAuth_t www_auth_content = CACHE_AUTH_NONE;
 


### PR DESCRIPTION
TrafficServer accidentally adds Expires header generated by negative_caching_lifetime to non-negative responses. Due to the addition of Expires header,  the expiration of non-negative cache that has neither Cache-Control nor Expires is determined by `proxy.config.http.negative_caching_lifetime` . In this case, the expiration should be determined by heuristic expiration (between `proxy.config.http.cache.heuristic_min_lifetime` and `proxy.config.http.cache.heuristic_max_lifetime` ).

Also, this breaks the response to a conditional request.

This is caused by https://github.com/apache/trafficserver/commit/8eb68266167d8f8b3fa3a00ca9f6b7889e8ec101 .


# How to reproduce

## settings

### records.config
```
CONFIG proxy.config.http.negative_caching_enabled INT 1
CONFIG proxy.config.http.negative_caching_lifetime INT 10
CONFIG proxy.config.http.cache.required_headers INT 0
CONFIG proxy.config.http.insert_response_via_str INT 2
```

### remap.config
```
map / https://httpbin.org/
```


## unnecessary addition of Expires header

1. purge cache just in case
```
$ curl -X PURGE -D - -s -o /dev/null 'http://localhost:8080/get'
```

2. send request
```
$ curl -D - -s -o /dev/null 'http://localhost:8080/get' | grep -E '(Date|Expires|Via|Age)'
Date: Fri, 18 Dec 2020 00:46:09 GMT
Age: 0
Via: https/1.1 traffic_server (ApacheTrafficServer/10.0.0 [cMsSfW])
```

3. send request within 10 seconds from step 2
```
$ curl -D - -s -o /dev/null 'http://localhost:8080/get' | grep -E '(Date|Expires|Via|Age)'
Date: Fri, 18 Dec 2020 00:46:09 GMT
Expires: Fri, 18 Dec 2020 00:46:19 GMT
Age: 7
Via: http/1.1 traffic_server (ApacheTrafficServer/10.0.0 [cHs f ])
```
The cached response should not contain Expires header.

4. send request after 10 seconds from step 2
```
$ curl -D - -s -o /dev/null 'http://localhost:8080/get' | grep -E '(Date|Expires|Via|Age)'
Date: Fri, 18 Dec 2020 00:46:20 GMT
Age: 2
Via: https/1.1 traffic_server (ApacheTrafficServer/10.0.0 [cSsSfU])
```


## invalid response to conditional request

1. purge cache just in case
```
$ curl -X PURGE -D - -s -o /dev/null 'http://localhost:8080/response-headers?Last-Modified=Fri%2C+18+Dec+2020+00%3A00%3A00+GMT'
```

2. send request
```
$ curl -D - -s -o /dev/null -H 'If-Modified-Since: Fri, 18 Dec 2020 00:00:00 GMT' 'http://localhost:8080/response-headers?Last-Modified=Fri%2C+18+Dec+2020+00%3A00%3A00+GMT' | grep -E '(HTTP|Via)'
HTTP/1.1 200 OK
Via: https/1.1 traffic_server (ApacheTrafficServer/10.0.0 [cMsSfW])
```
In this case, the response code should be `304 Not Modified` .