### PR TITLE
Add event loop timing histogram data.

### DIFF
--- a/include/tscpp/util/Histogram.h
+++ b/include/tscpp/util/Histogram.h
@@ -1,0 +1,195 @@
+/** @file
+ *
+ * Fast small foot print histogram support.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <array>
+
+namespace ts
+{
+/** Small fast histogram.
+ *
+ * This is a stepped logarithmic histogram. Each range is twice the size of the previous range. Each range is divided into equal
+ * sized spans, with a bucket for each span. The ranges and spans are defined by the @a R and @a S template parameters. There is
+ * an underflow range for values less than @c 2^S. There is a range for each power of 2 from @c 2^S to @c 2^(S+R-1) and overflow
+ * bucket for values greater than or equal to @c 2^(R+S-1).
+ *
+ * This can also been seen as having a range for each bit from @c S to @c S+R-1. The bucket is determined by the most significant
+ * bit of the value. If it is past @c S+R-1 then it is put in the overflow bucket. If the MSB is less than @c S then it is put in
+ * a bucket in the underflow range, values <tt>0 .. (2^S)-1</tt>. For normal ranges, the range is determined by the bit index and
+ * the next @c S bits are used as an index into the buckets for that range. Note this is the same for the underflow range which is
+ * used when the MSB is in the first @c S bits.
+ *
+ * For example, if @a S is 2 then the buckets are (where @c U is an underflow bucket)
+ * <tt>0,1,2,3,4,5,6,7,8,10,12,14,16,20,24,28, ...</tt> <- Sample value
+ * <tt>U U U U 0 0 0 0 1  1  1  1  2  2  2  2  ...</tt> <- Range
+ *
+ * To keep data relevant there is a decay mechanism will divides all of the bucket counts by 2. If done periodically this creates
+ * an exponential decay of sample data, which is less susceptible to timing issues. Instances can be summed so that parallel
+ * instances can be kept on different threads without locking and then combined.
+ *
+ * @tparam R Bits for the overall range of the histogram.
+ * @tparam S Bits used for spans inside a range.
+ *
+ */
+template <auto R, auto S> class Histogram
+{
+  using self_type = Histogram; ///< Self reference type.
+
+public:
+  /// Type used for internal calculations.
+  using raw_type = uint64_t;
+  /// Number of bits to use for the base range.
+  static constexpr raw_type N_RANGE_BITS = R;
+  /// Number of bits to split each base range in to span buckets.
+  static constexpr raw_type N_SPAN_BITS = S;
+  /// Number of buckets per span.
+  static constexpr raw_type N_SPAN_BUCKETS = 1 << N_SPAN_BITS;
+  /// Mask to extract the local bucket index from a sample.
+  static constexpr raw_type SPAN_MASK = (1 << N_SPAN_BITS) - 1;
+  /// Initial mask to find the MSB in the sample.
+  static constexpr raw_type MSB_MASK = 1 << (N_RANGE_BITS + N_SPAN_BITS - 1);
+  /// Total number of buckets - 1 for overflow and an extra range for less than @c LOWER_BOUND
+  static constexpr raw_type N_BUCKETS = ((N_RANGE_BITS + 1) * N_SPAN_BUCKETS) + 1;
+  /// Samples less than this go in the underflow range.
+  static constexpr raw_type LOWER_BOUND = 1 << N_SPAN_BITS;
+  /// Sample equal or greater than this  go in the overflow bucket.
+  static constexpr raw_type UPPER_BOUND = 1 << (N_RANGE_BITS + N_SPAN_BITS + 1);
+
+  /** Add @sample to the histogram.
+   *
+   * @param sample Value to add.
+   * @return @a this
+   */
+  self_type &operator()(raw_type sample);
+
+  /** Decrease all values by a factor of 2.
+   *
+   * @return @a this
+   */
+  self_type &decay();
+
+  /** Get bucket count.
+   *
+   * @param idx Index of the bucket.
+   * @return Count in the bucket.
+   */
+  raw_type operator[](unsigned idx);
+
+  /** Lower bound for samples in bucket.
+   *
+   * @param idx Index of the bucket.
+   * @return The smallest sample value that will increment the bucket.
+   */
+  static raw_type lower_bound(unsigned idx);
+
+  /** Add counts from another histogram.
+   *
+   * @param that Source histogram.
+   * @return @a this
+   *
+   * The buckets are added in parallel.
+   */
+  self_type &operator+=(self_type const &that);
+
+protected:
+  /// The buckets.
+  std::array<raw_type, N_BUCKETS> _bucket = {0};
+};
+
+/// @cond INTERNAL_DETAIL
+template <auto R, auto S>
+auto
+Histogram<R, S>::operator[](unsigned int idx) -> raw_type
+{
+  return _bucket[idx];
+}
+
+template <auto R, auto S>
+auto
+Histogram<R, S>::operator+=(self_type const &that) -> self_type &
+{
+  auto dst = _bucket.data();
+  auto src = that._bucket.data();
+  for (raw_type idx = 0; idx < N_BUCKETS; ++idx) {
+    *dst++ += *src++;
+  }
+  return *this;
+}
+
+template <auto R, auto S>
+auto
+Histogram<R, S>::operator()(raw_type sample) -> self_type &
+{
+  int idx = N_BUCKETS - 1; // index of overflow bucket
+  if (sample < LOWER_BOUND) {
+    idx = sample;                    // sample -> bucket is identity in the underflow range.
+  } else if (sample < UPPER_BOUND) { // not overflow bucket.
+    idx -= N_SPAN_BUCKETS;           // bottom bucket in the range.
+    auto mask = MSB_MASK;            // Mask to probe for bit set.
+    // Shift needed after finding the MSB to put the span bits in the LSBs.
+    unsigned normalize_shift_count = N_RANGE_BITS - 1;
+    // Walk the mask bit down until the MSB is found. Each span bumps down the bucket index
+    // and the shift for the span bits. An MSB will be found because @a sample >= @c LOWER_BOUND
+    // The MSB is not before @c MSB_MASK because @a sample < @c UPPER_BOUND
+    while (0 == (sample & mask)) {
+      mask >>= 1;
+      --normalize_shift_count;
+      idx -= N_SPAN_BUCKETS;
+    }
+    idx += (sample >> normalize_shift_count) & SPAN_MASK;
+  } // else idx remains the overflow bucket.
+  ++_bucket[idx];
+  return *this;
+}
+
+template <auto R, auto S>
+auto
+Histogram<R, S>::lower_bound(unsigned idx) -> raw_type
+{
+  auto range         = idx / N_SPAN_BUCKETS;
+  raw_type base      = 0; // minimum value for the range (not span!).
+  raw_type span_size = 1; // for @a range 0 or 1
+  if (range > 0) {
+    base = 1 << (range + N_SPAN_BITS - 1);
+    if (range > 1) { // at @a range == 1 this would be 0, which is wrong.
+      span_size = base >> N_SPAN_BITS;
+    }
+  }
+  return base + span_size * (idx & SPAN_MASK);
+}
+
+template <auto R, auto S>
+auto
+Histogram<R, S>::decay() -> self_type &
+{
+  for (auto &v : _bucket) {
+    v >>= 1;
+  }
+  return *this;
+}
+
+/// @endcond
+
+} // namespace ts

