### PR TITLE
Make separate read and write vc_handlers

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1998,8 +1998,6 @@ HttpSM::state_read_server_response_header(int event, void *data)
   // a WRITE event appear after receiving EOS from the server connection
   if (server_entry->eos) {
     return 0;
-  } else if (data == server_entry->write_vio) {
-    return this->state_send_server_request_header(event, data);
   }
 
   ink_assert(server_entry->eos != true);
@@ -2165,9 +2163,6 @@ int
 HttpSM::state_send_server_request_header(int event, void *data)
 {
   ink_assert(server_entry != nullptr);
-  if (server_entry->read_vio == data) {
-    return this->state_read_server_response_header(event, data);
-  }
   ink_assert(server_entry->eos == false);
   ink_assert(server_entry->write_vio == (VIO *)data);
   STATE_ENTER(&HttpSM::state_send_server_request_header, event);

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -90,7 +90,8 @@ struct HttpVCTableEntry {
   MIOBuffer *write_buffer;
   VIO *read_vio;
   VIO *write_vio;
-  HttpSMHandler vc_handler;
+  HttpSMHandler vc_read_handler;
+  HttpSMHandler vc_write_handler;
   HttpVC_t vc_type;
   HttpSM *sm;
   bool eos;


### PR DESCRIPTION
I have noticed occasional crashes in working with the H2 to origin branch and in our 9.1 with producer_run().  Both branches include PR #7976.  With this change, we need to be ready to respond to both read and write events on the server_entry->vc (read for responses and write for post bodies).  Currently we do a vio check in both state_read_server_response_header and state_send_server_request_header to hand the incorrectly passed read/write to othe other side.

In general with the vc_entry we have parallel entries for read and write operations, except for the vc_handler.  This does result in some write events unexpectedly showing up in a read handler and visa versa which ends up with confusing code.

This PR, splits the vc_handler into vc_read_handler and vc_write_handler.  That should hopefully simplify some of handler logic moving forward.