### PR TITLE
Add support for Remap rule hit stats

### DIFF
--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -27,6 +27,7 @@
 #include "HttpSessionAccept.h"
 #include "ReverseProxy.h"
 #include "HttpSessionManager.h"
+#include "remap/RemapHitCount.h"
 #ifdef USE_HTTP_DEBUG_LISTS
 #include "Http1ClientSession.h"
 #endif
@@ -374,6 +375,7 @@ start_HttpProxyServer()
 
   // Set up stat page for http connection count
   statPagesManager.register_http("connection_count", register_ShowConnectionCount);
+  statPagesManager.register_http("remap_hits", register_ShowRemapHitCount);
 
   // Alert plugins that connections will be accepted.
   APIHook *hook = lifecycle_hooks->get(TS_LIFECYCLE_PORTS_READY_HOOK);

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -48,6 +48,8 @@ libhttp_remap_a_SOURCES = \
 	NextHopStrategyFactory.cc \
 	RemapConfig.cc \
 	RemapConfig.h \
+        RemapHitCount.cc \
+        RemapHitCount.h \
 	RemapPluginInfo.cc \
 	RemapPluginInfo.h \
 	PluginDso.cc \

--- a/proxy/http/remap/RemapHitCount.cc
+++ b/proxy/http/remap/RemapHitCount.cc
@@ -1,0 +1,47 @@
+/** @file
+
+  Stats to track remap rule matches
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "RemapHitCount.h"
+#include "UrlRewrite.h"
+
+extern UrlRewrite *rewrite_table;
+
+struct ShowRemapCount : public ShowCont {
+  ShowRemapCount(Continuation *c, HTTPHdr *h) : ShowCont(c, h) { SET_HANDLER(&ShowRemapCount::showHandler); }
+  int
+  showHandler(int event, Event *e)
+  {
+    auto table = rewrite_table->acquire();
+    CHECK_SHOW(show(rewrite_table->PrintRemapHits().c_str()));
+    table->release();
+    return completeJson(event, e);
+  }
+};
+
+Action *
+register_ShowRemapHitCount(Continuation *c, HTTPHdr *h)
+{
+  ShowRemapCount *s = new ShowRemapCount(c, h);
+  this_ethread()->schedule_imm(s);
+  return &s->action;
+}

--- a/proxy/http/remap/RemapHitCount.h
+++ b/proxy/http/remap/RemapHitCount.h
@@ -1,0 +1,30 @@
+/** @file
+
+  Show endpoint for remap rule hits
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "HTTP.h"
+#include "I_EventSystem.h"
+#include "Show.h"
+
+Action *register_ShowRemapHitCount(Continuation *, HTTPHdr *);

--- a/proxy/http/remap/UrlMapping.cc
+++ b/proxy/http/remap/UrlMapping.cc
@@ -95,6 +95,13 @@ url_mapping::Print() const
          _plugin_inst_list.size());
 }
 
+std::string
+url_mapping::PrintRemapHitCount() const
+{
+  std::string result = "{\"fromURL\": \"" + remapKey + "\", \"hit_count\": " + std::to_string(_hitCount) + "}";
+  return result;
+}
+
 /**
  *
  **/

--- a/proxy/http/remap/UrlMapping.h
+++ b/proxy/http/remap/UrlMapping.h
@@ -29,6 +29,7 @@
 #include "tscore/ink_config.h"
 #include "AclFiltering.h"
 #include "URL.h"
+#include "RemapHitCount.h"
 #include "RemapPluginInfo.h"
 #include "PluginFactory.h"
 #include "tscore/Regex.h"
@@ -93,6 +94,7 @@ public:
   }
 
   void Print() const;
+  std::string PrintRemapHitCount() const;
 
   int from_path_len = 0;
   URL fromURL;
@@ -112,6 +114,8 @@ public:
   acl_filter_rule *filter            = nullptr; // acl filtering (list of rules)
   LINK(url_mapping, link);                      // For use with the main Queue linked list holding all the mapping
   std::shared_ptr<NextHopSelectionStrategy> strategy = nullptr;
