### PR TITLE
Add normalize_ae option 3

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1894,6 +1894,8 @@ Proxy User Variables
          *blank* (for any header that does not include ``gzip``)
    ``2`` ``Accept-Encoding: br`` if the header has ``br`` (with any ``q``) **ELSE**
          normalize as for value ``1``
+   ``3`` ``Accept-Encoding: br, gzip`` (if the header has ``br`` and ``gzip`` (with any ``q`` for either) then ``br, gzip``) **ELSE**
+         normalize as for value ``2``
    ===== ======================================================================
 
    This is useful for minimizing cached alternates of documents (e.g. ``gzip, deflate`` vs. ``deflate, gzip``).

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -1235,6 +1235,22 @@ HttpTransactHeaders::normalize_accept_encoding(const OverridableHttpConfigParams
           header->field_delete(ae_field);
           Debug("http_trans", "[Headers::normalize_accept_encoding] removed non-br Accept-Encoding");
         }
+      } else if (normalize_ae == 3) {
+        // Force Accept-Encoding header to br,gzip, or br, or gzip, or no header.
+        if (HttpTransactCache::match_content_encoding(ae_field, "br") &&
+            HttpTransactCache::match_content_encoding(ae_field, "gzip")) {
+          header->field_value_set(ae_field, "br, gzip", 8);
+          Debug("http_trans", "[Headers::normalize_accept_encoding] normalized Accept-Encoding to br, gzip");
+        } else if (HttpTransactCache::match_content_encoding(ae_field, "br")) {
+          header->field_value_set(ae_field, "br", 2);
+          Debug("http_trans", "[Headers::normalize_accept_encoding] normalized Accept-Encoding to br");
+        } else if (HttpTransactCache::match_content_encoding(ae_field, "gzip")) {
+          header->field_value_set(ae_field, "gzip", 4);
+          Debug("http_trans", "[Headers::normalize_accept_encoding] normalized Accept-Encoding to gzip");
+        } else {
+          header->field_delete(ae_field);
+          Debug("http_trans", "[Headers::normalize_accept_encoding] removed non-br non-gzip Accept-Encoding");
+        }
       } else {
         static bool logged = false;
 

--- a/tests/gold_tests/headers/normalize_ae.gold
+++ b/tests/gold_tests/headers/normalize_ae.gold
@@ -50,6 +50,19 @@ br
 -
 br
 -
+X-Au-Test: www.ae-3.com
+ACCEPT-ENCODING MISSING
+-
+gzip
+-
+gzip
+-
+br
+-
+br, gzip
+-
+br, gzip
+-
 X-Au-Test: www.no-oride.com
 ACCEPT-ENCODING MISSING
 -
@@ -101,4 +114,17 @@ br
 br
 -
 br
+-
+X-Au-Test: www.ae-3.com
+ACCEPT-ENCODING MISSING
+-
+gzip
+-
+gzip
+-
+br
+-
+br, gzip
+-
+br, gzip
 -

--- a/tests/gold_tests/headers/normalize_ae.test.py
+++ b/tests/gold_tests/headers/normalize_ae.test.py
@@ -74,6 +74,7 @@ def baselineTsSetup(ts):
         ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=3'
     )
 
+
 baselineTsSetup(ts)
 
 # set up to check the output after the tests have run.

--- a/tests/gold_tests/headers/normalize_ae.test.py
+++ b/tests/gold_tests/headers/normalize_ae.test.py
@@ -69,7 +69,10 @@ def baselineTsSetup(ts):
         'map http://www.ae-2.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
         ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2'
     )
-
+    ts.Disk.remap_config.AddLine(
+        'map http://www.ae-3.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
+        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=3'
+    )
 
 baselineTsSetup(ts)
 
@@ -130,6 +133,7 @@ def perTsTest(shouldWaitForUServer, ts):
     allAEHdrs(False, False, ts, 'www.ae-0.com')
     allAEHdrs(False, False, ts, 'www.ae-1.com')
     allAEHdrs(False, False, ts, 'www.ae-2.com')
+    allAEHdrs(False, False, ts, 'www.ae-3.com')
 
 
 perTsTest(True, ts)


### PR DESCRIPTION
This normalizes when both `br` and `gzip` are present to `br, gzip`. In the other cases the AE gets stripped down a single value, eliminating options for origin responses. In this case the origin still has the option to
send back br or gzip while normalizing the cached AE header to still keep alternates to a minimum and still have compression. If both are not present then it acts like the existing option `2` if br is present, then option
`1` if `br` is not present but `gzip` is