### PR TITLE
Fix the final consumer write size from unchunked to chunked tunnel

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1010,7 +1010,7 @@ HttpTunnel::producer_handler_dechunked(int event, HttpTunnelProducer *p)
       HttpTunnelConsumer *c;
       for (c = p->consumer_list.head; c; c = c->link.next) {
         if (c->alive) {
-          c->write_vio->nbytes = p->chunked_handler.chunked_size;
+          c->write_vio->nbytes = p->chunked_handler.chunked_size + p->chunked_handler.skip_bytes;
           // consumer_handler(VC_EVENT_WRITE_COMPLETE, c);
         }
       }

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1001,10 +1001,12 @@ HttpTunnel::producer_handler_dechunked(int event, HttpTunnelProducer *p)
 
   // We only interested in translating certain events
   switch (event) {
-  case VC_EVENT_READ_READY:
   case VC_EVENT_READ_COMPLETE:
   case HTTP_TUNNEL_EVENT_PRECOMPLETE:
   case VC_EVENT_EOS:
+    p->alive = false; // Update the producer state for final_consumer_bytes_to_write
+    /* fallthrough */
+  case VC_EVENT_READ_READY:
     p->last_event = p->chunked_handler.last_server_event = event;
     if (p->chunked_handler.generate_chunked_content()) { // We are done, make sure the consumer is activated
       HttpTunnelConsumer *c;

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1010,7 +1010,7 @@ HttpTunnel::producer_handler_dechunked(int event, HttpTunnelProducer *p)
       HttpTunnelConsumer *c;
       for (c = p->consumer_list.head; c; c = c->link.next) {
         if (c->alive) {
-          c->write_vio->nbytes = p->chunked_handler.chunked_size + p->chunked_handler.skip_bytes;
+          c->write_vio->nbytes = final_consumer_bytes_to_write(p, c);
           // consumer_handler(VC_EVENT_WRITE_COMPLETE, c);
         }
       }


### PR DESCRIPTION
Another issue I ran into with the H2 to origin work.  This case may not occur outside of that.

Client is Http/1.1.  Server is Http/2.  The server returns a header with no content length set, so the data is coming back in a series of data chunks.  Thus, it must be returned to the client chunked.  The response tunnel is set up for do_chunking.  That all works well, but the final call on the consumer side of the tunnel sets the total number of bytes read incorrectly. It only sets the number of data bytes.  It does not include the header bytes which is tracked by p->chunked_handler.skip_bytes.

In my case, only 5 bytes were being returned to the client. From the client's perspective, it looked like a stall.
