### PR TITLE
Add an assert to check do_io_close is called for Unix/SSLNetVC

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -134,7 +134,6 @@ public:
   int sslClientHandShakeEvent(int &err);
   void net_read_io(NetHandler *nh, EThread *lthread) override;
   int64_t load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf, int64_t &total_written, int &needs) override;
-  void do_io_close(int lerrno = -1) override;
 
   ////////////////////////////////////////////////////////////
   // Instances of NetVConnection should be allocated        //
@@ -435,6 +434,8 @@ public:
   }
 
 protected:
+  void _do_io_close(int lerrno) override;
+
   SSL *
   _get_ssl_object() const override
   {

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -271,7 +271,12 @@ public:
 
   friend void write_to_net_io(NetHandler *, UnixNetVConnection *, EThread *);
 
+protected:
+  virtual void _do_io_close(int lerrno);
+
 private:
+  bool _need_do_io_close = false;
+
   virtual void *_prepareForMigration();
   virtual NetProcessor *_getNetProcessor();
 };
@@ -357,7 +362,10 @@ UnixNetVConnection::cancel_active_timeout()
   next_activity_timeout_at = 0;
 }
 
-inline UnixNetVConnection::~UnixNetVConnection() {}
+inline UnixNetVConnection::~UnixNetVConnection()
+{
+  ink_assert(!this->_need_do_io_close);
+}
 
 inline SOCKET
 UnixNetVConnection::get_socket()

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -891,7 +891,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
 SSLNetVConnection::SSLNetVConnection() {}
 
 void
-SSLNetVConnection::do_io_close(int lerrno)
+SSLNetVConnection::_do_io_close(int lerrno)
 {
   if (this->ssl != nullptr) {
     if (get_context() == NET_VCONNECTION_OUT) {
@@ -937,7 +937,7 @@ SSLNetVConnection::do_io_close(int lerrno)
     }
   }
   // Go on and do the unix socket cleanups
-  super::do_io_close(lerrno);
+  super::_do_io_close(lerrno);
 }
 
 void

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -586,14 +586,15 @@ UnixNetVConnection::get_data(int id, void *data)
 VIO *
 UnixNetVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  if (buf) {
-    this->_need_do_io_close = true;
-  }
-
   if (closed && !(c == nullptr && nbytes == 0 && buf == nullptr)) {
     Error("do_io_read invoked on closed vc %p, cont %p, nbytes %" PRId64 ", buf %p", this, c, nbytes, buf);
     return nullptr;
   }
+
+  if (buf) {
+    this->_need_do_io_close = true;
+  }
+
   read.vio.op        = VIO::READ;
   read.vio.mutex     = c ? c->mutex : this->mutex;
   read.vio.cont      = c;
@@ -615,14 +616,15 @@ UnixNetVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 VIO *
 UnixNetVConnection::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *reader, bool owner)
 {
-  if (reader) {
-    this->_need_do_io_close = true;
-  }
-
   if (closed && !(c == nullptr && nbytes == 0 && reader == nullptr)) {
     Error("do_io_write invoked on closed vc %p, cont %p, nbytes %" PRId64 ", reader %p", this, c, nbytes, reader);
     return nullptr;
   }
+
+  if (reader) {
+    this->_need_do_io_close = true;
+  }
+
   write.vio.op        = VIO::WRITE;
   write.vio.mutex     = c ? c->mutex : this->mutex;
   write.vio.cont      = c;


### PR DESCRIPTION
We should always call `do_io_close` if `do_io_read/write` is called. I could implement auto-do_io_close but I didn't, because the intention is to detect abrupt destruction of NetVCs.

This is something similar to #7595, but for Unix/SSLNetVC.