### PR TITLE
Make HTTP/2 session and stream windows configurable

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4155,10 +4155,10 @@ HTTP/2 Configuration
    The initial HTTP/2 stream window size for inbound connections that |TS| as a
    receiver advertises to the peer. See IETF RFC 9113 section 5.2 for details
    concerning HTTP/2 flow control. See
-   :ts:cv:`proxy.config.http2.flow_control.policy.in` for how HTTP/2 stream and
+   :ts:cv:`proxy.config.http2.flow_control.policy_in` for how HTTP/2 stream and
    session windows are maintained over the lifetime of HTTP/2 sessions.
 
-.. ts:cv:: CONFIG proxy.config.http2.flow_control.policy.in INT 0
+.. ts:cv:: CONFIG proxy.config.http2.flow_control.policy_in INT 0
    :reloadable:
 
    Specifies the mechanism |TS| uses to maintian flow control via the HTTP/2

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4156,7 +4156,7 @@ HTTP/2 Configuration
    receiver advertises to the peer. See IETF RFC 9113 section 5.2 for details
    concerning HTTP/2 flow control. See
    :ts:cv:`proxy.config.http2.flow_control.in.policy` for how HTTP/2 stream and
-   session windows are maintained over the lifetime of HTTP/2 connections.
+   session windows are maintained over the lifetime of HTTP/2 sessions.
 
 .. ts:cv:: CONFIG proxy.config.http2.flow_control.in.policy INT 0
    :reloadable:
@@ -4170,20 +4170,20 @@ HTTP/2 Configuration
    ===== ===========================================================================================
    ``0`` Session and stream receive windows are initialized and maintained at the value as specified
          in :ts:cv:`proxy.config.http2.initial_window_size_in` over the lifetime of HTTP/2
-         connections.
+         sessions.
    ``1`` Session receive windows are initialized to the value of the product of
          :ts:cv:`proxy.config.http2.initial_window_size_in` and
          :ts:cv:`proxy.config.http2.max_concurrent_streams_in` and are maintained as such over the
-         lifetime of HTTP/2 connections. Stream windows are initialized to the value of
+         lifetime of HTTP/2 sessions. Stream windows are initialized to the value of
          :ts:cv:`proxy.config.http2.initial_window_size_in` and are maintained as such over the
          lifetime of each HTTP/2 stream.
    ``2`` Session receive windows are initialized to the value of the product of
          :ts:cv:`proxy.config.http2.initial_window_size_in` and
          :ts:cv:`proxy.config.http2.max_concurrent_streams_in` and are maintained as such over the
-         lifetime of HTTP/2 connections. Stream windows are initialized to the value of
+         lifetime of HTTP/2 sessions. Stream windows are initialized to the value of
          :ts:cv:`proxy.config.http2.initial_window_size_in` but are dynamically adjusted to the
          session window size divided by the number of concurrent streams over the lifetime of HTTP/2
-         connections. That is, stream window sizes dynamically adjust to fill the session window in
+         sessions. That is, stream window sizes dynamically adjust to fill the session window in
          a way that shares the window equally among all concurrent streams.
    ===== ===========================================================================================
 

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4155,10 +4155,10 @@ HTTP/2 Configuration
    The initial HTTP/2 stream window size for inbound connections that |TS| as a
    receiver advertises to the peer. See IETF RFC 9113 section 5.2 for details
    concerning HTTP/2 flow control. See
-   :ts:cv:`proxy.config.http2.flow_control.in.policy` for how HTTP/2 stream and
+   :ts:cv:`proxy.config.http2.flow_control.policy.in` for how HTTP/2 stream and
    session windows are maintained over the lifetime of HTTP/2 sessions.
 
-.. ts:cv:: CONFIG proxy.config.http2.flow_control.in.policy INT 0
+.. ts:cv:: CONFIG proxy.config.http2.flow_control.policy.in INT 0
    :reloadable:
 
    Specifies the mechanism |TS| uses to maintian flow control via the HTTP/2

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4152,7 +4152,40 @@ HTTP/2 Configuration
    :reloadable:
    :units: bytes
 
