### PR TITLE
Fixes issue #8807 nexthop failure threshold.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -863,7 +863,7 @@ case $host_os_def in
     AS_IF([test "x$ax_cv_c_compiler_vendor" = "xgnu"], [
       # This is useful for finding odd conversions
       #    common_opt="-pipe -Wall -Wconversion -Wno-sign-conversion -Wno-format-truncation"
-      common_opt="-pipe -Wall -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow"
+      common_opt="-pipe -Wall -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow -Wno-deprecated-declarations"
       debug_opt="-ggdb3 $common_opt"
       release_opt="-g $common_opt $optimizing_flags -feliminate-unused-debug-symbols -fno-strict-aliasing"
       cxx_opt="-Wno-invalid-offsetof -Wno-noexcept-type"

--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -474,7 +474,7 @@ wipeField(char **field, char *pattern, const char *uppercase_field)
 
       // search new param again
       const char *new_param = strchr(lookup_query_param + field_pos, '&');
-      if (new_param && (new_param + 1)) {
+      if (new_param && *(new_param + 1)) {
         pattern_in_param_name = findPatternFromParamName(new_param + 1, pattern);
       } else {
         break;


### PR DESCRIPTION
This was originally fixed in ATS 9.2.x with PR #8365 but #8365
was big and not backported to 9.1.x as it was a late PR and
zwoop did not want to bring it into 9.1.x at that time.

Anyway, this fixes the issue where the failure count on a parent
is not incremented properly.