### PR TITLE
Reduce overhead incurred by enabling debug output.

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3221,6 +3221,10 @@ Diagnostic Logging Configuration
 
    When set to 2, interprets the :ts:cv:`proxy.config.diags.debug.client_ip` setting determine whether diagnostic messages are logged.
 
+   When set to 3, enables logging for diagnostic messages whose log level is `diag` or `debug`, except those
+   output by deprecated functions such as `TSDebug()` and `TSDebugSpecific()`.  Using the value 3 will have less
+   of a negative impact on proxy throughput than using the value 1.
+
 .. ts:cv:: CONFIG proxy.config.diags.debug.client_ip STRING NULL
 
    if :ts:cv:`proxy.config.diags.debug.enabled` is set to 2, this value is tested against the source IP of the incoming connection.  If there is a match, all the diagnostic messages for that connection and the related outgoing connection will be logged.
@@ -3243,7 +3247,7 @@ Diagnostic Logging Configuration
    ssl           TLS termination and certificate processing
    ============  =====================================================
 
-   |TS| plugins will typically log debug messages using the :c:func:`TSDebug`
+   |TS| plugins will typically log debug messages using the :c:func:`TSDbg`
    API, passing the plugin name as the debug tag.
 
 .. ts:cv:: CONFIG proxy.config.diags.debug.throttling_interval_msec INT 0

--- a/doc/developer-guide/api/functions/TSDebug.en.rst
+++ b/doc/developer-guide/api/functions/TSDebug.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: c
 
-TSDebug
-*******
+TSDbg
+*****
 
 Traffic Server Debugging APIs.
 
@@ -37,7 +37,11 @@ Synopsis
 .. function:: void TSFatal(const char * format, ...)
 .. function:: void TSAlert(const char * format, ...)
 .. function:: void TSEmergency(const char * format, ...)
+.. type:: TSDbgCtl
+.. function:: void TSDbg(const TSDbgCtl * ctlptr, const char * format, ...)
+.. function:: const TSDbgCtl * TSDbgCtlCreate(const char * tag)
 .. function:: void TSDebug(const char * tag, const char * format, ...)
+.. function:: int TSIsDbgCtlSet(const TSDbgCtl * ctlptr)
 .. function:: int TSIsDebugTagSet(const char * tag)
 .. function:: void TSDebugSpecific(int debug_flag, const char * tag, const char * format, ...)
 .. function:: void TSHttpTxnDebugSet(TSHttpTxn txnp, int on)
@@ -76,10 +80,19 @@ Traffic Server, Traffic Manager, AuTest, CI, and your log monitoring service/das
 trafficserver.out
 =================
 
-:func:`TSDebug` logs the debug message only if the given debug :arg:`tag` is enabled.
+:func:`TSDbg` logs the debug message only if the given debug control pointed to by
+:arg:`ctlptr` is enabled.  It writes output to the Traffic Server debug log through stderr.
+
+:func:`TSDbgCtlCreate` creates a debug control, associated with the
+debug :arg:`tag`, and returns a const pointer to it.
+
+:func:`TSIsDbgCtlSet` returns non-zero if the given debug control, pointed to by :arg:`ctlptr`, is
+enabled.
+
+:func:`TSDebug` (deprecated) logs the debug message only if the given debug :arg:`tag` is enabled.
 It writes output to the Traffic Server debug log through stderr.
 
-:func:`TSIsDebugTagSet` returns non-zero if the given debug :arg:`tag` is
+:func:`TSIsDebugTagSet` (deprecated) returns non-zero if the given debug :arg:`tag` is
 enabled.
 
 In debug mode, :macro:`TSAssert` Traffic Server to prints the file

--- a/doc/developer-guide/debugging/debug-tags.en.rst
+++ b/doc/developer-guide/debugging/debug-tags.en.rst
@@ -22,15 +22,33 @@
 Debug Tags
 **********
 
-Use the API
-``void TSDebug (const char *tag, const char *format_str, ...)`` to add
-traces in your plugin. In this API:
+Use the API macro
+``TSDbg(ctlptr, const char *format_str, ...)`` to add
+traces in your plugin. In this macro:
+
+-  ``ctlptr`` is the Traffic Server parameter that enables Traffic Server
+   to print out ``format_str``.  It is returned by ``TSDbgCtlCreate()``.
+
+-  ``...`` are variables for ``format_str`` in the standard ``printf``
+   style.
+
+``void TSDbgCtlCreate (const char *tag)`` returns a (const) pointer to
+``TSDbgCtl``.  The ``TSDbgCtl`` control is enabled when debug output is
+enabled globally by configuaration, and ``tag`` matches a configured
+regular expression.
+
+The deprecated API
+``void TSDebug (const char *tag, const char *format_str, ...)`` also
+outputs traces.  In this API:
 
 -  ``tag`` is the Traffic Server parameter that enables Traffic Server
-   to print out *``format_str``*
+   to print out ``format_str``
 
--  ``...`` are variables for *``format_str``* in the standard ``printf``
+-  ``...`` are variables for ``format_str`` in the standard ``printf``
    style.
+
+Use of ``TSDebug()`` causes trace output to have a more negative impact
+on proxy throughput.
 
 Run Traffic Server with the ``-Ttag`` option. For example, if the tag is
 ``my-plugin``, then the debug output goes to ``traffic.out.``\ See
@@ -40,7 +58,7 @@ below:
 
        traffic_server -T"my-plugin"
 
