### PR TITLE
Parent autest

### DIFF
--- a/tests/gold_tests/custom_routing/parent_basic.test.py
+++ b/tests/gold_tests/custom_routing/parent_basic.test.py
@@ -1,0 +1,91 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import util
+import pop
+Test.Summary = '''
+Basic Parent selection test.
+'''
+
+
+sys.path += [Test.TestDirectory]  # allows importing other modules
+
+pop.Test = Test
+pop.Testers = Testers
+pop.When = When
+
+util.Test = Test
+util.Testers = Testers
+
+# Needs Curl
+Test.SkipUnless(
+    Condition.HasProgram("curl", "curl needs to be installed on system for this test to work"),
+    Condition.HasProgram("nc", "nc needs to be installed on system for this test to work")
+)
+Test.ContinueOnFail = False
+
+# Make a fake origin server
+origin = Test.MakeOriginServer("origin")
+
+# Define multiple ATS nodes, per pop
+num_hosts = 2
+edge = pop.makeATS(['edge' + str(i) for i in range(num_hosts)], origin)
+mid = pop.makeATS(['mid' + str(i) for i in range(num_hosts)], origin)
+
+# setup dns for all ats servers
+dns = Test.MakeDNServer("dns")
+pop.cfgDNS(edge + mid, dns)
+
+# configure edge to shard to mid
+pop.cfgParents(edge, mid)
+
+routing_logs = pop.enableRoutingLog(edge + mid)
+
+all_proc = edge + mid + [dns, origin]
+
+pop.cfgResponse(origin, dns, 'parent.test', '/basic.txt', "hello")
+
+# START ROUTING TESTS
+
+# Basic Parent Test
+tr = Test.AddTestRun("Test traffic server started properly")
+p = tr.Processes.Default
+p.Command = "curl --proxy 127.0.0.1:{} http://parent.test/basic.txt".format(edge[0].Variables.port)
+#p.Command += '; sleep 2; cat '+routing_logs[0]
+p.ReturnCode = 0
+pop.waitAllStarted(tr, all_proc)
+p.StillRunningAfter = all_proc
+
+# END ROUTING TESTS
+tr = pop.checkAllProcessRunning(all_proc)
+
+
+# Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
+tr = Test.AddTestRun('poll logs')
+ts = edge[0]
+cmd_text = os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + routing_logs[0]
+print(cmd_text)
+tr.Processes.Default.Command = cmd_text
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun("parse logs")
+log = tr.Disk.File(routing_logs[0])
+
+util.logContains(log, "parent")

