### PR TITLE
Move has_request_body to ProxyTransaction

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -215,3 +215,9 @@ ProxyTransaction::reenable(VIO *vio)
 {
   _proxy_ssn->reenable(vio);
 }
+
+bool
+ProxyTransaction::has_request_body(int64_t request_content_length, bool is_chunked) const
+{
+  return request_content_length > 0 || is_chunked;
+}

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -83,6 +83,9 @@ public:
 
   virtual void set_proxy_ssn(ProxySession *set_proxy_ssn);
 
+  // Returns true if there is a request body for this request
+  virtual bool has_request_body(int64_t content_length, bool is_chunked_set) const;
+
   /// Non-Virtual Methods
   //
   const char *get_protocol_string();

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1990,7 +1990,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
     server_session->set_inactivity_timeout(get_server_inactivity_timeout());
 
     // For requests that contain a body, we can cancel the ua inactivity timeout.
-    if (ua_txn && t_state.hdr_info.request_content_length) {
+    if (ua_txn && t_state.hdr_info.request_content_length != HTTP_UNDEFINED_CL) {
       ua_txn->cancel_inactivity_timeout();
     }
   }
@@ -3622,7 +3622,7 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
 
     // Now that we have communicated the post body, turn off the inactivity timeout
     // until the server starts sending data back
