### PR TITLE
Fix reload memory leak

### DIFF
--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -166,6 +166,7 @@ struct CacheHostTableConfig : public Continuation {
     CacheHostTable *t   = new CacheHostTable((*ppt)->cache, (*ppt)->type);
     CacheHostTable *old = (CacheHostTable *)ink_atomic_swap(&t, *ppt);
     new_Deleter(old, CACHE_MEM_FREE_TIMEOUT);
+    delete this;
     return EVENT_DONE;
   }
 };


### PR DESCRIPTION
Fixes a memory leak when reloading hosting.config.

I manually tested and ran, modified hosting.config and reloaded. Appears to work, requests and things continue to work, debug prints in the constructor and destructor show a new `CacheHostTableConfig` being allocated on reload, and the old one being deleted once and only once.

Recommend backporting to All The Things. Appears to have been a bug forever.