### PR TITLE
Autest - Proxy Verifier Extension, add context template $-base string…

### DIFF
--- a/tests/gold_tests/autest-site/verifier_client.test.ext
+++ b/tests/gold_tests/autest-site/verifier_client.test.ext
@@ -19,12 +19,13 @@ Implement the Proxy Verifier client extensions.
 
 
 import os
-from verifier_common import create_address_argument
+from verifier_common import create_address_argument, substitute_context_in_replay_file
 
 
 def _configure_client(obj, process, name, replay_path, http_ports=None,
                       https_ports=None, http3_ports=None, keys=None,
-                      ssl_cert='', ca_cert='', verbose=True, other_args=''):
+                      ssl_cert='', ca_cert='', verbose=True, other_args='',
+                      context=None):
     """
     Configure the process for running the verifier-client.
 
@@ -53,6 +54,10 @@ def _configure_client(obj, process, name, replay_path, http_ports=None,
     # Configure the verifier-client command line arguments.
     command = "verifier-client run "
     if replay_path:
+        if context:
+            # replace the passed replay file with the new one generated using the passed
+            # context
+            replay_path = substitute_context_in_replay_file(process, replay_path, context)
         # Create a copy of the replay directory in the run directory.
         run_replay_path = os.path.join(client_dir, os.path.basename(replay_path))
         process.Setup.Copy(replay_path, run_replay_path, CopyLogic.SoftFiles)
@@ -133,7 +138,8 @@ def _configure_client(obj, process, name, replay_path, http_ports=None,
 
 def AddVerifierClientProcess(run, name, replay_path, http_ports=None,
                              https_ports=None, http3_ports=None, keys=None,
-                             ssl_cert='', ca_cert='', verbose=True, other_args=''):
+                             ssl_cert='', ca_cert='', verbose=True, other_args='',
+                             context=None):
     """
     Set the Default process of the test run to a verifier-client Process.
 
