### PR TITLE
Add URLImpl::get_scheme

### DIFF
--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -712,6 +712,21 @@ url_string_get_buf(URLImpl *url, char *dstbuf, int dstbuf_size, int *length)
   -------------------------------------------------------------------------*/
 
 const char *
+URLImpl::get_scheme(int *length)
+{
+  if (this->m_scheme_wks_idx >= 0) {
+    *length = hdrtoken_index_to_length(this->m_scheme_wks_idx);
+    return hdrtoken_index_to_wks(this->m_scheme_wks_idx);
+  } else {
+    *length = this->m_len_scheme;
+    return this->m_ptr_scheme;
+  }
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+const char *
 URLImpl::get_user(int *length)
 {
   *length = this->m_len_user;

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -82,6 +82,7 @@ public:
   // 8 bytes + 4 bits, will result in padding
 
   // Accessors
+  const char *get_scheme(int *length);
   const char *set_scheme(HdrHeap *heap, const char *value, int value_wks_idx, int length, bool copy_string);
   const char *get_user(int *length);
   void set_user(HdrHeap *heap, const char *value, int length, bool copy_string);
@@ -514,13 +515,9 @@ inline const std::string_view
 URL::scheme_get()
 {
   ink_assert(valid());
-
-  if (m_url_impl->m_scheme_wks_idx >= 0) {
-    return std::string_view{hdrtoken_index_to_wks(m_url_impl->m_scheme_wks_idx),
-                            static_cast<size_t>(hdrtoken_index_to_length(m_url_impl->m_scheme_wks_idx))};
-  } else {
-    return std::string_view{m_url_impl->m_ptr_scheme, m_url_impl->m_len_scheme};
-  }
+  int length;
+  const char *scheme = m_url_impl->get_scheme(&length);
+  return std::string_view{scheme, static_cast<size_t>(length)};
 }
 
 inline const char *


### PR DESCRIPTION
`URLImpl::get_scheme` doesn't exist somehow where there are accessors for other parts, and `URL` has to touch member variables in `URLImpl` directly because of that.

This add `URLImpl::get_scheme` and move the current implantation in `URL` into `URLImpl`. There should be no logic/behavior change.