### PR TITLE
fix: properly process If-Range headers in client requests

### DIFF
--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -1363,7 +1363,8 @@ HttpTransactCache::match_response_to_request_conditionals(HTTPHdr *request, HTTP
 }
 
 /**
-  Validates the contents of If-range headers in client requests.
+  Validates the contents of If-range headers in client requests. The presence of Range
+  headers needs to be checked before calling this method.
 
   @return Whether the condition specified by If-range is met, if there is any.
     If there's no If-range header, then true.
@@ -1372,7 +1373,7 @@ HttpTransactCache::match_response_to_request_conditionals(HTTPHdr *request, HTTP
 bool
 HttpTransactCache::validate_ifrange_header_if_any(HTTPHdr *request, HTTPHdr *response)
 {
-  if (!(request->presence(MIME_PRESENCE_RANGE) && request->presence(MIME_PRESENCE_IF_RANGE))) {
+  if (!request->presence(MIME_PRESENCE_IF_RANGE)) {
     return true;
   }
 

--- a/proxy/http/HttpTransactCache.h
+++ b/proxy/http/HttpTransactCache.h
@@ -80,4 +80,6 @@ public:
 
   static HTTPStatus match_response_to_request_conditionals(HTTPHdr *ua_request, HTTPHdr *c_response,
                                                            ink_time_t response_received_time);
+
+  static bool validate_ifrange_header_if_any(HTTPHdr *ua_request, HTTPHdr *c_response);
 };

--- a/tests/gold_tests/headers/gold/range-200.gold
+++ b/tests/gold_tests/headers/gold/range-200.gold
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Server: ATS/``
+Cache-Control: max-age=``
+Last-Modified: Thu, 10 Feb 2022 00:00:00 GMT
+ETag: range
+Content-Length: 11
+Date: ``
+Age: ``
+Connection: keep-alive
+
+0123456789

--- a/tests/gold_tests/headers/gold/range-206-revalidated.gold
+++ b/tests/gold_tests/headers/gold/range-206-revalidated.gold
@@ -1,0 +1,12 @@
+HTTP/1.1 206 Partial Content
+Server: ATS/``
+Cache-Control: max-age=1
+Last-Modified: Thu, 10 Feb 2022 00:00:00 GMT
+Content-Length: 5
+Date: ``
+Etag: range
+Age: ``
+Content-Range: bytes 1-5/11
+Connection: keep-alive
+
+12345``

--- a/tests/gold_tests/headers/gold/range-206.gold
+++ b/tests/gold_tests/headers/gold/range-206.gold
@@ -1,0 +1,12 @@
+HTTP/1.1 206 Partial Content
+Server: ATS/``
+Cache-Control: max-age=300
+Last-Modified: Thu, 10 Feb 2022 00:00:00 GMT
+ETag: range
+Content-Length: 5
+Date: ``
+Age: ``
+Content-Range: bytes 1-5/11
+Connection: keep-alive
+
+12345``

--- a/tests/gold_tests/headers/gold/range-416.gold
+++ b/tests/gold_tests/headers/gold/range-416.gold
@@ -1,0 +1,6 @@
+HTTP/1.1 416 Requested Range Not Satisfiable
+Date: ``
+Connection: keep-alive
+Server: ATS/``
+Cache-Control: no-store
+``

--- a/tests/gold_tests/headers/range.test.py
+++ b/tests/gold_tests/headers/range.test.py
@@ -1,0 +1,229 @@
+"""
+"""
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = """
+Test range requests
+"""
+
+Test.ContinueOnFail = True
+
+CACHE_SHORT_MAXAGE = 1
+
+
+def register(microserver, request_hdr, request_body, response_hdr, response_body):
+    request = {
+        "headers": "{}\r\n\r\n".format(
+            "\r\n".join(line for line in request_hdr.split("\n") if line)
+        ),
+        "timestamp": "1469733493.993",
+        "body": request_body,
+    }
+    response = {
+        "headers": "{}\r\n\r\n".format(
+            "\r\n".join(line for line in response_hdr.split("\n") if line)
+        ),
+        "timestamp": "1469733493.993",
+        "body": response_body,
+    }
+    microserver.addResponse("sessionlog.json", request, response)
+
+
+def curl_whole(ts, path=""):
+    return f"curl -sSv -D - http://127.0.0.1:{ts.Variables.port}/{path}"
+
+
+def curl_range(ts, path="", ifrange=None, start=1, end=5):
+    opt = f"-H 'If-Range: {ifrange}'" if ifrange else ""
+    return f"curl -sSv -D - {opt} -H 'Range: bytes={start}-{end}' http://127.0.0.1:{ts.Variables.port}/{path}"
+
+
+# ----
+# Setup Origin Server
+# ----
+microserver = Test.MakeOriginServer("microserver")
+
+request_hdr = """
+GET / HTTP/1.1
+Host: 127.0.0.1
+"""
+
+response_hdr = """
+HTTP/1.1 200 OK
+Server: microserver
+Connection: close
+Cache-Control: max-age=300
+Last-Modified: Thu, 10 Feb 2022 00:00:00 GMT
+ETag: range
+"""
+
+short_cache_request_hdr = """
+GET /short HTTP/1.1
+Host: 127.0.0.1
+"""
+
+short_cache_response_hdr = f"""
+HTTP/1.1 200 OK
+Server: microserver
+Connection: close
+Cache-Control: max-age={CACHE_SHORT_MAXAGE}
+Last-Modified: Thu, 10 Feb 2022 00:00:00 GMT
+ETag: range
+"""
+
+response_body = f"{''.join(str(i) for i in range(10))}\n"
+
+register(microserver, request_hdr, "", response_hdr, response_body)
+register(
+    microserver, short_cache_request_hdr, "", short_cache_response_hdr, response_body
+)
+
+# The purpose here is to have a somewhat smarter origin that can respond to If-Modified-Since queries.
+# We then can test how the cache server using this origin deals with stale caches.
+origin = Test.MakeATSProcess("origin")
+
+origin.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{microserver.Variables.Port}")
+
+origin.Disk.records_config.update(
+    {
+        "proxy.config.http.cache.http": 1,
+        "proxy.config.http.wait_for_cache": 1,
+        "proxy.config.http.insert_age_in_response": 0,
+        "proxy.config.http.request_via_str": 0,
+        "proxy.config.http.response_via_str": 0,
+        "proxy.config.diags.debug.enabled": 1,
+        "proxy.config.diags.debug.tags": "http",
+    }
+)
+
+# Make the origin return 304 Not Modified for stale caches
+origin.Disk.cache_config.AddLine("dest_ip=127.0.0.1 pin-in-cache=1d")
+
+# ----
+# Setup ATS
+# ----
+# HACK: Don't use a fixed port because it causes ensuing tests to fail. The problem
+# appears to be microDNS not allowing address reuse.
+#
+# https://docs.python.org/3/library/socketserver.html#socketserver.BaseServer.allow_reuse_address
+ts = Test.MakeATSProcess("ts")
+
+ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{origin.Variables.port}/")
+
+ts.Disk.records_config.update(
+    {
+        "proxy.config.http.cache.http": 1,
+        "proxy.config.http.cache.range.write": 1,
+        "proxy.config.http.response_via_str": 3,
+        "proxy.config.http.wait_for_cache": 1,
+        "proxy.config.diags.debug.enabled": 1,
+        "proxy.config.diags.debug.tags": "http",
+    }
+)
+# ----
+# Test Cases
+# ----
+
+# On cache miss
+# ---
+
+# ATS should ignore the Range header when given an If-Range header with the incorrect etag
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, ifrange='"should-not-match"')
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(
+    microserver, ready=When.PortOpen(microserver.Variables.Port)
+)
+tr.Processes.Default.StartBefore(origin, ready=When.PortOpen(origin.Variables.port))
+tr.Processes.Default.StartBefore(
+    Test.Processes.ts, ready=When.PortOpen(ts.Variables.port)
+)
+tr.Processes.Default.Streams.stdout = "gold/range-200.gold"
+
+# On cache hit
+# ---
+
+# ATS should respond to Range requests with partial content
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-206.gold"
+
+# ATS should respond to Range requests with partial content when given an If-Range header with
+# the correct etag
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, ifrange='"range"')
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-206.gold"
+
+# ATS should respond to Range requests with partial content when given an If-Range header
+# that matches the Last-Modified header of the cached response
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, ifrange="Thu, 10 Feb 2022 00:00:00 GMT")
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-206.gold"
+
+# ATS should respond to Range requests with the full content when given an If-Range header
+# that doesn't match the Last-Modified header of the cached response
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, ifrange="Thu, 10 Feb 2022 01:00:00 GMT")
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-200.gold"
+
+# ATS should respond to Range requests with a 416 error code when the given Range is invalid
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, start=100, end=105)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-416.gold"
+
+# ATS should ignore the Range header when given an If-Range header with the incorrect etag
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, ifrange='"should-not-match"')
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-200.gold"
+
+# ATS should ignore the Range header when given an If-Range header with weak etags
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, ifrange='W/"range"')
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-200.gold"
+
+# ATS should ignore the Range header when given an If-Range header with a date older than the
+# Last-Modified header of the cached response
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_range(ts, ifrange="Wed, 09 Feb 2022 23:00:00 GMT")
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-200.gold"
+
+# Write to the cache by requesting the entire content
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = curl_whole(ts, path="short")
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-200.gold"
+
+# ATS should respond to range requests with partial content for stale caches in response to
+# valid If-Range requests if the origin responds with 304 Not Modified.
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = f"sleep {2 * CACHE_SHORT_MAXAGE}; " + curl_range(
+    ts, path="short", ifrange='"range"'
+)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/range-206-revalidated.gold"
+
+tr.StillRunningAfter = origin
+tr.StillRunningAfter = microserver
+tr.StillRunningAfter = ts


### PR DESCRIPTION
# Problem
ATS doesn't respond correctly to conditional range requests. According to [the spec][1], ATS must ignore the `Range` header and send back the full content when the condition in the `If-Range` header isn't satisified. ATS responds with `416 Requested Range Not Satisfiable` instead.

# How to reproduce
1. Prepare a cacheable HTTP endpoint for ATS (e.g., http://localhost/)
2. Launch ATS
3. Send a normal request for the entire content so that it'd be cached in ATS (e.g., `curl -vv http://localhost`)
4. Send a conditional range request for the cached content. Specify a weak etag so that it'd fail to meet the requirements needed to receive a partial response. (e.g., `curl -vv -H 'If-Range: W/"this_wont_match"' http://localhost`)

# Cause
ATS validates `If-Range` headers in `match_response_to_request_conditionals()`. If the condition specified in `If-Range` isn't met, `match_response_to_request_conditionals()` returns a response code of `HTTP_STATUS_RANGE_NOT_SATISFIABLE`. However, ATS can't determine whether a `HTTP_STATUS_RANGE_NOT_SATISFIABLE` response code came from `match_response_to_request_conditionals()` or the response of the original content. This confusion led ATS to return incorrect responses to conditional range requests.

# Changes made
- Move the `If-Range` header validation code out of `match_response_to_request_conditionals()` so that it would run right before processing the `Range` header. This makes it easier to determine the correct response.
- Add autest test cases to check how ATS responds to range requests.

[1]: https://datatracker.ietf.org/doc/html/rfc7233#section-3.2
