### PR TITLE
LGTM: Remove superfluous const qualifier in return type

### DIFF
--- a/include/tscore/AtomicBit.h
+++ b/include/tscore/AtomicBit.h
@@ -64,7 +64,7 @@ public:
   }
 
   // allow cast to bool
-  explicit operator const bool() const { return (*_byte_ptr) & _mask; }
+  explicit operator bool() const { return (*_byte_ptr) & _mask; }
 
   // allows compare with bool
   bool

--- a/include/tscore/Extendible.h
+++ b/include/tscore/Extendible.h
@@ -359,7 +359,7 @@ namespace details
   /// Bool specializations
 
   template <typename Derived_t>
-  const bool
+  bool
   fieldGet(const void *fld_ptr, FieldId<Derived_t, bool> const &field)
   {
     return bool((*static_cast<const uint8_t *>(fld_ptr)) & field.desc->mask);
@@ -395,7 +395,7 @@ namespace details
   /// std::atomic<bool> specializations (same as bool)
 
   template <typename Derived_t>
-  inline const bool
+  inline bool
   fieldGet(void const *fld_ptr, FieldId<Derived_t, std::atomic<bool>> const &field)
   {
     return bool(fld_ptr & field.mask);

--- a/iocore/net/quic/QUICTypes.cc
+++ b/iocore/net/quic/QUICTypes.cc
@@ -355,7 +355,7 @@ QUICResumptionToken::cid() const
   return QUICTypeUtil::read_QUICConnectionId(this->_token + (1 + 20 + 4), this->_token_len - (1 + 20 + 4));
 }
 
-const ink_hrtime
+ink_hrtime
 QUICResumptionToken::expire_time() const
 {
   return QUICIntUtil::read_nbytes_as_uint(this->_token + (1 + 20), 4);

--- a/iocore/net/quic/QUICTypes.h
+++ b/iocore/net/quic/QUICTypes.h
@@ -373,7 +373,7 @@ public:
   bool is_valid(const IpEndpoint &src) const;
 
   const QUICConnectionId cid() const;
-  const ink_hrtime expire_time() const;
+  ink_hrtime expire_time() const;
 };
 
 class QUICRetryToken : public QUICAddressValidationToken

--- a/plugins/experimental/ssl_session_reuse/src/connection.h
+++ b/plugins/experimental/ssl_session_reuse/src/connection.h
@@ -55,7 +55,7 @@ public:
    * management.
    * @return
    */
-  inline redisContext *const
+  inline redisContext *
   c_ptr() const
   {
     return c;


### PR DESCRIPTION
```
The 'const' modifier has no effect on return types. The 'const' modifying the return type can be removed.
```
https://lgtm.com/projects/g/apache/trafficserver/?mode=tree&ruleFocus=2157860314
https://lgtm.com/projects/g/apache/trafficserver/?mode=tree&ruleFocus=2156200647