### PR TITLE
Pin Jinja2 for doc builds

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -25,6 +25,10 @@ verify_ssl = true
 
 sphinx = "*"
 
+# Sphinx 3.x builds break with the latest jinja2. This jinja2 pin can be
+# removed when we move to Sphinx 4.x.
+jinja2 = "<3.1"
+
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 # i18n


### PR DESCRIPTION
The latest jinja2 breaks Sphinx 3.x builds. For now, pinning jinja2 to
an earlier release for doc builds.