### PR TITLE
CI: allow whitespace in *.test_input test files

### DIFF
--- a/ci/jenkins/bin/clang-format.sh
+++ b/ci/jenkins/bin/clang-format.sh
@@ -20,7 +20,9 @@ set +x
 cd "${WORKSPACE}/src"
 
 # First, make sure there are no trailing WS!!!
-git grep -IE ' +$' | fgrep -v '.gold:'
+git grep -IE ' +$' | \
+  fgrep -v '.gold:' | \
+  fgrep -v '.test_input'
 if [ "1" != "$?" ]; then
     echo "Error: Trailing whitespaces are not allowed!"
     echo "Error: Please run: git grep -IE ' +$'"
@@ -29,7 +31,9 @@ fi
 echo "Success! No trailing whitespace"
 
 # Make sure there are no DOS shit here.
-git grep -IE $'\r$' | fgrep -v 'lib/yamlcpp'
+git grep -IE $'\r$' | \
+    fgrep -v 'lib/yamlcpp' | \
+    fgrep -v '.test_input'
 if [ "1" != "$?" ]; then
     echo "Error: Please make sure to run dos2unix on the above file(s)"
     exit 1


### PR DESCRIPTION
Some of our test input files require trailing white space. We already
allow this for `*.gold` files. Naming all such input files `*.gold`
which are not in fact gold files would be confusing. This tweaks our CI
formatting check to also ignore the more generic `.test_input` extension
so that people writing tests with trailing white space can use that
extension to skip the trailing white space check in ci.

---

For reference, this will help with PR: #8096.