### PR TITLE
prefetch: add --two-tier option with header to deprecate --front

### DIFF
--- a/plugins/prefetch/configs.cc
+++ b/plugins/prefetch/configs.cc
@@ -46,6 +46,12 @@ isTrue(const char *arg)
   return (0 == strncasecmp("true", arg, 4) || 0 == strncasecmp("1", arg, 1) || 0 == strncasecmp("yes", arg, 3));
 }
 
+inline static char const *const
+stringForBool(bool val)
+{
+  return val ? "true" : "false";
+}
+
 /**
  * @brief initializes plugin configuration.
  * @param argc number of plugin parameters
@@ -56,8 +62,10 @@ PrefetchConfig::init(int argc, char *argv[])
 {
   static const struct option longopt[] = {
     {const_cast<char *>("front"),              optional_argument, nullptr, 'f'},
+    {const_cast<char *>("two-tier"),           required_argument, nullptr, 'w'},
     {const_cast<char *>("api-header"),         optional_argument, nullptr, 'h'},
     {const_cast<char *>("cmcd-nor"),           optional_argument, nullptr, 'd'},
+    {const_cast<char *>("tier-header"),        required_argument, nullptr, 't'},
     {const_cast<char *>("next-header"),        optional_argument, nullptr, 'n'},
     {const_cast<char *>("fetch-policy"),       optional_argument, nullptr, 'p'},
     {const_cast<char *>("fetch-count"),        optional_argument, nullptr, 'c'},
@@ -94,12 +102,20 @@ PrefetchConfig::init(int argc, char *argv[])
       _front = ::isTrue(optarg);
       break;
 
+    case 'w': /* --two-tier */
+      _two_tier = ::isTrue(optarg);
+      break;
+
     case 'h': /* --api-header */
       setApiHeader(optarg);
       break;
 
     case 'd': /* --cmcd-nor */
       _cmcd_nor = ::isTrue(optarg);
+      break;
+
+    case 't': /* --tier-header */
+      setTierHeader(optarg);
       break;
 
     case 'n': /* --next-header */
