### PR TITLE
HostDBProcessor: ensure hostname_offset is initialized to '0' to indicate null hostname

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -2257,7 +2257,11 @@ struct HostDBRegressionContinuation : public Continuation {
       // since this is a lookup done, data is either hostdbInfo or nullptr
       if (r) {
         rprintf(test, "hostdbinfo r=%x\n", r);
-        rprintf(test, "hostdbinfo hostname=%s\n", r->perm_hostname());
+        char const *hname = r->perm_hostname();
+        if (nullptr == hname) {
+          hname = "(null)";
+        }
+        rprintf(test, "hostdbinfo hostname=%s\n", hname);
         rprintf(test, "hostdbinfo rr %x\n", r->rr());
         // If RR, print all of the enclosed records
         if (r->rr()) {

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -319,7 +319,7 @@ struct HostDBInfo : public RefCountObj {
     }
   }
 
-  uint64_t key;
+  uint64_t key{0};
 
   // Application specific data. NOTE: We need an integral number of
   // these per block. This structure is 32 bytes. (at 200k hosts =
@@ -332,11 +332,11 @@ struct HostDBInfo : public RefCountObj {
     SRVInfo srv;
   } data;
 
-  unsigned int hostname_offset; // always maintain a permanent copy of the hostname for non-rev dns records.
+  unsigned int hostname_offset{0}; // always maintain a permanent copy of the hostname for non-rev dns records.
 
-  unsigned int ip_timestamp;
+  unsigned int ip_timestamp{0};
 
-  unsigned int ip_timeout_interval; // bounded between 1 and HOST_DB_MAX_TTL (0x1FFFFF, 24 days)
+  unsigned int ip_timeout_interval{0}; // bounded between 1 and HOST_DB_MAX_TTL (0x1FFFFF, 24 days)
 
   unsigned int is_srv : 1;
   unsigned int reverse_dns : 1;


### PR DESCRIPTION
In the new CI there is a periodic crash while running the HostDBProcessor regression test.

Running valgrind I see a complaints about
"Conditional jump or move depends on uninitialised value" during the regression test run.

One run pointed out
hostname_offset being uninitialized in the following call for the hostname_offset:

```
char *
HostDBInfo::perm_hostname() const
{
  if (hostname_offset == 0) {
    return nullptr;
  }

  return (char *)this + hostname_offset;
}
```

Setting initializer values for these data members in HostDBProcessor cleans up the valgrind messages.