### PR TITLE
Fix compile warning on BoringSSL build

### DIFF
--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -130,7 +130,7 @@ stapling_get_issuer(SSL_CTX *ssl_ctx, X509 *x)
     goto end;
   }
 
-  for (int i = 0; i < sk_X509_num(extra_certs); i++) {
+  for (int i = 0; i < static_cast<int>(sk_X509_num(extra_certs)); i++) {
     issuer = sk_X509_value(extra_certs, i);
     if (X509_check_issued(issuer, x) == X509_V_OK) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000


### PR DESCRIPTION
Same as code below:
https://github.com/apache/trafficserver/blob/c54a2e2b77151869ff014fbdc4c82cec0afcbb8c/tests/tools/plugins/ssl_client_verify_test.cc#L116-L117