### PR TITLE
Fast log buffering mode

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -3031,6 +3031,14 @@ Logging Configuration
 
    Refer to :ref:`admin-logging` for more information on event logging.
 
+.. ts:cv:: CONFIG proxy.config.log.log_fast_buffer INT 0
+   :reloadable:
+
+   Enables ``fast`` logging mode as the default for all log objects.  This mode
+   can log larger transaction rates, but log entries will appear out of order
+   in the log output. You can enable ``fast`` mode for individual log objects in
+   ``logging.yaml`` file by adding ``fast: true`` to that object's config.
+
 .. ts:cv:: CONFIG proxy.config.log.max_secs_per_buffer INT 5
    :reloadable:
 

--- a/doc/admin-guide/logging/understanding.en.rst
+++ b/doc/admin-guide/logging/understanding.en.rst
@@ -157,3 +157,19 @@ aforementioned aggregate functions and the specification of an interval, as so:
 The interval itself is given with *n* as the number of seconds for each period
 of aggregation. There is no default value.
 
+Logging Performance
+-------------------
+
+In normal operations, log entries are strictly ordered in the output file.
+This serialization of entries comes at a cost as multiple threads potentially
+contend for log access.  For binary logs or when order does not matter, ATS supports
+faster logging where each thread can buffer its own entries.  In this mode, log
+parsers will need to expect out of order entries, but ATS can log much larger
+transaction rates.
+
+.. code:: yaml
+
+   formats:
+   - name: mysummary
+     format: '%<operator(field)> , %<operator(field)>'
+     fast: true

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1039,6 +1039,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.log.log_buffer_size", RECD_INT, "9216", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.log.log_fast_buffer", RECD_INT, "9216", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.log.max_secs_per_buffer", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.log.max_space_mb_for_logs", RECD_INT, "25000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -150,6 +150,7 @@ public:
     return (ink_atomic_cas(&m_state.ival, old_state.ival, new_state.ival));
   }
 
+  LB_ResultCode add_entry(size_t *write_offset, size_t write_size);
   LB_ResultCode checkout_write(size_t *write_offset, size_t write_size);
   LB_ResultCode checkin_write(size_t write_offset);
   void force_full();

--- a/proxy/logging/LogConfig.cc
+++ b/proxy/logging/LogConfig.cc
@@ -71,6 +71,7 @@ LogConfig::setup_default_values()
 {
   hostname              = ats_strdup(Machine::instance()->host_name.c_str());
   log_buffer_size       = static_cast<int>(10 * LOG_KILOBYTE);
+  log_fast_buffer       = false;
   max_secs_per_buffer   = 5;
   max_space_mb_for_logs = 100;
   max_space_mb_headroom = 10;
@@ -126,6 +127,11 @@ LogConfig::read_configuration_variables()
   val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.log_buffer_size"));
   if (val > 0) {
     log_buffer_size = val;
+  }
+
+  val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.log_fast_buffer"));
+  if (val > 0) {
+    log_fast_buffer = true;
   }
 
   val = static_cast<int>(REC_ConfigReadInteger("proxy.config.log.max_secs_per_buffer"));

--- a/proxy/logging/LogConfig.h
+++ b/proxy/logging/LogConfig.h
@@ -183,6 +183,7 @@ public:
   LogFormatList format_list;
 
   int log_buffer_size;
+  bool log_fast_buffer;
   int max_secs_per_buffer;
   int max_space_mb_for_logs;
   int max_space_mb_headroom;

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <vector>
 #include <thread>
+#include <map>
 
 static bool
 should_roll_on_time(Log::RollingEnabledValues roll)
@@ -92,7 +93,7 @@ LogBufferManager::preproc_buffers(LogBufferSink *sink)
 LogObject::LogObject(LogConfig *cfg, const LogFormat *format, const char *log_dir, const char *basename, LogFileFormat file_format,
                      const char *header, Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec,
                      int rolling_offset_hr, int rolling_size_mb, bool auto_created, int rolling_max_count, int rolling_min_count,
-                     bool reopen_after_rolling, int pipe_buffer_size)
+                     bool reopen_after_rolling, int pipe_buffer_size, bool fast)
   : m_alt_filename(nullptr),
     m_flags(0),
     m_signature(0),
