### PR TITLE
Remove unnecessary IPAddr cast.

### DIFF
--- a/proxy/logging/LogFilter.cc
+++ b/proxy/logging/LogFilter.cc
@@ -843,7 +843,7 @@ LogFilterIP::is_match(LogAccess *lad)
     } else if (field_ip_storage._ip._family == AF_INET6) {
       field_ip = field_ip_storage._ip6._addr;
     }
-    zret = m_map.contains(reinterpret_cast<IpAddr &>(field_ip));
+    zret = m_map.contains(field_ip);
   }
 
   return zret;


### PR DESCRIPTION
Removing a cast to IpAddr for a variable which is already an IpAddr in
the LogFilterIP code.