### PR TITLE
Add proxy.config.http2.stream_error_sampling_threshold

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4157,6 +4157,11 @@ HTTP/2 Configuration
    |TS| gracefully closes connections that have stream error rates above this
    setting by sending GOAWAY frames.
 
+.. ts:cv:: CONFIG proxy.config.http2.stream_error_sampling_threashold INT 10
+   :reloadable:
+
+   This is the threashold of sampling stream number to start checking the stream error rate.
+
 .. ts:cv:: CONFIG proxy.config.http2.max_settings_per_frame INT 7
    :reloadable:
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1368,6 +1368,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http2.stream_error_rate_threshold", RECD_FLOAT, "0.1", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http2.stream_error_sampling_threshold", RECD_INT, "10", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.http2.max_settings_per_frame", RECD_INT, "7", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http2.max_settings_per_minute", RECD_INT, "14", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -784,33 +784,34 @@ http2_decode_header_blocks(HTTPHdr *hdr, const uint8_t *buf_start, const uint32_
 }
 
 // Initialize this subsystem with librecords configs (for now)
-uint32_t Http2::max_concurrent_streams_in      = 100;
-uint32_t Http2::min_concurrent_streams_in      = 10;
-uint32_t Http2::max_active_streams_in          = 0;
-bool Http2::throttling                         = false;
-uint32_t Http2::stream_priority_enabled        = 0;
-uint32_t Http2::initial_window_size            = 65535;
-uint32_t Http2::max_frame_size                 = 16384;
-uint32_t Http2::header_table_size              = 4096;
-uint32_t Http2::max_header_list_size           = 4294967295;
-uint32_t Http2::accept_no_activity_timeout     = 120;
-uint32_t Http2::no_activity_timeout_in         = 120;
-uint32_t Http2::active_timeout_in              = 0;
-uint32_t Http2::push_diary_size                = 256;
-uint32_t Http2::zombie_timeout_in              = 0;
-float Http2::stream_error_rate_threshold       = 0.1;
-uint32_t Http2::max_settings_per_frame         = 7;
-uint32_t Http2::max_settings_per_minute        = 14;
-uint32_t Http2::max_settings_frames_per_minute = 14;
-uint32_t Http2::max_ping_frames_per_minute     = 60;
-uint32_t Http2::max_priority_frames_per_minute = 120;
-float Http2::min_avg_window_update             = 2560.0;
-uint32_t Http2::con_slow_log_threshold         = 0;
-uint32_t Http2::stream_slow_log_threshold      = 0;
-uint32_t Http2::header_table_size_limit        = 65536;
-uint32_t Http2::write_buffer_block_size        = 262144;
-float Http2::write_size_threshold              = 0.5;
-uint32_t Http2::write_time_threshold           = 100;
+uint32_t Http2::max_concurrent_streams_in       = 100;
+uint32_t Http2::min_concurrent_streams_in       = 10;
+uint32_t Http2::max_active_streams_in           = 0;
+bool Http2::throttling                          = false;
+uint32_t Http2::stream_priority_enabled         = 0;
+uint32_t Http2::initial_window_size             = 65535;
+uint32_t Http2::max_frame_size                  = 16384;
+uint32_t Http2::header_table_size               = 4096;
+uint32_t Http2::max_header_list_size            = 4294967295;
+uint32_t Http2::accept_no_activity_timeout      = 120;
+uint32_t Http2::no_activity_timeout_in          = 120;
+uint32_t Http2::active_timeout_in               = 0;
+uint32_t Http2::push_diary_size                 = 256;
+uint32_t Http2::zombie_timeout_in               = 0;
+float Http2::stream_error_rate_threshold        = 0.1;
+uint32_t Http2::stream_error_sampling_threshold = 10;
+uint32_t Http2::max_settings_per_frame          = 7;
+uint32_t Http2::max_settings_per_minute         = 14;
+uint32_t Http2::max_settings_frames_per_minute  = 14;
+uint32_t Http2::max_ping_frames_per_minute      = 60;
+uint32_t Http2::max_priority_frames_per_minute  = 120;
+float Http2::min_avg_window_update              = 2560.0;
+uint32_t Http2::con_slow_log_threshold          = 0;
+uint32_t Http2::stream_slow_log_threshold       = 0;
+uint32_t Http2::header_table_size_limit         = 65536;
+uint32_t Http2::write_buffer_block_size         = 262144;
+float Http2::write_size_threshold               = 0.5;
+uint32_t Http2::write_time_threshold            = 100;
 
 void
 Http2::init()
@@ -829,6 +830,7 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(push_diary_size, "proxy.config.http2.push_diary_size");
   REC_EstablishStaticConfigInt32U(zombie_timeout_in, "proxy.config.http2.zombie_debug_timeout_in");
   REC_EstablishStaticConfigFloat(stream_error_rate_threshold, "proxy.config.http2.stream_error_rate_threshold");
+  REC_EstablishStaticConfigInt32U(stream_error_sampling_threshold, "proxy.config.http2.stream_error_sampling_threshold");
   REC_EstablishStaticConfigInt32U(max_settings_per_frame, "proxy.config.http2.max_settings_per_frame");
   REC_EstablishStaticConfigInt32U(max_settings_per_minute, "proxy.config.http2.max_settings_per_minute");
   REC_EstablishStaticConfigInt32U(max_settings_frames_per_minute, "proxy.config.http2.max_settings_frames_per_minute");

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -396,6 +396,7 @@ public:
   static uint32_t push_diary_size;
   static uint32_t zombie_timeout_in;
   static float stream_error_rate_threshold;
+  static uint32_t stream_error_sampling_threshold;
   static uint32_t max_settings_per_frame;
   static uint32_t max_settings_per_minute;
   static uint32_t max_settings_frames_per_minute;

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -283,6 +283,10 @@ Http2ConnectionState::get_stream_error_rate() const
 {
   int total = get_stream_requests();
 
+  if (static_cast<uint32_t>(total) < Http2::stream_error_sampling_threshold) {
+    return 0;
+  }
+
   if (total >= (1 / Http2::stream_error_rate_threshold)) {
     return (double)stream_error_count / (double)total;
   } else {


### PR DESCRIPTION
We faced a situation to increase the `proxy.config.http2.stream_error_rate_threshold` (default `0.1`) and noticed that increasing the rate reduces the sampling number in the `Http2ConnectionState::get_stream_error_rate()`.
- e.g. Imagine an error happens on the first stream, with 0.1 we would kill the conn after another 9 successful streams but at 0.3 we would kill the connection after just another 3 streams I think ( from Leif )

I'd like to introduce a config to set the minimum threshold of the sampling number.

----

Co-authored-by: Leif Hedstrom <zwoop@apache.org>