-   The initial window size for inbound connections.
+   The initial HTTP/2 stream window size for inbound connections that |TS| as a
+   receiver advertises to the peer. See IETF RFC 9113 section 5.2 for details
+   concerning HTTP/2 flow control. See
+   :ts:cv:`proxy.config.http2.flow_control.in.policy` for how HTTP/2 stream and
+   session windows are maintained over the lifetime of HTTP/2 connections.
+
+.. ts:cv:: CONFIG proxy.config.http2.flow_control.in.policy INT 0
+   :reloadable:
+
+   Specifies the mechanism |TS| uses to maintian flow control via the HTTP/2
+   stream and session windows for inbound connections. See IETF RFC 9113
+   section 5.2 for details concerning HTTP/2 flow control.
+
+   ===== ===========================================================================================
+   Value Description
+   ===== ===========================================================================================
+   ``0`` Session and stream receive windows are initialized and maintained at the value as specified
+         in :ts:cv:`proxy.config.http2.initial_window_size_in` over the lifetime of HTTP/2
+         connections.
+   ``1`` Session receive windows are initialized to the value of the product of
+         :ts:cv:`proxy.config.http2.initial_window_size_in` and
+         :ts:cv:`proxy.config.http2.max_concurrent_streams_in` and are maintained as such over the
+         lifetime of HTTP/2 connections. Stream windows are initialized to the value of
+         :ts:cv:`proxy.config.http2.initial_window_size_in` and are maintained as such over the
+         lifetime of each HTTP/2 stream.
+   ``2`` Session receive windows are initialized to the value of the product of
+         :ts:cv:`proxy.config.http2.initial_window_size_in` and
+         :ts:cv:`proxy.config.http2.max_concurrent_streams_in` and are maintained as such over the
+         lifetime of HTTP/2 connections. Stream windows are initialized to the value of
+         :ts:cv:`proxy.config.http2.initial_window_size_in` but are dynamically adjusted to the
+         session window size divided by the number of concurrent streams over the lifetime of HTTP/2
+         connections. That is, stream window sizes dynamically adjust to fill the session window in
+         a way that shares the window equally among all concurrent streams.
+   ===== ===========================================================================================
 
 .. ts:cv:: CONFIG proxy.config.http2.max_frame_size INT 16384
    :reloadable:

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1301,6 +1301,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http2.initial_window_size_in", RECD_INT, "65535", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http2.flow_control.in.policy", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "[0-2]", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.http2.max_frame_size", RECD_INT, "16384", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http2.header_table_size", RECD_INT, "4096", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1301,7 +1301,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http2.initial_window_size_in", RECD_INT, "65535", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http2.flow_control.in.policy", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "[0-2]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http2.flow_control.policy.in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http2.max_frame_size", RECD_INT, "16384", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -1301,7 +1301,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http2.initial_window_size_in", RECD_INT, "65535", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http2.flow_control.policy.in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "[0-2]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http2.flow_control.policy_in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http2.max_frame_size", RECD_INT, "16384", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -608,9 +608,9 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(initial_window_size_in, "proxy.config.http2.initial_window_size_in");
 
   uint32_t flow_control_policy_in_int = 0;
-  REC_EstablishStaticConfigInt32U(flow_control_policy_in_int, "proxy.config.http2.flow_control.in.policy");
+  REC_EstablishStaticConfigInt32U(flow_control_policy_in_int, "proxy.config.http2.flow_control.policy.in");
   if (flow_control_policy_in_int > 2) {
-    Error("Invalid value for proxy.config.http2.flow_control.in.policy: %d", flow_control_policy_in_int);
+    Error("Invalid value for proxy.config.http2.flow_control.policy.in: %d", flow_control_policy_in_int);
     flow_control_policy_in_int = 0;
   }
   flow_control_policy_in = static_cast<Http2FlowControlPolicy>(flow_control_policy_in_int);

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -608,9 +608,9 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(initial_window_size_in, "proxy.config.http2.initial_window_size_in");
 
   uint32_t flow_control_policy_in_int = 0;
-  REC_EstablishStaticConfigInt32U(flow_control_policy_in_int, "proxy.config.http2.flow_control.policy.in");
+  REC_EstablishStaticConfigInt32U(flow_control_policy_in_int, "proxy.config.http2.flow_control.policy_in");
   if (flow_control_policy_in_int > 2) {
-    Error("Invalid value for proxy.config.http2.flow_control.policy.in: %d", flow_control_policy_in_int);
+    Error("Invalid value for proxy.config.http2.flow_control.policy_in: %d", flow_control_policy_in_int);
     flow_control_policy_in_int = 0;
   }
   flow_control_policy_in = static_cast<Http2FlowControlPolicy>(flow_control_policy_in_int);

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -567,35 +567,36 @@ http2_decode_header_blocks(HTTPHdr *hdr, const uint8_t *buf_start, const uint32_
 }
 
 // Initialize this subsystem with librecords configs (for now)
