### PR TITLE
Use proxy.config.log.hostname for rotated log filenames

### DIFF
--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -23,6 +23,7 @@
 
 #include "tscore/ink_platform.h"
 #include "tscore/I_Layout.h"
+#include "I_Machine.h"
 
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
@@ -68,13 +69,7 @@
 void
 LogConfig::setup_default_values()
 {
-  const unsigned int bufSize = 512;
-  char name[bufSize];
-  if (gethostname(name, bufSize) == -1) {
-    ink_strlcpy(name, "unknown_host_name", sizeof(name));
-  }
-  hostname = ats_strdup(name);
-
+  hostname              = ats_strdup(Machine::instance()->hostname);
   log_buffer_size       = static_cast<int>(10 * LOG_KILOBYTE);
   max_secs_per_buffer   = 5;
   max_space_mb_for_logs = 100;

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -70,7 +70,7 @@ LogConfig::setup_default_values()
 {
   const unsigned int bufSize = 512;
   char name[bufSize];
-  if (!gethostname(name, bufSize)) {
+  if (gethostname(name, bufSize) == -1) {
     ink_strlcpy(name, "unknown_host_name", sizeof(name));
   }
   hostname = ats_strdup(name);
@@ -160,7 +160,7 @@ LogConfig::read_configuration_variables()
   ats_free(ptr);
 
   ptr = REC_ConfigReadString("proxy.config.log.hostname");
-  if (ptr != nullptr) {
+  if (ptr != nullptr && std::string_view(ptr) != "localhost") {
     ats_free(hostname);
     hostname = ptr;
   }

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -73,7 +73,9 @@ LogFile::LogFile(const char *name, const char *header, LogFileFormat format, uin
 {
   if (m_file_format != LOG_FILE_PIPE) {
     m_log = new BaseLogFile(name, m_signature);
-    m_log->set_hostname(Machine::instance()->hostname);
+    // Use Log::config->hostname rather than Machine::instance()->hostname
+    // because the former is reloadable.
+    m_log->set_hostname(Log::config->hostname);
   } else {
     m_log = nullptr;
   }

--- a/proxy/shared/UglyLogStubs.cc
+++ b/proxy/shared/UglyLogStubs.cc
@@ -66,13 +66,31 @@ ConfigUpdateCbTable::invoke(const char * /* name ATS_UNUSED */)
 }
 
 struct Machine {
+  Machine();
+  ~Machine();
   static Machine *instance();
+  char *hostname = nullptr;
+
+private:
+  static Machine _instance;
 };
+
+Machine Machine::_instance;
+
+Machine::Machine()
+{
+  hostname = ats_strdup("test.host.com");
+}
+
+Machine::~Machine()
+{
+  ats_free(hostname);
+}
+
 Machine *
 Machine::instance()
 {
-  ink_release_assert(false);
-  return nullptr;
+  return &_instance;
 }
 
 NetAccept *

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1943,7 +1943,13 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   } else if (HttpConfig::m_master.inbound_ip6.isValid()) {
     machine_addr.assign(HttpConfig::m_master.inbound_ip6);
   }
-  Machine::init(nullptr, &machine_addr.sa);
+  char *hostname = REC_ConfigReadString("proxy.config.log.hostname");
+  if (hostname != nullptr && std::string_view(hostname) == "localhost") {
+    // The default value was used. Let Machine::init derive the hostname.
+    hostname = nullptr;
+  }
+  Machine::init(hostname, &machine_addr.sa);
+  ats_free(hostname);
 
   RecRegisterStatString(RECT_PROCESS, "proxy.process.version.server.uuid", (char *)Machine::instance()->uuid.getString(),
                         RECP_NON_PERSISTENT);


### PR DESCRIPTION
When ATS rotates logs it includes the hostname in the rotated log
filename.  The user has the ability to set the hostname via
'proxy.config.log.hostname', however ATS did not respected this
configuration parameter when naming the rotated log file.  Rather, ATS
always used the result of gethostname().  This fixes the log rotation
mechanism so that if the user sets 'proxy.config.log.hostname' to a
non-default value, then ATS will use that when naming the rotated log
filename.

---

This fixes #7922.

