### PR TITLE
fatal.test.py autest: make it more reliable

### DIFF
--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -46,6 +46,7 @@ tr.Processes.Default.Command = 'printf "Fatal Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 ts.ReturnCode = 70
-ts.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
+ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing fatal shutdown")
+ts.Timeout = 5
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing fatal shutdown', 'should contain "testing fatal shutdown"')


### PR DESCRIPTION
The fatal.test.py test has been flaky because of a race condition between the process shutdown caused by TSFatal and the autest shutting down the process because the Default Process print statement finished. This patch adds a FileContaines ready condition for the TSFatal log message before ending the TestRun which makes it run correctly more reliably.