### PR TITLE
Limit the serching range of static table by the first letter of header name

### DIFF
--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -298,13 +298,13 @@ namespace HpackStaticTable
     // Limit the search range of static table
     unsigned int start = 1; // First effective index for TS_HPACK_STATIC_TABLE_ENTRY is 1
     unsigned int end   = TS_HPACK_STATIC_TABLE_ENTRY_NUM;
-    if ('a' <= header.name[0] && header.name[0] <= 'z') {
-      start = HPACK_STATIC_TABLE_OFFSET[header.name[0] - 'a'];
-      if ('z' != header.name[0]) {
+    if (const auto c = header.name[0]; 'a' <= c && c <= 'z') {
+      start = HPACK_STATIC_TABLE_OFFSET[c - 'a'];
+      if ('z' != c) {
         // This does not always set the ideal end index but works for some cases
-        end = HPACK_STATIC_TABLE_OFFSET[header.name[0] - 'a' + 1];
+        end = HPACK_STATIC_TABLE_OFFSET[c - 'a' + 1];
       }
-    } else if (':' == header.name[0]) {
+    } else if (':' == c) {
       end = HPACK_STATIC_TABLE_OFFSET[0];
     }
 

--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -99,6 +99,35 @@ using TS_HPACK_STATIC_TABLE_ENTRY = enum {
   TS_HPACK_STATIC_TABLE_ENTRY_NUM
 };
 
+constexpr int HPACK_STATIC_TABLE_OFFSET[26] = {
+  TS_HPACK_STATIC_TABLE_ACCEPT_CHARSET,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_CACHE_CONTROL,
+  TS_HPACK_STATIC_TABLE_DATE,
+  TS_HPACK_STATIC_TABLE_ETAG,
+  TS_HPACK_STATIC_TABLE_FROM,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_HOST,
+  TS_HPACK_STATIC_TABLE_IF_MATCH,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_LAST_MODIFIED,
+  TS_HPACK_STATIC_TABLE_MAX_FORWARDS,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_PROXY_AUTHENTICATE,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_RANGE,
+  TS_HPACK_STATIC_TABLE_SERVER,
+  TS_HPACK_STATIC_TABLE_TRANSFER_ENCODING,
+  TS_HPACK_STATIC_TABLE_USER_AGENT,
+  TS_HPACK_STATIC_TABLE_VARY,
+  TS_HPACK_STATIC_TABLE_WWW_AUTHENTICATE,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+  TS_HPACK_STATIC_TABLE_ENTRY_NUM,
+};
+
 constexpr HpackHeaderField STATIC_TABLE[] = {{"", ""},
                                              {":authority", ""},
                                              {":method", "GET"},
@@ -266,7 +295,20 @@ namespace HpackStaticTable
   {
     HpackLookupResult result;
 
-    for (unsigned int index = 1; index < TS_HPACK_STATIC_TABLE_ENTRY_NUM; ++index) {
+    // Limit the search range of static table
+    unsigned int start = 1;
+    unsigned int end   = TS_HPACK_STATIC_TABLE_ENTRY_NUM;
+    if ('a' <= header.name[0] && header.name[0] <= 'z') {
+      start = HPACK_STATIC_TABLE_OFFSET[header.name[0] - 'a'];
+      if ('z' != header.name[0]) {
+        // This does not always set the ideal end index but works for some cases
+        end = HPACK_STATIC_TABLE_OFFSET[header.name[0] - 'a' + 1];
+      }
+    } else if (':' == header.name[0]) {
+      end = HPACK_STATIC_TABLE_OFFSET[0];
+    }
+
+    for (unsigned int index = start; index < end; ++index) {
       // Profiling showed that use of const reference here is more performant than copying string_views.
       const std::string_view &name  = STATIC_TABLE[index].name;
       const std::string_view &value = STATIC_TABLE[index].value;

--- a/proxy/http2/HPACK.cc
+++ b/proxy/http2/HPACK.cc
@@ -296,7 +296,7 @@ namespace HpackStaticTable
     HpackLookupResult result;
 
     // Limit the search range of static table
-    unsigned int start = 1;
+    unsigned int start = 1; // First effective index for TS_HPACK_STATIC_TABLE_ENTRY is 1
     unsigned int end   = TS_HPACK_STATIC_TABLE_ENTRY_NUM;
     if ('a' <= header.name[0] && header.name[0] <= 'z') {
       start = HPACK_STATIC_TABLE_OFFSET[header.name[0] - 'a'];


### PR DESCRIPTION
Before:
```
finished in 14.74s, 6784.85 req/s, 53.19MB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 783.92MB (822000249) total, 976.78KB (1000219) headers (space savings 96.45%), 781.25MB (819200000) data
                     min         max         mean         sd        +/- sd
time for request:      860us      3.60ms      1.45ms       179us    89.26%
time for connect:     4.08ms      4.08ms      4.08ms         0us   100.00%
time to 1st byte:     7.58ms      7.58ms      7.58ms         0us   100.00%
req/s           :    6784.90     6784.90     6784.90        0.00   100.00%
```

After:
```
finished in 13.09s, 7642.25 req/s, 59.91MB/s
requests: 100000 total, 100000 started, 100000 done, 100000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 100000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 783.92MB (822000227) total, 976.75KB (1000197) headers (space savings 96.44%), 781.25MB (819200000) data
                     min         max         mean         sd        +/- sd
time for request:      766us      3.28ms      1.28ms       163us    89.01%
time for connect:     3.78ms      3.78ms      3.78ms         0us   100.00%
time to 1st byte:     6.61ms      6.61ms      6.61ms         0us   100.00%
req/s           :    7642.30     7642.30     7642.30        0.00   100.00%
```


Before:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/153144/211675718-a81853dc-5c85-4d8e-b577-e57229d0bba6.png">

After:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/153144/211675748-a70b3d58-2abc-4893-9e53-c0ab09416860.png">
