### PR TITLE
10-Dev: active_timeout.test.py: do not enable QUIC yet

### DIFF
--- a/tests/gold_tests/timeout/active_timeout.test.py
+++ b/tests/gold_tests/timeout/active_timeout.test.py
@@ -22,7 +22,9 @@ Test.SkipUnless(
     Condition.HasCurlFeature('http2')
 )
 
-if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
+# TODO: Add this back in (i.e., remove the False boolean) when ATS 10.x builds
+# correctly with openssl-quic.
+if False and Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
     ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_quic=True)
 else:
     ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)


### PR DESCRIPTION
We are currently working on fixing 10.x when built with openssl-quic.
Until that is completed, the active_timeout test fails when enabling
QUIC. Temporarily avoid enabling it until that is resolved.