### PR TITLE
Do NOT kill tunnel if it has any consumer besides HT_HTTP_CLIENT (#7641)

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -839,9 +839,9 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
    * client.
    */
   case VC_EVENT_EOS: {
-    // We got an early EOS.
+    // We got an early EOS. If the tunnal has cache writer, don't kill it for background fill.
     NetVConnection *netvc = ua_txn->get_netvc();
-    if (ua_txn->allow_half_open()) {
+    if (ua_txn->allow_half_open() || tunnel.has_consumer_besides_client()) {
       if (netvc) {
         netvc->do_io_shutdown(IO_SHUTDOWN_READ);
       }

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -521,7 +521,7 @@ HttpTunnel::has_cache_writer() const
 inline bool
 HttpTunnel::has_consumer_besides_client() const
 {
-  bool res = true;
+  bool res = false; // case of no consumers
 
   for (const auto &consumer : consumers) {
     if (!consumer.alive) {

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -282,6 +282,7 @@ public:
   }
   bool is_tunnel_alive() const;
   bool has_cache_writer() const;
+  bool has_consumer_besides_client() const;
 
   HttpTunnelProducer *add_producer(VConnection *vc, int64_t nbytes, IOBufferReader *reader_start, HttpProducerHandler sm_handler,
                                    HttpTunnelType_t vc_type, const char *name);
@@ -512,6 +513,31 @@ HttpTunnel::has_cache_writer() const
     }
   }
   return false;
+}
+
+/**
+   Return false if there is only a consumer for client
+ */
+inline bool
+HttpTunnel::has_consumer_besides_client() const
+{
+  bool res = true;
+
+  for (const auto &consumer : consumers) {
+    if (!consumer.alive) {
+      continue;
+    }
+
+    if (consumer.vc_type == HT_HTTP_CLIENT) {
+      res = false;
+      continue;
+    } else {
+      res = true;
+      break;
+    }
+  }
+
+  return res;
 }
 
 inline bool


### PR DESCRIPTION
    Fix has_consumer_besides_client to deal with no clients (#7685)

    (cherry picked from commit 09e72839258a4f748aace4908c996e843e6d5176)
----
    Do NOT kill tunnel if it has any consumer besides HT_HTTP_CLIENT (#7641)

    (cherry picked from commit 270ca6e84eba758e44c9b2a15046eaa7b8af8d8a)
----
Backport #7641 and #7685 to the 8.1.x branch.