-Set the following variables in :file:`records.config` (in the Traffic Server
+Sets the following variables in :file:`records.config` (in the Traffic Server
 ``config`` directory):
 
 ::
@@ -48,13 +66,22 @@ Set the following variables in :file:`records.config` (in the Traffic Server
        CONFIG proxy.config.diags.debug.enabled INT 1
        CONFIG proxy.config.diags.debug.tags STRING debug-tag-name
 
+(Performance will be better if ``enabled`` is set to 3 rather than 1, but,
+using 3, output from ``TSDebug()`` will not be enabled, only from ``TSDbg()``.)
 In this case, debug output goes to ``traffic.out``.
 
 Example:
 
 .. code-block:: c
 
-       TSDebug ("my-plugin", "Starting my-plugin at %d", the_time);
+       static TSDbgCtl const *my_dbg_ctl; // Non-local variable.
+       ...
+       my_dbg_ctl = TSDbgCtlCreate("my-plugin"); // In TSPluginInit() or TSRemapInit().
+       ...
+       TSDbg(my_dbg_ctl, "Starting my-plugin at %d", the_time);
+       ...
+       TSDbg(my_dbg_ctl, "Later on in my-plugin");
+
 
 The statement ``"Starting my-plugin at <time>"`` appears whenever you
 run Traffic Server with the ``my-plugin`` tag:
@@ -62,6 +89,16 @@ run Traffic Server with the ``my-plugin`` tag:
 ::
 
        traffic_server -T"my-plugin"
+
+If your plugin is a C++ plugin, the above example can be written as:
+
+.. code-block:: cpp
+
+       static auto my_dbg_ctl = TSDbgCtlCreate("my-plugin"); // Non-local variable.
+       ...
+       TSDbg(my_dbg_ctl, "Starting my-plugin at %d", the_time);
+       ...
+       TSDbg(my_dbg_ctl, "Later on in my-plugin");
 
 Other Useful Internal Debug Tags
 ================================
@@ -71,7 +108,7 @@ internal debugging purposes. These can also be used to follow Traffic
 Server behavior for testing and analysis.
 
 The debug tag setting (``-T`` and ``proxy.config.diags.debug.tags``) is a
-anchored regular expression against which the tag for a specific debug
+anchored regular expression (PCRE) against which the tag for a specific debug
 message is matched. This means the value "http" matches debug messages
 with the tag "http" but also "http\_seq" and "http\_trans". If you want
 multiple tags then use a pipe symbol to separate the tags. For example

--- a/doc/developer-guide/plugins/plugin-interfaces.en.rst
+++ b/doc/developer-guide/plugins/plugin-interfaces.en.rst
@@ -122,14 +122,15 @@ The thread functions are listed below:
 Debugging Functions
 ===================
 
--  :c:func:`TSDebug`
-   prints out a formatted statement if you are running Traffic Server in
-   debug mode.
+-  :c:func:`TSDbg`
+   (replaces deprecated :c:func:`TSDebug`) prints out a formatted
+   statement if you are running Traffic Server in debug mode.
 
--  :c:func:`TSIsDebugTagSet`
-   checks to see if a debug tag is set. If the debug tag is set, then
-   Traffic Server prints out all debug statements associated with the
-   tag.
+-  :c:func:`TSIsDbgCtlSet`
+   (replaces deprecated :c:func:`TSIsDebugTagSet`)
+   checks to see if a debug control (associated with a debug tag) is
+   set. If the debug tag is set, then Traffic Server prints out all
+   debug statements associated with the control.
 
 -  :c:func:`TSError`
    prints error messages to Traffic Server's error log

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -1080,6 +1080,11 @@ typedef struct TSHttpConnectOptions_s {
   TSIOBufferWaterMark buffer_water_mark;
 } TSHttpConnectOptions;
 
+typedef struct TSDbgCtl_s {
+  char volatile on; // Flag
+  char const *tag;
+} TSDbgCtl;
+
 /* --------------------------------------------------------------------------
    Init */
 

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2187,10 +2187,39 @@ tsapi void TSDebug(const char *tag, const char *format_str, ...) TS_PRINTFLIKE(2
     @param ... Format arguments.
  */
 tsapi void TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...) TS_PRINTFLIKE(3, 4);
-extern int diags_on_for_plugins;
+extern int diags_on_for_plugins; /* Do not use directly. */
 #define TSDEBUG             \
   if (diags_on_for_plugins) \
   TSDebug
+
+extern char ts_new_debug_on_flag_; /* Do not use directly. */
+
+#define TSIsDbgCtlSet(ctlp__) (ts_new_debug_on_flag_ && ctlp__->on)
+
+/**
+    Output a debug line if the debug output control is turned on.
+
+    @param ctlp pointer to TSDbgCtl, returned by TSDbgCtlCreate().
+    @param ...  Format string and (optional) arguments.
+ */
+#define TSDbg(ctlp, ...)              \
+  do {                                \
+    if (TSIsDbgCtlSet(ctlp)) {        \
+      _TSDbg(ctlp->tag, __VA_ARGS__); \
+    }                                 \
+  } while (0)
+
+/**
+    Return a pointer for use with TSDbg().  For good performance,
+    this should be called in TSPluginInit() or TSRemapInit(), or in
+    static initialization in C++ (with the result stored in a
+    static pointer).
+
+    @param tag Debug tag for the control.
+ */
+tsapi TSDbgCtl const *TSDbgCtlCreate(char const *tag);
+
+void _TSDbg(const char *tag, const char *format_str, ...) TS_PRINTFLIKE(2, 3); /* Not for direct use. */
 
 /* --------------------------------------------------------------------------
    logging api */

--- a/include/tscore/DbgCtl.h
+++ b/include/tscore/DbgCtl.h
@@ -1,0 +1,56 @@
+/** @file
+
+  DbgCtl class header file.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <ts/ts.h>
+
+// For use with TSDbg().
+//
+class DbgCtl
+{
+public:
+  // Tag is a debug tag.  Debug output associated with this control will be output when debug output
+  // is enabled globally, and the tag matches the configured debug tag regular expression.
+  //
+  DbgCtl(char const *tag) : _ptr(_get_ptr(tag)) {}
+
+  TSDbgCtl const *
+  ptr() const
+  {
+    return _ptr;
+  }
+
+  // Call this when the compiled regex to enable tags may have changed.
+  //
+  static void update();
+
+private:
+  TSDbgCtl const *const _ptr;
+
+  static const TSDbgCtl *_get_ptr(char const *tag);
+
+  class _RegistryAccessor;
+
+  friend TSDbgCtl const *TSDbgCtlCreate(char const *tag);
+};

--- a/include/tscore/Diags.h
+++ b/include/tscore/Diags.h
@@ -56,7 +56,21 @@
 #endif
 #endif
 
-extern Diags *diags;
+class DiagsPtr
+{
+public:
+  friend Diags *diags();
+  static void set(Diags *new_ptr);
+
+private:
+  static Diags *_diags_ptr;
+};
+
+inline Diags *
+diags()
+{
+  return DiagsPtr::_diags_ptr;
+}
 
 // Note that the log functions being implemented as a macro has the advantage
 // that the pre-compiler expands this in place such that the call to
@@ -66,7 +80,7 @@ extern Diags *diags;
     static const SourceLocation loc = MakeSourceLocation(); \
     static LogMessage log_message;                          \
     log_message.message(level, loc, __VA_ARGS__);           \
-  } while (0)
+  } while (false)
 
 #define Status(...) DiagsError(DL_Status, __VA_ARGS__)       // Log information
 #define Note(...) DiagsError(DL_Note, __VA_ARGS__)           // Log significant information
@@ -92,7 +106,7 @@ extern Diags *diags;
     static const SourceLocation loc = MakeSourceLocation(); \
     static LogMessage log_message{IS_THROTTLED};            \
     log_message.message(level, loc, __VA_ARGS__);           \
-  } while (0)
+  } while (false)
 
 #define SiteThrottledStatus(...) SiteThrottledDiagsError(DL_Status, __VA_ARGS__)   // Log information
 #define SiteThrottledNote(...) SiteThrottledDiagsError(DL_Note, __VA_ARGS__)       // Log significant information
@@ -110,7 +124,7 @@ extern Diags *diags;
     static const SourceLocation loc = MakeSourceLocation(); \
     static LogMessage log_message;                          \
     log_message.message_va(level, loc, fmt, ap);            \
-  } while (0)
+  } while (false)
 
 #define StatusV(fmt, ap) DiagsErrorV(DL_Status, fmt, ap)
 #define NoteV(fmt, ap) DiagsErrorV(DL_Note, fmt, ap)
@@ -127,7 +141,7 @@ extern Diags *diags;
     static const SourceLocation loc = MakeSourceLocation(); \
     static LogMessage log_message{IS_THROTTLED};            \
     log_message.message_va(level, loc, fmt, ap);            \
-  } while (0)
+  } while (false)
 
 #define SiteThrottledStatusV(fmt, ap) SiteThrottledDiagsErrorV(DL_Status, fmt, ap)
 #define SiteThrottledNoteV(fmt, ap) SiteThrottledDiagsErrorV(DL_Note, fmt, ap)
@@ -142,50 +156,81 @@ extern Diags *diags;
 /// A Diag version of the above.
 #define Diag(tag, ...)                                        \
   do {                                                        \
-    if (unlikely(diags->on())) {                              \
+    if (unlikely(diags()->on())) {                            \
       static const SourceLocation loc = MakeSourceLocation(); \
       static LogMessage log_message;                          \
       log_message.diag(tag, loc, __VA_ARGS__);                \
     }                                                         \
-  } while (0)
+  } while (false)
 
-/// A Debug version of the above.
-#define Debug(tag, ...)                                       \
-  do {                                                        \
-    if (unlikely(diags->on())) {                              \
-      static const SourceLocation loc = MakeSourceLocation(); \
-      static LogMessage log_message;                          \
-      log_message.debug(tag, loc, __VA_ARGS__);               \
-    }                                                         \
-  } while (0)
+inline bool
+is_dbg_ctl_enabled(DbgCtl const &ctl)
+{
+  return unlikely(diags()->on()) && ctl.ptr()->on;
+}
 
-/** Same as Debug above, but this allows a positive override of the tag
- * mechanism by a flag boolean.
- *
- * @param[in] flag True if the message should be logged regardless of tag
- * configuration, false if the logging of the message should respsect the tag
- * configuration.
- */
-#define SpecificDebug(flag, tag, ...)                                                                       \
-  do {                                                                                                      \
-    if (unlikely(diags->on())) {                                                                            \
-      static const SourceLocation loc = MakeSourceLocation();                                               \
-      static LogMessage log_message;                                                                        \
-      flag ? log_message.print(tag, DL_Debug, loc, __VA_ARGS__) : log_message.debug(tag, loc, __VA_ARGS__); \
-    }                                                                                                       \
-  } while (0)
+// printf-line debug output.  First parameter must be DbgCtl instance. Assumes debug control is enabled, and
+// debug output globablly enabled.
+//
+#define DbgPrint(ctl__, ...)                                             \
+  do {                                                                   \
+    static const SourceLocation loc__ = MakeSourceLocation();            \
+    static LogMessage log_message__;                                     \
+    log_message__.print(ctl__.ptr()->tag, DL_Debug, loc__, __VA_ARGS__); \
+  } while (false)
 
-#define is_debug_tag_set(_t) unlikely(diags->on(_t, DiagsTagType_Debug))
-#define is_action_tag_set(_t) unlikely(diags->on(_t, DiagsTagType_Action))
+// printf-like debug output.  First parameter must be an instance of DbgCtl.
+//
+#define Dbg(ctl__, ...)                               \
+  do {                                                \
+    if (unlikely(diags()->on()) && ctl__.ptr()->on) { \
+      DbgPrint(ctl__, __VA_ARGS__);                   \
+    }                                                 \
+  } while (false)
+
+// printf-like debug output.  First parameter must be tag (C-string literal, or otherwise
+// a constexpr returning char const pointer to null-terminated C-string).
+//
+#define Debug(tag__, ...)             \
+  do {                                \
+    if (unlikely(diags()->on())) {    \
+      static DbgCtl ctl__(tag__);     \
+      if (ctl__.ptr()->on) {          \
+        DbgPrint(ctl__, __VA_ARGS__); \
+      }                               \
+    }                                 \
+  } while (false)
+
+// Same as Dbg above, but this allows a positive override of the DbgCtl, if flag is true.
+//
+#define SpecificDbg(flag__, ctl__, ...) \
+  do {                                  \
+    if (unlikely(diags()->on())) {      \
+      if (flag__ || ctl__.ptr()->on) {  \
+        DbgPrint(ctl__, __VA_ARGS__);   \
+      }                                 \
+    }                                   \
+  } while (false)
+
+// For better performance, use this instead of diags()->on(tag) when the tag parameter is a C-string literal.
+//
+#define is_debug_tag_set(tag__)               \
+  (unlikely(diags()->on()) && ([]() -> bool { \
+     static DbgCtl ctl__(tag__);              \
+     return ctl__.ptr()->on != 0;             \
+   }()))
+
+#define is_action_tag_set(_t) unlikely(diags()->on(_t, DiagsTagType_Action))
 #define debug_tag_assert(_t, _a) (is_debug_tag_set(_t) ? (ink_release_assert(_a), 0) : 0)
 #define action_tag_assert(_t, _a) (is_action_tag_set(_t) ? (ink_release_assert(_a), 0) : 0)
-#define is_diags_on(_t) unlikely(diags->on(_t))
+#define is_diags_on(_t) is_debug_tag_set(_t) // Deprecated.
 
 #else // TS_USE_DIAGS
 
-#define Diag(tag, fmt, ...)
-#define Debug(tag, fmt, ...)
-#define SpecificDebug(flag, tag, ...)
+#define Diag(...)
+#define Dbg(...)
+#define Debug(...)
+#define SpecificDbg(...)
 
 #define is_debug_tag_set(_t) 0
 #define is_action_tag_set(_t) 0

--- a/include/tscore/DiagsTypes.h
+++ b/include/tscore/DiagsTypes.h
@@ -41,6 +41,7 @@
 #include "ink_mutex.h"
 #include "Regex.h"
 #include "SourceLocation.h"
+#include "DbgCtl.h"
 
 #define DIAGS_MAGIC 0x12345678
 #define BYTES_IN_MB 1000000
@@ -85,10 +86,21 @@ enum DiagsShowLocation { SHOW_LOCATION_NONE = 0, SHOW_LOCATION_DEBUG, SHOW_LOCAT
 //   cleanup process state
 typedef void (*DiagsCleanupFunc)();
 
-struct DiagsConfigState {
-  // this is static to eliminate many loads from the critical path
-  static int enabled[2];                     // one debug, one action
+class DiagsConfigState
+{
+public:
+  static int
+  enabled(DiagsTagType dtt)
+  {
+    return _enabled[dtt];
+  }
+
+  static void enabled(DiagsTagType dtt, int new_value);
+
   DiagsModeOutput outputs[DiagsLevel_Count]; // where each level prints
+
+private:
+  static int _enabled[2]; // one debug, one action
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -138,22 +150,51 @@ public:
     return this->debug_client_ip == test_ip;
   }
 
+  // It seems to make a big difference to performance (due to the caching of the enabled flag) to call this
+  // function first before doing anything else for debug output.  This includes entering blocks with static
+  // DbgCtl instances, or other static variables with non-const initialization.  Static variables with
+  // non-const initialization inside a function have a hidden flag that is checked every time the containing
+  // block is entered, to see if the variable has been initialized or not.
+  //
   bool
   on(DiagsTagType mode = DiagsTagType_Debug) const
   {
-    return ((config.enabled[mode] == 1) || (config.enabled[mode] == 2 && this->get_override()));
+    return (config.enabled(mode) & 1) || (config.enabled(mode) == 2 && this->get_override());
   }
 
   bool
+  on_for_TSDebug() const
+  {
+    return (config.enabled(DiagsTagType_Debug) == 1) || (config.enabled(DiagsTagType_Debug) == 2 && this->get_override());
+  }
+
+  // is_debug_tag_set() is the faster alternative to this for debug mode, when the tag is a literal C-string
+  // (or otherwise is a constexpr returning char const *).
+  //
+  bool
   on(const char *tag, DiagsTagType mode = DiagsTagType_Debug) const
   {
-    return this->on(mode) && tag_activated(tag, mode);
+    return unlikely(this->on(mode)) && tag_activated(tag, mode);
+  }
+
+  bool
+  on_for_TSDebug(const char *tag) const
+  {
+    return unlikely(this->on_for_TSDebug()) && tag_activated(tag, DiagsTagType_Debug);
+  }
+
+  bool
+  on(DbgCtl const &ctl) const
+  {
+    return unlikely(this->on(DiagsTagType_Debug)) && ctl.ptr()->on;
   }
 
   /////////////////////////////////////
   // low-level tag inquiry functions //
   /////////////////////////////////////
 
+  // This does regex match against the tag.
+  //
   bool tag_activated(const char *tag, DiagsTagType mode = DiagsTagType_Debug) const;
 
   /////////////////////////////

--- a/include/tscore/LogMessage.h
+++ b/include/tscore/LogMessage.h
@@ -61,7 +61,6 @@ public:
 
   /* TODO: Add BufferWriter overloads for these. */
   void diag(const char *tag, SourceLocation const &loc, const char *fmt, ...) TS_PRINTFLIKE(4, 5);
-  void debug(const char *tag, SourceLocation const &loc, const char *fmt, ...) TS_PRINTFLIKE(4, 5);
   void status(SourceLocation const &loc, const char *fmt, ...) TS_PRINTFLIKE(3, 4);
   void note(SourceLocation const &loc, const char *fmt, ...) TS_PRINTFLIKE(3, 4);
   void warning(SourceLocation const &loc, const char *fmt, ...) TS_PRINTFLIKE(3, 4);
@@ -123,7 +122,7 @@ private:
    */
   void message_debug_helper(const char *tag, DiagsLevel level, SourceLocation const &loc, const char *fmt, va_list args);
 
-  /** Same as above, but uses the tag-ignoring diags->print variant. */
+  /** Same as above, but uses the tag-ignoring diags()->print variant. */
   void message_print_helper(const char *tag, DiagsLevel level, SourceLocation const &loc, const char *fmt, va_list args);
 
 private:

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -42,10 +42,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "*" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("cache.*|agg.*|locks", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "*" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("cache.*|agg.*|locks", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     mime_init();
     Layout::create();

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1333,7 +1333,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
       restore_info(r, old_r.get(), old_info, old_rr_data);
     }
     ink_assert(!r || !r->round_robin || !r->reverse_dns);
-    ink_assert(failed || !r->round_robin || r->app.rr.offset);
+    ink_assert(failed || ((r != nullptr) && (!r->round_robin || r->app.rr.offset)));
 
     if (!serve_stale) {
       hostDB.refcountcache->put(hash.hash.fold(), r, allocSize, r->expiry_time());

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -282,14 +282,14 @@ inline void
 UnixNetVConnection::set_remote_addr()
 {
   ats_ip_copy(&remote_addr, &con.addr);
-  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags->test_override_ip(remote_addr));
+  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags()->test_override_ip(remote_addr));
 }
 
 inline void
 UnixNetVConnection::set_remote_addr(const sockaddr *new_sa)
 {
   ats_ip_copy(&remote_addr, new_sa);
-  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags->test_override_ip(remote_addr));
+  this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags()->test_override_ip(remote_addr));
 }
 
 inline void

--- a/iocore/net/SSLDiags.h
+++ b/iocore/net/SSLDiags.h
@@ -39,5 +39,11 @@ void SSLDiagnostic(const SourceLocation &loc, bool debug, SSLNetVConnection *vc,
 // Return a static string name for a SSL_ERROR constant.
 const char *SSLErrorName(int ssl_error);
 
-// Log a SSL network buffer.
-void SSLDebugBufferPrint(const char *tag, const char *buffer, unsigned buflen, const char *message);
+// Log a SSL network buffer.  tag__ must be a C-string literal debug tag.
+#define SSLDebugBufferPrint(tag__, buffer__, buffer_len__, message__) \
+  do {                                                                \
+    if (is_debug_tag_set(tag__))                                      \
+      SSLDebugBufferPrint_(buffer__, buffer_len__, message__);        \
+  } while (0)
+
+void SSLDebugBufferPrint_(const char *buffer, unsigned buflen, const char *message);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -204,11 +204,14 @@ ssl_new_cached_session(SSL *ssl, SSL_SESSION *sess)
 
   SSLSessionID sid(id, len);
 
-  if (diags->tag_activated("ssl.session_cache")) {
-    char printable_buf[(len * 2) + 1];
+  if (diags()->on()) {
+    static DbgCtl dbg_ctl("ssl.session_cache.insert");
+    if (dbg_ctl.ptr()->on) {
+      char printable_buf[(len * 2) + 1];
 
-    sid.toString(printable_buf, sizeof(printable_buf));
-    Debug("ssl.session_cache.insert", "ssl_new_cached_session session '%s' and context %p", printable_buf, SSL_get_SSL_CTX(ssl));
+      sid.toString(printable_buf, sizeof(printable_buf));
+      DbgPrint(dbg_ctl, "ssl_new_cached_session session '%s' and context %p", printable_buf, SSL_get_SSL_CTX(ssl));
+    }
   }
 
   SSL_INCREMENT_DYN_STAT(ssl_session_cache_new_session);
@@ -244,10 +247,13 @@ ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess)
     hook = hook->m_link.next;
   }
 
-  if (diags->tag_activated("ssl.session_cache")) {
-    char printable_buf[(len * 2) + 1];
-    sid.toString(printable_buf, sizeof(printable_buf));
-    Debug("ssl.session_cache.remove", "ssl_rm_cached_session cached session '%s'", printable_buf);
+  if (diags()->on()) {
+    static DbgCtl dbg_ctl("ssl.session_cache.remove");
+    if (dbg_ctl.ptr()->on) {
+      char printable_buf[(len * 2) + 1];
+      sid.toString(printable_buf, sizeof(printable_buf));
+      DbgPrint(dbg_ctl, "ssl_rm_cached_session cached session '%s'", printable_buf);
+    }
   }
 
   session_cache->removeSession(sid);

--- a/iocore/net/TLSSessionResumptionSupport.cc
+++ b/iocore/net/TLSSessionResumptionSupport.cc
@@ -134,10 +134,13 @@ TLSSessionResumptionSupport::getSession(SSL *ssl, const unsigned char *id, int l
   SSLSessionID sid(id, len);
 
   *copy = 0;
-  if (diags->tag_activated("ssl.session_cache")) {
-    char printable_buf[(len * 2) + 1];
-    sid.toString(printable_buf, sizeof(printable_buf));
-    Debug("ssl.session_cache.get", "ssl_get_cached_session cached session '%s' context %p", printable_buf, SSL_get_SSL_CTX(ssl));
+  if (diags()->on()) {
+    static DbgCtl dbg_ctl("ssl.session_cache.get");
+    if (dbg_ctl.ptr()->on) {
+      char printable_buf[(len * 2) + 1];
+      sid.toString(printable_buf, sizeof(printable_buf));
+      DbgPrint(dbg_ctl, "ssl_get_cached_session cached session '%s' context %p", printable_buf, SSL_get_SSL_CTX(ssl));
+    }
   }
 
   APIHook *hook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_SESSION_HOOK));

--- a/iocore/net/quic/test/event_processor_main.cc
+++ b/iocore/net/quic/test/event_processor_main.cc
@@ -43,10 +43,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/iocore/net/quic/test/main.cc
+++ b/iocore/net/quic/test/main.cc
@@ -40,10 +40,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/iocore/net/test_certlookup.cc
+++ b/iocore/net/test_certlookup.cc
@@ -214,7 +214,7 @@ int
 main(int argc, const char **argv)
 {
   BaseLogFile *blf = new BaseLogFile("stdout");
-  diags            = new Diags("test_certlookup", nullptr, nullptr, blf);
+  DiagsPtr::set(new Diags("test_certlookup", nullptr, nullptr, blf));
   res_track_memory = 1;
 
   SSL_library_init();

--- a/iocore/utils/diags.i
+++ b/iocore/utils/diags.i
@@ -41,13 +41,9 @@ reconfigure_diags()
   DiagsConfigState c;
 
 
-  // initial value set to 0 or 1 based on command line tags
-  c.enabled[DiagsTagType_Debug] = (diags->base_debug_tags != nullptr);
-  c.enabled[DiagsTagType_Action] = (diags->base_action_tags != nullptr);
-
-  c.enabled[DiagsTagType_Debug] = 1;
-  c.enabled[DiagsTagType_Action] = 1;
-  diags->show_location = SHOW_LOCATION_ALL;
+  c.enabled(DiagsTagType_Debug, 1);
+  c.enabled(DiagsTagType_Action, 1);
+  diags()->show_location = SHOW_LOCATION_ALL;
 
 
   // read output routing values
@@ -62,27 +58,27 @@ reconfigure_diags()
   // clear out old tag tables //
   //////////////////////////////
 
-  diags->deactivate_all(DiagsTagType_Debug);
-  diags->deactivate_all(DiagsTagType_Action);
+  diags()->deactivate_all(DiagsTagType_Debug);
+  diags()->deactivate_all(DiagsTagType_Action);
 
   //////////////////////////////////////////////////////////////////////
   //                     add new tag tables
   //////////////////////////////////////////////////////////////////////
 
-  if (diags->base_debug_tags) {
-    diags->activate_taglist(diags->base_debug_tags, DiagsTagType_Debug);
+  if (diags()->base_debug_tags) {
+    diags()->activate_taglist(diags()->base_debug_tags, DiagsTagType_Debug);
 }
-  if (diags->base_action_tags) {
-    diags->activate_taglist(diags->base_action_tags, DiagsTagType_Action);
+  if (diags()->base_action_tags) {
+    diags()->activate_taglist(diags()->base_action_tags, DiagsTagType_Action);
 }
 
 ////////////////////////////////////
 // change the diags config values //
 ////////////////////////////////////
 #if !defined(__GNUC__) && !defined(hpux)
-  diags->config = c;
+  diags()->config = c;
 #else
-  memcpy(((void *)&diags->config), ((void *)&c), sizeof(DiagsConfigState));
+  memcpy(((void *)&diags()->config), ((void *)&c), sizeof(DiagsConfigState));
 #endif
 }
 
@@ -93,7 +89,7 @@ init_diags(const char *bdt, const char *bat)
   char diags_logpath[500];
   strcpy(diags_logpath, DIAGS_LOG_FILE);
 
-  diags = new Diags("test", bdt, bat, new BaseLogFile(diags_logpath));
+  DiagsPtr::set(new Diags("test", bdt, bat, new BaseLogFile(diags_logpath)));
   Status("opened %s", diags_logpath);
 
   reconfigure_diags();

--- a/lib/records/test_I_RecLocal.cc
+++ b/lib/records/test_I_RecLocal.cc
@@ -27,7 +27,12 @@
 
 #include "P_RecCore.h"
 
-Diags *diags = nullptr;
+void
+DiagsPtr::set(Diags *new_ptr)
+{
+  _diags_ptr = new_ptr;
+}
+
 void RecDumpRecordsHt(RecT rec_type);
 
 //-------------------------------------------------------------------------
@@ -179,12 +184,12 @@ main(int argc, char **argv)
       log_fp = nullptr;
     }
   }
-  diags = new Diags("rec", nullptr, log_fp);
-  diags->activate_taglist(diags->base_debug_tags, DiagsTagType_Debug);
-  diags->log(nullptr, DTA(DL_Note), "Starting '%s'", argv[0]);
+  DiagsPtr::set(new Diags("rec", nullptr, log_fp));
+  diags()->activate_taglist(diags()->base_debug_tags, DiagsTagType_Debug);
+  diags()->log(nullptr, DTA(DL_Note), "Starting '%s'", argv[0]);
 
   // system initialization
-  RecLocalInit(diags);
+  RecLocalInit(diags());
   RecLocalInitMessage();
   RecordsConfigRegister();
   RecLocalStart();

--- a/lib/records/unit_tests/test_RecHttp.cc
+++ b/lib/records/unit_tests/test_RecHttp.cc
@@ -33,7 +33,7 @@ using ts::TextView;
 TEST_CASE("RecHttp", "[librecords][RecHttp]")
 {
   std::vector<HttpProxyPort> ports;
-  CatchDiags *cdiag = static_cast<CatchDiags *>(diags);
+  CatchDiags *cdiag = static_cast<CatchDiags *>(diags());
   cdiag->messages.clear();
 
   SECTION("base")

--- a/lib/records/unit_tests/unit_test_main.cc
+++ b/lib/records/unit_tests/unit_test_main.cc
@@ -33,7 +33,7 @@ int
 main(int argc, char *argv[])
 {
   // Set the global diags variable
-  diags = new CatchDiags;
+  DiagsPtr::set(new CatchDiags);
 
   // Global data initialization needed for the unit tests.
   ts_session_protocol_well_known_name_indices_init();

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -194,7 +194,7 @@ static const RecordElement RecordsConfig[] =
   //#    L  diags.log
   //#
   //##############################################################################
-  {RECT_CONFIG, "proxy.config.diags.debug.enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.diags.debug.enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, "[0-3]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.diags.debug.tags", RECD_STRING, "http|dns", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -46,19 +46,19 @@
  * API Memory Management
  ***************************************************************************/
 void *
-_TSmalloc(unsigned int size, const char * /* path ATS_UNUSED */)
+_TSmalloc(size_t size, const char * /* path ATS_UNUSED */)
 {
   return ats_malloc(size);
 }
 
 void *
-_TSrealloc(void *ptr, unsigned int size, const char * /* path ATS_UNUSED */)
+_TSrealloc(void *ptr, size_t size, const char * /* path ATS_UNUSED */)
 {
   return ats_realloc(ptr, size);
 }
 
 char *
-_TSstrdup(const char *str, int length, const char * /* path ATS_UNUSED */)
+_TSstrdup(const char *str, int64_t length, const char * /* path ATS_UNUSED */)
 {
   return ats_strndup(str, length);
 }

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -234,9 +234,9 @@ typedef void (*TSDisconnectFunc)(void *data);
 #define TSstrndup(p, n) _TSstrdup((p), (n), TS_RES_MEM_PATH)
 #define TSfree(p) _TSfree(p)
 
-tsapi void *_TSmalloc(unsigned int size, const char *path);
-tsapi void *_TSrealloc(void *ptr, unsigned int size, const char *path);
-tsapi char *_TSstrdup(const char *str, int length, const char *path);
+tsapi void *_TSmalloc(size_t size, const char *path);
+tsapi void *_TSrealloc(void *ptr, size_t size, const char *path);
+tsapi char *_TSstrdup(const char *str, int64_t length, const char *path);
 tsapi void _TSfree(void *ptr);
 
 /***************************************************************************

--- a/mgmt/utils/MgmtUtils.cc
+++ b/mgmt/utils/MgmtUtils.cc
@@ -228,7 +228,7 @@ mgmt_log(const char *message_format, ...)
   char extended_format[4096], message[4096];
 
   va_start(ap, message_format);
-  if (diags) {
+  if (diags()) {
     NoteV(message_format, ap);
   } else {
     if (use_syslog) {
@@ -254,7 +254,7 @@ mgmt_elog(const int lerrno, const char *message_format, ...)
 
   va_start(ap, message_format);
 
-  if (diags) {
+  if (diags()) {
     ErrorV(message_format, ap);
     if (lerrno != 0) {
       Error("last system error %d: %s", lerrno, strerror(lerrno));
@@ -288,7 +288,7 @@ mgmt_fatal(const int lerrno, const char *message_format, ...)
 
   va_start(ap, message_format);
 
-  if (diags) {
+  if (diags()) {
     if (lerrno != 0) {
       Error("last system error %d: %s", lerrno, strerror(lerrno));
     }

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -37,7 +37,7 @@
 // Emit a debug message conditional on whether this particular client session
 // has debugging enabled. This should only be called from within a client session
 // member function.
-#define SsnDebug(ssn, tag, ...) SpecificDebug((ssn)->debug(), tag, __VA_ARGS__)
+#define SsnDebug(ssn, dbg_ctl, ...) SpecificDbg((ssn)->debug(), dbg_ctl, __VA_ARGS__)
 
 class ProxyTransaction;
 class PoolableSession;

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -24,7 +24,8 @@
 #include "http/HttpSM.h"
 #include "Plugin.h"
 
-#define HttpTxnDebug(fmt, ...) SsnDebug(this, "http_txn", fmt, __VA_ARGS__)
+static DbgCtl http_txn_dbg_ctl("http_txn");
+#define HttpTxnDebug(fmt, ...) SsnDebug(this, http_txn_dbg_ctl, fmt, __VA_ARGS__)
 
 extern ClassAllocator<HttpSM> httpSMAllocator;
 

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -98,6 +98,8 @@ int URL_LEN_MMST;
 // url_CryptoHash_get_fast() does NOT produce the same result as url_CryptoHash_get_general().
 static int url_hash_method = 0;
 
+static DbgCtl http_dbg{"http"};
+
 // test to see if a character is a valid character for a host in a URI according to
 // RFC 3986 and RFC 1034
 inline static int
@@ -1151,7 +1153,7 @@ url_is_strictly_compliant(const char *start, const char *end)
 {
   for (const char *i = start; i < end; ++i) {
     if (!ParseRules::is_uri(*i)) {
-      Debug("http", "Non-RFC compliant character [0x%.2X] found in URL", (unsigned char)*i);
+      Dbg(http_dbg, "Non-RFC compliant character [0x%.2X] found in URL", (unsigned char)*i);
       return false;
     }
   }
@@ -1666,22 +1668,22 @@ url_describe(HdrHeapObjImpl *raw, bool /* recurse ATS_UNUSED */)
 {
   URLImpl *obj = (URLImpl *)raw;
 
-  Debug("http", "[URLTYPE: %d, SWKSIDX: %d,", obj->m_url_type, obj->m_scheme_wks_idx);
-  Debug("http", "\tSCHEME: \"%.*s\", SCHEME_LEN: %d,", obj->m_len_scheme, (obj->m_ptr_scheme ? obj->m_ptr_scheme : "NULL"),
-        obj->m_len_scheme);
-  Debug("http", "\tUSER: \"%.*s\", USER_LEN: %d,", obj->m_len_user, (obj->m_ptr_user ? obj->m_ptr_user : "NULL"), obj->m_len_user);
-  Debug("http", "\tPASSWORD: \"%.*s\", PASSWORD_LEN: %d,", obj->m_len_password,
-        (obj->m_ptr_password ? obj->m_ptr_password : "NULL"), obj->m_len_password);
-  Debug("http", "\tHOST: \"%.*s\", HOST_LEN: %d,", obj->m_len_host, (obj->m_ptr_host ? obj->m_ptr_host : "NULL"), obj->m_len_host);
-  Debug("http", "\tPORT: \"%.*s\", PORT_LEN: %d, PORT_NUM: %d", obj->m_len_port, (obj->m_ptr_port ? obj->m_ptr_port : "NULL"),
-        obj->m_len_port, obj->m_port);
-  Debug("http", "\tPATH: \"%.*s\", PATH_LEN: %d,", obj->m_len_path, (obj->m_ptr_path ? obj->m_ptr_path : "NULL"), obj->m_len_path);
-  Debug("http", "\tPARAMS: \"%.*s\", PARAMS_LEN: %d,", obj->m_len_params, (obj->m_ptr_params ? obj->m_ptr_params : "NULL"),
-        obj->m_len_params);
-  Debug("http", "\tQUERY: \"%.*s\", QUERY_LEN: %d,", obj->m_len_query, (obj->m_ptr_query ? obj->m_ptr_query : "NULL"),
-        obj->m_len_query);
-  Debug("http", "\tFRAGMENT: \"%.*s\", FRAGMENT_LEN: %d]", obj->m_len_fragment,
-        (obj->m_ptr_fragment ? obj->m_ptr_fragment : "NULL"), obj->m_len_fragment);
+  Dbg(http_dbg, "[URLTYPE: %d, SWKSIDX: %d,", obj->m_url_type, obj->m_scheme_wks_idx);
+  Dbg(http_dbg, "\tSCHEME: \"%.*s\", SCHEME_LEN: %d,", obj->m_len_scheme, (obj->m_ptr_scheme ? obj->m_ptr_scheme : "NULL"),
+      obj->m_len_scheme);
+  Dbg(http_dbg, "\tUSER: \"%.*s\", USER_LEN: %d,", obj->m_len_user, (obj->m_ptr_user ? obj->m_ptr_user : "NULL"), obj->m_len_user);
+  Dbg(http_dbg, "\tPASSWORD: \"%.*s\", PASSWORD_LEN: %d,", obj->m_len_password,
+      (obj->m_ptr_password ? obj->m_ptr_password : "NULL"), obj->m_len_password);
+  Dbg(http_dbg, "\tHOST: \"%.*s\", HOST_LEN: %d,", obj->m_len_host, (obj->m_ptr_host ? obj->m_ptr_host : "NULL"), obj->m_len_host);
+  Dbg(http_dbg, "\tPORT: \"%.*s\", PORT_LEN: %d, PORT_NUM: %d", obj->m_len_port, (obj->m_ptr_port ? obj->m_ptr_port : "NULL"),
+      obj->m_len_port, obj->m_port);
+  Dbg(http_dbg, "\tPATH: \"%.*s\", PATH_LEN: %d,", obj->m_len_path, (obj->m_ptr_path ? obj->m_ptr_path : "NULL"), obj->m_len_path);
+  Dbg(http_dbg, "\tPARAMS: \"%.*s\", PARAMS_LEN: %d,", obj->m_len_params, (obj->m_ptr_params ? obj->m_ptr_params : "NULL"),
+      obj->m_len_params);
+  Dbg(http_dbg, "\tQUERY: \"%.*s\", QUERY_LEN: %d,", obj->m_len_query, (obj->m_ptr_query ? obj->m_ptr_query : "NULL"),
+      obj->m_len_query);
+  Dbg(http_dbg, "\tFRAGMENT: \"%.*s\", FRAGMENT_LEN: %d]", obj->m_len_fragment,
+      (obj->m_ptr_fragment ? obj->m_ptr_fragment : "NULL"), obj->m_len_fragment);
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/hdrs/load_http_hdr.cc
+++ b/proxy/hdrs/load_http_hdr.cc
@@ -297,7 +297,7 @@ main(int argc, const char *argv[])
   hdr_type h_type = UNKNOWN_HDR;
 
   http_init();
-  diags = new Diags(NULL, NULL);
+  DiagsPtr::set(new Diags(nullptr, nullptr));
   if (argc != 3) {
     fprintf(stderr, "Usage: %s req|res <file>\n", argv[0]);
     exit(1);

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -40,7 +40,9 @@
 
 #include "P_SSLNetVConnection.h"
 
-#define HttpSsnDebug(fmt, ...) SsnDebug(this, "http_cs", fmt, __VA_ARGS__)
+static DbgCtl http_cs_dbg_ctl("http_cs");
+
+#define HttpSsnDebug(fmt, ...) SsnDebug(this, http_cs_dbg_ctl, fmt, __VA_ARGS__)
 
 #define STATE_ENTER(state_name, event, vio)                                                             \
   do {                                                                                                  \

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -64,7 +64,7 @@ static char range_type[] = "multipart/byteranges; boundary=RANGE_SEPARATOR";
 #define TRANSACT_SETUP_RETURN(n, r) \
   s->next_action           = n;     \
   s->transact_return_point = r;     \
-  SpecificDebug((s->state_machine && s->state_machine->debug_on), "http_trans", "Next action %s; %s", #n, #r);
+  SpecificDbg((s->state_machine && s->state_machine->debug_on), http_trans_dbg_ctl, "Next action %s; %s", #n, #r);
 
 #define TRANSACT_RETURN(n, r) \
   TRANSACT_SETUP_RETURN(n, r) \
@@ -85,8 +85,27 @@ static char range_type[] = "multipart/byteranges; boundary=RANGE_SEPARATOR";
     }                                                               \
   }
 
-#define TxnDebug(tag, fmt, ...) \
-  SpecificDebug((s->state_machine->debug_on), tag, "[%" PRId64 "] " fmt, s->state_machine->sm_id, ##__VA_ARGS__)
+namespace
+{
+DbgCtl http_dbg_ctl("http");
+DbgCtl http_redirect_dbg_ctl("http_redirect");
+DbgCtl http_hdrs_dbg_ctl("http_hdrs");
+DbgCtl http_timeout_dbg_ctl("http_timeout");
+DbgCtl http_trans_dbg_ctl("http_trans");
+DbgCtl http_trans_upgrade_dbg_ctl("http_trans_upgrade");
+DbgCtl http_trans_websocket_dbg_ctl("http_trans_websocket");
+DbgCtl http_trans_websocket_upgrade_pre_remap_dbg_ctl("http_trans_websocket_upgrade_pre_remap");
+DbgCtl http_trans_websocket_upgrade_post_remap_dbg_ctl("http_trans_websocket_upgrade_post_remap");
+DbgCtl http_transact_dbg_ctl("http_transact");
+DbgCtl http_match_dbg_ctl("http_match");
+DbgCtl http_error_dbg_ctl("http_error");
+DbgCtl http_seq_dbg_ctl("http_seq");
+DbgCtl ip_allow_dbg_ctl("ip-allow");
+DbgCtl parent_down_dbg_ctl("parent_down");
+} // namespace
+
+#define TxnDbg(dbg_ctl, fmt, ...) \
+  SpecificDbg((s->state_machine->debug_on), dbg_ctl, "[%" PRId64 "] " fmt, s->state_machine->sm_id, ##__VA_ARGS__)
 
 extern HttpBodyFactory *body_factory;
 
@@ -257,9 +276,9 @@ parentExists(HttpTransact::State *s)
 inline static void
 nextParent(HttpTransact::State *s)
 {
-  TxnDebug("parent_down", "sm_id[%" PRId64 "] connection to parent %s failed, conn_state: %s, request to origin: %s",
-           s->state_machine->sm_id, s->parent_result.hostname, HttpDebugNames::get_server_state_name(s->current.state),
-           s->request_data.get_host());
+  TxnDbg(parent_down_dbg_ctl, "sm_id[%" PRId64 "] connection to parent %s failed, conn_state: %s, request to origin: %s",
+         s->state_machine->sm_id, s->parent_result.hostname, HttpDebugNames::get_server_state_name(s->current.state),
+         s->request_data.get_host());
   url_mapping *mp = s->url_map.getMapping();
   if (s->response_action.handled) {
     s->parent_result.hostname = s->response_action.action.hostname;
@@ -342,39 +361,39 @@ HttpTransact::is_response_valid(State *s, HTTPHdr *incoming_response)
     return true;
 #endif
   case NO_RESPONSE_HEADER_ERROR:
-    TxnDebug("http_trans", "[is_response_valid] No errors in response");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] No errors in response");
     return true;
 
   case MISSING_REASON_PHRASE:
-    TxnDebug("http_trans", "[is_response_valid] Response Error: Missing reason phrase - allowing");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] Response Error: Missing reason phrase - allowing");
     return true;
 
   case STATUS_CODE_SERVER_ERROR:
-    TxnDebug("http_trans", "[is_response_valid] Response Error: Origin Server returned 500 - allowing");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] Response Error: Origin Server returned 500 - allowing");
     return true;
 
   case CONNECTION_OPEN_FAILED:
-    TxnDebug("http_trans", "[is_response_valid] Response Error: connection open failed");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] Response Error: connection open failed");
     s->current.state = CONNECTION_ERROR;
     return false;
 
   case NON_EXISTANT_RESPONSE_HEADER:
-    TxnDebug("http_trans", "[is_response_valid] Response Error: No response header");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] Response Error: No response header");
     s->current.state = BAD_INCOMING_RESPONSE;
     return false;
 
   case NOT_A_RESPONSE_HEADER:
-    TxnDebug("http_trans", "[is_response_valid] Response Error: Not a response header");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] Response Error: Not a response header");
     s->current.state = BAD_INCOMING_RESPONSE;
     return false;
 
   case MISSING_STATUS_CODE:
-    TxnDebug("http_trans", "[is_response_valid] Response Error: Missing status code");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] Response Error: Missing status code");
     s->current.state = BAD_INCOMING_RESPONSE;
     return false;
 
   default:
-    TxnDebug("http_trans", "[is_response_valid] Errors in response");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_valid] Errors in response");
     s->current.state = BAD_INCOMING_RESPONSE;
     return false;
   }
@@ -561,10 +580,10 @@ is_negative_caching_appropriate(HttpTransact::State *s)
   int status  = s->hdr_info.server_response.status_get();
   auto params = s->http_config_param;
   if (params->negative_caching_list[status]) {
-    TxnDebug("http_trans", "%d is eligible for negative caching", status);
+    TxnDbg(http_trans_dbg_ctl, "%d is eligible for negative caching", status);
     return true;
   } else {
-    TxnDebug("http_trans", "%d is NOT eligible for negative caching", status);
+    TxnDbg(http_trans_dbg_ctl, "%d is NOT eligible for negative caching", status);
     return false;
   }
 }
@@ -579,7 +598,7 @@ find_server_and_update_current_info(HttpTransact::State *s)
     // Do not forward requests to local_host onto a parent.
     // I just wanted to do this for cop heartbeats, someone else
     // wanted it for all requests to local_host.
-    TxnDebug("http_trans", "request is from localhost, so bypass parent");
+    TxnDbg(http_trans_dbg_ctl, "request is from localhost, so bypass parent");
     s->parent_result.result = PARENT_DIRECT;
   } else if (s->method == HTTP_WKSIDX_CONNECT && s->http_config_param->disable_ssl_parenting) {
     if (s->parent_result.result == PARENT_SPECIFIED) {
@@ -588,7 +607,7 @@ find_server_and_update_current_info(HttpTransact::State *s)
       findParent(s);
     }
     if (!s->parent_result.is_some() || is_api_result(s) || parent_is_proxy(s)) {
-      TxnDebug("http_trans", "request not cacheable, so bypass parent");
+      TxnDbg(http_trans_dbg_ctl, "request not cacheable, so bypass parent");
       s->parent_result.result = PARENT_DIRECT;
     }
   } else if (s->txn_conf->uncacheable_requests_bypass_parent && s->http_config_param->no_dns_forward_to_parent == 0 &&
@@ -605,7 +624,7 @@ find_server_and_update_current_info(HttpTransact::State *s)
       findParent(s);
     }
     if (!s->parent_result.is_some() || is_api_result(s) || parent_is_proxy(s)) {
-      TxnDebug("http_trans", "request not cacheable, so bypass parent");
+      TxnDbg(http_trans_dbg_ctl, "request not cacheable, so bypass parent");
       s->parent_result.result = PARENT_DIRECT;
     }
   } else {
@@ -833,8 +852,8 @@ how_to_open_connection(HttpTransact::State *s)
 void
 HttpTransact::BadRequest(State *s)
 {
-  TxnDebug("http_trans", "[BadRequest]"
-                         "parser marked request bad");
+  TxnDbg(http_trans_dbg_ctl, "[BadRequest]"
+                             "parser marked request bad");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
 
   const char *body_factory_template = "request#syntax_error";
@@ -867,8 +886,8 @@ HttpTransact::BadRequest(State *s)
 void
 HttpTransact::PostActiveTimeoutResponse(State *s)
 {
-  TxnDebug("http_trans", "[PostActiveTimeoutResponse]"
-                         "post active timeout");
+  TxnDbg(http_trans_dbg_ctl, "[PostActiveTimeoutResponse]"
+                             "post active timeout");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
   build_error_response(s, HTTP_STATUS_REQUEST_TIMEOUT, "Active Timeout", "timeout#activity");
   TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -877,8 +896,8 @@ HttpTransact::PostActiveTimeoutResponse(State *s)
 void
 HttpTransact::PostInactiveTimeoutResponse(State *s)
 {
-  TxnDebug("http_trans", "[PostInactiveTimeoutResponse]"
-                         "post inactive timeout");
+  TxnDbg(http_trans_dbg_ctl, "[PostInactiveTimeoutResponse]"
+                             "post inactive timeout");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
   build_error_response(s, HTTP_STATUS_REQUEST_TIMEOUT, "Inactive Timeout", "timeout#inactivity");
   TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -887,8 +906,8 @@ HttpTransact::PostInactiveTimeoutResponse(State *s)
 void
 HttpTransact::Forbidden(State *s)
 {
-  TxnDebug("http_trans", "[Forbidden]"
-                         "IpAllow marked request forbidden");
+  TxnDbg(http_trans_dbg_ctl, "[Forbidden]"
+                             "IpAllow marked request forbidden");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
   build_error_response(s, HTTP_STATUS_FORBIDDEN, "Access Denied", "access#denied");
   TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -897,8 +916,8 @@ HttpTransact::Forbidden(State *s)
 void
 HttpTransact::SelfLoop(State *s)
 {
-  TxnDebug("http_trans", "[Loop]"
-                         "Request will selfloop.");
+  TxnDbg(http_trans_dbg_ctl, "[Loop]"
+                             "Request will selfloop.");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
   build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Direct self loop detected", "request#cycle_detected");
   TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -907,8 +926,8 @@ HttpTransact::SelfLoop(State *s)
 void
 HttpTransact::TooEarly(State *s)
 {
-  TxnDebug("http_trans", "[TooEarly]"
-                         "Early Data method is not safe");
+  TxnDbg(http_trans_dbg_ctl, "[TooEarly]"
+                             "Early Data method is not safe");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
   build_error_response(s, HTTP_STATUS_TOO_EARLY, "Too Early", "too#early");
   TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -917,7 +936,7 @@ HttpTransact::TooEarly(State *s)
 void
 HttpTransact::OriginDead(State *s)
 {
-  TxnDebug("http_trans", "origin server is marked down");
+  TxnDbg(http_trans_dbg_ctl, "origin server is marked down");
   bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
   build_error_response(s, HTTP_STATUS_BAD_GATEWAY, "Origin Server Marked Down", "connect#failed_connect");
   HTTP_INCREMENT_DYN_STAT(http_dead_server_no_requests);
@@ -944,7 +963,7 @@ HttpTransact::HandleBlindTunnel(State *s)
   // IpEndpoint dest_addr;
   // ip_text_buffer new_host;
 
-  TxnDebug("http_trans", "[HttpTransact::HandleBlindTunnel]");
+  TxnDbg(http_trans_dbg_ctl, "[HttpTransact::HandleBlindTunnel]");
 
   // We set the version to 0.9 because once we know where we are going
   //   this blind ssl tunnel is indistinguishable from a "CONNECT 0.9"
@@ -958,8 +977,8 @@ HttpTransact::HandleBlindTunnel(State *s)
   if (is_debug_tag_set("http_trans")) {
     int host_len;
     const char *host = s->hdr_info.client_request.url_get()->host_get(&host_len);
-    TxnDebug("http_trans", "[HandleBlindTunnel] destination set to %.*s:%d", host_len, host,
-             s->hdr_info.client_request.url_get()->port_get());
+    TxnDbg(http_trans_dbg_ctl, "[HandleBlindTunnel] destination set to %.*s:%d", host_len, host,
+           s->hdr_info.client_request.url_get()->port_get());
   }
 
   // Set the mode to tunnel so that we don't lookup the cache
@@ -974,7 +993,7 @@ void
 HttpTransact::StartRemapRequest(State *s)
 {
   if (s->api_skip_all_remapping) {
-    TxnDebug("http_trans", "API request to skip remapping");
+    TxnDbg(http_trans_dbg_ctl, "API request to skip remapping");
 
     s->hdr_info.client_request.set_url_target_from_host_field();
 
@@ -990,7 +1009,7 @@ HttpTransact::StartRemapRequest(State *s)
     TRANSACT_RETURN(SM_ACTION_POST_REMAP_SKIP, HttpTransact::HandleRequest);
   }
 
-  TxnDebug("http_trans", "START HttpTransact::StartRemapRequest");
+  TxnDbg(http_trans_dbg_ctl, "START HttpTransact::StartRemapRequest");
 
   //////////////////////////////////////////////////////////////////
   // FIX: this logic seems awfully convoluted and hard to follow; //
@@ -1010,7 +1029,7 @@ HttpTransact::StartRemapRequest(State *s)
   /////////////////////////////////////////////////////////////////
 
   if (is_debug_tag_set("http_chdr_describe") || is_debug_tag_set("http_trans")) {
-    TxnDebug("http_trans", "Before Remapping:");
+    TxnDbg(http_trans_dbg_ctl, "Before Remapping:");
     obj_describe(s->hdr_info.client_request.m_http, true);
   }
   DUMP_HEADER("http_hdrs", &s->hdr_info.client_request, s->state_machine_id, "Incoming Request");
@@ -1022,12 +1041,12 @@ HttpTransact::StartRemapRequest(State *s)
     }
   }
 
-  TxnDebug("http_trans", "END HttpTransact::StartRemapRequest");
+  TxnDbg(http_trans_dbg_ctl, "END HttpTransact::StartRemapRequest");
 
-  TxnDebug("http_trans", "Checking if transaction wants to upgrade");
+  TxnDbg(http_trans_dbg_ctl, "Checking if transaction wants to upgrade");
   if (handle_upgrade_request(s)) {
     // everything should be handled by the upgrade handler.
-    TxnDebug("http_trans", "Transaction will be upgraded by the appropriate upgrade handler.");
+    TxnDbg(http_trans_dbg_ctl, "Transaction will be upgraded by the appropriate upgrade handler.");
     return;
   }
 
@@ -1037,20 +1056,20 @@ HttpTransact::StartRemapRequest(State *s)
 void
 HttpTransact::PerformRemap(State *s)
 {
-  TxnDebug("http_trans", "Inside PerformRemap");
+  TxnDbg(http_trans_dbg_ctl, "Inside PerformRemap");
   TRANSACT_RETURN(SM_ACTION_REMAP_REQUEST, HttpTransact::EndRemapRequest);
 }
 
 void
 HttpTransact::EndRemapRequest(State *s)
 {
-  TxnDebug("http_trans", "START HttpTransact::EndRemapRequest");
+  TxnDbg(http_trans_dbg_ctl, "START HttpTransact::EndRemapRequest");
 
   HTTPHdr *incoming_request = &s->hdr_info.client_request;
   int method                = incoming_request->method_get_wksidx();
   int host_len;
   const char *host = incoming_request->host_get(&host_len);
-  TxnDebug("http_trans", "EndRemapRequest host is %.*s", host_len, host);
+  TxnDbg(http_trans_dbg_ctl, "EndRemapRequest host is %.*s", host_len, host);
 
   // Setting enable_redirection according to HttpConfig (master or overridable). We
   // defer this as late as possible, to allow plugins to modify the overridable
@@ -1123,7 +1142,7 @@ HttpTransact::EndRemapRequest(State *s)
      * Or those successfully remapped rules might be redirected
      **/
     if (handleIfRedirect(s)) {
-      TxnDebug("http_trans", "END HttpTransact::RemapRequest");
+      TxnDbg(http_trans_dbg_ctl, "END HttpTransact::RemapRequest");
       TRANSACT_RETURN(SM_ACTION_INTERNAL_CACHE_NOOP, nullptr);
     }
 
@@ -1188,7 +1207,7 @@ done:
   }
 
   if (is_debug_tag_set("http_chdr_describe") || is_debug_tag_set("http_trans") || is_debug_tag_set("url_rewrite")) {
-    TxnDebug("http_trans", "After Remapping:");
+    TxnDbg(http_trans_dbg_ctl, "After Remapping:");
     obj_describe(s->hdr_info.client_request.m_http, true);
   }
 
@@ -1201,13 +1220,13 @@ done:
     otherwise, 502/404 the request right now. /eric
   */
   if (!s->reverse_proxy && s->state_machine->plugin_tunnel_type == HTTP_NO_PLUGIN_TUNNEL) {
-    TxnDebug("http_trans", "END HttpTransact::EndRemapRequest");
+    TxnDbg(http_trans_dbg_ctl, "END HttpTransact::EndRemapRequest");
     HTTP_INCREMENT_DYN_STAT(http_invalid_client_requests_stat);
     TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
   } else {
     s->hdr_info.client_response.destroy(); // release the underlying memory.
     s->hdr_info.client_response.clear();   // clear the pointers.
-    TxnDebug("http_trans", "END HttpTransact::EndRemapRequest");
+    TxnDbg(http_trans_dbg_ctl, "END HttpTransact::EndRemapRequest");
 
     if (s->is_upgrade_request && s->post_remap_upgrade_return_point) {
       TRANSACT_RETURN(SM_ACTION_API_POST_REMAP, s->post_remap_upgrade_return_point);
@@ -1243,7 +1262,7 @@ HttpTransact::handle_upgrade_request(State *s)
 
   if (!upgrade_hdr || !connection_hdr || connection_hdr->value_get_comma_list(&connection_hdr_vals) == 0 ||
       (upgrade_hdr_val = upgrade_hdr->value_get(&upgrade_hdr_val_len)) == nullptr) {
-    TxnDebug("http_trans_upgrade", "Transaction wasn't a valid upgrade request, proceeding as a normal HTTP request.");
+    TxnDbg(http_trans_upgrade_dbg_ctl, "Transaction wasn't a valid upgrade request, proceeding as a normal HTTP request.");
     return false;
   }
 
@@ -1263,8 +1282,8 @@ HttpTransact::handle_upgrade_request(State *s)
   }
 
   if (!connection_contains_upgrade) {
-    TxnDebug("http_trans_upgrade",
-             "Transaction wasn't a valid upgrade request, proceeding as a normal HTTP request, missing Connection upgrade header.");
+    TxnDbg(http_trans_upgrade_dbg_ctl,
+           "Transaction wasn't a valid upgrade request, proceeding as a normal HTTP request, missing Connection upgrade header.");
     return false;
   }
 
@@ -1291,11 +1310,11 @@ HttpTransact::handle_upgrade_request(State *s)
         s->hdr_info.client_request.field_find(MIME_FIELD_SEC_WEBSOCKET_VERSION, MIME_LEN_SEC_WEBSOCKET_VERSION);
 
       if (sec_websocket_key && sec_websocket_ver && sec_websocket_ver->value_get_int() == 13) {
-        TxnDebug("http_trans_upgrade", "Transaction wants upgrade to websockets");
+        TxnDbg(http_trans_upgrade_dbg_ctl, "Transaction wants upgrade to websockets");
         handle_websocket_upgrade_pre_remap(s);
         return true;
       } else {
-        TxnDebug("http_trans_upgrade", "Unable to upgrade connection to websockets, invalid headers (RFC 6455).");
+        TxnDbg(http_trans_upgrade_dbg_ctl, "Unable to upgrade connection to websockets, invalid headers (RFC 6455).");
       }
     } else if (s->upgrade_token_wks == MIME_VALUE_H2C) {
       // We need to recognize h2c to not handle it as an error.
@@ -1304,7 +1323,7 @@ HttpTransact::handle_upgrade_request(State *s)
       return false;
     }
   } else {
-    TxnDebug("http_trans_upgrade", "Transaction requested upgrade for unknown protocol: %s", upgrade_hdr_val);
+    TxnDbg(http_trans_upgrade_dbg_ctl, "Transaction requested upgrade for unknown protocol: %s", upgrade_hdr_val);
   }
 
   build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid Upgrade Request", "request#syntax_error");
@@ -1317,7 +1336,7 @@ HttpTransact::handle_upgrade_request(State *s)
 void
 HttpTransact::handle_websocket_upgrade_pre_remap(State *s)
 {
-  TxnDebug("http_trans_websocket_upgrade_pre_remap", "Prepping transaction before remap.");
+  TxnDbg(http_trans_websocket_upgrade_pre_remap_dbg_ctl, "Prepping transaction before remap.");
 
   /*
    * We will use this opportunity to set everything up so that during the remap stage we can deal with
@@ -1329,13 +1348,13 @@ HttpTransact::handle_websocket_upgrade_pre_remap(State *s)
   /* let's modify the url scheme to be wss or ws, so remapping will happen as expected */
   URL *url = s->hdr_info.client_request.url_get();
   if (url->scheme_get_wksidx() == URL_WKSIDX_HTTP) {
-    TxnDebug("http_trans_websocket_upgrade_pre_remap", "Changing scheme to WS for remapping.");
+    TxnDbg(http_trans_websocket_upgrade_pre_remap_dbg_ctl, "Changing scheme to WS for remapping.");
     url->scheme_set(URL_SCHEME_WS, URL_LEN_WS);
   } else if (url->scheme_get_wksidx() == URL_WKSIDX_HTTPS) {
-    TxnDebug("http_trans_websocket_upgrade_pre_remap", "Changing scheme to WSS for remapping.");
+    TxnDbg(http_trans_websocket_upgrade_pre_remap_dbg_ctl, "Changing scheme to WSS for remapping.");
     url->scheme_set(URL_SCHEME_WSS, URL_LEN_WSS);
   } else {
-    TxnDebug("http_trans_websocket_upgrade_pre_remap", "Invalid scheme for websocket upgrade");
+    TxnDbg(http_trans_websocket_upgrade_pre_remap_dbg_ctl, "Invalid scheme for websocket upgrade");
     build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid Upgrade Request", "request#syntax_error");
     TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
   }
@@ -1346,7 +1365,7 @@ HttpTransact::handle_websocket_upgrade_pre_remap(State *s)
 void
 HttpTransact::handle_websocket_upgrade_post_remap(State *s)
 {
-  TxnDebug("http_trans_websocket_upgrade_post_remap", "Remap is complete, start websocket upgrade");
+  TxnDbg(http_trans_websocket_upgrade_post_remap_dbg_ctl, "Remap is complete, start websocket upgrade");
 
   TRANSACT_RETURN(SM_ACTION_API_POST_REMAP, HttpTransact::handle_websocket_connection);
 }
@@ -1354,7 +1373,7 @@ HttpTransact::handle_websocket_upgrade_post_remap(State *s)
 void
 HttpTransact::handle_websocket_connection(State *s)
 {
-  TxnDebug("http_trans_websocket", "START handle_websocket_connection");
+  TxnDbg(http_trans_websocket_dbg_ctl, "START handle_websocket_connection");
 
   HandleRequest(s);
 }
@@ -1379,7 +1398,7 @@ HttpTransact::ModifyRequest(State *s)
   HTTPHdr &request              = s->hdr_info.client_request;
   static const int PORT_PADDING = 8;
 
-  TxnDebug("http_trans", "START HttpTransact::ModifyRequest");
+  TxnDbg(http_trans_dbg_ctl, "START HttpTransact::ModifyRequest");
 
   // Initialize the state vars necessary to sending error responses
   bootstrap_state_variables_from_request(s, &request);
@@ -1453,7 +1472,7 @@ HttpTransact::ModifyRequest(State *s)
     }
   }
 
-  TxnDebug("http_trans", "END HttpTransact::ModifyRequest");
+  TxnDbg(http_trans_dbg_ctl, "END HttpTransact::ModifyRequest");
 
   TRANSACT_RETURN(SM_ACTION_API_READ_REQUEST_HDR, HttpTransact::StartRemapRequest);
 }
@@ -1492,7 +1511,7 @@ HttpTransact::handleIfRedirect(State *s)
 void
 HttpTransact::HandleRequest(State *s)
 {
-  TxnDebug("http_trans", "START HttpTransact::HandleRequest");
+  TxnDbg(http_trans_dbg_ctl, "START HttpTransact::HandleRequest");
 
   if (!s->state_machine->is_waiting_for_full_body && !s->state_machine->is_using_post_buffer) {
     ink_assert(!s->hdr_info.server_request.valid());
@@ -1509,12 +1528,12 @@ HttpTransact::HandleRequest(State *s)
 
     if (!(is_request_valid(s, &s->hdr_info.client_request))) {
       HTTP_INCREMENT_DYN_STAT(http_invalid_client_requests_stat);
-      TxnDebug("http_seq", "[HttpTransact::HandleRequest] request invalid.");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleRequest] request invalid.");
       s->next_action = SM_ACTION_SEND_ERROR_CACHE_NOOP;
       //  s->next_action = HttpTransact::PROXY_INTERNAL_CACHE_NOOP;
       return;
     }
-    TxnDebug("http_seq", "[HttpTransact::HandleRequest] request valid.");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleRequest] request valid.");
 
     if (is_debug_tag_set("http_chdr_describe")) {
       obj_describe(s->hdr_info.client_request.m_http, true);
@@ -1529,7 +1548,7 @@ HttpTransact::HandleRequest(State *s)
       HTTP_READ_DYN_SUM(http_websocket_current_active_client_connections_stat, val);
       if (val >= s->http_config_param->max_websocket_connections) {
         s->is_websocket = false; // unset to avoid screwing up stats.
-        TxnDebug("http_trans", "Rejecting websocket connection because the limit has been exceeded");
+        TxnDbg(http_trans_dbg_ctl, "Rejecting websocket connection because the limit has been exceeded");
         bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
         build_error_response(s, HTTP_STATUS_SERVICE_UNAVAILABLE, "WebSocket Connection Limit Exceeded", nullptr);
         TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -1539,8 +1558,8 @@ HttpTransact::HandleRequest(State *s)
     // The following code is configurable to allow a user to control the max post size (TS-3631)
     if (s->http_config_param->max_post_size > 0 && s->hdr_info.request_content_length > 0 &&
         s->hdr_info.request_content_length > s->http_config_param->max_post_size) {
-      TxnDebug("http_trans", "Max post size %" PRId64 " Client tried to post a body that was too large.",
-               s->http_config_param->max_post_size);
+      TxnDbg(http_trans_dbg_ctl, "Max post size %" PRId64 " Client tried to post a body that was too large.",
+             s->http_config_param->max_post_size);
       HTTP_INCREMENT_DYN_STAT(http_post_body_too_large);
       bootstrap_state_variables_from_request(s, &s->hdr_info.client_request);
       build_error_response(s, HTTP_STATUS_REQUEST_ENTITY_TOO_LARGE, "Request Entity Too Large", "request#entity_too_large");
@@ -1558,7 +1577,7 @@ HttpTransact::HandleRequest(State *s)
         expect_hdr_val             = expect->value_get(&expect_hdr_val_len);
         if (ptr_len_casecmp(expect_hdr_val, expect_hdr_val_len, HTTP_VALUE_100_CONTINUE, HTTP_LEN_100_CONTINUE) == 0) {
           // Let's error out this request.
-          TxnDebug("http_trans", "Client sent a post expect: 100-continue, sending 405.");
+          TxnDbg(http_trans_dbg_ctl, "Client sent a post expect: 100-continue, sending 405.");
           HTTP_INCREMENT_DYN_STAT(disallowed_post_100_continue);
           build_error_response(s, HTTP_STATUS_METHOD_NOT_ALLOWED, "Method Not Allowed", "request#method_unsupported");
           TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -1726,7 +1745,7 @@ HttpTransact::setup_plugin_request_intercept(State *s)
 void
 HttpTransact::HandleApiErrorJump(State *s)
 {
-  TxnDebug("http_trans", "[HttpTransact::HandleApiErrorJump]");
+  TxnDbg(http_trans_dbg_ctl, "[HttpTransact::HandleApiErrorJump]");
 
   // since the READ_REQUEST_HDR_HOOK is processed before
   //   we examine the request, returning TS_EVENT_ERROR will cause
@@ -1793,7 +1812,7 @@ HttpTransact::PPDNSLookupAPICall(State *s)
 void
 HttpTransact::PPDNSLookup(State *s)
 {
-  TxnDebug("http_trans", "[HttpTransact::PPDNSLookup]");
+  TxnDbg(http_trans_dbg_ctl, "[HttpTransact::PPDNSLookup]");
 
   ink_assert(s->dns_info.looking_up == PARENT_PROXY);
   if (!s->dns_info.lookup_success) {
@@ -1831,8 +1850,8 @@ HttpTransact::PPDNSLookup(State *s)
     get_ka_info_from_host_db(s, &s->parent_info, &s->client_info, &s->host_db_info);
 
     char addrbuf[INET6_ADDRSTRLEN];
-    TxnDebug("http_trans", "[PPDNSLookup] DNS lookup for sm_id[%" PRId64 "] successful IP: %s", s->state_machine->sm_id,
-             ats_ip_ntop(&s->parent_info.dst_addr.sa, addrbuf, sizeof(addrbuf)));
+    TxnDbg(http_trans_dbg_ctl, "[PPDNSLookup] DNS lookup for sm_id[%" PRId64 "] successful IP: %s", s->state_machine->sm_id,
+           ats_ip_ntop(&s->parent_info.dst_addr.sa, addrbuf, sizeof(addrbuf)));
   }
 
   // Since this function can be called several times while retrying
@@ -1892,8 +1911,8 @@ HttpTransact::ReDNSRoundRobin(State *s)
     get_ka_info_from_host_db(s, &s->server_info, &s->client_info, &s->host_db_info);
 
     char addrbuf[INET6_ADDRSTRLEN];
-    TxnDebug("http_trans", "[ReDNSRoundRobin] DNS lookup for O.S. successful IP: %s",
-             ats_ip_ntop(&s->server_info.dst_addr.sa, addrbuf, sizeof(addrbuf)));
+    TxnDbg(http_trans_dbg_ctl, "[ReDNSRoundRobin] DNS lookup for O.S. successful IP: %s",
+           ats_ip_ntop(&s->server_info.dst_addr.sa, addrbuf, sizeof(addrbuf)));
 
     s->next_action = how_to_open_connection(s);
   } else {
@@ -1942,11 +1961,11 @@ HttpTransact::OSDNSLookup(State *s)
 {
   ink_assert(s->dns_info.looking_up == ORIGIN_SERVER);
 
-  TxnDebug("http_trans", "[HttpTransact::OSDNSLookup]");
+  TxnDbg(http_trans_dbg_ctl, "[HttpTransact::OSDNSLookup]");
 
   // It's never valid to connect *to* INADDR_ANY, so let's reject the request now.
   if (ats_is_ip_any(s->host_db_info.ip())) {
-    TxnDebug("http_trans", "[OSDNSLookup] Invalid request IP: INADDR_ANY");
+    TxnDbg(http_trans_dbg_ctl, "[OSDNSLookup] Invalid request IP: INADDR_ANY");
     build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Bad Destination Address", "request#syntax_error");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -1960,9 +1979,9 @@ HttpTransact::OSDNSLookup(State *s)
        */
       s->dns_info.lookup_success = true;
       s->dns_info.os_addr_style  = DNSLookupInfo::OS_Addr::OS_ADDR_USE_CLIENT;
-      TxnDebug("http_seq", "[HttpTransact::OSDNSLookup] DNS lookup unsuccessful, using client target address");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::OSDNSLookup] DNS lookup unsuccessful, using client target address");
     } else {
-      TxnDebug("http_seq", "[HttpTransact::OSDNSLookup] DNS Lookup unsuccessful");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::OSDNSLookup] DNS Lookup unsuccessful");
 
       // output the DNS failure error message
       SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
@@ -1979,7 +1998,7 @@ HttpTransact::OSDNSLookup(State *s)
 
   // The dns lookup succeeded
   ink_assert(s->dns_info.lookup_success);
-  TxnDebug("http_seq", "[HttpTransact::OSDNSLookup] DNS Lookup successful");
+  TxnDbg(http_seq_dbg_ctl, "[HttpTransact::OSDNSLookup] DNS Lookup successful");
 
   // For the transparent case, nail down the kind of address we are really using
   if (DNSLookupInfo::OS_Addr::OS_ADDR_TRY_HOSTDB == s->dns_info.os_addr_style) {
@@ -2017,10 +2036,10 @@ HttpTransact::OSDNSLookup(State *s)
   get_ka_info_from_host_db(s, &s->server_info, &s->client_info, &s->host_db_info);
 
   char addrbuf[INET6_ADDRSTRLEN];
-  TxnDebug("http_trans",
-           "[OSDNSLookup] DNS lookup for O.S. successful "
-           "IP: %s",
-           ats_ip_ntop(&s->server_info.dst_addr.sa, addrbuf, sizeof(addrbuf)));
+  TxnDbg(http_trans_dbg_ctl,
+         "[OSDNSLookup] DNS lookup for O.S. successful "
+         "IP: %s",
+         ats_ip_ntop(&s->server_info.dst_addr.sa, addrbuf, sizeof(addrbuf)));
 
   if (s->redirect_info.redirect_in_process) {
     // If dns lookup was not successful, the code below will handle the error.
@@ -2036,13 +2055,13 @@ HttpTransact::OSDNSLookup(State *s)
     }
 
     if (action == RedirectEnabled::Action::FOLLOW) {
-      TxnDebug("http_trans", "[OSDNSLookup] Invalid redirect address. Following");
+      TxnDbg(http_trans_dbg_ctl, "[OSDNSLookup] Invalid redirect address. Following");
     } else if (action == RedirectEnabled::Action::REJECT || s->hdr_info.server_response.valid() == false) {
       if (action == RedirectEnabled::Action::REJECT) {
-        TxnDebug("http_trans", "[OSDNSLookup] Invalid redirect address. Rejecting.");
+        TxnDbg(http_trans_dbg_ctl, "[OSDNSLookup] Invalid redirect address. Rejecting.");
       } else {
         // Invalid server response, since we can't copy it we are going to reject
-        TxnDebug("http_trans", "[OSDNSLookup] Invalid server response. Rejecting.");
+        TxnDbg(http_trans_dbg_ctl, "[OSDNSLookup] Invalid server response. Rejecting.");
         Error("Invalid server response. Rejecting.");
       }
       build_error_response(s, HTTP_STATUS_FORBIDDEN, nullptr, "request#syntax_error");
@@ -2051,9 +2070,9 @@ HttpTransact::OSDNSLookup(State *s)
     } else {
       // Return this 3xx to the client as-is
       if (action == RedirectEnabled::Action::RETURN) {
-        TxnDebug("http_trans", "[OSDNSLookup] Configured to return on invalid redirect address.");
+        TxnDbg(http_trans_dbg_ctl, "[OSDNSLookup] Configured to return on invalid redirect address.");
       } else {
-        TxnDebug("http_trans", "[OSDNSLookup] Invalid redirect address. Returning.");
+        TxnDbg(http_trans_dbg_ctl, "[OSDNSLookup] Invalid redirect address. Returning.");
       }
       build_response_copy(s, &s->hdr_info.server_response, &s->hdr_info.client_response, s->client_info.http_version);
       TRANSACT_RETURN(SM_ACTION_INTERNAL_CACHE_NOOP, nullptr);
@@ -2154,8 +2173,8 @@ HttpTransact::DecideCacheLookup(State *s)
 
   // now decide whether the cache can even be looked up.
   if (s->cache_info.action == CACHE_DO_LOOKUP) {
-    TxnDebug("http_trans", "[DecideCacheLookup] Will do cache lookup.");
-    TxnDebug("http_seq", "[DecideCacheLookup] Will do cache lookup");
+    TxnDbg(http_trans_dbg_ctl, "[DecideCacheLookup] Will do cache lookup.");
+    TxnDbg(http_seq_dbg_ctl, "[DecideCacheLookup] Will do cache lookup");
     ink_assert(s->current.mode != TUNNELLING_PROXY);
 
     if (s->cache_info.lookup_url == nullptr) {
@@ -2202,8 +2221,8 @@ HttpTransact::DecideCacheLookup(State *s)
   } else {
     ink_assert(s->cache_info.action != CACHE_DO_LOOKUP && s->cache_info.action != CACHE_DO_SERVE);
 
-    TxnDebug("http_trans", "[DecideCacheLookup] Will NOT do cache lookup.");
-    TxnDebug("http_seq", "[DecideCacheLookup] Will NOT do cache lookup");
+    TxnDbg(http_trans_dbg_ctl, "[DecideCacheLookup] Will NOT do cache lookup.");
+    TxnDbg(http_seq_dbg_ctl, "[DecideCacheLookup] Will NOT do cache lookup");
     // If this is a push request, we need send an error because
     //   since what ever was sent is not cacheable
     if (s->method == HTTP_WKSIDX_PUSH) {
@@ -2414,7 +2433,7 @@ HttpTransact::HandlePushError(State *s, const char *reason)
 void
 HttpTransact::HandleCacheOpenRead(State *s)
 {
-  TxnDebug("http_trans", "[HttpTransact::HandleCacheOpenRead]");
+  TxnDbg(http_trans_dbg_ctl, "[HttpTransact::HandleCacheOpenRead]");
 
   SET_VIA_STRING(VIA_DETAIL_CACHE_TYPE, VIA_DETAIL_CACHE);
 
@@ -2444,7 +2463,7 @@ HttpTransact::HandleCacheOpenRead(State *s)
     HandleCacheOpenReadPush(s, read_successful);
   } else if (read_successful == false) {
     // cache miss
-    TxnDebug("http_trans", "CacheOpenRead -- miss");
+    TxnDbg(http_trans_dbg_ctl, "CacheOpenRead -- miss");
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_NOT_CACHED);
     // Perform DNS for the origin when it is required.
     // 1. If parent configuration does not allow to go to origin there is no need of performing DNS
@@ -2452,7 +2471,7 @@ HttpTransact::HandleCacheOpenRead(State *s)
     HandleCacheOpenReadMiss(s);
   } else {
     // cache hit
-    TxnDebug("http_trans", "CacheOpenRead -- hit");
+    TxnDbg(http_trans_dbg_ctl, "CacheOpenRead -- hit");
     TRANSACT_RETURN(SM_ACTION_API_READ_CACHE_HDR, HandleCacheOpenReadHitFreshness);
   }
 
@@ -2502,10 +2521,10 @@ HttpTransact::issue_revalidate(State *s)
     // action should be when the response is received.
     if (does_method_require_cache_copy_deletion(s->http_config_param, s->method)) {
       s->cache_info.action = CACHE_PREPARE_TO_DELETE;
-      TxnDebug("http_seq", "[HttpTransact::issue_revalidate] cache action: DELETE");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::issue_revalidate] cache action: DELETE");
     } else {
       s->cache_info.action = CACHE_PREPARE_TO_UPDATE;
-      TxnDebug("http_seq", "[HttpTransact::issue_revalidate] cache action: UPDATE");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::issue_revalidate] cache action: UPDATE");
     }
   } else {
     // We've looped back around due to missing the write lock
@@ -2529,15 +2548,15 @@ HttpTransact::issue_revalidate(State *s)
   bool no_cache_in_request = false;
 
   if (s->hdr_info.client_request.is_pragma_no_cache_set() || s->hdr_info.client_request.is_cache_control_set(HTTP_VALUE_NO_CACHE)) {
-    TxnDebug("http_trans", "[issue_revalidate] no-cache header directive in request, folks");
+    TxnDbg(http_trans_dbg_ctl, "[issue_revalidate] no-cache header directive in request, folks");
     no_cache_in_request = true;
   }
 
   if ((!(s->hdr_info.client_request.presence(MIME_PRESENCE_IF_MODIFIED_SINCE))) &&
       (!(s->hdr_info.client_request.presence(MIME_PRESENCE_IF_NONE_MATCH))) && (no_cache_in_request == true) &&
       (!s->txn_conf->cache_ims_on_client_no_cache) && (s->www_auth_content == CACHE_AUTH_NONE)) {
-    TxnDebug("http_trans",
-             "[issue_revalidate] Can not make this a conditional request. This is the force update of the cached copy case");
+    TxnDbg(http_trans_dbg_ctl,
+           "[issue_revalidate] Can not make this a conditional request. This is the force update of the cached copy case");
     // set cache action to update. response will be a 200 or error,
     // causing cached copy to be replaced (if 200).
     s->cache_info.action = CACHE_PREPARE_TO_UPDATE;
@@ -2590,8 +2609,8 @@ HttpTransact::issue_revalidate(State *s)
   case HTTP_STATUS_GONE: // 410
   /* fall through */
   default:
-    TxnDebug("http_trans", "[issue_revalidate] cached response is"
-                           "not a 200 response so no conditionalization.");
+    TxnDbg(http_trans_dbg_ctl, "[issue_revalidate] cached response is"
+                               "not a 200 response so no conditionalization.");
     s->cache_info.action = CACHE_PREPARE_TO_UPDATE;
     break;
   case HTTP_STATUS_PARTIAL_CONTENT:
@@ -2606,10 +2625,10 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
   CacheHTTPInfo *&obj = s->cache_info.object_read;
 
   ink_release_assert((s->request_sent_time == UNDEFINED_TIME) && (s->response_received_time == UNDEFINED_TIME));
-  TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHitFreshness] Hit in cache");
+  TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHitFreshness] Hit in cache");
 
   if (delete_all_document_alternates_and_return(s, true)) {
-    TxnDebug("http_trans", "[HandleCacheOpenReadHitFreshness] Delete and return");
+    TxnDbg(http_trans_dbg_ctl, "[HandleCacheOpenReadHitFreshness] Delete and return");
     s->cache_info.action = CACHE_DO_DELETE;
     s->next_action       = HttpTransact::SM_ACTION_INTERNAL_CACHE_DELETE;
     return;
@@ -2628,8 +2647,9 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
 
   ink_assert(s->request_sent_time <= s->response_received_time);
 
-  TxnDebug("http_trans", "[HandleCacheOpenReadHitFreshness] request_sent_time      : %" PRId64, (int64_t)s->request_sent_time);
-  TxnDebug("http_trans", "[HandleCacheOpenReadHitFreshness] response_received_time : %" PRId64, (int64_t)s->response_received_time);
+  TxnDbg(http_trans_dbg_ctl, "[HandleCacheOpenReadHitFreshness] request_sent_time      : %" PRId64, (int64_t)s->request_sent_time);
+  TxnDbg(http_trans_dbg_ctl, "[HandleCacheOpenReadHitFreshness] response_received_time : %" PRId64,
+         (int64_t)s->response_received_time);
   // if the plugin has already decided the freshness, we don't need to
   // do it again
   if (s->cache_lookup_result == HttpTransact::CACHE_LOOKUP_NONE) {
@@ -2638,18 +2658,18 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
     Freshness_t freshness = what_is_document_freshness(s, &s->hdr_info.client_request, obj->response_get());
     switch (freshness) {
     case FRESHNESS_FRESH:
-      TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHitFreshness] "
-                           "Fresh copy");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHitFreshness] "
+                               "Fresh copy");
       s->cache_lookup_result = HttpTransact::CACHE_LOOKUP_HIT_FRESH;
       break;
     case FRESHNESS_WARNING:
-      TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHitFreshness] "
-                           "Heuristic-based Fresh copy");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHitFreshness] "
+                               "Heuristic-based Fresh copy");
       s->cache_lookup_result = HttpTransact::CACHE_LOOKUP_HIT_WARNING;
       break;
     case FRESHNESS_STALE:
-      TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHitFreshness] "
-                           "Stale in cache");
+      TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHitFreshness] "
+                               "Stale in cache");
       s->cache_lookup_result = HttpTransact::CACHE_LOOKUP_HIT_STALE;
       break;
     default:
@@ -2685,11 +2705,11 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
 void
 HttpTransact::CallOSDNSLookup(State *s)
 {
-  TxnDebug("http", "[HttpTransact::callos] %s ", s->server_info.name);
+  TxnDbg(http_dbg_ctl, "[HttpTransact::callos] %s ", s->server_info.name);
   HostStatus &pstatus = HostStatus::instance();
   HostStatRec *hst    = pstatus.getHostStatus(s->server_info.name);
   if (hst && hst->status == TSHostStatus::TS_HOST_STATUS_DOWN) {
-    TxnDebug("http", "[HttpTransact::callos] %d ", s->cache_lookup_result);
+    TxnDbg(http_dbg_ctl, "[HttpTransact::callos] %d ", s->cache_lookup_result);
     s->current.state = OUTBOUND_CONGESTION;
     if (s->cache_lookup_result == CACHE_LOOKUP_HIT_STALE || s->cache_lookup_result == CACHE_LOOKUP_HIT_WARNING ||
         s->cache_lookup_result == CACHE_LOOKUP_HIT_FRESH) {
@@ -2733,24 +2753,24 @@ HttpTransact::need_to_revalidate(State *s)
 
   switch (authentication_needed) {
   case AUTHENTICATION_SUCCESS:
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication not needed");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication not needed");
     needs_authenticate = false;
     break;
   case AUTHENTICATION_MUST_REVALIDATE:
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_METHOD);
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication needed");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication needed");
     needs_authenticate = true;
     break;
   case AUTHENTICATION_MUST_PROXY:
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication needed");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication needed");
     needs_authenticate = true;
     break;
   case AUTHENTICATION_CACHE_AUTH:
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication needed for cache_auth_content");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication needed for cache_auth_content");
     needs_authenticate = false;
     needs_cache_auth   = true;
     break;
@@ -2830,24 +2850,24 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
 
   switch (authentication_needed) {
   case AUTHENTICATION_SUCCESS:
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication not needed");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication not needed");
     needs_authenticate = false;
     break;
   case AUTHENTICATION_MUST_REVALIDATE:
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_METHOD);
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication needed");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication needed");
     needs_authenticate = true;
     break;
   case AUTHENTICATION_MUST_PROXY:
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication needed");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication needed");
     HandleCacheOpenReadMiss(s);
     return;
   case AUTHENTICATION_CACHE_AUTH:
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Authentication needed for cache_auth_content");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Authentication needed for cache_auth_content");
     needs_authenticate = false;
     needs_cache_auth   = true;
     break;
