### PR TITLE
body factory does not respect runroot

### DIFF
--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -89,7 +89,7 @@ RecConfigOverrideFromRunroot(const char *name)
   if (!get_runroot().empty()) {
     if (!strcmp(name, "proxy.config.bin_path") || !strcmp(name, "proxy.config.local_state_dir") ||
         !strcmp(name, "proxy.config.log.logfile_dir") || !strcmp(name, "proxy.config.plugin.plugin_dir") ||
-        !strcmp(name, "proxy.config.hostdb.storage_path")) {
+        !strcmp(name, "proxy.config.hostdb.storage_path") || !strcmp(name, "proxy.config.body_factory.template_sets_dir")) {
       return true;
     }
   }

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -282,7 +282,13 @@ HttpBodyFactory::reconfigure()
   rec_err   = RecGetRecordString_Xmalloc("proxy.config.body_factory.template_sets_dir", &s);
   all_found = all_found && (rec_err == REC_ERR_OKAY);
   if (rec_err == REC_ERR_OKAY) {
-    directory_of_template_sets = Layout::get()->relative(s);
+    // check if we should tweak with run_root value
+    if (s && strlen(s) > 0) {
+      // the value is set via config file or ENV var
+      directory_of_template_sets = Layout::get()->relative(s);
+    } else {
+      directory_of_template_sets = Layout::relative_to(RecConfigReadConfigDir(), "body_factory");
+    }
     if (access(directory_of_template_sets, R_OK) < 0) {
       Warning("Unable to access() directory '%s': %d, %s", (const char *)directory_of_template_sets, errno, strerror(errno));
       Warning(" Please set 'proxy.config.body_factory.template_sets_dir' ");


### PR DESCRIPTION
Current logic with body_factory is that it will use the prefix value and the compile-time logic for the config dir. When a run_root.yaml file uses a different path structure for the config dir such as config/trafficserver instead of build time etc/trafficserver, Trafficserver will fail to load the body_factory templates. This patch addresses this issues