### PR TITLE
Reply with a 503 response when per_server.connection.max is exceeded

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5206,7 +5206,7 @@ HttpSM::do_http_server_open(bool raw)
       HTTP_INCREMENT_DYN_STAT(http_origin_connections_throttled_stat);
       ct_state.Warn_Blocked(&t_state.txn_conf->outbound_conntrack, sm_id, ccount - 1, &t_state.current.server->dst_addr.sa,
                             debug_on && is_debug_tag_set("http") ? "http" : nullptr);
-
+      send_origin_throttled_response();
       return;
     } else {
       ct_state.Note_Unblocked(&t_state.txn_conf->outbound_conntrack, ccount, &t_state.current.server->dst_addr.sa);


### PR DESCRIPTION
When the number of origin connections to a server exceeds proxy.config.http.per_server.connection.max, we should reply with a 503. This is done on master, but after a refactoring in 10-Dev, this was missed. This adds the call back in that replies with a 503 when the max is reached.

Fixes #9120

---

Note, this is only needed for, and only applies to, 10-Dev and should not be backported.