@@ -163,15 +169,27 @@ def AddVerifierClientProcess(run, name, replay_path, http_ports=None,
 
         other_args: (str) Any other arbitrary options to pass to verifier-client.
 
+        context: Any dictionary-like object with keys that match the placeholders
+                 in the replay file.
+                 Template strings support $-based substitutions in the replay file.
+                 You can refer to https://docs.python.org/3/library/string.html#template-strings
+                 for more information how to add template strings to the replay file.
     Returns:
         The newly constructed verifier-client for the test run, which is also the
         Default Process of the test run.
+    Throws:
+        ValueError:
+            If context substitution is expected to be done but a directory is passed as a
+            replay_path.
+        OSError in case of any issues related to I/O error, ie: File Not found for the replay
+            file when a context substitution is expected.
+        KeyError if placeholders are missing from the mapping between context and the replay file.
     """
 
     p = run.Processes.Default
     _configure_client(run, p, name, replay_path, http_ports, https_ports,
                       http3_ports, keys, ssl_cert, ca_cert, verbose,
-                      other_args)
+                      other_args, context)
     return p
 
 

--- a/tests/gold_tests/autest-site/verifier_common.py
+++ b/tests/gold_tests/autest-site/verifier_common.py
@@ -16,6 +16,9 @@ Common utilities for the Proxy Verifier extensions.
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import os
+import tempfile
+from string import Template
 
 
 def create_address_argument(ports):
@@ -33,3 +36,24 @@ def create_address_argument(ports):
         argument += "127.0.0.1:{}".format(port)
     argument += '"'
     return argument
+
+
+def substitute_context_in_replay_file(process, replay_path, context):
+    '''
+    Perform substitution base on the passed context dict.
+    This function will return the new replay_path file
+    '''
+    # Only files for now
+    if os.path.isdir(replay_path):
+        raise ValueError(f"Mapping substitution not supported for directories.")
+
+    with open(os.path.join(process.TestDirectory, replay_path), 'r') as replay_file:
+        replay_template = Template(replay_file.read())
+        replay_content = replay_template.substitute(context)
+        tf = tempfile.NamedTemporaryFile(delete=False, dir=process.RunDirectory, suffix=f"_{os.path.basename(replay_path)}")
+        replay_path = tf.name
+        with open(replay_path, "w") as new_replay_file:
+            new_replay_file.write(replay_content)
+
+    # use this as replay_path
+    return replay_path

--- a/tests/gold_tests/autest-site/verifier_server.test.ext
+++ b/tests/gold_tests/autest-site/verifier_server.test.ext
@@ -18,13 +18,14 @@ Implement the Proxy Verifier test server extension.
 #  limitations under the License.
 
 import os
+
 from ports import get_port
-from verifier_common import create_address_argument
+from verifier_common import create_address_argument, substitute_context_in_replay_file
 
 
 def _configure_server(obj, process, name, replay_path, http_ports=None, https_ports=None,
                       http3_ports=None, ssl_cert='', ca_cert='', verbose=True,
-                      other_args=''):
+                      other_args='', context=None):
     """
     Configure the provided process to run a verifier-server command.
 
@@ -119,8 +120,13 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
             command += ' --ca-certs "{}" '.format(run_ca_cert)
 
     if replay_path:
-        # Create a copy of the replay directory in the run directory.
+        if context:
+            # replace the passed replay file with the new one generated using the passed
+            # context
+            replay_path = substitute_context_in_replay_file(process, replay_path, context)
+
         run_replay_path = os.path.join(server_dir, os.path.basename(replay_path))
+        # Create a copy of the replay directory in the run directory.
         process.Setup.Copy(replay_path, run_replay_path, CopyLogic.SoftFiles)
         command += "{} ".format(run_replay_path)
 
@@ -141,7 +147,7 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
 
 def MakeVerifierServerProcess(test, name, replay_path, http_ports=None,
                               https_ports=None, http3_ports=None, ssl_cert='',
-                              ca_cert='', verbose=True, other_args=''):
+                              ca_cert='', verbose=True, other_args='', context=None):
     """
     Create a verifier-server process for the Test.
 
@@ -174,19 +180,30 @@ def MakeVerifierServerProcess(test, name, replay_path, http_ports=None,
 
         other_args: (str) Any other arbitrary options to pass to verifier-server.
 
+        context: Any dictionary-like object with keys that match the placeholders
+                 in the replay file.
+                 Template strings support $-based substitutions in the
+                 replay file.
+                 You can refer to https://docs.python.org/3/library/string.html#template-strings
+                 for more information how to add template strings to the replay file.
     Raises:
         ValueError if https_ports is non-empty and a valid ssl_cert could not
             be derived.
+            If context substitution is expected to be done but a directory is passed as a
+            replay_path.
+        OSError in case of any issues related to I/O error, ie: File Not found for the replay
+            file when a context substitution is expected.
+        KeyError if placeholders are missing from the mapping between context and the replay file.
     """
     server = test.Processes.Process(name)
     _configure_server(test, server, name, replay_path, http_ports, https_ports,
-                      http3_ports, ssl_cert, ca_cert, verbose, other_args)
+                      http3_ports, ssl_cert, ca_cert, verbose, other_args, context)
     return server
 
 
 def AddVerifierServerProcess(run, name, replay_path, http_ports=None,
                              https_ports=None, http3_ports=None, ssl_cert='',
-                             ca_cert='', verbose=True, other_args=''):
+                             ca_cert='', verbose=True, other_args='', context=None):
     """
     Create a verifier-server process and configure it for the given TestRun.
 
@@ -201,7 +218,7 @@ def AddVerifierServerProcess(run, name, replay_path, http_ports=None,
 
     server = run.Processes.Process(name)
     _configure_server(run, server, name, replay_path, http_ports, https_ports,
-                      http3_ports, ssl_cert, ca_cert, verbose, other_args)
+                      http3_ports, ssl_cert, ca_cert, verbose, other_args, context)
 
     client = run.Processes.Default
     client.StartBefore(server)


### PR DESCRIPTION

Add support for `$-base` string   substitution on the passed replay file. 
With this feature we now should be able to have a replay file with `$-base` strings which will be replaced by the PV extension using a context dict-like structure.

A good use case for this would be that a particular PV Server(b) needs to redirect to another PV Server(a) , so the port needs to be part of the host string in the server's(b) replay file:

`my_replaty_file.yaml`
```
....
  server-response:
        status: 302
        reason: Redirect
        headers:
          fields:
          - [ Location, "http://a.test:${a_port}/" ]
```
my unit test
```
... 
Test.MakeVerifierServerProcess("b_server", "my_replaty_file.yaml", 
          context={"a_port": a_server.Variables.http_port})
```
