### PR TITLE
dns error logging to diags

### DIFF
--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1564,7 +1564,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       server_ok = false; // could be server problems
       goto Lerror;
     case NOERROR: // NOERROR the if condition excludes this status code to avoid spamming the logs, good for testing
-      SiteThrottledNote("NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
+      Debug("dns", "NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
       break;
     case FORMERR: // FORMERR unrecoverable errors
       SiteThrottledNote("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1563,43 +1563,50 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       retry     = true;
       server_ok = false; // could be server problems
       goto Lerror;
-    case NOERROR: // NOERROR the if condition excludes this status code to avoid spamming the logs, good for testing
+      break;
+    case NOERROR: // Included for completeness. The above condition ensures that NOERROR should not enter this block.
       Debug("dns", "NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
       break;
-    case FORMERR: // FORMERR unrecoverable errors
+    case FORMERR: // unrecoverable errors
       SiteThrottledNote("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
+      goto Lerror;
       break;
-    case SERVFAIL: // SERVFAIL recoverable error
+    case SERVFAIL: // recoverable error
       SiteThrottledNote("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
       retry = true;
       break;
-    case NXDOMAIN: // NXDOMAIN
+    case NXDOMAIN: 
       SiteThrottledNote("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
       retry     = false;
       tcp_retry = false;
+      goto Lerror;
       break;
-    case NOTIMP: // NOTIMP
+    case NOTIMP: 
       SiteThrottledNote("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
       server_ok = false; // could be server problems
       goto Lerror;
       break;
-    case REFUSED: // REFUSED
+    case REFUSED:
       SiteThrottledNote("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
       goto Lerror;
       break;
-    case YXDOMAIN: // YXDOMAIN
+    case YXDOMAIN: 
       SiteThrottledNote("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
+      goto Lerror;
       break;
-    case YXRRSET: // YXRRSET
+    case YXRRSET:
       SiteThrottledNote("YXRRSET: DNS error %d for [%s]: RRSet that should not exist, does exist.", h->rcode, e->qname);
+      goto Lerror;
       break;
-    case NXRRSET: // NXRRSET
+    case NXRRSET:
       SiteThrottledNote("NXRRSET: DNS error %d for [%s]: RRSet that should not exist, does not exist.", h->rcode, e->qname);
+      goto Lerror;
       break;
-    case NOTAUTH: // NOTAUTH
+    case NOTAUTH:
       SiteThrottledNote("NOTAUTH: DNS error %d for [%s]: Server not authorative for the zone.", h->rcode, e->qname);
+      goto Lerror;
       break;
-    case NOTZONE: // NOTZONE
+    case NOTZONE:
       SiteThrottledNote("NOTZONE: DNS error %d for [%s]: Name not in zone.", h->rcode, e->qname);
       goto Lerror;
       break;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1559,7 +1559,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     Debug("dns", "received rcode = %d", h->rcode);
     switch (h->rcode) {
     default:
-      SiteThrottledNote("Unknown: DNS error %d for [%s]", h->rcode, e->qname);
+      SiteThrottledWarning("Unknown: DNS error %d for [%s]", h->rcode, e->qname);
       retry     = true;
       server_ok = false; // could be server problems
       goto Lerror;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1558,51 +1558,51 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
   if (h->rcode != NOERROR || !h->ancount) {
     Debug("dns", "received rcode = %d", h->rcode);
     switch (h->rcode) {
-      default:
-        SiteThrottledWarning("Unknown: DNS error %d for [%s]", h->rcode, e->qname);
-        retry     = true;
-        server_ok = false; // could be server problems
-        goto Lerror;
-      case NOERROR: // NOERROR the if condition excludes this status code to avoid spamming the logs, good for testing
-        SiteThrottledStatus("NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
-        break;
-      case FORMERR: // FORMERR unrecoverable errors
-        SiteThrottledError("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
-        break;
-      case SERVFAIL: // SERVFAIL recoverable error
-        SiteThrottledError("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
-        retry = true;
-        break;
-      case NXDOMAIN: // NXDOMAIN
-        SiteThrottledError("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
-        retry= false;
-        tcp_retry= false;
-        break;
-      case NOTIMP: // NOTIMP
-        SiteThrottledError("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
-        server_ok = false; // could be server problems
-        goto Lerror;
-        break;
-      case REFUSED: // REFUSED
-        SiteThrottledError("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
-        goto Lerror;
-        break;
-      case YXDOMAIN:  // YXDOMAIN
-        SiteThrottledError("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
-        break;
-      case YXRRSET:  // YXRRSET
-        SiteThrottledError("YXRRSET: DNS error %d for [%s]: RRSet that should not exist, does exist.", h->rcode, e->qname);
-        break;
-      case NXRRSET:  // NXRRSET
-        SiteThrottledError("NXRRSET: DNS error %d for [%s]: RRSet that should not exist, does not exist.", h->rcode, e->qname);
-        break;
-      case NOTAUTH:  // NOTAUTH
-        SiteThrottledError("NOTAUTH: DNS error %d for [%s]: Server not authorative for the zone.", h->rcode, e->qname);
-        break;
-      case NOTZONE: // NOTZONE
-        SiteThrottledError("NOTZONE: DNS error %d for [%s]: Name not in zone.", h->rcode, e->qname);
-        goto Lerror;
-        break;
+    default:
+      SiteThrottledWarning("Unknown: DNS error %d for [%s]", h->rcode, e->qname);
+      retry     = true;
+      server_ok = false; // could be server problems
+      goto Lerror;
+    case NOERROR: // NOERROR the if condition excludes this status code to avoid spamming the logs, good for testing
+      SiteThrottledStatus("NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
+      break;
+    case FORMERR: // FORMERR unrecoverable errors
+      SiteThrottledError("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
+      break;
+    case SERVFAIL: // SERVFAIL recoverable error
+      SiteThrottledError("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
+      retry = true;
+      break;
+    case NXDOMAIN: // NXDOMAIN
+      SiteThrottledError("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
+      retry     = false;
+      tcp_retry = false;
+      break;
+    case NOTIMP: // NOTIMP
+      SiteThrottledError("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
+      server_ok = false; // could be server problems
+      goto Lerror;
+      break;
+    case REFUSED: // REFUSED
+      SiteThrottledError("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
+      goto Lerror;
+      break;
+    case YXDOMAIN: // YXDOMAIN
+      SiteThrottledError("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
+      break;
+    case YXRRSET: // YXRRSET
+      SiteThrottledError("YXRRSET: DNS error %d for [%s]: RRSet that should not exist, does exist.", h->rcode, e->qname);
+      break;
+    case NXRRSET: // NXRRSET
+      SiteThrottledError("NXRRSET: DNS error %d for [%s]: RRSet that should not exist, does not exist.", h->rcode, e->qname);
+      break;
+    case NOTAUTH: // NOTAUTH
+      SiteThrottledError("NOTAUTH: DNS error %d for [%s]: Server not authorative for the zone.", h->rcode, e->qname);
+      break;
+    case NOTZONE: // NOTZONE
+      SiteThrottledError("NOTZONE: DNS error %d for [%s]: Name not in zone.", h->rcode, e->qname);
+      goto Lerror;
+      break;
     }
   } else {
     //

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1082,7 +1082,7 @@ write_dns(DNSHandler *h, bool tcp_retry)
     max_nscount = MAX_NAMED;
   }
   if (max_nscount <= 0) {
-    Warning("There is no name server found in the resolv.conf");
+    Error("There is no name server found in the resolv.conf");
     if (h->entries.head) {
       dns_result(h, h->entries.head, nullptr, false);
     }
@@ -1553,32 +1553,56 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     goto Lerror;
   }
 
+  // Logs using SiteThrottled* version is helpful for noisy logs, being used here
+  // instead of print statements to help with the possible retries when a dns code occurs
   if (h->rcode != NOERROR || !h->ancount) {
     Debug("dns", "received rcode = %d", h->rcode);
     switch (h->rcode) {
-    default:
-      Warning("Unknown DNS error %d for [%s]", h->rcode, e->qname);
-      retry     = true;
-      server_ok = false; // could be server problems
-      goto Lerror;
-    case SERVFAIL: // recoverable error
-      retry = true;
-      break;
-    case FORMERR: // unrecoverable errors
-    case REFUSED:
-    case NOTIMP:
-      Debug("dns", "DNS error %d for [%s]", h->rcode, e->qname);
-      server_ok = false; // could be server problems
-      goto Lerror;
-    case NOERROR:
-    case NXDOMAIN:
-    case 6:  // YXDOMAIN
-    case 7:  // YXRRSET
-    case 8:  // NOTAUTH
-    case 9:  // NOTAUTH
-    case 10: // NOTZONE
-      Debug("dns", "DNS error %d for [%s]", h->rcode, e->qname);
-      goto Lerror;
+      default:
+        SiteThrottledWarning("Unknown: DNS error %d for [%s]", h->rcode, e->qname);
+        retry     = true;
+        server_ok = false; // could be server problems
+        goto Lerror;
+      case NOERROR: // NOERROR the if condition excludes this status code to avoid spamming the logs, good for testing
+        SiteThrottledStatus("NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
+        break;
+      case FORMERR: // FORMERR unrecoverable errors
+        SiteThrottledError("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
+        break;
+      case SERVFAIL: // SERVFAIL recoverable error
+        SiteThrottledError("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
+        retry = true;
+        break;
+      case NXDOMAIN: // NXDOMAIN
+        SiteThrottledError("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
+        retry= false;
+        tcp_retry= false;
+        break;
+      case NOTIMP: // NOTIMP
+        SiteThrottledError("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
+        server_ok = false; // could be server problems
+        goto Lerror;
+        break;
+      case REFUSED: // REFUSED
+        SiteThrottledError("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
+        goto Lerror;
+        break;
+      case YXDOMAIN:  // YXDOMAIN
+        SiteThrottledError("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
+        break;
+      case YXRRSET:  // YXRRSET
+        SiteThrottledError("YXRRSET: DNS error %d for [%s]: RRSet that should not exist, does exist.", h->rcode, e->qname);
+        break;
+      case NXRRSET:  // NXRRSET
+        SiteThrottledError("NXRRSET: DNS error %d for [%s]: RRSet that should not exist, does not exist.", h->rcode, e->qname);
+        break;
+      case NOTAUTH:  // NOTAUTH
+        SiteThrottledError("NOTAUTH: DNS error %d for [%s]: Server not authorative for the zone.", h->rcode, e->qname);
+        break;
+      case NOTZONE: // NOTZONE
+        SiteThrottledError("NOTZONE: DNS error %d for [%s]: Name not in zone.", h->rcode, e->qname);
+        goto Lerror;
+        break;
     }
   } else {
     //

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1575,13 +1575,13 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       SiteThrottledNote("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
       retry = true;
       break;
-    case NXDOMAIN: 
+    case NXDOMAIN:
       SiteThrottledNote("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
       retry     = false;
       tcp_retry = false;
       goto Lerror;
       break;
-    case NOTIMP: 
+    case NOTIMP:
       SiteThrottledNote("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
       server_ok = false; // could be server problems
       goto Lerror;
@@ -1590,7 +1590,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       SiteThrottledNote("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
       goto Lerror;
       break;
-    case YXDOMAIN: 
+    case YXDOMAIN:
       SiteThrottledNote("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
       goto Lerror;
       break;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -32,8 +32,6 @@
 #define SRV_SERVER (RRFIXEDSZ + 6)
 #define SRV_FIXEDSZ (RRFIXEDSZ + 6)
 
-#define RCODE_ARRAY_SIZE 11
-
 EventType ET_DNS = ET_CALL;
 
 //
@@ -1531,11 +1529,11 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
   bool server_ok    = true;
   uint32_t temp_ttl = 0;
 
-  const char *RCODE_NAME[RCODE_ARRAY_SIZE] = {
+  const char *RCODE_NAME[] = {
     "NOERROR", "FORMERR", "SERVFAIL", "NXDOMAIN", "NOTIMP", "REFUSED", "YXDOMAIN", "YXRRSET", "NXRRSET", "NOTAUTH", "NOTZONE",
   };
 
-  const char *RCODE_DESCRIPTION[RCODE_ARRAY_SIZE] = {
+  const char *RCODE_DESCRIPTION[] = {
     "No Error",
     "Format Error",
     "Server Failure",
@@ -1583,9 +1581,9 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       retry     = true;
       server_ok = false; // could be server problems
       goto Lerror;
-    case NOERROR: // Included for completeness. The above condition ensures that NOERROR should not enter this block.
+    case NOERROR: // included for completeness.
       Debug("dns", "%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
-      break; // need to break here or this fails test: proxy_serve_stale_dns_fail even though NOERROR is not used in this block.
+      break;
     case SERVFAIL: // recoverable error
       SiteThrottledNote("%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
       retry = true;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1593,7 +1593,8 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       SiteThrottledNote("%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
       server_ok = false; // could be server problems
       goto Lerror;
-    case NOERROR:
+    case NOERROR: // Included for completeness. The above condition ensures that NOERROR should not enter this block.
+      Debug("dns", "%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
     case NXDOMAIN:
     case YXDOMAIN:
     case YXRRSET:

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1583,6 +1583,9 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       retry     = true;
       server_ok = false; // could be server problems
       goto Lerror;
+    case NOERROR: // Included for completeness. The above condition ensures that NOERROR should not enter this block.
+      Debug("dns", "%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
+      break; // need to break here or this fails test: proxy_serve_stale_dns_fail even though NOERROR is not used in this block.
     case SERVFAIL: // recoverable error
       SiteThrottledNote("%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
       retry = true;
@@ -1593,8 +1596,6 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       SiteThrottledNote("%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
       server_ok = false; // could be server problems
       goto Lerror;
-    case NOERROR: // Included for completeness. The above condition ensures that NOERROR should not enter this block.
-      Debug("dns", "%s: DNS error %d for [%s]: %s", RCODE_NAME[h->rcode], h->rcode, e->qname, RCODE_DESCRIPTION[h->rcode]);
     case NXDOMAIN:
     case YXDOMAIN:
     case YXRRSET:

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1563,53 +1563,33 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
       retry     = true;
       server_ok = false; // could be server problems
       goto Lerror;
-      break;
-    case NOERROR: // Included for completeness. The above condition ensures that NOERROR should not enter this block.
-      Debug("dns", "NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
-      break;
-    case FORMERR: // unrecoverable errors
-      SiteThrottledNote("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
-      goto Lerror;
-      break;
     case SERVFAIL: // recoverable error
       SiteThrottledNote("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
       retry = true;
       break;
-    case NXDOMAIN:
-      SiteThrottledNote("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
-      retry     = false;
-      tcp_retry = false;
-      goto Lerror;
-      break;
+    case FORMERR: // unrecoverable errors
+      SiteThrottledNote("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
+    case REFUSED:
+      SiteThrottledNote("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
     case NOTIMP:
       SiteThrottledNote("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
       server_ok = false; // could be server problems
       goto Lerror;
-      break;
-    case REFUSED:
-      SiteThrottledNote("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
-      goto Lerror;
-      break;
+    case NOERROR: // Included for completeness. The above condition ensures that NOERROR should not enter this block.
+      Debug("dns", "NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
+    case NXDOMAIN:
+      SiteThrottledNote("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
     case YXDOMAIN:
       SiteThrottledNote("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
-      goto Lerror;
-      break;
     case YXRRSET:
       SiteThrottledNote("YXRRSET: DNS error %d for [%s]: RRSet that should not exist, does exist.", h->rcode, e->qname);
-      goto Lerror;
-      break;
     case NXRRSET:
-      SiteThrottledNote("NXRRSET: DNS error %d for [%s]: RRSet that should not exist, does not exist.", h->rcode, e->qname);
-      goto Lerror;
-      break;
+      SiteThrottledNote("NXRRSET: DNS error %d for [%s]: RRset that should exist, does not exist", h->rcode, e->qname);
     case NOTAUTH:
-      SiteThrottledNote("NOTAUTH: DNS error %d for [%s]: Server not authorative for the zone.", h->rcode, e->qname);
-      goto Lerror;
-      break;
+      SiteThrottledNote("NOTAUTH: DNS error %d for [%s]: Not Authorized.", h->rcode, e->qname);
     case NOTZONE:
       SiteThrottledNote("NOTZONE: DNS error %d for [%s]: Name not in zone.", h->rcode, e->qname);
       goto Lerror;
-      break;
     }
   } else {
     //

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -1082,7 +1082,7 @@ write_dns(DNSHandler *h, bool tcp_retry)
     max_nscount = MAX_NAMED;
   }
   if (max_nscount <= 0) {
-    Error("There is no name server found in the resolv.conf");
+    Warning("There is no name server found in the resolv.conf");
     if (h->entries.head) {
       dns_result(h, h->entries.head, nullptr, false);
     }
@@ -1559,48 +1559,48 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
     Debug("dns", "received rcode = %d", h->rcode);
     switch (h->rcode) {
     default:
-      SiteThrottledWarning("Unknown: DNS error %d for [%s]", h->rcode, e->qname);
+      SiteThrottledNote("Unknown: DNS error %d for [%s]", h->rcode, e->qname);
       retry     = true;
       server_ok = false; // could be server problems
       goto Lerror;
     case NOERROR: // NOERROR the if condition excludes this status code to avoid spamming the logs, good for testing
-      SiteThrottledStatus("NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
+      SiteThrottledNote("NOERROR: DNS code %d for [%s]: DNS Query completed successfully.", h->rcode, e->qname);
       break;
     case FORMERR: // FORMERR unrecoverable errors
-      SiteThrottledError("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
+      SiteThrottledNote("FORMERR: DNS error %d for [%s]: DNS Query Format Error.", h->rcode, e->qname);
       break;
     case SERVFAIL: // SERVFAIL recoverable error
-      SiteThrottledError("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
+      SiteThrottledNote("SERVFAIL: DNS error %d for [%s]: Server failed to complete the DNS request.", h->rcode, e->qname);
       retry = true;
       break;
     case NXDOMAIN: // NXDOMAIN
-      SiteThrottledError("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
+      SiteThrottledNote("NXDOMAIN: DNS error %d for [%s]: Domain name does not exist.", h->rcode, e->qname);
       retry     = false;
       tcp_retry = false;
       break;
     case NOTIMP: // NOTIMP
-      SiteThrottledError("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
+      SiteThrottledNote("NOTIMP: DNS error %d for [%s]: Function not implemented.", h->rcode, e->qname);
       server_ok = false; // could be server problems
       goto Lerror;
       break;
     case REFUSED: // REFUSED
-      SiteThrottledError("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
+      SiteThrottledNote("REFUSED: DNS error %d for [%s]: The server refused to answer for the query.", h->rcode, e->qname);
       goto Lerror;
       break;
     case YXDOMAIN: // YXDOMAIN
-      SiteThrottledError("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
+      SiteThrottledNote("YXDOMAIN: DNS error %d for [%s]: Name that should not exist, does exist.", h->rcode, e->qname);
       break;
     case YXRRSET: // YXRRSET
-      SiteThrottledError("YXRRSET: DNS error %d for [%s]: RRSet that should not exist, does exist.", h->rcode, e->qname);
+      SiteThrottledNote("YXRRSET: DNS error %d for [%s]: RRSet that should not exist, does exist.", h->rcode, e->qname);
       break;
     case NXRRSET: // NXRRSET
-      SiteThrottledError("NXRRSET: DNS error %d for [%s]: RRSet that should not exist, does not exist.", h->rcode, e->qname);
+      SiteThrottledNote("NXRRSET: DNS error %d for [%s]: RRSet that should not exist, does not exist.", h->rcode, e->qname);
       break;
     case NOTAUTH: // NOTAUTH
-      SiteThrottledError("NOTAUTH: DNS error %d for [%s]: Server not authorative for the zone.", h->rcode, e->qname);
+      SiteThrottledNote("NOTAUTH: DNS error %d for [%s]: Server not authorative for the zone.", h->rcode, e->qname);
       break;
     case NOTZONE: // NOTZONE
-      SiteThrottledError("NOTZONE: DNS error %d for [%s]: Name not in zone.", h->rcode, e->qname);
+      SiteThrottledNote("NOTZONE: DNS error %d for [%s]: Name not in zone.", h->rcode, e->qname);
       goto Lerror;
       break;
     }


### PR DESCRIPTION
Logs using SiteThrottled* version is helpful for noisy logs, being used here instead of print statements to help with the possible retries when a dns code occurs