### PR TITLE
Remove leftovers from SSL wire tracing

### DIFF
--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -27,7 +27,6 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy \
 	-I$(abs_top_srcdir)/proxy/hdrs \
 	-I$(abs_top_srcdir)/proxy/shared \
-	-I$(abs_top_srcdir)/proxy/logging \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
 	-I$(abs_top_srcdir)/proxy/http \
@@ -63,7 +62,6 @@ test_UDPNet_CPPFLAGS = \
 	-I$(abs_top_srcdir)/proxy \
 	-I$(abs_top_srcdir)/proxy/hdrs \
 	-I$(abs_top_srcdir)/proxy/http \
-	-I$(abs_top_srcdir)/proxy/logging \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
 	@OPENSSL_INCLUDES@
@@ -97,7 +95,6 @@ test_libinknet_CPPFLAGS = \
 	-I$(abs_top_srcdir)/proxy \
 	-I$(abs_top_srcdir)/proxy/hdrs \
 	-I$(abs_top_srcdir)/proxy/http \
-	-I$(abs_top_srcdir)/proxy/logging \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
 	@OPENSSL_INCLUDES@

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -31,7 +31,6 @@
 #include "P_QUICPacketHandler.h"
 #include "P_Net.h"
 #include "InkAPIInternal.h" // Added to include the quic_hook definitions
-#include "Log.h"
 
 #include "P_SSLNextProtocolSet.h"
 #include "QUICMultiCertConfigLoader.h"

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -27,7 +27,6 @@
 #include "tscore/TSSystemState.h"
 
 #include "InkAPIInternal.h" // Added to include the ssl_hook definitions
-#include "Log.h"
 #include "HttpTunnel.h"
 #include "ProxyProtocol.h"
 #include "HttpConfig.h"

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -24,7 +24,6 @@
 #include "P_Net.h"
 #include "tscore/ink_platform.h"
 #include "tscore/InkErrno.h"
-#include "Log.h"
 
 #include <termios.h>
 

--- a/iocore/net/libinknet_stub.cc
+++ b/iocore/net/libinknet_stub.cc
@@ -71,19 +71,6 @@ ParentConfigParams::nextParent(HttpRequestData *, ParentResult *, unsigned int, 
   ink_assert(false);
 }
 
-#include "Log.h"
-void
-Log::trace_in(sockaddr const *, unsigned short, char const *, ...)
-{
-  ink_assert(false);
-}
-
-void
-Log::trace_out(sockaddr const *, unsigned short, char const *, ...)
-{
-  ink_assert(false);
-}
-
 #include "InkAPIInternal.h"
 int
 APIHook::invoke(int, void *) const

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -1240,50 +1240,6 @@ Log::va_error(const char *format, va_list ap)
 }
 
 /*-------------------------------------------------------------------------
-  Log::trace
-
-  These functions are used for wiretracing of incoming SSL connections.
-  They are an extension of the existing Log::error functionality but with
-  special formatting and handling of the non null terminated buffer.
-  -------------------------------------------------------------------------*/
-
-void
-Log::trace_in(const sockaddr *peer_addr, uint16_t peer_port, const char *format_string, ...)
-{
-  va_list ap;
-  va_start(ap, format_string);
-  trace_va(true, peer_addr, peer_port, format_string, ap);
-  va_end(ap);
-}
-
-void
-Log::trace_out(const sockaddr *peer_addr, uint16_t peer_port, const char *format_string, ...)
-{
-  va_list ap;
-  va_start(ap, format_string);
-  trace_va(false, peer_addr, peer_port, format_string, ap);
-  va_end(ap);
-}
-
-void
-Log::trace_va(bool in, const sockaddr *peer_addr, uint16_t peer_port, const char *format_string, va_list ap)
-{
-  if (!peer_addr || !format_string) {
-    return;
-  }
-
-  char ip[INET6_ADDRSTRLEN];
-  ats_ip_ntop(peer_addr, ip, sizeof(ip));
-
-  struct timeval tp = ink_gettimeofday();
-
-  Log::error("[%9d.%03d] Trace {0x%" PRIx64 "} %s %s:%d: ", static_cast<int>(tp.tv_sec), static_cast<int>(tp.tv_usec / 1000),
-             reinterpret_cast<uint64_t>(ink_thread_self()), in ? "RECV" : "SEND", ip, peer_port);
-  Log::va_error(format_string, ap);
-  Log::error("[End Trace]\n");
-}
-
-/*-------------------------------------------------------------------------
   Log::preproc_thread_main
 
   This function defines the functionality of the logging flush preprocess

--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -173,13 +173,6 @@ public:
   static int va_error(const char *format, va_list ap);
   static int error(const char *format, ...) TS_PRINTFLIKE(1, 2);
 
-  /////////////////////////////////////////////////////////////////////////
-  // 'Wire tracing' enabled by source ip or by percentage of connections //
-  /////////////////////////////////////////////////////////////////////////
-  static void trace_in(const sockaddr *peer_addr, uint16_t peer_port, const char *format_string, ...) TS_PRINTFLIKE(3, 4);
-  static void trace_out(const sockaddr *peer_addr, uint16_t peer_port, const char *format_string, ...) TS_PRINTFLIKE(3, 4);
-  static void trace_va(bool in, const sockaddr *peer_addr, uint16_t peer_port, const char *format_string, va_list ap);
-
   // public data members
   static LogObject *error_log;
   /** The latest fully initialized LogConfig.
@@ -240,15 +233,3 @@ LogRollingEnabledIsValid(int enabled)
 {
   return (enabled >= Log::NO_ROLLING || enabled < Log::INVALID_ROLLING_VALUE); // lgtm[cpp/constant-comparison]
 }
-
-#define TraceIn(flag, ...)        \
-  do {                            \
-    if (unlikely(flag))           \
-      Log::trace_in(__VA_ARGS__); \
-  } while (0)
-
-#define TraceOut(flag, ...)        \
-  do {                             \
-    if (unlikely(flag))            \
-      Log::trace_out(__VA_ARGS__); \
-  } while (0)

--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -172,19 +172,6 @@ ParentConfigParams::nextParent(HttpRequestData *, ParentResult *, unsigned int, 
   ink_assert(false);
 }
 
-#include "Log.h"
-void
-Log::trace_in(sockaddr const *, unsigned short, char const *, ...)
-{
-  ink_assert(false);
-}
-
-void
-Log::trace_out(sockaddr const *, unsigned short, char const *, ...)
-{
-  ink_assert(false);
-}
-
 #include "InkAPIInternal.h"
 
 APIHook *


### PR DESCRIPTION
Code for SSL wire tracing was partially removed by #4677 and #7368 but there are still some leftovers. This is an additional cleanup for #4652. 

