### PR TITLE
Use BRAVO lock for g_records_rwlock

### DIFF
--- a/include/records/P_RecCore.h
+++ b/include/records/P_RecCore.h
@@ -26,6 +26,7 @@
 #include "tscore/ink_thread.h"
 #include "tscore/ink_rwlock.h"
 #include "tscore/TextBuffer.h"
+#include "tscpp/util/Bravo.h"
 
 #include "I_RecCore.h"
 #include "P_RecDefs.h"
@@ -39,7 +40,7 @@
 // records, record hash-table, and hash-table rwlock
 extern RecRecord *g_records;
 extern std::unordered_map<std::string, RecRecord *> g_records_ht;
-extern ink_rwlock g_records_rwlock;
+extern ts::bravo::shared_mutex g_records_rwlock;
 extern int g_num_records;
 
 // records.yaml items

--- a/src/records/RecRawStats.cc
+++ b/src/records/RecRawStats.cc
@@ -23,6 +23,9 @@ Record statistics support
 
 #include "records/P_RecCore.h"
 #include "records/P_RecProcess.h"
+
+#include "tscpp/util/Bravo.h"
+
 #include <string_view>
 
 //-------------------------------------------------------------------------
@@ -309,7 +312,7 @@ RecRegisterRawStatSyncCb(const char *name, RecRawStatSyncCb sync_cb, RecRawStatB
 {
   int err = REC_ERR_FAIL;
 
-  ink_rwlock_rdlock(&g_records_rwlock);
+  ts::bravo::shared_lock lock(g_records_rwlock);
   if (auto it = g_records_ht.find(name); it != g_records_ht.end()) {
     RecRecord *r = it->second;
 
@@ -334,8 +337,6 @@ RecRegisterRawStatSyncCb(const char *name, RecRawStatSyncCb sync_cb, RecRawStatB
     }
     rec_mutex_release(&(r->lock));
   }
-
-  ink_rwlock_unlock(&g_records_rwlock);
 
   return err;
 }

--- a/src/records/RecYAMLDecoder.cc
+++ b/src/records/RecYAMLDecoder.cc
@@ -54,13 +54,13 @@ struct scoped_cond_lock {
   scoped_cond_lock(bool lock = false) : _lock(lock)
   {
     if (_lock) {
-      ink_rwlock_wrlock(&g_records_rwlock);
+      g_records_rwlock.lock();
     }
   }
   ~scoped_cond_lock()
   {
     if (_lock) {
-      ink_rwlock_unlock(&g_records_rwlock);
+      g_records_rwlock.unlock();
     }
   }
   bool _lock{false};


### PR DESCRIPTION
On top of the `ts::bravo::shared_lock` change (#9394), replace `ink_rwlock g_records_rwlock` with it. 
The difference is noticeable when plugins call Rec* APIs through TSAPIs.

# Benchmark

CPU
- Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz
- 64 core

Client
- Run 8 wrk2 processes against 8 different URLs

ATS
- Enable `remap_stats.so` in the plugin.config
- Set exec_thread.limit: 64

## Results

- Vanilla master: 554388 req/sec
- With ts::bravo::shared_lock: 582533 req/sec