### PR TITLE
Increase Proxy Verifier caching delay.

### DIFF
--- a/tests/gold_tests/cache/replay/cache-control-max-age.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-max-age.replay.yaml
@@ -36,7 +36,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
   - request_for_zero_max_age: &request_for_zero_max_age
       client-request:
@@ -50,7 +50,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
   - request_for_negative_max_age: &request_for_negative_max_age
       client-request:
@@ -64,7 +64,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
   - request_for_non_number_max_age: &request_for_non_number_max_age
       client-request:
@@ -78,7 +78,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
   - 200_ok_response: &200_ok_response
       server-response:
@@ -267,7 +267,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # This should be replied to out of the cache, therefore this 400 response
     # should not make it to the client.
@@ -318,7 +318,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # This should go through to the server because the 0 max-age
     # directive in the request should make ATS consider it stale.
@@ -371,7 +371,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # This should go through to the server because the negative max-age
     # directive in the request should make ATS consider it stale.

--- a/tests/gold_tests/cache/replay/negative-caching-300-second-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-300-second-timeout.replay.yaml
@@ -38,7 +38,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
 sessions:
 - transactions:

--- a/tests/gold_tests/cache/replay/negative-caching-customized.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-customized.replay.yaml
@@ -74,7 +74,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # Since 404 responses are customized to not be cached, this will go
     # through.
@@ -121,7 +121,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # By customization, the 400 will be cached and this will not go through.
     <<: *200_response
@@ -161,7 +161,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # This should not go to the server since the 200 response is cached.
     server-response:

--- a/tests/gold_tests/cache/replay/negative-caching-default.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-default.replay.yaml
@@ -71,7 +71,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # 404 responses should be cached when negative caching is enabled, so this
     # should not get to the server.  But if it does, return a 200 so the test
@@ -119,7 +119,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # 400 responses should not be cached. Verify this goes to the server
     # by returning and expecting a 200 response.
@@ -159,7 +159,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # This should not go to the server, but if it does return a 400 so we catch
     # it.
@@ -211,7 +211,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # 405 responses should not be cached. Verify this goes to the server
     # by returning and expecting a 200 response.

--- a/tests/gold_tests/cache/replay/negative-caching-disabled.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-disabled.replay.yaml
@@ -34,7 +34,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
   - request_for_path_404: &request_for_path_404
       client-request:
@@ -48,7 +48,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
   - request_for_no_cache_control_response: &request_for_no_cache_control_response
       client-request:
@@ -62,7 +62,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
 
   - request_for_404_with_cc: &request_for_404_with_cc
@@ -77,7 +77,7 @@ meta:
 
         # Add a delay so ATS has time to finish any caching IO for the previous
         # transaction.
-        delay: 50ms
+        delay: 100ms
 
 sessions:
 - transactions:

--- a/tests/gold_tests/cache/replay/negative-caching-no-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-no-timeout.replay.yaml
@@ -41,7 +41,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # This should not go to the server. Verify we get the cached 404 response
     # instead of this new 403 response.

--- a/tests/gold_tests/cache/replay/negative-caching-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-timeout.replay.yaml
@@ -76,7 +76,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 50ms
+      delay: 100ms
 
     # 403 responses should be cached when negative caching is enabled, so this
     # should not get to the server.  But if it does, return a 404 so the test


### PR DESCRIPTION
Increasing the Proxy Verifier caching delay from 50ms to 100ms to
accommodate slow IO situations.