### PR TITLE
Cleanup: Rename IOBufferReader of Http2ClientSession

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -177,12 +177,12 @@ Http2ClientSession::start()
   HTTP2_SET_SESSION_HANDLER(&Http2ClientSession::state_read_connection_preface);
 
   VIO *read_vio = this->do_io_read(this, INT64_MAX, this->read_buffer);
-  write_vio     = this->do_io_write(this, INT64_MAX, this->sm_writer);
+  write_vio     = this->do_io_write(this, INT64_MAX, this->_write_buffer_reader);
 
   this->connection_state.init();
   send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_INIT, this);
 
-  if (this->_reader->is_read_avail_more_than(0)) {
+  if (this->_read_buffer_reader->is_read_avail_more_than(0)) {
     this->handleEvent(VC_EVENT_READ_READY, read_vio);
   }
 }
@@ -217,12 +217,12 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 
   this->read_buffer             = iobuf ? iobuf : new_MIOBuffer(HTTP2_HEADER_BUFFER_SIZE_INDEX);
   this->read_buffer->water_mark = connection_state.server_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE);
-  this->_reader                 = reader ? reader : this->read_buffer->alloc_reader();
+  this->_read_buffer_reader     = reader ? reader : this->read_buffer->alloc_reader();
 
   // This block size is the buffer size that we pass to SSLWriteBuffer
   auto buffer_block_size_index = iobuffer_size_to_index(Http2::write_buffer_block_size, MAX_BUFFER_SIZE_INDEX);
   this->write_buffer           = new_MIOBuffer(buffer_block_size_index);
-  this->sm_writer              = this->write_buffer->alloc_reader();
+  this->_write_buffer_reader   = this->write_buffer->alloc_reader();
   this->_write_size_threshold  = index_to_buffer_size(buffer_block_size_index) * Http2::write_size_threshold;
 
   this->_handle_if_ssl(new_vc);
@@ -392,11 +392,11 @@ Http2ClientSession::state_read_connection_preface(int event, void *edata)
   STATE_ENTER(&Http2ClientSession::state_read_connection_preface, event);
   ink_assert(event == VC_EVENT_READ_COMPLETE || event == VC_EVENT_READ_READY);
 
