### PR TITLE
Traffic Dump: Allow unlimited disk utilization

### DIFF
--- a/doc/admin-guide/plugins/traffic_dump.en.rst
+++ b/doc/admin-guide/plugins/traffic_dump.en.rst
@@ -46,7 +46,7 @@ Plugin Configuration
 
    .. option:: --limit <N>
 
-   (`required`) - Specifies the max disk usage to N bytes (approximate). Traffic Dump will stop capturing new sessions once disk usage exceeds this limit.
+   (`required`) - Specifies the maximum disk usage to N bytes (approximate). Traffic Dump will stop capturing new sessions once disk usage exceeds this limit. Setting this value to ``0`` disables the disk utilization limit.
 
    .. option:: --sensitive-fields <field1,field2,...,fieldn>
 

--- a/doc/admin-guide/plugins/traffic_dump.en.rst
+++ b/doc/admin-guide/plugins/traffic_dump.en.rst
@@ -46,7 +46,7 @@ Plugin Configuration
 
    .. option:: --limit <N>
 
-   (`required`) - Specifies the maximum disk usage to N bytes (approximate). Traffic Dump will stop capturing new sessions once disk usage exceeds this limit. Setting this value to ``0`` disables the disk utilization limit.
+   (`optional`) - Specifies the maximum disk usage to N bytes (approximate). Traffic Dump will stop capturing new sessions once disk usage exceeds this limit. If this option is not used then no disk utilization limit will be enforced.
 
    .. option:: --sensitive-fields <field1,field2,...,fieldn>
 
@@ -62,6 +62,7 @@ Plugin Configuration
    * ``traffic_ctl plugin msg traffic_dump.sample N`` - changes the sampling ratio N as mentioned above.
    * ``traffic_ctl plugin msg traffic_dump.reset`` - resets the disk usage counter.
    * ``traffic_ctl plugin msg traffic_dump.limit N`` - changes the max disk usage to N bytes as mentioned above.
+   * ``traffic_ctl plugin msg traffic_dump.unlimit`` - configure Traffic Dump to not enforce a disk usage limit.
 
 Replay Format
 =============

--- a/plugins/experimental/traffic_dump/session_data.cc
+++ b/plugins/experimental/traffic_dump/session_data.cc
@@ -151,6 +151,7 @@ int SessionData::session_arg_index                 = -1;
 std::atomic<int64_t> SessionData::sample_pool_size = default_sample_pool_size;
 std::atomic<int64_t> SessionData::max_disk_usage   = default_max_disk_usage;
 std::atomic<int64_t> SessionData::disk_usage       = 0;
+std::atomic<bool> SessionData::enforce_disk_limit  = default_enforce_disk_limit;
 ts::file::path SessionData::log_directory{default_log_directory};
 uint64_t SessionData::session_counter = 0;
 std::string SessionData::sni_filter;
@@ -175,17 +176,26 @@ SessionData::reset_disk_usage()
 }
 
 void
+SessionData::disable_disk_limit_enforcement()
+{
+  enforce_disk_limit = false;
+}
+
+void
 SessionData::set_max_disk_usage(int64_t new_max_disk_usage)
 {
-  max_disk_usage = new_max_disk_usage;
+  enforce_disk_limit = true;
+  max_disk_usage     = new_max_disk_usage;
 }
 
 bool
