### PR TITLE
Jsonrpc socket credentials work( and related work to support this sort of checks )

### DIFF
--- a/doc/admin-guide/files/jsonrpc.yaml.en.rst
+++ b/doc/admin-guide/files/jsonrpc.yaml.en.rst
@@ -56,7 +56,7 @@ In order for programs to communicate with |TS|, the server exposes a
 will find some of the configurable arguments that can be changed.
 
 
-.. _admnin-jsonrpc-configuration:
+.. _admin-jsonrpc-configuration:
 
 Configuration
 =============
@@ -68,9 +68,9 @@ Configuration
 If a non-default configuration is needed, the following describes the configuration
 structure.
 
-File `jsonrpc.yaml` is a YAML format. The default configuration is:
+File `jsonrpc.yaml` is a YAML format. The default configuration looks like:
 
-.. code:: yaml
+.. code-block:: yaml
 
    rpc:
      enabled: true
@@ -90,26 +90,34 @@ Field Name            Description
 IPC Socket (``unix``)
 ---------------------
 
-===================================== ==========================================
+Unix Domain Socket related configuration.
+
+===================================== =========================================================================================
 Field Name                            Description
-===================================== ==========================================
-``lock_path_name``                    Lock path, including the file name.
-                                      (changing this may have impacts in
-                                      :program:`traffic_ctl`)
-``sock_path_name``                    Sock path, including the file name. This
-                                      will be used as ``sockaddr_un.sun_path``
-                                      (changing this may have impacts in :program:`traffic_ctl`)
+===================================== =========================================================================================
+``lock_path_name``                    Lock path, including the file name. (changing this may have impacts in :program:`traffic_ctl`)
+``sock_path_name``                    Sock path, including the file name. This will be used as ``sockaddr_un.sun_path``. (changing
+                                      this may have impacts in :program:`traffic_ctl`)
 ``backlog``                           Check https://man7.org/linux/man-pages/man2/listen.2.html
-``max_retry_on_transient_errors``     Number of times the implementation is
-                                      allowed to retry when a transient error is
-                                      encountered.
-``restricted_api``                    Used to set rpc unix socket permissions.
-                                      If restricted `0700` will be set, otherwise
-                                      `0777`. ``true`` by default.
-===================================== ==========================================
+``max_retry_on_transient_errors``     Number of times the implementation is allowed to retry when a transient error is encountered.
+``restricted_api``                    This setting specifies whether the jsonrpc node access should be restricted to root processes.
+                                      If this is set to ``false``, then on platforms that support passing process credentials, non-root
+                                      processes will be allowed to make read-only JSONRPC calls. Any calls that modify server state
+                                      (eg. setting a configuration variable) will still be restricted to root processes. If set to ``true``
+                                      then only root processes will be allowed to perform any api call.
+                                      If restricted, the Unix Domain Socket will be created with `0700` permissions, otherwise `0777`.
+                                      ``true`` by default.
+                                      In case of an unauthorized call is made, a corresponding rpc error will be returned, you can
+                                      check :ref:`jsonrpc-node-errors-unauthorized-action` for details about the errors.
+===================================== =========================================================================================
 
 
 .. note::
 
    Currently, there is only 1 communication mechanism supported. Unix Domain Sockets
 
+
+See also
+========
+
+:ref:`traffic_ctl_jsonrpc`

--- a/doc/appendices/command-line/traffic_ctl_jsonrpc.en.rst
+++ b/doc/appendices/command-line/traffic_ctl_jsonrpc.en.rst
@@ -604,5 +604,5 @@ See also
 
 :manpage:`records.config(5)`,
 :manpage:`storage.config(5)`,
-:ref:`admnin-jsonrpc-configuration`,
+:ref:`admin-jsonrpc-configuration`,
 :ref:`jsonrpc-protocol`

--- a/doc/developer-guide/jsonrpc/HandlerError.en.rst
+++ b/doc/developer-guide/jsonrpc/HandlerError.en.rst
@@ -26,7 +26,7 @@ API Handler error codes
 ***********************
 
 High level handler error codes, each particular handler can be fit into one of the following categories.
-A good approach could be the following. This required coordination among all the errors, just for now, this soluction seems ok.
+A good approach could be the following. This required coordination among all the errors, just for now, this solution seems ok.
 
 .. code-block:: cpp
 

--- a/doc/developer-guide/jsonrpc/index.en.rst
+++ b/doc/developer-guide/jsonrpc/index.en.rst
@@ -28,6 +28,7 @@ JSONRPC
    jsonrpc-architecture.en
    jsonrpc-api.en
    jsonrpc-node.en
+   jsonrpc-node-errors.en
    jsonrpc-handler-development.en
    jsonrpc-client-api.en
    traffic_ctl-development.en

--- a/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
@@ -960,7 +960,7 @@ Request:
 
 Response:
 
-The response will contain the default `success_response`  or an :cpp:class:`RPCErrorCode`.
+The response will contain the default `success_response`  or a proper rpc error, check :ref:`jsonrpc-node-errors` for mode details.
 
 
 Validation:
@@ -1070,7 +1070,7 @@ Parameters
 Result
 ~~~~~~
 
