### PR TITLE
Add TCP info from server socket

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -520,9 +520,23 @@ TCP-INFO
 ::
 
     cond %{<name>}
-        add-header @PropertyName "%{TCP-INFO}"
+        add-header @PropertyName "%{TCP-INFO:<part>}"
 
-This operation records TCP Info struct field values as an Internal remap as well as global header at the event hook specified by the condition. Supported hook conditions include TXN_START_HOOK, SEND_RESPONSE_HEADER_HOOK and TXN_CLOSE_HOOK in the Global plugin and REMAP_PSEUDO_HOOK, SEND_RESPONSE_HEADER_HOOK and TXN_CLOSE_HOOK in the Remap plugin. Conditions supported as request headers include TXN_START_HOOK and REMAP_PSEUDO_HOOK. The other conditions are supported as response headers. TCP Info fields currently recorded include rtt, rto, snd_cwnd and all_retrans. This operation is not supported on transactions originated within Traffic Server (for e.g using the |TS| :c:func:`TSHttpTxnIsInternal`)
+This operation records TCP Info struct field values as an Internal remap as well
+as global header at the event hook specified by the condition. Qualifiers can be
+used to specifiy TCP Info from either the client or server socket. Without any
+qualifiers specified, the client socket is defaulted. Supported hook
+conditions include SEND_RESPONSE_HEADER_HOOK, READ_REQUEST_HDR_HOOK,
+READ_RESPONSE_HDR_HOOK, SEND_REQUEST_HDR_HOOK, and TXN_CLOSE_HOOK. In addition,
+the Global plugin includes TXN_START_HOOK while the Remap plugin includes
+REMAP_PSEUDO_HOOK. Conditions supported as request headers include TXN_START_HOOK,
+REMAP_PSEUDO_HOOK, READ_REQUEST_HDR_HOOK and SEND_REQUEST_HDR_HOOK. The other
+conditions are supported as response headers. TCP Info fields currently recorded
+include rtt, rto, snd_cwnd and all_retrans. This operation is not supported on
+transactions originated within Traffic Server (for e.g using the |TS| :c:func:`TSHttpTxnIsInternal`)
+
+    %{TCP-INFO:CLIENT}    TCP Info values from client socket (default)
+    %{TCP-INFO:SERVER}    TCP Info values from server socket
 
 Condition Operands
 ------------------

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -535,8 +535,8 @@ conditions are supported as response headers. TCP Info fields currently recorded
 include rtt, rto, snd_cwnd and all_retrans. This operation is not supported on
 transactions originated within Traffic Server (for e.g using the |TS| :c:func:`TSHttpTxnIsInternal`)
 
-    %{TCP-INFO:CLIENT}    TCP Info values from client socket (default)
-    %{TCP-INFO:SERVER}    TCP Info values from server socket
+    %{TCP-INFO:INBOUND}    TCP Info values from client socket (default)
+    %{TCP-INFO:OUTBOUND}    TCP Info values from server socket
 
 Condition Operands
 ------------------

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1245,10 +1245,10 @@ ConditionTcpInfo::set_qualifier(const std::string &q)
 
   TSDebug(PLUGIN_NAME, "\tParsing %%{TCP-INFO:%s} qualifier", q.c_str());
 
-  if (q == "CLIENT") {
-    _tcp_qual = TCP_QUAL_CLIENT;
-  } else if (q == "SERVER") {
-    _tcp_qual = TCP_QUAL_SERVER;
+  if (q == "INBOUND") {
+    _tcp_qual = TCP_QUAL_INBOUND;
+  } else if (q == "OUTBOUND") {
+    _tcp_qual = TCP_QUAL_OUTBOUND;
   } else {
     TSError("[%s] Unknown TCP-INFO() qualifier: %s", PLUGIN_NAME, q.c_str());
   }
@@ -1267,10 +1267,10 @@ ConditionTcpInfo::append_value(std::string &s, Resources const &res)
   struct tcp_info info;
   socklen_t tcp_info_len = sizeof(info);
   switch (_tcp_qual) {
-  case TCP_QUAL_CLIENT:
+  case TCP_QUAL_INBOUND:
     tsSsn = TSHttpTxnClientFdGet(res.txnp, &fd);
     break;
-  case TCP_QUAL_SERVER:
+  case TCP_QUAL_OUTBOUND:
     tsSsn = TSHttpTxnServerFdGet(res.txnp, &fd);
     break;
   }

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -577,11 +577,15 @@ public:
   void operator=(const ConditionTcpInfo &) = delete;
 
   void initialize(Parser &p) override;
+  void set_qualifier(const std::string &q) override;
   void append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
   void initialize_hooks() override; // Return status only valid in certain hooks
+
+private:
+  TcpQualifiers _tcp_qual = TCP_QUAL_CLIENT;
 };
 
 // Cache Lookup Results

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -585,7 +585,7 @@ protected:
   void initialize_hooks() override; // Return status only valid in certain hooks
 
 private:
-  TcpQualifiers _tcp_qual = TCP_QUAL_CLIENT;
+  TcpQualifiers _tcp_qual = TCP_QUAL_INBOUND;
 };
 
 // Cache Lookup Results

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -95,8 +95,8 @@ enum NetworkSessionQualifiers {
 
 // TCP Info
 enum TcpQualifiers {
-  TCP_QUAL_CLIENT,
-  TCP_QUAL_SERVER,
+  TCP_QUAL_INBOUND,
+  TCP_QUAL_OUTBOUND,
 };
 
 class Statement

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -93,6 +93,12 @@ enum NetworkSessionQualifiers {
   NET_QUAL_STACK,       ///< Full protocol stack.
 };
 
+// TCP Info
+enum TcpQualifiers {
+  TCP_QUAL_CLIENT,
+  TCP_QUAL_SERVER,
+};
+
 class Statement
 {
 public:


### PR DESCRIPTION
Current tcpinfo condition from header_rewrite plugin only provides tcp info from the client socket. 
- Adding a CLIENT and SERVER qualifier within this condition will provide tcp info from both client and server sockets. This could be beneficial in getting more info on the server connection behavior