### PR TITLE
Revert "9.2: Fix s3_auth_config test output check (#9123)"

### DIFF
--- a/tests/gold_tests/pluginTest/s3_auth/s3_auth_config.test.py
+++ b/tests/gold_tests/pluginTest/s3_auth/s3_auth_config.test.py
@@ -62,5 +62,5 @@ tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = "gold/s3_auth_parsing.gold"
 tr.StillRunningAfter = server
 
-ts.Streams.stderr = "gold/s3_auth_parsing_ts.gold"
+ts.Disk.traffic_out.Content = "gold/s3_auth_parsing_ts.gold"
 ts.ReturnCode = 0


### PR DESCRIPTION
This reverts commit 5d0a72afaa0ed80e0317b2a08edd6b36f7d9ce9f on 9.2.x branch.

https://github.com/apache/trafficserver/pull/8919 was cherry picked to 9.2.x, so the commit is no longer needed and it actually causes a test failure.