### PR TITLE
Issue 9274: read-while-writer readers can't find fragment inserted

### DIFF
--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -640,8 +640,20 @@ Lagain:
     goto Lagain;
   }
 Llink:
-  dir_set_next(e, dir_next(b));
-  dir_set_next(b, dir_to_offset(e, seg));
+  // dir_probe searches from head to tail of list and resumes from last_collision.
+  // Need to insert at the tail of the list so that no entries can be inserted
+  // before last_collision. This means walking the entire list on each insert,
+  // but at least the lists are completely in memory and should be quite short
+  Dir *prev, *last;
+
+  last = b;
+  do {
+    prev = last;
+    last = next_dir(last, seg);
+  } while (last);
+
+  dir_set_next(e, 0);
+  dir_set_next(prev, dir_to_offset(e, seg));
 Lfill:
   dir_assign_data(e, to_part);
   dir_set_tag(e, key->slice32(2));


### PR DESCRIPTION
When last_collision is set, dir_probe starts at the bucket head and skips all collisions until last_collision is reached, then continues the probe from that point. dir_insert always inserts new entries immediately after the bucket head. So unless last_collision is the bucket head, any new entries inserted with last_collision set will be inserted before last_collision and will never be found by rww readers.

Modify dir_insert to always insert new entries at the tail of the list. This will entail walking the entire list once on each insert. However, the lists should be entirely in memory and quite short, so this should not present too much performance hit.