### PR TITLE
AuTest extension: check for unrecognized configurations

### DIFF
--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -187,6 +187,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
         "ERROR:", "diags.log should not contain errors")
     p.Disk.diags_log.Content += Testers.ExcludesExpression(
         "FATAL:", "diags.log should not contain errors")
+    p.Disk.diags_log.Content += Testers.ExcludesExpression(
+        "Unrecognized configuration value",
+        "diags.log should not contain a warning about an unrecognized configuration")
 
     if command == "traffic_manager":
         fname = "manager.log"

--- a/tests/gold_tests/basic/deny0.test.py
+++ b/tests/gold_tests/basic/deny0.test.py
@@ -35,7 +35,6 @@ ts = Test.MakeATSProcess("ts", enable_cache=False)
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'http|dns|redirect',
-    'proxy.config.http.redirection_enabled': 1,
     'proxy.config.http.number_of_redirections': 1,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
     'proxy.config.dns.resolv_conf': 'NULL',

--- a/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
@@ -35,7 +35,6 @@ ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 ts.addDefaultSSLFiles()
 
 ts.Disk.records_config.update({
-    'proxy.config.http2.enabled': 1,    # this option is for VZM-internal only
     'proxy.config.diags.debug.enabled': 0,
     'proxy.config.diags.debug.tags': 'http',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),

--- a/tests/gold_tests/slow_post/slow_post.test.py
+++ b/tests/gold_tests/slow_post/slow_post.test.py
@@ -56,8 +56,6 @@ class SlowPostAttack:
             'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': 'http',
             'proxy.config.http.per_server.connection.max': self._origin_max_connections,
-            # Disable queueing when connection reaches limit
-            'proxy.config.http.per_server.connection.queue_size': 0,
         })
 
     def run(self):

--- a/tests/gold_tests/timeout/conn_timeout.test.py
+++ b/tests/gold_tests/timeout/conn_timeout.test.py
@@ -33,7 +33,6 @@ server4 = Test.MakeOriginServer("server4")
 ts.Disk.records_config.update({
     'proxy.config.url_remap.remap_required': 1,
     'proxy.config.http.connect_attempts_timeout': 2,
-    'proxy.config.http.post_connect_attempts_timeout': 2,
     'proxy.config.http.connect_attempts_max_retries': 0,
     'proxy.config.http.transaction_no_activity_timeout_out': 5,
     'proxy.config.diags.debug.enabled': 0,

--- a/tests/gold_tests/timeout/tls_conn_timeout.test.py
+++ b/tests/gold_tests/timeout/tls_conn_timeout.test.py
@@ -43,7 +43,6 @@ delay_get_ttfb = Test.Processes.Process(
 ts.Disk.records_config.update({
     'proxy.config.url_remap.remap_required': 1,
     'proxy.config.http.connect_attempts_timeout': 1,
-    'proxy.config.http.post_connect_attempts_timeout': 1,
     'proxy.config.http.connect_attempts_max_retries': 1,
     'proxy.config.http.transaction_no_activity_timeout_out': 4,
     'proxy.config.diags.debug.enabled': 0,


### PR DESCRIPTION
This adds a trafficserver AuTest extension check to verify that the
tester did not accidentally add an unrecognized configuration option.