### PR TITLE
9.2: Fix s3_auth_config test output check

### DIFF
--- a/tests/gold_tests/pluginTest/s3_auth/s3_auth_config.test.py
+++ b/tests/gold_tests/pluginTest/s3_auth/s3_auth_config.test.py
@@ -62,5 +62,5 @@ tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = "gold/s3_auth_parsing.gold"
 tr.StillRunningAfter = server
 
-ts.Disk.traffic_out.Content = "gold/s3_auth_parsing_ts.gold"
+ts.Streams.stderr = "gold/s3_auth_parsing_ts.gold"
 ts.ReturnCode = 0


### PR DESCRIPTION
The way ATS output is checked has changed between master and 9.2.x. This updates the 9.2.x version of the test for the different expectations. Without this patch, the s3_auth_config test fails with an exception.