### PR TITLE
AuTest: address various permissions issues

### DIFF
--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -1121,7 +1121,7 @@ ContentTypeHandler::loadAllowList(std::string const &file_spec)
   bool extra_junk_on_line{false};
   int line_num = 0;
 
-  fs.open(file_spec);
+  fs.open(file_spec, std::ios_base::in);
   if (fs.good()) {
     for (;;) {
       ++line_num;

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -85,14 +85,13 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     p.Setup.Copy(p.Variables.BINDIR, bin_path, CopyLogic.SoftFiles)
 
     # setup config directory
+    AddMethodToInstance(p, chownForATSProcess)
 
     # copy all basic config files we need to get this to work
     cfg_dir = os.path.join(AUTEST_SITE_PATH, "min_cfg")
 
     p.Setup.MakeDir(config_dir)
-    p.Setup.Chown(config_dir, "nobody", "nobody", ignore=True)
-    # covers ubuntu's unprivileged group
-    p.Setup.Chown(config_dir, "nobody", "nogroup", ignore=True)
+    p.chownForATSProcess(config_dir)
 
     for f in os.listdir(cfg_dir):
         p.Setup.CopyAs(os.path.join(cfg_dir, f), config_dir)
@@ -126,9 +125,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     # create subdirectories that need to exist (but are empty)
     # log directory has to be created with correct permissions
     p.Setup.MakeDir(log_dir)  # log directory has to be created
-    p.Setup.Chown(log_dir, "nobody", "nobody", ignore=True)
-    # covers ubuntu's unprivileged group
-    p.Setup.Chown(log_dir, "nobody", "nogroup", ignore=True)
+    p.chownForATSProcess(log_dir)
 
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_LOG_LOGFILE_DIR'] = log_dir
@@ -143,9 +140,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     p.Variables.LOCALSTATEDIR = runtime_dir
 
     p.Setup.MakeDir(runtime_dir)
-    p.Setup.Chown(runtime_dir, "nobody", "nobody", ignore=True)
-    # covers ubuntu's unprivileged group
-    p.Setup.Chown(runtime_dir, "nobody", "nogroup", ignore=True)
+    p.chownForATSProcess(runtime_dir)
 
     # will need this for traffic_manager is it runs
     p.Setup.MakeDir(os.path.join(config_dir, 'snapshots'))
@@ -154,9 +149,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     # create subdirectories that need to exist (but are empty)
     # ssl directory has to be created for keeping certs and keys
     p.Setup.MakeDir(ssl_dir)
-    p.Setup.Chown(ssl_dir, "nobody", "nobody", ignore=True)
-    # covers ubuntu's unprivileged server
-    p.Setup.Chown(ssl_dir, "nobody", "nogroup", ignore=True)
+    p.chownForATSProcess(ssl_dir)
 
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_SSL_DIR'] = ssl_dir
@@ -169,9 +162,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     ########################################################
     # cache.db directory
     p.Setup.MakeDir(storage_dir)
-    p.Setup.Chown(storage_dir, "nobody", "nobody", ignore=True)
-    # covers ubuntu's unprivileged group
-    p.Setup.Chown(storage_dir, "nobody", "nogroup", ignore=True)
+    p.chownForATSProcess(storage_dir)
 
     # set env so traffic server uses correct locations
     p.Env['PROXY_CONFIG_STORAGE_DIR'] = storage_dir
@@ -461,6 +452,12 @@ class RecordsConfig(Config, dict):
 ##########################################################################
 
 
+def chownForATSProcess(self, path):
+    self.Setup.Chown(path, "nobody", "nobody", ignore=True)
+    # covers ubuntu's unprivileged group
+    self.Setup.Chown(path, "nobody", "nogroup", ignore=True)
+
+
 def addSSLfile(self, filename):
     self.Setup.CopyAs(filename, self.Variables.SSLDir)
 
@@ -476,4 +473,5 @@ def addSSLFileFromDefaultTestFolder(self, filename):
 
 RegisterFileType(Config, "ats:config")
 RegisterFileType(RecordsConfig, "ats:config:records")
+ExtendTestRun(chownForATSProcess, name="ChownForATSProcess")
 ExtendTest(MakeATSProcess, name="MakeATSProcess")

--- a/tests/gold_tests/pluginTest/combo_handler/combo_handler.test.py
+++ b/tests/gold_tests/pluginTest/combo_handler/combo_handler.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+
 Test.Summary = '''
 Test combo_handler plugin
 '''
@@ -104,12 +106,8 @@ ts.Disk.remap_config.AddLine(
     'map http://localhost/sub/ http://127.0.0.1:{}/sub/'.format(server.Variables.Port)
 )
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/ctwl.txt", id="ctwl_cfg", typename="ats:config")
-ts.Disk.ctwl_cfg.AddLine("# test  ")
-ts.Disk.ctwl_cfg.AddLine("")
-ts.Disk.ctwl_cfg.AddLine("		text/javascript  # test side comment")
-ts.Disk.ctwl_cfg.AddLine("  application/javascript")
-ts.Disk.ctwl_cfg.AddLine("text/css")
+# Configure the combo_handler's configuration file.
+ts.Setup.Copy("ctwl.txt", ts.Variables.CONFIGDIR)
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/pluginTest/combo_handler/ctwl.txt
+++ b/tests/gold_tests/pluginTest/combo_handler/ctwl.txt
@@ -1,0 +1,5 @@
+# test
+
+		text/javascript  # test side comment
+  application/javascript
+text/css

--- a/tests/gold_tests/pluginTest/lua/lua_watermark.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_watermark.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+
 Test.Summary = '''
 Test lua functionality
 '''
@@ -41,8 +43,11 @@ server.addResponse("sessionfile.log", request_header, response_header)
 
 ts.Disk.remap_config.AddLine(
     'map / http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=tslua.so @pparam={}/watermark.lua'.format(Test.TestDirectory)
+    ' @plugin=tslua.so @pparam=watermark.lua'
 )
+
+# Configure the tslua's configuration file.
+ts.Setup.Copy("watermark.lua", ts.Variables.CONFIGDIR)
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,

--- a/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
@@ -26,9 +26,6 @@ Test.SkipUnless(
 )
 Test.ContinueOnFail = True
 
-# test_hooks.so will output test logging to this file.
-Test.Env["OUTPUT_FILE"] = Test.RunDirectory + "/log.txt"
-
 server = Test.MakeOriginServer("server")
 
 request_header = {
@@ -39,6 +36,10 @@ server.addResponse("sessionlog.json", request_header, response_header)
 # Disable the cache to make sure each request is forwarded to the origin
 # server.
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_cache=False)
+
+# test_hooks.so will output test logging to this file.
+log_path = os.path.join(ts.Variables.LOGDIR, "log.txt")
+Test.Env["OUTPUT_FILE"] = log_path
 
 ts.addDefaultSSLFiles()
 
@@ -96,6 +97,6 @@ tr.Processes.Default.ReturnCode = 0
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "echo check log"
 tr.Processes.Default.ReturnCode = 0
-f = tr.Disk.File("log.txt")
+f = tr.Disk.File(log_path)
 f.Content = "log.gold"
 f.Content += Testers.ContainsExpression("Global: event=TS_EVENT_VCONN_CLOSE", "VCONN_CLOSE should trigger 2 times")

--- a/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
+++ b/tests/gold_tests/pluginTest/url_sig/url_sig.test.py
@@ -63,35 +63,36 @@ ts.Disk.ssl_multicert_config.AddLine(
 
 # Use unchanged incoming URL.
 #
+ts.Setup.Copy("url_sig.config", ts.Variables.CONFIGDIR)
 ts.Disk.remap_config.AddLine(
-    'map http://one.two.three/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=url_sig.so @pparam={}/url_sig.config'.format(Test.TestDirectory)
+    f'map http://one.two.three/ http://127.0.0.1:{server.Variables.Port}/' +
+    ' @plugin=url_sig.so @pparam=url_sig.config'
 )
 
 # Use unchanged incoming HTTPS URL.
 #
 ts.Disk.remap_config.AddLine(
-    'map https://one.two.three/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=url_sig.so @pparam={}/url_sig.config'.format(Test.TestDirectory)
+    f'map https://one.two.three/ http://127.0.0.1:{server.Variables.Port}/' +
+    ' @plugin=url_sig.so @pparam=url_sig.config'
 )
 
 # Use pristine URL, incoming URL unchanged.
 #
 ts.Disk.remap_config.AddLine(
-    'map http://four.five.six/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=url_sig.so @pparam={}/url_sig.config @pparam=pristineurl'.format(Test.TestDirectory)
+    f'map http://four.five.six/ http://127.0.0.1:{server.Variables.Port}/' +
+    ' @plugin=url_sig.so @pparam=url_sig.config @pparam=pristineurl'
 )
 
 # Use pristine URL, incoming URL changed.
 #
 ts.Disk.remap_config.AddLine(
-    'map http://seven.eight.nine/ http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=url_sig.so @pparam={}/url_sig.config @pparam=PristineUrl'.format(Test.TestDirectory)
+    f'map http://seven.eight.nine/ http://127.0.0.1:{server.Variables.Port}' +
+    ' @plugin=url_sig.so @pparam=url_sig.config @pparam=PristineUrl'
 )
 
 # Validation failure tests.
 
-LogTee = " 2>&1 | grep '^<' | tee -a {}/url_sig_long.log".format(Test.RunDirectory)
+LogTee = f" 2>&1 | grep '^<' | tee -a {Test.RunDirectory}/url_sig_long.log"
 
 # Bad client / MD5 / P=101 / URL pristine / URL altered.
 #
@@ -100,7 +101,7 @@ tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.2&E=33046620008&A=2&K=13&P=101&S=d1f352d4f1d931ad2f441013402d93f8'" +
     LogTee
 )
@@ -110,7 +111,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=1&A=2&K=13&P=010&S=f237aad1fa010234d7bf8108a0e36387'" +
     LogTee
 )
@@ -120,7 +121,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&K=13&P=101&S=d1f352d4f1d931ad2f441013402d93f8'" +
     LogTee
 )
