### PR TITLE
Clean up constructors and initialization in LogAccess class.

### DIFF
--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -51,32 +51,7 @@ char INVALID_STR[] = "!INVALID_STR!";
   machine pointer.
   -------------------------------------------------------------------------*/
 
-LogAccess::LogAccess(HttpSM *sm)
-  : m_http_sm(sm),
-    m_arena(),
-    m_client_request(nullptr),
-    m_proxy_response(nullptr),
-    m_proxy_request(nullptr),
-    m_server_response(nullptr),
-    m_cache_response(nullptr),
-    m_client_req_url_str(nullptr),
-    m_client_req_url_len(0),
-    m_client_req_url_canon_str(nullptr),
-    m_client_req_url_canon_len(0),
-    m_client_req_unmapped_url_canon_str(nullptr),
-    m_client_req_unmapped_url_canon_len(0),
-    m_client_req_unmapped_url_path_str(nullptr),
-    m_client_req_unmapped_url_path_len(0),
-    m_client_req_unmapped_url_host_str(nullptr),
-    m_client_req_unmapped_url_host_len(0),
-    m_client_req_url_path_str(nullptr),
-    m_client_req_url_path_len(0),
-    m_proxy_resp_content_type_str(nullptr),
-    m_proxy_resp_content_type_len(0),
-    m_proxy_resp_reason_phrase_str(nullptr),
-    m_proxy_resp_reason_phrase_len(0),
-    m_cache_lookup_url_canon_str(nullptr),
-    m_cache_lookup_url_canon_len(0)
+LogAccess::LogAccess(HttpSM *sm) : m_http_sm(sm)
 {
   ink_assert(m_http_sm != nullptr);
 }
@@ -1189,10 +1164,7 @@ void
 LogAccess::set_client_req_url_path(char *buf, int len)
 {
   //?? use m_client_req_unmapped_url_path_str for now..may need to enhance later..
-  if (buf && m_client_req_unmapped_url_path_str) {
-    m_client_req_url_path_len = std::min(len, m_client_req_url_path_len);
-    ink_strlcpy(m_client_req_unmapped_url_path_str, buf, m_client_req_url_path_len + 1);
-  }
+  this->set_client_req_unmapped_url_path(buf, len);
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -113,11 +113,7 @@ enum LogCacheWriteCodeType {
 class LogAccess
 {
 public:
-  inkcoreapi
-  LogAccess()
-  {
-  }
-
+  LogAccess() = delete;
   explicit LogAccess(HttpSM *sm);
 
   inkcoreapi ~LogAccess() {}
@@ -348,34 +344,34 @@ public:
   LogAccess &operator=(LogAccess &rhs) = delete; // or assignment
 
 private:
-  HttpSM *m_http_sm;
+  HttpSM *m_http_sm = nullptr;
 
   Arena m_arena;
 
-  HTTPHdr *m_client_request;
-  HTTPHdr *m_proxy_response;
-  HTTPHdr *m_proxy_request;
-  HTTPHdr *m_server_response;
-  HTTPHdr *m_cache_response;
+  HTTPHdr *m_client_request  = nullptr;
+  HTTPHdr *m_proxy_response  = nullptr;
+  HTTPHdr *m_proxy_request   = nullptr;
+  HTTPHdr *m_server_response = nullptr;
+  HTTPHdr *m_cache_response  = nullptr;
 
-  char *m_client_req_url_str;
-  int m_client_req_url_len;
-  char *m_client_req_url_canon_str;
-  int m_client_req_url_canon_len;
-  char *m_client_req_unmapped_url_canon_str;
-  int m_client_req_unmapped_url_canon_len;
-  char *m_client_req_unmapped_url_path_str;
-  int m_client_req_unmapped_url_path_len;
-  char *m_client_req_unmapped_url_host_str;
-  int m_client_req_unmapped_url_host_len;
-  char const *m_client_req_url_path_str;
-  int m_client_req_url_path_len;
-  char *m_proxy_resp_content_type_str;
-  int m_proxy_resp_content_type_len;
-  char *m_proxy_resp_reason_phrase_str;
-  int m_proxy_resp_reason_phrase_len;
-  char *m_cache_lookup_url_canon_str;
-  int m_cache_lookup_url_canon_len;
+  char *m_client_req_url_str                = nullptr;
+  int m_client_req_url_len                  = 0;
+  char *m_client_req_url_canon_str          = nullptr;
+  int m_client_req_url_canon_len            = 0;
+  char *m_client_req_unmapped_url_canon_str = nullptr;
+  int m_client_req_unmapped_url_canon_len   = 0;
+  char *m_client_req_unmapped_url_path_str  = nullptr;
+  int m_client_req_unmapped_url_path_len    = 0;
+  char *m_client_req_unmapped_url_host_str  = nullptr;
+  int m_client_req_unmapped_url_host_len    = 0;
+  char const *m_client_req_url_path_str     = nullptr;
+  int m_client_req_url_path_len             = 0;
+  char *m_proxy_resp_content_type_str       = nullptr;
+  int m_proxy_resp_content_type_len         = 0;
+  char *m_proxy_resp_reason_phrase_str      = nullptr;
+  int m_proxy_resp_reason_phrase_len        = 0;
+  char *m_cache_lookup_url_canon_str        = nullptr;
+  int m_cache_lookup_url_canon_len          = 0;
 
   void validate_unmapped_url();
   void validate_unmapped_url_path();


### PR DESCRIPTION
Modernize the constructors for `LogAccess`.