### PR TITLE
Add an option to avoid heap allocation in TSMimeHdrField* APIs

### DIFF
--- a/example/plugins/c-api/append_transform/append_transform.c
+++ b/example/plugins/c-api/append_transform/append_transform.c
@@ -256,7 +256,7 @@ transformable(TSHttpTxn txnp)
     if (TS_HTTP_STATUS_OK == TSHttpHdrStatusGet(bufp, hdr_loc)) {
       /* We only want to do the transformation on documents that have a
          content type of "text/html". */
-      TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, "Content-Type", 12);
+      TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, "Content-Type", 12, NULL);
       if (!field_loc) {
         ASSERT_SUCCESS(TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc));
         return 0;

--- a/example/plugins/c-api/basic_auth/basic_auth.c
+++ b/example/plugins/c-api/basic_auth/basic_auth.c
@@ -101,7 +101,7 @@ handle_dns(TSHttpTxn txnp, TSCont contp)
     goto done;
   }
 
-  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_PROXY_AUTHORIZATION, TS_MIME_LEN_PROXY_AUTHORIZATION);
+  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_PROXY_AUTHORIZATION, TS_MIME_LEN_PROXY_AUTHORIZATION, NULL);
   if (!field_loc) {
     TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
     TSError("[%s] No Proxy-Authorization field", PLUGIN_NAME);

--- a/example/plugins/c-api/remap/remap.cc
+++ b/example/plugins/c-api/remap/remap.cc
@@ -255,12 +255,13 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
   // InkAPI usage case
   const char *value;
 
-  if ((cfield = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, TS_MIME_FIELD_DATE, -1)) != TS_NULL_MLOC) {
+  if ((cfield = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, TS_MIME_FIELD_DATE, -1, nullptr)) != TS_NULL_MLOC) {
     TSDebug(PLUGIN_NAME, "We have \"Date\" header in request\n");
     value = TSMimeHdrFieldValueStringGet(rri->requestBufp, rri->requestHdrp, cfield, -1, nullptr);
     TSDebug(PLUGIN_NAME, "Header value: %s\n", value);
   }
-  if ((cfield = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, "MyHeader", sizeof("MyHeader") - 1)) != TS_NULL_MLOC) {
+  if ((cfield = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, "MyHeader", sizeof("MyHeader") - 1, nullptr)) !=
+      TS_NULL_MLOC) {
     TSDebug(PLUGIN_NAME, "We have \"MyHeader\" header in request\n");
     value = TSMimeHdrFieldValueStringGet(rri->requestBufp, rri->requestHdrp, cfield, -1, nullptr);
     TSDebug(PLUGIN_NAME, "Header value: %s\n", value);

--- a/example/plugins/c-api/replace_header/replace_header.c
+++ b/example/plugins/c-api/replace_header/replace_header.c
@@ -53,7 +53,7 @@ replace_header(TSHttpTxn txnp)
     goto done;
   }
 
-  field_loc = TSMimeHdrFieldFind(resp_bufp, resp_loc, TS_MIME_FIELD_ACCEPT_RANGES, TS_MIME_LEN_ACCEPT_RANGES);
+  field_loc = TSMimeHdrFieldFind(resp_bufp, resp_loc, TS_MIME_FIELD_ACCEPT_RANGES, TS_MIME_LEN_ACCEPT_RANGES, NULL);
   if (field_loc == TS_NULL_MLOC) {
     /* field was not found */
 

--- a/example/plugins/c-api/response_header_1/response_header_1.c
+++ b/example/plugins/c-api/response_header_1/response_header_1.c
@@ -134,7 +134,7 @@ modify_header(TSHttpTxn txnp)
     }
 
     /* Get the cached MIME field name for this HTTP header */
-    cached_field_loc = TSMimeHdrFieldFind(cached_bufp, cached_loc, (const char *)mimehdr1_name, strlen(mimehdr1_name));
+    cached_field_loc = TSMimeHdrFieldFind(cached_bufp, cached_loc, (const char *)mimehdr1_name, strlen(mimehdr1_name), NULL);
     if (TS_NULL_MLOC == cached_field_loc) {
       TSError("[%s] Can't find header %s in cached document", PLUGIN_NAME, mimehdr1_name);
       TSHandleMLocRelease(resp_bufp, TS_NULL_MLOC, resp_loc);

--- a/example/plugins/c-api/thread_pool/psi.c
+++ b/example/plugins/c-api/thread_pool/psi.c
@@ -856,7 +856,7 @@ transformable(TSHttpTxn txnp)
     }
 
     TSMLoc field_loc;
-    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, -1);
+    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, -1, NULL);
     if (field_loc == TS_NULL_MLOC) {
       TSError("[%s] Unable to search Content-Type field", PLUGIN_NAME);
       TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
@@ -872,7 +872,7 @@ transformable(TSHttpTxn txnp)
 
     TSHandleMLocRelease(bufp, hdr_loc, field_loc);
 
-    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, MIME_FIELD_XPSI, -1);
+    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, MIME_FIELD_XPSI, -1, NULL);
 
     TSHandleMLocRelease(bufp, hdr_loc, field_loc);
     TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);

--- a/example/plugins/c-api/txn_data_sink/txn_data_sink.c
+++ b/example/plugins/c-api/txn_data_sink/txn_data_sink.c
@@ -119,7 +119,7 @@ enable_agent_check(TSHttpTxn txnp)
 
   // Enable the sink agent if the header is present.
   if (TS_SUCCESS == TSHttpTxnClientReqGet(txnp, &req_buf, &req_loc)) {
-    TSMLoc range_field = TSMimeHdrFieldFind(req_buf, req_loc, FLAG_MIME_FIELD, FLAG_MIME_LEN);
+    TSMLoc range_field = TSMimeHdrFieldFind(req_buf, req_loc, FLAG_MIME_FIELD, FLAG_MIME_LEN, NULL);
     zret               = NULL == range_field ? 0 : 1;
   }
 

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -168,6 +168,17 @@ typedef struct {
 } TSPluginMsg;
 
 /**
+   A struct to avoid heap allocations in TSMimeHdrField* APIs
+
+   WARNING:  Contents invalidated by calls to TSHttpTxnReenable().
+ */
+typedef struct {
+  void *_d[3]; // private
+} TSHdrHandle;
+
+#define TS_MLOC_FROM_HDR_HANDLE(HH_) ((TSMLoc)((HH_)._d))
+
+/**
     This set of enums are possible values returned by
     TSHttpHdrParseReq() and TSHttpHdrParseResp().
 

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -961,7 +961,7 @@ tsapi TSMLoc TSMimeHdrFieldGet(TSMBuffer bufp, TSMLoc hdr, int idx);
       not be found, returns TS_NULL_MLOC.
 
  */
-tsapi TSMLoc TSMimeHdrFieldFind(TSMBuffer bufp, TSMLoc hdr, const char *name, int length);
+tsapi TSMLoc TSMimeHdrFieldFind(TSMBuffer bufp, TSMLoc hdr, const char *name, int length, TSHdrHandle *handle);
 
 /**
     Returns the TSMLoc location of a specified MIME field from within

--- a/plugins/authproxy/utils.cc
+++ b/plugins/authproxy/utils.cc
@@ -50,7 +50,7 @@ HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, unsigned value)
 {
   TSMLoc mloc;
 
-  mloc = TSMimeHdrFieldFind(mbuf, mhdr, name, -1);
+  mloc = TSMimeHdrFieldFind(mbuf, mhdr, name, -1, nullptr);
   if (mloc == TS_NULL_MLOC) {
     TSReleaseAssert(TSMimeHdrFieldCreateNamed(mbuf, mhdr, name, -1, &mloc) == TS_SUCCESS);
   } else {
@@ -68,7 +68,7 @@ HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, const char *val
 {
   TSMLoc mloc;
 
-  mloc = TSMimeHdrFieldFind(mbuf, mhdr, name, -1);
+  mloc = TSMimeHdrFieldFind(mbuf, mhdr, name, -1, nullptr);
   if (mloc == TS_NULL_MLOC) {
     TSReleaseAssert(TSMimeHdrFieldCreateNamed(mbuf, mhdr, name, -1, &mloc) == TS_SUCCESS);
   } else {
@@ -87,7 +87,7 @@ HttpGetContentLength(TSMBuffer mbuf, TSMLoc mhdr)
   TSMLoc mloc;
   unsigned value = 0;
 
-  mloc = TSMimeHdrFieldFind(mbuf, mhdr, TS_MIME_FIELD_CONTENT_LENGTH, -1);
+  mloc = TSMimeHdrFieldFind(mbuf, mhdr, TS_MIME_FIELD_CONTENT_LENGTH, -1, nullptr);
   if (mloc != TS_NULL_MLOC) {
     value = TSMimeHdrFieldValueUintGet(mbuf, mhdr, mloc, 0 /* index */);
   }
@@ -102,7 +102,7 @@ HttpIsChunkedEncoding(TSMBuffer mbuf, TSMLoc mhdr)
   TSMLoc mloc;
   bool ischunked = false;
 
