### PR TITLE
Disable read from client when HttpTunnelConsumer for client is set up

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6779,6 +6779,7 @@ HttpSM::setup_server_transfer()
 
   tunnel.add_consumer(ua_entry->vc, server_entry->vc, &HttpSM::tunnel_handler_ua, HT_HTTP_CLIENT, "user agent");
 
+  ua_entry->read_vio      = ua_txn->do_io_read(this, 0, nullptr);
   ua_entry->in_tunnel     = true;
   server_entry->in_tunnel = true;
 


### PR DESCRIPTION
Fix #7603.

The read from the client is enabled to watch the client abort, but this makes ATS signals EOS event to the HttpSM and goes `HttpSM::state_watch_for_client_abort()` handler.

https://github.com/apache/trafficserver/blob/7af385faf5bfb644ae200682fb156d1433437683/proxy/http/HttpSM.cc#L899-L900

When HttpSM sets up a HttpTunnelConsumer for a client, we can disable read to avoid the issue because there is nothing to read from the client. The EOS is handled by write op and signaled to HttpTunnel correctly.