### PR TITLE
Remove cqhv log field

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -558,7 +558,6 @@ cqint Client Request   If a request was generated internally (via a plugin), the
 Protocols and Versions
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. _cqhv:
 .. _cqpv:
 .. _csshv:
 .. _sshv:
@@ -569,8 +568,6 @@ were in effect for a given event.
 ===== ===================== ===================================================
 Field Source                Description
 ===== ===================== ===================================================
-cqhv  Client Request        Client request HTTP version. Deprecated since 9.0.
-                            Use ``cqpv`` instead.
 cqpv  Client Request        Client request protocol and version.
 sqpv  Proxy Request         Origin negotiated protocol and version
 csshv Cached Proxy Response Origin server's HTTP version from cached version of

--- a/doc/locale/ja/LC_MESSAGES/admin-guide/monitoring/logging/log-formats.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/monitoring/logging/log-formats.en.po
@@ -988,11 +988,6 @@ msgstr ""
 "他のものです。( ``cqtx`` のサブセット )"
 
 #: ../../../admin-guide/monitoring/logging/log-formats.en.rst:403
-#, fuzzy
-msgid "``cqhv``"
-msgstr "``cqhl``"
-
-#: ../../../admin-guide/monitoring/logging/log-formats.en.rst:403
 msgid "The client request HTTP version."
 msgstr "クライアントリクエストの HTTP バージョン。"
 
@@ -2462,9 +2457,6 @@ msgstr "クライアントが接続したが、その後リクエストを送る
 
 #~ msgid "chp"
 #~ msgstr "chp"
-
-#~ msgid "cqhv"
-#~ msgstr "cqhv"
 
 #~ msgid "cqpv"
 #~ msgstr "cqpv"

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -454,11 +454,6 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("pqup", field);
 
-  field = new LogField("client_req_http_version", "cqhv", LogField::dINT, &LogAccess::marshal_client_req_http_version,
-                       &LogAccess::unmarshal_http_version);
-  global_field_list.add(field, false);
-  field_symbol_hash.emplace("cqhv", field);
-
   field = new LogField("client_req_protocol_version", "cqpv", LogField::dINT, &LogAccess::marshal_client_req_protocol_version,
                        &LogAccess::unmarshal_str);
   global_field_list.add(field, false);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -917,7 +917,7 @@ LogAccess::unmarshal_http_version(char **buf, char *dest, int len)
   LogAccess::unmarshal_http_text
 
   The http text is simply the fields http_method (cqhm) + url (pqu) +
-  http_version (cqhv), all right next to each other, in that order.
+  http_version (cqhv, which was removed on 10.0.0), all right next to each other, in that order.
   -------------------------------------------------------------------------*/
 
 int

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -916,8 +916,8 @@ LogAccess::unmarshal_http_version(char **buf, char *dest, int len)
 /*-------------------------------------------------------------------------
   LogAccess::unmarshal_http_text
 
-  The http text is simply the fields http_method (cqhm) + url (pqu) +
-  http_version (cqhv, which was removed on 10.0.0), all right next to each other, in that order.
+  The http text is a reproduced HTTP/1.x request line. It's HTTP method (cqhm) + URL (pqu) + HTTP version.
+  This doesn't support HTTP/2 and HTTP/3 since those don't have a request line.
   -------------------------------------------------------------------------*/
 
 int


### PR DESCRIPTION
This removes `cqhv` log field. It was deprecated on 9.0.0.

https://lists.apache.org/thread/zqmo3sj1m1s6tv9b7zdo86q0qpf2mjow

Unfortunately, we can't remove the marshaling and unmarshaling functions. The marshaling function is also used for `cqtx`, which reproduces HTTP/1.x request line. The unmarshaling function is also used for server request.