### PR TITLE
Change TSMimeHdrFieldNext to use field iterators for better performance.

### DIFF
--- a/proxy/hdrs/MIME.cc
+++ b/proxy/hdrs/MIME.cc
@@ -1691,6 +1691,19 @@ mime_hdr_field_delete(HdrHeap *heap, MIMEHdrImpl *mh, MIMEField *field, bool del
   MIME_HDR_SANITY_CHECK(mh);
 }
 
+auto
+MIMEHdrImpl::find(MIMEField const *field) -> iterator
+{
+  for (MIMEFieldBlockImpl *fblock = &m_first_fblock; fblock != nullptr; fblock = fblock->m_next) {
+    if (fblock->contains(field)) {
+      return {fblock, unsigned(field - fblock->m_field_slots)};
+    }
+  }
+  return {};
+}
+
+// This function needs to be removed - use of it indicates poorly implemented code.
+// That code should be updated to use the field iterators, which are much more performant.
 int
 mime_hdr_field_slotnum(MIMEHdrImpl *mh, MIMEField *field)
 {

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -334,6 +334,14 @@ struct MIMEHdrImpl : public HdrHeapObjImpl {
   iterator begin();
   /// Iterator past last field.
   iterator end();
+
+  /** Find a field by address.
+   *
+   * @param field Target to find.
+   * @return An iterator referencing @a field if it is in the header, an empty iterator
+   * if not.
+   */
+  iterator find(MIMEField const *field);
 };
 
 inline auto


### PR DESCRIPTION
This still must do an initial block scan to find the pointer, but it at least tracks the block as it iterates for the next field instead of block scanning *every time*. What would help beyond this is passing back the block ptr as part of the plugin API.