### PR TITLE
Traffic Dump: Use the correct transaction user index

### DIFF
--- a/plugins/experimental/traffic_dump/transaction_data.cc
+++ b/plugins/experimental/traffic_dump/transaction_data.cc
@@ -479,7 +479,7 @@ TransactionData::global_transaction_handler(TSCont contp, TSEvent event, void *e
   }
 
   case TS_EVENT_HTTP_TXN_CLOSE: {
-    TransactionData *txnData = static_cast<TransactionData *>(TSUserArgGet(txnp, SessionData::get_session_arg_index()));
+    TransactionData *txnData = static_cast<TransactionData *>(TSUserArgGet(txnp, transaction_arg_index));
     if (!txnData) {
       TSError("[%s] No transaction data found for the close hook we registered for.", traffic_dump::debug_tag);
       break;


### PR DESCRIPTION
Traffic Dump has both session and transaction user data. In one of the
calls to TSUserArgGet, it accidentally used the session index to access
the transaction data. This could result in the corruption of another
plugin's session data. This patch fixes this so the correct index is
used.

---

In parallel I'm working on a core change that will detect incorrect indexing rather than allow the accidental corrupting of another plugin's data. See: #8550.