--- a/tests/gold_tests/custom_routing/pop.py
+++ b/tests/gold_tests/custom_routing/pop.py
@@ -1,0 +1,184 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import socket
+from ports import get_port
+import socket
+import time
+
+from util import debugOut, addLogging
+
+When = None
+Test = None
+Testers = None
+localhost = socket.gethostname()
+start_time = time.clock()
+
+
+def makeATS(name, origin):
+    if (not isinstance(name, str)) and isinstance(name, list):
+        return [makeATS(p, origin) for p in name]
+    # name -> ts.Name
+    # return <- ts
+
+    ts = Test.MakeATSProcess(name)
+
+    ts.Disk.records_config.update({
+        'proxy.config.http.response_via_str': 3,
+        'proxy.config.http.cache.http': 1,
+        'proxy.config.http.wait_for_cache': 1,
+    })
+
+    ts.Env['PROXY_CONFIG_HTTP_SERVER_PORTS'] = "{} {}:ipv6 ".format(ts.Variables.port, ts.Variables.portv6)
+
+    ts.Disk.remap_config.AddLine(
+        'map / http://127.0.0.1:{port}'.format(port=origin.Variables.Port)
+    )
+
+    debugOut('makeATS', ts.Name, ts.Variables.port)
+    return ts
+
+
+def enableRoutingLog(ts):
+    if isinstance(ts, list):
+        ret = []
+        for p in ts:
+            ret += [enableRoutingLog(p)]
+        return ret
+    # log format:
+    log_fmt_str = ' '.join([
+        '%<cquuc>',         # client_req_unmapped_url_canonical
+        '%<crc>',           # cache_resp_code
+        '%<nhi>:%<nhp>',    # nexthop_ip:port
+        '%<pqsi>:%<pqsp>',  # server_ip:port
+        '%<sssc>',          # server_resp_code
+        '%<sstc>',          # server_transact_count
+    ])
+    return addLogging(ts, 'routing.log', 'routing', log_fmt_str)
+
+    #test.Disk.File(logfilename, exists=True).Content = Testers.FileContentCallback(g, 'validate_forwards_logged')
+
+
+def addPort(ts, port_name, ipv6=False):
+    if isinstance(ts, list):
+        for p in ts:
+            addPort(ts, port_name, ipv6)
+        return
+    get_port(ts, port_name)
+    ts.Env['PROXY_CONFIG_HTTP_SERVER_PORTS'] += "{}{}".format(ts.Variables[port_name], ':ipv6' if ipv6 else '')
+    debugOut('addPort', [ts.Name, port_name, ts.Variables[port_name]])
+
+
+def cfgDNS(ts, dns):
+    if isinstance(ts, list):
+        for p in ts:
+            cfgDNS(p, dns)
+        return
+
+    debugOut('cfgDNS', ts.Name, dns.Name)
+    dns.addRecords(records={ts.Name: ['127.0.0.1', '::{}'.format(ts.Variables.port)]})
+    ts.Disk.records_config.update({
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.url_remap.remap_required': 0,
+        'proxy.config.http.connect_attempts_timeout': 5
+    })
+
+
+def cfgParents(ts, parents):
+    if isinstance(ts, list):
+        for p in ts:
+            cfgParents(p, parents)
+        return
+
+    debugOut('cfgParents', '{} -> {}'.format(ts.Name, [p.Name for p in parents]))
+
+    # update debug tags
+    ts.Disk.records_config.update({
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'parent_select|conn'
+    })
+
+    # setup parent config
+    fname = os.path.join(ts.Variables.CONFIGDIR, "parent.config")
+    file = ts.Disk.File(fname, id='parent_config', typename="ats:config")
+
+    # write the config file to map to all nodes in the Pod
+    parent_fmt_list = ';'.join([localhost + ':{}'.format(p.Variables.port) for p in parents])
+    config_text = 'dest_domain=. parent="{}" round_robin=consistent_hash'.format(parent_fmt_list)
+    file.AddLine(config_text)
+
+    # Each process starts and waits for ready serially.
+    # So to wait until all nodes are up and have passed a health check,
+    # we will create a test with a custom ready conditions rather than use the process ready feature.
+    # ts.Ready = When.FileContains(ts.Disk.diags_log.AbsPath, 'healthcheck status to 1 at time')#, len(peers)-1)
+
+    ts.StartupTimeout = 15
+    ts.TimeOut = 150
+
+    debugOut('/cfgParents', [fname, config_text])
+
+
+def cfgHC(ts, up):
+    """Configure the Healthcheck plugin
+
+    Args:
+        ts (object): ATS instance
+        up (bool): set it to be in an UP state.
+    """
+    if isinstance(ts, list):
+        for p in ts:
+            cfgHC(p, up)
+        return
+    debugOut('cfgHC', [ts, up])
+    hc_conf_file = os.path.join(Test.RunDirectory, "hc_{}.config".format(ts.Name))
+    status_file = os.path.join(Test.RunDirectory, "status_{}.html".format(ts.Name))
+    ts.Disk.plugin_config.AddLine('healthchecks.so ' + hc_conf_file)
+    with open(hc_conf_file, 'w') as f:
+        f.write('/status.html {} text/plain 200 404'.format(status_file))
+        ts.Disk.File(hc_conf_file, id='ats_hc_up', typename="ats:config")
+    if up:
+        with open(status_file, 'w') as f:
+            f.write('some status msg')
+            ts.Disk.File(status_file, id='hc_status_{}'.format(ts.Name), typename="ats:config")
+
+
+def waitAllStarted(tr, proc_list, when_cond=None):
+    if not isinstance(proc_list, list):
+        proc_list = [proc_list]
+    for proc in proc_list:
+        tr.Processes.Default.StartBefore(proc, when_cond=when_cond)
+    return tr
+
+
+def checkAllProcessRunning(proc_list):
+    tr = Test.AddTestRun("Check all processes still running.")
+    tr.StillRunningAfter = proc_list
+    tr.TimeOut = 2
+    tr.Processes.Default.Command = 'echo ' + tr.Name
+    return tr
+
+
+def cfgResponse(server, dns, host, path, body="", cc="", resp_code=200):
+    dns.addRecords(records={host: ['127.0.0.1', '::{}'.format(server.Variables.Port)]})
+    request_header = {
+        "headers": "GET {} HTTP/1.1\r\nHost: {}\r\n\r\n".format(path, host), "timestamp": "1469733493.993", "body": ""}
+    response_header = {"headers": "HTTP/1.1 {} OK\r\nConnection: close\r\nCache-Control: {}\r\n\r\n".format(
+        resp_code, cc), "timestamp": "1469733493.993", "body": body}
+    server.addResponse("sessionlog.json", request_header, response_header)

