### PR TITLE
libswoc: update to 1.4.4

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.4.4")
+set(LIBSWOC_VERSION "1.4.5")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.
@@ -61,7 +61,7 @@ set(CC_FILES
 add_library(libswoc SHARED ${CC_FILES})
 set_target_properties(libswoc PROPERTIES OUTPUT_NAME swoc-${LIBSWOC_VERSION})
 if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(libswoc PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic)
+    target_compile_options(libswoc PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic -Wshadow)
 endif()
 
 add_library(libswoc-static STATIC ${CC_FILES})

--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.4.2")
+set(LIBSWOC_VERSION "1.4.4")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.
@@ -9,54 +9,54 @@ set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "directory for libraries" FORCE)
 include(GNUInstallDirs)
 
 cmake_dependent_option(LIBSWOC_INSTALL
-        "Enable generation of libswoc install targets" ON
-        "NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT" OFF)
+    "Enable generation of libswoc install targets" ON
+    "NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT" OFF)
 
 set(HEADER_FILES
-        include/swoc/swoc_version.h
-        include/swoc/ArenaWriter.h
-        include/swoc/BufferWriter.h
-        include/swoc/bwf_base.h
-        include/swoc/bwf_ex.h
-        include/swoc/bwf_ip.h
-        include/swoc/bwf_std.h
-        include/swoc/DiscreteRange.h
-        include/swoc/Errata.h
-        include/swoc/IntrusiveDList.h
-        include/swoc/IntrusiveHashMap.h
-        include/swoc/swoc_ip.h
-        include/swoc/IPEndpoint.h
-        include/swoc/IPAddr.h
-        include/swoc/IPSrv.h
-        include/swoc/IPRange.h
-        include/swoc/Lexicon.h
-        include/swoc/MemArena.h
-        include/swoc/MemSpan.h
-        include/swoc/Scalar.h
-        include/swoc/TextView.h
-        include/swoc/swoc_file.h
-        include/swoc/swoc_meta.h
-        include/swoc/string_view.h
-        include/swoc/Vectray.h
-        )
+    include/swoc/swoc_version.h
+    include/swoc/ArenaWriter.h
+    include/swoc/BufferWriter.h
+    include/swoc/bwf_base.h
+    include/swoc/bwf_ex.h
+    include/swoc/bwf_ip.h
+    include/swoc/bwf_std.h
+    include/swoc/DiscreteRange.h
+    include/swoc/Errata.h
+    include/swoc/IntrusiveDList.h
+    include/swoc/IntrusiveHashMap.h
+    include/swoc/swoc_ip.h
+    include/swoc/IPEndpoint.h
+    include/swoc/IPAddr.h
+    include/swoc/IPSrv.h
+    include/swoc/IPRange.h
+    include/swoc/Lexicon.h
+    include/swoc/MemArena.h
+    include/swoc/MemSpan.h
+    include/swoc/Scalar.h
+    include/swoc/TextView.h
+    include/swoc/swoc_file.h
+    include/swoc/swoc_meta.h
+    include/swoc/string_view.h
+    include/swoc/Vectray.h
+    )
 
 # These are external but required.
 set(EXTERNAL_HEADER_FILES
-        include/swoc/ext/HashFNV.h
-        )
+    include/swoc/ext/HashFNV.h
+)
 
 set(CC_FILES
-        src/bw_format.cc
-        src/bw_ip_format.cc
-        src/ArenaWriter.cc
-        src/Errata.cc
-        src/swoc_ip.cc
-        src/MemArena.cc
-        src/RBTree.cc
-        src/swoc_file.cc
-        src/TextView.cc
-        src/string_view_util.cc
-        )
+    src/bw_format.cc
+    src/bw_ip_format.cc
+    src/ArenaWriter.cc
+    src/Errata.cc
+    src/swoc_ip.cc
+    src/MemArena.cc
+    src/RBTree.cc
+    src/swoc_file.cc
+    src/TextView.cc
+    src/string_view_util.cc
+    )
 
 add_library(libswoc SHARED ${CC_FILES})
 set_target_properties(libswoc PROPERTIES OUTPUT_NAME swoc-${LIBSWOC_VERSION})
@@ -67,61 +67,23 @@ endif()
 add_library(libswoc-static STATIC ${CC_FILES})
 set_target_properties(libswoc-static PROPERTIES OUTPUT_NAME swoc-static-${LIBSWOC_VERSION})
 if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(libswoc-static PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic)
+    target_compile_options(libswoc-static PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic -Wshadow)
 endif()
 
 # Not quite sure how this works, but I think it generates one of two paths depending on the context.
 # That is, the generator functions return non-empty strings only in the corresponding context.
 target_include_directories(libswoc-static
-        PUBLIC
+    PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
-        )
+    )
 
 target_include_directories(libswoc
-        PUBLIC
+    PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
-        )
+    )
 
-if (LIBSWOC_INSTALL)
-    # These install target variables are created by GNUInstallDirs.
-    install(TARGETS libswoc-static
-            EXPORT libswoc-static-config
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} # seems to have no effect.
-            )
-    install(TARGETS libswoc
-            EXPORT libswoc-config
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} # seems to have no effect.
-            )
-    install(DIRECTORY include/swoc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-    set(link-target libswoc.so)
-    set(link-src $<TARGET_FILE_NAME:libswoc>)
-    install(CODE
-            "execute_process(COMMAND bash -c \"echo Linking ${link-src} to ${link-target};cd ${CMAKE_INSTALL_FULL_LIBDIR} && (rm -f ${link-target};ln -s ${link-src} ${link-target})
-        \")"
-            )
-
-    install(EXPORT libswoc-static-config
-            NAMESPACE libswoc::
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libswoc
-            )
-
-    install(EXPORT libswoc-config
-            NAMESPACE libswoc::
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libswoc
-            )
-
-    #    set(PKG_CONFIG_FILE libswoc.pc)
-    #    set(PKG_STATIC_CONFIG_FILE libswoc-static.pc)
-    #    configure_file("libswoc.pc.cmake" ${PKG_CONFIG_FILE} @ONLY)
-    #
-    # configure_file("libswoc.pc.cmake" libswoc.pc @ONLY)
-    # configure_file("libswoc-static.pc.cmake" libswoc-static.pc @ONLY)
-    # install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libswoc.pc ${CMAKE_CURRENT_BINARY_DIR}/libswoc-static.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-    #    install(FILES ${PKG_STATIC_CONFIG_FILE} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-endif()
 
 # Alledgedly this makes the targets "importable from the build directory" but I see no evidence of that.
 # AFAICT the file isn't created at all even with this enabled.

--- a/lib/swoc/Makefile.am
+++ b/lib/swoc/Makefile.am
@@ -22,7 +22,7 @@ library_includedir=$(includedir)/swoc
 
 AM_CPPFLAGS += @SWOC_INCLUDES@
 
-libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.4.0
+libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.4.4
 libtsswoc_la_SOURCES = \
 	src/ArenaWriter.cc  src/bw_format.cc  src/bw_ip_format.cc  src/Errata.cc  src/MemArena.cc  src/RBTree.cc  src/swoc_file.cc  src/swoc_ip.cc  src/TextView.cc src/string_view_util.cc
 

--- a/lib/swoc/Makefile.am
+++ b/lib/swoc/Makefile.am
@@ -22,7 +22,7 @@ library_includedir=$(includedir)/swoc
 
 AM_CPPFLAGS += @SWOC_INCLUDES@
 
-libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.4.4
+libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.4.5
 libtsswoc_la_SOURCES = \
 	src/ArenaWriter.cc  src/bw_format.cc  src/bw_ip_format.cc  src/Errata.cc  src/MemArena.cc  src/RBTree.cc  src/swoc_file.cc  src/swoc_ip.cc  src/TextView.cc src/string_view_util.cc
 

--- a/lib/swoc/include/swoc/Errata.h
+++ b/lib/swoc/include/swoc/Errata.h
@@ -37,14 +37,14 @@
 
 #pragma once
 
-#include "swoc/swoc_version.h"
-
 #include <vector>
 #include <string_view>
 #include <functional>
 #include <atomic>
 #include <optional>
 
+#include "swoc/swoc_version.h"
+#include "swoc/MemSpan.h"
 #include "swoc/MemArena.h"
 #include "swoc/bwf_base.h"
 #include "swoc/IntrusiveDList.h"

--- a/lib/swoc/include/swoc/Errata.h
+++ b/lib/swoc/include/swoc/Errata.h
@@ -505,8 +505,8 @@ protected:
 
   /// Implementation instance.
   /// @internal Because this is used with a self-containing @c MemArena standard smart pointers do not
-  /// work correctly. Instead the @c reset method must be used to release the memory.
-  /// @see reset
+  /// work correctly. Instead the @c clear method must be used to release the memory.
+  /// @see clear
   Data *_data = nullptr;
 
   /// Force data existence.
@@ -1014,7 +1014,7 @@ Errata::note_sv(std::optional<Severity> severity, std::string_view fmt, std::tup
       span = this->alloc(bw.extent());
       FixedBufferWriter{span}.print_v(fmt, args);
     }
-    this->note_localized(span.view(), severity);
+    this->note_localized(TextView(span), severity);
   }
   return *this;
 }

