### PR TITLE
Fixed spelling mistakes in code and other files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -502,7 +502,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  * The implementation was written so as to conform with Netscapes SSL.
  *
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
+ * the following conditions are adhered to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -527,7 +527,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
@@ -545,7 +545,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * The licence and distribution terms for any publically available version or
+ * The licence and distribution terms for any publicly available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]

--- a/README-EC2
+++ b/README-EC2
@@ -26,7 +26,7 @@ Author: Jason Giedymin
 -------
 
 1.0 Ubuntu Based Images
-  This is the prefered image as Ubuntu is kept up to date by Canonical.
+  This is the preferred image as Ubuntu is kept up to date by Canonical.
 
 1.1 Ubuntu AMI Details
   Name: Amuxbit-Karmic-ApacheTrafficServer-AMI

--- a/build/ax_lib_curl.m4
+++ b/build/ax_lib_curl.m4
@@ -8,7 +8,7 @@
 #
 # DESCRIPTION
 #
-#   Checks for minimum curl library version VERSION. If successfull executes
+#   Checks for minimum curl library version VERSION. If successful executes
 #   ACTION-IF-SUCCESS otherwise ACTION-IF-FAILURE.
 #
 #   Defines CURL_LIBS and CURL_CFLAGS.

--- a/ci/jenkins/bin/gh-mirror.sh
+++ b/ci/jenkins/bin/gh-mirror.sh
@@ -53,7 +53,7 @@ function checkBuild() {
 	# Check if commits have doc/ changes
 	echo -n "$diff" | ${GREP} -F -e doc/ >/dev/null
 	if [ 0 == $? ]; then
-		echo "Triggerd Docs build for ${branch}"
+		echo "Triggered Docs build for ${branch}"
 		${CURL} -o /dev/null -s ${BASE_URL}/job/docs-${branch}/${token}
 	fi
 

--- a/ci/jenkins/git-jenkins-setup.sh
+++ b/ci/jenkins/git-jenkins-setup.sh
@@ -46,7 +46,7 @@ fi
     done
 )
 
-# The directory names corresponsing to the branches should match the names
+# The directory names corresponding to the branches should match the names
 # used by jenkins; see jobs.yaml.
 branch trafficserver_3.2 3.2.x
 branch trafficserver_4 4.1.x

