### PR TITLE
Update to libswoc 1.4.5

### DIFF
--- a/lib/swoc/include/swoc/IPAddr.h
+++ b/lib/swoc/include/swoc/IPAddr.h
@@ -50,7 +50,7 @@ public:
   explicit IP4Addr(sockaddr_in const *s);
 
   /// Construct from text representation.
-  /// If the @a text is invalid the result is an invalid instance.
+  /// If the @a text is invalid the result is @c INADDR_ANY
   IP4Addr(string_view const &text);
 
   /// Self assignment.
@@ -83,8 +83,21 @@ public:
   /// Apply @a mask to address, creating the broadcast address.
   self_type &operator|=(IPMask const &mask);
 
-  /// Write this adddress and @a host_order_port to the sockaddr @a sa.
-  sockaddr_in *copy_to(sockaddr_in *sa, in_port_t port = 0) const;
+  /** Update socket address with this address.
+   *
+   * @param sa Socket address.
+   * @return @sa
+   *
+   * @a sa is assumed to be large enough to hold an IPv4 address.
+   */
+  sockaddr *copy_to(sockaddr *sa) const;
+
+  /** Update socket address with this address.
+   *
+   * @param sin IPv4 socket address.
+   * @return @sin
+   */
+  sockaddr_in *copy_to(sockaddr_in *sin) const;
 
   /// @return The address in network order.
   in_addr_t network_order() const;
@@ -92,11 +105,13 @@ public:
   /// @return The address in host order.
   in_addr_t host_order() const;
 
-  /** Parse @a text as IPv4 address.
-      The address resulting from the parse is copied to this object if the conversion is successful,
-      otherwise this object is invalidated.
-
-      @return @c true on success, @c false otherwise.
+  /** Parse IPv4 address.
+   *
+   * @param text Text to parse.
+   *
+   * @return @c true if @a text is a valid IPv4 address, @c false otherwise.
+   *
+   * Whitespace is trimmed from @text before parsing. If the parse fails @a this is set to @c INADDR_ANY.
   */
   bool load(string_view const &text);
 
@@ -281,14 +296,41 @@ public:
    */
   constexpr uint8_t operator [] (int idx) const;
 
-  /// Write to @c sockaddr using network order and @a host_order_port.
-  sockaddr *copy_to(sockaddr *sa, in_port_t port = 0) const;
+  /** Update socket address with this address.
+   *
+   * @param sin IPv6 socket address.
+   * @return @sin
+   */
+  sockaddr_in6 *copy_to(sockaddr_in6 *sin6) const;
 
-  /// Copy address to @a addr in network order.
-  in6_addr &copy_to(in6_addr &addr) const;
+  /** Update socket address with this address.
+   *
+   * @param sa Socket address.
+   * @return @sin
+   *
+   * @a sa is assumed to be large enough to hold an IPv6 address.
+   */
+  sockaddr *copy_to(sockaddr *sa) const;
+
+  /// Return the address in host order.
+  in6_addr host_order() const;
+
+  /** Copy the address in host order.
+   *
+   * @param dst Destination for host order address.
+   * @return @a dst
+   */
+  in6_addr& host_order(in6_addr & dst) const;
 
   /// Return the address in network order.
   in6_addr network_order() const;
