### PR TITLE
Re-introduce import to get man_pages list available for sphinx.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,6 +38,10 @@ import sys
 import os
 from datetime import date
 from sphinx import version_info
+# Import man_pages from manpages.py to get the list of manpages to generate in
+# separate files. Default is to put everything in apachetrafficserver.1
+# For these reasons, despite what linting tools might say, this import is required.
+from manpages import man_pages
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
As explain in #8858, current man pages generation is broken.
Re-introducing the import fixes it.
Error has been introduced in commit 005b04bfbaa0381ccf214e4f781f6bf402426de0
 Closes #8858