### PR TITLE
UnixNetVConnection: add chek for nh in fail block

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1238,7 +1238,9 @@ fail:
   if (fd != NO_FD) {
     con.fd = NO_FD;
   }
-  nh->free_netevent(this);
+  if (nullptr != nh) {
+    nh->free_netevent(this);
+  }
   return CONNECT_FAILURE;
 }
 


### PR DESCRIPTION
Ran into this core dump while performing network stress testing.

In UnixNetVConnection::connectUp
if this fails:
```
  if ((res = get_NetHandler(t)->startIO(this)) < 0) {
    goto fail;
  }
```
this->nh is never set.  In the fail block check this->nh.