### PR TITLE
Fix BoringSSL build

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -950,6 +950,8 @@ SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams *params, const char *ke
       }
     }
   }
+#else
+  void *e = nullptr;
 #endif
   if (pkey == nullptr) {
     scoped_BIO bio(BIO_new_mem_buf(secret_data, secret_data_len));


### PR DESCRIPTION
#6609 broke BoringSSL build.

```
  CXX      SSLUtils.o
SSLUtils.cc:966:9: error: use of undeclared identifier 'e'
    if (e == nullptr && !SSL_CTX_check_private_key(ctx)) {
        ^
1 error generated.
```