### PR TITLE
Cleanup url_*_get/set functions

### DIFF
--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -79,6 +79,7 @@ test_UDPNet_LDADD = \
 	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/lib/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@
 

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -386,17 +386,17 @@ URLImpl::check_strings(HeapCheck *heaps, int num_heaps)
  ***********************************************************************/
 
 const char *
-url_scheme_set(HdrHeap *heap, URLImpl *url, const char *scheme_str, int scheme_wks_idx, int length, bool copy_string)
+URLImpl::set_scheme(HdrHeap *heap, const char *scheme_str, int scheme_wks_idx, int length, bool copy_string)
 {
   const char *scheme_wks;
-  url_called_set(url);
+  url_called_set(this);
   if (length == 0) {
     scheme_str = nullptr;
   }
 
-  mime_str_u16_set(heap, scheme_str, length, &(url->m_ptr_scheme), &(url->m_len_scheme), copy_string);
+  mime_str_u16_set(heap, scheme_str, length, &(this->m_ptr_scheme), &(this->m_len_scheme), copy_string);
 
-  url->m_scheme_wks_idx = scheme_wks_idx;
+  this->m_scheme_wks_idx = scheme_wks_idx;
   if (scheme_wks_idx >= 0) {
     scheme_wks = hdrtoken_index_to_wks(scheme_wks_idx);
   } else {
@@ -404,11 +404,11 @@ url_scheme_set(HdrHeap *heap, URLImpl *url, const char *scheme_str, int scheme_w
   }
 
   if (scheme_wks == URL_SCHEME_HTTP || scheme_wks == URL_SCHEME_WS) {
-    url->m_url_type = URL_TYPE_HTTP;
+    this->m_url_type = URL_TYPE_HTTP;
   } else if (scheme_wks == URL_SCHEME_HTTPS || scheme_wks == URL_SCHEME_WSS) {
-    url->m_url_type = URL_TYPE_HTTPS;
+    this->m_url_type = URL_TYPE_HTTPS;
   } else {
-    url->m_url_type = URL_TYPE_HTTP;
+    this->m_url_type = URL_TYPE_HTTP;
   }
 
   return scheme_wks; // tokenized string or NULL if not well known
@@ -418,59 +418,59 @@ url_scheme_set(HdrHeap *heap, URLImpl *url, const char *scheme_str, int scheme_w
   -------------------------------------------------------------------------*/
 
 void
-url_user_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_user(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
+  url_called_set(this);
   if (length == 0) {
     value = nullptr;
   }
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_user), &(url->m_len_user), copy_string);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_user), &(this->m_len_user), copy_string);
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_password_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_password(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
+  url_called_set(this);
   if (length == 0) {
     value = nullptr;
   }
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_password), &(url->m_len_password), copy_string);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_password), &(this->m_len_password), copy_string);
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_host_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_host(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
+  url_called_set(this);
   if (length == 0) {
     value = nullptr;
   }
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_host), &(url->m_len_host), copy_string);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_host), &(this->m_len_host), copy_string);
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_port_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_port(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
+  url_called_set(this);
   if (length == 0) {
     value = nullptr;
   }
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_port), &(url->m_len_port), copy_string);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_port), &(this->m_len_port), copy_string);
 
-  url->m_port = 0;
+  this->m_port = 0;
   for (int i = 0; i < length; i++) {
     if (!ParseRules::is_digit(value[i])) {
       break;
     }
-    url->m_port = url->m_port * 10 + (value[i] - '0');
+    this->m_port = this->m_port * 10 + (value[i] - '0');
   }
 }
 
@@ -478,32 +478,32 @@ url_port_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool co
   -------------------------------------------------------------------------*/
 
 void
