### PR TITLE
Add autest to cover updates to cache with alternates

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -454,6 +454,8 @@ CacheVC::set_http_info(CacheHTTPInfo *ainfo)
   MIMEField *field = ainfo->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
   if (field && !field->value_get_int64()) {
     f.allow_empty_doc = 1;
+    // Set the object size here to zero in case this is a cache replace where the new object
+    // length is zero but the old object was not.
     ainfo->object_size_set(0);
   } else {
     f.allow_empty_doc = 0;

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -454,6 +454,7 @@ CacheVC::set_http_info(CacheHTTPInfo *ainfo)
   MIMEField *field = ainfo->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
   if (field && !field->value_get_int64()) {
     f.allow_empty_doc = 1;
+    ainfo->object_size_set(0);
   } else {
     f.allow_empty_doc = 0;
   }

--- a/tests/gold_tests/cache/alternate-caching.test.py
+++ b/tests/gold_tests/cache/alternate-caching.test.py
@@ -1,0 +1,52 @@
+'''
+Test the alternate caching features
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test the alternate caching feature.
+'''
+
+#
+# Verify disabled negative_revalidating behavior.
+#
+ts = Test.MakeATSProcess("ts-alternate-caching")
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http|cache',
+
+    'proxy.config.http.cache.max_stale_age': 6,
+    'proxy.config.cache.select_alternate': 1,
+    'proxy.config.cache.limits.http.max_alts': 4,
+
+    # Try with and without this
+    'proxy.config.http.negative_revalidating_enabled': 1,
+    'proxy.config.http.negative_caching_enabled': 1,
+    'proxy.config.http.negative_caching_lifetime': 30
+
+})
+tr = Test.AddTestRun("Verify disabled negative revalidating behavior.")
+replay_file = "replay/alternate-caching-update-size.yaml"
+server = tr.AddVerifierServerProcess("server1", replay_file)
+server_port = server.Variables.http_port
+tr.AddVerifierClientProcess("client1", replay_file, http_ports=[ts.Variables.port])
+ts.Disk.remap_config.AddLine(
+    'map / http://127.0.0.1:{0}'.format(server_port)
+)
+tr.Processes.Default.StartBefore(ts)
+tr.StillRunningAfter = ts
+

--- a/tests/gold_tests/cache/alternate-caching.test.py
+++ b/tests/gold_tests/cache/alternate-caching.test.py
@@ -49,4 +49,3 @@ ts.Disk.remap_config.AddLine(
 )
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = ts
-

--- a/tests/gold_tests/cache/replay/alternate-caching-update-size.yaml
+++ b/tests/gold_tests/cache/replay/alternate-caching-update-size.yaml
@@ -52,6 +52,7 @@ meta:
 
 sessions:
 - transactions:
+  # These first two requests just store the two alternats for this url
   - all: { headers: { fields: [[ uuid, 1 ]]}}
     <<: *request_for_en_US
 
@@ -62,7 +63,7 @@ sessions:
         fields:
         - [ Content-Length, 16 ]
         - [ Cache-Control, max-age=4 ]
-        - [ Content-Language, en-US ]
+        - [ Content-Language, en_US ]
         - [ Vary, Accept-Language ]
 
 
@@ -78,12 +79,13 @@ sessions:
         fields:
         - [ Content-Length, 20 ]
         - [ Cache-Control, max-age=4 ]
-        - [ Content-Language, es-US ]
+        - [ Content-Language, es_US ]
         - [ Vary, Accept-Language ]
 
     proxy-response:
       status: 200
 
+  # This request serves as a way to introduce a 5 second delay so we can replace the cache objects
   - all: { headers: { fields: [[ uuid, 3 ]]}}
     client-request:
       method: "GET"
@@ -106,6 +108,7 @@ sessions:
     proxy-response:
       status: 200
 
+  # Replace the es_US alternate (this works fine)
   - all: { headers: { fields: [[ uuid, 4 ]]}}
     <<: *request_for_es_US
 
@@ -116,12 +119,13 @@ sessions:
         fields:
         - [ Content-Length, 0 ]
         - [ Cache-Control, max-age=10 ]
-        - [ Content-Language, es-US ]
+        - [ Content-Language, es_US ]
         - [ Vary, Accept-Language ]
 
     proxy-response:
       status: 404
 
+  # Replace the en_US alternate (this request breaks the cache)
   - all: { headers: { fields: [[ uuid, 5 ]]}}
     <<: *request_for_en_US
 
@@ -132,12 +136,13 @@ sessions:
         fields:
         - [ Content-Length, 0 ]
         - [ Cache-Control, max-age=10 ]
-        - [ Content-Language, en-US ]
+        - [ Content-Language, en_US ]
         - [ Vary, Accept-Language ]
 
     proxy-response:
       status: 404
 
+  # Expect a CL 0 response, but the server returns a chunked encoded, 16 byte response
   - all: { headers: { fields: [[ uuid, 6 ]]}}
     <<: *request_for_en_US
 

--- a/tests/gold_tests/cache/replay/alternate-caching-update-size.yaml
+++ b/tests/gold_tests/cache/replay/alternate-caching-update-size.yaml
@@ -62,7 +62,7 @@ sessions:
       headers:
         fields:
         - [ Content-Length, 16 ]
