### PR TITLE
Cleanup generated LDFLAGS for jemalloc

### DIFF
--- a/build/jemalloc.m4
+++ b/build/jemalloc.m4
@@ -55,8 +55,7 @@ if test "$enable_jemalloc" != "no"; then
   jemalloc_have_libs=0
   if test "$jemalloc_base_dir" != "/usr"; then
     TS_ADDTO(CPPFLAGS, [-I${jemalloc_include}])
-    TS_ADDTO(LDFLAGS, [-L${jemalloc_ldflags}])
-    TS_ADDTO(LDFLAGS, [-Wl,--add-needed -L${jemalloc_base_dir}/lib -Wl,-rpath,${jemalloc_base_dir}/lib -Wl,--no-as-needed])
+    TS_ADDTO(LDFLAGS, [-L${jemalloc_ldflags} -Wl,-rpath,${jemalloc_ldflags}])
     TS_ADDTO_RPATH(${jemalloc_ldflags})
   fi
   # On Darwin, jemalloc symbols are prefixed with je_. Search for that first, then fall back


### PR DESCRIPTION
Use the already expanded jemalloc_ldflags instead of overwriting what
was previously specified earlier in the file.

Also, drop use --add-needed,--no-as-needed