### PR TITLE
Fix dynamic-stack-buffer-overflow of cachekey plugin

### DIFF
--- a/plugins/cachekey/cachekey.cc
+++ b/plugins/cachekey/cachekey.cc
@@ -41,7 +41,7 @@ appendEncoded(String &target, const char *s, size_t len)
     return;
   }
 
-  char tmp[len * 2];
+  char tmp[len * 3 + 1];
   size_t written;
 
   /* The default table does not encode the comma, so we need to use our own table here. */

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -360,7 +360,7 @@ escapify_url_common(Arena *arena, char *url, size_t len_in, int *len_out, char *
   //
   size_t out_len = len_in + 2 * count;
 
-  if (dst && out_len > dst_size) {
+  if (dst && (out_len + 1) > dst_size) {
     *len_out = 0;
     return nullptr;
   }


### PR DESCRIPTION
We got an ASan report on 8.1.2. It looks like the temporal buffer on the stack is not enough to escape the URL.
```
 ==37529==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow on address 0x7f7c922ec824 at pc 0x55fc2573e23a bp 0x7f7c922ec570 sp 0x7f7c922ec568
 WRITE of size 1 at 0x7f7c922ec824 thread T3 ([ET_NET 1])
    #0 0x55fc2573e239 in _ZN12_GLOBAL__N_119escapify_url_commonEP5ArenaPcmPiS2_mPKhb proxy/logging/LogUtils.cc:393:7
    #1 0x55fc2573e34d in _ZN8LogUtils17pure_escapify_urlEP5ArenaPcmPiS2_mPKh proxy/logging/LogUtils.cc:410:10
    #2 0x55fc2544eb34 in TSStringPercentEncode src/traffic_server/InkAPI.cc:2372:18
    #3 0x7f7c4ece0529 in _ZL13appendEncodedRNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEPKcm plugins/cachekey/cachekey.cc:70:7
    #4 0x7f7c4ece33a7 in _ZN8CacheKey6appendERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE plugins/cachekey/cachekey.cc:334:3
    #5 0x7f7c4ece33a7 in _ZN8CacheKey10appendPathER7PatternS1_ plugins/cachekey/cachekey.cc:481:5
    ...
```