### PR TITLE
Fixing the httpbin AuTests by pinning Werkzeug

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -43,5 +43,11 @@ microserver = ">=1.0.6"
 jsonschema = "*"
 python-jose = "*"
 
+# The latest version of Werkzeug (2.1.0) breaks httpbin because it removes
+# deprecated function `BaseResponse` that httpbin directly or indirectly
+# depends upon. Pinning Wekrzeug for now until httpbin or its dependencies is
+# updated for the changed API.
+Werkzeug = "==2.0.3"
+
 [requires]
 python_version = "3"


### PR DESCRIPTION
The AuTests using httpbin all started failing today when new AuTest
pipenv environments started using the 2.1.0 version of Werkzeug. This
new Werkzeug release removes its BaseResponse API because it has been
deprecated for a few releases. httpbin has a dependency upon
BaseResponse, however, and thus it currently fails with this latest
Werkzeug release. This patch temporarily pins Werkzeug until httpbin is
updated so that our httpbin AuTests can run.