### PR TITLE
Make HTTP/2 configs reloadable

### DIFF
--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -362,7 +362,8 @@ bool http2_parse_goaway(IOVec, Http2Goaway &);
 
 bool http2_parse_window_update(IOVec, uint32_t &);
 
-Http2ErrorCode http2_decode_header_blocks(HTTPHdr *, const uint8_t *, const uint32_t, uint32_t *, HpackHandle &, bool &, uint32_t);
+Http2ErrorCode http2_decode_header_blocks(HTTPHdr *, const uint8_t *, const uint32_t, uint32_t *, HpackHandle &, bool &, uint32_t,
+                                          uint32_t);
 
 Http2ErrorCode http2_encode_header_blocks(HTTPHdr *, uint8_t *, uint32_t, uint32_t *, HpackHandle &, int32_t);
 
@@ -371,41 +372,10 @@ ParseResult http2_convert_header_from_1_1_to_2(HTTPHdr *);
 void http2_init_pseudo_headers(HTTPHdr &);
 void http2_init();
 
-// Not sure where else to put this, but figure this is as good of a start as
-// anything else.
-// Right now, only the static init() is available, which sets up some basic
-// librecords
-// dependencies.
 class Http2
 {
 public:
-  static uint32_t max_concurrent_streams_in;
-  static uint32_t min_concurrent_streams_in;
-  static uint32_t max_active_streams_in;
   static bool throttling;
-  static uint32_t stream_priority_enabled;
-  static uint32_t initial_window_size;
-  static uint32_t max_frame_size;
-  static uint32_t header_table_size;
-  static uint32_t max_header_list_size;
-  static uint32_t accept_no_activity_timeout;
-  static uint32_t no_activity_timeout_in;
-  static uint32_t active_timeout_in;
-  static uint32_t push_diary_size;
-  static uint32_t zombie_timeout_in;
-  static float stream_error_rate_threshold;
-  static uint32_t max_settings_per_frame;
-  static uint32_t max_settings_per_minute;
-  static uint32_t max_settings_frames_per_minute;
-  static uint32_t max_ping_frames_per_minute;
-  static uint32_t max_priority_frames_per_minute;
-  static float min_avg_window_update;
-  static uint32_t con_slow_log_threshold;
-  static uint32_t stream_slow_log_threshold;
-  static uint32_t header_table_size_limit;
-  static uint32_t write_buffer_block_size;
-  static float write_size_threshold;
-  static uint32_t write_time_threshold;
 
   static void init();
 };

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "HTTP2.h"
+#include "Http2Config.h"
 #include "Plugin.h"
 #include "ProxySession.h"
 #include "Http2ConnectionState.h"
@@ -96,6 +97,7 @@ public:
   const char *protocol_contains(std::string_view prefix) const override;
   void increment_current_active_connections_stat() override;
   void decrement_current_active_connections_stat() override;
+  const Http2ConfigParams *config() const;
 
   void set_upgrade_context(HTTPHdr *h);
   void set_dying_event(int event);
@@ -138,6 +140,7 @@ private:
 
   ////////
   // Variables
+  Http2ConfigParams *_config     = nullptr;
   SessionHandler session_handler = nullptr;
 
   MIOBuffer *read_buffer              = nullptr;
@@ -224,4 +227,10 @@ inline int64_t
 Http2ClientSession::write_buffer_size()
 {
   return write_buffer->max_read_avail();
+}
+
+inline const Http2ConfigParams *
+Http2ClientSession::config() const
+{
+  return _config;
 }

