### PR TITLE
slice and cache_range_requests: allow header override

### DIFF
--- a/doc/admin-guide/plugins/cache_range_requests.en.rst
+++ b/doc/admin-guide/plugins/cache_range_requests.en.rst
@@ -118,6 +118,8 @@ X-Crr-Ims header support
 
 .. option:: --consider-ims
 .. option:: -c
+.. option:: --ims-header=[header name] (default: X-Crr-Ims)
+.. option:: -i
 
 To support slice plugin self healing an option to force revalidation
 after cache lookup complete was added.  This option is triggered by a
@@ -136,6 +138,11 @@ request along with this X-Crr-Ims header is passed up to the parent.
 In order for this to properly work in a CDN each cache in the
 chain *SHOULD* also contain a remap rule with the
 :program:`cache_range_requests` plugin with this option set.
+
+When used with the :program:`slice` plugin its `--crr-ims-header`
+option must have the same value (or not be defined) in order to work.
+
+Presence of the `--ims-header` automatically sets the `--consider-ims` option.
 
 Don't modify the Cache Key
 --------------------------

--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -113,6 +113,19 @@ The slice plugin supports the following options::
         Requires setting up an intermediate loopback remap rule.
         -r for short
 
+    --skip-header=<header name> (default: X-Slicer-Info)
+        Header name used by the slice plugin after the loopback
+        to indicate that the slice plugin should be skipped.
+        -s for short
+
+    --crr-ims-header=<header name> (default: X-Crr-Ims)
+        Header name used by the slice plugin to tell the
+        `cache_range_requests` plugin that a request should
+        be marked as STALE.  Used for self healing.
+        This must match the `--ims-header` option used by the
+        `cache_range_requests` plugin.
+        -i for short
+
 Examples::
 
     @plugin=slice.so @pparam=--blockbytes=1000000 @plugin=cache_range_requests.so

