### PR TITLE
Adding clangd language server files to .gitignore (#8640)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,14 @@ Makefile.in
 
 .dirstamp
 
+# IDE generated files.
 .project
 .cproject
+
+# clangd language server files.
+/compile_commands.json
+/.cache
+*.plist
 
 .diags.log.meta
 


### PR DESCRIPTION
Adding some ignore entries for files generated by the clangd language
server for editors that use it.

(cherry picked from commit 178f57fdc2d4cfd98bd166f5cde8ebcbcd018876)