### PR TITLE
Removed unused dirname from LoadRefCountCacheFromPath

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -366,7 +366,7 @@ HostDBCache::start(int flags)
 
     Debug("hostdb", "Opening %s, partitions=%d storage_size=%" PRIu64 " items=%d", full_path, hostdb_partitions, hostdb_max_size,
           hostdb_max_count);
-    int load_ret = LoadRefCountCacheFromPath<HostDBInfo>(*this->refcountcache, storage_path, full_path, HostDBInfo::unmarshall);
+    int load_ret = LoadRefCountCacheFromPath<HostDBInfo>(*this->refcountcache, full_path, HostDBInfo::unmarshall);
     if (load_ret != 0) {
       Warning("Error loading cache from %s: %d", full_path, load_ret);
     }

--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -568,7 +568,7 @@ RefCountCache<C>::clear()
 // Errors are -1
 template <typename CacheEntryType>
 int
-LoadRefCountCacheFromPath(RefCountCache<CacheEntryType> &cache, const std::string &dirname, const std::string &filepath,
+LoadRefCountCacheFromPath(RefCountCache<CacheEntryType> &cache, const std::string &filepath,
                           CacheEntryType *(*load_func)(char *, unsigned int))
 {
   // If we have no load method, then we can't load anything so lets just stop right here

--- a/iocore/hostdb/test_RefCountCache.cc
+++ b/iocore/hostdb/test_RefCountCache.cc
@@ -220,7 +220,7 @@ test()
   RefCountCache<ExampleStruct> *cache = new RefCountCache<ExampleStruct>(cachePartitions);
   printf("Created...\n");
 
-  LoadRefCountCacheFromPath<ExampleStruct>(*cache, "/tmp", "/tmp/hostdb_cache", ExampleStruct::unmarshall);
+  LoadRefCountCacheFromPath<ExampleStruct>(*cache, "/tmp/hostdb_cache", ExampleStruct::unmarshall);
   printf("Cache started...\n");
   int numTestEntries = 10000;
 


### PR DESCRIPTION
AOCC flagged the parameter `dirname` from LoadRefCountCacheFromPath as
unused. This patch removes it.