### PR TITLE
Change RecHttpLoadIp to use ts::AddrPair

### DIFF
--- a/include/records/I_RecHttp.h
+++ b/include/records/I_RecHttp.h
@@ -34,7 +34,7 @@
 #include <algorithm>
 #include <array>
 
-/** Load IP addresses from a configuratiojn value.
+/** Load IP addresses from a configuration value.
  *
  * @param name Configuration variable name.
  * @return The results of parsing the value.

--- a/include/records/I_RecHttp.h
+++ b/include/records/I_RecHttp.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "tscore/ink_inet.h"
+#include "tscpp/util/ts_ip.h"
 #include "tscore/ink_resolver.h"
 #include "ts/apidefs.h"
 #include "ts/apidefs.h"
@@ -33,11 +34,12 @@
 #include <algorithm>
 #include <array>
 
-/// Load default inbound IP addresses from the configuration file.
-void RecHttpLoadIp(const char *name, ///< Name of value in configuration file.
-                   IpAddr &ip4,      ///< [out] IPv4 address.
-                   IpAddr &ip6       ///< [out] Ipv6 address.
-);
+/** Load IP addresses from a configuratiojn value.
+ *
+ * @param name Configuration variable name.
+ * @return The results of parsing the value.
+ */
+ts::IPAddrPair RecHttpLoadIp(char const *name);
 
 /// Load up an IpMap with IP addresses from the configuration file.
 void RecHttpLoadIpMap(const char *name, ///< Name of value in configuration file.
@@ -269,9 +271,7 @@ public:
   /// Local address for inbound connections (listen address).
   IpAddr m_inbound_ip;
   /// Local address for outbound connections (to origin server).
-  IpAddr m_outbound_ip4;
-  /// Local address for outbound connections (to origin server).
-  IpAddr m_outbound_ip6;
+  ts::IPAddrPair m_outbound;
   /// Ordered preference for DNS resolution family ( @c FamilyPrefence )
   /// A value of @c PREFER_NONE indicates that entry and subsequent ones
   /// are invalid.
@@ -283,13 +283,6 @@ public:
 
   /// Default constructor.
   HttpProxyPort();
-
-  /** Select the local outbound address object.
-
-      @return The IP address for @a family
-  */
-  IpAddr &outboundIp(uint16_t family ///< IP address family.
-  );
 
   /// Check for SSL port.
   bool isSSL() const;
@@ -466,18 +459,6 @@ inline bool
 HttpProxyPort::isPlugin() const
 {
   return TRANSPORT_PLUGIN == m_type;
-}
-
-inline IpAddr &
-HttpProxyPort::outboundIp(uint16_t family)
-{
-  static IpAddr invalid; // dummy to make compiler happy about return.
-  if (AF_INET == family)
-    return m_outbound_ip4;
-  else if (AF_INET6 == family)
-    return m_outbound_ip6;
-  ink_release_assert(!"Invalid family for outbound address on proxy port.");
-  return invalid; // never happens but compiler insists.
 }
 
 inline bool

--- a/include/tscpp/util/ts_ip.h
+++ b/include/tscpp/util/ts_ip.h
@@ -41,13 +41,20 @@ public:
    *
    * @param a4 Address.
    */
-  IPAddrPair(swoc::IP4Addr a4);
+  IPAddrPair(swoc::IP4Addr const &a4);
 
   /** Construct with IPv6 address.
    *
    * @param a6 Address.
    */
-  IPAddrPair(swoc::IP6Addr a6);
+  IPAddrPair(swoc::IP6Addr const &a6);
+
+  /** Construct from two addresses.
+   *
+   * @param addr4 IPv4 address.
+   * @param addr6 IPv6 address.
+   */
+  IPAddrPair(swoc::IP4Addr const &addr4, swoc::IP6Addr const &addr6);
 
   /// @return @c true if either address is present.
   bool has_value() const;
@@ -89,13 +96,23 @@ public:
    */
   self_type &operator=(swoc::IPAddr const &addr);
 
+  /** Additive / union.
+   *
+   * @param that Source value.
+   * @return @a this
+   *
+   * Missing values in @a that are not copied, the original value remains.
+   */
+  self_type &operator+=(self_type const &that);
+
 protected:
   std::optional<swoc::IP4Addr> _ip4;
   std::optional<swoc::IP6Addr> _ip6;
 };
 
