### PR TITLE
sslheaders AuTest: Skip if plugin does not exist

### DIFF
--- a/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
+++ b/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
@@ -22,6 +22,7 @@ Test sslheaders plugin.
 '''
 
 Test.SkipUnless(
+    Condition.PluginExists('sslheaders.so'),
     Condition.HasATSFeature('TS_USE_TLS_ALPN'),
     Condition.HasCurlFeature('http2'),
 )


### PR DESCRIPTION
Adding a skip condition on the sslheaders.test.py that verifies the
plugin exists (i.e., was configured and build) before running the test.
(cherry picked from commit 455b06eb3f44363007a475c1cd8c61d033a99c68)

Conflicts:
	tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py