### PR TITLE
Fix doc for http2.no_activity_timeout_in

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3913,6 +3913,7 @@ HTTP/2 Configuration
    The value of ``0`` specifies that there is no timeout.
 
 .. ts:cv:: CONFIG proxy.config.http2.accept_no_activity_timeout INT 120
+   :reloadable:
 
    Specifies how long |TS| keeps connections to clients open if no
    activity is received on the connection. Lowering this timeout can ease
@@ -3920,6 +3921,7 @@ HTTP/2 Configuration
    a large number of connections without submitting requests.
 
 .. ts:cv:: CONFIG proxy.config.http2.no_activity_timeout_in INT 120
+   :reloadable:
 
    Specifies how long |TS| keeps connections to clients open if a
    transaction stalls. Lowering this timeout can ease pressure on the proxy if

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3913,8 +3913,6 @@ HTTP/2 Configuration
    The value of ``0`` specifies that there is no timeout.
 
 .. ts:cv:: CONFIG proxy.config.http2.accept_no_activity_timeout INT 120
-   :reloadable:
-   :overridable:
 
    Specifies how long |TS| keeps connections to clients open if no
    activity is received on the connection. Lowering this timeout can ease
@@ -3922,8 +3920,6 @@ HTTP/2 Configuration
    a large number of connections without submitting requests.
 
 .. ts:cv:: CONFIG proxy.config.http2.no_activity_timeout_in INT 120
-   :reloadable:
-   :overridable:
 
    Specifies how long |TS| keeps connections to clients open if a
    transaction stalls. Lowering this timeout can ease pressure on the proxy if


### PR DESCRIPTION
This closes #1663 

As discussed in that issue, the http2.no_activity_timeout_in setting and related accept version cannot be overriden.  They are updated on reload.  This PR updates the documentation to reflect reality.