### PR TITLE
Remove dir_token, since it is never set

### DIFF
--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -400,7 +400,7 @@ dir_clear_range(off_t start, off_t end, Vol *vol)
 {
   for (off_t i = 0; i < vol->buckets * DIR_DEPTH * vol->segments; i++) {
     Dir *e = dir_index(vol, i);
-    if (!dir_token(e) && dir_offset(e) >= static_cast<int64_t>(start) && dir_offset(e) < static_cast<int64_t>(end)) {
+    if (dir_offset(e) >= static_cast<int64_t>(start) && dir_offset(e) < static_cast<int64_t>(end)) {
       CACHE_DEC_DIR_USED(vol->mutex);
       dir_set_offset(e, 0); // delete
     }

--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -203,8 +203,7 @@ struct FreeDir {
 #define dir_set_head(_e, _v) dir_set_bit(_e, 2, 13, _v)
 #define dir_pinned(_e) dir_bit(_e, 2, 14)
 #define dir_set_pinned(_e, _v) dir_set_bit(_e, 2, 14, _v)
-#define dir_token(_e) dir_bit(_e, 2, 15)
-#define dir_set_token(_e, _v) dir_set_bit(_e, 2, 15, _v)
+// Bit 2:15 is unused.
 #define dir_next(_e) (_e)->w[3]
 #define dir_set_next(_e, _o) (_e)->w[3] = (uint16_t)(_o)
 #define dir_prev(_e) (_e)->w[2]


### PR DESCRIPTION
The bit is checked for not being set, but is never set and therefore can be safely removed.

This depends on #8320 because I can't compile without that fix.
Close #5505.