-uint32_t Http2::max_concurrent_streams_in       = 100;
-uint32_t Http2::min_concurrent_streams_in       = 10;
-uint32_t Http2::max_active_streams_in           = 0;
-bool Http2::throttling                          = false;
-uint32_t Http2::stream_priority_enabled         = 0;
-uint32_t Http2::initial_window_size             = 65535;
-uint32_t Http2::max_frame_size                  = 16384;
-uint32_t Http2::header_table_size               = 4096;
-uint32_t Http2::max_header_list_size            = 4294967295;
-uint32_t Http2::accept_no_activity_timeout      = 120;
-uint32_t Http2::no_activity_timeout_in          = 120;
-uint32_t Http2::active_timeout_in               = 0;
-uint32_t Http2::push_diary_size                 = 256;
-uint32_t Http2::zombie_timeout_in               = 0;
-float Http2::stream_error_rate_threshold        = 0.1;
-uint32_t Http2::stream_error_sampling_threshold = 10;
-uint32_t Http2::max_settings_per_frame          = 7;
-uint32_t Http2::max_settings_per_minute         = 14;
-uint32_t Http2::max_settings_frames_per_minute  = 14;
-uint32_t Http2::max_ping_frames_per_minute      = 60;
-uint32_t Http2::max_priority_frames_per_minute  = 120;
-float Http2::min_avg_window_update              = 2560.0;
-uint32_t Http2::con_slow_log_threshold          = 0;
-uint32_t Http2::stream_slow_log_threshold       = 0;
-uint32_t Http2::header_table_size_limit         = 65536;
-uint32_t Http2::write_buffer_block_size         = 262144;
-float Http2::write_size_threshold               = 0.5;
-uint32_t Http2::write_time_threshold            = 100;
-uint32_t Http2::buffer_water_mark               = 0;
+uint32_t Http2::max_concurrent_streams_in            = 100;
+uint32_t Http2::min_concurrent_streams_in            = 10;
+uint32_t Http2::max_active_streams_in                = 0;
+bool Http2::throttling                               = false;
+uint32_t Http2::stream_priority_enabled              = 0;
+uint32_t Http2::initial_window_size_in               = 65535;
+Http2FlowControlPolicy Http2::flow_control_policy_in = Http2FlowControlPolicy::STATIC_SESSION_AND_STATIC_STREAM;
+uint32_t Http2::max_frame_size                       = 16384;
+uint32_t Http2::header_table_size                    = 4096;
+uint32_t Http2::max_header_list_size                 = 4294967295;
+uint32_t Http2::accept_no_activity_timeout           = 120;
+uint32_t Http2::no_activity_timeout_in               = 120;
+uint32_t Http2::active_timeout_in                    = 0;
+uint32_t Http2::push_diary_size                      = 256;
+uint32_t Http2::zombie_timeout_in                    = 0;
+float Http2::stream_error_rate_threshold             = 0.1;
+uint32_t Http2::stream_error_sampling_threshold      = 10;
+uint32_t Http2::max_settings_per_frame               = 7;
+uint32_t Http2::max_settings_per_minute              = 14;
+uint32_t Http2::max_settings_frames_per_minute       = 14;
+uint32_t Http2::max_ping_frames_per_minute           = 60;
+uint32_t Http2::max_priority_frames_per_minute       = 120;
+float Http2::min_avg_window_update                   = 2560.0;
+uint32_t Http2::con_slow_log_threshold               = 0;
+uint32_t Http2::stream_slow_log_threshold            = 0;
+uint32_t Http2::header_table_size_limit              = 65536;
+uint32_t Http2::write_buffer_block_size              = 262144;
+float Http2::write_size_threshold                    = 0.5;
+uint32_t Http2::write_time_threshold                 = 100;
+uint32_t Http2::buffer_water_mark                    = 0;
 
 void
 Http2::init()
@@ -604,7 +605,16 @@ Http2::init()
   REC_EstablishStaticConfigInt32U(min_concurrent_streams_in, "proxy.config.http2.min_concurrent_streams_in");
   REC_EstablishStaticConfigInt32U(max_active_streams_in, "proxy.config.http2.max_active_streams_in");
   REC_EstablishStaticConfigInt32U(stream_priority_enabled, "proxy.config.http2.stream_priority_enabled");
-  REC_EstablishStaticConfigInt32U(initial_window_size, "proxy.config.http2.initial_window_size_in");
+  REC_EstablishStaticConfigInt32U(initial_window_size_in, "proxy.config.http2.initial_window_size_in");
+
+  uint32_t flow_control_policy_in_int = 0;
+  REC_EstablishStaticConfigInt32U(flow_control_policy_in_int, "proxy.config.http2.flow_control.in.policy");
+  if (flow_control_policy_in_int > 2) {
+    Error("Invalid value for proxy.config.http2.flow_control.in.policy: %d", flow_control_policy_in_int);
+    flow_control_policy_in_int = 0;
+  }
+  flow_control_policy_in = static_cast<Http2FlowControlPolicy>(flow_control_policy_in_int);
+
   REC_EstablishStaticConfigInt32U(max_frame_size, "proxy.config.http2.max_frame_size");
   REC_EstablishStaticConfigInt32U(header_table_size, "proxy.config.http2.header_table_size");
   REC_EstablishStaticConfigInt32U(max_header_list_size, "proxy.config.http2.max_header_list_size");
