### PR TITLE
Reduce overhead incurred by enabling debug output.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3158,6 +3158,10 @@ Diagnostic Logging Configuration
 
    When set to 2, interprets the :ts:cv:`proxy.config.diags.debug.client_ip` setting determine whether diagnostic messages are logged.
 
+   When set to 3, enables logging for diagnostic messages whose log level is `diag` or `debug`, except those
+   output by deprecated functions such as `TSDebug()` and `TSDebugSpecific()`.  Using the value 3 will have less
+   of a negative impact on proxy throughput than using the value 1.
+
 .. ts:cv:: CONFIG proxy.config.diags.debug.client_ip STRING NULL
 
    if :ts:cv:`proxy.config.diags.debug.enabled` is set to 2, this value is tested against the source IP of the incoming connection.  If there is a match, all the diagnostic messages for that connection and the related outgoing connection will be logged.

--- a/doc/developer-guide/api/functions/TSDebug.en.rst
+++ b/doc/developer-guide/api/functions/TSDebug.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: c
 
-TSDebug
-*******
+TSDbg
+*****
 
 Traffic Server Debugging APIs.
 
@@ -37,7 +37,11 @@ Synopsis
 .. function:: void TSFatal(const char * format, ...)
 .. function:: void TSAlert(const char * format, ...)
 .. function:: void TSEmergency(const char * format, ...)
+.. type:: TSDbgCtl
+.. function:: void TSDbg(const TSDbgCtl * ctlptr, const char * format, ...)
+.. function:: const TSDbgCtl * TSDbgCtlCreate(const char * tag)
 .. function:: void TSDebug(const char * tag, const char * format, ...)
+.. function:: int TSIsDbgCtlSet(const TSDbgCtl * ctlptr)
 .. function:: int TSIsDebugTagSet(const char * tag)
 .. function:: void TSDebugSpecific(int debug_flag, const char * tag, const char * format, ...)
 .. function:: void TSHttpTxnDebugSet(TSHttpTxn txnp, int on)
@@ -76,10 +80,19 @@ Traffic Server, Traffic Manager, AuTest, CI, and your log monitoring service/das
 trafficserver.out
 =================
 
-:func:`TSDebug` logs the debug message only if the given debug :arg:`tag` is enabled.
+:func:`TSDbg` logs the debug message only if the given debug control pointed to by
+:arg:`ctlptr` is enabled.  It writes output to the Traffic Server debug log through stderr.
+
+:func:`TSDbgCtlCreate` creates a debug control, associated with the
+debug :arg:`tag`, and returns a const pointer to it.
+
+:func:`TSIsDbgCtlSet` returns non-zero if the given debug control, pointed to by :arg:`ctlptr`, is
+enabled.
+
+:func:`TSDebug` (deprecated) logs the debug message only if the given debug :arg:`tag` is enabled.
 It writes output to the Traffic Server debug log through stderr.
 
-:func:`TSIsDebugTagSet` returns non-zero if the given debug :arg:`tag` is
+:func:`TSIsDebugTagSet` (deprecated) returns non-zero if the given debug :arg:`tag` is
 enabled.
 
 In debug mode, :macro:`TSAssert` Traffic Server to prints the file

--- a/doc/developer-guide/debugging/debug-tags.en.rst
+++ b/doc/developer-guide/debugging/debug-tags.en.rst
@@ -22,15 +22,33 @@
 Debug Tags
 **********
 
-Use the API
-``void TSDebug (const char *tag, const char *format_str, ...)`` to add
-traces in your plugin. In this API:
+Use the API macro
+``TSDbg(ctlptr, const char *format_str, ...)`` to add
+traces in your plugin. In this macro:
+
+-  ``ctlptr`` is the Traffic Server parameter that enables Traffic Server
+   to print out ``format_str``.  It is returned by ``TSDbgCtlCreate()``.
+
+-  ``...`` are variables for ``format_str`` in the standard ``printf``
+   style.
+
+``void TSDbgCtlCreate (const char *tag)`` returns a (const) pointer to
+``TSDbgCtl``.  The ``TSDbgCtl`` control is enabled when debug output is
+enabled globally by configuaration, and ``tag`` matches a configured
+regular expression.
+
+The deprecated API
+``void TSDebug (const char *tag, const char *format_str, ...)`` also
+outputs traces.  In this API:
 
 -  ``tag`` is the Traffic Server parameter that enables Traffic Server
-   to print out *``format_str``*
+   to print out ``format_str``
 
--  ``...`` are variables for *``format_str``* in the standard ``printf``
+-  ``...`` are variables for ``format_str`` in the standard ``printf``
    style.
+
+Use of ``TSDebug()`` causes trace output to have a more negative impact
+on proxy throughput.
 
 Run Traffic Server with the ``-Ttag`` option. For example, if the tag is
 ``my-plugin``, then the debug output goes to ``traffic.out.``\ See
@@ -40,7 +58,7 @@ below:
 
        traffic_server -T"my-plugin"
 
-Set the following variables in :file:`records.config` (in the Traffic Server
+Sets the following variables in :file:`records.config` (in the Traffic Server
 ``config`` directory):
 
 ::
@@ -48,13 +66,22 @@ Set the following variables in :file:`records.config` (in the Traffic Server
        CONFIG proxy.config.diags.debug.enabled INT 1
        CONFIG proxy.config.diags.debug.tags STRING debug-tag-name
 
+(Performance will be better if ``enabled`` is set to 3 rather than 1, but,
+using 3, output from ``TSDebug()`` will not be enabled, only from ``TSDbg()``.)
 In this case, debug output goes to ``traffic.out``.
 
 Example:
 
 .. code-block:: c
 
-       TSDebug ("my-plugin", "Starting my-plugin at %d", the_time);
+       static TSDbgCtl const *my_dbg_ctl; // Non-local variable.
+       ...
+       my_dbg_ctl = TSDbgCtlCreate("my-plugin"); // In TSPluginInit() or TSRemapInit().
+       ...
+       TSDbg(my_dbg_ctl, "Starting my-plugin at %d", the_time);
+       ...
+       TSDbg(my_dbg_ctl, "Later on in my-plugin");
+
 
 The statement ``"Starting my-plugin at <time>"`` appears whenever you
 run Traffic Server with the ``my-plugin`` tag:
@@ -62,6 +89,16 @@ run Traffic Server with the ``my-plugin`` tag:
 ::
 
        traffic_server -T"my-plugin"
+
+If your plugin is a C++ plugin, the above example can be written as:
+
+.. code-block:: cpp
+
+       static auto my_dbg_ctl = TSDbgCtlCreate("my-plugin"); // Non-local variable.
+       ...
+       TSDbg(my_dbg_ctl, "Starting my-plugin at %d", the_time);
+       ...
+       TSDbg(my_dbg_ctl, "Later on in my-plugin");
 
 Other Useful Internal Debug Tags
 ================================
@@ -71,7 +108,7 @@ internal debugging purposes. These can also be used to follow Traffic
 Server behavior for testing and analysis.
 
 The debug tag setting (``-T`` and ``proxy.config.diags.debug.tags``) is a
-anchored regular expression against which the tag for a specific debug
+anchored regular expression (PCRE) against which the tag for a specific debug
 message is matched. This means the value "http" matches debug messages
 with the tag "http" but also "http\_seq" and "http\_trans". If you want
 multiple tags then use a pipe symbol to separate the tags. For example

--- a/doc/developer-guide/plugins/plugin-interfaces.en.rst
+++ b/doc/developer-guide/plugins/plugin-interfaces.en.rst
@@ -122,14 +122,15 @@ The thread functions are listed below:
 Debugging Functions
 ===================
 
--  :c:func:`TSDebug`
-   prints out a formatted statement if you are running Traffic Server in
-   debug mode.
+-  :c:func:`TSDbg`
+   (replaces deprecated :c:func:`TSDebug`) prints out a formatted
+   statement if you are running Traffic Server in debug mode.
 
--  :c:func:`TSIsDebugTagSet`
-   checks to see if a debug tag is set. If the debug tag is set, then
-   Traffic Server prints out all debug statements associated with the
-   tag.
+-  :c:func:`TSIsDbgCtlSet`
+   (replaces deprecated :c:func:`TSIsDebugTagSet`)
+   checks to see if a debug control (associated with a debug tag) is
+   set. If the debug tag is set, then Traffic Server prints out all
+   debug statements associated with the control.
 
 -  :c:func:`TSError`
    prints error messages to Traffic Server's error log

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -974,6 +974,11 @@ typedef struct TSSslSessionID_s {
   char bytes[TS_SSL_MAX_SSL_SESSION_ID_LENGTH];
 } TSSslSessionID;
 
+typedef struct TSDbgCtl_s {
+  char volatile on; // Flag
+  char const *tag;
+} TSDbgCtl;
+
 /* --------------------------------------------------------------------------
    Init */
 

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2145,10 +2145,39 @@ tsapi void TSDebug(const char *tag, const char *format_str, ...) TS_PRINTFLIKE(2
     @param ... Format arguments.
  */
 tsapi void TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...) TS_PRINTFLIKE(3, 4);
-extern int diags_on_for_plugins;
+extern int diags_on_for_plugins; /* Do not use directly. */
 #define TSDEBUG             \
   if (diags_on_for_plugins) \
   TSDebug
+
+extern char ts_new_debug_on_flag_; /* Do not use directly. */
+
+#define TSIsDbgCtlSet(ctlp__) (ts_new_debug_on_flag_ && ctlp__->on)
+
+/**
+    Output a debug line if the debug output control is turned on.
+
+    @param ctlp pointer to TSDbgCtl, returned by TSDbgCtlCreate().
+    @param ...  Format string and (optional) arguments.
+ */
+#define TSDbg(ctlp, ...)              \
+  do {                                \
+    if (TSIsDbgCtlSet(ctlp)) {        \
+      _TSDbg(ctlp->tag, __VA_ARGS__); \
+    }                                 \
+  } while (0)
+
+/**
+    Return a pointer for use with TSDbg().  For good performance,
+    this should be called in TSPluginInit() or TSRemapInit(), or in
+    static initialization in C++ (with the result stored in a
+    static pointer) for good performance.
+
+    @param tag Debug tag for the control.
+ */
+tsapi TSDbgCtl const *TSDbgCtlCreate(char const *tag);
+
+void _TSDbg(const char *tag, const char *format_str, ...) TS_PRINTFLIKE(2, 3); /* Not for direct use. */
 
 /* --------------------------------------------------------------------------
    logging api */

--- a/include/tscore/DbgCtl.h
+++ b/include/tscore/DbgCtl.h
@@ -1,0 +1,56 @@
+/** @file
+
+  DbgCtl class header file.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <ts/ts.h>
+
+// For use with TSDbg().
+//
+class DbgCtl
+{
+public:
+  // Tag is a debug tag.  Debug output associated with this control will be output when debug output
+  // is enabled globally, and the tag matches the configured debug tag regular expression.
+  //
+  DbgCtl(char const *tag) : _ptr(_get_ptr(tag)) {}
+
+  TSDbgCtl const *
+  ptr() const
+  {
+    return _ptr;
+  }
+
+  // Call this when the compiled regex to enable tags may have changed.
+  //
+  static void update();
+
+private:
+  TSDbgCtl const *const _ptr;
+
+  static const TSDbgCtl *_get_ptr(char const *tag);
+
+  class _RegistryAccessor;
+
+  friend TSDbgCtl const *TSDbgCtlCreate(char const *tag);
+};

--- a/include/tscore/LogMessage.h
+++ b/include/tscore/LogMessage.h
@@ -61,7 +61,6 @@ public:
 
   /* TODO: Add BufferWriter overloads for these. */
   void diag(const char *tag, SourceLocation const &loc, const char *fmt, ...);
-  void debug(const char *tag, SourceLocation const &loc, const char *fmt, ...);
   void status(SourceLocation const &loc, const char *fmt, ...);
   void note(SourceLocation const &loc, const char *fmt, ...);
   void warning(SourceLocation const &loc, const char *fmt, ...);

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -42,10 +42,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "*" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("cache.*|agg.*|locks", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "*" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("cache.*|agg.*|locks", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     mime_init();
     Layout::create();

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -304,14 +304,14 @@ inline void
 UnixNetVConnection::set_remote_addr()
 {
   ats_ip_copy(&remote_addr, &con.addr);
-  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags->test_override_ip(remote_addr));
+  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags()->test_override_ip(remote_addr));
 }
 
 inline void
 UnixNetVConnection::set_remote_addr(const sockaddr *new_sa)
 {
   ats_ip_copy(&remote_addr, new_sa);
-  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags->test_override_ip(remote_addr));
+  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags()->test_override_ip(remote_addr));
 }
 
 inline void