@@ -2900,17 +2920,17 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
     send_revalidate     = true;
   }
 
-  TxnDebug("http_trans", "CacheOpenRead --- needs_auth          = %d", needs_authenticate);
-  TxnDebug("http_trans", "CacheOpenRead --- needs_revalidate    = %d", needs_revalidate);
-  TxnDebug("http_trans", "CacheOpenRead --- response_returnable = %d", response_returnable);
-  TxnDebug("http_trans", "CacheOpenRead --- needs_cache_auth    = %d", needs_cache_auth);
-  TxnDebug("http_trans", "CacheOpenRead --- send_revalidate     = %d", send_revalidate);
+  TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- needs_auth          = %d", needs_authenticate);
+  TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- needs_revalidate    = %d", needs_revalidate);
+  TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- response_returnable = %d", response_returnable);
+  TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- needs_cache_auth    = %d", needs_cache_auth);
+  TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- send_revalidate     = %d", send_revalidate);
 
   if (send_revalidate) {
-    TxnDebug("http_trans", "CacheOpenRead --- HIT-STALE");
+    TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- HIT-STALE");
 
-    TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                         "Revalidate document with server");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                             "Revalidate document with server");
 
     find_server_and_update_current_info(s);
 
@@ -2926,7 +2946,7 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
         is_stale_cache_response_returnable(s) == true) {
       server_up = false;
       update_current_info(&s->current, nullptr, UNDEFINED_LOOKUP, 0);
-      TxnDebug("http_trans", "CacheOpenReadHit - server_down, returning stale document");
+      TxnDbg(http_trans_dbg_ctl, "CacheOpenReadHit - server_down, returning stale document");
     }
     // a parent lookup could come back as PARENT_FAIL if in parent.config, go_direct == false and
     // there are no available parents (all down).
