### PR TITLE
regex_reval: fix bug where rule type is always reported as the first

### DIFF
--- a/plugins/regex_revalidate/regex_revalidate.c
+++ b/plugins/regex_revalidate/regex_revalidate.c
@@ -341,7 +341,7 @@ list_config(plugin_state_t *pstate, invalidate_t *i)
   if (i) {
     iptr = i;
     while (iptr) {
-      char const *const typestr = strForResult(i->new_result);
+      char const *const typestr = strForResult(iptr->new_result);
       TSDebug(LOG_PREFIX, "%s epoch: %d expiry: %d result: %s", iptr->regex_text, (int)iptr->epoch, (int)iptr->expiry, typestr);
       if (pstate->log) {
         TSTextLogObjectWrite(pstate->log, "%s epoch: %d expiry: %d result: %s", iptr->regex_text, (int)iptr->epoch,


### PR DESCRIPTION
This fixes a bug when the regex_revalidate plugin has logging turned on.  For the new miss/stale feature it tags all entries with the first TYPE in the list.