### PR TITLE
Trim white spaces before and after the equal sign

### DIFF
--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -176,39 +176,32 @@ canonicalEncode(const String &in, bool isObjectName)
  * @param inLen input character count
  * @return pointer to the trimmed string.
  */
-std::string
+String
 trimWhiteSpacesAndSqueezeInnerSpaces(const char *in, size_t inLen)
 {
   if (nullptr == in || inLen == 0) {
-    return std::string(in, inLen);
+    return "";
   }
 
-  const char *first = in;
-  while (size_t(first - in) < inLen && isspace(*first)) {
-    first++;
-  }
+  String in_str = trimWhiteSpaces(String(in, inLen));
+  String out_str;
+  out_str.reserve(in_str.size());
+  size_t n    = 0;
+  char prev_c = '\0';
 
-  const char *last = in + inLen - 1;
-  while (last > in && isspace(*last)) {
-    last--;
-  }
-
-  std::stringstream result;
-  int consecutiveSpaces = 0;
-  while (first <= last) {
-    if (*first == ' ') {
-      consecutiveSpaces++;
-    } else {
-      if (consecutiveSpaces > 0) {
-        result << ' ';
-      }
-      consecutiveSpaces = 0;
-      result << *first;
+  for (auto &c : in_str) {
+    if (!isspace(c)) {
+      out_str += c;
+      ++n;
+    } else if (isspace(c) && !isspace(prev_c)) {
+      out_str += ' ';
+      ++n;
     }
-    first++;
+    prev_c = c;
   }
+  out_str.resize(n);
 
-  return result.str();
+  return out_str;
 }
 
 /**

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -554,24 +554,29 @@ S3Config::parse_config(const std::string &config_fname)
       }
 
       // Identify the keys (and values if appropriate)
-      if (0 == strncasecmp(pos2, "secret_key=", 11)) {
-        set_secret(pos2 + 11);
-      } else if (0 == strncasecmp(pos2, "access_key=", 11)) {
-        set_keyid(pos2 + 11);
-      } else if (0 == strncasecmp(pos2, "session_token=", 14)) {
-        set_token(pos2 + 14);
-      } else if (0 == strncasecmp(pos2, "version=", 8)) {
-        set_version(pos2 + 8);
-      } else if (0 == strncasecmp(pos2, "virtual_host", 12)) {
+      std::string key_val(pos2, pos1 - pos2 + 1);
+      size_t eq_pos       = key_val.find_first_of("=");
+      std::string key_str = trimWhiteSpaces(key_val.substr(0, eq_pos == String::npos ? key_val.size() : eq_pos));
+      std::string val_str = eq_pos == String::npos ? "" : trimWhiteSpaces(key_val.substr(eq_pos + 1, key_val.size()));
+
+      if (key_str == "secret_key") {
+        set_secret(val_str.c_str());
+      } else if (key_str == "access_key") {
+        set_keyid(val_str.c_str());
+      } else if (key_str == "session_token") {
+        set_token(val_str.c_str());
+      } else if (key_str == "version") {
+        set_version(val_str.c_str());
+      } else if (key_str == "virtual_host") {
         set_virt_host();
-      } else if (0 == strncasecmp(pos2, "v4-include-headers=", 19)) {
-        set_include_headers(pos2 + 19);
-      } else if (0 == strncasecmp(pos2, "v4-exclude-headers=", 19)) {
-        set_exclude_headers(pos2 + 19);
-      } else if (0 == strncasecmp(pos2, "v4-region-map=", 14)) {
-        set_region_map(pos2 + 14);
-      } else if (0 == strncasecmp(pos2, "expiration=", 11)) {
-        set_expiration(pos2 + 11);
+      } else if (key_str == "v4-include-headers") {
+        set_include_headers(val_str.c_str());
+      } else if (key_str == "v4-exclude-headers") {
+        set_exclude_headers(val_str.c_str());
+      } else if (key_str == "v4-region-map") {
+        set_region_map(val_str.c_str());
+      } else if (key_str == "expiration") {
+        set_expiration(val_str.c_str());
       } else {
         // ToDo: warnings?
       }

--- a/plugins/s3_auth/unit_tests/test_aws_auth_v4.cc
+++ b/plugins/s3_auth/unit_tests/test_aws_auth_v4.cc
@@ -260,16 +260,15 @@ TEST_CASE("trimWhiteSpacesAndSqueezeInnerSpaces(): squeeze middle spaces multipl
   CHECK(inLen - 6 == trimmed.length());
 }
 
-TEST_CASE("trimWhiteSpacesAndSqueezeInnerSpaces(): does not squeeze middle whitespaces different from spaces, check string",
-          "[utility]")
+TEST_CASE("trimWhiteSpacesAndSqueezeInnerSpaces(): squeeze middle whitespaces, check string", "[utility]")
 {
-  const char in[] = "Very \t\tImportant \t\t\tMessage";
+  const char in[] = "Very \t\nImportant \v\f\rMessage";
   size_t inLen    = strlen(in);
 
   const std::string trimmed = trimWhiteSpacesAndSqueezeInnerSpaces(in, inLen);
 
-  CHECK_FALSE(trimmed.compare("Very \t\tImportant \t\t\tMessage"));
-  CHECK(inLen == trimmed.length());
+  CHECK_FALSE(trimmed.compare("Very Important Message"));
+  CHECK(inLen - 5 == trimmed.length());
 }
 
 TEST_CASE("trimWhiteSpaces(): trim both, check string", "[utility]")


### PR DESCRIPTION
This fixes #7888 

Also cleans up the code for trimming and squeezing spaces.