### PR TITLE
AuTest: bind stdout/stderr to traffic.out

### DIFF
--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -40,7 +40,8 @@ default_log_data = {
 
 def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
                    enable_tls=False, enable_cache=True, enable_quic=False,
-                   block_for_debug=False, log_data=default_log_data):
+                   block_for_debug=False, log_data=default_log_data,
+                   use_traffic_out=True):
     #####################################
     # common locations
 
@@ -71,13 +72,28 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     storage_dir = os.path.join(ts_dir, 'storage')
     cache_dir = os.path.join(ts_dir, 'cache')
 
+    ts_args = ''
+    if use_traffic_out:
+        # Bind stdout/err to traffic.out. This allows tests to wait upon
+        # content from the traffic.out file, something that cannot be done on
+        # process stdout/stderr in AuTest.
+        traffic_out = os.path.join(log_dir, 'traffic.out')
+        ts_args += f' --bind_stderr {traffic_out}'
+        ts_args += f' --bind_stdout {traffic_out}'
+
     if block_for_debug:
-        if command.startswith('traffic_server'):
-            command += ' --block'
-        elif command.startswith('traffic_manager'):
-            if '--tsArgs' not in command:
-                command += ' --tsArgs'
-            command += ' --block'
+        ts_args += ' --block'
+
+    if 'traffic_manager' in command:
+        if '--tsArgs' in command:
+            # None of our tests do this, but if we eventually pass in --tsArgs
+            # at some point from a test, we'll need to figure out how to mix
+            # that with the arguments we're assembling for --tsArgs here.
+            host.WriteError('Do not know how to assemble --tsArgs.')
+        if ts_args:
+            command += f' --tsArgs "{ts_args}"'
+    elif 'traffic_server' in command:
+        command += ts_args
 
     # create process
     p = obj.Processes.Process(name, command)
@@ -220,7 +236,12 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
         "Unrecognized configuration value",
         f"Diags log file {fname} should not contain a warning about an unrecognized configuration")
 
-    if command == "traffic_manager":
+    # traffic.out
+    fname = "traffic.out"
+    tmpname = os.path.join(log_dir, fname)
+    p.Disk.File(tmpname, id='traffic_out')
+
+    if "traffic_manager" in command:
         fname = log_data['manager']
         if fname == 'stdout':
             p.Disk.manager_log = p.Streams.stdout
@@ -364,7 +385,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     p.Env['PROXY_CONFIG_ADMIN_AUTOCONF_PORT'] = str(
         p.Variables.admin_port)  # support pre ATS 6.x
 
-    if command == "traffic_manager":
+    if 'traffic_manager' in command:
         p.ReturnCode = 2
     else:
         p.ReturnCode = 0

--- a/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
@@ -160,7 +160,7 @@ class MalformedChunkHeaderTest:
         self.ts.Disk.remap_config.AddLine(
             f"map / http://127.0.0.1:{self.server.Variables.http_port}/",
         )
-        self.ts.Streams.stderr += Testers.ContainsExpression(
+        self.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
             "user agent post chunk decoding error",
             "Verify that ATS detected a problem parsing a chunk.")
 

--- a/tests/gold_tests/cont_schedule/schedule.test.py
+++ b/tests/gold_tests/cont_schedule/schedule.test.py
@@ -45,5 +45,5 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Test TSContSchedule API"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
-ts.Streams.All = "gold/schedule.gold"
-ts.Streams.All += Testers.ExcludesExpression('fail', 'should not contain "fail"')
+ts.Disk.traffic_out.Content = "gold/schedule.gold"
+ts.Disk.traffic_out.Content += Testers.ExcludesExpression('fail', 'should not contain "fail"')

--- a/tests/gold_tests/cont_schedule/schedule_on_pool.test.py
+++ b/tests/gold_tests/cont_schedule/schedule_on_pool.test.py
@@ -45,5 +45,5 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Test TSContScheduleOnPool API"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
-ts.Streams.All = "gold/schedule_on_pool.gold"
-ts.Streams.All += Testers.ExcludesExpression('fail', 'should not contain "fail"')
+ts.Disk.traffic_out.Content = "gold/schedule_on_pool.gold"
+ts.Disk.traffic_out.Content += Testers.ExcludesExpression('fail', 'should not contain "fail"')

--- a/tests/gold_tests/cont_schedule/schedule_on_thread.test.py
+++ b/tests/gold_tests/cont_schedule/schedule_on_thread.test.py
@@ -45,5 +45,5 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Test TSContScheduleOnThread API"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
-ts.Streams.All = "gold/schedule_on_thread.gold"
-ts.Streams.All += Testers.ExcludesExpression('fail', 'should not contain "fail"')
+ts.Disk.traffic_out.Content = "gold/schedule_on_thread.gold"
+ts.Disk.traffic_out.Content += Testers.ExcludesExpression('fail', 'should not contain "fail"')

--- a/tests/gold_tests/cont_schedule/thread_affinity.test.py
+++ b/tests/gold_tests/cont_schedule/thread_affinity.test.py
@@ -45,5 +45,5 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Test TSContThreadAffinity API"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
-ts.Streams.All = "gold/thread_affinity.gold"
-ts.Streams.All += Testers.ExcludesExpression('fail', 'should not contain "fail"')
+ts.Disk.traffic_out.Content = "gold/thread_affinity.gold"
+ts.Disk.traffic_out.Content += Testers.ExcludesExpression('fail', 'should not contain "fail"')

