### PR TITLE
Changes HttpSM to be Proxy Allocated

### DIFF
--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -122,6 +122,7 @@ public:
   ProxyAllocator http1ClientSessionAllocator;
   ProxyAllocator http2ClientSessionAllocator;
   ProxyAllocator http2StreamAllocator;
+  ProxyAllocator httpSMAllocator;
   ProxyAllocator quicClientSessionAllocator;
   ProxyAllocator httpServerSessionAllocator;
   ProxyAllocator hdrHeapAllocator;

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -26,6 +26,8 @@
 
 #define HttpTxnDebug(fmt, ...) SsnDebug(this, "http_txn", fmt, __VA_ARGS__)
 
+extern ClassAllocator<HttpSM> httpSMAllocator;
+
 ProxyTransaction::ProxyTransaction(ProxySession *session) : VConnection(nullptr), _proxy_ssn(session) {}
 
 ProxyTransaction::~ProxyTransaction()
@@ -43,7 +45,7 @@ ProxyTransaction::new_transaction(bool from_early_data)
   // connection re-use
 
   ink_release_assert(_proxy_ssn != nullptr);
-  _sm = HttpSM::allocate();
+  _sm = THREAD_ALLOC(httpSMAllocator, this_thread());
   _sm->init(from_early_data);
   HttpTxnDebug("[%" PRId64 "] Starting transaction %d using sm [%" PRId64 "]", _proxy_ssn->connection_id(),
                _proxy_ssn->get_transact_count(), _sm->sm_id);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -375,7 +375,7 @@ void
 HttpSM::destroy()
 {
   cleanup();
-  httpSMAllocator.free(this);
+  THREAD_FREE(this, httpSMAllocator, this_thread());
 }
 
 void

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -703,13 +703,6 @@ HttpSM::get_cache_sm()
   return cache_sm;
 }
 
-inline HttpSM *
-HttpSM::allocate()
-{
-  extern ClassAllocator<HttpSM> httpSMAllocator;
-  return httpSMAllocator.alloc();
-}
-
 inline int
 HttpSM::write_response_header_into_buffer(HTTPHdr *h, MIOBuffer *b)
 {

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -8696,11 +8696,13 @@ std::array<std::string_view, TS_CONFIG_LAST_ENTRY> SDK_Overridable_Configs = {
    "proxy.config.hostdb.ip_resolve",
    "proxy.config.http.connect.dead.policy"}};
 
+extern ClassAllocator<HttpSM> httpSMAllocator;
+
 REGRESSION_TEST(SDK_API_OVERRIDABLE_CONFIGS)(RegressionTest *test, int /* atype ATS_UNUSED */, int *pstatus)
 {
   TSOverridableConfigKey key;
   TSRecordDataType type;
-  HttpSM *s      = HttpSM::allocate();
+  HttpSM *s      = THREAD_ALLOC(httpSMAllocator, this_thread());
   bool success   = true;
   TSHttpTxn txnp = reinterpret_cast<TSHttpTxn>(s);
   InkRand generator(17);
@@ -8804,7 +8806,7 @@ REGRESSION_TEST(SDK_API_OVERRIDABLE_CONFIGS)(RegressionTest *test, int /* atype 
 
 REGRESSION_TEST(SDK_API_TXN_HTTP_INFO_GET)(RegressionTest *test, int /* atype ATS_UNUSED */, int *pstatus)
 {
-  HttpSM *s      = HttpSM::allocate();
+  HttpSM *s      = THREAD_ALLOC(httpSMAllocator, this_thread());
   bool success   = true;
   TSHttpTxn txnp = reinterpret_cast<TSHttpTxn>(s);
   TSMgmtInt ival_read;


### PR DESCRIPTION
A few comments on this:

1. I couldn't get the proxy allocation macros to work inside the HttpSM::allocate. But, this patch looks more like what we do for other allocators, making it explicit where we need to allocate a new HttpSM. If someone feels strongly that HttpSM::allocate has to survive, I can see if there's a way to make it work.
2. Bryan requested that I verify that the allocation of the HttpSM happens on the ET_NET thread even with accept threads, and I did verify that and it does. So the HttpSM gets allocated and released on the same ET_NET thread.