### PR TITLE
AuTests: Avoid capture_output subprocess command

### DIFF
--- a/tests/gold_tests/continuations/double_h2.test.py
+++ b/tests/gold_tests/continuations/double_h2.test.py
@@ -112,7 +112,8 @@ def make_done_stat_ready(tsenv):
         retval = subprocess.run(
             "traffic_ctl metric get continuations_verify.test.done",
             shell=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             env=tsenv)
         return retval.returncode == 0 and b'1' in retval.stdout
 

--- a/tests/gold_tests/continuations/openclose.test.py
+++ b/tests/gold_tests/continuations/openclose.test.py
@@ -89,7 +89,8 @@ def make_done_stat_ready(tsenv):
         retval = subprocess.run(
             "traffic_ctl metric get ssntxnorder_verify.test.done",
             shell=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             env=tsenv)
         return retval.returncode == 0 and b'1' in retval.stdout
 

--- a/tests/gold_tests/continuations/openclose_h2.test.py
+++ b/tests/gold_tests/continuations/openclose_h2.test.py
@@ -102,7 +102,8 @@ def make_done_stat_ready(tsenv):
         retval = subprocess.run(
             "traffic_ctl metric get ssntxnorder_verify.test.done",
             shell=True,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             env=tsenv)
         return retval.returncode == 0 and b'1' in retval.stdout
 


### PR DESCRIPTION
The subprocess capture_output is a Python 3.9 parameter. This changes
the AuTests that used it to instead use the older stdout/stderr
parameters because that's compatible with Python 3.9.