### PR TITLE
New rate_limit plugin for simple resource limitations

### DIFF
--- a/doc/admin-guide/plugins/index.en.rst
+++ b/doc/admin-guide/plugins/index.en.rst
@@ -164,6 +164,7 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
    MP4 <mp4.en>
    Multiplexer <multiplexer.en>
    MySQL Remap <mysql_remap.en>
+   Rate Limit <rate_limit.en>
    Signed URLs <url_sig.en>
    Slice <slice.en>
    SSL Headers <sslheaders.en>
@@ -227,6 +228,9 @@ directory of the |TS| source tree. Experimental plugins can be compiled by passi
 
 :doc:`Prefetch <prefetch.en>`
    Pre-fetch objects based on the requested URL path pattern.
+
+:doc:`Rate Limit <rate_limit.en>`
+   Simple transaction rate limiting.
 
 :doc:`Remap Purge <remap_purge.en>`
    This remap plugin allows the administrator to easily setup remotely

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -65,12 +65,17 @@ are available:
 .. option:: --header
 
    This is an optional HTTP header name, which will be added to the client
-   request header IF the transaction was delayed (queued). This can be useful
-   to for example log the delays for later analysis.
+   request header IF the transaction was delayed (queued). The value of the
+   header is the delay, in milliseconds. This can be useful to for example
+   log the delays for later analysis.
 
    It is recommended that an `@` header is used here, e.g. `@RateLimit-Delay`,
-   since this header will not leave the ATS server instance. The value here is
-   appended to the header should one already exist.
+   since this header will not leave the ATS server instance.
+
+.. option:: --maxage
+
+   An optional `max-age` for how long a transaction can sit in the delay queue.
+   The value (default 0) is the age in seconds.
 
 Examples
 --------

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -37,7 +37,7 @@ are available:
 
 .. option:: --limit
 
-   The maximum number of active connections.
+   The maximum number of active client transactions.
 
 .. option:: --queue
 
@@ -45,6 +45,12 @@ are available:
    on a FIFO queue. This option (optional) sets an upper bound on how many
    queued transactions we will allow. When this threshold is reached, all
    additional transactions are immediately served with an error message.
+
+   The queue is effectively disabled if this is set to `0`, which implies
+   that when the transaction limit is reached, we immediately start serving
+   error responses.
+
+   The default queue size is `UINT_MAX`, which is essentially unlimited.
 
 .. option:: --error
 
@@ -60,3 +66,10 @@ code `429` is used when queue is full.
 
     map http://cdn.example.com/ http://some-server.example.com \
       @plugin=rate_limit.so @pparam=--limit=128 @pparam=--queue=256
+
+
+This example would put a hard transaction (in) limit to 256, with no backoff
+queue:
+
+    map http://cdn.example.com/ http://some-server.example.com \
+      @plugin=rate_limit.so @pparam=--limit=256 @pparam=--queue=0

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -80,7 +80,7 @@ are available:
 Examples
 --------
 
-This example shows a simple rate limiting of `128` concurently active client
+This example shows a simple rate limiting of `128` concurrently active client
 transactions, with a maximum queue size of `256`. The default of HTTP status
 code `429` is used when queue is full.
 

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -75,7 +75,7 @@ are available:
 .. option:: --maxage
 
    An optional `max-age` for how long a transaction can sit in the delay queue.
-   The value (default 0) is the age in seconds.
+   The value (default 0) is the age in milliseconds.
 
 Examples
 --------

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -57,6 +57,16 @@ are available:
    An optional HTTP status error code, to be used together with the
    :option:`--queue` option above. The default is `429`.
 
+.. option:: --header
+
+   This is an optional HTTP header name, which will be added to the client
+   request header IF the transaction was delayed (queued). This can be useful
+   to for example log the delays for later analysis.
+
+   It is recommended that an `@` header is used here, e.g. `@RateLimit-Delay`,
+   since this header will not leave the ATS server instance. The value here is
+   appended to the header should one already exist.
+
 Examples
 --------
 
@@ -72,4 +82,5 @@ This example would put a hard transaction (in) limit to 256, with no backoff
 queue:
 
     map http://cdn.example.com/ http://some-server.example.com \
