### PR TITLE
Fixed some memory leaks with http/3

### DIFF
--- a/proxy/http3/Http3HeaderFramer.cc
+++ b/proxy/http3/Http3HeaderFramer.cc
@@ -36,6 +36,14 @@ Http3HeaderFramer::Http3HeaderFramer(Http3Transaction *transaction, VIO *source,
   http_parser_init(&this->_http_parser);
 }
 
+Http3HeaderFramer::~Http3HeaderFramer()
+{
+  _header.destroy();
+  if (_header_block != nullptr) {
+    free_MIOBuffer(_header_block);
+  }
+}
+
 Http3FrameUPtr
 Http3HeaderFramer::generate_frame()
 {

--- a/proxy/http3/Http3HeaderFramer.h
+++ b/proxy/http3/Http3HeaderFramer.h
@@ -38,6 +38,7 @@ class Http3HeaderFramer : public Http3FrameGenerator
 {
 public:
   Http3HeaderFramer(Http3Transaction *transaction, VIO *source, QPACK *qpack, uint64_t stream_id);
+  ~Http3HeaderFramer();
 
   // Http3FrameGenerator
   Http3FrameUPtr generate_frame() override;

--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -55,6 +55,7 @@ void
 HQSession::remove_transaction(HQTransaction *trans)
 {
   this->_transaction_list.remove(trans);
+  delete trans;
 
   return;
 }


### PR DESCRIPTION
These numbers are with using freelists:

Before:
`SUMMARY: AddressSanitizer: 9997094750 byte(s) leaked in 4587157 allocation(s).
`
After:
`SUMMARY: AddressSanitizer: 137185838 byte(s) leaked in 77301 allocation(s).
`