### PR TITLE
Cleanup: Get rid of HTTP2_SESSION_EVENT_INIT

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -177,8 +177,8 @@ Http2ClientSession::start()
   VIO *read_vio = this->do_io_read(this, INT64_MAX, this->read_buffer);
   write_vio     = this->do_io_write(this, INT64_MAX, this->_write_buffer_reader);
 
-  this->connection_state.init();
-  send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_INIT, this);
+  this->connection_state.init(this);
+  this->connection_state.send_connection_preface();
 
   if (this->_read_buffer_reader->is_read_avail_more_than(0)) {
     this->handleEvent(VC_EVENT_READ_READY, read_vio);

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -89,7 +89,8 @@ public:
   Http2ConnectionSettings server_settings;
   Http2ConnectionSettings client_settings;
 
-  void init();
+  void init(Http2ClientSession *ssn);
+  void send_connection_preface();
   void destroy();
 
   // Event handlers


### PR DESCRIPTION
Part of #7852. The definition will be removed by #7845 with other deprecated events.