### PR TITLE
Fix missing semi-colon

### DIFF
--- a/include/tscore/ink_memory.h
+++ b/include/tscore/ink_memory.h
@@ -119,7 +119,7 @@ static inline size_t __attribute__((const)) ats_pagesize()
   long ret  = sysconf(_SC_PAGESIZE);
   page_size = (size_t)((ret > -1) ? ret : 8192);
 #elif defined(HAVE_GETPAGESIZE)
-  page_size = (size_t)getpagesize()
+  page_size = (size_t)getpagesize();
 #else
   page_size = (size_t)8192;
 #endif


### PR DESCRIPTION
If `HAVE_SYSCONF` is false (it's pretty rare), we fall into this compile error. 
```
../../../include/tscore/ink_memory.h:122:36: error: expected ';' after expression
  page_size = (size_t)getpagesize()
                                   ^
                                   ;
```                                   