-      @plugin=rate_limit.so @pparam=--limit=256 @pparam=--queue=0
+      @plugin=rate_limit.so @pparam=--limit=256 @pparam=--queue=0 \
+      @pparam=--header=@RateLimit-Delay

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -1,0 +1,62 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+
+.. _admin-plugins-rate-limit:
+
+Rate Limit Plugin
+********************
+
+The :program:`rate_limit` plugin provides basic mechanism for how much
+traffic a particular service (remap rule) is allowed to do. Currently,
+the only implementation is a limit on how many active client transactions
+a service can have. However, it would be easy to refactor this plugin to
+allow for adding new limiter policies later on.
+
+The limit counters and queues are per remap rule only, i.e. there is
+(currently) no way to group transaction limits from different remap rules
+into a single rate limiter.
+
+All configuration is done via :file:`remap.config`, and the following options
+are available:
+
+.. program:: rate-limit
+
+.. option:: --limit
+
+   The maximum number of active connections.
+
+.. option:: --queue
+
+   When the limit (above) has been reached, all new transactions are placed
+   on a FIFO queue. This option (optional) sets an upper bound on how many
+   queued transactions we will allow. When this threshold is reached, all
+   additional transactions are immediately served with an error message.
+
+.. option:: --error
+
+   An optional HTTP status error code, to be used together with the
+   :option:`--queue` option above. The default is `429`.
+
+Examples
+--------
+
+This example shows a simple rate limiting of `128` concurently active client
+transactions, with a maximum queue size of `256`. The default of HTTP status
+code `429` is used when queue is full.
+
+    map http://cdn.example.com/ http://some-server.example.com \
+      @plugin=rate_limit.so @pparam=--limit=128 @pparam=--queue=256

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -79,6 +79,7 @@ include experimental/memory_profile/Makefile.inc
 include experimental/metalink/Makefile.inc
 include experimental/money_trace/Makefile.inc
 include experimental/mp4/Makefile.inc
+include experimental/rate_limit/Makefile.inc
 include experimental/redo_cache_lookup/Makefile.inc
 include experimental/remap_stats/Makefile.inc
 include experimental/slice/Makefile.inc

--- a/plugins/experimental/rate_limit/Makefile.inc
+++ b/plugins/experimental/rate_limit/Makefile.inc
@@ -1,0 +1,21 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+pkglib_LTLIBRARIES += experimental/rate_limit/rate_limit.la
+
+experimental_rate_limit_rate_limit_la_SOURCES = \
+  experimental/rate_limit/rate_limit.cc \
+  experimental/rate_limit/limiter.cc

--- a/plugins/experimental/rate_limit/limiter.cc
+++ b/plugins/experimental/rate_limit/limiter.cc
@@ -18,7 +18,7 @@
 #include "limiter.h"
 
 ///////////////////////////////////////////////////////////////////////////////
-// This is the continuation that gets scheduled perdiocally to process the
+// This is the continuation that gets scheduled periodically to process the
 // deque of waiting TXNs.
 //
 int

