### PR TITLE
Make jsonrcp restricted_api false by default.

### DIFF
--- a/configs/jsonrpc.yaml.default
+++ b/configs/jsonrpc.yaml.default
@@ -11,4 +11,4 @@
 # rpc:
 #   enabled: true
 #   unix:
-#      restricted_api: true
+#      restricted_api: false

--- a/doc/admin-guide/files/jsonrpc.yaml.en.rst
+++ b/doc/admin-guide/files/jsonrpc.yaml.en.rst
@@ -76,7 +76,7 @@ File `jsonrpc.yaml` is a YAML format. The default configuration looks like:
    rpc:
      enabled: true
      unix:
-       restricted_api: true
+       restricted_api: false
 
 
 ===================== ==========================================================

--- a/mgmt/rpc/server/IPCSocketServer.h
+++ b/mgmt/rpc/server/IPCSocketServer.h
@@ -119,7 +119,7 @@ protected: // unit test access
     int backlog{5};
     int maxRetriesOnTransientErrors{64};
     bool restrictedAccessApi{
-      true}; // This config value will drive the permissions of the jsonrpc socket(either 0700(default) or 0777).
+      NON_RESTRICTED_API}; // This config value will drive the permissions of the jsonrpc socket(either 0700(default) or 0777).
   };
 
   friend struct YAML::convert<rpc::comm::IPCSocketServer::Config>;


### PR DESCRIPTION
Making restricted_api false by default will cause ATS to enforce socket permissions rather than relying upon the DAC of the socket. With this change, ATS will restrict access to privileged users for write operations while allowing broader access for read-only options. Thus `traffic_ctl config get` will be generally accessible since it is a read-only operation, while `traffic_ctl config set` will require privilege since it modifies the configuration. This default should be reasonable since that is how 9.0 used to behave.