### PR TITLE
Introduce TLSTunnelSupport interface

### DIFF
--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -194,6 +194,7 @@ libinknet_a_SOURCES = \
 	TLSEarlyDataSupport.cc \
 	TLSSessionResumptionSupport.cc \
 	TLSSNISupport.cc \
+	TLSTunnelSupport.cc \
 	UDPIOEvent.cc \
 	UnixConnection.cc \
 	UnixNet.cc \

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -219,6 +219,7 @@ SSLNetVConnection::_bindSSLObject()
   TLSSessionResumptionSupport::bind(this->ssl, this);
   TLSSNISupport::bind(this->ssl, this);
   TLSEarlyDataSupport::bind(this->ssl, this);
+  TLSTunnelSupport::bind(this->ssl, this);
 }
 
 void
@@ -230,6 +231,7 @@ SSLNetVConnection::_unbindSSLObject()
   TLSSessionResumptionSupport::unbind(this->ssl);
   TLSSNISupport::unbind(this->ssl);
   TLSEarlyDataSupport::unbind(this->ssl);
+  TLSTunnelSupport::unbind(this->ssl);
 }
 
 static void
@@ -968,6 +970,7 @@ SSLNetVConnection::clear()
   TLSBasicSupport::clear();
   TLSSessionResumptionSupport::clear();
   TLSSNISupport::_clear();
+  TLSTunnelSupport::_clear();
 
   sslHandshakeStatus          = SSL_HANDSHAKE_ONGOING;
   sslLastWriteTime            = 0;
@@ -990,8 +993,6 @@ SSLNetVConnection::free(EThread *t)
     NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, -1);
   }
   con.close();
-
-  ats_free(tunnel_host);
 
 #if TS_HAS_TLS_EARLY_DATA
   if (_early_data_reader != nullptr) {
@@ -1340,7 +1341,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
       SSL_INCREMENT_DYN_STAT(ssl_total_success_handshake_count_in_stat);
     }
 
