### PR TITLE
Change squid log code for self looping

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6542,6 +6542,7 @@ HttpTransact::will_this_request_self_loop(State *s)
         TxnDebug("http_transact", "unknown's ip and port same as local ip and port - bailing");
         break;
       }
+      SET_VIA_STRING(VIA_ERROR_TYPE, VIA_ERROR_LOOP_DETECTED);
       build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Cycle Detected", "request#cycle_detected");
       return true;
     }


### PR DESCRIPTION
Switching from ERR_INVALID_REQ to ERR_LOOP_DETECTED when a loop is detected.  It is also possible that even if the via would match the ip and port match would happen before and not set the correct squid log code.  The change that made this happen is in #7069.

Before the change:
```
1611604780.208 0 127.0.0.1 ERR_INVALID_REQ/400 556 GET http://127.0.0.1:8080/hello - NONE/127.0.0.1 text/html
1611604780.746 1 127.0.0.1 ERR_INVALID_REQ/400 556 GET http://127.0.0.1:8080/hello - NONE/127.0.0.1 text/html
1611604781.252 0 127.0.0.1 ERR_INVALID_REQ/400 556 GET http://127.0.0.1:8080/hello - NONE/127.0.0.1 text/html

```
After the change:
```
1611604704.686 2 127.0.0.1 ERR_LOOP_DETECTED/400 556 GET http://127.0.0.1:8080/hello - NONE/127.0.0.1 text/html
1611604717.118 0 127.0.0.1 ERR_LOOP_DETECTED/400 556 GET http://127.0.0.1:8080/hello - NONE/127.0.0.1 text/html
1611604718.410 0 127.0.0.1 ERR_LOOP_DETECTED/400 556 GET http://127.0.0.1:8080/hello - NONE/127.0.0.1 text/html
```