### PR TITLE
Correctly pass back errno to HttpSM

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -490,7 +490,7 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
     }
 
     vc->write.triggered = 0;
-    write_signal_error(nh, vc, static_cast<int>(-total_written));
+    write_signal_error(nh, vc, static_cast<int>(-r));
     return;
   } else {                                        // Wrote data.  Finished without error
     int wbe_event = vc->write_buffer_empty_event; // save so we can clear if needed.

--- a/tests/gold_tests/headers/general-connection-failure-502.gold
+++ b/tests/gold_tests/headers/general-connection-failure-502.gold
@@ -1,4 +1,4 @@
-HTTP/1.1 502 connect failed
+HTTP/1.1 502 Connection refused
 Connection: keep-alive
 Cache-Control: no-store
 Content-Type: text/html


### PR DESCRIPTION
Noticed this while tracking down causes of origin connection problems.  This logic is trying to send the errno information to the continuation, but that information is in the variable r not total_written.