### PR TITLE
Errata severity

### DIFF
--- a/include/tscore/DiagsTypes.h
+++ b/include/tscore/DiagsTypes.h
@@ -43,6 +43,8 @@
 #include "SourceLocation.h"
 #include "DbgCtl.h"
 
+#include "tscpp/util/ts_diag_levels.h"
+
 #define DIAGS_MAGIC 0x12345678
 #define BYTES_IN_MB 1000000
 
@@ -57,19 +59,6 @@ struct DiagsModeOutput {
   bool to_stderr;
   bool to_syslog;
   bool to_diagslog;
-};
-
-enum DiagsLevel { // do not renumber --- used as array index
-  DL_Diag = 0,    // process does not die
-  DL_Debug,       // process does not die
-  DL_Status,      // process does not die
-  DL_Note,        // process does not die
-  DL_Warning,     // process does not die
-  DL_Error,       // process does not die
-  DL_Fatal,       // causes process termination
-  DL_Alert,       // causes process termination
-  DL_Emergency,   // causes process termination, exits with UNRECOVERABLE_EXIT
-  DL_Undefined    // must be last, used for size!
 };
 
 enum StdStream { STDOUT = 0, STDERR };

--- a/include/tscpp/util/ts_diag_levels.h
+++ b/include/tscpp/util/ts_diag_levels.h
@@ -1,0 +1,38 @@
+/** @file Diagnostic definitions and functions.
+
+@section license License
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+/// Severity level for diagnostics.
+/// @internal Used as array indices, do not renumber or rearrange.
+/// @see DiagTypes.h
+enum DiagsLevel {
+  DL_Diag = 0,  // process does not die
+  DL_Debug,     // process does not die
+  DL_Status,    // process does not die
+  DL_Note,      // process does not die
+  DL_Warning,   // process does not die
+  DL_Error,     // process does not die
+  DL_Fatal,     // causes process termination
+  DL_Alert,     // causes process termination
+  DL_Emergency, // causes process termination, exits with UNRECOVERABLE_EXIT
+  DL_Undefined  // must be last, used for size!
+};

--- a/include/tscpp/util/ts_errata.h
+++ b/include/tscpp/util/ts_errata.h
@@ -1,0 +1,40 @@
+/** @file Diagnostic definitions and functions.
+
+@section license License
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include "tscpp/util/ts_diag_levels.h"
+#include "swoc/TextView.h"
+#include "swoc/Errata.h"
+
+static constexpr swoc::Errata::Severity ERRATA_DIAG{DL_Diag};
+static constexpr swoc::Errata::Severity ERRATA_DEBUG{DL_Debug};
+static constexpr swoc::Errata::Severity ERRATA_STATUS{DL_Status};
+static constexpr swoc::Errata::Severity ERRATA_NOTE{DL_Note};
+static constexpr swoc::Errata::Severity ERRATA_WARN{DL_Warning};
+static constexpr swoc::Errata::Severity ERRATA_ERROR{DL_Error};
+static constexpr swoc::Errata::Severity ERRATA_FATAL{DL_Fatal};
+static constexpr swoc::Errata::Severity ERRATA_ALERT{DL_Alert};
+static constexpr swoc::Errata::Severity ERRATA_EMERGENCY{DL_Emergency};
+
+// This is treated as an array so must numerically match with @c DiagsLevel
+static constexpr std::array<swoc::TextView, 9> Severity_Names{
+  {"Diag", "Debug", "Status", "Note", "Warn", "Error", "Fatal", "Alert", "Emergency"}};

--- a/lib/swoc/Makefile.am
+++ b/lib/swoc/Makefile.am
@@ -55,6 +55,7 @@ library_include_HEADERS = \
         include/swoc/string_view_util.h \
         include/swoc/TextView.h \
         include/swoc/Vectray.h \
+	include/swoc/string_view_util.h \
         include/swoc/HashFNV.h
 endif
 

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -52,6 +52,7 @@ libtscore_la_LIBADD = \
 	@LIBCAP@ \
 	@HWLOC_LIBS@ \
 	@YAMLCPP_LIBS@ \
+	@SWOC_LIBS@ \
 	-lc
 
 libtscore_la_SOURCES = \

--- a/src/tscpp/api/Makefile.am
+++ b/src/tscpp/api/Makefile.am
@@ -19,7 +19,7 @@ include $(top_srcdir)/build/tidy.mk
 
 lib_LTLIBRARIES = libtscppapi.la
 
-libtscppapi_la_CPPFLAGS = $(AM_CPPFLAGS) -I $(abs_top_srcdir)/include
+libtscppapi_la_CPPFLAGS = $(AM_CPPFLAGS) -I $(abs_top_srcdir)/include @SWOC_INCLUDES@
 
 libtscppapi_la_LDFLAGS=-lz -lpthread -version-info @TS_LIBTOOL_VERSION@
 

--- a/src/tscpp/util/Makefile.am
+++ b/src/tscpp/util/Makefile.am
@@ -27,6 +27,7 @@ lib_LTLIBRARIES = libtscpputil.la
 AM_CPPFLAGS += -I$(abs_top_srcdir)/include @SWOC_INCLUDES@
 
 libtscpputil_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -version-info @TS_LIBTOOL_VERSION@ @SWOC_LDFLAGS@
+libtscpputil_la_LIBADD = @SWOC_LIBS@
 
 libtscpputil_la_SOURCES = \
 	ts_diags.cc TextView.cc

--- a/src/tscpp/util/Makefile.am
+++ b/src/tscpp/util/Makefile.am
@@ -29,7 +29,7 @@ AM_CPPFLAGS += -I$(abs_top_srcdir)/include @SWOC_INCLUDES@
 libtscpputil_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -version-info @TS_LIBTOOL_VERSION@ @SWOC_LDFLAGS@
 
 libtscpputil_la_SOURCES = \
-	TextView.cc
+	ts_diags.cc TextView.cc
 
 test_tscpputil_CPPFLAGS = $(AM_CPPFLAGS)\
 	-I$(abs_top_srcdir)/tests/include @SWOC_INCLUDES@

--- a/src/tscpp/util/ts_diags.cc
+++ b/src/tscpp/util/ts_diags.cc
@@ -1,0 +1,33 @@
+/** @file Support for common diagnostics between core, plugins, and libswoc.
+
+  This enables specifying the set of methods usable by a user agent based on the remove IP address
+  for a user agent connection.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "tscpp/util/ts_diag_levels.h"
+#include "tscpp/util/ts_errata.h"
+
+static const bool INITIALIZED = []() -> bool {
+  swoc::Errata::DEFAULT_SEVERITY = ERRATA_ERROR;
+  swoc::Errata::FAILURE_SEVERITY = ERRATA_WARN;
+  swoc::Errata::SEVERITY_NAMES   = swoc::MemSpan<swoc::TextView const>(Severity_Names.data(), Severity_Names.size());
+  return true;
+}();


### PR DESCRIPTION
A precursor to #9193 to split out some of the changes.

This enables using `Errata` with the internal ATS severity levels. One of the changes to `Errata` from ATS core to libswoc was to enable this convergence of values.

The levels are put into the CPP util directory to avoid circular dependencies in building, e.g. nothing in that directory depends on things built later.

Due to various linking problems, this requires #9203 