-    if (ua_txn && t_state.hdr_info.request_content_length) {
+    if (ua_txn && t_state.hdr_info.request_content_length != HTTP_UNDEFINED_CL) {
       ua_txn->cancel_inactivity_timeout();
     }
 
@@ -5035,8 +5035,8 @@ HttpSM::do_http_server_open(bool raw)
   }
 
   if ((raw == false) && TS_SERVER_SESSION_SHARING_MATCH_NONE != t_state.txn_conf->server_session_sharing_match &&
-      (t_state.txn_conf->keep_alive_post_out == 1 || t_state.hdr_info.request_content_length == 0) && !is_private() &&
-      ua_txn != nullptr) {
+      (t_state.txn_conf->keep_alive_post_out == 1 || t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) &&
+      !is_private() && ua_txn != nullptr) {
     HSMresult_t shared_result;
     shared_result = httpSessionManager.acquire_session(this,                                 // state machine
                                                        &t_state.current.server->dst_addr.sa, // ip + port
@@ -7500,7 +7500,7 @@ HttpSM::set_next_state()
       // light of this dependency, TS must ensure that the client finishes
       // sending its request and for this reason, the inactivity timeout
       // cannot be cancelled.
-      if (ua_txn && !t_state.hdr_info.request_content_length) {
+      if (ua_txn && t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) {
         ua_txn->cancel_inactivity_timeout();
       } else if (!ua_txn) {
         terminate_sm = true;
@@ -7545,7 +7545,7 @@ HttpSM::set_next_state()
       // light of this dependency, TS must ensure that the client finishes
       // sending its request and for this reason, the inactivity timeout
       // cannot be cancelled.
-      if (ua_txn && !t_state.hdr_info.request_content_length) {
+      if (ua_txn && t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) {
         ua_txn->cancel_inactivity_timeout();
       } else if (!ua_txn) {
         terminate_sm = true;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2110,7 +2110,9 @@ HttpSM::state_send_server_request_header(int event, void *data)
     free_MIOBuffer(server_entry->write_buffer);
     server_entry->write_buffer = nullptr;
     method                     = t_state.hdr_info.server_request.method_get_wksidx();
-    if (!t_state.api_server_request_body_set && method != HTTP_WKSIDX_TRACE && HttpTransact::has_request_body(&t_state, ua_txn)) {
+    if (!t_state.api_server_request_body_set && method != HTTP_WKSIDX_TRACE &&
+        ua_txn->has_request_body(t_state.hdr_info.request_content_length,
+                                 t_state.client_info.transfer_encoding == HttpTransact::CHUNKED_ENCODING)) {
       if (post_transform_info.vc) {
         setup_transform_to_server_transfer();
       } else {
@@ -6152,7 +6154,8 @@ HttpSM::attach_server_session(PoolableSession *s)
   server_session->set_active_timeout(get_server_active_timeout());
 
   // Do we need Transfer_Encoding?
-  if (HttpTransact::has_request_body(&t_state, ua_txn)) {
+  if (ua_txn->has_request_body(t_state.hdr_info.request_content_length,
+                               t_state.client_info.transfer_encoding == HttpTransact::CHUNKED_ENCODING)) {
     // See if we need to insert a chunked header
     if (!t_state.hdr_info.server_request.presence(MIME_PRESENCE_CONTENT_LENGTH)) {
       // Stuff in a TE setting so we treat this as chunked, sort of.

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1990,7 +1990,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
     server_session->set_inactivity_timeout(get_server_inactivity_timeout());
 
     // For requests that contain a body, we can cancel the ua inactivity timeout.
-    if (ua_txn && t_state.hdr_info.request_content_length != HTTP_UNDEFINED_CL) {
+    if (ua_txn && t_state.hdr_info.request_content_length > 0) {
       ua_txn->cancel_inactivity_timeout();
     }
   }
@@ -3622,7 +3622,7 @@ HttpSM::tunnel_handler_post_ua(int event, HttpTunnelProducer *p)
 
     // Now that we have communicated the post body, turn off the inactivity timeout
     // until the server starts sending data back
-    if (ua_txn && t_state.hdr_info.request_content_length != HTTP_UNDEFINED_CL) {
+    if (ua_txn && t_state.hdr_info.request_content_length > 0) {
       ua_txn->cancel_inactivity_timeout();
     }
 
@@ -5035,8 +5035,8 @@ HttpSM::do_http_server_open(bool raw)
   }
 
   if ((raw == false) && TS_SERVER_SESSION_SHARING_MATCH_NONE != t_state.txn_conf->server_session_sharing_match &&
-      (t_state.txn_conf->keep_alive_post_out == 1 || t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) &&
-      !is_private() && ua_txn != nullptr) {
+      (t_state.txn_conf->keep_alive_post_out == 1 || t_state.hdr_info.request_content_length <= 0) && !is_private() &&
+      ua_txn != nullptr) {
     HSMresult_t shared_result;
     shared_result = httpSessionManager.acquire_session(this,                                 // state machine
                                                        &t_state.current.server->dst_addr.sa, // ip + port
@@ -7500,7 +7500,7 @@ HttpSM::set_next_state()
       // light of this dependency, TS must ensure that the client finishes
       // sending its request and for this reason, the inactivity timeout
       // cannot be cancelled.
-      if (ua_txn && t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) {
+      if (ua_txn && t_state.hdr_info.request_content_length <= 0) {
         ua_txn->cancel_inactivity_timeout();
       } else if (!ua_txn) {
         terminate_sm = true;
@@ -7545,7 +7545,7 @@ HttpSM::set_next_state()
       // light of this dependency, TS must ensure that the client finishes
       // sending its request and for this reason, the inactivity timeout
       // cannot be cancelled.
-      if (ua_txn && t_state.hdr_info.request_content_length == HTTP_UNDEFINED_CL) {
+      if (ua_txn && t_state.hdr_info.request_content_length <= 0) {
         ua_txn->cancel_inactivity_timeout();
       } else if (!ua_txn) {
         terminate_sm = true;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1501,7 +1501,9 @@ HttpTransact::HandleRequest(State *s)
         }
       }
     }
-    if (s->txn_conf->request_buffer_enabled && has_request_body(s, s->state_machine->ua_txn)) {
+    if (s->txn_conf->request_buffer_enabled &&
+        s->state_machine->ua_txn->has_request_body(s->hdr_info.request_content_length,
+                                                   s->client_info.transfer_encoding == CHUNKED_ENCODING)) {
       TRANSACT_RETURN(SM_ACTION_WAIT_FOR_FULL_BODY, nullptr);
     }
   }
@@ -8847,15 +8849,6 @@ HttpTransact::change_response_header_because_of_range_request(State *s, HTTPHdr 
     // Always update the Content-Length: header.
     header->set_content_length(s->range_output_cl);
   }
-}
-
-bool
-HttpTransact::has_request_body(State *s, ProxyTransaction *txn)
-{
-  int method = s->hdr_info.client_request.method_get_wksidx();
-  return (method == HTTP_WKSIDX_POST || method == HTTP_WKSIDX_PUSH || method == HTTP_WKSIDX_PUT) &&
-         (s->hdr_info.request_content_length > 0 || s->client_info.transfer_encoding == CHUNKED_ENCODING ||
-          !txn->is_chunked_encoding_supported());
 }
 
 #if TS_HAS_TESTS

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1018,8 +1018,6 @@ public:
   static bool is_cache_hit(CacheLookupResult_t r);
   static bool is_fresh_cache_hit(CacheLookupResult_t r);
 
-  static bool has_request_body(State *s, ProxyTransaction *txn);
-
   static void build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_request, HTTPVersion outgoing_version);
   static void build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing_response, HTTPVersion outgoing_version,
                              HTTPStatus status_code, const char *reason_phrase = nullptr);

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -245,9 +245,12 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     if (stream == nullptr) {
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED,
                         "recv headers cannot find existing stream_id");
+    } else if (stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_STREAM_CLOSED,
+                        "recv_header to closed stream");
     } else if (!stream->has_trailing_header()) {
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
-                        "recv headers cannot find existing stream_id");
+                        "stream not expecting trailer header");
     }
   } else {
     // Create new stream

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1801,6 +1801,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   stream->change_state(HTTP2_FRAME_TYPE_PUSH_PROMISE, HTTP2_FLAGS_PUSH_PROMISE_END_HEADERS);
   stream->set_request_headers(hdr);
   stream->new_transaction();
+  stream->recv_end_stream = true; // No more data with the request
   stream->send_request(*this);
 
   return true;

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -191,6 +191,8 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     this->read_vio.nbytes = bufindex;
     this->signal_read_event(VC_EVENT_READ_COMPLETE);
   } else {
+    // End of header but not end of stream, must have some body frames coming
+    this->has_body = true;
     this->signal_read_event(VC_EVENT_READ_READY);
   }
 }
@@ -1011,4 +1013,10 @@ Http2Stream::read_vio_read_avail()
   }
 
   return 0;
+}
+
+bool
+Http2Stream::has_request_body(int64_t content_length, bool is_chunked_set) const
+{
+  return has_body;
 }

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -115,6 +115,8 @@ public:
   bool is_closed() const;
   IOBufferReader *response_get_data_reader() const;
 
+  bool has_request_body(int64_t content_length, bool is_chunked_set) const override;
+
   void mark_milestone(Http2StreamMilestone type);
 
   void increment_data_length(uint64_t length);
@@ -176,6 +178,7 @@ private:
   Milestones<Http2StreamMilestone, static_cast<size_t>(Http2StreamMilestone::LAST_ENTRY)> _milestones;
 
   bool trailing_header = false;
+  bool has_body        = false;
 
   // A brief discussion of similar flags and state variables:  _state, closed, terminate_stream
   //

--- a/proxy/http3/Http3Transaction.cc
+++ b/proxy/http3/Http3Transaction.cc
@@ -603,6 +603,13 @@ Http3Transaction::_on_qpack_decode_complete()
   return 1;
 }
 
+// TODO:  Just a place holder for now
+bool
+Http3Transaction::has_request_body(int64_t content_length, bool is_chunked_set) const
+{
+  return false;
+}
+
 //
 // Http09Transaction
 //

--- a/proxy/http3/Http3Transaction.h
+++ b/proxy/http3/Http3Transaction.h
@@ -106,6 +106,9 @@ public:
   bool is_response_header_sent() const;
   bool is_response_body_sent() const;
 
+  // TODO:  Just a place holder for now
+  bool has_request_body(int64_t content_length, bool is_chunked_set) const override;
+
 private:
   int64_t _process_read_vio() override;
   int64_t _process_write_vio() override;


### PR DESCRIPTION
This fixes an issue introduced by PR #7473 which I noticed while testing in production with that patch on my H2 to origin branch . The number of ERR_INVALID_REQ codes went up which I tracked down to requests using the PROPFIND method and sending a request body. 

My fix in PR #7473 makes the erroneous assumption that only POST, PUSH, and PUT methods will have request bodies instead of any method (except trace?) with the appropriate content length or transfer encoding headers (for HTTP/1.x) or with the appropriate end-stream flags (for HTTP/2).

This PR moves the logic about whether to expect a request body into the ProxyTransaction.  I put in a default implementation that looks at the header values and override it for HTTP/2 to consider the stream state flags at the time the headers were received.

I will be continuing to test with this patch with my H2 to origin testing.