### PR TITLE
conf_remap: demote 'Invalid configuration' to warning

### DIFF
--- a/plugins/conf_remap/conf_remap.cc
+++ b/plugins/conf_remap/conf_remap.cc
@@ -91,7 +91,7 @@ RemapConfigs::parse_inline(const char *arg)
   value = std::string(sep + 1, std::distance(sep + 1, arg + strlen(arg)));
 
   if (TSHttpTxnConfigFind(key.c_str(), -1 /* len */, &name, &type) != TS_SUCCESS) {
-    TSError("[%s] Invalid configuration variable '%s'", PLUGIN_NAME, key.c_str());
+    TSWarning("[%s] Invalid configuration variable '%s'", PLUGIN_NAME, key.c_str());
     return true;
   }
 


### PR DESCRIPTION
When I added this in b4241b99d0d6017397acf92a2562898b7b5e57b4, I
miscategorized the log message. Since the plugin continues the loading,
this should only be a warning.