### PR TITLE
Fixing compress expectation for new microserver

### DIFF
--- a/tests/gold_tests/pluginTest/compress/compress.gold
+++ b/tests/gold_tests/pluginTest/compress/compress.gold
@@ -184,5 +184,5 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 30
+< Content-Length: 71
 ===


### PR DESCRIPTION
The new 1.0.6 microserver generates a body such that the content length
for it is 71 instead of 30 for one of the tests. Updating the gold file
to match this expectation.