### PR TITLE
Cleanup: Remove unused member of Http2ClientSession

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -288,7 +288,6 @@ void
 Http2ClientSession::flush()
 {
   if (this->_pending_sending_data_size > 0) {
-    total_write_len += this->_pending_sending_data_size;
     this->_pending_sending_data_size = 0;
     this->_write_buffer_last_flush   = Thread::get_hrtime();
     write_reenable();

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -136,7 +136,6 @@ private:
 
   bool _should_do_something_else();
 
-  int64_t total_write_len             = 0;
   SessionHandler session_handler      = nullptr;
   MIOBuffer *read_buffer              = nullptr;
   IOBufferReader *_reader             = nullptr;


### PR DESCRIPTION
The `total_write_len` is incremented but not used after all.