### PR TITLE
Refine Inline.cc carveout for arm64 darwin builds

### DIFF
--- a/iocore/aio/Inline.cc
+++ b/iocore/aio/Inline.cc
@@ -26,7 +26,7 @@
  *
  */
 
-#if !defined(darwin)
+#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_AIO.h"
 #endif

--- a/iocore/cache/Inline.cc
+++ b/iocore/cache/Inline.cc
@@ -26,7 +26,7 @@
  *
  */
 
-#if !defined(darwin)
+#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_Cache.h"
 #endif

--- a/iocore/dns/Inline.cc
+++ b/iocore/dns/Inline.cc
@@ -26,7 +26,7 @@
  *
  */
 
-#if !defined(darwin)
+#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_DNS.h"
 #endif

--- a/iocore/eventsystem/Inline.cc
+++ b/iocore/eventsystem/Inline.cc
@@ -26,7 +26,7 @@
  *
  */
 
-#if !defined(darwin)
+#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_EventSystem.h"
 #endif

--- a/iocore/hostdb/Inline.cc
+++ b/iocore/hostdb/Inline.cc
@@ -26,7 +26,7 @@
  *
  */
 
-#if !defined(darwin)
+#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_HostDB.h"
 #endif

--- a/iocore/net/Inline.cc
+++ b/iocore/net/Inline.cc
@@ -26,7 +26,7 @@
  *
  */
 
-#if !defined(darwin)
+#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_Net.h"
 #endif


### PR DESCRIPTION
This allows the x86_64 macOS release build to complete successfully