--- a/plugins/experimental/rate_limit/limiter.cc
+++ b/plugins/experimental/rate_limit/limiter.cc
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "limiter.h"
+
+bool
+RateLimiter::reserve()
+{
+  TSReleaseAssert(_active <= limit);
+  TSMutexLock(_active_lock);
+  if (_active == limit) {
+    TSMutexUnlock(_active_lock);
+    return false;
+  } else {
+    ++_active;
+    TSDebug(PLUGIN_NAME, "Active txns == %u", active());
+    TSMutexUnlock(_active_lock);
+    return true;
+  }
+}
+
+void
+RateLimiter::release()
+{
+  TSMutexLock(_active_lock);
+  --_active;
+  TSMutexUnlock(_active_lock);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// This is the continuation that gets scheduled perdiocally to process the
+// deque of waiting TXNs.
+//
+int
+RateLimiter::queue_process_cont(TSCont cont, TSEvent event, void *edata)
+{
+  RateLimiter *limiter = static_cast<RateLimiter *>(TSContDataGet(cont));
+
+  while (limiter->size() > 0 && limiter->reserve()) {
+    QueueItem item = limiter->pop();
+
+    TSDebug(PLUGIN_NAME, "Enabling queued txn");
+    // Since this was a delayed transaction, we need to add the TXN_CLOSE hook to free the slot when done
+    TSHttpTxnHookAdd(std::get<0>(item), TS_HTTP_TXN_CLOSE_HOOK, std::get<1>(item));
+    TSHttpTxnReenable(std::get<0>(item), TS_EVENT_HTTP_CONTINUE);
+  }
+
+  return TS_EVENT_NONE;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The main rate limiting continuation. ToDo: Maybe this should be in the
+// RateLimiter class (static)?
+//
+int
+RateLimiter::rate_limit_cont(TSCont cont, TSEvent event, void *edata)
+{
+  RateLimiter *limiter = static_cast<RateLimiter *>(TSContDataGet(cont));
+  TSDebug(PLUGIN_NAME, "rate_limit_cont() called with event == %d", static_cast<int>(event));
+
+  switch (event) {
+  case TS_EVENT_HTTP_TXN_CLOSE:
+    TSDebug(PLUGIN_NAME, "Decrementing active count");
+    limiter->release();
+    TSContDestroy(cont); // We are done with this continuation now
+    TSHttpTxnReenable(static_cast<TSHttpTxn>(edata), TS_EVENT_HTTP_CONTINUE);
+    return TS_EVENT_CONTINUE;
+    break;
+
+  case TS_EVENT_HTTP_POST_REMAP:
+    TSDebug(PLUGIN_NAME, "Delaying request");
+    limiter->push(static_cast<TSHttpTxn>(edata), cont);
+    return TS_EVENT_NONE;
+    break;
+
+  default:
+    TSDebug(PLUGIN_NAME, "Unknown event");
+    TSError("Unknown event in %s", PLUGIN_NAME);
+    break;
+  }
+  return TS_EVENT_NONE;
+}

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -26,8 +26,8 @@
 
 #include <ts/ts.h>
 
-constexpr char const PLUGIN_NAME[]  = "rate_limit";
-constexpr unsigned QUEUE_DELAY_TIME = 100; // Examine the queue every 100ms.
+constexpr char const PLUGIN_NAME[] = "rate_limit";
+constexpr auto QUEUE_DELAY_TIME    = std::chrono::milliseconds{100}; // Examine the queue every 100ms
 
 using QueueTime = std::chrono::time_point<std::chrono::system_clock>;
 using QueueItem = std::tuple<TSHttpTxn, TSCont, QueueTime>;

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <deque>
+#include <tuple>
+#include <atomic>
+#include <cstring>
+#include <cstdio>
+
+#include <ts/ts.h>
+
+constexpr char const PLUGIN_NAME[]  = "rate_limit";
+constexpr unsigned QUEUE_DELAY_TIME = 100; // Examine the queue every 100ms.
+
+using QueueItem = std::tuple<TSHttpTxn, TSCont>;
+
+///////////////////////////////////////////////////////////////////////////////
+// Configuration object for a rate limiting remap rule.
+//
+class RateLimiter
+{
+public:
+  RateLimiter() : _queue_lock(TSMutexCreate()), _active_lock(TSMutexCreate()) {}
+
+  ~RateLimiter()
+  {
+    if (_queue_cont) {
+      TSContDestroy(_queue_cont);
+    }
+    TSMutexDestroy(_queue_lock);
+    TSMutexDestroy(_active_lock);
+  }
+
+  // Reserve / release a slot from the active connect limits. Reserve will return
+  // false if we are unable to reserve a slot.
+  bool reserve();
+  void release();
+
+  // Current size of the active_in connections
+  unsigned
+  active() const
+  {
+    return _active.load();
+  }
+
+  // Current size of the queue
+  unsigned
+  size() const
+  {
+    return _size.load();
+  }
+
+  // Is the queue full (at it's max size)?
+  bool
+  full() const
+  {
+    return (_size == max_queue);
+  }
+
+  void
+  push(TSHttpTxn txnp, TSCont cont)
+  {
+    TSMutexLock(_queue_lock);
+    _queue.push_back(std::make_tuple(txnp, cont));
+    ++_size;
+    TSMutexUnlock(_queue_lock);
+  }
+
+  QueueItem
+  pop()
+  {
+    QueueItem item{nullptr, nullptr};
+
+    TSMutexLock(_queue_lock);
+    if (!_queue.empty()) {
+      item = std::move(_queue.front());
+      _queue.pop_front();
+      --_size;
+    }
+    TSMutexUnlock(_queue_lock);
+
+    return item; // ToDo: do we see RVO here ?
+  }
+
+  // Setup the continuous queue processing continuation
+  void
+  setupQueueCont()
+  {
+    _queue_cont = TSContCreate(queue_process_cont, TSMutexCreate());
+    TSReleaseAssert(_queue_cont);
+    TSContDataSet(_queue_cont, this);
+    TSContScheduleEveryOnPool(_queue_cont, QUEUE_DELAY_TIME, TS_THREAD_POOL_TASK);
+  }
+
+  // Create and setup a TXN continuation for a connection that needs to be delayed
+  void
+  setupTxnCont(void *ih, TSHttpTxn txnp, TSHttpHookID hook)
+  {
+    TSCont cont = TSContCreate(rate_limit_cont, nullptr);
+    TSReleaseAssert(cont);
+
+    TSContDataSet(cont, ih);
+    TSHttpTxnHookAdd(txnp, hook, cont);
+  }
+
+  // These are the configurable portions of this limiter, public so sue me.
+  unsigned limit     = 100; // Arbitrary default, probably should be a required config
+  unsigned max_queue = 0;   // No queue limit, but if sets will give an immediate error if at max
+  unsigned error     = 429; // Error code when we decide not to allow a txn to be processed (e.g. queue full)
+
+private:
+  static int queue_process_cont(TSCont cont, TSEvent event, void *edata);
+  static int rate_limit_cont(TSCont cont, TSEvent event, void *edata);
+
+  std::atomic<unsigned> _active = 0; // Current active number of txns. This has to always stay <= limit above
+  std::atomic<unsigned> _size   = 0; // Current size of the pending queue of txns. This should aim to be < _max_queue.
+
+  TSMutex _queue_lock, _active_lock; // Resource locks
+  std::deque<QueueItem> _queue;      // Queue for the pending TXN's
+  TSCont _queue_cont = nullptr;      // Continuation processing the queue periodically.
+};

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -135,7 +135,7 @@ public:
       QueueItem item = _queue.back();
       TSMutexUnlock(_queue_lock); // A little ugly but this reduces the critical section for the lock a little bit.
 
-      long age = std::chrono::duration_cast<std::chrono::milliseconds>(now - std::get<2>(item)).count();
+      std::chrono::milliseconds age = std::chrono::duration_cast<std::chrono::milliseconds>(now - std::get<2>(item));
 
       return (age >= max_age);
     } else {
@@ -144,7 +144,7 @@ public:
     }
   }
 