-inline IPAddrPair::IPAddrPair(swoc::IP4Addr a4) : _ip4(a4) {}
-inline IPAddrPair::IPAddrPair(swoc::IP6Addr a6) : _ip6(a6) {}
+inline IPAddrPair::IPAddrPair(swoc::IP4Addr const &a4) : _ip4(a4) {}
+inline IPAddrPair::IPAddrPair(swoc::IP6Addr const &a6) : _ip6(a6) {}
+inline IPAddrPair::IPAddrPair(const swoc::IP4Addr &addr4, const swoc::IP6Addr &addr6) : _ip4(addr4), _ip6(addr6) {}
 
 inline bool
 IPAddrPair::has_value() const

--- a/proxy/ProxyTransaction.cc
+++ b/proxy/ProxyTransaction.cc
@@ -134,27 +134,27 @@ ProxyTransaction::set_outbound_port(in_port_t port)
 IpAddr
 ProxyTransaction::get_outbound_ip4() const
 {
-  return upstream_outbound_options.outbound_ip4;
+  if (upstream_outbound_options.outbound.has_ip4()) {
+    return IpAddr(upstream_outbound_options.outbound.ip4().network_order());
+  }
+  return IpAddr();
 }
 
 IpAddr
 ProxyTransaction::get_outbound_ip6() const
 {
-  return upstream_outbound_options.outbound_ip6;
+  if (upstream_outbound_options.outbound.has_ip6()) {
+    return IpAddr(upstream_outbound_options.outbound.ip6().network_order());
+  }
+  return IpAddr();
 }
 
 void
-ProxyTransaction::set_outbound_ip(const IpAddr &new_addr)
+ProxyTransaction::set_outbound_ip(swoc::IPAddr const &addr)
 {
-  if (new_addr.isIp4()) {
-    upstream_outbound_options.outbound_ip4 = new_addr;
-  } else if (new_addr.isIp6()) {
-    upstream_outbound_options.outbound_ip6 = new_addr;
-  } else {
-    upstream_outbound_options.outbound_ip4.invalidate();
-    upstream_outbound_options.outbound_ip6.invalidate();
-  }
+  upstream_outbound_options.outbound = addr;
 }
+
 bool
 ProxyTransaction::is_outbound_transparent() const
 {

--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -75,7 +75,7 @@ public:
   virtual IpAddr get_outbound_ip4() const;
   virtual IpAddr get_outbound_ip6() const;
   virtual void set_outbound_port(in_port_t port);
-  virtual void set_outbound_ip(const IpAddr &new_addr);
+  virtual void set_outbound_ip(swoc::IPAddr const &addr);
   virtual bool is_outbound_transparent() const;
   virtual void set_outbound_transparent(bool flag);
 

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1159,8 +1159,8 @@ HttpConfig::startup()
     c.proxy_hostname[0] = '\0';
   }
 
-  RecHttpLoadIp("proxy.local.incoming_ip_to_bind", c.inbound_ip4, c.inbound_ip6);
-  RecHttpLoadIp("proxy.local.outgoing_ip_to_bind", c.outbound_ip4, c.outbound_ip6);
+  c.inbound  += RecHttpLoadIp("proxy.local.incoming_ip_to_bind");
+  c.outbound += RecHttpLoadIp("proxy.local.outgoing_ip_to_bind");
   RecHttpLoadIpMap("proxy.config.http.proxy_protocol_allowlist", c.config_proxy_protocol_ipmap);
   SSLConfigInit(&c.config_proxy_protocol_ipmap);
 
@@ -1450,11 +1450,9 @@ HttpConfig::reconfigure()
 
   params = new HttpConfigParams;
 