--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -45,6 +45,9 @@ struct Config {
   enum RefType { First, Relative };
   RefType m_reftype{First}; // reference slice is relative to request
 
+  std::string m_skip_header;
+  std::string m_crr_ims_header;
+
   // Convert optarg to bytes
   static int64_t bytesFrom(char const *const valstr);
 

--- a/plugins/experimental/slice/HttpHeader.h
+++ b/plugins/experimental/slice/HttpHeader.h
@@ -36,8 +36,6 @@
 
 #include <string>
 
-static char const *const SLICER_MIME_FIELD_INFO = "X-Slicer-Info";
-
 /**
   Designed to be a cheap throwaway struct which allows a
   consumer to make various calls to manipulate headers.

--- a/plugins/experimental/slice/server.cc
+++ b/plugins/experimental/slice/server.cc
@@ -223,9 +223,9 @@ handleFirstServerHeader(Data *const data, TSCont const contp)
 void
 logSliceError(char const *const message, Data const *const data, HttpHeader const &header_resp)
 {
-  Config *const config = data->m_config;
+  Config *const conf = data->m_config;
 
-  bool const logToError = config->canLogError();
+  bool const logToError = conf->canLogError();
 
   // always write block stitch errors while in debug mode
   if (!logToError && !TSIsDebugTagSet(PLUGIN_NAME)) {
@@ -259,7 +259,7 @@ logSliceError(char const *const message, Data const *const data, HttpHeader cons
   // raw range request
   char rangestr[1024];
   int rangelen = sizeof(rangestr);
-  header_req.valueForKey(SLICER_MIME_FIELD_INFO, strlen(SLICER_MIME_FIELD_INFO), rangestr, &rangelen);
+  header_req.valueForKey(conf->m_skip_header.data(), conf->m_skip_header.size(), rangestr, &rangelen);
 
   // Normalized range request
   ContentRange const crange(data->m_req_range.m_beg, data->m_req_range.m_end, data->m_contentlen);
@@ -268,8 +268,8 @@ logSliceError(char const *const message, Data const *const data, HttpHeader cons
   crange.toStringClosed(normstr, &normlen);
 
   // block range request
-  int64_t const blockbeg = data->m_blocknum * data->m_config->m_blockbytes;
-  int64_t const blockend = std::min(blockbeg + data->m_config->m_blockbytes, data->m_contentlen);
+  int64_t const blockbeg = data->m_blocknum * conf->m_blockbytes;
+  int64_t const blockend = std::min(blockbeg + conf->m_blockbytes, data->m_contentlen);
 
   // Block response data
   TSHttpStatus const statusgot = header_resp.status();
@@ -416,8 +416,9 @@ handleNextServerHeader(Data *const data, TSCont const contp)
 
       // add special CRR IMS header to the request
       HttpHeader headerreq(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);
-      if (!headerreq.setKeyTime(X_CRR_IMS_HEADER.data(), X_CRR_IMS_HEADER.size(), dateims)) {
-        ERROR_LOG("Failed setting '%.*s'", (int)X_CRR_IMS_HEADER.size(), X_CRR_IMS_HEADER.data());
+      Config const *const conf = data->m_config;
+      if (!headerreq.setKeyTime(conf->m_crr_ims_header.data(), conf->m_crr_ims_header.size(), dateims)) {
+        ERROR_LOG("Failed setting '%s'", conf->m_crr_ims_header.c_str());
         return false;
       }
 
@@ -438,8 +439,9 @@ handleNextServerHeader(Data *const data, TSCont const contp)
 
       // add special CRR IMS header to the request
       HttpHeader headerreq(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);
-      if (!headerreq.setKeyTime(X_CRR_IMS_HEADER.data(), X_CRR_IMS_HEADER.size(), dateims)) {
-        ERROR_LOG("Failed setting '%.*s'", (int)X_CRR_IMS_HEADER.size(), X_CRR_IMS_HEADER.data());
+      Config const *const conf = data->m_config;
+      if (!headerreq.setKeyTime(conf->m_crr_ims_header.data(), conf->m_crr_ims_header.size(), dateims)) {
+        ERROR_LOG("Failed setting '%s'", conf->m_crr_ims_header.c_str());
         return false;
       }
 

--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -42,8 +42,7 @@ read_request(TSHttpTxn txnp, Config *const config)
   HttpHeader const header(hdrmgr.m_buffer, hdrmgr.m_lochdr);
 
   if (TS_HTTP_METHOD_GET == header.method()) {
-    static int const SLICER_MIME_LEN_INFO = strlen(SLICER_MIME_FIELD_INFO);
-    if (!header.hasKey(SLICER_MIME_FIELD_INFO, SLICER_MIME_LEN_INFO)) {
+    if (!header.hasKey(config->m_skip_header.data(), config->m_skip_header.size())) {
       // check if any previous plugin has monkeyed with the transaction status
       TSHttpStatus const txnstat = TSHttpTxnStatusGet(txnp);
       if (TS_HTTP_STATUS_NONE != txnstat) {
@@ -233,9 +232,7 @@ TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf */, int /* errbuf_size */)
 {
   Config *const config = new Config;
-  if (2 < argc) {
-    config->fromArgs(argc - 2, argv + 2);
-  }
+  config->fromArgs(argc - 2, argv + 2);
   *ih = static_cast<void *>(config);
   return TS_SUCCESS;
 }
@@ -274,9 +271,7 @@ TSPluginInit(int argc, char const *argv[])
     return;
   }
 
-  if (1 < argc) {
-    globalConfig.fromArgs(argc - 1, argv + 1);
-  }
+  globalConfig.fromArgs(argc - 1, argv + 1);
 
   TSCont const contp(TSContCreate(global_read_request_hook, nullptr));
 

