### PR TITLE
tscore: Remove unneeded and mispelled libswoc reference.

### DIFF
--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -152,7 +152,7 @@ ParseRulesCType: CompileParseRules
 	LSAN_OPTIONS='detect_leaks=0' ./CompileParseRules
 
 test_atomic_SOURCES = test_atomic.cc
-test_atomic_LDADD = libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la @SWOC_LIBSS@ @LIBPCRE@
+test_atomic_LDADD = libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la @LIBPCRE@
 
 test_freelist_SOURCES = test_freelist.cc
 test_freelist_LDADD = libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la @SWOC_LIBS@ @LIBPCRE@


### PR DESCRIPTION
The atomic tests had a link to "@SWOC_LIBSS@". How this typo passed all these months I have no idea. But it does break in some circumstances. It appears to have mostly worked because there are no missing links, therefore I removed the reference entirely.