### PR TITLE
Add a set-http-cntl operator for header_rewrite

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -703,6 +703,9 @@ the appropriate logs even when the debug tag has not been enabled. For
 additional information on |TS| debugging statements, refer to
 :ref:`developer-debug-tags` in the developer's documentation.
 
++**Note**: This operator is deprecated, use the ``set-http-cntl`` operator instead,
++with the ``TXN_DEBUG`` control.
+
 set-destination
 ~~~~~~~~~~~~~~~
 ::
@@ -794,6 +797,9 @@ When invoked, and when ``<value>`` is any of ``1``, ``true``, or ``TRUE``, this
 operator causes |TS| to abort further request remapping. Any other value and
 the operator will effectively be a no-op.
 
+**Note**: This operator is deprecated, use the ``set-http-cntl`` operator instead,
+with the ``SKIP_REMAP`` control.
+
 set-cookie
 ~~~~~~~~~~
 ::
@@ -802,6 +808,28 @@ set-cookie
 
 Replaces the value of cookie ``<name>`` with ``<value>``, creating the cookie
 if necessary.
+
+set-http-cntl
+~~~~~~~~~~~~~
+;;
+
+  set-http-cntl <controller> <flag>
+
+This operator lets you turn off (or on) the logging for a particular transaction.
+The ``<flag>`` is any of ``0``, ``off``, and ``false``, or ``1``, ``on`` and ``true``.
+The available controllers are:
+
+================ ====================================================================
+Controller       Description
+================ ====================================================================
+LOGGING          Turns off logging for the transction (default: ``on``)
+INTERCEPT_RETRY  Allow intercepts to be retried (default: ``off``)
+RESP_CACHEABLE   Force the response to be cacheable (default: ``off``)
+REQ_CACHEABLE    Force the request to be cacheable (default: ``off``)
+SERVER_NO_STORE  Don't allow the response to be written to cache (default: ``off``)
+TXN_DEBUG        Enable transaction debugging (default: ``off``)
+SKIP_REMAP       Don't require a remap match for the transaction (default: ``off``)
+================ ====================================================================
 
 Operator Flags
 --------------

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -73,6 +73,9 @@ operator_factory(const std::string &op)
     o = new OperatorSetDebug();
   } else if (op == "set-body") {
     o = new OperatorSetBody();
+  } else if (op == "set-http-cntl") {
+    o = new OperatorSetHttpCntl();
+
   } else {
     TSError("[%s] Unknown operator: %s", PLUGIN_NAME, op.c_str());
     return nullptr;

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -423,3 +423,23 @@ protected:
 private:
   Value _value;
 };
+
+class OperatorSetHttpCntl : public Operator
+{
+public:
+  OperatorSetHttpCntl() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for OperatorSetHttpCntl"); }
+
+  // noncopyable
+  OperatorSetHttpCntl(const OperatorSetHttpCntl &) = delete;
+  void operator=(const OperatorSetHttpCntl &) = delete;
+
+  void initialize(Parser &p) override;
+
+protected:
+  void initialize_hooks() override;
+  void exec(const Resources &res) const override;
+
+private:
+  bool _flag = false;
+  TSHttpCntlType _cntl_qual;
+};

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -69,6 +69,13 @@ public:
     return _val;
   }
 
+  // Return a copy of the string, this implies RVO as well
+  std::string
+  copy_value() const
+  {
+    return _val;
+  }
+
   bool
   mod_exist(const std::string &m) const
   {


### PR DESCRIPTION
This supports all the controllers that the new InkAPI supports, unclear if all or any of them are useful here. But the LOGGING controller definitely is.

```
        LOGGING          TS_HTTP_CNTL_LOGGING_MODE
        INTERCEPT_RETRY  TS_HTTP_CNTL_INTERCEPT_RETRY_MODE
        RESP_CACHEABLE   TS_HTTP_CNTL_RESPONSE_CACHEABLE
        REQ_CACHEABLE    TS_HTTP_CNTL_REQUEST_CACHEABLE
        SERVER_NO_STORE  TS_HTTP_CNTL_SERVER_NO_STORE
        TXN_DEBUG        TS_HTTP_CNTL_TXN_DEBUG
        SKIP_REMAP       TS_HTTP_CNTL_SKIP_REMAPPING
```