### PR TITLE
Pin Sphinx to 3.x to unblock `make html`

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -22,7 +22,16 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-sphinx = "*"
+
+# The latest 4.x sphinx release, currently 4.0.2, fails `make html`.  For
+# details, see: https://github.com/apache/trafficserver/issues/7938
+#
+# The 3.x releases build fine, however. So we currently pin to that.
+#
+# Once that issue, either with sphinx or our docs, is resolved, then we should
+# unpin sphinx by setting the following to "*".
+sphinx = "==3.*"
+
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 # i18n


### PR DESCRIPTION
The latest version of Sphinx, 4.0.2, fails to build our docs via the
`make html` target. The latest 3.x release, currently 3.5.4, builds our
docs fine. Pinning to 3.x.

---

Fixes #7938 