### PR TITLE
Fix the skipping logic for autest and docs

### DIFF
--- a/ci/jenkins/bin/autest.sh
+++ b/ci/jenkins/bin/autest.sh
@@ -16,14 +16,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-set +x
+set -x
 
 cd src
 sleep 30
 
 git branch --contains ${ghprbActualCommit} > /dev/null
 if [ $? = 0 -a ! -z "$ghprbActualCommit" ]; then
-    git diff ${ghprbActualCommit}^...${ghprbActualCommit} --name-only | egrep -E '^(build|iocore|proxy|tests|include|mgmt|plugins|proxy|src)/' > /dev/null
+    git diff HEAD~1 --name-only | egrep -E '^(build|iocore|proxy|tests|include|mgmt|plugins|proxy|src)/' > /dev/null
     if [ $? = 1 ]; then
         echo "No relevant files changed, skipping run"
         exit 0

--- a/ci/jenkins/bin/docs.sh
+++ b/ci/jenkins/bin/docs.sh
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+set -x
+
 # These shenanigans are here to allow it to run both manually, and via Jenkins
 test -z "${ATS_MAKE}" && ATS_MAKE="make"
 test ! -z "${WORKSPACE}" && cd "${WORKSPACE}/src"
@@ -24,7 +26,7 @@ test ! -z "${WORKSPACE}" && cd "${WORKSPACE}/src"
 INCLUDE_FILES=$(for i in $(git grep literalinclude doc/ | awk '{print $3}'); do basename $i; done | sort -u | paste -sd\|)
 echo $INCLUDE_FILES
 if [ ! -z "$ghprbActualCommit" ]; then
-    git diff ${ghprbActualCommit}^...${ghprbActualCommit} --name-only | egrep -E "(^doc/|$INCLUDE_FILES)" > /dev/null
+    git diff HEAD~1 --name-only | egrep -E "(^doc/|$INCLUDE_FILES)" > /dev/null
     if [ $? = 1 ]; then
         echo "No relevant files changed, skipping run"
         exit 0


### PR DESCRIPTION
Look at the difference in the main branch instead of looking at the last
commit on the branch is being merged in

Turned on debugging for the autest and docs build scripts

Here is an example of what was happening on our CI boxes:

After the merge the tree looked like this:
```
*   b05db4c2e - (HEAD, origin/pr/7925/merge) Merge 2e22854328145c4dbd79d286c684a6dca7cc22a7 into f15a71955830726a4f71cb5b47fd0bad1292dd18 (5 hours ago) <Walt Karas>
|\
| * 2e2285432 - (origin/pr/7925/head) Clarify when the keyword 'self' should be used in strategies.yaml. (5 hours ago) <Walter Karas>
| * b406fa47a - Fix clang format error. (6 hours ago) <Walter Karas>
| * abfaa1071 - Disambiguate overloads of Machine::is_self. (6 hours ago) <Walter Karas>
| * 3cc2bbc2a - For peering ring, make upstream group of hosts optional. (6 hours ago) <Walter Karas>
* | f15a71955 - Add the origin IP to the error message for invalid server response in OSDNSLookup (#8031) (6 hours ago) <Bryan Call>
|/
* 440382cdd - Fix heap-use-after-free of ts-lua plugin (#8215) (3 days ago) <Masaori Koshiba>
```

And the command CI was running was:
`++ git diff '2e22854328145c4dbd79d286c684a6dca7cc22a7^...2e22854328145c4dbd79d286c684a6dca7cc22a7' --name-only`

This would only pick up the change in the last commit on the branch that is being merged.