### PR TITLE
Use better done file locations for some AuTests

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,1 @@
 _sandbox/
-done

--- a/tests/gold_tests/continuations/double_h2.test.py
+++ b/tests/gold_tests/continuations/double_h2.test.py
@@ -109,10 +109,12 @@ tr.StillRunningAfter = ts
 
 def make_done_stat_ready(tsenv):
     def done_stat_ready(process, hasRunFor, **kw):
-        retval = subprocess.run("traffic_ctl metric get continuations_verify.test.done > done  2> /dev/null", shell=True, env=tsenv)
-        if retval.returncode == 0:
-            retval = subprocess.run("grep 1 done > /dev/null", shell=True, env=tsenv)
-        return retval.returncode == 0
+        retval = subprocess.run(
+            "traffic_ctl metric get continuations_verify.test.done",
+            shell=True,
+            capture_output=True,
+            env=tsenv)
+        return retval.returncode == 0 and b'1' in retval.stdout
 
     return done_stat_ready
 

--- a/tests/gold_tests/continuations/openclose.test.py
+++ b/tests/gold_tests/continuations/openclose.test.py
@@ -86,10 +86,12 @@ tr.StillRunningAfter = ts
 
 def make_done_stat_ready(tsenv):
     def done_stat_ready(process, hasRunFor, **kw):
-        retval = subprocess.run("traffic_ctl metric get ssntxnorder_verify.test.done > done  2> /dev/null", shell=True, env=tsenv)
-        if retval.returncode == 0:
-            retval = subprocess.run("grep 1 done > /dev/null", shell=True, env=tsenv)
-        return retval.returncode == 0
+        retval = subprocess.run(
+            "traffic_ctl metric get ssntxnorder_verify.test.done",
+            shell=True,
+            capture_output=True,
+            env=tsenv)
+        return retval.returncode == 0 and b'1' in retval.stdout
 
     return done_stat_ready
 

--- a/tests/gold_tests/continuations/openclose_h2.test.py
+++ b/tests/gold_tests/continuations/openclose_h2.test.py
@@ -99,10 +99,12 @@ tr.StillRunningAfter = ts
 
 def make_done_stat_ready(tsenv):
     def done_stat_ready(process, hasRunFor, **kw):
-        retval = subprocess.run("traffic_ctl metric get ssntxnorder_verify.test.done > done  2> /dev/null", shell=True, env=tsenv)
-        if retval.returncode == 0:
-            retval = subprocess.run("grep 1 done > /dev/null", shell=True, env=tsenv)
-        return retval.returncode == 0
+        retval = subprocess.run(
+            "traffic_ctl metric get ssntxnorder_verify.test.done",
+            shell=True,
+            capture_output=True,
+            env=tsenv)
+        return retval.returncode == 0 and b'1' in retval.stdout
 
     return done_stat_ready
 


### PR DESCRIPTION
Some of the AuTests used a done file for AuTest process Ready
conditions. These files got left around in the test directory. This
change puts these done files in the sandbox instead.

Fixes #5546