### PR TITLE
iocore/cache test_Alternate: up timeout to allow vc to write out

### DIFF
--- a/iocore/cache/test/test_Alternate_S_to_L_remove_L.cc
+++ b/iocore/cache/test/test_Alternate_S_to_L_remove_L.cc
@@ -186,7 +186,7 @@ public:
       this->_wt = nullptr;
       // to make sure writer successfully write the final doc done. we need to schedule
       // to wait for some while. This time should be large than cache_config_mutex_retry_delay
-      this_ethread()->schedule_in(this->_rt, HRTIME_SECONDS(1));
+      this_ethread()->schedule_in(this->_rt, HRTIME_SECONDS(3));
       break;
     case CACHE_EVENT_OPEN_READ:
       base->do_io_read();

--- a/iocore/cache/test/test_Alternate_S_to_L_remove_S.cc
+++ b/iocore/cache/test/test_Alternate_S_to_L_remove_S.cc
@@ -184,7 +184,7 @@ public:
       this->_wt = nullptr;
       // to make sure writer successfully write the final doc done. we need to schedule
       // to wait for some while. This time should be large than cache_config_mutex_retry_delay
-      this_ethread()->schedule_in(this->_rt, HRTIME_SECONDS(1));
+      this_ethread()->schedule_in(this->_rt, HRTIME_SECONDS(3));
       break;
     case CACHE_EVENT_OPEN_READ:
       base->do_io_read();


### PR DESCRIPTION
Fixes issue: #8775 at least for the case where disk I/O is very slow.