### PR TITLE
Fix tls_session_reuse test

### DIFF
--- a/tests/gold_tests/tls/tls_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_session_reuse.test.py
@@ -111,7 +111,8 @@ tr.Command = \
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts1)
-tr.Processes.Default.Streams.All = Testers.ContainsExpression('Reused, TLSv1.2', '')
+tr.Processes.Default.Streams.All = Testers.ContainsExpression('Reused, TLSv', '')
+tr.Processes.Default.Streams.All += Testers.ContainsExpression('Protocol  : TLSv1.2', '')
 tr.StillRunningAfter = server
 
 tr = Test.AddTestRun("TLSv1.2 Session Ticket")
@@ -121,7 +122,8 @@ tr.Command = \
     .format(ts2.Variables.ssl_port, os.path.join(Test.RunDirectory, 'sess.dat'))
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts2)
-tr.Processes.Default.Streams.All = Testers.ContainsExpression('Reused, TLSv1.2', '')
+tr.Processes.Default.Streams.All = Testers.ContainsExpression('Reused, TLSv', '')
+tr.Processes.Default.Streams.All += Testers.ContainsExpression('Protocol  : TLSv1.2', '')
 tr.StillRunningAfter = server
 
 tr = Test.AddTestRun("Disabled Session Cache")


### PR DESCRIPTION
Autest tls_session_reuse, which was added on #7529, fails on master. Output formats slightly differ depending on OpenSSL versions.

1.0.2
```
Reused, TLSv1/SSLv3, Cipher is ECDHE-RSA-CHACHA20-POLY1305
Server public key is 2048 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
```
1.1.1
```
Reused, TLSv1.2, Cipher is ECDHE-ECDSA-CHACHA20-POLY1305
Server public key is 256 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
```