@@ -130,7 +131,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=3&K=13&P=101&S=d1f352d4f1d931ad2f441013402d93f8'" +
     LogTee
 )
@@ -140,7 +141,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=2&K=13&S=d1f352d4f1d931ad2f441013402d93f8'" +
     LogTee
 )
@@ -150,7 +151,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=2&K=13&P=10&S=d1f352d4f1d931ad2f441013402d93f8'" +
     LogTee
 )
@@ -160,7 +161,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=2&K=13&P=101'" +
     LogTee
 )
@@ -170,7 +171,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=2&K=13&P=101&S=d1f452d4f1d931ad2f441013402d93f8'" +
     LogTee
 )
@@ -180,7 +181,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=2&&K=13&P=101&S=d1f352d4f1d931ad2f441013402d93f8#'" +
     LogTee
 )
@@ -192,7 +193,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://four.five.six/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://four.five.six/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046618556&A=1&K=15&P=1&S=f4103561a23adab7723a89b9831d77e0afb61d92'" +
     LogTee
 )
@@ -202,7 +203,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?E=33046618586&A=2&K=0&P=1&S=0364efa28afe345544596705b92d20ac'" +
     LogTee
 )
@@ -212,7 +213,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046619717&A=2&K=13&P=010&S=f237aad1fa010234d7bf8108a0e36387'" +
     LogTee
 )
