### PR TITLE
Remove ProxyTransaction::set_proxy_ssn

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -26,7 +26,7 @@
 
 #define HttpTxnDebug(fmt, ...) SsnDebug(this, "http_txn", fmt, __VA_ARGS__)
 
-ProxyTransaction::ProxyTransaction() : VConnection(nullptr) {}
+ProxyTransaction::ProxyTransaction(ProxySession *session) : VConnection(nullptr), _proxy_ssn(session) {}
 
 void
 ProxyTransaction::new_transaction(bool from_early_data)

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -32,7 +32,8 @@ class HttpSM;
 class ProxyTransaction : public VConnection
 {
 public:
-  ProxyTransaction();
+  ProxyTransaction() : VConnection(nullptr) {}
+  ProxyTransaction(ProxySession *ssn);
 
   /// Virtual Methods
   //
@@ -80,8 +81,6 @@ public:
 
   virtual bool get_half_close_flag() const;
   virtual bool is_chunked_encoding_supported() const;
-
-  virtual void set_proxy_ssn(ProxySession *set_proxy_ssn);
 
   // Returns true if there is a request body for this request
   virtual bool has_request_body(int64_t content_length, bool is_chunked_set) const;
@@ -189,12 +188,6 @@ inline ProxySession *
 ProxyTransaction::get_proxy_ssn()
 {
   return _proxy_ssn;
-}
-
-inline void
-ProxyTransaction::set_proxy_ssn(ProxySession *new_proxy_ssn)
-{
-  _proxy_ssn = new_proxy_ssn;
 }
 
 inline PoolableSession *

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -59,7 +59,7 @@ ink_mutex debug_cs_list_mutex;
 
 ClassAllocator<Http1ClientSession> http1ClientSessionAllocator("http1ClientSessionAllocator");
 
-Http1ClientSession::Http1ClientSession() {}
+Http1ClientSession::Http1ClientSession() : super(), trans(this) {}
 
 void
 Http1ClientSession::destroy()

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -451,7 +451,6 @@ Http1ClientSession::new_transaction()
 
   read_state = HCS_ACTIVE_READER;
 
-  trans.set_proxy_ssn(this);
   transact_count++;
 
   trans.new_transaction(read_from_early_data > 0 ? true : false);

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -125,7 +125,7 @@ public:
   /// Set outbound connection to transparent.
   bool f_outbound_transparent = false;
 
-  Http1Transaction trans;
+  Http1Transaction trans = {this};
 };
 
 extern ClassAllocator<Http1ClientSession> http1ClientSessionAllocator;

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -125,7 +125,7 @@ public:
   /// Set outbound connection to transparent.
   bool f_outbound_transparent = false;
 
-  Http1Transaction trans = {this};
+  Http1Transaction trans;
 };
 
 extern ClassAllocator<Http1ClientSession> http1ClientSessionAllocator;

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -32,7 +32,7 @@ class Http1Transaction : public ProxyTransaction
 public:
   using super_type = ProxyTransaction;
 
-  Http1Transaction() {}
+  Http1Transaction(ProxySession *session) : super_type(session) {}
 
   ////////////////////
   // Methods

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1819,6 +1819,7 @@ HttpSM::state_http_server_open(int event, void *data)
     Http1ServerSession *session = (TS_SERVER_SESSION_SHARING_POOL_THREAD == httpSessionManager.get_pool_type()) ?
                                     THREAD_ALLOC_INIT(httpServerSessionAllocator, mutex->thread_holding) :
                                     httpServerSessionAllocator.alloc();
+    new (session) Http1ServerSession();
     session->sharing_pool  = static_cast<TSServerSessionSharingPoolType>(t_state.http_config_param->server_session_sharing_pool);
     session->sharing_match = static_cast<TSServerSessionSharingMatchMask>(t_state.txn_conf->server_session_sharing_match);
 

--- a/proxy/http/HttpSessionAccept.cc
+++ b/proxy/http/HttpSessionAccept.cc
@@ -50,6 +50,7 @@ HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReade
   }
 
   Http1ClientSession *new_session = THREAD_ALLOC_INIT(http1ClientSessionAllocator, this_ethread());
