### PR TITLE
Adds a new member for TSRemapInterface tracking the plugin loaded

### DIFF
--- a/doc/developer-guide/api/functions/TSRemap.en.rst
+++ b/doc/developer-guide/api/functions/TSRemap.en.rst
@@ -39,6 +39,7 @@ Synopsis
 .. function:: TSReturnCode TSRemapNewInstance(int argc, char * argv[], void ** ih, char * errbuff, int errbuff_size)
 .. function:: void TSRemapDeleteInstance(void * )
 .. function:: void TSRemapOSResponse(void * ih, TSHttpTxn rh, int os_response_type)
+.. function:: void* TSRemapDLHandleGet(TSRemapPluginInfo plugin_info)
 
 Description
 ===========
@@ -63,6 +64,9 @@ will call the entry point each time a plugin is specified in a remap
 rule. When a remap plugin instance is no longer required, Traffic Server
 will call :func:`TSRemapDeleteInstance`. At that point, it's safe to remove
 any data or continuations associated with that instance.
+
+The function :func:`TSRemapDLHandleGet` will return the handle created for
+the loaded plugin, as returned by `dlopen()`.
 
 :func:`TSRemapDoRemap` is called for each HTTP transaction. This is a mandatory
 entry point. In this function, the remap plugin may examine and modify

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -196,6 +196,16 @@ more widely. Those are described on this page.
       The API version of the C API. The lower 16 bits are the minor version, and the upper bits
       the major version.
 
+   .. member:: TSRemapPluginInfo plugin_info
+
+      An opaque object, which holds various details about the currently loaded and running
+      plugin. You can't access the details directly, but rather must call an acess function
+      such as :func:`TSRemapDLHandleGet`.
+
+.. type:: TSRemapPluginInfo
+
+   Opaque data passed to a remap plugin via :func:`TSRemapInit` in the `plugin_info` member above.
+
 .. type:: TSRemapRequestInfo
 
    Data passed to a remap plugin during the invocation of a remap rule.

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -199,7 +199,7 @@ more widely. Those are described on this page.
    .. member:: TSRemapPluginInfo plugin_info
 
       An opaque object, which holds various details about the currently loaded and running
-      plugin. You can't access the details directly, but rather must call an acess function
+      plugin. You can't access the details directly, but rather must call an access function
       such as :func:`TSRemapDLHandleGet`.
 
 .. type:: TSRemapPluginInfo

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -1037,6 +1037,7 @@ typedef struct tsapi_bufferreader *TSIOBufferReader;
 typedef struct tsapi_hostlookupresult *TSHostLookupResult;
 typedef struct tsapi_aiocallback *TSAIOCallback;
 typedef struct tsapi_net_accept *TSAcceptor;
+typedef struct tsapi_remap_plugin_info *TSRemapPluginInfo;
 
 typedef struct tsapi_fetchsm *TSFetchSM;
 

--- a/include/ts/remap.h
+++ b/include/ts/remap.h
@@ -38,6 +38,7 @@ extern "C" {
 typedef struct _tsremap_api_info {
   unsigned long size;            /* in: sizeof(struct _tsremap_api_info) */
   unsigned long tsremap_version; /* in: TS supported version ((major << 16) | minor) */
+  TSRemapPluginInfo plugin_info; /* in: Pointer to the internal RemapPluginInst */
 } TSRemapInterface;
 
 typedef struct _tm_remap_request_info {

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2675,6 +2675,9 @@ tsapi TSReturnCode TSRemapFromUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp);
 //
 tsapi TSReturnCode TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp);
 
+// Get some plugin details from the TSRemapPluginInfo
+tsapi void *TSRemapDLHandleGet(TSRemapPluginInfo plugin_info);
+
 // Override response behavior, and hard-set the state machine for whether to succeed or fail, and how.
 tsapi void TSHttpTxnResponseActionSet(TSHttpTxn txnp, TSResponseAction *action);
 

--- a/proxy/http/remap/PluginDso.h
+++ b/proxy/http/remap/PluginDso.h
@@ -73,6 +73,11 @@ public:
   const fs::path &runtimePath() const;
   time_t modTime() const;
   void *dlOpenHandle() const;
+  void *
+  dlh() const
+  {
+    return _dlh;
+  }
 
   /* List used by the plugin factory */
   using self_type  = PluginDso; ///< Self reference type.

--- a/proxy/http/remap/RemapPluginInfo.cc
+++ b/proxy/http/remap/RemapPluginInfo.cc
@@ -134,6 +134,7 @@ RemapPluginInfo::init(std::string &error)
   ink_zero(ri);
   ri.size            = sizeof(ri);
   ri.tsremap_version = TSREMAP_VERSION;
+  ri.plugin_info     = reinterpret_cast<TSRemapPluginInfo>(this);
 
   setPluginContext();
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -10210,6 +10210,15 @@ TSRemapToUrlGet(TSHttpTxn txnp, TSMLoc *urlLocp)
   return remapUrlGet(txnp, urlLocp, &UrlMappingContainer::getToURL);
 }
 
+tsapi void *
+TSRemapDLHandleGet(TSRemapPluginInfo plugin_info)
+{
+  sdk_assert(sdk_sanity_check_null_ptr(plugin_info));
+  RemapPluginInfo *info = reinterpret_cast<RemapPluginInfo *>(plugin_info);
+
+  return info->dlh();
+}
+
 TSReturnCode
 TSHostnameIsSelf(const char *hostname, size_t hostname_len)
 {

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -429,7 +429,8 @@ public:
     int diags_log_roll_int    = static_cast<int>(REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_interval_sec"));
     int diags_log_roll_size   = static_cast<int>(REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_size_mb"));
     int diags_log_roll_enable = static_cast<int>(REC_ConfigReadInteger("proxy.config.diags.logfile.rolling_enabled"));
-    diags()->config_roll_diagslog(static_cast<RollingEnabledValues>(diags_log_roll_enable), diags_log_roll_int, diags_log_roll_size);
+    diags()->config_roll_diagslog(static_cast<RollingEnabledValues>(diags_log_roll_enable), diags_log_roll_int,
+                                  diags_log_roll_size);
 
     if (diags()->should_roll_diagslog()) {
       Note("Rolled %s", diags_log_filename);
@@ -442,7 +443,7 @@ public:
       int output_log_roll_size   = static_cast<int>(REC_ConfigReadInteger("proxy.config.output.logfile.rolling_size_mb"));
       int output_log_roll_enable = static_cast<int>(REC_ConfigReadInteger("proxy.config.output.logfile.rolling_enabled"));
       diags()->config_roll_outputlog(static_cast<RollingEnabledValues>(output_log_roll_enable), output_log_roll_int,
-                                   output_log_roll_size);
+                                     output_log_roll_size);
 
       if (diags()->should_roll_outputlog()) {
         Note("Rolled %s", traffic_out_name.c_str());


### PR DESCRIPTION
This allows for a plugin to introspect itself when TSRemapInit() is
being called. It's currently only implementing TSRemapDLHandleGet(),
which returns the handle to the .so as returned by dlopen(). With
this handle, a plugin can use e.g. dlsym() and dlinfo() to introspect
the plugin that it's loaded with.

Note that I've put this on 10-Dev. It's perhaps not ABI incompatible,
but seeing that it changes ts/remap.h internals, better to be safe
then sorry.