### PR TITLE
Relax key validation of sni.yaml

### DIFF
--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -158,7 +158,7 @@ template <> struct convert<YamlSNIConfig::Item> {
     for (const auto &elem : node) {
       if (std::none_of(valid_sni_config_keys.begin(), valid_sni_config_keys.end(),
                        [&elem](const std::string &s) { return s == elem.first.as<std::string>(); })) {
-        throw YAML::ParserException(elem.first.Mark(), "unsupported key " + elem.first.as<std::string>());
+        Warning("unsupported key '%s' in SNI config", elem.first.as<std::string>().c_str());
       }
     }
 


### PR DESCRIPTION
For the forward compatibility of new keys.

## Background

When ATS reads the `sni.yaml` file, it checks the keys of the yaml. This is a bit annoying when you deploy a new key to the env which has old and new versions of ATS.
IMO, just ignoring "unknown keys" is fine. Because the function touches the node by defined keys. Any concerns?