### PR TITLE
Make 204 cacheable again

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -453,7 +453,7 @@ CacheVC::set_http_info(CacheHTTPInfo *ainfo)
   }
 
   MIMEField *field = ainfo->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
-  if (field && !field->value_get_int64()) {
+  if ((field && !field->value_get_int64()) || ainfo->m_alt->m_response_hdr.status_get() == HTTP_STATUS_NO_CONTENT) {
     f.allow_empty_doc = 1;
     // Set the object size here to zero in case this is a cache replace where the new object
     // length is zero but the old object was not.


### PR DESCRIPTION
#9330 made 204 uncacheable regardless of negative caching list configuration, because ATS caches empty documents only if the size, which is 0, is explicitly indicated by Content-Length.

Status 204 response does not allowed to have any content, and Content-Length header is not required. We should allow this case too.