### PR TITLE
AuTest: Execute Test Python Scripts with sys.executable

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -35,6 +35,7 @@ dnslib = "*"
 requests = "*"
 gunicorn = "*"
 httpbin = "*"
+psutil = "*"
 
 # Keep init.cli.ext updated with this required microserver version.
 microserver = ">=1.0.6"

--- a/tests/gold_tests/basic/deny0.test.py
+++ b/tests/gold_tests/basic/deny0.test.py
@@ -18,6 +18,8 @@ Test that Trafficserver rejects requests for host 0
 #  limitations under the License.
 
 import os
+import sys
+
 Test.Summary = '''
 Test that Trafficserver rejects requests for host 0
 '''
@@ -61,10 +63,13 @@ def buildMetaTest(testName, requestString):
         tr.Processes.Default.StartBefore(ts)
         tr.Processes.Default.StartBefore(redirect_serv, ready=When.PortOpen(redirect_serv.Variables.Port))
         tr.Processes.Default.StartBefore(dns)
-    with open(os.path.join(data_path, tr.Name), 'w') as f:
+
+    requestCommandPath = os.path.join(data_path, tr.Name)
+    with open(requestCommandPath, 'w') as f:
         f.write(requestString)
-    tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | head -1".format(
-        ts.Variables.port, os.path.join(data_dirname, tr.Name))
+    tr.Processes.Default.Command = \
+        (f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} "
+         f"{requestCommandPath} | head -1")
     tr.ReturnCode = 0
     tr.Processes.Default.Streams.stdout = gold_filepath
     tr.StillRunningAfter = ts

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -17,6 +17,8 @@
 #  limitations under the License.
 
 import os
+import sys
+
 Test.Summary = '''
 Test a basic remap of a http/2 connection
 '''
@@ -143,7 +145,7 @@ ts.Setup.CopyAs('h2active_timeout.py', Test.RunDirectory)
 
 # Test Case 1:  basic H2 interaction
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 h2client.py -p {0}'.format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = f'{sys.executable} h2client.py -p {ts.Variables.ssl_port}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -152,14 +154,14 @@ tr.StillRunningAfter = server
 
 # Test Case 2: Make sure all the big file gets back.  Regression test for issue 1646
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 h2bigclient.py -p {0}'.format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = f'{sys.executable} h2bigclient.py -p {ts.Variables.ssl_port}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/bigfile.gold"
 tr.StillRunningAfter = server
 
 # Test Case 3: Chunked content
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 h2chunked.py -p {0}  -u /test2'.format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = f'{sys.executable} h2chunked.py -p {ts.Variables.ssl_port}  -u /test2'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/chunked.gold"
 tr.StillRunningAfter = server
@@ -168,15 +170,16 @@ tr.StillRunningAfter = server
 # Test Case 4: Multiple request
 # client_path = os.path.join(Test.Variables.AtsTestToolsDir, 'traffic-replay/')
 # tr = Test.AddTestRun()
-# tr.Processes.Default.Command = "python3 {0} -type {1} -log_dir {2} -port {3} -host '127.0.0.1' -s_port {4} -v -colorize False".format(
-#     client_path, 'h2', server.Variables.DataDir, ts.Variables.port, ts.Variables.ssl_port)
+# tr.Processes.Default.Command = \
+#     (f"{sys.executable} {client_path} -type h2 -log_dir {server.Variables.DataDir} "
+#      f"-port {ts.Variables.port} -host '127.0.0.1' -s_port {ts.Variables.ssl_port} -v -colorize False")
 # tr.Processes.Default.ReturnCode = 0
 # tr.Processes.Default.Streams.stdout = "gold/replay.gold"
 # tr.StillRunningAfter = server
 
 # Test Case 5: h2_active_timeout
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 h2active_timeout.py -p {0} -d 4'.format(ts.Variables.ssl_port)
+tr.Processes.Default.Command = f'{sys.executable} h2active_timeout.py -p {ts.Variables.ssl_port} -d 4'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/active_timeout.gold"
 tr.StillRunningAfter = server

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+import sys
 
 # ----
 # Setup Test
