### PR TITLE
Document TSHttpTxnPostBufferReaderGet

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnPostBufferReaderGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnPostBufferReaderGet.en.rst
@@ -1,0 +1,78 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSHttpTxnPostBufferReaderGet
+****************************
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: TSIOBufferReader TSHttpTxnPostBufferReaderGet(TSHttpTxn txnp)
+
+Description
+===========
+
+Retrieve the client request body for the transaction referenced by :arg:`txnp`.
+The body is read from via the returned :c:type:`TSIOBufferReader`. The returned
+:c:type:`TSIOBufferReader` is owned by the caller and the caller must free it
+via :c:func:`TSIOBufferReaderFree`. This function should be used in the handler
+for :data:`TS_HTTP_REQUEST_BUFFER_READ_COMPLETE_HOOK`. The following example
+handler makes use of :c:func:`TSHttpTxnPostBufferReaderGet`.
+
+.. code-block:: c
+
+   int
+   CB_Read_Request_Body_Hook(TSCont contp, TSEvent event, void* data) {
+     ink_assert(event == TS_EVENT_HTTP_REQUEST_BUFFER_COMPLETE);
+     auto txnp = reinterpret_cast<TSHttpTxn>(data);
+
+     TSIOBufferReader post_buffer_reader = TSHttpTxnPostBufferReaderGet(txnp);
+     int64_t read_avail                  = TSIOBufferReaderAvail(post_buffer_reader);
+
+     if (read_avail > 0) {
+       char *body_bytes = reinterpret_cast<char *>(TSmalloc(sizeof(char) * read_avail));
+
+       int64_t consumed      = 0;
+       TSIOBufferBlock block = TSIOBufferReaderStart(post_buffer_reader);
+       while (block != NULL) {
+         int64_t data_len        = 0;
+         const char *block_bytes = TSIOBufferBlockReadStart(block, post_buffer_reader, &data_len);
+         memcpy(body_bytes + consumed, block_bytes, data_len);
+         consumed += data_len;
+         block = TSIOBufferBlockNext(block);
+       }
+
+       // Now do something with body_bytes which contains the contents of the
+       // request's body.
+     }
+
+     // Remeber to free the TSIOBufferReader.
+     TSIOBufferReaderFree(post_buffer_reader);
+
+     TSHttpTxnReenable(txnp);
+     return 0;
+   }
+
+:ts:git:`example/plugins/c-api/request_buffer/request_buffer.c` is a simple
+yet complete plugin that accesses HTTP request bodies.

--- a/doc/developer-guide/api/types/TSHttpHookID.en.rst
+++ b/doc/developer-guide/api/types/TSHttpHookID.en.rst
@@ -38,6 +38,8 @@ Enumeration Members
 
    .. c:enumerator:: TS_HTTP_READ_REQUEST_HDR_HOOK
 
+   .. c:enumerator:: TS_HTTP_REQUEST_BUFFER_READ_COMPLETE_HOOK
+
    .. c:enumerator:: TS_HTTP_OS_DNS_HOOK
 
    .. c:enumerator:: TS_HTTP_SEND_REQUEST_HDR_HOOK

--- a/doc/developer-guide/plugins/hooks-and-transactions/http-transactions.en.rst
+++ b/doc/developer-guide/plugins/hooks-and-transactions/http-transactions.en.rst
@@ -26,9 +26,10 @@ The HTTP transaction functions enable you to set up plugin callbacks to
 HTTP transactions and obtain/modify information about particular HTTP
 transactions.
 
-As described in the section on HTTP sessions, an **HTTP transaction** is
-an object defined for the lifetime of a single request from a client and
-the corresponding response from Traffic Server. The ``TSHttpTxn``
+As described in :ref:`HTTP sessions
+<developer-plugins-hooks-http-sessions>`, an **HTTP transaction** is an
+object defined for the lifetime of a single request from a client and
+the corresponding response from Traffic Server. The :c:type:`TSHttpTxn`
 structure is the main handle given to a plugin for manipulating a
 transaction's internal state. Additionally, an HTTP transaction has a
 reference back to the HTTP session that created it.
@@ -168,8 +169,12 @@ The HTTP transaction functions are:
    - Note that it is an error to modify cached headers.
 
 -  :c:func:`TSHttpTxnClientReqGet`
-   - Plugins that must read client request headers use this call to
-   retrieve the HTTP header.
+   - Plugins that read client request headers use this call to retrieve the
+   HTTP header for any given :c:type:`TSHttpTxn`.
+
+-  :c:func:`TSHttpTxnPostBufferReaderGet`
+   - Plugins that read client request bodies use this call to retrieve the
+   HTTP body for any given :c:type:`TSHttpTxn`.
 
 -  :c:func:`TSHttpTxnClientRespGet`
 


### PR DESCRIPTION
This adds documentation for the TSHttpTxnPostBufferReaderGet transaction
function and for the corresponding
TS_HTTP_REQUEST_BUFFER_READ_COMPLETE_HOOK.