### PR TITLE
Add default implementation for allow_half_open

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -220,3 +220,9 @@ ProxyTransaction::has_request_body(int64_t request_content_length, bool is_chunk
 {
   return request_content_length > 0 || is_chunked;
 }
+
+bool
+ProxyTransaction::allow_half_open() const
+{
+  return false;
+}

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -62,7 +62,7 @@ public:
   virtual int get_transaction_id() const = 0;
   virtual int get_transaction_priority_weight() const;
   virtual int get_transaction_priority_dependence() const;
-  virtual bool allow_half_open() const              = 0;
+  virtual bool allow_half_open() const;
   virtual void increment_client_transactions_stat() = 0;
   virtual void decrement_client_transactions_stat() = 0;
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -100,7 +100,6 @@ public:
   bool is_active_timeout_expired(ink_hrtime now);
   bool is_inactive_timeout_expired(ink_hrtime now);
 
-  bool allow_half_open() const override;
   bool is_first_transaction() const override;
   void increment_client_transactions_stat() override;
   void decrement_client_transactions_stat() override;
@@ -292,12 +291,6 @@ Http2Stream::payload_length_is_valid() const
 {
   uint32_t content_length = _req_header.get_content_length();
   return content_length == 0 || content_length == data_length;
-}
-
-inline bool
-Http2Stream::allow_half_open() const
-{
-  return false;
 }
 
 inline bool

--- a/proxy/http3/Http3Transaction.cc
+++ b/proxy/http3/Http3Transaction.cc
@@ -110,12 +110,6 @@ HQTransaction::release(IOBufferReader *r)
   this->_sm = nullptr;
 }
 
-bool
-HQTransaction::allow_half_open() const
-{
-  return false;
-}
-
 VIO *
 HQTransaction::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {

--- a/proxy/http3/Http3Transaction.h
+++ b/proxy/http3/Http3Transaction.h
@@ -49,7 +49,6 @@ public:
   void set_inactivity_timeout(ink_hrtime timeout_in) override;
   void cancel_inactivity_timeout() override;
   void transaction_done() override;
-  bool allow_half_open() const override;
   void release(IOBufferReader *r) override;
   int get_transaction_id() const override;
   void increment_client_transactions_stat() override;


### PR DESCRIPTION
Adding implementation for allow_half_open in ProxyTransaction.  Only one case needs anything other than return false.  I had added in PR #7622  but @maskit noted that this fix should be pulled out and applied consistently.