### PR TITLE
Update docs languages file to add 9.1.x for en and ja

### DIFF
--- a/doc/static/languages.json
+++ b/doc/static/languages.json
@@ -3,6 +3,7 @@
         "name": "English",
         "versions": [
             "latest",
+            "9.1.x",
             "9.0.x",
             "8.1.x",
             "7.1.x"
@@ -12,6 +13,7 @@
         "name": "日本語",
         "versions": [
             "latest",
+            "9.1.x",
             "9.0.x",
             "8.1.x",
             "7.1.x"


### PR DESCRIPTION
This adds 9.1.x to the languages.json which determines which versions appear in the versions list.

Tested this over on the actual docs host by manually editing the existing file and after a purge and eventual recache the 9.1.x now appears in the list