### PR TITLE
Change linux/fs include to build with glibc 2.36

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1902,8 +1902,8 @@ AC_CHECK_HEADERS([sys/types.h \
 
 # On OpenBSD, pthread.h must be included before pthread_np.h
 AC_CHECK_HEADERS([pthread_np.h], [], [], [#include <pthread.h>])
-AC_CHECK_HEADERS([sys/statfs.h sys/statvfs.h sys/disk.h sys/disklabel.h])
-AC_CHECK_HEADERS([linux/hdreg.h linux/fs.h linux/major.h])
+AC_CHECK_HEADERS([sys/statfs.h sys/statvfs.h sys/disk.h sys/disklabel.h sys/mount.h])
+AC_CHECK_HEADERS([linux/hdreg.h linux/major.h])
 
 AC_CHECK_HEADERS([sys/sysctl.h], [], [],
                  [[#ifdef HAVE_SYS_PARAM_H

--- a/src/tscore/ink_file.cc
+++ b/src/tscore/ink_file.cc
@@ -52,8 +52,8 @@
 #include <linux/hdreg.h> /* for struct hd_geometry */
 #endif
 
-#if HAVE_LINUX_FS_H
-#include <linux/fs.h> /* for BLKGETSIZE.  sys/mount.h is another candidate */
+#if HAVE_SYS_MOUNT_H
+#include <sys/mount.h> /* for BLKGETSIZE */
 #endif
 
 using ioctl_arg_t = union {


### PR DESCRIPTION
glibc 2.36 includes changes (documented at https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E) that create build errors when including linux/fs.h for mount configuration.  sys/mount.h is a more appropriate include here, which works with older glibc as well.