### PR TITLE
Fix log filters for IP conditions.

### DIFF
--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -833,11 +833,17 @@ LogFilterIP::is_match(LogAccess *lad)
   bool zret = false;
 
   if (m_field && lad) {
-    LogFieldIpStorage value;
-    m_field->marshal(lad, reinterpret_cast<char *>(&value));
-    // This is bad, we abuse the fact that the initial layout of LogFieldIpStorage and IpAddr
-    // are identical. We should look at converting the log stuff to use IpAddr directly.
-    zret = m_map.contains(reinterpret_cast<IpAddr &>(value));
+    LogFieldIpStorage field_ip_storage;
+    m_field->marshal(lad, reinterpret_cast<char *>(&field_ip_storage));
+
+    // Convert to the IpAddr type that the map holds.
+    IpAddr field_ip;
+    if (field_ip_storage._ip._family == AF_INET) {
+      field_ip = field_ip_storage._ip4._addr;
+    } else if (field_ip_storage._ip._family == AF_INET6) {
+      field_ip = field_ip_storage._ip6._addr;
+    }
+    zret = m_map.contains(reinterpret_cast<IpAddr &>(field_ip));
   }
 
   return zret;


### PR DESCRIPTION
Our log filter mechanism for IP addresses did not compare the filter's
specified IP address with the log field's IP address correctly. This
fixes that matching mechanism.

Fixes #6405