### PR TITLE
Stabilize regex_revalidate Au test.

### DIFF
--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -147,7 +147,7 @@ ts.Disk.remap_config.AddLine(
 # minimal configuration
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'regex_revalidate',
+    'proxy.config.diags.debug.tags': 'http|regex_revalidate',
     #    'proxy.config.diags.debug.enabled': 0,
     'proxy.config.http.insert_age_in_response': 0,
     'proxy.config.http.response_via_str': 3,
@@ -185,6 +185,10 @@ tr.StillRunningAfter = ts
 
 # 4 Stage - Reload new regex_revalidate
 tr = Test.AddTestRun("Reload config add path1")
+# Need a sufficient delay so that the modification time difference of the new config file versus
+# the old is greater than the granularity of the time stamp used.  (The config file write
+# happens after the delay.)
+tr.DelayStart = 1
 tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
     path1_rule
 ])
@@ -214,6 +218,10 @@ tr.StillRunningAfter = ts
 
 # 7 Stage - Reload new regex_revalidate
 tr = Test.AddTestRun("Reload config add path2")
+# Need a sufficient delay so that the modification time difference of the new config file versus
+# the old is greater than the granularity of the time stamp used.  (The config file write
+# happens after the delay.)
+tr.DelayStart = 1
 tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
     path1_rule,
     'path2 {}\n'.format(int(time.time()) + 700)
@@ -247,6 +255,10 @@ tr.StillRunningAfter = ts
 
 # 10 Stage - regex_revalidate rewrite rule early expire
 tr = Test.AddTestRun("Reload config change path2")
+# Need a sufficient delay so that the modification time difference of the new config file versus
+# the old is greater than the granularity of the time stamp used.  (The config file write
+# happens after the delay.)
+tr.DelayStart = 1
 tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
     path1_rule,
     'path2 {}\n'.format(int(time.time()) - 100),


### PR DESCRIPTION
Delay sufficiently between writes of config file so the differences in the write times will be greater
than the granualirity of the timestamp used by the plugin.

(cherry picked from commit 9031965889ab430bd182dd5485ecda451ecb6a8a)