### PR TITLE
remap_load_empty_failure.test.py autest: make it more reliable

### DIFF
--- a/tests/gold_tests/remap/remap_load_empty_failure.test.py
+++ b/tests/gold_tests/remap/remap_load_empty_failure.test.py
@@ -24,7 +24,9 @@ ts = Test.MakeATSProcess("ts")
 ts.Disk.remap_config.AddLine(f"")  # empty file
 ts.Disk.records_config.update({'proxy.config.url_remap.min_rules_required': 1})
 ts.ReturnCode = 33  # expect to Emergency fail due to empty "remap.config".
+ts.Ready = When.FileContains(ts.Disk.diags_log.Name, "remap.config failed to load")
 
 tr = Test.AddTestRun("test")
-tr.Processes.Default.Command = "echo"
-tr.Processes.Default.StartAfter(ts, ready=When.FileExists(ts.Disk.diags_log))
+tr.Processes.Default.Command = "echo howdy"
+tr.TimeOut = 5
+tr.Processes.Default.StartBefore(ts)


### PR DESCRIPTION
The remap_load_empty_failure.test.py had a race condition between the autest run finishing due to the Default echo process finishing and the traffic server instance writing the "remap.config failed to load" message to the diags.log. This updates the Ready condition for the traffic server process to wait until that log is printed before running the echo and ending the test.