### PR TITLE
SNIConfig: tunnel_route -  Change the way we extract matched subgroups from the servename

### DIFF
--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -45,11 +45,14 @@ public:
    * Context should contain extra data needed to be passed to the actual SNIAction.
    */
   struct Context {
+    using CapturedGroupViewVec = std::vector<std::string_view>;
     /**
      * if any, fqdn_wildcard_captured_groups will hold the captured groups from the `fqdn`
-     * match which will be used to construct the tunnel destination.
+     * match which will be used to construct the tunnel destination. This vector contains only
+     * partial views of the original server name, group views are valid as long as the original
+     * string from where the groups were obtained lives.
      */
-    std::optional<std::vector<std::string>> _fqdn_wildcard_captured_groups;
+    std::optional<CapturedGroupViewVec> _fqdn_wildcard_captured_groups;
   };
 
   virtual int SNIAction(TLSSNISupport *snis, const Context &ctx) const = 0;
@@ -150,7 +153,7 @@ private:
    * groups could be at any order.
    */
   std::string
-  replace_match_groups(const std::string &dst, const std::vector<std::string> &groups) const
+  replace_match_groups(const std::string &dst, const ActionItem::Context::CapturedGroupViewVec &groups) const
   {
     if (dst.empty() || groups.empty()) {
       return dst;

--- a/iocore/net/P_SSLSNI.h
+++ b/iocore/net/P_SSLSNI.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <vector>
+#include <string_view>
 #include <strings.h>
 
 #include "ProxyConfig.h"
@@ -109,7 +110,7 @@ struct SNIConfigParams : public ConfigInfo {
   void cleanup();
   int Initialize();
   void loadSNIConfig();
-  std::pair<const actionVector *, ActionItem::Context> get(const std::string &servername) const;
+  std::pair<const actionVector *, ActionItem::Context> get(std::string_view servername) const;
 };
 
 struct SNIConfig {

--- a/iocore/net/TLSSNISupport.cc
+++ b/iocore/net/TLSSNISupport.cc
@@ -58,8 +58,13 @@ int
 TLSSNISupport::perform_sni_action()
 {
   const char *servername = this->_get_sni_server_name();
+  if (!servername) {
+    Debug("ssl_sni", "No servername provided");
+    return SSL_TLSEXT_ERR_OK;
+  }
+
   SNIConfig::scoped_config params;
-  if (const auto &actions = params->get(servername); !actions.first) {
+  if (const auto &actions = params->get({servername, std::strlen(servername)}); !actions.first) {
     Debug("ssl_sni", "%s not available in the map", servername);
   } else {
     for (auto &&item : *actions.first) {


### PR DESCRIPTION
This PR is created to fix the  [leak](https://github.com/apache/trafficserver/issues/8564) around the non-freed memory happening when there is more than one matched group detected when we try to rearrange the servername destination base on the SNI `tunnel_route` [configuration](https://docs.trafficserver.apache.org/en/latest/admin-guide/files/sni.yaml.en.html?highlight=tunnel_route). 

The allocation for the subgroups is removed and instead this now uses the provided offsets to read each matched sub-group from the server name, this avoids allocating(by `pcre_get_substring`) memory for each substring.
This change also removes the` std::vector<std::string>` to avoid an extra allocation for the string and instead it now holds only a view of the subgroup string.

Note:  `servername` gets allocated and copied inside the `TLSSNISupport` object, this chunk of memory is kept around for the durations of the [perform_sni_action](https://github.com/brbzull0/trafficserver/blob/dmeden%2Fissue_8564/iocore/net/SSLUtils.cc#L471-L472) call. With the string around it looks safe to hold the views instead of a copy of the substrings inside the `ActionItem::Context`.

This fixes  https://github.com/apache/trafficserver/issues/8564

