### PR TITLE
Fix uri_signing unit test for out of source builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1410,7 +1410,7 @@ TS_CHECK_BROTLI
 TS_CHECK_LUAJIT
 
 #
-# Enable experimental/uri_singing plugin
+# Enable experimental/uri_signing plugin
 # This is here, instead of above, because it needs to know if PCRE is available.
 #
 

--- a/plugins/experimental/uri_signing/Makefile.inc
+++ b/plugins/experimental/uri_signing/Makefile.inc
@@ -30,7 +30,12 @@ experimental_uri_signing_uri_signing_la_LIBADD = @LIBJANSSON@ @LIBCJOSE@ @LIBPCR
 
 check_PROGRAMS += experimental/uri_signing/test_uri_signing
 
-experimental_uri_signing_test_uri_signing_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DURI_SIGNING_UNIT_TEST
+experimental_uri_signing_test_uri_signing_CPPFLAGS = \
+  $(AM_CPPFLAGS) \
+  -I$(abs_top_srcdir)/tests/include \
+  -DURI_SIGNING_UNIT_TEST \
+  -DSRCDIR=\"$(srcdir)\"
+
 experimental_uri_signing_test_uri_signing_LDADD = @LIBJANSSON@ @LIBCJOSE@ @LIBPCRE@ -lm -lcrypto
 experimental_uri_signing_test_uri_signing_SOURCES = \
 	experimental/uri_signing/unit_tests/uri_signing_test.cc \

--- a/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
+++ b/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
@@ -571,7 +571,7 @@ TEST_CASE("7", "[TestsConfig]")
 
   SECTION("Config Loading ID Field")
   {
-    struct config *cfg = read_config("experimental/uri_signing/unit_tests/testConfig.config");
+    struct config *cfg = read_config(SRCDIR "/experimental/uri_signing/unit_tests/testConfig.config");
     REQUIRE(cfg != NULL);
     REQUIRE(strcmp(config_get_id(cfg), "tester") == 0);
     config_delete(cfg);
@@ -603,7 +603,7 @@ jws_validation_helper(const char *url, const char *package, struct config *cfg)
 TEST_CASE("8", "[TestsWithConfig]")
 {
   INFO("TEST 8, Tests Involving Validation with Config");
-  struct config *cfg = read_config("experimental/uri_signing/unit_tests/testConfig.config");
+  struct config *cfg = read_config(SRCDIR "/experimental/uri_signing/unit_tests/testConfig.config");
 
   SECTION("Validation of Valid Aud String in JWS")
   {


### PR DESCRIPTION
The URI signing plugin unit test accesses a config file in the source
directory. This works fine for in-source builds, but did not for out of
source. This updates the Makefile and unit test so that the file is
accessible for out of source builds.