### PR TITLE
remap_stats: ensure hostname is deleted in txn_close

### DIFF
--- a/tests/gold_tests/pluginTest/remap_stats/gold/metrics.gold
+++ b/tests/gold_tests/pluginTest/remap_stats/gold/metrics.gold
@@ -1,0 +1,2 @@
+plugin.remap_stats.one.status_2xx 1
+plugin.remap_stats.two.status_4xx 1

--- a/tests/gold_tests/pluginTest/remap_stats/metrics.sh
+++ b/tests/gold_tests/pluginTest/remap_stats/metrics.sh
@@ -1,0 +1,33 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+N=60
+while (( N > 0 ))
+do
+    rm -f metrics.out
+    traffic_ctl metric match \.remap_stats\. \
+      | grep status \
+      | sort \
+        > metrics.out
+    sleep 1
+    if diff metrics.out ${AUTEST_TEST_DIR}/gold/metrics.gold
+    then
+        exit 0
+    fi
+    let N=N-1
+done
+echo TIMEOUT
+exit 1

--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
@@ -19,9 +19,10 @@ Test remap_stats plugin
 '''
 # Skip if plugins not present.
 Test.SkipUnless(Condition.PluginExists('remap_stats.so'))
-Test.SkipIf(Condition.true("Test cannot deterministically wait until the stats appear"))
 
 server = Test.MakeOriginServer("server")
+
+Test.Setup.Copy("metrics.sh")
 
 request_header = {
     "headers": "GET /argh HTTP/1.1\r\nHost: one\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -64,13 +65,7 @@ tr.StillRunningAfter = server
 
 # 2 Test - Gather output
 tr = Test.AddTestRun("analyze stats")
-tr.Processes.Default.Command = r'traffic_ctl metric match \.\*remap_stats\*'
+tr.Processes.Default.Command = "bash -c ./metrics.sh"
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.TimeOut = 5
-tr.DelayStart = 15
-tr.TimeOut = 5
-tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
-    "plugin.remap_stats.one.status_2xx 1", "expected 2xx on first remap")
-tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-    "plugin.remap_stats.two.status_4xx 1", "expected 4xx on second remap")
+tr.StillRunningAfter = ts


### PR DESCRIPTION
The logic left a hole where hostname might not be deallocated.  Closes this hole.
Also reenables the autest by using a polling shell script on the traffic_ctl metrics match call.