### PR TITLE
Remove erroneous manager.log mesg with remap include file reload

### DIFF
--- a/mgmt/ConfigManager.cc
+++ b/mgmt/ConfigManager.cc
@@ -117,7 +117,9 @@ ConfigManager::checkForUserUpdate(RollBackCheckType how)
   if (fileLastModified < TS_ARCHIVE_STAT_MTIME(fileInfo)) {
     if (how == ROLLBACK_CHECK_AND_UPDATE) {
       fileLastModified = TS_ARCHIVE_STAT_MTIME(fileInfo);
-      configFiles->fileChanged(fileName, configName);
+      if (!this->isChildManaged()) {
+        configFiles->fileChanged(fileName, configName);
+      }
       mgmt_log("User has changed config file %s\n", fileName);
     }
     result = true;

--- a/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
+++ b/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
@@ -76,3 +76,7 @@ tr.Processes.Default.Command = (
 )
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
+
+ts.Disk.manager_log.Content += Testers.ExcludesExpression(
+    "needs restart",
+    "Ensure that extra msg reported in issue #7530 does not reappear")


### PR DESCRIPTION
Avoids calling file update in the case where the changed item is a member of a top level config file.

This closes #7530