### PR TITLE
Add HEAD requests to slice plugin

### DIFF
--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -45,6 +45,7 @@ struct Config {
   int m_prefetchcount{0}; // 0 disables prefetching
   enum RefType { First, Relative };
   RefType m_reftype{First}; // reference slice is relative to request
+  bool m_head_req{false};   // HEAD request
 
   std::string m_skip_header;
   std::string m_crr_ims_header;


### PR DESCRIPTION
- added feature: allow HEAD requests to go through slice
- when handling first server header (reference block), slice will expect only header bytes to be sent and 0 block body bytes
- HEAD request functionality remain the same