### PR TITLE
Remove configure-time loopback interface detection

### DIFF
--- a/build/network.m4
+++ b/build/network.m4
@@ -19,24 +19,6 @@ dnl network.m4: Trafficserver's autoconf macros for testing network support
 dnl
 
 dnl
-dnl TS_CHECK_LOOPBACK_IFACE: try to figure out default loopback interface
-dnl
-AC_DEFUN([TS_CHECK_LOOPBACK_IFACE], [
-default_loopback_iface=""
-AC_MSG_CHECKING([for loopback network interface])
-case $host_os in
-  linux*)
-    default_loopback_iface=lo
-  ;;
-darwin* | freebsd* | solaris*)
-  default_loopback_iface=lo0
-  ;;
-esac
-AC_MSG_RESULT([$default_loopback_iface])
-AC_SUBST([default_loopback_iface])
-])
-
-dnl
 dnl Check on IN6_IS_ADDR_UNSPECIFIED. We can't just check if it is defined
 dnl because some releases of FreeBSD and Solaris define it incorrectly.
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -2102,7 +2102,6 @@ AC_SUBST(has_so_mark)
 AC_SUBST(has_ip_tos)
 AC_SUBST(has_so_peercred)
 
-TS_CHECK_LOOPBACK_IFACE
 TS_CHECK_MACRO_IN6_IS_ADDR_UNSPECIFIED
 
 AC_CHECK_TYPE([struct tcp_info],

--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -121,7 +121,5 @@
 
 #define TS_BUILD_CANONICAL_HOST "@host@"
 
-#define TS_BUILD_DEFAULT_LOOPBACK_IFACE "@default_loopback_iface@"
-
 static const int DEFAULT_STACKSIZE = @default_stack_size@;
 /* clang-format on */


### PR DESCRIPTION
This was used by the now obsolete clustering implementation