### PR TITLE
Cleanup: More const-crrectness of cache read

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -488,7 +488,7 @@ CacheVC::get_pin_in_cache()
 }
 
 int
-Vol::begin_read(CacheVC *cont)
+Vol::begin_read(CacheVC *cont) const
 {
   ink_assert(cont->mutex->thread_holding == this_ethread());
   ink_assert(mutex->thread_holding == this_ethread());
@@ -523,7 +523,7 @@ Vol::begin_read(CacheVC *cont)
 }
 
 int
-Vol::close_read(CacheVC *cont)
+Vol::close_read(CacheVC *cont) const
 {
   EThread *t = cont->mutex->thread_holding;
   ink_assert(t == this_ethread());

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -152,7 +152,7 @@ OpenDir::close_write(CacheVC *cont)
 }
 
 OpenDirEntry *
-OpenDir::open_read(const CryptoHash *key)
+OpenDir::open_read(const CryptoHash *key) const
 {
   unsigned int h = key->slice32(0);
   int b          = h % OPEN_DIR_BUCKETS;

--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -250,7 +250,7 @@ struct OpenDir : public Continuation {
 
   int open_write(CacheVC *c, int allow_if_writers, int max_writers);
   int close_write(CacheVC *c);
-  OpenDirEntry *open_read(const CryptoHash *key);
+  OpenDirEntry *open_read(const CryptoHash *key) const;
   int signal_readers(int event, Event *e);
 
   OpenDir();

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -181,13 +181,13 @@ struct Vol : public Continuation {
   int open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers);
   int close_write(CacheVC *cont);
   int close_write_lock(CacheVC *cont);
-  int begin_read(CacheVC *cont);
+  int begin_read(CacheVC *cont) const;
   int begin_read_lock(CacheVC *cont);
   // unused read-write interlock code
   // currently http handles a write-lock failure by retrying the read
-  OpenDirEntry *open_read(const CryptoHash *key);
+  OpenDirEntry *open_read(const CryptoHash *key) const;
   OpenDirEntry *open_read_lock(CryptoHash *key, EThread *t);
-  int close_read(CacheVC *cont);
+  int close_read(CacheVC *cont) const;
   int close_read_lock(CacheVC *cont);
 
   int clear_dir();
@@ -481,7 +481,7 @@ free_EvacuationBlock(EvacuationBlock *b, EThread *t)
 }
 
 TS_INLINE OpenDirEntry *
-Vol::open_read(const CryptoHash *key)
+Vol::open_read(const CryptoHash *key) const
 {
   return open_dir.open_read(key);
 }


### PR DESCRIPTION
I noticed `Vol::open_read` and similar reading functions can be const.