### PR TITLE
Add synchronization between UDPNetProcessor::UDPBind in main Thread and initialize_thread_for_udp_net in ET_UDP Thread

### DIFF
--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -56,6 +56,10 @@ std::mutex proxyServerMutex;
 std::condition_variable proxyServerCheck;
 bool et_net_threads_ready = false;
 
+std::mutex etUdpMutex;
+std::condition_variable etUdpCheck;
+bool et_udp_threads_ready = false;
+
 extern int num_of_net_threads;
 extern int num_accept_threads;
 
@@ -322,6 +326,15 @@ init_HttpProxyServer()
     lock.unlock();
     proxyServerCheck.notify_one();
   }
+
+#if TS_USE_QUIC == 1
+  if (eventProcessor.has_tg_started(ET_UDP)) {
+    std::unique_lock<std::mutex> lock(etUdpMutex);
+    et_udp_threads_ready = true;
+    lock.unlock();
+    etUdpCheck.notify_one();
+  }
+#endif
 }
 
 void

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -52,3 +52,7 @@ NetProcessor::AcceptOptions make_net_accept_options(const HttpProxyPort *port, u
 extern std::mutex proxyServerMutex;
 extern std::condition_variable proxyServerCheck;
 extern bool et_net_threads_ready;
+
+extern std::mutex etUdpMutex;
+extern std::condition_variable etUdpCheck;
+extern bool et_udp_threads_ready;


### PR DESCRIPTION
When testing trafficserver **quic** , I fond that there is not synchronization between `UDPNetProcessor::UDPBind`  in main Thread and `initialize_thread_for_udp_net`  in ET_UDP  Thread


If we add  a `sleep(1)` at `Line 67` https://github.com/apache/trafficserver/blob/afc356b83a3cf2321bf7b0c7ec431bdab5d56561/iocore/net/UnixUDPNet.cc#L63-L70
  
then we‘ll get a crash at `Line 836` because `pd` may be `nullptr`
https://github.com/apache/trafficserver/blob/afc356b83a3cf2321bf7b0c7ec431bdab5d56561/iocore/net/UnixUDPNet.cc#L833-L839  

here is the stack
```
#0  EventIO::start_common (this=0x555561e5fed8, l=0x0, afd=195, e=-2147483647) at /home/yyd/code/yyd_traffic/trafficserver/iocore/net/P_UnixNet.h:663
#1  0x0000555555c34dda in EventIO::start (this=0x555561e5fed8, l=0x0, vc=0x555561e5fdf0, events=-2147483647) at P_UnixNet.h:611
#2  0x0000555555c32fe0 in UDPNetProcessor::UDPBind (this=0x5555562a9f30 <udpNetInternal>, cont=0x555561e5fc40, addr=0x555561e5fcc0, fd=195, send_bufsize=1048576, recv_bufsize=1048576)
    at UnixUDPNet.cc:836
#3  0x0000555555c3817b in QUICNetProcessor::main_accept (this=0x5555562aa080 <quic_NetProcessor>, cont=0x555562162ca0, fd=-1, opt=...) at QUICNetProcessor.cc:224
#4  0x00005555559c08d6 in start_HttpProxyServer () at HttpProxyServerMain.cc:349
#5  0x000055555596e64c in main (argv=0x7fffffffdef8) at traffic_server/traffic_server.cc:2151
```
  
I think we need some synchronization for that
  
