### PR TITLE
TSan: Fix data race of hostdb_current_timestamp

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -60,7 +60,7 @@ unsigned int hostdb_serve_stale_but_revalidate = 0;
 static ts_seconds hostdb_hostfile_check_interval{std::chrono::hours(24)};
 // Epoch timestamp of the current hosts file check. This also functions as a
 // cached version of ts_clock::now().
-ts_time hostdb_current_timestamp{TS_TIME_ZERO};
+std::atomic<ts_time> hostdb_current_timestamp{TS_TIME_ZERO};
 // Epoch timestamp of the last time we actually checked for a hosts file update.
 static ts_time hostdb_last_timestamp{TS_TIME_ZERO};
 // Epoch timestamp when we updated the hosts file last.
@@ -1479,7 +1479,7 @@ HostDBContinuation::backgroundEvent(int /* event ATS_UNUSED */, Event * /* e ATS
     return EVENT_CONT;
   }
 
-  if ((hostdb_current_timestamp - hostdb_last_timestamp) > hostdb_hostfile_check_interval) {
+  if ((hostdb_current_timestamp.load() - hostdb_last_timestamp) > hostdb_hostfile_check_interval) {
     bool update_p = false; // do we need to reparse the file and update?
     char path[PATH_NAME_MAX];
 

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -66,7 +66,7 @@ extern int hostdb_enable;
  * updated in backgroundEvent which runs every second, it should be
  * approximately accurate to a second.
  */
-extern ts_time hostdb_current_timestamp;
+extern std::atomic<ts_time> hostdb_current_timestamp;
 
 /** How long before any DNS response is consided stale, regardless of DNS TTL.
  * This corresponds to proxy.config.hostdb.verify_after.
@@ -753,7 +753,8 @@ HostDBRecord::ip_age() const
 {
   static constexpr ts_seconds ZERO{0};
   static constexpr ts_seconds MAX{0x7FFFFFFF};
-  return std::clamp(std::chrono::duration_cast<ts_seconds>(hostdb_current_timestamp - ip_timestamp), ZERO, MAX);
+
+  return std::clamp(std::chrono::duration_cast<ts_seconds>(hostdb_current_timestamp.load() - ip_timestamp), ZERO, MAX);
 }
 
 inline ts_seconds


### PR DESCRIPTION
Fix below TSan report.

```
WARNING: ThreadSanitizer: data race (pid=31862)
  Read of size 8 at 0x00000073f038 by thread T11 (mutexes: write M0, write M1):                                                                                                                                                                                                       #0 HostDBContinuation::lookup_done(ts::TextView, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >, SRVHosts*, Ptr<HostDBRecord>) HostDB.cc:949 (traffic_server:x86_64+0x30278b) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #1 HostDBContinuation::dnsEvent(int, HostEnt*) HostDB.cc:1101 (traffic_server:x86_64+0x3049ab) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #2 DNSEntry::postOneEvent(int, Event*) DNS.cc:1511 (traffic_server:x86_64+0x344da0) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #3 EThread::process_event(Event*, int) UnixEThread.cc:153 (traffic_server:x86_64+0x51e8fa) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #4 EThread::process_queue(Queue<Event, Event::Link_link>*, int*, int*) UnixEThread.cc:188 (traffic_server:x86_64+0x51f01f) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #5 EThread::execute_regular() UnixEThread.cc:244 (traffic_server:x86_64+0x51f831) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #6 EThread::execute() UnixEThread.cc:349 (traffic_server:x86_64+0x5202e9) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #7 spawn_thread_internal(void*) Thread.cc:79 (traffic_server:x86_64+0x51d488) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)

  Previous write of size 8 at 0x00000073f038 by thread T6 (mutexes: write M2, write M3):
    #0 HostDBContinuation::backgroundEvent(int, Event*) HostDB.cc:1475 (traffic_server:x86_64+0x2f9ad1) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #1 EThread::process_event(Event*, int) UnixEThread.cc:153 (traffic_server:x86_64+0x51e8fa) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #2 EThread::execute_regular() UnixEThread.cc:258 (traffic_server:x86_64+0x51f8af) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #3 EThread::execute() UnixEThread.cc:349 (traffic_server:x86_64+0x5202e9) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)
    #4 spawn_thread_internal(void*) Thread.cc:79 (traffic_server:x86_64+0x51d488) (BuildId: f46cd8a73ceb3a4da87ee2c9105ad1ff32000000200000000100000000000c00)

  Location is global 'hostdb_current_timestamp' at 0x00000073f038 (traffic_server+0x73f038)
```