### PR TITLE
10-Dev: gitignore updates for JSONRPC generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ src/traffic_cache_tool/traffic_cache_tool
 src/traffic_cop/traffic_cop
 src/traffic_crashlog/traffic_crashlog
 src/traffic_ctl/traffic_ctl
+src/traffic_ctl_jsonrpc/traffic_ctl
 src/traffic_layout/traffic_layout
 src/traffic_logcat/traffic_logcat
 src/traffic_logstats/traffic_logstats
@@ -155,6 +156,7 @@ plugins/esi/vars_test
 
 plugins/experimental/uri_signing/test_uri_signing
 
+mgmt2/rpc/overridable_txn_vars.cc
 mgmt/api/traffic_api_cli_remote
 mgmt/tools/traffic_mcast_snoop
 mgmt/tools/traffic_net_config


### PR DESCRIPTION
This updates the repository's .gitignore file to ignore the JSONRPC
traffic_ctl and the overridable_txn_vars.cc generated files.