### PR TITLE
Add TLSEarlyDataSupport

### DIFF
--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -191,6 +191,7 @@ libinknet_a_SOURCES = \
 	SSLUtils.cc \
 	OCSPStapling.cc \
 	TLSBasicSupport.cc \
+	TLSEarlyDataSupport.cc \
 	TLSSessionResumptionSupport.cc \
 	TLSSNISupport.cc \
 	UDPIOEvent.cc \

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -49,6 +49,7 @@
 #include "P_ALPNSupport.h"
 #include "TLSSessionResumptionSupport.h"
 #include "TLSSNISupport.h"
+#include "TLSEarlyDataSupport.h"
 #include "TLSBasicSupport.h"
 #include "P_SSLUtils.h"
 #include "P_SSLConfig.h"
@@ -99,6 +100,7 @@ class SSLNetVConnection : public UnixNetVConnection,
                           public ALPNSupport,
                           public TLSSessionResumptionSupport,
                           public TLSSNISupport,
+                          public TLSEarlyDataSupport,
                           public TLSBasicSupport
 {
   typedef UnixNetVConnection super; ///< Parent type.
@@ -359,12 +361,6 @@ public:
   bool protocol_mask_set = false;
   unsigned long protocol_mask;
 
-  // early data related stuff
-  bool early_data_finish            = false;
-  MIOBuffer *early_data_buf         = nullptr;
-  IOBufferReader *early_data_reader = nullptr;
-  int64_t read_from_early_data      = 0;
-
   // Only applies during the VERIFY certificate hooks (client and server side)
   // Means to give the plugin access to the data structure passed in during the underlying
   // openssl callback so the plugin can make more detailed decisions about the
@@ -502,6 +498,13 @@ private:
   std::unique_ptr<char[]> _ca_cert_dir;
 
   EventIO async_ep{};
+
+  // early data related stuff
+#if TS_HAS_TLS_EARLY_DATA
+  bool _early_data_finish            = false;
+  MIOBuffer *_early_data_buf         = nullptr;
+  IOBufferReader *_early_data_reader = nullptr;
+#endif
 
 private:
   void _make_ssl_connection(SSL_CTX *ctx);

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1066,6 +1066,7 @@ SSLInitializeLibrary()
   ALPNSupport::initialize();
   TLSSessionResumptionSupport::initialize();
   TLSSNISupport::initialize();
+  TLSEarlyDataSupport::initialize();
 
   open_ssl_initialized = true;
 }

