### PR TITLE
Add nullptr check of HTTPInfo

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4579,7 +4579,7 @@ HttpSM::parse_range_and_compare(MIMEField *field, int64_t content_length)
     ranges[nr]._end   = end;
     ++nr;
 
-    if (cache_sm.cache_read_vc) {
+    if (cache_sm.cache_read_vc && t_state.cache_info.object_read) {
       if (!cache_sm.cache_read_vc->is_pread_capable() && cache_config_read_while_writer == 2) {
         // write in progress, check if request range not in cache yet
         HTTPInfo::FragOffset *frag_offset_tbl = t_state.cache_info.object_read->get_frag_table();


### PR DESCRIPTION
Fix #8936. 

I'm not familiar with range request handling code, but HttpSM has the nullptr check of `cache_info.object_read` in many places. It looks like the `HttpSM::parse_range_and_compare` lacks the check. 
- e.g. the caller of `HttpSM::parse_range_and_compare` has one.

https://github.com/apache/trafficserver/blob/c54fbc9a8bb078b3163461ebbed392269cf3ce7f/proxy/http/HttpSM.cc#L4651

/cc @elsloo and @cmcfarlen

