### PR TITLE
Fixes the cache unit tests by removing an undeclared class function.

### DIFF
--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -179,11 +179,6 @@ HostStatus::getHostStatus(const std::string_view name)
   return nullptr;
 }
 
-void
-HostStatus::createHostStat(const std::string_view name, const char *data)
-{
-}
-
 HostStatus::HostStatus() {}
 
 HostStatus::~HostStatus() {}


### PR DESCRIPTION
Fixes the cache unit tests on the 10-Dev branch by removing an undeclared class function HostStatus::createHostStat(), that was removed with PR #8689 