### PR TITLE
stek_share test: compare output with the correct Process

### DIFF
--- a/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
+++ b/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
@@ -223,10 +223,10 @@ tr1.Processes.Default.StartBefore(ts4)
 tr1.Processes.Default.StartBefore(ts5)
 tr1.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
 ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
-ts1.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts2.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts3.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts4.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
+ts5.Disk.traffic_out.Content = Testers.ContainsExpression('Generate initial STEK succeeded', 'should succeed')
 tr1.StillRunningAfter = server
 tr1.StillRunningAfter += ts1
 tr1.StillRunningAfter += ts2


### PR DESCRIPTION
This fixes the stek_share.test.py AuTest to verify the traffic.out
output against the correct ts process, rather than just using ts1 for
each check. This is fixing a copy and paste bug introduced in #8919.