### PR TITLE
QUIC: Make some adjustment to the qlog configuration

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4415,11 +4415,26 @@ QUIC Configuration
 All configurations for QUIC are still experimental and may be changed or
 removed in the future without prior notice.
 
-.. ts:cv:: CONFIG proxy.config.quic.qlog_dir STRING NULL
+.. ts:cv:: CONFIG proxy.config.quic.qlog.file_base STRING NULL
    :reloadable:
 
-    The qlog is enabled when this configuration is not NULL. And will dump
-    the qlog to this dir.
+   Sets qlog output to a specific base file name.  For a given file base name the file becomes
+   ``{file_base}-{trace id}.sqlog``.
+   Absolute path or relative to the configured prefix can be used.
+   Qlog is emitted  for each connection.
+
+   .. code-block:: yaml
+
+      ts:
+        quic:
+          qlog:
+            file_base: /my/logs/test1
+
+   The above configuration will make |TS| to generate Qlogs with the following format:
+
+.. code-block:: bash
+
+   /my/logs/test1-e9158839e54cb8f34ab00d34236ad5e19a49.sqlog
 
 .. ts:cv:: CONFIG proxy.config.quic.instance_id INT 0
    :reloadable:

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -477,7 +477,7 @@ QUICNetVConnection::start()
   this->_frame_dispatcher->add_handler(this->_handshake_handler);
 
   // register qlog
