### PR TITLE
Fix a compile error

### DIFF
--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -290,7 +290,7 @@ Vol::force_evacuate_head(Dir *evac_dir, int pinned)
 {
   auto bucket = dir_evac_bucket(evac_dir);
   if (!evac_bucket_valid(bucket)) {
-    DDebug("cache_evac", "dir_evac_bucket out of bounds, skipping evacuate: %ld(%d), %d, %d", bucket, evacuate_size,
+    DDebug("cache_evac", "dir_evac_bucket out of bounds, skipping evacuate: %" PRId64 "(%d), %d, %d", bucket, evacuate_size,
            (int)dir_offset(evac_dir), (int)dir_phase(evac_dir));
     return nullptr;
   }


### PR DESCRIPTION
The error was introduced by #8716. Probably need to be backported to 9.2.x.

```
Making all in cache
  CXX      CacheWrite.o
CacheWrite.cc:293:95: error: format specifies type 'long' but the argument has type 'long long' [-Werror,-Wformat]
    DDebug("cache_evac", "dir_evac_bucket out of bounds, skipping evacuate: %ld(%d), %d, %d", bucket, evacuate_size,
                                                                            ~~~               ^~~~~~
                                                                            %lld
```