### PR TITLE
Adding back set_connect_fail for generic I/O error

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1919,9 +1919,6 @@ HttpSM::state_http_server_open(int event, void *data)
 
       server_entry->write_vio = server_txn->do_io_write(this, nbytes, server_txn->get_remote_reader());
 
-      // Pre-emptively set a server connect failure that will be cleared once a WRITE_READY is received from origin or
-      // bytes are received back
-      t_state.set_connect_fail(EIO);
     } else { // in the case of an intercept plugin don't to the connect timeout change
       SMDebug("http", "not setting handler for TCP handshake");
       handle_http_server_open();
@@ -7626,6 +7623,9 @@ HttpSM::set_next_state()
   }
 
   case HttpTransact::SM_ACTION_ORIGIN_SERVER_OPEN: {
+    // Pre-emptively set a server connect failure that will be cleared once a WRITE_READY is received from origin or
+    // bytes are received back
+    t_state.set_connect_fail(EIO);
     HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_http_server_open);
 
     // We need to close the previous attempt

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3752,11 +3752,6 @@ HttpTransact::handle_response_from_server(State *s)
   case CONNECTION_CLOSED:
   case BAD_INCOMING_RESPONSE:
 
-    // Set to generic I/O error if not already set specifically.
-    if (!s->current.server->had_connect_fail()) {
-      s->set_connect_fail(EIO);
-    }
-
     if (is_server_negative_cached(s)) {
       max_connect_retries = s->txn_conf->connect_attempts_max_retries_dead_server - 1;
     } else {

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3752,6 +3752,11 @@ HttpTransact::handle_response_from_server(State *s)
   case CONNECTION_CLOSED:
   case BAD_INCOMING_RESPONSE:
 
+    // Set to generic I/O error if not already set specifically.
+    if (!s->current.server->had_connect_fail()) {
+      s->set_connect_fail(EIO);
+    }
+
     if (is_server_negative_cached(s)) {
       max_connect_retries = s->txn_conf->connect_attempts_max_retries_dead_server - 1;
     } else {

--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -47,9 +47,10 @@ class DownCachedOriginServerTest:
             'proxy.config.hostdb.fail.timeout': 10,
             'proxy.config.dns.resolv_conf': 'NULL',
             'proxy.config.hostdb.ttl_mode': 1,
-            'proxy.config.hostdb.timeout': 10,
+            'proxy.config.hostdb.timeout': 2,
             'proxy.config.hostdb.lookup_timeout': 2,
             'proxy.config.http.transaction_no_activity_timeout_in': 2,
+            'proxy.config.http.connect_attempts_timeout': 2,
             'proxy.config.hostdb.host_file.interval': 1,
             'proxy.config.hostdb.host_file.path': os.path.join(Test.TestDirectory, "hosts_file"),
         })

