### PR TITLE
Remove bucket search from IntrusiveHashMap::erase

### DIFF
--- a/include/tscore/IntrusiveHashMap.h
+++ b/include/tscore/IntrusiveHashMap.h
@@ -580,21 +580,12 @@ template <typename H>
 bool
 IntrusiveHashMap<H>::erase(value_type *v)
 {
-  ++(this->iterator_for(v)); // get around no const_iterator -> iterator.
-  Bucket *b         = this->bucket_for(H::key_of(v));
-  value_type *nv    = H::next_ptr(v);
-  value_type *limit = b->limit();
-  if (b->_v == v) {    // removed first element in bucket, update bucket
-    if (limit == nv) { // that was also the only element, deactivate bucket
-      _active_buckets.erase(b);
-      b->clear();
-    } else {
-      b->_v = nv;
-      --b->_count;
-    }
+  auto loc = this->iterator_for(v);
+  if (loc != this->end()) {
+    this->erase(loc);
+    return true;
   }
-  _list.erase(v);
-  return true;
+  return false;
 }
 
 template <typename H>


### PR DESCRIPTION
Noticed this while working with the origin session pool tracking down a problem with too many origin connections in the pool.  In perftop both FQDNLinkage::find and IPLinkage::find were showing up in the top 20. 

Looking at erase taking a value argument (instead of an iterator), the erase logic was doing a find() first to make sure the value was still there.  Even though the value has the next/prev links intrusively embedded in the object. 

This code change makes the value-based erase act like the iterator based erase.  It seems that we should have a different call if we are not sure whether the object is in the container or not.  In the case of the origin session pools, we do know that it is in the pool when we get ready to erase it.