### PR TITLE
Fixed issue with SDK_API_HttpParentProxySet_Fail regression test

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -313,7 +313,7 @@ HttpTransact::is_response_valid(State *s, HTTPHdr *incoming_response)
     ink_assert((s->current.state == CONNECTION_ERROR) || (s->current.state == OPEN_RAW_ERROR) ||
                (s->current.state == PARSE_ERROR) || (s->current.state == CONNECTION_CLOSED) ||
                (s->current.state == INACTIVE_TIMEOUT) || (s->current.state == ACTIVE_TIMEOUT) ||
-               s->current.state == OUTBOUND_CONGESTION);
+               s->current.state == OUTBOUND_CONGESTION || s->current.state == BAD_INCOMING_RESPONSE);
 
     s->hdr_info.response_error = CONNECTION_OPEN_FAILED;
     return false;


### PR DESCRIPTION
When testing 9.2.0 RC0 I ran into an issue with the regression tests (-R 3 -r SDK_API_HttpParentProxySet_Fail) crashing with the debug build.  I tracked down the commit that caused the issue to be  #7976.

s->current.state changed from being CONNECTION_CLOSED to BAD_INCOMING_RESPONSE and the debug assert doesn't handle that condition.

Regression test before #7976
+++++++++ Incoming O.S. Response +++++++++
```
-- State Machine Id: 0
HTTP/1.0 0

[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <HttpTransact.cc:3499 (HandleResponse)> (http_seq) [0] [HttpTransact::HandleResponse] Response not valid
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <HttpTransact.cc:3634 (handle_response_from_parent)> (http_trans) [0] [handle_response_from_parent] (hrfp)
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <HttpTransact.cc:3667 (handle_response_from_parent)> (http_trans) [0] [hrfp] connection not alive
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <HttpTransact.cc:3680 (handle_response_from_parent)> (http_trans) [0] [0] failed to connect to parent 127.0.0.1
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <HttpTransact.cc:3706 (handle_response_from_parent)> (http_trans) [0] [handle_response_from_parent] 1 per parent attempts exhausted
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <HttpTransact.cc:260 (nextParent)> (parent_down) [0] sm_id[0] connection to parent 127.0.0.1 failed, conn_state: CONNECTION_CLOSED, request to origin: trafficserver.apache.org
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <ParentSelection.cc:176 (nextParent)> (parent_select) ParentConfigParams::nextParent(): parent_table: 0x1d1ee50, result->rec: 0xeeeeffff
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <ParentSelection.cc:188 (nextParent)> (parent_select) Retry result for trafficserver.apache.org was PARENT_SPECIFIED
[Jan 11 18:05:57.124] [ET_NET 14] DEBUG: <HttpTransactHeaders.cc:1147 (add_server_header_to_response)> (http_trans) Adding Server: ATS/10.0.0
```

Regression test after #7976
```
+++++++++ Incoming O.S. Response +++++++++
-- State Machine Id: 0
HTTP/1.0 0

[Jan 11 17:53:32.904] [ET_NET 11] DEBUG: <HttpTransact.cc:359 (is_response_valid)> (http_trans) [0] Response Error: Missing status code
[Jan 11 17:53:32.904] [ET_NET 11] DEBUG: <HttpTransact.cc:3434 (HandleResponse)> (http_seq) [0] Response not valid
[Jan 11 17:53:32.904] [ET_NET 11] DEBUG: <HttpTransact.cc:3569 (handle_response_from_parent)> (http_trans) [0] (hrfp)
Fatal: ../../../proxy/http/HttpTransact.cc:313: failed assertion `(s->current.state == CONNECTION_ERROR) || (s->current.state == OPEN_RAW_ERROR) || (s->current.state == PARSE_ERROR) || (s->current.state == CONNECTION_CLOSED) || (s->current.state == INACTIVE_TIMEOUT) || (s->current.state == ACTIVE_TIMEOUT) || s->current.state == OUTBOUND_CONGESTION`

```

Regression test after this change
```
+++++++++ Incoming O.S. Response +++++++++
-- State Machine Id: 0
HTTP/1.0 0

[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:359 (is_response_valid)> (http_trans) [0] Response Error: Missing status code
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:3434 (HandleResponse)> (http_seq) [0] Response not valid
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:3569 (handle_response_from_parent)> (http_trans) [0] (hrfp)
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:3615 (handle_response_from_parent)> (http_trans) [0] [hrfp] connection not alive
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:3628 (handle_response_from_parent)> (http_trans) [0] [0] failed to connect to parent 127.0.0.1
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:3654 (handle_response_from_parent)> (http_trans) [0] [handle_response_from_parent] 1 per parent attempts exhausted
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:278 (nextParent)> (parent_down) [0] connection to parent 127.0.0.1 failed, conn_state: BAD_INCOMING_RESPONSE, request to origin: trafficserver.apache.org
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <ParentSelection.cc:176 (nextParent)> (parent_select) ParentConfigParams::nextParent(): parent_table: 0x223a360, result->rec: 0xeeeeffff
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <ParentSelection.cc:188 (nextParent)> (parent_select) Retry result for trafficserver.apache.org was PARENT_SPECIFIED
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:3883 (handle_server_connection_not_open)> (http_trans) [0] (hscno)
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransact.cc:3884 (handle_server_connection_not_open)> (http_seq) [0] Entering HttpTransact::handle_server_connection_not_open
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpSM.cc:4348 (do_hostdb_update_if_necessary)> (http) [0] server info = 127.0.0.1:3300
[Jan 11 17:54:04.784] [ET_NET 10] DEBUG: <HttpTransactHeaders.cc:1165 (add_server_header_to_response)> (http_trans) Adding Server: ATS/10.0.0
```



