### PR TITLE
Fix a leak in HostDBRecord

### DIFF
--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -2082,7 +2082,7 @@ REGRESSION_TEST(HostDBProcessor)(RegressionTest *t, int atype, int *pstatus)
 void
 HostDBRecord::free()
 {
-  if (_iobuffer_index > 0) {
+  if (_iobuffer_index >= 0) {
     Debug("hostdb", "freeing %d bytes at [%p]", (1 << (7 + _iobuffer_index)), this);
     ioBufAllocator[_iobuffer_index].free_void(static_cast<void *>(this));
   }


### PR DESCRIPTION
It's possible to have a 128-byte HostDBRecord.  In this case, iobuffer_index is 0.  This caused HostDBRecords to be leaked.  Fix this by also freeing HostDBRecords which have iobuffer_index == 0.