### PR TITLE
Revert PRs 7667 and 7807

### DIFF
--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -101,10 +101,6 @@ HttpCacheSM::state_cache_open_read(int event, void *data)
   ink_assert(captive_action.cancelled == 0);
   pending_action = nullptr;
 
-  if (captive_action.cancelled == 1) {
-    return VC_EVENT_CONT; // SM gave up on us
-  }
-
   switch (event) {
   case CACHE_EVENT_OPEN_READ:
     HTTP_INCREMENT_DYN_STAT(http_current_cache_connections_stat);
@@ -115,11 +111,10 @@ HttpCacheSM::state_cache_open_read(int event, void *data)
     }
     open_read_cb  = true;
     cache_read_vc = static_cast<CacheVConnection *>(data);
-    master_sm->handleEvent(event, &captive_action);
+    master_sm->handleEvent(event, data);
     break;
 
   case CACHE_EVENT_OPEN_READ_FAILED:
-    err_code = reinterpret_cast<intptr_t>(data);
     if ((intptr_t)data == -ECACHE_DOC_BUSY) {
       // Somebody else is writing the object
       if (open_read_tries <= master_sm->t_state.txn_conf->max_cache_open_read_retries) {
@@ -130,12 +125,12 @@ HttpCacheSM::state_cache_open_read(int event, void *data)
         // Give up; the update didn't finish in time
         // HttpSM will inform HttpTransact to 'proxy-only'
         open_read_cb = true;
-        master_sm->handleEvent(event, &captive_action);
+        master_sm->handleEvent(event, data);
       }
     } else {
       // Simple miss in the cache.
       open_read_cb = true;
-      master_sm->handleEvent(event, &captive_action);
+      master_sm->handleEvent(event, data);
     }
     break;
 
@@ -179,9 +174,6 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
   ink_assert(captive_action.cancelled == 0);
   pending_action = nullptr;
 
-  if (captive_action.cancelled == 1) {
-    return VC_EVENT_CONT; // SM gave up on us
-  }
   bool read_retry_on_write_fail = false;
 
   switch (event) {
@@ -190,7 +182,7 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
     ink_assert(cache_write_vc == nullptr);
     cache_write_vc = static_cast<CacheVConnection *>(data);
     open_write_cb  = true;
-    master_sm->handleEvent(event, &captive_action);
+    master_sm->handleEvent(event, data);
     break;
 
   case CACHE_EVENT_OPEN_WRITE_FAILED: {
@@ -225,6 +217,8 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
     if (read_retry_on_write_fail || !write_retry_done()) {
       // Retry open write;
       open_write_cb = false;
+      // reset captive_action since HttpSM cancelled it
+      captive_action.cancelled = 0;
       do_schedule_in();
     } else {
       // The cache is hosed or full or something.
@@ -234,8 +228,7 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
             "done retrying...",
             master_sm->sm_id, open_write_tries);
       open_write_cb = true;
-      err_code      = reinterpret_cast<intptr_t>(data);
-      master_sm->handleEvent(event, &captive_action);
+      master_sm->handleEvent(event, data);
     }
   } break;
 
@@ -246,7 +239,7 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
             "falling back to read retry...",
             master_sm->sm_id, open_write_tries);
       open_read_cb = false;
-      master_sm->handleEvent(CACHE_EVENT_OPEN_READ, &captive_action);
+      master_sm->handleEvent(CACHE_EVENT_OPEN_READ, data);
     } else {
       Debug("http_cache",
             "[%" PRId64 "] [state_cache_open_write] cache open write failure %d. "
@@ -295,6 +288,8 @@ HttpCacheSM::do_cache_open_read(const HttpCacheKey &key)
   } else {
     ink_assert(open_read_cb == false);
   }
+  // reset captive_action since HttpSM cancelled it during open read retry
+  captive_action.cancelled = 0;
   // Initialising read-while-write-inprogress flag
   this->readwhilewrite_inprogress = false;
   Action *action_handle = cacheProcessor.open_read(this, &key, this->read_request_hdr, this->http_params, this->read_pin_in_cache);
@@ -310,7 +305,6 @@ HttpCacheSM::do_cache_open_read(const HttpCacheKey &key)
     return ACTION_RESULT_DONE;
   } else {
     ink_assert(pending_action != nullptr || write_locked == true);
-    captive_action.cancelled = 0; // Make sure not cancelled before we hand it out
     return &captive_action;
   }
 }
