### PR TITLE
Add an ink_mutex destroy function that tolerates the mutex being locked.

### DIFF
--- a/include/tscpp/util/TsSharedMutex.h
+++ b/include/tscpp/util/TsSharedMutex.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <pthread.h>
+
 #include <tscpp/util/Strerror.h>
 
 #if __has_include(<ts/ts.h>)

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -592,7 +592,7 @@ ProxyMutex::free()
   print_lock_stats(1);
 #endif
 #endif
-  ink_mutex_destroy(&the_mutex);
+  ink_mutex_safer_destroy(&the_mutex);
   mutexAllocator.free(this);
 }
 

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -84,6 +84,7 @@ libtscore_la_SOURCES = \
 	ink_inet.cc \
 	ink_memory.cc \
 	ink_mutex.cc \
+	ink_mutex_sd.cc \
 	ink_queue.cc \
 	ink_queue_utils.cc \
 	ink_rand.cc \

--- a/src/tscore/ink_mutex_sd.cc
+++ b/src/tscore/ink_mutex_sd.cc
@@ -23,47 +23,38 @@
 
 #include <tscore/ink_error.h>
 #include <tscore/ink_mutex.h>
+#include <tscore/Diags.h>
 #include <tscpp/util/Strerror.h>
 
-ink_mutex __global_death = PTHREAD_MUTEX_INITIALIZER;
-
-class x_pthread_mutexattr_t
-{
-public:
-  x_pthread_mutexattr_t()
-  {
-    pthread_mutexattr_init(&attr);
-#ifndef POSIX_THREAD_10031c
-    pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
-#endif
-
-#if DEBUG && HAVE_PTHREAD_MUTEXATTR_SETTYPE
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
-#endif
-  }
-
-  ~x_pthread_mutexattr_t() { pthread_mutexattr_destroy(&attr); }
-
-  pthread_mutexattr_t attr;
-};
-
-static x_pthread_mutexattr_t attr;
+// This is in a separate module from ink_mutex because some TS tools don't need this function, and also do not link in
+// the Diags objects.  So putting this in ink_mutex causes a link error for these tools for the Warning() call.
 
 void
-ink_mutex_init(ink_mutex *m)
+ink_mutex_safer_destroy(ink_mutex *m)
 {
   int error;
 
-  error = pthread_mutex_init(m, &attr.attr);
+  error = pthread_mutex_trylock(m);
   if (unlikely(error != 0)) {
-    ink_abort("pthread_mutex_init(%p) failed: %s (%d)", m, ts::Strerror(error).c_str(), error);
-  }
-}
+    if (error != EBUSY) {
+      ink_abort("pthread_mutex_trylock(%p) failed: %s (%d)", m, ts::Strerror(error).c_str(), error);
+    } else {
+#if DEBUG
+      ink_abort("destroying mutex (%p) that is still locked", m);
+#else
+      Warning("ink_mutex_safer_destroy: destroying mutex (%p) that is still locked", m);
+#endif
 
-void
-ink_mutex_destroy(ink_mutex *m)
-{
-  int error;
+      timespec timeout;
+      timeout.tv_sec  = 10;
+      timeout.tv_nsec = 0;
+      error           = pthread_mutex_timedlock(m, &timeout);
+      if (error != 0) {
+        ink_abort("pthread_mutex_trylock(%p) failed: %s (%d)", m, ts::Strerror(error).c_str(), error);
+      }
+    }
+  }
+  ink_mutex_release(m);
 
   error = pthread_mutex_destroy(m);
   if (unlikely(error != 0)) {


### PR DESCRIPTION
Also converts more calls from strerror() to thread-safe ts::Strerror class.

This is hopefully a work-around for crashes that Yahoo prod is seeing on config reload.