@@ -105,7 +106,8 @@ LogObject::LogObject(LogConfig *cfg, const LogFormat *format, const char *log_di
     m_min_rolled(rolling_min_count),
     m_reopen_after_rolling(reopen_after_rolling),
     m_buffer_manager_idx(0),
-    m_pipe_buffer_size(pipe_buffer_size)
+    m_pipe_buffer_size(pipe_buffer_size),
+    m_fast(fast)
 {
   ink_release_assert(format);
   m_format         = new LogFormat(*format);
@@ -129,10 +131,11 @@ LogObject::LogObject(LogConfig *cfg, const LogFormat *format, const char *log_di
     m_logFile->open_file();
   }
 
-  LogBuffer *b = new LogBuffer(cfg, this, cfg->log_buffer_size);
-  ink_assert(b);
-  SET_FREELIST_POINTER_VERSION(m_log_buffer, b, 0);
-
+  if (!m_fast) {
+    LogBuffer *b = new LogBuffer(cfg, this, cfg->log_buffer_size);
+    ink_assert(b);
+    SET_FREELIST_POINTER_VERSION(m_log_buffer, b, 0);
+  }
   _setup_rolling(cfg, rolling_enabled, rolling_interval_sec, rolling_offset_hr, rolling_size_mb);
 
   Debug("log-config", "exiting LogObject constructor, filename=%s this=%p", m_filename, this);
@@ -148,7 +151,9 @@ LogObject::~LogObject()
   ats_free(m_alt_filename);
   delete m_format;
   delete[] m_buffer_manager;
-  delete static_cast<LogBuffer *>(FREELIST_POINTER(m_log_buffer));
+  if (!m_fast) {
+    delete static_cast<LogBuffer *>(FREELIST_POINTER(m_log_buffer));
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -428,7 +433,6 @@ LogObject::_checkout_write(size_t *write_offset, size_t bytes_needed)
       }
 #endif
     }
-
   } while (retry && write_offset); // if write_offset is null, we do
   // not retry because we really do not want to write to the buffer,
   // only to mark the buffer as full
@@ -475,6 +479,83 @@ LogObject::log(LogAccess *lad, const char *text_entry)
 {
   // Clang doesn't like initializing a view with nullptr, have to check.
   return this->log(lad, std::string_view{text_entry ? text_entry : ""});
+}
+
+class ThreadLocalLogBufferManager : public Continuation
+{
+public:
+  ThreadLocalLogBufferManager()
+  {
+    this->thread_affinity = this_ethread();
+    SET_HANDLER(&ThreadLocalLogBufferManager::wakeup);
+
+    int period = Log::config->max_secs_per_buffer >> 1;
+    if (period < 1) {
+      period = 1;
+    }
+    eventProcessor.schedule_every(this, period * HRTIME_SECOND, ET_CALL);
+  }
+  ~ThreadLocalLogBufferManager()
+  {
+    for (auto [o, b] : current_buffers) {
+      o->flush_buffer(b);
+    }
+  }
+  int
+  wakeup(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
+  {
+    for (auto &[o, b] : current_buffers) {
+      if (b && ink_hrtime_to_sec(Thread::get_hrtime()) > b->expiration_time()) {
+        o->flush_buffer(b);
+        b = nullptr;
+      }
+    }
+
+    return EVENT_CONT;
+  }
+
+  LogBuffer *
+  current_buffer(LogObject *o, size_t *offset, size_t bytes_needed)
+  {
+    LogBuffer *buffer = current_buffers[o];
+    if (buffer == nullptr) {
+      buffer             = new LogBuffer(Log::config, o, Log::config->log_buffer_size);
+      current_buffers[o] = buffer;
+    }
+    if (buffer->add_entry(offset, bytes_needed) != LogBuffer::LB_OK) {
+      o->flush_buffer(buffer);
+
+      buffer             = new LogBuffer(Log::config, o, Log::config->log_buffer_size);
+      current_buffers[o] = buffer;
+      if (buffer->add_entry(offset, bytes_needed) != LogBuffer::LB_OK) {
+        return nullptr;
+      }
+    };
+    return buffer;
+  }
+
+private:
+  std::map<LogObject *, LogBuffer *> current_buffers;
+};
+
+/*
+ * This will return a LogBuffer object that is per-LogObject and per-Thread.  This function will handle all of
+ * the details around flushing buffers to the preproc threads and periodically checking for idle buffers.
+ */
+LogBuffer *
+thread_local_buffer(LogObject *o, size_t *offset, size_t bytes_needed)
+{
+  thread_local ThreadLocalLogBufferManager manager;
+  return manager.current_buffer(o, offset, bytes_needed);
+}
+
+void
+LogObject::flush_buffer(LogBuffer *buffer)
+{
+  int idx = m_buffer_manager_idx++ % m_flush_threads;
+  Debug("log-logbuffer", "adding buffer %d to flush list after checkout", buffer->get_id());
+  m_buffer_manager[idx].add_to_flush_queue(buffer);
+  Log::preproc_notify[idx].signal();
 }
 
 int
@@ -553,7 +634,11 @@ LogObject::log(LogAccess *lad, std::string_view text_entry)
   }
 
   // Now try to place this entry in the current LogBuffer.
