### PR TITLE
Remove unneccessary const qualifiers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -874,7 +874,7 @@ case $host_os_def in
 
   darwin)
     AS_IF([test "x$ax_cv_c_compiler_vendor" = "xclang"], [
-      common_opt="-pipe -Wall -Qunused-arguments -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter"
+      common_opt="-pipe -Wall -Qunused-arguments -Wextra -Wno-unused-parameter"
       debug_opt="-g $common_opt"
       release_opt="-g $common_opt $optimizing_flags -fno-strict-aliasing"
       cxx_opt="-Wno-invalid-offsetof"

--- a/iocore/net/quic/QUICFrame.cc
+++ b/iocore/net/quic/QUICFrame.cc
@@ -939,13 +939,13 @@ QUICAckFrame::AckBlockSection::const_iterator::operator++()
   return this->_current_block;
 }
 
-const bool
+bool
 QUICAckFrame::AckBlockSection::const_iterator::operator!=(const const_iterator &ite) const
 {
   return this->_index != ite._index;
 }
 
-const bool
+bool
 QUICAckFrame::AckBlockSection::const_iterator::operator==(const const_iterator &ite) const
 {
   return this->_index == ite._index;

--- a/iocore/net/quic/QUICFrame.h
+++ b/iocore/net/quic/QUICFrame.h
@@ -223,8 +223,8 @@ public:
         return &this->_current_block;
       };
       const QUICAckFrame::AckBlock &operator++();
-      const bool operator!=(const const_iterator &ite) const;
-      const bool operator==(const const_iterator &ite) const;
+      bool operator!=(const const_iterator &ite) const;
+      bool operator==(const const_iterator &ite) const;
 
     private:
       uint8_t _index                                         = 0;

--- a/iocore/net/quic/QUICPacket.cc
+++ b/iocore/net/quic/QUICPacket.cc
@@ -1066,7 +1066,7 @@ QUICVersionNegotiationPacketR::payload_block() const
   return this->_payload_block;
 }
 
-const QUICVersion
+QUICVersion
 QUICVersionNegotiationPacketR::supported_version(uint8_t index) const
 {
   return QUICTypeUtil::read_QUICVersion(this->_versions + sizeof(QUICVersion) * index);

--- a/iocore/net/quic/QUICPacket.h
+++ b/iocore/net/quic/QUICPacket.h
@@ -354,7 +354,7 @@ public:
   Ptr<IOBufferBlock> header_block() const override;
   Ptr<IOBufferBlock> payload_block() const override;
 
-  const QUICVersion supported_version(uint8_t index) const;
+  QUICVersion supported_version(uint8_t index) const;
   int nversions() const;
 
 private:

--- a/plugins/regex_revalidate/regex_revalidate.c
+++ b/plugins/regex_revalidate/regex_revalidate.c
@@ -95,7 +95,7 @@ increment_stat(TSCacheLookupResult const result)
   }
 }
 
-static char const *const
+static const char *
 strForResult(TSCacheLookupResult const result)
 {
   switch (result) {


### PR DESCRIPTION
This fixes these type of errors (warnings) below, and also enables warning for ignored-qualifiers on macOS.
```
regex_revalidate/regex_revalidate.c:98:20: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
static char const *const
                   ^~~~~
```

```
./QUICPacket.h:357:3: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  const QUICVersion supported_version(uint8_t index) const;./QUICPacket.h:357:3: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
```