### PR TITLE
Cleanup of legacy, makes newer clang-format crash right now

### DIFF
--- a/plugins/experimental/sslheaders/expand.cc
+++ b/plugins/experimental/sslheaders/expand.cc
@@ -105,7 +105,7 @@ x509_expand_notafter(X509 *x509, BIO *bio)
   ASN1_TIME_print(bio, time);
 }
 
-static const std::array<x509_expansion, SSL_HEADERS_FIELD_MAX> expansions = {{
+static const std::array<x509_expansion, SSL_HEADERS_FIELD_MAX> expansions = {
   x509_expand_none,        // SSL_HEADERS_FIELD_NONE
   x509_expand_certificate, // SSL_HEADERS_FIELD_CERTIFICATE
   x509_expand_subject,     // SSL_HEADERS_FIELD_SUBJECT
@@ -114,7 +114,7 @@ static const std::array<x509_expansion, SSL_HEADERS_FIELD_MAX> expansions = {{
   x509_expand_signature,   // SSL_HEADERS_FIELD_SIGNATURE
   x509_expand_notbefore,   // SSL_HEADERS_FIELD_NOTBEFORE
   x509_expand_notafter,    // SSL_HEADERS_FIELD_NOTAFTER
-}};
+};
 
 bool
 SslHdrExpandX509Field(BIO *bio, X509 *x509, ExpansionField field)


### PR DESCRIPTION
This should not be needed as of a C++11 revision from like 12 years ago. Unfortunately, the double {{ }} makes my new version of clang-format crash. I think this change should be safe.