### PR TITLE
Truly treat multiple certs with the same SAN as a warning (#8303)

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1408,7 +1408,6 @@ SSLMultiCertConfigLoader::_store_ssl_ctx(SSLCertLookup *lookup, const shared_SSL
   shared_SSL_CTX ctx(this->init_server_ssl_ctx(data, sslMultCertSettings.get(), common_names), SSL_CTX_free);
 
   if (!ctx || !sslMultCertSettings || !this->_store_single_ssl_ctx(lookup, sslMultCertSettings, ctx, common_names)) {
-    retval = false;
     std::string names;
     for (auto name : data.cert_names_list) {
       names.append(name);


### PR DESCRIPTION
(cherry picked from commit 5c75a3052e1022662f06ea2b7d8139bb01e32f9b)

Conflicts:
    iocore/net/SSLUtils.cc