+  new (new_session) Http1ClientSession();
 
   new_session->accept_options = static_cast<Options *>(this);
   new_session->acl            = std::move(acl);

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -67,7 +67,7 @@ send_connection_event(Continuation *cont, int event, void *edata)
   return cont->handleEvent(event, edata);
 }
 
-Http2ClientSession::Http2ClientSession() = default;
+Http2ClientSession::Http2ClientSession() : super() {}
 
 void
 Http2ClientSession::destroy()

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1221,7 +1221,7 @@ Http2ConnectionState::create_stream(Http2StreamId new_id, Http2Error &error)
   }
 
   Http2Stream *new_stream = THREAD_ALLOC_INIT(http2StreamAllocator, this_ethread());
-  new_stream->init(new_id, client_settings.get(HTTP2_SETTINGS_INITIAL_WINDOW_SIZE));
+  new (new_stream) Http2Stream(ua_session, new_id, client_settings.get(HTTP2_SETTINGS_INITIAL_WINDOW_SIZE));
 
   ink_assert(nullptr != new_stream);
   ink_assert(!stream_list.in(new_stream));
@@ -1243,7 +1243,6 @@ Http2ConnectionState::create_stream(Http2StreamId new_id, Http2Error &error)
     zombie_event = nullptr;
   }
 
-  new_stream->set_proxy_ssn(ua_session);
   new_stream->mutex                     = new_ProxyMutex();
   new_stream->is_first_transaction_flag = get_stream_requests() == 0;
   increment_stream_requests();

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -54,8 +54,9 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
   }
 
   Http2ClientSession *new_session = THREAD_ALLOC_INIT(http2ClientSessionAllocator, this_ethread());
-  new_session->acl                = std::move(session_acl);
-  new_session->accept_options     = &options;
+  new (new_session) Http2ClientSession();
+  new_session->acl            = std::move(session_acl);
+  new_session->accept_options = &options;
 
   // Pin session to current ET_NET thread
   new_session->setThreadAffinity(this_ethread());

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -39,14 +39,11 @@
 
 ClassAllocator<Http2Stream> http2StreamAllocator("http2StreamAllocator");
 
-Http2Stream::Http2Stream(Http2StreamId sid, ssize_t initial_rwnd) : _id(sid), _client_rwnd(initial_rwnd)
+Http2Stream::Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_rwnd)
+  : super(session), _id(sid), _client_rwnd(initial_rwnd)
 {
   SET_HANDLER(&Http2Stream::main_event_handler);
-}
 
-void
-Http2Stream::init(Http2StreamId sid, ssize_t initial_rwnd)
-{
   this->mark_milestone(Http2StreamMilestone::OPEN);
 
   this->_sm          = nullptr;

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -54,9 +54,8 @@ public:
   const int retry_delay = HRTIME_MSECONDS(10);
   using super           = ProxyTransaction; ///< Parent type.
 
-  Http2Stream(Http2StreamId sid = 0, ssize_t initial_rwnd = Http2::initial_window_size);
-
-  void init(Http2StreamId sid, ssize_t initial_rwnd);
+  Http2Stream() {} // Just to satisfy ClassAllocator
+  Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_rwnd);
 
   int main_event_handler(int event, void *edata);
 

--- a/proxy/http3/Http3Transaction.cc
+++ b/proxy/http3/Http3Transaction.cc
@@ -57,12 +57,10 @@
 //
 // HQTransaction
 //
-HQTransaction::HQTransaction(HQSession *session, QUICStreamIO *stream_io) : super(), _stream_io(stream_io)
+HQTransaction::HQTransaction(HQSession *session, QUICStreamIO *stream_io) : super(session), _stream_io(stream_io)
 {
   this->mutex   = new_ProxyMutex();
   this->_thread = this_ethread();
-
-  this->set_proxy_ssn(session);
 
   this->_reader = this->_read_vio_buf.alloc_reader();
 


### PR DESCRIPTION
A ProxySession is set to ProxyTransaction by calling `set_proxy_ssn`. However, the function should not exist because a session for a transaction should not be changed in the middle of a transaction.

This PR adds `ProxySession *session` param to ProxyTransaction's constructor to guarantee a session is always set and it won't be accidentally changed later.

Also, this integrates `Http2Stream::init` into Http2Stream's constructor.