### PR TITLE
Add zlib1g-dev to Debian dependencies in README (#7303)

### DIFF
--- a/README
+++ b/README
@@ -101,6 +101,7 @@ plugins to build large scale web applications.
     pkg-config
     libmodule-install-perl
     gcc/g++ or clang/clang++
+    zlib1g-dev
     libssl-dev
     libpcre3-dev
     libcap-dev (optional, highly recommended)


### PR DESCRIPTION
Hi,

I saw this issue and as I'd had the same problem (not had zlib downloaded) I thought I'd add it to the readme. I hope it's OK.