-This api will only inform for errors during the metric update. Errors will be tracked down in the :cpp:class:`RPCErrorCode` field.
+This api will only inform for errors during the metric update. Errors will be tracked down in the `error` field.
 
 .. note::
 
@@ -1095,7 +1095,7 @@ Request:
 
 Response:
 
-The response will contain the default `success_response`  or an :cpp:class:`RPCErrorCode`.
+The response will contain the default `success_response`  or an error. :ref:`jsonrpc-node-errors`.
 
 
 .. _admin_host_set_status:
@@ -1164,7 +1164,7 @@ marking this reason as "down" in that case.
 Result
 ~~~~~~
 
-The response will contain the default `success_response`  or an :cpp:class:`RPCErrorCode`.
+The response will contain the default `success_response`  or an error. :ref:`jsonrpc-node-errors`.
 
 
 Examples
@@ -1260,7 +1260,7 @@ Parameters
 Result
 ~~~~~~
 
-The response will contain the default `success_response`  or an :cpp:class:`RPCErrorCode`.
+The response will contain the default `success_response`  or an error. :ref:`jsonrpc-node-errors`.
 
 
 Examples
@@ -1302,7 +1302,7 @@ Field                   Type          Description
 Result
 ~~~~~~
 
-The response will contain the default `success_response`  or an :cpp:class:`RPCErrorCode`.
+The response will contain the default `success_response`  or an error. :ref:`jsonrpc-node-errors`.
 
 .. note::
 
@@ -1380,7 +1380,7 @@ Field                   Type          Description
 Result
 ~~~~~~
 
-The response will contain the default `success_response`  or an :cpp:class:`RPCErrorCode`.
+The response will contain the default `success_response`  or an error. :ref:`jsonrpc-node-errors`.
 
 Examples
 ~~~~~~~~
@@ -1781,3 +1781,8 @@ Response:
          ]
       }
    }
+
+See also
+========
+
+:ref:`jsonrpc-node-errors`

--- a/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
@@ -55,7 +55,7 @@ IPC
 
 The current server implementation runs on an IPC Socket(Unix Domain Socket). This server implements an iterative server style.
 The implementation runs on a dedicated ``TSThread`` and as their style express, this performs blocking calls to all the registered handlers.
-Configuration for this particular server style can be found in the admin section :ref:`admnin-jsonrpc-configuration`.
+Configuration for this particular server style can be found in the admin section :ref:`admin-jsonrpc-configuration`.
 
 
 Using the JSONRPC mechanism
@@ -464,61 +464,6 @@ Response:
       }
 
 
-.. _rpc-error-code:
-
-Internally we have defined an ``enum`` class that keeps track of the errors that the server will inform in most of the cases.
-Some of this errors are already defined by the `JSONRPC`_ specs and some (``>=1``) are defined by |TS|.
-
-.. class:: RPCErrorCode
-
-   Defines the API error codes that will be used in case of any RPC error.
-
-   .. enumerator:: INVALID_REQUEST  = -32600
-   .. enumerator:: METHOD_NOT_FOUND = -32601
-   .. enumerator:: INVALID_PARAMS   = -32602
-   .. enumerator:: INTERNAL_ERROR   = -32603
-   .. enumerator:: PARSE_ERROR      = -32700
-
-      `JSONRPC`_ defined errors.
-
-   .. enumerator:: InvalidVersion     = 1
-
-      The passed version is invalid. must be 2.0
-
-   .. enumerator:: InvalidVersionType = 2
-
-      The passed version field type is invalid. must be a ``string``
-
-   .. enumerator:: MissingVersion = 3
-
-      Version field is missing from the request. This field is mandatory.
-
-   .. enumerator:: InvalidMethodType = 4
-
-      The passed method field type is invalid. must be a ``string``
-
-   .. enumerator:: MissingMethod = 5
-
-      Method field is missing from the request. This field is mandatory.
-
-   .. enumerator:: InvalidParamType = 6
-
-      The passed parameter field type is not valid.
-
-   .. enumerator:: InvalidIdType = 7
-
-      The passed id field type is invalid.
-
-   .. enumerator:: NullId = 8
-
-      The passed if is ``null``
-
-   .. enumerator:: ExecutionError = 9
-
-      An error occurred during the execution of the RPC call. This error is used as a generic High level error. The details details about
-      the error, in most cases are specified in the ``data`` field.
-
-
 .. information:
 
    According to the |RPC| specs, if you get an error, the ``result`` field will not be set. |TS| will grant this.
@@ -535,5 +480,6 @@ Development Guide
 See also
 ========
 
-:ref:`admnin-jsonrpc-configuration`,
+:ref:`admin-jsonrpc-configuration`,
+:ref:`jsonrpc-node-errors`,
 :ref:`traffic_ctl_jsonrpc`

--- a/doc/developer-guide/jsonrpc/jsonrpc-handler-development.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-handler-development.en.rst
@@ -186,7 +186,7 @@ We recommend some ways to deal with this:
 
 This can be set in case you would like to let the server to respond with an |RPC| error, ``ExecutionError`` will be used to catch all the
 errors that are fired from within the function call, either by setting the proper errata or by throwing an exception.
-Please check the `rpc-error-code` and in particular ``ExecutionError = 9``. Also check :ref:`jsonrpc-handler-errors`
+Please check the :ref:`jsonrpc-node-errors` and in particular ``ExecutionError = 9``. Also check :ref:`jsonrpc-handler-errors`
 
 .. important::
 
