### PR TITLE
Added support for promoting internal (plugin-initiated) requests.

### DIFF
--- a/doc/admin-guide/plugins/cache_promote.en.rst
+++ b/doc/admin-guide/plugins/cache_promote.en.rst
@@ -77,7 +77,11 @@ If :option:`--policy` is set to ``lru`` the following options are also available
 *  **plugin.cache_promote.${remap-identifier}.promoted** - count requests promoted, available in all policies.
 *  **plugin.cache_promote.${remap-identifier}.total_requests** - count of all requests.
 
-These two options combined with your usage patterns will control how likely a
+.. option:: --internal-enabled
+
+   Allow cache promote to operate on internal (plugin-initiated) requests.
+
+These options combined with your usage patterns will control how likely a
 URL is to become promoted to enter the cache.
 
 Examples

--- a/plugins/cache_promote/cache_promote.cc
+++ b/plugins/cache_promote/cache_promote.cc
@@ -50,7 +50,7 @@ cont_handle_policy(TSCont contp, TSEvent event, void *edata)
   switch (event) {
   // After the cache lookups check if it should be promoted on cache misses
   case TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE:
-    if (!TSHttpTxnIsInternal(txnp)) {
+    if (!TSHttpTxnIsInternal(txnp) || config->getPolicy()->isInternalEnabled()) {
       int obj_status;
 
       if (TS_ERROR != TSHttpTxnCacheLookupStatusGet(txnp, &obj_status)) {

--- a/plugins/cache_promote/configs.cc
+++ b/plugins/cache_promote/configs.cc
@@ -34,6 +34,7 @@ static const struct option longopt[] = {
   {const_cast<char *>("hits"), required_argument, nullptr, 'h'},
   {const_cast<char *>("bytes"), required_argument, nullptr, 'B'},
   {const_cast<char *>("label"), required_argument, nullptr, 'l'},
+  {const_cast<char *>("internal-enabled"), no_argument, nullptr, 'i'},
   // EOF
   {nullptr, no_argument, nullptr, '\0'},
 };
@@ -80,6 +81,9 @@ PromotionConfig::factory(int argc, char *argv[])
         // The --sample (-s) option is allowed for all configs, but only after --policy is specified.
         if (opt == 's') {
           _policy->setSample(optarg);
+        } else if (opt == 'i') {
+          _policy->setInternalEnabled(true);
+          TSDebug(PLUGIN_NAME, "internal_enabled set to true");
         } else {
           if (!_policy->parseOption(opt, optarg)) {
             TSError("[%s] The specified policy (%s) does not support the -%c option", PLUGIN_NAME, _policy->policyName(), opt);

--- a/plugins/cache_promote/lru_policy.h
+++ b/plugins/cache_promote/lru_policy.h
@@ -120,7 +120,8 @@ public:
   const std::string
   id() const override
   {
-    return _label + ";LRU=b:" + std::to_string(_buckets) + ",h:" + std::to_string(_hits) + ",B:" + std::to_string(_bytes);
+    return _label + ";LRU=b:" + std::to_string(_buckets) + ",h:" + std::to_string(_hits) + ",B:" + std::to_string(_bytes) +
+           ",i:" + std::to_string(_internal_enabled);
   }
 
   void

--- a/plugins/cache_promote/policy.h
+++ b/plugins/cache_promote/policy.h
@@ -102,6 +102,18 @@ public:
   {
   }
 
+  bool
+  isInternalEnabled() const
+  {
+    return _internal_enabled;
+  }
+
+  void
+  setInternalEnabled(const bool enabled)
+  {
+    _internal_enabled = enabled;
+  }
+
   bool doSample() const;
   int create_stat(std::string_view name, std::string_view remap_identifier);
 
@@ -113,6 +125,7 @@ public:
 
   // when true stats are incremented.
   bool _stats_enabled    = false;
+  bool _internal_enabled = false;
   int _cache_hits_id     = -1;
   int _promoted_id       = -1;
   int _total_requests_id = -1;


### PR DESCRIPTION
* Allows an operator to specify whether or not internal requests are considered for promotion through a configuration option