### PR TITLE
Forward matched auth response headers to origin

### DIFF
--- a/plugins/authproxy/Makefile.inc
+++ b/plugins/authproxy/Makefile.inc
@@ -21,9 +21,5 @@ authproxy_authproxy_la_SOURCES = \
 	authproxy/utils.h
 
 check_PROGRAMS +=  authproxy/authproxy_test
-
 authproxy_authproxy_test_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include
-#authproxy_authproxy_test_LDADD = authproxy/authproxy.la
-authproxy_authproxy_test_SOURCES = \
-	authproxy/tests/authproxy_test.cc \
-	authproxy/utils.cc
+authproxy_authproxy_test_SOURCES = authproxy/tests/authproxy_test.cc 

--- a/plugins/authproxy/Makefile.inc
+++ b/plugins/authproxy/Makefile.inc
@@ -19,3 +19,11 @@ authproxy_authproxy_la_SOURCES = \
 	authproxy/authproxy.cc \
 	authproxy/utils.cc \
 	authproxy/utils.h
+
+check_PROGRAMS +=  authproxy/authproxy_test
+
+authproxy_authproxy_test_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include
+#authproxy_authproxy_test_LDADD = authproxy/authproxy.la
+authproxy_authproxy_test_SOURCES = \
+	authproxy/tests/authproxy_test.cc \
+	authproxy/utils.cc

--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -56,7 +56,7 @@ static TSCont AuthOsDnsContinuation;
 
 struct AuthOptions {
   std::string hostname;
-  string_view forward_header_prefix;
+  std::string forward_header_prefix;
   int hostport                   = -1;
   AuthRequestTransform transform = nullptr;
   bool force                     = false;

--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -612,6 +612,40 @@ StateAuthorized(AuthRequestContext *auth, void *)
     TSHttpTxnConfigIntSet(auth->txn, TS_CONFIG_HTTP_CACHE_IGNORE_AUTHENTICATION, 1);
   }
 
+  // Copy headers starting from "x-geneva" in the authentication response to the original request
+  const char *GENEVA_PLUGIN_PREFIX = "x-geneva";
+
+  TSMLoc field_loc;
+  TSMLoc next_field_loc;
+  TSMBuffer request_bufp;
+  TSMLoc request_hdr;
+
+  TSReleaseAssert(TSHttpTxnClientReqGet(auth->txn, &request_bufp, &request_hdr) == TS_SUCCESS);
+  field_loc = TSMimeHdrFieldGet(auth->rheader.buffer, auth->rheader.header, 0);
+  TSReleaseAssert(field_loc != TS_NULL_MLOC);
+
+  while (field_loc) {
+    int key_len = 0;
+    int val_len = 0;
+
+    char *key = const_cast<char *>(TSMimeHdrFieldNameGet(auth->rheader.buffer, auth->rheader.header, field_loc, &key_len));
+    char *val =
+      const_cast<char *>(TSMimeHdrFieldValueStringGet(auth->rheader.buffer, auth->rheader.header, field_loc, -1, &val_len));
+
+    if (key && val && ContainsPrefix(key, GENEVA_PLUGIN_PREFIX)) {
+      // Append the matched header to the request in original transection
+      char *key_buf = TSstrndup(key, key_len);
+      char *val_buf = TSstrndup(val, val_len);
+      HttpSetMimeHeader(request_bufp, request_hdr, key_buf, val_buf);
+    }
+
+    // Validate the next header field in sequence
+    next_field_loc = TSMimeHdrFieldNext(auth->rheader.buffer, auth->rheader.header, field_loc);
+    TSHandleMLocRelease(auth->rheader.buffer, auth->rheader.header, field_loc);
+    field_loc = next_field_loc;
+  }
+
+  // Proceed with the modified request
   TSHttpTxnReenable(auth->txn, TS_EVENT_HTTP_CONTINUE);
   return TS_EVENT_CONTINUE;
 }

--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -636,9 +636,7 @@ StateAuthorized(AuthRequestContext *auth, void *)
 
       if (key && val && ContainsPrefix(std::string_view(key, key_len), options->forwardHeaderPrefix)) {
         // Append the matched header to the request in original transection
-        char *key_buf = TSstrndup(key, key_len);
-        char *val_buf = TSstrndup(val, val_len);
-        HttpSetMimeHeader(request_bufp, request_hdr, key_buf, val_buf);
+        HttpSetMimeHeader(request_bufp, request_hdr, std::string_view(key, key_len), std::string_view(val, val_len));
       }
 
       // Validate the next header field in sequence

