### PR TITLE
Fix yamlcpp include folder by using the YAMLCPP_INCLUDE  variable

### DIFF
--- a/mgmt/Makefile.am
+++ b/mgmt/Makefile.am
@@ -34,7 +34,7 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy \
 	-I$(abs_top_srcdir)/proxy/http \
 	-I$(abs_top_srcdir)/proxy/hdrs \
-	-I$(abs_top_srcdir)/lib/yamlcpp/include \
+	@YAMLCPP_INCLUDES@ \
 	$(TS_INCLUDES)
 
 libmgmt_c_la_SOURCES = \

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -39,7 +39,7 @@ AM_CPPFLAGS += \
 	-I$(abs_srcdir)/hdrs \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	-I$(abs_top_srcdir)/lib/yamlcpp/include \
+	@YAMLCPP_INCLUDES@ \
 	$(TS_INCLUDES)
 
 noinst_HEADERS = \


### PR DESCRIPTION
Fix yamlcpp include folder by using the YAMLCPP_INCLUDE  variable,
so if we configure our own version of yamlcpp then the right include files will be picked up.
This will avoid mixin up the internal and the configured yamlcpp library.
