### PR TITLE
Fix yamlcpp include folder by using the YAMLCPP_INCLUDE variable (#8319)

### DIFF
--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -39,7 +39,7 @@ AM_CPPFLAGS += \
 	-I$(abs_srcdir)/hdrs \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	-I$(abs_top_srcdir)/lib/yamlcpp/include \
+	@YAMLCPP_INCLUDES@ \
 	$(TS_INCLUDES)
 
 noinst_HEADERS = \


### PR DESCRIPTION
so if we configure our own version of yamlcpp then the right include files will be picked up.
This will avoid mixin up the internal and the configured yamlcpp library

(cherry picked from commit 922a47013baf37fadbcc55dbe7b76d163a30020a)

Conflicts:
    mgmt/Makefile.am