-  params->inbound_ip4 = m_master.inbound_ip4;
-  params->inbound_ip6 = m_master.inbound_ip6;
+  params->inbound = m_master.inbound;
 
-  params->outbound_ip4 = m_master.outbound_ip4;
-  params->outbound_ip6 = m_master.outbound_ip6;
+  params->outbound = m_master.outbound;
 
   params->proxy_hostname                           = ats_strdup(m_master.proxy_hostname);
   params->proxy_hostname_len                       = (params->proxy_hostname) ? strlen(params->proxy_hostname) : 0;

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -52,6 +52,7 @@
 #include "ConfigProcessor.h"
 #include "records/I_RecProcess.h"
 #include "HttpConnectionCount.h"
+#include "tscpp/util/ts_ip.h"
 
 static const unsigned HTTP_STATUS_NUMBER = 600;
 using HttpStatusBitset                   = std::bitset<HTTP_STATUS_NUMBER>;
@@ -772,8 +773,9 @@ public:
   };
 
 public:
-  IpAddr inbound_ip4, inbound_ip6;
-  IpAddr outbound_ip4, outbound_ip6;
+  ts::IPAddrPair inbound;
+  // Initialize to any addr (default constructed) because these must always be set.
+  ts::IPAddrPair outbound;
   IpAddr proxy_protocol_ip4, proxy_protocol_ip6;
   IpMap config_proxy_protocol_ipmap;
 

--- a/proxy/http/HttpSessionAccept.h
+++ b/proxy/http/HttpSessionAccept.h
@@ -63,9 +63,7 @@ public:
   /// Set the transport type.
   self &setTransportType(int);
   /// Local address to bind for outbound connections.
-  IpAddr outbound_ip4;
-  /// Local address to bind for outbound connections.
-  IpAddr outbound_ip6;
+  ts::IPAddrPair outbound;
   /// Set the outbound IP address to @a ip.
   self &setOutboundIp(IpAddr &ip);
   /// Set the outbound IP address to @a ip.
@@ -93,7 +91,6 @@ public:
 };
 
 inline HttpSessionAcceptOptions::HttpSessionAcceptOptions()
-
 {
   host_res_preference = host_res_default_preference_order;
 }
@@ -109,19 +106,16 @@ inline HttpSessionAcceptOptions &
 HttpSessionAcceptOptions::setOutboundIp(IpAddr &ip)
 {
   if (ip.isIp4())
-    outbound_ip4 = ip;
+    outbound = swoc::IP4Addr(ip._addr._ip4);
   else if (ip.isIp6())
-    outbound_ip6 = ip;
+    outbound = swoc::IP6Addr(ip._addr._ip6);
   return *this;
 }
 
 inline HttpSessionAcceptOptions &
 HttpSessionAcceptOptions::setOutboundIp(IpEndpoint *ip)
 {
-  if (ip->isIp4())
-    outbound_ip4 = *ip;
-  else if (ip->isIp6())
-    outbound_ip6 = *ip;
+  outbound = swoc::IPAddr(&(ip->sa));
   return *this;
 }
 

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -102,13 +102,13 @@ test_proxy_http_SOURCES = \
 	HttpBodyFactory.h
 
 test_proxy_http_LDADD = \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/proxy/logging/liblogging.a \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/iocore/utils/libinkutils.a \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ \
 	@LIBCAP@
 

--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -29,6 +29,8 @@
 #include <cstring>
 #include <strings.h>
 #include "tscore/ink_inet.h"
+#include "swoc/BufferWriter.h"
+#include "swoc/bwf_ip.h"
 #include <string_view>
 #include <unordered_set>
 #include <tscore/IpMapConf.h>
@@ -104,40 +106,41 @@ mptcp_supported()
   return value != 0;
 }
 
