### PR TITLE
add a metric to track how often the range seek bug is detected

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -3088,6 +3088,7 @@ register_cache_stats(RecRawStatBlock *rsb, const char *prefix)
   REG_INT("read.active", cache_read_active_stat);
   REG_INT("read.success", cache_read_success_stat);
   REG_INT("read.failure", cache_read_failure_stat);
+  REG_INT("read.seek.failure", cache_read_seek_fail_stat);
   REG_INT("write.active", cache_write_active_stat);
   REG_INT("write.success", cache_write_success_stat);
   REG_INT("write.failure", cache_write_failure_stat);

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -749,6 +749,8 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
       doc->magic = DOC_CORRUPT;
 
+      CACHE_INCREMENT_DYN_STAT(cache_read_seek_fail_stat);
+
       CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
       if (!lock.is_locked()) {
         SET_HANDLER(&CacheVC::openReadDirDelete);

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -113,6 +113,7 @@ enum {
   cache_read_active_stat,
   cache_read_success_stat,
   cache_read_failure_stat,
+  cache_read_seek_fail_stat,
   cache_write_active_stat,
   cache_write_success_stat,
   cache_write_failure_stat,


### PR DESCRIPTION
This add a metric to track how often objects are deleted due to incorrect fragments or fragment table issues.  There is a comment that this occasionally happens in production, so I would like to be able to understand how often.