### PR TITLE
Remove UnixNetVConnection::startEvent - not actually called.

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -166,7 +166,6 @@ public:
   int connectUp(EThread *t, int fd) override;
 
   // QUICNetVConnection
-  int startEvent(int event, Event *e);
   int state_pre_handshake(int event, Event *data);
   int state_handshake(int event, Event *data);
   int state_connection_established(int event, Event *data);

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -268,7 +268,6 @@ public:
   bool from_accept_thread  = false;
   NetAccept *accept_object = nullptr;
 
-  int startEvent(int event, Event *e);
   int acceptEvent(int event, Event *e);
   int mainEvent(int event, Event *e);
   virtual int connectUp(EThread *t, int fd);

--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -149,7 +149,6 @@ QUICNetProcessor::connect_re(Continuation *cont, sockaddr const *remote_addr, Ne
   // Setup QUICNetVConnection
   QUICConnectionId client_dst_cid;
   client_dst_cid.randomize();
-  // vc->init set handler of vc `QUICNetVConnection::startEvent`
   vc->init(QUIC_SUPPORTED_VERSIONS[0], client_dst_cid, client_dst_cid, con, packet_handler, this->_rtable);
   packet_handler->init(vc);
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -242,7 +242,6 @@ void
 QUICNetVConnection::init(QUICVersion version, QUICConnectionId peer_cid, QUICConnectionId original_cid, UDPConnection *udp_con,
                          QUICPacketHandler *packet_handler, QUICResetTokenTable *rtable)
 {
-  SET_HANDLER((NetVConnHandler)&QUICNetVConnection::startEvent);
   this->_initial_version             = version;
   this->_udp_con                     = udp_con;
   this->_packet_handler              = packet_handler;
@@ -385,25 +384,6 @@ QUICNetVConnection::acceptEvent(int event, Event *e)
 
   action_.continuation->handleEvent(NET_EVENT_ACCEPT, this);
   this->_schedule_packet_write_ready();
-
-  return EVENT_DONE;
-}
-
-int
-QUICNetVConnection::startEvent(int event, Event *e)
-{
-  ink_assert(event == EVENT_IMMEDIATE);
-  MUTEX_TRY_LOCK(lock, get_NetHandler(e->ethread)->mutex, e->ethread);
-  if (!lock.is_locked()) {
-    e->schedule_in(HRTIME_MSECONDS(net_retry_delay));
-    return EVENT_CONT;
-  }
-
-  if (!action_.cancelled) {
-    this->connectUp(e->ethread, NO_FD);
-  } else {
-    this->free(e->ethread);
-  }
 
   return EVENT_DONE;
 }

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -984,7 +984,6 @@ SSLNetVConnection::free(EThread *t)
   early_data_buf    = nullptr;
 
   clear();
-  SET_CONTINUATION_HANDLER(this, (SSLNetVConnHandler)&SSLNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -883,10 +883,7 @@ UnixNetVConnection::reenable_re(VIO *vio)
   }
 }
 
-UnixNetVConnection::UnixNetVConnection()
-{
-  SET_HANDLER((NetVConnHandler)&UnixNetVConnection::startEvent);
-}
+UnixNetVConnection::UnixNetVConnection() {}
 
 // Private methods
 
@@ -1047,22 +1044,6 @@ void
 UnixNetVConnection::netActivity(EThread *lthread)
 {
   net_activity(this, lthread);
-}
-
-int
-UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
-{
-  MUTEX_TRY_LOCK(lock, get_NetHandler(e->ethread)->mutex, e->ethread);
-  if (!lock.is_locked()) {
-    e->schedule_in(HRTIME_MSECONDS(net_retry_delay));
-    return EVENT_CONT;
-  }
-  if (!action_.cancelled) {
-    connectUp(e->ethread, NO_FD);
-  } else {
-    free(e->ethread);
-  }
-  return EVENT_DONE;
 }
 
 int
@@ -1354,7 +1335,6 @@ UnixNetVConnection::free(EThread *t)
   con.close();
 
   clear();
-  SET_CONTINUATION_HANDLER(this, (NetVConnHandler)&UnixNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 


### PR DESCRIPTION
@bneradt noticed a problem reported by clang analyzer and asked me about it. In tracking it down and trying to understand what the code was doing, I noticed it didn't seem to ever be invoked. The result is this PR which removes the method, `UnixNetVConnection::startEvent` that contains the problematic code, thus resolving the clang analyzer issue.

AFAICT `startEvent` was previously used as initialization for the net threads, but after the restructuring of that a few years back it became dead code. Such initialization is handled via the `EThread::schedule_spawn`.