-  void delayHeader(TSHttpTxn txpn, long delay) const;
+  void delayHeader(TSHttpTxn txpn, std::chrono::microseconds delay) const;
   void retryAfter(TSHttpTxn txpn, unsigned after) const;
 
   // Continuation creation and scheduling
@@ -161,12 +161,12 @@ public:
   }
 
   // These are the configurable portions of this limiter, public so sue me.
-  unsigned limit     = 100;      // Arbitrary default, probably should be a required config
-  unsigned max_queue = UINT_MAX; // No queue limit, but if sets will give an immediate error if at max
-  unsigned max_age   = 0;        // Max age (ms) in the queue, at which point we send an error
-  unsigned error     = 429;      // Error code when we decide not to allow a txn to be processed (e.g. queue full)
-  unsigned retry     = 0;        // If > 0, we will also send a Retry-After: header with this retry value
-  std::string header;            // Header to put the latency metrics in, e.g. @RateLimit-Delay
+  unsigned limit                    = 100;      // Arbitrary default, probably should be a required config
+  unsigned max_queue                = UINT_MAX; // No queue limit, but if sets will give an immediate error if at max
+  unsigned error                    = 429;      // Error code when we decide not to allow a txn to be processed (e.g. queue full)
+  unsigned retry                    = 0;        // If > 0, we will also send a Retry-After: header with this retry value
+  std::chrono::milliseconds max_age = std::chrono::milliseconds::zero(); // Max age (ms) in the queue
+  std::string header; // Header to put the latency metrics in, e.g. @RateLimit-Delay
 
 private:
   static int queue_process_cont(TSCont cont, TSEvent event, void *edata);

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -126,6 +126,7 @@ public:
   }
 
   void delayHeader(TSHttpTxn txpn, long delay, const std::string &header) const;
