### PR TITLE
Cleanup: Remove unused members of NextHopProperty

### DIFF
--- a/iocore/net/P_SSLSNI.h
+++ b/iocore/net/P_SSLSNI.h
@@ -40,14 +40,11 @@
 
 // Properties for the next hop server
 struct NextHopProperty {
-  std::string name;                                                                // name of the server
   std::string client_cert_file;                                                    // full path to client cert file for lookup
   std::string client_key_file;                                                     // full path to client key file for lookup
   YamlSNIConfig::Policy verifyServerPolicy       = YamlSNIConfig::Policy::UNSET;   // whether to verify the next hop
   YamlSNIConfig::Property verifyServerProperties = YamlSNIConfig::Property::UNSET; // what to verify on the next hop
-  bool tls_upstream                              = false;                          // whether the upstream connection should be TLS
 
-  SSL_CTX *ctx = nullptr; // ctx generated off the certificate to present to this server
   NextHopProperty() {}
 };
 

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -101,7 +101,6 @@ SNIConfigParams::loadSNIConfig()
     nps->setGlobName(item.fqdn);
     nps->prop.verifyServerPolicy     = item.verify_server_policy;
     nps->prop.verifyServerProperties = item.verify_server_properties;
-    nps->prop.tls_upstream           = item.tls_upstream;
   } // end for
 }
 


### PR DESCRIPTION
These members are used somewhere?