### PR TITLE
Remove premature context updates in TSSslSecretSet().

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -9436,13 +9436,11 @@ TSSslSecretSet(const char *secret_name, int secret_name_length, const char *secr
   if (load_params != nullptr) { // Update the current data structure
     Debug("ssl.cert_update", "Setting secrets in SSLConfig load for: %.*s", secret_name_length, secret_name);
     load_params->secrets.setSecret(secret_name_str, std::string_view(secret_data, secret_data_len));
-    load_params->updateCTX(secret_name_str);
     SSLConfig::load_release(load_params);
   }
   if (params != nullptr) {
     Debug("ssl.cert_update", "Setting secrets in SSLConfig for: %.*s", secret_name_length, secret_name);
     params->secrets.setSecret(secret_name_str, std::string_view(secret_data, secret_data_len));
-    params->updateCTX(secret_name_str);
     SSLConfig::release(params);
   }
   return retval;


### PR DESCRIPTION
This PR partially reverts PR #8368.  SSL contexts (SSL_CTX) should only be updated by TSSslSecretUpdate() (which is only called for the main, not the related secret).  The update in TSSslSecretSet() is not merely redundant, it causes errors.  When an update is done, OpenSSL will check that the cert public key matches the private key.  Since TSSslSecretSet() can only set one at time, if it also updates, they will not match.

Contexts for a loading confguration never have to be updated, becasue no SSL_CTX's have been created using it yet.