### PR TITLE
Enable warning for deprecated declarations on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -874,7 +874,7 @@ case $host_os_def in
 
   darwin)
     AS_IF([test "x$ax_cv_c_compiler_vendor" = "xclang"], [
-      common_opt="-pipe -Wall -Wno-deprecated-declarations -Qunused-arguments -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter"
+      common_opt="-pipe -Wall -Qunused-arguments -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter"
       debug_opt="-g $common_opt"
       release_opt="-g $common_opt $optimizing_flags -fno-strict-aliasing"
       cxx_opt="-Wno-invalid-offsetof"


### PR DESCRIPTION
If we merge #8946, we can enable warning for deprecated declarations on macOS.