### PR TITLE
Remove unused function "ats_mallopt"

### DIFF
--- a/include/tscore/ink_memory.h
+++ b/include/tscore/ink_memory.h
@@ -99,7 +99,6 @@ void *ats_realloc(void *ptr, size_t size);
 void *ats_memalign(size_t alignment, size_t size);
 void ats_free(void *ptr);
 void *ats_free_null(void *ptr);
-int ats_mallopt(int param, int value);
 
 int ats_msync(caddr_t addr, size_t len, caddr_t end, int flags);
 int ats_madvise(caddr_t addr, size_t len, int flags);

--- a/src/tscore/ink_memory.cc
+++ b/src/tscore/ink_memory.cc
@@ -131,28 +131,6 @@ ats_free_null(void *ptr)
   return nullptr;
 } /* End ats_free_null */
 
-// This effectively makes mallopt() a no-op (currently) when tcmalloc
-// or jemalloc is used. This might break our usage for increasing the
-// number of mmap areas (ToDo: Do we still really need that??).
-//
-// TODO: I think we might be able to get rid of this?
-int
-ats_mallopt(int param ATS_UNUSED, int value ATS_UNUSED)
-{
-#if TS_HAS_JEMALLOC
-// TODO: jemalloc code ?
-#else
-#if TS_HAS_TCMALLOC
-// TODO: tcmalloc code ?
-#else
-#if defined(__GLIBC__)
-  return mallopt(param, value);
-#endif // ! defined(__GLIBC__)
-#endif // ! TS_HAS_TCMALLOC
-#endif // ! TS_HAS_JEMALLOC
-  return 0;
-}
-
 ats_unique_buf
 ats_unique_malloc(size_t size)
 {


### PR DESCRIPTION
I don't think we're using this `ats_mallopt` function anymore.