-  buffer = _checkout_write(&offset, bytes_needed);
+  if (!m_fast) {
+    buffer = _checkout_write(&offset, bytes_needed);
+  } else {
+    buffer = thread_local_buffer(this, &offset, bytes_needed);
+  }
 
   if (!buffer) {
     SiteThrottledNote("Skipping the current log entry for %s because its size (%zu) exceeds "
@@ -561,6 +646,7 @@ LogObject::log(LogAccess *lad, std::string_view text_entry)
                       m_basename, bytes_needed);
     return Log::FAIL;
   }
+
   //
   // Ok, the checkout_write was successful, which means we have a valid
   // offset into the current buffer.  Marshal the entry into the buffer,
@@ -583,7 +669,9 @@ LogObject::log(LogAccess *lad, std::string_view text_entry)
     memset(dst + text_entry.size(), 0, bytes_needed - text_entry.size());
   }
 
-  buffer->checkin_write(offset);
+  if (!m_fast) {
+    buffer->checkin_write(offset);
+  }
 
   return Log::LOG_OK;
 }
@@ -752,10 +840,10 @@ const LogFormat *TextLogObject::textfmt = MakeTextLogFormat();
 TextLogObject::TextLogObject(const char *name, const char *log_dir, bool timestamps, const char *header,
                              Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec,
                              int rolling_offset_hr, int rolling_size_mb, int rolling_max_count, int rolling_min_count,
-                             bool reopen_after_rolling)
+                             bool reopen_after_rolling, bool fast)
   : LogObject(Log::config, TextLogObject::textfmt, log_dir, name, LOG_FILE_ASCII, header, rolling_enabled, flush_threads,
               rolling_interval_sec, rolling_offset_hr, rolling_size_mb, /* auto_created */ false, rolling_max_count,
-              rolling_min_count, reopen_after_rolling)
+              rolling_min_count, reopen_after_rolling, fast)
 {
   if (timestamps) {
     this->set_fmt_timestamps();

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -96,7 +96,7 @@ public:
   LogObject(LogConfig *cfg, const LogFormat *format, const char *log_dir, const char *basename, LogFileFormat file_format,
             const char *header, Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec = 0,
             int rolling_offset_hr = 0, int rolling_size_mb = 0, bool auto_created = false, int rolling_max_count = 0,
-            int rolling_min_count = 0, bool reopen_after_rolling = false, int pipe_buffer_size = 0);
+            int rolling_min_count = 0, bool reopen_after_rolling = false, int pipe_buffer_size = 0, bool m_fast = true);
   ~LogObject() override;
 
   void add_filter(LogFilter *filter, bool copy = true);
@@ -239,6 +239,8 @@ public:
     _checkout_write(nullptr, 0);
   }
 
+  void flush_buffer(LogBuffer *);
+
   bool operator==(LogObject &rhs);
 
 public:
@@ -276,6 +278,7 @@ private:
   LogBufferManager *m_buffer_manager;
 
   int m_pipe_buffer_size;
