### PR TITLE
Cleanup: Don't refer to P_*.h from header files in proxy dir

### DIFF
--- a/iocore/dns/I_DNSProcessor.h
+++ b/iocore/dns/I_DNSProcessor.h
@@ -24,7 +24,11 @@
 #pragma once
 
 #include "tscore/ink_resolver.h"
+#include "I_EventSystem.h"
 #include "SRV.h"
+
+// Events
+#define DNS_EVENT_LOOKUP DNS_EVENT_EVENTS_START
 
 const int DOMAIN_SERVICE_PORT = NAMESERVER_PORT;
 

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -74,9 +74,6 @@ extern unsigned int dns_sequence_number;
 #define QFIXEDSZ 4
 #endif
 
-// Events
-#define DNS_EVENT_LOOKUP DNS_EVENT_EVENTS_START
-
 // Stats
 enum DNS_Stats {
   dns_total_lookups_stat,

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -35,7 +35,6 @@
 #include "tscore/HTTPVersion.h"
 #include "I_EventSystem.h"
 #include "SRV.h"
-#include "P_RefCountCache.h"
 
 // Event returned on a lookup
 #define EVENT_HOST_DB_LOOKUP (HOSTDB_EVENT_EVENTS_START + 0)

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -86,6 +86,7 @@ test_UDPNet_SOURCES = \
 	test_I_UDPNet.cc
 
 test_libinknet_SOURCES = \
+	libinknet_stub.cc \
 	unit_tests/test_ProxyProtocol.cc
 
 test_libinknet_CPPFLAGS = \
@@ -109,6 +110,7 @@ test_libinknet_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \

--- a/proxy/CacheControl.h
+++ b/proxy/CacheControl.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 #include "ControlBase.h"
 #include "tscore/Result.h"
 

--- a/proxy/HostStatus.h
+++ b/proxy/HostStatus.h
@@ -34,7 +34,7 @@
 #include <string>
 #include <sstream>
 #include "tscore/ink_rwlock.h"
-#include "records/P_RecProcess.h"
+#include "records/I_RecProcess.h"
 
 #include <unordered_map>
 

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -23,13 +23,13 @@
 
 #pragma once
 
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 #include "URL.h"
-#include "P_Net.h"
+#include "I_Net.h"
 #include "HTTP.h"
 #include "tscore/List.h"
 #include "ProxyConfig.h"
-#include "P_Cache.h"
+#include "I_Cache.h"
 #include "I_Tasks.h"
 #include "Plugin.h"
 

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -33,7 +33,7 @@
 #include "ProxyConfig.h"
 #include "ControlBase.h"
 #include "ControlMatcher.h"
-#include "records/P_RecProcess.h"
+#include "records/I_RecProcess.h"
 #include "tscore/ConsistentHash.h"
 #include "tscore/Tokenizer.h"
 #include "tscore/ink_apidefs.h"

--- a/proxy/PluginVC.h
+++ b/proxy/PluginVC.h
@@ -36,7 +36,7 @@
 #pragma once
 
 #include "Plugin.h"
-#include "P_Net.h"
+#include "I_Net.h"
 #include "tscore/ink_atomic.h"
 
 class PluginVCCore;

--- a/proxy/ProxySession.h
+++ b/proxy/ProxySession.h
@@ -28,7 +28,6 @@
 #include "tscore/TSSystemState.h"
 #include <string_view>
 #include <memory>
-#include "P_Net.h"
 #include "InkAPIInternal.h"
 #include "http/HttpSessionAccept.h"
 #include "IPAllow.h"

--- a/proxy/ReverseProxy.h
+++ b/proxy/ReverseProxy.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include "records/P_RecProcess.h"
+#include "records/I_RecProcess.h"
 
 #include "tscore/ink_defs.h"
 #include "HttpTransact.h"

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -29,7 +29,7 @@
  ****************************************************************************/
 
 #pragma once
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 
 #include "HTTP.h"
 

--- a/proxy/Transform.h
+++ b/proxy/Transform.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 #include "HTTP.h"
 #include "InkAPIInternal.h"
 

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -31,7 +31,6 @@
 
 #pragma once
 
-#include "P_Net.h"
 #include "InkAPIInternal.h"
 #include "HTTP.h"
 #include "HttpConfig.h"

--- a/proxy/http/Http1ServerSession.h
+++ b/proxy/http/Http1ServerSession.h
@@ -32,8 +32,6 @@
 
 #pragma once
 
-#include "P_Net.h"
-
 #include "HttpConnectionCount.h"
 #include "HttpProxyAPIEnums.h"
 #include "PoolableSession.h"

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include "P_Cache.h"
+#include "I_Cache.h"
 #include "ProxyConfig.h"
 #include "URL.h"
 #include "HTTP.h"

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -50,7 +50,7 @@
 #include "tscore/BufferWriter.h"
 #include "HttpProxyAPIEnums.h"
 #include "ProxyConfig.h"
-#include "records/P_RecProcess.h"
+#include "records/I_RecProcess.h"
 #include "HttpConnectionCount.h"
 
 static const unsigned HTTP_STATUS_NUMBER = 600;

--- a/proxy/http/HttpPages.h
+++ b/proxy/http/HttpPages.h
@@ -34,7 +34,7 @@
 #pragma once
 
 #include "tscore/ink_platform.h"
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 #include "HTTP.h"
 #include "StatPages.h"
 #include "HttpSM.h"

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -35,7 +35,7 @@
 #include <optional>
 
 #include "tscore/ink_platform.h"
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 #include "HttpCacheSM.h"
 #include "HttpTransact.h"
 #include "UrlRewrite.h"

--- a/proxy/http/HttpSessionAccept.h
+++ b/proxy/http/HttpSessionAccept.h
@@ -25,7 +25,7 @@
 
 #include "tscore/ink_platform.h"
 #include "records/I_RecHttp.h"
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 #include "HttpConfig.h"
 #include "HTTP.h"
 #include "I_Net.h"

--- a/proxy/http/HttpSessionManager.h
+++ b/proxy/http/HttpSessionManager.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 #include "PoolableSession.h"
 #include "tscore/IntrusiveHashMap.h"
 

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -25,8 +25,7 @@
 
 #include "tscore/ink_assert.h"
 #include "tscore/ink_platform.h"
-#include "P_HostDB.h"
-#include "P_Net.h"
+#include "I_HostDB.h"
 #include "HttpConfig.h"
 #include "HTTP.h"
 #include "HttpTransactCache.h"

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -33,7 +33,7 @@
 #pragma once
 
 #include "tscore/ink_platform.h"
-#include "P_EventSystem.h"
+#include "I_EventSystem.h"
 
 // Get rid of any previous definition first... /leif
 #ifdef MAX_PRODUCERS

--- a/proxy/http/PreWarmManager.h
+++ b/proxy/http/PreWarmManager.h
@@ -25,23 +25,25 @@
 
 #include "PreWarmAlgorithm.h"
 
-#include "P_Net.h"
+#include "I_EventSystem.h"
 #include "I_NetVConnection.h"
-#include "P_SSLSNI.h"
-#include "P_HostDB.h"
+#include "I_HostDB.h"
 #include "YamlSNIConfig.h"
 #include "NetTimeout.h"
 #include "Milestones.h"
 
+#include "records/I_RecHttp.h"
 #include "records/DynamicStats.h"
 
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <queue>
 #include <string_view>
 
 class PreWarmSM;
 class PreWarmManager;
+struct SNIConfigParams;
 
 extern ClassAllocator<PreWarmSM> preWarmSMAllocator;
 extern PreWarmManager prewarmManager;

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -27,7 +27,7 @@
 #include "tscore/ink_memory.h"
 #include "HPACK.h"
 #include "MIME.h"
-#include "records/P_RecDefs.h"
+#include "records/I_RecDefs.h"
 
 class HTTPHdr;
 

--- a/proxy/http2/Http2Frame.h
+++ b/proxy/http2/Http2Frame.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "P_Net.h"
+#include "I_IOBuffer.h"
 
 #include "HTTP2.h"
 

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -67,7 +67,9 @@ TESTS = $(check_PROGRAMS)
 # The order of libinkevent.a and libhdrs.a is sensitive for LLD on debug build.
 # Be careful if you change the order. Details in GitHub #6666
 test_libhttp2_LDADD = \
-	libhttp2.a \
+	HTTP2.o \
+	Http2Frame.o \
+	HPACK.o \
 	$(top_builddir)/lib/records/librecords_p.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.la \

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -78,6 +78,14 @@ test_libhttp2_LDADD = \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
 	@HWLOC_LIBS@
 
+if OS_LINUX
+test_libhttp2_LDFLAGS = $(AM_LDFLAGS)\
+	-Wl,--unresolved-symbols=ignore-all
+else
+test_libhttp2_LDFLAGS = $(AM_LDFLAGS)\
+    -Wl,-undefined -Wl,suppress -Wl,-flat_namespace -Wl,-dead_strip
+endif
+
 test_libhttp2_CPPFLAGS = $(AM_CPPFLAGS)\
 	-I$(abs_top_srcdir)/tests/include
 

--- a/proxy/logging/Log.h
+++ b/proxy/logging/Log.h
@@ -55,7 +55,7 @@
 #include "tscore/ink_platform.h"
 #include "tscore/EventNotify.h"
 #include "tscore/Regression.h"
-#include "records/P_RecProcess.h"
+#include "records/I_RecProcess.h"
 #include "LogFile.h"
 #include "LogBuffer.h"
 

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -27,7 +27,7 @@
 #include <string>
 
 #include "tscore/ink_platform.h"
-#include "records/P_RecProcess.h"
+#include "records/I_RecProcess.h"
 #include "ProxyConfig.h"
 #include "LogObject.h"
 #include "RolledLogDeleter.h"


### PR DESCRIPTION
Including `P_*.h` is too much and that brings unnecessary dependencies. The source files (`*.cc`) in proxy directory still include `P_*.h` but that is ok for now because those files don't pollute other files by being included.