### PR TITLE
traffic_ctl - JSONRPC: make sure we display the error regardless of the formatting type.

### DIFF
--- a/include/shared/rpc/RPCRequests.h
+++ b/include/shared/rpc/RPCRequests.h
@@ -203,24 +203,10 @@ operator<<(std::ostream &os, const RecordLookUpResponse::RecordError &re)
 inline std::ostream &
 operator<<(std::ostream &os, const JSONRPCError &err)
 {
-  os << "Error found.\n";
-  os << "code: " << err.code << '\n';
-  os << "message: " << err.message << '\n';
-  if (err.data.size() > 0) {
-    os << "---\nAdditional error information found:\n";
-    auto my_print = [&](auto const &e) {
-      os << "+ code: " << e.first << '\n';
-      os << "+ message: " << e.second << '\n';
-    };
-
-    auto iter = std::begin(err.data);
-
-    my_print(*iter);
-    ++iter;
-    for (; iter != std::end(err.data); ++iter) {
-      os << "---\n";
-      my_print(*iter);
-    }
+  os << "Server Error found:\n";
+  os << "[" << err.code << "] " << err.message << '\n';
+  for (auto &&[code, message] : err.data) {
+    os << "- [" << code << "] " << message << '\n';
   }
 
   return os;

--- a/src/traffic_ctl_jsonrpc/CtrlPrinters.cc
+++ b/src/traffic_ctl_jsonrpc/CtrlPrinters.cc
@@ -59,9 +59,10 @@ BasePrinter::write_output(shared::rpc::JSONRPCResponse const &response)
     return;
   }
 
-  if (response.is_error() && this->is_pretty_format()) {
-    // we print the error in this case. Already formatted.
-    std::cout << response.error.as<shared::rpc::JSONRPCError>();
+  if (response.is_error()) {
+    // If an error is present, then as per the specs we can ignore the jsonrpc.result field, so we print the error and we are done
+    // here!
+    std::cout << response.error.as<shared::rpc::JSONRPCError>(); // Already formatted.
     return;
   }
 


### PR DESCRIPTION
While working on a different pr I found out that some error weren't displayed by `traffic_ctl` as it was before the jsonrpc change, this change fixes this and also changes the output style for a "better" quick read, more like it was before jsonrpc.

Now this prints the main error and in a second level the more specifics. There could be more than one second level error.
```
$ traffic_ctl config set invalid.record val
Server Error found:
[9] Error during execution
- [2000] Record not found.
```