### PR TITLE
Deprecate TSSslSecretGet (not thread safe).

### DIFF
--- a/doc/developer-guide/api/functions/TSSslSecret.en.rst
+++ b/doc/developer-guide/api/functions/TSSslSecret.en.rst
@@ -39,7 +39,8 @@ from the :cpp:enumerator:`TS_LIFECYCLE_SSL_SECRET_HOOK`.
 TSSslSecretGet
 **************
 
-Get the data associated with a secret name specified in the config.
+Get the data associated with a secret name specified in the config.  **Note:** this function is deprecated, it is not
+thread safe.  It will be replaced with a thread-safe function in Release 10.
 
 Synopsis
 ========

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1304,6 +1304,8 @@ tsapi TSReturnCode TSSslServerCertUpdate(const char *cert_path, const char *key_
 
 /* Update the transient secret table for SSL_CTX loading */
 tsapi TSReturnCode TSSslSecretSet(const char *secret_name, int secret_name_length, const char *secret_data, int secret_data_len);
+/* NOTE:  TSSslSecretGet() is deprecated, it is not thread-safe.  It will be replaced with a thread-safe function
+** in Release 10 */
 tsapi TSReturnCode TSSslSecretGet(const char *secret_name, int secret_name_length, const char **secret_data_return,
                                   int *secret_data_len);
 


### PR DESCRIPTION
The current version is not thread safe because it returns a pointer into a mutex-protected data structure, which may be invalidated by another thread