### PR TITLE
records.yaml - Allow the records.yaml parser to keep reading further docs even when an error is detected

### DIFF
--- a/src/records/RecConfigParse.cc
+++ b/src/records/RecConfigParse.cc
@@ -267,19 +267,20 @@ RecConfigFileParse(const char *path, RecConfigEntryCallback handler)
 swoc::Errata
 RecYAMLConfigFileParse(const char *path, RecYAMLNodeHandler handler)
 {
+  swoc::Errata status;
   try {
     auto nodes = YAML::LoadAllFromFile(path);
     // We will parse each doc from the stream, subsequently config node will overwrite
     // the value for previously loaded records. This would work similar to the old
     // records.config which a later CONFIG variable would overwrite a previous one.
     for (auto const &root : nodes) {
-      if (auto ret = ParseRecordsFromYAML(root, handler); !ret.empty()) {
-        return ret;
+      if (auto &&ret = ParseRecordsFromYAML(root, handler); !ret.empty()) {
+        status.note(ret);
       }
     }
   } catch (std::exception const &ex) {
-    return swoc::Errata(ERRATA_ERROR, "Error parsing {}. {}", path, ex.what());
+    status.note(ERRATA_ERROR, "Error parsing {}. {}", path, ex.what());
   }
 
-  return {};
+  return status;
 }


### PR DESCRIPTION
The idea is to make sure we parse the entire file. Without this change, if an error is found in a particular doc, then the rest of  the documents will be ignored.

Example:
```yaml
#doc 1
ts:
  field_a: 1
---
# doc 2
ts:
   some_error_here: 1
---
# doc 3
ts:
  field_b: 2
```

ATS will detect the `doc 2` error and will not even bother to parse the `doc 3.` 

This PR makes sure that all docs get read and  display any errors at the end.