### PR TITLE
Perf: Introduce TSMimeHdrFieldFast* APIs

### DIFF
--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -168,6 +168,15 @@ typedef struct {
 } TSPluginMsg;
 
 /**
+    A struct to avoid heap allocations in TSMimeHdrField* APIs
+  */
+typedef struct {
+  uint8_t _d[24]; // private
+} TSHdrHandle;
+
+#define TS_MLOC_FROM_HDR_HANDLE(HH_) ((TSMLoc)((HH_)._d))
+
+/**
     This set of enums are possible values returned by
     TSHttpHdrParseReq() and TSHttpHdrParseResp().
 

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1062,6 +1062,11 @@ tsapi TSReturnCode TSMimeHdrFieldValueDateInsert(TSMBuffer bufp, TSMLoc hdr, TSM
 
 tsapi TSReturnCode TSMimeHdrFieldValueDelete(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int idx);
 
+// TSHdrHandle APIs
+tsapi bool TSMimeHdrFieldIsEmptyHandler(TSHdrHandle handle);
+tsapi TSHdrHandle TSMimeHdrFieldFastFind(TSMBuffer bufp, TSMLoc hdr, const char *name, int length);
+tsapi TSHdrHandle TSMimeHdrFieldFastNextDup(TSMBuffer bufp, TSMLoc hdr, TSHdrHandle handle);
+
 /* --------------------------------------------------------------------------
    HTTP headers */
 tsapi TSHttpParser TSHttpParserCreate(void);


### PR DESCRIPTION
# Proposal 
Add new TSMimeHdrFieldFast* APIs which don't allocate `MIMEFieldSDKHandle`.
```
tsapi size_t TSMimeHdrFieldFastMLocSize();
tsapi TSReturnCode TSMimeHdrFieldFastFind(TSMBuffer bufp, TSMLoc hdr, const char *name, int length, TSMLoc *locp);
tsapi TSReturnCode TSMimeHdrFieldFastCreateNamed(TSMBuffer bufp, TSMLoc mh_mloc, const char *name, int name_len, TSMLoc *locp);
tsapi TSReturnCode TSMimeHdrFieldFastNextDup(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, TSMLoc *locp);
```

The changes in `plugins/header_rewrite/operators.cc` demonstrate how to use them. Currently, `add-header`, `set-header` and `rm-header` are improved. If we agree with this approach, I'll expand support later.

# Background

@c-taylor said, "every new header-rewrite condition you add, loses about 20,000 RPS". We looked at perf and the bottleneck is `MIMEFieldSDKHandle` allocation in `TSMimeHdrField*` APIs.
```
-    1.88%  [ET_NET 5]       libtscore.so.8.1.2       [.] freelist_new
     freelist_new                                                     
   - ink_freelist_new                                                 
      - 1.87% ClassAllocator<MIMEFieldSDKHandle>::alloc (inlined)     
         - sdk_alloc_field_handle (inlined)                           
            - 1.20% TSMimeHdrFieldCreateNamed                         
              0.67% TSMimeHdrFieldFind
```

It looks like we can avoid these expensive allocations by using a dynamic buffer on the stack. Because the allocated memory is released immediately. This change is a bit hacky but no allocation on the heap is the best choice from the performance perspective.

- e.g. `TSMimeHdrFieldCreateNamed` and `add-header` of header_rewrite
https://github.com/apache/trafficserver/blob/3412c4f69552b10779cfe0ce1bc6a71971734491/src/traffic_server/InkAPI.cc#L3148
https://github.com/apache/trafficserver/blob/3412c4f69552b10779cfe0ce1bc6a71971734491/plugins/header_rewrite/operators.cc#L613-L618

# Benchmark

@c-taylor measured the performance of this change with several traffic patterns. We got 50 - 70 % improvement on Keep-Alive traffic. No big difference on no Keep-Alive traffic but it's other issues.

----

Update: I forgot to mention this benchmark also has the xdebug plugin and improvements of it.

----

## Conditions
- AMD EPYC 7502P
- ATS 8.1.2, 28 thread, affinity 3
- header_rewrite plugin with 2 `add-header` & 2 `set-header`
- xdebug plugin
- openssl-1.1.1x

## Before
```
noKA:		108900
noKA-tls:	13500
KA:	     	112400
KA-tls:		114700
KA-tls-h2:	116300
```

## After
```
noKA:           109100
noKA-tls:       13400
KA:             184900
KA-tls:         196700
KA-tls-h2:      178000
```