### PR TITLE
Test: Make trafficserver ext test use runroot file by default.

### DIFF
--- a/doc/appendices/command-line/traffic_ctl_jsonrpc.en.rst
+++ b/doc/appendices/command-line/traffic_ctl_jsonrpc.en.rst
@@ -570,38 +570,9 @@ Configure Traffic Server to insert ``Via`` header in the response to the client
 Autest
 ======
 
-If you want to interact with |TS| under a unit test, then a few things need to be considered.
-
-- Runroot needs to be configured in order to  let `traffic_ctl` knows where to find the socket.
-
-   There are currently two ways to do this:
-
-   1. Using `run-root` param.
-
-      1. Let `Test.MakeATSProcess` to create the runroot file under the |TS| config directory. This can be done by passing `dump_runroot=True` to the above function:
-
-       .. code-block:: python
-
-         ts = Test.MakeATSProcess(..., dump_runroot=True)
-
-
-      `dump_runroot` will write out some of the keys inside the runroot file, in this case the `runtimedir`.
-
-      1. Then you should specify the :option:`traffic_ctl --run-root` when invoking the command:
-
-         .. code-block:: python
-
-            tr.Processes.Default.Command = f'traffic_ctl config reload --run-root {ts.Disk.runroot_yaml.Name}'
-
-   2. Setting up the `TS_RUNROOT` environment variable.
-      This is very similar to `1` but, instead of passing the `--run-root` param to `traffic_ctl`, you just need to specify the
-      `TS_RUNROOT` environment variable. To do that, just do as 1.1 shows and then:
-
-      .. code-block:: python
-
-         ts.SetRunRootEnv()
-
-      The above call will set the variable, please be aware that this variable will also be read by TS.
+Runroot needs to be configured in order to let `traffic_ctl` know where to find the socket. This is done by default
+and there is no change you have to do to interact with it, but make sure that you are not overriding the `dump_runroot=False`
+when creating the ATS Process, otherwise the `runroot.yaml` will not be set.
 
 See also
 ========

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -40,7 +40,7 @@ default_log_data = {
 
 def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
                    enable_tls=False, enable_cache=True, enable_quic=False,
-                   block_for_debug=False, log_data=default_log_data, dump_runroot=False):
+                   block_for_debug=False, log_data=default_log_data, dump_runroot=True):
     #####################################
     # common locations
 
@@ -307,14 +307,18 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     tmpname = os.path.join(config_dir, fname)
     p.Disk.File(tmpname, id=make_id(fname), typename="ats:config")
 
-    # Expect the instruction to set the variables inside the runroot. This is not mandatory
+    # Fill in the runroot file and set the config var, this will be used traffic_server
+    # and traffic_ctl
     if dump_runroot:
-        p.Disk.runroot_yaml.AddLine(f'runtimedir: {runtime_dir}')
-
-    def SetRunRootEnv(self):
-        self.Env['TS_RUNROOT'] = os.path.join(config_dir, "runroot.yaml")
-
-    AddMethodToInstance(p, SetRunRootEnv)
+        p.Disk.runroot_yaml.AddLines([f'runtimedir: {runtime_dir}',
+                                      f'cachedir: {cache_dir}',
+                                      f'localstatedir: {runtime_dir}',
+                                      f'bindir: {bin_dir}',
+                                      f'prefix: {ts_dir}',
+                                      f'logdir: {log_dir}',
+                                      f'sysconfdir: {config_dir}'])
+        # Add more if needed
+        p.Env['TS_RUNROOT'] = os.path.join(config_dir, "runroot.yaml")
 
     ##########################################################
     # set up default ports

