### PR TITLE
Fix double destuct on Http2Stream termination

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -482,7 +482,6 @@ Http2Stream::terminate_if_possible()
 
     Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
     SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
-    this->~Http2Stream();
     THREAD_FREE(this, http2StreamAllocator, this_ethread());
   }
 }


### PR DESCRIPTION
The bug was introduced by #7584.