### PR TITLE
TLS Session Resumption: fix timed out session

### DIFF
--- a/iocore/net/TLSSessionResumptionSupport.cc
+++ b/iocore/net/TLSSessionResumptionSupport.cc
@@ -184,6 +184,7 @@ TLSSessionResumptionSupport::getOriginSession(SSL *ssl, const std::string &looku
     if (is_ssl_session_timed_out(shared_sess.get())) {
       SSL_INCREMENT_DYN_STAT(ssl_origin_session_cache_miss);
       origin_sess_cache->remove_session(lookup_key);
+      shared_sess.reset();
     } else {
       SSL_INCREMENT_DYN_STAT(ssl_origin_session_cache_hit);
       this->_setSSLSessionCacheHit(true);


### PR DESCRIPTION
A recent change to use shared_ptr for sessions change modified the behavior of timed out sessions in `getOriginSession()`.  This change reverts the behavior of `getOriginSession()` for a timed out session to the previous behavior, where it returns a null session pointer.