### PR TITLE
Improve parsing error messages for strategies.yaml.

### DIFF
--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -34,6 +34,7 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy \
 	-I$(abs_top_srcdir)/proxy/http \
 	-I$(abs_top_srcdir)/proxy/hdrs \
+	-I$(abs_top_srcdir)/lib/yamlcpp/include \
 	$(TS_INCLUDES)
 
 libmgmt_c_la_SOURCES = \
@@ -51,7 +52,9 @@ libmgmt_p_la_SOURCES = \
 	ProcessManager.cc \
 	ProcessManager.h \
 	ProxyConfig.cc \
-	ProxyConfig.h
+	ProxyConfig.h \
+	YamlCfg.cc \
+	YamlCfg.h
 
 libmgmt_lm_la_SOURCES = \
 	$(libmgmt_COMMON) \

--- a/mgmt/YamlCfg.cc
+++ b/mgmt/YamlCfg.cc
@@ -1,0 +1,83 @@
+/** @file
+
+  Implementation file for YamlCfg.h.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "YamlCfg.h"
+
+#include <algorithm>
+#include <string>
+
+#include <tscore/ink_assert.h>
+
+namespace ts
+{
+namespace Yaml
+{
+  Map::Map(YAML::Node map) : _map{map}
+  {
+    if (!_map.IsMap()) {
+      throw YAML::ParserException(_map.Mark(), "map expected");
+    }
+  }
+
+  YAML::Node
+  Map::operator[](std::string_view key)
+  {
+    auto n = _map[std::string(key)];
+
+    if (n) {
+      // Add key to _used_key if not in it already.
+      //
+      if (std::find(_used_key.begin(), _used_key.end(), key) == _used_key.end()) {
+        _used_key.push_back(key);
+      }
+    }
+
+    return n;
+  }
+
+  void
+  Map::done()
+  {
+    if (!_bad && (_used_key.size() != _map.size())) {
+      ink_assert(_used_key.size() < _map.size());
+
+      std::string msg{(_map.size() - _used_key.size()) > 1 ? "keys " : "key "};
+      bool first{true};
+
+      for (auto const &kv : _map) {
+        auto key = kv.first.as<std::string>();
+
+        if (std::find(_used_key.begin(), _used_key.end(), key) == _used_key.end()) {
+          if (!first) {
+            msg += ", ";
+          }
+          first = false;
+          msg += key;
+        }
+      }
+      throw YAML::ParserException(_map.Mark(), msg + " invalid in this map");
+    }
+  }
+
+} // end namespace Yaml
+} // end namespace ts

--- a/mgmt/YamlCfg.h
+++ b/mgmt/YamlCfg.h
@@ -43,7 +43,7 @@ namespace Yaml
     explicit Map(YAML::Node map);
 
     // Get the node for a key.  Throw a YAML::Exception if 'key' is not in the map.  The node for each key in the
-    // map must be gotten at least once.  The lifetime of he char array referenced by passed key must be as long
+    // map must be gotten at least once.  The lifetime of the char array referenced by passed key must be as long
     // as this instance.
     //
     YAML::Node operator[](std::string_view key);

--- a/mgmt/YamlCfg.h
+++ b/mgmt/YamlCfg.h
@@ -1,0 +1,77 @@
+/** @file
+
+  Utilites to help with parsing YAML files with good error reporting.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+#include <string_view>
+
+#include <yaml-cpp/yaml.h>
+
+namespace ts
+{
+namespace Yaml
+{
+  // A class that is a wrapper for a YAML::Node that corresponds to a map in a YAML input file.
+  // It's purpose is to make sure all keys in the map are processed.
+  //
+  class Map
+  {
+  public:
+    // A YAML::ParserException will be thrown if 'map' isn't actually a map.
+    //
+    explicit Map(YAML::Node map);
+
+    // Get the node for a key.  Throw a YAML::Exception if 'key' is not in the map.  The node for each key in the
+    // map must be gotten at least once.  The lifetime of he char array referenced by passed key must be as long
+    // as this instance.
+    //
+    YAML::Node operator[](std::string_view key);
+
+    // Call this after the last call to the [] operator.  Will throw a YAML::ParserException if instance not
+    // already marked bad, and all keys in the map were not accessed at least once with the [] operator.  The
+    // 'what' of the exception will list the keys that were not accessed as invalid for the map.
+    //
+    void done();
+
+    // Mark instance as bad.
+    //
+    void
+    bad()
+    {
+      _bad = true;
+    }
+
+    // No copy/move.
+    //
+    Map(Map const &) = delete;
+    Map &operator=(Map const &) = delete;
+
+  private:
+    YAML::Node _map;
+    std::vector<std::string_view> _used_key;
+    bool _bad{false};
+  };
+
+} // end namespace Yaml
+} // end namespace ts

--- a/proxy/http/remap/NextHopConsistentHash.cc
+++ b/proxy/http/remap/NextHopConsistentHash.cc
@@ -26,6 +26,7 @@
 #include "tscore/HashSip.h"
 #include "HttpSM.h"
 #include "I_Machine.h"
+#include "YamlCfg.h"
 #include "NextHopConsistentHash.h"
 
 // hash_key strings.
@@ -63,7 +64,7 @@ NextHopConsistentHash::~NextHopConsistentHash()
 }
 
 bool
-NextHopConsistentHash::Init(const YAML::Node &n)
+NextHopConsistentHash::Init(ts::Yaml::Map &n)
 {
   ATSHash64Sip24 hash;
 

--- a/proxy/http/remap/NextHopConsistentHash.h
+++ b/proxy/http/remap/NextHopConsistentHash.h
@@ -48,6 +48,6 @@ public:
   NextHopConsistentHash() = delete;
   NextHopConsistentHash(const std::string_view name, const NHPolicyType &policy) : NextHopSelectionStrategy(name, policy) {}
   ~NextHopConsistentHash();
-  bool Init(const YAML::Node &n);
+  bool Init(ts::Yaml::Map &n);
   void findNextHop(TSHttpTxn txnp, void *ih = nullptr, time_t now = 0) override;
 };

--- a/proxy/http/remap/NextHopRoundRobin.h
+++ b/proxy/http/remap/NextHopRoundRobin.h
@@ -36,7 +36,7 @@ public:
   NextHopRoundRobin(const std::string_view &name, const NHPolicyType &policy) : NextHopSelectionStrategy(name, policy) {}
   ~NextHopRoundRobin();
   bool
-  Init(const YAML::Node &n)
+  Init(ts::Yaml::Map &n)
   {
     return NextHopSelectionStrategy::Init(n);
   }

--- a/proxy/http/remap/NextHopSelectionStrategy.h
+++ b/proxy/http/remap/NextHopSelectionStrategy.h
@@ -39,10 +39,13 @@
 
 constexpr const char *NH_DEBUG_TAG = "next_hop";
 
-namespace YAML
+namespace ts
 {
-class Node;
+namespace Yaml
+{
+  class Map;
 }
+} // namespace ts
 
 enum NHCmd { NH_MARK_UP, NH_MARK_DOWN };
 
@@ -235,7 +238,7 @@ public:
   NextHopSelectionStrategy();
   NextHopSelectionStrategy(const std::string_view &name, const NHPolicyType &type);
   virtual ~NextHopSelectionStrategy(){};
-  bool Init(const YAML::Node &n);
+  bool Init(ts::Yaml::Map &n);
   virtual void findNextHop(TSHttpTxn txnp, void *ih = nullptr, time_t now = 0) = 0;
   void markNextHop(TSHttpTxn txnp, const char *hostname, const int port, const NHCmd status, void *ih = nullptr,
                    const time_t now = 0);

--- a/proxy/http/remap/NextHopStrategyFactory.h
+++ b/proxy/http/remap/NextHopStrategyFactory.h
@@ -31,10 +31,13 @@
 #include "tscore/Diags.h"
 #include "NextHopSelectionStrategy.h"
 
-namespace YAML
+namespace ts
 {
-class Node;
-};
+namespace Yaml
+{
+  class Map;
+}
+} // namespace ts
 
 class NextHopStrategyFactory
 {
@@ -49,6 +52,6 @@ public:
 private:
   std::string fn;
   void loadConfigFile(const std::string &file, std::stringstream &doc, std::unordered_set<std::string> &include_once);
-  void createStrategy(const std::string &name, const NHPolicyType policy_type, const YAML::Node &node);
+  void createStrategy(const std::string &name, const NHPolicyType policy_type, ts::Yaml::Map &node);
   std::unordered_map<std::string, std::shared_ptr<NextHopSelectionStrategy>> _strategies;
 };

--- a/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
@@ -73,7 +73,7 @@ ts.Disk.records_config.update({
     'proxy.config.http.cache.http': 0,
     'proxy.config.http.uncacheable_requests_bypass_parent': 0,
     'proxy.config.http.no_dns_just_forward_to_parent': 1,
-    'proxy.config.http.parent_proxy.mark_down_hostdb': 1,
+    'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
     'proxy.config.http.parent_proxy.self_detect': 0,
 })
 


### PR DESCRIPTION
This PR primarily flags errors where an unrecognized key (perhaps due to a misspelling) appears in a YAML.

Error reporting could be further improved by including line numbers with errors whenever possible.
Unfortunately, the yamlcpp library seems to have a bug where it doesn't count comment lines when giving
a line number.