### PR TITLE
AuTest: use exteneded help output to determine curl feature support

### DIFF
--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -79,7 +79,7 @@ def HasCurlOption(self, option):
         return False
 
     return self.CheckOutput(
-        ['curl', '--help'],
+        ['curl', '--help', 'all'],
         default,
         "Curl needs to support option: {option}".format(option=option)
     )


### PR DESCRIPTION
I ran the AuTest suite with a recent development version of curl and
noticed that the proxy_protocol.test.py test was skipped because it
thought that the built curl version didn't have haproxy-protocol
support. It did have this support, but that version of curl didn't show
that option in the brief `--help` output but it was shown if `--help
all` was used. This change makes checking curl feature support use
`--help all` for all feature requests.