### PR TITLE
Do not merge: Test CI doc build

### DIFF
--- a/doc/developer-guide/api/functions/TSSslSecret.en.rst
+++ b/doc/developer-guide/api/functions/TSSslSecret.en.rst
@@ -67,7 +67,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: TSReturnCode TSSslSecretUpdate(const char * secret_name, int secret_name_length)
+.. function:: TSReturnCode TSSslSecretGet(const char * secret_name, int secret_name_length)
 
 Description
 ===========


### PR DESCRIPTION
Intentionally introducing a warning back in to verify that our PR CI doc
build fails if warnings are introduced.