### PR TITLE
Add PS debug to store requesting URL and add to notes

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -115,8 +115,9 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result, uns
     result->rec          = extApiRecord;
     result->start_parent = 0;
     result->last_parent  = 0;
-
-    Debug("parent_select", "Result for %s was API set parent %s:%d", rdata->get_host(), result->hostname, result->port);
+    result->url          = rdata->get_string();
+    Debug("parent_select", "Result for %s(%s) was API set parent %s:%d", rdata->get_host(), result->url, result->hostname,
+          result->port);
     return;
   }
 
@@ -125,6 +126,9 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result, uns
 
   tablePtr->Match(rdata, result);
   rec = result->rec;
+
+  // Set the result url string to store the URL request that initiated this
+  result->url = rdata->get_string();
 
   if (rec == nullptr) {
     // No parents were found

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -115,9 +115,9 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result, uns
     result->rec          = extApiRecord;
     result->start_parent = 0;
     result->last_parent  = 0;
-    result->url          = rdata->get_string();
-    Debug("parent_select", "Result for %s(%s) was API set parent %s:%d", rdata->get_host(), result->url, result->hostname,
-          result->port);
+    result->url          = rdata->get_host();
+
+    Debug("parent_select", "Result for %s was API set parent %s:%d", rdata->get_host(), result->hostname, result->port);
     return;
   }
 
@@ -125,10 +125,8 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result, uns
   result->reset();
 
   tablePtr->Match(rdata, result);
-  rec = result->rec;
-
-  // Set the result url string to store the URL request that initiated this
-  result->url = rdata->get_string();
+  rec         = result->rec;
+  result->url = rdata->get_host();
 
   if (rec == nullptr) {
     // No parents were found
@@ -147,23 +145,21 @@ ParentConfigParams::findParent(HttpRequestData *rdata, ParentResult *result, uns
     selectParent(true, result, rdata, fail_threshold, retry_time);
   }
 
-  const char *host = rdata->get_host();
-
   switch (result->result) {
   case PARENT_UNDEFINED:
     Debug("parent_select", "PARENT_UNDEFINED");
-    Debug("parent_select", "Result for %s was %s", host, ParentResultStr[result->result]);
+    Debug("parent_select", "Result for %s was %s", result->url, ParentResultStr[result->result]);
     break;
   case PARENT_FAIL:
     Debug("parent_select", "PARENT_FAIL");
     break;
   case PARENT_DIRECT:
     Debug("parent_select", "PARENT_DIRECT");
-    Debug("parent_select", "Result for %s was %s", host, ParentResultStr[result->result]);
+    Debug("parent_select", "Result for %s was %s", result->url, ParentResultStr[result->result]);
     break;
   case PARENT_SPECIFIED:
     Debug("parent_select", "PARENT_SPECIFIED");
-    Debug("parent_select", "Result for %s was parent %s:%d", host, result->hostname, result->port);
+    Debug("parent_select", "Result for %s was parent %s:%d", result->url, result->hostname, result->port);
     break;
   default:
     // Handled here:

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -185,6 +185,7 @@ struct ParentResult {
   // For outside consumption
   ParentResultType result;
   const char *hostname;
+  const char *url;
   int port;
   bool retry;
   bool chash_init[MAX_GROUP_RINGS] = {false};

--- a/proxy/ParentSelectionStrategy.cc
+++ b/proxy/ParentSelectionStrategy.cc
@@ -74,7 +74,6 @@ ParentSelectionStrategy::markParentDown(ParentResult *result, unsigned int fail_
 
     Note("Parent %s marked as down %s:%d for request %s", (result->retry) ? "retry" : "initially", pRec->hostname, pRec->port,
          result->url);
-
   } else {
     int old_count = 0;
     now           = time(nullptr);

--- a/proxy/ParentSelectionStrategy.cc
+++ b/proxy/ParentSelectionStrategy.cc
@@ -72,7 +72,8 @@ ParentSelectionStrategy::markParentDown(ParentResult *result, unsigned int fail_
       }
     }
 
-    Note("Parent %s marked as down %s:%d", (result->retry) ? "retry" : "initially", pRec->hostname, pRec->port);
+    Note("Parent %s marked as down %s:%d for request %s", (result->retry) ? "retry" : "initially", pRec->hostname, pRec->port,
+         result->url);
 
   } else {
     int old_count = 0;
@@ -93,8 +94,8 @@ ParentSelectionStrategy::markParentDown(ParentResult *result, unsigned int fail_
   }
 
   if (new_fail_count > 0 && new_fail_count >= static_cast<int>(fail_threshold)) {
-    Note("Failure threshold met failcount:%d >= threshold:%d, http parent proxy %s:%d marked down", new_fail_count, fail_threshold,
-         pRec->hostname, pRec->port);
+    Note("Failure threshold met failcount:%d >= threshold:%d, http parent proxy %s:%d marked down with request: %s", new_fail_count,
+         fail_threshold, pRec->hostname, pRec->port, result->url);
     pRec->available = false;
     Debug("parent_select", "Parent %s:%d marked unavailable, pRec->available=%d", pRec->hostname, pRec->port,
           pRec->available.load());
@@ -131,6 +132,6 @@ ParentSelectionStrategy::markParentUp(ParentResult *result)
   pRec->retriers = 0;
 
   if (old_count > 0) {
-    Note("http parent proxy %s:%d restored", pRec->hostname, pRec->port);
+    Note("http parent proxy %s:%d restored with request %s", pRec->hostname, pRec->port, result->url);
   }
 }


### PR DESCRIPTION
Parent mark down/up does not currently log the url of the request that caused the marking. This makes it hard to debug production issues when you have multiple parents and dest_domains being used, there is not a way currently to know which of them may be having an issue since the URL is not logged.

This adds a reference the requests http string, which is then used in the mark down/up notes that print out