### PR TITLE
Fix issue with unavailable server retry codes

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -332,15 +332,17 @@ UnavailableServerResponseCodes::UnavailableServerResponseCodes(char *val)
   numTok = pTok.Initialize(val, SHARE_TOKS);
   if (numTok == 0) {
     c = atoi(val);
-    if (c > 500 && c < 600) {
+    if (c > 499 && c < 600) {
       codes.push_back(HTTP_STATUS_SERVICE_UNAVAILABLE);
     }
   }
   for (int i = 0; i < numTok; i++) {
     c = atoi(pTok[i]);
-    if (c > 500 && c < 600) {
+    if (c > 499 && c < 600) {
       Debug("parent_select", "loading response code: %d", c);
       codes.push_back(c);
+    } else {
+      Warning("UnavailableServerResponseCodes received non-5xx code '%s', ignoring!", pTok[i]);
     }
   }
   std::sort(codes.begin(), codes.end());
@@ -368,6 +370,8 @@ SimpleRetryResponseCodes::SimpleRetryResponseCodes(char *val)
     if (c > 399 && c < 500) {
       Debug("parent_select", "loading simple response code: %d", c);
       codes.push_back(c);
+    } else {
+      Warning("SimpleRetryResponseCodes received non-4xx code '%s', ignoring!", pTok[i]);
     }
   }
   std::sort(codes.begin(), codes.end());


### PR DESCRIPTION
Currently when populating the list it checks for >500, this should be 499 to not exclude `500`

Also adding warnings during token parsing to notify if a user has added an erroneous err code to the unavailable or simple codes list