### PR TITLE
Ports #7897 from core strategies to parent_select plugin.

### DIFF
--- a/include/ts/parentselectdefs.h
+++ b/include/ts/parentselectdefs.h
@@ -57,4 +57,5 @@ typedef struct {
   bool responseIsRetryable;
   bool goDirect;
   bool parentIsProxy;
+  bool no_cache;
 } TSResponseAction;

--- a/plugins/experimental/parent_select/consistenthash.h
+++ b/plugins/experimental/parent_select/consistenthash.h
@@ -55,6 +55,7 @@ struct PLNextHopConsistentHashTxn {
   size_t hostname_len  = 0;
   in_port_t port       = 0;
   bool retry           = false;
+  bool no_cache        = false;
 };
 
 class PLNextHopConsistentHash : public PLNextHopSelectionStrategy
@@ -72,7 +73,8 @@ public:
   ~PLNextHopConsistentHash();
   bool Init(const YAML::Node &n);
   void next(TSHttpTxn txnp, void *strategyTxn, const char *exclude_hostname, size_t exclude_hostname_len, in_port_t exclude_port,
-            const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port, bool *out_retry, time_t now = 0) override;
+            const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port, bool *out_retry, bool *out_no_cache,
+            time_t now = 0) override;
   void mark(TSHttpTxn txnp, void *strategyTxn, const char *hostname, const size_t hostname_len, const in_port_t port,
             const PLNHCmd status, const time_t now) override;
   void *newTxn() override;

--- a/plugins/experimental/parent_select/strategy.cc
+++ b/plugins/experimental/parent_select/strategy.cc
@@ -47,12 +47,13 @@
 //
 
 // ring mode strings
-constexpr std::string_view alternate_rings = "alternate_ring";
-constexpr std::string_view exhaust_rings   = "exhaust_ring";
+const std::string_view alternate_rings = "alternate_ring";
+const std::string_view exhaust_rings   = "exhaust_ring";
+const std::string_view peering_rings   = "peering_ring";
 
 // health check strings
-constexpr std::string_view active_health_check  = "active";
-constexpr std::string_view passive_health_check = "passive";
+const std::string_view active_health_check  = "active";
+const std::string_view passive_health_check = "passive";
 
 PLNextHopSelectionStrategy::PLNextHopSelectionStrategy(const std::string_view &name)
 {
@@ -96,6 +97,10 @@ PLNextHopSelectionStrategy::Init(const YAML::Node &n)
       ignore_self_detect = n["ignore_self_detect"].as<bool>();
     }
 
