### PR TITLE
Use shared pointer to help with high memory utilization

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -333,7 +333,7 @@ public:
   ink_hrtime sslLastWriteTime = 0;
   int64_t sslTotalBytesSent   = 0;
 
-  SSL_SESSION *client_sess = nullptr;
+  std::shared_ptr<SSL_SESSION> client_sess = nullptr;
 
   // The serverName is either a pointer to the (null-terminated) name fetched from the
   // SSL object or the empty string.

--- a/iocore/net/SSLSessionCache.cc
+++ b/iocore/net/SSLSessionCache.cc
@@ -310,6 +310,13 @@ SSLSessionBucket::removeSession(const SSLSessionID &id)
   return;
 }
 
+// Custom deleter for shared origin sessions
+void
+SSLSessDeleter(SSL_SESSION *_p)
+{
+  SSL_SESSION_free(_p);
+}
+
 /* Session Bucket */
 SSLSessionBucket::SSLSessionBucket() {}
 
@@ -322,10 +329,6 @@ SSLOriginSessionCache::~SSLOriginSessionCache() {}
 void
 SSLOriginSessionCache::insert_session(const std::string &lookup_key, SSL_SESSION *sess, SSL *ssl)
 {
-  if (is_debug_tag_set("ssl.origin_session_cache")) {
-    Debug("ssl.origin_session_cache", "insert session: %s = %p", lookup_key.c_str(), sess);
-  }
-
   size_t len = i2d_SSL_SESSION(sess, nullptr); // make sure we're not going to need more than SSL_MAX_ORIG_SESSION_SIZE bytes
 
   /* do not cache a session that's too big. */
@@ -338,23 +341,34 @@ SSLOriginSessionCache::insert_session(const std::string &lookup_key, SSL_SESSION
     return;
   }
 
-  Ptr<IOBufferData> buf;
-  buf = new_IOBufferData(buffer_size_to_index(len, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-  ink_release_assert(static_cast<size_t>(buf->block_size()) >= len);
-  unsigned char *loc = reinterpret_cast<unsigned char *>(buf->data());
-  i2d_SSL_SESSION(sess, &loc);
+  // Duplicate the session from the connection, we'll be keeping track the ref-count with a shared pointer ourself
+  SSL_SESSION *sess_ptr = SSL_SESSION_dup(sess);
+
+  if (is_debug_tag_set("ssl.origin_session_cache")) {
+    Debug("ssl.origin_session_cache", "insert session: %s = %p", lookup_key.c_str(), sess_ptr);
+  }
+
+  // Create the shared pointer to the session, with the custom deleter
+  std::shared_ptr<SSL_SESSION> shared_sess(sess_ptr, SSLSessDeleter);
   ssl_curve_id curve = (ssl == nullptr) ? 0 : SSLGetCurveNID(ssl);
-  ats_scoped_obj<SSLOriginSession> ssl_orig_session(new SSLOriginSession(lookup_key, buf, len, curve));
+  ats_scoped_obj<SSLOriginSession> ssl_orig_session(new SSLOriginSession(lookup_key, curve, shared_sess));
   auto new_node = ssl_orig_session.release();
 
   std::unique_lock lock(mutex);
   auto entry = orig_sess_map.find(lookup_key);
   if (entry != orig_sess_map.end()) {
     auto node = entry->second;
+    if (is_debug_tag_set("ssl.origin_session_cache")) {
+      Debug("ssl.origin_session_cache", "found duplicate key: %s, replacing %p with %p", lookup_key.c_str(),
+            node->shared_sess.get(), sess_ptr);
+    }
     orig_sess_que.remove(node);
     orig_sess_map.erase(entry);
     delete node;
   } else if (orig_sess_map.size() >= SSLConfigParams::origin_session_cache_size) {
+    if (is_debug_tag_set("ssl.origin_session_cache")) {
+      Debug("ssl.origin_session_cache", "origin session cache full, removing oldest session");
+    }
     remove_oldest_session(lock);
   }
 
@@ -362,8 +376,8 @@ SSLOriginSessionCache::insert_session(const std::string &lookup_key, SSL_SESSION
   orig_sess_map[lookup_key] = new_node;
 }
 
-bool
-SSLOriginSessionCache::get_session(const std::string &lookup_key, SSL_SESSION **sess, ssl_curve_id *curve)
+std::shared_ptr<SSL_SESSION>
+SSLOriginSessionCache::get_session(const std::string &lookup_key, ssl_curve_id *curve)
 {
   if (is_debug_tag_set("ssl.origin_session_cache")) {
     Debug("ssl.origin_session_cache", "get session: %s", lookup_key.c_str());
@@ -372,27 +386,26 @@ SSLOriginSessionCache::get_session(const std::string &lookup_key, SSL_SESSION **
   std::shared_lock lock(mutex);
   auto entry = orig_sess_map.find(lookup_key);
   if (entry == orig_sess_map.end()) {
-    return false;
+    return nullptr;
   }
 
-  const unsigned char *loc = reinterpret_cast<const unsigned char *>(entry->second->asn1_data->data());
-  *sess                    = d2i_SSL_SESSION(nullptr, &loc, entry->second->len_asn1_data);
   if (curve != nullptr) {
     *curve = entry->second->curve_id;
   }
-  return true;
+
+  return entry->second->shared_sess;
 }
 
 void
 SSLOriginSessionCache::remove_oldest_session(const std::unique_lock<std::shared_mutex> &lock)
 {
   // Caller must hold the bucket shared_mutex with unique_lock.
-  ink_assert(lock.owns_lock());
+  ink_release_assert(lock.owns_lock());
 
   while (orig_sess_que.head && orig_sess_que.size >= static_cast<int>(SSLConfigParams::origin_session_cache_size)) {
     auto node = orig_sess_que.pop();
     if (is_debug_tag_set("ssl.origin_session_cache")) {
-      Debug("ssl.origin_session_cache", "remove oldest session: %s", node->key.c_str());
+      Debug("ssl.origin_session_cache", "remove oldest session: %s, session ptr: %p", node->key.c_str(), node->shared_sess.get());
     }
     orig_sess_map.erase(node->key);
     delete node;
@@ -403,14 +416,13 @@ void
 SSLOriginSessionCache::remove_session(const std::string &lookup_key)
 {
   // We can't bail on contention here because this session MUST be removed.
-  if (is_debug_tag_set("ssl.origin_session_cache")) {
-    Debug("ssl.origin_session_cache", "remove session: %s", lookup_key.c_str());
-  }
-
   std::unique_lock lock(mutex);
   auto entry = orig_sess_map.find(lookup_key);
   if (entry != orig_sess_map.end()) {
     auto node = entry->second;
+    if (is_debug_tag_set("ssl.origin_session_cache")) {
+      Debug("ssl.origin_session_cache", "remove session: %s, session ptr: %p", lookup_key.c_str(), node->shared_sess.get());
+    }
     orig_sess_que.remove(node);
     orig_sess_map.erase(entry);
     delete node;

--- a/iocore/net/SSLSessionCache.h
+++ b/iocore/net/SSLSessionCache.h
@@ -188,12 +188,11 @@ class SSLOriginSession
 {
 public:
   std::string key;
-  Ptr<IOBufferData> asn1_data; /* this is the ASN1 representation of the SSL_CTX */
-  size_t len_asn1_data;
   ssl_curve_id curve_id;
+  std::shared_ptr<SSL_SESSION> shared_sess = nullptr;
 
-  SSLOriginSession(const std::string &lookup_key, const Ptr<IOBufferData> &asn1, size_t len_asn1, ssl_curve_id curve)
-    : key(lookup_key), asn1_data(asn1), len_asn1_data(len_asn1), curve_id(curve)
+  SSLOriginSession(const std::string &lookup_key, ssl_curve_id curve, std::shared_ptr<SSL_SESSION> session)
+    : key(lookup_key), curve_id(curve), shared_sess(session)
   {
   }
 
@@ -207,7 +206,7 @@ public:
   ~SSLOriginSessionCache();
 
   void insert_session(const std::string &lookup_key, SSL_SESSION *sess, SSL *ssl);
-  bool get_session(const std::string &lookup_key, SSL_SESSION **sess, ssl_curve_id *curve);
+  std::shared_ptr<SSL_SESSION> get_session(const std::string &lookup_key, ssl_curve_id *curve);
   void remove_session(const std::string &lookup_key);
 
 private:

--- a/iocore/net/TLSSessionResumptionSupport.h
+++ b/iocore/net/TLSSessionResumptionSupport.h
@@ -51,7 +51,7 @@ public:
   ssl_curve_id getSSLCurveNID() const;
 
   SSL_SESSION *getSession(SSL *ssl, const unsigned char *id, int len, int *copy);
-  SSL_SESSION *getOriginSession(SSL *ssl, const std::string &lookup_key);
+  std::shared_ptr<SSL_SESSION> getOriginSession(SSL *ssl, const std::string &lookup_key);
 
 protected:
   void clear();


### PR DESCRIPTION
We've been seeing some high memory utilization after turning on origin session cache in production. After some investigation, I find that the cause is due connections (anywhere from 20~50) could be using the same session at the same time. And since the sessions are stored in a way such that when a new connections requests for a session, it allocates a new one for that connection (to prevent double freeing when connection closes, and avoid using OpenSSL's internal ref-counter to have less ambiguity), it uses a lot more memory than what I expected. 

Some calculations here:
Session objects for origin sessions are limited to 4KB each, default cache pool size is 10240, the 50x multiplication factor increase the size from 40MB to 2GB. Not too big of a problem on hosts with lots of memory, but for some smaller ones it is bad news.

The changes in this PR uses shared pointer to share sessions among connections, this will help with high memory utilization. It also eliminates `d2i_SSL_SESSION`/`i2d_SSL_SESSION` conversions all together, so there's a slight performance improvement as well.