### PR TITLE
Add close header normalize openclose test

### DIFF
--- a/tests/gold_tests/continuations/openclose.test.py
+++ b/tests/gold_tests/continuations/openclose.test.py
@@ -51,7 +51,8 @@ ts.Disk.remap_config.AddLine(
         ts.Variables.port, server.Variables.Port)
 )
 
-cmd = 'curl -vs -H "host:oc.test" http://127.0.0.1:{0}'.format(ts.Variables.port)
+# Add connection close to ensure that the client connection closes promptly after completing the transaction
+cmd = 'curl -H "Connection: close" -vs -H "host:oc.test" http://127.0.0.1:{0}'.format(ts.Variables.port)
 numberOfRequests = 100
 
 tr = Test.AddTestRun()


### PR DESCRIPTION
Had a problem when debugging the H2 origin branch (PR #7622) that the openclose was failing because the client connections were staying open.  Adding the Connection: close header to the curl request to ensure that the client session is closed in a timely manner.