### PR TITLE
Don't call next next dup on destroyed mime field mloc. (#7833)

### DIFF
--- a/plugins/background_fetch/headers.cc
+++ b/plugins/background_fetch/headers.cc
@@ -75,6 +75,7 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
     bool first = true;
 
     while (field_loc) {
+      tmp = TSMimeHdrFieldNextDup(bufp, hdr_loc, field_loc);
       if (first) {
         first = false;
         if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdr_loc, field_loc, -1, val, val_len)) {
@@ -83,7 +84,6 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
       } else {
         TSMimeHdrFieldDestroy(bufp, hdr_loc, field_loc);
       }
-      tmp = TSMimeHdrFieldNextDup(bufp, hdr_loc, field_loc);
       TSHandleMLocRelease(bufp, hdr_loc, field_loc);
       field_loc = tmp;
     }

--- a/plugins/experimental/access_control/headers.cc
+++ b/plugins/experimental/access_control/headers.cc
@@ -156,6 +156,7 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
     bool first = true;
 
     while (fieldLoc) {
+      tmp = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
       if (first) {
         first = false;
         if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdrLoc, fieldLoc, -1, value, valuelen)) {
@@ -164,7 +165,6 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
       } else {
         TSMimeHdrFieldDestroy(bufp, hdrLoc, fieldLoc);
       }
-      tmp = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
       TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
       fieldLoc = tmp;
     }

--- a/plugins/experimental/cache_fill/background_fetch.cc
+++ b/plugins/experimental/cache_fill/background_fetch.cc
@@ -68,6 +68,7 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
     bool first = true;
 
     while (field_loc) {
+      tmp = TSMimeHdrFieldNextDup(bufp, hdr_loc, field_loc);
       if (first) {
         first = false;
         if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdr_loc, field_loc, -1, val, val_len)) {
@@ -76,7 +77,6 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
       } else {
         TSMimeHdrFieldDestroy(bufp, hdr_loc, field_loc);
       }
-      tmp = TSMimeHdrFieldNextDup(bufp, hdr_loc, field_loc);
       TSHandleMLocRelease(bufp, hdr_loc, field_loc);
       field_loc = tmp;
     }

--- a/plugins/experimental/cache_range_requests/cache_range_requests.cc
+++ b/plugins/experimental/cache_range_requests/cache_range_requests.cc
@@ -433,6 +433,7 @@ set_header(TSMBuffer buf, TSMLoc hdr_loc, const char *header, int len, const cha
     bool first = true;
 
     while (field_loc) {
+      tmp = TSMimeHdrFieldNextDup(buf, hdr_loc, field_loc);
       if (first) {
         first = false;
         if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(buf, hdr_loc, field_loc, -1, val, val_len)) {
@@ -441,7 +442,6 @@ set_header(TSMBuffer buf, TSMLoc hdr_loc, const char *header, int len, const cha
       } else {
         TSMimeHdrFieldDestroy(buf, hdr_loc, field_loc);
       }
-      tmp = TSMimeHdrFieldNextDup(buf, hdr_loc, field_loc);
       TSHandleMLocRelease(buf, hdr_loc, field_loc);
       field_loc = tmp;
     }

--- a/plugins/experimental/prefetch/headers.cc
+++ b/plugins/experimental/prefetch/headers.cc
@@ -156,6 +156,7 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
     bool first = true;
 
     while (fieldLoc) {
+      tmp = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
       if (first) {
         first = false;
         if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdrLoc, fieldLoc, -1, value, valuelen)) {
@@ -164,7 +165,6 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
       } else {
         TSMimeHdrFieldDestroy(bufp, hdrLoc, fieldLoc);
       }
-      tmp = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
       TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
       fieldLoc = tmp;
     }

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -621,6 +621,7 @@ OperatorSetHeader::exec(const Resources &res) const
       bool first = true;
 
       while (field_loc) {
+        tmp = TSMimeHdrFieldNextDup(res.bufp, res.hdr_loc, field_loc);
         if (first) {
           first = false;
           if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(res.bufp, res.hdr_loc, field_loc, -1, value.c_str(), value.size())) {
@@ -629,7 +630,6 @@ OperatorSetHeader::exec(const Resources &res) const
         } else {
           TSMimeHdrFieldDestroy(res.bufp, res.hdr_loc, field_loc);
         }
-        tmp = TSMimeHdrFieldNextDup(res.bufp, res.hdr_loc, field_loc);
         TSHandleMLocRelease(res.bufp, res.hdr_loc, field_loc);
         field_loc = tmp;
       }


### PR DESCRIPTION
plugins/background_fetch/headers.cc
plugins/cache_range_requests/cache_range_requests.cc
plugins/experimental/access_control/headers.cc
plugins/experimental/cache_fill/background_fetch.cc
plugins/header_rewrite/operators.cc
plugins/prefetch/headers.cc

(cherry picked from commit dc10eae8a85e9b1c3436d15bb97219e98b41d42e)