### PR TITLE
Fix HPACK eviction iterator manipulation

### DIFF
--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -461,17 +461,18 @@ HpackDynamicTable::_evict_overflowed_entries()
     return;
   }
 
-  for (auto h = this->_headers.rbegin(); h != this->_headers.rend(); ++h) {
+  while (!this->_headers.empty()) {
+    auto h = this->_headers.back();
     int name_len, value_len;
-    (*h)->name_get(&name_len);
-    (*h)->value_get(&value_len);
+    h->name_get(&name_len);
+    h->value_get(&value_len);
 
     this->_current_size -= ADDITIONAL_OCTETS + name_len + value_len;
 
     if (this->_mhdr_old && this->_mhdr_old->fields_count() != 0) {
-      this->_mhdr_old->field_delete(*h, false);
+      this->_mhdr_old->field_delete(h, false);
     } else {
-      this->_mhdr->field_delete(*h, false);
+      this->_mhdr->field_delete(h, false);
     }
 
     this->_headers.pop_back();


### PR DESCRIPTION
Found this while investigating #7838.  According to https://en.cppreference.com/w/cpp/container/deque/pop_back#:~:text=std%3A%3Adeque%3A%3Apop_back&text=Removes%20the%20last%20element%20of,the%2Dend%20iterator%20is%20invalidated. After pop_back is called "Iterators and references to the erased element are invalidated".  In the current logic, the increment is called on the old iterator after pop_back is called.

I'm not 100% sure this is causing our crash.  If most of the time only one item is evicted, this case won't happen very often and maybe most of the time you get lucky.

I will get this patched rolled into our build. Even if it does not fix the crash the new logic is safer and looks cleaner.

This closes #7838