### PR TITLE
Fix unused-but-set-variable warnings by llvm-15

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2889,7 +2889,6 @@ cplist_reconfigure()
       }
 
       int64_t size_to_alloc = size_in_blocks - cp->size;
-      int disk_full         = 0;
       for (int i = 0; (i < gndisks) && size_to_alloc; i++) {
         int disk_no = sorted_vols[i];
         ink_assert(cp->disk_vols[sorted_vols[gndisks - 1]]);
@@ -2921,10 +2920,6 @@ cplist_reconfigure()
             break;
           }
         } while ((size_diff > 0));
-
-        if (!dpb) {
-          disk_full++;
-        }
 
         size_to_alloc = size_in_blocks - cp->size;
       }

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -303,7 +303,6 @@ Result
 Store::read_config()
 {
   int n_dsstore   = 0;
-  int ln          = 0;
   int i           = 0;
   const char *err = nullptr;
   Span *sd = nullptr, *cur = nullptr;
@@ -326,10 +325,6 @@ Store::read_config()
   while ((len = ink_file_fd_readline(fd, sizeof(line), line)) > 0) {
     const char *path;
     const char *seed = nullptr;
-    // update lines
-
-    ++ln;
-
     // Because the SimpleTokenizer is a bit too simple, we have to normalize whitespace.
     for (char *spot = line, *limit = line + len; spot < limit; ++spot) {
       if (ParseRules::is_space(*spot)) {

--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -148,7 +148,7 @@ is_inkeylist(const char *key, ...)
   va_start(ap, key);
 
   const char *str = va_arg(ap, const char *);
-  for (unsigned idx = 1; str; idx++) {
+  while (str) {
     if (!strcasecmp(key, str)) {
       va_end(ap);
       return true;

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -1128,8 +1128,6 @@ LogObjectManager::open_local_pipes()
 void
 LogObjectManager::transfer_objects(LogObjectManager &old_mgr)
 {
-  unsigned num_kept_objects = 0;
-
   Debug("log-config-transfer", "transferring objects from LogObjectManager %p, to %p", &old_mgr, this);
 
   if (is_debug_tag_set("log-config-transfer")) {
@@ -1172,7 +1170,6 @@ LogObjectManager::transfer_objects(LogObjectManager &old_mgr)
         if (new_obj->refcount_dec() == 0) {
           delete new_obj;
         }
-        ++num_kept_objects;
         break;
       }
     }

--- a/src/traffic_cache_tool/CacheDefs.cc
+++ b/src/traffic_cache_tool/CacheDefs.cc
@@ -542,10 +542,8 @@ Stripe::walk_bucket_chain(int s)
     CacheDirEntry *p = nullptr;
     auto *dir_b      = dir_bucket(b, seg);
     CacheDirEntry *e = dir_b;
-    int len          = 0;
 
     while (e) {
-      len++;
       int i = dir_to_offset(e, seg);
       if (b_bitset.test(i)) {
         std::cout << "bit already set in "

--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -105,8 +105,6 @@ spawn_same_session_send(void *arg)
 
   SSL_set_fd(ssl, sfd);
   int ret            = SSL_connect(ssl);
-  int read_count     = 0;
-  int write_count    = 1;
   int write_ret      = -1;
   int post_write_ret = -1;
 
@@ -120,12 +118,10 @@ spawn_same_session_send(void *arg)
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_ACCEPT:
       FD_SET(sfd, &reads);
-      read_count++;
       break;
     case SSL_ERROR_WANT_CONNECT:
     case SSL_ERROR_WANT_WRITE:
       FD_SET(sfd, &writes);
-      write_count++;
       break;
     case SSL_ERROR_SYSCALL:
     case SSL_ERROR_SSL:


### PR DESCRIPTION
llvm-15 (clang-15) generates below "unused-but-set-variable" warnings. 

```
Cache.cc:2892:11: warning: variable 'disk_full' set but not used [-Wunused-but-set-variable]
      int disk_full         = 0;
          ^      
Store.cc:306:7: warning: variable 'ln' set but not used [-Wunused-but-set-variable]
  int ln          = 0;
      ^
RemapConfig.cc:151:17: warning: variable 'idx' set but not used [-Wunused-but-set-variable]
  for (unsigned idx = 1; str; idx++) {
                ^
LogObject.cc:1131:12: warning: variable 'num_kept_objects' set but not used [-Wunused-but-set-variable]
  unsigned num_kept_objects = 0;      
           ^
traffic_cache_tool/CacheDefs.cc:545:9: warning: variable 'len' set but not used [-Wunused-but-set-variable]
    int len          = 0;
        ^
gold_tests/tls/ssl-post.c:108:7: warning: variable 'read_count' set but not used [-Wunused-but-set-variable]
  int read_count     = 0;
      ^
gold_tests/tls/ssl-post.c:109:7: warning: variable 'write_count' set but not used [-Wunused-but-set-variable]
  int write_count    = 1;
      ^
```

The release note of clang 15.0.0 says below.

```
Improvements to Clang’s diagnostics
...
  * -Wunused-but-set-variable now also warns if the variable is only used by unary operators.
...  
```
https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics