### PR TITLE
Fix parent connect fail segfault

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -380,6 +380,10 @@ response_is_retryable(HttpTransact::State *s, HTTPStatus response_code)
 inline static void
 simple_or_unavailable_server_retry(HttpTransact::State *s)
 {
+  if (!HttpTransact::is_response_valid(s, &s->hdr_info.server_response)) {
+    return; // must return now if the response isn't valid, before calling http_hdr_status_get on uninitialized data
+  }
+
   HTTPStatus server_response = http_hdr_status_get(s->hdr_info.server_response.m_http);
   switch (response_is_retryable(s, server_response)) {
   case PARENT_RETRY_SIMPLE:


### PR DESCRIPTION
Fixes a segfault when a parent connect fails. 

HandleResponse is reading header variables that don't exist on connect fail. This fixes it to not read them if the connect failed. 

Later code doesn't need what this does if the connect fails, this would have returned `PARENT_RETRY_NONE` anyway, since `response_is_retryable` returns false when `!is_response_valid`.

It actually will retry, not in `case PARENT_RETRY:` but in the `default: TxnDebug("http_trans", "[hrfp] connection not alive");` which calls `find_server_and_update_current_info`.

So, I believe this makes the retry work as it should.

I manually tested, and saw a connect-failing parent retry thrice then try the origin, as expected.

Also, this appears to maybe not happen in release builds. I couldn't reproduce. But the segfault happens with debug builds, and looking at the code, it's obvious why. I'm not sure how release builds don't segfault.