### PR TITLE
Add an SNI action to reject QUIC connections

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -45,7 +45,7 @@ the user needs to enter the fqdn in the configuration with a ``*.`` followed by 
 For some settings, there is no guarantee that they will be applied to a connection under certain conditions.
 An established TLS connection may be reused for another server name if it’s used for HTTP/2. This also means that settings
 for server name A may affects requests for server name B as well. See https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/
-for a more detailed description of HTTP/2 connection coalescing. Similar thing can happen on a QUIC connection for HTTP/3 as welll.
+for a more detailed description of HTTP/2 connection coalescing. Similar thing can happen on a QUIC connection for HTTP/3 as well.
 
 .. _override-verify-server-policy:
 .. _override-verify-server-properties:

--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -45,7 +45,7 @@ the user needs to enter the fqdn in the configuration with a ``*.`` followed by 
 For some settings, there is no guarantee that they will be applied to a connection under certain conditions.
 An established TLS connection may be reused for another server name if it’s used for HTTP/2. This also means that settings
 for server name A may affects requests for server name B as well. See https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/
-for a more detailed description of HTTP/2 connection coalescing.
+for a more detailed description of HTTP/2 connection coalescing. Similar thing can happen on a QUIC connection for HTTP/3 as welll.
 
 .. _override-verify-server-policy:
 .. _override-verify-server-properties:
@@ -173,6 +173,10 @@ http2                     Inbound   Indicates whether the H2 protocol should be 
 http2_buffer_water_mark   Inbound   Specifies the high water mark for all HTTP/2 frames on an outoging connection.
                                     By default this is :ts:cv:`proxy.config.http2.default_buffer_water_mark`.
                                     NOTE: Connection coalescing may prevent this taking effect.
+
+quic                      Inbound   Indicates whether QUIC connections should be accepted. The valid values are :code:`on` or
+                                    :code:`off`. Note that this is an additional setting to configure QUIC availability per server
+                                    name. You need to configure :ts:cv:`proxy.config.http.server_ports` to open ports for QUIC.
 
 tunnel_route              Inbound   Destination as an FQDN and port, separated by a colon ``:``.
                                     Match group number can be specified by ``$N`` where N should refer to a specified group

--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -45,7 +45,7 @@ the user needs to enter the fqdn in the configuration with a ``*.`` followed by 
 For some settings, there is no guarantee that they will be applied to a connection under certain conditions.
 An established TLS connection may be reused for another server name if it’s used for HTTP/2. This also means that settings
 for server name A may affects requests for server name B as well. See https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/
-for a more detailed description of HTTP/2 connection coalescing. Similar thing can happen on a QUIC connection for HTTP/3 as well.
+for a more detailed description of HTTP/2 connection coalescing. A similar thing can happen on a QUIC connection for HTTP/3 as well.
 
 .. _override-verify-server-policy:
 .. _override-verify-server-properties:
@@ -175,8 +175,9 @@ http2_buffer_water_mark   Inbound   Specifies the high water mark for all HTTP/2
                                     NOTE: Connection coalescing may prevent this taking effect.
 
 quic                      Inbound   Indicates whether QUIC connections should be accepted. The valid values are :code:`on` or
-                                    :code:`off`. Note that this is an additional setting to configure QUIC availability per server
-                                    name. You need to configure :ts:cv:`proxy.config.http.server_ports` to open ports for QUIC.
+                                    :code:`off`. Note that this is a more specific setting to configure QUIC availability per server
+                                    name. More broadly, you will also need to configure :ts:cv:`proxy.config.http.server_ports` to
+                                    open ports for QUIC.
 
 tunnel_route              Inbound   Destination as an FQDN and port, separated by a colon ``:``.
                                     Match group number can be specified by ``$N`` where N should refer to a specified group

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -117,6 +117,11 @@ test_LDADD = \
 	@YAMLCPP_LIBS@ \
 	-lm
 
+if ENABLE_QUIC
+test_LDADD += \
+  $(top_builddir)/iocore/net/quic/libquic.a
+endif
+
 check_PROGRAMS = \
   test_Cache \
   test_RWW \

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -121,6 +121,11 @@ test_libinknet_LDADD = \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@ @SWOC_LIBS@
 
