### PR TITLE
Tweak MimeHdr::get_host_port_values to not run over the end of the TextView

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -2282,20 +2282,15 @@ MIMEHdr::get_host_port_values(const char **host_ptr, ///< Pointer to host.
     if (b) {
       if ('[' == *b) {
         auto idx = b.find(']');
-        if (idx <= b.size() && b[idx + 1] == ':') {
+        if (idx < b.size() - 1 && b[idx + 1] == ':') {
           host = b.take_prefix_at(idx + 1);
           port = b;
         } else {
           host = b;
         }
       } else {
-        auto x = b.split_prefix_at(':');
-        if (x) {
-          host = x;
-          port = b;
-        } else {
-          host = b;
-        }
+        host = b.take_prefix_at(':');
+        port = b;
       }
 
       if (host) {

--- a/src/tscpp/util/unit_tests/test_TextView.cc
+++ b/src/tscpp/util/unit_tests/test_TextView.cc
@@ -275,20 +275,15 @@ TEST_CASE("TextView Affixes", "[libts][TextView]")
   auto f_host = [](TextView b, TextView &host, TextView &port) -> void {
     if ('[' == *b) {
       auto idx = b.find(']');
-      if (idx <= b.size() && b[idx + 1] == ':') {
+      if (idx < b.size() - 1 && b[idx + 1] == ':') {
         host = b.take_prefix_at(idx + 1);
         port = b;
       } else {
         host = b;
       }
     } else {
-      auto x = b.split_prefix_at(':');
-      if (x) {
-        host = x;
-        port = b;
-      } else {
-        host = b;
-      }
+      host = b.take_prefix_at(':');
+      port = b;
     }
   };
 


### PR DESCRIPTION
In practice going past the end is fine in this specific case because of how the fields and values are layed out for MIME headers. However it's probably best to be clean and not depend on external circumstances.

This makes the same change twice, because the `TextView`  has a test to make sure the logic yields the correct values.

Closing #8461