### PR TITLE
Add `#pragma once` for PendingAction.h

### DIFF
--- a/include/tscore/PendingAction.h
+++ b/include/tscore/PendingAction.h
@@ -21,6 +21,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#pragma once
+
 /** Hold a pending @c Action.
  *
  * This is modeled on smart pointer classes. This class wraps a pointer to


### PR DESCRIPTION
PendingAction.h needs a `#pragma once` to protect it from double
inclusion. This patch adds this. This has not caused problems yet
because it is currently only used once in HttpSM.h, but as it gets more
use this will be required.