### PR TITLE
Fix the schedule AuTest for 9.1.x: use PrepareTestPlugin

### DIFF
--- a/tests/gold_tests/cont_schedule/schedule.test.py
+++ b/tests/gold_tests/cont_schedule/schedule.test.py
@@ -38,7 +38,7 @@ ts.Disk.records_config.update({
 })
 
 # Load plugin
-Test.PreparePlugin(os.path.join(Test.Variables.AtsTestToolsDir, 'plugins', 'cont_schedule.cc'), ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'cont_schedule.so'), ts)
 
 # www.example.com Host
 tr = Test.AddTestRun()


### PR DESCRIPTION
By reverting cefe4826c919847385aa9d8459b9d5cfc20377f9 from master (see
0bc58d28412bdc58859431c9eaf3cefffd2acabb) we also reverted some test
updates in addition to removing the incompatible API change. This
addresses that by fixing the schedule.test.py to use the new
PrepareTestPlugin API that master uses.

Fixes #7538. This is a 9.1.x only change.