### PR TITLE
s3_auth_parsing.gold: Make Age Less Specified

### DIFF
--- a/tests/gold_tests/pluginTest/s3_auth/gold/s3_auth_parsing.gold
+++ b/tests/gold_tests/pluginTest/s3_auth/gold/s3_auth_parsing.gold
@@ -9,7 +9,7 @@
 < HTTP/1.1 200 OK
 < Content-Length: 8
 < Date: ``
-< Age: 0
+< Age: ``
 < Connection: keep-alive
 < Server: ``
 < 


### PR DESCRIPTION
The s3_auth_parsing.gold file overspecified the value of Age. We aren't testing that value in the test and due to timing issues the value can be 1 or 0. Making it allow other values.