### PR TITLE
RefCountObj - further improvements wrt copy construction.

### DIFF
--- a/include/tscore/Ptr.h
+++ b/include/tscore/Ptr.h
@@ -23,8 +23,7 @@
 
 #pragma once
 
-#include "tscore/ink_atomic.h"
-
+#include <atomic>
 #include <cstddef>
 
 ////////////////////////////////////////////////////////////////////
@@ -47,32 +46,23 @@ class RefCountObj : public ForceVFPTToTop
 {
 public:
   RefCountObj() {}
-  RefCountObj(const RefCountObj &s)
-  {
-    (void)s;
-    return;
-  }
-
+  RefCountObj(const RefCountObj &) = delete;
   ~RefCountObj() override {}
-  RefCountObj &
-  operator=(const RefCountObj &s)
-  {
-    (void)s;
-    return (*this);
-  }
+
+  RefCountObj &operator=(const RefCountObj &) = delete;
 
   // Increment the reference count, returning the new count.
   int
   refcount_inc()
   {
-    return ink_atomic_increment((int *)&m_refcount, 1) + 1;
+    return ++m_refcount;
   }
 
   // Decrement the reference count, returning the new count.
   int
   refcount_dec()
   {
-    return ink_atomic_increment((int *)&m_refcount, -1) - 1;
+    return --m_refcount;
   }
 
   int
@@ -88,7 +78,7 @@ public:
   }
 
 private:
-  int m_refcount = 0;
+  std::atomic<int> m_refcount = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -32,6 +32,7 @@
 
 #include "I_EThread.h"
 #include "I_EventProcessor.h"
+#include "tscore/ink_atomic.h"
 #include <execinfo.h>
 
 const ink_hrtime DELAY_FOR_RETRY = HRTIME_MSECONDS(10);

--- a/iocore/eventsystem/unit_tests/test_EventSystem.cc
+++ b/iocore/eventsystem/unit_tests/test_EventSystem.cc
@@ -25,6 +25,7 @@
 #include "catch.hpp"
 
 #include "I_EventSystem.h"
+#include "tscore/ink_atomic.h"
 #include "tscore/I_Layout.h"
 #include "tscore/TSSystemState.h"
 

--- a/iocore/net/P_UDPConnection.h
+++ b/iocore/net/P_UDPConnection.h
@@ -30,6 +30,7 @@
  ****************************************************************************/
 #pragma once
 
+#include "tscore/ink_atomic.h"
 #include "I_UDPNet.h"
 
 class UDPConnectionInternal : public UDPConnection

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -24,6 +24,7 @@
 #include "tsmemcache.h"
 #include "I_NetVConnection.h"
 #include "I_NetProcessor.h"
+#include "tscore/ink_atomic.h"
 
 /*
   TODO

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "tscore/ink_platform.h"
+#include "tscore/ink_atomic.h"
 #include "tscore/Diags.h"
 #include "LogFormat.h"
 #include "LogLimits.h"

--- a/proxy/logging/LogFile.cc
+++ b/proxy/logging/LogFile.cc
@@ -93,27 +93,6 @@ LogFile::LogFile(const char *name, const char *header, LogFileFormat format, uin
   This (copy) constructor builds a LogFile object from another LogFile object.
   -------------------------------------------------------------------------*/
 
-LogFile::LogFile(const LogFile &copy)
-  : RefCountObj(copy),
-    m_file_format(copy.m_file_format),
-    m_name(ats_strdup(copy.m_name)),
-    m_header(ats_strdup(copy.m_header)),
-    m_signature(copy.m_signature),
-    m_ascii_buffer_size(copy.m_ascii_buffer_size),
-    m_max_line_size(copy.m_max_line_size),
-    m_pipe_buffer_size(copy.m_pipe_buffer_size),
-    m_fd(copy.m_fd)
-{
-  ink_release_assert(m_ascii_buffer_size >= m_max_line_size);
-
-  if (copy.m_log) {
-    m_log = new BaseLogFile(*(copy.m_log));
-  } else {
-    m_log = nullptr;
-  }
-
-  Debug("log-file", "exiting LogFile copy constructor, m_name=%s, this=%p", m_name, this);
-}
 /*-------------------------------------------------------------------------
   LogFile::~LogFile
   -------------------------------------------------------------------------*/

--- a/proxy/logging/LogFile.h
+++ b/proxy/logging/LogFile.h
@@ -44,7 +44,7 @@ class LogFile : public LogBufferSink, public RefCountObj
 public:
   LogFile(const char *name, const char *header, LogFileFormat format, uint64_t signature, size_t ascii_buffer_size = 4 * 9216,
           size_t max_line_size = 9216, int pipe_buffer_size = 0, LogEscapeType escape_type = LOG_ESCAPE_NONE);
-  LogFile(const LogFile &);
+  LogFile(const LogFile &) = delete;
   ~LogFile() override;
 
   enum {

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -206,7 +206,7 @@ LogFormat::LogFormat(const char *name, const char *format_str, unsigned interval
   -------------------------------------------------------------------------*/
 
 LogFormat::LogFormat(const LogFormat &rhs)
-  : RefCountObj(rhs),
+  : RefCountObj(),
     m_interval_sec(0),
     m_interval_next(0),
     m_agg_marshal_space(nullptr),


### PR DESCRIPTION
I thought this was already partially done, but this PR removes the `RefCountObj` copy constructor and fixes the resulting compile problems. It also changes that class to use standard atomics instead of ATS functions.