### PR TITLE
Move hwloc-based functions into it's own header/compilation unit

### DIFF
--- a/include/tscore/ink_defs.h
+++ b/include/tscore/ink_defs.h
@@ -100,10 +100,6 @@ countof(const T (&)[N])
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #endif
 
-#if TS_USE_HWLOC
-#include <hwloc.h>
-#endif
-
 #if defined(MAP_NORESERVE)
 #define MAP_SHARED_MAP_NORESERVE (MAP_SHARED | MAP_NORESERVE)
 #else
@@ -119,7 +115,6 @@ extern int on;
 /* Functions
  */
 int ink_sys_name_release(char *name, int namelen, char *release, int releaselen);
-int ink_number_of_processors();
 int ink_login_name_max();
 
 #ifdef __cplusplus
@@ -135,9 +130,4 @@ ROUNDUP(ArithmeticV value, ArithmeticM m)
   }
   return value;
 }
-#endif
-
-#if TS_USE_HWLOC
-// Get the hardware topology
-hwloc_topology_t ink_get_topology();
 #endif

--- a/include/tscore/ink_hw.h
+++ b/include/tscore/ink_hw.h
@@ -1,0 +1,33 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "tscore/ink_config.h"
+
+#if TS_USE_HWLOC
+#include <hwloc.h>
+
+// Get the hardware topology
+hwloc_topology_t ink_get_topology();
+#endif
+
+int ink_number_of_processors();

--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -25,7 +25,8 @@
  * Async Disk IO operations.
  */
 
-#include <tscore/TSSystemState.h>
+#include "tscore/TSSystemState.h"
+#include "tscore/ink_hw.h"
 
 #include "P_AIO.h"
 

--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -23,6 +23,7 @@
 
 #include "P_AIO.h"
 #include "InkAPIInternal.h"
+#include "tscore/ink_hw.h"
 #include "tscore/I_Layout.h"
 #include "tscore/TSSystemState.h"
 #include "tscore/Random.h"

--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -30,6 +30,7 @@
 #include <hwloc.h>
 #endif
 #include "tscore/ink_defs.h"
+#include "tscore/ink_hw.h"
 #include "tscore/hugepages.h"
 
 /// Global singleton.

--- a/iocore/net/test_I_Net.cc
+++ b/iocore/net/test_I_Net.cc
@@ -22,6 +22,9 @@
  */
 
 #include "P_Net.h"
+
+#include "tscore/ink_hw.h"
+
 #include <netdb.h>
 
 #include "diags.i"

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -30,6 +30,10 @@
 #include "RecordsConfig.h"
 #include "info.h"
 
+#if TS_USE_HWLOC
+#include <hwloc.h>
+#endif
+
 #if HAVE_ZLIB_H
 #include <zlib.h>
 #endif

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -33,6 +33,7 @@
 #include "tscore/ink_platform.h"
 #include "tscore/ink_sys_control.h"
 #include "tscore/ink_args.h"
+#include "tscore/ink_hw.h"
 #include "tscore/ink_lockfile.h"
 #include "tscore/ink_stack_trace.h"
 #include "tscore/ink_syslog.h"

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -79,6 +79,7 @@ libtscore_la_SOURCES = \
 	ink_error.cc \
 	ink_file.cc \
 	ink_hrtime.cc \
+	ink_hw.cc \
 	ink_inet.cc \
 	ink_memory.cc \
 	ink_mutex.cc \

--- a/src/tscore/ink_defs.cc
+++ b/src/tscore/ink_defs.cc
@@ -41,32 +41,6 @@
 int off = 0;
 int on  = 1;
 
-#if TS_USE_HWLOC
-
-#include <hwloc.h>
-
-// Little helper to initialize the hwloc topology, once.
-static hwloc_topology_t
-setup_hwloc()
-{
-  hwloc_topology_t topology;
-
-  hwloc_topology_init(&topology);
-  hwloc_topology_load(topology);
-
-  return topology;
-}
-
-// Get the topology
-hwloc_topology_t
-ink_get_topology()
-{
-  static hwloc_topology_t topology = setup_hwloc();
-  return topology;
-}
-
-#endif
-
 int
 ink_sys_name_release(char *name, int namelen, char *release, int releaselen)
 {
@@ -114,28 +88,6 @@ ink_sys_name_release(char *name, int namelen, char *release, int releaselen)
   return 0;
 #else
   return -1;
-#endif
-}
-
-int
-ink_number_of_processors()
-{
-#if TS_USE_HWLOC
-#if HAVE_HWLOC_OBJ_PU
-  return hwloc_get_nbobjs_by_type(ink_get_topology(), HWLOC_OBJ_PU);
-#else
-  return hwloc_get_nbobjs_by_type(ink_get_topology(), HWLOC_OBJ_CORE);
-#endif
-#elif defined(freebsd)
-  int mib[2], n;
-  mib[0]     = CTL_HW;
-  mib[1]     = HW_NCPU;
-  size_t len = sizeof(n);
-  if (sysctl(mib, 2, &n, &len, nullptr, 0) == -1)
-    return 1;
-  return n;
-#else
-  return sysconf(_SC_NPROCESSORS_ONLN); // number of processing units (includes Hyper Threading)
 #endif
 }
 

--- a/src/tscore/ink_hw.cc
+++ b/src/tscore/ink_hw.cc
@@ -1,0 +1,70 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "tscore/ink_hw.h"
+#include "tscore/ink_platform.h"
+
+#if TS_USE_HWLOC
+
+#include <hwloc.h>
+
+// Little helper to initialize the hwloc topology, once.
+static hwloc_topology_t
+setup_hwloc()
+{
+  hwloc_topology_t topology;
+
+  hwloc_topology_init(&topology);
+  hwloc_topology_load(topology);
+
+  return topology;
+}
+
+// Get the topology
+hwloc_topology_t
+ink_get_topology()
+{
+  static hwloc_topology_t topology = setup_hwloc();
+  return topology;
+}
+
+int
+ink_number_of_processors()
+{
+#if TS_USE_HWLOC
+#if HAVE_HWLOC_OBJ_PU
+  return hwloc_get_nbobjs_by_type(ink_get_topology(), HWLOC_OBJ_PU);
+#else
+  return hwloc_get_nbobjs_by_type(ink_get_topology(), HWLOC_OBJ_CORE);
+#endif
+#elif defined(freebsd)
+  int mib[2], n;
+  mib[0]     = CTL_HW;
+  mib[1]     = HW_NCPU;
+  size_t len = sizeof(n);
+  if (sysctl(mib, 2, &n, &len, nullptr, 0) == -1)
+    return 1;
+  return n;
+#else
+  return sysconf(_SC_NPROCESSORS_ONLN); // number of processing units (includes Hyper Threading)
+#endif
+}
+#endif

--- a/src/tscore/unit_tests/freelist_benchmark.cc
+++ b/src/tscore/unit_tests/freelist_benchmark.cc
@@ -24,6 +24,7 @@
 
 #include "catch.hpp"
 
+#include "tscore/ink_hw.h"
 #include "tscore/ink_thread.h"
 #include "tscore/ink_memory.h"
 #include "tscore/ink_queue.h"


### PR DESCRIPTION
Reduces everything needing to include hwloc.h