### PR TITLE
Add SSLSessionDup for older OpenSSL and BoringSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1311,6 +1311,7 @@ AC_CHECK_FUNCS([ \
   X509_get0_signature \
   ERR_get_error_all \
   SHA1 \
+  SSL_SESSION_dup \
 ])
 
 AC_CHECK_FUNC([ASN1_STRING_get0_data], [],

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -53,6 +53,8 @@ typedef uint16_t ssl_curve_id;
 // Return the SSL Curve ID associated to the specified SSL connection
 ssl_curve_id SSLGetCurveNID(SSL *ssl);
 
+SSL_SESSION *SSLSessionDup(SSL_SESSION *sess);
+
 enum class SSLCertContextType;
 
 struct SSLLoadingContext {

--- a/iocore/net/SSLSessionCache.cc
+++ b/iocore/net/SSLSessionCache.cc
@@ -342,7 +342,7 @@ SSLOriginSessionCache::insert_session(const std::string &lookup_key, SSL_SESSION
   }
 
   // Duplicate the session from the connection, we'll be keeping track the ref-count with a shared pointer ourself
-  SSL_SESSION *sess_ptr = SSL_SESSION_dup(sess);
+  SSL_SESSION *sess_ptr = SSLSessionDup(sess);
 
   if (is_debug_tag_set("ssl.origin_session_cache")) {
     Debug("ssl.origin_session_cache", "insert session: %s = %p", lookup_key.c_str(), sess_ptr);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2635,3 +2635,27 @@ SSLGetCurveNID(SSL *ssl)
   return SSL_get_curve_id(ssl);
 #endif
 }
+
+SSL_SESSION *
+SSLSessionDup(SSL_SESSION *sess)
+{
+#ifdef HAVE_SSL_SESSION_DUP
+  return SSL_SESSION_dup(sess);
+#else
+  SSL_SESSION *duplicated = nullptr;
+  int len = i2d_SSL_SESSION(sess, nullptr);
+  if (len < 0) {
+    return nullptr;
+  }
+  uint8_t *buf = static_cast<uint8_t *>(alloca(len));
+  uint8_t **tmp = &buf;
+
+  i2d_SSL_SESSION(sess, tmp);
+  tmp = &buf;
+  if (d2i_SSL_SESSION(&duplicated, const_cast<const uint8_t **>(tmp), len) == nullptr) {
+    return nullptr;
+  }
+
+  return duplicated;
+#endif
+}


### PR DESCRIPTION
PR #8498 uses `SSL_SESSION_dup` which is available since OpenSSL 1.1.1. I only confirmed BoringSSL build is broken, but it probably doesn't build with older OpenSSL as well.

This PR introduces a wrapper function for `SSL_SESSION_dup`, and it mimics the behavior of `SSL_SESSION_dup` if the function is unavailable. I didn't test the implementation very seriously, but it should work if I understand the code before #8498.