### PR TITLE
Removes deprecated sni.yaml option: disable_h2

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -117,9 +117,6 @@ client_key                The file containing the client private key that corres
 http2                     Indicates whether the H2 protocol should be added to or removed from the
                           protocol negotiation list.  The valid values are :code:`on` or :code:`off`.
 
-disable_h2                Deprecated for the more general h2 setting.  Setting disable_h2
-                          to :code:`true` is the same as setting http2 to :code:`on`.
-
 tunnel_route              Destination as an FQDN and port, separated by a colon ``:``.
                           Match group number can be specified by ``$N`` where N should refer to a specified group
                           in the FQDN, ``tunnel_route: $1.domain``.

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -98,7 +98,6 @@ TsEnumDescriptor PROPERTIES_DESCRIPTOR    = {{{"NONE", 0}, {"SIGNATURE", 0x1}, {
 TsEnumDescriptor TLS_PROTOCOLS_DESCRIPTOR = {{{"TLSv1", 0}, {"TLSv1_1", 1}, {"TLSv1_2", 2}, {"TLSv1_3", 3}}};
 
 std::set<std::string> valid_sni_config_keys = {TS_fqdn,
-                                               TS_disable_h2,
                                                TS_verify_client,
                                                TS_verify_client_ca_certs,
                                                TS_tunnel_route,
@@ -132,9 +131,6 @@ template <> struct convert<YamlSNIConfig::Item> {
       item.fqdn = node[TS_fqdn].as<std::string>();
     } else {
       return false; // servername must be present
-    }
-    if (node[TS_disable_h2]) {
-      item.offer_h2 = false;
     }
     if (node[TS_http2]) {
       item.offer_h2 = node[TS_http2].as<bool>();

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -32,7 +32,6 @@
 
 #define TSDECL(id) constexpr char TS_##id[] = #id
 TSDECL(fqdn);
-TSDECL(disable_h2);
 TSDECL(verify_client);
 TSDECL(verify_client_ca_certs);
 TSDECL(tunnel_route);
@@ -52,8 +51,7 @@ TSDECL(host_sni_policy);
 const int start = 0;
 struct YamlSNIConfig {
   enum class Action {
-    disable_h2 = start,
-    verify_client,
+    verify_client = start,
     verify_client_ca_certs,
     tunnel_route,             // blind tunnel action
     forward_route,            // decrypt data and then blind tunnel action


### PR DESCRIPTION
Just to make sure we break Sudheer’s config properly, here’s a PR to eliminate the config

This was deprecated in 9.x.