### PR TITLE
Fix .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -11,8 +11,8 @@ github:
     - cdn
     - cache
     - apache
-    - http/2
-    - http/3
+    - http2
+    - http3
     - quic
     - forwardproxy
     - reverseproxy


### PR DESCRIPTION
> An error occurred while running github feature in .asf.yaml!:
.asf.yaml: Invalid GitHub label 'http/2' - must be lowercase alphanumerical and <= 35 characters!

"label", which is officially called "topic" on GitHub, is used like this, so we can't have "/" in it. 
> https://github.com/topics/proxy

And a couple of implementations I know use "http2" and "http3". We should just follow it.

