### PR TITLE
marks the HostStatusGetRequest::get_method as an override.

### DIFF
--- a/src/traffic_ctl_jsonrpc/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl_jsonrpc/jsonrpc/CtrlRPCRequests.h
@@ -145,7 +145,7 @@ struct HostGetStatusRequest : shared::rpc::ClientRequest {
   HostGetStatusRequest(Params p) { super::params = std::move(p); }
 
   std::string
-  get_method() const
+  get_method() const override
   {
     return "admin_host_get_status";
   }


### PR DESCRIPTION
marks the HostStatus GetRequest::get_method as an override, now required from PR #8737 #8740