### PR TITLE
Reject Transfer-Encoding in pre-HTTP/1.1 requests

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5449,6 +5449,17 @@ HttpTransact::check_request_validity(State *s, HTTPHdr *incoming_hdr)
       return BAD_CONNECT_PORT;
     }
 
+    if (s->client_info.transfer_encoding == CHUNKED_ENCODING && incoming_hdr->version_get() < HTTP_1_1) {
+      // Per spec, Transfer-Encoding is only supported in HTTP/1.1. For earlier
+      // versions, we must reject Transfer-Encoding rather than interpret it
+      // since downstream proxies may ignore the chunk header and rely upon the
+      // Content-Length, or interpret the body some other way. These
+      // differences in interpretation may open up the door to compatibility
+      // issues. To protect against this, we reply with a 4xx if the client
+      // uses Transfer-Encoding with HTTP versions that do not support it.
+      return UNACCEPTABLE_TE_REQUIRED;
+    }
+
     // Require Content-Length/Transfer-Encoding for POST/PUSH/PUT
     if ((scheme == URL_WKSIDX_HTTP || scheme == URL_WKSIDX_HTTPS) &&
         (method == HTTP_WKSIDX_POST || method == HTTP_WKSIDX_PUSH || method == HTTP_WKSIDX_PUT) &&

--- a/tests/gold_tests/chunked_encoding/replays/chunked_in_http_1_0.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/chunked_in_http_1_0.replay.yaml
@@ -1,0 +1,48 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "POST"
+      # HTTP/1.0 does not support Transfer-Encoding. ATS should therefore
+      # reject it with a 4xx response.
+      version: "1.0"
+      url: /unexpected/chunk/header
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ Transfer-Encoding, chunked ]
+        - [ uuid, 51 ]
+      content:
+        size: 32
+
+    # This request should not make it to the server, but if it does reply with
+    # a 200 response so that we detect the non-4xx response we expect.
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ X-Response, "Unexpected origin response." ]
+
+    proxy-response:
+      status: 406
+      reason: "Transcoding Not Available"


### PR DESCRIPTION
Per spec, Transfer-Encoding is only supported in HTTP/1.1. For earlier
versions, we must reject Transfer-Encoding rather than interpret it
since downstream proxies may ignore the chunk header and rely upon the
Content-Length, or interpret the body some other way.  These differences
in interpretation may open up the door to compatibility issues. To
protect against this, we reply with a 4xx if the client uses
Transfer-Encoding with HTTP versions that do not support it.