### PR TITLE
Update asf.yaml to require Rocky over CentOS build

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,7 +33,7 @@ github:
         strict: false
         contexts:
           - AuTest
-          - CentOS
+          - Rocky
           - Clang-Analyzer
           - Clang-Format
           - Debian


### PR DESCRIPTION
We have changed the CI to use rocky now that centos is defunct, need to update the asf to match