### PR TITLE
Remove plugin parent_select unused symbols

### DIFF
--- a/plugins/experimental/parent_select/consistenthash.cc
+++ b/plugins/experimental/parent_select/consistenthash.cc
@@ -288,9 +288,8 @@ PLNextHopConsistentHash::deleteTxn(void *txn)
 }
 
 void
-PLNextHopConsistentHash::next(TSHttpTxn txnp, void *strategyTxn, const char *exclude_hostname, size_t exclude_hostname_len,
-                              in_port_t exclude_port, const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port,
-                              bool *out_retry, bool *out_no_cache, time_t now)
+PLNextHopConsistentHash::next(TSHttpTxn txnp, void *strategyTxn, const char **out_hostname, size_t *out_hostname_len,
+                              in_port_t *out_port, bool *out_retry, bool *out_no_cache, time_t now)
 {
   // TODO add logic in the strategy to track when someone is retrying, and not give it out to multiple threads at once, to prevent
   // thundering retries See github issue #7485

--- a/plugins/experimental/parent_select/consistenthash.h
+++ b/plugins/experimental/parent_select/consistenthash.h
@@ -75,9 +75,8 @@ public:
   PLNextHopConsistentHash() = delete;
   PLNextHopConsistentHash(const std::string_view name, const YAML::Node &n);
   ~PLNextHopConsistentHash();
-  void next(TSHttpTxn txnp, void *strategyTxn, const char *exclude_hostname, size_t exclude_hostname_len, in_port_t exclude_port,
-            const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port, bool *out_retry, bool *out_no_cache,
-            time_t now = 0) override;
+  void next(TSHttpTxn txnp, void *strategyTxn, const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port,
+            bool *out_retry, bool *out_no_cache, time_t now = 0) override;
   void mark(TSHttpTxn txnp, void *strategyTxn, const char *hostname, const size_t hostname_len, const in_port_t port,
             const PLNHCmd status, const time_t now) override;
   void *newTxn() override;

--- a/plugins/experimental/parent_select/parent_select.cc
+++ b/plugins/experimental/parent_select/parent_select.cc
@@ -128,6 +128,7 @@ handle_read_response(TSHttpTxn txnp, StrategyTxn *strategyTxn)
     TSResponseAction ra;
     TSHttpTxnResponseActionGet(txnp, &ra);
     ra.responseIsRetryable = strategy->responseIsRetryable(strategyTxn->request_count - 1, status);
+
     TSHttpTxnResponseActionSet(txnp, &ra);
   }
 
@@ -168,11 +169,7 @@ handle_os_dns(TSHttpTxn txnp, StrategyTxn *strategyTxn)
 
   TSResponseAction ra;
   memset(&ra, 0, sizeof(TSResponseAction));
-  const char *const exclude_host = strategyTxn->prev_ra.hostname;
-  const size_t exclude_host_len  = strategyTxn->prev_ra.hostname_len;
-  const in_port_t exclude_port   = strategyTxn->prev_ra.port;
-  strategy->next(txnp, strategyTxn->txn, exclude_host, exclude_host_len, exclude_port, &ra.hostname, &ra.hostname_len, &ra.port,
-                 &ra.is_retry, &ra.no_cache);
+  strategy->next(txnp, strategyTxn->txn, &ra.hostname, &ra.hostname_len, &ra.port, &ra.is_retry, &ra.no_cache);
 
   ra.fail = ra.hostname == nullptr; // failed is whether to immediately fail and return the client a 502. In this case: whether or
                                     // not we found another parent.
@@ -340,11 +337,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   TSResponseAction ra;
   memset(&ra, 0, sizeof(TSResponseAction)); // because {0} gives a C++ warning. Ugh.
-  constexpr const char *const exclude_host = nullptr;
-  constexpr const size_t exclude_host_len  = 0;
-  constexpr const in_port_t exclude_port   = 0;
-  strategy->next(txnp, strategyTxn->txn, exclude_host, exclude_host_len, exclude_port, &ra.hostname, &ra.hostname_len, &ra.port,
-                 &ra.is_retry, &ra.no_cache);
+  strategy->next(txnp, strategyTxn->txn, &ra.hostname, &ra.hostname_len, &ra.port, &ra.is_retry, &ra.no_cache);
 
   ra.nextHopExists = ra.hostname != nullptr;
   ra.fail          = !ra.nextHopExists;

--- a/plugins/experimental/parent_select/strategy.h
+++ b/plugins/experimental/parent_select/strategy.h
@@ -220,8 +220,7 @@ public:
   virtual ~TSNextHopSelectionStrategy(){};
 
   virtual const char *name()                                                                        = 0;
-  virtual void next(TSHttpTxn txnp, void *strategyTxn, const char *exclude_hostname, size_t exclude_hostname_len,
-                    in_port_t exclude_port, const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port,
+  virtual void next(TSHttpTxn txnp, void *strategyTxn, const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port,
                     bool *out_retry, bool *out_no_cache, time_t now = 0)                            = 0;
   virtual void mark(TSHttpTxn txnp, void *strategyTxn, const char *hostname, const size_t hostname_len, const in_port_t port,
                     const PLNHCmd status, const time_t now = 0)                                     = 0;
@@ -244,11 +243,10 @@ public:
   PLNextHopSelectionStrategy(const std::string_view &name, const YAML::Node &n);
   virtual ~PLNextHopSelectionStrategy(){};
 
-  void next(TSHttpTxn txnp, void *strategyTxn, const char *exclude_hostname, size_t exclude_hostname_len, in_port_t exclude_port,
-            const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port, bool *out_retry, bool *out_no_cache,
-            time_t now = 0) override                             = 0;
+  void next(TSHttpTxn txnp, void *strategyTxn, const char **out_hostname, size_t *out_hostname_len, in_port_t *out_port,
+            bool *out_retry, bool *out_no_cache, time_t now = 0) override = 0;
   void mark(TSHttpTxn txnp, void *strategyTxn, const char *hostname, const size_t hostname_len, const in_port_t port,
-            const PLNHCmd status, const time_t now = 0) override = 0;
+            const PLNHCmd status, const time_t now = 0) override          = 0;
   bool nextHopExists(TSHttpTxn txnp) override;
   bool codeIsFailure(TSHttpStatus response_code) override;
   bool responseIsRetryable(unsigned int current_retry_attempts, TSHttpStatus response_code) override;


### PR DESCRIPTION
These `exclude_hostname` and `exclude_port` args were needed due to limitations on events, the parent_select plugin needed to get the subsequent parent to try, if necessary, because no event would fire. So it needed to say, "give me the next parent *if* this one were marked down, even though it isn't."

Their usage got lost in the parent_select consistent hash refactor (#8590), which I thought would break failover.

But I just extensively tested failover, for DNS, network, and internal code failures, and everything worked up to 3 tries. So it seems either #8590 (#7925 and #8365) or possibly the recent HostDB refactor (#8953) changed something to not make it necessary.

So this PR cleans up the parameters and variables, and just removes them entirely.

This is purely cleanup, doesn't affect behavior. But I recommend backporting to 9.2.x just to reduce future merge conflicts.