### PR TITLE
MiMalloc nodump allocator

### DIFF
--- a/build/mimalloc.m4
+++ b/build/mimalloc.m4
@@ -52,6 +52,7 @@ AC_ARG_WITH([mimalloc], [AS_HELP_STRING([--with-mimalloc=DIR],[use a specific mi
 ])
 
 mimalloch=0
+mimalloc_libs=""
 if test "$has_mimalloc" != "no"; then
   saved_ldflags=$LDFLAGS
   saved_cppflags=$CPPFLAGS
@@ -82,7 +83,10 @@ if test "$has_mimalloc" != "no"; then
           #endif
         ]
       )],
-      [mimalloch=1],
+      [
+        mimalloch=1
+        mimalloc_libs="-lmimalloc"
+      ],
       [AC_MSG_ERROR(mimalloc has bogus version)]
     )
   else
@@ -92,4 +96,5 @@ if test "$has_mimalloc" != "no"; then
   fi
 fi
 AC_SUBST(mimalloch)
+AC_SUBST([mimalloc_libs])
 ])

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -103,7 +103,7 @@ libtscore_la_SOURCES = \
 	ink_uuid.cc \
 	IpMap.cc \
 	IpMapConf.cc \
-	JeAllocator.cc \
+	JeMiAllocator.cc \
 	Layout.cc \
 	llqueue.cc \
 	lockfile.cc \

--- a/src/tscore/ink_queue.cc
+++ b/src/tscore/ink_queue.cc
@@ -51,7 +51,7 @@
 #include "tscore/ink_align.h"
 #include "tscore/hugepages.h"
 #include "tscore/Diags.h"
-#include "tscore/JeAllocator.h"
+#include "tscore/JeMiAllocator.h"
 
 #define DEBUG_TAG "freelist"
 
@@ -66,7 +66,7 @@
 #define DEADBEEF
 #endif
 
-static auto jna = jearena::globalJemallocNodumpAllocator();
+static auto jma = je_mi_malloc::globalJeMiNodumpAllocator();
 
 struct ink_freelist_ops {
   void *(*fl_new)(InkFreeList *);
@@ -265,7 +265,7 @@ malloc_new(InkFreeList *f)
   void *newp = nullptr;
 
   if (f->alignment) {
-    newp = jna.allocate(f);
+    newp = jma.allocate(f);
   } else {
     newp = ats_malloc(f->type_size);
   }
@@ -328,7 +328,7 @@ static void
 malloc_free(InkFreeList *f, void *item)
 {
   if (f->alignment) {
-    jna.deallocate(f, item);
+    jma.deallocate(f, item);
   } else {
     ats_free(item);
   }


### PR DESCRIPTION
When building with MiMalloc, create a no dump heap for each thread, which should behave just like the custom no dump arena for jemalloc. Also updated the license of the file since this is now very different from what facebook had (which this was based on when it all started).

It would be great if @bryancall can run some benchmarks like the ones did for #7501.