### PR TITLE
Adds efficient IP range matching to HRW conditions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -523,7 +523,7 @@ PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ >= 7], [
   TS_ADDTO(LIBMAGICKCPP_CFLAGS, [-DMAGICK_VERSION=7])
   have_libmagickcpp=yes
   AS_IF([test "x$enable_experimental_plugins" = "xyes"], [
-    enable_image_magick_plugins=yes
+    enable_image_magick_plugins=no
   ])
 ],
 [
@@ -531,7 +531,7 @@ PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ >= 7], [
     TS_ADDTO(LIBMAGICKCPP_CFLAGS, [-DMAGICK_VERSION=6])
     have_libmagickcpp=yes
     AS_IF([test "x$enable_experimental_plugins" = "xyes"], [
-      enable_image_magick_plugins=yes
+      enable_image_magick_plugins=no
     ])
   ],
   [

--- a/configure.ac
+++ b/configure.ac
@@ -523,7 +523,7 @@ PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ >= 7], [
   TS_ADDTO(LIBMAGICKCPP_CFLAGS, [-DMAGICK_VERSION=7])
   have_libmagickcpp=yes
   AS_IF([test "x$enable_experimental_plugins" = "xyes"], [
-    enable_image_magick_plugins=no
+    enable_image_magick_plugins=yes
   ])
 ],
 [
@@ -531,7 +531,7 @@ PKG_CHECK_MODULES([LIBMAGICKCPP],[Magick++ >= 7], [
     TS_ADDTO(LIBMAGICKCPP_CFLAGS, [-DMAGICK_VERSION=6])
     have_libmagickcpp=yes
     AS_IF([test "x$enable_experimental_plugins" = "xyes"], [
-      enable_image_magick_plugins=no
+      enable_image_magick_plugins=yes
     ])
   ],
   [

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -377,7 +377,7 @@ same way.
 As a special matcher, the inbound IP addresses can be matched against a list of IP ranges, e.g.
 ::
 
-   cond %{INBOUND:REMOTE-ADDR} {192.168.201.0/24,10.0.0.0}
+   cond %{INBOUND:REMOTE-ADDR} {192.168.201.0/24,10.0.0.0/8}
 
 Note that this will not work against the non-IP based conditions, such as the protocol families,
 and the configuration parser will error out. The format here is very specific, in particular no
@@ -411,7 +411,7 @@ actually as a value to an operator, e.g. ::
 As a special matcher, the `IP` can be matched against a list of IP ranges, e.g.
 ::
 
-   cond %{IP:CLIENT} {192.168.201.0/24,10.0.0.0}
+   cond %{IP:CLIENT} {192.168.201.0/24,10.0.0.0/8}
 
 The format here is very specific, in particular no white spaces are allowed between the
 ranges.

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -374,6 +374,14 @@ string. Therefore the condition is treated as if it were ::
 which is true when the connection is not TLS. The arguments ``H2``, ``IPV4``, and ``IPV6`` work the
 same way.
 
+As a special matcher, the inbound IP addresses can be matched against a list of IP ranges, e.g.
+::
+
+   cond %{INBOUND:REMOTE-ADDR} {192.168.201.0/24,10.0.0.0}
+
+Note that this will not work against the non-IP based conditions, such as the protocol families,
+and the configuration parser will error out. The format here is very specific, in particular no
+white spaces are allowed between the ranges.
 
 IP
 ~~
@@ -400,6 +408,13 @@ actually as a value to an operator, e.g. ::
      set-header X-Server-IP %{IP:SERVER}
      set-header X-Outbound-IP %{IP:OUTBOUND}
 
+As a special matcher, the `IP` can be matched against a list of IP ranges, e.g.
+::
+
+   cond %{IP:CLIENT} {192.168.201.0/24,10.0.0.0}
+
+The format here is very specific, in particular no white spaces are allowed between the
+ranges.
 
 INTERNAL-TRANSACTION
 ~~~~~~~~~~~~~~~~~~~~

--- a/plugins/header_rewrite/Makefile.inc
+++ b/plugins/header_rewrite/Makefile.inc
@@ -35,6 +35,8 @@ header_rewrite_header_rewrite_la_SOURCES = \
 	header_rewrite/operators.h \
 	header_rewrite/regex_helper.cc \
 	header_rewrite/regex_helper.h \
+	header_rewrite/ipranges_helper.cc \
+	header_rewrite/ipranges_helper.h \
 	header_rewrite/resources.cc \
 	header_rewrite/resources.h \
 	header_rewrite/ruleset.cc \

--- a/plugins/header_rewrite/condition.cc
+++ b/plugins/header_rewrite/condition.cc
@@ -46,6 +46,10 @@ parse_matcher_op(std::string &arg)
     arg.erase(arg.length() - 1, arg.length());
     return MATCH_REGULAR_EXPRESSION;
     break;
+  case '{':
+    arg.erase(0, 1);
+    arg.erase(arg.length() - 1, arg.length());
+    return MATCH_IP_RANGES;
   default:
     return MATCH_EQUAL;
     break;

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -348,6 +348,7 @@ protected:
 class ConditionIp : public Condition
 {
   typedef Matchers<std::string> MatcherType;
+  typedef Matchers<const sockaddr *> MatcherTypeIp;
 
 public:
   explicit ConditionIp() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionIp"); };
@@ -503,8 +504,9 @@ private:
 /// Information about the inbound (client) session.
 class ConditionInbound : public Condition
 {
-  using MatcherType = Matchers<std::string>;
-  using self        = ConditionInbound;
+  using MatcherType   = Matchers<std::string>;
+  using MatcherTypeIp = Matchers<const sockaddr *>;
+  using self          = ConditionInbound;
 
 public:
   explicit ConditionInbound() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionInbound"); };

--- a/plugins/header_rewrite/ipranges_helper.cc
+++ b/plugins/header_rewrite/ipranges_helper.cc
@@ -1,0 +1,63 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#include "ipranges_helper.h"
+
+#include <string_view>
+#include <vector>
+
+static std::vector<std::string_view>
+splitter(std::string_view input, char delim)
+{
+  std::vector<std::string_view> output;
+  size_t first = 0;
+
+  while (first < input.size()) {
+    const auto second = input.find_first_of(delim, first);
+
+    if (first != second) {
+      output.emplace_back(input.substr(first, second - first));
+    }
+    if (second == std::string_view::npos) {
+      break;
+    }
+    first = second + 1;
+  }
+
+  return output; // RVO
+}
+
+bool
+ipRangesHelper::addIpRanges(const std::string &s)
+{
+  auto ranges = splitter(s, ',');
+
+  for (auto &it : ranges) {
+    IpAddr start, end;
+
+    ats_ip_range_parse(it, start, end);
+    _ipRanges.mark(start, end);
+  }
+
+  if (_ipRanges.count() > 0) {
+    TSDebug(PLUGIN_NAME, "    Added %zu IP ranges while parsing", _ipRanges.count());
+    return true;
+  } else {
+    TSDebug(PLUGIN_NAME, "    No IP ranges added, possibly bad input");
+    return false;
+  }
+}

--- a/plugins/header_rewrite/ipranges_helper.cc
+++ b/plugins/header_rewrite/ipranges_helper.cc
@@ -28,8 +28,9 @@ ipRangesHelper::addIpRanges(const std::string &s)
   while (src) {
     IpAddr start, end;
 
-    ats_ip_range_parse(src.take_prefix_at(','), start, end);
-    _ipRanges.mark(start, end);
+    if (TS_SUCCESS == ats_ip_range_parse(src.take_prefix_at(','), start, end)) {
+      _ipRanges.mark(start, end);
+    }
   }
 
   if (_ipRanges.count() > 0) {

--- a/plugins/header_rewrite/ipranges_helper.cc
+++ b/plugins/header_rewrite/ipranges_helper.cc
@@ -16,40 +16,19 @@
   limitations under the License.
 */
 #include "ipranges_helper.h"
+#include "tscpp/util/TextView.h"
 
-#include <string_view>
 #include <vector>
-
-static std::vector<std::string_view>
-splitter(std::string_view input, char delim)
-{
-  std::vector<std::string_view> output;
-  size_t first = 0;
-
-  while (first < input.size()) {
-    const auto second = input.find_first_of(delim, first);
-
-    if (first != second) {
-      output.emplace_back(input.substr(first, second - first));
-    }
-    if (second == std::string_view::npos) {
-      break;
-    }
-    first = second + 1;
-  }
-
-  return output; // RVO
-}
 
 bool
 ipRangesHelper::addIpRanges(const std::string &s)
 {
-  auto ranges = splitter(s, ',');
+  ts::TextView src{s};
 
-  for (auto &it : ranges) {
+  while (src) {
     IpAddr start, end;
 
-    ats_ip_range_parse(it, start, end);
+    ats_ip_range_parse(src.take_prefix_at(','), start, end);
     _ipRanges.mark(start, end);
   }
 

--- a/plugins/header_rewrite/ipranges_helper.h
+++ b/plugins/header_rewrite/ipranges_helper.h
@@ -1,0 +1,46 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#pragma once
+
+#include "tscore/IpMap.h"
+#include "tscore/ink_inet.h"
+
+#include "ts/ts.h"
+
+#include "lulu.h"
+
+#include <string>
+
+class ipRangesHelper
+{
+public:
+  ~ipRangesHelper() {}
+
+  bool addIpRanges(const std::string &s);
+
+  bool
+  ipRangesMatch(const sockaddr *addr) const
+  {
+    void *ptr = nullptr;
+
+    return _ipRanges.contains(addr, &ptr);
+  }
+
+private:
+  IpMap _ipRanges;
+};

--- a/plugins/header_rewrite/ruleset.cc
+++ b/plugins/header_rewrite/ruleset.cc
@@ -46,7 +46,7 @@ RuleSet::add_condition(Parser &p, const char *filename, int lineno)
   Condition *c = condition_factory(p.get_op());
 
   if (nullptr != c) {
-    TSDebug(PLUGIN_NAME, "   Adding condition: %%{%s} with arg: %s", p.get_op().c_str(), p.get_arg().c_str());
+    TSDebug(PLUGIN_NAME, "    Adding condition: %%{%s} with arg: %s", p.get_op().c_str(), p.get_arg().c_str());
     c->initialize(p);
     if (!c->set_hook(_hook)) {
       delete c;
@@ -76,7 +76,7 @@ RuleSet::add_operator(Parser &p, const char *filename, int lineno)
   Operator *o = operator_factory(p.get_op());
 
   if (nullptr != o) {
-    TSDebug(PLUGIN_NAME, "   Adding operator: %s(%s)=\"%s\"", p.get_op().c_str(), p.get_arg().c_str(), p.get_value().c_str());
+    TSDebug(PLUGIN_NAME, "    Adding operator: %s(%s)=\"%s\"", p.get_op().c_str(), p.get_arg().c_str(), p.get_value().c_str());
     o->initialize(p);
     if (!o->set_hook(_hook)) {
       delete o;


### PR DESCRIPTION
This should allow for much more efficient IP address checks, rather than having to convert IPs to strings (multiple times) and do string comparisons.

Jeff E. suggested we ought to generalize the notion of "ranges" in matching here, but I'd like to leave that for a future addition.