### PR TITLE
Fix stall on outbound TLS handshake

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6119,9 +6119,7 @@ HttpSM::attach_server_session(Http1ServerSession *s)
   // first tunnel was sometimes behind handled by the consumer of the
   // first tunnel instead of the producer of the second tunnel.
   // The real read is setup in setup_server_read_response_header()
-  //
-  // Keep the read disabled until setup_server_read_response_header
-  server_entry->read_vio = server_session->do_io_read(this, 0, nullptr);
+  server_entry->read_vio = server_session->do_io_read(this, 0, server_session->read_buffer);
 
   // Transfer control of the write side as well
   server_entry->write_vio = server_session->do_io_write(this, 0, nullptr);


### PR DESCRIPTION
# Summary
I observed outbound TLS handshake is intermittently stall on mater and 9.0.x (almost always on my local box). 

When the stall happened, `SSLNetVConnection::sslClientHandShakeEvent()` was called twice but nothing happened after that until inactive timeout kicks in. These calls come from `write_to_net_io()`.

# Logs
## ATS Debug
```
[Jan 19 09:43:42.921] [ET_NET 4] DEBUG: <HttpSM.cc:1773 (state_http_server_open)> (http) [0] [&HttpSM::state_http_server_open, NET_EVENT_OPEN/TS_EVENT_NET_CONNECT]
[Jan 19 09:43:42.923] [ET_NET 4] DEBUG: <Http1ServerSession.cc:81 (new_connection)> (http_ss) [0] session born, netvc 0x94d8b00
[Jan 19 09:43:42.923] [ET_NET 4] DEBUG: <HttpSM.cc:1824 (state_http_server_open)> (http) [0] setting handler for TCP handshake
[Jan 19 09:43:42.924] [ET_NET 4] DEBUG: <SSLNetVConnection.cc:1138 (sslStartHandShake)> (ssl) using SNI name 'localhost' for client handshake
[Jan 19 09:43:42.924] [ET_NET 4] DEBUG: <SSLNetVConnection.cc:1418 (sslClientHandShakeEvent)> (ssl) Initialize outbound connect curHook from NULL
[Jan 19 09:43:42.924] [ET_NET 4] DEBUG: <SSLNetVConnection.cc:1461 (sslClientHandShakeEvent)> (ssl.error) SSL_ERROR_WANT_READ
[Jan 19 09:43:42.924] [ET_NET 4] DEBUG: <SSLNetVConnection.cc:1418 (sslClientHandShakeEvent)> (ssl) Initialize outbound connect curHook from NULL
[Jan 19 09:43:42.924] [ET_NET 4] DEBUG: <SSLNetVConnection.cc:1461 (sslClientHandShakeEvent)> (ssl.error) SSL_ERROR_WANT_READ
```

## Wireshark
```
29	8.599979	127.0.0.1	56211	127.0.0.1	8443	573	Client Hello
31	8.601103	127.0.0.1	8443	127.0.0.1	56211	1458	Server Hello, Change Cipher Spec, Application Data, Application Data, Application Data, Application Data
```

# Route Cause
It looks like `a2d15151a5c1a69a3826e086ac497a94a4bfa7ea` made the read operation for TLS handshake disabled.

```
-  ua_entry->read_vio  = client_vc->do_io_read(this, 0, buffer_reader->mbuf);
+   //  hold onto enabling read until setup_client_read_request_header
+   ua_entry->read_vio  = client_vc->do_io_read(this, 0, nullptr);
```
https://github.com/apache/trafficserver/commit/a2d15151a5c1a69a3826e086ac497a94a4bfa7ea#diff-85a75d910dc93751ef5d568fc20fc73b01bfadac58844e88c7b8e68cedda0f0bL580-R584