@@ -420,7 +420,10 @@ Important Notes
 * To interact directly with the |RPC| node, please check :ref:`jsonrpc-node`
 
 
-:ref:`admnin-jsonrpc-configuration`
+See also
+========
+
+:ref:`admin-jsonrpc-configuration`
 :ref:`jsonrpc-protocol`
 :ref:`developer-guide-traffic_ctl-development`
 

--- a/doc/developer-guide/jsonrpc/jsonrpc-node-errors.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-node-errors.en.rst
@@ -1,0 +1,143 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../common.defs
+
+.. highlight:: cpp
+.. default-domain:: cpp
+
+.. _JSONRPC: https://www.jsonrpc.org/specification
+.. _JSON: https://www.json.org/json-en.html
+
+
+.. _jsonrpc-node-errors:
+
+
+JSON RPC errors
+***************
+
+A list of codes and descriptions of errors that could be send back from the JSONRPC server. JSONRPC response messages could contains
+different set of errors in the following format:
+
+.. note::
+
+   Check  :ref:`jsonrpc-error` for details about the error structure.
+
+
+.. code-block::json
+
+   {
+      "error": {
+         "code": -32601,
+         "message": "Method not found"
+      },
+      "id": "ded7018e-0720-11eb-abe2-001fc69cc946",
+      "jsonrpc": "2.0"
+   }
+
+In some cases the data field could be populated:
+
+.. code-block:: json
+
+   {
+      "jsonrpc": "2.0",
+      "error":{
+         "code": 10,
+         "message": "Unauthorized action",
+         "data":[
+            {
+               "code": 2,
+               "message":"Denied privileged API access for uid=XXX gid=XXX"
+            }
+         ]
+      },
+      "id":"5e273ec0-3e3b-4a81-90ec-aeee3d38073f"
+   }
+
+
+.. _jsonrpc-node-errors-standard-errors:
+
+Standard errors
+===============
+
+=============== ========================================= =========================================================
+Field           Message                                   Description
+=============== ========================================= =========================================================
+-32700          Parse error                               Invalid JSON was received by the server.
+                                                          An error occurred on the server while parsing the JSON text.
+-32600          Invalid Request                           The JSON sent is not a valid Request object.
+-32601          Method not found                          The method does not exist / is not available.
+-32602          Invalid params                            Invalid method parameter(s).
+-32603          Internal error                            Internal `JSONRPC`_ error.
+=============== ========================================= =========================================================
+
+.. _jsonrpc-node-errors-custom-errors:
+
+Custom errors
+=============
+
+The following error list are defined by the server.
+
+=============== ========================================= =========================================================
+Field           Message                                   Description
+=============== ========================================= =========================================================
+1               Invalid version, 2.0 only                 The server only accepts version field equal to `2.0`.
+2               Invalid version type, should be a string  Version field should be a literal string.
+3               Missing version field                     No version field present, version field is mandatory.
+4               Invalid method type, should be a string   The method field should be a literal string.
+5               Missing method field                      No method field present, method field is mandatory.
+6               Invalid params type. A Structured value   Params field should be a structured type, list or structure.
+                is expected                               This is similar to `-32602`
+7               Invalid id type                           If field should be a literal string.
+8               Use of null as id is discouraged          Id field value is null, as per the specs this is discouraged,
+                                                          the server will not accept it.
+9               Error during execution                    An error occurred during the execution of the RPC call.
+                                                          This error is used as a generic High level error. The specifics
+                                                          details about the error, in most cases are specified in the
+                                                          ``data`` field.
+10              Unauthorized action                       The rpc method will not be invoked because the action is not
+                                                          permitted by some constraint or authorization issue. Check
+                                                          :ref:`jsonrpc-node-errors-unauthorized-action` for mode details.
+=============== ========================================= =========================================================
+
+.. _jsonrpc-node-errors-unauthorized-action:
+
+Unauthorized action
+-------------------
+
+Under this error, the `data` field could be populated with the following errors, eventually more than one could be in set.
+
+.. code-block:: json
+
+   "data":[
+      {
+         "code":2,
+         "message":"Denied privileged API access for uid=XXX gid=XXX"
+      }
+   ]
+
+=============== ========================================= =========================================================
+Field           Message                                   Description
+=============== ========================================= =========================================================
+1               Error getting peer credentials: {}        Something happened while trying to get the peers credentials.
+                                                          The error string will show the error code(`errno`) returned by the
+                                                          server.
+2               Denied privileged API access for uid={}   Permission denied. Unix Socket credentials were checked and they haven't meet
+                gid={}                                    the required policy. The handler was configured as restricted
+                                                          and the socket credentials failed to validate. Check TBC for
+                                                          more information.
+=============== ========================================= =========================================================

--- a/doc/developer-guide/jsonrpc/jsonrpc-node.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-node.en.rst
@@ -36,7 +36,7 @@ IPC Node
 ========
 
 You can directly connect to the Unix Domain Socket used for the |RPC| node, the location of the sockets
-will depend purely on how did you configure the server, please check :ref:`admnin-jsonrpc-configuration` for
+will depend purely on how did you configure the server, please check :ref:`admin-jsonrpc-configuration` for
 information regarding configuration.
 
 