@@ -632,7 +642,7 @@ Http2::init()
   // If any settings is broken, ATS should not start
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, max_concurrent_streams_in}));
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, min_concurrent_streams_in}));
-  ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_INITIAL_WINDOW_SIZE, initial_window_size}));
+  ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_INITIAL_WINDOW_SIZE, initial_window_size_in}));
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_FRAME_SIZE, max_frame_size}));
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_HEADER_TABLE_SIZE, header_table_size}));
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, max_header_list_size}));

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -362,7 +362,7 @@ ParseResult http2_convert_header_from_1_1_to_2(HTTPHdr *);
 void http2_init();
 
 /** Each of these values correspond to the flow control policy described in or
- * records.config documentation for proxy.config.http2.flow_control.policy.in.
+ * records.config documentation for proxy.config.http2.flow_control.policy_in.
  */
 enum class Http2FlowControlPolicy {
   STATIC_SESSION_AND_STATIC_STREAM,

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -31,14 +31,15 @@
 
 class HTTPHdr;
 
-typedef unsigned Http2StreamId;
+// [RFC 9113] 5.1.1 Stream identifiers.
+using Http2StreamId = uint32_t;
 
-constexpr Http2StreamId HTTP2_CONNECTION_CONTROL_STRTEAM = 0;
-constexpr uint8_t HTTP2_FRAME_NO_FLAG                    = 0;
+constexpr Http2StreamId HTTP2_CONNECTION_CONTROL_STREAM = 0;
+constexpr uint8_t HTTP2_FRAME_NO_FLAG                   = 0;
 
 // [RFC 7540] 6.9.2. Initial Flow Control Window Size
 // the flow control window can be come negative so we need to track it with a signed type.
-typedef int32_t Http2WindowSize;
+using Http2WindowSize = int32_t;
 
 extern const char *const HTTP2_CONNECTION_PREFACE;
 const size_t HTTP2_CONNECTION_PREFACE_LEN = 24;
@@ -360,6 +361,15 @@ ParseResult http2_convert_header_from_2_to_1_1(HTTPHdr *);
 ParseResult http2_convert_header_from_1_1_to_2(HTTPHdr *);
 void http2_init();
 
+/** Each of these values correspond to the flow control policy described in or
+ * records.config documentation for proxy.config.http2.flow_control.in.policy.
+ */
+enum class Http2FlowControlPolicy {
+  STATIC_SESSION_AND_STATIC_STREAM,
+  LARGE_SESSION_AND_STATIC_STREAM,
+  LARGE_SESSION_AND_DYNAMIC_STREAM,
+};
+
 // Not sure where else to put this, but figure this is as good of a start as
 // anything else.
 // Right now, only the static init() is available, which sets up some basic
@@ -373,7 +383,8 @@ public:
   static uint32_t max_active_streams_in;
   static bool throttling;
   static uint32_t stream_priority_enabled;
-  static uint32_t initial_window_size;
+  static uint32_t initial_window_size_in;
+  static Http2FlowControlPolicy flow_control_policy_in;
   static uint32_t max_frame_size;
   static uint32_t header_table_size;
   static uint32_t max_header_list_size;

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -362,7 +362,7 @@ ParseResult http2_convert_header_from_1_1_to_2(HTTPHdr *);
 void http2_init();
 
 /** Each of these values correspond to the flow control policy described in or
- * records.config documentation for proxy.config.http2.flow_control.in.policy.
+ * records.config documentation for proxy.config.http2.flow_control.policy.in.
  */
 enum class Http2FlowControlPolicy {
   STATIC_SESSION_AND_STATIC_STREAM,

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <atomic>
+#include <queue>
 
 #include "NetTimeout.h"
 
@@ -90,6 +91,22 @@ public:
    * SETTINGS frames. */
   Http2ConnectionSettings local_settings;
 
+  /** The latest set of settings that have been acknowledged by the peer.
+   *
+   * The default constructed value of this via the Http2ConnectionSettings
+   * constructor (i.e., the value before any SETTINGS ACK frames have been
+   * received) will instantiate these settings to the default HTTP/2 settings
+   * values.
+   *
+   * @note that @a local_settings are our latest configured settings which have
+   * been sent to the peer but may not be acknowledged yet. @a
+   * last_acknowledged_settings are the latest settings of which the peer has
+   * acknowledged receipt. For this reason, window enforcement behavior and
+   * WINDOW_UPDATE calculations should be based upon @a
+   * last_acknowledged_settings.
+   */
+  Http2ConnectionSettings acknowledged_local_settings;
+
   /** The HTTP/2 settings configured by the peer and dictated to ATS via
    * SETTINGS frames. */
   Http2ConnectionSettings peer_settings;
@@ -150,6 +167,7 @@ public:
    * @param[in] new_settings The settings to send to the peer.
    */
   void send_settings_frame(const Http2ConnectionSettings &new_settings);
+
   void send_ping_frame(Http2StreamId id, uint8_t flag, const uint8_t *opaque_data);
   void send_goaway_frame(Http2StreamId id, Http2ErrorCode ec);
   void send_window_update_frame(Http2StreamId id, uint32_t size);
@@ -207,6 +225,13 @@ private:
   };
 
   unsigned _adjust_concurrent_stream();
+
+  /** Receive and process a SETTINGS frame with the ACK flag set.
+   *
+   * This function will process any settings updates that have now been
+   * acknowleged by the peer.
+   */
+  void _process_incoming_settings_ack_frame();
 
   /** Calculate the initial session window size that we communicate to peers.
    *
@@ -285,6 +310,54 @@ private:
   Http2FrequencyCounter _received_settings_frame_counter;
   Http2FrequencyCounter _received_ping_frame_counter;
   Http2FrequencyCounter _received_priority_frame_counter;
+
+  /** Records the various settings for each SETTINGS frame that we've sent.
+   *
+   * There are certain SETTINGS values that we send but cannot act upon until the
+   * peer acknowledges them. For instance, we cannot enforce reduced stream
+   * window sizes until the peer acknowledges the SETTINGS frame that shrinks the
+   * size.
+   *
+   * There is an OutstandingSettingsFrame instance for each SETTINGS frame that
+   * we send. We store these in a queue and associate each SETTINGS frame with
+   * an ACK flag from the peer with a corresponding OutstandingSettingsFrame
+   * instance.
+   *
+   * For details about SETTINGS synchronization via the ACK flag, see:
+   *
+   *   [RFC 9113] 6.5.3 Settings Synchronization
+   */
+  class OutstandingSettingsFrame
+  {
+  public:
+    OutstandingSettingsFrame(const Http2ConnectionSettings &settings) : _settings(settings) {}
+
+    /** Returns the settings parameters that were configured via the SETTINGS frame
+     * associated with this instance.
+     *
+     * @return The settigns parameters that were configured at the time the
+     * associated SETTINGS frame was sent. @note that this is not just the
+     * values in the SETTINGS frame, but those values along with all the local
+     * settings that were in place but not explicitly configured via the frame.
+     * Thus this returns the snapshot of the entire set of settings configured
+     * when the SETTINGS frame was sent.
+     */
+    Http2ConnectionSettings const &
+    get_outstanding_settings() const
+    {
+      return _settings;
+    }
+
+  private:
+    /** The SETTINGS parameters that were set at the time of the associated
+     * SETTINGS frame being sent.
+     */
+    Http2ConnectionSettings const _settings;
+  };
+
+  /** The queue of SETTINGS frames that we have sent but have not yet been
+   * acknowledged by the peer. */
+  std::queue<OutstandingSettingsFrame> _outstanding_settings_frames;
 
   // NOTE: Id of stream which MUST receive CONTINUATION frame.
   //   - [RFC 7540] 6.2 HEADERS

--- a/proxy/http2/Http2Frame.h
+++ b/proxy/http2/Http2Frame.h
@@ -210,7 +210,7 @@ class Http2GoawayFrame : public Http2TxFrame
 {
 public:
   Http2GoawayFrame(Http2Goaway p)
-    : Http2TxFrame({HTTP2_GOAWAY_LEN, HTTP2_FRAME_TYPE_GOAWAY, HTTP2_FRAME_NO_FLAG, HTTP2_CONNECTION_CONTROL_STRTEAM}), _params(p)
+    : Http2TxFrame({HTTP2_GOAWAY_LEN, HTTP2_FRAME_TYPE_GOAWAY, HTTP2_FRAME_NO_FLAG, HTTP2_CONNECTION_CONTROL_STREAM}), _params(p)
   {
   }
 

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -40,18 +40,15 @@
 
 ClassAllocator<Http2Stream, true> http2StreamAllocator("http2StreamAllocator");
 
-Http2Stream::Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_rwnd)
-  : super(session), _id(sid), _client_rwnd(initial_rwnd)
+Http2Stream::Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_client_rwnd, ssize_t initial_server_rwnd)
+  : super(session), _id(sid), _client_rwnd(initial_client_rwnd), _server_rwnd(initial_server_rwnd)
 {
   SET_HANDLER(&Http2Stream::main_event_handler);
 
   this->mark_milestone(Http2StreamMilestone::OPEN);
 
   this->_sm                       = nullptr;
-  this->_id                       = sid;
   this->_thread                   = this_ethread();
-  this->_client_rwnd              = initial_rwnd;
-  this->_server_rwnd              = Http2::initial_window_size;
   this->upstream_outbound_options = *(session->accept_options);
 
   this->_reader = this->_receive_buffer.alloc_reader();

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -55,7 +55,7 @@ public:
   using super           = ProxyTransaction; ///< Parent type.
 
   Http2Stream() {} // Just to satisfy ClassAllocator
-  Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_rwnd);
+  Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_client_rwnd, ssize_t initial_server_rwnd);
   ~Http2Stream();
 
   int main_event_handler(int event, void *edata);