@@ -222,7 +223,7 @@ tr.Processes.Default.Command = (
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} 'http://seven.eight.nine/".format(ts.Variables.port) +
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} 'http://seven.eight.nine/" +
     "foo/abcde/qrstuvwxyz?C=127.0.0.1&E=33046620008&A=2&K=13&P=101&S=d1f352d4f1d931ad2f441013402d93f8'" +
     LogTee
 )
@@ -238,25 +239,25 @@ def sign(payload, key):
 # No client / SHA1 / P=1 / URL not pristine / URL not altered.
 #
 path = "foo/abcde/qrstuvwxyz?E=33046618506&A=1&K=7&P=1&S="
-to_sign = "127.0.0.1:{}/".format(server.Variables.Port) + path
+to_sign = f"127.0.0.1:{server.Variables.Port}/{path}"
 url = "http://one.two.three/" + path + sign(to_sign, "dqsgopTSM_doT6iAysasQVUKaPykyb6e")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --proxy http://127.0.0.1:{} '{}'".format(ts.Variables.port, url) + LogTee
+    f"curl --verbose --proxy http://127.0.0.1:{ts.Variables.port} '{url}'" + LogTee
 )
 
 # No client / SHA1 / P=1 / URL not pristine / URL not altered -- HTTPS.
 #
 path = "foo/abcde/qrstuvwxyz?E=33046618506&A=1&K=7&P=1&S="
-to_sign = "127.0.0.1:{}/".format(server.Variables.Port) + path
-url = "https://127.0.0.1:{}/".format(ts.Variables.ssl_port) + path + sign(to_sign, "dqsgopTSM_doT6iAysasQVUKaPykyb6e")
+to_sign = f"127.0.0.1:{server.Variables.Port}/{path}"
+url = f"https://127.0.0.1:{ts.Variables.ssl_port}/{path}" + sign(to_sign, "dqsgopTSM_doT6iAysasQVUKaPykyb6e")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    "curl --verbose --http1.1 --insecure --header 'Host: one.two.three' '{}'".format(url) +
+    f"curl --verbose --http1.1 --insecure --header 'Host: one.two.three' '{url}'" +
     LogTee + " ; grep -F -e '< HTTP' -e Authorization {0}/url_sig_long.log > {0}/url_sig_short.log ".format(ts.RunDirectory)
 )
 

--- a/tests/gold_tests/runroot/runroot_manager.test.py
+++ b/tests/gold_tests/runroot/runroot_manager.test.py
@@ -24,13 +24,13 @@ Test for using of runroot of traffic_manager.
 Test.ContinueOnFail = False
 
 # create runroot for testing