--- a/tests/gold_tests/custom_routing/util.py
+++ b/tests/gold_tests/custom_routing/util.py
@@ -1,0 +1,164 @@
+from pprint import pprint
+import os
+import socket
+from ports import get_port
+import socket
+import time
+
+When = None
+Test = None
+Testers = None
+localhost = socket.gethostname()
+start_time = time.clock()
+
+
+def pluginPath():
+    p = Test.TestDirectory
+    return p[:p.rfind('/')]
+
+
+def getStr(obj):
+    try:
+        return obj.Name
+    except BaseException:
+        pass
+    return str(obj)
+
+
+def debugOut(func, *kargs):
+    dt = str(int(1000 * (time.clock() - start_time)))
+    print('{:5} {:<15} -'.format(dt, func), *kargs)
+
+
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+def extract(content, prefix, suffix):
+    a = content.find(prefix)
+    if a == -1:
+        return None
+    a += len(prefix)
+    b = content.find(suffix, a)
+    if b == -1:
+        return None
+    return content[a:b]
+
+
+def addLogging(ts, filename, name, log_fmt_str):
+
+    ts.Disk.records_config.update({
+        'proxy.config.log.logging_enabled': 3,
+        'proxy.config.log.max_secs_per_buffer': 1,
+    })
+
+    if hasattr(ts.Disk, 'logging_yaml'):
+        cfg_text = '''
+logging:
+  formats:
+    - name: {name}
+      format: "{fmt}"
+  logs:
+    - filename: {filename}
+      format: {name}
+'''
+        cfg_file = ts.Disk.logging_yaml
+    else:
+        cfg_text = '''{name} = format {
+        Format = "{fmt}"
+        }
+
+        log.ascii {
+        Format = {name},
+        Filename = '{filename}'
+        } '''
+        cfg_file = ts.Disk.logging_config
+
+    cfg_text = cfg_text.format(filename=filename, fmt=log_fmt_str, name=name)
+    cfg_file.AddLine(cfg_text)
+    debugOut('addLogging', filename)
+
+    return os.path.join(ts.Variables.LOGDIR, filename)
+
+
+def saveLogging(ts, filename):
+    tr = Test.AddTestRun('Save ' + filename)
+    tr.Processes.Default.Command = '; sleep 1'
+    ts_list = ts if isinstance(ts, list) else[ts]
+    for ts in ts_list:
+        src_f = ts.Disk.File(filename)
+        dst_f = tr.Disk.File(ts.Name + '_' + filename)
+        debugOut('move file ', [src_f, dst_f])
+        tr.Processes.Default.Command += '; mv {src} {dst}'.format(src_f.filename, dst_f.filename)
+
+
+def logFindStrings(content, substr_list):
+    debugOut('logFindStrings', substr_list)
+    for line in content.split('\n'):
+        i = 0
+        found = ''
+        for s in substr_list:
+            i = line.find(s, i)
+            if i == -1:
+                break
+            found += '^' * (i - len(found)) + s
+            i += len(s)
+
+        if i > 0:
+            print('\n' + line)
+            print(found)
+            return ''  # everything found in one line
+    print('missing ' + str(substr_list))
+    return 'missing ' + str(substr_list)
+
+
+def logContains(log, substr_list):
+    def f(content): return logFindStrings(content, substr_list)
+    log += Testers.FileContentCallback(f, 'logFindStrings')
+
+    #g = lambda x: validate_forwards_logged(x, owner_name, ingress)
+    #logfilename = os.path.join(ts.Variables.LOGDIR, 'carp{}.log'.format(ts.Variables.port))
+    #Test.Disk.File(logfilename, exists=True).Content = Testers.FileContentCallback(g, 'validate_forwards_logged')
+
+
+def objSearch(obj, key, prefix=[], ignore=None):
+    if obj is not dict:
+        try:
+            methods = dir(obj)
+            obj = obj.__dict__
+        except BaseException:
+            return
+    for k in obj:
+        if k.find(key) >= 0:
+            print('.'.join(prefix + [k]))
+            # pprint(type(obj[k]))
+            # if type(obj[k]) == dict:
+            #    pprint(obj[k])
+            # if type(obj[k]) != str:
+            #    pprint(dir(obj[k]))
+            #    if '__dict__' in dir(obj[k]):
+            #        pprint(obj[k].__dict__)
+            return
+        if ignore and k.find(ignore) >= 0:
+            continue
+        if len(prefix) < 12 and k not in prefix:
+            objSearch(obj[k], key, prefix + [k], ignore)
+
+    for k in methods:
+        if k.find(key) >= 0:
+            print('.'.join(prefix + [k]))