+  bool m_fast; // use fast buffering (thread local logbuffers)
 
   void generate_filenames(const char *log_dir, const char *basename, LogFileFormat file_format);
   void _setup_rolling(LogConfig *cfg, Log::RollingEnabledValues rolling_enabled, int rolling_interval_sec, int rolling_offset_hr,
@@ -302,7 +305,7 @@ class TextLogObject : public LogObject
 public:
   TextLogObject(const char *name, const char *log_dir, bool timestamps, const char *header,
                 Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec, int rolling_offset_hr,
-                int rolling_size_mb, int rolling_max_count, int rolling_min_count, bool reopen_after_rolling);
+                int rolling_size_mb, int rolling_max_count, int rolling_min_count, bool reopen_after_rolling, bool fast = false);
 
   int write(const char *format, ...) TS_PRINTFLIKE(2, 3);
   int va_write(const char *format, va_list ap);

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -102,7 +102,8 @@ test_RolledLogDeleter_SOURCES = \
 test_RolledLogDeleter_LDADD = \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	@HWLOC_LIBS@
 
 benchmark_LogObject_SOURCES = unit-tests/benchmark_LogObject.cc LogConfig.cc
 benchmark_LogObject_CPPFLAGS = \

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -70,7 +70,8 @@ liblogging_a_SOURCES = \
 
 check_PROGRAMS = \
 	test_LogUtils \
-	test_RolledLogDeleter
+	test_RolledLogDeleter \
+	benchmark_LogObject
 
 TESTS = $(check_PROGRAMS)
 
@@ -102,6 +103,24 @@ test_RolledLogDeleter_LDADD = \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a
+
+benchmark_LogObject_SOURCES = unit-tests/benchmark_LogObject.cc LogConfig.cc
+benchmark_LogObject_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I$(abs_top_srcdir)/tests/include
+benchmark_LogObject_LDADD = \
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	$(top_builddir)/mgmt/libmgmt_p.la \
+	$(top_builddir)/lib/records/librecords_p.a \
+	$(top_builddir)/lib/records/librecords_lm.a \
+	$(top_builddir)/proxy/logging/liblogging.a \
+	$(top_builddir)/proxy/http/libhttp.a \
+	$(top_builddir)/proxy/hdrs/libhdrs.a \
+	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
+	$(top_builddir)/proxy/shared/libdiagsconfig.a
+
 
 clang-tidy-local: $(liblogging_a_SOURCES) $(EXTRA_DIST)
 	$(CXX_Clang_Tidy)

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -68,7 +68,6 @@ liblogging_a_SOURCES = \
 	YamlLogConfigDecoders.cc \
 	YamlLogConfig.h
 
-noinst_PROGRAMS = benchmark_LogObject
 check_PROGRAMS = \
 	test_LogUtils \
 	test_RolledLogDeleter
@@ -103,27 +102,6 @@ test_RolledLogDeleter_LDADD = \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
-	@HWLOC_LIBS@
-
-benchmark_LogObject_SOURCES = unit-tests/benchmark_LogObject.cc LogConfig.cc
-benchmark_LogObject_CPPFLAGS = \
-	$(AM_CPPFLAGS) \
-	-I$(abs_top_srcdir)/tests/include
-benchmark_LogObject_LDADD = \
-	$(top_builddir)/src/tscore/libtscore.la \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a \
-	$(top_builddir)/mgmt/libmgmt_p.la \
-	$(top_builddir)/proxy/logging/liblogging.a \
-	$(top_builddir)/lib/records/librecords_p.a \
-	$(top_builddir)/lib/records/librecords_lm.a \
-	$(top_builddir)/proxy/logging/liblogging.a \
-	$(top_builddir)/proxy/http/libhttp.a \
-	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a \
-	$(top_builddir)/mgmt/libmgmt_p.la \
-	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
-	$(top_builddir)/proxy/shared/libdiagsconfig.a \
 	@HWLOC_LIBS@
 
 

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -120,7 +120,8 @@ benchmark_LogObject_LDADD = \
 	$(top_builddir)/proxy/http/libhttp.a \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
-	$(top_builddir)/proxy/shared/libdiagsconfig.a
+	$(top_builddir)/proxy/shared/libdiagsconfig.a \
+	@HWLOC_LIBS@
 
 
 clang-tidy-local: $(liblogging_a_SOURCES) $(EXTRA_DIST)

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -68,10 +68,10 @@ liblogging_a_SOURCES = \
 	YamlLogConfigDecoders.cc \
 	YamlLogConfig.h
 
+noinst_PROGRAMS = benchmark_LogObject
 check_PROGRAMS = \
 	test_LogUtils \
