### PR TITLE
Remove UnixNetVConnection::startEvent - not actually called.

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -266,7 +266,6 @@ public:
   const sockaddr *origin_trace_addr;
   int origin_trace_port;
 
-  int startEvent(int event, Event *e);
   int acceptEvent(int event, Event *e);
   int mainEvent(int event, Event *e);
   virtual int connectUp(EThread *t, int fd);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -957,7 +957,6 @@ SSLNetVConnection::free(EThread *t)
   con.close();
 
   clear();
-  SET_CONTINUATION_HANDLER(this, (SSLNetVConnHandler)&SSLNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -894,7 +894,6 @@ UnixNetVConnection::UnixNetVConnection()
     origin_trace_addr(nullptr),
     origin_trace_port(0)
 {
-  SET_HANDLER((NetVConnHandler)&UnixNetVConnection::startEvent);
 }
 
 // Private methods
@@ -1066,22 +1065,6 @@ void
 UnixNetVConnection::netActivity(EThread *lthread)
 {
   net_activity(this, lthread);
-}
-
-int
-UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
-{
-  MUTEX_TRY_LOCK(lock, get_NetHandler(e->ethread)->mutex, e->ethread);
-  if (!lock.is_locked()) {
-    e->schedule_in(HRTIME_MSECONDS(net_retry_delay));
-    return EVENT_CONT;
-  }
-  if (!action_.cancelled) {
-    connectUp(e->ethread, NO_FD);
-  } else {
-    free(e->ethread);
-  }
-  return EVENT_DONE;
 }
 
 int
@@ -1373,7 +1356,6 @@ UnixNetVConnection::free(EThread *t)
   con.close();
 
   clear();
-  SET_CONTINUATION_HANDLER(this, (NetVConnHandler)&UnixNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 


### PR DESCRIPTION
(cherry picked from commit a56638f8ba92c48e2cc8b677438c36e13f393e2b)

This is a cherry-pick of #7596 to 8.1.x