### PR TITLE
Port #7749 from core strategy to plugin

### DIFF
--- a/plugins/experimental/parent_select/consistenthash.cc
+++ b/plugins/experimental/parent_select/consistenthash.cc
@@ -443,8 +443,10 @@ PLNextHopConsistentHash::next(TSHttpTxn txnp, void *strategyTxn, const char *exc
       }
       switch (ring_mode) {
       case PL_NH_ALTERNATE_RING:
-        if (groups > 0) {
+        if (pRec && groups > 0) {
           cur_ring = (pRec->group_index + 1) % groups;
+        } else {
+          cur_ring = 0;
         }
         break;
       case PL_NH_EXHAUST_RING:


### PR DESCRIPTION
Ports #7749 fix for core strategies to the parent_select plugin.

Fixes a crash when a strategy has a bad 'to' URL, which manifests as a
missing null pointer check.