### PR TITLE
TSan: Fix data race of g_num_records

### DIFF
--- a/src/records/P_RecCore.cc
+++ b/src/records/P_RecCore.cc
@@ -655,6 +655,8 @@ RecExecConfigUpdateCbs(unsigned int update_required_type)
   int i, num_records;
   RecUpdateT update_type = RECU_NULL;
 
+  ink_rwlock_rdlock(&g_records_rwlock);
+
   num_records = g_num_records;
   for (i = 0; i < num_records; i++) {
     r = &(g_records[i]);
@@ -686,6 +688,8 @@ RecExecConfigUpdateCbs(unsigned int update_required_type)
     }
     rec_mutex_release(&(r->lock));
   }
+
+  ink_rwlock_unlock(&g_records_rwlock);
 
   return update_type;
 }

--- a/src/records/RecUtils.cc
+++ b/src/records/RecUtils.cc
@@ -55,7 +55,7 @@ RecAlloc(RecT rec_type, const char *name, RecDataT data_type)
     return nullptr;
   }
 
-  int i        = ink_atomic_increment(&g_num_records, 1);
+  int i        = g_num_records++;
   RecRecord *r = &(g_records[i]);
 
   RecRecordInit(r);


### PR DESCRIPTION
Fix below TSan report.

```
WARNING: ThreadSanitizer: data race (pid=2377)
  Read of size 4 at 0x00001020f720 by thread T18 (mutexes: write M0, write M1):
    #0 RecExecConfigUpdateCbs(unsigned int) P_RecCore.cc:658 (traffic_server:x86_64+0x5042db) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #1 config_update_cont::exec_callbacks(int, Event*) RecProcess.cc:161 (traffic_server:x86_64+0x51cb6c) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #2 EThread::process_event(Event*, int) UnixEThread.cc:153 (traffic_server:x86_64+0x52283b) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #3 EThread::execute_regular() UnixEThread.cc:258 (traffic_server:x86_64+0x52379f) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #4 EThread::execute() UnixEThread.cc:349 (traffic_server:x86_64+0x5241d9) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #5 spawn_thread_internal(void*) Thread.cc:79 (traffic_server:x86_64+0x521258) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)

  Previous atomic write of size 4 at 0x00001020f720 by thread T8 (mutexes: write M2, write M3, write M4):
    #0 RecAlloc(RecT, char const*, RecDataT) RecUtils.cc:58 (traffic_server:x86_64+0x5190b9) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #1 register_record(RecT, char const*, RecDataT, RecData, RecPersistT, bool*) RecCore.cc:88 (traffic_server:x86_64+0x50ade4) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #2 RecRegisterStat(RecT, char const*, RecDataT, RecData, RecPersistT) RecCore.cc:865 (traffic_server:x86_64+0x50aae5) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #3 _RecRegisterRawStat(RecRawStatBlock*, RecT, char const*, RecDataT, RecPersistT, int, int (*)(char const*, RecDataT, RecData*, RecRawStatBlock*, int)) RecRawStats.cc:262 (traffic_server:x86_64+0x5161de) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #4 register_cache_stats(RecRawStatBlock*, char const*) Cache.cc:3136 (traffic_server:x86_64+0x35adfb) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #5 CacheProcessor::diskInitialized() Cache.cc:822 (traffic_server:x86_64+0x352c5c) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #6 CacheDisk::openStart(int, void*) CacheDisk.cc:208 (traffic_server:x86_64+0x380309) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #7 AIOCallbackInternal::io_complete(int, void*) P_AIO.h:122 (traffic_server:x86_64+0x3d7dad) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #8 EThread::process_event(Event*, int) UnixEThread.cc:153 (traffic_server:x86_64+0x52283b) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #9 EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*) UnixEThread.cc:188 (traffic_server:x86_64+0x522f6f) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #10 EThread::execute_regular() UnixEThread.cc:244 (traffic_server:x86_64+0x523721) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #11 EThread::execute() UnixEThread.cc:349 (traffic_server:x86_64+0x5241d9) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)
    #12 spawn_thread_internal(void*) Thread.cc:79 (traffic_server:x86_64+0x521258) (BuildId: fd5ac86be47a3d099e1161ab8724ba5432000000200000000100000000000c00)

  Location is global 'g_num_records' at 0x00001020f720 (traffic_server+0x746720)
```

It looks like the `g_records_rwlock` is the guard of access to the `g_records`, `g_records_ht`, and `g_num_records`, (global variables and shared across threads).
https://github.com/apache/trafficserver/blob/3e4eb4eb4b1272dd7b2cd584d64b347bbb4336ef/src/records/RecCore.cc#L41-L44

1. `RecAlloc()` is always called under the write lock of `g_records_rwlock`. We don't need atomic increment.
2. `RecExecConfigUpdateCbs()` needs the read lock of `g_records_rwlock` to refer the `g_num_records` and `g_records`.