### PR TITLE
Fix race condition on server session state

### DIFF
--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -228,8 +228,6 @@ Http1ServerSession ::release_transaction()
       // The session was successfully put into the session
       //    manager and it will manage it
       // (Note: should never get HSM_NOT_FOUND here)
-      // Set our state to KA for stat issues
-      state = KA_POOLED;
       ink_assert(r == HSM_DONE);
       // If the session got picked up immediately by another thread the transact_count could be greater
       ink_release_assert(transact_count >= released_transactions);


### PR DESCRIPTION
Fixes issue introduced in PR #7849.  Found while running those changes against our 9.1.x on a production box this afternoon. Two times we triggered the assert in Http1ServerSesssion::release().  The state was set to KA_POOLED.  The state was getting set to KA_POOLED both from the HttpSessionManager and within Http1ServerSession::release_transaction after calling httpSessionManager.release_session().

We are running with global pool. I think the session had been reassigned to another thread (the one that ultimately asserted) when the original thread set the state variable again.  We should not be touching the server session again after releasing it in any case, and the change is unnecessary since it has already been set by the HttpSessionManager.