### PR TITLE
Fix unused-but-set-variable warnings (#8435)

### DIFF
--- a/mgmt/api/CoreAPIShared.cc
+++ b/mgmt/api/CoreAPIShared.cc
@@ -142,7 +142,6 @@ TSMgmtError
 sendHTTPRequest(int sock, char *req, uint64_t timeout)
 {
   char request[BUFSIZ];
-  char *requestPtr;
   size_t length = 0;
 
   memset(request, 0, BUFSIZ);
@@ -158,7 +157,6 @@ sendHTTPRequest(int sock, char *req, uint64_t timeout)
     goto error;
   }
   // Write the request to the server.
-  requestPtr = request;
   while (length > 0) {
     do {
       err = write(sock, request, length);
@@ -168,7 +166,6 @@ sendHTTPRequest(int sock, char *req, uint64_t timeout)
       //      printf("(test) write failed [%d '%s']\n", errno, strerror (errno));
       goto error;
     }
-    requestPtr += err;
     length -= err;
   }
 

--- a/plugins/esi/lib/EsiGunzip.cc
+++ b/plugins/esi/lib/EsiGunzip.cc
@@ -78,7 +78,6 @@ EsiGunzip::stream_decode(const char *data, int data_len, std::string &udata)
     _zstrm.avail_in = data_len;
     char raw_buf[BUF_SIZE];
     int inflate_result;
-    int32_t unzipped_data_size = 0;
     int32_t curr_buf_size;
 
     do {
@@ -99,7 +98,6 @@ EsiGunzip::stream_decode(const char *data, int data_len, std::string &udata)
         _errorLog("[%s] buf below zero", __FUNCTION__);
         break;
       }
-      unzipped_data_size += curr_buf_size;
 
       // push empty object onto list and add data to in-list object to
       // avoid data copy for temporary

--- a/plugins/experimental/statichit/statichit.cc
+++ b/plugins/experimental/statichit/statichit.cc
@@ -366,7 +366,6 @@ StaticHitInterceptHook(TSCont contp, TSEvent event, void *edata)
     VDEBUG("reading vio=%p vc=%p, trq=%p", arg.vio, TSVIOVConnGet(arg.vio), cdata.trq);
 
     TSIOBufferBlock blk;
-    ssize_t consumed     = 0;
     TSParseResult result = TS_PARSE_CONT;
 
     for (blk = TSIOBufferReaderStart(cdata.trq->readio.reader); blk; blk = TSIOBufferBlockNext(blk)) {
@@ -408,8 +407,7 @@ StaticHitInterceptHook(TSCont contp, TSEvent event, void *edata)
         return TS_EVENT_NONE;
 
       case TS_PARSE_CONT:
-        // We consumed the buffer we got minus the remainder.
-        consumed += (nbytes - std::distance(ptr, end));
+        break;
       }
     }
 

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -475,7 +475,6 @@ GeneratorInterceptHook(TSCont contp, TSEvent event, void *edata)
     VDEBUG("reading vio=%p vc=%p, grq=%p", arg.vio, TSVIOVConnGet(arg.vio), cdata.grq);
 
     TSIOBufferBlock blk;
-    ssize_t consumed     = 0;
     TSParseResult result = TS_PARSE_CONT;
 
     for (blk = TSIOBufferReaderStart(cdata.grq->readio.reader); blk; blk = TSIOBufferBlockNext(blk)) {
@@ -530,8 +529,7 @@ GeneratorInterceptHook(TSCont contp, TSEvent event, void *edata)
         return TS_EVENT_NONE;
 
       case TS_PARSE_CONT:
-        // We consumed the buffer we got minus the remainder.
-        consumed += (nbytes - std::distance(ptr, end));
+        break;
       }
     }
 

--- a/src/traffic_logcat/logcat.cc
+++ b/src/traffic_logcat/logcat.cc
@@ -119,7 +119,6 @@ process_file(int in_fd, int out_fd)
 {
   char buffer[MAX_LOGBUFFER_SIZE];
   int nread, buffer_bytes;
-  unsigned bytes = 0;
 
   while (true) {
     // read the next buffer from file descriptor
@@ -200,7 +199,7 @@ process_file(int in_fd, int out_fd)
     // convert the buffer to ascii entries and place onto stdout
     //
     if (header->fmt_fieldlist()) {
-      bytes += LogFile::write_ascii_logbuffer(header, out_fd, ".", alt_format);
+      LogFile::write_ascii_logbuffer(header, out_fd, ".", alt_format);
     } else {
       // TODO investigate why this buffer goes wonky
     }

--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -161,14 +161,12 @@ spawn_same_session_send(void *arg)
 
   char input_buf[1024];
   int read_bytes = SSL_read(ssl, input_buf, sizeof(input_buf));
-  int total_read = 0;
   while (read_bytes != 0) {
     fd_set reads;
     fd_set writes;
     FD_ZERO(&reads);
     FD_ZERO(&writes);
     if (read_bytes > 0) {
-      total_read += read_bytes;
       FD_SET(sfd, &reads);
     } else {
       int error = SSL_get_error(ssl, read_bytes);


### PR DESCRIPTION
Backport #8435 to the 9.1.x branch.

----

(cherry picked from commit fcc7268f8c00daeac1a10107dc2aad6f1b01077e)

Conflicts:
	plugins/generator/generator.cc