### PR TITLE
TSSslSecretSet: Update SSL_CTX TLS Secrets

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -573,6 +573,9 @@ SSLCertificateConfig::acquire()
 void
 SSLCertificateConfig::release(SSLCertLookup *lookup)
 {
+  if (lookup == nullptr) {
+    return;
+  }
   configProcessor.release(configid, lookup);
 }
 

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1747,6 +1747,13 @@ SSLMultiCertConfigLoader::update_ssl_ctx(const std::string &secret_name)
   bool retval = true;
 
   SSLCertificateConfig::scoped_config lookup;
+  if (!lookup) {
+    // SSLCertificateConfig is still being configured, thus there are no SSL
+    // contexts to update. This situation can happen during startup if a
+    // registered hook updates certs before SSLCertContext configuration is
+    // complete.
+    return retval;
+  }
   std::set<shared_SSLMultiCertConfigParams> policies;
   lookup->getPolicies(secret_name, policies);
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -9511,15 +9511,19 @@ TSSslSecretSet(const char *secret_name, int secret_name_length, const char *secr
   SSLConfigParams *load_params = SSLConfig::load_acquire();
   SSLConfigParams *params      = SSLConfig::acquire();
   if (load_params != nullptr) { // Update the current data structure
+    Debug("ssl.cert_update", "Setting secrets in SSLConfig load for: %.*s", secret_name_length, secret_name);
     if (!load_params->secrets.setSecret(std::string(secret_name, secret_name_length), secret_data, secret_data_len)) {
       retval = TS_ERROR;
     }
-    SSLConfig::load_release(params);
+    load_params->updateCTX(std::string(secret_name, secret_name_length));
+    SSLConfig::load_release(load_params);
   }
   if (params != nullptr) {
+    Debug("ssl.cert_update", "Setting secrets in SSLConfig for: %.*s", secret_name_length, secret_name);
     if (!params->secrets.setSecret(std::string(secret_name, secret_name_length), secret_data, secret_data_len)) {
       retval = TS_ERROR;
     }
+    params->updateCTX(std::string(secret_name, secret_name_length));
     SSLConfig::release(params);
   }
   return retval;


### PR DESCRIPTION
TSSslSecretSet previously updated the in-memory certificate data stored
in SSLSecret, but did not update the stored SSL_CTX certificates. As a
result, any newly created SSL contexts would get the updated secret
while the previously stored contexts would still use the old secrets.
This patch updates TSSslSecretSet to also update the secrets for stored
SSL_CTX objects.

This also fixes the related SSLSecret debug logging which had formatting
issues, rendering their output unreadable.