### PR TITLE
autest: double the initial port pool for get_port

### DIFF
--- a/tests/gold_tests/autest-site/ports.py
+++ b/tests/gold_tests/autest-site/ports.py
@@ -117,7 +117,7 @@ def _get_available_port(queue):
     return port
 
 
-def _setup_port_queue(amount=1000):
+def _setup_port_queue(amount=2000):
     """
     Build up the set of ports that the OS in theory will not use.
     """


### PR DESCRIPTION
We're running into issues with port selection with our tests. This seems
to be an issue with recycled ports. This temporarily expands the number
of ports in the port pool to avert this problem while we investigate
this issue further.