### PR TITLE
Avoid memory allocation in CryptoHash

### DIFF
--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -168,26 +168,23 @@ public:
   }; ///< What type of hash we really are.
   static HashType Setting;
 
-  ~CryptoContext()
-  {
-    delete _base;
-    _base = nullptr;
-  }
+  ~CryptoContext() { reinterpret_cast<CryptoContextBase *>(_base)->~CryptoContextBase(); }
 
 private:
-  CryptoContextBase *_base = nullptr;
+  static size_t constexpr OBJ_SIZE = 256;
+  char _base[OBJ_SIZE];
 };
 
 inline bool
 CryptoContext::update(void const *data, int length)
 {
-  return _base->update(data, length);
+  return reinterpret_cast<CryptoContextBase *>(_base)->update(data, length);
 }
 
 inline bool
 CryptoContext::finalize(CryptoHash &hash)
 {
-  return _base->finalize(hash);
+  return reinterpret_cast<CryptoContextBase *>(_base)->finalize(hash);
 }
 
 ts::BufferWriter &bwformat(ts::BufferWriter &w, ts::BWFSpec const &spec, ats::CryptoHash const &hash);

--- a/src/tscore/CryptoHash.cc
+++ b/src/tscore/CryptoHash.cc
@@ -45,12 +45,12 @@ CryptoContext::CryptoContext()
   case UNSPECIFIED:
 #if TS_ENABLE_FIPS == 0
   case MD5:
-    static_assert(OBJ_SIZE > sizeof(MD5Context));
+    static_assert(OBJ_SIZE >= sizeof(MD5Context));
     new (_base) MD5Context;
     break;
 #else
   case SHA256:
-    static_assert(OBJ_SIZE > sizeof(SHA256Context));
+    static_assert(OBJ_SIZE >= sizeof(SHA256Context));
     new (_base) SHA256Context;
     break;
 #endif

--- a/src/tscore/CryptoHash.cc
+++ b/src/tscore/CryptoHash.cc
@@ -45,11 +45,11 @@ CryptoContext::CryptoContext()
   case UNSPECIFIED:
 #if TS_ENABLE_FIPS == 0
   case MD5:
-    _base = new MD5Context;
+    new (_base) MD5Context;
     break;
 #else
   case SHA256:
-    _base = new SHA256Context;
+    new (_base) SHA256Context;
     break;
 #endif
   default:

--- a/src/tscore/CryptoHash.cc
+++ b/src/tscore/CryptoHash.cc
@@ -45,10 +45,12 @@ CryptoContext::CryptoContext()
   case UNSPECIFIED:
 #if TS_ENABLE_FIPS == 0
   case MD5:
+    static_assert(OBJ_SIZE > sizeof(MD5Context));
     new (_base) MD5Context;
     break;
 #else
   case SHA256:
+    static_assert(OBJ_SIZE > sizeof(SHA256Context));
     new (_base) SHA256Context;
     break;
 #endif


### PR DESCRIPTION
This partially reverts #8719. I think the memory leak is because of not calling the destructor of `CryptoContextBase`. Although use of `new` and `delete` makes the code easy to understand, we should avoid the memory allocation.