### PR TITLE
Use Sphinx 4.x

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -23,14 +23,7 @@ verify_ssl = true
 
 [packages]
 
-# The latest 4.x sphinx release, currently 4.0.2, fails `make html`.  For
-# details, see: https://github.com/apache/trafficserver/issues/7938
-#
-# The 3.x releases build fine, however. So we currently pin to that.
-#
-# Once that issue, either with sphinx or our docs, is resolved, then we should
-# unpin sphinx by setting the following to "*".
-sphinx = "==3.*"
+sphinx = "*"
 
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"

--- a/doc/developer-guide/api/types/TSSslSession.en.rst
+++ b/doc/developer-guide/api/types/TSSslSession.en.rst
@@ -28,6 +28,8 @@ Synopsis
 
     #include <ts/apidefs.h>
 
+.. c:macro:: TS_SSL_MAX_SSL_SESSION_ID_LENGTH
+
 .. type:: TSSslSessionID
 
    .. member:: size_t len


### PR DESCRIPTION
Sphinx has fixed the following issue that was blocking us from moving to
Sphinx 4.x:
https://github.com/sphinx-doc/sphinx/issues/9322

With that fixed, we can unpin from 3.x, which this patch does.

Fixes: #7941