### PR TITLE
QUIC: Avoid crash when IO is disabled by the caller. 

### DIFF
--- a/proxy/http3/Http3Transaction.cc
+++ b/proxy/http3/Http3Transaction.cc
@@ -113,8 +113,10 @@ HQTransaction::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
   this->_read_vio.vc_server = this;
   this->_read_vio.op        = VIO::READ;
 
-  this->_process_read_vio();
-  this->_send_tracked_event(this->_read_event, VC_EVENT_READ_READY, &this->_read_vio);
+  if (buf) {
+    this->_process_read_vio();
+    this->_send_tracked_event(this->_read_event, VC_EVENT_READ_READY, &this->_read_vio);
+  }
 
   return &this->_read_vio;
 }


### PR DESCRIPTION
This was detected when performing a post over http3.

`do_io_read/write` is called without buffer.
```
#5  0x0000555555ecf67f in HQTransaction::do_io_read (this=0x7fffbc0dce40, c=0x7fffc8d31f40, nbytes=0, buf=0x0) at Http3Transaction.cc:116
```


```bash
gdb) f 2
#2  0x0000555555ee2627 in Http3StreamDataVIOAdaptor::handle_frame (this=0x7fffc01ccf20, 
    frame=std::shared_ptr<const Http3Frame> (use count 3, weak count 0) = {...}) at Http3StreamDataVIOAdaptor.cc:44
44        writer->write(dframe->payload(), dframe->payload_length());
(gdb) print writer
$1 = (MIOBuffer *) 0x0
(gdb) 
```

```bash
#0  0x00005555559ca08c in Ptr<IOBufferBlock>::operator bool (this=0x10) at ../include/tscore/Ptr.h:114
#1  0x0000555555ef9bb2 in MIOBuffer::write (this=0x0, abuf=0x7fffef7e5c43, alen=147) at IOBuffer.cc:85
#2  0x0000555555ee2627 in Http3StreamDataVIOAdaptor::handle_frame (this=0x7fffbc0d3450, frame=
    std::shared_ptr<const Http3Frame> (use count 3, weak count 0) = {...}) at Http3StreamDataVIOAdaptor.cc:44
#3  0x0000555555edd284 in Http3FrameDispatcher::on_read_ready (this=0x7fffbc0dd0b0, stream_id=0, reader=..., nread=@0x7fffef7f5d78: 245)
    at Http3FrameDispatcher.cc:108
#4  0x0000555555ed228a in Http3Transaction::_process_read_vio (this=0x7fffbc0dce40) at Http3Transaction.cc:469
#5  0x0000555555ecf67f in HQTransaction::do_io_read (this=0x7fffbc0dce40, c=0x7fffc8d31f40, nbytes=0, buf=0x0) at Http3Transaction.cc:116
#6  0x0000555555a9a783 in HttpSM::attach_client_session (this=0x7fffc8d31f40, client_vc=0x7fffbc0dce40) at HttpSM.cc:605
#7  0x0000555555d991cd in ProxyTransaction::new_transaction (this=0x7fffbc0dce40, from_early_data=false) at ProxyTransaction.cc:63
#8  0x0000555555ec7c37 in Http3App::_handle_bidi_stream_on_read_ready (this=0x7fffbc0d3b10, event=100, vio=0x7fffbc0db7f0) at Http3App.cc:242
#9  0x0000555555ec709c in Http3App::main_event_handler (this=0x7fffbc0d3b10, event=100, data=0x5555564e1980) at Http3App.cc:134
#10 0x00005555559c7207 in Continuation::handleEvent (this=0x7fffbc0d3b10, event=100, data=0x5555564e1980)
    at /home/dmeden/code/git/trafficserver-h3/iocore/eventsystem/I_Continuation.h:228
#11 0x0000555555efd50f in EThread::process_event (this=0x555556f910a0, e=0x5555564e1980, calling_code=100) at UnixEThread.cc:151
#12 0x0000555555efd75c in EThread::process_queue (this=0x555556f910a0, NegativeQueue=0x7fffef7f6170, ev_count=0x7fffef7f6124, nq_count=0x7fffef7f6120)
    at UnixEThread.cc:186
#13 0x0000555555efda78 in EThread::execute_regular (this=0x555556f910a0) at UnixEThread.cc:243
#14 0x0000555555efde96 in EThread::execute (this=0x555556f910a0) at UnixEThread.cc:336
#15 0x0000555555efc5a6 in spawn_thread_internal (a=0x5555564d5ad0) at Thread.cc:79
#16 0x00007ffff76e4609 in start_thread (arg=<optimized out>) at pthread_create.c:477
```