### PR TITLE
Enable all iocore/cache tests

### DIFF
--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -117,7 +117,6 @@ test_LDADD = \
 	@YAMLCPP_LIBS@ \
 	-lm
 
-if EXPENSIVE_TESTS
 check_PROGRAMS = \
   test_Cache \
   test_RWW \
@@ -130,7 +129,6 @@ check_PROGRAMS = \
   test_Update_L_to_S \
   test_Update_S_to_L \
   test_Update_header
-endif
 
 test_main_SOURCES = \
   ./test/main.cc \

--- a/iocore/cache/test/test_RWW.cc
+++ b/iocore/cache/test/test_RWW.cc
@@ -275,7 +275,7 @@ public:
     case VC_EVENT_ERROR:
     case VC_EVENT_EOS:
       if (this->_size == LARGE_FILE) {
-        REQUIRE(base->vio->ndone >= 1 * 1024 * 1024 - sizeof(Doc));
+        REQUIRE(base->vio->ndone >= int64_t(1 * 1024 * 1024 - sizeof(Doc)));
       } else {
         REQUIRE(base->vio->ndone == 0);
       }


### PR DESCRIPTION
```
PASS: test_Cache
PASS: test_RWW
PASS: test_Alternate_L_to_S
PASS: test_Alternate_S_to_L
PASS: test_Alternate_L_to_S_remove_L
PASS: test_Alternate_L_to_S_remove_S
PASS: test_Alternate_S_to_L_remove_S
PASS: test_Alternate_S_to_L_remove_L
PASS: test_Update_L_to_S
PASS: test_Update_S_to_L
PASS: test_Update_header
============================================================================
Testsuite summary for Apache Traffic Server 10.0.0
============================================================================
# TOTAL: 11
# PASS:  11
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

real    0m6.364s
user    0m5.691s
sys     0m31.733s
