### PR TITLE
Add virtual destructor to Http2CommonSession because it now has virtual methods.

### DIFF
--- a/proxy/http2/Http2CommonSession.h
+++ b/proxy/http2/Http2CommonSession.h
@@ -73,6 +73,8 @@ class Http2CommonSession
 public:
   using SessionHandler = int (Http2CommonSession::*)(int, void *);
 
+  virtual ~Http2CommonSession() = default;
+
   /////////////////////
   // Methods
 


### PR DESCRIPTION
It's unsafe to add a virtual method without a virtual destructor.