### PR TITLE
Pin flask to version 2.1.3

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -48,6 +48,7 @@ python-jose = "*"
 # depends upon. Pinning Wekrzeug for now until httpbin or its dependencies is
 # updated for the changed API.
 Werkzeug = "==2.0.3"
+flask = "==2.1.3"
 
 [requires]
 python_version = "3"


### PR DESCRIPTION
This resolves an AuTest Pipenv package dependency conflict for Werkzeug,
which is used by httpbin. Latest versions of flask require newer
versions of flask which conflicts with our pin to keep httpbin working.