### PR TITLE
Move plugin_init for verify cmd

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -895,6 +895,13 @@ cmd_verify(char * /* cmd ATS_UNUSED */)
     Layout::get()->update_sysconfdir(conf_dir);
   }
 
+  if (!plugin_init(true)) {
+    exitStatus |= (1 << 2);
+    fprintf(stderr, "ERROR: Failed to load %s, exitStatus %d\n\n", ts::filename::PLUGIN, exitStatus);
+  } else {
+    fprintf(stderr, "INFO: Successfully loaded %s\n\n", ts::filename::PLUGIN);
+  }
+
   if (!urlRewriteVerify()) {
     exitStatus |= (1 << 0);
     fprintf(stderr, "ERROR: Failed to load %s, exitStatus %d\n\n", ts::filename::REMAP, exitStatus);
@@ -907,13 +914,6 @@ cmd_verify(char * /* cmd ATS_UNUSED */)
     fprintf(stderr, "ERROR: Failed to load %s, exitStatus %d\n\n", ts::filename::RECORDS, exitStatus);
   } else {
     fprintf(stderr, "INFO: Successfully loaded %s\n\n", ts::filename::RECORDS);
-  }
-
-  if (!plugin_init(true)) {
-    exitStatus |= (1 << 2);
-    fprintf(stderr, "ERROR: Failed to load %s, exitStatus %d\n\n", ts::filename::PLUGIN, exitStatus);
-  } else {
-    fprintf(stderr, "INFO: Successfully loaded %s\n\n", ts::filename::PLUGIN);
   }
 
   SSLInitializeLibrary();


### PR DESCRIPTION
plugin_init calls api_init which will intialize all the global hooks needed for lifecycle and other plugins. Without doing this those hook objects are empty so if a plugin (such as lua) makes a call to add a lifecycle hook on remapinit, this will crash since they haven't been initialized. This occurs during the urlRewriteVerify step of verification where it tries to load plugins or at least initialize them, these will crash