### PR TITLE
Clear random header value by AIO read error

### DIFF
--- a/iocore/cache/CacheDisk.cc
+++ b/iocore/cache/CacheDisk.cc
@@ -97,7 +97,7 @@ CacheDisk::open(char *s, off_t blocks, off_t askip, int ahw_sector_size, int fil
     }
   }
 
-  //
+  // read disk header
   SET_HANDLER(&CacheDisk::openStart);
   io.aiocb.aio_offset = skip;
   io.aiocb.aio_buf    = reinterpret_cast<char *>(header);
@@ -165,6 +165,10 @@ CacheDisk::openStart(int event, void * /* data ATS_UNUSED */)
 
   if (io.aiocb.aio_nbytes != static_cast<size_t>(io.aio_result)) {
     Warning("could not read disk header for disk %s: declaring disk bad", path);
+
+    // the header could have random values by the AIO read error
+    memset(header, 0, header_len);
+
     incrErrors(&io);
     SET_DISK_BAD(this);
     SET_HANDLER(&CacheDisk::openDone);


### PR DESCRIPTION
Fix #7865. We observed the crash loop on start-up with a bad disk.

# Backtrace
```
[ 00 ] libpthread-2.17.so waitpid 
[ 01 ] traffic_server crash_logger_invoke(int, siginfo_t*, void*) ( Crash.cc:165 ) 
[ 02 ] libpthread-2.17.so 
[ 03 ] traffic_server CacheDisk::~CacheDisk() ( List.h:293 ) 
[ 04 ] traffic_server CacheDisk::~CacheDisk() ( CacheDisk.cc:112 ) 
[ 05 ] traffic_server CacheProcessor::diskInitialized() ( Cache.cc:767 ) 
[ 06 ] traffic_server CacheDisk::openStart(int, void*) ( CacheDisk.cc:213 ) 
[ 07 ] traffic_server AIOCallbackInternal::io_complete(int, void*) ( eventsystem/I_Continuation.h:160 ) 
[ 08 ] traffic_server EThread::process_event(Event*, int) ( I_Continuation.h:160 ) 
[ 09 ] traffic_server EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*) ( UnixEThread.cc:170 ) 
[ 10 ] traffic_server EThread::execute_regular() ( UnixEThread.cc:230 ) 
[ 11 ] traffic_server spawn_thread_internal(void*) ( Thread.cc:85 ) 
[ 12 ] libpthread-2.17.so start_thread 
```

# Log
```
[ET_AIO 0:99] WARNING: cache disk operation failed READ -1 61
[ET_NET 9] WARNING: could not read disk header for disk /dev/disk/****: declaring disk bad
[ET_NET 9] WARNING: failed operation: READ (opcode=1), span: /dev/disk/**** (fd=99)
```

# Conditions

1. Some HDD on a box got broken
2. (re)start ATS for some reason

# Scenario

1. On `ET_NET` thread, `CacheDisk::open` schedule AIO read to load disk header info into `DiskHeader *header` member.
2. On `ET_AIO ` thread, `cache_op` try to read the disk but got an error (errno=61). When this error happens, the given buffer (`header`) has a random value.
3. On `ET_NET` thread, `CacheDisk::openStart` handles the callback and declares it's a bad disk because of the result. It deletes the `CacheDisk` object. 
4. The `CacheDisk` destructor refers to the `header` which has a random value on a loop and got heap-buffer-overflow.

# Affected Version
8.1.x, 9.0.x, and master