### PR TITLE
Add new TS API function TSUrlRawPortGet.

### DIFF
--- a/doc/developer-guide/api/functions/TSUrlHostGet.en.rst
+++ b/doc/developer-guide/api/functions/TSUrlHostGet.en.rst
@@ -37,6 +37,7 @@ Synopsis
 .. function:: const char * TSUrlUserGet(TSMBuffer bufp, TSMLoc offset, int * length)
 .. function:: const char * TSUrlPasswordGet(TSMBuffer bufp, TSMLoc offset, int* length)
 .. function:: int TSUrlPortGet(TSMBuffer bufp, TSMLoc offset)
+.. function:: int TSUrlRawPortGet(TSMBuffer bufp, TSMLoc offset)
 .. function:: const char * TSUrlPathGet(TSMBuffer bufp, TSMLoc offset, int * length)
 .. function:: const char * TSUrlHttpQueryGet(TSMBuffer bufp, TSMLoc offset, int * length)
 .. function:: const char * TSUrlHttpParamsGet(TSMBuffer bufp, TSMLoc offset, int * length)
@@ -67,17 +68,22 @@ URL type (HTTP or HTTPS) if there is no explicit scheme.
 port number in the URL, a canonicalized valued is returned based on the URL
 scheme.
 
+:func:`TSUrlRawPortGet` also retrieves the port number portion of the URL located at
+:arg:`offset` within the marshal buffer :arg:`bufp`. If there is no explicit
+port number in the URL, zero is returned.
+
 Return Values
 =============
 
-All APIs except :func:`TSUrlPortGet` returns a string, which is not guaranteed
-to be NULL terminated. You must therefore always use the :arg:`length` value
+All APIs except :func:`TSUrlPortGet` and :func:`TSUrlRawPortGet` return a string, which is
+not guaranteed to be NULL terminated. You must therefore always use the :arg:`length` value
 to determine the actual length of the returned string.
 
 :func:`TSUrlPortGet` simply returns the port number as an integer, possibly
 canonicalized with :literal:`80` for HTTP and :literal:`443` for HTTPS schemes. If
 there is neither port nor scheme information available in the URL, :literal:`0`
-is returned.
+is returned. :func:`TSUrlRawPortGet`, by contrast, returns 0 in all cases where the
+port is not explicitly present in the URL.
 
 See Also
 ========

--- a/doc/developer-guide/plugins/http-headers/urls.en.rst
+++ b/doc/developer-guide/plugins/http-headers/urls.en.rst
@@ -149,6 +149,7 @@ Traffic Server **URL functions** are listed below:
 :c:func:`TSUrlPathGet`
 :c:func:`TSUrlPathSet`
 :c:func:`TSUrlPortGet`
+:c:func:`TSUrlRawPortGet`
 :c:func:`TSUrlPortSet`
 :c:func:`TSUrlSchemeGet`
 :c:func:`TSUrlSchemeSet`

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -555,7 +555,8 @@ tsapi const char *TSUrlHostGet(TSMBuffer bufp, TSMLoc offset, int *length);
 tsapi TSReturnCode TSUrlHostSet(TSMBuffer bufp, TSMLoc offset, const char *value, int length);
 
 /**
-    Retrieves the port portion of the URL located at url_loc.
+    Returns the port portion of the URL located at url_loc if explicitly present,
+    otherwise the canonical port for the URL.
 
     @param bufp marshal buffer containing the URL.
     @param offset location of the URL.
@@ -563,6 +564,17 @@ tsapi TSReturnCode TSUrlHostSet(TSMBuffer bufp, TSMLoc offset, const char *value
 
  */
 tsapi int TSUrlPortGet(TSMBuffer bufp, TSMLoc offset);
