### PR TITLE
Add pooled_server_connections metric

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -138,6 +138,12 @@ HTTP Connection
 
    This tracks the number of origin connections denied due to being over the :ts:cv:`proxy.config.http.per_server.connection.max` limit.
 
+.. ts:stat:: global proxy.process.http.pooled_server_connections integer
+   :type: counter
+
+   This metric tracks the number of server connections currently in the server session sharing pools. The server session sharing is
+   controlled by settings :ts:cv:`proxy.config.http.server_session_sharing.pool` and :ts:cv:`proxy.config.http.server_session_sharing.match`.
+
 
 HTTP/2
 ------

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -413,6 +413,10 @@ register_stat_callbacks()
                      RECP_PERSISTENT, (int)http_ua_msecs_counts_errors_pre_accept_hangups_stat,
                      RecRawStatSyncIntMsecsToFloatSeconds);
 
+  RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.pooled_server_connections", RECD_INT, RECP_NON_PERSISTENT,
+                     (int)http_pooled_server_connections_stat, RecRawStatSyncSum);
+  HTTP_CLEAR_DYN_STAT(http_pooled_server_connections_stat);
+
   // Transactional stats
 
   RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.incoming_requests", RECD_COUNTER, RECP_PERSISTENT,

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -65,6 +65,7 @@ enum {
   http_current_client_transactions_stat,
   http_total_incoming_connections_stat,
   http_current_server_transactions_stat,
+  http_pooled_server_connections_stat,
 
   //  Http Abort information (from HttpNetConnection)
   http_ua_msecs_counts_errors_pre_accept_hangups_stat,

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -167,6 +167,7 @@ ServerSessionPool::acquireSession(sockaddr const *addr, CryptoHash const &hostna
     }
     if (zret == HSM_DONE) {
       to_return = first;
+      HTTP_DECREMENT_DYN_STAT(http_pooled_server_connections_stat);
       m_fqdn_pool.erase(first);
       m_ip_pool.erase(to_return);
     }
@@ -191,6 +192,7 @@ ServerSessionPool::acquireSession(sockaddr const *addr, CryptoHash const &hostna
     }
     if (zret == HSM_DONE) {
       to_return = first;
+      HTTP_DECREMENT_DYN_STAT(http_pooled_server_connections_stat);
       m_ip_pool.erase(first);
       m_fqdn_pool.erase(to_return);
     }
@@ -217,6 +219,8 @@ ServerSessionPool::releaseSession(PoolableSession *ss)
   // put it in the pools.
   m_ip_pool.insert(ss);
   m_fqdn_pool.insert(ss);
+
+  HTTP_INCREMENT_DYN_STAT(http_pooled_server_connections_stat);
 
   Debug("http_ss",
         "[%" PRId64 "] [release session] "
@@ -288,6 +292,7 @@ ServerSessionPool::eventHandler(int event, void *data)
       // Drop connection on this end.
       s->do_io_close();
       found = true;
+      HTTP_DECREMENT_DYN_STAT(http_pooled_server_connections_stat);
       break;
     }
   }


### PR DESCRIPTION
Originally added by PR #7622.  The new stat was useful for debugging lost connections.  @maskit pointed out that the metric would be useful independent of the H2 to origin logic, so I've pulled it out separately.