### PR TITLE
cache-request-method autest: Extending IO delay

### DIFF
--- a/tests/gold_tests/cache/replay/post_with_post_caching_enabled.replay.yaml
+++ b/tests/gold_tests/cache/replay/post_with_post_caching_enabled.replay.yaml
@@ -128,7 +128,7 @@ sessions:
 
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
-      delay: 100ms
+      delay: 500ms
 
     # The request should be served out of cache, so this 403 should not be
     # received.


### PR DESCRIPTION
This tweaks a delay that waits upon IO to finish in the
cache-request-method autest which has frequently failed because the item
is not yet cached.