### PR TITLE
API to retrieve NoStore set by plugins

### DIFF
--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1378,6 +1378,13 @@ tsapi void TSHttpTxnReqCacheableSet(TSHttpTxn txnp, int flag);
 */
 tsapi TSReturnCode TSHttpTxnServerRespNoStoreSet(TSHttpTxn txnp, int flag);
 
+/** Get flag indicating whether or not to cache the server response for
+    given TSHttpTxn
+    @param txnp The transaction whose server response you do not want to store.
+
+    @return TS_SUCCESS.
+*/
+tsapi bool TSHttpTxnServerRespNoStoreGet(TSHttpTxn txnp);
 tsapi TSReturnCode TSFetchPageRespGet(TSHttpTxn txnp, TSMBuffer *bufp, TSMLoc *offset);
 tsapi char *TSFetchRespGet(TSHttpTxn txnp, int *length);
 tsapi TSReturnCode TSHttpTxnCacheLookupStatusGet(TSHttpTxn txnp, int *lookup_status);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5596,6 +5596,15 @@ TSHttpTxnServerRespNoStoreSet(TSHttpTxn txnp, int flag)
   return TS_SUCCESS;
 }
 
+bool
+TSHttpTxnServerRespNoStoreGet(TSHttpTxn txnp)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  HttpTransact::State *s = &(((HttpSM *)txnp)->t_state);
+  return s->api_server_response_no_store;
+}
+
 TSReturnCode
 TSHttpTxnServerRespIgnore(TSHttpTxn txnp)
 {


### PR DESCRIPTION
A plugin can use TSHttpTxnServerRespNoStoreSet to make ATS not cache the Origin Server's response. Traffic Server does the right thing using the flag api_server_response_no_store, but there is no API to 'get' this flag for other plugins to use it. This PR provides 'GetAPI' for the flag set by TSHttpTxnServerRespNoStoreSet.