### PR TITLE
Remove out of bound SSL log

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2368,7 +2368,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
         name = sk_GENERAL_NAME_value(names, i);
         if (name->type == GEN_DNS) {
           ats_scoped_str dns(asn1_strdup(name->d.dNSName));
-          Debug("ssl_load", "inserting dns '%s' in certificate: %s", dns.get(), data.cert_names_list[i].c_str());
+          Debug("ssl_load", "inserting dns '%s' in certificate", dns.get());
           name_set.insert(dns.get());
         }
       }


### PR DESCRIPTION
index variable `i` reinstantiated in inner for loop making ssl debug log call cert name out of bound
- bug from #9225 