### PR TITLE
Revert "Use Sphinx 4.x (second attempt) (#8757)"

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -23,7 +23,12 @@ verify_ssl = true
 
 [packages]
 
-sphinx = "*"
+# The latest 4.x sphinx release has issues with style rendering. The 3.x
+# releases build and render fine, however. So we currently pin to that.
+#
+# Once that issue, either with sphinx or our docs, is resolved, then we should
+# unpin sphinx by setting the following to "*".
+sphinx = "==3.*"
 
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -280,7 +280,6 @@ html_static_path = ['static']
 # content wrapping.
 html_context = {
     'css_files': [
-        '_static/css/theme.css',
         '_static/override.css'
     ]
 }


### PR DESCRIPTION
This reverts commit 4dbf9147c639afdc2d6e21b98218240563ea91d2.

In the previous attempt to use Sphinx 4.x, I tried to fix our CSS 4.x
rendering by explicitly adding theme.css to the css_files html_context.
That did indeed add the needed theme.css rendering to the various docs,
but there are still some artifacts that don't render correctly (such as
ts:cv parameters). Reverting 4.x for now since 3.x works fine and moving
to 4.x is turning out to be a bigger project than I expected.