### PR TITLE
Disable ja3 plugin when building with boringssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1363,7 +1363,7 @@ AC_EGREP_CPP(yes, [
   #endif
   ], [
     AC_MSG_RESULT(yes)
-    AS_IF([test "x${enable_experimental_plugins}" = "xyes"], [
+    AS_IF([test "x${enable_experimental_plugins}" = "xyes" && -z "$openssl_is_boringssl"], [
       enable_ja3_plugin=yes
     ])
   ], [AC_MSG_RESULT(no)])


### PR DESCRIPTION
SSL_client_hello_get0_legacy_version is not available under boringssl