### PR TITLE
Adding regex capability based on pristine host name

### DIFF
--- a/doc/admin-guide/plugins/maxmind_acl.en.rst
+++ b/doc/admin-guide/plugins/maxmind_acl.en.rst
@@ -50,9 +50,11 @@ An example configuration ::
       - DE
      ip:
       - 127.0.0.1
-     regex:
+     regex_path:
       - [US, ".*\\.txt"]  # Because these get parsed you must escape the escape of the ``.`` in order to have it be escaped in the regex, resulting in ".*\.txt"
       - [US, ".*\\.mp3"]
+     regex_host:
+      - [US, ".*test.*"]
 
 In order to load an updated configuration while ATS is running you will have to touch or modify the remap.config file in order to initiate a plugin reload to pull in any changes.
 
@@ -64,6 +66,12 @@ The IP rules can take either single IPs or cidr formatted rules. It will also ac
 
 The regex portion can be added to both the allow and deny sections for creating allowable or deniable regexes. Each regex takes a country code first and a regex second.
 In the above example all requests from the US would be allowed except for those on ``txt`` and ``mp3`` files. More rules should be added as pairs, not as additions to existing lists.
+
+*NOTE* ``regex`` will continue to work but has been deprecated in favor of ``regex_path``. Either will match on the path currently.
+
+You can also specify ``regex_host`` which will match based on the pristine (pre-remapped) fqdn. This can be useful depending on particular automation setups where you may have
+multiple generated remap lines just with slight differences (such as a country code) but wish to have a single MaxMind configuration. For these instances you can 
+use the regex_host field to then allow or deny specific country codes to matching fqdns. In the above instance it will block all US IP when the request entered on any fqdn matching ``test``.
 
 Currently the only rules available are ``country``, ``ip``, and ``regex``, though more can easily be added if needed. Each config file does require a top level
 ``maxmind`` entry as well as a ``database`` entry for the IP lookups.  You can supply a separate database for each remap used in case you use custom

--- a/doc/admin-guide/plugins/maxmind_acl.en.rst
+++ b/doc/admin-guide/plugins/maxmind_acl.en.rst
@@ -70,7 +70,7 @@ In the above example all requests from the US would be allowed except for those 
 *NOTE* ``regex`` will continue to work but has been deprecated in favor of ``regex_path``. Either will match on the path currently.
 
 You can also specify ``regex_host`` which will match based on the pristine (pre-remapped) fqdn. This can be useful depending on particular automation setups where you may have
-multiple generated remap lines just with slight differences (such as a country code) but wish to have a single MaxMind configuration. For these instances you can 
+multiple generated remap lines just with slight differences (such as a country code) but wish to have a single MaxMind configuration. For these instances you can
 use the regex_host field to then allow or deny specific country codes to matching fqdns. In the above instance it will block all US IP when the request entered on any fqdn matching ``test``.
 
 Currently the only rules available are ``country``, ``ip``, and ``regex``, though more can easily be added if needed. Each config file does require a top level

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -551,7 +551,7 @@ Acl::eval(TSRemapRequestInfo *rri, TSHttpTxn txnp)
 #endif
 
       MMDB_entry_data_s entry_data;
-      int path_len, host_len = 0;
+      int path_len = 0, host_len = 0;
       const char *path = nullptr;
       const char *host = nullptr;
       if (!allow_regex_path.empty() || !deny_regex_path.empty()) {


### PR DESCRIPTION
Adds a new `regex_host` field to the maxmind plugin and also renames `regex` to `regex_path`. This allows doing regex based allow/deny based on the pristine hostname that the request came in on which can be useful for a variety of scenarios