### PR TITLE
Cleanup: Get rid of deprecated functions of NetVConnection

### DIFF
--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -594,23 +594,12 @@ public:
   sockaddr const *get_local_addr();
   IpEndpoint const &get_local_endpoint();
 
-  /** Returns local ip.
-      @deprecated get_local_addr() should be used instead for AF_INET6 compatibility.
-  */
-
-  in_addr_t get_local_ip();
-
   /** Returns local port. */
   uint16_t get_local_port();
 
   /** Returns remote sockaddr storage. */
   sockaddr const *get_remote_addr();
   IpEndpoint const &get_remote_endpoint();
-
-  /** Returns remote ip.
-      @deprecated get_remote_addr() should be used instead for AF_INET6 compatibility.
-  */
-  in_addr_t get_remote_ip();
 
   /** Returns remote port. */
   uint16_t get_remote_port();

--- a/iocore/net/P_NetVConnection.h
+++ b/iocore/net/P_NetVConnection.h
@@ -45,13 +45,6 @@ NetVConnection::get_remote_endpoint()
   return remote_addr;
 }
 
-inline in_addr_t
-NetVConnection::get_remote_ip()
-{
-  sockaddr const *addr = this->get_remote_addr();
-  return ats_is_ip4(addr) ? ats_ip4_addr_cast(addr) : 0;
-}
-
 /// @return The remote port in host order.
 inline uint16_t
 NetVConnection::get_remote_port()
@@ -78,13 +71,6 @@ NetVConnection::get_local_addr()
     }
   }
   return &local_addr.sa;
-}
-
-inline in_addr_t
-NetVConnection::get_local_ip()
-{
-  sockaddr const *addr = this->get_local_addr();
-  return ats_is_ip4(addr) ? ats_ip4_addr_cast(addr) : 0;
 }
 
 /// @return The local port in host order.


### PR DESCRIPTION
These functions have been deprecated since 3.1.0 (TS-919 https://github.com/apache/trafficserver/commit/8247bcac9e326746132d6526469c6b30146c0baf)