### PR TITLE
records.yaml - Add support to load multiple YAML docs from the same file and let traffic_ctl to modify a records.yaml file

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -31,9 +31,7 @@ records.yaml
 
 The :file:`records.yaml` file (by default, located in
 ``/usr/local/etc/trafficserver/``) is a YAML base configuration file used by
-the |TS| software. Many of the fields in :file:`records.yaml` are set
-automatically when you set configuration options with :option:`traffic_ctl config set`. After you
-modify :file:`records.yaml`, run the command :option:`traffic_ctl config reload`
+the |TS| software. After you modify :file:`records.yaml`, run the command :option:`traffic_ctl config reload`
 to apply the changes.
 
 .. note::
@@ -47,7 +45,8 @@ to apply the changes.
 YAML structure
 ==============
 
-All fields are located inside the ``ts`` root node.
+All fields are located inside the ``ts`` root node. ATS supports reading multiple documents from
+the same YAML stream, subsequent documents overrides earlier fields.
 
 
 .. code-block:: yaml

--- a/src/records/RecConfigParse.cc
+++ b/src/records/RecConfigParse.cc
@@ -268,9 +268,14 @@ swoc::Errata
 RecYAMLConfigFileParse(const char *path, RecYAMLNodeHandler handler)
 {
   try {
-    auto root = YAML::LoadFile(path);
-    if (auto ret = ParseRecordsFromYAML(root, handler); !ret.empty()) {
-      return ret;
+    auto nodes = YAML::LoadAllFromFile(path);
+    // We will parse each doc from the stream, subsequently config node will overwrite
+    // the value for previously loaded records. This would work similar to the old
+    // records.config which a later CONFIG variable would overwrite a previous one.
+    for (auto const &root : nodes) {
+      if (auto ret = ParseRecordsFromYAML(root, handler); !ret.empty()) {
+        return ret;
+      }
     }
   } catch (std::exception const &ex) {
     return swoc::Errata(ERRATA_ERROR, "Error parsing {}. {}", path, ex.what());

--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -24,11 +24,16 @@
 #include "CtrlCommands.h"
 #include "jsonrpc/CtrlRPCRequests.h"
 #include "jsonrpc/ctrl_yaml_codecs.h"
+#include "utils/yaml_utils.h"
+#include "swoc/TextView.h"
+#include "swoc/BufferWriter.h"
+#include "swoc/bwf_base.h"
+
 namespace
 {
 /// We use yamlcpp as codec implementation.
 using Codec = yamlcpp_json_emitter;
-
+} // namespace
 const std::unordered_map<std::string_view, BasePrinter::Options::OutputFormat> _Fmt_str_to_enum = {
   {"pretty", BasePrinter::Options::OutputFormat::PRETTY},
   {"legacy", BasePrinter::Options::OutputFormat::LEGACY},
@@ -59,7 +64,6 @@ parse_print_opts(ts::Arguments *args)
 {
   return {parse_format(args)};
 }
-} // namespace
 
 //------------------------------------------------------------------------------------------------------------------------------------
 CtrlCommand::CtrlCommand(ts::Arguments *args) : _arguments(args) {}
@@ -75,7 +79,7 @@ CtrlCommand::execute()
 }
 
 std::string
-CtrlCommand::invoke_rpc(std::string const &request)
+RPCAccessor::invoke_rpc(std::string const &request)
 {
   if (_printer->print_rpc_message()) {
     std::string text;
@@ -96,7 +100,7 @@ CtrlCommand::invoke_rpc(std::string const &request)
 }
 
 shared::rpc::JSONRPCResponse
-CtrlCommand::invoke_rpc(shared::rpc::ClientRequest const &request)
+RPCAccessor::invoke_rpc(shared::rpc::ClientRequest const &request)
 {
   std::string encodedRequest = Codec::encode(request);
   std::string resp           = invoke_rpc(encodedRequest);
@@ -104,7 +108,7 @@ CtrlCommand::invoke_rpc(shared::rpc::ClientRequest const &request)
 }
 
 void
-CtrlCommand::invoke_rpc(shared::rpc::ClientRequest const &request, std::string &resp)
+RPCAccessor::invoke_rpc(shared::rpc::ClientRequest const &request, std::string &resp)
 {
   std::string encodedRequest = Codec::encode(request);
   resp                       = invoke_rpc(encodedRequest);
@@ -207,6 +211,7 @@ ConfigCommand::config_set()
 
   _printer->write_output(response);
 }
+
 void
 ConfigCommand::config_reload()
 {

--- a/src/traffic_ctl/FileConfigCommand.cc
+++ b/src/traffic_ctl/FileConfigCommand.cc
@@ -1,0 +1,340 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+#include <fstream>
+#include <unordered_map>
+
+#include "FileConfigCommand.h"
+#include "utils/yaml_utils.h"
+#include "swoc/TextView.h"
+#include "swoc/BufferWriter.h"
+#include "swoc/bwf_base.h"
+
+namespace
+{
+constexpr std::string_view PREFIX{"proxy.config."};
+constexpr std::string_view TS_PREFIX{"ts."};
+
+constexpr bool CREATE_IF_NOT_EXIST{true};
+constexpr bool DO_NOT_CREATE_IF_NOT_EXIST{false};
+const std::pair<bool, YAML::Node> NOT_FOUND{false, {}};
+
+/// We support either passing variables with the prefix 'proxy.config.' or 'ts.'
+/// Internally we need to use 'ts.variable' as the root node starts with 'ts' for records
+/// configs.
+std::string
+amend_variable_name(swoc::TextView variable)
+{
+  std::string var{TS_PREFIX};
+  // If the variable is prefixed with "proxy.config" we will remove it and replace it
+  // with the records "ts." root name.
+  if (swoc::TextView{variable}.starts_with(PREFIX)) {
+    var += variable.substr(PREFIX.size());
+    return var;
+  }
+
+  // you may be using "ts." already or some other name maybe for a different file.
+  // we expect either `ts` or `proxy.config`
+  return {variable.data(), variable.size()};
+}
+
+/// traffic_ctl should work without the need to pass the filename, so use the data
+/// we have to figure out the file path. If the filename is specified in the traffic_ctl
+/// arguments, then we use that.
+void
+fix_filename(std::string &filename)
+{
+  if (filename.empty()) {
+    std::string sysconfdir;
+    if (const char *env = getenv("PROXY_CONFIG_CONFIG_DIR")) {
+      sysconfdir = Layout::get()->relative(env);
+    } else {
+      sysconfdir = Layout::get()->sysconfdir;
+    }
+    filename = Layout::get()->relative_to(sysconfdir, "records.yaml");
+  }
+}
+
+/// Function to open a file if it exists, if not and is requested we will create the file.
+std::string
+open_file(std::string const &filename, std::fstream &fs, std::ios_base::openmode mode = std::ios::in | std::ios::out,
+          bool create = false)
+{
+  fs.open(filename, mode);
+
+  if (!fs.is_open()) {
+    if (create) {
+      fs.clear();
+      if (fs.open(filename, std::ios::out); fs.is_open()) {
+        return {};
+      }
+    }
+    std::string text;
+    return swoc::bwprint(text, "We couldn't open '{}': {}", filename, strerror(errno));
+  }
+  return {};
+}
+
+/// Bunch of mapping flags for the TAGS.
+std::string
+get_tag(swoc::TextView tag)
+{
+  static std::vector<std::pair<std::string_view, std::vector<std::string_view>>> const Str_to_Tag{
+    {yaml_utils::YAML_INT_TAG_URI,   {"int", "i", "I", "INT", "integer"}         },
+    {yaml_utils::YAML_FLOAT_TAG_URI, {"float", "f", "F", "FLOAT"}                },
+    {yaml_utils::YAML_STR_TAG_URI,   {"str", "s", "S", "STR", "string", "STRING"}}
+  };
+
+  for (auto const &[yaml_tag, strs] : Str_to_Tag) {
+    if (auto found = std::find_if(std::begin(strs), std::end(strs), [&tag](auto t) { return tag == t; }); found != std::end(strs)) {
+      return std::string{yaml_tag.data(), yaml_tag.size()};
+    }
+  }
+
+  return std::string{tag.data(), tag.size()};
+}
+
+std::string
+get_leading_comment()
+{
+  std::string text;
+  std::time_t result = std::time(nullptr);
+  return swoc::bwprint(text, "Document modified by traffic_ctl {}", std::asctime(std::localtime(&result)));
+}
+
+std::pair<bool, YAML::Node>
+search_node(swoc::TextView variable, YAML::Node root, bool create)
+{
+  auto const key{variable.take_prefix_at('.').remove_suffix_at('.')};
+  auto const key_str = std::string{key.data(), key.size()};
+  if (variable.empty()) {
+    if (root.IsMap() && root[key_str]) {
+      return {true, root[key_str]};
+    } else {
+      if (create) {
+        YAML::Node n;
+        root[key_str] = n;
+        return {true, n}; // new one created;
+      } else {
+        return NOT_FOUND;
+      }
+    }
+  }
+  if (!root[key_str]) {
+    if (create) {
+      YAML::Node n;
+      root[key_str] = n;
+      return search_node(variable, n, create);
+    }
+  } else {
+    return search_node(variable, root[key_str], create);
+  }
+  return NOT_FOUND;
+}
+} // namespace
+
+YAML::Node
+FlatYAMLAccessor::find_or_create_node(swoc::TextView variable, bool search_all)
+{
+  if (!search_all) {
+    if (_docs.size() == 0) {
+      // If nothing in it. Add one, it'll be the new node.
+      _docs.emplace_back(YAML::NodeType::Map);
+    }
+    return search_node(variable, _docs.back(), CREATE_IF_NOT_EXIST).second;
+  } else {
+    for (auto iter = _docs.rbegin(); iter != _docs.rend(); ++iter) {
+      if (auto [found, node] = search_node(variable, *iter, DO_NOT_CREATE_IF_NOT_EXIST); found) {
+        return node;
+      }
+    }
+    // We haven't found the node, so we will create a new field in the latest doc.
+    if (_docs.size() == 0) {
+      // if nothing in it. Add one, it'll be the new node.
+      _docs.emplace_back(YAML::NodeType::Map);
+    }
+    // Use the last doc.
+    return search_node(variable, _docs.back(), CREATE_IF_NOT_EXIST).second;
+  }
+
+  return {};
+}
+
+std::pair<bool, YAML::Node>
+FlatYAMLAccessor::find_node(swoc::TextView variable)
+{
+  if (_docs.size() > 0) { // make sure there is something
+    // We start from the bottom.
+    for (auto iter = std::rbegin(_docs); iter != std::rend(_docs); ++iter) {
+      if (auto [found, node] = search_node(variable, *iter, DO_NOT_CREATE_IF_NOT_EXIST); found) {
+        // found it.
+        return {true, node};
+      }
+    }
+  }
+
+  return NOT_FOUND; // couldn't find the node;
+}
+
+void
+FlatYAMLAccessor::make_tree_node(swoc::TextView variable, swoc::TextView value, swoc::TextView tag, YAML::Emitter &out)
+{
+  auto key{variable.take_prefix_at('.').remove_suffix_at('.')};
+  auto key_str = std::string{key.data(), key.size()};
+  if (variable.empty()) {
+    out << YAML::BeginMap << YAML::Key << key_str;
+    if (!tag.empty()) {
+      out << YAML::VerbatimTag(get_tag(tag));
+    }
+    out << YAML::Value << std::string{value.data(), value.size()} << YAML::EndMap;
+  } else {
+    out << YAML::BeginMap << YAML::Key << key_str;
+    make_tree_node(variable, value, tag, out);
+    out << YAML::EndMap;
+  }
+}
+
+FileConfigCommand::FileConfigCommand(ts::Arguments *args) : CtrlCommand(args)
+{
+  BasePrinter::Options printOpts{parse_print_opts(args)};
+  _printer = std::make_unique<GenericPrinter>(printOpts);
+  if (args->get(SET_STR)) {
+    _invoked_func = [&]() { config_set(); };
+  } else if (args->get(GET_STR)) {
+    _invoked_func = [&]() { config_get(); };
+  } else {
+    throw std::invalid_argument("Can't deal with the provided arguments");
+  }
+}
+
+void
+FileConfigCommand::config_get()
+{
+  auto filename = get_parsed_arguments()->get(COLD_STR).value(); // could be empty which means we should use the default file name
+  auto const &data = get_parsed_arguments()->get(GET_STR);
+  std::string text;
+
+  fix_filename(filename);
+  try {
+    FlatYAMLAccessor::load(YAML::LoadAllFromFile(filename));
+
+    for (auto const &var : data) { // we support multiple get's
+      std::string variable = amend_variable_name(var);
+      auto [found, search] = find_node(variable);
+
+      if (found) {
+        _printer->write_output(swoc::bwprint(text, "{}: {}", var, search.as<std::string>()));
+      } else {
+        _printer->write_output(swoc::bwprint(text, "{} not found", var));
+      }
+    }
+  } catch (YAML::Exception const &ex) {
+    throw std::logic_error(swoc::bwprint(text, "config get error: {}", ex.what()));
+  }
+}
+
+void
+FileConfigCommand::config_set()
+{
+  static const std::string CREATE_STR{"create"};
+  static const std::string TYPE_STR{"type"};
+
+  auto filename = get_parsed_arguments()->get(COLD_STR).value(); // could be empty which means we should use the default file name
+  bool append   = !get_parsed_arguments()->get(UPDATE_STR);
+  auto const &data = get_parsed_arguments()->get(SET_STR);
+
+  std::string passed_tag;
+  if (auto p = get_parsed_arguments()->get(TYPE_STR); p) {
+    passed_tag = p.value();
+  }
+  // Get the default records.yaml if nothing is passed.
+  fix_filename(filename);
+  if (filename.empty()) {
+    throw std::logic_error("Can't deduce the file path.");
+  }
+
+  std::ios_base::openmode mode = std::ios::in | std::ios::out;
+  if (append) {
+    mode = std::ios::out | std::ios::app;
+  }
+
+  std::fstream fs;
+  if (auto err = open_file(filename, fs, mode, true); !err.empty()) {
+    throw std::logic_error(err);
+  }
+
+  std::string const &variable = amend_variable_name(data[0]);
+  try {
+    if (append) {
+      YAML::Emitter doc; // we will build the document again, either to append the
+                         // new node or to modify the existing one.
+      doc << YAML::Comment(get_leading_comment()) << YAML::BeginDoc;
+      make_tree_node(variable, data[1], passed_tag, doc);
+      doc << YAML::Newline;
+
+      fs.write(doc.c_str(), doc.size());
+      fs.close();
+    } else {
+      FlatYAMLAccessor::load(YAML::LoadAll(fs));
+      fs.close();
+
+      auto new_node = find_or_create_node(variable);
+
+      new_node = data[1];
+
+      if (!passed_tag.empty()) {
+        new_node.SetTag(get_tag(passed_tag));
+      }
+      // try gain
+      if (auto err = open_file(filename, fs, std::ios::out | std::ios::trunc); !err.empty()) {
+        throw std::logic_error(err);
+      }
+
+      YAML::Emitter doc;
+      YAML::Node last_node;
+      if (_docs.size() > 0) {
+        last_node = _docs.back();
+        _docs.pop_back();
+      }
+
+      for (auto const &n : _docs) {
+        if (!n.IsNull()) {
+          doc << n;
+        }
+      }
+
+      if (doc.size() > 0) {
+        // There is something already, so add a new line.
+        doc << YAML::Newline;
+      }
+      doc << YAML::Comment(get_leading_comment()) << YAML::BeginDoc << last_node << YAML::Newline;
+
+      fs.write(doc.c_str(), doc.size());
+      fs.close();
+    }
+    std::string text;
+    _printer->write_output(swoc::bwprint(text, "Set {}", variable));
+  } catch (std::exception const &ex) {
+    if (fs.is_open()) {
+      fs.close();
+    }
+    throw ex;
+  }
+}

--- a/src/traffic_ctl/FileConfigCommand.h
+++ b/src/traffic_ctl/FileConfigCommand.h
@@ -1,0 +1,88 @@
+/**
+@section license License
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <utility>
+
+#include "tscore/ArgParser.h"
+#include "CtrlCommands.h"
+#include "swoc/TextView.h"
+
+/// @brief Very basic flat YAML node handling.
+///
+/// The whole idea is to be able to set some YAML nodes and being able to search for flat nodes, nodes
+/// can be created if requested. This should also help on creating the whole node tree from a legacy
+/// record variable style. For more complex updates we should tweak this class a bit.
+struct FlatYAMLAccessor {
+  ///
+  /// @brief Find a node based on the passed record variable name.
+  ///
+  /// This function will only search for a specific node, it will not create one.
+  /// @param variable the record name.
+  /// @return std::pair<bool, YAML::Node>  First value will be set to true if found and the relevant Node will be set in the second
+  /// parameter
+  ///
+
+  std::pair<bool, YAML::Node> find_node(swoc::TextView variable);
+  /// @brief Find a node based on the passed record variable name. Create if not exist.
+  ///
+  /// This function will first try to find the passed variable, if not it will create a new with the passed tree.
+  /// @param variable the record name.
+  /// @param all_docs Search in all the nodes from the parsed stream. Default is true. No need to change this now.
+  /// @return
+  YAML::Node find_or_create_node(swoc::TextView variable, bool all_docs = true);
+
+  /// @brief Build up a YAML node including TAG and Value. This is used to append just a single variable in a file.
+  /// @param variable The record name.
+  /// @param value The value to be set on the node.
+  /// @param tag The tag to be set on the node.
+  /// @param out The YAML::Emitter used to build up the node. This can just be streamed out to a string or a file.
+  void make_tree_node(swoc::TextView variable, swoc::TextView value, swoc::TextView tag, YAML::Emitter &out);
+
+  /// @brief  Set the internal list of nodes from the parsed file. Caller should deal with the YAML::LoadAll or any other way.
+  /// @param streams A list of docs.
+  void
+  load(std::vector<YAML::Node> streams)
+  {
+    _docs = std::move(streams);
+  }
+
+protected:
+  std::vector<YAML::Node> _docs;
+  std::unique_ptr<BasePrinter> _printer; //!< Specific output formatter. This should be created by the derived class.
+};
+
+/// @brief Class used to deal with the config file changes. Append or modify an existing records.yaml field
+class FileConfigCommand : public CtrlCommand, FlatYAMLAccessor
+{
+  static inline const std::string SET_STR{"set"}; // we support get, set only for now.
+  static inline const std::string GET_STR{"get"};
+
+  static inline const std::string COLD_STR{"cold"};     // Meaning that the change is on a file.
+  static inline const std::string UPDATE_STR{"update"}; // Append the new field to a file.
+
+  void config_set();
+  void config_get();
+
+public:
+  FileConfigCommand(ts::Arguments *args);
+};

--- a/src/traffic_ctl/Makefile.inc
+++ b/src/traffic_ctl/Makefile.inc
@@ -30,6 +30,7 @@ traffic_ctl_traffic_ctl_SOURCES = \
 	traffic_ctl/traffic_ctl.cc \
 	traffic_ctl/CtrlPrinters.cc \
 	traffic_ctl/CtrlCommands.cc \
+  traffic_ctl/FileConfigCommand.cc \
 	shared/rpc/IPCSocketClient.cc
 
 traffic_ctl_traffic_ctl_LDADD = \

--- a/src/traffic_ctl/utils/yaml_utils.h
+++ b/src/traffic_ctl/utils/yaml_utils.h
@@ -1,0 +1,32 @@
+/** @file
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+#pragma once
+#include <string_view>
+#include <swoc/Lexicon.h>
+
+namespace yaml_utils
+{
+// TODO: This should be sourced from another place
+constexpr std::string_view YAML_FLOAT_TAG_URI{"tag:yaml.org,2002:float"};
+constexpr std::string_view YAML_INT_TAG_URI{"tag:yaml.org,2002:int"};
+constexpr std::string_view YAML_STR_TAG_URI{"tag:yaml.org,2002:str"};
+
+} // namespace yaml_utils

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -514,7 +514,10 @@ class YAMLFile(File):
             execute=False,
             runtime=True)
         self.__root_tag = root_tag
-        self.__content = {}
+        # We support multiple docs in the same file, every time append_to_document
+        # is called, a new item will be created in the following list. At the end
+        # all of them will be written in the same stream.
+        self.__content = [{}]
 
         self.WriteCustomOn(self._do_write)
 
@@ -531,17 +534,28 @@ class YAMLFile(File):
             with open(name, 'w') as f:
                 yaml.add_representer(float, float_representer)
                 yaml.add_representer(int, int_representer)
-                updated_content = {}
-                if self.__root_tag:
-                    updated_content[self.__root_tag] = self.__content
-                else:
-                    updated_content = self.__content
+                docs = []
+                for content in self.__content:
+                    updated_content = {}
 
-                yaml.dump(updated_content, f)
+                    if self.__root_tag:
+                        updated_content[self.__root_tag] = content
+                    else:
+                        updated_content = content
+
+                    docs.append(updated_content)
+
+                yaml.dump_all(docs, f)
 
         return (True,
                 "Writing config file {0}".format(os.path.split(self.Name)[-1]),
                 "Success")
+
+    def __transform_content(self, content):
+        if isinstance(content, str):  # from new style
+            return yaml.load(content, Loader=yaml.Loader)
+        else:
+            return content  # Already an object.
 
     def __update(self, content, out):
         for key, value in content.items():
@@ -556,13 +570,13 @@ class YAMLFile(File):
                 out[key] = value
 
     def update(self, content):
-        data = {}
-        if isinstance(content, str):  # from new style
-            data = yaml.load(content, Loader=yaml.Loader)
-        else:
-            data = content  # Already an object.
+        self.__update(self.__transform_content(content), self.__content[0])
 
-        self.__update(data, self.__content)
+    def append_to_document(self, content):
+        # We want to append a new doc in the same YAML stream.
+        new_doc = {}
+        self.__update(self.__transform_content(content), new_doc)
+        self.__content.append(new_doc)
 
 
 class RecordsYAML(YAMLFile):
@@ -599,7 +613,7 @@ class RecordsYAML(YAMLFile):
 
             self._make_obj_from_legacy_record(config[key], var[index + 1:], value)
 
-    def __legacy_update(self, obj):
+    def __legacy_update(self, obj, new_doc=False):
         config = {}
         for name, value in obj.items():
             ori_name = name
@@ -612,7 +626,10 @@ class RecordsYAML(YAMLFile):
             # unwrap the record and make it a YAML field.
             self._make_obj_from_legacy_record(config, name, value)
 
-        super(RecordsYAML, self).update(config)
+        if new_doc:
+            super(RecordsYAML, self).append_to_document(config)
+        else:
+            super(RecordsYAML, self).update(config)
 
     def update(self, data):
         if isinstance(data, dict):
@@ -627,7 +644,18 @@ class RecordsYAML(YAMLFile):
             '''
             super(RecordsYAML, self).update(data)
 
-
+    def append_to_document(self, data):
+        if isinstance(data, dict):
+            '''
+            If the data is already parsed or (more likely) is a legacy objects
+            we still support it, so update from the passed object.
+            '''
+            self.__legacy_update(data, new_doc=True)
+        else:
+            '''
+            We also support plain YAML(str) to be passed on. Base class will load from the yaml parser.
+            '''
+            super(RecordsYAML, self).append_to_document(data)
 ##########################################################################
 
 

--- a/tests/gold_tests/records/gold/records.yaml.cold_test0.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test0.gold
@@ -1,0 +1,9 @@
+ts:
+``
+# Document modified by traffic_ctl ``
+#``
+---
+ts:
+  diags:
+    debug:
+      tags: http

--- a/tests/gold_tests/records/gold/records.yaml.cold_test2.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test2.gold
@@ -1,0 +1,9 @@
+ts:
+``
+# Document modified by traffic_ctl ``
+#``
+---
+ts:
+  diags:
+    debug:
+      tags: http

--- a/tests/gold_tests/records/gold/records.yaml.cold_test4.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test4.gold
@@ -1,0 +1,10 @@
+ts:
+``
+# Document modified by traffic_ctl ``
+#``
+---
+ts:
+  cache:
+    limits:
+      http:
+        max_alts: !<tag:yaml.org,2002:int> 1

--- a/tests/gold_tests/records/gold/records.yaml.cold_test5.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test5.gold
@@ -1,0 +1,8 @@
+# Document modified by traffic_ctl ``
+#``
+---
+ts:
+  cache:
+    limits:
+      http:
+        max_alts: 3

--- a/tests/gold_tests/records/traffic_ctl_cold_config.test.py
+++ b/tests/gold_tests/records/traffic_ctl_cold_config.test.py
@@ -1,0 +1,100 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+from jsonrpc import Notification, Request, Response
+
+Test.Summary = 'Basic records test. Testing the new records.yaml logic and making sure it works as expected.'
+
+ts = Test.MakeATSProcess("ts")
+
+ts.Disk.records_config.update(
+    '''
+    accept_threads: 1
+    cache:
+      limits:
+        http:
+          max_alts: 5
+    diags:
+      debug:
+        enabled: 0
+        tags: http|dns
+    '''
+)
+
+# 0 - We want to make sure that the unregistered records are still being detected.
+tr = Test.AddTestRun("Test Append value to existing records.yaml")
+
+tr.Processes.Default.Command = 'traffic_ctl config set proxy.config.diags.debug.tags rpc --cold'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.StartBefore(ts)
+ts.Disk.records_config.Content = 'gold/records.yaml.cold_test0.gold'
+
+# 1
+tr = Test.AddTestRun("Get value from latest added node.")
+tr.Processes.Default.Command = 'traffic_ctl config get proxy.config.diags.debug.tags --cold'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+
+tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+    'proxy.config.diags.debug.tags: rpc',
+    'Config should show the right tags'
+)
+
+# 2
+tr = Test.AddTestRun("Test modify latest yaml document from records.yaml")
+tr.Processes.Default.Command = 'traffic_ctl config set proxy.config.diags.debug.tags http -u -c'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+ts.Disk.records_config.Content = 'gold/records.yaml.cold_test2.gold'
+
+# 3
+tr = Test.AddTestRun("Get value from latest added node 1.")
+tr.Processes.Default.Command = 'traffic_ctl config get proxy.config.diags.debug.tags --cold'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+
+tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+    'proxy.config.diags.debug.tags: http',
+    'Config should show the right tags'
+)
+
+# 4
+tr = Test.AddTestRun("Append a new field node using a tag")
+tr.Processes.Default.Command = 'traffic_ctl config set proxy.config.cache.limits.http.max_alts 1 -t int -c'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+ts.Disk.records_config.Content = 'gold/records.yaml.cold_test4.gold'
+
+
+# 5
+file = os.path.join(ts.Variables.CONFIGDIR, "new_records.yaml")
+tr = Test.AddTestRun("Adding a new node(with update flag set) to a non existing file")
+tr.Processes.Default.Command = f'traffic_ctl config set proxy.config.cache.limits.http.max_alts 3  -u -c {file}'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+tr.Disk.File(file).Content = 'gold/records.yaml.cold_test5.gold'
+
+# 5
+file = os.path.join(ts.Variables.CONFIGDIR, "new_records2.yaml")
+tr = Test.AddTestRun("Adding a new node to a non existing file")
+tr.Processes.Default.Command = f'traffic_ctl config set proxy.config.cache.limits.http.max_alts 3 -c {file}'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Env = ts.Env
+tr.Disk.File(file).Content = 'gold/records.yaml.cold_test5.gold'


### PR DESCRIPTION
This includes 2 changes.

1 - Support for loading multiple YAML documents from the same `records.yaml`  file. This is done basically to  keep the same behavior as we had before with `records.config` where the latest config set overwrites a previous set. So basically:

`records.yaml`:
```yaml
---
ts:
  diags:
    debug:
      enabled: 0
---
ts:
  diags:
    debug:
      enabled: 1
```
So, `enabled=1` will be the variable value after loading.

2 - Add support for modifying a `records.yaml` file  using `traffic_ctl`, this will let `traffic_ctl` to:

- Append  a new configuration field in a new YAML doc (same file)
```bash
traffic_ctl config set proxy.config.diags.debug.enabled 1 -c [file]
```
- Modify the latest(top to bottom) YAML doc without appending a new doc
```bash
traffic_ctl config set proxy.config.diags.debug.enabled 1 -u -c [file]
```
- Get a value from a `records.yaml` file
```bash
traffic_ctl config get proxy.config.diags.debug.enabled -c [file]
```

`traffic_ctl` docs are updated to reflect these changes.

https://github.com/apache/trafficserver/issues/9384


