### PR TITLE
TSan: Fix data race of RecMutex::thread_holding

### DIFF
--- a/include/records/I_RecMutex.h
+++ b/include/records/I_RecMutex.h
@@ -26,6 +26,8 @@
 #include "tscore/ink_mutex.h"
 #include "tscore/ink_thread.h"
 
+#include <atomic>
+
 /**
   A wrapper to ink_mutex class. It allows multiple acquire of mutex lock
   by the SAME thread. This is a trimmed down version of ProxyMutex.
@@ -33,7 +35,7 @@
 */
 struct RecMutex {
   size_t nthread_holding;
-  ink_thread thread_holding;
+  std::atomic<ink_thread> thread_holding;
   ink_mutex the_mutex;
 };
 

--- a/src/records/RecMutex.cc
+++ b/src/records/RecMutex.cc
@@ -45,7 +45,7 @@ rec_mutex_acquire(RecMutex *m)
 {
   ink_thread this_thread = ink_thread_self();
 
-  if (m->thread_holding != this_thread) {
+  if (!pthread_equal(m->thread_holding, this_thread)) {
     ink_mutex_acquire(&(m->the_mutex));
     m->thread_holding = this_thread;
   }


### PR DESCRIPTION
Fix below TSan report.
```
WARNING: ThreadSanitizer: data race (pid=2305)
  Read of size 8 at 0x00001461a4d0 by thread T4 (mutexes: write M0, write M1, read M2):
    #0 rec_mutex_acquire(RecMutex*) RecMutex.cc:48 (traffic_server:x86_64+0x515e4d) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #1 RecGetRecord_Xmalloc(char const*, RecDataT, RecData*, bool) RecCore.cc:931 (traffic_server:x86_64+0x508b88) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #2 REC_ConfigReadInteger(char const*) RecCore.cc:1064 (traffic_server:x86_64+0x50bb77) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #3 DiagsLogContinuation::periodic(int, Event*) traffic_server.cc:394 (traffic_server:x86_64+0x7981c) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #4 EThread::process_event(Event*, int) UnixEThread.cc:153 (traffic_server:x86_64+0x52283b) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #5 EThread::execute_regular() UnixEThread.cc:258 (traffic_server:x86_64+0x52379f) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #6 EThread::execute() UnixEThread.cc:349 (traffic_server:x86_64+0x5241d9) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #7 spawn_thread_internal(void*) Thread.cc:79 (traffic_server:x86_64+0x521258) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)

  Previous write of size 8 at 0x00001461a4d0 by main thread (mutexes: write M3, write M4, write M5, write M6, write M7, write M8, write M9, write M10, write M11, write M12, write M13, write M14, write M15, write M16, write M17):
    #0 rec_mutex_acquire(RecMutex*) RecMutex.cc:50 (traffic_server:x86_64+0x515e6e) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #1 RecConfigWarnIfUnregistered() RecCore.cc:1288 (traffic_server:x86_64+0x50c7fa) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #2 main traffic_server.cc:2192 (traffic_server:x86_64+0x70767) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)

  Location is heap block of size 520000 at 0x000014601000 allocated by main thread:
    #0 malloc <null>:293963721 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x3732c) (BuildId: 065b6c81cd87343dafd65694f305ecb72400000010000000000a0a0000030c00)
    #1 ats_malloc ink_memory.cc:64 (libtscore.10.dylib:x86_64+0x4381f) (BuildId: 1386e942a0b13818b09d1adaec428fdd32000000200000000100000000000c00)
    #2 RecCoreInit(RecModeT, Diags*) RecCore.cc:206 (traffic_server:x86_64+0x507b86) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #3 RecProcessInit(RecModeT, Diags*) RecProcess.cc:214 (traffic_server:x86_64+0x51b13d) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #4 main traffic_server.cc:1783 (traffic_server:x86_64+0x6de6a) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
```

We probably need to fix `ProxyMutex::thread_holding` too. ( I haven't faced the TSan report about it yet )