### PR TITLE
10-Dev: Remove MakeATSProcess default paramater invocations in AuTests

### DIFF
--- a/tests/gold_tests/cache/cache-generation-clear.test.py
+++ b/tests/gold_tests/cache/cache-generation-clear.test.py
@@ -23,7 +23,7 @@ Test that incrementing the cache generation acts like a cache clear
 '''
 Test.ContinueOnFail = True
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # setup some config file for this server
 ts.Disk.records_config.update({

--- a/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
@@ -25,7 +25,7 @@ Test unsupported values for chunked_encoding
 Test.ContinueOnFail = True
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts1", enable_tls=False)
+ts = Test.MakeATSProcess("ts1")
 server = Test.MakeOriginServer("server")
 
 testName = ""

--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -24,7 +24,7 @@ Test transactions and sessions for http1, making sure the two continuations catc
 
 Test.ContinueOnFail = True
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 server = Test.MakeOriginServer("server")
 
 Test.testName = ""

--- a/tests/gold_tests/continuations/double_h2.test.py
+++ b/tests/gold_tests/continuations/double_h2.test.py
@@ -26,7 +26,7 @@ Test.SkipUnless(
 )
 Test.ContinueOnFail = True
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", enable_tls=True, command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 server = Test.MakeOriginServer("server")
 server2 = Test.MakeOriginServer("server2")
 

--- a/tests/gold_tests/continuations/openclose.test.py
+++ b/tests/gold_tests/continuations/openclose.test.py
@@ -23,7 +23,7 @@ Test transactions and sessions, making sure they open and close in the proper or
 '''
 
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 
 server = Test.MakeOriginServer("server")
 server2 = Test.MakeOriginServer("server2")

--- a/tests/gold_tests/continuations/openclose_h2.test.py
+++ b/tests/gold_tests/continuations/openclose_h2.test.py
@@ -27,7 +27,7 @@ Test.SkipUnless(
 )
 
 # Define default ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", enable_tls=True, command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 
 
 server = Test.MakeOriginServer("server")

--- a/tests/gold_tests/continuations/session_id.test.py
+++ b/tests/gold_tests/continuations/session_id.test.py
@@ -34,7 +34,7 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-L
 server.addResponse("sessionfile.log", request_header, response_header)
 
 # Configure ATS. Disable the cache to simplify the test.
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True, enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 
 ts.addDefaultSSLFiles()
 

--- a/tests/gold_tests/headers/forwarded.test.py
+++ b/tests/gold_tests/headers/forwarded.test.py
@@ -192,7 +192,7 @@ TestHttp1_1('www.forwarded-connection-compact.com')
 TestHttp1_1('www.forwarded-connection-std.com')
 TestHttp1_1('www.forwarded-connection-full.com')
 
-ts2 = Test.MakeATSProcess("ts2", command="traffic_server", enable_tls=True)
+ts2 = Test.MakeATSProcess("ts2", enable_tls=True)
 
 baselineTsSetup(ts2)
 

--- a/tests/gold_tests/ip_allow/ip_allow.test.py
+++ b/tests/gold_tests/ip_allow/ip_allow.test.py
@@ -24,8 +24,7 @@ Verify ip_allow filtering behavior.
 Test.ContinueOnFail = True
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server",
-                         enable_tls=True, enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 server = Test.MakeOriginServer("server", ssl=True)
 
 testName = ""

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
@@ -34,7 +34,7 @@ Test.ContinueOnFail = False
 Test.testName = "cache_range_requests"
 
 # Define and configure ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # Define and configure origin server
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cache_complete_responses.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cache_complete_responses.test.py
@@ -59,7 +59,7 @@ for i in range(slice_body_len):
     slice_body += 'x'
 
 # Define and configure ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # Define and configure origin server
 server = Test.MakeOriginServer("server", lookup_key="{%UID}")

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey.test.py
@@ -34,7 +34,7 @@ Test.ContinueOnFail = False
 Test.testName = "cache_range_requests_cachekey"
 
 # Define and configure ATS, enable traffic_ctl config reload
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # Define and configure origin server
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey_global.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey_global.test.py
@@ -34,7 +34,7 @@ Test.ContinueOnFail = False
 Test.testName = "cache_range_requests_cachekey_global"
 
 # Define and configure ATS, enable traffic_ctl config reload
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # Define and configure origin server
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
@@ -35,7 +35,7 @@ Test.ContinueOnFail = False
 Test.testName = "cache_range_requests_ims"
 
 # Define and configure ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # Define and configure origin server
 server = Test.MakeOriginServer("server")

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -36,7 +36,7 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionlog.json", request_header, response_header)
 
 # Set up ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=1)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 
 # Set up ssl files
 ts.addSSLfile("ssl/server1.pem")

