### PR TITLE
Add proxy.process.hostdb.total_serve_stale

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/hostdb.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/hostdb.en.rst
@@ -49,6 +49,15 @@ origin servers' hostnames prior to object revalidation or retrieval.
    satisfied by entries in the HostDB lookup cache, since statistics collection
    began.
 
+.. ts:stat:: global proxy.process.hostdb.total_serve_stale integer
+   :type: counter
+
+   Represents the total number of origin server name resolutions which were
+   satisfied by entries in the HostDB lookup cache while those entries were
+   stale, since statistics collection began. See
+   :ts:cv:`proxy.config.hostdb.serve_stale_for` for how this feature is
+   configured.
+
 .. ts:stat:: global proxy.process.hostdb.total_lookups integer
    :type: counter
 

--- a/doc/appendices/command-line/traffic_top.en.rst
+++ b/doc/appendices/command-line/traffic_top.en.rst
@@ -207,6 +207,16 @@ cache.
 
 Statistic: :ts:stat:`proxy.process.hostdb.total_hits`.
 
+DNS Serve Stale
+~~~~~~~~~~~~~~~
+
+Total number of DNS lookups which were successfully served from the HostDB
+cache while the HostDB cache entry was stale. See
+:ts:cv:`proxy.config.hostdb.serve_stale_for` for how this feature is
+configured.
+
+Statistic: :ts:stat:`proxy.process.hostdb.total_serve_stale`.
+
 Ram Hit
 ~~~~~~~
 

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -571,6 +571,7 @@ probe(const Ptr<ProxyMutex> &mutex, HostDBHash const &hash, bool ignore_timeout)
 
   // If the record is stale, but we want to revalidate-- lets start that up
   if ((!ignore_timeout && r->is_ip_stale() && !r->reverse_dns) || (r->is_ip_timeout() && r->serve_stale_but_revalidate())) {
+    HOSTDB_INCREMENT_DYN_STAT(hostdb_total_serve_stale_stat);
     if (hostDB.is_pending_dns_for_hash(hash.hash)) {
       Debug("hostdb", "stale %u %u %u, using it and pending to refresh it", r->ip_interval(), r->ip_timestamp,
             r->ip_timeout_interval);
@@ -2090,6 +2091,9 @@ ink_hostdb_init(ts::ModuleVersion v)
 
   RecRegisterRawStat(hostdb_rsb, RECT_PROCESS, "proxy.process.hostdb.total_hits", RECD_INT, RECP_PERSISTENT,
                      (int)hostdb_total_hits_stat, RecRawStatSyncSum);
+
+  RecRegisterRawStat(hostdb_rsb, RECT_PROCESS, "proxy.process.hostdb.total_serve_stale", RECD_INT, RECP_PERSISTENT,
+                     (int)hostdb_total_serve_stale_stat, RecRawStatSyncSum);
 
   RecRegisterRawStat(hostdb_rsb, RECT_PROCESS, "proxy.process.hostdb.ttl", RECD_FLOAT, RECP_PERSISTENT, (int)hostdb_ttl_stat,
                      RecRawStatSyncAvg);

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -136,9 +136,10 @@ struct HostEnt;
 // Stats
 enum HostDB_Stats {
   hostdb_total_lookups_stat,
-  hostdb_total_hits_stat,  // D == total hits
-  hostdb_ttl_stat,         // D average TTL
-  hostdb_ttl_expires_stat, // D == TTL Expires
+  hostdb_total_hits_stat,        // D == total hits
+  hostdb_total_serve_stale_stat, // D == total times we served a stale response
+  hostdb_ttl_stat,               // D average TTL
+  hostdb_ttl_expires_stat,       // D == TTL Expires
   hostdb_re_dns_on_reload_stat,
   hostdb_insert_duplicate_to_pending_dns_stat,
   HostDB_Stat_Count

--- a/src/traffic_top/stats.h
+++ b/src/traffic_top/stats.h
@@ -112,6 +112,7 @@ public:
     lookup_table.insert(make_pair("dns_entry", LookupItem("DNS Entry", "proxy.process.hostdb.cache.current_items", 1)));
     lookup_table.insert(make_pair("dns_hits", LookupItem("DNS Hits", "proxy.process.hostdb.total_hits", 2)));
     lookup_table.insert(make_pair("dns_lookups", LookupItem("DNS Lookups", "proxy.process.hostdb.total_lookups", 2)));
+    lookup_table.insert(make_pair("dns_serve_stale", LookupItem("DNS Serve Stale", "proxy.process.hostdb.total_serve_stale", 2)));
 
     // Incoming HTTP/1.1 and HTTP/2 connections - some metrics are HTTP version specific
     lookup_table.insert(make_pair("client_req", LookupItem("Requests", "proxy.process.http.incoming_requests", 2)));


### PR DESCRIPTION
Add a HostDB statistic for the number of times we serve a stale DNS
response from the HostDB cache while a DNS refresh fetch is taking
place.