### PR TITLE
libswoc: Fix "string_view_util.h" export duplication

### DIFF
--- a/lib/swoc/Makefile.am
+++ b/lib/swoc/Makefile.am
@@ -55,7 +55,6 @@ library_include_HEADERS = \
         include/swoc/string_view_util.h \
         include/swoc/TextView.h \
         include/swoc/Vectray.h \
-	include/swoc/string_view_util.h \
         include/swoc/HashFNV.h
 endif
 


### PR DESCRIPTION
The "string_view_util.h" file shows up twice in the libswoc "Makefile.am" for export which causes complaints.