@@ -386,8 +380,7 @@ HttpCacheSM::open_write(const HttpCacheKey *key, URL *url, HTTPHdr *request, Cac
   // Changed by YTS Team, yamsat Plugin
   // two criteria, either write retries over the amount OR timeout
   if (open_write_tries > master_sm->redirection_tries && write_retry_done()) {
-    err_code = -ECACHE_DOC_BUSY;
-    master_sm->handleEvent(CACHE_EVENT_OPEN_WRITE_FAILED, &captive_action);
+    master_sm->handleEvent(CACHE_EVENT_OPEN_WRITE_FAILED, (void *)-ECACHE_DOC_BUSY);
     return ACTION_RESULT_DONE;
   }
 
@@ -407,7 +400,6 @@ HttpCacheSM::open_write(const HttpCacheKey *key, URL *url, HTTPHdr *request, Cac
     return ACTION_RESULT_DONE;
   } else {
     ink_assert(pending_action != nullptr);
-    captive_action.cancelled = 0; // Make sure not cancelled before we hand it out
     return &captive_action;
   }
 }

--- a/proxy/http/HttpCacheSM.h
+++ b/proxy/http/HttpCacheSM.h
@@ -201,12 +201,6 @@ public:
     abort_write();
   }
 
-  inline int
-  get_last_error() const
-  {
-    return err_code;
-  }
-
 private:
   void do_schedule_in();
   Action *do_cache_open_read(const HttpCacheKey &);
@@ -238,7 +232,4 @@ private:
   // to keep track of multiple cache lookups
   int lookup_max_recursive = 0;
   int current_lookup_level = 0;
-
-  // last error from the cache subsystem
-  int err_code = 0;
 };

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1505,6 +1505,9 @@ HttpSM::state_api_callout(int event, void *data)
   // This is a reschedule via the tunnel.  Just fall through
   //
   case EVENT_INTERVAL:
+    if (data != pending_action) {
+      pending_action->cancel();
+    }
     pending_action = nullptr;
   // FALLTHROUGH
   case EVENT_NONE:
@@ -1555,7 +1558,7 @@ plugins required to work with sni_routing.
       if (!lock.is_locked()) {
         api_timer = -Thread::get_hrtime_updated();
         HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
-        ink_release_assert(pending_action.empty());
+        ink_assert(pending_action == nullptr);
         pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
         return -1;
       }
@@ -1879,7 +1882,7 @@ HttpSM::state_http_server_open(int event, void *data)
   SMDebug("http_track", "entered inside state_http_server_open: %s", HttpDebugNames::get_event_name(event));
   STATE_ENTER(&HttpSM::state_http_server_open, event);
   ink_release_assert(event == EVENT_INTERVAL || event == NET_EVENT_OPEN || event == NET_EVENT_OPEN_FAILED ||
-                     pending_action.empty());
+                     pending_action == nullptr);
   if (event != NET_EVENT_OPEN) {
     pending_action = nullptr;
   }
@@ -1902,7 +1905,7 @@ HttpSM::state_http_server_open(int event, void *data)
     // Since the UnixNetVConnection::action_ or SocksEntry::action_ may be returned from netProcessor.connect_re, and the
     // SocksEntry::action_ will be copied into UnixNetVConnection::action_ before call back NET_EVENT_OPEN from SocksEntry::free(),
     // so we just compare the Continuation between pending_action and VC's action_.
