### PR TITLE
Short circuit remap reload when a valid remap file is not specified

### DIFF
--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -67,9 +67,10 @@ init_reverse_proxy()
 
   Note("%s loading ...", ts::filename::REMAP);
   if (!rewrite_table->load()) {
-    Fatal("%s failed to load", ts::filename::REMAP);
+    Warning("%s failed to load", ts::filename::REMAP);
+  } else {
+    Note("%s finished loading", ts::filename::REMAP);
   }
-  Note("%s finished loading", ts::filename::REMAP);
 
   REC_RegisterConfigUpdateFunc("proxy.config.url_remap.filename", url_rewrite_CB, (void *)FILE_CHANGED);
   REC_RegisterConfigUpdateFunc("proxy.config.proxy_name", url_rewrite_CB, (void *)TSNAME_CHANGED);

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -945,15 +945,9 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
 
   std::error_code ec;
   std::string content{ts::file::load(ts::file::path{path}, ec)};
-  if (ec) {
-    switch (ec.value()) {
-    case ENOENT:
-      Warning("Can't open remapping configuration file %s - %s", path, strerror(ec.value()));
-      break;
-    default:
-      Error("Failed load remapping configuration file %s - %s", path, strerror(ec.value()));
-      return false;
-    }
+  if (ec.value()) {
+    Warning("Failed to open remapping configuration file %s - %s", path, strerror(ec.value()));
+    return false;
   }
 
   Debug("url_rewrite", "[BuildTable] UrlRewrite::BuildTable()");

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -656,9 +656,11 @@ UrlRewrite::BuildTable(const char *path)
   temporary_redirects.hash_lookup.reset(new URLTable);
   forward_mappings_with_recv_port.hash_lookup.reset(new URLTable);
 
+  int zret = 0;
+
   if (!remap_parse_config(path, this)) {
     // XXX handle file reload error
-    return 3;
+    zret = 3;
   }
 
   // Destroy unused tables
@@ -686,7 +688,7 @@ UrlRewrite::BuildTable(const char *path)
     forward_mappings_with_recv_port.hash_lookup.reset(nullptr);
   }
 
-  return 0;
+  return zret;
 }
 
 /**


### PR DESCRIPTION
This fixes issue #7767 

Ensures resiliency against config errors erasing remaps previously loaded.

Note that failing to load remap.config during startup will no longer fail
the TS startup to allow for optionality in remap.config. The missing remaps
would need to be detected via functional tests