### PR TITLE
Tidy up session/transaction destruction process

### DIFF
--- a/proxy/ProxySession.cc
+++ b/proxy/ProxySession.cc
@@ -30,6 +30,18 @@ ProxySession::ProxySession() : VConnection(nullptr) {}
 
 ProxySession::ProxySession(NetVConnection *vc) : VConnection(nullptr), _vc(vc) {}
 
+ProxySession::~ProxySession()
+{
+  if (schedule_event) {
+    schedule_event->cancel();
+    schedule_event = nullptr;
+  }
+  this->api_hooks.clear();
+  this->mutex.clear();
+  this->acl.clear();
+  this->_ssl.reset();
+}
+
 void
 ProxySession::set_session_active()
 {
@@ -68,19 +80,6 @@ static const TSEvent eventmap[TS_HTTP_LAST_HOOK + 1] = {
   TS_EVENT_NONE,                       // TS_HTTP_RESPONSE_CLIENT_HOOK
   TS_EVENT_NONE,                       // TS_HTTP_LAST_HOOK
 };
-
-void
-ProxySession::free()
-{
-  if (schedule_event) {
-    schedule_event->cancel();
-    schedule_event = nullptr;
-  }
-  this->api_hooks.clear();
-  this->mutex.clear();
-  this->acl.clear();
-  this->_ssl.reset();
-}
 
 int
 ProxySession::state_api_callout(int event, void *data)

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -79,6 +79,7 @@ class ProxySession : public VConnection, public PluginUserArgs<TS_USER_ARGS_SSN>
 public:
   ProxySession();
   ProxySession(NetVConnection *vc);
+  virtual ~ProxySession();
 
   // noncopyable
   ProxySession(ProxySession &) = delete;
@@ -94,7 +95,7 @@ public:
   virtual void release(ProxyTransaction *trans) = 0;
 
   virtual void destroy() = 0;
-  virtual void free();
+  virtual void free()    = 0;
 
   virtual void increment_current_active_connections_stat() = 0;
   virtual void decrement_current_active_connections_stat() = 0;

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -28,6 +28,12 @@
 
 ProxyTransaction::ProxyTransaction(ProxySession *session) : VConnection(nullptr), _proxy_ssn(session) {}
 
+ProxyTransaction::~ProxyTransaction()
+{
+  this->_sm = nullptr;
+  this->mutex.clear();
+}
+
 void
 ProxyTransaction::new_transaction(bool from_early_data)
 {
@@ -59,13 +65,6 @@ bool
 ProxyTransaction::attach_server_session(PoolableSession *ssession, bool transaction_done)
 {
   return _proxy_ssn->attach_server_session(ssession, transaction_done);
-}
-
-void
-ProxyTransaction::destroy()
-{
-  _sm = nullptr;
-  this->mutex.clear();
 }
 
 void

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -34,6 +34,7 @@ class ProxyTransaction : public VConnection
 public:
   ProxyTransaction() : VConnection(nullptr) {}
   ProxyTransaction(ProxySession *ssn);
+  virtual ~ProxyTransaction();
 
   /// Virtual Methods
   //
@@ -42,7 +43,6 @@ public:
   Action *adjust_thread(Continuation *cont, int event, void *data);
   virtual void release(IOBufferReader *r) = 0;
   virtual void transaction_done();
-  virtual void destroy();
 
   virtual void set_active_timeout(ink_hrtime timeout_in);
   virtual void set_inactivity_timeout(ink_hrtime timeout_in);

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -115,15 +115,12 @@ Http1ClientSession::free()
     conn_decrease = false;
   }
 
-  // Free the transaction resources
-  this->trans.super_type::destroy();
-
   if (_vc) {
     _vc->do_io_close();
     _vc = nullptr;
   }
 
-  super::free();
+  this->~Http1ClientSession();
   THREAD_FREE(this, http1ClientSessionAllocator, this_thread());
 }
 
@@ -394,7 +391,8 @@ Http1ClientSession::release(ProxyTransaction *trans)
 
   // When release is called from start() to read the first transaction, get_sm()
   // will return null.
-  HttpSM *sm = trans->get_sm();
+  HttpSM *sm                = trans->get_sm();
+  Http1Transaction *h1trans = static_cast<Http1Transaction *>(trans);
   if (sm) {
     MgmtInt ka_in = trans->get_sm()->t_state.txn_conf->keep_alive_no_activity_timeout_in;
     set_inactivity_timeout(HRTIME_SECONDS(ka_in));
@@ -412,7 +410,7 @@ Http1ClientSession::release(ProxyTransaction *trans)
   //  IO to wait for new data
   bool more_to_read = this->_reader->is_read_avail_more_than(0);
   if (more_to_read) {
-    trans->destroy();
+    h1trans->reset();
     HttpSsnDebug("[%" PRId64 "] data already in buffer, starting new transaction", con_id);
     new_transaction();
   } else {
@@ -426,7 +424,7 @@ Http1ClientSession::release(ProxyTransaction *trans)
       _vc->cancel_active_timeout();
       _vc->add_to_keep_alive_queue();
     }
-    trans->destroy();
+    h1trans->reset();
   }
 }
 

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -54,6 +54,7 @@ class Http1ClientSession : public ProxySession
 public:
   typedef ProxySession super; ///< Parent type.
   Http1ClientSession();
