### PR TITLE
header_rewrite rm-destination support

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -689,6 +689,18 @@ used as its replacement. You must supply a non-zero length value, otherwise
 this operator will be an effective no-op (though a warning will be emitted to
 the logs if debugging is enabled).
 
+rm-destination
+~~~~~~~~~~~~~~
+::
+
+  rm-destination <part>
+
+Removes individual components of the remapped destination's address. When
+changing the remapped destination, ``<part>`` should be used to indicate the
+component that is being modified (see `URL Parts`_). Currently the only valid
+parts for rm-destination are QUERY, PATH, and PORT.
+
+
 set-header
 ~~~~~~~~~~
 ::
@@ -1204,3 +1216,11 @@ could each be tagged with a consistent name to make finding logs easier.::
    set-header @PropertyName "someproperty"
 
 (Then in :file:`logging.yaml`, log ``%<{@PropertyName}cqh>``)
+
+Remove Client Query Parameters
+------------------------------------
+
+The following ruleset removes any query parameters set by the client.::
+
+   cond %{REMAP_PSEUDO_HOOK}
+   rm-destination QUERY

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -47,6 +47,8 @@ operator_factory(const std::string &op)
     o = new OperatorSetStatusReason();
   } else if (op == "set-destination") {
     o = new OperatorSetDestination();
+  } else if (op == "rm-destination") {
+    o = new OperatorRMDestination();
   } else if (op == "set-redirect") {
     o = new OperatorSetRedirect();
   } else if (op == "timeout-out") {

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -113,6 +113,25 @@ private:
   Value _value;
 };
 
+// All the header operators share a base class
+class OperatorRMDestination : public Operator
+{
+public:
+  OperatorRMDestination() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for OperatorRMDestination"); }
+
+  // noncopyable
+  OperatorRMDestination(const OperatorRMDestination &) = delete;
+  void operator=(const OperatorRMDestination &) = delete;
+
+  void initialize(Parser &p) override;
+
+protected:
+  void exec(const Resources &res) const override;
+
+private:
+  UrlQualifiers _url_qual = URL_QUAL_NONE;
+};
+
 class OperatorSetRedirect : public Operator
 {
 public:


### PR DESCRIPTION
Adds a new `rm-destination`, this lets you specify either QUERY or PATH, and be able to drop them from the incoming request

closes #8024 
closes #4670 