### PR TITLE
Use SSL_get1_peer_certificate on OpenSSL3 build

### DIFF
--- a/example/plugins/c-api/verify_cert/verify_cert.cc
+++ b/example/plugins/c-api/verify_cert/verify_cert.cc
@@ -64,7 +64,11 @@ CB_clientcert(TSCont /* contp */, TSEvent /* event */, void *edata)
   TSVConn ssl_vc         = reinterpret_cast<TSVConn>(edata);
   TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
   SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-  X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+  X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+  X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
   TSDebug(PLUGIN_NAME, "plugin verify_cert verifying client certificate");
   if (cert) {
     debug_certificate("client certificate subject CN is %s", X509_get_subject_name(cert));

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -345,7 +345,11 @@ public:
   bool
   peer_provided_cert() const override
   {
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(this->ssl);
+#else
     X509 *cert = SSL_get_peer_certificate(this->ssl);
+#endif
     if (cert != nullptr) {
       X509_free(cert);
       return true;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -1350,7 +1350,11 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
   switch (ssl_error) {
   case SSL_ERROR_NONE:
     if (is_debug_tag_set("ssl")) {
+#ifdef OPENSSL_IS_OPENSSL3
+      X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
       X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
 
       Debug("ssl", "SSL server handshake completed successfully");
       if (cert) {
@@ -1535,7 +1539,11 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
   switch (ssl_error) {
   case SSL_ERROR_NONE:
     if (is_debug_tag_set("ssl")) {
+#ifdef OPENSSL_IS_OPENSSL3
+      X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
       X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
 
       Debug("ssl", "SSL client handshake completed successfully");
 

--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -154,7 +154,11 @@ private:
   void
   _set()
   {
+#ifdef OPENSSL_IS_OPENSSL3
+    _x509 = (IsClient ? SSL_get1_peer_certificate : SSL_get_certificate)(_ssl);
+#else
     _x509 = (IsClient ? SSL_get_peer_certificate : SSL_get_certificate)(_ssl);
+#endif
   }
 };
 } // end anonymous namespace

--- a/plugins/experimental/wasm/ats_context.cc
+++ b/plugins/experimental/wasm/ats_context.cc
@@ -567,7 +567,11 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn client_conn    = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj = TSVConnSslConnectionGet(client_conn);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-    X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
     if (cert != nullptr) {
       m = true;
       X509_free(cert);
@@ -631,7 +635,11 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn client_conn    = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj = TSVConnSslConnectionGet(client_conn);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-    X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
     if (cert != nullptr) {
       print_certificate(result, X509_get_subject_name(cert));
       X509_free(cert);
@@ -665,7 +673,11 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn client_conn    = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj = TSVConnSslConnectionGet(client_conn);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-    X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
     if (cert != nullptr) {
       print_san_certificate(result, cert, GEN_DNS);
       X509_free(cert);
@@ -699,7 +711,11 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn client_conn    = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj = TSVConnSslConnectionGet(client_conn);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-    X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
     if (cert != nullptr) {
       print_san_certificate(result, cert, GEN_URI);
       X509_free(cert);
@@ -784,7 +800,11 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn client_conn    = TSHttpSsnServerVConnGet(ssnp);
     TSSslConnection sslobj = TSVConnSslConnectionGet(client_conn);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-    X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
     if (cert != nullptr) {
       print_certificate(result, X509_get_subject_name(cert));
       X509_free(cert);
@@ -818,7 +838,11 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn client_conn    = TSHttpSsnServerVConnGet(ssnp);
     TSSslConnection sslobj = TSVConnSslConnectionGet(client_conn);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-    X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
     if (cert != nullptr) {
       print_san_certificate(result, cert, GEN_DNS);
       X509_free(cert);
@@ -852,7 +876,11 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn client_conn    = TSHttpSsnServerVConnGet(ssnp);
     TSSslConnection sslobj = TSVConnSslConnectionGet(client_conn);
     SSL *ssl               = reinterpret_cast<SSL *>(sslobj);
-    X509 *cert             = SSL_get_peer_certificate(ssl);
+#ifdef OPENSSL_IS_OPENSSL3
+    X509 *cert = SSL_get1_peer_certificate(ssl);
+#else
+    X509 *cert = SSL_get_peer_certificate(ssl);
+#endif
     if (cert != nullptr) {
       print_san_certificate(result, cert, GEN_URI);
       X509_free(cert);


### PR DESCRIPTION
> SSL_get0_peer_certificate() and SSL_get1_peer_certificate() were added in 3.0.0. SSL_get_peer_certificate() was deprecated in 3.0.0.

> SSL_get_peer_certificate() is an alias of SSL_get1_peer_certificate().

https://www.openssl.org/docs/man3.0/man3/SSL_get_peer_certificate.html