### PR TITLE
remove unused RecConfigFileEntry struct

### DIFF
--- a/lib/records/P_RecDefs.h
+++ b/lib/records/P_RecDefs.h
@@ -58,11 +58,6 @@ enum RecEntryT {
   RECE_RECORD,
 };
 
-struct RecConfigFileEntry {
-  RecEntryT entry_type;
-  char *entry;
-};
-
 typedef struct RecConfigCbList_t {
   RecConfigUpdateCb update_cb;
   void *update_cookie;


### PR DESCRIPTION
Follow up to e52009cee1ccccff154b2dc3955697d2adb6bb05