### PR TITLE
Add metrics for loop detection.

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -149,6 +149,16 @@ HTTP Connection
 
    Tracks the number of client requests that did not have a request sent to the origin server because the origin server was marked dead.
 
+.. ts:stat:: global proxy.process.http.http_proxy_loop_detected integer
+   :type: counter
+
+   Counts the number of times a proxy loop was detected
+
+.. ts:stat:: global proxy.process.http.http_proxy_mh_loop_detected integer
+   :type: counter
+
+   Counts the number of times a multi-hop proxy loop was detected
+
 HTTP/2
 ------
 

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -495,6 +495,12 @@ register_stat_callbacks()
   RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.extension_method_requests", RECD_COUNTER, RECP_PERSISTENT,
                      (int)http_extension_method_requests_stat, RecRawStatSyncCount);
 
+  RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.http_proxy_loop_detected", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)http_proxy_loop_detected_stat, RecRawStatSyncCount);
+
+  RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.http_proxy_mh_loop_detected", RECD_COUNTER, RECP_PERSISTENT,
+                     (int)http_proxy_mh_loop_detected_stat, RecRawStatSyncCount);
+
   RecRegisterRawStat(http_rsb, RECT_PROCESS, "proxy.process.http.broken_server_connections", RECD_COUNTER, RECP_PERSISTENT,
                      (int)http_broken_server_connections_stat, RecRawStatSyncCount);
 

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -112,6 +112,8 @@ enum {
   http_purge_requests_stat,
   http_connect_requests_stat,
   http_extension_method_requests_stat,
+  http_proxy_loop_detected_stat,
+  http_proxy_mh_loop_detected_stat,
 
   http_completed_requests_stat,
   http_broken_server_connections_stat,

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6711,6 +6711,7 @@ HttpTransact::will_this_request_self_loop(State *s)
           break;
         }
         SET_VIA_STRING(VIA_ERROR_TYPE, VIA_ERROR_LOOP_DETECTED);
+        HTTP_INCREMENT_DYN_STAT(http_proxy_loop_detected_stat);
         build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Cycle Detected", "request#cycle_detected");
         return true;
       }
@@ -6744,6 +6745,7 @@ HttpTransact::will_this_request_self_loop(State *s)
     if (count > max_proxy_cycles) {
       TxnDebug("http_transact", "count = %d > max_proxy_cycles = %d : detected loop", count, max_proxy_cycles);
       SET_VIA_STRING(VIA_ERROR_TYPE, VIA_ERROR_LOOP_DETECTED);
+      HTTP_INCREMENT_DYN_STAT(http_proxy_mh_loop_detected_stat);
       build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Multi-Hop Cycle Detected", "request#cycle_detected");
       return true;
     } else {


### PR DESCRIPTION
Fixes #7900 

ATS detect loops and multi-hop loops.  I added separate metrics for these, but I can combine them if that is preferred.