### PR TITLE
Rename outbound_conntrack to global_outbound_conntrack to reduce confusion.

### DIFF
--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1399,7 +1399,7 @@ HttpConfig::startup()
 
   HttpEstablishStaticConfigStringAlloc(c.oride.ssl_client_sni_policy, "proxy.config.ssl.client.sni_policy");
 
-  OutboundConnTrack::config_init(&c.outbound_conntrack, &c.oride.outbound_conntrack);
+  OutboundConnTrack::config_init(&c.global_outbound_conntrack, &c.oride.outbound_conntrack);
 
   MUTEX_TRY_LOCK(lock, http_config_cont->mutex, this_ethread());
   if (!lock.is_locked()) {
@@ -1445,10 +1445,10 @@ HttpConfig::reconfigure()
   params->server_max_connections    = m_master.server_max_connections;
   params->max_websocket_connections = m_master.max_websocket_connections;
   params->oride.outbound_conntrack  = m_master.oride.outbound_conntrack;
-  params->outbound_conntrack        = m_master.outbound_conntrack;
+  params->global_outbound_conntrack = m_master.global_outbound_conntrack;
 
   // If queuing for outbound connection tracking is enabled without enabling max connections, it is meaningless, so we'll warn
-  if (params->outbound_conntrack.queue_size > 0 &&
+  if (params->global_outbound_conntrack.queue_size > 0 &&
       !(params->oride.outbound_conntrack.max > 0 || params->oride.outbound_conntrack.min > 0)) {
     Warning("'%s' is set, but neither '%s' nor '%s' are "
             "set, please correct your %s",

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -832,7 +832,7 @@ public:
 
   MgmtByte server_session_sharing_pool = TS_SERVER_SESSION_SHARING_POOL_THREAD;
 
-  OutboundConnTrack::GlobalConfig outbound_conntrack;
+  OutboundConnTrack::GlobalConfig global_outbound_conntrack;
 
   // bitset to hold the status codes that will BE cached with negative caching enabled
   HttpStatusBitset negative_caching_list;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5258,18 +5258,18 @@ HttpSM::do_http_server_open(bool raw)
       ink_assert(pending_action.is_empty()); // in case of reschedule must not have already pending.
 
       // If the queue is disabled, reschedule.
-      if (t_state.http_config_param->outbound_conntrack.queue_size < 0) {
+      if (t_state.http_config_param->global_outbound_conntrack.queue_size < 0) {
         ct_state.enqueue();
         ct_state.rescheduled();
-        pending_action =
-          eventProcessor.schedule_in(this, HRTIME_MSECONDS(t_state.http_config_param->outbound_conntrack.queue_delay.count()));
-      } else if (t_state.http_config_param->outbound_conntrack.queue_size > 0) { // queue enabled, check for a slot
+        pending_action = eventProcessor.schedule_in(
+          this, HRTIME_MSECONDS(t_state.http_config_param->global_outbound_conntrack.queue_delay.count()));
+      } else if (t_state.http_config_param->global_outbound_conntrack.queue_size > 0) { // queue enabled, check for a slot
         auto wcount = ct_state.enqueue();
-        if (wcount < t_state.http_config_param->outbound_conntrack.queue_size) {
+        if (wcount < t_state.http_config_param->global_outbound_conntrack.queue_size) {
           ct_state.rescheduled();
           SMDebug("http", "%s", lbw().print("[{}] queued for {}\0", sm_id, t_state.current.server->dst_addr).data());
-          pending_action =
-            eventProcessor.schedule_in(this, HRTIME_MSECONDS(t_state.http_config_param->outbound_conntrack.queue_delay.count()));
+          pending_action = eventProcessor.schedule_in(
+            this, HRTIME_MSECONDS(t_state.http_config_param->global_outbound_conntrack.queue_delay.count()));
         } else {              // the queue is full
           ct_state.dequeue(); // release the queue slot
           ct_state.blocked(); // note the blockage.


### PR DESCRIPTION
Trying to reduce confusion between the following two structures.
```
OutboundConnTrack::TxnConfig outbound_conntrack;
OutboundConnTrack::GlobalConfig outbound_conntrack;
```
This is a follow up of https://github.com/apache/trafficserver/pull/8328

_Open for discussion how to make this a bit better._
