### PR TITLE
Fix mutex use after free

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1213,7 +1213,6 @@ UnixNetVConnection::connectUp(EThread *t, int fd)
     res = con.connect(nullptr, options);
     if (res != 0) {
       // fast stopIO
-      nh = nullptr;
       goto fail;
     }
   }

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1004,7 +1004,7 @@ UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
   if (!action_.cancelled) {
     connectUp(e->ethread, NO_FD);
   } else {
-    this->free(e->ethread);
+    get_NetHandler(e->ethread)->free_netevent(this);
   }
   return EVENT_DONE;
 }

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1239,7 +1239,7 @@ fail:
   if (fd != NO_FD) {
     con.fd = NO_FD;
   }
-  free(t);
+  nh->free_netevent(this);
   return CONNECT_FAILURE;
 }
 


### PR DESCRIPTION
Clang-analyzer is complaining that the are calling the MutexTryLock destructor (which references the net handler's mutex) after destroying the netvc.   If the mutex's ref count went to zero, this would be a problem.  Trying the free_netevent method to clean up instead.  That is what is used on the normal netvc cleanup path.  Perhaps the naked free() has a ref counting problem.