+  ~Http1ClientSession() = default;
 
   // Implement ProxySession interface.
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override;

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -50,11 +50,18 @@ Http1ServerSession::destroy()
   }
 
   mutex.clear();
+  this->~Http1ServerSession();
   if (httpSessionManager.get_pool_type() == TS_SERVER_SESSION_SHARING_POOL_THREAD) {
     THREAD_FREE(this, httpServerSessionAllocator, this_thread());
   } else {
     httpServerSessionAllocator.free(this);
   }
+}
+
+void
+Http1ServerSession::free()
+{
+  // Unlike Http1ClientSession, Http1ServerSession is freed in destroy()
 }
 
 void

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -56,11 +56,13 @@ public:
   Http1ServerSession() : super_type() {}
   Http1ServerSession(self_type const &) = delete;
   self_type &operator=(self_type const &) = delete;
+  ~Http1ServerSession()                   = default;
 
   ////////////////////
   // Methods
   void release(ProxyTransaction *) override;
   void destroy() override;
+  void free() override;
 
   // VConnection Methods
   void do_io_close(int lerrno = -1) override;

--- a/proxy/http/Http1Transaction.cc
+++ b/proxy/http/Http1Transaction.cc
@@ -31,7 +31,7 @@ Http1Transaction::release(IOBufferReader *r)
 }
 
 void
-Http1Transaction::destroy() // todo make ~Http1Transaction()
+Http1Transaction::reset()
 {
   _sm = nullptr;
 }

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -33,11 +33,11 @@ public:
   using super_type = ProxyTransaction;
 
   Http1Transaction(ProxySession *session) : super_type(session) {}
+  ~Http1Transaction() = default;
 
   ////////////////////
   // Methods
   void release(IOBufferReader *r) override;
-  void destroy() override; // todo make ~Http1Transaction()
 
   bool allow_half_open() const override;
   void transaction_done() override;
@@ -45,6 +45,7 @@ public:
   void increment_client_transactions_stat() override;
   void decrement_client_transactions_stat() override;
 
+  void reset();
   void set_reader(IOBufferReader *reader);
 
   ////////////////////

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -161,10 +161,9 @@ Http2ClientSession::free()
   delete _h2_pushed_urls;
   this->connection_state.destroy();
 
-  super::free();
-
   free_MIOBuffer(this->read_buffer);
   free_MIOBuffer(this->write_buffer);
+  this->~Http2ClientSession();
   THREAD_FREE(this, http2ClientSessionAllocator, this_ethread());
 }
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -56,10 +56,10 @@ public:
 
   Http2Stream() {} // Just to satisfy ClassAllocator
   Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_rwnd);
+  ~Http2Stream();
 
   int main_event_handler(int event, void *edata);
 
-  void destroy() override;
   void release(IOBufferReader *r) override;
   void reenable(VIO *vio) override;
   void transaction_done() override;

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -140,6 +140,12 @@ HQSession::destroy()
 }
 
 void
+HQSession::free()
+{
+  delete this;
+}
+
+void
 HQSession::release(ProxyTransaction *trans)
 {
   return;

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -48,6 +48,7 @@ public:
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override;
   void start() override;
   void destroy() override;
+  void free() override;
   void release(ProxyTransaction *trans) override;
   int get_transact_count() const override;
 

--- a/proxy/http3/Http3Transaction.cc
+++ b/proxy/http3/Http3Transaction.cc
@@ -216,12 +216,6 @@ HQTransaction::reenable(VIO *vio)
 }
 
 void
-HQTransaction::destroy()
-{
-  _sm = nullptr;
-}
-
-void
 HQTransaction::transaction_done()
 {
   // TODO: start closing transaction

--- a/proxy/http3/Http3Transaction.h
+++ b/proxy/http3/Http3Transaction.h
@@ -50,7 +50,6 @@ public:
   void cancel_inactivity_timeout() override;
   void transaction_done() override;
   bool allow_half_open() const override;
-  void destroy() override;
   void release(IOBufferReader *r) override;
   int get_transaction_id() const override;
   void increment_client_transactions_stat() override;


### PR DESCRIPTION
The primary goal is to call destructors of ProxySession, ProxyTransaction and their subclasses.

ProxySession
  Made `free()` pure virtual function -- ProxySession does not know how to free itself and current code does not free.
  Added destructor -- The code originally in `free()` is now in the destructor.

ProxyTransaction
  Removed `destroy()` -- I don't see any reasons to have this as a normal function. The existence is confusing.
  Added destructor -- The code originally in `destroy()` is now in the destructor

Http1ClientSession
  Added destructor -- To call ProxySession's destructor automatically. The normal destruction process is easier to follow.
  Changed a function name to call -- See Http1Transaction.

Http1ServerSession
  Added destructor -- Just for consistency.
  Added `free()` -- It does nothing because it's freed in `destroy()` unlike Http1ClientSession.

Http1Transaction
  Renamed `destroy()` to `reset()` -- `Http1Transaction::destroy()` didn't actually destroy itself, but reset its state.

Http2ClientSession
  Added destructor -- To call ProxySession's destructor automatically.

Http2Stream
  Converted `destroy()` to the destructor
  Unified the process to destroy itself

Http3Session
  Added `free()` -- It has never been freed.
  

