### PR TITLE
Make the InkAPI mHandleAllocator be a Proxy Allocator

### DIFF
--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -134,6 +134,7 @@ public:
   ProxyAllocator ioDataAllocator;
   ProxyAllocator ioAllocator;
   ProxyAllocator ioBlockAllocator;
+  ProxyAllocator mHandleAllocator;
 
   /** Start the underlying thread.
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -773,7 +773,7 @@ isWriteable(TSMBuffer bufp)
 static MIMEFieldSDKHandle *
 sdk_alloc_field_handle(TSMBuffer /* bufp ATS_UNUSED */, MIMEHdrImpl *mh)
 {
-  MIMEFieldSDKHandle *handle = mHandleAllocator.alloc();
+  MIMEFieldSDKHandle *handle = THREAD_ALLOC(mHandleAllocator, this_thread());
 
   // TODO: Should remove this when memory allocation can't fail.
   sdk_assert(sdk_sanity_check_null_ptr((void *)handle) == TS_SUCCESS);
@@ -788,7 +788,7 @@ static void
 sdk_free_field_handle(TSMBuffer bufp, MIMEFieldSDKHandle *field_handle)
 {
   if (sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS) {
-    mHandleAllocator.free(field_handle);
+    THREAD_FREE(field_handle, mHandleAllocator, this_thread());
   }
 }
 


### PR DESCRIPTION
Running a test with xdebug.so and header_rewrite.so with rules to both trigger xdebug and read and update a few headers via header_rewrite, I see about a 30% increase on RPS with this, and a 50% reduction in response latency. It's also using a noticeably less amount of CPU even with those RPS increases (likely we can see even more RPS increase if I had clients that could push the servers).