### PR TITLE
Adds a new member for TSRemapInterface tracking the plugin loaded

### DIFF
--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -1036,6 +1036,7 @@ typedef struct tsapi_bufferreader *TSIOBufferReader;
 typedef struct tsapi_hostlookupresult *TSHostLookupResult;
 typedef struct tsapi_aiocallback *TSAIOCallback;
 typedef struct tsapi_net_accept *TSAcceptor;
+typedef struct tsapi_remap_plugin_info *TSRemapPluginInfo;
 
 typedef struct tsapi_fetchsm *TSFetchSM;
 

--- a/include/ts/remap.h
+++ b/include/ts/remap.h
@@ -38,6 +38,7 @@ extern "C" {
 typedef struct _tsremap_api_info {
   unsigned long size;            /* in: sizeof(struct _tsremap_api_info) */
   unsigned long tsremap_version; /* in: TS supported version ((major << 16) | minor) */
+  TSRemapPluginInfo plugin_info; /* in: Pointer to the internal RemapPluginInst */
 } TSRemapInterface;
 
 typedef struct _tm_remap_request_info {

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2646,6 +2646,9 @@ tsapi TSReturnCode TSRemapFromUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp);
 //
 tsapi TSReturnCode TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp);
 
+// Get some plugin details from the TSRemapPluginInfo
+tsapi void *TSRemapDLHandleGet(TSRemapPluginInfo plugin_info);
+
 // Override response behavior, and hard-set the state machine for whether to succeed or fail, and how.
 tsapi void TSHttpTxnResponseActionSet(TSHttpTxn txnp, TSResponseAction *action);
 

--- a/proxy/http/remap/PluginDso.h
+++ b/proxy/http/remap/PluginDso.h
@@ -73,6 +73,11 @@ public:
   const fs::path &runtimePath() const;
   time_t modTime() const;
   void *dlOpenHandle() const;
+  void *
+  dlh() const
+  {
+    return _dlh;
+  }
 
   /* List used by the plugin factory */
   using self_type  = PluginDso; ///< Self reference type.

--- a/proxy/http/remap/RemapPluginInfo.cc
+++ b/proxy/http/remap/RemapPluginInfo.cc
@@ -134,6 +134,7 @@ RemapPluginInfo::init(std::string &error)
   ink_zero(ri);
   ri.size            = sizeof(ri);
   ri.tsremap_version = TSREMAP_VERSION;
+  ri.plugin_info     = reinterpret_cast<TSRemapPluginInfo>(this);
 
   setPluginContext();
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -10199,6 +10199,15 @@ TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp)
   return remapUrlGet(txnp, urlLocp, &UrlMappingContainer::getToURL);
 }
 
+tsapi void *
+TSRemapDLHandleGet(TSRemapPluginInfo plugin_info)
+{
+  sdk_assert(sdk_sanity_check_null_ptr(plugin_info));
+  RemapPluginInfo *info = reinterpret_cast<RemapPluginInfo *>(plugin_info);
+
+  return info->dlh();
+}
+
 TSReturnCode
 TSHostnameIsSelf(const char *hostname, size_t hostname_len)
 {


### PR DESCRIPTION
This allows for a plugin to introspect itself when TSRemapInit() is
being called. It's currently only implementing TSRemapDLHandleGet(),
which returns the handle to the .so as returned by dlopen(). With
this handle, a plugin can use e.g. dlsym() and dlinfo() to introspect
the plugin that it's loaded with.

Note that I've put this on 10-Dev. It's perhaps not ABI incompatible,
but seeing that it changes ts/remap.h internals, better to be safe
then sorry.