### PR TITLE
Added a log message when individual plugin is loaded

### DIFF
--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -189,7 +189,7 @@ single_plugin_init(int argc, char *argv[], bool validateOnly)
   }
 
   plugin_reg_current = nullptr;
-
+  Note("plugin '%s' finished loading", path);
   return true;
 }
 


### PR DESCRIPTION
This PR adds a NOTE-level log message when each plugin is successfully loaded. Previously there are only log messages indicating the plugin is load**ing**:
```
[Feb 13 21:43:54.597] traffic_server NOTE: plugin.config loading ...
[Feb 13 21:43:54.597] traffic_server NOTE: loading plugin '/tmp/sb/certifier/ts1/plugin/certifier.so'
[Feb 13 21:43:54.599] traffic_server NOTE: loading plugin '/tmp/sb/certifier/ts1/plugin/xdebug.so'
[Feb 13 21:43:54.601] traffic_server NOTE: plugin.config finished loading
```
After this PR:
```
[Feb 13 21:48:22.761] traffic_server NOTE: plugin.config loading ...
[Feb 13 21:48:22.761] traffic_server NOTE: loading plugin '/tmp/sb/certifier/ts1/plugin/certifier.so'
[Feb 13 21:48:22.764] traffic_server NOTE: plugin '/tmp/sb/certifier/ts1/plugin/certifier.so' finished loading
[Feb 13 21:48:22.764] traffic_server NOTE: loading plugin '/tmp/sb/certifier/ts1/plugin/xdebug.so'
[Feb 13 21:48:22.774] traffic_server NOTE: plugin '/tmp/sb/certifier/ts1/plugin/xdebug.so' finished loading
[Feb 13 21:48:22.774] traffic_server NOTE: plugin.config finished loading
```
This makes it clear whether a specific plugin is loaded properly.