### PR TITLE
Traffic Dump: fix YAML format for CONNECT requests

### DIFF
--- a/plugins/experimental/traffic_dump/transaction_data.cc
+++ b/plugins/experimental/traffic_dump/transaction_data.cc
@@ -367,7 +367,14 @@ TransactionData::write_proxy_request_node(TSMBuffer &buffer, TSMLoc &hdr_loc)
 {
   std::ostringstream proxy_request_node;
   proxy_request_node << R"(,"proxy-request":{)";
-  proxy_request_node << _server_protocol_description + ",";
+  // For CONNECT requests, the _server_protocol_description will be empty
+  // because it gets populated on receipt of an HTTP response. For tunnels, we
+  // establish a connection to the origin for the tunnel but don't send an HTTP
+  // request nor does the server send a response. Therefore the protocol is
+  // never populated and will be empty here.
+  if (!_server_protocol_description.empty()) {
+    proxy_request_node << _server_protocol_description + ",";
+  }
   proxy_request_node << write_message_node(buffer, hdr_loc, TSHttpTxnServerReqBodyBytesGet(_txnp));
   _txn_json += proxy_request_node.str();
 }

--- a/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump.yaml
+++ b/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump.yaml
@@ -333,3 +333,38 @@ sessions:
     proxy-response:
       status: 200
 
+- transactions:
+  - client-request:
+      method: CONNECT
+      url: www.connect_target.com:443/tunnel/me
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.connect_target.com ]
+        - [ X-Request-1, request_tunnel ]
+        - [ Content-Length, 0 ]
+        - [ uuid, tunnel ]
+
+    proxy-request:
+      headers:
+        fields:
+        # The field should get through to the server. The traffic dump, though,
+        # should not contain it since x-request-1 is a sensitive field.
+        - [ X-Request-1, { value: request_tunnel, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ X-Response-1,  response_tunnel ]
+
+    proxy-response:
+      status: 200
+      headers:
+        field:
+        # Again, the sensitive set-cookie should get through to the client, it
+        # just shouldn't be dumped in traffic dumps.
+        - [ X-Response-1, { value: response_tunnel, as: equal } ]
+


### PR DESCRIPTION
For CONNECT requests, Traffic Dump will not have a server-side protocol stack because we populate that on response from the server. Since the connection is left open for tunneling, it never gets populated. This resulted in mal-formed YAML because we had an empty string followed by a ','.