--- a/plugins/authproxy/tests/authproxy_test.cc
+++ b/plugins/authproxy/tests/authproxy_test.cc
@@ -26,14 +26,14 @@ TEST_CASE("Util methods", "[authproxy][utility]")
 {
   SECTION("ContainsPrefix()")
   {
-    CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abc"}) == true);
-    CHECK(ContainsPrefix(string_view{"abc"}, string_view{"abcdef"}) == false);
-    CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abd"}) == false);
-    CHECK(ContainsPrefix(string_view{"abc"}, string_view{"abc"}) == true);
-    CHECK(ContainsPrefix(string_view{""}, string_view{""}) == true);
-    CHECK(ContainsPrefix(string_view{"abc"}, string_view{""}) == true);
-    CHECK(ContainsPrefix(string_view{""}, string_view{"abc"}) == false);
-    CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abc\0"}) == true);
-    CHECK(ContainsPrefix(string_view{"abcdef\0"}, string_view{"abc\0"}) == true);
+    CHECK(ContainsPrefix(string_view{"abcdef"}, "abc") == true);
+    CHECK(ContainsPrefix(string_view{"abc"}, "abcdef") == false);
+    CHECK(ContainsPrefix(string_view{"abcdef"}, "abd") == false);
+    CHECK(ContainsPrefix(string_view{"abc"}, "abc") == true);
+    CHECK(ContainsPrefix(string_view{""}, "") == true);
+    CHECK(ContainsPrefix(string_view{"abc"}, "") == true);
+    CHECK(ContainsPrefix(string_view{""}, "abc") == false);
+    CHECK(ContainsPrefix(string_view{"abcdef"}, "abc\0") == true);
+    CHECK(ContainsPrefix(string_view{"abcdef\0"}, "abc\0") == true);
   }
 }

--- a/plugins/authproxy/tests/authproxy_test.cc
+++ b/plugins/authproxy/tests/authproxy_test.cc
@@ -1,0 +1,22 @@
+#include <string_view>
+#define CATCH_CONFIG_MAIN /* include main function */
+#include <catch.hpp>      /* catch unit-test framework */
+#include "../utils.h"
+
+using std::string_view;
+
+TEST_CASE("ContainsPrefix(): contains prefix", "[authproxy][utility]")
+{
+  CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abc"}) == true);
+}
+
+// TEST_CASE("ContainsPrefix(): contains prefix", "[authproxy][utility]")
+// {
+//     CHECK(ContainsPrefix("abc", "abcdef") == false);
+// }
+
+// TEST_CASE("ContainsPrefix(): contains prefix", "[authproxy][utility]")
+// {
+//     CHECK(ContainsPrefix("abc", "abc") == true);
+
+// }

--- a/plugins/authproxy/tests/authproxy_test.cc
+++ b/plugins/authproxy/tests/authproxy_test.cc
@@ -4,19 +4,18 @@
 #include "../utils.h"
 
 using std::string_view;
-
-TEST_CASE("ContainsPrefix(): contains prefix", "[authproxy][utility]")
+TEST_CASE("Util methods", "[authproxy][utility]")
 {
-  CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abc"}) == true);
+  SECTION("ContainsPrefix()")
+  {
+    CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abc"}) == true);
+    CHECK(ContainsPrefix(string_view{"abc"}, string_view{"abcdef"}) == false);
+    CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abd"}) == false);
+    CHECK(ContainsPrefix(string_view{"abc"}, string_view{"abc"}) == true);
+    CHECK(ContainsPrefix(string_view{""}, string_view{""}) == true);
+    CHECK(ContainsPrefix(string_view{"abc"}, string_view{""}) == true);
+    CHECK(ContainsPrefix(string_view{""}, string_view{"abc"}) == false);
+    CHECK(ContainsPrefix(string_view{"abcdef"}, string_view{"abc\0"}) == true);
+    CHECK(ContainsPrefix(string_view{"abcdef\0"}, string_view{"abc\0"}) == true);
+  }
 }
-
-// TEST_CASE("ContainsPrefix(): contains prefix", "[authproxy][utility]")
-// {
-//     CHECK(ContainsPrefix("abc", "abcdef") == false);
-// }
-
-// TEST_CASE("ContainsPrefix(): contains prefix", "[authproxy][utility]")
-// {
-//     CHECK(ContainsPrefix("abc", "abc") == true);
-
-// }

--- a/plugins/authproxy/tests/authproxy_test.cc
+++ b/plugins/authproxy/tests/authproxy_test.cc
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <string_view>
 #define CATCH_CONFIG_MAIN /* include main function */
 #include <catch.hpp>      /* catch unit-test framework */

--- a/plugins/authproxy/utils.cc
+++ b/plugins/authproxy/utils.cc
@@ -135,10 +135,4 @@ HttpIsChunkedEncoding(TSMBuffer mbuf, TSMLoc mhdr)
   return ischunked;
 }
 
-bool
-ContainsPrefix(const std::string_view str, const std::string_view prefix)
-{
-  return str.size() < prefix.size() ? false : (strncmp(str.data(), prefix.data(), prefix.size()) == 0);
-}
-
 // vim: set ts=4 sw=4 et :

--- a/plugins/authproxy/utils.cc
+++ b/plugins/authproxy/utils.cc
@@ -117,4 +117,10 @@ HttpIsChunkedEncoding(TSMBuffer mbuf, TSMLoc mhdr)
   return ischunked;
 }
 
