### PR TITLE
Fixed issues when compiling with -Og

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -1434,7 +1434,7 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
 {
   uint32_t got_len         = 0;
   uint32_t max_sync_serial = header->sync_serial;
-  char *s, *e;
+  char *s, *e = nullptr;
   if (event == EVENT_IMMEDIATE) {
     if (header->sync_serial == 0) {
       io.aiocb.aio_buf = nullptr;

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -606,7 +606,7 @@ http2_convert_header_from_1_1_to_2(HTTPHdr *headers)
 
     // :path
     if (MIMEField *field = headers->field_find(HTTP2_VALUE_PATH, HTTP2_LEN_PATH); field != nullptr) {
-      int value_len;
+      int value_len     = 0;
       const char *value = headers->path_get(&value_len);
 
       ts::LocalBuffer<char> buf(value_len + 1);

--- a/tests/gold_tests/chunked_encoding/smuggle-client.c
+++ b/tests/gold_tests/chunked_encoding/smuggle-client.c
@@ -48,7 +48,7 @@ main(int argc, char *argv[])
 {
   struct addrinfo hints;
   struct addrinfo *result, *rp;
-  int sfd, s;
+  int sfd = -1, s;
 
   if (argc < 3) {
     fprintf(stderr, "Usage: %s <target addr> <target_port>\n", argv[0]);

--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -222,7 +222,7 @@ main(int argc, char *argv[])
 {
   struct addrinfo hints;
   struct addrinfo *result, *rp;
-  int sfd, s;
+  int sfd = -1, s;
 
   if (argc < 4) {
     fprintf(stderr, "Usage: %s host thread-count header-count [port]\n", argv[0]);


### PR DESCRIPTION
abi-dumper likes to have binaries compiled with -Og for better testing of binary compatibility.

https://github.com/lvc/abi-dumper