### PR TITLE
QUIC: Add support to configure UDP max payload limit. 

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4667,6 +4667,23 @@ removed in the future without prior notice.
    that |TS| is willing to store. The value MUST be at least 2.
    Transport Parameter.
 
+.. ts:cv:: CONFIG proxy.config.quic.max_recv_udp_payload_size_in INT 65527
+
+   This value will be advertised as ``max_udp_payload_size`` Transport Parameter.
+
+.. ts:cv:: CONFIG proxy.config.quic.max_recv_udp_payload_size_out INT 65527
+
+   This value will be advertised as ``max_udp_payload_size`` Transport Parameter.
+
+.. ts:cv:: CONFIG proxy.config.quic.max_send_udp_payload_size_in INT 65527
+
+   Specified the maximum outgoing UDP payload size.
+
+.. ts:cv:: CONFIG proxy.config.quic.max_send_udp_payload_size_out INT 65527
+
+   Specified the maximum outgoing UDP payload size.
+
+
 UDP Configuration
 =====================
 
@@ -4679,6 +4696,7 @@ UDP Configuration
 
    Enables (``1``) or disables (``0``) UDP GSO. When enabled, |TS| tries to use UDP GSO,
    and disables it automatically if it causes send errors.
+
 
 Plug-in Configuration
 =====================

--- a/iocore/net/QUICNetProcessor_quiche.cc
+++ b/iocore/net/QUICNetProcessor_quiche.cc
@@ -90,8 +90,8 @@ QUICNetProcessor::start(int, size_t stacksize)
   }
 
   quiche_config_set_max_idle_timeout(this->_quiche_config, params->no_activity_timeout_in());
-  quiche_config_set_max_recv_udp_payload_size(this->_quiche_config, 16384);
-  quiche_config_set_max_send_udp_payload_size(this->_quiche_config, 16384);
+  quiche_config_set_max_recv_udp_payload_size(this->_quiche_config, params->get_max_recv_udp_payload_size_in());
+  quiche_config_set_max_send_udp_payload_size(this->_quiche_config, params->get_max_send_udp_payload_size_in());
   quiche_config_set_initial_max_data(this->_quiche_config, params->initial_max_data_in());
   quiche_config_set_initial_max_stream_data_bidi_local(this->_quiche_config, params->initial_max_stream_data_bidi_local_in());
   quiche_config_set_initial_max_stream_data_bidi_remote(this->_quiche_config, params->initial_max_stream_data_bidi_remote_in());

--- a/iocore/net/quic/QUICConfig.cc
+++ b/iocore/net/quic/QUICConfig.cc
@@ -156,6 +156,10 @@ QUICConfigParams::initialize()
   REC_EstablishStaticConfigInt32U(this->_active_cid_limit_in, "proxy.config.quic.active_cid_limit_in");
   REC_EstablishStaticConfigInt32U(this->_active_cid_limit_out, "proxy.config.quic.active_cid_limit_out");
   REC_EstablishStaticConfigInt32U(this->_disable_active_migration, "proxy.config.quic.disable_active_migration");
+  REC_EstablishStaticConfigInt32U(this->_max_recv_udp_payload_size_in, "proxy.config.quic.max_recv_udp_payload_size_in");
+  REC_EstablishStaticConfigInt32U(this->_max_recv_udp_payload_size_out, "proxy.config.quic.max_recv_udp_payload_size_out");
+  REC_EstablishStaticConfigInt32U(this->_max_send_udp_payload_size_in, "proxy.config.quic.max_send_udp_payload_size_in");
+  REC_EstablishStaticConfigInt32U(this->_max_send_udp_payload_size_out, "proxy.config.quic.max_send_udp_payload_size_out");
 
   // Loss Detection
   REC_EstablishStaticConfigInt32U(this->_ld_packet_threshold, "proxy.config.quic.loss_detection.packet_threshold");
@@ -364,6 +368,30 @@ bool
 QUICConfigParams::disable_active_migration() const
 {
   return this->_disable_active_migration;
+}
+
+uint32_t
+QUICConfigParams::get_max_recv_udp_payload_size_in() const
+{
+  return this->_max_recv_udp_payload_size_in;
+}
+
+uint32_t
+QUICConfigParams::get_max_recv_udp_payload_size_out() const
+{
+  return this->_max_recv_udp_payload_size_out;
+}
+
+uint32_t
+QUICConfigParams::get_max_send_udp_payload_size_in() const
+{
+  return this->_max_send_udp_payload_size_in;
+}
+
+uint32_t
+QUICConfigParams::get_max_send_udp_payload_size_out() const
+{
+  return this->_max_send_udp_payload_size_out;
 }
 
 const char *

--- a/iocore/net/quic/QUICConfig.h
+++ b/iocore/net/quic/QUICConfig.h
@@ -76,6 +76,11 @@ public:
   uint8_t active_cid_limit_in() const;
   uint8_t active_cid_limit_out() const;
   bool disable_active_migration() const;
+  uint32_t get_max_recv_udp_payload_size_in() const;
+  uint32_t get_max_recv_udp_payload_size_out() const;
+
+  uint32_t get_max_send_udp_payload_size_in() const;
+  uint32_t get_max_send_udp_payload_size_out() const;
 
   // Loss Detection
   uint32_t ld_packet_threshold() const;
@@ -139,6 +144,11 @@ private:
   uint32_t _active_cid_limit_in                     = 0;
   uint32_t _active_cid_limit_out                    = 0;
   uint32_t _disable_active_migration                = 0;
+  uint32_t _max_recv_udp_payload_size_in            = 0;
+  uint32_t _max_recv_udp_payload_size_out           = 0;
+
+  uint32_t _max_send_udp_payload_size_in  = 0;
+  uint32_t _max_send_udp_payload_size_out = 0;
 
   // [draft-17 recovery] 6.4.1.  Constants of interest
   uint32_t _ld_packet_threshold = 3;

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -1439,6 +1439,15 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.quic.disable_active_migration", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "[0-1]", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.quic.max_recv_udp_payload_size_in", RECD_INT, "65527", RECU_DYNAMIC, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.quic.max_recv_udp_payload_size_out", RECD_INT, "65527", RECU_DYNAMIC, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.quic.max_send_udp_payload_size_in", RECD_INT, "65527", RECU_DYNAMIC, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.quic.max_send_udp_payload_size_out", RECD_INT, "65527", RECU_DYNAMIC, RR_NULL, RECC_NULL, "^[0-9]+$", RECA_NULL}
+  ,
+
   // Constants of Loss Detection
   {RECT_CONFIG, "proxy.config.quic.loss_detection.packet_threshold", RECD_INT, "3", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-?[0-9]+$", RECA_NULL}
   ,


### PR DESCRIPTION
This commit also makes this configuration available for the quiche quic implementation.