### PR TITLE
Revert "TSSslSecretSet: Update SSL_CTX TLS Secrets"

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -573,9 +573,6 @@ SSLCertificateConfig::acquire()
 void
 SSLCertificateConfig::release(SSLCertLookup *lookup)
 {
-  if (lookup == nullptr) {
-    return;
-  }
   configProcessor.release(configid, lookup);
 }
 

--- a/iocore/net/SSLSecret.cc
+++ b/iocore/net/SSLSecret.cc
@@ -82,7 +82,7 @@ SSLSecret::setSecret(const std::string &name, const char *data, int data_len)
     return false;
   }
   iter->second.assign(data, data_len);
-  Debug("ssl_secret", "Set secret for %s to %.*s", name.c_str(), static_cast<int>(iter->second.size()), iter->second.data());
+  Debug("secret_ssl", "Set secret=%10.s... to %*.s", name.c_str(), static_cast<int>(iter->second.size()), iter->second.data());
   return true;
 }
 
@@ -102,10 +102,9 @@ SSLSecret::getSecret(const std::string &name, std::string_view &data) const
 {
   const std::string *data_item = this->getSecretItem(name);
   if (data_item) {
-    Debug("ssl_secret", "Get secret for %s: %.*s", name.c_str(), static_cast<int>(data_item->length()), data_item->data());
+    Debug("secret_ssl", "Get secret=%10.s...  %s(%zd)", name.c_str(), data_item->data(), data_item->length());
     data = *data_item;
   } else {
-    Debug("ssl_secret", "Get secret for %s: not found", name.c_str());
     data = std::string_view{};
   }
   return data_item != nullptr;
@@ -114,12 +113,11 @@ SSLSecret::getSecret(const std::string &name, std::string_view &data) const
 bool
 SSLSecret::getOrLoadSecret(const std::string &name1, const std::string &name2, std::string_view &data1, std::string_view &data2)
 {
-  Debug("ssl_secret", "lookup up secrets for %s and %s", name1.c_str(), name2.c_str());
   std::scoped_lock lock(secret_map_mutex);
   bool found_secret1 = this->getSecret(name1, data1);
   bool found_secret2 = name2.empty() || this->getSecret(name2, data2);
 
-  // If we can't find either secret, load them both again
+  // If we can't find either secret, load the both again
   if (!found_secret1 || !found_secret2) {
     // Make sure each name has an entry
     if (!found_secret1) {

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1747,13 +1747,6 @@ SSLMultiCertConfigLoader::update_ssl_ctx(const std::string &secret_name)
   bool retval = true;
 
   SSLCertificateConfig::scoped_config lookup;
-  if (!lookup) {
-    // SSLCertificateConfig is still being configured, thus there are no SSL
-    // contexts to update. This situation can happen during startup if a
-    // registered hook updates certs before SSLCertContext configuration is
-    // complete.
-    return retval;
-  }
   std::set<shared_SSLMultiCertConfigParams> policies;
   lookup->getPolicies(secret_name, policies);
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -9511,19 +9511,15 @@ TSSslSecretSet(const char *secret_name, int secret_name_length, const char *secr
   SSLConfigParams *load_params = SSLConfig::load_acquire();
   SSLConfigParams *params      = SSLConfig::acquire();
   if (load_params != nullptr) { // Update the current data structure
-    Debug("ssl.cert_update", "Setting secrets in SSLConfig load for: %.*s", secret_name_length, secret_name);
     if (!load_params->secrets.setSecret(std::string(secret_name, secret_name_length), secret_data, secret_data_len)) {
       retval = TS_ERROR;
     }
-    load_params->updateCTX(std::string(secret_name, secret_name_length));
-    SSLConfig::load_release(load_params);
+    SSLConfig::load_release(params);
   }
   if (params != nullptr) {
-    Debug("ssl.cert_update", "Setting secrets in SSLConfig for: %.*s", secret_name_length, secret_name);
     if (!params->secrets.setSecret(std::string(secret_name, secret_name_length), secret_data, secret_data_len)) {
       retval = TS_ERROR;
     }
-    params->updateCTX(std::string(secret_name, secret_name_length));
     SSLConfig::release(params);
   }
   return retval;


### PR DESCRIPTION
Reverts apache/trafficserver#8368

---

I'm reverting this because I noticed in further testing that this change causes issues with OCSP.