### PR TITLE
Fix `COMPRESSION_ERROR` on valid HPACK input

### DIFF
--- a/proxy/hdrs/HuffmanCodec.cc
+++ b/proxy/hdrs/HuffmanCodec.cc
@@ -165,14 +165,6 @@ huffman_decode(char *dst_start, const uint8_t *src, uint32_t src_len)
       current       = current->left;
       includes_zero = true;
     }
-
-    if (current->leaf_node == true) {
-      *dst_end = current->ascii_code;
-      ++dst_end;
-      current               = HUFFMAN_TREE_ROOT;
-      byte_boundary_crossed = 0;
-      includes_zero         = false;
-    }
     if (shift) {
       --shift;
     } else {
@@ -180,6 +172,13 @@ huffman_decode(char *dst_start, const uint8_t *src, uint32_t src_len)
       ++src;
       --src_len;
       ++byte_boundary_crossed;
+    }
+    if (current->leaf_node == true) {
+      *dst_end = current->ascii_code;
+      ++dst_end;
+      current               = HUFFMAN_TREE_ROOT;
+      byte_boundary_crossed = 0;
+      includes_zero         = false;
     }
     if (byte_boundary_crossed > 3) {
       return -1;

--- a/proxy/hdrs/test_Huffmancode.cc
+++ b/proxy/hdrs/test_Huffmancode.cc
@@ -171,6 +171,28 @@ encode_test()
   }
 }
 
+void
+decode_errors_test()
+{
+  const static struct {
+    char *input;
+    int input_len;
+  } test_cases[] = {
+    {(char *)"\x00", 1},
+    {(char *)"\xff", 1},
+    {(char *)"\x1f\xff", 2},
+    {(char *)"\xff\x9f\xff\xff\xff", 5},
+  };
+
+  for (unsigned int i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+    int dst_len = 2 * test_cases[i].input_len;
+    char *dst   = (char *)malloc(dst_len);
+    int len     = huffman_decode(dst, (uint8_t *)test_cases[i].input, test_cases[i].input_len);
+    assert(len == -1);
+    free(dst);
+  }
+}
+
 int
 main()
 {
@@ -180,6 +202,7 @@ main()
     random_test();
   }
   values_test();
+  decode_errors_test();
 
   hpack_huffman_fin();
 

--- a/proxy/hdrs/test_Huffmancode.cc
+++ b/proxy/hdrs/test_Huffmancode.cc
@@ -136,6 +136,12 @@ values_test()
 
     int bytes        = huffman_decode(dst_start, encoded_mapped.y, encoded_size);
     char ascii_value = i / 2;
+
+    // EOS is treated as invalid so check for an error
+    if (value == 0x3fffffff) {
+      assert(bytes == -1);
+      continue;
+    }
     assert(dst_start[0] == ascii_value);
     assert(bytes == 1);
   }
@@ -178,10 +184,7 @@ decode_errors_test()
     char *input;
     int input_len;
   } test_cases[] = {
-    {(char *)"\x00", 1},
-    {(char *)"\xff", 1},
-    {(char *)"\x1f\xff", 2},
-    {(char *)"\xff\x9f\xff\xff\xff", 5},
+    {(char *)"\x00", 1}, {(char *)"\xff", 1}, {(char *)"\x1f\xff", 2}, {(char *)"\xff\xae", 2}, {(char *)"\xff\x9f\xff\xff\xff", 5},
   };
 
   for (unsigned int i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {

--- a/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -73,22 +73,28 @@ TEST_CASE("XPACK_String", "[xpack]")
     uint32_t raw_string_len;
     uint8_t *encoded_field;
     int encoded_field_len;
-  } string_test_case[] = {{(char *)"", 0,
-                           (uint8_t *)"\x0"
-                                      "",
-                           1},
-                          {(char *)"custom-key", 10,
-                           (uint8_t *)"\xA"
-                                      "custom-key",
-                           11},
-                          {(char *)"", 0,
-                           (uint8_t *)"\x80"
-                                      "",
-                           1},
-                          {(char *)"custom-key", 10,
-                           (uint8_t *)"\x88"
-                                      "\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f",
-                           9}};
+  } string_test_case[] = {
+    {(char *)"", 0,
+     (uint8_t *)"\x0"
+                "",
+     1},
+    {(char *)"custom-key", 10,
+     (uint8_t *)"\xA"
+                "custom-key",
+     11},
+    {(char *)"", 0,
+     (uint8_t *)"\x80"
+                "",
+     1},
+    {(char *)"custom-key", 10,
+     (uint8_t *)"\x88"
+                "\x25\xa8\x49\xe9\x5b\xa9\x7d\x7f",
+     9},
+    {(char *)"cw Times New Roman_σ=1", 23,
+     (uint8_t *)"\x95"
+                "\x27\x85\x37\x9a\x92\xa1\x4d\x25\xf0\xa6\xd3\xd2\x3a\xa2\xff\xff\xf6\xff\xff\x44\x01",
+     22},
+  };
 
   SECTION("Encoding")
   {

--- a/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -65,32 +65,6 @@ TEST_CASE("XPACK_Integer", "[xpack]")
   }
 }
 
-TEST_CASE("huffman_decode", "[decoding_errors]")
-{
-  SECTION("Decoding")
-  {
-    hpack_huffman_init();
-    Arena arena;
-
-    const static struct {
-      char *input;
-      int input_len;
-    } test_cases[] = {
-      {(char *)"\x00", 1},
-      {(char *)"\xff", 1},
-      {(char *)"\x1f\xff", 2},
-      {(char *)"\xff\x9f\xff\xff\xff", 5},
-    };
-
-    for (unsigned int i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
-      int dst_len = 2 * test_cases[i].input_len;
-      char *dst   = arena.str_alloc(dst_len);
-      int len     = huffman_decode(dst, (uint8_t *)test_cases[i].input, test_cases[i].input_len);
-      REQUIRE(len == -1);
-    }
-  }
-}
-
 TEST_CASE("XPACK_String", "[xpack]")
 {
   // Example: custom-key: custom-header

--- a/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -65,6 +65,32 @@ TEST_CASE("XPACK_Integer", "[xpack]")
   }
 }
 
+TEST_CASE("huffman_decode", "[decoding_errors]")
+{
+  SECTION("Decoding")
+  {
+    hpack_huffman_init();
+    Arena arena;
+
+    const static struct {
+      char *input;
+      int input_len;
+    } test_cases[] = {
+      {(char *)"\x00", 1},
+      {(char *)"\xff", 1},
+      {(char *)"\x1f\xff", 2},
+      {(char *)"\xff\x9f\xff\xff\xff", 5},
+    };
+
+    for (unsigned int i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+      int dst_len = 2 * test_cases[i].input_len;
+      char *dst   = arena.str_alloc(dst_len);
+      int len     = huffman_decode(dst, (uint8_t *)test_cases[i].input, test_cases[i].input_len);
+      REQUIRE(len == -1);
+    }
+  }
+}
+
 TEST_CASE("XPACK_String", "[xpack]")
 {
   // Example: custom-key: custom-header


### PR DESCRIPTION
This fixes a bug that causes a valid http2 header value to be rejected with a `COMPRESSION_ERROR`:

With the test input I added, a leaf node is found exactly on a byte boundary. Because the leaf node check happens before the shift check, `byte_boundary_crossed` is set to 0, but then immediately incremented again. And because finding the next leaf node crosses three byte boundaries, we end up with 4 total and return an error. Reordering the checks fixes the issue.

Note: I wasn't able to run the whole test suite so I'm not sure if this breaks anything else.