+  std::string remapKey;
+  std::atomic<uint64_t> _hitCount = 0; // counter can overflow
 
   int
   getRank() const
@@ -123,6 +127,24 @@ public:
   {
     _rank = rank;
   };
+
+  void
+  setRemapKey()
+  {
+    remapKey = fromURL.string_get_ref();
+  }
+
+  const std::string &
+  getRemapKey()
+  {
+    return remapKey;
+  }
+
+  void
+  incrementCount()
+  {
+    _hitCount++;
+  }
 
 private:
   std::vector<RemapPluginInst *> _plugin_inst_list;

--- a/proxy/http/remap/UrlMappingPathIndex.cc
+++ b/proxy/http/remap/UrlMappingPathIndex.cc
@@ -91,3 +91,16 @@ UrlMappingPathIndex::Print() const
     m_trie.second->Print();
   }
 }
+
+std::string
+UrlMappingPathIndex::PrintUrlMappingPathIndex() const
+{
+  std::string result;
+  for (auto &m_trie : m_tries) {
+    for (auto const &node : *m_trie.second) {
+      result += node.PrintRemapHitCount();
+      result += ",\n";
+    }
+  }
+  return result;
+}

--- a/proxy/http/remap/UrlMappingPathIndex.h
+++ b/proxy/http/remap/UrlMappingPathIndex.h
@@ -38,6 +38,7 @@ public:
   bool Insert(url_mapping *mapping);
   url_mapping *Search(URL *request_url, int request_port, bool normal_search = true) const;
   void Print() const;
+  std::string PrintUrlMappingPathIndex() const;
 
 private:
   typedef Trie<url_mapping> UrlMappingTrie;

--- a/proxy/http/remap/UrlRewrite.h
+++ b/proxy/http/remap/UrlRewrite.h
@@ -146,6 +146,8 @@ public:
 
   void PerformACLFiltering(HttpTransact::State *s, url_mapping *mapping);
   void PrintStore(const MappingsStore &store) const;
+  std::string PrintRemapHits();
+  std::string PrintRemapHitsStore(MappingsStore &store);
 
   void
   DestroyStore(MappingsStore &store)


### PR DESCRIPTION
This change adds stats to track hit rate for each remap rule (based
on the map fromURL in the remap.config file) to allow for such
visibility via a new http endpoint {remap_stats} which returns the
stats in a json format

More Context:
Ordering of remap rules in remap.config in an efficient manner is
very important as it can have a significant impact on performance and
throughput that can be achieved using ATS as a proxy server. For example,
ATS uses a prefix trie to match a forward map rule, but, has to run
through the regex_map rules sequentially. Interleaving regex_map rules
with forward map rules can thus result in unnecessary overhead when
those rules are not overlapping. Further, within regex_map rules, as far
as possible ordering them based on their "hit" rate (decreasing order) can
result in a significant performance improvement.


Note: PR #7909 tries to address the same requirement with the traditional TS metrics (that can be queried using standard traffic_ctl management API) instead of adding a separate HTTP endpoint based support, but, it has a few limitations:

Need to setup the stats during TS startup ahead of time and can't set them up on-the-fly during remap reloads
Uses the rank/line number of the remap rule as s the key, as the actual rules and map fromURL are not available yet at the time of setting up the stats. This makes it harder to read them and requires another level of mapping to the actual remap line. The rank/line number can change during reloads and this makes the stats unreliable.
sample output:

Remap Rule to setup the stats:

map                                     /_remap_hits/  http://{remap_hits} @action=allow @src_ip=127.0.0.1 @src_ip=::1
Output:

{
  "list": [
    {
      "fromURL": "http:///_remap_hits/",
      "hit_count": "1"
    },
    {
      "fromURL": "http:///admin",
      "hit_count": "101"
    },
    {
      "fromURL": "http://^.*$/admin",
      "hit_count": "42"
    },
    {
      "fromURL": "http://dns-query/dns-query",
      "hit_count": "3"
    },
    {
      "fromURL": "http:///_stat/",
      "hit_count": "1"
    },
    {
      "fromURL": "http:///_connection_count/",
      "hit_count": "1"
    }
  ]
}

