### PR TITLE
8.1.x: docs: Add option to mostly strictly check URL characters (#8012)

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1136,8 +1136,10 @@ mptcp
 
 .. ts:cv:: CONFIG proxy.config.http.strict_uri_parsing INT 0
 
-   Enables (``1``) or disables (``0``) Traffic Server to return a 400 Bad Request
-   if client's request URI includes character which is not RFC 3986 compliant
+   Takes a value between 0 and 2.  ``0`` disables strict_uri_parsing.  Any character can appears
+   in the URI.  ``1`` causes |TS| to return 400 Bad Request
+   if client's request URI includes character which is not RFC 3986 compliant. ``2`` directs |TS|
+   to reject the clients request if it contains whitespace or non-printable characters.
 
 .. ts:cv:: CONFIG proxy.config.http.errors.log_error_pages INT 1
    :reloadable:


### PR DESCRIPTION
(cherry picked from commit 284fe0a0393eca07640f8236f60a6f46f8f132e9)

This just includes the doc changes so that they run via CI separately. For the non-doc changes, see:
https://github.com/apache/trafficserver/pull/8701