### PR TITLE
Origin session cache mem leak fix

### DIFF
--- a/iocore/net/SSLSessionCache.h
+++ b/iocore/net/SSLSessionCache.h
@@ -187,15 +187,15 @@ class SSLOriginSession
 {
 public:
   std::string key;
-  Ptr<IOBufferData> asn1_data; /* this is the ASN1 representation of the SSL_CTX */
-  size_t len_asn1_data;
-  Ptr<IOBufferData> extra_data;
+  SSL_SESSION *session;
+  ssl_curve_id curve_id;
 
-  SSLOriginSession(const std::string &lookup_key, const Ptr<IOBufferData> &ssl_asn1_data, size_t len_asn1,
-                   Ptr<IOBufferData> &exdata)
-    : key(lookup_key), asn1_data(ssl_asn1_data), len_asn1_data(len_asn1), extra_data(exdata)
+  SSLOriginSession(const std::string &lookup_key, SSL_SESSION *sess, ssl_curve_id curve)
+    : key(lookup_key), session(sess), curve_id(curve)
   {
   }
+
+  ~SSLOriginSession() { SSL_SESSION_free(session); }
 
   LINK(SSLOriginSession, link);
 };
@@ -207,7 +207,7 @@ public:
   ~SSLOriginSessionCache();
 
   void insert_session(const std::string &lookup_key, SSL_SESSION *sess, SSL *ssl);
-  bool get_session(const std::string &lookup_key, SSL_SESSION **sess, ssl_session_cache_exdata **data);
+  bool get_session(const std::string &lookup_key, SSL_SESSION **sess, ssl_curve_id *curve);
 
 private:
   void remove_oldest_session(const std::unique_lock<std::shared_mutex> &lock);

--- a/iocore/net/TLSSessionResumptionSupport.cc
+++ b/iocore/net/TLSSessionResumptionSupport.cc
@@ -175,11 +175,10 @@ TLSSessionResumptionSupport::getSession(SSL *ssl, const unsigned char *id, int l
 SSL_SESSION *
 TLSSessionResumptionSupport::getOriginSession(SSL *ssl, const std::string &lookup_key)
 {
-  SSL_SESSION *session             = nullptr;
-  ssl_session_cache_exdata *exdata = nullptr;
-  if (origin_sess_cache->get_session(lookup_key, &session, &exdata)) {
+  SSL_SESSION *session = nullptr;
+  ssl_curve_id curve   = 0;
+  if (origin_sess_cache->get_session(lookup_key, &session, &curve)) {
     ink_assert(session);
-    ink_assert(exdata);
 
     // Double check the timeout
     if (is_ssl_session_timed_out(session)) {
@@ -188,7 +187,7 @@ TLSSessionResumptionSupport::getOriginSession(SSL *ssl, const std::string &looku
     } else {
       SSL_INCREMENT_DYN_STAT(ssl_origin_session_cache_hit);
       this->_setSSLSessionCacheHit(true);
-      this->_setSSLCurveNID(exdata->curve);
+      this->_setSSLCurveNID(curve);
     }
   } else {
     SSL_INCREMENT_DYN_STAT(ssl_origin_session_cache_miss);


### PR DESCRIPTION
After running #7808 in our production for a while, we noticed there are memory leakage. Turns out ATS isn't following OpenSSL's documentation on how we store sessions externally, namely our `new_session_cb` (https://www.openssl.org/docs/manmaster/man3/SSL_CTX_sess_set_get_cb.html) always returns 0. So using the same method with the origin session cache caused the leak. 

Also, simplified the way we store ex_data, which is just a `curve_id`, not sure why we created struct `ssl_session_cache_exdata` to just store this integer value.

Mentioning #7479 to link all related PRs.