### PR TITLE
Fix autest: Add missing config value for origin's dead policy.

### DIFF
--- a/tests/gold_tests/tls/tls_verify_override_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_override_base.test.py
@@ -114,7 +114,8 @@ ts.Disk.records_config.update({
     'proxy.config.exec_thread.autoconfig.scale': 1.0,
     'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
     'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE'
+    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    'proxy.config.http.connect.dead.policy': 1,  # Don't count TLS failures for dead upstream.
 })
 
 dns.addRecords(records={"foo.com.": ["127.0.0.1"]})


### PR DESCRIPTION

This seems to be in [master](https://github.com/apache/trafficserver/blob/80a0ff9e9ccbdfa1667a836291d9fd18f3937762/tests/gold_tests/tls/tls_verify_override_base.test.py#L118) but missing in [10-Dev](https://github.com/apache/trafficserver/blob/1b982db067c9285b8c65b2a0ed5a30c73d3a5789/tests/gold_tests/tls/tls_verify_override_base.test.py#L117)