### PR TITLE
Add ACCEPT_FILTER Support on FreeBSD

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4461,6 +4461,7 @@ Sockets
 
    This directive enables operating system specific optimizations for a listening socket. ``defer_accept`` holds a call to ``accept(2)``
    back until data has arrived. In Linux' special case this is up to a maximum of 45 seconds.
+   On FreeBSD, ``accf_data`` module needs to be loaded.
 
 .. ts:cv:: CONFIG proxy.config.net.listen_backlog INT -1
    :reloadable:

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -171,6 +171,7 @@ struct Server : public Connection {
 
   int listen(bool non_blocking, const NetProcessor::AcceptOptions &opt);
   int setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions &opt);
+  int setup_fd_after_listen(const NetProcessor::AcceptOptions &opt);
 
   Server() : Connection() { ink_zero(accept_addr); }
 };


### PR DESCRIPTION
ATS has `TCP_DEFER_ACCEPT` support on Linux but not on FreeBSD. The ACCEPT_FILTER is the similar one.

ACCF_DATA(9) https://www.freebsd.org/cgi/man.cgi?query=accf_data&manpath=FreeBSD+13.0-RELEASE+and+Ports