### PR TITLE
Fix the connection limit crash while using parents (#7602)

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5214,11 +5214,10 @@ HttpSM::do_http_server_open(bool raw)
       } else { // queue size is 0, always block.
         ct_state.blocked();
         HTTP_INCREMENT_DYN_STAT(http_origin_connections_throttled_stat);
+        ct_state.Warn_Blocked(&t_state.txn_conf->outbound_conntrack, sm_id, ccount - 1, &t_state.current.server->dst_addr.sa,
+                              debug_on && is_debug_tag_set("http") ? "http" : nullptr);
         send_origin_throttled_response();
       }
-
-      ct_state.Warn_Blocked(&t_state.txn_conf->outbound_conntrack, sm_id, ccount - 1, &t_state.current.server->dst_addr.sa,
-                            debug_on && is_debug_tag_set("http") ? "http" : nullptr);
 
       return;
     } else {


### PR DESCRIPTION
(cherry picked from commit e8db7c495127915c0fd3d7eb4d9daa6f1b2fa67d)

The original fix for this on master was in #7604 however I think a lot of that code got reverted on master during prep for 9.2. In the mean time a fix went into 9.0/9.1 in #7602 . That fix was then never brought into master with the reverted code or on 9.2. So we need this both in master and picked back to 9.2