### PR TITLE
Address issues with python 3.10

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -26,7 +26,7 @@ pyflakes = "*"
 [packages]
 
 # Keep init.cli.ext updated with this required autest version.
-autest = "==1.10.0"
+autest = "==1.10.1"
 
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 hyper = "*"

--- a/tests/gold_tests/autest-site/ordered_set_queue.py
+++ b/tests/gold_tests/autest-site/ordered_set_queue.py
@@ -20,6 +20,11 @@ Implement an OrderedSetQueue
 
 import collections
 try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
+try:
     import queue as Queue
 except ImportError:
     import Queue
@@ -30,7 +35,7 @@ except ImportError:
 # https://code.activestate.com/recipes/576694/
 #
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collectionsAbc.MutableSet):
 
     def __init__(self, iterable=None):
         self.end = end = []


### PR DESCRIPTION
This PR updates AuTest to 1.10.1 which has fixes to python 3.10
Also a fix to an extension to Trafficserver that 