### PR TITLE
Update bootstrap autest version to match the rest of autest

### DIFF
--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -26,7 +26,7 @@ import platform
 import sys
 
 pip_packages = [
-    "autest==1.8.0",
+    "autest==1.10.0",
     "hyper",
     "requests",
     "dnslib",


### PR DESCRIPTION
We updated autest to ver 1.10, however the bootstrap file still references 1.8 in 8.1.x. This causes autest to download the older version which then fails the version checks later.

I dont think we see this during open source CI since it uses pre-made sandboxes, however we see this locally in our own builds which build a new env for each run