### PR TITLE
tls_bad_alpn: Add an openssl version skip check

### DIFF
--- a/tests/gold_tests/tls/tls_bad_alpn.test.py
+++ b/tests/gold_tests/tls/tls_bad_alpn.test.py
@@ -23,6 +23,9 @@ Test.Summary = '''
 Ensure that handshake fails if invalid alpn string is offered
 '''
 
+# Only later versions of openssl support the `-alpn` option.
+Test.SkipUnless(Condition.HasOpenSSLVersion('1.1.1'))
+
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 


### PR DESCRIPTION
The tls_bad_alpn.test.py test requires a later version of openssl which
supports the `-alpn` feature. If the system is not using that version of
openssl, then the test should be skipped. This patch adds that
openssl version skip condition.

---

This fixes: #8023 