### PR TITLE
Port #6816 from core strategy to plugin

### DIFF
--- a/plugins/experimental/parent_select/consistenthash_config.cc
+++ b/plugins/experimental/parent_select/consistenthash_config.cc
@@ -201,6 +201,7 @@ loadConfigFile(const std::string &fileName, std::stringstream &doc, std::unorder
         }
       }
     }
+    closedir(dir);
   } else {
     std::ifstream file(fileName);
     if (file.is_open()) {


### PR DESCRIPTION
Ports #6816 fix for core strategies to the parent_select plugin.

Fixes a bug with the YAML loading calling opendir but not closedir,
which leaked the file descriptor.