### PR TITLE
Deprecated parameter that wasn't in upgrade notes

### DIFF
--- a/doc/release-notes/upgrading.en.rst
+++ b/doc/release-notes/upgrading.en.rst
@@ -91,6 +91,7 @@ The following settings are simply gone, and have no purpose:
 * `proxy.config.cache.storage_filename` (see next section as well)
 * `proxy.config.http.server_tcp_init_cwnd` (see Solaris section below)
 * `proxy.config.http.parent_proxy_routing_enable` (implicit by use of :file:`parent.config`)
+* `proxy.config.disable_configuration_modification` (is always on)
 
 All the `Vary` related configuration overrides were eliminated, prefer to set this via the origin server, or modify the `Vary`
 header on server responses instead.


### PR DESCRIPTION
This parameter was deprecated in 9.x but not listed in the upgrading release notes page