### PR TITLE
Introduce TLSBasicSupport interface

### DIFF
--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -184,6 +184,7 @@ libinknet_a_SOURCES = \
 	SSLSessionTicket.cc \
 	SSLUtils.cc \
 	OCSPStapling.cc \
+	TLSBasicSupport.cc \
 	TLSSessionResumptionSupport.cc \
 	TLSSNISupport.cc \
 	UDPIOEvent.cc \

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -95,7 +95,11 @@ enum SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHA
 //  A VConnection for a network socket.
 //
 //////////////////////////////////////////////////////////////////
-class SSLNetVConnection : public UnixNetVConnection, public ALPNSupport, public TLSSessionResumptionSupport, public TLSSNISupport, public TLSBasicSupport
+class SSLNetVConnection : public UnixNetVConnection,
+                          public ALPNSupport,
+                          public TLSSessionResumptionSupport,
+                          public TLSSNISupport,
+                          public TLSBasicSupport
 {
   typedef UnixNetVConnection super; ///< Parent type.
 

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -49,6 +49,7 @@
 #include "P_ALPNSupport.h"
 #include "TLSSessionResumptionSupport.h"
 #include "TLSSNISupport.h"
+#include "TLSBasicSupport.h"
 #include "P_SSLUtils.h"
 #include "P_SSLConfig.h"
 
@@ -94,7 +95,7 @@ enum SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHA
 //  A VConnection for a network socket.
 //
 //////////////////////////////////////////////////////////////////
-class SSLNetVConnection : public UnixNetVConnection, public ALPNSupport, public TLSSessionResumptionSupport, public TLSSNISupport
+class SSLNetVConnection : public UnixNetVConnection, public ALPNSupport, public TLSSessionResumptionSupport, public TLSSNISupport, public TLSBasicSupport
 {
   typedef UnixNetVConnection super; ///< Parent type.
 
@@ -106,9 +107,9 @@ public:
   bool
   trackFirstHandshake() override
   {
-    bool retval = sslHandshakeBeginTime == 0;
+    bool retval = this->get_tls_handshake_begin_time() == 0;
     if (retval) {
-      sslHandshakeBeginTime = Thread::get_hrtime();
+      this->_record_tls_handshake_begin_time();
     }
     return retval;
   }
@@ -275,43 +276,6 @@ public:
     return retval;
   }
 
-  const char *
-  getSSLProtocol() const
-  {
-    return ssl ? SSL_get_version(ssl) : nullptr;
-  }
-
-  const char *
-  getSSLCipherSuite() const
-  {
-    return ssl ? SSL_get_cipher_name(ssl) : nullptr;
-  }
-
-  const char *
-  getSSLCurve() const
-  {
-    if (!ssl) {
-      return nullptr;
-    }
-    ssl_curve_id curve;
-    if (getSSLSessionCacheHit()) {
-      curve = getSSLCurveNID();
-    } else {
-      curve = SSLGetCurveNID(ssl);
-    }
-#ifndef OPENSSL_IS_BORINGSSL
-    if (curve == NID_undef) {
-      return nullptr;
-    }
-    return OBJ_nid2sn(curve);
-#else
-    if (curve == 0) {
-      return nullptr;
-    }
-    return SSL_get_curve_name(curve);
-#endif
-  }
-
   bool
   has_tunnel_destination() const
   {
@@ -362,11 +326,9 @@ public:
    */
   int populate(Connection &con, Continuation *c, void *arg) override;
 
-  SSL *ssl                         = nullptr;
-  ink_hrtime sslHandshakeBeginTime = 0;
-  ink_hrtime sslHandshakeEndTime   = 0;
-  ink_hrtime sslLastWriteTime      = 0;
-  int64_t sslTotalBytesSent        = 0;
+  SSL *ssl                    = nullptr;
+  ink_hrtime sslLastWriteTime = 0;
+  int64_t sslTotalBytesSent   = 0;
 
   // The serverName is either a pointer to the (null-terminated) name fetched from the
   // SSL object or the empty string.
@@ -468,6 +430,13 @@ public:
   }
 
 protected:
+  SSL *
+  _get_ssl_object() const override
+  {
+    return this->ssl;
+  }
+  ssl_curve_id _get_tls_curve() const override;
+
   const IpEndpoint &
   _getLocalEndpoint() override
   {

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -872,6 +872,7 @@ SSLInitializeLibrary()
   // the SSLNetVConnection to the SSL session.
   ssl_vc_index = SSL_get_ex_new_index(0, (void *)"NetVC index", nullptr, nullptr, nullptr);
 
+  TLSBasicSupport::initialize();
   TLSSessionResumptionSupport::initialize();
   TLSSNISupport::initialize();
 

--- a/iocore/net/TLSBasicSupport.cc
+++ b/iocore/net/TLSBasicSupport.cc
@@ -1,0 +1,134 @@
+/** @file
+
+  TLSSBasicSupport.cc provides implmentations for
+  TLSBasicSupport methods
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "TLSBasicSupport.h"
+#include "SSLStats.h"
+
+int TLSBasicSupport::_ex_data_index = -1;
+
+void
+TLSBasicSupport::initialize()
+{
+  ink_assert(_ex_data_index == -1);
+  if (_ex_data_index == -1) {
+    _ex_data_index = SSL_get_ex_new_index(0, (void *)"TLSBasicSupport index", nullptr, nullptr, nullptr);
+  }
+}
+
+TLSBasicSupport *
+TLSBasicSupport::getInstance(SSL *ssl)
+{
+  return static_cast<TLSBasicSupport *>(SSL_get_ex_data(ssl, _ex_data_index));
+}
+
+void
+TLSBasicSupport::bind(SSL *ssl, TLSBasicSupport *srs)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, srs);
+}
+
+void
+TLSBasicSupport::unbind(SSL *ssl)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, nullptr);
+}
+
+void
+TLSBasicSupport::clear()
+{
+  this->_tls_handshake_begin_time = 0;
+  this->_tls_handshake_end_time   = 0;
+}
+
+const char *
+TLSBasicSupport::get_tls_protocol_name() const
+{
+  auto ssl = this->_get_ssl_object();
+  if (ssl) {
+    return SSL_get_version(ssl);
+  } else {
+    return nullptr;
+  }
+}
+
+const char *
+TLSBasicSupport::get_tls_cipher_suite() const
+{
+  auto ssl = this->_get_ssl_object();
+  if (ssl) {
+    return SSL_get_cipher_name(ssl);
+  } else {
+    return nullptr;
+  }
+}
+
+const char *
+TLSBasicSupport::get_tls_curve() const
+{
+  auto ssl = this->_get_ssl_object();
+
+  if (!ssl) {
+    return nullptr;
+  }
+  ssl_curve_id curve = this->_get_tls_curve();
+#ifndef OPENSSL_IS_BORINGSSL
+  if (curve == NID_undef) {
+    return nullptr;
+  }
+  return OBJ_nid2sn(curve);
+#else
+  if (curve == 0) {
+    return nullptr;
+  }
+  return SSL_get_curve_name(curve);
+#endif
+}
+
+ink_hrtime
+TLSBasicSupport::get_tls_handshake_begin_time() const
+{
+  return this->_tls_handshake_begin_time;
+}
+
+ink_hrtime
+TLSBasicSupport::get_tls_handshake_end_time() const
+{
+  return this->_tls_handshake_end_time;
+}
+
+void
+TLSBasicSupport::_record_tls_handshake_begin_time()
+{
+  this->_tls_handshake_begin_time = Thread::get_hrtime();
+}
+
+void
+TLSBasicSupport::_record_tls_handshake_end_time()
+{
+  this->_tls_handshake_end_time       = Thread::get_hrtime();
+  const ink_hrtime ssl_handshake_time = this->_tls_handshake_end_time - this->_tls_handshake_begin_time;
+
+  Debug("ssl", "ssl handshake time:%" PRId64, ssl_handshake_time);
+  SSL_INCREMENT_DYN_STAT_EX(ssl_total_handshake_time_stat, ssl_handshake_time);
+}

--- a/iocore/net/TLSBasicSupport.h
+++ b/iocore/net/TLSBasicSupport.h
@@ -1,0 +1,62 @@
+/** @file
+
+  TLSBasicSupport implements common methods and members to
+  support basic features on TLS connections
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <openssl/ssl.h>
+
+#include "tscore/ink_hrtime.h"
+#include "P_SSLUtils.h"
+
+class TLSBasicSupport
+{
+public:
+  virtual ~TLSBasicSupport() = default;
+
+  static void initialize();
+  static TLSBasicSupport *getInstance(SSL *ssl);
+  static void bind(SSL *ssl, TLSBasicSupport *srs);
+  static void unbind(SSL *ssl);
+
+  const char *get_tls_protocol_name() const;
+  const char *get_tls_cipher_suite() const;
+  const char *get_tls_curve() const;
+  ink_hrtime get_tls_handshake_begin_time() const;
+  ink_hrtime get_tls_handshake_end_time() const;
+
+protected:
+  void clear();
+
+  virtual SSL *_get_ssl_object() const        = 0;
+  virtual ssl_curve_id _get_tls_curve() const = 0;
+
+  void _record_tls_handshake_begin_time();
+  void _record_tls_handshake_end_time();
+
+private:
+  static int _ex_data_index;
+
+  ink_hrtime _tls_handshake_begin_time = 0;
+  ink_hrtime _tls_handshake_end_time   = 0;
+};

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -552,18 +552,18 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc, IOBufferReader *buffe
   if (ssl_vc != nullptr) {
     client_connection_is_ssl = true;
     client_ssl_reused        = ssl_vc->getSSLSessionCacheHit();
-    const char *protocol     = ssl_vc->getSSLProtocol();
+    const char *protocol     = ssl_vc->get_tls_protocol_name();
     client_sec_protocol      = protocol ? protocol : "-";
-    const char *cipher       = ssl_vc->getSSLCipherSuite();
+    const char *cipher       = ssl_vc->get_tls_cipher_suite();
     client_cipher_suite      = cipher ? cipher : "-";
-    const char *curve        = ssl_vc->getSSLCurve();
+    const char *curve        = ssl_vc->get_tls_curve();
     client_curve             = curve ? curve : "-";
     client_alpn_id           = ssl_vc->get_negotiated_protocol_id();
 
     if (!client_tcp_reused) {
       // Copy along the TLS handshake timings
-      milestones[TS_MILESTONE_TLS_HANDSHAKE_START] = ssl_vc->sslHandshakeBeginTime;
-      milestones[TS_MILESTONE_TLS_HANDSHAKE_END]   = ssl_vc->sslHandshakeEndTime;
+      milestones[TS_MILESTONE_TLS_HANDSHAKE_START] = ssl_vc->get_tls_handshake_begin_time();
+      milestones[TS_MILESTONE_TLS_HANDSHAKE_END]   = ssl_vc->get_tls_handshake_end_time();
     }
   }
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -54,6 +54,7 @@
 #include "P_SSLClientUtils.h"
 #include "SSLDiags.h"
 #include "SSLInternal.h"
+#include "TLSBasicSupport.h"
 #include "ProxyConfig.h"
 #include "Plugin.h"
 #include "LogObject.h"
@@ -6650,28 +6651,28 @@ TSVConnIsSslReused(TSVConn sslp)
 const char *
 TSVConnSslCipherGet(TSVConn sslp)
 {
-  NetVConnection *vc        = reinterpret_cast<NetVConnection *>(sslp);
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
+  NetVConnection *vc     = reinterpret_cast<NetVConnection *>(sslp);
+  TLSBasicSupport *tlsbs = dynamic_cast<TLSBasicSupport *>(vc);
 
-  return ssl_vc ? ssl_vc->getSSLCipherSuite() : nullptr;
+  return tlsbs ? tlsbs->get_tls_cipher_suite() : nullptr;
 }
 
 const char *
 TSVConnSslProtocolGet(TSVConn sslp)
 {
-  NetVConnection *vc        = reinterpret_cast<NetVConnection *>(sslp);
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
+  NetVConnection *vc     = reinterpret_cast<NetVConnection *>(sslp);
+  TLSBasicSupport *tlsbs = dynamic_cast<TLSBasicSupport *>(vc);
 
-  return ssl_vc ? ssl_vc->getSSLProtocol() : nullptr;
+  return tlsbs ? tlsbs->get_tls_protocol_name() : nullptr;
 }
 
 const char *
 TSVConnSslCurveGet(TSVConn sslp)
 {
-  NetVConnection *vc        = reinterpret_cast<NetVConnection *>(sslp);
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
+  NetVConnection *vc     = reinterpret_cast<NetVConnection *>(sslp);
+  TLSBasicSupport *tlsbs = dynamic_cast<TLSBasicSupport *>(vc);
 
-  return ssl_vc ? ssl_vc->getSSLCurve() : nullptr;
+  return tlsbs ? tlsbs->get_tls_curve() : nullptr;
 }
 
 int


### PR DESCRIPTION
This introduces an abstract interface to support QUICNetVC where we currently only supports SSLNetVC (e.g. TS API).

Some functions in SSLNetVC are moved into TLSBasicSupport. like we did for other TLSSomethingSupport. I only moved easy ones on this PR.