### PR TITLE
build_h3_tools: use OpenSSL_1_1_1k+quic

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -19,15 +19,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# Probably have to change these to your preferred installation directory
+set -e
+
+# Update this as the draft we support updates.
+OPENSSL_BRANCH=${OPENSSL_BRANCH:-"OpenSSL_1_1_1k+quic"}
+
+# Set these, if desired, to change these to your preferred installation
+# directory
 BASE=${BASE:-"/opt"}
-OPENSSL=${OPENSSL:-"${BASE}/openssl-quic"}
+OPENSSL_BASE=${OPENSSL_BASE:-"${BASE}/openssl-quic"}
+OPENSSL_PREFIX=${OPENSSL_PREFIX:-"${OPENSSL_BASE}-${OPENSSL_BRANCH}"}
 MAKE="make"
 
 # These are for Linux like systems, specially the LDFLAGS, also depends on dirs above
 CFLAGS=${CFLAGS:-"-O3 -g"}
 CXXFLAGS=${CXXFLAGS:-"-O3 -g"}
-LDFLAGS=${LDFLAGS:-"-Wl,-rpath=${OPENSSL}/lib"}
+LDFLAGS=${LDFLAGS:-"-Wl,-rpath=${OPENSSL_PREFIX}/lib"}
 
 if [ -e /etc/redhat-release ]; then
     MAKE="gmake"
@@ -52,13 +59,19 @@ elif [ -e /etc/debian_version ]; then
     echo
 fi
 
+set -x
+
 # OpenSSL needs special hackery ... Only grabbing the branch we need here... Bryan has shit for network.
 echo "Building OpenSSL with QUIC support"
-[ ! -d openssl-quic ] && git clone -b OpenSSL_1_1_1g-quic-draft-32 --depth 1 https://github.com/tatsuhiro-t/openssl openssl-quic
+[ ! -d openssl-quic ] && git clone -b ${OPENSSL_BRANCH} --depth 1 https://github.com/quictls/openssl.git openssl-quic
 cd openssl-quic
-./config --prefix=${OPENSSL}
+./config --prefix=${OPENSSL_PREFIX}
 ${MAKE} -j $(nproc)
 sudo ${MAKE} install
+
+# The symlink target provides a more convenient path for the user while also
+# providing, in the symlink source, the precise branch of the OpenSSL build.
+sudo ln -sf ${OPENSSL_PREFIX} ${OPENSSL_BASE}
 cd ..
 
 # Then nghttp3
@@ -66,7 +79,7 @@ echo "Building nghttp3..."
 [ ! -d nghttp3 ] && git clone https://github.com/ngtcp2/nghttp3.git
 cd nghttp3
 autoreconf -if
-./configure --prefix=${BASE} PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL}/lib/pkgconfig CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
+./configure --prefix=${BASE} PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_PREFIX}/lib/pkgconfig CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
 ${MAKE} -j $(nproc)
 sudo ${MAKE} install
 cd ..
@@ -76,7 +89,7 @@ echo "Building ngtcp2..."
 [ ! -d ngtcp2 ] && git clone https://github.com/ngtcp2/ngtcp2.git
 cd ngtcp2
 autoreconf -if
-./configure --prefix=${BASE} PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL}/lib/pkgconfig CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
+./configure --prefix=${BASE} PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_PREFIX}/lib/pkgconfig CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
 ${MAKE} -j $(nproc)
 sudo ${MAKE} install
 cd ..
@@ -87,7 +100,7 @@ echo "Building nghttp2 ..."
 cd nghttp2
 git checkout --track -b quic origin/quic
 autoreconf -if
-./configure --prefix=${BASE} PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL}/lib/pkgconfig CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
+./configure --prefix=${BASE} PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_PREFIX}/lib/pkgconfig CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
 ${MAKE} -j $(nproc)
 sudo ${MAKE} install
 cd ..
@@ -97,6 +110,6 @@ echo "Building curl ..."
 [ ! -d curl ] && git clone https://github.com/curl/curl.git
 cd curl
 autoreconf -i
-./configure --prefix=${BASE} --with-ssl=${OPENSSL} --with-nghttp2=${BASE} --with-nghttp3=${BASE} --with-ngtcp2=${BASE} CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
+./configure --prefix=${BASE} --with-ssl=${OPENSSL_PREFIX} --with-nghttp2=${BASE} --with-nghttp3=${BASE} --with-ngtcp2=${BASE} CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
 ${MAKE} -j $(nproc)
 sudo ${MAKE} install


### PR DESCRIPTION
The previous version of build_h3_tools.sh built openssl with
OpenSSL_1_1_1g-quic-draft-32 which, when linked against, caused neither
ATS nor curl to not be able to respond to HTTPS requests. This addresses
this by changing to the quictls/openssl and using the
OpenSSL_1_1_1k+quic branch.  This is what the author of ngtcp2 has done,
so this seems like a good direction for building these tools (one of
which is ngtcp2). Making this change fixes HTTPS for both curl and ATS
and still leads to functional HTTP/3 support.

This also makes /opt/openssl-quic a symlink to the built directory which
contains the explicit openssl draft branch name. Thus, with default
environment parameters, running the script results in the following:

$ ls -lad /opt/openssl-quic*
lrwxrwxrwx 1 root root  37 May 13 02:57 /opt/openssl-quic -> /opt/openssl-quic-OpenSSL_1_1_1k+quic
drwxr-xr-x 7 root root  67 May 13 02:56 /opt/openssl-quic-OpenSSL_1_1_1k+quic