### PR TITLE
Fixes an issue where next hop unit tests crash when run on macOS.

### DIFF
--- a/proxy/http/remap/NextHopSelectionStrategy.cc
+++ b/proxy/http/remap/NextHopSelectionStrategy.cc
@@ -42,7 +42,7 @@ NextHopSelectionStrategy::NextHopSelectionStrategy(const std::string_view &name,
   int _max_retriers = 0;
   strategy_name     = name;
   policy_type       = policy;
-  REC_ReadConfigInteger(_max_retriers, "proxy.config.http.parent_proxy.max_trans_retries");
+  NH_GetConfig(_max_retriers, "proxy.config.http.parent_proxy.max_trans_retries");
 
   // config settings may not be available when running unit tests.
   // so use the max_retriers default setting.

--- a/proxy/http/remap/NextHopSelectionStrategy.h
+++ b/proxy/http/remap/NextHopSelectionStrategy.h
@@ -31,6 +31,7 @@
 #define NH_Error(...) DiagsError(DL_Error, __VA_ARGS__)
 #define NH_Note(...) DiagsError(DL_Note, __VA_ARGS__)
 #define NH_Warn(...) DiagsError(DL_Warning, __VA_ARGS__)
+#define NH_GetConfig(v, n) REC_ReadConfigInteger(v, n)
 #else
 #include "unit-tests/nexthop_test_stubs.h"
 #endif /* _NH_UNIT_TESTS_ */

--- a/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
+++ b/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
@@ -126,6 +126,18 @@ build_request(int64_t sm_id, HttpSM *sm, sockaddr_in *ip, const char *os_hostnam
 }
 
 void
+GetConfigInteger(int *v, const char *n)
+{
+  if (v != nullptr && n != nullptr) {
+    if (strcmp(n, "proxy.config.http.parent_proxy.max_trans_retries") == 0) {
+      *v = 1;
+    } else {
+      *v = 0;
+    }
+  }
+}
+
+void
 PrintToStdErr(const char *fmt, ...)
 {
   va_list args;

--- a/proxy/http/remap/unit-tests/nexthop_test_stubs.h
+++ b/proxy/http/remap/unit-tests/nexthop_test_stubs.h
@@ -44,9 +44,11 @@ extern "C" {
 #define NH_Error(fmt, ...) PrintToStdErr("%s:%d:%s() " fmt "\n", __FILE__, __LINE__, __func__, ##__VA_ARGS__)
 #define NH_Note(fmt, ...) PrintToStdErr("%s:%d:%s() " fmt "\n", __FILE__, __LINE__, __func__, ##__VA_ARGS__)
 #define NH_Warn(fmt, ...) PrintToStdErr("%s:%d:%s() " fmt "\n", __FILE__, __LINE__, __func__, ##__VA_ARGS__)
+#define NH_GetConfig(v, n) GetConfigInteger(&v, n)
 
 class HttpRequestData;
 
+void GetConfigInteger(int *v, const char *n);
 void PrintToStdErr(const char *fmt, ...);
 void build_request(HttpRequestData &h, const char *os_hostname);
 


### PR DESCRIPTION
Fixes an issue when running the Next Hop unit tests on macOS.  macOS crashes due to a SIGABRT when a read/write lock cannot be obtained to read a config variable in the NextHopSelectStrategy constructor.  This PR basically creates a mock around REC_ReadConfigInteger().