### PR TITLE
Fixes Issue #7824 - The strategies.yaml parser can incorrectly interpret

### DIFF
--- a/plugins/experimental/parent_select/strategy.cc
+++ b/plugins/experimental/parent_select/strategy.cc
@@ -401,11 +401,19 @@ template <> struct convert<PLNHProtocol> {
       } else if (node["scheme"].Scalar() == "https") {
         nh.scheme = PL_NH_SCHEME_HTTPS;
       } else {
-        nh.scheme = PL_NH_SCHEME_NONE;
+        throw YAML::ParserException(node["scheme"].Mark(), "no valid scheme defined, valid schemes are http or https");
       }
+    } else {
+      throw YAML::ParserException(node["scheme"].Mark(), "no scheme defined, valid schemes are http or https");
     }
     if (node["port"]) {
       nh.port = node["port"].as<int>();
+      if (nh.port <= 0 || nh.port > 65535) {
+        throw YAML::ParserException(node["port"].Mark(), "port number must be in (inclusive) range 1 - 65,536");
+      }
+    } else {
+      throw YAML::ParserException(node["port"].Mark(),
+                                  "no port is defined, a port number must be defined within (inclusive) range 1 - 65,536");
     }
     if (node["health_check_url"]) {
       nh.health_check_url = node["health_check_url"].Scalar();

--- a/proxy/http/remap/NextHopSelectionStrategy.cc
+++ b/proxy/http/remap/NextHopSelectionStrategy.cc
@@ -393,13 +393,19 @@ template <> struct convert<NHProtocol> {
       } else if (map["scheme"].Scalar() == "https") {
         nh.scheme = NH_SCHEME_HTTPS;
       } else {
-        nh.scheme = NH_SCHEME_NONE;
+        throw YAML::ParserException(map["scheme"].Mark(), "no valid scheme defined, valid schemes are http or https");
       }
+    } else {
+      throw YAML::ParserException(map["scheme"].Mark(), "no scheme defined, valid schemes are http or https");
     }
     if (map["port"]) {
       nh.port = map["port"].as<int>();
-      if ((nh.port <= 0) || (nh.port > 65535)) {
-        throw YAML::ParserException(map["port"].Mark(), "port number must be in (inclusive) range 0 - 65,536");
+      if (nh.port <= 0 || nh.port > 65535) {
+        throw YAML::ParserException(map["port"].Mark(), "port number must be in (inclusive) range 1 - 65,536");
+      }
+    } else {
+      if (nh.port == 0) {
+        throw YAML::ParserException(map["port"].Mark(), "no port defined must be in (inclusive) range 1 - 65,536");
       }
     }
     if (map["health_check_url"]) {


### PR DESCRIPTION
Fixes Issue #7824 - The strategies.yaml parser can incorrectly interpret the YAML elements in the host protocol in both core and the parent_select plugin.