### PR TITLE
Allow for long Http* error.log lines

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -101,6 +101,9 @@ namespace
 // Unique state machine identifier
 std::atomic<int64_t> next_sm_id(0);
 
+/// Buffer for some error logs.
+thread_local std::string error_bw_buffer;
+
 /**
    Outbound PROXY Protocol
 
@@ -4168,27 +4171,18 @@ HttpSM::check_sni_host()
             Warning("No SNI for TLS request with hostname %.*s action=%s", host_len, host_name, action_value);
             SMDebug("ssl_sni", "No SNI for TLS request with hostname %.*s action=%s", host_len, host_name, action_value);
             if (host_sni_policy == 2) {
-              Log::error("%s", lbw()
-                                 .clip(1)
-                                 .print("No SNI for TLS request: connecting to {} for host='{}', returning a 403",
-                                        t_state.client_info.dst_addr, std::string_view{host_name, static_cast<size_t>(host_len)})
-                                 .extend(1)
-                                 .write('\0')
-                                 .data());
+              ts::bwprint(error_bw_buffer, "No SNI for TLS request: connecting to {} for host='{}', returning a 403",
+                          t_state.client_info.dst_addr, std::string_view{host_name, static_cast<size_t>(host_len)});
+              Log::error("%s", error_bw_buffer.c_str());
               this->t_state.client_connection_enabled = false;
             }
           } else if (strncasecmp(host_name, sni_value, host_len) != 0) { // Name mismatch
             Warning("SNI/hostname mismatch sni=%s host=%.*s action=%s", sni_value, host_len, host_name, action_value);
             SMDebug("ssl_sni", "SNI/hostname mismatch sni=%s host=%.*s action=%s", sni_value, host_len, host_name, action_value);
             if (host_sni_policy == 2) {
-              Log::error("%s", lbw()
-                                 .clip(1)
-                                 .print("SNI/hostname mismatch: connecting to {} for host='{}' sni='{}', returning a 403",
-                                        t_state.client_info.dst_addr, std::string_view{host_name, static_cast<size_t>(host_len)},
-                                        sni_value)
-                                 .extend(1)
-                                 .write('\0')
-                                 .data());
+              ts::bwprint(error_bw_buffer, "SNI/hostname mismatch: connecting to {} for host='{}' sni='{}', returning a 403",
+                          t_state.client_info.dst_addr, std::string_view{host_name, static_cast<size_t>(host_len)}, sni_value);
+              Log::error("%s", error_bw_buffer.c_str());
               this->t_state.client_connection_enabled = false;
             }
           } else {
@@ -5556,14 +5550,10 @@ HttpSM::mark_host_failure(HostDBInfo *info, time_t time_down)
         int host_len;
         const char *host_name_ptr = t_state.unmapped_url.host_get(&host_len);
         std::string_view host_name{host_name_ptr, size_t(host_len)};
-        Log::error("%s", lbw()
-                           .clip(1)
-                           .print("CONNECT: {::s} connecting to {} for host='{}' url='{}' marking down",
-                                  ts::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr,
-                                  host_name, ts::bwf::FirstOf(url_str, "<none>"))
-                           .extend(1)
-                           .write('\0')
-                           .data());
+        ts::bwprint(error_bw_buffer, "CONNECT: {::s} connecting to {} for host='{}' url='{}' marking down",
+                    ts::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr, host_name,
+                    ts::bwf::FirstOf(url_str, "<none>"));
+        Log::error("%s", error_bw_buffer.c_str());
 
         if (url_str) {
           t_state.arena.str_free(url_str);


### PR DESCRIPTION
Many URLs and log paths are long enough that the previous 256 byte
error.log limit for HttpSM and HttpTransact made it so that the logs got
truncated. Some of those logs had meaningful strings at the end which
made them hard to interpret unless you had the source code in front of
you to figure out what was truncated. This utilizes bwprint and local
std::string buffers for arbitrarily long log lines.
