### PR TITLE
Fix the Proxy Verifier AuTest extension to handle cert paths correctly

### DIFF
--- a/tests/gold_tests/autest-site/verifier_client.test.ext
+++ b/tests/gold_tests/autest-site/verifier_client.test.ext
@@ -78,10 +78,8 @@ def _configure_client(obj, process, name, replay_path, http_ports=None,
                 raise ValueError("Tried to use '{}' for --client-cert, but it is not "
                                  "a valid file.".format(ssl_cert))
         if ssl_cert:
-            run_ssl_cert = ssl_cert
-            if os.path.isfile(ssl_cert):
-                run_ssl_cert = os.path.join(client_dir, os.path.basename(ssl_cert))
-                process.Setup.Copy(ssl_cert, run_ssl_cert, CopyLogic.SoftFiles)
+            run_ssl_cert = os.path.join(client_dir, os.path.basename(ssl_cert))
+            process.Setup.Copy(ssl_cert, run_ssl_cert, CopyLogic.SoftFiles)
             command += ' --client-cert "{}" '.format(run_ssl_cert)
 
         if ca_cert == '':
@@ -92,10 +90,8 @@ def _configure_client(obj, process, name, replay_path, http_ports=None,
                 raise ValueError("Tried to use '{}' for --ca-certs, but it is not "
                                  "a valid file.".format(ca_cert))
         if ca_cert:
-            run_ca_cert = ca_cert
-            if os.path.isfile(ca_cert):
-                run_ca_cert = os.path.join(client_dir, os.path.basename(ca_cert))
-                process.Setup.Copy(ca_cert, run_ca_cert, CopyLogic.SoftFiles)
+            run_ca_cert = os.path.join(client_dir, os.path.basename(ca_cert))
+            process.Setup.Copy(ca_cert, run_ca_cert, CopyLogic.SoftFiles)
             command += ' --ca-certs "{}" '.format(run_ca_cert)
 
     if other_args:

--- a/tests/gold_tests/autest-site/verifier_server.test.ext
+++ b/tests/gold_tests/autest-site/verifier_server.test.ext
@@ -78,10 +78,8 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
                 raise ValueError("Tried to use '{}' for --server-cert, but it is not "
                                  "a valid file.".format(ssl_cert))
         if ssl_cert:
-            run_ssl_cert = ssl_cert
-            if os.path.isfile(ssl_cert):
-                run_ssl_cert = os.path.join(server_dir, os.path.basename(ssl_cert))
-                process.Setup.Copy(ssl_cert, run_ssl_cert, CopyLogic.SoftFiles)
+            run_ssl_cert = os.path.join(server_dir, os.path.basename(ssl_cert))
+            process.Setup.Copy(ssl_cert, run_ssl_cert, CopyLogic.SoftFiles)
             command += ' --server-cert "{}" '.format(run_ssl_cert)
 
         if ca_cert == '':
@@ -92,10 +90,8 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
                 raise ValueError("Tried to use '{}' for --ca-certs, but it is not "
                                  "a valid file.".format(ca_cert))
         if ca_cert:
-            run_ca_cert = ca_cert
-            if os.path.isfile(ca_cert):
-                run_ca_cert = os.path.join(server_dir, os.path.basename(ca_cert))
-                process.Setup.Copy(ca_cert, run_ca_cert, CopyLogic.SoftFiles)
+            run_ca_cert = os.path.join(server_dir, os.path.basename(ca_cert))
+            process.Setup.Copy(ca_cert, run_ca_cert, CopyLogic.SoftFiles)
             command += ' --ca-certs "{}" '.format(run_ca_cert)
 
     if replay_path:
@@ -103,6 +99,7 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
         run_replay_path = os.path.join(server_dir, os.path.basename(replay_path))
         process.Setup.Copy(replay_path, run_replay_path, CopyLogic.SoftFiles)
         command += "{} ".format(run_replay_path)
+
     if other_args:
         command += "{} ".format(other_args)
     process.Command = command


### PR DESCRIPTION
None of our current AuTests use Proxy Verifier for TLS connections, but
if they do they'll need this fix to correctly copy down and reference
the needed certs in the Proxy Verifier invocations.