### PR TITLE
Add <limits> include to BufferWriterForward.h

### DIFF
--- a/include/tscore/BufferWriterForward.h
+++ b/include/tscore/BufferWriterForward.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <limits>
 #include <utility>
 #include <cstring>
 #include <vector>


### PR DESCRIPTION
Adding the include of <limits> in BufferWriterForward.h because it uses
numeric_limits. Certain compilers require this.

Fixes: #8342

---

I reproduced the #8342 build failure locally on the 8.1.x branch without this change, and verified that this patch fixes Fedora 34 GCC 11 builds.