-void
-RecHttpLoadIp(const char *value_name, IpAddr &ip4, IpAddr &ip6)
+ts::IPAddrPair
+RecHttpLoadIp(char const *name)
 {
+  ts::IPAddrPair zret;
   char value[1024];
-  ip4.invalidate();
-  ip6.invalidate();
-  if (REC_ERR_OKAY == RecGetRecordString(value_name, value, sizeof(value))) {
+
+  if (REC_ERR_OKAY == RecGetRecordString(name, value, sizeof(value))) {
     Tokenizer tokens(", ");
     int n_addrs = tokens.Initialize(value);
     for (int i = 0; i < n_addrs; ++i) {
       const char *host = tokens[i];
-      IpEndpoint tmp4, tmp6;
       // For backwards compatibility we need to support the use of host names
       // for the address to bind.
-      if (0 == ats_ip_getbestaddrinfo(host, &tmp4, &tmp6)) {
-        if (ats_is_ip4(&tmp4)) {
-          if (!ip4.isValid()) {
-            ip4 = tmp4;
+      auto addrs = ts::getbestaddrinfo(host);
+      if (addrs.has_value()) {
+        if (addrs.has_ip4()) {
+          if (!zret.has_ip4()) {
+            zret = addrs.ip4();
           } else {
-            Warning("'%s' specifies more than one IPv4 address, ignoring %s.", value_name, host);
+            Warning("'%s' specifies more than one IPv4 address, ignoring %s.", name, host);
           }
         }
-        if (ats_is_ip6(&tmp6)) {
-          if (!ip6.isValid()) {
-            ip6 = tmp6;
+        if (addrs.has_ip6()) {
+          if (!zret.has_ip6()) {
+            zret = addrs.ip6();
           } else {
-            Warning("'%s' specifies more than one IPv6 address, ignoring %s.", value_name, host);
+            Warning("'%s' specifies more than one IPv6 address, ignoring %s.", name, host);
           }
         }
       } else {
-        Warning("'%s' has an value '%s' that is not recognized as an IP address, ignored.", value_name, host);
+        Warning("'%s' has an value '%s' that is not recognized as an IP address, ignored.", name, host);
       }
     }
   }
+  return zret;
 }
 
 void
@@ -393,8 +396,8 @@ HttpProxyPort::processOptions(const char *opts)
         Warning("Invalid IP address value '%s' in port descriptor '%s'", item, opts);
       }
     } else if (nullptr != (value = this->checkPrefix(item, OPT_OUTBOUND_IP_PREFIX, OPT_OUTBOUND_IP_PREFIX_LEN))) {
-      if (0 == ip.load(value)) {
-        this->outboundIp(ip.family()) = ip;
+      if (swoc::IPAddr addr; addr.load(value)) {
+        this->m_outbound = addr;
       } else {
         Warning("Invalid IP address value '%s' in port descriptor '%s'", item, opts);
       }
@@ -558,22 +561,24 @@ HttpProxyPort::print(char *out, size_t n)
     return n;
   }
 
-  if (m_outbound_ip4.isValid()) {
+  if (m_outbound.has_ip4()) {
     if (need_colon_p) {
       out[zret++] = ':';
     }
-    zret         += snprintf(out + zret, n - zret, "%s=[%s]", OPT_OUTBOUND_IP_PREFIX, m_outbound_ip4.toString(ipb, sizeof(ipb)));
+    zret         += snprintf(out + zret, n - zret, "%s=[%s]", OPT_OUTBOUND_IP_PREFIX,
+                             swoc::FixedBufferWriter(ipb, sizeof(ipb)).print("{}", m_outbound.ip4()).data());
     need_colon_p = true;
   }
   if (zret >= n) {
     return n;
   }
 
-  if (m_outbound_ip6.isValid()) {
+  if (m_outbound.has_ip6()) {
     if (need_colon_p) {
       out[zret++] = ':';
     }
-    zret         += snprintf(out + zret, n - zret, "%s=[%s]", OPT_OUTBOUND_IP_PREFIX, m_outbound_ip6.toString(ipb, sizeof(ipb)));
+    zret         += snprintf(out + zret, n - zret, "%s=[%s]", OPT_OUTBOUND_IP_PREFIX,
+                             swoc::FixedBufferWriter(ipb, sizeof(ipb)).print("{}", m_outbound.ip6()).data());
     need_colon_p = true;
   }
   if (zret >= n) {

--- a/src/records/unit_tests/test_RecHttp.cc
+++ b/src/records/unit_tests/test_RecHttp.cc
@@ -92,8 +92,8 @@ TEST_CASE("RecHttp", "[librecords][RecHttp]")
     REQUIRE(ports[0].m_port == 4443);
     REQUIRE(ports[0].m_family == AF_INET6);
     REQUIRE(ports[0].isSSL() == true);
-    REQUIRE(ports[0].m_outbound_ip6.isValid() == true);
-    REQUIRE(ports[0].m_outbound_ip4.isValid() == true);
+    REQUIRE(ports[0].m_outbound.has_ip6() == true);
+    REQUIRE(ports[0].m_outbound.has_ip4() == true);
     REQUIRE(ports[0].m_inbound_ip.isValid() == false);
     REQUIRE(view.find(":ssl") != TextView::npos);
     REQUIRE(view.find(":proto") == TextView::npos); // it's default, should not have this.

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5891,7 +5891,7 @@ TSHttpTxnOutgoingAddrSet(TSHttpTxn txnp, const struct sockaddr *addr)
   HttpSM *sm = (HttpSM *)txnp;
 
   sm->ua_txn->upstream_outbound_options.outbound_port = ats_ip_port_host_order(addr);
-  sm->ua_txn->set_outbound_ip(IpAddr(addr));
+  sm->ua_txn->set_outbound_ip(swoc::IPAddr(addr));
   return TS_SUCCESS;
 }
 

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1939,16 +1939,16 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   /* Set up the machine with the outbound address if that's set,
      or the inbound address if set, otherwise let it default.
   */
-  IpEndpoint machine_addr;
+  swoc::IPEndpoint machine_addr;
   ink_zero(machine_addr);
-  if (HttpConfig::m_master.outbound_ip4.isValid()) {
-    machine_addr.assign(HttpConfig::m_master.outbound_ip4);
-  } else if (HttpConfig::m_master.outbound_ip6.isValid()) {
-    machine_addr.assign(HttpConfig::m_master.outbound_ip6);
-  } else if (HttpConfig::m_master.inbound_ip4.isValid()) {
-    machine_addr.assign(HttpConfig::m_master.inbound_ip4);
-  } else if (HttpConfig::m_master.inbound_ip6.isValid()) {
-    machine_addr.assign(HttpConfig::m_master.inbound_ip6);
+  if (HttpConfig::m_master.outbound.has_ip4()) {
+    machine_addr.assign(HttpConfig::m_master.outbound.ip4());
+  } else if (HttpConfig::m_master.outbound.has_ip6()) {
+    machine_addr.assign(HttpConfig::m_master.outbound.ip6());
+  } else if (HttpConfig::m_master.inbound.has_ip4()) {
+    machine_addr.assign(HttpConfig::m_master.inbound.ip4());
+  } else if (HttpConfig::m_master.inbound.has_ip6()) {
+    machine_addr.assign(HttpConfig::m_master.inbound.ip6());
   }
   char *hostname = REC_ConfigReadString("proxy.config.log.hostname");
   if (hostname != nullptr && std::string_view(hostname) == "localhost") {

--- a/src/tscpp/util/ts_ip.cc
+++ b/src/tscpp/util/ts_ip.cc
@@ -30,6 +30,18 @@
 
 namespace ts
 {
+IPAddrPair::self_type &
+IPAddrPair::operator+=(const IPAddrPair::self_type &that)
+{
+  if (that.has_ip4()) {
+    _ip4 = that._ip4;
+  }
+  if (that.has_ip6()) {
+    _ip6 = that._ip6;
+  }
+  return *this;
+}
+
 IPAddrPair
 getbestaddrinfo(swoc::TextView name)
 {


### PR DESCRIPTION
First steps to updating "RecHttp.cc" to libswoc which will also remove another use of `IpMap`.

This is going to involve some ugly shimming between old IP support and libswoc, but that's temporary and better than the incredibly massive (and likely not debuggable) PR to change this everywhere all at once.