### PR TITLE
Fix stall on sending response for request with trailer header

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -298,7 +298,7 @@ Http2Stream::change_state(uint8_t type, uint8_t flags)
   case Http2StreamState::HTTP2_STREAM_STATE_OPEN:
     if (type == HTTP2_FRAME_TYPE_RST_STREAM) {
       _state = Http2StreamState::HTTP2_STREAM_STATE_CLOSED;
-    } else if (type == HTTP2_FRAME_TYPE_DATA) {
+    } else if (type == HTTP2_FRAME_TYPE_HEADERS || type == HTTP2_FRAME_TYPE_DATA) {
       if (recv_end_stream) {
         _state = Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE;
       } else if (send_end_stream) {

--- a/tests/gold_tests/h2/gold/nghttp_0_stdout.gold
+++ b/tests/gold_tests/h2/gold/nghttp_0_stdout.gold
@@ -12,6 +12,5 @@
 ``
 [``] recv (stream_id=1) :status: 200
 ``
-[``] recv RST_STREAM frame <length=4, flags=0x00, stream_id=1>
-``(error_code=NO_ERROR(0x00))
+``; END_STREAM
 ``


### PR DESCRIPTION
Prior to the change, `Http2Stream::change_state()` assumes the END_STREAM flag comes from the DATA frame on the OPEN state. But HEADERS frame can send END_STREAM flag too[*1]. The trailer header case is exactly the case. ( An example is on RFC 7540 Section 8.1.3.[*2] ) When Http2Stream falls in this bug, it stalls because the stream is not restarted on receiving WINDOW_UPDATE frames.

The prior AuTest of the trailer header didn't detect this bug, because the response was smaller than the initial window.

[*1] 5.1. Stream States
https://datatracker.ietf.org/doc/html/rfc7540#section-5.1

[*2] 8.1.3.  Examples (trailing header fields)
https://datatracker.ietf.org/doc/html/rfc7540#page-59