### PR TITLE
FileManager string update

### DIFF
--- a/mgmt/config/FileManager.cc
+++ b/mgmt/config/FileManager.cc
@@ -368,27 +368,21 @@ FileManager::ConfigManager::ConfigManager(const char *fileName_, const char *con
   }
 
   // Copy the file name.
-  fileName   = ats_strdup(fileName_);
-  configName = ats_strdup(configName_);
+  fileName   = std::string(fileName_);
+  configName = std::string(configName_);
 
   ink_mutex_init(&fileAccessLock);
   // Check to make sure that our configuration file exists
   //
   if (statFile(&fileInfo) < 0) {
-    Debug(logTag, "%s  Unable to load: %s", fileName, strerror(errno));
+    Debug(logTag, "%s  Unable to load: %s", fileName.c_str(), strerror(errno));
 
     if (isRequired) {
-      Debug(logTag, " Unable to open required configuration file %s\n\t failed :%s", fileName, strerror(errno));
+      Debug(logTag, " Unable to open required configuration file %s\n\t failed :%s", fileName.c_str(), strerror(errno));
     }
   } else {
     fileLastModified = TS_ARCHIVE_STAT_MTIME(fileInfo);
   }
-}
-
-FileManager::ConfigManager::~ConfigManager()
-{
-  ats_free(fileName);
-  ats_free(configName);
 }
 
 //
@@ -431,7 +425,7 @@ FileManager::ConfigManager::checkForUserUpdate(FileManager::RollBackCheckType ho
       fileLastModified = TS_ARCHIVE_STAT_MTIME(fileInfo);
       // TODO: syslog????
     }
-    Debug(logTag, "User has changed config file %s\n", fileName);
+    Debug(logTag, "User has changed config file %s\n", fileName.c_str());
     result = true;
   } else {
     result = false;

--- a/mgmt/config/FileManager.h
+++ b/mgmt/config/FileManager.h
@@ -51,7 +51,6 @@ public:
     // fileName_ should be rooted or a base file name.
     ConfigManager(const char *fileName_, const char *configName_, bool root_access_needed, bool isRequired_,
                   ConfigManager *parentConfig_);
-    ~ConfigManager();
 
     // Manual take out of lock required
     void
@@ -73,13 +72,13 @@ public:
     const char *
     getFileName() const
     {
-      return fileName;
+      return fileName.c_str();
     }
 
     const char *
     getConfigName() const
     {
-      return configName;
+      return configName.c_str();
     }
 
     bool
@@ -114,8 +113,8 @@ public:
     int statFile(struct stat *buf);
 
     ink_mutex fileAccessLock;
-    char *fileName;
-    char *configName;
+    std::string fileName;
+    std::string configName;
     bool root_access_needed;
     bool isRequired;
     ConfigManager *parentConfig;


### PR DESCRIPTION
Rather than manage FileManager's fileName and configName char* strings with ats_strdup and ats_free, this converts them to std::string and lets it manage the memory.