### PR TITLE
Fix compile on M1 Mac

### DIFF
--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -140,7 +140,8 @@ public:
 void
 ThreadAffinityInitializer::setup_stack_guard(void *stack, int stackguard_pages)
 {
-#if !(defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined(__mips__))
+#if !(defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || \
+      defined(__mips__))
 #error Unknown stack growth direction.  Determine the stack growth direction of your platform.
 // If your stack grows upwards, you need to change this function and the calculation of stack_begin in do_alloc_stack.
 #endif


### PR DESCRIPTION
Add arm64 to the list of known stack growth directions.