### PR TITLE
Fix traffic_top build when using -Werror=format-security

### DIFF
--- a/src/traffic_top/traffic_top.cc
+++ b/src/traffic_top/traffic_top.cc
@@ -126,7 +126,7 @@ prettyPrint(const int x, const int y, const double number, const int type)
   }
   attron(COLOR_PAIR(color));
   attron(A_BOLD);
-  mvprintw(y, x, buffer);
+  mvprintw(y, x, "%s", buffer);
   attroff(COLOR_PAIR(color));
   attroff(A_BOLD);
 }
@@ -143,7 +143,7 @@ makeTable(const int x, const int y, const list<string> &items, Stats &stats)
     int type;
 
     stats.getStat(item, value, prettyName, type);
-    mvprintw(my_y, x, prettyName.c_str());
+    mvprintw(my_y, x, "%s", prettyName.c_str());
     prettyPrint(x + 10, my_y++, value, type);
   }
 }


### PR DESCRIPTION
When building ATS 9.1.0 on Debian, build fails with error:

```
traffic_top/traffic_top.cc: In function 'void prettyPrint(int, int,
double, int)':
traffic_top/traffic_top.cc:129:18: error: format not a string literal
and no format arguments [-Werror=format-security]
  129 |   mvprintw(y, x, buffer);
      |                  ^~~~~~
traffic_top/traffic_top.cc: In function 'void makeTable(int, int, const
std::__cxx11::list<std::__cxx11::basic_string<char> >&, Stats&)':
traffic_top/traffic_top.cc:146:13: error: format not a string literal
and no format arguments [-Werror=format-security]
  146 |     mvprintw(my_y, x, prettyName.c_str());
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
make[3]: *** [Makefile:2743: traffic_top/traffic_top-traffic_top.o] Error 1
make[3]: Leaving directory '/home/debocker/source/build/src'
make[2]: *** [Makefile:2805: all-recursive] Error 1
make[2]: Leaving directory '/home/debocker/source/build/src'
make[1]: *** [Makefile:868: all-recursive] Error 1
make[1]: Leaving directory '/home/debocker/source/build'
dh_auto_build: error: make -j1 returned exit code 2
make: *** [debian/rules:32: binary] Error 2
```

When using `-Werror=format-security` option, we need to specify which format is expected, therefore the "%s" addition