### PR TITLE
Call do_io_close instead of HTTP2_SESSION_EVENT_FINI handler

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -757,7 +757,7 @@ rcv_goaway_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
                    static_cast<int>(goaway.error_code));
 
   cstate.rx_error_code = {ProxyErrorClass::SSN, static_cast<uint32_t>(goaway.error_code)};
-  cstate.handleEvent(HTTP2_SESSION_EVENT_FINI, nullptr);
+  cstate.ua_session->do_io_close();
 
   return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
 }


### PR DESCRIPTION
While I was looking into #7471, I realized that `Http2ClientSession::do_io_close` is not called if clients send GOAWAY.

Calling `do_io_close` is not equivalent to calling `HTTP2_SESSION_EVENT_FINI` event handler, and touching this area is always scary, but I don't think we should skip `do_io_close`. In case this change causes something we should keep `do_io_close` and fix the new issue.