### PR TITLE
Fix parameter parser in ssl_hook_test plugin

### DIFF
--- a/tests/tools/plugins/ssl_hook_test.cc
+++ b/tests/tools/plugins/ssl_hook_test.cc
@@ -246,11 +246,11 @@ parse_callbacks(int argc, const char *argv[], int &preaccept_count, int &client_
         ptr = index(argv[i], '=');
         if (ptr) {
           if (strncmp(argv[i] + 1, "close", strlen("close")) == 0) {
-            close_count = atoi(ptr + i);
+            close_count = atoi(ptr + 1);
           } else if (strncmp(argv[i] + 1, "client_hello_imm", strlen("client_hello_imm")) == 0) {
-            client_hello_count_immediate = atoi(ptr + i);
+            client_hello_count_immediate = atoi(ptr + 1);
           } else if (strncmp(argv[i] + 1, "client_hello", strlen("client_hello")) == 0) {
-            client_hello_count = atoi(ptr + i);
+            client_hello_count = atoi(ptr + 1);
           } else {
             cert_count = atoi(ptr + 1);
           }


### PR DESCRIPTION
As you can see on the other lines that use `atoi()`, it should be `ptr + 1` but not `ptr + i`. Current code fails to read the specified value if these parameters are not the first parameter.