@@ -125,7 +125,8 @@ public:
   Http2StreamId get_id() const;
   Http2StreamState get_state() const;
   bool change_state(uint8_t type, uint8_t flags);
-  void update_initial_rwnd(Http2WindowSize new_size);
+  void set_client_rwnd(Http2WindowSize new_size);
+  void set_server_rwnd(Http2WindowSize new_size);
   bool has_trailing_header() const;
   void set_receive_headers(HTTPHdr &h2_headers);
   MIOBuffer *read_vio_writer() const;
@@ -259,9 +260,15 @@ Http2Stream::get_state() const
 }
 
 inline void
-Http2Stream::update_initial_rwnd(Http2WindowSize new_size)
+Http2Stream::set_client_rwnd(Http2WindowSize new_size)
 {
   this->_client_rwnd = new_size;
+}
+
+inline void
+Http2Stream::set_server_rwnd(Http2WindowSize new_size)
+{
+  this->_server_rwnd = new_size;
 }
 
 inline bool

--- a/tests/gold_tests/h2/http2_flow_control.test.py
+++ b/tests/gold_tests/h2/http2_flow_control.test.py
@@ -28,10 +28,13 @@ class Http2FlowControlTest:
     """Define an object to test HTTP/2 flow control behavior."""
 
     _replay_file: str = 'http2_flow_control.replay.yaml'
