### PR TITLE
Removes remaining vestiges to the backdoor port

### DIFF
--- a/doc/appendices/command-line/traffic_manager.en.rst
+++ b/doc/appendices/command-line/traffic_manager.en.rst
@@ -34,7 +34,6 @@ Description
 .. option:: --help
 .. option:: --nosyslog
 .. option:: --path FILE
-.. option:: --proxyBackDoor PORT
 .. option:: --proxyOff
 .. option:: --listenOff
 .. option:: --proxyPort PORT

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -69,7 +69,6 @@ public:
     /// Are frequent accepts expected?
     /// Default: @c false.
     bool frequent_accept;
-    bool backdoor;
 
     /// Socket receive buffer size.
     /// 0 => OS default.

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -320,7 +320,7 @@ NetAccept::do_blocking_accept(EThread *t)
       }
     }
     // check for throttle
-    if (!opt.backdoor && check_net_throttle(ACCEPT)) {
+    if (check_net_throttle(ACCEPT)) {
       check_throttle_warning(ACCEPT);
       // close the connection as we are in throttle state
       con.close();
@@ -437,7 +437,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
 
     if (likely(fd >= 0)) {
       // check for throttle
-      if (!opt.backdoor && check_net_throttle(ACCEPT)) {
+      if (check_net_throttle(ACCEPT)) {
         // close the connection as we are in throttle state
         con.close();
         NET_SUM_DYN_STAT(net_connections_throttled_in_stat, 1);

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -43,7 +43,6 @@ NetProcessor::AcceptOptions::reset()
   etype                 = ET_NET;
   localhost_only        = false;
   frequent_accept       = true;
-  backdoor              = false;
   recv_bufsize          = 0;
   send_bufsize          = 0;
   sockopt_flags         = 0;


### PR DESCRIPTION
* Majority of code was removed in #4866

* `--proxyBackDoor` argument removed from `traffic_manager` in #3609