### PR TITLE
Fixed memory leak in the QUIC stream manager

### DIFF
--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -123,9 +123,6 @@ public:
   ProxyAllocator http2ClientSessionAllocator;
   ProxyAllocator http2StreamAllocator;
   ProxyAllocator quicClientSessionAllocator;
-  ProxyAllocator quicBidiStreamAllocator;
-  ProxyAllocator quicSendStreamAllocator;
-  ProxyAllocator quicReceiveStreamAllocator;
   ProxyAllocator httpServerSessionAllocator;
   ProxyAllocator hdrHeapAllocator;
   ProxyAllocator strHeapAllocator;

--- a/iocore/net/quic/QUICStreamFactory.cc
+++ b/iocore/net/quic/QUICStreamFactory.cc
@@ -26,30 +26,20 @@
 #include "QUICUnidirectionalStream.h"
 #include "QUICStreamFactory.h"
 
-ClassAllocator<QUICBidirectionalStream> quicBidiStreamAllocator("quicBidiStreamAllocator");
-ClassAllocator<QUICSendStream> quicSendStreamAllocator("quicSendStreamAllocator");
-ClassAllocator<QUICReceiveStream> quicReceiveStreamAllocator("quicReceiveStreamAllocator");
-
 QUICStreamVConnection *
 QUICStreamFactory::create(QUICStreamId sid, uint64_t local_max_stream_data, uint64_t remote_max_stream_data)
 {
   QUICStreamVConnection *stream = nullptr;
   switch (QUICTypeUtil::detect_stream_direction(sid, this->_info->direction())) {
   case QUICStreamDirection::BIDIRECTIONAL:
-    // TODO Free the stream somewhere
-    stream = THREAD_ALLOC(quicBidiStreamAllocator, this_ethread());
-    new (stream) QUICBidirectionalStream(this->_rtt_provider, this->_info, sid, local_max_stream_data, remote_max_stream_data);
+    stream = new QUICBidirectionalStream(this->_rtt_provider, this->_info, sid, local_max_stream_data, remote_max_stream_data);
     break;
   case QUICStreamDirection::SEND:
-    // TODO Free the stream somewhere
-    stream = THREAD_ALLOC(quicSendStreamAllocator, this_ethread());
-    new (stream) QUICSendStream(this->_info, sid, remote_max_stream_data);
+    stream = new QUICSendStream(this->_info, sid, remote_max_stream_data);
     break;
   case QUICStreamDirection::RECEIVE:
     // server side
-    // TODO Free the stream somewhere
-    stream = THREAD_ALLOC(quicReceiveStreamAllocator, this_ethread());
-    new (stream) QUICReceiveStream(this->_rtt_provider, this->_info, sid, local_max_stream_data);
+    stream = new QUICReceiveStream(this->_rtt_provider, this->_info, sid, local_max_stream_data);
     break;
   default:
     ink_assert(false);
@@ -62,23 +52,5 @@ QUICStreamFactory::create(QUICStreamId sid, uint64_t local_max_stream_data, uint
 void
 QUICStreamFactory::delete_stream(QUICStreamVConnection *stream)
 {
-  if (!stream) {
-    return;
-  }
-
-  stream->~QUICStreamVConnection();
-  switch (stream->direction()) {
-  case QUICStreamDirection::BIDIRECTIONAL:
-    THREAD_FREE(static_cast<QUICBidirectionalStream *>(stream), quicBidiStreamAllocator, this_thread());
-    break;
-  case QUICStreamDirection::SEND:
-    THREAD_FREE(static_cast<QUICSendStream *>(stream), quicSendStreamAllocator, this_thread());
-    break;
-  case QUICStreamDirection::RECEIVE:
-    THREAD_FREE(static_cast<QUICReceiveStream *>(stream), quicReceiveStreamAllocator, this_thread());
-    break;
-  default:
-    ink_assert(false);
-    break;
-  }
+  delete stream;
 }

--- a/iocore/net/quic/QUICStreamManager.cc
+++ b/iocore/net/quic/QUICStreamManager.cc
@@ -41,6 +41,13 @@ QUICStreamManager::QUICStreamManager(QUICContext *context, QUICApplicationMap *a
   }
 }
 
+QUICStreamManager::~QUICStreamManager()
+{
+  for (auto stream = stream_list.pop(); stream != nullptr; stream = stream_list.pop()) {
+    _stream_factory.delete_stream(stream);
+  }
+}
+
 std::vector<QUICFrameType>
 QUICStreamManager::interests()
 {

--- a/iocore/net/quic/QUICStreamManager.h
+++ b/iocore/net/quic/QUICStreamManager.h
@@ -40,6 +40,12 @@ class QUICStreamManager : public QUICFrameHandler, public QUICFrameGenerator
 {
 public:
   QUICStreamManager(QUICContext *context, QUICApplicationMap *app_map);
+  ~QUICStreamManager()
+  {
+    for (auto stream = stream_list.pop(); stream != nullptr; stream = stream_list.pop()) {
+      _stream_factory.delete_stream(stream);
+    }
+  }
 
   void init_flow_control_params(const std::shared_ptr<const QUICTransportParameters> &local_tp,
                                 const std::shared_ptr<const QUICTransportParameters> &remote_tp);

--- a/iocore/net/quic/QUICStreamManager.h
+++ b/iocore/net/quic/QUICStreamManager.h
@@ -40,12 +40,7 @@ class QUICStreamManager : public QUICFrameHandler, public QUICFrameGenerator
 {
 public:
   QUICStreamManager(QUICContext *context, QUICApplicationMap *app_map);
-  ~QUICStreamManager()
-  {
-    for (auto stream = stream_list.pop(); stream != nullptr; stream = stream_list.pop()) {
-      _stream_factory.delete_stream(stream);
-    }
-  }
+  ~QUICStreamManager();
 
   void init_flow_control_params(const std::shared_ptr<const QUICTransportParameters> &local_tp,
                                 const std::shared_ptr<const QUICTransportParameters> &remote_tp);


### PR DESCRIPTION
Removed the proxy allocator for the streams.  They can be added back in if there is a performance issue.