### PR TITLE
Use only one map in session cache instead of two

### DIFF
--- a/iocore/net/SSLSessionCache.h
+++ b/iocore/net/SSLSessionCache.h
@@ -135,14 +135,6 @@ private:
   mutable uint64_t hash_value = 0;
 };
 
-struct SSLSessionIDHash {
-  uint64_t
-  operator()(const SSLSessionID &id) const
-  {
-    return id.hash();
-  }
-};
-
 class SSLSession
 {
 public:
@@ -150,11 +142,9 @@ public:
   Ptr<IOBufferData> asn1_data; /* this is the ASN1 representation of the SSL_CTX */
   size_t len_asn1_data;
   Ptr<IOBufferData> extra_data;
-  ink_hrtime time_stamp;
 
-  SSLSession(const SSLSessionID &id, const Ptr<IOBufferData> &ssl_asn1_data, size_t len_asn1, Ptr<IOBufferData> &exdata,
-             ink_hrtime ts)
-    : session_id(id), asn1_data(ssl_asn1_data), len_asn1_data(len_asn1), extra_data(exdata), time_stamp(ts)
+  SSLSession(const SSLSessionID &id, const Ptr<IOBufferData> &ssl_asn1_data, size_t len_asn1, Ptr<IOBufferData> &exdata)
+    : session_id(id), asn1_data(ssl_asn1_data), len_asn1_data(len_asn1), extra_data(exdata)
   {
   }
 
@@ -177,8 +167,7 @@ private:
   void removeOldestSession(const std::unique_lock<std::shared_mutex> &lock);
 
   mutable std::shared_mutex mutex;
-  std::unordered_map<SSLSessionID, SSLSession *, SSLSessionIDHash> bucket_data;
-  std::map<ink_hrtime, SSLSession *> bucket_data_ts;
+  std::map<SSLSessionID, SSLSession *> bucket_data;
 };
 
 class SSLSessionCache


### PR DESCRIPTION
This should help reduce the CPU utilization some more, @shinrich found this when testing a new build in prod. The `std::unordered_map` was supposed to provide speed when `getSession` takes up majority of the session cache workload. But to retain the functionalities it had to work along side `std::map`, and looks like that is messing things up a bit.

```
   4.51%  traffic_server                                 [.] std::_Hashtable<SSLSessionID, std::pair<SSLSessionID const, SSLSession*>, std::allocator<std::pair<SSLSessionID const, SSLSession*> >, std::__detail::_Select1st, std:
   4.28%  libwaflzts.so                                  [.] ns_waflz::ac::find
   1.96%  libc-2.17.so                                   [.] __memcmp_sse4_1
```