### PR TITLE
records.yaml - Make some changes on the convert script.

### DIFF
--- a/doc/admin-guide/tools/converting-records-to-yaml.en.rst
+++ b/doc/admin-guide/tools/converting-records-to-yaml.en.rst
@@ -145,7 +145,7 @@ Converting a file with a detailed output.
 .. code-block:: bash
    :linenos:
 
-   $ python3 convert2yaml.py -f records.config -S records.yaml -y
+   $ python3 convert2yaml.py -f records.config -o records.yaml
    [████████████████████████████████████████] 494/494
 
    ┌■ 8 Renamed records:
@@ -171,12 +171,11 @@ Converting a file with no output. If any, errors are displayed.
 
 .. code-block:: bash
 
-   $ convert2yaml.py -f records.config -S records.yaml -y -m
+   $ convert2yaml.py -f records.config -o records.yaml -m
 
 .. note::
 
    Use -m, --mute to mute the output.
-
 
 Non core records
 ================
@@ -221,7 +220,7 @@ non core records, for instance:
 
 .. code-block:: bash
 
-   $ convert2yaml.py -f records.config -S records.yaml -y -t float,int
+   $ convert2yaml.py -f records.config -o records.yaml -t float,int
 
    $ cat records.yaml
    ts:

--- a/tests/gold_tests/records/records_config_to_yaml.test.py
+++ b/tests/gold_tests/records/records_config_to_yaml.test.py
@@ -28,7 +28,7 @@ tr = Test.AddTestRun("Test records to yaml convert script - full file")
 
 tr.Setup.Copy(os.path.join(Test.Variables.BuildRoot, "tools/records/convert2yaml.py"))
 tr.Setup.Copy('legacy_config/full_records.config')
-tr.Processes.Default.Command = f'python3 convert2yaml.py -f full_records.config --save2 generated{file_suffix}.yaml --yaml --mute'
+tr.Processes.Default.Command = f'python3 convert2yaml.py -f full_records.config --output generated{file_suffix}.yaml --yaml --mute'
 f = tr.Disk.File(f"generated{file_suffix}.yaml")
 f.Content = "gold/full_records.yaml"
 
@@ -37,7 +37,7 @@ file_suffix = file_suffix + 1
 tr = Test.AddTestRun("Test records to yaml convert script -only renamed records.")
 tr.Setup.Copy(os.path.join(Test.Variables.BuildRoot, "tools/records/convert2yaml.py"))
 tr.Setup.Copy('legacy_config/old_records.config')
-tr.Processes.Default.Command = f'python3 convert2yaml.py -f old_records.config --save2 generated{file_suffix}.yaml --yaml'
+tr.Processes.Default.Command = f'python3 convert2yaml.py -f old_records.config --output generated{file_suffix}.yaml --yaml'
 tr.Processes.Default.Stream = 'gold/renamed_records.out'
 f = tr.Disk.File(f"generated{file_suffix}.yaml")
 f.Content = "gold/renamed_records.yaml"
@@ -46,7 +46,7 @@ f.Content = "gold/renamed_records.yaml"
 tr = Test.AddTestRun("Test errors when trying to override values ")
 tr.Setup.Copy(os.path.join(Test.Variables.BuildRoot, "tools/records/convert2yaml.py"))
 tr.Setup.Copy('legacy_config/override_value.config')
-tr.Processes.Default.Command = f'python3 convert2yaml.py -f override_value.config --save2 generated{file_suffix}.yaml --yaml -m'
+tr.Processes.Default.Command = f'python3 convert2yaml.py -f override_value.config --output generated{file_suffix}.yaml --yaml -m'
 tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
     "We cannot continue with 'proxy.config.ssl.client.verify.server.policy' at line '3' as a value node will be overridden",
     "Error should be present")
@@ -54,7 +54,7 @@ tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
 tr = Test.AddTestRun("Test errors when trying to override maps")
 tr.Setup.Copy(os.path.join(Test.Variables.BuildRoot, "tools/records/convert2yaml.py"))
 tr.Setup.Copy('legacy_config/override_map.config')
-tr.Processes.Default.Command = f'python3 convert2yaml.py -f override_map.config --save2 generated{file_suffix}.yaml --yaml -m'
+tr.Processes.Default.Command = f'python3 convert2yaml.py -f override_map.config --output generated{file_suffix}.yaml --yaml -m'
 tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
     "We cannot continue with 'proxy.config.ssl.client.verify.server' at line '3' as an existing YAML map will be overridden.",
     "Error should be present")


### PR DESCRIPTION
Just few improvements:

- Make the convert script executable. 
- use `-o|--output` instead of `-S|--save2`
- Make `-y` not required, true by default.
- Make `-f` and `-o`  no required, Set  defaults to `records.config` and `records.yaml`.
