### PR TITLE
Build: improve libswoc building.

### DIFF
--- a/build/libswoc.m4
+++ b/build/libswoc.m4
@@ -20,68 +20,77 @@ dnl
 
 dnl
 dnl TS_CHECK_LIBSWOC: look for libswoc libraries and headers
+dnl value
+dnl   "yes" libswoc is presumed available already and nothing needs to be done.
+dnl   "no" Not allowed, generates an error.
+dnl   * Presumed to be a directory containing libswoc.
 dnl
 AC_DEFUN([TS_CHECK_LIBSWOC], [
-has_libswoc=no
-AC_ARG_WITH(libswoc, [AS_HELP_STRING([--with-libswoc=DIR],[use a specific libswoc library])],
-[
-  if test "x$withval" != "xyes" && test "x$withval" != "x"; then
-    libswoc_base_dir="$withval"
-    if test "$withval" != "no"; then
-      has_libswoc=yes
-      case "$withval" in
-      *":"*)
-        swoc_include="`echo $withval |sed -e 's/:.*$//'`"
-        swoc_ldflags="`echo $withval |sed -e 's/^.*://'`"
-        AC_MSG_CHECKING(checking for libswoc includes in $swoc_include libs in $swoc_ldflags )
-        ;;
-      *)
-        swoc_include="$withval/include"
-        swoc_ldflags="$withval/lib"
-        libswoc_base_dir="$withval"
-        AC_MSG_CHECKING(libswoc includes in $withval libs in $swoc_ldflags)
-        ;;
-      esac
-    fi
-  fi
-
-  if test -d $swoc_include && test -d $swoc_ldflags && test -f $swoc_include/libswoc/swoc_version.h; then
-    AC_MSG_RESULT([ok])
-  else
-    AC_MSG_RESULT([not found])
-  fi
-
-if test "$has_libswoc" != "no"; then
-  saved_ldflags=$LDFLAGS
-  saved_cppflags=$CPPFLAGS
-
-  SWOC_LIBS=-ltsswoc
-  if test "$libswoc_base_dir" != "/usr"; then
-    SWOC_INCLUDES=-I${swoc_include}
-    SWOC_LDFLAGS=-L${swoc_ldflags}
-
-    TS_ADDTO_RPATH(${swoc_ldflags})
-  fi
-
-  if test "$swoc_include" != "0"; then
-    SWOC_INCLUDES=-I${swoc_include}
-  else
-    has_libswoc=no
-    CPPFLAGS=$saved_cppflags
-    LDFLAGS=$saved_ldflags
-  fi
-fi
-],
-[
+  # internal defaults.
   has_libswoc=no
   SWOC_INCLUDES=-I\${abs_top_srcdir}/lib/swoc/include
   SWOC_LIBS=-ltsswoc
   SWOC_LDFLAGS=-L\${abs_top_builddir}/lib/swoc
-])
+  AC_ARG_WITH(libswoc, [AS_HELP_STRING([--with-libswoc=DIR],[use a specific libswoc library])],
+    [
+    AC_MSG_CHECKING(checking libswoc)
+    # Check for override.
+    if test "x$withval" != "x"; then
+      has_libswoc=yes # inhibit internal build of libswoc
+      if test "$withval" = "no" ; then
+        AC_MSG_ERROR([libswoc is required internally, it cannot be disabled])
+      elif test "$withval" = "yes" ; then # assume libswoc is installed in a standard place
+        SWOC_INCLUDES=
+        SWOC_LIBS=-lswoc
+        SWOC_LDFLAGS=
+        AC_MSG_RESULT([ok])
+      else
+        swoc_pkg_cfg=""
+        # Defaults if pkg config not found.
+        SWOC_INCLUDES="-I${withval}/include"
+        SWOC_LIBS="-lswoc"
+        SWOC_LDFLAGS="-L${withval}/lib"
+        if test -n "$PKG_CONFIG" ; then # pkg-config binary was found
+          for pk in "lib/pkgconfig" "lib" "." ; do
+            if PKG_CONFIG_LIBDIR=${withval}/${pk} $PKG_CONFIG --exists libswoc ; then
+              swoc_pkg_cfg=" [pkg-config: ${pk}]"
+              SWOC_INCLUDES=$(PKG_CONFIG_LIBDIR=${withval}/${pk} $PKG_CONFIG --cflags libswoc)
+              SWOC_LIBS=$(PKG_CONFIG_LIBDIR=${withval}/${pk} $PKG_CONFIG --libs-only-l libswoc)
+              SWOC_LDFLAGS=$(PKG_CONFIG_LIBDIR=${withval}/${pk} $PKG_CONFIG --libs-only-L libswoc)
+              break
+            fi
+          done
+        fi
 
-AC_SUBST([SWOC_INCLUDES])
-AC_SUBST([SWOC_LIBS])
-AC_SUBST([SWOC_LDFLAGS])
+        # time to see if things work
+
+        swoc_CXXFLAGS="$CXXFLAGS"
+        swoc_LIBS="${LIBS}"
+        CXXFLAGS="$CXXFLAGS ${SWOC_INCLUDES}"
+        LIBS="${SWOC_LDFLAGS} ${SWOC_LIBS}"
+
+        AC_LANG_PUSH(C++)
+        AC_LINK_IFELSE(
+          [AC_LANG_PROGRAM([#include <swoc/TextView.h>], [swoc::TextView tv{"Evil Dave Rulz"};])],
+          [AC_MSG_RESULT([ok${swoc_pkg_cfg}])],
+          [
+            AC_MSG_RESULT([failed${swoc_pkg_cfg}])
+            AC_MSG_ERROR([${withval} does not contain a valid libswoc.])
+          ]
+        )
+        AC_LANG_POP
+
+        CXXFLAGS="${swoc_CXXFLAGS}"
+        LIBS="${swoc_LIBS}"
+
+      fi # valid override
+    fi # override provided
+
+    ])
+
+  AC_SUBST([SWOC_INCLUDES])
+  AC_SUBST([SWOC_LIBS])
+  AC_SUBST([SWOC_LDFLAGS])
 
 ])
 
@@ -90,7 +99,11 @@ AC_DEFUN([TS_CHECK_SWOC_HEADERS_EXPORT], [
 AC_MSG_CHECKING([whether to export libswoc headers])
 AC_ARG_ENABLE([swoc-headers],
   [AS_HELP_STRING([--enable-swoc-headers],[Export libswoc headers])],
-  [],
+  [
+  if test "x$has_libswoc" = "xyes" ; then
+    enable_swoc_headers="no - cannot export external headers"
+  fi
+  ],
   [enable_swoc_headers=no]
 )
 AC_MSG_RESULT([$enable_swoc_headers])

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,8 @@ TS_ENABLE_LAYOUT(TrafficServer, [cachedir docdir])
 # Reparse the configure arguments so we can override the layout.
 TS_PARSE_ARGUMENTS
 
+AC_PATH_PROG(PKG_CONFIG, pkg-config)
+
 #
 # Host detection
 #
@@ -1476,7 +1478,7 @@ TS_CHECK_YAML_HEADERS_EXPORT
 AM_CONDITIONAL([EXPORT_YAML_HEADERS], [test x"$enable_yaml_headers" = x"yes"])
 
 TS_CHECK_LIBSWOC
-AM_CONDITIONAL([BUILD_SWOC], [test x"$has_libswoc" = x"no"])
+AM_CONDITIONAL([BUILD_SWOC], [test "$has_libswoc" = "no"])
 
 TS_CHECK_SWOC_HEADERS_EXPORT
 AM_CONDITIONAL([EXPORT_SWOC_HEADERS], [test x"$enable_swoc_headers" = x"yes"])

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -22,7 +22,6 @@ AM_CPPFLAGS += \
 	$(iocore_include_dirs) \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/lib \
-	-I$(abs_top_srcdir)/lib/swoc/include \
 	-I$(abs_top_srcdir)/proxy \
 	-I$(abs_top_srcdir)/proxy/http \
 	-I$(abs_top_srcdir)/proxy/http/remap \
@@ -30,8 +29,7 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/shared \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
-	$(TS_INCLUDES) \
-	@YAMLCPP_INCLUDES@
+	$(TS_INCLUDES) @SWOC_INCLUDES@ @YAMLCPP_INCLUDES@
 
 EXTRA_DIST = LogStandalone.cc
 

--- a/src/records/Makefile.am
+++ b/src/records/Makefile.am
@@ -21,7 +21,6 @@ include $(top_srcdir)/build/tidy.mk
 check_PROGRAMS = test_librecords test_librecords_on_eventsystem
 
 AM_CPPFLAGS += \
-        -I$(abs_top_srcdir)/lib/swoc/include \
 	-I$(abs_top_srcdir)/iocore/eventsystem \
 	-I$(abs_top_srcdir)/iocore/utils \
 	-I$(abs_top_srcdir)/include \


### PR DESCRIPTION
This fixes some issues with libswoc from the merge of 10-Dev to master.

*  There were some absolute paths for libswoc headers which caused conflicts with external libswoc use.
*  Some `@SWOC_INCLUDES@` were missing (this caused the "string_view_util.h" issue).
*  Tweaked up the libswoc checks to handle `-ltsswoc` vs. `-lswoc`.
*  Added support for pulling data from the pkg config file in libswoc.
*  Removed "split values" where the lib and include could be done separately by using a colon separator. This is just extraneous junk since libswoc provides a pkg config file (see previous item).
*  Replaced file checks with compile check.
*  libswoc headers are *not* exported for external libswoc.

For external libswoc use, this now assumes there is a "libswoc.so" to link. This should be done with a symlink in the standard way. The internal built libswoc is named "libtsswoc.so" to help avoid collisions.