### PR TITLE
Fixing Throttler.h for older clang and gcc compilers

### DIFF
--- a/src/tscore/Throttler.cc
+++ b/src/tscore/Throttler.cc
@@ -29,7 +29,7 @@ bool
 Throttler::is_throttled(uint64_t &skipped_count)
 {
   TimePoint const now = Clock::now();
-  TimePoint last_allowed_time{_last_allowed_time};
+  TimePoint last_allowed_time{_last_allowed_time.load()};
   if ((last_allowed_time + _interval.load()) <= now) {
     if (_last_allowed_time.compare_exchange_strong(last_allowed_time, now)) {
       skipped_count     = _suppressed_count;


### PR DESCRIPTION
This is a workaround for older gcc and clang compilers which implemented
an older version of the standard which made atomic's noexcept
construction specification not compatible with Throttler's use of
time_point's undecorated constructor.