### PR TITLE
Remove deprecated ld option (--add-needed)

### DIFF
--- a/build/jemalloc.m4
+++ b/build/jemalloc.m4
@@ -58,7 +58,7 @@ if test "$has_jemalloc" != "no"; then
   if test "$jemalloc_base_dir" != "/usr"; then
     TS_ADDTO(CPPFLAGS, [-I${jemalloc_include}])
     TS_ADDTO(LDFLAGS, [-L${jemalloc_ldflags}])
-    TS_ADDTO(LDFLAGS, [-Wl,--add-needed -L${jemalloc_ldflags} -Wl,-rpath,${jemalloc_ldflags} -Wl,--no-as-needed])
+    TS_ADDTO(LDFLAGS, [-Wl,--as-needed -L${jemalloc_ldflags} -Wl,-rpath,${jemalloc_ldflags} -Wl,--no-as-needed])
     TS_ADDTO_RPATH(${jemalloc_ldflags})
   fi
   # On Darwin, jemalloc symbols are prefixed with je_. Search for that first, then fall back

--- a/build/mimalloc.m4
+++ b/build/mimalloc.m4
@@ -62,7 +62,7 @@ if test "$has_mimalloc" != "no"; then
   if test "$mimalloc_base_dir" != "/usr"; then
     TS_ADDTO(CPPFLAGS, [-I${mimalloc_include}])
     TS_ADDTO(LDFLAGS, [-L${mimalloc_ldflags}])
-    TS_ADDTO(LDFLAGS, [-Wl,--add-needed -L${mimalloc_ldflags} -Wl,-rpath,${mimalloc_ldflags} -Wl,--no-as-needed])
+    TS_ADDTO(LDFLAGS, [-Wl,--as-needed -L${mimalloc_ldflags} -Wl,-rpath,${mimalloc_ldflags} -Wl,--no-as-needed])
     TS_ADDTO_RPATH(${mimalloc_ldflags})
   fi
   AC_SEARCH_LIBS([mi_malloc], [mimalloc], [mimalloc_has_libs=1])


### PR DESCRIPTION
While I'm trying mimalloc (and jemalloc) with llvm toolchain (`lld`), I got the below error.

```
ld.lld: error: unknown argument '--add-needed'
```

It looks like `lld` doesn't support this option. Also `ld` deprecated this option.

> --add-needed
--no-add-needed
These two options have been deprecated because of the similarity of their names to the --as-needed and --no-as-needed options. They have been replaced by --copy-dt-needed-entries and --no-copy-dt-needed-entries.

https://sourceware.org/binutils/docs/ld/Options.html