+if ENABLE_QUIC
+test_libinknet_LDADD += \
+	$(top_builddir)/iocore/net/quic/libquic.a
+endif
+
 libinknet_a_SOURCES = \
 	ALPNSupport.cc \
 	BIO_fastopen.cc \

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -86,6 +86,11 @@ test_UDPNet_LDADD = \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@ @SWOC_LIBS@
 
+if ENABLE_QUIC
+test_UDPNet_LDADD += \
+	$(top_builddir)/iocore/net/quic/libquic.a
+endif
+
 test_UDPNet_SOURCES = \
 	libinknet_stub.cc \
 	test_I_UDPNet.cc

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -46,13 +46,19 @@
 class ControlQUIC : public ActionItem
 {
 public:
+#if TS_USE_QUIC == 1
   ControlQUIC(bool turn_on) : enable_quic(turn_on) {}
+#else
+  ControlQUIC(bool turn_on);
+#endif
   ~ControlQUIC() override {}
 
   int SNIAction(TLSSNISupport *snis, const Context &ctx) const override;
 
 private:
+#if TS_USE_QUIC == 1
   bool enable_quic = false;
+#endif
 };
 
 class ControlH2 : public ActionItem

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -36,9 +36,6 @@
 #include "I_EventSystem.h"
 #include "P_SSLNextProtocolAccept.h"
 #include "P_SSLNetVConnection.h"
-#if TS_USE_QUIC == 1
-#include "P_QUICNetVConnection.h"
-#endif
 #include "SNIActionPerformer.h"
 #include "SSLTypes.h"
 
@@ -52,28 +49,7 @@ public:
   ControlQUIC(bool turn_on) : enable_quic(turn_on) {}
   ~ControlQUIC() override {}
 
-  int
-  SNIAction(TLSSNISupport *snis, const Context &ctx) const override
-  {
-    if (enable_quic) {
-      return SSL_TLSEXT_ERR_OK;
-    }
-
-#if TS_USE_QUIC == 1
-    // This action is only available for QUIC connections
-    auto *quic_vc = dynamic_cast<QUICNetVConnection *>(snis);
-    if (quic_vc == nullptr) {
-      return SSL_TLSEXT_ERR_OK;
-    }
-
-    if (is_debug_tag_set("ssl_sni")) {
-      const char *servername = quic_vc->get_server_name();
-      Debug("ssl_sni", "Rejecting handshake, fqdn [%s]", servername);
-    }
-#endif
-
-    return SSL_TLSEXT_ERR_ALERT_FATAL;
-  }
+  int SNIAction(TLSSNISupport *snis, const Context &ctx) const override;
 
 private:
   bool enable_quic = false;

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -36,7 +36,9 @@
 #include "I_EventSystem.h"
 #include "P_SSLNextProtocolAccept.h"
 #include "P_SSLNetVConnection.h"
+#if TS_USE_QUIC == 1
 #include "P_QUICNetVConnection.h"
+#endif
 #include "SNIActionPerformer.h"
 #include "SSLTypes.h"
 
@@ -57,6 +59,7 @@ public:
       return SSL_TLSEXT_ERR_OK;
     }
 
+#if TS_USE_QUIC == 1
     // This action is only available for QUIC connections
     auto *quic_vc = dynamic_cast<QUICNetVConnection *>(snis);
     if (quic_vc == nullptr) {
@@ -67,6 +70,7 @@ public:
       const char *servername = quic_vc->get_server_name();
       Debug("ssl_sni", "Rejecting handshake, fqdn [%s]", servername);
     }
+#endif
 
     return SSL_TLSEXT_ERR_ALERT_FATAL;
   }

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -49,7 +49,7 @@ public:
 #if TS_USE_QUIC == 1
   ControlQUIC(bool turn_on) : enable_quic(turn_on) {}
 #else
-  ControlQUIC(bool turn_on);
+  ControlQUIC(bool turn_on) {}
 #endif
   ~ControlQUIC() override {}
 