--- a/tests/gold_tests/continuations/session_id.test.py
+++ b/tests/gold_tests/continuations/session_id.test.py
@@ -106,4 +106,4 @@ def verify_session_count(output):
     return ""
 
 
-ts.Streams.All += Testers.FileContentCallback(verify_session_count, 'verify_session_count')
+ts.Disk.traffic_out.Content += Testers.FileContentCallback(verify_session_count, 'verify_session_count')

--- a/tests/gold_tests/h2/nghttp.test.py
+++ b/tests/gold_tests/h2/nghttp.test.py
@@ -90,4 +90,4 @@ tr.Processes.Default.Streams.stdout = "gold/nghttp_1_stdout.gold"
 tr.StillRunningAfter = httpbin
 tr.StillRunningAfter = ts
 
-ts.Streams.stderr = "gold/nghttp_ts_stderr.gold"
+ts.Disk.traffic_out.Content = "gold/nghttp_ts_stderr.gold"

--- a/tests/gold_tests/ip_allow/ip_allow.test.py
+++ b/tests/gold_tests/ip_allow/ip_allow.test.py
@@ -131,10 +131,10 @@ ts.Disk.ip_allow_yaml.AddLines(
 '''.split("\n")
 )
 
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Line 1 denial for 'CONNECT' from 127.0.0.1",
     "The CONNECT request should be denied by ip_allow")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Line 1 denial for 'PUSH' from 127.0.0.1",
     "The PUSH request should be denied by ip_allow")
 

--- a/tests/gold_tests/logging/log-debug-client-ip.test.py
+++ b/tests/gold_tests/logging/log-debug-client-ip.test.py
@@ -37,16 +37,16 @@ ts.Disk.remap_config.AddLine(
 
 # Verify that the various aspects of the expected debug output for the
 # transaction are logged.
-ts.Streams.stderr = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     r"\+ Incoming Request \+",
     "Make sure the client request information is present.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     r"\+ Proxy's Request after hooks \+",
     "Make sure the proxy request information is present.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     r"\+ Incoming O.S. Response \+",
     "Make sure the server's response information is present.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     r"\+ Proxy's Response 2 \+",
     "Make sure the proxy response information is present.")
 

--- a/tests/gold_tests/logging/log-filenames.test.py
+++ b/tests/gold_tests/logging/log-filenames.test.py
@@ -67,7 +67,7 @@ class LogFilenamesTest:
         self._ts_name = f"ts{LogFilenamesTest.__ts_counter}"
         LogFilenamesTest.__ts_counter += 1
         self.ts = Test.MakeATSProcess(self._ts_name, command="traffic_manager",
-                                      log_data=log_data)
+                                      use_traffic_out=False, log_data=log_data)
         self.ts.Disk.records_config.update({
             'proxy.config.diags.debug.enabled': 0,
             'proxy.config.diags.debug.tags': 'log',

--- a/tests/gold_tests/logging/log_pipe.test.py
+++ b/tests/gold_tests/logging/log_pipe.test.py
@@ -75,15 +75,15 @@ logging:
 
 pipe_path = os.path.join(ts.Variables.LOGDIR, pipe_name)
 
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Created named pipe .*{}".format(pipe_name),
     "Verify that the named pipe was created")
 
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "no readers for pipe .*{}".format(pipe_name),
     "Verify that no readers for the pipe was detected.")
 
-ts.Streams.All += Testers.ExcludesExpression(
+ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "New buffer size for pipe".format(pipe_name),
     "Verify that the default pipe size was used.")
 
@@ -136,15 +136,15 @@ logging:
 
 pipe_path = os.path.join(ts.Variables.LOGDIR, pipe_name)
 
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Created named pipe .*{}".format(pipe_name),
     "Verify that the named pipe was created")
 
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "no readers for pipe .*{}".format(pipe_name),
     "Verify that no readers for the pipe was detected.")
 
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Previous buffer size for pipe .*{}".format(pipe_name),
     "Verify that the named pipe's size was adjusted")
 
@@ -156,7 +156,7 @@ ts.Streams.All += Testers.ContainsExpression(
 # requested, but it should be at least that big. We use the
 # pipe_buffer_is_larger_than.py helper script to verify that the pipe grew in
 # size.
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "New buffer size for pipe.*{}".format(pipe_name),
     "Verify that the named pipe's size was adjusted")
 buffer_verifier = "pipe_buffer_is_larger_than.py"

--- a/tests/gold_tests/logging/log_retention.test.py
+++ b/tests/gold_tests/logging/log_retention.test.py
@@ -174,23 +174,23 @@ logging:
 )
 
 # Verify that each log type was registered for auto-deletion.
-test.ts.Streams.stderr = Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_deletion.log with min roll count 0",
     "Verify test_deletion.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for error.log with min roll count 0",
     "Verify error.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for traffic.out with min roll count 0",
     "Verify traffic.out auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for diags.log with min roll count 0",
     "Verify diags.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for manager.log with min roll count 0",
     "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_deletion.log_{specified_hostname}.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed")
 
@@ -222,24 +222,24 @@ logging:
 )
 
 # Verify that each log type was registered for auto-deletion.
-test.ts.Streams.stderr = Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_deletion.log with min roll count 1",
     "Verify test_deletion.log auto-delete configuration")
 # Only the test_deletion should have its min_count overridden.
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for error.log with min roll count 0",
     "Verify error.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for traffic.out with min roll count 0",
     "Verify traffic.out auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for diags.log with min roll count 0",
     "Verify diags.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for manager.log with min roll count 0",
     "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_deletion.log_{specified_hostname}.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed")
 
@@ -257,23 +257,23 @@ test = TestLogRetention(twelve_meg_log_space,
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'test_log_interface.so'), test.ts)
 
 # Verify that the plugin's logs and other core logs were registered for deletion.
-test.ts.Streams.stderr = Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_log_interface.log with min roll count 0",
     "Verify test_log_interface.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for error.log with min roll count 0",
     "Verify error.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for traffic.out with min roll count 0",
     "Verify traffic.out auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for diags.log with min roll count 0",
     "Verify diags.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for manager.log with min roll count 0",
     "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "The rolled logfile.*test_log_interface.log_.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed")
 
@@ -313,34 +313,34 @@ logging:
 )
 
 # Verify that each log type was registered for auto-deletion.
-test.ts.Streams.stderr = Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_low_priority_deletion.log with min roll count 5",
     "Verify test_low_priority_deletion.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for test_high_priority_deletion.log with min roll count 1",
     "Verify test_high_priority_deletion.log auto-delete configuration")
 # Only the test_deletion should have its min_count overridden.
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for error.log with min roll count 0",
     "Verify error.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for traffic.out with min roll count 0",
     "Verify traffic.out auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for diags.log with min roll count 0",
     "Verify diags.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for manager.log with min roll count 0",
     "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
-test.ts.Streams.stderr += Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "The rolled logfile.*test_low_priority_deletion.log_.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed from test_high_priority_deletion")
 
 # Verify that ATS derives the hostname correctly if the user does not specify a
 # hostname via 'proxy.config.log.hostname'.
 hostname = socket.gethostname()
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_high_priority_deletion.log_{hostname}.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed from test_high_priority_deletion")
 
@@ -362,21 +362,21 @@ test = TestLogRetention(various_min_count_overrides,
                         "Verify that the various min_count configurations behave as expected")
 
 # Only the test_deletion should have its min_count overridden.
-test.ts.Streams.stderr = Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for error.log with min roll count 3",
     "Verify error.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for traffic.out with min roll count 4",
     "Verify traffic.out auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for diags.log with min roll count 5",
     "Verify diags.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for manager.log with min roll count 5",
     "Verify manager.log auto-delete configuration")
 # In case a future log is added, make sure the developer doesn't forget to
 # set the min count per configuration.
-test.ts.Streams.stderr += Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "Registering .* with min roll count 0",
     "Verify nothing has a default min roll count of 0 per configuration")
 
@@ -415,24 +415,24 @@ logging:
 )
 
 # Verify that each log type was registered for auto-deletion.
-test.ts.Streams.stderr = Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
     "Registering rotated log deletion for test_deletion.log with min roll count 1",
     "Verify test_deletion.log auto-delete configuration")
 # Only the test_deletion should have its min_count overridden.
-test.ts.Streams.stderr += Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "Registering rotated log deletion for error.log with min roll count 0",
     "Verify error.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "Registering rotated log deletion for traffic.out with min roll count 0",
     "Verify traffic.out auto-delete configuration")
-test.ts.Streams.stderr += Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "Registering rotated log deletion for diags.log with min roll count 0",
     "Verify diags.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "Registering rotated log deletion for manager.log with min roll count 0",
     "Verify manager.log auto-delete configuration")
 # Verify test_deletion was not deleted.
-test.ts.Streams.stderr += Testers.ExcludesExpression(
+test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "The rolled logfile.*test_deletion.log_.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed")
 
@@ -472,7 +472,7 @@ logging:
 )
 
 # Verify that trim happened for the rolled file.
-test.ts.Streams.stderr = Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "rolled logfile.*test_deletion.log.*old.* was auto-deleted",
     "Verify test_deletion.log was trimmed")
 
@@ -500,23 +500,23 @@ logging:
 )
 
 # Verify that the plugin's logs and other core logs were registered for deletion.
-test.ts.Streams.stderr = Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_deletion.log with min roll count 0",
     "Verify test_deletion.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for error.log with min roll count 0",
     "Verify error.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for traffic.out with min roll count 0",
     "Verify traffic.out auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for diags.log with min roll count 0",
     "Verify diags.log auto-delete configuration")
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Registering rotated log deletion for manager.log with min roll count 0",
     "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
-test.ts.Streams.stderr += Testers.ContainsExpression(
+test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "The rolled logfile.*test_deletion.log_.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed")
 

--- a/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
@@ -51,7 +51,7 @@ dns = Test.MakeDNServer("dns")
 num_nh = 8
 ts_nh = []
 for i in range(num_nh):
-    ts = Test.MakeATSProcess(f"ts_nh{i}", command=f"traffic_server 2>nh_trace{i}.log")
+    ts = Test.MakeATSProcess(f"ts_nh{i}", use_traffic_out=False, command=f"traffic_server 2>nh_trace{i}.log")
     ts.Disk.records_config.update({
         'proxy.config.diags.debug.enabled': 1,
         'proxy.config.diags.debug.tags': 'http|dns',

--- a/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
@@ -63,7 +63,7 @@ for i in range(num_nh):
     )
     ts_nh.append(ts)
 
-ts = Test.MakeATSProcess("ts", command="traffic_server 2> trace.log")
+ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,

--- a/tests/gold_tests/next_hop/zzz_strategies_peer/zzz_strategies_peer.test.py
+++ b/tests/gold_tests/next_hop/zzz_strategies_peer/zzz_strategies_peer.test.py
@@ -72,7 +72,7 @@ for i in range(num_upstream):
 num_peer = 8
 ts_peer = []
 for i in range(num_peer):
-    ts = Test.MakeATSProcess(f"ts_peer{i}", command=f"traffic_server 2> trace_peer{i}.log")
+    ts = Test.MakeATSProcess(f"ts_peer{i}", use_traffic_out=False, command=f"traffic_server 2> trace_peer{i}.log")
     ts_peer.append(ts)
 for i in range(num_peer):
     ts = ts_peer[i]

--- a/tests/gold_tests/next_hop/zzz_strategies_peer2/zzz_strategies_peer2.test.py
+++ b/tests/gold_tests/next_hop/zzz_strategies_peer2/zzz_strategies_peer2.test.py
@@ -72,7 +72,7 @@ for i in range(num_upstream):
 num_peer = 8
 ts_peer = []
 for i in range(num_peer):
-    ts = Test.MakeATSProcess(f"ts_peer{i}", command=f"traffic_server 2> trace_peer{i}.log")
+    ts = Test.MakeATSProcess(f"ts_peer{i}", use_traffic_out=False, command=f"traffic_server 2> trace_peer{i}.log")
     ts_peer.append(ts)
 for i in range(num_peer):
     ts = ts_peer[i]

--- a/tests/gold_tests/null_transform/null_transform.test.py
+++ b/tests/gold_tests/null_transform/null_transform.test.py
@@ -67,4 +67,4 @@ tr.Processes.Default.Streams.stderr = "gold/null_transform-200.gold"
 tr.StillRunningAfter = server
 
 # Check Plugin Loading Information
-ts.Streams.All = "gold/null_transform-tag.gold"
+ts.Disk.traffic_out.Content = "gold/null_transform-tag.gold"

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -93,7 +93,7 @@ tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = (
     '{0}/traffic_ctl plugin msg cert_update.server {1}/server2.pem'.format(ts.Variables.BINDIR, ts.Variables.SSLDir)
 )
-ts.Streams.all = "gold/update.gold"
+ts.Disk.traffic_out.Content = "gold/update.gold"
 ts.StillRunningAfter = server
 
 # Server-Cert-After
@@ -127,7 +127,7 @@ tr.Processes.Default.Command = (
     'mv {0}/client2.pem {0}/client1.pem && {1}/traffic_ctl plugin msg cert_update.client {0}/client1.pem'.format(
         ts.Variables.SSLDir, ts.Variables.BINDIR)
 )
-ts.Streams.all = "gold/update.gold"
+ts.Disk.traffic_out.Content = "gold/update.gold"
 ts.StillRunningAfter = server
 
 # Client-Cert-After

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite.test.py
@@ -58,4 +58,4 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stderr = "gold/header_rewrite-303.gold"
 tr.StillRunningAfter = server
 
-ts.Streams.All = "gold/header_rewrite-tag.gold"
+ts.Disk.traffic_out.Content = "gold/header_rewrite-tag.gold"

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_l_value.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_l_value.test.py
@@ -61,4 +61,4 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stderr = "gold/header_rewrite-l_value.gold"
 tr.StillRunningAfter = server
-ts.Streams.All = "gold/header_rewrite-tag.gold"
+ts.Disk.traffic_out.Content = "gold/header_rewrite-tag.gold"

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
@@ -68,7 +68,7 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stderr = "gold/header_rewrite-client.gold"
 tr.StillRunningAfter = server
-ts.Streams.All = "gold/header_rewrite-tag.gold"
+ts.Disk.traffic_out.Content = "gold/header_rewrite-tag.gold"
 
 # Test TO-URL in a set-redirect operator.
 tr = Test.AddTestRun()
@@ -77,4 +77,4 @@ tr.Processes.Default.Command = 'curl --head 127.0.0.1:{0} -H "Host: no_path.com"
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/set-redirect.gold"
 tr.StillRunningAfter = server
-ts.Streams.All = "gold/header_rewrite-tag.gold"
+ts.Disk.traffic_out.Content = "gold/header_rewrite-tag.gold"

--- a/tests/gold_tests/pluginTest/lua/lifecycle_stats.sh
+++ b/tests/gold_tests/pluginTest/lua/lifecycle_stats.sh
@@ -20,7 +20,7 @@ while (( N > 0 ))
 do
     sleep 1
     rm -f lifecycle.out
-    grep -F ' ts_lua ' ts.stderr.txt | \
+    grep -F ' ts_lua ' ${PROXY_CONFIG_LOG_LOGFILE_DIR}/traffic.out | \
         sed -e 's/^.* ts_lua //' -e 's/ gc_kb:.*gc_kb_max:.*threads:.*threads_max:.*$//' > lifecycle.out
     if diff lifecycle.out ${AUTEST_TEST_DIR}/gold/lifecycle.gold > /dev/null
     then

--- a/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
@@ -28,12 +28,7 @@ Test.ContinueOnFail = True
 # Define default ATS
 server = Test.MakeOriginServer("server")
 
-# It is necessary to redirect stderr to a file so it will be available for examination by a test run.
-ts = Test.MakeATSProcess(
-    "ts", command="traffic_manager 2> " + Test.RunDirectory + "/ts.stderr.txt", select_ports=True
-)
-# For unknown reasons, traffic_manager returns 2 instead of 0 on exit with stderr redirect here.
-ts.ReturnCode = 2
+ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True)
 
 Test.testName = "Lua states and stats"
 

--- a/tests/gold_tests/pluginTest/lua/lua_watermark.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_watermark.test.py
@@ -55,7 +55,7 @@ ts.Disk.records_config.update({
 })
 
 # Test for watermark debug output
-ts.Streams.All = Testers.ContainsExpression(r"WMbytes\(31337\)", "Upstream watermark should be properly set")
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(r"WMbytes\(31337\)", "Upstream watermark should be properly set")
 
 # Test if watermark upstream is set
 tr = Test.AddTestRun("Lua Watermark")

--- a/tests/gold_tests/pluginTest/parent_select/parent_select.test.py
+++ b/tests/gold_tests/pluginTest/parent_select/parent_select.test.py
@@ -56,7 +56,7 @@ dns = Test.MakeDNServer("dns")
 num_nh = 8
 ts_nh = []
 for i in range(num_nh):
-    ts = Test.MakeATSProcess(f"ts_nh{i}", command=f"traffic_server 2>nh_trace{i}.log")
+    ts = Test.MakeATSProcess(f"ts_nh{i}", use_traffic_out=False, command=f"traffic_server 2>nh_trace{i}.log")
     ts.Disk.records_config.update({
         'proxy.config.diags.debug.enabled': 1,
         'proxy.config.diags.debug.tags': 'http|dns',

--- a/tests/gold_tests/pluginTest/parent_select/parent_select_optional_scheme_matching.test.py
+++ b/tests/gold_tests/pluginTest/parent_select/parent_select_optional_scheme_matching.test.py
@@ -56,7 +56,7 @@ dns = Test.MakeDNServer("dns")
 num_nh = 8
 ts_nh = []
 for i in range(num_nh):
-    ts = Test.MakeATSProcess(f"ts_nh{i}", command=f"traffic_server 2>nh_trace{i}.log")
+    ts = Test.MakeATSProcess(f"ts_nh{i}", use_traffic_out=False, command=f"traffic_server 2>nh_trace{i}.log")
     ts.Disk.records_config.update({
         'proxy.config.diags.debug.enabled': 1,
         'proxy.config.diags.debug.tags': 'http|dns',

--- a/tests/gold_tests/pluginTest/parent_select/parent_select_peer.test.py
+++ b/tests/gold_tests/pluginTest/parent_select/parent_select_peer.test.py
@@ -72,7 +72,7 @@ for i in range(num_upstream):
 num_peer = 8
 ts_peer = []
 for i in range(num_peer):
-    ts = Test.MakeATSProcess(f"ts_peer{i}", command=f"traffic_server 2> trace_peer{i}.log")
+    ts = Test.MakeATSProcess(f"ts_peer{i}", use_traffic_out=False, command=f"traffic_server 2> trace_peer{i}.log")
     ts_peer.append(ts)
 for i in range(num_peer):
     ts = ts_peer[i]

--- a/tests/gold_tests/pluginTest/parent_select/parent_select_peer2.test.py
+++ b/tests/gold_tests/pluginTest/parent_select/parent_select_peer2.test.py
@@ -72,7 +72,7 @@ for i in range(num_upstream):
 num_peer = 8
 ts_peer = []
 for i in range(num_peer):
-    ts = Test.MakeATSProcess(f"ts_peer{i}", command=f"traffic_server 2> trace_peer{i}.log")
+    ts = Test.MakeATSProcess(f"ts_peer{i}", use_traffic_out=False, command=f"traffic_server 2> trace_peer{i}.log")
     ts_peer.append(ts)
 for i in range(num_peer):
     ts = ts_peer[i]

--- a/tests/gold_tests/pluginTest/prefetch_simple/prefetch_simple.test.py
+++ b/tests/gold_tests/pluginTest/prefetch_simple/prefetch_simple.test.py
@@ -43,7 +43,7 @@ for i in range(4):
 
 dns = Test.MakeDNServer("dns")
 
-ts = Test.MakeATSProcess("ts", command="traffic_server 2> trace.log")
+ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'http|dns|prefetch',

--- a/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
+++ b/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
@@ -222,11 +222,11 @@ tr1.Processes.Default.StartBefore(ts3)
 tr1.Processes.Default.StartBefore(ts4)
 tr1.Processes.Default.StartBefore(ts5)
 tr1.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
-ts1.Streams.All = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts2.Streams.All = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts3.Streams.All = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts4.Streams.All = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts5.Streams.All = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
 tr1.StillRunningAfter = server
 tr1.StillRunningAfter += ts1
 tr1.StillRunningAfter += ts2

--- a/tests/gold_tests/pluginTest/test_hooks/hook_add.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/hook_add.test.py
@@ -55,4 +55,4 @@ tr.Processes.Default.Command = (
 tr.Processes.Default.ReturnCode = 0
 
 # Look at the debug output from the plugin
-ts.Streams.All = "hook_add.gold"
+ts.Disk.traffic_out.Content = "hook_add.gold"

--- a/tests/gold_tests/pluginTest/test_hooks/ssn_start_delay_hook.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/ssn_start_delay_hook.test.py
@@ -57,4 +57,4 @@ tr.Processes.Default.Command = (
 tr.Processes.Default.ReturnCode = 0
 
 # Look at the debug output from the plugin
-ts.Streams.All = "ssn_delay.gold"
+ts.Disk.traffic_out.Content = "ssn_delay.gold"

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -98,16 +98,16 @@ logging:
 ts.Disk.diags_log.Content = Testers.ContainsExpression(
     "loading plugin.*traffic_dump.so",
     "Verify the traffic_dump plugin got loaded.")
-ts.Streams.stderr = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     f"Initialized with log directory: {replay_dir}",
     "Verify traffic_dump initialized with the configured directory.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Initialized with sample pool size 1 bytes and disk limit 1000000000 bytes",
     "Verify traffic_dump initialized with the configured disk limit.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Finish a session with log file of.*bytes",
     "Verify traffic_dump sees the end of sessions and accounts for it.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Dumping body bytes: false",
     "Verify that dumping body bytes is enabled.")
 

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
@@ -101,13 +101,13 @@ logging:
 ts.Disk.diags_log.Content = Testers.ContainsExpression(
     "loading plugin.*traffic_dump.so",
     "Verify the traffic_dump plugin got loaded.")
-ts.Streams.stderr = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     f"Initialized with log directory: {ts_log_dir}",
     "Verify traffic_dump initialized with the configured directory.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Initialized with sample pool size 1 bytes and disk limit 1000000000 bytes",
     "Verify traffic_dump initialized with the configured disk limit.")
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Finish a session with log file of.*bytes",
     "Verify traffic_dump sees the end of sessions and accounts for it.")
 

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
@@ -75,7 +75,7 @@ ts1, ts1_replay_file = get_common_ats_process(
     "ts1",
     'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 127.0.0.1',
     replay_exists=True)
-ts1.Streams.stderr += Testers.ContainsExpression(
+ts1.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Filtering to only dump connections with ip: 127.0.0.1",
     "Verify the IP filter status message.")
 tr.AddVerifierClientProcess(
@@ -103,7 +103,7 @@ ts2, ts2_replay_file = get_common_ats_process(
     "ts2",
     'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 1.2.3.4',
     replay_exists=False)
-ts2.Streams.stderr += Testers.ContainsExpression(
+ts2.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Filtering to only dump connections with ip: 1.2.3.4",
     "Verify the IP filter status message.")
 tr.AddVerifierClientProcess(

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
@@ -79,7 +79,7 @@ ts.Disk.File(ts_dump_2, exists=True)
 ts_dump_3 = os.path.join(replay_dir, "127", "0000000000000003")
 ts.Disk.File(ts_dump_3, exists=True)
 
-ts.Streams.stderr = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Dumping body bytes: true",
     "Verify that dumping body bytes is enabled.")
 

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
@@ -79,11 +79,11 @@ ts.Disk.plugin_config.AddLine(
 )
 
 # Set up trafficserver expectations.
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"Filtering to only dump connections with SNI: {sni_filter}",
     "Verify filtering for the expected SNI.")
 
-ts.Streams.stderr += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Ignore HTTPS session with non-filtered SNI: dave",
     "Verify that the non-desired SNI session was filtered out.")
 

--- a/tests/gold_tests/pluginTest/transform/transaction_data_sink.test.py
+++ b/tests/gold_tests/pluginTest/transform/transaction_data_sink.test.py
@@ -41,7 +41,7 @@ ts.Disk.plugin_config.AddLine('txn_data_sink.so')
 
 # Verify that the various aspects of the expected debug output for the
 # transaction are logged.
-ts.Streams.stderr = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     '"http1.1_response_body"',
     "The response body should be printed by the plugin.")
 

--- a/tests/gold_tests/pluginTest/uri_signing/uri_signing.test.py
+++ b/tests/gold_tests/pluginTest/uri_signing/uri_signing.test.py
@@ -211,6 +211,8 @@ ps = tr.Processes.Default
 ps.Command = curl_and_args + '"http://somehost/someasset.ts?URISigningPackage=ewogICJ0eXAiOiAiSldUIiwKICAiYWxnIjogIkhTMjU2Igp9.ewogICJleHAiOiAxOTIzMDU2MDg0Cn0.zw_wFQ-wvrWmfPLGj3hAUWn-GOHkiJZi2but4KV0paY"'
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/403.gold"
-ts.Streams.stderr = Testers.ContainsExpression("Initial JWT Failure: iss is missing, must be present", "should fail the validation")
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
+    "Initial JWT Failure: iss is missing, must be present",
+    "should fail the validation")
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/session_sharing/session_match.test.py
+++ b/tests/gold_tests/session_sharing/session_match.test.py
@@ -82,13 +82,13 @@ class SessionMatchTest:
 
     def runAndExpectSharing(self):
         self._runTraffic()
-        self._ts.Streams.stderr = Testers.ContainsExpression(
+        self._ts.Disk.traffic_out.Content = Testers.ContainsExpression(
             "global pool search successful",
             "Verify that sessions got shared")
 
     def runAndExpectNoSharing(self):
         self._runTraffic()
-        self._ts.Streams.stderr = Testers.ExcludesExpression(
+        self._ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
             "global pool search successful",
             "Verify that sessions did not get shared")
 

--- a/tests/gold_tests/shutdown/emergency.test.py
+++ b/tests/gold_tests/shutdown/emergency.test.py
@@ -47,5 +47,5 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 ts.ReturnCode = 33
 ts.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
-ts.Streams.All = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
+ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing emergency shutdown', 'should contain "testing emergency shutdown"')

--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -47,5 +47,5 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 ts.ReturnCode = 70
 ts.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
-ts.Streams.All = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
+ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing fatal shutdown', 'should contain "testing fatal shutdown"')

--- a/tests/gold_tests/tls/ssl_multicert_loader.test.py
+++ b/tests/gold_tests/tls/ssl_multicert_loader.test.py
@@ -107,7 +107,7 @@ tr4.Processes.Default.StartBefore(ts2)
 
 ts2.ReturnCode = 2
 ts2.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
-ts2.Streams.All = Testers.ExcludesExpression(
+ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
     'Traffic Server is fully initialized',
     'process should fail when invalid certificate specified')
 ts2.Disk.diags_log.Content = Testers.IncludesExpression('FATAL: failed to load SSL certificate file', 'check diags.log"')

--- a/tests/gold_tests/tls/tls_engine.test.py
+++ b/tests/gold_tests/tls/tls_engine.test.py
@@ -99,4 +99,4 @@ tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Varia
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(r"HTTP/(2|1\.1) 200", "Request succeeds")
 tr.StillRunningAfter = server
 
-ts.Streams.All += Testers.ContainsExpression("Send signal to ", "The Async engine triggers")
+ts.Disk.traffic_out.Content += Testers.ContainsExpression("Send signal to ", "The Async engine triggers")

--- a/tests/gold_tests/tls/tls_hooks_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_client_verify.test.py
@@ -104,11 +104,11 @@ tr3.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key
 tr3.Processes.Default.ReturnCode = 35
 tr3.Processes.Default.Streams.all = Testers.ContainsExpression("error", "Curl attempt should have failed")
 
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Client verify callback 0 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Client verify callback 1 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Client verify callback 0 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Client verify callback 1 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")

--- a/tests/gold_tests/tls/tls_hooks_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_verify.test.py
@@ -101,16 +101,16 @@ ts.Disk.diags_log.Content += Testers.ContainsExpression(
     "bar.com should fail but continue")
 ts.Disk.diags_log.Content += Testers.ExcludesExpression("SNI=foo.com", "foo.com should not fail in any way")
 
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Server verify callback 0 [\da-fx]+? - event is good SNI=foo.com good HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Server verify callback 1 [\da-fx]+? - event is good SNI=foo.com good HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Server verify callback 0 [\da-fx]+? - event is good SNI=random.com error HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Server verify callback 1 [\da-fx]+? - event is good SNI=random.com error HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Server verify callback 0 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Server verify callback 1 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
-ts.Streams.All += Testers.ContainsExpression("Server verify callback SNI APIs match=true", "verify SNI names match")
+ts.Disk.traffic_out.Content += Testers.ContainsExpression("Server verify callback SNI APIs match=true", "verify SNI names match")

--- a/tests/gold_tests/tls/tls_origin_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_origin_session_reuse.test.py
@@ -155,8 +155,8 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts1)
 tr.Processes.Default.StartBefore(ts2)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
-ts2.Streams.All = Testers.ContainsExpression('new session to origin', '')
-ts2.Streams.All += Testers.ContainsExpression('reused session to origin', '')
+ts2.Disk.traffic_out.Content = Testers.ContainsExpression('new session to origin', '')
+ts2.Disk.traffic_out.Content += Testers.ContainsExpression('reused session to origin', '')
 tr.StillRunningAfter = server
 tr.StillRunningAfter += ts1
 tr.StillRunningAfter += ts2
@@ -166,9 +166,9 @@ tr.Processes.Default.Command = 'curl https://127.0.0.1:{0}/remove_oldest -k && c
     ts2.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
-ts2.Streams.All = Testers.ContainsExpression('remove oldest session', '')
-ts2.Streams.All += Testers.ContainsExpression('new session to origin', '')
-ts2.Streams.All += Testers.ContainsExpression('reused session to origin', '')
+ts2.Disk.traffic_out.Content = Testers.ContainsExpression('remove oldest session', '')
+ts2.Disk.traffic_out.Content += Testers.ContainsExpression('new session to origin', '')
+ts2.Disk.traffic_out.Content += Testers.ContainsExpression('reused session to origin', '')
 tr.StillRunningAfter = server
 
 tr = Test.AddTestRun('disable origin session reuse, reuse should fail')
@@ -177,5 +177,5 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts3)
 tr.Processes.Default.StartBefore(ts4)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
-ts4.Streams.All = Testers.ContainsExpression('new session to origin', '')
-ts4.Streams.All += Testers.ExcludesExpression('reused session to origin', '')
+ts4.Disk.traffic_out.Content = Testers.ContainsExpression('new session to origin', '')
+ts4.Disk.traffic_out.Content += Testers.ExcludesExpression('reused session to origin', '')

--- a/tests/gold_tests/tls_hooks/gold/ts-close-out-close.gold
+++ b/tests/gold_tests/tls_hooks/gold/ts-close-out-close.gold
@@ -1,3 +1,4 @@
 `` DIAG: (ssl_hook_test) Outbound close callback `` - event is good
 `` DIAG: (ssl_hook_test) Close callback 0 `` - event is good
 `` DIAG: (ssl_hook_test) Close callback 1 `` - event is good
+``

--- a/tests/gold_tests/tls_hooks/tls_hooks.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks.test.py
@@ -62,11 +62,11 @@ tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression(
     "TLSv1.3 (IN), TLS handshake, Finished (20):", "Should not negotiate a TLSv1.3 connection")
 
-ts.Streams.stderr = "gold/ts-preaccept-1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-preaccept-1.gold"
 
 # the preaccept may get triggered twice because the test framework creates a TCP connection before handing off to traffic_server
 preacceptstring = "Pre accept callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(preacceptstring),
     "Pre accept message appears only once or twice",
     reflags=re.S | re.M)

--- a/tests/gold_tests/tls_hooks/tls_hooks10.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks10.test.py
@@ -56,7 +56,7 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
-ts.Streams.stderr = "gold/ts-cert-1-im-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-cert-1-im-2.gold"
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks11.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks11.test.py
@@ -58,10 +58,10 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-preaccept-delayed-1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-preaccept-delayed-1.gold"
 
 preacceptstring = "Pre accept delay callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(preacceptstring),
     "Pre accept message appears only once or twice",
     reflags=re.S | re.M)

--- a/tests/gold_tests/tls_hooks/tls_hooks12.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks12.test.py
@@ -56,7 +56,7 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
-ts.Streams.stderr = "gold/ts-preaccept-delayed-1-immdate-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-preaccept-delayed-1-immdate-2.gold"
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks13.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks13.test.py
@@ -56,7 +56,7 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
-ts.Streams.stderr = "gold/ts-out-start-close-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-out-start-close-2.gold"
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks14.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks14.test.py
@@ -57,7 +57,7 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
-ts.Streams.stderr = "gold/ts-out-delay-start-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-out-delay-start-2.gold"
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks15.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks15.test.py
@@ -56,7 +56,7 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
-ts.Streams.stderr = "gold/ts-close-out-close.gold"
+ts.Disk.traffic_out.Content = "gold/ts-close-out-close.gold"
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks16.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks16.test.py
@@ -62,10 +62,10 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/client-hello-1.gold"
 
-ts.Streams.stderr = "gold/ts-client-hello-1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-client-hello-1.gold"
 
 snistring = "Client Hello callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -63,10 +63,10 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/client-hello-1.gold"
 
-ts.Streams.stderr = "gold/ts-client-hello-delayed-1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-client-hello-delayed-1.gold"
 
 snistring = "Client Hello callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -63,13 +63,13 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-client-hello-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-client-hello-2.gold"
 
 certstring0 = "Client Hello callback 0"
 certstring1 = "Client Hello callback 1"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks2.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks2.test.py
@@ -58,10 +58,10 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-sni-1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-sni-1.gold"
 
 snistring = "SNI callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks3.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks3.test.py
@@ -58,10 +58,10 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-cert-1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-cert-1.gold"
 
 certstring = "Cert callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring), "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks4.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks4.test.py
@@ -58,17 +58,17 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-preaccept1-sni1-cert1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-preaccept1-sni1-cert1.gold"
 snistring = "SNI callback 0"
 preacceptstring = "Pre accept callback 0"
 certstring = "Cert callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
 # the preaccept may get triggered twice because the test framework creates a TCP connection before handing off to traffic_server
-ts.Streams.All += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(
     preacceptstring), "Pre accept message appears only once or twice", reflags=re.S | re.M)
-ts.Streams.All += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring),
-                                             "Cert message appears only once", reflags=re.S | re.M)
+ts.Disk.traffic_out.Content += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring),
+                                                          "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks6.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks6.test.py
@@ -58,16 +58,16 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-preaccept-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-preaccept-2.gold"
 
 # the preaccept may get triggered twice because the test framework creates a TCP connection before handing off to traffic_server
 preacceptstring0 = "Pre accept callback 0"
 preacceptstring1 = "Pre accept callback 1"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(preacceptstring0),
     "Pre accept message appears only once or twice",
     reflags=re.S | re.M)
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(preacceptstring1),
     "Pre accept message appears only once or twice",
     reflags=re.S | re.M)

--- a/tests/gold_tests/tls_hooks/tls_hooks7.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks7.test.py
@@ -58,13 +58,13 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-sni-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-sni-2.gold"
 
 snistring0 = "SNI callback 0"
 snistring1 = "SNI callback 1"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring0), "SNI message appears only once", reflags=re.S | re.M)
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring1), "SNI message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks8.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks8.test.py
@@ -58,13 +58,13 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-cert-2.gold"
+ts.Disk.traffic_out.Content = "gold/ts-cert-2.gold"
 
 certstring0 = "Cert callback 0"
 certstring1 = "Cert callback 1"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks9.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks9.test.py
@@ -58,10 +58,10 @@ tr.Processes.Default.Command = 'curl -k -H \'host:example.com:{0}\' https://127.
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 
-ts.Streams.stderr = "gold/ts-cert-im-1.gold"
+ts.Disk.traffic_out.Content = "gold/ts-cert-im-1.gold"
 
 certstring0 = "Cert callback 0"
-ts.Streams.All = Testers.ContainsExpression(
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15


### PR DESCRIPTION
This updates our AuTest invocation of traffic_server to bind its stdout
and stderr output to traffic.out. Doing this allows the tests to
dynamically interact with the traffic.out content, such as waiting upon
certian debug tag lines. It also serves as a debugging convenience since
all logging output for a Traffic Server process will be in its log dir:
diags.log, error.log, etc., and now traffic.out.