### PR TITLE
For test async_engine, export all symbols

### DIFF
--- a/tests/gold_tests/logging/log-filenames.test.py
+++ b/tests/gold_tests/logging/log-filenames.test.py
@@ -124,7 +124,7 @@ class LogFilenamesTest:
         tr = Test.AddTestRun(f'Run traffic for: {description}')
         tr.Processes.Default.Command = (
             f'curl http://127.0.0.1:{self.ts.Variables.port}/some/path --verbose --next '
-            f'curl http://127.0.0.1:{self.ts.Variables.port}/server/down --verbose'
+            f'http://127.0.0.1:{self.ts.Variables.port}/server/down --verbose'
         )
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.StartBefore(self.ts)

--- a/tests/tools/plugins/Makefile.inc
+++ b/tests/tools/plugins/Makefile.inc
@@ -80,4 +80,9 @@ tools_plugins_user_args_la_SOURCES = tools/plugins/user_args.cc
 
 noinst_LTLIBRARIES += tools/plugins/async_engine.la
 tools_plugins_async_engine_la_SOURCES = tools/plugins/async_engine.cc
+tools_plugins_async_engine_la_LDFLAGS = \
+  -module \
+  -shared \
+  -avoid-version \
+  -rpath $(abs_builddir)
 


### PR DESCRIPTION
  This fixes the test run for tls_engine on macOS
