### PR TITLE
Remove second call to TRANSACT_RETURN while handling cache write lock

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3265,8 +3265,6 @@ HttpTransact::handle_cache_write_lock(State *s)
       ink_assert(s->next_action == SM_ACTION_DNS_LOOKUP);
       return;
     }
-
-    TRANSACT_RETURN(next, nullptr);
   }
 }
 


### PR DESCRIPTION
Discussion in the issue.

This closes #7872