### PR TITLE
Clean up Machine implementation for issue #4159.

### DIFF
--- a/include/tscpp/util/TextView.h
+++ b/include/tscpp/util/TextView.h
@@ -1265,6 +1265,32 @@ namespace literals
   constexpr ts::TextView operator"" _tv(const char *s, size_t n) { return {s, n}; }
 } // namespace literals
 
+/** Functor for STL containers that need caseless comparisons of standard string types.
+ *
+ * For example a @c std::set of strings with caseless comparison would be
+ *
+ * @code
+ * std::set<std::string, ts::caseless_compare> strings;
+ * @endcode
+ */
+struct caseless_compare {
+  bool
+  operator()(std::string_view const &lhs, std::string_view const &rhs) const
+  {
+    return strcasecmp(lhs, rhs);
+  }
+  bool
+  operator()(TextView const &lhs, TextView const &rhs) const
+  {
+    return strcasecmp(lhs, rhs);
+  }
+  bool
+  operator()(std::string const &lhs, std::string const &rhs) const
+  {
+    return strcasecmp(lhs, rhs);
+  }
+};
+
 } // namespace ts
 
 namespace std

--- a/iocore/utils/I_Machine.h
+++ b/iocore/utils/I_Machine.h
@@ -33,9 +33,10 @@
 #include "tscore/ink_inet.h"
 #include "tscore/ink_uuid.h"
 
-#include <unordered_map>
 #include <unordered_set>
 #include <memory>
