### PR TITLE
Docs: Fix default value of proxy.config.ssl.handshake_timeout_in

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3787,9 +3787,9 @@ SSL Termination
    This feature requires |TS| to be built with POSIX
    capabilities enabled.
 
-.. ts:cv:: CONFIG proxy.config.ssl.handshake_timeout_in INT 0
+.. ts:cv:: CONFIG proxy.config.ssl.handshake_timeout_in INT 30
 
-   When enabled this limits the total duration for the server side SSL
+   When enabled this limits the total duration for the incoming side SSL
    handshake.
 
    See :ref:`admin-performance-timeouts` for more discussion on |TS| timeouts.

--- a/doc/admin-guide/performance/index.en.rst
+++ b/doc/admin-guide/performance/index.en.rst
@@ -392,7 +392,7 @@ engine.
 
 :ts:cv:`proxy.config.ssl.handshake_timeout_in` configures the time, in seconds,
 after which incoming client connections will abort should the SSL handshake not
-be completed. The default of ``0`` disables the timeout.
+be completed. A value of ``0`` will disable the timeout.
 
 When :ref:`admin-ocsp-stapling` is enabled in |TS|, you can configure two
 separate timeouts; one for setting the length of time which cached OCSP results
@@ -406,7 +406,7 @@ cached in |TS| using :ts:cv:`proxy.config.ssl.session_cache.timeout`.
 
 ::
 
-    CONFIG proxy.config.ssl.handshake_timeout_in INT 0
+    CONFIG proxy.config.ssl.handshake_timeout_in INT 30
     CONFIG proxy.config.ssl.ocsp.cache_timeout INT 3600
     CONFIG proxy.config.ssl.ocsp.request_timeout INT 10
     CONFIG proxy.config.ssl.session_cache.timeout INT 0


### PR DESCRIPTION
https://github.com/apache/trafficserver/commit/218881036c6bcf78bad7f5308545b6790096f886 (#6781) changed the default value of `proxy.config.ssl.handshake_timeout_in` from `0` to `30` since 9.0.0. This follows the change on the docs.