### PR TITLE
Use EVP API instead of legacy APIs (s3 auth)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1309,6 +1309,7 @@ AC_CHECK_FUNCS([ \
   BIO_sock_non_fatal_error \
   CRYPTO_set_mem_functions \
   HMAC_CTX_new \
+  EVP_MAC_CTX_new \
   X509_get0_signature \
   ERR_get_error_all \
 ])

--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -307,8 +307,8 @@ getPayloadSha256(bool signPayload)
     return UNSIGNED_PAYLOAD;
   }
 
-  unsigned char payloadHash[SHA256_DIGEST_LENGTH];
-  EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+  unsigned char payloadHash[SHA256_DIGEST_LENGTH] = {0};
+  EVP_MD_CTX *ctx                                 = EVP_MD_CTX_new();
   if (EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr)) {
     EVP_DigestUpdate(ctx, reinterpret_cast<const unsigned char *>(""), 0); /* empty content */
     EVP_DigestFinal_ex(ctx, payloadHash, nullptr);

--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -22,21 +22,24 @@
  * @see aws_auth_v4.h
  */
 
-#include <cstring>              /* strlen() */
-#include <string>               /* stoi() */
-#include <ctime>                /* strftime(), time(), gmtime_r() */
-#include <iomanip>              /* std::setw */
-#include <sstream>              /* std::stringstream */
-#include <openssl/sha.h>        /* SHA256_DIGEST_LENGTH */
-#include <openssl/evp.h>        /* EVP_DigestInit_ex, etc.*/
-#include <openssl/hmac.h>       /* HMAC() */
+#include <cstring> /* strlen() */
+#include <string>  /* stoi() */
+#include <ctime>   /* strftime(), time(), gmtime_r() */
+#include <iomanip> /* std::setw */
+#include <sstream> /* std::stringstream */
+
+#include "tscore/ink_config.h"
+
+#include <openssl/sha.h>  /* SHA256_DIGEST_LENGTH */
+#include <openssl/evp.h>  /* EVP_DigestInit_ex, etc.*/
+#include <openssl/hmac.h> /* HMAC() */
+#if defined(HAVE_EVP_MAC_CTX_NEW)
 #include <openssl/core_names.h> /* OSSL_MAC_PARAM_KEY, etc.  */
+#endif
 
 #ifdef AWS_AUTH_V4_DETAILED_DEBUG_OUTPUT
 #include <iostream>
 #endif
-
-#include "tscore/ink_config.h"
 
 #include "aws_auth_v4.h"
 

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -34,13 +34,16 @@
 #include <string>
 #include <unordered_map>
 
+#include "tscore/ink_config.h"
+
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
+#if defined(HAVE_EVP_MAC_CTX_NEW)
 #include <openssl/core_names.h>
+#endif
 
 #include <ts/ts.h>
 #include <ts/remap.h>
-#include "tscore/ink_config.h"
 
 #include "aws_auth_v4.h"
 


### PR DESCRIPTION
https://www.openssl.org/docs/manmaster/man3/SHA256_Init.html
https://www.openssl.org/docs/manmaster/man3/HMAC_Init_ex.html

SHA256 API and HMAC API are going to be deprecated.