### PR TITLE
Fix outbound client cert override to support disable

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -784,7 +784,7 @@ SSLConfigParams::getCTX(const std::string &client_cert, const std::string &key_f
   ctx_key = client_cert;
   ts::bwprint(top_level_key, "{}:{}", ca_bundle_file, ca_bundle_path);
 
-  Debug("ssl_client_ctx", "Look for client cert %s %s", top_level_key.c_str(), ctx_key.c_str());
+  Debug("ssl_client_ctx", "Look for client cert \"%s\" \"%s\"", top_level_key.c_str(), ctx_key.c_str());
 
   ink_mutex_acquire(&ctxMapLock);
   auto ctx_map_iter = top_level_ctx_map.find(top_level_key);


### PR DESCRIPTION
It is possible to change the client certificate on outbound connections via the plugin API. This does not work if the goal is to disable the client certificate (e.g. do not send a client cert). I consider that a bug. This change makes it so that setting either the empty string or the literal string "NULL" will prevent sending an outbound client certificate. The string value is chosen to be compatible with standard practice in "records.config" where a value of "STRING NULL" is used to indicate disabling. This should have no effect on existing code and plugins.

I was not able to create an AuTest to verify this in Traffic Server. I did my testing using TxnBox where it was easy. Unfortunately this yields a precedence problem where I can't commit that test to TxnBox until this fix is merged, otherwise the test will always fail.