### PR TITLE
Resolve a waring about uninitialized variable in header version converter

### DIFF
--- a/proxy/hdrs/VersionConverter.cc
+++ b/proxy/hdrs/VersionConverter.cc
@@ -28,7 +28,7 @@
 int
 VersionConverter::convert(HTTPHdr &header, int from, int to) const
 {
-  int type;
+  int type = 0;
 
   switch (http_hdr_type_get(header.m_http)) {
   case HTTP_TYPE_REQUEST:


### PR DESCRIPTION
```
VersionConverter.cc: In member function ‘int VersionConverter::convert(HTTPHdr&, int, int) const’:
VersionConverter.cc:48:64: error: ‘type’ may be used uninitialized [-Werror=maybe-uninitialized]
   48 |   int ret = (this->*_convert_functions[type][from - 1][to - 1])(header);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
VersionConverter.cc:31:7: note: ‘type’ was declared here
   31 |   int type;
      |       ^~~~
```