### PR TITLE
Fix simple remapping in regex_remap plugin.

### DIFF
--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -1067,7 +1067,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
           const char *start = dest;
 
           // Setup the new URL
-          if (TS_PARSE_ERROR == TSUrlParse(src_url.bufp, src_url.loc, &start, start + dest_len)) {
+          if (TS_PARSE_ERROR == TSUrlParse(rri->redirect ? src_url.bufp : rri->requestBufp,
+                                           rri->redirect ? src_url.loc : rri->requestUrl, &start, start + dest_len)) {
             TSHttpTxnStatusSet(txnp, TS_HTTP_STATUS_INTERNAL_SERVER_ERROR);
             TSError("[%s] can't parse substituted URL string", PLUGIN_NAME);
           }

--- a/tests/gold_tests/pluginTest/regex_remap/gold/regex_remap_simple.gold
+++ b/tests/gold_tests/pluginTest/regex_remap/gold/regex_remap_simple.gold
@@ -1,0 +1,2 @@
+HTTP/1.1 200 OK
+Content-Length: 6128


### PR DESCRIPTION
Adds a test run to successfully remap a URL with host example.three, resulting in a 200 response.
It includes a bug fix for regex_remap.cc, needed so the test run will succeed.  The bug was probably
introduced by commit fee5ba1.