### PR TITLE
Remove unused read_vio_cont/write_vio_cont methods

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -389,12 +389,6 @@ public:
   */
   VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override = 0;
 
-  virtual Continuation *
-  read_vio_cont()
-  {
-    return nullptr;
-  }
-
   /**
     Initiates write. Thread-safe, may be called when not handling
     an event from the NetVConnection, or the NetVConnection creation
@@ -431,11 +425,6 @@ public:
   */
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false) override = 0;
 
-  virtual Continuation *
-  write_vio_cont()
-  {
-    return nullptr;
-  }
   /**
     Closes the vconnection. A state machine MUST call do_io_close()
     when it has finished with a VConnection. do_io_close() indicates

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -111,9 +111,6 @@ public:
   VIO *do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override;
   VIO *do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false) override;
 
-  Continuation *read_vio_cont() override;
-  Continuation *write_vio_cont() override;
-
   bool get_data(int id, void *data) override;
 
   Action *send_OOB(Continuation *cont, char *buf, int len) override;

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -633,18 +633,6 @@ UnixNetVConnection::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader 
   return &write.vio;
 }
 
-Continuation *
-UnixNetVConnection::read_vio_cont()
-{
-  return read.vio.cont;
-}
-
-Continuation *
-UnixNetVConnection::write_vio_cont()
-{
-  return write.vio.cont;
-}
-
 void
 UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
 {


### PR DESCRIPTION
These methods were added by PR #7096, but the use of these methods were backed out with PR #7586.  Noticed they were untested in the code coverage report.  May as well tidy up.