### PR TITLE
Destroy ssl context after use.

### DIFF
--- a/doc/developer-guide/api/functions/TSSslClientContext.en.rst
+++ b/doc/developer-guide/api/functions/TSSslClientContext.en.rst
@@ -59,4 +59,9 @@ Server source distribution. It demonstrates how to use :func:`TSSslClientContext
 
 .. literalinclude:: ../../../../example/plugins/c-api/client_context_dump/client_context_dump.cc
   :language: c
-  :lines: 137-145
+  :lines: 154-166
+
+
+.. literalinclude:: ../../../../example/plugins/c-api/client_context_dump/client_context_dump.cc
+  :language: c
+  :lines: 51-55

--- a/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
+++ b/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
@@ -51,9 +51,9 @@ asn1_string_extract(ASN1_STRING *s)
 void
 dump_context(const char *ca_path, const char *ck_path)
 {
-  SSL_CTX *ctx = reinterpret_cast<SSL_CTX *>(TSSslClientContextFindByName(ca_path, ck_path));
+  TSSslContext ctx = TSSslClientContextFindByName(ca_path, ck_path);
   if (ctx) {
-    SSL *s = SSL_new(ctx);
+    SSL *s = SSL_new(reinterpret_cast<SSL_CTX *>(ctx));
     if (s) {
       char *data  = nullptr;
       long length = 0;
@@ -137,6 +137,7 @@ dump_context(const char *ca_path, const char *ck_path)
       }
     }
     SSL_free(s);
+    TSSslContextDestroy(ctx);
   }
 }
 


### PR DESCRIPTION
As per the [docs](https://docs.trafficserver.apache.org/en/latest/developer-guide/api/functions/TSSslClientContext.en.html?highlight=tssslclientcontextsnamesget#description) this needs to be released after use, this was missing from the `cert_reporting_tool` plugin.
This also fixes the example in the docs.