### PR TITLE
Don't use Http1ClientTransaction as an event handler

### DIFF
--- a/proxy/http/Http1ClientTransaction.cc
+++ b/proxy/http/Http1ClientTransaction.cc
@@ -31,7 +31,7 @@ Http1ClientTransaction::release()
   // Turn off reading until we are done with the SM
   // At that point the transaction/session with either be closed
   // or be put into keep alive state to wait from the next transaction
-  this->do_io_read(this, 0, nullptr);
+  this->do_io_read(this->_sm, 0, nullptr);
   _proxy_ssn->clear_session_active();
 }
 


### PR DESCRIPTION
Using `Http1ClientTransaction` as an event hander (in other words, passing it to `do_io_read` as a continuation) does not make sense because it does not have code for event handling.

The point of this `do_io_read` seems to be passing 0 and nullptr as the 2nd and 3rd argument, but not changing the continuation, and the original continuation here is probably always HttpSM.

This closes #8604.