### PR TITLE
Fixup TS_USE_LINUX_NATIVE_AIO AIO_MODE_NATIVE

### DIFF
--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -53,6 +53,7 @@ struct AIOCallbackInternal : public AIOCallback {
   AIOCallbackInternal()
   {
     memset((void *)&(this->aiocb), 0, sizeof(this->aiocb));
+    this->aiocb.aio_fildes = -1;
     SET_HANDLER(&AIOCallbackInternal::io_complete);
   }
 };

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -574,17 +574,12 @@ CacheProcessor::start_internal(int flags)
   ink_assert((int)TS_EVENT_CACHE_SCAN_OPERATION_BLOCKED == (int)CACHE_EVENT_SCAN_OPERATION_BLOCKED);
   ink_assert((int)TS_EVENT_CACHE_SCAN_OPERATION_FAILED == (int)CACHE_EVENT_SCAN_OPERATION_FAILED);
   ink_assert((int)TS_EVENT_CACHE_SCAN_DONE == (int)CACHE_EVENT_SCAN_DONE);
-
 #if AIO_MODE == AIO_MODE_NATIVE
-  int etype            = ET_NET;
-  int n_netthreads     = eventProcessor.n_threads_for_type[etype];
-  EThread **netthreads = eventProcessor.eventthread[etype];
-  for (int i = 0; i < n_netthreads; ++i) {
-    netthreads[i]->diskHandler = new DiskHandler();
-    netthreads[i]->schedule_imm(netthreads[i]->diskHandler);
+  for (EThread *et : eventProcessor.active_group_threads(ET_NET)) {
+    et->diskHandler = new DiskHandler();
+    et->schedule_imm(et->diskHandler);
   }
 #endif
-
   start_internal_flags = flags;
   clear                = !!(flags & PROCESSOR_RECONFIGURE) || auto_clear_flag;
   fix                  = !!(flags & PROCESSOR_FIX);


### PR DESCRIPTION

```
./configure --enable-experimental-linux-native-aio && make 
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
Cache.cc: In member function ‘virtual int CacheProcessor::start_internal(int)’:
Cache.cc:580:41: error: ‘class EventProcessor’ has no member named ‘n_threads_for_type’
  580 |   int n_netthreads     = eventProcessor.n_threads_for_type[etype];
Cache.cc:581:41: error: ‘class EventProcessor’ has no member named ‘eventthread’
  581 |   EThread **netthreads = eventProcessor.eventthread[etype];
```