### PR TITLE
Use Sphinx 4.x (second attempt)

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -23,14 +23,7 @@ verify_ssl = true
 
 [packages]
 
-# The latest 4.x sphinx release, currently 4.0.2, fails `make html`.  For
-# details, see: https://github.com/apache/trafficserver/issues/7938
-#
-# The 3.x releases build fine, however. So we currently pin to that.
-#
-# Once that issue, either with sphinx or our docs, is resolved, then we should
-# unpin sphinx by setting the following to "*".
-sphinx = "==3.*"
+sphinx = "*"
 
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -280,6 +280,7 @@ html_static_path = ['static']
 # content wrapping.
 html_context = {
     'css_files': [
+        '_static/css/theme.css',
         '_static/override.css'
     ]
 }

--- a/doc/developer-guide/api/types/TSSslSession.en.rst
+++ b/doc/developer-guide/api/types/TSSslSession.en.rst
@@ -28,6 +28,8 @@ Synopsis
 
     #include <ts/apidefs.h>
 
+.. c:macro:: TS_SSL_MAX_SSL_SESSION_ID_LENGTH
+
 .. type:: TSSslSessionID
 
    .. member:: size_t len


### PR DESCRIPTION
This is a second attempt to upgrade to Sphinx 4.x. The first was #8750.
It was noticed, however, that the new Sphinx didn't automatically
deliver the theme.css file. This updates the conf.py file to make the
addition of theme.css explicit.