### PR TITLE
Fix tls_client_versions and tls_hooks18 tests

### DIFF
--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -49,6 +49,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 ts.Disk.records_config.update({
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.url_remap.pristine_host_hdr': 1,
     'proxy.config.ssl.TLSv1': 0,

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -38,11 +38,10 @@ server.addResponse("sessionlog.json", request_header, response_header)
 ts.addDefaultSSLFiles()
 
 ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl_hook_test',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-     })
-                               'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2', })
+                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
+                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+                               })
 
 ts.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
@@ -54,23 +53,23 @@ ts.Disk.remap_config.AddLine(
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello=2')
 
-tr=Test.AddTestRun("Test two client hello hooks")
+tr = Test.AddTestRun("Test two client hello hooks")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.StillRunningAfter=ts
-tr.StillRunningAfter=server
-tr.Processes.Default.Command='curl -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
-tr.Processes.Default.ReturnCode=0
-tr.Processes.Default.Streams.stdout="gold/preaccept-1.gold"
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr="gold/ts-client-hello-2.gold"
+ts.Streams.stderr = "gold/ts-client-hello-2.gold"
 
-certstring0="Client Hello callback 0"
-certstring1="Client Hello callback 1"
-ts.Streams.All=Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags = re.S | re.M)
-ts.Streams.All=Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags = re.S | re.M)
+certstring0 = "Client Hello callback 0"
+certstring1 = "Client Hello callback 1"
+ts.Streams.All = Testers.ContainsExpression(
+    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
+ts.Streams.All = Testers.ContainsExpression(
+    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
 
-tr.Processes.Default.TimeOut=15
-tr.TimeOut=15
+tr.Processes.Default.TimeOut = 15
+tr.TimeOut = 15


### PR DESCRIPTION
This is a tweak on top of the following cleanup commit:

8f25b6b871a9e96c3e87789f728a0016975094ba

This commit fixes the following tests:

tests/gold_tests/tls_hooks/tls_hooks18.test.py
tests/gold_tests/tls/tls_client_versions.test.py

The change to tls_hooks18.test.py simply removes an extra line that accidentally got added in:

`                               'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2', })
`

The rest of the change in the file is simply autopep8 whitespace changes.