### PR TITLE
Clean up some errors in output of ASAN build.

### DIFF
--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -162,9 +162,13 @@ LogConfig::read_configuration_variables()
   ats_free(ptr);
 
   ptr = REC_ConfigReadString("proxy.config.log.hostname");
-  if (ptr != nullptr && std::string_view(ptr) != "localhost") {
-    ats_free(hostname);
-    hostname = ptr;
+  if (ptr != nullptr) {
+    if (std::string_view(ptr) != "localhost") {
+      ats_free(hostname);
+      hostname = ptr;
+    } else {
+      ats_free(ptr);
+    }
   }
 
   ptr = REC_ConfigReadString("proxy.config.error.logfile.filename");

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1917,6 +1917,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   char *hostname = REC_ConfigReadString("proxy.config.log.hostname");
   if (hostname != nullptr && std::string_view(hostname) == "localhost") {
     // The default value was used. Let Machine::init derive the hostname.
+    ats_free(hostname);
     hostname = nullptr;
   }
   Machine::init(hostname, &machine_addr.sa);


### PR DESCRIPTION
The "leak" of the DbgCtl tags is actually benign, since these are not dereferenced until TS process exit.
