### PR TITLE
9.1.x: Unit test compiler and library run time fixes

### DIFF
--- a/iocore/net/quic/test/test_QUICPacket.cc
+++ b/iocore/net/quic/test/test_QUICPacket.cc
@@ -249,7 +249,8 @@ TEST_CASE("Sending Packet", "[quic]")
     CHECK(packet.is_crypto_packet());
 
     packet.store(buf, &len);
-    CHECK(len == packet.size() - 16);
+    // See above packet.size() CHECK: packet.size must be greater than 16.
+    CHECK(len == static_cast<size_t>(packet.size() - 16));
     CHECK(memcmp(buf, expected, len - 16) == 0);
   }
 

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -38,7 +38,7 @@ AM_CPPFLAGS += \
 	$(TS_INCLUDES) \
 	@YAMLCPP_INCLUDES@
 
-libtscore_la_LDFLAGS = -no-undefined -version-info @TS_LIBTOOL_VERSION@ @YAMLCPP_LDFLAGS@
+libtscore_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -version-info @TS_LIBTOOL_VERSION@ @YAMLCPP_LDFLAGS@
 libtscore_la_LIBADD = \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@HWLOC_LIBS@ \


### PR DESCRIPTION
This fixes a signed type warning and a library runtime warning in the unit
(Catch) tests.