### PR TITLE
Provide libquic.a definition to VIO::VIO()

### DIFF
--- a/src/traffic_server/Makefile.inc
+++ b/src/traffic_server/Makefile.inc
@@ -100,5 +100,6 @@ endif
 if ENABLE_QUIC
 traffic_server_traffic_server_LDADD += \
   $(top_builddir)/proxy/http3/libhttp3.a \
-  $(top_builddir)/iocore/net/quic/libquic.a
+  $(top_builddir)/iocore/net/quic/libquic.a \
+  $(top_builddir)/iocore/eventsystem/libinkevent.a
 endif


### PR DESCRIPTION
Building with Clang 13 resulted in an undefined sybmol for VIO::VIO().
That is provided by libinkevent.a. Providing that after libquic.a so it
can find the symbol.

This closes #8686