### PR TITLE
uri_signing: embed config into the unit test

### DIFF
--- a/plugins/experimental/uri_signing/config.c
+++ b/plugins/experimental/uri_signing/config.c
@@ -178,16 +178,9 @@ load_jwk(json_t *obj, cjose_err *err)
   return jwk;
 }
 
-struct config *
-read_config(const char *path)
+static struct config *
+read_config_from_json(json_t *const issuer_json)
 {
-  json_error_t err    = {0};
-  json_t *issuer_json = json_load_file(path, 0, &err);
-  if (!issuer_json) {
-    JSONError(err);
-    goto fail;
-  }
-
   if (!json_is_object(issuer_json)) {
     PluginError("Config file is not a valid JSON object");
     goto issuer_fail;
@@ -346,8 +339,31 @@ cfg_fail:
   config_delete(cfg);
 issuer_fail:
   json_decref(issuer_json);
-fail:
   return NULL;
+}
+
+struct config *
+read_config_from_path(char const *const path)
+{
+  json_error_t err    = {0};
+  json_t *issuer_json = json_load_file(path, 0, &err);
+  if (!issuer_json) {
+    JSONError(err);
+    return NULL;
+  }
+  return read_config_from_json(issuer_json);
+}
+
+struct config *
+read_config_from_string(char const *const buffer)
+{
+  json_error_t err    = {0};
+  json_t *issuer_json = json_loads(buffer, 0, &err);
+  if (!issuer_json) {
+    JSONError(err);
+    return NULL;
+  }
+  return read_config_from_json(issuer_json);
 }
 
 struct signer *

--- a/plugins/experimental/uri_signing/config.h
+++ b/plugins/experimental/uri_signing/config.h
@@ -29,7 +29,8 @@ struct signer {
   char *alg;
 };
 
-struct config *read_config(const char *path);
+struct config *read_config_from_path(const char *const path);
+struct config *read_config_from_string(const char *const buffer);
 void config_delete(struct config *g);
 struct signer *config_signer(struct config *);
 struct _cjose_jwk_int **find_keys(struct config *cfg, const char *issuer);

--- a/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
+++ b/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
@@ -33,6 +33,112 @@ extern "C" {
 #include "../config.h"
 }
 
+static char const *const testConfig =
+  R"(
+{
+    "Master Issuer": {
+        "renewal_kid": "6",
+        "id": "tester",
+        "auth_directives": [
+            {
+                "auth": "allow",
+                "uri": "regex:invalid"
+            }
+        ],
+        "keys": [
+         {
+          "alg": "HS256",
+          "k": "nxb7fyO5Z2hGz9E3oKm1357ptvC2su5QwQUb4YaIaIc",
+          "kid": "0",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "cXKukBqFvQ0n3WAuRnWfExC14dmHdGoJULoZjGu9tJC",
+          "kid": "1",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "38pJlSXfX87jWL0a03luml9QzUmM4qts1nmfIHA3B7r",
+          "kid": "2",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "zNQPphknDGvzR5kA7IonXIDWKMyB1b8NpGmmDNlpgtM",
+          "kid": "3",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "iB2ogCmQRt7r5hW7pgyP5FqiFcCl53MPQvfXv8wrZAn",
+          "kid": "4",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "GJMCTyZhNoSOZvUOKmmY9MtGSLaONNLHqtKwsC3MWKo",
+          "kid": "5",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "u2LziZKJFBnOfjUQUmvot7C9t91jj7ocJPIU9aDdbUl",
+          "kid": "6",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "DRBKrBh87NYkH3UzfW1tWbiXCYXiYGZUE9w1orZngL0",
+          "kid": "7",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "KNNKFbun8lEs7GbiKlo9mYGNdvpt33tdFzHbNnasDyP",
+          "kid": "8",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "yb6kOddMUdupPRSkWMUdE6jrWT4MqUnVyTjpeJBYIqp",
+          "kid": "9",
+          "kty": "oct"
+         }
+        ]
+    },
+    "Second Issuer": {
+        "keys": [
+         {
+          "alg": "HS256",
+          "k": "testkey1",
+          "kid": "one",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "testkey2",
+          "kid": "two",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "testkey3",
+          "kid": "three",
+          "kty": "oct"
+         },
+         {
+          "alg": "HS256",
+          "k": "testkey4",
+          "kid": "four",
+          "kty": "oct"
+         }
+        ]
+    }
+}
+)";
+
 bool
 jwt_parsing_helper(const char *jwt_string)
 {
@@ -569,9 +675,12 @@ TEST_CASE("7", "[TestsConfig]")
 {
   INFO("TEST 7, Config Loading and Config Functions");
 
+  fprintf(stderr, "%s\n", testConfig);
+  fflush(stderr);
+
   SECTION("Config Loading ID Field")
   {
-    struct config *cfg = read_config(SRCDIR "/experimental/uri_signing/unit_tests/testConfig.config");
+    struct config *cfg = read_config_from_string(testConfig);
     REQUIRE(cfg != NULL);
     REQUIRE(strcmp(config_get_id(cfg), "tester") == 0);
     config_delete(cfg);
@@ -603,7 +712,7 @@ jws_validation_helper(const char *url, const char *package, struct config *cfg)
 TEST_CASE("8", "[TestsWithConfig]")
 {
   INFO("TEST 8, Tests Involving Validation with Config");
-  struct config *cfg = read_config(SRCDIR "/experimental/uri_signing/unit_tests/testConfig.config");
+  struct config *cfg = read_config_from_string(testConfig);
 
   SECTION("Validation of Valid Aud String in JWS")
   {

--- a/plugins/experimental/uri_signing/uri_signing.c
+++ b/plugins/experimental/uri_signing/uri_signing.c
@@ -80,7 +80,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
   }
 
   TSDebug(PLUGIN_NAME, "config file name: %s", config_file);
-  struct config *cfg = read_config(config_file);
+  struct config *cfg = read_config_from_path(config_file);
   if (!cfg) {
     snprintf(errbuf, errbuf_size, "Unable to open config file: \"%s\"", config_file);
     free(config_file);


### PR DESCRIPTION
This changes the uri_signing unit test so that the config is embedded in the executable instead of needing to be loaded from a specific location on disk.

A slight change was made to the uri signing config loader to allow jansson to load from either a config file or from a string buffer.