--- a/iocore/net/SSLDiags.cc
+++ b/iocore/net/SSLDiags.cc
@@ -29,6 +29,8 @@
 #include "SSLStats.h"
 #include "P_SSLNetVConnection.h"
 
+static DbgCtl ssl_diags_dbg_ctl{"ssl-diag"};
+
 // return true if we have a stat for the error
 static bool
 increment_ssl_client_error(unsigned long err)
@@ -145,15 +147,15 @@ SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc, cons
   while ((l = ERR_get_error_line_data(&file, &line, &data, &flags)) != 0) {
 #endif
     if (debug) {
-      if (unlikely(diags->on())) {
-        diags->log("ssl-diag", DL_Debug, &loc, "SSL::%lu:%s:%s:%d%s%s%s%s", es, ERR_error_string(l, buf), file, line,
-                   (flags & ERR_TXT_STRING) ? ":" : "", (flags & ERR_TXT_STRING) ? data : "", vc ? ": peer address is " : "",
-                   ip_buf);
+      if (unlikely(diags()->on())) {
+        diags()->log(ssl_diags_dbg_ctl, DL_Debug, &loc, "SSL::%lu:%s:%s:%d%s%s%s%s", es, ERR_error_string(l, buf), file, line,
+                     (flags & ERR_TXT_STRING) ? ":" : "", (flags & ERR_TXT_STRING) ? data : "", vc ? ": peer address is " : "",
+                     ip_buf);
       }
     } else {
-      diags->error(DL_Error, &loc, "SSL::%lu:%s:%s:%d%s%s%s%s", es, ERR_error_string(l, buf), file, line,
-                   (flags & ERR_TXT_STRING) ? ":" : "", (flags & ERR_TXT_STRING) ? data : "", vc ? ": peer address is " : "",
-                   ip_buf);
+      diags()->error(DL_Error, &loc, "SSL::%lu:%s:%s:%d%s%s%s%s", es, ERR_error_string(l, buf), file, line,
+                     (flags & ERR_TXT_STRING) ? ":" : "", (flags & ERR_TXT_STRING) ? data : "", vc ? ": peer address is " : "",
+                     ip_buf);
     }
 
     // Tally desired stats (only client/server connection stats, not init
@@ -170,9 +172,9 @@ SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc, cons
 
   va_start(ap, fmt);
   if (debug) {
-    diags->log_va("ssl-diag", DL_Debug, &loc, fmt, ap);
+    diags()->log_va(ssl_diags_dbg_ctl, DL_Debug, &loc, fmt, ap);
   } else {
-    diags->error_va(DL_Error, &loc, fmt, ap);
+    diags()->error_va(DL_Error, &loc, fmt, ap);
   }
   va_end(ap);
 }
@@ -192,15 +194,13 @@ SSLErrorName(int ssl_error)
 }
 
 void
