### PR TITLE
9.2.x: Revert remap.config loading changes

### DIFF
--- a/proxy/ReverseProxy.cc
+++ b/proxy/ReverseProxy.cc
@@ -67,10 +67,9 @@ init_reverse_proxy()
 
   Note("%s loading ...", ts::filename::REMAP);
   if (!rewrite_table->load()) {
-    Warning("%s failed to load", ts::filename::REMAP);
-  } else {
-    Note("%s finished loading", ts::filename::REMAP);
+    Fatal("%s failed to load", ts::filename::REMAP);
   }
+  Note("%s finished loading", ts::filename::REMAP);
 
   REC_RegisterConfigUpdateFunc("proxy.config.url_remap.filename", url_rewrite_CB, (void *)FILE_CHANGED);
   REC_RegisterConfigUpdateFunc("proxy.config.proxy_name", url_rewrite_CB, (void *)TSNAME_CHANGED);

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -944,9 +944,15 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
 
   std::error_code ec;
   std::string content{ts::file::load(ts::file::path{path}, ec)};
-  if (ec.value()) {
-    Warning("Failed to open remapping configuration file %s - %s", path, strerror(ec.value()));
-    return false;
+  if (ec) {
+    switch (ec.value()) {
+    case ENOENT:
+      Warning("Can't open remapping configuration file %s - %s", path, strerror(ec.value()));
+      break;
+    default:
+      Error("Failed load remapping configuration file %s - %s", path, strerror(ec.value()));
+      return false;
+    }
   }
 
   Debug("url_rewrite", "[BuildTable] UrlRewrite::BuildTable()");

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -698,11 +698,9 @@ UrlRewrite::BuildTable(const char *path)
   temporary_redirects.hash_lookup.reset(new URLTable);
   forward_mappings_with_recv_port.hash_lookup.reset(new URLTable);
 
-  int zret = 0;
-
   if (!remap_parse_config(path, this)) {
     // XXX handle file reload error
-    zret = 3;
+    return 3;
   }
 
   // Destroy unused tables
@@ -730,7 +728,7 @@ UrlRewrite::BuildTable(const char *path)
     forward_mappings_with_recv_port.hash_lookup.reset(nullptr);
   }
 
-  return zret;
+  return 0;
 }
 
 /**


### PR DESCRIPTION
Revert "Short circuit remap reload when a valid remap file is not specified (#7782)"

This reverts commit d7847f23717d3a8be8341c244bbe1e27b2a6a77a.

This is being reverted from 9.2.x because changing remap.config loading
behavior was deemed too big a change to make within the 9.x releases.
See the discussion in #8802. These remap.config changes will be pursued
in the 10.x train.