### PR TITLE
[autest] Make s3_auth_config less strict

### DIFF
--- a/tests/gold_tests/pluginTest/s3_auth/gold/s3_auth_parsing.gold
+++ b/tests/gold_tests/pluginTest/s3_auth/gold/s3_auth_parsing.gold
@@ -9,8 +9,8 @@
 < HTTP/1.1 200 OK
 < Content-Length: 8
 < Date: ``
-< Age: 0
-< Connection: keep-alive
+< Age: ``
+< Connection: ``
 < Server: ``
 < 
 { [8 bytes data]


### PR DESCRIPTION
Don't check header values that are not relevant to the test.