-    ink_release_assert(pending_action.empty() || pending_action.get_continuation() == vc->get_action()->continuation);
+    ink_release_assert(pending_action == nullptr || pending_action->continuation == vc->get_action()->continuation);
     pending_action = nullptr;
 
     if (this->plugin_tunnel_type == HTTP_NO_PLUGIN_TUNNEL) {
@@ -2369,8 +2372,12 @@ HttpSM::state_hostdb_lookup(int event, void *data)
     opt.timeout        = (t_state.api_txn_dns_timeout_value != -1) ? t_state.api_txn_dns_timeout_value : 0;
     opt.host_res_style = ats_host_res_from(ua_txn->get_netvc()->get_local_addr()->sa_family, t_state.txn_conf->host_res_data.order);
 
-    pending_action = hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info, host_name, 0, opt);
-    if (pending_action.empty()) {
+    Action *dns_lookup_action_handle =
+      hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info, host_name, 0, opt);
+    if (dns_lookup_action_handle != ACTION_RESULT_DONE) {
+      ink_assert(!pending_action);
+      pending_action = dns_lookup_action_handle;
+    } else {
       call_transact_and_set_next_state(nullptr);
     }
   } break;
@@ -2492,16 +2499,14 @@ HttpSM::state_cache_open_write(int event, void *data)
 
   // Make sure we are on the "right" thread
   if (ua_txn) {
-    pending_action = ua_txn->adjust_thread(this, event, data);
-    if (!pending_action.empty()) {
+    if (pending_action) {
+      pending_action->cancel();
+    }
+    if ((pending_action = ua_txn->adjust_thread(this, event, data))) {
       HTTP_INCREMENT_DYN_STAT(http_cache_open_write_adjust_thread_stat);
       return 0; // Go away if we reschedule
     }
-    NetVConnection *vc = ua_txn->get_netvc();
-    ink_release_assert(vc && vc->thread == this_ethread());
   }
-
-  pending_action.clear_if_action_is(reinterpret_cast<Action *>(data));
 
   milestones[TS_MILESTONE_CACHE_OPEN_WRITE_END] = Thread::get_hrtime();
   pending_action                                = nullptr;
@@ -2611,8 +2616,6 @@ HttpSM::state_cache_open_read(int event, void *data)
 {
   STATE_ENTER(&HttpSM::state_cache_open_read, event);
 
-  pending_action.clear_if_action_is(reinterpret_cast<Action *>(data));
-
   ink_assert(server_entry == nullptr);
   ink_assert(t_state.cache_info.object_read == nullptr);
 
@@ -2643,13 +2646,13 @@ HttpSM::state_cache_open_read(int event, void *data)
   case CACHE_EVENT_OPEN_READ_FAILED:
     pending_action = nullptr;
 
-    SMDebug("http", "cache_open_read - CACHE_EVENT_OPEN_READ_FAILED with %s (%d)", InkStrerror(-cache_sm.get_last_error()),
-            -cache_sm.get_last_error());
+    SMDebug("http", "[%" PRId64 "] cache_open_read - CACHE_EVENT_OPEN_READ_FAILED with %s (%d)", sm_id,
+            InkStrerror(-(intptr_t)data), (int)(intptr_t)data);
 
     SMDebug("http", "open read failed.");
     // Inform HttpTransact somebody else is updating the document
     // HttpCacheSM already waited so transact should go ahead.
-    if (cache_sm.get_last_error() == -ECACHE_DOC_BUSY) {
+    if ((intptr_t)data == -ECACHE_DOC_BUSY) {
       t_state.cache_lookup_result = HttpTransact::CACHE_LOOKUP_DOC_BUSY;
     } else {
       t_state.cache_lookup_result = HttpTransact::CACHE_LOOKUP_MISS;
@@ -4197,7 +4200,13 @@ HttpSM::do_remap_request(bool run_inline)
   }
 
   SMDebug("url_rewrite", "Found a remap map entry, attempting to remap request and call any plugins");
-  pending_action = remapProcessor.perform_remap(this, &t_state);
+  Action *remap_action_handle = remapProcessor.perform_remap(this, &t_state);
+
+  if (remap_action_handle != ACTION_RESULT_DONE) {
+    SMDebug("url_rewrite", "Still more remapping needed for [%" PRId64 "]", sm_id);
+    ink_assert(!pending_action);
+    pending_action = remap_action_handle;
+  }
 
   return;
 }
@@ -4206,7 +4215,7 @@ void
 HttpSM::do_hostdb_lookup()
 {
   ink_assert(t_state.dns_info.lookup_name != nullptr);
-  ink_assert(pending_action.empty());
+  ink_assert(pending_action == nullptr);
 
   milestones[TS_MILESTONE_DNS_LOOKUP_BEGIN] = Thread::get_hrtime();
 
@@ -4223,8 +4232,13 @@ HttpSM::do_hostdb_lookup()
     if (t_state.api_txn_dns_timeout_value != -1) {
       opt.timeout = t_state.api_txn_dns_timeout_value;
     }
-    pending_action = hostDBProcessor.getSRVbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_srv_info, d, 0, opt);
-    if (pending_action.empty()) {
+    Action *srv_lookup_action_handle =
+      hostDBProcessor.getSRVbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_srv_info, d, 0, opt);
+
+    if (srv_lookup_action_handle != ACTION_RESULT_DONE) {
+      ink_assert(!pending_action);
+      pending_action = srv_lookup_action_handle;
+    } else {
       char const *host_name = t_state.dns_info.resolved_p ? t_state.dns_info.srv_hostname : t_state.dns_info.lookup_name;
       opt.port              = t_state.dns_info.resolved_p ?
                    t_state.dns_info.srv_port :
@@ -4236,8 +4250,12 @@ HttpSM::do_hostdb_lookup()
       opt.host_res_style =
         ats_host_res_from(ua_txn->get_netvc()->get_local_addr()->sa_family, t_state.txn_conf->host_res_data.order);
 
-      pending_action = hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info, host_name, 0, opt);
-      if (pending_action.empty()) {
+      Action *dns_lookup_action_handle =
+        hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info, host_name, 0, opt);
+      if (dns_lookup_action_handle != ACTION_RESULT_DONE) {
+        ink_assert(!pending_action);
+        pending_action = dns_lookup_action_handle;
+      } else {
         call_transact_and_set_next_state(nullptr);
       }
     }
@@ -4268,9 +4286,13 @@ HttpSM::do_hostdb_lookup()
 
     opt.host_res_style = ats_host_res_from(ua_txn->get_netvc()->get_local_addr()->sa_family, t_state.txn_conf->host_res_data.order);
 
-    pending_action = hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info,
-                                                   t_state.dns_info.lookup_name, 0, opt);
-    if (pending_action.empty()) {
+    Action *dns_lookup_action_handle = hostDBProcessor.getbyname_imm(this, (cb_process_result_pfn)&HttpSM::process_hostdb_info,
+                                                                     t_state.dns_info.lookup_name, 0, opt);
+
+    if (dns_lookup_action_handle != ACTION_RESULT_DONE) {
+      ink_assert(!pending_action);
+      pending_action = dns_lookup_action_handle;
+    } else {
       call_transact_and_set_next_state(nullptr);
     }
     return;
@@ -4283,13 +4305,18 @@ void
 HttpSM::do_hostdb_reverse_lookup()
 {
   ink_assert(t_state.dns_info.lookup_name != nullptr);
-  ink_assert(pending_action.empty());
+  ink_assert(pending_action == nullptr);
 
   SMDebug("http_seq", "Doing reverse DNS Lookup");
 
   IpEndpoint addr;
   ats_ip_pton(t_state.dns_info.lookup_name, &addr.sa);
-  pending_action = hostDBProcessor.getbyaddr_re(this, &addr.sa);
+  Action *dns_lookup_action_handle = hostDBProcessor.getbyaddr_re(this, &addr.sa);
+
+  if (dns_lookup_action_handle != ACTION_RESULT_DONE) {
+    ink_assert(!pending_action);
+    pending_action = dns_lookup_action_handle;
+  }
 
   return;
 }
@@ -4701,7 +4728,7 @@ HttpSM::do_cache_lookup_and_read()
 {
   // TODO decide whether to uncomment after finish testing redirect
   // ink_assert(server_txn == NULL);
-  ink_assert(pending_action.empty());
+  ink_assert(pending_action == nullptr);
 
   t_state.request_sent_time      = UNDEFINED_TIME;
   t_state.response_received_time = UNDEFINED_TIME;
@@ -4726,7 +4753,7 @@ HttpSM::do_cache_lookup_and_read()
   HttpCacheKey key;
   Cache::generate_key(&key, c_url, t_state.txn_conf->cache_generation_number);
 
-  pending_action = cache_sm.open_read(
+  Action *cache_action_handle = cache_sm.open_read(
     &key, c_url, &t_state.hdr_info.client_request, t_state.txn_conf,
     static_cast<time_t>((t_state.cache_control.pin_in_cache_for < 0) ? 0 : t_state.cache_control.pin_in_cache_for));
   //
@@ -4735,7 +4762,11 @@ HttpSM::do_cache_lookup_and_read()
   // optimize the typical open_read/open_read failed/open_write
   // sequence.
   //
-  REMEMBER((long)pending_action.get(), reentrancy_count);
+  if (cache_action_handle != ACTION_RESULT_DONE) {
+    ink_assert(!pending_action);
+    pending_action = cache_action_handle;
+  }
+  REMEMBER((long)pending_action, reentrancy_count);
 
   return;
 }
@@ -4748,9 +4779,16 @@ HttpSM::do_cache_delete_all_alts(Continuation *cont)
 
   SMDebug("http_seq", "Issuing cache delete for %s", t_state.cache_info.lookup_url->string_get_ref());
 
+  Action *cache_action_handle = nullptr;
   HttpCacheKey key;
   Cache::generate_key(&key, t_state.cache_info.lookup_url, t_state.txn_conf->cache_generation_number);
-  pending_action = cacheProcessor.remove(cont, &key);
+  cache_action_handle = cacheProcessor.remove(cont, &key);
+  if (cont != nullptr) {
+    if (cache_action_handle != ACTION_RESULT_DONE) {
+      ink_assert(!pending_action);
+      pending_action = cache_action_handle;
+    }
+  }
 
   return;
 }
@@ -4800,7 +4838,7 @@ HttpSM::do_cache_prepare_action(HttpCacheSM *c_sm, CacheHTTPInfo *object_read_in
   URL *o_url, *s_url;
   bool restore_client_request = false;
 
-  ink_assert(pending_action.empty());
+  ink_assert(!pending_action);
 
   if (t_state.redirect_info.redirect_in_process) {
     o_url = &(t_state.redirect_info.original_url);
@@ -4829,10 +4867,14 @@ HttpSM::do_cache_prepare_action(HttpCacheSM *c_sm, CacheHTTPInfo *object_read_in
   HttpCacheKey key;
   Cache::generate_key(&key, s_url, t_state.txn_conf->cache_generation_number);
 
-  pending_action =
+  Action *cache_action_handle =
     c_sm->open_write(&key, s_url, &t_state.hdr_info.client_request, object_read_info,
                      static_cast<time_t>((t_state.cache_control.pin_in_cache_for < 0) ? 0 : t_state.cache_control.pin_in_cache_for),
                      retry, allow_multiple);
+  if (cache_action_handle != ACTION_RESULT_DONE) {
+    ink_assert(!pending_action);
+    pending_action = cache_action_handle;
+  }
 }
 
 void
@@ -4939,9 +4981,15 @@ HttpSM::do_http_server_open(bool raw)
   auto fam_name = ats_ip_family_name(ip_family);
   SMDebug("http_track", "entered inside do_http_server_open ][%.*s]", static_cast<int>(fam_name.size()), fam_name.data());
 
-  NetVConnection *vc = ua_txn->get_netvc();
-  ink_release_assert(vc && vc->thread == this_ethread());
+  // Make sure we are on the "right" thread
+  if (ua_txn) {
+    if ((pending_action = ua_txn->adjust_thread(this, EVENT_INTERVAL, nullptr))) {
+      HTTP_INCREMENT_DYN_STAT(http_origin_connect_adjust_thread_stat);
+      return; // Go away if we reschedule
+    }
+  }
   pending_action = nullptr;
+  ink_assert(server_entry == nullptr);
 
   // Clean up connection tracking info if any. Need to do it now so the selected group
   // is consistent with the actual upstream in case of retry.
@@ -4960,7 +5008,7 @@ HttpSM::do_http_server_open(bool raw)
   ink_assert(ua_entry != nullptr || t_state.req_flavor == HttpTransact::REQ_FLAVOR_SCHEDULED_UPDATE ||
              t_state.req_flavor == HttpTransact::REQ_FLAVOR_REVPROXY);
 
-  ink_assert(pending_action.empty());
+  ink_assert(pending_action == nullptr);
   ink_assert(t_state.current.server->dst_addr.network_order_port() != 0);
 
   char addrbuf[INET6_ADDRPORTSTRLEN];
@@ -5192,7 +5240,7 @@ HttpSM::do_http_server_open(bool raw)
     if (ccount > t_state.txn_conf->outbound_conntrack.max) {
       ct_state.release();
 
-      ink_assert(pending_action.empty()); // in case of reschedule must not have already pending.
+      ink_assert(pending_action == nullptr); // in case of reschedule must not have already pending.
 
       // If the queue is disabled, reschedule.
       if (t_state.http_config_param->global_outbound_conntrack.queue_size < 0) {
@@ -5230,6 +5278,7 @@ HttpSM::do_http_server_open(bool raw)
   }
 
   // We did not manage to get an existing session and need to open a new connection
+  Action *connect_action_handle;
   NetVCOptions opt;
   opt.f_blocking_connect = false;
   opt.set_sock_param(t_state.txn_conf->sock_recv_buffer_size_out, t_state.txn_conf->sock_send_buffer_size_out,
@@ -5362,14 +5411,19 @@ HttpSM::do_http_server_open(bool raw)
       opt.set_ssl_servername(t_state.server_info.name);
     }
 
-    pending_action = sslNetProcessor.connect_re(this,                                 // state machine
-                                                &t_state.current.server->dst_addr.sa, // addr + port
-                                                &opt);
+    connect_action_handle = sslNetProcessor.connect_re(this,                                 // state machine
+                                                       &t_state.current.server->dst_addr.sa, // addr + port
+                                                       &opt);
   } else {
     SMDebug("http", "calling netProcessor.connect_re");
-    pending_action = netProcessor.connect_re(this,                                 // state machine
-                                             &t_state.current.server->dst_addr.sa, // addr + port
-                                             &opt);
+    connect_action_handle = netProcessor.connect_re(this,                                 // state machine
+                                                    &t_state.current.server->dst_addr.sa, // addr + port
+                                                    &opt);
+  }
+
+  if (connect_action_handle != ACTION_RESULT_DONE) {
+    ink_assert(!pending_action);
+    pending_action = connect_action_handle;
   }
 
   return;
@@ -7097,10 +7151,11 @@ HttpSM::kill_this()
     // state. This is because we are depending on the
     // callout to complete for the state machine to
     // get killed.
-    if (callout_state == HTTP_API_NO_CALLOUT && !pending_action.empty()) {
+    if (callout_state == HTTP_API_NO_CALLOUT && pending_action) {
+      pending_action->cancel();
       pending_action = nullptr;
-    } else if (!pending_action.empty()) {
-      ink_assert(pending_action.empty());
+    } else if (pending_action) {
+      ink_assert(pending_action == nullptr);
     }
 
     cache_sm.end_both();
@@ -7160,7 +7215,10 @@ HttpSM::kill_this()
   //   then the value of kill_this_async_done has changed so
   //   we must check it again
   if (kill_this_async_done == true) {
-    pending_action = nullptr;
+    if (pending_action) {
+      pending_action->cancel();
+      pending_action = nullptr;
+    }
     if (t_state.http_config_param->enable_http_stats) {
       update_stats();
     }
@@ -7198,7 +7256,7 @@ HttpSM::kill_this()
       plugin_tunnel = nullptr;
     }
 
-    ink_assert(pending_action.empty());
+    ink_assert(pending_action == nullptr);
     ink_release_assert(vc_table.is_table_clear() == true);
     ink_release_assert(tunnel.is_tunnel_active() == false);
 
@@ -7781,10 +7839,16 @@ HttpSM::set_next_state()
     break;
   }
 
-  case HttpTransact::SM_ACTION_INTERNAL_REQUEST:
+  case HttpTransact::SM_ACTION_INTERNAL_REQUEST: {
     HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_handle_stat_page);
-    pending_action = statPagesManager.handle_http(this, &t_state.hdr_info.client_request);
+    Action *action_handle = statPagesManager.handle_http(this, &t_state.hdr_info.client_request);
+
+    if (action_handle != ACTION_RESULT_DONE) {
+      ink_assert(pending_action == nullptr);
+      pending_action = action_handle;
+    }
     break;
+  }
 
   case HttpTransact::SM_ACTION_ORIGIN_SERVER_RR_MARK_DOWN: {
     HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_mark_os_down);
@@ -8187,7 +8251,7 @@ HttpSM::get_http_schedule(int event, void * /* data ATS_UNUSED */)
 
     if (!plugin_lock) {
       HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::get_http_schedule);
-      ink_assert(pending_action.empty());
+      ink_assert(pending_action == nullptr);
       pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
       return 0;
     } else {

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -384,8 +384,8 @@ private:
   HttpCacheSM transform_cache_sm;
 
   HttpSMHandler default_handler = nullptr;
-  PendingAction pending_action;
-  Continuation *schedule_cont = nullptr;
+  Action *pending_action        = nullptr;
+  Continuation *schedule_cont   = nullptr;
 
   HTTPParser http_parser;
   void start_sub_sm();


### PR DESCRIPTION
**Motivation**:  In a production system that was configured to chase redirects, we noticed a dramatic increase in aborts and began caching (and serving) the intermediate 302 response instead of chasing the redirect.

**Possible Fix**: Revert PRs #7667 and #7807.

PR #7807 could leave the  HTTP State machine in a INACTIVE state. 

For example, if state_cache_open_read is rescheduled in an error using the below code.


```
case CACHE_EVENT_OPEN_READ_FAILED:
    if ((intptr_t)data == -ECACHE_DOC_BUSY) {
      // Somebody else is writing the object
      if (open_read_tries <= master_sm->t_state.txn_conf->max_cache_open_read_retries) {
        // Retry to read; maybe the update finishes in time
        open_read_cb = false;
        do_schedule_in();
      } else {
```
This code will return to event system leaving the state machine in a INACTIVE state and results in an abort.
```
  if (captive_action.cancelled == 1) {
    return VC_EVENT_CONT; // SM gave up on us
  }
```

This can be easily reproduced by setting proxy.config.http.number_of_redirections greater than zero.(https://docs.trafficserver.apache.org/en/8.1.x/admin-guide/files/records.config.en.html#proxy-config-http-number-of-redirections)


Although I like the idea behind #7667, I am proposing reverting #7667 along with #7807 as there were concerns about the crashes with 7667. I am yet to look at PRs #8423 and #8443
