### PR TITLE
Updated logic for server no-cache and no-store

### DIFF
--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -421,14 +421,14 @@ HttpTransactHeaders::calculate_document_age(ink_time_t request_time, ink_time_t 
 }
 
 bool
-HttpTransactHeaders::does_server_allow_response_to_be_stored(HTTPHdr *resp)
+HttpTransactHeaders::does_server_allow_response_to_be_stored(HTTPHdr *resp, bool ignore_no_store_and_no_cache_directives)
 {
-  uint32_t cc_mask = (MIME_COOKED_MASK_CC_NO_CACHE | MIME_COOKED_MASK_CC_NO_STORE | MIME_COOKED_MASK_CC_PRIVATE);
+  uint32_t cc_mask = MIME_COOKED_MASK_CC_PRIVATE | (ignore_no_store_and_no_cache_directives ? 0 : MIME_COOKED_MASK_CC_NO_STORE);
 
   // According to https://www.rfc-editor.org/rfc/rfc7234#section-5.4
   // ... When the Cache-Control header field is also present and
   // understood in a request, Pragma is ignored.
-  if (resp->get_cooked_cc_mask() == 0 && resp->get_cooked_pragma_no_cache()) {
+  if (!ignore_no_store_and_no_cache_directives && resp->get_cooked_cc_mask() == 0 && resp->get_cooked_pragma_no_cache()) {
     return false;
   } else if (resp->get_cooked_cc_mask() & cc_mask) {
     return false;

--- a/proxy/http/HttpTransactHeaders.h
+++ b/proxy/http/HttpTransactHeaders.h
@@ -52,7 +52,7 @@ public:
 
   static ink_time_t calculate_document_age(ink_time_t request_time, ink_time_t response_time, HTTPHdr *base_response,
                                            ink_time_t base_response_date, ink_time_t now);
-  static bool does_server_allow_response_to_be_stored(HTTPHdr *resp);
+  static bool does_server_allow_response_to_be_stored(HTTPHdr *resp, bool does_server_allow_response_to_be_stored);
   static bool downgrade_request(bool *origin_server_keep_alive, HTTPHdr *outgoing_request);
   static bool is_method_safe(int method);
   static bool is_method_idempotent(int method);

--- a/tests/gold_tests/cache/cache-control.test.py
+++ b/tests/gold_tests/cache/cache-control.test.py
@@ -268,10 +268,14 @@ class ResponseCacheControlDefaultTest:
             f"map / http://127.0.0.1:{self.server.Variables.http_port}/",
         )
 
-        # Verify logs for the response containing no-cache or no-store
+        # Verify logs for the response containing no-cache
+        self.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+            "Revalidate document with server",
+            "Verify that ATS honors the no-cache in response and performs a revalidation.")
+        # Verify logs for the response containing no-store
         self.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
             "server does not permit storing and config file does not indicate that server directive should be ignored",
-            "Verify that ATS honors the no-cache(or no-store) in response and bypasses the cache.")
+            "Verify that ATS honors the no-store in response and bypasses the cache.")
 
     def runTraffic(self):
         tr = Test.AddTestRun("Verify the proper handling of cache-control directives in responses in default configuration")
@@ -319,8 +323,11 @@ class ResponseCacheControlIgnoredTest:
 
         # Verify logs for the response containing no-cache or no-store
         self.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
+            "Revalidate document with server",
+            "Verify that ATS ignores the no-cache in response and therefore doesn't perform a revalidation.")
+        self.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
             "server does not permit storing and config file does not indicate that server directive should be ignored",
-            "Verify that ATS ignores the no-cache(or no-store) in response and caches the responses despite their presence.")
+            "Verify that ATS ignores the no-store in response and caches the responses despite its presence.")
 
     def runTraffic(self):
         tr = Test.AddTestRun(
@@ -338,5 +345,5 @@ class ResponseCacheControlIgnoredTest:
     def run(self):
         self.runTraffic()
 
-# Commenting out as this test would fail due to issue #9283
-# ResponseCacheControlIgnoredTest().run()
+
+ResponseCacheControlIgnoredTest().run()


### PR DESCRIPTION
This PR fixes #9283. 

### issues prior to this change
* With `ignore_server_no_cache = 0`(honoring the directives), ATS would determine responses containing `no-cache` as non-cacheable, while those should be cacheable but just require revalidation on future requests.
* With `ignore_server_no_cache = 1`(ignoring the directives), ATS fails to ignore the 'no-cache' and `no-store` in responses while it is asked to. 

After this change, ATS handles `no-cache` and `no-store` in responses correctly, both when configured to honor and ignore them.