### PR TITLE
JSONRPC:  replace std::string with std::string_view when registring a new endpoint.

### DIFF
--- a/mgmt2/rpc/jsonrpc/JsonRPC.h
+++ b/mgmt2/rpc/jsonrpc/JsonRPC.h
@@ -33,7 +33,7 @@ extern RPCRegistryInfo core_ats_rpc_service_provider_handle;
 /// @see JsonRPCManager::add_method_handler for details
 template <typename Func>
 inline bool
-add_method_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info = nullptr)
+add_method_handler(std::string_view name, Func &&call, const RPCRegistryInfo *info = nullptr)
 {
   return JsonRPCManager::instance().add_method_handler(name, std::forward<Func>(call), info);
 }
@@ -41,7 +41,7 @@ add_method_handler(const std::string &name, Func &&call, const RPCRegistryInfo *
 /// @see JsonRPCManager::add_notification_handler for details
 template <typename Func>
 inline bool
-add_notification_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info = nullptr)
+add_notification_handler(std::string_view name, Func &&call, const RPCRegistryInfo *info = nullptr)
 {
   return JsonRPCManager::instance().add_notification_handler(name, std::forward<Func>(call), info);
 }

--- a/mgmt2/rpc/jsonrpc/JsonRPCManager.cc
+++ b/mgmt2/rpc/jsonrpc/JsonRPCManager.cc
@@ -52,7 +52,7 @@ RPCRegistryInfo core_ats_rpc_service_provider_handle = {
 std::mutex g_rpcHandlingMutex;
 std::condition_variable g_rpcHandlingCompletion;
 ts::Rv<YAML::Node> g_rpcHandlerResponseData;
-bool g_rpcHandlerProccessingCompleted{false};
+bool g_rpcHandlerProcessingCompleted{false};
 
 // jsonrpc log tag.
 static constexpr auto logTag    = "rpc";
@@ -164,7 +164,7 @@ JsonRPCManager::Dispatcher::invoke_notification_handler(JsonRPCManager::Dispatch
 }
 
 bool
-JsonRPCManager::Dispatcher::remove_handler(std::string const &name)
+JsonRPCManager::Dispatcher::remove_handler(std::string_view name)
 {
   std::lock_guard<std::mutex> lock(_mutex);
   auto foundIt = std::find_if(std::begin(_handlers), std::end(_handlers), [&](auto const &p) { return p.first == name; });
@@ -177,7 +177,7 @@ JsonRPCManager::Dispatcher::remove_handler(std::string const &name)
 }
 // --- JsonRPCManager
 bool
-JsonRPCManager::remove_handler(std::string const &name)
+JsonRPCManager::remove_handler(std::string_view name)
 {
   return _dispatcher.remove_handler(name);
 }
@@ -289,8 +289,8 @@ JsonRPCManager::Dispatcher::InternalHandler::invoke(specs::RPCRequestInfo const 
                                     // cond var will give us green to proceed.
                                     handler.cb(*request.id, request.params);
                                     std::unique_lock<std::mutex> lock(g_rpcHandlingMutex);
-                                    g_rpcHandlingCompletion.wait(lock, []() { return g_rpcHandlerProccessingCompleted; });
-                                    g_rpcHandlerProccessingCompleted = false;
+                                    g_rpcHandlingCompletion.wait(lock, []() { return g_rpcHandlerProcessingCompleted; });
+                                    g_rpcHandlerProcessingCompleted = false;
                                     // seems to be done, set the response. As the response data is a ts::Rv this will handle both,
                                     // error and non error cases.
                                     ret = g_rpcHandlerResponseData;

--- a/mgmt2/rpc/jsonrpc/JsonRPCManager.h
+++ b/mgmt2/rpc/jsonrpc/JsonRPCManager.h
@@ -76,7 +76,7 @@ public:
   /// @param info RPCRegistryInfo pointer.
   /// @return bool Boolean flag. true if the callback was successfully added, false otherwise
   ///
-  template <typename Func> bool add_method_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info);
+  template <typename Func> bool add_method_handler(std::string_view name, Func &&call, const RPCRegistryInfo *info);
 
   ///
   /// @brief Add new registered notification handler to the JSON RPC engine.
@@ -87,7 +87,7 @@ public:
   /// @param info RPCRegistryInfo pointer.
   /// @return bool Boolean flag. true if the callback was successfully added, false otherwise
   ///
-  template <typename Func> bool add_notification_handler(const std::string &name, Func &&call, const RPCRegistryInfo *info);
+  template <typename Func> bool add_notification_handler(std::string_view name, Func &&call, const RPCRegistryInfo *info);
 
   ///
   /// @brief This function handles the incoming jsonrpc request and dispatch the associated registered handler.
@@ -124,8 +124,8 @@ protected: // For unit test.
   /// @return true If all is good.
   /// @return false If we could not remove it.
   ///
-  bool remove_handler(std::string const &name);
-  friend bool test_remove_handler(std::string const &name);
+  bool remove_handler(std::string_view name);
+  friend bool test_remove_handler(std::string_view name);
 
 private:
   ///
@@ -166,7 +166,7 @@ private:
     /// Add a method handler to the internal container
     /// @return True if was successfully added, False otherwise.
     template <typename FunctionWrapperType, typename Handler>
-    bool add_handler(std::string const &name, Handler &&handler, const RPCRegistryInfo *info);
+    bool add_handler(std::string_view name, Handler &&handler, const RPCRegistryInfo *info);
 
     /// Find and call the request's callback. If any error occurs, the return type will have the specific error.
     /// For notifications the @c RPCResponseInfo will not be set as part of the response. @c response_type
@@ -177,7 +177,7 @@ private:
     ///         be false and the handler null.
     InternalHandler const &find_handler(specs::RPCRequestInfo const &request, std::error_code &ec) const;
     /// Removes a method handler. Unit test mainly.
-    bool remove_handler(std::string const &name);
+    bool remove_handler(std::string_view name);
 
     // JSONRPC API - here for now.
     ts::Rv<YAML::Node> show_registered_handlers(std::string_view const &, const YAML::Node &);
@@ -244,14 +244,14 @@ private:
 // ------------------------------ JsonRPCManager -------------------------------
 template <typename Handler>
 bool
-JsonRPCManager::add_method_handler(const std::string &name, Handler &&call, const RPCRegistryInfo *info)
+JsonRPCManager::add_method_handler(std::string_view name, Handler &&call, const RPCRegistryInfo *info)
 {
   return _dispatcher.add_handler<Dispatcher::Method, Handler>(name, std::forward<Handler>(call), info);
 }
 
 template <typename Handler>
 bool
-JsonRPCManager::add_notification_handler(const std::string &name, Handler &&call, const RPCRegistryInfo *info)
+JsonRPCManager::add_notification_handler(std::string_view name, Handler &&call, const RPCRegistryInfo *info)
 {
   return _dispatcher.add_handler<Dispatcher::Notification, Handler>(name, std::forward<Handler>(call), info);
 }
@@ -276,7 +276,7 @@ bool inline JsonRPCManager::Dispatcher::InternalHandler::operator!() const
 // ----------------------------- Dispatcher ------------------------------------
 template <typename FunctionWrapperType, typename Handler>
 bool
-JsonRPCManager::Dispatcher::add_handler(std::string const &name, Handler &&handler, const RPCRegistryInfo *info)
+JsonRPCManager::Dispatcher::add_handler(std::string_view name, Handler &&handler, const RPCRegistryInfo *info)
 {
   std::lock_guard<std::mutex> lock(_mutex);
   InternalHandler call{info};

--- a/mgmt2/rpc/server/unit_tests/test_rpcserver.cc
+++ b/mgmt2/rpc/server/unit_tests/test_rpcserver.cc
@@ -51,7 +51,7 @@ namespace fs = ts::file;
 namespace rpc
 {
 bool
-test_remove_handler(std::string const &name)
+test_remove_handler(std::string_view name)
 {
   return rpc::JsonRPCManager::instance().remove_handler(name);
 }


### PR DESCRIPTION
1 - Use `std::string_view` in the RPC manager class to avoid possible extra heap allocation when registring a new endpoint.
2 - Fix typo.