### PR TITLE
Add escape json for logging

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -882,5 +882,7 @@ Some examples below ::
   '%<cqup[-10:]>' // the last 10 characters of <cqup>.
   '%<cqup[:-5]>'  // everything except the last 5 characters of <cqup>.
 
-Note the slicing is done before escaping log fields when ``escape`` in
-``format`` is set to ``json``.
+Note when ``escape`` in ``format`` is set to ``json``, the start is the
+position before escaping JSON strings, and escaped values are sliced at
+the length (= end - start). If slicing cuts in the middle of escaped
+characters, the whole character is removed.

--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -39,7 +39,8 @@ fairly simple: every format must contain a ``Format`` attribute, which is the
 string defining the contents of each line in the log, and may also contain an
 optional ``Interval`` attribute defining the log aggregation interval for
 any logs which use the format (see :ref:`admin-logging-type-summary` for more
-information).
+information). It may also contain an optional ``escape`` attribute defining the
+escape of log fields. Possible values for ``escape`` are ``json`` or ``none``.
 
 The return value from the ``format`` function is the log format object which
 may then be supplied to the appropriate ``log.*`` functions that define your
@@ -880,3 +881,6 @@ Some examples below ::
   '%<cqup[0:30]>' // the first 30 characters of <cqup>.
   '%<cqup[-10:]>' // the last 10 characters of <cqup>.
   '%<cqup[:-5]>'  // everything except the last 5 characters of <cqup>.
+
+Note the slicing is done before escaping log fields when ``escape`` in
+``format`` is set to ``json``.

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -685,6 +685,7 @@ EscLookup::_LUT::_LUT()
   table['\r'] = 'r';
   table['\\'] = '\\';
   table['\"'] = '"';
+  table['/']  = '/';
 }
 
 char

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -947,7 +947,6 @@ LogAccess::unmarshal_http_text_json(char **buf, char *dest, int len, LogSlice *s
 
   char *p = dest;
 
-  //    int res1 = unmarshal_http_method (buf, p, len);
   int res1 = unmarshal_str_json(buf, p, len);
   if (res1 < 0) {
     return -1;

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -678,14 +678,14 @@ EscLookup::_LUT::_LUT()
 
   // Short escapes.
   //
-  table['\b'] = 'b';
-  table['\t'] = 't';
-  table['\n'] = 'n';
-  table['\f'] = 'f';
-  table['\r'] = 'r';
-  table['\\'] = '\\';
-  table['\"'] = '"';
-  table['/']  = '/';
+  table[static_cast<int>('\b')] = 'b';
+  table[static_cast<int>('\t')] = 't';
+  table[static_cast<int>('\n')] = 'n';
+  table[static_cast<int>('\f')] = 'f';
+  table[static_cast<int>('\r')] = 'r';
+  table[static_cast<int>('\\')] = '\\';
+  table[static_cast<int>('\"')] = '"';
+  table[static_cast<int>('/')]  = '/';
 }
 
 char

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -684,7 +684,7 @@ EscLookup::_LUT::_LUT()
   table['\f'] = 'f';
   table['\r'] = 'r';
   table['\\'] = '\\';
-  table['\"'] = '\\';
+  table['\"'] = '"';
 }
 
 char

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -305,12 +305,14 @@ public:
   static int unmarshal_int_to_str(char **buf, char *dest, int len);
   static int unmarshal_int_to_str_hex(char **buf, char *dest, int len);
   static int unmarshal_str(char **buf, char *dest, int len, LogSlice *slice = nullptr);
+  static int unmarshal_str_json(char **buf, char *dest, int len, LogSlice *slice = nullptr);
   static int unmarshal_ttmsf(char **buf, char *dest, int len);
   static int unmarshal_int_to_date_str(char **buf, char *dest, int len);
   static int unmarshal_int_to_time_str(char **buf, char *dest, int len);
   static int unmarshal_int_to_netscape_str(char **buf, char *dest, int len);
   static int unmarshal_http_version(char **buf, char *dest, int len);
   static int unmarshal_http_text(char **buf, char *dest, int len, LogSlice *slice = nullptr);
+  static int unmarshal_http_text_json(char **buf, char *dest, int len, LogSlice *slice = nullptr);
   static int unmarshal_http_status(char **buf, char *dest, int len);
   static int unmarshal_ip(char **buf, IpEndpoint *dest);
   static int unmarshal_ip_to_str(char **buf, char *dest, int len);

--- a/proxy/logging/LogBuffer.cc
+++ b/proxy/logging/LogBuffer.cc
@@ -445,7 +445,7 @@ LogBuffer::max_entry_bytes()
 int
 LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char *read_from, char *write_to, int write_to_len,
                                 long timestamp, long timestamp_usec, unsigned buffer_version, LogFieldList *alt_fieldlist,
