### PR TITLE
9.2.x: http2_flow_control.test.py: Correctly enable debug logs

### DIFF
--- a/tests/gold_tests/h2/http2_flow_control.test.py
+++ b/tests/gold_tests/h2/http2_flow_control.test.py
@@ -108,7 +108,7 @@ class Http2FlowControlTest:
             'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
             'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(self._dns.Variables.Port),
 
-            'proxy.config.diags.debug.enabled': 3,
+            'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': 'http',
         })
 


### PR DESCRIPTION
The http2_flow_control.test.py AuTest was ported from 10.x which supports a value of 3 for `proxy.config.diags.debug.enabled`. 9.2.x, however, does not support 3 and therefore debug logging hasn't been working for this test in 9.2.x. This fixes that. This, incidentally, seems to make the test run more reliably in the opensource CI environment.