### PR TITLE
Memory leaks with storing configuration filenames

### DIFF
--- a/mgmt/config/AddConfigFilesHere.cc
+++ b/mgmt/config/AddConfigFilesHere.cc
@@ -27,7 +27,6 @@
 #include "tscore/Diags.h"
 #include "FileManager.h"
 #include "tscore/Errata.h"
-#include "tscore/ink_memory.h"
 
 static constexpr bool REQUIRED{true};
 static constexpr bool NOT_REQUIRED{false};
@@ -42,10 +41,7 @@ registerFile(const char *configName, const char *defaultName, bool isRequired)
 {
   bool found = false;
   ats_scoped_str fname(REC_readString(configName, &found));
-  if (!found) {
-    fname = defaultName;
-  }
-  FileManager::instance().addFile(fname, configName, false, isRequired);
+  FileManager::instance().addFile(found ? fname : defaultName, configName, false, isRequired);
 }
 
 //

--- a/mgmt/config/AddConfigFilesHere.cc
+++ b/mgmt/config/AddConfigFilesHere.cc
@@ -27,6 +27,7 @@
 #include "tscore/Diags.h"
 #include "FileManager.h"
 #include "tscore/Errata.h"
+#include "tscore/ink_memory.h"
 
 static constexpr bool REQUIRED{true};
 static constexpr bool NOT_REQUIRED{false};
@@ -39,8 +40,8 @@ static constexpr bool NOT_REQUIRED{false};
 void
 registerFile(const char *configName, const char *defaultName, bool isRequired)
 {
-  bool found        = false;
-  const char *fname = REC_readString(configName, &found);
+  bool found = false;
+  ats_scoped_str fname(REC_readString(configName, &found));
   if (!found) {
     fname = defaultName;
   }

--- a/mgmt/config/FileManager.cc
+++ b/mgmt/config/FileManager.cc
@@ -388,6 +388,7 @@ FileManager::ConfigManager::ConfigManager(const char *fileName_, const char *con
 FileManager::ConfigManager::~ConfigManager()
 {
   ats_free(fileName);
+  ats_free(configName);
 }
 
 //


### PR DESCRIPTION
```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x6651f7 in malloc (/opt/ats/bin/traffic_server+0x6651f7) (BuildId: 6cec0e60aa1fe241c1cb6927ced97cdd18bde355)
    #1 0x7fcfa46eb8a1 in ats_malloc /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/tscore/../../../src/tscore/ink_memory.cc:64:9
    #2 0x7fcfa46eb8a1 in _xstrdup /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/tscore/../../../src/tscore/ink_memory.cc:249:34
    #3 0xf150e2 in FileManager::ConfigManager::ConfigManager(char const*, char const*, bool, bool, FileManager::ConfigManager*) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/FileManager.cc:372:16
    #4 0xf0c1cb in FileManager::addFileHelper(char const*, char const*, bool, bool, FileManager::ConfigManager*) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/FileManager.cc:144:38
    #5 0xf0c1cb in FileManager::addFile(char const*, char const*, bool, bool, FileManager::ConfigManager*) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/FileManager.cc:134:3
    #6 0xf192f9 in registerFile(char const*, char const*, bool) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/AddConfigFilesHere.cc:47:27
    #7 0xf19475 in initializeRegistry() /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/AddConfigFilesHere.cc:71:3
    #8 0x76b43b in initialize_file_manager() /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/../../src/traffic_server/traffic_server.cc:698:3
    #9 0x76b43b in main /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/../../src/traffic_server/traffic_server.cc:1819:3
    #10 0x7fcfa364a50f in __libc_start_call_main (/lib64/libc.so.6+0x2750f) (BuildId: 81daba31ee66dbd63efdc4252a872949d874d136)
```

```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x6651f7 in malloc (/opt/ats/bin/traffic_server+0x6651f7) (BuildId: 6cec0e60aa1fe241c1cb6927ced97cdd18bde355)
    #1 0x7fcfa46eb8a1 in ats_malloc /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/tscore/../../../src/tscore/ink_memory.cc:64:9
    #2 0x7fcfa46eb8a1 in _xstrdup /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/tscore/../../../src/tscore/ink_memory.cc:249:34
    #3 0xf150e2 in FileManager::ConfigManager::ConfigManager(char const*, char const*, bool, bool, FileManager::ConfigManager*) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/FileManager.cc:372:16
    #4 0xf0c1cb in FileManager::addFileHelper(char const*, char const*, bool, bool, FileManager::ConfigManager*) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/FileManager.cc:144:38
    #5 0xf0c1cb in FileManager::addFile(char const*, char const*, bool, bool, FileManager::ConfigManager*) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/FileManager.cc:134:3
    #6 0xf192f9 in registerFile(char const*, char const*, bool) /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/AddConfigFilesHere.cc:47:27
    #7 0xf19475 in initializeRegistry() /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/mgmt/config/../../../mgmt/config/AddConfigFilesHere.cc:71:3
    #8 0x76b43b in initialize_file_manager() /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/../../src/traffic_server/traffic_server.cc:698:3
    #9 0x76b43b in main /home/bcall/dev/apache/trafficserver/build-Linux_clang_h3_asan/src/../../src/traffic_server/traffic_server.cc:1819:3
    #10 0x7fcfa364a50f in __libc_start_call_main (/lib64/libc.so.6+0x2750f) (BuildId: 81daba31ee66dbd63efdc4252a872949d874d136)
```