### PR TITLE
docs: Update host_sni_policy for some behaviors

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -2009,9 +2009,14 @@ Security
    is 1, a warning is generated but the transaction is allowed to proceed.  If the value is 2 and there is a
    mismatch, a warning is generated and a status 403 is returned.
 
-   You can override this global setting on a per domain basis in the :file:`sni.yaml` file using the :ref:`host_sni_policy attribute<override-host-sni-policy>` action.
+   Note that SNI and hostname consistency checking is not performed on all connections indiscriminately, even if this
+   global ``proxy.config.http.host_sni_policy`` is set to a value of 1 or 2. It is only performed for connections to
+   hosts specifying ``verify_client`` and/or ``ip_allow`` policies in :file:`sni.yaml`. That is, the SNI and hostname
+   mismatch check is only performed if a relevant security policy for the SNI is set in :file:`sni.yaml`. The
+   ``proxy.config.http.host_sni_policy`` :file:`records.config` value is used as the default value if either of these
+   policies is set in the corresponding :file:`sni.yaml` file entry and the :file:`sni.yaml` entry does not override
+   this value via a :ref:`host_sni_policy attribute<override-host-sni-policy>` action.
 
-   Currently, only the verify_client and ip_allow policies are checked for host name and SNI matching.
 
 Cache Control
 =============

--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -26,7 +26,7 @@ Description
 ===========
 
 This file is used to configure aspects of TLS connection handling for both inbound and outbound
-connections. The configuration is driven by the SNI values provided by the inbound connection. The
+connections. With the exception of ``host_sni_policy`` (see the description below), the configuration is driven by the SNI values provided by the inbound connection. The
 file consists of a set of configuration items, each identified by an SNI value (``fqdn``).
 When an inbound TLS connection is made, the SNI value from the TLS negotiation is matched against
 the items specified by this file and if there is a match, the values specified in that item override
@@ -89,7 +89,16 @@ host_sni_policy           Inbound   One of the values :code:`DISABLED`, :code:`P
 
                                     If not specified, the value of :ts:cv:`proxy.config.http.host_sni_policy` is used.
                                     This controls how policy impacting mismatches between host header and SNI values are
-                                    dealt with.
+                                    dealt with.  For details about hos this configuration behaves, see the corresponding
+                                    :ts:cv:`proxy.config.http.host_sni_policy` :file:`records.config` documentation.
+
+                                    Note that this particular configuration will be inspected at the time the HTTP Host
+                                    header field is processed. Further, this policy check will be keyed off of the Host header
+                                    field value rather than the SNI in this :file:`sni.yaml` file. This is done because
+                                    the Host header field is ultimately the resource that will be retrieved from the
+                                    origin and the administrator will intend to guard this resource rather than the SNI,
+                                    which a malicious user may alter to some other server value whose policies are more
+                                    lenient than the host he is trying to access.
 
 valid_tls_versions_in     Inbound   This specifies the list of TLS protocols that will be offered to user agents during
                                     the TLS negotiation.  This replaces the global settings in

--- a/tests/gold_tests/tls/tls_sni_host_policy.test.py
+++ b/tests/gold_tests/tls/tls_sni_host_policy.test.py
@@ -88,6 +88,11 @@ tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
+#
+# For the following tests, note that host_sni_policy is keyed off of the HTTP Host
+# header field rather than the SNI in sni.yaml.
+#
+
 # case 3
 # sni=dave and host=bob.  Do not provide client cert.  Should fail due to sni-host mismatch
 tr = Test.AddTestRun("Connect to dave without cert")
@@ -130,6 +135,8 @@ tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "
 
 # case 7
 # sni=ellen and host=fran.  Do not provide client cert.  No warning since neither name is mentioned in sni.yaml
+# and the records.config host_sni_policy only applies to hosts which have relevant security policies configured
+# in sni.yaml.
 tr = Test.AddTestRun("Connect to ellen without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
@@ -139,7 +146,9 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
 
 # case 8
-# sni=ellen and host=fran.  Do provide client cert.  No warning since neither name is mentioned in sni.yaml
+# sni=ellen and host=fran.  Do provide client cert.  No warning since neither name is mentioned in sni.yaml and
+# the records.config host_sni_policy only applies to hosts which have security relevant policies configured in
+# sni.yaml.
 tr = Test.AddTestRun("Connect to ellen with cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server


### PR DESCRIPTION
This expands the documentation for a few behaviors of the
`host_sni_policy` feature that can be unexpected for users.  Namely:

* `host_sni_policy` is keyed off of the Host header field instead of the
SNI value in the handshake.
* The records.config global `host_sni_policy` only applies when there is
a relevant security policy set for the host in the sni.yaml file but no
specific `host_sni_policy` is set there.