### PR TITLE
Don't initialize the member variables of HistoryEntry and SourceLocation

### DIFF
--- a/include/tscore/History.h
+++ b/include/tscore/History.h
@@ -32,8 +32,8 @@
 
 struct HistoryEntry {
   SourceLocation location;
-  unsigned short event = 0;
-  short reentrancy     = 0;
+  unsigned short event;
+  short reentrancy;
 };
 
 template <unsigned Count> class History

--- a/include/tscore/SourceLocation.h
+++ b/include/tscore/SourceLocation.h
@@ -34,9 +34,9 @@
 class SourceLocation
 {
 public:
-  const char *file = nullptr;
-  const char *func = nullptr;
-  int line         = 0;
+  const char *file;
+  const char *func;
+  int line;
 
   SourceLocation()                          = default;
   SourceLocation(const SourceLocation &rhs) = default;


### PR DESCRIPTION
This is a tiny optimization, but it allows us to use History and SourceLocation without worrying about performance at more places.

History and SourceLocation are just for debugging, and the values are not read by the code. Having uninitialized random values in each entry should not affect anything, and a human can see whether an entry is an actual record by checking the count of entries in History.

Client:
```
h2load -n 100000 -c 1 -m 10 -t 1 "https://localhost:8443/8k"
```

Before:
<img width="729" alt="image" src="https://user-images.githubusercontent.com/153144/211635672-6ed9773e-d250-4f97-8d46-aea6c40c05a1.png">

After:
<img width="695" alt="image" src="https://user-images.githubusercontent.com/153144/211635735-9b2d56cb-ed23-41e0-99e4-fc0f469029c5.png">

