### PR TITLE
Short circuit remap reload when non-existent remap file is specified

### DIFF
--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -67,7 +67,7 @@ init_reverse_proxy()
 
   Note("%s loading ...", ts::filename::REMAP);
   if (!rewrite_table->load()) {
-    Fatal("%s failed to load", ts::filename::REMAP);
+    Warning("%s failed to load", ts::filename::REMAP);
   }
   Note("%s finished loading", ts::filename::REMAP);
 

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -946,14 +946,8 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
   std::error_code ec;
   std::string content{ts::file::load(ts::file::path{path}, ec)};
   if (ec) {
-    switch (ec.value()) {
-    case ENOENT:
-      Warning("Can't open remapping configuration file %s - %s", path, strerror(ec.value()));
-      break;
-    default:
-      Error("Failed load remapping configuration file %s - %s", path, strerror(ec.value()));
-      return false;
-    }
+    Warning("Failed to open remapping configuration file %s - %s", path, strerror(ec.value()));
+    return false;
   }
 
   Debug("url_rewrite", "[BuildTable] UrlRewrite::BuildTable()");


### PR DESCRIPTION
This fixes issue #7767 

Ensures resiliency against config errors erasing remaps previously loaded.