+#include <string_view>
+#include <tscpp/util/TextView.h>
 
 /**
   The Machine is a simple place holder for the hostname and the ip
@@ -52,21 +53,14 @@
 
  */
 struct Machine {
-  typedef Machine self; ///< Self reference type.
-
-  char *hostname;   // name of the internet host
-  int hostname_len; // size of the string pointed to by hostname
+  using self_type = Machine; ///< Self reference type.
 
   IpEndpoint ip;  ///< Preferred IP address of the host (network order)
   IpEndpoint ip4; ///< IPv4 address if present.
   IpEndpoint ip6; ///< IPv6 address if present.
 
-  ip_text_buffer ip_string; // IP address of the host as a string.
-  int ip_string_len;
-
-  char ip_hex_string[TS_IP6_SIZE * 2 + 1]; ///< IP address as hex string
-  int ip_hex_string_len;
-
+  std::string host_name;
+  std::string ip_hex_string; ///< IP address as hex string
   ATSUuid uuid;
 
   ~Machine();
@@ -77,22 +71,22 @@ struct Machine {
       @note This must be called before called @c instance so that the
       singleton is not @em inadvertently default initialized.
   */
-  static self *init(char const *name     = nullptr, ///< Host name of the machine.
-                    sockaddr const *addr = nullptr  ///< Primary IP address of the machine.
+  static self_type *init(char const *name     = nullptr, ///< Host name of the machine.
+                         sockaddr const *addr = nullptr  ///< Primary IP address of the machine.
   );
   /// @return The global instance of this class.
-  static self *instance();
-  bool is_self(const char *name);
-  bool is_self(const char *name, int name_len);
-  bool is_self(const IpAddr *ipaddr);
+  static self_type *instance();
+  bool is_self(std::string_view name);
+  bool is_self(std::string const &name);
+  bool is_self(IpAddr const &ipaddr);
   bool is_self(struct sockaddr const *addr);
-  void insert_id(char *id);
-  void insert_id(IpAddr *ipaddr);
+  void insert_id(char const *id);
+  void insert_id(IpAddr const &ipaddr);
 
 protected:
   Machine(char const *hostname, sockaddr const *addr);
 
-  static self *_instance; ///< Singleton for the class.
-  std::unordered_set<std::string> machine_id_strings;
-  std::unordered_map<std::string, IpAddr *> machine_id_ipaddrs;
+  static self_type *_instance; ///< Singleton for the class.
+  std::unordered_set<std::string, std::hash<std::string>, ts::caseless_compare> machine_id_strings;
+  std::unordered_set<IpAddr, IpAddr::Hasher> machine_id_ipaddrs;
 };

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -394,7 +394,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
       ink_assert(length < sizeof(fqdn));
       memset(fqdn, 0, sizeof(fqdn));
       strncpy(fqdn, token, length);
-      if (self_detect && machine->is_self(fqdn)) {
+      if (self_detect && machine->is_self(std::string_view(fqdn))) {
         if (self_detect == 1) {
           Debug("parent_select", "token: %s, matches this machine.  Removing self from parent list at line %d", fqdn, line_num);
           token = strtok_r(nullptr, PARENT_DELIMITERS, &savePtr);
@@ -405,7 +405,7 @@ ParentRecord::PreProcessParents(const char *val, const int line_num, char *buf, 
         }
       }
     } else {
-      if (self_detect && machine->is_self(token)) {
+      if (self_detect && machine->is_self(std::string_view(token))) {
         if (self_detect == 1) {
           Debug("parent_select", "token: %s, matches this machine.  Removing self from parent list at line %d", token, line_num);
           token = strtok_r(nullptr, PARENT_DELIMITERS, &savePtr);

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -1008,7 +1008,7 @@ HttpTransactHeaders::add_forwarded_field_to_request(HttpTransact::State *s, HTTP
       hdr << "by=_" << m.uuid.getString();
     }
 
-    if (optSet[HttpForwarded::BY_IP] and (m.ip_string_len > 0)) {
+    if (optSet[HttpForwarded::BY_IP] and m.ip.isValid()) {
       if (hdr.size()) {
         hdr << ';';
       }

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -133,7 +133,6 @@ test_NextHopStrategyFactory_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopStrategyFactory_LDADD = \
-  $(top_builddir)/src/tscpp/util/libtscpputil.la \
   $(top_builddir)/src/tscore/libtscore.la \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
@@ -141,6 +140,7 @@ test_NextHopStrategyFactory_LDADD = \
   $(top_builddir)/proxy/logging/liblogging.a \
   $(top_builddir)/mgmt/libmgmt_p.la \
   $(top_builddir)/iocore/utils/libinkutils.a \
+  $(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@YAMLCPP_LIBS@ \
 	@HWLOC_LIBS@
 
@@ -164,7 +164,6 @@ test_NextHopRoundRobin_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopRoundRobin_LDADD = \
-  $(top_builddir)/src/tscpp/util/libtscpputil.la \
   $(top_builddir)/src/tscore/libtscore.la \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
@@ -172,19 +171,20 @@ test_NextHopRoundRobin_LDADD = \
   $(top_builddir)/proxy/logging/liblogging.a \
   $(top_builddir)/mgmt/libmgmt_p.la \
   $(top_builddir)/iocore/utils/libinkutils.a \
+  $(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@YAMLCPP_LIBS@ \
 	@HWLOC_LIBS@
 
-test_NextHopRoundRobin_LDFLAGS = $(AM_LDFLAGS) -L$(top_builddir)/src/tscore/.libs -ltscore
+test_NextHopRoundRobin_LDFLAGS = $(AM_LDFLAGS) -L$(top_builddir)/src/tscore/.libs -ltscore -L$(top_builddir)/src/tscpp/util/.libs -ltscpputil
 
 test_NextHopRoundRobin_SOURCES = \
+	unit-tests/test_NextHopRoundRobin.cc \
+	unit-tests/nexthop_test_stubs.cc \
 	NextHopSelectionStrategy.cc \
 	NextHopStrategyFactory.cc \
 	NextHopRoundRobin.cc \
 	NextHopConsistentHash.cc \
-	NextHopHealthStatus.cc \
-	unit-tests/test_NextHopRoundRobin.cc \
-	unit-tests/nexthop_test_stubs.cc
+	NextHopHealthStatus.cc
 
 test_NextHopConsistentHash_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -195,7 +195,6 @@ test_NextHopConsistentHash_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopConsistentHash_LDADD = \
-  $(top_builddir)/src/tscpp/util/libtscpputil.la \
   $(top_builddir)/src/tscore/libtscore.la \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
@@ -203,6 +202,7 @@ test_NextHopConsistentHash_LDADD = \
   $(top_builddir)/proxy/logging/liblogging.a \
   $(top_builddir)/mgmt/libmgmt_p.la \
   $(top_builddir)/iocore/utils/libinkutils.a \
+  $(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@YAMLCPP_LIBS@ \
 	@HWLOC_LIBS@
 

--- a/proxy/http/remap/NextHopConsistentHash.cc
+++ b/proxy/http/remap/NextHopConsistentHash.cc
@@ -292,7 +292,7 @@ NextHopConsistentHash::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
         result->first_choice_status = (hst) ? hst->status : TSHostStatus::TS_HOST_STATUS_UP;
         // if peering and the selected host is myself, change rings and search for an upstream
         // parent.
-        if (ring_mode == NH_PEERING_RING && machine->is_self(pRec->hostname.c_str())) {
+        if (ring_mode == NH_PEERING_RING && machine->is_self(pRec->hostname)) {
           // switch to the upstream ring.
           cur_ring = 1;
           continue;

--- a/proxy/http/remap/NextHopSelectionStrategy.cc
+++ b/proxy/http/remap/NextHopSelectionStrategy.cc
@@ -214,7 +214,7 @@ NextHopSelectionStrategy::Init(ts::Yaml::Map &n)
               std::shared_ptr<HostRecord> host_rec = std::make_shared<HostRecord>(hosts_list[hst].as<HostRecord>());
               host_rec->group_index                = grp;
               host_rec->host_index                 = hst;
-              if (mach->is_self(host_rec->hostname.c_str())) {
+              if (mach->is_self(host_rec->hostname)) {
                 h_stat.setHostStatus(host_rec->hostname.c_str(), TSHostStatus::TS_HOST_STATUS_DOWN, 0, Reason::SELF_DETECT);
               }
               hosts_inner.push_back(std::move(host_rec));

--- a/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
+++ b/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
@@ -27,6 +27,8 @@
 
  */
 
+#include <memory>
+
 #include "HttpSM.h"
 #include "nexthop_test_stubs.h"
 
@@ -176,26 +178,10 @@ ConfigUpdateCbTable::invoke(char const *p)
 
 #include "I_Machine.h"
 
-static Machine *my_machine = nullptr;
-
-Machine::Machine(char const *hostname, sockaddr const *addr) {}
-Machine::~Machine()
-{
-  delete my_machine;
-}
-Machine *
-Machine::instance()
-{
-  if (my_machine == nullptr) {
-    my_machine = new Machine(nullptr, nullptr);
-  }
-  return my_machine;
-}
-bool
-Machine::is_self(const char *name)
-{
-  return false;
-}
+static bool StubMachineInit = []() -> bool {
+  Machine::init("localhost", nullptr);
+  return true;
+}();
 
 #include "HostStatus.h"
 

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -110,16 +110,15 @@ LogAccess::init()
 int
 LogAccess::marshal_proxy_host_name(char *buf)
 {
-  char *str        = nullptr;
-  int len          = 0;
-  Machine *machine = Machine::instance();
+  int len         = 0;
+  char const *str = nullptr;
 
-  if (machine) {
-    str = machine->hostname;
+  if (Machine *machine = Machine::instance(); machine) {
+    str = machine->host_name.c_str();
+    len = machine->host_name.length();
   }
 
-  len = LogAccess::strlen(str);
-
+  len = INK_ALIGN_DEFAULT(len + 1);
   if (buf) {
     marshal_str(buf, str, len);
   }

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -69,7 +69,7 @@
 void
 LogConfig::setup_default_values()
 {
-  hostname              = ats_strdup(Machine::instance()->hostname);
+  hostname              = ats_strdup(Machine::instance()->host_name.c_str());
   log_buffer_size       = static_cast<int>(10 * LOG_KILOBYTE);
   max_secs_per_buffer   = 5;
   max_space_mb_for_logs = 100;

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -10090,7 +10090,7 @@ TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp)
 TSReturnCode
 TSHostnameIsSelf(const char *hostname, size_t hostname_len)
 {
-  return Machine::instance()->is_self(hostname, hostname_len) ? TS_SUCCESS : TS_ERROR;
+  return Machine::instance()->is_self(std::string_view{hostname, hostname_len}) ? TS_SUCCESS : TS_ERROR;
 }
 
 TSReturnCode


### PR DESCRIPTION
Closing #4159 

* Replace `ats_strdup` with `std::string` for better cleanup.
* Store `IpAddr` directly in the set instead of allocated instances.
* Index the IP addresses by address, rather than requiring a string conversion.
* Make the hostname `std::set` use a caseless comparison, rather than converting strings to lower case.