### PR TITLE
Fix a potential H2 stall

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1655,6 +1655,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
 
   if (this->session->write_avail() == 0) {
     Http2StreamDebug(this->session, stream->get_id(), "Not write avail");
+    this->session->flush();
     return Http2SendDataFrameResult::NOT_WRITE_AVAIL;
   }
 


### PR DESCRIPTION
I was looking into an H2 stall issue on production, and the cause was in code that hasn't been publicly available yet, but realized that this code has the same issue. Like "no window" case, we need to call `flush()` here, otherwise data can stay in write_buffer forever.