### PR TITLE
Fix the connection limit crash while using parents

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5158,11 +5158,10 @@ HttpSM::do_http_server_open(bool raw)
       } else { // queue size is 0, always block.
         ct_state.blocked();
         HTTP_INCREMENT_DYN_STAT(http_origin_connections_throttled_stat);
+        ct_state.Warn_Blocked(&t_state.txn_conf->outbound_conntrack, sm_id, ccount - 1, &t_state.current.server->dst_addr.sa,
+                              debug_on && is_debug_tag_set("http") ? "http" : nullptr);
         send_origin_throttled_response();
       }
-
-      ct_state.Warn_Blocked(&t_state.txn_conf->outbound_conntrack, sm_id, ccount - 1, &t_state.current.server->dst_addr.sa,
-                            debug_on && is_debug_tag_set("http") ? "http" : nullptr);
 
       return;
     } else {


### PR DESCRIPTION
Fix for #7521. do_http_server_open can be called recursively when there are multiple parents for a domain. Warn_Blocked can crash in this scenario. 