### PR TITLE
Revert "autest: double the initial port pool for get_port (#8292)"

### DIFF
--- a/tests/gold_tests/autest-site/ports.py
+++ b/tests/gold_tests/autest-site/ports.py
@@ -115,7 +115,7 @@ def _get_available_port(queue):
     return port
 
 
-def _setup_port_queue(amount=2000):
+def _setup_port_queue(amount=1000):
     """
     Build up the set of ports that the OS in theory will not use.
     """


### PR DESCRIPTION
This reverts commit d15a0422eedf526de90ee5f76243e5fb8d8bd185.

This port pool expansion should no longer be needed now that the port
queue was made a unique set (see #8299). This commit therefore reverts
what was intended to be temporary.