-  if (this->_context->config()->qlog_dir() != nullptr) {
+  if (this->_context->config()->get_qlog_file_base_name() != nullptr) {
     this->_qlog = std::make_unique<QLog::QLogListener>(*this->_context, this->_original_quic_connection_id.hex());
     this->_qlog->last_trace().set_vantage_point(
       {"ats", QLog::Trace::VantagePointType::server, QLog::Trace::VantagePointType::server});

--- a/iocore/net/quic/QUICConfig.cc
+++ b/iocore/net/quic/QUICConfig.cc
@@ -95,8 +95,9 @@ quic_init_client_ssl_ctx(const QUICConfigParams *params)
 //
 QUICConfigParams::~QUICConfigParams()
 {
-  this->_server_supported_groups = (char *)ats_free_null(this->_server_supported_groups);
-  this->_client_supported_groups = (char *)ats_free_null(this->_client_supported_groups);
+  this->_server_supported_groups = static_cast<char *>(ats_free_null(this->_server_supported_groups));
+  this->_client_supported_groups = static_cast<char *>(ats_free_null(this->_client_supported_groups));
+  this->_qlog_file_base_name     = static_cast<char *>(ats_free_null(this->_qlog_file_base_name));
 
   SSL_CTX_free(this->_client_ssl_ctx.get());
 };
@@ -117,7 +118,9 @@ QUICConfigParams::initialize()
   REC_ReadConfigStringAlloc(this->_server_supported_groups, "proxy.config.quic.server.supported_groups");
   REC_ReadConfigStringAlloc(this->_client_supported_groups, "proxy.config.quic.client.supported_groups");
   REC_ReadConfigStringAlloc(this->_client_session_file, "proxy.config.quic.client.session_file");
-  REC_ReadConfigStringAlloc(this->_qlog_dir, "proxy.config.quic.qlog_dir");
+
+  // Qlog
+  REC_ReadConfigStringAlloc(this->_qlog_file_base_name, "proxy.config.quic.qlog.file_base");
 
   // Transport Parameters
   REC_EstablishStaticConfigInt32U(this->_no_activity_timeout_in, "proxy.config.quic.no_activity_timeout_in");
@@ -442,9 +445,9 @@ QUICConfigParams::client_session_file() const
 }
 
 const char *
-QUICConfigParams::qlog_dir() const
+QUICConfigParams::get_qlog_file_base_name() const
 {
-  return this->_qlog_dir;
+  return this->_qlog_file_base_name;
 }
 
 //

--- a/iocore/net/quic/QUICConfig.h
+++ b/iocore/net/quic/QUICConfig.h
@@ -46,7 +46,9 @@ public:
   const char *server_supported_groups() const;
   const char *client_supported_groups() const;
   const char *client_session_file() const;
-  const char *qlog_dir() const;
+
+  // qlog
+  const char *get_qlog_file_base_name() const;
 
   shared_SSL_CTX client_ssl_ctx() const;
 
@@ -106,7 +108,8 @@ private:
   char *_server_supported_groups = nullptr;
   char *_client_supported_groups = nullptr;
   char *_client_session_file     = nullptr;
-  char *_qlog_dir                = nullptr;
+  // qlog
+  char *_qlog_file_base_name = nullptr;
 
   shared_SSL_CTX _client_ssl_ctx = nullptr;
 

--- a/iocore/net/quic/qlog/QLogListener.h
+++ b/iocore/net/quic/qlog/QLogListener.h
@@ -99,7 +99,7 @@ public:
   void
   connection_close_callback(QUICCallbackContext &) override
   {
-    this->_log.dump(this->_context.config()->qlog_dir());
+    this->_log.dump(this->_context.config()->get_qlog_file_base_name());
   }
 
   Trace &

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -1390,7 +1390,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.quic.client.session_file", RECD_STRING, nullptr , RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.quic.qlog_dir", RECD_STRING, nullptr , RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.quic.qlog.file_base", RECD_STRING, nullptr , RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   // Transport Parameters
   {RECT_CONFIG, "proxy.config.quic.no_activity_timeout_in", RECD_INT, "30000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
@@ -55,7 +55,7 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'traffic_dump|quic',
     'proxy.config.http.insert_age_in_response': 0,
 
-    'proxy.config.quic.qlog_dir': qlog_dir,
+    'proxy.config.quic.qlog.file_base': qlog_dir,
 
     'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
     'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,

--- a/tests/gold_tests/records/gold/full_records.yaml
+++ b/tests/gold_tests/records/gold/full_records.yaml
@@ -462,7 +462,8 @@ ts:
     num_alt_connection_ids: 8
     preferred_address_ipv4: null
     preferred_address_ipv6: null
-    qlog_dir: null
+    qlog:
+      file_base: null
     server:
       quantum_readiness_test_enabled: 0
       stateless_retry_enabled: 0

--- a/tests/gold_tests/records/legacy_config/full_records.config
+++ b/tests/gold_tests/records/legacy_config/full_records.config
@@ -448,7 +448,7 @@ CONFIG proxy.config.quic.server.quantum_readiness_test_enabled INT 0
 CONFIG proxy.config.quic.server.supported_groups STRING P-256:X25519:P-384:P-52
 CONFIG proxy.config.quic.client.supported_groups STRING P-256:X25519:P-384:P-52
 CONFIG proxy.config.quic.client.session_file STRING nullptr
-CONFIG proxy.config.quic.qlog_dir STRING nullptr
+CONFIG proxy.config.quic.qlog.file_base STRING nullptr
 CONFIG proxy.config.quic.no_activity_timeout_in INT 30000
 CONFIG proxy.config.quic.no_activity_timeout_out INT 30000
 CONFIG proxy.config.quic.preferred_address_ipv4 STRING nullptr


### PR DESCRIPTION
Renamed the `qlog_dir` and make `qlog` its own map inside quic config.
```yaml
ts:
  quic:
    qlog:
      file_base: zyx
```
This change algo let the user to set, beside the path, the common name used in each qlog file, so base on the above example ATS will generate the following qlog files:

```
zyx-e9158839e54cb8f34ab00d34236ad5e19a49.sqlog
zyx-39e54cb8f3e91586ad5e19a4984ab00d3423.sqlog
zyx-8839e54cbd5e19a498f34e915ab00d34236a.sqlog
...
```

try the qlog [here](https://qvis.quictools.info/#/files)

Docs are updated too.

Fixes https://github.com/apache/trafficserver/issues/9343