### PR TITLE
 Refine connection failure logging and messages and eliminate spurious connection errors

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1222,10 +1222,12 @@ HttpSM::state_raw_http_server_open(int event, void *data)
 
     netvc->set_inactivity_timeout(get_server_inactivity_timeout());
     netvc->set_active_timeout(get_server_active_timeout());
+    t_state.current.server->clear_connect_fail();
     break;
 
   case VC_EVENT_ERROR:
   case NET_EVENT_OPEN_FAILED:
+    t_state.set_connect_fail(server_session->get_netvc()->lerrno);
     t_state.current.state = HttpTransact::OPEN_RAW_ERROR;
     // use this value just to get around other values
     t_state.hdr_info.response_error = HttpTransact::STATUS_CODE_SERVER_ERROR;
@@ -1867,8 +1869,11 @@ HttpSM::state_http_server_open(int event, void *data)
       }
 
       server_entry->write_vio = server_session->do_io_write(this, nbytes, server_session->get_reader());
-    } else {
-      // in the case of an intercept plugin don't to the connect timeout change
+
+      // Pre-emptively set a server connect failure that will be cleared once a WRITE_READY is received from origin or
+      // bytes are received back
+      t_state.set_connect_fail(EIO);
+    } else { // in the case of an intercept plugin don't to the connect timeout change
       SMDebug("http", "[%" PRId64 "] not setting handler for TCP handshake", sm_id);
       handle_http_server_open();
     }
@@ -1884,6 +1889,7 @@ HttpSM::state_http_server_open(int event, void *data)
 
     // Reset the timeout to the non-connect timeout
     server_session->set_inactivity_timeout(get_server_inactivity_timeout());
+    t_state.current.server->clear_connect_fail();
     handle_http_server_open();
     return 0;
   case EVENT_INTERVAL: // Delayed call from another thread
