### PR TITLE
Add pointer check in TSHttpTxnAborted

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5679,6 +5679,7 @@ TSReturnCode
 TSHttpTxnAborted(TSHttpTxn txnp, bool *client_abort)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  sdk_assert(client_abort != nullptr);
 
   *client_abort = false;
   HttpSM *sm    = (HttpSM *)txnp;


### PR DESCRIPTION
When reviewing recent commits, I found that `TSHttpTxnAborted` didn't check the pointer parameter `client_abort` like other functions. I think we need to add some checks for that.