@@ -57,3 +57,8 @@ Using traffic_ctl
 :program:`traffic_ctl` can also be used to directly send raw |RPC| messages to the server's node, :program:`traffic_ctl` provides
 several options to achieve this, please check ``traffic_ctl_rpc``.
 
+
+Error responses
+---------------
+
+The server will indicate in case of any error processing the call, check :ref:`jsonrpc-node-errors` for more details.

--- a/doc/developer-guide/jsonrpc/traffic_ctl-development.en.rst
+++ b/doc/developer-guide/jsonrpc/traffic_ctl-development.en.rst
@@ -208,7 +208,10 @@ There is code that was written in this way by design, ``RecordPrinter`` and ``Re
 that needs to query and print records without any major hassle.
 
 
+See also
+========
 
-:ref:`admnin-jsonrpc-configuration`,
+:ref:`admin-jsonrpc-configuration`,
 :ref:`traffic_ctl_jsonrpc`,
-:ref:`jsonrpc_development`
+:ref:`jsonrpc_development`,
+:ref:`jsonrpc-node-errors`

--- a/mgmt2/config/FileManager.cc
+++ b/mgmt2/config/FileManager.cc
@@ -91,12 +91,11 @@ FileManager::FileManager()
   this->registerCallback(&handle_file_reload);
 
   // Register the files registry jsonrpc endpoint
-  rpc::add_method_handler(
-    "filemanager.get_files_registry",
-    [this](std::string_view const &id, const YAML::Node &req) -> ts::Rv<YAML::Node> {
-      return get_files_registry_rpc_endpoint(id, req);
-    },
-    &rpc::core_ats_rpc_service_provider_handle);
+  rpc::add_method_handler("filemanager.get_files_registry",
+                          [this](std::string_view const &id, const YAML::Node &req) -> ts::Rv<YAML::Node> {
+                            return get_files_registry_rpc_endpoint(id, req);
+                          },
+                          &rpc::core_ats_rpc_service_provider_handle, {rpc::NON_RESTRICTED_API});
 }
 
 // FileManager::~FileManager

--- a/mgmt2/rpc/Makefile.am
+++ b/mgmt2/rpc/Makefile.am
@@ -45,7 +45,9 @@ libjsonrpc_protocol_COMMON = \
 	jsonrpc/error/RPCError.cc \
 	jsonrpc/error/RPCError.h \
 	jsonrpc/JsonRPCManager.cc \
-	jsonrpc/JsonRPCManager.h
+	jsonrpc/JsonRPCManager.h \
+	jsonrpc/Context.cc \
+	jsonrpc/Context.h
 
 libjsonrpc_protocol_la_SOURCES = \
 	$(libjsonrpc_protocol_COMMON)

--- a/mgmt2/rpc/jsonrpc/Context.cc
+++ b/mgmt2/rpc/jsonrpc/Context.cc
@@ -17,31 +17,19 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-#pragma once
+#include "Context.h"
 
-#include <system_error>
-
-#include <tscore/Errata.h>
-
-#include "rpc/config/JsonRPCConfig.h"
-
-namespace rpc::comm
+namespace rpc
 {
-struct BaseCommInterface {
-  virtual ~BaseCommInterface() {}
-  virtual bool configure(YAML::Node const &params) = 0;
-  virtual void run()                               = 0;
-  virtual std::error_code init()                   = 0;
-  virtual bool stop()                              = 0;
-  virtual std::string const &name() const          = 0;
-};
-
-enum class InternalError { MAX_TRANSIENT_ERRORS_HANDLED = 1, POLLIN_ERROR, PARTIAL_READ, FULL_BUFFER };
-std::error_code make_error_code(rpc::comm::InternalError e);
-
-} // namespace rpc::comm
-namespace std
+// --- Call Context impl
+ts::Errata
+Context::Auth::check_for_permissions(HandlerOptions const &options) const
 {
-template <> struct is_error_code_enum<rpc::comm::InternalError> : true_type {
+  ts::Errata out;
+  // check every registered callback and see if they have something to say. Then report back to the manager
+  for (auto &&check : _permissionCheckers) {
+    check(options, out);
+  }
+  return out;
 };
-} // namespace std
+} // namespace rpc

