### PR TITLE
traffic_ctl: Add support to monitor metrics.

### DIFF
--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -258,6 +258,36 @@ traffic_ctl metric
 
    Error output available if ``--format pretty`` is specified.
 
+.. program:: traffic_ctl metric
+.. option:: monitor [-i, -c] METRIC [METRIC...]
+
+   Display the current value of the specified metric(s) using an interval time
+   and a count value. Use ``-i`` to set the interval time between requests, and
+   ``-c`` to set the number of requests the program will send in total per metric.
+   Note that the metric will display `+` or `-` depending on the value of the last
+   metric and the current being shown, if current is greater, then  `+` will be
+   added beside the metric value, `-` if the last value is less than current,
+   and no symbol is the same.
+
+   Example:
+
+   .. code-block:: bash
+
+      $ traffic_ctl  metric monitor proxy.process.eventloop.time.min.10s -i 2 -c 10
+      proxy.process.eventloop.time.min.10s: 4025085
+      proxy.process.eventloop.time.min.10s: 4025085
+      proxy.process.eventloop.time.min.10s: 4025085
+      proxy.process.eventloop.time.min.10s: 4025085
+      proxy.process.eventloop.time.min.10s: 4011194 -
+      proxy.process.eventloop.time.min.10s: 4011194
+      proxy.process.eventloop.time.min.10s: 4011194
+      proxy.process.eventloop.time.min.10s: 4011194
+      proxy.process.eventloop.time.min.10s: 4011194
+      proxy.process.eventloop.time.min.10s: 4018669 +
+      --- metric monitor statistics ---
+      ┌ proxy.process.eventloop.time.min.10s
+      └─ min/avg/max = 4011194/4017498/4025085
+
 .. _traffic-control-command-server:
 
 traffic_ctl server

--- a/src/traffic_ctl/CtrlCommands.h
+++ b/src/traffic_ctl/CtrlCommands.h
@@ -136,12 +136,14 @@ class MetricCommand : public RecordCommand
 {
   static inline const std::string CLEAR_STR{"clear"};
   static inline const std::string ZERO_STR{"zero"};
+  static inline const std::string MONITOR_STR{"monitor"};
 
   void metric_get();
   void metric_match();
   void metric_describe();
   void metric_clear();
   void metric_zero();
+  void metric_monitor();
 
 public:
   MetricCommand(ts::Arguments *args);

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -111,8 +111,11 @@ main(int argc, const char **argv)
                              [&]() { command->execute(); }); // not implemented
   metric_command.add_command("match", "Get metrics matching a regular expression", "", MORE_THAN_ZERO_ARG_N,
                              [&]() { command->execute(); });
-  metric_command.add_command("monitor", "Display the value of a metric over time", "", MORE_THAN_ZERO_ARG_N,
-                             [&]() { CtrlUnimplementedCommand("monitor"); }); // not implemented
+  metric_command
+    .add_command("monitor", "Display the value of a metric(s) over time", "", MORE_THAN_ZERO_ARG_N, [&]() { command->execute(); })
+    .add_example_usage("traffic_ctl metric monitor METRIC -i 3 -c 10")
+    .add_option("--count", "-c", "Stop after requesting count metrics.", "", 1, "10")
+    .add_option("--interval", "-i", "Wait interval seconds between sending each metric request. Minimum value is 1s.", "", 1, "5");
   metric_command.add_command("zero", "Clear one or more metric values", "", MORE_THAN_ONE_ARG_N, [&]() { command->execute(); });
 
   // plugin command


### PR DESCRIPTION
Handles metric monitor in a simply way giving some data out as a summary.

![monitor3](https://user-images.githubusercontent.com/16683788/219365830-219a279e-5876-4c82-aac1-af8354a50ad6.gif)

PS: I'll have a different PR to handle SIGINT to display the summary(as in `ping`).