### PR TITLE
Make header prefix matching case-insensitive in authProxy

### DIFF
--- a/plugins/authproxy/tests/authproxy_test.cc
+++ b/plugins/authproxy/tests/authproxy_test.cc
@@ -34,6 +34,8 @@ TEST_CASE("Util methods", "[authproxy][utility]")
     CHECK(ContainsPrefix(string_view{"abc"}, "") == true);
     CHECK(ContainsPrefix(string_view{""}, "abc") == false);
     CHECK(ContainsPrefix(string_view{"abcdef"}, "abc\0") == true);
-    CHECK(ContainsPrefix(string_view{"abcdef\0"}, "abc\0") == true);
+    CHECK(ContainsPrefix(string_view{"AbCdef\0"}, "abc\0") == true);
+    CHECK(ContainsPrefix(string_view{"abcdef\0"}, "aBc\0") == true);
+    CHECK(ContainsPrefix(string_view{"abc\0"}, "aBcdEf\0") == false);
   }
 }

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -113,6 +113,6 @@ void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);
 inline bool
 ContainsPrefix(const std::string_view str, const std::string &prefix)
 {
-  return str.size() < prefix.size() ? false : (strncmp(str.data(), prefix.data(), prefix.size()) == 0);
+  return str.size() < prefix.size() ? false : (strncasecmp(str.data(), prefix.data(), prefix.size()) == 0);
 }
 // vim: set ts=4 sw=4 et :


### PR DESCRIPTION
An update on #9271, making the matching of headers and prefix param case-insensitive.