--- a/mgmt2/rpc/jsonrpc/Context.h
+++ b/mgmt2/rpc/jsonrpc/Context.h
@@ -1,0 +1,92 @@
+/**
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#pragma once
+
+#include <vector>
+#include <functional>
+#include <string_view>
+
+#include "tscore/Errata.h"
+#include "rpc/handlers/common/ErrorUtils.h"
+
+namespace rpc
+{
+const bool RESTRICTED_API{true};
+const bool NON_RESTRICTED_API{false};
+///
+//
+/// @brief Handler options
+///
+/// This class holds information about how a handler will be managed and delivered when called by an external client.
+/// The JSONRPC manager would use this object to perform certain validation, ie: If the rpc endpoint(function handler) should be
+/// restricted depending on the configuration rules.
+///
+struct HandlerOptions {
+  HandlerOptions() = default;
+  HandlerOptions(bool restricted) : auth{restricted} {}
+  struct Auth {
+    bool restricted{RESTRICTED_API}; ///< Tells the RPC Manager if the call can be delivered or not based on the config rules.
+  } auth;
+};
+
+///
+/// @brief RPC call context class.
+///
+/// This class is used to carry information from the transport logic to the rpc invocation logic, the transport may need to block
+/// some rpc handlers from being executed which at the time of finish ups reading the raw message is yet too early to know the
+/// actual handler.
+///
+class Context
+{
+  using checker_cb = std::function<void(HandlerOptions const &, ts::Errata &)>;
+  /// @brief Internal class to hold the permission checker part.
+  struct Auth {
+    /// Checks for permissions. This function checks for every registered permission checker.
+    ///
+    /// @param options Registered handler options.
+    /// @return ts::Errata The errata will be filled by each of the registered checkers, if there was any issue validating the
+    ///                    call, then the errata reflects that.
+    ts::Errata check_for_permissions(HandlerOptions const &options) const;
+
+    /// Add permission checkers.
+    template <typename F>
+    void
+    add_late_permission_checker(F &&f)
+    {
+      _permissionCheckers.emplace_back(std::forward<F>(f));
+    }
+
+  private:
+    std::vector<checker_cb> _permissionCheckers; ///< cb collection.
+  } _auth;
+
+public:
+  Auth &
+  get_auth()
+  {
+    return _auth;
+  }
+  Auth const &
+  get_auth() const
+  {
+    return _auth;
+  }
+};
+} // namespace rpc

--- a/mgmt2/rpc/jsonrpc/Defs.h
+++ b/mgmt2/rpc/jsonrpc/Defs.h
@@ -48,6 +48,10 @@ struct RPCResponseInfo {
   RPCResponseInfo(std::optional<std::string> const &id_) : id{id_} {}
   RPCResponseInfo(std::error_code const &ec_) : error{ec_, {}} {}
   RPCResponseInfo(std::optional<std::string> const &id_, std::error_code const &ec_) : error{ec_, {}}, id{id_} {}
+  RPCResponseInfo(std::optional<std::string> const &id_, std::error_code const &ec_, ts::Errata const &errata)
+    : error{ec_, errata}, id{id_}
+  {
+  }
   RPCResponseInfo() = default;
 
   RPCHandlerResponse callResult;

--- a/mgmt2/rpc/jsonrpc/Defs.h
+++ b/mgmt2/rpc/jsonrpc/Defs.h
@@ -45,11 +45,16 @@ public:
 };
 
 struct RPCResponseInfo {
-  RPCResponseInfo(std::optional<std::string> const &id_) : id(id_) {}
+  RPCResponseInfo(std::optional<std::string> const &id_) : id{id_} {}
+  RPCResponseInfo(std::error_code const &ec_) : error{ec_, {}} {}
+  RPCResponseInfo(std::optional<std::string> const &id_, std::error_code const &ec_) : error{ec_, {}}, id{id_} {}
   RPCResponseInfo() = default;
 
   RPCHandlerResponse callResult;
-  std::error_code rpcError;
+  struct Error {
+    std::error_code ec;
+    ts::Errata data;
+  } error;
   std::optional<std::string> id;
 };
 

--- a/mgmt2/rpc/jsonrpc/JsonRPC.h
+++ b/mgmt2/rpc/jsonrpc/JsonRPC.h
@@ -33,17 +33,17 @@ extern RPCRegistryInfo core_ats_rpc_service_provider_handle;
 /// @see JsonRPCManager::add_method_handler for details
 template <typename Func>
 inline bool
-add_method_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info = nullptr)
+add_method_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info = nullptr, HandlerOptions opt = {})
 {
-  return JsonRPCManager::instance().add_method_handler(name, std::forward<Func>(call), info);
+  return JsonRPCManager::instance().add_method_handler(name, std::forward<Func>(call), info, opt);
 }
 
 /// @see JsonRPCManager::add_notification_handler for details
 template <typename Func>
 inline bool
-add_notification_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info = nullptr)
+add_notification_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info = nullptr, HandlerOptions opt = {})
 {
-  return JsonRPCManager::instance().add_notification_handler(name, std::forward<Func>(call), info);
+  return JsonRPCManager::instance().add_notification_handler(name, std::forward<Func>(call), info, opt);
 }
 
 } // namespace rpc

--- a/mgmt2/rpc/jsonrpc/JsonRPCManager.h
+++ b/mgmt2/rpc/jsonrpc/JsonRPCManager.h
@@ -144,9 +144,9 @@ private:
   /// signatures inside a @c std::variant
   class Dispatcher
   {
-    using response_type = std::pair<
-      std::optional<specs::RPCResponseInfo>,
-      std::error_code>; ///< The response type used internally, notifications won't fill in the optional response. @c ec will be set
+    /// The response type used internally, notifications won't fill in the optional response.  Internal response's @ ec will be set
+    /// in case of any error.
+    using response_type = std::optional<specs::RPCResponseInfo>;
 
     ///
     /// @brief Class that wraps the actual std::function<T>.

--- a/mgmt2/rpc/jsonrpc/JsonRPCManager.h
+++ b/mgmt2/rpc/jsonrpc/JsonRPCManager.h
@@ -34,6 +34,7 @@
 #include "ts/apidefs.h"
 
 #include "Defs.h"
+#include "Context.h"
 
 namespace rpc
 {
@@ -44,9 +45,14 @@ namespace json_codecs
   class yamlcpp_json_encoder;
 } // namespace json_codecs
 
+///
+/// @brief This class keeps all relevant @c RPC provider's info.
+///
 struct RPCRegistryInfo {
-  std::string_view provider;
+  std::string_view provider; ///< Who's the rpc endpoint provider, could be ATS or a plugins. When requesting the service info from
+                             ///< the rpc node, this will be part of the service info.
 };
+
 ///
 /// @brief JSONRPC registration and JSONRPC invocation logic  https://www.jsonrpc.org/specification
 /// doc TBC
@@ -74,9 +80,11 @@ public:
   ///             'get_stats'...} .
   /// @param call The function handler.
   /// @param info RPCRegistryInfo pointer.
+  /// @param opt  Handler options, used to pass information about the registered handler.
   /// @return bool Boolean flag. true if the callback was successfully added, false otherwise
   ///
-  template <typename Func> bool add_method_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info);
+  template <typename Func>
+  bool add_method_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info, HandlerOptions opt);
 
   ///
   /// @brief Add new registered notification handler to the JSON RPC engine.
@@ -85,18 +93,21 @@ public:
   /// @param name Name to be exposed by the RPC Engine.
   /// @param call The callback function that needs handler.
   /// @param info RPCRegistryInfo pointer.
+  /// @param opt  Handler options, used to pass information about the registered handler.
   /// @return bool Boolean flag. true if the callback was successfully added, false otherwise
   ///
-  template <typename Func> bool add_notification_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info);
+  template <typename Func>
+  bool add_notification_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info, HandlerOptions opt);
 
   ///
   /// @brief This function handles the incoming jsonrpc request and dispatch the associated registered handler.
   ///
+  /// @param ctx @c Context object used pass information between rpc layers.
   /// @param jsonString The incoming jsonrpc 2.0 message. \link https://www.jsonrpc.org/specification
   /// @return std::optional<std::string> For methods, a valid jsonrpc 2.0 json string will be passed back. Notifications will not
   ///         contain any json back.
   ///
-  std::optional<std::string> handle_call(std::string const &jsonString);
+  std::optional<std::string> handle_call(Context const &ctx, std::string const &jsonString);
 
   ///
   /// @brief Get the instance of the whole RPC engine.
@@ -166,11 +177,11 @@ private:
     /// Add a method handler to the internal container
     /// @return True if was successfully added, False otherwise.
     template <typename FunctionWrapperType, typename Handler>
-    bool add_handler(std::string const &name, Handler &&handler, const RPCRegistryInfo *info);
+    bool add_handler(std::string const &name, Handler &&handler, const RPCRegistryInfo *info, HandlerOptions opt);
 
     /// Find and call the request's callback. If any error occurs, the return type will have the specific error.
     /// For notifications the @c RPCResponseInfo will not be set as part of the response. @c response_type
-    response_type dispatch(specs::RPCRequestInfo const &request) const;
+    response_type dispatch(Context const &ctx, specs::RPCRequestInfo const &request) const;
 
     /// Find a particular registered handler(method) by its associated name.
     /// @return A pair. The handler itself and a boolean flag indicating that the handler was found. If not found, second will
@@ -206,7 +217,7 @@ private:
     /// simplify the logic to insert and fetch callable objects from our container.
     struct InternalHandler {
       InternalHandler() = default;
-      InternalHandler(const RPCRegistryInfo *info) : _regInfo(info) {}
+      InternalHandler(const RPCRegistryInfo *info, HandlerOptions opt) : _regInfo(info), _options(opt) {}
       /// Sets the handler.
       template <class T, class F> void set_callback(F &&t);
       explicit operator bool() const;
@@ -223,6 +234,13 @@ private:
         return _regInfo;
       }
 
+      /// Returns the configured options associated with this particular handler.
+      HandlerOptions const &
+      get_options() const
+      {
+        return _options;
+      }
+
     private:
       // We need to keep this match with the order of types in the _func variant. This will help us to identify the holding type.
       enum class VariantTypeIndexId : std::size_t { NOTIFICATION = 1, METHOD = 2, METHOD_FROM_PLUGIN = 3 };
@@ -231,6 +249,7 @@ private:
       std::variant<std::monostate, Notification, Method, PluginMethod> _func;
       const RPCRegistryInfo *_regInfo; ///< Can hold internal information about the handler, this could be null as it is optional.
                                        ///< This pointer can eventually holds important information about the call.
+      HandlerOptions _options;
     };
     // We will keep all the handlers wrapped inside the InternalHandler class, this will help us
     // to have a single container for all the types(method, notification & plugin method(cond var)).
@@ -244,19 +263,19 @@ private:
 // ------------------------------ JsonRPCManager -------------------------------
 template <typename Handler>
 bool
-JsonRPCManager::add_method_handler(const std::string &name, Handler &&call, const RPCRegistryInfo *info)
+JsonRPCManager::add_method_handler(const std::string &name, Handler &&call, const RPCRegistryInfo *info, HandlerOptions opt)
 {
-  return _dispatcher.add_handler<Dispatcher::Method, Handler>(name, std::forward<Handler>(call), info);
+  return _dispatcher.add_handler<Dispatcher::Method, Handler>(name, std::forward<Handler>(call), info, opt);
 }
 
 template <typename Handler>
 bool
-JsonRPCManager::add_notification_handler(const std::string &name, Handler &&call, const RPCRegistryInfo *info)
+JsonRPCManager::add_notification_handler(const std::string &name, Handler &&call, const RPCRegistryInfo *info, HandlerOptions opt)
 {
-  return _dispatcher.add_handler<Dispatcher::Notification, Handler>(name, std::forward<Handler>(call), info);
+  return _dispatcher.add_handler<Dispatcher::Notification, Handler>(name, std::forward<Handler>(call), info, opt);
 }
 
-// ----------------------------- InternalHandler ------------------------------------
+// ----------------------------- InternalHandler -------------------------------
 template <class T, class F>
 void
 JsonRPCManager::Dispatcher::InternalHandler::set_callback(F &&f)
@@ -276,10 +295,10 @@ bool inline JsonRPCManager::Dispatcher::InternalHandler::operator!() const
 // ----------------------------- Dispatcher ------------------------------------
 template <typename FunctionWrapperType, typename Handler>
 bool
-JsonRPCManager::Dispatcher::add_handler(std::string const &name, Handler &&handler, const RPCRegistryInfo *info)
+JsonRPCManager::Dispatcher::add_handler(std::string const &name, Handler &&handler, const RPCRegistryInfo *info, HandlerOptions opt)
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  InternalHandler call{info};
+  InternalHandler call{info, opt};
   call.set_callback<FunctionWrapperType>(std::forward<Handler>(handler));
   return _handlers.emplace(name, std::move(call)).second;
 }

--- a/mgmt2/rpc/jsonrpc/error/RPCError.cc
+++ b/mgmt2/rpc/jsonrpc/error/RPCError.cc
@@ -74,6 +74,8 @@ RPCErrorCategory::message(int ev) const
     return {"Use of null as id is discouraged"};
   case RPCErrorCode::ExecutionError:
     return {"Error during execution"};
+  case RPCErrorCode::Unauthorized:
+    return {"Unauthorized action"};
   default:
     return "Rpc error " + std::to_string(ev);
   }

--- a/mgmt2/rpc/jsonrpc/error/RPCError.h
+++ b/mgmt2/rpc/jsonrpc/error/RPCError.h
@@ -59,10 +59,12 @@ enum class RPCErrorCode {
   // execution errors
 
   // Internal rpc error when executing the method.
-  ExecutionError
+  ExecutionError,
+  Unauthorized
 };
 // TODO: force non 0 check
 std::error_code make_error_code(rpc::error::RPCErrorCode e);
+
 } // namespace rpc::error
 
 namespace std

--- a/mgmt2/rpc/jsonrpc/json/YAMLCodec.h
+++ b/mgmt2/rpc/jsonrpc/json/YAMLCodec.h
@@ -216,33 +216,11 @@ class yamlcpp_json_encoder
 
   /// Convenience functions to call encode_error.
   static void
-  encode_error(std::error_code error, YAML::Emitter &json)
-  {
-    ts::Errata errata{};
-    encode_error(error, errata, json);
-  }
-  /// Convenience functions to call encode_error.
-  static void
   encode_error(ts::Errata const &errata, YAML::Emitter &json)
   {
     encode_error({error::RPCErrorCode::ExecutionError}, errata, json);
   }
 
-  static void
-  encode_error_from_callee(ts::Errata const &errata, YAML::Emitter &json)
-  {
-    if (!errata.isOK()) {
-      json << YAML::Key << "errors";
-      json << YAML::BeginSeq;
-      for (auto const &err : errata) {
-        json << YAML::BeginMap;
-        json << YAML::Key << "code" << YAML::Value << err.getCode();
-        json << YAML::Key << "message" << YAML::Value << err.text();
-        json << YAML::EndMap;
-      }
-      json << YAML::EndSeq;
-    }
-  }
   ///
   /// @brief Function to encode a single response(no batch) into an emitter.
   ///
@@ -257,9 +235,9 @@ class yamlcpp_json_encoder
 
     // Important! As per specs, errors have preference over the result, we ignore result if error was set.
 
-    if (resp.rpcError) {
+    if (resp.error.ec) {
       // internal library detected error: Decoding, etc.
-      encode_error(resp.rpcError, json);
+      encode_error(resp.error.ec, resp.error.data, json);
     }
     // Registered handler error: They have set the error on the response from the registered handler. This uses ExecutionError as
     // top error.

--- a/mgmt2/rpc/jsonrpc/unit_tests/test_basic_protocol.cc
+++ b/mgmt2/rpc/jsonrpc/unit_tests/test_basic_protocol.cc
@@ -37,19 +37,25 @@ struct JsonRpcUnitTest : rpc::JsonRPCManager {
   bool
   remove_handler(std::string const &name)
   {
-    return rpc::JsonRPCManager::remove_handler(name);
+    return base::remove_handler(name);
   }
   template <typename Func>
   bool
   add_notification_handler(const std::string &name, Func &&call)
   {
-    return base::add_notification_handler(name, std::forward<Func>(call), nullptr);
+    return base::add_notification_handler(name, std::forward<Func>(call), nullptr, {});
   }
   template <typename Func>
   bool
   add_method_handler(const std::string &name, Func &&call)
   {
-    return base::add_method_handler(name, std::forward<Func>(call), nullptr);
+    return base::add_method_handler(name, std::forward<Func>(call), nullptr, {});
+  }
+
+  std::optional<std::string>
+  handle_call(std::string const &jsonString)
+  {
+    return base::handle_call(rpc::Context{}, jsonString);
   }
 };
 
@@ -63,8 +69,6 @@ test_callback_ok_or_error(std::string_view const &id, YAML::Node const &params)
   if (YAML::Node n = params["return_error"]) {
     auto yesOrNo = n.as<std::string>();
     if (yesOrNo == "yes") {
-      // Can we just have a helper for this?
-      // resp.errata.push(static_cast<int>(TestErrors::ERR1), "Just an error message to add more meaning to the failure");
       resp.errata().push(ErratId, static_cast<int>(TestErrors::ERR1), "Just an error message to add more meaning to the failure");
     } else {
       resp.result()["ran"] = "ok";

--- a/mgmt2/rpc/server/IPCSocketServer.h
+++ b/mgmt2/rpc/server/IPCSocketServer.h
@@ -46,6 +46,12 @@ namespace rpc::comm
 ///       Buffer size = 32k
 class IPCSocketServer : public BaseCommInterface
 {
+  // Error codes to track any unauthorized call to a rpc handler.
+  enum class UnauthorizedErrorCode {
+    PEER_CREDENTIALS_ERROR = 1, ///< Error while trying to read the peer credentials from the unix socket.
+    PERMISSION_DENIED      = 2  ///< Client's socket credential didn't wasn't sufficient to execute the method.
+  };
+
   ///
   /// @brief Connection abstraction class that deals with sending and receiving data from the connected peer.
   ///
@@ -129,6 +135,8 @@ private:
   void bind(std::error_code &ec);
   void listen(std::error_code &ec);
   void close();
+
+  void late_check_peer_credentials(int peedFd, rpc::HandlerOptions const &options, ts::Errata &errata) const;
 
   std::atomic_bool _running;
 

--- a/src/traffic_server/RpcAdminPubHandlers.cc
+++ b/src/traffic_server/RpcAdminPubHandlers.cc
@@ -40,7 +40,8 @@ register_admin_jsonrpc_handlers()
 
   // Records
   using namespace rpc::handlers::records;
-  rpc::add_method_handler("admin_lookup_records", &lookup_records, &core_ats_rpc_service_provider_handle);
+  rpc::add_method_handler("admin_lookup_records", &lookup_records, &core_ats_rpc_service_provider_handle,
+                          {rpc::NON_RESTRICTED_API});
   rpc::add_method_handler("admin_clear_all_metrics_records", &clear_all_metrics_records, &core_ats_rpc_service_provider_handle);
   rpc::add_method_handler("admin_clear_metrics_records", &clear_metrics_records, &core_ats_rpc_service_provider_handle);
 
@@ -58,6 +59,7 @@ register_admin_jsonrpc_handlers()
   // storage
   using namespace rpc::handlers::storage;
   rpc::add_method_handler("admin_storage_set_device_offline", &set_storage_offline, &core_ats_rpc_service_provider_handle);
-  rpc::add_method_handler("admin_storage_get_device_status", &get_storage_status, &core_ats_rpc_service_provider_handle);
+  rpc::add_method_handler("admin_storage_get_device_status", &get_storage_status, &core_ats_rpc_service_provider_handle,
+                          {rpc::NON_RESTRICTED_API});
 }
 } // namespace rpc::admin


### PR DESCRIPTION
**I will split this PR into two separade ones, 1 with the Context change and another one for the credentials work, so it will be easy to takle on a review**

When moved from `traffic_manger` admin socket to the new `JSONRPC` api the management api [restrictions](https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.config.en.html?highlight=restricted#proxy.config.admin.api.restricted) were left out, the only restriction in place was related to the creation of the jsonrpc unix socket(either `700` or `777`) just at user level, before we have the capability to check the socket’s peers credentials and allow or deny certain operations, like read only(record lookup) vs operation that can change the state of ATS(like a record set). This was a useful method to allow some non-root users to perform some actions while we leave root users to have full access to the API. 
This change brings a similar base approach,  and allows the RPC API to let the developers specify this restriction when registering the jsonrpc node handler.

As(of course) the message parsing is done earlier than the actual rpc handler callback is made and there was no connection between them, so  I had to implement a sort of late check **(this logic is most of this change)** that can be set by the network part and be executed later on right before the actual call is made, now a Context object travels from the server to the actual rpc manager which can be populated with specific checks which are executed after the rpc handler was found valid.

All this permissions checks are handled by a new error code (`Unauthorized Action`) which is the high level error, depending of the particular check that failed to pass the sub error section will be set, leaving the client an error like this:

```
   {
      "jsonrpc": "2.0",
      "error":{
         "code": 10,
         "message": "Unauthorized action",
         "data":[
            {
               "code": 2,
               "message":"Denied privileged API access for uid=XXX gid=XXX"
            }
         ]
      },
      "id":"5e273ec0-3e3b-4a81-90ec-aeee3d38073f"
   }
```
This change also includes:
- Documentation support 
- Some clean up in the code.

