### PR TITLE
Fix a use-after-free reported by clang-analyzer

### DIFF
--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -168,6 +168,7 @@ public:
   int connectUp(EThread *t, int fd) override;
 
   // QUICNetVConnection
+  int startEvent(int event, Event *e);
   int state_pre_handshake(int event, Event *data);
   int state_handshake(int event, Event *data);
   int state_connection_established(int event, Event *data);

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -245,6 +245,7 @@ public:
   bool from_accept_thread  = false;
   NetAccept *accept_object = nullptr;
 
+  int startEvent(int event, Event *e);
   int acceptEvent(int event, Event *e);
   int mainEvent(int event, Event *e);
   virtual int connectUp(EThread *t, int fd);

--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -149,6 +149,7 @@ QUICNetProcessor::connect_re(Continuation *cont, sockaddr const *remote_addr, Ne
   // Setup QUICNetVConnection
   QUICConnectionId client_dst_cid;
   client_dst_cid.randomize();
+  // vc->init set handler of vc `QUICNetVConnection::startEvent`
   vc->init(QUIC_SUPPORTED_VERSIONS[0], client_dst_cid, client_dst_cid, con, packet_handler, this->_rtable);
   packet_handler->init(vc);
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -242,6 +242,7 @@ void
 QUICNetVConnection::init(QUICVersion version, QUICConnectionId peer_cid, QUICConnectionId original_cid, UDPConnection *udp_con,
                          QUICPacketHandler *packet_handler, QUICResetTokenTable *rtable)
 {
+  SET_HANDLER((NetVConnHandler)&QUICNetVConnection::startEvent);
   this->_initial_version             = version;
   this->_udp_con                     = udp_con;
   this->_packet_handler              = packet_handler;
@@ -384,6 +385,25 @@ QUICNetVConnection::acceptEvent(int event, Event *e)
 
   action_.continuation->handleEvent(NET_EVENT_ACCEPT, this);
   this->_schedule_packet_write_ready();
+
+  return EVENT_DONE;
+}
+
+int
+QUICNetVConnection::startEvent(int event, Event *e)
+{
+  ink_assert(event == EVENT_IMMEDIATE);
+  MUTEX_TRY_LOCK(lock, get_NetHandler(e->ethread)->mutex, e->ethread);
+  if (!lock.is_locked()) {
+    e->schedule_in(HRTIME_MSECONDS(net_retry_delay));
+    return EVENT_CONT;
+  }
+
+  if (!action_.cancelled) {
+    this->connectUp(e->ethread, NO_FD);
+  } else {
+    this->free(e->ethread);
+  }
 
   return EVENT_DONE;
 }

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -991,6 +991,7 @@ SSLNetVConnection::free(EThread *t)
   early_data_buf    = nullptr;
 
   clear();
+  SET_CONTINUATION_HANDLER(this, (SSLNetVConnHandler)&SSLNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -828,7 +828,10 @@ UnixNetVConnection::reenable_re(VIO *vio)
   }
 }
 
-UnixNetVConnection::UnixNetVConnection() {}
+UnixNetVConnection::UnixNetVConnection()
+{
+  SET_HANDLER((NetVConnHandler)&UnixNetVConnection::startEvent);
+}
 
 // Private methods
 
@@ -988,6 +991,22 @@ void
 UnixNetVConnection::netActivity(EThread *lthread)
 {
   net_activity(this, lthread);
+}
+
+int
+UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
+{
+  MUTEX_TRY_LOCK(lock, get_NetHandler(e->ethread)->mutex, e->ethread);
+  if (!lock.is_locked()) {
+    e->schedule_in(HRTIME_MSECONDS(net_retry_delay));
+    return EVENT_CONT;
+  }
+  if (!action_.cancelled) {
+    connectUp(e->ethread, NO_FD);
+  } else {
+    free(e->ethread);
+  }
+  return EVENT_DONE;
 }
 
 int
@@ -1277,6 +1296,7 @@ UnixNetVConnection::free(EThread *t)
   con.close();
 
   clear();
+  SET_CONTINUATION_HANDLER(this, (NetVConnHandler)&UnixNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1004,7 +1004,7 @@ UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
   if (!action_.cancelled) {
     connectUp(e->ethread, NO_FD);
   } else {
-    free(e->ethread);
+    this->free(e->ethread);
   }
   return EVENT_DONE;
 }


### PR DESCRIPTION
Address a use-after-free on top of #8182.
https://ci.trafficserver.apache.org/clang-analyzer/github/8182/2021-07-28-135835-24348-1/report-26932e.html#EndPath
