### PR TITLE
Run autest tls_hooks17 and tls_hooks18 on BoringSSL build

### DIFF
--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -26,7 +26,6 @@ Test different combinations of TLS handshake hooks to ensure they are applied co
 
 Test.SkipUnless(
     Condition.HasOpenSSLVersion("1.1.1"),
-    Condition.IsOpenSSL()
 )
 
 ts = Test.MakeATSProcess("ts", enable_tls=True)

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -26,7 +26,6 @@ Test different combinations of TLS handshake hooks to ensure they are applied co
 
 Test.SkipUnless(
     Condition.HasOpenSSLVersion("1.1.1"),
-    Condition.IsOpenSSL()
 )
 
 ts = Test.MakeATSProcess("ts", enable_tls=True)


### PR DESCRIPTION
The tests are currently skipped, but those actually pass on BoringSSL.