### PR TITLE
Compilation error fixes for QUIC unit tests

### DIFF
--- a/iocore/net/quic/Mock.h
+++ b/iocore/net/quic/Mock.h
@@ -194,13 +194,6 @@ class MockQUICConnectionInfoProvider : public QUICConnectionInfoProvider
     return NET_VCONNECTION_OUT;
   }
 
-  int
-  select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
-                       unsigned inlen) const override
-  {
-    return SSL_TLSEXT_ERR_OK;
-  }
-
   bool
   is_closed() const override
   {
@@ -510,13 +503,6 @@ public:
   negotiated_application_name() const override
   {
     return negotiated_application_name_sv;
-  }
-
-  int
-  select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
-                       unsigned inlen) const override
-  {
-    return SSL_TLSEXT_ERR_OK;
   }
 
   int _transmit_count   = 0;

--- a/iocore/net/quic/test/test_QUICPacket.cc
+++ b/iocore/net/quic/test/test_QUICPacket.cc
@@ -249,7 +249,8 @@ TEST_CASE("Sending Packet", "[quic]")
     CHECK(packet.is_crypto_packet());
 
     packet.store(buf, &len);
-    CHECK(len == packet.size() - 16);
+    // See above packet.size() CHECK: packet.size must be greater than 16.
+    CHECK(len == static_cast<size_t>(packet.size() - 16));
     CHECK(memcmp(buf, expected, len - 16) == 0);
   }
 

--- a/proxy/http3/test/test_QPACK.cc
+++ b/proxy/http3/test/test_QPACK.cc
@@ -221,17 +221,16 @@ output_decoded_headers(FILE *fd, HTTPHdr **headers, uint64_t n)
     }
     fprintf(fd, "# stream %" PRIu64 "\n", i + 1);
     MIMEFieldIter field_iter;
-    for (MIMEField *field = header_set->iter_get_first(&field_iter); field != nullptr;
-         field            = header_set->iter_get_next(&field_iter)) {
-      int name_len;
-      int value_len;
+    for (auto const &field : *header_set) {
+      int name_len  = 0;
+      int value_len = 0;
       Arena arena;
-      const char *name   = field->name_get(&name_len);
+      const char *name   = field.name_get(&name_len);
       char *lowered_name = arena.str_store(name, name_len);
       for (int i = 0; i < name_len; i++) {
         lowered_name[i] = ParseRules::ink_tolower(lowered_name[i]);
       }
-      const char *value = field->value_get(&value_len);
+      const char *value = field.value_get(&value_len);
       fprintf(fd, "%.*s\t%.*s\n", name_len, lowered_name, value_len, value);
     }
     fprintf(fd, "\n");


### PR DESCRIPTION
When configured with a QUIC version of OpenSSL, `make check` runs the
QUIC unit tests. These have fallen under disrepair, with recent changes
causing the build of them to fail. This addresses those compilation
issues. All the `check` make target tests build and pass with this
change.

select_next_protocol got moved from QUICConnection in commit:
cb247c6af699cb08286f04bd2ef481031b5babc7

HTTPHdr received an iterate change in:
98176750ecb42ab5ec97a49570c5aff1175a014a