--- a/tests/gold_tests/cache/cache-generation-clear.test.py
+++ b/tests/gold_tests/cache/cache-generation-clear.test.py
@@ -23,7 +23,7 @@ Test that incrementing the cache generation acts like a cache clear
 '''
 Test.ContinueOnFail = True
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
 
 # setup some config file for this server
 ts.Disk.records_config.update({
@@ -63,7 +63,7 @@ tr.Processes.Default.Streams.All = "gold/hit_default-1.gold"
 
 # Call traffic_ctrl to set new generation
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = f'traffic_ctl --debug config set proxy.config.http.cache.generation 77 --run-root {ts.Disk.runroot_yaml.Name}'
+tr.Processes.Default.Command = f'traffic_ctl --debug config set proxy.config.http.cache.generation 77'
 tr.Processes.Default.ForceUseShell = False
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Env = ts.Env  # set the environment for traffic_control to run in

--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -24,11 +24,8 @@ Test transactions and sessions for http1, making sure the two continuations catc
 
 Test.ContinueOnFail = True
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", select_ports=True, command="traffic_server", enable_cache=False, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", select_ports=True, command="traffic_server", enable_cache=False)
 server = Test.MakeOriginServer("server")
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
 
 Test.testName = ""
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: double_h2.test\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/continuations/double_h2.test.py
+++ b/tests/gold_tests/continuations/double_h2.test.py
@@ -26,13 +26,10 @@ Test.SkipUnless(
 )
 Test.ContinueOnFail = True
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, command="traffic_server", enable_cache=False, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, command="traffic_server", enable_cache=False)
 server = Test.MakeOriginServer("server")
 server2 = Test.MakeOriginServer("server2")
 
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
 
 Test.testName = ""
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: double_h2.test\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/continuations/openclose.test.py
+++ b/tests/gold_tests/continuations/openclose.test.py
@@ -23,7 +23,7 @@ Test transactions and sessions, making sure they open and close in the proper or
 '''
 
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
 
 server = Test.MakeOriginServer("server")
 server2 = Test.MakeOriginServer("server2")
@@ -72,8 +72,6 @@ server.StartAfter(*ps)
 tr.StillRunningAfter = ts
 
 
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
 # Signal that all the curl processes have completed
 tr = Test.AddTestRun("Curl Done")
 tr.DelayStart = 2  # Delaying a couple seconds to make sure the global continuation's lock contention resolves.

--- a/tests/gold_tests/continuations/openclose_h2.test.py
+++ b/tests/gold_tests/continuations/openclose_h2.test.py
@@ -27,7 +27,7 @@ Test.SkipUnless(
 )
 
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, command="traffic_server", enable_cache=False, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, command="traffic_server", enable_cache=False)
 
 
 server = Test.MakeOriginServer("server")
@@ -84,9 +84,6 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 ts.StartAfter(*ps)
 server.StartAfter(*ps)
 tr.StillRunningAfter = ts
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
 
 # Signal that all the curl processes have completed
 tr = Test.AddTestRun("Curl Done")

--- a/tests/gold_tests/headers/forwarded.test.py
+++ b/tests/gold_tests/headers/forwarded.test.py
@@ -192,7 +192,7 @@ TestHttp1_1('www.forwarded-connection-compact.com')
 TestHttp1_1('www.forwarded-connection-std.com')
 TestHttp1_1('www.forwarded-connection-full.com')
 
-ts2 = Test.MakeATSProcess("ts2", command="traffic_server", enable_tls=True, dump_runroot=True)
+ts2 = Test.MakeATSProcess("ts2", command="traffic_server", enable_tls=True)
 
 baselineTsSetup(ts2)
 
@@ -205,8 +205,6 @@ ts2.Disk.remap_config.AddLine(
     'map https://www.no-oride.com http://127.0.0.1:{0}'.format(server.Variables.Port)
 )
 
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts2.SetRunRootEnv()
 
 # Forwarded header with UUID of 2nd ATS.
 tr = Test.AddTestRun()

