### PR TITLE
Docs: Unpin Sphinx

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -23,18 +23,10 @@ verify_ssl = true
 
 [packages]
 
-# The latest 4.x sphinx release has issues with style rendering. The 3.x
-# releases build and render fine, however. So we currently pin to that.
-#
-# Once that issue, either with sphinx or our docs, is resolved, then we should
-# unpin sphinx by setting the following to "*".
-sphinx = "==3.*"
-
-# Sphinx 3.x builds break with the latest jinja2. This jinja2 pin can be
-# removed when we move to Sphinx 4.x.
-jinja2 = "<3.1"
+sphinx = ">=6.x"
 
 sphinx-rtd-theme = "*"
+sphinxcontrib-jquery = "*"
 sphinxcontrib-plantuml = "*"
 # i18n
 sphinx-intl = "*"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,6 +61,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinxcontrib.plantuml',
+    'sphinxcontrib.jquery',
     'traffic-server',
 ]
 

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -106,7 +106,7 @@ class TSConfVar(std.Target):
         title['first'] = False
         title['objtype'] = 'cv'
         self.add_name(title)
-        title.set_class('ts-cv-title')
+        title['classes'].append('ts-cv-title')
 
         # Finally, add a desc_name() node to display the name of the
         # configuration variable.
@@ -115,7 +115,7 @@ class TSConfVar(std.Target):
         node.append(title)
 
         if ('class' in self.options):
-            title.set_class(self.options.get('class'))
+            title['classes'].append(self.options.get('class'))
         # This has to be a distinct node before the title. if nested then
         # the browser will scroll forward to just past the title.
         nodes.target('', '', names=[cv_name])
@@ -244,7 +244,7 @@ class TSStat(std.Target):
         title['first'] = False
         title['objtype'] = 'stat'
         self.add_name(title)
-        title.set_class('ts-stat-title')
+        title['classes'].append('ts-stat-title')
 
         # Finally, add a desc_name() node to display the name of the
         # configuration variable.


### PR DESCRIPTION
When Sphinx 4.x was initially released there were rendering issues with it building the ATS docs. To address this we simply pinned to the 3.x releases. Currently the latest Sphinx release is v6.1.3 and I noticed that unpinning doesn't have issues with our code anymore. This therefore unpins Sphinx. This also addresses a deprecated use of set_class from traffic-server.py.