### PR TITLE
Fix crash in open_close_h2 (#7586)

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -384,11 +384,8 @@ HttpSM::state_add_to_list(int event, void * /* data ATS_UNUSED */)
     if (ua_entry->read_vio) {
       // Seems like ua_entry->read_vio->disable(); should work, but that was
       // not sufficient to stop the state machine from processing IO events until the
-      // TXN_START hooks had completed
-      // Preserve the current read cont and mutex
-      NetVConnection *netvc = ((ProxyTransaction *)ua_entry->vc)->get_netvc();
-      ink_assert(netvc != nullptr);
-      ua_entry->read_vio = ua_entry->vc->do_io_read(netvc->read_vio_cont(), 0, nullptr);
+      // TXN_START hooks had completed.  Just set the number of bytes to read to 0
+      ua_entry->read_vio = ua_entry->vc->do_io_read(this, 0, nullptr);
     }
     return EVENT_CONT;
   }

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -194,11 +194,14 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     return;
   }
 
-  if (this->recv_end_stream) {
-    this->read_vio.nbytes = bufindex;
-    this->signal_read_event(VC_EVENT_READ_COMPLETE);
-  } else {
-    this->signal_read_event(VC_EVENT_READ_READY);
+  // Is the _sm ready to process the header?
+  if (this->read_vio.nbytes > 0) {
+    if (this->recv_end_stream) {
+      this->read_vio.nbytes = bufindex;
+      this->signal_read_event(VC_EVENT_READ_COMPLETE);
+    } else {
+      this->signal_read_event(VC_EVENT_READ_READY);
+    }
   }
 }
 


### PR DESCRIPTION
Backport #7586 to the 9.0.x branch.

----
(cherry picked from commit 050b2dfe9a89348b4105183a2b31e7cc59fc389d)

Conflicts:
	proxy/http2/Http2Stream.cc