### PR TITLE
remap_stats: convert to using TSHttpTxnPristineUrlGet and TSHttpTxnClienReqGet

### DIFF
--- a/tests/gold_tests/pluginTest/remap_stats/gold/metrics.gold
+++ b/tests/gold_tests/pluginTest/remap_stats/gold/metrics.gold
@@ -1,0 +1,2 @@
+plugin.remap_stats.one.status_2xx 1
+plugin.remap_stats.two.status_4xx 1

--- a/tests/gold_tests/pluginTest/remap_stats/gold/metrics_post.gold
+++ b/tests/gold_tests/pluginTest/remap_stats/gold/metrics_post.gold
@@ -1,0 +1,2 @@
+plugin.remap_stats.127.0.0.1.status_2xx 1
+plugin.remap_stats.127.0.0.1.status_4xx 1

--- a/tests/gold_tests/pluginTest/remap_stats/metrics.sh
+++ b/tests/gold_tests/pluginTest/remap_stats/metrics.sh
@@ -1,0 +1,33 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+N=60
+while (( N > 0 ))
+do
+    rm -f metrics.out
+    traffic_ctl metric match \.remap_stats\. \
+      | grep status \
+      | sort \
+        > metrics.out
+    sleep 1
+    if diff metrics.out "${AUTEST_TEST_DIR}/gold/metrics.gold"
+    then
+        exit 0
+    fi
+    let N=N-1
+done
+echo TIMEOUT
+exit 1

--- a/tests/gold_tests/pluginTest/remap_stats/metrics_post.sh
+++ b/tests/gold_tests/pluginTest/remap_stats/metrics_post.sh
@@ -1,0 +1,33 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+N=60
+while (( N > 0 ))
+do
+    rm -f metrics.out
+    traffic_ctl metric match \.remap_stats\. \
+      | grep status \
+      | sort \
+        > metrics.out
+    sleep 1
+    if diff metrics.out "${AUTEST_TEST_DIR}/gold/metrics_post.gold"
+    then
+        exit 0
+    fi
+    let N=N-1
+done
+echo TIMEOUT
+exit 1

--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats_post.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats_post.test.py
@@ -22,7 +22,7 @@ Test.SkipUnless(Condition.PluginExists('remap_stats.so'))
 
 server = Test.MakeOriginServer("server")
 
-Test.Setup.Copy("metrics.sh")
+Test.Setup.Copy("metrics_post.sh")
 
 request_header = {
     "headers": "GET /argh HTTP/1.1\r\nHost: one\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -32,7 +32,7 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True)
 
-ts.Disk.plugin_config.AddLine('remap_stats.so')
+ts.Disk.plugin_config.AddLine('remap_stats.so --post-remap-host')
 
 ts.Disk.remap_config.AddLine(
     "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
@@ -65,7 +65,7 @@ tr.StillRunningAfter = server
 
 # 2 Test - Gather output
 tr = Test.AddTestRun("analyze stats")
-tr.Processes.Default.Command = 'bash -c ./metrics.sh'
+tr.Processes.Default.Command = 'bash -c ./metrics_post.sh'
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts


### PR DESCRIPTION
remap_stats: convert to using TSHttpTxnPristineUrlGet and TSHttpTxnClienReqGet only during TXN_CLOSE hook.
remove pre remap continuation
post remap continuation now only sets a value.
also fixes and adds an autest for --post-remap-host
Includes memory leak fix for hostname when the old post_remap hook wasn't hit.

Regression tested for some days using the default (post remap) configuration with cloned prod traffic.  Also flipped to using -P (pristine) and values seem to match.