### PR TITLE
Revert "Remove UnixNetVConnection::startEvent - not actually called."

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -266,6 +266,7 @@ public:
   const sockaddr *origin_trace_addr;
   int origin_trace_port;
 
+  int startEvent(int event, Event *e);
   int acceptEvent(int event, Event *e);
   int mainEvent(int event, Event *e);
   virtual int connectUp(EThread *t, int fd);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -957,6 +957,7 @@ SSLNetVConnection::free(EThread *t)
   con.close();
 
   clear();
+  SET_CONTINUATION_HANDLER(this, (SSLNetVConnHandler)&SSLNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -894,6 +894,7 @@ UnixNetVConnection::UnixNetVConnection()
     origin_trace_addr(nullptr),
     origin_trace_port(0)
 {
+  SET_HANDLER((NetVConnHandler)&UnixNetVConnection::startEvent);
 }
 
 // Private methods
@@ -1065,6 +1066,22 @@ void
 UnixNetVConnection::netActivity(EThread *lthread)
 {
   net_activity(this, lthread);
+}
+
+int
+UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
+{
+  MUTEX_TRY_LOCK(lock, get_NetHandler(e->ethread)->mutex, e->ethread);
+  if (!lock.is_locked()) {
+    e->schedule_in(HRTIME_MSECONDS(net_retry_delay));
+    return EVENT_CONT;
+  }
+  if (!action_.cancelled) {
+    connectUp(e->ethread, NO_FD);
+  } else {
+    free(e->ethread);
+  }
+  return EVENT_DONE;
 }
 
 int
@@ -1356,6 +1373,7 @@ UnixNetVConnection::free(EThread *t)
   con.close();
 
   clear();
+  SET_CONTINUATION_HANDLER(this, (NetVConnHandler)&UnixNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 


### PR DESCRIPTION
Reverts #7609

In #7609, UnixNetVConnection::startEvent was removed but it's necessary in UnixNetProcessor::connect_re_internal.
In the following code, UnixNetVConnection is scheduled if some mutexes can't be locked.
https://github.com/apache/trafficserver/blob/5a1697d23d200ce27f06abbe9aca394fb779ad60/iocore/net/UnixNetProcessor.cc#L275-L295

In this case, UnixNetVConnection::startEvent is appropriate as a handler 
because UnixNetVConnection is scheduled to execute UnixNetVConnection::connectUp.
Before #7609, UnixNetVConnection::startEvent was set as a handler in constructor, so I revert it.