### PR TITLE
Fix a bug in tspush that pushes corrupted content to cache

### DIFF
--- a/tools/tspush
+++ b/tools/tspush
@@ -50,8 +50,8 @@ HELP
 die ("--file and --url must be given!" ) unless ( $f_name && $url) ;
 
 open (my $fh, '<', $f_name) or die $!;
+chomp (my $f_type = `file -b --mime $f_name`);
 my $uri = URI->new($url);
-my $f_type = `file -b --mime $f_name`;
 
 #
 # read the file in one go:


### PR DESCRIPTION
`tspush` uses output from `file -b --mime` to set the `Content-Type` header for the cached object, but fails to strip a trailing newline in doing so. The extraneous newline inadvertently terminates the HTTP header, making Traffic Server recognize the following header fields as part of the cached body.

The following is an output of a curl request to content pushed using `tspush`. As can be seen, `Content-length: 34` is prepended to the response body.

    *   Trying 192.168.1.1:80...
    * Connected to ats (192.168.1.1) port 80 (#0)
    > GET /tspush HTTP/1.1
    > Host: ats
    > User-Agent: curl/7.74.0
    > Accept: */*
    >
    * Mark bundle as not supporting multiuse
    < HTTP/1.1 200 OK
    < Content-type: text/plain; charset=us-ascii
    < Age: 0
    < Date: Sun, 11 Apr 2021 07:17:59 GMT
    < Content-Length: 56
    < Connection: keep-alive
    < Server: ATS/9.0.0
    <
    Content-length: 34

    It's the season of White Album.

    * Connection #0 to host ats left intact
