### PR TITLE
Fix dynamic-stack-buffer-overflow of cachekey plugin (#7945)

### DIFF
--- a/plugins/cachekey/cachekey.cc
+++ b/plugins/cachekey/cachekey.cc
@@ -41,7 +41,7 @@ appendEncoded(String &target, const char *s, size_t len)
     return;
   }
 
-  char tmp[len * 2];
+  char tmp[len * 3 + 1];
   size_t written;
 
   /* The default table does not encode the comma, so we need to use our own table here. */

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -343,7 +343,7 @@ escapify_url_common(Arena *arena, char *url, size_t len_in, int *len_out, char *
   //
   size_t out_len = len_in + 2 * count;
 
-  if (dst && out_len > dst_size) {
+  if (dst && (out_len + 1) > dst_size) {
     *len_out = 0;
     return nullptr;
   }


### PR DESCRIPTION
Backport #7945

----

* Fix dynamic-stack-buffer-overflow of cachekey plugin

* Check dst_size include null termination

(cherry picked from commit 5a9339d7bc65e1c2d8d2a0fc80bb051daf3cdb0b)