### PR TITLE
Fix a compile error in SSLCertLookup

### DIFF
--- a/iocore/net/SSLCertLookup.cc
+++ b/iocore/net/SSLCertLookup.cc
@@ -363,6 +363,7 @@ SSLCertLookup::insert(const char *name, SSLCertContext const &cc)
     return this->ec_storage->insert(name, cc);
   default:
     ink_assert(false);
+    return -1;
   }
 #else
   return this->ssl_storage->insert(name, cc);
@@ -383,6 +384,7 @@ SSLCertLookup::insert(const IpEndpoint &address, SSLCertContext const &cc)
     return this->ec_storage->insert(key.get(), cc);
   default:
     ink_assert(false);
+    return -1;
   }
 #else
   return this->ssl_storage->insert(key.get(), cc);


### PR DESCRIPTION
```
  CXX      SSLCertLookup.o
SSLCertLookup.cc: In member function ?int SSLCertLookup::insert(const char*, const SSLCertContext&)?:
SSLCertLookup.cc:364:3: error: control reaches end of non-void function [-Werror=return-type]
  364 |   default:
      |   ^~~~~~~
```
Found on Fedora 34 with gcc-11 and BoringSSL.

The code was introduce by #8014. There's no need to backport this to 9.1.x.