### PR TITLE
Docs: Fix doc links for cookie_remap doc file.

### DIFF
--- a/doc/admin-guide/plugins/cookie_remap.en.rst
+++ b/doc/admin-guide/plugins/cookie_remap.en.rst
@@ -25,42 +25,41 @@ Cookie Based Routing Inside TrafficServer Using cookie_remap
 
 * `Cookie Based Routing Inside TrafficServer Using cookie_remap <#cookie-based-routing-inside-trafficserver-using-cookie_remap>`_
 
-  * `Features <#features>`_
-  * `Limitations <#limitations>`_
-  * `Setup <#setup>`_
-  * `Operations <#operations>`_
+  * :ref:`Features <features>`
+  * :ref:`Limitations <limitations>`
+  * :ref:`Setup <setup>`
+  * :ref:`Operations <operations>`
 
-    * `Comments <#comments>`_
-    * `cookie: X|X.Y <#cookie-xxy>`_
-    * `target: puri <#purl>`_
-    * `operation: exists|not exists|string|regex|bucket <#operation-existsnot-existsstringregexbucket>`_
-    * `match: str <#match-str>`_
-    * `regex: str <#regex-str>`_
-    * `bucket|hash: X/Y <#buckethash-xy>`_
-    * `sendto|url: url <#sendtourl-url>`_
-    * `status: HTTP status-code <#status-http-status-code>`_
-    * `else: url [optional] <#else-url-optional>`_
-    * `connector: and <#connector-and>`_
+    * :ref:`Comments <comments>`
+    * :ref:`cookie: X|X.Y <cookie-xxy>`
+    * :ref:`target: puri <purl>`
+    * :ref:`operation: exists|not exists|string|regex|bucket <operation-existsnot-existsstringregexbucket>`
+    * :ref:`match: str <match-str>`
+    * :ref:`regex: str <regex-str>`
+    * :ref:`bucket|hash: X/Y <buckethash-xy>`
+    * :ref:`sendto|url: url <sendtourl-url>`
+    * :ref:`status: HTTP status-code <status-http-status-code>`
+    * :ref:`else: url [optional] <else-url-optional>`
+    * :ref:`connector: and <connector-and>`
 
-  * `Reserved path expressions <#reserved-path-expressions>`_
+  * :ref:`Reserved path expressions <reserved-path-expressions>`
 
-    * `$cr_req_url <#cr_req_url-v-15>`_
-    * `$cr_urlencode() <#cr_urlencode-v-15>`_
-    * `$path <#path>`_
-    * `$unmatched_path <#unmatched_path>`_
+    * :ref:`$cr_req_url <cr_req_url-v-15>`
+    * :ref:`$cr_urlencode() <cr_urlencode-v-15>`
+    * :ref:`$path <path>`
+    * :ref:`$unmatched_path <unmatched_path>`
 
-  * `An example configuration file <#an-example-configuration-file>`_
-  * `Debugging things <#debugging-things>`_
+  * :ref:`An example configuration file <an-example-configuration-file>`
+  * :ref:`Debugging things <debugging-things>`
 
-    * `Initial output <#initial-output>`_
+    * :ref:`Initial output <initial-output>`
 
 This remap plugin makes decisions about where to send your request based on properties present (or absent) within the HTTP Cookie header.  It can also make decisions based on your uri (url path + query.)
 
+.. _features:
+
 Features
 --------
-
-----
-
 
 * Also supports sub-level cookies
 
@@ -73,33 +72,29 @@ Features
 * Cookie falls into a hash/bucket range
 * Can url encode dynamic data
 
+.. _limitations:
+
 Limitations
 -----------
 
-----
-
-
 * Does not support :ref:`remap-config-plugin-chaining`
+
+.. _setup:
 
 Setup
 -----
 
-----
-
 The plugin is specified in remap.config using a syntax similar to:
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    map http://foo.com http://bar.com @plugin=/usr/bin/trafficserver/libexec64/cookie_remap.so @pparam=/home/trafficserver/conf/cookie_remap/cookie_remap.txt
-   </pre>
 
+.. _operations:
 
 Operations
 ----------
-
-----
 
 All operations are specified in a YAML configuration file you pass as @pparam on the plugin configuration line. YAML is very simple syntax. See the example configuration files below.
 
@@ -111,17 +106,19 @@ Each operation results in a sendto action. That means that, if matched, cookie_r
 
 Each ``operation`` can have multiple "sub-operations", connected with an conjunction operator.  Currently, only the ``and`` operator is supported. So, you can say, "if cookie exists, ``and`` uri is ``x``\ , then redirect."
 
-Comments
-^^^^^^^^
+.. _comments:
 
-----
+Comments
+~~~~~~~~
+
 
 Comments are allowed in the configuration file if they begin with '#'
 
