### PR TITLE
Fix Clang 13.0.1 compiler warnings

### DIFF
--- a/iocore/net/quic/QUICVersionNegotiator.cc
+++ b/iocore/net/quic/QUICVersionNegotiator.cc
@@ -46,11 +46,9 @@ QUICVersionNegotiator::negotiate(const QUICPacket &packet)
   case QUICPacketType::VERSION_NEGOTIATION: {
     const QUICVersionNegotiationPacketR &vn_packet = static_cast<const QUICVersionNegotiationPacketR &>(packet);
     uint16_t n_supported_version                   = vn_packet.nversions();
-    uint16_t len                                   = 0;
 
     for (int i = 0; i < n_supported_version; ++i) {
       QUICVersion version = vn_packet.supported_version(i);
-      len += sizeof(QUICVersion);
 
       if (QUICTypeUtil::is_supported_version(version)) {
         this->_status             = QUICVersionNegotiationStatus::NEGOTIATED;

--- a/lib/swoc/include/swoc/MemSpan.h
+++ b/lib/swoc/include/swoc/MemSpan.h
@@ -277,6 +277,9 @@ public:
   /// Copy constructor.
   constexpr MemSpan(self_type const &that) = default;
 
+  /// Copy assignment operator.
+  constexpr self_type& operator=(self_type const &that) = default;
+
   /** Cross type copy constructor.
    *
    * @tparam U Type for source span.


### PR DESCRIPTION
This fixes a couple compiler warnings raised by Clang 13.0.1.