### PR TITLE
Stabilize autest tls_hook18

### DIFF
--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -52,7 +52,7 @@ ts.Disk.remap_config.AddLine(
     'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
 )
 
-Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello=2')
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello=2 -close=1')
 
 tr = Test.AddTestRun("Test two client hello hooks")
 tr.Processes.Default.StartBefore(server)


### PR DESCRIPTION
The test can crash in `ReenableSSL` because it can be called in 2 seconds regardless of the status of VC.