### PR TITLE
fix: ensure DNS resolution for parent proxy

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7572,7 +7572,7 @@ HttpSM::set_next_state()
       t_state.dns_info.resolved_p = true; // seems dangerous - where's the IP address?
       call_transact_and_set_next_state(nullptr);
       break;
-    } else if (t_state.dns_info.resolve_immediate()) {
+    } else if (t_state.parent_result.result == PARENT_UNDEFINED && t_state.dns_info.resolve_immediate()) {
       call_transact_and_set_next_state(nullptr);
       break;
     }


### PR DESCRIPTION
HostDB restructure introduced a regression where DNS resolution for
parent proxies would be skipped and the origin's address would be used
instead.

It seems related to this diff: https://github.com/apache/trafficserver/commit/156528de4ce4d6bef2f2d2bc0963dadd9f122eec#diff-85a75d910dc93751ef5d568fc20fc73b01bfadac58844e88c7b8e68cedda0f0bL7636

Fixes: #8953