### PR TITLE
Remove inactive include of IpMapConf.h

### DIFF
--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -31,7 +31,6 @@
 #include "tscore/ink_inet.h"
 #include <string_view>
 #include <unordered_set>
-#include <tscore/IpMapConf.h>
 
 using ts::TextView;
 


### PR DESCRIPTION
`IpMap` cleanup - get rid of potential reference because it's not used.