--- a/plugins/experimental/slice/slice.h
+++ b/plugins/experimental/slice/slice.h
@@ -32,8 +32,6 @@
 #define PLUGIN_NAME "slice"
 #endif
 
-constexpr std::string_view X_CRR_IMS_HEADER = {"X-Crr-Ims"};
-
 #if !defined(UNITTEST)
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)

--- a/plugins/experimental/slice/util.cc
+++ b/plugins/experimental/slice/util.cc
@@ -125,14 +125,16 @@ request_block(TSCont contp, Data *const data)
   case BlockState::Pending:
     data->m_blockstate = BlockState::Active;
     break;
-  case BlockState::PendingInt:
-    data->m_blockstate = BlockState::ActiveInt;
-    header.removeKey(X_CRR_IMS_HEADER.data(), X_CRR_IMS_HEADER.size());
-    break;
-  case BlockState::PendingRef:
-    data->m_blockstate = BlockState::ActiveRef;
-    header.removeKey(X_CRR_IMS_HEADER.data(), X_CRR_IMS_HEADER.size());
-    break;
+  case BlockState::PendingInt: {
+    data->m_blockstate       = BlockState::ActiveInt;
+    Config const *const conf = data->m_config;
+    header.removeKey(conf->m_crr_ims_header.c_str(), conf->m_crr_ims_header.size());
+  } break;
+  case BlockState::PendingRef: {
+    data->m_blockstate       = BlockState::ActiveRef;
+    Config const *const conf = data->m_config;
+    header.removeKey(conf->m_crr_ims_header.c_str(), conf->m_crr_ims_header.size());
+  } break;
   default:
     ERROR_LOG("Invalid blockstate");
     return false;

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
@@ -88,10 +88,13 @@ res_full = {"headers":
 server.addResponse("sessionlog.json", req_full, res_full)
 
 # cache range requests plugin remap
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{}'.format(server.Variables.Port) +
+ts.Disk.remap_config.AddLines([
+    f'map http://ims http://127.0.0.1:{server.Variables.Port}' +
     ' @plugin=cache_range_requests.so @pparam=--consider-ims',
-)
+    f'map http://imsheader http://127.0.0.1:{server.Variables.Port}' +
+    ' @plugin=cache_range_requests.so @pparam=--consider-ims' +
+    ' @pparam=--ims-header=CrrIms',
+])
 
 # cache debug
 ts.Disk.plugin_config.AddLine('xdebug.so')
@@ -109,29 +112,40 @@ tr = Test.AddTestRun("0- range cache load")
 ps = tr.Processes.Default
 ps.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 ps.StartBefore(Test.Processes.ts)
-ps.Command = curl_and_args + ' http://www.example.com/path -r 0-'
+ps.Command = curl_and_args + ' http://ims/path -r 0-'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss for load")
 tr.StillRunningAfter = ts
 
 
-# set up the IMS date field (go in the future) RFC 2616
-futuretime = time.time() + 100  # seconds
-futurestr = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(futuretime))
-
 # test inner range
 # 1 Test - Fetch range into cache
 tr = Test.AddTestRun("0- cache hit check")
 ps = tr.Processes.Default
-ps.Command = curl_and_args + ' http://www.example.com/path -r 0-'.format(futurestr)
+ps.Command = curl_and_args + ' http://ims/path -r 0-'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
 tr.StillRunningAfter = ts
 
+# set up the IMS date field (go in the future) RFC 2616
+futuretime = time.time() + 100  # seconds
+futurestr = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(futuretime))
+
 # 2 Test - Ensure X-CRR-IMS header results in hit-stale
 tr = Test.AddTestRun("0- range X-CRR-IMS check")
 ps = tr.Processes.Default
