### PR TITLE
Add thread yeield to avoid busy waiting in LogObject::_checkout_write(). (#7576)

### DIFF
--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <thread>
 
 static bool
 should_roll_on_time(Log::RollingEnabledValues roll)
@@ -462,7 +463,9 @@ LogObject::_checkout_write(size_t *write_offset, size_t bytes_needed)
       break;
 
     case LogBuffer::LB_RETRY:
-      // no more room, but another thread should be taking care of creating a new buffer, so try again
+      // no more room, but another thread should be taking care of creating a new buffer, so yield to let
+      // the other thread finish, then try again
+      std::this_thread::yield();
       break;
 
     case LogBuffer::LB_BUFFER_TOO_SMALL:


### PR DESCRIPTION
(cherry picked from commit f278427b1ecdc5ce9e758de51a7faf83bcc58643)