### PR TITLE
MGMT - Improve invalid rpc param error description and some cleanup.

### DIFF
--- a/mgmt2/rpc/jsonrpc/error/RPCError.cc
+++ b/mgmt2/rpc/jsonrpc/error/RPCError.cc
@@ -21,7 +21,7 @@
 #include "RPCError.h"
 
 #include <string>
-#include <system_error> // TODO: remove
+#include <system_error>
 
 namespace
 { // anonymous namespace
@@ -66,7 +66,7 @@ RPCErrorCategory::message(int ev) const
     return {"Missing method field"};
   // params
   case RPCErrorCode::InvalidParamType:
-    return {"Invalid params type, should be a structure"};
+    return {"Invalid params type. A Structured value is expected"};
   // id
   case RPCErrorCode::InvalidIdType:
     return {"Invalid id type"};

--- a/mgmt2/rpc/jsonrpc/unit_tests/test_basic_protocol.cc
+++ b/mgmt2/rpc/jsonrpc/unit_tests/test_basic_protocol.cc
@@ -302,7 +302,7 @@ TEST_CASE("Invalid parameters base on the jsonrpc 2.0 protocol", "[protocol]")
 
       REQUIRE(resp);
       const std::string_view expected =
-        R"({"jsonrpc": "2.0", "error": {"code": 6, "message": "Invalid params type, should be a structure"}, "id": "13"})";
+        R"({"jsonrpc": "2.0", "error": {"code": 6, "message": "Invalid params type. A Structured value is expected"}, "id": "13"})";
       REQUIRE(*resp == expected);
     }
   }


### PR DESCRIPTION
Use same description as the jsonrpc specs.