### PR TITLE
Minor updates to HTTP version validation

### DIFF
--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -633,26 +633,23 @@ http_hdr_type_set(HTTPHdrImpl *hh, HTTPType type)
   -------------------------------------------------------------------------*/
 
 bool
-is_version_supported(const uint8_t major, const uint8_t minor)
+is_http1_version(const uint8_t major, const uint8_t minor)
 {
-  if (major == 1) {
-    return minor == 1 || minor == 0;
-  }
-
-  return false;
+  // Return true if 1.1 or 1.0
+  return (major == 1) && (minor == 1 || minor == 0);
 }
 
 bool
-is_http_hdr_version_supported(const HTTPVersion &http_version)
+is_http1_hdr_version_supported(const HTTPVersion &http_version)
 {
-  return is_version_supported(http_version.get_major(), http_version.get_minor());
+  return is_http1_version(http_version.get_major(), http_version.get_minor());
 }
 
 bool
 http_hdr_version_set(HTTPHdrImpl *hh, const HTTPVersion &ver)
 {
   hh->m_version = ver;
-  return is_version_supported(ver.get_major(), ver.get_minor());
+  return is_http1_version(ver.get_major(), ver.get_minor());
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -462,7 +462,7 @@ HTTPValRange*          http_parse_range (const char *buf, Arena *arena);
 */
 HTTPValTE *http_parse_te(const char *buf, int len, Arena *arena);
 
-bool is_http_hdr_version_supported(const HTTPVersion &http_version);
+bool is_http1_hdr_version_supported(const HTTPVersion &http_version);
 
 class IOBufferReader;
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -820,7 +820,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
       t_state.http_return_code = HTTP_STATUS_REQUEST_URI_TOO_LONG :
       t_state.http_return_code = HTTP_STATUS_NONE;
 
-    if (!is_http_hdr_version_supported(t_state.hdr_info.client_request.version_get())) {
+    if (!is_http1_hdr_version_supported(t_state.hdr_info.client_request.version_get())) {
       t_state.http_return_code = HTTP_STATUS_HTTPVER_NOT_SUPPORTED;
     }
 


### PR DESCRIPTION
Renamed the functions to be more explicit about only supporting HTTP/1.x
Changed the version check to be only a logic statement

This is a update to #7875

I would like to pull #7875 into the 9.1.x branch because we right now have an autest for testing invalid versions and it is failing right now (because of #7885).  However, @zwoop and I didn't like the function names.
