### PR TITLE
Remove unused OOB network logic

### DIFF
--- a/iocore/eventsystem/I_VConnection.h
+++ b/iocore/eventsystem/I_VConnection.h
@@ -88,8 +88,6 @@
 */
 #define VC_EVENT_ACTIVE_TIMEOUT (VC_EVENT_EVENTS_START + 6)
 
-#define VC_EVENT_OOB_COMPLETE (VC_EVENT_EVENTS_START + 7)
-
 //
 // Event names
 //

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -473,21 +473,6 @@ public:
   void do_io_shutdown(ShutdownHowTo_t howto) override = 0;
 
   /**
-    Sends out of band messages over the connection. This function
-    is used to send out of band messages (is this still useful?).
-    cont is called back with VC_EVENT_OOB_COMPLETE - on successful
-    send or VC_EVENT_EOS - if the other side has shutdown the
-    connection. These callbacks could be re-entrant. Only one
-    send_OOB can be in progress at any time for a VC.
-
-    @param cont to be called back with events.
-    @param buf message buffer.
-    @param len length of the message.
-
-  */
-  virtual Action *send_OOB(Continuation *cont, char *buf, int len);
-
-  /**
     Return the server name that is appropriate for the network VC type
   */
   virtual const char *
@@ -495,15 +480,6 @@ public:
   {
     return nullptr;
   }
-
-  /**
-    Cancels a scheduled send_OOB. Part of the message could have
-    been sent already. Not callbacks to the cont are made after
-    this call. The Action returned by send_OOB should not be accessed
-    after cancel_OOB.
-
-  */
-  virtual void cancel_OOB();
 
   ////////////////////////////////////////////////////////////
   // Set the timeouts associated with this connection.      //

--- a/iocore/net/NetVConnection.cc
+++ b/iocore/net/NetVConnection.cc
@@ -36,17 +36,6 @@
 ////
 // NetVConnection
 //
-Action *
-NetVConnection::send_OOB(Continuation *, char *, int)
-{
-  return ACTION_RESULT_DONE;
-}
-
-void
-NetVConnection::cancel_OOB()
-{
-  return;
-}
 
 /**
    PROXY Protocol check with IOBufferReader

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -86,23 +86,6 @@ NetVCOptions::set_sock_param(int _recv_bufsize, int _send_bufsize, unsigned long
   packet_tos          = _packet_tos;
 }
 
-struct OOB_callback : public Continuation {
-  char *data;
-  int length;
-  Event *trigger;
-  UnixNetVConnection *server_vc;
-  Continuation *server_cont;
-  int retry_OOB_send(int, Event *);
-
-  OOB_callback(Ptr<ProxyMutex> &m, NetVConnection *vc, Continuation *cont, char *buf, int len)
-    : Continuation(m), data(buf), length(len), trigger(nullptr)
-  {
-    server_vc   = (UnixNetVConnection *)vc;
-    server_cont = cont;
-    SET_HANDLER(&OOB_callback::retry_OOB_send);
-  }
-};
-
 enum tcp_congestion_control_t { CLIENT_SIDE, SERVER_SIDE };
 
 class UnixNetVConnection : public NetVConnection, public NetEvent
@@ -115,9 +98,6 @@ public:
   Continuation *write_vio_cont() override;
 
   bool get_data(int id, void *data) override;
-
-  Action *send_OOB(Continuation *cont, char *buf, int len) override;
-  void cancel_OOB() override;
 
   const char *
   get_server_name() const override
@@ -265,7 +245,6 @@ public:
 
   Connection con;
   int recursion            = 0;
-  OOB_callback *oob_ptr    = nullptr;
   bool from_accept_thread  = false;
   NetAccept *accept_object = nullptr;
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -971,8 +971,6 @@ SSLNetVConnection::free(EThread *t)
 {
   ink_release_assert(t == this_ethread());
 
-  // cancel OOB
-  cancel_OOB();
   // close socket fd
   if (con.fd != NO_FD) {
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, -1);


### PR DESCRIPTION
Another observation from the code coverage report.  This PR removes code that is only within methods with OOB in the name with two exceptions.  The free methods for SSLNetVConnection and UnixNetVConnection call cancelOOB.  But I saw nowhere that started an OOB operation.  Even one of the comments on send_OOB questioned the need for its existence.