### PR TITLE
Ran clang-tidy over the master branch

### DIFF
--- a/include/tscore/LogMessage.h
+++ b/include/tscore/LogMessage.h
@@ -111,7 +111,7 @@ private:
    *
    * @param[in] args The parameters for the above format string.
    */
-  void message_helper(std::chrono::microseconds current_configured_interval, log_function_f log_function, const char *fmt,
+  void message_helper(std::chrono::microseconds current_configured_interval, const log_function_f &log_function, const char *fmt,
                       va_list args);
 
   /** Message handling for non-debug logs. */

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -108,7 +108,7 @@ protected:
 private:
   virtual const char *_debug_tag() const;
   virtual bool _store_ssl_ctx(SSLCertLookup *lookup, shared_SSLMultiCertConfigParams ssl_multi_cert_params);
-  bool _prep_ssl_ctx(const shared_SSLMultiCertConfigParams sslMultCertSettings, SSLMultiCertConfigLoader::CertLoadData &data,
+  bool _prep_ssl_ctx(const shared_SSLMultiCertConfigParams &sslMultCertSettings, SSLMultiCertConfigLoader::CertLoadData &data,
                      std::set<std::string> &common_names, std::unordered_map<int, std::set<std::string>> &unique_names);
   virtual void _set_handshake_callbacks(SSL_CTX *ctx);
   virtual bool _setup_session_cache(SSL_CTX *ctx);

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -785,7 +785,7 @@ SSLConfigParams::getCTX(const std::string &client_cert, const std::string &key_f
 
       biop = BIO_new_mem_buf(secret_data.data(), secret_data.size());
 
-      cert = PEM_read_bio_X509(biop, NULL, 0, NULL);
+      cert = PEM_read_bio_X509(biop, nullptr, nullptr, nullptr);
       if (!cert) {
         SSLError("failed to load cert %s", client_cert.c_str());
         goto fail;
@@ -797,14 +797,14 @@ SSLConfigParams::getCTX(const std::string &client_cert, const std::string &key_f
       X509_free(cert);
 
       // Continue to fetch certs to associate intermediate certificates
-      cert = PEM_read_bio_X509(biop, NULL, 0, NULL);
+      cert = PEM_read_bio_X509(biop, nullptr, nullptr, nullptr);
       while (cert) {
         if (!SSL_CTX_use_certificate(client_ctx.get(), cert)) {
           SSLError("failed to attach client chain certificate from %s", client_cert.c_str());
           goto fail;
         }
         X509_free(cert);
-        cert = PEM_read_bio_X509(biop, NULL, 0, NULL);
+        cert = PEM_read_bio_X509(biop, nullptr, nullptr, nullptr);
       }
 
       cleanup_bio(biop);
@@ -819,7 +819,7 @@ SSLConfigParams::getCTX(const std::string &client_cert, const std::string &key_f
         biop = BIO_new_mem_buf(secret_data.data(), secret_data.size());
       }
 
-      key = PEM_read_bio_PrivateKey(biop, NULL, 0, NULL);
+      key = PEM_read_bio_PrivateKey(biop, nullptr, nullptr, nullptr);
       if (!key) {
         SSLError("failed to load client private key file from %s", key_file_name.c_str());
         goto fail;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1648,7 +1648,7 @@ SSLCreateServerContext(const SSLConfigParams *params, const SSLMultiCertConfigPa
  * Common name resolution and cert validation
  */
 bool
-SSLMultiCertConfigLoader::_prep_ssl_ctx(const shared_SSLMultiCertConfigParams sslMultCertSettings,
+SSLMultiCertConfigLoader::_prep_ssl_ctx(const shared_SSLMultiCertConfigParams &sslMultCertSettings,
                                         SSLMultiCertConfigLoader::CertLoadData &data, std::set<std::string> &common_names,
                                         std::unordered_map<int, std::set<std::string>> &unique_names)
 {

--- a/mgmt/YamlCfg.cc
+++ b/mgmt/YamlCfg.cc
@@ -32,7 +32,7 @@ namespace ts
 {
 namespace Yaml
 {
-  Map::Map(YAML::Node map) : _map{map}
+  Map::Map(const YAML::Node &map) : _map{map}
   {
     if (!_map.IsMap()) {
       throw YAML::ParserException(_map.Mark(), "map expected");

--- a/mgmt/YamlCfg.h
+++ b/mgmt/YamlCfg.h
@@ -40,7 +40,7 @@ namespace Yaml
   public:
     // A YAML::ParserException will be thrown if 'map' isn't actually a map.
     //
-    explicit Map(YAML::Node map);
+    explicit Map(const YAML::Node &map);
 
     // Get the node for a key.  Throw a YAML::Exception if 'key' is not in the map.  The node for each key in the
     // map must be gotten at least once.  The lifetime of the char array referenced by passed key must be as long

--- a/plugins/experimental/cache_fill/background_fetch.cc
+++ b/plugins/experimental/cache_fill/background_fetch.cc
@@ -38,7 +38,7 @@
 #include "ts/ts.h"
 #include "ts/remap.h"
 #include "background_fetch.h"
-typedef std::unordered_map<std::string, bool> OutstandingRequests;
+using OutstandingRequests = std::unordered_map<std::string, bool>;
 
 ///////////////////////////////////////////////////////////////////////////
 // Set a header to a specific value. This will avoid going to through a

--- a/plugins/experimental/cache_fill/cache_fill.cc
+++ b/plugins/experimental/cache_fill/cache_fill.cc
@@ -68,11 +68,12 @@ getCacheLookupResultName(TSCacheLookupResult result)
 static bool
 cont_check_cacheable(TSHttpTxn txnp)
 {
-  if (TSHttpTxnIsInternal(txnp))
+  if (TSHttpTxnIsInternal(txnp)) {
     return false;
+  }
   int lookupStatus;
   TSHttpTxnCacheLookupStatusGet(txnp, &lookupStatus);
-  TSDebug(PLUGIN_NAME, "lookup status: %s", getCacheLookupResultName((TSCacheLookupResult)lookupStatus));
+  TSDebug(PLUGIN_NAME, "lookup status: %s", getCacheLookupResultName(static_cast<TSCacheLookupResult>(lookupStatus)));
   bool ret = false;
   if (TS_CACHE_LOOKUP_MISS == lookupStatus || TS_CACHE_LOOKUP_HIT_STALE == lookupStatus) {
     bool const nostore = TSHttpTxnServerRespNoStoreGet(txnp);

--- a/plugins/experimental/parent_select/strategy.cc
+++ b/plugins/experimental/parent_select/strategy.cc
@@ -296,7 +296,7 @@ template <> struct convert<PLHostRecord> {
       throw std::invalid_argument("Invalid host protocol definition, expected a sequence.");
     } else {
       for (auto &&ii : proto) {
-        YAML::Node protocol_node         = ii;
+        const YAML::Node &protocol_node  = ii;
         std::shared_ptr<PLNHProtocol> pr = std::make_shared<PLNHProtocol>(protocol_node.as<PLNHProtocol>());
         nh.protocols.push_back(std::move(pr));
       }

--- a/plugins/experimental/rate_limit/sni_limiter.cc
+++ b/plugins/experimental/rate_limit/sni_limiter.cc
@@ -107,7 +107,7 @@ SniRateLimiter::initialize(int argc, const char *argv[])
   };
 
   while (true) {
-    int opt = getopt_long(argc, (char *const *)argv, "", longopt, nullptr);
+    int opt = getopt_long(argc, const_cast<char *const *>(argv), "", longopt, nullptr);
 
     switch (opt) {
     case 'l':

--- a/plugins/experimental/rate_limit/sni_selector.cc
+++ b/plugins/experimental/rate_limit/sni_selector.cc
@@ -20,7 +20,7 @@
 // Needs special OpenSSL APIs as a global plugin for early CLIENT_HELLO inspection
 #if TS_USE_HELLO_CB
 
-#include <string.h>
+#include <cstring>
 
 #include "sni_limiter.h"
 #include "sni_selector.h"

--- a/plugins/experimental/rate_limit/txn_limiter.cc
+++ b/plugins/experimental/rate_limit/txn_limiter.cc
@@ -114,7 +114,7 @@ TxnRateLimiter::initialize(int argc, const char *argv[])
   };
 
   while (true) {
-    int opt = getopt_long(argc, (char *const *)argv, "", longopt, nullptr);
+    int opt = getopt_long(argc, const_cast<char *const *>(argv), "", longopt, nullptr);
 
     switch (opt) {
     case 'l':

--- a/plugins/header_rewrite/conditions_geo_maxmind.cc
+++ b/plugins/header_rewrite/conditions_geo_maxmind.cc
@@ -114,7 +114,7 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
   }
   ret = std::string(entry_data.utf8_string, entry_data.data_size);
 
-  if (NULL != entry_data_list) {
+  if (nullptr != entry_data_list) {
     MMDB_free_entry_data_list(entry_data_list);
   }
 
@@ -176,7 +176,7 @@ MMConditionGeo::get_geo_int(const sockaddr *addr) const
   }
   ret = entry_data.uint32;
 
-  if (NULL != entry_data_list) {
+  if (nullptr != entry_data_list) {
     MMDB_free_entry_data_list(entry_data_list);
   }
 

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -302,7 +302,7 @@ cont_rewrite_headers(TSCont contp, TSEvent event, void *edata)
   return 0;
 }
 
-static const struct option longopt[] = {{"geo-db-path", required_argument, NULL, 'm'}, {NULL, no_argument, NULL, '\0'}};
+static const struct option longopt[] = {{"geo-db-path", required_argument, nullptr, 'm'}, {nullptr, no_argument, nullptr, '\0'}};
 
 ///////////////////////////////////////////////////////////////////////////////
 // Initialize the InkAPI plugin for the global hooks we support.
@@ -323,7 +323,7 @@ TSPluginInit(int argc, const char *argv[])
 
   std::string geoDBpath;
   while (true) {
-    int opt = getopt_long(argc, (char *const *)argv, "m:", longopt, NULL);
+    int opt = getopt_long(argc, const_cast<char *const *>(argv), "m:", longopt, nullptr);
 
     switch (opt) {
     case 'm': {
@@ -335,7 +335,7 @@ TSPluginInit(int argc, const char *argv[])
     }
   }
 
-  if (!geoDBpath.empty() && geoDBpath.find("/") != 0) {
+  if (!geoDBpath.empty() && geoDBpath.find('/') != 0) {
     geoDBpath = std::string(TSConfigDirGet()) + '/' + geoDBpath;
   }
 
@@ -421,7 +421,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 
   std::string geoDBpath;
   while (true) {
-    int opt = getopt_long(argc, (char *const *)argv, "m:", longopt, NULL);
+    int opt = getopt_long(argc, (char *const *)argv, "m:", longopt, nullptr);
 
     switch (opt) {
     case 'm': {
@@ -434,7 +434,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
   }
 
   if (!geoDBpath.empty()) {
-    if (geoDBpath.find("/") != 0) {
+    if (geoDBpath.find('/') != 0) {
       geoDBpath = std::string(TSConfigDirGet()) + '/' + geoDBpath;
     }
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7792,7 +7792,7 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
 
   URL *url = outgoing_request->url_get();
   // Remove fragment from upstream URL
-  url->fragment_set(NULL, 0);
+  url->fragment_set(nullptr, 0);
 
   // Check whether a Host header field is missing from a 1.0 or 1.1 request.
   if (outgoing_version != HTTP_0_9 && !outgoing_request->presence(MIME_PRESENCE_HOST)) {

--- a/proxy/http/remap/UrlMapping.cc
+++ b/proxy/http/remap/UrlMapping.cc
@@ -98,7 +98,7 @@ url_mapping::Print() const
 std::string
 url_mapping::PrintRemapHitCount() const
 {
-  std::string result = "{\"fromURL\": \"" + remapKey + "\", \"hit_count\": " + std::to_string(_hitCount) + "}";
+  std::string result = R"({"fromURL": ")" + remapKey + R"(", "hit_count": )" + std::to_string(_hitCount) + "}";
   return result;
 }
 

--- a/src/tscore/LogMessage.cc
+++ b/src/tscore/LogMessage.cc
@@ -45,8 +45,8 @@ LogMessage::set_default_debug_throttling_interval(std::chrono::milliseconds new_
 }
 
 void
-LogMessage::message_helper(std::chrono::microseconds current_configured_interval, log_function_f log_function, const char *fmt,
-                           va_list args)
+LogMessage::message_helper(std::chrono::microseconds current_configured_interval, const log_function_f &log_function,
+                           const char *fmt, va_list args)
 {
   if (!_is_throttled) {
     // If throttling is disabled, make this operation as efficient as possible.

--- a/src/tscore/unit_tests/freelist_benchmark.cc
+++ b/src/tscore/unit_tests/freelist_benchmark.cc
@@ -130,7 +130,7 @@ setup_test_case_1(const int64_t n)
   assert(obj_count > 0);
 
   for (int i = 0; i < n; i++) {
-    ink_thread_create(&list[i], test_case_1, (void *)((intptr_t)i), 0, 0, nullptr);
+    ink_thread_create(&list[i], test_case_1, (void *)(static_cast<intptr_t>(i)), 0, 0, nullptr);
 
     int dst = i;
     if (thread_assiging_order == 1) {
@@ -146,7 +146,7 @@ setup_test_case_1(const int64_t n)
 
     if (debug_enabled) {
       int cpu_mask_len = hwloc_bitmap_snprintf(nullptr, 0, obj->cpuset) + 1;
-      char *cpu_mask   = (char *)alloca(cpu_mask_len);
+      char *cpu_mask   = static_cast<char *>(alloca(cpu_mask_len));
       hwloc_bitmap_snprintf(cpu_mask, cpu_mask_len, obj->cpuset);
 
       std::cout << "tid=" << list[i] << " obj->logical_index=" << obj->logical_index << " cpu_mask=" << cpu_mask << std::endl;

--- a/src/tscore/unit_tests/test_MMH.cc
+++ b/src/tscore/unit_tests/test_MMH.cc
@@ -30,8 +30,8 @@
 static int
 xxcompar(const void *a, const void *b)
 {
-  int **x = static_cast<int **>(a);
-  int **y = static_cast<int **>(b);
+  int *const *x = static_cast<int *const *>(a);
+  int *const *y = static_cast<int *const *>(b);
   for (int i = 0; i < 4; i++) {
     if (x[i] > y[i]) {
       return 1;

--- a/src/tscore/unit_tests/test_MMH.cc
+++ b/src/tscore/unit_tests/test_MMH.cc
@@ -30,13 +30,15 @@
 static int
 xxcompar(const void *a, const void *b)
 {
-  int **x = (int **)a;
-  int **y = (int **)b;
+  int **x = static_cast<int **>(a);
+  int **y = static_cast<int **>(b);
   for (int i = 0; i < 4; i++) {
-    if (x[i] > y[i])
+    if (x[i] > y[i]) {
       return 1;
-    if (x[i] < y[i])
+    }
+    if (x[i] < y[i]) {
       return -1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Ran clang-tidy over the master and 9.1.x branches to reduce the number of conflicts between branches.