### PR TITLE
Fix build on FreeBSD 13

### DIFF
--- a/include/tscore/EventNotify.h
+++ b/include/tscore/EventNotify.h
@@ -45,7 +45,7 @@ public:
   ~EventNotify();
 
 private:
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
   int m_event_fd;
   int m_epoll_fd;
 #else

--- a/src/tscore/EventNotify.cc
+++ b/src/tscore/EventNotify.cc
@@ -31,7 +31,7 @@
 #include "tscore/ink_hrtime.h"
 #include "tscore/ink_defs.h"
 
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
 #include <sys/eventfd.h>
 #include <fcntl.h>
 #include <sys/epoll.h>
@@ -39,7 +39,7 @@
 
 EventNotify::EventNotify()
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
   int ret;
   struct epoll_event ev;
 
@@ -63,7 +63,7 @@ EventNotify::EventNotify()
 void
 EventNotify::signal()
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
   uint64_t value = 1;
   //
   // If the addition would cause the counter's value of eventfd
@@ -79,7 +79,7 @@ EventNotify::signal()
 int
 EventNotify::wait()
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
   ssize_t nr, nr_fd;
   uint64_t value = 0;
   struct epoll_event ev;
@@ -107,7 +107,7 @@ EventNotify::wait()
 int
 EventNotify::timedwait(int timeout) // milliseconds
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
   ssize_t nr, nr_fd = 0;
   uint64_t value = 0;
   struct epoll_event ev;
@@ -148,7 +148,7 @@ EventNotify::timedwait(int timeout) // milliseconds
 void
 EventNotify::lock()
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
 // do nothing
 #else
   ink_mutex_acquire(&m_mutex);
@@ -158,7 +158,7 @@ EventNotify::lock()
 bool
 EventNotify::trylock()
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
   return true;
 #else
   return ink_mutex_try_acquire(&m_mutex);
@@ -168,7 +168,7 @@ EventNotify::trylock()
 void
 EventNotify::unlock()
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
 // do nothing
 #else
   ink_mutex_release(&m_mutex);
@@ -177,7 +177,7 @@ EventNotify::unlock()
 
 EventNotify::~EventNotify()
 {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && TS_USE_EPOLL == 1
   close(m_event_fd);
   close(m_epoll_fd);
 #else


### PR DESCRIPTION
FreeBSD 13 added eventfd(2), which means that now having eventfd no
longer means that you'll also have epoll. This change updates
EventNotify to check for both eventfd(2) and epoll before trying to
use epoll.

Issue #7656 