### PR TITLE
Fix error handling in SSL cert/key load failures

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1427,7 +1427,6 @@ fail:
   ink_assert(ctx != nullptr);
   SSLMultiCertConfigLoader::clear_pw_references(ctx);
   SSL_CTX_free(ctx);
-  ret.emplace_back(SSLLoadingContext(ctx, ctx_type));
 
   return ret;
 }


### PR DESCRIPTION
Fix a use-after-free error when after encountering an error on SSL cert or key load.