### PR TITLE
Fix has_consumer_besides_client to deal with no clients

### DIFF
--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -520,7 +520,7 @@ HttpTunnel::has_cache_writer() const
 inline bool
 HttpTunnel::has_consumer_besides_client() const
 {
-  bool res = true;
+  bool res = false; // case of no consumers
 
   for (const auto &consumer : consumers) {
     if (!consumer.alive) {


### PR DESCRIPTION
Introduced by PR #7641.   has_consumer_besides_clent should return false if there are no live consumers.

I ran into problems with the h2spec test on the h2 to origin branch once I rebased in this change.