### PR TITLE
traffic_ctl - Remove legacy/pretty format output options.

### DIFF
--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -78,17 +78,14 @@ Options
    =================== ========================================================================
    Options             Description
    =================== ========================================================================
-   ``legacy``          Will honour the old :program:`traffic_ctl` output messages. This is the default format type.
-   ``pretty``          <if available> will print a different output, a prettier output. This depends on the implementation,
-                       it's not required to always implement a pretty output
    ``json``            It will show the response message formatted to `JSON`_. This is ideal if you want to redirect the stdout to a different source.
                        It will only stream the json response, no other messages.
+                       This option only applies to the RPC request or response.
    ``rpc``             Show the JSONRPC request and response + the default output.
+                       This option only applies to the RPC request or response.
    =================== ========================================================================
 
    In case of a record request(config) ``--records`` overrides this flag.
-
-   Default: ``legacy``
 
    Example:
 
@@ -148,8 +145,6 @@ traffic_ctl config
    Display all the known information about a configuration record. This includes the current and
    default values, the data type, the record class and syntax checking expression.
 
-   Error output available if  ``--format pretty`` is specified.
-
 .. program:: traffic_ctl config
 .. option:: diff [--records]
 
@@ -164,8 +159,6 @@ traffic_ctl config
    :ref:`admin_lookup_records`
 
 Display the current value of a configuration record.
-
-   Error output available if ``--format pretty`` is specified.
 
 .. program:: traffic_ctl config get
 .. option:: --records
@@ -304,8 +297,6 @@ traffic_ctl metric
 
    Display the current value of the specified statistics.
 
-   Error output available if ``--format pretty`` is specified.
-
 .. program:: traffic_ctl metric
 .. option:: match REGEX [REGEX...]
 
@@ -327,8 +318,6 @@ traffic_ctl metric
    :ref:`admin_lookup_records`
 
    Display all the known information about a metric record.
-
-   Error output available if ``--format pretty`` is specified.
 
 .. program:: traffic_ctl metric
 .. option:: monitor [-i, -c] METRIC [METRIC...]

--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -37,10 +37,8 @@ namespace
 using Codec = yamlcpp_json_emitter;
 } // namespace
 const std::unordered_map<std::string_view, BasePrinter::Options::OutputFormat> _Fmt_str_to_enum = {
-  {"pretty", BasePrinter::Options::OutputFormat::PRETTY},
-  {"legacy", BasePrinter::Options::OutputFormat::LEGACY},
-  {"json",   BasePrinter::Options::OutputFormat::JSON  },
-  {"rpc",    BasePrinter::Options::OutputFormat::RPC   }
+  {"json", BasePrinter::Options::OutputFormat::JSON},
+  {"rpc",  BasePrinter::Options::OutputFormat::RPC }
 };
 
 BasePrinter::Options::OutputFormat
@@ -50,7 +48,7 @@ parse_format(ts::Arguments *args)
     return BasePrinter::Options::OutputFormat::RECORDS;
   }
 
