### PR TITLE
BWF: Add support for std::error_code.

### DIFF
--- a/include/tscore/bwf_std_format.h
+++ b/include/tscore/bwf_std_format.h
@@ -37,10 +37,13 @@ bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, atomic<T> const &v)
 {
   return ts::bwformat(w, spec, v.load());
 }
+
 } // end namespace std
 
 namespace ts
 {
+BufferWriter &bwformat(BufferWriter &w, BWFSpec const &spec, std::error_code const &ec);
+
 namespace bwf
 {
   using namespace std::literals; // enable ""sv

--- a/src/tscore/BufferWriterFormat.cc
+++ b/src/tscore/BufferWriterFormat.cc
@@ -911,6 +911,24 @@ bwformat(BufferWriter &w, BWFSpec const &spec, bwf::Errno const &e)
   return w;
 }
 
+BufferWriter &
+bwformat(BufferWriter &w, BWFSpec const &spec, std::error_code const &ec)
+{
+  // This provides convenient safe access to the errno short name array.
+  static const BWFormat number_fmt{"[{}]"_sv}; // numeric value format.
+  if (spec.has_numeric_type()) {               // if numeric type, print just the numeric
+    // part.
+    w.print(number_fmt, ec.value());
+  } else {
+    w.write(ec.message());
+    if (spec._type != 's' && spec._type != 'S') {
+      w.write(' ');
+      w.print(number_fmt, ec.value());
+    }
+  }
+  return w;
+}
+
 bwf::Date::Date(std::string_view fmt) : _epoch(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now())), _fmt(fmt) {}
 
 BufferWriter &


### PR DESCRIPTION
As we transition to more C++ based mechanisms, BW formatting should support `std::error_code`.