### PR TITLE
CacheRead: clear dir entry if doc is found to be truncated

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -565,7 +565,6 @@ CacheVC::openReadReadDone(int event, Event *e)
       VC_SCHED_LOCK_RETRY();
     }
     if (event == AIO_EVENT_DONE && !io.ok()) {
-      dir_delete(&earliest_key, vol, &earliest_dir);
       goto Lerror;
     }
     if (last_collision &&     // no missed lock
@@ -623,10 +622,11 @@ Lerror : {
   if (request.valid()) {
     int url_length;
     const char *url_text = request.url_get()->string_get_ref(&url_length);
-    Warning("Document %s truncated, url[%.*s]", earliest_key.toHexStr(tmpstring), url_length, url_text);
+    Warning("Document %s truncated, url[%.*s] .. clearing", earliest_key.toHexStr(tmpstring), url_length, url_text);
   } else {
-    Warning("Document %s truncated", earliest_key.toHexStr(tmpstring));
+    Warning("Document %s truncated .. clearing", earliest_key.toHexStr(tmpstring));
   }
+  dir_delete(&earliest_key, vol, &earliest_dir);
   return calluser(VC_EVENT_ERROR);
 }
 Ldone:


### PR DESCRIPTION
(cherry picked from commit 5b38fb26737b38267615102775d81136a843075c)