### PR TITLE
9.1.x: Fix a couple compiler warnings

### DIFF
--- a/plugins/experimental/traffic_dump/json_utils.cc
+++ b/plugins/experimental/traffic_dump/json_utils.cc
@@ -114,7 +114,7 @@ esc_json_out(const char *buf, int64_t len, std::ostream &jsonfile)
       break;
     }
     default: {
-      if ('\x00' <= c && c <= '\x1f') {
+      if (c <= '\x1f') {
         write_buffered_context(buf, prevIdx, idx, jsonfile);
         jsonfile << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c);
       }

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1125,9 +1125,9 @@ ConditionInbound::append_value(std::string &s, const Resources &res, NetworkSess
     zret = TSHttpTxnClientProtocolStackContains(res.txnp, "ip");
     break;
   case NET_QUAL_STACK: {
-    std::array<char const *, 8> tags;
-    int count  = 0;
-    size_t len = 0;
+    std::array<char const *, 8> tags = {};
+    int count                        = 0;
+    size_t len                       = 0;
     TSHttpTxnClientProtocolStackGet(res.txnp, tags.size(), tags.data(), &count);
     for (int i = 0; i < count; ++i) {
       len += 1 + strlen(tags[i]);


### PR DESCRIPTION
This pulls in a couple compiler warning fixes from later 9.x branches.

Type error:

```
experimental/traffic_dump/json_utils.cc: In function ‘int {anonymous}::esc_json_out(const char*, int64_t, std::ostream&)’:
experimental/traffic_dump/json_utils.cc:117:18: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  117 |       if ('\x00' <= c && c <= '\x1f') {
      |           ~~~~~~~^~~~


```Maybe uninitialized error:

```
header_rewrite/conditions.cc: In static member function ‘static void ConditionInbound::append_value(std::string&, const Resources&, NetworkSessionQualifiers)’:
header_rewrite/conditions.cc:1131:56: error: ‘tags’ may be used uninitialized [-Werror=maybe-uninitialized]
 1131 |     TSHttpTxnClientProtocolStackGet(res.txnp, tags.size(), tags.data(), &count);
      |                                               ~~~~~~~~~^~
In file included from header_rewrite/conditions.cc:29:
/opt/rh/gcc-toolset-11/root/usr/include/c++/11/array:176:7: note: by argument 1 of type ‘const std::array<const char*, 8>*’ to ‘constexpr std::array<_Tp, _Nm>::size_type std::array<_Tp, _Nm>::size() const [with _Tp = const char*; long unsigned int _Nm = 8]’ declared here
  176 |       size() const noexcept { return _Nm; }
      |       ^~~~
header_rewrite/conditions.cc:1128:33: note: ‘tags’ declared here
 1128 |     std::array<char const *, 8> tags;
      |                                 ^~~~
```