### PR TITLE
url_sig: add url_type = pristine config file option

### DIFF
--- a/doc/admin-guide/plugins/url_sig.en.rst
+++ b/doc/admin-guide/plugins/url_sig.en.rst
@@ -129,6 +129,12 @@ on our website ``foo.com`` we might have a remap line like this::
     map http://foo.com/download/ http://origin.server.tld/download/ \
         @plugin=url_sig.so @pparam=url_sig.config
 
+.. note::
+
+   To be consistent, the config file option `pristine = true` should
+   be preferred over using a plugin argument.
+
+
 Signing a URL
 =============
 
@@ -257,6 +263,37 @@ Signature query parameters embedded in the URL path.
       --algorithm 1 --duration 86400 --key kSCE1_uBREdGI3TPnr_dXKc9f_J4ZV2f --pathparams --siganchor urlsig
 
       curl -s -o /dev/null -v --max-redirs 0 'http://test-remap.domain.com/vod/t;urlsig=O0U9MTQ2MzkyOTM4NTtBPTE7Sz0zO1A9MTtTPTIxYzk2YWRiZWZk'
+
+Other Config File Options
+=========================
+
+In addition to the keys and error_url, the following options are supported
+in the configuration file::
+
+    sig_anchor
+        signed anchor string token in url
+        default: no anchor
+
+    excl_regex
+        pcre regex for urls that aren't signed.
+        default: no regex
+
+    url_type
+        which url to match against
+        pristine or remap
+        default: remap
+
+     ignore_expiry
+        option which assists in testing where the timestamp check is skipped
+        DO NOT run with this set in production!
+        default: false
+
+Example::
+
+    sig_anchor = urlsig
+    excl_regex = (/crossdomain.xml|/clientaccesspolicy.xml|/test.html)
+    url_type = pristine
+    ignore_expiry = true
 
 
 Edge Cache Debugging
@@ -387,21 +424,3 @@ Example
     <
     { [data not shown]
     * Connection #0 to host localhost left intact
-
-
-Replay test support
-===================
-
-To assist in log replay an option is available in the config file which
-will ignore the expiration date.  This allows all url_sig tests to
-pass the expiration date.
-
-The config file option to enable this is::
-
-    ignore_expiry = true
-
-Once updated, touch `remap.config` then issue a
-:option:`traffic_ctl config reload` to make the settings active.
-
-Do NOT deploy this to production as it will disable valid checks
-on signed urls!

--- a/plugins/experimental/url_sig/url_sig.c
+++ b/plugins/experimental/url_sig/url_sig.c
@@ -236,6 +236,11 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
         cfg->ignore_expiry = true;
         TSError("[url_sig] Plugin IGNORES sig expiration");
       }
+    } else if (strncmp(line, "url_type", 8) == 0) {
+      if (strncmp(value, "pristine", 8) == 0) {
+        cfg->pristine_url_flag = 1;
+        TSDebug(PLUGIN_NAME, "Pristine URLs (from config) will be used");
+      }
     } else {
       TSError("[url_sig] Error parsing line %d of file %s (%s)", line_no, config_file, line);
     }
@@ -246,6 +251,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
   if (argc > 3) {
     if (strcasecmp(argv[3], "pristineurl") == 0) {
       cfg->pristine_url_flag = 1;
+      TSDebug(PLUGIN_NAME, "Pristine URLs (from args) will be used");
 
     } else {
       snprintf(errbuf, errbuf_size, "[TSRemapNewInstance] - second pparam (if present) must be pristineurl");

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.all.config
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.all.config
@@ -1,0 +1,22 @@
+#This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line. This is a very long test line.
+key0 = hV3wqyq1QxJeF76JkzHf93tuLYv_abw5
+key1 = nIpyXbVqPFVN7y8yMlfgFBLnOqDSufMy
+key2 = 4UED1ELmHkEcXrS_7yEYPKtgUZdGWaP2
+key3 = mv2vPGJpq2iFDbiV3dJG4ZqCAzRTIpTD
+key4 = 2cnob1tuGEiYhwJLYRLa5bfyuZH1zI0S
+key5 = poC7zK9IrDl3rljvuZ0bbMP3e5f0woKt
+key6 = _k8diypYMebSCEEjYNszZbG906JZI6Bx
+key7 = dqsgopTSM_doT6iAysasQVUKaPykyb6e
+key8 = AzM3mhTDEkyJjyqQctv0NVxCL3FmXDzW
+key9 = iRHQE9ucS44oAhdXmM148wMTJAO4XAVV
+key10 = b1OMb39dGhMSg_wArQnvqGIBgQGFjnNl
+key11 = YpA8qBkvohdamogQ4zTuoPw50PbezdL0
+key12 = 4Q4OCnY_gmcDuw5756Wk1XG7PEi24g1_
+key13 = CGRDwMO96_vRjFCfks6oxkeV7IdTnA6f
+key14 = sXTWfNyHkN2SJ9eKifetPzfcg0_rNhXM
+key15 = 9MuXIiZ70HPi_qhqfSgdu9oJHpcj9yaO
+error_url = 403
+sig_anchor = urlsig
+excl_regex = (/crossdomain.xml|/clientaccesspolicy.xml|/test.html)
+url_type = pristine
+ignore_expiry = true

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
@@ -90,6 +90,14 @@ ts.Disk.remap_config.AddLine(
     ' @plugin=url_sig.so @pparam=url_sig.config @pparam=PristineUrl'
 )
 
+# Use config with all settings set
+#
+ts.Setup.Copy("url_sig.all.config", ts.Variables.CONFIGDIR)
+ts.Disk.remap_config.AddLine(
+    f'map http://ten.eleven.twelve/ http://127.0.0.1:{server.Variables.Port}/' +
+    ' @plugin=url_sig.so @pparam=url_sig.all.config'
+)
+
 # Validation failure tests.
 
 LogTee = f" 2>&1 | grep '^<' | tee -a {Test.RunDirectory}/url_sig_long.log"
@@ -259,6 +267,16 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
     f"curl --verbose --http1.1 --insecure --header 'Host: one.two.three' '{url}'" +
     LogTee + " ; grep -F -e '< HTTP' -e Authorization {0}/url_sig_long.log > {0}/url_sig_short.log ".format(ts.RunDirectory)
+)
+
+# With client / MD5 / P=101 / URL pristine / URL altered.
+# uses url_type pristine in config
+tr = Test.AddTestRun()
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Command = (
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://ten.eleven.twelve/" +
+    "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=2&K=13&P=101&S=586ef8e808caeeea025c525c89ff2638'" +
+    LogTee
 )
 
 # Overriding the built in ERROR check since we expect some ERROR messages


### PR DESCRIPTION
In addition to the plugin arg pristineurl this also adds a config file option to do the same

url_type = pristine

I attempted to clean up the config file argument document and added a single test.