### PR TITLE
Cleanup: Get rid of HTTP2_SESSION_EVENT_RECV

### DIFF
--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -523,7 +523,8 @@ Http2ClientSession::do_complete_frame_read()
   ink_release_assert(this->_read_buffer_reader->read_avail() >= this->current_hdr.length);
 
   Http2Frame frame(this->current_hdr, this->_read_buffer_reader, this->cur_frame_from_early_data);
-  send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_RECV, &frame);
+  connection_state.rcv_frame(&frame);
+
   // Check whether data is read from early data
   if (this->read_from_early_data > 0) {
     this->read_from_early_data -=

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -34,6 +34,7 @@
 #include "Http2FrequencyCounter.h"
 
 class Http2ClientSession;
+class Http2Frame;
 
 enum class Http2SendDataFrameResult {
   NO_ERROR = 0,
@@ -91,6 +92,7 @@ public:
 
   void init();
   void destroy();
+  void rcv_frame(const Http2Frame *frame);
 
   // Event handlers
   int main_event_handler(int, void *);


### PR DESCRIPTION
Part of #7852. The definition will be removed by #7845 with other deprecated events.