### PR TITLE
Fixed a scoping bug that leads to "sticky" parent weights

### DIFF
--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -446,7 +446,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
   int port            = 0;
   char *tmp = nullptr, *tmp2 = nullptr, *tmp3 = nullptr;
   const char *errPtr = nullptr;
-  float weight       = 1.0;
+  float weight       = DEFAULT_PARENT_WEIGHT;
 
   if (parents != nullptr && isPrimary == true) {
     return "Can not specify more than one set of parents";
@@ -470,6 +470,7 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
   // Loop through the set of parents specified
   //
   for (int i = 0; i < numTok; i++) {
+    weight  = DEFAULT_PARENT_WEIGHT; // reset weight to the default
     current = pTok[i];
 
     // Find the parent port

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -43,6 +43,7 @@
 #include <vector>
 
 #define MAX_PARENTS 64
+#define DEFAULT_PARENT_WEIGHT 1.0
 
 struct RequestData;
 struct matcher_line;


### PR DESCRIPTION
* Due to scoping, the last user-provided weight seen in `parent.config` will be applied to all subsequent parents that lack a weight

* Added a constant to specify the default weight

* Resets the weight to default prior to parsing each parent's configuration to ensure defaults are used when no weight exists