### PR TITLE
HTTP/2 Session & ConnectionState Cleanup

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4010,15 +4010,6 @@ HTTP/2 Configuration
    misconfigured or misbehaving clients are opening a large number of
    connections without submitting requests.
 
-.. ts:cv:: CONFIG proxy.config.http2.zombie_debug_timeout_in INT 0
-   :reloadable:
-
-   This timeout enables the zombie debugging feature.  If it is non-zero, it sets a zombie event to go off that
-   many seconds in the future when the HTTP2 session reaches one but not both of the terminating events, i.e received
-   a close event (via client goaway or timeout) and the number of active streams has gone to zero.  If the event is executed,
-   the |TS| process will assert.  This mechanism is useful to debug potential leaks in the HTTP2 Stream and Session
-   processing.
-
 .. ts:cv:: CONFIG proxy.config.http2.push_diary_size INT 256
    :reloadable:
 

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -793,7 +793,6 @@ uint32_t Http2::accept_no_activity_timeout     = 120;
 uint32_t Http2::no_activity_timeout_in         = 120;
 uint32_t Http2::active_timeout_in              = 0;
 uint32_t Http2::push_diary_size                = 256;
-uint32_t Http2::zombie_timeout_in              = 0;
 float Http2::stream_error_rate_threshold       = 0.1;
 uint32_t Http2::max_settings_per_frame         = 7;
 uint32_t Http2::max_settings_per_minute        = 14;
@@ -823,7 +822,6 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(no_activity_timeout_in, "proxy.config.http2.no_activity_timeout_in");
   REC_EstablishStaticConfigInt32U(active_timeout_in, "proxy.config.http2.active_timeout_in");
   REC_EstablishStaticConfigInt32U(push_diary_size, "proxy.config.http2.push_diary_size");
-  REC_EstablishStaticConfigInt32U(zombie_timeout_in, "proxy.config.http2.zombie_debug_timeout_in");
   REC_EstablishStaticConfigFloat(stream_error_rate_threshold, "proxy.config.http2.stream_error_rate_threshold");
   REC_EstablishStaticConfigInt32U(max_settings_per_frame, "proxy.config.http2.max_settings_per_frame");
   REC_EstablishStaticConfigInt32U(max_settings_per_minute, "proxy.config.http2.max_settings_per_minute");

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -392,7 +392,6 @@ public:
   static uint32_t no_activity_timeout_in;
   static uint32_t active_timeout_in;
   static uint32_t push_diary_size;
-  static uint32_t zombie_timeout_in;
   static float stream_error_rate_threshold;
   static uint32_t max_settings_per_frame;
   static uint32_t max_settings_per_minute;

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -482,6 +482,10 @@ Http2ClientSession::state_aborted(int event, void *edata)
 
     break;
   }
+  case HTTP2_SESSION_EVENT_GRACEFUL_SHUTDOWN: {
+    _graceful_shutdown_event = nullptr;
+    [[fallthrough]];
+  }
   case VC_EVENT_READ_READY:
   case VC_EVENT_READ_COMPLETE:
   case VC_EVENT_WRITE_READY:

--- a/proxy/http2/Http2ClientSession.h
+++ b/proxy/http2/Http2ClientSession.h
@@ -49,7 +49,9 @@ enum class Http2SsnMilestone {
 
 size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ_BUFFER_SIZE_INDEX;
 
+// clang-format off
 /**
+
    @startuml
    title ProxySession Continuation Handler
    hide empty description
@@ -70,6 +72,8 @@ size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ_BUFFE
    state_aborted --> state_closed  : all transaction is done
 
    state_open              --> state_graceful_shutdown : graceful shutdown
+   state_graceful_shutdown --> state_aborted           : VC_EVENT_EOS\lVC_EVENT_ERROR\lrecv GOAWAY frame with error code
+   state_graceful_shutdown --> state_goaway            : VC_EVENT_ACTIVE_TIMEOUT\lVC_EVENT_INACTIVITY_TIMEOUT\lsend GOAWAY frame with error code
    state_graceful_shutdown --> state_closed            : all transaction is done
 
    state_open   --> state_goaway : VC_EVENT_ACTIVE_TIMEOUT\lVC_EVENT_INACTIVITY_TIMEOUT\lsend GOAWAY frame with error code
@@ -91,6 +95,7 @@ size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = CLIENT_CONNECTION_FIRST_READ_BUFFE
 
    @enduml
  */
+// clang-format on
 class Http2ClientSession : public ProxySession
 {
 public:

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -8223,7 +8223,7 @@ TSHttpTxnServerPush(TSHttpTxn txnp, const char *url, int url_len)
 
   Http2ClientSession *ua_session = static_cast<Http2ClientSession *>(stream->get_proxy_ssn());
   SCOPED_MUTEX_LOCK(lock, ua_session->mutex, this_ethread());
-  if (ua_session->connection_state.is_state_closed() || ua_session->is_url_pushed(url, url_len)) {
+  if (ua_session->is_state_closed() || ua_session->is_url_pushed(url, url_len)) {
     url_obj.destroy();
     return TS_ERROR;
   }


### PR DESCRIPTION
Part of address #6877. One of things makes HTTP/2 Session complicated is `Http2ClientSession` & `Http2ConnectionState` are calling each other as `Continuation`. To make this simple, I propose below.

1). Make `Http2ConnectionState` just a class
2). Introduce states of HTTP/2 session as Continuation Handler

<img width="1030" alt="Screen Shot 2021-07-07 at 15 50 21" src="https://user-images.githubusercontent.com/741391/124713132-1dbe3000-df3b-11eb-8fe9-d69d5ac95d32.png">

https://gist.github.com/masaori335/f16a851b50bec2f69e4034844a40ab59#file-http2ssn-uml