### PR TITLE
Clean up HTTP version processing

### DIFF
--- a/include/tscore/HTTPVersion.h
+++ b/include/tscore/HTTPVersion.h
@@ -1,0 +1,152 @@
+/** @file
+
+  HTTPVersion - class to track the HTTP version
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+class HTTPVersion
+{
+public:
+  HTTPVersion() {}
+  HTTPVersion(HTTPVersion const &that) = default;
+  explicit HTTPVersion(int version);
+  constexpr HTTPVersion(uint8_t ver_major, uint8_t ver_minor);
+
+  int operator==(const HTTPVersion &hv) const;
+  int operator!=(const HTTPVersion &hv) const;
+  int operator>(const HTTPVersion &hv) const;
+  int operator<(const HTTPVersion &hv) const;
+  int operator>=(const HTTPVersion &hv) const;
+  int operator<=(const HTTPVersion &hv) const;
+
+  uint8_t get_major() const;
+  uint8_t get_minor() const;
+  int get_flat_version() const;
+
+private:
+  uint8_t vmajor = 0;
+  uint8_t vminor = 0;
+};
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline HTTPVersion::HTTPVersion(int version)
+{
+  vmajor = (version >> 16) & 0xFFFF;
+  vminor = version & 0xFFFF;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline constexpr HTTPVersion::HTTPVersion(uint8_t ver_major, uint8_t ver_minor) : vmajor(ver_major), vminor(ver_minor) {}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline uint8_t
+HTTPVersion::get_major() const
+{
+  return vmajor;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline uint8_t
+HTTPVersion::get_minor() const
+{
+  return vminor;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline int
+HTTPVersion::get_flat_version() const
+{
+  return vmajor << 16 | vminor;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline int
+HTTPVersion::operator==(const HTTPVersion &hv) const
+{
+  return vmajor == hv.get_major() && vminor == hv.get_minor();
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline int
+HTTPVersion::operator!=(const HTTPVersion &hv) const
+{
+  return !(*this == hv);
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline int
+HTTPVersion::operator>(const HTTPVersion &hv) const
+{
+  return vmajor > hv.get_major() || (vmajor == hv.get_major() && vminor > hv.get_minor());
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline int
+HTTPVersion::operator<(const HTTPVersion &hv) const
+{
+  return vmajor < hv.get_major() || (vmajor == hv.get_major() && vminor < hv.get_minor());
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline int
+HTTPVersion::operator>=(const HTTPVersion &hv) const
+{
+  return vmajor > hv.get_major() || (vmajor == hv.get_major() && vminor >= hv.get_minor());
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+inline int
+HTTPVersion::operator<=(const HTTPVersion &hv) const
+{
+  return vmajor < hv.get_major() || (vmajor == hv.get_major() && vminor <= hv.get_minor());
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+constexpr HTTPVersion HTTP_INVALID{0, 0};
+constexpr HTTPVersion HTTP_0_9{0, 9};
+constexpr HTTPVersion HTTP_1_0{1, 0};
+constexpr HTTPVersion HTTP_1_1{1, 1};
+constexpr HTTPVersion HTTP_2_0{2, 0};

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -31,6 +31,7 @@
 #include "I_EventSystem.h"
 #include "SRV.h"
 #include "P_RefCountCache.h"
+#include "HTTP.h"
 
 // Event returned on a lookup
 #define EVENT_HOST_DB_LOOKUP (HOSTDB_EVENT_EVENTS_START + 0)
@@ -99,17 +100,10 @@ union HostDBApplicationInfo {
     unsigned int application2;
   } allotment;
 
-  enum HttpVersion : uint8_t {
-    HTTP_VERSION_UNDEFINED = 0,
-    HTTP_VERSION_09        = 1,
-    HTTP_VERSION_10        = 2,
-    HTTP_VERSION_11        = 3,
-  };
-
   //////////////////////////////////////////////////////////
   // http server attributes in the host database          //
   //                                                      //
-  // http_version       - one of HttpVersion              //
+  // http_version       - one of HTTPVersion              //
   // last_failure       - UNIX time for the last time     //
   //                      we tried the server & failed    //
   // fail_count         - Number of times we tried and    //
@@ -117,13 +111,15 @@ union HostDBApplicationInfo {
   //////////////////////////////////////////////////////////
   struct http_server_attr {
     uint32_t last_failure;
-    HttpVersion http_version;
+    HTTPVersion http_version;
     uint8_t fail_count;
+    http_server_attr() : http_version() {}
   } http_data;
 
   struct application_data_rr {
     unsigned int offset;
   } rr;
+  HostDBApplicationInfo() : http_data() {}
 };
 
 struct HostDBRoundRobin;

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -28,10 +28,10 @@
 #include "tscore/CryptoHash.h"
 #include "tscore/ink_align.h"
 #include "tscore/ink_resolver.h"
+#include "tscore/HTTPVersion.h"
 #include "I_EventSystem.h"
 #include "SRV.h"
 #include "P_RefCountCache.h"
-#include "HTTP.h"
 
 // Event returned on a lookup
 #define EVENT_HOST_DB_LOOKUP (HOSTDB_EVENT_EVENTS_START + 0)

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -248,7 +248,7 @@ class HTTPVersion
 public:
   HTTPVersion() {}
   HTTPVersion(HTTPVersion const &that) = default;
-  explicit HTTPVersion(uint16_t version);
+  explicit HTTPVersion(int version);
   constexpr HTTPVersion(uint8_t ver_major, uint8_t ver_minor);
 
   int operator==(const HTTPVersion &hv) const;
@@ -260,7 +260,7 @@ public:
 
   uint8_t get_major() const;
   uint8_t get_minor() const;
-  uint16_t get_flat_version() const;
+  int get_flat_version() const;
 
 private:
   uint8_t vmajor = 0;
@@ -696,10 +696,10 @@ private:
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline HTTPVersion::HTTPVersion(uint16_t version)
+inline HTTPVersion::HTTPVersion(int version)
 {
-  vmajor = (version & 0xFF00) >> 8;
-  vminor = version & 0xFF;
+  vmajor = (version & 0xFFFF0000) >> 16;
+  vminor = version & 0xFFFF;
 }
 
 /*-------------------------------------------------------------------------
@@ -728,10 +728,10 @@ HTTPVersion::get_minor() const
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline uint16_t
+inline int
 HTTPVersion::get_flat_version() const
 {
-  return vmajor << 8 | vminor;
+  return vmajor << 16 | vminor;
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -26,6 +26,7 @@
 #include <cassert>
 #include "tscore/Arena.h"
 #include "tscore/CryptoHash.h"
+#include "tscore/HTTPVersion.h"
 #include "MIME.h"
 #include "URL.h"
 
@@ -241,30 +242,6 @@ enum HTTPType {
   HTTP_TYPE_UNKNOWN,
   HTTP_TYPE_REQUEST,
   HTTP_TYPE_RESPONSE,
-};
-
-class HTTPVersion
-{
-public:
-  HTTPVersion() {}
-  HTTPVersion(HTTPVersion const &that) = default;
-  explicit HTTPVersion(int version);
-  constexpr HTTPVersion(uint8_t ver_major, uint8_t ver_minor);
-
-  int operator==(const HTTPVersion &hv) const;
-  int operator!=(const HTTPVersion &hv) const;
-  int operator>(const HTTPVersion &hv) const;
-  int operator<(const HTTPVersion &hv) const;
-  int operator>=(const HTTPVersion &hv) const;
-  int operator<=(const HTTPVersion &hv) const;
-
-  uint8_t get_major() const;
-  uint8_t get_minor() const;
-  int get_flat_version() const;
-
-private:
-  uint8_t vmajor = 0;
-  uint8_t vminor = 0;
 };
 
 struct HTTPHdrImpl : public HdrHeapObjImpl {
@@ -692,110 +669,6 @@ protected:
 private:
   friend class UrlPrintHack; // don't ask.
 };
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline HTTPVersion::HTTPVersion(int version)
-{
-  vmajor = (version & 0xFFFF0000) >> 16;
-  vminor = version & 0xFFFF;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline constexpr HTTPVersion::HTTPVersion(uint8_t ver_major, uint8_t ver_minor) : vmajor(ver_major), vminor(ver_minor) {}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline uint8_t
-HTTPVersion::get_major() const
-{
-  return vmajor;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline uint8_t
-HTTPVersion::get_minor() const
-{
-  return vminor;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPVersion::get_flat_version() const
-{
-  return vmajor << 16 | vminor;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPVersion::operator==(const HTTPVersion &hv) const
-{
-  return vmajor == hv.get_major() && vminor == hv.get_minor();
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPVersion::operator!=(const HTTPVersion &hv) const
-{
-  return !(*this == hv);
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPVersion::operator>(const HTTPVersion &hv) const
-{
-  return *this == hv || !(*this < hv);
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPVersion::operator<(const HTTPVersion &hv) const
-{
-  return vmajor < hv.get_major() || (vmajor == hv.get_major() && vminor < hv.get_minor());
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPVersion::operator>=(const HTTPVersion &hv) const
-{
-  return !(*this < hv);
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-inline int
-HTTPVersion::operator<=(const HTTPVersion &hv) const
-{
-  return *this == hv || *this < hv;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-constexpr HTTPVersion HTTP_INVALID{0, 0};
-constexpr HTTPVersion HTTP_0_9{0, 9};
-constexpr HTTPVersion HTTP_1_0{1, 0};
-constexpr HTTPVersion HTTP_1_1{1, 1};
-constexpr HTTPVersion HTTP_2_0{2, 0};
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -874,7 +874,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
 
     ua_txn->set_session_active();
 
-    if (t_state.hdr_info.client_request.version_get() == HTTPVersion(1, 1) &&
+    if (t_state.hdr_info.client_request.version_get() == HTTP_1_1 &&
         (t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_POST ||
          t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_PUT) &&
         t_state.http_config_param->send_100_continue_response) {
@@ -1162,7 +1162,7 @@ HttpSM::state_read_push_response_header(int event, void *data)
   }
   // Don't allow 0.9 (unparsable headers) since TS doesn't
   //   cache 0.9 responses
-  if (state == PARSE_RESULT_DONE && t_state.hdr_info.server_response.version_get() == HTTPVersion(0, 9)) {
+  if (state == PARSE_RESULT_DONE && t_state.hdr_info.server_response.version_get() == HTTP_0_9) {
     state = PARSE_RESULT_ERROR;
   }
 
@@ -2006,7 +2006,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
 
   // Don't allow HTTP 0.9 (unparsable headers) on resued connections.
   // And don't allow empty headers from closed connections
-  if ((state == PARSE_RESULT_DONE && t_state.hdr_info.server_response.version_get() == HTTPVersion(0, 9) &&
+  if ((state == PARSE_RESULT_DONE && t_state.hdr_info.server_response.version_get() == HTTP_0_9 &&
        server_session->get_transact_count() > 1) ||
       (server_entry->eos && vio->ndone == 0)) {
     state = PARSE_RESULT_ERROR;
@@ -4299,7 +4299,7 @@ HttpSM::do_hostdb_update_if_necessary()
     return;
   }
 
-  if (t_state.updated_server_version != HostDBApplicationInfo::HTTP_VERSION_UNDEFINED) {
+  if (t_state.updated_server_version != HTTP_INVALID) {
     // we may have incorrectly assumed that the hostdb had the wrong version of
     // http for the server because our first few connect attempts to the server
     // failed, causing us to downgrade our requests to a lower version and changing
@@ -4312,7 +4312,7 @@ HttpSM::do_hostdb_update_if_necessary()
       issue_update |= 1;
     }
 
-    t_state.updated_server_version = HostDBApplicationInfo::HTTP_VERSION_UNDEFINED;
+    t_state.updated_server_version = HTTP_INVALID;
   }
   // Check to see if we need to report or clear a connection failure
   if (t_state.current.server->had_connect_fail()) {
@@ -4605,7 +4605,7 @@ HttpSM::do_range_setup_if_necessary()
 
   t_state.range_setup = HttpTransact::RANGE_NONE;
 
-  if (t_state.method == HTTP_WKSIDX_GET && t_state.hdr_info.client_request.version_get() == HTTPVersion(1, 1)) {
+  if (t_state.method == HTTP_WKSIDX_GET && t_state.hdr_info.client_request.version_get() == HTTP_1_1) {
     do_range_parse(field);
 
     if (t_state.range_setup == HttpTransact::RANGE_REQUESTED) {
@@ -6387,7 +6387,7 @@ HttpSM::setup_100_continue_transfer()
   IOBufferReader *buf_start = buf->alloc_reader();
 
   // First write the client response header into the buffer
-  ink_assert(t_state.client_info.http_version != HTTPVersion(0, 9));
+  ink_assert(t_state.client_info.http_version != HTTP_0_9);
   client_response_hdr_bytes = write_header_into_buffer(&t_state.hdr_info.client_response, buf);
   ink_assert(client_response_hdr_bytes > 0);
 
@@ -6762,7 +6762,7 @@ HttpSM::setup_server_transfer()
     }
   } else {
     if (t_state.current.server->transfer_encoding != HttpTransact::CHUNKED_ENCODING) {
-      if (t_state.client_info.http_version == HTTPVersion(0, 9)) {
+      if (t_state.client_info.http_version == HTTP_0_9) {
         action = TCA_PASSTHRU_DECHUNKED_CONTENT; // send as-is
       } else {
         action = TCA_CHUNK_CONTENT;
@@ -7466,13 +7466,7 @@ HttpSM::set_next_state()
                 ats_ip_ntop(addr, ipb, sizeof(ipb)));
       }
       ats_ip_copy(t_state.host_db_info.ip(), addr);
-      if (t_state.hdr_info.client_request.version_get() == HTTPVersion(0, 9)) {
-        t_state.host_db_info.app.http_data.http_version = HostDBApplicationInfo::HTTP_VERSION_09;
-      } else if (t_state.hdr_info.client_request.version_get() == HTTPVersion(1, 0)) {
-        t_state.host_db_info.app.http_data.http_version = HostDBApplicationInfo::HTTP_VERSION_10;
-      } else {
-        t_state.host_db_info.app.http_data.http_version = HostDBApplicationInfo::HTTP_VERSION_11;
-      }
+      t_state.host_db_info.app.http_data.http_version = t_state.hdr_info.client_request.version_get();
 
       t_state.dns_info.lookup_success = true;
       // cache this result so we don't have to unreliably duplicate the
@@ -8260,13 +8254,13 @@ HttpSM::server_protocol_contains(std::string_view tag_prefix) const
 std::string_view
 HttpSM::find_proto_string(HTTPVersion version) const
 {
-  if (version == HTTPVersion(2, 0)) {
+  if (version == HTTP_2_0) {
     return IP_PROTO_TAG_HTTP_2_0;
-  } else if (version == HTTPVersion(1, 1)) {
+  } else if (version == HTTP_1_1) {
     return IP_PROTO_TAG_HTTP_1_1;
-  } else if (version == HTTPVersion(1, 0)) {
+  } else if (version == HTTP_1_0) {
     return IP_PROTO_TAG_HTTP_1_0;
-  } else if (version == HTTPVersion(0, 9)) {
+  } else if (version == HTTP_0_9) {
     return IP_PROTO_TAG_HTTP_0_9;
   }
   return {};

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -481,7 +481,7 @@ update_cache_control_information_from_config(HttpTransact::State *s)
   s->cache_info.directives.does_client_permit_dns_storing =
     HttpTransact::does_client_request_permit_dns_caching(&s->cache_control, &s->hdr_info.client_request);
 
-  if (s->client_info.http_version == HTTPVersion(0, 9)) {
+  if (s->client_info.http_version == HTTP_0_9) {
     s->cache_info.directives.does_client_permit_lookup  = false;
     s->cache_info.directives.does_client_permit_storing = false;
   }
@@ -809,7 +809,7 @@ how_to_open_connection(HttpTransact::State *s)
   }
 
   if (!s->already_downgraded) { // false unless downgraded previously (possibly due to HTTP 505)
-    (&s->hdr_info.server_request)->version_set(HTTPVersion(1, 1));
+    (&s->hdr_info.server_request)->version_set(HTTP_1_1);
     HttpTransactHeaders::convert_request(s->current.server->http_version, &s->hdr_info.server_request);
   }
 
@@ -1208,7 +1208,7 @@ HttpTransact::handle_upgrade_request(State *s)
         be at least 1.1. */
   if (!s->hdr_info.client_request.presence(MIME_PRESENCE_UPGRADE) ||
       !s->hdr_info.client_request.presence(MIME_PRESENCE_CONNECTION) || s->method != HTTP_WKSIDX_GET ||
-      s->hdr_info.client_request.version_get() < HTTPVersion(1, 1)) {
+      s->hdr_info.client_request.version_get() < HTTP_1_1) {
     return false;
   }
 
