### PR TITLE
Use deprecated OpenSSL APIs for MD5 and SHA256 if available (#9469)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1327,6 +1327,8 @@ AC_CHECK_FUNCS([ \
   X509_get0_signature \
   ERR_get_error_all \
   SHA1 \
+  SHA256_Init \
+  MD5_Init \
   SSL_SESSION_dup \
 ])
 

--- a/include/tscore/SHA256.h
+++ b/include/tscore/SHA256.h
@@ -34,8 +34,10 @@
 
 class SHA256Context : public ats::CryptoContextBase
 {
+#ifndef HAVE_SHA256_INIT
 protected:
   EVP_MD_CTX *ctx;
+#endif
 
 public:
   SHA256Context()
@@ -58,7 +60,6 @@ public:
     EVP_MD_CTX_free(_ctx);
 #endif
   }
->>>>>>> 2c1c6d263 (Use deprecated OpenSSL APIs for MD5 and SHA256 if available (#9469))
   /// Update the hash with @a data of @a length bytes.
   bool
   update(void const *data, int length) override

--- a/include/tscore/SHA256.h
+++ b/include/tscore/SHA256.h
@@ -26,7 +26,11 @@
 #include "tscore/ink_code.h"
 #include "tscore/ink_defs.h"
 #include "tscore/CryptoHash.h"
+#if HAVE_SHA256_INIT
+#include <openssl/sha.h>
+#else
 #include <openssl/evp.h>
+#endif
 
 class SHA256Context : public ats::CryptoContextBase
 {
@@ -36,20 +40,53 @@ protected:
 public:
   SHA256Context()
   {
-    ctx = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr);
+#if HAVE_SHA256_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    SHA256_Init(&_sha256ctx);
+#pragma GCC diagnostic pop
+#else
+    _ctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(_ctx, EVP_sha256(), nullptr);
+#endif
   }
-  ~SHA256Context() { EVP_MD_CTX_free(ctx); }
+  ~SHA256Context()
+  {
+#if HAVE_SHA256_INIT
+    // _sha256ctx does not need to be freed
+#else
+    EVP_MD_CTX_free(_ctx);
+#endif
+  }
+>>>>>>> 2c1c6d263 (Use deprecated OpenSSL APIs for MD5 and SHA256 if available (#9469))
   /// Update the hash with @a data of @a length bytes.
   bool
   update(void const *data, int length) override
   {
-    return EVP_DigestUpdate(ctx, data, length);
+#if HAVE_SHA256_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    return SHA256_Update(&_sha256ctx, data, length);
+#pragma GCC diagnostic pop
+#else
+    return EVP_DigestUpdate(_ctx, data, length);
+#endif
   }
   /// Finalize and extract the @a hash.
   bool
   finalize(CryptoHash &hash) override
   {
-    return EVP_DigestFinal_ex(ctx, hash.u8, nullptr);
+#if HAVE_SHA256_INIT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    return SHA256_Final(hash.u8, &_sha256ctx);
+#pragma GCC diagnostic pop
+#else
+    return EVP_DigestFinal_ex(_ctx, hash.u8, nullptr);
+#endif
   }
+#if HAVE_SHA256_INIT
+private:
+  SHA256_CTX _sha256ctx;
+#endif
 };


### PR DESCRIPTION
This back ports #9469 for 9.2.x. We use the deprecated API for MD5 on 9.2.x, so this PR only applies the change for SHA256.

----
(cherry picked from commit 2c1c6d2632f147e6858bc758ba7c4ffbc163dc65)

 Conflicts:
	include/tscore/INK_MD5.h
	include/tscore/SHA256.h