### PR TITLE
traffic_ctl - Add rpc invoke option.

### DIFF
--- a/doc/appendices/command-line/traffic_ctl_jsonrpc.en.rst
+++ b/doc/appendices/command-line/traffic_ctl_jsonrpc.en.rst
@@ -538,6 +538,42 @@ but rather to the rpc endpoint, so you can directly send requests and receive re
          }
       }
 
+
+.. option:: invoke
+
+   Invoke a remote call by using the method name as parameter. This could be a handy option if you are developing a new handler or you
+   just don't want to expose the method in :program:`traffic_ctl`, for instance when implementing a custom handler inside a proprietary plugin.
+
+   .. option:: --params, -p
+
+      Parameters to be passed in the request, YAML or JSON format are accepted. If JSON is passed as param it should not
+      be mixed with YAML. It's important that you follow the :ref:`jsonrpc-protocol` specs. If the passed param does not
+      follows the specs the server will reject the request.
+
+.. _rpc_invoke_example_1:
+
+   Example 1:
+
+   Call a jsonrpc method with no parameter.
+
+   .. code-block::
+
+      $ traffic_ctl rpc invoke some_jsonrpc_handler
+      --> {"id": "0dbab88d-b78f-4ebf-8aa3-f100031711a5", "jsonrpc": "2.0", "method": "some_jsonrpc_handler"}
+      <-- { response }
+
+.. _rpc_invoke_example_2:
+
+   Example 2:
+
+   Call a jsonrpc method with parameters.
+
+   .. code-block::
+
+      $ traffic_ctl rpc invoke reload_files_from_folder --params 'filenames: ["file1", "file2"]' 'folder: "/path/to/folder"'
+      --> {"id": "9ac68652-5133-4d5f-8260-421baca4c67f", "jsonrpc": "2.0", "method": "reload_files_from_folder", "params": {"filenames": ["file1", "file2"], "folder": "/path/to/folder"}}
+      <-- { response }
+
 Examples
 ========
 

--- a/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
@@ -132,7 +132,6 @@ Please find the `jsonrpc 2.0 request` schema for reference ( `mgmt2/rpc/schema/j
 * Optional parameters:
 
 
-
    * ``params``:
 
       A Structured value that holds the parameter values to be used during the invocation of the method. This member

--- a/include/shared/rpc/RPCRequests.h
+++ b/include/shared/rpc/RPCRequests.h
@@ -42,7 +42,7 @@ struct JSONRPCRequest {
   virtual std::string
   get_method() const
   {
-    return "method";
+    return this->method;
   }
 };
 

--- a/src/traffic_ctl_jsonrpc/CtrlCommands.h
+++ b/src/traffic_ctl_jsonrpc/CtrlCommands.h
@@ -163,6 +163,7 @@ private:
   void from_file_request();
   void get_rpc_api();
   void read_from_input();
+  void invoke_method();
   /// run a YAML validation on the input.
   bool validate_input(std::string const &in) const;
 };

--- a/src/traffic_ctl_jsonrpc/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl_jsonrpc/jsonrpc/CtrlRPCRequests.h
@@ -221,17 +221,6 @@ struct ShowRegisterHandlersRequest : shared::rpc::ClientRequest {
   }
 };
 //------------------------------------------------------------------------------------------------------------------------------------
-// We expect the method to be passed, this request is used to create dynamic requests by using (traffic_ctl rpc invoke "func_name")
-struct CustomizableRequest : shared::rpc::ClientRequest {
-  using super = shared::rpc::ClientRequest;
-  CustomizableRequest(std::string const &methodName) { super::method = methodName; }
-  std::string
-  get_method() const
-  {
-    return super::method;
-  }
-};
-//------------------------------------------------------------------------------------------------------------------------------------
 ///
 /// @brief Config status request mapping class.
 ///

--- a/src/traffic_ctl_jsonrpc/traffic_ctl.cc
+++ b/src/traffic_ctl_jsonrpc/traffic_ctl.cc
@@ -160,7 +160,11 @@ main(int argc, const char **argv)
                 "No json/yaml parse validation will take place, the raw content will be directly send to the server.", "", 0, "",
                 "raw")
     .add_example_usage("traffic_ctl rpc input ");
-
+  direct_rpc_command
+    .add_command("invoke", "Call a method by using the method name as input parameter", "", MORE_THAN_ONE_ARG_N,
+                 [&]() { command->execute(); })
+    .add_option("--params", "-p", "Parameters to be passed in the request, YAML or JSON format", "", MORE_THAN_ONE_ARG_N, "", "")
+    .add_example_usage("traffic_ctl rpc invoke foo_bar -p \"numbers: [1, 2, 3]\"");
   try {
     auto args = parser.parse(argv);
     argparser_runroot_handler(args.get("run-root").value(), argv[0]);


### PR DESCRIPTION
Add Input option to invoke a rpc function by specifying the method name and the parameters directly
from the command line.

With this change we now can call any rpc method without the need to support it in traffic_ctl:

```
$ traffic_ctl rpc invoke get_service_descriptor
--> {"id": "50d9431e-85f9-4999-abc7-4f26ac3cc1e1", "jsonrpc": "2.0", "method": "get_service_descriptor"}
<--  {response}
```

This also removed `CustomizableRequest` which is no longer needed(it was unused but left it as base for this case).