### PR TITLE
Adds a new config to parallelize loading of ssl_multicert.config

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3463,6 +3463,13 @@ SSL Termination
    :file:`ssl_multicert.config` file successfully load.  If false (``0``), SSL certificate
    load failures will not prevent |TS| from starting.
 
+.. ts:cv:: CONFIG proxy.config.ssl.server.multicert.concurrency INT 0
+
+   If set to a non-zero value, allow the loading and reloading of
+   :file:`ssl_multicert.config` to be parallelized. The value specifies the
+   concurrency, i.e. how many threads will process the file in parallel. A
+   value of ``-1`` means to create one thread for each core.
+
 .. ts:cv:: CONFIG proxy.config.ssl.server.cert.path STRING /config
 
    The location of the SSL certificates and chains used for accepting

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -76,6 +76,7 @@ struct SSLConfigParams : public ConfigInfo {
   char *cipherSuite;
   char *client_cipherSuite;
   int configExitOnLoadError;
+  int configLoadConcurrency;
   int clientCertLevel;
   int verify_depth;
   int ssl_origin_session_cache;

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -63,7 +63,7 @@ public:
   SSLMultiCertConfigLoader(const SSLConfigParams *p) : _params(p) { ink_mutex_init(&m_mutex); }
   virtual ~SSLMultiCertConfigLoader() { ink_mutex_destroy(&m_mutex); };
 
-  bool load(SSLCertLookup *lookup);
+  bool load(SSLCertLookup *lookup, bool firstLoad);
 
   virtual SSL_CTX *default_server_ssl_ctx();
   virtual SSL_CTX *init_server_ssl_ctx(CertLoadData const &data, const SSLMultiCertConfigParams *sslMultCertSettings,

--- a/iocore/net/QUICMultiCertConfigLoader.cc
+++ b/iocore/net/QUICMultiCertConfigLoader.cc
@@ -53,7 +53,7 @@ QUICCertConfig::reconfigure()
   SSLCertLookup *lookup = new SSLCertLookup();
 
   QUICMultiCertConfigLoader loader(params);
-  loader.load(lookup);
+  loader.load(lookup, 0 == _config_id);
 
   _config_id = configProcessor.set(_config_id, lookup);
 }

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -33,6 +33,7 @@
 
 #include <cstring>
 #include <cmath>
+#include <thread>
 
 #include "tscore/ink_config.h"
 #include "tscore/ink_platform.h"
@@ -307,6 +308,10 @@ SSLConfigParams::initialize()
 
   configFilePath = ats_stringdup(RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename"));
   REC_ReadConfigInteger(configExitOnLoadError, "proxy.config.ssl.server.multicert.exit_on_load_fail");
+  REC_ReadConfigInteger(configLoadConcurrency, "proxy.config.ssl.server.multicert.concurrency");
+  if (configLoadConcurrency < 0) {
+    configLoadConcurrency = std::thread::hardware_concurrency();
+  }
 
   REC_ReadConfigStringAlloc(ssl_server_private_key_path, "proxy.config.ssl.server.private_key.path");
   set_paths_helper(ssl_server_private_key_path, nullptr, &serverKeyPathOnly, nullptr);

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -505,7 +505,7 @@ SSLCertificateConfig::reconfigure()
   }
 
   SSLMultiCertConfigLoader loader(params);
-  loader.load(lookup);
+  loader.load(lookup, 0 == configid); // The flag indicates if this is a first time load or not
 
   if (!lookup->is_valid) {
     retStatus = false;

--- a/iocore/net/SSLStats.cc
+++ b/iocore/net/SSLStats.cc
@@ -257,7 +257,6 @@ SSLInitializeStatistics()
       RecRegisterRawStat(ssl_rsb, RECT_PROCESS, statName.c_str(), RECD_INT, RECP_NON_PERSISTENT,
                          (int)ssl_cipher_stats_start + index, RecRawStatSyncSum);
       SSL_CLEAR_DYN_STAT((int)ssl_cipher_stats_start + index);
-      Debug("ssl", "registering SSL cipher metric '%s'", statName.c_str());
     }
   }
 

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1767,7 +1767,7 @@ SSLMultiCertConfigLoader::_load_lines(SSLCertLookup *lookup, SSLConfigLines::con
 }
 
 bool
-SSLMultiCertConfigLoader::load(SSLCertLookup *lookup)
+SSLMultiCertConfigLoader::load(SSLCertLookup *lookup, bool firstLoad)
 {
   Note("%s loading ...", ts::filename::SSL_MULTICERT);
   Debug("ssl", "%s loading ...", ts::filename::SSL_MULTICERT);
@@ -1817,7 +1817,9 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup)
 
   // Process all the lines if we're not running parallelization on multiple threads
   if (params->configLoadConcurrency > 0) {
-    std::size_t bucket_size = std::max(1u, static_cast<unsigned>(single_lines.size() / params->configLoadConcurrency));
+    int num_threads = firstLoad ? std::max(static_cast<int>(std::thread::hardware_concurrency()), params->configLoadConcurrency) :
+                                  params->configLoadConcurrency;
+    std::size_t bucket_size                = std::max(1u, static_cast<unsigned>(single_lines.size() / num_threads));
     SSLConfigLines::const_iterator current = std::as_const(single_lines).begin();
     std::list<std::thread> threads;
     std::size_t num_lines = single_lines.size();

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1109,7 +1109,9 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.ssl.server.multicert.filename", RECD_STRING, ts::filename::SSL_MULTICERT, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.multicert.exit_on_load_fail", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-1]", RECA_NULL}
-,
+  ,
+  {RECT_CONFIG, "proxy.config.ssl.server.multicert.concurrency", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.ssl.servername.filename", RECD_STRING, ts::filename::SNI, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.ticket_key.filename", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}


### PR DESCRIPTION
The new setting is (default: 0):

    CONFIG proxy.config.ssl.server.multicert.concurrency INT 24

A setting of -1 will create one loader thread per system CPU. Still testing performance implications here, but this likely is only a noticeable win with many, many thousands of certificates, or, a very slow "file system".

I intentionally left the line parser as-is, to avoid too much breakage and change. I think we should redo this parser, and use standard STL streams etc. to read the file line by line rather than loading the entire file into memory.