-        - [ Cache-Control, max-age=4 ]
+        - [ Cache-Control, max-age=1 ]
         - [ Content-Language, en_US ]
         - [ Vary, Accept-Language ]
 
@@ -78,7 +78,7 @@ sessions:
       headers:
         fields:
         - [ Content-Length, 20 ]
-        - [ Cache-Control, max-age=4 ]
+        - [ Cache-Control, max-age=1 ]
         - [ Content-Language, es_US ]
         - [ Vary, Accept-Language ]
 
@@ -97,14 +97,13 @@ sessions:
         - [ Host, example.com ]
         - [ Accept, "*/*" ]
         - [ Accept-Language, es_US ]
-      delay: 5s
+      delay: 2s
     server-response:
       status: 500
       reason: NOT USED
       headers:
         fields:
         - [ Content-Length, 20 ]
-        - [ Cache-Control, max-age=10 ]
     proxy-response:
       status: 200
 
@@ -135,7 +134,7 @@ sessions:
       headers:
         fields:
         - [ Content-Length, 0 ]
-        - [ Cache-Control, max-age=10 ]
+        - [ Cache-Control, max-age=1 ]
         - [ Content-Language, en_US ]
         - [ Vary, Accept-Language ]
 
@@ -152,7 +151,7 @@ sessions:
       headers:
         fields:
         - [ Content-Length, 0 ]
-        - [ Cache-Control, max-age=10 ]
+        - [ Cache-Control, max-age=1 ]
 
     proxy-response:
       status: 404

--- a/tests/gold_tests/cache/replay/alternate-caching-update-size.yaml
+++ b/tests/gold_tests/cache/replay/alternate-caching-update-size.yaml
@@ -1,0 +1,158 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# Verify negative_revalidating disabled behavior. This replay file assumes:
+#   * ATS is configured with negative_revalidating disabled.
+#   * max_stale_age is set to 6 seconds.
+#
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - request_for_positive_max_age: &request_for_en_US
+      client-request:
+        method: "GET"
+        version: "1.1"
+        scheme: "http"
+        url: /path/request
+        headers:
+          fields:
+          - [ Host, example.com ]
+          - [ Accept, "*/*" ]
+          - [ Accept-Language, en_US ]
+        delay: 100ms
+
+  - request_for_positive_max_age: &request_for_es_US
+      client-request:
+        method: "GET"
+        version: "1.1"
+        scheme: "http"
+        url: /path/request
+        headers:
+          fields:
+          - [ Host, example.com ]
+          - [ Accept, "*/*" ]
+          - [ Accept-Language, es_US ]
+        delay: 100ms
+
+sessions:
+- transactions:
+  - all: { headers: { fields: [[ uuid, 1 ]]}}
+    <<: *request_for_en_US
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Cache-Control, max-age=4 ]
+        - [ Content-Language, en-US ]
+        - [ Vary, Accept-Language ]
+
+
+    proxy-response:
+      status: 200
+  - all: { headers: { fields: [[ uuid, 2 ]]}}
+    <<: *request_for_es_US
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 20 ]
+        - [ Cache-Control, max-age=4 ]
+        - [ Content-Language, es-US ]
+        - [ Vary, Accept-Language ]
+
+    proxy-response:
+      status: 200
+
+  - all: { headers: { fields: [[ uuid, 3 ]]}}
+    client-request:
+      method: "GET"
+      version: "1.1"
+      scheme: "http"
+      url: /path/request
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ Accept, "*/*" ]
+        - [ Accept-Language, es_US ]
+      delay: 5s
+    server-response:
+      status: 500
+      reason: NOT USED
+      headers:
+        fields:
+        - [ Content-Length, 20 ]
+        - [ Cache-Control, max-age=10 ]
+    proxy-response:
+      status: 200
+
+  - all: { headers: { fields: [[ uuid, 4 ]]}}
+    <<: *request_for_es_US
+
+    server-response:
+      status: 404
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ Cache-Control, max-age=10 ]
+        - [ Content-Language, es-US ]
+        - [ Vary, Accept-Language ]
+
+    proxy-response:
+      status: 404
+
+  - all: { headers: { fields: [[ uuid, 5 ]]}}
+    <<: *request_for_en_US
+
+    server-response:
+      status: 404
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ Cache-Control, max-age=10 ]
+        - [ Content-Language, en-US ]
+        - [ Vary, Accept-Language ]
+
+    proxy-response:
+      status: 404
+
+  - all: { headers: { fields: [[ uuid, 6 ]]}}
+    <<: *request_for_en_US
+
+    server-response:
+      status: 500
+      reason: NOT USED
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ Cache-Control, max-age=10 ]
+
+    proxy-response:
+      status: 404
+      headers:
+        fields:
+          - [ Content-Length, { value: "0", as: equal} ]
+
+


### PR DESCRIPTION
This autest demonstrates an issue with cache alternates and updating from a response with a content-length to one with content-length 0.

When an alternate is replaced, and previously had a content-length, there is a bug where then old content is preserved and only this headers are changed (and the new 0-length content is not "written").  When this half-updated asset is served from cache, the content length is mismatched, delivered via chunked encoding and the old contents are shipped to the client.
