### PR TITLE
Rollback LAZY_BUF_ALLOC remove in HttpTunnel

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1234,7 +1234,7 @@ HttpTunnel::consumer_reenable(HttpTunnelConsumer *c)
 {
   HttpTunnelProducer *p = c->producer;
 
-  if (p && p->alive && p->read_buffer->write_avail() > 0) {
+  if (p && p->alive) {
     // Only do flow control if enabled and the producer is an external
     // source.  Otherwise disable by making the backlog zero. Because
     // the backlog short cuts quit when the value is equal (or
@@ -1370,7 +1370,7 @@ HttpTunnel::consumer_handler(int event, HttpTunnelConsumer *c)
     //    the SM since the reenabling has the side effect
     //    updating the buffer state for the VConnection
     //    that is being reenabled
-    if (p->alive && p->read_vio && p->read_buffer->write_avail() > 0) {
+    if (p->alive && p->read_vio) {
       if (p->is_throttled()) {
         this->consumer_reenable(c);
       } else {


### PR DESCRIPTION
This is partial revert of b4f8d1c2ca5895c81dd7137b11620e421c1e8582 which removed `LAZY_BUF_ALLOC`. 
The MIOBuffer allocation change is fine, but the change in the HttpTunnel.cc might be a problem. 

At the beginning of `HttpTunnel::consumer_reenable(HttpTunnelConsumer *c)`, the change is below
```
-  if (p && p->alive
- #ifndef LAZY_BUF_ALLOC
-       && p->read_buffer->write_avail() > 0
- #endif
+  if (p && p->alive && p->read_buffer->write_avail() > 0
```
https://github.com/apache/trafficserver/pull/5029/files#diff-fa7d3bd44e7a4b62e39f491b2cfa19b9f93b9fe7e20bdae1bcccd251b0583342L1275-L1278

`LAZY_BUF_ALLOC` was defined prior to the commit, so the change is equivalent to 

```
- if (p && p->alive)
+ if (p && p->alive && p->read_buffer->write_avail() > 0)
```

This might change the behavior of the HTTP Flow Control (throttling) when the read_buffer is full.