### PR TITLE
Prevent object_read and cache_lookup_result diverge

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -430,10 +430,10 @@ CacheVC::set_data(int /* i ATS_UNUSED */, void * /* data */)
   return true;
 }
 
-void
-CacheVC::get_http_info(CacheHTTPInfo **ainfo)
+CacheHTTPInfo *
+CacheVC::get_http_info()
 {
-  *ainfo = &(this)->alternate;
+  return &(this)->alternate;
 }
 
 // set_http_info must be called before do_io_write

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -184,8 +184,8 @@ struct CacheVConnection : public VConnection {
   virtual int set_header(void *ptr, int len)        = 0;
   virtual int get_single_data(void **ptr, int *len) = 0;
 
-  virtual void set_http_info(CacheHTTPInfo *info)  = 0;
-  virtual void get_http_info(CacheHTTPInfo **info) = 0;
+  virtual void set_http_info(CacheHTTPInfo *info) = 0;
+  virtual CacheHTTPInfo *get_http_info()          = 0;
 
   virtual bool is_ram_cache_hit() const   = 0;
   virtual bool set_pin_in_cache(time_t t) = 0;

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -389,7 +389,7 @@ struct CacheVC : public CacheVConnection {
   void cancel_trigger();
   int64_t get_object_size() override;
   void set_http_info(CacheHTTPInfo *info) override;
-  void get_http_info(CacheHTTPInfo **info) override;
+  CacheHTTPInfo *get_http_info() override;
   /** Get the fragment table.
       @return The address of the start of the fragment table,
       or @c nullptr if there is no fragment table.

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -281,8 +281,8 @@ CacheReadTest::do_io_read(size_t size)
   if (size == 0) {
     size = this->_size;
   }
-  this->vc->get_http_info(&this->read_http_info);
-  this->vio = this->vc->do_io_read(this, size, this->_read_buffer);
+  this->read_http_info = this->vc->get_http_info();
+  this->vio            = this->vc->do_io_read(this, size, this->_read_buffer);
 }
 
 int

--- a/proxy/http/HttpCacheSM.cc
+++ b/proxy/http/HttpCacheSM.cc
@@ -257,7 +257,7 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
       // than or equal to the max number of open write retries
       ink_assert(!write_retry_done());
 
-      open_write(&cache_key, lookup_url, read_request_hdr, master_sm->t_state.cache_info.object_read,
+      open_write(&cache_key, lookup_url, read_request_hdr, master_sm->t_state.cache_info.get_object_read(),
                  static_cast<time_t>(
                    (master_sm->t_state.cache_control.pin_in_cache_for < 0) ? 0 : master_sm->t_state.cache_control.pin_in_cache_for),
                  retry_write, false);

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -7455,7 +7455,7 @@ cache_hook_handler(TSCont contp, TSEvent event, void *edata)
       SDK_RPRINT(data->test, "TSHttpTxnCachedReqGet", "TestCase1", TC_FAIL, "TSHttpTxnCachedReqGet returns 0");
     } else {
       if ((reqbuf == reinterpret_cast<TSMBuffer>(((HttpSM *)txnp)->t_state.cache_req_hdr_heap_handle)) &&
-          (reqhdr == reinterpret_cast<TSMLoc>((((HttpSM *)txnp)->t_state.cache_info.object_read->request_get())->m_http))) {
+          (reqhdr == reinterpret_cast<TSMLoc>((((HttpSM *)txnp)->t_state.cache_info.get_object_read()->request_get())->m_http))) {
         SDK_RPRINT(data->test, "TSHttpTxnCachedReqGet", "TestCase1", TC_PASS, "ok");
         data->test_passed_txn_cached_req_get = true;
       } else {
@@ -7467,7 +7467,7 @@ cache_hook_handler(TSCont contp, TSEvent event, void *edata)
       SDK_RPRINT(data->test, "TSHttpTxnCachedRespGet", "TestCase1", TC_FAIL, "TSHttpTxnCachedRespGet returns 0");
     } else {
       if ((respbuf == reinterpret_cast<TSMBuffer>(((HttpSM *)txnp)->t_state.cache_resp_hdr_heap_handle)) &&
-          (resphdr == reinterpret_cast<TSMLoc>((((HttpSM *)txnp)->t_state.cache_info.object_read->response_get())->m_http))) {
+          (resphdr == reinterpret_cast<TSMLoc>((((HttpSM *)txnp)->t_state.cache_info.get_object_read()->response_get())->m_http))) {
         SDK_RPRINT(data->test, "TSHttpTxnCachedRespGet", "TestCase1", TC_PASS, "ok");
         data->test_passed_txn_cached_resp_get = true;
       } else {


### PR DESCRIPTION
We've been occasionally seeing crashes caused by accessing invalid (nullptr) `object_read`. We could add null checks here and there but I don't want to repeat crash-then-bandaid process for it.

I think there is a seed that started causing the crashes somewhere and ideally we should find and remove the root cause, but that'd be difficult. This change does not fix the root cause, but should prevent accessing invalid `object_read` where `cache_lookup_result` suggests it's cache-hit and an object should be read and available, by adding accessor functions that restricts setting/getting unreasonable values. It might not be complete, but `object_read` is read at many places that assumes it's cache-hit and returning cache-miss when there's doubt avoids the problematic access.

The key change is in HttpTransaction.h. When ATS accesses `cache_lookup_result`, the setter function detects unreasonable change and try to keep it makes sense, and the getter detects outdated result value and return a safer value (i.e. cache miss).