### PR TITLE
Fix use after free

### DIFF
--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -207,7 +207,6 @@ Http1ServerSession ::release_transaction()
       HTTP_INCREMENT_DYN_STAT(http_origin_close_private);
     }
     this->do_io_close();
-    ink_release_assert(transact_count == released_transactions);
   } else if (state == SSN_TO_RELEASE) {
     _vc->control_flags.set_flags(0);
 


### PR DESCRIPTION
Introduced by PR #7849 

Ran into it while debugging another issue.  The Http1ServerSession may be deleted by the time do_io_close() returns so we cannot safely access member variables.