### PR TITLE
Revert "body factory does not respect runroot"

### DIFF
--- a/lib/records/RecConfigParse.cc
+++ b/lib/records/RecConfigParse.cc
@@ -89,7 +89,7 @@ RecConfigOverrideFromRunroot(const char *name)
   if (!get_runroot().empty()) {
     if (!strcmp(name, "proxy.config.bin_path") || !strcmp(name, "proxy.config.local_state_dir") ||
         !strcmp(name, "proxy.config.log.logfile_dir") || !strcmp(name, "proxy.config.plugin.plugin_dir") ||
-        !strcmp(name, "proxy.config.hostdb.storage_path") || !strcmp(name, "proxy.config.body_factory.template_sets_dir")) {
+        !strcmp(name, "proxy.config.hostdb.storage_path")) {
       return true;
     }
   }

--- a/proxy/http/HttpBodyFactory.cc
+++ b/proxy/http/HttpBodyFactory.cc
@@ -277,13 +277,7 @@ HttpBodyFactory::reconfigure()
   rec_err   = RecGetRecordString_Xmalloc("proxy.config.body_factory.template_sets_dir", &s);
   all_found = all_found && (rec_err == REC_ERR_OKAY);
   if (rec_err == REC_ERR_OKAY) {
-    // check if we should tweak with run_root value
-    if (s && strlen(s) > 0) {
-      // the value is set via config file or ENV var
-      directory_of_template_sets = Layout::get()->relative(s);
-    } else {
-      directory_of_template_sets = Layout::relative_to(RecConfigReadConfigDir(), "body_factory");
-    }
+    directory_of_template_sets = Layout::get()->relative(s);
     if (access(directory_of_template_sets, R_OK) < 0) {
       Warning("Unable to access() directory '%s': %d, %s", (const char *)directory_of_template_sets, errno, strerror(errno));
       if (TSSystemState::is_initializing()) {


### PR DESCRIPTION
Reverts apache/trafficserver#8388

---

I'm reverting this because we've noticed internally that this breaks the use of `proxy.config.body_factory.template_sets_dir` to override the TS_RUNROOT configuration.