+  void retryAfter(TSHttpTxn txpn, unsigned after) const;
 
   // Continuation creation and scheduling
   void setupQueueCont();
@@ -144,6 +145,7 @@ public:
   unsigned limit     = 100;      // Arbitrary default, probably should be a required config
   unsigned max_queue = UINT_MAX; // No queue limit, but if sets will give an immediate error if at max
   unsigned error     = 429;      // Error code when we decide not to allow a txn to be processed (e.g. queue full)
+  unsigned retry     = 0;        // If > 0, we will also send a Retry-After: header with this retry value
   std::string header;            // Header to put the latency metrics in, e.g. @RateLimit-Delay
 
 private:

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -17,6 +17,7 @@
  */
 #include <deque>
 #include <tuple>
+#include <climits>
 #include <atomic>
 #include <cstring>
 #include <cstdio>
@@ -118,9 +119,9 @@ public:
   }
 
   // These are the configurable portions of this limiter, public so sue me.
-  unsigned limit     = 100; // Arbitrary default, probably should be a required config
-  unsigned max_queue = 0;   // No queue limit, but if sets will give an immediate error if at max
-  unsigned error     = 429; // Error code when we decide not to allow a txn to be processed (e.g. queue full)
+  unsigned limit     = 100;      // Arbitrary default, probably should be a required config
+  unsigned max_queue = UINT_MAX; // No queue limit, but if sets will give an immediate error if at max
+  unsigned error     = 429;      // Error code when we decide not to allow a txn to be processed (e.g. queue full)
 
 private:
   static int queue_process_cont(TSCont cont, TSEvent event, void *edata);

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -59,6 +59,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     {const_cast<char *>("error"), required_argument, nullptr, 'e'},
     {const_cast<char *>("retry"), required_argument, nullptr, 'r'},
     {const_cast<char *>("header"), required_argument, nullptr, 'h'},
+    {const_cast<char *>("maxage"), required_argument, nullptr, 'm'},
     // EOF
     {nullptr, no_argument, nullptr, '\0'},
   };
@@ -85,6 +86,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
       break;
     case 'r':
       limiter->retry = strtol(optarg, nullptr, 10);
+      break;
+    case 'm':
+      limiter->max_age = 1000 * strtol(optarg, nullptr, 10);
       break;
     case 'h':
       limiter->header = optarg;

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -88,7 +88,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
       limiter->retry = strtol(optarg, nullptr, 10);
       break;
     case 'm':