-path = os.path.join(Test.RunDirectory, "runroot")
+runroot_path = os.path.join(Test.RunDirectory, "runroot")
 rr_file = os.path.join(Test.RunDirectory, "rr_tmp")
 
 tr = Test.AddTestRun("create runroot and deal with it")
-tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + path + " --absolute; " + \
+tr.Processes.Default.Command = "$ATS_BIN/traffic_layout init --path " + runroot_path + " --absolute; " + \
     "mkdir " + rr_file + "; mv " + \
-    os.path.join(path, "runroot.yaml") + " " + \
+    os.path.join(runroot_path, "runroot.yaml") + " " + \
     os.path.join(rr_file, "runroot.yaml")
 f = tr.Disk.File(os.path.join(rr_file, "runroot.yaml"))
 f.Exists = True
@@ -43,8 +43,12 @@ def StopProcess(event, time):
 
 
 tr = Test.AddTestRun("manager runroot test")
+
+trafficserver_dir = os.path.join(runroot_path, 'var', 'trafficserver')
+tr.ChownForATSProcess(trafficserver_dir)
+
 p = tr.Processes.Default
 p.Command = "$ATS_BIN/traffic_manager --run-root=" + rr_file
 p.RunningEvent.Connect(Testers.Lambda(lambda ev: StopProcess(ev, 10)))
 p.Streams.All = Testers.ContainsExpression("traffic_server: using root directory '" +
-                                           path + "'", "check if the right runroot is passed down")
+                                           runroot_path + "'", "check if the right runroot is passed down")

--- a/tests/gold_tests/tls/tls_client_verify3.test.py
+++ b/tests/gold_tests/tls/tls_client_verify3.test.py
@@ -33,22 +33,25 @@ server.addResponse("sessionlog.json", request_header, response_header)
 ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
-ts.Setup.Copy(Test.TestDirectory + "/ssl/bbb-ca.pem", ts.Variables.CONFIGDIR)
+ts.Setup.Copy("ssl/bbb-ca.pem", ts.Variables.CONFIGDIR)
+ts.Setup.Copy("ssl/bbb-signed.key", ts.Variables.SSLDir)
+ts.Setup.Copy("ssl/bbb-signed.pem", ts.Variables.SSLDir)
+ts.Setup.Copy("ssl/aaa-ca.pem", ts.Variables.SSLDir)
+ts.Setup.Copy("ssl/ccc-ca.pem", ts.Variables.SSLDir)
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
     'proxy.config.url_remap.pristine_host_hdr': 1,
     'proxy.config.ssl.client.certification_level': 2,
-    'proxy.config.ssl.CA.cert.filename': '{0}/ssl/aaa-ca.pem'.format(Test.TestDirectory),
+    'proxy.config.ssl.CA.cert.filename': f'{ts.Variables.SSLDir}/aaa-ca.pem',
     'proxy.config.ssl.TLSv1_3': 0
 })
 
 ts.Disk.ssl_multicert_config.AddLine(
-    'ssl_cert_name={0}/bbb-signed.pem ssl_key_name={0}/bbb-signed.key'.format(Test.TestDirectory + "/ssl")
+    'ssl_cert_name=bbb-signed.pem ssl_key_name=bbb-signed.key'
 )
 ts.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
@@ -56,7 +59,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 
 # Just map everything through to origin.  This test is concentrating on the user-agent side.
 ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}/'.format(server.Variables.Port)
+    f'map / http://127.0.0.1:{server.Variables.Port}/'
 )
 
 ts.Disk.sni_yaml.AddLines([
@@ -70,7 +73,7 @@ ts.Disk.sni_yaml.AddLines([
     '- fqdn: ccc.com',
     '  verify_client: STRICT',
     '  verify_client_ca_certs:',
-    '    file: {}/ssl/ccc-ca.pem'.format(Test.TestDirectory),
+    f'    file: {ts.Variables.SSLDir}/ccc-ca.pem'
 ])
 
 # Success test runs.


### PR DESCRIPTION
By default, the Traffic Server process runs as user nobody. This often isn't a
problem with the AuTest runs, but in certain circumstances this process will
not be able to either read or write from certain locations. For instance, by
default, shells in docker containers run as root and the home directory is
/root with permissions set to 550. There's nothing fundamental about AuTest
that prevents this, but since the ATS process is unprivileged it will not be
able to read or write to anything in /root.  There can be other manifestations
of permissions limitations like this.

The AuTest Traffic Server extension already sets up various directories in the
sandbox chowned to nobody for the ATS process to access. This tweaks a few of
the tests that assumed ATS access outside of these directories to use these
designated ones. This allows the test to run in more environments.

(cherry picked from commit 36440ef175d08f33887551f7dc721c68c6d97147)

Conflicts:
    tests/gold_tests/tls/tls_client_verify3.test.py