### PR TITLE
Tweak QUIC protocol stack support to include TLS.

### DIFF
--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1040,7 +1040,10 @@ QUICNetVConnection::populate_protocol(std::string_view *results, int n) const
   if (n > retval) {
     results[retval++] = IP_PROTO_TAG_QUIC;
     if (n > retval) {
-      retval += super::populate_protocol(results + retval, n - retval);
+      results[retval++] = IP_PROTO_TAG_TLS_1_3;
+      if (n > retval) {
+        retval += super::populate_protocol(results + retval, n - retval);
+      }
     }
   }
   return retval;
@@ -1049,10 +1052,12 @@ QUICNetVConnection::populate_protocol(std::string_view *results, int n) const
 const char *
 QUICNetVConnection::protocol_contains(std::string_view prefix) const
 {
-  const char *retval   = nullptr;
-  std::string_view tag = IP_PROTO_TAG_QUIC;
-  if (prefix.size() <= tag.size() && strncmp(tag.data(), prefix.data(), prefix.size()) == 0) {
-    retval = tag.data();
+  const char *retval = nullptr;
+  if (prefix.size() <= IP_PROTO_TAG_QUIC.size() && strncmp(IP_PROTO_TAG_QUIC.data(), prefix.data(), prefix.size()) == 0) {
+    retval = IP_PROTO_TAG_QUIC.data();
+  } else if (prefix.size() <= IP_PROTO_TAG_TLS_1_3.size() &&
+             strncmp(IP_PROTO_TAG_TLS_1_3.data(), prefix.data(), prefix.size()) == 0) {
+    retval = IP_PROTO_TAG_TLS_1_3.data();
   } else {
     retval = super::protocol_contains(prefix);
   }


### PR DESCRIPTION
QUIC is based on TLS and from an external point of view, it's TLS (i.e. all standard TLS operations are expected to work, e.g. pulling the SANS from the client certificate). Therefore the protocol stack should indicate this.