### PR TITLE
AuTest automatic keylog file configuration

### DIFF
--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -339,6 +339,14 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
     get_port(p, "manager_port")
     get_port(p, "admin_port")
 
+    if enable_tls or enable_quic:
+        fname = "tls_session_keys.txt"
+        tmpname = os.path.join(log_dir, fname)
+        p.Disk.File(tmpname, id='tls_session_keys')
+        p.Disk.records_config.update({
+            'proxy.config.ssl.keylog_file': tmpname,
+        })
+
     if enable_cache:
         # In records.config, the cache is enabled by default so there's nothing
         # we have to do here to functionally enable it. However, the tests that

--- a/tests/gold_tests/forward_proxy/forward_proxy.test.py
+++ b/tests/gold_tests/forward_proxy/forward_proxy.test.py
@@ -68,7 +68,6 @@ class ForwardProxyTest:
             'proxy.config.ssl.server.cert.path': self.ts.Variables.SSLDir,
             'proxy.config.ssl.server.private_key.path': self.ts.Variables.SSLDir,
             'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-            'proxy.config.ssl.keylog_file': '/tmp/keylog.txt',
 
             'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': "http",

--- a/tests/gold_tests/h2/http2_flow_control.test.py
+++ b/tests/gold_tests/h2/http2_flow_control.test.py
@@ -107,7 +107,6 @@ class Http2FlowControlTest:
             'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
             'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
             'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(self._dns.Variables.Port),
-            'proxy.config.ssl.keylog_file': os.path.join(Test.RunDirectory, 'tls_session_keys.txt'),
 
             'proxy.config.diags.debug.enabled': 3,
             'proxy.config.diags.debug.tags': 'http',

--- a/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
+++ b/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
@@ -111,7 +111,6 @@ class MultiplexerTestBase:
             "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
             "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
             "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
-            'proxy.config.ssl.keylog_file': '/tmp/tls_session_keys.txt',
 
             'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': 'multiplexer',

--- a/tests/gold_tests/tls/tls_session_key_logging.test.py
+++ b/tests/gold_tests/tls/tls_session_key_logging.test.py
@@ -66,6 +66,10 @@ class TlsKeyloggingTest:
 
         keylog_file = os.path.join(self.ts.Variables.LOGDIR, "tls_secrets.txt")
 
+        # Remove the keylog_file configuration automatically configured via the
+        # trafficserver AuTest extension.
+        del self.ts.Disk.records_config['proxy.config.ssl.keylog_file']
+
         if enable_secrets_logging:
             self.ts.Disk.records_config.update({
                 'proxy.config.ssl.keylog_file': keylog_file,


### PR DESCRIPTION
Some tests have ad hoc TLS keylogging configured in case it is helpful for analyzing TLS traffic later. This modifies the AuTest Traffic Server process extension to automatically configure keylogging and to place it in the Traffic Server process's log directory, which should be available to the process in all CI environments.