### PR TITLE
8.1.x: Add option to mostly strictly check URL characters (#8012)

### DIFF
--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -354,7 +354,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.post.check.content_length.enabled", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.strict_uri_parsing", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.strict_uri_parsing", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   //       # Send http11 requests
   //       #

--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -885,7 +885,7 @@ http_parser_clear(HTTPParser *parser)
 
 ParseResult
 http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const char **start, const char *end,
-                      bool must_copy_strings, bool eof, bool strict_uri_parsing)
+                      bool must_copy_strings, bool eof, int strict_uri_parsing)
 {
   if (parser->m_parsing_http) {
     MIMEScanner *scanner = &parser->m_mime_parser.m_scanner;

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -447,7 +447,7 @@ const char *http_hdr_reason_lookup(unsigned status);
 void http_parser_init(HTTPParser *parser);
 void http_parser_clear(HTTPParser *parser);
 ParseResult http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const char **start, const char *end,
-                                  bool must_copy_strings, bool eof, bool strict_uri_parsing);
+                                  bool must_copy_strings, bool eof, int strict_uri_parsing);
 ParseResult validate_hdr_host(HTTPHdrImpl *hh);
 ParseResult validate_hdr_content_length(HdrHeap *heap, HTTPHdrImpl *hh);
 ParseResult http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const char **start, const char *end,
@@ -626,10 +626,10 @@ public:
   const char *reason_get(int *length);
   void reason_set(const char *value, int length);
 
-  ParseResult parse_req(HTTPParser *parser, const char **start, const char *end, bool eof, bool strict_uri_parsing = false);
+  ParseResult parse_req(HTTPParser *parser, const char **start, const char *end, bool eof, int strict_uri_parsing = 0);
   ParseResult parse_resp(HTTPParser *parser, const char **start, const char *end, bool eof);
 
-  ParseResult parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool eof, bool strict_uri_parsing = false);
+  ParseResult parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool eof, int strict_uri_parsing = 0);
   ParseResult parse_resp(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool eof);
 
 public:
@@ -1227,7 +1227,7 @@ HTTPHdr::reason_set(const char *value, int length)
   -------------------------------------------------------------------------*/
 
 inline ParseResult
