### PR TITLE
Don't require branch to be up to date before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,7 +28,8 @@ github:
   protected_branches:
     master:
       required_status_checks:
-        strict: true
+        # strict means "Require branches to be up to date before merging"
+        strict: false
         contexts:
           - AuTest
           - CentOS


### PR DESCRIPTION
Should have read what "strict" does, we don't want to have this enabled.

https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-BranchProtection