### PR TITLE
is_stale_cache_response_returnable: verify HTTP method

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6079,6 +6079,19 @@ HttpTransact::is_stale_cache_response_returnable(State *s)
     return false;
   }
 
+  // We may be caching responses to methods other than GET, such as POST. Make
+  // sure that our cached resource has a method that matches the incoming
+  // requests's method. If not, then we cannot reply with the cached resource.
+  // That is, we cannot reply to an incoming GET request with a response to a
+  // previous POST request.
+  int const client_request_method = s->hdr_info.client_request.method_get_wksidx();
+  int const cached_request_method = s->cache_info.object_read->request_get()->method_get_wksidx();
+  if (client_request_method != cached_request_method) {
+    TxnDebug("http_trans", "[is_stale_cache_response_returnable] "
+                           "mismatched method prevents serving stale");
+    return false;
+  }
+
   TxnDebug("http_trans", "[is_stale_cache_response_returnable] can serve stale");
   return true;
 }


### PR DESCRIPTION
This adds the method verification check currently in
is_cache_response_returnable to is_stale_cache_response_returnable. That
is, if an object is being requested by the client and the object is in
our cache, we can only reply with the cached object if the method of the
incoming request is the same as the method of the request for the cached
object.

---

This PR came out of a discussion with @serrislew about the check here:
https://github.com/apache/trafficserver/blob/master/proxy/http/HttpTransact.cc#L1958

We shouldn't build and reply with that response if the method of the incoming request doesn't match the method of the request that resulted in the cached response.