### PR TITLE
Add proxy.process.http.background_fill_total_count

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/cache.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/cache.en.rst
@@ -168,7 +168,16 @@ Cache
    :ungathered:
 
 .. ts:stat:: global proxy.process.http.background_fill_current_count integer
+   :type: gauge
    :ungathered:
+
+   Represents the current number of background fill
+
+.. ts:stat:: global proxy.process.http.background_fill_total_count integer
+   :type: counter
+   :ungathered:
+
+   Represents the total number of background fill
 
 .. ts:stat:: global proxy.process.http.cache_deletes integer
 .. ts:stat:: global proxy.process.http.cache_hit_fresh integer
@@ -223,4 +232,3 @@ Cache
 .. ts:stat:: global proxy.process.http.tcp_refresh_miss_count_stat integer
 .. ts:stat:: global proxy.process.http.tcp_refresh_miss_origin_server_bytes_stat integer
 .. ts:stat:: global proxy.process.http.tcp_refresh_miss_user_agent_bytes_stat integer
-

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -352,6 +352,9 @@ register_stat_callbacks()
   RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.total_parent_marked_down_count", RECD_COUNTER, RECP_PERSISTENT,
                      (int)http_total_parent_marked_down_count, RecRawStatSyncCount);
 
+  RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.background_fill_total_count", RECD_INT, RECP_PERSISTENT,
+                     (int)http_background_fill_total_count_stat, RecRawStatSyncCount);
+
   // Stats to track causes of ATS initiated origin shutdowns
   RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.origin_shutdown.pool_lock_contention", RECD_INT,
                      RECP_NON_PERSISTENT, (int)http_origin_shutdown_pool_lock_contention, RecRawStatSyncCount);

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -84,6 +84,7 @@ enum {
   http_total_parent_switches_stat,
   http_total_parent_retries_exhausted_stat,
   http_total_parent_marked_down_count,
+  http_background_fill_total_count_stat,
   http_current_parent_proxy_connections_stat,
   http_current_server_connections_stat,
   http_current_cache_connections_stat,

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -3318,6 +3318,8 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
       //  detach the user agent
       if (background_fill == BACKGROUND_FILL_STARTED) {
         HTTP_INCREMENT_DYN_STAT(http_background_fill_current_count_stat);
+        HTTP_INCREMENT_DYN_STAT(http_background_fill_total_count_stat);
+
         ink_assert(server_entry->vc == server_session);
         ink_assert(c->is_downstream_from(server_session));
         server_session->set_active_timeout(HRTIME_SECONDS(t_state.txn_conf->background_fill_active_timeout));


### PR DESCRIPTION
We have a gauge of background fill (`proxy.process.http.background_fill_current_count`), but no counter. 
The counter gives us how many times the background fill worked and more understanding of #7603.
