### PR TITLE
Enable slice prefetching for range requests

### DIFF
--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -130,8 +130,9 @@ The slice plugin supports the following options::
         Default is 0
         Prefetches successive 'n' slice block requests in the background
         and caches (with `cache_range_requests` plugin). Prefetching is only
-        enabled when first block is a cacheable object with miss or hit-stale status.
-        Especially for large objects, prefetching can improve cache miss latency.
+        enabled when first block (of the client request) is a cacheable object
+        with miss or hit-stale status. Especially for large objects, prefetching
+        can improve cache miss latency.
         -f for short
 
 Examples::

--- a/plugins/experimental/slice/server.cc
+++ b/plugins/experimental/slice/server.cc
@@ -223,7 +223,8 @@ handleFirstServerHeader(Data *const data, TSCont const contp)
   data->m_bytessent = hbytes;
   TSVIOReenable(output_vio);
 
-  if (data->m_config->m_prefetchcount > 0 && header.hasKey(SLICE_CRR_HEADER.data(), SLICE_CRR_HEADER.size())) {
+  if (data->m_config->m_prefetchcount > 0 && data->m_blocknum == data->m_req_range.firstBlockFor(data->m_config->m_blockbytes) &&
+      header.hasKey(SLICE_CRR_HEADER.data(), SLICE_CRR_HEADER.size())) {
     data->m_prefetchable = true;
   }
 
@@ -478,6 +479,11 @@ handleNextServerHeader(Data *const data, TSCont const contp)
   }
 
   data->m_blockexpected = blockcr.rangeSize();
+
+  if (data->m_config->m_prefetchcount > 0 && data->m_blocknum == data->m_req_range.firstBlockFor(data->m_config->m_blockbytes) &&
+      header.hasKey(SLICE_CRR_HEADER.data(), SLICE_CRR_HEADER.size())) {
+    data->m_prefetchable = true;
+  }
 
   return true;
 }

--- a/plugins/experimental/slice/util.cc
+++ b/plugins/experimental/slice/util.cc
@@ -88,7 +88,8 @@ request_block(TSCont contp, Data *const data)
   }
 
   header.removeKey(SLICE_CRR_HEADER.data(), SLICE_CRR_HEADER.size());
-  if (data->m_blocknum == 0 && data->m_config->m_prefetchcount > 0) {
+  if (data->m_config->m_prefetchcount > 0 && data->m_req_range.m_beg >= 0 &&
+      data->m_blocknum == data->m_req_range.firstBlockFor(data->m_config->m_blockbytes)) {
     header.setKeyVal(SLICE_CRR_HEADER.data(), SLICE_CRR_HEADER.size(), SLICE_CRR_VAL.data(), SLICE_CRR_VAL.size());
   }
 
@@ -119,8 +120,8 @@ request_block(TSCont contp, Data *const data)
 
   // if prefetch config set, schedule next block requests in background
   if (data->m_prefetchable && data->m_config->m_prefetchcount > 0) {
-    int nextblocknum = 2;
-    if (data->m_blocknum > 1) {
+    int nextblocknum = data->m_blocknum + 1;
+    if (data->m_blocknum > data->m_req_range.firstBlockFor(data->m_config->m_blockbytes) + 1) {
       nextblocknum = data->m_blocknum + data->m_config->m_prefetchcount;
     }
     for (int i = nextblocknum; i <= data->m_blocknum + data->m_config->m_prefetchcount; i++) {

--- a/tests/gold_tests/pluginTest/slice/gold/slice_prefetch.gold
+++ b/tests/gold_tests/pluginTest/slice/gold/slice_prefetch.gold
@@ -12,16 +12,15 @@ bytes ``/18 hit-stale
 bytes ``/18 hit-stale
 bytes 14-17/18 hit-fresh
 - hit-stale, none
-bytes 0-4/18 miss
-bytes ``/18 ``
-bytes ``/18 ``
-bytes ``/18 ``
-bytes ``/18 ``
-bytes 15-17/18 hit-fresh
-bytes 0-17/18 miss, none
 bytes 0-6/18 hit-fresh
 bytes 7-13/18 hit-fresh
 bytes 14-17/18 hit-fresh
-bytes 5-16/18 hit-fresh, none
+bytes 0-17/18 hit-fresh, none
+bytes 0-4/18 miss
+bytes ``/18 miss
+bytes ``/18 miss
+bytes ``/18 miss
+bytes 15-17/18 hit-fresh
+bytes 5-16/18 miss, none
 bytes 0-6/18 hit-fresh
 */18 hit-fresh, none

--- a/tests/gold_tests/pluginTest/slice/slice_prefetch.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_prefetch.test.py
@@ -150,25 +150,26 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content += Testers.ContainsExpression("X-Cache: hit-stale", "expected cache hit-stale")
 tr.StillRunningAfter = ts
 
-# 3 Test - Full object slice (miss) with only blocks 10-14, 15-19 prefetched in background, block bytes= 5
-tr = Test.AddTestRun("Full object slice: first block is miss, only blocks 10-14, 15-19 prefetched")
+# 3 Test - Full object slice (hit-fresh) with no prefetched blocks, block bytes= 7
+tr = Test.AddTestRun("Full object slice: first block is hit-fresh with range 0-, no blocks prefetched")
 ps = tr.Processes.Default
-ps.Command = curl_and_args + ' http://sliceprefetchbytes2/path' + ' -r 0-'
+ps.Command = curl_and_args + ' http://sliceprefetchbytes1/path' + ' -r 0-'
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/slice_200.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 response")
 ps.Streams.stdout.Content += Testers.ContainsExpression("Content-Range: bytes 0-17/18", "mismatch byte content response")
-ps.Streams.stdout.Content += Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
+ps.Streams.stdout.Content += Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit-fresh")
 tr.StillRunningAfter = ts
 
-# 4 Test - Non aligned slice request
-tr = Test.AddTestRun("Non aligned slice request")
+# 4 Test - Client range request (hit-stale/miss) enables prefetching
+tr = Test.AddTestRun("Client range request")
 ps = tr.Processes.Default
-ps.Command = curl_and_args + ' http://sliceprefetchbytes1/path' + ' -r 5-16'
+ps.Command = curl_and_args + ' http://sliceprefetchbytes2/path' + ' -r 5-16'
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/slice_mid.stderr.gold"
 ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 response")
 ps.Streams.stdout.Content += Testers.ContainsExpression("Content-Range: bytes 5-16/18", "mismatch byte content response")
+ps.Streams.stdout.Content += Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 tr.StillRunningAfter = ts
 
 # 5 Test - special case, begin inside last slice block but outside asset len


### PR DESCRIPTION
Currently slice's prefetching feature relies only on the reference block (block 0 of the full object) to determine whether the successive blocks should be prefetched. This new update uses the first block of the client request as opposed to the first block of the full object (bytes=0-)
- Doesn't change functionality for full get request
- Doesn't change how reference block is used, only adds prefetching to be enabled when conditions are met on the first block of the client request (cacheable, hit-stale/miss status)