### PR TITLE
CryptoContext: Clean up to avoid compiler problem.

### DIFF
--- a/include/tscore/MD5.h
+++ b/include/tscore/MD5.h
@@ -31,7 +31,7 @@
 #include <openssl/evp.h>
 #endif
 
-class MD5Context : public ats::CryptoContextBase
+class MD5Context : public ats::CryptoContext::Hasher
 {
 public:
   MD5Context()
@@ -90,4 +90,4 @@ private:
 #endif
 };
 
-typedef CryptoHash INK_MD5;
+using INK_MD5 = CryptoHash;

--- a/include/tscore/MMH.h
+++ b/include/tscore/MMH.h
@@ -50,7 +50,7 @@ int ink_code_MMH(unsigned char *input, int len, unsigned char *sixteen_byte_hash
   cost.
 
 */
-class MMHContext : public ats::CryptoContextBase
+class MMHContext : public ats::CryptoContext::Hasher
 {
 protected:
   MMH_CTX _ctx;

--- a/include/tscore/SHA256.h
+++ b/include/tscore/SHA256.h
@@ -31,7 +31,7 @@
 #include <openssl/evp.h>
 #endif
 
-class SHA256Context : public ats::CryptoContextBase
+class SHA256Context : public ats::CryptoContext::Hasher
 {
 public:
   SHA256Context()


### PR DESCRIPTION
With commit d07a6acc760350a44be6b47a532a2564080c5926 for #9474 and g++ 12.2.2 on Fedora 36 I get compiler errrors, which is basically this repeatedly.

```
In file included from ink_inet.cc:30:
In destructor 'virtual ats::CryptoContext::~CryptoContext()',
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'virtual ats::CryptoContext::~CryptoContext()' at ../../include/tscore/CryptoHash.h:171:86,
    inlined from 'uint32_t ats_ip_hash(const sockaddr*)' at ink_inet.cc:381:5:
../../include/tscore/CryptoHash.h:171:90: error: array subscript 'ats::CryptoContext[0]' is partly outside array bounds of 'ats::CryptoContext [1]' [-Werror=array-bounds]
  171 |   ~CryptoContext() { reinterpret_cast<CryptoContextBase *>(_base)->~CryptoContextBase(); }
      |                                                                                          ^
ink_inet.cc: In function 'uint32_t ats_ip_hash(const sockaddr*)':
ink_inet.cc:381:19: note: at offset 144 into object '<anonymous>' of size 272
  381 |     CryptoContext().hash_immediate(hash, ats_ip_addr8_cast(addr), TS_IP6_SIZE);
      |                   
```
My opinion is this is a compiler issue, that it's getting confused because the wrapper type is a subclass of the cast type. This causes repeated inlining of the same code, while `array bounds of 'ats::CryptoContext [1]` makes no sense at all, given there is no array of that type.

This fixes the problem by having `CryptoContext` not inherit from the protocol class. That inheritance is unnecessary and adds an extra virtual function call for no benefit. At that point it seems better to move the protocol class inside `CryptoContext` for better scoping.