### PR TITLE
Fix compress issues with 304s, only looks at 304 headers

### DIFF
--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -657,6 +657,16 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
     return 0;
   }
 
+  // We got a server response but it was a 304
+  // we need to update our data to come from cache instead of
+  // the 304 response which does not need to include all headers
+  if ((server) && (resp_status == TS_HTTP_STATUS_NOT_MODIFIED)) {
+    TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
+    if (TS_SUCCESS != TSHttpTxnCachedRespGet(txnp, &bufp, &hdr_loc)) {
+      return 0;
+    }
+  }
+
   if (TS_SUCCESS != TSHttpTxnClientReqGet(txnp, &cbuf, &chdr)) {
     info("cound not get client request");
     TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);


### PR DESCRIPTION
Add a check for compress response, if from server and 304, then check cache for headers instead of the 304 response. In testing we have seen origins respond with 304's with no content-type, which is perfectly legal, however the compress plugin only looks at the headers returned in the 304 and not the cache to determine compress-ability. 

I believe this should also resolve #6852, which is the inverse of this. We have a cached compressed copy by enabling caching on the compress plugin. We get a 304 from the origin which only includes the content-type, which is compressible.

However the plugin only looks at the 304 headers, so it thinks it needs to compress again, and when the transform happens its actually occurring on the cached version, and you end up with double compression. With this change the plugin will be looking at the cached headers instead and will know that it is already compressed

