### PR TITLE
AuTest: Enable h2spec generic test cases

### DIFF
--- a/tests/gold_tests/h2/h2spec.test.py
+++ b/tests/gold_tests/h2/h2spec.test.py
@@ -59,7 +59,7 @@ ts.Disk.records_config.update({
 # ----
 
 # In case you need to disable some of the tests, you can specify sections like http2/6.4.
-h2spec_targets = "http2/1 http2/2 http2/3 http2/4 http2/5 http2/6 http2/7 http2/8 hpack"
+h2spec_targets = "generic http2/3 http2/4 http2/5 http2/6 http2/7 http2/8 hpack"
 
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = 'h2spec {0} -t -k --timeout 10 -p {1}'.format(h2spec_targets, ts.Variables.ssl_port)


### PR DESCRIPTION
`h2spec` doesn't have test cases called `http2/1 http2/2`. Basic tests are called "generic".
I made this mistake when I introduced h2spec for AuTest.