### PR TITLE
Fix traffic_ctl server drain(undo) jsonrpc api call. 

### DIFF
--- a/src/traffic_ctl_jsonrpc/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl_jsonrpc/jsonrpc/CtrlRPCRequests.h
@@ -170,11 +170,7 @@ struct ServerStartDrainRequest : shared::rpc::ClientRequest {
   struct Params {
     bool waitForNewConnections{false};
   };
-  ServerStartDrainRequest(Params p)
-  {
-    super::method = "admin_server_start_drain";
-    super::params = p;
-  }
+  ServerStartDrainRequest(Params p) { super::params = p; }
   std::string
   get_method() const override
   {
@@ -187,7 +183,7 @@ struct ServerStopDrainRequest : shared::rpc::ClientRequest {
   std::string
   get_method() const override
   {
-    return "admin_server_start_drain";
+    return "admin_server_stop_drain";
   }
 };
 //------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
It was wrongly calling `admin_server_start_drain` when it was supposed to call `admin_server_stop_drain`.

```
$ traffic_ctl server drain --undo -f rpc
--> {"id": "af5e7d34-8143-45be-98d0-448ad2c3cb01", "jsonrpc": "2.0", "method": "admin_server_stop_drain"}
<-- {"jsonrpc": "2.0", "result": "success", "id": "af5e7d34-8143-45be-98d0-448ad2c3cb01"}
```