### PR TITLE
Adapt to continuation changes in write event handling

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -431,6 +431,9 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   if (towrite != ntodo && buf.writer()->write_avail()) {
     if (write_signal_and_update(VC_EVENT_WRITE_READY, vc) != EVENT_CONT) {
       return;
+    } else if (c != s->vio.cont) { /* The write vio was updated in the handler */
+      write_reschedule(nh, vc);
+      return;
     }
 
     ntodo = s->vio.ntodo();

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -353,6 +353,7 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
 {
   NetState *s       = &vc->write;
   ProxyMutex *mutex = thread->mutex.get();
+  Continuation *c   = vc->write.vio.cont;
 
   MUTEX_TRY_LOCK(lock, s->vio.mutex, thread);
 


### PR DESCRIPTION
Another issue I encountered with the H2 to origin processing.  But this one could affect other code paths as well.

In the write_to_net_io(), we deliver the WRITE_READY event to the write_vio continuation for processing.  It is possible in the handlers, the write_vio is adjusted so the continuation is changed.  In that case, the write processing should be restarted to make the appropriate changes to the new version of the write_vio.

In my original version, I just added the continuation check to the proceeding if.  So if the write_signal_and_update returned something other than EVENT_CONT or the continuation in the vio changed, we just returned.  However, in that case we would lose the WRITE_READY.  By rescheduling the WRITE_READY is delivered to the new continuation if there is more data to be processed than handled by the original continuation.