### PR TITLE
Avoid allocation when matching hosts for vol lookup

### DIFF
--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -112,9 +112,7 @@ CacheHostMatcher::Match(const char *rdata, int rlen, CacheHostResult *result) co
     return;
   }
 
-  char *data = static_cast<char *>(ats_malloc(rlen + 1));
-  memcpy(data, rdata, rlen);
-  *(data + rlen) = '\0';
+  std::string_view data{rdata, static_cast<size_t>(rlen)};
   HostLookupState s;
 
   r = host_lookup->MatchFirst(data, &s, &opaque_ptr);
@@ -122,11 +120,10 @@ CacheHostMatcher::Match(const char *rdata, int rlen, CacheHostResult *result) co
   while (r == true) {
     ink_assert(opaque_ptr != nullptr);
     data_ptr = static_cast<CacheHostRecord *>(opaque_ptr);
-    data_ptr->UpdateMatch(result, data);
+    data_ptr->UpdateMatch(result);
 
     r = host_lookup->MatchNext(&s, &opaque_ptr);
   }
-  ats_free(data);
 }
 
 //
@@ -577,7 +574,7 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
 }
 
 void
-CacheHostRecord::UpdateMatch(CacheHostResult *r, char * /* rd ATS_UNUSED */)
+CacheHostRecord::UpdateMatch(CacheHostResult *r)
 {
   r->record = this;
 }

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -38,7 +38,7 @@ struct CacheHostRecord {
   int Init(CacheType typ);
   int Init(matcher_line *line_info, CacheType typ);
 
-  void UpdateMatch(CacheHostResult *r, char *rd);
+  void UpdateMatch(CacheHostResult *r);
   void Print() const;
 
   ~CacheHostRecord()


### PR DESCRIPTION
This avoids a malloc, free, memcpy and a scan for end of string (for string_view construction).

This call to `CacheHostMatcher::Match` could happen multiple times per request when a hosting.config is used.