### PR TITLE
Remove use of sbrk()

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -260,11 +260,7 @@ struct AutoStopCont : public Continuation {
 class SignalContinuation : public Continuation
 {
 public:
-  SignalContinuation() : Continuation(new_ProxyMutex())
-  {
-    end = snap = nullptr;
-    SET_HANDLER(&SignalContinuation::periodic);
-  }
+  SignalContinuation() : Continuation(new_ProxyMutex()) { SET_HANDLER(&SignalContinuation::periodic); }
 
   int
   periodic(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
@@ -275,19 +271,6 @@ public:
       // TODO: TS-567 Integrate with debugging allocators "dump" features?
       ink_freelists_dump(stderr);
       ResourceTracker::dump(stderr);
-
-      if (!end) {
-        end = static_cast<char *>(sbrk(0));
-      }
-
-      if (!snap) {
-        snap = static_cast<char *>(sbrk(0));
-      }
-
-      char *now = static_cast<char *>(sbrk(0));
-      Note("sbrk 0x%" PRIu64 " from first %" PRIu64 " from last %" PRIu64 "\n", (uint64_t)((ptrdiff_t)now),
-           (uint64_t)((ptrdiff_t)(now - end)), (uint64_t)((ptrdiff_t)(now - snap)));
-      snap = now;
     }
 
     if (signal_received[SIGUSR2]) {
@@ -331,10 +314,6 @@ public:
 
     return EVENT_CONT;
   }
-
-private:
-  const char *end;
-  const char *snap;
 };
 
 class TrackerContinuation : public Continuation


### PR DESCRIPTION
sbrk() is unavailable on FreeBSD on arm64 platforms, and it's marked as deprecated on macOS.

It seems like `sbrk(0)` is used for memory usage tracking, but I'm not sure how much this is useful because we can monitor memory usage by other tools unlike freelist usage.

Removing the function calls allows you to run ATS on FreeBSD on arm64, and it also allows us to remove `-Wno-deprecated-declarations` from compile options for macOS.

