### PR TITLE
Fix double test flakiness due to EOS/TXN_CLOSE race

### DIFF
--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -28,6 +28,10 @@
 void
 Http1ClientTransaction::release()
 {
+  // Turn off reading until we are done with the SM
+  // At that point the transaction/session with either be closed
+  // or be put into keep alive state to wait from the next transaction
+  this->do_io_read(this, 0, nullptr);
   _proxy_ssn->clear_session_active();
 }
 


### PR DESCRIPTION
Introduced by PR #7849.  That PR keeps around the ua_txn object a bit longer.  The double test runs into lock contention with a global continuation processing TXN_CLOSE hook.  The assert occurs if the TXN_CLOSE hook is deferred due to not getting the lock and the user agent EOS sneaks in.  The fix disables read operations until the HttpSM is done and then either the associated net VC is closed or the reads are reenabled to wait for the next transaction.

Ran through my loop 2x50 times.  Without the fix, would crash within 10 iterations.

This closes #7946