### PR TITLE
Add clang-format-tests to clang-format target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -131,7 +131,8 @@ CLANG_FORMAT_DIR_TARGETS = \
 	clang-format-mgmt \
 	clang-format-plugins \
 	clang-format-proxy \
-	clang-format-tools
+	clang-format-tools \
+	clang-format-tests
 
 .PHONY:	$(CLANG_FORMAT_DIR_TARGETS)
 


### PR DESCRIPTION
`clang-format-tests` isn't ran when `make clang-format`.

Is it actually intentional by any chance?