### PR TITLE
.gitignore rules for gcov generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,10 @@ BUILDS
 DEBUG
 RELEASE
 
+# lcov generated files.
+*.gcda
+*.gcno
+
 # autest
 tests/env-test/
 tests/proxy-verifier


### PR DESCRIPTION
This adds .gitignore rules for the instrumented object files and data
files generated by gcov.