### PR TITLE
Check verify policy and properties

### DIFF
--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -144,6 +144,10 @@ void setTLSValidProtocols(SSL *ssl, unsigned long proto_mask, unsigned long max_
 // Used as part of the lookup key into the origin server session cache
 std::string get_sni_addr(SSL *ssl);
 
+// Helper functions to retrieve server verify policy and properties from a SSL object
+// Used as part of the lookup key into the origin server session cache
+std::string get_verify_str(SSL *ssl);
+
 namespace ssl
 {
 namespace detail

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -161,11 +161,8 @@ ssl_new_session_callback(SSL *ssl, SSL_SESSION *sess)
 {
   std::string sni_addr = get_sni_addr(ssl);
   if (!sni_addr.empty()) {
-    SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
-    std::stringstream ctx_ss;
-    ctx_ss << static_cast<const void *>(ctx);
     std::string lookup_key;
-    ts::bwprint(lookup_key, "{}:{}", sni_addr.c_str(), ctx_ss.str().c_str());
+    ts::bwprint(lookup_key, "{}:{}:{}", sni_addr.c_str(), SSL_get_SSL_CTX(ssl), get_verify_str(ssl));
     origin_sess_cache->insert_session(lookup_key, sess);
     return 1;
   } else {


### PR DESCRIPTION
Another bug fix for Origin Session Reuse #7479 

The problem this time is that the verify property and policy can also be different from rule to rule, this adds the policy and property string to the lookup key for sessions. 

Now enabling session reuse for origin servers by default #7537 should not fail any tests.