### PR TITLE
Adds the AR env variable to config.nice

### DIFF
--- a/build/common.m4
+++ b/build/common.m4
@@ -40,6 +40,15 @@ EOF
   if test -n "$LD"; then
     echo "LD=\"$LD\"; export LD" >> $1
   fi
+  if test -n "$AR"; then
+    echo "AR=\"$AR\"; export AR" >> $1
+  fi
+  if test -n "$RANLIB"; then
+    echo "RANLIB=\"$RANLIB\"; export RANLIB" >> $1
+  fi
+  if test -n "NM"; then
+    echo "NM=\"$NM\"; export NM" >> $1
+  fi
   if test -n "$CFLAGS"; then
     echo "CFLAGS=\"$CFLAGS\"; export CFLAGS" >> $1
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -2446,6 +2446,9 @@ AC_MSG_NOTICE([Build option summary:
     CXX:                $CXX
     CPP:                $CPP
     LD:                 $LD
+    AR:                 $AR
+    RANLIB:             $RANLIB
+    NM:                 $NM
     CFLAGS:             $CFLAGS
     CXXFLAGS:           $CXXFLAGS
     CPPFLAGS:           $CPPFLAGS


### PR DESCRIPTION
This is useful when using custom compile tool chains, and the "ar" that comes with the system may be different or too old. For example, when compiling with LTO and a custom LLVM compiler.