### PR TITLE
Remove a layer of Action from HttpCacheSM

### DIFF
--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -41,28 +41,16 @@
 class HttpSM;
 class HttpCacheSM;
 
-struct HttpCacheAction : public Action {
-  HttpCacheAction();
-  void cancel(Continuation *c = nullptr) override;
-  void
-  init(HttpCacheSM *sm_arg)
-  {
-    sm = sm_arg;
-  };
-  HttpCacheSM *sm = nullptr;
-};
-
 class HttpCacheSM : public Continuation
 {
 public:
-  HttpCacheSM();
+  HttpCacheSM() : Continuation(nullptr) {}
 
   void
   init(HttpSM *sm_arg, Ptr<ProxyMutex> &amutex)
   {
     master_sm = sm_arg;
     mutex     = amutex;
-    captive_action.init(this);
   }
 
   Action *open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, const OverridableHttpConfigParams *params,
@@ -202,7 +190,6 @@ private:
   int state_cache_open_read(int event, void *data);
   int state_cache_open_write(int event, void *data);
 
-  HttpCacheAction captive_action;
   bool open_read_cb  = false;
   bool open_write_cb = false;
 


### PR DESCRIPTION
Yet another attempt to address issue #7705.  Based on the discussion on PR #7807, @masaori335 convinced me that the captive_action in HttpCacheSM is not doing anything for us.  We would be better off passing through the pending_action that we received from the CacheProcessor (which points at the _action member of the CacheVC).  The only point of the pending_action member in HttpSM is to cancel outstanding actions if the HttpSM goes away.  Nothing looks at the cancel bit of the HttpCacheSM other than some asserts.

@SolidWallOfCode and I reviewed the lifecycle of the HttpCacheSM::pending_action because we were concerned that the current logic would lose the CacheVC actions in case the HttpSM goes away while the cache is still opening.  However, ultimately the HttpSM will close the CacheVC's which will clean up outstanding actions in HttpSM::kill_this

```
    cache_sm.end_both();
    transform_cache_sm.end_both();
```

So we can safely return the HttpCacheSM::pending_action or ACTION_RESULT_DONE instead of the captive action.  It doesn't matter that the HttpSM cancels the action through its pending_action member since the CacheVC cleanup will ultimately do it.  However, it is important that an action is returned so HttpSM knows whether the open action completed immediately or not.

This should solve the assert by removing the assert and associated data structure.

In fact, I think we can get rid of the HttpCacheSM::pending_action member too.  I'll add another commit to do that.

This closes #7705