### PR TITLE
Autest: This tests seems not happy when using traffic_manager instead of traffic_server.

### DIFF
--- a/tests/gold_tests/remap/remap_reload.test.py
+++ b/tests/gold_tests/remap/remap_reload.test.py
@@ -25,7 +25,7 @@ replay_file_2 = "reload_2.replay.yaml"
 replay_file_3 = "reload_3.replay.yaml"
 replay_file_4 = "reload_4.replay.yaml"
 
-tm = Test.MakeATSProcess("tm", command="traffic_manager", select_ports=True)
+tm = Test.MakeATSProcess("tm", select_ports=True)
 tm.Disk.diags_log.Content = Testers.ContainsExpression("remap.config failed to load", "Remap should fail to load")
 remap_cfg_path = os.path.join(tm.Variables.CONFIGDIR, 'remap.config')
 


### PR DESCRIPTION
As traffic_manager is no longer needed to handle the reload message use traffic_server instead.

Note:
I am not really clear why this seems to be an issue as `traffic_ctl` works with `traffic_manager` anyway, the message seems to be arriving to TS rpc manager but the second reload seems is not. This works locally, lets see if works here.