### PR TITLE
Add parent_select plugin strategy caching

### DIFF
--- a/plugins/experimental/parent_select/consistenthash_config.h
+++ b/plugins/experimental/parent_select/consistenthash_config.h
@@ -24,7 +24,8 @@
 
 class TSNextHopSelectionStrategy;
 
-typedef std::map<std::string, std::unique_ptr<TSNextHopSelectionStrategy>, std::less<>> strategies_map;
+typedef std::map<std::string, std::shared_ptr<TSNextHopSelectionStrategy>, std::less<>> strategies_map;
 
+void clearStrategiesCache(void);
 strategies_map createStrategiesFromFile(const char *file);
 TSNextHopSelectionStrategy *createStrategy(const std::string &name, const YAML::Node &node);

--- a/plugins/experimental/parent_select/parent_select.cc
+++ b/plugins/experimental/parent_select/parent_select.cc
@@ -376,18 +376,8 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuff, int errbuff
   TSDebug(PLUGIN_NAME, "'%s' '%s' successfully created strategies in file %s num %d", remap_from, remap_to, config_file_path,
           int(file_strategies.size()));
 
-  std::unique_ptr<TSNextHopSelectionStrategy> new_strategy;
-
-  for (auto &[name, strategy] : file_strategies) {
-    TSDebug(PLUGIN_NAME, "'%s' '%s' TSRemapNewInstance strategy file had strategy named '%s'", remap_from, remap_to, name.c_str());
-    if (strncmp(strategy_name, name.c_str(), strlen(strategy_name)) != 0) {
-      continue;
-    }
-    TSDebug(PLUGIN_NAME, "'%s' '%s' TSRemapNewInstance using '%s'", remap_from, remap_to, name.c_str());
-    new_strategy = std::move(strategy);
-  }
-
-  if (new_strategy.get() == nullptr) {
+  auto new_strategy = file_strategies.find(strategy_name);
+  if (new_strategy == file_strategies.end()) {
     TSDebug(PLUGIN_NAME, "'%s' '%s' TSRemapNewInstance strategy '%s' not found in file '%s'", remap_from, remap_to, strategy_name,
             config_file_path);
     return TS_ERROR;
@@ -395,7 +385,12 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuff, int errbuff
 
   TSDebug(PLUGIN_NAME, "'%s' '%s' TSRemapNewInstance successfully loaded strategy '%s' from '%s'.", remap_from, remap_to,
           strategy_name, config_file_path);
-  *ih = static_cast<void *>(new_strategy.release());
+
+  // created a raw pointer _to_ a shared_ptr, because ih needs a raw pointer.
+  // The raw pointer in ih will be deleted in TSRemapDeleteInstance,
+  // which will destruct the shared_ptr,
+  // destroying the strategy if this is the last remap rule using it.
+  *ih = static_cast<void *>(new std::shared_ptr<TSNextHopSelectionStrategy>(new_strategy->second));
 
   // Associate our config file with remap.config to be able to initiate reloads
   TSMgmtString result;
@@ -411,7 +406,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 {
   TSDebug(PLUGIN_NAME, "TSRemapDoRemap calling");
 
-  auto strategy = static_cast<TSNextHopSelectionStrategy *>(ih);
+  auto strategy_ptr = static_cast<std::shared_ptr<TSNextHopSelectionStrategy> *>(ih);
+  auto strategy     = strategy_ptr->get();
 
   TSDebug(PLUGIN_NAME, "TSRemapDoRemap got strategy '%s'", strategy->name());
 
@@ -468,6 +464,14 @@ extern "C" tsapi void
 TSRemapDeleteInstance(void *ih)
 {
   TSDebug(PLUGIN_NAME, "TSRemapDeleteInstance calling");
-  auto strategy = static_cast<TSNextHopSelectionStrategy *>(ih);
-  delete strategy;
+  auto strategy_ptr = static_cast<std::shared_ptr<TSNextHopSelectionStrategy> *>(ih);
+  delete strategy_ptr;
+  TSDebug(PLUGIN_NAME, "TSRemapDeleteInstance deleted strategy pointer");
+}
+
+void
+TSRemapPreConfigReload(void)
+{
+  TSDebug(PLUGIN_NAME, "TSRemapPreConfigReload clearing strategies cache");
+  clearStrategiesCache();
 }


### PR DESCRIPTION
Without this, large production strategies.yaml files with thousands
of remaps take hours to load, because each remap independently
loads and parses the strategies.yaml file.

This makes the plugin reuse the parsed object if multiple remaps
use the same file. On reload, files are loaded again.