### PR TITLE
Fix autest uses of File exists parameter

### DIFF
--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -201,7 +201,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
         p.Disk.error_log = p.Streams.stderr
     else:
         tmpname = os.path.join(log_dir, fname)
-        p.Disk.File(tmpname, id='error_log', exists=False)
+        p.Disk.File(tmpname, id='error_log')
     # diags.log
     fname = log_data['diags']
     if fname == 'stdout':

--- a/tests/gold_tests/pluginTest/cookie_remap/bucketcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/bucketcookie.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/bucketconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/bucketconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/collapseslashes.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/collapseslashes.test.py
@@ -51,7 +51,7 @@ ts.Disk.records_config.update({
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/collapseconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/collapseconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/connector.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/connector.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/connectorconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/connectorconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/existscookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/existscookie.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/existsconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/existsconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/matchcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matchcookie.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/matchconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/matchconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/matchuri.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matchuri.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/matchuriconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/matchuriconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/matrixparams.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matrixparams.test.py
@@ -76,7 +76,7 @@ ts.Disk.records_config.update({
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/matrixconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/matrixconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/notexistscookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/notexistscookie.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/notexistsconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/notexistsconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/pcollapseslashes.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/pcollapseslashes.test.py
@@ -51,7 +51,7 @@ ts.Disk.records_config.update({
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/collapseconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/collapseconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/psubstitute.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/psubstitute.test.py
@@ -67,7 +67,7 @@ ts.Disk.records_config.update({
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/substituteconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/substituteconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/regexcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/regexcookie.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/regexconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/regexconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/setstatus.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/setstatus.test.py
@@ -37,7 +37,7 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
 })
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/statusconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/statusconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/subcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/subcookie.test.py
@@ -61,7 +61,7 @@ ts.Disk.records_config.update({
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/subcookie.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/subcookie.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/pluginTest/cookie_remap/substitute.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/substitute.test.py
@@ -59,7 +59,7 @@ ts.Disk.records_config.update({
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
-ts.Disk.File(ts.Variables.CONFIGDIR + "/substituteconfig.txt", exists=False, id="config1")
+ts.Disk.File(ts.Variables.CONFIGDIR + "/substituteconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(


### PR DESCRIPTION
The AuTest File exists parameter can be configured in one of three ways:

1. If True, then AuTest will fail unless the file exists.
2. If False, then AuTest will fail unless the file does not exist.
3. If None (the default) then no existence check is done.

Many of our tests configured exists=False assuming it would behave like
the default None configuration above. That is, they used exists=False to
turn off verification. That is in fact how AuTest has behaved until now,
but that is a bug in the AuTest framework. The next release of AuTest
will have a fix such that exists=False will now verify that a file does
not in fact exist which will cause some of our tests to fail. This patch
anticipates that fix to AuTest and fixes our use of exists accordingly.