### PR TITLE
Make plugin DSO work on macOS

### DIFF
--- a/proxy/http/remap/PluginDso.cc
+++ b/proxy/http/remap/PluginDso.cc
@@ -90,7 +90,11 @@ PluginDso::load(std::string &error)
       PluginDebug(_tag, "plugin '%s' modification time %ld", _configPath.c_str(), _mtime);
 
       /* Now attempt to load the plugin DSO */
+#if defined(darwin)
+      if (!dlopen_preflight(_runtimePath.c_str()) || (_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW | RTLD_LOCAL)) == nullptr) {
+#else
       if ((_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW | RTLD_LOCAL)) == nullptr) {
+#endif
 #if defined(freebsd) || defined(openbsd)
         char *err = (char *)dlerror();
 #else


### PR DESCRIPTION
`dlopen` doesn't return an error even if target file is invalid at all on macOS. We need to call `dlopen_preflight` to examine target file.
With this fix, test_PluginDso passes on macOS.