-cookie: X|X.Y
-^^^^^^^^^^^^^
+.. _cookie-xxy:
 
-----
+cookie: X|X.Y
+~~~~~~~~~~~~~
+
 
 This sub-operation is testing against the X cookie or X.Y cookie where X.Y denotes the X cookie, sub cookie Y
 e.g
@@ -136,18 +133,20 @@ B will operate on ``data&f=fsub&z=zsub``
 
 B.f will operate on ``fsub``
 
-target: puri
-^^^^^^^^^^^^
+.. _purl:
 
-----
+target: puri
+~~~~~~~~~~~~
+
 
 When the cookie key is omitted, the operation is applied to the request uri instead.  If this key and value
 is specified, the uri for the operation will be the pre-remapped, rather than the remapped, uri.
 
-operation: exists|not exists|string|regex|bucket
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _operation-existsnot-existsstringregexbucket:
 
-----
+operation: exists|not exists|string|regex|bucket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 This keyword actually denotes a "suboperation" - it can be specified multiple times, connected with ``and``\ , and send the user to a given destination.
 
@@ -162,230 +161,204 @@ The ``cookie`` operator must be specified in the YAML file just before the subop
 
 The ``string``, ``regex`` and ``bucket`` operate on the specified cookie, or if no cookie is specified, they will operate on the uri of the request.
 
-match: str
-^^^^^^^^^^
+.. _match-str:
 
-----
+match: str
+~~~~~~~~~~
 
 Match the cookie data to str.  If no cookie is specified, match to the request uri.
 
-regex: str
-^^^^^^^^^^
+.. _regex-str:
 
-----
+regex: str
+~~~~~~~~~~
 
 Sets the regex to str. Matching is enabled with $1-$9 (replaced in sendto).  Note that only the final regex match in an operation will be used to populate the substitutions $1-$9.  If no cookie is specified, match to the request uri.
 
-bucket|hash: X/Y
-^^^^^^^^^^^^^^^^
+.. _buckethash-xy:
 
-----
+bucket|hash: X/Y
+~~~~~~~~~~~~~~~~
 
 Hashes (bucketizes) the data in Y buckets. If you fall into the first X of them, this suboperation passes. If no cookie is specified, match to the request uri.
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    bucket: 1/100
    will effectively bucketize 1% of your users
-   </pre>
 
+.. _sendtourl-url:
 
 sendto|url: url
-^^^^^^^^^^^^^^^
-
-----
+~~~~~~~~~~~~~~~
 
 if the sub-operation(s) all match, send to url
 
-status: HTTP status-code
-^^^^^^^^^^^^^^^^^^^^^^^^
+.. _status-http-status-code:
 
-----
+status: HTTP status-code
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 if the sub-operation(s) all match, set the status code (e.g. set it to 302). In the case of a redirect, the sendto URL becomes the redirect URL.
 
-else: url [optional]
-^^^^^^^^^^^^^^^^^^^^
+.. _else-url-optional:
 
-----
+else: url [optional]
+~~~~~~~~~~~~~~~~~~~~
 
 If one of the sub-operations fails, send to url. This is optional. If there is no 'else', we will continue to process operations until either one succeeds, there is an else in one of the operations or we fall through to the default mapping from remap.config
 
-connector: and
-^^^^^^^^^^^^^^
+.. _connector-and:
 
-----
+connector: and
+~~~~~~~~~~~~~~
 
 'and' is the only supported connector
+
+.. _reserved-path-expressions:
 
 Reserved path expressions
 -------------------------
 
-----
 
 The following expressions can be used in either the sendto **or** ``else`` URLs, and will be expanded.
 
-$cr_req_url
-^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _cr_req_url-v-15:
 
-----
+$cr_req_url
+~~~~~~~~~~~
 
 Replaced with the full original url.
 
 Therefore, a rule like:
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    op:
      cookie: K
      operation: exists
      sendto: http://foo.com/?.done=$cr_req_url
-   </pre>
 
 
 and a request that matches, e.g.
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    http://bar.com/hello?fruit=bananas
-   </pre>
 
 
 will become
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    http://foo.com/?.done=http://bar.com/hello?fruit=bananas
-   </pre>
 
+
+.. _cr_urlencode-v-15:
 
 $cr_urlencode()
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-----
+~~~~~~~~~~~~~~~
 
 Replaced with a urlencoded version of its argument.  The url argument is aggressively encoded such that all non-alphanumeric characters are converted to % hex notation.  The simple algorithm could probably be refined in the future to be less aggressive (encode fewer characters.)
 
 Therefore, a rule like:
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    op:
      cookie: B
      operation: exists
      sendto: http://foo.com/?.done=$cr_urlencode($cr_req_url)