-ps.Command = curl_and_args + ' http://www.example.com/path -r 0- -H "X-CRR-IMS: {}"'.format(futurestr)
+ps.Command = curl_and_args + ' http://ims/path -r 0- -H "X-CRR-IMS: {}"'.format(futurestr)
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-stale", "expected cache hit-stale")
+tr.StillRunningAfter = ts
+
+futuretime += 10  # seconds
+futurestr = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(futuretime))
+
+# 3 Test - Ensure CrrIms header results in hit-stale
+tr = Test.AddTestRun("0- range CrrIms check, override header")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://imsheader/path -r 0- -H "CrrIms: {}"'.format(futurestr)
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-stale", "expected cache hit-stale")
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -82,9 +82,13 @@ curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x http://127.0.0.1:{}'.f
 
 # set up whole asset fetch into cache
 ts.Disk.remap_config.AddLines([
-    'map http://preload/ http://127.0.0.1:{}'.format(server.Variables.Port),
-    'map http://slice/ http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=--blockbytes-test={}'.format(block_bytes)
+    f'map http://preload/ http://127.0.0.1:{server.Variables.Port}',
+    f'map http://slice_only/ http://127.0.0.1:{server.Variables.Port}',
+    f'map http://slice/ http://127.0.0.1:{server.Variables.Port}' +
+    f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}',
+    f'map http://slicehdr/ http://127.0.0.1:{server.Variables.Port}' +
+    f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}' +
+    ' @pparam=--skip-header=SkipSlice',
 ])
 
 ts.Disk.records_config.update({
@@ -179,4 +183,15 @@ end = beg + block_bytes
 ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://slice/path' + ' -r {}-{}'.format(beg, end)
 ps.Streams.stdout.Content = Testers.ContainsExpression("416 Requested Range Not Satisfiable", "expected 416 response")
+tr.StillRunningAfter = ts
+
+# 9 Test - First complete slice using override header
+# if this fails it will infinite loop
+tr = Test.AddTestRun("Fetch first slice range")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slicehdr/path' + ' -r 0-6'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/slice_first.stderr.gold"
+ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 response")
+ps.Streams.stdout.Content += Testers.ContainsExpression("Content-Range: bytes 0-6/18", "mismatch byte content response")
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
@@ -15,15 +15,26 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import time
+import datetime
 
 Test.Summary = '''
 Slice selfhealing test
 '''
 
+
+def to_httpdate(dt):
+    # string representation of a date according to RFC 1123 (HTTP/1.1).
+    weekday = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][dt.weekday()]
+    month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][dt.month - 1]
+    return "%s, %02d %s %04d %02d:%02d:%02d GMT" % (weekday, dt.day, month,
+                                                    dt.year, dt.hour, dt.minute, dt.second)
+
 # Test description:
 # Preload the cache with the entire asset to be range requested.
 # Reload remap rule with slice plugin
 # Request content through the slice plugin
