### PR TITLE
Update nghttp gold file based on previous h2 fix

### DIFF
--- a/tests/gold_tests/h2/gold/nghttp_1_stdout.gold
+++ b/tests/gold_tests/h2/gold/nghttp_1_stdout.gold
@@ -7,6 +7,6 @@
 [``] recv GOAWAY frame <length=8, flags=0x00, stream_id=0>
           (last_stream_id=1, error_code=NO_ERROR(0x00), opaque_data(0)=[])
 ``
-[``] recv DATA frame <length=0, flags=0x01, stream_id=1>
+[``] recv DATA frame <length=1, flags=0x01, stream_id=1>
           ; END_STREAM
 ``

--- a/tests/gold_tests/pluginTest/test_hooks/body_buffer.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/body_buffer.test.py
@@ -99,10 +99,10 @@ class BodyBufferTest:
         })
 
         self._ts.Streams.stderr = Testers.ContainsExpression(
-            rf"request_buffer_plugin gets the request body with length\[{self.content_length_size}\]",
+            rfr"request_buffer_plugin gets the request body with length\[{self.content_length_size}\]",
             "Verify that the plugin parsed the content-length request body data.")
         self._ts.Streams.stderr += Testers.ContainsExpression(
-            rf"request_buffer_plugin gets the request body with length\[{self.encoded_chunked_size}\]",
+            rfr"request_buffer_plugin gets the request body with length\[{self.encoded_chunked_size}\]",
             "Verify that the plugin parsed the chunked request body.")
 
     def run(self):

--- a/tests/gold_tests/pluginTest/test_hooks/body_buffer.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/body_buffer.test.py
@@ -99,10 +99,10 @@ class BodyBufferTest:
         })
 
         self._ts.Streams.stderr = Testers.ContainsExpression(
-            rfr"request_buffer_plugin gets the request body with length\[{self.content_length_size}\]",
+            rf"request_buffer_plugin gets the request body with length\[{self.content_length_size}\]",
             "Verify that the plugin parsed the content-length request body data.")
         self._ts.Streams.stderr += Testers.ContainsExpression(
-            rfr"request_buffer_plugin gets the request body with length\[{self.encoded_chunked_size}\]",
+            rf"request_buffer_plugin gets the request body with length\[{self.encoded_chunked_size}\]",
             "Verify that the plugin parsed the chunked request body.")
 
     def run(self):


### PR DESCRIPTION
Due to PR #8201 the output of the nghttp test changes.  The last DATA frame is not empty.  This PR fixes that output expectation.

This fixes #8297