### PR TITLE
TLS tunnel destination parse fix

### DIFF
--- a/iocore/net/TLSTunnelSupport.h
+++ b/iocore/net/TLSTunnelSupport.h
@@ -43,7 +43,7 @@ public:
   bool is_upstream_tls() const;
 
   SNIRoutingType get_tunnel_type() const;
-  const char *get_tunnel_host() const;
+  std::string_view get_tunnel_host() const;
   ushort get_tunnel_port() const;
 
   bool has_tunnel_destination() const;
@@ -56,7 +56,7 @@ protected:
 private:
   static int _ex_data_index;
 
-  char *_tunnel_host                           = nullptr;
+  std::string _tunnel_host;
   in_port_t _tunnel_port                       = 0;
   SNIRoutingType _tunnel_type                  = SNIRoutingType::NONE;
   YamlSNIConfig::TunnelPreWarm _tunnel_prewarm = YamlSNIConfig::TunnelPreWarm::UNSET;
@@ -71,10 +71,10 @@ TLSTunnelSupport::get_tunnel_type() const
 inline bool
 TLSTunnelSupport::has_tunnel_destination() const
 {
-  return _tunnel_host != nullptr;
+  return !_tunnel_host.empty();
 }
 
-inline const char *
+inline std::string_view
 TLSTunnelSupport::get_tunnel_host() const
 {
   return _tunnel_host;

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -660,8 +660,8 @@ HttpSM::setup_blind_tunnel_port()
   if (!ua_txn->is_outbound_transparent() && (tts = dynamic_cast<TLSTunnelSupport *>(netvc))) {
     if (!t_state.hdr_info.client_request.url_get()->host_get(&host_len)) {
       if (tts->has_tunnel_destination()) {
-        const char *tunnel_host = tts->get_tunnel_host();
-        t_state.hdr_info.client_request.url_get()->host_set(tunnel_host, strlen(tunnel_host));
+        auto tunnel_host = tts->get_tunnel_host();
+        t_state.hdr_info.client_request.url_get()->host_set(tunnel_host.data(), tunnel_host.size());
         if (tts->get_tunnel_port() > 0) {
           t_state.hdr_info.client_request.url_get()->port_set(tts->get_tunnel_port());
         } else {
@@ -1519,8 +1519,8 @@ plugins required to work with sni_routing.
       auto *tts             = dynamic_cast<TLSTunnelSupport *>(netvc);
 
       if (tts && tts->has_tunnel_destination()) {
-        const char *tunnel_host = tts->get_tunnel_host();
-        t_state.hdr_info.client_request.url_get()->host_set(tunnel_host, strlen(tunnel_host));
+        auto tunnel_host = tts->get_tunnel_host();
+        t_state.hdr_info.client_request.url_get()->host_set(tunnel_host.data(), tunnel_host.size());
         ushort tunnel_port = tts->get_tunnel_port();
         if (tunnel_port > 0) {
           t_state.hdr_info.client_request.url_get()->port_set(tunnel_port);


### PR DESCRIPTION
* Clean up the destination parsing code so it's shorter and doesn't break for IPv6 addresses.
* Change the internal host name to a `std::string` to simplify memory management.

~Draft because I'm not sure what to do about a bad parse. Previously this would result in a non-resolvable host name. We could maintain that behavior, but it seems better to generate some kind of warning.~

Spoke with @bneradt and decided just a warning was better than the current code.

Depends on #9492 