### PR TITLE
Serve stale content when DNS lookup fails

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1969,6 +1969,13 @@ HttpTransact::OSDNSLookup(State *s)
     } else {
       TxnDebug("http_seq", "[HttpTransact::OSDNSLookup] DNS Lookup unsuccessful");
 
+      // Even with unsuccessful DNS lookup, return stale object from cache if applicable
+      if (is_cache_hit(s->cache_lookup_result) && is_stale_cache_response_returnable(s)) {
+        s->source = SOURCE_CACHE;
+        TxnDebug("http_trans", "[hscno] serving stale doc to client");
+        build_response_from_cache(s, HTTP_WARNING_CODE_REVALIDATION_FAILED);
+        return;
+      }
       // output the DNS failure error message
       SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
       // Set to internal server error so later logging will pick up SQUID_LOG_ERR_DNS_FAIL
@@ -2669,16 +2676,7 @@ HttpTransact::HandleCacheOpenReadHitFreshness(State *s)
     SET_VIA_STRING(VIA_CACHE_RESULT, VIA_IN_CACHE_STALE);
   }
 
-  if (!s->force_dns) { // If DNS is not performed before
-    if (need_to_revalidate(s)) {
-      TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE,
-                      CallOSDNSLookup); // content needs to be revalidated and we did not perform a dns ....calling DNS lookup
-    } else {                            // document can be served can cache
-      TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE, HttpTransact::HandleCacheOpenReadHit);
-    }
-  } else { // we have done dns . Its up to HandleCacheOpenReadHit to decide to go OS or serve from cache
-    TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE, HttpTransact::HandleCacheOpenReadHit);
-  }
+  TRANSACT_RETURN(SM_ACTION_API_CACHE_LOOKUP_COMPLETE, HttpTransact::HandleCacheOpenReadHit);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/gold_tests/proxy_protocol/gold/serve_stale_dns_fail.gold
+++ b/tests/gold_tests/proxy_protocol/gold/serve_stale_dns_fail.gold
@@ -1,0 +1,57 @@
+``
+> GET / HTTP/1.1
+> Host: ``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 200 OK
+< Server: ATS``
+< Accept-Ranges: bytes
+< Content-Length: 6
+< Cache-Control: public, max-age=5
+< Expires: ``
+< Age: ``
+< Date: ``
+< Connection: keep-alive
+``
+> GET / HTTP/1.1
+> Host: ``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 500 Cannot find server.
+< Date: ``
+< Server: ATS``
+< Cache-Control: no-store
+< Content-Type: ``
+< Content-Language: ``
+< Content-Length: ``
+< Connection: keep-alive
+``
+> GET / HTTP/1.1
+> Host: ``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 200 OK
+< Server: ATS``
+< Accept-Ranges: bytes
+< Content-Length: 6
+< Cache-Control: public, max-age=5
+< Age: ``
+< Date: ``
+< Connection: keep-alive
+``
+> GET / HTTP/1.1
+> Host: ``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 500 Cannot find server.
+< Date: ``
+< Server: ATS``
+< Cache-Control: no-store
+< Content-Type: ``
+< Content-Language: ``
+< Content-Length: ``
+``