-   </pre>
 
 
 and a request that matches, e.g.
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    http://bar.com/hello?fruit=bananas
-   </pre>
 
 
 will become
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    http://foo.com/?.done=http%3A%2F%2Fbar%2Ecom@2Fhello%3Ffruit%3Dbananas
-   </pre>
 
+.. _path:
 
 $path
-^^^^^
-
-----
+~~~~~
 
 $path can be used to replace in either the sendto **or** else URLs the original request path. Therefore a rule like:
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    op:
      cookie: K
      operation: exists
      sendto: http://foo.com/$path/x/y/z
-   </pre>
 
 
 and a request like `http://finance.yahoo.com/photos/what/ever/ <http://foo.com/photos/what/ever/>`_ that matches the rule
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    map http://finance.yahoo.com/photos/ http://newfinance.yahoo.com/1k.html @plugin=cookie_remap.so @pparam=foo.txt
-   </pre>
 
 
 will become `http://foo.com/photos/what/ever/x/y/z <http://foo.com/photos/what/ever/x/y/z>`_
 
-$unmatched_path
-^^^^^^^^^^^^^^^
+.. _unmatched_path:
 
-----
+$unmatched_path
+~~~~~~~~~~~~~~~
 
 $unmatched_path can be used to gather the URL arguments **beyond** what was matched by the remap rule. Therefore a rule like:
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    op:
      cookie: K
      operation: exists
      sendto: http://foo.com/$unmatched_path/x/y/z
-   </pre>
 
 
 and a request like `http://finance.yahoo.com/photos/what/ever/ <http://foo.com/photos/what/ever/>`_ that matches the rule
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    map http://finance.yahoo.com/photos/ http://newfinance.yahoo.com/1k.html @plugin=cookie_remap.so @pparam=foo.txt
-   </pre>
 
 
 will become `http://foo.com/what/ever/matches/x/y/z <http://foo.com/what/ever/matches/x/y/z>`_
 
 Alternatives using pre-remapped URL
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 $cr_req_url, $path and $unamatched_path are based on the remapped URL.  To use the pre-remapped
 URL, instead use $cr_req_purl, $ppath and $unmatched_ppath, respectively.
 
+.. _an-example-configuration-file:
+
 An example configuration file
 -----------------------------
-
-----
-
-
 
 * first match "wins" (top down)
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    #comments
    #are allowed
    op:
@@ -415,37 +388,32 @@ An example configuration file
      match: foobar
      sendto: http://cnn.com/$1
      else: http://yahoo.com
-   </pre>
 
+.. _debugging-things:
 
 Debugging things
 ----------------
 
-----
-
 The easiest way to debug problems with this plugin is to run in the following manner:
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    bin/traffic_server -T cookie_remap
-   </pre>
 
 
 which will produce output on startup, and for each request. Be aware that this mode of running trafficserver is **extremely** inefficient and should only be used for debugging.
 
-Initial output
-^^^^^^^^^^^^^^
+.. _initial-output:
 
-----
+Initial output
+~~~~~~~~~~~~~~
 
 Initially, you will notice output describing each operation and how trafficserver interpreted the information from your configuration file:
 
 
-.. raw:: html
+.. code-block::
 
-   <pre>
    [Jul  8 13:08:34.183] Server {3187168} DIAG: (cookie_remap) loading cookie remap configuration file from /homes/ebalsa/dev/yts_mods/cookie_remap/example_config.txt
    [Jul  8 13:08:34.199] Server {3187168} DIAG: (cookie_remap) ++++operation++++
    [Jul  8 13:08:34.199] Server {3187168} DIAG: (cookie_remap) sending to: http://finance.yahoo.com/2k.html
@@ -466,7 +434,6 @@ Initially, you will notice output describing each operation and how trafficserve
    [Jul  8 13:08:34.201] Server {3187168} DIAG: (cookie_remap)         cookie: PH.l
    [Jul  8 13:08:34.202] Server {3187168} DIAG: (cookie_remap)         operation: exists
    [Jul  8 13:08:34.202] Server {3187168} DIAG: (cookie_remap) # of ops: 2
-   </pre>
 
 
 each operation is enumerated and is more-or-less human readable from the top-down.  From now on, each request has information spit out to the console with debugging information on how the cookie_remap is treating this request.


### PR DESCRIPTION
While reading about `cr_urlencode`  found that [links](https://docs.trafficserver.apache.org/en/latest/admin-guide/plugins/cookie_remap.en.html?highlight=cr_urlencode#cookie-based-routing-inside-trafficserver-using-cookie-remap) are faulty, so too much effort  involed in scrolling down, so I fixed it. While I was there replaced the `raw:: html` code for `block-code`,  also changed some stuffs to follow the convention.