-                                char *alt_printf_str)
+                                char *alt_printf_str, LogEscapeType escape_type)
 {
   if (fieldlist == nullptr || printf_str == nullptr) {
     return 0;
@@ -501,7 +501,7 @@ LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char 
       ++markCount;
       if (field != nullptr) {
         char *to = &write_to[bytes_written];
-        res      = field->unmarshal(&read_from, to, write_to_len - bytes_written);
+        res      = field->unmarshal(&read_from, to, write_to_len - bytes_written, escape_type);
 
         if (res < 0) {
           SiteThrottledNote("%s", buffer_size_exceeded_msg);
@@ -549,7 +549,7 @@ LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char 
   -------------------------------------------------------------------------*/
 int
 LogBuffer::to_ascii(LogEntryHeader *entry, LogFormatType type, char *buf, int buf_len, const char *symbol_str, char *printf_str,
-                    unsigned buffer_version, const char *alt_format)
+                    unsigned buffer_version, const char *alt_format, LogEscapeType escape_type)
 {
   ink_assert(entry != nullptr);
   ink_assert(type == LOG_FORMAT_CUSTOM || type == LOG_FORMAT_TEXT);
@@ -642,7 +642,7 @@ LogBuffer::to_ascii(LogEntryHeader *entry, LogFormatType type, char *buf, int bu
   }
 
   int ret = resolve_custom_entry(fieldlist, printf_str, read_from, write_to, buf_len, entry->timestamp, entry->timestamp_usec,
-                                 buffer_version, alt_fieldlist, alt_printf_str);
+                                 buffer_version, alt_fieldlist, alt_printf_str, escape_type);
 
   delete alt_fieldlist;
   ats_free(alt_printf_str);

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -189,10 +189,10 @@ public:
   // static functions
   static size_t max_entry_bytes();
   static int to_ascii(LogEntryHeader *entry, LogFormatType type, char *buf, int max_len, const char *symbol_str, char *printf_str,
-                      unsigned buffer_version, const char *alt_format = nullptr);
+                      unsigned buffer_version, const char *alt_format = nullptr, LogEscapeType escape_type = LOG_ESCAPE_NONE);
   static int resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char *read_from, char *write_to, int write_to_len,
                                   long timestamp, long timestamp_us, unsigned buffer_version, LogFieldList *alt_fieldlist = nullptr,
-                                  char *alt_printf_str = nullptr);
+                                  char *alt_printf_str = nullptr, LogEscapeType escape_type = LOG_ESCAPE_NONE);
 
   static void
   destroy(LogBuffer *&lb)

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -32,6 +32,8 @@
 #include "LogFieldAliasMap.h"
 #include "Milestones.h"
 
+enum LogEscapeType { LOG_ESCAPE_NONE, LOG_ESCAPE_JSON };
+
 class LogAccess;
 
 struct LogSlice {
@@ -133,7 +135,7 @@ public:
   unsigned marshal_len(LogAccess *lad);
   unsigned marshal(LogAccess *lad, char *buf);
   unsigned marshal_agg(char *buf);
-  unsigned unmarshal(char **buf, char *dest, int len);
+  unsigned unmarshal(char **buf, char *dest, int len, LogEscapeType escape_type = LOG_ESCAPE_NONE);
   void display(FILE *fd = stdout);
   bool operator==(LogField &rhs);
   void updateField(LogAccess *lad, char *val, int len);

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -63,9 +63,10 @@
   -------------------------------------------------------------------------*/
 
 LogFile::LogFile(const char *name, const char *header, LogFileFormat format, uint64_t signature, size_t ascii_buffer_size,
-                 size_t max_line_size, int pipe_buffer_size)
+                 size_t max_line_size, int pipe_buffer_size, LogEscapeType escape_type)
   : m_file_format(format),
     m_name(ats_strdup(name)),
+    m_escape_type(escape_type),
     m_header(ats_strdup(header)),
     m_signature(signature),
     m_max_line_size(max_line_size),
