### PR TITLE
better logic for checking if a server allows storing

### DIFF
--- a/tests/gold_tests/cache/replay/cache-control-pragma.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-pragma.replay.yaml
@@ -1,0 +1,215 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# This replay file assumes that caching is enabled and
+# proxy.config.http.cache.ignore_client_cc_max_age is set to 0 so that we can
+# test max-age in the client requests.
+#
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  # Pragma: no-cache will prevent caching
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /pragma/no-cache
+      headers:
+        fields:
+          - [ uuid, pragma-populate-cache]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 4 ]
+        - [ Pragma, "no-cache" ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 4, as: equal}]
+  # Re-request to make sure it cached
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /pragma/no-cache
+      headers:
+        fields:
+          - [ uuid, pragma-populate-cache-verify]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+          # change content length
+        - [ Content-Length, 5 ]
+        - [ Pragma, "no-cache" ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 5, as: equal}]
+
+  # Cache-Control: no-cache will not cache
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cc/no-cache
+      headers:
+        fields:
+          - [ uuid, cc-no-cache]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 4 ]
+        - [ Cache-Control, "no-cache" ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 4, as: equal}]
+  # Re-request to make sure it cached
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cc/no-cache
+      headers:
+        fields:
+          - [ uuid, cc-no-cache-verify]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+          # change content length
+        - [ Content-Length, 5 ]
+        - [ Cache-Control, "no-cache" ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 5, as: equal}]
+
+  # Cache-Control: no-store also does not cache
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cc/no-store
+      headers:
+        fields:
+          - [ uuid, cc-no-store]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 4 ]
+        - [ Cache-Control, "no-cache" ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 4, as: equal}]
+  # Re-request to make sure it cached
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cc/no-cache
+      headers:
+        fields:
+          - [ uuid, cc-no-store-verify]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+          # change content length
+        - [ Content-Length, 5 ]
+        - [ Cache-Control, "no-cache" ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 5, as: equal}]
+
+
+  # Pragma: no-cache is ignored if cache-control is specified
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /pragma/cache-control
+      headers:
+        fields:
+          - [ uuid, ignore-pragma-cc]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 4 ]
+        - [ Cache-Control, "max-age=5,public" ]
+        - [ Pragma, "no-cache" ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 4, as: equal}]
+  # Re-request to make sure it cached
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /pragma/cache-control
+      headers:
+        fields:
+          - [ uuid, ignore-pragma-cc-verify]
+          - [ Host, example.com ]
+
+    server-response:
+      status: 404
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 4, as: equal}]
+

--- a/tests/gold_tests/cache/replay/cache-control-pragma.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-pragma.replay.yaml
@@ -48,7 +48,7 @@ sessions:
       headers:
         fields:
           - [ Content-Length, { value: 4, as: equal}]
-  # Re-request to make sure it cached
+  # Re-request to make sure it was not cached
   - client-request:
       method: "GET"
       version: "1.1"
@@ -63,7 +63,8 @@ sessions:
       reason: OK
       headers:
         fields:
-          # change content length
+        # change content length to differentiate from the previous
+        # response to verify it was not cached.
         - [ Content-Length, 5 ]
         - [ Pragma, "no-cache" ]
 
@@ -96,7 +97,7 @@ sessions:
       headers:
         fields:
           - [ Content-Length, { value: 4, as: equal}]
-  # Re-request to make sure it cached
+  # Re-request to make sure it was not cached
   - client-request:
       method: "GET"
       version: "1.1"
@@ -111,7 +112,8 @@ sessions:
       reason: OK
       headers:
         fields:
-          # change content length
+        # change content length to differentiate from the previous
+        # response to verify it was not cached.
         - [ Content-Length, 5 ]
         - [ Cache-Control, "no-cache" ]
 
@@ -144,7 +146,7 @@ sessions:
       headers:
         fields:
           - [ Content-Length, { value: 4, as: equal}]
-  # Re-request to make sure it cached
+  # Re-request to make sure it was not cached
   - client-request:
       method: "GET"
       version: "1.1"
@@ -159,7 +161,8 @@ sessions:
       reason: OK
       headers:
         fields:
-          # change content length
+        # change content length to differentiate from the previous
+        # response to verify it was not cached.
         - [ Content-Length, 5 ]
         - [ Cache-Control, "no-cache" ]
 


### PR DESCRIPTION
Fixes #9087 

I also added `MIME_COOKED_MASK_CC_NO_CACHE` to the cc_mask for checking cache-control because I didn't see anything that equated that with `NO_STORE`.  Let me know if that is problematic.