### PR TITLE
Add ALPN support on TLS Partial Blind Tunnel

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -139,6 +139,11 @@ partial_blind_route       Destination as an FQDN and port, separated by a colon 
                           In addition partial_blind_route creates a new TLS connection to the specified origin.
                           It does not interpret the decrypted data before passing it to the origin TLS
                           connection, so the contents do not need to be HTTP.
+
+tunnel_alpn               List of ALPN Protocol Ids for Partial Blind Tunnel.
+
+                          ATS negotiates application protocol with the client on behalf of the origin server.
+                          This only works with ``partial_blind_route``.
 ========================= ========================================================================================
 
 Client verification, via ``verify_client``, corresponds to setting

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -95,7 +95,8 @@ private:
 class TunnelDestination : public ActionItem
 {
 public:
-  TunnelDestination(const std::string_view &dest, SNIRoutingType type) : destination(dest), type(type)
+  TunnelDestination(const std::string_view &dest, SNIRoutingType type, const std::vector<int> &alpn)
+    : destination(dest), type(type), alpn_ids(alpn)
   {
     need_fix = (destination.find_first_of('$') != std::string::npos);
   }
@@ -115,8 +116,14 @@ public:
       } else {
         ssl_netvc->set_tunnel_destination(destination, type);
       }
+
       if (type == SNIRoutingType::BLIND) {
         ssl_netvc->attributes = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
+      }
+
+      // ALPN
+      for (int id : alpn_ids) {
+        ssl_netvc->enableProtocol(id);
       }
     }
 
@@ -191,6 +198,7 @@ private:
 
   std::string destination;
   SNIRoutingType type = SNIRoutingType::NONE;
+  const std::vector<int> &alpn_ids;
   bool need_fix;
 };
 

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -77,7 +77,7 @@ SNIConfigParams::loadSNIConfig()
       ai->actions.push_back(std::make_unique<TLSValidProtocols>(item.protocol_mask));
     }
     if (item.tunnel_destination.length() > 0) {
-      ai->actions.push_back(std::make_unique<TunnelDestination>(item.tunnel_destination, item.tunnel_type));
+      ai->actions.push_back(std::make_unique<TunnelDestination>(item.tunnel_destination, item.tunnel_type, item.tunnel_alpn));
     }
 
     ai->actions.push_back(std::make_unique<SNI_IpAllow>(item.ip_allow, item.fqdn));

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -38,6 +38,7 @@ TSDECL(verify_client_ca_certs);
 TSDECL(tunnel_route);
 TSDECL(forward_route);
 TSDECL(partial_blind_route);
+TSDECL(tunnel_alpn);
 TSDECL(verify_server_policy);
 TSDECL(verify_server_properties);
 TSDECL(verify_origin_server);
@@ -88,6 +89,7 @@ struct YamlSNIConfig {
     std::string ip_allow;
     bool protocol_unset = true;
     unsigned long protocol_mask;
+    std::vector<int> tunnel_alpn{};
 
     void EnableProtocol(YamlSNIConfig::TLSProtocol proto);
   };

--- a/lib/records/I_RecHttp.h
+++ b/lib/records/I_RecHttp.h
@@ -167,6 +167,8 @@ public:
   static int constexpr MAX     = SessionProtocolSet::MAX; ///< Maximum # of registered names.
   static int constexpr INVALID = -1;                      ///< Normalized invalid index value.
 
+  static std::string_view convert_openssl_alpn_wire_format(int index);
+
   using TextView = ts::TextView;
 
   /// Default constructor.
@@ -194,6 +196,15 @@ public:
       @return A pointer to the name or @c nullptr if the index isn't registered.
   */
   TextView nameFor(int index) const;
+
+  /** Convert an @a index to the corresponding name in OpenSSL ALPN wire format.
+
+      OpenSSL ALPN wire format (vector of non-empty, 8-bit length-prefixed, byte strings)
+      https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_alpn_protos.html
+
+      @return A pointer to the name or @c nullptr if the index isn't registered.
+  */
+  static TextView wireNameFor(int index);
 
   /// Mark protocols as present in @a sp_set based on the names in @a value.
   /// The names can be separated by ;/|,: and space.