-  BasePrinter::Options::OutputFormat val{BasePrinter::Options::OutputFormat::LEGACY};
+  BasePrinter::Options::OutputFormat val{BasePrinter::Options::OutputFormat::NOT_SET};
 
   if (auto data = args->get("format"); data) {
     ts::TextView fmt{data.value()};
@@ -457,7 +455,7 @@ DirectRPCCommand::DirectRPCCommand(ts::Arguments *args) : CtrlCommand(args)
     _invoked_func = [&]() { read_from_input(); };
   } else if (get_parsed_arguments()->get(INVOKE_STR)) {
     _invoked_func = [&]() { invoke_method(); };
-    if (printOpts._format == BasePrinter::Options::OutputFormat::LEGACY) {
+    if (printOpts._format == BasePrinter::Options::OutputFormat::NOT_SET) {
       // overwrite this and let it drop json instead.
       printOpts._format = BasePrinter::Options::OutputFormat::RPC;
     }

--- a/src/traffic_ctl/CtrlPrinters.h
+++ b/src/traffic_ctl/CtrlPrinters.h
@@ -39,15 +39,14 @@ public:
   /// This enum maps the --format flag coming from traffic_ctl. (also --records is included here, see comments down below.)
   struct Options {
     enum class OutputFormat {
-      LEGACY = 0, // Legacy format, mimics the old traffic_ctl output
-      PRETTY,     // Enhanced printing messages. (in case you would like to generate them)
-      JSON,       // Json formatting
-      RECORDS,    // only valid for configs, but it's handy to have it here.
-      RPC         // Print JSONRPC request and response + default output.
+      NOT_SET = 0, // nothing set.
+      JSON,        // Json formatting
+      RECORDS,     // only valid for configs, but it's handy to have it here.
+      RPC          // Print JSONRPC request and response + default output.
     };
     Options() = default;
     Options(OutputFormat fmt) : _format(fmt) {}
-    OutputFormat _format{OutputFormat::LEGACY}; //!< selected(passed) format.
+    OutputFormat _format{OutputFormat::NOT_SET}; //!< selected(passed) format.
   };
 
   /// Printer constructor. Needs the format as it will be used by derived classes.
@@ -83,9 +82,7 @@ public:
   Options::OutputFormat get_format() const;
   bool print_rpc_message() const;
   bool is_json_format() const;
-  bool is_legacy_format() const;
   bool is_records_format() const;
-  bool is_pretty_format() const;
 
 protected:
   void write_output_json(YAML::Node const &node) const;
@@ -111,19 +108,9 @@ BasePrinter::is_json_format() const
 }
 
 inline bool
-BasePrinter::is_legacy_format() const
-{
-  return get_format() == Options::OutputFormat::LEGACY;
-}
-inline bool
 BasePrinter::is_records_format() const
 {
   return get_format() == Options::OutputFormat::RECORDS;
-}
-inline bool
-BasePrinter::is_pretty_format() const
-{
-  return get_format() == Options::OutputFormat::PRETTY;
 }
 //------------------------------------------------------------------------------------------------------------------------------------
 class GenericPrinter : public BasePrinter
@@ -141,8 +128,6 @@ public:
 class RecordPrinter : public BasePrinter
 {
   void write_output(YAML::Node const &result) override;
-  void write_output_legacy(shared::rpc::RecordLookUpResponse const &result);
-  void write_output_pretty(shared::rpc::RecordLookUpResponse const &result);
 
 public:
   RecordPrinter(Options opt) : BasePrinter(opt) { _printAsRecords = is_records_format(); }
@@ -162,7 +147,6 @@ public:
 class DiffConfigPrinter : public RecordPrinter
 {
   void write_output(YAML::Node const &result) override;
-  void write_output_pretty(YAML::Node const &result);
 
 public:
   DiffConfigPrinter(BasePrinter::Options opt) : RecordPrinter(opt) {}
@@ -171,7 +155,6 @@ public:
 class ConfigReloadPrinter : public BasePrinter
 {
   void write_output(YAML::Node const &result) override;
-  void write_output_pretty(YAML::Node const &result);
 
 public:
   ConfigReloadPrinter(BasePrinter::Options opt) : BasePrinter(opt) {}
@@ -180,7 +163,6 @@ public:
 class ConfigShowFileRegistryPrinter : public BasePrinter
 {
   void write_output(YAML::Node const &result) override;
-  void write_output_pretty(YAML::Node const &result);
 
 public:
   using BasePrinter::BasePrinter;
@@ -196,8 +178,6 @@ public:
 //------------------------------------------------------------------------------------------------------------------------------------
 class RecordDescribePrinter : public BasePrinter
 {
-  void write_output_legacy(shared::rpc::RecordLookUpResponse const &result);
-  void write_output_pretty(shared::rpc::RecordLookUpResponse const &result);
   void write_output(YAML::Node const &result) override;
 
 public:
@@ -222,7 +202,6 @@ public:
 //------------------------------------------------------------------------------------------------------------------------------------
 class CacheDiskStoragePrinter : public BasePrinter
 {
-  void write_output_pretty(YAML::Node const &result);
   void write_output(YAML::Node const &result) override;
 
 public:
@@ -232,7 +211,6 @@ public:
 class CacheDiskStorageOfflinePrinter : public BasePrinter
 {
   void write_output(YAML::Node const &result) override;
-  void write_output_pretty(YAML::Node const &result);
 
 public:
   CacheDiskStorageOfflinePrinter(BasePrinter::Options opt) : BasePrinter(opt) {}

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -56,7 +56,7 @@ main(int argc, const char **argv)
     .add_option("--version", "-V", "Print version string")
     .add_option("--help", "-h", "Print usage information")
     .add_option("--run-root", "", "using TS_RUNROOT as sandbox", "TS_RUNROOT", 1)
-    .add_option("--format", "-f", "Use a specific output format {legacy|pretty|json|rpc}", "", 1, "legacy", "format");
+    .add_option("--format", "-f", "Use a specific output format {json|rpc}", "", 1, "", "format");
 
   auto &config_command     = parser.add_command("config", "Manipulate configuration records").require_commands();
   auto &metric_command     = parser.add_command("metric", "Manipulate performance metrics").require_commands();


### PR DESCRIPTION
TL;DR; `pretty|legacy` aren't really needed anymore(or ever for what is worth). 



They were introduced to help with the migration from the old mgmt api to the jsonrpc, the idea was to keep the legacy output messages as well as new ones if needed. This was never used, legacy and pretty can both live together without the need to have them separated. 

If something this was only adding complexity.

This is a cleanup, no new feature and it does not break anything.

