### PR TITLE
Autest: Increase the delay time after a config reload rpc all was done.

### DIFF
--- a/tests/gold_tests/remap/remap_reload.test.py
+++ b/tests/gold_tests/remap/remap_reload.test.py
@@ -56,28 +56,24 @@ tr_2.Disk.File(remap_cfg_path, typename="ats:config").AddLines([
     f"map http://alpha.ex http://alpha.ex:{pv_port}", f"map http://bravo.ex http://bravo.ex:{pv_port}"
 ])
 
-tr_3 = Test.AddTestRun("pause")
-tr_3.Processes.Default.Command = 'sleep 5'
+tr_3 = Test.AddTestRun("after first reload")
+tr_3.DelayStart = 10
+tr_3.AddVerifierClientProcess("client_2", replay_file_2, http_ports=[tm.Variables.port])
 
-tr_4 = Test.AddTestRun("after first reload")
-tr_4.AddVerifierClientProcess("client_2", replay_file_2, http_ports=[tm.Variables.port])
-
-tr_5 = Test.AddTestRun("reload-succeed")
-tr_5.Processes.Default.Command = 'traffic_ctl config reload'
-tr_5.Processes.Default.Env = tm.Env
-tr_5.Disk.File(remap_cfg_path).WriteOn("")
-tr_5.Disk.File(remap_cfg_path,
+tr_4 = Test.AddTestRun("reload-succeed")
+tr_4.Processes.Default.Command = 'traffic_ctl config reload'
+tr_4.Processes.Default.Env = tm.Env
+tr_4.Disk.File(remap_cfg_path).WriteOn("")
+tr_4.Disk.File(remap_cfg_path,
                typename="ats:config").AddLines([f"map http://echo.ex http://echo.ex:{pv_port}",
                                                 f"map http://foxtrot.ex http://foxtrot.ex:{pv_port}",
                                                 f"map http://golf.ex http://golf.ex:{pv_port}",
                                                 f"map http://hotel.ex http://hotel.ex:{pv_port}",
                                                 f"map http://india.ex http://india.ex:{pv_port}"])
 
-tr_6 = Test.AddTestRun("pause")
-tr_6.Processes.Default.Command = 'sleep 5'
+tr_5 = Test.AddTestRun("post update charlie")
+tr_5.DelayStart = 10
+tr_5.AddVerifierClientProcess("client_3", replay_file_3, http_ports=[tm.Variables.port])
 
-tr_7 = Test.AddTestRun("post update charlie")
-tr_7.AddVerifierClientProcess("client_3", replay_file_3, http_ports=[tm.Variables.port])
-
-tr_8 = Test.AddTestRun("post update golf")
-tr_8.AddVerifierClientProcess("client_4", replay_file_4, http_ports=[tm.Variables.port])
+tr_6 = Test.AddTestRun("post update golf")
+tr_6.AddVerifierClientProcess("client_4", replay_file_4, http_ports=[tm.Variables.port])


### PR DESCRIPTION
This particular test `remap_reload` seems to be failing randomly, it could be the delay time was too short, setting it to 10s now.

Let's see if this fixes https://github.com/apache/trafficserver/issues/8860

If not, I'll be happy to revert this back.