### PR TITLE
Add an assert to check do_io_close is called

### DIFF
--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -154,6 +154,7 @@ public:
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
   VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
   void do_io_shutdown(ShutdownHowTo_t howto) override;
+  void do_io_close(int alerrno = -1) override;
   void reenable(VIO *vio) override;
 
   ////////////////////
@@ -167,6 +168,8 @@ public:
   ink_hrtime ssn_last_txn_time = 0;
 
 protected:
+  virtual void _do_io_close(int alerrno) = 0;
+
   // Hook dispatching state
   HttpHookState hook_state;
 
@@ -201,6 +204,8 @@ private:
 
   std::unique_ptr<SSLProxySession> _ssl;
   static inline int64_t next_cs_id = 0;
+
+  bool _need_do_io_close = false;
 };
 
 ///////////////////

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -205,7 +205,7 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 }
 
 void
-Http1ClientSession::do_io_close(int alerrno)
+Http1ClientSession::_do_io_close(int alerrno)
 {
   if (read_state == HCS_CLOSED) {
     return; // Don't double call session close

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -66,9 +66,6 @@ public:
 
   bool attach_server_session(PoolableSession *ssession, bool transaction_done = true) override;
 
-  // Implement VConnection interface.
-  void do_io_close(int lerrno = -1) override;
-
   // Accessor Methods
   bool allow_half_open() const;
   void set_half_close_flag(bool flag) override;
@@ -82,6 +79,10 @@ public:
 
   void increment_current_active_connections_stat() override;
   void decrement_current_active_connections_stat() override;
+
+protected:
+  // Implement ProxySession interface
+  void _do_io_close(int lerrno) override;
 
 private:
   Http1ClientSession(Http1ClientSession &);

--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -105,7 +105,7 @@ Http1ServerSession::enable_outbound_connection_tracking(OutboundConnTrack::Group
 }
 
 void
-Http1ServerSession::do_io_close(int alerrno)
+Http1ServerSession::_do_io_close(int alerrno)
 {
   ts::LocalBufferWriter<256> w;
   bool debug_p = is_debug_tag_set("http_ss");

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -64,9 +64,6 @@ public:
   void destroy() override;
   void free() override;
 
-  // VConnection Methods
-  void do_io_close(int lerrno = -1) override;
-
   // ProxySession Methods
   int get_transact_count() const override;
   const char *get_protocol_string() const override;
@@ -100,6 +97,10 @@ public:
   //   not change the buffer for I/O without issuing a
   //   an asynchronous cancel on NT
   MIOBuffer *read_buffer = nullptr;
+
+protected:
+  // Implement ProxySession interface
+  void _do_io_close(int lerrno) override;
 
 private:
   int magic = HTTP_SS_MAGIC_DEAD;

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -233,7 +233,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 // are scenarios where we would like to complete the outstanding streams.
 
 void
-Http2ClientSession::do_io_close(int alerrno)
+Http2ClientSession::_do_io_close(int alerrno)
 {
   REMEMBER(NO_EVENT, this->recursion)
   Http2SsnDebug("session closed");

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -71,9 +71,6 @@ public:
   /////////////////////
   // Methods
 
-  // Implement VConnection interface
-  void do_io_close(int lerrno = -1) override;
-
   // Implement ProxySession interface
   void new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reader) override;
   void start() override;
@@ -133,6 +130,9 @@ private:
   // event handler.  Both feed into state_process_frame_read which may iterate
   // if there are multiple frames ready on the wire
   int state_process_frame_read(int event, VIO *vio, bool inside_frame);
+
+  // Implement ProxySession interface
+  void _do_io_close(int lerrno) override;
 
   bool _should_do_something_else();
 

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -97,7 +97,7 @@ HQSession::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, boo
 }
 
 void
-HQSession::do_io_close(int lerrno)
+HQSession::_do_io_close(int lerrno)
 {
   // TODO
   return;

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -38,7 +38,6 @@ public:
   // Implement VConnection interface
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
   VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
-  void do_io_close(int lerrno = -1) override;
   void do_io_shutdown(ShutdownHowTo_t howto) override;
   void reenable(VIO *vio) override;
 
@@ -55,6 +54,10 @@ public:
   // HQSession
   void add_transaction(HQTransaction *);
   HQTransaction *get_transaction(QUICStreamId);
+
+protected:
+  // Implement ProxySession interface
+  void _do_io_close(int lerrno) override;
 
 private:
   // this should be unordered map?


### PR DESCRIPTION
I think we should always call `do_io_close` if `do_io_read/write` is called.

This should not be merged until #7594 is merged.