### PR TITLE
Cleanup: Remove a meaningless Http2Stream::do_io_close() call

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -539,7 +539,6 @@ Http2Stream::initiating_close()
       }
     } else if (!sent_write_complete) {
       // Transaction is already gone or not started. Kill yourself
-      do_io_close();
       terminate_stream = true;
       terminate_if_possible();
     }


### PR DESCRIPTION
At the beginning of `Http2Stream::initiating_close()`, the `closed` flag is set `true`. Calling `Http2Stream::do_io_close()` after setting the flag does nothing.

`Http2Stream::initiating_close()`
https://github.com/apache/trafficserver/blob/31a580d0d89b2c141655ea167e4ad1b6b4e4973c/proxy/http2/Http2Stream.cc#L500

`Http2Stream::do_io_close(int /* flags */)`
https://github.com/apache/trafficserver/blob/31a580d0d89b2c141655ea167e4ad1b6b4e4973c/proxy/http2/Http2Stream.cc#L425