### PR TITLE
Optimize HPACK string comparison

### DIFF
--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -191,6 +191,7 @@ hpack_field_is_literal(HpackField ftype)
 
 // Try not to use memcmp(sv, sv) and strncasecmp(sv, sv) because we don't care which value comes first on a dictionary.
 // Return immediately if the lengths of given strings don't match.
+// Also, we noticed with profiling that taking char* and int was more performant than taking std::string_view.
 static inline bool
 match(const char *s1, int s1_len, const char *s2, int s2_len)
 {
@@ -266,6 +267,7 @@ namespace HpackStaticTable
     HpackLookupResult result;
 
     for (unsigned int index = 1; index < TS_HPACK_STATIC_TABLE_ENTRY_NUM; ++index) {
+      // Profiling showed that use of const reference here is more performant than copying string_views.
       const std::string_view &name  = STATIC_TABLE[index].name;
       const std::string_view &value = STATIC_TABLE[index].value;
 

--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -189,6 +189,44 @@ hpack_field_is_literal(HpackField ftype)
   return ftype == HpackField::INDEXED_LITERAL || ftype == HpackField::NOINDEX_LITERAL || ftype == HpackField::NEVERINDEX_LITERAL;
 }
 
+// Try not to use memcmp(sv, sv) and strncasecmp(sv, sv) because we don't care which value comes first on a dictionary.
+// Return immediately if the lengths of given strings don't match.
+static inline bool
+match(const char *s1, int s1_len, const char *s2, int s2_len)
+{
+  if (s1_len != s2_len) {
+    return false;
+  }
+
+  if (s1 == s2) {
+    return true;
+  }
+
+  if (memcmp(s1, s2, s1_len) != 0) {
+    return false;
+  }
+
+  return true;
+}
+
+static inline bool
+match_ignore_case(const char *s1, int s1_len, const char *s2, int s2_len)
+{
+  if (s1_len != s2_len) {
+    return false;
+  }
+
+  if (s1 == s2) {
+    return true;
+  }
+
+  if (strncasecmp(s1, s2, s1_len) != 0) {
+    return false;
+  }
+
+  return true;
+}
+
 //
 // The first byte of an HPACK field unambiguously tells us what
 // kind of field it is. Field types are specified in the high 4 bits
@@ -228,12 +266,12 @@ namespace HpackStaticTable
     HpackLookupResult result;
 
     for (unsigned int index = 1; index < TS_HPACK_STATIC_TABLE_ENTRY_NUM; ++index) {
-      std::string_view name  = STATIC_TABLE[index].name;
-      std::string_view value = STATIC_TABLE[index].value;
+      const std::string_view &name  = STATIC_TABLE[index].name;
+      const std::string_view &value = STATIC_TABLE[index].value;
 
       // Check whether name (and value) are matched
-      if (memcmp(header.name, name) == 0) {
-        if (memcmp(header.value, value) == 0) {
+      if (match(header.name.data(), header.name.length(), name.data(), name.length())) {
+        if (match(header.value.data(), header.value.length(), value.data(), value.length())) {
           result.index      = index;
           result.index_type = HpackIndex::STATIC;
           result.match_type = HpackMatch::EXACT;
@@ -402,10 +440,9 @@ HpackDynamicTable::lookup(const HpackHeaderField &header) const
     std::string_view name    = m_field->name_get();
     std::string_view value   = m_field->value_get();
 
-    // TODO: replace `strcasecmp` with `memcmp`
     // Check whether name (and value) are matched
-    if (strcasecmp(header.name, name) == 0) {
-      if (memcmp(header.value, value) == 0) {
+    if (match_ignore_case(header.name.data(), header.name.length(), name.data(), name.length())) {
+      if (match(header.value.data(), header.value.length(), value.data(), value.length())) {
         result.index      = index;
         result.index_type = HpackIndex::DYNAMIC;
         result.match_type = HpackMatch::EXACT;
@@ -924,7 +961,8 @@ hpack_encode_header_block(HpackIndexingTable &indexing_table, uint8_t *out_buf, 
     // - Authorization header obviously should not be indexed
     // - Short Cookie header should not be indexed because of low entropy
     HpackField field_type;
-    if ((value.size() < 20 && memcmp(name, HPACK_HDR_FIELD_COOKIE) == 0) || memcmp(name, HPACK_HDR_FIELD_AUTHORIZATION) == 0) {
+    if ((value.size() < 20 && match(name.data(), name.length(), HPACK_HDR_FIELD_COOKIE.data(), HPACK_HDR_FIELD_COOKIE.length())) ||
+        match(name.data(), name.length(), HPACK_HDR_FIELD_AUTHORIZATION.data(), HPACK_HDR_FIELD_AUTHORIZATION.length())) {
       field_type = HpackField::NEVERINDEX_LITERAL;
     } else {
       field_type = HpackField::INDEXED_LITERAL;


### PR DESCRIPTION
When compare strings in HPACK, we don't care which string comes first on a dictionary. We just want to know the two strings are exactly the same.

This PR replaces memcmp(sv, sv) and strcasecmp(sv, sv) with local functions that immediately return `false` when the lengths don't match.

Before:
```
finished in 14.74s, 6784.85 req/s, 53.19MB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 783.92MB (822000249) total, 976.78KB (1000219) headers (space savings 96.45%), 781.25MB (819200000) data
                     min         max         mean         sd        +/- sd
time for request:      860us      3.60ms      1.45ms       179us    89.26%
time for connect:     4.08ms      4.08ms      4.08ms         0us   100.00%
time to 1st byte:     7.58ms      7.58ms      7.58ms         0us   100.00%
req/s           :    6784.90     6784.90     6784.90        0.00   100.00%
```

After:
```
finished in 12.77s, 7829.25 req/s, 61.38MB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 783.92MB (822000238) total, 976.77KB (1000208) headers (space savings 96.45%), 781.25MB (819200000) data
                     min         max         mean         sd        +/- sd
time for request:      797us      2.85ms      1.25ms       155us    89.15%
time for connect:     2.79ms      2.79ms      2.79ms         0us   100.00%
time to 1st byte:     5.49ms      5.49ms      5.49ms         0us   100.00%
req/s           :    7829.30     7829.30     7829.30        0.00   100.00%
```

Before:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/153144/211663677-170934a4-8678-43bd-b95a-9e6733ae878e.png">

After:
<img width="730" alt="image" src="https://user-images.githubusercontent.com/153144/211664220-37a65713-e5be-416d-8940-66517d4a8256.png">