+bool
+ContainsPrefix(const char *str, const char *prefix)
+{
+  return strlen(str) < strlen(prefix) ? false : (strncmp(str, prefix, strlen(prefix)) == 0);
+}
+
 // vim: set ts=4 sw=4 et :

--- a/plugins/authproxy/utils.cc
+++ b/plugins/authproxy/utils.cc
@@ -26,6 +26,7 @@
 #include <getopt.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <string_view>
 
 void
 HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr)
@@ -81,6 +82,23 @@ HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, const char *val
   TSHandleMLocRelease(mbuf, mhdr, mloc);
 }
 
+void
+HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const std::string_view name, const std::string_view value)
+{
+  TSMLoc mloc;
+  mloc = TSMimeHdrFieldFind(mbuf, mhdr, name.data(), name.size());
+  if (mloc == TS_NULL_MLOC) {
+    TSReleaseAssert(TSMimeHdrFieldCreateNamed(mbuf, mhdr, name.data(), name.size(), &mloc) == TS_SUCCESS);
+  } else {
+    TSReleaseAssert(TSMimeHdrFieldValuesClear(mbuf, mhdr, mloc) == TS_SUCCESS);
+  }
+
+  TSReleaseAssert(TSMimeHdrFieldValueStringInsert(mbuf, mhdr, mloc, 0 /* index */, value.data(), value.size()) == TS_SUCCESS);
+  TSReleaseAssert(TSMimeHdrFieldAppend(mbuf, mhdr, mloc) == TS_SUCCESS);
+
+  TSHandleMLocRelease(mbuf, mhdr, mloc);
+}
+
 unsigned
 HttpGetContentLength(TSMBuffer mbuf, TSMLoc mhdr)
 {
@@ -118,9 +136,9 @@ HttpIsChunkedEncoding(TSMBuffer mbuf, TSMLoc mhdr)
 }
 
 bool
-ContainsPrefix(const char *str, const char *prefix)
+ContainsPrefix(const std::string_view str, const std::string_view prefix)
 {
-  return strlen(str) < strlen(prefix) ? false : (strncmp(str, prefix, strlen(prefix)) == 0);
+  return str.size() < prefix.size() ? false : (strncmp(str.data(), prefix.data(), prefix.size()) == 0);
 }
 
 // vim: set ts=4 sw=4 et :

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <string>
 #include <string_view>
 #include <ts/ts.h>
 #include <netinet/in.h>
@@ -110,7 +111,7 @@ void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);
 
 // Check if the string contains the prefix
 inline bool
-ContainsPrefix(const std::string_view str, const std::string_view prefix)
+ContainsPrefix(const std::string_view str, const std::string prefix)
 {
   return str.size() < prefix.size() ? false : (strncmp(str.data(), prefix.data(), prefix.size()) == 0);
 }

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -106,4 +106,7 @@ void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, unsigned v
 // Dump the given HTTP header to the debug log.
 void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);
 
+// Check if the string contains the prefix
+bool ContainsPrefix(const char *str, const char *prefix);
+
 // vim: set ts=4 sw=4 et :

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <string_view>
 #include <ts/ts.h>
 #include <netinet/in.h>
 #include <memory>
@@ -107,6 +108,6 @@ void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, unsigned v
 void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);
 
 // Check if the string contains the prefix
-bool ContainsPrefix(const char *str, const char *prefix);
+bool ContainsPrefix(const std::string_view str, const std::string_view prefix);
 
 // vim: set ts=4 sw=4 et :

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -109,6 +109,9 @@ void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const std::string_view name,
 void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);
 
 // Check if the string contains the prefix
-bool ContainsPrefix(const std::string_view str, const std::string_view prefix);
-
+inline bool
+ContainsPrefix(const std::string_view str, const std::string_view prefix)
+{
+  return str.size() < prefix.size() ? false : (strncmp(str.data(), prefix.data(), prefix.size()) == 0);
+}
 // vim: set ts=4 sw=4 et :

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -103,6 +103,7 @@ unsigned HttpGetContentLength(TSMBuffer mbuf, TSMLoc mhdr);
 // Set the value of an arbitrary HTTP header.
 void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, const char *value);
 void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, unsigned value);
+void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const std::string_view name, const std::string_view value);
 
 // Dump the given HTTP header to the debug log.
 void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -111,7 +111,7 @@ void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);
 
 // Check if the string contains the prefix
 inline bool
-ContainsPrefix(const std::string_view str, const std::string prefix)
+ContainsPrefix(const std::string_view str, const std::string &prefix)
 {
   return str.size() < prefix.size() ? false : (strncmp(str.data(), prefix.data(), prefix.size()) == 0);
 }


### PR DESCRIPTION
Added a header prefix field to the config. Headers from the authentication response with the prefix will be appended to the original request.

new parameter: `@pparam=--forward-header-prefix`
