### PR TITLE
Restrict HTTP versions allowed on the HTTP request line

### DIFF
--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -424,7 +424,7 @@ inkcoreapi int http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hh, char *buf, int buf
 
 void http_hdr_describe(HdrHeapObjImpl *obj, bool recurse = true);
 
-inkcoreapi void http_hdr_version_set(HTTPHdrImpl *hh, const HTTPVersion &ver);
+inkcoreapi bool http_hdr_version_set(HTTPHdrImpl *hh, const HTTPVersion &ver);
 
 const char *http_hdr_method_get(HTTPHdrImpl *hh, int *length);
 inkcoreapi void http_hdr_method_set(HdrHeap *heap, HTTPHdrImpl *hh, const char *method, int16_t method_wks_idx, int method_length,
@@ -461,6 +461,8 @@ const char*            http_parse_cache_directive (const char **buf);
 HTTPValRange*          http_parse_range (const char *buf, Arena *arena);
 */
 HTTPValTE *http_parse_te(const char *buf, int len, Arena *arena);
+
+inkcoreapi bool is_http_hdr_version_supported(const HTTPVersion &http_version);
 
 class IOBufferReader;
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -818,6 +818,10 @@ HttpSM::state_read_client_request_header(int event, void *data)
       t_state.http_return_code = HTTP_STATUS_REQUEST_URI_TOO_LONG :
       t_state.http_return_code = HTTP_STATUS_NONE;
 
+    if (!is_http_hdr_version_supported(t_state.hdr_info.client_request.version_get())) {
+      t_state.http_return_code = HTTP_STATUS_HTTPVER_NOT_SUPPORTED;
+    }
+
     call_transact_and_set_next_state(HttpTransact::BadRequest);
     break;
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -840,6 +840,10 @@ HttpTransact::BadRequest(State *s)
     status                = s->http_return_code;
     reason                = "Field not implemented";
     body_factory_template = "transcoding#unsupported";
+    break;
+  case HTTP_STATUS_HTTPVER_NOT_SUPPORTED:
+    status = s->http_return_code;
+    reason = "Unsupported HTTP Version";
   default:
     break;
   }


### PR DESCRIPTION
This change restricts allowed HTTP versions to 1.0, 1.1 on the
HTTP request line to prevent potential mishandling, request
smugging or other vulns due to random/arbitrary version tags

Note that HTTP/2.0 and HTTP/3.0 are negotiated via ALPN on TLS
and not via the HTTP request line.