### PR TITLE
Fix pre-warm std::string parameter

### DIFF
--- a/proxy/http/PreWarmManager.h
+++ b/proxy/http/PreWarmManager.h
@@ -54,7 +54,7 @@ namespace PreWarm
 // Dst
 //
 struct Dst {
-  Dst(const std::string &h, in_port_t p, SNIRoutingType t, int a) : host(h), port(p), type(t), alpn_index(a) {}
+  Dst(std::string_view h, in_port_t p, SNIRoutingType t, int a) : host(h), port(p), type(t), alpn_index(a) {}
 
   std::string host;
   in_port_t port      = 0;


### PR DESCRIPTION
Don't require an actual string, allow passing a view. This avoids a allocation / copy.