-      limiter->max_age = 1000 * strtol(optarg, nullptr, 10);
+      limiter->max_age = std::chrono::milliseconds(strtol(optarg, nullptr, 10));
       break;
     case 'h':
       limiter->header = optarg;

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <unistd.h>
+#include <getopt.h>
+#include <stdlib.h>
+#include <ts/ts.h>
+#include <ts/remap.h>
+
+#include "limiter.h"
+
+///////////////////////////////////////////////////////////////////////////////
+// Setup stuff for the remap plugin
+//
+TSReturnCode
+TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+{
+  if (!api_info) {
+    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
+    return TS_ERROR;
+  }
+
+  if (api_info->tsremap_version < TSREMAP_VERSION) {
+    snprintf(errbuf, errbuf_size - 1, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
+             (api_info->tsremap_version & 0xffff));
+    return TS_ERROR;
+  }
+
+  TSDebug(PLUGIN_NAME, "plugin is successfully initialized");
+  return TS_SUCCESS;
+}
+
+void
+TSRemapDeleteInstance(void *ih)
+{
+  delete static_cast<RateLimiter *>(ih);
+}
+
+TSReturnCode
+TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
+{
+  static const struct option longopt[] = {
+    // There's only one limiter right now, so no option for --limiter
+    {const_cast<char *>("limit"), required_argument, nullptr, 'l'},
+    {const_cast<char *>("queue"), required_argument, nullptr, 'q'},
+    {const_cast<char *>("error"), required_argument, nullptr, 'e'},
+    // EOF
+    {nullptr, no_argument, nullptr, '\0'},
+  };
+
+  RateLimiter *limiter = new RateLimiter();
+  TSReleaseAssert(limiter);
+  // argv contains the "to" and "from" URLs. Skip the first so that the
+  // second one poses as the program name.
+  --argc;
+  ++argv;
+
+  while (true) {
+    int opt = getopt_long(argc, (char *const *)argv, "", longopt, nullptr);
+
+    switch (opt) {
+    case 'l':
+      limiter->limit = strtol(optarg, nullptr, 10);
+      break;
+    case 'q':
+      limiter->max_queue = strtol(optarg, nullptr, 10);
+      break;
+    case 'e':
+      limiter->error = strtol(optarg, nullptr, 10);
+      break;
+    }
+    if (opt == -1) {
+      break;
+    }
+  }
+
+  limiter->setupQueueCont();
+
+  TSDebug(PLUGIN_NAME, "Added active_in limiter rule (limit=%u, queue=%u, error=%u", limiter->limit, limiter->max_queue,
+          limiter->error);
+  *ih = static_cast<void *>(limiter);
+
+  return TS_SUCCESS;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// This is the main "entry" point for the plugin, called for every request.
+//
+TSRemapStatus
+TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
+{
+  RateLimiter *limiter = static_cast<RateLimiter *>(ih);
+
+  if (limiter) {
+    if (!limiter->reserve()) {
+      if (limiter->max_queue > 0 && limiter->full()) {
+        // We are running at limit, and the queue has reached max capacity, give back an error and be done.
+        TSDebug(PLUGIN_NAME, "Rejecting request, we're at capacity and queue is full");
+        TSHttpTxnStatusSet(txnp, static_cast<TSHttpStatus>(limiter->error));
+      } else {
+        limiter->setupTxnCont(ih, txnp, TS_HTTP_POST_REMAP_HOOK);
+        TSDebug(PLUGIN_NAME, "Adding rate limiting hook, we are at capacity");
+      }
+    } else {
+      limiter->setupTxnCont(ih, txnp, TS_HTTP_TXN_CLOSE_HOOK);
+      TSDebug(PLUGIN_NAME, "Adding txn-close hook, we're not at capacity");
+    }
+  }
+
+  return TSREMAP_NO_REMAP;
+}

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -54,10 +54,10 @@ TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   static const struct option longopt[] = {
-    // There's only one limiter right now, so no option for --limiter
     {const_cast<char *>("limit"), required_argument, nullptr, 'l'},
     {const_cast<char *>("queue"), required_argument, nullptr, 'q'},
     {const_cast<char *>("error"), required_argument, nullptr, 'e'},
+    {const_cast<char *>("header"), required_argument, nullptr, 'h'},
     // EOF
     {nullptr, no_argument, nullptr, '\0'},
   };
@@ -81,6 +81,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
       break;
     case 'e':
       limiter->error = strtol(optarg, nullptr, 10);
+      break;
+    case 'h':
+      limiter->header = optarg;
       break;
     }
     if (opt == -1) {

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -107,7 +107,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   if (limiter) {
     if (!limiter->reserve()) {
-      if (limiter->max_queue > 0 && limiter->full()) {
+      if (!limiter->max_queue || limiter->full()) {
         // We are running at limit, and the queue has reached max capacity, give back an error and be done.
         TSDebug(PLUGIN_NAME, "Rejecting request, we're at capacity and queue is full");
         TSHttpTxnStatusSet(txnp, static_cast<TSHttpStatus>(limiter->error));


### PR DESCRIPTION
This current version has only one limiter, which implements
a basic active_in limitation. However, at least for now,
these connections that are queued wills still count against
the active connection metrics and limits that are in the core.

I'm open for a refactoring of this, if or when we want to have
different types of limiters. Similar to the policies for the
cache_promote plugin.