### PR TITLE
Move reopen_moved_log_files to log flushing thread

### DIFF
--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -206,15 +206,16 @@ public:
   // reconfiguration stuff
   static void change_configuration();
 
+  static int handle_logging_mode_change(const char *name, RecDataT data_type, RecData data, void *cookie);
+  static int handle_periodic_tasks_int_change(const char *name, RecDataT data_type, RecData data, void *cookie);
+
   /** Check each log file path to see whether it exists and re-open if not.
    *
    * This is called when an external log rotation entity has moved log files to
    * rolled names. This checks whether the original log file exists and, if
    * not, closes the file descriptor and re-opens the file.
    */
-  static void reopen_moved_log_files();
-  static int handle_logging_mode_change(const char *name, RecDataT data_type, RecData data, void *cookie);
-  static int handle_periodic_tasks_int_change(const char *name, RecDataT data_type, RecData data, void *cookie);
+  static int handle_log_rotation_request();
 
   friend void RegressionTest_LogObjectManager_Transfer(RegressionTest *, int, int *);
 
@@ -226,6 +227,7 @@ private:
   static int init_status;
   static int config_flags;
   static bool logging_mode_changed;
+  static bool log_rotate_signal_received;
   static uint32_t periodic_tasks_interval;
 };
 

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -290,7 +290,7 @@ public:
         Note("Could not reseat %s", DIAGS_LOG_FILENAME);
       }
       // Reload any of the other moved log files (such as the ones in logging.yaml).
-      Log::reopen_moved_log_files();
+      Log::handle_log_rotation_request();
     }
 
     if (signal_received[SIGTERM] || signal_received[SIGINT]) {

--- a/tests/gold_tests/logging/sigusr2.test.py
+++ b/tests/gold_tests/logging/sigusr2.test.py
@@ -43,6 +43,7 @@ class Sigusr2Test:
             'proxy.config.http.wait_for_cache': 1,
             'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': 'log',
+            'proxy.config.log.periodic_tasks_interval': 1,
 
             # All log rotation should be handled externally.
             'proxy.config.log.rolling_enabled': 0,


### PR DESCRIPTION
The handling of the log rotation signal was locking against the periodic
flushing thread. This moves the log rotation handling logic into the
same flushing thread so they will not lock against each other.