--- a/lib/swoc/include/swoc/IPAddr.h
+++ b/lib/swoc/include/swoc/IPAddr.h
@@ -543,8 +543,14 @@ public:
   /// @return As IPv4 address - results are undefined if it is not actually IPv4.
   IP4Addr const &ip4() const;
 
+  /// @return As IPv4 address - results are undefined if it is not actually IPv4.
+  explicit operator IP4Addr() const;
+
   /// @return As IPv6 address - results are undefined if it is not actually IPv6.
   IP6Addr const &ip6() const;
+
+  /// @return As IPv6 address - results are undefined if it is not actually IPv6.
+  explicit operator IP6Addr() const;
 
   /// Test for validity.
   bool is_valid() const;
@@ -1257,16 +1263,11 @@ operator!=(sockaddr const *lhs, IPAddr const &rhs) {
   return !(rhs == lhs);
 }
 
-/// Equality.
-inline IP4Addr const &
-IPAddr::ip4() const {
-  return _addr._ip4;
-}
+inline IP4Addr const & IPAddr::ip4() const { return _addr._ip4; }
+inline IPAddr::operator IP4Addr() const { return _addr._ip4; }
 
-inline IP6Addr const &
-IPAddr::ip6() const {
-  return _addr._ip6;
-}
+inline IP6Addr const & IPAddr::ip6() const { return _addr._ip6; }
+inline IPAddr::operator IP6Addr() const { return _addr._ip6; }
 
 inline bool
 IPAddr::operator==(self_type const &that) const {

--- a/lib/swoc/include/swoc/IPEndpoint.h
+++ b/lib/swoc/include/swoc/IPEndpoint.h
@@ -12,6 +12,7 @@
 #include <stdexcept>
 
 #include "swoc/swoc_version.h"
+#include "swoc/MemSpan.h"
 #include "swoc/TextView.h"
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
@@ -169,6 +170,14 @@ union IPEndpoint {
   /// Automatic conversion to @c sockaddr.
   operator sockaddr const *() const { return &sa; }
 
+  /** The address as a byte sequence.
+   *
+   * @return Span of the address memory.
+   *
+   * This is raw access. If the contained data is not a valid address family an empty span is returned.
+   */
+  swoc::MemSpan<void const> raw_addr() const;
+
   /// The string name of the address family.
   static string_view family_name(sa_family_t family);
 };
@@ -181,8 +190,8 @@ inline IPEndpoint::IPEndpoint(IPAddr const &addr) {
   this->assign(addr);
 }
 
-inline IPEndpoint::IPEndpoint(sockaddr const *sa) {
-  this->assign(sa);
+inline IPEndpoint::IPEndpoint(sockaddr const *socketaddr) {
+  this->assign(socketaddr);
 }
 
 inline IPEndpoint::IPEndpoint(IPEndpoint::self_type const &that) : self_type(&that.sa) {}
@@ -271,6 +280,15 @@ IPEndpoint::port(sockaddr const *sa) {
 inline in_port_t
 IPEndpoint::host_order_port(sockaddr const *sa) {
   return ntohs(self_type::port(sa));
+}
+
+inline swoc::MemSpan<void const>
+IPEndpoint::raw_addr() const {
+  switch (sa.sa_family) {
+  case AF_INET: return { &sa4.sin_addr , sizeof(sa4.sin_addr) };
+  case AF_INET6: return { &sa6.sin6_addr, sizeof(sa6.sin6_addr) };
+  }
+  return {};
 }
 
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/include/swoc/Lexicon.h
+++ b/lib/swoc/include/swoc/Lexicon.h
@@ -592,9 +592,9 @@ template <typename E> Lexicon<E>::Lexicon(DefaultHandler handler_1, DefaultHandl
 template <typename E>
 std::string_view
 Lexicon<E>::localize(std::string_view const &name) {
-  auto span = _arena.alloc(name.size());
-  memcpy(span.data(), name.data(), name.size());
-  return span.view();
+  auto span = _arena.alloc_span<char>(name.size());
+  memcpy(span, name);
+  return { span.data(), span.size() };
 }
 
 template <typename E>

--- a/lib/swoc/include/swoc/MemSpan.h
+++ b/lib/swoc/include/swoc/MemSpan.h
@@ -10,15 +10,16 @@
 #pragma once
 
 #include <cstring>
-#include <iosfwd>
-#include <iostream>
 #include <cstddef>
-#include <array>
-#include <string_view>
 #include <type_traits>
 #include <ratio>
 #include <tuple>
 #include <exception>
+
+/// For template deduction guides
+#include <array>
+#include <vector>
+#include <string_view>
 
 #include "swoc/swoc_version.h"
 #include "swoc/Scalar.h"
@@ -63,20 +64,22 @@ public:
 
   /// Copy constructor.
   constexpr MemSpan(self_type const &that) = default;
+  /// Copy constructor.
+  constexpr MemSpan(self_type & that) = default;
 
   /** Construct from a first element @a start and a @a count of elements.
    *
    * @param start First element.
    * @param count Total number of elements.
    */
-  constexpr MemSpan(value_type *start, size_t count);
+  constexpr MemSpan(value_type *ptr, size_t count);
 
   /** Construct from a half open range [start, last).
    *
-   * @param start Start of range.
-   * @param last Past end of range.
+   * @param begin Start of range.
+   * @param end Past end of range.
    */
-  constexpr MemSpan(value_type *start, value_type *last);
+  constexpr MemSpan(value_type *begin, value_type *end);
 
   /** Construct to cover an array.
    *
@@ -124,6 +127,28 @@ public:
    >>>
    constexpr MemSpan(MemSpan<U> const& that) : _ptr(that.data()), _count(that.count()) {}
 
+
+  /** Construct from any vector like container.
+   *
+   * @tparam C Container type.
+   * @param c container
+   *
+   * The container type must have the methods @c data and @c size which must return values convertible
+   * to the pointer type for @a T and @c size_t respectively.
+   *
+   * @note If the container is constant then the span type must also be constant.
+   *
+   * @internal constness is a bit funky, because it can come from the container type or the
+   * element type, i.e. passing a container as @c const& means the span must be @c const ).
+   * If the argument is constant, that gets baked in to @a C.
+   */
+  template < typename C
+            , typename = std::enable_if_t<
+              std::is_convertible_v<decltype(std::declval<C>().data()), T *> &&
+                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
+              , void
+              >
+            > constexpr MemSpan(C & c);
 
   /** Construct from nullptr.
       This implicitly makes the length 0.
@@ -179,10 +204,17 @@ public:
   constexpr T *end() const;
 
   /// Number of elements in the span
+  constexpr size_t size() const;
+
+  /// Number of elements in the span
+  /// @note Deprecate for 1.5.0.
   constexpr size_t count() const;
 
+  /// Number of elements in the span
+  constexpr size_t length() const;
+
   /// Number of bytes in the span.
-  size_t size() const;
+  constexpr size_t data_size() const;
 
   /// @return Pointer to memory in the span.
   T * data() const;
@@ -225,13 +257,13 @@ public:
                     size_t count ///< # of elements.
   );
 
-  /// Set the span.
-  /// This is faster but equivalent to constructing a new span with the same
-  /// arguments and assigning it.
-  /// @return @c this.
-  self_type &assign(T *first,     ///< First valid element.
-                    T const *last ///< First invalid element.
-  );
+  /** Adjust the span.
+   *
+   * @param first Starting point of the span.
+   * @param last Past the end of the span.
+   * @return @a this
+   */
+  self_type &assign(T *first, T const *last);
 
   /// Clear the span (become an empty span).
   self_type &clear();
@@ -294,11 +326,16 @@ public:
    */
   constexpr self_type subspan(size_t offset, size_t count) const;
 
-  /** Return a view of the memory.
+  /** Construct all elements in the span.
    *
-   * @return A @c string_view covering the span contents.
+   * For each element in the span, construct an instance of the span type using the @a args. If the
+   * instances need destruction this must be done explicitly.
    */
-  std::string_view view() const;
+  template <typename... Args> self_type & make(Args &&... args);
+
+  /// Destruct all elements in the span.
+  void destroy();
+
 
   template <typename U> friend class MemSpan;
 };
@@ -309,21 +346,21 @@ public:
  *
  * - No subscript operator.
  * - No array initialization.
- * - All other @c MemSpan types implicitly convert to this type.
+ * - Other non-const @c MemSpan types implicitly convert to this type.
  *
  * @internal I tried to be clever about the base template but there were too many differences
  * One major issue was the array initialization did not work at all if the @c void case didn't
  * exclude that. Once separate there are a number of useful tweaks available.
  */
-template <> class MemSpan<void> {
+template <> class MemSpan<void const> {
   using self_type = MemSpan; ///< Self reference type.
   template <typename U> friend class MemSpan;
 
 public:
-  using value_type = void; /// Export base type.
+  using value_type = void const; /// Export base type.
 
 protected:
-  value_type *_ptr = nullptr; ///< Pointer to base of memory chunk.
+  void *_ptr = nullptr; ///< Pointer to base of memory chunk.
   size_t _size     = 0;       ///< Number of bytes in the chunk.
 
 public:
@@ -336,11 +373,14 @@ public:
   /// Copy assignment
   constexpr self_type & operator = (self_type const& that) = default;
 
+  /// Special constructor for @c void
+  constexpr MemSpan(MemSpan<void> const& that);
+
   /** Cross type copy constructor.
    *
    * @tparam U Type for source span.
    * @param that Source span.
-   *
+   *`
    * This enables any @c MemSpan to be automatically converted to a void span, just as any pointer
    * can convert to a void pointer.
    */
@@ -351,14 +391,29 @@ public:
    * @param start Start of the span.
    * @param n # of bytes in the span.
    */
-  constexpr MemSpan(value_type *start, size_t n);
+  constexpr MemSpan(value_type *ptr, size_t n);
 
   /** Construct from a half open range of [start, last).
    *
    * @param start Start of the range.
    * @param last Past end of range.
    */
-  MemSpan(value_type *start, value_type *last);
+  MemSpan(value_type *begin, value_type *end);
+
+  /** Construct from any vector like container.
+   *
+   * @tparam C Container type.
+   * @param c container
+   *
+   * The container type must have the methods @c data and @c size which must return values convertible
+   * to @c void* and @c size_t respectively.
+   */
+  template < typename C
+            , typename = std::enable_if_t<
+                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
+              , void
+              >
+            > constexpr MemSpan(C const& c);
 
   /** Construct from nullptr.
       This implicitly makes the length 0.
@@ -374,7 +429,7 @@ public:
    */
   bool operator==(self_type const &that) const;
 
-  /** Identical.
+  /** Equivalent.
 
       Check if the spans refer to the same span of memory.
 
@@ -388,24 +443,31 @@ public:
    */
   bool operator!=(self_type const &that) const;
 
-  /// Assignment - the span is copied, not the content.
-  /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
-  template <typename U> self_type &operator=(MemSpan<U> const &that);
+  /// Check for non-empty span.
+  /// @return @c true if the span contains bytes.
+  explicit operator bool() const;
 
   /// Check for empty span.
   /// @return @c true if the span is empty (no contents), @c false otherwise.
   bool operator!() const;
 
-  /// Check for non-empty span.
-  /// @return @c true if the span contains bytes.
-  explicit operator bool() const;
-
   /// Check for empty span (no content).
   /// @see operator bool
-  bool empty() const;
+  constexpr bool empty() const;
+
+  /// @return Number of bytes in the span.
+  constexpr size_t size() const;
+
+  /// @return Number of bytes in the span.
+  /// @note Template compatibility.
+  constexpr size_t count() const;
+
+  /// @return Number of bytes in the span.
+  /// @note Template compatibility.
+  constexpr size_t length() const;
 
   /// Number of bytes in the span.
-  size_t size() const;
+  constexpr size_t data_size() const;
 
   /// Pointer to memory in the span.
   constexpr value_type *data() const;
@@ -413,12 +475,12 @@ public:
   /// Pointer to just after memory in the span.
   value_type *data_end() const;
 
-  /** Create a new span for a different type @a V on the same memory.
-   *
-   * @tparam V Type for the created span.
-   * @return A @c MemSpan which contains the same memory as instances of @a V.
-   */
-  template <typename U> MemSpan<U> rebind() const;
+  /// Assignment - special handling for @c void.
+  constexpr self_type &operator=(MemSpan<void> const &that);
+
+  /// Assignment - the span is copied, not the content.
+  /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
+  template <typename U> self_type &operator=(MemSpan<U> const &that);
 
   /** Update the span.
    *
@@ -436,11 +498,27 @@ public:
    */
   self_type &assign(value_type *first, value_type const *last);
 
+  /** Create a new span for a different type @a V on the same memory.
+   *
+   * @tparam V Type for the created span.
+   * @return A @c MemSpan which contains the same memory as instances of @a V.
+   */
+  template <typename U> MemSpan<U> rebind() const;
+
+  /** Cast the span as a the instance of a type.
+   *
+   * @tparam U Target type.
+   * @return A pointer to the span as a constant instance of @a U.
+   *
+   * @note This throws if the size is not a match for @a U.
+   */
+  template <typename U> U const * as_ptr() const;
+
   /// Clear the span (become an empty span).
   self_type &clear();
 
   /// @return @c true if the byte at @a *ptr is in the span.
-  bool contains(value_type const *ptr) const;
+  bool contains(void const *ptr) const;
 
   /** Get the initial segment of @a n bytes.
 
@@ -453,7 +531,164 @@ public:
    * @param count The number of elements to remove.
    * @return @c *this
    */
+  self_type &remove_prefix(size_t n);
 
+  /** Get the trailing segment of @a n bytes.
+   *
+   * @param n Number of bytes to retrieve.
+   * @return An instance that contains the trailing @a count elements of @a this.
+   */
+  self_type suffix(size_t n) const;
+
+  /** Shrink the span by removing @a n bytes.
+   *
+   * @param n Number of bytes to remove.
+   * @return @c *this
+   */
+  self_type &remove_suffix(size_t n);
+
+  /** Return a sub span of @a this span.
+   *
+   * @param offset Offset (index) of first element.
+   * @param n Number of elements.
+   * @return The span starting at @a offset for @a count elements in @a this.
+   *
+   * The result is clipped by @a this - if @a offset is out of range an empty span is returned. Otherwise @c count is clipped by the
+   * number of elements available in @a this. In effect the intersection of the span described by ( @a offset , @a count ) and @a
+   * this span is returned, which may be the empty span.
+   */
+  constexpr self_type subspan(size_t offset, size_t n) const;
+
+  /** Align span for a type.
+   *
+   * @tparam T Alignment type.
+   * @return A suffix of the span suitably aligned for @a T.
+   *
+   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
+   */
+  template <typename T> self_type align() const;
+
+  /** Force memory alignment.
+   *
+   * @param alignment Alignment size (must be power of 2).
+   * @return An aligned span.
+   *
+   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
+   */
+  self_type align(size_t alignment) const;
+
+  /** Force memory alignment.
+   *
+   * @param alignment Alignment size (must be power of 2).
+   * @param obj_size Size of instances requiring alignment.
+   * @return An aligned span.
+   *
+   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty). Trailing space
+   * is discarded such that the resulting memory space is a multiple of @a size.
+   *
+   * @note @a obj_size should be a multiple of @a alignment. This happens naturally if @c sizeof is used.
+   */
+  self_type align(size_t alignment, size_t obj_size) const;
+};
+
+template <> class MemSpan<void> : public MemSpan<void const> {
+  using self_type = MemSpan;
+  using super_type = MemSpan<void const>;
+  template <typename U> friend class MemSpan;
+public:
+  using value_type = void;
+
+  /// Default constructor (empty buffer).
+  constexpr MemSpan() = default;
+
+  /// Copy constructor.
+  constexpr MemSpan(self_type const &that) = default;
+
+  /// Copy assignment
+  constexpr self_type & operator = (self_type const& that) = default;
+
+  /** Cross type copy constructor.
+   *
+   * @tparam U Type for source span.
+   * @param that Source span.
+   *`
+   * This enables any @c MemSpan to be automatically converted to a void span, just as any pointer
+   * can convert to a void pointer.
+   */
+  template <typename U> constexpr MemSpan(MemSpan<U> const &that);
+
+  /** Construct from a pointer @a start and a size @a n bytes.
+   *
+   * @param start Start of the span.
+   * @param n # of bytes in the span.
+   */
+  constexpr MemSpan(value_type *start, size_t n);
+
+  /** Construct from a half open range of [start, last).
+   *
+   * @param begin Start of the range.
+   * @param end Past end of range.
+   */
+  MemSpan(value_type *begin, value_type *end);
+
+  /** Construct from nullptr.
+      This implicitly makes the length 0.
+  */
+  constexpr MemSpan(std::nullptr_t);
+
+  /// Pointer to memory in the span.
+  constexpr value_type *data() const;
+
+  /// Pointer to just after memory in the span.
+  value_type *data_end() const;
+
+  /// Assignment - the span is copied, not the content.
+  /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
+  template <typename U> self_type &operator=(MemSpan<U> const &that);
+
+  /** Construct from any vector like container.
+   *
+   * @tparam C Container type.
+   * @param c container
+   *
+   * The container type must have the methods @c data and @c size which must return values convertible
+   * to @c void* and @c size_t respectively.
+   */
+  template < typename C
+            , typename = std::enable_if_t<
+              ! std::is_const_v<decltype(std::declval<C>().data()[0])> &&
+                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
+              , void
+              >
+            > constexpr MemSpan(C const& c);
+
+  /** Update the span.
+   *
+   * @param ptr Start of span memory.
+   * @param n Number of elements in the span.
+   * @return @a this
+   */
+  self_type &assign(value_type *ptr, size_t n);
+
+  /** Update the span.
+   *
+   * @param first First element in the span.
+   * @param last One past the last element in the span.
+   * @return @a this
+   */
+  self_type &assign(value_type *first, value_type const *last);
+
+   /// @return An instance that contains the leading @a n bytes of @a this.
+  self_type prefix(size_t n) const;
+
+  /** Shrink the span by removing @a n leading bytes.
+   *
+   * @param count The number of elements to remove.
+   * @return @c *this
+   */
   self_type &remove_prefix(size_t count);
 
   /** Get the trailing segment of @a n bytes.
@@ -473,14 +708,14 @@ public:
   /** Return a sub span of @a this span.
    *
    * @param offset Offset (index) of first element.
-   * @param count Number of elements.
+   * @param n Number of elements.
    * @return The span starting at @a offset for @a count elements in @a this.
    *
    * The result is clipped by @a this - if @a offset is out of range an empty span is returned. Otherwise @c count is clipped by the
    * number of elements available in @a this. In effect the intersection of the span described by ( @a offset , @a count ) and @a
    * this span is returned, which may be the empty span.
    */
-  constexpr self_type subspan(size_t offset, size_t count) const;
+  constexpr self_type subspan(size_t offset, size_t n) const;
 
   /** Align span for a type.
    *
@@ -494,20 +729,49 @@ public:
 
   /** Force memory alignment.
    *
-   * @param n Alignment size (must be power of 2).
+   * @param alignment Alignment size (must be power of 2).
    * @return An aligned span.
    *
    * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
    * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
    */
-  self_type align(size_t n) const;
+  self_type align(size_t alignment) const;
 
-  /** Return a view of the memory.
+  /** Force memory alignment.
    *
-   * @return A @c string_view covering the span contents.
+   * @param alignment Alignment size (must be power of 2).
+   * @param obj_size Size of instances requiring alignment.
+   * @return An aligned span.
+   *
+   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty). Trailing space
+   * is discarded such that the resulting memory space is a multiple of @a size.
+   *
+   * @note @a obj_size should be a multiple of @a alignment. This happens naturally if @c sizeof is used.
    */
-  std::string_view view() const;
+  self_type align(size_t alignment, size_t obj_size) const;
+
+  /** Create a new span for a different type @a V on the same memory.
+   *
+   * @tparam V Type for the created span.
+   * @return A @c MemSpan which contains the same memory as instances of @a V.
+   */
+  template <typename U> MemSpan<U> rebind() const;
+
+  /** Cast the span as a the instance of a type.
+   *
+   * @tparam U Target type.
+   * @return A pointer to the span as a constant instance of @a U.
+   *
+   * @note This throws if the size is not a match for @a U.
+   */
+  template <typename U> U * as_ptr() const;
+
+  /// Clear the span (become an empty span).
+  self_type &clear();
+
 };
+
 
 // -- Implementation --
 
@@ -528,6 +792,12 @@ inline void *
 ptr_add(void *ptr, size_t count) {
   return static_cast<char *>(ptr) + count;
 }
+
+inline void const *
+ptr_add(void const * ptr, size_t count) {
+  return static_cast<char const *>(ptr) + count;
+}
+
 /// @endcond
 
 /** Meta Function to check the type compatibility of two spans..
@@ -578,7 +848,18 @@ template <typename T> struct is_span_compatible<T, void> {
 template <typename T>
 size_t
 is_span_compatible<T, void>::count(size_t size) {
-  return size;
+  return sizeof(T) * size;
+}
+
+template <typename T> struct is_span_compatible<T, void const> {
+  static constexpr bool value = true;
+  static size_t count(size_t size);
+};
+
+template <typename T>
+size_t
+is_span_compatible<T, void const>::count(size_t size) {
+  return sizeof(T) * size;
 }
 /// @endcond
 
@@ -688,7 +969,7 @@ using std::memset;
 
 template <typename T> constexpr MemSpan<T>::MemSpan(T *ptr, size_t count) : _ptr{ptr}, _count{count} {}
 
-template <typename T> constexpr MemSpan<T>::MemSpan(T *first, T *last) : _ptr{first}, _count{detail::ptr_distance(first, last)} {}
+template <typename T> constexpr MemSpan<T>::MemSpan(T *begin, T *end) : _ptr{begin}, _count{detail::ptr_distance(begin, end)} {}
 
 template <typename T> template <auto N> constexpr MemSpan<T>::MemSpan(T (&a)[N]) : _ptr{a}, _count{N} {}
 
@@ -696,6 +977,7 @@ template <typename T> constexpr MemSpan<T>::MemSpan(std::nullptr_t) {}
 
 template <typename T> template <auto N, typename U, typename META> constexpr MemSpan<T>::MemSpan(std::array<U,N> const& a) : _ptr{a.data()} , _count{a.size()} {}
 template <typename T> template <auto N> constexpr MemSpan<T>::MemSpan(std::array<T,N> & a) : _ptr{a.data()} , _count{a.size()} {}
+template <typename T> template <typename C, typename> constexpr MemSpan<T>::MemSpan(C &c) : _ptr(c.data()), _count(c.size()) {}
 
 template <typename T>
 MemSpan<T> &
@@ -787,13 +1069,25 @@ MemSpan<T>::operator[](size_t idx) const {
 
 template <typename T> constexpr
 size_t
-MemSpan<T>::count() const {
+MemSpan<T>::size() const {
+  return _count;
+}
+
+template <typename T> constexpr
+  size_t
+  MemSpan<T>::count() const {
+  return _count;
+}
+
+template <typename T> constexpr
+  size_t
+  MemSpan<T>::length() const {
   return _count;
 }
 
 template <typename T>
-size_t
-MemSpan<T>::size() const {
+constexpr size_t
+MemSpan<T>::data_size() const {
   return _count * sizeof(T);
 }
 
@@ -879,73 +1173,144 @@ MemSpan<T>::rebind() const {
   static_assert(detail::is_span_compatible<T, U>::value,
                 "MemSpan only allows rebinding between types where the sizes are such that one is an integral multiple of the other.");
   using VOID_PTR = std::conditional_t<std::is_const_v<U>, const void *, void*>;
-  return {static_cast<U *>(static_cast<VOID_PTR>(_ptr)), detail::is_span_compatible<T, U>::count(this->size())};
+  return {static_cast<U *>(static_cast<VOID_PTR>(_ptr)), detail::is_span_compatible<T, U>::count(this->data_size())};
 }
 
 template <typename T>
-std::string_view
-MemSpan<T>::view() const {
-  return {static_cast<const char *>(_ptr), this->size()};
+template <typename... Args>
+auto
+MemSpan<T>::make(Args &&...args) -> self_type & {
+  for ( T * elt = this->data(), * limit = this->data_end() ; elt < limit ; ++elt ) {
+    new (elt) T(std::forward<Args>(args)...);
+  }
+  return *this;
 }
 
-// --- void specialization ---
+template <typename T>
+void
+MemSpan<T>::destroy() {
+  for ( T * elt = this->data(), * limit = this->data_end() ; elt < limit ; ++elt ) {
+    std::destroy_at(elt);
+  }
+}
 
-template <typename U> constexpr MemSpan<void>::MemSpan(MemSpan<U> const &that) : _ptr(that._ptr), _size(that.size()) {}
+// --- void specializations ---
 
-inline constexpr MemSpan<void>::MemSpan(value_type *ptr, size_t n) : _ptr{ptr}, _size{n} {}
+template <typename U> constexpr MemSpan<void const>::MemSpan(MemSpan<U> const &that) : _ptr(const_cast<std::remove_const_t<U> *>(that._ptr)), _size(sizeof(U) * that.size()) {}
+template <typename U> constexpr MemSpan<void>::MemSpan(MemSpan<U> const &that) : super_type(that) { static_assert(!std::is_const_v<U>, "MemSpan<void> does not support constant memory."); }
 
-inline MemSpan<void>::MemSpan(value_type *first, value_type *last) : _ptr{first}, _size{detail::ptr_distance(first, last)} {}
+inline constexpr MemSpan<void const>::MemSpan(MemSpan<void> const &that) : _ptr(that._ptr), _size(that.size()) {}
 
+inline constexpr MemSpan<void const>::MemSpan(value_type *ptr, size_t n) : _ptr{const_cast<void*>(ptr)}, _size{n} {}
+inline constexpr MemSpan<void>::MemSpan(value_type *ptr, size_t n) : super_type(ptr, n) {}
+
+inline MemSpan<void const>::MemSpan(value_type *begin, value_type *end) : _ptr{const_cast<void*>(begin)}, _size{detail::ptr_distance(begin, end)} {}
+inline MemSpan<void >::MemSpan(value_type *begin, value_type *end) : super_type(begin, end) {}
+
+template <typename C, typename>
+constexpr MemSpan<void const>::MemSpan(C const &c)
+  : _ptr(const_cast<std::remove_const_t<std::remove_reference_t<decltype(*(std::declval<C>().data()))>> *>(c.data()))
+    , _size(c.size() * sizeof(*(std::declval<C>().data()))) {}
+template <typename C, typename>
+constexpr MemSpan<void>::MemSpan(C const &c) : super_type(c) {}
+
+inline constexpr MemSpan<void const>::MemSpan(std::nullptr_t) {}
 inline constexpr MemSpan<void>::MemSpan(std::nullptr_t) {}
 
-inline MemSpan<void> &
-MemSpan<void>::assign(value_type *ptr, size_t n) {
-  _ptr  = ptr;
+inline bool
+MemSpan<void const>::is_same(self_type const &that) const {
+  return _ptr == that._ptr && _size == that._size;
+}
+
+inline bool
+MemSpan<void const>::operator==(self_type const &that) const {
+  return _size == that._size && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, _size));
+}
+
+inline bool
+MemSpan<void const>::operator!=(self_type const &that) const {
+  return !(*this == that);
+}
+
+inline MemSpan<void const>::operator bool() const {
+  return _size != 0;
+}
+
+inline bool
+MemSpan<void const>::operator!() const {
+  return _size == 0;
+}
+
+inline constexpr bool
+MemSpan<void const>::empty() const {
+  return _size == 0;
+}
+
+template <typename U>
+auto
+MemSpan<void const>::operator=(MemSpan<U> const &that) -> self_type & {
+  _ptr  = that._ptr;
+  _size = sizeof(U) * that.size();
+  return *this;
+}
+
+inline constexpr auto
+MemSpan<void const>::operator=(MemSpan<void> const &that) -> self_type & {
+  _ptr  = that._ptr;
+  _size = that.size();
+  return *this;
+}
+
+template <typename U>
+auto
+MemSpan<void>::operator=(MemSpan<U> const &that) -> self_type & {
+  static_assert(! std::is_const_v<U>, "Cannot assign constant pointer to MemSpan<void>");
+  this->super_type::operator=(that);
+  return *this;
+}
+
+inline auto
+MemSpan<void const>::assign(value_type *ptr, size_t n) -> self_type & {
+  _ptr  = const_cast<void*>(ptr);
   _size = n;
   return *this;
 }
 
-inline MemSpan<void> &
-MemSpan<void>::assign(value_type *first, value_type const *last) {
-  _ptr  = first;
+inline auto
+MemSpan<void>::assign(value_type * ptr, size_t n) -> self_type & {
+  super_type::assign(ptr, n);
+  return *this;
+}
+
+inline auto
+MemSpan<void const>::assign(value_type *first, value_type const *last) -> self_type & {
+  _ptr  = const_cast<void*>(first);
   _size = detail::ptr_distance(first, last);
   return *this;
 }
 
-inline MemSpan<void> &
-MemSpan<void>::clear() {
+inline auto
+MemSpan<void>::assign(value_type *first, value_type const *last) -> self_type & {
+  super_type::assign(first, last);
+  return *this;
+}
+
+inline auto
+MemSpan<void const>::clear() -> self_type & {
   _ptr  = nullptr;
   _size = 0;
   return *this;
 }
 
-inline bool
-MemSpan<void>::is_same(self_type const &that) const {
-  return _ptr == that._ptr && _size == that._size;
+inline auto
+MemSpan<void>::clear() -> self_type & {
+  super_type::clear();
+  return *this;
 }
 
-inline bool
-MemSpan<void>::operator==(self_type const &that) const {
-  return _size == that._size && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, _size));
-}
-
-inline bool
-MemSpan<void>::operator!=(self_type const &that) const {
-  return !(*this == that);
-}
-
-inline bool
-MemSpan<void>::operator!() const {
-  return _size == 0;
-}
-
-inline MemSpan<void>::operator bool() const {
-  return _size != 0;
-}
-
-inline bool
-MemSpan<void>::empty() const {
-  return _size == 0;
+inline constexpr void const *
+MemSpan<void const>::data() const {
+  return _ptr;
 }
 
 inline constexpr void *
@@ -953,91 +1318,187 @@ MemSpan<void>::data() const {
   return _ptr;
 }
 
+inline void const *
+MemSpan<void const>::data_end() const {
+  return detail::ptr_add(_ptr, _size);
+}
+
 inline void *
 MemSpan<void>::data_end() const {
   return detail::ptr_add(_ptr, _size);
 }
 
-inline size_t
-MemSpan<void>::size() const {
+inline constexpr size_t
+MemSpan<void const>::size() const {
   return _size;
 }
 
-template <typename U>
-auto
-MemSpan<void>::operator=(MemSpan<U> const &that) -> self_type & {
-  _ptr  = that._ptr;
-  _size = that.size();
-  return *this;
+inline constexpr size_t
+MemSpan<void const>::count() const {
+  return _size;
 }
 
-inline constexpr MemSpan<void>
-MemSpan<void>::subspan(size_t offset, size_t count) const {
-  return offset <= _size ? self_type{detail::ptr_add(this->data(), offset), std::min(count, _size - offset)} : self_type{};
+inline constexpr size_t
+MemSpan<void const>::length() const {
+  return _size;
+}
+
+inline constexpr size_t
+MemSpan<void const>::data_size() const {
+  return _size;
 }
 
 inline bool
-MemSpan<void>::contains(value_type const *ptr) const {
+MemSpan<void const>::contains(value_type const *ptr) const {
   return _ptr <= ptr && ptr < this->data_end();
 }
 
-inline MemSpan<void>
-MemSpan<void>::prefix(size_t n) const {
+inline auto
+MemSpan<void const>::prefix(size_t n) const -> self_type {
   return {_ptr, std::min(n, _size)};
 }
 
-inline MemSpan<void> &
-MemSpan<void>::remove_prefix(size_t n) {
+inline auto
+MemSpan<void>::prefix(size_t n) const -> self_type {
+  return {_ptr, std::min(n, _size)};
+}
+
+inline auto
+MemSpan<void const>::remove_prefix(size_t n) -> self_type & {
   n = std::min(_size, n);
   _size -= n;
-  _ptr = static_cast<char *>(_ptr) + n;
+  _ptr = detail::ptr_add(_ptr, n);
   return *this;
 }
 
-inline MemSpan<void>
-MemSpan<void>::suffix(size_t count) const {
-  count = std::min(count, _size);
-  return {static_cast<char *>(this->data_end()) - count, count};
-}
-
-inline MemSpan<void> &
-MemSpan<void>::remove_suffix(size_t count) {
-  _size -= std::min(count, _size);
+inline auto
+MemSpan<void>::remove_prefix(size_t n) -> self_type & {
+  super_type::remove_prefix(n);
   return *this;
 }
 
-template <typename T>
-MemSpan<void>::self_type
-MemSpan<void>::align() const { return this->align(alignof(T)); }
+inline auto
+MemSpan<void const>::suffix(size_t n) const -> self_type {
+  n = std::min(n, _size);
+  return {detail::ptr_add(this->data_end(), -n), n};
+}
 
-inline MemSpan<void>::self_type
-MemSpan<void>::align(size_t n) const {
+inline auto
+MemSpan<void>::suffix(size_t n) const -> self_type {
+  n = std::min(n, _size);
+  return {detail::ptr_add(this->data_end(), -n), n};
+}
+
+inline auto
+MemSpan<void const>::remove_suffix(size_t n) -> self_type & {
+  _size -= std::min(n, _size);
+  return *this;
+}
+
+inline auto
+MemSpan<void>::remove_suffix(size_t n) -> self_type & {
+  this->super_type::remove_suffix(n);
+  return *this;
+}
+
+inline constexpr auto
+MemSpan<void const>::subspan(size_t offset, size_t n) const -> self_type {
+  return offset <= _size ? self_type{detail::ptr_add(this->data(), offset), std::min(n, _size - offset)} : self_type{};
+}
+
+inline constexpr auto
+MemSpan<void>::subspan(size_t offset, size_t n) const -> self_type {
+  return offset <= _size ? self_type{detail::ptr_add(this->data(), offset), std::min(n, _size - offset)} : self_type{};
+}
+
+template <typename T> auto
+MemSpan<void const>::align() const -> self_type { return this->align(alignof(T), sizeof(T)); }
+
+template <typename T> auto
+MemSpan<void>::align() const -> self_type { return this->align(alignof(T), sizeof(T)); }
+
+inline auto
+MemSpan<void const>::align(size_t alignment) const -> self_type {
   auto p = uintptr_t(_ptr);
-  auto padding = p & (n - 1);
-  return { reinterpret_cast<void*>(p + padding), _size - std::min<uintptr_t>(_size, padding) };
+  auto padding = p & (alignment - 1);
+  size_t size = 0;
+  if (_size > padding) { // if there's not enough to pad, result is zero size.
+    size = _size - padding;
+  }
+  return { reinterpret_cast<void*>(p + padding), size };
 }
 
-template <typename U>
-MemSpan<U>
+inline auto
+MemSpan<void>::align(size_t alignment) const -> self_type {
+  auto && [ ptr, size ] = super_type::align(alignment);
+  return { ptr, size };
+}
+
+inline auto
+MemSpan<void const>::align(size_t alignment, size_t obj_size) const -> self_type {
+  auto p = uintptr_t(_ptr);
+  auto padding = p & (alignment - 1);
+  size_t size = 0;
+  if (_size > padding) { // if there's not enough to pad, result is zero size.
+    size = ((_size - padding) / obj_size ) * obj_size;
+  }
+  return { reinterpret_cast<void*>(p + padding), size };
+}
+
+inline auto
+MemSpan<void>::align(size_t alignment, size_t obj_size) const -> self_type {
+  auto && [ ptr, n ] = super_type::align(alignment, obj_size);
+  return { ptr, n };
+}
+
+template < typename U > MemSpan<U>
+MemSpan<void const>::rebind() const {
+  static_assert(std::is_const_v<U>, "Cannot rebind MemSpan<const void> to non-const type.");
+  return {static_cast<U *>(_ptr), detail::is_span_compatible<value_type, U>::count(_size)};
+}
+
+template < typename U > MemSpan<U>
 MemSpan<void>::rebind() const {
-  return {static_cast<U *>(_ptr), detail::is_span_compatible<void, U>::count(_size)};
+  return {static_cast<U *>(_ptr), detail::is_span_compatible<value_type, U>::count(_size)};
 }
 
 // Specialize so that @c void -> @c void rebinding compiles and works as expected.
 template <>
-inline MemSpan<void>
-MemSpan<void>::rebind() const {
+inline auto
+MemSpan<void const>::rebind() const -> self_type {
   return *this;
 }
 
-inline std::string_view
-MemSpan<void>::view() const {
-  return {static_cast<char const *>(_ptr), _size};
+template <>
+inline auto
+MemSpan<void>::rebind() const -> self_type {
+  return *this;
 }
 
-/// Deduction guide for constructing from a @c std::array.
+template <typename U> U *
+MemSpan<void>::as_ptr() const {
+  if (_size != sizeof(U)) {
+    throw std::invalid_argument("MemSpan::as size is not compatible with target type.");
+  }
+  return static_cast<U *>(_ptr);
+}
+
+template <typename U> U const *
+MemSpan<void const>::as_ptr() const {
+  if (_size != sizeof(U)) {
+    throw std::invalid_argument("MemSpan::as size is not compatible with target type.");
+  }
+  return static_cast<U const *>(_ptr);
+}
+
+/// Deduction guides
 template<typename T, size_t N> MemSpan(std::array<T,N> &) -> MemSpan<T>;
 template<typename T, size_t N> MemSpan(std::array<T,N> const &) -> MemSpan<T const>;
+template<typename T> MemSpan(std::vector<T> &) -> MemSpan<T>;
+template<typename T> MemSpan(std::vector<T> const&) -> MemSpan<T const>;
+MemSpan(std::string_view const&) -> MemSpan<char const>;
+MemSpan(std::string &) -> MemSpan<char>;
+MemSpan(std::string const&) -> MemSpan<char const>;
 
 }} // namespace swoc::SWOC_VERSION_NS
 

--- a/lib/swoc/include/swoc/TextView.h
+++ b/lib/swoc/include/swoc/TextView.h
@@ -537,7 +537,7 @@ public:
 
   /** Get a view of the last @a n bytes.
    *
-   * @param n Number of chars in the prefix.
+   * @param n Number of chars in the suffix.
    * @return A view of the last @a n characters in @a this, bounded by the size of @a this.
    */
   constexpr self_type suffix(size_t n) const noexcept;
@@ -600,6 +600,8 @@ public:
    * @tparam F Predicate function type.
    * @param pred The predicate instance.
    * @return @a this.
+   *
+   * If predicate is never true the view is cleared.
    */
   template <typename F> self_type &remove_suffix_if(F const &pred);
 
@@ -1263,26 +1265,26 @@ TextView::remove_suffix(size_t n) -> self_type & {
 inline TextView &
 TextView::remove_suffix_at(char c) {
   if (auto n = this->rfind(c); n != npos) {
-    this->remove_suffix(this->size() - n);
+    return this->remove_suffix(this->size() - n);
   }
-  return *this;
+  return this->clear();
 }
 
 inline TextView &
 TextView::remove_suffix_at(std::string_view const &delimiters) {
   if (auto n = this->find_last_of(delimiters); n != npos) {
-    this->remove_suffix(this->size() - n);
+    return this->remove_suffix(this->size() - n);
   }
-  return *this;
+  return this->clear();
 }
 
 template <typename F>
 TextView::self_type &
 TextView::remove_suffix_if(F const &pred) {
   if (auto n = this->rfind_if(pred); n != npos) {
-    this->remove_suffix(this->size() - n);
+    return this->remove_suffix(this->size() - n);
   }
-  return *this;
+  return this->clear();
 }
 
 inline TextView
@@ -1543,16 +1545,16 @@ template <typename Stream>
 Stream &
 TextView::stream_write(Stream &os, const TextView &b) const {
   // Local function, avoids extra template work.
-  static const auto stream_fill = [](Stream &os, size_t n) -> Stream & {
+  static const auto stream_fill = [](Stream &ostream, size_t n) -> Stream & {
     static constexpr size_t pad_size = 8;
     typename Stream::char_type padding[pad_size];
 
-    std::fill_n(padding, pad_size, os.fill());
-    for (; n >= pad_size && os.good(); n -= pad_size)
-      os.write(padding, pad_size);
-    if (n > 0 && os.good())
-      os.write(padding, n);
-    return os;
+    std::fill_n(padding, pad_size, ostream.fill());
+    for (; n >= pad_size && ostream.good(); n -= pad_size)
+      ostream.write(padding, pad_size);
+    if (n > 0 && ostream.good())
+      ostream.write(padding, n);
+    return ostream;
   };
 
   const std::size_t w = os.width();

--- a/lib/swoc/include/swoc/bwf_base.h
+++ b/lib/swoc/include/swoc/bwf_base.h
@@ -538,7 +538,7 @@ template <typename F> NameMap<F>::NameMap(std::initializer_list<std::tuple<std::
 template <typename F>
 std::string_view
 NameMap<F>::localize(std::string_view const &name) {
-  auto span = _arena.alloc(name.size()).rebind<char>();
+  auto span = _arena.alloc_span<char>(name.size());
   memcpy(span, name);
   return std::string_view(span.data(), span.size());
 }

--- a/lib/swoc/include/swoc/bwf_base.h
+++ b/lib/swoc/include/swoc/bwf_base.h
@@ -538,9 +538,9 @@ template <typename F> NameMap<F>::NameMap(std::initializer_list<std::tuple<std::
 template <typename F>
 std::string_view
 NameMap<F>::localize(std::string_view const &name) {
-  auto span = _arena.alloc(name.size());
+  auto span = _arena.alloc(name.size()).rebind<char>();
   memcpy(span, name);
-  return span.view();
+  return std::string_view(span.data(), span.size());
 }
 
 template <typename F>
@@ -972,6 +972,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, std::nullptr_t) {
   return bwformat(w, spec, static_cast<void *>(nullptr));
 }
 
+// Char pointer formatting
 inline BufferWriter &
 bwformat(BufferWriter &w, bwf::Spec const &spec, const char *v) {
   if (spec._type == 'x' || spec._type == 'X' || spec._type == 'p' || spec._type == 'P') {
@@ -983,6 +984,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, const char *v) {
   }
   return w;
 }
+// doc end
 
 inline BufferWriter &
 bwformat(BufferWriter &w, bwf::Spec const &spec, std::string const &s) {
@@ -1005,7 +1007,8 @@ bwformat(BufferWriter &w, bwf::Spec const &, TransformView<X, V> &&view) {
 template <typename F>
 auto
 bwformat(BufferWriter &w, bwf::Spec const &spec, F &&f) ->
-  typename std::enable_if<std::is_floating_point<typename std::remove_reference<F>::type>::value, BufferWriter &>::type {
+  typename std::enable_if<std::is_floating_point_v<typename std::remove_reference_t<F>>, BufferWriter &>::type
+{
   return f < 0 ? bwf::Format_Float(w, spec, -f, true) : bwf::Format_Float(w, spec, f, false);
 }
 

--- a/lib/swoc/include/swoc/bwf_ip.h
+++ b/lib/swoc/include/swoc/bwf_ip.h
@@ -30,6 +30,12 @@ BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Addr const &ad
 
 BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPAddr const &addr);
 
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Srv const &addr);
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Srv const &addr);
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPSrv const &addr);
+
 BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Range const &range);
 
 BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Range const &range);

--- a/lib/swoc/include/swoc/swoc_meta.h
+++ b/lib/swoc/include/swoc/swoc_meta.h
@@ -141,7 +141,7 @@ template <typename... Args> vary(Args...) -> vary<Args...>;
  * @c enable_if to enable a function / method only if the argument type is one of a fixed set.
  * @code
  *   template < typename T > auto f(T const& t)
- *     -> std::enable_if_t<swoc::meta::is_any_of<T, int, float, bool>::value, void>
+ *     -> std::enable_if_t<swoc::meta::is_any_of<T, int, float, bool>::value, void>::value
  *   { ... }
  */
 template <typename T, typename... Types> struct is_any_of {

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_4_4
+#define SWOC_VERSION_NS _1_4_5
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 4;
-static constexpr unsigned POINT_VERSION = 4;
+static constexpr unsigned POINT_VERSION = 5;
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_4_0
+#define SWOC_VERSION_NS _1_4_4
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 4;
-static constexpr unsigned POINT_VERSION = 0;
+static constexpr unsigned POINT_VERSION = 4;
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/src/Errata.cc
+++ b/lib/swoc/src/Errata.cc
@@ -29,9 +29,9 @@ std::string_view Errata::DEFAULT_GLUE{"\n", 1};
 
 string_view
 Errata::Data::localize(string_view src) {
-  auto span = _arena.alloc(src.size());
+  auto span = _arena.alloc(src.size()).rebind<char>();
   memcpy(span.data(), src.data(), src.size());
-  return span.view();
+  return { span.data(), span.size() };
 }
 
 /* ----------------------------------------------------------------------- */
@@ -88,7 +88,7 @@ Errata::note_s(std::optional<Severity> severity, std::string_view text) {
   if (!severity.has_value() || *severity >= FILTER_SEVERITY) {
     auto span = this->alloc(text.size());
     memcpy(span, text);
-    this->note_localized(span.view(), severity);
+    this->note_localized(TextView(span), severity);
   }
   return *this;
 }

--- a/lib/swoc/src/bw_format.cc
+++ b/lib/swoc/src/bw_format.cc
@@ -648,6 +648,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, std::string_view sv) {
   return w;
 }
 
+// Generic pointer formatting
 BufferWriter &
 bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr) {
   using namespace swoc::literals;
@@ -671,6 +672,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr) {
   }
   return bwf::Format_Integer(w, ptr_spec, reinterpret_cast<intptr_t>(ptr), false);
 }
+// doc end
 
 BufferWriter &
 bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::HexDump const &hex) {
@@ -698,7 +700,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span) {
   if ('x' == spec._type || 'X' == spec._type) {
     const char *digits =  ('X' == spec._type) ? bwf::UPPER_DIGITS : bwf::LOWER_DIGITS;
     size_t block       = spec._prec > 0 ? spec._prec : span.size();
-    TextView view{span.view()};
+    TextView view{span.rebind<char>()};
     bool space_p = false;
     while (view) {
       if (space_p)

--- a/lib/swoc/src/bw_ip_format.cc
+++ b/lib/swoc/src/bw_ip_format.cc
@@ -208,6 +208,35 @@ bwformat(BufferWriter &w, Spec const &spec, IP6Addr const &addr) {
 }
 
 BufferWriter &
+bwformat(BufferWriter &w, Spec const &spec, IP4Srv const& srv) {
+  bwformat(w, spec, srv.addr());
+  if (srv.host_order_port()) {
+    w.print(":{}", srv.host_order_port());
+  }
+  return w;
+}
+
+BufferWriter &
+bwformat(BufferWriter &w, Spec const &spec, IP6Srv const& srv) {
+  auto port = srv.host_order_port();
+  if (port) {
+    w.write('[');
+    bwformat(w, spec, srv.addr());
+    w.print("]:{}", port);
+  } else {
+    bwformat(w, spec, srv.addr());
+  }
+  return w;
+}
+
+BufferWriter &
+bwformat(BufferWriter &w, Spec const &spec, IPSrv const& srv) {
+  if (srv.is_ip4()) { bwformat(w, spec, IP4Srv(srv)); }
+  else if (srv.is_ip6()) { bwformat(w, spec, IP6Srv(srv)); }
+  return w;
+}
+
+BufferWriter &
 bwformat(BufferWriter &w, Spec const &spec, IPAddr const &addr) {
   Spec local_spec{spec}; // Format for address elements and port.
   bool addr_p{true};

--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -802,10 +802,10 @@ SessionProtocolNameRegistry::toIndex(ts::TextView name)
     if (m_n < MAX) {
       // Localize the name by copying it in to the arena.
       auto text = m_arena.alloc(name.size() + 1).rebind<char>();
-      memcpy(text.data(), name.data(), name.size());
+      memcpy(text, name);
       text.end()[-1] = '\0';
-      m_names[m_n]   = text.view();
-      zret           = m_n++;
+      m_names[m_n].assign(text.data(), name.size());
+      zret = m_n++;
     } else {
       ink_release_assert(!"Session protocol name registry overflow");
     }


### PR DESCRIPTION
Update to libswoc 1.4.4. This contains a number of fixes, primarily for `MemSpan`.

Note: slight issue with 1.4.3 on Ubuntu, tweaked to deal with that and bumped the libswoc version to be safe.