### PR TITLE
Prevent bad ssl_multicert.config load from being swapped in

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -559,7 +559,7 @@ SSLCertificateConfig::reconfigure()
 
   // If there are errors in the certificate configs and we had wanted to exit on error
   // we won't want to reset the config
-  if (lookup->is_valid || !params->configExitOnLoadError) {
+  if (retStatus || !params->configExitOnLoadError) {
     configid = configProcessor.set(configid, lookup);
   } else {
     delete lookup;


### PR DESCRIPTION
retStatus contains the load status of the config file, but wasn't used
to check if it successful before being swapped in

This is a follow up to #8256