### PR TITLE
Exclude a common error case from the http/2 error rate calculation

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1176,7 +1176,7 @@ Http2ConnectionState::rcv_frame(const Http2Frame *frame)
         Error("HTTP/2 stream error code=0x%02x client_ip=%s session_id=%" PRId64 " stream_id=%u %s", static_cast<int>(error.code),
               client_ip, ua_session->connection_id(), stream_id, error.msg);
       }
-      this->send_rst_stream_frame(stream_id, error.code);
+      this->send_rst_stream_frame(stream_id, error.code, error.msg != nullptr);
     }
   }
 }
@@ -1922,11 +1922,11 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
 }
 
 void
-Http2ConnectionState::send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec)
+Http2ConnectionState::send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec, bool include_error)
 {
   Http2StreamDebug(ua_session, id, "Send RST_STREAM frame");
 
-  if (ec != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
+  if (ec != Http2ErrorCode::HTTP2_ERROR_NO_ERROR && include_error) {
     HTTP2_INCREMENT_THREAD_DYN_STAT(HTTP2_STAT_STREAM_ERRORS_COUNT, this_ethread());
     ++stream_error_count;
   }

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -131,7 +131,7 @@ public:
   Http2SendDataFrameResult send_a_data_frame(Http2Stream *stream, size_t &payload_length);
   void send_headers_frame(Http2Stream *stream);
   bool send_push_promise_frame(Http2Stream *stream, URL &url, const MIMEField *accept_encoding);
-  void send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec);
+  void send_rst_stream_frame(Http2StreamId id, Http2ErrorCode ec, bool include_in_error_count = true);
   void send_settings_frame(const Http2ConnectionSettings &new_settings);
   void send_ping_frame(Http2StreamId id, uint8_t flag, const uint8_t *opaque_data);
   void send_goaway_frame(Http2StreamId id, Http2ErrorCode ec);


### PR DESCRIPTION
Another possible solution to #8163.  Excludes the error case that is common and I would argument innocuous from the calculation of the HTTP2 session error rate.

This closes #8163