### PR TITLE
Cleanup: Remove dependency on SSLNetVC from ProxySession

### DIFF
--- a/proxy/ProxySession.cc
+++ b/proxy/ProxySession.cc
@@ -24,7 +24,7 @@
 #include "HttpConfig.h"
 #include "HttpDebugNames.h"
 #include "ProxySession.h"
-#include "P_SSLNetVConnection.h"
+#include "TLSBasicSupport.h"
 
 ProxySession::ProxySession() : VConnection(nullptr) {}
 
@@ -276,10 +276,10 @@ ProxySession::get_local_addr()
 void
 ProxySession::_handle_if_ssl(NetVConnection *new_vc)
 {
-  auto ssl_vc = dynamic_cast<SSLNetVConnection *>(new_vc);
-  if (ssl_vc) {
+  auto tbs = dynamic_cast<TLSBasicSupport *>(new_vc);
+  if (tbs) {
     _ssl = std::make_unique<SSLProxySession>();
-    _ssl.get()->init(*ssl_vc);
+    _ssl.get()->init(*new_vc);
   }
 }
 

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -121,6 +121,7 @@ void
 HQSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reade)
 {
   this->con_id = static_cast<QUICConnection *>(reinterpret_cast<QUICNetVConnection *>(new_vc))->connection_id();
+  this->_handle_if_ssl(new_vc);
 
   return;
 }

--- a/proxy/private/SSLProxySession.cc
+++ b/proxy/private/SSLProxySession.cc
@@ -24,18 +24,21 @@
 #include <cstring>
 
 #include "SSLProxySession.h"
-#include "P_Net.h"
-#include "P_SSLNetVConnection.h"
+#include "I_EventSystem.h"
+#include "I_NetVConnection.h"
+#include "TLSSNISupport.h"
 
 void
-SSLProxySession::init(SSLNetVConnection const &new_vc)
+SSLProxySession::init(NetVConnection const &new_vc)
 {
-  char const *name = new_vc.get_server_name();
-  int length       = std::strlen(name) + 1;
-  if (length > 1) {
-    char *n = new char[length];
-    std::memcpy(n, name, length);
-    _client_sni_server_name.reset(n);
+  if (dynamic_cast<const TLSSNISupport *>(&new_vc) != nullptr) {
+    char const *name = new_vc.get_server_name();
+    int length       = std::strlen(name) + 1;
+    if (length > 1) {
+      char *n = new char[length];
+      std::memcpy(n, name, length);
+      _client_sni_server_name.reset(n);
+    }
   }
   _client_provided_cert = new_vc.peer_provided_cert();
 }

--- a/proxy/private/SSLProxySession.h
+++ b/proxy/private/SSLProxySession.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <string_view>
 
-class SSLNetVConnection;
+class NetVConnection;
 
 class SSLProxySession
 {
@@ -45,7 +45,7 @@ public:
     return _client_provided_cert;
   }
 
-  void init(SSLNetVConnection const &new_vc);
+  void init(NetVConnection const &new_vc);
 
 private:
   std::unique_ptr<char[]> _client_sni_server_name;


### PR DESCRIPTION
This removes dependency on SSLNetVC, and also enables QUICNetVC to be supported in the future.