### PR TITLE
Adds new X-Cache-Info header to the xdebug plugin (#7784)

### DIFF
--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -135,7 +135,13 @@ public:
   int
   get_volume_number()
   {
-    return cache_read_vc ? (cache_read_vc->get_volume_number()) : -1;
+    if (cache_read_vc) {
+      return cache_read_vc->get_volume_number();
+    } else if (cache_write_vc) {
+      return cache_write_vc->get_volume_number();
+    }
+
+    return -1;
   }
 
   inline void

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/none.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/none.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: none
+X-Debug: X-Cache-Info
+

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/one.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/one.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: one
+X-Debug: X-Cache-Info
+

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/out.gold
@@ -1,0 +1,60 @@
+HTTP/1.1 500 Cannot find server.
+Date:``
+Connection: keep-alive
+Server:``
+Cache-Control: no-store
+Content-Type: text/html
+Content-Language: en
+Content-Length: 391
+
+<HTML>
+<HEAD>
+<TITLE>Unknown Host</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>Unknown Host</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial"><B>
+Description: Unable to locate the server requested ---
+the server does not have a DNS entry.  Perhaps there is a misspelling
+in the server name, or the server no longer exists.  Double-check the
+name and try again.
+</B></FONT>
+<HR>
+</BODY>
+======
+HTTP/1.1 200 OK
+Date:``
+Age:``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server:``
+X-Cache-Info: path=``/x_cache_info/ts/storage/cache.db; volume=0
+
+0
+
+======
+HTTP/1.1 200 OK
+Date:``
+Age:``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server:``
+X-Cache-Info: path=``/x_cache_info/ts/storage/cache.db; volume=0
+
+0
+
+======
+HTTP/1.1 200 OK
+Date:``
+Age:``
+Transfer-Encoding: chunked
+Connection: keep-alive
+Server:``
+X-Cache-Info: path=``/x_cache_info/ts/storage/cache.db; volume=0
+
+0
+
+======

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/three.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/three.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: three123
+X-Debug: x-cACHE-iNFO
+

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/two.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/two.in
@@ -1,0 +1,4 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: x-cache-info
+

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/x_cache_info.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/x_cache_info.test.py
@@ -1,0 +1,76 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test xdebug plugin X-Cache-Info header
+'''
+
+server = Test.MakeOriginServer("server")
+started = False
+
+request_header = {
+    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+
+ts = Test.MakeATSProcess("ts")
+
+ts.Disk.records_config.update({
+    'proxy.config.url_remap.remap_required': 0,
+    'proxy.config.diags.debug.enabled': 0,
+    'proxy.config.diags.debug.tags': 'http'
+})
+
+ts.Disk.plugin_config.AddLine('xdebug.so')
+
+ts.Disk.remap_config.AddLine(
+    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
+)
+ts.Disk.remap_config.AddLine(
+    "map http://two http://127.0.0.1:{0}".format(server.Variables.Port)
+)
+ts.Disk.remap_config.AddLine(
+    "regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port)
+)
+
+Test.Setup.Copy(f'{Test.Variables.AtsTestToolsDir}')
+
+files = ["none", "one", "two", "three"]
+
+for file in files:
+    Test.Setup.Copy(f'{Test.TestDirectory}/{file}.in')
+
+
+def sendMsg(msgFile):
+    global started
+    tr = Test.AddTestRun()
+    tr.Processes.Default.Command = f"( python3 tools/tcp_client.py 127.0.0.1 {ts.Variables.port} {msgFile}.in ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  out.log 2>&1"
+    tr.Processes.Default.ReturnCode = 0
+
+    if not started:
+        tr.Processes.Default.StartBefore(Test.Processes.ts)
+        tr.Processes.Default.StartBefore(Test.Processes.server)
+        started = True
+
+
+for file in files:
+    sendMsg(file)
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "echo test gold"
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File("out.log")
+f.Content = "out.gold"


### PR DESCRIPTION
This is a backport of changes made to the xdebug plugin via PR #7784 and it depends on backport PR #7919.

(cherry picked from commit 7433038df97229a056775de24008c2c7ef7b608f)