--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -1,0 +1,93 @@
+'''
+Verify ATS handles down origin servers with domain cached correctly.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from ports import get_port
+import os
+
+Test.Summary = '''
+Verify ATS handles down origin servers with cached domain correctly.
+'''
+
+class DownCachedOriginServerTest:
+    replay_file = "replay/server_down.replay.yaml"
+
+    def __init__(self, host_down = False):
+        """Initialize the Test processes for the test runs."""
+        self._dns_port = None
+
+    def _configure_trafficserver(self):
+        """Configure Traffic Server."""
+        self._ts = Test.MakeATSProcess("ts", enable_cache=False)
+
+        self._ts.Disk.remap_config.AddLine(
+            f"map / http://resolve.this.com:{self._server.Variables.http_port}/"
+        )
+
+        self._ts.Disk.records_config.update({
+            'proxy.config.diags.debug.enabled': 0,
+            'proxy.config.diags.debug.tags': 'hostdb|dns|http|socket',
+            'proxy.config.http.connect_attempts_max_retries': 0,
+            'proxy.config.http.connect_attempts_rr_retries': 0,
+            'proxy.config.hostdb.fail.timeout': 10,
+            'proxy.config.dns.resolv_conf': 'NULL',
+            'proxy.config.hostdb.ttl_mode': 1,
+            'proxy.config.hostdb.timeout': 10,
+            'proxy.config.hostdb.lookup_timeout': 2,
+            'proxy.config.http.transaction_no_activity_timeout_in': 2,
+            'proxy.config.hostdb.host_file.interval' : 1,
+            'proxy.config.hostdb.host_file.path': os.path.join(Test.TestDirectory, "hosts_file"),
+        })
+
+    # Even when the origin server is down, SM will return a hit-fresh domain from HostDB.
+    # After request has failed, SM should mark the IP as down
+    def _test_host_mark_down(self):
+        tr = Test.AddTestRun()
+        self._server = tr.AddVerifierServerProcess("server", DownCachedOriginServerTest.replay_file)
+        self._configure_trafficserver()
+
+        tr.Processes.Default.StartBefore(self._server)
+        tr.Processes.Default.StartBefore(self._ts)
+
+        tr.DelayStart = 1
+        tr.AddVerifierClientProcess(
+            "client-1",
+            DownCachedOriginServerTest.replay_file,
+            http_ports=[self._ts.Variables.port],
+            other_args='--keys 1')
+
+        tr.NotRunningAfter = self._server
+
+    # After host has been marked down from previous test, HostDB should not return
+    # the host as available and DNS lookup should fail.
+    def _test_host_unreachable(self):
+        tr = Test.AddTestRun()
+
+        tr.NotRunningBefore = self._server
+
+        tr.DelayStart = 1
+        tr.AddVerifierClientProcess(
+            "client-2",
+            DownCachedOriginServerTest.replay_file,
+            http_ports=[self._ts.Variables.port],
+            other_args='--keys 2')
+
+    def run(self):
+        self._test_host_mark_down()
+        self._test_host_unreachable()
+
+DownCachedOriginServerTest().run()

--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -23,10 +23,11 @@ Test.Summary = '''
 Verify ATS handles down origin servers with cached domain correctly.
 '''
 
+
 class DownCachedOriginServerTest:
     replay_file = "replay/server_down.replay.yaml"
 
-    def __init__(self, host_down = False):
+    def __init__(self):
         """Initialize the Test processes for the test runs."""
         self._dns_port = None
 
@@ -39,7 +40,7 @@ class DownCachedOriginServerTest:
         )
 
         self._ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 0,
+            'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': 'hostdb|dns|http|socket',
             'proxy.config.http.connect_attempts_max_retries': 0,
             'proxy.config.http.connect_attempts_rr_retries': 0,
@@ -49,7 +50,7 @@ class DownCachedOriginServerTest:
             'proxy.config.hostdb.timeout': 10,
             'proxy.config.hostdb.lookup_timeout': 2,
             'proxy.config.http.transaction_no_activity_timeout_in': 2,
-            'proxy.config.hostdb.host_file.interval' : 1,
+            'proxy.config.hostdb.host_file.interval': 1,
             'proxy.config.hostdb.host_file.path': os.path.join(Test.TestDirectory, "hosts_file"),
         })
 
@@ -89,5 +90,6 @@ class DownCachedOriginServerTest:
     def run(self):
         self._test_host_mark_down()
         self._test_host_unreachable()
+
 
 DownCachedOriginServerTest().run()

--- a/tests/gold_tests/dns/hosts_file
+++ b/tests/gold_tests/dns/hosts_file
@@ -1,1 +1,17 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 0.0.0.1 resolve.this.com

--- a/tests/gold_tests/dns/hosts_file
+++ b/tests/gold_tests/dns/hosts_file
@@ -1,0 +1,1 @@
+0.0.0.1 resolve.this.com

--- a/tests/gold_tests/dns/replay/server_down.replay.yaml
+++ b/tests/gold_tests/dns/replay/server_down.replay.yaml
@@ -1,0 +1,54 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      delay: 2s
+      method: "GET"
+      version: "1.1"
+      url: /dns/mark/down
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ X-Request, request ]
+        - [ uuid, 1 ]
+
+    server-response:
+      status: 200
+
+    proxy-response:
+      status: 502
+
+  - client-request:
+      delay: 2s
+      method: "GET"
+      version: "1.1"
+      url: /dns/unreachable
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ X-Request, request ]
+        - [ uuid, 2 ]
+
+    server-response:
+      status: 200
+
+    proxy-response:
+      status: 500

--- a/tests/gold_tests/dns/replay/server_down.replay.yaml
+++ b/tests/gold_tests/dns/replay/server_down.replay.yaml
@@ -20,6 +20,7 @@ meta:
 sessions:
 - transactions:
   - client-request:
+      # Delay to allow hostdb to sync external host file
       delay: 2s
       method: "GET"
       version: "1.1"
@@ -30,13 +31,16 @@ sessions:
         - [ X-Request, request ]
         - [ uuid, 1 ]
 
+    # Shouldn't be reached since server IP is unreachable
     server-response:
       status: 200
 
+    # Returns 502 since server connection is unreachable
     proxy-response:
       status: 502
 
   - client-request:
+      # Delay to allow hostdb to sync external host file
       delay: 2s
       method: "GET"
       version: "1.1"
@@ -47,8 +51,11 @@ sessions:
         - [ X-Request, request ]
         - [ uuid, 2 ]
 
+    # Shouldn't be reached since server IP is unreachable
     server-response:
       status: 200
 
+    # Previous request marked host down so DNS lookup returns unsuccessful
+    # 500 response indicates no valid server
     proxy-response:
       status: 500


### PR DESCRIPTION
Without setting the generic I/O error, the server doesn't know it has failed and `t_state.current.server->had_connect_fail()` in `HttpSM::track_connect_fail()` always returns false. As a result, when the server has exhausted its attempts, it fails to reach `mark_host_failure` and does not update that HostDBInfo entry's last_failure timeout field

I am not sure why it was deleted before and do not see its replacement where the server's `connect_result` field is updated