+
+/**
+    Returns the port portion of the URL located at url_loc if explicitly present,
+    otherwise 0.
+
+    @param bufp marshal buffer containing the URL.
+    @param offset location of the URL.
+    @return port portion of the URL.
+
+ */
+tsapi int TSUrlRawPortGet(TSMBuffer bufp, TSMLoc offset);
 
 /**
     Sets the port portion of the URL located at url_loc.

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -2435,6 +2435,19 @@ TSUrlPortGet(TSMBuffer bufp, TSMLoc obj)
   return u.port_get();
 }
 
+int
+TSUrlRawPortGet(TSMBuffer bufp, TSMLoc obj)
+{
+  sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_url_handle(obj) == TS_SUCCESS);
+
+  URL u;
+  u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
+  u.m_url_impl = (URLImpl *)obj;
+
+  return u.port_get_raw();
+}
+
 TSReturnCode
 TSUrlPortSet(TSMBuffer bufp, TSMLoc obj, int port)
 {

--- a/tests/gold_tests/pluginTest/tsapi/log.gold
+++ b/tests/gold_tests/pluginTest/tsapi/log.gold
@@ -18,6 +18,7 @@ TSHttpHdrEffectiveUrlBufGet():  http://myhost.test/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 Transaction: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://mYhOsT.teSt/
 Client Request:
@@ -25,18 +26,21 @@ TSHttpHdrEffectiveUrlBufGet():  http://myhost.test/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 TSRemapDoRemap(): instance=0 redirect=0
 Remap Request:
 TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  SERVER_PORT
+TSUrlRawPortGet():  SERVER_PORT
 TSRemapDoRemap(): instance=1 redirect=0
 Remap Request:
 TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  SERVER_PORT
+TSUrlRawPortGet():  SERVER_PORT
 Global: event=TS_EVENT_HTTP_SEND_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://127.0.0.1:SERVER_PORT/
 Request To Server:
@@ -44,6 +48,7 @@ TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  failed to get raw URL scheme
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 Transaction: event=TS_EVENT_HTTP_SEND_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://127.0.0.1:SERVER_PORT/
 Request To Server:
@@ -51,6 +56,7 @@ TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  failed to get raw URL scheme
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 Global: event=TS_EVENT_HTTP_TXN_START
 Global: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://mYhOsT.teSt/xYz
@@ -59,6 +65,7 @@ TSHttpHdrEffectiveUrlBufGet():  http://myhost.test/xYz
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 Transaction: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://mYhOsT.teSt/xYz
 Client Request:
@@ -66,18 +73,21 @@ TSHttpHdrEffectiveUrlBufGet():  http://myhost.test/xYz
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 TSRemapDoRemap(): instance=0 redirect=0
 Remap Request:
 TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/xYz
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  SERVER_PORT
+TSUrlRawPortGet():  SERVER_PORT
 TSRemapDoRemap(): instance=1 redirect=0
 Remap Request:
 TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/xYz
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  SERVER_PORT
+TSUrlRawPortGet():  SERVER_PORT
 Global: event=TS_EVENT_HTTP_SEND_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://127.0.0.1:SERVER_PORT/xYz
 Request To Server:
@@ -85,6 +95,7 @@ TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/xYz
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  failed to get raw URL scheme
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 Transaction: event=TS_EVENT_HTTP_SEND_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://127.0.0.1:SERVER_PORT/xYz
 Request To Server:
@@ -92,6 +103,7 @@ TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/xYz
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  failed to get raw URL scheme
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 Global: event=TS_EVENT_HTTP_TXN_START
 Global: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  https://myhost.test:123/
@@ -100,6 +112,7 @@ TSHttpHdrEffectiveUrlBufGet():  https://myhost.test:123/
 TSUrlSchemeGet():  https
 TSUrlRawSchemeGet():  https
 TSUrlPortGet():  123
+TSUrlRawPortGet():  123
 Transaction: event=TS_EVENT_HTTP_READ_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  https://myhost.test:123/
 Client Request:
@@ -107,18 +120,21 @@ TSHttpHdrEffectiveUrlBufGet():  https://myhost.test:123/
 TSUrlSchemeGet():  https
 TSUrlRawSchemeGet():  https
 TSUrlPortGet():  123
+TSUrlRawPortGet():  123
 TSRemapDoRemap(): instance=2 redirect=0
 Remap Request:
 TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  SERVER_PORT
+TSUrlRawPortGet():  SERVER_PORT
 TSRemapDoRemap(): instance=3 redirect=0
 Remap Request:
 TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  http
 TSUrlPortGet():  SERVER_PORT
+TSUrlRawPortGet():  SERVER_PORT
 Global: event=TS_EVENT_HTTP_SEND_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://127.0.0.1:SERVER_PORT/
 Request To Server:
@@ -126,6 +142,7 @@ TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  failed to get raw URL scheme
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0
 Transaction: event=TS_EVENT_HTTP_SEND_REQUEST_HDR
 TSHttpTxnEffectiveUrlStringGet():  http://127.0.0.1:SERVER_PORT/
 Request To Server:
@@ -133,3 +150,4 @@ TSHttpHdrEffectiveUrlBufGet():  http://127.0.0.1:SERVER_PORT/
 TSUrlSchemeGet():  http
 TSUrlRawSchemeGet():  failed to get raw URL scheme
 TSUrlPortGet():  80
+TSUrlRawPortGet():  0

--- a/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
@@ -106,6 +106,7 @@ testsForReqHdr(char const *desc, TSMBuffer hbuf, TSMLoc hloc)
       logFile << std::string_view(scheme_data, scheme_len) << std::endl;
     }
     logFile << "TSUrlPortGet():  " << TSUrlPortGet(hbuf, url_loc) << std::endl;
+    logFile << "TSUrlRawPortGet():  " << TSUrlRawPortGet(hbuf, url_loc) << std::endl;
   }
 }
 


### PR DESCRIPTION
Returns only an explicit port number in the URL, no canonical port number.