### PR TITLE
Revert "Use Sphinx 4.x"

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -23,7 +23,14 @@ verify_ssl = true
 
 [packages]
 
-sphinx = "*"
+# The latest 4.x sphinx release, currently 4.0.2, fails `make html`.  For
+# details, see: https://github.com/apache/trafficserver/issues/7938
+#
+# The 3.x releases build fine, however. So we currently pin to that.
+#
+# Once that issue, either with sphinx or our docs, is resolved, then we should
+# unpin sphinx by setting the following to "*".
+sphinx = "==3.*"
 
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"

--- a/doc/developer-guide/api/types/TSSslSession.en.rst
+++ b/doc/developer-guide/api/types/TSSslSession.en.rst
@@ -28,8 +28,6 @@ Synopsis
 
     #include <ts/apidefs.h>
 
-.. c:macro:: TS_SSL_MAX_SSL_SESSION_ID_LENGTH
-
 .. type:: TSSslSessionID
 
    .. member:: size_t len


### PR DESCRIPTION
Reverts apache/trafficserver#8750

Reverting because this breaks the rendering of our docs. The build succeeds, but the css seems broken. This will need to be investigated further. For now I'll simply revert this for later investigation.