### PR TITLE
Create clean exit path for traffic_manager on SIGTERM

### DIFF
--- a/src/traffic_manager/traffic_manager.cc
+++ b/src/traffic_manager/traffic_manager.cc
@@ -982,6 +982,8 @@ SignalHandler(int sig)
   case SIGXCPU:
   case SIGXFSZ:
     abort();
+  case SIGTERM:
+    ::exit(0);
   default:
     fprintf(stderr, "[TrafficManager] ==> signal #%d\n", sig);
     mgmt_log("[TrafficManager] ==> signal #%d\n", sig);


### PR DESCRIPTION
Since the removal of traffic_cop, it appears that there is no way to cause traffic_manager to exit cleanly.  SIGTERM causes the cleanup of child processes and a graceful shutdown, however still exits with code 15.  We can ignore this in the systemd unit file, but it's cleaner to have some path to a clean exit of traffic_manager.