### PR TITLE
Cleanup: Constify MIMEHdr

### DIFF
--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -115,7 +115,7 @@ struct MIMEField {
   }
 
   bool
-  is_cooked()
+  is_cooked() const
   {
     return (m_flags & MIME_FIELD_SLOT_FLAGS_COOKED) ? true : false;
   }
@@ -1033,10 +1033,10 @@ public:
   void create(HdrHeap *heap = nullptr);
   void copy(const MIMEHdr *hdr);
 
-  int length_get();
+  int length_get() const;
 
   void fields_clear();
-  int fields_count();
+  int fields_count() const;
 
   MIMEField *field_create(const char *name = nullptr, int length = -1);
   MIMEField *field_find(const char *name, int length);
@@ -1046,8 +1046,8 @@ public:
   void field_delete(MIMEField *field, bool delete_all_dups = true);
   void field_delete(const char *name, int name_length);
 
-  iterator begin();
-  iterator end();
+  iterator begin() const;
+  iterator end() const;
 
   /*
   MIMEField *iter_get_first(MIMEFieldIter *iter);
@@ -1055,7 +1055,7 @@ public:
   MIMEField *iter_get_next(MIMEFieldIter *iter);
    */
 
-  uint64_t presence(uint64_t mask);
+  uint64_t presence(uint64_t mask) const;
 
   int print(char *buf, int bufsize, int *bufindex, int *chars_to_skip);
 
@@ -1092,23 +1092,23 @@ public:
                           const char separator = ',');
   void value_append_or_set(const char *name, const int name_length, char *value, int value_length);
   void field_combine_dups(MIMEField *field, bool prepend_comma = false, const char separator = ',');
-  time_t get_age();
+  time_t get_age() const;
   int64_t get_content_length() const;
-  time_t get_date();
-  time_t get_expires();
-  time_t get_if_modified_since();
-  time_t get_if_unmodified_since();
-  time_t get_last_modified();
-  time_t get_if_range_date();
-  int32_t get_max_forwards();
+  time_t get_date() const;
+  time_t get_expires() const;
+  time_t get_if_modified_since() const;
+  time_t get_if_unmodified_since() const;
+  time_t get_last_modified() const;
+  time_t get_if_range_date() const;
+  int32_t get_max_forwards() const;
   int32_t get_warning(int idx = 0);
 
-  uint32_t get_cooked_cc_mask();
-  int32_t get_cooked_cc_max_age();
-  int32_t get_cooked_cc_s_maxage();
-  int32_t get_cooked_cc_max_stale();
-  int32_t get_cooked_cc_min_fresh();
-  bool get_cooked_pragma_no_cache();
+  uint32_t get_cooked_cc_mask() const;
+  int32_t get_cooked_cc_max_age() const;
+  int32_t get_cooked_cc_s_maxage() const;
+  int32_t get_cooked_cc_max_stale() const;
+  int32_t get_cooked_cc_min_fresh() const;
+  bool get_cooked_pragma_no_cache() const;
 
   /** Get the value of the host field.
       This parses the host field for brackets and port value.
@@ -1187,7 +1187,7 @@ MIMEHdr::copy(const MIMEHdr *src_hdr)
   -------------------------------------------------------------------------*/
 
 inline int
-MIMEHdr::length_get()
+MIMEHdr::length_get() const
 {
   return mime_hdr_length_get(m_mime);
 }
@@ -1205,7 +1205,7 @@ MIMEHdr::fields_clear()
   -------------------------------------------------------------------------*/
 
 inline int
-MIMEHdr::fields_count()
+MIMEHdr::fields_count() const
 {
   return mime_hdr_fields_count(m_mime);
 }
@@ -1230,7 +1230,7 @@ MIMEHdr::field_create(const char *name, int length)
   -------------------------------------------------------------------------*/
 
 inline MIMEField *
