### PR TITLE
Remove unused macros defined on ink_apidefs.h

### DIFF
--- a/include/tscore/Arena.h
+++ b/include/tscore/Arena.h
@@ -39,14 +39,14 @@ class Arena
 public:
   Arena() {}
   ~Arena() { reset(); }
-  inkcoreapi void *alloc(size_t size, size_t alignment = sizeof(double));
+  void *alloc(size_t size, size_t alignment = sizeof(double));
   void free(void *mem, size_t size);
   size_t str_length(const char *str);
   char *str_alloc(size_t len);
   void str_free(char *str);
   char *str_store(const char *str, size_t len);
 
-  inkcoreapi void reset();
+  void reset();
 
 private:
   ArenaBlock *m_blocks = nullptr;

--- a/include/tscore/Diags.h
+++ b/include/tscore/Diags.h
@@ -56,7 +56,7 @@
 #endif
 #endif
 
-extern inkcoreapi Diags *diags;
+extern Diags *diags;
 
 // Note that the log functions being implemented as a macro has the advantage
 // that the pre-compiler expands this in place such that the call to

--- a/include/tscore/MMH.h
+++ b/include/tscore/MMH.h
@@ -40,10 +40,10 @@ struct MMH_CTX {
 // signed-unsigned-const gratuitous differences brought
 // to you by history and the ANSI committee
 
-int inkcoreapi ink_code_incr_MMH_init(MMH_CTX *context);
-int inkcoreapi ink_code_incr_MMH_update(MMH_CTX *context, const char *input, int input_length);
-int inkcoreapi ink_code_incr_MMH_final(uint8_t *sixteen_byte_hash_pointer, MMH_CTX *context);
-int inkcoreapi ink_code_MMH(unsigned char *input, int len, unsigned char *sixteen_byte_hash);
+int ink_code_incr_MMH_init(MMH_CTX *context);
+int ink_code_incr_MMH_update(MMH_CTX *context, const char *input, int input_length);
+int ink_code_incr_MMH_final(uint8_t *sixteen_byte_hash_pointer, MMH_CTX *context);
+int ink_code_MMH(unsigned char *input, int len, unsigned char *sixteen_byte_hash);
 
 /**
   MMH will return different values on big-endian and little-endian

--- a/include/tscore/ParseRules.h
+++ b/include/tscore/ParseRules.h
@@ -71,9 +71,9 @@ typedef unsigned int CTypeResult;
 /* shut up the DEC compiler */
 #define is_http_field_value_BIT (((CTypeResult)1) << 31)
 
-extern ink_undoc_liapi const CTypeResult parseRulesCType[];
-inkcoreapi extern const char parseRulesCTypeToUpper[];
-inkcoreapi extern const char parseRulesCTypeToLower[];
+extern const CTypeResult parseRulesCType[];
+extern const char parseRulesCTypeToUpper[];
+extern const char parseRulesCTypeToLower[];
 
 class ParseRules
 {

--- a/include/tscore/Tokenizer.h
+++ b/include/tscore/Tokenizer.h
@@ -123,11 +123,11 @@ struct tok_iter_state {
 class Tokenizer
 {
 public:
-  inkcoreapi Tokenizer(const char *StrOfDelimiters);
-  inkcoreapi ~Tokenizer();
+  Tokenizer(const char *StrOfDelimiters);
+  ~Tokenizer();
 
   unsigned Initialize(char *str, unsigned options);
-  inkcoreapi unsigned Initialize(const char *str); // Automatically sets option to copy
+  unsigned Initialize(const char *str); // Automatically sets option to copy
   const char *operator[](unsigned index) const;
 
   void
@@ -145,8 +145,8 @@ public:
   unsigned count() const;
   void Print() const;
 
-  inkcoreapi const char *iterFirst(tok_iter_state *state);
-  inkcoreapi const char *iterNext(tok_iter_state *state);
+  const char *iterFirst(tok_iter_state *state);
+  const char *iterNext(tok_iter_state *state);
 
   // noncopyable
   Tokenizer &operator=(const Tokenizer &) = delete;

--- a/include/tscore/ink_apidefs.h
+++ b/include/tscore/ink_apidefs.h
@@ -23,11 +23,6 @@
 
 #pragma once
 
-#define inkliapi
-#define inkcoreapi
-#define ink_undoc_liapi
-#define ink_undoc_coreapi inkcoreapi
-
 #if defined(__GNUC__) || defined(__clang__)
 #ifndef likely
 #define likely(x) __builtin_expect(!!(x), 1)

--- a/include/tscore/ink_assert.h
+++ b/include/tscore/ink_assert.h
@@ -41,7 +41,7 @@ extern "C" {
 #undef __ASSERT_H__
 #define __ASSERT_H__
 
-inkcoreapi void _ink_assert(const char *a, const char *f, int l) TS_NORETURN;
+void _ink_assert(const char *a, const char *f, int l) TS_NORETURN;
 
 #if defined(DEBUG) || defined(ENABLE_ALL_ASSERTS) || defined(__clang_analyzer__) || defined(__COVERITY__)
 #define ink_assert(EX) ((void)(__builtin_expect(!!(EX), 1) ? (void)0 : _ink_assert(#EX, __FILE__, __LINE__)))

--- a/include/tscore/ink_code.h
+++ b/include/tscore/ink_code.h
@@ -35,8 +35,8 @@ typedef MD5_CTX INK_DIGEST_CTX;
   Wrappers around the MD5 functions, all of this should be deprecated and just use the functions directly
 */
 
-inkcoreapi int ink_code_md5(unsigned const char *input, int input_length, unsigned char *sixteen_byte_hash_pointer);
-inkcoreapi int ink_code_incr_md5_init(INK_DIGEST_CTX *context);
-inkcoreapi int ink_code_incr_md5_update(INK_DIGEST_CTX *context, const char *input, int input_length);
-inkcoreapi int ink_code_incr_md5_final(char *sixteen_byte_hash_pointer, INK_DIGEST_CTX *context);
+int ink_code_md5(unsigned const char *input, int input_length, unsigned char *sixteen_byte_hash_pointer);
+int ink_code_incr_md5_init(INK_DIGEST_CTX *context);
+int ink_code_incr_md5_update(INK_DIGEST_CTX *context, const char *input, int input_length);
+int ink_code_incr_md5_final(char *sixteen_byte_hash_pointer, INK_DIGEST_CTX *context);
 #endif

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -176,7 +176,7 @@ int ats_ip_check_characters(std::string_view text);
   @param s IP address in the Internet standard dot notation.
 
 */
-inkcoreapi uint32_t ats_inet_addr(const char *s);
+uint32_t ats_inet_addr(const char *s);
 
 const char *ats_ip_ntop(const struct sockaddr *addr, char *dst, size_t size);
 

--- a/include/tscore/ink_queue.h
+++ b/include/tscore/ink_queue.h
@@ -187,12 +187,12 @@ void ink_freelist_init_ops(int nofl_class, int nofl_proxy);
  */
 InkFreeList *ink_freelist_create(const char *name, uint32_t type_size, uint32_t chunk_size, uint32_t alignment);
 
-inkcoreapi void ink_freelist_init(InkFreeList **fl, const char *name, uint32_t type_size, uint32_t chunk_size, uint32_t alignment);
-inkcoreapi void ink_freelist_madvise_init(InkFreeList **fl, const char *name, uint32_t type_size, uint32_t chunk_size,
-                                          uint32_t alignment, int advice);
-inkcoreapi void *ink_freelist_new(InkFreeList *f);
-inkcoreapi void ink_freelist_free(InkFreeList *f, void *item);
-inkcoreapi void ink_freelist_free_bulk(InkFreeList *f, void *head, void *tail, size_t num_item);
+void ink_freelist_init(InkFreeList **fl, const char *name, uint32_t type_size, uint32_t chunk_size, uint32_t alignment);
+void ink_freelist_madvise_init(InkFreeList **fl, const char *name, uint32_t type_size, uint32_t chunk_size, uint32_t alignment,
+                               int advice);
+void *ink_freelist_new(InkFreeList *f);
+void ink_freelist_free(InkFreeList *f, void *item);
+void ink_freelist_free_bulk(InkFreeList *f, void *head, void *tail, size_t num_item);
 void ink_freelists_dump(FILE *f);
 void ink_freelists_dump_baselinerel(FILE *f);
 void ink_freelists_snap_baseline();
@@ -213,11 +213,11 @@ struct InkAtomicList {
 
 // WARNING: the "name" string is not copied, it has to be a statically-stored constant string.
 //
-inkcoreapi void ink_atomiclist_init(InkAtomicList *l, const char *name, uint32_t offset_to_next);
+void ink_atomiclist_init(InkAtomicList *l, const char *name, uint32_t offset_to_next);
 
-inkcoreapi void *ink_atomiclist_push(InkAtomicList *l, void *item);
+void *ink_atomiclist_push(InkAtomicList *l, void *item);
 void *ink_atomiclist_pop(InkAtomicList *l);
-inkcoreapi void *ink_atomiclist_popall(InkAtomicList *l);
+void *ink_atomiclist_popall(InkAtomicList *l);
 /*
  * WARNING WARNING WARNING WARNING WARNING WARNING WARNING
  * only if only one thread is doing pops it is possible to have a "remove"

--- a/include/tscore/ink_rand.h
+++ b/include/tscore/ink_rand.h
@@ -69,7 +69,7 @@ public:
   InkRand(uint64_t d);
 
   void seed(uint64_t d);
-  inkcoreapi uint64_t random();
+  uint64_t random();
   double drandom();
 
 private:

--- a/include/tscore/ink_sock.h
+++ b/include/tscore/ink_sock.h
@@ -91,6 +91,6 @@ int close_socket(int s);
 int write_socket(int s, const char *buffer, int length);
 int read_socket(int s, char *buffer, int length);
 
-inkcoreapi uint32_t ink_inet_addr(const char *s);
+uint32_t ink_inet_addr(const char *s);
 
 int bind_unix_domain_socket(const char *path, mode_t mode);

--- a/include/tscore/ink_string.h
+++ b/include/tscore/ink_string.h
@@ -48,10 +48,10 @@
  *===========================================================================*/
 /* these are supposed to be fast */
 
-inkcoreapi char *ink_memcpy_until_char(char *dst, char *src, unsigned int n, unsigned char c);
-inkcoreapi char *ink_string_concatenate_strings(char *dest, ...);
-inkcoreapi char *ink_string_concatenate_strings_n(char *dest, int n, ...);
-inkcoreapi char *ink_string_append(char *dest, char *src, int n);
+char *ink_memcpy_until_char(char *dst, char *src, unsigned int n, unsigned char c);
+char *ink_string_concatenate_strings(char *dest, ...);
+char *ink_string_concatenate_strings_n(char *dest, int n, ...);
+char *ink_string_append(char *dest, char *src, int n);
 
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters

--- a/include/tscore/ink_time.h
+++ b/include/tscore/ink_time.h
@@ -72,8 +72,8 @@ int cftime_replacement(char *s, int maxsize, const char *format, const time_t *c
 
 ink_time_t convert_tm(const struct tm *tp);
 
-inkcoreapi char *ink_ctime_r(const ink_time_t *clock, char *buf);
-inkcoreapi struct tm *ink_localtime_r(const ink_time_t *clock, struct tm *res);
+char *ink_ctime_r(const ink_time_t *clock, char *buf);
+struct tm *ink_localtime_r(const ink_time_t *clock, struct tm *res);
 
 /*===========================================================================*
                               Inline Stuffage

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -1085,13 +1085,13 @@ CacheProcessor::lookup(Continuation *cont, const CacheKey *key, CacheFragType fr
   return caches[frag_type]->lookup(cont, key, frag_type, hostname, host_len);
 }
 
-inkcoreapi Action *
+Action *
 CacheProcessor::open_read(Continuation *cont, const CacheKey *key, CacheFragType frag_type, const char *hostname, int hostlen)
 {
   return caches[frag_type]->open_read(cont, key, frag_type, hostname, hostlen);
 }
 
-inkcoreapi Action *
+Action *
 CacheProcessor::open_write(Continuation *cont, CacheKey *key, CacheFragType frag_type, int expected_size ATS_UNUSED, int options,
                            time_t pin_in_cache, char *hostname, int host_len)
 {

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -74,20 +74,19 @@ struct CacheProcessor : public Processor {
   int dir_check(bool fix);
   int db_check(bool fix);
 
-  inkcoreapi Action *lookup(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
-                            const char *hostname = nullptr, int host_len = 0);
-  inkcoreapi Action *open_read(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
-                               const char *hostname = nullptr, int host_len = 0);
-  inkcoreapi Action *open_write(Continuation *cont, CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
-                                int expected_size = CACHE_EXPECTED_SIZE, int options = 0, time_t pin_in_cache = (time_t)0,
-                                char *hostname = nullptr, int host_len = 0);
-  inkcoreapi Action *remove(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
-                            const char *hostname = nullptr, int host_len = 0);
+  Action *lookup(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
+                 const char *hostname = nullptr, int host_len = 0);
+  Action *open_read(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
+                    const char *hostname = nullptr, int host_len = 0);
+  Action *open_write(Continuation *cont, CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
+                     int expected_size = CACHE_EXPECTED_SIZE, int options = 0, time_t pin_in_cache = (time_t)0,
+                     char *hostname = nullptr, int host_len = 0);
+  Action *remove(Continuation *cont, const CacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_NONE,
+                 const char *hostname = nullptr, int host_len = 0);
   Action *scan(Continuation *cont, char *hostname = nullptr, int host_len = 0, int KB_per_second = SCAN_KB_PER_SECOND);
   Action *lookup(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
-  inkcoreapi Action *open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request,
-                               const OverridableHttpConfigParams *params, time_t pin_in_cache = (time_t)0,
-                               CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
+  Action *open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request, const OverridableHttpConfigParams *params,
+                    time_t pin_in_cache = (time_t)0, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   Action *open_write(Continuation *cont, int expected_size, const HttpCacheKey *key, CacheHTTPHdr *request, CacheHTTPInfo *old_info,
                      time_t pin_in_cache = (time_t)0, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   Action *remove(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
@@ -220,5 +219,5 @@ struct CacheVConnection : public VConnection {
 };
 
 void ink_cache_init(ts::ModuleVersion version);
-extern inkcoreapi CacheProcessor cacheProcessor;
+extern CacheProcessor cacheProcessor;
 extern Continuation *cacheRegexDeleteCont;

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -993,11 +993,11 @@ struct Cache {
   int close();
 
   Action *lookup(Continuation *cont, const CacheKey *key, CacheFragType type, const char *hostname, int host_len);
-  inkcoreapi Action *open_read(Continuation *cont, const CacheKey *key, CacheFragType type, const char *hostname, int len);
-  inkcoreapi Action *open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_type, int options = 0,
-                                time_t pin_in_cache = (time_t)0, const char *hostname = nullptr, int host_len = 0);
-  inkcoreapi Action *remove(Continuation *cont, const CacheKey *key, CacheFragType type = CACHE_FRAG_TYPE_HTTP,
-                            const char *hostname = nullptr, int host_len = 0);
+  Action *open_read(Continuation *cont, const CacheKey *key, CacheFragType type, const char *hostname, int len);
+  Action *open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_type, int options = 0,
+                     time_t pin_in_cache = (time_t)0, const char *hostname = nullptr, int host_len = 0);
+  Action *remove(Continuation *cont, const CacheKey *key, CacheFragType type = CACHE_FRAG_TYPE_HTTP, const char *hostname = nullptr,
+                 int host_len = 0);
   Action *scan(Continuation *cont, const char *hostname = nullptr, int host_len = 0, int KB_per_second = 2500);
 
   Action *open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, const OverridableHttpConfigParams *params,
@@ -1022,7 +1022,7 @@ struct Cache {
 };
 
 extern Cache *theCache;
-inkcoreapi extern Cache *caches[NUM_CACHE_FRAG_TYPES];
+extern Cache *caches[NUM_CACHE_FRAG_TYPES];
 
 TS_INLINE void
 Cache::generate_key(CryptoHash *hash, CacheURL *url)

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -31,10 +31,10 @@
 //
 // General Buffer Allocator
 //
-inkcoreapi Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
-inkcoreapi ClassAllocator<MIOBuffer> ioAllocator("ioAllocator", DEFAULT_BUFFER_NUMBER);
-inkcoreapi ClassAllocator<IOBufferData> ioDataAllocator("ioDataAllocator", DEFAULT_BUFFER_NUMBER);
-inkcoreapi ClassAllocator<IOBufferBlock> ioBlockAllocator("ioBlockAllocator", DEFAULT_BUFFER_NUMBER);
+Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
+ClassAllocator<MIOBuffer> ioAllocator("ioAllocator", DEFAULT_BUFFER_NUMBER);
+ClassAllocator<IOBufferData> ioDataAllocator("ioDataAllocator", DEFAULT_BUFFER_NUMBER);
+ClassAllocator<IOBufferBlock> ioBlockAllocator("ioBlockAllocator", DEFAULT_BUFFER_NUMBER);
 int64_t default_large_iobuffer_size = DEFAULT_LARGE_BUFFER_SIZE;
 int64_t default_small_iobuffer_size = DEFAULT_SMALL_BUFFER_SIZE;
 int64_t max_iobuffer_size           = DEFAULT_BUFFER_SIZES - 1;

--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -407,6 +407,6 @@ private:
   ink_mutex dedicated_thread_spawn_mutex;
 };
 
-extern inkcoreapi class EventProcessor eventProcessor;
+extern class EventProcessor eventProcessor;
 
 void thread_started(EThread *);

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -109,7 +109,7 @@ enum AllocType {
 #define BUFFER_SIZE_FOR_CONSTANT(_size) (_size - DEFAULT_BUFFER_SIZES)
 #define BUFFER_SIZE_INDEX_FOR_CONSTANT_SIZE(_size) (_size + DEFAULT_BUFFER_SIZES)
 
-inkcoreapi extern Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
+extern Allocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
 
 void init_buffer_allocators(int iobuffer_advice);
 
@@ -237,7 +237,7 @@ public:
   IOBufferData &operator=(const IOBufferData &) = delete;
 };
 
-inkcoreapi extern ClassAllocator<IOBufferData> ioDataAllocator;
+extern ClassAllocator<IOBufferData> ioDataAllocator;
 
 /**
   A linkable portion of IOBufferData. IOBufferBlock is a chainable
@@ -480,7 +480,7 @@ public:
   IOBufferBlock &operator=(const IOBufferBlock &) = delete;
 };
 
-extern inkcoreapi ClassAllocator<IOBufferBlock> ioBlockAllocator;
+extern ClassAllocator<IOBufferBlock> ioBlockAllocator;
 
 /** A class for holding a chain of IO buffer blocks.
     This class is intended to be used as a member variable for other classes that
@@ -789,7 +789,7 @@ public:
       occurrence.
 
   */
-  inkcoreapi int64_t memchr(char c, int64_t len = INT64_MAX, int64_t offset = 0);
+  int64_t memchr(char c, int64_t len = INT64_MAX, int64_t offset = 0);
 
   /**
     Copies and consumes data. Copies len bytes of data from the buffer
@@ -805,7 +805,7 @@ public:
     @return number of bytes copied and consumed.
 
   */
-  inkcoreapi int64_t read(void *buf, int64_t len);
+  int64_t read(void *buf, int64_t len);
 
   /**
     Copy data but do not consume it. Copies 'len' bytes of data from
@@ -824,7 +824,7 @@ public:
       parameter buf is set to this value also.
 
   */
-  inkcoreapi char *memcpy(void *buf, int64_t len = INT64_MAX, int64_t offset = 0);
+  char *memcpy(void *buf, int64_t len = INT64_MAX, int64_t offset = 0);
 
   /**
     Subscript operator. Returns a reference to the character at the
@@ -953,7 +953,7 @@ public:
     control. Returns the number of bytes added.
 
   */
-  inkcoreapi int64_t write(const void *rbuf, int64_t nbytes);
+  int64_t write(const void *rbuf, int64_t nbytes);
 
   /**
     Add by data from IOBufferReader r to the this buffer by reference. If
@@ -980,7 +980,7 @@ public:
     rather than sharing blocks to prevent a build of blocks on the buffer.
 
   */
-  inkcoreapi int64_t write(IOBufferReader *r, int64_t len = INT64_MAX, int64_t offset = 0);
+  int64_t write(IOBufferReader *r, int64_t len = INT64_MAX, int64_t offset = 0);
 
   /** Copy data from the @a chain to this buffer.
       New IOBufferBlocks are allocated so this gets a copy of the data that is independent of the source.

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -126,9 +126,9 @@ class EThread;
 typedef EThread *EThreadPtr;
 
 #if DEBUG
-inkcoreapi extern void lock_waiting(const SourceLocation &, const char *handler);
-inkcoreapi extern void lock_holding(const SourceLocation &, const char *handler);
-inkcoreapi extern void lock_taken(const SourceLocation &, const char *handler);
+extern void lock_waiting(const SourceLocation &, const char *handler);
+extern void lock_holding(const SourceLocation &, const char *handler);
+extern void lock_taken(const SourceLocation &, const char *handler);
 #endif
 
 /**
@@ -249,7 +249,7 @@ public:
 };
 
 // The ClassAllocator for ProxyMutexes
-extern inkcoreapi ClassAllocator<ProxyMutex> mutexAllocator;
+extern ClassAllocator<ProxyMutex> mutexAllocator;
 
 inline bool
 Mutex_trylock(

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -112,7 +112,7 @@ public:
 
   virtual void set_specific();
 
-  inkcoreapi static ink_thread_key thread_data_key;
+  static ink_thread_key thread_data_key;
 
   // For THREAD_ALLOC
   ProxyAllocator eventAllocator;

--- a/iocore/eventsystem/I_VIO.h
+++ b/iocore/eventsystem/I_VIO.h
@@ -118,7 +118,7 @@ public:
     as they hurt system throughput and waste CPU.
 
   */
-  inkcoreapi void reenable();
+  void reenable();
 
   /**
     Reenable the IO operation.
@@ -135,7 +135,7 @@ public:
     as they hurt system throughput and waste CPU.
 
   */
-  inkcoreapi void reenable_re();
+  void reenable_re();
 
   void disable();
   bool is_disabled() const;

--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -616,7 +616,7 @@ IOBufferReader::reset()
 //      inline functions definitions
 //
 ////////////////////////////////////////////////////////////////
-inkcoreapi extern ClassAllocator<MIOBuffer> ioAllocator;
+extern ClassAllocator<MIOBuffer> ioAllocator;
 ////////////////////////////////////////////////////////////////
 //
 //  MIOBuffer::MIOBuffer()

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -36,7 +36,7 @@
 ///////////////////////////////////////////////
 
 ink_hrtime Thread::cur_time = ink_get_hrtime_internal();
-inkcoreapi ink_thread_key Thread::thread_data_key;
+ink_thread_key Thread::thread_data_key;
 
 namespace
 {

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -471,7 +471,7 @@ struct HostDBProcessor : public Processor {
   static Options const DEFAULT_OPTIONS;
 
   HostDBProcessor() {}
-  inkcoreapi Action *getbyname_re(Continuation *cont, const char *hostname, int len, Options const &opt = DEFAULT_OPTIONS);
+  Action *getbyname_re(Continuation *cont, const char *hostname, int len, Options const &opt = DEFAULT_OPTIONS);
 
   Action *getbynameport_re(Continuation *cont, const char *hostname, int len, Options const &opt = DEFAULT_OPTIONS);
 
@@ -542,6 +542,6 @@ public:
 
 void run_HostDBTest();
 
-extern inkcoreapi HostDBProcessor hostDBProcessor;
+extern HostDBProcessor hostDBProcessor;
 
 void ink_hostdb_init(ts::ModuleVersion version);

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -134,7 +134,7 @@ public:
     @return Action, that can be cancelled to cancel the accept. The
       port becomes free immediately.
    */
-  inkcoreapi virtual Action *accept(Continuation *cont, AcceptOptions const &opt = DEFAULT_ACCEPT_OPTIONS);
+  virtual Action *accept(Continuation *cont, AcceptOptions const &opt = DEFAULT_ACCEPT_OPTIONS);
 
   /**
     Accepts incoming connections on port. Accept connections on port.
@@ -182,7 +182,7 @@ public:
 
   */
 
-  inkcoreapi Action *connect_re(Continuation *cont, sockaddr const *addr, NetVCOptions *options = nullptr);
+  Action *connect_re(Continuation *cont, sockaddr const *addr, NetVCOptions *options = nullptr);
 
   /**
     Initializes the net processor. This must be called before the event threads are started.
@@ -192,7 +192,7 @@ public:
 
   virtual void init_socks() = 0;
 
-  inkcoreapi virtual NetVConnection *allocate_vc(EThread *) = 0;
+  virtual NetVConnection *allocate_vc(EThread *) = 0;
 
   /** Private constructor. */
   NetProcessor(){};
@@ -247,7 +247,7 @@ private:
   @endcode
 
 */
-extern inkcoreapi NetProcessor &netProcessor;
+extern NetProcessor &netProcessor;
 
 /**
   Global netProcessor singleton object for making ssl enabled net
@@ -256,5 +256,5 @@ extern inkcoreapi NetProcessor &netProcessor;
   over ssl.
 
 */
-extern inkcoreapi NetProcessor &sslNetProcessor;
-extern inkcoreapi NetProcessor &quicNetProcessor;
+extern NetProcessor &sslNetProcessor;
+extern NetProcessor &quicNetProcessor;

--- a/iocore/net/I_UDPConnection.h
+++ b/iocore/net/I_UDPConnection.h
@@ -49,7 +49,7 @@ public:
   SOCKET getFd();
   void setBinding(struct sockaddr const *);
   void setBinding(const IpAddr &, in_port_t);
-  inkcoreapi bool getBinding(struct sockaddr *);
+  bool getBinding(struct sockaddr *);
 
   void destroy();
   int shouldDestroy();

--- a/iocore/net/I_UDPNet.h
+++ b/iocore/net/I_UDPNet.h
@@ -72,7 +72,7 @@ public:
      @return Action* Always returns ACTION_RESULT_DONE if socket was
      created successfully, or ACTION_IO_ERROR if not.
   */
-  inkcoreapi Action *UDPBind(Continuation *c, sockaddr const *addr, int fd = -1, int send_bufsize = 0, int recv_bufsize = 0);
+  Action *UDPBind(Continuation *c, sockaddr const *addr, int fd = -1, int send_bufsize = 0, int recv_bufsize = 0);
 
   // Regarding sendto_re, sendmsg_re, recvfrom_re:
   // * You may be called back on 'c' with completion or error status.
@@ -102,7 +102,7 @@ public:
                       bool useReadCont = true, int timeout = 0);
 };
 
-inkcoreapi extern UDPNetProcessor &udpNet;
+extern UDPNetProcessor &udpNet;
 extern EventType ET_UDP;
 
 #include "I_UDPPacket.h"

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -55,7 +55,7 @@ public:
      @param block block chain to add.
 
    */
-  inkcoreapi void append_block(IOBufferBlock *block);
+  void append_block(IOBufferBlock *block);
 
   IpEndpoint from; // what address came from
   IpEndpoint to;   // what address to send to

--- a/iocore/net/P_UDPPacket.h
+++ b/iocore/net/P_UDPPacket.h
@@ -55,7 +55,7 @@ public:
   int in_heap               = 0;
 };
 
-inkcoreapi extern ClassAllocator<UDPPacketInternal> udpPacketAllocator;
+extern ClassAllocator<UDPPacketInternal> udpPacketAllocator;
 
 TS_INLINE
 UDPPacketInternal::UDPPacketInternal()

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -39,7 +39,7 @@
 
 using UDPNetContHandler = int (UDPNetHandler::*)(int, void *);
 
-inkcoreapi ClassAllocator<UDPPacketInternal> udpPacketAllocator("udpPacketAllocator");
+ClassAllocator<UDPPacketInternal> udpPacketAllocator("udpPacketAllocator");
 EventType ET_UDP;
 
 //

--- a/iocore/net/libinknet_stub.cc
+++ b/iocore/net/libinknet_stub.cc
@@ -153,7 +153,7 @@ LifecycleAPIHooks *lifecycle_hooks = nullptr;
 StatPagesManager statPagesManager;
 
 #include "ProcessManager.h"
-inkcoreapi ProcessManager *pmgmt = nullptr;
+ProcessManager *pmgmt = nullptr;
 
 int
 BaseManager::registerMgmtCallback(int, MgmtCallback const &)

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -32,7 +32,7 @@
 /*
  * Global ProcessManager
  */
-inkcoreapi ProcessManager *pmgmt = nullptr;
+ProcessManager *pmgmt = nullptr;
 
 // read_management_message attempts to read a message from the management
 // socket. Returns -errno on error, otherwise 0. If a message was read the

--- a/mgmt/ProcessManager.h
+++ b/mgmt/ProcessManager.h
@@ -57,9 +57,9 @@ public:
   // Stop the process manager, dropping any unprocessed messages.
   void stop();
 
-  inkcoreapi void signalConfigFileChild(const char *parent, const char *child);
-  inkcoreapi void signalManager(int msg_id, const char *data_str);
-  inkcoreapi void signalManager(int msg_id, const char *data_raw, int data_len);
+  void signalConfigFileChild(const char *parent, const char *child);
+  void signalManager(int msg_id, const char *data_str);
+  void signalManager(int msg_id, const char *data_raw, int data_len);
 
   /** Send a management message of type @a msg_id with @a text.
    *
@@ -68,9 +68,9 @@ public:
    *
    * A terminating null character is added automatically.
    */
-  inkcoreapi void signalManager(int msg_id, std::string_view text);
+  void signalManager(int msg_id, std::string_view text);
 
-  inkcoreapi void signalManager(MgmtMessageHdr *mh);
+  void signalManager(MgmtMessageHdr *mh);
 
   void reconfigure();
   void initLMConnection();
@@ -112,4 +112,4 @@ private:
   static void *processManagerThread(void *arg);
 };
 
-inkcoreapi extern ProcessManager *pmgmt;
+extern ProcessManager *pmgmt;

--- a/proxy/CacheControl.h
+++ b/proxy/CacheControl.h
@@ -62,7 +62,7 @@ struct matcher_line;
 class CacheControlResult
 {
 public:
-  inkcoreapi CacheControlResult();
+  CacheControlResult();
   void Print() const;
 
   // Data for external use
@@ -108,7 +108,7 @@ public:
   int time_arg                   = 0;
   int cache_responses_to_cookies = -1;
   Result Init(matcher_line *line_info);
-  inkcoreapi void UpdateMatch(CacheControlResult *result, RequestData *rdata);
+  void UpdateMatch(CacheControlResult *result, RequestData *rdata);
   void Print() const;
 };
 
@@ -121,10 +121,10 @@ class URL;
 struct HttpConfigParams;
 struct OverridableHttpConfigParams;
 
-inkcoreapi void getCacheControl(CacheControlResult *result, HttpRequestData *rdata, const OverridableHttpConfigParams *h_txn_conf,
-                                char *tag = nullptr);
-inkcoreapi bool host_rule_in_CacheControlTable();
-inkcoreapi bool ip_rule_in_CacheControlTable();
+void getCacheControl(CacheControlResult *result, HttpRequestData *rdata, const OverridableHttpConfigParams *h_txn_conf,
+                     char *tag = nullptr);
+bool host_rule_in_CacheControlTable();
+bool ip_rule_in_CacheControlTable();
 
 void initCacheControl();
 void reloadCacheControl();

--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -132,10 +132,10 @@ public:
 class HttpRequestData : public RequestData
 {
 public:
-  inkcoreapi char *get_string() override;
-  inkcoreapi const char *get_host() override;
-  inkcoreapi sockaddr const *get_ip() override;
-  inkcoreapi sockaddr const *get_client_ip() override;
+  char *get_string() override;
+  const char *get_host() override;
+  sockaddr const *get_ip() override;
+  sockaddr const *get_client_ip() override;
 
   HttpRequestData()
 

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -76,7 +76,7 @@ struct StatPageData {
 struct StatPagesManager {
   void init();
 
-  inkcoreapi void register_http(const char *hostname, StatPagesFunc func);
+  void register_http(const char *hostname, StatPagesFunc func);
 
   // Private
   Action *handle_http(Continuation *cont, HTTPHdr *header);
@@ -86,7 +86,7 @@ struct StatPagesManager {
   ink_mutex stat_pages_mutex;
 };
 
-inkcoreapi extern StatPagesManager statPagesManager;
+extern StatPagesManager statPagesManager;
 
 // Stole Pete's code for formatting the page and slapped it here
 //   for easy reuse
@@ -97,23 +97,23 @@ public:
   ~BaseStatPagesHandler() override { resp_clear(); };
 
 protected:
-  inkcoreapi void resp_clear();
-  inkcoreapi void resp_add(const char *fmt, ...);
-  inkcoreapi void resp_add_sep();
-  inkcoreapi void resp_begin(const char *title);
-  inkcoreapi void resp_end();
+  void resp_clear();
+  void resp_add(const char *fmt, ...);
+  void resp_add_sep();
+  void resp_begin(const char *title);
+  void resp_end();
   void resp_begin_numbered();
   void resp_end_numbered();
-  inkcoreapi void resp_begin_unnumbered();
-  inkcoreapi void resp_end_unnumbered();
-  inkcoreapi void resp_begin_item();
+  void resp_begin_unnumbered();
+  void resp_end_unnumbered();
+  void resp_begin_item();
   void resp_end_item();
-  inkcoreapi void resp_begin_table(int border, int columns, int percent);
-  inkcoreapi void resp_end_table();
-  inkcoreapi void resp_begin_row();
-  inkcoreapi void resp_end_row();
-  inkcoreapi void resp_begin_column(int percent = -1, const char *align = nullptr);
-  inkcoreapi void resp_end_column();
+  void resp_begin_table(int border, int columns, int percent);
+  void resp_end_table();
+  void resp_begin_row();
+  void resp_end_row();
+  void resp_begin_column(int percent = -1, const char *align = nullptr);
+  void resp_end_column();
 
   char *response;
   int response_size;

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -415,20 +415,20 @@ void http_hdr_adjust(HTTPHdrImpl *hdrp, int32_t offset, int32_t length, int32_t 
 /* Public */
 void http_init();
 
-inkcoreapi HTTPHdrImpl *http_hdr_create(HdrHeap *heap, HTTPType polarity);
+HTTPHdrImpl *http_hdr_create(HdrHeap *heap, HTTPType polarity);
 void http_hdr_init(HdrHeap *heap, HTTPHdrImpl *hh, HTTPType polarity);
 HTTPHdrImpl *http_hdr_clone(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HdrHeap *d_heap);
 void http_hdr_copy_onto(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HTTPHdrImpl *d_hh, HdrHeap *d_heap, bool inherit_strs);
 
-inkcoreapi int http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
+int http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
 
 void http_hdr_describe(HdrHeapObjImpl *obj, bool recurse = true);
 
-inkcoreapi bool http_hdr_version_set(HTTPHdrImpl *hh, const HTTPVersion &ver);
+bool http_hdr_version_set(HTTPHdrImpl *hh, const HTTPVersion &ver);
 
 const char *http_hdr_method_get(HTTPHdrImpl *hh, int *length);
-inkcoreapi void http_hdr_method_set(HdrHeap *heap, HTTPHdrImpl *hh, const char *method, int16_t method_wks_idx, int method_length,
-                                    bool must_copy);
+void http_hdr_method_set(HdrHeap *heap, HTTPHdrImpl *hh, const char *method, int16_t method_wks_idx, int method_length,
+                         bool must_copy);
 
 void http_hdr_url_set(HdrHeap *heap, HTTPHdrImpl *hh, URLImpl *url);
 
@@ -462,7 +462,7 @@ HTTPValRange*          http_parse_range (const char *buf, Arena *arena);
 */
 HTTPValTE *http_parse_te(const char *buf, int len, Arena *arena);
 
-inkcoreapi bool is_http_hdr_version_supported(const HTTPVersion &http_version);
+bool is_http_hdr_version_supported(const HTTPVersion &http_version);
 
 class IOBufferReader;
 
@@ -1344,8 +1344,8 @@ public:
   void copy_frag_offsets_from(HTTPInfo *src);
   HTTPInfo &operator=(const HTTPInfo &m);
 
-  inkcoreapi int marshal_length();
-  inkcoreapi int marshal(char *buf, int len);
+  int marshal_length();
+  int marshal(char *buf, int len);
   static int unmarshal(char *buf, int len, RefCountObj *block_ref);
   static int unmarshal_v24_1(char *buf, int len, RefCountObj *block_ref);
   void set_buffer_reference(RefCountObj *block_ref);

--- a/proxy/hdrs/HdrHeap.h
+++ b/proxy/hdrs/HdrHeap.h
@@ -172,7 +172,7 @@ public:
   static constexpr int DEFAULT_SIZE = 2048;
 
   void init();
-  inkcoreapi void destroy();
+  void destroy();
 
   // PtrHeap allocation
   HdrHeapObjImpl *allocate_obj(int nbytes, int type);
@@ -185,8 +185,8 @@ public:
   void free_string(const char *s, int len);
 
   // Marshalling
-  inkcoreapi int marshal_length();
-  inkcoreapi int marshal(char *buf, int length);
+  int marshal_length();
+  int marshal(char *buf, int length);
   int unmarshal(int buf_length, int obj_type, HdrHeapObjImpl **found_obj, RefCountObj *block_ref);
   /// Computes the valid data size of an unmarshalled instance.
   /// Callers should round up to HDR_PTR_SIZE to get the actual footprint.
@@ -499,6 +499,6 @@ HdrHeapSDKHandle::set(const HdrHeapSDKHandle *from)
 }
 
 HdrStrHeap *new_HdrStrHeap(int requested_size);
-inkcoreapi HdrHeap *new_HdrHeap(int size = HdrHeap::DEFAULT_SIZE);
+HdrHeap *new_HdrHeap(int size = HdrHeap::DEFAULT_SIZE);
 
 void hdr_heap_test();

--- a/proxy/hdrs/HdrToken.h
+++ b/proxy/hdrs/HdrToken.h
@@ -103,7 +103,7 @@ extern uint32_t hdrtoken_str_flags[];
 
 extern void hdrtoken_init();
 extern int hdrtoken_tokenize_dfa(const char *string, int string_len, const char **wks_string_out = nullptr);
-inkcoreapi extern int hdrtoken_tokenize(const char *string, int string_len, const char **wks_string_out = nullptr);
+extern int hdrtoken_tokenize(const char *string, int string_len, const char **wks_string_out = nullptr);
 extern int hdrtoken_method_tokenize(const char *string, int string_len);
 extern const char *hdrtoken_string_to_wks(const char *string);
 extern const char *hdrtoken_string_to_wks(const char *string, int length);

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -420,7 +420,7 @@ extern const char *MIME_FIELD_KEEP_ALIVE;
 extern const char *MIME_FIELD_KEYWORDS;
 extern const char *MIME_FIELD_LAST_MODIFIED;
 extern const char *MIME_FIELD_LINES;
-inkcoreapi extern const char *MIME_FIELD_LOCATION;
+extern const char *MIME_FIELD_LOCATION;
 extern const char *MIME_FIELD_MAX_FORWARDS;
 extern const char *MIME_FIELD_MESSAGE_ID;
 extern const char *MIME_FIELD_NEWSGROUPS;
@@ -525,7 +525,7 @@ extern int MIME_LEN_KEEP_ALIVE;
 extern int MIME_LEN_KEYWORDS;
 extern int MIME_LEN_LAST_MODIFIED;
 extern int MIME_LEN_LINES;
-inkcoreapi extern int MIME_LEN_LOCATION;
+extern int MIME_LEN_LOCATION;
 extern int MIME_LEN_MAX_FORWARDS;
 extern int MIME_LEN_MESSAGE_ID;
 extern int MIME_LEN_NEWSGROUPS;
@@ -704,7 +704,7 @@ void mime_hdr_fields_clear(HdrHeap *heap, MIMEHdrImpl *mh);
 MIMEField *_mime_hdr_field_list_search_by_wks(MIMEHdrImpl *mh, int wks_idx);
 MIMEField *_mime_hdr_field_list_search_by_string(MIMEHdrImpl *mh, const char *field_name_str, int field_name_len);
 MIMEField *_mime_hdr_field_list_search_by_slotnum(MIMEHdrImpl *mh, int slotnum);
-inkcoreapi MIMEField *mime_hdr_field_find(MIMEHdrImpl *mh, const char *field_name_str, int field_name_len);
+MIMEField *mime_hdr_field_find(MIMEHdrImpl *mh, const char *field_name_str, int field_name_len);
 
 MIMEField *mime_hdr_field_get(MIMEHdrImpl *mh, int idx);
 MIMEField *mime_hdr_field_get_slotnum(MIMEHdrImpl *mh, int slotnum);
@@ -722,7 +722,7 @@ void mime_hdr_field_delete(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, boo
  * Returned slotnum is not a persistent value. A slotnum may refer a different field after making changes to a mime header.
  */
 int mime_hdr_field_slotnum(MIMEHdrImpl *mh, MIMEField *field);
-inkcoreapi MIMEField *mime_hdr_prepare_for_value_set(HdrHeap *heap, MIMEHdrImpl *mh, const char *name, int name_length);
+MIMEField *mime_hdr_prepare_for_value_set(HdrHeap *heap, MIMEHdrImpl *mh, const char *name, int name_length);
 
 void mime_field_destroy(MIMEHdrImpl *mh, MIMEField *field);
 
@@ -745,8 +745,7 @@ void mime_field_value_extend_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField
 void mime_field_value_insert_comma_val(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, int idx, const char *new_piece_str,
                                        int new_piece_len);
 
-inkcoreapi void mime_field_value_set(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, const char *value, int length,
-                                     bool must_copy_string);
+void mime_field_value_set(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, const char *value, int length, bool must_copy_string);
 void mime_field_value_set_int(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, int32_t value);
 void mime_field_value_set_uint(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, uint32_t value);
 void mime_field_value_set_int64(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, int64_t value);

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -860,8 +860,8 @@ public:
 
   static void reconfigure();
 
-  inkcoreapi static HttpConfigParams *acquire();
-  inkcoreapi static void release(HttpConfigParams *params);
+  static HttpConfigParams *acquire();
+  static void release(HttpConfigParams *params);
 
   static bool load_server_session_sharing_match(const char *key, MgmtByte &mask);
 

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -1114,4 +1114,4 @@ is_response_body_precluded(HTTPStatus status_code, int method)
   }
 }
 
-inkcoreapi extern ink_time_t ink_local_time();
+extern ink_time_t ink_local_time();

--- a/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
+++ b/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
@@ -241,5 +241,5 @@ UDPConnection::Release()
 }
 
 #include "P_UDPPacket.h"
-inkcoreapi ClassAllocator<UDPPacketInternal> udpPacketAllocator("udpPacketAllocator");
+ClassAllocator<UDPPacketInternal> udpPacketAllocator("udpPacketAllocator");
 // for UDPPacketInternal::free()

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -56,7 +56,7 @@
 #define PERIODIC_TASKS_INTERVAL_FALLBACK 5
 
 // Log global objects
-inkcoreapi LogObject *Log::error_log = nullptr;
+LogObject *Log::error_log = nullptr;
 LogFieldList Log::global_field_list;
 Log::LoggingMode Log::logging_mode = LOG_MODE_NONE;
 

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -113,161 +113,158 @@ enum LogCacheWriteCodeType {
 class LogAccess
 {
 public:
-  inkcoreapi
-  LogAccess()
-  {
-  }
+  LogAccess() {}
 
   explicit LogAccess(HttpSM *sm);
 
-  inkcoreapi ~LogAccess() {}
-  inkcoreapi void init();
+  ~LogAccess() {}
+  void init();
 
   //
   // client -> proxy fields
   //
-  inkcoreapi int marshal_client_host_ip(char *);                // STR
-  inkcoreapi int marshal_host_interface_ip(char *);             // STR
-  inkcoreapi int marshal_client_host_port(char *);              // INT
-  inkcoreapi int marshal_client_auth_user_name(char *);         // STR
-  inkcoreapi int marshal_client_req_timestamp_sec(char *);      // INT
-  inkcoreapi int marshal_client_req_timestamp_ms(char *);       // INT
-  inkcoreapi int marshal_client_req_text(char *);               // STR
-  inkcoreapi int marshal_client_req_http_method(char *);        // STR
-  inkcoreapi int marshal_client_req_url(char *);                // STR
-  inkcoreapi int marshal_client_req_url_canon(char *);          // STR
-  inkcoreapi int marshal_client_req_unmapped_url_canon(char *); // STR
-  inkcoreapi int marshal_client_req_unmapped_url_path(char *);  // STR
-  inkcoreapi int marshal_client_req_unmapped_url_host(char *);  // STR
-  inkcoreapi int marshal_client_req_url_path(char *);           // STR
-  inkcoreapi int marshal_client_req_url_scheme(char *);         // STR
-  inkcoreapi int marshal_client_req_http_version(char *);       // INT
-  inkcoreapi int marshal_client_req_protocol_version(char *);   // STR
-  inkcoreapi int marshal_server_req_protocol_version(char *);   // STR
-  inkcoreapi int marshal_client_req_squid_len(char *);          // INT
-  inkcoreapi int marshal_client_req_header_len(char *);         // INT
-  inkcoreapi int marshal_client_req_content_len(char *);        // INT
-  inkcoreapi int marshal_client_req_tcp_reused(char *);         // INT
-  inkcoreapi int marshal_client_req_is_ssl(char *);             // INT
-  inkcoreapi int marshal_client_req_ssl_reused(char *);         // INT
-  inkcoreapi int marshal_client_req_is_internal(char *);        // INT
-  inkcoreapi int marshal_client_req_mptcp_state(char *);        // INT
-  inkcoreapi int marshal_client_security_protocol(char *);      // STR
-  inkcoreapi int marshal_client_security_cipher_suite(char *);  // STR
-  inkcoreapi int marshal_client_security_curve(char *);         // STR
-  inkcoreapi int marshal_client_security_alpn(char *);          // STR
-  inkcoreapi int marshal_client_finish_status_code(char *);     // INT
-  inkcoreapi int marshal_client_req_id(char *);                 // INT
-  inkcoreapi int marshal_client_req_uuid(char *);               // STR
-  inkcoreapi int marshal_client_rx_error_code(char *);          // STR
-  inkcoreapi int marshal_client_tx_error_code(char *);          // STR
-  inkcoreapi int marshal_client_req_all_header_fields(char *);  // STR
+  int marshal_client_host_ip(char *);                // STR
+  int marshal_host_interface_ip(char *);             // STR
+  int marshal_client_host_port(char *);              // INT
+  int marshal_client_auth_user_name(char *);         // STR
+  int marshal_client_req_timestamp_sec(char *);      // INT
+  int marshal_client_req_timestamp_ms(char *);       // INT
+  int marshal_client_req_text(char *);               // STR
+  int marshal_client_req_http_method(char *);        // STR
+  int marshal_client_req_url(char *);                // STR
+  int marshal_client_req_url_canon(char *);          // STR
+  int marshal_client_req_unmapped_url_canon(char *); // STR
+  int marshal_client_req_unmapped_url_path(char *);  // STR
+  int marshal_client_req_unmapped_url_host(char *);  // STR
+  int marshal_client_req_url_path(char *);           // STR
+  int marshal_client_req_url_scheme(char *);         // STR
+  int marshal_client_req_http_version(char *);       // INT
+  int marshal_client_req_protocol_version(char *);   // STR
+  int marshal_server_req_protocol_version(char *);   // STR
+  int marshal_client_req_squid_len(char *);          // INT
+  int marshal_client_req_header_len(char *);         // INT
+  int marshal_client_req_content_len(char *);        // INT
+  int marshal_client_req_tcp_reused(char *);         // INT
+  int marshal_client_req_is_ssl(char *);             // INT
+  int marshal_client_req_ssl_reused(char *);         // INT
+  int marshal_client_req_is_internal(char *);        // INT
+  int marshal_client_req_mptcp_state(char *);        // INT
+  int marshal_client_security_protocol(char *);      // STR
+  int marshal_client_security_cipher_suite(char *);  // STR
+  int marshal_client_security_curve(char *);         // STR
+  int marshal_client_security_alpn(char *);          // STR
+  int marshal_client_finish_status_code(char *);     // INT
+  int marshal_client_req_id(char *);                 // INT
+  int marshal_client_req_uuid(char *);               // STR
+  int marshal_client_rx_error_code(char *);          // STR
+  int marshal_client_tx_error_code(char *);          // STR
+  int marshal_client_req_all_header_fields(char *);  // STR
 
   //
   // proxy -> client fields
   //
-  inkcoreapi int marshal_proxy_resp_content_type(char *);      // STR
-  inkcoreapi int marshal_proxy_resp_reason_phrase(char *);     // STR
-  inkcoreapi int marshal_proxy_resp_squid_len(char *);         // INT
-  inkcoreapi int marshal_proxy_resp_content_len(char *);       // INT
-  inkcoreapi int marshal_proxy_resp_status_code(char *);       // INT
-  inkcoreapi int marshal_proxy_resp_header_len(char *);        // INT
-  inkcoreapi int marshal_proxy_finish_status_code(char *);     // INT
-  inkcoreapi int marshal_cache_result_code(char *);            // INT
-  inkcoreapi int marshal_cache_result_subcode(char *);         // INT
-  inkcoreapi int marshal_proxy_host_port(char *);              // INT
-  inkcoreapi int marshal_cache_hit_miss(char *);               // INT
-  inkcoreapi int marshal_proxy_resp_all_header_fields(char *); // STR
+  int marshal_proxy_resp_content_type(char *);      // STR
+  int marshal_proxy_resp_reason_phrase(char *);     // STR
+  int marshal_proxy_resp_squid_len(char *);         // INT
+  int marshal_proxy_resp_content_len(char *);       // INT
+  int marshal_proxy_resp_status_code(char *);       // INT
+  int marshal_proxy_resp_header_len(char *);        // INT
+  int marshal_proxy_finish_status_code(char *);     // INT
+  int marshal_cache_result_code(char *);            // INT
+  int marshal_cache_result_subcode(char *);         // INT
+  int marshal_proxy_host_port(char *);              // INT
+  int marshal_cache_hit_miss(char *);               // INT
+  int marshal_proxy_resp_all_header_fields(char *); // STR
 
   //
   // proxy -> server fields
   //
-  inkcoreapi int marshal_proxy_req_header_len(char *);        // INT
-  inkcoreapi int marshal_proxy_req_squid_len(char *);         // INT
-  inkcoreapi int marshal_proxy_req_content_len(char *);       // INT
-  inkcoreapi int marshal_proxy_req_server_ip(char *);         // INT
-  inkcoreapi int marshal_proxy_req_server_port(char *);       // INT
-  inkcoreapi int marshal_proxy_hierarchy_route(char *);       // INT
-  inkcoreapi int marshal_next_hop_ip(char *);                 // STR
-  inkcoreapi int marshal_next_hop_port(char *);               // INT
-  inkcoreapi int marshal_proxy_host_name(char *);             // STR
-  inkcoreapi int marshal_proxy_host_ip(char *);               // STR
-  inkcoreapi int marshal_proxy_req_is_ssl(char *);            // INT
-  inkcoreapi int marshal_proxy_req_all_header_fields(char *); // STR
+  int marshal_proxy_req_header_len(char *);        // INT
+  int marshal_proxy_req_squid_len(char *);         // INT
+  int marshal_proxy_req_content_len(char *);       // INT
+  int marshal_proxy_req_server_ip(char *);         // INT
+  int marshal_proxy_req_server_port(char *);       // INT
+  int marshal_proxy_hierarchy_route(char *);       // INT
+  int marshal_next_hop_ip(char *);                 // STR
+  int marshal_next_hop_port(char *);               // INT
+  int marshal_proxy_host_name(char *);             // STR
+  int marshal_proxy_host_ip(char *);               // STR
+  int marshal_proxy_req_is_ssl(char *);            // INT
+  int marshal_proxy_req_all_header_fields(char *); // STR
 
   //
   // server -> proxy fields
   //
-  inkcoreapi int marshal_server_host_ip(char *);                // INT
-  inkcoreapi int marshal_server_host_name(char *);              // STR
-  inkcoreapi int marshal_server_resp_status_code(char *);       // INT
-  inkcoreapi int marshal_server_resp_squid_len(char *);         // INT
-  inkcoreapi int marshal_server_resp_content_len(char *);       // INT
-  inkcoreapi int marshal_server_resp_header_len(char *);        // INT
-  inkcoreapi int marshal_server_resp_http_version(char *);      // INT
-  inkcoreapi int marshal_server_resp_time_ms(char *);           // INT
-  inkcoreapi int marshal_server_resp_time_s(char *);            // INT
-  inkcoreapi int marshal_server_transact_count(char *);         // INT
-  inkcoreapi int marshal_server_connect_attempts(char *);       // INT
-  inkcoreapi int marshal_server_resp_all_header_fields(char *); // STR
+  int marshal_server_host_ip(char *);                // INT
+  int marshal_server_host_name(char *);              // STR
+  int marshal_server_resp_status_code(char *);       // INT
+  int marshal_server_resp_squid_len(char *);         // INT
+  int marshal_server_resp_content_len(char *);       // INT
+  int marshal_server_resp_header_len(char *);        // INT
+  int marshal_server_resp_http_version(char *);      // INT
+  int marshal_server_resp_time_ms(char *);           // INT
+  int marshal_server_resp_time_s(char *);            // INT
+  int marshal_server_transact_count(char *);         // INT
+  int marshal_server_connect_attempts(char *);       // INT
+  int marshal_server_resp_all_header_fields(char *); // STR
 
   //
   // cache -> client fields
   //
-  inkcoreapi int marshal_cache_resp_status_code(char *);       // INT
-  inkcoreapi int marshal_cache_resp_squid_len(char *);         // INT
-  inkcoreapi int marshal_cache_resp_content_len(char *);       // INT
-  inkcoreapi int marshal_cache_resp_header_len(char *);        // INT
-  inkcoreapi int marshal_cache_resp_http_version(char *);      // INT
-  inkcoreapi int marshal_cache_resp_all_header_fields(char *); // STR
+  int marshal_cache_resp_status_code(char *);       // INT
+  int marshal_cache_resp_squid_len(char *);         // INT
+  int marshal_cache_resp_content_len(char *);       // INT
+  int marshal_cache_resp_header_len(char *);        // INT
+  int marshal_cache_resp_http_version(char *);      // INT
+  int marshal_cache_resp_all_header_fields(char *); // STR
 
-  inkcoreapi void set_client_req_url(char *, int);                // STR
-  inkcoreapi void set_client_req_url_canon(char *, int);          // STR
-  inkcoreapi void set_client_req_unmapped_url_canon(char *, int); // STR
-  inkcoreapi void set_client_req_unmapped_url_path(char *, int);  // STR
-  inkcoreapi void set_client_req_unmapped_url_host(char *, int);  // STR
-  inkcoreapi void set_client_req_url_path(char *, int);           // STR
+  void set_client_req_url(char *, int);                // STR
+  void set_client_req_url_canon(char *, int);          // STR
+  void set_client_req_unmapped_url_canon(char *, int); // STR
+  void set_client_req_unmapped_url_path(char *, int);  // STR
+  void set_client_req_unmapped_url_host(char *, int);  // STR
+  void set_client_req_url_path(char *, int);           // STR
 
   //
   // congestion control -- client_retry_after_time
   //
-  inkcoreapi int marshal_client_retry_after_time(char *); // INT
+  int marshal_client_retry_after_time(char *); // INT
 
   //
   // cache write fields
   //
-  inkcoreapi int marshal_cache_write_code(char *);           // INT
-  inkcoreapi int marshal_cache_write_transform_code(char *); // INT
+  int marshal_cache_write_code(char *);           // INT
+  int marshal_cache_write_transform_code(char *); // INT
 
   // other fields
   //
-  inkcoreapi int marshal_transfer_time_ms(char *);                            // INT
-  inkcoreapi int marshal_transfer_time_s(char *);                             // INT
-  inkcoreapi int marshal_file_size(char *);                                   // INT
-  inkcoreapi int marshal_plugin_identity_id(char *);                          // INT
-  inkcoreapi int marshal_plugin_identity_tag(char *);                         // STR
-  inkcoreapi int marshal_process_uuid(char *);                                // STR
-  inkcoreapi int marshal_client_http_connection_id(char *);                   // INT
-  inkcoreapi int marshal_client_http_transaction_id(char *);                  // INT
-  inkcoreapi int marshal_client_http_transaction_priority_weight(char *);     // INT
-  inkcoreapi int marshal_client_http_transaction_priority_dependence(char *); // INT
-  inkcoreapi int marshal_cache_lookup_url_canon(char *);                      // STR
-  inkcoreapi int marshal_client_sni_server_name(char *);                      // STR
-  inkcoreapi int marshal_client_provided_cert(char *);                        // INT
-  inkcoreapi int marshal_proxy_provided_cert(char *);                         // INT
-  inkcoreapi int marshal_version_build_number(char *);                        // STR
-  inkcoreapi int marshal_version_string(char *);                              // STR
-  inkcoreapi int marshal_cache_read_retries(char *);                          // INT
-  inkcoreapi int marshal_cache_write_retries(char *);                         // INT
-  inkcoreapi int marshal_cache_collapsed_connection_success(char *);          // INT
-  inkcoreapi int marshal_proxy_protocol_version(char *);                      // STR
-  inkcoreapi int marshal_proxy_protocol_src_ip(char *);                       // STR
-  inkcoreapi int marshal_proxy_protocol_dst_ip(char *);                       // STR
+  int marshal_transfer_time_ms(char *);                            // INT
+  int marshal_transfer_time_s(char *);                             // INT
+  int marshal_file_size(char *);                                   // INT
+  int marshal_plugin_identity_id(char *);                          // INT
+  int marshal_plugin_identity_tag(char *);                         // STR
+  int marshal_process_uuid(char *);                                // STR
+  int marshal_client_http_connection_id(char *);                   // INT
+  int marshal_client_http_transaction_id(char *);                  // INT
+  int marshal_client_http_transaction_priority_weight(char *);     // INT
+  int marshal_client_http_transaction_priority_dependence(char *); // INT
+  int marshal_cache_lookup_url_canon(char *);                      // STR
+  int marshal_client_sni_server_name(char *);                      // STR
+  int marshal_client_provided_cert(char *);                        // INT
+  int marshal_proxy_provided_cert(char *);                         // INT
+  int marshal_version_build_number(char *);                        // STR
+  int marshal_version_string(char *);                              // STR
+  int marshal_cache_read_retries(char *);                          // INT
+  int marshal_cache_write_retries(char *);                         // INT
+  int marshal_cache_collapsed_connection_success(char *);          // INT
+  int marshal_proxy_protocol_version(char *);                      // STR
+  int marshal_proxy_protocol_src_ip(char *);                       // STR
+  int marshal_proxy_protocol_dst_ip(char *);                       // STR
 
   // named fields from within a http header
   //
-  inkcoreapi int marshal_http_header_field(LogField::Container container, char *field, char *buf);
-  inkcoreapi int marshal_http_header_field_escapify(LogField::Container container, char *field, char *buf);
+  int marshal_http_header_field(LogField::Container container, char *field, char *buf);
+  int marshal_http_header_field_escapify(LogField::Container container, char *field, char *buf);
 
   //
   // named records.config int variables
@@ -287,15 +284,15 @@ public:
   //
   // milestones access
   //
-  inkcoreapi int marshal_milestone(TSMilestonesType ms, char *buf);
-  inkcoreapi int marshal_milestone_fmt_sec(TSMilestonesType ms, char *buf);
-  inkcoreapi int marshal_milestone_fmt_squid(TSMilestonesType ms, char *buf);
-  inkcoreapi int marshal_milestone_fmt_netscape(TSMilestonesType ms, char *buf);
-  inkcoreapi int marshal_milestone_fmt_date(TSMilestonesType ms, char *buf);
-  inkcoreapi int marshal_milestone_fmt_time(TSMilestonesType ms, char *buf);
-  inkcoreapi int marshal_milestone_fmt_ms(TSMilestonesType ms, char *buf);
-  inkcoreapi int marshal_milestone_diff(TSMilestonesType ms1, TSMilestonesType ms2, char *buf);
-  inkcoreapi void set_http_header_field(LogField::Container container, char *field, char *buf, int len);
+  int marshal_milestone(TSMilestonesType ms, char *buf);
+  int marshal_milestone_fmt_sec(TSMilestonesType ms, char *buf);
+  int marshal_milestone_fmt_squid(TSMilestonesType ms, char *buf);
+  int marshal_milestone_fmt_netscape(TSMilestonesType ms, char *buf);
+  int marshal_milestone_fmt_date(TSMilestonesType ms, char *buf);
+  int marshal_milestone_fmt_time(TSMilestonesType ms, char *buf);
+  int marshal_milestone_fmt_ms(TSMilestonesType ms, char *buf);
+  int marshal_milestone_diff(TSMilestonesType ms1, TSMilestonesType ms2, char *buf);
+  void set_http_header_field(LogField::Container container, char *field, char *buf, int len);
   //
   // unmarshalling routines
   //
@@ -337,10 +334,10 @@ public:
   static int strlen(const char *str);
 
 public:
-  inkcoreapi static void marshal_int(char *dest, int64_t source);
-  inkcoreapi static void marshal_str(char *dest, const char *source, int padded_len);
-  inkcoreapi static void marshal_mem(char *dest, const char *source, int actual_len, int padded_len);
-  inkcoreapi static int marshal_ip(char *dest, sockaddr const *ip);
+  static void marshal_int(char *dest, int64_t source);
+  static void marshal_str(char *dest, const char *source, int padded_len);
+  static void marshal_mem(char *dest, const char *source, int actual_len, int padded_len);
+  static int marshal_ip(char *dest, sockaddr const *ip);
 
   // noncopyable
   // -- member functions that are not allowed --

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -174,7 +174,7 @@ public:
     return m_time_field;
   }
 
-  inkcoreapi void set_http_header_field(LogAccess *lad, LogField::Container container, char *field, char *buf, int len);
+  void set_http_header_field(LogAccess *lad, LogField::Container container, char *field, char *buf, int len);
   void set_aggregate_op(Aggregate agg_op);
   void update_aggregate(int64_t val);
 

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -311,13 +311,12 @@ private:
 class TextLogObject : public LogObject
 {
 public:
-  inkcoreapi TextLogObject(const char *name, const char *log_dir, bool timestamps, const char *header,
-                           Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec,
-                           int rolling_offset_hr, int rolling_size_mb, int rolling_max_count, int rolling_min_count,
-                           bool reopen_after_rolling);
+  TextLogObject(const char *name, const char *log_dir, bool timestamps, const char *header,
+                Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec, int rolling_offset_hr,
+                int rolling_size_mb, int rolling_max_count, int rolling_min_count, bool reopen_after_rolling);
 
-  inkcoreapi int write(const char *format, ...) TS_PRINTFLIKE(2, 3);
-  inkcoreapi int va_write(const char *format, va_list ap);
+  int write(const char *format, ...) TS_PRINTFLIKE(2, 3);
+  int va_write(const char *format, va_list ap);
 
   static const LogFormat *textfmt;
 };

--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -85,14 +85,14 @@ extern "C" int getpwnam_r(const char *name, struct passwd *result, char *buffer,
 
 static AppVersionInfo appVersionInfo; // Build info for this application
 
-static inkcoreapi DiagsConfig *diagsConfig = nullptr;
-static char debug_tags[1024]               = "";
-static char action_tags[1024]              = "";
-static int proxy_off                       = false;
-static int listen_off                      = false;
-static char bind_stdout[512]               = "";
-static char bind_stderr[512]               = "";
-static const char *mgmt_path               = nullptr;
+static DiagsConfig *diagsConfig = nullptr;
+static char debug_tags[1024]    = "";
+static char action_tags[1024]   = "";
+static int proxy_off            = false;
+static int listen_off           = false;
+static char bind_stdout[512]    = "";
+static char bind_stderr[512]    = "";
+static const char *mgmt_path    = nullptr;
 
 // By default, set the current directory as base
 static const char *recs_conf = ts::filename::RECORDS;

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -164,11 +164,11 @@ int remote_management_flag      = DEFAULT_REMOTE_MANAGEMENT_FLAG;
 static char bind_stdout[512]    = "";
 static char bind_stderr[512]    = "";
 
-static char error_tags[1024]               = "";
-static char action_tags[1024]              = "";
-static int show_statistics                 = 0;
-static inkcoreapi DiagsConfig *diagsConfig = nullptr;
-HttpBodyFactory *body_factory              = nullptr;
+static char error_tags[1024]    = "";
+static char action_tags[1024]   = "";
+static int show_statistics      = 0;
+static DiagsConfig *diagsConfig = nullptr;
+HttpBodyFactory *body_factory   = nullptr;
 
 static int accept_mss           = 0;
 static int poll_timeout         = -1; // No value set.

--- a/src/tscore/Diags.cc
+++ b/src/tscore/Diags.cc
@@ -51,7 +51,7 @@ int diags_on_for_plugins         = 0;
 int DiagsConfigState::enabled[2] = {0, 0};
 
 // Global, used for all diagnostics
-inkcoreapi Diags *diags = nullptr;
+Diags *diags = nullptr;
 
 static bool
 location(const SourceLocation *loc, DiagsShowLocation show, DiagsLevel level)


### PR DESCRIPTION
The following macros on `include/tscore/ink_apidefs.h` expand to empty string.

```cpp
#define inkliapi
#define inkcoreapi
#define ink_undoc_liapi
#define ink_undoc_coreapi inkcoreapi
```

This PR removes them and their references.

No mention about the macros is found on GitHub/JIRA/ML/docs.