### PR TITLE
Fix spacing in clang-analyzer.sh script

### DIFF
--- a/ci/jenkins/bin/clang-analyzer.sh
+++ b/ci/jenkins/bin/clang-analyzer.sh
@@ -47,7 +47,7 @@ if [ "${JOB_NAME#*-github}" != "${JOB_NAME}" ]; then
     ATS_BRANCH="github"
     if [ -w "${OUTPUT_BASE}/${ATS_BRANCH}" ]; then
         output="${OUTPUT_BASE}/${ATS_BRANCH}/${ghprbPullId}"
-        [ ! -d "${output}"] && mkdir "${output}"
+        [ ! -d "${output}" ] && mkdir "${output}"
     fi
     github_pr=" PR #${ghprbPullId}"
     results_url="https://ci.trafficserver.apache.org/clang-analyzer/${ATS_BRANCH}/${ghprbPullId}/"


### PR DESCRIPTION
I noticed this in my latest clang-analyzer.sh CI output:

```
++ '[' '!' -d '/home/jenkins/clang-analyzer/github/7279]'
/home/jenkins/bin/clang-analyzer.sh: line 50: [: missing `]'

```

See:
https://ci.trafficserver.apache.org/job/clang-analyzer-github/13244/consoleText