@@ -169,11 +185,13 @@ PrefetchConfig::init(int argc, char *argv[])
 bool
 PrefetchConfig::finalize()
 {
-  PrefetchDebug("front-end: %s", (_front ? "true" : "false"));
-  PrefetchDebug("exact match: %s", (_exactMatch ? "true" : "false"));
+  PrefetchDebug("front-end: %s", stringForBool(_front));
+  PrefetchDebug("two-tier: %s", stringForBool(_two_tier));
+  PrefetchDebug("exact match: %s", stringForBool(_exactMatch));
   PrefetchDebug("query key: %s", _queryKey.c_str());
   PrefetchDebug("cncd-nor: %s", (_front ? "true" : "false"));
   PrefetchDebug("API header name: %s", _apiHeader.c_str());
+  PrefetchDebug("tier header name: %s", _tierHeader.c_str());
   PrefetchDebug("next object header name: %s", _nextHeader.c_str());
   PrefetchDebug("fetch policy parameters: %s", _fetchPolicy.c_str());
   PrefetchDebug("fetch count: %d", _fetchCount);

--- a/plugins/prefetch/configs.h
+++ b/plugins/prefetch/configs.h
@@ -36,6 +36,7 @@ class PrefetchConfig
 public:
   PrefetchConfig()
     : _apiHeader("X-CDN-Prefetch"),
+      _tierHeader("X-CDN-Prefetch-Tier"), // seen by front 2tier
       _nextHeader("X-CDN-Prefetch-Next"),
       _replaceHost(),
       _namespace("default"),
@@ -61,6 +62,18 @@ public:
   getApiHeader() const
   {
     return _apiHeader;
+  }
+
+  void
+  setTierHeader(const char *optarg)
+  {
+    _tierHeader.assign(optarg);
+  }
+
+  const std::string &
+  getTierHeader() const
+  {
+    return _tierHeader;
   }
 
   void
@@ -103,6 +116,12 @@ public:
   isFront() const
   {
     return _front;
+  }
+
+  bool
+  isTwoTier() const
+  {
+    return _two_tier;
   }
 
   bool
@@ -203,6 +222,7 @@ public:
 
 private:
   std::string _apiHeader;
+  std::string _tierHeader;
   std::string _nextHeader;
   std::string _fetchPolicy;
   std::string _replaceHost;
@@ -213,6 +233,7 @@ private:
   unsigned _fetchCount = 1;
   unsigned _fetchMax   = 0;
   bool _front          = false;
+  bool _two_tier       = false;
   bool _exactMatch     = false;
   bool _cmcd_nor       = false;
   MultiPattern _nextPaths;

--- a/plugins/prefetch/fetch.cc
+++ b/plugins/prefetch/fetch.cc
@@ -518,7 +518,7 @@ BgFetch::init(TSMBuffer reqBuffer, TSMLoc reqHdrLoc, TSHttpTxn txnp, const char 
 
   /* Now set or remove the prefetch API header */
   const String &apiHeader = _config.getApiHeader();
-  bool const hasApiHeader = headerExist(_mbuf, _headerLoc, apiHeader.data(), apiHeader.length());
+  const bool hasApiHeader = headerExist(_mbuf, _headerLoc, apiHeader.data(), apiHeader.length());
 
   if (hasApiHeader) {
     if (removeHeader(_mbuf, _headerLoc, apiHeader.c_str(), apiHeader.length())) {

--- a/plugins/prefetch/headers.cc
+++ b/plugins/prefetch/headers.cc
@@ -120,37 +120,6 @@ getHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, char
 }
 
 /**
- * @brief Get the header value int
- *
- * @param bufp request's buffer
- * @param hdrLoc request's header location
- * @param header header name
- * @param headerlen header name length
- * @param value buffer for the value
- * @param valuelen length of the buffer for the value
- * @return pointer to the string with the value.
- */
-int
-getHeaderInt(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
-{
-  int val = 0;
-
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
-  while (TS_NULL_MLOC != fieldLoc) {
-    TSMLoc const next = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
-
-    int count = TSMimeHdrFieldValuesCount(bufp, hdrLoc, fieldLoc);
-    for (int i = 0; i < count && 0 == val; ++i) {
-      val = TSMimeHdrFieldValueIntGet(bufp, hdrLoc, fieldLoc, i);
-    }
-    TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
-    fieldLoc = next;
-  }
-
-  return val;
-}
-
-/**
  * @brief Set a header to a specific value.
  *
  * This will avoid going to through a remove / add sequence in case of an existing header but clean.
@@ -191,59 +160,6 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
       if (first) {
         first = false;
         if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdrLoc, fieldLoc, -1, value, valuelen)) {
-          ret = true;
-        }
-      } else {
-        TSMimeHdrFieldDestroy(bufp, hdrLoc, fieldLoc);
-      }
-      TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
-      fieldLoc = tmp;
-    }
-  }
-
-  return ret;
-}
-
-/**
- * @brief Set a header to a specific value int.
- *
- * This will avoid going to through a remove / add sequence in case of an existing header but clean.
- *
- * @param bufp request's buffer
- * @param hdrLoc request's header location
- * @param header header name
- * @param headerlen header name len
- * @param value the new value
- * @param valuelen length of the value
- * @return true - OK, false - failed
- */
-bool
-setHeaderInt(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, int value)
-{
-  if (!bufp || !hdrLoc || !header || headerlen <= 0) {
-    return false;
-  }
-
-  bool ret        = false;
-  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
-
-  if (TS_NULL_MLOC == fieldLoc) {
-    // No existing header, so create one
-    if (TS_SUCCESS == TSMimeHdrFieldCreateNamed(bufp, hdrLoc, header, headerlen, &fieldLoc)) {
-      if (TS_SUCCESS == TSMimeHdrFieldValueIntSet(bufp, hdrLoc, fieldLoc, -1, value)) {
-        TSMimeHdrFieldAppend(bufp, hdrLoc, fieldLoc);
-        ret = true;
-      }
-      TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
-    }
-  } else {
-    bool first = true;
-
-    while (TS_NULL_MLOC != fieldLoc) {
-      TSMLoc const tmp = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
-      if (first) {
-        first = false;
-        if (TS_SUCCESS == TSMimeHdrFieldValueIntSet(bufp, hdrLoc, fieldLoc, -1, value)) {
           ret = true;
         }
       } else {

--- a/plugins/prefetch/headers.cc
+++ b/plugins/prefetch/headers.cc
@@ -88,8 +88,8 @@ getHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, char
 {
   TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
   char *dst       = value;
-  while (fieldLoc) {
-    TSMLoc next = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
+  while (TS_NULL_MLOC != fieldLoc) {
+    TSMLoc const next = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
 
     int count = TSMimeHdrFieldValuesCount(bufp, hdrLoc, fieldLoc);
     for (int i = 0; i < count; ++i) {
@@ -117,6 +117,37 @@ getHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, char
 
   *valuelen = dst - value;
   return value;
+}
+
+/**
+ * @brief Get the header value int
+ *
+ * @param bufp request's buffer
+ * @param hdrLoc request's header location
+ * @param header header name
+ * @param headerlen header name length
+ * @param value buffer for the value
+ * @param valuelen length of the buffer for the value
+ * @return pointer to the string with the value.
+ */
+int
+getHeaderInt(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen)
+{
+  int val = 0;
+
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+  while (TS_NULL_MLOC != fieldLoc) {
+    TSMLoc const next = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
+
+    int count = TSMimeHdrFieldValuesCount(bufp, hdrLoc, fieldLoc);
+    for (int i = 0; i < count && 0 == val; ++i) {
+      val = TSMimeHdrFieldValueIntGet(bufp, hdrLoc, fieldLoc, i);
+    }
+    TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
+    fieldLoc = next;
+  }
+
+  return val;
 }
 
 /**
@@ -160,6 +191,59 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
       if (first) {
         first = false;
         if (TS_SUCCESS == TSMimeHdrFieldValueStringSet(bufp, hdrLoc, fieldLoc, -1, value, valuelen)) {
+          ret = true;
+        }
+      } else {
+        TSMimeHdrFieldDestroy(bufp, hdrLoc, fieldLoc);
+      }
+      TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
+      fieldLoc = tmp;
+    }
+  }
+
+  return ret;
+}
+
+/**
+ * @brief Set a header to a specific value int.
+ *
+ * This will avoid going to through a remove / add sequence in case of an existing header but clean.
+ *
+ * @param bufp request's buffer
+ * @param hdrLoc request's header location
+ * @param header header name
+ * @param headerlen header name len
+ * @param value the new value
+ * @param valuelen length of the value
+ * @return true - OK, false - failed
+ */
+bool
+setHeaderInt(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, int value)
+{
+  if (!bufp || !hdrLoc || !header || headerlen <= 0) {
+    return false;
+  }
+
+  bool ret        = false;
+  TSMLoc fieldLoc = TSMimeHdrFieldFind(bufp, hdrLoc, header, headerlen);
+
+  if (TS_NULL_MLOC == fieldLoc) {
+    // No existing header, so create one
+    if (TS_SUCCESS == TSMimeHdrFieldCreateNamed(bufp, hdrLoc, header, headerlen, &fieldLoc)) {
+      if (TS_SUCCESS == TSMimeHdrFieldValueIntSet(bufp, hdrLoc, fieldLoc, -1, value)) {
+        TSMimeHdrFieldAppend(bufp, hdrLoc, fieldLoc);
+        ret = true;
+      }
+      TSHandleMLocRelease(bufp, hdrLoc, fieldLoc);
+    }
+  } else {
+    bool first = true;
+
+    while (TS_NULL_MLOC != fieldLoc) {
+      TSMLoc const tmp = TSMimeHdrFieldNextDup(bufp, hdrLoc, fieldLoc);
+      if (first) {
+        first = false;
+        if (TS_SUCCESS == TSMimeHdrFieldValueIntSet(bufp, hdrLoc, fieldLoc, -1, value)) {
           ret = true;
         }
       } else {

--- a/plugins/prefetch/headers.h
+++ b/plugins/prefetch/headers.h
@@ -27,9 +27,6 @@ int removeHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 bool headerExist(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 
 char *getHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int headerlen, char *value, int *valuelen);
-int getHeaderInt(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int headerlen);
-
 bool setHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const char *val, int val_len);
-bool setHeaderInt(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, int const val);
 
 void dumpHeaders(TSMBuffer bufp, TSMLoc hdr_loc);

--- a/plugins/prefetch/headers.h
+++ b/plugins/prefetch/headers.h
@@ -25,7 +25,11 @@
 
 int removeHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 bool headerExist(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
+
 char *getHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int headerlen, char *value, int *valuelen);
+int getHeaderInt(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int headerlen);
 
 bool setHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const char *val, int val_len);
+bool setHeaderInt(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, int const val);
+
 void dumpHeaders(TSMBuffer bufp, TSMLoc hdr_loc);

--- a/plugins/prefetch/plugin.cc
+++ b/plugins/prefetch/plugin.cc
@@ -838,24 +838,24 @@ TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   PrefetchInstance *inst = static_cast<PrefetchInstance *>(instance);
 
   if (nullptr != inst) {
-    TSMBuffer const reqBuf = rri->requestBufp;
-    TSMLoc const reqHdr    = rri->requestHdrp;
+    const TSMBuffer reqBuf = rri->requestBufp;
+    const TSMLoc reqHdr    = rri->requestHdrp;
 
     PrefetchConfig &config = inst->_config;
 
     int methodLen      = 0;
     const char *method = TSHttpHdrMethodGet(reqBuf, reqHdr, &methodLen);
     if (nullptr != method && methodLen == TS_HTTP_LEN_GET && 0 == memcmp(TS_HTTP_METHOD_GET, method, TS_HTTP_LEN_GET)) {
-      bool const twotier = config.isTwoTier();
+      const bool twotier = config.isTwoTier();
       bool front         = config.isFront();
       bool firstPass     = true;
 
-      String const &apiHeader = config.getApiHeader();
-      bool const hasApiHeader = headerExist(reqBuf, reqHdr, apiHeader.c_str(), apiHeader.length());
+      const String &apiHeader = config.getApiHeader();
+      const bool hasApiHeader = headerExist(reqBuf, reqHdr, apiHeader.c_str(), apiHeader.length());
 
       /* two tier configuration trumps front configuration */
       if (twotier) {
-        String const &tierHeader = config.getTierHeader();
+        const String &tierHeader = config.getTierHeader();
         front                    = !headerExist(reqBuf, reqHdr, tierHeader.data(), tierHeader.length());
       }
 

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_cmcd0.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_cmcd0.gold
@@ -1,13 +1,13 @@
-http://ts0/tests/request.txt 200 TCP_MISS FIN 33 -
-http://ts0/tests/request.txt 200 TCP_HIT - 33 -
-http://ts0/tests/prefetch.txt 200 TCP_MISS - 16 tests/request.txt
-http://ts0/tests/prefetch.txt 200 TCP_MISS FIN 34 -
-http://ts0/tests/request.txt 200 ``_HIT - 33 -
-http://ts0/tests/prefetch.txt 208 TCP_HIT - 20 tests/request.txt
-http://ts0/tests/prefetch.txt 200 ``_HIT - 34 -
-http://ts0/tests/query?this=foo&that 200 TCP_MISS FIN 41 -
-http://ts0/tests/query?bar=baz 200 TCP_MISS - 16 tests/query
-http://ts0/tests/query?bar=baz 200 TCP_MISS FIN 35 -
-http://ts0/root.txt 200 TCP_MISS FIN 30 -
-http://ts0/rooted 200 TCP_MISS - 16 root.txt
-http://ts0/crr.txt 404 TCP_MISS - 5 -
+http://ts0/tests/request.txt 200 TCP_MISS FIN 33 - -
+http://ts0/tests/request.txt 200 TCP``_HIT - 33 - -
+http://ts0/tests/prefetch.txt 200 TCP_MISS - 16 tests/prefetch.txt backend
+http://ts0/tests/prefetch.txt 200 TCP_MISS FIN 34 - -
+http://ts0/tests/request.txt 200 TCP``_HIT - 33 - -
+http://ts0/tests/prefetch.txt 208 TCP``_HIT - 20 tests/prefetch.txt -
+http://ts0/tests/prefetch.txt 200 TCP``_HIT - 34 - -
+http://ts0/tests/query?this=foo&that 200 TCP_MISS FIN 41 - -
+http://ts0/tests/query?bar=baz 200 TCP_MISS - 16 tests/query?bar=baz backend
+http://ts0/tests/query?bar=baz 200 TCP_MISS FIN 35 - -
+http://ts0/root.txt 200 TCP_MISS FIN 30 - -
+http://ts0/rooted 200 TCP_MISS - 16 rooted backend
+http://ts0/crr.txt 404 TCP_MISS - 5 - -

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_cmcd1.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_cmcd1.gold
@@ -1,12 +1,12 @@
-http://ts1:``/tests/request.txt 200 TCP_MISS FIN 33 -
-http://ts1:``/tests/prefetch.txt 200 TCP_MISS - 16 tests/request.txt
-http://ts1:``/tests/prefetch.txt 200 TCP_MISS FIN 34 -
-http://ts1:``/tests/prefetch.txt 200 TCP_HIT - 34 -
-http://ts1:``/tests/query?this=foo&that 200 TCP_MISS FIN 41 -
-http://ts1:``/tests/query?bar=baz 200 TCP_MISS - 16 tests/query
-http://ts1:``/tests/query?bar=baz 200 TCP_MISS FIN 35 -
-http://ts1:``/tests/query?bar=baz 200 TCP_HIT - 35 -
-http://ts1:``/root.txt 200 TCP_MISS FIN 30 -
-http://ts1:``/rooted 200 TCP_MISS - 16 root.txt
-http://ts1:``/rooted 200 TCP_MISS FIN 28 -
-http://ts1:``/crr.txt 404 TCP_MISS - 5 -
+http://ts1:``/tests/request.txt 200 TCP_MISS FIN 33  - -
+http://ts1:``/tests/prefetch.txt 200 TCP_MISS - 16  tests/prefetch.txt backend
+http://ts1:``/tests/prefetch.txt 200 TCP_MISS FIN 34  - -
+http://ts1:``/tests/prefetch.txt 200 TCP``_HIT - 34  - -
+http://ts1:``/tests/query?this=foo&that 200 TCP_MISS FIN 41  - -
+http://ts1:``/tests/query?bar=baz 200 TCP_MISS - 16  tests/query?bar=baz backend
+http://ts1:``/tests/query?bar=baz 200 TCP_MISS FIN 35  - -
+http://ts1:``/tests/query?bar=baz 200 TCP``_HIT - 35  - -
+http://ts1:``/root.txt 200 TCP_MISS FIN 30  - -
+http://ts1:``/rooted 200 TCP_MISS - 16  rooted backend
+http://ts1:``/rooted 200 TCP_MISS FIN 28  - -
+http://ts1:``/crr.txt 404 TCP_MISS - 5  - -

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_fb0.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_fb0.gold
@@ -1,0 +1,2 @@
+test/demo-0.txt 200 TCP_MISS FIN 33 -
+test/demo-1.txt 200 TCP_MISS - 16 test/demo-1.txt

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_fb1.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_fb1.gold
@@ -1,0 +1,3 @@
+test/demo-0.txt 200 TCP_MISS FIN 33 -
+test/demo-1.txt 200 TCP_MISS - 16 test/demo-1.txt
+test/demo-1.txt 200 TCP_MISS FIN 33 -

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_frontback.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_frontback.test.py
@@ -1,0 +1,151 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Test prefetch.so plugin (tiered mode).
+'''
+
+origin = Test.MakeOriginServer("origin")
+for ind in range(2):
+    filename = f"demo-{ind}.txt"
+    request_header = {
+        "headers":
+            f"GET /test/{filename} HTTP/1.1\r\n" +
+            "Host: does.not.matter\r\n" +  # But cannot be omitted.
+            "\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }
+    response_header = {
+        "headers":
+            "HTTP/1.1 200 OK\r\n" +
+            "Connection: close\r\n" +
+            "Cache-control: max-age=85000\r\n" +
+            "\r\n",
+        "timestamp": "1469733493.993",
+        "body": f"This is the body for {filename}.\n"
+    }
+    origin.addResponse("sessionlog.json", request_header, response_header)
+
+# allows for multiple ats on localhost
+dns = Test.MakeDNServer("dns")
+
+# next hop trafficserver instance
+ts1 = Test.MakeATSProcess("ts1")
+ts1.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'prefetch|http',
+    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+    'proxy.config.dns.resolv_conf': "NULL",
+    'proxy.config.http.parent_proxy.self_detect': 0,
+})
+dns.addRecords(records={f"ts1": ["127.0.0.1"]})
+ts1.Disk.remap_config.AddLine(
+    f"map / http://127.0.0.1:{origin.Variables.Port}" +
+    " @plugin=cachekey.so @pparam==--remove-all-params=true"
+    " @plugin=prefetch.so @pparam==--front=false"
+)
+
+ts1.Disk.logging_yaml.AddLines(
+    '''
+logging:
+ formats:
+  - name: custom
+    format: '%<cqup> %<pssc> %<crc> %<cwr> %<pscl> %<{X-CDN-Prefetch}cqh>'
+ logs:
+  - filename: transaction
+    format: custom
+'''.split("\n")
+)
+
+ts0 = Test.MakeATSProcess("ts0")
+ts0.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'prefetch|http',
+    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+    'proxy.config.dns.resolv_conf': "NULL",
+    'proxy.config.http.parent_proxy.self_detect': 0,
+})
+
+dns.addRecords(records={f"ts0": ["127.0.0.1"]})
+ts0.Disk.remap_config.AddLine(
+    f"map http://ts0 http://ts1:{ts1.Variables.port}" +
+    " @plugin=cachekey.so @pparam=--remove-all-params=true"
+    " @plugin=prefetch.so" +
+    " @pparam=--front=true" +
+    " @pparam=--fetch-policy=simple" +
+    r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" +
+    "@pparam=--fetch-count=1"
+)
+
+ts0.Disk.logging_yaml.AddLines(
+    '''
+logging:
+ formats:
+  - name: custom
+    format: '%<cqup> %<pssc> %<crc> %<cwr> %<pscl> %<{X-CDN-Prefetch}cqh>'
+ logs:
+  - filename: transaction
+    format: custom
+'''.split("\n")
+)
+
+
+# start everything up
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(origin)
+tr.Processes.Default.StartBefore(dns)
+tr.Processes.Default.StartBefore(ts0)
+tr.Processes.Default.StartBefore(ts1)
+tr.Processes.Default.Command = 'echo start TS, TSH_N, HTTP origin and DNS.'
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = (
+    f'curl --verbose --proxy 127.0.0.1:{ts0.Variables.port} http://ts0/test/demo-0.txt'
+)
+tr.Processes.Default.ReturnCode = 0
+
+condwaitpath = os.path.join(Test.Variables.AtsTestToolsDir, 'condwait')
+
+# look for ts transaction log
+ts0log = os.path.join(ts0.Variables.LOGDIR, 'transaction.log')
+tr = Test.AddTestRun()
+ps = tr.Processes.Default
+ps.Command = (
+    condwaitpath + ' 60 1 -f ' + ts0log
+)
+
+# look for ts1 transaction log
+ts1log = os.path.join(ts1.Variables.LOGDIR, 'transaction.log')
+tr = Test.AddTestRun()
+ps = tr.Processes.Default
+ps.Command = (
+    condwaitpath + ' 60 1 -f ' + ts1log
+)
+
+tr.Processes.Default.Command = (
+    f"cat {ts0log}"
+)
+tr.Streams.stdout = "prefetch_fb0.gold"
+
+tr.Processes.Default.Command = (
+    f"cat {ts1log}"
+)
+tr.Streams.stdout = "prefetch_fb1.gold"

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_twotier.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_twotier.test.py
@@ -1,0 +1,151 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+Test.Summary = '''
+Test prefetch.so plugin (tiered mode).
+'''
+
+origin = Test.MakeOriginServer("origin")
+for ind in range(2):
+    filename = f"demo-{ind}.txt"
+    request_header = {
+        "headers":
+            f"GET /test/{filename} HTTP/1.1\r\n" +
+            "Host: does.not.matter\r\n" +  # But cannot be omitted.
+            "\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }
+    response_header = {
+        "headers":
+            "HTTP/1.1 200 OK\r\n" +
+            "Connection: close\r\n" +
+            "Cache-control: max-age=85000\r\n" +
+            "\r\n",
+        "timestamp": "1469733493.993",
+        "body": f"This is the body for {filename}.\n"
+    }
+    origin.addResponse("sessionlog.json", request_header, response_header)
+
+# allows for multiple ats on localhost
+dns = Test.MakeDNServer("dns")
+
+# next hop trafficserver instance
+ts1 = Test.MakeATSProcess("ts1")
+ts1.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'prefetch|http',
+    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+    'proxy.config.dns.resolv_conf': "NULL",
+    'proxy.config.http.parent_proxy.self_detect': 0,
+})
+dns.addRecords(records={f"ts1": ["127.0.0.1"]})
+ts1.Disk.remap_config.AddLine(
+    f"map / http://127.0.0.1:{origin.Variables.Port}" +
+    " @plugin=cachekey.so @pparam==--remove-all-params=true"
+    " @plugin=prefetch.so @pparam==--two-tier=true"
+)
+
+ts1.Disk.logging_yaml.AddLines(
+    '''
+logging:
+ formats:
+  - name: custom
+    format: '%<cqup> %<pssc> %<crc> %<cwr> %<pscl> %<{X-CDN-Prefetch}cqh> %<{X-CDN-Prefetch-Tier}cqh>'
+ logs:
+  - filename: transaction
+    format: custom
+'''.split("\n")
+)
+
+ts0 = Test.MakeATSProcess("ts0")
+ts0.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'prefetch|http',
+    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+    'proxy.config.dns.resolv_conf': "NULL",
+    'proxy.config.http.parent_proxy.self_detect': 0,
+})
+
+dns.addRecords(records={f"ts0": ["127.0.0.1"]})
+ts0.Disk.remap_config.AddLine(
+    f"map http://ts0 http://ts1:{ts1.Variables.port}" +
+    " @plugin=cachekey.so @pparam=--remove-all-params=true"
+    " @plugin=prefetch.so" +
+    " @pparam=--two-tier=true" +
+    " @pparam=--fetch-policy=simple" +
+    r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" +
+    "@pparam=--fetch-count=1"
+)
+
+ts0.Disk.logging_yaml.AddLines(
+    '''
+logging:
+ formats:
+  - name: custom
+    format: '%<cqup> %<pssc> %<crc> %<cwr> %<pscl> %<{X-CDN-Prefetch}cqh> %<{X-CDN-Prefetch-Tier}cqh>'
+ logs:
+  - filename: transaction
+    format: custom
+'''.split("\n")
+)
+
+
+# start everything up
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(origin)
+tr.Processes.Default.StartBefore(dns)
+tr.Processes.Default.StartBefore(ts0)
+tr.Processes.Default.StartBefore(ts1)
+tr.Processes.Default.Command = 'echo start TS, TSH_N, HTTP origin and DNS.'
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = (
+    f'curl --verbose --proxy 127.0.0.1:{ts0.Variables.port} http://ts0/test/demo-0.txt'
+)
+tr.Processes.Default.ReturnCode = 0
+
+condwaitpath = os.path.join(Test.Variables.AtsTestToolsDir, 'condwait')
+
+# look for ts transaction log
+ts0log = os.path.join(ts0.Variables.LOGDIR, 'transaction.log')
+tr = Test.AddTestRun()
+ps = tr.Processes.Default
+ps.Command = (
+    condwaitpath + ' 60 1 -f ' + ts0log
+)
+
+# look for ts1 transaction log
+ts1log = os.path.join(ts1.Variables.LOGDIR, 'transaction.log')
+tr = Test.AddTestRun()
+ps = tr.Processes.Default
+ps.Command = (
+    condwaitpath + ' 60 1 -f ' + ts1log
+)
+
+tr.Processes.Default.Command = (
+    f"cat {ts0log}"
+)
+tr.Streams.stdout = "prefetch_twotier0.gold"
+
+tr.Processes.Default.Command = (
+    f"cat {ts1log}"
+)
+tr.Streams.stdout = "prefetch_twotier1.gold"

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_twotier0.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_twotier0.gold
@@ -1,0 +1,2 @@
+test/demo-0.txt 200 TCP_MISS FIN 33 - -
+test/demo-1.txt 200 TCP_MISS - 16 test/demo-1.txt backend

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_twotier1.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_twotier1.gold
@@ -1,0 +1,3 @@
+test/demo-0.txt 200 TCP_MISS FIN 33 - -
+test/demo-1.txt 200 TCP_MISS - 16 test/demo-1.txt backend
+test/demo-1.txt 200 TCP_MISS FIN 33 - -


### PR DESCRIPTION
This adds yet another header to pass along which allows the plugin to detect if its in front or back mode.  This is important when something like edge peering is in play.