### PR TITLE
Fix so EOS are delivered to sessions in the pool

### DIFF
--- a/proxy/PoolableSession.h
+++ b/proxy/PoolableSession.h
@@ -83,6 +83,8 @@ public:
 
   void set_netvc(NetVConnection *newvc);
 
+  virtual IOBufferReader *get_reader() = 0;
+
 private:
   // Sessions become if authentication headers
   //  are sent over them

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -468,7 +468,7 @@ Http1ClientSession::attach_server_session(PoolableSession *ssession, bool transa
     //  have it call the client session back.  This IO also prevent
     //  the server net conneciton from calling back a dead sm
     SET_HANDLER(&Http1ClientSession::state_keep_alive);
-    slave_ka_vio = ssession->do_io_read(this, 0, nullptr);
+    slave_ka_vio = ssession->do_io_read(this, INT64_MAX, ssession->get_reader()->mbuf);
     ink_assert(slave_ka_vio != ka_vio);
 
     // Transfer control of the write side as well

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -76,7 +76,7 @@ public:
   void start() override;
 
   void enable_outbound_connection_tracking(OutboundConnTrack::Group *group);
-  IOBufferReader *get_reader();
+  IOBufferReader *get_reader() override;
   void attach_hostname(const char *hostname);
   IpEndpoint const &get_server_ip() const;
 

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -206,7 +206,9 @@ ServerSessionPool::releaseSession(PoolableSession *ss)
   //  if it closes on us.  We will get called back in the
   //  continuation for this bucket, ensuring we have the lock
   //  to remove the connection from our lists
-  ss->do_io_read(this, 0, nullptr);
+  //  Actually need to have a buffer here, otherwise the vc is
+  //  disabled
+  ss->do_io_read(this, 0, ss->get_reader()->mbuf);
 
   // Transfer control of the write side as well
   ss->do_io_write(this, 0, nullptr);

--- a/proxy/http/HttpSessionManager.cc
+++ b/proxy/http/HttpSessionManager.cc
@@ -208,7 +208,7 @@ ServerSessionPool::releaseSession(PoolableSession *ss)
   //  to remove the connection from our lists
   //  Actually need to have a buffer here, otherwise the vc is
   //  disabled
-  ss->do_io_read(this, 0, ss->get_reader()->mbuf);
+  ss->do_io_read(this, INT64_MAX, ss->get_reader()->mbuf);
 
   // Transfer control of the write side as well
   ss->do_io_write(this, 0, nullptr);


### PR DESCRIPTION
This fixes an issue introduced in PR #7418.  I just filed issue #7827 about it.  The 9.1.x servers would consistently have slightly more ERR_CONNECT_FAILS than its 9.0.x peer.  I finally got one of the transactions in a packet trace and it looks like the origin had closed the connection.  Then a short while later ATS would start sending traffic on the connection.  Then the resets would fly and the transaction would fail due to an EOS in state_read_response_header.

I finally tracked it down to a change in how the session is released to the pool.  In 9.0.x, the release involves doing do_io_read to the pool with max int bytes against the server session's buffer.  In 9.1.x the buffer is null, so the vc is not enabled.  So the EOS is not delivered while the session is in the pool. I confirmed this with additional warning messages in a test build.

With this change we add back the buffer into the do_io_read.  The EOS's are being delivered while the session is in the pool.  With this change the ERR_CONNECT_FAILS are consistent between the 9.1.x box and its 9.0 peer in production traffic.

This closes #7827.