### PR TITLE
docs: fix fedora install notes and spelling issues

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4157,10 +4157,10 @@ HTTP/2 Configuration
    |TS| gracefully closes connections that have stream error rates above this
    setting by sending GOAWAY frames.
 
-.. ts:cv:: CONFIG proxy.config.http2.stream_error_sampling_threashold INT 10
+.. ts:cv:: CONFIG proxy.config.http2.stream_error_sampling_threshold INT 10
    :reloadable:
 
-   This is the threashold of sampling stream number to start checking the stream error rate.
+   This is the threshold of sampling stream number to start checking the stream error rate.
 
 .. ts:cv:: CONFIG proxy.config.http2.max_settings_per_frame INT 7
    :reloadable:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -131,7 +131,7 @@ if os.environ.get('READTHEDOCS') == 'True':
     print("done")
 else:
     # On RedHat-based distributions, install the python-sphinx_rtd_theme package
-    # to get an end result tht looks more like readthedoc.org.
+    # to get an end result that looks more like readthedoc.org.
     try:
         import sphinx_rtd_theme
         html_theme = 'sphinx_rtd_theme'

--- a/doc/developer-guide/api/functions/TSHttpTxnPostBufferReaderGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnPostBufferReaderGet.en.rst
@@ -67,7 +67,7 @@ handler makes use of :c:func:`TSHttpTxnPostBufferReaderGet`.
        // request's body.
      }
 
-     // Remeber to free the TSIOBufferReader.
+     // Remember to free the TSIOBufferReader.
      TSIOBufferReaderFree(post_buffer_reader);
 
      TSHttpTxnReenable(txnp);

--- a/doc/getting-started/index.en.rst
+++ b/doc/getting-started/index.en.rst
@@ -123,7 +123,7 @@ RHEL / CentOS
 configured on your machine yet, you must install them first with the following::
 
     wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    sudo rpm -Uvh epel-release-7*.rpm
+    sudo rpm -Uvh epel-release-latest-7*.rpm
 
 Ensuring that you replace the release number with a value that is appropriate
 for your system. Once you have EPEL installed, you may install |TS| itself. ::


### PR DESCRIPTION
Closes #8536 