### PR TITLE
.fit/fmt/.clang-format-installed prerequisite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,11 +133,12 @@ CLANG_FORMAT_DIR_TARGETS = \
 
 .PHONY:	$(CLANG_FORMAT_DIR_TARGETS)
 
-$(top_srcdir)/.git/fmt:
+CLANG_FORMAT_SENTINEL = $(top_srcdir)/.git/fmt/.clang-format-installed
+$(CLANG_FORMAT_SENTINEL):
 	@$(top_srcdir)/tools/clang-format.sh --install
 
 .PHONY:	clang-format
-clang-format: $(top_srcdir)/.git/fmt
+clang-format: $(CLANG_FORMAT_SENTINEL)
 	$(MAKE) $(CLANG_FORMAT_DIR_TARGETS)
 
 clang-format-src:

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -24,6 +24,8 @@ PKGDATE="20200514"
 function main() {
   set -e # exit on error
   ROOT=${ROOT:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
+  # The presence of this file indicates clang-format was successfully installed.
+  INSTALLED_SENTINEL=${ROOT}/.clang-format-installed
 
   # Check for the option to just install clang-format without running it.
   just_install=0
@@ -85,32 +87,32 @@ EOF
       echo "See https://bintray.com/apache/trafficserver/clang-format-tools/view for a newer version,"
       echo "or alternatively, undefine the FORMAT environment variable"
       exit 1
-  else
-      [ ${just_install} -eq 1 ] && return
-
-      # Efficiently retrieving modification timestamps in a platform
-      # independent way is challenging. We use find's -newer argument, which
-      # seems to be broadly supported. The following file is created and has a
-      # timestamp just before running clang-format. Any file with a timestamp
-      # after this we assume was modified by clang-format.
-      start_time_file=$(mktemp -t clang-format-start-time.XXXXXXXXXX)
-      touch ${start_time_file}
-
-      target_files=$(find $DIR -iname \*.[ch] -o -iname \*.cc -o -iname \*.h.in)
-      for file in ${target_files}; do
-        # The ink_autoconf.h and ink_autoconf.h.in files are generated files,
-        # so they do not need to be re-formatted by clang-format. Doing so
-        # results in make rebuilding all our files, so we skip formatting them
-        # here.
-        base_name=$(basename ${file})
-        [ ${base_name} = 'ink_autoconf.h.in' -o ${base_name} = 'ink_autoconf.h' ] && continue
-
-        ${FORMAT} -i $file
-      done
-
-      find ${target_files} -newer ${start_time_file}
-      rm ${start_time_file}
   fi
+  touch ${INSTALLED_SENTINEL}
+  [ ${just_install} -eq 1 ] && return
+
+  # Efficiently retrieving modification timestamps in a platform
+  # independent way is challenging. We use find's -newer argument, which
+  # seems to be broadly supported. The following file is created and has a
+  # timestamp just before running clang-format. Any file with a timestamp
+  # after this we assume was modified by clang-format.
+  start_time_file=$(mktemp -t clang-format-start-time.XXXXXXXXXX)
+  touch ${start_time_file}
+
+  target_files=$(find $DIR -iname \*.[ch] -o -iname \*.cc -o -iname \*.h.in)
+  for file in ${target_files}; do
+    # The ink_autoconf.h and ink_autoconf.h.in files are generated files,
+    # so they do not need to be re-formatted by clang-format. Doing so
+    # results in make rebuilding all our files, so we skip formatting them
+    # here.
+    base_name=$(basename ${file})
+    [ ${base_name} = 'ink_autoconf.h.in' -o ${base_name} = 'ink_autoconf.h' ] && continue
+
+    ${FORMAT} -i $file
+  done
+
+  find ${target_files} -newer ${start_time_file}
+  rm ${start_time_file}
 }
 
 if [[ "$(basename -- "$0")" == 'clang-format.sh' ]]; then


### PR DESCRIPTION
Before this patch, .git/fmt was used as the prerequisite to determine
whether clang-format was installed. But this directory was also created
by the autopep8 target, so if someone ran autopep8 before clang-format,
Make would think that clang-format was installed already. This adds a
hidden sentinel file to the clang-format install process that can be
used as a specific target in our clang-format Makefile.am.

---

## For Review

Use the ignore whitespace option to simplify the diff. I had to change indentation.