### PR TITLE
Add <limits> include to BufferWriterForward.h (#8345)

### DIFF
--- a/include/tscore/BufferWriterForward.h
+++ b/include/tscore/BufferWriterForward.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <limits>
 #include <utility>
 #include <cstring>
 #include <vector>


### PR DESCRIPTION
Adding the include of <limits> in BufferWriterForward.h because it uses
numeric_limits. Certain compilers require this.

Fixes: #8342
(cherry picked from commit 4507d5e1167cb39837572017e72e096ad7b438fd)

---

This PR ports #8345 to 8.1.x