-url_port_set(HdrHeap *heap, URLImpl *url, unsigned int port)
+URLImpl::set_port(HdrHeap *heap, unsigned int port)
 {
-  url_called_set(url);
+  url_called_set(this);
   if (port > 0) {
     char value[6];
     int length;
 
     length = ink_fast_itoa(port, value, sizeof(value));
-    mime_str_u16_set(heap, value, length, &(url->m_ptr_port), &(url->m_len_port), true);
+    mime_str_u16_set(heap, value, length, &(this->m_ptr_port), &(this->m_len_port), true);
   } else {
-    mime_str_u16_set(heap, nullptr, 0, &(url->m_ptr_port), &(url->m_len_port), true);
+    mime_str_u16_set(heap, nullptr, 0, &(this->m_ptr_port), &(this->m_len_port), true);
   }
-  url->m_port = port;
+  this->m_port = port;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_path_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_path(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
+  url_called_set(this);
   if (length == 0) {
     value = nullptr;
   }
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_path), &(url->m_len_path), copy_string);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_path), &(this->m_len_path), copy_string);
 }
 
 /*-------------------------------------------------------------------------
@@ -513,50 +513,50 @@ url_path_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool co
 // url_{params|query|fragment}_set()
 
 void
-url_params_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_params(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_params), &(url->m_len_params), copy_string);
+  url_called_set(this);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_params), &(this->m_len_params), copy_string);
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_query_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_query(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_query), &(url->m_len_query), copy_string);
+  url_called_set(this);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_query), &(this->m_len_query), copy_string);
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_fragment_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string)
+URLImpl::set_fragment(HdrHeap *heap, const char *value, int length, bool copy_string)
 {
-  url_called_set(url);
-  mime_str_u16_set(heap, value, length, &(url->m_ptr_fragment), &(url->m_len_fragment), copy_string);
+  url_called_set(this);
+  mime_str_u16_set(heap, value, length, &(this->m_ptr_fragment), &(this->m_len_fragment), copy_string);
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_type_set(URLImpl *url, int type)
+URLImpl::set_type(int type)
 {
-  url_called_set(url);
-  url->m_url_type = type;
+  url_called_set(this);
+  this->m_url_type = type;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 void
-url_type_code_set(URLImpl *url, unsigned int typecode)
+URLImpl::set_type_code(unsigned int typecode)
 {
-  url_called_set(url);
-  url->m_type_code = typecode;
+  url_called_set(this);
+  this->m_type_code = typecode;
 }
 
 /*-------------------------------------------------------------------------
@@ -682,97 +682,97 @@ url_string_get_buf(URLImpl *url, char *dstbuf, int dstbuf_size, int *length)
   -------------------------------------------------------------------------*/
 
 const char *