--- a/iocore/net/SNIActionPerformer.cc
+++ b/iocore/net/SNIActionPerformer.cc
@@ -48,7 +48,7 @@ ControlQUIC::SNIAction(TLSSNISupport *snis, const Context &ctx) const
 
   if (is_debug_tag_set("ssl_sni")) {
     const char *servername = quic_vc->get_server_name();
-    Debug("ssl_sni", "Rejecting handshake, fqdn [%s]", servername);
+    Debug("ssl_sni", "Rejecting handshake due to QUIC being disabled for fqdn [%s]", servername);
   }
 
   return SSL_TLSEXT_ERR_ALERT_FATAL;

--- a/iocore/net/SSLSNIConfig.cc
+++ b/iocore/net/SSLSNIConfig.cc
@@ -119,6 +119,9 @@ SNIConfigParams::load_sni_config()
     if (item.offer_h2.has_value()) {
       ai->actions.push_back(std::make_unique<ControlH2>(item.offer_h2.value()));
     }
+    if (item.offer_quic.has_value()) {
+      ai->actions.push_back(std::make_unique<ControlQUIC>(item.offer_quic.value()));
+    }
     if (item.verify_client_level != 255) {
       ai->actions.push_back(
         std::make_unique<VerifyClient>(item.verify_client_level, item.verify_client_ca_file, item.verify_client_ca_dir));

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -151,6 +151,7 @@ std::set<std::string> valid_sni_config_keys = {TS_fqdn,
                                                TS_client_sni_policy,
                                                TS_http2,
                                                TS_http2_buffer_water_mark,
+                                               TS_quic,
                                                TS_ip_allow,
 #if TS_USE_HELLO_CB || defined(OPENSSL_IS_BORINGSSL)
                                                TS_valid_tls_versions_in,
@@ -183,6 +184,9 @@ template <> struct convert<YamlSNIConfig::Item> {
     }
     if (node[TS_http2_buffer_water_mark]) {
       item.http2_buffer_water_mark = node[TS_http2_buffer_water_mark].as<int>();
+    }
+    if (node[TS_quic]) {
+      item.offer_quic = node[TS_quic].as<bool>();
     }
 
     // enum

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -57,6 +57,7 @@ TSDECL(valid_tls_version_min_in);
 TSDECL(valid_tls_version_max_in);
 TSDECL(http2);
 TSDECL(http2_buffer_water_mark);
+TSDECL(quic);
 TSDECL(host_sni_policy);
 TSDECL(server_max_early_data);
 #undef TSDECL
@@ -71,7 +72,8 @@ struct YamlSNIConfig {
 
   struct Item {
     std::string fqdn;
-    std::optional<bool> offer_h2; // Has no value by default, so do not initialize!
+    std::optional<bool> offer_h2;   // Has no value by default, so do not initialize!
+    std::optional<bool> offer_quic; // Has no value by default, so do not initialize!
     uint8_t verify_client_level = 255;
     std::string verify_client_ca_file;
     std::string verify_client_ca_dir;

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -114,11 +114,6 @@ test_proxy_http_LDADD = \
 	@SWOC_LIBS@ @HWLOC_LIBS@ \
 	@LIBCAP@
 
-if ENABLE_QUIC
-test_proxy_http_LDADD += \
-	$(top_builddir)/iocore/net/quic/libquic.a
-endif
-
 test_PreWarm_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	-I$(abs_top_srcdir)/lib/catch2
@@ -159,6 +154,11 @@ test_HttpTransact_LDADD  =  \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	-lz -llzma -lcrypto -lresolv -lssl \
 	@LIBPCRE@ @HWLOC_LIBS@ @SWOC_LIBS@
+
+if ENABLE_QUIC
+test_HttpTransact_LDADD += \
+	$(top_builddir)/iocore/net/quic/libquic.a
+endif
 
 test_HttpTransact_SOURCES = \
 	../../iocore/cache/test/stub.cc \

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -114,6 +114,11 @@ test_proxy_http_LDADD = \
 	@SWOC_LIBS@ @HWLOC_LIBS@ \
 	@LIBCAP@
 
+if ENABLE_QUIC
+test_proxy_http_LDADD += \
+	$(top_builddir)/iocore/net/quic/libquic.a
+endif
+
 test_PreWarm_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	-I$(abs_top_srcdir)/lib/catch2


### PR DESCRIPTION
Adds `quic` SNI action to on/off QUIC availability per server name.

This depends on #9347.