@@ -75,8 +76,8 @@ logging:
 Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'access.log'), exists=True, content='gold/httpbin_access.gold')
 
 # TODO: when httpbin 0.8.0 or later is released, remove below json pretty print hack
-json_printer = '''
-python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2, separators=(',', ': ')))"
+json_printer = f'''
+{sys.executable} -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2, separators=(',', ': ')))"
 '''
 
 # ----

--- a/tests/gold_tests/headers/domain-blacklist-30x.test.py
+++ b/tests/gold_tests/headers/domain-blacklist-30x.test.py
@@ -18,6 +18,7 @@ Tests 30x responses are returned for matching domains
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Tests 30x responses are returned for matching domains
@@ -56,57 +57,51 @@ set-redirect {0} "%{{CLIENT-URL}}"
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
 
-redirect301tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_301_HOST))
+redirect301tr = Test.AddTestRun(f"Test domain {REDIRECT_301_HOST}")
 redirect301tr.Processes.Default.StartBefore(Test.Processes.ts)
 redirect301tr.StillRunningAfter = ts
-redirect301tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_301_HOST))
+redirect301tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} data/{REDIRECT_301_HOST}_get.txt | grep -v '^Date: '| grep -v '^Server: ATS/'"
 redirect301tr.Processes.Default.TimeOut = 5  # seconds
 redirect301tr.Processes.Default.ReturnCode = 0
 redirect301tr.Processes.Default.Streams.stdout = "redirect301_get.gold"
 
-redirect302tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_302_HOST))
+redirect302tr = Test.AddTestRun(f"Test domain {REDIRECT_302_HOST}")
 redirect302tr.StillRunningBefore = ts
 redirect302tr.StillRunningAfter = ts
-redirect302tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_302_HOST))
+redirect302tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} data/{REDIRECT_302_HOST}_get.txt | grep -v '^Date: '| grep -v '^Server: ATS/'"
 redirect302tr.Processes.Default.TimeOut = 5  # seconds
 redirect302tr.Processes.Default.ReturnCode = 0
 redirect302tr.Processes.Default.Streams.stdout = "redirect302_get.gold"
 
 
-redirect307tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_307_HOST))
+redirect307tr = Test.AddTestRun(f"Test domain {REDIRECT_307_HOST}")
 redirect302tr.StillRunningBefore = ts
 redirect307tr.StillRunningAfter = ts
-redirect307tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_307_HOST))
+redirect307tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} data/{REDIRECT_307_HOST}_get.txt | grep -v '^Date: '| grep -v '^Server: ATS/'"
 redirect307tr.Processes.Default.TimeOut = 5  # seconds
 redirect307tr.Processes.Default.ReturnCode = 0
 redirect307tr.Processes.Default.Streams.stdout = "redirect307_get.gold"
 
-redirect308tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_308_HOST))
+redirect308tr = Test.AddTestRun(f"Test domain {REDIRECT_308_HOST}")
 redirect308tr.StillRunningBefore = ts
 redirect308tr.StillRunningAfter = ts
-redirect308tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_308_HOST))
+redirect308tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} data/{REDIRECT_308_HOST}_get.txt | grep -v '^Date: '| grep -v '^Server: ATS/'"
 redirect308tr.Processes.Default.TimeOut = 5  # seconds
 redirect308tr.Processes.Default.ReturnCode = 0
 redirect308tr.Processes.Default.Streams.stdout = "redirect308_get.gold"
 
-redirect0tr = Test.AddTestRun("Test domain {0}".format(REDIRECT_0_HOST))
+redirect0tr = Test.AddTestRun(f"Test domain {REDIRECT_0_HOST}")
 redirect0tr.StillRunningBefore = ts
 redirect0tr.StillRunningAfter = ts
-redirect0tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(REDIRECT_0_HOST))
+redirect0tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} data/{REDIRECT_0_HOST}_get.txt | grep -v '^Date: '| grep -v '^Server: ATS/'"
 redirect0tr.Processes.Default.TimeOut = 5  # seconds
 redirect0tr.Processes.Default.ReturnCode = 0
 redirect0tr.Processes.Default.Streams.stdout = "redirect0_get.gold"
 
-passthroughtr = Test.AddTestRun("Test domain {0}".format(PASSTHRU_HOST))
+passthroughtr = Test.AddTestRun(f"Test domain {PASSTHRU_HOST}")
 passthroughtr.StillRunningBefore = ts
 passthroughtr.StillRunningAfter = ts
-passthroughtr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | grep -v '^Date: '| grep -v '^Server: ATS/'".\
-    format(ts.Variables.port, 'data/{0}_get.txt'.format(PASSTHRU_HOST))
+passthroughtr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} data/{PASSTHRU_HOST}_get.txt | grep -v '^Date: '| grep -v '^Server: ATS/'"
 passthroughtr.Processes.Default.TimeOut = 5  # seconds
 passthroughtr.Processes.Default.ReturnCode = 0
 passthroughtr.Processes.Default.Streams.stdout = "passthrough_get.gold"

--- a/tests/gold_tests/headers/general-connection-failure-502.test.py
+++ b/tests/gold_tests/headers/general-connection-failure-502.test.py
@@ -18,6 +18,7 @@ Test response when connection to origin fails
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Test response when connection to origin fails
@@ -39,7 +40,8 @@ data_file.WriteOn("GET / HTTP/1.1\r\nHost: {host}\r\n\r\n".format(host=HOST))
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 # Do not start the origin server: We wish to simulate connection refused while hopefully no one else uses this port.
-tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | sed -e '/^Date: /d' -e '/^Server: ATS\//d'"\
-    .format(ts.Variables.port, "www.connectfail502.test-get.txt")
+tr.Processes.Default.Command = \
+    (f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} www.connectfail502.test-get.txt | "
+     "sed -e '/^Date: /d' -e '/^Server: ATS\//d'")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = 'general-connection-failure-502.gold'

--- a/tests/gold_tests/headers/http408.test.py
+++ b/tests/gold_tests/headers/http408.test.py
@@ -18,6 +18,7 @@ Test the 408 response header.
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Check 408 response header for protocol stack data.
@@ -50,8 +51,8 @@ Test.Setup.Copy('data')
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.Processes.Default.Command = 'python3 tcp_client.py 127.0.0.1 {0} {1} --delay-after-send {2}'\
-    .format(ts.Variables.port, 'data/{0}.txt'.format(HTTP_408_HOST), TIMEOUT + 2)
+DELAY = TIMEOUT + 2
+tr.Processes.Default.Command = f'{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} data/{HTTP_408_HOST}.txt --delay-after-send {DELAY}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.TimeOut = 10
 tr.Processes.Default.Streams.stdout = "http408.gold"

--- a/tests/gold_tests/logging/log_pipe.test.py
+++ b/tests/gold_tests/logging/log_pipe.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Test custom log file format
@@ -162,7 +163,7 @@ buffer_verifier = "pipe_buffer_is_larger_than.py"
 tr.Setup.Copy(buffer_verifier)
 verify_buffer_size = tr.Processes.Process(
     "verify_buffer_size",
-    "python3 {} {} {}".format(buffer_verifier, pipe_path, pipe_size))
+    f"{sys.executable} {buffer_verifier} {pipe_path} {pipe_size}")
 verify_buffer_size.Return = 0
 verify_buffer_size.Streams.All += Testers.ContainsExpression(
     "Success",

--- a/tests/gold_tests/logging/new_log_flds.test.py
+++ b/tests/gold_tests/logging/new_log_flds.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Test new log fields
@@ -117,7 +118,7 @@ test_run.Processes.Default.ReturnCode = 0
 # Validate generated log.
 #
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 {0} < {1}'.format(
-    os.path.join(Test.TestDirectory, 'new_log_flds_observer.py'),
-    os.path.join(ts.Variables.LOGDIR, 'test_new_log_flds.log'))
+observer_script = os.path.join(Test.TestDirectory, 'new_log_flds_observer.py')
+log_path = os.path.join(ts.Variables.LOGDIR, 'test_new_log_flds.log')
+tr.Processes.Default.Command = f'{sys.executable} {observer_script} < {log_path}'
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/logging/sigusr2.test.py
+++ b/tests/gold_tests/logging/sigusr2.test.py
@@ -18,6 +18,7 @@ Verify support of external log rotation via SIGUSR2.
 #  limitations under the License.
 
 import os
+import sys
 
 
 TRAFFIC_MANAGER_PID_SCRIPT = 'ts_process_handler.py'
@@ -107,8 +108,8 @@ class Sigusr2Test:
         Return the command that will send a USR2 signal to the traffic manager
         process.
         """
-        return r"python3 {} --parent --signal SIGUSR2 {}".format(
-            TRAFFIC_MANAGER_PID_SCRIPT, self._ts_name)
+        return (f"{sys.executable} {TRAFFIC_MANAGER_PID_SCRIPT} --parent "
+                f"--signal SIGUSR2 {self._ts_name}")
 
 
 Test.Summary = '''

