### PR TITLE
Use deprecated OpenSSL APIs for MD5 and SHA256 if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1307,6 +1307,8 @@ AC_CHECK_FUNCS([ \
   X509_get0_signature \
   ERR_get_error_all \
   SHA1 \
+  SHA256_Init \
+  MD5_Init \
   SSL_SESSION_dup \
 ])
 

--- a/include/tscore/MD5.h
+++ b/include/tscore/MD5.h
@@ -25,29 +25,69 @@
 
 #include "tscore/ink_defs.h"
 #include "tscore/CryptoHash.h"
+#if HAVE_MD5_INIT
+#include <openssl/md5.h>
+#else
 #include <openssl/evp.h>
+#endif
 
 class MD5Context : public ats::CryptoContextBase
 {
 public:
   MD5Context()
   {
+#if HAVE_MD5_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    MD5_Init(&_md5ctx);
+#pragma GCC diagnostic pop
+#else
     _ctx = EVP_MD_CTX_new();
     EVP_DigestInit_ex(_ctx, EVP_md5(), nullptr);
+#endif
   }
-  ~MD5Context() { EVP_MD_CTX_free(_ctx); }
+  ~MD5Context()
+  {
+#if HAVE_MD5_INIT
+    // _md5ctx does not need to be freed
+#else
+    EVP_MD_CTX_free(_ctx);
+#endif
+  }
   /// Update the hash with @a data of @a length bytes.
   bool
   update(void const *data, int length) override
   {
+#if HAVE_MD5_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    return MD5_Update(&_md5ctx, data, length);
+#pragma GCC diagnostic pop
+#else
     return EVP_DigestUpdate(_ctx, data, length);
+#endif
   }
   /// Finalize and extract the @a hash.
   bool
   finalize(CryptoHash &hash) override
   {
+#if HAVE_MD5_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    return MD5_Final(hash.u8, &_md5ctx);
+#pragma GCC diagnostic pop
+#else
     return EVP_DigestFinal_ex(_ctx, hash.u8, nullptr);
+#endif
   }
+
+#if HAVE_MD5_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+private:
+  MD5_CTX _md5ctx;
+#pragma GCC diagnostic pop
+#endif
 };
 
 typedef CryptoHash INK_MD5;

--- a/include/tscore/SHA256.h
+++ b/include/tscore/SHA256.h
@@ -25,27 +25,63 @@
 
 #include "tscore/ink_defs.h"
 #include "tscore/CryptoHash.h"
+#if HAVE_SHA256_INIT
+#include <openssl/sha.h>
+#else
 #include <openssl/evp.h>
+#endif
 
 class SHA256Context : public ats::CryptoContextBase
 {
 public:
   SHA256Context()
   {
+#if HAVE_SHA256_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    SHA256_Init(&_sha256ctx);
+#pragma GCC diagnostic pop
+#else
     _ctx = EVP_MD_CTX_new();
     EVP_DigestInit_ex(_ctx, EVP_sha256(), nullptr);
+#endif
   }
-  ~SHA256Context() { EVP_MD_CTX_free(_ctx); }
+  ~SHA256Context()
+  {
+#if HAVE_SHA256_INIT
+    // _sha256ctx does not need to be freed
+#else
+    EVP_MD_CTX_free(_ctx);
+#endif
+  }
   /// Update the hash with @a data of @a length bytes.
   bool
   update(void const *data, int length) override
   {
+#if HAVE_SHA256_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    return SHA256_Update(&_sha256ctx, data, length);
+#pragma GCC diagnostic pop
+#else
     return EVP_DigestUpdate(_ctx, data, length);
+#endif
   }
   /// Finalize and extract the @a hash.
   bool
   finalize(CryptoHash &hash) override
   {
+#if HAVE_SHA256_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    return SHA256_Final(hash.u8, &_sha256ctx);
+#pragma GCC diagnostic pop
+#else
     return EVP_DigestFinal_ex(_ctx, hash.u8, nullptr);
+#endif
   }
+#if HAVE_SHA256_INIT
+private:
+  SHA256_CTX _sha256ctx;
+#endif
 };


### PR DESCRIPTION
The new API requires heap allocation. We want to stick with the old API that doesn't require it as long as it's available.