### PR TITLE
Doc: Clarify connection direction of configs in sni.yaml

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -46,106 +46,106 @@ the user needs to enter the fqdn in the configuration with a ``*.`` followed by 
 .. _override-verify-server-properties:
 .. _override-host-sni-policy:
 
-========================= ========================================================================================
-Key                       Meaning
-========================= ========================================================================================
-fqdn                      Fully Qualified Domain Name. This item is used if the SNI value matches this.
+========================= ========= ========================================================================================
+Key                       Direction Meaning
+========================= ========= ========================================================================================
+fqdn                      Both      Fully Qualified Domain Name. This item is used if the SNI value matches this.
 
-ip_allow                  Specify a list of client IP address, subnets, or ranges what are allowed to complete
-                          the connection. This list is comma separated. IPv4 and IPv6 addresses can be specified.
-                          Here is an example list: 192.168.1.0/24,192.168.10.1-4. This would allow connections
-                          from clients in the 19.168.1.0 network or in the range from 192.168.10.1 to 192.168.1.4.
+ip_allow                  Inbound   Specify a list of client IP address, subnets, or ranges what are allowed to complete
+                                    the connection. This list is comma separated. IPv4 and IPv6 addresses can be specified.
+                                    Here is an example list: 192.168.1.0/24,192.168.10.1-4. This would allow connections
+                                    from clients in the 19.168.1.0 network or in the range from 192.168.10.1 to 192.168.1.4.
 
-verify_server_policy      One of the values :code:`DISABLED`, :code:`PERMISSIVE`, or :code:`ENFORCED`.
+verify_server_policy      Outbound  One of the values :code:`DISABLED`, :code:`PERMISSIVE`, or :code:`ENFORCED`.
 
-                          By default this is :ts:cv:`proxy.config.ssl.client.verify.server.policy`.
-                          This controls how |TS| evaluated the origin certificate.
+                                    By default this is :ts:cv:`proxy.config.ssl.client.verify.server.policy`.
+                                    This controls how |TS| evaluated the origin certificate.
 
-verify_server_properties  One of the values :code:`NONE`, :code:`SIGNATURE`, :code:`NAME`, and :code:`ALL`
+verify_server_properties  Outbound  One of the values :code:`NONE`, :code:`SIGNATURE`, :code:`NAME`, and :code:`ALL`
 
-                          By default this is :ts:cv:`proxy.config.ssl.client.verify.server.properties`.
-                          This controls what |TS| checks when evaluating the origin certificate.
+                                    By default this is :ts:cv:`proxy.config.ssl.client.verify.server.properties`.
+                                    This controls what |TS| checks when evaluating the origin certificate.
 
-verify_client             One of the values :code:`NONE`, :code:`MODERATE`, or :code:`STRICT`.
-                          If ``NONE`` is specified, |TS| requests no certificate.  If ``MODERATE`` is specified
-                          |TS| will verify a certificate that is presented by the client, but it will not
-                          fail the TLS handshake if no certificate is presented.  If ``STRICT`` is specified
-                          the client must present a certificate during the TLS handshake.
+verify_client             Outbound  One of the values :code:`NONE`, :code:`MODERATE`, or :code:`STRICT`.
+                                    If ``NONE`` is specified, |TS| requests no certificate.  If ``MODERATE`` is specified
+                                    |TS| will verify a certificate that is presented by the client, but it will not
+                                    fail the TLS handshake if no certificate is presented.  If ``STRICT`` is specified
+                                    the client must present a certificate during the TLS handshake.
 
-                          By default this is :ts:cv:`proxy.config.ssl.client.certification_level`.
+                                    By default this is :ts:cv:`proxy.config.ssl.client.certification_level`.
 
