### PR TITLE
Allow plugin continuation on API hook returning error to set 3xx HTTP status.

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1753,12 +1753,12 @@ HttpTransact::HandleApiErrorJump(State *s)
   s->source = SOURCE_INTERNAL;
 
   /**
-    The API indicated an error. Lets use a >=400 error from the state (if one's set) or fallback to a
+    The API indicated an error. Lets use a >=300 error from the state (if one's set) or fallback to a
     generic HTTP/1.X 500 INKApi Error
   **/
-  if (s->http_return_code && s->http_return_code >= HTTP_STATUS_BAD_REQUEST) {
+  if (s->http_return_code && s->http_return_code >= HTTP_STATUS_MULTIPLE_CHOICES) {
     const char *reason = http_hdr_reason_lookup(s->http_return_code);
-    ;
+
     build_response(s, &s->hdr_info.client_response, s->client_info.http_version, s->http_return_code, reason ? reason : "Error");
   } else {
     build_response(s, &s->hdr_info.client_response, s->client_info.http_version, HTTP_STATUS_INTERNAL_SERVER_ERROR, "INKApi Error");


### PR DESCRIPTION
I've got an urgent ask from Yahoo Production to be able to decide, in an internal plugin on the POST_REMAP hook, to bypass any cache lookup or request to server, and send a redirect response to the client.  I'd rather not have our internal TS diverge from open source here, would like the capability to do this in both.