### PR TITLE
Use ts::shared_lock for ReplaceablePtr

### DIFF
--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -27,6 +27,7 @@
 #include "P_Cache.h"
 #include "tscore/MatcherUtils.h"
 #include "tscore/HostLookup.h"
+#include "tscpp/util/TsSharedMutex.h"
 
 #define CACHE_MEM_FREE_TIMEOUT HRTIME_SECONDS(1)
 
@@ -209,7 +210,7 @@ private:
   ReplaceablePtr &operator=(const ReplaceablePtr &) = delete;
 
   std::unique_ptr<T> h = nullptr;
-  std::shared_mutex m;
+  ts::shared_mutex m;
 
   friend class ReplaceablePtr::ScopedReader;
 };


### PR DESCRIPTION
I have been running my own eBPF based mutex profiling tool. Recently a mutex lock shows up with the latest mater branch that I haven't seen before.

## Report from profiler
```
        mutex [unknown] ::: wait time 228741.80us ::: hold time 57441.78us ::: enter count 6754 ::: try-lock failure count 0
                std::__1::mutex::lock()+0x6 [libc++.so.1.0] (7f31fb7347f6)
                Cache::open_read(Continuation*, ats::CryptoHash const*, HTTPHdr*, OverridableHttpConfigParams const*, CacheFragType, char const*, int)+0x42 [traffic_server] (55dd98786a32)
                CacheProcessor::open_read(Continuation*, HttpCacheKey const*, HTTPHdr*, OverridableHttpConfigParams const*, long, CacheFragType)+0x27 [traffic_server] (55dd9876b5c7)
                HttpCacheSM::open_read(HttpCacheKey const*, URL*, HTTPHdr*, OverridableHttpConfigParams const*, long)+0x9d [traffic_server] (55dd985f9cad)
                HttpSM::do_cache_lookup_and_read()+0x169 [traffic_server] (55dd985ec0d9)
```

It looks like the `std::__1::mutex::lock` is called from `ReplaceablePtr<CacheHostTable>::ScopedReader` introduced by https://github.com/apache/trafficserver/pull/9046. 

https://github.com/apache/trafficserver/blob/e37b35d79e4760d42c258a98a369c9ba827a5935/iocore/cache/Cache.cc#L3003-L3006

It loosk like replacing `std::shared_lock` with `ts::shared_mutex` mitigates the issue. At least the profiler stoped complaining.

