### PR TITLE
9.2.x: Fix Clang 13.0.1 and GCC 12.0.1 Compiler Warnings

### DIFF
--- a/example/plugins/cpp-api/boom/boom.cc
+++ b/example/plugins/cpp-api/boom/boom.cc
@@ -98,13 +98,16 @@ GlobalPlugin *plugin;
 // Functor that decides whether the HTTP error can be rewritten or not.
 // Rewritable codes are: 2xx, 3xx, 4xx, 5xx and 6xx.
 // 1xx is NOT rewritable!
-class IsRewritableCode : public std::unary_function<std::string, bool>
+class IsRewritableCode
 { // could probably be replaced with mem_ptr_fun()..
 private:
   int current_code_;
   std::string current_code_string_;
 
 public:
+  using argument_type = std::string;
+  using result_type   = bool;
+
   explicit IsRewritableCode(int current_code) : current_code_(current_code)
   {
     std::ostringstream oss;

--- a/include/tscore/IntrusivePtr.h
+++ b/include/tscore/IntrusivePtr.h
@@ -330,9 +330,13 @@ public:
   static void finalize(T *t);
 
   /// Strict weak order for STL containers.
-  class Order : public std::binary_function<IntrusivePtr<T>, IntrusivePtr<T>, bool>
+  class Order
   {
   public:
+    using first_argument_type  = IntrusivePtr<T>;
+    using second_argument_type = IntrusivePtr<T>;
+    using result_type          = bool;
+
     /// Default constructor.
     Order() {}
     /// Compare by raw pointer.

--- a/include/tscpp/api/Headers.h
+++ b/include/tscpp/api/Headers.h
@@ -109,12 +109,15 @@ class HeaderField;
 /**
  * @brief A header field value iterator iterates through all header fields.
  */
-class header_field_value_iterator : public std::iterator<std::forward_iterator_tag, int>
+class header_field_value_iterator
 {
 private:
   HeaderFieldValueIteratorState *state_;
 
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type        = int;
+
   /**
    * Constructor for header_field_value_iterator, this shouldn't need to be used directly.
    * @param bufp the TSMBuffer associated with the headers
@@ -169,13 +172,16 @@ public:
 /**
  * @brief A header field iterator is an iterator that dereferences to a HeaderField.
  */
-class header_field_iterator : public std::iterator<std::forward_iterator_tag, int>
+class header_field_iterator
 {
 private:
   HeaderFieldIteratorState *state_;
   header_field_iterator(void *hdr_buf, void *hdr_loc, void *field_loc);
 
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type        = int;
+
   ~header_field_iterator();
 
   /**

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -204,9 +204,12 @@ public:
   class AckBlockSection
   {
   public:
-    class const_iterator : public std::iterator<std::input_iterator_tag, QUICAckFrame::AckBlock>
+    class const_iterator
     {
     public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type        = QUICAckFrame::AckBlock;
+
       const_iterator(uint8_t index, const std::vector<QUICAckFrame::AckBlock> *ack_blocks);
 
       const QUICAckFrame::AckBlock &

--- a/iocore/net/quic/QUICVersionNegotiator.cc
+++ b/iocore/net/quic/QUICVersionNegotiator.cc
@@ -46,11 +46,9 @@ QUICVersionNegotiator::negotiate(const QUICPacket &packet)
   case QUICPacketType::VERSION_NEGOTIATION: {
     const QUICVersionNegotiationPacketR &vn_packet = static_cast<const QUICVersionNegotiationPacketR &>(packet);
     uint16_t n_supported_version                   = vn_packet.nversions();
-    uint16_t len                                   = 0;
 
     for (int i = 0; i < n_supported_version; ++i) {
       QUICVersion version = vn_packet.supported_version(i);
-      len += sizeof(QUICVersion);
 
       if (QUICTypeUtil::is_supported_version(version)) {
         this->_status             = QUICVersionNegotiationStatus::NEGOTIATED;

--- a/src/tscore/HostLookup.cc
+++ b/src/tscore/HostLookup.cc
@@ -231,7 +231,11 @@ struct CharIndexBlock {
 class CharIndex
 {
 public:
-  struct iterator : public std::iterator<std::forward_iterator_tag, HostBranch, int> {
+  struct iterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type        = HostBranch;
+    using difference_type   = int;
+
     using self_type = iterator;
 
     struct State {

--- a/src/wccp/WccpMeta.h
+++ b/src/wccp/WccpMeta.h
@@ -54,7 +54,11 @@ template <bool VALUE> struct TEST_IF_TRUE : public TEST_RESULT<TEST_BOOL<VALUE>>
 };
 
 // Helper for assigning a value to all instances in a container.
-template <typename T, typename R, typename A1> struct TsAssignMember : public std::binary_function<T, A1, R> {
+template <typename T, typename R, typename A1> struct TsAssignMember {
+  using first_argument_type  = T;
+  using second_argument_type = A1;
+  using result_type          = R;
+
   R T::*_m;
   A1 _arg1;
   TsAssignMember(R T::*m, A1 const &arg1) : _m(m), _arg1(arg1) {}


### PR DESCRIPTION
This cherry-picks two commits from master:

Fix Clang 13.0.1 compiler warnings (#8685)

This fixes a couple compiler warnings raised by Clang 13.0.1.

(cherry picked from commit 96ce993fa53a05b872c5041629e3aac0bc15d56d)

Fix warnings from GCC 12.0.1 (#8684)

This patch fixes warnings generated by GCC 12.0.1. The warnings involved the
use of the deprecated std::binary_function, std::unary_function, and
std::iterator interfaces. The use of these was considered more confusing than
explicitly declaring the associated types. Therefore this patch replaces the
use of these deprecated interfaces with the declaration of the associated
types.

(cherry picked from commit 0ae34d4d1699d978f6938027efb2ecb9ae05c89a)