### PR TITLE
Validate request-target

### DIFF
--- a/proxy/hdrs/HTTP.cc
+++ b/proxy/hdrs/HTTP.cc
@@ -1000,6 +1000,9 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
                                           false, max_hdr_field_size);
       // If we're done with the main parse do some validation
       if (ret == PARSE_RESULT_DONE) {
+        ret = validate_hdr_request_target(HTTP_WKSIDX_GET, url);
+      }
+      if (ret == PARSE_RESULT_DONE) {
         ret = validate_hdr_host(hh); // check HOST header
       }
       if (ret == PARSE_RESULT_DONE) {
@@ -1155,11 +1158,45 @@ http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const 
                                       max_hdr_field_size);
   // If we're done with the main parse do some validation
   if (ret == PARSE_RESULT_DONE) {
+    ret = validate_hdr_request_target(hh->u.req.m_method_wks_idx, hh->u.req.m_url_impl);
+  }
+  if (ret == PARSE_RESULT_DONE) {
     ret = validate_hdr_host(hh); // check HOST header
   }
   if (ret == PARSE_RESULT_DONE) {
     ret = validate_hdr_content_length(heap, hh);
   }
+  return ret;
+}
+
+ParseResult
+validate_hdr_request_target(int method_wk_idx, URLImpl *url)
+{
+  ParseResult ret = PARSE_RESULT_DONE;
+  int host_len;
+  url->get_host(&host_len);
+  int path_len;
+  const char *path = url->get_path(&path_len);
+  int scheme_len;
+  url->get_scheme(&scheme_len);
+
+  if (host_len == 0) {
+    if (path_len == 1 && path[0] == '*') { // asterisk-form
+      // Skip this check for now because URLImpl can't distinguish '*' and '/*'
+      // if (method_wk_idx != HTTP_WKSIDX_OPTIONS) {
+      //   ret = PARSE_RESULT_ERROR;
+      // }
+    } else { // origin-form
+      // Nothing to check here
+    }
+  } else if (scheme_len == 0 && host_len != 0) { // authority-form
+    if (method_wk_idx != HTTP_WKSIDX_CONNECT) {
+      ret = PARSE_RESULT_ERROR;
+    }
+  } else { // absolute-form
+    // Nothing to check here
+  }
+
   return ret;
 }
 

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -451,6 +451,7 @@ void http_parser_clear(HTTPParser *parser);
 ParseResult http_parser_parse_req(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const char **start, const char *end,
                                   bool must_copy_strings, bool eof, int strict_uri_parsing, size_t max_request_line_size,
                                   size_t max_hdr_field_size);
+ParseResult validate_hdr_request_target(int method_wks_idx, URLImpl *url);
 ParseResult validate_hdr_host(HTTPHdrImpl *hh);
 ParseResult validate_hdr_content_length(HdrHeap *heap, HTTPHdrImpl *hh);
 ParseResult http_parser_parse_resp(HTTPParser *parser, HdrHeap *heap, HTTPHdrImpl *hh, const char **start, const char *end,

--- a/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -46,7 +46,7 @@ TEST_CASE("HdrTestHttpParse", "[proxy][hdrtest]")
     int expected_result;
     int expected_bytes_consumed;
   };
-  static const std::array<Test, 21> tests = {{
+  static const std::array<Test, 23> tests = {{
     {"GET /index.html HTTP/1.0\r\n", PARSE_RESULT_DONE, 26},
     {"GET /index.html HTTP/1.0\r\n\r\n***BODY****", PARSE_RESULT_DONE, 28},
     {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n\r\n***BODY****", PARSE_RESULT_DONE, 48},
@@ -67,6 +67,8 @@ TEST_CASE("HdrTestHttpParse", "[proxy][hdrtest]")
     {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n", PARSE_RESULT_DONE, 46},
     {"GET /index.html HTTP/1.0\r\n", PARSE_RESULT_DONE, 26},
     {"GET /index.html hTTP/1.0\r\n", PARSE_RESULT_ERROR, 26},
+    {"CONNECT foo.example HTTP/1.1\r\n", PARSE_RESULT_DONE, 30},
+    {"GET foo.example HTTP/1.1\r\n", PARSE_RESULT_ERROR, 26},
     {"", PARSE_RESULT_ERROR, 0},
   }};
 


### PR DESCRIPTION
This should fixes https://github.com/apache/trafficserver/issues/9094.

The validation is not very strict. It still allows "authority-form" that doesn't have a port number, but I think it's enough for #9094 and I didn't want to make it overly strict.