### PR TITLE
Fix hosting.config reload

### DIFF
--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -229,7 +229,7 @@ int
 CacheHostTable::config_callback(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */,
                                 RecData /* data ATS_UNUSED */, void *cookie)
 {
-  CacheHostTable **ppt = static_cast<CacheHostTable **>(cookie);
+  ReplaceablePtr<CacheHostTable> *ppt = static_cast<ReplaceablePtr<CacheHostTable> *>(cookie);
   eventProcessor.schedule_imm(new CacheHostTableConfig(ppt));
   return 0;
 }

--- a/iocore/cache/CacheVol.cc
+++ b/iocore/cache/CacheVol.cc
@@ -57,14 +57,18 @@ CacheVC::scanVol(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   if (_action.cancelled) {
     return free_CacheVC(this);
   }
-  CacheHostRecord *rec = &theCache->hosttable->gen_host_rec;
+
+  ReplaceablePtr<CacheHostTable>::ScopedReader hosttable(&theCache->hosttable);
+
+  const CacheHostRecord *rec = &hosttable->gen_host_rec;
   if (host_len) {
     CacheHostResult res;
-    theCache->hosttable->Match(hostname, host_len, &res);
+    hosttable->Match(hostname, host_len, &res);
     if (res.record) {
       rec = res.record;
     }
   }
+
   if (!vol) {
     if (!rec->num_vols) {
       goto Ldone;

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -28,6 +28,7 @@
 
 #include "HTTP.h"
 #include "P_CacheHttp.h"
+#include "P_CacheHosting.h"
 
 struct EvacuationBlock;
 
@@ -987,9 +988,10 @@ struct Cache {
   int total_nvol            = 0;
   int ready                 = CACHE_INITIALIZING;
   int64_t cache_size        = 0; // in store block size
-  CacheHostTable *hosttable = nullptr;
   int total_initialized_vol = 0;
   CacheType scheme          = CACHE_NONE_TYPE;
+
+  ReplaceablePtr<CacheHostTable> hosttable;
 
   int open(bool reconfigure, bool fix);
   int close();


### PR DESCRIPTION
This is an alternative to https://github.com/apache/trafficserver/pull/8664. That PR is fine in-itself and fixes a bug around the the atomic swap not actually reloading. But fixing that bug so that reloading hosting.config works exposes another deeper bug: the reloaded object has no synchronization around it. 

Not only is the pointer itself never read with synchronization, even if it were, the object itself is never synchronized. So even if the pointer were atomic, the object reads could get different variables from different objects, when callers that need multiple variables really need them to come from a single object. Worse, if a request takes longer than the arbitrary delete timer, it could access freed memory.

This fixes the object to be synchronized, and all access behind a mutex. The reload swap and bad drive removal acquire a write lock, and all other accesses (none of which modify the object) acquire a read lock.

I really don't like adding a mutex to the request path. But the only other options I see are an incredibly complex and bug-prone lock-free solution, or not making it possible to reload hosting.config. As much as I dislike it, the mutex should never have contention except on reload or drive failure. So it's probably actually faster and fewer atomic instructions than even a lock-free solution.

This also adds some helper classes, to make it impossible to accidentally forget to acquire or release the mutex, or modify the object with a readlock, via RAII idioms.

Recommend backporting to 9.2.

Fixes #7220