@@ -1893,18 +1899,19 @@ HttpSM::state_http_server_open(int event, void *data)
     break;
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_ACTIVE_TIMEOUT:
+    t_state.set_connect_fail(ETIMEDOUT);
+  /* fallthrough */
   case VC_EVENT_ERROR:
   case NET_EVENT_OPEN_FAILED: {
     if (server_session) {
       NetVConnection *vc = server_session->get_netvc();
       if (vc) {
+        t_state.set_connect_fail(vc->lerrno);
         server_connection_provided_cert = vc->provided_cert();
       }
     }
 
     t_state.current.state = HttpTransact::CONNECTION_ERROR;
-    // save the errno from the connect fail for future use (passed as negative value, flip back)
-    t_state.current.server->set_connect_fail(event == NET_EVENT_OPEN_FAILED ? -reinterpret_cast<intptr_t>(data) : ECONNABORTED);
     t_state.outbound_conn_track_state.clear();
 
     /* If we get this error in transparent mode, then we simply can't bind to the 4-tuple to make the connection.  There's no hope
@@ -3076,7 +3083,9 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
       t_state.current.server->abort      = HttpTransact::ABORTED;
       t_state.client_info.keep_alive     = HTTP_NO_KEEPALIVE;
       t_state.current.server->keep_alive = HTTP_NO_KEEPALIVE;
-      t_state.squid_codes.log_code       = SQUID_LOG_ERR_READ_ERROR;
+      if (event == VC_EVENT_EOS) {
+        t_state.squid_codes.log_code = SQUID_LOG_ERR_READ_ERROR;
+      }
     } else {
       SMDebug("http", "[%" PRId64 "] [HttpSM::tunnel_handler_server] finishing HTTP tunnel", sm_id);
       p->read_success               = true;
@@ -3672,6 +3681,28 @@ HttpSM::tunnel_handler_post_server(int event, HttpTunnelConsumer *c)
   case VC_EVENT_ERROR:
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_ACTIVE_TIMEOUT:
+
+    switch (event) {
+    case VC_EVENT_INACTIVITY_TIMEOUT:
+      t_state.current.state = HttpTransact::INACTIVE_TIMEOUT;
+      t_state.set_connect_fail(ETIMEDOUT);
+      break;
+    case VC_EVENT_ACTIVE_TIMEOUT:
+      t_state.current.state = HttpTransact::ACTIVE_TIMEOUT;
+      t_state.set_connect_fail(ETIMEDOUT);
+      break;
+    case VC_EVENT_EOS:
+      t_state.current.state = HttpTransact::CONNECTION_CLOSED;
+      t_state.set_connect_fail(EPIPE);
+      break;
+    case VC_EVENT_ERROR:
+      t_state.current.state = HttpTransact::CONNECTION_CLOSED;
+      t_state.set_connect_fail(server_session->get_netvc()->lerrno);
+      break;
+    default:
+      break;
+    }
+
     //  Did not complete post tunneling
     //
     //    In the http case, we don't want to close
@@ -5379,7 +5410,7 @@ HttpSM::mark_host_failure(HostDBInfo *info, time_t time_down)
         char *url_str = t_state.hdr_info.client_request.url_string_get(&t_state.arena, nullptr);
         Log::error("%s", lbw()
                            .clip(1)
-                           .print("CONNECT Error: {} connecting to {} for '{}' (setting last failure time)",
+                           .print("CONNECT Error: {} connecting to {} for '{}' marking down",
                                   ts::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr,
                                   ts::bwf::FirstOf(url_str, "<none>"))
                            .extend(1)
@@ -5474,7 +5505,7 @@ HttpSM::mark_server_down_on_client_abort()
         wait = 0;
       }
       if (ink_hrtime_to_sec(wait) > t_state.txn_conf->client_abort_threshold) {
-        t_state.current.server->set_connect_fail(ETIMEDOUT);
+        t_state.set_connect_fail(ETIMEDOUT);
         do_hostdb_update_if_necessary();
       }
     }
@@ -5590,7 +5621,10 @@ HttpSM::handle_post_failure()
     tunnel.deallocate_buffers();
     tunnel.reset();
     // Server died
-    t_state.current.state = HttpTransact::CONNECTION_CLOSED;
+    if (t_state.current.state == HttpTransact::STATE_UNDEFINED || t_state.current.state == HttpTransact::CONNECTION_ALIVE) {
+      t_state.set_connect_fail(server_session->get_netvc()->lerrno);
+      t_state.current.state = HttpTransact::CONNECTION_CLOSED;
+    }
     call_transact_and_set_next_state(HttpTransact::HandleResponse);
   }
 }
@@ -5708,12 +5742,14 @@ HttpSM::handle_server_setup_error(int event, void *data)
   switch (event) {
   case VC_EVENT_EOS:
     t_state.current.state = HttpTransact::CONNECTION_CLOSED;
+    t_state.set_connect_fail(EPIPE);
     break;
   case VC_EVENT_ERROR:
-    t_state.current.state        = HttpTransact::CONNECTION_ERROR;
-    t_state.cause_of_death_errno = server_session->get_netvc()->lerrno;
+    t_state.current.state = HttpTransact::CONNECTION_ERROR;
+    t_state.set_connect_fail(server_session->get_netvc()->lerrno);
     break;
   case VC_EVENT_ACTIVE_TIMEOUT:
+    t_state.set_connect_fail(ETIMEDOUT);
     t_state.current.state = HttpTransact::ACTIVE_TIMEOUT;
     break;
 
@@ -5723,6 +5759,7 @@ HttpSM::handle_server_setup_error(int event, void *data)
     //   server failed
     // In case of TIMEOUT, the iocore sends back
     // server_entry->read_vio instead of the write_vio
+    t_state.set_connect_fail(ETIMEDOUT);
     if (server_entry->write_vio && server_entry->write_vio->nbytes > 0 && server_entry->write_vio->ndone == 0) {
       t_state.current.state = HttpTransact::CONNECTION_ERROR;
     } else {
@@ -7735,6 +7772,9 @@ HttpSM::set_next_state()
   }
 
   case HttpTransact::SM_ACTION_ORIGIN_SERVER_RAW_OPEN: {
+    // Pre-emptively set a server connect failure that will be cleared once a WRITE_READY is received from origin or
+    // bytes are received back
+    t_state.set_connect_fail(EIO);
     HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_raw_http_server_open);
 
     ink_assert(server_entry == nullptr);

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1314,6 +1314,10 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
   switch (event) {
   case VC_EVENT_WRITE_READY:
     this->consumer_reenable(c);
+    // Once we get a write ready from the origin, we can assume the connect to some degree succeeded
+    if (c->vc_type == HT_HTTP_SERVER) {
+      sm->t_state.current.server->clear_connect_fail();
+    }
     break;
 
   case VC_EVENT_WRITE_COMPLETE:

--- a/src/traffic_cache_tool/Makefile.inc
+++ b/src/traffic_cache_tool/Makefile.inc
@@ -42,6 +42,7 @@ traffic_cache_tool_traffic_cache_tool_LDADD = \
     $(top_builddir)/src/tscore/.libs/ink_mutex.o \
     $(top_builddir)/src/tscore/.libs/ink_string.o \
     $(top_builddir)/src/tscore/.libs/BufferWriterFormat.o \
+    $(top_builddir)/src/tscore/.libs/InkErrno.o \
     $(top_builddir)/src/tscore/.libs/ts_file.o \
     $(top_builddir)/src/tscore/.libs/Errata.o \
     $(top_builddir)/src/tscpp/util/.libs/TextView.o \

--- a/src/tscore/BufferWriterFormat.cc
+++ b/src/tscore/BufferWriterFormat.cc
@@ -24,6 +24,7 @@
 #include "tscore/BufferWriter.h"
 #include "tscore/bwf_std_format.h"
 #include "tscore/ink_thread.h"
+#include "tscore/InkErrno.h"
 #include <unistd.h>
 #include <sys/param.h>
 #include <cctype>
@@ -896,8 +897,12 @@ bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Errno const &e)
   if (spec.has_numeric_type()) {              // if numeric type, print just the numeric part.
     w.print(number_fmt, e._e);
   } else {
-    w.write(short_name(e._e));
-    w.write(strerror(e._e));
+    if (e._e < 0) {
+      w.write(InkStrerror(-e._e));
+    } else {
+      w.write(short_name(e._e));
+      w.write(strerror(e._e));
+    }
     if (spec._type != 's' && spec._type != 'S') {
       w.write(' ');
       w.print(number_fmt, e._e);

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
@@ -1,4 +1,4 @@
-HTTP/1.1 502 Cannot find server.
+HTTP/1.1 500 Cannot find server.
 Date: ``
 Connection: close
 Server: ATS/``

--- a/tests/gold_tests/redirect/redirect_actions.test.py
+++ b/tests/gold_tests/redirect/redirect_actions.test.py
@@ -184,7 +184,7 @@ class ActionE(Enum):
     Follow = {'config': 'follow', 'expectedStatusLine': 'HTTP/1.1 204 No Content\r\n'}
 
     # Added to test failure modes.
-    Break = {'expectedStatusLine': 'HTTP/1.1 502 Cannot find server.\r\n'}
+    Break = {'expectedStatusLine': 'HTTP/1.1 500 Cannot find server.\r\n'}
 
 
 scenarios = [

--- a/tests/gold_tests/timeout/tls_conn_timeout.test.py
+++ b/tests/gold_tests/timeout/tls_conn_timeout.test.py
@@ -70,7 +70,7 @@ tr.Processes.Default.StartBefore(delay_post_connect, ready=When.PortOpen(Test.Va
 tr.Processes.Default.Command = 'curl -H"Connection:close" -d "bob" -i http://127.0.0.1:{0}/connect_blocked --tlsv1.2'.format(
     ts.Variables.port)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "HTTP/1.1 502 internal error - server connection terminated", "Connect failed")
+    "HTTP/1.1 502 connect failed", "Connect failed")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_post_connect
 tr.StillRunningAfter = Test.Processes.ts
@@ -94,7 +94,7 @@ tr.Processes.Default.StartBefore(delay_get_connect, ready=When.PortOpen(Test.Var
 tr.Processes.Default.Command = 'curl -H"Connection:close" -i http://127.0.0.1:{0}/get_connect_blocked --tlsv1.2'.format(
     ts.Variables.port)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "HTTP/1.1 502 internal error - server connection terminated", "Connect failed")
+    "HTTP/1.1 502 connect failed", "Connect failed")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_get_connect
 


### PR DESCRIPTION
These are changes I made working with @djcarlin to clean up our error messages on connection failures.  These changes are in a build that we are rolling out.  Currently running in a couple pods.

The problem was that messages in errors.log about connection closing were confusing and in some cases missing information. One issue is that the HttpSM had two pieces of information that were tracking the reason for a connection failure (t_state.current.server->connect_result and t_state.cause_of_death_errno), and they weren't always being set consistently. This PR uses an updated version of set_connect_fail() to set them both consistently.

The PR also changes the logic of setting those values.  The original would set EIO if nothing else was set.  The PR sets EIO and clears it on success.  Later calls to set_connect_fail will override the EIO..

The PR also attempts to make the SQUID log codes more detailed in the case of connection failure.

Finally, the PR adjusts the logs to error.log. There was one failure path that was not logging, so I added HttpTransact::error_log_connection_failure. and called that from both locations.  Also added an error.log entry for the DNS failure case.

I see that there are some changes in HttpTunnel and Http2Stream which seem unrelated.  I just wrote quite a lot here, so I'll go ahead and set up the PR and push up another commit to eliminate those changes.