### PR TITLE
Propagate proxy.config.net.sock_option_flag_in to newly accepted connections

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4545,7 +4545,7 @@ Sockets
 
    Sets the receive buffer size for connections from the client to |TS|.
 
-.. ts:cv:: CONFIG proxy.config.net.sock_option_flag_in INT 0x5
+.. ts:cv:: CONFIG proxy.config.net.sock_option_flag_in INT 0x1
 
    Turns different options "on" for the socket handling client connections:::
 

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -338,6 +338,7 @@ NetAccept::do_blocking_accept(EThread *t)
     vc->action_     = *action_;
     vc->set_is_transparent(opt.f_inbound_transparent);
     vc->set_is_proxy_protocol(opt.f_proxy_protocol);
+    vc->options.sockopt_flags        = opt.sockopt_flags;
     vc->options.packet_mark          = opt.packet_mark;
     vc->options.packet_tos           = opt.packet_tos;
     vc->options.packet_notsent_lowat = opt.packet_notsent_lowat;
@@ -490,6 +491,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     vc->action_     = *action_;
     vc->set_is_transparent(opt.f_inbound_transparent);
     vc->set_is_proxy_protocol(opt.f_proxy_protocol);
+    vc->options.sockopt_flags        = opt.sockopt_flags;
     vc->options.packet_mark          = opt.packet_mark;
     vc->options.packet_tos           = opt.packet_tos;
     vc->options.packet_notsent_lowat = opt.packet_notsent_lowat;

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -760,7 +760,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.net.sock_send_buffer_size_in", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.net.sock_option_flag_in", RECD_INT, "0x5", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.sock_option_flag_in", RECD_INT, "0x1", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.net.sock_packet_mark_in", RECD_INT, "0x0", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,


### PR DESCRIPTION
* For client connections, disable setting SO_LINGER by default