### PR TITLE
Call je_dallocx with flags when needed

### DIFF
--- a/include/tscore/JeAllocator.h
+++ b/include/tscore/JeAllocator.h
@@ -67,6 +67,7 @@ class JemallocNodumpAllocator
 {
 public:
   void *allocate(InkFreeList *f);
+  void deallocate(InkFreeList *f, void *ptr);
 
 private:
 #if JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED

--- a/src/tscore/JeAllocator.cc
+++ b/src/tscore/JeAllocator.cc
@@ -120,6 +120,22 @@ JemallocNodumpAllocator::allocate(InkFreeList *f)
   return newp;
 }
 
+void
+JemallocNodumpAllocator::deallocate(InkFreeList *f, void *ptr)
+{
+  if (f->advice) {
+#if JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
+    if (likely(ptr)) {
+      dallocx(ptr, MALLOCX_TCACHE_NONE);
+    }
+#else
+    ats_free(ptr);
+#endif
+  } else {
+    ats_free(ptr);
+  }
+}
+
 JemallocNodumpAllocator &
 globalJemallocNodumpAllocator()
 {

--- a/src/tscore/ink_queue.cc
+++ b/src/tscore/ink_queue.cc
@@ -327,9 +327,11 @@ freelist_free(InkFreeList *f, void *item)
 static void
 malloc_free(InkFreeList *f, void *item)
 {
-  // Avoid compiler warnings
-  (void)f;
-  ats_free(item);
+  if (f->alignment) {
+    jna.deallocate(f, item);
+  } else {
+    ats_free(item);
+  }
 }
 
 void


### PR DESCRIPTION
Have been seeing some weird ASan outputs like this:
```
=================================================================
==21402==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x7f23e542d000 in thread T52 ([LOG_PREPROC 0]) 
    #0 0x668e70 in __interceptor_free (/opt/oath/trafficserver/9.1/bin/traffic_server+0x668e70)
    #1 0x7f2405d1f76c in ink_freelist_free ../../../../../../_scm/trafficserver9.1_asan/src/tscore/ink_queue.cc:281
    #2 0xb336f7 in LogBuffer::destroy(LogBuffer*&) ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/LogBuffer.h:205
    #3 0xb336f7 in LogFile::preproc_and_try_delete(LogBuffer*) ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/LogFile.cc:497
    #4 0xb5414e in LogBufferManager::preproc_buffers(LogBufferSink*) ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/LogObject.cc:79
    #5 0xb5c27d in LogObject::preproc_buffers(int) ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/LogObject.h:146
    #6 0xb5c27d in LogObjectManager::preproc_buffers(int) ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/LogObject.cc:1084
    #7 0xafc42b in Log::preproc_thread_main(void*) ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/Log.cc:1305
    #8 0xb0894c in LoggingPreprocContinuation::mainEvent(int, void*) ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/Log.cc:266
    #9 0x107d687 in Continuation::handleEvent(int, void*) ../../../../../../_scm/trafficserver9.1_asan/iocore/eventsystem/I_Continuation.h:219
    #10 0x107d687 in Continuation::handleEvent(int, void*) ../../../../../../_scm/trafficserver9.1_asan/iocore/eventsystem/I_Continuation.h:215
    #11 0x107d687 in EThread::execute() ../../../../../../_scm/trafficserver9.1_asan/iocore/eventsystem/UnixEThread.cc:348
    #12 0x1078345 in spawn_thread_internal ../../../../../../_scm/trafficserver9.1_asan/iocore/eventsystem/Thread.cc:92
    #13 0x7f2404303ea4 in start_thread /usr/src/debug/glibc-2.17-c758a686/nptl/pthread_create.c:307
    #14 0x7f24034009fc in clone (/lib64/libc.so.6+0xfe9fc)

Address 0x7f23e542d000 is a wild pointer.
SUMMARY: AddressSanitizer: bad-free (/opt/oath/trafficserver/9.1/bin/traffic_server+0x668e70) in __interceptor_free
Thread T52 ([LOG_PREPROC 0]) created by T0 here:
    #0 0x5ccd0f in pthread_create (/opt/oath/trafficserver/9.1/bin/traffic_server+0x5ccd0f)
    #1 0x10794be in ink_thread_create /sd/workspace/src/git.vzbuilders.com/Edge/build/_build/build_release_posix-x86_64_gcc_8/trafficserver9.1_asan/build/../../../../_scm/trafficserver9.1_asan/include/tscore/ink_thread.h:159
    #2 0x10794be in Thread::start(char const*, void*, unsigned long, std::function<void ()> const&) ../../../../../../_scm/trafficserver9.1_asan/iocore/eventsystem/Thread.cc:109
    #3 0x10879cb in EventProcessor::spawn_thread(Continuation*, char const*, unsigned long) ../../../../../../_scm/trafficserver9.1_asan/iocore/eventsystem/UnixEventProcessor.cc:497
    #4 0xafe0b3 in Log::create_threads() ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/Log.cc:1110
    #5 0xafe61b in Log::init_when_enabled() ../../../../../../_scm/trafficserver9.1_asan/proxy/logging/Log.cc:1082
    #6 0x54eb0e in main ../../../../../_scm/trafficserver9.1_asan/src/traffic_server/traffic_server.cc:2186
    #7 0x7f2403324554 in __libc_start_main ../csu/libc-start.c:266

==21402==ABORTING
=================================================================
```

This fixes the problem.