--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -30,6 +30,7 @@
 #include "I_Thread.h"
 #include "I_PriorityEventQueue.h"
 #include "I_ProtectedQueue.h"
+#include "tscpp/util/Histogram.h"
 
 // TODO: This would be much nicer to have "run-time" configurable (or something),
 // perhaps based on proxy.config.stat_api.max_stats_allowed or other configs. XXX
@@ -360,8 +361,7 @@ public:
   */
   class DefaultTailHandler : public LoopTailHandler
   {
-    // cppcheck-suppress noExplicitConstructor; allow implicit conversion
-    DefaultTailHandler(ProtectedQueue &q) : _q(q) {}
+    explicit DefaultTailHandler(ProtectedQueue &q) : _q(q) {}
 
     int
     waitForActivity(ink_hrtime timeout) override
@@ -383,84 +383,234 @@ public:
     ProtectedQueue &_q;
 
     friend class EThread;
-  } DEFAULT_TAIL_HANDLER = EventQueueExternal;
+  } DEFAULT_TAIL_HANDLER = DefaultTailHandler(EventQueueExternal);
 
-  /// Statistics data for event dispatching.
-  struct EventMetrics {
-    /// Time the loop was active, not including wait time but including event dispatch time.
-    struct LoopTimes {
-      ink_hrtime _start = 0;         ///< The time of the first loop for this sample. Used to mark valid entries.
-      ink_hrtime _min   = INT64_MAX; ///< Shortest loop time.
-      ink_hrtime _max   = 0;         ///< Longest loop time.
-      LoopTimes() {}
-    } _loop_time;
+  struct Metrics {
+    using self_type = Metrics; ///< Self reference type.
 
-    struct Events {
-      int _min   = INT_MAX;
-      int _max   = 0;
-      int _total = 0;
-      Events() {}
-    } _events;
+    /// Information about loops within the same time slice.
+    struct Slice {
+      using self_type = Slice;
 
-    int _count = 0; ///< # of times the loop executed.
-    int _wait  = 0; ///< # of timed wait for events
+      /// Data for timing of the loop.
+      struct Duration {
+        ink_hrtime _start = 0;         ///< The time of the first loop for this sample. Used to mark valid entries.
+        ink_hrtime _min   = INT64_MAX; ///< Shortest loop time.
+        ink_hrtime _max   = 0;         ///< Longest loop time.
+        Duration()        = default;
+      } _duration;
 
-    /// Add @a that to @a this data.
-    /// This embodies the custom logic per member concerning whether each is a sum, min, or max.
-    EventMetrics &operator+=(EventMetrics const &that);
+      /// Events in the slice.
+      struct Events {
+        int _min   = INT_MAX; ///< Minimum # of events in a loop.
+        int _max   = 0;       ///< Maximum # of events in a loop.
+        int _total = 0;       ///< Total # of events.
+        Events() {}
+      } _events;
 
-    EventMetrics() {}
+      int _count = 0; ///< # of times the loop executed.
+      int _wait  = 0; ///< # of timed wait for events
+
+      /** Record the loop start time.
+       *
+       * @param t Start time.
+       * @return @a this
+       */
+      self_type &record_loop_start(ink_hrtime t);
+
+      /** Record event loop duration.
+       *
+       * @param delta Duration of the loop.
+       * @return @a this.
+       */
+      self_type &record_loop_duration(ink_hrtime delta);
+
+      /** Record number of events in a loop.
+       *
+       * @param count Event count.
+       * @return
+       */
+      self_type &record_event_count(int count);
+
+      /// Add @a that to @a this data.
+      /// This embodies the custom logic per member concerning whether each is a sum, min, or max.
+      Slice &operator+=(Slice const &that);
+
+      /** Slice related statistics.
+          THE ORDER IS VERY SENSITIVE.
+          More than one part of the code depends on this exact order. Be careful and thorough when changing.
+      */
+      enum class STAT_ID {
+        LOOP_COUNT,      ///< # of event loops executed.
+        LOOP_EVENTS,     ///< # of events
+        LOOP_EVENTS_MIN, ///< min # of events dispatched in a loop
+        LOOP_EVENTS_MAX, ///< max # of events dispatched in a loop
+        LOOP_WAIT,       ///< # of loops that did a conditional wait.
+        LOOP_TIME_MIN,   ///< Shortest time spent in loop.
+        LOOP_TIME_MAX,   ///< Longest time spent in loop.
+      };
+      /// Number of statistics for a slice.
+      static constexpr unsigned N_STAT_ID = unsigned(STAT_ID::LOOP_TIME_MAX) + 1;
+
+      /// Statistic name stems.
+      /// These will be qualfied by time scale.
+      static char const *const STAT_NAME[N_STAT_ID];
+
+      Slice() = default;
+    };
+
+    /** The number of slices.
+        This is a circular buffer, with one slice per second. We have a bit more than the required 1000
+        to provide sufficient slop for cross thread reading of the data (as only the current slice
+        is being updated).
+    */
+    static constexpr int N_SLICES = 1024;
+    /// The slices.
+    std::array<Slice, N_SLICES> _slice;
+
+    Slice *volatile current_slice = nullptr; ///< The current slice.
+
+    /** The number of time scales used in the event statistics.
+        Currently these are 10s, 100s, 1000s.
+    */
+    static constexpr unsigned N_TIMESCALES = 3;
+
+    /// # of samples for each time scale.
+    static constexpr std::array<unsigned, 3> SLICE_SAMPLE_COUNT = {10, 100, 1000};
+
+    /// Total # of stats created for slice metrics.
+    static constexpr unsigned N_SLICE_STATS = Slice::N_STAT_ID * N_TIMESCALES;
+
+    /// Back up the metric pointer, wrapping as needed.
+    Slice *prev_slice(Slice *current);
+    /// Advance the metric pointer, wrapping as needed.
+    Slice *next_slice(Slice *current);
+
+    /** Record a loop time sample in the histogram.
+     *
+     * @param delta Loop time.
+     * @return @a this
+     */
+    self_type &record_loop_time(ink_hrtime delta);
+
+    /** Record total api sample in the histogram.
+     *
+     * @param delta Duration.
+     * @return @a this
+     */
+    self_type &record_api_time(ink_hrtime delta);
+
+    /// Do any accumulated data decay that's required.
+    self_type &decay();
+
+    /// Base name for event loop histogram stats.
+    /// The actual stats are determined by the @c Histogram properties.
+    static constexpr ts::TextView LOOP_HISTOGRAM_STAT_STEM = "proxy.process.eventloop.time.";
+    /// Base bucket size for @c Graph
+    static constexpr ts_milliseconds LOOP_HISTOGRAM_BUCKET_SIZE{5};
+
+    /// Histogram type. 7,2 provides a reasonable range (5-2560 ms) and accuracy.
+    using Graph = ts::Histogram<7, 2>;
+    Graph _loop_timing; ///< Event loop timings.
+    /// Base name for event loop histogram stats.
+    /// The actual stats are determined by the @c Histogram properties.
+    static constexpr ts::TextView API_HISTOGRAM_STAT_STEM = "proxy.process.api.time.";
+    /// Base bucket size in milliseconds for plugin API timings.
+    static constexpr ts_milliseconds API_HISTOGRAM_BUCKET_SIZE{1};
+    Graph _api_timing; ///< Plugin API callout timings.
+
+    /// Data in the histogram needs to decay over time. To avoid races and locks the
+    /// summarizing thread bumps this to indicate a decay is needed and doesn't update if
+    /// this is non-zero. The event loop does the decay and decrements the count.
+    std::atomic<unsigned> _decay_count = 0;
+    /// Decay this often.
+    static inline std::chrono::duration _decay_delay = std::chrono::seconds{90};
+    /// Time of last decay.
+    static inline ts_clock::time_point _last_decay_time;
+
+    /// Total number of metric based statistics.
+    static constexpr unsigned N_STATS = N_SLICE_STATS + 2 * Graph::N_BUCKETS;
+
+    /// Summarize this instance into a global instance.
+    void summarize(self_type &global);
   };
 
-  /** The number of metric blocks kept.
-      This is a circular buffer, with one block per second. We have a bit more than the required 1000
-      to provide sufficient slop for cross thread reading of the data (as only the current metric block
-      is being updated).
-  */
-  static int const N_EVENT_METRICS = 1024;
-
-  volatile EventMetrics *current_metric = nullptr; ///< The current element of @a metrics
-  EventMetrics metrics[N_EVENT_METRICS];
-
-  /** The various stats provided to the administrator.
-      THE ORDER IS VERY SENSITIVE.
-      More than one part of the code depends on this exact order. Be careful and thorough when changing.
-  */
-  enum STAT_ID {
-    STAT_LOOP_COUNT,      ///< # of event loops executed.
-    STAT_LOOP_EVENTS,     ///< # of events
-    STAT_LOOP_EVENTS_MIN, ///< min # of events dispatched in a loop
-    STAT_LOOP_EVENTS_MAX, ///< max # of events dispatched in a loop
-    STAT_LOOP_WAIT,       ///< # of loops that did a conditional wait.
-    STAT_LOOP_TIME_MIN,   ///< Shortest time spent in loop.
-    STAT_LOOP_TIME_MAX,   ///< Longest time spent in loop.
-    N_EVENT_STATS         ///< NOT A VALID STAT INDEX - # of different stat types.
-  };
-
-  static char const *const STAT_NAME[N_EVENT_STATS];
-
-  /** The number of time scales used in the event statistics.
-      Currently these are 10s, 100s, 1000s.
-  */
-  static int const N_EVENT_TIMESCALES = 3;
-  /// # of samples for each time scale.
-  static int const SAMPLE_COUNT[N_EVENT_TIMESCALES];
-
-  /// Process the last 1000s of data and write out the summaries to @a summary.
-  void summarize_stats(EventMetrics summary[N_EVENT_TIMESCALES]);
-  /// Back up the metric pointer, wrapping as needed.
-  EventMetrics *
-  prev(EventMetrics volatile *current)
-  {
-    return const_cast<EventMetrics *>(--current < metrics ? &metrics[N_EVENT_METRICS - 1] : current); // cast to remove volatile
-  }
-  /// Advance the metric pointer, wrapping as needed.
-  EventMetrics *
-  next(EventMetrics volatile *current)
-  {
-    return const_cast<EventMetrics *>(++current > &metrics[N_EVENT_METRICS - 1] ? metrics : current); // cast to remove volatile
-  }
+  Metrics metrics;
 };
