### PR TITLE
Fix out of bounds access error in ats_base64_decode

### DIFF
--- a/src/tscore/ink_base64.cc
+++ b/src/tscore/ink_base64.cc
@@ -136,7 +136,7 @@ ats_base64_decode(const char *inBuffer, size_t inBufferSize, unsigned char *outB
 
   // Ignore any trailing ='s or other undecodable characters.
   // TODO: Perhaps that ought to be an error instead?
-  while (printableToSixBit[static_cast<uint8_t>(inBuffer[inBytes])] <= MAX_PRINT_VAL) {
+  while (inBytes < inBufferSize && printableToSixBit[static_cast<uint8_t>(inBuffer[inBytes])] <= MAX_PRINT_VAL) {
     ++inBytes;
   }
 


### PR DESCRIPTION
This fixes at minimum one of errors reported on #7489.

https://github.com/apache/trafficserver/commit/1ad4e81e37f1d21c9ee6d1075478cf6eee7e782e is the trigger of the CI job failure but the actual bug has been there for long time in `ats_base64_decode`.

On master, the functions is only used by plugins. Plugins using `ats_base64_decode` are access_control, metalink, magick, ssl_session_reuse, url_sig and lua.