+
+  /** Copy the address in network order.
+   *
+   * @param dst Destination for network order address.
+   * @return @a dst
+   */
+  in6_addr &network_order(in6_addr &dst) const;
 
   /** Parse a string for an IP address.
 
@@ -403,11 +445,13 @@ protected:
   /// These are in sort of host order - @a _store elements are host order, but the
   /// MSW and LSW are swapped (big-endian). This makes various bits of the implementation
   /// easier. Conversion to and from network order is via the @c reorder method.
-  union {
+  union Addr {
     word_store_type _store = {0}; ///< 0 is MSW, 1 is LSW.
     quad_store_type _quad;        ///< By quad.
     raw_type _raw;                ///< By byte.
+    in6_addr _in6;                ///< By networking type (but in host order!)
   } _addr;
+  static_assert(sizeof(in6_addr) == sizeof(raw_type));
 
   static constexpr unsigned LSW = 1; ///< Least significant word index.
   static constexpr unsigned MSW = 0; ///< Most significant word index.
@@ -417,7 +461,7 @@ protected:
   static constexpr std::array<unsigned, N_QUADS> QUAD_IDX = {3, 2, 1, 0, 7, 6, 5, 4};
 
   /// Index of bytes in @a _addr._raw
-  /// This converts MSB (0) to LSB (15) indicies to the bytes in the binary format.
+  /// This converts MSB (0) to LSB (15) indices to the bytes in the binary format.
   static constexpr std::array<unsigned, SIZE> RAW_IDX = { 7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8 };
 
   /// Convert between network and host order.
@@ -515,6 +559,13 @@ public:
   self_type &operator&=(IPMask const &mask);
 
   self_type &operator|=(IPMask const &mask);
+
+  /** Copy the address to a socket address.
+   *
+   * @param sa Destination.
+   * @return @a sa
+   */
+  sockaddr * copy_to(sockaddr * sa);
 
   /** Parse a string and load the result in @a this.
    *
@@ -764,6 +815,12 @@ IP4Addr::operator=(in_addr_t ip) -> self_type & {
   return *this;
 }
 
+inline sockaddr *
+IP4Addr::copy_to(sockaddr *sa) const {
+  this->copy_to(reinterpret_cast<sockaddr_in*>(sa));
+  return sa;
+}
+
 /// Equality.
 inline bool
 operator==(IP4Addr const &lhs, IP4Addr const &rhs) {
@@ -909,16 +966,30 @@ inline bool IP6Addr::is_private() const {
   return (_addr._raw[RAW_IDX[0]]& 0xFE) == 0xFC; // fc00::/7
 }
 
+inline in6_addr
+IP6Addr::host_order() const {
+  Addr zret { {_addr._store[LSW], _addr._store[MSW] }};
+  return zret._in6;
+}
+
 inline in6_addr &
-IP6Addr::copy_to(in6_addr &addr) const {
-  self_type::reorder(addr, _addr._raw);
-  return addr;
+IP6Addr::host_order(in6_addr & dst) const {
+  Addr * addr = reinterpret_cast<Addr*>(&dst);
+  addr->_store[0] = _addr._store[LSW];
+  addr->_store[1] = _addr._store[MSW];
+  return dst;
 }
 
 inline in6_addr
 IP6Addr::network_order() const {
   in6_addr zret;
-  return this->copy_to(zret);
+  return this->network_order(zret);
+}
+
+inline in6_addr &
+IP6Addr::network_order(in6_addr & dst) const {
+  self_type::reorder(dst, _addr._raw);
+  return dst;
 }
 
 inline auto
@@ -1002,6 +1073,12 @@ operator<=(IP6Addr const &lhs, IP6Addr const &rhs) {
 inline bool
 operator>=(IP6Addr const &lhs, IP6Addr const &rhs) {
   return rhs <= lhs;
+}
+
+inline sockaddr *
+IP6Addr::copy_to(sockaddr *sa) const {
+  this->copy_to(reinterpret_cast<sockaddr_in6*>(sa));
+  return sa;
 }
 
 inline IP6Addr &

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <string_view>
+#include <variant> // for std::monostate
+
 #include <swoc/DiscreteRange.h>
 #include <swoc/IPAddr.h>
 

--- a/lib/swoc/src/swoc_ip.cc
+++ b/lib/swoc/src/swoc_ip.cc
@@ -66,22 +66,62 @@ IPEndpoint::assign(sockaddr *dst, sockaddr const *src) {
 }
 
 IPEndpoint &
-IPEndpoint::assign(IPAddr const &src, in_port_t port) {
+IPEndpoint::assign(IP4Addr const &addr) {
+  memset(&sa4, 0, sizeof sa4);
+  sa4.sin_family      = AF_INET;
+  sa4.sin_addr.s_addr = addr.network_order();
+  Set_Sockaddr_Len(&sa4);
+  return *this;
+}
+
+IPEndpoint &
+IPEndpoint::assign(IP6Addr const &addr) {
+  memset(&sa6, 0, sizeof sa6);
+  sa6.sin6_family = AF_INET6;
+  addr.network_order(sa6.sin6_addr);
+  Set_Sockaddr_Len(&sa6);
+  return *this;
+}
+
+IPEndpoint &
+IPEndpoint::assign(IPAddr const &src) {
   switch (src.family()) {
   case AF_INET: {
     memset(&sa4, 0, sizeof sa4);
     sa4.sin_family      = AF_INET;
     sa4.sin_addr.s_addr = src.ip4().network_order();
-    sa4.sin_port        = port;
     Set_Sockaddr_Len(&sa4);
   } break;
   case AF_INET6: {
     memset(&sa6, 0, sizeof sa6);
     sa6.sin6_family = AF_INET6;
     sa6.sin6_addr   = src.ip6().network_order();
-    sa6.sin6_port   = port;
     Set_Sockaddr_Len(&sa6);
   } break;
+  }
+  return *this;
+}
+
+IPEndpoint &
+IPEndpoint::assign(IPSrv const &src) {
+  switch (src.family()) {
+  case AF_INET:
+    memset(&sa4, 0, sizeof sa4);
+    sa4.sin_family      = AF_INET;
+    sa4.sin_addr.s_addr = src.ip4().addr().network_order();
+    sa4.sin_port        = src.network_order_port();
+    Set_Sockaddr_Len(&sa4);
+    break;
+  case AF_INET6:
+    memset(&sa6, 0, sizeof sa6);
+    sa6.sin6_family = AF_INET6;
+    sa6.sin6_addr   = src.ip6().addr().network_order();
+    sa6.sin6_port   = src.network_order_port();
+    Set_Sockaddr_Len(&sa6);
+    break;
+  default:
+    memset(&sa, 0, sizeof sa);
+    sa.sa_family = AF_UNSPEC;
   }
   return *this;
 }
@@ -146,24 +186,9 @@ IPEndpoint::tokenize(std::string_view str, std::string_view *addr, std::string_v
 
 bool
 IPEndpoint::parse(std::string_view const &str) {
-  TextView addr_str, port_str, rest;
-  TextView src{TextView{str}.trim_if(&isspace)};
-
-  if (this->tokenize(src, &addr_str, &port_str, &rest)) {
-    if (rest.empty()) {
-      if (IPAddr addr; addr.load(addr_str)) {
-        in_port_t port = 0;
-        if (!port_str.empty()) {
-          uintmax_t n{swoc::svto_radix<10>(port_str)};
-          if (!port_str.empty() || n > std::numeric_limits<in_port_t>::max()) {
-            return false;
-          }
-          port = n;
-        }
-        this->assign(addr, htons(port));
-        return true;
-      }
-    }
+  if (IPSrv srv; srv.load(TextView(str).trim_if(&isspace))) {
+    this->assign(srv);
+    return true;
   }
   return false;
 }
@@ -261,6 +286,7 @@ IP4Addr::load(std::string_view const &text) {
   _addr = INADDR_ANY; // clear to zero.
 
   // empty or trailing dot or empty brackets or unmatched brackets.
+  src.trim_if(&isspace);
   if (src.empty() || src.back() == '.' || ('[' == *src && ((++src).empty() || src.back() != ']'))) {
     return false;
   }
@@ -305,20 +331,21 @@ IP4Addr::operator=(sockaddr_in const *sa) -> self_type & {
 }
 
 sockaddr_in *
-IP4Addr::copy_to(sockaddr_in *sa, in_port_t port) const {
-  sa->sin_addr.s_addr = this->network_order();
-  sa->sin_port        = port;
-  return sa;
+IP4Addr::copy_to(sockaddr_in *sin) const {
+  sin->sin_family = AF_INET;
+  sin->sin_addr.s_addr = this->network_order();
+  Set_Sockaddr_Len(sin);
+  return sin;
 }
 
 // --- IPv6
 
-sockaddr *
-IP6Addr::copy_to(sockaddr *sa, in_port_t port) const {
-  IPEndpoint addr(sa);
-  self_type::reorder(addr.sa6.sin6_addr, _addr._raw);
-  addr.network_order_port() = port;
-  return sa;
+sockaddr_in6 *
+IP6Addr::copy_to(sockaddr_in6 *sin6) const {
+  sin6->sin6_family = AF_INET6;
+  self_type::reorder(sin6->sin6_addr, _addr._raw);
+  Set_Sockaddr_Len(sin6);
+  return sin6;
 }
 
 int
@@ -377,6 +404,7 @@ IP6Addr::load(std::string_view const &str) {
   int empty_idx = -1;
   auto quad     = _addr._quad.data();
 
+  src.trim_if(&isspace);
   if (src && '[' == *src) {
     ++src;
     if (src.empty() || src.back() != ']') {
@@ -472,6 +500,16 @@ IPAddr::IPAddr(IPEndpoint const &addr) {
 IPAddr &
 IPAddr::operator=(IPEndpoint const &addr) {
   return this->assign(&addr.sa);
+}
+
+sockaddr *
+IPAddr::copy_to(sockaddr *sa) {
+  if (this->is_ip4()) {
+    _addr._ip4.copy_to(sa);
+  } else if (this->is_ip6()) {
+    _addr._ip6.copy_to(sa);
+  }
+  return sa;
 }
 
 bool


### PR DESCRIPTION
This has a number of IP support improvements, driven by work to replace the current IP networking support with libswoc. Primarily this is better conversions between IP data types.

This also adds `bwappend` which is `bwprint` except it appends instead of replacing.