### PR TITLE
Adds a --enable-lto option (Link Time Optimization)

### DIFF
--- a/build/common.m4
+++ b/build/common.m4
@@ -37,6 +37,9 @@ EOF
   if test -n "$CXX"; then
     echo "CXX=\"$CXX\"; export CXX" >> $1
   fi
+  if test -n "$LD"; then
+    echo "LD=\"$LD\"; export LD" >> $1
+  fi
   if test -n "$CFLAGS"; then
     echo "CFLAGS=\"$CFLAGS\"; export CFLAGS" >> $1
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,17 @@ AC_ARG_ENABLE([tsan],
 AC_MSG_RESULT([$enable_tsan])
 
 #
+# Enable Link Time Optimization. This may need different settings per compiler?
+#
+AC_MSG_CHECKING([whether to enable LTO])
+AC_ARG_ENABLE([lto],
+  [AS_HELP_STRING([--enable-lto],[turn on Link Time Optimization])],
+  [],
+  [enable_lto=no]
+)
+AC_MSG_RESULT([$enable_lto])
+
+#
 # Fast SDK APIs, this disables the parameter checks (assert)
 # on all APIs.
 #
@@ -936,6 +947,19 @@ AS_IF([test x"$enable_coverage" = "xyes"], [
 AS_IF([test x"$enable_werror" = "xyes"], [
   TS_ADDTO(release_opt, -Werror)
   TS_ADDTO(debug_opt, -Werror)
+])
+
+# Add the necessary flags for LTO
+AS_IF([test x"$enable_lto" = "xyes"], [
+  AS_IF([test "x$ax_cv_c_compiler_vendor" = "xclang"], [
+    TS_ADDTO(AM_CXXFLAGS, [-flto=thin -fuse-ld=lld])
+    TS_ADDTO(AM_CFLAGS, [-flto=thin -fuse-ld=lld])
+    TS_ADDTO(AM_LDFLAGS, [-flto=thin -fuse-ld=lld])
+    ], [
+    TS_ADDTO(AM_CXXFLAGS, [-flto])
+    TS_ADDTO(AM_CFLAGS, [-flto])
+    TS_ADDTO(AM_LDFLAGS, [-flto])
+    ])
 ])
 
 cc_oflag_opt=$release_opt
@@ -2419,6 +2443,7 @@ AC_MSG_NOTICE([Build option summary:
     CC:                 $CC
     CXX:                $CXX
     CPP:                $CPP
+    LD:                 $LD
     CFLAGS:             $CFLAGS
     CXXFLAGS:           $CXXFLAGS
     CPPFLAGS:           $CPPFLAGS


### PR DESCRIPTION
In my tests (not particularly scientific), this is about 10% more RPS (faster), while at the same time over 40% lower latency on first response byte. Yes, this can be accomplished without a new configure option, I just find this more convenient.

I've only tested this with LLVM.