### PR TITLE
Remove inline for detail::cache::CacheData::idAddr

### DIFF
--- a/src/wccp/WccpEndPoint.cc
+++ b/src/wccp/WccpEndPoint.cc
@@ -357,7 +357,7 @@ CacheImpl::RouterData::waitTime(time_t now) const
   return m_assign ? 0 : this->pingTime(now);
 }
 
-inline uint32_t
+uint32_t
 detail::cache::CacheData::idAddr() const
 {
   return m_id.getAddr();


### PR DESCRIPTION
This avoids a warning in FreeBSD clang-10 builds.
(cherry picked from commit 7af385faf5bfb644ae200682fb156d1433437683)

-----

This is a backport of #7592 to 8.1.x