### PR TITLE
Clean up the formatting of build options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2443,10 +2443,10 @@ AC_MSG_NOTICE([Build option summary:
     CXXFLAGS:           $CXXFLAGS
     CPPFLAGS:           $CPPFLAGS
     LDFLAGS:            $LDFLAGS
-    AM@&t@_CFLAGS:      $AM_CFLAGS
-    AM@&t@_CXXFLAGS:    $AM_CXXFLAGS
-    AM@&t@_CPPFLAGS:    $AM_CPPFLAGS
-    AM@&t@_LDFLAGS:     $AM_LDFLAGS
+    AM@&t@_CFLAGS:          $AM_CFLAGS
+    AM@&t@_CXXFLAGS:        $AM_CXXFLAGS
+    AM@&t@_CPPFLAGS:        $AM_CPPFLAGS
+    AM@&t@_LDFLAGS:         $AM_LDFLAGS
     TS_INCLUDES:        $TS_INCLUDES
     OPENSSL_LDFLAGS:    $OPENSSL_LDFLAGS
     OPENSSL_INCLUDES:   $OPENSSL_INCLUDES


### PR DESCRIPTION
The flags are now aligned. 

```
    CC:                 ccache cc
    CXX:                ccache c++
    CPP:                cc -E
    CFLAGS:
    CXXFLAGS:
    CPPFLAGS:           -D_GNU_SOURCE -DOPENSSL_NO_SSL_INTERN -DOPENSSL_API_COMPAT=10002 -DOPENSSL_IS_OPENSSL3 -I/opt/quiche/include
    LDFLAGS:            -L/opt/quiche/lib
    AM_CFLAGS:          -std=gnu99 -g -pipe -Wall -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow -O3 -feliminate-unused-debug-symbols -fno-strict-aliasing -Werror -mcx16
    AM_CXXFLAGS:        -std=c++17 -g -pipe -Wall -Wextra -Wno-ignored-qualifiers -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow -O3 -feliminate-unused-debug-symbols -fno-strict-aliasing -Werror -Wno-invalid-offsetof -Wno-noexcept-type -Wsuggest-override -mcx16
    AM_CPPFLAGS:        -Dlinux -D_LARGEFILE64_SOURCE=1 -D_COMPILE64BIT_SOURCE=1 -D_REENTRANT -D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1
    AM_LDFLAGS:         -rdynamic -Wl,--as-needed -R/opt/quiche/lib
    TS_INCLUDES:
    OPENSSL_LDFLAGS:
    OPENSSL_INCLUDES:
    YAMLCPP_LDFLAGS:    -L${abs_top_builddir}/lib/yamlcpp
    YAMLCPP_INCLUDES:   -I${abs_top_srcdir}/lib/yamlcpp/include
    SWOC_LDFLAGS:       -L${abs_top_builddir}/lib/swoc
    SWOC_INCLUDES:      -I${abs_top_srcdir}/lib/swoc/include
    NURAFT_LDFLAGS:
    NURAFT_INCLUDES:
```