--- a/tests/gold_tests/pluginTest/combo_handler/combo_handler.test.py
+++ b/tests/gold_tests/pluginTest/combo_handler/combo_handler.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Test combo_handler plugin
@@ -36,7 +37,7 @@ _data_file__file_count = 0
 
 def data_file(data):
     global _data_file__file_count
-    file_path = Test.RunDirectory + "/tcp_client_in_{}".format(_data_file__file_count)
+    file_path = Test.RunDirectory + f"/tcp_client_in_{_data_file__file_count}"
     _data_file__file_count += 1
     with open(file_path, "x") as f:
         f.write(data)
@@ -47,7 +48,7 @@ def data_file(data):
 
 
 def tcp_client_cmd(host, port, file_path):
-    return "python3 {}/tcp_client.py {} {} {}".format(Test.Variables.AtsTestToolsDir, host, port, file_path)
+    return f"{sys.executable} {Test.Variables.AtsTestToolsDir}/tcp_client.py {host} {port} {file_path}"
 
 # Function to return command (string) to run tcp_client.py tool.  'host' and 'port' are the first two parameters to tcp_client.
 # 'data' is the data to put in the data file input to tcp_client.
@@ -100,10 +101,10 @@ ts.Disk.remap_config.AddLine(
     'map http://xyz/ http://127.0.0.1/ @plugin=combo_handler.so'
 )
 ts.Disk.remap_config.AddLine(
-    'map http://localhost/127.0.0.1/ http://127.0.0.1:{}/'.format(server.Variables.Port)
+    f'map http://localhost/127.0.0.1/ http://127.0.0.1:{server.Variables.Port}/'
 )
 ts.Disk.remap_config.AddLine(
-    'map http://localhost/sub/ http://127.0.0.1:{}/sub/'.format(server.Variables.Port)
+    f'map http://localhost/sub/ http://127.0.0.1:{server.Variables.Port}/sub/'
 )
 
 # Configure the combo_handler's configuration file.

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
@@ -18,6 +18,7 @@ Verify traffic_dump IP filter functionality.
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Verify traffic_dump IP filter functionality.
@@ -64,7 +65,7 @@ def get_common_ats_process(name, plugin_command, replay_exists):
 # Common verification variables.
 verify_replay = "verify_replay.py"
 schema = os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json')
