### PR TITLE
Abstract adding Connection: close header to avoid triggering H2 draining logic

### DIFF
--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -240,3 +240,11 @@ ProxyTransaction::allow_half_open() const
 {
   return false;
 }
+
+// Most protocols will not want to set the Connection: header
+// For H2 it will initiate the drain logic.  So we make do nothing
+// the default action.
+void
+ProxyTransaction::set_close_connection(HTTPHdr &hdr) const
+{
+}

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -87,6 +87,10 @@ public:
   // Returns true if there is a request body for this request
   virtual bool has_request_body(int64_t content_length, bool is_chunked_set) const;
 
+  // Worker function to set Connection:close header if appropriate for
+  // underlying protocol
+  virtual void set_close_connection(HTTPHdr &hdr) const;
+
   sockaddr const *get_remote_addr() const;
 
   virtual HTTPVersion get_version(HTTPHdr &hdr) const;

--- a/proxy/http/Http1Transaction.h
+++ b/proxy/http/Http1Transaction.h
@@ -43,6 +43,7 @@ public:
   // Methods
   int get_transaction_id() const override;
   void set_reader(IOBufferReader *reader);
+  void set_close_connection(HTTPHdr &hdr) const override;
 
   ////////////////////
   // Variables
@@ -70,4 +71,10 @@ inline void
 Http1Transaction::set_reader(IOBufferReader *reader)
 {
   _reader = reader;
+}
+
+inline void
+Http1Transaction::set_close_connection(HTTPHdr &hdr) const
+{
+  hdr.value_set(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION, "close", 5);
 }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5872,7 +5872,7 @@ HttpSM::do_drain_request_body(HTTPHdr &response)
 
 close_connection:
   t_state.client_info.keep_alive = HTTP_NO_KEEPALIVE;
-  response.value_set(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION, "close", 5);
+  ua_txn->set_close_connection(response);
 }
 
 void

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7052,7 +7052,7 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
     if (s->client_info.keep_alive != HTTP_NO_KEEPALIVE || (ver == HTTP_1_1)) {
       if (s->client_info.proxy_connect_hdr) {
         heads->value_set(c_hdr_field_str, c_hdr_field_len, "close", 5);
-      } else {
+      } else if (s->state_machine->ua_txn != nullptr) {
         s->state_machine->ua_txn->set_close_connection(*heads);
       }
       s->client_info.keep_alive = HTTP_NO_KEEPALIVE;

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6891,7 +6891,10 @@ HttpTransact::handle_request_keep_alive_headers(State *s, HTTPVersion ver, HTTPH
         if (s->current.request_to == PARENT_PROXY && parent_is_proxy(s)) {
           heads->value_set(MIME_FIELD_PROXY_CONNECTION, MIME_LEN_PROXY_CONNECTION, "close", 5);
         } else {
-          s->state_machine->get_server_txn()->set_close_connection(*heads);
+          ProxyTransaction *svr = s->state_machine->get_server_txn();
+          if (svr) {
+            svr->set_close_connection(*heads);
+          }
         }
       }
       // Note: if we are 1.1, we always need to send the close

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6891,7 +6891,7 @@ HttpTransact::handle_request_keep_alive_headers(State *s, HTTPVersion ver, HTTPH
         if (s->current.request_to == PARENT_PROXY && parent_is_proxy(s)) {
           heads->value_set(MIME_FIELD_PROXY_CONNECTION, MIME_LEN_PROXY_CONNECTION, "close", 5);
         } else {
-          heads->value_set(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION, "close", 5);
+          s->state_machine->get_server_txn()->set_close_connection(*heads);
         }
       }
       // Note: if we are 1.1, we always need to send the close
@@ -7050,7 +7050,11 @@ HttpTransact::handle_response_keep_alive_headers(State *s, HTTPVersion ver, HTTP
   case KA_CLOSE:
   case KA_DISABLED:
     if (s->client_info.keep_alive != HTTP_NO_KEEPALIVE || (ver == HTTP_1_1)) {
-      heads->value_set(c_hdr_field_str, c_hdr_field_len, "close", 5);
+      if (s->client_info.proxy_connect_hdr) {
+        heads->value_set(c_hdr_field_str, c_hdr_field_len, "close", 5);
+      } else {
+        s->state_machine->ua_txn->set_close_connection(*heads);
+      }
       s->client_info.keep_alive = HTTP_NO_KEEPALIVE;
     }
     // Note: if we are 1.1, we always need to send the close


### PR DESCRIPTION
Ran across this while production testing H2 to origin.  Details of that investigation in #7622.

The upshot is that the HTTP/2 logic does pay attention to the Connection header if the value is "closed".  In the HTTP core logic, it regularly sets the "Connection: closed" header in the case of an error to ensure that in the HTTP/1.x case, the client or server connection is closed so any junk left on the socket will not be interpreted as a new transaction.  I had been assuming that adding this header for HTTP/2 ua_txn's was a no-op since HTTP/2 doesn't use the Connection header.

But our implementation will take the presence of a Connection:closed header as an indication that it should start draining the HTTP/2 session.  This PR replaces the logic that directly sets the Connection:closed header with a call to a virtual method.   The HTTP/1.x version will set the header, and the default version does nothing.

https://docs.trafficserver.apache.org/en/latest/admin-guide/plugins/header_rewrite.en.html?highlight=connection%20close%20drain#close-connections-for-draining

With this change adding a header-rewrite rule to add the Connection:closed header will still work to trigger the draining logic.  But core logic to clean up HTTP/1.x connections will not trigger the draining logic.  In theory this change should increase the lifetime of HTTP/2 Sessions.