### PR TITLE
Use OpenSSL EVP API if SHA1 API is not available (cache_promote)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1302,6 +1302,7 @@ AC_CHECK_FUNCS([ \
   HMAC_CTX_new \
   X509_get0_signature \
   ERR_get_error_all \
+  SHA1 \
 ])
 
 AC_CHECK_FUNC([ASN1_STRING_get0_data], [],

--- a/plugins/cache_promote/lru_policy.h
+++ b/plugins/cache_promote/lru_policy.h
@@ -17,7 +17,12 @@
 */
 #pragma once
 
+#include "tscore/ink_defs.h"
+
 #include <openssl/sha.h>
+#ifndef HAVE_SHA1
+#include <openssl/evp.h>
+#endif
 #include <cstring>
 #include <unordered_map>
 #include <list>


### PR DESCRIPTION
https://www.openssl.org/docs/manmaster/man3/SHA1_Init.html

> All of the functions described on this page are deprecated. Applications should instead use EVP_DigestInit_ex(3), EVP_DigestUpdate(3) and EVP_DigestFinal_ex(3).