### PR TITLE
Handle hit as miss when cach obj is invalid

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2798,6 +2798,11 @@ HttpTransact::HandleCacheOpenReadHit(State *s)
     obj = s->cache_info.object_read;
   }
 
+  if (obj == nullptr || !obj->valid()) {
+    HandleCacheOpenReadMiss(s);
+    return;
+  }
+
   // do we have to authenticate with the server before
   // sending back the cached response to the client?
   Authentication_t authentication_needed = AuthenticationNeeded(s->txn_conf, &s->hdr_info.client_request, obj->response_get());


### PR DESCRIPTION
When cache object is invalid but has a hit status, it should be handled as a miss so no assumptions or invalid access to the object will be made