### PR TITLE
Fixes issue #8366, assertion failure in HttpTransact.cc::is_response_valid()

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -331,7 +331,7 @@ HttpTransact::is_response_valid(State *s, HTTPHdr *incoming_response)
     ink_assert((s->current.state == CONNECTION_ERROR) || (s->current.state == OPEN_RAW_ERROR) ||
                (s->current.state == PARSE_ERROR) || (s->current.state == CONNECTION_CLOSED) ||
                (s->current.state == INACTIVE_TIMEOUT) || (s->current.state == ACTIVE_TIMEOUT) ||
-               s->current.state == OUTBOUND_CONGESTION);
+               (s->current.state == BAD_INCOMING_RESPONSE) || s->current.state == OUTBOUND_CONGESTION);
 
     s->hdr_info.response_error = CONNECTION_OPEN_FAILED;
     return false;


### PR DESCRIPTION
Fixes #8366 An assertion failure occurs at HttpTransact::is_response_valid() when the current.state is BAD_INCOMING_RESPONSE.  I ran into this while testing Nexthop strategies and parent selection with a down unreachable parent.

This ink_assert() check was added with PR #6782 - NextHopStrategy Refactor and Fixes.

