### PR TITLE
Fix output '\n' HTTP field line endings

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2580,6 +2580,8 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
       }
       field_name.rtrim_if(&ParseRules::is_ws);
       raw_print_field = false;
+    } else if (parsed.suffix(2) != "\r\n") {
+      raw_print_field = false;
     }
 
     // find value first


### PR DESCRIPTION
This is another attempt to fix what was initially addressed in #8096 but
got backed out via #8305. That more extensive patch was considered too
invasive and potentially risky.  This more targeted patch will fix
clients that only send the \n endings but it will force the \r\n line
ending on output.

This was mostly in place except for header lines that get
m_n_v_raw_printable set, which seems to be most header lines. The
addition checks to see if the header line ends in \r\n. If it does not
the m_n_v_raw_printable flag gets cleared and the logic that explicitly
adds the line endings while be invoked on output.