### PR TITLE
Fix reverting PR#7302

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5201,7 +5201,6 @@ HttpSM::do_http_server_open(bool raw)
 
       ct_state.Warn_Blocked(&t_state.txn_conf->outbound_conntrack, sm_id, ccount - 1, &t_state.current.server->dst_addr.sa,
                             debug_on && is_debug_tag_set("http") ? "http" : nullptr);
-      send_origin_throttled_response();
 
       return;
     } else {


### PR DESCRIPTION
Fix #8974

#7302 was reverted by #8316 as an incompatible change for 9.2.0.
It looks like the revert commit has a mistake that possibly made 
a crash by calling `HttpSM::send_origin_throttled_response()` twice.

The code prior to the #7302 is below.

https://github.com/apache/trafficserver/blob/d4f202c808dd1b76255ce8991960ff83c07a9c46/proxy/http/HttpSM.cc#L5114-L5123