-    _valid_policy_values: List[int] = list(range(0, 2))
+    _valid_policy_values: List[int] = list(range(0, 3))
+    _flow_control_policy: Optional[int] = None
+    _flow_control_policy_is_malformed: bool = False
 
     _default_initial_window_size: int = 65535
     _default_max_concurrent_streams_in: int = 100
+    _default_flow_control_policy: int = 0
 
     _dns_counter: int = 0
     _server_counter: int = 0
@@ -43,7 +46,7 @@ class Http2FlowControlTest:
             description: str,
             initial_window_size: Optional[int] = None,
             max_concurrent_streams_in: Optional[int] = None,
-            verify_window_update_frames: bool = False):
+            flow_control_policy: Optional[int] = None):
         """Declare the various test Processes.
 
         :param description: A description of the test.
@@ -58,13 +61,16 @@ class Http2FlowControlTest:
         records.config file. If the paramenter is None, then no window size
         will be explicitly set and ATS will use the default value.
 
-        :param verify_window_update_frames: If True, then the test will verify
-        that it sees HTTP/2 WINDOW_UPDATE frames as data is sent.
+        :param flow_control_policy: The value with which to configure the
+        proxy.config.http2.flow_control.in.policy ATS parameter the
+        records.config file. If the paramenter is None, then no policy
+        configuration will be explicitly set and ATS will use the default
+        value.
         """
         self._description = description
 
         self._initial_window_size = initial_window_size
-        self._expected_initial_window_size = (
+        self._expected_initial_stream_window_size = (
             initial_window_size if initial_window_size is not None
             else self._default_initial_window_size)
 
@@ -73,7 +79,14 @@ class Http2FlowControlTest:
             max_concurrent_streams_in if max_concurrent_streams_in is not None
             else self._default_max_concurrent_streams_in)
 
-        self._verify_window_update_frames = verify_window_update_frames
+        self._flow_control_policy = flow_control_policy
+        self._expected_flow_control_policy = (
+            flow_control_policy if flow_control_policy is not None
+            else self._default_flow_control_policy)
+
+        self._flow_control_policy_is_malformed = (
+            self._flow_control_policy is not None and
+            self._flow_control_policy not in self._valid_policy_values)
 
         self._dns = self._configure_dns()
         self._server = self._configure_server()
