### PR TITLE
compress.test.py: Reference config file from Test.RunDirectory

### DIFF
--- a/tests/gold_tests/pluginTest/compress/compress.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress.test.py
@@ -85,19 +85,22 @@ def oneTs(name, AeHdr1='gzip, deflate, sdch, br'):
         'proxy.config.http.normalize_ae': 0,
     })
 
+    ts.Setup.Copy("compress.config")
+    ts.Setup.Copy("compress2.config")
+
     ts.Disk.remap_config.AddLine(
         'map http://ae-0/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-        ' @plugin=compress.so @pparam={}/compress.config'.format(Test.TestDirectory)
+        ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory)
     )
     ts.Disk.remap_config.AddLine(
         'map http://ae-1/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
         ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=1' +
-        ' @plugin=compress.so @pparam={}/compress.config'.format(Test.TestDirectory)
+        ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory)
     )
     ts.Disk.remap_config.AddLine(
         'map http://ae-2/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
         ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2' +
-        ' @plugin=compress.so @pparam={}/compress2.config'.format(Test.TestDirectory)
+        ' @plugin=compress.so @pparam={}/compress2.config'.format(Test.RunDirectory)
     )
 
     for i in range(3):


### PR DESCRIPTION
This is a cherry-pick of the following master PR to 8.1.x:
https://github.com/apache/trafficserver/pull/7725

-------

In certain environments in which AuTest is run, Test.TestDirectory is
not readable to the ATS process. Alter the test to reference the
compress.config file from the sandbox, which is curated to be readable
by the ATS process.
(cherry picked from commit 642003be5e6d7354dbf88451ad81e82f89478683)

Conflicts:
	tests/gold_tests/pluginTest/compress/compress.test.py