@@ -83,7 +84,7 @@ LogFile::LogFile(const char *name, const char *header, LogFileFormat format, uin
   m_fd                = -1;
   m_ascii_buffer_size = (ascii_buffer_size < max_line_size ? max_line_size : ascii_buffer_size);
 
-  Debug("log-file", "exiting LogFile constructor, m_name=%s, this=%p", m_name, this);
+  Debug("log-file", "exiting LogFile constructor, m_name=%s, this=%p, escape_type=%d", m_name, this, escape_type);
 }
 
 /*-------------------------------------------------------------------------
@@ -627,7 +628,7 @@ LogFile::write_ascii_logbuffer3(LogBufferHeader *buffer_header, const char *alt_
       }
 
       int bytes = LogBuffer::to_ascii(entry_header, format_type, &ascii_buffer[fmt_buf_bytes], m_max_line_size - 1, fieldlist_str,
-                                      printf_str, buffer_header->version, alt_format);
+                                      printf_str, buffer_header->version, alt_format, get_escape_type());
 
       if (bytes > 0) {
         fmt_buf_bytes += bytes;

--- a/proxy/logging/LogFile.h
+++ b/proxy/logging/LogFile.h
@@ -43,7 +43,7 @@ class LogFile : public LogBufferSink, public RefCountObj
 {
 public:
   LogFile(const char *name, const char *header, LogFileFormat format, uint64_t signature, size_t ascii_buffer_size = 4 * 9216,
-          size_t max_line_size = 9216, int pipe_buffer_size = 0);
+          size_t max_line_size = 9216, int pipe_buffer_size = 0, LogEscapeType escape_type = LOG_ESCAPE_NONE);
   LogFile(const LogFile &);
   ~LogFile() override;
 
@@ -83,6 +83,12 @@ public:
     return m_file_format;
   }
 
+  LogEscapeType
+  get_escape_type() const
+  {
+    return m_escape_type;
+  }
+
   const char *
   get_format_name() const
   {
@@ -120,6 +126,7 @@ public:
 
 private:
   char *m_name;
+  LogEscapeType m_escape_type;
 
 public:
   BaseLogFile *m_log; // BaseLogFile backs the actual file on disk

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -177,7 +177,7 @@ LogFormat::init_variables(const char *name, const char *fieldlist_str, const cha
   form %<symbol>.
   -------------------------------------------------------------------------*/
 
-LogFormat::LogFormat(const char *name, const char *format_str, unsigned interval_sec)
+LogFormat::LogFormat(const char *name, const char *format_str, unsigned interval_sec, LogEscapeType escape_type)
   : m_interval_sec(0),
     m_interval_next(0),
     m_agg_marshal_space(nullptr),
