### PR TITLE
Add debug message when there is a header parse error for http/2

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -218,8 +218,12 @@ Http2Stream::main_event_handler(int event, void *edata)
 Http2ErrorCode
 Http2Stream::decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_table_size)
 {
-  return http2_decode_header_blocks(&_req_header, (const uint8_t *)header_blocks, header_blocks_length, nullptr, hpack_handle,
-                                    trailing_header, maximum_table_size);
+  Http2ErrorCode error = http2_decode_header_blocks(&_req_header, header_blocks, header_blocks_length, nullptr, hpack_handle,
+                                                    trailing_header, maximum_table_size);
+  if (error != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
+    Http2StreamDebug("Error decoding header blocks: %u", static_cast<uint32_t>(error));
+  }
+  return error;
 }
 
 void


### PR DESCRIPTION
Without this change I was scratching my head as to why we were sending a RST_STREAM frame:

```
[Aug 11 11:34:02.460] [ET_NET 12] DEBUG: <Http2Stream.cc:374 (change_state)> (http2_stream) [0] [13] Http2StreamState::HTTP2_STREAM_STATE_OPEN
[Aug 11 11:34:02.460] [ET_NET 12] DEBUG: <Http2ConnectionState.cc:1927 (send_rst_stream_frame)> (http2_con) [0] [13] Send RST_STREAM frame
```

So now it will look like this:
```
[Aug 11 11:34:02.460] [ET_NET 12] DEBUG: <Http2Stream.cc:374 (change_state)> (http2_stream) [0] [13] Http2StreamState::HTTP2_STREAM_STATE_OPEN
[Aug 11 11:34:02.460] [ET_NET 12] DEBUG: <Http2Stream.cc:224 (decode_header_blocks)> (http2_stream) [0] [13] Error decoding header blocks: 1
[Aug 11 11:34:02.460] [ET_NET 12] DEBUG: <Http2ConnectionState.cc:1927 (send_rst_stream_frame)> (http2_con) [0] [13] Send RST_STREAM frame
```