### PR TITLE
Update location for core rule set

### DIFF
--- a/example/plugins/lua-api/modsecurity/README.md
+++ b/example/plugins/lua-api/modsecurity/README.md
@@ -1,7 +1,7 @@
 Integrating ATS with ModSecurity V3 using LuaJIT and FFI
 ====
 
-Opensource WAF for [Apache Traffic Server](http://trafficserver.apache.org/).
+Open source WAF for [Apache Traffic Server](http://trafficserver.apache.org/).
 
 Tested with the following
 ====
@@ -30,7 +30,7 @@ Contents/Rules inside example.conf
 
 Working with CRS
 ====
- - Go to [here](https://github.com/SpiderLabs/owasp-modsecurity-crs) and get release v3.2.0
+ - Go [here](https://github.com/coreruleset/coresuleset) and download release v3.3.2
  - Uncompress the contents and copy `crs-setup.conf.example` to `/usr/local/var/modsecurity` and rename it to `crs-setup.conf`
  - Copy all files in `rules` directory to `/usr/local/var/modsecurity/rules`
  - Copy `owasp.conf` in this repository to `/usr/local/var/modsecurity`

--- a/example/plugins/lua-api/modsecurity/owasp.conf
+++ b/example/plugins/lua-api/modsecurity/owasp.conf
@@ -51,6 +51,7 @@ SecRuleRemoveById 951230
 SecRuleRemoveById 951240
 SecRuleRemoveById 951250
 SecRuleRemoveById 951260
+SecRuleRemoveById 952100
 SecRuleRemoveById 952110
 SecRuleRemoveById 953100
 SecRuleRemoveById 953110


### PR DESCRIPTION
The location of OWASP core rule set has been changed a while back.
Thus updating the documentation to reflect them.

Also find that I miss a rule that I want to remove since the lua example here does not support examining response body yet. 