### PR TITLE
Prevent calling SSL_set_session in the middle of handshake

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -459,6 +459,7 @@ private:
 
   enum SSLHandshakeStatus sslHandshakeStatus = SSL_HANDSHAKE_ONGOING;
   bool sslClientRenegotiationAbort           = false;
+  bool first_ssl_connect                     = true;
   MIOBuffer *handShakeBuffer                 = nullptr;
   IOBufferReader *handShakeHolder            = nullptr;
   IOBufferReader *handShakeReader            = nullptr;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -2080,19 +2080,22 @@ SSLNetVConnection::_ssl_connect()
   ERR_clear_error();
 
   SSL_SESSION *sess = SSL_get_session(ssl);
-  if (!sess && SSLConfigParams::origin_session_cache == 1 && SSLConfigParams::origin_session_cache_size > 0) {
-    std::string sni_addr = get_sni_addr(ssl);
-    if (!sni_addr.empty()) {
-      std::string lookup_key;
-      ts::bwprint(lookup_key, "{}:{}:{}", sni_addr.c_str(), SSL_get_SSL_CTX(ssl), get_verify_str(ssl));
+  if (first_ssl_connect) {
+    first_ssl_connect = false;
+    if (!sess && SSLConfigParams::origin_session_cache == 1 && SSLConfigParams::origin_session_cache_size > 0) {
+      std::string sni_addr = get_sni_addr(ssl);
+      if (!sni_addr.empty()) {
+        std::string lookup_key;
+        ts::bwprint(lookup_key, "{}:{}:{}", sni_addr.c_str(), SSL_get_SSL_CTX(ssl), get_verify_str(ssl));
 
-      Debug("ssl.origin_session_cache", "origin session cache lookup key = %s", lookup_key.c_str());
+        Debug("ssl.origin_session_cache", "origin session cache lookup key = %s", lookup_key.c_str());
 
-      std::shared_ptr<SSL_SESSION> shared_sess = this->getOriginSession(ssl, lookup_key);
+        std::shared_ptr<SSL_SESSION> shared_sess = this->getOriginSession(ssl, lookup_key);
 
-      if (shared_sess && SSL_set_session(ssl, shared_sess.get())) {
-        // Keep a reference of this shared pointer in the connection
-        this->client_sess = shared_sess;
+        if (shared_sess && SSL_set_session(ssl, shared_sess.get())) {
+          // Keep a reference of this shared pointer in the connection
+          this->client_sess = shared_sess;
+        }
       }
     }
   }


### PR DESCRIPTION
ATS crashes if origin session cache is used with BoringSSL, because BoringSSL doesn't allow you to call SSL_set_session after starting handshake.

The crash is not 100% reproducible and I was only able to reproduce it on 9.2.x, but the change should make sense on master as well.

https://www.openssl.org/docs/man1.1.1/man3/SSL_set_session.html
> If there is already a session set inside ssl (because it was set with SSL_set_session() before or because the same ssl was already used for a connection), SSL_SESSION_free() will be called for that session. If that old session is still open, it is considered bad and will be removed from the session cache (if used). A session is considered open, if SSL_shutdown(3) was not called for the connection (or at least SSL_set_shutdown(3) was used to set the SSL_SENT_SHUTDOWN state).

https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_set_session
> It is an error to call this function after the handshake has begun.

The change is very small if you hide whitespace (indent) changes.