### PR TITLE
fix for collapsed forwarding ink_abort for CacheHitFresh fail

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4743,6 +4743,9 @@ HttpSM::do_cache_lookup_and_read()
   // ink_assert(server_txn == NULL);
   ink_assert(pending_action.empty());
 
+  t_state.request_sent_time      = UNDEFINED_TIME;
+  t_state.response_received_time = UNDEFINED_TIME;
+
   HTTP_INCREMENT_DYN_STAT(http_cache_lookups_stat);
 
   milestones[TS_MILESTONE_CACHE_OPEN_READ_BEGIN] = Thread::get_hrtime();


### PR DESCRIPTION
This fixes an abort when
```CONFIG proxy.config.http.cache.open_write_fail_action INT 5```
is set which rewinds the state machine to before cache read/write.

This was tested by simulating a manifest that updates every 10s with max-age=1 cache control, hitting that asset with a thundering herd.

The failure was happening with a cache hit on a stale manifest.

While this "fix" allows ATS to to run without aborting, under testing 1 or more transactions end up with a client timeout with no bytes transferred.