### PR TITLE
Traffic Dump: update json-schema for new tuple requirements

### DIFF
--- a/tests/tools/lib/replay_schema.json
+++ b/tests/tools/lib/replay_schema.json
@@ -135,7 +135,7 @@
           "items": {
             "description": "HTTP field.",
             "type": "array",
-            "items": [
+            "prefixItems": [
               {
                 "description": "Name of the field.",
                 "type": "string"


### PR DESCRIPTION
This is a backport of #8370 to 8.1.x

---

More recent versions of json-schema have tuple array element
specifications described with "prefixItems" rather than with "items".
This updates our Traffic Dump schema to match this requirement.

I verified that our tests that use this work with both the older
jsonschema 3.2.0 pip package and the current 4.0.1 package.

Fixes: 8369
(cherry picked from commit cba5e85cb4cfd8f49b1ff1ac358f7cfba8ee3715)