### PR TITLE
Add ts::overloaded as a type matching helper of std::visit

### DIFF
--- a/include/tscpp/util/Overloaded.h
+++ b/include/tscpp/util/Overloaded.h
@@ -1,0 +1,52 @@
+/** @file
+
+   A brief file description
+
+   @section license License
+
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+
+namespace ts
+{
+/**
+   Type matching helper for the visitor.
+   More details in https://en.cppreference.com/w/cpp/utility/variant/visit
+
+   Example:
+
+```
+std::variant<int, double> var;
+
+std::visit(ts::overloaded{
+             [](int &v) {std::cout << v << std::endl;},
+             [](double &v) {std::cout << v << std::endl;},
+           },
+           var});
+```
+
+ */
+
+template <class... Ts> struct overloaded : Ts... {
+  using Ts::operator()...;
+};
+
+// Explicit deduction guide (not needed as of C++20)
+template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+} // namespace ts


### PR DESCRIPTION
This is pretty useful when we use `std::variant` and `std::visit`. An example is in the comment. 
More details are in https://en.cppreference.com/w/cpp/utility/variant/visit.
