### PR TITLE
Reload server session inactivity timeout before placing a session into the pool

### DIFF
--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -212,8 +212,10 @@ ServerSessionPool::releaseSession(PoolableSession *ss)
   ss->do_io_write(this, 0, nullptr);
 
   // we probably don't need the active timeout set, but will leave it for now
-  ss->set_inactivity_timeout(ss->get_netvc()->get_inactivity_timeout());
-  ss->set_active_timeout(ss->get_netvc()->get_active_timeout());
+  HttpConfigParams *http_config_params = HttpConfig::acquire();
+  ss->set_inactivity_timeout(HRTIME_SECONDS(http_config_params->oride.keep_alive_no_activity_timeout_out));
+  ss->set_active_timeout(HRTIME_SECONDS(http_config_params->oride.keep_alive_no_activity_timeout_out));
+  HttpConfig::release(http_config_params);
   // put it in the pools.
   m_ip_pool.insert(ss);
   m_fqdn_pool.insert(ss);
@@ -270,8 +272,8 @@ ServerSessionPool::eventHandler(int event, void *data)
                 "[%" PRId64 "] [session_bucket] session received io notice [%s], "
                 "resetting timeout to maintain minimum number of connections",
                 s->connection_id(), HttpDebugNames::get_event_name(event));
-          s->get_netvc()->set_inactivity_timeout(s->get_netvc()->get_inactivity_timeout());
-          s->get_netvc()->set_active_timeout(s->get_netvc()->get_active_timeout());
+          s->get_netvc()->set_inactivity_timeout(HRTIME_SECONDS(http_config_params->oride.keep_alive_no_activity_timeout_out));
+          s->get_netvc()->set_active_timeout(HRTIME_SECONDS(http_config_params->oride.keep_alive_no_activity_timeout_out));
           found = true;
           break;
         }


### PR DESCRIPTION
This may fix #7471. 

I'm not sure if this really solves the issue, but there's a possibility that inactivity timeout is set to 0 on some server sessions and those sessions stay in the pool forever.

Setting active timeout to the value of `keep_alive_no_activity_timeout_out` looks odd, but it's actually the original behavior before [TS-863](https://issues.apache.org/jira/browse/TS-863). Since there should be no activity, it doesn't really matter, like the comment on line 214 says.