### PR TITLE
Fix crash during raw connect failures

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1244,7 +1244,6 @@ HttpSM::state_raw_http_server_open(int event, void *data)
 
   case VC_EVENT_ERROR:
   case NET_EVENT_OPEN_FAILED:
-    t_state.set_connect_fail(server_txn->get_netvc()->lerrno);
     t_state.current.state = HttpTransact::OPEN_RAW_ERROR;
     // use this value just to get around other values
     t_state.hdr_info.response_error = HttpTransact::STATUS_CODE_SERVER_ERROR;


### PR DESCRIPTION
In the case of raw open, the server_txn will generally be a nullptr.  We
tried to use server_txn when calling set_connect_fail, which resulted in
a crash. This change simply removes the call. Note that a generic call
to set_connect_fail was already called previous to calling this
function.

This error was introduced with PR #7849