### PR TITLE
Exclude 3rd party libs from LGTM checks

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -14,7 +14,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
+path_classifiers:
+  3rd-party:
+    - "lib/fastlz"
+    - "lib/yamlcpp"
+    - "tests/include/catch.hpp"
+queries:
+  - exclude:
+      tags:
+        - "3rd-party"
 extraction:
   cpp:
     prepare:


### PR DESCRIPTION
Trying to exclude this alert in the `lib/yamlcpp`.
https://lgtm.com/projects/g/apache/trafficserver/alerts/?mode=tree&ruleFocus=2156200647

According to the docs, it looks like excluding from the `queries` seems to work.
https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html