--- a/lib/records/RecHttp.cc
+++ b/lib/records/RecHttp.cc
@@ -198,6 +198,12 @@ size_t const OPT_OUTBOUND_IP_PREFIX_LEN = strlen(HttpProxyPort::OPT_OUTBOUND_IP_
 size_t const OPT_INBOUND_IP_PREFIX_LEN  = strlen(HttpProxyPort::OPT_INBOUND_IP_PREFIX);
 size_t const OPT_HOST_RES_PREFIX_LEN    = strlen(HttpProxyPort::OPT_HOST_RES_PREFIX);
 size_t const OPT_PROTO_PREFIX_LEN       = strlen(HttpProxyPort::OPT_PROTO_PREFIX);
+
+constexpr std::string_view TS_ALPN_PROTO_ID_OPENSSL_HTTP_0_9("\x8http/0.9");
+constexpr std::string_view TS_ALPN_PROTO_ID_OPENSSL_HTTP_1_0("\x8http/1.0");
+constexpr std::string_view TS_ALPN_PROTO_ID_OPENSSL_HTTP_1_1("\x8http/1.1");
+constexpr std::string_view TS_ALPN_PROTO_ID_OPENSSL_HTTP_2("\x2h2");
+constexpr std::string_view TS_ALPN_PROTO_ID_OPENSSL_HTTP_3("\x2h3");
 } // namespace
 
 namespace
@@ -758,6 +764,31 @@ RecNormalizeProtoTag(const char *tag)
 {
   auto findResult = TSProtoTags.find(tag);
   return findResult == TSProtoTags.end() ? nullptr : findResult->data();
+}
+
+/**
+   Convert TS_ALPN_PROTOCOL_INDEX_* into OpenSSL ALPN Wire Format
+
+   https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_alpn_protos.html
+
+   TODO: support dynamic generation of wire format
+ */
+std::string_view
+SessionProtocolNameRegistry::convert_openssl_alpn_wire_format(int index)
+{
+  if (index == TS_ALPN_PROTOCOL_INDEX_HTTP_0_9) {
+    return TS_ALPN_PROTO_ID_OPENSSL_HTTP_0_9;
+  } else if (index == TS_ALPN_PROTOCOL_INDEX_HTTP_1_0) {
+    return TS_ALPN_PROTO_ID_OPENSSL_HTTP_1_0;
+  } else if (index == TS_ALPN_PROTOCOL_INDEX_HTTP_1_1) {
+    return TS_ALPN_PROTO_ID_OPENSSL_HTTP_1_1;
+  } else if (index == TS_ALPN_PROTOCOL_INDEX_HTTP_2_0) {
+    return TS_ALPN_PROTO_ID_OPENSSL_HTTP_2;
+  } else if (index == TS_ALPN_PROTOCOL_INDEX_HTTP_3) {
+    return TS_ALPN_PROTO_ID_OPENSSL_HTTP_3;
+  }
+
+  return {};
 }
 
 int

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5168,6 +5168,14 @@ HttpSM::do_http_server_open(bool raw)
     SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(ua_txn->get_netvc());
     if (ssl_vc && raw) {
       tls_upstream = ssl_vc->upstream_tls();
+
+      // ALPN on TLS Partial Blind Tunnel - set negotiated ALPN id
+      if (ssl_vc->tunnel_type() == SNIRoutingType::PARTIAL_BLIND) {
+        int pid = ssl_vc->get_negotiated_protocol_id();
+        if (pid != SessionProtocolNameRegistry::INVALID) {
+          opt.alpn_protos = SessionProtocolNameRegistry::convert_openssl_alpn_wire_format(pid);
+        }
+      }
     }
     opt.local_port = ua_txn->get_outbound_port();
 


### PR DESCRIPTION
# Motivation
HTTP/2 over TLS Partial Blind Tunnel support.

# Approach
ATS negotiates application protocol with the client on behalf of the origin server. ATS uses the negotiated protocol id on ClientHello to the origin server ( for the Partial Blind Tunnel )

<img width="558" alt="Screen Shot 2021-02-09 at 16 11 59" src="https://user-images.githubusercontent.com/741391/107328138-9a1a2780-6af1-11eb-8426-9edb9b92abab.png">

Ideally, ATS should forward the protocol list from the client first and wait for ServerHello from the origin server. But it requires changing the whole design of the Partial Blind Tunnel, so I'm on this hacky approach.

# Config
`tunnel_alpn` on `sni.yaml` takes a list of protocol id for the Partial Blind Tunnel.

# Link
Part of #7241.
Depends on #7491.