### PR TITLE
Add server_name option to proxy.config.ssl.client.sni_policy

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3636,6 +3636,9 @@ Client-Related Configuration
    ``host``
       This is the default. The value of the ``Host`` field in the proxy request is used.
 
+   ``server_name``
+      The SNI value of the inbound TLS connection is used.
+
    ``remap``
       The remapped upstream name is used.
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4874,6 +4874,8 @@ HttpSM::get_outbound_sni() const
     int len;
     char const *ptr = t_state.hdr_info.server_request.host_get(&len);
     zret.assign(ptr, len);
+  } else if (ua_txn && !strcmp(policy, "server_name"_tv)) {
+    zret.assign(ua_txn->get_netvc()->get_server_name(), ts::TextView::npos);
   } else if (policy.front() == '@') { // guaranteed non-empty from previous clause
     zret = policy.remove_prefix(1);
   } else {

--- a/tests/gold_tests/tls/tls_verify_override_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_override_base.test.py
@@ -21,7 +21,7 @@ Test tls server certificate verification options. Exercise conf_remap
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", select_ports=True)
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server_foo = Test.MakeOriginServer("server_foo",
                                    ssl=True,
                                    options={"--key": "{0}/signed-foo.key".format(Test.RunDirectory),
@@ -85,10 +85,16 @@ ts.Disk.remap_config.AddLine(
     'map /snipolicyfoohost  https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=host'.format(
         server_bar.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
+    'map /snipolicyfooservername  https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=server_name'.format(
+        server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine(
     'map /snipolicybarremap  https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=remap'.format(
         server_bar.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
     'map /snipolicybarhost  https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=host'.format(
+        server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine(
+    'map /snipolicybarservername  https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=server_name'.format(
         server_bar.Variables.SSL_Port))
 
 ts.Disk.ssl_multicert_config.AddLine(
@@ -194,6 +200,15 @@ tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not connect", "Curl attempt should fail")
 
 # Should fail
+tr = Test.AddTestRun("foo-to-bar-sni-policy-servername")
+tr.Processes.Default.Command = "curl -k --resolv foo.com:{0}:127.0.0.1 https://foo.com:{0}/snipolicybarservername".format(
+    ts.Variables.ssl_port)
+tr.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not connect", "Curl attempt should fail")
+
+# Should fail
 tr = Test.AddTestRun("bar-to-foo-sni-policy-remap")
 tr.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfooremap".format(ts.Variables.port)
 tr.ReturnCode = 0
@@ -204,6 +219,15 @@ tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not conn
 # Should succeed
 tr = Test.AddTestRun("bar-to-foo-sni-policy-host")
 tr.Processes.Default.Command = "curl -k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfoohost".format(ts.Variables.port)
+tr.ReturnCode = 0
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could not connect", "Curl attempt should succeed")
+
+# Should succeed
+tr = Test.AddTestRun("bar-to-foo-sni-policy-servername")
+tr.Processes.Default.Command = "curl -k --resolv bar.com:{0}:127.0.0.1 https://bar.com:{0}/snipolicyfooservername".format(
+    ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts


### PR DESCRIPTION
To forward SNI in particular with the Partial Blind Tunnel case. It's almost the same as ` proxy.config.ssl.client.sni_policy=host` + `proxy.config.url_remap.pristine_host_hdr=1`, but we can't rely on `host` in the Partial Blind Tunnel case.