### PR TITLE
Do not write to the cache if the plugin decides not to write 

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3254,6 +3254,8 @@ HttpTransact::HandleCacheOpenReadMiss(State *s)
              does_method_effect_cache(s->method) == false || s->range_setup == RANGE_NOT_SATISFIABLE ||
              s->range_setup == RANGE_NOT_HANDLED) {
     s->cache_info.action = CACHE_DO_NO_ACTION;
+  } else if (s->api_server_response_no_store) { // plugin may have decided not to cache the response
+    s->cache_info.action = CACHE_DO_NO_ACTION;
   } else {
     s->cache_info.action = CACHE_PREPARE_TO_WRITE;
   }


### PR DESCRIPTION
TSHttpTxnServerRespNoStoreSet can be called after READ_REQUEST_HDR state. For example, cache promotes plugin calls this at TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE hook. 
Checking the api_server_response_no_store flag after receiving the origin server response could create a race condition when a request that is not chosen to update the cache by cache promote plugin is holding the lock.

request1---holds the locks( not chosen to write to cache)---request2---fails to acquire the lock(selected to write to cache)

This causes both the requests to not write to cache.

Checking for the flag api_server_response_no_store before moving into the CACHE_ISSUE_WRITE state avoids the cache write lock and avoids the race.