--- a/proxy/http2/Http2Config.cc
+++ b/proxy/http2/Http2Config.cc
@@ -1,0 +1,115 @@
+/** @file
+
+  Configs for HTTP/2
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "Http2Config.h"
+
+////
+// Http2ConfigParams
+//
+Http2ConfigParams::Http2ConfigParams()
+{
+  REC_EstablishStaticConfigInt32U(max_concurrent_streams_in, "proxy.config.http2.max_concurrent_streams_in");
+  REC_EstablishStaticConfigInt32U(min_concurrent_streams_in, "proxy.config.http2.min_concurrent_streams_in");
+  REC_EstablishStaticConfigInt32U(max_active_streams_in, "proxy.config.http2.max_active_streams_in");
+  REC_EstablishStaticConfigInt32U(stream_priority_enabled, "proxy.config.http2.stream_priority_enabled");
+  REC_EstablishStaticConfigInt32U(initial_window_size, "proxy.config.http2.initial_window_size_in");
+  REC_EstablishStaticConfigInt32U(max_frame_size, "proxy.config.http2.max_frame_size");
+  REC_EstablishStaticConfigInt32U(header_table_size, "proxy.config.http2.header_table_size");
+  REC_EstablishStaticConfigInt32U(max_header_list_size, "proxy.config.http2.max_header_list_size");
+  REC_EstablishStaticConfigInt32U(accept_no_activity_timeout, "proxy.config.http2.accept_no_activity_timeout");
+  REC_EstablishStaticConfigInt32U(no_activity_timeout_in, "proxy.config.http2.no_activity_timeout_in");
+  REC_EstablishStaticConfigInt32U(active_timeout_in, "proxy.config.http2.active_timeout_in");
+  REC_EstablishStaticConfigInt32U(push_diary_size, "proxy.config.http2.push_diary_size");
+  REC_EstablishStaticConfigInt32U(zombie_timeout_in, "proxy.config.http2.zombie_debug_timeout_in");
+  REC_EstablishStaticConfigFloat(stream_error_rate_threshold, "proxy.config.http2.stream_error_rate_threshold");
+  REC_EstablishStaticConfigInt32U(max_settings_per_frame, "proxy.config.http2.max_settings_per_frame");
+  REC_EstablishStaticConfigInt32U(max_settings_per_minute, "proxy.config.http2.max_settings_per_minute");
+  REC_EstablishStaticConfigInt32U(max_settings_frames_per_minute, "proxy.config.http2.max_settings_frames_per_minute");
+  REC_EstablishStaticConfigInt32U(max_ping_frames_per_minute, "proxy.config.http2.max_ping_frames_per_minute");
+  REC_EstablishStaticConfigInt32U(max_priority_frames_per_minute, "proxy.config.http2.max_priority_frames_per_minute");
+  REC_EstablishStaticConfigFloat(min_avg_window_update, "proxy.config.http2.min_avg_window_update");
+  REC_EstablishStaticConfigInt32U(con_slow_log_threshold, "proxy.config.http2.connection.slow.log.threshold");
+  REC_EstablishStaticConfigInt32U(stream_slow_log_threshold, "proxy.config.http2.stream.slow.log.threshold");
+  REC_EstablishStaticConfigInt32U(header_table_size_limit, "proxy.config.http2.header_table_size_limit");
+  REC_EstablishStaticConfigInt32U(write_buffer_block_size, "proxy.config.http2.write_buffer_block_size");
+  REC_EstablishStaticConfigFloat(write_size_threshold, "proxy.config.http2.write_size_threshold");
+  REC_EstablishStaticConfigInt32U(write_time_threshold, "proxy.config.http2.write_time_threshold");
+}
+
+////
+// Http2Config
+//
+void
+Http2Config::startup()
+{
+  _config_update_handler = std::make_unique<ConfigUpdateHandler<Http2Config>>();
+
+  // dynamic configs
+  _config_update_handler->attach("proxy.config.http2.max_concurrent_streams_in");
+  _config_update_handler->attach("proxy.config.http2.min_concurrent_streams_in");
+  _config_update_handler->attach("proxy.config.http2.max_active_streams_in");
+  _config_update_handler->attach("proxy.config.http2.stream_priority_enabled");
+  _config_update_handler->attach("proxy.config.http2.initial_window_size_in");
+  _config_update_handler->attach("proxy.config.http2.max_frame_size");
+  _config_update_handler->attach("proxy.config.http2.header_table_size");
+  _config_update_handler->attach("proxy.config.http2.max_header_list_size");
+  _config_update_handler->attach("proxy.config.http2.accept_no_activity_timeout");
+  _config_update_handler->attach("proxy.config.http2.no_activity_timeout_in");
+  _config_update_handler->attach("proxy.config.http2.active_timeout_in");
+  _config_update_handler->attach("proxy.config.http2.push_diary_size");
+  _config_update_handler->attach("proxy.config.http2.zombie_debug_timeout_in");
+  _config_update_handler->attach("proxy.config.http2.stream_error_rate_threshold");
+  _config_update_handler->attach("proxy.config.http2.max_settings_per_frame");
+  _config_update_handler->attach("proxy.config.http2.max_settings_per_minute");
+  _config_update_handler->attach("proxy.config.http2.max_settings_frames_per_minute");
+  _config_update_handler->attach("proxy.config.http2.max_ping_frames_per_minute");
+  _config_update_handler->attach("proxy.config.http2.max_priority_frames_per_minute");
+  _config_update_handler->attach("proxy.config.http2.min_avg_window_update");
+  _config_update_handler->attach("proxy.config.http2.connection.slow.log.threshold");
+  _config_update_handler->attach("proxy.config.http2.stream.slow.log.threshold");
+  _config_update_handler->attach("proxy.config.http2.header_table_size_limit");
+  _config_update_handler->attach("proxy.config.http2.write_buffer_block_size");
+  _config_update_handler->attach("proxy.config.http2.write_size_threshold");
+  _config_update_handler->attach("proxy.config.http2.write_time_threshold");
+
+  reconfigure();
+}
+
+void
+Http2Config::reconfigure()
+{
+  Http2ConfigParams *params = new Http2ConfigParams();
+  _config_id                = configProcessor.set(_config_id, params);
+}
+
+Http2ConfigParams *
+Http2Config::acquire()
+{
+  return static_cast<Http2ConfigParams *>(configProcessor.get(_config_id));
+}
+
+void
+Http2Config::release(Http2ConfigParams *params)
+{
+  configProcessor.release(_config_id, params);
+}

--- a/proxy/http2/Http2Config.h
+++ b/proxy/http2/Http2Config.h
@@ -1,0 +1,82 @@
+/** @file
+
+  Configs for HTTP/2
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "ProxyConfig.h"
+
+struct Http2ConfigParams : public ConfigInfo {
+  Http2ConfigParams();
+
+  // noncopyable
+  Http2ConfigParams(const Http2ConfigParams &) = delete;
+  Http2ConfigParams &operator=(const Http2ConfigParams &) = delete;
+
+  // Config Params
+  uint32_t max_concurrent_streams_in      = 100;
+  uint32_t min_concurrent_streams_in      = 10;
+  uint32_t max_active_streams_in          = 0;
+  bool throttling                         = false;
+  uint32_t stream_priority_enabled        = 0;
+  uint32_t initial_window_size            = 65535;
+  uint32_t max_frame_size                 = 16384;
+  uint32_t header_table_size              = 4096;
+  uint32_t max_header_list_size           = 4294967295;
+  uint32_t accept_no_activity_timeout     = 120;
+  uint32_t no_activity_timeout_in         = 120;
+  uint32_t active_timeout_in              = 0;
+  uint32_t push_diary_size                = 256;
+  uint32_t zombie_timeout_in              = 0;
+  float stream_error_rate_threshold       = 0.1;
+  uint32_t max_settings_per_frame         = 7;
+  uint32_t max_settings_per_minute        = 14;
+  uint32_t max_settings_frames_per_minute = 14;
+  uint32_t max_ping_frames_per_minute     = 60;
+  uint32_t max_priority_frames_per_minute = 120;
+  float min_avg_window_update             = 2560.0;
+  uint32_t con_slow_log_threshold         = 0;
+  uint32_t stream_slow_log_threshold      = 0;
+  uint32_t header_table_size_limit        = 65536;
+  uint32_t write_buffer_block_size        = 262144;
+  float write_size_threshold              = 0.5;
+  uint32_t write_time_threshold           = 100;
+};
+
+class Http2Config
+{
+public:
+  using scoped_config = ConfigProcessor::scoped_config<Http2Config, Http2ConfigParams>;
+
+  static void startup();
+
+  // ConfigUpdateContinuation interface
+  static void reconfigure();
+
+  // ConfigProcessor::scoped_config interface
+  static Http2ConfigParams *acquire();
+  static void release(Http2ConfigParams *params);
+
+private:
+  inline static int _config_id = 0;
+  inline static std::unique_ptr<ConfigUpdateHandler<Http2Config>> _config_update_handler;
+};

--- a/proxy/http2/Http2Frame.cc
+++ b/proxy/http2/Http2Frame.cc
@@ -76,11 +76,6 @@ Http2DataFrame::write_to(MIOBuffer *iobuffer) const
 int64_t
 Http2HeadersFrame::write_to(MIOBuffer *iobuffer) const
 {
-  // Validation
-  if (this->_hdr_block_len > Http2::max_frame_size) {
-    return -1;
-  }
-
   // Write frame header
   uint8_t buf[HTTP2_FRAME_HEADER_LEN];
   http2_write_frame_header(this->_hdr, make_iovec(buf));
@@ -153,11 +148,6 @@ Http2SettingsFrame::write_to(MIOBuffer *iobuffer) const
 int64_t
 Http2PushPromiseFrame::write_to(MIOBuffer *iobuffer) const
 {
-  // Validation
-  if (this->_hdr_block_len > Http2::max_frame_size) {
-    return -1;
-  }
-
   // Write frame header
   uint8_t buf[HTTP2_FRAME_HEADER_LEN];
   http2_write_frame_header(this->_hdr, make_iovec(buf));
@@ -234,11 +224,6 @@ Http2WindowUpdateFrame::write_to(MIOBuffer *iobuffer) const
 int64_t
 Http2ContinuationFrame::write_to(MIOBuffer *iobuffer) const
 {
-  // Validation
-  if (this->_hdr_block_len > Http2::max_frame_size) {
-    return -1;
-  }
-
   // Write frame header
   uint8_t buf[HTTP2_FRAME_HEADER_LEN];
   http2_write_frame_header(this->_hdr, make_iovec(buf));

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -69,7 +69,7 @@ public:
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool owner = false) override;
   void do_io_close(int lerrno = -1) override;
 
-  Http2ErrorCode decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_table_size);
+  Http2ErrorCode decode_header_blocks(HpackHandle &hpack_handle, uint32_t max_header_size, uint32_t maximum_table_size);
   void send_request(Http2ConnectionState &cstate);
   void initiating_close();
   void terminate_if_possible();

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -42,6 +42,7 @@ libhttp2_a_SOURCES = \
 	Http2Frame.h \
 	Http2ClientSession.cc \
 	Http2ClientSession.h \
+	Http2Config.cc \
 	Http2ConnectionState.cc \
 	Http2ConnectionState.h \
 	Http2DebugNames.cc \


### PR DESCRIPTION
~~The doc says HTTP/2 configs are reloadable, but all HTTP/2 configs require restarting ATS to apply.~~

This introduces `Http2Config` and `Http2ConfigParams` like other subsystems have.