### PR TITLE
Revert "Remove UnixNetVConnection::startEvent - not actually called. (#7596)

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -266,6 +266,7 @@ public:
   const sockaddr *origin_trace_addr;
   int origin_trace_port;
 
+  int startEvent(int event, Event *e);
   int acceptEvent(int event, Event *e);
   int mainEvent(int event, Event *e);
   virtual int connectUp(EThread *t, int fd);

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -957,6 +957,7 @@ SSLNetVConnection::free(EThread *t)
   con.close();
 
   clear();
+  SET_CONTINUATION_HANDLER(this, (SSLNetVConnHandler)&SSLNetVConnection::startEvent);
   ink_assert(con.fd == NO_FD);
   ink_assert(t == this_ethread());
 


### PR DESCRIPTION
Backport #8184 to the 8.1.x branch.

----

* Revert "Remove UnixNetVConnection::startEvent - not actually called. (#7596)"

This reverts commit a56638f8ba92c48e2cc8b677438c36e13f393e2b.

* Fix a use-after-free reported by clang-analyzer

Co-authored-by: Tomoaki Tanaka <tomoatan@yahoo-corp.jp>

(cherry picked from commit 6efb8d8090b9f6f820e8dd48505134af143c7005)

Conflicts:
	iocore/net/P_QUICNetVConnection.h
	iocore/net/QUICNetProcessor.cc
	iocore/net/QUICNetVConnection.cc
	iocore/net/UnixNetVConnection.cc