@@ -118,6 +131,11 @@ class Http2FlowControlTest:
                 'proxy.config.http2.initial_window_size_in': self._initial_window_size,
             })
 
+        if self._flow_control_policy is not None:
+            ts.Disk.records_config.update({
+                'proxy.config.http2.flow_control.in.policy': self._flow_control_policy,
+            })
+
         if self._max_concurrent_streams_in is not None:
             ts.Disk.records_config.update({
                 'proxy.config.http2.max_concurrent_streams_in': self._max_concurrent_streams_in,
@@ -130,6 +148,11 @@ class Http2FlowControlTest:
         ts.Disk.remap_config.AddLine(
             f'map / http://127.0.0.1:{self._server.Variables.http_port}'
         )
+
+        if self._flow_control_policy_is_malformed:
+            ts.Disk.diags_log.Content = Testers.ContainsExpression(
+                "ERROR.*proxy.config.http2.flow_control.in.policy",
+                "There should be an about an invalid flow control policy.")
 
         return ts
 
@@ -144,39 +167,84 @@ class Http2FlowControlTest:
             https_ports=[self._ts.Variables.ssl_port])
         Http2FlowControlTest._client_counter += 1
 
+        if self._flow_control_policy_is_malformed:
+            # Since we're just testing ATS configuration errors, there's no
+            # need to set up client expectations.
+            return
+
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
             f'MAX_CONCURRENT_STREAMS:{self._expected_max_concurrent_streams_in}',
             "Client should receive a MAX_CONCURRENT_STREAMS setting.")
 
         if self._initial_window_size is not None:
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'INITIAL_WINDOW_SIZE:{self._expected_initial_window_size}',
+                f'INITIAL_WINDOW_SIZE:{self._expected_initial_stream_window_size}',
                 "Client should receive an INITIAL_WINDOW_SIZE setting.")
 
-        if self._verify_window_update_frames:
-            tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 0: {self._expected_initial_window_size}',
-                "Client should receive a session WINDOW_UPDATE.")
+            if self._expected_flow_control_policy == 0:
+                update_window_size = (
+                    self._expected_initial_stream_window_size -
+                    self._default_initial_window_size)
+                if update_window_size > 0:
+                    tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+                        f'WINDOW_UPDATE.*id 0: {update_window_size}',
+                        "Client should receive a session WINDOW_UPDATE.")
 
+        if self._expected_flow_control_policy in (1, 2):
+            # Verify the larger window size.
+
+            session_window_size = (
+                self._expected_initial_stream_window_size *
+                self._expected_max_concurrent_streams_in)
+            # ATS will send a WINDOW_UPDATE frame to the client to increase
+            # the session window size to the configured value from the default
+            # value.
+            update_window_size = (
+                session_window_size - self._expected_initial_stream_window_size)
+
+            # A WINDOW_UPDATE can only increase the window size. So make sure that
+            # the new window size is greater than the default window size.
+            if update_window_size > Http2FlowControlTest._default_initial_window_size:
+                tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+                    f'WINDOW_UPDATE.*id 0: {update_window_size}',
+                    "Client should receive a session WINDOW_UPDATE.")
+
+            if self._expected_flow_control_policy == 2:
+                # Verify the streams window sizes get updated.
+                stream_window_1 = session_window_size
+                stream_window_2 = int(session_window_size / 2)
+                stream_window_3 = int(session_window_size / 3)
+                tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+                    (f'INITIAL_WINDOW_SIZE:{stream_window_1}.*'
+                     f'INITIAL_WINDOW_SIZE:{stream_window_2}.*'
+                     f'INITIAL_WINDOW_SIZE:{stream_window_3}'),
+                    "Client should stream receive window updates",
+                    reflags=re.DOTALL | re.MULTILINE)
+
+        if self._expected_initial_stream_window_size < 1000:
+            # For the smaller session window sizes, we expect WINDOW_UPDATE frames.
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 3: {self._expected_initial_window_size}',
+                f'WINDOW_UPDATE.*id 3: {self._expected_initial_stream_window_size}',
                 "Client should receive a stream WINDOW_UPDATE.")
 
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 5: {self._expected_initial_window_size}',
+                f'WINDOW_UPDATE.*id 5: {self._expected_initial_stream_window_size}',
                 "Client should receive a stream WINDOW_UPDATE.")
 
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 7: {self._expected_initial_window_size}',
+                f'WINDOW_UPDATE.*id 7: {self._expected_initial_stream_window_size}',
                 "Client should receive a stream WINDOW_UPDATE.")
 
     def run(self):
         """Configure the TestRun."""
         tr = Test.AddTestRun(self._description)
