### PR TITLE
Cleanup: refer Http2ClientSession::mutex

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -241,10 +241,7 @@ Http2ClientSession::do_io_close(int alerrno)
   ink_assert(this->mutex->thread_holding == this_ethread());
   send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_FINI, this);
 
-  {
-    SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
-    this->connection_state.release_stream();
-  }
+  this->connection_state.release_stream();
 
   this->clear_session_active();
 
@@ -571,7 +568,6 @@ Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_fr
     if (err > Http2ErrorCode::HTTP2_ERROR_NO_ERROR || do_start_frame_read(err) < 0) {
       // send an error if specified.  Otherwise, just go away
       if (err > Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
-        SCOPED_MUTEX_LOCK(lock, this->connection_state.mutex, this_ethread());
         if (!this->connection_state.is_state_closed()) {
           this->connection_state.send_goaway_frame(this->connection_state.get_latest_stream_id_in(), err);
           this->set_half_close_local_flag(true);

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -78,7 +78,7 @@ Http2Stream::~Http2Stream()
     cid = _proxy_ssn->connection_id();
 
     Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(_proxy_ssn);
-    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
     // Make sure the stream is removed from the stream list and priority tree
     // In many cases, this has been called earlier, so this call is a no-op
     h2_proxy_ssn->connection_state.delete_stream(this);
@@ -433,7 +433,7 @@ Http2Stream::do_io_close(int /* flags */)
       // Make sure any trailing end of stream frames are sent
       // Wee will be removed at send_data_frames or closing connection phase
       Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
-      SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+      SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
       h2_proxy_ssn->connection_state.send_data_frames(this);
     }
 
@@ -475,7 +475,7 @@ Http2Stream::terminate_if_possible()
     REMEMBER(NO_EVENT, this->reentrancy_count);
 
     Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
-    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
     THREAD_FREE(this, http2StreamAllocator, this_ethread());
   }
 }
@@ -656,7 +656,7 @@ Http2Stream::update_write_request(bool call_update)
         int len;
         const char *value = field->value_get(&len);
         if (memcmp(HTTP_VALUE_CLOSE, value, HTTP_LEN_CLOSE) == 0) {
-          SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+          SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
           if (h2_proxy_ssn->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
             h2_proxy_ssn->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED, Http2ErrorCode::HTTP2_ERROR_NO_ERROR);
           }
@@ -664,7 +664,7 @@ Http2Stream::update_write_request(bool call_update)
       }
 
       {
-        SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+        SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
         // Send the response header back
         h2_proxy_ssn->connection_state.send_headers_frame(this);
       }
@@ -769,7 +769,7 @@ bool
 Http2Stream::push_promise(URL &url, const MIMEField *accept_encoding)
 {
   Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
-  SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+  SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
   return h2_proxy_ssn->connection_state.send_push_promise_frame(this, url, accept_encoding);
 }
 
@@ -780,12 +780,12 @@ Http2Stream::send_response_body(bool call_update)
   _timeout.update_inactivity();
 
   if (Http2::stream_priority_enabled) {
-    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
     h2_proxy_ssn->connection_state.schedule_stream(this);
     // signal_write_event() will be called from `Http2ConnectionState::send_data_frames_depends_on_priority()`
     // when write_vio is consumed
   } else {
-    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+    SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
     h2_proxy_ssn->connection_state.send_data_frames(this);
     this->signal_write_event(call_update);
     // XXX The call to signal_write_event can destroy/free the Http2Stream.
@@ -803,7 +803,7 @@ Http2Stream::reenable(VIO *vio)
     } else if (vio->op == VIO::READ) {
       Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
       {
-        SCOPED_MUTEX_LOCK(ssn_lock, h2_proxy_ssn->connection_state.mutex, this_ethread());
+        SCOPED_MUTEX_LOCK(ssn_lock, h2_proxy_ssn->mutex, this_ethread());
         h2_proxy_ssn->connection_state.restart_receiving(this);
       }
 


### PR DESCRIPTION
`Http2ConnectionState::mutex` is the same as `Http2ClientSession::mutex`.

https://github.com/apache/trafficserver/blob/19dfdd4753232d0b77ca555f7ef5f5ba3d2ccae1/proxy/http2/Http2ClientSession.cc#L204

Use `Http2ClientSession::mutex` and remove meaningless `SCOPED_MUTEX_LOCK` to minimize diff of #7845.

Part of #7852