### PR TITLE
Include in parentselectdefs.h in install target

### DIFF
--- a/include/ts/Makefile.am
+++ b/include/ts/Makefile.am
@@ -22,7 +22,8 @@ library_include_HEADERS = \
 	apidefs.h \
 	ts.h \
 	remap.h \
-	experimental.h
+	experimental.h \
+	parentselectdefs.h
 
 noinst_HEADERS = \
 	InkAPIPrivateIOCore.h


### PR DESCRIPTION
Required now that ts/ts.h includes it (#7467)