### PR TITLE
Fix log filteris for IP conditions.

### DIFF
--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -270,29 +270,3 @@ private:
   Queue<LogField> m_field_list;
   std::string _badSymbols;
 };
-
-/** Base IP address data.
-    To unpack an IP address, the generic memory is first cast to
-    this type to get the family. That pointer can then be static_cast
-    to the appropriate subtype to get the actual address data.
-
-    @note We don't use our own enum for the family. Instead we use
-    @c AF_INET and @c AF_INET6.
-*/
-struct LogFieldIp {
-  uint16_t _family; ///< IP address family.
-};
-/// IPv4 address as log field.
-struct LogFieldIp4 : public LogFieldIp {
-  in_addr_t _addr; ///< IPv4 address.
-};
-/// IPv6 address as log field.
-struct LogFieldIp6 : public LogFieldIp {
-  in6_addr _addr; ///< IPv6 address.
-};
-/// Something big enough to hold any of the IP field types.
-union LogFieldIpStorage {
-  LogFieldIp _ip;
-  LogFieldIp4 _ip4;
-  LogFieldIp6 _ip6;
-};

--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -833,11 +833,9 @@ LogFilterIP::is_match(LogAccess *lad)
   bool zret = false;
 
   if (m_field && lad) {
-    LogFieldIpStorage value;
-    m_field->marshal(lad, reinterpret_cast<char *>(&value));
-    // This is bad, we abuse the fact that the initial layout of LogFieldIpStorage and IpAddr
-    // are identical. We should look at converting the log stuff to use IpAddr directly.
-    zret = m_map.contains(reinterpret_cast<IpAddr &>(value));
+    IpAddr field_ip_addr;
+    m_field->marshal(lad, reinterpret_cast<char *>(&field_ip_addr));
+    zret = m_map.contains(field_ip_addr);
   }
 
   return zret;

--- a/src/traffic_logstats/logstats.cc
+++ b/src/traffic_logstats/logstats.cc
@@ -1317,14 +1317,12 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false, bool aggregate
         state = P_STATE_RESULT;
         // Just skip the IP, we no longer assume it's always the same.
         {
-          LogFieldIp *ip = reinterpret_cast<LogFieldIp *>(read_from);
-          int len        = sizeof(LogFieldIp);
-          if (AF_INET == ip->_family) {
+          IpAddr *ip        = reinterpret_cast<IpAddr *>(read_from);
+          constexpr int len = sizeof(IpAddr);
+          if (ip->isIp4()) {
             ipv6 = false;
-            len  = sizeof(LogFieldIp4);
-          } else if (AF_INET6 == ip->_family) {
+          } else if (ip->isIp6()) {
             ipv6 = true;
-            len  = sizeof(LogFieldIp6);
           }
           read_from += INK_ALIGN_DEFAULT(len);
         }


### PR DESCRIPTION
Our log filter mechanism for IP addresses was broken. This fixes the
matching mechanism so it compares IP addresses with log fields
correctly.

Fixes #6405

---

The LogFilterIP::is_match mechanism stopped working at some point in the past. That is what the linked issue observes.  I fixed this by addressing the warning in the comment that was in that function:

```
    // This is bad, we abuse the fact that the initial layout of LogFieldIpStorage and IpAddr
    // are identical. We should look at converting the log stuff to use IpAddr directly.
```

Those structures have diverged such that they do not match between each other anymore. I thus converted the use of LogFieldIp* types to IpAddr. @SolidWallOfCode : you wrote that code (and the comment) initially. Can you please verify that what I'm doing here is what you had in mind?