### PR TITLE
Fix to allow running autopep8 from outside top_srcdir

### DIFF
--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -93,7 +93,7 @@ function main() {
       --aggressive \
       --aggressive \
       --recursive \
-      plugins/experimental/metalink/test
+      ${DIR}/plugins/experimental/metalink/test
   echo "autopep8 completed."
   rm -rf ${tmp_dir}
   deactivate


### PR DESCRIPTION
Sometimes I like to build in a subdirectory but this script is not happy with that.