### PR TITLE
Change use of std::shared_mutex to ts::shared_mutex.

### DIFF
--- a/include/tscore/JeAllocator.h
+++ b/include/tscore/JeAllocator.h
@@ -25,7 +25,6 @@
 #include <cstddef>
 #include <unordered_map>
 #include <mutex>
-#include <shared_mutex>
 
 #if TS_HAS_JEMALLOC
 #include <jemalloc/jemalloc.h>

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -36,6 +36,7 @@
 #include <algorithm>
 #include <random>
 #include <chrono>
+#include <shared_mutex>
 #include <http/HttpConfig.h>
 
 using ts::TextView;

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -27,8 +27,9 @@
 
 #pragma once
 
-#include <shared_mutex>
 #include <unordered_map>
+
+#include <tscpp/util/TsSharedMutex.h>
 
 #include "I_HostDBProcessor.h"
 #include "P_RefCountCache.h"
@@ -164,7 +165,7 @@ struct HostDBCache {
   int start(int flags = 0);
   // Map to contain all of the host file overrides, initialize it to empty
   std::shared_ptr<HostFile> host_file;
-  std::shared_mutex host_file_mutex;
+  ts::shared_mutex host_file_mutex;
 
   // TODO: make ATS call a close() method or something on shutdown (it does nothing of the sort today)
   RefCountCache<HostDBRecord> *refcountcache = nullptr;

--- a/iocore/net/P_TLSKeyLogger.h
+++ b/iocore/net/P_TLSKeyLogger.h
@@ -28,7 +28,7 @@
 
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
+#include <tscpp/util/TsSharedMutex.h>
 
 /** A class for handling TLS secrets logging. */
 class TLSKeyLogger
@@ -126,5 +126,5 @@ private:
 
   /** A mutex to coordinate dynamically changing TLS logging config changes and
    * logging to the TLS log file. */
-  std::shared_mutex _mutex;
+  ts::shared_mutex _mutex;
 };

--- a/iocore/net/SSLSessionCache.cc
+++ b/iocore/net/SSLSessionCache.cc
@@ -25,6 +25,7 @@
 
 #include <cstring>
 #include <memory>
+#include <shared_mutex>
 
 #define SSLSESSIONCACHE_STRINGIFY0(x) #x
 #define SSLSESSIONCACHE_STRINGIFY(x) SSLSESSIONCACHE_STRINGIFY0(x)
@@ -274,7 +275,7 @@ void inline SSLSessionBucket::print(const char *ref_str) const
   }
 }
 
-void inline SSLSessionBucket::removeOldestSession(const std::unique_lock<std::shared_mutex> &lock)
+void inline SSLSessionBucket::removeOldestSession(const std::unique_lock<ts::shared_mutex> &lock)
 {
   // Caller must hold the bucket shared_mutex with unique_lock.
   ink_assert(lock.owns_lock());
@@ -398,7 +399,7 @@ SSLOriginSessionCache::get_session(const std::string &lookup_key, ssl_curve_id *
 }
 
 void
-SSLOriginSessionCache::remove_oldest_session(const std::unique_lock<std::shared_mutex> &lock)
+SSLOriginSessionCache::remove_oldest_session(const std::unique_lock<ts::shared_mutex> &lock)
 {
   // Caller must hold the bucket shared_mutex with unique_lock.
   ink_release_assert(lock.owns_lock());

--- a/iocore/net/SSLSessionCache.h
+++ b/iocore/net/SSLSessionCache.h
@@ -30,7 +30,7 @@
 #include "ts/apidefs.h"
 #include <openssl/ssl.h>
 #include <mutex>
-#include <shared_mutex>
+#include <tscpp/util/TsSharedMutex.h>
 
 #define SSL_MAX_SESSION_SIZE 256
 #define SSL_MAX_ORIG_SESSION_SIZE 4096
@@ -159,9 +159,9 @@ public:
 private:
   /* these method must be used while hold the lock */
   void print(const char *) const;
-  void removeOldestSession(const std::unique_lock<std::shared_mutex> &lock);
+  void removeOldestSession(const std::unique_lock<ts::shared_mutex> &lock);
 
-  mutable std::shared_mutex mutex;
+  mutable ts::shared_mutex mutex;
   CountQueue<SSLSession> bucket_que;
   std::map<SSLSessionID, SSLSession *> bucket_map;
 };
@@ -210,9 +210,9 @@ public:
   void remove_session(const std::string &lookup_key);
 
 private:
-  void remove_oldest_session(const std::unique_lock<std::shared_mutex> &lock);
+  void remove_oldest_session(const std::unique_lock<ts::shared_mutex> &lock);
 
-  mutable std::shared_mutex mutex;
+  mutable ts::shared_mutex mutex;
   CountQueue<SSLOriginSession> orig_sess_que;
   std::map<std::string, SSLOriginSession *> orig_sess_map;
 };

--- a/iocore/net/TLSKeyLogger.cc
+++ b/iocore/net/TLSKeyLogger.cc
@@ -23,6 +23,7 @@
 #include "tscore/Diags.h"
 
 #include <cstring>
+#include <shared_mutex>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Typically when shared_mutex is used, the ratio of shared_locks versus unique_locks is high, so writer starvation is a risk.  On Linux, ts::shared_mutex avoids writer starvation (std::shared_mutex does not).