### PR TITLE
include <cstring> for access to C-string operations

### DIFF
--- a/plugins/experimental/icap/icap_plugin.cc
+++ b/plugins/experimental/icap/icap_plugin.cc
@@ -26,6 +26,7 @@
 */
 
 #include <string>
+#include <cstring>
 #include <regex>
 
 #include <netinet/in.h>

--- a/plugins/experimental/redo_cache_lookup/redo_cache_lookup.cc
+++ b/plugins/experimental/redo_cache_lookup/redo_cache_lookup.cc
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <regex>
+#include <cstring>
 #include <set>
 #include <sstream>
 #include <getopt.h>


### PR DESCRIPTION
GCC 12 (libstdc++12) no longer provides strlen() via \<string>; these files must #include \<cstring> to build on Fedora 36 and later.

Also, hello!  I am planning to be the Fedora/EPEL package maintainer for ATS.  I'll introduce myself on the mailing list once I have a successfully building Copr repo.