+
 
 Test.SkipUnless(
     Condition.PluginExists('slice.so'),
@@ -60,10 +71,15 @@ server.addResponse("sessionlog.json", req_header_chk, res_header_chk)
 
 # set up slice plugin with remap host into cache_range_requests
 ts.Disk.remap_config.AddLines([
-    'map http://slice/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=--blockbytes-test=3 @pparam=--remap-host=cache_range_requests',
-    'map http://cache_range_requests/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
+    f'map http://slice/ http://127.0.0.1:{server.Variables.Port}/' +
+    ' @plugin=slice.so @pparam=--blockbytes-test=3 @pparam=--remap-host=crr',
+    f'map http://crr/ http://127.0.0.1:{server.Variables.Port}/' +
     '  @plugin=cache_range_requests.so @pparam=--consider-ims',
+    f'map http://slicehdr/ http://127.0.0.1:{server.Variables.Port}/' +
+    ' @plugin=slice.so @pparam=--blockbytes-test=3' +
+    ' @pparam=--remap-host=crrhdr @pparam=--crr-ims-header=crr-foo',
+    f'map http://crrhdr/ http://127.0.0.1:{server.Variables.Port}/'
+    '  @plugin=cache_range_requests.so @pparam=--ims-header=crr-foo',
 ])
 
 ts.Disk.plugin_config.AddLine('xdebug.so')
@@ -154,16 +170,16 @@ tr = Test.AddTestRun("Preload reference etagnew-0")
 ps = tr.Processes.Default
 ps.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 ps.StartBefore(Test.Processes.ts)
-ps.Command = curl_and_args + ' http://cache_range_requests/second -r 0-2 -H "uuid: etagnew-0"'
+ps.Command = curl_and_args + ' http://crr/second -r 0-2 -H "uuid: etagnew-0"'
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/bbb.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("etagnew", "expected etagnew")
 tr.StillRunningAfter = ts
 
-# 1 Test - Preload reference etagold-1
+# 1 Test - Preload slice etagold-1
 tr = Test.AddTestRun("Preload slice etagold-1")
 ps = tr.Processes.Default
-ps.Command = curl_and_args + ' http://cache_range_requests/second -r 3-5 -H "uuid: etagold-1"'
+ps.Command = curl_and_args + ' http://crr/second -r 3-5 -H "uuid: etagold-1"'
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/aa.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("etagold", "expected etagold")
@@ -264,7 +280,7 @@ server.addResponse("sessionlog.json", req_header_refnew1, res_header_refnew1)
 # 4 Test - Preload reference etagold-0
 tr = Test.AddTestRun("Preload reference etagold-0")
 ps = tr.Processes.Default
-ps.Command = curl_and_args + ' http://cache_range_requests/reference -r 0-2 -H "uuid: etagold-0"'
+ps.Command = curl_and_args + ' http://crr/reference -r 0-2 -H "uuid: etagold-0"'
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/aaa.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("etagold", "expected etagold")
@@ -273,7 +289,7 @@ tr.StillRunningAfter = ts
 # 5 Test - Preload reference etagnew-1
 tr = Test.AddTestRun("Preload slice etagnew-1")
 ps = tr.Processes.Default
-ps.Command = curl_and_args + ' http://cache_range_requests/reference -r 3-5 -H "uuid: etagnew-1"'
+ps.Command = curl_and_args + ' http://crr/reference -r 3-5 -H "uuid: etagnew-1"'
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/bb.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("etagnew", "expected etagnew")
@@ -384,6 +400,29 @@ ps = tr.Processes.Default
 ps.Command = curl_and_args + ' http://slice/assetgone'
 # ps.ReturnCode = 0 # curl will return non zero
 ps.Streams.stdout.Content = Testers.ContainsExpression("404 Not Found", "Expected 404")
+tr.StillRunningAfter = ts
+
+# custom headers
+
+edt = datetime.datetime.fromtimestamp(time.time() + 100)
+edate = to_httpdate(edt)
+
+# 12 Test - Preload reference etagold-1
+tr = Test.AddTestRun("Preload slice etagold-1")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + f' http://crrhdr/second -r 3-5 -H "uuid: etagold-1" -H "crr-foo: {edate}"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/aa.gold"
+ps.Streams.stdout.Content = Testers.ContainsExpression("etagold", "expected etagold")
+tr.StillRunningAfter = ts
+
+# 13 Test - Request second slice via slice plugin, with instructions to fetch new 2nd slice
+tr = Test.AddTestRun("Request 2nd slice (expect refetch)")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slicehdr/second -r 3- -H "uuid: etagnew-1"'
+ps.ReturnCode = 0
+ps.Streams.stderr = "gold/bb.gold"
+ps.Streams.stdout.Content = Testers.ContainsExpression("etagnew", "expected etagnew")
 tr.StillRunningAfter = ts
 
 # Over riding the built in ERROR check since we expect to see logSliceErrors


### PR DESCRIPTION
This adds the ability to override the internal slice skip header (was hard coded to X-Slicer-Info) and the cache_range_requests ims header (was hard coded to X-Crr-Ims).