### PR TITLE
Fix the autest Proxy Verifier version check

### DIFF
--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -67,7 +67,8 @@ def HasCurlVersion(self, version):
 
 
 def HasProxyVerifierVersion(self, version):
-    return self.EnsureVersion(["verifier-client", "--version"], min_version=version)
+    verifier_path = os.path.join(self.Variables.VerifierBinPath, 'verifier-client')
+    return self.EnsureVersion([verifier_path, "--version"], min_version=version)
 
 
 def HasCurlFeature(self, feature):


### PR DESCRIPTION
The Proxy Verifier autest version check logic assumed that verifier-client was in the PATH. This is most often not the case, and even if it is it can be the wrong one since the test will by default use the unpacked Proxy Verifier from bintray. This fixes the check so that it explicitly refers to the verifier-client that the test will use.