--- a/tests/gold_tests/custom_routing/util.py
+++ b/tests/gold_tests/custom_routing/util.py
@@ -123,13 +123,14 @@ def logFindStrings(content, substr_list):
             print('\n' + line)
             print(found)
             return ''  # everything found in one line
-    print('missing ' + str(substr_list))
+    print(content)
+    print('----\nmissing ' + str(substr_list))
     return 'missing ' + str(substr_list)
 
 
 def logContains(log, substr_list):
     def f(content): return logFindStrings(content, substr_list)
-    log += Testers.FileContentCallback(f, 'logFindStrings')
+    log.Content += Testers.FileContentCallback(f, 'logFindStrings')
 
     #g = lambda x: validate_forwards_logged(x, owner_name, ingress)
     #logfilename = os.path.join(ts.Variables.LOGDIR, 'carp{}.log'.format(ts.Variables.port))


### PR DESCRIPTION
WIP
This is an attempt for autests to run a complete CDN, and evaluate via headers for correct routing and caching behavior for parent selection or other upstream routing plugins.

TODO: 
+ move pop.py and util.py into autest extensions?
+ use namespace to create 8+ virtual IPs 
+ use the virtual IPs for each process. [DNS, uServer, ATS]
+ convert carp's cacheControl autests for parent selection.
+ replicate tests for Nexthop
+ replicate tests for Rob's Router Plugin
+ write test for CARP style architecture (single pop, self hashing)

Notes:
ParentSelection's self detection may/will cause issues. I'm hoping the VIP will work for it.