### PR TITLE
Temporarily skip the double AuTest to unblock PRs

### DIFF
--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -22,6 +22,10 @@ Test.Summary = '''
 Test transactions and sessions for http1, making sure the two continuations catch the same number of hooks.
 '''
 
+# Temporarily skip this test for now while we investigate:
+# https://github.com/apache/trafficserver/issues/7946
+Test.SkipIf(Condition.true("To unblock CI, skip this test temporarily. See issue #7946."))
+
 Test.ContinueOnFail = True
 # Define default ATS. Disable the cache to simplify the test.
 ts = Test.MakeATSProcess("ts", select_ports=True, command="traffic_manager", enable_cache=False)


### PR DESCRIPTION
There is an issue opened to track the intermittent failures in the
double.test.py, see #7946.

In the meantime, concurrently with that being actively investigated,
this PR skips the double.test.py. This is a temporary workaround to
remove the friction this test is adding to our PR process. This patch
should not remain in place for more than a few days.