### PR TITLE
Make HTTP/2 Curl AuTest gold files case insensitive

### DIFF
--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -206,7 +206,8 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl -vs -k --http2 https://127.0.0.1:{0}/huge_resp_hdrs'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/http2_8_stdout.gold"
-tr.Processes.Default.Streams.stderr = "gold/http2_8_stderr.gold"
+# Different versions of curl will have different cases for HTTP/2 field names.
+tr.Processes.Default.Streams.stderr = Testers.GoldFile("gold/http2_8_stderr.gold", case_insensitive=True)
 tr.StillRunningAfter = server
 
 # Test Case 9: Header Only Response - e.g. 204
@@ -214,5 +215,6 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl -vs -k --http2 https://127.0.0.1:{0}/status/204'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/http2_9_stdout.gold"
-tr.Processes.Default.Streams.stderr = "gold/http2_9_stderr.gold"
+# Different versions of curl will have different cases for HTTP/2 field names.
+tr.Processes.Default.Streams.stderr = Testers.GoldFile("gold/http2_9_stderr.gold", case_insensitive=True)
 tr.StillRunningAfter = server

--- a/tests/gold_tests/h2/http2_priority.test.py
+++ b/tests/gold_tests/h2/http2_priority.test.py
@@ -74,5 +74,6 @@ tr.Processes.Default.TimeOut = 5
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stdout = "gold/priority_0_stdout.gold"
-tr.Processes.Default.Streams.stderr = "gold/priority_0_stderr.gold"
+# Different versions of curl will have different cases for HTTP/2 field names.
+tr.Processes.Default.Streams.stderr = Testers.GoldFile("gold/priority_0_stderr.gold", case_insensitive=True)
 tr.StillRunningAfter = server

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -91,7 +91,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
 test_run.Processes.Default.StartBefore(Test.Processes.ts)
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_0_stdout.gold"
-test_run.Processes.Default.Streams.stderr = "gold/httpbin_0_stderr.gold"
+# Different versions of curl will have different cases for HTTP/2 field names.
+test_run.Processes.Default.Streams.stderr = Testers.GoldFile("gold/httpbin_0_stderr.gold", case_insensitive=True)
 test_run.StillRunningAfter = httpbin
 
 # Test Case 1: Empty response body
@@ -99,7 +100,8 @@ test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = 'curl -vs -k --http2 https://127.0.0.1:{0}/bytes/0'.format(ts.Variables.ssl_port)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_1_stdout.gold"
-test_run.Processes.Default.Streams.stderr = "gold/httpbin_1_stderr.gold"
+# Different versions of curl will have different cases for HTTP/2 field names.
+test_run.Processes.Default.Streams.stderr = Testers.GoldFile("gold/httpbin_1_stderr.gold", case_insensitive=True)
 test_run.StillRunningAfter = httpbin
 
 # Test Case 2: Chunked
@@ -108,7 +110,8 @@ test_run.Processes.Default.Command = 'curl -vs -k --http2 https://127.0.0.1:{0}/
     ts.Variables.ssl_port)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_2_stdout.gold"
-test_run.Processes.Default.Streams.stderr = "gold/httpbin_2_stderr.gold"
+# Different versions of curl will have different cases for HTTP/2 field names.
+test_run.Processes.Default.Streams.stderr = Testers.GoldFile("gold/httpbin_2_stderr.gold", case_insensitive=True)
 test_run.StillRunningAfter = httpbin
 
 # Test Case 3: Expect 100-Continue
@@ -117,7 +120,8 @@ test_run.Processes.Default.Command = "curl -vs -k --http2 https://127.0.0.1:{0}/
     ts.Variables.ssl_port, json_printer)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_3_stdout.gold"
-test_run.Processes.Default.Streams.stderr = "gold/httpbin_3_stderr.gold"
+# Different versions of curl will have different cases for HTTP/2 field names.
+test_run.Processes.Default.Streams.stderr = Testers.GoldFile("gold/httpbin_3_stderr.gold", case_insensitive=True)
 test_run.StillRunningAfter = httpbin
 
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.


### PR DESCRIPTION
Newer versions of Curl (7.67.0) lowercase HTTP/2 field names in
compliance with the HTTP/2 spec. Since some devs will have newer and
some older versions of Curl, this accommodates both by making the HTTP/2
gold files for AuTests match case-insensitively.