### PR TITLE
Fix traffic_manager build when mime-sanity-check is enabled

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -557,7 +557,7 @@ checksum_block(const char *s, int len)
   return sum;
 }
 
-#ifdef DEBUG
+#ifdef ENABLE_MIME_SANITY_CHECK
 void
 mime_hdr_sanity_check(MIMEHdrImpl *mh)
 {


### PR DESCRIPTION
When building ATS 9.1.0 on Debian with `--enable-mime-sanity-check` option, build fails with `undefined reference` error for `mime_hdr_sanity_check` method.