--- a/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
+++ b/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
@@ -25,7 +25,7 @@ Test client_context_dump plugin
 Test.SkipUnless(Condition.PluginExists('client_context_dump.so'))
 
 # Set up ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 
 # Set up ssl files
 ts.addSSLfile("ssl/one.com.pem")

--- a/tests/gold_tests/pluginTest/lua/lua_debug_tags.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_debug_tags.test.py
@@ -28,7 +28,7 @@ Test.SkipUnless(
 
 Test.ContinueOnFail = False
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 ts.Disk.remap_config.AddLine(
     'map http://test http://127.0.0.1/ @plugin=tslua.so @pparam=tags.lua'

--- a/tests/gold_tests/pluginTest/money_trace/money_trace.test.py
+++ b/tests/gold_tests/pluginTest/money_trace/money_trace.test.py
@@ -27,7 +27,7 @@ Test.ContinueOnFail = False
 Test.testName = "money_trace remap"
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 
 # configure origin server
 server = Test.MakeOriginServer("server")

--- a/tests/gold_tests/pluginTest/money_trace/money_trace_global.test.py
+++ b/tests/gold_tests/pluginTest/money_trace/money_trace_global.test.py
@@ -29,7 +29,7 @@ Test.ContinueOnFail = False
 Test.testName = "money_trace global"
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 
 # configure origin server
 server = Test.MakeOriginServer("server")

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -44,7 +44,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 Test.testName = "regex_revalidate"
 Test.Setup.Copy("metrics.sh")

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
@@ -38,7 +38,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 Test.testName = "regex_revalidate_miss"
 Test.Setup.Copy("metrics_miss.sh")

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_state.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_state.test.py
@@ -35,7 +35,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # **testname is required**
 testName = "regex_revalidate_state"

--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
@@ -30,7 +30,7 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
                    "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 ts.Disk.plugin_config.AddLine('remap_stats.so')
 

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -34,7 +34,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # default root
 request_header_chk = {"headers":

--- a/tests/gold_tests/pluginTest/slice/slice_error.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_error.test.py
@@ -34,7 +34,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server", lookup_key="{%Range}{PATH}")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 
 body = "the quick brown fox"  # len 19
 

--- a/tests/gold_tests/pluginTest/slice/slice_prefetch.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_prefetch.test.py
@@ -36,7 +36,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server", lookup_key="{%Range}")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 block_bytes_1 = 7
 block_bytes_2 = 5

--- a/tests/gold_tests/pluginTest/slice/slice_regex.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_regex.test.py
@@ -34,7 +34,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server")
 
 # Define ATS and configure.
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 
 # default root
 request_header_chk = {"headers":

--- a/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
@@ -47,7 +47,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 # default root
 req_header_chk = {"headers":

--- a/tests/gold_tests/pluginTest/test_hooks/hook_add.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/hook_add.test.py
@@ -30,7 +30,7 @@ request_header = {
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts = Test.MakeATSProcess("ts", enable_tls=False, enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'test',

--- a/tests/gold_tests/pluginTest/test_hooks/ssn_start_delay_hook.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/ssn_start_delay_hook.test.py
@@ -30,7 +30,7 @@ request_header = {
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts = Test.MakeATSProcess("ts", enable_tls=False)
+ts = Test.MakeATSProcess("ts")
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'test',

--- a/tests/gold_tests/remap/conf_remap_float.test.py
+++ b/tests/gold_tests/remap/conf_remap_float.test.py
@@ -20,7 +20,7 @@ Test command: traffic_ctl config describe proxy.config.http.background_fill_comp
 '''
 Test.testName = 'Float in conf_remap Config Test'
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 ts.Disk.MakeConfigFile('conf_remap.config').AddLines([
     'CONFIG proxy.config.http.background_fill_completed_threshold FLOAT 0.500000'

--- a/tests/gold_tests/tls/ssl_multicert_loader.test.py
+++ b/tests/gold_tests/tls/ssl_multicert_loader.test.py
@@ -20,7 +20,7 @@ Test reloading ssl_multicert.config with errors and keeping around the old ssl c
 
 sni_domain = 'example.com'
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 server = Test.MakeOriginServer("server")
 server2 = Test.MakeOriginServer("server3")
 request_header = {"headers": f"GET / HTTP/1.1\r\nHost: {sni_domain}\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -95,7 +95,7 @@ tr3.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_doma
 # Also, not explicitly setting proxy.config.ssl.server.multicert.exit_on_load_fail
 # to catch if the current default (1) changes in the future
 
-ts2 = Test.MakeATSProcess("ts2", command="traffic_server", enable_tls=True)
+ts2 = Test.MakeATSProcess("ts2", enable_tls=True)
 ts2.Disk.ssl_multicert_config.AddLines([
     'dest_ip=* ssl_cert_name=server.pem_doesnotexist ssl_key_name=server.key',
 ])

--- a/tests/gold_tests/tls/tls_check_cert_select_plugin.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_select_plugin.test.py
@@ -23,7 +23,7 @@ Test ATS offering different certificates based on SNI. Load via plugin
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 server = Test.MakeOriginServer("server", ssl=True)
 dns = Test.MakeDNServer("dns")
 

--- a/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
@@ -21,7 +21,7 @@ Test ATS offering different certificates based on SNI
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 server = Test.MakeOriginServer("server", ssl=True)
 server3 = Test.MakeOriginServer("server3", ssl=True)
 

--- a/tests/gold_tests/tls/tls_client_cert.test.py
+++ b/tests/gold_tests/tls/tls_client_cert.test.py
@@ -21,7 +21,7 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 # --clientverify: "" empty string because microserver does store_true for argparse, but options is a dictionary

--- a/tests/gold_tests/tls/tls_client_cert2.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2.test.py
@@ -21,7 +21,7 @@ Test.Summary = '''
 Test client certs to origin selected via wildcard names in sni
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 server = Test.MakeOriginServer("server",

--- a/tests/gold_tests/tls/tls_client_cert2_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2_plugin.test.py
@@ -24,7 +24,7 @@ Test.Summary = '''
 Test offering client cert to origin, but using plugin for cert loading
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 server = Test.MakeOriginServer("server",

--- a/tests/gold_tests/tls/tls_client_cert_override.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_override.test.py
@@ -21,7 +21,7 @@ Test.Summary = '''
 Test conf_remp to specify different client certificates to offer to the origin
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 server = Test.MakeOriginServer("server",

--- a/tests/gold_tests/tls/tls_client_cert_override_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_override_plugin.test.py
@@ -21,7 +21,7 @@ Test conf_remp to specify different client certificates to offer to the origin. 
 '''
 
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)

--- a/tests/gold_tests/tls/tls_client_cert_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_plugin.test.py
@@ -24,7 +24,7 @@ Test.Summary = '''
 Test offering client cert to origin, but using plugin for cert loading
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server")
+ts = Test.MakeATSProcess("ts")
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 # --clientverify: "" empty string because microserver does store_true for argparse, but options is a dictionary

--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -22,7 +22,7 @@ Test.Summary = '''
 Test various options for requiring certificate from client for mutual authentication TLS
 '''
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
 server = Test.MakeOriginServer("server")

--- a/tests/gold_tests/tls/tls_sni_yaml_reload.test.py
+++ b/tests/gold_tests/tls/tls_sni_yaml_reload.test.py
@@ -21,7 +21,7 @@ Test reloading sni.yaml behaves as expected
 
 sni_domain = 'example.com'
 
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 server = Test.MakeOriginServer("server")
 server2 = Test.MakeOriginServer("server3")
 request_header = {"headers": f"GET / HTTP/1.1\r\nHost: {sni_domain}\r\n\r\n", "timestamp": "1469733493.993", "body": ""}

--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -21,7 +21,7 @@ Test tunneling based on SNI
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_tls=True)
+ts = Test.MakeATSProcess("ts", enable_tls=True)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True)
 server_bar = Test.MakeOriginServer("server_bar", ssl=True)
 server2 = Test.MakeOriginServer("server2")

--- a/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
+++ b/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
@@ -24,7 +24,7 @@ Test.ContinueOnFail = False
 Test.Setup.Copy("wait_reload.sh")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
+ts = Test.MakeATSProcess("ts", enable_cache=False)
 nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
 ts.Disk.File(ts.Variables.CONFIGDIR + "/test.inc", id="test_cfg", typename="ats:config")


### PR DESCRIPTION
This removes the use of explicit default parameter invocations of the Test.MakeATSProcess in the AuTests.

---

# For Review

The great preponderance of this patch is removing `command="traffic_server"` which is particularly unnecessary in 10-Dev because the traffic_manager process has been removed.