### PR TITLE
Update NextHop strategies so that unavailable server retry codes are configurable.

### DIFF
--- a/doc/admin-guide/files/strategies.yaml.en.rst
+++ b/doc/admin-guide/files/strategies.yaml.en.rst
@@ -183,6 +183,7 @@ Each **strategy** in the list may using the following parameters::
 - **scheme** Indicates which scheme the strategy supports, *http* or *https*
   - **failover**: A map of **failover** information.
   - **max_simple_retries**: Part of the **failover** map and is an integer value of the maximum number of retries for a **simple retry** on the list of indicated response codes.  **simple retry** is used to retry an upstream request using another upstream server if the response received on from the original upstream request matches any of the response codes configured for this strategy in the **failover** map.  If no failover response codes are configured, no **simple retry** is attempted.
+  - **max_unavailable_retries Part of the **failover** map and is an integer value of the maximum number of retries for a **unavailable retry** on the list of indicated markdown response codes.  **unavailable retry** is used to retry an upstream request using another upstream server if the response received on from the original upstream request matches any of the markdown response codes configured for this strategy in the **failover** map.  If no failover markdown response codes are configured, no **unavailable retry** is attempted.  **unavailable retry** differs from **simple retry** in that if a failover for retry is done, the previously retried server is marked down for rety.
 
   - **ring_mode**: Part of the **failover** map. The host ring selection mode.  Use either **exhaust_ring** or **alternate_ring**
 
@@ -190,6 +191,7 @@ Each **strategy** in the list may using the following parameters::
    #. **alternate_ring**: retry hosts are selected from groups in an alternating group fashion.
 
   - **response_codes**: Part of the **failover** map.  This is a list of **http** response codes that may be used for **simple retry**.
+  - **markdown_codes**: Part of the **failover** map.  This is a list of **http** response codes that may be used for **unavailable retry** which will cause a parent markdown.
   - **health_check**: Part of the **failover** map.  A list of health checks. **passive** is the default and means that the state machine marks down **hosts** when a transaction timeout or connection error is detected.  **passive** is always used by the next hop strategies.  **active** means that some external process may actively health check the hosts using the defined **health check url** and mark them down using **traffic_ctl**.
 
 
@@ -211,6 +213,7 @@ Example:
         ring_mode: exhaust_ring
         response_codes:
           - 404
+        markdown_codes:
           - 503
         health_check:
           - passive
@@ -226,6 +229,7 @@ Example:
         ring_mode: exhaust_ring
         response_codes:
           - 404
+        markdown_codes:
           - 503
         health_check:
           - passive

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -380,15 +380,7 @@ response_is_retryable(HttpTransact::State *s, HTTPStatus response_code)
   }
   const url_mapping *mp = s->url_map.getMapping();
   if (mp && mp->strategy) {
-    if (mp->strategy->responseIsRetryable(s->current.simple_retry_attempts, response_code)) {
-      if (mp->strategy->onFailureMarkParentDown(response_code)) {
-        return PARENT_RETRY_UNAVAILABLE_SERVER;
-      } else {
-        return PARENT_RETRY_SIMPLE;
-      }
-    } else {
-      return PARENT_RETRY_NONE;
-    }
+    return mp->strategy->responseIsRetryable(s->state_machine->sm_id, s->current, response_code);
   }
 
   if (s->parent_params && !s->parent_result.response_is_retryable(response_code)) {

--- a/proxy/http/remap/NextHopSelectionStrategy.h
+++ b/proxy/http/remap/NextHopSelectionStrategy.h
@@ -25,6 +25,7 @@
 
 #include "ts/parentselectdefs.h"
 #include "ParentSelection.h"
+#include "HttpTransact.h"
 
 #ifndef _NH_UNIT_TESTS_
 #define NH_Debug(tag, ...) Debug(tag, __VA_ARGS__)
@@ -240,8 +241,7 @@ public:
                    const time_t now = 0);
   bool nextHopExists(TSHttpTxn txnp, void *ih = nullptr);
 
