### PR TITLE
Proxy Verifier: Making use of delay directives for caching tests.

### DIFF
--- a/tests/gold_tests/cache/replay/cache-control-max-age.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-max-age.replay.yaml
@@ -34,6 +34,10 @@ meta:
           fields:
           - [ Host, example.com ]
 
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
+
   - request_for_zero_max_age: &request_for_zero_max_age
       client-request:
         method: "GET"
@@ -43,6 +47,10 @@ meta:
         headers:
           fields:
           - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
 
   - request_for_negative_max_age: &request_for_negative_max_age
       client-request:
@@ -54,6 +62,10 @@ meta:
           fields:
           - [ Host, example.com ]
 
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
+
   - request_for_non_number_max_age: &request_for_non_number_max_age
       client-request:
         method: "GET"
@@ -63,6 +75,10 @@ meta:
         headers:
           fields:
           - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
 
   - 200_ok_response: &200_ok_response
       server-response:
@@ -249,6 +265,10 @@ sessions:
         - [ Host, example.com ]
         - [ Cache-Control, max-age=300 ]
 
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
+
     # This should be replied to out of the cache, therefore this 400 response
     # should not make it to the client.
     server-response:
@@ -295,6 +315,10 @@ sessions:
         fields:
         - [ Host, example.com ]
         - [ Cache-Control, max-age=0 ]
+
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
 
     # This should go through to the server because the 0 max-age
     # directive in the request should make ATS consider it stale.
@@ -344,6 +368,10 @@ sessions:
         fields:
         - [ Host, example.com ]
         - [ Cache-Control, max-age=-300 ]
+
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
 
     # This should go through to the server because the negative max-age
     # directive in the request should make ATS consider it stale.

--- a/tests/gold_tests/cache/replay/negative-caching-300-second-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-300-second-timeout.replay.yaml
@@ -36,6 +36,10 @@ meta:
           fields:
           - [ Host, example.com ]
 
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
+
 sessions:
 - transactions:
 

--- a/tests/gold_tests/cache/replay/negative-caching-customized.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-customized.replay.yaml
@@ -72,6 +72,10 @@ sessions:
         fields:
         - [ Host, example.com ]
 
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
+
     # Since 404 responses are customized to not be cached, this will go
     # through.
     <<: *200_response
@@ -115,6 +119,10 @@ sessions:
         fields:
         - [ Host, example.com ]
 
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
+
     # By customization, the 400 will be cached and this will not go through.
     <<: *200_response
 
@@ -150,6 +158,10 @@ sessions:
       headers:
         fields:
         - [ Host, example.com ]
+
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
 
     # This should not go to the server since the 200 response is cached.
     server-response:

--- a/tests/gold_tests/cache/replay/negative-caching-default.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-default.replay.yaml
@@ -69,6 +69,10 @@ sessions:
         fields:
         - [ Host, example.com ]
 
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
+
     # 404 responses should be cached when negative caching is enabled, so this
     # should not get to the server.  But if it does, return a 200 so the test
     # knows that something went wrong.
@@ -113,6 +117,10 @@ sessions:
         fields:
         - [ Host, example.com ]
 
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
+
     # 400 responses should not be cached. Verify this goes to the server
     # by returning and expecting a 200 response.
     <<: *200_response
@@ -148,6 +156,10 @@ sessions:
       headers:
         fields:
         - [ Host, example.com ]
+
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
 
     # This should not go to the server, but if it does return a 400 so we catch
     # it.
@@ -196,6 +208,10 @@ sessions:
       headers:
         fields:
         - [ Host, example.com ]
+
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
 
     # 405 responses should not be cached. Verify this goes to the server
     # by returning and expecting a 200 response.

--- a/tests/gold_tests/cache/replay/negative-caching-disabled.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-disabled.replay.yaml
@@ -32,6 +32,10 @@ meta:
           fields:
           - [ Host, example.com ]
 
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
+
   - request_for_path_404: &request_for_path_404
       client-request:
         method: "GET"
@@ -41,6 +45,10 @@ meta:
         headers:
           fields:
           - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
 
   - request_for_no_cache_control_response: &request_for_no_cache_control_response
       client-request:
@@ -52,6 +60,11 @@ meta:
           fields:
           - [ Host, example.com ]
 
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
+
+
   - request_for_404_with_cc: &request_for_404_with_cc
       client-request:
         method: "GET"
@@ -61,6 +74,10 @@ meta:
         headers:
           fields:
           - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 50ms
 
 sessions:
 - transactions:

--- a/tests/gold_tests/cache/replay/negative-caching-no-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-no-timeout.replay.yaml
@@ -39,6 +39,10 @@ sessions:
         fields:
         - [ Host, example.com ]
 
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
+
     # This should not go to the server. Verify we get the cached 404 response
     # instead of this new 403 response.
     server-response:

--- a/tests/gold_tests/cache/replay/negative-caching-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-timeout.replay.yaml
@@ -74,6 +74,10 @@ sessions:
         fields:
         - [ Host, example.com ]
 
+      # Add a delay so ATS has time to finish any caching IO for the previous
+      # transaction.
+      delay: 50ms
+
     # 403 responses should be cached when negative caching is enabled, so this
     # should not get to the server.  But if it does, return a 404 so the test
     # knows that something went wrong.


### PR DESCRIPTION
The non-Proxy Verifier tests handle transactions more slowly than Proxy
Verifier since they spin up a new AuTest curl process for each one.
Proxy Verifier, on the other hand, runs all the transactions in a replay
file in one process.  It has been observed that certain tests that rely
upon caching between transactions can get false negatives because a
subsequent transaction occurs before the IO for caching completes. This
can also result in false positives too where the inverse happens: the
ATS process may be incorrectly trying to cache something it shouldn't,
but the test misses it because the subsequent transaction happens too
quickly.

This makes use of Proxy Verifier's delay directive to slow down certain
transactions to give enough time for any IO to complete.