-    if (_tunnel_type != SNIRoutingType::NONE) {
+    if (this->get_tunnel_type() != SNIRoutingType::NONE) {
       // Foce to use HTTP/1.1 endpoint for SNI Routing
       if (!this->setSelectedProtocol(reinterpret_cast<const unsigned char *>(IP_PROTO_TAG_HTTP_1_1.data()),
                                      IP_PROTO_TAG_HTTP_1_1.size())) {
@@ -1364,7 +1365,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
       }
 
       if (len) {
-        if (_tunnel_type == SNIRoutingType::NONE && !this->setSelectedProtocol(proto, len)) {
+        if (this->get_tunnel_type() == SNIRoutingType::NONE && !this->setSelectedProtocol(proto, len)) {
           return EVENT_ERROR;
         }
         this->set_negotiated_protocol_id({reinterpret_cast<const char *>(proto), static_cast<size_t>(len)});

--- a/iocore/net/TLSTunnelSupport.cc
+++ b/iocore/net/TLSTunnelSupport.cc
@@ -1,0 +1,81 @@
+/** @file
+
+  TLSSTunnelSupport.cc provides implementations for
+  TLSTunnelSupport methods
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "TLSTunnelSupport.h"
+#include "tscore/ink_assert.h"
+
+int TLSTunnelSupport::_ex_data_index = -1;
+
+void
+TLSTunnelSupport::initialize()
+{
+  ink_assert(_ex_data_index == -1);
+  if (_ex_data_index == -1) {
+    _ex_data_index = SSL_get_ex_new_index(0, (void *)"TLSTunnelSupport index", nullptr, nullptr, nullptr);
+  }
+}
+
+TLSTunnelSupport *
+TLSTunnelSupport::getInstance(SSL *ssl)
+{
+  return static_cast<TLSTunnelSupport *>(SSL_get_ex_data(ssl, _ex_data_index));
+}
+
+void
+TLSTunnelSupport::bind(SSL *ssl, TLSTunnelSupport *srs)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, srs);
+}
+
+void
+TLSTunnelSupport::unbind(SSL *ssl)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, nullptr);
+}
+
+void
+TLSTunnelSupport::_clear()
+{
+  ats_free(_tunnel_host);
+}
+
+void
+TLSTunnelSupport::set_tunnel_destination(const std::string_view &destination, SNIRoutingType type,
+                                         YamlSNIConfig::TunnelPreWarm prewarm)
+{
+  _tunnel_type    = type;
+  _tunnel_prewarm = prewarm;
+
+  auto pos = destination.find(":");
+  if (nullptr != _tunnel_host) {
+    ats_free(_tunnel_host);
+  }
+  if (pos != std::string::npos) {
+    _tunnel_port = std::stoi(destination.substr(pos + 1).data());
+    _tunnel_host = ats_strndup(destination.substr(0, pos).data(), pos);
+  } else {
+    _tunnel_port = 0;
+    _tunnel_host = ats_strndup(destination.data(), destination.length());
+  }
+}

--- a/iocore/net/TLSTunnelSupport.h
+++ b/iocore/net/TLSTunnelSupport.h
@@ -26,6 +26,7 @@
 
 #include <openssl/ssl.h>
 #include "tscore/ink_memory.h"
+#include "tscore/ink_inet.h"
 #include "YamlSNIConfig.h"
 
 class TLSTunnelSupport

--- a/iocore/net/TLSTunnelSupport.h
+++ b/iocore/net/TLSTunnelSupport.h
@@ -1,0 +1,110 @@
+/** @file
+
+  TLSTunnelSupport implements common methods and members to
+  support basic features on TLS connections
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <openssl/ssl.h>
+#include "tscore/ink_memory.h"
+#include "YamlSNIConfig.h"
+
+class TLSTunnelSupport
+{
+public:
+  virtual ~TLSTunnelSupport() = default;
+
+  static void initialize();
+  static TLSTunnelSupport *getInstance(SSL *ssl);
+  static void bind(SSL *ssl, TLSTunnelSupport *srs);
+  static void unbind(SSL *ssl);
+
+  bool is_decryption_needed() const;
+  bool is_upstream_tls() const;
+
+  SNIRoutingType get_tunnel_type() const;
+  const char *get_tunnel_host() const;
+  ushort get_tunnel_port() const;
+
+  bool has_tunnel_destination() const;
+  void set_tunnel_destination(const std::string_view &destination, SNIRoutingType type, YamlSNIConfig::TunnelPreWarm prewarm);
+  YamlSNIConfig::TunnelPreWarm get_tunnel_prewarm_configuration() const;
+
+protected:
+  void _clear();
+
+private:
+  static int _ex_data_index;
+
+  char *_tunnel_host                           = nullptr;
+  in_port_t _tunnel_port                       = 0;
+  SNIRoutingType _tunnel_type                  = SNIRoutingType::NONE;
+  YamlSNIConfig::TunnelPreWarm _tunnel_prewarm = YamlSNIConfig::TunnelPreWarm::UNSET;
+};
+
+inline SNIRoutingType
+TLSTunnelSupport::get_tunnel_type() const
+{
+  return this->_tunnel_type;
+}
+
+inline bool
+TLSTunnelSupport::has_tunnel_destination() const
+{
+  return _tunnel_host != nullptr;
+}
+
+inline const char *
+TLSTunnelSupport::get_tunnel_host() const
+{
+  return _tunnel_host;
+}
+
+inline ushort
+TLSTunnelSupport::get_tunnel_port() const
+{
+  return _tunnel_port;
+}
+
+/**
+   Returns true if this vc was configured for forward_route or partial_blind_route
+ */
+inline bool
+TLSTunnelSupport::is_decryption_needed() const
+{
+  return this->_tunnel_type == SNIRoutingType::FORWARD || this->_tunnel_type == SNIRoutingType::PARTIAL_BLIND;
+}
+
+/**
+   Returns true if this vc was configured partial_blind_route
+ */
+inline bool
+TLSTunnelSupport::is_upstream_tls() const
+{
+  return _tunnel_type == SNIRoutingType::PARTIAL_BLIND;
+}
+
+inline YamlSNIConfig::TunnelPreWarm
+TLSTunnelSupport::get_tunnel_prewarm_configuration() const
+{
+  return _tunnel_prewarm;
+}


### PR DESCRIPTION
This introduces a mix-in class for TLS tunneling stuff.

The goal of this PR is to remove `dynamic_cast<SSLNetVConnection *>` from `HttpSM` and cleanup SSLNetVC a bit. Although some code that can be moved to the mix-in class is remained, code for tunneling is spread over multiple modules and I'd like to hand over that part to someone who is familiar with tunneling stuff.

On this PR, although there are two small changes, I simply moved functions that are just for tunneling into the mix-in class, so the logic isn't changed. Please see inline comments for the two changes
