### PR TITLE
Use snprintf

### DIFF
--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -116,11 +116,11 @@ build_hdrs(HTTPInfo &info, const char *url, const char *content_type)
 
   REQUIRE(url != nullptr);
 
-  p += snprintf(p, sizeof(buf), "GET %s HTTP/1.1\n", url);
-  p += snprintf(p, sizeof(buf), "User-Agent: curl/7.47.0\n");
-  p += snprintf(p, sizeof(buf), "Accept: %s\n", content_type);
-  p += snprintf(p, sizeof(buf), "Vary: Content-type\n");
-  p += snprintf(p, sizeof(buf), "Proxy-Connection: Keep-Alive\n\n");
+  p += snprintf(p, sizeof(buf) - (p - buf), "GET %s HTTP/1.1\n", url);
+  p += snprintf(p, sizeof(buf) - (p - buf), "User-Agent: curl/7.47.0\n");
+  p += snprintf(p, sizeof(buf) - (p - buf), "Accept: %s\n", content_type);
+  p += snprintf(p, sizeof(buf) - (p - buf), "Vary: Content-type\n");
+  p += snprintf(p, sizeof(buf) - (p - buf), "Proxy-Connection: Keep-Alive\n\n");
 
   req.create(HTTP_TYPE_REQUEST);
   http_parser_init(&parser);
@@ -142,10 +142,10 @@ build_hdrs(HTTPInfo &info, const char *url, const char *content_type)
   }
 
   p = buf;
-  p += snprintf(p, sizeof(buf), "HTTP/1.1 200 OK\n");
-  p += snprintf(p, sizeof(buf), "Content-Type: %s\n", content_type);
-  p += snprintf(p, sizeof(buf), "Expires: Fri, 15 Mar 2219 08:55:45 GMT\n");
-  p += snprintf(p, sizeof(buf), "Last-Modified: Thu, 14 Mar 2019 08:47:40 GMT\n\n");
+  p += snprintf(p, sizeof(buf) - (p - buf), "HTTP/1.1 200 OK\n");
+  p += snprintf(p, sizeof(buf) - (p - buf), "Content-Type: %s\n", content_type);
+  p += snprintf(p, sizeof(buf) - (p - buf), "Expires: Fri, 15 Mar 2219 08:55:45 GMT\n");
+  p += snprintf(p, sizeof(buf) - (p - buf), "Last-Modified: Thu, 14 Mar 2019 08:47:40 GMT\n\n");
 
   resp.create(HTTP_TYPE_RESPONSE);
   http_parser_init(&parser);

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -116,11 +116,11 @@ build_hdrs(HTTPInfo &info, const char *url, const char *content_type)
 
   REQUIRE(url != nullptr);
 
-  p += sprintf(p, "GET %s HTTP/1.1\n", url);
-  p += sprintf(p, "User-Agent: curl/7.47.0\n");
-  p += sprintf(p, "Accept: %s\n", content_type);
-  p += sprintf(p, "Vary: Content-type\n");
-  p += sprintf(p, "Proxy-Connection: Keep-Alive\n\n");
+  p += snprintf(p, sizeof(buf), "GET %s HTTP/1.1\n", url);
+  p += snprintf(p, sizeof(buf), "User-Agent: curl/7.47.0\n");
+  p += snprintf(p, sizeof(buf), "Accept: %s\n", content_type);
+  p += snprintf(p, sizeof(buf), "Vary: Content-type\n");
+  p += snprintf(p, sizeof(buf), "Proxy-Connection: Keep-Alive\n\n");
 
   req.create(HTTP_TYPE_REQUEST);
   http_parser_init(&parser);
@@ -142,10 +142,10 @@ build_hdrs(HTTPInfo &info, const char *url, const char *content_type)
   }
 
   p = buf;
-  p += sprintf(p, "HTTP/1.1 200 OK\n");
-  p += sprintf(p, "Content-Type: %s\n", content_type);
-  p += sprintf(p, "Expires: Fri, 15 Mar 2219 08:55:45 GMT\n");
-  p += sprintf(p, "Last-Modified: Thu, 14 Mar 2019 08:47:40 GMT\n\n");
+  p += snprintf(p, sizeof(buf), "HTTP/1.1 200 OK\n");
+  p += snprintf(p, sizeof(buf), "Content-Type: %s\n", content_type);
+  p += snprintf(p, sizeof(buf), "Expires: Fri, 15 Mar 2219 08:55:45 GMT\n");
+  p += snprintf(p, sizeof(buf), "Last-Modified: Thu, 14 Mar 2019 08:47:40 GMT\n\n");
 
   resp.create(HTTP_TYPE_RESPONSE);
   http_parser_init(&parser);

--- a/iocore/net/QUICPacketHandler_quiche.cc
+++ b/iocore/net/QUICPacketHandler_quiche.cc
@@ -287,8 +287,8 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
       const uint8_t *quic_trace_id;
       size_t quic_trace_id_len = 0;
       quiche_conn_trace_id(quiche_con, &quic_trace_id, &quic_trace_id_len);
-      sprintf(qlog_filepath, "%s/%.*s.sqlog", Layout::get()->relative(params->qlog_dir()).c_str(),
-              static_cast<int>(quic_trace_id_len), quic_trace_id);
+      snprintf(qlog_filepath, PATH_MAX, "%s/%.*s.sqlog", Layout::get()->relative(params->qlog_dir()).c_str(),
+               static_cast<int>(quic_trace_id_len), quic_trace_id);
       quiche_conn_set_qlog_path(quiche_con, qlog_filepath, "ats", "");
     }
 

--- a/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -151,7 +151,7 @@ getTemporaryDir()
   tmpDir          /= "sandbox_XXXXXX";
 
   char dirNameTemplate[tmpDir.string().length() + 1];
-  sprintf(dirNameTemplate, "%s", tmpDir.c_str());
+  snprintf(dirNameTemplate, sizeof(dirNameTemplate), "%s", tmpDir.c_str());
 
   return fs::path(mkdtemp(dirNameTemplate));
 }


### PR DESCRIPTION
Another cleanup for deprecated sprintf. This makes `make` and `make check` happy with my configuration (there are still some sprintf left).