-        self._configure_client(tr)
-        tr.Processes.Default.StartBefore(self._dns)
-        tr.Processes.Default.StartBefore(self._server)
-        tr.StillRunningAfter = self._ts
+        if not self._flow_control_policy_is_malformed:
+            self._configure_client(tr)
+            tr.Processes.Default.StartBefore(self._dns)
+            tr.Processes.Default.StartBefore(self._server)
+            tr.StillRunningAfter = self._ts
+        else:
+            tr.Processes.Default.Command = "true"
         tr.Processes.Default.StartBefore(self._ts)
 
 
@@ -198,14 +266,31 @@ test.run()
 # Configuring initial_window_size.
 #
 test = Http2FlowControlTest(
-    description="Configure a large initial_window_size_in",
+    description="Configure a larger initial_window_size_in",
     initial_window_size=100123)
 test.run()
 
-
+#
+# Configuring flow_control_policy.
+#
 test = Http2FlowControlTest(
-    description="Configure a small initial_window_size_in",
+    description="Configure an unrecognized flow_control.in.policy",
+    flow_control_policy=23)
+test.run()
+test = Http2FlowControlTest(
+    description="Static flow control with a small initial_window_size_in",
+    initial_window_size=500,
+    flow_control_policy=0)
+test.run()
+test = Http2FlowControlTest(
+    description="Static flow control with a large initial_window_size_in",
     max_concurrent_streams_in=10,
     initial_window_size=10,
-    verify_window_update_frames=True)
+    flow_control_policy=1)
+test.run()
+test = Http2FlowControlTest(
+    description="Dynamic flow control with a small initial_window_size_in",
+    max_concurrent_streams_in=10,
+    initial_window_size=10,
+    flow_control_policy=2)
 test.run()

--- a/tests/gold_tests/h2/http2_flow_control.test.py
+++ b/tests/gold_tests/h2/http2_flow_control.test.py
@@ -62,7 +62,7 @@ class Http2FlowControlTest:
         will be explicitly set and ATS will use the default value.
 
         :param flow_control_policy: The value with which to configure the
-        proxy.config.http2.flow_control.in.policy ATS parameter the
+        proxy.config.http2.flow_control.policy.in ATS parameter the
         records.config file. If the paramenter is None, then no policy
         configuration will be explicitly set and ATS will use the default
         value.
@@ -133,7 +133,7 @@ class Http2FlowControlTest:
 
         if self._flow_control_policy is not None:
             ts.Disk.records_config.update({
-                'proxy.config.http2.flow_control.in.policy': self._flow_control_policy,
+                'proxy.config.http2.flow_control.policy.in': self._flow_control_policy,
             })
 
         if self._max_concurrent_streams_in is not None:
@@ -151,7 +151,7 @@ class Http2FlowControlTest:
 
         if self._flow_control_policy_is_malformed:
             ts.Disk.diags_log.Content = Testers.ContainsExpression(
-                "ERROR.*proxy.config.http2.flow_control.in.policy",
+                "ERROR.*proxy.config.http2.flow_control.policy.in",
                 "There should be an about an invalid flow control policy.")
 
         return ts

--- a/tests/gold_tests/h2/http2_flow_control.test.py
+++ b/tests/gold_tests/h2/http2_flow_control.test.py
@@ -62,7 +62,7 @@ class Http2FlowControlTest:
         will be explicitly set and ATS will use the default value.
 
         :param flow_control_policy: The value with which to configure the
-        proxy.config.http2.flow_control.policy.in ATS parameter the
+        proxy.config.http2.flow_control.policy_in ATS parameter the
         records.config file. If the paramenter is None, then no policy
         configuration will be explicitly set and ATS will use the default
         value.
@@ -133,7 +133,7 @@ class Http2FlowControlTest:
 
         if self._flow_control_policy is not None:
             ts.Disk.records_config.update({
-                'proxy.config.http2.flow_control.policy.in': self._flow_control_policy,
+                'proxy.config.http2.flow_control.policy_in': self._flow_control_policy,
             })
 
         if self._max_concurrent_streams_in is not None:
@@ -151,7 +151,7 @@ class Http2FlowControlTest:
 
         if self._flow_control_policy_is_malformed:
             ts.Disk.diags_log.Content = Testers.ContainsExpression(
-                "ERROR.*proxy.config.http2.flow_control.policy.in",
+                "ERROR.*proxy.config.http2.flow_control.policy_in",
                 "There should be an about an invalid flow control policy.")
 
         return ts


### PR DESCRIPTION
Issue #8199 outlines the issue. This PR adds a new setting to allow for setting the session window separately from the stream window.

Closes #8199

---

This takes over for PR #8203 since that now has conflicts.