### PR TITLE
Reduce possibility for H2 client count mismatch

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1508,13 +1508,6 @@ Http2ConnectionState::delete_stream(Http2Stream *stream)
   }
 
   stream_list.remove(stream);
-  if (http2_is_client_streamid(stream->get_id())) {
-    ink_assert(client_streams_in_count > 0);
-    --client_streams_in_count;
-  } else {
-    ink_assert(client_streams_out_count > 0);
-    --client_streams_out_count;
-  }
   // total_client_streams_count will be decremented in release_stream(), because it's a counter include streams in the process of
   // shutting down.
 

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -147,6 +147,8 @@ public:
   Event *get_zombie_event();
   void schedule_zombie_event();
 
+  void decrement_stream_count(Http2StreamId id);
+
   void increment_received_settings_count(uint32_t count);
   uint32_t get_received_settings_count();
   void increment_received_settings_frame_count();
@@ -345,5 +347,15 @@ Http2ConnectionState::schedule_zombie_event()
       zombie_event->cancel();
     }
     zombie_event = this_ethread()->schedule_in(this, HRTIME_SECONDS(Http2::zombie_timeout_in));
+  }
+}
+
+inline void
+Http2ConnectionState::decrement_stream_count(Http2StreamId id)
+{
+  if (http2_is_client_streamid(id)) {
+    --client_streams_in_count;
+  } else {
+    --client_streams_out_count;
   }
 }


### PR DESCRIPTION
Details in issue #8200.  The code change pulls up the decrementing logic for the client stream count, so we can be more likely to be consistent with the H2 peers counting.

This closes #8200