### PR TITLE
FQ pacing plugin memory leak fix

### DIFF
--- a/plugins/experimental/fq_pacing/fq_pacing.c
+++ b/plugins/experimental/fq_pacing/fq_pacing.c
@@ -196,6 +196,7 @@ reset_pacing_cont(TSCont contp, TSEvent event, void *edata)
 #endif
 
   TSfree(txn_data);
+  TSContDestroy(contp);
   TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
   return 0;
 }


### PR DESCRIPTION
Add tscontdestroy when transaction is closed and pacing rate is reset