### PR TITLE
In event processing, assert that mutex is unlocked before freeing mutex.

### DIFF
--- a/doc/developer-guide/api/functions/TSContCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSContCreate.en.rst
@@ -32,3 +32,8 @@ Synopsis
 
 Description
 ===========
+Creates a continuation, which can be destroyed with :func:`TSContDestroy`.
+**Note:** when a mutex is passed to a call to this function, it creates a
+reference to the mutex.  The mutex will be destroyed when the number of
+continuations refering to it becomes zero (due to calls to :func:`TSContDestroy`).
+:func:`TSMutexDestroy` must not be called for the mutex.

--- a/doc/developer-guide/api/functions/TSContDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSContDestroy.en.rst
@@ -32,3 +32,19 @@ Synopsis
 
 Description
 ===========
+
+Destroys a continuation created with :func:`TSContCreate`.  If :func:`TSContDestroy` is called
+in the continuation's handler function, and the contination has a mutex, it must be unlocked just
+before destroying the continuation.  Otherwise, |TS| will abort.  Example:
+
+.. code-block:: cpp
+
+    int handler(TSCont contp, TSEvent, void *)
+    {
+      TSMutex mtx = TSContMutexGet(contp);
+      if (mtx) {
+        TSMutexUnlock(mtx);
+      }
+      TSContDestroy(contp);
+      return 0;
+    }

--- a/doc/developer-guide/api/functions/TSMutexDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSMutexDestroy.en.rst
@@ -34,4 +34,6 @@ Description
 ===========
 
 Destroys the indicated :arg:`mutex` previously created via
-:func:`TSMutexCreate`.
+:func:`TSMutexCreate`.  **Note:**  Do not call this function for a mutex that
+was passed to :func:`TSContCreate` as a parameter.  It will be destroyed by call(s)
+to :func:`TSContDestroy`.

--- a/include/tscore/Ptr.h
+++ b/include/tscore/Ptr.h
@@ -45,17 +45,12 @@ class RefCountObj : public ForceVFPTToTop
 {
 public:
   RefCountObj() {}
-  RefCountObj(const RefCountObj &s)
-  {
-    (void)s;
-    return;
-  }
+  RefCountObj(const RefCountObj &) {}
 
   ~RefCountObj() override {}
   RefCountObj &
-  operator=(const RefCountObj &s)
+  operator=(const RefCountObj &)
   {
-    (void)s;
     return (*this);
   }
 

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -592,6 +592,7 @@ ProxyMutex::free()
   print_lock_stats(1);
 #endif
 #endif
+  ink_release_assert(0 == nthread_holding);
   ink_mutex_destroy(&the_mutex);
   mutexAllocator.free(this);
 }

--- a/src/traffic_server/InkIOCoreAPI.cc
+++ b/src/traffic_server/InkIOCoreAPI.cc
@@ -247,9 +247,6 @@ TSMutexCreate()
 {
   ProxyMutex *mutexp = new_ProxyMutex();
 
-  // TODO: Remove this when allocations can never fail.
-  sdk_assert(sdk_sanity_check_mutex((TSMutex)mutexp) == TS_SUCCESS);
-
   return (TSMutex)mutexp;
 }
 


### PR DESCRIPTION
The lifetime of mutex used for TS continuations is controlled by the number of referring continuations, it must not be destroyed with TSMutextDestroy().

Also has some very minor cleanup of Ptr.h.
