### PR TITLE
Remove IpMap dependency from NetVConnection infrastructure.

### DIFF
--- a/include/records/I_RecHttp.h
+++ b/include/records/I_RecHttp.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
+#include "swoc/swoc_ip.h"
+
 #include "tscore/ink_inet.h"
 #include "tscpp/util/ts_ip.h"
 #include "tscore/ink_resolver.h"
 #include "ts/apidefs.h"
 #include "ts/apidefs.h"
 #include "tscore/ink_assert.h"
-#include "tscore/IpMap.h"
 #include "tscore/MemArena.h"
 #include <algorithm>
 #include <array>
@@ -42,9 +43,13 @@
 ts::IPAddrPair RecHttpLoadIp(char const *name);
 
 /// Load up an IpMap with IP addresses from the configuration file.
-void RecHttpLoadIpMap(const char *name, ///< Name of value in configuration file.
-                      IpMap &ipmap      ///< [out] IpMap.
-);
+
+/** Load a se of IP address from a configuration variable.
+ *
+ * @param name Variable name
+ * @param addrs Destination address set.
+ */
+void RecHttpLoadIpAddrsFromConfVar(const char *name, swoc::IPRangeSet &addrs);
 
 /** A set of session protocols.
     This depends on using @c SessionProtocolNameRegistry to get the indices.

--- a/include/records/I_RecHttp.h
+++ b/include/records/I_RecHttp.h
@@ -44,7 +44,7 @@ ts::IPAddrPair RecHttpLoadIp(char const *name);
 
 /// Load up an IpMap with IP addresses from the configuration file.
 
-/** Load a se of IP address from a configuration variable.
+/** Load a set of IP address from a configuration variable.
  *
  * @param name Variable name
  * @param addrs Destination address set.

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include "tscore/IpMap.h"
 #include "I_EventSystem.h"
 #include "I_Socks.h"
 #include "I_NetVConnection.h"

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -30,15 +30,16 @@
  ****************************************************************************/
 #pragma once
 
+#include "swoc/TextView.h"
+#include "swoc/swoc_ip.h"
+
 #include "I_EventSystem.h"
 #include "P_SSLNextProtocolAccept.h"
 #include "P_SSLNetVConnection.h"
 #include "SNIActionPerformer.h"
 #include "SSLTypes.h"
-#include "swoc/TextView.h"
 
 #include "tscore/ink_inet.h"
-#include "swoc/TextView.h"
 
 #include <vector>
 
