### PR TITLE
slice/server: handleFirstServerHeader exit sooner on detected requested range errors.

### DIFF
--- a/plugins/experimental/slice/Range.h
+++ b/plugins/experimental/slice/Range.h
@@ -29,7 +29,7 @@
 
 struct Range {
 public:
-  static int64_t constexpr maxval = (std::numeric_limits<int64_t>::max() >> 2);
+  static int64_t constexpr maxval = (std::numeric_limits<int64_t>::max() / 2);
 
   int64_t m_beg{-1};
   int64_t m_end{-1}; // half open

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -171,3 +171,12 @@ ps.Streams.stderr = "gold/slice_mid.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 response")
 ps.Streams.stdout.Content += Testers.ContainsExpression("Content-Range: bytes 5-16/18", "mismatch byte content response")
 tr.StillRunningAfter = ts
+
+# 8 Test - special case, begin inside last slice block but outside asset len
+tr = Test.AddTestRun("Invalid end range request, 416")
+beg = len(body) + 1
+end = beg + block_bytes
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slice/path' + ' -r {}-{}'.format(beg, end)
+ps.Streams.stdout.Content = Testers.ContainsExpression("416 Requested Range Not Satisfiable", "expected 416 response")
+tr.StillRunningAfter = ts


### PR DESCRIPTION
When examining the first server response header with a bad range request the function should exit sooner.

I was able to recreate a crash and added a test case for it.