### PR TITLE
Fix 32bit build failure on Odroid Xu-4

### DIFF
--- a/proxy/logging/LogUtils.cc
+++ b/proxy/logging/LogUtils.cc
@@ -599,7 +599,7 @@ LogUtils::file_is_writeable(const char *full_filename, off_t *size_bytes, bool *
     if (e < 0) {
       ret_val = -1;
     } else {
-      if (limit_data.rlim_cur != static_cast<rlim_t> RLIM_INFINITY) {
+      if (limit_data.rlim_cur != static_cast<rlim_t>(RLIM_INFINITY)) {
         if (has_size_limit) {
           *has_size_limit = true;
         }


### PR DESCRIPTION
It's and oddball device but ATS now builds and runs well on it.
Also built and tested on OpenSuSE  Tumbleweed, Fedora-35 and Centos-8 aarch64 and x86_64 platforms.

Signed-off-by: Randy DuCharme <radio.ad5gb@gmail.com>