### PR TITLE
Fix MLoc assert caused by s3auth

### DIFF
--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -991,36 +991,40 @@ S3Request::authorizeV2(S3Config *s3)
 int
 event_handler(TSCont cont, TSEvent event, void *edata)
 {
-  TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
-  S3Config *s3   = static_cast<S3Config *>(TSContDataGet(cont));
-
-  S3Request request(txnp);
-  TSHttpStatus status  = TS_HTTP_STATUS_INTERNAL_SERVER_ERROR;
+  TSHttpTxn txnp       = static_cast<TSHttpTxn>(edata);
+  S3Config *s3         = static_cast<S3Config *>(TSContDataGet(cont));
   TSEvent enable_event = TS_EVENT_HTTP_CONTINUE;
 
-  switch (event) {
-  case TS_EVENT_HTTP_SEND_REQUEST_HDR:
-    if (request.initialize()) {
-      while (s3->reload_waiting) {
-        std::this_thread::yield();
+  {
+    S3Request request(txnp);
+    TSHttpStatus status = TS_HTTP_STATUS_INTERNAL_SERVER_ERROR;
+
+    switch (event) {
+    case TS_EVENT_HTTP_SEND_REQUEST_HDR:
+      if (request.initialize()) {
+        while (s3->reload_waiting) {
+          std::this_thread::yield();
+        }
+
+        std::shared_lock lock(s3->reload_mutex);
+        status = request.authorize(s3);
       }
 
-      std::shared_lock lock(s3->reload_mutex);
-      status = request.authorize(s3);
+      if (TS_HTTP_STATUS_OK == status) {
+        TSDebug(PLUGIN_NAME, "Successfully signed the AWS S3 URL");
+      } else {
+        TSDebug(PLUGIN_NAME, "Failed to sign the AWS S3 URL, status = %d", status);
+        TSHttpTxnStatusSet(txnp, status);
+        enable_event = TS_EVENT_HTTP_ERROR;
+      }
+      break;
+    default:
+      TSError("[%s] Unknown event for this plugin", PLUGIN_NAME);
+      TSDebug(PLUGIN_NAME, "unknown event for this plugin");
+      break;
     }
-
-    if (TS_HTTP_STATUS_OK == status) {
-      TSDebug(PLUGIN_NAME, "Successfully signed the AWS S3 URL");
-    } else {
-      TSDebug(PLUGIN_NAME, "Failed to sign the AWS S3 URL, status = %d", status);
-      TSHttpTxnStatusSet(txnp, status);
-      enable_event = TS_EVENT_HTTP_ERROR;
-    }
-    break;
-  default:
-    TSError("[%s] Unknown event for this plugin", PLUGIN_NAME);
-    TSDebug(PLUGIN_NAME, "unknown event for this plugin");
-    break;
+    // Most get S3Request out of scope in case the later plugins invalidate the TSAPI
+    // objects it references.  Some cases were causing asserts from the destructor
   }
 
   TSHttpTxnReenable(txnp, enable_event);


### PR DESCRIPTION
The problem is that the S3auth object contains a URL MLoc reference in _url_mloc.  In our configuration, one of the plugins called after s3auth changes the server_request URL in such as way that the _url_mloc reference is old and destroyed, see http_hdr_url_set in proxy/hdrs/HTTP.cc.  deallocate_obj clears the m_type which causes the later assert in MLocRelease.

By causing the S3Request object to clean up before calling TSHttpTxnReenable, the _url_mloc is not stale when MLocRelease is called.

We only see this problem in 9.0 not in 9.1, and I don't know why.  All of the relevant pieces of code are the same, and we are running with the same configs.  It is possible there are other changes that cause ATS to take the other path in http_hdr_url_set which updates the URLImpl object in place rather than just updating a pointer.  

This fixes #7780