-MIMEHdr::field_find(const char *name, int length)
+MIMEHdr::field_find(const char *name, int length) // NOLINT(readability-make-member-function-const)
 {
   //    ink_assert(valid());
   return mime_hdr_field_find(m_mime, name, length);
@@ -1248,7 +1248,7 @@ MIMEHdr::field_find(const char *name, int length) const
   -------------------------------------------------------------------------*/
 
 inline void
-MIMEHdr::field_attach(MIMEField *field)
+MIMEHdr::field_attach(MIMEField *field) // NOLINT(readability-make-member-function-const)
 {
   mime_hdr_field_attach(m_mime, field, 1, nullptr);
 }
@@ -1257,7 +1257,7 @@ MIMEHdr::field_attach(MIMEField *field)
   -------------------------------------------------------------------------*/
 
 inline void
-MIMEHdr::field_detach(MIMEField *field, bool detach_all_dups)
+MIMEHdr::field_detach(MIMEField *field, bool detach_all_dups) // NOLINT(readability-make-member-function-const)
 {
   mime_hdr_field_detach(m_mime, field, detach_all_dups);
 }
@@ -1272,7 +1272,7 @@ MIMEHdr::field_delete(MIMEField *field, bool delete_all_dups)
 }
 
 inline auto
-MIMEHdr::begin() -> iterator
+MIMEHdr::begin() const -> iterator
 {
   iterator spot;
   spot._block = &m_mime->m_first_fblock;
@@ -1281,7 +1281,7 @@ MIMEHdr::begin() -> iterator
 }
 
 inline auto
-MIMEHdr::end() -> iterator
+MIMEHdr::end() const -> iterator
 {
   return {}; // default constructed iterator.
 }
@@ -1357,7 +1357,7 @@ MIMEHdr::field_delete(const char *name, int name_length)
   -------------------------------------------------------------------------*/
 
 inline uint64_t
-MIMEHdr::presence(uint64_t mask)
+MIMEHdr::presence(uint64_t mask) const
 {
   return (m_mime->m_presence_bits & mask);
 }
