### PR TITLE
Fix a bug in H3 event handling

### DIFF
--- a/proxy/http3/Http3Transaction.cc
+++ b/proxy/http3/Http3Transaction.cc
@@ -356,13 +356,13 @@ Http3Transaction::state_stream_open(int event, void *edata)
     this->_info.read_vio->reenable();
     break;
   case VC_EVENT_READ_COMPLETE:
+    Http3TransVDebug("%s (%d)", get_vc_event_name(event), event);
+    this->_process_read_vio();
     if (!this->_header_handler->is_complete()) {
       // Delay processing READ_COMPLETE
       this_ethread()->schedule_imm(this, VC_EVENT_READ_COMPLETE);
       break;
     }
-    Http3TransVDebug("%s (%d)", get_vc_event_name(event), event);
-    this->_process_read_vio();
     this->_data_handler->finalize();
     // always signal regardless of progress
     this->_signal_read_event();


### PR DESCRIPTION
If there is no READ_READY event on a stream and READ_COMPLETE event is the first read event, current code can go into a infinite event loop because header handler never gets a chance to read incoming data.