### PR TITLE
records.yaml: NULL strings should explicitly be set to null.

### DIFF
--- a/src/records/RecUtils.cc
+++ b/src/records/RecUtils.cc
@@ -357,7 +357,7 @@ RecDataSetFromString(RecDataT data_type, RecData *data_dst, const char *data_str
     data_src.rec_float = atof(data_string);
     break;
   case RECD_STRING:
-    if (data_string && (strlen(data_string) == 4) && strncmp((data_string), "NULL", 4) == 0) {
+    if (data_string && (strlen(data_string) == 4) && strncasecmp((data_string), "NULL", 4) == 0) {
       data_src.rec_string = nullptr;
     } else {
       // It's OK to cast away the const here, because RecDataSet will copy the string.

--- a/tests/gold_tests/records/records_yaml.test.py
+++ b/tests/gold_tests/records/records_yaml.test.py
@@ -157,3 +157,41 @@ tr2.Processes.Default.Streams.stdout += Testers.ContainsExpression(
     'proxy.config.diags.debug.tags: filemanager',
     'Config should show a different tag'
 )
+
+
+ts2.Disk.records_config.append_to_document(
+    '''
+    dns:
+      resolv_conf: NULL
+      nameservers: null
+      local_ipv6: Null
+    ssl:
+      client:
+        cert:
+          filename: ~
+    '''
+)
+
+
+tr3 = Test.AddTestRun("test null string")
+tr3.Processes.Default.Command = 'traffic_ctl config get  proxy.config.dns.resolv_conf proxy.config.dns.local_ipv6 proxy.config.dns.nameservers proxy.config.ssl.client.cert.filename'
+tr3.Processes.Default.Env = ts2.Env
+tr3.Processes.Default.ReturnCode = 0
+
+# Make sure it's what we want.
+tr3.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+    'proxy.config.dns.resolv_conf: null',
+    'should be set to null'
+)
+tr3.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+    'proxy.config.dns.nameservers: null',
+    'should be set to null'
+)
+tr3.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+    'proxy.config.ssl.client.cert.filename: null',
+    'should be set to null'
+)
+tr3.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+    'proxy.config.dns.local_ipv6: null',
+    'should be set to null'
+)


### PR DESCRIPTION
Make sure when a string field is set to NULL then this gets replicated into the records and not get lost as null field which is not the intention of null strings.
NULL string fields should still make the internal records as null value.