### PR TITLE
Skip dns_host_down autest from 9.2.x branch

### DIFF
--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -23,8 +23,9 @@ Test.Summary = '''
 Verify ATS handles down origin servers with cached domain correctly.
 '''
 # This test is dependent on the new HostDB restructure that is not in 9.2.x.
-# The code is still applicable for 9.2.x but the autest created to show its
-# functionality is a workaround that only applies to 10-Dev.
+# The production patch associated with this test is still applicable for 9.2.x
+# but the autest created to show its functionality relies upon the restructured
+# HostDB's relationship with down nameservers, which only applies to 10-Dev.
 Test.SkipIf(Condition.true("This test depends on new HostDB restructure"))
 
 

--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -22,6 +22,10 @@ import os
 Test.Summary = '''
 Verify ATS handles down origin servers with cached domain correctly.
 '''
+# This test is dependent on the new HostDB restructure that is not in 9.2.x.
+# The code is still applicable for 9.2.x but the autest created to show its
+# functionality is a workaround that only applies to 10-Dev.
+Test.SkipIf(Condition.true("This test depends on new HostDB restructure"))
 
 
 class DownCachedOriginServerTest:


### PR DESCRIPTION
Autest created for #9181 fix is dependent on HostDB's new restructure implementation that is only in 10-Dev. The issue in that PR is still applicable to 9.2.x (and other versions) as it was a refactoring fix that was missed but the autest created to show the specific case used a workaround that only applies to the new restructure. I think for that reason, this autest can be skipped for 9.2.x branch