### PR TITLE
Stablize trace curl test in good_request_after_bad

### DIFF
--- a/tests/gold_tests/headers/gold/bad_good_request_header.gold
+++ b/tests/gold_tests/headers/gold/bad_good_request_header.gold
@@ -1,0 +1,5 @@
+``HTTP/1.1 400 Invalid HTTP Request
+``Connection: close
+``Server: ATS/``
+``Content-Length: 219
+``


### PR DESCRIPTION
I noticed that "Trace request with a chunked body via curl" test in good_request_after_bad fails with some frequency.  It may just be an oddity of the curl output where short output is not always displayed if it is closely followed by a FIN.  Or there may be a real problem where ATS is cutting off the body.  This PR attempts to write the output to a file using the -o option and test that.

Of course it always works for me locally.