### PR TITLE
libswoc: Export "ts_diag_levels.h".

### DIFF
--- a/include/tscpp/util/Makefile.am
+++ b/include/tscpp/util/Makefile.am
@@ -19,6 +19,7 @@
 library_includedir=$(includedir)/tscpp/util
 
 library_include_HEADERS = \
+        ts_diag_levels.h \
 	IntrusiveDList.h \
 	LocalBuffer.h \
 	PostScript.h \


### PR DESCRIPTION
This was omitted in #9199. It is needed to make the header file available to plugins.