### PR TITLE
Allocator that just uses malloc and bypasses custom jemalloc/freelist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1825,6 +1825,17 @@ TS_CHECK_JEMALLOC
 TS_CHECK_MIMALLOC
 
 #
+# Check whether to use malloc or freelist allocator
+AC_MSG_CHECKING([Use malloc allocator])
+AC_ARG_ENABLE([malloc-allocator],
+  [AS_HELP_STRING([--enable-malloc-allocator],[Allocator uses malloc])],
+  [enable_malloc_allocator=1],
+  [enable_malloc_allocator=0]
+)
+AC_MSG_RESULT([$enable_malloc_allocator])
+AC_SUBST(enable_malloc_allocator)
+
+#
 # Check for libreadline/libedit
 AX_LIB_READLINE
 

--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -54,6 +54,8 @@
 #define TS_HAS_TCMALLOC @has_tcmalloc@
 #define TS_HAS_MIMALLOC @mimalloch@
 
+#define TS_USE_MALLOC_ALLOCATOR @enable_malloc_allocator@
+
 /* Features */
 #define TS_HAS_IN6_IS_ADDR_UNSPECIFIED @has_in6_is_addr_unspecified@
 #define TS_HAS_BACKTRACE @has_backtrace@

--- a/iocore/eventsystem/I_ProxyAllocator.h
+++ b/iocore/eventsystem/I_ProxyAllocator.h
@@ -62,9 +62,8 @@ thread_alloc(CAlloc &a, ProxyAllocator &l, Args &&... args)
   return a.alloc(std::forward<Args>(args)...);
 }
 
-class Allocator;
-
 void *thread_alloc(Allocator &a, ProxyAllocator &l);
+
 void thread_freeup(Allocator &a, ProxyAllocator &l);
 
 #if 1

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -101,6 +101,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.memory.max_usage", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.memory.malloc_stats_print_opts", RECD_STRING, "", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   //##############################################################################
   //# Traffic Server system settings
   //##############################################################################

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -274,6 +274,12 @@ public:
       // TODO: TS-567 Integrate with debugging allocators "dump" features?
       ink_freelists_dump(stderr);
       ResourceTracker::dump(stderr);
+
+#if TS_HAS_JEMALLOC
+      char buf[PATH_NAME_MAX] = "";
+      RecGetRecordString("proxy.config.memory.malloc_stats_print_opts", buf, PATH_NAME_MAX);
+      malloc_stats_print(nullptr, nullptr, buf);
+#endif
     }
 
     if (signal_received[SIGUSR2]) {


### PR DESCRIPTION
This PR reimplements Allocator to just use malloc/free and completely ignores the ink_freelist code. It doesn't disable ProxyAllocator freelists. This means the -F (proxy allocator disable) works, but -f (disable freelist) does nothing.

This differs from the -f option (when jemalloc is enabled) in the following ways:

 - honors advice and calls (jemalloc's) madvise (for nodump support on io buffers).
 - Does not use the jemallocnodumallocator for aligned allocation, but uses (jemalloc's) aligned_alloc.
 - does not use posix_madvise, or posix_memalign in any case

To use this allocator, one must pass `--enable-malloc-allocator` to `configure` otherwise it will behave as it always has.