### PR TITLE
Add ThreadSanitizer suppressions file to ignore data race of freelist

### DIFF
--- a/.tsan_suppressions
+++ b/.tsan_suppressions
@@ -1,0 +1,27 @@
+#
+#  ThreadSanitizer suppressions file
+#
+#  ```
+#  TSAN_OPTIONS="suppressions=/PATH/TO/THE/.tsan_suppressions" ./traffic_server
+#  ```
+#
+#  https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Ignore data race of freelist
+race:freelist_new


### PR DESCRIPTION
TSan detects some data race with freelist. However, it looks like these are false positives because the freelist is recycled.

The format of the suppression file is below.
https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions

```
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=31765)
  Write of size 8 at 0x7ba80000bb80 by thread T12:
    #0 initialize_thread_for_net(EThread*) UnixNet.cc:254 (traffic_server:x86_64+0x4cd59f) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #1 (anonymous namespace)::ThreadInitByFunc::invoke(int, Event*) UnixEventProcessor.cc:134 (traffic_server:x86_64+0x526edf) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #2 EventProcessor::initThreadState(EThread*) UnixEventProcessor.cc:464 (traffic_server:x86_64+0x52572c) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #3 EventProcessor::ThreadInit::init(int, Event*) I_EventProcessor.h:388 (traffic_server:x86_64+0x526fd7) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #4 EThread::execute() UnixEThread.cc:333 (traffic_server:x86_64+0x520124) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #5 spawn_thread_internal(void*) Thread.cc:79 (traffic_server:x86_64+0x51d488) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)

  Previous read of size 8 at 0x7ba80000bb80 by main thread (mutexes: write M0, write M1, write M2, write M3, write M4, write M5, write M6, write M7, write M8, write M9, write M10, write M11, write M12, write M13):
    #0 freelist_new(_InkFreeList*) ink_queue.cc:239 (libtscore.10.dylib:x86_64+0x4557d) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #1 ink_freelist_new ink_queue.cc:187 (libtscore.10.dylib:x86_64+0x44ac5) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #2 main traffic_server.cc:2027 (traffic_server:x86_64+0x6c8c8) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)

  Location is heap block of size 24576 at 0x7ba800006000 allocated by main thread:
    #0 posix_memalign <null>:28420041 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x37643) (BuildId: 065b6c81cd87343dafd65694f305ecb72400000010000000000a0a0000030c00)
    #1 ats_memalign ink_memory.cc:107 (libtscore.10.dylib:x86_64+0x43989) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #2 freelist_new(_InkFreeList*) ink_queue.cc:216 (libtscore.10.dylib:x86_64+0x45674) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #3 ink_freelist_new ink_queue.cc:187 (libtscore.10.dylib:x86_64+0x44ac5) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #4 EventProcessor::schedule_spawn(void (*)(EThread*), int) UnixEventProcessor.cc:375 (traffic_server:x86_64+0x52444b) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #5 UnixNetProcessor::init() UnixNetProcessor.cc:288 (traffic_server:x86_64+0x4e127e) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #6 main traffic_server.cc:1996 (traffic_server:x86_64+0x6c636) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
```

```
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=34955)
  Write of size 8 at 0x7b9800001f20 by thread T12:
    #0 ServerSessionPool::ServerSessionPool() HttpSessionManager.cc:47 (traffic_server:x86_64+0x123300) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #1 initialize_thread_for_http_sessions(EThread*) HttpSessionManager.cc:42 (traffic_server:x86_64+0x123217) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #2 (anonymous namespace)::ThreadInitByFunc::invoke(int, Event*) UnixEventProcessor.cc:134 (traffic_server:x86_64+0x526edf) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #3 EventProcessor::initThreadState(EThread*) UnixEventProcessor.cc:464 (traffic_server:x86_64+0x52572c) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #4 EventProcessor::ThreadInit::init(int, Event*) I_EventProcessor.h:388 (traffic_server:x86_64+0x526fd7) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #5 EThread::execute() UnixEThread.cc:333 (traffic_server:x86_64+0x520124) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #6 spawn_thread_internal(void*) Thread.cc:79 (traffic_server:x86_64+0x51d488) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)

  Previous read of size 8 at 0x7b9800001f20 by main thread (mutexes: write M0, write M1, write M2, write M3, write M4, write M5, write M6, write M7, write M8, write M9, write M10, write M11, write M12, write M13):
    #0 freelist_new(_InkFreeList*) ink_queue.cc:239 (libtscore.10.dylib:x86_64+0x4557d) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #1 ink_freelist_new ink_queue.cc:187 (libtscore.10.dylib:x86_64+0x44ac5) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #2 Thread::Thread() Thread.cc:42 (traffic_server:x86_64+0x51cfc7) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #3 EThread::EThread(ThreadType, int) UnixEThread.cc:79 (traffic_server:x86_64+0x51d999) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #4 EThread::EThread(ThreadType, int) UnixEThread.cc:80 (traffic_server:x86_64+0x51ddb9) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #5 EventProcessor::spawn_event_threads(int, int, unsigned long) UnixEventProcessor.cc:421 (traffic_server:x86_64+0x52496e) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #6 TasksProcessor::start(int, unsigned long) Tasks.cc:42 (traffic_server:x86_64+0x51cac0) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #7 main traffic_server.cc:2070 (traffic_server:x86_64+0x6cdc3) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)

  Location is heap block of size 12288 at 0x7b9800000000 allocated by main thread:
    #0 posix_memalign <null>:28420041 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x37643) (BuildId: 065b6c81cd87343dafd65694f305ecb72400000010000000000a0a0000030c00)
    #1 ats_memalign ink_memory.cc:107 (libtscore.10.dylib:x86_64+0x43989) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #2 freelist_new(_InkFreeList*) ink_queue.cc:216 (libtscore.10.dylib:x86_64+0x45674) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #3 ink_freelist_new ink_queue.cc:187 (libtscore.10.dylib:x86_64+0x44ac5) (BuildId: ddb6086f2f64376aae6ba04a59161d1132000000200000000100000000000c00)
    #4 Thread::Thread() Thread.cc:42 (traffic_server:x86_64+0x51cfc7) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #5 EThread::EThread() UnixEThread.cc:74 (traffic_server:x86_64+0x51d602) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #6 EThread::EThread() UnixEThread.cc:75 (traffic_server:x86_64+0x51d949) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
    #7 main traffic_server.cc:1859 (traffic_server:x86_64+0x6ba84) (BuildId: 22e8dcbdfd8a3fe2ab9e7f65ec81f14632000000200000000100000000000c00)
```