### PR TITLE
Support autest sharding of 4 for required autest checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,7 +39,10 @@ github:
         # strict means "Require branches to be up to date before merging"
         strict: false
         contexts:
-          - AuTest
+          - AuTest 0of4
+          - AuTest 1of4
+          - AuTest 2of4
+          - AuTest 3of4
           - Rocky
           - Clang-Analyzer
           - Clang-Format


### PR DESCRIPTION
This is to support the changeover from a single autest to 4 shards with names

- AuTest 0of4
- AuTetst 1of4
- etc

instead of just AuTest for the required github CI checks for allowing a PR to merge.