### PR TITLE
Removed references to the throttle option from the slice plugin. (#8373)

### DIFF
--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -113,17 +113,6 @@ The slice plugin supports the following options::
         Requires setting up an intermediate loopback remap rule.
         -r for short
 
-    --throttle (optional)
-        Under certain circumstances where many contiguous slices are in
-        RAM cache ATS will aggressively try to push these through the
-        slice plugin.  The downside of this is that all these contiguous
-        slices end up being marked as fresh even if the downstream
-        client aborts.  This option keeps track of how much data the
-        client has already passed down and slows down issuing new
-        slice requests.
-        Normally leave this off.
-        -o for short
-
     --prefetch-count=<int> (optional)
         Default is 0
         Prefetches successive 'n' slice block requests in the background

--- a/plugins/experimental/slice/Config.cc
+++ b/plugins/experimental/slice/Config.cc
@@ -122,7 +122,7 @@ Config::fromArgs(int const argc, char const *const argv[])
   // getopt assumes args start at '1' so this hack is needed
   char *const *argvp = (const_cast<char *const *>(argv) - 1);
   for (;;) {
-    int const opt = getopt_long(argc + 1, argvp, "b:de:i:lop:r:t:", longopts, nullptr);
+    int const opt = getopt_long(argc + 1, argvp, "b:de:i:lp:r:t:", longopts, nullptr);
     if (-1 == opt) {
       break;
     }


### PR DESCRIPTION
(cherry picked from commit e7b69489716a2c4460b482c59bf013e241c44e9b)