### PR TITLE
tunnel_route: Support local inbound and proxy protocol ports

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -172,6 +172,11 @@ tunnel_route              Inbound   Destination as an FQDN and port, separated b
                                     Protocol <proxy-protocol>` for more information on Proxy Protocol and how it is
                                     configured for |TS|.
 
+                                    For each of these tunnel targets, unless the port is explicitly specified in the target
+                                    (e.g., if the port is derived from the Proxy Protocol header), the port must be
+                                    specified in the :ts:cv:`proxy.config.http.connect_ports` configuration in order for
+                                    the tunnel to succeed.
+
 forward_route             Inbound   Destination as an FQDN and port, separated by a colon ``:``.
 
                                     This is similar to tunnel_route, but it terminates the TLS connection and forwards the
@@ -319,7 +324,8 @@ Second part is using multiple groups, having ``bob.bar.example.com`` as FQDN, ``
 ``bar.some.bob.yahoo``.
 
 Establish a blind tunnel to the backend server, connecting to the server's port with the destination port specified
-in the Proxy Protocol from the inbound connection.
+in the Proxy Protocol from the inbound connection. Remember to add any expected values for ``{proxy_protocol_port}`` to
+the :ts:cv:`proxy.config.http.connect_ports` list.
 
 .. code-block:: yaml
 

--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -159,6 +159,19 @@ tunnel_route              Inbound   Destination as an FQDN and port, separated b
                                     This will forward all traffic to the specified destination without first terminating
                                     the incoming TLS connection.
 
+                                    The destination port can be designated with the literal string
+                                    ``{inbound_local_port}`` to specify that |TS| should connect to the tunnel route's
+                                    port on the same destination port that the incoming connection had. For
+                                    example, if a client connected to |TS| on port ``4443`` and the associated
+                                    ``tunnel_route`` had ``{inbound_local_port}`` for the port designation, then |TS|
+                                    will connect to the specified host using port ``4443``.
+
+                                    The destination port can also be designated with the literal string
+                                    ``{proxy_protocol_port}``, in which case |TS| will connect to the specified host on
+                                    the port that was specified by the incoming Proxy Protocol payload. See :ref:`Proxy
+                                    Protocol <proxy-protocol>` for more information on Proxy Protocol and how it is
+                                    configured for |TS|.
+
 forward_route             Inbound   Destination as an FQDN and port, separated by a colon ``:``.
 
                                     This is similar to tunnel_route, but it terminates the TLS connection and forwards the
@@ -304,6 +317,15 @@ FQDN ``some.foo.com`` will match and the captured string will be replaced in the
 ``some.myfoo``.
 Second part is using multiple groups, having ``bob.bar.example.com`` as FQDN, ``tunnel_route`` will end up being
 ``bar.some.bob.yahoo``.
+
+Establish a blind tunnel to the backend server, connecting to the server's port with the destination port specified
+in the Proxy Protocol from the inbound connection.
+
+.. code-block:: yaml
+
+   sni:
+   - fqdn: tunnel-pp.example.com
+     tunnel_route: my.backend.example.com:{proxy_protocol_port}
 
 See Also
 ========

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -100,8 +100,8 @@ class TunnelDestination : public ActionItem
     MAP_WITH_PROXY_PROTOCOL_PORT, // Use port from the proxy protocol
     MAX                           // Always at the end and do not change the value of the above items.
   };
-  const std::string MAP_WITH_RECV_PORT_STR           = "{inbound_local_port}";
-  const std::string MAP_WITH_PROXY_PROTOCOL_PORT_STR = "{proxy_protocol_port}";
+  static constexpr std::string_view MAP_WITH_RECV_PORT_STR           = "{inbound_local_port}";
+  static constexpr std::string_view MAP_WITH_PROXY_PROTOCOL_PORT_STR = "{proxy_protocol_port}";
 
 public:
   TunnelDestination(const std::string_view &dest, SNIRoutingType type, YamlSNIConfig::TunnelPreWarm prewarm,
@@ -225,7 +225,7 @@ private:
 
   std::string destination;
 
-  /// The start position of a tunnel destination variable.
+  /// The start position of a tunnel destination variable, such as '{proxy_protocol_port}'.
   size_t var_start_pos{0};
   SNIRoutingType type                         = SNIRoutingType::NONE;
   YamlSNIConfig::TunnelPreWarm tunnel_prewarm = YamlSNIConfig::TunnelPreWarm::UNSET;
@@ -234,7 +234,7 @@ private:
   OpId fnArrIndex{OpId::DEFAULT}; /// On creation, we decide which function needs to be called, set the index and then we
                                   /// call it with the relevant data
 
-  // callback array.
+  /// tunnel_route destination callback array.
   static std::array<std::function<std::string(std::string_view,    // destination view
                                               size_t,              // The start position for any relevant tunnel_route variable.
                                               const Context &,     // Context

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -168,7 +168,7 @@ public:
     SSLNetVConnection *ssl_netvc = dynamic_cast<SSLNetVConnection *>(snis);
     const char *servername       = snis->get_sni_server_name();
     if (ssl_netvc) {
-      if (fnArrIndex < 0) {
+      if (fnArrIndex == OpId::DEFAULT) {
         ssl_netvc->set_tunnel_destination(destination, type, !TLSTunnelSupport::PORT_IS_DYNAMIC, tunnel_prewarm);
         Debug("ssl_sni", "Destination now is [%s], fqdn [%s]", destination.c_str(), servername);
       } else {

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -38,6 +38,7 @@
 #include "swoc/TextView.h"
 
 #include "tscore/ink_inet.h"
+#include "swoc/TextView.h"
 
 #include <vector>
 
@@ -242,7 +243,7 @@ private:
           real_dst += *c;
           continue;
         }
-        const std::size_t group_index = std::stoi(std::string{number_str});
+        const std::size_t group_index = swoc::svtoi(std::string{number_str});
         if ((group_index - 1) < groups.size()) {
           // place the captured group.
           real_dst += groups[group_index - 1];

--- a/iocore/net/TLSTunnelSupport.cc
+++ b/iocore/net/TLSTunnelSupport.cc
@@ -63,11 +63,12 @@ TLSTunnelSupport::_clear()
 }
 
 void
-TLSTunnelSupport::set_tunnel_destination(const std::string_view &destination, SNIRoutingType type,
+TLSTunnelSupport::set_tunnel_destination(const std::string_view &destination, SNIRoutingType type, bool port_is_dynamic,
                                          YamlSNIConfig::TunnelPreWarm prewarm)
 {
-  _tunnel_type    = type;
-  _tunnel_prewarm = prewarm;
+  _tunnel_type     = type;
+  _tunnel_prewarm  = prewarm;
+  _port_is_dynamic = port_is_dynamic;
 
   if (std::string_view host, port; swoc::IPEndpoint::tokenize(destination, &host, &port)) {
     _tunnel_port = swoc::svtou(port);

--- a/iocore/net/TLSTunnelSupport.h
+++ b/iocore/net/TLSTunnelSupport.h
@@ -45,9 +45,13 @@ public:
   SNIRoutingType get_tunnel_type() const;
   std::string_view get_tunnel_host() const;
   ushort get_tunnel_port() const;
+  bool tunnel_port_is_dynamic() const;
 
   bool has_tunnel_destination() const;
-  void set_tunnel_destination(const std::string_view &destination, SNIRoutingType type, YamlSNIConfig::TunnelPreWarm prewarm);
+
+  static constexpr bool PORT_IS_DYNAMIC = true;
+  void set_tunnel_destination(const std::string_view &destination, SNIRoutingType type, bool port_is_dynamic,
+                              YamlSNIConfig::TunnelPreWarm prewarm);
   YamlSNIConfig::TunnelPreWarm get_tunnel_prewarm_configuration() const;
 
 protected:
@@ -60,6 +64,10 @@ private:
   in_port_t _tunnel_port                       = 0;
   SNIRoutingType _tunnel_type                  = SNIRoutingType::NONE;
   YamlSNIConfig::TunnelPreWarm _tunnel_prewarm = YamlSNIConfig::TunnelPreWarm::UNSET;
+
+  /** Whether the tunnel destination port is statically configured or
+   * dynamically derived from runtime information on the wire. */
+  bool _port_is_dynamic = false;
 };
 
 inline SNIRoutingType
@@ -84,6 +92,12 @@ inline ushort
 TLSTunnelSupport::get_tunnel_port() const
 {
   return _tunnel_port;
+}
+
+inline bool
+TLSTunnelSupport::tunnel_port_is_dynamic() const
+{
+  return _port_is_dynamic;
 }
 
 /**

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -353,3 +353,56 @@ template <> struct convert<YamlSNIConfig::Item> {
   }
 };
 } // namespace YAML
+
+// Initialize the static TunnelDestination::fix_destination.
+std::array<std::function<std::string(std::string_view,            // destination view
+                                     size_t,                      // The start position for any relevant tunnel_route variable.
+                                     const ActionItem::Context &, // Context
+                                     SSLNetVConnection *,         // Net vc to get the port.
+                                     bool &                       // Whether the port is derived from information on the wire.
+                                     )>,
+           TunnelDestination::OpId::MAX>
+  TunnelDestination::fix_destination = {
+
+    // Replace wildcards with matched groups.
+    [](std::string_view destination, size_t var_start_pos, const Context &ctx, SSLNetVConnection *,
+       bool &port_is_dynamic) -> std::string {
+      port_is_dynamic = false;
+      if ((destination.find_first_of('$') != std::string::npos) && ctx._fqdn_wildcard_captured_groups) {
+        auto const fixed_dst =
+          TunnelDestination::replace_match_groups(destination, *ctx._fqdn_wildcard_captured_groups, port_is_dynamic);
+        return fixed_dst;
+      }
+      return {};
+    },
+
+    // Use local port for the tunnel.
+    [](std::string_view destination, size_t var_start_pos, const Context &ctx, SSLNetVConnection *vc,
+       bool &port_is_dynamic) -> std::string {
+      port_is_dynamic = true;
+      if (vc) {
+        if (var_start_pos != std::string::npos) {
+          const auto local_port = vc->get_local_port();
+          std::string dst{destination.substr(0, var_start_pos)};
+          dst += std::to_string(local_port);
+          return dst;
+        }
+      }
+      return {};
+    },
+
+    // Use the Proxy Protocol port for the tunnel.
+    [](std::string_view destination, size_t var_start_pos, const Context &ctx, SSLNetVConnection *vc,
+       bool &port_is_dynamic) -> std::string {
+      port_is_dynamic = true;
+      if (vc) {
+        if (var_start_pos != std::string::npos) {
+          const auto local_port = vc->get_proxy_protocol_dst_port();
+          std::string dst{destination.substr(0, var_start_pos)};
+          dst += std::to_string(local_port);
+          return dst;
+        }
+      }
+      return {};
+    },
+};

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -663,6 +663,7 @@ HttpSM::setup_blind_tunnel_port()
         auto tunnel_host = tts->get_tunnel_host();
         t_state.hdr_info.client_request.url_get()->host_set(tunnel_host.data(), tunnel_host.size());
         if (tts->get_tunnel_port() > 0) {
+          t_state.tunnel_port_is_dynamic = tts->tunnel_port_is_dynamic();
           t_state.hdr_info.client_request.url_get()->port_set(tts->get_tunnel_port());
         } else {
           t_state.hdr_info.client_request.url_get()->port_set(netvc->get_local_port());

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -5361,6 +5361,7 @@ HttpTransact::check_request_validity(State *s, HTTPHdr *incoming_hdr)
     }
     if ((method == HTTP_WKSIDX_CONNECT) && !s->transparent_passthrough &&
         (!is_port_in_range(incoming_hdr->url_get()->port_get(), s->http_config_param->connect_ports))) {
+      TxnDebug("http_trans", "Rejected a CONNECT to port %d not in connect_ports", incoming_hdr->url_get()->port_get());
       return BAD_CONNECT_PORT;
     }
 
@@ -6366,8 +6367,16 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
   RequestError_t incoming_error;
   URL *url = nullptr;
 
-  // If we are blind tunneling the header is just a synthesized placeholder anyway
+  // If we are blind tunneling the header is just a synthesized placeholder anyway.
+  // But we do have to check that we are not tunneling to a dynamic port that is
+  // not in the connect_ports list.
   if (s->client_info.port_attribute == HttpProxyPort::TRANSPORT_BLIND_TUNNEL) {
+    if (!is_port_in_range(incoming_request->url_get()->port_get(), s->http_config_param->connect_ports)) {
+      TxnDebug("http_trans", "Rejected a tunnel to port %d not in connect_ports", incoming_request->url_get()->port_get());
+      return false;
+      ;
+    }
+
     return true;
   }
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6371,12 +6371,11 @@ HttpTransact::is_request_valid(State *s, HTTPHdr *incoming_request)
   // But we do have to check that we are not tunneling to a dynamic port that is
   // not in the connect_ports list.
   if (s->client_info.port_attribute == HttpProxyPort::TRANSPORT_BLIND_TUNNEL) {
-    if (!is_port_in_range(incoming_request->url_get()->port_get(), s->http_config_param->connect_ports)) {
+    if (s->tunnel_port_is_dynamic &&
+        !is_port_in_range(incoming_request->url_get()->port_get(), s->http_config_param->connect_ports)) {
       TxnDebug("http_trans", "Rejected a tunnel to port %d not in connect_ports", incoming_request->url_get()->port_get());
       return false;
-      ;
     }
-
     return true;
   }
 

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -813,6 +813,14 @@ public:
       return *p;
     }
 
+    /** Whether a tunnel is requested to a port which has ben dynamically
+     * determined by parsing traffic content.
+     *
+     * Dynamically determined ports require verification against the
+     * proxy.config.http.connect_ports.
+     */
+    bool tunnel_port_is_dynamic = false;
+
     ResponseAction response_action;
 
     // Methods

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -813,7 +813,7 @@ public:
       return *p;
     }
 
-    /** Whether a tunnel is requested to a port which has ben dynamically
+    /** Whether a tunnel is requested to a port which has been dynamically
      * determined by parsing traffic content.
      *
      * Dynamically determined ports require verification against the

--- a/tests/gold_tests/tls/proxy_protocol_client.py
+++ b/tests/gold_tests/tls/proxy_protocol_client.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import argparse
+import socket
+import sys
+import struct
+import ssl
+
+
+VERSION_2_SIGNATURE = b'\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A'
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "server_address",
+        help="The server IP address to connect to.")
+    parser.add_argument(
+        "server_port",
+        type=int,
+        help="The server port to connect to.")
+    parser.add_argument(
+        "sni",
+        help="The SNI to include in the CLIENT_HELLO.")
+    parser.add_argument(
+        "proxy_src_ip",
+        help="The source IP address in the PROXY message.")
+    parser.add_argument(
+        "proxy_dest_ip",
+        help="The destination IP address in the PROXY message.")
+    parser.add_argument(
+        "proxy_src_port",
+        type=int,
+        help="The source port in the PROXY message.")
+    parser.add_argument(
+        "proxy_dest_port",
+        type=int,
+        help="The destination port in the PROXY message.")
+    parser.add_argument(
+        "protocol_version",
+        type=int,
+        choices=[1, 2],
+        help="the proxy protocol version(either 1 or 2).")
+    parser.add_argument(
+        "--https",
+        action="store_true",
+        help="Send https data after the PROXY message.")
+    return parser.parse_args()
+
+
+def construct_proxy_header_v1(src_addr: tuple, dst_addr: tuple) -> bytes:
+    """Construct a PROXY protocol v1 header.
+
+    :param src_addr: The source address and port.
+    :param dst_addr: The destination address.
+
+    :return: A PROXY protocol v1 header.
+    """
+    return f"PROXY TCP4 {src_addr[0]} {dst_addr[0]} {src_addr[1]} {dst_addr[1]}\r\n".encode()
+
+
+def construct_proxy_header_v2(src_addr: tuple, dst_addr: tuple) -> bytes:
+    """Construct a PROXY protocol v2 header.
+
+    :param src_addr: The source address.
+    :param dst_addr: The destination address.
+
+    :return: A PROXY protocol v2 header.
+    """
+    header = VERSION_2_SIGNATURE
+    # Protocol version 2 + PROXY command
+    header += b'\x21'
+    # TCP over IPv4
+    header += b'\x11'
+    # address length
+    header += b'\x00\x0C'
+    header += socket.inet_pton(socket.AF_INET, src_addr[0])
+    header += socket.inet_pton(socket.AF_INET, dst_addr[0])
+    header += struct.pack('!H', src_addr[1])
+    header += struct.pack('!H', dst_addr[1])
+    return header
+
+
+def send_proxy_header(
+        socket: socket.socket,
+        src_ip: str,
+        src_port: str,
+        dest_ip: int,
+        dest_port: int,
+        proxy_protocol_version: int) -> None:
+    """Send the specified PROXY protocol header.
+
+    :param socket: The socket to send the header on.
+    :param src_ip: The source IP address.
+    :param src_port: The source port.
+    :param dest_ip: The destination IP address.
+    :param dest_port: The destination port.
+    :param proxy_protocol_version: The PROXY protocol version.
+    """
+    logging.info(f'Sending PROXY protocol version {proxy_protocol_version}')
+    if proxy_protocol_version == 1:
+        header = construct_proxy_header_v1((src_ip, src_port),
+                                           (dest_ip, dest_port))
+    elif proxy_protocol_version == 2:
+        header = construct_proxy_header_v2((src_ip, src_port),
+                                           (dest_ip, dest_port))
+    else:
+        raise ValueError(
+            f'Invalid proxy protocol version: {proxy_protocol_version}')
+
+    socket.sendall(header)
+
+
+def send_and_receive_http(sock: socket.socket, host: str) -> None:
+    """Send and receive HTTP data on the specified socket.
+
+    :param sock: The socket to send and receive data on.
+    :param host: The Host header value to send in the HTTP request.
+    """
+    request = f"GET /proxy_protocol HTTP/1.1\r\nHost: {host}\r\n\r\n"
+    logging.info("Sending:")
+    logging.info(f'\n{request}')
+    sock.sendall(request.encode())
+
+    response = b''
+    while True:
+        data = sock.recv(1024)
+        if not data:
+            break
+        response += data
+    logging.info("Received:")
+    logging.info(f'\n{response.decode()}')
+
+
+def main() -> None:
+    """Open and HTTP(S) connection with a Proxy Protocol header."""
+    args = parse_args()
+    with socket.create_connection((args.server_address, args.server_port)) as sock:
+        # send the PROXY header
+        send_proxy_header(sock, args.proxy_src_ip, args.proxy_src_port,
+                          args.proxy_dest_ip, args.proxy_dest_port, args.protocol_version)
+        if args.https:
+            # https
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+            with context.wrap_socket(sock, server_hostname=args.sni) as ssock:
+                send_and_receive_http(ssock, args.sni)
+        else:
+            # plain http
+            send_and_receive_http(sock, args.sni)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    sys.exit(main())

--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -16,6 +16,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import sys
+
 Test.Summary = '''
 Test tunneling based on SNI
 '''
@@ -25,14 +27,24 @@ ts = Test.MakeATSProcess("ts", enable_tls=True, enable_proxy_protocol=True)
 server_foo = Test.MakeOriginServer("server_foo", ssl=True)
 server_bar = Test.MakeOriginServer("server_bar", ssl=True)
 server2 = Test.MakeOriginServer("server2")
+# The following server will listen on a port that is not in the connect_ports
+# list.
+server_forbidden = Test.MakeOriginServer("forbidden", ssl=True)
 dns = Test.MakeDNServer("dns")
 
 request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 request_bar_header = {"headers": "GET / HTTP/1.1\r\nHost: bar.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_pp_header = {
+    "headers": "GET /proxy_protocol HTTP/1.1\r\nHost: proxy.protocol.port.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""}
 response_foo_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "foo ok"}
 response_bar_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "bar ok"}
+response_pp_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "pp ok"}
 server_foo.addResponse("sessionlog.json", request_foo_header, response_foo_header)
+server_foo.addResponse("sessionlog.json", request_pp_header, response_pp_header)
 server_bar.addResponse("sessionlog.json", request_bar_header, response_bar_header)
+server_forbidden.addResponse("sessionlog.json", request_pp_header, response_pp_header)
 
 # add ssl materials like key, certificates for the server
 ts.addSSLfile("ssl/signed-foo.pem")
@@ -60,19 +72,17 @@ ts.Disk.ssl_multicert_config.AddLine(
 #         override for foo.com policy=enforced properties=all
 ts.Disk.records_config.update({'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
                                'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.http.connect_ports': '{0} {1} {2} {3}'.format(ts.Variables.ssl_port,
-                                                                                           server_foo.Variables.SSL_Port,
-                                                                                           server_bar.Variables.SSL_Port,
-                                                                                           ts.Variables.proxy_protocol_ssl_port),
+                               'proxy.config.http.connect_ports': '{0} {1} {2}'.format(ts.Variables.ssl_port,
+                                                                                       server_foo.Variables.SSL_Port,
+                                                                                       server_bar.Variables.SSL_Port),
                                'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
                                'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
                                'proxy.config.exec_thread.autoconfig.scale': 1.0,
                                'proxy.config.url_remap.pristine_host_hdr': 1,
                                'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'http|ssl_sni',
+                               'proxy.config.diags.debug.tags': 'http|ssl_sni|proxyprotocol',
                                'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
                                'proxy.config.dns.resolv_conf': 'NULL'})
-
 
 # foo.com should not terminate.  Just tunnel to server_foo
 # bar.com should terminate.  Forward its tcp stream to server_bar
@@ -103,6 +113,9 @@ tr.Processes.Default.StartBefore(server_bar)
 tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
+tr.StillRunningAfter = server_foo
+tr.StillRunningAfter = server_bar
+tr.StillRunningAfter = dns
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression(
     "Not Found on Accelerato", "Should not try to remap on Traffic Server")
@@ -171,7 +184,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK"
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("ATS", "Do not terminate on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("foo ok", "Should get a response from tm")
 
-tr = Test.AddTestRun("test inbound_local_port")
+tr = Test.AddTestRun("test {inbound_local_port}")
 tr.Processes.Default.Command = "curl -vvv --resolve 'incoming.port.com:{0}:127.0.0.1' -k  https://incoming.port.com:{0}".format(
     ts.Variables.ssl_port)
 # The tunnel connecting to the outgoing port which is the same as the incoming
@@ -186,25 +199,42 @@ ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Verify a CONNECT request is handled")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression("HTTP/1.1 400 Direct self loop detected", "The loop should be detected")
 
-tr = Test.AddTestRun("test proxy_protocol_port")
+tr = Test.AddTestRun("test {proxy_protocol_port}")
+tr.Setup.Copy('proxy_protocol_client.py')
 tr.Processes.Default.Command = (
-    "curl -vvv -k --http1.1 --haproxy-protocol "
-    f"--resolve 'proxy.protocol.port.com:{ts.Variables.proxy_protocol_ssl_port}:127.0.0.1' "
-    f"https://proxy.protocol.port.com:{ts.Variables.proxy_protocol_ssl_port}"
+    f'{sys.executable} proxy_protocol_client.py '
+    f'127.0.0.1 {ts.Variables.proxy_protocol_ssl_port} proxy.protocol.port.com '
+    f'127.0.0.1 127.0.0.1 60123 {server_foo.Variables.SSL_Port} '
+    f'2 --https'
 )
-# The tunnel connecting to the outgoing port which is the same as the incoming
-# port (per the Proxy Protocol configuration) will result in ATS connecting
-# back to itself. This will result in a connection close and a non-zero return
-# code from curl. In production, the server will listen on the same port as ATS
-# but have a different IP.
-tr.ReturnCode = 35
+tr.ReturnCode = 0
+tr.TimeOut = 5
 tr.StillRunningAfter = ts
+tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+    "HTTP/1.1 200 OK",
+    "Verify a successful response is received")
+
+tr = Test.AddTestRun("test proxy_protocol_port - not in connect_ports")
+tr.Processes.Default.StartBefore(server_forbidden)
+tr.Setup.Copy('proxy_protocol_client.py')
+# Note that server_forbidden is listing on a port that is not in the
+# connect_ports list. Therefore the tunnel should be rejected.
+rejected_port = server_forbidden.Variables.SSL_Port
+tr.Processes.Default.Command = (
+    f'{sys.executable} proxy_protocol_client.py '
+    f'127.0.0.1 {ts.Variables.proxy_protocol_ssl_port} proxy.protocol.port.com '
+    f'127.0.0.1 127.0.0.1 60123 {rejected_port} '
+    f'2 --https'
+)
+tr.ReturnCode = 1
+tr.TimeOut = 5
+tr.StillRunningAfter = ts
+tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+    "ssl.SSLEOFError",
+    "Verify a the handshake failed")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    f"CONNECT tunnel://backend.proxy.protocol.port.com:{ts.Variables.proxy_protocol_ssl_port} HTTP/1.1",
-    "Verify a CONNECT request is handled")
-ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "HTTP/1.1 400 Direct self loop detected",
-    "The loop should be detected")
+    f"Rejected a tunnel to port {rejected_port} not in connect_ports",
+    "Verify the tunnel was rejected")
 
 # Update sni file and reload
 tr = Test.AddTestRun("Update config files")


### PR DESCRIPTION
This patch adds the ability to specify that ATS connect to the tunnel_route host using the port that was either:

1. The destination port on the client-side (inbound) connection that instigated the tunnel_route. This is specified as {inbound_local_port} for the tunnel_route host port target.
2. The destination port specified via the inbound Proxy Protocol string that instigated the tunnel_route. This is specified as {proxy_protocol_port} for the tunnel_route host port target.


---

Marking this as a draft while this is reviewed in the dev mailing list.