### PR TITLE
Fix return types of equality operators

### DIFF
--- a/include/tscore/Ptr.h
+++ b/include/tscore/Ptr.h
@@ -119,25 +119,25 @@ public:
   // Making this explicit avoids unwanted conversions.  See https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Safe_bool .
   explicit operator bool() const { return m_ptr != nullptr; }
 
-  int
+  bool
   operator==(const T *p)
   {
     return (m_ptr == p);
   }
 
-  int
+  bool
   operator==(const Ptr<T> &p)
   {
     return (m_ptr == p.m_ptr);
   }
 
-  int
+  bool
   operator!=(const T *p)
   {
     return (m_ptr != p);
   }
 
-  int
+  bool
   operator!=(const Ptr<T> &p)
   {
     return (m_ptr != p.m_ptr);


### PR DESCRIPTION
Found this while working on #9319. Why int?

```
/home/mkitajo/src/trafficserver/iocore/eventsystem/I_IOBuffer.h: In member function ‘IOBufferChain& IOBufferChain::operator+=(const self_type&)’:
/home/mkitajo/src/trafficserver/iocore/eventsystem/I_IOBuffer.h:1412:45: error: return type of ‘int Ptr<T>::operator==(const T*) [with T = IOBufferBlock]’ is not ‘bool’
 1412 |   if (static_cast<IOBufferBlock *>(nullptr) == _head)
/home/mkitajo/src/trafficserver/iocore/eventsystem/I_IOBuffer.h:1412:45: note: used as rewritten candidate for comparison of ‘IOBufferBlock*’ and ‘Ptr<IOBufferBlock>’
make[1]: *** [Makefile:1037: RecRawStats.o] Error 1
```