### PR TITLE
Handle opentelemetry-cpp v1.3.0 upgrade for otel_tracer plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1792,7 +1792,7 @@ AC_CHECK_HEADERS([opentelemetry/trace/provider.h], [
   AC_CHECK_LIB([curl], [curl_version], [
     AC_CHECK_LIB([protobuf], [main], [
       AC_CHECK_LIB([opentelemetry_exporter_otlp_http], [main], [
-        AC_SUBST([OTEL_LIBS], [" -lopentelemetry_exporter_otlp_http -lopentelemetry_exporter_otlp_http_client -lopentelemetry_otlp_recordable -lopentelemetry_proto -lopentelemetry_trace -lopentelemetry_resources -lopentelemetry_version -lopentelemetry_common -lhttp_client_curl -lcurl -lprotobuf "])
+        AC_SUBST([OTEL_LIBS], [" -lopentelemetry_exporter_otlp_http -lopentelemetry_exporter_otlp_http_client -lopentelemetry_otlp_recordable -lopentelemetry_proto -lopentelemetry_trace -lopentelemetry_resources -lopentelemetry_version -lopentelemetry_common -lopentelemetry_http_client_curl -lcurl -lprotobuf "])
         AC_SUBST(has_otel, 1)
       ], [
         AC_SUBST([OTEL_LIBS], [""])

--- a/doc/admin-guide/plugins/otel_tracer.en.rst
+++ b/doc/admin-guide/plugins/otel_tracer.en.rst
@@ -82,9 +82,9 @@ opentelemetry-cpp
 ::
 
   cd
-  wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.2.0.tar.gz
-  tar zxvf v1.2.0.tar.gz
-  cd opentelemetry-cpp-1.2.0
+  wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.3.0.tar.gz
+  tar zxvf v1.3.0.tar.gz
+  cd opentelemetry-cpp-1.3.0
   mkdir build
   cd build
   cmake .. -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_JAEGER=OFF -DWITH_OTLP=ON -DWITH_OTLP_GRPC=OFF -DWITH_OTLP_HTTP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON


### PR DESCRIPTION
opentelemetry-cpp v1.3.0 was released a couple weeks back and added a prefix to one of its library. 

https://github.com/open-telemetry/opentelemetry-cpp/pull/1301

Thus we need to update the link library parameters for compiling the otel_tracer plugin