### PR TITLE
Update INSTALL for URLs and version number

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -68,9 +68,9 @@ questions.  There are many valuable forums to help you get started.
 Please refer your questions to the appropriate forum, such as the
 Users Mailing List at
 
-    http://cwiki.apache.org/confluence/display/TS/Traffic+Server
+    https://cwiki.apache.org/confluence/display/TS/Apache+Traffic+Server
 
-Thanks for using the Apache Traffic Server, version 5.
+Thanks for using the Apache Traffic Server.
 
              The Apache Software Foundation
-             http://www.apache.org/
+             https://www.apache.org/


### PR DESCRIPTION
While reading INSTALL, I noticed:

- the links are broken or insecure.
- the version number was not maintained since version 5.

This PR updates these links and removes the version number (seems there is no need).