### PR TITLE
Fix out of bounds access error in jtest

### DIFF
--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -4800,7 +4800,7 @@ ink_web_escapify_string(char *dest_in, char *src_in, int max_dest_len)
   int quit   = 0;
 
   while ((*src != 0) && (dcount < max_dest_len) && (quit == 0)) {
-    if ((char *)memchr(dontescapify, *src, INT_MAX) || ParseRules::is_alpha(*src) || ParseRules::is_digit(*src)) {
+    if ((char *)strchr(dontescapify, *src) || ParseRules::is_alpha(*src) || ParseRules::is_digit(*src)) {
       /* this is regular character, don't escapify it */
       if (dcount + 1 < max_dest_len) {
         *dest++ = *src;


### PR DESCRIPTION
Found on Fedora 34 (GCC 11)
```
make[1]: Entering directory '/home/masakazu/git/trafficserver/tools'
  CXX      jtest/jtest.o
In file included from jtest/jtest.cc:27:
In function 'const void* memchr(const void*, int, size_t)',
    inlined from 'int ink_web_escapify_string(char*, char*, int)' at jtest/jtest.cc:4803:23:
/usr/include/string.h:86:27: error: 'void* __builtin_memchr(const void*, int, long unsigned int)' specified bound 2147483647 exceeds source size 15 [-Werror=stringop-overread]
   86 |   return __builtin_memchr (__s, __c, __n);
      |          ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```