### PR TITLE
Dual cert support for BoringSSL

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -96,8 +96,8 @@ valid_tls_versions_in     This specifies the list of TLS protocols that will be 
                           :ts:cv:`proxy.config.ssl.TLSv1`, :ts:cv:`proxy.config.ssl.TLSv1_1`,
                           :ts:cv:`proxy.config.ssl.TLSv1_2`, and :ts:cv:`proxy.config.ssl.TLSv1_3`. The potential
                           values are TLSv1, TLSv1_1, TLSv1_2, and TLSv1_3.  You must list all protocols that |TS|
-                          should offer to the client when using this key.  This key is only valid for openssl
-                          1.1.0 and later. Older versions of openssl do not provide a hook early enough to update
+                          should offer to the client when using this key.  This key is only valid for OpenSSL
+                          1.1.0 and later and BoringSSL. Older versions of OpenSSL do not provide a hook early enough to update
                           the SSL object.  It is a syntax error for |TS| built against earlier versions.
 
 client_cert               The file containing the client certificate to use for the outbound connection.

--- a/iocore/net/BoringSSLUtils.cc
+++ b/iocore/net/BoringSSLUtils.cc
@@ -1,0 +1,138 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+// Borrowed from Envoy
+// https://github.com/envoyproxy/envoy/blob/329b2491949fc52f4dc5c4a778ea158bfe6fe979/source/extensions/transport_sockets/tls/context_impl.cc#L962
+
+#include "BoringSSLUtils.h"
+
+#ifdef OPENSSL_IS_BORINGSSL
+namespace BoringSSLUtils
+{
+bool
+cbsContainsU16(CBS &cbs, uint16_t n)
+{
+  while (CBS_len(&cbs) > 0) {
+    uint16_t v;
+    if (!CBS_get_u16(&cbs, &v)) {
+      return false;
+    }
+    if (v == n) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool
+isCipherEnabled(SSL_CTX *ctx, uint16_t cipher_id, uint16_t client_version)
+{
+  const SSL_CIPHER *c = SSL_get_cipher_by_value(cipher_id);
+  if (c == nullptr) {
+    return false;
+  }
+  // Skip TLS 1.2 only ciphersuites unless the client supports it.
+  if (SSL_CIPHER_get_min_version(c) > client_version) {
+    return false;
+  }
+  if (SSL_CIPHER_get_auth_nid(c) != NID_auth_ecdsa) {
+    return false;
+  }
+  for (const SSL_CIPHER *our_c : SSL_CTX_get_ciphers(ctx)) {
+    if (SSL_CIPHER_get_id(our_c) == SSL_CIPHER_get_id(c)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool
+isClientEcdsaCapable(const SSL_CLIENT_HELLO *ssl_client_hello)
+{
+  CBS client_hello;
+  CBS_init(&client_hello, ssl_client_hello->client_hello, ssl_client_hello->client_hello_len);
+
+  // This is the TLSv1.3 case (TLSv1.2 on the wire and the supported_versions extensions present).
+  // We just need to look at signature algorithms.
+  const uint16_t client_version = ssl_client_hello->version;
+  if (client_version == TLS1_2_VERSION && true) {
+    // If the supported_versions extension is found then we assume that the client is competent
+    // enough that just checking the signature_algorithms is sufficient.
+    const uint8_t *supported_versions_data;
+    size_t supported_versions_len;
+    if (SSL_early_callback_ctx_extension_get(ssl_client_hello, TLSEXT_TYPE_supported_versions, &supported_versions_data,
+                                             &supported_versions_len)) {
+      const uint8_t *signature_algorithms_data;
+      size_t signature_algorithms_len;
+      if (SSL_early_callback_ctx_extension_get(ssl_client_hello, TLSEXT_TYPE_signature_algorithms, &signature_algorithms_data,
+                                               &signature_algorithms_len)) {
+        CBS signature_algorithms_ext, signature_algorithms;
+        CBS_init(&signature_algorithms_ext, signature_algorithms_data, signature_algorithms_len);
+        if (!CBS_get_u16_length_prefixed(&signature_algorithms_ext, &signature_algorithms) ||
+            CBS_len(&signature_algorithms_ext) != 0) {
+          return false;
+        }
+        if (cbsContainsU16(signature_algorithms, SSL_SIGN_ECDSA_SECP256R1_SHA256)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }
+
+  // Otherwise we are < TLSv1.3 and need to look at both the curves in the supported_groups for
+  // ECDSA and also for a compatible cipher suite. https://tools.ietf.org/html/rfc4492#section-5.1.1
+  const uint8_t *curvelist_data;
+  size_t curvelist_len;
+  if (!SSL_early_callback_ctx_extension_get(ssl_client_hello, TLSEXT_TYPE_supported_groups, &curvelist_data, &curvelist_len)) {
+    return false;
+  }
+
+  CBS curvelist;
+  CBS_init(&curvelist, curvelist_data, curvelist_len);
+
+  // We only support P256 ECDSA curves today.
+  if (!cbsContainsU16(curvelist, SSL_CURVE_SECP256R1)) {
+    return false;
+  }
+
+  // The client must have offered an ECDSA ciphersuite that we like.
+  CBS cipher_suites;
+  CBS_init(&cipher_suites, ssl_client_hello->cipher_suites, ssl_client_hello->cipher_suites_len);
+
+  while (CBS_len(&cipher_suites) > 0) {
+    uint16_t cipher_id;
+    if (!CBS_get_u16(&cipher_suites, &cipher_id)) {
+      return false;
+    }
+
+    SSL_CTX *ctx = SSL_get_SSL_CTX(ssl_client_hello->ssl);
+    if (isCipherEnabled(ctx, cipher_id, client_version)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace BoringSSLUtils
+#endif

--- a/iocore/net/BoringSSLUtils.h
+++ b/iocore/net/BoringSSLUtils.h
@@ -1,0 +1,30 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <openssl/ssl.h>
+
+#ifdef OPENSSL_IS_BORINGSSL
+namespace BoringSSLUtils
+{
+bool isClientEcdsaCapable(const SSL_CLIENT_HELLO *ssl_client_hello);
+
+} // namespace BoringSSLUtils
+#endif

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -119,6 +119,8 @@ libinknet_a_SOURCES = \
 	ALPNSupport.cc \
 	BIO_fastopen.cc \
 	BIO_fastopen.h \
+	BoringSSLUtils.cc \
+	BoringSSLUtils.h \
 	Connection.cc \
 	I_Net.h \
 	I_NetProcessor.h \
@@ -143,7 +145,7 @@ libinknet_a_SOURCES = \
 	P_Socks.h \
 	P_SSLCertLookup.h \
 	P_SSLConfig.h \
-        P_SSLSecret.h \
+	P_SSLSecret.h \
 	P_SSLNetAccept.h \
 	P_SSLNetProcessor.h \
 	P_SSLNetVConnection.h \
@@ -172,7 +174,7 @@ libinknet_a_SOURCES = \
 	SSLClientCoordinator.cc \
 	SSLClientUtils.cc \
 	SSLConfig.cc \
-        SSLSecret.cc \
+	SSLSecret.cc \
 	SSLDiags.cc \
 	SSLInternal.cc \
 	SSLNetAccept.cc \

--- a/iocore/net/P_SSLCertLookup.h
+++ b/iocore/net/P_SSLCertLookup.h
@@ -40,6 +40,14 @@ enum class SSLCertContextOption {
   OPT_TUNNEL ///< Just tunnel, don't terminate.
 };
 
+/** Used to discern the context type when BoringSSL is used for the SSL implementation.
+ */
+enum class SSLCertContextType {
+  GENERIC, ///< Generic Context (can be either EC or RSA)
+  RSA,     ///< RSA-based Context
+  EC       ///< EC-based Context
+};
+
 /**
    @brief Gather user provided settings from ssl_multicert.config in to this single struct
  */
@@ -100,14 +108,17 @@ public:
     : ctx_mutex(), ctx(c, SSL_CTX_free), opt(SSLCertContextOption::OPT_NONE), userconfig(nullptr), keyblock(nullptr)
   {
   }
-  SSLCertContext(shared_SSL_CTX sc, shared_SSLMultiCertConfigParams u)
-    : ctx_mutex(), ctx(sc), opt(u->opt), userconfig(u), keyblock(nullptr)
+
+  SSLCertContext(shared_SSL_CTX sc, SSLCertContextType ctx_type, shared_SSLMultiCertConfigParams u)
+    : ctx_mutex(), ctx(sc), ctx_type(ctx_type), opt(u->opt), userconfig(u), keyblock(nullptr)
   {
   }
-  SSLCertContext(shared_SSL_CTX sc, shared_SSLMultiCertConfigParams u, shared_ssl_ticket_key_block kb)
-    : ctx_mutex(), ctx(sc), opt(u->opt), userconfig(u), keyblock(kb)
+
+  SSLCertContext(shared_SSL_CTX sc, SSLCertContextType ctx_type, shared_SSLMultiCertConfigParams u, shared_ssl_ticket_key_block kb)
+    : ctx_mutex(), ctx(sc), ctx_type(ctx_type), opt(u->opt), userconfig(u), keyblock(kb)
   {
   }
+
   SSLCertContext(SSLCertContext const &other);
   SSLCertContext &operator=(SSLCertContext const &other);
   ~SSLCertContext() {}
@@ -117,6 +128,7 @@ public:
   void setCtx(shared_SSL_CTX sc);
   void release();
 
+  SSLCertContextType ctx_type                = SSLCertContextType::GENERIC;
   SSLCertContextOption opt                   = SSLCertContextOption::OPT_NONE; ///< Special handling option.
   shared_SSLMultiCertConfigParams userconfig = nullptr;                        ///< User provided settings
   shared_ssl_ticket_key_block keyblock       = nullptr;                        ///< session keys associated with this address
@@ -124,6 +136,8 @@ public:
 
 struct SSLCertLookup : public ConfigInfo {
   SSLContextStorage *ssl_storage;
+  SSLContextStorage *ec_storage;
+
   shared_SSL_CTX ssl_default;
   bool is_valid = true;
 
@@ -141,7 +155,7 @@ struct SSLCertLookup : public ConfigInfo {
       Exact matches have priority, then wildcards. Only destination based matches are checked.
       @return @c A pointer to the matched context, @c nullptr if no match is found.
   */
-  SSLCertContext *find(const std::string &name) const;
+  SSLCertContext *find(const std::string &name, SSLCertContextType ctxType = SSLCertContextType::GENERIC) const;
 
   // Return the last-resort default TLS context if there is no name or address match.
   SSL_CTX *

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -42,7 +42,7 @@ class SSLNetVConnection;
 
 typedef int ssl_error_t;
 
-#ifndef OPENSSL_IS_BORING
+#ifndef OPENSSL_IS_BORINGSSL
 typedef int ssl_curve_id;
 #else
 typedef uint16_t ssl_curve_id;

--- a/iocore/net/SSLCertLookup.cc
+++ b/iocore/net/SSLCertLookup.cc
@@ -253,6 +253,7 @@ SSLCertContext::SSLCertContext(SSLCertContext const &other)
   opt        = other.opt;
   userconfig = other.userconfig;
   keyblock   = other.keyblock;
+  ctx_type   = other.ctx_type;
   std::lock_guard<std::mutex> lock(other.ctx_mutex);
   ctx = other.ctx;
 }
@@ -264,6 +265,7 @@ SSLCertContext::operator=(SSLCertContext const &other)
     this->opt        = other.opt;
     this->userconfig = other.userconfig;
     this->keyblock   = other.keyblock;
+    this->ctx_type   = other.ctx_type;
     std::lock_guard<std::mutex> lock(other.ctx_mutex);
     this->ctx = other.ctx;
   }
@@ -284,16 +286,30 @@ SSLCertContext::setCtx(shared_SSL_CTX sc)
   ctx = std::move(sc);
 }
 
-SSLCertLookup::SSLCertLookup() : ssl_storage(new SSLContextStorage()), ssl_default(nullptr), is_valid(true) {}
+SSLCertLookup::SSLCertLookup()
+  : ssl_storage(new SSLContextStorage()), ec_storage(new SSLContextStorage()), ssl_default(nullptr), is_valid(true)
+{
+}
 
 SSLCertLookup::~SSLCertLookup()
 {
   delete this->ssl_storage;
+  delete this->ec_storage;
 }
 
 SSLCertContext *
-SSLCertLookup::find(const std::string &address) const
+SSLCertLookup::find(const std::string &address, SSLCertContextType ctxType) const
 {
+#ifdef OPENSSL_IS_BORINGSSL
+  // If the context is EC supportable, try finding that first.
+  if (ctxType == SSLCertContextType::EC) {
+    auto ctx = this->ec_storage->lookup(address);
+    if (ctx != nullptr) {
+      return ctx;
+    }
+  }
+#endif
+  // non-EC last resort
   return this->ssl_storage->lookup(address);
 }
 
@@ -302,6 +318,24 @@ SSLCertLookup::find(const IpEndpoint &address) const
 {
   SSLCertContext *cc;
   SSLAddressLookupKey key(address);
+
+#ifdef OPENSSL_IS_BORINGSSL
+  // If the context is EC supportable, try finding that first.
+  if ((cc = this->ec_storage->lookup(key.get()))) {
+    return cc;
+  }
+
+  // If that failed, try the address without the port.
+  if (address.port()) {
+    key.split();
+    if ((cc = this->ec_storage->lookup(key.get()))) {
+      return cc;
+    }
+  }
+
+  // reset for search across RSA
+  key = SSLAddressLookupKey(address);
+#endif
 
   // First try the full address.
   if ((cc = this->ssl_storage->lookup(key.get()))) {
@@ -320,14 +354,39 @@ SSLCertLookup::find(const IpEndpoint &address) const
 int
 SSLCertLookup::insert(const char *name, SSLCertContext const &cc)
 {
+#ifdef OPENSSL_IS_BORINGSSL
+  switch (cc.ctx_type) {
+  case SSLCertContextType::GENERIC:
+  case SSLCertContextType::RSA:
+    return this->ssl_storage->insert(name, cc);
+  case SSLCertContextType::EC:
+    return this->ec_storage->insert(name, cc);
+  default:
+    ink_assert(false);
+  }
+#else
   return this->ssl_storage->insert(name, cc);
+#endif
 }
 
 int
 SSLCertLookup::insert(const IpEndpoint &address, SSLCertContext const &cc)
 {
   SSLAddressLookupKey key(address);
+
+#ifdef OPENSSL_IS_BORINGSSL
+  switch (cc.ctx_type) {
+  case SSLCertContextType::GENERIC:
+  case SSLCertContextType::RSA:
+    return this->ssl_storage->insert(key.get(), cc);
+  case SSLCertContextType::EC:
+    return this->ec_storage->insert(key.get(), cc);
+  default:
+    ink_assert(false);
+  }
+#else
   return this->ssl_storage->insert(key.get(), cc);
+#endif
 }
 
 unsigned

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -710,7 +710,7 @@ cleanup_bio(BIO *&biop)
 void
 SSLConfigParams::updateCTX(const std::string &cert_secret_name) const
 {
-  // Clear the corresponding client CTX's.  They will be lazy loaded later
+  // Clear the corresponding client CTXs.  They will be lazy loaded later
   Debug("ssl", "Update cert %s", cert_secret_name.c_str());
   this->clearCTX(cert_secret_name);
 

--- a/iocore/net/TLSSNISupport.h
+++ b/iocore/net/TLSSNISupport.h
@@ -40,8 +40,12 @@ public:
 
   int perform_sni_action();
   // Callback functions for OpenSSL libraries
-#if TS_USE_HELLO_CB
+#if TS_USE_HELLO_CB || defined(OPENSSL_IS_BORINGSSL)
+#ifdef OPENSSL_IS_BORINGSSL
+  void on_client_hello(const SSL_CLIENT_HELLO *client_hello);
+#else
   void on_client_hello(SSL *ssl, int *al, void *arg);
+#endif
 #endif
   void on_servername(SSL *ssl, int *al, void *arg);
 

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -136,7 +136,7 @@ std::set<std::string> valid_sni_config_keys = {TS_fqdn,
                                                TS_client_sni_policy,
                                                TS_http2,
                                                TS_ip_allow,
-#if TS_USE_HELLO_CB
+#if TS_USE_HELLO_CB || defined(OPENSSL_IS_BORINGSSL)
                                                TS_valid_tls_versions_in,
 #endif
                                                TS_host_sni_policy};

--- a/tests/gold_tests/tls_hooks/tls_hooks14.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks14.test.py
@@ -23,10 +23,6 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.IsOpenSSL()
-)
-
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server", ssl=True)
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls_hooks/tls_hooks16.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks16.test.py
@@ -25,8 +25,7 @@ Test different combinations of TLS handshake hooks to ensure they are applied co
 '''
 
 Test.SkipUnless(
-    Condition.HasOpenSSLVersion("1.1.1"),
-    Condition.IsOpenSSL()
+    Condition.HasOpenSSLVersion("1.1.1")
 )
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)


### PR DESCRIPTION
 BoringSSL removed support for slotted SSL_CTXs. This is key for
 supporting multiple certs for a CTX. When BoringSSL is used,
 multiple CTXs will be created if more than one cert type is specified.
 When a client connection does come in, ATS will interrogate the
  connection and present the approriate CTX (preferring ECDSA)