-	test_RolledLogDeleter \
-	benchmark_LogObject
+	test_RolledLogDeleter
 
 TESTS = $(check_PROGRAMS)
 
@@ -114,11 +114,14 @@ benchmark_LogObject_LDADD = \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/mgmt/libmgmt_p.la \
+	$(top_builddir)/proxy/logging/liblogging.a \
 	$(top_builddir)/lib/records/librecords_p.a \
 	$(top_builddir)/lib/records/librecords_lm.a \
 	$(top_builddir)/proxy/logging/liblogging.a \
 	$(top_builddir)/proxy/http/libhttp.a \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	$(top_builddir)/mgmt/libmgmt_p.la \
 	$(top_builddir)/proxy/shared/libUglyLogStubs.a \
 	$(top_builddir)/proxy/shared/libdiagsconfig.a \
 	@HWLOC_LIBS@

--- a/proxy/logging/YamlLogConfig.cc
+++ b/proxy/logging/YamlLogConfig.cc
@@ -121,7 +121,8 @@ std::set<std::string> valid_log_object_keys = {"filename",
                                                "rolling_min_count",
                                                "rolling_max_count",
                                                "rolling_allow_empty",
-                                               "pipe_buffer_size"};
+                                               "pipe_buffer_size",
+                                               "fast"};
 
 LogObject *
 YamlLogConfig::decodeLogObject(const YAML::Node &node)
@@ -152,6 +153,11 @@ YamlLogConfig::decodeLogObject(const YAML::Node &node)
   if (!fmt) {
     Error("Format %s is not a known format; cannot create LogObject", format.c_str());
     return nullptr;
+  }
+
+  bool fast = cfg->log_fast_buffer;
+  if (node["fast"]) {
+    fast = node["fast"].as<bool>();
   }
 
   // file format
@@ -220,7 +226,7 @@ YamlLogConfig::decodeLogObject(const YAML::Node &node)
                                  static_cast<Log::RollingEnabledValues>(obj_rolling_enabled), cfg->preproc_threads,
                                  obj_rolling_interval_sec, obj_rolling_offset_hr, obj_rolling_size_mb, /* auto_created */ false,
                                  /* rolling_max_count */ obj_rolling_max_count, /* rolling_min_count */ obj_rolling_min_count,
-                                 /* reopen_after_rolling */ obj_rolling_allow_empty > 0, pipe_buffer_size);
+                                 /* reopen_after_rolling */ obj_rolling_allow_empty > 0, pipe_buffer_size, fast);
 
   // Generate LogDeletingInfo entry for later use
   std::string ext;

