### PR TITLE
Make clang-format not modify ink_autoconf.h.in and ink_autoconf.h

### DIFF
--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -78,8 +78,15 @@ EOF
       exit 1
   else
       for file in $(find $DIR -iname \*.[ch] -o -iname \*.cc -o -iname \*.h.in); do
-    echo $file
-    ${FORMAT} -i $file
+        # The ink_autoconf.h and ink_autoconf.h.in files are generated files,
+        # so they do not need to be re-formatted by clang-format. Doing so
+        # results in make rebuilding all our files, so we skip formatting them
+        # here.
+        base_name=$(basename ${file})
+        [ ${base_name} = 'ink_autoconf.h.in' -o ${base_name} = 'ink_autoconf.h' ] && continue
+
+        echo $file
+        ${FORMAT} -i $file
       done
   fi
 }


### PR DESCRIPTION
ink_autoconf.h.in and ink_autoconf.h are generated files created with
autoconf. After they are made, if the user builds with them and then
calls the clang-format target, clang-format will dutifully format these
files according to our .clang-format specification. This then results in
a future invocation of make rebuilding most of the files in the
repository because those file are fundamental dependencies in our
repository.

This patch addresses the issue by simply not calling clang-format on
these generated, not checked in, files.

This fixes #8934