### PR TITLE
Save and propagate epoll network error

### DIFF
--- a/iocore/net/NetEvent.h
+++ b/iocore/net/NetEvent.h
@@ -55,6 +55,9 @@ public:
   // Close when EventIO close;
   virtual int close() = 0;
 
+  bool has_error() const;
+  void set_error();
+
   // get fd
   virtual int get_fd()                   = 0;
   virtual Ptr<ProxyMutex> &get_mutex()   = 0;
@@ -65,6 +68,7 @@ public:
   NetState write{};
 
   int closed     = 0;
+  int error      = 0;
   NetHandler *nh = nullptr;
 
   ink_hrtime inactivity_timeout_in      = 0;
@@ -94,3 +98,16 @@ public:
     } f;
   };
 };
+
+inline bool
+NetEvent::has_error() const
+{
+  return error != 0;
+}
+
+inline void
+NetEvent::set_error()
+{
+  socklen_t errlen = sizeof(error);
+  getsockopt(this->get_fd(), SOL_SOCKET, SO_ERROR, (void *)&error, &errlen);
+}

--- a/iocore/net/NetEvent.h
+++ b/iocore/net/NetEvent.h
@@ -56,7 +56,7 @@ public:
   virtual int close() = 0;
 
   bool has_error() const;
-  void set_error();
+  void set_error_from_socket();
 
   // get fd
   virtual int get_fd()                   = 0;
@@ -106,7 +106,7 @@ NetEvent::has_error() const
 }
 
 inline void
-NetEvent::set_error()
+NetEvent::set_error_from_socket()
 {
   socklen_t errlen = sizeof(error);
   getsockopt(this->get_fd(), SOL_SOCKET, SO_ERROR, (void *)&error, &errlen);

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -509,7 +509,7 @@ NetHandler::waitForActivity(ink_hrtime timeout)
       }
       int flags = get_ev_events(pd, x);
       if (flags & (EVENTIO_ERROR)) {
-        ne->set_error();
+        ne->set_error_from_socket();
       }
       if (flags & (EVENTIO_READ)) {
         ne->read.triggered = 1;

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -507,27 +507,24 @@ NetHandler::waitForActivity(ink_hrtime timeout)
       if (cop_list.in(ne)) {
         cop_list.remove(ne);
       }
-      if (get_ev_events(pd, x) & (EVENTIO_READ | EVENTIO_ERROR)) {
+      int flags = get_ev_events(pd, x);
+      if (flags & (EVENTIO_ERROR)) {
+        ne->set_error();
+      }
+      if (flags & (EVENTIO_READ)) {
         ne->read.triggered = 1;
         if (!read_ready_list.in(ne)) {
           read_ready_list.enqueue(ne);
-        } else if (get_ev_events(pd, x) & EVENTIO_ERROR) {
-          // check for unhandled epoll events that should be handled
-          Debug("iocore_net_main", "Unhandled epoll event on read: 0x%04x read.enabled=%d closed=%d read.netready_queue=%d",
-                get_ev_events(pd, x), ne->read.enabled, ne->closed, read_ready_list.in(ne));
         }
       }
-      if (get_ev_events(pd, x) & (EVENTIO_WRITE | EVENTIO_ERROR)) {
+      if (flags & (EVENTIO_WRITE)) {
         ne->write.triggered = 1;
         if (!write_ready_list.in(ne)) {
           write_ready_list.enqueue(ne);
-        } else if (get_ev_events(pd, x) & EVENTIO_ERROR) {
-          // check for unhandled epoll events that should be handled
-          Debug("iocore_net_main", "Unhandled epoll event on write: 0x%04x write.enabled=%d closed=%d write.netready_queue=%d",
-                get_ev_events(pd, x), ne->write.enabled, ne->closed, write_ready_list.in(ne));
         }
-      } else if (!(get_ev_events(pd, x) & EVENTIO_READ)) {
+      } else if (!(flags & (EVENTIO_READ))) {
         Debug("iocore_net_main", "Unhandled epoll event: 0x%04x", get_ev_events(pd, x));
+        ink_release_assert(false);
       }
     } else if (epd->type == EVENTIO_DNS_CONNECTION) {
       if (epd->data.dnscon != nullptr) {

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -199,6 +199,12 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
     return;
   }
 
+  if (vc->has_error()) {
+    vc->lerrno = vc->error;
+    vc->readSignalAndUpdate(VC_EVENT_ERROR);
+    return;
+  }
+
   // It is possible that the closed flag got set from HttpSessionManager in the
   // global session pool case.  If so, the closed flag should be stable once we get the
   // s->vio.mutex (the global session pool mutex).
@@ -365,6 +371,12 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
 
   if (!lock.is_locked() || lock.get_mutex() != s->vio.mutex.get()) {
     write_reschedule(nh, vc);
+    return;
+  }
+
+  if (vc->has_error()) {
+    vc->lerrno = vc->error;
+    write_signal_and_update(VC_EVENT_ERROR, vc);
     return;
   }
 


### PR DESCRIPTION
Another approach to PR #7803.  In addition to storing that one of the EPOLLERR bits was set, this code grabs a copy of error sitting on the socket and sends a VC_EVENT_ERROR from the read or write method with the lerrno set appropriately.

With this change, the case where there is no one listening on the origin port and a ICMP or reset is returned is correctly identified as a connection error instead of a failure after the TCP handshake succeeded.

I have been running this code change this afternoon on a production box.

Tracking down correctly handing origin connection errors and marking things down appropriately is discussed in issue #7290
