### PR TITLE
Register ET_UDP thread type even if no UDP threads are requested

### DIFF
--- a/iocore/net/I_UDPNet.h
+++ b/iocore/net/I_UDPNet.h
@@ -44,6 +44,7 @@
 class UDPNetProcessor : public Processor
 {
 public:
+  virtual EventType register_event_type()                 = 0;
   int start(int n_upd_threads, size_t stacksize) override = 0;
 
   // this function was internal initially.. this is required for public and

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -44,7 +44,10 @@ static inline PollCont *get_UDPPollCont(EThread *);
 
 class UDPNetHandler;
 
-struct UDPNetProcessorInternal : public UDPNetProcessor {
+class UDPNetProcessorInternal : public UDPNetProcessor
+{
+public:
+  EventType register_event_type() override;
   int start(int n_udp_threads, size_t stacksize) override;
   void udp_read_from_net(UDPNetHandler *nh, UDPConnection *uc);
   int udp_callback(UDPNetHandler *nh, UDPConnection *uc, EThread *thread);

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -111,6 +111,13 @@ initialize_thread_for_udp_net(EThread *thread)
 #endif
 }
 
+EventType
+UDPNetProcessorInternal::register_event_type()
+{
+  ET_UDP = eventProcessor.register_event_type("ET_UDP");
+  return ET_UDP;
+}
+
 int
 UDPNetProcessorInternal::start(int n_upd_threads, size_t stacksize)
 {
@@ -121,7 +128,6 @@ UDPNetProcessorInternal::start(int n_upd_threads, size_t stacksize)
   pollCont_offset      = eventProcessor.allocate(sizeof(PollCont));
   udpNetHandler_offset = eventProcessor.allocate(sizeof(UDPNetHandler));
 
-  ET_UDP = eventProcessor.register_event_type("ET_UDP");
   eventProcessor.schedule_spawn(&initialize_thread_for_udp_net, ET_UDP);
   eventProcessor.spawn_event_threads(ET_UDP, n_upd_threads, stacksize);
 

--- a/proxy/shared/UglyLogStubs.cc
+++ b/proxy/shared/UglyLogStubs.cc
@@ -39,6 +39,12 @@ int fds_limit = 8000;
 
 class FakeUDPNetProcessor : public UDPNetProcessor
 {
+  EventType
+  register_event_type() override
+  {
+    return 999;
+  }
+
   int
   start(int, size_t) override
   {

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2160,6 +2160,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     if (!num_of_udp_threads) {
       REC_ReadConfigInteger(num_of_udp_threads, "proxy.config.udp.threads");
     }
+
+    udpNet.register_event_type();
     if (num_of_udp_threads) {
       udpNet.start(num_of_udp_threads, stacksize);
       eventProcessor.thread_group[ET_UDP]._afterStartCallback = init_HttpProxyServer;


### PR DESCRIPTION
ET_UDP has to have a valid value because it's used to check the number of threads for the type.
https://github.com/apache/trafficserver/blob/1a5853908ff9b5251c691a3efcd4765344491427/iocore/net/QUICPacketHandler.cc#L214-L220

The way of registering event type is inconsistent in ATS. This follows what we do for ET_TASK.