### PR TITLE
Treat Sphinx doc build warnings as errors.

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -44,7 +44,7 @@ endif # BUILD_MANPAGES
 # see https://media.readthedocs.org/pdf/sphinx/1.6.3/sphinx.pdf
 # section 24.3.2 around page 247, third item for 'NotImplementedError', so this is kind of useless.
 
-ALLSPHINXOPTS   = $(SPHINXOPTS)
+ALLSPHINXOPTS   = $(SPHINXOPTS) -W
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(SPHINXOPTS)
 

--- a/doc/developer-guide/api/functions/TSSslSecret.en.rst
+++ b/doc/developer-guide/api/functions/TSSslSecret.en.rst
@@ -34,7 +34,7 @@ Description
 
 :func:`TSSslSecretSet` updates the current secret map. Generally the secret name corresponds to the name of a certificate or a key.
 Future creation of SSL_CTX objects that use the secret will use the newly specified data. It can be useful to call this function
-from the :data:`TS_LIFECYCLE_SSL_SECRET_HOOK`.
+from the :cpp:enumerator:`TS_LIFECYCLE_SSL_SECRET_HOOK`.
 
 TSSslSecretGet
 **************
@@ -67,7 +67,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: TSReturnCode TSSslSecretGet(const char * secret_name, int secret_name_length)
+.. function:: TSReturnCode TSSslSecretUpdate(const char * secret_name, int secret_name_length)
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -187,6 +187,26 @@ more widely. Those are described on this page.
 
       Flag for using the remapped URL as an explicit redirection. This can be set by the remap plugin.
 
+.. type:: TSSecretID
+
+   Contains the data for a TLS certificate and key.
+
+   .. member:: const char * cert_name;
+
+      The TLS certificate name.
+
+   .. member:: size_t cert_name_len;
+
+      The length of the TLS certificate name.
+
+   .. member:: const char * key_name;
+
+      The name of the TLS key.
+
+   .. member:: size_t key_name_len;
+
+      The length of the name of the TLS key.
+
 .. type:: TSSslX509
 
     This type represents the :code:`X509` object created from an SSL certificate.


### PR DESCRIPTION
It's easy to introduce warnings in the doc build without noticing them
due to the amount of output from the build. This changes the
sphinx-build invocation to treat any warnings we introduce as errors so
that such problems will get caught.

It also fixes a handful of warnings that got introduced recently as
well. With this patch, the build runs cleanly without warnings.