### PR TITLE
Fix length bug in validate_unmapped_url_path

### DIFF
--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -1505,7 +1505,7 @@ LogAccess::validate_unmapped_url_path()
           // Attempt to find first '/' in the path
           if (m_client_req_unmapped_url_host_len > 0 &&
               (c = static_cast<char *>(
-                 memchr((void *)m_client_req_unmapped_url_host_str, '/', m_client_req_unmapped_url_path_len))) != nullptr) {
+                 memchr((void *)m_client_req_unmapped_url_host_str, '/', m_client_req_unmapped_url_host_len))) != nullptr) {
             m_client_req_unmapped_url_host_len = static_cast<int>(c - m_client_req_unmapped_url_host_str);
             m_client_req_unmapped_url_path_str = &m_client_req_unmapped_url_host_str[m_client_req_unmapped_url_host_len];
             m_client_req_unmapped_url_path_len = m_client_req_unmapped_url_path_len - len - m_client_req_unmapped_url_host_len;


### PR DESCRIPTION
This was the cause of some crashes in production. The host length has been adjusted for skipping the scheme but the path length has not, so using the latter causes the search to proceed beyond the end of the string. The result is if there is no '/' in the URL but there is a '/' within a few characters of the end of the URL, that '/' will be found leading to negative lengths being stored and thence `assert` failures dues to the logging output being too small.