### PR TITLE
Make TLSSNISupport::get_sni_server_name public

### DIFF
--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -50,7 +50,7 @@ public:
   SNIAction(TLSSNISupport *snis, const Context &ctx) const override
   {
     auto ssl_vc            = dynamic_cast<SSLNetVConnection *>(snis);
-    const char *servername = ssl_vc->get_server_name();
+    const char *servername = snis->get_sni_server_name();
     if (ssl_vc) {
       if (!enable_h2) {
         ssl_vc->disableProtocol(TS_ALPN_PROTOCOL_INDEX_HTTP_2_0);
@@ -103,7 +103,7 @@ public:
   {
     // Set the netvc option?
     SSLNetVConnection *ssl_netvc = dynamic_cast<SSLNetVConnection *>(snis);
-    const char *servername       = ssl_netvc->get_server_name();
+    const char *servername       = snis->get_sni_server_name();
     if (ssl_netvc) {
       // If needed, we will try to amend the tunnel destination.
       if (ctx._fqdn_wildcard_captured_groups && need_fix) {
@@ -216,7 +216,7 @@ public:
   SNIAction(TLSSNISupport *snis, const Context &ctx) const override
   {
     auto ssl_vc            = dynamic_cast<SSLNetVConnection *>(snis);
-    const char *servername = ssl_vc->get_server_name();
+    const char *servername = snis->get_sni_server_name();
     Debug("ssl_sni", "action verify param %d, fqdn [%s]", this->mode, servername);
     setClientCertLevel(ssl_vc->ssl, this->mode);
     ssl_vc->set_ca_cert_file(ca_file, ca_dir);
@@ -282,7 +282,7 @@ public:
   {
     if (!unset) {
       auto ssl_vc            = dynamic_cast<SSLNetVConnection *>(snis);
-      const char *servername = ssl_vc->get_server_name();
+      const char *servername = snis->get_sni_server_name();
       Debug("ssl_sni", "TLSValidProtocol param 0%x, fqdn [%s]", static_cast<unsigned int>(this->protocol_mask), servername);
       ssl_vc->set_valid_tls_protocols(protocol_mask, TLSValidProtocols::max_mask);
     }

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -302,7 +302,7 @@ public:
   const char *
   get_server_name() const override
   {
-    return _get_sni_server_name() ? _get_sni_server_name() : "";
+    return get_sni_server_name() ? get_sni_server_name() : "";
   }
 
   bool

--- a/iocore/net/TLSSNISupport.cc
+++ b/iocore/net/TLSSNISupport.cc
@@ -57,7 +57,7 @@ TLSSNISupport::unbind(SSL *ssl)
 int
 TLSSNISupport::perform_sni_action()
 {
-  const char *servername = this->_get_sni_server_name();
+  const char *servername = this->get_sni_server_name();
   if (!servername) {
     Debug("ssl_sni", "No servername provided");
     return SSL_TLSEXT_ERR_OK;
@@ -142,7 +142,7 @@ TLSSNISupport::_clear()
 }
 
 const char *
-TLSSNISupport::_get_sni_server_name() const
+TLSSNISupport::get_sni_server_name() const
 {
   return _sni_server_name.get() ? _sni_server_name.get() : "";
 }

--- a/iocore/net/TLSSNISupport.h
+++ b/iocore/net/TLSSNISupport.h
@@ -50,6 +50,8 @@ public:
 #endif
   void on_servername(SSL *ssl, int *al, void *arg);
 
+  const char *get_sni_server_name() const;
+
   struct HintsFromSNI {
     std::optional<uint32_t> http2_buffer_water_mark;
   } hints_from_sni;
@@ -58,7 +60,6 @@ protected:
   virtual void _fire_ssl_servername_event() = 0;
 
   void _clear();
-  const char *_get_sni_server_name() const;
 
 private:
   static int _ex_data_index;


### PR DESCRIPTION
`NetVConnection::get_server_name()` is widely used in SNI actions and it requires a cast to `SSLNetVC`. We can simply call `TLSSNISupport::get_sni_server_name()` instead by making it public.

The only difference between `get_server_name()` and `get_sni_server_name()` is that `get_server_name()` returns empty string ("") instead of `nullptr`. This sounds like we cannot simply replace the functions, but such case is checked at another place, so `get_sni_server_name()` does not return `nullptr` in SNI actions.
https://github.com/apache/trafficserver/blob/697da390e93d214dedcc8b2a1f31f4c1ff8830c2/iocore/net/TLSSNISupport.cc#L58-L64