+    if (n["cache_peer_result"]) {
+      cache_peer_result = n["cache_peer_result"].as<bool>();
+    }
+
     // failover node.
     YAML::Node failover_node;
     if (n["failover"]) {
@@ -106,6 +111,8 @@ PLNextHopSelectionStrategy::Init(const YAML::Node &n)
           ring_mode = PL_NH_ALTERNATE_RING;
         } else if (ring_mode_val == exhaust_rings) {
           ring_mode = PL_NH_EXHAUST_RING;
+        } else if (ring_mode_val == peering_rings) {
+          ring_mode = PL_NH_PEERING_RING;
         } else {
           ring_mode = PL_NH_ALTERNATE_RING;
           PL_NH_Note("Invalid 'ring_mode' value, '%s', for the strategy named '%s', using default '%s'.", ring_mode_val.c_str(),

--- a/plugins/experimental/parent_select/strategy.h
+++ b/plugins/experimental/parent_select/strategy.h
@@ -38,6 +38,15 @@
 
 constexpr const char *PL_NH_DEBUG_TAG = "plugin_nexthop";
 
+// ring mode strings
+extern const std::string_view alternate_rings;
+extern const std::string_view exhaust_rings;
+extern const std::string_view peering_rings;
+
+// health check strings
+extern const std::string_view active_health_check;
+extern const std::string_view passive_health_check;
+
 #define PL_NH_Debug(tag, fmt, ...) TSDebug(tag, "[%s:%d]: " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
 #define PL_NH_Error(fmt, ...) TSError("(%s) [%s:%d]: " fmt, PLUGIN_NAME, __FILE__, __LINE__, ##__VA_ARGS__)
 #define PL_NH_Note(fmt, ...) TSDebug(PL_NH_DEBUG_TAG, "[%s:%d]: " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
@@ -59,7 +68,7 @@ enum PLNHPolicyType {
 
 enum PLNHSchemeType { PL_NH_SCHEME_NONE = 0, PL_NH_SCHEME_HTTP, PL_NH_SCHEME_HTTPS };
 
-enum PLNHRingMode { PL_NH_ALTERNATE_RING = 0, PL_NH_EXHAUST_RING };
+enum PLNHRingMode { PL_NH_ALTERNATE_RING = 0, PL_NH_EXHAUST_RING, PL_NH_PEERING_RING };
 
 // response codes container
 struct PLResponseCodes {
@@ -209,7 +218,7 @@ public:
   virtual const char *name()                                                                        = 0;
   virtual void next(TSHttpTxn txnp, void *strategyTxn, const char *exclude_hostname, size_t exclude_hostname_len,
                     in_port_t exclude_port, const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port,
-                    bool *out_retry, time_t now = 0)                                                = 0;
+                    bool *out_retry, bool *out_no_cache, time_t now = 0)                            = 0;
   virtual void mark(TSHttpTxn txnp, void *strategyTxn, const char *hostname, const size_t hostname_len, const in_port_t port,
                     const PLNHCmd status, const time_t now = 0)                                     = 0;
   virtual bool nextHopExists(TSHttpTxn txnp)                                                        = 0;
@@ -234,9 +243,9 @@ public:
 
   virtual void next(TSHttpTxn txnp, void *strategyTxn, const char *exclude_hostname, size_t exclude_hostname_len,
                     in_port_t exclude_port, const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port,
-                    bool *out_retry, time_t now = 0)            = 0;
+                    bool *out_retry, bool *out_no_cache, time_t now = 0) = 0;
   virtual void mark(TSHttpTxn txnp, void *strategyTxn, const char *hostname, const size_t hostname_len, const in_port_t port,
-                    const PLNHCmd status, const time_t now = 0) = 0;
+                    const PLNHCmd status, const time_t now = 0)          = 0;
   virtual bool nextHopExists(TSHttpTxn txnp);
   virtual bool codeIsFailure(TSHttpStatus response_code);
   virtual bool responseIsRetryable(unsigned int current_retry_attempts, TSHttpStatus response_code);
@@ -256,6 +265,7 @@ protected:
   bool go_direct          = true;
   bool parent_is_proxy    = true;
   bool ignore_self_detect = false;
+  bool cache_peer_result  = true;
   PLNHSchemeType scheme   = PL_NH_SCHEME_NONE;
   PLNHRingMode ring_mode  = PL_NH_ALTERNATE_RING;
   PLResponseCodes resp_codes;     // simple retry codes

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3642,9 +3642,16 @@ HttpTransact::handle_response_from_parent(State *s)
     }
     // the next hop strategy is configured not
     // to cache a response from a next hop peer.
-    if (s->parent_result.do_not_cache_response) {
-      TxnDebug("http_trans", "response is from a next hop peer, do not cache.");
-      s->cache_info.action = CACHE_DO_NO_ACTION;
+    if (s->response_action.handled) {
+      if (s->response_action.action.no_cache) {
+        TxnDebug("http_trans", "plugin set response_action.no_cache, do not cache.");
+        s->cache_info.action = CACHE_DO_NO_ACTION;
+      }
+    } else {
+      if (s->parent_result.do_not_cache_response) {
+        TxnDebug("http_trans", "response is from a next hop peer, do not cache.");
+        s->cache_info.action = CACHE_DO_NO_ACTION;
+      }
     }
     handle_forward_server_connection_open(s);
     break;


### PR DESCRIPTION
Ports #7897 from core strategies to parent_select plugin.

Adds a new peering_ring mode to strategies, which allows parenting to
a consistent-hashed peer instead of the next hierarchical tier,
which can be useful in many situations, especially when the requesting
client itself is requesting different caches for the same key.