### PR TITLE
Make the plugin load tests expensive

### DIFF
--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -80,7 +80,10 @@ clang-tidy-local: $(libhttp_remap_a_SOURCES)
 	$(CXX_Clang_Tidy)
 
 TESTS = $(check_PROGRAMS)
-check_PROGRAMS =  test_PluginDso test_PluginFactory test_RemapPluginInfo test_NextHopStrategyFactory test_NextHopRoundRobin test_NextHopConsistentHash
+check_PROGRAMS =  test_NextHopStrategyFactory test_NextHopRoundRobin test_NextHopConsistentHash
+
+if EXPENSIVE_TESTS
+check_PROGRAMS += test_PluginFactory test_PluginDso test_RemapPluginInfo
 
 test_PluginDso_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/tests/include -DPLUGIN_DSO_TESTS
 test_PluginDso_LIBTOOLFLAGS = --preserve-dup-deps
@@ -123,6 +126,7 @@ test_RemapPluginInfo_SOURCES = \
 	unit-tests/test_RemapPlugin.cc \
 	PluginDso.cc \
 	RemapPluginInfo.cc
+endif
 
 test_NextHopStrategyFactory_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -224,6 +228,8 @@ DSO_LDFLAGS = \
 	-export-symbols-regex '^(TSRemapInit|TSRemapDone|TSRemapDoRemap|TSRemapNewInstance|TSRemapDeleteInstance|TSRemapOSResponse|TSRemapPreConfigReload|TSRemapPostConfigReload|TSPluginInit|pluginDsoVersionTest|getPluginDebugObjectTest)$$'
 
 # Build plugins for unit testing the plugin (re)load.
+if EXPENSIVE_TESTS
+
 pkglib_LTLIBRARIES = \
 	unit-tests/plugin_v1.la \
 	unit-tests/plugin_v2.la \
@@ -265,3 +271,5 @@ unit_tests_plugin_missing_newinstance_la_CPPFLAGS = -DPLUGINDSOVER=1 $(AM_CPPFLA
 unit_tests_plugin_testing_calls_la_SOURCES = unit-tests/plugin_testing_calls.cc unit-tests/plugin_testing_common.cc
 unit_tests_plugin_testing_calls_la_LDFLAGS = $(DSO_LDFLAGS)
 unit_tests_plugin_testing_calls_la_CPPFLAGS = -DPLUGINDSOVER=1 $(AM_CPPFLAGS)
+
+endif


### PR DESCRIPTION
This avoids having all the test plugins (.so's) be installed in the installation directory, unless you enable the expensive tests. This is not a great solution, if there's some better way of avoiding the installation of all those libraries, disregard this patch and do that instead.

The issue is that all these plugins for testing gets installed in .../lib, which is not cool.

```
-rwxr-xr-x 1 root root   71776 Feb 23 09:11 plugin_v1.so
-rwxr-xr-x 1 root root     933 Feb 23 09:11 plugin_v1.la
-rwxr-xr-x 1 root root   71776 Feb 23 09:11 plugin_v2.so
-rwxr-xr-x 1 root root     933 Feb 23 09:11 plugin_v2.la
-rwxr-xr-x 1 root root   69680 Feb 23 09:11 plugin_init_fail.so
-rwxr-xr-x 1 root root   70008 Feb 23 09:11 plugin_instinit_fail.so
-rwxr-xr-x 1 root root     999 Feb 23 09:11 plugin_instinit_fail.la
-rwxr-xr-x 1 root root     975 Feb 23 09:11 plugin_init_fail.la
-rwxr-xr-x 1 root root   16376 Feb 23 09:11 plugin_required_cb.so
-rwxr-xr-x 1 root root     987 Feb 23 09:11 plugin_required_cb.la
-rwxr-xr-x 1 root root   16576 Feb 23 09:11 plugin_missing_deleteinstance.so
-rwxr-xr-x 1 root root   15952 Feb 23 09:11 plugin_missing_doremap.so
-rwxr-xr-x 1 root root    1011 Feb 23 09:11 plugin_missing_doremap.la
-rwxr-xr-x 1 root root    1053 Feb 23 09:11 plugin_missing_deleteinstance.la
-rwxr-xr-x 1 root root   16536 Feb 23 09:11 plugin_missing_newinstance.so
-rwxr-xr-x 1 root root   16080 Feb 23 09:11 plugin_missing_init.so
-rwxr-xr-x 1 root root     993 Feb 23 09:11 plugin_missing_init.la
-rwxr-xr-x 1 root root  113440 Feb 23 09:11 plugin_testing_calls.so
-rwxr-xr-x 1 root root     999 Feb 23 09:11 plugin_testing_calls.la
-rwxr-xr-x 1 root root    1035 Feb 23 09:11 plugin_missing_newinstance.la
```