@@ -2934,7 +2954,7 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
       if (is_server_negative_cached(s) && response_returnable == true && is_stale_cache_response_returnable(s) == true) {
         server_up = false;
         update_current_info(&s->current, nullptr, UNDEFINED_LOOKUP, 0);
-        TxnDebug("http_trans", "CacheOpenReadHit - server_down, returning stale document");
+        TxnDbg(http_trans_dbg_ctl, "CacheOpenReadHit - server_down, returning stale document");
       } else {
         handle_parent_died(s);
         return;
@@ -2947,7 +2967,7 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
 
       if (s->current.server != nullptr) {
         bool check_hostdb = get_ka_info_from_config(s, s->current.server);
-        TxnDebug("http_trans", "CacheOpenReadHit - check_hostdb %d", check_hostdb);
+        TxnDbg(http_trans_dbg_ctl, "CacheOpenReadHit - check_hostdb %d", check_hostdb);
         if (check_hostdb || !s->current.server->dst_addr.isValid()) {
           // We must be going a PARENT PROXY since so did
           //  origin server DNS lookup right after state Start
@@ -2974,7 +2994,7 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
         http_version = s->current.server->http_version;
       }
 
-      TxnDebug("http_trans", "CacheOpenReadHit - version %d.%d", http_version.get_major(), http_version.get_minor());
+      TxnDbg(http_trans_dbg_ctl, "CacheOpenReadHit - version %d.%d", http_version.get_major(), http_version.get_minor());
       build_request(s, &s->hdr_info.client_request, &s->hdr_info.server_request, http_version);
 
       issue_revalidate(s);
@@ -3010,9 +3030,9 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
   //
   ink_assert((send_revalidate == true && server_up == false) || (send_revalidate == false && server_up == true));
 
-  TxnDebug("http_trans", "CacheOpenRead --- HIT-FRESH");
-  TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
-                       "Serve from cache");
+  TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- HIT-FRESH");
+  TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] "
+                           "Serve from cache");
 
   // ToDo: Should support other levels of cache hits here, but the cache does not support it (yet)
   if (SQUID_HIT_RAM == s->cache_info.hit_miss_code) {
@@ -3022,7 +3042,7 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
   }
 
   HttpCacheSM &cache_sm = s->state_machine->get_cache_sm();
-  TxnDebug("http_trans", "CacheOpenRead --- HIT-FRESH read while write %d", cache_sm.is_readwhilewrite_inprogress());
+  TxnDbg(http_trans_dbg_ctl, "CacheOpenRead --- HIT-FRESH read while write %d", cache_sm.is_readwhilewrite_inprogress());
   if (cache_sm.is_readwhilewrite_inprogress())
     SET_VIA_STRING(VIA_CACHE_RESULT, VIA_IN_CACHE_RWW_HIT);
 
@@ -3085,7 +3105,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
   case HTTP_STATUS_NOT_MODIFIED:
     // A IMS or INM GET client request with conditions being met
     // by the cached response.  Send back a NOT MODIFIED response.
-    TxnDebug("http_trans", "[build_response_from_cache] Not modified");
+    TxnDbg(http_trans_dbg_ctl, "[build_response_from_cache] Not modified");
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_HIT_CONDITIONAL);
 
     build_response(s, cached_response, &s->hdr_info.client_response, s->client_info.http_version, client_response_code);
@@ -3096,7 +3116,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
   case HTTP_STATUS_PRECONDITION_FAILED:
     // A conditional request with conditions not being met by the cached
     // response.  Send back a PRECONDITION FAILED response.
-    TxnDebug("http_trans", "[build_response_from_cache] Precondition Failed");
+    TxnDbg(http_trans_dbg_ctl, "[build_response_from_cache] Precondition Failed");
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_CONDITIONAL);
 
     build_response(s, &s->hdr_info.client_response, s->client_info.http_version, client_response_code);
@@ -3115,7 +3135,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
     if (s->method == HTTP_WKSIDX_GET || (s->http_config_param->cache_post_method == 1 && s->method == HTTP_WKSIDX_POST) ||
         s->api_resp_cacheable == true) {
       // send back the full document to the client.
-      TxnDebug("http_trans", "[build_response_from_cache] Match! Serving full document.");
+      TxnDbg(http_trans_dbg_ctl, "[build_response_from_cache] Match! Serving full document.");
       s->cache_info.action = CACHE_DO_SERVE;
 
       // Check if cached response supports Range. If it does, append
@@ -3133,7 +3153,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
           // or if the range can't be satisfied from the cache
           // In that case we fetch the entire source so it's OK to switch
           // this late.
-          TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] Out-of-order Range request - tunneling");
+          TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadHit] Out-of-order Range request - tunneling");
           s->cache_info.action = CACHE_DO_NO_ACTION;
           if (s->force_dns) {
             HandleCacheOpenReadMiss(s); // DNS is already completed no need of doing DNS
@@ -3154,7 +3174,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
     }
     // If the client request is a HEAD, then serve the header from cache.
     else if (s->method == HTTP_WKSIDX_HEAD) {
-      TxnDebug("http_trans", "[build_response_from_cache] Match! Serving header only.");
+      TxnDbg(http_trans_dbg_ctl, "[build_response_from_cache] Match! Serving header only.");
 
       build_response(s, cached_response, &s->hdr_info.client_response, s->client_info.http_version);
       s->cache_info.action = CACHE_DO_NO_ACTION;
@@ -3163,7 +3183,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
       // We handled the request but it's not GET or HEAD (eg. DELETE),
       // and server is not reachable: 502
       //
-      TxnDebug("http_trans", "[build_response_from_cache] No match! Connection failed.");
+      TxnDbg(http_trans_dbg_ctl, "[build_response_from_cache] No match! Connection failed.");
       build_error_response(s, HTTP_STATUS_BAD_GATEWAY, "Connection Failed", "connect#failed_connect");
       s->cache_info.action = CACHE_DO_NO_ACTION;
       s->next_action       = SM_ACTION_INTERNAL_CACHE_NOOP;
@@ -3212,7 +3232,7 @@ HttpTransact::handle_cache_write_lock(State *s)
     case CACHE_WL_FAIL_ACTION_ERROR_ON_MISS:
     case CACHE_WL_FAIL_ACTION_ERROR_ON_MISS_STALE_ON_REVALIDATE:
     case CACHE_WL_FAIL_ACTION_ERROR_ON_MISS_OR_REVALIDATE:
-      TxnDebug("http_error", "cache_open_write_fail_action %d, cache miss, return error", s->cache_open_write_fail_action);
+      TxnDbg(http_error_dbg_ctl, "cache_open_write_fail_action %d, cache miss, return error", s->cache_open_write_fail_action);
       s->cache_info.write_status = CACHE_WRITE_ERROR;
       build_error_response(s, HTTP_STATUS_BAD_GATEWAY, "Connection Failed", "connect#failed_connect");
       MIMEField *ats_field;
@@ -3225,10 +3245,10 @@ HttpTransact::handle_cache_write_lock(State *s)
       }
       if (likely(ats_field)) {
         int value = (s->cache_info.object_read) ? 1 : 0;
-        TxnDebug("http_error", "Adding Ats-Internal-Messages: %d", value);
+        TxnDbg(http_error_dbg_ctl, "Adding Ats-Internal-Messages: %d", value);
         header->field_value_set_int(ats_field, value);
       } else {
-        TxnDebug("http_error", "failed to add Ats-Internal-Messages");
+        TxnDbg(http_error_dbg_ctl, "failed to add Ats-Internal-Messages");
       }
 
       TRANSACT_RETURN(SM_ACTION_SEND_ERROR_CACHE_NOOP, nullptr);