-SSLDebugBufferPrint(const char *tag, const char *buffer, unsigned buflen, const char *message)
+SSLDebugBufferPrint_(const char *buffer, unsigned buflen, const char *message)
 {
-  if (is_debug_tag_set(tag)) {
-    if (message != nullptr) {
-      fprintf(stdout, "%s\n", message);
-    }
-    for (unsigned ii = 0; ii < buflen; ii++) {
-      putc(buffer[ii], stdout);
-    }
-    putc('\n', stdout);
+  if (message != nullptr) {
+    fprintf(stdout, "%s\n", message);
   }
+  for (unsigned ii = 0; ii < buflen; ii++) {
+    putc(buffer[ii], stdout);
+  }
+  putc('\n', stdout);
 }

--- a/iocore/net/SSLDiags.h
+++ b/iocore/net/SSLDiags.h
@@ -39,5 +39,11 @@ void SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc,
 // Return a static string name for a SSL_ERROR constant.
 const char *SSLErrorName(int ssl_error);
 
-// Log a SSL network buffer.
-void SSLDebugBufferPrint(const char *tag, const char *buffer, unsigned buflen, const char *message);
+// Log a SSL network buffer.  tag__ must be a C-string literal debug tag.
+#define SSLDebugBufferPrint(tag__, buffer__, buffer_len__, message__) \
+  do {                                                                \
+    if (is_debug_tag_set(tag__))                                      \
+      SSLDebugBufferPrint_(buffer__, buffer_len__, message__);        \
+  } while (0)
+
+void SSLDebugBufferPrint_(const char *buffer, unsigned buflen, const char *message);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -83,6 +83,8 @@ static constexpr std::string_view SSL_KEY_DIALOG("ssl_key_dialog"sv);
 static constexpr std::string_view SSL_SERVERNAME("dest_fqdn"sv);
 static constexpr char SSL_CERT_SEPARATE_DELIM = ',';
 
+DbgCtl ssl_ssn_cache_dbg_ctl("ssl.session_cache");
+
 #ifndef evp_md_func
 #ifdef OPENSSL_NO_SHA256
 #define evp_md_func EVP_sha1()
@@ -202,7 +204,7 @@ ssl_new_cached_session(SSL *ssl, SSL_SESSION *sess)
 
   SSLSessionID sid(id, len);
 
-  if (diags->tag_activated("ssl.session_cache")) {
+  if (ssl_ssn_cache_dbg_ctl.ptr()->on) {
     char printable_buf[(len * 2) + 1];
 
     sid.toString(printable_buf, sizeof(printable_buf));
@@ -242,7 +244,7 @@ ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess)
     hook = hook->m_link.next;
   }
 
-  if (diags->tag_activated("ssl.session_cache")) {
+  if (ssl_ssn_cache_dbg_ctl.ptr()->on) {
     char printable_buf[(len * 2) + 1];
     sid.toString(printable_buf, sizeof(printable_buf));
     Debug("ssl.session_cache.remove", "ssl_rm_cached_session cached session '%s'", printable_buf);

--- a/iocore/net/TLSSessionResumptionSupport.cc
+++ b/iocore/net/TLSSessionResumptionSupport.cc
@@ -134,7 +134,8 @@ TLSSessionResumptionSupport::getSession(SSL *ssl, const unsigned char *id, int l
   SSLSessionID sid(id, len);
 
   *copy = 0;
-  if (diags->tag_activated("ssl.session_cache")) {
+  static DbgCtl ctl("ssl.session_cache");
+  if (ctl.ptr()->on) {
     char printable_buf[(len * 2) + 1];
     sid.toString(printable_buf, sizeof(printable_buf));
     Debug("ssl.session_cache.get", "ssl_get_cached_session cached session '%s' context %p", printable_buf, SSL_get_SSL_CTX(ssl));

--- a/iocore/net/quic/test/event_processor_main.cc
+++ b/iocore/net/quic/test/event_processor_main.cc
@@ -43,10 +43,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/iocore/net/quic/test/main.cc
+++ b/iocore/net/quic/test/main.cc
@@ -40,10 +40,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/iocore/net/test_certlookup.cc
+++ b/iocore/net/test_certlookup.cc
@@ -214,7 +214,7 @@ int
 main(int argc, const char **argv)
 {
   BaseLogFile *blf = new BaseLogFile("stdout");
-  diags            = new Diags("test_certlookup", nullptr, nullptr, blf);
+  DiagsPtr::set(new Diags("test_certlookup", nullptr, nullptr, blf));
   res_track_memory = 1;
 
   SSL_library_init();

--- a/iocore/utils/diags.i
+++ b/iocore/utils/diags.i
@@ -41,13 +41,9 @@ reconfigure_diags()
   DiagsConfigState c;
 
 
-  // initial value set to 0 or 1 based on command line tags
-  c.enabled[DiagsTagType_Debug] = (diags->base_debug_tags != nullptr);
-  c.enabled[DiagsTagType_Action] = (diags->base_action_tags != nullptr);
-
-  c.enabled[DiagsTagType_Debug] = 1;
-  c.enabled[DiagsTagType_Action] = 1;
-  diags->show_location = SHOW_LOCATION_ALL;
+  c.enabled(DiagsTagType_Debug, 1);
+  c.enabled(DiagsTagType_Action, 1);
+  diags()->show_location = SHOW_LOCATION_ALL;
 
 
   // read output routing values
@@ -62,27 +58,27 @@ reconfigure_diags()
   // clear out old tag tables //
   //////////////////////////////
 
-  diags->deactivate_all(DiagsTagType_Debug);
-  diags->deactivate_all(DiagsTagType_Action);
+  diags()->deactivate_all(DiagsTagType_Debug);
+  diags()->deactivate_all(DiagsTagType_Action);
 
   //////////////////////////////////////////////////////////////////////
   //                     add new tag tables
   //////////////////////////////////////////////////////////////////////
 
-  if (diags->base_debug_tags) {
-    diags->activate_taglist(diags->base_debug_tags, DiagsTagType_Debug);
+  if (diags()->base_debug_tags) {
+    diags()->activate_taglist(diags()->base_debug_tags, DiagsTagType_Debug);
 }
-  if (diags->base_action_tags) {
-    diags->activate_taglist(diags->base_action_tags, DiagsTagType_Action);
+  if (diags()->base_action_tags) {
+    diags()->activate_taglist(diags()->base_action_tags, DiagsTagType_Action);
 }
 
 ////////////////////////////////////
 // change the diags config values //
 ////////////////////////////////////
 #if !defined(__GNUC__) && !defined(hpux)
-  diags->config = c;
+  diags()->config = c;
 #else
-  memcpy(((void *)&diags->config), ((void *)&c), sizeof(DiagsConfigState));
+  memcpy(((void *)&diags()->config), ((void *)&c), sizeof(DiagsConfigState));
 #endif
 }
 
@@ -93,7 +89,7 @@ init_diags(const char *bdt, const char *bat)
   char diags_logpath[500];
   strcpy(diags_logpath, DIAGS_LOG_FILE);
 
-  diags = new Diags("test", bdt, bat, new BaseLogFile(diags_logpath));
+  DiagsPtr::set(new Diags("test", bdt, bat, new BaseLogFile(diags_logpath)));
   Status("opened %s", diags_logpath);
 
   reconfigure_diags();

--- a/lib/records/test_I_RecLocal.cc
+++ b/lib/records/test_I_RecLocal.cc
@@ -27,7 +27,12 @@
 
 #include "P_RecCore.h"
 
-Diags *diags = nullptr;
+void
+DiagsPtr::set(Diags *new_ptr)
+{
+  _diags_ptr = new_ptr;
+}
+
 void RecDumpRecordsHt(RecT rec_type);
 
 //-------------------------------------------------------------------------
@@ -179,9 +184,9 @@ main(int argc, char **argv)
       log_fp = nullptr;
     }
   }
-  diags = new Diags("rec", nullptr, log_fp);
-  diags->activate_taglist(diags->base_debug_tags, DiagsTagType_Debug);
-  diags->log(nullptr, DTA(DL_Note), "Starting '%s'", argv[0]);
+  DiagsPtr::set(new Diags("rec", nullptr, log_fp));
+  diags()->activate_taglist(diags()->base_debug_tags, DiagsTagType_Debug);
+  diags()->log(nullptr, DTA(DL_Note), "Starting '%s'", argv[0]);
 
   // system initialization
   RecLocalInit(diags);

--- a/lib/records/unit_tests/test_RecHttp.cc
+++ b/lib/records/unit_tests/test_RecHttp.cc
@@ -33,7 +33,7 @@ using ts::TextView;
 TEST_CASE("RecHttp", "[librecords][RecHttp]")
 {
   std::vector<HttpProxyPort> ports;
-  CatchDiags *cdiag = static_cast<CatchDiags *>(diags);
+  CatchDiags *cdiag = static_cast<CatchDiags *>(diags());
   cdiag->messages.clear();
 
   SECTION("base")

--- a/lib/records/unit_tests/unit_test_main.cc
+++ b/lib/records/unit_tests/unit_test_main.cc
@@ -33,7 +33,7 @@ int
 main(int argc, char *argv[])
 {
   // Set the global diags variable
-  diags = new CatchDiags;
+  DiagsPtr::set(new CatchDiags);
 
   // Global data initialization needed for the unit tests.
   ts_session_protocol_well_known_name_indices_init();

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -194,7 +194,7 @@ static const RecordElement RecordsConfig[] =
   //#    L  diags.log
   //#
   //##############################################################################
-  {RECT_CONFIG, "proxy.config.diags.debug.enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.diags.debug.enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, "[0-3]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.diags.debug.tags", RECD_STRING, "http|dns", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -46,19 +46,19 @@
  * API Memory Management
  ***************************************************************************/
 void *
-_TSmalloc(unsigned int size, const char * /* path ATS_UNUSED */)
+_TSmalloc(size_t size, const char * /* path ATS_UNUSED */)
 {
   return ats_malloc(size);
 }
 
 void *
-_TSrealloc(void *ptr, unsigned int size, const char * /* path ATS_UNUSED */)
+_TSrealloc(void *ptr, size_t size, const char * /* path ATS_UNUSED */)
 {
   return ats_realloc(ptr, size);
 }
 
 char *
-_TSstrdup(const char *str, int length, const char * /* path ATS_UNUSED */)
+_TSstrdup(const char *str, int64_t length, const char * /* path ATS_UNUSED */)
 {
   return ats_strndup(str, length);
 }

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -234,9 +234,9 @@ typedef void (*TSDisconnectFunc)(void *data);
 #define TSstrndup(p, n) _TSstrdup((p), (n), TS_RES_MEM_PATH)
 #define TSfree(p) _TSfree(p)
 
-tsapi void *_TSmalloc(unsigned int size, const char *path);
-tsapi void *_TSrealloc(void *ptr, unsigned int size, const char *path);
-tsapi char *_TSstrdup(const char *str, int length, const char *path);
+tsapi void *_TSmalloc(size_t size, const char *path);
+tsapi void *_TSrealloc(void *ptr, size_t size, const char *path);
+tsapi char *_TSstrdup(const char *str, int64_t length, const char *path);
 tsapi void _TSfree(void *ptr);
 
 /***************************************************************************

--- a/mgmt/utils/MgmtUtils.cc
+++ b/mgmt/utils/MgmtUtils.cc
@@ -228,7 +228,7 @@ mgmt_log(const char *message_format, ...)
   char extended_format[4096], message[4096];
 
   va_start(ap, message_format);
-  if (diags) {
+  if (diags()) {
     NoteV(message_format, ap);
   } else {
     if (use_syslog) {
@@ -254,7 +254,7 @@ mgmt_elog(const int lerrno, const char *message_format, ...)
 
   va_start(ap, message_format);
 
-  if (diags) {
+  if (diags()) {
     ErrorV(message_format, ap);
     if (lerrno != 0) {
       Error("last system error %d: %s", lerrno, strerror(lerrno));
@@ -288,7 +288,7 @@ mgmt_fatal(const int lerrno, const char *message_format, ...)
 
   va_start(ap, message_format);
 
-  if (diags) {
+  if (diags()) {
     if (lerrno != 0) {
       Error("last system error %d: %s", lerrno, strerror(lerrno));
     }

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -98,6 +98,8 @@ int URL_LEN_MMST;
 // url_CryptoHash_get_fast() does NOT produce the same result as url_CryptoHash_get_general().
 static int url_hash_method = 0;
 
+static DbgCtl http_dbg{"http"};
+
 // test to see if a character is a valid character for a host in a URI according to
 // RFC 3986 and RFC 1034
 inline static int
@@ -1184,7 +1186,7 @@ url_is_strictly_compliant(const char *start, const char *end)
 {
   for (const char *i = start; i < end; ++i) {
     if (!ParseRules::is_uri(*i)) {
-      Debug("http", "Non-RFC compliant character [0x%.2X] found in URL", (unsigned char)*i);
+      Dbg(http_dbg, "Non-RFC compliant character [0x%.2X] found in URL", (unsigned char)*i);
       return false;
     }
   }
@@ -1675,22 +1677,22 @@ url_describe(HdrHeapObjImpl *raw, bool /* recurse ATS_UNUSED */)
 {
   URLImpl *obj = (URLImpl *)raw;
 
-  Debug("http", "[URLTYPE: %d, SWKSIDX: %d,", obj->m_url_type, obj->m_scheme_wks_idx);
-  Debug("http", "\tSCHEME: \"%.*s\", SCHEME_LEN: %d,", obj->m_len_scheme, (obj->m_ptr_scheme ? obj->m_ptr_scheme : "NULL"),
-        obj->m_len_scheme);
-  Debug("http", "\tUSER: \"%.*s\", USER_LEN: %d,", obj->m_len_user, (obj->m_ptr_user ? obj->m_ptr_user : "NULL"), obj->m_len_user);
-  Debug("http", "\tPASSWORD: \"%.*s\", PASSWORD_LEN: %d,", obj->m_len_password,
-        (obj->m_ptr_password ? obj->m_ptr_password : "NULL"), obj->m_len_password);
-  Debug("http", "\tHOST: \"%.*s\", HOST_LEN: %d,", obj->m_len_host, (obj->m_ptr_host ? obj->m_ptr_host : "NULL"), obj->m_len_host);
-  Debug("http", "\tPORT: \"%.*s\", PORT_LEN: %d, PORT_NUM: %d", obj->m_len_port, (obj->m_ptr_port ? obj->m_ptr_port : "NULL"),
-        obj->m_len_port, obj->m_port);
-  Debug("http", "\tPATH: \"%.*s\", PATH_LEN: %d,", obj->m_len_path, (obj->m_ptr_path ? obj->m_ptr_path : "NULL"), obj->m_len_path);
-  Debug("http", "\tPARAMS: \"%.*s\", PARAMS_LEN: %d,", obj->m_len_params, (obj->m_ptr_params ? obj->m_ptr_params : "NULL"),
-        obj->m_len_params);
-  Debug("http", "\tQUERY: \"%.*s\", QUERY_LEN: %d,", obj->m_len_query, (obj->m_ptr_query ? obj->m_ptr_query : "NULL"),
-        obj->m_len_query);
-  Debug("http", "\tFRAGMENT: \"%.*s\", FRAGMENT_LEN: %d]", obj->m_len_fragment,
-        (obj->m_ptr_fragment ? obj->m_ptr_fragment : "NULL"), obj->m_len_fragment);
+  Dbg(http_dbg, "[URLTYPE: %d, SWKSIDX: %d,", obj->m_url_type, obj->m_scheme_wks_idx);
+  Dbg(http_dbg, "\tSCHEME: \"%.*s\", SCHEME_LEN: %d,", obj->m_len_scheme, (obj->m_ptr_scheme ? obj->m_ptr_scheme : "NULL"),
+      obj->m_len_scheme);
+  Dbg(http_dbg, "\tUSER: \"%.*s\", USER_LEN: %d,", obj->m_len_user, (obj->m_ptr_user ? obj->m_ptr_user : "NULL"), obj->m_len_user);
+  Dbg(http_dbg, "\tPASSWORD: \"%.*s\", PASSWORD_LEN: %d,", obj->m_len_password,
+      (obj->m_ptr_password ? obj->m_ptr_password : "NULL"), obj->m_len_password);
+  Dbg(http_dbg, "\tHOST: \"%.*s\", HOST_LEN: %d,", obj->m_len_host, (obj->m_ptr_host ? obj->m_ptr_host : "NULL"), obj->m_len_host);
+  Dbg(http_dbg, "\tPORT: \"%.*s\", PORT_LEN: %d, PORT_NUM: %d", obj->m_len_port, (obj->m_ptr_port ? obj->m_ptr_port : "NULL"),
+      obj->m_len_port, obj->m_port);
+  Dbg(http_dbg, "\tPATH: \"%.*s\", PATH_LEN: %d,", obj->m_len_path, (obj->m_ptr_path ? obj->m_ptr_path : "NULL"), obj->m_len_path);
+  Dbg(http_dbg, "\tPARAMS: \"%.*s\", PARAMS_LEN: %d,", obj->m_len_params, (obj->m_ptr_params ? obj->m_ptr_params : "NULL"),
+      obj->m_len_params);
+  Dbg(http_dbg, "\tQUERY: \"%.*s\", QUERY_LEN: %d,", obj->m_len_query, (obj->m_ptr_query ? obj->m_ptr_query : "NULL"),
+      obj->m_len_query);
+  Dbg(http_dbg, "\tFRAGMENT: \"%.*s\", FRAGMENT_LEN: %d]", obj->m_len_fragment,
+      (obj->m_ptr_fragment ? obj->m_ptr_fragment : "NULL"), obj->m_len_fragment);
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/hdrs/load_http_hdr.cc
+++ b/proxy/hdrs/load_http_hdr.cc
@@ -297,7 +297,7 @@ main(int argc, const char *argv[])
   hdr_type h_type = UNKNOWN_HDR;
 
   http_init();
-  diags = new Diags(NULL, NULL);
+  DiagsPtr::set(new Diags(nullptr, nullptr));
   if (argc != 3) {
     fprintf(stderr, "Usage: %s req|res <file>\n", argv[0]);
     exit(1);

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -47,7 +47,7 @@
 
 #define DUMP_HEADER(T, H, I, S)                                 \
   {                                                             \
-    if (diags->on(T)) {                                         \
+    if (is_debug_tag_set(T)) {                                  \
       fprintf(stderr, "+++++++++ %s +++++++++\n", S);           \
       fprintf(stderr, "-- State Machine Id: %" PRId64 "\n", I); \
       char b[4096];                                             \

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -41,6 +41,8 @@
 
 using namespace std::literals;
 
+static DbgCtl http_trans_dbg{"http_trans"};
+
 bool
 HttpTransactHeaders::is_method_cacheable(const HttpConfigParams *http_config_param, const int method)
 {
@@ -255,7 +257,7 @@ HttpTransactHeaders::convert_request(HTTPVersion outgoing_ver, HTTPHdr *outgoing
   } else if (outgoing_ver == HTTPVersion(1, 1)) {
     convert_to_1_1_request_header(outgoing_request);
   } else {
-    Debug("http_trans", "[HttpTransactHeaders::convert_request]"
+    Dbg(http_trans_dbg, "[HttpTransactHeaders::convert_request]"
                         "Unsupported Version - passing through");
   }
 }
@@ -270,7 +272,7 @@ HttpTransactHeaders::convert_response(HTTPVersion outgoing_ver, HTTPHdr *outgoin
   } else if (outgoing_ver == HTTPVersion(1, 1)) {
     convert_to_1_1_response_header(outgoing_response);
   } else {
-    Debug("http_trans", "[HttpTransactHeaders::convert_response]"
+    Dbg(http_trans_dbg, "[HttpTransactHeaders::convert_response]"
                         "Unsupported Version - passing through");
   }
 }
@@ -922,8 +924,8 @@ HttpTransactHeaders::add_global_user_agent_header_to_request(const OverridableHt
   if (http_txn_conf->global_user_agent_header) {
     MIMEField *ua_field;
 
-    Debug("http_trans", "Adding User-Agent: %.*s", static_cast<int>(http_txn_conf->global_user_agent_header_size),
-          http_txn_conf->global_user_agent_header);
+    Dbg(http_trans_dbg, "Adding User-Agent: %.*s", static_cast<int>(http_txn_conf->global_user_agent_header_size),
+        http_txn_conf->global_user_agent_header);
     if ((ua_field = header->field_find(MIME_FIELD_USER_AGENT, MIME_LEN_USER_AGENT)) == nullptr) {
       if (likely((ua_field = header->field_create(MIME_FIELD_USER_AGENT, MIME_LEN_USER_AGENT)) != nullptr)) {
         header->field_attach(ua_field);
@@ -957,7 +959,7 @@ HttpTransactHeaders::add_forwarded_field_to_request(HttpTransact::State *s, HTTP
       }
 
       if (ats_ip_ntop(&s->client_info.src_addr.sa, hdr.auxBuffer(), hdr.remaining()) == nullptr) {
-        Debug("http_trans", "[add_forwarded_field_to_outgoing_request] ats_ip_ntop() call failed");
+        Dbg(http_trans_dbg, "[add_forwarded_field_to_outgoing_request] ats_ip_ntop() call failed");
         return;
       }
 
@@ -1011,7 +1013,7 @@ HttpTransactHeaders::add_forwarded_field_to_request(HttpTransact::State *s, HTTP
       }
 
       if (ats_ip_ntop(&s->client_info.dst_addr.sa, hdr.auxBuffer(), hdr.remaining()) == nullptr) {
-        Debug("http_trans", "[add_forwarded_field_to_outgoing_request] ats_ip_ntop() call failed");
+        Dbg(http_trans_dbg, "[add_forwarded_field_to_outgoing_request] ats_ip_ntop() call failed");
         return;
       }
 
@@ -1108,8 +1110,8 @@ HttpTransactHeaders::add_forwarded_field_to_request(HttpTransact::State *s, HTTP
       request->value_append(MIME_FIELD_FORWARDED, MIME_LEN_FORWARDED, sV.data(), sV.size(), true, ','); // true => separator must
                                                                                                         // be inserted
 
-      Debug("http_trans", "[add_forwarded_field_to_outgoing_request] Forwarded header (%.*s) added", static_cast<int>(hdr.size()),
-            hdr.data());
+      Dbg(http_trans_dbg, "[add_forwarded_field_to_outgoing_request] Forwarded header (%.*s) added", static_cast<int>(hdr.size()),
+          hdr.data());
     }
   }
 
@@ -1133,7 +1135,7 @@ HttpTransactHeaders::add_server_header_to_response(const OverridableHttpConfigPa
 
     // This will remove any old string (free it), and set our Server header.
     if (do_add && likely(ua_field)) {
-      Debug("http_trans", "Adding Server: %s", http_txn_conf->proxy_response_server_string);
+      Dbg(http_trans_dbg, "Adding Server: %s", http_txn_conf->proxy_response_server_string);
       header->field_value_set(ua_field, http_txn_conf->proxy_response_server_string,
                               http_txn_conf->proxy_response_server_string_len);
     }
@@ -1207,22 +1209,22 @@ HttpTransactHeaders::normalize_accept_encoding(const OverridableHttpConfigParams
         // Force Accept-Encoding header to gzip or no header.
         if (HttpTransactCache::match_content_encoding(ae_field, "gzip")) {
           header->field_value_set(ae_field, "gzip", 4);
-          Debug("http_trans", "[Headers::normalize_accept_encoding] normalized Accept-Encoding to gzip");
+          Dbg(http_trans_dbg, "[Headers::normalize_accept_encoding] normalized Accept-Encoding to gzip");
         } else {
           header->field_delete(ae_field);
-          Debug("http_trans", "[Headers::normalize_accept_encoding] removed non-gzip Accept-Encoding");
+          Dbg(http_trans_dbg, "[Headers::normalize_accept_encoding] removed non-gzip Accept-Encoding");
         }
       } else if (normalize_ae == 2) {
         // Force Accept-Encoding header to br (Brotli) or no header.
         if (HttpTransactCache::match_content_encoding(ae_field, "br")) {
           header->field_value_set(ae_field, "br", 2);
-          Debug("http_trans", "[Headers::normalize_accept_encoding] normalized Accept-Encoding to br");
+          Dbg(http_trans_dbg, "[Headers::normalize_accept_encoding] normalized Accept-Encoding to br");
         } else if (HttpTransactCache::match_content_encoding(ae_field, "gzip")) {
           header->field_value_set(ae_field, "gzip", 4);
-          Debug("http_trans", "[Headers::normalize_accept_encoding] normalized Accept-Encoding to gzip");
+          Dbg(http_trans_dbg, "[Headers::normalize_accept_encoding] normalized Accept-Encoding to gzip");
         } else {
           header->field_delete(ae_field);
-          Debug("http_trans", "[Headers::normalize_accept_encoding] removed non-br Accept-Encoding");
+          Dbg(http_trans_dbg, "[Headers::normalize_accept_encoding] removed non-br Accept-Encoding");
         }
       } else {
         static bool logged = false;

--- a/proxy/http3/test/main.cc
+++ b/proxy/http3/test/main.cc
@@ -39,10 +39,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug], 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/proxy/http3/test/main_qpack.cc
+++ b/proxy/http3/test/main_qpack.cc
@@ -56,10 +56,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("qpack", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DaigsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("qpack", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug], 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/proxy/logging/LogStandalone.cc
+++ b/proxy/logging/LogStandalone.cc
@@ -60,7 +60,6 @@ char error_tags[1024]    = "";
 char action_tags[1024]   = "";
 char command_string[512] = "";
 
-// Diags *diags = NULL;
 DiagsConfig *diagsConfig      = nullptr;
 HttpBodyFactory *body_factory = nullptr;
 AppVersionInfo appVersionInfo;
@@ -104,9 +103,9 @@ initialize_process_manager()
   }
 
   // diags should have been initialized by caller, e.g.: sac.cc
-  ink_assert(diags);
+  ink_assert(diags());
 
-  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags);
+  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags());
   LibRecordsConfigInit();
 
   // Start up manager

--- a/proxy/shared/DiagsConfig.cc
+++ b/proxy/shared/DiagsConfig.cc
@@ -67,20 +67,20 @@ DiagsConfig::reconfigure_diags()
   all_found = true;
 
   // initial value set to 0 or 1 based on command line tags
-  c.enabled[DiagsTagType_Debug]  = (_diags->base_debug_tags != nullptr);
-  c.enabled[DiagsTagType_Action] = (_diags->base_action_tags != nullptr);
+  c.enabled(DiagsTagType_Debug, _diags->base_debug_tags != nullptr ? 1 : 0);
+  c.enabled(DiagsTagType_Action, _diags->base_action_tags != nullptr ? 1 : 0);
 
   // enabled if records.config set
 
   e = static_cast<int>(REC_readInteger("proxy.config.diags.debug.enabled", &found));
   if (e && found) {
-    c.enabled[DiagsTagType_Debug] = e; // implement OR logic
+    c.enabled(DiagsTagType_Debug, e); // implement OR logic
   }
   all_found = all_found && found;
 
   e = static_cast<int>(REC_readInteger("proxy.config.diags.action.enabled", &found));
   if (e && found) {
-    c.enabled[DiagsTagType_Action] = true; // implement OR logic
+    c.enabled(DiagsTagType_Action, 1); // implement OR logic
   }
   all_found = all_found && found;
 
@@ -172,7 +172,7 @@ diags_config_callback(const char * /* name ATS_UNUSED */, RecDataT /* data_type 
   DiagsConfig *diagsConfig;
 
   diagsConfig = static_cast<DiagsConfig *>(opaque_token);
-  ink_assert(::diags->magic == DIAGS_MAGIC);
+  ink_assert(::diags()->magic == DIAGS_MAGIC);
   diagsConfig->reconfigure_diags();
   return (0);
 }
@@ -226,16 +226,16 @@ DiagsConfig::config_diags_norecords()
 
   if (_diags->base_debug_tags) {
     _diags->activate_taglist(_diags->base_debug_tags, DiagsTagType_Debug);
-    c.enabled[DiagsTagType_Debug] = true;
+    c.enabled(DiagsTagType_Debug, 1);
   } else {
-    c.enabled[DiagsTagType_Debug] = false;
+    c.enabled(DiagsTagType_Debug, 0);
   }
 
   if (_diags->base_action_tags) {
     _diags->activate_taglist(_diags->base_action_tags, DiagsTagType_Action);
-    c.enabled[DiagsTagType_Action] = true;
+    c.enabled(DiagsTagType_Action, 1);
   } else {
-    c.enabled[DiagsTagType_Action] = false;
+    c.enabled(DiagsTagType_Action, 0);
   }
 
 #if !defined(__GNUC__)
@@ -259,8 +259,8 @@ DiagsConfig::DiagsConfig(std::string_view prefix_string, const char *filename, c
   ////////////////////////////////////////////////////////////////////
 
   if (!use_records) {
-    _diags  = new Diags(prefix_string, tags, actions, nullptr);
-    ::diags = _diags;
+    _diags = new Diags(prefix_string, tags, actions, nullptr);
+    DiagsPtr::set(_diags);
     config_diags_norecords();
     return;
   }
@@ -298,7 +298,7 @@ DiagsConfig::DiagsConfig(std::string_view prefix_string, const char *filename, c
   // Set up diags, FILE streams are opened in Diags constructor
   diags_log = new BaseLogFile(diags_logpath);
   _diags    = new Diags(prefix_string, tags, actions, diags_log, diags_perm_parsed, output_perm_parsed);
-  ::diags   = _diags;
+  DiagsPtr::set(_diags);
   _diags->config_roll_diagslog(static_cast<RollingEnabledValues>(diags_log_roll_enable), diags_log_roll_int, diags_log_roll_size);
   _diags->config_roll_outputlog(static_cast<RollingEnabledValues>(output_log_roll_enable), output_log_roll_int,
                                 output_log_roll_size);

--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -138,7 +138,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   crashlog_target target;
   pid_t parent = getppid();
 
-  diags = new Diags("traffic_crashlog", "" /* tags */, "" /* actions */, new BaseLogFile("stderr"));
+  DiagsPtr::set(new Diags("traffic_crashlog", "" /* tags */, "" /* actions */, new BaseLogFile("stderr")));
 
   appVersionInfo.setup(PACKAGE_NAME, "traffic_crashlog", PACKAGE_VERSION, __DATE__, __TIME__, BUILD_MACHINE, BUILD_PERSON, "");
 
@@ -182,14 +182,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     }
 
     openlog(appVersionInfo.AppStr, LOG_PID | LOG_NDELAY | LOG_NOWAIT, facility);
-    diags->config.outputs[DL_Debug].to_syslog     = true;
-    diags->config.outputs[DL_Status].to_syslog    = true;
-    diags->config.outputs[DL_Note].to_syslog      = true;
-    diags->config.outputs[DL_Warning].to_syslog   = true;
-    diags->config.outputs[DL_Error].to_syslog     = true;
-    diags->config.outputs[DL_Fatal].to_syslog     = true;
-    diags->config.outputs[DL_Alert].to_syslog     = true;
-    diags->config.outputs[DL_Emergency].to_syslog = true;
+    diags()->config.outputs[DL_Debug].to_syslog     = true;
+    diags()->config.outputs[DL_Status].to_syslog    = true;
+    diags()->config.outputs[DL_Note].to_syslog      = true;
+    diags()->config.outputs[DL_Warning].to_syslog   = true;
+    diags()->config.outputs[DL_Error].to_syslog     = true;
+    diags()->config.outputs[DL_Fatal].to_syslog     = true;
+    diags()->config.outputs[DL_Alert].to_syslog     = true;
+    diags()->config.outputs[DL_Emergency].to_syslog = true;
   }
 
   Note("crashlog started, target=%ld, debug=%s syslog=%s, uid=%ld euid=%ld", (long)target_pid, debug_mode ? "true" : "false",

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -267,12 +267,12 @@ main(int argc, const char **argv)
   engine.arguments = engine.parser.parse(argv);
 
   BaseLogFile *base_log_file = new BaseLogFile("stderr");
-  diags                      = new Diags("traffic_ctl", "" /* tags */, "" /* actions */, base_log_file);
+  DiagsPtr::set(new Diags("traffic_ctl", "" /* tags */, "" /* actions */, base_log_file));
 
   if (engine.arguments.get("debug")) {
-    diags->activate_taglist("traffic_ctl", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    diags()->activate_taglist("traffic_ctl", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
   }
 
   argparser_runroot_handler(engine.arguments.get("run-root").value(), argv[0]);
@@ -280,7 +280,7 @@ main(int argc, const char **argv)
 
   // This is a little bit of a hack, for now it'll suffice.
   max_records_entries = 262144;
-  RecProcessInit(RECM_STAND_ALONE, diags);
+  RecProcessInit(RECM_STAND_ALONE, diags());
   LibRecordsConfigInit();
 
   ats_scoped_str rundir(RecConfigReadRuntimeDir());

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -126,15 +126,15 @@ rotateLogs()
   int diags_log_roll_int     = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_interval_sec");
   int diags_log_roll_size    = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb");
   int diags_log_roll_enable  = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
-  diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
-  diags->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
+  diags()->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
+  diags()->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
 
   // Now we can actually roll the logs (if necessary)
-  if (diags->should_roll_diagslog()) {
+  if (diags()->should_roll_diagslog()) {
     mgmt_log("Rotated %s", DIAGS_LOG_FILENAME);
   }
 
-  if (diags->should_roll_outputlog()) {
+  if (diags()->should_roll_outputlog()) {
     // send a signal to TS to reload traffic.out, so the logfile is kept
     // synced across processes
     mgmt_log("Sending SIGUSR2 to TS");
@@ -546,8 +546,8 @@ main(int argc, const char **argv)
   // Bootstrap the Diags facility so that we can use it while starting
   //  up the manager
   diagsConfig = new DiagsConfig("Manager", DIAGS_LOG_FILENAME, debug_tags, action_tags, false);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
 
   RecLocalInit();
   LibRecordsConfigInit();
@@ -598,14 +598,14 @@ main(int argc, const char **argv)
     old_diagsconfig = nullptr;
   }
 
-  RecSetDiags(diags);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  RecSetDiags(diags());
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
 
   if (is_debug_tag_set("diags")) {
-    diags->dump();
+    diags()->dump();
   }
-  diags->cleanup_func = mgmt_cleanup;
+  diags()->cleanup_func = mgmt_cleanup;
 
   // Setup the exported manager version records.
   RecSetRecordString("proxy.node.version.manager.short", appVersionInfo.VersionStr, REC_SOURCE_DEFAULT);
@@ -934,9 +934,9 @@ SignalHandler(int sig)
     if (lmgmt && lmgmt->watched_process_pid != -1) {
       kill(lmgmt->watched_process_pid, sig);
     }
-    diags->set_std_output(StdStream::STDOUT, bind_stdout);
-    diags->set_std_output(StdStream::STDERR, bind_stderr);
-    if (diags->reseat_diagslog()) {
+    diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+    diags()->set_std_output(StdStream::STDERR, bind_stderr);
+    if (diags()->reseat_diagslog()) {
       Note("Reseated %s", DIAGS_LOG_FILENAME);
     } else {
       Note("Could not reseat %s", DIAGS_LOG_FILENAME);

--- a/src/traffic_quic/diags.h
+++ b/src/traffic_quic/diags.h
@@ -34,13 +34,9 @@ reconfigure_diags()
   int i;
   DiagsConfigState c;
 
-  // initial value set to 0 or 1 based on command line tags
-  c.enabled[DiagsTagType_Debug]  = (diags->base_debug_tags != nullptr);
-  c.enabled[DiagsTagType_Action] = (diags->base_action_tags != nullptr);
-
-  c.enabled[DiagsTagType_Debug]  = 1;
-  c.enabled[DiagsTagType_Action] = 1;
-  diags->show_location           = SHOW_LOCATION_ALL;
+  c.enabled(DiagsTagType_Debug, 1);
+  c.enabled(DiagsTagType_Action, 1);
+  diags()->show_location = SHOW_LOCATION_ALL;
 
   // read output routing values
   for (i = 0; i < DL_Status; i++) {
@@ -61,25 +57,27 @@ reconfigure_diags()
   // clear out old tag tables //
   //////////////////////////////
 
-  diags->deactivate_all(DiagsTagType_Debug);
-  diags->deactivate_all(DiagsTagType_Action);
+  diags()->deactivate_all(DiagsTagType_Debug);
+  diags()->deactivate_all(DiagsTagType_Action);
 
   //////////////////////////////////////////////////////////////////////
   //                     add new tag tables
   //////////////////////////////////////////////////////////////////////
 
-  if (diags->base_debug_tags)
-    diags->activate_taglist(diags->base_debug_tags, DiagsTagType_Debug);
-  if (diags->base_action_tags)
-    diags->activate_taglist(diags->base_action_tags, DiagsTagType_Action);
+  if (diags()->base_debug_tags) {
+    diags()->activate_taglist(diags()->base_debug_tags, DiagsTagType_Debug);
+  }
+  if (diags()->base_action_tags) {
+    diags()->activate_taglist(diags()->base_action_tags, DiagsTagType_Action);
+  }
 
 ////////////////////////////////////
 // change the diags config values //
 ////////////////////////////////////
 #if !defined(__GNUC__) && !defined(hpux)
-  diags->config = c;
+  diags()->config = c;
 #else
-  memcpy(((void *)&diags->config), ((void *)&c), sizeof(DiagsConfigState));
+  memcpy(((void *)&diags()->config), ((void *)&c), sizeof(DiagsConfigState));
 #endif
 }
 
@@ -89,7 +87,7 @@ init_diags(const char *bdt, const char *bat)
   char diags_logpath[500];
   strcpy(diags_logpath, DIAGS_LOG_FILE);
 
-  diags = new Diags("Client", bdt, bat, new BaseLogFile(diags_logpath));
+  DiagsPtr::set(new Diags("Client", bdt, bat, new BaseLogFile(diags_logpath)));
   Status("opened %s", diags_logpath);
 
   reconfigure_diags();

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -24,15 +24,13 @@
 #include <cstdio>
 #include <atomic>
 #include <string_view>
-#include <tuple>
-#include <unordered_map>
-#include <string_view>
 
 #include "tscore/ink_platform.h"
 #include "tscore/ink_base64.h"
 #include "tscore/PluginUserArgs.h"
 #include "tscore/I_Layout.h"
 #include "tscore/I_Version.h"
+#include "tscore/Diags.h"
 
 #include "InkAPIInternal.h"
 #include "Log.h"
@@ -7602,17 +7600,17 @@ ink_sanity_check_stat_structure(void *obj)
 int
 TSIsDebugTagSet(const char *t)
 {
-  return is_debug_tag_set(t);
+  return diags()->on_for_TSDebug(t);
 }
 
 void
 TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...)
 {
-  if ((debug_flag && diags->on()) || is_debug_tag_set(tag)) {
+  if ((debug_flag && diags()->on_for_TSDebug()) || diags()->on_for_TSDebug(tag)) {
     va_list ap;
 
     va_start(ap, format_str);
-    diags->print_va(tag, DL_Diag, nullptr, format_str, ap);
+    diags()->print_va(tag, DL_Diag, nullptr, format_str, ap);
     va_end(ap);
   }
 }
@@ -7622,13 +7620,23 @@ TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...)
 void
 TSDebug(const char *tag, const char *format_str, ...)
 {
-  if (is_debug_tag_set(tag)) {
+  if (diags()->on_for_TSDebug() && diags()->tag_activated(tag)) {
     va_list ap;
 
     va_start(ap, format_str);
-    diags->print_va(tag, DL_Diag, nullptr, format_str, ap);
+    diags()->print_va(tag, DL_Diag, nullptr, format_str, ap);
     va_end(ap);
   }
+}
+
+void
+_TSDbg(const char *tag, const char *format_str, ...)
+{
+  va_list ap;
+
+  va_start(ap, format_str);
+  diags()->print_va(tag, DL_Diag, nullptr, format_str, ap);
+  va_end(ap);
 }
 
 /**************************   Logging API   ****************************/
@@ -9998,4 +10006,13 @@ TSHttpTxnPostBufferReaderGet(TSHttpTxn txnp)
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   HttpSM *sm = (HttpSM *)txnp;
   return (TSIOBufferReader)sm->get_postbuf_clone_reader();
+}
+
+tsapi TSDbgCtl const *
+TSDbgCtlCreate(char const *tag)
+{
+  sdk_assert(tag != nullptr);
+  sdk_assert(*tag != '\0');
+
+  return DbgCtl::_get_ptr(tag);
 }

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -282,9 +282,9 @@ public:
 
       Debug("log", "received SIGUSR2, reloading traffic.out");
       // reload output logfile (file is usually called traffic.out)
-      diags->set_std_output(StdStream::STDOUT, bind_stdout);
-      diags->set_std_output(StdStream::STDERR, bind_stderr);
-      if (diags->reseat_diagslog()) {
+      diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+      diags()->set_std_output(StdStream::STDERR, bind_stderr);
+      if (diags()->reseat_diagslog()) {
         Note("Reseated %s", DIAGS_LOG_FILENAME);
       } else {
         Note("Could not reseat %s", DIAGS_LOG_FILENAME);
@@ -393,9 +393,9 @@ public:
     int diags_log_roll_int    = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_interval_sec");
     int diags_log_roll_size   = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb");
     int diags_log_roll_enable = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
-    diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
+    diags()->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
 
-    if (diags->should_roll_diagslog()) {
+    if (diags()->should_roll_diagslog()) {
       Note("Rolled %s", DIAGS_LOG_FILENAME);
     }
     return EVENT_CONT;
@@ -499,9 +499,9 @@ void
 set_debug_ip(const char *ip_string)
 {
   if (ip_string) {
-    diags->debug_client_ip.load(ip_string);
+    diags()->debug_client_ip.load(ip_string);
   } else {
-    diags->debug_client_ip.invalidate();
+    diags()->debug_client_ip.invalidate();
   }
 }
 
@@ -660,7 +660,7 @@ initialize_process_manager()
     EnableDeathSignal(SIGTERM);
   }
 
-  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags);
+  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags());
   LibRecordsConfigInit();
 
   // Start up manager
@@ -1778,10 +1778,10 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // This is also needed for log rotation - setting up the file can cause privilege
   // related errors and if diagsConfig isn't get up yet that will crash on a NULL pointer.
   diagsConfig = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, false);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
   if (is_debug_tag_set("diags")) {
-    diags->dump();
+    diags()->dump();
   }
 
   // Bind stdout and stderr to specified switches
@@ -1872,11 +1872,11 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // Re-initialize diagsConfig based on records.config configuration
   DiagsConfig *old_log = diagsConfig;
   diagsConfig          = new DiagsConfig("Server", DIAGS_LOG_FILENAME, error_tags, action_tags, true);
-  RecSetDiags(diags);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  RecSetDiags(diags());
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
   if (is_debug_tag_set("diags")) {
-    diags->dump();
+    diags()->dump();
   }
 
   if (old_log) {

--- a/src/tscore/DbgCtl.cc
+++ b/src/tscore/DbgCtl.cc
@@ -1,0 +1,111 @@
+/** @file
+
+  Implementation file for DbgCtl class.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <mutex>
+#include <atomic>
+#include <set>
+#include <cstring>
+
+#include <tscore/Diags.h>
+
+// The resistry of fast debug controllers has a ugly implementation to handle the whole-program initialization
+// order problem with C++.
+//
+class DbgCtl::_RegistryAccessor
+{
+private:
+  struct TagCmp {
+    bool
+    operator()(TSDbgCtl const &a, TSDbgCtl const &b) const
+    {
+      return std::strcmp(a.tag, b.tag) < 0;
+    }
+  };
+
+public:
+  _RegistryAccessor() : _lg(data().mtx) {}
+
+  using Set = std::set<TSDbgCtl, TagCmp>;
+
+  struct Data {
+    std::mutex mtx;
+    Set set;
+  };
+
+  Data &
+  data()
+  {
+    static Data d;
+    return d;
+  }
+
+private:
+  std::lock_guard<std::mutex> _lg;
+};
+
+TSDbgCtl const *
+DbgCtl::_get_ptr(char const *tag)
+{
+  ink_assert(tag != nullptr);
+
+  TSDbgCtl ctl;
+
+  ctl.tag = tag;
+
+  _RegistryAccessor ra;
+
+  auto &d{ra.data()};
+
+  if (auto it = d.set.find(ctl); it != d.set.end()) {
+    return &*it;
+  }
+
+  auto sz = std::strlen(tag);
+
+  ink_assert(sz > 0);
+
+  {
+    char *t = new char[sz + 1]; // Deleted implicitly by program termination.
+    std::memcpy(t, tag, sz + 1);
+    ctl.tag = t;
+  }
+  ctl.on = diags() && diags()->tag_activated(tag, DiagsTagType_Debug);
+
+  auto res = d.set.insert(ctl);
+
+  return &*res.first;
+}
+
+void
+DbgCtl::update()
+{
+  ink_release_assert(diags() != nullptr);
+
+  _RegistryAccessor ra;
+
+  auto &d{ra.data()};
+
+  for (auto &i : d.set) {
+    const_cast<char volatile &>(i.on) = diags()->tag_activated(i.tag, DiagsTagType_Debug);
+  }
+}

--- a/src/tscore/Diags.cc
+++ b/src/tscore/Diags.cc
@@ -47,11 +47,34 @@
 #include "tscore/BufferWriter.h"
 #include "tscore/Diags.h"
 
-int diags_on_for_plugins         = 0;
-int DiagsConfigState::enabled[2] = {0, 0};
+int diags_on_for_plugins          = 0;
+char ts_new_debug_on_flag_        = 0;
+int DiagsConfigState::_enabled[2] = {0, 0};
+
+void
+DiagsConfigState::enabled(DiagsTagType dtt, int new_value)
+{
+  if (_enabled[dtt] == new_value) {
+    return;
+  }
+  _enabled[dtt] = new_value;
+
+  if (DiagsTagType_Debug == dtt) {
+    diags_on_for_plugins  = (1 & new_value) != 0;
+    ts_new_debug_on_flag_ = 3 == new_value;
+  }
+}
 
 // Global, used for all diagnostics
-inkcoreapi Diags *diags = nullptr;
+Diags *DiagsPtr::_diags_ptr = nullptr;
+
+void
+DiagsPtr::set(Diags *new_ptr)
+{
+  _diags_ptr = new_ptr;
+
+  DbgCtl::update();
+}
 
 static bool
 location(const SourceLocation *loc, DiagsShowLocation show, DiagsLevel level)
@@ -115,9 +138,8 @@ Diags::Diags(std::string_view prefix_string, const char *bdt, const char *bat, B
     base_action_tags = ats_strdup(bat);
   }
 
-  config.enabled[DiagsTagType_Debug]  = (base_debug_tags != nullptr);
-  config.enabled[DiagsTagType_Action] = (base_action_tags != nullptr);
-  diags_on_for_plugins                = config.enabled[DiagsTagType_Debug];
+  config.enabled(DiagsTagType_Debug, base_debug_tags != nullptr ? 1 : 0);
+  config.enabled(DiagsTagType_Action, base_action_tags != nullptr ? 1 : 0);
 
   // The caller must always provide a non-empty prefix.
 
@@ -375,6 +397,9 @@ Diags::activate_taglist(const char *taglist, DiagsTagType mode)
     activated_tags[mode]->compile(taglist);
     unlock();
   }
+  if ((DiagsTagType_Debug == mode) && (this == diags())) {
+    DbgCtl::update();
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -396,6 +421,9 @@ Diags::deactivate_all(DiagsTagType mode)
     activated_tags[mode] = nullptr;
   }
   unlock();
+  if ((DiagsTagType_Debug == mode) && (this == diags())) {
+    DbgCtl::update();
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -446,9 +474,9 @@ Diags::dump(FILE *fp) const
   int i;
 
   fprintf(fp, "Diags:\n");
-  fprintf(fp, "  debug.enabled: %d\n", config.enabled[DiagsTagType_Debug]);
+  fprintf(fp, "  debug.enabled: %d\n", config.enabled(DiagsTagType_Debug));
   fprintf(fp, "  debug default tags: '%s'\n", (base_debug_tags ? base_debug_tags : "NULL"));
-  fprintf(fp, "  action.enabled: %d\n", config.enabled[DiagsTagType_Action]);
+  fprintf(fp, "  action.enabled: %d\n", config.enabled(DiagsTagType_Action));
   fprintf(fp, "  action default tags: '%s'\n", (base_action_tags ? base_action_tags : "NULL"));
   fprintf(fp, "  outputs:\n");
   for (i = 0; i < DiagsLevel_Count; i++) {

--- a/src/tscore/LogMessage.cc
+++ b/src/tscore/LogMessage.cc
@@ -84,7 +84,7 @@ LogMessage::standard_message_helper(DiagsLevel level, SourceLocation const &loc,
 {
   message_helper(
     _default_log_throttling_interval.load(),
-    [level, &loc](const char *fmt, va_list args) { diags->error_va(level, &loc, fmt, args); }, fmt, args);
+    [level, &loc](const char *fmt, va_list args) { diags()->error_va(level, &loc, fmt, args); }, fmt, args);
 }
 
 void
@@ -92,7 +92,7 @@ LogMessage::message_debug_helper(const char *tag, DiagsLevel level, SourceLocati
 {
   message_helper(
     _default_debug_throttling_interval.load(),
-    [tag, level, &loc](const char *fmt, va_list args) { diags->log_va(tag, level, &loc, fmt, args); }, fmt, args);
+    [tag, level, &loc](const char *fmt, va_list args) { diags()->log_va(tag, level, &loc, fmt, args); }, fmt, args);
 }
 
 void
@@ -100,7 +100,7 @@ LogMessage::message_print_helper(const char *tag, DiagsLevel level, SourceLocati
 {
   message_helper(
     _default_debug_throttling_interval.load(),
-    [tag, level, &loc](const char *fmt, va_list args) { diags->print_va(tag, level, &loc, fmt, args); }, fmt, args);
+    [tag, level, &loc](const char *fmt, va_list args) { diags()->print_va(tag, level, &loc, fmt, args); }, fmt, args);
 }
 
 LogMessage::LogMessage(bool is_throttled)
@@ -121,15 +121,6 @@ LogMessage::diag(const char *tag, SourceLocation const &loc, const char *fmt, ..
   va_list args;
   va_start(args, fmt);
   message_debug_helper(tag, DL_Diag, loc, fmt, args);
-  va_end(args);
-}
-
-void
-LogMessage::debug(const char *tag, SourceLocation const &loc, const char *fmt, ...)
-{
-  va_list args;
-  va_start(args, fmt);
-  message_debug_helper(tag, DL_Debug, loc, fmt, args);
   va_end(args);
 }
 

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -59,6 +59,7 @@ libtscore_la_SOURCES = \
 	ConsistentHash.cc \
 	ContFlags.cc \
 	CryptoHash.cc \
+	DbgCtl.cc \
 	Diags.cc \
 	Errata.cc \
 	EventNotify.cc \

--- a/src/tscore/ink_cap.cc
+++ b/src/tscore/ink_cap.cc
@@ -46,7 +46,7 @@ ink_mutex ElevateAccess::lock = INK_MUTEX_INIT;
 
 #define DEBUG_CREDENTIALS(tag)                                                                                               \
   do {                                                                                                                       \
-    if (is_debug_tag_set(tag)) {                                                                                             \
+    if (diags()->on(tag)) {                                                                                                  \
       uid_t uid = -1, euid = -1, suid = -1;                                                                                  \
       gid_t gid = -1, egid = -1, sgid = -1;                                                                                  \
       getresuid(&uid, &euid, &suid);                                                                                         \
@@ -60,7 +60,7 @@ ink_mutex ElevateAccess::lock = INK_MUTEX_INIT;
 
 #define DEBUG_PRIVILEGES(tag)                                                                                    \
   do {                                                                                                           \
-    if (is_debug_tag_set(tag)) {                                                                                 \
+    if (diags()->on(tag)) {                                                                                      \
       cap_t caps      = cap_get_proc();                                                                          \
       char *caps_text = cap_to_text(caps, nullptr);                                                              \
       Debug(tag, "caps='%s', core=%s, death signal=%d, thread=0x%llx", caps_text, is_dumpable(), death_signal(), \
@@ -74,7 +74,7 @@ ink_mutex ElevateAccess::lock = INK_MUTEX_INIT;
 
 #define DEBUG_PRIVILEGES(tag)                                                                       \
   do {                                                                                              \
-    if (is_debug_tag_set(tag)) {                                                                    \
+    if (diags()->on(tag)) {                                                                         \
       Debug(tag, "caps='', core=%s, death signal=%d, thread=0x%llx", is_dumpable(), death_signal(), \
             (unsigned long long)pthread_self());                                                    \
     }                                                                                               \

--- a/src/tscore/unit_tests/test_X509HostnameValidator.cc
+++ b/src/tscore/unit_tests/test_X509HostnameValidator.cc
@@ -172,7 +172,7 @@ int
 main(int argc, const char **argv)
 {
   BaseLogFile *blf = new BaseLogFile("stdout");
-  diags            = new Diags("test_x509", nullptr, nullptr, blf);
+  DiagsPtr::set(new Diags("test_x509", nullptr, nullptr, blf));
   res_track_memory = 1;
 
   SSL_library_init();

--- a/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
@@ -40,6 +40,10 @@ namespace
 {
 char PIName[] = PINAME;
 
+auto dbg_ctl = TSDbgCtlCreate(PIName);
+
+auto off_dbg_ctl = TSDbgCtlCreate("yada-yada-yada");
+
 // NOTE:  It's important to flush this after writing so that a gold test using this plugin can examine the log before TS
 // terminates.
 //
@@ -171,7 +175,11 @@ transactionContFunc(TSCont, TSEvent event, void *eventData)
 {
   logFile << "Transaction: event=" << TSHttpEventNameLookup(event) << std::endl;
 
-  TSDebug(PIName, "Transaction: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
+  TSDbg(dbg_ctl, "Transaction: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
+
+  TSDebug(PIName, "Should not see this, enabled set to 3");
+
+  TSDbg(off_dbg_ctl, "Should not see this, tag does not match regular expression");
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR: {
@@ -204,7 +212,7 @@ globalContFunc(TSCont, TSEvent event, void *eventData)
 {
   logFile << "Global: event=" << TSHttpEventNameLookup(event) << std::endl;
 
-  TSDebug(PIName, "Global: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
+  TSDbg(dbg_ctl, "Global: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
 
   switch (event) {
   case TS_EVENT_HTTP_TXN_START: {
@@ -246,7 +254,7 @@ globalContFunc(TSCont, TSEvent event, void *eventData)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  TSDebug(PIName, "TSRemapInit()");
+  TSDbg(dbg_ctl, "TSRemapInit()");
 
   TSReleaseAssert(api_info && errbuf && errbuf_size);
 

--- a/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
@@ -52,7 +52,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.enabled': 3,
     'proxy.config.diags.debug.tags': 'http|test_tsapi',
 })
 


### PR DESCRIPTION
Also adds OneWriterMultiReader.h, higher-performance alternative to std::shared_mutex (also with logic to prevent writer starvation).

Setting proxy.config.diags.debug.enabled to 1 or 3 enables output for Debug macros with DbgCtl as first parameter or TSFDbg if the tag for the DbgClt/TSFDbCtl matches debug.tags regular expression.  (A value of 1 still only enables Debug/TSDebug macros with a C-string tag as the first parameter.)