### PR TITLE
Add warning message about why enhance your calm is being sent

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -811,7 +811,7 @@ rcv_window_update_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
 
     auto error = cstate.increment_client_rwnd(size);
     if (error != Http2ErrorCode::HTTP2_ERROR_NO_ERROR) {
-      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, error);
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, error, "Erroneous client window update");
     }
 
     cstate.restart_streams();


### PR DESCRIPTION
Noticed this while debugging H2 to origin.  The warning message was being printed that an ENHANCE_YOUR_CALM error was being returned, but no message about why as is normal for most of the connection/stream errors.