### PR TITLE
ssl_verify_test: clang-analyzer fix to account for null sni_name

### DIFF
--- a/tests/tools/plugins/ssl_verify_test.cc
+++ b/tests/tools/plugins/ssl_verify_test.cc
@@ -46,24 +46,27 @@ CB_server_verify(TSCont cont, TSEvent event, void *edata)
   int count = reinterpret_cast<intptr_t>(TSContDataGet(cont));
 
   // Is this a good name or not?
-  TSEvent reenable_event = TS_EVENT_CONTINUE;
-  TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
-  SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-  const char *sni_name   = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+  TSEvent reenable_event       = TS_EVENT_CONTINUE;
+  TSSslConnection const sslobj = TSVConnSslConnectionGet(ssl_vc);
+  SSL const *const ssl         = reinterpret_cast<SSL *>(sslobj);
+  char const *const sni_name   = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (sni_name) {
     std::string sni_string(sni_name);
     if (bad_names.find(sni_string) != bad_names.end()) {
       reenable_event = TS_EVENT_ERROR;
     }
+
+    TSDebug(PN, "Server verify callback %d %p - event is %s SNI=%s %s", count, ssl_vc,
+            event == TS_EVENT_SSL_VERIFY_SERVER ? "good" : "bad", sni_name,
+            reenable_event == TS_EVENT_ERROR ? "error HS" : "good HS");
+
+    int len;
+    char const *const method2_name = TSVConnSslSniGet(ssl_vc, &len);
+    TSDebug(PN, "Server verify callback SNI APIs match=%s", 0 == strncmp(method2_name, sni_name, len) ? "true" : "false");
+  } else {
+    TSDebug(PN, "SSL_get_servername failed");
+    reenable_event = TS_EVENT_ERROR;
   }
-
-  TSDebug(PN, "Server verify callback %d %p - event is %s SNI=%s %s", count, ssl_vc,
-          event == TS_EVENT_SSL_VERIFY_SERVER ? "good" : "bad", sni_name,
-          reenable_event == TS_EVENT_ERROR ? "error HS" : "good HS");
-
-  int len;
-  const char *method2_name = TSVConnSslSniGet(ssl_vc, &len);
-  TSDebug(PN, "Server verify callback SNI APIs match=%s", 0 == strncmp(method2_name, sni_name, len) ? "true" : "false");
 
   // All done, reactivate things
   TSVConnReenableEx(ssl_vc, reenable_event);


### PR DESCRIPTION
clang-analyzer was upset due to a debug statement using a char* that could potentially be null.  This should resolve the error.