### PR TITLE
Updating to AuTest 1.10.0

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -24,7 +24,10 @@ autopep8 = "*"
 pyflakes = "*"
 
 [packages]
-autest = "==1.8.0"
+
+# Keep init.cli.ext updated with this required autest version.
+autest = "==1.10.0"
+
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"
 dnslib = "*"

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -23,7 +23,7 @@ if sys.version_info < (3, 5, 0):
     host.WriteError(
         "You need python 3.5 or later to run these tests\n", show_stack=False)
 
-autest_version ="1.7.0"
+autest_version ="1.10.0"
 if AuTestVersion() < autest_version:
     host.WriteError(
         "Tests need AuTest version {ver} or better\n Please update AuTest:\n  pip install --upgrade autest\n".format(ver=autest_version), show_stack=False)


### PR DESCRIPTION
This is a cherry-pick of #7682 to 8.1.x

---

This new release supports case-insensitive gold files. We intend to use
this for HTTP/2 curl AuTest gold files which, depending upon the version
of curl, may or may not lowercase field names.
(cherry picked from commit 4c882701eac237614aea24485da4233a7aed99ce)

Conflicts:
	tests/Pipfile
	tests/gold_tests/autest-site/init.cli.ext