-  if (this->_reader->read_avail() >= static_cast<int64_t>(HTTP2_CONNECTION_PREFACE_LEN)) {
+  if (this->_read_buffer_reader->read_avail() >= static_cast<int64_t>(HTTP2_CONNECTION_PREFACE_LEN)) {
     char buf[HTTP2_CONNECTION_PREFACE_LEN];
     unsigned nbytes;
 
-    nbytes = copy_from_buffer_reader(buf, this->_reader, sizeof(buf));
+    nbytes = copy_from_buffer_reader(buf, this->_read_buffer_reader, sizeof(buf));
     ink_release_assert(nbytes == HTTP2_CONNECTION_PREFACE_LEN);
 
     if (memcmp(HTTP2_CONNECTION_PREFACE, buf, nbytes) != 0) {
@@ -411,7 +411,7 @@ Http2ClientSession::state_read_connection_preface(int event, void *edata)
     }
 
     Http2SsnDebug("received connection preface");
-    this->_reader->consume(nbytes);
+    this->_read_buffer_reader->consume(nbytes);
     HTTP2_SET_SESSION_HANDLER(&Http2ClientSession::state_start_frame_read);
 
     _vc->set_inactivity_timeout(HRTIME_SECONDS(Http2::no_activity_timeout_in));
@@ -420,7 +420,7 @@ Http2ClientSession::state_read_connection_preface(int event, void *edata)
     // XXX start the write VIO ...
 
     // If we have unconsumed data, start tranferring frames now.
-    if (this->_reader->is_read_avail_more_than(0)) {
+    if (this->_read_buffer_reader->is_read_avail_more_than(0)) {
       return this->handleEvent(VC_EVENT_READ_READY, vio);
     }
   }
@@ -448,13 +448,13 @@ int
 Http2ClientSession::do_start_frame_read(Http2ErrorCode &ret_error)
 {
   ret_error = Http2ErrorCode::HTTP2_ERROR_NO_ERROR;
-  ink_release_assert(this->_reader->read_avail() >= (int64_t)HTTP2_FRAME_HEADER_LEN);
+  ink_release_assert(this->_read_buffer_reader->read_avail() >= (int64_t)HTTP2_FRAME_HEADER_LEN);
 
   uint8_t buf[HTTP2_FRAME_HEADER_LEN];
   unsigned nbytes;
 
   Http2SsnDebug("receiving frame header");
-  nbytes = copy_from_buffer_reader(buf, this->_reader, sizeof(buf));
+  nbytes = copy_from_buffer_reader(buf, this->_read_buffer_reader, sizeof(buf));
 
   this->cur_frame_from_early_data = false;
   if (!http2_parse_frame_header(make_iovec(buf), this->current_hdr)) {
@@ -472,7 +472,7 @@ Http2ClientSession::do_start_frame_read(Http2ErrorCode &ret_error)
   Http2SsnDebug("frame header length=%u, type=%u, flags=0x%x, streamid=%u", (unsigned)this->current_hdr.length,
                 (unsigned)this->current_hdr.type, (unsigned)this->current_hdr.flags, this->current_hdr.streamid);
 
-  this->_reader->consume(nbytes);
+  this->_read_buffer_reader->consume(nbytes);
 
   if (!http2_frame_header_is_valid(this->current_hdr, this->connection_state.server_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE))) {
     ret_error = Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR;
@@ -502,7 +502,7 @@ Http2ClientSession::state_complete_frame_read(int event, void *edata)
   VIO *vio = static_cast<VIO *>(edata);
   STATE_ENTER(&Http2ClientSession::state_complete_frame_read, event);
   ink_assert(event == VC_EVENT_READ_COMPLETE || event == VC_EVENT_READ_READY);
-  if (this->_reader->read_avail() < this->current_hdr.length) {
+  if (this->_read_buffer_reader->read_avail() < this->current_hdr.length) {
     if (this->_should_do_something_else()) {
       if (this->_reenable_event == nullptr) {
         vio->disable();
@@ -515,7 +515,7 @@ Http2ClientSession::state_complete_frame_read(int event, void *edata)
     }
     return 0;
   }
-  Http2SsnDebug("completed frame read, %" PRId64 " bytes available", this->_reader->read_avail());
+  Http2SsnDebug("completed frame read, %" PRId64 " bytes available", this->_read_buffer_reader->read_avail());
 
   return state_process_frame_read(event, vio, true);
 }
@@ -524,16 +524,16 @@ int
 Http2ClientSession::do_complete_frame_read()
 {
   // XXX parse the frame and handle it ...
-  ink_release_assert(this->_reader->read_avail() >= this->current_hdr.length);
+  ink_release_assert(this->_read_buffer_reader->read_avail() >= this->current_hdr.length);
 
-  Http2Frame frame(this->current_hdr, this->_reader, this->cur_frame_from_early_data);
+  Http2Frame frame(this->current_hdr, this->_read_buffer_reader, this->cur_frame_from_early_data);
   send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_RECV, &frame);
   // Check whether data is read from early data
   if (this->read_from_early_data > 0) {
     this->read_from_early_data -=
       this->read_from_early_data > this->current_hdr.length ? this->current_hdr.length : this->read_from_early_data;
   }
-  this->_reader->consume(this->current_hdr.length);
+  this->_read_buffer_reader->consume(this->current_hdr.length);
   ++(this->_n_frame_read);
 
   // Set the event handler if there is no more data to process a new frame
@@ -549,7 +549,7 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
     do_complete_frame_read();
   }
 
-  while (this->_reader->read_avail() >= static_cast<int64_t>(HTTP2_FRAME_HEADER_LEN)) {
+  while (this->_read_buffer_reader->read_avail() >= static_cast<int64_t>(HTTP2_FRAME_HEADER_LEN)) {
     // Cancel reading if there was an error or connection is closed
     if (connection_state.tx_error_code.code != static_cast<uint32_t>(Http2ErrorCode::HTTP2_ERROR_NO_ERROR) ||
         connection_state.is_state_closed()) {
@@ -581,7 +581,7 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
     }
 
     // If there is no more data to finish the frame, set up the event handler and reenable
-    if (this->_reader->read_avail() < this->current_hdr.length) {
+    if (this->_read_buffer_reader->read_avail() < this->current_hdr.length) {
       HTTP2_SET_SESSION_HANDLER(&Http2ClientSession::state_complete_frame_read);
       break;
     }

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -136,11 +136,17 @@ private:
 
   bool _should_do_something_else();
 
-  SessionHandler session_handler      = nullptr;
+  ////////
+  // Variables
+  SessionHandler session_handler = nullptr;
+
   MIOBuffer *read_buffer              = nullptr;
-  IOBufferReader *_reader             = nullptr;
-  MIOBuffer *write_buffer             = nullptr;
-  IOBufferReader *sm_writer           = nullptr;
+  IOBufferReader *_read_buffer_reader = nullptr;
+
+  VIO *write_vio                       = nullptr;
+  MIOBuffer *write_buffer              = nullptr;
+  IOBufferReader *_write_buffer_reader = nullptr;
+
   Http2FrameHeader current_hdr        = {0, 0, 0, 0};
   uint32_t _write_size_threshold      = 0;
   uint32_t _write_time_threshold      = 100;
@@ -152,7 +158,6 @@ private:
   History<HISTORY_DEFAULT_SIZE> _history;
   Milestones<Http2SsnMilestone, static_cast<size_t>(Http2SsnMilestone::LAST_ENTRY)> _milestones;
 
-  VIO *write_vio                 = nullptr;
   int dying_event                = 0;
   bool kill_me                   = false;
   Http2SessionCod cause_of_death = Http2SessionCod::NOT_PROVIDED;


### PR DESCRIPTION
No logic change. Just renaming 2 IOBufferReader(s).
```
-  IOBufferReader *_reader             = nullptr;
+  IOBufferReader *_read_buffer_reader = nullptr;
```
```
-  IOBufferReader *sm_writer           = nullptr;
+  IOBufferReader *_write_buffer_reader = nullptr;
```