### PR TITLE
Fix outbound transparent HTTP/2 and DNS issues

### DIFF
--- a/proxy/ProxySession.cc
+++ b/proxy/ProxySession.cc
@@ -312,3 +312,9 @@ ProxySession::support_sni() const
 {
   return _vc ? _vc->support_sni() : false;
 }
+
+bool
+ProxySession::is_outbound_transparent() const
+{
+  return accept_options->f_outbound_transparent;
+}

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -100,6 +100,8 @@ public:
   virtual void increment_current_active_connections_stat() = 0;
   virtual void decrement_current_active_connections_stat() = 0;
 
+  virtual bool is_outbound_transparent() const;
+
   // Virtual Accessors
   virtual int get_transact_count() const          = 0;
   virtual const char *get_protocol_string() const = 0;

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -158,7 +158,7 @@ ProxyTransaction::set_outbound_ip(const IpAddr &new_addr)
 bool
 ProxyTransaction::is_outbound_transparent() const
 {
-  return upstream_outbound_options.f_outbound_transparent;
+  return _proxy_ssn->is_outbound_transparent();
 }
 
 void

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -508,6 +508,11 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc)
     return;
   }
   ua_txn = client_vc;
+  if (ua_txn->is_outbound_transparent()) {
+    // Turn off the DNS lookup
+    t_state.force_dns = false;
+    ats_ip_copy(t_state.server_info.dst_addr, this->ua_txn->get_netvc()->get_local_addr());
+  }
 
   // It seems to be possible that the ua_txn pointer will go stale before log entries for this HTTP transaction are
   // generated.  Therefore, collect information that may be needed for logging from the ua_txn object at this point.

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2664,6 +2664,16 @@ void
 HttpTransact::CallOSDNSLookup(State *s)
 {
   TxnDebug("http", "[HttpTransact::callos] %s ", s->server_info.name);
+  if (s->state_machine->ua_txn->is_outbound_transparent()) {
+    // No DNS lookup if outbound transparent
+    find_server_and_update_current_info(s);
+    if (!s->hdr_info.server_request.valid()) {
+      build_request(s, &s->hdr_info.client_request, &s->hdr_info.server_request, s->current.server->http_version);
+    }
+    // what kind of a connection (raw, simple)
+    s->next_action = how_to_open_connection(s);
+    return;
+  }
   HostStatus &pstatus = HostStatus::instance();
   HostStatRec *hst    = pstatus.getHostStatus(s->server_info.name);
   if (hst && hst->status == TSHostStatus::TS_HOST_STATUS_DOWN) {


### PR DESCRIPTION
Fixes issues with propagating the outbound transparent flag.  Would like @SolidWallOfCode to review. This fix removes the ability to override outbound transparent on a per transaction basis, but I fail to see how that would have ever been useful.

Also adds a check to avoid exercising the DNS lookup if outbound transparent is enabled.

This closes #8587