### PR TITLE
Update prepare_proxy_verifier.sh to work in non-git directories

### DIFF
--- a/tests/autest.sh
+++ b/tests/autest.sh
@@ -17,10 +17,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-./prepare_proxy_verifier.sh
+fail()
+{
+    echo $1
+    exit 1
+}
+./prepare_proxy_verifier.sh || fail "Failed to install Proxy Verifier."
 pushd $(dirname $0) > /dev/null
 export PYTHONPATH=$(pwd):$PYTHONPATH
-./test-env-check.sh
+./test-env-check.sh || fail "Failed Python environment checks."
 # this is for rhel or centos systems
 echo "Environment config finished. Running AuTest..."
 pipenv run autest -D gold_tests "$@"

--- a/tests/prepare_proxy_verifier.sh
+++ b/tests/prepare_proxy_verifier.sh
@@ -17,7 +17,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-ROOT=${ROOT:-$(cd $(dirname $0) && git rev-parse --show-toplevel)}
+fail()
+{
+    echo $1
+    exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+ROOT=${ROOT:-${SCRIPT_DIR}}
+[ -d "${ROOT}" ] || fail "ROOT: \"${ROOT}\" is not a directory."
+[ -d "${ROOT}/tests" ] || fail "\"${ROOT}/tests\" is not a directory."
+
+PV_VERSION_FILE="${ROOT}/tests/proxy-verifier-version.txt"
+[ -r "${PV_VERSION_FILE}" ] || fail "\"${PV_VERSION_FILE}\" does not exist."
+
 pv_name="proxy-verifier"
 pv_version=`cat ${ROOT}/tests/proxy-verifier-version.txt`
 pv_top_dir="${ROOT}/tests/proxy-verifier"
@@ -32,11 +45,6 @@ pv_client="${bin_dir}/verifier-client"
 pv_server="${bin_dir}/verifier-server"
 TAR=${TAR:-tar}
 CURL=${CURL:-curl}
-fail()
-{
-    echo $1
-    exit 1
-}
 # Check to see whether Proxy Verifier has already been unpacked.
 if ! [ -x ${pv_client} -a -x ${pv_server} ]
 then
@@ -52,7 +60,8 @@ then
             SHASUM=${SHASUM:-shasum}
         fi
         mkdir -p ${pv_top_dir}
-        ${CURL} -L --progress-bar -o ${pv_tar} ${pv_tar_url}
+        ${CURL} -L --progress-bar -o ${pv_tar} ${pv_tar_url} || \
+            fail "Failed to download ${pv_tar_url}."
         cat > ${pv_top_dir}/sha1 << EOF
 ${expected_sha1}  ${pv_tar}
 EOF


### PR DESCRIPTION
prepare_proxy_verifier.sh was written assuming that the user was in a
git repository. The user, however, may have a source code only copy of
the tree and thus may not be in a git repository. This makes the script
versatile to handle both of these environments.

Fixes #9045