### PR TITLE
Update HTTP version info in HostDB on new outbound connection

### DIFF
--- a/include/tscore/HTTPVersion.h
+++ b/include/tscore/HTTPVersion.h
@@ -150,3 +150,4 @@ constexpr HTTPVersion HTTP_0_9{0, 9};
 constexpr HTTPVersion HTTP_1_0{1, 0};
 constexpr HTTPVersion HTTP_1_1{1, 1};
 constexpr HTTPVersion HTTP_2_0{2, 0};
+constexpr HTTPVersion HTTP_3_0{3, 0};

--- a/proxy/ProxySession.cc
+++ b/proxy/ProxySession.cc
@@ -255,6 +255,12 @@ ProxySession::protocol_contains(std::string_view tag_prefix) const
   return _vc ? _vc->protocol_contains(tag_prefix) : nullptr;
 }
 
+HTTPVersion
+ProxySession::get_version(HTTPHdr &hdr) const
+{
+  return hdr.version_get();
+}
+
 sockaddr const *
 ProxySession::get_remote_addr() const
 {

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -124,6 +124,7 @@ public:
 
   virtual int populate_protocol(std::string_view *result, int size) const;
   virtual const char *protocol_contains(std::string_view tag_prefix) const;
+  virtual HTTPVersion get_version(HTTPHdr &hdr) const;
 
   // Non-Virtual Methods
   NetVConnection *get_netvc() const;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -8303,3 +8303,9 @@ HttpSM::get_server_session() const
 {
   return server_session;
 }
+
+HTTPVersion
+HttpSM::get_server_version(HTTPHdr &hdr) const
+{
+  return this->server_session->get_version(hdr);
+}

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -266,6 +266,8 @@ public:
   // the current active server session
   PoolableSession *get_server_session() const;
 
+  HTTPVersion get_server_version(HTTPHdr &hdr) const;
+
   ProxyTransaction *
   get_ua_txn()
   {

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -695,6 +695,12 @@ Http2ClientSession::protocol_contains(std::string_view prefix) const
   return retval;
 }
 
+HTTPVersion
+Http2ClientSession::get_version(HTTPHdr &hdr) const
+{
+  return HTTP_2_0;
+}
+
 void
 Http2ClientSession::add_url_to_pushed_table(const char *url, int url_len)
 {

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -94,6 +94,7 @@ public:
   const char *get_protocol_string() const override;
   int populate_protocol(std::string_view *result, int size) const override;
   const char *protocol_contains(std::string_view prefix) const override;
+  HTTPVersion get_version(HTTPHdr &hdr) const override;
   void increment_current_active_connections_stat() override;
   void decrement_current_active_connections_stat() override;
 

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -175,6 +175,12 @@ Http3Session::~Http3Session()
   delete this->_remote_qpack;
 }
 
+HTTPVersion
+Http3Session::get_version(HTTPHdr &hdr) const
+{
+  return HTTP_3_0;
+}
+
 void
 Http3Session::increment_current_active_connections_stat()
 {
@@ -205,6 +211,12 @@ Http3Session::remote_qpack()
 Http09Session::~Http09Session()
 {
   this->_vc = nullptr;
+}
+
+HTTPVersion
+Http09Session::get_version(HTTPHdr &hdr) const
+{
+  return HTTP_0_9;
 }
 
 void

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -72,6 +72,7 @@ public:
   ~Http3Session();
 
   // ProxySession interface
+  HTTPVersion get_version(HTTPHdr &hdr) const override;
   void increment_current_active_connections_stat() override;
   void decrement_current_active_connections_stat() override;
 
@@ -95,6 +96,7 @@ public:
   ~Http09Session();
 
   // ProxySession interface
+  HTTPVersion get_version(HTTPHdr &hdr) const override;
   void increment_current_active_connections_stat() override;
   void decrement_current_active_connections_stat() override;
 


### PR DESCRIPTION
Most of the change is from #7706. I added code for HTTP/3.