### PR TITLE
url_sig: change cleanup msg from TSError to TSDebug

### DIFF
--- a/plugins/experimental/url_sig/url_sig.c
+++ b/plugins/experimental/url_sig/url_sig.c
@@ -66,7 +66,7 @@ struct config {
 static void
 free_cfg(struct config *cfg)
 {
-  TSError("[url_sig] Cleaning up");
+  TSDebug(PLUGIN_NAME, "Cleaning up");
   TSfree(cfg->err_url);
   TSfree(cfg->sig_anchor);
 


### PR DESCRIPTION
This removes an annoying message from url_sig whenever configs are reloaded.