-SessionData::init(std::string_view log_directory, int64_t max_disk_usage, int64_t sample_size, std::string_view ip_filter)
+SessionData::init(std::string_view log_directory, bool enforce_disk_limit, int64_t max_disk_usage, int64_t sample_size,
+                  std::string_view ip_filter)
 {
-  SessionData::log_directory    = log_directory;
-  SessionData::max_disk_usage   = max_disk_usage;
-  SessionData::sample_pool_size = sample_size;
+  SessionData::log_directory      = log_directory;
+  SessionData::max_disk_usage     = max_disk_usage;
+  SessionData::enforce_disk_limit = enforce_disk_limit;
+  SessionData::sample_pool_size   = sample_size;
 
   if (!ip_filter.empty()) {
     client_ip_filter.emplace();
@@ -210,7 +220,7 @@ SessionData::init(std::string_view log_directory, int64_t max_disk_usage, int64_
   TSHttpHookAdd(TS_HTTP_SSN_CLOSE_HOOK, ssncont);
 
   TSDebug(debug_tag, "Initialized with log directory: %s", SessionData::log_directory.c_str());
-  if (SessionData::max_disk_usage == 0) {
+  if (!SessionData::enforce_disk_limit) {
     TSDebug(debug_tag, "Initialized with sample pool size of %" PRId64 " bytes and unlimited disk utilization", sample_size);
   } else {
     TSDebug(debug_tag, "Initialized with sample pool size of %" PRId64 " bytes and disk limit of %" PRId64 " bytes", sample_size,
@@ -220,10 +230,10 @@ SessionData::init(std::string_view log_directory, int64_t max_disk_usage, int64_
 }
 
 bool
-SessionData::init(std::string_view log_directory, int64_t max_disk_usage, int64_t sample_size, std::string_view ip_filter,
-                  std::string_view sni_filter)
+SessionData::init(std::string_view log_directory, bool enforce_disk_limit, int64_t max_disk_usage, int64_t sample_size,
+                  std::string_view ip_filter, std::string_view sni_filter)
 {
-  if (!init(log_directory, max_disk_usage, sample_size, ip_filter)) {
+  if (!init(log_directory, enforce_disk_limit, max_disk_usage, sample_size, ip_filter)) {
     return false;
   }
   SessionData::sni_filter = sni_filter;
@@ -468,7 +478,7 @@ SessionData::global_session_handler(TSCont contp, TSEvent event, void *edata)
     if (this_session_count % sample_pool_size != 0) {
       TSDebug(debug_tag, "Ignore session %" PRId64 " per the random sampling mechanism", id);
       break;
-    } else if (max_disk_usage > 0 && disk_usage >= max_disk_usage) {
+    } else if (enforce_disk_limit && disk_usage >= max_disk_usage) {
       TSDebug(debug_tag, "Ignore session %" PRId64 " due to disk usage %" PRId64 " bytes", id, disk_usage.load());
       break;
     } else {

--- a/plugins/experimental/traffic_dump/session_data.h
+++ b/plugins/experimental/traffic_dump/session_data.h
@@ -92,7 +92,7 @@ private:
   /// be dumped.
   static std::atomic<int64_t> sample_pool_size;
   /// The maximum space logs should take up before stopping the dumping of new
-  /// sessions.
+  /// sessions. A value of 0 correlates with unlimited space utilization.
   static std::atomic<int64_t> max_disk_usage;
   /// The amount of bytes currently written to dump files.
   static std::atomic<int64_t> disk_usage;

--- a/plugins/experimental/traffic_dump/session_data.h
+++ b/plugins/experimental/traffic_dump/session_data.h
@@ -50,6 +50,8 @@ public:
   static constexpr int64_t default_sample_pool_size = 1000;
   /// By default, logging will stop after 10 MB have been dumped.
   static constexpr int64_t default_max_disk_usage = 10 * 1000 * 1000;
+  /// By default, do not enforce disk utilization limits.
+  static constexpr bool default_enforce_disk_limit = false;
 
 private:
   //
@@ -92,10 +94,12 @@ private:
   /// be dumped.
   static std::atomic<int64_t> sample_pool_size;
   /// The maximum space logs should take up before stopping the dumping of new
-  /// sessions. A value of 0 correlates with unlimited space utilization.
+  /// sessions. This is only enforced if enforce_disk_limit is true.
   static std::atomic<int64_t> max_disk_usage;
   /// The amount of bytes currently written to dump files.
   static std::atomic<int64_t> disk_usage;
+  /// Whether to enforce a disk utilization limit.
+  static std::atomic<bool> enforce_disk_limit;
 
   /// The directory into which to put the dump files.
   static ts::file::path log_directory;
@@ -120,9 +124,10 @@ public:
    *
    * @return True if initialization is successful, false otherwise.
    */
-  static bool init(std::string_view log_directory, int64_t max_disk_usage, int64_t sample_size, std::string_view ip_filter);
-  static bool init(std::string_view log_directory, int64_t max_disk_usage, int64_t sample_size, std::string_view ip_filter,
-                   std::string_view sni_filter);
+  static bool init(std::string_view log_directory, bool enforce_disk_limit, int64_t max_disk_usage, int64_t sample_size,
+                   std::string_view ip_filter);
+  static bool init(std::string_view log_directory, bool enforce_disk_limit, int64_t max_disk_usage, int64_t sample_size,
+                   std::string_view ip_filter, std::string_view sni_filter);
 
   /** Set the sample_pool_size to a new value.
    *
@@ -132,6 +137,12 @@ public:
 
   /** Reset the disk usage counter to 0. */
   static void reset_disk_usage();
+
+  /** Disable disk usage enforcement.
+   *
+   * @param[in] new_max_disk_usage The new value to set for max_disk_usage.
+   */
+  static void disable_disk_limit_enforcement();
 
   /** Set the max_disk_usage to a new value.
    *

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -38,7 +38,7 @@ server = Test.MakeVerifierServerProcess(
 
 
 # Define ATS and configure it.
-ts = Test.MakeATSProcess("ts", enable_tls=True)
+ts = Test.MakeATSProcess("ts", command='traffic_manager', enable_tls=True)
 replay_dir = os.path.join(ts.RunDirectory, "ts", "log")
 
 ts.addSSLfile("ssl/server.pem")
@@ -133,6 +133,20 @@ replay_file_session_10 = os.path.join(replay_dir, "127", "0000000000000009")
 ts.Disk.File(replay_file_session_10, exists=True)
 replay_file_session_11 = os.path.join(replay_dir, "127", "000000000000000a")
 ts.Disk.File(replay_file_session_11, exists=True)
+
+# The following will not be written to disk because of a restricted disk limit.
+replay_file_session_12 = os.path.join(replay_dir, "127", "000000000000000b")
+ts.Disk.File(replay_file_session_12, exists=False)
+
+# The following will be written to disk because the disk restriction will be
+# removed.
+replay_file_session_13 = os.path.join(replay_dir, "127", "000000000000000c")
+ts.Disk.File(replay_file_session_13, exists=True)
+
+# The following will not be written to disk because the restriction will be
+# re-added.
+replay_file_session_14 = os.path.join(replay_dir, "127", "000000000000000d")
+ts.Disk.File(replay_file_session_14, exists=False)
 
 # Run our test traffic.
 tr = Test.AddTestRun("Run the test traffic.")
@@ -317,3 +331,78 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
+
+#
+# Test 10: Verify that we can change the --limit value.
+#
+tr = Test.AddTestRun("Verify changing --limit via traffic_ctl.")
+tr.Processes.Default.Command = "traffic_ctl plugin msg traffic_dump.limit 0"
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Run some more test traffic with the restricted disk limit.")
+tr.AddVerifierClientProcess(
+    "client-2", replay_file, http_ports=[ts.Variables.port],
+    https_ports=[ts.Variables.ssl_port],
+    ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem",
+    other_args='--keys 1')
+
+# Since the limit is zero, we should not see any new replay file created.
+tr = Test.AddTestRun("Verify no new traffic was dumped")
+# Sleep 2 seconds to give the replay plugin plenty of time to write the file.
+tr.Processes.Default.Command = "sleep 2"
+tr.Processes.Default.ReturnCode = 0
+file = tr.Disk.File(replay_file_session_12)
+file.Exists = False
+
+#
+# Test 11: Verify that we can remove the disk limit.
+#
+tr = Test.AddTestRun("Removing the disk limit via traffic_ctl.")
+tr.Processes.Default.Command = "traffic_ctl plugin msg traffic_dump.unlimit"
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Run some more test traffic with no disk limit.")
+tr.AddVerifierClientProcess(
+    "client-3", replay_file, http_ports=[ts.Variables.port],
+    https_ports=[ts.Variables.ssl_port],
+    ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem",
+    other_args='--keys 1')
+
+# Since the limit is zero, we should not see any new replay file created.
+tr = Test.AddTestRun("Verify the new traffic was dumped")
+# Sleep 2 seconds to give the replay plugin plenty of time to write the file.
+tr.Processes.Default.Command = "sleep 2"
+tr.Processes.Default.ReturnCode = 0
+file = tr.Disk.File(replay_file_session_13)
+file.Exists = True
+
+#
+# Test 11: Verify that we can again restrict the disk limit.
+#
+# Verify that the restriction can be re-added after unlimit was set. This
+# verifies correct handling of the boolean controlling unlimited disk space.
+#
+tr = Test.AddTestRun("Verify re-adding --limit via traffic_ctl.")
+tr.Processes.Default.Command = "traffic_ctl plugin msg traffic_dump.limit 0"
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("Run test traffic with newly restricted disk limit.")
+tr.AddVerifierClientProcess(
+    "client-4", replay_file, http_ports=[ts.Variables.port],
+    https_ports=[ts.Variables.ssl_port],
+    ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem",
+    other_args='--keys 1')
+
+# Since the limit is zero, we should not see any new replay file created.
+tr = Test.AddTestRun("Verify no new traffic was dumped")
+# Sleep 2 seconds to give the replay plugin plenty of time to write the file.
+tr.Processes.Default.Command = "sleep 2"
+tr.Processes.Default.ReturnCode = 0
+file = tr.Disk.File(replay_file_session_14)
+file.Exists = False

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -101,7 +101,7 @@ ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     f"Initialized with log directory: {replay_dir}",
     "Verify traffic_dump initialized with the configured directory.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Initialized with sample pool size 1 bytes and disk limit 1000000000 bytes",
+    "Initialized with sample pool size of 1 bytes and disk limit of 1000000000 bytes",
     "Verify traffic_dump initialized with the configured disk limit.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Finish a session with log file of.*bytes",

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
@@ -105,7 +105,7 @@ ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     f"Initialized with log directory: {ts_log_dir}",
     "Verify traffic_dump initialized with the configured directory.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Initialized with sample pool size 1 bytes and disk limit 1000000000 bytes",
+    "Initialized with sample pool size of 1 bytes and disk limit of 1000000000 bytes",
     "Verify traffic_dump initialized with the configured disk limit.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Finish a session with log file of.*bytes",

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
@@ -74,7 +74,7 @@ ts.Disk.sni_yaml.AddLines([
 # Configure traffic_dump's SNI filter to only dump connections with SNI bob.com.
 sni_filter = "bob.com"
 ts.Disk.plugin_config.AddLine(
-    f'traffic_dump.so --logdir {replay_dir} --sample 1 --limit 0 '
+    f'traffic_dump.so --logdir {replay_dir} --sample 1 '
     f'--sni-filter "{sni_filter}"'
 )
 

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_sni_filter.test.py
@@ -74,7 +74,7 @@ ts.Disk.sni_yaml.AddLines([
 # Configure traffic_dump's SNI filter to only dump connections with SNI bob.com.
 sni_filter = "bob.com"
 ts.Disk.plugin_config.AddLine(
-    f'traffic_dump.so --logdir {replay_dir} --sample 1 --limit 1000000000 '
+    f'traffic_dump.so --logdir {replay_dir} --sample 1 --limit 0 '
     f'--sni-filter "{sni_filter}"'
 )
 
@@ -86,6 +86,10 @@ ts.Disk.traffic_out.Content += Testers.ContainsExpression(
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Ignore HTTPS session with non-filtered SNI: dave",
     "Verify that the non-desired SNI session was filtered out.")
+
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+    "Initialized with sample pool size of 1 bytes and unlimited disk utilization",
+    "Verify traffic_dump initialized with the configured disk limit.")
 
 # Set up the json replay file expectations.
 replay_file_session_1 = os.path.join(replay_dir, "127", "0000000000000000")


### PR DESCRIPTION
The traffic_dump.so plugin has a --limit argument that specifies how much disk space the plugin will use before stopping writing out new sessions to replay files. This patch allows the user to configure unrestricted disk utilization by making --limit optional and making the absence of `--limit` imply no disk utilization.