### PR TITLE
Update AuTest version update directions for pipenv

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -24,7 +24,10 @@ autopep8 = "*"
 pyflakes = "*"
 
 [packages]
+
+# Keep init.cli.ext updated with this required autest version.
 autest = "==1.8.1"
+
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"
 dnslib = "*"
@@ -32,7 +35,10 @@ dnslib = "*"
 requests = "*"
 gunicorn = "*"
 httpbin = "*"
+
+# Keep init.cli.ext updated with this required microserver version.
 microserver = ">=1.0.6"
+
 jsonschema = "*"
 python-jose = "*"
 

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -17,20 +17,28 @@
 #  limitations under the License.
 
 import sys
+import microserver
 
 if sys.version_info < (3, 6, 0):
     host.WriteError(
         "You need python 3.6 or later to run these tests\n", show_stack=False)
 
-autest_version = "1.8.1"
-if AuTestVersion() < autest_version:
+needed_autest_version = "1.8.1"
+found_autest_version = AuTestVersion()
+if AuTestVersion() < needed_autest_version:
     host.WriteError(
-        "Tests need AuTest version {needed_version} or better, found version {found_version}\n"
-        "Please update AuTest:\n  pip install --upgrade autest\n".format(
-            needed_version=autest_version,
-            found_version=AuTestVersion()),
+        f"Tests need AuTest version {needed_autest_version} or better, found version {found_autest_version}\n"
+        "Please update AuTest:\n  pipenv --rm && pipenv install\n",
         show_stack=False)
 
+
+needed_microserver_version = "1.0.6"
+found_microserver_version = microserver.__version__
+if found_microserver_version < needed_microserver_version:
+    host.WriteError(
+        f"Tests need a MicroServer version {needed_microserver_version} or better, found version {found_microserver_version}\n"
+        "Please update MicroServer:\n  pipenv --rm && pipenv install\n",
+        show_stack=False)
 
 Settings.path_argument(["--ats-bin"],
                        required=True,


### PR DESCRIPTION
The current AuTest extension describes how to update AuTest for pip,
not the currently used pipenv environment. This updates those directions
for pipenv.

This also adds a version check for microserver analogous to the version
check for AuTest.