### PR TITLE
Remove the unnecessary runroot flag from traffic_ctl cmd in a unit test.

### DIFF
--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
@@ -64,7 +64,7 @@ tr.StillRunningAfter = server
 
 # 2 Test - Gather output
 tr = Test.AddTestRun("analyze stats")
-tr.Processes.Default.Command = r'traffic_ctl metric match \.\*remap_stats\* {0}'.format(ts.Disk.runroot_yaml.Name)
+tr.Processes.Default.Command = r'traffic_ctl metric match \.\*remap_stats\*'
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.TimeOut = 5


### PR DESCRIPTION
During my last change around the removal of the explicit and unnecessary use of the runroot flag when calling  `traffic_ctl` inside a unit test I missed this one file. 
