### PR TITLE
Marks tls_engine test as OpenSSL-only

### DIFF
--- a/tests/gold_tests/tls/tls_engine.test.py
+++ b/tests/gold_tests/tls/tls_engine.test.py
@@ -27,7 +27,10 @@ Test.Summary = '''
 Test tls via the async interface with the sample async_engine
 '''
 
-Test.SkipUnless(Condition.HasOpenSSLVersion('1.1.1'))
+Test.SkipUnless(
+    Condition.HasOpenSSLVersion('1.1.1'),
+    Condition.IsOpenSSL(),
+)
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)


### PR DESCRIPTION
Test exercises OpenSSL specific APIs