### PR TITLE
Fix Rocky Linux 8 arm64 GCC Compiler Warnings

### DIFF
--- a/iocore/eventsystem/I_Continuation.h
+++ b/iocore/eventsystem/I_Continuation.h
@@ -71,6 +71,14 @@ constexpr ContinuationHandler
 continuation_handler_void_ptr(int (C::*fp)(int, T *))
 {
   auto fp2 = reinterpret_cast<int (C::*)(int, void *)>(fp);
+
+  // We keep this a static_cast for added static type analysis from the
+  // compiler. If a compiler warning is generated for the following line of
+  // code of the type "-Werror=shift-negative-value", then this may be an issue
+  // with multiple inheritance of the C templated type. Make sure that for type
+  // C the Continuation parent is listed first (either directly or indirectly
+  // via the inheritance tree) before any other parent in the multiple class
+  // heirarchy of C.
   return static_cast<ContinuationHandler>(fp2);
 }
 

--- a/iocore/net/quic/QUICStreamVCAdapter.cc
+++ b/iocore/net/quic/QUICStreamVCAdapter.cc
@@ -24,7 +24,7 @@
 #include "I_VConnection.h"
 #include "QUICStreamVCAdapter.h"
 
-QUICStreamVCAdapter::QUICStreamVCAdapter(QUICStream &stream) : QUICStreamAdapter(stream), VConnection(new_ProxyMutex())
+QUICStreamVCAdapter::QUICStreamVCAdapter(QUICStream &stream) : VConnection(new_ProxyMutex()), QUICStreamAdapter(stream)
 {
   SET_HANDLER(&QUICStreamVCAdapter::state_stream_open);
 }

--- a/iocore/net/quic/QUICStreamVCAdapter.h
+++ b/iocore/net/quic/QUICStreamVCAdapter.h
@@ -25,7 +25,7 @@
 #include "QUICStreamAdapter.h"
 #include "I_IOBuffer.h"
 
-class QUICStreamVCAdapter : public QUICStreamAdapter, public VConnection
+class QUICStreamVCAdapter : public VConnection, public QUICStreamAdapter
 {
 public:
   class IOInfo;

--- a/lib/fastlz/fastlz.cc
+++ b/lib/fastlz/fastlz.cc
@@ -205,7 +205,7 @@ flz_copy64(uint8_t *dest, const uint8_t *src, uint32_t count)
 {
   const uint8_t *p = (const uint8_t *)src;
   uint8_t *q       = (uint8_t *)dest;
-  int c;
+  unsigned int c;
   for (c = 0; c < count * 8; ++c) {
     *q++ = *p++;
   }

--- a/plugins/experimental/traffic_dump/json_utils.cc
+++ b/plugins/experimental/traffic_dump/json_utils.cc
@@ -114,7 +114,7 @@ esc_json_out(const char *buf, int64_t len, std::ostream &jsonfile)
       break;
     }
     default: {
-      if ('\x00' <= c && c <= '\x1f') {
+      if (c <= '\x1f') {
         write_buffered_context(buf, prevIdx, idx, jsonfile);
         jsonfile << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c);
       }

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1125,9 +1125,9 @@ ConditionInbound::append_value(std::string &s, const Resources &res, NetworkSess
     zret = TSHttpTxnClientProtocolStackContains(res.txnp, "ip");
     break;
   case NET_QUAL_STACK: {
-    std::array<char const *, 8> tags;
-    int count  = 0;
-    size_t len = 0;
+    std::array<char const *, 8> tags = {};
+    int count                        = 0;
+    size_t len                       = 0;
     TSHttpTxnClientProtocolStackGet(res.txnp, tags.size(), tags.data(), &count);
     for (int i = 0; i < count; ++i) {
       len += 1 + strlen(tags[i]);

--- a/proxy/http3/Http3HeaderVIOAdaptor.h
+++ b/proxy/http3/Http3HeaderVIOAdaptor.h
@@ -27,7 +27,7 @@
 
 #include "Http3FrameHandler.h"
 
-class Http3HeaderVIOAdaptor : public Http3FrameHandler, public Continuation
+class Http3HeaderVIOAdaptor : public Continuation, public Http3FrameHandler
 {
 public:
   Http3HeaderVIOAdaptor(VIO *sink, HTTPType http_type, QPACK *qpack, uint64_t stream_id);


### PR DESCRIPTION
This patch addresses the compiler warnings raised by the GCC 11.2.1
compiler on Rocky Linux 8 arm64:

-Werror=shift-negative-value in I_Continuation.h:

```
In file included from src/ts_asf_master_test_build/iocore/eventsystem/I_Action.h:29,
                 from src/ts_asf_master_test_build/iocore/eventsystem/I_EventSystem.h:32,
                 from src/ts_asf_master_test_build/iocore/eventsystem/I_VConnection.h:29,
                 from QUICStreamVCAdapter.cc:24:
src/ts_asf_master_test_build/iocore/eventsystem/I_Continuation.h: In instantiation of _constexpr int (Continuation::* continuation_handler_void_ptr(int (C::*)(int, T*)))(int, void*) [with C = QUICStreamVCAdapter; T = void; ContinuationHandler = int (Continuation:
:*)(int, void*)]_:
QUICStreamVCAdapter.cc:29:3:   required from here
src/ts_asf_master_test_build/iocore/eventsystem/I_Continuation.h:74:10: error: left shift of negative value [-Werror=shift-negative-value]
   74 |   return static_cast<ContinuationHandler>(fp2);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

-Werror=sign-compare in fastlz.cc:

```
fastlz.cc: In function _void flz_copy64(uint8_t*, const uint8_t*, uint32_t)_:
fastlz.cc:209:17: error: comparison of integer expressions of different signedness: _int_ and _uint32_t_ {aka _unsigned int_} [-Werror=sign-compare]
  209 |   for (c = 0; c < count * 8; ++c) {
      |               ~~^~~~~~~~~~~
```

-Werror=maybe-uninitialized in header_rewrite:

```
header_rewrite/conditions.cc: In static member function _static void ConditionInbound::append_value(std::string&, const Resources&, NetworkSessionQualifiers)_:
header_rewrite/conditions.cc:1131:56: error: _tags_ may be used uninitialized [-Werror=maybe-uninitialized]
 1131 |     TSHttpTxnClientProtocolStackGet(res.txnp, tags.size(), tags.data(), &count);
      |                                               ~~~~~~~~~^~
In file included from header_rewrite/conditions.cc:29:
/opt/rh/gcc-toolset-11/root/usr/include/c++/11/array:176:7: note: by argument 1 of type _const std::array<const char*, 8>*_ to _constexpr std::array<_Tp, _Nm>::size_type std::array<_Tp, _Nm>::size() const [with _Tp = const char*; long unsigned int _Nm = 8]_ declared here
  176 |       size() const noexcept { return _Nm; }
      |       ^~~~
header_rewrite/conditions.cc:1128:33: note: _tags_ declared here
 1128 |     std::array<char const *, 8> tags;
      |                                 ^~~~
```

-Werror=type-limits in traffic_dump:

```
experimental/traffic_dump/json_utils.cc: In function _int {anonymous}::esc_json_out(const char*, int64_t, std::ostream&)_:
experimental/traffic_dump/json_utils.cc:117:18: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  117 |       if ('\x00' <= c && c <= '\x1f') {
      |           ~~~~~~~^~~~
```