--- a/iocore/net/TLSEarlyDataSupport.cc
+++ b/iocore/net/TLSEarlyDataSupport.cc
@@ -1,0 +1,74 @@
+/** @file
+
+  TLSSEarlyDataSupport.cc provides implmentations for
+  TLSEarlyDataSupport methods
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <openssl/ssl.h>
+#include "TLSEarlyDataSupport.h"
+#include "tscore/ink_assert.h"
+
+int TLSEarlyDataSupport::_ex_data_index = -1;
+
+void
+TLSEarlyDataSupport::initialize()
+{
+  ink_assert(_ex_data_index == -1);
+  if (_ex_data_index == -1) {
+    _ex_data_index = SSL_get_ex_new_index(0, (void *)"TLSEarlyDataSupport index", nullptr, nullptr, nullptr);
+  }
+}
+
+TLSEarlyDataSupport *
+TLSEarlyDataSupport::getInstance(SSL *ssl)
+{
+  return static_cast<TLSEarlyDataSupport *>(SSL_get_ex_data(ssl, _ex_data_index));
+}
+
+void
+TLSEarlyDataSupport::bind(SSL *ssl, TLSEarlyDataSupport *srs)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, srs);
+}
+
+void
+TLSEarlyDataSupport::unbind(SSL *ssl)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, nullptr);
+}
+
+void
+TLSEarlyDataSupport::clear()
+{
+  this->_early_data_len = 0;
+}
+
+size_t
+TLSEarlyDataSupport::get_early_data_len() const
+{
+  return this->_early_data_len;
+}
+
+void
+TLSEarlyDataSupport::_increment_early_data_len(size_t amount)
+{
+  this->_early_data_len += amount;
+}

--- a/iocore/net/TLSEarlyDataSupport.h
+++ b/iocore/net/TLSEarlyDataSupport.h
@@ -1,0 +1,50 @@
+/** @file
+
+  TLSEarlyDataSupport implements common methods and members to
+  support TLS Early Data
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <openssl/ssl.h>
+
+class TLSEarlyDataSupport
+{
+public:
+  virtual ~TLSEarlyDataSupport() = default;
+
+  static void initialize();
+  static TLSEarlyDataSupport *getInstance(SSL *ssl);
+  static void bind(SSL *ssl, TLSEarlyDataSupport *srs);
+  static void unbind(SSL *ssl);
+
+  size_t get_early_data_len() const;
+
+protected:
+  void clear();
+
+  void _increment_early_data_len(size_t amount);
+
+private:
+  static int _ex_data_index;
+
+  size_t _early_data_len = 0;
+};

--- a/proxy/http/Http1ClientSession.cc
+++ b/proxy/http/Http1ClientSession.cc
@@ -38,7 +38,8 @@
 #include "Plugin.h"
 #include "PoolableSession.h"
 
-#include "P_SSLNetVConnection.h"
+#include "TLSBasicSupport.h"
+#include "TLSEarlyDataSupport.h"
 
 #define HttpSsnDebug(fmt, ...) SsnDebug(this, "http_cs", fmt, __VA_ARGS__)
 
@@ -140,9 +141,9 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   trans.mutex = mutex; // Share this mutex with the transaction
   in_destroy  = false;
 
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(new_vc);
-  if (ssl_vc != nullptr) {
-    read_from_early_data = ssl_vc->read_from_early_data;
+  TLSEarlyDataSupport *eds = dynamic_cast<TLSEarlyDataSupport *>(new_vc);
+  if (eds != nullptr) {
+    read_from_early_data = eds->get_early_data_len();
     Debug("ssl_early_data", "read_from_early_data = %" PRId64, read_from_early_data);
   }
 
@@ -533,7 +534,7 @@ bool
 Http1ClientSession::allow_half_open() const
 {
   // Only allow half open connections if the not over TLS
-  return (_vc && dynamic_cast<SSLNetVConnection *>(_vc) == nullptr);
+  return (_vc && dynamic_cast<TLSBasicSupport *>(_vc) == nullptr);
 }
 
 void

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -25,7 +25,7 @@
 #include "HttpDebugNames.h"
 #include "tscore/ink_base64.h"
 #include "Http2CommonSessionInternal.h"
-#include "P_SSLNetVConnection.h"
+#include "TLSEarlyDataSupport.h"
 
 ClassAllocator<Http2ClientSession, true> http2ClientSessionAllocator("http2ClientSessionAllocator");
 
@@ -101,9 +101,9 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 
   this->connection_state.mutex = this->mutex;
 
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(new_vc);
-  if (ssl_vc != nullptr) {
-    this->read_from_early_data = ssl_vc->read_from_early_data;
+  TLSEarlyDataSupport *eds = dynamic_cast<TLSEarlyDataSupport *>(new_vc);
+  if (eds != nullptr) {
+    this->read_from_early_data = eds->get_early_data_len();
     Debug("ssl_early_data", "read_from_early_data = %" PRId64, this->read_from_early_data);
   }
 


### PR DESCRIPTION
Like other `TLS*Support`, this defines an interface for TLS Early Data.

Since we already use the same interface for the both Early Data and Non-Early Data in terms of data I/O, `TLSEarlyDataSupport` only provides an auxiliary function. It doesn't really clean up code, but removes a dependency for `SSLNetVC` from proxy sessions, and clarify how to access necessary information.

For QUIC, `TLSEarlyDataSupport` will also be implemented by `QUICStream` that is in between `QUICNetVC` and HTTP/3 proxy session, in addition to `QUICNetVC`. Then we will be able to use the same interface from proxy layer in spite of difference between non-multiplexed connections (regular TLS) and multiplexed connections (QUIC).