### PR TITLE
Allow for unlimited ProxyAllocator sizes

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4596,7 +4596,7 @@ Sockets
 .. ts:cv:: CONFIG proxy.config.allocator.thread_freelist_size INT 512
 
    Sets the maximum number of elements that can be contained in a ProxyAllocator (per-thread)
-   before returning the objects to the global pool
+   before returning the objects to the global pool. If set to ``0``, there is no limit enforced.
 
 .. ts:cv:: CONFIG proxy.config.allocator.thread_freelist_low_watermark INT 32
 

--- a/iocore/eventsystem/I_ProxyAllocator.h
+++ b/iocore/eventsystem/I_ProxyAllocator.h
@@ -83,16 +83,16 @@ void thread_freeup(Allocator &a, ProxyAllocator &l);
 
 #endif
 
-#define THREAD_FREE(_p, _a, _t)                              \
-  do {                                                       \
-    ::_a.destroy_if_enabled(_p);                             \
-    if (!cmd_disable_pfreelist) {                            \
-      *(char **)_p    = (char *)_t->_a.freelist;             \
-      _t->_a.freelist = _p;                                  \
-      _t->_a.allocated++;                                    \
-      if (_t->_a.allocated > thread_freelist_high_watermark) \
-        thread_freeup(::_a.raw(), _t->_a);                   \
-    } else {                                                 \
-      ::_a.raw().free_void(_p);                              \
-    }                                                        \
+#define THREAD_FREE(_p, _a, _t)                                                                    \
+  do {                                                                                             \
+    ::_a.destroy_if_enabled(_p);                                                                   \
+    if (!cmd_disable_pfreelist) {                                                                  \
+      *(char **)_p    = (char *)_t->_a.freelist;                                                   \
+      _t->_a.freelist = _p;                                                                        \
+      _t->_a.allocated++;                                                                          \
+      if (thread_freelist_high_watermark > 0 && _t->_a.allocated > thread_freelist_high_watermark) \
+        thread_freeup(::_a.raw(), _t->_a);                                                         \
+    } else {                                                                                       \
+      ::_a.raw().free_void(_p);                                                                    \
+    }                                                                                              \
   } while (0)


### PR DESCRIPTION
This may be necessary if we want to add an option to have iobuffer's using Proxy Allocators as well, and honestly, is a nicer way to configure "unlimited" proxy allocators rather than setting an arbitrarily large value.