### PR TITLE
For test async_engine, export all symbols

### DIFF
--- a/tests/tools/plugins/Makefile.inc
+++ b/tests/tools/plugins/Makefile.inc
@@ -82,4 +82,9 @@ tools_plugins_user_args_la_SOURCES = tools/plugins/user_args.cc
 
 noinst_LTLIBRARIES += tools/plugins/async_engine.la
 tools_plugins_async_engine_la_SOURCES = tools/plugins/async_engine.cc
+tools_plugins_async_engine_la_LDFLAGS = \
+  -module \
+  -shared \
+  -avoid-version \
+  -rpath $(abs_builddir)
 


### PR DESCRIPTION
This fixes the test run for tls_engine on macOS

(cherry picked from commit 63f2aeac4ceb04166f87e904ed73661bf9ea0f05)

Conflicts:
    tests/gold_tests/logging/log-filenames.test.py