### PR TITLE
Exports all symbols for missing_mangled_definition.so test plugin

### DIFF
--- a/tests/tools/plugins/Makefile.inc
+++ b/tests/tools/plugins/Makefile.inc
@@ -43,6 +43,11 @@ tools_plugins_missing_mangled_definition_la_SOURCES = \
   tools/plugins/missing_mangled_definition_c.c \
   tools/plugins/missing_mangled_definition_cpp.cc \
   tools/plugins/missing_mangled_definition.h
+tools_plugins_missing_mangled_definition_la_LDFLAGS = \
+  -module \
+  -shared \
+  -avoid-version \
+  -rpath $(abs_builddir)
 
 noinst_LTLIBRARIES += tools/plugins/missing_ts_plugin_init.la
 tools_plugins_missing_ts_plugin_init_la_SOURCES = tools/plugins/missing_ts_plugin_init.cc


### PR DESCRIPTION
This fixes the tests verify_global_plugin and verify_remap_plugin when
using lld and LTO