### PR TITLE
Add method to write an IpAddr value to a sockaddr.

### DIFF
--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1231,6 +1231,16 @@ struct IpAddr {
                  size_t len  ///< [in] Size of buffer.
   ) const;
 
+  /** Write the address to a socket address.
+   *
+   * @param dest Socket address to update.
+   * @return @a dest
+   *
+   * The address and family are updated. The port is unchanged. @a dest is assumed to be the
+   * appropriate underlying type for the family of @a this.
+   */
+  sockaddr *toSockAddr(sockaddr *dest) const;
+
   /// Equality.
   bool
   operator==(self const &that) const

--- a/src/tscore/ink_inet.cc
+++ b/src/tscore/ink_inet.cc
@@ -463,6 +463,27 @@ IpAddr::toString(char *dest, size_t len) const
   return dest;
 }
 
+sockaddr *
+IpAddr::toSockAddr(sockaddr *dest) const
+{
+  if (AF_INET == _family) {
+    dest->sa_family         = AF_INET;
+    ats_ip4_addr_cast(dest) = _addr._ip4;
+#if HAVE_STRUCT_SOCKADDR_SA_LEN
+    dest->sa_len = sizeof(sockaddr_in);
+#endif
+  } else if (AF_INET6 == _family) {
+    dest->sa_family         = AF_INET6;
+    ats_ip6_addr_cast(dest) = _addr._ip6;
+#if HAVE_STRUCT_SOCKADDR_SA_LEN
+    dest->sa_len = sizeof(sockaddr_in6);
+#endif
+  } else {
+    dest->sa_family = AF_UNSPEC;
+  }
+  return dest;
+}
+
 bool
 IpAddr::isMulticast() const
 {


### PR DESCRIPTION
This method is needed for HostDB restructuring so that an address stored in an `IpAddr` can be easily written to a `sockaddr`. It's already possible to extract an `IpAddr` from a `sockaddr` and should be easy to do the reverse.

I'm not completely thrilled with the method name, so I'm open bikeshedding on that.