### PR TITLE
Fix a compile error in rate_limit plugin

### DIFF
--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <chrono>
 #include <string>
+#include <climits>
 
 #include "tscore/ink_config.h"
 #include "ts/ts.h"


### PR DESCRIPTION
```
  CXX      experimental/rate_limit/rate_limit.lo
In file included from experimental/rate_limit/txn_limiter.h:20,
                 from experimental/rate_limit/rate_limit.cc:25:
experimental/rate_limit/limiter.h:146:39: error: ?UINT_MAX? was not declared in this scope
  146 |   unsigned max_queue                = UINT_MAX; // No queue limit, but if sets will give an immediate error if at max
      |                                       ^~~~~~~~
experimental/rate_limit/limiter.h:29:1: note: ?UINT_MAX? is defined in header ?<climits>?; did you forget to ?#include <climits>??
   28 | #include "utilities.h"
  +++ |+#include <climits>
   29 | 
```
Found on Fedora 34 with gcc11.

The code was added by #7623, and it's on 9.1.0. This is not a security fix but I mark this for 9.1.x because it's very safe to backport.