-  mloc = TSMimeHdrFieldFind(mbuf, mhdr, TS_MIME_FIELD_TRANSFER_ENCODING, -1);
+  mloc = TSMimeHdrFieldFind(mbuf, mhdr, TS_MIME_FIELD_TRANSFER_ENCODING, -1, nullptr);
   if (mloc != TS_NULL_MLOC) {
     const char *str;
     int len;

--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -674,10 +674,10 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo * /* rri */)
   TSMLoc req_hdrs;
 
   if (TS_SUCCESS == TSHttpTxnClientReqGet(txnp, &bufp, &req_hdrs)) {
-    TSMLoc field_loc = TSMimeHdrFieldFind(bufp, req_hdrs, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
+    TSMLoc field_loc = TSMimeHdrFieldFind(bufp, req_hdrs, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE, nullptr);
 
     if (!field_loc) { // Less common case, but also allow If-Range header to trigger, but only if Range not present
-      field_loc = TSMimeHdrFieldFind(bufp, req_hdrs, TS_MIME_FIELD_IF_RANGE, TS_MIME_LEN_IF_RANGE);
+      field_loc = TSMimeHdrFieldFind(bufp, req_hdrs, TS_MIME_FIELD_IF_RANGE, TS_MIME_LEN_IF_RANGE, nullptr);
     }
 
     if (field_loc) {

--- a/plugins/background_fetch/headers.cc
+++ b/plugins/background_fetch/headers.cc
@@ -32,7 +32,7 @@
 int
 remove_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len)
 {
-  TSMLoc field = TSMimeHdrFieldFind(bufp, hdr_loc, header, len);
+  TSMLoc field = TSMimeHdrFieldFind(bufp, hdr_loc, header, len, nullptr);
   int cnt      = 0;
 
   while (field) {
@@ -59,7 +59,7 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
   }
 
   bool ret         = false;
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, header, len);
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, header, len, nullptr);
 
   if (!field_loc) {
     // No existing header, so create one

--- a/plugins/background_fetch/rules.cc
+++ b/plugins/background_fetch/rules.cc
@@ -97,7 +97,7 @@ BgFetchRule::check_field_configured(TSHttpTxn txnp) const
   // Check response headers. ToDo: This doesn't check e.g. Content-Type :-/.
   if (!strcmp(_field, "Content-Length")) {
     if (TS_SUCCESS == TSHttpTxnServerRespGet(txnp, &hdr_bufp, &hdr_loc)) {
-      TSMLoc loc = TSMimeHdrFieldFind(hdr_bufp, hdr_loc, _field, -1);
+      TSMLoc loc = TSMimeHdrFieldFind(hdr_bufp, hdr_loc, _field, -1, nullptr);
 
       if (TS_NULL_MLOC != loc) {
         unsigned int content_len = TSMimeHdrFieldValueUintGet(hdr_bufp, hdr_loc, loc, 0 /* index */);
@@ -119,7 +119,7 @@ BgFetchRule::check_field_configured(TSHttpTxn txnp) const
 
   // Check request headers
   if (TS_SUCCESS == TSHttpTxnClientReqGet(txnp, &hdr_bufp, &hdr_loc)) {
-    TSMLoc loc = TSMimeHdrFieldFind(hdr_bufp, hdr_loc, _field, -1);
+    TSMLoc loc = TSMimeHdrFieldFind(hdr_bufp, hdr_loc, _field, -1, nullptr);
 
     if (TS_NULL_MLOC != loc) {
       if (!strcmp(_value, "*")) {

--- a/plugins/cache_promote/lru_policy.cc
+++ b/plugins/cache_promote/lru_policy.cc
@@ -147,7 +147,7 @@ LRUPolicy::doPromote(TSHttpTxn txnp)
       const char *method = TSHttpHdrMethodGet(request, req_hdr, &method_len);
 
       if (TS_HTTP_METHOD_GET == method) { // Only allow GET requests (for now) to actually do the promotion
-        TSMLoc range = TSMimeHdrFieldFind(request, req_hdr, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
+        TSMLoc range = TSMimeHdrFieldFind(request, req_hdr, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE, nullptr);
 
         if (TS_NULL_MLOC != range) { // Found a Range: header, not cacheable
           TSHandleMLocRelease(request, req_hdr, range);
@@ -233,7 +233,7 @@ LRUPolicy::addBytes(TSHttpTxn txnp)
       TSMLoc resp_hdr;
 
       if (TS_SUCCESS == TSHttpTxnServerRespGet(txnp, &resp, &resp_hdr)) {
-        TSMLoc field_loc = TSMimeHdrFieldFind(resp, resp_hdr, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH);
+        TSMLoc field_loc = TSMimeHdrFieldFind(resp, resp_hdr, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH, nullptr);
 
         if (field_loc) {
           auto &[val_key, val_hits, val_bytes] = *(map_it->second);

--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -188,7 +188,7 @@ range_header_check(TSHttpTxn txnp, pluginconfig *const pc)
   TSCont txn_contp;
 
   if (TS_SUCCESS == TSHttpTxnClientReqGet(txnp, &hdr_buf, &hdr_loc)) {
-    loc = TSMimeHdrFieldFind(hdr_buf, hdr_loc, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
+    loc = TSMimeHdrFieldFind(hdr_buf, hdr_loc, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE, nullptr);
     if (TS_NULL_MLOC != loc) {
       const char *hdr_value = TSMimeHdrFieldValueStringGet(hdr_buf, hdr_loc, loc, 0, &length);
       TSHandleMLocRelease(hdr_buf, hdr_loc, loc);
@@ -244,7 +244,7 @@ range_header_check(TSHttpTxn txnp, pluginconfig *const pc)
 
             // optionally consider an X-CRR-IMS header
             if (pc->consider_ims_header) {
-              TSMLoc const imsloc = TSMimeHdrFieldFind(hdr_buf, hdr_loc, X_IMS_HEADER.data(), X_IMS_HEADER.size());
+              TSMLoc const imsloc = TSMimeHdrFieldFind(hdr_buf, hdr_loc, X_IMS_HEADER.data(), X_IMS_HEADER.size(), nullptr);
               if (TS_NULL_MLOC != imsloc) {
                 time_t const itime = TSMimeHdrFieldValueDateGet(hdr_buf, hdr_loc, imsloc);
                 DEBUG_LOG("Servicing the '%.*s' header", (int)X_IMS_HEADER.size(), X_IMS_HEADER.data());
@@ -392,7 +392,7 @@ handle_server_read_response(TSHttpTxn txnp, txndata *const txn_state)
 int
 remove_header(TSMBuffer buf, TSMLoc hdr_loc, const char *header, int len)
 {
-  TSMLoc field = TSMimeHdrFieldFind(buf, hdr_loc, header, len);
+  TSMLoc field = TSMimeHdrFieldFind(buf, hdr_loc, header, len, nullptr);
   int cnt      = 0;
 
   while (field) {
@@ -423,7 +423,7 @@ set_header(TSMBuffer buf, TSMLoc hdr_loc, const char *header, int len, const cha
 
   DEBUG_LOG("header: %s, len: %d, val: %s, val_len: %d", header, len, val, val_len);
   bool ret         = false;
-  TSMLoc field_loc = TSMimeHdrFieldFind(buf, hdr_loc, header, len);
+  TSMLoc field_loc = TSMimeHdrFieldFind(buf, hdr_loc, header, len, nullptr);
 
   if (!field_loc) {
     // No existing header, so create one
@@ -464,7 +464,7 @@ get_date_from_cached_hdr(TSHttpTxn txn)
   time_t date = 0;
 
   if (TSHttpTxnCachedRespGet(txn, &buf, &hdr_loc) == TS_SUCCESS) {
-    date_loc = TSMimeHdrFieldFind(buf, hdr_loc, TS_MIME_FIELD_DATE, TS_MIME_LEN_DATE);
+    date_loc = TSMimeHdrFieldFind(buf, hdr_loc, TS_MIME_FIELD_DATE, TS_MIME_LEN_DATE, nullptr);
     if (date_loc != TS_NULL_MLOC) {
       date = TSMimeHdrFieldValueDateGet(buf, hdr_loc, date_loc);
       TSHandleMLocRelease(buf, hdr_loc, date_loc);

--- a/plugins/cachekey/cachekey.cc
+++ b/plugins/cachekey/cachekey.cc
@@ -151,7 +151,7 @@ classifyUserAgent(const Classifier &c, TSMBuffer buf, TSMLoc hdrs, String &class
   TSMLoc field;
   bool matched = false;
 
-  field = TSMimeHdrFieldFind(buf, hdrs, TS_MIME_FIELD_USER_AGENT, TS_MIME_LEN_USER_AGENT);
+  field = TSMimeHdrFieldFind(buf, hdrs, TS_MIME_FIELD_USER_AGENT, TS_MIME_LEN_USER_AGENT, nullptr);
   while (field != TS_NULL_MLOC && !matched) {
     const char *value;
     int len;
@@ -489,7 +489,7 @@ CacheKey::processHeader(const String &name, const ConfigHeaders &config, T &dst,
 {
   TSMLoc field;
 
-  for (field = TSMimeHdrFieldFind(_buf, _hdrs, name.c_str(), name.size()); field != TS_NULL_MLOC;
+  for (field = TSMimeHdrFieldFind(_buf, _hdrs, name.c_str(), name.size(), nullptr); field != TS_NULL_MLOC;
        field = ::nextDuplicate(_buf, _hdrs, field)) {
     const char *value;
     int vlen;
@@ -593,7 +593,7 @@ CacheKey::appendCookies(const ConfigCookies &config)
   TSMLoc field;
   StringSet cset; /* sort and uniquify the cookies list in the cache key */
 
-  for (field = TSMimeHdrFieldFind(_buf, _hdrs, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE); field != TS_NULL_MLOC;
+  for (field = TSMimeHdrFieldFind(_buf, _hdrs, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, nullptr); field != TS_NULL_MLOC;
        field = ::nextDuplicate(_buf, _hdrs, field)) {
     int count = TSMimeHdrFieldValuesCount(_buf, _hdrs, field);
 
@@ -692,7 +692,7 @@ CacheKey::appendUaCaptures(Pattern &config)
   const char *value;
   int len;
 
-  field = TSMimeHdrFieldFind(_buf, _hdrs, TS_MIME_FIELD_USER_AGENT, TS_MIME_LEN_USER_AGENT);
+  field = TSMimeHdrFieldFind(_buf, _hdrs, TS_MIME_FIELD_USER_AGENT, TS_MIME_LEN_USER_AGENT, nullptr);
   if (field == TS_NULL_MLOC) {
     CacheKeyDebug("missing %.*s header", TS_MIME_LEN_USER_AGENT, TS_MIME_FIELD_USER_AGENT);
     return;

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -202,7 +202,7 @@ vary_header(TSMBuffer bufp, TSMLoc hdr_loc)
   TSReturnCode ret;
   TSMLoc ce_loc;
 
-  ce_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_VARY, TS_MIME_LEN_VARY);
+  ce_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_VARY, TS_MIME_LEN_VARY, nullptr);
   if (ce_loc) {
     int idx, count, len;
 
@@ -244,7 +244,7 @@ etag_header(TSMBuffer bufp, TSMLoc hdr_loc)
   TSReturnCode ret = TS_SUCCESS;
   TSMLoc ce_loc;
 
-  ce_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_ETAG, TS_MIME_LEN_ETAG);
+  ce_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_ETAG, TS_MIME_LEN_ETAG, nullptr);
 
   if (ce_loc) {
     int strl;
@@ -675,7 +675,7 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
 
   // check if Range Requests are cacheable
   bool range_request = host_configuration->range_request();
-  rfield             = TSMimeHdrFieldFind(cbuf, chdr, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
+  rfield             = TSMimeHdrFieldFind(cbuf, chdr, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE, nullptr);
   if (rfield != TS_NULL_MLOC && !range_request) {
     debug("Range header found in the request and range_request is configured as false, not compressible");
     TSHandleMLocRelease(cbuf, chdr, rfield);
@@ -697,7 +697,7 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
   }
 
   *algorithms = host_configuration->compression_algorithms();
-  cfield      = TSMimeHdrFieldFind(cbuf, chdr, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING);
+  cfield      = TSMimeHdrFieldFind(cbuf, chdr, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING, nullptr);
   if (cfield != TS_NULL_MLOC) {
     int compression_acceptable = 0;
     int nvalues                = TSMimeHdrFieldValuesCount(cbuf, chdr, cfield);
@@ -743,7 +743,7 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
 
   /* If there already exists a content encoding then we don't want
      to do anything. */
-  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_ENCODING, -1);
+  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_ENCODING, -1, nullptr);
   if (field_loc) {
     info("response is already content encoded, not compressible");
     TSHandleMLocRelease(bufp, hdr_loc, field_loc);
@@ -751,7 +751,7 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
     return 0;
   }
 
-  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH);
+  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH, nullptr);
   if (field_loc != TS_NULL_MLOC) {
     unsigned int hdr_value = TSMimeHdrFieldValueUintGet(bufp, hdr_loc, field_loc, -1);
     TSHandleMLocRelease(bufp, hdr_loc, field_loc);
@@ -768,7 +768,7 @@ transformable(TSHttpTxn txnp, bool server, HostConfiguration *host_configuration
 
   /* We only want to do gzip compression on documents that have a
      content type of "text/" or "application/x-javascript". */
-  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, -1);
+  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, -1, nullptr);
   if (!field_loc) {
     info("no content type header found, not compressible");
     TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
@@ -818,7 +818,7 @@ compress_transform_add(TSHttpTxn txnp, HostConfiguration *hc, int compress_type,
 HostConfiguration *
 find_host_configuration(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer bufp, TSMLoc locp, Configuration *config)
 {
-  TSMLoc fieldp    = TSMimeHdrFieldFind(bufp, locp, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST);
+  TSMLoc fieldp    = TSMimeHdrFieldFind(bufp, locp, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST, nullptr);
   int strl         = 0;
   const char *strv = nullptr;
   HostConfiguration *host_configuration;

--- a/plugins/compress/misc.cc
+++ b/plugins/compress/misc.cc
@@ -80,7 +80,7 @@ strip_ae_value(ts::TextView &value)
 void
 normalize_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLoc hdr_loc)
 {
-  TSMLoc field = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING);
+  TSMLoc field = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING, nullptr);
   bool deflate = false;
   bool gzip    = false;
   bool br      = false;
@@ -134,7 +134,7 @@ normalize_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLo
 void
 hide_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLoc hdr_loc, const char *hidden_header_name)
 {
-  TSMLoc field = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING);
+  TSMLoc field = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING, nullptr);
   while (field) {
     TSMLoc tmp;
     tmp = TSMimeHdrFieldNextDup(reqp, hdr_loc, field);
@@ -147,7 +147,7 @@ hide_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLoc hdr
 void
 restore_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLoc hdr_loc, const char *hidden_header_name)
 {
-  TSMLoc field = TSMimeHdrFieldFind(reqp, hdr_loc, hidden_header_name, -1);
+  TSMLoc field = TSMimeHdrFieldFind(reqp, hdr_loc, hidden_header_name, -1, nullptr);
 
   while (field) {
     TSMLoc tmp;

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -254,7 +254,7 @@ CacheControlHeader::update(TSMBuffer bufp, TSMLoc hdr_loc)
   bool found_private   = false;
 
   // Load each value from the Cache-Control header into the vector values
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CACHE_CONTROL, TS_MIME_LEN_CACHE_CONTROL);
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CACHE_CONTROL, TS_MIME_LEN_CACHE_CONTROL, nullptr);
   if (field_loc != TS_NULL_MLOC) {
     int n_values = TSMimeHdrFieldValuesCount(bufp, hdr_loc, field_loc);
     if ((n_values != TS_ERROR) && (n_values > 0)) {
@@ -555,7 +555,7 @@ getDefaultBucket(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer bufp, TSMLoc hdr_obj
   int host_len            = 0;
   bool defaultBucketFound = false;
 
-  field_loc = TSMimeHdrFieldFind(bufp, hdr_obj, TS_MIME_FIELD_HOST, -1);
+  field_loc = TSMimeHdrFieldFind(bufp, hdr_obj, TS_MIME_FIELD_HOST, -1, nullptr);
   if (field_loc == TS_NULL_MLOC) {
     LOG_ERROR("Host field not found");
     return false;
@@ -719,7 +719,7 @@ static void
 checkGzipAcceptance(TSMBuffer bufp, TSMLoc hdr_loc, ClientRequest &creq)
 {
   creq.gzip_accepted = false;
-  TSMLoc field_loc   = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING);
+  TSMLoc field_loc   = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING, nullptr);
   if (field_loc != TS_NULL_MLOC) {
     const char *value;
     int value_len;
@@ -979,7 +979,7 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
         // Load this document's Cache-Control header into our managing object
         cch.update(resp_data.bufp, resp_data.hdr_loc);
 
-        field_loc = TSMimeHdrFieldFind(resp_data.bufp, resp_data.hdr_loc, TS_MIME_FIELD_EXPIRES, TS_MIME_LEN_EXPIRES);
+        field_loc = TSMimeHdrFieldFind(resp_data.bufp, resp_data.hdr_loc, TS_MIME_FIELD_EXPIRES, TS_MIME_LEN_EXPIRES, nullptr);
         if (field_loc != TS_NULL_MLOC) {
           time_t curr_field_expires_time;
           int n_values = TSMimeHdrFieldValuesCount(resp_data.bufp, resp_data.hdr_loc, field_loc);
@@ -1002,7 +1002,7 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
 
           const string &header = HEADER_ALLOWLIST[i];
 
-          field_loc = TSMimeHdrFieldFind(resp_data.bufp, resp_data.hdr_loc, header.c_str(), header.size());
+          field_loc = TSMimeHdrFieldFind(resp_data.bufp, resp_data.hdr_loc, header.c_str(), header.size(), nullptr);
           if (field_loc != TS_NULL_MLOC) {
             bool values_added = false;
             const char *value;
@@ -1070,7 +1070,7 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
 bool
 ContentTypeHandler::nextObjectHeader(TSMBuffer bufp, TSMLoc hdr_loc)
 {
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE);
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE, nullptr);
   if (field_loc != TS_NULL_MLOC) {
     bool values_added = false;
     const char *value;

--- a/plugins/esi/esi.cc
+++ b/plugins/esi/esi.cc
@@ -1161,7 +1161,7 @@ static bool
 checkHeaderValue(TSMBuffer bufp, TSMLoc hdr_loc, const char *name, int name_len, const char *exp_value, int exp_value_len,
                  bool prefix)
 {
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, name, name_len);
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, name, name_len, nullptr);
   if (!field_loc) {
     return false;
   }

--- a/plugins/esi/fetcher/HttpDataFetcherImpl.cc
+++ b/plugins/esi/fetcher/HttpDataFetcherImpl.cc
@@ -231,7 +231,7 @@ bool
 HttpDataFetcherImpl::_checkHeaderValue(TSMBuffer bufp, TSMLoc hdr_loc, const char *name, int name_len, const char *exp_value,
                                        int exp_value_len, bool prefix) const
 {
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, name, name_len);
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, name, name_len, nullptr);
   if (!field_loc) {
     return false;
   }

--- a/plugins/esi/serverIntercept.cc
+++ b/plugins/esi/serverIntercept.cc
@@ -158,7 +158,7 @@ handleRead(SContData *cont_data, bool &read_complete)
             TS_PARSE_DONE) {
           TSDebug(DEBUG_TAG, "[%s] Parsed header", __FUNCTION__);
           TSMLoc content_len_loc =
-            TSMimeHdrFieldFind(cont_data->req_hdr_bufp, cont_data->req_hdr_loc, TS_MIME_FIELD_CONTENT_LENGTH, -1);
+            TSMimeHdrFieldFind(cont_data->req_hdr_bufp, cont_data->req_hdr_loc, TS_MIME_FIELD_CONTENT_LENGTH, -1, nullptr);
           if (!content_len_loc) {
             TSError("[server_intercept][%s] request doesn't contain content length header [%s]", __FUNCTION__,
                     TS_MIME_FIELD_CONTENT_TYPE);

--- a/plugins/experimental/access_control/headers.cc
+++ b/plugins/experimental/access_control/headers.cc
@@ -39,7 +39,7 @@
 int
 removeHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 {
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
   int cnt         = 0;
 
   while (fieldLoc) {
@@ -64,7 +64,7 @@ removeHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 bool
 headerExist(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 {
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
   if (TS_NULL_MLOC != fieldLoc) {
     TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
     return true;
@@ -86,7 +86,7 @@ headerExist(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 char *
 getHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, char *value, int *valuelen)
 {
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
   char *dst       = value;
   while (fieldLoc) {
     TSMLoc next = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
@@ -140,7 +140,7 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
   }
 
   bool ret        = false;
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
 
   if (!fieldLoc || duplicateOk) {
     // No existing header or duplicates ok, so create one

--- a/plugins/experimental/access_control/plugin.cc
+++ b/plugins/experimental/access_control/plugin.cc
@@ -234,7 +234,7 @@ getCookieByName(TSHttpTxn txn, TSMBuffer buf, TSMLoc hdrs, const String &cookieN
 {
   TSMLoc field;
 
-  for (field = TSMimeHdrFieldFind(buf, hdrs, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE); field != TS_NULL_MLOC;
+  for (field = TSMimeHdrFieldFind(buf, hdrs, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, nullptr); field != TS_NULL_MLOC;
        field = ::nextDuplicate(buf, hdrs, field)) {
     int count = TSMimeHdrFieldValuesCount(buf, hdrs, field);
 

--- a/plugins/experimental/cache_fill/background_fetch.cc
+++ b/plugins/experimental/cache_fill/background_fetch.cc
@@ -52,7 +52,7 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
   }
 
   bool ret         = false;
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, header, len);
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, header, len, nullptr);
 
   if (!field_loc) {
     // No existing header, so create one

--- a/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
+++ b/plugins/experimental/collapsed_forwarding/collapsed_forwarding.cc
@@ -85,7 +85,7 @@ static int
 add_redirect_header(TSMBuffer &bufp, TSMLoc &hdr_loc, const std::string &location)
 {
   // This is needed in case the response already contains a Location header
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, LOCATION_HEADER, strlen(LOCATION_HEADER));
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, LOCATION_HEADER, strlen(LOCATION_HEADER), nullptr);
 
   if (field_loc == TS_NULL_MLOC) {
     TSMimeHdrFieldCreateNamed(bufp, hdr_loc, LOCATION_HEADER, strlen(LOCATION_HEADER), &field_loc);
@@ -115,7 +115,7 @@ check_internal_message_hdr(TSHttpTxn &txnp)
     return false;
   }
 
-  TSMLoc header_loc = TSMimeHdrFieldFind(bufp, hdr_loc, ATS_INTERNAL_MESSAGE, strlen(ATS_INTERNAL_MESSAGE));
+  TSMLoc header_loc = TSMimeHdrFieldFind(bufp, hdr_loc, ATS_INTERNAL_MESSAGE, strlen(ATS_INTERNAL_MESSAGE), nullptr);
   if (header_loc) {
     found = true;
     // found the header, remove it now..

--- a/plugins/experimental/cookie_remap/cookie_remap.cc
+++ b/plugins/experimental/cookie_remap/cookie_remap.cc
@@ -1180,7 +1180,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   std::string rewrite_to;
   char cookie_str[] = "Cookie";
-  TSMLoc field      = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, cookie_str, sizeof(cookie_str) - 1);
+  TSMLoc field      = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, cookie_str, sizeof(cookie_str) - 1, nullptr);
 
   // cookie header doesn't exist
   if (field == nullptr) {

--- a/plugins/experimental/custom_redirect/custom_redirect.cc
+++ b/plugins/experimental/custom_redirect/custom_redirect.cc
@@ -63,7 +63,7 @@ handle_response(TSHttpTxn txnp, TSCont /* contp ATS_UNUSED */)
         const char *method = TSHttpHdrMethodGet(req_bufp, req_loc, &method_len);
         if ((return_code == TS_HTTP_STATUS_NONE || return_code == status) &&
             ((strncasecmp(method, TS_HTTP_METHOD_GET, TS_HTTP_LEN_GET) == 0))) {
-          redirect_url_loc = TSMimeHdrFieldFind(resp_bufp, resp_loc, redirect_url_header, redirect_url_header_len);
+          redirect_url_loc = TSMimeHdrFieldFind(resp_bufp, resp_loc, redirect_url_header, redirect_url_header_len, nullptr);
 
           if (redirect_url_loc) {
             redirect_url_str = TSMimeHdrFieldValueStringGet(resp_bufp, resp_loc, redirect_url_loc, -1, &redirect_url_length);

--- a/plugins/experimental/inliner/ats-inliner.cc
+++ b/plugins/experimental/inliner/ats-inliner.cc
@@ -141,7 +141,7 @@ transformable(TSHttpTxn txnp)
 
   if (returnValue) {
     returnValue        = false;
-    const TSMLoc field = TSMimeHdrFieldFind(buffer, location, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE);
+    const TSMLoc field = TSMimeHdrFieldFind(buffer, location, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE, nullptr);
 
     if (field != TS_NULL_MLOC) {
       int length                = 0;

--- a/plugins/experimental/inliner/cache-handler.h
+++ b/plugins/experimental/inliner/cache-handler.h
@@ -51,7 +51,7 @@ bool
 getHeader(TSMBuffer buffer, TSMLoc location, const std::string &name, std::string &value)
 {
   bool result        = false;
-  const TSMLoc field = TSMimeHdrFieldFind(buffer, location, name.c_str(), name.size());
+  const TSMLoc field = TSMimeHdrFieldFind(buffer, location, name.c_str(), name.size(), nullptr);
   if (field != nullptr) {
     int length                = 0;
     const char *const content = TSMimeHdrFieldValueStringGet(buffer, location, field, -1, &length);

--- a/plugins/experimental/inliner/fetcher.h
+++ b/plugins/experimental/inliner/fetcher.h
@@ -181,7 +181,7 @@ template <class T> struct HttpTransaction {
     assert(b != nullptr);
     assert(l != nullptr);
     bool result        = false;
-    const TSMLoc field = TSMimeHdrFieldFind(b, l, TS_MIME_FIELD_TRANSFER_ENCODING, TS_MIME_LEN_TRANSFER_ENCODING);
+    const TSMLoc field = TSMimeHdrFieldFind(b, l, TS_MIME_FIELD_TRANSFER_ENCODING, TS_MIME_LEN_TRANSFER_ENCODING, nullptr);
     if (field != nullptr) {
       int length;
       const char *const value = TSMimeHdrFieldValueStringGet(b, l, field, -1, &length);

--- a/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/experimental/ja3_fingerprint/ja3_fingerprint.cc
@@ -274,7 +274,7 @@ append_to_field(TSMBuffer bufp, TSMLoc hdr_loc, const char *field, int field_len
     return;
   }
 
-  TSMLoc target = TSMimeHdrFieldFind(bufp, hdr_loc, field, field_len);
+  TSMLoc target = TSMimeHdrFieldFind(bufp, hdr_loc, field, field_len, nullptr);
   if (target == TS_NULL_MLOC) {
     TSMimeHdrFieldCreateNamed(bufp, hdr_loc, field, field_len, &target);
     TSMimeHdrFieldAppend(bufp, hdr_loc, target);

--- a/plugins/experimental/metalink/metalink.cc
+++ b/plugins/experimental/metalink/metalink.cc
@@ -781,7 +781,7 @@ http_send_response_hdr(TSCont contp, void *edata)
    * Then scan if the URL or digest already exist in the cache. */
 
   /* If the response has a Location header */
-  data->location_loc = TSMimeHdrFieldFind(data->resp_bufp, data->hdr_loc, TS_MIME_FIELD_LOCATION, TS_MIME_LEN_LOCATION);
+  data->location_loc = TSMimeHdrFieldFind(data->resp_bufp, data->hdr_loc, TS_MIME_FIELD_LOCATION, TS_MIME_LEN_LOCATION, nullptr);
   if (!data->location_loc) {
     TSHandleMLocRelease(data->resp_bufp, TS_NULL_MLOC, data->hdr_loc);
 
@@ -825,7 +825,7 @@ http_send_response_hdr(TSCont contp, void *edata)
   }
 
   /* ... and a Digest header */
-  data->digest_loc = TSMimeHdrFieldFind(data->resp_bufp, data->hdr_loc, "Digest", 6);
+  data->digest_loc = TSMimeHdrFieldFind(data->resp_bufp, data->hdr_loc, "Digest", 6, nullptr);
   while (data->digest_loc) {
     int count = TSMimeHdrFieldValuesCount(data->resp_bufp, data->hdr_loc, data->digest_loc);
     for (data->idx = 0; data->idx < count; data->idx += 1) {

--- a/plugins/experimental/money_trace/money_trace.cc
+++ b/plugins/experimental/money_trace/money_trace.cc
@@ -116,7 +116,7 @@ mt_check_request_header(TSHttpTxn txnp)
 
   // check for a money trace header.  If there is one, schedule appropriate continuations.
   if (TS_SUCCESS == TSHttpTxnClientReqGet(txnp, &bufp, &hdr_loc)) {
-    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, MIME_FIELD_MONEY_TRACE, MIME_LEN_MONEY_TRACE);
+    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, MIME_FIELD_MONEY_TRACE, MIME_LEN_MONEY_TRACE, nullptr);
     if (TS_NULL_MLOC != field_loc) {
       const char *hdr_value = TSMimeHdrFieldValueStringGet(bufp, hdr_loc, field_loc, 0, &length);
       if (!hdr_value || length <= 0) {
@@ -200,7 +200,7 @@ mt_send_server_request(TSHttpTxn txnp, struct txndata *txn_data)
   }
 
   if (TS_SUCCESS == TSHttpTxnServerReqGet(txnp, &bufp, &hdr_loc)) {
-    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, MIME_FIELD_MONEY_TRACE, MIME_LEN_MONEY_TRACE);
+    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, MIME_FIELD_MONEY_TRACE, MIME_LEN_MONEY_TRACE, nullptr);
     if (TS_NULL_MLOC != field_loc) {
       if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdr_loc, field_loc, -1, txn_data->new_span_mt_header,
                                                      strlen(txn_data->new_span_mt_header))) {

--- a/plugins/experimental/mp4/mp4.cc
+++ b/plugins/experimental/mp4/mp4.cc
@@ -126,14 +126,15 @@ TSRemapDoRemap(void * /* ih ATS_UNUSED */, TSHttpTxn rh, TSRemapRequestInfo *rri
   TSUrlHttpQuerySet(rri->requestBufp, rri->requestUrl, buf, buf_len);
 
   // remove Accept-Encoding
-  ae_field = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING);
+  ae_field =
+    TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING, nullptr);
   if (ae_field) {
     TSMimeHdrFieldDestroy(rri->requestBufp, rri->requestHdrp, ae_field);
     TSHandleMLocRelease(rri->requestBufp, rri->requestHdrp, ae_field);
   }
 
   // remove Range
-  range_field = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
+  range_field = TSMimeHdrFieldFind(rri->requestBufp, rri->requestHdrp, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE, nullptr);
   if (range_field) {
     TSMimeHdrFieldDestroy(rri->requestBufp, rri->requestHdrp, range_field);
     TSHandleMLocRelease(rri->requestBufp, rri->requestHdrp, range_field);
@@ -211,7 +212,7 @@ mp4_cache_lookup_complete(Mp4Context *mc, TSHttpTxn txnp)
 
   n = 0;
 
-  cl_field = TSMimeHdrFieldFind(bufp, hdrp, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH);
+  cl_field = TSMimeHdrFieldFind(bufp, hdrp, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH, nullptr);
   if (cl_field) {
     n = TSMimeHdrFieldValueInt64Get(bufp, hdrp, cl_field, -1);
     TSHandleMLocRelease(bufp, hdrp, cl_field);
@@ -249,7 +250,7 @@ mp4_read_response(Mp4Context *mc, TSHttpTxn txnp)
   }
 
   n        = 0;
-  cl_field = TSMimeHdrFieldFind(bufp, hdrp, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH);
+  cl_field = TSMimeHdrFieldFind(bufp, hdrp, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH, nullptr);
   if (cl_field) {
     n = TSMimeHdrFieldValueInt64Get(bufp, hdrp, cl_field, -1);
     TSHandleMLocRelease(bufp, hdrp, cl_field);

--- a/plugins/experimental/mysql_remap/mysql_remap.cc
+++ b/plugins/experimental/mysql_remap/mysql_remap.cc
@@ -64,7 +64,7 @@ do_mysql_remap(TSCont contp, TSHttpTxn txnp)
     goto release_hdr;
   }
 
-  field_loc = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST);
+  field_loc = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST, nullptr);
 
   if (!field_loc) {
     TSDebug(PLUGIN_NAME, "couldn't retrieve request HOST header");

--- a/plugins/experimental/slice/HttpHeader.cc
+++ b/plugins/experimental/slice/HttpHeader.cc
@@ -137,7 +137,7 @@ HttpHeader::hasKey(char const *const key, int const keylen) const
     return false;
   }
 
-  TSMLoc const locfield(TSMimeHdrFieldFind(m_buffer, m_lochdr, key, keylen));
+  TSMLoc const locfield(TSMimeHdrFieldFind(m_buffer, m_lochdr, key, keylen, nullptr));
   if (nullptr != locfield) {
     TSHandleMLocRelease(m_buffer, m_lochdr, locfield);
     return true;
@@ -155,7 +155,7 @@ HttpHeader::removeKey(char const *const keystr, int const keylen)
 
   bool status = true;
 
-  TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen);
+  TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen, nullptr);
   if (nullptr != locfield) {
     int const rcode = TSMimeHdrFieldRemove(m_buffer, m_lochdr, locfield);
     status          = (TS_SUCCESS == rcode);
@@ -175,7 +175,7 @@ HttpHeader::valueForKey(char const *const keystr, int const keylen, char *const 
 
   bool status = false;
 
-  TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen);
+  TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen, nullptr);
 
   if (nullptr != locfield) {
     int getlen               = 0;
@@ -209,7 +209,7 @@ HttpHeader::setKeyVal(char const *const keystr, int const keylen, char const *co
 
   bool status(false);
 
-  TSMLoc locfield(TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen));
+  TSMLoc locfield(TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen, nullptr));
 
   if (nullptr != locfield) {
     status = TS_SUCCESS == TSMimeHdrFieldValueStringSet(m_buffer, m_lochdr, locfield, index, valstr, vallen);
@@ -244,7 +244,7 @@ HttpHeader::timeForKey(char const *const keystr, int const keylen, time_t *const
 
   bool status = false;
 
-  TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen);
+  TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen, nullptr);
 
   if (nullptr != locfield) {
     *timeval = TSMimeHdrFieldValueDateGet(m_buffer, m_lochdr, locfield);
@@ -265,7 +265,7 @@ HttpHeader::setKeyTime(char const *const keystr, int const keylen, time_t const 
 
   bool status(false);
 
-  TSMLoc locfield(TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen));
+  TSMLoc locfield(TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen, nullptr));
 
   if (nullptr == locfield) {
     DEBUG_LOG("Creating header %.*s", keylen, keystr);

--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -75,7 +75,7 @@ SslHdrRemoveHeader(TSMBuffer mbuf, TSMLoc mhdr, const std::string &name)
   TSMLoc field;
   TSMLoc next;
 
-  field = TSMimeHdrFieldFind(mbuf, mhdr, name.c_str(), name.size());
+  field = TSMimeHdrFieldFind(mbuf, mhdr, name.c_str(), name.size(), nullptr);
   for (; field != TS_NULL_MLOC; field = next) {
     next = TSMimeHdrFieldNextDup(mbuf, mhdr, field);
     TSMimeHdrFieldDestroy(mbuf, mhdr, field);
@@ -94,7 +94,7 @@ SslHdrSetHeader(TSMBuffer mbuf, TSMLoc mhdr, const std::string &name, BIO *value
 
   SslHdrDebug("SSL header '%s'", name.c_str());
 
-  field = TSMimeHdrFieldFind(mbuf, mhdr, name.c_str(), name.size());
+  field = TSMimeHdrFieldFind(mbuf, mhdr, name.c_str(), name.size(), nullptr);
   if (field == TS_NULL_MLOC) {
     TSMimeHdrFieldCreateNamed(mbuf, mhdr, name.c_str(), name.size(), &field);
     TSMimeHdrFieldValueStringSet(mbuf, mhdr, field, -1, vptr, vlen);

--- a/plugins/experimental/tls_bridge/tls_bridge.cc
+++ b/plugins/experimental/tls_bridge/tls_bridge.cc
@@ -48,7 +48,7 @@ void
 Hdr_Remove_Field(TSMBuffer mbuf, TSMLoc hdr_loc, TextView field)
 {
   TSMLoc field_loc;
-  if (TS_NULL_MLOC != (field_loc = TSMimeHdrFieldFind(mbuf, hdr_loc, field.data(), field.size()))) {
+  if (TS_NULL_MLOC != (field_loc = TSMimeHdrFieldFind(mbuf, hdr_loc, field.data(), field.size(), nullptr))) {
     TSMimeHdrFieldDestroy(mbuf, hdr_loc, field_loc);
     TSHandleMLocRelease(mbuf, hdr_loc, field_loc);
   }

--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -215,7 +215,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
       goto fail;
     }
 
-    field = TSMimeHdrFieldFind(buffer, hdr, "Cookie", 6);
+    field = TSMimeHdrFieldFind(buffer, hdr, "Cookie", 6, NULL);
     if (field == TS_NULL_MLOC) {
       TSHandleMLocRelease(buffer, TS_NULL_MLOC, hdr);
       if (!checked_auth) {

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -282,7 +282,7 @@ GeneratorGetRequestHeader(GeneratorHttpHeader &request, const char *field_name, 
 {
   TSMLoc field;
 
-  field = TSMimeHdrFieldFind(request.buffer, request.header, field_name, field_len);
+  field = TSMimeHdrFieldFind(request.buffer, request.header, field_name, field_len, nullptr);
   if (field != TS_NULL_MLOC) {
     default_value = TSMimeHdrFieldValueInt64Get(request.buffer, request.header, field, -1);
   }

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -231,7 +231,7 @@ ConditionHeader::append_value(std::string &s, const Resources &res)
   if (bufp && hdr_loc) {
     TSMLoc field_loc;
 
-    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, _qualifier.c_str(), _qualifier.size());
+    field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, _qualifier.c_str(), _qualifier.size(), nullptr);
     TSDebug(PLUGIN_NAME, "Getting Header: %s, field_loc: %p", _qualifier.c_str(), field_loc);
 
     while (field_loc) {
@@ -477,7 +477,7 @@ ConditionCookie::append_value(std::string &s, const Resources &res)
   }
 
   // Find Cookie
-  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE);
+  field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, nullptr);
   if (field_loc == nullptr) {
     return;
   }

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -573,7 +573,7 @@ OperatorRMHeader::exec(const Resources &res) const
 
   if (res.bufp && res.hdr_loc) {
     TSDebug(PLUGIN_NAME, "OperatorRMHeader::exec() invoked on %s", _header.c_str());
-    field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, _header.c_str(), _header.size());
+    field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, _header.c_str(), _header.size(), nullptr);
     while (field_loc) {
       TSDebug(PLUGIN_NAME, "   Deleting header %s", _header.c_str());
       tmp = TSMimeHdrFieldNextDup(res.bufp, res.hdr_loc, field_loc);
@@ -643,7 +643,7 @@ OperatorSetHeader::exec(const Resources &res) const
   }
 
   if (res.bufp && res.hdr_loc) {
-    TSMLoc field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, _header.c_str(), _header.size());
+    TSMLoc field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, _header.c_str(), _header.size(), nullptr);
 
     TSDebug(PLUGIN_NAME, "OperatorSetHeader::exec() invoked on %s: %s", _header.c_str(), value.c_str());
 
@@ -722,10 +722,10 @@ OperatorRMCookie::exec(const Resources &res) const
 {
   if (res.bufp && res.hdr_loc) {
     TSDebug(PLUGIN_NAME, "OperatorRMCookie::exec() invoked on cookie %s", _cookie.c_str());
-    TSMLoc field_loc;
 
     // Find Cookie
-    field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE);
+    TSHdrHandle handle;
+    TSMLoc field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, &handle);
     if (nullptr == field_loc) {
       TSDebug(PLUGIN_NAME, "OperatorRMCookie::exec, no cookie");
       return;
@@ -744,7 +744,6 @@ OperatorRMCookie::exec(const Resources &res) const
         TSDebug(PLUGIN_NAME, "OperatorRMCookie::exec, updated_cookie = [%s]", updated_cookie.c_str());
       }
     }
-    TSHandleMLocRelease(res.bufp, res.hdr_loc, field_loc);
   }
 }
 
@@ -765,10 +764,10 @@ OperatorAddCookie::exec(const Resources &res) const
 
   if (res.bufp && res.hdr_loc) {
     TSDebug(PLUGIN_NAME, "OperatorAddCookie::exec() invoked on cookie %s", _cookie.c_str());
-    TSMLoc field_loc;
 
     // Find Cookie
-    field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE);
+    TSHdrHandle handle;
+    TSMLoc field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, &handle);
     if (nullptr == field_loc) {
       TSDebug(PLUGIN_NAME, "OperatorAddCookie::exec, no cookie");
       if (TS_SUCCESS == TSMimeHdrFieldCreateNamed(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, &field_loc)) {
@@ -777,7 +776,6 @@ OperatorAddCookie::exec(const Resources &res) const
           TSDebug(PLUGIN_NAME, "Adding cookie %s", _cookie.c_str());
           TSMimeHdrFieldAppend(res.bufp, res.hdr_loc, field_loc);
         }
-        TSHandleMLocRelease(res.bufp, res.hdr_loc, field_loc);
       }
       return;
     }
@@ -810,10 +808,10 @@ OperatorSetCookie::exec(const Resources &res) const
 
   if (res.bufp && res.hdr_loc) {
     TSDebug(PLUGIN_NAME, "OperatorSetCookie::exec() invoked on cookie %s", _cookie.c_str());
-    TSMLoc field_loc;
 
     // Find Cookie
-    field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE);
+    TSHdrHandle handle;
+    TSMLoc field_loc = TSMimeHdrFieldFind(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, &handle);
     if (nullptr == field_loc) {
       TSDebug(PLUGIN_NAME, "OperatorSetCookie::exec, no cookie");
       if (TS_SUCCESS == TSMimeHdrFieldCreateNamed(res.bufp, res.hdr_loc, TS_MIME_FIELD_COOKIE, TS_MIME_LEN_COOKIE, &field_loc)) {
@@ -822,7 +820,6 @@ OperatorSetCookie::exec(const Resources &res) const
           TSDebug(PLUGIN_NAME, "Adding cookie %s", _cookie.c_str());
           TSMimeHdrFieldAppend(res.bufp, res.hdr_loc, field_loc);
         }
-        TSHandleMLocRelease(res.bufp, res.hdr_loc, field_loc);
       }
       return;
     }
@@ -835,7 +832,6 @@ OperatorSetCookie::exec(const Resources &res) const
           TSMimeHdrFieldValueStringSet(res.bufp, res.hdr_loc, field_loc, -1, updated_cookie.c_str(), updated_cookie.size())) {
       TSDebug(PLUGIN_NAME, "OperatorSetCookie::exec, updated_cookie = [%s]", updated_cookie.c_str());
     }
-    TSHandleMLocRelease(res.bufp, res.hdr_loc, field_loc);
   }
 }
 

--- a/plugins/lua/ts_lua_cached_response.c
+++ b/plugins/lua/ts_lua_cached_response.c
@@ -154,7 +154,7 @@ ts_lua_cached_response_header_get(lua_State *L)
   TS_LUA_CHECK_CACHED_RESPONSE_HDR(http_ctx);
 
   if (key && key_len) {
-    field_loc = TSMimeHdrFieldFind(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, key, key_len);
+    field_loc = TSMimeHdrFieldFind(http_ctx->cached_response_bufp, http_ctx->cached_response_hdrp, key, key_len, NULL);
 
     if (field_loc != TS_NULL_MLOC) {
       count = 0;

--- a/plugins/lua/ts_lua_client_request.c
+++ b/plugins/lua/ts_lua_client_request.c
@@ -167,7 +167,7 @@ ts_lua_client_request_header_get(lua_State *L)
   key = luaL_checklstring(L, 2, &key_len);
 
   if (key && key_len) {
-    field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len);
+    field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len, NULL);
 
     if (field_loc != TS_NULL_MLOC) {
       count = 0;
@@ -223,7 +223,7 @@ ts_lua_client_request_header_set(lua_State *L)
     val = luaL_checklstring(L, 3, &val_len);
   }
 
-  field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len);
+  field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len, NULL);
 
   if (remove) {
     while (field_loc != TS_NULL_MLOC) {
@@ -435,13 +435,13 @@ ts_lua_client_request_get_url_host(lua_State *L)
 
     TSMLoc field_loc;
 
-    field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len);
+    field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, key, key_len, NULL);
     if (field_loc) {
       host = TSMimeHdrFieldValueStringGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, &len);
       TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);
 
     } else {
-      field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, l_key, key_len);
+      field_loc = TSMimeHdrFieldFind(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, l_key, key_len, NULL);
       if (field_loc) {
         host = TSMimeHdrFieldValueStringGet(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc, -1, &len);
         TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, field_loc);

--- a/plugins/lua/ts_lua_client_response.c
+++ b/plugins/lua/ts_lua_client_response.c
@@ -100,7 +100,7 @@ ts_lua_client_response_header_get(lua_State *L)
   }
 
   if (key && key_len) {
-    field_loc = TSMimeHdrFieldFind(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, key, key_len);
+    field_loc = TSMimeHdrFieldFind(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, key, key_len, NULL);
     if (field_loc != TS_NULL_MLOC) {
       count = 0;
       while (field_loc != TS_NULL_MLOC) {
@@ -161,7 +161,7 @@ ts_lua_client_response_header_set(lua_State *L)
     }
   }
 
-  field_loc = TSMimeHdrFieldFind(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, key, key_len);
+  field_loc = TSMimeHdrFieldFind(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, key, key_len, NULL);
 
   if (remove) {
     while (field_loc != TS_NULL_MLOC) {
@@ -423,7 +423,7 @@ ts_lua_client_response_set_error_resp(lua_State *L)
   }
 
   field_loc = TSMimeHdrFieldFind(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, TS_MIME_FIELD_TRANSFER_ENCODING,
-                                 TS_MIME_LEN_TRANSFER_ENCODING);
+                                 TS_MIME_LEN_TRANSFER_ENCODING, NULL);
 
   if (field_loc) {
     TSMimeHdrFieldDestroy(http_ctx->client_response_bufp, http_ctx->client_response_hdrp, field_loc);

--- a/plugins/lua/ts_lua_server_request.c
+++ b/plugins/lua/ts_lua_server_request.c
@@ -188,7 +188,7 @@ ts_lua_server_request_header_get(lua_State *L)
   }
 
   if (key && key_len) {
-    field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len);
+    field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len, NULL);
 
     if (field_loc != TS_NULL_MLOC) {
       count = 0;
@@ -250,7 +250,7 @@ ts_lua_server_request_header_set(lua_State *L)
     }
   }
 
-  field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len);
+  field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len, NULL);
 
   if (remove) {
     while (field_loc != TS_NULL_MLOC) {
@@ -596,13 +596,13 @@ ts_lua_server_request_get_url_host(lua_State *L)
 
     TSMLoc field_loc;
 
-    field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len);
+    field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, key, key_len, NULL);
     if (field_loc) {
       host = TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &len);
       TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);
 
     } else {
-      field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, l_key, key_len);
+      field_loc = TSMimeHdrFieldFind(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, l_key, key_len, NULL);
       if (field_loc) {
         host = TSMimeHdrFieldValueStringGet(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc, -1, &len);
         TSHandleMLocRelease(http_ctx->server_request_bufp, http_ctx->server_request_hdrp, field_loc);

--- a/plugins/lua/ts_lua_server_response.c
+++ b/plugins/lua/ts_lua_server_response.c
@@ -181,7 +181,7 @@ ts_lua_server_response_header_get(lua_State *L)
   TS_LUA_CHECK_SERVER_RESPONSE_HDR(http_ctx);
 
   if (key && key_len) {
-    field_loc = TSMimeHdrFieldFind(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, key, key_len);
+    field_loc = TSMimeHdrFieldFind(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, key, key_len, NULL);
     if (field_loc != TS_NULL_MLOC) {
       count = 0;
       while (field_loc != TS_NULL_MLOC) {
@@ -238,7 +238,7 @@ ts_lua_server_response_header_set(lua_State *L)
 
   TS_LUA_CHECK_SERVER_RESPONSE_HDR(http_ctx);
 
-  field_loc = TSMimeHdrFieldFind(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, key, key_len);
+  field_loc = TSMimeHdrFieldFind(http_ctx->server_response_bufp, http_ctx->server_response_hdrp, key, key_len, NULL);
 
   if (remove) {
     while (field_loc != TS_NULL_MLOC) {

--- a/plugins/multiplexer/fetcher.h
+++ b/plugins/multiplexer/fetcher.h
@@ -160,7 +160,7 @@ template <class T> struct HttpTransaction {
     assert(b != nullptr);
     assert(l != nullptr);
     bool result        = false;
-    const TSMLoc field = TSMimeHdrFieldFind(b, l, TS_MIME_FIELD_TRANSFER_ENCODING, TS_MIME_LEN_TRANSFER_ENCODING);
+    const TSMLoc field = TSMimeHdrFieldFind(b, l, TS_MIME_FIELD_TRANSFER_ENCODING, TS_MIME_LEN_TRANSFER_ENCODING, nullptr);
     if (field != nullptr) {
       int length;
       const char *const value = TSMimeHdrFieldValueStringGet(b, l, field, -1, &length);

--- a/plugins/multiplexer/original-request.cc
+++ b/plugins/multiplexer/original-request.cc
@@ -63,12 +63,12 @@ OriginalRequest::OriginalRequest(const TSMBuffer b, const TSMLoc l) : buffer_(b)
   /*
    * this code assumes the request has a single Host header
    */
-  hostHeader_ = TSMimeHdrFieldFind(b, l, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST);
+  hostHeader_ = TSMimeHdrFieldFind(b, l, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST, nullptr);
   assert(hostHeader_ != nullptr);
 
   const_cast<std::string &>(original.hostHeader) = get(buffer_, location_, hostHeader_);
 
-  xMultiplexerHeader_ = TSMimeHdrFieldFind(b, l, "X-Multiplexer", 13);
+  xMultiplexerHeader_ = TSMimeHdrFieldFind(b, l, "X-Multiplexer", 13, nullptr);
 
   if (xMultiplexerHeader_ != nullptr) {
     const_cast<std::string &>(original.xMultiplexerHeader) = get(buffer_, location_, xMultiplexerHeader_);

--- a/plugins/prefetch/headers.cc
+++ b/plugins/prefetch/headers.cc
@@ -39,7 +39,7 @@
 int
 removeHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 {
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
   int cnt         = 0;
 
   while (fieldLoc) {
@@ -64,7 +64,7 @@ removeHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 bool
 headerExist(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 {
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
   if (TS_NULL_MLOC != fieldLoc) {
     TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
     return true;
@@ -86,7 +86,7 @@ headerExist(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
 char *
 getHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, char *value, int *valuelen)
 {
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
   char *dst       = value;
   while (fieldLoc) {
     TSMLoc next = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
@@ -140,7 +140,7 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
   }
 
   bool ret        = false;
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen, nullptr);
 
   if (!fieldLoc) {
     // No existing header, so create one

--- a/plugins/regex_revalidate/regex_revalidate.c
+++ b/plugins/regex_revalidate/regex_revalidate.c
@@ -589,7 +589,7 @@ get_date_from_cached_hdr(TSHttpTxn txn)
   time_t date = 0;
 
   if (TSHttpTxnCachedRespGet(txn, &buf, &hdr_loc) == TS_SUCCESS) {
-    date_loc = TSMimeHdrFieldFind(buf, hdr_loc, TS_MIME_FIELD_DATE, TS_MIME_LEN_DATE);
+    date_loc = TSMimeHdrFieldFind(buf, hdr_loc, TS_MIME_FIELD_DATE, TS_MIME_LEN_DATE, NULL);
     if (date_loc != TS_NULL_MLOC) {
       date = TSMimeHdrFieldValueDateGet(buf, hdr_loc, date_loc);
       TSHandleMLocRelease(buf, hdr_loc, date_loc);

--- a/plugins/remap_purge/remap_purge.c
+++ b/plugins/remap_purge/remap_purge.c
@@ -190,7 +190,7 @@ handle_purge(TSHttpTxn txnp, PurgeInstance *purge)
     if ((TS_HTTP_METHOD_PURGE == method) || ((TS_HTTP_METHOD_GET == method) && purge->allow_get)) {
       /* First see if we require the "secret" to be passed in a header, and then use that */
       if (purge->header) {
-        TSMLoc field_loc = TSMimeHdrFieldFind(reqp, hdr_loc, purge->header, purge->header_len);
+        TSMLoc field_loc = TSMimeHdrFieldFind(reqp, hdr_loc, purge->header, purge->header_len, NULL);
 
         if (field_loc) {
           const char *header;

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -706,7 +706,7 @@ S3Request::set_header(const char *header, int header_len, const char *val, int v
   }
 
   bool ret         = false;
-  TSMLoc field_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, header, header_len);
+  TSMLoc field_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, header, header_len, nullptr);
 
   if (!field_loc) {
     // No existing header, so create one
@@ -866,7 +866,7 @@ S3Request::authorizeV2(S3Config *s3)
   // If the configuration is a "virtual host" (foo.s3.aws ...), extract the
   // first portion into the Host: header.
   if (s3->virt_host()) {
-    host_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST);
+    host_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST, nullptr);
     if (host_loc) {
       host      = TSMimeHdrFieldValueStringGet(_bufp, _hdr_loc, host_loc, -1, &host_len);
       host_endp = static_cast<const char *>(memchr(host, '.', host_len));
@@ -876,14 +876,14 @@ S3Request::authorizeV2(S3Config *s3)
   }
 
   // Just in case we add Content-MD5 if present
-  md5_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, TS_MIME_FIELD_CONTENT_MD5, TS_MIME_LEN_CONTENT_MD5);
+  md5_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, TS_MIME_FIELD_CONTENT_MD5, TS_MIME_LEN_CONTENT_MD5, nullptr);
   if (md5_loc) {
     con_md5 = TSMimeHdrFieldValueStringGet(_bufp, _hdr_loc, md5_loc, -1, &con_md5_len);
   }
 
   // get the Content-Type if available - (buggy) clients may send it
   // for GET requests too
-  contype_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE);
+  contype_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE, nullptr);
   if (contype_loc) {
     con_type = TSMimeHdrFieldValueStringGet(_bufp, _hdr_loc, contype_loc, -1, &con_type_len);
   }

--- a/plugins/stats_over_http/stats_over_http.c
+++ b/plugins/stats_over_http/stats_over_http.c
@@ -597,7 +597,7 @@ stats_origin(TSCont contp ATS_UNUSED, TSEvent event ATS_UNUSED, void *edata)
   memset(my_state, 0, sizeof(*my_state));
   icontp = TSContCreate(stats_dostuff, TSMutexCreate());
 
-  accept_field     = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT, TS_MIME_LEN_ACCEPT);
+  accept_field     = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT, TS_MIME_LEN_ACCEPT, NULL);
   my_state->output = JSON_OUTPUT; // default to json output
   // accept header exists, use it to determine response type
   if (accept_field != TS_NULL_MLOC) {
@@ -613,7 +613,7 @@ stats_origin(TSCont contp ATS_UNUSED, TSEvent event ATS_UNUSED, void *edata)
   }
 
   // Check for Accept Encoding and init
-  accept_encoding_field = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING);
+  accept_encoding_field = TSMimeHdrFieldFind(reqp, hdr_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING, NULL);
   my_state->encoding    = NONE;
   if (accept_encoding_field != TS_NULL_MLOC) {
     int len         = -1;

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -101,7 +101,7 @@ FindOrMakeHdrField(TSMBuffer buffer, TSMLoc hdr, const char *name, unsigned len)
 {
   TSMLoc field;
 
-  field = TSMimeHdrFieldFind(buffer, hdr, name, len);
+  field = TSMimeHdrFieldFind(buffer, hdr, name, len, nullptr);
   if (field == TS_NULL_MLOC) {
     if (TSMimeHdrFieldCreateNamed(buffer, hdr, name, len, &field) == TS_SUCCESS) {
       TSReleaseAssert(TSMimeHdrFieldAppend(buffer, hdr, field) == TS_SUCCESS);
@@ -582,7 +582,7 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
   TSDebug("xdebug", "scanning for %s header values", xDebugHeader.str);
 
   // Walk the X-Debug header values and determine what to inject into the response.
-  field = TSMimeHdrFieldFind(buffer, hdr, xDebugHeader.str, xDebugHeader.len);
+  field = TSMimeHdrFieldFind(buffer, hdr, xDebugHeader.str, xDebugHeader.len, nullptr);
   while (field != TS_NULL_MLOC) {
     int count = TSMimeHdrFieldValuesCount(buffer, hdr, field);
 
@@ -700,7 +700,7 @@ XDeleteDebugHdr(TSCont /* contp */, TSEvent event, void *edata)
     return TS_EVENT_NONE;
   }
 
-  field = TSMimeHdrFieldFind(buffer, hdr, xDebugHeader.str, xDebugHeader.len);
+  field = TSMimeHdrFieldFind(buffer, hdr, xDebugHeader.str, xDebugHeader.len, nullptr);
   if (field == TS_NULL_MLOC) {
     return TS_EVENT_NONE;
   }

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -450,14 +450,13 @@ static int
 get_request_id_value(const char *name, TSMBuffer buf, TSMLoc hdr)
 {
   int id = -1;
-  TSMLoc field;
+  TSHdrHandle handle;
 
-  field = TSMimeHdrFieldFind(buf, hdr, name, -1);
+  TSMLoc field = TSMimeHdrFieldFind(buf, hdr, name, -1, &handle);
   if (field != TS_NULL_MLOC) {
     id = TSMimeHdrFieldValueIntGet(buf, hdr, field, 0);
   }
 
-  TSHandleMLocRelease(buf, hdr, field);
   return id;
 }
 
@@ -5400,7 +5399,7 @@ REGRESSION_TEST(SDK_API_TSMimeHdrField)(RegressionTest *test, int /* atype ATS_U
     if (TSMimeHdrFieldDestroy(bufp1, mime_loc1, field_loc15) != TS_SUCCESS) {
       SDK_RPRINT(test, "TSMimeHdrFieldDestroy", "TestCase1", TC_FAIL, "TSMimeHdrFieldDestroy returns TS_ERROR");
     } else {
-      if ((test_field_loc15 = TSMimeHdrFieldFind(bufp1, mime_loc1, field5Name, -1)) == TS_NULL_MLOC) {
+      if ((test_field_loc15 = TSMimeHdrFieldFind(bufp1, mime_loc1, field5Name, -1, nullptr)) == TS_NULL_MLOC) {
         SDK_RPRINT(test, "TSMimeHdrFieldDestroy", "TestCase1", TC_PASS, "ok");
         test_passed_Mime_Hdr_Field_Destroy = true;
       } else {
@@ -5930,7 +5929,7 @@ REGRESSION_TEST(SDK_API_TSMimeHdrParse)(RegressionTest *test, int /* atype ATS_U
 
   // TSMimeHdrFieldNextDup
   if (test_passed_parse == true) {
-    if ((field_loc1 = TSMimeHdrFieldFind(bufp1, mime_hdr_loc1, DUPLICATE_FIELD_NAME, -1)) == TS_NULL_MLOC) {
+    if ((field_loc1 = TSMimeHdrFieldFind(bufp1, mime_hdr_loc1, DUPLICATE_FIELD_NAME, -1, nullptr)) == TS_NULL_MLOC) {
       SDK_RPRINT(test, "TSMimeHdrFieldNextDup", "TestCase1", TC_FAIL, "TSMimeHdrFieldFind returns TS_NULL_MLOC");
       SDK_RPRINT(test, "TSMimeHdrFieldFind", "TestCase1", TC_PASS, "TSMimeHdrFieldFind returns TS_NULL_MLOC");
     } else {
@@ -6006,14 +6005,14 @@ REGRESSION_TEST(SDK_API_TSMimeHdrParse)(RegressionTest *test, int /* atype ATS_U
 
   // TSMimeHdrFieldRemove
   if (test_passed_mime_hdr_copy == true) {
-    if ((field_loc1 = TSMimeHdrFieldFind(bufp2, mime_hdr_loc2, REMOVE_FIELD_NAME, -1)) == TS_NULL_MLOC) {
+    if ((field_loc1 = TSMimeHdrFieldFind(bufp2, mime_hdr_loc2, REMOVE_FIELD_NAME, -1, nullptr)) == TS_NULL_MLOC) {
       SDK_RPRINT(test, "TSMimeHdrFieldRemove", "TestCase1", TC_FAIL, "TSMimeHdrFieldFind returns TS_NULL_MLOC");
     } else {
       if (TSMimeHdrFieldRemove(bufp2, mime_hdr_loc2, field_loc1) != TS_SUCCESS) {
         SDK_RPRINT(test, "TSMimeHdrFieldRemove", "TestCase1", TC_FAIL, "TSMimeHdrFieldRemove returns TS_ERROR");
       } else {
         // Make sure the remove actually took effect
-        field_loc2 = TSMimeHdrFieldFind(bufp2, mime_hdr_loc2, REMOVE_FIELD_NAME, -1);
+        field_loc2 = TSMimeHdrFieldFind(bufp2, mime_hdr_loc2, REMOVE_FIELD_NAME, -1, nullptr);
         if ((field_loc2 == TS_NULL_MLOC) || (field_loc1 != field_loc2)) {
           test_passed_mime_hdr_field_remove = true;
         } else {
@@ -7894,7 +7893,7 @@ transform_hook_handler(TSCont contp, TSEvent event, void *edata)
       if (TSHttpTxnClientReqGet(txnp, &bufp, &hdr) != TS_SUCCESS) {
         SDK_RPRINT(data->test, "TSHttpTxnTransform", "TestCase", TC_FAIL, "TSHttpTxnClientReqGet returns 0");
       } else {
-        if (TS_NULL_MLOC == (field = TSMimeHdrFieldFind(bufp, hdr, "Request", -1))) {
+        if (TS_NULL_MLOC == (field = TSMimeHdrFieldFind(bufp, hdr, "Request", -1, nullptr))) {
           SDK_RPRINT(data->test, "TSHttpTxnTransform", "TestCase", TC_FAIL, "Didn't find field request");
         } else {
           int reqid = TSMimeHdrFieldValueIntGet(bufp, hdr, field, 0);

--- a/src/tscpp/api/Headers.cc
+++ b/src/tscpp/api/Headers.cc
@@ -643,7 +643,7 @@ Headers::find(const std::string &key)
 header_field_iterator
 Headers::find(const char *key, int length)
 {
-  TSMLoc field_loc = TSMimeHdrFieldFind(state_->hdr_buf_, state_->hdr_loc_, key, length);
+  TSMLoc field_loc = TSMimeHdrFieldFind(state_->hdr_buf_, state_->hdr_loc_, key, length, nullptr);
   if (field_loc != TS_NULL_MLOC) {
     return header_field_iterator(state_->hdr_buf_, state_->hdr_loc_, field_loc);
   }

--- a/tests/tools/plugins/user_args.cc
+++ b/tests/tools/plugins/user_args.cc
@@ -44,7 +44,7 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, const char *val)
   }
 
   bool ret         = false;
-  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, header, strlen(header));
+  TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, header, strlen(header), nullptr);
 
   TSReleaseAssert(!field_loc); // The headers are for testing, should never exist
   if (TS_SUCCESS == TSMimeHdrFieldCreateNamed(bufp, hdr_loc, header, strlen(header), &field_loc)) {


### PR DESCRIPTION
An alternative approach of #8052 following @zwoop's suggestion.