--- a/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
+++ b/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
@@ -94,9 +94,7 @@ def add_testrun_for_jsonrpc_request(
     return tr
 
 
-ts = Test.MakeATSProcess('ts', enable_cache=True, dump_runroot=True)
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
+ts = Test.MakeATSProcess('ts', enable_cache=True)
 
 Test.testName = 'Basic JSONRPC API test'
 

--- a/tests/gold_tests/logging/log_retention.test.py
+++ b/tests/gold_tests/logging/log_retention.test.py
@@ -110,7 +110,7 @@ class TestLogRetention:
         """
         ts_name = "ts{counter}".format(counter=TestLogRetention.__ts_counter)
         TestLogRetention.__ts_counter += 1
-        self.ts = Test.MakeATSProcess(ts_name, command=command, dump_runroot=True)
+        self.ts = Test.MakeATSProcess(ts_name, command=command)
 
         combined_records_config = TestLogRetention.__base_records_config.copy()
         combined_records_config.update(records_config)
@@ -525,9 +525,6 @@ test.tr.Processes.Default.Command = "touch " + test.ts.Disk.logging_yaml.AbsRunT
 test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-test.ts.SetRunRootEnv()
 
 tr = Test.AddTestRun("Perform a config reload")
 tr.Processes.Default.Command = "traffic_ctl config reload"

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -36,16 +36,13 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionlog.json", request_header, response_header)
 
 # Set up ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=1, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=1)
 
 # Set up ssl files
 ts.addSSLfile("ssl/server1.pem")
 ts.addSSLfile("ssl/server2.pem")
 ts.addSSLfile("ssl/client1.pem")
 ts.addSSLfile("ssl/client2.pem")
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
 
 # reserve port, attach it to 'ts' so it is released later
 ports.get_port(ts, 's_server_port')

--- a/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
+++ b/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
@@ -25,7 +25,7 @@ Test client_context_dump plugin
 Test.SkipUnless(Condition.PluginExists('client_context_dump.so'))
 
 # Set up ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, enable_tls=True, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, enable_tls=True)
 
 # Set up ssl files
 ts.addSSLfile("ssl/one.com.pem")
@@ -73,6 +73,6 @@ p.StartBefore(Test.Processes.ts)
 tr = Test.AddTestRun()
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = (
-    '{0}/traffic_ctl plugin msg client_context_dump.t 1 --run-root {1}'.format(ts.Variables.BINDIR, ts.Disk.runroot_yaml.Name)
+    '{0}/traffic_ctl plugin msg client_context_dump.t 1'.format(ts.Variables.BINDIR)
 )
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
@@ -30,8 +30,8 @@ server = Test.MakeOriginServer("server")
 
 # It is necessary to redirect stderr to a file so it will be available for examination by a test run.
 ts = Test.MakeATSProcess(
-    "ts", command="traffic_server 2> " + Test.RunDirectory + "/ts.stderr.txt", select_ports=True, dump_runroot=True
-)
+    "ts", command="traffic_server 2> " + Test.RunDirectory + "/ts.stderr.txt", select_ports=True)
+
 ts.ReturnCode = 0
 
 Test.testName = "Lua states and stats"
@@ -63,9 +63,6 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'ts_lua',
     'proxy.config.plugin.lua.max_states': 4,
 })
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
 
 curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} '.format(ts.Variables.port)
 

--- a/tests/gold_tests/pluginTest/regex_revalidate/metrics.sh
+++ b/tests/gold_tests/pluginTest/regex_revalidate/metrics.sh
@@ -18,7 +18,7 @@ N=60
 while (( N > 0 ))
 do
     rm -f metrics.out
-    traffic_ctl metric match regex_revalidate --run-root $1 > metrics.out
+    traffic_ctl metric match regex_revalidate > metrics.out
     sleep 1
     if diff metrics.out ${AUTEST_TEST_DIR}/gold/metrics.gold
     then

--- a/tests/gold_tests/pluginTest/regex_revalidate/metrics_miss.sh
+++ b/tests/gold_tests/pluginTest/regex_revalidate/metrics_miss.sh
@@ -18,7 +18,7 @@ N=60
 while (( N > 0 ))
 do
     rm -f metrics.out
-    traffic_ctl metric match regex_revalidate --run-root $1 > metrics.out
+    traffic_ctl metric match regex_revalidate > metrics.out
     sleep 1
     if diff metrics.out ${AUTEST_TEST_DIR}/gold/metrics_miss.gold
     then

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -44,7 +44,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
 
 Test.testName = "regex_revalidate"
 Test.Setup.Copy("metrics.sh")
@@ -279,7 +279,8 @@ tr.StillRunningAfter = ts
 # 12 Stats check
 tr = Test.AddTestRun("Check stats")
 tr.DelayStart = 5
-tr.Processes.Default.Command = f"bash -c './metrics.sh {ts.Disk.runroot_yaml.Name}'"
+# tr.Processes.Default.Command = f"bash -c './metrics.sh {ts.Disk.runroot_yaml.Name}'"
+tr.Processes.Default.Command = f"bash -c './metrics.sh'"
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
@@ -38,7 +38,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server", dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server")
 
 Test.testName = "regex_revalidate_miss"
 Test.Setup.Copy("metrics_miss.sh")
@@ -149,7 +149,7 @@ tr.TimeOut = 5
 # 3 Test - Revalidate path1
 tr = Test.AddTestRun("Revalidate MISS path1")
 ps = tr.Processes.Default
-tr.DelayStart = 5
+tr.DelayStart = 7
 ps.Command = curl_and_args + ' http://ats/path1'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss response")
@@ -178,7 +178,7 @@ tr.TimeOut = 5
 # 6 Test - Cache stale
 tr = Test.AddTestRun("Cache stale path1")
 ps = tr.Processes.Default
-tr.DelayStart = 5
+tr.DelayStart = 7
 ps.Command = curl_and_args + ' http://ats/path1'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-stale", "expected cache hit stale response")
@@ -199,7 +199,7 @@ tr.TimeOut = 5
 # 8 Test - Cache stale
 tr = Test.AddTestRun("Cache stale path1")
 ps = tr.Processes.Default
-tr.DelayStart = 5
+tr.DelayStart = 7
 ps.Command = curl_and_args + ' http://ats/path1'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss response")
@@ -220,7 +220,7 @@ tr.TimeOut = 5
 # 10 Test - Cache stale
 tr = Test.AddTestRun("Cache stale path1")
 ps = tr.Processes.Default
-tr.DelayStart = 5
+tr.DelayStart = 7
 ps.Command = curl_and_args + ' http://ats/path1'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit response")
@@ -229,7 +229,7 @@ tr.StillRunningAfter = ts
 # 11 Stats check
 tr = Test.AddTestRun("Check stats")
 tr.DelayStart = 5
-tr.Processes.Default.Command = f"bash -c './metrics_miss.sh {ts.Disk.runroot_yaml.Name}'"
+tr.Processes.Default.Command = f"bash -c ./metrics_miss.sh"
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
@@ -29,7 +29,7 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
                    "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
 
 ts.Disk.plugin_config.AddLine('remap_stats.so')
 

--- a/tests/gold_tests/remap/conf_remap_float.py
+++ b/tests/gold_tests/remap/conf_remap_float.py
@@ -24,10 +24,7 @@ Test command: traffic_ctl config describe proxy.config.http.background_fill_comp
 '''
 Test.testName = 'Float in conf_remap Config Test'
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, dump_runroot=True)
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
 
 # Add dummy remap rule
 ts.Disk.remap_config.AddLine(
@@ -50,6 +47,6 @@ tr.TimeOut = 5
 tr.StillRunningAfter = ts
 
 p = tr.Processes.Default
-p.Command = f"traffic_ctl config describe proxy.config.http.background_fill_completed_threshold --run-root {ts.Disk.runroot_yaml.Name}"
+p.Command = f"traffic_ctl config describe proxy.config.http.background_fill_completed_threshold"
 p.ReturnCode = 0
 p.StartBefore(Test.Processes.ts, ready=When.FileExists(os.path.join(tr.RunDirectory, 'ts/log/diags.log')))

--- a/tests/gold_tests/runroot/runroot_manager.test.py
+++ b/tests/gold_tests/runroot/runroot_manager.test.py
@@ -48,7 +48,7 @@ trafficserver_dir = os.path.join(runroot_path, 'var', 'trafficserver')
 tr.ChownForATSProcess(trafficserver_dir)
 
 p = tr.Processes.Default
-p.Command = "$ATS_BIN/traffic_manager --run-root=" + rr_file
+p.Command = "$ATS_BIN/traffic_server --run-root=" + rr_file
 p.RunningEvent.Connect(Testers.Lambda(lambda ev: StopProcess(ev, 10)))
 p.Streams.All = Testers.ContainsExpression("traffic_server: using root directory '" +
                                            runroot_path + "'", "check if the right runroot is passed down")

--- a/tests/gold_tests/tls/tls_check_cert_select_plugin.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_select_plugin.test.py
@@ -23,8 +23,7 @@ Test ATS offering different certificates based on SNI. Load via plugin
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, enable_tls=True, dump_runroot=True)
-ts.SetRunRootEnv()
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server", ssl=True)
 dns = Test.MakeDNServer("dns")
 

--- a/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
@@ -21,8 +21,7 @@ Test ATS offering different certificates based on SNI
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True, dump_runroot=True)
-ts.SetRunRootEnv()
+ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
 server = Test.MakeOriginServer("server", ssl=True)
 server3 = Test.MakeOriginServer("server3", ssl=True)
 

--- a/tests/gold_tests/tls/tls_client_cert.test.py
+++ b/tests/gold_tests/tls/tls_client_cert.test.py
@@ -21,7 +21,7 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 # --clientverify: "" empty string because microserver does store_true for argparse, but options is a dictionary
@@ -189,9 +189,6 @@ tr2.Processes.Default.Command = 'echo Updated configs'
 # Need to copy over the environment so traffic_ctl knows where to find the unix domain socket
 tr2.Processes.Default.Env = ts.Env
 tr2.Processes.Default.ReturnCode = 0
-
-# Set TS_RUNROOT, traffic_ctl needs it to find the socket.
-ts.SetRunRootEnv()
 
 tr2reload = Test.AddTestRun("Reload config")
 tr2reload.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_client_cert_override_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_override_plugin.test.py
@@ -21,8 +21,8 @@ Test conf_remp to specify different client certificates to offer to the origin. 
 '''
 
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, dump_runroot=True)
-ts.SetRunRootEnv()
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
+
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 server = Test.MakeOriginServer("server",

--- a/tests/gold_tests/tls/tls_client_cert_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_plugin.test.py
@@ -24,8 +24,7 @@ Test.Summary = '''
 Test offering client cert to origin, but using plugin for cert loading
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, dump_runroot=True)
-ts.SetRunRootEnv()
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 # --clientverify: "" empty string because microserver does store_true for argparse, but options is a dictionary

--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -21,7 +21,7 @@ Test tunneling based on SNI
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, enable_tls=True, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True, enable_tls=True)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True)
 server_bar = Test.MakeOriginServer("server_bar", ssl=True)
 server2 = Test.MakeOriginServer("server2")
@@ -184,7 +184,7 @@ trreload = Test.AddTestRun("Reload config")
 trreload.StillRunningAfter = ts
 trreload.StillRunningAfter = server_foo
 trreload.StillRunningAfter = server_bar
-trreload.Processes.Default.Command = 'traffic_ctl config reload --run-root {}'.format(ts.Disk.runroot_yaml.Name)
+trreload.Processes.Default.Command = 'traffic_ctl config reload'
 # Need to copy over the environment so traffic_ctl knows where to find the unix domain socket
 trreload.Processes.Default.Env = ts.Env
 trreload.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
+++ b/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
@@ -24,7 +24,7 @@ Test.ContinueOnFail = False
 Test.Setup.Copy("wait_reload.sh")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False, dump_runroot=True)
+ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
 
 ts.Disk.File(ts.Variables.CONFIGDIR + "/test.inc", id="test_cfg", typename="ats:config")
 ts.Disk.test_cfg.AddLine(
@@ -60,7 +60,7 @@ tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Reload config")
 tr.StillRunningAfter = ts
-tr.Processes.Default.Command = f'traffic_ctl config reload --run-root {ts.Disk.runroot_yaml.Name}'
+tr.Processes.Default.Command = f'traffic_ctl config reload'
 # Need to copy over the environment so traffic_ctl knows where to find the unix domain socket
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
The idea of this change is to let  `traffic_server` and `traffic_ctl` use  the `runroot` file by defaut in the tests, this can be disable when calling `MakeATSProcess` with `dump_runroot=False`.
This change also:
- Removes the previous and ambiguos way to set up the runroot, which it was introduced in 10-Dev only.
- Updates docs.

Note:
I am expecting the regex_revalidate_miss test to fail, it seems to be a transient error when updating the  config file which is not picked up properly by the config reloader as the two versions shows the same timestamp. There is another [PR](https://github.com/apache/trafficserver/pull/8644) to fix this.