### PR TITLE
Fix ja3_fingerprint configure syntax

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1363,7 +1363,7 @@ AC_EGREP_CPP(yes, [
   #endif
   ], [
     AC_MSG_RESULT(yes)
-    AS_IF([test "x${enable_experimental_plugins}" = "xyes" && -z "$openssl_is_boringssl"], [
+    AS_IF([test "x${enable_experimental_plugins}" = "xyes" && test -z "$openssl_is_boringssl"], [
       enable_ja3_plugin=yes
     ])
   ], [AC_MSG_RESULT(no)])


### PR DESCRIPTION
A call to "test" was missed in the ja3_fingerprint logic. Before the
patch in this commit, this would result in the following output:

checking for JA3 compatible OpenSSL version... yes
./configure: line 25014: -z: command not found