### PR TITLE
Change Content-Type to text/plain if xdebug modifies response body

### DIFF
--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -401,6 +401,29 @@ InjectEffectiveURLHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 }
 
 static void
+InjectOriginalContentTypeHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
+{
+  TSMLoc ct_field = TSMimeHdrFieldFind(buffer, hdr, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE);
+  if (TS_NULL_MLOC != ct_field) {
+    int original_content_type_len     = 0;
+    const char *original_content_type = TSMimeHdrFieldValueStringGet(buffer, hdr, ct_field, -1, &original_content_type_len);
+    if (original_content_type != nullptr) {
+      TSMLoc dst = FindOrMakeHdrField(buffer, hdr, "X-Original-Content-Type", lengthof("X-Original-Content-Type"));
+      TSReleaseAssert(TS_NULL_MLOC != dst);
+      TSReleaseAssert(TSMimeHdrFieldValueStringInsert(buffer, hdr, dst, -1 /* idx */, original_content_type,
+                                                      original_content_type_len) == TS_SUCCESS);
+    }
+  } else {
+    if (TSMimeHdrFieldCreateNamed(buffer, hdr, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE, &ct_field) == TS_SUCCESS) {
+      TSReleaseAssert(TSMimeHdrFieldAppend(buffer, hdr, ct_field) == TS_SUCCESS);
+    }
+  }
+
+  TSMimeHdrFieldValuesClear(buffer, hdr, ct_field);
+  TSReleaseAssert(TSMimeHdrFieldValueStringSet(buffer, hdr, ct_field, -1, "text/plain", lengthof("text/plain")) == TS_SUCCESS);
+}
+
+static void
 InjectTxnUuidHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 {
   TSMLoc dst = FindOrMakeHdrField(buffer, hdr, "X-Transaction-ID", lengthof("X-Transaction-ID"));
@@ -519,6 +542,7 @@ XInjectResponseHeaders(TSCont /* contp */, TSEvent event, void *edata)
   }
 
   if (xheaders & XHEADER_X_PROBE_HEADERS) {
+    InjectOriginalContentTypeHeader(txn, buffer, hdr);
     BodyBuilder *data = AuxDataMgr::data(txn).body_builder.get();
     TSDebug("xdebug_transform", "XInjectResponseHeaders(): client resp header ready");
     if (data == nullptr) {

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
@@ -6,6 +6,7 @@ Cache-Control: no-store
 Content-Type: text/html
 Content-Language: en
 X-Remap: from=Not-Found, to=Not-Found
+X-Original-Content-Type: text/html; charset=utf-8
 Content-Length: 391
 
 <HTML>
@@ -33,6 +34,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://one/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -66,7 +68,8 @@ X-Remap: from=http://one/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://one/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://one/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -80,6 +83,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -113,7 +117,8 @@ X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -127,6 +132,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://three[0-9]+/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -160,7 +166,8 @@ X-Remap: from=http://three[0-9]+/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://three[0-9]+/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://three[0-9]+/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -174,6 +181,7 @@ Age: ``
 Transfer-Encoding: chunked
 Connection: close
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -208,7 +216,8 @@ X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 	'Age' : '``
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
-	'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -222,6 +231,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -257,7 +267,8 @@ X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -271,6 +282,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -304,7 +316,8 @@ X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -318,6 +331,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -353,7 +367,8 @@ X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -367,6 +382,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -402,7 +418,8 @@ X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }
@@ -416,6 +433,7 @@ Transfer-Encoding: chunked
 Connection: close
 Server: ATS/``
 X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
+Content-Type: text/plain
 
 ``
 {'xDebugProbeAt' : '``
@@ -449,7 +467,8 @@ X-Remap: from=http://two/, to=http://127.0.0.1:SERVER_PORT/
 	'Transfer-Encoding' : 'chunked',
 	'Connection' : 'close',
 	'Server' : 'ATS/``
-	'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/'
+       'X-Remap' : 'from=http://two/, to=http://127.0.0.1:SERVER_PORT/',
+       'Content-Type' : 'text/plain'
 	}}
    ]
 }


### PR DESCRIPTION
Since the response body is modified, the original content type doesn't make sense. The original content-length header value  is kept as x-original-content-length.