### PR TITLE
oscp crashfix: add check for the validity of the certLookup

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -510,7 +510,7 @@ ocsp_update()
   time_t current_time;
 
   SSLCertificateConfig::scoped_config certLookup;
-  const unsigned ctxCount = certLookup->count();
+  const unsigned ctxCount = certLookup ? certLookup->count() : 0;
 
   Debug("ssl_ocsp", "updating OCSP data");
   for (unsigned i = 0; i < ctxCount; i++) {


### PR DESCRIPTION
In my test environment ATS starting crashing on startup due to SSL cert loading failing (default multicert file in test environ).  The culprit is a simple looking declaration has a bit of hidden complexity behind it.

Uncovered by: #9163 