### PR TITLE
TSMLoc should be considered volatile

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -602,14 +602,16 @@ globalHookHandler(TSCont contp, TSEvent event ATS_UNUSED, void *edata)
   http_ctx->rri      = NULL;
   http_ctx->has_hook = 0;
 
-  if (!http_ctx->client_request_bufp) {
-    if (TSHttpTxnClientReqGet(txnp, &bufp, &hdr_loc) == TS_SUCCESS) {
-      http_ctx->client_request_bufp = bufp;
-      http_ctx->client_request_hdrp = hdr_loc;
+  // This is a memory location relative to a header heap represented by a TSMBuffer and must always
+  // be used in conjunction with that TSMBuffer instance. It identifies a specific object in the TSMBuffer.
+  // This indirection is needed so that the TSMBuffer can reallocate space as needed. Therefore a raw address
+  // obtained from a TSMLoc should be considered volatile that may become invalid across any API call.
+  if (TSHttpTxnClientReqGet(txnp, &bufp, &hdr_loc) == TS_SUCCESS) {
+    http_ctx->client_request_bufp = bufp;
+    http_ctx->client_request_hdrp = hdr_loc;
 
-      if (TSHttpHdrUrlGet(bufp, hdr_loc, &url_loc) == TS_SUCCESS) {
-        http_ctx->client_request_url = url_loc;
-      }
+    if (TSHttpHdrUrlGet(bufp, hdr_loc, &url_loc) == TS_SUCCESS) {
+      http_ctx->client_request_url = url_loc;
     }
   }
 

--- a/plugins/lua/ts_lua_util.c
+++ b/plugins/lua/ts_lua_util.c
@@ -675,6 +675,9 @@ ts_lua_destroy_http_ctx(ts_lua_http_ctx *http_ctx)
 
   if (http_ctx->rri == NULL) {
     if (http_ctx->client_request_bufp) {
+      if (http_ctx->client_request_url) {
+        TSHandleMLocRelease(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, http_ctx->client_request_url);
+      }
       TSHandleMLocRelease(http_ctx->client_request_bufp, TS_NULL_MLOC, http_ctx->client_request_hdrp);
     }
   }


### PR DESCRIPTION
This essentially reverts https://github.com/apache/trafficserver/commit/63400cb4f75873c92352eadecf4510d8893782da

We've been seeing some lua plugin related crashes recently, and noticed that it's because the location was reused. Also, found this in the docs https://docs.trafficserver.apache.org/en/latest/developer-guide/api/functions/TSTypes.en.html#c.TSMLoc