### PR TITLE
Clear random header value by AIO read error (#8559)

### DIFF
--- a/iocore/cache/CacheDisk.cc
+++ b/iocore/cache/CacheDisk.cc
@@ -98,7 +98,7 @@ CacheDisk::open(char *s, off_t blocks, off_t askip, int ahw_sector_size, int fil
     }
   }
 
-  //
+  // read disk header
   SET_HANDLER(&CacheDisk::openStart);
   io.aiocb.aio_offset = skip;
   io.aiocb.aio_buf    = (char *)header;
@@ -166,6 +166,10 @@ CacheDisk::openStart(int event, void * /* data ATS_UNUSED */)
 
   if ((size_t)io.aiocb.aio_nbytes != (size_t)io.aio_result) {
     Warning("could not read disk header for disk %s: declaring disk bad", path);
+
+    // the header could have random values by the AIO read error
+    memset(header, 0, header_len);
+
     incrErrors(&io);
     SET_DISK_BAD(this);
     SET_HANDLER(&CacheDisk::openDone);


### PR DESCRIPTION
(cherry picked from commit 61c0fcc7e949d64d3ad5070b1e8e947d1f75f69a)

Backport #8559 to the 8.1.x branch.