### PR TITLE
Propagate accept options to HTTP/2

### DIFF
--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -46,11 +46,12 @@ Http2Stream::Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initi
 
   this->mark_milestone(Http2StreamMilestone::OPEN);
 
-  this->_sm          = nullptr;
-  this->_id          = sid;
-  this->_thread      = this_ethread();
-  this->_client_rwnd = initial_rwnd;
-  this->_server_rwnd = Http2::initial_window_size;
+  this->_sm                       = nullptr;
+  this->_id                       = sid;
+  this->_thread                   = this_ethread();
+  this->_client_rwnd              = initial_rwnd;
+  this->_server_rwnd              = Http2::initial_window_size;
+  this->upstream_outbound_options = *(session->accept_options);
 
   this->_reader = this->_request_buffer.alloc_reader();
 


### PR DESCRIPTION
Propagates the outbound transparent field so HTTP/2 requests pass over the transparent session. Details in issue.

This closes #8587