### PR TITLE
JSONRPC: Deal with an empty id as an id error.

### DIFF
--- a/doc/developer-guide/jsonrpc/jsonrpc-handler-development.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-handler-development.en.rst
@@ -186,7 +186,7 @@ We recommend some ways to deal with this:
 
 This can be set in case you would like to let the server to respond with an |RPC| error, ``ExecutionError`` will be used to catch all the
 errors that are fired from within the function call, either by setting the proper errata or by throwing an exception.
-Please check the :ref:`jsonrpc-node-errors` and in particular ``ExecutionError = 9``. Also check :ref:`jsonrpc-handler-errors`
+Please check the :ref:`jsonrpc-node-errors` and in particular ``ExecutionError``. Also check :ref:`jsonrpc-handler-errors`
 
 .. important::
 

--- a/doc/developer-guide/jsonrpc/jsonrpc-node-errors.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-node-errors.en.rst
@@ -75,7 +75,7 @@ Standard errors
 ===============
 
 =============== ========================================= =========================================================
-Field           Message                                   Description
+Id              Message                                   Description
 =============== ========================================= =========================================================
 -32700          Parse error                               Invalid JSON was received by the server.
                                                           An error occurred on the server while parsing the JSON text.
@@ -93,7 +93,7 @@ Custom errors
 The following error list are defined by the server.
 
 =============== ========================================= =========================================================
-Field           Message                                   Description
+Id              Message                                   Description
 =============== ========================================= =========================================================
 1               Invalid version, 2.0 only                 The server only accepts version field equal to `2.0`.
 2               Invalid version type, should be a string  Version field should be a literal string.
@@ -112,6 +112,8 @@ Field           Message                                   Description
 10              Unauthorized action                       The rpc method will not be invoked because the action is not
                                                           permitted by some constraint or authorization issue.Check
                                                           :ref:`jsonrpc-node-errors-unauthorized-action` for mode details.
+11              Use of an empty string as id is           An empty string "" as an id will not be accepted by the server.
+                discouraged
 =============== ========================================= =========================================================
 
 .. _jsonrpc-node-errors-unauthorized-action:
@@ -131,7 +133,7 @@ Under this error, the `data` field could be populated with the following errors,
    ]
 
 =============== ========================================= =========================================================
-Field           Message                                   Description
+Id              Message                                   Description
 =============== ========================================= =========================================================
 1               Error getting peer credentials: {}        Something happened while trying to get the peers credentials.
                                                           The error string will show the error code(`errno`) returned by the

--- a/mgmt2/rpc/jsonrpc/error/RPCError.cc
+++ b/mgmt2/rpc/jsonrpc/error/RPCError.cc
@@ -52,22 +52,18 @@ RPCErrorCategory::message(int ev) const
     return {"Internal error"};
   case RPCErrorCode::PARSE_ERROR:
     return {"Parse error"};
-  // version
   case RPCErrorCode::InvalidVersion:
     return {"Invalid version, 2.0 only"};
   case RPCErrorCode::InvalidVersionType:
     return {"Invalid version type, should be a string"};
   case RPCErrorCode::MissingVersion:
     return {"Missing version field"};
-  // method
   case RPCErrorCode::InvalidMethodType:
     return {"Invalid method type, should be a string"};
   case RPCErrorCode::MissingMethod:
     return {"Missing method field"};
-  // params
   case RPCErrorCode::InvalidParamType:
     return {"Invalid params type. A Structured value is expected"};
-  // id
   case RPCErrorCode::InvalidIdType:
     return {"Invalid id type"};
   case RPCErrorCode::NullId:
@@ -76,6 +72,8 @@ RPCErrorCategory::message(int ev) const
     return {"Error during execution"};
   case RPCErrorCode::Unauthorized:
     return {"Unauthorized action"};
+  case RPCErrorCode::EmptyId:
+    return {"Use of an empty string as id is discouraged"};
   default:
     return "Rpc error " + std::to_string(ev);
   }

--- a/mgmt2/rpc/jsonrpc/error/RPCError.h
+++ b/mgmt2/rpc/jsonrpc/error/RPCError.h
@@ -39,29 +39,18 @@ enum class RPCErrorCode {
   INTERNAL_ERROR   = -32603,
   PARSE_ERROR      = -32700,
 
-  // Custom errors.
-
-  // version
-  InvalidVersion     = 1,
-  InvalidVersionType = 2,
-  MissingVersion,
-  // method
-  InvalidMethodType,
-  MissingMethod,
-
-  // params
-  InvalidParamType,
-
-  // id
-  InvalidIdType,
-  NullId = 8,
-
-  // execution errors
-
-  // Internal rpc error when executing the method.
-  //
-  ExecutionError, //!< Handler's general error.
-  Unauthorized    //!< In case we want to block the call based on privileges, access permissions, etc.
+  // Custom errors. A more grained error codes than the main above.
+  InvalidVersion = 1, //!< Version should be equal to "2.0".
+  InvalidVersionType, //!< Invalid string conversion.
+  MissingVersion,     //!< Missing version field.
+  InvalidMethodType,  //!< Should be a string.
+  MissingMethod,      //!< Method name missing.
+  InvalidParamType,   //!< Not a valid structured type.
+  InvalidIdType,      //!< Invalid string conversion.
+  NullId,             //!< null id.
+  ExecutionError,     //!< Handler's general error.
+  Unauthorized,       //!< In case we want to block the call based on privileges, access permissions, etc.
+  EmptyId             //!< Empty id("").
 };
 // TODO: force non 0 check
 std::error_code make_error_code(rpc::error::RPCErrorCode e);

--- a/mgmt2/rpc/jsonrpc/json/YAMLCodec.h
+++ b/mgmt2/rpc/jsonrpc/json/YAMLCodec.h
@@ -66,6 +66,9 @@ class yamlcpp_json_decoder
 
         try {
           request.id = id.as<std::string>();
+          if (request.id.empty()) {
+            return {request, error::RPCErrorCode::EmptyId};
+          }
         } catch (YAML::Exception const &) {
           return {request, error::RPCErrorCode::InvalidIdType};
         }


### PR DESCRIPTION
Using an empty `""` id is discouraged as it lost the meaning of having an id, so now we mark this as an error and inform the caller about it.

```json
{
   "id":"",
   "jsonrpc":"2.0",
   "method":"will_not_pass_the_validation"
}
```
Response
```json
{
   "jsonrpc":"2.0",
   "error":{
      "code":11,
      "message":"Use of an empty string as id is discouraged"
   }
}
``` 
Beside this, docs are also updated to reflect this and  there are some small fixes around documentation.