### PR TITLE
doc: header_rewrite random function not inclusive (backport #7760)

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -470,7 +470,7 @@ RANDOM
 
     cond %{RANDOM:<n>} <operand>
 
-Generates a random integer between ``0`` and ``<n>``, inclusive.
+Generates a random integer from ``0`` up to (but not including) ``<n>``. Mathmatically, ``[0,n)`` or ``0 <= r < n``.
 
 STATUS
 ~~~~~~


### PR DESCRIPTION
In testing %{RANDOM:3}, ATS only prints 0,1, and 2. The code
rand_r(&_seed) % _max)
implies that the n value would not be chosen.

(cherry picked from commit 22cd7dafeddd5bec8b1623e9c135bb54f4160ee0)