### PR TITLE
QUIC: Support active_connection_id_limit for quche impl.

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4447,7 +4447,7 @@ HTTP/3 Configuration
 There is no configuration available yet on this release.
 
 QUIC Configuration
-====================
+==================
 
 All configurations for QUIC are still experimental and may be changed or
 removed in the future without prior notice.
@@ -4674,6 +4674,13 @@ removed in the future without prior notice.
 
    This is just for debugging. Do not change it from the default value unless
    you really understand what this is.
+
+.. ts:cv:: CONFIG proxy.config.quic.active_cid_limit_in INT 2
+   :reloadable:
+
+   Integer value specifying the maximum number of connection IDs from the peer
+   that |TS| is willing to store. The value MUST be at least 2.
+   Transport Parameter.
 
 UDP Configuration
 =====================

--- a/iocore/net/QUICNetProcessor_quiche.cc
+++ b/iocore/net/QUICNetProcessor_quiche.cc
@@ -99,6 +99,7 @@ QUICNetProcessor::start(int, size_t stacksize)
   quiche_config_set_initial_max_streams_bidi(this->_quiche_config, params->initial_max_streams_bidi_in());
   quiche_config_set_initial_max_streams_uni(this->_quiche_config, params->initial_max_streams_uni_in());
   quiche_config_set_disable_active_migration(this->_quiche_config, params->disable_active_migration());
+  quiche_config_set_active_connection_id_limit(this->_quiche_config, params->active_cid_limit_in());
   quiche_config_set_cc_algorithm(this->_quiche_config, QUICHE_CC_RENO);
 
 #ifdef TLS1_3_VERSION_DRAFT_TXT

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -1437,7 +1437,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.quic.max_ack_delay_out", RECD_INT, "25", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.quic.active_cid_limit_in", RECD_INT, "4", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.quic.active_cid_limit_in", RECD_INT, "2", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.quic.active_cid_limit_out", RECD_INT, "8", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,


### PR DESCRIPTION
with:
```yaml
ts:
  quic:
    active_cid_limit_in: 10
```
then:
```
I00000017 0x51204e25173e688b cry remote transport_parameters active_connection_id_limit=10
```
if we set less that what's accepted, then:

```yaml
ts:
  quic:
    active_cid_limit_in: 1
```
then:
```
I00000049 0x80075250bbfc334b cry remote transport_parameters active_connection_id_limit=2
```

fixes https://github.com/apache/trafficserver/issues/9419