### PR TITLE
Test: Add nameserver to TLS tunnel forward test.

### DIFF
--- a/tests/gold_tests/tls/tls_tunnel_forward.test.py
+++ b/tests/gold_tests/tls/tls_tunnel_forward.test.py
@@ -25,6 +25,7 @@ ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True)
 server_bar = Test.MakeOriginServer("server_bar", ssl=False)
 server_random = Test.MakeOriginServer("server_random", ssl=False)
+nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
 request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 request_bar_header = {"headers": "GET / HTTP/1.1\r\nHost: bar.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -65,7 +66,9 @@ ts.Disk.records_config.update({'proxy.config.ssl.server.cert.path': '{0}'.format
                                'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
                                'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
                                'proxy.config.exec_thread.autoconfig.scale': 1.0,
-                               'proxy.config.url_remap.pristine_host_hdr': 1})
+                               'proxy.config.url_remap.pristine_host_hdr': 1,
+                               'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+                               'proxy.config.dns.resolv_conf': 'NULL'})
 
 # foo.com should not terminate.  Just tunnel to server_foo
 # bar.com should terminate.  Forward its tcp stream to server_bar
@@ -85,6 +88,7 @@ tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(server_bar)
 tr.Processes.Default.StartBefore(server_random)
+tr.Processes.Default.StartBefore(nameserver)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")


### PR DESCRIPTION
This test uses an FQDN ("localhost") and therefore needs a local nameserver to make sure that is resolved as expected.