### PR TITLE
Update HostDBContinuation timeout handling to clear pending queue.

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -1109,11 +1109,20 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
   }
   EThread *thread = mutex->thread_holding;
   if (event != DNS_EVENT_LOOKUP) {
-    // This was an event_interval or an event_immediate
-    // Either we timed out, or remove_trigger_pending gave up on us
+    // Event should be immediate or interval.
     if (!action.continuation) {
-      // give up on insert, it has been too long
-      hostDB.pending_dns_for_hash(hash.hash).remove(this);
+      // Nothing to do, give up.
+      if (event == EVENT_INTERVAL) {
+        // Timeout - clear all queries queued up for this FQDN because none of the other ones have sent an
+        // actual DNS query. If the request rate is high enough this can cause a persistent queue where the
+        // DNS query is never sent and all requests timeout, even if it was a transient error.
+        // See issue #8417.
+        remove_trigger_pending_dns();
+      } else {
+        // "local" signal to give up, usually due this being one of those "other" queries.
+        // That generally means @a this has already been removed from the queue, but just in case...
+        hostDB.pending_dns_for_hash(hash.hash).remove(this);
+      }
       hostdb_cont_free(this);
       return EVENT_DONE;
     }


### PR DESCRIPTION
After pondering the proposed fix in #8417 I think I understand what's going on and why that change works. A key point is a query rate that is fast enough that the pending queue for that FQDN never empties. In such a case a transient error (which can happen, it's UDP) causes a permanent block because new queries to HostDB see the non-empty queue and don't send a DNS query on the wire. As long as the requests keep coming in, this condition persists. The change is that if there is a timeout on a HostDB query, clear the queue and fail all of the currently pending requests. After that, the next HostDB query will generate a DNS query and if the error was transient then queries will work again.

I concur that it was probably #6686 that caused this problem.

Closing #8417