### PR TITLE
LogFilter: fix NULL termination check

### DIFF
--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -474,7 +474,7 @@ wipeField(char **field, char *pattern, const char *uppercase_field)
 
       // search new param again
       const char *new_param = strchr(lookup_query_param + field_pos, '&');
-      if (new_param && (new_param + 1)) {
+      if (new_param && *(new_param + 1)) {
         pattern_in_param_name = findPatternFromParamName(new_param + 1, pattern);
       } else {
         break;


### PR DESCRIPTION
gcc-12 generated the following warning:

proxy/logging/LogFilter.h: In function 'void wipeField(char**, char*, const char*)':
proxy/logging/LogFilter.h:477:35: error: comparing the result of pointer addition '(new_param + 1)' and NULL [-Werror=address]
  477 |       if (new_param && (new_param + 1)) {
      |                        ~~~~~~~~~~~^~~~

That is indeed a bug. `new_param + 1` will always be non-NULL even if new_param
is NULL because 1 will be added to it. The intention was to check for the
string's null terminator at the offset, which is done via a dereference.