@@ -1635,7 +1635,7 @@ MIMEHdr::value_append(const char *name, int name_length, const char *value, int 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 inline time_t
-MIMEHdr::get_age()
+MIMEHdr::get_age() const
 {
   int64_t age = value_get_int64(MIME_FIELD_AGE, MIME_LEN_AGE);
 
@@ -1661,7 +1661,7 @@ MIMEHdr::get_content_length() const
   -------------------------------------------------------------------------*/
 
 inline time_t
-MIMEHdr::get_date()
+MIMEHdr::get_date() const
 {
   return value_get_date(MIME_FIELD_DATE, MIME_LEN_DATE);
 }
@@ -1670,7 +1670,7 @@ MIMEHdr::get_date()
   -------------------------------------------------------------------------*/
 
 inline time_t
-MIMEHdr::get_expires()
+MIMEHdr::get_expires() const
 {
   return value_get_date(MIME_FIELD_EXPIRES, MIME_LEN_EXPIRES);
 }
@@ -1679,7 +1679,7 @@ MIMEHdr::get_expires()
   -------------------------------------------------------------------------*/
 
 inline time_t
-MIMEHdr::get_if_modified_since()
+MIMEHdr::get_if_modified_since() const
 {
   return value_get_date(MIME_FIELD_IF_MODIFIED_SINCE, MIME_LEN_IF_MODIFIED_SINCE);
 }
@@ -1688,7 +1688,7 @@ MIMEHdr::get_if_modified_since()
   -------------------------------------------------------------------------*/
 
 inline time_t
-MIMEHdr::get_if_unmodified_since()
+MIMEHdr::get_if_unmodified_since() const
 {
   return value_get_date(MIME_FIELD_IF_UNMODIFIED_SINCE, MIME_LEN_IF_UNMODIFIED_SINCE);
 }
@@ -1697,7 +1697,7 @@ MIMEHdr::get_if_unmodified_since()
   -------------------------------------------------------------------------*/
 
 inline time_t
-MIMEHdr::get_last_modified()
+MIMEHdr::get_last_modified() const
 {
   return value_get_date(MIME_FIELD_LAST_MODIFIED, MIME_LEN_LAST_MODIFIED);
 }
@@ -1706,7 +1706,7 @@ MIMEHdr::get_last_modified()
   -------------------------------------------------------------------------*/
 
 inline time_t
-MIMEHdr::get_if_range_date()
+MIMEHdr::get_if_range_date() const
 {
   return value_get_date(MIME_FIELD_IF_RANGE, MIME_LEN_IF_RANGE);
 }
@@ -1715,7 +1715,7 @@ MIMEHdr::get_if_range_date()
   -------------------------------------------------------------------------*/
 
 inline int32_t
-MIMEHdr::get_max_forwards()
+MIMEHdr::get_max_forwards() const
 {
   return value_get_int(MIME_FIELD_MAX_FORWARDS, MIME_LEN_MAX_FORWARDS);
 }
@@ -1736,7 +1736,7 @@ MIMEHdr::get_warning(int idx)
   -------------------------------------------------------------------------*/
 
 inline uint32_t
-MIMEHdr::get_cooked_cc_mask()
+MIMEHdr::get_cooked_cc_mask() const
 {
   return m_mime->m_cooked_stuff.m_cache_control.m_mask;
 }
@@ -1745,7 +1745,7 @@ MIMEHdr::get_cooked_cc_mask()
   -------------------------------------------------------------------------*/
 
 inline int32_t
-MIMEHdr::get_cooked_cc_max_age()
+MIMEHdr::get_cooked_cc_max_age() const
 {
   return m_mime->m_cooked_stuff.m_cache_control.m_secs_max_age;
 }
@@ -1754,7 +1754,7 @@ MIMEHdr::get_cooked_cc_max_age()
   -------------------------------------------------------------------------*/
 
 inline int32_t
-MIMEHdr::get_cooked_cc_s_maxage()
+MIMEHdr::get_cooked_cc_s_maxage() const
 {
   return m_mime->m_cooked_stuff.m_cache_control.m_secs_s_maxage;
 }
@@ -1763,7 +1763,7 @@ MIMEHdr::get_cooked_cc_s_maxage()
   -------------------------------------------------------------------------*/
 
 inline int32_t
-MIMEHdr::get_cooked_cc_max_stale()
+MIMEHdr::get_cooked_cc_max_stale() const
 {
   return m_mime->m_cooked_stuff.m_cache_control.m_secs_max_stale;
 }
@@ -1772,7 +1772,7 @@ MIMEHdr::get_cooked_cc_max_stale()
   -------------------------------------------------------------------------*/
 
 inline int32_t
-MIMEHdr::get_cooked_cc_min_fresh()
+MIMEHdr::get_cooked_cc_min_fresh() const
 {
   return m_mime->m_cooked_stuff.m_cache_control.m_secs_min_fresh;
 }
@@ -1781,7 +1781,7 @@ MIMEHdr::get_cooked_cc_min_fresh()
   -------------------------------------------------------------------------*/
 
 inline bool
-MIMEHdr::get_cooked_pragma_no_cache()
+MIMEHdr::get_cooked_pragma_no_cache() const
 {
   return m_mime->m_cooked_stuff.m_pragma.m_no_cache;
 }
@@ -1790,7 +1790,7 @@ MIMEHdr::get_cooked_pragma_no_cache()
   -------------------------------------------------------------------------*/
 
 inline void
-MIMEHdr::set_cooked_cc_need_revalidate_once()
+MIMEHdr::set_cooked_cc_need_revalidate_once() // NOLINT(readability-make-member-function-const)
 {
   m_mime->m_cooked_stuff.m_cache_control.m_mask |= MIME_COOKED_MASK_CC_NEED_REVALIDATE_ONCE;
 }
@@ -1799,7 +1799,7 @@ MIMEHdr::set_cooked_cc_need_revalidate_once()
   -------------------------------------------------------------------------*/
 
 inline void
-MIMEHdr::unset_cooked_cc_need_revalidate_once()
+MIMEHdr::unset_cooked_cc_need_revalidate_once() // NOLINT(readability-make-member-function-const)
 {
   m_mime->m_cooked_stuff.m_cache_control.m_mask &= ~((uint32_t)MIME_COOKED_MASK_CC_NEED_REVALIDATE_ONCE);
 }


### PR DESCRIPTION
With a little help from running `readability-make-member-function-const` of clang-tidy.

https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-make-member-function-const.html