### PR TITLE
Fix handling of OPTIONS request

### DIFF
--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -31,6 +31,8 @@
 #include "HTTP.h"
 #include "tscore/Diags.h"
 
+const char URLImpl::ASTERISK = '\xff';
+
 const char *URL_SCHEME_FILE;
 const char *URL_SCHEME_FTP;
 const char *URL_SCHEME_GOPHER;
@@ -1688,11 +1690,17 @@ url_print(URLImpl *url, char *buf_start, int buf_length, int *buf_index_inout, i
     }
   }
 
-  if (!url->m_path_is_empty) {
-    TRY(mime_mem_print("/", 1, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
-  }
-  if (url->m_ptr_path) {
-    TRY(mime_mem_print(url->m_ptr_path, url->m_len_path, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
+  if (url->m_len_path == 1 && url->m_ptr_path[0] == URLImpl::ASTERISK) {
+    if (!url->m_path_is_empty) {
+      TRY(mime_mem_print("*", 1, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
+    }
+  } else {
+    if (!url->m_path_is_empty) {
+      TRY(mime_mem_print("/", 1, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
+    }
+    if (url->m_ptr_path) {
+      TRY(mime_mem_print(url->m_ptr_path, url->m_len_path, buf_start, buf_length, buf_index_inout, buf_chars_to_skip_inout));
+    }
   }
 
   if (url->m_ptr_params && url->m_len_params > 0) {

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -43,6 +43,8 @@ enum URLType {
 class URLImpl : public HdrHeapObjImpl
 {
 public:
+  static const char ASTERISK;
+
   // HdrHeapObjImpl is 4 bytes
   uint16_t m_len_scheme;
   uint16_t m_len_user;

--- a/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -46,7 +46,7 @@ TEST_CASE("HdrTestHttpParse", "[proxy][hdrtest]")
     int expected_result;
     int expected_bytes_consumed;
   };
-  static const std::array<Test, 23> tests = {{
+  static const std::array<Test, 28> tests = {{
     {"GET /index.html HTTP/1.0\r\n", PARSE_RESULT_DONE, 26},
     {"GET /index.html HTTP/1.0\r\n\r\n***BODY****", PARSE_RESULT_DONE, 28},
     {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n\r\n***BODY****", PARSE_RESULT_DONE, 48},
@@ -69,6 +69,11 @@ TEST_CASE("HdrTestHttpParse", "[proxy][hdrtest]")
     {"GET /index.html hTTP/1.0\r\n", PARSE_RESULT_ERROR, 26},
     {"CONNECT foo.example HTTP/1.1\r\n", PARSE_RESULT_DONE, 30},
     {"GET foo.example HTTP/1.1\r\n", PARSE_RESULT_ERROR, 26},
+    {"OPTIONS /index.html HTTP/1.1\r\n", PARSE_RESULT_DONE, 30},
+    {"OPTIONS /* HTTP/1.1\r\n", PARSE_RESULT_DONE, 21},
+    {"OPTIONS * HTTP/1.1\r\n", PARSE_RESULT_DONE, 20},
+    {"GET /* HTTP/1.1\r\n", PARSE_RESULT_DONE, 17},
+    {"GET * HTTP/1.1\r\n", PARSE_RESULT_ERROR, 16},
     {"", PARSE_RESULT_ERROR, 0},
   }};
 


### PR DESCRIPTION
When I worked on #9094, I found that OPTIONS request (asterisk-form) is not handled correctly either.

HTTPHdr treats anything between request method and "HTTP/1.x" as URL, and it tries to parse the surrounded part by `url_parse`. When a request is asterisk-form (i.e. `OPTIONS * HTTP/1.1`) The parsing fails because "*" is not a valid URL.

This PR adds a special handling of asterisk-form. The change is small but it's a bit hacky, so I'm not going to strongly push this change and any feedback is welcome, but this allows users to proxy OPTIONS requests.

