### PR TITLE
Update iocore/cache/test to fix the build

### DIFF
--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -105,6 +105,7 @@ test_LDADD = \
 	$(top_builddir)/iocore/aio/libinkaio.a \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/lib/fastlz/libfastlz.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	@HWLOC_LIBS@ \
 	@LIBPCRE@ \

--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -21,10 +21,16 @@
   limitations under the License.
  */
 
+#include <string_view>
+
 #include "HttpSessionManager.h"
 #include "HttpBodyFactory.h"
 #include "DiagsConfig.h"
 #include "ts/InkAPIPrivateIOCore.h"
+
+#include "tscore/I_Version.h"
+
+AppVersionInfo appVersionInfo;
 
 void
 initialize_thread_for_http_sessions(EThread *, int)
@@ -67,6 +73,11 @@ HttpHookState::HttpHookState() {}
 
 void
 HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
+{
+}
+
+void
+api_init()
 {
 }
 
@@ -157,18 +168,19 @@ ts::svtoi(TextView src, TextView *out, int base)
 }
 
 void
-HostStatus::setHostStatus(const char *name, TSHostStatus status, const unsigned int down_time, const unsigned int reason)
+HostStatus::setHostStatus(const std::string_view name, const TSHostStatus status, const unsigned int down_time,
+                          const unsigned int reason)
 {
 }
 
 HostStatRec *
-HostStatus::getHostStatus(const char *name)
+HostStatus::getHostStatus(const std::string_view name)
 {
   return nullptr;
 }
 
 void
-HostStatus::createHostStat(const char *name, const char *data)
+HostStatus::createHostStat(const std::string_view name, const char *data)
 {
 }
 


### PR DESCRIPTION
I noticed the iocore/cache tests didn't compile with `--enable-expensive-tests` passed to the configure script.  This PR restores them to working order.