### PR TITLE
Adjust vc read errors

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -199,12 +199,6 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
     return;
   }
 
-  if (vc->has_error()) {
-    vc->lerrno = vc->error;
-    vc->readSignalAndUpdate(VC_EVENT_ERROR);
-    return;
-  }
-
   // It is possible that the closed flag got set from HttpSessionManager in the
   // global session pool case.  If so, the closed flag should be stable once we get the
   // s->vio.mutex (the global session pool mutex).
@@ -316,6 +310,7 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   } else {
     r = 0;
   }
+  ink_release_assert(!vc->has_error());
 
   // Signal read ready, check if user is not done
   if (r) {

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -310,7 +310,6 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
   } else {
     r = 0;
   }
-  ink_release_assert(!vc->has_error());
 
   // Signal read ready, check if user is not done
   if (r) {
@@ -332,6 +331,7 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
       }
     }
   }
+  ink_release_assert(!vc->has_error());
   // If here are is no more room, or nothing to do, disable the connection
   if (s->vio.ntodo() <= 0 || !s->enabled || !buf.writer()->write_avail()) {
     read_disable(nh, vc);

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -330,8 +330,12 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
         return;
       }
     }
+  } else if (vc->has_error()) {
+    vc->lerrno = vc->error;
+    read_signal_and_update(VC_EVENT_ERROR, vc);
+    return;
   }
-  ink_release_assert(!vc->has_error());
+
   // If here are is no more room, or nothing to do, disable the connection
   if (s->vio.ntodo() <= 0 || !s->enabled || !buf.writer()->write_avail()) {
     read_disable(nh, vc);

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -330,10 +330,6 @@ read_from_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
         return;
       }
     }
-  } else if (vc->has_error()) {
-    vc->lerrno = vc->error;
-    read_signal_and_update(VC_EVENT_ERROR, vc);
-    return;
   }
 
   // If here are is no more room, or nothing to do, disable the connection


### PR DESCRIPTION
Changing how we handle the read error.  I think the h2spec test case is failing with fair frequency because the data delivery (to read) and the epoll error are notified in the same epoll interval.  Normally this wouldn't matter much since the connection has closed in any case, so actually processing the data from the client wouldn't really matter.  But in the failing h2spec test case, we are verifying that ATS was able to process the data frame. 

This PR attempts to perform the read first always (making it like the the code pre #7809).  Assuming the socket had failed with a EPIPE (which is what I was seeing), the reads will succeed until all the data is read from the TCP buffer then the read will.  If for some reason the read did not fail,  this change then sends along the read error event.

This closes #7915