### PR TITLE
Cancel active timeout when releasing session

### DIFF
--- a/proxy/http/Http1ServerSession.cc
+++ b/proxy/http/Http1ServerSession.cc
@@ -146,6 +146,11 @@ Http1ServerSession::release(ProxyTransaction *trans)
   Debug("http_ss", "[%" PRId64 "] Releasing session, private_session=%d, sharing_match=%d", con_id, this->is_private(),
         sharing_match);
   if (state == SSN_IN_USE) {
+    // The caller should have already set the inactive timeout to the keep alive timeout
+    // Unfortunately, we do not have access to that value from here.
+    // However we can clear the active timeout here.  The active timeout makes no sense
+    // in the keep alive state
+    cancel_active_timeout();
     state = SSN_TO_RELEASE;
     return;
   }


### PR DESCRIPTION
More details are in the issue.  This fix cancels the active timeout when the server session is released.  It may be a while still before the HttpSM is killed and the server session is actually put in the server session pool as discussed in the issue.

This PR also partially undoes the change in PR #7618.  I actually reviewed and approved that one, but on looking at it more closely while debugging this issue, I think the change is faulty since it will lose any overriden value associated with the Transaction, making the overridable nature of the keep alive timeout ineffective.

This change fixed our TxnBox-based reproducing test.  I am getting ready to set this up for testing in our 9.1 based production build.

I'll try to set up a reproducing test in another PR that uses a transform plugin that is already in the trafficserver code base.

This closes #8079 