### PR TITLE
Remove unused variable is_revalidation_necessary

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2620,8 +2620,7 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
     case FRESHNESS_STALE:
       TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHitFreshness] "
                            "Stale in cache");
-      s->cache_lookup_result       = HttpTransact::CACHE_LOOKUP_HIT_STALE;
-      s->is_revalidation_necessary = true; // to identify a revalidation occurrence
+      s->cache_lookup_result = HttpTransact::CACHE_LOOKUP_HIT_STALE;
       break;
     default:
       ink_assert(!("what_is_document_freshness has returned unsupported code."));

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -677,7 +677,6 @@ public:
     HostDBApplicationInfo::HttpVersion updated_server_version = HostDBApplicationInfo::HTTP_VERSION_UNDEFINED;
     bool force_dns                                            = false;
     MgmtByte cache_open_write_fail_action                     = 0;
-    bool is_revalidation_necessary = false; // Added to check if revalidation is necessary - YTS Team, yamsat
     ConnectionAttributes client_info;
     ConnectionAttributes parent_info;
     ConnectionAttributes server_info;


### PR DESCRIPTION
```
$ git grep is_revalidation_necessary
proxy/http/HttpTransact.cc:      s->is_revalidation_necessary = true; // to identify a revalidation occurrence
proxy/http/HttpTransact.h:    bool is_revalidation_necessary = false; // Added to check if revalidation is necessary - YTS Team, yamsat
```

The code that used this variable was removed on dc33143ad63f9e6baff08697959572ad777e7008 in 2011.