### PR TITLE
Make sure the include files are built first

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ export CCACHE_BASEDIR
 # and mgmt, hence we have to build proxy/hdrs first.
 
 # depends on the generates ts/ts.h include file.
-SUBDIRS = src/tscpp/util lib src/tscore iocore proxy mgmt src plugins tools example rc configs include tests
+SUBDIRS = include src/tscpp/util lib src/tscore iocore proxy mgmt src plugins tools example rc configs tests
 
 if BUILD_DOCS
 SUBDIRS += doc include

--- a/configure.ac
+++ b/configure.ac
@@ -2246,6 +2246,8 @@ AC_CONFIG_FILES([
   include/ts/Makefile
   include/tscpp/api/Makefile
   include/tscpp/util/Makefile
+  include/ts/apidefs.h
+  include/tscore/ink_config.h
   iocore/Makefile
   iocore/aio/Makefile
   iocore/cache/Makefile
@@ -2260,8 +2262,6 @@ AC_CONFIG_FILES([
   lib/perl/Makefile
   lib/perl/lib/Apache/TS.pm
   lib/records/Makefile
-  include/ts/apidefs.h
-  include/tscore/ink_config.h
   src/wccp/Makefile
   lib/fastlz/Makefile
   lib/yamlcpp/Makefile


### PR DESCRIPTION
This makes sure that files like apidefs.h are rebuilt when they are changed, before the code using them.