### PR TITLE
Update server_response_body_bytes when background fill worked

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3544,6 +3544,10 @@ HttpSM::tunnel_handler_cache_write(int event, HttpTunnelConsumer *c)
     break;
   }
 
+  if (background_fill != BACKGROUND_FILL_NONE) {
+    server_response_body_bytes = c->bytes_written;
+  }
+
   HTTP_DECREMENT_DYN_STAT(http_current_cache_connections_stat);
   return 0;
 }


### PR DESCRIPTION
Address https://github.com/apache/trafficserver/issues/7603#issuecomment-806367746

> proxy.process.http.background_fill_bytes_aborted_stat and proxy.process.http.background_fill_bytes_completed_stat might also be broken. Both of them keep saying 0 even if proxy.process.http.background_fill_current_count is more than 1.

These metrics are the sum of "how many bytes the background fill wrote to the cache".

https://github.com/apache/trafficserver/blob/f639621e238f778ba6f18aaa5de47772d6504e55/proxy/http/HttpTransact.cc#L8610

The `HttpSM::server_response_body_bytes` (= `origin_server_response_body_size`) is set on `HttpSM::tunnel_handler_ua` when client aborted.
https://github.com/apache/trafficserver/blob/f639621e238f778ba6f18aaa5de47772d6504e55/proxy/http/HttpSM.cc#L3387

But it never updated, so `bg_size` is always `0`. IMO, we need to set `HttpSM::server_response_body_bytes` when background fill is done (or stopped).