### PR TITLE
Test: update tls_forward_nonhttp to have a nameserver.

### DIFF
--- a/tests/gold_tests/tls/tls_forward_nonhttp.test.py
+++ b/tests/gold_tests/tls/tls_forward_nonhttp.test.py
@@ -33,6 +33,8 @@ ts.addSSLfile("ssl/server.key")
 # reserve a port of the s_client that will be released with 'ts'
 ports.get_port(ts, 's_client_port')
 
+nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
+
 # Need no remap rules.  Everything should be proccessed by sni
 
 # Make sure the TS server certs are different from the origin certs
@@ -47,7 +49,9 @@ ts.Disk.records_config.update({
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.connect_ports': '{0} {1}'.format(ts.Variables.ssl_port, ts.Variables.s_client_port),
     'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1
+    'proxy.config.url_remap.pristine_host_hdr': 1,
+    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+    'proxy.config.dns.resolv_conf': 'NULL'
 })
 
 # foo.com should not terminate.  Just tunnel to server_foo
@@ -62,6 +66,7 @@ tr = Test.AddTestRun("forward-non-http")
 tr.Setup.Copy("test-nc-s_client.sh")
 tr.Processes.Default.Command = "sh test-nc-s_client.sh {1} {0}".format(ts.Variables.ssl_port, ts.Variables.s_client_port)
 tr.ReturnCode = 0
+tr.Processes.Default.StartBefore(nameserver)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 testout_path = os.path.join(Test.RunDirectory, "test.out")


### PR DESCRIPTION
This test uses "localhost" and therefore should have a local nameserver.