### PR TITLE
Update .gitignore for overridable_txn_vars.cc in mgmt/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,7 @@ plugins/esi/vars_test
 
 plugins/experimental/uri_signing/test_uri_signing
 
-mgmt2/rpc/overridable_txn_vars.cc
+mgmt/rpc/overridable_txn_vars.cc
 mgmt/api/traffic_api_cli_remote
 mgmt/tools/traffic_mcast_snoop
 mgmt/tools/traffic_net_config


### PR DESCRIPTION
mgmt/rpc/overridable_txn_vars.cc is a generated file that our .gitignore should ignore. This used to be in mgmt2, but after #8633 it is now in the mgmt directory. This updates the .gitignore file for the new location.