### PR TITLE
Fixes macOS arm64 builds (again)

### DIFF
--- a/iocore/aio/Inline.cc
+++ b/iocore/aio/Inline.cc
@@ -26,7 +26,5 @@
  *
  */
 
-#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_AIO.h"
-#endif

--- a/iocore/cache/Inline.cc
+++ b/iocore/cache/Inline.cc
@@ -26,7 +26,5 @@
  *
  */
 
-#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_Cache.h"
-#endif

--- a/iocore/dns/Inline.cc
+++ b/iocore/dns/Inline.cc
@@ -26,7 +26,5 @@
  *
  */
 
-#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_DNS.h"
-#endif

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -110,7 +110,7 @@ public:
   */
   Ptr<ProxyMutex> mutex;
 
-  virtual void set_specific();
+  virtual void set_specific() = 0;
 
   static ink_thread_key thread_data_key;
 

--- a/iocore/eventsystem/Inline.cc
+++ b/iocore/eventsystem/Inline.cc
@@ -26,7 +26,5 @@
  *
  */
 
-#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_EventSystem.h"
-#endif

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -25,9 +25,8 @@
 
   Basic Threads
 
-
-
 **************************************************************************/
+
 #include "P_EventSystem.h"
 #include "tscore/ink_string.h"
 

--- a/iocore/eventsystem/unit_tests/test_IOBuffer.cc
+++ b/iocore/eventsystem/unit_tests/test_IOBuffer.cc
@@ -28,9 +28,6 @@
 
 #include "I_EventSystem.h"
 #include "RecordsConfig.h"
-#if defined(darwin)
-#include "P_IOBuffer.h"
-#endif
 
 #include "diags.i"
 

--- a/iocore/hostdb/Inline.cc
+++ b/iocore/hostdb/Inline.cc
@@ -26,7 +26,5 @@
  *
  */
 
-#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_HostDB.h"
-#endif

--- a/iocore/net/Inline.cc
+++ b/iocore/net/Inline.cc
@@ -26,7 +26,5 @@
  *
  */
 
-#if !(defined(darwin) && defined(__aarch64__))
 #define TS_INLINE
 #include "P_Net.h"
-#endif

--- a/iocore/net/test_I_UDPNet.cc
+++ b/iocore/net/test_I_UDPNet.cc
@@ -31,13 +31,8 @@
 #include "I_EventSystem.h"
 #include "I_Net.h"
 #include "I_UDPNet.h"
-#if defined(darwin)
-#include "P_UDPConnection.h"
-#include "P_UDPPacket.h"
-#else
 #include "I_UDPPacket.h"
 #include "I_UDPConnection.h"
-#endif
 
 #include "diags.i"
 


### PR DESCRIPTION
This change reverts 43452ca8 (#7662) and fa8b3f9a (#7389) and fixes the
real issue, where Thread::set_specific was not a pure virtual function,
leading to link issues:

```
duplicate symbol 'vtable for Thread' in:
    ../iocore/eventsystem/libinkevent.a(Inline.o)
    ../iocore/eventsystem/libinkevent.a(Thread.o)
duplicate symbol 'typeinfo name for Thread' in:
    ../iocore/eventsystem/libinkevent.a(Inline.o)
    ../iocore/eventsystem/libinkevent.a(Thread.o)
duplicate symbol 'typeinfo for Thread' in:
    ../iocore/eventsystem/libinkevent.a(Inline.o)
    ../iocore/eventsystem/libinkevent.a(Thread.o)
```