### PR TITLE
UnixNetVConnection: add check for nh in fail block

### DIFF
--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -678,7 +678,7 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
     if (nh) {
       nh->free_netevent(this);
     } else {
-      free(t);
+      this->free(t);
     }
   }
 }
@@ -1238,7 +1238,11 @@ fail:
   if (fd != NO_FD) {
     con.fd = NO_FD;
   }
-  nh->free_netevent(this);
+  if (nullptr != nh) {
+    nh->free_netevent(this);
+  } else {
+    this->free(t);
+  }
   return CONNECT_FAILURE;
 }
 


### PR DESCRIPTION
Ran into this core dump while performing network stress testing.

In UnixNetVConnection::connectUp
if this fails:
```
  if ((res = get_NetHandler(t)->startIO(this)) < 0) {
    goto fail;
  }
```
this->nh is never set. In the fail block check this->nh.