### PR TITLE
Fix H2 logic when setting EOS flag on DATA frame

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1677,6 +1677,8 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
     payload_length = 0;
   }
 
+  stream->update_sent_count(payload_length);
+
   // Are we at the end?
   // If we return here, we never send the END_STREAM in the case of a early terminating OS.
   // OK if there is no body yet. Otherwise continue on to send a DATA frame and delete the stream
@@ -1700,8 +1702,6 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
 
   Http2DataFrame data(stream->get_id(), flags, resp_reader, payload_length);
   this->ua_session->xmit(data, flags & HTTP2_FLAGS_DATA_END_STREAM);
-
-  stream->update_sent_count(payload_length);
 
   if (flags & HTTP2_FLAGS_DATA_END_STREAM) {
     Http2StreamDebug(ua_session, stream->get_id(), "END_STREAM");

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1688,7 +1688,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
     return Http2SendDataFrameResult::NO_PAYLOAD;
   }
 
-  if (stream->is_write_vio_done() && !resp_reader->is_read_avail_more_than(0)) {
+  if (stream->is_write_vio_done()) {
     flags |= HTTP2_FLAGS_DATA_END_STREAM;
   }
 


### PR DESCRIPTION
Noticed this while debugging HTTP2 to origin.  stream->update_sent_count() updates the write_vio.ndone.  But in the original code this update is done after the stream->is_write_vio_done() check is made to determine whether the EOS flag should be set.  The EOS flag will only be set if the payload is 0.

I would think this would have caused problems quite a lot of the time.  Generally showing up as timeouts as the client waits forever for the EOS flag after receiving all the data.