+
+// --- Inline implementation
+
+inline auto
+EThread::Metrics::Slice::record_loop_start(ink_hrtime t) -> self_type &
+{
+  _duration._start = t;
+  return *this;
+}
+
+inline auto
+EThread::Metrics::Slice::record_loop_duration(ink_hrtime delta) -> self_type &
+{
+  if (delta > _duration._max) {
+    _duration._max = delta;
+  }
+  if (delta < _duration._min) {
+    _duration._min = delta;
+  }
+  return *this;
+}
+
+inline auto
+EThread::Metrics::Slice::record_event_count(int count) -> self_type &
+{
+  if (count < _events._min) {
+    _events._min = count;
+  }
+  if (count > _events._max) {
+    _events._max = _count;
+  }
+  _events._total += count;
+  return *this;
+}
+
+inline EThread::Metrics::Slice *
+EThread::Metrics::prev_slice(EThread::Metrics::Slice *current)
+{
+  return --current < _slice.data() ? &_slice[N_SLICES - 1] : current;
+}
+
+inline EThread::Metrics::Slice *
+EThread::Metrics::next_slice(EThread::Metrics::Slice *current)
+{
+  return ++current > &_slice[N_SLICES - 1] ? _slice.data() : current;
+}
+
+inline auto
+EThread::Metrics::record_loop_time(ink_hrtime delta) -> self_type &
+{
+  static auto constexpr DIVISOR = std::chrono::duration_cast<ts_nanoseconds>(LOOP_HISTOGRAM_BUCKET_SIZE).count();
+  current_slice->record_loop_duration(delta);
+  _loop_timing(delta / DIVISOR);
+  return *this;
+}
+
+inline auto
+EThread::Metrics::record_api_time(ink_hrtime delta) -> self_type &
+{
+  static auto constexpr DIVISOR = std::chrono::duration_cast<ts_nanoseconds>(LOOP_HISTOGRAM_BUCKET_SIZE).count();
+  _api_timing(delta / DIVISOR);
+  return *this;
+}
+
+inline auto
+EThread::Metrics::decay() -> self_type &
+{
+  while (_decay_count) {
+    _loop_timing.decay();
+    _api_timing.decay();
+    --_decay_count;
+  }
+  return *this;
+}
 
 /**
   This is used so that we dont use up operator new(size_t, void *)

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -8438,14 +8438,11 @@ HttpSM::milestone_update_api_time()
     if (!active) {
       api_timer = -api_timer;
     }
-    delta     = Thread::get_hrtime_updated() - api_timer;
-    api_timer = 0;
     // Zero or negative time is a problem because we want to signal *something* happened
     // vs. no API activity at all. This can happen due to graininess or real time
     // clock adjustment.
-    if (delta <= 0) {
-      delta = 1;
-    }
+    delta     = std::max<ink_hrtime>(1, Thread::get_hrtime_updated() - api_timer);
+    api_timer = 0;
 
     if (0 == milestones[TS_MILESTONE_PLUGIN_TOTAL]) {
       milestones[TS_MILESTONE_PLUGIN_TOTAL] = milestones[TS_MILESTONE_SM_START];
@@ -8457,5 +8454,6 @@ HttpSM::milestone_update_api_time()
       }
       milestones[TS_MILESTONE_PLUGIN_ACTIVE] += delta;
     }
+    this_ethread()->metrics.record_api_time(delta);
   }
 }

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -175,6 +175,7 @@ test_tscore_SOURCES = \
 	unit_tests/test_BufferWriterFormat.cc \
 	unit_tests/test_CryptoHash.cc \
 	unit_tests/test_Extendible.cc \
+	unit_tests/test_Histogram.cc \
 	unit_tests/test_History.cc \
 	unit_tests/test_ink_inet.cc \
 	unit_tests/test_ink_memory.cc \

--- a/src/tscore/unit_tests/test_Histogram.cc
+++ b/src/tscore/unit_tests/test_Histogram.cc
@@ -1,0 +1,56 @@
+/** @file
+
+    Histogram unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <sstream>
+#include <catch.hpp>
+#include "tscpp/util/Histogram.h"
+
+// -------------
+// --- TESTS ---
+// -------------
+TEST_CASE("Histogram Basic", "[libts][histogram]")
+{
+  ts::Histogram<7, 2> h;
+
+  h(12);
+  REQUIRE(h[10] == 1);
+
+  REQUIRE(h.lower_bound(0) == 0);
+  REQUIRE(h.lower_bound(3) == 3);
+  REQUIRE(h.lower_bound(4) == 4);
+  REQUIRE(h.lower_bound(8) == 8);
+  REQUIRE(h.lower_bound(9) == 10);
+  REQUIRE(h.lower_bound(12) == 16);
+  REQUIRE(h.lower_bound(13) == 20);
+  REQUIRE(h.lower_bound(16) == 32);
+  REQUIRE(h.lower_bound(17) == 40);
+
+  for (auto x : {0, 1, 4, 6, 19, 27, 36, 409, 16000, 1097}) {
+    h(x);
+  }
+  REQUIRE(h[0] == 1);
+  REQUIRE(h[1] == 1);
+  REQUIRE(h[2] == 0);
+  REQUIRE(h[12] == 1); // sample 19 shoud be here.
+  REQUIRE(h[14] == 1); // sample 27 should be here.
+};


### PR DESCRIPTION
This is based on a problem I had at LinkedIn involving latency in requests. The event loop data looked as if the event loops were very long (billions of nanoseconds in some cases) but it wasn't possible to tell if this was the exception or the rule (i.e. is there a plugin that now and then blocks on an `ET_NET` thread, or are the plugins in general slowing things up?). This adds histogram data for event loop timing so it's possible to see

1. How relatively common long loops are.
2. Whether there a variety of timings for long loops, instead of tracking only the very longest.
3. Whether there are clusters at certain timings.

This should be backwards compatible with 9.x.

As part of this work, the `Histogram` class is added. It is designed to log samples performantly and provides a decay mechanism to keep the data relevant. These call all be adjusted by tweaking various compile time constants.