### PR TITLE
Enable UDP GSO by default

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4684,7 +4684,7 @@ UDP Configuration
    Specifies the number of UDP threads to run. By default 0 threads are dedicated to UDP,
    which results in effectively disabling UDP support.
 
-.. ts:cv:: CONFIG proxy.config.udp.enable_gso INT 0
+.. ts:cv:: CONFIG proxy.config.udp.enable_gso INT 1
 
    Enables (``1``) or disables (``0``) UDP GSO. When enabled, |TS| tries to use UDP GSO,
    and disables it automatically if it causes send errors.

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -260,7 +260,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.udp.threads", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.udp.enable_gso", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.udp.enable_gso", RECD_INT, "1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
 
   //##############################################################################


### PR DESCRIPTION
There's no reason not to enable GSO by default. If it's enabled on a system that doesn't support GSO, ATS fallbacks to non GSO mode automatically.