### PR TITLE
Add hit stats for remap rules

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1470,6 +1470,8 @@ static const RecordElement RecordsConfig[] =
   //# Librecords based stats system (new as of v2.1.3)
   {RECT_CONFIG, "proxy.config.stat_api.max_stats_allowed", RECD_INT, "256", RECU_RESTART_TS, RR_NULL, RECC_INT, "[256-1000]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.stat_remap.max_stats_allowed", RECD_INT, "256", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
 
   //############
   //#


### PR DESCRIPTION
Ordering of remap rules in remap.config in an efficient manner is
very important as it can have a significant impact on performance and
throughput that can be achieved using ATS as a proxy server. For example,
ATS uses a prefix trie to match a forward map rule, but, has to run
through the regex_map rules sequentially. Interleaving regex_map rules
with forward map rules can thus result in unnecessary overhead when
those rules are not overlapping. Further, within regex_map rules, as far
as possible ordering them based on their "hit" rate (decreasing order) can
result in a significant performance improvement. This change adds stats
to track hit rate for each remap rule (based on their line number/rank in the
remap.config file) to allow for such visibility.