### PR TITLE
Change the function signature of safe_[get|set]sockopt

### DIFF
--- a/include/tscore/ink_sock.h
+++ b/include/tscore/ink_sock.h
@@ -34,7 +34,7 @@
 
 #include "tscore/ink_apidefs.h"
 
-int safe_setsockopt(int s, int level, int optname, void *optval, int optlevel);
+int safe_setsockopt(int s, int level, int optname, const void *optval, int optlevel);
 int safe_getsockopt(int s, int level, int optname, void *optval, int *optlevel);
 int safe_bind(int s, struct sockaddr const *name, int namelen);
 int safe_listen(int s, int backlog);

--- a/include/tscore/ink_sock.h
+++ b/include/tscore/ink_sock.h
@@ -34,8 +34,8 @@
 
 #include "tscore/ink_apidefs.h"
 
-int safe_setsockopt(int s, int level, int optname, char *optval, int optlevel);
-int safe_getsockopt(int s, int level, int optname, char *optval, int *optlevel);
+int safe_setsockopt(int s, int level, int optname, void *optval, int optlevel);
+int safe_getsockopt(int s, int level, int optname, void *optval, int *optlevel);
 int safe_bind(int s, struct sockaddr const *name, int namelen);
 int safe_listen(int s, int backlog);
 int safe_getsockname(int s, struct sockaddr *name, int *namelen);

--- a/src/tscore/ink_sock.cc
+++ b/src/tscore/ink_sock.cc
@@ -59,7 +59,7 @@ check_valid_sockaddr(sockaddr *sa, char *file, int line)
 #endif
 
 int
-safe_setsockopt(int s, int level, int optname, void *optval, int optlevel)
+safe_setsockopt(int s, int level, int optname, const void *optval, int optlevel)
 {
   int r;
   do {

--- a/src/tscore/ink_sock.cc
+++ b/src/tscore/ink_sock.cc
@@ -59,7 +59,7 @@ check_valid_sockaddr(sockaddr *sa, char *file, int line)
 #endif
 
 int
-safe_setsockopt(int s, int level, int optname, char *optval, int optlevel)
+safe_setsockopt(int s, int level, int optname, void *optval, int optlevel)
 {
   int r;
   do {
@@ -69,7 +69,7 @@ safe_setsockopt(int s, int level, int optname, char *optval, int optlevel)
 }
 
 int
-safe_getsockopt(int s, int level, int optname, char *optval, int *optlevel)
+safe_getsockopt(int s, int level, int optname, void *optval, int *optlevel)
 {
   int r;
   do {


### PR DESCRIPTION
The type of `optval` argument for [get|set]sockopt is `void*`, but not `char*`.
Some values don't fit into a `char`, and casting the pointer to `char*` causes compile error.

```
       int getsockopt(int sockfd, int level, int optname,
                      void *optval, socklen_t *optlen);
       int setsockopt(int sockfd, int level, int optname,
                      const void *optval, socklen_t optlen);
```