@@ -189,7 +189,8 @@ LogFormat::LogFormat(const char *name, const char *format_str, unsigned interval
     m_field_count(0),
     m_printf_str(nullptr),
     m_aggregate(false),
-    m_format_str(nullptr)
+    m_format_str(nullptr),
+    m_escape_type(escape_type)
 {
   setup(name, format_str, interval_sec);
 
@@ -218,7 +219,8 @@ LogFormat::LogFormat(const LogFormat &rhs)
     m_printf_str(nullptr),
     m_aggregate(false),
     m_format_str(nullptr),
-    m_format_type(rhs.m_format_type)
+    m_format_type(rhs.m_format_type),
+    m_escape_type(rhs.m_escape_type)
 {
   if (m_valid) {
     if (m_format_type == LOG_FORMAT_TEXT) {

--- a/proxy/logging/LogFormat.h
+++ b/proxy/logging/LogFormat.h
@@ -52,7 +52,7 @@ enum LogFileFormat {
 class LogFormat : public RefCountObj
 {
 public:
-  LogFormat(const char *name, const char *format_str, unsigned interval_sec = 0);
+  LogFormat(const char *name, const char *format_str, unsigned interval_sec = 0, LogEscapeType escape_type = LOG_ESCAPE_NONE);
   LogFormat(const char *name, const char *fieldlist_str, const char *printf_str, unsigned interval_sec = 0);
   LogFormat(const LogFormat &rhs);
 
@@ -94,6 +94,11 @@ public:
   type() const
   {
     return m_format_type;
+  }
+  LogEscapeType
+  escape_type() const
+  {
+    return m_escape_type;
   }
   char *
   printf_str() const
@@ -158,6 +163,7 @@ private:
   bool m_aggregate;
   char *m_format_str;
   LogFormatType m_format_type;
+  LogEscapeType m_escape_type;
 
 public:
   LINK(LogFormat, link);

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -122,8 +122,8 @@ LogObject::LogObject(LogConfig *cfg, const LogFormat *format, const char *log_di
   // compute_signature is a static function
   m_signature = compute_signature(m_format, m_basename, m_flags);
 
-  m_logFile =
-    new LogFile(m_filename, header, file_format, m_signature, cfg->ascii_buffer_size, cfg->max_line_size, m_pipe_buffer_size);
+  m_logFile = new LogFile(m_filename, header, file_format, m_signature, cfg->ascii_buffer_size, cfg->max_line_size,
+                          m_pipe_buffer_size, format->escape_type());
 
   if (m_reopen_after_rolling) {
     m_logFile->open_file();

--- a/tests/gold_tests/logging/gold/field-json-test.gold
+++ b/tests/gold_tests/logging/gold/field-json-test.gold
@@ -1,0 +1,3 @@
+{"foo":"ab\td\/ef","foo-slice":"\td"}
+{"foo":"ab\u001fd\/ef","foo-slice":"\u001fd"}
+{"foo":"abc\u007fde","foo-slice":"c"}

--- a/tests/gold_tests/logging/log-field-json.test.py
+++ b/tests/gold_tests/logging/log-field-json.test.py
@@ -1,0 +1,109 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Test log fields.
+'''
+
+ts = Test.MakeATSProcess("ts", enable_cache=False)
+server = Test.MakeOriginServer("server")
+
+request_header = {'timestamp': 100, "headers": "GET /test-1 HTTP/1.1\r\nHost: test-1\r\n\r\n", "body": ""}
+response_header = {
+    'timestamp': 100,
+    "headers": "HTTP/1.1 200 OK\r\nTest: 1\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+    "body": "Test 1"}
+server.addResponse("sessionlog.json", request_header, response_header)
+server.addResponse("sessionlog.json",
+                   {'timestamp': 101,
+                    "headers": "GET /test-2 HTTP/1.1\r\nHost: test-2\r\n\r\n",
+                    "body": ""},
+                   {'timestamp': 101,
+                       "headers": "HTTP/1.1 200 OK\r\nTest: 2\r\nContent-Type: application/jason\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+                       "body": "Test 2"})
+server.addResponse("sessionlog.json",
+                   {'timestamp': 102,
+                    "headers": "GET /test-3 HTTP/1.1\r\nHost: test-3\r\n\r\n",
+                    "body": ""},
+                   {'timestamp': 102,
+                       "headers": "HTTP/1.1 200 OK\r\nTest: 3\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+                       "body": "Test 3"})
+
+nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
+
+ts.Disk.records_config.update({
+    'proxy.config.net.connections_throttle': 100,
+    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+    'proxy.config.dns.resolv_conf': 'NULL'
+})
+# setup some config file for this server
+ts.Disk.remap_config.AddLine(
+    'map / http://localhost:{}/'.format(server.Variables.Port)
+)
+
+ts.Disk.logging_yaml.AddLines(
+    '''
+logging:
+  formats:
+    - name: custom
+      escape: json
+      format: '{"foo":"%<{Foo}cqh>","foo-slice":"%<{Foo}cqh[2:-3]>"}'
+  logs:
+    - filename: field-json-test
+      format: custom
+'''.split("\n")
+)
+
+# #########################################################################
+# at the end of the different test run a custom log file should exist
+# Because of this we expect the testruns to pass the real test is if the
+# customlog file exists and passes the format check
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'field-json-test.log'),
+               exists=True, content='gold/field-json-test.gold')
+
+# first test is a miss for default
+tr = Test.AddTestRun()
+# Wait for the micro server
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(nameserver)
+# Delay on readiness of our ssl ports
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-1" --header "Foo: ab\td/ef" http://localhost:{0}/test-1' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" --header "Foo: ab\x1fd/ef" http://localhost:{0}/test-2' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-3" --header "Foo: abc\x7fde" http://localhost:{0}/test-3' .format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+
+# Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
+test_run = Test.AddTestRun()
+test_run.Processes.Default.Command = (
+    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
+    os.path.join(ts.Variables.LOGDIR, 'field-json-test.log')
+)
+test_run.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
This pull requests adds an optional `escape` attribute in `format` entries in `logging.yaml`.
The possible values are `json` and `none`.

An example `logging.yaml`

```
logging:
  formats:
    - name: "mycustom"
      escape: "json"
      format: '{"chi":"%<chi>","caun":"%<caun>","cqtn":"%<cqtn>","cqtx":"%<cqtx>","pssc":"%<pssc>","pscl":"%<pscl>","sssc":"%<sssc>","sscl":"%<sscl>","cqcl":"%<cqcl>","pqcl":"%<pqcl>","cqhl":"%<cqhl>","pshl":"%<pshl>","pqhl":"%<pqhl>","sshl":"%<sshl>","tts":"%<tts>","phr":"%<phr>","cfsc":"%<cfsc>","pfsc":"%<pfsc>","crc":"%<crc>","my_header":"%<{My-Header}cqh>","my_header_slice":"%<{My-Header}cqh[2:-3]>"}'

  logs:
    - filename: custom
      format: mycustom
      mode: ascii
```

An example request:

```
curl -v -H $'My-Header: a\tbcde\x1dfghijkl\x1em' 'localhost:8080?a=c\td'
```

An example log output:

```
{"chi":"127.0.0.1","caun":"-","cqtn":"04/Jun/2022:10:46:55 +0900","cqtx":"GET http://127.0.0.1/?a=c\\td HTTP/1.1","pssc":"200","pscl":"34","sssc":"200","sscl":"34","cqcl":"0","pqcl":"0","cqhl":"125","pshl":"242","pqhl":"256","sshl":"236","tts":"0","phr":"DIRECT","cfsc":"FIN","pfsc":"FIN","crc":"TCP_MISS","my_header":"a\tbcde\u001dfghijkl\u001em","my_header_slice":"bcde\u001df"}
```