@@ -3289,7 +3309,7 @@ HttpTransact::handle_cache_write_lock(State *s)
   }
 
   if (s->cache_info.write_lock_state == CACHE_WL_READ_RETRY) {
-    TxnDebug("http_error", "calling hdr_info.server_request.destroy");
+    TxnDbg(http_error_dbg_ctl, "calling hdr_info.server_request.destroy");
     s->hdr_info.server_request.destroy();
     HandleCacheOpenReadHitFreshness(s);
   } else {
@@ -3325,12 +3345,12 @@ HttpTransact::handle_cache_write_lock(State *s)
 void
 HttpTransact::HandleCacheOpenReadMiss(State *s)
 {
-  TxnDebug("http_trans", "[HandleCacheOpenReadMiss] --- MISS");
-  TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadMiss] "
-                       "Miss in cache");
+  TxnDbg(http_trans_dbg_ctl, "[HandleCacheOpenReadMiss] --- MISS");
+  TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleCacheOpenReadMiss] "
+                           "Miss in cache");
 
   if (delete_all_document_alternates_and_return(s, false)) {
-    TxnDebug("http_trans", "[HandleCacheOpenReadMiss] Delete and return");
+    TxnDbg(http_trans_dbg_ctl, "[HandleCacheOpenReadMiss] Delete and return");
     s->cache_info.action = CACHE_DO_NO_ACTION;
     s->next_action       = SM_ACTION_INTERNAL_CACHE_NOOP;
     return;
@@ -3428,7 +3448,7 @@ HttpTransact::HandleCacheOpenReadMiss(State *s)
 void
 HttpTransact::OriginServerRawOpen(State *s)
 {
-  TxnDebug("http_trans", "[HttpTransact::OriginServerRawOpen]");
+  TxnDbg(http_trans_dbg_ctl, "[HttpTransact::OriginServerRawOpen]");
 
   switch (s->current.state) {
   case STATE_UNDEFINED:
@@ -3449,7 +3469,7 @@ HttpTransact::OriginServerRawOpen(State *s)
   case CONNECTION_ALIVE:
     build_response(s, &s->hdr_info.client_response, s->client_info.http_version, HTTP_STATUS_OK);
 
-    TxnDebug("http_trans", "[OriginServerRawOpen] connection alive. next action is ssl_tunnel");
+    TxnDbg(http_trans_dbg_ctl, "[OriginServerRawOpen] connection alive. next action is ssl_tunnel");
     s->next_action = SM_ACTION_SSL_TUNNEL;
     break;
   default:
@@ -3484,15 +3504,15 @@ HttpTransact::OriginServerRawOpen(State *s)
 void
 HttpTransact::HandleResponse(State *s)
 {
-  TxnDebug("http_trans", "[HttpTransact::HandleResponse]");
-  TxnDebug("http_seq", "[HttpTransact::HandleResponse] Response received");
+  TxnDbg(http_trans_dbg_ctl, "[HttpTransact::HandleResponse]");
+  TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleResponse] Response received");
 
   s->source                 = SOURCE_HTTP_ORIGIN_SERVER;
   s->response_received_time = ink_local_time();
   ink_assert(s->response_received_time >= s->request_sent_time);
   s->current.now = s->response_received_time;
 
-  TxnDebug("http_trans", "[HandleResponse] response_received_time: %" PRId64, (int64_t)s->response_received_time);
+  TxnDbg(http_trans_dbg_ctl, "[HandleResponse] response_received_time: %" PRId64, (int64_t)s->response_received_time);
   DUMP_HEADER("http_hdrs", &s->hdr_info.server_response, s->state_machine_id, "Incoming O.S. Response");
 
   HTTP_INCREMENT_DYN_STAT(http_incoming_responses_stat);
@@ -3507,9 +3527,9 @@ HttpTransact::HandleResponse(State *s)
   }
 
   if (!HttpTransact::is_response_valid(s, &s->hdr_info.server_response)) {
-    TxnDebug("http_seq", "[HttpTransact::HandleResponse] Response not valid");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleResponse] Response not valid");
   } else {
-    TxnDebug("http_seq", "[HttpTransact::HandleResponse] Response valid");
+    TxnDbg(http_seq_dbg_ctl, "[HttpTransact::HandleResponse] Response valid");
     initialize_state_variables_from_response(s, &s->hdr_info.server_response);
   }
 
@@ -3642,7 +3662,7 @@ void
 HttpTransact::handle_response_from_parent(State *s)
 {
   LookingUp_t next_lookup = UNDEFINED_LOOKUP;
-  TxnDebug("http_trans", "[handle_response_from_parent] (hrfp)");
+  TxnDbg(http_trans_dbg_ctl, "[handle_response_from_parent] (hrfp)");
   HTTP_RELEASE_ASSERT(s->current.server == &s->parent_info);
 
   // if this parent was retried from a markdown, then
@@ -3656,7 +3676,7 @@ HttpTransact::handle_response_from_parent(State *s)
   s->parent_info.state = s->current.state;
   switch (s->current.state) {
   case CONNECTION_ALIVE:
-    TxnDebug("http_trans", "[hrfp] connection alive");
+    TxnDbg(http_trans_dbg_ctl, "[hrfp] connection alive");
     s->current.server->connect_result = 0;
     SET_VIA_STRING(VIA_DETAIL_PP_CONNECT, VIA_DETAIL_PP_SUCCESS);
     if (s->parent_result.retry) {
@@ -3665,7 +3685,7 @@ HttpTransact::handle_response_from_parent(State *s)
     // the next hop strategy is configured not
     // to cache a response from a next hop peer.
     if (s->parent_result.do_not_cache_response) {
-      TxnDebug("http_trans", "response is from a next hop peer, do not cache.");
+      TxnDbg(http_trans_dbg_ctl, "response is from a next hop peer, do not cache.");
       s->cache_info.action = CACHE_DO_NO_ACTION;
     }
     handle_forward_server_connection_open(s);
@@ -3681,7 +3701,7 @@ HttpTransact::handle_response_from_parent(State *s)
     s->current.retry_type = PARENT_RETRY_NONE;
     break;
   default:
-    TxnDebug("http_trans", "[hrfp] connection not alive");
+    TxnDbg(http_trans_dbg_ctl, "[hrfp] connection not alive");
     SET_VIA_STRING(VIA_DETAIL_PP_CONNECT, VIA_DETAIL_PP_FAILURE);
 
     ink_assert(s->hdr_info.server_request.valid());
@@ -3694,8 +3714,8 @@ HttpTransact::handle_response_from_parent(State *s)
     }
 
     char addrbuf[INET6_ADDRSTRLEN];
-    TxnDebug("http_trans", "[%d] failed to connect to parent %s", s->current.attempts,
-             ats_ip_ntop(&s->current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
+    TxnDbg(http_trans_dbg_ctl, "[%d] failed to connect to parent %s", s->current.attempts,
+           ats_ip_ntop(&s->current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
 
     // If the request is not retryable, just give up!
     if (!is_request_retryable(s)) {
@@ -3716,11 +3736,11 @@ HttpTransact::handle_response_from_parent(State *s)
         // No we are not done with this parent so retry
         HTTP_INCREMENT_DYN_STAT(http_total_parent_switches_stat);
         s->next_action = how_to_open_connection(s);
-        TxnDebug("http_trans", "%s Retrying parent for attempt %d, max %" PRId64, "[handle_response_from_parent]",
-                 s->current.attempts, s->txn_conf->per_parent_connect_attempts);
+        TxnDbg(http_trans_dbg_ctl, "%s Retrying parent for attempt %d, max %" PRId64, "[handle_response_from_parent]",
+               s->current.attempts, s->txn_conf->per_parent_connect_attempts);
         return;
       } else {
-        TxnDebug("http_trans", "%s %d per parent attempts exhausted", "[handle_response_from_parent]", s->current.attempts);
+        TxnDbg(http_trans_dbg_ctl, "%s %d per parent attempts exhausted", "[handle_response_from_parent]", s->current.attempts);
         HTTP_INCREMENT_DYN_STAT(http_total_parent_retries_exhausted_stat);
 
         // Only mark the parent down if we failed to connect
@@ -3736,7 +3756,7 @@ HttpTransact::handle_response_from_parent(State *s)
       // Done trying parents... fail over to origin server if that is
       //   appropriate
       HTTP_INCREMENT_DYN_STAT(http_total_parent_retries_exhausted_stat);
-      TxnDebug("http_trans", "[handle_response_from_parent] Error. No more retries.");
+      TxnDbg(http_trans_dbg_ctl, "[handle_response_from_parent] Error. No more retries.");
       if (s->current.state == CONNECTION_ERROR) {
         markParentDown(s);
       }
@@ -3788,7 +3808,7 @@ HttpTransact::handle_response_from_parent(State *s)
 void
 HttpTransact::handle_response_from_server(State *s)
 {
-  TxnDebug("http_trans", "[handle_response_from_server] (hrfs)");
+  TxnDbg(http_trans_dbg_ctl, "[handle_response_from_server] (hrfs)");
   HTTP_RELEASE_ASSERT(s->current.server == &s->server_info);
   unsigned max_connect_retries = 0;
 
@@ -3800,13 +3820,13 @@ HttpTransact::handle_response_from_server(State *s)
 
   switch (s->current.state) {
   case CONNECTION_ALIVE:
-    TxnDebug("http_trans", "[hrfs] connection alive");
+    TxnDbg(http_trans_dbg_ctl, "[hrfs] connection alive");
     SET_VIA_STRING(VIA_DETAIL_SERVER_CONNECT, VIA_DETAIL_SERVER_SUCCESS);
     s->current.server->clear_connect_fail();
     handle_forward_server_connection_open(s);
     break;
   case OUTBOUND_CONGESTION:
-    TxnDebug("http_trans", "[handle_response_from_server] Error. congestion control -- congested.");
+    TxnDbg(http_trans_dbg_ctl, "[handle_response_from_server] Error. congestion control -- congested.");
     SET_VIA_STRING(VIA_DETAIL_SERVER_CONNECT, VIA_DETAIL_SERVER_FAILURE);
     s->set_connect_fail(EUSERS); // too many users
     handle_server_connection_not_open(s);
@@ -3826,7 +3846,7 @@ HttpTransact::handle_response_from_server(State *s)
       max_connect_retries = s->txn_conf->connect_attempts_max_retries;
     }
 
-    TxnDebug("http_trans", "max_connect_retries: %d s->current.attempts: %d", max_connect_retries, s->current.attempts);
+    TxnDbg(http_trans_dbg_ctl, "max_connect_retries: %d s->current.attempts: %d", max_connect_retries, s->current.attempts);
 
     if (is_request_retryable(s) && s->current.attempts < max_connect_retries) {
       // If this is a round robin DNS entry & we're tried configured
@@ -3850,7 +3870,7 @@ HttpTransact::handle_response_from_server(State *s)
         return;
       } else {
         retry_server_connection_not_open(s, s->current.state, max_connect_retries);
-        TxnDebug("http_trans", "[handle_response_from_server] Error. Retrying...");
+        TxnDbg(http_trans_dbg_ctl, "[handle_response_from_server] Error. Retrying...");
         s->next_action = how_to_open_connection(s);
 
         if (s->api_server_addr_set) {
@@ -3866,13 +3886,13 @@ HttpTransact::handle_response_from_server(State *s)
       }
     } else {
       error_log_connection_failure(s, s->current.state);
-      TxnDebug("http_trans", "[handle_response_from_server] Error. No more retries.");
+      TxnDbg(http_trans_dbg_ctl, "[handle_response_from_server] Error. No more retries.");
       SET_VIA_STRING(VIA_DETAIL_SERVER_CONNECT, VIA_DETAIL_SERVER_FAILURE);
       handle_server_connection_not_open(s);
     }
     break;
   case ACTIVE_TIMEOUT:
-    TxnDebug("http_trans", "[hrfs] connection not alive");
+    TxnDbg(http_trans_dbg_ctl, "[hrfs] connection not alive");
     SET_VIA_STRING(VIA_DETAIL_SERVER_CONNECT, VIA_DETAIL_SERVER_FAILURE);
     s->set_connect_fail(ETIMEDOUT);
     handle_server_connection_not_open(s);
@@ -3902,16 +3922,16 @@ HttpTransact::delete_server_rr_entry(State *s, int max_retries)
 {
   char addrbuf[INET6_ADDRSTRLEN];
 
-  TxnDebug("http_trans", "[%d] failed to connect to %s", s->current.attempts,
-           ats_ip_ntop(&s->current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
-  TxnDebug("http_trans", "[delete_server_rr_entry] marking rr entry "
-                         "down and finding next one");
+  TxnDbg(http_trans_dbg_ctl, "[%d] failed to connect to %s", s->current.attempts,
+         ats_ip_ntop(&s->current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
+  TxnDbg(http_trans_dbg_ctl, "[delete_server_rr_entry] marking rr entry "
+                             "down and finding next one");
   ink_assert(s->current.server->had_connect_fail());
   ink_assert(s->current.request_to == ORIGIN_SERVER);
   ink_assert(s->current.server == &s->server_info);
   update_dns_info(&s->dns_info, &s->current);
   s->current.attempts++;
-  TxnDebug("http_trans", "[delete_server_rr_entry] attempts now: %d, max: %d", s->current.attempts, max_retries);
+  TxnDbg(http_trans_dbg_ctl, "[delete_server_rr_entry] attempts now: %d, max: %d", s->current.attempts, max_retries);
   TRANSACT_RETURN(SM_ACTION_ORIGIN_SERVER_RR_MARK_DOWN, ReDNSRoundRobin);
 }
 
@@ -3919,8 +3939,8 @@ void
 HttpTransact::error_log_connection_failure(State *s, ServerState_t conn_state)
 {
   char addrbuf[INET6_ADDRSTRLEN];
-  TxnDebug("http_trans", "[%d] failed to connect [%d] to %s", s->current.attempts, conn_state,
-           ats_ip_ntop(&s->current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
+  TxnDbg(http_trans_dbg_ctl, "[%d] failed to connect [%d] to %s", s->current.attempts, conn_state,
+         ats_ip_ntop(&s->current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
 
   if (s->current.server->had_connect_fail()) {
     char *url_str             = s->hdr_info.client_request.url_string_get(&s->arena);
@@ -3973,7 +3993,7 @@ HttpTransact::retry_server_connection_not_open(State *s, ServerState_t conn_stat
   s->current.server->keep_alive = HTTP_NO_KEEPALIVE;
   s->current.attempts++;
 
-  TxnDebug("http_trans", "[retry_server_connection_not_open] attempts now: %d, max: %d", s->current.attempts, max_retries);
+  TxnDbg(http_trans_dbg_ctl, "[retry_server_connection_not_open] attempts now: %d, max: %d", s->current.attempts, max_retries);
 
   return;
 }
@@ -3993,8 +4013,8 @@ HttpTransact::handle_server_connection_not_open(State *s)
 {
   bool serve_from_cache = false;
 
-  TxnDebug("http_trans", "[handle_server_connection_not_open] (hscno)");
-  TxnDebug("http_seq", "[HttpTransact::handle_server_connection_not_open] ");
+  TxnDbg(http_trans_dbg_ctl, "[handle_server_connection_not_open] (hscno)");
+  TxnDbg(http_seq_dbg_ctl, "[HttpTransact::handle_server_connection_not_open] ");
   ink_assert(s->current.state != CONNECTION_ALIVE);
 
   SET_VIA_STRING(VIA_SERVER_RESULT, VIA_SERVER_ERROR);
@@ -4044,7 +4064,7 @@ HttpTransact::handle_server_connection_not_open(State *s)
     ink_assert(s->cache_info.action == CACHE_DO_UPDATE || s->cache_info.action == CACHE_DO_SERVE);
     ink_assert(s->internal_msg_buffer == nullptr);
     s->source = SOURCE_CACHE;
-    TxnDebug("http_trans", "[hscno] serving stale doc to client");
+    TxnDbg(http_trans_dbg_ctl, "[hscno] serving stale doc to client");
     build_response_from_cache(s, HTTP_WARNING_CODE_REVALIDATION_FAILED);
   } else {
     handle_server_died(s);
@@ -4072,15 +4092,15 @@ HttpTransact::handle_server_connection_not_open(State *s)
 void
 HttpTransact::handle_forward_server_connection_open(State *s)
 {
-  TxnDebug("http_trans", "[handle_forward_server_connection_open] (hfsco)");
-  TxnDebug("http_seq", "[HttpTransact::handle_server_connection_open] ");
+  TxnDbg(http_trans_dbg_ctl, "[handle_forward_server_connection_open] (hfsco)");
+  TxnDbg(http_seq_dbg_ctl, "[HttpTransact::handle_server_connection_open] ");
   ink_release_assert(s->current.state == CONNECTION_ALIVE);
 
   HTTPVersion real_version = s->state_machine->get_server_version(s->hdr_info.server_response);
   if (real_version != s->host_db_info.app.http_data.http_version) {
     // Need to update the hostdb
     s->updated_server_version = real_version;
-    TxnDebug("http_trans", "Update hostdb history of server HTTP version 0x%x", s->updated_server_version.get_flat_version());
+    TxnDbg(http_trans_dbg_ctl, "Update hostdb history of server HTTP version 0x%x", s->updated_server_version.get_flat_version());
   }
 
   s->state_machine->do_hostdb_update_if_necessary();
@@ -4119,7 +4139,7 @@ HttpTransact::handle_forward_server_connection_open(State *s)
       case HTTP_STATUS_PERMANENT_REDIRECT: // 308
         break;
       default:
-        TxnDebug("http_trans", "[hfsco] redirect in progress, non-3xx response, setting cache_do_write");
+        TxnDbg(http_trans_dbg_ctl, "[hfsco] redirect in progress, non-3xx response, setting cache_do_write");
         if (cw_vc && s->txn_conf->cache_http) {
           s->cache_info.action = CACHE_DO_WRITE;
         }
@@ -4134,7 +4154,7 @@ HttpTransact::handle_forward_server_connection_open(State *s)
   case CACHE_DO_UPDATE:
   /* fall through */
   case CACHE_DO_DELETE:
-    TxnDebug("http_trans", "[hfsco] cache action: %s", HttpDebugNames::get_cache_action_name(s->cache_info.action));
+    TxnDbg(http_trans_dbg_ctl, "[hfsco] cache action: %s", HttpDebugNames::get_cache_action_name(s->cache_info.action));
     handle_cache_operation_on_forward_server_response(s);
     break;
   case CACHE_PREPARE_TO_DELETE:
@@ -4155,7 +4175,7 @@ HttpTransact::handle_forward_server_connection_open(State *s)
   /* fall through */
   default:
     // Just tunnel?
-    TxnDebug("http_trans", "[hfsco] cache action: %s", HttpDebugNames::get_cache_action_name(s->cache_info.action));
+    TxnDbg(http_trans_dbg_ctl, "[hfsco] cache action: %s", HttpDebugNames::get_cache_action_name(s->cache_info.action));
     handle_no_cache_operation_on_forward_server_response(s);
     break;
   }
@@ -4263,8 +4283,8 @@ HttpTransact::build_response_copy(State *s, HTTPHdr *base_response, HTTPHdr *out
 void
 HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
 {
-  TxnDebug("http_trans", "[handle_cache_operation_on_forward_server_response] (hcoofsr)");
-  TxnDebug("http_seq", "[handle_cache_operation_on_forward_server_response]");
+  TxnDbg(http_trans_dbg_ctl, "[handle_cache_operation_on_forward_server_response] (hcoofsr)");
+  TxnDbg(http_seq_dbg_ctl, "[handle_cache_operation_on_forward_server_response]");
 
   HTTPHdr *base_response          = nullptr;
   HTTPStatus server_response_code = HTTP_STATUS_NONE;
@@ -4273,7 +4293,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
   bool cacheable                  = false;
 
   cacheable = is_response_cacheable(s, &s->hdr_info.client_request, &s->hdr_info.server_response);
-  TxnDebug("http_trans", "[hcoofsr] response %s cacheable", cacheable ? "is" : "is not");
+  TxnDbg(http_trans_dbg_ctl, "[hcoofsr] response %s cacheable", cacheable ? "is" : "is not");
 
   // set the correct next action, cache action, response code, and base response
 
@@ -4290,8 +4310,8 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
       ink_assert(s->cache_info.object_read);
       base_response        = s->cache_info.object_read->response_get();
       s->cache_info.action = CACHE_DO_SERVE;
-      TxnDebug("http_trans", "[hcoofsr] not merging, cache action changed to: %s",
-               HttpDebugNames::get_cache_action_name(s->cache_info.action));
+      TxnDbg(http_trans_dbg_ctl, "[hcoofsr] not merging, cache action changed to: %s",
+             HttpDebugNames::get_cache_action_name(s->cache_info.action));
       s->next_action       = SM_ACTION_SERVE_FROM_CACHE;
       client_response_code = base_response->status_get();
     } else if ((s->cache_info.action == CACHE_DO_DELETE) || ((s->cache_info.action == CACHE_DO_UPDATE) && !cacheable)) {
@@ -4375,7 +4395,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
       // bogus response from server. deal by tunnelling to client.
       // server should not have sent back a 304 because our request
       // should not have been an conditional.
-      TxnDebug("http_trans", "[hcoofsr] 304 for non-conditional request");
+      TxnDbg(http_trans_dbg_ctl, "[hcoofsr] 304 for non-conditional request");
       s->cache_info.action = CACHE_DO_NO_ACTION;
       s->next_action       = SM_ACTION_INTERNAL_CACHE_NOOP;
       client_response_code = s->hdr_info.server_response.status_get();
@@ -4420,7 +4440,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
     return;
 
   default:
-    TxnDebug("http_trans", "[hcoofsr] response code: %d", server_response_code);
+    TxnDbg(http_trans_dbg_ctl, "[hcoofsr] response code: %d", server_response_code);
     SET_VIA_STRING(VIA_SERVER_RESULT, VIA_SERVER_SERVED);
     SET_VIA_STRING(VIA_PROXY_RESULT, VIA_PROXY_SERVED);
 
@@ -4436,7 +4456,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
       HTTPStatus cached_response_code = s->cache_info.object_read->response_get()->status_get();
       if (!(cached_response_code == HTTP_STATUS_INTERNAL_SERVER_ERROR || cached_response_code == HTTP_STATUS_GATEWAY_TIMEOUT ||
             cached_response_code == HTTP_STATUS_BAD_GATEWAY || cached_response_code == HTTP_STATUS_SERVICE_UNAVAILABLE)) {
-        TxnDebug("http_trans", "[hcoofsr] negative revalidating: revalidate stale object and serve from cache");
+        TxnDbg(http_trans_dbg_ctl, "[hcoofsr] negative revalidating: revalidate stale object and serve from cache");
 
         s->cache_info.object_store.create();
         s->cache_info.object_store.request_set(&s->hdr_info.client_request);
@@ -4513,10 +4533,10 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
       ink_assert(s->cache_info.object_read);
       base_response        = s->cache_info.object_read->response_get();
       s->cache_info.action = CACHE_DO_SERVE;
-      TxnDebug("http_trans",
-               "[hcoofsr] ignoring server response, "
-               "cache action changed to: %s",
-               HttpDebugNames::get_cache_action_name(s->cache_info.action));
+      TxnDbg(http_trans_dbg_ctl,
+             "[hcoofsr] ignoring server response, "
+             "cache action changed to: %s",
+             HttpDebugNames::get_cache_action_name(s->cache_info.action));
       s->next_action       = SM_ACTION_SERVE_FROM_CACHE;
       client_response_code = base_response->status_get();
     } else if (s->cache_info.action == CACHE_DO_UPDATE) {
@@ -4602,10 +4622,10 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
         client_response_code = HttpTransactCache::match_response_to_request_conditionals(
           &s->hdr_info.client_request, &s->hdr_info.server_response, s->response_received_time);
 
-        TxnDebug("http_trans",
-                 "[hcoofsr] conditional request, 200 "
-                 "response, send back 304 if possible [crc=%d]",
-                 client_response_code);
+        TxnDbg(http_trans_dbg_ctl,
+               "[hcoofsr] conditional request, 200 "
+               "response, send back 304 if possible [crc=%d]",
+               client_response_code);
         if ((client_response_code == HTTP_STATUS_NOT_MODIFIED) || (client_response_code == HTTP_STATUS_PRECONDITION_FAILED)) {
           switch (s->cache_info.action) {
           case CACHE_DO_WRITE:
@@ -4636,12 +4656,12 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
   case CACHE_DO_SERVE_AND_DELETE:
   // fall through
   case CACHE_DO_DELETE:
-    TxnDebug("http_trans", "[hcoofsr] delete cached copy");
+    TxnDbg(http_trans_dbg_ctl, "[hcoofsr] delete cached copy");
     SET_VIA_STRING(VIA_CACHE_FILL_ACTION, VIA_CACHE_DELETED);
     HTTP_INCREMENT_DYN_STAT(http_cache_deletes_stat);
     break;
   case CACHE_DO_WRITE:
-    TxnDebug("http_trans", "[hcoofsr] cache write");
+    TxnDbg(http_trans_dbg_ctl, "[hcoofsr] cache write");
     SET_VIA_STRING(VIA_CACHE_FILL_ACTION, VIA_CACHE_WRITTEN);
     HTTP_INCREMENT_DYN_STAT(http_cache_writes_stat);
     break;
@@ -4650,7 +4670,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
   case CACHE_DO_UPDATE:
   // fall through
   case CACHE_DO_REPLACE:
-    TxnDebug("http_trans", "[hcoofsr] cache update/replace");
+    TxnDbg(http_trans_dbg_ctl, "[hcoofsr] cache update/replace");
     SET_VIA_STRING(VIA_CACHE_FILL_ACTION, VIA_CACHE_UPDATED);
     HTTP_INCREMENT_DYN_STAT(http_cache_updates_stat);
     break;
@@ -4661,7 +4681,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
   if ((client_response_code == HTTP_STATUS_NOT_MODIFIED) && (s->cache_info.action != CACHE_DO_NO_ACTION)) {
     /* ink_assert(GET_VIA_STRING(VIA_CLIENT_REQUEST)
        != VIA_CLIENT_SIMPLE); */
-    TxnDebug("http_trans", "[hcoofsr] Client request was conditional");
+    TxnDbg(http_trans_dbg_ctl, "[hcoofsr] Client request was conditional");
     SET_VIA_STRING(VIA_CLIENT_REQUEST, VIA_CLIENT_IMS);
     SET_VIA_STRING(VIA_PROXY_RESULT, VIA_PROXY_NOT_MODIFIED);
   } else {
@@ -4675,7 +4695,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
 
   // first update the cached object
   if ((s->cache_info.action == CACHE_DO_UPDATE) || (s->cache_info.action == CACHE_DO_SERVE_AND_UPDATE)) {
-    TxnDebug("http_trans", "[hcoofsr] merge and update cached copy");
+    TxnDbg(http_trans_dbg_ctl, "[hcoofsr] merge and update cached copy");
     merge_and_update_headers_for_cache_update(s);
     base_response = s->cache_info.object_store.response_get();
     // unset Cache-control: "need-revalidate-once" (if it's set)
@@ -4753,22 +4773,22 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
 void
 HttpTransact::handle_no_cache_operation_on_forward_server_response(State *s)
 {
-  TxnDebug("http_trans", "[handle_no_cache_operation_on_forward_server_response] (hncoofsr)");
-  TxnDebug("http_seq", "[handle_no_cache_operation_on_forward_server_response]");
+  TxnDbg(http_trans_dbg_ctl, "[handle_no_cache_operation_on_forward_server_response] (hncoofsr)");
+  TxnDbg(http_seq_dbg_ctl, "[handle_no_cache_operation_on_forward_server_response]");
 
   bool keep_alive       = s->current.server->keep_alive == HTTP_KEEPALIVE;
   const char *warn_text = nullptr;
 
   switch (s->hdr_info.server_response.status_get()) {
   case HTTP_STATUS_OK:
-    TxnDebug("http_trans", "[hncoofsr] server sent back 200");
+    TxnDbg(http_trans_dbg_ctl, "[hncoofsr] server sent back 200");
     SET_VIA_STRING(VIA_SERVER_RESULT, VIA_SERVER_SERVED);
     SET_VIA_STRING(VIA_PROXY_RESULT, VIA_PROXY_SERVED);
     if (s->method == HTTP_WKSIDX_CONNECT) {
-      TxnDebug("http_trans", "[hncoofsr] next action is SSL_TUNNEL");
+      TxnDbg(http_trans_dbg_ctl, "[hncoofsr] next action is SSL_TUNNEL");
       s->next_action = SM_ACTION_SSL_TUNNEL;
     } else {
-      TxnDebug("http_trans", "[hncoofsr] next action will be OS_READ_CACHE_NOOP");
+      TxnDbg(http_trans_dbg_ctl, "[hncoofsr] next action will be OS_READ_CACHE_NOOP");
 
       ink_assert(s->cache_info.action == CACHE_DO_NO_ACTION);
       s->next_action = SM_ACTION_SERVER_READ;
@@ -4778,7 +4798,7 @@ HttpTransact::handle_no_cache_operation_on_forward_server_response(State *s)
     }
     break;
   case HTTP_STATUS_NOT_MODIFIED:
-    TxnDebug("http_trans", "[hncoofsr] server sent back 304. IMS from client?");
+    TxnDbg(http_trans_dbg_ctl, "[hncoofsr] server sent back 304. IMS from client?");
     SET_VIA_STRING(VIA_SERVER_RESULT, VIA_SERVER_NOT_MODIFIED);
     SET_VIA_STRING(VIA_PROXY_RESULT, VIA_PROXY_NOT_MODIFIED);
 
@@ -4813,7 +4833,7 @@ HttpTransact::handle_no_cache_operation_on_forward_server_response(State *s)
     s->next_action = SM_ACTION_SERVER_READ;
     break;
   default:
-    TxnDebug("http_trans", "[hncoofsr] server sent back something other than 100,304,200");
+    TxnDbg(http_trans_dbg_ctl, "[hncoofsr] server sent back something other than 100,304,200");
     /* Default behavior is to pass-through response to the client */
 
     ink_assert(s->cache_info.action == CACHE_DO_NO_ACTION);
@@ -5230,8 +5250,8 @@ HttpTransact::get_ka_info_from_config(State *s, ConnectionAttributes *server_inf
   bool check_hostdb = false;
 
   if (server_info->http_version > HTTP_0_9) {
-    TxnDebug("http_trans", "get_ka_info_from_config, version already set server_info->http_version %d.%d",
-             server_info->http_version.get_major(), server_info->http_version.get_minor());
+    TxnDbg(http_trans_dbg_ctl, "get_ka_info_from_config, version already set server_info->http_version %d.%d",
+           server_info->http_version.get_major(), server_info->http_version.get_minor());
     return false;
   }
   switch (s->txn_conf->send_http11_requests) {
@@ -5257,8 +5277,8 @@ HttpTransact::get_ka_info_from_config(State *s, ConnectionAttributes *server_inf
     server_info->http_version = HTTP_1_1;
     break;
   }
-  TxnDebug("http_trans", "get_ka_info_from_config, server_info->http_version %d.%d, check_hostdb %d",
-           server_info->http_version.get_major(), server_info->http_version.get_minor(), check_hostdb);
+  TxnDbg(http_trans_dbg_ctl, "get_ka_info_from_config, server_info->http_version %d.%d, check_hostdb %d",
+         server_info->http_version.get_major(), server_info->http_version.get_minor(), check_hostdb);
 
   // Set keep_alive info based on the records.config setting
   server_info->keep_alive = s->txn_conf->keep_alive_enabled_out ? HTTP_KEEPALIVE : HTTP_NO_KEEPALIVE;
@@ -5358,7 +5378,7 @@ HttpTransact::add_client_ip_to_outgoing_request(State *s, HTTPHdr *request)
     switch (s->txn_conf->anonymize_insert_client_ip) {
     case 1: { // Insert the client-ip, but only if the UA did not send one
       bool client_ip_set = request->presence(MIME_PRESENCE_CLIENT_IP);
-      TxnDebug("http_trans", "client_ip_set = %d", client_ip_set);
+      TxnDbg(http_trans_dbg_ctl, "client_ip_set = %d", client_ip_set);
 
       if (client_ip_set == true) {
         break;
@@ -5368,7 +5388,7 @@ HttpTransact::add_client_ip_to_outgoing_request(State *s, HTTPHdr *request)
     // FALL-THROUGH
     case 2: // Always insert the client-ip
       request->value_set(MIME_FIELD_CLIENT_IP, MIME_LEN_CLIENT_IP, ip_string, ip_string_size);
-      TxnDebug("http_trans", "inserted request header 'Client-ip: %s'", ip_string);
+      TxnDbg(http_trans_dbg_ctl, "inserted request header 'Client-ip: %s'", ip_string);
       break;
 
     default: // don't insert client-ip
@@ -5379,10 +5399,10 @@ HttpTransact::add_client_ip_to_outgoing_request(State *s, HTTPHdr *request)
   // Add or append to the X-Forwarded-For header
   if (s->txn_conf->insert_squid_x_forwarded_for) {
     request->value_append_or_set(MIME_FIELD_X_FORWARDED_FOR, MIME_LEN_X_FORWARDED_FOR, ip_string, ip_string_size);
-    TxnDebug("http_trans",
-             "[add_client_ip_to_outgoing_request] Appended connecting client's "
-             "(%s) to the X-Forwards header",
-             ip_string);
+    TxnDbg(http_trans_dbg_ctl,
+           "[add_client_ip_to_outgoing_request] Appended connecting client's "
+           "(%s) to the X-Forwards header",
+           ip_string);
   }
 }
 
@@ -5542,7 +5562,7 @@ HttpTransact::set_client_request_state(State *s, HTTPHdr *incoming_hdr)
     s->hdr_info.request_content_length = HTTP_UNDEFINED_CL; // content length less than zero is invalid
   }
 
-  TxnDebug("http_trans", "[set_client_request_state] set req cont length to %" PRId64, s->hdr_info.request_content_length);
+  TxnDbg(http_trans_dbg_ctl, "[set_client_request_state] set req cont length to %" PRId64, s->hdr_info.request_content_length);
 }
 
 HttpTransact::ResponseError_t
@@ -5577,11 +5597,11 @@ HttpTransact::check_response_validity(State *s, HTTPHdr *incoming_hdr)
   if (incoming_hdr->presence(MIME_PRESENCE_DATE)) {
     time_t date_value = incoming_hdr->get_date();
     if (date_value <= 0) {
-      TxnDebug("http_trans", "[check_response_validity] Bogus date in response");
+      TxnDbg(http_trans_dbg_ctl, "[check_response_validity] Bogus date in response");
       return BOGUS_OR_NO_DATE_IN_RESPONSE;
     }
   } else {
-    TxnDebug("http_trans", "[check_response_validity] No date in response");
+    TxnDbg(http_trans_dbg_ctl, "[check_response_validity] No date in response");
     return BOGUS_OR_NO_DATE_IN_RESPONSE;
   }
 #endif
@@ -5639,7 +5659,7 @@ HttpTransact::handle_trace_and_options_requests(State *s, HTTPHdr *incoming_hdr)
     // if max-forward is 0 the request must not //
     // be forwarded to the origin server.       //
     //////////////////////////////////////////////
-    TxnDebug("http_trans", "[handle_trace] max-forwards: 0, building response...");
+    TxnDbg(http_trans_dbg_ctl, "[handle_trace] max-forwards: 0, building response...");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_response(s, &s->hdr_info.client_response, s->client_info.http_version, HTTP_STATUS_OK);
 
@@ -5648,7 +5668,7 @@ HttpTransact::handle_trace_and_options_requests(State *s, HTTPHdr *incoming_hdr)
     // the request header as the body.    //
     ////////////////////////////////////////
     if (s->method == HTTP_WKSIDX_TRACE) {
-      TxnDebug("http_trans", "[handle_trace] inserting request in body.");
+      TxnDbg(http_trans_dbg_ctl, "[handle_trace] inserting request in body.");
       int req_length = incoming_hdr->length_get();
       HTTP_RELEASE_ASSERT(req_length > 0);
 
@@ -5678,7 +5698,7 @@ HttpTransact::handle_trace_and_options_requests(State *s, HTTPHdr *incoming_hdr)
       s->hdr_info.client_response.set_content_length(used);
     } else {
       // For OPTIONS request insert supported methods in ALLOW field
-      TxnDebug("http_trans", "[handle_options] inserting methods in Allow.");
+      TxnDbg(http_trans_dbg_ctl, "[handle_options] inserting methods in Allow.");
       HttpTransactHeaders::insert_supported_methods_in_response(&s->hdr_info.client_response, s->scheme);
     }
     return true;
@@ -5689,7 +5709,7 @@ HttpTransact::handle_trace_and_options_requests(State *s, HTTPHdr *incoming_hdr)
     // Would be negative in that case.  Already checked negative in the other case.  Noted by coverity
 
     --max_forwards;
-    TxnDebug("http_trans", "[handle_trace_options] Decrementing max_forwards to %d", max_forwards);
+    TxnDbg(http_trans_dbg_ctl, "[handle_trace_options] Decrementing max_forwards to %d", max_forwards);
     incoming_hdr->set_max_forwards(max_forwards);
 
     // Trace and Options requests should not be looked up in cache.
@@ -5774,12 +5794,12 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
   // you'll need to force the next hop to be https.
   if (s->is_websocket) {
     if (s->next_hop_scheme == URL_WKSIDX_WS) {
-      TxnDebug("http_trans", "Switching WS next hop scheme to http.");
+      TxnDbg(http_trans_dbg_ctl, "Switching WS next hop scheme to http.");
       s->next_hop_scheme = URL_WKSIDX_HTTP;
       s->scheme          = URL_WKSIDX_HTTP;
       // s->request_data.hdr->url_get()->scheme_set(URL_SCHEME_HTTP, URL_LEN_HTTP);
     } else if (s->next_hop_scheme == URL_WKSIDX_WSS) {
-      TxnDebug("http_trans", "Switching WSS next hop scheme to https.");
+      TxnDbg(http_trans_dbg_ctl, "Switching WSS next hop scheme to https.");
       s->next_hop_scheme = URL_WKSIDX_HTTPS;
       s->scheme          = URL_WKSIDX_HTTPS;
       // s->request_data.hdr->url_get()->scheme_set(URL_SCHEME_HTTPS, URL_LEN_HTTPS);
@@ -5872,8 +5892,8 @@ HttpTransact::initialize_state_variables_from_response(State *s, HTTPHdr *incomi
   }
 
   if (s->current.server->keep_alive == HTTP_KEEPALIVE) {
-    TxnDebug("http_hdrs", "[initialize_state_variables_from_response]"
-                          "Server is keep-alive.");
+    TxnDbg(http_hdrs_dbg_ctl, "[initialize_state_variables_from_response]"
+                              "Server is keep-alive.");
   } else if (s->state_machine->ua_txn && s->state_machine->ua_txn->is_outbound_transparent() &&
              s->state_machine->t_state.http_config_param->use_client_source_port) {
     /* If we are reusing the client<->ATS 4-tuple for ATS<->server then if the server side is closed, we can't
@@ -5912,7 +5932,7 @@ HttpTransact::initialize_state_variables_from_response(State *s, HTTPHdr *incomi
       const char *wks_value = hdrtoken_string_to_wks(enc_value, enc_val_len);
 
       if (wks_value == HTTP_VALUE_CHUNKED && !is_response_body_precluded(status_code, s->method)) {
-        TxnDebug("http_hdrs", "[init_state_vars_from_resp] transfer encoding: chunked!");
+        TxnDbg(http_hdrs_dbg_ctl, "[init_state_vars_from_resp] transfer encoding: chunked!");
         s->current.server->transfer_encoding = CHUNKED_ENCODING;
 
         s->hdr_info.response_content_length = HTTP_UNDEFINED_CL;
@@ -6035,8 +6055,8 @@ HttpTransact::is_stale_cache_response_returnable(State *s)
   cc_mask = (MIME_COOKED_MASK_CC_MUST_REVALIDATE | MIME_COOKED_MASK_CC_PROXY_REVALIDATE | MIME_COOKED_MASK_CC_NEED_REVALIDATE_ONCE |
              MIME_COOKED_MASK_CC_NO_CACHE | MIME_COOKED_MASK_CC_NO_STORE | MIME_COOKED_MASK_CC_S_MAXAGE);
   if ((cached_response->get_cooked_cc_mask() & cc_mask) || cached_response->is_pragma_no_cache_set()) {
-    TxnDebug("http_trans", "[is_stale_cache_response_returnable] "
-                           "document headers prevent serving stale");
+    TxnDbg(http_trans_dbg_ctl, "[is_stale_cache_response_returnable] "
+                               "document headers prevent serving stale");
     return false;
   }
   // See how old the document really is.  We don't want create a
@@ -6046,22 +6066,22 @@ HttpTransact::is_stale_cache_response_returnable(State *s)
                                                                    cached_response, cached_response->get_date(), s->current.now);
   // Negative age is overflow
   if ((current_age < 0) || (current_age > s->txn_conf->cache_max_stale_age)) {
-    TxnDebug("http_trans",
-             "[is_stale_cache_response_returnable] "
-             "document age is too large %" PRId64,
-             (int64_t)current_age);
+    TxnDbg(http_trans_dbg_ctl,
+           "[is_stale_cache_response_returnable] "
+           "document age is too large %" PRId64,
+           (int64_t)current_age);
     return false;
   }
   // If the stale document requires authorization, we can't return it either.
   Authentication_t auth_needed = AuthenticationNeeded(s->txn_conf, &s->hdr_info.client_request, cached_response);
 
   if (auth_needed != AUTHENTICATION_SUCCESS) {
-    TxnDebug("http_trans", "[is_stale_cache_response_returnable] "
-                           "authorization prevent serving stale");
+    TxnDbg(http_trans_dbg_ctl, "[is_stale_cache_response_returnable] "
+                               "authorization prevent serving stale");
     return false;
   }
 
-  TxnDebug("http_trans", "[is_stale_cache_response_returnable] can serve stale");
+  TxnDbg(http_trans_dbg_ctl, "[is_stale_cache_response_returnable] can serve stale");
   return true;
 }
 
@@ -6250,8 +6270,8 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   // of other trafficserver clients. The flag is set in the
   // process_host_db_info method
   if (!s->dns_info.lookup_validated && s->client_info.is_transparent) {
-    TxnDebug("http_trans", "[is_response_cacheable] "
-                           "Lookup not validated.  Possible DNS cache poison.  Don't cache");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                               "Lookup not validated.  Possible DNS cache poison.  Don't cache");
     return false;
   }
 
@@ -6266,17 +6286,17 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   // be served to a GET url1 request, but we just match URL not method.
   int req_method = request->method_get_wksidx();
   if (!(HttpTransactHeaders::is_method_cacheable(s->http_config_param, req_method)) && s->api_req_cacheable == false) {
-    TxnDebug("http_trans", "[is_response_cacheable] "
-                           "only GET, and some HEAD and POST are cacheable");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                               "only GET, and some HEAD and POST are cacheable");
     return false;
   }
-  // TxnDebug("http_trans", "[is_response_cacheable] method is cacheable");
+  // TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] method is cacheable");
   // If the request was not looked up in the cache, the response
   // should not be cached (same subsequent requests will not be
   // looked up, either, so why cache this).
   if (!(is_request_cache_lookupable(s))) {
-    TxnDebug("http_trans", "[is_response_cacheable] "
-                           "request is not cache lookupable, response is not cacheable");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                               "request is not cache lookupable, response is not cacheable");
     return false;
   }
   // already has a fresh copy in the cache
@@ -6288,42 +6308,42 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   // If there are cookies in response but a ttl is set, allow caching
   if ((s->cache_control.ttl_in_cache <= 0) &&
       do_cookies_prevent_caching(static_cast<int>(s->txn_conf->cache_responses_to_cookies), request, response)) {
-    TxnDebug("http_trans", "[is_response_cacheable] "
-                           "response has uncachable cookies, response is not cacheable");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                               "response has uncachable cookies, response is not cacheable");
     return false;
   }
   // if server spits back a WWW-Authenticate
   if ((s->txn_conf->cache_ignore_auth) == 0 && response->presence(MIME_PRESENCE_WWW_AUTHENTICATE)) {
-    TxnDebug("http_trans", "[is_response_cacheable] "
-                           "response has WWW-Authenticate, response is not cacheable");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                               "response has WWW-Authenticate, response is not cacheable");
     return false;
   }
   // does server explicitly forbid storing?
   // If OS forbids storing but a ttl is set, allow caching
   if (!s->cache_info.directives.does_server_permit_storing && (s->cache_control.ttl_in_cache <= 0)) {
-    TxnDebug("http_trans", "[is_response_cacheable] server does not permit storing and config file does not "
-                           "indicate that server directive should be ignored");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] server does not permit storing and config file does not "
+                               "indicate that server directive should be ignored");
     return false;
   }
-  // TxnDebug("http_trans", "[is_response_cacheable] server permits storing");
+  // TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] server permits storing");
 
   // does config explicitly forbid storing?
   // ttl overrides other config parameters
   if ((!s->cache_info.directives.does_config_permit_storing && (s->cache_control.ttl_in_cache <= 0)) ||
       (s->cache_control.never_cache)) {
-    TxnDebug("http_trans", "[is_response_cacheable] config doesn't allow storing, and cache control does not "
-                           "say to ignore no-cache and does not specify never-cache or a ttl");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] config doesn't allow storing, and cache control does not "
+                               "say to ignore no-cache and does not specify never-cache or a ttl");
     return false;
   }
-  // TxnDebug("http_trans", "[is_response_cacheable] config permits storing");
+  // TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] config permits storing");
 
   // does client explicitly forbid storing?
   if (!s->cache_info.directives.does_client_permit_storing && !s->cache_control.ignore_client_no_cache) {
-    TxnDebug("http_trans", "[is_response_cacheable] client does not permit storing, "
-                           "and cache control does not say to ignore client no-cache");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] client does not permit storing, "
+                               "and cache control does not say to ignore client no-cache");
     return false;
   }
-  TxnDebug("http_trans", "[is_response_cacheable] client permits storing");
+  TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] client permits storing");
 
   HTTPStatus response_code = response->status_get();
 
@@ -6339,15 +6359,15 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
       // and we are configured to not cache without them.
       switch (s->txn_conf->cache_required_headers) {
       case HttpConfigParams::CACHE_REQUIRED_HEADERS_NONE:
-        TxnDebug("http_trans", "[is_response_cacheable] "
-                               "no response headers required");
+        TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                                   "no response headers required");
         break;
 
       case HttpConfigParams::CACHE_REQUIRED_HEADERS_AT_LEAST_LAST_MODIFIED:
         if (!response->presence(MIME_PRESENCE_EXPIRES) && !(response->get_cooked_cc_mask() & cc_mask) &&
             !response->get_last_modified()) {
-          TxnDebug("http_trans", "[is_response_cacheable] "
-                                 "last_modified, expires, or max-age is required");
+          TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                                     "last_modified, expires, or max-age is required");
 
           s->squid_codes.hit_miss_code = ((response->get_date() == 0) ? (SQUID_MISS_HTTP_NO_DLE) : (SQUID_MISS_HTTP_NO_LE));
           return false;
@@ -6356,8 +6376,8 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
 
       case HttpConfigParams::CACHE_REQUIRED_HEADERS_CACHE_CONTROL:
         if (!response->presence(MIME_PRESENCE_EXPIRES) && !(response->get_cooked_cc_mask() & cc_mask)) {
-          TxnDebug("http_trans", "[is_response_cacheable] "
-                                 "expires header or max-age is required");
+          TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] "
+                                     "expires header or max-age is required");
           return false;
         }
         break;
@@ -6369,10 +6389,10 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   }
   // do not cache partial content - Range response
   if (response_code == HTTP_STATUS_PARTIAL_CONTENT || response_code == HTTP_STATUS_RANGE_NOT_SATISFIABLE) {
-    TxnDebug("http_trans",
-             "[is_response_cacheable] "
-             "response code %d - don't cache",
-             response_code);
+    TxnDbg(http_trans_dbg_ctl,
+           "[is_response_cacheable] "
+           "response code %d - don't cache",
+           response_code);
     return false;
   }
 
@@ -6380,7 +6400,7 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   int indicator;
   indicator = response_cacheable_indicated_by_cc(response);
   if (indicator > 0) { // cacheable indicated by cache control header
-    TxnDebug("http_trans", "[is_response_cacheable] YES by response cache control");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] YES by response cache control");
     // even if it is authenticated, this is cacheable based on regular rules
     s->www_auth_content = CACHE_AUTH_NONE;
     return true;
@@ -6389,10 +6409,10 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
     // If a ttl is set, allow caching even if response contains
     // Cache-Control headers to prevent caching
     if (s->cache_control.ttl_in_cache > 0) {
-      TxnDebug("http_trans", "[is_response_cacheable] Cache-control header directives in response overridden by ttl in %s",
-               ts::filename::CACHE);
+      TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] Cache-control header directives in response overridden by ttl in %s",
+             ts::filename::CACHE);
     } else {
-      TxnDebug("http_trans", "[is_response_cacheable] NO by response cache control");
+      TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] NO by response cache control");
       return false;
     }
   }
@@ -6400,21 +6420,21 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   // continue to determine cacheability
 
   if (response->presence(MIME_PRESENCE_EXPIRES)) {
-    TxnDebug("http_trans", "[is_response_cacheable] YES response w/ Expires");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] YES response w/ Expires");
     return true;
   }
   // if it's a 302 or 307 and no positive indicator from cache-control, reject
   if (response_code == HTTP_STATUS_MOVED_TEMPORARILY || response_code == HTTP_STATUS_TEMPORARY_REDIRECT) {
-    TxnDebug("http_trans", "[is_response_cacheable] cache-control or expires header is required for 302");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] cache-control or expires header is required for 302");
     return false;
   }
   // if it's a POST request and no positive indicator from cache-control
   if (req_method == HTTP_WKSIDX_POST) {
     // allow caching for a POST requests w/o Expires but with a ttl
     if (s->cache_control.ttl_in_cache > 0) {
-      TxnDebug("http_trans", "[is_response_cacheable] POST method with a TTL");
+      TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] POST method with a TTL");
     } else {
-      TxnDebug("http_trans", "[is_response_cacheable] NO POST w/o Expires or CC");
+      TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] NO POST w/o Expires or CC");
       return false;
     }
   }
@@ -6422,7 +6442,7 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   if ((response_code == HTTP_STATUS_OK) || (response_code == HTTP_STATUS_NOT_MODIFIED) ||
       (response_code == HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION) || (response_code == HTTP_STATUS_MOVED_PERMANENTLY) ||
       (response_code == HTTP_STATUS_MULTIPLE_CHOICES) || (response_code == HTTP_STATUS_GONE)) {
-    TxnDebug("http_trans", "[is_response_cacheable] YES response code seems fine");
+    TxnDbg(http_trans_dbg_ctl, "[is_response_cacheable] YES response code seems fine");
     return true;
   }
   // Notice that the following are not overridable by negative caching.
@@ -6458,10 +6478,10 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
   incoming_error = check_request_validity(s, incoming_request);
   switch (incoming_error) {
   case NO_REQUEST_HEADER_ERROR:
-    TxnDebug("http_trans", "[is_request_valid] no request header errors");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] no request header errors");
     break;
   case FAILED_PROXY_AUTHORIZATION:
-    TxnDebug("http_trans", "[is_request_valid] failed proxy authorization");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] failed proxy authorization");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED, "Proxy Authentication Required",
                          "access#proxy_auth_required");
@@ -6469,7 +6489,7 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
   case NON_EXISTANT_REQUEST_HEADER:
   /* fall through */
   case BAD_HTTP_HEADER_SYNTAX: {
-    TxnDebug("http_trans", "[is_request_valid] non-existent/bad header");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] non-existent/bad header");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid HTTP Request", "request#syntax_error");
     return false;
@@ -6492,7 +6512,7 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
     //      determine the cases should be hidden behind the method.   //
     ////////////////////////////////////////////////////////////////////
 
-    TxnDebug("http_trans", "[is_request_valid] missing host field");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] missing host field");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     if (s->http_config_param->reverse_proxy_enabled) { // host header missing and reverse proxy on
       build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Host Header Required", "request#no_host");
@@ -6504,37 +6524,37 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
     return false;
   case SCHEME_NOT_SUPPORTED:
   case NO_REQUEST_SCHEME: {
-    TxnDebug("http_trans", "[is_request_valid] unsupported or missing request scheme");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] unsupported or missing request scheme");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Unsupported URL Scheme", "request#scheme_unsupported");
     return false;
   }
   /* fall through */
   case METHOD_NOT_SUPPORTED:
-    TxnDebug("http_trans", "[is_request_valid] unsupported method");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] unsupported method");
     s->current.mode = TUNNELLING_PROXY;
     return true;
   case BAD_CONNECT_PORT:
     int port;
     port = url ? url->port_get() : 0;
-    TxnDebug("http_trans", "[is_request_valid] %d is an invalid connect port", port);
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] %d is an invalid connect port", port);
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_FORBIDDEN, "Tunnel Forbidden", "access#connect_forbidden");
     return false;
   case NO_POST_CONTENT_LENGTH: {
-    TxnDebug("http_trans", "[is_request_valid] post request without content length");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] post request without content length");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_LENGTH_REQUIRED, "Content Length Required", "request#no_content_length");
     return false;
   }
   case UNACCEPTABLE_TE_REQUIRED: {
-    TxnDebug("http_trans", "[is_request_valid] TE required is unacceptable.");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] TE required is unacceptable.");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_NOT_ACCEPTABLE, "Transcoding Not Available", "transcoding#unsupported");
     return false;
   }
   case INVALID_POST_CONTENT_LENGTH: {
-    TxnDebug("http_trans", "[is_request_valid] post request with negative content length value");
+    TxnDbg(http_trans_dbg_ctl, "[is_request_valid] post request with negative content length value");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid Content Length", "request#invalid_content_length");
     return false;
@@ -6621,7 +6641,7 @@ HttpTransact::process_quick_http_filter(State *s, int method)
       }
     }
     if (deny_request) {
-      if (is_debug_tag_set("ip-allow")) {
+      if (is_dbg_ctl_enabled(ip_allow_dbg_ctl)) {
         ip_text_buffer ipb;
         if (method != -1) {
           method_str     = hdrtoken_index_to_wks(method);
@@ -6629,8 +6649,8 @@ HttpTransact::process_quick_http_filter(State *s, int method)
         } else if (!method_str) {
           method_str = s->hdr_info.client_request.method_get(&method_str_len);
         }
-        TxnDebug("ip-allow", "Line %d denial for '%.*s' from %s", acl.source_line(), method_str_len, method_str,
-                 ats_ip_ntop(&s->client_info.src_addr.sa, ipb, sizeof(ipb)));
+        TxnDbg(ip_allow_dbg_ctl, "Line %d denial for '%.*s' from %s", acl.source_line(), method_str_len, method_str,
+               ats_ip_ntop(&s->client_info.src_addr.sa, ipb, sizeof(ipb)));
       }
       s->client_connection_enabled = false;
     }
@@ -6652,24 +6672,24 @@ HttpTransact::will_this_request_self_loop(State *s)
   // check if we are about to self loop //
   ////////////////////////////////////////
   if (s->dns_info.lookup_success) {
-    TxnDebug("http_transact", "max_proxy_cycles = %d", max_proxy_cycles);
+    TxnDbg(http_transact_dbg_ctl, "max_proxy_cycles = %d", max_proxy_cycles);
     if (max_proxy_cycles == 0) {
       in_port_t dst_port   = s->hdr_info.client_request.url_get()->port_get(); // going to this port.
       in_port_t local_port = s->client_info.dst_addr.host_order_port();        // already connected proxy port.
       // It's a loop if connecting to the same port as it already connected to the proxy and
       // it's a proxy address or the same address it already connected to.
-      TxnDebug("http_transact", "dst_port = %d local_port = %d", dst_port, local_port);
+      TxnDbg(http_transact_dbg_ctl, "dst_port = %d local_port = %d", dst_port, local_port);
       if (dst_port == local_port && (ats_ip_addr_eq(s->host_db_info.ip(), &Machine::instance()->ip.sa) ||
                                      ats_ip_addr_eq(s->host_db_info.ip(), s->client_info.dst_addr))) {
         switch (s->dns_info.looking_up) {
         case ORIGIN_SERVER:
-          TxnDebug("http_transact", "host ip and port same as local ip and port - bailing");
+          TxnDbg(http_transact_dbg_ctl, "host ip and port same as local ip and port - bailing");
           break;
         case PARENT_PROXY:
-          TxnDebug("http_transact", "parent proxy ip and port same as local ip and port - bailing");
+          TxnDbg(http_transact_dbg_ctl, "parent proxy ip and port same as local ip and port - bailing");
           break;
         default:
-          TxnDebug("http_transact", "unknown's ip and port same as local ip and port - bailing");
+          TxnDbg(http_transact_dbg_ctl, "unknown's ip and port same as local ip and port - bailing");
           break;
         }
         SET_VIA_STRING(VIA_ERROR_TYPE, VIA_ERROR_LOOP_DETECTED);
@@ -6692,24 +6712,24 @@ HttpTransact::will_this_request_self_loop(State *s)
       if ((count <= max_proxy_cycles) && via_string) {
         std::string_view current{via_field->value_get()};
         std::string_view::size_type offset;
-        TxnDebug("http_transact", "Incoming via: \"%.*s\" --has-- (%s[%s] (%s))", via_len, via_string,
-                 s->http_config_param->proxy_hostname, uuid.data(), s->http_config_param->proxy_request_via_string);
+        TxnDbg(http_transact_dbg_ctl, "Incoming via: \"%.*s\" --has-- (%s[%s] (%s))", via_len, via_string,
+               s->http_config_param->proxy_hostname, uuid.data(), s->http_config_param->proxy_request_via_string);
         while ((count <= max_proxy_cycles) && (std::string_view::npos != (offset = current.find(uuid)))) {
           current.remove_prefix(offset + TS_UUID_STRING_LEN);
           count++;
-          TxnDebug("http_transact", "count = %d current = %.*s", count, static_cast<int>(current.length()), current.data());
+          TxnDbg(http_transact_dbg_ctl, "count = %d current = %.*s", count, static_cast<int>(current.length()), current.data());
         }
       }
 
       via_field = via_field->m_next_dup;
     }
     if (count > max_proxy_cycles) {
-      TxnDebug("http_transact", "count = %d > max_proxy_cycles = %d : detected loop", count, max_proxy_cycles);
+      TxnDbg(http_transact_dbg_ctl, "count = %d > max_proxy_cycles = %d : detected loop", count, max_proxy_cycles);
       SET_VIA_STRING(VIA_ERROR_TYPE, VIA_ERROR_LOOP_DETECTED);
       build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Multi-Hop Cycle Detected", "request#cycle_detected");
       return true;
     } else {
-      TxnDebug("http_transact", "count = %d <= max_proxy_cycles = %d : allowing loop", count, max_proxy_cycles);
+      TxnDbg(http_transact_dbg_ctl, "count = %d <= max_proxy_cycles = %d : allowing loop", count, max_proxy_cycles);
     }
   }
   return false;
@@ -6756,8 +6776,8 @@ HttpTransact::handle_content_length_header(State *s, HTTPHdr *header, HTTPHdr *b
         else if (s->cache_info.object_read->object_size_get() == cl) {
           s->hdr_info.trust_response_cl = true;
         } else {
-          TxnDebug("http_trans", "Content Length header and cache object size mismatch."
-                                 "Disabling keep-alive");
+          TxnDbg(http_trans_dbg_ctl, "Content Length header and cache object size mismatch."
+                                     "Disabling keep-alive");
           s->hdr_info.trust_response_cl = false;
         }
         break;
@@ -6781,7 +6801,7 @@ HttpTransact::handle_content_length_header(State *s, HTTPHdr *header, HTTPHdr *b
       header->field_delete(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
       s->hdr_info.trust_response_cl = false;
     }
-    TxnDebug("http_trans", "[handle_content_length_header] RESPONSE cont len in hdr is %" PRId64, header->get_content_length());
+    TxnDbg(http_trans_dbg_ctl, "[handle_content_length_header] RESPONSE cont len in hdr is %" PRId64, header->get_content_length());
   } else {
     // No content length header.
     // If the source is cache or server returned 304 response,
@@ -6970,7 +6990,7 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
   if (s->is_upgrade_request && heads->status_get() == HTTP_STATUS_SWITCHING_PROTOCOL && s->source == SOURCE_HTTP_ORIGIN_SERVER) {
     s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
     if (s->is_websocket) {
-      TxnDebug("http_trans", "transaction successfully upgraded to websockets.");
+      TxnDbg(http_trans_dbg_ctl, "transaction successfully upgraded to websockets.");
       // s->transparent_passthrough = true;
       heads->value_set(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION, MIME_FIELD_UPGRADE, MIME_LEN_UPGRADE);
       heads->value_set(MIME_FIELD_UPGRADE, MIME_LEN_UPGRADE, "websocket", 9);
@@ -7117,10 +7137,10 @@ HttpTransact::delete_all_document_alternates_and_return(State *s, bool cache_hit
     }
 
     if (s->method == HTTP_WKSIDX_PURGE || (valid_max_forwards && max_forwards <= 0)) {
-      TxnDebug("http_trans",
-               "[delete_all_document_alternates_and_return] "
-               "DELETE with Max-Forwards: %d",
-               max_forwards);
+      TxnDbg(http_trans_dbg_ctl,
+             "[delete_all_document_alternates_and_return] "
+             "DELETE with Max-Forwards: %d",
+             max_forwards);
 
       SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
 
@@ -7136,10 +7156,10 @@ HttpTransact::delete_all_document_alternates_and_return(State *s, bool cache_hit
     } else {
       if (valid_max_forwards) {
         --max_forwards;
-        TxnDebug("http_trans",
-                 "[delete_all_document_alternates_and_return] "
-                 "Decrementing max_forwards to %d",
-                 max_forwards);
+        TxnDbg(http_trans_dbg_ctl,
+               "[delete_all_document_alternates_and_return] "
+               "Decrementing max_forwards to %d",
+               max_forwards);
         s->hdr_info.client_request.value_set_int(MIME_FIELD_MAX_FORWARDS, MIME_LEN_MAX_FORWARDS, max_forwards);
       }
     }
@@ -7246,7 +7266,7 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
 
   if (max_age >= 0) {
     freshness_limit = std::min(std::max(0, max_age), static_cast<int>(s->txn_conf->cache_guaranteed_max_lifetime));
-    TxnDebug("http_match", "calculate_document_freshness_limit --- freshness_limit = %d", freshness_limit);
+    TxnDbg(http_match_dbg_ctl, "calculate_document_freshness_limit --- freshness_limit = %d", freshness_limit);
   } else {
     date_set = last_modified_set = false;
 
@@ -7263,9 +7283,9 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
       date_set = true;
     } else {
       date_value = s->request_sent_time;
-      TxnDebug("http_match",
-               "calculate_document_freshness_limit --- Expires header = %" PRId64 " no date, using sent time %" PRId64,
-               (int64_t)expires_value, (int64_t)date_value);
+      TxnDbg(http_match_dbg_ctl,
+             "calculate_document_freshness_limit --- Expires header = %" PRId64 " no date, using sent time %" PRId64,
+             (int64_t)expires_value, (int64_t)date_value);
     }
     ink_assert(date_value > 0);
 
@@ -7276,12 +7296,14 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
     if (expires_set && !cache_sm.is_readwhilewrite_inprogress()) {
       if (expires_value == UNDEFINED_TIME || expires_value <= date_value) {
         expires_value = date_value;
-        TxnDebug("http_match", "calculate_document_freshness_limit --- no expires, using date %" PRId64, (int64_t)expires_value);
+        TxnDbg(http_match_dbg_ctl, "calculate_document_freshness_limit --- no expires, using date %" PRId64,
+               (int64_t)expires_value);
       }
       freshness_limit = static_cast<int>(expires_value - date_value);
 
-      TxnDebug("http_match", "calculate_document_freshness_limit --- Expires: %" PRId64 ", Date: %" PRId64 ", freshness_limit = %d",
-               (int64_t)expires_value, (int64_t)date_value, freshness_limit);
+      TxnDbg(http_match_dbg_ctl,
+             "calculate_document_freshness_limit --- Expires: %" PRId64 ", Date: %" PRId64 ", freshness_limit = %d",
+             (int64_t)expires_value, (int64_t)date_value, freshness_limit);
 
       freshness_limit = std::min(std::max(0, freshness_limit), static_cast<int>(s->txn_conf->cache_guaranteed_max_lifetime));
     } else {
@@ -7289,15 +7311,15 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
       if (response->presence(MIME_PRESENCE_LAST_MODIFIED)) {
         last_modified_set   = true;
         last_modified_value = response->get_last_modified();
-        TxnDebug("http_match", "calculate_document_freshness_limit --- Last Modified header = %" PRId64,
-                 (int64_t)last_modified_value);
+        TxnDbg(http_match_dbg_ctl, "calculate_document_freshness_limit --- Last Modified header = %" PRId64,
+               (int64_t)last_modified_value);
 
         if (last_modified_value == UNDEFINED_TIME) {
           last_modified_set = false;
         } else if (last_modified_value > date_value) {
           last_modified_value = date_value;
-          TxnDebug("http_match", "calculate_document_freshness_limit --- no last-modified, using sent time %" PRId64,
-                   (int64_t)last_modified_value);
+          TxnDbg(http_match_dbg_ctl, "calculate_document_freshness_limit --- no last-modified, using sent time %" PRId64,
+                 (int64_t)last_modified_value);
         }
       }
 
@@ -7308,13 +7330,13 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
         ink_time_t time_since_last_modify = date_value - last_modified_value;
         int h_freshness                   = static_cast<int>(time_since_last_modify * f);
         freshness_limit                   = std::max(h_freshness, 0);
-        TxnDebug("http_match",
-                 "calculate_document_freshness_limit --- heuristic: date=%" PRId64 ", lm=%" PRId64
-                 ", time_since_last_modify=%" PRId64 ", f=%g, freshness_limit = %d",
-                 (int64_t)date_value, (int64_t)last_modified_value, (int64_t)time_since_last_modify, f, freshness_limit);
+        TxnDbg(http_match_dbg_ctl,
+               "calculate_document_freshness_limit --- heuristic: date=%" PRId64 ", lm=%" PRId64 ", time_since_last_modify=%" PRId64
+               ", f=%g, freshness_limit = %d",
+               (int64_t)date_value, (int64_t)last_modified_value, (int64_t)time_since_last_modify, f, freshness_limit);
       } else {
         freshness_limit = s->txn_conf->cache_heuristic_min_lifetime;
-        TxnDebug("http_match", "calculate_document_freshness_limit --- heuristic: freshness_limit = %d", freshness_limit);
+        TxnDbg(http_match_dbg_ctl, "calculate_document_freshness_limit --- heuristic: freshness_limit = %d", freshness_limit);
       }
     }
   }
@@ -7336,7 +7358,7 @@ HttpTransact::calculate_document_freshness_limit(State *s, HTTPHdr *response, ti
     freshness_limit = min_freshness_bounds;
   }
 
-  TxnDebug("http_match", "calculate_document_freshness_limit --- final freshness_limit = %d", freshness_limit);
+  TxnDbg(http_match_dbg_ctl, "calculate_document_freshness_limit --- final freshness_limit = %d", freshness_limit);
 
   return (freshness_limit);
 }
@@ -7366,7 +7388,7 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
 
   if (s->cache_open_write_fail_action & CACHE_WL_FAIL_ACTION_STALE_ON_REVALIDATE) {
     if (is_stale_cache_response_returnable(s)) {
-      TxnDebug("http_match", "[what_is_document_freshness] cache_serve_stale_on_write_lock_fail, return FRESH");
+      TxnDbg(http_match_dbg_ctl, "[what_is_document_freshness] cache_serve_stale_on_write_lock_fail, return FRESH");
       return (FRESHNESS_FRESH);
     }
   }
@@ -7381,8 +7403,8 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
     // but for how long it has been stored in the cache (resident time)
     int resident_time = s->current.now - s->response_received_time;
 
-    TxnDebug("http_match", "[..._document_freshness] ttl-in-cache = %d, resident time = %d", s->cache_control.ttl_in_cache,
-             resident_time);
+    TxnDbg(http_match_dbg_ctl, "[..._document_freshness] ttl-in-cache = %d, resident time = %d", s->cache_control.ttl_in_cache,
+           resident_time);
     if (resident_time > s->cache_control.ttl_in_cache) {
       return (FRESHNESS_STALE);
     } else {
@@ -7397,8 +7419,8 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
   // Check to see if the server forces revalidation
 
   if ((cooked_cc_mask & cc_mask) && s->cache_control.revalidate_after <= 0) {
-    TxnDebug("http_match", "[what_is_document_freshness] document stale due to "
-                           "server must-revalidate");
+    TxnDbg(http_match_dbg_ctl, "[what_is_document_freshness] document stale due to "
+                               "server must-revalidate");
     return FRESHNESS_STALE;
   }
 
@@ -7421,7 +7443,8 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
     current_age = std::max(static_cast<time_t>(s->txn_conf->cache_guaranteed_max_lifetime), current_age);
   }
 
-  TxnDebug("http_match", "[what_is_document_freshness] fresh_limit:  %d  current_age: %" PRId64, fresh_limit, (int64_t)current_age);
+  TxnDbg(http_match_dbg_ctl, "[what_is_document_freshness] fresh_limit:  %d  current_age: %" PRId64, fresh_limit,
+         (int64_t)current_age);
 
   ink_assert(client_request == &s->hdr_info.client_request);
 
@@ -7432,22 +7455,22 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
       break;
     case 1: // Stale if heuristic
       if (heuristic) {
-        TxnDebug("http_match", "[what_is_document_freshness] config requires FRESHNESS_STALE because heuristic calculation");
+        TxnDbg(http_match_dbg_ctl, "[what_is_document_freshness] config requires FRESHNESS_STALE because heuristic calculation");
         return (FRESHNESS_STALE);
       }
       break;
     case 2: // Always stale
-      TxnDebug("http_match", "[what_is_document_freshness] config "
-                             "specifies always FRESHNESS_STALE");
+      TxnDbg(http_match_dbg_ctl, "[what_is_document_freshness] config "
+                                 "specifies always FRESHNESS_STALE");
       return (FRESHNESS_STALE);
     case 3: // Never stale
-      TxnDebug("http_match", "[what_is_document_freshness] config "
-                             "specifies always FRESHNESS_FRESH");
+      TxnDbg(http_match_dbg_ctl, "[what_is_document_freshness] config "
+                                 "specifies always FRESHNESS_FRESH");
       return (FRESHNESS_FRESH);
     case 4: // Stale if IMS
       if (client_request->presence(MIME_PRESENCE_IF_MODIFIED_SINCE)) {
-        TxnDebug("http_match", "[what_is_document_freshness] config "
-                               "specifies FRESHNESS_STALE if IMS present");
+        TxnDbg(http_match_dbg_ctl, "[what_is_document_freshness] config "
+                                   "specifies FRESHNESS_STALE if IMS present");
         return (FRESHNESS_STALE);
       }
     default: // Bad config, ignore
@@ -7464,7 +7487,7 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
   //     max-stale:      (current_age <= fresh_limit + max_stale)     //
   //////////////////////////////////////////////////////////////////////
   age_limit = fresh_limit; // basic constraint
-  TxnDebug("http_match", "[..._document_freshness] initial age limit: %d", age_limit);
+  TxnDbg(http_match_dbg_ctl, "[..._document_freshness] initial age limit: %d", age_limit);
 
   cooked_cc_mask = client_request->get_cooked_cc_mask();
   cc_mask        = (MIME_COOKED_MASK_CC_MAX_STALE | MIME_COOKED_MASK_CC_MIN_FRESH | MIME_COOKED_MASK_CC_MAX_AGE);
@@ -7474,8 +7497,8 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
     /////////////////////////////////////////////////
     if (cooked_cc_mask & MIME_COOKED_MASK_CC_MAX_STALE) {
       if (os_specifies_revalidate) {
-        TxnDebug("http_match", "[...document_freshness] OS specifies revalidation; "
-                               "ignoring client's max-stale request...");
+        TxnDbg(http_match_dbg_ctl, "[...document_freshness] OS specifies revalidation; "
+                                   "ignoring client's max-stale request...");
       } else {
         int max_stale_val = client_request->get_cooked_cc_max_stale();
 
@@ -7484,7 +7507,7 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
         } else {
           age_limit = max_stale_val;
         }
-        TxnDebug("http_match", "[..._document_freshness] max-stale set, age limit: %d", age_limit);
+        TxnDbg(http_match_dbg_ctl, "[..._document_freshness] max-stale set, age limit: %d", age_limit);
       }
     }
     /////////////////////////////////////////////////////
@@ -7492,7 +7515,7 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
     /////////////////////////////////////////////////////
     if (cooked_cc_mask & MIME_COOKED_MASK_CC_MIN_FRESH) {
       age_limit = std::min(age_limit, fresh_limit - client_request->get_cooked_cc_min_fresh());
-      TxnDebug("http_match", "[..._document_freshness] min_fresh set, age limit: %d", age_limit);
+      TxnDbg(http_match_dbg_ctl, "[..._document_freshness] min_fresh set, age limit: %d", age_limit);
     }
     ///////////////////////////////////////////////////
     // if max-age set, constrain the freshness limit //
@@ -7503,7 +7526,7 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
         do_revalidate = true;
       }
       age_limit = std::min(age_limit, age_val);
-      TxnDebug("http_match", "[..._document_freshness] min_fresh set, age limit: %d", age_limit);
+      TxnDbg(http_match_dbg_ctl, "[..._document_freshness] min_fresh set, age limit: %d", age_limit);
     }
   }
   /////////////////////////////////////////////////////////
@@ -7517,34 +7540,34 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
     // if instead the revalidate_after overrides all other variables
     age_limit = s->cache_control.revalidate_after;
 
-    TxnDebug("http_match", "[..._document_freshness] revalidate_after set, age limit: %d", age_limit);
+    TxnDbg(http_match_dbg_ctl, "[..._document_freshness] revalidate_after set, age limit: %d", age_limit);
   }
 
-  TxnDebug("http_match", "document_freshness --- current_age = %" PRId64, (int64_t)current_age);
-  TxnDebug("http_match", "document_freshness --- age_limit   = %d", age_limit);
-  TxnDebug("http_match", "document_freshness --- fresh_limit = %d", fresh_limit);
-  TxnDebug("http_seq", "document_freshness --- current_age = %" PRId64, (int64_t)current_age);
-  TxnDebug("http_seq", "document_freshness --- age_limit   = %d", age_limit);
-  TxnDebug("http_seq", "document_freshness --- fresh_limit = %d", fresh_limit);
+  TxnDbg(http_match_dbg_ctl, "document_freshness --- current_age = %" PRId64, (int64_t)current_age);
+  TxnDbg(http_match_dbg_ctl, "document_freshness --- age_limit   = %d", age_limit);
+  TxnDbg(http_match_dbg_ctl, "document_freshness --- fresh_limit = %d", fresh_limit);
+  TxnDbg(http_seq_dbg_ctl, "document_freshness --- current_age = %" PRId64, (int64_t)current_age);
+  TxnDbg(http_seq_dbg_ctl, "document_freshness --- age_limit   = %d", age_limit);
+  TxnDbg(http_seq_dbg_ctl, "document_freshness --- fresh_limit = %d", fresh_limit);
   ///////////////////////////////////////////
   // now, see if the age is "fresh enough" //
   ///////////////////////////////////////////
 
   if (do_revalidate || !age_limit || current_age > age_limit) { // client-modified limit
-    TxnDebug("http_match", "[..._document_freshness] document needs revalidate/too old; "
-                           "returning FRESHNESS_STALE");
+    TxnDbg(http_match_dbg_ctl, "[..._document_freshness] document needs revalidate/too old; "
+                               "returning FRESHNESS_STALE");
     return (FRESHNESS_STALE);
   } else if (current_age > fresh_limit) { // original limit
     if (os_specifies_revalidate) {
-      TxnDebug("http_match", "[..._document_freshness] document is stale and OS specifies revalidation; "
-                             "returning FRESHNESS_STALE");
+      TxnDbg(http_match_dbg_ctl, "[..._document_freshness] document is stale and OS specifies revalidation; "
+                                 "returning FRESHNESS_STALE");
       return (FRESHNESS_STALE);
     }
-    TxnDebug("http_match", "[..._document_freshness] document is stale but no revalidation explicitly required; "
-                           "returning FRESHNESS_WARNING");
+    TxnDbg(http_match_dbg_ctl, "[..._document_freshness] document is stale but no revalidation explicitly required; "
+                               "returning FRESHNESS_WARNING");
     return (FRESHNESS_WARNING);
   } else {
-    TxnDebug("http_match", "[..._document_freshness] document is fresh; returning FRESHNESS_FRESH");
+    TxnDbg(http_match_dbg_ctl, "[..._document_freshness] document is fresh; returning FRESHNESS_FRESH");
     return (FRESHNESS_FRESH);
   }
 }
@@ -7658,7 +7681,7 @@ HttpTransact::handle_server_died(State *s)
     break;
   case ACTIVE_TIMEOUT:
     if (s->api_txn_active_timeout_value != -1) {
-      TxnDebug("http_timeout", "Maximum active time of %d msec exceeded", s->api_txn_active_timeout_value);
+      TxnDbg(http_timeout_dbg_ctl, "Maximum active time of %d msec exceeded", s->api_txn_active_timeout_value);
     }
     status    = HTTP_STATUS_GATEWAY_TIMEOUT;
     reason    = "Maximum Transaction Time Exceeded";
@@ -7666,7 +7689,7 @@ HttpTransact::handle_server_died(State *s)
     break;
   case INACTIVE_TIMEOUT:
     if (s->api_txn_connect_timeout_value != -1) {
-      TxnDebug("http_timeout", "Maximum connect time of %d msec exceeded", s->api_txn_connect_timeout_value);
+      TxnDbg(http_timeout_dbg_ctl, "Maximum connect time of %d msec exceeded", s->api_txn_connect_timeout_value);
     }
     status    = HTTP_STATUS_GATEWAY_TIMEOUT;
     reason    = "Connection Timed Out";
@@ -7839,14 +7862,14 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
   } else if (s->current.request_to == PARENT_PROXY && parent_is_proxy(s)) {
     // If we have a parent proxy set the URL target field.
     if (!outgoing_request->is_target_in_url()) {
-      TxnDebug("http_trans", "[build_request] adding target to URL for parent proxy");
+      TxnDbg(http_trans_dbg_ctl, "[build_request] adding target to URL for parent proxy");
       outgoing_request->set_url_target_from_host_field();
     }
   } else if (s->next_hop_scheme == URL_WKSIDX_HTTP || s->next_hop_scheme == URL_WKSIDX_HTTPS ||
              s->next_hop_scheme == URL_WKSIDX_WS || s->next_hop_scheme == URL_WKSIDX_WSS) {
     // Otherwise, remove the URL target from HTTP and Websocket URLs since certain origins
     // cannot deal with absolute URLs.
-    TxnDebug("http_trans", "[build_request] removing host name from url");
+    TxnDbg(http_trans_dbg_ctl, "[build_request] removing host name from url");
     HttpTransactHeaders::remove_host_name_from_url(outgoing_request);
   }
 
@@ -7858,24 +7881,24 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
   if (s->current.mode == GENERIC_PROXY) {
     if (is_request_likely_cacheable(s, base_request)) {
       if (s->txn_conf->cache_when_to_revalidate != 4) {
-        TxnDebug("http_trans", "[build_request] "
-                               "request like cacheable and conditional headers removed");
+        TxnDbg(http_trans_dbg_ctl, "[build_request] "
+                                   "request like cacheable and conditional headers removed");
         HttpTransactHeaders::remove_conditional_headers(outgoing_request);
       } else {
-        TxnDebug("http_trans", "[build_request] "
-                               "request like cacheable but keep conditional headers");
+        TxnDbg(http_trans_dbg_ctl, "[build_request] "
+                                   "request like cacheable but keep conditional headers");
       }
     } else {
       // In this case, we send a conditional request
       // instead of the normal non-conditional request.
-      TxnDebug("http_trans", "[build_request] "
-                             "request not like cacheable and conditional headers not removed");
+      TxnDbg(http_trans_dbg_ctl, "[build_request] "
+                                 "request not like cacheable and conditional headers not removed");
     }
   }
 
   if (s->http_config_param->send_100_continue_response) {
     HttpTransactHeaders::remove_100_continue_headers(s, outgoing_request);
-    TxnDebug("http_trans", "[build_request] request expect 100-continue headers removed");
+    TxnDbg(http_trans_dbg_ctl, "[build_request] request expect 100-continue headers removed");
   }
 
   if (base_request->is_early_data()) {
@@ -7888,7 +7911,7 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
   // The assert is backwards in this case because request is being (re)sent.
   ink_assert(s->request_sent_time >= s->response_received_time);
 
-  TxnDebug("http_trans", "[build_request] request_sent_time: %" PRId64, (int64_t)s->request_sent_time);
+  TxnDbg(http_trans_dbg_ctl, "[build_request] request_sent_time: %" PRId64, (int64_t)s->request_sent_time);
   DUMP_HEADER("http_hdrs", outgoing_request, s->state_machine_id, "Proxy's Request");
 
   HTTP_INCREMENT_DYN_STAT(http_outgoing_requests_stat);
@@ -8016,7 +8039,7 @@ HttpTransact::build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing
   // Add HSTS header (Strict-Transport-Security) if max-age is set and the request was https
   // and the incoming request was remapped correctly
   if (s->orig_scheme == URL_WKSIDX_HTTPS && s->txn_conf->proxy_response_hsts_max_age >= 0 && s->url_remap_success == true) {
-    TxnDebug("http_hdrs", "hsts max-age=%" PRId64, s->txn_conf->proxy_response_hsts_max_age);
+    TxnDbg(http_hdrs_dbg_ctl, "hsts max-age=%" PRId64, s->txn_conf->proxy_response_hsts_max_age);
     HttpTransactHeaders::insert_hsts_header_in_response(s, outgoing_response);
   }
 
@@ -8239,7 +8262,7 @@ HttpTransact::build_error_response(State *s, HTTPStatus status_code, const char 
 void
 HttpTransact::build_redirect_response(State *s)
 {
-  TxnDebug("http_redirect", "[HttpTransact::build_redirect_response]");
+  TxnDbg(http_redirect_dbg_ctl, "[HttpTransact::build_redirect_response]");
   URL *u;
   const char *old_host;
   int old_host_len;
@@ -8700,7 +8723,7 @@ HttpTransact::client_result_stat(State *s, ink_hrtime total_time, ink_hrtime req
   default:
     HTTP_SUM_DYN_STAT(http_ua_msecs_counts_other_unclassified_stat, total_msec);
     // This can happen if a plugin manually sets the status code after an error.
-    TxnDebug("http", "Unclassified statistic");
+    TxnDbg(http_dbg_ctl, "Unclassified statistic");
     break;
   }
 }
@@ -8967,7 +8990,7 @@ HttpTransact::change_response_header_because_of_range_request(State *s, HTTPHdr 
   MIMEField *field;
   char *reason_phrase;
 
-  TxnDebug("http_trans", "Partial content requested, re-calculating content-length");
+  TxnDbg(http_trans_dbg_ctl, "Partial content requested, re-calculating content-length");
 
   header->status_set(HTTP_STATUS_PARTIAL_CONTENT);
   reason_phrase = const_cast<char *>(http_hdr_reason_lookup(HTTP_STATUS_PARTIAL_CONTENT));

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -48,7 +48,7 @@
 
 #define DUMP_HEADER(T, H, I, S)                                 \
   {                                                             \
-    if (diags->on(T)) {                                         \
+    if (is_debug_tag_set(T)) {                                  \
       fprintf(stderr, "+++++++++ %s +++++++++\n", S);           \
       fprintf(stderr, "-- State Machine Id: %" PRId64 "\n", I); \
       char b[4096];                                             \

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -32,14 +32,16 @@
     this->remember(MakeSourceLocation(), e, r); \
   }
 
-#define STATE_ENTER(state_name, event)                                                       \
-  do {                                                                                       \
-    REMEMBER(event, this->recursion)                                                         \
-    SsnDebug(this, "http2_cs", "[%" PRId64 "] [%s, %s]", this->connection_id(), #state_name, \
-             HttpDebugNames::get_event_name(event));                                         \
+static DbgCtl http2_cs_dbg_ctl("http2_cs");
+
+#define STATE_ENTER(state_name, event)                                                             \
+  do {                                                                                             \
+    REMEMBER(event, this->recursion)                                                               \
+    SsnDebug(this, http2_cs_dbg_ctl, "[%" PRId64 "] [%s, %s]", this->connection_id(), #state_name, \
+             HttpDebugNames::get_event_name(event));                                               \
   } while (0)
 
-#define Http2SsnDebug(fmt, ...) SsnDebug(this, "http2_cs", "[%" PRId64 "] " fmt, this->connection_id(), ##__VA_ARGS__)
+#define Http2SsnDebug(fmt, ...) SsnDebug(this, http2_cs_dbg_ctl, "[%" PRId64 "] " fmt, this->connection_id(), ##__VA_ARGS__)
 
 #define HTTP2_SET_SESSION_HANDLER(handler) \
   do {                                     \

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -42,11 +42,13 @@
     }                                                         \
   }
 
+static DbgCtl http2_con_dbg_ctl("http2_con");
+
 #define Http2ConDebug(ua_session, fmt, ...) \
-  SsnDebug(ua_session, "http2_con", "[%" PRId64 "] " fmt, ua_session->connection_id(), ##__VA_ARGS__);
+  SsnDebug(ua_session, http2_con_dbg_ctl, "[%" PRId64 "] " fmt, ua_session->connection_id(), ##__VA_ARGS__);
 
 #define Http2StreamDebug(ua_session, stream_id, fmt, ...) \
-  SsnDebug(ua_session, "http2_con", "[%" PRId64 "] [%u] " fmt, ua_session->connection_id(), stream_id, ##__VA_ARGS__);
+  SsnDebug(ua_session, http2_con_dbg_ctl, "[%" PRId64 "] [%u] " fmt, ua_session->connection_id(), stream_id, ##__VA_ARGS__);
 
 using http2_frame_dispatch = Http2Error (*)(Http2ConnectionState &, const Http2Frame &);
 

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -34,8 +34,10 @@
     this->_history.push_back(MakeSourceLocation(), e, r); \
   }
 
+static DbgCtl http2_stream_dbg_ctl("http2_stream");
+
 #define Http2StreamDebug(fmt, ...) \
-  SsnDebug(_proxy_ssn, "http2_stream", "[%" PRId64 "] [%u] " fmt, _proxy_ssn->connection_id(), this->get_id(), ##__VA_ARGS__);
+  SsnDebug(_proxy_ssn, http2_stream_dbg_ctl, "[%" PRId64 "] [%u] " fmt, _proxy_ssn->connection_id(), this->get_id(), ##__VA_ARGS__);
 
 ClassAllocator<Http2Stream, true> http2StreamAllocator("http2StreamAllocator");
 

--- a/proxy/http3/test/main.cc
+++ b/proxy/http3/test/main.cc
@@ -41,10 +41,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DiagsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("vv_quic|quic", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/proxy/http3/test/main_qpack.cc
+++ b/proxy/http3/test/main_qpack.cc
@@ -56,10 +56,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   testRunStarting(Catch::TestRunInfo const &testRunInfo) override
   {
     BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    diags                      = new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file);
-    diags->activate_taglist("qpack", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    DaigsPtr::set(new Diags(testRunInfo.name, "" /* tags */, "" /* actions */, base_log_file));
+    diags()->activate_taglist("qpack", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
 
     Layout::create();
     RecProcessInit(RECM_STAND_ALONE);

--- a/proxy/logging/LogStandalone.cc
+++ b/proxy/logging/LogStandalone.cc
@@ -60,7 +60,6 @@ char error_tags[1024]    = "";
 char action_tags[1024]   = "";
 char command_string[512] = "";
 
-// Diags *diags = NULL;
 DiagsConfig *diagsConfig      = nullptr;
 HttpBodyFactory *body_factory = nullptr;
 AppVersionInfo appVersionInfo;
@@ -104,9 +103,9 @@ initialize_process_manager()
   }
 
   // diags should have been initialized by caller, e.g.: sac.cc
-  ink_assert(diags);
+  ink_assert(diags());
 
-  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags);
+  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags());
   LibRecordsConfigInit();
 
   // Start up manager

--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -138,7 +138,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   crashlog_target target;
   pid_t parent = getppid();
 
-  diags = new Diags("traffic_crashlog", "" /* tags */, "" /* actions */, new BaseLogFile("stderr"));
+  DiagsPtr::set(new Diags("traffic_crashlog", "" /* tags */, "" /* actions */, new BaseLogFile("stderr")));
 
   appVersionInfo.setup(PACKAGE_NAME, "traffic_crashlog", PACKAGE_VERSION, __DATE__, __TIME__, BUILD_MACHINE, BUILD_PERSON, "");
 
@@ -182,14 +182,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     }
 
     openlog(appVersionInfo.AppStr, LOG_PID | LOG_NDELAY | LOG_NOWAIT, facility);
-    diags->config.outputs[DL_Debug].to_syslog     = true;
-    diags->config.outputs[DL_Status].to_syslog    = true;
-    diags->config.outputs[DL_Note].to_syslog      = true;
-    diags->config.outputs[DL_Warning].to_syslog   = true;
-    diags->config.outputs[DL_Error].to_syslog     = true;
-    diags->config.outputs[DL_Fatal].to_syslog     = true;
-    diags->config.outputs[DL_Alert].to_syslog     = true;
-    diags->config.outputs[DL_Emergency].to_syslog = true;
+    diags()->config.outputs[DL_Debug].to_syslog     = true;
+    diags()->config.outputs[DL_Status].to_syslog    = true;
+    diags()->config.outputs[DL_Note].to_syslog      = true;
+    diags()->config.outputs[DL_Warning].to_syslog   = true;
+    diags()->config.outputs[DL_Error].to_syslog     = true;
+    diags()->config.outputs[DL_Fatal].to_syslog     = true;
+    diags()->config.outputs[DL_Alert].to_syslog     = true;
+    diags()->config.outputs[DL_Emergency].to_syslog = true;
   }
 
   Note("crashlog started, target=%ld, debug=%s syslog=%s, uid=%ld euid=%ld", static_cast<long>(target_pid),

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -267,12 +267,12 @@ main(int argc, const char **argv)
   engine.arguments = engine.parser.parse(argv);
 
   BaseLogFile *base_log_file = new BaseLogFile("stderr");
-  diags                      = new Diags("traffic_ctl", "" /* tags */, "" /* actions */, base_log_file);
+  DiagsPtr::set(new Diags("traffic_ctl", "" /* tags */, "" /* actions */, base_log_file));
 
   if (engine.arguments.get("debug")) {
-    diags->activate_taglist("traffic_ctl", DiagsTagType_Debug);
-    diags->config.enabled[DiagsTagType_Debug] = true;
-    diags->show_location                      = SHOW_LOCATION_DEBUG;
+    diags()->activate_taglist("traffic_ctl", DiagsTagType_Debug);
+    diags()->config.enabled(DiagsTagType_Debug, 1);
+    diags()->show_location = SHOW_LOCATION_DEBUG;
   }
 
   argparser_runroot_handler(engine.arguments.get("run-root").value(), argv[0]);
@@ -280,7 +280,7 @@ main(int argc, const char **argv)
 
   // This is a little bit of a hack, for now it'll suffice.
   max_records_entries = 262144;
-  RecProcessInit(RECM_STAND_ALONE, diags);
+  RecProcessInit(RECM_STAND_ALONE, diags());
   LibRecordsConfigInit();
 
   ats_scoped_str rundir(RecConfigReadRuntimeDir());

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -128,15 +128,15 @@ rotateLogs()
   int diags_log_roll_int     = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_interval_sec");
   int diags_log_roll_size    = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb");
   int diags_log_roll_enable  = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
-  diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
-  diags->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
+  diags()->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
+  diags()->config_roll_outputlog((RollingEnabledValues)output_log_roll_enable, output_log_roll_int, output_log_roll_size);
 
   // Now we can actually roll the logs (if necessary)
-  if (diags->should_roll_diagslog()) {
+  if (diags()->should_roll_diagslog()) {
     mgmt_log("Rotated %s", diags_log_filename);
   }
 
-  if (diags->should_roll_outputlog()) {
+  if (diags()->should_roll_outputlog()) {
     // send a signal to TS to reload traffic.out, so the logfile is kept
     // synced across processes
     mgmt_log("Sending SIGUSR2 to TS");
@@ -548,8 +548,8 @@ main(int argc, const char **argv)
   // Bootstrap the Diags facility so that we can use it while starting
   //  up the manager
   diagsConfig = new DiagsConfig("Manager", DEFAULT_DIAGS_LOG_FILENAME, debug_tags, action_tags, false);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
 
   RecLocalInit();
   LibRecordsConfigInit();
@@ -604,14 +604,14 @@ main(int argc, const char **argv)
     old_diagsconfig = nullptr;
   }
 
-  RecSetDiags(diags);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  RecSetDiags(diags());
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
 
   if (is_debug_tag_set("diags")) {
-    diags->dump();
+    diags()->dump();
   }
-  diags->cleanup_func = mgmt_cleanup;
+  diags()->cleanup_func = mgmt_cleanup;
 
   // Setup the exported manager version records.
   RecSetRecordString("proxy.node.version.manager.short", appVersionInfo.VersionStr, REC_SOURCE_DEFAULT);
@@ -940,9 +940,9 @@ SignalHandler(int sig)
     if (lmgmt && lmgmt->watched_process_pid != -1) {
       kill(lmgmt->watched_process_pid, sig);
     }
-    diags->set_std_output(StdStream::STDOUT, bind_stdout);
-    diags->set_std_output(StdStream::STDERR, bind_stderr);
-    if (diags->reseat_diagslog()) {
+    diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+    diags()->set_std_output(StdStream::STDERR, bind_stderr);
+    if (diags()->reseat_diagslog()) {
       Note("Reseated %s", diags_log_filename);
     } else {
       Note("Could not reseat %s", diags_log_filename);

--- a/src/traffic_quic/diags.h
+++ b/src/traffic_quic/diags.h
@@ -34,13 +34,9 @@ reconfigure_diags()
   int i;
   DiagsConfigState c;
 
-  // initial value set to 0 or 1 based on command line tags
-  c.enabled[DiagsTagType_Debug]  = (diags->base_debug_tags != nullptr);
-  c.enabled[DiagsTagType_Action] = (diags->base_action_tags != nullptr);
-
-  c.enabled[DiagsTagType_Debug]  = 1;
-  c.enabled[DiagsTagType_Action] = 1;
-  diags->show_location           = SHOW_LOCATION_ALL;
+  c.enabled(DiagsTagType_Debug, 1);
+  c.enabled(DiagsTagType_Action, 1);
+  diags()->show_location = SHOW_LOCATION_ALL;
 
   // read output routing values
   for (i = 0; i < DL_Status; i++) {
@@ -61,25 +57,27 @@ reconfigure_diags()
   // clear out old tag tables //
   //////////////////////////////
 
-  diags->deactivate_all(DiagsTagType_Debug);
-  diags->deactivate_all(DiagsTagType_Action);
+  diags()->deactivate_all(DiagsTagType_Debug);
+  diags()->deactivate_all(DiagsTagType_Action);
 
   //////////////////////////////////////////////////////////////////////
   //                     add new tag tables
   //////////////////////////////////////////////////////////////////////
 
-  if (diags->base_debug_tags)
-    diags->activate_taglist(diags->base_debug_tags, DiagsTagType_Debug);
-  if (diags->base_action_tags)
-    diags->activate_taglist(diags->base_action_tags, DiagsTagType_Action);
+  if (diags()->base_debug_tags) {
+    diags()->activate_taglist(diags()->base_debug_tags, DiagsTagType_Debug);
+  }
+  if (diags()->base_action_tags) {
+    diags()->activate_taglist(diags()->base_action_tags, DiagsTagType_Action);
+  }
 
 ////////////////////////////////////
 // change the diags config values //
 ////////////////////////////////////
 #if !defined(__GNUC__) && !defined(hpux)
-  diags->config = c;
+  diags()->config = c;
 #else
-  memcpy(((void *)&diags->config), ((void *)&c), sizeof(DiagsConfigState));
+  memcpy(((void *)&diags()->config), ((void *)&c), sizeof(DiagsConfigState));
 #endif
 }
 
@@ -89,7 +87,7 @@ init_diags(const char *bdt, const char *bat)
   char diags_logpath[500];
   strcpy(diags_logpath, DIAGS_LOG_FILE);
 
-  diags = new Diags("Client", bdt, bat, new BaseLogFile(diags_logpath));
+  DiagsPtr::set(new Diags("Client", bdt, bat, new BaseLogFile(diags_logpath)));
   Status("opened %s", diags_logpath);
 
   reconfigure_diags();

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -24,15 +24,13 @@
 #include <cstdio>
 #include <atomic>
 #include <string_view>
-#include <tuple>
-#include <unordered_map>
-#include <string_view>
 
 #include "tscore/ink_platform.h"
 #include "tscore/ink_base64.h"
 #include "tscore/PluginUserArgs.h"
 #include "tscore/I_Layout.h"
 #include "tscore/I_Version.h"
+#include "tscore/Diags.h"
 
 #include "InkAPIInternal.h"
 #include "Log.h"
@@ -7695,17 +7693,17 @@ ink_sanity_check_stat_structure(void *obj)
 int
 TSIsDebugTagSet(const char *t)
 {
-  return is_debug_tag_set(t);
+  return diags()->on_for_TSDebug(t);
 }
 
 void
 TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...)
 {
-  if ((debug_flag && diags->on()) || is_debug_tag_set(tag)) {
+  if ((debug_flag && diags()->on_for_TSDebug()) || diags()->on_for_TSDebug(tag)) {
     va_list ap;
 
     va_start(ap, format_str);
-    diags->print_va(tag, DL_Diag, nullptr, format_str, ap);
+    diags()->print_va(tag, DL_Diag, nullptr, format_str, ap);
     va_end(ap);
   }
 }
@@ -7715,13 +7713,23 @@ TSDebugSpecific(int debug_flag, const char *tag, const char *format_str, ...)
 void
 TSDebug(const char *tag, const char *format_str, ...)
 {
-  if (is_debug_tag_set(tag)) {
+  if (diags()->on_for_TSDebug() && diags()->tag_activated(tag)) {
     va_list ap;
 
     va_start(ap, format_str);
-    diags->print_va(tag, DL_Diag, nullptr, format_str, ap);
+    diags()->print_va(tag, DL_Diag, nullptr, format_str, ap);
     va_end(ap);
   }
+}
+
+void
+_TSDbg(const char *tag, const char *format_str, ...)
+{
+  va_list ap;
+
+  va_start(ap, format_str);
+  diags()->print_va(tag, DL_Diag, nullptr, format_str, ap);
+  va_end(ap);
 }
 
 /**************************   Logging API   ****************************/
@@ -10226,4 +10234,13 @@ TSHttpTxnPostBufferReaderGet(TSHttpTxn txnp)
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   HttpSM *sm = (HttpSM *)txnp;
   return (TSIOBufferReader)sm->get_postbuf_clone_reader();
+}
+
+tsapi TSDbgCtl const *
+TSDbgCtlCreate(char const *tag)
+{
+  sdk_assert(tag != nullptr);
+  sdk_assert(*tag != '\0');
+
+  return DbgCtl::_get_ptr(tag);
 }

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -294,9 +294,9 @@ public:
 
       Debug("log", "received SIGUSR2, reloading traffic.out");
       // reload output logfile (file is usually called traffic.out)
-      diags->set_std_output(StdStream::STDOUT, bind_stdout);
-      diags->set_std_output(StdStream::STDERR, bind_stderr);
-      if (diags->reseat_diagslog()) {
+      diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+      diags()->set_std_output(StdStream::STDERR, bind_stderr);
+      if (diags()->reseat_diagslog()) {
         Note("Reseated %s", diags_log_filename);
       } else {
         Note("Could not reseat %s", diags_log_filename);
@@ -405,9 +405,9 @@ public:
     int diags_log_roll_int    = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_interval_sec");
     int diags_log_roll_size   = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb");
     int diags_log_roll_enable = (int)REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled");
-    diags->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
+    diags()->config_roll_diagslog((RollingEnabledValues)diags_log_roll_enable, diags_log_roll_int, diags_log_roll_size);
 
-    if (diags->should_roll_diagslog()) {
+    if (diags()->should_roll_diagslog()) {
       Note("Rolled %s", diags_log_filename);
     }
     return EVENT_CONT;
@@ -511,9 +511,9 @@ void
 set_debug_ip(const char *ip_string)
 {
   if (ip_string) {
-    diags->debug_client_ip.load(ip_string);
+    diags()->debug_client_ip.load(ip_string);
   } else {
-    diags->debug_client_ip.invalidate();
+    diags()->debug_client_ip.invalidate();
   }
 }
 
@@ -672,7 +672,7 @@ initialize_process_manager()
     EnableDeathSignal(SIGTERM);
   }
 
-  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags);
+  RecProcessInit(remote_management_flag ? RECM_CLIENT : RECM_STAND_ALONE, diags());
   LibRecordsConfigInit();
 
   // Start up manager
@@ -1788,10 +1788,10 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // This is also needed for log rotation - setting up the file can cause privilege
   // related errors and if diagsConfig isn't get up yet that will crash on a NULL pointer.
   diagsConfig = new DiagsConfig("Server", DEFAULT_DIAGS_LOG_FILENAME, error_tags, action_tags, false);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
   if (is_debug_tag_set("diags")) {
-    diags->dump();
+    diags()->dump();
   }
 
   // Bind stdout and stderr to specified switches
@@ -1886,11 +1886,11 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   }
   DiagsConfig *old_log = diagsConfig;
   diagsConfig          = new DiagsConfig("Server", diags_log_filename, error_tags, action_tags, true);
-  RecSetDiags(diags);
-  diags->set_std_output(StdStream::STDOUT, bind_stdout);
-  diags->set_std_output(StdStream::STDERR, bind_stderr);
+  RecSetDiags(diags());
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
   if (is_debug_tag_set("diags")) {
-    diags->dump();
+    diags()->dump();
   }
 
   if (old_log) {

--- a/src/tscore/DbgCtl.cc
+++ b/src/tscore/DbgCtl.cc
@@ -1,0 +1,111 @@
+/** @file
+
+  Implementation file for DbgCtl class.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <mutex>
+#include <atomic>
+#include <set>
+#include <cstring>
+
+#include <tscore/Diags.h>
+
+// The resistry of fast debug controllers has a ugly implementation to handle the whole-program initialization
+// order problem with C++.
+//
+class DbgCtl::_RegistryAccessor
+{
+private:
+  struct TagCmp {
+    bool
+    operator()(TSDbgCtl const &a, TSDbgCtl const &b) const
+    {
+      return std::strcmp(a.tag, b.tag) < 0;
+    }
+  };
+
+public:
+  _RegistryAccessor() : _lg(data().mtx) {}
+
+  using Set = std::set<TSDbgCtl, TagCmp>;
+
+  struct Data {
+    std::mutex mtx;
+    Set set;
+  };
+
+  static Data &
+  data()
+  {
+    static Data d;
+    return d;
+  }
+
+private:
+  std::lock_guard<std::mutex> _lg;
+};
+
+TSDbgCtl const *
+DbgCtl::_get_ptr(char const *tag)
+{
+  ink_assert(tag != nullptr);
+
+  TSDbgCtl ctl;
+
+  ctl.tag = tag;
+
+  _RegistryAccessor ra;
+
+  auto &d{ra.data()};
+
+  if (auto it = d.set.find(ctl); it != d.set.end()) {
+    return &*it;
+  }
+
+  auto sz = std::strlen(tag);
+
+  ink_assert(sz > 0);
+
+  {
+    char *t = new char[sz + 1]; // Deleted implicitly by program termination.
+    std::memcpy(t, tag, sz + 1);
+    ctl.tag = t;
+  }
+  ctl.on = diags() && diags()->tag_activated(tag, DiagsTagType_Debug);
+
+  auto res = d.set.insert(ctl);
+
+  return &*res.first;
+}
+
+void
+DbgCtl::update()
+{
+  ink_release_assert(diags() != nullptr);
+
+  _RegistryAccessor ra;
+
+  auto &d{ra.data()};
+
+  for (auto &i : d.set) {
+    const_cast<char volatile &>(i.on) = diags()->tag_activated(i.tag, DiagsTagType_Debug);
+  }
+}

--- a/src/tscore/Diags.cc
+++ b/src/tscore/Diags.cc
@@ -47,11 +47,34 @@
 #include "tscore/BufferWriter.h"
 #include "tscore/Diags.h"
 
-int diags_on_for_plugins         = 0;
-int DiagsConfigState::enabled[2] = {0, 0};
+int diags_on_for_plugins          = 0;
+char ts_new_debug_on_flag_        = 0;
+int DiagsConfigState::_enabled[2] = {0, 0};
+
+void
+DiagsConfigState::enabled(DiagsTagType dtt, int new_value)
+{
+  if (_enabled[dtt] == new_value) {
+    return;
+  }
+  _enabled[dtt] = new_value;
+
+  if (DiagsTagType_Debug == dtt) {
+    diags_on_for_plugins  = (1 & new_value) != 0;
+    ts_new_debug_on_flag_ = 3 == new_value;
+  }
+}
 
 // Global, used for all diagnostics
-Diags *diags = nullptr;
+Diags *DiagsPtr::_diags_ptr = nullptr;
+
+void
+DiagsPtr::set(Diags *new_ptr)
+{
+  _diags_ptr = new_ptr;
+
+  DbgCtl::update();
+}
 
 static bool
 location(const SourceLocation *loc, DiagsShowLocation show, DiagsLevel level)
@@ -115,9 +138,8 @@ Diags::Diags(std::string_view prefix_string, const char *bdt, const char *bat, B
     base_action_tags = ats_strdup(bat);
   }
 
-  config.enabled[DiagsTagType_Debug]  = (base_debug_tags != nullptr);
-  config.enabled[DiagsTagType_Action] = (base_action_tags != nullptr);
-  diags_on_for_plugins                = config.enabled[DiagsTagType_Debug];
+  config.enabled(DiagsTagType_Debug, base_debug_tags != nullptr ? 1 : 0);
+  config.enabled(DiagsTagType_Action, base_action_tags != nullptr ? 1 : 0);
 
   // The caller must always provide a non-empty prefix.
 
@@ -375,6 +397,9 @@ Diags::activate_taglist(const char *taglist, DiagsTagType mode)
     activated_tags[mode]->compile(taglist);
     unlock();
   }
+  if ((DiagsTagType_Debug == mode) && (this == diags())) {
+    DbgCtl::update();
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -396,6 +421,9 @@ Diags::deactivate_all(DiagsTagType mode)
     activated_tags[mode] = nullptr;
   }
   unlock();
+  if ((DiagsTagType_Debug == mode) && (this == diags())) {
+    DbgCtl::update();
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -446,9 +474,9 @@ Diags::dump(FILE *fp) const
   int i;
 
   fprintf(fp, "Diags:\n");
-  fprintf(fp, "  debug.enabled: %d\n", config.enabled[DiagsTagType_Debug]);
+  fprintf(fp, "  debug.enabled: %d\n", config.enabled(DiagsTagType_Debug));
   fprintf(fp, "  debug default tags: '%s'\n", (base_debug_tags ? base_debug_tags : "NULL"));
-  fprintf(fp, "  action.enabled: %d\n", config.enabled[DiagsTagType_Action]);
+  fprintf(fp, "  action.enabled: %d\n", config.enabled(DiagsTagType_Action));
   fprintf(fp, "  action default tags: '%s'\n", (base_action_tags ? base_action_tags : "NULL"));
   fprintf(fp, "  outputs:\n");
   for (i = 0; i < DiagsLevel_Count; i++) {

--- a/src/tscore/LogMessage.cc
+++ b/src/tscore/LogMessage.cc
@@ -84,7 +84,7 @@ LogMessage::standard_message_helper(DiagsLevel level, SourceLocation const &loc,
 {
   message_helper(
     _default_log_throttling_interval.load(),
-    [level, &loc](const char *fmt, va_list args) { diags->error_va(level, &loc, fmt, args); }, fmt, args);
+    [level, &loc](const char *fmt, va_list args) { diags()->error_va(level, &loc, fmt, args); }, fmt, args);
 }
 
 void
@@ -92,7 +92,7 @@ LogMessage::message_debug_helper(const char *tag, DiagsLevel level, SourceLocati
 {
   message_helper(
     _default_debug_throttling_interval.load(),
-    [tag, level, &loc](const char *fmt, va_list args) { diags->log_va(tag, level, &loc, fmt, args); }, fmt, args);
+    [tag, level, &loc](const char *fmt, va_list args) { diags()->log_va(tag, level, &loc, fmt, args); }, fmt, args);
 }
 
 void
@@ -100,7 +100,7 @@ LogMessage::message_print_helper(const char *tag, DiagsLevel level, SourceLocati
 {
   message_helper(
     _default_debug_throttling_interval.load(),
-    [tag, level, &loc](const char *fmt, va_list args) { diags->print_va(tag, level, &loc, fmt, args); }, fmt, args);
+    [tag, level, &loc](const char *fmt, va_list args) { diags()->print_va(tag, level, &loc, fmt, args); }, fmt, args);
 }
 
 LogMessage::LogMessage(bool is_throttled)
@@ -121,15 +121,6 @@ LogMessage::diag(const char *tag, SourceLocation const &loc, const char *fmt, ..
   va_list args;
   va_start(args, fmt);
   message_debug_helper(tag, DL_Diag, loc, fmt, args);
-  va_end(args);
-}
-
-void
-LogMessage::debug(const char *tag, SourceLocation const &loc, const char *fmt, ...)
-{
-  va_list args;
-  va_start(args, fmt);
-  message_debug_helper(tag, DL_Debug, loc, fmt, args);
   va_end(args);
 }
 

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -59,6 +59,7 @@ libtscore_la_SOURCES = \
 	ConsistentHash.cc \
 	ContFlags.cc \
 	CryptoHash.cc \
+	DbgCtl.cc \
 	Diags.cc \
 	Errata.cc \
 	EventNotify.cc \

--- a/src/tscore/ink_cap.cc
+++ b/src/tscore/ink_cap.cc
@@ -46,7 +46,7 @@ ink_mutex ElevateAccess::lock = INK_MUTEX_INIT;
 
 #define DEBUG_CREDENTIALS(tag)                                                                                               \
   do {                                                                                                                       \
-    if (is_debug_tag_set(tag)) {                                                                                             \
+    if (diags()->on(tag)) {                                                                                                  \
       uid_t uid = -1, euid = -1, suid = -1;                                                                                  \
       gid_t gid = -1, egid = -1, sgid = -1;                                                                                  \
       getresuid(&uid, &euid, &suid);                                                                                         \
@@ -60,7 +60,7 @@ ink_mutex ElevateAccess::lock = INK_MUTEX_INIT;
 
 #define DEBUG_PRIVILEGES(tag)                                                                                    \
   do {                                                                                                           \
-    if (is_debug_tag_set(tag)) {                                                                                 \
+    if (diags()->on(tag)) {                                                                                      \
       cap_t caps      = cap_get_proc();                                                                          \
       char *caps_text = cap_to_text(caps, nullptr);                                                              \
       Debug(tag, "caps='%s', core=%s, death signal=%d, thread=0x%llx", caps_text, is_dumpable(), death_signal(), \
@@ -74,7 +74,7 @@ ink_mutex ElevateAccess::lock = INK_MUTEX_INIT;
 
 #define DEBUG_PRIVILEGES(tag)                                                                       \
   do {                                                                                              \
-    if (is_debug_tag_set(tag)) {                                                                    \
+    if (diags()->on(tag)) {                                                                         \
       Debug(tag, "caps='', core=%s, death signal=%d, thread=0x%llx", is_dumpable(), death_signal(), \
             (unsigned long long)pthread_self());                                                    \
     }                                                                                               \

--- a/src/tscore/unit_tests/test_X509HostnameValidator.cc
+++ b/src/tscore/unit_tests/test_X509HostnameValidator.cc
@@ -172,7 +172,7 @@ int
 main(int argc, const char **argv)
 {
   BaseLogFile *blf = new BaseLogFile("stdout");
-  diags            = new Diags("test_x509", nullptr, nullptr, blf);
+  DiagsPtr::set(new Diags("test_x509", nullptr, nullptr, blf));
   res_track_memory = 1;
 
   SSL_library_init();

--- a/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
@@ -40,6 +40,10 @@ namespace
 {
 char PIName[] = PINAME;
 
+auto dbg_ctl = TSDbgCtlCreate(PIName);
+
+auto off_dbg_ctl = TSDbgCtlCreate("yada-yada-yada");
+
 // NOTE:  It's important to flush this after writing so that a gold test using this plugin can examine the log before TS
 // terminates.
 //
@@ -172,7 +176,11 @@ transactionContFunc(TSCont, TSEvent event, void *eventData)
 {
   logFile << "Transaction: event=" << TSHttpEventNameLookup(event) << std::endl;
 
-  TSDebug(PIName, "Transaction: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
+  TSDbg(dbg_ctl, "Transaction: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
+
+  TSDebug(PIName, "Should not see this, enabled set to 3");
+
+  TSDbg(off_dbg_ctl, "Should not see this, tag does not match regular expression");
 
   switch (event) {
   case TS_EVENT_HTTP_READ_REQUEST_HDR: {
@@ -205,7 +213,7 @@ globalContFunc(TSCont, TSEvent event, void *eventData)
 {
   logFile << "Global: event=" << TSHttpEventNameLookup(event) << std::endl;
 
-  TSDebug(PIName, "Global: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
+  TSDbg(dbg_ctl, "Global: event=%s(%d) eventData=%p", TSHttpEventNameLookup(event), event, eventData);
 
   switch (event) {
   case TS_EVENT_HTTP_TXN_START: {
@@ -247,7 +255,7 @@ globalContFunc(TSCont, TSEvent event, void *eventData)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  TSDebug(PIName, "TSRemapInit()");
+  TSDbg(dbg_ctl, "TSRemapInit()");
 
   TSReleaseAssert(api_info && errbuf && errbuf_size);
 

--- a/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
@@ -53,7 +53,7 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.enabled': 3,
     'proxy.config.diags.debug.tags': 'http|test_tsapi',
 })
 


### PR DESCRIPTION
Setting proxy.config.diags.debug.enabled to 3 enables most core debug output (whose tag matches the debug
regex), and plugin debug output from the new API macro TSDbg().  Setting it to 1 enables all (matching) debug
output, but with the previous high overhead.

Note that enabling a large qualtity of debug output will still have a big impact on performance.