### PR TITLE
Fixes leak of sni config filename on load (#8821)

### DIFF
--- a/iocore/net/P_SSLSNI.h
+++ b/iocore/net/P_SSLSNI.h
@@ -99,7 +99,6 @@ typedef std::vector<actionElement> SNIList;
 typedef std::vector<NextHopItem> NextHopPropertyList;
 
 struct SNIConfigParams : public ConfigInfo {
-  char *sni_filename = nullptr;
   SNIList sni_action_list;
   NextHopPropertyList next_hop_list;
   YamlSNIConfig Y_sni;

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -154,14 +154,14 @@ SNIConfigParams::get(const std::string &servername) const
 int
 SNIConfigParams::Initialize()
 {
-  sni_filename = ats_stringdup(RecConfigReadConfigPath("proxy.config.ssl.servername.filename"));
+  std::string sni_filename = RecConfigReadConfigPath("proxy.config.ssl.servername.filename");
 
-  Note("%s loading ...", sni_filename);
+  Note("%s loading ...", sni_filename.c_str());
 
   struct stat sbuf;
-  if (stat(sni_filename, &sbuf) == -1 && errno == ENOENT) {
-    Note("%s failed to load", sni_filename);
-    Warning("Loading SNI configuration - filename: %s doesn't exist", sni_filename);
+  if (stat(sni_filename.c_str(), &sbuf) == -1 && errno == ENOENT) {
+    Note("%s failed to load", sni_filename.c_str());
+    Warning("Loading SNI configuration - filename: %s doesn't exist", sni_filename.c_str());
     return 1;
   }
 
@@ -169,12 +169,12 @@ SNIConfigParams::Initialize()
   if (!zret.isOK()) {
     std::stringstream errMsg;
     errMsg << zret;
-    Error("%s failed to load: %s", sni_filename, errMsg.str().c_str());
+    Error("%s failed to load: %s", sni_filename.c_str(), errMsg.str().c_str());
     return 1;
   }
 
   loadSNIConfig();
-  Note("%s finished loading", sni_filename);
+  Note("%s finished loading", sni_filename.c_str());
 
   return 0;
 }

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -61,7 +61,7 @@ load_tunnel_alpn(std::vector<int> &dst, const YAML::Node &node)
 } // namespace
 
 ts::Errata
-YamlSNIConfig::loader(const char *cfgFilename)
+YamlSNIConfig::loader(const std::string &cfgFilename)
 {
   try {
     YAML::Node config = YAML::LoadFile(cfgFilename);

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -94,7 +94,7 @@ struct YamlSNIConfig {
     void EnableProtocol(YamlSNIConfig::TLSProtocol proto);
   };
 
-  ts::Errata loader(const char *cfgFilename);
+  ts::Errata loader(const std::string &cfgFilename);
 
   std::vector<YamlSNIConfig::Item> items;
 };


### PR DESCRIPTION
(cherry picked from commit e99f33c2635eac8e3894b71a3afe45c36844e25c)

Conflicts:
    iocore/net/SSLSNIConfig.cc