### PR TITLE
Fix heap-use-after-free of ts-lua plugin

### DIFF
--- a/plugins/lua/ts_lua_util.c
+++ b/plugins/lua/ts_lua_util.c
@@ -42,6 +42,20 @@ static void ts_lua_init_globals(lua_State *L);
 static void ts_lua_inject_ts_api(lua_State *L);
 static ts_lua_ctx_stats *ts_lua_create_ctx_stats();
 static void ts_lua_destroy_ctx_stats(ts_lua_ctx_stats *stats);
+static void ts_lua_update_server_response_hdrp(ts_lua_http_ctx *http_ctx);
+
+/**
+   Update http_ctx->server_response_hdrp if there.
+
+   This is required in the beginning of toughing response, because holding old pointer could be freed by core.
+ */
+void
+ts_lua_update_server_response_hdrp(ts_lua_http_ctx *http_ctx)
+{
+  if (http_ctx->server_response_hdrp) {
+    TSHttpTxnServerRespGet(http_ctx->txnp, &http_ctx->server_response_bufp, &http_ctx->server_response_hdrp);
+  }
+}
 
 int
 ts_lua_create_vm(ts_lua_main_ctx *arr, int n)
@@ -913,6 +927,7 @@ ts_lua_http_cont_handler(TSCont contp, TSEvent ev, void *edata)
     break;
 
   case TS_EVENT_HTTP_READ_RESPONSE_HDR:
+    ts_lua_update_server_response_hdrp(http_ctx);
 
     lua_getglobal(L, TS_LUA_FUNCTION_READ_RESPONSE);
 
@@ -993,6 +1008,8 @@ ts_lua_http_cont_handler(TSCont contp, TSEvent ev, void *edata)
     break;
 
   case TS_EVENT_HTTP_TXN_CLOSE:
