### PR TITLE
Fix a libswoc build error on macOS

### DIFF
--- a/lib/swoc/include/swoc/swoc_ip.h
+++ b/lib/swoc/include/swoc/swoc_ip.h
@@ -10,6 +10,7 @@
 #include <netinet/in.h>
 #include <string_view>
 #include <variant>
+#include <array>
 
 #include "swoc/swoc_version.h"
 #include "swoc/TextView.h"


### PR DESCRIPTION
This change fixes a build failure on macOS by including `<array>` in `swoc_ip.h`.