### PR TITLE
Fix origin_session_reuse test

### DIFF
--- a/tests/gold_tests/tls/tls_origin_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_origin_session_reuse.test.py
@@ -149,7 +149,7 @@ ts4.Disk.records_config.update({
     'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
     'proxy.config.ssl.session_cache.timeout': 0,
     'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 0,
+    'proxy.config.ssl.server.session_ticket.enable': 1,
     'proxy.config.ssl.origin_session_cache': 1,
     'proxy.config.ssl.origin_session_cache.size': 1
 })
@@ -167,8 +167,8 @@ ts5.Disk.records_config.update({
     'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
     'proxy.config.ssl.session_cache.timeout': 0,
     'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 0,
-    'proxy.config.ssl.origin_session_cache': 1,
+    'proxy.config.ssl.server.session_ticket.enable': 1,
+    'proxy.config.ssl.origin_session_cache': 0,
     'proxy.config.ssl.origin_session_cache.size': 1
 })
 
@@ -196,7 +196,7 @@ ts3.Streams.All += Testers.ContainsExpression('new session to origin', '')
 ts3.Streams.All += Testers.ContainsExpression('reused session to origin', '')
 tr.StillRunningAfter = server
 
-tr = Test.AddTestRun('disable tls tickets, reuse should fail')
+tr = Test.AddTestRun('disable origin session reuse, reuse should fail')
 tr.Processes.Default.Command = 'curl https://127.0.0.1:{0} -k && curl https://127.0.0.1:{0} -k'.format(ts5.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts4)


### PR DESCRIPTION
The reason of tls_origin_session_reuse failure on autest-master job is TLS version used on the test.

Current test passes only if the connection is TLS 1.3, because a session can be resumed by session id on TLS 1.2.
The box for autest-github has recent OpenSSL and it supports TLS 1.3, so disabling ticket means disabling session reuse.
On the other hand, the box for autest-master has OpenSSL 1.0.2 and it does not support TLS 1.3, so disabling ticket does not mean disabling session reuse.
I confirmed on my laptop that the test fails if I set `proxy.config.ssl.TLSv1_3` to 0 on the test file.

In short, disabling ticket is not enough for disabling session reuse.
On this test, I think we should check that we can disable session reuse at all by setting `origin_session_cache` to 0. In that sense, we may want to have two tests, one for TLS 1.2 and one for TLS 1.3, but I'd like to fix the test failure first.