### PR TITLE
docs: only use -W for supported branches.

### DIFF
--- a/ci/jenkins/bin/docs.sh
+++ b/ci/jenkins/bin/docs.sh
@@ -36,9 +36,19 @@ autoreconf -fi && ./configure --enable-docs || exit 1
 
 cd doc
 
-echo "Building English version with warnings treated as errors"
+W_OPTION=""
+if grep ALLSPHINXOPTS Makefile.am | grep -q -- -W
+then
+  # We use the presence of -W in ALLSPHINXOPTS as a marker that we can treat
+  # warnings as errors.
+  echo "Building English version with warnings treated as errors"
+  W_OPTION="-W"
+else
+  echo "Building English version"
+fi
+make clean || true
 rm -rf docbuild/html
-${ATS_MAKE} -e SPHINXOPTS="-W -D language='en'" html
+${ATS_MAKE} -e SPHINXOPTS="${W_OPTION} -D language='en'" html
 [ $? != 0 ] && exit 1
 
 # Only continue with the rsync and JA build if we're on the official docs updates


### PR DESCRIPTION
I noticed the latest 9.0.x and 9.1.x CI doc builds failed because they
do not support -W. This changes out jenkins script so that it does not
run with the -W flag unless our change to support that option is in the
branch under build.