### PR TITLE
Disable the QUIC TestRun in active_timeout AuTest

### DIFF
--- a/tests/gold_tests/timeout/active_timeout.test.py
+++ b/tests/gold_tests/timeout/active_timeout.test.py
@@ -64,7 +64,10 @@ tr3 = Test.AddTestRun("tr")
 tr3.Processes.Default.Command = 'curl -k -i --http2 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port)
 tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")
 
-if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
-    tr4 = Test.AddTestRun("tr")
-    tr4.Processes.Default.Command = 'curl -k -i --http3 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port)
-    tr4.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")
+# Commenting out the HTTP/3 test since 9.x and before does not support the
+# latest version of HTTP/3 which is used by curl. ATS 10.x does support this
+# later version, so this test is run for that release and later.
+# if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
+#     tr4 = Test.AddTestRun("tr")
+#     tr4.Processes.Default.Command = 'curl -k -i --http3 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port)
+#     tr4.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")


### PR DESCRIPTION
We have added QUIC version 0x1 support to our 10-Dev branch via #8956,
but that has not been backported to 9.x and we don't plan to backport
that at this time. ASF CI will be updated with the latest version of
curl which uses 0x1 and would therefore fail. This change disables the
QUIC TestRun of active_timeout so it doesn't run on 9.x since ATS
doesn't support the latest QUIC test tools on that branch. This patch,
therefore, should not go into 10-Dev.

Note that this patch can be reverted in the future if we decide to
backport QUIC 0x1 support to 9.x.