### PR TITLE
lua: add ts.is_debug_tag_set function

### DIFF
--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -251,6 +251,24 @@ We should write this TAG in records.config(If TAG is missing, default TAG will b
 
 :ref:`TOP <admin-plugins-ts-lua>`
 
+ts.is_debug_tag_set
+-------------------
+**syntax:** *ts.is_debug_tag_set(TAG?)*
+
+**context:** global
+
+**description**: Returns '1' if debug TAG is enabled(the default TAG is **ts_lua**).
+
+Here is an example:
+
+::
+
+       if ts.is_debug_tag_set() then
+           ts.debug("hello world")
+       end
+
+:ref:`TOP <admin-plugins-ts-lua>`
+
 ts.error
 --------
 **syntax:** *ts.error(MESSAGE)*

--- a/plugins/lua/ts_lua_misc.c
+++ b/plugins/lua/ts_lua_misc.c
@@ -23,6 +23,7 @@
 static int ts_lua_get_process_id(lua_State *L);
 static int ts_lua_get_now_time(lua_State *L);
 static int ts_lua_debug(lua_State *L);
+static int ts_lua_is_debug_tag_set(lua_State *L);
 static int ts_lua_error(lua_State *L);
 static int ts_lua_emergency(lua_State *L);
 static int ts_lua_fatal(lua_State *L);
@@ -65,6 +66,10 @@ ts_lua_inject_misc_api(lua_State *L)
   /* ts.debug(...) */
   lua_pushcfunction(L, ts_lua_debug);
   lua_setfield(L, -2, "debug");
+
+  /* ts.is_debug_tag_set(...) */
+  lua_pushcfunction(L, ts_lua_is_debug_tag_set);
+  lua_setfield(L, -2, "is_debug_tag_set");
 
   /* ts.error(...) */
   lua_pushcfunction(L, ts_lua_error);
@@ -180,6 +185,29 @@ ts_lua_debug(lua_State *L)
   }
 
   return 0;
+}
+
+static int
+ts_lua_is_debug_tag_set(lua_State *L)
+{
+  const char *flag;
+  size_t flag_len = 0;
+  int stat        = 0;
+
+  if (lua_gettop(L) == 1) {
+    flag = luaL_checklstring(L, 1, &flag_len);
+    stat = TSIsDebugTagSet(flag);
+  } else {
+    stat = TSIsDebugTagSet(TS_LUA_DEBUG_TAG);
+  }
+
+  if (0 == stat) {
+    lua_pushboolean(L, 0);
+  } else {
+    lua_pushboolean(L, 1);
+  }
+
+  return 1;
 }
 
 static int

--- a/tests/gold_tests/pluginTest/lua/lua_debug_tags.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_debug_tags.test.py
@@ -1,0 +1,55 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Test lua is_debug_tag_set functionality
+'''
+
+Test.SkipUnless(
+    Condition.PluginExists('tslua.so'),
+)
+
+Test.ContinueOnFail = False
+# Define default ATS
+ts = Test.MakeATSProcess("ts", command="traffic_manager")
+
+ts.Disk.remap_config.AddLine(
+    'map http://test http://127.0.0.1/ @plugin=tslua.so @pparam=tags.lua'
+)
+
+# Configure the tslua's configuration file.
+ts.Setup.Copy("tags.lua", ts.Variables.CONFIGDIR)
+ts.Setup.Copy("tags.sh")
+
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'foo|ts_lua',
+})
+
+curl_and_args = f'curl -s -D /dev/stderr -o /dev/stdout -x localhost:{ts.Variables.port} http://test/test.html'
+
+# 0 Ensure no debug tag set
+tr = Test.AddTestRun("check tags")
+ps = tr.Processes.Default
+tr.StillRunningAfter = ts
+ps.StartBefore(Test.Processes.ts)
+ps.Command = f"bash ./tags.sh {curl_and_args}"
+ps.Env = ts.Env
+ps.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/lua/tags.lua
+++ b/tests/gold_tests/pluginTest/lua/tags.lua
@@ -1,0 +1,31 @@
+--  Licensed to the Apache Software Foundation (ASF) under one
+--  or more contributor license agreements.  See the NOTICE file
+--  distributed with this work for additional information
+--  regarding copyright ownership.  The ASF licenses this file
+--  to you under the Apache License, Version 2.0 (the
+--  "License"); you may not use this file except in compliance
+--  with the License.  You may obtain a copy of the License at
+--
+--  http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+
+function do_remap()
+  if 'GET' == ts.client_request.get_method() then
+    local msg = ""
+    if ts.is_debug_tag_set() then
+      msg = msg .. " default"
+    end
+    if ts.is_debug_tag_set("foo") then
+      msg = msg .. " foo"
+    end
+    if ts.is_debug_tag_set("ts_lua") then
+      msg = msg .. " ts_lua"
+    end
+    ts.http.set_resp(200, msg)
+  end
+end

--- a/tests/gold_tests/pluginTest/lua/tags.sh
+++ b/tests/gold_tests/pluginTest/lua/tags.sh
@@ -1,0 +1,32 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+echo $*
+expected=" default foo ts_lua"
+
+N=15
+while (( N > 0 ))
+do
+    output=$(eval $*)
+    echo ${output}
+    if [ "${expected}" = "${output}" ]; then
+        exit 0
+    fi
+    let N=N-1
+    sleep 1
+done
+echo TIMEOUT
+exit 1


### PR DESCRIPTION
This exposes TSIsDebugTagSet to the lua plugin to allow for complex debug logic to only be calculated when debug is turned on.