### PR TITLE
s3_auth: Schedule reloading config event on TASK thread

### DIFF
--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -488,7 +488,7 @@ public:
     if (_conf_rld_act != nullptr && !TSActionDone(_conf_rld_act)) {
       TSActionCancel(_conf_rld_act);
     }
-    _conf_rld_act = TSContScheduleOnPool(_conf_rld, delay * 1000, TS_THREAD_POOL_NET);
+    _conf_rld_act = TSContScheduleOnPool(_conf_rld, delay * 1000, TS_THREAD_POOL_TASK);
   }
 
   ts::shared_mutex reload_mutex;


### PR DESCRIPTION
The conf reload event of the s3_auth plugin is scheduled on the NET thread. The TASK thread is the appropriate thread to reload configs.