### PR TITLE
records.yaml - Fix record name comparison logic.

### DIFF
--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -1531,7 +1531,7 @@ const RecordElement *
 GetRecordElementByName(std::string_view name)
 {
   for (unsigned i = 0; i < countof(RecordsConfig); ++i) {
-    if (strncmp(RecordsConfig[i].name, name.data(), name.size()) == 0) {
+    if (name.compare(RecordsConfig[i].name) == 0) {
       return &RecordsConfig[i];
     }
   }

--- a/tests/gold_tests/records/records_yaml.test.py
+++ b/tests/gold_tests/records/records_yaml.test.py
@@ -32,6 +32,8 @@ ts.Disk.records_config.update(
       client:
         cert:
           filename: null
+          filenamee: some.txt
+          filenam: some2.txt
     dns:
       nameservers: null
     test:
@@ -69,6 +71,12 @@ ts.Disk.diags_log.Content += Testers.ContainsExpression(
     f"Unrecognized configuration value '{var2}",
     "Field should be ignored")
 
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+    f"Ignoring field 'filenamee'",
+    "Field should be ignored")
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+    f"Ignoring field 'filenam'",
+    "Field should be ignored")
 
 # 1
 tr = Test.AddTestRun("Query unregistered records.")


### PR DESCRIPTION
There was a bug when you were trying to get a record by name from the registered records. Without this fix you could request  for instance a shorter record name and the comparison will still be valid.

So you could have configured:
```yaml
ts:
  diags:
    debug:
      enable: 1 # note the missing "d" at the end. 
```
and still be valid, even though the registered record is: `proxy.config.diags.debug.enabled`
