### PR TITLE
Update h2disable tests for new curl output

### DIFF
--- a/tests/gold_tests/h2/h2disable.test.py
+++ b/tests/gold_tests/h2/h2disable.test.py
@@ -70,7 +70,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.TimeOut = 5
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Using HTTP2", "Curl should negotiate HTTP2")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2", "Curl should negotiate HTTP2")
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
@@ -80,7 +80,7 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
@@ -91,5 +91,5 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5

--- a/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
@@ -70,7 +70,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.TimeOut = 5
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Using HTTP2", "Curl should negotiate HTTP2")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2", "Curl should negotiate HTTP2")
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
@@ -80,7 +80,7 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
@@ -91,5 +91,5 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5


### PR DESCRIPTION
The h2disable and h2disable_no_accept_threads autests both had curl output expectations that have changed in the recent release of curl. Here is the old output:

```
Using HTTP2, server supports multiplexing
```

Here is the new output

```
using HTTP/2
```

This updates the ContainsExpression and ExcludesExpression strings to be able to work with both versions of curl.