@@ -1451,7 +1451,7 @@ HttpTransact::handleIfRedirect(State *s)
     s->remap_redirect = redirect_url.string_get(&s->arena, &remap_redirect_len);
     redirect_url.destroy();
     if (answer == TEMPORARY_REDIRECT) {
-      if ((s->client_info).http_version.m_version == HTTP_VERSION(1, 1)) {
+      if ((s->client_info).http_version == HTTP_1_1) {
         build_error_response(s, HTTP_STATUS_TEMPORARY_REDIRECT, "Redirect", "redirect#moved_temporarily");
       } else {
         build_error_response(s, HTTP_STATUS_MOVED_TEMPORARILY, "Redirect", "redirect#moved_temporarily");
@@ -1679,9 +1679,9 @@ HttpTransact::setup_plugin_request_intercept(State *s)
 
   // Also "fake" the info we'd normally get from
   //   hostDB
-  s->server_info.http_version.set(1, 0);
+  s->server_info.http_version                = HTTP_1_0;
   s->server_info.keep_alive                  = HTTP_NO_KEEPALIVE;
-  s->host_db_info.app.http_data.http_version = HostDBApplicationInfo::HTTP_VERSION_10;
+  s->host_db_info.app.http_data.http_version = HTTP_1_0;
   s->server_info.dst_addr.setToAnyAddr(AF_INET);                                 // must set an address or we can't set the port.
   s->server_info.dst_addr.port() = htons(s->hdr_info.client_request.port_get()); // this is the info that matters.
 
@@ -2944,7 +2944,7 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
         http_version = s->current.server->http_version;
       }
 
-      TxnDebug("http_trans", "CacheOpenReadHit - version %d", http_version.m_version);
+      TxnDebug("http_trans", "CacheOpenReadHit - version %d.%d", http_version.get_major(), http_version.get_minor());
       build_request(s, &s->hdr_info.client_request, &s->hdr_info.server_request, http_version);
 
       issue_revalidate(s);
@@ -3343,7 +3343,7 @@ HttpTransact::HandleCacheOpenReadMiss(State *s)
     if (!s->current.server || !s->current.server->dst_addr.isValid()) {
       // Short term hack.  get_ka_info_from_config assumes if http_version is > 0,9 it has already been
       // set and skips the rest of the function.  The default functor sets it to 1,0
-      s->server_info.http_version = HTTPVersion(0, 9);
+      s->server_info.http_version = HTTP_0_9;
       get_ka_info_from_config(s, &s->server_info);
     }
     find_server_and_update_current_info(s);
@@ -4027,37 +4027,8 @@ HttpTransact::handle_forward_server_connection_open(State *s)
   TxnDebug("http_seq", "[HttpTransact::handle_server_connection_open] ");
   ink_release_assert(s->current.state == CONNECTION_ALIVE);
 
-  if (s->hdr_info.server_response.version_get() == HTTPVersion(0, 9)) {
-    TxnDebug("http_trans", "[hfsco] server sent 0.9 response, reading...");
-    build_response(s, &s->hdr_info.client_response, s->client_info.http_version, HTTP_STATUS_OK, "Connection Established");
-
-    s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
-    s->cache_info.action      = CACHE_DO_NO_ACTION;
-    s->next_action            = SM_ACTION_SERVER_READ;
-    return;
-
-  } else if (s->hdr_info.server_response.version_get() == HTTPVersion(1, 0)) {
-    if (s->current.server->http_version == HTTPVersion(0, 9)) {
-      // update_hostdb_to_indicate_server_version_is_1_0
-      s->updated_server_version = HostDBApplicationInfo::HTTP_VERSION_10;
-    } else if (s->current.server->http_version == HTTPVersion(1, 1)) {
-      // update_hostdb_to_indicate_server_version_is_1_0
-      s->updated_server_version = HostDBApplicationInfo::HTTP_VERSION_10;
-    } else {
-      // dont update the hostdb. let us try again with what we currently think.
-    }
-  } else if (s->hdr_info.server_response.version_get() == HTTPVersion(1, 1)) {
-    if (s->current.server->http_version == HTTPVersion(0, 9)) {
-      // update_hostdb_to_indicate_server_version_is_1_1
-      s->updated_server_version = HostDBApplicationInfo::HTTP_VERSION_11;
-    } else if (s->current.server->http_version == HTTPVersion(1, 0)) {
-      // update_hostdb_to_indicate_server_version_is_1_1
-      s->updated_server_version = HostDBApplicationInfo::HTTP_VERSION_11;
-    } else {
-      // dont update the hostdb. let us try again with what we currently think.
-    }
-  } else {
-    // dont update the hostdb. let us try again with what we currently think.
+  if (s->hdr_info.server_response.version_get() != s->current.server->http_version) {
+    s->updated_server_version = s->hdr_info.server_response.version_get();
   }
 
   if (s->hdr_info.server_response.status_get() == HTTP_STATUS_CONTINUE ||
@@ -4152,9 +4123,9 @@ HttpTransact::handle_100_continue_response(State *s)
   bool forward_100 = false;
 
   HTTPVersion ver = s->hdr_info.client_request.version_get();
-  if (ver == HTTPVersion(1, 1)) {
+  if (ver == HTTP_1_1) {
     forward_100 = true;
-  } else if (ver == HTTPVersion(1, 0)) {
+  } else if (ver == HTTP_1_0) {
     if (s->hdr_info.client_request.value_get_int(MIME_FIELD_EXPECT, MIME_LEN_EXPECT) == 100) {
       forward_100 = true;
     }
@@ -5179,22 +5150,22 @@ HttpTransact::get_ka_info_from_config(State *s, ConnectionAttributes *server_inf
 {
   bool check_hostdb = false;
 
-  if (server_info->http_version > HTTPVersion(0, 9)) {
-    TxnDebug("http_trans", "get_ka_info_from_config, version already set server_info->http_version %d",
-             server_info->http_version.m_version);
+  if (server_info->http_version > HTTP_0_9) {
+    TxnDebug("http_trans", "get_ka_info_from_config, version already set server_info->http_version %d.%d",
+             server_info->http_version.get_major(), server_info->http_version.get_minor());
     return false;
   }
   switch (s->txn_conf->send_http11_requests) {
   case HttpConfigParams::SEND_HTTP11_NEVER:
-    server_info->http_version = HTTPVersion(1, 0);
+    server_info->http_version = HTTP_1_0;
     break;
   case HttpConfigParams::SEND_HTTP11_UPGRADE_HOSTDB:
-    server_info->http_version = HTTPVersion(1, 0);
+    server_info->http_version = HTTP_1_0;
     check_hostdb              = true;
     break;
   case HttpConfigParams::SEND_HTTP11_IF_REQUEST_11_AND_HOSTDB:
-    server_info->http_version = HTTPVersion(1, 0);
-    if (s->hdr_info.client_request.version_get() == HTTPVersion(1, 1)) {
+    server_info->http_version = HTTP_1_0;
+    if (s->hdr_info.client_request.version_get() == HTTP_1_1) {
       // check hostdb only if client req is http/1.1
       check_hostdb = true;
     }
@@ -5204,11 +5175,11 @@ HttpTransact::get_ka_info_from_config(State *s, ConnectionAttributes *server_inf
     ink_assert(0);
   // fallthrough
   case HttpConfigParams::SEND_HTTP11_ALWAYS:
-    server_info->http_version = HTTPVersion(1, 1);
+    server_info->http_version = HTTP_1_1;
     break;
   }
-  TxnDebug("http_trans", "get_ka_info_from_config, server_info->http_version %d, check_hostdb %d",
-           server_info->http_version.m_version, check_hostdb);
+  TxnDebug("http_trans", "get_ka_info_from_config, server_info->http_version %d.%d, check_hostdb %d",
+           server_info->http_version.get_major(), server_info->http_version.get_minor(), check_hostdb);
 
   // Set keep_alive info based on the records.config setting
   server_info->keep_alive = s->txn_conf->keep_alive_enabled_out ? HTTP_KEEPALIVE : HTTP_NO_KEEPALIVE;
@@ -5238,7 +5209,7 @@ HttpTransact::get_ka_info_from_host_db(State *s, ConnectionAttributes *server_in
     http11_if_hostdb = true;
     break;
   case HttpConfigParams::SEND_HTTP11_IF_REQUEST_11_AND_HOSTDB:
-    if (s->hdr_info.client_request.version_get() == HTTPVersion(1, 1)) {
+    if (s->hdr_info.client_request.version_get() == HTTP_1_1) {
       http11_if_hostdb = true;
     }
     break;
@@ -5251,23 +5222,22 @@ HttpTransact::get_ka_info_from_host_db(State *s, ConnectionAttributes *server_in
     break;
   }
 
-  if (force_http11 == true ||
-      (http11_if_hostdb == true && host_db_info->app.http_data.http_version == HostDBApplicationInfo::HTTP_VERSION_11)) {
-    server_info->http_version.set(1, 1);
-    server_info->keep_alive = HTTP_KEEPALIVE;
-  } else if (host_db_info->app.http_data.http_version == HostDBApplicationInfo::HTTP_VERSION_10) {
-    server_info->http_version.set(1, 0);
-    server_info->keep_alive = HTTP_KEEPALIVE;
-  } else if (host_db_info->app.http_data.http_version == HostDBApplicationInfo::HTTP_VERSION_09) {
-    server_info->http_version.set(0, 9);
-    server_info->keep_alive = HTTP_NO_KEEPALIVE;
+  if (force_http11 == true || (http11_if_hostdb == true && host_db_info->app.http_data.http_version == HTTP_1_1)) {
+    server_info->http_version = HTTP_1_1;
+    server_info->keep_alive   = HTTP_KEEPALIVE;
+  } else if (host_db_info->app.http_data.http_version == HTTP_1_0) {
+    server_info->http_version = HTTP_1_0;
+    server_info->keep_alive   = HTTP_KEEPALIVE;
+  } else if (host_db_info->app.http_data.http_version == HTTP_0_9) {
+    server_info->http_version = HTTP_0_9;
+    server_info->keep_alive   = HTTP_NO_KEEPALIVE;
   } else {
     //////////////////////////////////////////////
     // not set yet for this host. set defaults. //
     //////////////////////////////////////////////
-    server_info->http_version.set(1, 0);
+    server_info->http_version                = HTTP_1_0;
     server_info->keep_alive                  = HTTP_KEEPALIVE;
-    host_db_info->app.http_data.http_version = HostDBApplicationInfo::HTTP_VERSION_10;
+    host_db_info->app.http_data.http_version = HTTP_1_0;
   }
 
   /////////////////////////////
@@ -5455,7 +5425,7 @@ HttpTransact::check_request_validity(State *s, HTTPHdr *incoming_hdr)
     }
   }
   // Check whether a Host header field is missing in the request.
-  if (!incoming_hdr->presence(MIME_PRESENCE_HOST) && incoming_hdr->version_get() != HTTPVersion(0, 9)) {
+  if (!incoming_hdr->presence(MIME_PRESENCE_HOST) && incoming_hdr->version_get() != HTTP_0_9) {
     // Update the number of incoming 1.0 or 1.1 requests that do
     // not contain Host header fields.
     HTTP_INCREMENT_DYN_STAT(http_missing_host_hdr_stat);
@@ -6776,7 +6746,7 @@ HttpTransact::handle_request_keep_alive_headers(State *s, HTTPVersion ver, HTTPH
   // Check preconditions for Keep-Alive
   if (!upstream_ka) {
     ka_action = KA_DISABLED;
-  } else if (HTTP_MAJOR(ver.m_version) == 0) { /* No K-A for 0.9 apps */
+  } else if (ver.get_major() == 0) { /* No K-A for 0.9 apps */
     ka_action = KA_DISABLED;
   }
   // If preconditions are met, figure out what action to take
@@ -6808,7 +6778,7 @@ HttpTransact::handle_request_keep_alive_headers(State *s, HTTPVersion ver, HTTPH
     switch (ka_action) {
     case KA_CONNECTION:
       ink_assert(s->current.server->keep_alive != HTTP_NO_KEEPALIVE);
-      if (ver == HTTPVersion(1, 0)) {
+      if (ver == HTTP_1_0) {
         if (s->current.request_to == PARENT_PROXY && parent_is_proxy(s)) {
           heads->value_set(MIME_FIELD_PROXY_CONNECTION, MIME_LEN_PROXY_CONNECTION, "keep-alive", 10);
         } else {
@@ -6820,7 +6790,7 @@ HttpTransact::handle_request_keep_alive_headers(State *s, HTTPVersion ver, HTTPH
       break;
     case KA_DISABLED:
     case KA_CLOSE:
-      if (s->current.server->keep_alive != HTTP_NO_KEEPALIVE || (ver == HTTPVersion(1, 1))) {
+      if (s->current.server->keep_alive != HTTP_NO_KEEPALIVE || (ver == HTTP_1_1)) {
         /* Had keep-alive */
         s->current.server->keep_alive = HTTP_NO_KEEPALIVE;
         if (s->current.request_to == PARENT_PROXY && parent_is_proxy(s)) {
@@ -6905,7 +6875,7 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
   }
 
   // Check pre-conditions for keep-alive
-  if (HTTP_MAJOR(ver.m_version) == 0) { /* No K-A for 0.9 apps */
+  if (ver.get_major() == 0) { /* No K-A for 0.9 apps */
     ka_action = KA_DISABLED;
   } else if (heads->status_get() == HTTP_STATUS_NO_CONTENT &&
              ((s->source == SOURCE_HTTP_ORIGIN_SERVER && s->current.server->transfer_encoding != NO_TRANSFER_ENCODING) ||
@@ -6923,7 +6893,7 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
     // check that the client protocol is HTTP/1.1 and the conf allows chunking or
     // the client protocol doesn't support chunked transfer coding (i.e. HTTP/1.0, HTTP/2, and HTTP/3)
     if (s->state_machine->ua_txn && s->state_machine->ua_txn->is_chunked_encoding_supported() &&
-        s->client_info.http_version == HTTPVersion(1, 1) && s->txn_conf->chunking_enabled == 1 &&
+        s->client_info.http_version == HTTP_1_1 && s->txn_conf->chunking_enabled == 1 &&
         s->state_machine->ua_txn->is_chunked_encoding_supported() &&
         // if we're not sending a body, don't set a chunked header regardless of server response
         !is_response_body_precluded(s->hdr_info.client_response.status_get(), s->method) &&
@@ -6984,7 +6954,7 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
     break;
   case KA_CLOSE:
   case KA_DISABLED:
-    if (s->client_info.keep_alive != HTTP_NO_KEEPALIVE || (ver == HTTPVersion(1, 1))) {
+    if (s->client_info.keep_alive != HTTP_NO_KEEPALIVE || (ver == HTTP_1_1)) {
       heads->value_set(c_hdr_field_str, c_hdr_field_len, "close", 5);
       s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
     }
@@ -7715,15 +7685,15 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
 
   // We build 1.1 request header and then convert as necessary to
   //  the appropriate version in HttpTransact::build_request
-  outgoing_request->version_set(HTTPVersion(1, 1));
+  outgoing_request->version_set(HTTP_1_1);
 
   // Make sure our request version is defined
-  ink_assert(outgoing_version != HTTPVersion(0, 0));
+  ink_assert(outgoing_version != HTTP_0_9);
 
   // HttpTransactHeaders::convert_request(outgoing_version, outgoing_request); // commented out this idea
 
   // Check whether a Host header field is missing from a 1.0 or 1.1 request.
-  if (outgoing_version != HTTPVersion(0, 9) && !outgoing_request->presence(MIME_PRESENCE_HOST)) {
+  if (outgoing_version != HTTP_0_9 && !outgoing_request->presence(MIME_PRESENCE_HOST)) {
     URL *url = outgoing_request->url_get();
     int host_len;
     const char *host = url->host_get(&host_len);

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -674,9 +674,9 @@ public:
     DNSLookupInfo dns_info;
     RedirectInfo redirect_info;
     OutboundConnTrack::TxnState outbound_conn_track_state;
-    HostDBApplicationInfo::HttpVersion updated_server_version = HostDBApplicationInfo::HTTP_VERSION_UNDEFINED;
-    bool force_dns                                            = false;
-    MgmtByte cache_open_write_fail_action                     = 0;
+    HTTPVersion updated_server_version    = HTTP_INVALID;
+    bool force_dns                        = false;
+    MgmtByte cache_open_write_fail_action = 0;
     ConnectionAttributes client_info;
     ConnectionAttributes parent_info;
     ConnectionAttributes server_info;

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -839,7 +839,8 @@ HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPH
   int n_proto = 0;
 
   // Should suffice - if we're adding a response VIA, the connection is HTTP and only 1.0 and 1.1 are supported outbound.
-  proto_buf[n_proto++] = HTTP_MINOR(header->version_get().m_version) == 0 ? IP_PROTO_TAG_HTTP_1_0 : IP_PROTO_TAG_HTTP_1_1;
+  // TODO H2 expand for HTTP/2 outbound
+  proto_buf[n_proto++] = header->version_get().get_minor() == 0 ? IP_PROTO_TAG_HTTP_1_0 : IP_PROTO_TAG_HTTP_1_1;
 
   auto ss = s->state_machine->get_server_session();
   if (ss) {

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1735,15 +1735,14 @@ int
 LogAccess::marshal_client_req_http_version(char *buf)
 {
   if (buf) {
-    int64_t major = 0;
-    int64_t minor = 0;
     if (m_client_request) {
       HTTPVersion versionObject = m_client_request->version_get();
-      major                     = HTTP_MAJOR(versionObject.m_version);
-      minor                     = HTTP_MINOR(versionObject.m_version);
+      marshal_int(buf, versionObject.get_major());
+      marshal_int((buf + INK_MIN_ALIGN), versionObject.get_minor());
+    } else {
+      marshal_int(buf, 0);
+      marshal_int((buf + INK_MIN_ALIGN), 0);
     }
-    marshal_int(buf, major);
-    marshal_int((buf + INK_MIN_ALIGN), minor);
   }
   return (2 * INK_MIN_ALIGN);
 }
@@ -1761,11 +1760,9 @@ LogAccess::marshal_client_req_protocol_version(char *buf)
   if (::strlen(protocol_str) == 4 && strncmp("http", protocol_str, 4) == 0) {
     if (m_client_request) {
       HTTPVersion versionObject = m_client_request->version_get();
-      int64_t major             = HTTP_MAJOR(versionObject.m_version);
-      int64_t minor             = HTTP_MINOR(versionObject.m_version);
-      if (major == 1 && minor == 1) {
+      if (versionObject == HTTP_1_1) {
         protocol_str = "http/1.1";
-      } else if (major == 1 && minor == 0) {
+      } else if (versionObject == HTTP_1_0) {
         protocol_str = "http/1.0";
       } // else invalid http version
     } else {
@@ -1795,11 +1792,9 @@ LogAccess::marshal_server_req_protocol_version(char *buf)
   if (::strlen(protocol_str) == 4 && strncmp("http", protocol_str, 4) == 0) {
     if (m_proxy_request) {
       HTTPVersion versionObject = m_proxy_request->version_get();
-      int64_t major             = HTTP_MAJOR(versionObject.m_version);
-      int64_t minor             = HTTP_MINOR(versionObject.m_version);
-      if (major == 1 && minor == 1) {
+      if (versionObject == HTTP_1_1) {
         protocol_str = "http/1.1";
-      } else if (major == 1 && minor == 0) {
+      } else if (versionObject == HTTP_1_0) {
         protocol_str = "http/1.0";
       } // else invalid http version
     } else {
@@ -2456,8 +2451,8 @@ LogAccess::marshal_server_resp_http_version(char *buf)
     int64_t major = 0;
     int64_t minor = 0;
     if (m_server_response) {
-      major = HTTP_MAJOR(m_server_response->version_get().m_version);
-      minor = HTTP_MINOR(m_server_response->version_get().m_version);
+      major = m_server_response->version_get().get_major();
+      minor = m_server_response->version_get().get_minor();
     }
     marshal_int(buf, major);
     marshal_int((buf + INK_MIN_ALIGN), minor);
@@ -2583,8 +2578,8 @@ LogAccess::marshal_cache_resp_http_version(char *buf)
     int64_t major = 0;
     int64_t minor = 0;
     if (m_cache_response) {
-      major = HTTP_MAJOR(m_cache_response->version_get().m_version);
-      minor = HTTP_MINOR(m_cache_response->version_get().m_version);
+      major = m_cache_response->version_get().get_major();
+      minor = m_cache_response->version_get().get_minor();
     }
     marshal_int(buf, major);
     marshal_int((buf + INK_MIN_ALIGN), minor);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -4047,7 +4047,7 @@ TSHttpHdrVersionGet(TSMBuffer bufp, TSMLoc obj)
 
   SET_HTTP_HDR(h, bufp, obj);
   HTTPVersion ver = h.version_get();
-  return ver.m_version;
+  return ver.get_flat_version();
 }
 
 TSReturnCode
@@ -4065,7 +4065,7 @@ TSHttpHdrVersionSet(TSMBuffer bufp, TSMLoc obj, int ver)
   }
 
   HTTPHdr h;
-  HTTPVersion version(ver);
+  HTTPVersion version{static_cast<uint16_t>(ver)};
 
   SET_HTTP_HDR(h, bufp, obj);
   ink_assert(h.m_http->m_type == HDR_HEAP_OBJ_HTTP_HEADER);

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -4065,7 +4065,7 @@ TSHttpHdrVersionSet(TSMBuffer bufp, TSMLoc obj, int ver)
   }
 
   HTTPHdr h;
-  HTTPVersion version{static_cast<uint16_t>(ver)};
+  HTTPVersion version{ver};
 
   SET_HTTP_HDR(h, bufp, obj);
   ink_assert(h.m_http->m_type == HDR_HEAP_OBJ_HTTP_HEADER);

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -46,7 +46,7 @@ ts.Setup.Copy("ssl/signed-foo.key")
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'traffic_dump|http',
+    'proxy.config.diags.debug.tags': 'traffic_dump',
     'proxy.config.http.insert_age_in_response': 0,
 
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -46,7 +46,7 @@ ts.Setup.Copy("ssl/signed-foo.key")
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'traffic_dump',
+    'proxy.config.diags.debug.tags': 'traffic_dump|http',
     'proxy.config.http.insert_age_in_response': 0,
 
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),


### PR DESCRIPTION
This is an extended version of PR #7706.

@zwoop started reviewing PR #7706 and reasonably asked, why do we have two different structures/enums tracking HTTP versions.  This PR gets rid of the HostDBApplicationInfo::HTTPVersion that was used in HostDBInfo.  It replaces it with HTTPVersion which is used everywhere else.

Also adjust HTTPVersion to be smaller (2 uint8_t's) and stored as major and minor versions since that is how most cases were using the data.  Added some constants for our current HTTP versions to get rid of inline constructors.

Because of the elimination of the HostDBApplicationInfo::HTTPVersion, we don't have to do the conversion function that was in PR #7706.  Instead we can just assign the version from one member to another.