### PR TITLE
Ethread::process_event(): make sure event mutex is unlocked before freeing event.

### DIFF
--- a/doc/developer-guide/api/functions/TSContCreate.en.rst
+++ b/doc/developer-guide/api/functions/TSContCreate.en.rst
@@ -32,3 +32,8 @@ Synopsis
 
 Description
 ===========
+Creates a continuation, which can be destroyed with :func:`TSContDestroy`.
+**Note:** when a mutex is passed to a call to this function, it creates a
+reference to the mutex.  The mutex will be destroyed when the number of
+continuations refering to it becomes zero (due to calls to :func:`TSContDestroy`).
+:func:`TSMutexDestroy` must not be called for the mutex.

--- a/doc/developer-guide/api/functions/TSMutexDestroy.en.rst
+++ b/doc/developer-guide/api/functions/TSMutexDestroy.en.rst
@@ -34,4 +34,6 @@ Description
 ===========
 
 Destroys the indicated :arg:`mutex` previously created via
-:func:`TSMutexCreate`.
+:func:`TSMutexCreate`.  **Note:**  Do not call this function for a mutex that
+was passed to :func:`TSContCreate` as a parameter.  It will be destroyed by call(s)
+to :func:`TSContDestroy`.

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -139,6 +139,7 @@ EThread::process_event(Event *e, int calling_code)
     EventQueueExternal.enqueue_local(e);
   } else {
     if (e->cancelled) {
+      MUTEX_RELEASE(lock);
       free_event(e);
       return;
     }


### PR DESCRIPTION
Also adds important information to docs about TSMutexDestroy().