--- a/proxy/logging/unit-tests/benchmark_LogObject.cc
+++ b/proxy/logging/unit-tests/benchmark_LogObject.cc
@@ -1,0 +1,144 @@
+/** @file
+
+Simple benchmark for LogObject
+
+@section license License
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "LogConfig.h"
+#include "Log.h"
+#include "DiagsConfig.h"
+#include "records/I_RecLocal.h"
+#include "tscore/I_Layout.h"
+
+#include <thread>
+#include <barrier>
+#include <chrono>
+
+AppVersionInfo appVersionInfo;
+static char bind_stdout[512] = "";
+static char bind_stderr[512] = "";
+
+TEST_CASE("LogObject", "[proxy/logging]")
+{
+  Thread *main_thread = new EThread;
+  main_thread->set_specific();
+
+  init_buffer_allocators(0);
+
+  auto diagsConfig = new DiagsConfig("Server", "diags.log", "", "", false);
+  diags()->set_std_output(StdStream::STDOUT, bind_stdout);
+  diags()->set_std_output(StdStream::STDERR, bind_stderr);
+
+  if (is_debug_tag_set("diags")) {
+    diags()->dump();
+  }
+  Layout::create("/opt/ats");
+  RecProcessInit(RECM_STAND_ALONE);
+
+  size_t stacksize;
+  REC_ReadConfigInteger(stacksize, "proxy.config.thread.default.stacksize");
+  eventProcessor.start(10, stacksize);
+
+  pmgmt = new ProcessManager(RECM_STAND_ALONE);
+
+  Log::init(Log::NO_REMOTE_MANAGEMENT);
+
+  LogFormat *fmt = MakeTextLogFormat();
+
+  fmt->display(stdout);
+
+  Log::config->format_list.add(fmt, false);
+  Log::config->display(stdout);
+
+  LogObject *slowo = new LogObject(Log::config, fmt, "/tmp", "atsbenchlogslow.txt", LOG_FILE_ASCII, "testheader", Log::NO_ROLLING,
+                                   1, 100, 100, 10, false, 0, 0, false, 0);
+  LogObject *fasto = new LogObject(Log::config, fmt, "/tmp", "atsbenchlogfast.txt", LOG_FILE_ASCII, "testheader", Log::NO_ROLLING,
+                                   1, 100, 100, 10, false, 0, 0, false, 0, true);
+
+  Log::config->log_object_manager.manage_object(slowo);
+  Log::config->log_object_manager.manage_object(fasto);
+
+  BENCHMARK("logobject fast")
+  {
+    int thread_cnt = 40;
+    std::barrier barrier(thread_cnt);
+    auto test_object = [&](LogObject *o) {
+      Thread *me = new EThread;
+      me->set_specific();
+      barrier.arrive_and_wait();
+
+      std::string_view logline = "012345678901234567890123456789012345678901234567890";
+      int total                = 0;
+      while (total < Log::config->log_buffer_size * 100) {
+        o->log(nullptr, logline);
+        total += logline.size();
+      }
+    };
+
+    REQUIRE(fasto->writes_to_disk());
+    REQUIRE(!fasto->writes_to_pipe());
+
+    std::vector<std::thread> threads;
+    threads.reserve(thread_cnt);
+
+    for (int i = 0; i < thread_cnt; ++i) {
+      threads.emplace_back(test_object, fasto);
+    }
+    for (int i = 0; i < thread_cnt; ++i) {
+      threads[i].join();
+    }
+  };
+
+  BENCHMARK("logobject slow")
+  {
+    int thread_cnt = 40;
+    std::barrier barrier(thread_cnt);
+
+    auto test_object = [&](LogObject *o) {
+      Thread *me = new EThread;
+      me->set_specific();
+      barrier.arrive_and_wait();
+
+      std::string_view logline = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw";
+      int total                = 0;
+      while (total < Log::config->log_buffer_size * 100) {
+        o->log(nullptr, logline);
+        total += logline.size();
+      }
+    };
+
+    REQUIRE(slowo->writes_to_disk());
+    REQUIRE(!slowo->writes_to_pipe());
+
+    std::vector<std::thread> threads;
+    threads.reserve(thread_cnt);
+
+    for (int i = 0; i < thread_cnt; ++i) {
+      threads.emplace_back(test_object, slowo);
+    }
+    for (int i = 0; i < thread_cnt; ++i) {
+      threads[i].join();
+    }
+  };
+}

--- a/proxy/logging/unit-tests/benchmark_LogObject.cc
+++ b/proxy/logging/unit-tests/benchmark_LogObject.cc
@@ -70,6 +70,8 @@ TEST_CASE("LogObject", "[proxy/logging]")
   main_thread->set_specific();
 
   auto diagsConfig = new DiagsConfig("Server", "diags.log", "", "", false);
+  // unused, but constructor must be called for side effects.
+  (void)diagsConfig;
   diags()->set_std_output(StdStream::STDOUT, bind_stdout);
   diags()->set_std_output(StdStream::STDERR, bind_stderr);
 

--- a/proxy/logging/unit-tests/benchmark_LogObject.cc
+++ b/proxy/logging/unit-tests/benchmark_LogObject.cc
@@ -85,7 +85,7 @@ TEST_CASE("LogObject", "[proxy/logging]")
   REC_ReadConfigInteger(stacksize, "proxy.config.thread.default.stacksize");
   eventProcessor.start(10, stacksize);
 
-  pmgmt = new ProcessManager(RECM_STAND_ALONE);
+  pmgmt = new ProcessManager(false);
 
   Log::init(Log::NO_REMOTE_MANAGEMENT);
 


### PR DESCRIPTION
This adds a configurable `fast` mode to log objects that use per-thread log buffers rather than having all threads contend for per-object buffers.  While this is much faster, it does not support ordered log entries.  This makes it situationally useful, but if a user has binary logs or doesn't need ordered log output, this could allow them to log many more transactions.  Its configurable either globally via records.config or per-log via logging.yaml.