-verify_client_ca_certs    Specifies an alternate set of certificate authority certs to use to verify the
-                          client cert.  The value must be either a file path, or a nested set of key /
-                          value pairs.  If the value is a file path, it must specify a file containing the
-                          CA certs.  Otherwise, there should be up to two nested pairs.  The possible keys
-                          are ``file`` and ``dir``.  The value for ``file`` must be a file path for a file
-                          containing CA certs.  The value for ``dir`` must be a file path for an OpenSSL
-                          X509 hashed directory containing CA certs.  If a given file path does not being
-                          with ``/`` , it must be relative to the |TS| configuration directory.
-                          ``verify_client_ca_certs`` can only be used with capbilities provided by
-                          OpenSSL 1.0.2 or later.
+verify_client_ca_certs    Both      Specifies an alternate set of certificate authority certs to use to verify the
+                                    client cert.  The value must be either a file path, or a nested set of key /
+                                    value pairs.  If the value is a file path, it must specify a file containing the
+                                    CA certs.  Otherwise, there should be up to two nested pairs.  The possible keys
+                                    are ``file`` and ``dir``.  The value for ``file`` must be a file path for a file
+                                    containing CA certs.  The value for ``dir`` must be a file path for an OpenSSL
+                                    X509 hashed directory containing CA certs.  If a given file path does not being
+                                    with ``/`` , it must be relative to the |TS| configuration directory.
+                                    ``verify_client_ca_certs`` can only be used with capbilities provided by
+                                    OpenSSL 1.0.2 or later.
 
-host_sni_policy           One of the values :code:`DISABLED`, :code:`PERMISSIVE`, or :code:`ENFORCED`.
+host_sni_policy           Inbound   One of the values :code:`DISABLED`, :code:`PERMISSIVE`, or :code:`ENFORCED`.
 
-                          If not specified, the value of :ts:cv:`proxy.config.http.host_sni_policy` is used.
-                          This controls how policy impacting mismatches between host header and SNI values are
-                          dealt with.
+                                    If not specified, the value of :ts:cv:`proxy.config.http.host_sni_policy` is used.
+                                    This controls how policy impacting mismatches between host header and SNI values are
+                                    dealt with.
 
-valid_tls_versions_in     This specifies the list of TLS protocols that will be offered to user agents during
-                          the TLS negotiation.  This replaces the global settings in
-                          :ts:cv:`proxy.config.ssl.TLSv1`, :ts:cv:`proxy.config.ssl.TLSv1_1`,
-                          :ts:cv:`proxy.config.ssl.TLSv1_2`, and :ts:cv:`proxy.config.ssl.TLSv1_3`. The potential
-                          values are TLSv1, TLSv1_1, TLSv1_2, and TLSv1_3.  You must list all protocols that |TS|
-                          should offer to the client when using this key.  This key is only valid for OpenSSL
-                          1.1.0 and later and BoringSSL. Older versions of OpenSSL do not provide a hook early enough to update
-                          the SSL object.  It is a syntax error for |TS| built against earlier versions.
+valid_tls_versions_in     Inbound   This specifies the list of TLS protocols that will be offered to user agents during
+                                    the TLS negotiation.  This replaces the global settings in
+                                    :ts:cv:`proxy.config.ssl.TLSv1`, :ts:cv:`proxy.config.ssl.TLSv1_1`,
+                                    :ts:cv:`proxy.config.ssl.TLSv1_2`, and :ts:cv:`proxy.config.ssl.TLSv1_3`. The potential
+                                    values are TLSv1, TLSv1_1, TLSv1_2, and TLSv1_3.  You must list all protocols that |TS|
+                                    should offer to the client when using this key.  This key is only valid for OpenSSL
+                                    1.1.0 and later and BoringSSL. Older versions of OpenSSL do not provide a hook early enough to update
+                                    the SSL object.  It is a syntax error for |TS| built against earlier versions.
 
-client_cert               The file containing the client certificate to use for the outbound connection.
+client_cert               Outbound  The file containing the client certificate to use for the outbound connection.
 
-                          If this is relative, it is relative to the path in
-                          :ts:cv:`proxy.config.ssl.client.cert.path`. If not set
-                          :ts:cv:`proxy.config.ssl.client.cert.filename` is used.
+                                    If this is relative, it is relative to the path in
+                                    :ts:cv:`proxy.config.ssl.client.cert.path`. If not set
+                                    :ts:cv:`proxy.config.ssl.client.cert.filename` is used.
 
-client_key                The file containing the client private key that corresponds to the certificate
-                          for the outbound connection.
+client_key                Outbound  The file containing the client private key that corresponds to the certificate
+                                    for the outbound connection.
 
