### PR TITLE
Cleanup: Add SNIRoutingType

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -330,25 +330,15 @@ public:
     return tunnel_port;
   }
 
-  /* Returns true if this vc was configured for forward_route or partial_blind_route
-   */
-  bool
-  decrypt_tunnel()
-  {
-    return has_tunnel_destination() && tunnel_decrypt;
-  }
-
-  /* Returns true if this vc was configured partial_blind_route
-   */
-  bool
-  upstream_tls()
-  {
-    return has_tunnel_destination() && tls_upstream;
-  }
+  bool decrypt_tunnel() const;
+  bool upstream_tls() const;
+  SNIRoutingType tunnel_type() const;
 
   void
-  set_tunnel_destination(const std::string_view &destination, bool decrypt, bool upstream_tls)
+  set_tunnel_destination(const std::string_view &destination, SNIRoutingType type)
   {
+    _tunnel_type = type;
+
     auto pos = destination.find(":");
     if (nullptr != tunnel_host) {
       ats_free(tunnel_host);
@@ -360,8 +350,6 @@ public:
       tunnel_port = 0;
       tunnel_host = ats_strndup(destination.data(), destination.length());
     }
-    tunnel_decrypt = decrypt;
-    tls_upstream   = upstream_tls;
   }
 
   int populate_protocol(std::string_view *results, int n) const override;
@@ -529,8 +517,7 @@ private:
   int64_t redoWriteSize       = 0;
   char *tunnel_host           = nullptr;
   in_port_t tunnel_port       = 0;
-  bool tunnel_decrypt         = false;
-  bool tls_upstream           = false;
+  SNIRoutingType _tunnel_type = SNIRoutingType::NONE;
   X509_STORE_CTX *verify_cert = nullptr;
 
   // Null-terminated string, or nullptr if there is no SNI server name.
@@ -548,3 +535,30 @@ private:
 typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);
 
 extern ClassAllocator<SSLNetVConnection> sslNetVCAllocator;
+
+//
+// Inline Functions
+//
+inline SNIRoutingType
+SSLNetVConnection::tunnel_type() const
+{
+  return _tunnel_type;
+}
+
+/**
+   Returns true if this vc was configured for forward_route or partial_blind_route
+ */
+inline bool
+SSLNetVConnection::decrypt_tunnel() const
+{
+  return _tunnel_type == SNIRoutingType::FORWARD || _tunnel_type == SNIRoutingType::PARTIAL_BLIND;
+}
+
+/**
+   Returns true if this vc was configured partial_blind_route
+ */
+inline bool
+SSLNetVConnection::upstream_tls() const
+{
+  return _tunnel_type == SNIRoutingType::PARTIAL_BLIND;
+}

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -77,7 +77,7 @@ SNIConfigParams::loadSNIConfig()
       ai->actions.push_back(std::make_unique<TLSValidProtocols>(item.protocol_mask));
     }
     if (item.tunnel_destination.length() > 0) {
-      ai->actions.push_back(std::make_unique<TunnelDestination>(item.tunnel_destination, item.tunnel_decrypt, item.tls_upstream));
+      ai->actions.push_back(std::make_unique<TunnelDestination>(item.tunnel_destination, item.tunnel_type));
     }
 
     ai->actions.push_back(std::make_unique<SNI_IpAllow>(item.ip_allow, item.fqdn));

--- a/iocore/net/SSLTypes.h
+++ b/iocore/net/SSLTypes.h
@@ -1,0 +1,31 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+enum class SNIRoutingType {
+  NONE = 0,
+  BLIND,
+  FORWARD,
+  PARTIAL_BLIND,
+};

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -207,16 +207,13 @@ template <> struct convert<YamlSNIConfig::Item> {
 
     if (node[TS_tunnel_route]) {
       item.tunnel_destination = node[TS_tunnel_route].as<std::string>();
-      item.tunnel_decrypt     = false;
-      item.tls_upstream       = false;
+      item.tunnel_type        = SNIRoutingType::BLIND;
     } else if (node[TS_forward_route]) {
       item.tunnel_destination = node[TS_forward_route].as<std::string>();
-      item.tunnel_decrypt     = true;
-      item.tls_upstream       = false;
+      item.tunnel_type        = SNIRoutingType::FORWARD;
     } else if (node[TS_partial_blind_route]) {
       item.tunnel_destination = node[TS_partial_blind_route].as<std::string>();
-      item.tunnel_decrypt     = true;
-      item.tls_upstream       = true;
+      item.tunnel_type        = SNIRoutingType::PARTIAL_BLIND;
     }
 
     if (node[TS_verify_server_policy]) {

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -26,6 +26,8 @@
 #include <optional>
 #include <memory>
 
+#include "SSLTypes.h"
+
 #include "tscore/Errata.h"
 
 #define TSDECL(id) constexpr char TS_##id[] = #id
@@ -76,10 +78,9 @@ struct YamlSNIConfig {
     uint8_t verify_client_level = 255;
     std::string verify_client_ca_file;
     std::string verify_client_ca_dir;
-    uint8_t host_sni_policy = 255;
+    uint8_t host_sni_policy    = 255;
+    SNIRoutingType tunnel_type = SNIRoutingType::NONE;
     std::string tunnel_destination;
-    bool tunnel_decrypt               = false;
-    bool tls_upstream                 = false;
     Policy verify_server_policy       = Policy::UNSET;
     Property verify_server_properties = Property::UNSET;
     std::string client_cert;


### PR DESCRIPTION
In `SSLNetVConnection`, SNI Routing Types (`tunnel_route`, `forward_route`, and `partial_blind_route`) are represented by combination of `tunnel_decrypt` and `tls_upstream`. It'd be clear if we get rid of these flags and have one `SNIRoutingType`.