### PR TITLE
Address assert on captive_action

### DIFF
--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -283,6 +283,7 @@ HttpCacheSM::do_cache_open_read(const HttpCacheKey &key)
     return ACTION_RESULT_DONE;
   } else {
     ink_assert(pending_action != nullptr || write_locked == true);
+    captive_action.cancelled = false; // Make sure not cancelled before we hand it out
     return &captive_action;
   }
 }
@@ -375,6 +376,7 @@ HttpCacheSM::open_write(const HttpCacheKey *key, URL *url, HTTPHdr *request, Cac
     return ACTION_RESULT_DONE;
   } else {
     ink_assert(pending_action != nullptr);
+    captive_action.cancelled = false; // Make sure not cancelled before we hand it out
     return &captive_action;
   }
 }

--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -288,7 +288,7 @@ HttpCacheSM::do_cache_open_read(const HttpCacheKey &key)
     return ACTION_RESULT_DONE;
   } else {
     ink_assert(pending_action != nullptr || write_locked == true);
-    captive_action.cancelled = false; // Make sure not cancelled before we hand it out
+    captive_action.cancelled = 0; // Make sure not cancelled before we hand it out
     return &captive_action;
   }
 }
@@ -382,7 +382,7 @@ HttpCacheSM::open_write(const HttpCacheKey *key, URL *url, HTTPHdr *request, Cac
     return ACTION_RESULT_DONE;
   } else {
     ink_assert(pending_action != nullptr);
-    captive_action.cancelled = false; // Make sure not cancelled before we hand it out
+    captive_action.cancelled = 0; // Make sure not cancelled before we hand it out
     return &captive_action;
   }
 }

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -50,6 +50,7 @@ struct HttpCacheAction : public Action {
     sm = sm_arg;
   };
   HttpCacheSM *sm = nullptr;
+  int err_code    = 0;
 };
 
 class HttpCacheSM : public Continuation

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -50,7 +50,6 @@ struct HttpCacheAction : public Action {
     sm = sm_arg;
   };
   HttpCacheSM *sm = nullptr;
-  int err_code    = 0;
 };
 
 class HttpCacheSM : public Continuation
@@ -184,6 +183,12 @@ public:
     abort_write();
   }
 
+  inline int
+  get_last_error() const
+  {
+    return err_code;
+  }
+
 private:
   void do_schedule_in();
   Action *do_cache_open_read(const HttpCacheKey &);
@@ -212,4 +217,7 @@ private:
   // to keep track of multiple cache lookups
   int lookup_max_recursive = 0;
   int current_lookup_level = 0;
+
+  // last error from the cache subsystem
+  int err_code = 0;
 };

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2616,8 +2616,6 @@ HttpSM::state_cache_open_read(int event, void *data)
 
   pending_action.try_clear(reinterpret_cast<Action *>(data));
 
-  HttpCacheAction *cache_action = reinterpret_cast<HttpCacheAction *>(data);
-
   ink_assert(server_entry == nullptr);
   ink_assert(t_state.cache_info.object_read == nullptr);
 
@@ -2649,12 +2647,12 @@ HttpSM::state_cache_open_read(int event, void *data)
     pending_action = nullptr;
 
     SMDebug("http", "[%" PRId64 "] cache_open_read - CACHE_EVENT_OPEN_READ_FAILED with %s (%d)", sm_id,
-            InkStrerror(-cache_action->err_code), -cache_action->err_code);
+            InkStrerror(-cache_sm.get_last_error()), -cache_sm.get_last_error());
 
     SMDebug("http", "[state_cache_open_read] open read failed.");
     // Inform HttpTransact somebody else is updating the document
     // HttpCacheSM already waited so transact should go ahead.
-    if (cache_action->err_code == -ECACHE_DOC_BUSY) {
+    if (cache_sm.get_last_error() == -ECACHE_DOC_BUSY) {
       t_state.cache_lookup_result = HttpTransact::CACHE_LOOKUP_DOC_BUSY;
     } else {
       t_state.cache_lookup_result = HttpTransact::CACHE_LOOKUP_MISS;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2503,7 +2503,7 @@ HttpSM::state_cache_open_write(int event, void *data)
     ink_release_assert(vc && vc->thread == this_ethread());
   }
 
-  pending_action.try_clear(reinterpret_cast<Action *>(data));
+  pending_action.clear_if_action_is(reinterpret_cast<Action *>(data));
 
   milestones[TS_MILESTONE_CACHE_OPEN_WRITE_END] = Thread::get_hrtime();
   pending_action                                = nullptr;
@@ -2614,7 +2614,7 @@ HttpSM::state_cache_open_read(int event, void *data)
   STATE_ENTER(&HttpSM::state_cache_open_read, event);
   milestones[TS_MILESTONE_CACHE_OPEN_READ_END] = Thread::get_hrtime();
 
-  pending_action.try_clear(reinterpret_cast<Action *>(data));
+  pending_action.clear_if_action_is(reinterpret_cast<Action *>(data));
 
   ink_assert(server_entry == nullptr);
   ink_assert(t_state.cache_info.object_read == nullptr);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -2492,6 +2492,8 @@ HttpSM::state_cache_open_write(int event, void *data)
 {
   STATE_ENTER(&HttpSM : state_cache_open_write, event);
 
+  pending_action.try_clear(reinterpret_cast<Action *>(data));
+
   // Make sure we are on the "right" thread
   if (ua_txn) {
     pending_action = ua_txn->adjust_thread(this, event, data);
@@ -2611,6 +2613,8 @@ HttpSM::state_cache_open_read(int event, void *data)
 {
   STATE_ENTER(&HttpSM::state_cache_open_read, event);
   milestones[TS_MILESTONE_CACHE_OPEN_READ_END] = Thread::get_hrtime();
+
+  pending_action.try_clear(reinterpret_cast<Action *>(data));
 
   ink_assert(server_entry == nullptr);
   ink_assert(t_state.cache_info.object_read == nullptr);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -197,7 +197,7 @@ public:
     return pending_action;
   }
   void
-  try_clear(Action *current_action)
+  clear_if_action_is(Action *current_action)
   {
     if (current_action == pending_action) {
       pending_action = nullptr;

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -196,6 +196,13 @@ public:
   {
     return pending_action;
   }
+  void
+  try_clear(Action *current_action)
+  {
+    if (current_action == pending_action) {
+      pending_action = nullptr;
+    }
+  }
   ~PendingAction()
   {
     if (pending_action) {


### PR DESCRIPTION
This addresses the ink_assert described in #7705 two ways.  First, it always clears the cancelled bit in the captive_action before returning the captive action.  Second, the HttpSM handlers that are storing references to the HttpCacheSM captive_action, use the new try_clear() action to clear the pending_action member without cancelling it if it matches the action passed into the handler.  Based on the stack trace in the issue,  the handler in frame #27 with this change will not mark the captive action cancelled when clearing it.

I'll try to spend some time to exercise this case, but I haven't run into this yet.  So verification from those who can reproduce the case would be appreciated.

This closes #7705