### PR TITLE
Fix clang-format installation with multiple threads

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ endif
 rat:
 	java -jar $(top_srcdir)/ci/apache-rat-0.13-SNAPSHOT.jar -E $(top_srcdir)/ci/rat-regex.txt  -d $(top_srcdir)
 
+.PHONY: autopep8
 autopep8:
 	@$(top_srcdir)/tools/autopep8.sh $(top_srcdir)
 
@@ -120,11 +121,24 @@ autopep8:
 #
 # If you make changes to directory structures, you must update this as well.
 #
-.PHONY:	clang-format-src clang-format-example clang-format-iocore clang-format-lib clang-format-mgmt \
-	clang-format-plugins clang-format-proxy clang-format-tools perltidy
+CLANG_FORMAT_DIR_TARGETS = \
+	clang-format-src \
+	clang-format-example \
+	clang-format-iocore \
+	clang-format-lib \
+	clang-format-mgmt \
+	clang-format-plugins \
+	clang-format-proxy \
+	clang-format-tools
 
-clang-format: 	clang-format-src clang-format-example clang-format-iocore clang-format-lib clang-format-mgmt \
-		clang-format-plugins clang-format-proxy clang-format-tools clang-format-tests
+.PHONY:	$(CLANG_FORMAT_DIR_TARGETS)
+
+$(top_srcdir)/.git/fmt:
+	@$(top_srcdir)/tools/clang-format.sh --install
+
+.PHONY:	clang-format
+clang-format: $(top_srcdir)/.git/fmt
+	$(MAKE) $(CLANG_FORMAT_DIR_TARGETS)
 
 clang-format-src:
 	@$(top_srcdir)/tools/clang-format.sh $(top_srcdir)/src
@@ -154,6 +168,12 @@ clang-format-tools:
 clang-format-tests:
 	@$(top_srcdir)/tools/clang-format.sh $(top_srcdir)/tests
 
+# Run the various format targets. perltidy is not included because the user may
+# not have it installed.
+.PHONY: format
+format: clang-format autopep8
+
+.PHONY: perltidy
 perltidy:
 	perltidy -q -b -bext='/' `find . -name \*.pm -o -name \*.pl`
 

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -25,6 +25,15 @@ function main() {
   set -e # exit on error
   ROOT=${ROOT:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
 
+  # Check for the option to just install clang-format without running it.
+  just_install=0
+  if [ $1 = "--install" ] ; then
+    just_install=1
+    if [ $# -ne 1 ] ; then
+      echo "No other arguments should be used with --install."
+      exit 2
+    fi
+  fi
   DIR=${@:-.}
   PACKAGE="clang-format-${PKGDATE}.tar.bz2"
   VERSION="clang-format version 10.0.0 (https://github.com/llvm/llvm-project.git d32170dbd5b0d54436537b6b75beaf44324e0c28)"
@@ -77,6 +86,7 @@ EOF
       echo "or alternatively, undefine the FORMAT environment variable"
       exit 1
   else
+      [ ${just_install} -eq 1 ] && return
       for file in $(find $DIR -iname \*.[ch] -o -iname \*.cc -o -iname \*.h.in); do
     echo $file
     ${FORMAT} -i $file


### PR DESCRIPTION
The initial run of the clang-format target with multiple threads would
invoke multiple instances of tools/clang-format.sh at the same time.
This would result in multiple processes trying to install the
clang-format binary into .git/fmt, leading to a failure with a a "Text
file busy" error. Subsequent runs would succeed, however, because the
binary had already been installed.

This updates the tools/clang-format.sh script to take a `--install`
argument which just installs clang-format to .git/fmt, and makes the
existence of that directory a prerequisite for the clang-format target.
If it doesn't exist, then it is created with a run of
`tools/clang-format.sh --install`. Then the various `clang-format-<dir>`
targets run in parallel without each trying to install the tool.

This also adds, for convenience, a `format` target that runs both
`clang-format` and `autopep8`.