+    ts_lua_update_server_response_hdrp(http_ctx);
+
     lua_getglobal(L, TS_LUA_FUNCTION_TXN_CLOSE);
     if (lua_type(L, -1) == LUA_TFUNCTION) {
       if (lua_pcall(L, 0, 1, 0)) {


### PR DESCRIPTION
ASan reported heap-use-after-free(2) on touching response server headers by the ts-lua plugin.

# Problem
It looks like the holding `http_ctx->server_response_hdrp` pointer becomes garbage when the TXN goes `HttpSM::setup_server_read_response_header()` twice - e.g. 100 Continue & 200 OK responses.

https://github.com/apache/trafficserver/blob/11f987e3a84df907582ac6ea8150b414d15fc15e/proxy/http/HttpSM.cc#L6324

# Fix
I suggest update it at the begging of the `TS_EVENT_HTTP_READ_RESPONSE_HDR` and `TS_EVENT_HTTP_TXN_CLOSE` handler.

# ASan Reports 
## heap-use-after-free(1)
```
==3436==ERROR: AddressSanitizer: heap-use-after-free on address 0x61d002fe1908 at pc 0x56153bef12ce bp 0x7fdac1f0ffa0 sp 0x7fdac1f0ff98
READ of size 4 at 0x61d002fe1908 thread T22 ([ET_NET 20])
    #0 0x56153bef12cd in _Z32sdk_sanity_check_mime_hdr_handleP10tsapi_mloc src/traffic_server/InkAPI.cc:614:21
    #1 0x56153bef12cd in TSMimeHdrFieldFind src/traffic_server/InkAPI.cc:2932:3
    #2 0x7fda5b108387 in ts_lua_server_response_header_get plugins/lua/ts_lua_server_response.c:176:17
    #3 0x7fda5ae34675 in _init ??:0:0
    #4 0x7fda5b10d57a in ts_lua_http_cont_handler plugins/lua/ts_lua_util.c:0:0
    #5 0x56153bee1459 in _ZN15INKContInternal12handle_eventEiPv src/traffic_server/InkAPI.cc:1137:29
    #6 0x56153bee4925 in _ZN12Continuation11handleEventEiPv iocore/eventsystem/I_Continuation.h:219:12
    #7 0x56153bee4925 in _ZNK7APIHook6invokeEiPv src/traffic_server/InkAPI.cc:1374:18
    #8 0x56153c023749 in _ZN6HttpSM17state_api_calloutEiPv proxy/http/HttpSM.cc:1504:13
    #9 0x56153c020cb7 in _ZN6HttpSM18state_api_callbackEiPv proxy/http/HttpSM.cc:1380:3
    #10 0x56153bf0beb9 in TSHttpTxnReenable src/traffic_server/InkAPI.cc:6248:11
    ...
0x61d002fe1908 is located 136 bytes inside of 2048-byte region [0x61d002fe1880,0x61d002fe2080)
freed by thread T22 ([ET_NET 20]) here:
    #0 0x56153be83fe2 in free ??:0:0
    #1 0x7fdaccd4c42f in ink_freelist_free src/tscore/ink_queue.cc:281:5
    #2 0x56153c0404d5 in _ZN16HdrHeapSDKHandle7destroyEv proxy/hdrs/HdrHeap.h:488:13
    #3 0x56153c0404d5 in _ZN6HttpSM33setup_server_read_response_headerEv proxy/http/HttpSM.cc:6311:36
    #4 0x56153c0392a8 in _ZN6HttpSM32state_send_server_request_headerEiPv proxy/http/HttpSM.cc:2078:7
    #5 0x56153bffcbb4 in _ZN6HttpSM12main_handlerEiPv proxy/http/HttpSM.cc:0:0
    #6 0x56153c6bf572 in _ZN12Continuation11handleEventEiPv iocore/eventsystem/I_Continuation.h:219:12
    #7 0x56153c6bf572 in _ZL23write_signal_and_updateiP18UnixNetVConnection iocore/net/UnixNetVConnection.cc:117:25
    #8 0x56153c6bb5ae in _ZL17write_signal_doneiP10NetHandlerP18UnixNetVConnection iocore/net/UnixNetVConnection.cc:162:7
    #9 0x56153c6bb5ae in _Z15write_to_net_ioP10NetHandlerP18UnixNetVConnectionP7EThread iocore/net/UnixNetVConnection.cc:504:7
    #10 0x56153c69066d in _ZN10NetHandler18process_ready_listEv iocore/net/UnixNet.cc:429:11
    #11 0x56153c692094 in _ZN10NetHandler15waitForActivityEl iocore/net/UnixNet.cc:547:3
    #12 0x56153c69286c in _ZThn64_N10NetHandler15waitForActivityEl iocore/net/UnixNet.cc:0:0
    #13 0x56153c7313c3 in _ZN7EThread15execute_regularEv iocore/eventsystem/UnixEThread.cc:266:14
    #14 0x56153c731bc3 in _ZN7EThread7executeEv iocore/eventsystem/UnixEThread.cc:327:11
    #15 0x56153c72d4de in _ZL21spawn_thread_internalPv iocore/eventsystem/Thread.cc:0:0
    #16 0x7fdacb8f4ea4 in start_thread ??:0:0
```

## heap-use-after-free(2)
We added a workaround fix in the `ts_lua_server_response_header_get()` for the above heap-use-after-free(1) but start facing this.
```
==7552==ERROR: AddressSanitizer: heap-use-after-free on address 0x61d0009fed08 at pc 0x55b0ff68903b bp 0x7ff6f49be900 sp 0x7ff6f49be8f8
READ of size 4 at 0x61d0009fed08 thread T15 ([ET_NET 13])
    #0 0x55b0ff68903a in TSHandleMLocRelease src/traffic_server/InkAPI.cc:2101
    #1 0x7ff69fa0d882 in ts_lua_destroy_http_ctx plugins/lua/ts_lua_util.c:677
    #2 0x7ff69fa0e414 in ts_lua_http_cont_handler plugins/lua/ts_lua_util.c:1003
    #3 0x55b0ff67f459 in _ZN15INKContInternal12handle_eventEiPv src/traffic_server/InkAPI.cc:1137
    #4 0x55b0ff682925 in _ZN12Continuation11handleEventEiPv iocore/eventsystem/I_Continuation.h:219
    #5 0x55b0ff682925 in _ZNK7APIHook6invokeEiPv src/traffic_server/InkAPI.cc:1374
    #6 0x55b0ff7c1749 in _ZN6HttpSM17state_api_calloutEiPv proxy/http/HttpSM.cc:1504
    #7 0x55b0ff7becb7 in _ZN6HttpSM18state_api_callbackEiPv proxy/http/HttpSM.cc:1380
    #8 0x55b0ff6a9eb9 in TSHttpTxnReenable src/traffic_server/InkAPI.cc:6248
    ...
0x61d0009fed08 is located 136 bytes inside of 2048-byte region [0x61d0009fec80,0x61d0009ff480)
freed by thread T15 ([ET_NET 13]) here:
    #0 0x55b0ff621fe2 in __interceptor_free ??:?
    #1 0x7ff6febc642f in ink_freelist_free src/tscore/ink_queue.cc:281
    #2 0x55b0ff7de4d5 in _ZN16HdrHeapSDKHandle7destroyEv proxy/hdrs/HdrHeap.h:488
    #3 0x55b0ff7de4d5 in _ZN6HttpSM33setup_server_read_response_headerEv proxy/http/HttpSM.cc:6311
    #4 0x55b0ff7d72a8 in _ZN6HttpSM32state_send_server_request_headerEiPv proxy/http/HttpSM.cc:2078
    #5 0x55b0ff79abb4 in _ZN6HttpSM12main_handlerEiPv ??:?
    #6 0x55b0ffe5d572 in _ZN12Continuation11handleEventEiPv iocore/eventsystem/I_Continuation.h:219
    #7 0x55b0ffe5d572 in _ZL23write_signal_and_updateiP18UnixNetVConnection iocore/net/UnixNetVConnection.cc:117
    #8 0x55b0ffe595ae in _ZL17write_signal_doneiP10NetHandlerP18UnixNetVConnection iocore/net/UnixNetVConnection.cc:162
    #9 0x55b0ffe595ae in _Z15write_to_net_ioP10NetHandlerP18UnixNetVConnectionP7EThread iocore/net/UnixNetVConnection.cc:504
    #10 0x55b0ffe2e66d in _ZN10NetHandler18process_ready_listEv iocore/net/UnixNet.cc:429
    #11 0x55b0ffe30094 in _ZN10NetHandler15waitForActivityEl iocore/net/UnixNet.cc:547
    #12 0x55b0ffe3086c in _ZThn64_N10NetHandler15waitForActivityEl ??:?
    #13 0x55b0ffecf3c3 in _ZN7EThread15execute_regularEv iocore/eventsystem/UnixEThread.cc:266
    #14 0x55b0ffecfbc3 in _ZN7EThread7executeEv iocore/eventsystem/UnixEThread.cc:327
    #15 0x55b0ffecb4de in _ZL21spawn_thread_internalPv Thread.cc:?
    #16 0x7ff6fd76eea4 in start_thread pthread_create.c:?
```

# Affected Versions
- 8.0.x
- 9.0.x