### PR TITLE
Default proxy.config.http.strict_uri_parsing to "2" (#8632)

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -1134,7 +1134,7 @@ mptcp
    An arbitrary string value that, if set, will be used to replace any request
    ``User-Agent`` header.
 
-.. ts:cv:: CONFIG proxy.config.http.strict_uri_parsing INT 0
+.. ts:cv:: CONFIG proxy.config.http.strict_uri_parsing INT 2
 
    Takes a value between 0 and 2.  ``0`` disables strict_uri_parsing.  Any character can appears
    in the URI.  ``1`` causes |TS| to return 400 Bad Request

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -354,7 +354,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.post.check.content_length.enabled", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.strict_uri_parsing", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.strict_uri_parsing", RECD_INT, "2", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   //       # Send http11 requests
   //       #

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -848,7 +848,7 @@ public:
   MgmtByte referer_filter_enabled  = 0;
   MgmtByte referer_format_redirect = 0;
 
-  MgmtByte strict_uri_parsing = 0;
+  MgmtByte strict_uri_parsing = 2;
 
   MgmtByte reverse_proxy_enabled = 0;
   MgmtByte url_remap_required    = 1;


### PR DESCRIPTION
Following up on Susan's #8012, this patch makes the default parsing
option "2", which enforces no white spaces in URL components.

(cherry picked from commit 03b063a9ebd7caeb7afd71a255f388fac9e54601)