### PR TITLE
uri_signing: address memory leak with the internal jwt struct

### DIFF
--- a/plugins/experimental/uri_signing/jwt.c
+++ b/plugins/experimental/uri_signing/jwt.c
@@ -52,6 +52,7 @@ parse_jwt(json_t *raw)
   }
 
   struct jwt *jwt = malloc(sizeof *jwt);
+  jwt->raw        = raw;
   jwt->iss        = json_string_value(json_object_get(raw, "iss"));
   jwt->sub        = json_string_value(json_object_get(raw, "sub"));
   jwt->aud        = json_object_get(raw, "aud");
@@ -76,7 +77,7 @@ jwt_delete(struct jwt *jwt)
     return;
   }
 
-  json_decref(jwt->aud);
+  json_decref(jwt->raw);
   free(jwt);
 }
 

--- a/plugins/experimental/uri_signing/jwt.h
+++ b/plugins/experimental/uri_signing/jwt.h
@@ -22,6 +22,7 @@
 #include <jansson.h>
 
 struct jwt {
+  json_t *raw;
   const char *iss;
   const char *sub;
   json_t *aud;


### PR DESCRIPTION
This primarily addresses a memory leak from using the jansson library regarding reference counting and maintaining the base structures for the views.

This also fixes related memory access faults in the unit test.

Also note this PR for the cjose library which also fixes a memory leak.  Not sure how to document this:  https://github.com/cisco/cjose/pull/117