### PR TITLE
Adding clangd language server files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,15 @@ Makefile.in
 
 .dirstamp
 
+# IDE generated files.
 .project
 .cproject
 .idea
+
+# clangd language server files.
+/compile_commands.json
+/.cache
+*.plist
 
 .diags.log.meta
 


### PR DESCRIPTION
Adding some ignore entries for files generated by the clangd language
server for editors that use it.