### PR TITLE
Fix the body_buffer AuTest for 10-Dev

### DIFF
--- a/tests/gold_tests/pluginTest/test_hooks/body_buffer.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/body_buffer.test.py
@@ -98,10 +98,10 @@ class BodyBufferTest:
             'proxy.config.diags.debug.tags': 'request_buffer',
         })
 
-        self._ts.Streams.stderr = Testers.ContainsExpression(
+        self._ts.Disk.traffic_out.Content = Testers.ContainsExpression(
             rf"request_buffer_plugin gets the request body with length\[{self.content_length_size}\]",
             "Verify that the plugin parsed the content-length request body data.")
-        self._ts.Streams.stderr += Testers.ContainsExpression(
+        self._ts.Disk.traffic_out.Content += Testers.ContainsExpression(
             rf"request_buffer_plugin gets the request body with length\[{self.encoded_chunked_size}\]",
             "Verify that the plugin parsed the chunked request body.")
 


### PR DESCRIPTION
The body_buffer test is new to 10-Dev so it wasn't updated with the
traffic.out changes we made on master for the trafficserver.test.ext
AuTest extension. This updates the test to expect the stderr output to
go to traffic.out instead of the Streams.stderr AuTest file.