### PR TITLE
Make fqdn of sni.yaml case insensitive.

### DIFF
--- a/iocore/net/P_SSLSNI.h
+++ b/iocore/net/P_SSLSNI.h
@@ -76,7 +76,7 @@ public:
     const char *err_ptr;
     int err_offset = 0;
     if (!regexName.empty()) {
-      match = pcre_compile(regexName.c_str(), PCRE_ANCHORED, &err_ptr, &err_offset, nullptr);
+      match = pcre_compile(regexName.c_str(), PCRE_ANCHORED | PCRE_CASELESS, &err_ptr, &err_offset, nullptr);
     } else {
       match = nullptr;
     }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4195,7 +4195,7 @@ HttpSM::check_sni_host()
             if (host_sni_policy == 2) {
               this->t_state.client_connection_enabled = false;
             }
-          } else if (strncmp(host_name, sni_value, host_len) != 0) { // Name mismatch
+          } else if (strncasecmp(host_name, sni_value, host_len) != 0) { // Name mismatch
             Warning("SNI/hostname mismatch sni=%s host=%.*s action=%s", sni_value, host_len, host_name, action_value);
             if (host_sni_policy == 2) {
               this->t_state.client_connection_enabled = false;


### PR DESCRIPTION
SNI and fqdn of sni.yaml should be matched case insensitvely. This
changes the matching mechanism for these to be case insensitive.
