### PR TITLE
Add a check for compress response for 304

### DIFF
--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -663,6 +663,16 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
     return 0;
   }
 
+  // We got a server response but it was a 304
+  // we need to update our data to come from cache instead of
+  // the 304 response which does not need to include all headers
+  if ((server) && (resp_status == TS_HTTP_STATUS_NOT_MODIFIED)) {
+    TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
+    if (TS_SUCCESS != TSHttpTxnCachedRespGet(txnp, &bufp, &hdr_loc)) {
+      return 0;
+    }
+  }
+
   if (TS_SUCCESS != TSHttpTxnClientReqGet(txnp, &cbuf, &chdr)) {
     info("cound not get client request");
     TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);


### PR DESCRIPTION
If from server and 304 then check cache for headers instead of the 304 response (#7564)

(cherry picked from commit b1a5cbd8e46b3dbffa7fb73bf6c100b84cbee239)