-                          If this is relative, it is relative to the path in
-                          :ts:cv:`proxy.config.ssl.client.private_key.path`. If not set,
-                          |TS| tries to use a private key in client_cert.  Otherwise,
-                          :ts:cv:`proxy.config.ssl.client.private_key.filename` is used.
+                                    If this is relative, it is relative to the path in
+                                    :ts:cv:`proxy.config.ssl.client.private_key.path`. If not set,
+                                    |TS| tries to use a private key in client_cert.  Otherwise,
+                                    :ts:cv:`proxy.config.ssl.client.private_key.filename` is used.
 
-client_sni_policy         Policy of SNI on outbound connection.
+client_sni_policy         Outbound  Policy of SNI on outbound connection.
 
-                          If not specified, the value of :ts:cv:`proxy.config.ssl.client.sni_policy` is used.
+                                    If not specified, the value of :ts:cv:`proxy.config.ssl.client.sni_policy` is used.
 
-http2                     Indicates whether the H2 protocol should be added to or removed from the
-                          protocol negotiation list.  The valid values are :code:`on` or :code:`off`.
+http2                     Inbound   Indicates whether the H2 protocol should be added to or removed from the
+                                    protocol negotiation list.  The valid values are :code:`on` or :code:`off`.
 
-tunnel_route              Destination as an FQDN and port, separated by a colon ``:``.
-                          Match group number can be specified by ``$N`` where N should refer to a specified group
-                          in the FQDN, ``tunnel_route: $1.domain``.
+tunnel_route              Inbound   Destination as an FQDN and port, separated by a colon ``:``.
+                                    Match group number can be specified by ``$N`` where N should refer to a specified group
+                                    in the FQDN, ``tunnel_route: $1.domain``.
 
-                          This will forward all traffic to the specified destination without first terminating
-                          the incoming TLS connection.
+                                    This will forward all traffic to the specified destination without first terminating
+                                    the incoming TLS connection.
 
-forward_route             Destination as an FQDN and port, separated by a colon ``:``.
+forward_route             Inbound   Destination as an FQDN and port, separated by a colon ``:``.
 
-                          This is similar to tunnel_route, but it terminates the TLS connection and forwards the
-                          decrypted traffic. |TS| will not interpret the decrypted data, so the contents do not
-                          need to be HTTP.
+                                    This is similar to tunnel_route, but it terminates the TLS connection and forwards the
+                                    decrypted traffic. |TS| will not interpret the decrypted data, so the contents do not
+                                    need to be HTTP.
 
-partial_blind_route       Destination as an FQDN and port, separated by a colon ``:``.
+partial_blind_route       Inbound   Destination as an FQDN and port, separated by a colon ``:``.
 
-                          This is similar to forward_route in that |TS| terminates the incoming TLS connection.
-                          In addition partial_blind_route creates a new TLS connection to the specified origin.
-                          It does not interpret the decrypted data before passing it to the origin TLS
-                          connection, so the contents do not need to be HTTP.
+                                    This is similar to forward_route in that |TS| terminates the incoming TLS connection.
+                                    In addition partial_blind_route creates a new TLS connection to the specified origin.
+                                    It does not interpret the decrypted data before passing it to the origin TLS
+                                    connection, so the contents do not need to be HTTP.
 
-tunnel_alpn               List of ALPN Protocol Ids for Partial Blind Tunnel.
+tunnel_alpn               Inbound   List of ALPN Protocol Ids for Partial Blind Tunnel.
 
-                          ATS negotiates application protocol with the client on behalf of the origin server.
-                          This only works with ``partial_blind_route``.
-========================= ========================================================================================
+                                    ATS negotiates application protocol with the client on behalf of the origin server.
+                                    This only works with ``partial_blind_route``.
+========================= ========= ========================================================================================
 
 Client verification, via ``verify_client``, corresponds to setting
 :ts:cv:`proxy.config.ssl.client.certification_level` for this connection as noted below.


### PR DESCRIPTION
IIUC, the `sni.yaml` works for both inbound and outbound TLS connections. But almost all of the configs work on inbound *or* outbound. This change clarifies which config works in which direction of TLS connection.