### PR TITLE
Clear lua plugin http context after each hook handler

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -644,14 +644,6 @@ globalHookHandler(TSCont contp, TSEvent event ATS_UNUSED, void *edata)
     break;
 
   case TS_EVENT_HTTP_SEND_RESPONSE_HDR:
-    // client response can be changed within a transaction
-    // (e.g. due to the follow redirect feature). So, clearing the pointers
-    // to allow API(s) to fetch the pointers again when it re-enters the hook
-    if (http_ctx->client_response_hdrp != NULL) {
-      TSHandleMLocRelease(http_ctx->client_response_bufp, TS_NULL_MLOC, http_ctx->client_response_hdrp);
-      http_ctx->client_response_bufp = NULL;
-      http_ctx->client_response_hdrp = NULL;
-    }
     lua_getglobal(l, TS_LUA_FUNCTION_G_SEND_RESPONSE);
     break;
 
@@ -708,14 +700,7 @@ globalHookHandler(TSCont contp, TSEvent event ATS_UNUSED, void *edata)
   ret = lua_tointeger(l, -1);
   lua_pop(l, 1);
 
-  // client response can be changed within a transaction
-  // (e.g. due to the follow redirect feature). So, clearing the pointers
-  // to allow API(s) to fetch the pointers again when it re-enters the hook
-  if (http_ctx->client_response_hdrp != NULL) {
-    TSHandleMLocRelease(http_ctx->client_response_bufp, TS_NULL_MLOC, http_ctx->client_response_hdrp);
-    http_ctx->client_response_bufp = NULL;
-    http_ctx->client_response_hdrp = NULL;
-  }
+  ts_lua_clear_http_ctx(http_ctx);
 
   if (http_ctx->has_hook) {
     // add a hook to release resources for context

--- a/plugins/lua/ts_lua_util.h
+++ b/plugins/lua/ts_lua_util.h
@@ -55,6 +55,7 @@ ts_lua_http_ctx *ts_lua_get_http_ctx(lua_State *L);
 
 ts_lua_http_ctx *ts_lua_create_http_ctx(ts_lua_main_ctx *mctx, ts_lua_instance_conf *conf);
 void ts_lua_destroy_http_ctx(ts_lua_http_ctx *http_ctx);
+void ts_lua_clear_http_ctx(ts_lua_http_ctx *http_ctx);
 
 ts_lua_http_transform_ctx *ts_lua_create_http_transform_ctx(ts_lua_http_ctx *http_ctx, TSVConn connp);
 void ts_lua_destroy_http_transform_ctx(ts_lua_http_transform_ctx *transform_ctx);


### PR DESCRIPTION
The lua plugin kept the TSMBuffer and TSMLoc for client request, server request, server response, client response and cached response in the http context object for reuse. But these are volatile across hook handler functions. So they needs to be cleared afterwards. 

This fixes #8351 