-verify_command_prefix = f'python3 {verify_replay} {schema}'
+verify_command_prefix = f'{sys.executable} {verify_replay} {schema}'
 
 #
 # Test 1: Verify -4 works for a specified address.

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
@@ -18,6 +18,7 @@ Verify traffic_dump response body functionality.
 #  limitations under the License.
 
 import os
+import sys
 
 Test.Summary = '''
 Verify traffic_dump response body functionality.
@@ -99,7 +100,7 @@ tr.StillRunningAfter = ts
 # Common verification variables.
 verify_replay = "verify_replay.py"
 schema = os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json')
-verify_command_prefix = f'python3 {verify_replay} {schema}'
+verify_command_prefix = f'{sys.executable} {verify_replay} {schema}'
 
 #
 # Verify a response without a body is dumped correctly.

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/x_cache_info.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/x_cache_info.test.py
@@ -14,6 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 Test.Summary = '''
 Test xdebug plugin X-Cache-Info header
 '''
@@ -57,7 +59,7 @@ for file in files:
 def sendMsg(msgFile):
     global started
     tr = Test.AddTestRun()
-    tr.Processes.Default.Command = f"( python3 tools/tcp_client.py 127.0.0.1 {ts.Variables.port} {msgFile}.in ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  out.log 2>&1"
+    tr.Processes.Default.Command = f"( {sys.executable} tools/tcp_client.py 127.0.0.1 {ts.Variables.port} {msgFile}.in ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  out.log 2>&1"
     tr.Processes.Default.ReturnCode = 0
 
     if not started:

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/x_effective_url.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/x_effective_url.test.py
@@ -14,6 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 Test.Summary = '''
 Test xdebug plugin X-Effective header
 '''
@@ -61,10 +63,8 @@ def sendMsg(msgFile):
 
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
-        "( python3 {}/tcp_client.py 127.0.0.1 {} {}/{}.in".format(
-            Test.RunDirectory, ts.Variables.port, Test.TestDirectory, msgFile) +
-        " ; echo '======' ) | sed 's/:{}/:SERVER_PORT/' >>  {}/out.log 2>&1 ".format(
-            server.Variables.Port, Test.RunDirectory)
+        f"( {sys.executable} {Test.RunDirectory}/tcp_client.py 127.0.0.1 {ts.Variables.port} {Test.TestDirectory}/{msgFile}.in"
+        f" ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  {Test.RunDirectory}/out.log 2>&1 "
     )
     tr.Processes.Default.ReturnCode = 0
 

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
@@ -14,6 +14,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 Test.Summary = '''
 Test xdebug plugin X-Remap, Probe and fwd headers
 '''
@@ -59,10 +61,8 @@ def sendMsg(msgFile):
 
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
-        "( python3 {}/tcp_client.py 127.0.0.1 {} {}/{}.in".format(
-            Test.RunDirectory, ts.Variables.port, Test.TestDirectory, msgFile) +
-        " ; echo '======' ) | sed 's/:{}/:SERVER_PORT/' >>  {}/out.log 2>&1 ".format(
-            server.Variables.Port, Test.RunDirectory)
+        f"( {sys.executable} {Test.RunDirectory}/tcp_client.py 127.0.0.1 {ts.Variables.port} {Test.TestDirectory}/{msgFile}.in"
+        f" ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  {Test.RunDirectory}/out.log 2>&1 "
     )
     tr.Processes.Default.ReturnCode = 0
 

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -18,6 +18,8 @@ Test redirection
 #  limitations under the License.
 
 import os
+import sys
+
 Test.Summary = '''
 Test redirection
 '''
@@ -71,10 +73,10 @@ os.makedirs(data_path, exist_ok=True)
 # Here and below: spaces are deliberately omitted from the test run names because autest creates directories using these names.
 tr = Test.AddTestRun("FollowsRedirectWithAbsoluteLocationURI")
 # Here and below: because autest's Copy does not behave like standard cp, it's easiest to write all of our files out and copy last.
-with open(os.path.join(data_path, tr.Name), 'w') as f:
+command_path = os.path.join(data_path, tr.Name)
+with open(command_path, 'w') as f:
     f.write('GET /redirect HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
-tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(
-    ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} {command_path} | egrep -v '^(Date: |Server: ATS/)'"
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(redirect_serv)
 tr.Processes.Default.StartBefore(dest_serv)
@@ -92,11 +94,11 @@ redirect_response_header = {"headers": "HTTP/1.1 204 No Content\r\nConnection: c
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
 tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURI")
-with open(os.path.join(data_path, tr.Name), 'w') as f:
+command_path = os.path.join(data_path, tr.Name)
+with open(command_path, 'w') as f:
     f.write(
         'GET /redirect-relative-path HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
-tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(
-    ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} {command_path} | egrep -v '^(Date: |Server: ATS/)'"
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = redirect_serv
 tr.StillRunningAfter = dest_serv
@@ -111,11 +113,11 @@ redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: redirect
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
 tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURIMissingLeadingSlash")
-with open(os.path.join(data_path, tr.Name), 'w') as f:
+command_path = os.path.join(data_path, tr.Name)
+with open(command_path, 'w') as f:
     f.write(
         'GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
-tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".format(
-    ts.Variables.port, os.path.join(data_dirname, tr.Name))
+tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} {command_path} | egrep -v '^(Date: |Server: ATS/)'"
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = redirect_serv
 tr.StillRunningAfter = dest_serv
@@ -149,12 +151,12 @@ for status, phrase in sorted({
     redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
     tr = Test.AddTestRun("FollowsRedirect{0}".format(status))
-    with open(os.path.join(data_path, tr.Name), 'w') as f:
+    command_path = os.path.join(data_path, tr.Name)
+    with open(command_path, 'w') as f:
         f.write(('GET /redirect{0} HTTP/1.1\r\n'
                  'Host: iwillredirect.test:{1}\r\n\r\n').
                 format(status, redirect_serv.Variables.Port))
-    tr.Processes.Default.Command = "python3 tcp_client.py 127.0.0.1 {0} {1} | egrep -v '^(Date: |Server: ATS/)'".\
-        format(ts.Variables.port, os.path.join(data_dirname, tr.Name))
+    tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} {command_path} | egrep -v '^(Date: |Server: ATS/)'"
     tr.StillRunningAfter = ts
     tr.StillRunningAfter = redirect_serv
     tr.StillRunningAfter = dest_serv

--- a/tests/gold_tests/slow_post/slow_post.test.py
+++ b/tests/gold_tests/slow_post/slow_post.test.py
@@ -16,6 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
 
 Test.SkipUnless(
     Condition.PluginExists('request_buffer.so')
@@ -60,8 +61,8 @@ class SlowPostAttack:
 
     def run(self):
         tr = Test.AddTestRun()
-        tr.Processes.Default.Command = 'python3 {0} -p {1} -c {2}'.format(
-            self._slow_post_client, self._ts.Variables.port, self._origin_max_connections)
+        tr.Processes.Default.Command = \
+            f'{sys.executable} {self._slow_post_client} -p {self._ts.Variables.port} -c {self._origin_max_connections}'
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.StartBefore(self._server)
         tr.Processes.Default.StartBefore(Test.Processes.ts)

--- a/tests/gold_tests/thread_config/thread_config.test.py
+++ b/tests/gold_tests/thread_config/thread_config.test.py
@@ -16,6 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
 
 Test.Summary = 'Test that Trafficserver starts with different thread configurations.'
 Test.ContinueOnFail = True
@@ -33,7 +34,8 @@ ts.Disk.records_config.update({
 ts.Setup.CopyAs('check_threads.py', Test.RunDirectory)
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 1, 0, 1, 1)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 1 -a 0 -t 1 -c 1'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -49,7 +51,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 1, 1, 2, 8)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 1 -a 1 -t 2 -c 8'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -65,8 +68,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(
-    ts.Env['TS_ROOT'], 1, 10, 10, 32)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 1 -a 10 -t 10 -c 32'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -82,7 +85,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 2, 0, 1, 1)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 2 -a 0 -t 1 -c 1'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -98,7 +102,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 2, 1, 2, 8)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 2 -a 1 -t 2 -c 8'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -114,8 +119,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(
-    ts.Env['TS_ROOT'], 2, 10, 10, 32)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 2 -a 10 -t 10 -c 32'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -131,7 +136,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 32, 0, 1, 1)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 32 -a 0 -t 1 -c 1'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -147,7 +153,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 32, 1, 2, 8)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 32 -a 1 -t 2 -c 8'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -163,8 +170,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(
-    ts.Env['TS_ROOT'], 32, 10, 10, 32)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 32 -a 10 -t 10 -c 32'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -180,7 +187,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 100, 0, 1, 1)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 100 -a 0 -t 1 -c 1'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -196,7 +204,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(ts.Env['TS_ROOT'], 100, 1, 2, 8)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 100 -a 1 -t 2 -c 8'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
@@ -212,7 +221,7 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'python3 check_threads.py -p {0} -e {1} -a {2} -t {3} -c {4}'.format(
-    ts.Env['TS_ROOT'], 100, 10, 10, 32)
+TS_ROOT = ts.Env['TS_ROOT']
+tr.Processes.Default.Command = f'{sys.executable} check_threads.py -p {TS_ROOT} -e 100 -a 10 -t 10 -c 32'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/tls/tls_0rtt_server.test.py
+++ b/tests/gold_tests/tls/tls_0rtt_server.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 Test.Summary = '''
 Test ATS TLSv1.3 0-RTT support
 '''
@@ -143,8 +145,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter += ts
 
 tr = Test.AddTestRun('TLSv1.3 0-RTT Support (HTTP/1.1 GET)')
-tr.Processes.Default.Command = 'python3 test-0rtt-s_client.py {0} {1} {2} {3}'.format(
-    ts.Variables.ssl_port, 'h1', 'get', Test.RunDirectory)
+tr.Processes.Default.Command = f'{sys.executable} test-0rtt-s_client.py {ts.Variables.ssl_port} h1 get {Test.RunDirectory}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('early data accepted', '')
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression('curl test', '')
@@ -152,8 +153,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter += ts
 
 tr = Test.AddTestRun('TLSv1.3 0-RTT Support (HTTP/1.1 POST)')
-tr.Processes.Default.Command = 'python3 test-0rtt-s_client.py {0} {1} {2} {3}'.format(
-    ts.Variables.ssl_port, 'h1', 'post', Test.RunDirectory)
+tr.Processes.Default.Command = f'{sys.executable} test-0rtt-s_client.py {ts.Variables.ssl_port} h1 post {Test.RunDirectory}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('HTTP/1.1 425 Too Early', '')
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression('curl test', '')
@@ -162,8 +162,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter += ts
 
 tr = Test.AddTestRun('TLSv1.3 0-RTT Support (HTTP/2 GET)')
-tr.Processes.Default.Command = 'python3 test-0rtt-s_client.py {0} {1} {2} {3}'.format(
-    ts.Variables.ssl_port, 'h2', 'get', Test.RunDirectory)
+tr.Processes.Default.Command = f'{sys.executable} test-0rtt-s_client.py {ts.Variables.ssl_port} h2 get {Test.RunDirectory}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('early data accepted', '')
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression('curl test', '')
@@ -171,8 +170,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter += ts
 
 tr = Test.AddTestRun('TLSv1.3 0-RTT Support (HTTP/2 POST)')
-tr.Processes.Default.Command = 'python3 test-0rtt-s_client.py {0} {1} {2} {3}'.format(
-    ts.Variables.ssl_port, 'h2', 'post', Test.RunDirectory)
+tr.Processes.Default.Command = f'{sys.executable} test-0rtt-s_client.py {ts.Variables.ssl_port} h2 post {Test.RunDirectory}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(':status 425', 'Only safe methods are allowed')
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression('curl test', '')
@@ -181,8 +179,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter += ts
 
 tr = Test.AddTestRun('TLSv1.3 0-RTT Support (HTTP/2 Multiplex)')
-tr.Processes.Default.Command = 'python3 test-0rtt-s_client.py {0} {1} {2} {3}'.format(
-    ts.Variables.ssl_port, 'h2', 'multi1', Test.RunDirectory)
+tr.Processes.Default.Command = f'{sys.executable} test-0rtt-s_client.py {ts.Variables.ssl_port} h2 multi1 {Test.RunDirectory}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('early data accepted multi_1', '')
 tr.Processes.Default.Streams.All += Testers.ContainsExpression('early data accepted multi_2', '')
@@ -192,8 +189,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter += ts
 
 tr = Test.AddTestRun('TLSv1.3 0-RTT Support (HTTP/2 Multiplex with POST)')
-tr.Processes.Default.Command = 'python3 test-0rtt-s_client.py {0} {1} {2} {3}'.format(
-    ts.Variables.ssl_port, 'h2', 'multi2', Test.RunDirectory)
+tr.Processes.Default.Command = f'{sys.executable} test-0rtt-s_client.py {ts.Variables.ssl_port} h2 multi2 {Test.RunDirectory}'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('early data accepted multi_1', '')
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(':status 425', 'Only safe methods are allowed')


### PR DESCRIPTION
A handful of our AuTests execute their own Python scripts. Generally
these just ran with whatever `python3` picked up. This changes those to
use {sys.executable} which will run those scripts with the same Python
being used for autest itself rather than some other system Python which
may not have the required dependencies installed in it. This way any
requirements for the scripts can be placed in the tests/Pipfile and it
should be available for those scripts.


---
### For Review

The diff looks big, but all this does is change the python3 calls to `{sys.executable}` and fix up some other format strings where it seemed appropriate for the file.