-url_user_get(URLImpl *url, int *length)
+URLImpl::get_user(int *length)
 {
-  *length = url->m_len_user;
-  return url->m_ptr_user;
+  *length = this->m_len_user;
+  return this->m_ptr_user;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 const char *
-url_password_get(URLImpl *url, int *length)
+URLImpl::get_password(int *length)
 {
-  *length = url->m_len_password;
-  return url->m_ptr_password;
+  *length = this->m_len_password;
+  return this->m_ptr_password;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 const char *
-url_host_get(URLImpl *url, int *length)
+URLImpl::get_host(int *length)
 {
-  *length = url->m_len_host;
-  return url->m_ptr_host;
+  *length = this->m_len_host;
+  return this->m_ptr_host;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 int
-url_port_get(URLImpl *url)
+URLImpl::get_port()
 {
-  return url->m_port;
+  return this->m_port;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 const char *
-url_path_get(URLImpl *url, int *length)
+URLImpl::get_path(int *length)
 {
-  *length = url->m_len_path;
-  return url->m_ptr_path;
+  *length = this->m_len_path;
+  return this->m_ptr_path;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 const char *
-url_params_get(URLImpl *url, int *length)
+URLImpl::get_params(int *length)
 {
-  *length = url->m_len_params;
-  return url->m_ptr_params;
+  *length = this->m_len_params;
+  return this->m_ptr_params;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 const char *
-url_query_get(URLImpl *url, int *length)
+URLImpl::get_query(int *length)
 {
-  *length = url->m_len_query;
-  return url->m_ptr_query;
+  *length = this->m_len_query;
+  return this->m_ptr_query;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 const char *
-url_fragment_get(URLImpl *url, int *length)
+URLImpl::get_fragment(int *length)
 {
-  *length = url->m_len_fragment;
-  return url->m_ptr_fragment;
+  *length = this->m_len_fragment;
+  return this->m_ptr_fragment;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 int
-url_type_get(URLImpl *url)
+URLImpl::get_type()
 {
-  return url->m_url_type;
+  return this->m_url_type;
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 int
-url_type_code_get(URLImpl *url)
+URLImpl::get_type_code()
 {
-  return url->m_type_code;
+  return this->m_type_code;
 }
 
 /*-------------------------------------------------------------------------
@@ -1147,7 +1147,7 @@ url_parse_scheme(HdrHeap *heap, URLImpl *url, const char **start, const char *en
             }
           }
         }
-        url_scheme_set(heap, url, scheme_start, scheme_wks_idx, scheme_end - scheme_start, copy_strings_p);
+        url->set_scheme(heap, scheme_start, scheme_wks_idx, scheme_end - scheme_start, copy_strings_p);
       }
     }
     *start = scheme_end;
@@ -1339,9 +1339,9 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, const char **start, char const *
   // character past the parse area.
 
   if (user) {
-    url_user_set(heap, url, user._ptr, user._size, copy_strings_p);
+    url->set_user(heap, user._ptr, user._size, copy_strings_p);
     if (passw) {
-      url_password_set(heap, url, passw._ptr, passw._size, copy_strings_p);
+      url->set_password(heap, passw._ptr, passw._size, copy_strings_p);
     }
   }
 
@@ -1356,7 +1356,7 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, const char **start, char const *
   }
   if (host._size) {
     if (!verify_host_characters || validate_host_name(std::string_view(host._ptr, host._size))) {
-      url_host_set(heap, url, host._ptr, host._size, copy_strings_p);
+      url->set_host(heap, host._ptr, host._size, copy_strings_p);
     } else {
       return PARSE_RESULT_ERROR;
     }
@@ -1368,7 +1368,7 @@ url_parse_internet(HdrHeap *heap, URLImpl *url, const char **start, char const *
     if (!port._size) {
       return PARSE_RESULT_ERROR; // colon w/o port value.
     }
-    url_port_set(heap, url, port._ptr, port._size, copy_strings_p);
+    url->set_port(heap, port._ptr, port._size, copy_strings_p);
   }
   *start = cur;
   return PARSE_RESULT_DONE;
@@ -1492,7 +1492,7 @@ done:
       // absolutely empty so we can reconstruct such URLs.
       ++path_start;
     }
-    url_path_set(heap, url, path_start, path_end - path_start, copy_strings);
+    url->set_path(heap, path_start, path_end - path_start, copy_strings);
   } else if (!nothing_after_host) {
     // There was no path set via '/': it is absolutely empty. However, if there
     // is no path, query, or fragment after the host, we by convention add a
@@ -1504,21 +1504,21 @@ done:
     if (!params_end) {
       params_end = cur;
     }
-    url_params_set(heap, url, params_start, params_end - params_start, copy_strings);
+    url->set_params(heap, params_start, params_end - params_start, copy_strings);
   }
   if (query_start) {
     // There was a query string marked by '?'.
     if (!query_end) {
       query_end = cur;
     }
-    url_query_set(heap, url, query_start, query_end - query_start, copy_strings);
+    url->set_query(heap, query_start, query_end - query_start, copy_strings);
   }
   if (fragment_start) {
     // There was a fragment string marked by '#'.
     if (!fragment_end) {
       fragment_end = cur;
     }
-    url_fragment_set(heap, url, fragment_start, fragment_end - fragment_start, copy_strings);
+    url->set_fragment(heap, fragment_start, fragment_end - fragment_start, copy_strings);
   }
 
   *start = cur;
@@ -1571,16 +1571,16 @@ url_parse_http_regex(HdrHeap *heap, URLImpl *url, const char **start, const char
       port_len = host_end - port - 1; // must compute this first.
       host_end = port;                // then point at colon.
       ++port;                         // drop colon from port.
-      url_port_set(heap, url, port, port_len, copy_strings);
+      url->set_port(heap, port, port_len, copy_strings);
     }
 
     // Now we can set the host.
-    url_host_set(heap, url, base, host_end - base, copy_strings);
+    url->set_host(heap, base, host_end - base, copy_strings);
   }
 
   // path is anything that's left.
   if (cur < end) {
-    url_path_set(heap, url, cur, end - cur, copy_strings);
+    url->set_path(heap, cur, end - cur, copy_strings);
     cur = end;
   }
   *start = cur;

--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -543,7 +543,17 @@ url_fragment_set(HdrHeap *heap, URLImpl *url, const char *value, int length, boo
   -------------------------------------------------------------------------*/
 
 void
-url_type_set(URLImpl *url, unsigned int typecode)
+url_type_set(URLImpl *url, int type)
+{
+  url_called_set(url);
+  url->m_url_type = type;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+void
+url_type_code_set(URLImpl *url, unsigned int typecode)
 {
   url_called_set(url);
   url->m_type_code = typecode;
@@ -752,6 +762,15 @@ url_fragment_get(URLImpl *url, int *length)
 
 int
 url_type_get(URLImpl *url)
+{
+  return url->m_url_type;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
+url_type_code_get(URLImpl *url)
 {
   return url->m_type_code;
 }

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -40,7 +40,9 @@ enum URLType {
   URL_TYPE_HTTPS,
 };
 
-struct URLImpl : public HdrHeapObjImpl {
+class URLImpl : public HdrHeapObjImpl
+{
+public:
   // HdrHeapObjImpl is 4 bytes
   uint16_t m_len_scheme;
   uint16_t m_len_user;
@@ -79,6 +81,30 @@ struct URLImpl : public HdrHeapObjImpl {
   uint32_t m_normalization_flags : 2; // Only valid if both m_clean and m_ptr_printed_sting are non-zero.
   // 8 bytes + 4 bits, will result in padding
 
+  // Accessors
+  const char *set_scheme(HdrHeap *heap, const char *value, int value_wks_idx, int length, bool copy_string);
+  const char *get_user(int *length);
+  void set_user(HdrHeap *heap, const char *value, int length, bool copy_string);
+  const char *get_password(int *length);
+  void set_password(HdrHeap *heap, const char *value, int length, bool copy_string);
+  const char *get_host(int *length);
+  void set_host(HdrHeap *heap, const char *value, int length, bool copy_string);
+  int get_port();
+  void set_port(HdrHeap *heap, unsigned int port);
+  void set_port(HdrHeap *heap, const char *value, int length, bool copy_string);
+  const char *get_path(int *length);
+  void set_path(HdrHeap *heap, const char *value, int length, bool copy_string);
+  int get_type();
+  void set_type(int type);
+  int get_type_code();
+  void set_type_code(unsigned int typecode);
+  const char *get_params(int *length);
+  void set_params(HdrHeap *heap, const char *value, int length, bool copy_string);
+  const char *get_query(int *length);
+  void set_query(HdrHeap *heap, const char *value, int length, bool copy_string);
+  const char *get_fragment(int *length);
+  void set_fragment(HdrHeap *heap, const char *value, int length, bool copy_string);
+
   // Marshaling Functions
   int marshal(MarshalXlate *str_xlate, int num_xlate);
   void unmarshal(intptr_t offset);
@@ -88,6 +114,8 @@ struct URLImpl : public HdrHeapObjImpl {
 
   // Sanity Check Functions
   void check_strings(HeapCheck *heaps, int num_heaps);
+
+private:
 };
 
 using URLHashContext = CryptoContext;
@@ -187,34 +215,6 @@ char *url_string_get_buf(URLImpl *url, char *dstbuf, int dstbuf_size, int *lengt
 
 void url_CryptoHash_get(const URLImpl *url, CryptoHash *hash, cache_generation_t generation = -1);
 void url_host_CryptoHash_get(URLImpl *url, CryptoHash *hash);
-const char *url_scheme_set(HdrHeap *heap, URLImpl *url, const char *value, int value_wks_idx, int length, bool copy_string);
-
-/* Internet specific */
-const char *url_user_get(URLImpl *url, int *length);
-const char *url_password_get(URLImpl *url, int *length);
-const char *url_host_get(URLImpl *url, int *length);
-int url_port_get(URLImpl *url);
-void url_user_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
-void url_password_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
-void url_host_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
-void url_port_set(HdrHeap *heap, URLImpl *url, unsigned int port);
-
-/* HTTP specific */
-const char *url_path_get(URLImpl *url, int *length);
-void url_path_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
-
-int url_type_get(URLImpl *url);
-void url_type_set(URLImpl *url, int type);
-int url_type_code_get(URLImpl *url);
-void url_type_code_set(URLImpl *url, unsigned int typecode);
-
-/* HTTP specific */
-const char *url_params_get(URLImpl *url, int *length);
-const char *url_query_get(URLImpl *url, int *length);
-const char *url_fragment_get(URLImpl *url, int *length);
-void url_params_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
-void url_query_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
-void url_fragment_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 
 constexpr bool USE_STRICT_URI_PARSING = true;
 
@@ -544,7 +544,7 @@ URL::scheme_set(const char *value, int length)
 {
   ink_assert(valid());
   int scheme_wks_idx = (value ? hdrtoken_tokenize(value, length) : -1);
-  url_scheme_set(m_heap, m_url_impl, value, scheme_wks_idx, length, true);
+  m_url_impl->set_scheme(m_heap, value, scheme_wks_idx, length, true);
 }
 
 /*-------------------------------------------------------------------------
@@ -554,7 +554,7 @@ inline const char *
 URL::user_get(int *length)
 {
   ink_assert(valid());
-  return url_user_get(m_url_impl, length);
+  return m_url_impl->get_user(length);
 }
 
 /*-------------------------------------------------------------------------
@@ -564,7 +564,7 @@ inline void
 URL::user_set(const char *value, int length)
 {
   ink_assert(valid());
-  url_user_set(m_heap, m_url_impl, value, length, true);
+  m_url_impl->set_user(m_heap, value, length, true);
 }
 
 /*-------------------------------------------------------------------------
@@ -574,7 +574,7 @@ inline const char *
 URL::password_get(int *length)
 {
   ink_assert(valid());
-  return url_password_get(m_url_impl, length);
+  return m_url_impl->get_password(length);
 }
 
 /*-------------------------------------------------------------------------
@@ -584,7 +584,7 @@ inline void
 URL::password_set(const char *value, int length)
 {
   ink_assert(valid());
-  url_password_set(m_heap, m_url_impl, value, length, true);
+  m_url_impl->set_password(m_heap, value, length, true);
 }
 
 /*-------------------------------------------------------------------------
@@ -594,7 +594,7 @@ inline const char *
 URL::host_get(int *length)
 {
   ink_assert(valid());
-  return url_host_get(m_url_impl, length);
+  return m_url_impl->get_host(length);
 }
 
 /*-------------------------------------------------------------------------
@@ -604,7 +604,7 @@ inline void
 URL::host_set(const char *value, int length)
 {
   ink_assert(valid());
-  url_host_set(m_heap, m_url_impl, value, length, true);
+  m_url_impl->set_host(m_heap, value, length, true);
 }
 
 /*-------------------------------------------------------------------------
@@ -614,7 +614,7 @@ inline int
 URL::port_get() const
 {
   ink_assert(valid());
-  return url_canonicalize_port(url_type_get(m_url_impl), url_port_get(m_url_impl));
+  return url_canonicalize_port(m_url_impl->get_type(), m_url_impl->get_port());
 }
 
 /*-------------------------------------------------------------------------
@@ -624,7 +624,7 @@ inline int
 URL::port_get_raw() const
 {
   ink_assert(valid());
-  return url_port_get(m_url_impl);
+  return m_url_impl->get_port();
 }
 
 /*-------------------------------------------------------------------------
@@ -634,7 +634,7 @@ inline void
 URL::port_set(int port)
 {
   ink_assert(valid());
-  url_port_set(m_heap, m_url_impl, port);
+  m_url_impl->set_port(m_heap, port);
 }
 
 /*-------------------------------------------------------------------------
@@ -644,7 +644,7 @@ inline const char *
 URL::path_get(int *length)
 {
   ink_assert(valid());
-  return url_path_get(m_url_impl, length);
+  return m_url_impl->get_path(length);
 }
 
 /*-------------------------------------------------------------------------
@@ -654,7 +654,7 @@ inline void
 URL::path_set(const char *value, int length)
 {
   ink_assert(valid());
-  url_path_set(m_heap, m_url_impl, value, length, true);
+  m_url_impl->set_path(m_heap, value, length, true);
 }
 
 /*-------------------------------------------------------------------------
@@ -664,7 +664,7 @@ inline int
 URL::type_code_get()
 {
   ink_assert(valid());
-  return url_type_code_get(m_url_impl);
+  return m_url_impl->get_type_code();
 }
 
 /*-------------------------------------------------------------------------
@@ -674,7 +674,7 @@ inline void
 URL::type_code_set(int typecode)
 {
   ink_assert(valid());
-  url_type_code_set(m_url_impl, typecode);
+  m_url_impl->set_type_code(typecode);
 }
 
 /*-------------------------------------------------------------------------
@@ -684,7 +684,7 @@ inline const char *
 URL::params_get(int *length)
 {
   ink_assert(valid());
-  return url_params_get(m_url_impl, length);
+  return m_url_impl->get_params(length);
 }
 
 /*-------------------------------------------------------------------------
@@ -694,7 +694,7 @@ inline void
 URL::params_set(const char *value, int length)
 {
   ink_assert(valid());
-  url_params_set(m_heap, m_url_impl, value, length, true);
+  m_url_impl->set_params(m_heap, value, length, true);
 }
 
 /*-------------------------------------------------------------------------
@@ -704,7 +704,7 @@ inline const char *
 URL::query_get(int *length)
 {
   ink_assert(valid());
-  return url_query_get(m_url_impl, length);
+  return m_url_impl->get_query(length);
 }
 
 /*-------------------------------------------------------------------------
@@ -714,7 +714,7 @@ inline void
 URL::query_set(const char *value, int length)
 {
   ink_assert(valid());
-  url_query_set(m_heap, m_url_impl, value, length, true);
+  m_url_impl->set_query(m_heap, value, length, true);
 }
 
 /*-------------------------------------------------------------------------
@@ -724,7 +724,7 @@ inline const char *
 URL::fragment_get(int *length)
 {
   ink_assert(valid());
-  return url_fragment_get(m_url_impl, length);
+  return m_url_impl->get_fragment(length);
 }
 
 /*-------------------------------------------------------------------------
@@ -734,7 +734,7 @@ inline void
 URL::fragment_set(const char *value, int length)
 {
   ink_assert(valid());
-  url_fragment_set(m_heap, m_url_impl, value, length, true);
+  m_url_impl->set_fragment(m_heap, value, length, true);
 }
 
 /**

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -190,17 +190,28 @@ void url_host_CryptoHash_get(URLImpl *url, CryptoHash *hash);
 const char *url_scheme_set(HdrHeap *heap, URLImpl *url, const char *value, int value_wks_idx, int length, bool copy_string);
 
 /* Internet specific */
+const char *url_user_get(URLImpl *url, int *length);
+const char *url_password_get(URLImpl *url, int *length);
+const char *url_host_get(URLImpl *url, int *length);
+int url_port_get(URLImpl *url);
 void url_user_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 void url_password_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 void url_host_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 void url_port_set(HdrHeap *heap, URLImpl *url, unsigned int port);
 
 /* HTTP specific */
+const char *url_path_get(URLImpl *url, int *length);
 void url_path_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 
-void url_type_set(URLImpl *url, unsigned int type);
+int url_type_get(URLImpl *url);
+void url_type_set(URLImpl *url, int type);
+int url_type_code_get(URLImpl *url);
+void url_type_code_set(URLImpl *url, unsigned int typecode);
 
 /* HTTP specific */
+const char *url_params_get(URLImpl *url, int *length);
+const char *url_query_get(URLImpl *url, int *length);
+const char *url_fragment_get(URLImpl *url, int *length);
 void url_params_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 void url_query_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 void url_fragment_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
@@ -285,8 +296,8 @@ public:
   const char *path_get(int *length);
   void path_set(const char *value, int length);
 
-  int type_get();
-  void type_set(int type);
+  int type_code_get();
+  void type_code_set(int type);
 
   const char *params_get(int *length);
   void params_set(const char *value, int length);
@@ -543,8 +554,7 @@ inline const char *
 URL::user_get(int *length)
 {
   ink_assert(valid());
-  *length = m_url_impl->m_len_user;
-  return m_url_impl->m_ptr_user;
+  return url_user_get(m_url_impl, length);
 }
 
 /*-------------------------------------------------------------------------
@@ -564,8 +574,7 @@ inline const char *
 URL::password_get(int *length)
 {
   ink_assert(valid());
-  *length = m_url_impl->m_len_password;
-  return m_url_impl->m_ptr_password;
+  return url_password_get(m_url_impl, length);
 }
 
 /*-------------------------------------------------------------------------
@@ -585,8 +594,7 @@ inline const char *
 URL::host_get(int *length)
 {
   ink_assert(valid());
-  *length = m_url_impl->m_len_host;
-  return m_url_impl->m_ptr_host;
+  return url_host_get(m_url_impl, length);
 }
 
 /*-------------------------------------------------------------------------
@@ -606,7 +614,7 @@ inline int
 URL::port_get() const
 {
   ink_assert(valid());
-  return url_canonicalize_port(m_url_impl->m_url_type, m_url_impl->m_port);
+  return url_canonicalize_port(url_type_get(m_url_impl), url_port_get(m_url_impl));
 }
 
 /*-------------------------------------------------------------------------
@@ -616,7 +624,7 @@ inline int
 URL::port_get_raw() const
 {
   ink_assert(valid());
-  return m_url_impl->m_port;
+  return url_port_get(m_url_impl);
 }
 
 /*-------------------------------------------------------------------------
@@ -636,8 +644,7 @@ inline const char *
 URL::path_get(int *length)
 {
   ink_assert(valid());
-  *length = m_url_impl->m_len_path;
-  return m_url_impl->m_ptr_path;
+  return url_path_get(m_url_impl, length);
 }
 
 /*-------------------------------------------------------------------------
@@ -654,20 +661,20 @@ URL::path_set(const char *value, int length)
   -------------------------------------------------------------------------*/
 
 inline int
-URL::type_get()
+URL::type_code_get()
 {
   ink_assert(valid());
-  return m_url_impl->m_type_code;
+  return url_type_code_get(m_url_impl);
 }
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
 inline void
-URL::type_set(int type)
+URL::type_code_set(int typecode)
 {
   ink_assert(valid());
-  url_type_set(m_url_impl, type);
+  url_type_code_set(m_url_impl, typecode);
 }
 
 /*-------------------------------------------------------------------------
@@ -677,8 +684,7 @@ inline const char *
 URL::params_get(int *length)
 {
   ink_assert(valid());
-  *length = m_url_impl->m_len_params;
-  return m_url_impl->m_ptr_params;
+  return url_params_get(m_url_impl, length);
 }
 
 /*-------------------------------------------------------------------------
@@ -698,8 +704,7 @@ inline const char *
 URL::query_get(int *length)
 {
   ink_assert(valid());
-  *length = m_url_impl->m_len_query;
-  return m_url_impl->m_ptr_query;
+  return url_query_get(m_url_impl, length);
 }
 
 /*-------------------------------------------------------------------------
@@ -719,8 +724,7 @@ inline const char *
 URL::fragment_get(int *length)
 {
   ink_assert(valid());
-  *length = m_url_impl->m_len_fragment;
-  return m_url_impl->m_ptr_fragment;
+  return url_fragment_get(m_url_impl, length);
 }
 
 /*-------------------------------------------------------------------------

--- a/proxy/hdrs/unit_tests/test_HdrHeap.cc
+++ b/proxy/hdrs/unit_tests/test_HdrHeap.cc
@@ -42,7 +42,7 @@ TEST_CASE("HdrHeap", "[proxy][hdrheap]")
 
   // Checking that we have no rw heap
   CHECK(heap->m_read_write_heap.get() == nullptr);
-  url_path_set(heap, url, buf, next_required_overflow_size, true);
+  url->set_path(heap, buf, next_required_overflow_size, true);
 
   // Checking that we've completely consumed the rw heap
   CHECK(heap->m_read_write_heap->m_free_size == 0);
@@ -63,7 +63,7 @@ TEST_CASE("HdrHeap", "[proxy][hdrheap]")
     }
 
     URLImpl *url2 = url_create(heap);
-    url_path_set(heap, url2, buf2, next_required_overflow_size, true);
+    url2->set_path(heap, buf2, next_required_overflow_size, true);
 
     // Checking the current rw heap is next_rw_heap_size bytes
     CHECK(heap->m_read_write_heap->m_heap_size == (uint32_t)next_rw_heap_size);
@@ -92,7 +92,7 @@ TEST_CASE("HdrHeap", "[proxy][hdrheap]")
   }
 
   URLImpl *aliased_str_url = url_create(heap);
-  url_path_set(heap, aliased_str_url, buf3, next_required_overflow_size, false); // don't copy this string
+  aliased_str_url->set_path(heap, buf3, next_required_overflow_size, false); // don't copy this string
   // Checking that the aliased string shows having proper length
   CHECK(aliased_str_url->m_len_path == next_required_overflow_size);
   // Checking that the aliased string is correctly pointing at buf

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -431,7 +431,7 @@ http2_convert_header_from_2_to_1_1(HTTPHdr *headers)
       const char *scheme = field->value_get(&scheme_len);
 
       int scheme_wks_idx = hdrtoken_tokenize(scheme, scheme_len);
-      url_scheme_set(headers->m_heap, headers->m_http->u.req.m_url_impl, scheme, scheme_wks_idx, scheme_len, true);
+      headers->m_http->u.req.m_url_impl->set_scheme(headers->m_heap, scheme, scheme_wks_idx, scheme_len, true);
 
       headers->field_delete(field);
     } else {
@@ -444,7 +444,7 @@ http2_convert_header_from_2_to_1_1(HTTPHdr *headers)
       int authority_len;
       const char *authority = field->value_get(&authority_len);
 
-      url_host_set(headers->m_heap, headers->m_http->u.req.m_url_impl, authority, authority_len, true);
+      headers->m_http->u.req.m_url_impl->set_host(headers->m_heap, authority, authority_len, true);
 
       headers->field_delete(field);
     } else {
@@ -462,7 +462,7 @@ http2_convert_header_from_2_to_1_1(HTTPHdr *headers)
         --path_len;
       }
 
-      url_path_set(headers->m_heap, headers->m_http->u.req.m_url_impl, path, path_len, true);
+      headers->m_http->u.req.m_url_impl->set_path(headers->m_heap, path, path_len, true);
 
       headers->field_delete(field);
     } else {

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -2492,7 +2492,7 @@ TSUrlFtpTypeGet(TSMBuffer bufp, TSMLoc obj)
   URL u;
   u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
   u.m_url_impl = (URLImpl *)obj;
-  return u.type_get();
+  return u.type_code_get();
 }
 
 TSReturnCode
@@ -2508,7 +2508,7 @@ TSUrlFtpTypeSet(TSMBuffer bufp, TSMLoc obj, int type)
 
     u.m_heap     = ((HdrHeapSDKHandle *)bufp)->m_heap;
     u.m_url_impl = (URLImpl *)obj;
-    u.type_set(type);
+    u.type_code_set(type);
     return TS_SUCCESS;
   }
 


### PR DESCRIPTION
An alternative to #8170. Instead of removing unused free functions, this converts the free functions to methods of URLImpl class and call those from URL class.

This also changes names of type_get/set to type_code_get/set, because there are "type" and "type code" in URLImpl and type_get/set were used for "type code". And I redefined type_get/set for "type".

I could add a constructor and make other functions to methods as well, and member variables of URLImpl should be private, but I didn't make those changes for now because this is enough to save the unused functions.