### PR TITLE
Pass through expect header and handle 100-continue response

### DIFF
--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -116,7 +116,7 @@ test_run.StillRunningAfter = httpbin
 
 # Test Case 3: Expect 100-Continue
 test_run = Test.AddTestRun()
-test_run.Processes.Default.Command = "curl -vs -k --http2 https://127.0.0.1:{0}/post --data 'key=value' -H 'Expect: 100-continue' --expect100-timeout 1 --max-time 5 | {1}".format(
+test_run.Processes.Default.Command = "curl -vs -k --http2 https://127.0.0.1:{0}/post --data 'key=value' -H 'Expect: 100-continue' --max-time 5 | {1}".format(
     ts.Variables.ssl_port, json_printer)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_3_stdout.gold"

--- a/tests/gold_tests/post/gold/post-h1.gold
+++ b/tests/gold_tests/post/gold/post-h1.gold
@@ -1,0 +1,4 @@
+``> POST /post HTTP/1.1
+``
+< HTTP/1.1 200 OK
+``

--- a/tests/gold_tests/post/gold/post-h2.gold
+++ b/tests/gold_tests/post/gold/post-h2.gold
@@ -1,0 +1,4 @@
+``POST /post HTTP/2
+``
+HTTP/2 200 
+``

--- a/tests/gold_tests/post/post-continue.test.py
+++ b/tests/gold_tests/post/post-continue.test.py
@@ -124,7 +124,7 @@ test_run = Test.AddTestRun("http2 POST small body with Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
     ts.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts
@@ -134,7 +134,7 @@ test_run = Test.AddTestRun("http2 POST large body with Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
     ts.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts
@@ -144,7 +144,7 @@ test_run = Test.AddTestRun("http2 POST small body w/o Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d "small body" -k https://127.0.0.1:{0}/post'.format(
     ts.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts
@@ -154,7 +154,7 @@ test_run = Test.AddTestRun("http2 POST large body w/o Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
     ts.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts
@@ -206,7 +206,7 @@ test_run = Test.AddTestRun("http2 POST small body with Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
     ts2.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts2
@@ -216,7 +216,7 @@ test_run = Test.AddTestRun("http2 POST large body with Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
     ts2.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts2
@@ -226,7 +226,7 @@ test_run = Test.AddTestRun("http2 POST small body w/o Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d "small body" -k https://127.0.0.1:{0}/post'.format(
     ts2.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts2
@@ -236,7 +236,7 @@ test_run = Test.AddTestRun("http2 POST large body w/o Expect header")
 test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
     ts2.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
-test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
 test_run.StillRunningAfter = httpbin
 test_run.StillRunningAfter = ts2

--- a/tests/gold_tests/post/post-continue.test.py
+++ b/tests/gold_tests/post/post-continue.test.py
@@ -1,0 +1,243 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+# ----
+# Setup Test
+# ----
+Test.Summary = '''
+Test the Expect header in post
+'''
+# Require HTTP/2 enabled Curl
+Test.SkipUnless(
+    Condition.HasCurlFeature('http2'),
+)
+Test.ContinueOnFail = True
+
+# ----
+# Setup httpbin Origin Server
+# ----
+httpbin = Test.MakeHttpBinServer("httpbin")
+
+# ----
+# Setup ATS
+# ----
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_cache=False)
+
+ts2 = Test.MakeATSProcess("ts2", select_ports=True, enable_tls=True, enable_cache=False)
+
+# add ssl materials like key, certificates for the server
+ts.addDefaultSSLFiles()
+ts2.addDefaultSSLFiles()
+
+ts.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}'.format(httpbin.Variables.Port)
+)
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+ts.Disk.records_config.update({
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http',
+
+})
+ts2.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}'.format(httpbin.Variables.Port)
+)
+ts2.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+ts2.Disk.records_config.update({
+    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.diags.debug.enabled': 0,
+    'proxy.config.diags.debug.tags': 'http',
+    'proxy.config.http.send_100_continue_response': 1
+})
+
+big_post_body = "0123456789" * 131070
+big_post_body_file = open(os.path.join(Test.RunDirectory, "big_post_body"), "w")
+big_post_body_file.write(big_post_body)
+big_post_body_file.close()
+
+test_run = Test.AddTestRun("http1.1 POST small body with Expect header")
+test_run.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+test_run.Processes.Default.StartBefore(Test.Processes.ts)
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 Continue", "Has Expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http1.1 POST large body with Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 Continue", "Has Expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http1.1 POST small body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect:" -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 Continue", "Does not have Expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect: 100-continue", "Does not have Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http1.1 POST large body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 Continue", "Does not have Expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect: 100-continue", "Does not have Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST small body with Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST large body with Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST small body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST large body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts
+test_run.Processes.Default.ReturnCode = 0
+
+# Do them all again against the TS that will return 100-continue immediately
+test_run = Test.AddTestRun("http1.1 POST small body with Expect header")
+test_run.Processes.Default.StartBefore(Test.Processes.ts2)
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 Continue", "Has Expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http1.1 POST large body with Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 Continue", "Has Expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http1.1 POST small body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect:" -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 Continue", "Has Expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect 100-continue", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http1.1 POST large body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 Continue", "Has Expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect 100-continue", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST small body with Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST large body with Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST small body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d "small body" -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0
+
+test_run = Test.AddTestRun("http2 POST large body w/o Expect header")
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
+    ts2.Variables.ssl_port)
+test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("expect: 100-continue", "Has expect header")
+test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
+test_run.StillRunningAfter = httpbin
+test_run.StillRunningAfter = ts2
+test_run.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/redirect/redirect_post.test.py
+++ b/tests/gold_tests/redirect/redirect_post.test.py
@@ -64,7 +64,7 @@ ts.Disk.remap_config.AddLine(
 )
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'touch largefile.txt && truncate largefile.txt -s 50M && curl -i http://127.0.0.1:{0}/redirect1 -F "filename=@./largefile.txt" && rm -f largefile.txt'.format(
+tr.Processes.Default.Command = 'touch largefile.txt && truncate largefile.txt -s 50M && curl -H "Expect: " -i http://127.0.0.1:{0}/redirect1 -F "filename=@./largefile.txt" && rm -f largefile.txt'.format(
     ts.Variables.port)
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(redirect_serv1)


### PR DESCRIPTION
The fixes the code to correctly send the request header and wait for the 100-continue response before setting up the post tunnel. Must of the logic was already in the code, but just not wired up correctly.  If you did not have proxy.config.http.send_100_continue_response set to 1 so ATS returns the 100 continue immediately, ATS would go ahead and set up the post tunnel before sending the request header and giving the origin a chance to respond with 100 continue.  Curl would still continue to work in the scenario although with higher latency because it would eventually timeout and send the post data anyway.

I had to adjust one of the tests because it appears that microserver does not correctly respond to the Expect header.

This closes #7346