### PR TITLE
8.1.x: Fixing the httpbin AuTests by pinning Werkzeug

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -39,5 +39,11 @@ microserver = ">=1.0.6"
 jsonschema = "*"
 python-jose = "*"
 
+# The latest version of Werkzeug (2.1.0) breaks httpbin because it removes
+# deprecated function `BaseResponse` that httpbin directly or indirectly
+# depends upon. Pinning Wekrzeug for now until httpbin or its dependencies is
+# updated for the changed API.
+Werkzeug = "==2.0.3"
+
 [requires]
 python_version = "3"

--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -37,7 +37,13 @@ pip_packages = [
     "dnslib",
     "httpbin",
     "gunicorn",
-    "traffic-replay"  # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
+    "traffic-replay",  # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
+
+    # The latest version of Werkzeug (2.1.0) breaks httpbin because it removes
+    # deprecated function `BaseResponse` that httpbin directly or indirectly
+    # depends upon. Pinning Wekrzeug for now until httpbin or its dependencies
+    # is updated for the changed API.
+    "Werkzeug==2.0.3"
 ]
 
 


### PR DESCRIPTION
The AuTests using httpbin all started failing today when new AuTest
pipenv environments started using the 2.1.0 version of Werkzeug. This
new Werkzeug release removes its BaseResponse API because it has been
deprecated for a few releases. httpbin has a dependency upon
BaseResponse, however, and thus it currently fails with this latest
Werkzeug release. This patch temporarily pins Werkzeug until httpbin is
updated so that our httpbin AuTests can run.

This is a rebase of #8765 to 8.1.x.