### PR TITLE
Do not delete the continuation twice

### DIFF
--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -657,8 +657,6 @@ void
 TSRemapDeleteInstance(void *ih)
 {
   BgFetchConfig *config = static_cast<BgFetchConfig *>(ih);
-
-  TSContDestroy(config->getCont());
   delete config;
 }
 


### PR DESCRIPTION
Continuation is destroyed both in the destructor of BgFetchConfig and by calling TSContDestroy in TSRemapDeleteInstance. 