### PR TITLE
Report an error if configure can't find zlib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1373,6 +1373,9 @@ AM_CONDITIONAL([BUILD_JA3_PLUGIN], [test "x${enable_ja3_plugin}" = "xyes"])
 #
 # Check for zlib presence and usability
 TS_CHECK_ZLIB
+if test "x${enable_zlib}" != "xyes"; then
+  AC_MSG_ERROR([Cannot find zlib library. Configure --with-zlib=DIR])
+fi
 
 #
 # Check for lzma presence and usability


### PR DESCRIPTION
This is what it will do now:
```
checking for zlib.h... no
configure: error: Cannot find zlib library. Configure --with-zlib=DIR
```

This closes #5837