### PR TITLE
Fix clearing all stats function

### DIFF
--- a/lib/records/P_RecCore.cc
+++ b/lib/records/P_RecCore.cc
@@ -746,7 +746,7 @@ RecResetStatRecord(RecT type, bool all)
   for (i = 0; i < num_records; i++) {
     RecRecord *r1 = &(g_records[i]);
 
-    if (REC_TYPE_IS_STAT(r1->rec_type)) {
+    if (!REC_TYPE_IS_STAT(r1->rec_type)) {
       continue;
     }
 


### PR DESCRIPTION
While doing some unit tests for the JSONRPC branch I found that the `traffic_ctl metric clear` wasn't working. Found out that this was already noticed by #5188. This PR should fix this issue.

```
$ traffic_ctl metric get proxy.process.http.completed_requests
proxy.process.http.completed_requests 0

$ ab -n 1000 -c 10 http://127.0.0.1:8080/
....
$ traffic_ctl metric get proxy.process.http.completed_requests
proxy.process.http.completed_requests 797

$ traffic_ctl metric clear <<<<

$ traffic_ctl metric get proxy.process.http.completed_requests
proxy.process.http.completed_requests 0
```

_This issues seems to go a while back._