### PR TITLE
quic: make sure we create a stream if none available.

### DIFF
--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -539,8 +539,12 @@ QUICNetVConnection::_handle_write_ready()
     quiche_stream_iter *writable = quiche_conn_writable(this->_quiche_con);
     uint64_t s                   = 0;
     while (quiche_stream_iter_next(writable, &s)) {
-      QUICStreamImpl *stream;
-      stream = static_cast<QUICStreamImpl *>(quiche_conn_stream_application_data(this->_quiche_con, s));
+      QUICStreamImpl *stream = static_cast<QUICStreamImpl *>(quiche_conn_stream_application_data(this->_quiche_con, s));
+      if (stream == nullptr) {
+        this->_stream_manager->create_stream(s);
+        stream = static_cast<QUICStreamImpl *>(this->_stream_manager->find_stream(s));
+        quiche_conn_stream_init_application_data(this->_quiche_con, s, stream);
+      }
       stream->send_data(this->_quiche_con);
     }
     quiche_stream_iter_free(writable);


### PR DESCRIPTION
While doing some tests with different `initial_max_streams_*` configuration I found out that when increasing the streams using h2load ATS crashes as the requested stream is not created. This PR follows the same logic as `read_ready` and creates the stream if needed.

Crash:


```
Thread 4 "[ET_NET 1]" received signal SIGSEGV, Segmentation fault.                                                                                            
[Switching to Thread 0x7ffff41df700 (LWP 965501)]                                                                                                             
0x0000555555ef0872 in QUICStreamImpl::send_data (this=0x0, quiche_con=0x7fff8cba7e50) at QUICStream_quiche.cc:78                                              
78        len = quiche_conn_stream_capacity(quiche_con, this->_id);                                                                                           
(gdb) bt                                                                                                                                                      
#0  0x0000555555ef0872 in QUICStreamImpl::send_data (this=0x0, quiche_con=0x7fff8cba7e50) at QUICStream_quiche.cc:78                                          
#1  0x0000555555e4a3b4 in QUICNetVConnection::_handle_write_ready (this=0x7fff8c5b3ca0) at QUICNetVConnection_quiche.cc:544
#2  0x0000555555e489c1 in QUICNetVConnection::state_established (this=0x7fff8c5b3ca0, event=2501, data=0x7fffde2f8040) at QUICNetVConnection_quiche.cc:168
#3  0x00005555559c31a7 in Continuation::handleEvent (this=0x7fff8c5b3ca0, event=2501, data=0x7fffde2f8040)
    at /home/dmeden/code/git/trafficserver/iocore/eventsystem/I_Continuation.h:228
#4  0x0000555555ef8103 in EThread::process_event (this=0x555556616650, e=0x7fffde2f8040, calling_code=2501) at UnixEThread.cc:150
#5  0x0000555555ef876c in EThread::execute_regular (this=0x555556616650) at UnixEThread.cc:256
#6  0x0000555555ef8a8a in EThread::execute (this=0x555556616650) at UnixEThread.cc:335
#7  0x0000555555ef71a6 in spawn_thread_internal (a=0x5555564d11d0) at Thread.cc:79
#8  0x00007ffff76e6609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#9  0x00007ffff7038133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95


(gdb) f 1
#1  0x0000555555e4a3b4 in QUICNetVConnection::_handle_write_ready (this=0x7fff8c5b3ca0) at QUICNetVConnection_quiche.cc:544
544           stream->send_data(this->_quiche_con);
(gdb) p s
$5 = 4232
(gdb) p stream
$6 = (QUICStreamImpl *) 0x0
```