### PR TITLE
Adjust connection timeout for TLS

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -376,8 +376,9 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   // vc is an SSLNetVConnection.
   if (!vc->getSSLHandShakeComplete()) {
     if (vc->trackFirstHandshake()) {
-      // Send the write ready on up to the state machine
-      write_signal_and_update(VC_EVENT_WRITE_READY, vc);
+      // Eat the first write-ready.  Until the TLS handshake is complete,
+      // we should still be under the connect timeout and shouldn't bother
+      // the state machine until the TLS handshake is complete
       vc->write.triggered = 0;
       nh->write_ready_list.remove(vc);
     }


### PR DESCRIPTION
(cherry picked from commit 33818ba9aa228bd451b004d2d5f408fad7471a60)

Conflicts:
	proxy/http/HttpSM.cc
	
----

Backport #4903 to the 8.1.x branch.

We backported #4028 to the 8.1.x branch by #7715, but #4028 had a crash which is fixed by #4903.