### PR TITLE
Update descriptions of sni.yaml.default

### DIFF
--- a/configs/sni.yaml.default
+++ b/configs/sni.yaml.default
@@ -1,26 +1,45 @@
 # sni.yaml
 #
+# Documentation:
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/sni.yaml.en.html
+#
+#
 # This configuration file
-#     - sets the SSL actions to be performed based on the servername provided during SSL handhshake phase (SNI extension)
+#     - sets the SSL actions to be performed based on the servername provided during SSL handshake phase (SNI extension)
 #     - sets the SSL properties required to make SSL connection with the next hop or origin server.
 #
 # YAML-based Configuration file
 #  Format :
 #  Actions available:
-#    http2 - adds or removes HTTP/2 (H2) from the protocol list advertised by ATS; parameter required = None, parameters = on or off
-#    verify_client - sets the verification flag for verifying the client certificate; parameters = one of 'NONE', 'MODERATE' or 'STRICT'
-#    verify_origin_server - sets the verification flag for verifying the server certificate; parameters = one of 'NONE', 'MODERATE' or 'STRICT'
-#    client_cert - sets the client certificate to present to the server specified in dest_host; parameters = certificate file .
-#                      The location of the certificate file is relative to proxy.config.ssl.server.cert.path directory.
-#    tunnel_route  - sets the e2e tunnel route
-#    ip_allow - lists or range of client IP addresses, subnets that are allowed for this connection. This accepts CIDR format
-#              for subnet specification.
+#    ip_allow                 - lists or range of client IP addresses, subnets that are allowed for this connection. This accepts CIDR format
+#                               for subnet specification.
+#    verify_server_policy     - sets the verification flag for verifying the server certificate; parameters = one of 'DISABLED', 'PERMISSIVE', 'ENFORCED'
+#    verify_server_properties - sets the flag to control what Traffic Server checks when evaluating the origin certificate;
+#                               parameters = one of 'NONE', 'SIGNATURE', 'NAME', and 'ALL'
+#    verify_client            - sets the verification flag for verifying the client certificate; parameters = one of 'NONE', 'MODERATE' or 'STRICT'
+#    verify_client_ca_certs   - specifies an alternate set of certificate authority certs to use to verify the client cert.
+#    host_sni_policy          - sets the flag to control how policy impacting mismatches between host header and SNI values are dealt with;
+#                               parameters = one of 'DISABLED', 'PERMISSIVE', or 'ENFORCED'
+#    valid_tls_versions_in    - sets the list of TLS protocols that will be offered to user agents during the TLS negotiation;
+#                               parameters = one of 'TLSv1', 'TLSv1_1', 'TLSv1_2', and 'TLSv1_3'.
+#    client_cert              - sets the client certificate to present to the server specified in dest_host; parameters = certificate file .
+#                               The location of the certificate file is relative to proxy.config.ssl.server.cert.path directory.
+#    client_key               - sets the file containing the client private key that corresponds to the certificate for the outbound connection.
+#    client_sni_policy        - policy of SNI on outbound connection.
+#    http2                    - adds or removes HTTP/2 (H2) from the protocol list advertised by ATS; parameter required = None, parameters = on or off
+#    tunnel_route             - sets the e2e tunnel route
+#    forward_route            - destination as an FQDN and port, separated by a colon :.
+#                               this is similar to tunnel_route, but it terminates the TLS connection and forwards the decrypted traffic.
+#    partial_blind_route      - destination as an FQDN and port, separated by a colon :.
+#                               this is similar to forward_route in that Traffic Server terminates the incoming TLS connection.
+#                               in addition partial_blind_route creates a new TLS connection to the specified origin.
+#    tunnel_alpn              - list of ALPN Protocol Ids for Partial Blind Tunnel.
 #
 #  Example:
 # sni:
 #   - fqdn: one.com
 #     http2: off
-#     verify_origin_server: STRICT
+#     verify_server_policy: ENFORCED
 #     client_cert: somepem.pem
 #     verify_client: MODERATE
 #   - fqdn: two.com


### PR DESCRIPTION
Update the descriptions of sni.yaml.default about the following two things.
- Replace`verify_origin_server` to `verify_server_policy`.
`verify_origin_server` is old setting of ssl_server_name.yaml in version 8.1.x.
- Add descriptions about some keys that were not explained.