### PR TITLE
For verify_global_plugin test, check for platform independent error message

### DIFF
--- a/tests/gold_tests/command_argument/verify_global_plugin.test.py
+++ b/tests/gold_tests/command_argument/verify_global_plugin.test.py
@@ -166,8 +166,8 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: .*: undefined symbol: .*foo.*",
-    "Should warn about the need for the TSPluginInit symbol")
+    "ERROR:.*unable to load",
+    "Should log failure to load shared object")
 ts.Disk.diags_log.Content = Testers.ContainsExpression(
     "ERROR",
-    "ERROR: .*: undefined symbol: .*foo.*")
+    "Should log failure to load shared object")


### PR DESCRIPTION
This allows the test to work on something other than Linux