### PR TITLE
Fix autest flakiness

### DIFF
--- a/tests/gold_tests/remap/remap_load_empty_failure.test.py
+++ b/tests/gold_tests/remap/remap_load_empty_failure.test.py
@@ -24,7 +24,9 @@ ts = Test.MakeATSProcess("ts")
 ts.Disk.remap_config.AddLine(f"")  # empty file
 ts.Disk.records_config.update({'proxy.config.url_remap.min_rules_required': 1})
 ts.ReturnCode = 33  # expect to Emergency fail due to empty "remap.config".
+ts.Ready = When.FileContains(ts.Disk.diags_log.Name, "remap.config failed to load")
 
 tr = Test.AddTestRun("test")
-tr.Processes.Default.Command = "echo"
-tr.Processes.Default.StartAfter(ts, ready=When.FileExists(ts.Disk.diags_log))
+tr.Processes.Default.Command = "echo howdy"
+tr.TimeOut = 5
+tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/shutdown/emergency.test.py
+++ b/tests/gold_tests/shutdown/emergency.test.py
@@ -45,7 +45,9 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Emergency Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
+tr.Timeout = 5
+
 ts.ReturnCode = 33
-ts.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
+ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing emergency shutdown")
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing emergency shutdown', 'should contain "testing emergency shutdown"')

--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -45,8 +45,9 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Fatal Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
+tr.Timeout = 5
+
 ts.ReturnCode = 70
 ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing fatal shutdown")
-ts.Timeout = 5
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing fatal shutdown', 'should contain "testing fatal shutdown"')

--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -46,6 +46,7 @@ tr.Processes.Default.Command = 'printf "Fatal Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 ts.ReturnCode = 70
-ts.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
+ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing fatal shutdown")
+ts.Timeout = 5
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing fatal shutdown', 'should contain "testing fatal shutdown"')


### PR DESCRIPTION
A number of tests were flakey because of race conditions between the AuTest framework finishing the Default TestRun process and ending the test, and therefore the traffic server process, before traffic server had time to exercise the expected functionality of the test. This improves the Ready conditions for these tests which should improve their reliability.