### PR TITLE
TSan: Make Thread::cur_time thread local

### DIFF
--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -156,8 +156,8 @@ public:
       This gets a cached copy of the time so it is very fast and reasonably accurate.
       The cached time is updated every time the actual operating system time is fetched which is
       at least every 10ms and generally more frequently.
-      @note The cached copy shared among threads which means the cached copy is updated
-      for all threads if any thread updates it.
+
+      @note The cached copy is thread local which means each thread need to update the cached copy by itself.
   */
   static ink_hrtime get_hrtime();
 
@@ -177,7 +177,7 @@ public:
 protected:
   Thread();
 
-  static ink_hrtime cur_time;
+  static thread_local ink_hrtime cur_time;
 };
 
 extern Thread *this_thread();

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -34,7 +34,7 @@
 // Common Interface impl                     //
 ///////////////////////////////////////////////
 
-ink_hrtime Thread::cur_time = ink_get_hrtime_internal();
+thread_local ink_hrtime Thread::cur_time = ink_get_hrtime_internal();
 thread_local Thread *Thread::this_thread_ptr;
 
 Thread::Thread()

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -1399,7 +1399,7 @@ Log::flush_thread_main(void * /* args ATS_UNUSED */)
 
     // Time to work on periodic events??
     //
-    now = Thread::get_hrtime() / HRTIME_SECOND;
+    now = Thread::get_hrtime_updated() / HRTIME_SECOND;
     if (now >= last_time + periodic_tasks_interval) {
       Debug("log-preproc", "periodic tasks for %" PRId64, (int64_t)now);
       periodic_tasks(now);


### PR DESCRIPTION
The alternative (original) approach of #9168 to fix the data race.