### PR TITLE
Updated warning message for adding duplicated remap entries

### DIFF
--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -769,7 +769,7 @@ UrlRewrite::TableInsert(std::unique_ptr<URLTable> &h_table, url_mapping *mapping
     h_table->emplace(src_host, ht_contents);
   }
   if (!ht_contents->Insert(mapping)) {
-    Warning("Could not insert new mapping");
+    Warning("Could not insert new mapping: duplicated entry exists.");
     return false;
   }
   return true;

--- a/proxy/http/remap/UrlRewrite.cc
+++ b/proxy/http/remap/UrlRewrite.cc
@@ -769,7 +769,8 @@ UrlRewrite::TableInsert(std::unique_ptr<URLTable> &h_table, url_mapping *mapping
     h_table->emplace(src_host, ht_contents);
   }
   if (!ht_contents->Insert(mapping)) {
-    Warning("Could not insert new mapping: duplicated entry exists.");
+    // Trie::Insert only fails due to an attempt to add a duplicate entry.
+    Warning("Could not insert new mapping: duplicated entry exists");
     return false;
   }
   return true;


### PR DESCRIPTION
Current logs when the user specifies duplicated remap rules:
```
[Jan 10 23:34:36.437] traffic_server ERROR: Couldn't insert into trie!
[Jan 10 23:34:36.437] traffic_server WARNING: Could not insert new mapping
[Jan 10 23:34:36.437] traffic_server ERROR: [ReverseProxy] failed to add remap rule at /tmp/sb/duplicated_remap_entries/ts2/config/remap.config line 2: unable to add mapping rule to lookup table
[Jan 10 23:34:36.437] traffic_server WARNING: something failed during BuildTable() -- check your remap plugins!
[Jan 10 23:34:36.437] traffic_server EMERGENCY: remap.config failed to load
```
This PR changes the `Could not insert new mapping` to `Could not insert new mapping: duplicated entry exists.` to make it more explicit why the rule insertion fails.