### PR TITLE
Updating to AuTest 1.10.0

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -26,7 +26,7 @@ pyflakes = "*"
 [packages]
 
 # Keep init.cli.ext updated with this required autest version.
-autest = "==1.8.1"
+autest = "==1.10.0"
 
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -23,7 +23,7 @@ if sys.version_info < (3, 6, 0):
     host.WriteError(
         "You need python 3.6 or later to run these tests\n", show_stack=False)
 
-needed_autest_version = "1.8.1"
+needed_autest_version = "1.10.0"
 found_autest_version = AuTestVersion()
 if AuTestVersion() < needed_autest_version:
     host.WriteError(


### PR DESCRIPTION
This new release supports case-insensitive gold files. We intend to use
this for HTTP/2 curl AuTest gold files which, depending upon the version
of curl, may or may not lowercase field names.