### PR TITLE
check-unused-dependencies: add librt for clang/asan case

### DIFF
--- a/tools/check-unused-dependencies
+++ b/tools/check-unused-dependencies
@@ -53,7 +53,8 @@ def get_dependencies(program):
                     'libdl.so.',      # Because we add -ldl to LIBS
                     'libgcc_s.so.',
                     'libm.so.',       # Why does Libtool call ld with -lm?
-                    'libpthread.so.'  # Because we add -lpthread to LIBS
+                    'libpthread.so.', # Because we add -lpthread to LIBS
+                    'librt.so.'       # clang + asan pulls this in
                 ])):
             continue
 


### PR DESCRIPTION
With the new CI while running asan with clang tools/jtest and tools/http_load fail due to librt getting pulled in.  This adds librt to the ignore list which allows make check to pass.