### PR TITLE
TSHttpTxnCacheLookupStatusGet: call need_to_revalidate

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2756,13 +2756,12 @@ HttpTransact::need_to_revalidate(State *s)
     needs_revalidate = false;
   }
 
-  s->cache_hit_but_revalidate =
-    ((needs_authenticate == true) || (needs_revalidate == true) || (is_cache_response_returnable(s) == false));
+  bool send_revalidate = ((needs_authenticate == true) || (needs_revalidate == true) || (is_cache_response_returnable(s) == false));
   if (needs_cache_auth == true) {
-    s->www_auth_content         = s->cache_hit_but_revalidate ? CACHE_AUTH_STALE : CACHE_AUTH_FRESH;
-    s->cache_hit_but_revalidate = true;
+    s->www_auth_content = send_revalidate ? CACHE_AUTH_STALE : CACHE_AUTH_FRESH;
+    send_revalidate     = true;
   }
-  return s->cache_hit_but_revalidate;
+  return send_revalidate;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2881,21 +2880,21 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
   // do we need to revalidate. in other words if the response
   // has to be authorized, is stale or can not be returned, do
   // a revalidate.
-  s->cache_hit_but_revalidate = (needs_authenticate || needs_revalidate || !response_returnable);
+  bool send_revalidate = (needs_authenticate || needs_revalidate || !response_returnable);
 
   if (needs_cache_auth == true) {
     SET_VIA_STRING(VIA_DETAIL_CACHE_LOOKUP, VIA_DETAIL_MISS_EXPIRED);
-    s->www_auth_content         = s->cache_hit_but_revalidate ? CACHE_AUTH_STALE : CACHE_AUTH_FRESH;
-    s->cache_hit_but_revalidate = true;
+    s->www_auth_content = send_revalidate ? CACHE_AUTH_STALE : CACHE_AUTH_FRESH;
+    send_revalidate     = true;
   }
 
   TxnDebug("http_trans", "CacheOpenRead --- needs_auth          = %d", needs_authenticate);
   TxnDebug("http_trans", "CacheOpenRead --- needs_revalidate    = %d", needs_revalidate);
   TxnDebug("http_trans", "CacheOpenRead --- response_returnable = %d", response_returnable);
   TxnDebug("http_trans", "CacheOpenRead --- needs_cache_auth    = %d", needs_cache_auth);
-  TxnDebug("http_trans", "CacheOpenRead --- send_revalidate     = %d", s->cache_hit_but_revalidate);
+  TxnDebug("http_trans", "CacheOpenRead --- send_revalidate     = %d", send_revalidate);
 
-  if (s->cache_hit_but_revalidate) {
+  if (send_revalidate) {
     TxnDebug("http_trans", "CacheOpenRead --- HIT-STALE");
 
     TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "
@@ -2997,8 +2996,7 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
   // realistically, if we can not make this claim, then there
   // is no reason to cache anything.
   //
-  ink_assert((s->cache_hit_but_revalidate == true && server_up == false) ||
-             (s->cache_hit_but_revalidate == false && server_up == true));
+  ink_assert((send_revalidate == true && server_up == false) || (send_revalidate == false && server_up == true));
 
   TxnDebug("http_trans", "CacheOpenRead --- HIT-FRESH");
   TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] "

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -700,13 +700,6 @@ public:
     ParentResult parent_result;
     CacheControlResult cache_control;
     CacheLookupResult_t cache_lookup_result = CACHE_LOOKUP_NONE;
-    /** There was a cache hit, but the cached resource cannot be used.
-     *
-     * This may happen because it is stale, it needs authentication, or the
-     * request method of the incoming request doesn't match that of the request
-     * corresponding to the cached resource.
-     */
-    bool cache_hit_but_revalidate = false;
 
     StateMachineAction_t next_action                      = SM_ACTION_UNDEFINED; // out
     StateMachineAction_t api_next_action                  = SM_ACTION_UNDEFINED; // out

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5429,7 +5429,7 @@ TSHttpTxnCacheLookupStatusGet(TSHttpTxn txnp, int *lookup_status)
     break;
   case HttpTransact::CACHE_LOOKUP_HIT_WARNING:
   case HttpTransact::CACHE_LOOKUP_HIT_FRESH:
-    if (sm->t_state.cache_hit_but_revalidate) {
+    if (HttpTransact::need_to_revalidate(&sm->t_state)) {
       *lookup_status = TS_CACHE_LOOKUP_MISS;
     } else {
       *lookup_status = TS_CACHE_LOOKUP_HIT_FRESH;


### PR DESCRIPTION
This reverts #8548 and instead directly calls
HttpTransact::need_to_revalidate in TSHttpTxnCacheLookupStatusGet to
ensure that an object which is a cache hit is indeed something ATS can
return to the client.

Fixes #8616

---

## For Review:

This fixes the cache-request-method.test.py AuTest which is currently failing CI for master. Most of this change simply reverts #8548. The only real change is calling need_to_revalidate in InkAPI.cc in TSHttpTxnCacheLookupStatusGet.