### PR TITLE
Fix Http2Stream leaks

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -154,10 +154,12 @@ Http2Stream::main_event_handler(int event, void *edata)
   if (e == _read_vio_event) {
     _read_vio_event = nullptr;
     this->signal_read_event(e->callback_event);
+    reentrancy_count--;
     return 0;
   } else if (e == _write_vio_event) {
     _write_vio_event = nullptr;
     this->signal_write_event(e->callback_event);
+    reentrancy_count--;
     return 0;
   } else if (e == cross_thread_event) {
     cross_thread_event = nullptr;
@@ -516,7 +518,7 @@ Http2Stream::initiating_close()
       if (write_vio.cont) {
         SCOPED_MUTEX_LOCK(lock, write_vio.mutex, this_ethread());
         // Are we done?
-        if (write_vio.nbytes == write_vio.ndone) {
+        if (write_vio.nbytes > 0 && write_vio.nbytes == write_vio.ndone) {
           Http2StreamDebug("handle write from destroy (event=%d)", VC_EVENT_WRITE_COMPLETE);
           write_event = send_tracked_event(write_event, VC_EVENT_WRITE_COMPLETE, &write_vio);
         } else {


### PR DESCRIPTION
We have been observing high memory utilization in production after upgrading to ats9.1. JeMalloc profiling shows the problem is related to `Http2Stream`.

