### PR TITLE
Fix ordering Via response header values

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -4614,11 +4614,17 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
     //  the order of the fields
     MIMEField *resp_via = s->hdr_info.server_response.field_find(MIME_FIELD_VIA, MIME_LEN_VIA);
     if (resp_via) {
+      int saved_our_via_len = 0;
+      char saved_our_via[1024]; // 512-bytes for hostname+via string, 512-bytes for the debug info
       MIMEField *our_via;
       our_via = s->hdr_info.client_response.field_find(MIME_FIELD_VIA, MIME_LEN_VIA);
       if (our_via == nullptr) {
         our_via = s->hdr_info.client_response.field_create(MIME_FIELD_VIA, MIME_LEN_VIA);
         s->hdr_info.client_response.field_attach(our_via);
+      } else {
+        const char *src = our_via->value_get(&saved_our_via_len);
+        memcpy(saved_our_via, src, saved_our_via_len);
+        s->hdr_info.client_response.field_value_set(our_via, "", 0, true);
       }
       // HDR FIX ME - Multiple appends are VERY slow
       while (resp_via) {
@@ -4626,6 +4632,9 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
         const char *cfield = resp_via->value_get(&clen);
         s->hdr_info.client_response.field_value_append(our_via, cfield, clen, true);
         resp_via = resp_via->m_next_dup;
+      }
+      if (saved_our_via_len) {
+        s->hdr_info.client_response.field_value_append(our_via, saved_our_via, saved_our_via_len, true);
       }
     }
     // a warning text is added only in the case of a NOT MODIFIED response

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -45,6 +45,8 @@
 #include "ProxySession.h"
 #include "MgmtDefs.h"
 
+#define HTTP_OUR_VIA_MAX_LENGTH 1024 // 512-bytes for hostname+via string, 512-bytes for the debug info
+
 #define HTTP_RELEASE_ASSERT(X) ink_release_assert(X)
 
 #define DUMP_HEADER(T, H, I, S)                                 \

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -842,7 +842,7 @@ HttpTransactHeaders::insert_hsts_header_in_response(HttpTransact::State *s, HTTP
 void
 HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPHdr *header)
 {
-  char new_via_string[1024]; // 512-bytes for hostname+via string, 512-bytes for the debug info
+  char new_via_string[HTTP_OUR_VIA_MAX_LENGTH];
   char *via_string = new_via_string;
   char *via_limit  = via_string + sizeof(new_via_string);
 


### PR DESCRIPTION
Currently, when upstream returns 304 response, the order of Via response header values is wrong.

```
Expected order: upstream's Via, our Via
Actual order: our Via, upstream's Via
```

This pull request fixes this.

