### PR TITLE
LGTM: Fix pointless comparison of unsigined value to zero

### DIFF
--- a/include/tscpp/util/TextView.h
+++ b/include/tscpp/util/TextView.h
@@ -619,15 +619,22 @@ svto_radix(ts::TextView &src)
 {
   static_assert(0 < N && N <= 36, "Radix must be in the range 1..36");
   uintmax_t zret{0};
-  uintmax_t v;
-  while (src.size() && (0 <= (v = ts::svtoi_convert[static_cast<unsigned char>(*src)])) && v < N) {
+
+  if (src.empty()) {
+    return zret;
+  }
+
+  uintmax_t v = ts::svtoi_convert[static_cast<unsigned char>(*src)];
+  while (src.size() && v < N) {
     auto n = zret * N + v;
     if (n < zret) { // overflow / wrap
       return std::numeric_limits<uintmax_t>::max();
     }
     zret = n;
     ++src;
+    v = ts::svtoi_convert[static_cast<unsigned char>(*src)];
   }
+
   return zret;
 };
 


### PR DESCRIPTION
> An unsigned value is always non-negative, even if it has been assigned a negative number, so the comparison is redundant and may mask a bug because a different check was intended.

https://lgtm.com/projects/g/apache/trafficserver/snapshot/9b7ce2afbd6d45d5a6e8e5f9f5d5b8a1b979405b/files/include/tscpp/util/TextView.h?sort=name&dir=ASC&mode=heatmap#xc51c1ab852bf545e:1