### PR TITLE
Fixing DNS local_ipv* config option (#7507)

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2419,6 +2419,15 @@ DNS
    ``2`` TCP_ONLY:  |TS| always talks to nameservers over TCP.
    ===== ======================================================================
 
+.. ts:cv:: CONFIG proxy.config.dns.local_ipv4 STRING NULL
+
+   Local IPV4 address to bind to in order to make DNS requests
+
+.. ts:cv:: CONFIG proxy.config.dns.local_ipv6 STRING NULL
+
+   Local IPV6 address to bind to in order to make DNS requests
+
+
 HostDB
 ======
 

--- a/iocore/dns/DNSConnection.cc
+++ b/iocore/dns/DNSConnection.cc
@@ -140,17 +140,6 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
 
   if (opt._bind_random_port) {
     int retries = 0;
-    IpEndpoint bind_addr;
-    size_t bind_size = 0;
-    memset(&bind_addr, 0, sizeof bind_addr);
-    bind_addr.sa.sa_family = af;
-    if (AF_INET6 == af) {
-      bind_addr.sin6.sin6_addr = in6addr_any;
-      bind_size                = sizeof bind_addr.sin6;
-    } else {
-      bind_addr.sin.sin_addr.s_addr = INADDR_ANY;
-      bind_size                     = sizeof bind_addr.sin;
-    }
     while (retries++ < 10000) {
       ip_port_text_buffer b;
       uint32_t p                      = generator.random();


### PR DESCRIPTION
The DNS local ip setting currently does not work. It gets overwritten with a default ANY address when we, by default, go to choose a random port. This removes the shadowing of the local variable that already has the local address either set via parameter or set to ANY if a parameter is not set.

Also adding records docs to make this a real parameter that people can know about

(cherry picked from commit 5feefebddc430322c1c3b6bec37e6fbce1c4b06a)