### PR TITLE
Add STL compliant field iteration to MIMEHdr.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -4951,17 +4951,14 @@ HttpTransact::set_headers_for_cache_write(State *s, HTTPInfo *cache_info, HTTPHd
 void
 HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, HTTPHdr *response_header)
 {
-  MIMEField *field;
   MIMEField *new_field;
-  MIMEFieldIter fiter;
   const char *name;
   bool dups_seen = false;
 
-  field = response_header->iter_get_first(&fiter);
-
-  for (; field != nullptr; field = response_header->iter_get_next(&fiter)) {
+  for (auto spot = response_header->begin(), limit = response_header->end(); spot != limit; ++spot) {
+    MIMEField &field{*spot};
     int name_len;
-    name = field->name_get(&name_len);
+    name = field.name_get(&name_len);
 
     ///////////////////////////
     // is hop-by-hop header? //
@@ -5011,31 +5008,20 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
     //   the remaining fields one by one from the
     //   response header
     //
-    if (field->m_next_dup) {
+    if (field.m_next_dup) {
       if (dups_seen == false) {
-        MIMEField *dfield;
         // use a second iterator to delete the
         // remaining response headers in the cached response,
         // so that they will be added in the next iterations.
-        MIMEFieldIter fiter2 = fiter;
-        const char *dname    = name;
-        int dlen             = name_len;
-
-        while (dname) {
-          cached_header->field_delete(dname, dlen);
-          dfield = response_header->iter_get_next(&fiter2);
-          if (dfield) {
-            dname = dfield->name_get(&dlen);
-          } else {
-            dname = nullptr;
-          }
+        for (auto spot2 = spot; spot2 != limit; ++spot2) {
+          cached_header->field_delete(&*spot2, true);
         }
         dups_seen = true;
       }
     }
 
     int value_len;
-    const char *value = field->value_get(&value_len);
+    const char *value = field.value_get(&value_len);
 
     if (dups_seen == false) {
       cached_header->value_set(name, name_len, value, value_len);

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -200,8 +200,6 @@ HttpTransactHeaders::copy_header_fields(HTTPHdr *src_hdr, HTTPHdr *new_hdr, bool
   ink_assert(src_hdr->valid());
   ink_assert(!new_hdr->valid());
 
-  MIMEField *field;
-  MIMEFieldIter field_iter;
   bool date_hdr = false;
 
   // Start with an exact duplicate
@@ -222,19 +220,19 @@ HttpTransactHeaders::copy_header_fields(HTTPHdr *src_hdr, HTTPHdr *new_hdr, bool
   //         is changed for example by dechunking, the transfer encoding
   //         should be modified when when the decision is made to dechunk it
 
-  for (field = new_hdr->iter_get_first(&field_iter); field != nullptr; field = new_hdr->iter_get_next(&field_iter)) {
-    if (field->m_wks_idx == -1) {
+  for (auto &field : *new_hdr) {
+    if (field.m_wks_idx == -1) {
       continue;
     }
 
-    int field_flags = hdrtoken_index_to_flags(field->m_wks_idx);
+    int field_flags = hdrtoken_index_to_flags(field.m_wks_idx);
 
     if (field_flags & HTIF_HOPBYHOP) {
       // Delete header if not in special proxy_auth retention mode
       if ((!retain_proxy_auth_hdrs) || (!(field_flags & HTIF_PROXYAUTH))) {
-        new_hdr->field_delete(field);
+        new_hdr->field_delete(&field);
       }
-    } else if (field->m_wks_idx == MIME_WKSIDX_DATE) {
+    } else if (field.m_wks_idx == MIME_WKSIDX_DATE) {
       date_hdr = true;
     }
   }

--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -908,11 +908,10 @@ hpack_encode_header_block(HpackIndexingTable &indexing_table, uint8_t *out_buf, 
     cursor += written;
   }
 
-  MIMEFieldIter field_iter;
-  for (MIMEField *field = hdr->iter_get_first(&field_iter); field != nullptr; field = hdr->iter_get_next(&field_iter)) {
+  for (auto &field : *hdr) {
     // Convert field name to lower case to follow HTTP2 spec
     // This conversion is needed because WKSs in MIMEFields is old fashioned
-    std::string_view original_name = field->name_get();
+    std::string_view original_name = field.name_get();
     int name_len                   = original_name.size();
     ts::LocalBuffer<char> local_buffer(name_len);
     char *lower_name = local_buffer.data();
@@ -921,7 +920,7 @@ hpack_encode_header_block(HpackIndexingTable &indexing_table, uint8_t *out_buf, 
     }
 
     std::string_view name{lower_name, static_cast<size_t>(name_len)};
-    std::string_view value = field->value_get();
+    std::string_view value = field.value_get();
 
     // Choose field representation (See RFC7541 7.1.3)
     // - Authorization header obviously should not be indexed

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -498,9 +498,8 @@ http2_convert_header_from_2_to_1_1(HTTPHdr *headers)
   }
 
   // Check validity of all names and values
-  MIMEFieldIter iter;
-  for (auto *mf = headers->iter_get_first(&iter); mf != nullptr; mf = headers->iter_get_next(&iter)) {
-    if (!mf->name_is_valid() || !mf->value_is_valid()) {
+  for (auto &mf : *headers) {
+    if (!mf.name_is_valid() || !mf.value_is_valid()) {
       return PARSE_RESULT_ERROR;
     }
   }
@@ -707,8 +706,8 @@ http2_decode_header_blocks(HTTPHdr *hdr, const uint8_t *buf_start, const uint32_
   if (is_trailing_header) {
     expected_pseudo_header_count = 0;
   }
-  for (field = hdr->iter_get_first(&iter); field != nullptr; field = hdr->iter_get_next(&iter)) {
-    value = field->name_get(&len);
+  for (auto &field : *hdr) {
+    value = field.name_get(&len);
     // Pseudo headers must appear before regular headers
     if (len && value[0] == ':') {
       ++pseudo_header_count;

--- a/proxy/http2/test_HPACK.cc
+++ b/proxy/http2/test_HPACK.cc
@@ -133,16 +133,14 @@ compare_header_fields(HTTPHdr *a, HTTPHdr *b)
     return -1;
   }
 
-  MIMEFieldIter a_iter, b_iter;
+  auto a_spot = a->begin(), a_limit = a->end();
+  auto b_spot = b->begin(), b_limit = b->end();
 
-  const MIMEField *a_field = a->iter_get_first(&a_iter);
-  const MIMEField *b_field = b->iter_get_first(&b_iter);
-
-  while (a_field != nullptr && b_field != nullptr) {
+  while (a_spot != a_limit && b_spot != b_limit) {
     int a_str_len, b_str_len;
     // compare header name
-    const char *a_str = a_field->name_get(&a_str_len);
-    const char *b_str = b_field->name_get(&b_str_len);
+    const char *a_str = a_spot->name_get(&a_str_len);
+    const char *b_str = b_spot->name_get(&b_str_len);
     if (a_str_len != b_str_len) {
       if (memcmp(a_str, b_str, a_str_len) != 0) {
         print_difference(a_str, a_str_len, b_str, b_str_len);
@@ -150,17 +148,16 @@ compare_header_fields(HTTPHdr *a, HTTPHdr *b)
       }
     }
     // compare header value
-    a_str = a_field->value_get(&a_str_len);
-    b_str = b_field->value_get(&b_str_len);
+    a_str = a_spot->value_get(&a_str_len);
+    b_str = b_spot->value_get(&b_str_len);
     if (a_str_len != b_str_len) {
       if (memcmp(a_str, b_str, a_str_len) != 0) {
         print_difference(a_str, a_str_len, b_str, b_str_len);
         return -1;
       }
     }
-
-    a_field = a->iter_get_next(&a_iter);
-    b_field = b->iter_get_next(&b_iter);
+    ++a_spot;
+    ++b_spot;
   }
 
   return 0;

--- a/proxy/http3/QPACK.cc
+++ b/proxy/http3/QPACK.cc
@@ -191,9 +191,8 @@ QPACK::encode(uint64_t stream_id, HTTPHdr &header_set, MIOBuffer *header_block, 
   IOBufferBlock *compressed_headers = new_IOBufferBlock();
   compressed_headers->alloc(BUFFER_SIZE_INDEX_2K);
 
-  MIMEFieldIter field_iter;
-  for (MIMEField *field = header_set.iter_get_first(&field_iter); field != nullptr; field = header_set.iter_get_next(&field_iter)) {
-    int ret            = this->_encode_header(*field, base_index, compressed_headers, referred_index);
+  for (auto &field : header_set) {
+    int ret            = this->_encode_header(field, base_index, compressed_headers, referred_index);
     largest_reference  = std::max(largest_reference, referred_index);
     smallest_reference = std::min(smallest_reference, referred_index);
     if (ret < 0) {

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -670,14 +670,9 @@ marshalMimeHdr(MIMEHdr *hdr, char *buf)
   ts::FixedBufferWriter bw(buf, bwSize);
 
   if (hdr) {
-    MIMEFieldIter mfIter;
-    const MIMEField *mfp = hdr->iter_get_first(&mfIter);
-
-    while (mfp) {
-      marshalStr(bw, *mfp, &MIMEField::name_get);
-      marshalStr(bw, *mfp, &MIMEField::value_get);
-
-      mfp = hdr->iter_get_next(&mfIter);
+    for (auto const &mfp : *hdr) {
+      marshalStr(bw, mfp, &MIMEField::name_get);
+      marshalStr(bw, mfp, &MIMEField::value_get);
     }
   }
 

--- a/proxy/logging/unit-tests/test_LogUtils.cc
+++ b/proxy/logging/unit-tests/test_LogUtils.cc
@@ -52,8 +52,6 @@ test(const MIMEField *pairs, int numPairs, const char *asciiResult, int extraUnm
 
   REQUIRE(binAlignSize < static_cast<int>(sizeof(binBuf)));
 
-  hdr.reset();
-
   REQUIRE(marshalMimeHdr(numPairs ? &hdr : nullptr, binBuf) == binAlignSize);
 
   int binSize{1};

--- a/proxy/logging/unit-tests/test_LogUtils.h
+++ b/proxy/logging/unit-tests/test_LogUtils.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cstring>
+#include <tscpp/util/MemSpan.h>
 
 struct MIMEField {
   const char *tag, *value;
@@ -42,34 +43,22 @@ struct MIMEField {
   }
 };
 
-struct MIMEFieldIter {
-};
-
 class MIMEHdr
 {
-public:
-  MIMEHdr(const MIMEField *first, int count) : _first(first), _count(count), _idx(0) {}
-
-  const MIMEField *
-  iter_get_first(MIMEFieldIter *)
-  {
-    return _idx < _count ? _first + _idx : nullptr;
-  }
-  const MIMEField *
-  iter_get_next(MIMEFieldIter *)
-  {
-    ++_idx;
-    return iter_get_first(nullptr);
-  }
-
-  void
-  reset()
-  {
-    _idx = 0;
-  }
-
 private:
-  const MIMEField *const _first;
-  const int _count;
-  int _idx;
+  ts::MemSpan<MIMEField const> _fields;
+
+public:
+  MIMEHdr(const MIMEField *first, int count) : _fields{first, size_t(count)} {}
+
+  auto
+  begin()
+  {
+    return _fields.begin();
+  }
+  auto
+  end()
+  {
+    return _fields.end();
+  }
 };


### PR DESCRIPTION
Changes for issue #7472. This removes the old "iter" methods and replaces them with an STL compliant iterator. Uses of the old methods are updated to use the new iterator.