### PR TITLE
Use SSL_CTX address as part of the lookup key

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -140,6 +140,10 @@ void setClientCertLevel(SSL *ssl, uint8_t certLevel);
 void setClientCertCACerts(SSL *ssl, const char *file, const char *dir);
 void setTLSValidProtocols(SSL *ssl, unsigned long proto_mask, unsigned long max_mask);
 
+// Helper functions to retrieve sni name or ip address from a SSL object
+// Used as part of the lookup key into the origin server session cache
+std::string get_sni_addr(SSL *ssl);
+
 namespace ssl
 {
 namespace detail

--- a/iocore/net/SSLSessionCache.cc
+++ b/iocore/net/SSLSessionCache.cc
@@ -313,7 +313,7 @@ void
 SSLOriginSessionCache::insert_session(std::string lookup_key, SSL_SESSION *sess)
 {
   if (is_debug_tag_set("ssl.origin_session_cache")) {
-    Debug("ssl.origin_session_cache", "insert session: %lx = %p", std::hash<std::string>{}(lookup_key), sess);
+    Debug("ssl.origin_session_cache", "insert session: %s = %p", lookup_key.c_str(), sess);
   }
 
   std::unique_lock lock(mutex);
@@ -330,7 +330,7 @@ void
 SSLOriginSessionCache::remove_session(std::string lookup_key)
 {
   if (is_debug_tag_set("ssl.origin_session_cache")) {
-    Debug("ssl.origin_session_cache", "remove session: %lx", std::hash<std::string>{}(lookup_key));
+    Debug("ssl.origin_session_cache", "remove session: %s", lookup_key.c_str());
   }
 
   std::unique_lock lock(mutex);
@@ -345,7 +345,7 @@ SSL_SESSION *
 SSLOriginSessionCache::get_session(std::string lookup_key)
 {
   if (is_debug_tag_set("ssl.origin_session_cache")) {
-    Debug("ssl.origin_session_cache", "get session: %lx", std::hash<std::string>{}(lookup_key));
+    Debug("ssl.origin_session_cache", "get session: %s", lookup_key.c_str());
   }
 
   std::shared_lock lock(mutex);
@@ -365,7 +365,7 @@ SSLOriginSessionCache::remove_oldest_session(const std::unique_lock<std::shared_
   auto node = origin_sessions.begin();
 
   if (is_debug_tag_set("ssl.origin_session_cache")) {
-    Debug("ssl.origin_session_cache", "remove oldest session: %lx = %p", std::hash<std::string>{}(node->first), node->second);
+    Debug("ssl.origin_session_cache", "remove oldest session: %s = %p", node->first.c_str(), node->second);
   }
 
   SSL_SESSION_free(node->second);

--- a/tests/gold_tests/tls/tls_origin_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_origin_session_reuse.test.py
@@ -26,7 +26,6 @@ ts1 = Test.MakeATSProcess("ts1", select_ports=True, enable_tls=True)
 ts2 = Test.MakeATSProcess("ts2", select_ports=True, enable_tls=True)
 ts3 = Test.MakeATSProcess("ts3", select_ports=True, enable_tls=True)
 ts4 = Test.MakeATSProcess("ts4", select_ports=True, enable_tls=True)
-ts5 = Test.MakeATSProcess("ts5", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
 
 # Add info the origin server responses
@@ -51,24 +50,19 @@ ts3.addSSLfile("ssl/server.pem")
 ts3.addSSLfile("ssl/server.key")
 ts4.addSSLfile("ssl/server.pem")
 ts4.addSSLfile("ssl/server.key")
-ts5.addSSLfile("ssl/server.pem")
-ts5.addSSLfile("ssl/server.key")
 
 ts1.Disk.remap_config.AddLine(
     'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
 )
-ts2.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts3.Disk.remap_config.AddLines([
-    'map /ts1 https://127.0.0.1:{0}'.format(ts1.Variables.ssl_port),
-    'map /ts2 https://127.0.0.1:{0}'.format(ts2.Variables.ssl_port)
+ts2.Disk.remap_config.AddLines([
+    'map /reuse_session https://127.0.0.1:{0}'.format(ts1.Variables.ssl_port),
+    'map /remove_oldest https://127.0.1.1:{0}'.format(ts1.Variables.ssl_port)
 ])
-ts4.Disk.remap_config.AddLine(
+ts3.Disk.remap_config.AddLine(
     'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
 )
-ts5.Disk.remap_config.AddLine(
-    'map / https://127.0.0.1:{0}'.format(ts4.Variables.ssl_port)
+ts4.Disk.remap_config.AddLine(
+    'map / https://127.0.0.1:{0}'.format(ts3.Variables.ssl_port)
 )
 
 ts1.Disk.ssl_multicert_config.AddLine(
@@ -81,9 +75,6 @@ ts3.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
 )
 ts4.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts5.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
 )
 
@@ -105,6 +96,8 @@ ts1.Disk.records_config.update({
 })
 ts2.Disk.records_config.update({
     'proxy.config.http.cache.http': 0,
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'ssl.origin_session_cache',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts2.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts2.Variables.SSLDir),
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
@@ -121,8 +114,6 @@ ts2.Disk.records_config.update({
 })
 ts3.Disk.records_config.update({
     'proxy.config.http.cache.http': 0,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl.origin_session_cache',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts3.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts3.Variables.SSLDir),
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
@@ -139,26 +130,10 @@ ts3.Disk.records_config.update({
 })
 ts4.Disk.records_config.update({
     'proxy.config.http.cache.http': 0,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts4.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts4.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-    'proxy.config.ssl.origin_session_cache': 1,
-    'proxy.config.ssl.origin_session_cache.size': 1
-})
-ts5.Disk.records_config.update({
-    'proxy.config.http.cache.http': 0,
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'ssl.origin_session_cache',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts5.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts5.Variables.SSLDir),
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts4.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts4.Variables.SSLDir),
     'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.ssl.session_cache': 2,
@@ -173,34 +148,34 @@ ts5.Disk.records_config.update({
 })
 
 tr = Test.AddTestRun('new session then reuse')
-tr.Processes.Default.Command = 'curl https://127.0.0.1:{0}/ts1 -k && curl https://127.0.0.1:{0}/ts1 -k'.format(
-    ts3.Variables.ssl_port)
+tr.Processes.Default.Command = 'curl https://127.0.0.1:{0}/reuse_session -k && curl https://127.0.0.1:{0}/reuse_session -k'.format(
+    ts2.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts1)
-tr.Processes.Default.StartBefore(ts3)
-tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
-ts3.Streams.All = Testers.ContainsExpression('new session to origin', '')
-ts3.Streams.All += Testers.ContainsExpression('reused session to origin', '')
-tr.StillRunningAfter = server
-tr.StillRunningAfter += ts3
-
-tr = Test.AddTestRun('remove oldest session, new session then reuse')
-tr.Processes.Default.Command = 'curl https://127.0.0.1:{0}/ts2 -k && curl https://127.0.0.1:{0}/ts2 -k'.format(
-    ts3.Variables.ssl_port)
-tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts2)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
-ts3.Streams.All = Testers.ContainsExpression('remove oldest session', '')
-ts3.Streams.All += Testers.ContainsExpression('new session to origin', '')
-ts3.Streams.All += Testers.ContainsExpression('reused session to origin', '')
+ts2.Streams.All = Testers.ContainsExpression('new session to origin', '')
+ts2.Streams.All += Testers.ContainsExpression('reused session to origin', '')
+tr.StillRunningAfter = server
+tr.StillRunningAfter += ts1
+tr.StillRunningAfter += ts2
+
+tr = Test.AddTestRun('remove oldest session, new session then reuse')
+tr.Processes.Default.Command = 'curl https://127.0.0.1:{0}/remove_oldest -k && curl https://127.0.0.1:{0}/remove_oldest -k'.format(
+    ts2.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
+ts2.Streams.All = Testers.ContainsExpression('remove oldest session', '')
+ts2.Streams.All += Testers.ContainsExpression('new session to origin', '')
+ts2.Streams.All += Testers.ContainsExpression('reused session to origin', '')
 tr.StillRunningAfter = server
 
 tr = Test.AddTestRun('disable origin session reuse, reuse should fail')
-tr.Processes.Default.Command = 'curl https://127.0.0.1:{0} -k && curl https://127.0.0.1:{0} -k'.format(ts5.Variables.ssl_port)
+tr.Processes.Default.Command = 'curl https://127.0.0.1:{0} -k && curl https://127.0.0.1:{0} -k'.format(ts4.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(ts3)
 tr.Processes.Default.StartBefore(ts4)
-tr.Processes.Default.StartBefore(ts5)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
-ts5.Streams.All = Testers.ContainsExpression('new session to origin', '')
-ts5.Streams.All += Testers.ExcludesExpression('reused session to origin', '')
+ts4.Streams.All = Testers.ContainsExpression('new session to origin', '')
+ts4.Streams.All += Testers.ExcludesExpression('reused session to origin', '')


### PR DESCRIPTION
This fixes the issue found in PR #7537, as described in this comment https://github.com/apache/trafficserver/pull/7537#issuecomment-783658010

The reason we can use this address is because we create a `SSL_CTX` object for different certs as seen here. 
https://github.com/apache/trafficserver/blob/master/iocore/net/SSLNetVConnection.cc#L1079
```
      if (options.ssl_client_cert_name) {
        std::string certFilePath = Layout::get()->relative_to(params->clientCertPathOnly, options.ssl_client_cert_name.get());
        std::string keyFilePath;
        if (options.ssl_client_private_key_name) {
          keyFilePath = Layout::get()->relative_to(params->clientKeyPathOnly, options.ssl_client_private_key_name);
        }
        std::string caCertFilePath;
        if (options.ssl_client_ca_cert_name) {
          caCertFilePath = Layout::get()->relative_to(params->clientCACertPath, options.ssl_client_ca_cert_name);
        }
        sharedCTX =
          params->getCTX(certFilePath.c_str(), keyFilePath.empty() ? nullptr : keyFilePath.c_str(),
                         caCertFilePath.empty() ? params->clientCACertFilename : caCertFilePath.c_str(), params->clientCACertPath);
      } else if (options.ssl_client_ca_cert_name) {
        std::string caCertFilePath = Layout::get()->relative_to(params->clientCACertPath, options.ssl_client_ca_cert_name);
        sharedCTX = params->getCTX(params->clientCertPath, params->clientKeyPath, caCertFilePath.c_str(), params->clientCACertPath);
      } else if (nps && !nps->client_cert_file.empty()) {
        // If no overrides available, try the available nextHopProperty by reading from context mappings
        sharedCTX =
          params->getCTX(nps->client_cert_file.c_str(), nps->client_key_file.empty() ? nullptr : nps->client_key_file.c_str(),
                         params->clientCACertFilename, params->clientCACertPath);
      } else { // Just stay with the values passed down from the SM for verify
        clientCTX = params->client_ctx.get();
      }

      if (sharedCTX) {
        clientCTX = sharedCTX.get();
      }
```

This means each `SSL` object is bound together with their own `SSL_CTX` object, and the `SSL_CTX` object is bound to different key/cert configurations. So using the SNI or IP address of the origin server, combined with the `SSL_CTX` object's address, it'll make sure sessions are not mistakenly reused for connections it's not supposed to be used on.

Also, cleaned up the code a bit.

Linking to #7479 in case we backport.