### PR TITLE
Fix the Loading of Client Certificate Chains

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -834,7 +834,7 @@ SSLConfigParams::getCTX(const std::string &client_cert, const std::string &key_f
       // Continue to fetch certs to associate intermediate certificates
       cert = PEM_read_bio_X509(biop, nullptr, nullptr, nullptr);
       while (cert) {
-        if (!SSL_CTX_use_certificate(client_ctx.get(), cert)) {
+        if (!SSL_CTX_add_extra_chain_cert(client_ctx.get(), cert)) {
           SSLError("failed to attach client chain certificate from %s", client_cert.c_str());
           goto fail;
         }


### PR DESCRIPTION
Additional certificates in a chain should be loaded with the `SSL_CTX_add_extra_chain_cert` API.
