### PR TITLE
Eliminate a redundant data copy in H3 framer

### DIFF
--- a/proxy/http3/Http3DataFramer.cc
+++ b/proxy/http3/Http3DataFramer.cc
@@ -37,7 +37,7 @@ Http3DataFramer::generate_frame()
   Http3FrameUPtr frame   = Http3FrameFactory::create_null_frame();
   IOBufferReader *reader = this->_source_vio->get_reader();
 
-  size_t payload_len = 128 * 1024;
+  size_t payload_len = 1024 * 1024;
   if (!reader->is_read_avail_more_than(payload_len)) {
     payload_len = reader->read_avail();
   }

--- a/proxy/http3/Http3Frame.h
+++ b/proxy/http3/Http3Frame.h
@@ -75,7 +75,8 @@ class Http3DataFrame : public Http3Frame
 public:
   Http3DataFrame() : Http3Frame() {}
   Http3DataFrame(const uint8_t *buf, size_t len);
-  Http3DataFrame(ats_unique_buf payload, size_t payload_len);
+  Http3DataFrame(IOBufferReader *reader, size_t payload_len);
+  ~Http3DataFrame();
 
   Ptr<IOBufferBlock> to_io_buffer_block() const override;
   void reset(const uint8_t *buf, size_t len) override;
@@ -84,6 +85,7 @@ public:
   uint64_t payload_length() const;
 
 private:
+  IOBufferReader *_reader      = nullptr;
   const uint8_t *_payload      = nullptr;
   ats_unique_buf _payload_uptr = {nullptr};
   size_t _payload_len          = 0;
@@ -235,7 +237,6 @@ public:
   /*
    * Creates a DATA frame.
    */
-  static Http3DataFrameUPtr create_data_frame(const uint8_t *data, size_t data_len);
   static Http3DataFrameUPtr create_data_frame(IOBufferReader *reader, size_t data_len);
 
 private:

--- a/proxy/http3/Http3FrameCollector.cc
+++ b/proxy/http3/Http3FrameCollector.cc
@@ -38,8 +38,10 @@ Http3FrameCollector::on_write_ready(QUICStreamId stream_id, MIOBuffer &writer, s
     size_t len           = 0;
     Http3FrameUPtr frame = g->generate_frame();
     if (frame) {
-      auto b = frame->to_io_buffer_block();
-      len    = writer.write(b.get(), INT64_MAX, 0);
+      Ptr<IOBufferBlock> parent = frame->to_io_buffer_block();
+      for (auto *b = parent.get(); b != nullptr; b = b->next.get()) {
+        len += writer.write(b, b->read_avail(), 0);
+      }
       nwritten += len;
       Debug("http3", "[TX] [%" PRIu64 "] | %s size=%zu", stream_id, Http3DebugNames::frame_type(frame->type()), len);
     }

--- a/proxy/http3/test/test_Http3Frame.cc
+++ b/proxy/http3/test/test_Http3Frame.cc
@@ -83,18 +83,21 @@ TEST_CASE("Store DATA Frame", "[http3]")
       0x11, 0x22, 0x33, 0x44, // Payload
     };
 
-    uint8_t raw1[]          = "\x11\x22\x33\x44";
-    ats_unique_buf payload1 = ats_unique_malloc(4);
-    memcpy(payload1.get(), raw1, 4);
+    uint8_t raw1[] = "\x11\x22\x33\x44";
+    IOBufferReader reader1;
+    reader1.block = make_ptr<IOBufferBlock>(new_IOBufferBlock());
+    reader1.block->alloc(BUFFER_SIZE_INDEX_1K);
+    memcpy(reader1.block->start(), raw1, 4);
+    reader1.block->fill(4);
 
-    Http3DataFrame data_frame(std::move(payload1), 4);
+    Http3DataFrame data_frame(&reader1, 4);
     CHECK(data_frame.length() == 4);
 
     auto ibb = data_frame.to_io_buffer_block();
-    IOBufferReader reader;
-    reader.block = ibb.get();
-    len          = reader.read_avail();
-    reader.read(buf, sizeof(buf));
+    IOBufferReader reader2;
+    reader2.block = ibb.get();
+    len           = reader2.read_avail();
+    reader2.read(buf, sizeof(buf));
     CHECK(len == 6);
     CHECK(memcmp(buf, expected1, len) == 0);
   }


### PR DESCRIPTION
Data copy was needed because of buffer type difference in HTTP/3 module. This PR removes the data copy (IOBufferBlock -> Regular buffer -> IOBufferBlock) by keeping the data in the original IOBufferBlock.

This change could land on master as well, but I didn't want to accidentally break HTTP/3 on master because this change is only tested with other changes on 10-Dev.