### PR TITLE
Updates to origin side ALPN configuration implementation

### DIFF
--- a/include/records/I_RecHttp.h
+++ b/include/records/I_RecHttp.h
@@ -542,5 +542,9 @@ extern void ts_session_protocol_well_known_name_indices_init();
  * @return True if the conversion was successful, false otherwise. Note that
  * the wire format does not support an empty protocol list, therefore this
  * function returns false if @a protocols is an empty string.
+ *
+ * TODO: ideally this would take a ts::TextView for @a protocols, but currently
+ * ts::TextView does not have a char* constructor while std::string_view does.
+ * Once that is added, this can be seemlessly switched to a ts::TextView.
  */
 bool convert_alpn_to_wire_format(std::string_view protocols, unsigned char *wire_format_buffer, int &wire_format_buffer_len);

--- a/src/records/unit_tests/test_RecHttp.cc
+++ b/src/records/unit_tests/test_RecHttp.cc
@@ -197,8 +197,15 @@ std::vector<ConvertAlpnToWireFormatTestCase> convertAlpnToWireFormatTestCases = 
     true
   },
   {
-    "Multiple protocols: HTTP/0.9, HTTP/1.0, HTTP/1.1",
+    "Multiple protocols: HTTP/1.0, HTTP/1.1",
     "http/1.1,http/1.0",
+    {0x08, 'h', 't', 't', 'p', '/', '1', '.', '1', 0x08, 'h', 't', 't', 'p', '/', '1', '.', '0'},
+    18,
+    true
+  },
+  {
+    "Whitespace: verify that we gracefully handle padded whitespace",
+    "http/1.1, http/1.0",
     {0x08, 'h', 't', 't', 'p', '/', '1', '.', '1', 0x08, 'h', 't', 't', 'p', '/', '1', '.', '0'},
     18,
     true

--- a/tests/gold_tests/tls/tls_client_alpn_configuration.test.py
+++ b/tests/gold_tests/tls/tls_client_alpn_configuration.test.py
@@ -134,12 +134,12 @@ class TestAlpnFunctionality:
         )
 
         if alpn_is_malformed:
-            ts.Disk.diags_log.Content += Testers.ContainsExpression(
-                "WARNING.*ALPN",
+            ts.Disk.diags_log.Content = Testers.ContainsExpression(
+                "ERROR.*ALPN",
                 "There should be no ALPN parse warnings.")
         else:
             ts.Disk.diags_log.Content += Testers.ExcludesExpression(
-                "WARNING.*ALPN",
+                "ERROR.*ALPN",
                 "There should be no ALPN parse warnings.")
 
         return ts


### PR DESCRIPTION
ATS will now emit an ERROR instead of a WARNING if there are issues with
the user configured ALPN string. Also, the ALPN parsing is updated to
use the more capable TextView API.