### PR TITLE
TSUserArg: add value type checking

### DIFF
--- a/include/tscore/PluginUserArgs.h
+++ b/include/tscore/PluginUserArgs.h
@@ -35,6 +35,41 @@ static constexpr std::array<size_t, TS_USER_ARGS_COUNT> MAX_USER_ARGS = {{
   128 /* max number of user arguments for GLB */
 }};
 
+/** Stagger each user argument value so we can detect mismatched
+ * indices.
+ *
+ * For example, say a plugin associates data with both sessions and
+ * transactions and that its session index is 2 and its transaction index is 4.
+ * In this case, we'll hand back to the plugin 2002 for its session index and
+ * 1004 for its transaction index. If it then accidentally uses its session
+ * index to reference its transaction index, it will pass back 2002 instead of
+ * 1004, which we will identify as belonging to the wrong user argument type
+ * because it is in the 2000 session block rather than the expected 1000
+ * transaction block.
+ *
+ * Note that these higher value 1000 block indices are only used when
+ * interfacing with the plugin. Internally the lower valued index is used.
+ * That is, for a transaction, expect internally a value of 3 instead of 1003.
+ */
+static constexpr size_t
+get_user_arg_offset(TSUserArgType type)
+{
+  // TS_USER_ARGS_TXN indices begin at 1000, TS_USER_ARGS_SSN begin at 2000,
+  // etc.
+  return (static_cast<size_t>(type) + 1) * 1000;
+}
+
+/** Verify that the user passed in an index whose value corresponds with the
+ * type. See the comment above the declaration of get_user_arg_offset for the
+ * intention behind this.
+ */
+static constexpr inline bool
+SanityCheckUserIndex(TSUserArgType type, int idx)
+{
+  int const block_start = get_user_arg_offset(type);
+  return idx >= block_start && idx < block_start + 1000;
+}
+
 /**
   This is a mixin class (sort of), implementing the appropriate APIs and data storage for
   a particular user arg table. Used by VConn / Ssn / Txn user arg data.
@@ -53,6 +88,8 @@ public:
   void *
   get_user_arg(size_t ix) const
   {
+    ink_release_assert(SanityCheckUserIndex(I, ix));
+    ix -= get_user_arg_offset(I);
     ink_release_assert(ix < user_args.size());
     return this->user_args[ix];
   };
@@ -60,6 +97,8 @@ public:
   void
   set_user_arg(size_t ix, void *arg)
   {
+    ink_release_assert(SanityCheckUserIndex(I, ix));
+    ix -= get_user_arg_offset(I);
     ink_release_assert(ix < user_args.size());
     user_args[ix] = arg;
   };

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -183,6 +183,7 @@ test_tscore_SOURCES = \
 	unit_tests/test_MemArena.cc \
 	unit_tests/test_MT_hashtable.cc \
 	unit_tests/test_ParseRules.cc \
+	unit_tests/test_PluginUserArgs.cc \
 	unit_tests/test_PriorityQueue.cc \
 	unit_tests/test_Ptr.cc \
 	unit_tests/test_Regex.cc \

--- a/src/tscore/unit_tests/test_PluginUserArgs.cc
+++ b/src/tscore/unit_tests/test_PluginUserArgs.cc
@@ -1,0 +1,56 @@
+/**
+  @file Test for Regex.cc
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "tscore/PluginUserArgs.h"
+#include "catch.hpp"
+
+TEST_CASE("get_user_arg_offset", "[libts][PluginUserArgs]")
+{
+  CHECK(get_user_arg_offset(TS_USER_ARGS_TXN) == 1000);
+  CHECK(get_user_arg_offset(TS_USER_ARGS_SSN) == 2000);
+  CHECK(get_user_arg_offset(TS_USER_ARGS_VCONN) == 3000);
+  CHECK(get_user_arg_offset(TS_USER_ARGS_GLB) == 4000);
+}
+
+TEST_CASE("SanityCheckUserIndex", "[libts][PluginUserArgs]")
+{
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_TXN, 0));
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_TXN, 1));
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_TXN, 999));
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_TXN, 2000));
+
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_TXN, 1000));
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_TXN, 1001));
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_TXN, 1999));
+
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_SSN, 1000));
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_SSN, 3000));
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_SSN, 2000));
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_SSN, 2001));
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_SSN, 2999));
+
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_VCONN, 2000));
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_VCONN, 3000));
+
+  CHECK_FALSE(SanityCheckUserIndex(TS_USER_ARGS_GLB, 3000));
+  CHECK(SanityCheckUserIndex(TS_USER_ARGS_GLB, 4000));
+}


### PR DESCRIPTION
A plugin may have multiple user argument types. For instance, it may
have both TS_USER_ARGS_SSN and TS_USER_ARGS_TXN plugin data. Due to a
coding error, it is possible that it may accidentally use the wrong
index type while retrieving one or the other user data types. For
instance, if it uses its transaction index to retrieve its session data,
this may result in them getting the transaction data for another plugin.
In these situations, the plugin will either read what looks like garbage
data to it (because it is casting incorrect memory to its data type), or
it may write to that data and thus corrupt the other plugin's data, or
both.

This change updates the core to segment off the plugin user data ids by
category. This allows the core to verify that the plugin passes the
correct id type per the data type (session, transaction, etc.) and
fails an assertion if there is a mismatch.

---

Note: autests for this PR will fail until a couple plugins with indexing issues uncovered by this patch are merged in:

* #8548
* #8551