### PR TITLE
Cleanup Http2ClientSession SessionHandler

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -437,7 +437,7 @@ Http2ClientSession::state_start_frame_read(int event, void *edata)
 
   STATE_ENTER(&Http2ClientSession::state_start_frame_read, event);
   ink_assert(event == VC_EVENT_READ_COMPLETE || event == VC_EVENT_READ_READY);
-  return state_process_frame_read(event, vio, false);
+  return do_process_frame_read(event, vio, false);
 }
 
 int
@@ -513,7 +513,7 @@ Http2ClientSession::state_complete_frame_read(int event, void *edata)
   }
   Http2SsnDebug("completed frame read, %" PRId64 " bytes available", this->_read_buffer_reader->read_avail());
 
-  return state_process_frame_read(event, vio, true);
+  return do_process_frame_read(event, vio, true);
 }
 
 int
@@ -539,7 +539,7 @@ Http2ClientSession::do_complete_frame_read()
 }
 
 int
-Http2ClientSession::state_process_frame_read(int event, VIO *vio, bool inside_frame)
+Http2ClientSession::do_process_frame_read(int event, VIO *vio, bool inside_frame)
 {
   if (inside_frame) {
     do_complete_frame_read();


### PR DESCRIPTION
Rename `state_process_frame_read` to `do_process_frame_read`, because it's not SessionHandler nor state.
No logic change. Part of #7852.

<img width="597" alt="Screen Shot 2021-05-25 at 14 59 12" src="https://user-images.githubusercontent.com/741391/119446727-dd7b6780-bd69-11eb-9731-43b551e6f7b8.png">
