### PR TITLE
Fixes Issue #7739 - Next hop strategy with bad 'to' URL causes TS crash.

### DIFF
--- a/proxy/http/remap/NextHopConsistentHash.cc
+++ b/proxy/http/remap/NextHopConsistentHash.cc
@@ -320,8 +320,10 @@ NextHopConsistentHash::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
       }
       switch (ring_mode) {
       case NH_ALTERNATE_RING:
-        if (groups > 0) {
+        if (pRec && groups > 0) {
           cur_ring = (pRec->group_index + 1) % groups;
+        } else {
+          cur_ring = 0;
         }
         break;
       case NH_EXHAUST_RING:


### PR DESCRIPTION
Fixes #7739 NextHopConsistentHash::findParent().  A crash occurs when searching for an available next hop results in a failure and alternate_ring mode is used.