-  virtual bool responseIsRetryable(unsigned int current_retry_attempts, HTTPStatus response_code);
-  virtual bool onFailureMarkParentDown(HTTPStatus response_code);
+  virtual ParentRetry_t responseIsRetryable(int64_t sm_id, HttpTransact::CurrentInfo &current_info, HTTPStatus response_code);
 
   std::string strategy_name;
   bool go_direct           = true;
@@ -250,15 +250,17 @@ public:
   NHPolicyType policy_type = NH_UNDEFINED;
   NHSchemeType scheme      = NH_SCHEME_NONE;
   NHRingMode ring_mode     = NH_ALTERNATE_RING;
-  ResponseCodes resp_codes;
+  ResponseCodes resp_codes;     // simple retry codes
+  ResponseCodes markdown_codes; // unavailable server retry and markdown codes
   HealthChecks health_checks;
   NextHopHealthStatus passive_health;
   std::vector<std::vector<std::shared_ptr<HostRecord>>> host_groups;
-  uint32_t max_simple_retries = 1;
-  uint32_t groups             = 0;
-  uint32_t grp_index          = 0;
-  uint32_t hst_index          = 0;
-  uint32_t num_parents        = 0;
-  uint32_t distance           = 0; // index into the strategies list.
-  int max_retriers            = 1;
+  uint32_t max_simple_retries      = 1;
+  uint32_t max_unavailable_retries = 1;
+  uint32_t groups                  = 0;
+  uint32_t grp_index               = 0;
+  uint32_t hst_index               = 0;
+  uint32_t num_parents             = 0;
+  uint32_t distance                = 0; // index into the strategies list.
+  int max_retriers                 = 1;
 };

--- a/proxy/http/remap/unit-tests/combined.yaml
+++ b/proxy/http/remap/unit-tests/combined.yaml
@@ -89,10 +89,15 @@ strategies:
         exhaust_ring # enumerated as exhaust_ring or alternate_ring
         #1) in 'exhaust_ring' mode all the servers in a ring are exhausted before failing over to secondary ring
         #2) in 'alternate_ring' mode causes the failover to another server in secondary ring.
-      response_codes: # defines the responses codes for failover in exhaust_ring mode
+      response_codes: # defines the responses codes for simple retry failover in
         - 404
+        - 402
+        - 403
+      markdown_codes: # defines the response codes for unavailble server retry
+        - 405
         - 502
         - 503
+
       health_check: # specifies the list of healthchecks that should be considered for failover. A list of enums: 'passive' or 'active'
         - passive
         - active

--- a/proxy/http/remap/unit-tests/test_NextHopStrategyFactory.cc
+++ b/proxy/http/remap/unit-tests/test_NextHopStrategyFactory.cc
@@ -386,7 +386,7 @@ SCENARIO("factory tests loading yaml configs", "[loadConfig]")
         CHECK(strategy->ring_mode == NH_EXHAUST_RING);
         CHECK(strategy->groups == 2);
         CHECK(strategy->resp_codes.contains(404));
-        CHECK(strategy->resp_codes.contains(502));
+        CHECK(strategy->resp_codes.contains(402));
         CHECK(!strategy->resp_codes.contains(604));
         CHECK(strategy->health_checks.active == true);
         CHECK(strategy->health_checks.passive == true);
@@ -446,7 +446,7 @@ SCENARIO("factory tests loading yaml configs", "[loadConfig]")
           }
         }
         CHECK(strategy->resp_codes.contains(404));
-        CHECK(strategy->resp_codes.contains(503));
+        CHECK(strategy->resp_codes.contains(403));
         CHECK(!strategy->resp_codes.contains(604));
       }
     }
@@ -870,6 +870,9 @@ SCENARIO("factory tests loading yaml configs from a directory", "[loadConfig]")
         CHECK(strategy->resp_codes.contains(404));
         CHECK(strategy->resp_codes.contains(503));
         CHECK(!strategy->resp_codes.contains(604));
+        CHECK(!strategy->markdown_codes.contains(405));
+        CHECK(!strategy->markdown_codes.contains(502));
+        CHECK(!strategy->markdown_codes.contains(503));
       }
     }
 


### PR DESCRIPTION
Update NextHop strategies so that unavailable server retry codes are configurable in the YAML instead of using a hard coded range of codes.  This conforms to the same configuration capability in parent.config.