### PR TITLE
if transaction status non-success, bypass intercept plugin

### DIFF
--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -46,8 +46,8 @@ read_request(TSHttpTxn txnp, Config *const config)
     if (!header.hasKey(SLICER_MIME_FIELD_INFO, SLICER_MIME_LEN_INFO)) {
       // check if any previous plugin has monkeyed with the transaction status
       TSHttpStatus const txnstat = TSHttpTxnStatusGet(txnp);
-      if (0 != static_cast<int>(txnstat)) {
-        DEBUG_LOG("txn status change detected (%d), skipping plugin\n", (int)txnstat);
+      if (TS_HTTP_STATUS_NONE != txnstat) {
+        DEBUG_LOG("txn status change detected (%d), skipping plugin\n", static_cast<int>(txnstat));
         return false;
       }
 

--- a/plugins/experimental/statichit/statichit.cc
+++ b/plugins/experimental/statichit/statichit.cc
@@ -563,6 +563,12 @@ TSRemapInit(TSRemapInterface * /* api_info */, char * /* errbuf */, int /* errbu
 TSRemapStatus
 TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
 {
+  const TSHttpStatus txnstat = TSHttpTxnStatusGet(rh);
+  if (txnstat != TS_HTTP_STATUS_NONE && txnstat != TS_HTTP_STATUS_OK) {
+    VDEBUG("transaction status_code=%d already set; skipping processing", static_cast<int>(txnstat));
+    return TSREMAP_NO_REMAP;
+  }
+
   StaticHitConfig *cfg = static_cast<StaticHitConfig *>(ih);
 
   if (!cfg) {

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -732,6 +732,12 @@ TSRemapInit(TSRemapInterface * /* api_info */, char * /* errbuf */, int /* errbu
 TSRemapStatus
 TSRemapDoRemap(void * /* ih */, TSHttpTxn txn, TSRemapRequestInfo *rri)
 {
+  const TSHttpStatus txnstat = TSHttpTxnStatusGet(txn);
+  if (txnstat != TS_HTTP_STATUS_NONE && txnstat != TS_HTTP_STATUS_OK) {
+    VDEBUG("transaction status_code=%d already set; skipping processing", static_cast<int>(txnstat));
+    return TSREMAP_NO_REMAP;
+  }
+
   // Check if we should turn off the cache before doing anything else ...
   CheckCacheable(txn, rri->requestUrl, rri->requestBufp);
   TSHttpTxnHookAdd(txn, TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK, TxnHook);


### PR DESCRIPTION
Don't allow the generator or statichit plugin to intercept the transaction
if a prior plugin has changed the transaction status to something non-success.