### PR TITLE
Add a knob to enable kTLS 

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3806,6 +3806,18 @@ SSL Termination
 
    This feature is disabled by default.
 
+.. ts:cv:: CONFIG proxy.config.ssl.ktls.enabled INT 0
+
+   Enables the use of Kernel TLS. This configuration requires OpenSSL v3.0 and
+   above, and it must have been compiled with support for Kernel TLS.
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``0`` Disables the use of Kernel TLS.
+   ``1`` Enables the use of Kernel TLS..
+   ===== ======================================================================
+
 Client-Related Configuration
 ----------------------------
 

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -108,6 +108,8 @@ struct SSLConfigParams : public ConfigInfo {
 
   char *keylog_file;
 
+  static bool ssl_ktls_enabled;
+
   static uint32_t server_max_early_data;
   static uint32_t server_recv_max_early_data;
   static bool server_allow_early_data_params;

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -224,6 +224,7 @@ private:
   virtual bool _set_npn_callback(SSL_CTX *ctx);
   virtual bool _set_alpn_callback(SSL_CTX *ctx);
   virtual bool _set_keylog_callback(SSL_CTX *ctx);
+  virtual bool _enable_ktls(SSL_CTX *ctx);
 };
 
 // Create a new SSL server context fully configured (cert and keys are optional).

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -435,6 +435,11 @@ SSLConfigParams::initialize()
   }
 
   REC_ReadConfigInt32(ssl_ktls_enabled, "proxy.config.ssl.ktls.enabled");
+#ifndef SSL_OP_ENABLE_KTLS
+  if (ssl_ktls_enabled) {
+    Error("kTLS configured but not supported by OpenSSL library");
+  }
+#endif
 
   REC_ReadConfigInt32(ssl_allow_client_renegotiation, "proxy.config.ssl.allow_client_renegotiation");
 

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -76,6 +76,7 @@ size_t SSLConfigParams::session_cache_max_bucket_size       = 100;
 init_ssl_ctx_func SSLConfigParams::init_ssl_ctx_cb          = nullptr;
 load_ssl_file_func SSLConfigParams::load_ssl_file_cb        = nullptr;
 IpMap *SSLConfigParams::proxy_protocol_ipmap                = nullptr;
+bool SSLConfigParams::ssl_ktls_enabled                      = false;
 
 const uint32_t EARLY_DATA_DEFAULT_SIZE               = 16384;
 uint32_t SSLConfigParams::server_max_early_data      = 0;
@@ -432,6 +433,8 @@ SSLConfigParams::initialize()
   } else {
     TLSKeyLogger::enable_keylogging(keylog_file);
   }
+
+  REC_ReadConfigInt32(ssl_ktls_enabled, "proxy.config.ssl.ktls.enabled");
 
   REC_ReadConfigInt32(ssl_allow_client_renegotiation, "proxy.config.ssl.allow_client_renegotiation");
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -170,7 +170,7 @@ SSLNetVConnection::_make_ssl_connection(SSL_CTX *ctx)
     } else {
       this->initialize_handshake_buffers();
       BIO *rbio = BIO_new(BIO_s_mem());
-      BIO *wbio = BIO_new_fd(this->get_socket(), BIO_NOCLOSE);
+      BIO *wbio = BIO_new_socket(this->get_socket(), BIO_NOCLOSE);
       BIO_set_mem_eof_return(wbio, -1);
       SSL_set_bio(ssl, rbio, wbio);
 
@@ -515,7 +515,7 @@ SSLNetVConnection::update_rbio(bool move_to_socket)
       retval = true;
       // Handshake buffer is empty but we have read something, move to the socket rbio
     } else if (move_to_socket && this->handShakeHolder->is_read_avail_more_than(0)) {
-      BIO *rbio = BIO_new_fd(this->get_socket(), BIO_NOCLOSE);
+      BIO *rbio = BIO_new_socket(this->get_socket(), BIO_NOCLOSE);
       BIO_set_mem_eof_return(rbio, -1);
       SSL_set0_rbio(this->ssl, rbio);
       free_handshake_buffers();

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -680,6 +680,21 @@ DH_get_2048_256()
 }
 #endif
 
+bool
+SSLMultiCertConfigLoader::_enable_ktls(SSL_CTX *ctx)
+{
+#ifdef SSL_OP_ENABLE_KTLS
+  if (SSLConfigParams::ssl_ktls_enabled) {
+    if (SSL_CTX_set_options(ctx, SSL_OP_ENABLE_KTLS)) {
+      Debug("ssl.ktls", "KTLS is enabled");
+    } else {
+      return false;
+    }
+  }
+#endif
+  return true;
+}
+
 static SSL_CTX *
 ssl_context_enable_dhe(const char *dhparams_file, SSL_CTX *ctx)
 {
@@ -1412,6 +1427,10 @@ SSLMultiCertConfigLoader::init_server_ssl_ctx(CertLoadData const &data, const SS
     }
 
     if (!this->_set_curves(ctx)) {
+      goto fail;
+    }
+
+    if (!this->_enable_ktls(ctx)) {
       goto fail;
     }
 

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1214,6 +1214,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.keylog_file", RECD_STRING, nullptr, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.ssl.ktls.enabled", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  ,
   //##############################################################################
   //#
   //# OCSP (Online Certificate Status Protocol) Stapling Configuration


### PR DESCRIPTION
This adds `proxy.config.ssl.ktls.enabled` to enable kTLS. With the setting enabled, ATS passes `SSL_OP_ENABLE_KTLS` to OpenSSL.