### PR TITLE
traffic_ctl - Fix lookup key for run-root option.

### DIFF
--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -104,7 +104,7 @@ versions of the content as :term:`alternates <alternate>`. When set to
 by the origin. Enabled by default.
 
 range-request
------
+-------------
 
 When set to ``true``, causes |TS| to compress responses to Range Requests.
 Disabled by default. Setting this to true while setting cache to false leads to delivering corrupted content.

--- a/doc/developer-guide/internal-libraries/ArgParser.en.rst
+++ b/doc/developer-guide/internal-libraries/ArgParser.en.rst
@@ -158,7 +158,9 @@ Classes
 
    .. function:: Option &add_option(std::string const &long_option, std::string const &short_option, std::string const &description, std::string const &envvar = "", unsigned arg_num = 0, std::string const &default_value = "", std::string const &key = "")
 
-      Add an option to current command with *long name*, *short name*, *help description*, *environment variable*, *arguments expected*, *default value* and *lookup key*. Return The Option object itself.
+      Add an option to current command with *long name*, *short name*, *help description*, *environment variable*, *arguments expected*, *default value* and *lookup key*.
+      If no *lookup key* is provided, the *long name* will be used as lookup key without the prefix, for instance, for a long option ``--debug`` you should use ``debug`` as
+      as lookup key. Return The Option object itself.
 
    .. function:: Command &add_command(std::string const &cmd_name, std::string const &cmd_description, std::function<void()> const &f = nullptr, std::string const &key = "")
 

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -275,7 +275,7 @@ main(int argc, const char **argv)
     diags->show_location                      = SHOW_LOCATION_DEBUG;
   }
 
-  argparser_runroot_handler(engine.arguments.get("--run-root").value(), argv[0]);
+  argparser_runroot_handler(engine.arguments.get("run-root").value(), argv[0]);
   Layout::create();
 
   // This is a little bit of a hack, for now it'll suffice.


### PR DESCRIPTION
During some tests I was running I found out that the `--run-root` option in `traffic_ctl` wasn't working as excpected. I seems that the argparser lookup key wasn't used correctly.
This PR:
- Fixes  the key for run-root option.
- Update ArgParser docs to make this clear. 
- Also fix another doc warning.