### PR TITLE
Fixes issue #8951 Client Request Body processing

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7727,6 +7727,7 @@ HttpSM::set_next_state()
     if (t_state.api_next_action == HttpTransact::SM_ACTION_API_SEND_RESPONSE_HDR) {
       handle_api_return();
     } else {
+      do_drain_request_body(t_state.hdr_info.client_response);
       t_state.api_next_action = HttpTransact::SM_ACTION_API_SEND_RESPONSE_HDR;
       do_api_callout();
     }


### PR DESCRIPTION
Fixes[https://github.com/apache/trafficserver/issues/8951](https://github.com/apache/trafficserver/issues/8951).
It's okay call to `do_drain_request_body` if `t_state.next_action` is `SM_ACTION_INTERNAL_CACHE_NOOP`.
Calling `do_drain_request_body` to process unwanted Body.