--- a/configs/strategies.schema.json
+++ b/configs/strategies.schema.json
@@ -9,7 +9,7 @@
             "properties": {
                 "hosts": {
                     "type": "array",
-                    "description": "An array of hosts assinged to a group",
+                    "description": "An array of hosts assigned to a group",
                     "items": {
                         "$ref": "#/definitions/Host"
                     }

--- a/configs/strategies.yaml.default
+++ b/configs/strategies.yaml.default
@@ -14,7 +14,7 @@
 #   'hosts' is a YAML list of host's definitions and is used when defining 'groups' YAML
 #     references are supported.
 #   'groups' is a YAML list that aggregates a group of hosts together and serves as the
-#     equivalent to the rings used in parent.config.  You may define upto five groups in a
+#     equivalent to the rings used in parent.config.  You may define up to five groups in a
 #     config, see MAX_GROUPS.
 #   'strategies' is a YAML list of strategy definitions.
 #
@@ -96,7 +96,7 @@
 #     go_direct: true # transactions may routed directly to the origin true/false default is true.
 #     parent_is_proxy: false  # next hop hosts  are origin servers when set to 'false', defaults to true and indicates next hop hosts are ats cache's.
 #     cache_peer_result: true # only used when the 'ring_mode' is set to 'peering_ring' and the policy is 'consistent_hash'.  The default value is
-#                        true which means to always allow caching responses.  When set to 'false' reponses received from peer hosts will not be
+#                        true which means to always allow caching responses.  When set to 'false' responses received from peer hosts will not be
 #                        cached, only responses received from upstream parents or origins will be cached.
 #     groups: # groups of hosts, these groups are used as rings in consistent hash and arrays of host groups for round_robin.
 #       - *g1

--- a/configure.ac
+++ b/configure.ac
@@ -428,7 +428,7 @@ AC_ARG_ENABLE([hwloc],
 AC_MSG_RESULT([$enable_hwloc])
 
 #
-# Enble ccache explicitly (it's disabled by default, because of build problems in some cases)
+# Enable ccache explicitly (it's disabled by default, because of build problems in some cases)
 #
 AC_MSG_CHECKING([whether to enable ccache])
 AC_ARG_ENABLE([ccache],
@@ -439,7 +439,7 @@ AC_ARG_ENABLE([ccache],
 AC_MSG_RESULT([$enable_ccache])
 
 #
-# Enble hardening of the executables
+# Enable hardening of the executables
 #
 AC_MSG_CHECKING([whether to enable hardening of the executables])
 AC_ARG_ENABLE([hardening],
@@ -1113,7 +1113,7 @@ if test "x${GCC}" = "xyes"; then
   fi
 fi
 
-# Overrride detected architecture with the user suplied one
+# Override detected architecture with the user supplied one
 #
 AC_ARG_WITH(architecture, [AC_HELP_STRING([--with-architecture=ARCH],[use a specific CPU architecture])],
 [
@@ -1165,7 +1165,7 @@ AS_IF([test "x${enable_hardening}" = "xyes"], [
 
 #
 # Note:  These are site-specific macro's that do various tests
-#         on the selected compilers.  There was some tunning
+#         on the selected compilers.  There was some tuning
 #         associated with our not wanting to use GNU for _everything_.
 # Note:  This macro may set certain parameters when run.
 #
@@ -1198,7 +1198,7 @@ AC_CHECK_FUNCS([pthread_mutexattr_settype])
 dnl XXX The following check incorrectly causes the build to succeed
 dnl on Darwin. We should be using AC_SEARCH_LIBS, but rest_init is
 dnl actually present in libsystem. We are searching for the library
-dnl that contains the full Bind 9 API (which is acutally libresolv).
+dnl that contains the full Bind 9 API (which is actually libresolv).
 dnl However, the resolv API uses macros to rename it's APIs to per-version
 dnl symbols, so standard autoconf macros cannot reasonably be used to
 dnl check for it. We need to write custom macros to detect it properly.
@@ -2211,7 +2211,7 @@ AC_SUBST([iocore_include_dirs])
 # TS_INCLUDES *not* to AM_CPPFLAGS. If you add then to AM_CPPFLAGS
 # then they are always prepended to the local AM_CPPFLAGS which risks
 # name collisions with in-tree files. We always want the in-tree files
-# to have precendence.
+# to have precedence.
 AC_SUBST([TS_INCLUDES])
 
 AS_IF([test "x$RPATH" != "x"], [

--- a/contrib/install_trafficserver.sh
+++ b/contrib/install_trafficserver.sh
@@ -185,7 +185,7 @@ function rebuild() {
     make clean
 
     # Here is where things are dumb.  We don't check for
-    # successful builds yet.  Thats in the next release.
+    # successful builds yet.  That's in the next release.
     # This is why I call it dumb.
     make
     make uninstall

--- a/example/plugins/c-api/thread_pool/test/SynTest/Tests/Psi/psi_files/tc6_file.txt
+++ b/example/plugins/c-api/thread_pool/test/SynTest/Tests/Psi/psi_files/tc6_file.txt
@@ -1,1 +1,1 @@
-should keep the uncomplete tag and include nothing<!--incl
+should keep the incomplete tag and include nothing<!--incl

--- a/example/plugins/lua-api/modsecurity/ats-luajit-modsecurity.lua
+++ b/example/plugins/lua-api/modsecurity/ats-luajit-modsecurity.lua
@@ -138,7 +138,7 @@ end
 
 -- function run when response is received from origin
 function read_response()
-  -- retriving modsecurity object
+  -- retrieving modsecurity object
   local txn = ts.ctx["mst"]
 
   if(txn == nil) then

--- a/example/plugins/lua-api/modsecurity/owasp.conf
+++ b/example/plugins/lua-api/modsecurity/owasp.conf
@@ -23,7 +23,7 @@ SecRuleEngine On
 #SecAuditEngine On
 #SecAuditLog /tmp/audit.log
 
-# Uncomment the following 2 lines to enable debuging and put debug logs in /tmp/debug.log
+# Uncomment the following 2 lines to enable debugging and put debug logs in /tmp/debug.log
 #SecDebugLog /tmp/debug.log
 #SecDebugLogLevel 9
 

--- a/include/ts/InkAPIPrivateIOCore.h
+++ b/include/ts/InkAPIPrivateIOCore.h
@@ -105,7 +105,7 @@ public:
  * Any plugin using the IO Core must enter
  *   with a held mutex.  SDK 1.0, 1.1 & 2.0 did not
  *   have this restriction so we need to add a mutex
- *   to Plugin's Continuation if it trys to use the IOCore
+ *   to Plugin's Continuation if it tries to use the IOCore
  * Not only does the plugin have to have a mutex
  *   before entering the IO Core.  The mutex needs to be held.
  *   We now take out the mutex on each call to ensure it is

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -960,7 +960,7 @@ typedef struct {
   uint8_t priority_type; /** HTTP_PROTOCOL_TYPE_HTTP_2 */
   uint8_t weight;
   /** The stream dependency. Per spec, see RFC 7540 section 6.2, this is 31
-   * bits. We use a signed 32 bit stucture to store either a valid dependency
+   * bits. We use a signed 32 bit structure to store either a valid dependency
    * or -1 if the stream has no dependency. */
   int32_t stream_dependency;
 } TSHttp2Priority;

--- a/include/tscore/BufferWriter.h
+++ b/include/tscore/BufferWriter.h
@@ -515,7 +515,7 @@ namespace bw_fmt
   // MSVC will expand the parameter pack inside a lambda but not gcc, so this indirection is required.
 
   /// This selects the @a I th argument in the @a TUPLE arg pack and calls the formatter on it. This
-  /// (or the equivalent lambda) is needed because the array of formatters must have a homogenous
+  /// (or the equivalent lambda) is needed because the array of formatters must have a homogeneous
   /// signature, not vary per argument. Effectively this indirection erases the type of the specific
   /// argument being formatted. Instances of this have the signature @c ArgFormatterSignature.
   template <typename TUPLE, size_t I>

--- a/include/tscore/Errata.h
+++ b/include/tscore/Errata.h
@@ -9,7 +9,7 @@
     augmented as the error travels up the stack frame.
 
     This could be done with exceptions but
-    - That is more effort to implemention
+    - That is more effort to implementation
     - Generally more expensive.
 
     Each message on a stack contains text and a numeric identifier.
@@ -188,7 +188,7 @@ public:
 
   /** Push a constructed @c Message.
       The @c Message is set to have the @a id and @a code. The other arguments are converted
-      to strings and concatenated to form the messsage text.
+      to strings and concatenated to form the message text.
       @return A reference to this object.
   */
   template <typename... Args> self &push(Id id, Code code, Args const &... args);
@@ -313,7 +313,7 @@ public:
     SinkHandlerFunction m_f; ///< Client supplied handler.
   };
 
-  /// Register a sink function for abandonded erratum.
+  /// Register a sink function for abandoned erratum.
   static void
   registerSink(SinkHandlerFunction f)
   {
@@ -333,7 +333,7 @@ public:
    */
   std::ostream &write(std::ostream &out, ///< Output stream.
                       int offset,        ///< Lead white space for every line.
-                      int indent,        ///< Additional indention per line for messages.
+                      int indent,        ///< Additional indentation per line for messages.
                       int shift,         ///< Additional @a indent for nested @c Errata.
                       char const *lead   ///< Leading text for nested @c Errata.
   ) const;
@@ -342,7 +342,7 @@ public:
   size_t write(char *buffer,    ///< Output buffer.
                size_t n,        ///< Buffer size.
                int offset,      ///< Lead white space for every line.
-               int indent,      ///< Additional indention per line for messages.
+               int indent,      ///< Additional indentation per line for messages.
                int shift,       ///< Additional @a indent for nested @c Errata.
                char const *lead ///< Leading text for nested @c Errata.
   ) const;

--- a/include/tscore/Extendible.h
+++ b/include/tscore/Extendible.h
@@ -617,16 +617,16 @@ namespace details
   /// recursively init all extendible structures, and construct fields
   template <typename Derived_t>
   uintptr_t
-  initRecurseSuper(Derived_t &devired, uintptr_t tail_ptr /*= 0*/)
+  initRecurseSuper(Derived_t &derived, uintptr_t tail_ptr /*= 0*/)
   {
-    // track a tail pointer, that starts after the class, and interate each extendible block
+    // track a tail pointer, that starts after the class, and iterate each extendible block
     if constexpr (has_super_type<Derived_t>::value) {
       // init super type, move tail pointer
-      tail_ptr = initRecurseSuper<typename Derived_t::super_type>(devired, tail_ptr);
+      tail_ptr = initRecurseSuper<typename Derived_t::super_type>(derived, tail_ptr);
     }
     if constexpr (std::is_base_of<Extendible<Derived_t>, Derived_t>::value) {
       // set start for this extendible block after the previous extendible, and move tail pointer to after this block
-      tail_ptr = devired.Extendible<Derived_t>::initFields(tail_ptr);
+      tail_ptr = derived.Extendible<Derived_t>::initFields(tail_ptr);
     }
     return tail_ptr;
   }

--- a/include/tscore/I_Layout.h
+++ b/include/tscore/I_Layout.h
@@ -43,7 +43,7 @@ struct Layout {
 
   /**
    Setup the runroot for layout class
-   Return true if runroot is setup succesfully and false if runroot is not used
+   Return true if runroot is setup successfully and false if runroot is not used
    */
   bool runroot_setup();
 

--- a/include/tscore/NumericType.h
+++ b/include/tscore/NumericType.h
@@ -124,7 +124,7 @@ public:
   /// User conversion to implementation type.
   /// @internal If we have just a single const method conversion to a copy
   /// of the @c raw_type then the stream operators don't work. Only a CR
-  /// conversion operator satisifies the argument matching.
+  /// conversion operator satisfies the argument matching.
   operator raw_type const &() const { return _t; }
   /// User conversion to implementation type.
   operator raw_type &() { return _t; }

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1148,7 +1148,7 @@ uint32_t ats_ip_hash(sockaddr const *addr);
 
 uint64_t ats_ip_port_hash(sockaddr const *addr);
 
-/** Convert address to string as a hexidecimal value.
+/** Convert address to string as a hexadecimal value.
     The string is always nul terminated, the output string is clipped
     if @a dst is insufficient.
     @return The length of the resulting string (not including nul).

--- a/include/tscpp/api/Url.h
+++ b/include/tscpp/api/Url.h
@@ -119,7 +119,7 @@ public:
 
   /**
    * Set the port portion of the url.
-   * @param port this is a uint16_t which represents the port (in host order, there is no need to conver to network order). You
+   * @param port this is a uint16_t which represents the port (in host order, there is no need to convert to network order). You
    * might use a value such as 80 or 8080.
    */
   void setPort(const uint16_t);

--- a/include/tscpp/util/MemSpan.h
+++ b/include/tscpp/util/MemSpan.h
@@ -383,7 +383,7 @@ public:
 
 namespace detail
 {
-  /// Suport pointer distance calculations for all types, @b include @c <void*>.
+  /// Support pointer distance calculations for all types, @b include @c <void*>.
   /// This is useful in templates.
   inline size_t
   ptr_distance(void const *first, void const *last)

--- a/include/tscpp/util/TextView.h
+++ b/include/tscpp/util/TextView.h
@@ -75,7 +75,7 @@ int memcmp(const std::string_view &lhs, const std::string_view &rhs);
  * @code
  *   memcpy(dst, src.data(), size.size());
  * @endcode
- * Therefore @a dst must point at a buffer large enought to hold @a src. If this is not already
+ * Therefore @a dst must point at a buffer large enough to hold @a src. If this is not already
  * determined, then presuming @c DST_SIZE is the size of the buffer at @a dst
  * @code
  *   memcpy(dst, src.prefix(DST_SIZE));

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2587,7 +2587,7 @@ cplist_update()
 
     if (!config_vol) {
       // did not find a matching volume in the config file.
-      // Delete hte volume from the cache vol list
+      // Delete the volume from the cache vol list
       int d_no;
       for (d_no = 0; d_no < gndisks; d_no++) {
         if (cp->disk_vols[d_no]) {
@@ -2831,7 +2831,7 @@ cplist_reconfigure()
       }
 
       if (!config_vol->cachep) {
-        // we did not find a corresponding entry in cache vol...creat one
+        // we did not find a corresponding entry in cache vol...create one
 
         CacheVol *new_cp  = new CacheVol();
         new_cp->disk_vols = static_cast<DiskVol **>(ats_malloc(gndisks * sizeof(DiskVol *)));

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -170,7 +170,7 @@ public:
   Span(Span const &that)
   {
     /* I looked at simplifying this by changing the @c ats_scoped_str instances to @c std::string
-     * but that actually makes it worse. The copy constructor @b must be overriden to get the
+     * but that actually makes it worse. The copy constructor @b must be overridden to get the
      * internal link (@a link.next) correct. Given that, changing to @c std::string means doing
      * explicit assignment for every member, which has its own problems.
      */

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -243,7 +243,7 @@ inkcoreapi extern ClassAllocator<IOBufferData> ioDataAllocator;
   A linkable portion of IOBufferData. IOBufferBlock is a chainable
   buffer block descriptor. The IOBufferBlock represents both the used
   and available space in the underlying block. The IOBufferBlock is not
-  sharable between buffers but rather represents what part of the data
+  shareable between buffers but rather represents what part of the data
   block is both in use and usable by the MIOBuffer it is attached to.
 
 */

--- a/iocore/eventsystem/I_ProxyAllocator.h
+++ b/iocore/eventsystem/I_ProxyAllocator.h
@@ -69,14 +69,14 @@ void thread_freeup(Allocator &a, ProxyAllocator &l);
 
 #if 1
 
-// Potentially empty varaiable arguments -- non-standard GCC way
+// Potentially empty variable arguments -- non-standard GCC way
 //
 #define THREAD_ALLOC(_a, _t, ...) thread_alloc(::_a, _t->_a, ##__VA_ARGS__)
 #define THREAD_ALLOC_INIT(_a, _t, ...) thread_alloc(::_a, _t->_a, ##__VA_ARGS__)
 
 #else
 
-// Potentially empty varaiable arguments -- Standard C++20 way
+// Potentially empty variable arguments -- Standard C++20 way
 //
 #define THREAD_ALLOC(_a, _t, ...) thread_alloc(::_a, _t->_a __VA_OPT__(, ) __VA_ARGS__)
 #define THREAD_ALLOC_INIT(_a, _t, ...) thread_alloc(::_a, _t->_a __VA_OPT__(, ) __VA_ARGS__)

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -187,7 +187,7 @@ EThread::schedule_spawn(Continuation *c, int ev, void *cookie)
 TS_INLINE EThread *
 this_ethread()
 {
-  // The `dynamic_cast` has a significant performace impact (~6%).
+  // The `dynamic_cast` has a significant performance impact (~6%).
   // Reported by masaori and create PR #6281 to fix it.
   return static_cast<EThread *>(ink_thread_getspecific(ethread_key));
 }

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -55,7 +55,7 @@ int thread_max_heartbeat_mseconds = THREAD_MAX_HEARTBEAT_MSECONDS;
 //   1) Define an independent ink_thread_key
 //   2) Override Thread::set_specific()
 //   3) Define this_Xthread() which get thread specific data by the independent key
-//   4) Clear thread specific data at destructor funtion.
+//   4) Clear thread specific data at destructor function.
 //
 // The below comments are copied from I_Thread.h
 //

--- a/iocore/net/ALPNSupport.cc
+++ b/iocore/net/ALPNSupport.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  ALPNSupport.cc provides implmentations for ALPNSupport methods
+  ALPNSupport.cc provides implementations for ALPNSupport methods
 
   @section license License
 

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -77,7 +77,7 @@ public:
     /// Socket transmit buffer size.
     /// 0 => OS default.
     int send_bufsize;
-    /// defer accpet for @c sockopt.
+    /// defer accept for @c sockopt.
     /// 0 => OS default.
     int defer_accept;
     /// Socket options for @c sockopt.

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -149,7 +149,7 @@ protected:
    * @return @a this
    *
    * This is protected because it is not safe in the general case, but is valid for
-   * certain subclasses. Those provide a public assignemnt that depends on this method.
+   * certain subclasses. Those provide a public assignment that depends on this method.
    */
   Connection &operator=(Connection const &that) = default;
   void _cleanup();

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -56,7 +56,7 @@ public:
 
   /**
     This method tests whether this action would have been triggered by a
-    particuarly SNI value and IP address combination.  This is run after the
+    particularly SNI value and IP address combination.  This is run after the
     TLS exchange finished to see if the client used an SNI name different from
     the host name to avoid SNI-based policy
   */

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -125,7 +125,7 @@ struct EventIO {
    */
   int refresh(int events);
 
-  /// Remove the kernal or epoll event. Returns 0 on success.
+  /// Remove the kernel or epoll event. Returns 0 on success.
   int stop();
 
   /// Remove the epoll event and close the connection. Returns 0 on success.

--- a/iocore/net/P_UnixNetProcessor.h
+++ b/iocore/net/P_UnixNetProcessor.h
@@ -51,7 +51,7 @@ public:
   off_t netHandler_offset;
   off_t pollCont_offset;
 
-  // we probably wont need these members
+  // we probably won't need these members
   int n_netthreads;
   EThread **netthreads;
 };

--- a/iocore/net/QUICMultiCertConfigLoader.cc
+++ b/iocore/net/QUICMultiCertConfigLoader.cc
@@ -105,7 +105,7 @@ QUICMultiCertConfigLoader::_set_info_callback(SSL_CTX *ctx)
 bool
 QUICMultiCertConfigLoader::_set_npn_callback(SSL_CTX *ctx)
 {
-  // Do not set a callback for NPN since QUIC doens't use it
+  // Do not set a callback for NPN since QUIC doesn't use it
   return true;
 }
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -461,7 +461,7 @@ QUICNetVConnection::start()
   this->_frame_dispatcher->add_handler(this->_path_validator);
   this->_frame_dispatcher->add_handler(this->_handshake_handler);
 
-  // regist qlog
+  // register qlog
   if (this->_context->config()->qlog_dir() != nullptr) {
     this->_qlog = std::make_unique<QLog::QLogListener>(*this->_context, this->_original_quic_connection_id.hex());
     this->_qlog->last_trace().set_vantage_point(

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -482,7 +482,7 @@ SSLConfig::reconfigure()
   int loading_config_index        = get_loading_config_index();
   configids[loading_config_index] = configProcessor.set(configids[loading_config_index], params);
   params->initialize(); // re-read configuration
-  // Make the new config avaiable for use.
+  // Make the new config available for use.
   commit_config_id();
 }
 

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -216,7 +216,7 @@ SNIConfig::release(SNIConfigParams *params)
 
 // See if any of the client-side actions would trigger for this combination of servername and
 // client IP
-// host_sni_policy is an in/out paramter.  It starts with the global policy from the records.config
+// host_sni_policy is an in/out parameter.  It starts with the global policy from the records.config
 // setting proxy.config.http.host_sni_policy and is possibly overridden if the sni policy
 // contains a host_sni_policy entry
 bool

--- a/iocore/net/SSLSessionTicket.cc
+++ b/iocore/net/SSLSessionTicket.cc
@@ -53,8 +53,8 @@ ssl_callback_session_ticket(SSL *ssl, unsigned char *keyname, unsigned char *iv,
   if (srs) {
     return srs->processSessionTicket(ssl, keyname, iv, cipher_ctx, hctx, enc);
   } else {
-    // We could implement a default behavior that would have been done if this callback was not registred, but it's not necessary at
-    // the moment because TLSSessionResumptionSupport is alawys available when the callback is registerd.
+    // We could implement a default behavior that would have been done if this callback was not registered, but it's not necessary
+    // at the moment because TLSSessionResumptionSupport is alawys available when the callback is registerd.
     ink_assert(!"srs should be available");
 
     // For now, make it an error (this would cause handshake failure)

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -335,7 +335,7 @@ set_context_cert(SSL *ssl)
     SSL_CTX_set_tlsext_ticket_key_cb(ctx.get(), ssl_callback_session_ticket);
 #endif
 #endif
-    // After replacing the SSL_CTX, make sure the overriden ca_cert_file is still set
+    // After replacing the SSL_CTX, make sure the overridden ca_cert_file is still set
     setClientCertCACerts(ssl, netvc->get_ca_cert_file(), netvc->get_ca_cert_dir());
   } else {
     found = false;
@@ -1534,7 +1534,7 @@ SSLMultiCertConfigLoader::_prep_ssl_ctx(const shared_SSLMultiCertConfigParams ss
 }
 
 /**
-   Insert SSLCertContext (SSL_CTX ans options) into SSLCertLookup with key.
+   Insert SSLCertContext (SSL_CTX and options) into SSLCertLookup with key.
    Do NOT call SSL_CTX_set_* functions from here. SSL_CTX should be set up by SSLMultiCertConfigLoader::init_server_ssl_ctx().
  */
 bool
@@ -1966,7 +1966,7 @@ get_verify_str(SSL *ssl)
 
 /**
  * Process the config to pull out the list of file names, and process the certs to get the list
- * of subject and sni names.  Thanks to dual cert configurations, there may be mulitple files of each type.
+ * of subject and sni names.  Thanks to dual cert configurations, there may be multiple files of each type.
  * If some names are not in all the listed certs they are listed in the uniqe_names map, keyed by the index
  * of the including certificate
  */

--- a/iocore/net/TLSBasicSupport.cc
+++ b/iocore/net/TLSBasicSupport.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  TLSSBasicSupport.cc provides implmentations for
+  TLSSBasicSupport.cc provides implementations for
   TLSBasicSupport methods
 
   @section license License

--- a/iocore/net/TLSSNISupport.cc
+++ b/iocore/net/TLSSNISupport.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  SNISupport.cc provides implmentations for SNISupport methods
+  SNISupport.cc provides implementations for SNISupport methods
 
   @section license License
 

--- a/iocore/net/TLSSessionResumptionSupport.cc
+++ b/iocore/net/TLSSessionResumptionSupport.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  TLSSessionResumptionSupport.cc provides implmentations for
+  TLSSessionResumptionSupport.cc provides implementations for
   TLSSessionResumptionSupport methods
 
   @section license License

--- a/iocore/net/quic/QUICContext.h
+++ b/iocore/net/quic/QUICContext.h
@@ -84,7 +84,7 @@ public:
   virtual QUICRTTProvider *rtt_provider() const;
   virtual QUICPathManager *path_manager() const;
 
-  // regist a callback which will be called when specified event happen.
+  // register a callback which will be called when specified event happen.
   void
   regist_callback(std::shared_ptr<QUICCallback> cbs)
   {

--- a/lib/perl/lib/Apache/TS/Config/Records.pm
+++ b/lib/perl/lib/Apache/TS/Config/Records.pm
@@ -19,7 +19,7 @@
 # This is a simple module to let you read, modify and add to an Apache
 # Traffic Server records.config file. The idea is that you would write a
 # simple script (like example below) to update a "stock" records.config with
-# the changes applicable to your application. This allows you to uprade to
+# the changes applicable to your application. This allows you to upgrade to
 # a newer default config file from a new release. See the embedded
 # perldoc for more details.
 ############################################################################

--- a/lib/records/RecUtils.cc
+++ b/lib/records/RecUtils.cc
@@ -91,7 +91,7 @@ RecDataSetMax(RecDataT type, RecData *data)
     data->rec_float = FLT_MAX;
     break;
   default:
-    Fatal("unsupport type:%d\n", type);
+    Fatal("unsupported type:%d\n", type);
   }
 }
 
@@ -107,7 +107,7 @@ RecDataSetMin(RecDataT type, RecData *data)
     data->rec_float = FLT_MIN;
     break;
   default:
-    Fatal("unsupport type:%d\n", type);
+    Fatal("unsupported type:%d\n", type);
   }
 }
 
@@ -190,7 +190,7 @@ RecDataCmp(RecDataT type, RecData left, RecData right)
       return -1;
     }
   default:
-    Fatal("unsupport type:%d\n", type);
+    Fatal("unsupported type:%d\n", type);
     return 0;
   }
 }

--- a/lib/yamlcpp/src/scanner.cpp
+++ b/lib/yamlcpp/src/scanner.cpp
@@ -88,7 +88,7 @@ void Scanner::ScanNextToken() {
     return StartStream();
   }
 
-  // get rid of whitespace, etc. (in between tokens it should be irrelevent)
+  // get rid of whitespace, etc. (in between tokens it should be irrelevant)
   ScanToNextToken();
 
   // maybe need to end some blocks

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -620,7 +620,7 @@ static const RecordElement RecordsConfig[] =
   //
   //       #  required headers: three options
   //       #
-  //       #  0 - No required headers to make document cachable
+  //       #  0 - No required headers to make document cacheable
   //       #  1 - at least, "Last-Modified:" header required
   //       #  2 - explicit lifetime required, "Expires:" or "Cache-Control:"
   //       #

--- a/mgmt/WebMgmtUtils.cc
+++ b/mgmt/WebMgmtUtils.cc
@@ -102,8 +102,8 @@ varSetFromStr(const char *varName, const char *value)
 //
 //  Sets the variable specified by varName to value.  varName
 //   must be a RecFloat variable.  No conversion is done for
-//   other types unless convert is set to ture. In the case
-//   of convert is ture, type conversion is perform if applicable.
+//   other types unless convert is set to true. In the case
+//   of convert is true, type conversion is perform if applicable.
 //   By default, convert is set to be false and can be overridden
 //   when the function is called.
 //
@@ -153,8 +153,8 @@ varSetFloat(const char *varName, RecFloat value, bool convert)
 //
 //  Sets the variable specified by varName to value.  varName
 //   must be an RecCounter variable.  No conversion is done for
-//   other types unless convert is set to ture. In the case
-//   of convert is ture, type conversion is perform if applicable.
+//   other types unless convert is set to true. In the case
+//   of convert is true, type conversion is perform if applicable.
 //   By default, convert is set to be false and can be overridden
 //   when the function is called.
 //
@@ -203,8 +203,8 @@ varSetCounter(const char *varName, RecCounter value, bool convert)
 //
 //  Sets the variable specified by varName to value.  varName
 //   must be an RecInt variable.  No conversion is done for
-//   other types unless convert is set to ture. In the case
-//   of convert is ture, type conversion is perform if applicable.
+//   other types unless convert is set to true. In the case
+//   of convert is true, type conversion is perform if applicable.
 //   By default, convert is set to be false and can be overridden
 //   when the function is called.
 //
@@ -270,7 +270,7 @@ varSetData(RecDataT varType, const char *varName, RecData value)
     err = RecSetRecordFloat(const_cast<char *>(varName), value.rec_float, REC_SOURCE_EXPLICIT);
     break;
   default:
-    Fatal("unsupport type:%d\n", varType);
+    Fatal("unsupported type:%d\n", varType);
   }
   return (err == REC_ERR_OKAY);
 }

--- a/mgmt/YamlCfg.h
+++ b/mgmt/YamlCfg.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Utilites to help with parsing YAML files with good error reporting.
+  Utilities to help with parsing YAML files with good error reporting.
 
   @section license License
 

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -989,7 +989,7 @@ done:
 /**************************************************************************
  * handle_lifecycle_message
  *
- * purpose: handle lifecyle message to plugins
+ * purpose: handle lifecycle message to plugins
  * output: TS_ERR_xx
  * note: None
  *************************************************************************/

--- a/plugins/cache_promote/cache_promote.cc
+++ b/plugins/cache_promote/cache_promote.cc
@@ -28,7 +28,7 @@ const char *PLUGIN_NAME = "cache_promote";
 int TXN_ARG_IDX;
 
 // This has to be a global here. I tried doing a classic singleton (with a getInstance()) in the PolicyManager,
-// but then reloading the DSO does not work. What happens is that the old singleton is stil there, even though
+// but then reloading the DSO does not work. What happens is that the old singleton is still there, even though
 // the rest of the plugin is reloaded. Very scary, and not what we need / want; if the plugin reloads, the
 // PolicyManager has to reload (and start fresh) as well.
 static PolicyManager gManager;

--- a/plugins/cache_promote/lru_policy.cc
+++ b/plugins/cache_promote/lru_policy.cc
@@ -137,7 +137,7 @@ LRUPolicy::doPromote(TSHttpTxn txnp)
     TSMBuffer request;
     TSMLoc req_hdr;
 
-    // This is beacuse compilers before gcc 8 aren't smart enough to ignore the unused structured bindings
+    // This is because compilers before gcc 8 aren't smart enough to ignore the unused structured bindings
     (void)val_key;
 
     // We check that the request is cacheable, we will still count the request, but if not cacheable, we
@@ -239,7 +239,7 @@ LRUPolicy::addBytes(TSHttpTxn txnp)
           auto &[val_key, val_hits, val_bytes] = *(map_it->second);
           int64_t cl                           = TSMimeHdrFieldValueInt64Get(resp, resp_hdr, field_loc, -1);
 
-          // This is beacuse compilers before gcc 8 aren't smart enough to ignore the unused structured bindings
+          // This is because compilers before gcc 8 aren't smart enough to ignore the unused structured bindings
           (void)val_key, (void)val_hits;
 
           val_bytes += cl;

--- a/plugins/cachekey/cachekey.cc
+++ b/plugins/cachekey/cachekey.cc
@@ -383,7 +383,7 @@ CacheKey::appendPrefix(const String &prefix, Pattern &prefixCapture, Pattern &pr
   // "true" would mean that the plugin config meant to override the default prefix, "false" means use default.
   bool customPrefix = false;
 
-  /* For all the following operations if a canonical prefix is required then appned to the key with no separator
+  /* For all the following operations if a canonical prefix is required then append to the key with no separator
    * to leave the door open for potential valid host name formed in the final resulting cache key. */
 
   if (!prefix.empty()) {
@@ -753,7 +753,7 @@ CacheKey::finalize() const
   switch (_keyType) {
   case CACHE_KEY: {
     if (TS_SUCCESS == TSCacheUrlSet(_txn, &(_key[0]), _key.size())) {
-      /* Set cache key succesfully */
+      /* Set cache key successfully */
       msg.assign("set cache key to ").append(_key);
       res = true;
     } else {

--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -429,7 +429,7 @@ shadow_cert_generator(TSCont contp, TSEvent event, void *edata)
 
   struct stat st;
   FILE *fp = nullptr;
-  /// If directory doesn't exist, creat one
+  /// If directory doesn't exist, create one
   if (stat(path.c_str(), &st) == -1) {
     mkdir(path.c_str(), 0755);
   } else {

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -42,7 +42,7 @@ using namespace std;
 using namespace Gzip;
 
 // FIXME: custom dictionaries would be nice. configurable/content-type?
-// a GPRS device might benefit from a higher compression ratio, whereas a desktop w. high bandwith
+// a GPRS device might benefit from a higher compression ratio, whereas a desktop w. high bandwidth
 // might be served better with little or no compression at all
 // FIXME: look into compressing from the task thread pool
 // FIXME: make normalizing accept encoding configurable

--- a/plugins/experimental/access_control/unit_tests/test_utils.cc
+++ b/plugins/experimental/access_control/unit_tests/test_utils.cc
@@ -180,7 +180,7 @@ TEST_CASE("Base64: quick encode / decode with '+', '/' and various paddings", "[
     CHECK(0 == strncmp(encodedMessage, encoded[i], encodedMessageLen));
 
     /* Decode */
-    // Keep test around incase our implementation's estimation gets better
+    // Keep test around in case our implementation's estimation gets better
     // size_t decodedMessageEstimatedLen = cryptoBase64DecodeSize(encodedMessage, encodedMessageLen);
     // CHECK(strlen(decoded[i]) == decodedMessageEstimatedLen);
     char decodedMessage[encodedMessageEstimatedLen];

--- a/plugins/experimental/cookie_remap/cookie_remap.cc
+++ b/plugins/experimental/cookie_remap/cookie_remap.cc
@@ -773,7 +773,7 @@ public:
           TSDebug(MY_NAME, "we hashed in the range, yay!");
           continue; // we hashed in the range
         } else {
-          TSDebug(MY_NAME, "we didnt hash in the "
+          TSDebug(MY_NAME, "we didn't hash in the "
                            "range requested, so "
                            "sad");
           retval &= 0;
@@ -1045,7 +1045,7 @@ sub_lookup(char const *targ, int targ_len)
   for (;;) {
     while ((targ_len < static_cast<int>(opt->comp.size())) || (std::string_view(targ, opt->comp.size()) != opt->comp)) {
       if (!--count) {
-        return 1; // Failed lookup, return some positive numver.
+        return 1; // Failed lookup, return some positive number.
       }
       ++opt;
     }

--- a/plugins/experimental/cookie_remap/strip.h
+++ b/plugins/experimental/cookie_remap/strip.h
@@ -37,7 +37,7 @@ extern "C" {
 #define STRIP_FLAG_LEAVE_WHITESP 0x4   /**< all: avoid trimming spaces */
 #define STRIP_FLAG_UNSAFE_QUOTES 0x8   /**< html: dont encode quotes */
 #define STRIP_FLAG_UNSAFE_SLASHES 0x10 /**< all: dont encode backslashes */
-#define STRIP_FLAG_UNSAFE_SPACES 0x20  /**< html: stripped tag isnt space */
+#define STRIP_FLAG_UNSAFE_SPACES 0x20  /**< html: stripped tag isn't space */
 
 /** Output the input after stripping all characters that are
  *  unsafe in an HTML context.

--- a/plugins/experimental/fastcgi/src/ats_fcgi_client.cc
+++ b/plugins/experimental/fastcgi/src/ats_fcgi_client.cc
@@ -79,7 +79,7 @@ FCGIClientRequest::FCGIClientRequest(int request_id, TSHttpTxn txn)
       atscppapi::header_field_iterator it = h.find(key);
       if (it != h.end()) {
         atscppapi::HeaderField hf(*it);
-        string value                             = hf.values(","); // delimeter for header values
+        string value                             = hf.values(","); // delimiter for header values
         state_->requestHeaders["CONTENT_LENGTH"] = value.c_str();
       }
 
@@ -87,7 +87,7 @@ FCGIClientRequest::FCGIClientRequest(int request_id, TSHttpTxn txn)
       it  = h.find(key);
       if (it != h.end()) {
         HeaderField hf1(*it);
-        string value                           = hf1.values(","); // delimeter for header values
+        string value                           = hf1.values(","); // delimiter for header values
         state_->requestHeaders["CONTENT_TYPE"] = value.c_str();
       }
     }
@@ -105,7 +105,7 @@ FCGIClientRequest::FCGIClientRequest(int request_id, TSHttpTxn txn)
 }
 
 // destructor will reset the client_req_id and delete the recListState_ object
-// holding respose records received from fcgi server
+// holding response records received from fcgi server
 FCGIClientRequest::~FCGIClientRequest()
 {
   if (_headerRecord)
@@ -578,7 +578,7 @@ FCGIClientRequest::fcgiProcessBuffer(uchar *beg_buf, uchar *end_buf, std::ostrin
                 atscppapi::header_field_iterator it = h.find(key);
                 if (it != h.end()) {
                   atscppapi::HeaderField hf(*it);
-                  string value = hf.values(","); // delimeter for header values
+                  string value = hf.values(","); // delimiter for header values
                   output << HTTP_VERSION_STRINGS[HTTP_VERSION_1_1] << " ";
                   output << value.c_str() << "\r\n";
                 } else {

--- a/plugins/experimental/fastcgi/src/configuru.hpp
+++ b/plugins/experimental/fastcgi/src/configuru.hpp
@@ -424,7 +424,7 @@ public:
   }
 
 // ----------------------------------------
-// Convertors:
+// Converters:
 
 #if CONFIGURU_IMPLICIT_CONVERSIONS
   /// Explicit casting, for overloads of as<T>
@@ -1382,7 +1382,7 @@ Config parse_file(const std::string &path, const FormatOptions &options, DocInfo
 // ----------------------------------------------------------
 /// Writes the config as a string in the given format.
 /// May call CONFIGURU_ONERROR if the given config is invalid. This can happen if
-/// a Config is unitialized (and options write_uninitialized is not set) or
+/// a Config is uninitialized (and options write_uninitialized is not set) or
 /// a Config contains inf/nan (and options.inf/options.nan aren't set).
 std::string dump_string(const Config &config, const FormatOptions &options);
 
@@ -2110,16 +2110,16 @@ Config::on_error(const std::string &msg) const
 }
 
 void
-Config::assert_type(Type exepected) const
+Config::assert_type(Type expected) const
 {
   if (_type == BadLookupType) {
     auto where = where_is(_u.bad_lookup->doc, _u.bad_lookup->line);
     CONFIGURU_ONERROR(where + "Failed to find key '" + _u.bad_lookup->key + "'");
-  } else if (_type != exepected) {
-    const auto message = where() + "Expected " + type_str(exepected) + ", got " + type_str(_type);
-    if (_type == Uninitialized && exepected == Object) {
+  } else if (_type != expected) {
+    const auto message = where() + "Expected " + type_str(expected) + ", got " + type_str(_type);
+    if (_type == Uninitialized && expected == Object) {
       CONFIGURU_ONERROR(message + ". Did you forget to call Config::object()?");
-    } else if (_type == Uninitialized && exepected == Array) {
+    } else if (_type == Uninitialized && expected == Array) {
       CONFIGURU_ONERROR(message + ". Did you forget to call Config::array()?");
     } else {
       CONFIGURU_ONERROR(message);

--- a/plugins/experimental/fastcgi/src/server_connection.cc
+++ b/plugins/experimental/fastcgi/src/server_connection.cc
@@ -132,7 +132,7 @@ ServerConnection::~ServerConnection()
     TSVConnClose(vc_);
     vc_ = nullptr;
   }
-  // XXX(oschaaf): check commmented line below.
+  // XXX(oschaaf): check commented line below.
   // readio.vio = writeio.vio = nullptr;
   _requestId    = 0;
   _max_requests = 0;

--- a/plugins/experimental/icap/icap_plugin.cc
+++ b/plugins/experimental/icap/icap_plugin.cc
@@ -702,7 +702,7 @@ transform_bypass(TSCont contp, TransformData *data)
 
 /*
  * transform_buffer_os_resp (Used only in debug-mode)
- * Description: Buffer resposne body from origin server.
+ * Description: Buffer response body from origin server.
  */
 static int
 transform_buffer_os_resp(TSCont contp, TransformData *data)

--- a/plugins/experimental/magick/README
+++ b/plugins/experimental/magick/README
@@ -22,7 +22,7 @@ openssl genrsa -out rsa256-private 512;
 openssl rsa -in rsa256-private -pubout > rsa256-public;
 ```
 
-The `test.sh` script, helps verifing ImageMagick's convert works. The script outputs the right query parameter for you.
+The `test.sh` script, helps verifying ImageMagick's convert works. The script outputs the right query parameter for you.
 
 `
 

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -392,7 +392,7 @@ Acl::loaddb(const YAML::Node &dbNode)
 
   int status = MMDB_open(dbloc.c_str(), MMDB_MODE_MMAP, &_mmdb);
   if (MMDB_SUCCESS != status) {
-    TSDebug(PLUGIN_NAME, "Cant open DB %s - %s", dbloc.c_str(), MMDB_strerror(status));
+    TSDebug(PLUGIN_NAME, "Can't open DB %s - %s", dbloc.c_str(), MMDB_strerror(status));
     return false;
   }
 

--- a/plugins/experimental/mysql_remap/lib/dictionary.c
+++ b/plugins/experimental/mysql_remap/lib/dictionary.c
@@ -31,7 +31,7 @@
 
    This module implements a simple dictionary object, i.e. a list
    of string/string associations. This object is useful to store e.g.
-   informations retrieved from a configuration file (ini files).
+   information retrieved from a configuration file (ini files).
 */
 /*--------------------------------------------------------------------------*/
 
@@ -140,7 +140,7 @@ dictionary_hash(char *key)
 /**
   @brief	Create a new dictionary object.
   @param	size	Optional initial size of the dictionary.
-  @return	1 newly allocated dictionary objet.
+  @return	1 newly allocated dictionary object.
 
   This function allocates a new dictionary object of given size and returns
   it. If you do not know in advance (roughly) the number of entries in the

--- a/plugins/experimental/mysql_remap/lib/dictionary.h
+++ b/plugins/experimental/mysql_remap/lib/dictionary.h
@@ -31,7 +31,7 @@
 
    This module implements a simple dictionary object, i.e. a list
    of string/string associations. This object is useful to store e.g.
-   informations retrieved from a configuration file (ini files).
+   information retrieved from a configuration file (ini files).
 */
 /*--------------------------------------------------------------------------*/
 
@@ -97,7 +97,7 @@ unsigned dictionary_hash(char *key);
 /**
   @brief    Create a new dictionary object.
   @param    size    Optional initial size of the dictionary.
-  @return   1 newly allocated dictionary objet.
+  @return   1 newly allocated dictionary object.
 
   This function allocates a new dictionary object of given size and returns
   it. If you do not know in advance (roughly) the number of entries in the

--- a/plugins/experimental/parent_select/consistenthash.cc
+++ b/plugins/experimental/parent_select/consistenthash.cc
@@ -414,7 +414,7 @@ PLNextHopConsistentHash::next(TSHttpTxn txnp, void *strategyTxn, const char *exc
     pRec ? (TSHostStatusGet(pRec->hostname.c_str(), pRec->hostname.size(), &hostStatus, &hostReasons) == TS_SUCCESS) : false;
   host_stat = hostExists ? hostStatus : TSHostStatus::TS_HOST_STATUS_UP;
   // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-  // ignore the down status and mark it as avaialble
+  // ignore the down status and mark it as available
   if ((pRec && ignore_self_detect) && (hostExists && hostStatus == TS_HOST_STATUS_DOWN)) {
     if (hostReasons & TS_HOST_STATUS_SELF_DETECT) {
       host_stat = TS_HOST_STATUS_UP;
@@ -471,7 +471,7 @@ PLNextHopConsistentHash::next(TSHttpTxn txnp, void *strategyTxn, const char *exc
         host_stat = hostExists ? hostStatus : TSHostStatus::TS_HOST_STATUS_UP;
 
         // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-        // ignore the down status and mark it as avaialble
+        // ignore the down status and mark it as available
         if ((pRec && ignore_self_detect) && (hostExists && hostStatus == TS_HOST_STATUS_DOWN)) {
           if (hostReasons & TS_HOST_STATUS_SELF_DETECT) {
             host_stat = TS_HOST_STATUS_UP;

--- a/plugins/experimental/parent_select/consistenthash_config.cc
+++ b/plugins/experimental/parent_select/consistenthash_config.cc
@@ -145,7 +145,7 @@ createStrategiesFromFile(const char *file)
  * loads the contents of a file into a std::stringstream document.  If the file has a '#include file'
  * directive, that 'file' is read into the document beginning at the the point where the
  * '#include' was found. This allows the 'strategy' and 'hosts' yaml files to be separate.  The
- * 'strategy' yaml file would then normally have the '#include hosts.yml' in it's begining.
+ * 'strategy' yaml file would then normally have the '#include hosts.yml' in it's beginning.
  */
 void
 loadConfigFile(const std::string &fileName, std::stringstream &doc, std::unordered_set<std::string> &include_once)

--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -54,7 +54,7 @@ struct Config {
   // Parse from args, ast one wins
   bool fromArgs(int const argc, char const *const argv[]);
 
-  // Check if the error should can be logged, if sucessful may update m_nexttime
+  // Check if the error should can be logged, if successful may update m_nexttime
   bool canLogError();
 
   // Check if regex supplied

--- a/plugins/experimental/slice/README.md
+++ b/plugins/experimental/slice/README.md
@@ -69,7 +69,7 @@ with loopback remap host may be used by adding the '-r <hostname>' or
 Using the `--remap-host` option splits the plugin chain into 2 remap rules.
 One remap rule for all the incoming requests and the other for just the block
 range requests.  This allows for easier trouble shooting via logs and
-also allows for more effecient plugin rules.  The default pristine method
+also allows for more efficient plugin rules.  The default pristine method
 runs the remap plugins twice, one for the incoming request and one for
 eace slice.  Splitting the rules allows for plugins like URI signing to
 be done on the client request only.

--- a/plugins/experimental/slice/unit-tests/slice_test.cc
+++ b/plugins/experimental/slice/unit-tests/slice_test.cc
@@ -126,7 +126,7 @@ testParseRange()
 
   for (size_t index(0); index < gots.size(); ++index) {
     if (exps[index] != gots[index] || expsres[index] != gotsres[index]) {
-      oss << "Eror parsing index: " << index << std::endl;
+      oss << "Error parsing index: " << index << std::endl;
       oss << "test: '" << teststrings[index] << "'" << std::endl;
       oss << "exp: " << exps[index].m_beg << ' ' << exps[index].m_end << std::endl;
       oss << "expsres: " << (int)expsres[index] << std::endl;

--- a/plugins/experimental/ssl_session_reuse/src/common.h
+++ b/plugins/experimental/ssl_session_reuse/src/common.h
@@ -1,6 +1,6 @@
 /** @file
 
-  commmon.h - Things that need to be everywhere
+  common.h - Things that need to be everywhere
 
   @section license License
 

--- a/plugins/experimental/ssl_session_reuse/src/session_process.cc
+++ b/plugins/experimental/ssl_session_reuse/src/session_process.cc
@@ -122,7 +122,7 @@ decrypt_session(const std::string &encrypted_data, const unsigned char *key, int
       goto Cleanup;
     }
 
-    // If there is less data than the maxiumum buffer size, reduce accordingly
+    // If there is less data than the maximum buffer size, reduce accordingly
     if (ret < session_data_len) {
       session_data_len = ret;
     }

--- a/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
+++ b/plugins/experimental/ssl_session_reuse/src/ssl_key_utils.cc
@@ -75,7 +75,7 @@ isSTEKMaster()
  * This ensures proper key rotation.
  *
  * One node in the pod is configured to be Master STEK setter in charge of key rotations.
- * The alogrithm implemented allows for the POD to dynamically self configure a master
+ * The algorithm implemented allows for the POD to dynamically self configure a master
  * which can recover from death of master, misconfigurations, ultimately ineffective rotations.
  *
  * General description:
@@ -353,7 +353,7 @@ STEK_Update_Checker_Thread(void *arg)
 
   TSDebug(PLUGIN, "Starting STEK_Update_Checker_Thread.");
 
-  lastChangeTime = lastWarningTime = time(&currentTime); // init to current to supress a startup warning.
+  lastChangeTime = lastWarningTime = time(&currentTime); // init to current to suppress a startup warning.
   int check_count                  = 0;                  // Keep track of how many times we've checked whether we got a new STEK.
 
   while (!plugin_threads.shutdown) {
@@ -429,7 +429,7 @@ STEK_init_keys()
   //  Initialize starter Session Ticket Encryption Key
   //  Will sync up with master later
   if (!STEK_CreateNew(&initKey, 0, 0 /*fast start*/)) {
-    TSError("Cant init STEK.");
+    TSError("Can't init STEK.");
     return -1;
   }
   memcpy(&ssl_param.ticket_keys[0], &initKey, sizeof(struct ssl_ticket_key_t));

--- a/plugins/experimental/uri_signing/jwt.c
+++ b/plugins/experimental/uri_signing/jwt.c
@@ -159,14 +159,14 @@ jwt_check_aud(json_t *aud, const char *id)
   /* If aud is a string, do a simple string comparison */
   const char *aud_str = json_string_value(aud);
   if (aud_str) {
-    PluginDebug("Checking aud %s agaisnt token aud string \"%s\"", id, aud_str);
+    PluginDebug("Checking aud %s against token aud string \"%s\"", id, aud_str);
     /* Both strings will be null terminated per jansson docs */
     if (strcmp(aud_str, id) == 0) {
       return true;
     }
     return false;
   }
-  PluginDebug("Checking aud %s agaisnt token aud array", id);
+  PluginDebug("Checking aud %s against token aud array", id);
   /* If aud is an array, check all items */
   if (json_is_array(aud)) {
     size_t index;

--- a/plugins/experimental/url_sig/url_sig.c
+++ b/plugins/experimental/url_sig/url_sig.c
@@ -458,7 +458,7 @@ urlParse(char const *const url_in, char *anchor, char *new_path_seg, int new_pat
     } else {
       TSError("insufficient space to copy into new_path_seg buffer.");
     }
-  } else { // no signature anchor string was found, assum it is in the last path segment.
+  } else { // no signature anchor string was found, assume it is in the last path segment.
     if (strlen(segment[numtoks - 2]) < signed_seg_len) {
       memcpy(signed_seg, segment[numtoks - 2], strlen(segment[numtoks - 2]));
     } else {

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -500,7 +500,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   }
 
   // Now handle the remap specific rules for the "remap hook" (which is not a real hook).
-  // This is sufficiently differen than the normal cont_rewrite_headers() callback, and
+  // This is sufficiently different than the normal cont_rewrite_headers() callback, and
   // we can't (shouldn't) schedule this as a TXN hook.
   RuleSet *rule = conf->rule(TS_REMAP_PSEUDO_HOOK);
   Resources res(rh, rri);

--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -155,7 +155,7 @@ create_lua_vms()
     return NULL;
   }
 
-  // Initalize the GC numbers, no need to lock here
+  // Initialize the GC numbers, no need to lock here
   for (int index = 0; index < ts_lua_max_state_count; ++index) {
     ts_lua_main_ctx *const main_ctx = (ctx_array + index);
     lua_State *const lstate         = main_ctx->lua;

--- a/plugins/prefetch/headers.cc
+++ b/plugins/prefetch/headers.cc
@@ -80,7 +80,7 @@ headerExist(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
  * @param header header name
  * @param headerlen header name length
  * @param value buffer for the value
- * @param valuelen lenght of the buffer for the value
+ * @param valuelen length of the buffer for the value
  * @return pointer to the string with the value.
  */
 char *
@@ -129,7 +129,7 @@ getHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, char
  * @param header header name
  * @param headerlen header name len
  * @param value the new value
- * @param valuelen lenght of the value
+ * @param valuelen length of the value
  * @return true - OK, false - failed
  */
 bool

--- a/plugins/stats_over_http/stats_over_http.c
+++ b/plugins/stats_over_http/stats_over_http.c
@@ -194,10 +194,10 @@ init_gzip(stats_state *my_state, int mode)
   my_state->zstrm.data_type = Z_ASCII;
   int err = deflateInit2(&my_state->zstrm, ZLIB_COMPRESSION_LEVEL, Z_DEFLATED, mode, ZLIB_MEMLEVEL, Z_DEFAULT_STRATEGY);
   if (err != Z_OK) {
-    TSDebug(PLUGIN_NAME, "gzip intialization failed");
+    TSDebug(PLUGIN_NAME, "gzip initialization failed");
     return NONE;
   } else {
-    TSDebug(PLUGIN_NAME, "gzip initialized succesfully");
+    TSDebug(PLUGIN_NAME, "gzip initialized successfully");
     if (mode == GZIP_MODE) {
       return GZIP;
     } else if (mode == DEFLATE_MODE) {

--- a/plugins/xdebug/Cleanup.h
+++ b/plugins/xdebug/Cleanup.h
@@ -124,7 +124,7 @@ protected:
 
 using TxnAuxMgrData = TxnAuxDataMgrBase::MgrData;
 
-// Class to manage auxilliary data for a transaction.  If an instance is created for the transaction, the instance
+// Class to manage auxiliary data for a transaction.  If an instance is created for the transaction, the instance
 // will be deleted on the TXN_CLOSE transaction hook (which is always triggered for all transactions).
 // The TxnAuxData class must have a public default constructor.
 //

--- a/proxy/CacheControl.h
+++ b/proxy/CacheControl.h
@@ -83,7 +83,7 @@ public:
   //   Keeps track of the last line number
   //    on which a parameter was set
   //   Used to tell if a parameter needs to
-  //    be overriden by something that appeared
+  //    be overridden by something that appeared
   //    earlier in the the config file
   //
   int reval_line         = -1;

--- a/proxy/ControlMatcher.cc
+++ b/proxy/ControlMatcher.cc
@@ -156,7 +156,7 @@ HostMatcher<Data, MatchResult>::Match(RequestData *rdata, MatchResult *result) c
   Data *data_ptr;
   bool r;
 
-  // Check to see if there is any work to do before makeing
+  // Check to see if there is any work to do before making
   //   the string copy
   if (num_el <= 0) {
     return;
@@ -511,7 +511,7 @@ RegexMatcher<Data, MatchResult>::Match(RequestData *rdata, MatchResult *result) 
       Debug("matcher", "%s Matched %s with regex at line %d", matcher_name, url_str, data_array[i].line_num);
       data_array[i].UpdateMatch(result, rdata);
     } else if (r < -1) {
-      // An error has occured
+      // An error has occurred
       Warning("Error [%d] matching regex at line %d.", r, data_array[i].line_num);
     } // else it's -1 which means no match was found.
   }
@@ -560,7 +560,7 @@ HostRegexMatcher<Data, MatchResult>::Match(RequestData *rdata, MatchResult *resu
             this->data_array[i].line_num);
       this->data_array[i].UpdateMatch(result, rdata);
     } else {
-      // An error has occured
+      // An error has occurred
       Warning("error matching regex at line %d", this->data_array[i].line_num);
     }
   }

--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -68,7 +68,7 @@
  *
  *   ip table - supports ip ranges.  A single ip address is treated as
  *       a range with the same beginning and end address.  The table is
- *       is devided up into a fixed number of  levels, indexed 8 bit
+ *       is divided up into a fixed number of  levels, indexed 8 bit
  *       boundaries, starting at the the high bit of the address.  Subsequent
  *       levels are allocated only when needed.
  *

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -119,7 +119,7 @@ chash_lookup(ATSConsistentHash *fhash, uint64_t path_hash, ATSConsistentHashIter
   } else {
     prtmp = (pRecord *)fhash->lookup(nullptr, chashIter, wrap_around, hash);
   }
-  // Do not set wrap_around to true until we try all the parents atleast once.
+  // Do not set wrap_around to true until we try all the parents at least once.
   bool wrapped = *wrap_around;
   *wrap_around = (*mapWrapped && *wrap_around) ? true : false;
   if (!*mapWrapped && wrapped) {
@@ -221,7 +221,7 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
   }
 
   // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-  // ignore the down status and mark it as avaialble
+  // ignore the down status and mark it as available
   if ((pRec && result->rec->ignore_self_detect) && (hst && hst->status == TS_HOST_STATUS_DOWN)) {
     if (hst->reasons == Reason::SELF_DETECT) {
       host_stat = TS_HOST_STATUS_UP;
@@ -306,7 +306,7 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
       hst       = (pRec) ? pStatus.getHostStatus(pRec->hostname) : nullptr;
       host_stat = (hst) ? hst->status : TSHostStatus::TS_HOST_STATUS_UP;
       // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-      // ignore the down status and mark it as avaialble
+      // ignore the down status and mark it as available
       if ((pRec && result->rec->ignore_self_detect) && (hst && hst->status == TS_HOST_STATUS_DOWN)) {
         if (hst->reasons == Reason::SELF_DETECT) {
           host_stat = TS_HOST_STATUS_UP;
@@ -322,7 +322,7 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
   // ----------------------------------------------------------------------------------------------------
 
   // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-  // ignore the down status and mark it as avaialble
+  // ignore the down status and mark it as available
   if ((pRec && result->rec->ignore_self_detect) && (hst && hst->status == TS_HOST_STATUS_DOWN)) {
     if (hst->reasons == Reason::SELF_DETECT) {
       host_stat = TS_HOST_STATUS_UP;

--- a/proxy/ParentRoundRobin.cc
+++ b/proxy/ParentRoundRobin.cc
@@ -139,7 +139,7 @@ ParentRoundRobin::selectParent(bool first_call, ParentResult *result, RequestDat
     HostStatRec *hst = pStatus.getHostStatus(parents[cur_index].hostname);
     host_stat        = (hst) ? hst->status : TSHostStatus::TS_HOST_STATUS_UP;
     // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-    // ignore the down status and mark it as avaialble
+    // ignore the down status and mark it as available
     if (result->rec->ignore_self_detect && (hst && hst->status == TS_HOST_STATUS_DOWN)) {
       if (hst->reasons == Reason::SELF_DETECT) {
         host_stat = TS_HOST_STATUS_UP;

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -29,7 +29,7 @@
       continuation to another via a mechanism that impersonates a
       NetVC.  Should implement all external attributes of NetVConnections.
 
-   Since data is transfered within Traffic Server, this is a two
+   Since data is transferred within Traffic Server, this is a two
    headed beast.  One NetVC on initiating side (active side) and
    one NetVC on the receiving side (passive side).
 
@@ -406,7 +406,7 @@ PluginVC::do_io_shutdown(ShutdownHowTo_t howto)
 // int PluginVC::transfer_bytes(MIOBuffer* transfer_to,
 //                              IOBufferReader* transfer_from, int act_on)
 //
-//   Takes care of transfering bytes from a reader to another buffer
+//   Takes care of transferring bytes from a reader to another buffer
 //      In the case of large transfers, we move blocks.  In the case
 //      of small transfers we copy data so as to not build too many
 //      buffer blocks
@@ -417,7 +417,7 @@ PluginVC::do_io_shutdown(ShutdownHowTo_t howto)
 //   act_on: is the max number of bytes we are to copy.  There must
 //          be at least act_on bytes available from transfer_from
 //
-// Returns number of bytes transfered
+// Returns number of bytes transferred
 //
 int64_t
 PluginVC::transfer_bytes(MIOBuffer *transfer_to, IOBufferReader *transfer_from, int64_t act_on)

--- a/proxy/README-stats.otl
+++ b/proxy/README-stats.otl
@@ -76,7 +76,7 @@ it introduces grouping in time as well. Unfortunately, an implementation
 requires the notion of "local" and "global" stats.
 
 Now, stats fall into three categories:
-1) transactional (dyanmic) stats: e.g. number of current origin server
+1) transactional (dynamic) stats: e.g. number of current origin server
    connections,
 2) incremental stats: number of bytes from origin server,
 3) transactional stats: number of requests served.
@@ -283,7 +283,7 @@ Types Of Stats:
  		*** number of cache lookups
  			**** number of alternates
  		*** number of cache hits
-                        cache hits, misses, etc. stats should be catagorized
+                        cache hits, misses, etc. stats should be categorized
                         the same way they are categorized in WUTS (squid logs).
  			**** fresh hits
  			**** stale hits
@@ -452,7 +452,7 @@ Date: Thu, 26 Mar 1998 11:48:15 -0800
 >From a Support standpoint, I do have some reservations about hacking
 information and function out of the Traffic Manager for TS Lite. Less
 information in the Monitor makes it more difficult to observe Traffic Server
-operation. Less functionality in Configure means more manual editting of
+operation. Less functionality in Configure means more manual editing of
 config files and greater chance of admin errors. These factors could greatly
 increase our support problems and cost for "Lite" customers.
 
@@ -501,7 +501,7 @@ Adam Beguelin wrote:
 >         Adam
 >
 > On the dashboard add these stats:
->  o Cahce Free Space
+>  o Cache Free Space
 >  o Cache Size
 >  o DNS Hit rate
 >

--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -124,7 +124,7 @@ urlRewriteVerify()
 
 /**
   Called when the remap.config file changes. Since it called infrequently,
-  we do the load of new file as blocking I/O and lock aquire is also
+  we do the load of new file as blocking I/O and lock acquire is also
   blocking.
 
 */

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -36,7 +36,7 @@
 //              SPECIAL URLs
 //
 //
-// 1. Access from Browswers
+// 1. Access from Browsers
 //
 //    By special URLS:
 //
@@ -55,7 +55,7 @@
 //
 //         http://{http}/groups/use_graph.gif?august
 //
-//    B. Each protocol/sybsystem should have their own information.
+//    B. Each protocol/subsystem should have their own information.
 //       For example
 
 #define STAT_PAGE_SUCCESS STAT_PAGES_EVENTS_START + 0

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -575,7 +575,7 @@ public:
       This is a reference, not allocated.
       @return A pointer to the fragment or @c NULL if there is no valid URL.
   */
-  const char *fragment_get(int *length ///< Storage for fragement length.
+  const char *fragment_get(int *length ///< Storage for fragment length.
   );
 
   /** Get the target host name.

--- a/proxy/hdrs/HdrHeap.cc
+++ b/proxy/hdrs/HdrHeap.cc
@@ -1070,7 +1070,7 @@ HdrHeap::inherit_string_heaps(const HdrHeap *inherit_from)
     // Coalesce can't know the inherited str size so we pass it
     //  it in so that it can allocate a new read-write string heap
     //  large enough (INKqa07513).
-    // INVARIENT: inherit_str_heaps can only be called after
+    // INVARIANT: inherit_str_heaps can only be called after
     //  all the objects the callee wants to inherit strings for
     //  are put into the heap
     coalesce_str_heaps(inherit_str_size);

--- a/proxy/hdrs/HdrTSOnly.cc
+++ b/proxy/hdrs/HdrTSOnly.cc
@@ -157,7 +157,7 @@ HdrHeap::set_ronly_str_heap_end(int slot, const char *end)
 
 // void HdrHeap::attach_block(IOBufferBlock* b, const char* use_start)
 //
-//    Attachs data from an IOBuffer block to
+//    Attaches data from an IOBuffer block to
 //      as a read-only string heap.  Looks through existing
 //      to expand an existing string heap entry if necessary
 //

--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2854,7 +2854,7 @@ mime_str_u16_set(HdrHeap *heap, const char *s_str, int s_len, const char **d_str
 {
   ink_assert(s_len >= 0 && s_len < UINT16_MAX);
   // INKqa08287 - keep track of free string space.
-  //  INVARIENT: passed in result pointers must be to
+  //  INVARIANT: passed in result pointers must be to
   //    either NULL or be valid ptr for a string already
   //    the string heaps
   heap->free_string(*d_str, *d_len);

--- a/proxy/hdrs/load_http_hdr.cc
+++ b/proxy/hdrs/load_http_hdr.cc
@@ -33,12 +33,12 @@
  ****************************************************************************/
 
 /***************************************************************************
- *  USAGE NOTE:  This program was orignally built for reading TS 3.0.X &
- *    TS 3.5.X header dumps.  These data structures were always continguous.
+ *  USAGE NOTE:  This program was originally built for reading TS 3.0.X &
+ *    TS 3.5.X header dumps.  These data structures were always contiguous.
  *    TS 4.0.X and later have completely redesigned data structures that
  *    are more complicated but much faster.  This program has been adapted
  *    read headers that have been unmarshalled from cache, in which
- *    case they are contiguious.  It's conversion is in a half baked
+ *    case they are contiguous.  It's conversion is in a half baked
  *    state and is therefore not useful for must purposes.
  ***************************************************************************/
 
@@ -181,7 +181,7 @@ loop_over_heap_objs(HdrHeap *hdr_heap, int offset)
       printf("  HDR_HEAP_OBJ_EMPTY       %d bytes\n", obj->m_length);
       break;
     default:
-      printf("  OBJ UNKONWN (%d)  %d bytes\n", obj->m_type, obj->m_length);
+      printf("  OBJ UNKNOWN (%d)  %d bytes\n", obj->m_type, obj->m_length);
     }
 
     if (obj->m_length == 0) {

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -487,7 +487,7 @@ Http1ClientSession::attach_server_session(PoolableSession *ssession, bool transa
 
     // Since this our slave, issue an IO to detect a close and
     //  have it call the client session back.  This IO also prevent
-    //  the server net conneciton from calling back a dead sm
+    //  the server net connection from calling back a dead sm
     SET_HANDLER(&Http1ClientSession::state_keep_alive);
     slave_ka_vio = ssession->do_io_read(this, INT64_MAX, ssession->get_remote_reader()->mbuf);
     ink_assert(slave_ka_vio != ka_vio);

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -673,7 +673,7 @@ HttpBodyFactory::is_response_suppressed(HttpTransact::State *context)
   // as the connection is going to be closed anyway.
   /*
      if (context->client_info.port_attribute == SERVER_PORT_BLIND_TUNNEL) {
-     // Blind SSL tunnels always supress error messages
+     // Blind SSL tunnels always suppress error messages
      return true;
      } else
    */

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -727,7 +727,7 @@ struct OverridableHttpConfigParams {
 //
 // struct HttpConfigParams
 //
-// configuration parameters as they apear in the global
+// configuration parameters as they appear in the global
 // configuration file.
 /////////////////////////////////////////////////////////////
 struct HttpConfigParams : public ConfigInfo {

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -36,7 +36,7 @@ void prep_HttpProxyServer();
  */
 void init_accept_HttpProxyServer(int n_accept_threads = 0);
 
-/** Checkes whether we can call start_HttpProxyServer().
+/** Checks whether we can call start_HttpProxyServer().
  */
 void init_HttpProxyServer();
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -313,7 +313,7 @@ HttpVCTable::cleanup_all()
 
 /*
  * Helper functions to ensure that the parallel
- * API set timeouts are set consistenly with the records.config settings
+ * API set timeouts are set consistently with the records.config settings
  */
 ink_hrtime
 HttpSM::get_server_inactivity_timeout()
@@ -4753,7 +4753,7 @@ HttpSM::do_cache_lookup_and_read()
 void
 HttpSM::do_cache_delete_all_alts(Continuation *cont)
 {
-  // Do not delete a non-existant object.
+  // Do not delete a non-existent object.
   ink_assert(t_state.cache_info.object_read);
 
   SMDebug("http_seq", "[HttpSM::do_cache_delete_all_alts] Issuing cache delete for %s",
@@ -5280,7 +5280,7 @@ HttpSM::do_http_server_open(bool raw)
     }
   }
 
-  // draft-stenberg-httpbis-tcp recommends only enabling TFO on indempotent methods or
+  // draft-stenberg-httpbis-tcp recommends only enabling TFO on idempotent methods or
   // those with intervening protocol layers (eg. TLS).
 
   if (tls_upstream || HttpTransactHeaders::is_method_idempotent(t_state.method)) {

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -292,7 +292,7 @@ public:
   void do_hostdb_update_if_necessary();
 
   // Look at the configured policy and the current server connect_result
-  // to deterine whether this connection attempt should contribute to the
+  // to determine whether this connection attempt should contribute to the
   // dead server count
   bool track_connect_fail() const;
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1633,7 +1633,7 @@ HttpTransact::HandleRequest(State *s)
 
   // Added to skip the dns if the document is in the cache.
   // DNS is requested before cache lookup only if there are rules in cache.config , parent.config or
-  // if the newly added varible doc_in_cache_skip_dns is not enabled
+  // if the newly added variable doc_in_cache_skip_dns is not enabled
   if (s->dns_info.lookup_name[0] <= '9' && s->dns_info.lookup_name[0] >= '0' &&
       (!s->state_machine->enable_redirection || !s->redirect_info.redirect_in_process) &&
       s->parent_params->parent_table->hostMatch) {
@@ -2194,9 +2194,9 @@ HttpTransact::DecideCacheLookup(State *s)
     TxnDebug("http_trans", "[DecideCacheLookup] Will NOT do cache lookup.");
     TxnDebug("http_seq", "[DecideCacheLookup] Will NOT do cache lookup");
     // If this is a push request, we need send an error because
-    //   since what ever was sent is not cachable
+    //   since what ever was sent is not cacheable
     if (s->method == HTTP_WKSIDX_PUSH) {
-      HandlePushError(s, "Request Not Cachable");
+      HandlePushError(s, "Request Not Cacheable");
       return;
     }
     // for redirect, we skipped cache lookup to do the automatic redirection
@@ -2307,7 +2307,7 @@ HttpTransact::HandlePushResponseHdr(State *s)
 
     TRANSACT_RETURN(SM_ACTION_CACHE_ISSUE_WRITE, HandlePushCacheWrite);
   } else {
-    HandlePushError(s, "Response Not Cachable");
+    HandlePushError(s, "Response Not Cacheable");
   }
 }
 
@@ -2379,7 +2379,7 @@ HttpTransact::HandlePushError(State *s, const char *reason)
   s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
 
   // Set half close flag to prevent TCP
-  //   reset from the body still being transfered
+  //   reset from the body still being transferred
   s->state_machine->set_ua_half_close_flag();
 
   build_error_response(s, HTTP_STATUS_BAD_REQUEST, reason, "default");
@@ -2437,7 +2437,7 @@ HttpTransact::HandleCacheOpenRead(State *s)
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_NOT_CACHED);
     // Perform DNS for the origin when it is required.
     // 1. If parent configuration does not allow to go to origin there is no need of performing DNS
-    // 2. If parent satisfies the request there is no need to go to origin to perfrom DNS
+    // 2. If parent satisfies the request there is no need to go to origin to perform DNS
     HandleCacheOpenReadMiss(s);
   } else {
     // cache hit
@@ -3097,7 +3097,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
   // Check if cached response supports Range. If it does, append
   // Range transformation plugin
   // A little misnomer. HTTP_STATUS_RANGE_NOT_SATISFIABLE
-  // acutally means If-Range match fails here.
+  // actually means If-Range match fails here.
   // fall through
   default:
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_HIT_SERVED);
@@ -4689,7 +4689,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
         our_via = s->hdr_info.client_response.field_create(MIME_FIELD_VIA, MIME_LEN_VIA);
         s->hdr_info.client_response.field_attach(our_via);
       }
-      // HDR FIX ME - Mulitple appends are VERY slow
+      // HDR FIX ME - Multiple appends are VERY slow
       while (resp_via) {
         int clen;
         const char *cfield = resp_via->value_get(&clen);
@@ -4996,7 +4996,7 @@ HttpTransact::set_headers_for_cache_write(State *s, HTTPInfo *cache_info, HTTPHd
   //  quite beyond me.  Seems like a unsafe practice so
   //  FIX ME!
 
-  // Logic added to restore the orignal URL for multiple cache lookup
+  // Logic added to restore the original URL for multiple cache lookup
   // and automatic redirection
   if (s->redirect_info.redirect_in_process) {
     temp_url = &s->redirect_info.original_url;
@@ -6247,7 +6247,7 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   int req_method = request->method_get_wksidx();
   if (!(HttpTransactHeaders::is_method_cacheable(s->http_config_param, req_method)) && s->api_req_cacheable == false) {
     TxnDebug("http_trans", "[is_response_cacheable] "
-                           "only GET, and some HEAD and POST are cachable");
+                           "only GET, and some HEAD and POST are cacheable");
     return false;
   }
   // TxnDebug("http_trans", "[is_response_cacheable] method is cacheable");
@@ -6256,7 +6256,7 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
   // looked up, either, so why cache this).
   if (!(is_request_cache_lookupable(s))) {
     TxnDebug("http_trans", "[is_response_cacheable] "
-                           "request is not cache lookupable, response is not cachable");
+                           "request is not cache lookupable, response is not cacheable");
     return false;
   }
   // already has a fresh copy in the cache
@@ -6264,18 +6264,18 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
     return false;
   }
 
-  // Check whether the response is cachable based on its cookie
+  // Check whether the response is cacheable based on its cookie
   // If there are cookies in response but a ttl is set, allow caching
   if ((s->cache_control.ttl_in_cache <= 0) &&
       do_cookies_prevent_caching(static_cast<int>(s->txn_conf->cache_responses_to_cookies), request, response)) {
     TxnDebug("http_trans", "[is_response_cacheable] "
-                           "response has uncachable cookies, response is not cachable");
+                           "response has uncachable cookies, response is not cacheable");
     return false;
   }
   // if server spits back a WWW-Authenticate
   if ((s->txn_conf->cache_ignore_auth) == 0 && response->presence(MIME_PRESENCE_WWW_AUTHENTICATE)) {
     TxnDebug("http_trans", "[is_response_cacheable] "
-                           "response has WWW-Authenticate, response is not cachable");
+                           "response has WWW-Authenticate, response is not cacheable");
     return false;
   }
   // does server explicitly forbid storing?
@@ -6449,7 +6449,7 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
   case NON_EXISTANT_REQUEST_HEADER:
   /* fall through */
   case BAD_HTTP_HEADER_SYNTAX: {
-    TxnDebug("http_trans", "[is_request_valid] non-existant/bad header");
+    TxnDebug("http_trans", "[is_request_valid] non-existent/bad header");
     SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
     build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid HTTP Request", "request#syntax_error");
     return false;

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -215,7 +215,7 @@ HttpTransactHeaders::copy_header_fields(HTTPHdr *src_hdr, HTTPHdr *new_hdr, bool
 
   // Nuke hop-by-hop headers
   //
-  //    The hop-by-hop header fields are layed out by the spec
+  //    The hop-by-hop header fields are laid out by the spec
   //    with two adjustments
   //      1) we treat TE as hop-by-hop because spec implies
   //         that it is by declaring anyone who sends a TE must

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1029,7 +1029,7 @@ HttpTunnel::producer_handler_dechunked(int event, HttpTunnelProducer *p)
 //
 //   Handles events from chunked producers.  It calls the chunking handlers
 //    if appropriate and then translates the event we got into a suitable
-//    event to represent the unchunked state, and does chunked bookeeping
+//    event to represent the unchunked state, and does chunked bookkeeping
 //
 int
 HttpTunnel::producer_handler_chunked(int event, HttpTunnelProducer *p)
@@ -1521,7 +1521,7 @@ HttpTunnel::finish_all_internal(HttpTunnelProducer *p, bool chain)
       }
       // The IO Core will not call us back if there
       //   is nothing to do.  Check to see if there is
-      //   nothing to do and take the appripriate
+      //   nothing to do and take the appropriate
       //   action
       if (c->write_vio && c->alive && c->write_vio->nbytes == c->write_vio->ndone) {
         consumer_handler(VC_EVENT_WRITE_COMPLETE, c);
@@ -1632,7 +1632,7 @@ HttpTunnel::main_handler(int event, void *data)
 
   // We called a vc handler, the tunnel might be
   //  finished.  Check to see if there are any remaining
-  //  VConnections alive.  If not, notifiy the state machine
+  //  VConnections alive.  If not, notify the state machine
   //
   // Don't call out if we are nested
   if (call_sm || (sm_callback && !is_tunnel_alive())) {

--- a/proxy/http/remap/NextHopConsistentHash.cc
+++ b/proxy/http/remap/NextHopConsistentHash.cc
@@ -313,7 +313,7 @@ NextHopConsistentHash::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
   hst       = (pRec) ? pStatus.getHostStatus(pRec->hostname.c_str()) : nullptr;
   host_stat = (hst) ? hst->status : TSHostStatus::TS_HOST_STATUS_UP;
   // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-  // ignore the down status and mark it as avaialble
+  // ignore the down status and mark it as available
   if ((pRec && ignore_self_detect) && (hst && hst->status == TS_HOST_STATUS_DOWN)) {
     if (hst->reasons == Reason::SELF_DETECT) {
       host_stat = TS_HOST_STATUS_UP;
@@ -366,7 +366,7 @@ NextHopConsistentHash::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
         hst       = (pRec) ? pStatus.getHostStatus(pRec->hostname.c_str()) : nullptr;
         host_stat = (hst) ? hst->status : TSHostStatus::TS_HOST_STATUS_UP;
         // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-        // ignore the down status and mark it as avaialble
+        // ignore the down status and mark it as available
         if ((pRec && ignore_self_detect) && (hst && hst->status == TS_HOST_STATUS_DOWN)) {
           if (hst->reasons == Reason::SELF_DETECT) {
             host_stat = TS_HOST_STATUS_UP;

--- a/proxy/http/remap/NextHopRoundRobin.cc
+++ b/proxy/http/remap/NextHopRoundRobin.cc
@@ -124,7 +124,7 @@ NextHopRoundRobin::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
     HostStatRec *hst = pStatus.getHostStatus(cur_host->hostname.c_str());
     host_stat        = (hst) ? hst->status : TSHostStatus::TS_HOST_STATUS_UP;
     // if the config ignore_self_detect is set to true and the host is down due to SELF_DETECT reason
-    // ignore the down status and mark it as avaialble
+    // ignore the down status and mark it as available
     if (ignore_self_detect && (hst && hst->status == TS_HOST_STATUS_DOWN)) {
       if (hst->reasons == Reason::SELF_DETECT) {
         host_stat = TS_HOST_STATUS_UP;

--- a/proxy/http/remap/NextHopStrategyFactory.cc
+++ b/proxy/http/remap/NextHopStrategyFactory.cc
@@ -154,7 +154,7 @@ NextHopStrategyFactory::strategyInstance(const char *name)
   std::shared_ptr<NextHopSelectionStrategy> ps_strategy;
 
   if (!strategies_loaded) {
-    NH_Error("no strategy configurations were defined, see defintions in '%s' file", fn.c_str());
+    NH_Error("no strategy configurations were defined, see definitions in '%s' file", fn.c_str());
     return nullptr;
   } else {
     auto it = _strategies.find(name);
@@ -174,7 +174,7 @@ NextHopStrategyFactory::strategyInstance(const char *name)
  * loads the contents of a file into a std::stringstream document.  If the file has a '#include file'
  * directive, that 'file' is read into the document beginning at the the point where the
  * '#include' was found. This allows the 'strategy' and 'hosts' yaml files to be separate.  The
- * 'strategy' yaml file would then normally have the '#include hosts.yml' in it's begining.
+ * 'strategy' yaml file would then normally have the '#include hosts.yml' in it's beginning.
  */
 void
 NextHopStrategyFactory::loadConfigFile(const std::string &fileName, std::stringstream &doc,

--- a/proxy/http/remap/PluginDso.cc
+++ b/proxy/http/remap/PluginDso.cc
@@ -89,7 +89,7 @@ PluginDso::load(std::string &error)
       _mtime             = fs::modification_time(fs);
       PluginDebug(_tag, "plugin '%s' modification time %ld", _configPath.c_str(), _mtime);
 
-      /* Now attemt to load the plugin DSO */
+      /* Now attempt to load the plugin DSO */
       if ((_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW | RTLD_LOCAL)) == nullptr) {
 #if defined(freebsd) || defined(openbsd)
         char *err = (char *)dlerror();

--- a/proxy/http/remap/PluginFactory.cc
+++ b/proxy/http/remap/PluginFactory.cc
@@ -127,7 +127,7 @@ PluginFactory::setRuntimeDir(const fs::path &runtimeDir)
 const char *
 PluginFactory::getUuid()
 {
-  return _uuid ? _uuid->getString() : "uknown";
+  return _uuid ? _uuid->getString() : "unknown";
 }
 
 /**

--- a/proxy/http/remap/PluginFactory.h
+++ b/proxy/http/remap/PluginFactory.h
@@ -77,7 +77,7 @@ public:
  *
  * Each plugin factory instance corresponds to a config reload, each new config file set is meant to use a new factory instance.
  * A notion of runtime directory is maintained to make sure the DSO library files are not erased or modified while the library are
- * loaded in memory and make sure if the library file is overriden with a new DSO file that the new overriding plugin's
+ * loaded in memory and make sure if the library file is overridden with a new DSO file that the new overriding plugin's
  * functionality will be loaded with the next factory, it also handles some problems noticed on different OSes in handling
  * filesystem links and different dl library implementations.
  *

--- a/proxy/http/remap/RemapPlugins.cc
+++ b/proxy/http/remap/RemapPlugins.cc
@@ -72,7 +72,7 @@ RemapPlugins::run_plugin(RemapPluginInst *plugin)
 
   @return 1 when you are done doing crap (otherwise, you get re-called
     with schedule_imm and i hope you have something more to do), else
-    0 if you have something more do do (this isnt strict and we check
+    0 if you have something more do do (this isn't strict and we check
     there actually *is* something to do).
 
 */

--- a/proxy/http/remap/unit-tests/plugin_testing_calls.cc
+++ b/proxy/http/remap/unit-tests/plugin_testing_calls.cc
@@ -115,7 +115,7 @@ TSRemapPostConfigReload(TSRemapReloadStatus reloadStatus)
   debugObject.postReloadConfigStatus = reloadStatus;
 }
 
-/* The folowing functions are meant for unit testing */
+/* The following functions are meant for unit testing */
 int
 pluginDsoVersionTest()
 {

--- a/proxy/http/remap/unit-tests/test_NextHopConsistentHash.cc
+++ b/proxy/http/remap/unit-tests/test_NextHopConsistentHash.cc
@@ -533,7 +533,7 @@ SCENARIO("Testing NextHopConsistentHash class (alternating rings), using policy 
       }
     }
 
-    // makeing requests and marking down hosts with a config set for alternating ring mode.
+    // making requests and marking down hosts with a config set for alternating ring mode.
     WHEN("requests are made in a config set for alternating rings and hosts are marked down.")
     {
       HttpSM sm;

--- a/proxy/http/remap/unit-tests/test_PluginFactory.cc
+++ b/proxy/http/remap/unit-tests/test_PluginFactory.cc
@@ -65,7 +65,7 @@ thread_local PluginThreadContext *pluginThreadContext;
 std::error_code ec;
 static void *INSTANCE_HANDLER = (void *)789;
 
-/* Mock of PluginFactory just to get consisten UUID to be able to test consistently */
+/* Mock of PluginFactory just to get consistent UUID to be able to test consistently */
 static fs::path tempComponent = fs::path("c71e2bab-90dc-4770-9535-c9304c3de38e");
 class PluginFactoryUnitTest : public PluginFactory
 {
@@ -727,7 +727,7 @@ SCENARIO("loading multiple version of the same plugin at the same time", "[plugi
         testSetupLoadPlugin(configName, buildPath_v2, uuid_t2, 1556825557, effectivePath_v2, runtimePath_v2);
       plugin_v1->_plugin.getSymbol("TSRemapInit", tsRemapInitSym_v1_t2, error);
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
       /* Although effective path is the same runtime paths should be different */
       CHECK(runtimePath_v1 != runtimePath_v2);
@@ -769,7 +769,7 @@ SCENARIO("loading multiple version of the same plugin at the same time", "[plugi
         testSetupLoadPlugin(configName, buildPath_v2, uuid_t2, 1556825556, effectivePath_v2, runtimePath_v2);
       plugin_v1->_plugin.getSymbol("TSRemapInit", tsRemapInitSym_v1_t2, error);
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
 
       THEN("expect only v1 plugin to be loaded since the timestamp has not changed")
@@ -807,7 +807,7 @@ SCENARIO("loading multiple version of the same plugin at the same time", "[plugi
         testSetupLoadPlugin(configName, buildPath_v2, uuid_t2, 1556825557, effectivePath_v2, runtimePath_v2);
       plugin_v1->_plugin.getSymbol("TSRemapInit", tsRemapInitSym_v1_t2, error);
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
       /* since dynamic reload is disabled, runtimepaths should be same */
       CHECK(runtimePath_v1 == runtimePath_v2);
@@ -849,7 +849,7 @@ SCENARIO("loading multiple version of the same plugin at the same time", "[plugi
         testSetupLoadPluginWithOptOut(configName, buildPath_v2, uuid_t2, 1556825557, effectivePath_v2, runtimePath_v2);
       plugin_v1->_plugin.getSymbol("TSRemapInit", tsRemapInitSym_v1_t2, error);
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
 
       /* since dynamic reload is disabled, runtimepaths should be same */
@@ -894,7 +894,7 @@ SCENARIO("loading multiple version of the same plugin at the same time", "[plugi
         testSetupLoadPlugin(configName, buildPath_v2, uuid_t2, 1556825556, effectivePath_v2, runtimePath_v2);
       plugin_v1->_plugin.getSymbol("TSRemapInit", tsRemapInitSym_v1_t2, error);
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
       /* since dynamic reload is disabled, runtimepaths should be same */
       CHECK(runtimePath_v1 == runtimePath_v2);
@@ -986,7 +986,7 @@ SCENARIO("loading multiple version of the same plugin in mixed mode - global as 
       PluginFactoryUnitTest *factory2 = getFactory(uuid_t2);
       RemapPluginInst *plugin_v2      = factory2->getRemapPlugin(configName, 0, nullptr, error2, isPluginDynamicReloadEnabled());
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
 
       /* since dynamic reload is disabled, runtimepaths should be same */
@@ -1044,7 +1044,7 @@ SCENARIO("loading multiple version of the same plugin in mixed mode - global as 
 
       RemapPluginInst *plugin_v2 = factory->getRemapPlugin(configName, 0, nullptr, error2, isPluginDynamicReloadEnabled());
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
 
       /* since dynamic reload is disabled, runtimepaths should be same */
@@ -1095,7 +1095,7 @@ SCENARIO("loading multiple version of the same plugin in mixed mode - global as 
       PluginFactoryUnitTest *factory2 = getFactory(uuid_t2);
       RemapPluginInst *plugin_v2      = factory2->getRemapPlugin(configName, 0, nullptr, error2, isPluginDynamicReloadEnabled());
 
-      /* Make sure plugin.so was overriden */
+      /* Make sure plugin.so was overridden */
       CHECK(effectivePath_v1 == effectivePath_v2);
 
       /* since dynamic reload is disabled, runtimepaths should be same */
@@ -1382,7 +1382,7 @@ SCENARIO("notifying plugins of config reload", "[plugin][core]")
       RemapPluginInst *pluginInst1 = factory1->getRemapPlugin(configName1, 0, nullptr, error, isPluginDynamicReloadEnabled());
       RemapPluginInst *pluginInst2 = factory1->getRemapPlugin(configName2, 0, nullptr, error, isPluginDynamicReloadEnabled());
 
-      /* only 1 plugin loaded by the 2st factory */
+      /* only 1 plugin loaded by the 2nd factory */
       RemapPluginInst *pluginInst3 = factory2->getRemapPlugin(configName1, 0, nullptr, error, isPluginDynamicReloadEnabled());
 
       /* pluginInst1 and pluginInst3 should be using the same plugin DSO named configName1

--- a/proxy/http/remap/unit-tests/test_RemapPlugin.cc
+++ b/proxy/http/remap/unit-tests/test_RemapPlugin.cc
@@ -231,7 +231,7 @@ checkCallTest(bool shouldHaveFailed, bool result, const std::string &error, std:
     CHECK(false == result);
     CHECK(error == expectedError); // Appropriate error was returned.
   } else {
-    CHECK(true == result); // Init succesfull - returned TS_SUCCESS.
+    CHECK(true == result); // Init successful - returned TS_SUCCESS.
     CHECK(error.empty());  // No error was returned.
   }
 }

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -363,7 +363,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       }
       // If the flag has already been set before decoding header blocks, this is the trailing header.
       // Set a flag to avoid initializing fetcher for now.
-      // Decoding header blocks is stil needed to maintain a HPACK dynamic table.
+      // Decoding header blocks is still needed to maintain a HPACK dynamic table.
       // TODO: TS-3812
       empty_request = true;
     }
@@ -393,7 +393,7 @@ rcv_headers_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       // Send request header to SM
       stream->send_request(cstate);
     } else {
-      // Signal VC_EVENT_READ_COMPLETE becasue received trailing header fields with END_STREAM flag
+      // Signal VC_EVENT_READ_COMPLETE because received trailing header fields with END_STREAM flag
       stream->signal_read_event(VC_EVENT_READ_COMPLETE);
     }
   } else {
@@ -649,7 +649,7 @@ rcv_settings_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
     ++n_settings;
   }
 
-  // Update settigs count per minute
+  // Update settings count per minute
   cstate.increment_received_settings_count(n_settings);
   // Close this connection if its settings count received exceeds a limit
   if (cstate.get_received_settings_count() > Http2::max_settings_per_minute) {
@@ -1059,7 +1059,7 @@ Http2ConnectionState::init(Http2ClientSession *ssn)
    Send connection preface
 
    The client connection preface is HTTP2_CONNECTION_PREFACE.
-   The server connection preface consists of a potentially emptry SETTINGS frame.
+   The server connection preface consists of a potentially empty SETTINGS frame.
 
    Details in [RFC 7540] 3.5. HTTP/2 Connection Preface
 
@@ -1211,7 +1211,7 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
     _scheduled = false;
   } break;
 
-  // Initiate a gracefull shutdown
+  // Initiate a graceful shutdown
   case HTTP2_SESSION_EVENT_SHUTDOWN_INIT: {
     REMEMBER(event, this->recursion);
     ink_assert(shutdown_state == HTTP2_SHUTDOWN_NOT_INITIATED);
@@ -1225,7 +1225,7 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
     shutdown_cont_event = this_ethread()->schedule_in((Continuation *)this, HRTIME_SECONDS(2), HTTP2_SESSION_EVENT_SHUTDOWN_CONT);
   } break;
 
-  // Continue a gracefull shutdown
+  // Continue a graceful shutdown
   case HTTP2_SESSION_EVENT_SHUTDOWN_CONT: {
     REMEMBER(event, this->recursion);
     ink_assert(shutdown_state == HTTP2_SHUTDOWN_INITIATED);
@@ -1255,7 +1255,7 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
       if (lock.is_locked()) {
         this->ua_session->free();
         // After the free, the Http2ConnectionState object is also freed.
-        // The Http2ConnectionState object is allocted within the Http2ClientSession object
+        // The Http2ConnectionState object is allocated within the Http2ClientSession object
       }
     }
   }
@@ -1988,7 +1988,7 @@ Http2ConnectionState::send_ping_frame(Http2StreamId id, uint8_t flag, const uint
   this->ua_session->xmit(ping);
 }
 
-// As for gracefull shutdown, TS should process outstanding stream as long as possible.
+// As for graceful shutdown, TS should process outstanding stream as long as possible.
 // As for signal connection error, TS should close connection immediately.
 void
 Http2ConnectionState::send_goaway_frame(Http2StreamId id, Http2ErrorCode ec)

--- a/proxy/http2/Http2DependencyTree.h
+++ b/proxy/http2/Http2DependencyTree.h
@@ -359,7 +359,7 @@ Tree<T>::remove(Node *node)
     return;
   }
 
-  // Make a note of node's ancestory
+  // Make a note of node's ancestry
   add_ancestor(node);
 
   Node *parent = node->parent;

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -434,7 +434,7 @@ Http2Stream::do_io_close(int /* flags */)
 
     if (_proxy_ssn && this->is_client_state_writeable()) {
       // Make sure any trailing end of stream frames are sent
-      // Wee will be removed at send_data_frames or closing connection phase
+      // We will be removed at send_data_frames or closing connection phase
       Http2ClientSession *h2_proxy_ssn = static_cast<Http2ClientSession *>(this->_proxy_ssn);
       SCOPED_MUTEX_LOCK(lock, h2_proxy_ssn->mutex, this_ethread());
       h2_proxy_ssn->connection_state.send_data_frames(this);

--- a/proxy/http3/Http3App.cc
+++ b/proxy/http3/Http3App.cc
@@ -152,7 +152,7 @@ Http3App::create_uni_stream(QUICStreamId &new_stream_id, Http3StreamType type)
 
     Debug("http3", "[%" PRIu64 "] %s stream is created", new_stream_id, Http3DebugNames::stream_type(type));
   } else {
-    Debug("http3", "Could not creat %s stream", Http3DebugNames::stream_type(type));
+    Debug("http3", "Could not create %s stream", Http3DebugNames::stream_type(type));
   }
 
   return error;
@@ -277,7 +277,7 @@ Http3App::_set_qpack_stream(Http3StreamType type, QUICStreamIO *stream_io)
       this->_ssn->remote_qpack()->set_decoder_stream(stream_io);
     }
   } else {
-    ink_abort("unkown stream type");
+    ink_abort("unknown stream type");
   }
 }
 

--- a/proxy/http3/QPACK.cc
+++ b/proxy/http3/QPACK.cc
@@ -1173,7 +1173,7 @@ QPACK::StaticTable::lookup(const char *name, int name_len, const char *value, in
           match_type = QPACK::LookupResult::MatchType::EXACT;
           break;
         } else {
-          // Name match -- Keep it for no exact matchs
+          // Name match -- Keep it for no exact matches
           match_type = QPACK::LookupResult::MatchType::NAME;
         }
       }
@@ -1277,7 +1277,7 @@ QPACK::DynamicTable::lookup(const char *name, int name_len, const char *value, i
           match_type = QPACK::LookupResult::MatchType::EXACT;
           break;
         } else {
-          // Name match -- Keep it for no exact matchs
+          // Name match -- Keep it for no exact matches
           match_type = QPACK::LookupResult::MatchType::NAME;
         }
       }

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -1167,7 +1167,7 @@ Log::access(LogAccess *lad)
     ret = Log::SKIP;
     goto done;
   }
-  // initialize this LogAccess object and proccess
+  // initialize this LogAccess object and process
   //
   lad->init();
   ret = config->log_object_manager.log(lad);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1476,7 +1476,7 @@ LogAccess::validate_unmapped_url_path()
     // Use unmapped canonical URL as default
     m_client_req_unmapped_url_path_str = m_client_req_unmapped_url_canon_str;
     m_client_req_unmapped_url_path_len = m_client_req_unmapped_url_canon_len;
-    // Incase the code below fails, we prevent it from being used.
+    // In case the code below fails, we prevent it from being used.
     m_client_req_unmapped_url_host_str = INVALID_STR;
 
     if (m_client_req_unmapped_url_path_len >= 6) { // xxx:// - minimum schema size

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -225,7 +225,7 @@ private:
   uint32_t m_id; // unique buffer id (for debugging)
 public:
   LB_State m_state; // buffer state
-  int m_references; // oustanding checkout_write references.
+  int m_references; // outstanding checkout_write references.
 
   // noncopyable
   // -- member functions that are not allowed --

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -79,7 +79,7 @@ extern RecRawStatBlock *log_rsb;
 struct dirent;
 
 /*-------------------------------------------------------------------------
-  this object keeps the state of the logging configuraion variables.  upon
+  this object keeps the state of the logging configuration variables.  upon
   construction, the log configuration file is read and the logging
   variables are initialized.
 

--- a/proxy/logging/LogFieldAliasMap.h
+++ b/proxy/logging/LogFieldAliasMap.h
@@ -54,7 +54,7 @@ error status.
 2) asString(IntType key, char *buf, size_t bufLen, size_t *numChars=0)
 
 This method takes an IntType key and writes its equivalent string to a
-bufer buf of length bufLen. It sets the number of written characters
+buffer buf of length bufLen. It sets the number of written characters
 numChars (if numChars is not NULL), and returns an error status.
 
 The IntType to string conversion is used when unmarshaling data prior to

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -89,7 +89,7 @@ LogFile::LogFile(const char *name, const char *header, LogFileFormat format, uin
 /*-------------------------------------------------------------------------
   LogFile::LogFile
 
-  This (copy) contructor builds a LogFile object from another LogFile object.
+  This (copy) constructor builds a LogFile object from another LogFile object.
   -------------------------------------------------------------------------*/
 
 LogFile::LogFile(const LogFile &copy)

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -109,7 +109,7 @@ LogFormat::id_from_name(const char *name)
     CryptoHash hash;
     CryptoContext().hash_immediate(hash, name, static_cast<int>(strlen(name)));
 #if defined(linux)
-    /* Mask most signficant bit so that return value of this function
+    /* Mask most significant bit so that return value of this function
      * is not sign extended to be a negative number.
      * This problem is only known to occur on Linux which
      * is a 32-bit OS.

--- a/proxy/logging/LogLimits.h
+++ b/proxy/logging/LogLimits.h
@@ -22,7 +22,7 @@
  */
 
 /***************************************************************************
- This file contains constants and other limitis used within the logging
+ This file contains constants and other limits used within the logging
  module.
  ***************************************************************************/
 

--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -495,7 +495,7 @@ LogUtils::get_unrolled_filename(ts::TextView rolled_filename)
   // something like this, for example:
   //   diags.log.20191114.21h43m16s-20191114.21h43m17s.old
   //
-  // For these, the second delimeter will be a period. For this reason, we also
+  // For these, the second delimiter will be a period. For this reason, we also
   // split_prefix_at with a period as well.
   if (suffix.split_prefix_at('_') || suffix.split_prefix_at('.')) {
     // ' + 1' to remove the '_' or second '.':

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -83,7 +83,7 @@
  * Any plugin using the IO Core must enter
  *   with a held mutex.  SDK 1.0, 1.1 & 2.0 did not
  *   have this restriction so we need to add a mutex
- *   to Plugin's Continuation if it trys to use the IOCore
+ *   to Plugin's Continuation if it tries to use the IOCore
  * Not only does the plugin have to have a mutex
  *   before entering the IO Core.  The mutex needs to be held.
  *   We now take out the mutex on each call to ensure it is

--- a/src/tscore/Extendible.cc
+++ b/src/tscore/Extendible.cc
@@ -102,7 +102,7 @@ namespace details
     ++cnt_fld_constructed; // don't allow schema modification
     ink_assert(cnt_fld_constructed <= cnt_constructed);
 
-    // init all extendible memory to 0, incase constructors don't
+    // init all extendible memory to 0, in case constructors don't
     memset(reinterpret_cast<void *>(ext_loc), 0, alloc_size);
 
     for (auto const &elm : fields) {

--- a/src/tscore/MatcherUtils.cc
+++ b/src/tscore/MatcherUtils.cc
@@ -309,7 +309,7 @@ const char *matcher_type_str[] = {"invalid", "host", "domain", "ip", "url_regex"
 
 // char* processDurationString(char* str, int* seconds)
 //
-//   Take a duration sting which is composed of
+//   Take a duration string which is composed of
 //      digits followed by a unit specifier
 //         w - week
 //         d - day
@@ -341,7 +341,7 @@ processDurationString(char *str, int *seconds)
   len = strlen(str);
   for (int i = 0; i < len; i++) {
     if (!ParseRules::is_digit(*current)) {
-      // Make sure there is a time to proces
+      // Make sure there is a time to process
       if (current == s) {
         return "Malformed time";
       }

--- a/src/tscore/test_geometry.cc
+++ b/src/tscore/test_geometry.cc
@@ -27,7 +27,7 @@
 
 // This isn't really a unit test. It's just a dumb little program to probe the disk
 // geometry of an arbitrary device file. That's useful when figuring out how ATS will
-// perceive different devices on differen operating systems.
+// perceive different devices on different operating systems.
 
 int
 main(int argc, const char **argv)

--- a/src/tscore/unit_tests/test_ts_file.cc
+++ b/src/tscore/unit_tests/test_ts_file.cc
@@ -261,7 +261,7 @@ TEST_CASE("ts_file::path::copy", "[libts][fs_file]")
   CHECK_FALSE(ts::file::copy(file1, path(), ec));
   CHECK(ec.value() == EINVAL);
 
-  // successfull copy: "to" is directory
+  // successful copy: "to" is directory
   CHECK(ts::file::copy(file1, testdir2, ec));
   CHECK(ec.value() == 0);
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -216,7 +216,7 @@ ts.Disk.remap_config.AddLine(
  * name - A name for this instance of the DNS.
  * default - if a list argument is provided, uDNS will reply with the list contents instead of NXDOMAIN if a DNS can't be found for a partcular entry
 
- This function returns a AuTest process object that launches the python-based microDNS (uDNS). uDNS is a mock DNS which responds to DNS queries. uDNS needs to be setup for the tests that require made-up domains. The server reads a JSON-formatted data file that contains mappings of domain to IP addresses. uDNS responds with the approriate IP addresses if the requested domain is in uDNS' mappings.
+ This function returns a AuTest process object that launches the python-based microDNS (uDNS). uDNS is a mock DNS which responds to DNS queries. uDNS needs to be setup for the tests that require made-up domains. The server reads a JSON-formatted data file that contains mappings of domain to IP addresses. uDNS responds with the appropriate IP addresses if the requested domain is in uDNS' mappings.
 
  * addRecords(records=None, jsonFile=None)
 
@@ -330,7 +330,7 @@ Test.SkipUnless(
 ### Condition.HasCurlFeature(feature)
  * feature - The feature to test for
 
- This function tests for Curl for possible feature it has been compiled with. Consult Curl documenation for feature set.
+ This function tests for Curl for possible feature it has been compiled with. Consult Curl documentation for feature set.
 
 ### Example
 ```python

--- a/tests/gold_tests/autest-site/min_cfg/storage.config
+++ b/tests/gold_tests/autest-site/min_cfg/storage.config
@@ -1,4 +1,4 @@
-# seems good enought for doing something for playing with.
+# seems good enough for doing something for playing with.
 # not good for production
 # File must exist and must have this value in it
 storage 256M

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -123,7 +123,7 @@ if ENV['ATS_BIN'] is not None:
     Variables.trafficserver_version = out
     host.WriteVerbose(['ats'], "Traffic server version:", out)
 
-    # this querys tsxs for build flags so we can build code for the tests and get certain
+    # this queries tsxs for build flags so we can build code for the tests and get certain
     # useful flags as which openssl to use when we don't use the system version
     out = {
         'CPPFLAGS': '',

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -86,9 +86,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     # p.StartBefore(p_debug)
     # we want to have a few directories more fixed
     # this helps with debugging as location are common
-    # we do this by overiding locations from the "layout"
+    # we do this by overriding locations from the "layout"
     # used as part of build. This means loctaion such as
-    # PROXY_CONFIG_BIN_PATH with alway be $root/bin
+    # PROXY_CONFIG_BIN_PATH with always be $root/bin
     # not something else such as bin64
     #####
 
@@ -425,7 +425,7 @@ class Config(File):
         '''
         Write contents to disk
         '''
-        host.WriteVerbosef('ats-config-file', "Writting out file {0}",
+        host.WriteVerbosef('ats-config-file', "Writing out file {0}",
                            self.Name)
         if self.content is not None:
             with open(name, 'w') as f:
@@ -480,7 +480,7 @@ class RecordsConfig(Config, dict):
         self.WriteCustomOn(self._do_write)
 
     def _do_write(self, name):
-        host.WriteVerbosef('ats-config-file', "Writting out file {0}", name)
+        host.WriteVerbosef('ats-config-file', "Writing out file {0}", name)
         if len(self) > 0:
             with open(name, 'w') as f:
                 for name, val in self.items():

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -104,7 +104,7 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(server2)
 tr.Processes.Default.StartBefore(server3)
-# Delay on readyness of our ssl ports
+# Delay on readiness of our ssl ports
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stderr = "gold/chunked_GET_200.gold"
 tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/compress/compress.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress.test.py
@@ -192,7 +192,7 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = curl_post(ts, 3, "gzip")
 
 # compress_long.log contains all the output from the curl commands.  The tr removes the carriage returns for easier
-# readability.  Curl seems to have a bug, where it will neglect to output an end of line before outputing an HTTP
+# readability.  Curl seems to have a bug, where it will neglect to output an end of line before outputting an HTTP
 # message header line.  The sed command is a work-around for this problem.  greplog.sh uses the grep command to
 # select HTTP request/response line that should be consistent every time the test runs.
 #

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
@@ -164,7 +164,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "ex
 tr.StillRunningAfter = ts
 
 # 5 Stage - Change from MISS to STALE, reload
-tr = Test.AddTestRun("Reload config path1 STYLE")
+tr = Test.AddTestRun("Reload config path1 STALE")
 ps = tr.Processes.Default
 tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLine(path1_rule + ' STALE')
 tr.Disk.File(regex_revalidate_conf_path + "_tr5", typename="ats:config").AddLine(path1_rule + ' STALE')

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
@@ -164,7 +164,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "ex
 tr.StillRunningAfter = ts
 
 # 5 Stage - Change from MISS to STALE, reload
-tr = Test.AddTestRun("Reload config path1 STLE")
+tr = Test.AddTestRun("Reload config path1 STYLE")
 ps = tr.Processes.Default
 tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLine(path1_rule + ' STALE')
 tr.Disk.File(regex_revalidate_conf_path + "_tr5", typename="ats:config").AddLine(path1_rule + ' STALE')

--- a/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
@@ -275,7 +275,7 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
     return TS_ERROR;
   }
 
-  // Mutex to protext the logFile object.
+  // Mutex to protect the logFile object.
   //
   TSMutex mtx = TSMutexCreate();
 

--- a/tests/gold_tests/redirect/number_of_redirects.test.py
+++ b/tests/gold_tests/redirect/number_of_redirects.test.py
@@ -96,4 +96,4 @@ NumberOfRedirectionsTest("Test number_of_redirections=1", 1).run()
 # The client will just get 200OK and no redirect will be done by it, TS will follow the two
 # 302 Redirect.
 NumberOfRedirectionsTest("Test number_of_redirections=2", 2).run()
-# If adding more, need to touch the server side  as well. It wont be enough.
+# If adding more, need to touch the server side  as well. It won't be enough.

--- a/tests/gold_tests/tls/tls_engine.test.py
+++ b/tests/gold_tests/tls/tls_engine.test.py
@@ -33,7 +33,7 @@ Test.SkipUnless(Condition.HasOpenSSLVersion('1.1.1'))
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
 
-# Compile with tsxs.  That should bring in the consisten versions of openssl
+# Compile with tsxs.  That should bring in the consistent versions of openssl
 ts.Setup.Copy(os.path.join(Test.Variables.AtsTestPluginsDir, 'async_engine.so'), Test.RunDirectory)
 
 # Add info the origin server responses

--- a/tests/gold_tests/tls/tls_ocsp.test.py
+++ b/tests/gold_tests/tls/tls_ocsp.test.py
@@ -23,7 +23,7 @@ Test tls server prefetched OCSP responses
 
 Test.SkipUnless(
     Condition.HasCurlVersion("7.41.0"),  # curl --cert-status option has been introduced in version 7.41.0
-    Condition.IsOpenSSL(),  # functionality tested in this test requires OpenSSL specifc APIs
+    Condition.IsOpenSSL(),  # functionality tested in this test requires OpenSSL specific APIs
 )
 
 # Define default ATS

--- a/tests/include/catch.hpp
+++ b/tests/include/catch.hpp
@@ -107,7 +107,7 @@ namespace Catch {
 // The following features are defined:
 //
 // CATCH_CONFIG_COUNTER : is the __COUNTER__ macro supported?
-// CATCH_CONFIG_WINDOWS_SEH : is Windows SEH supported?
+// CATCH_CONFIG_WINDOWS_SEH : is Windows SHE supported?
 // CATCH_CONFIG_POSIX_SIGNALS : are POSIX signals supported?
 // CATCH_CONFIG_DISABLE_EXCEPTIONS : Are exceptions enabled?
 // ****************
@@ -205,7 +205,7 @@ namespace Catch {
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// Not all Windows environments support SEH properly
+// Not all Windows environments support SHE properly
 #if defined(__MINGW32__)
 #    define CATCH_INTERNAL_CONFIG_NO_WINDOWS_SEH
 #endif
@@ -240,7 +240,7 @@ namespace Catch {
 #  define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
 #  define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  __pragma( warning(pop) )
 
-// Universal Windows platform does not support SEH
+// Universal Windows platform does not support SHE
 // Or console colours (or console at all...)
 #  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 #    define CATCH_CONFIG_COLOUR_NONE
@@ -10573,7 +10573,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurence of ":"
+                // Find last occurrence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;
@@ -10749,7 +10749,7 @@ namespace {
     }
 }
 
-#endif // signals/SEH handling
+#endif // signals/SHE handling
 
 #if defined( CATCH_CONFIG_WINDOWS_SEH )
 
@@ -10888,7 +10888,7 @@ namespace Catch {
     void FatalConditionHandler::reset() {}
 }
 
-#endif // signals/SEH handling
+#endif // signals/SHE handling
 
 #if defined(__GNUC__)
 #    pragma GCC diagnostic pop

--- a/tests/include/catch.hpp
+++ b/tests/include/catch.hpp
@@ -107,7 +107,7 @@ namespace Catch {
 // The following features are defined:
 //
 // CATCH_CONFIG_COUNTER : is the __COUNTER__ macro supported?
-// CATCH_CONFIG_WINDOWS_SEH : is Windows SHE supported?
+// CATCH_CONFIG_WINDOWS_SEH : is Windows SEH supported?
 // CATCH_CONFIG_POSIX_SIGNALS : are POSIX signals supported?
 // CATCH_CONFIG_DISABLE_EXCEPTIONS : Are exceptions enabled?
 // ****************
@@ -205,7 +205,7 @@ namespace Catch {
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// Not all Windows environments support SHE properly
+// Not all Windows environments support SEH properly
 #if defined(__MINGW32__)
 #    define CATCH_INTERNAL_CONFIG_NO_WINDOWS_SEH
 #endif
@@ -240,7 +240,7 @@ namespace Catch {
 #  define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
 #  define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  __pragma( warning(pop) )
 
-// Universal Windows platform does not support SHE
+// Universal Windows platform does not support SEH
 // Or console colours (or console at all...)
 #  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 #    define CATCH_CONFIG_COLOUR_NONE
@@ -10573,7 +10573,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurrence of ":"
+                // Find last occurence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;
@@ -10749,7 +10749,7 @@ namespace {
     }
 }
 
-#endif // signals/SHE handling
+#endif // signals/SEH handling
 
 #if defined( CATCH_CONFIG_WINDOWS_SEH )
 
@@ -10888,7 +10888,7 @@ namespace Catch {
     void FatalConditionHandler::reset() {}
 }
 
-#endif // signals/SHE handling
+#endif // signals/SEH handling
 
 #if defined(__GNUC__)
 #    pragma GCC diagnostic pop

--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -122,31 +122,31 @@
       "required": ["name"],
       "properties": {
         "name": {
-          "desciption": "The name of the protocol.",
+          "description": "The name of the protocol.",
           "type": "string"
         },
         "version": {
-          "desciption": "The version of the protocol.",
+          "description": "The version of the protocol.",
           "type": "string"
         },
         "sni": {
-          "desciption": "The SNI in the client hello.",
+          "description": "The SNI in the client hello.",
           "type": "string"
         },
         "request-certificate": {
-          "desciption": "Whether a certificate should be requested from the proxy.",
+          "description": "Whether a certificate should be requested from the proxy.",
           "type": "boolean"
         },
         "verify-mode": {
-          "desciption": "The server or client's OpenSSL verify mode against the proxy.",
+          "description": "The server or client's OpenSSL verify mode against the proxy.",
           "type": "boolean"
         },
         "proxy-verify-mode": {
-          "desciption": "The proxy's OpenSSL verify mode against the peer.",
+          "description": "The proxy's OpenSSL verify mode against the peer.",
           "type": "integer"
         },
         "proxy-provided-certificate": {
-          "desciption": "Whether the proxy provided a cert in the handshake.",
+          "description": "Whether the proxy provided a cert in the handshake.",
           "type": "boolean"
         }
       }

--- a/tests/tools/plugins/test_hooks.cc
+++ b/tests/tools/plugins/test_hooks.cc
@@ -312,7 +312,7 @@ TSPluginInit(int argc, const char *argv[])
     return;
   }
 
-  // Mutex to protext the logFile object.
+  // Mutex to protect the logFile object.
   //
   TSMutex mtx = TSMutexCreate();
 

--- a/tools/cvtremappi
+++ b/tools/cvtremappi
@@ -443,7 +443,7 @@ def handle_header_rewrite(pathspec, obj):
                     rc.lines[pair[1]] = ln[:ofst] + self._first.pathspec + ln[ofst + len(self._base.pathspec):]
 
     # Returns a pair: length of string before # comment, and a flag indicating if %< (beginning of a variable
-    # exapansion) was in any of the double-quoted strings.
+    # expansion) was in any of the double-quoted strings.
     #
     def get_content_len(s):
         # States.

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -296,7 +296,7 @@ static const ArgumentDescription argument_descriptions[] = {
   {"abort_retry_speed", 'o', "Abort/Retry Speed", "I", &abort_retry_speed, "JTEST_ABORT_RETRY_SPEED", nullptr},
   {"abort_retry_bytes", ' ', "Abort/Retry Threshold (bytes)", "I", &abort_retry_bytes, "JTEST_ABORT_RETRY_THRESHHOLD_BYTES",
    nullptr},
-  {"abort_retry_secs", ' ', "Abort/Retry Threshhold (secs)", "I", &abort_retry_secs, "JTEST_ABORT_RETRY_THRESHHOLD_SECS", nullptr},
+  {"abort_retry_secs", ' ', "Abort/Retry Threshold (secs)", "I", &abort_retry_secs, "JTEST_ABORT_RETRY_THRESHHOLD_SECS", nullptr},
   {"reload_rate", 'W', "Reload Rate", "D", &reload_rate, "JTEST_RELOAD_RATE", nullptr},
   {"compd_port", 'O', "Compd port", "I", &compd_port, "JTEST_COMPD_PORT", nullptr},
   {"compd_suite", '1', "Compd Suite", "F", &compd_suite, "JTEST_COMPD_SUITE", nullptr},
@@ -1052,7 +1052,7 @@ process_header(int sock, char *buffer, int offset)
       fd[sock].range_bytes = length - fd[sock].range_start + 1;
     } else {
       if (verbose)
-        printf("unvalid 206");
+        printf("invalid 206");
     }
     ims = nullptr;
     if (verbose) {
@@ -1958,7 +1958,7 @@ defer_url(char *url)
   if (n_defered_urls < MAX_DEFERED_URLS - 1) {
     defered_urls[n_defered_urls++] = strdup(url);
   } else {
-    fprintf(stderr, "too many defered urls, dropping '%s'\n", url);
+    fprintf(stderr, "too many deferred urls, dropping '%s'\n", url);
   }
 }
 

--- a/tools/package/trafficserver.spec
+++ b/tools/package/trafficserver.spec
@@ -21,7 +21,7 @@
 %define _hardened_build 1
 %endif
 
-# This can be overriden via command line option, e.g.  --define "release 12"
+# This can be overridden via command line option, e.g.  --define "release 12"
 %{!?release: %define release 1}
 
 Summary:	Apache Traffic Server, a reverse, forward and transparent HTTP proxy cache
@@ -187,11 +187,11 @@ getent passwd ats >/dev/null || useradd -r -u 176 -g ats -d / -s /sbin/nologin -
 
 %changelog
 * Wed Sep 19 2018 Bryan Call <bcall@apache.org> - 8.0.0-1
-- Changed the owner ofthe configuration files to ats
+- Changed the owner of the configuration files to ats
 - Include files for the C++ APIs moved
 - C++ library name changed
 
 * Tue Dec 19 2017 Leif Hedstrom <zwoop@apache.org> - 7.1.2-1
 - Cleanup for 7.1.x, and various other changes. This needs more work
   upstream though, since I'm finding issues.
-- Losely based on ideas from the Fedora .spec
+- Loosely based on ideas from the Fedora .spec


### PR DESCRIPTION
Commands used:
```
codespell -w -L reenable,reenabled,anid,ned,larg,aci,tolen,aparent,toLen,ONL,doubleclick,ADMi,ded,ect,SEH
git co -- proxy/http2/hpack-tests
git co -- plugins/esi/test/parser_test.cc
git co -- doc
```