### PR TITLE
Fixes issue with file size calculation for existing logs

### DIFF
--- a/src/tscore/BaseLogFile.cc
+++ b/src/tscore/BaseLogFile.cc
@@ -333,7 +333,8 @@ BaseLogFile::open_file(int perm)
   }
 
   // set m_bytes_written to force the rolling based on file size.
-  m_bytes_written = fseek(m_fp, 0, SEEK_CUR);
+  fseek(m_fp, 0, SEEK_END);
+  m_bytes_written = ftell(m_fp);
 
   log_log_trace("BaseLogFile %s is now open (fd=%d)\n", m_name.get(), fileno(m_fp));
   m_is_init = true;


### PR DESCRIPTION
* Issue arises with existing log files at startup

* Because the existing bytes are not accounted for, log rolling does not occur at the correct time

* Existing code can lead to logging being suspended indefinitely without manual intervention if thresholds are exceeded and no rolled log files can be deleted

* Corner case more evident when other data not rolled by ATS is present in the logging directory