### PR TITLE
Fix client ip debug logging for the entire transaction

### DIFF
--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -282,6 +282,7 @@ UnixNetVConnection::set_remote_addr()
 {
   ats_ip_copy(&remote_addr, &con.addr);
   this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags->test_override_ip(remote_addr));
+  set_cont_flags(get_control_flags());
 }
 
 inline void
@@ -289,6 +290,7 @@ UnixNetVConnection::set_remote_addr(const sockaddr *new_sa)
 {
   ats_ip_copy(&remote_addr, new_sa);
   this->control_flags.set_flag(ContFlags::DEBUG_OVERRIDE, diags->test_override_ip(remote_addr));
+  set_cont_flags(get_control_flags());
 }
 
 inline void

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -87,6 +87,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
     vc->id = net_next_connection_number();
     vc->con.move(con);
+    vc->set_remote_addr(con.addr);
     vc->submit_time = Thread::get_hrtime();
     vc->action_     = *na->action_;
     vc->set_is_transparent(na->opt.f_inbound_transparent);
@@ -331,6 +332,7 @@ NetAccept::do_blocking_accept(EThread *t)
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
     vc->id = net_next_connection_number();
     vc->con.move(con);
+    vc->set_remote_addr(con.addr);
     vc->submit_time = Thread::get_hrtime();
     vc->action_     = *action_;
     vc->set_is_transparent(opt.f_inbound_transparent);
@@ -481,6 +483,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
     vc->id = net_next_connection_number();
     vc->con.move(con);
+    vc->set_remote_addr(con.addr);
     vc->submit_time = Thread::get_hrtime();
     vc->action_     = *action_;
     vc->set_is_transparent(opt.f_inbound_transparent);

--- a/tests/gold_tests/logging/log-debug-client-ip.test.py
+++ b/tests/gold_tests/logging/log-debug-client-ip.test.py
@@ -1,0 +1,56 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Test log filter.
+'''
+
+ts = Test.MakeATSProcess("ts", enable_cache=False)
+replay_file = "log-filter.replays.yaml"
+server = Test.MakeVerifierServerProcess("server", replay_file)
+
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 2,
+    'proxy.config.diags.debug.tags': 'http',
+    'proxy.config.diags.debug.client_ip': '127.0.0.1',
+})
+ts.Disk.remap_config.AddLine(
+    'map / http://localhost:{}/'.format(server.Variables.http_port)
+)
+
+# Verify that the various aspects of the expected debug output for the
+# transaction are logged.
+ts.Streams.stderr = Testers.ContainsExpression(
+    r"\+ Incoming Request \+",
+    "Make sure the client request information is present.")
+ts.Streams.stderr += Testers.ContainsExpression(
+    r"\+ Proxy's Request after hooks \+",
+    "Make sure the proxy request information is present.")
+ts.Streams.stderr += Testers.ContainsExpression(
+    r"\+ Incoming O.S. Response \+",
+    "Make sure the server's response information is present.")
+ts.Streams.stderr += Testers.ContainsExpression(
+    r"\+ Proxy's Response 2 \+",
+    "Make sure the proxy response information is present.")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(ts)
+tr.AddVerifierClientProcess("client-1", replay_file, http_ports=[ts.Variables.port], other_args="--keys test-1")


### PR DESCRIPTION
This fixes debug client ip logging so that the remote address and debug
tag are set on the thread and netvc earlier so that the debug logs for
the entire transaction.