### PR TITLE
Adds new X-Effective-URL header to the xdebug plugin

### DIFF
--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -380,8 +380,6 @@ InjectRemapHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 static void
 InjectEffectiveURLHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 {
-  TSMLoc dst = TS_NULL_MLOC;
-
   struct {
     char *ptr;
     int len;
@@ -392,14 +390,11 @@ InjectEffectiveURLHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
   strval.ptr = TSHttpTxnEffectiveUrlStringGet(txn, &strval.len);
 
   if (strval.ptr != nullptr && strval.len > 0) {
-    dst = FindOrMakeHdrField(buffer, hdr, "X-Effective-URL", lengthof("X-Effective-URL"));
+    TSMLoc dst = FindOrMakeHdrField(buffer, hdr, "X-Effective-URL", lengthof("X-Effective-URL"));
     if (dst != TS_NULL_MLOC) {
       TSReleaseAssert(TSMimeHdrFieldValueStringInsert(buffer, hdr, dst, -1 /* idx */, strval.ptr, strval.len) == TS_SUCCESS);
+      TSHandleMLocRelease(buffer, hdr, dst);
     }
-  }
-
-  if (dst != TS_NULL_MLOC) {
-    TSHandleMLocRelease(buffer, hdr, dst);
   }
 
   TSfree(strval.ptr);

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/none.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/none.in
@@ -1,0 +1,5 @@
+GET /argh HTTP/1.1
+Host: none
+X-Debug: X-Effective-URL
+Connection: close
+

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/one.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/one.in
@@ -1,0 +1,5 @@
+GET /argh HTTP/1.1
+Host: one
+X-Debug: x-effective-url
+Connection: close
+

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/out.gold
@@ -1,4 +1,4 @@
-HTTP/1.1 502 Cannot find server.
+HTTP/1.1 500 Cannot find server.
 Date: ``
 Connection: close
 Server: ATS/``

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/out.gold
@@ -1,0 +1,61 @@
+HTTP/1.1 502 Cannot find server.
+Date: ``
+Connection: close
+Server: ATS/``
+Cache-Control: no-store
+Content-Type: text/html
+Content-Language: en
+X-Effective-URL: http://none/argh
+Content-Length: 391
+
+<HTML>
+<HEAD>
+<TITLE>Unknown Host</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>Unknown Host</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial"><B>
+Description: Unable to locate the server requested ---
+the server does not have a DNS entry.  Perhaps there is a misspelling
+in the server name, or the server no longer exists.  Double-check the
+name and try again.
+</B></FONT>
+<HR>
+</BODY>
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: close
+Server: ATS/``
+X-Effective-URL: http://127.0.0.1:SERVER_PORT/argh
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: close
+Server: ATS/``
+X-Effective-URL: http://127.0.0.1:SERVER_PORT/two/argh
+
+0
+
+======
+HTTP/1.1 200 OK
+Date: ``
+Age: ``
+Transfer-Encoding: chunked
+Connection: close
+Server: ATS/``
+X-Effective-URL: http://127.0.0.1:SERVER_PORT/argh
+
+0
+
+======

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/three.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/three.in
@@ -1,0 +1,5 @@
+GET /argh HTTP/1.1
+Host: three123
+X-Debug: X-effective-url
+Connection: close
+

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/two.in
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/two.in
@@ -1,0 +1,5 @@
+GET /argh HTTP/1.1
+Host: two
+X-Debug: X-EFFECTIVE-URL
+Connection: close
+

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/x_effective_url.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/x_effective_url.test.py
@@ -1,0 +1,81 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test xdebug plugin X-Effective header
+'''
+
+server = Test.MakeOriginServer("server")
+
+request_header = {
+    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+                   "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+
+request_header_two = {
+    "headers": "GET /two/argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header_two, response_header)
+
+ts = Test.MakeATSProcess("ts")
+
+ts.Disk.records_config.update({
+    'proxy.config.url_remap.remap_required': 0,
+    'proxy.config.diags.debug.enabled': 0,
+})
+
+ts.Disk.plugin_config.AddLine('xdebug.so')
+
+ts.Disk.remap_config.AddLine(
+    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
+)
+ts.Disk.remap_config.AddLine(
+    "map http://two http://127.0.0.1:{0}".format(server.Variables.Port) + "/two"
+)
+ts.Disk.remap_config.AddLine(
+    "regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port)
+)
+
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.StartBefore(Test.Processes.server)
+tr.Processes.Default.Command = "cp {}/tcp_client.py {}/tcp_client.py".format(
+    Test.Variables.AtsTestToolsDir, Test.RunDirectory)
+tr.Processes.Default.ReturnCode = 0
+
+
+def sendMsg(msgFile):
+
+    tr = Test.AddTestRun()
+    tr.Processes.Default.Command = (
+        "( python3 {}/tcp_client.py 127.0.0.1 {} {}/{}.in".format(
+            Test.RunDirectory, ts.Variables.port, Test.TestDirectory, msgFile) +
+        " ; echo '======' ) | sed 's/:{}/:SERVER_PORT/' >>  {}/out.log 2>&1 ".format(
+            server.Variables.Port, Test.RunDirectory)
+    )
+    tr.Processes.Default.ReturnCode = 0
+
+
+sendMsg('none')
+sendMsg('one')
+sendMsg('two')
+sendMsg('three')
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = "echo test out.gold"
+tr.Processes.Default.ReturnCode = 0
+f = tr.Disk.File("out.log")
+f.Content = "out.gold"


### PR DESCRIPTION
By adding "X-Effective-URL" to the request header "X-Debug",
the header "X-Effective-URL" header will be inserted to the
request headers with the effective URL value.

Exposes the TSHttpTxnEffectiveUrlStringGet() result, which is
the URL after the remap.

Note: the inserted header is intentionally X-prefixed for consistency
with the other headers inserted by the xdebug plugin.