### PR TITLE
ts_lua: change type in stats struct from 'int' to 'TSMgmtInt' to avoid overflow

### DIFF
--- a/plugins/lua/ts_lua.c
+++ b/plugins/lua/ts_lua.c
@@ -73,8 +73,8 @@ static char const *const ts_lua_g_stat_strs[] = {
 typedef struct {
   ts_lua_main_ctx *main_ctx_array;
 
-  int gc_kb;   // last collected gc in kb
-  int threads; // last collected number active threads
+  TSMgmtInt gc_kb;   // last collected gc in kb
+  TSMgmtInt threads; // last collected number active threads
 
   int stat_inds[TS_LUA_IND_SIZE]; // stats indices
 
@@ -184,8 +184,8 @@ collectStats(ts_lua_plugin_stats *const plugin_stats)
       ts_lua_ctx_stats *const stats = main_ctx->stats;
 
       TSMutexLock(stats->mutexp);
-      gc_kb_total += (TSMgmtInt)stats->gc_kb;
-      threads_total += (TSMgmtInt)stats->threads;
+      gc_kb_total += stats->gc_kb;
+      threads_total += stats->threads;
       TSMutexUnlock(stats->mutexp);
     }
   }


### PR DESCRIPTION
The logic for computing bytes from kb was being done as an 'int' type and not as a 'TSMgmtInt'