-HTTPHdr::parse_req(HTTPParser *parser, const char **start, const char *end, bool eof, bool strict_uri_parsing)
+HTTPHdr::parse_req(HTTPParser *parser, const char **start, const char *end, bool eof, int strict_uri_parsing)
 {
   ink_assert(valid());
   ink_assert(m_http->m_polarity == HTTP_TYPE_REQUEST);

--- a/proxy/hdrs/HdrTSOnly.cc
+++ b/proxy/hdrs/HdrTSOnly.cc
@@ -45,7 +45,7 @@
   -------------------------------------------------------------------------*/
 
 ParseResult
-HTTPHdr::parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool eof, bool strict_uri_parsing)
+HTTPHdr::parse_req(HTTPParser *parser, IOBufferReader *r, int *bytes_used, bool eof, int strict_uri_parsing)
 {
   const char *start;
   const char *tmp;

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -198,14 +198,13 @@ void url_query_set(HdrHeap *heap, URLImpl *url, const char *value, int length, b
 void url_fragment_set(HdrHeap *heap, URLImpl *url, const char *value, int length, bool copy_string);
 
 ParseResult url_parse(HdrHeap *heap, URLImpl *url, const char **start, const char *end, bool copy_strings,
-                      bool strict_uri_parsing = false);
+                      int strict_uri_parsing = false);
 ParseResult url_parse_no_path_component_breakdown(HdrHeap *heap, URLImpl *url, const char **start, const char *end,
                                                   bool copy_strings);
 ParseResult url_parse_internet(HdrHeap *heap, URLImpl *url, const char **start, const char *end, bool copy_strings);
 ParseResult url_parse_http(HdrHeap *heap, URLImpl *url, const char **start, const char *end, bool copy_strings);
 ParseResult url_parse_http_no_path_component_breakdown(HdrHeap *heap, URLImpl *url, const char **start, const char *end,
                                                        bool copy_strings);
-
 char *url_unescapify(Arena *arena, const char *str, int length);
 
 void unescape_str(char *&buf, char *buf_e, const char *&str, const char *str_e, int &state);

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1475,7 +1475,7 @@ HttpConfig::reconfigure()
   params->referer_filter_enabled  = INT_TO_BOOL(m_master.referer_filter_enabled);
   params->referer_format_redirect = INT_TO_BOOL(m_master.referer_format_redirect);
 
-  params->strict_uri_parsing = INT_TO_BOOL(m_master.strict_uri_parsing);
+  params->strict_uri_parsing = m_master.strict_uri_parsing;
 
   params->oride.down_server_timeout    = m_master.oride.down_server_timeout;
   params->oride.client_abort_threshold = m_master.oride.client_abort_threshold;

--- a/tests/gold_tests/headers/gold/bad_good_request.gold
+++ b/tests/gold_tests/headers/gold/bad_good_request.gold
@@ -1,0 +1,9 @@
+``HTTP/1.1 400 Invalid HTTP Request
+``Connection: close
+``Server: ATS/``
+``Content-Length: 219
+``
+<TITLE>Bad Request</TITLE>
+``<H1>Bad Request</H1>
+``Description: Could not process this request.
+``

--- a/tests/gold_tests/headers/gold/bad_good_request_header.gold
+++ b/tests/gold_tests/headers/gold/bad_good_request_header.gold
@@ -1,0 +1,5 @@
+``HTTP/1.1 400 Invalid HTTP Request
+``Connection: close
+``Server: ATS/``
+``Content-Length: 219
+``

--- a/tests/gold_tests/headers/gold/bad_good_request_http1.gold
+++ b/tests/gold_tests/headers/gold/bad_good_request_http1.gold
@@ -1,0 +1,8 @@
+``HTTP/1.0 400 Invalid HTTP Request
+``Server: ATS/``
+``Content-Length: 219
+``
+<TITLE>Bad Request</TITLE>
+``<H1>Bad Request</H1>
+``Description: Could not process this request.
+``

--- a/tests/gold_tests/headers/gold/bad_method.gold
+++ b/tests/gold_tests/headers/gold/bad_method.gold
@@ -1,0 +1,24 @@
+HTTP/1.1 501 Unsupported method ('gET')
+Content-Type: text/html;charset=utf-8
+Content-Length: 496
+Date: ``
+Age: 0
+Connection: keep-alive
+Server: ATS/``
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+        <title>Error response</title>
+    </head>
+    <body>
+        <h1>Error response</h1>
+        <p>Error code: 501</p>
+        <p>Message: Unsupported method ('gET').</p>
+        <p>Error code explanation: HTTPStatus.NOT_IMPLEMENTED - Server does not support this operation.</p>
+    </body>
+</html>
+HTTP/1.1 200 OK
+``

--- a/tests/gold_tests/headers/gold/bad_protocol_number.gold
+++ b/tests/gold_tests/headers/gold/bad_protocol_number.gold
@@ -1,0 +1,22 @@
+HTTP/1.1 505 Unsupported HTTP Version
+Date: ``
+Server: ATS/``
+Cache-Control: no-store
+Content-Type: text/html
+Content-Language: en
+Content-Length: 219
+
+<HTML>
+<HEAD>
+<TITLE>Bad Request</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>Bad Request</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial"><B>
+Description: Could not process this request.
+</B></FONT>
+<HR>
+</BODY>

--- a/tests/gold_tests/headers/gold/bad_te_value.gold
+++ b/tests/gold_tests/headers/gold/bad_te_value.gold
@@ -1,0 +1,25 @@
+HTTP/1.1 501 Field not implemented
+Date: ``
+Connection: keep-alive
+Server: ATS/``
+Cache-Control: no-store
+Content-Type: text/html
+Content-Language: en
+Content-Length: 289
+
+<HTML>
+<HEAD>
+<TITLE>Transcoding Not Available</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>Transcoding Not Available</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial">
+
+<B> Description: Unable to provide the document in the
+format requested by your browser.
+</B></FONT>
+<HR>
+</BODY>

--- a/tests/gold_tests/headers/good_request_after_bad.test.py
+++ b/tests/gold_tests/headers/good_request_after_bad.test.py
@@ -1,0 +1,196 @@
+'''
+Verify that request following a ill-formed request is not processed
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Verify that request following a ill-formed request is not processed
+'''
+Test.ContinueOnFail = True
+ts = Test.MakeATSProcess("ts")
+Test.ContinueOnFail = True
+ts.Disk.records_config.update({'proxy.config.diags.debug.tags': 'http',
+                               'proxy.config.diags.debug.enabled': 0,
+                               'proxy.config.http.strict_uri_parsing': 1
+                               })
+
+ts2 = Test.MakeATSProcess("ts2")
+
+ts2.Disk.records_config.update({'proxy.config.diags.debug.tags': 'http',
+                                'proxy.config.diags.debug.enabled': 0,
+                                'proxy.config.http.strict_uri_parsing': 2
+                                })
+
+
+server = Test.MakeOriginServer("server")
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nLast-Modified: Tue, 08 May 2018 15:49:41 GMT\r\nCache-Control: max-age=1000\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"}
+server.addResponse("sessionlog.json", request_header, response_header)
+
+ts.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+ts.Disk.remap_config.AddLine(
+    'map /bob<> http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+ts2.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+ts2.Disk.remap_config.AddLine(
+    'map /bob<> http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+
+trace_out = Test.Disk.File("trace_curl.txt")
+
+# Make a good request to get item in the cache for later tests
+tr = Test.AddTestRun("Good control")
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nHost: bob\r\n\r\n" | nc  127.0.0.1 {}'.format(ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun("Good control")
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(Test.Processes.ts2)
+tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nHost: bob\r\n\r\n" | nc  127.0.0.1 {}'.format(ts2.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun("space after header name")
+tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nHost : bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = 'gold/bad_good_request.gold'
+
+# Commenting out a bunch of tests on master whose fixes are not in 8.1.x.
+#tr = Test.AddTestRun("Bad protocol number")
+#tr.Processes.Default.Command = 'printf "GET / HTTP/11.1\r\nhost: bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_protocol_number.gold'
+#
+#tr = Test.AddTestRun("Unsupported Transfer Encoding value")
+#tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nhost: bob\r\ntransfer-encoding: random\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_te_value.gold'
+#
+#tr = Test.AddTestRun("Another unsupported Transfer Encoding value")
+#tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nhost: bob\r\ntransfer-encoding: \x08chunked\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_te_value.gold'
+#
+#tr = Test.AddTestRun("Extra characters in content-length")
+#tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nhost: bob\r\ncontent-length:+3\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_header.gold'
+#
+#tr = Test.AddTestRun("Different extra characters in content-length")
+#tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nhost: bob\r\ncontent-length:\x0c3\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_header.gold'
+#
+#
+## TRACE request with a body
+#tr = Test.AddTestRun("Trace request with a body")
+#tr.Processes.Default.Command = 'printf "TRACE /foo HTTP/1.1\r\nHost: bob\r\nContent-length:2\r\n\r\nokGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_good_request.gold'
+#
+#tr = Test.AddTestRun("Trace request with a chunked body")
+#tr.Processes.Default.Command = 'printf "TRACE /foo HTTP/1.1\r\nHost: bob\r\ntransfer-encoding: chunked\r\n\r\n2\r\nokGGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_good_request.gold'
+#
+#tr = Test.AddTestRun("Trace request with a chunked body via curl")
+#tr.Processes.Default.Command = 'curl -v --http1.1 --header "Transfer-Encoding: chunked" -d aaa -X TRACE -o trace_curl.txt -k http://127.0.0.1:{}/foo'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.All = 'gold/bad_good_request_header.gold'
+#trace_out.Content = Testers.ContainsExpression("<TITLE>Bad Request</TITLE>", "ATS error msg")
+#trace_out.Content += Testers.ContainsExpression("Description: Could not process this request.", "ATS error msg")
+#
+#tr = Test.AddTestRun("Trace request via curl")
+#tr.Processes.Default.Command = 'curl -v --http1.1 -X TRACE -k http://127.0.0.1:{}/bar'.format(ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+#    r"HTTP/1.1 501 Unsupported method \('TRACE'\)",
+#    "microserver does not support TRACE")
+#
+## Methods are case sensitive. Verify that "gET" is not confused with "GET".
+#tr = Test.AddTestRun("mixed case method")
+#tr.Processes.Default.Command = 'printf "gET / HTTP/1.1\r\nHost:bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_method.gold'
+#
+## mangled termination
+#tr = Test.AddTestRun("mangled line termination")
+#tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nHost:bob\r\n \r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+#    ts.Variables.port)
+#tr.Processes.Default.ReturnCode = 0
+#tr.Processes.Default.Streams.stdout = 'gold/bad_good_request.gold'
+
+tr = Test.AddTestRun("Catch bad URL characters")
+tr.Processes.Default.Command = 'printf "GET /bob<> HTTP/1.1\r\nhost: bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+# Since the request line is messsed up ATS will reply with HTTP/1.0
+tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_http1.gold'
+
+tr = Test.AddTestRun("Catch whitespace in URL")
+tr.Processes.Default.Command = 'printf "GET /bob foo HTTP/1.1\r\nhost: bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+# Since the request line is messsed up ATS will reply with HTTP/1.0
+tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_http1.gold'
+
+tr = Test.AddTestRun("Extra characters in protocol")
+tr.Processes.Default.Command = 'printf "GET / HTP/1.1\r\nhost: bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+# Since the request line is messsed up ATS will reply with HTTP/1.0
+tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_http1.gold'
+
+tr = Test.AddTestRun("Characters that are strict but not case 2 bad")
+tr.Processes.Default.Command = 'printf "GET /bob<> HTTP/1.1\r\nhost: bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+    ts2.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 200 OK", "Success")
+
+tr = Test.AddTestRun("Catch whitespace in URL")
+tr.Processes.Default.Command = 'printf "GET /bob foo HTTP/1.1\r\nhost: bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+    ts2.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+# Since the request line is messsed up ATS will reply with HTTP/1.0
+tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_http1.gold'
+
+tr = Test.AddTestRun("Extra characters in protocol")
+tr.Processes.Default.Command = 'printf "GET / HTP/1.1\r\nhost: bob\r\n\r\nGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
+    ts2.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+# Since the request line is messsed up ATS will reply with HTTP/1.0
+tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_http1.gold'


### PR DESCRIPTION
(cherry picked from commit 284fe0a0393eca07640f8236f60a6f46f8f132e9)

The doc change was separated out so that doc CI will not hold up this PR. For the doc change, see:
https://github.com/apache/trafficserver/pull/8703