### PR TITLE
uri_signing: fix warning which affects ubuntu:20.04 builds

### DIFF
--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -355,11 +355,10 @@ check_auth:
   }
   return status;
 fail:
-  PluginDebug("Invalid JWT for %.*s", url_ct, url);
   TSHttpTxnStatusSet(txnp, TS_HTTP_STATUS_FORBIDDEN);
-  PluginDebug("Spent %" PRId64 " ns uri_signing verification of %.*s.", mark_timer(&t), url_ct, url);
-
   if (url != NULL) {
+    PluginDebug("Invalid JWT for %.*s", url_ct, url);
+    PluginDebug("Spent %" PRId64 " ns uri_signing verification of %.*s.", mark_timer(&t), url_ct, url);
     TSfree((void *)url);
   }
   if (strip_uri != NULL) {


### PR DESCRIPTION
This fixes new CI errors in ubuntu:20.04 gcc due to these warnings:

```
In file included from ../../plugins/experimental/uri_signing/uri_signing.c:19:
../../plugins/experimental/uri_signing/uri_signing.c: In function 'TSRemapDoRemap':
../../plugins/experimental/uri_signing/common.h:37:31: error: '%.*s' directive argument is null [-Werror=format-overflow=]
   37 | #define PluginDebug(fmt, ...) TSDebug(PLUGIN_NAME, "[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../plugins/experimental/uri_signing/uri_signing.c:358:3: note: in expansion of macro 'PluginDebug'
  358 |   PluginDebug("Invalid JWT for %.*s", url_ct, url);
      |   ^~~~~~~~~~~
../../plugins/experimental/uri_signing/uri_signing.c:360:40: note: format string is defined here
  360 |   PluginDebug("Spent %" PRId64 " ns uri_signing verification of %.*s.", mark_timer(&t), url_ct, url);
      |                                        ^~~~
In file included from ../../plugins/experimental/uri_signing/uri_signing.c:19:
../../plugins/experimental/uri_signing/common.h:37:31: error: '%.*s' directive argument is null [-Werror=format-overflow=]
   37 | #define PluginDebug(fmt, ...) TSDebug(PLUGIN_NAME, "[%s:% 4d] %s(): " fmt, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../plugins/experimental/uri_signing/uri_signing.c:360:3: note: in expansion of macro 'PluginDebug'
  360 |   PluginDebug("Spent %" PRId64 " ns uri_signing verification of %.*s.", mark_timer(&t), url_ct, url);
      |   ^~~~~~~~~~~
../../plugins/experimental/uri_signing/uri_signing.c:360:65: note: format string is defined here
  360 |   PluginDebug("Spent %" PRId64 " ns uri_signing verification of %.*s.", mark_timer(&t), url_ct, url);
      |                                                                 ^~~~

```