### PR TITLE
Pin Sphinx to 3.x to unblock `make html`

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -22,7 +22,16 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-sphinx = "2.0.1"
+
+# The latest 4.x sphinx release, currently 4.0.2, fails `make html`.  For
+# details, see: https://github.com/apache/trafficserver/issues/7938
+#
+# The 3.x releases build fine, however. So we currently pin to that.
+#
+# Once that issue, either with sphinx or our docs, is resolved, then we should
+# unpin sphinx by setting the following to "*".
+sphinx = "==3.*"
+
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 # i18n

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -31,7 +31,7 @@ from docutils.parsers import rst
 from docutils.parsers.rst import directives
 from sphinx.domains import Domain, ObjType, std
 from sphinx.roles import XRefRole
-from sphinx.locale import l_, _
+from sphinx.locale import _
 import sphinx
 
 import subprocess


### PR DESCRIPTION
The latest version of Sphinx, 4.0.2, fails to build our docs via the
make html target. The latest 3.x release, currently 3.5.4, builds our
docs fine. Pinning to 3.x.

This also makes a fix for an API change in which sphinx.locale no longer
has `l_`.