### PR TITLE
Pin Jinja2 for doc builds (#8773)

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -32,6 +32,10 @@ verify_ssl = true
 # unpin sphinx by setting the following to "*".
 sphinx = "==3.*"
 
+# Sphinx 3.x builds break with the latest jinja2. This jinja2 pin can be
+# removed when we move to Sphinx 4.x.
+jinja2 = "<3.1"
+
 sphinx-rtd-theme = "*"
 sphinxcontrib-plantuml = "*"
 # i18n


### PR DESCRIPTION
The latest jinja2 breaks Sphinx 3.x builds. For now, pinning jinja2 to
an earlier release for doc builds.

(cherry picked from commit d9eeca39b7910e0b35d213a3c9be58e1edf01a53)