### PR TITLE
Use std:array instead of std:vector for H2 receive window hisotry

### DIFF
--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -230,8 +230,8 @@ private:
    */
   bool _server_rwnd_is_shrinking = false;
 
-  std::vector<size_t> _recent_rwnd_increment = {SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX};
-  int _recent_rwnd_increment_index           = 0;
+  std::array<size_t, 5> _recent_rwnd_increment = {SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX};
+  int _recent_rwnd_increment_index             = 0;
 
   Http2FrequencyCounter _received_settings_counter;
   Http2FrequencyCounter _received_settings_frame_counter;

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -205,8 +205,8 @@ private:
   ssize_t _client_rwnd = 0;
   ssize_t _server_rwnd = 0;
 
-  std::vector<size_t> _recent_rwnd_increment = {SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX};
-  int _recent_rwnd_increment_index           = 0;
+  std::array<size_t, 5> _recent_rwnd_increment = {SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX};
+  int _recent_rwnd_increment_index             = 0;
 
   Event *cross_thread_event = nullptr;
   Event *read_event         = nullptr;


### PR DESCRIPTION
This is a tiny optimization.

`std::array` is more appropriate for `_recent_rwnd_increment` because it's length never changes.
```
$ git grep _recent_rwnd_increment
proxy/http2/Http2ConnectionState.cc:  this->_recent_rwnd_increment[this->_recent_rwnd_increment_index] = amount;
proxy/http2/Http2ConnectionState.cc:  ++this->_recent_rwnd_increment_index;
proxy/http2/Http2ConnectionState.cc:  this->_recent_rwnd_increment_index %= this->_recent_rwnd_increment.size();
proxy/http2/Http2ConnectionState.cc:  double sum = std::accumulate(this->_recent_rwnd_increment.begin(), this->_recent_rwnd_increment.end(), 0.0);
proxy/http2/Http2ConnectionState.cc:  double avg = sum / this->_recent_rwnd_increment.size();
proxy/http2/Http2ConnectionState.h:  std::vector<size_t> _recent_rwnd_increment = {SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX};
proxy/http2/Http2ConnectionState.h:  int _recent_rwnd_increment_index           = 0;
proxy/http2/Http2Stream.cc:  this->_recent_rwnd_increment[this->_recent_rwnd_increment_index] = amount;
proxy/http2/Http2Stream.cc:  ++this->_recent_rwnd_increment_index;
proxy/http2/Http2Stream.cc:  this->_recent_rwnd_increment_index %= this->_recent_rwnd_increment.size();
proxy/http2/Http2Stream.cc:  double sum = std::accumulate(this->_recent_rwnd_increment.begin(), this->_recent_rwnd_increment.end(), 0.0);
proxy/http2/Http2Stream.cc:  double avg = sum / this->_recent_rwnd_increment.size();
proxy/http2/Http2Stream.h:  std::vector<size_t> _recent_rwnd_increment = {SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX};
proxy/http2/Http2Stream.h:  int _recent_rwnd_increment_index           = 0;
```

Before:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/153144/211651434-ac4f443b-3cb9-4b4e-be41-6c8eb3661828.png">

After:
<img width="726" alt="image" src="https://user-images.githubusercontent.com/153144/211651631-799843c1-3538-4fde-bd4f-3b9e2b4f0806.png">