### PR TITLE
Adds support for serving statichit content out of a directory

### DIFF
--- a/plugins/experimental/statichit/statichit.cc
+++ b/plugins/experimental/statichit/statichit.cc
@@ -115,7 +115,7 @@ struct StaticHitConfig {
         }
       }
     } else {
-      ret = {filePath};
+      ret = filePath;
     }
 
     return ret;


### PR DESCRIPTION
This does some fairly expensive computations when producing the directory paths. This is intentional,
to make sure requests aren't escaping the specified directory and out elsewhere. This cleans out abusive
requests such as get `/../../etc/hosts` etc.

The idea is that rather than having to specify every individual file that the server should service, you can specify a
directory and every file (and subdirectory thereunder) can now be served.