### PR TITLE
Doc: Fix INPUT tag of Doxyfile

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -746,11 +746,12 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = mainpage.doc \
+                         ../include \
                          ../iocore \
-                         ../lib/cppapi/include/atscppapi \
                          ../lib/records \
-                         ../lib/ts \
-                         ../proxy
+                         ../mgmt \
+                         ../proxy \
+                         ../src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Fix warnings on `make doxygen`
```
» make doxygen
...
warning: tag INPUT: input source `../lib/cppapi/include/atscppapi' does not exist
warning: tag INPUT: input source `../lib/ts' does not exist
...
```