### PR TITLE
Add support for caching complete responses to the cache range requests plugin

### DIFF
--- a/doc/admin-guide/plugins/cache_range_requests.en.rst
+++ b/doc/admin-guide/plugins/cache_range_requests.en.rst
@@ -185,6 +185,15 @@ status code is reset back to 206, which leads to the object not being cached.
 
 This option is useful when used with other plugins, such as Cache Promote.
 
+Cache Complete Responses
+------------------------
+
+.. option:: --cache-complete-responses
+.. option:: -r
+
+This option causes the plugin to cache complete responses (200 OK). By default,
+only 206 Partial Content responses are cached by this plugin; without this flag,
+any 200 OK observed will be marked as not cacheable.
 
 Configuration examples
 ======================

--- a/plugins/cache_range_requests/README.md
+++ b/plugins/cache_range_requests/README.md
@@ -79,12 +79,13 @@ X-CRR-IMS header support
     Consider using the header_rewrite plugin to protect the parent
 		from using this option as an attack vector against an origin.
 
-Object Cacheability:
+Object Cacheability
+
     Normally objects are forced into the cache by changing the status code in the
     response from the upstream host from 206 to 200. The default behavior is to
     perform this operation blindly without checking cacheability. Add the `-v`
     flag to cause the plugin to ensure the object is cacheable; when it is not,
-    the 206 status code is restored and the object will not be cached.
+    the status code is not changed to 200 and the object will not be cached.
 
     Global Plugin (plugin.config):
 
@@ -95,3 +96,19 @@ Object Cacheability:
 
       <from-url> <to-url> @plugin=cache_range_requests.so @pparam=--verify-cacheability
       <from-url> <to-url> @plugin=cache_range_requests.so @pparam=-v
+
+Caching Complete Responses
+
+    To enable caching of complete responses, that is, a 200 OK instead of a 206 Partial
+    Content response, add the `-r` flag to the plugin parameters. By default, complete
+    responses are marked as uncacheable.
+
+    Global Plugin (plugin.config):
+
+      cache_range_requests.so --cache-complete-responses
+      cache_range_requests.so -r
+
+    Remap Plugin (remap.config):
+
+      <from-url> <to-url> @plugin=cache_range_requests.so @pparam=--cache-complete-responses
+      <from-url> <to-url> @plugin=cache_range_requests.so @pparam=-r


### PR DESCRIPTION
* Adds support for caching full object responses.

* Refactored logic to be more efficient.

* Added new plugin parameter to relevant docs.