### PR TITLE
regex_revalidate: add stats for miss/stale counts

### DIFF
--- a/doc/admin-guide/plugins/regex_revalidate.en.rst
+++ b/doc/admin-guide/plugins/regex_revalidate.en.rst
@@ -40,6 +40,8 @@ regular expression against your origin URLs permits. Thus, individual cache
 objects may have rules created for them, or entire path prefixes, or even any
 cache objects with a particular file extension.
 
+Revalidate count  stats for MISS and STALE are recorded under plugins
+
 Installation
 ============
 

--- a/tests/gold_tests/pluginTest/regex_revalidate/gold/metrics.gold
+++ b/tests/gold_tests/pluginTest/regex_revalidate/gold/metrics.gold
@@ -1,0 +1,2 @@
+plugin.regex_revalidate.stale 3
+plugin.regex_revalidate.miss 0

--- a/tests/gold_tests/pluginTest/regex_revalidate/gold/metrics_miss.gold
+++ b/tests/gold_tests/pluginTest/regex_revalidate/gold/metrics_miss.gold
@@ -1,0 +1,2 @@
+plugin.regex_revalidate.stale 1
+plugin.regex_revalidate.miss 2

--- a/tests/gold_tests/pluginTest/regex_revalidate/metrics.sh
+++ b/tests/gold_tests/pluginTest/regex_revalidate/metrics.sh
@@ -1,0 +1,30 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+N=60
+while (( N > 0 ))
+do
+    rm -f metrics.out
+    traffic_ctl metric match regex_revalidate > metrics.out
+    sleep 1
+    if diff metrics.out ${AUTEST_TEST_DIR}/gold/metrics.gold
+    then
+        exit 0
+    fi
+    let N=N-1
+done
+echo TIMEOUT
+exit 1

--- a/tests/gold_tests/pluginTest/regex_revalidate/metrics_miss.sh
+++ b/tests/gold_tests/pluginTest/regex_revalidate/metrics_miss.sh
@@ -1,0 +1,30 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+N=60
+while (( N > 0 ))
+do
+    rm -f metrics.out
+    traffic_ctl metric match regex_revalidate > metrics.out
+    sleep 1
+    if diff metrics.out ${AUTEST_TEST_DIR}/gold/metrics_miss.gold
+    then
+        exit 0
+    fi
+    let N=N-1
+done
+echo TIMEOUT
+exit 1

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -44,6 +44,9 @@ server = Test.MakeOriginServer("server")
 # Define ATS and configure
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True)
 
+Test.testName = "regex_revalidate"
+Test.Setup.Copy("metrics.sh")
+
 # default root
 request_header_0 = {"headers":
                     "GET / HTTP/1.1\r\n" +
@@ -263,4 +266,12 @@ tr.DelayStart = 5
 tr.Processes.Default.Command = curl_and_args + ' http://127.0.0.1:{}/path2a'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/regex_reval-stale.gold"
+tr.StillRunningAfter = ts
+
+# 12 Stats check
+tr = Test.AddTestRun("Check stats")
+tr.DelayStart = 5
+tr.Processes.Default.Command = "bash -c ./metrics.sh"
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
@@ -38,8 +38,8 @@ server = Test.MakeOriginServer("server")
 # Define ATS and configure
 ts = Test.MakeATSProcess("ts", command="traffic_manager")
 
-# **testname is required**
-#testName = "regex_reval"
+Test.testName = "regex_revalidate_miss"
+Test.Setup.Copy("metrics_miss.sh")
 
 # default root
 request_header_0 = {"headers":
@@ -220,11 +220,19 @@ ps.ReturnCode = 0
 ps.TimeOut = 5
 tr.TimeOut = 5
 
-# 8 Test - Cache stale
+# 10 Test - Cache stale
 tr = Test.AddTestRun("Cache stale path1")
 ps = tr.Processes.Default
 tr.DelayStart = 5
 ps.Command = curl_and_args + ' http://ats/path1'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit response")
+tr.StillRunningAfter = ts
+
+# 11 Stats check
+tr = Test.AddTestRun("Check stats")
+tr.DelayStart = 5
+tr.Processes.Default.Command = "bash -c ./metrics_miss.sh"
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts


### PR DESCRIPTION
This add revalidation counts to the stats.

```
plugin.regex_revalidate.stale
plugin.regex_revalidate.miss
```

traffic_ctl metrics match regex_revalidate is sufficient to dump these.