### PR TITLE
This adds a simple (static) metric for counting cache stripes

### DIFF
--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -100,6 +100,7 @@ struct EvacuationBlock;
 enum {
   cache_bytes_used_stat,
   cache_bytes_total_stat,
+  cache_stripes_stat,
   cache_ram_cache_bytes_stat,
   cache_ram_cache_bytes_total_stat,
   cache_direntries_total_stat,


### PR DESCRIPTION
With this patch, we get metrics like

proxy.process.cache.stripes 4
proxy.process.cache.volume_0.stripes 2
proxy.process.cache.volume_1.stripes 2