### PR TITLE
Fixed warning in gcc 11 about array not being initalized

### DIFF
--- a/src/tscore/Regex.cc
+++ b/src/tscore/Regex.cc
@@ -111,7 +111,7 @@ Regex::get_capture_count()
 bool
 Regex::exec(std::string_view const &str)
 {
-  std::array<int, DEFAULT_GROUP_COUNT * 3> ovector;
+  std::array<int, DEFAULT_GROUP_COUNT * 3> ovector = {0};
   return this->exec(str, ovector.data(), ovector.size());
 }
 


### PR DESCRIPTION
```
../../../src/tscore/Regex.cc: In member function ‘bool Regex::exec(const string_view&)’:
../../../src/tscore/Regex.cc:115:54: error: ‘ovector’ may be used uninitialized [-Werror=maybe-uninitialized]
  115 |   return this->exec(str, ovector.data(), ovector.size());
      |                                          ~~~~~~~~~~~~^~
In file included from ../../../src/tscore/Regex.cc:24:
/usr/include/c++/11/array:176:7: note: by argument 1 of type ‘const std::array<int, 30>*’ to ‘constexpr std::array<_Tp, _Nm>::size_type std::array<_Tp, _Nm>::size() const [with _Tp = int; long unsigned int _Nm = 30]’ declared here
  176 |       size() const noexcept { return _Nm; }
      |       ^~~~
../../../src/tscore/Regex.cc:114:44: note: ‘ovector’ declared here
  114 |   std::array<int, DEFAULT_GROUP_COUNT * 3> ovector;
      |                                            ^~~~~~~
cc1plus: all warnings being treated as errors
```