### PR TITLE
Grants some karma to active contributors which are not committers

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,13 @@ github:
     rebase: false
     # Disable merge button:
     merge: false
+  collaborators:
+    - mtorluemke
+    - c-taylor
+    - moonchen
+    - cmcfarlen
+    - serrislew
+    - etapia
   protected_branches:
     master:
       required_status_checks:


### PR DESCRIPTION
This allows these people to do Issue and PR triaging. We have to remember to remove these as they become committers, since the list of collaborators is capped at 20 max.