--- a/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
@@ -28,7 +28,7 @@ Test.testName = "STALE"
 # Config child proxy to route to parent proxy
 ts_child.Disk.records_config.update({
     'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.http.cache.max_stale_age': 30,
+    'proxy.config.http.cache.max_stale_age': 10,
     'proxy.config.http.parent_proxy.self_detect': 0,
 })
 ts_child.Disk.parent_config.AddLine(
@@ -41,7 +41,7 @@ ts_child.Disk.remap_config.AddLine(
 # Configure parent proxy
 ts_parent.Disk.records_config.update({
     'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.http.cache.max_stale_age': 30,
+    'proxy.config.http.cache.max_stale_age': 10,
 })
 ts_parent.Disk.remap_config.AddLine(
     f'map http://localhost:{ts_parent.Variables.port} {server_name}'
@@ -52,20 +52,20 @@ ts_parent.Disk.remap_config.AddLine(
 
 # Object to push to proxies
 stale_5 = "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public, max-age=5\n\nCACHED"
-stale_30 = "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public, max-age=30\n\nCACHED"
+stale_10 = "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public, max-age=10\n\nCACHED"
 
 
 # Testing scenarios
 child_curl_request = (
     # Test child serving stale with failed DNS OS lookup
     f'curl -X PUSH -d "{stale_5}" "http://localhost:{ts_child.Variables.port}";'
-    f'curl -X PUSH -d "{stale_30}" "http://localhost:{ts_parent.Variables.port}";'
-    f'sleep 10; curl -s -v http://localhost:{ts_child.Variables.port};'
-    f'sleep 40; curl -s -v http://localhost:{ts_child.Variables.port};'
+    f'curl -X PUSH -d "{stale_10}" "http://localhost:{ts_parent.Variables.port}";'
+    f'sleep 7; curl -s -v http://localhost:{ts_child.Variables.port};'
+    f'sleep 15; curl -s -v http://localhost:{ts_child.Variables.port};'
     # Test parent serving stale with failed DNS OS lookup
     f'curl -X PUSH -d "{stale_5}" "http://localhost:{ts_parent.Variables.port}";'
-    f'sleep 10; curl -s -v http://localhost:{ts_parent.Variables.port};'
-    f'sleep 40; curl -s -v http://localhost:{ts_parent.Variables.port};'
+    f'sleep 7; curl -s -v http://localhost:{ts_parent.Variables.port};'
+    f'sleep 15; curl -s -v http://localhost:{ts_parent.Variables.port};'
 )
 
 # Test case for when parent server is down but child proxy can serve cache object

--- a/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
@@ -1,0 +1,79 @@
+'''
+Test proxy serving stale content when DNS lookup fails
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.ContinueOnFail = True
+# Set up hierarchical caching processes
+ts_child = Test.MakeATSProcess("ts_child")
+ts_parent = Test.MakeATSProcess("ts_parent")
+server_name = "http://unknown.domain.com/"
+
+Test.testName = "STALE"
+
+# Config child proxy to route to parent proxy
+ts_child.Disk.records_config.update({
+    'proxy.config.url_remap.pristine_host_hdr': 1,
+    'proxy.config.http.cache.max_stale_age': 30,
+    'proxy.config.http.parent_proxy.self_detect': 0,
+})
+ts_child.Disk.parent_config.AddLine(
+    f'dest_domain=. parent=localhost:{ts_parent.Variables.port} round_robin=consistent_hash go_direct=false'
+)
+ts_child.Disk.remap_config.AddLine(
+    f'map http://localhost:{ts_child.Variables.port} {server_name}'
+)
+
+# Configure parent proxy
+ts_parent.Disk.records_config.update({
+    'proxy.config.url_remap.pristine_host_hdr': 1,
+    'proxy.config.http.cache.max_stale_age': 30,
+})
+ts_parent.Disk.remap_config.AddLine(
+    f'map http://localhost:{ts_parent.Variables.port} {server_name}'
+)
+ts_parent.Disk.remap_config.AddLine(
+    f'map {server_name} {server_name}'
+)
+
+# Object to push to proxies
+stale_5 = "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public, max-age=5\n\nCACHED"
+stale_30 = "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public, max-age=30\n\nCACHED"
+
+
+# Testing scenarios
+child_curl_request = (
+    # Test child serving stale with failed DNS OS lookup
+    f'curl -X PUSH -d "{stale_5}" "http://localhost:{ts_child.Variables.port}";'
+    f'curl -X PUSH -d "{stale_30}" "http://localhost:{ts_parent.Variables.port}";'
+    f'sleep 10; curl -s -v http://localhost:{ts_child.Variables.port};'
+    f'sleep 40; curl -s -v http://localhost:{ts_child.Variables.port};'
+    # Test parent serving stale with failed DNS OS lookup
+    f'curl -X PUSH -d "{stale_5}" "http://localhost:{ts_parent.Variables.port}";'
+    f'sleep 10; curl -s -v http://localhost:{ts_parent.Variables.port};'
+    f'sleep 40; curl -s -v http://localhost:{ts_parent.Variables.port};'
+)
+
+# Test case for when parent server is down but child proxy can serve cache object
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = child_curl_request
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(ts_child)
+tr.Processes.Default.StartBefore(ts_parent)
+tr.Processes.Default.Streams.stderr = "gold/serve_stale_dns_fail.gold"
+tr.StillRunningAfter = ts_child
+tr.StillRunningAfter = ts_parent


### PR DESCRIPTION
Proxies should serve stale content even if DNS lookup to OS is unsuccessful. 
- For hierarchical caching, if a child proxy matches successfully to a parent proxy and child has requested stale object in its cache, it should not need to make a DNS request for the origin.
   - It can validate with the parent and return the object as expected. 
- Without hierarchical caching, if stale content is being requested from a proxy and the DNS lookup to the OS is unsuccessful, it should also serve the stale object
   - this behavior is similar to when the origin server is down and the proxy serves stale content with a warning header

These changes still respect the `max_stale_age` configurations and do not serve stale content pass the expiration date.

Autest tests the following using PUSH command to store stale content in proxy's cache: 
- With child mapping to an origin server without a DNS entry and child matching successfully to parent, a request from child after content becomes stale returns `200`
   - After `max_stale_age` has passed, request from child returns `500` as stale content is no longer returnable
- Without hierarchical caching and proxy mapping to an origin server without a DNS entry, a request from proxy after content becomes stale returns `200`
   - After `max_stale_age` has passed, request from proxy returns `500` as stale content is no longer returnable