### PR TITLE
HTTP: clean up the http_hdr_describe format error

### DIFF
--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -541,7 +541,7 @@ http_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
   HTTPHdrImpl *obj = (HTTPHdrImpl *)raw;
 
   if (obj->m_polarity == HTTP_TYPE_REQUEST) {
-    Debug("http", "[TYPE: REQ, V: %04X, URL: %p, METHOD: \"%.*s\", METHOD_LEN: %d, FIELDS: %p]", obj->m_version,
+    Debug("http", "[TYPE: REQ, V: %04X, URL: %p, METHOD: \"%.*s\", METHOD_LEN: %d, FIELDS: %p]", obj->m_version.get_flat_version(),
           obj->u.req.m_url_impl, obj->u.req.m_len_method, (obj->u.req.m_ptr_method ? obj->u.req.m_ptr_method : "NULL"),
           obj->u.req.m_len_method, obj->m_fields_impl);
     if (recurse) {
@@ -553,9 +553,9 @@ http_hdr_describe(HdrHeapObjImpl *raw, bool recurse)
       }
     }
   } else {
-    Debug("http", "[TYPE: RSP, V: %04X, STATUS: %d, REASON: \"%.*s\", REASON_LEN: %d, FIELDS: %p]", obj->m_version,
-          obj->u.resp.m_status, obj->u.resp.m_len_reason, (obj->u.resp.m_ptr_reason ? obj->u.resp.m_ptr_reason : "NULL"),
-          obj->u.resp.m_len_reason, obj->m_fields_impl);
+    Debug("http", "[TYPE: RSP, V: %04X, STATUS: %d, REASON: \"%.*s\", REASON_LEN: %d, FIELDS: %p]",
+          obj->m_version.get_flat_version(), obj->u.resp.m_status, obj->u.resp.m_len_reason,
+          (obj->u.resp.m_ptr_reason ? obj->u.resp.m_ptr_reason : "NULL"), obj->u.resp.m_len_reason, obj->m_fields_impl);
     if (recurse) {
       if (obj->m_fields_impl) {
         obj_describe(obj->m_fields_impl, recurse);


### PR DESCRIPTION
This fixes debug formatting error:
```
HTTP.cc: In function ‘void http_hdr_describe(HdrHeapObjImpl*, bool)’:
HTTP.cc:544:19: error: format ‘%x’ expects argument of type ‘unsigned int’, but argument 6 has type ‘HTTPVersion’ [-Werror=format=]
  544 |     Debug("http", "[TYPE: REQ, V: %04x, URL: %p, METHOD: \"%.*s\", METHOD_LEN: %d, FIELDS: %p]", obj->m_version,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~
```

by changing from obj->m_version to obj->m_version.get_flat_version()