### PR TITLE
strategy.yaml loading: give remap rule context in debug for troubleshooting

### DIFF
--- a/proxy/http/remap/NextHopStrategyFactory.cc
+++ b/proxy/http/remap/NextHopStrategyFactory.cc
@@ -102,6 +102,7 @@ NextHopStrategyFactory::NextHopStrategyFactory(const char *file) : fn(file)
         NH_Error("Invalid policy '%s' for the strategy named '%s', this strategy will be ignored.", policy_value.c_str(),
                  name.c_str());
       } else {
+        NH_Debug(NH_DEBUG_TAG, "createStragety '%s'", name.c_str());
         createStrategy(name, policy_type, strategy);
         strategy.done();
       }


### PR DESCRIPTION
As mentioned in PR #7948 (Improve parsing error messages for strategies.yaml.) a line number is not properly provided when an error like extra field is provided.
Adding this debug statement will print which strategy remap rule is being processed when the error is thrown.