### PR TITLE
Validate that content length header matches object size on cache read

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -3089,6 +3089,7 @@ register_cache_stats(RecRawStatBlock *rsb, const char *prefix)
   REG_INT("read.success", cache_read_success_stat);
   REG_INT("read.failure", cache_read_failure_stat);
   REG_INT("read.seek.failure", cache_read_seek_fail_stat);
+  REG_INT("read.invalid", cache_read_invalid_stat);
   REG_INT("write.active", cache_write_active_stat);
   REG_INT("write.success", cache_write_success_stat);
   REG_INT("write.failure", cache_write_failure_stat);

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -1177,12 +1177,13 @@ CacheVC::openReadStartHead(int event, Event *e)
       }
 
       // Now that we have selected an alternate, validate that the content length and object size match
-      MIMEField *field = alternate.request_get()->field_find(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
+      MIMEField *field = alternate.response_get()->field_find(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
       if (field) {
         int64_t cl = field->value_get_int64();
         if (cl != doc_len) {
-          Note("OpenReadHead failed for cachekey %X : alternate content length doesn't match doc_len %ld != %ld", key.slice32(0),
-               cl, doc_len);
+          Warning("OpenReadHead failed for cachekey %X : alternate content length doesn't match doc_len %ld != %ld", key.slice32(0),
+                  cl, doc_len);
+          CACHE_INCREMENT_DYN_STAT(cache_read_invalid_stat);
           err = ECACHE_BAD_META_DATA;
           goto Ldone;
         }

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -1179,7 +1179,7 @@ CacheVC::openReadStartHead(int event, Event *e)
       // Now that we have selected an alternate, validate that the content length and object size match
       MIMEField *field = alternate.response_get()->field_find(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
       if (field) {
-        int64_t cl = field->value_get_int64();
+        uint64_t cl = static_cast<uint64_t>(field->value_get_int64());
         if (cl != doc_len) {
           Warning("OpenReadHead failed for cachekey %X : alternate content length doesn't match doc_len %ld != %ld", key.slice32(0),
                   cl, doc_len);

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -114,6 +114,7 @@ enum {
   cache_read_success_stat,
   cache_read_failure_stat,
   cache_read_seek_fail_stat,
+  cache_read_invalid_stat,
   cache_write_active_stat,
   cache_write_success_stat,
   cache_write_failure_stat,


### PR DESCRIPTION
This PR will fail a cache read if the content-length in the cached response header does not match the cached object size.