### PR TITLE
Rate Limit Plugin: Re-enable VConnection when SNI is empty

### DIFF
--- a/plugins/experimental/rate_limit/sni_limiter.cc
+++ b/plugins/experimental/rate_limit/sni_limiter.cc
@@ -68,7 +68,10 @@ sni_limit_cont(TSCont contp, TSEvent event, void *edata)
         TSUserArgSet(vc, gVCIdx, reinterpret_cast<void *>(limiter));
         TSVConnReenable(vc);
       }
+    } else {
+      TSVConnReenable(vc);
     }
+
     break;
   }
 


### PR DESCRIPTION
When the rate limit plugin is used as a global plugin, the VConnection without SNI should be re-enabled immediately.