@@ -337,7 +338,7 @@ public:
 
 class SNI_IpAllow : public ActionItem
 {
-  IpMap ip_map;
+  swoc::IPRangeSet ip_addrs;
 
 public:
   SNI_IpAllow(std::string &ip_allow_list, const std::string &servername);

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -34,8 +34,9 @@
 
 #include <openssl/rand.h>
 
+#include "swoc/swoc_ip.h"
+
 #include "tscore/ink_inet.h"
-#include "tscore/IpMap.h"
 
 #include "ConfigProcessor.h"
 
@@ -137,7 +138,7 @@ struct SSLConfigParams : public ConfigInfo {
   static size_t session_cache_max_bucket_size;
   static bool session_cache_skip_on_lock_contention;
 
-  static IpMap *proxy_protocol_ipmap;
+  static swoc::IPRangeSet *proxy_protocol_ip_addrs;
 
   static init_ssl_ctx_func init_ssl_ctx_cb;
   static load_ssl_file_func load_ssl_file_cb;
@@ -171,7 +172,7 @@ struct SSLConfigParams : public ConfigInfo {
   void initialize();
   void cleanup();
   void reset();
-  void SSLConfigInit(IpMap *global);
+  void SSLConfigInit(swoc::IPRangeSet *global);
 
 private:
   // c_str() of string passed to in-progess call to updateCTX().

--- a/iocore/net/SNIActionPerformer.cc
+++ b/iocore/net/SNIActionPerformer.cc
@@ -21,10 +21,12 @@
   limitations under the License.
  */
 
-#include "P_SNIActionPerformer.h"
 #include "swoc/swoc_file.h"
 #include "swoc/BufferWriter.h"
 #include "swoc/bwf_std.h"
+#include "swoc/bwf_ip.h"
+
+#include "P_SNIActionPerformer.h"
 
 SNI_IpAllow::SNI_IpAllow(std::string &ip_allow_list, std::string const &servername)
 {
@@ -48,20 +50,17 @@ SNI_IpAllow::SNI_IpAllow(std::string &ip_allow_list, std::string const &serverna
 void
 SNI_IpAllow::load(swoc::TextView content, swoc::TextView server_name)
 {
-  IpAddr addr1;
-  IpAddr addr2;
   static constexpr swoc::TextView delim{",\n"};
-  static void *MARK{reinterpret_cast<void *>(1)};
 
   while (!content.ltrim(delim).empty()) {
-    swoc::TextView list{content.take_prefix_at(delim)};
-    if (0 != ats_ip_range_parse(list, addr1, addr2)) {
-      Debug("ssl_sni", "%.*s is not a valid format", static_cast<int>(list.size()), list.data());
+    swoc::TextView token{content.take_prefix_at(delim)};
+    if (swoc::IPRange r; r.load(token)) {
+      Debug("ssl_sni", "%.*s is not a valid format", static_cast<int>(token.size()), token.data());
       break;
     } else {
-      Debug("ssl_sni", "%.*s added to the ip_allow list %.*s", static_cast<int>(list.size()), list.data(), int(server_name.size()),
-            server_name.data());
-      ip_map.fill(IpEndpoint().assign(addr1), IpEndpoint().assign(addr2), MARK);
+      Debug("ssl_sni", "%.*s added to the ip_allow token %.*s", static_cast<int>(token.size()), token.data(),
+            int(server_name.size()), server_name.data());
+      ip_addrs.fill(r);
     }
   }
 }
@@ -70,20 +69,20 @@ int
 SNI_IpAllow::SNIAction(TLSSNISupport *snis, ActionItem::Context const &ctx) const
 {
   // i.e, ip filtering is not required
-  if (ip_map.count() == 0) {
+  if (ip_addrs.count() == 0) {
     return SSL_TLSEXT_ERR_OK;
   }
 
   auto ssl_vc = dynamic_cast<SSLNetVConnection *>(snis);
-  auto ip     = ssl_vc->get_remote_endpoint();
+  auto ip     = swoc::IPAddr(ssl_vc->get_remote_endpoint());
 
   // check the allowed ips
-  if (ip_map.contains(ip)) {
+  if (ip_addrs.contains(ip)) {
     return SSL_TLSEXT_ERR_OK;
   } else {
-    char buff[256];
-    ats_ip_ntop(&ip.sa, buff, sizeof(buff));
-    Debug("ssl_sni", "%s is not allowed. Denying connection", buff);
+    swoc::LocalBufferWriter<256> w;
+    w.print("{} is not allowed - denyint connection\0", ip);
+    Debug("ssl_sni", "%s", w.data());
     return SSL_TLSEXT_ERR_ALERT_FATAL;
   }
 }
@@ -91,5 +90,5 @@ SNI_IpAllow::SNIAction(TLSSNISupport *snis, ActionItem::Context const &ctx) cons
 bool
 SNI_IpAllow::TestClientSNIAction(char const *servrername, IpEndpoint const &ep, int &policy) const
 {
-  return ip_map.contains(ep);
+  return ip_addrs.contains(swoc::IPAddr(ep));
 }

--- a/iocore/net/SNIActionPerformer.cc
+++ b/iocore/net/SNIActionPerformer.cc
@@ -81,7 +81,7 @@ SNI_IpAllow::SNIAction(TLSSNISupport *snis, ActionItem::Context const &ctx) cons
     return SSL_TLSEXT_ERR_OK;
   } else {
     swoc::LocalBufferWriter<256> w;
-    w.print("{} is not allowed - denyint connection\0", ip);
+    w.print("{} is not allowed - denying connection\0", ip);
     Debug("ssl_sni", "%s", w.data());
     return SSL_TLSEXT_ERR_ALERT_FATAL;
   }

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -74,7 +74,7 @@ bool SSLConfigParams::session_cache_skip_on_lock_contention = false;
 size_t SSLConfigParams::session_cache_max_bucket_size       = 100;
 init_ssl_ctx_func SSLConfigParams::init_ssl_ctx_cb          = nullptr;
 load_ssl_file_func SSLConfigParams::load_ssl_file_cb        = nullptr;
-IpMap *SSLConfigParams::proxy_protocol_ipmap                = nullptr;
+swoc::IPRangeSet *SSLConfigParams::proxy_protocol_ip_addrs  = nullptr;
 bool SSLConfigParams::ssl_ktls_enabled                      = false;
 
 const uint32_t EARLY_DATA_DEFAULT_SIZE               = 16384;
@@ -100,9 +100,9 @@ SSLConfigParams::~SSLConfigParams()
 }
 
 void
-SSLConfigInit(IpMap *global)
+SSLConfigInit(swoc::IPRangeSet *global)
 {
-  SSLConfigParams::proxy_protocol_ipmap = global;
+  SSLConfigParams::proxy_protocol_ip_addrs = global;
 }
 
 void

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -426,8 +426,8 @@ SSLNetVConnection::read_raw_data()
   }
   NET_SUM_DYN_STAT(net_read_bytes_stat, r);
 
-  IpMap *pp_ipmap;
-  pp_ipmap = SSLConfigParams::proxy_protocol_ipmap;
+  swoc::IPRangeSet *pp_ipmap;
+  pp_ipmap = SSLConfigParams::proxy_protocol_ip_addrs;
 
   if (this->get_is_proxy_protocol() && this->get_proxy_protocol_version() == ProxyProtocolVersion::UNDEFINED) {
     Debug("proxyprotocol", "proxy protocol is enabled on this port");
@@ -438,8 +438,7 @@ SSLNetVConnection::read_raw_data()
       // proxy source IP, not the Proxy Protocol client ip. Since we are
       // checking the ip of the actual source of this connection, this is
       // what we want now.
-      void *payload = nullptr;
-      if (!pp_ipmap->contains(get_remote_addr(), &payload)) {
+      if (!pp_ipmap->contains(swoc::IPAddr(get_remote_addr()))) {
         Debug("proxyprotocol", "Source IP is NOT in the configured allowlist of trusted IPs - closing connection");
         r = -ENOTCONN; // Need a quick close/exit here to refuse the connection!!!!!!!!!
         goto proxy_protocol_bypass;

--- a/proxy/ProtocolProbeSessionAccept.cc
+++ b/proxy/ProtocolProbeSessionAccept.cc
@@ -98,15 +98,15 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
     // the trusted allowlist for proxy protocol, then check to see if it is
     // present
 
-    IpMap *pp_ipmap;
+    // Haha, can't do @c auto because the @c goto won't work across it.
+    swoc::IPRangeSet *pp_ipmap;
     pp_ipmap = probeParent->proxy_protocol_ipmap;
 
     if (netvc->get_is_proxy_protocol() && netvc->get_proxy_protocol_version() == ProxyProtocolVersion::UNDEFINED) {
       Debug("proxyprotocol", "ioCompletionEvent: proxy protocol is enabled on this port");
       if (pp_ipmap->count() > 0) {
         Debug("proxyprotocol", "ioCompletionEvent: proxy protocol has a configured allowlist of trusted IPs - checking");
-        void *payload = nullptr;
-        if (!pp_ipmap->contains(netvc->get_remote_addr(), &payload)) {
+        if (!pp_ipmap->contains(swoc::IPAddr(netvc->get_remote_addr()))) {
           Debug("proxyprotocol",
                 "ioCompletionEvent: Source IP is NOT in the configured allowlist of trusted IPs - closing connection");
           goto done;

--- a/proxy/ProtocolProbeSessionAccept.h
+++ b/proxy/ProtocolProbeSessionAccept.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "swoc/swoc_ip.h"
+
 #include "I_SessionAccept.h"
 
 struct ProtocolProbeSessionAcceptEnums {
@@ -53,7 +55,7 @@ public:
   ProtocolProbeSessionAccept(const ProtocolProbeSessionAccept &)            = delete; // disabled
   ProtocolProbeSessionAccept &operator=(const ProtocolProbeSessionAccept &) = delete; // disabled
 
-  IpMap *proxy_protocol_ipmap = nullptr;
+  swoc::IPRangeSet *proxy_protocol_ipmap = nullptr;
 
 private:
   int mainEvent(int event, void *netvc) override;

--- a/proxy/http/HttpConfig.cc
+++ b/proxy/http/HttpConfig.cc
@@ -1143,7 +1143,7 @@ load_negative_caching_var(RecRecord const *r, void *cookie)
 void
 HttpConfig::startup()
 {
-  extern void SSLConfigInit(IpMap * map);
+  extern void SSLConfigInit(swoc::IPRangeSet * addrs);
   http_rsb = RecAllocateRawStatBlock(static_cast<int>(http_stat_count));
   register_stat_callbacks();
 
@@ -1161,8 +1161,8 @@ HttpConfig::startup()
 
   c.inbound  += RecHttpLoadIp("proxy.local.incoming_ip_to_bind");
   c.outbound += RecHttpLoadIp("proxy.local.outgoing_ip_to_bind");
-  RecHttpLoadIpMap("proxy.config.http.proxy_protocol_allowlist", c.config_proxy_protocol_ipmap);
-  SSLConfigInit(&c.config_proxy_protocol_ipmap);
+  RecHttpLoadIpAddrsFromConfVar("proxy.config.http.proxy_protocol_allowlist", c.config_proxy_protocol_ip_addrs);
+  SSLConfigInit(&c.config_proxy_protocol_ip_addrs);
 
   HttpEstablishStaticConfigLongLong(c.server_max_connections, "proxy.config.http.server_max_connections");
   HttpEstablishStaticConfigLongLong(c.max_websocket_connections, "proxy.config.http.websocket.max_number_of_connections");

--- a/proxy/http/HttpConfig.h
+++ b/proxy/http/HttpConfig.h
@@ -46,7 +46,6 @@
 #include "tscore/ink_platform.h"
 #include "tscore/ink_inet.h"
 #include "tscore/ink_resolver.h"
-#include "tscore/IpMap.h"
 #include "tscore/Regex.h"
 #include "tscore/BufferWriter.h"
 #include "HttpProxyAPIEnums.h"
@@ -780,7 +779,7 @@ public:
   // Initialize to any addr (default constructed) because these must always be set.
   ts::IPAddrPair outbound;
   IpAddr proxy_protocol_ip4, proxy_protocol_ip6;
-  IpMap config_proxy_protocol_ipmap;
+  swoc::IPRangeSet config_proxy_protocol_ip_addrs;
 
   MgmtInt server_max_connections    = 0;
   MgmtInt max_websocket_connections = -1;

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -204,7 +204,7 @@ MakeHttpProxyAcceptor(HttpProxyAcceptor &acceptor, HttpProxyPort &port, unsigned
   ProtocolProbeSessionAccept *probe = new ProtocolProbeSessionAccept();
   HttpSessionAccept *http           = nullptr; // don't allocate this unless it will be used.
   probe->proxyPort                  = &port;
-  probe->proxy_protocol_ipmap       = &HttpConfig::m_master.config_proxy_protocol_ipmap;
+  probe->proxy_protocol_ipmap       = &HttpConfig::m_master.config_proxy_protocol_ip_addrs;
 
   if (port.m_session_protocol_preference.intersects(HTTP_PROTOCOL_SET)) {
     http = new HttpSessionAccept(accept_opt);


### PR DESCRIPTION
This is kind of a scattered PR but as usual the dependencies are interconnected. I was able to split part of it out to #9539.

This depends on PR #9539. Should be merged after #9514.