### PR TITLE
Docs: format typos in header_rewrite doc

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -719,8 +719,8 @@ the appropriate logs even when the debug tag has not been enabled. For
 additional information on |TS| debugging statements, refer to
 :ref:`developer-debug-tags` in the developer's documentation.
 
-+**Note**: This operator is deprecated, use the ``set-http-cntl`` operator instead,
-+with the ``TXN_DEBUG`` control.
+**Note**: This operator is deprecated, use the ``set-http-cntl`` operator instead,
+with the ``TXN_DEBUG`` control.
 
 set-destination
 ~~~~~~~~~~~~~~~
@@ -827,7 +827,7 @@ if necessary.
 
 set-http-cntl
 ~~~~~~~~~~~~~
-;;
+::
 
   set-http-cntl <controller> <flag>
 


### PR DESCRIPTION
Looks like a few git diff characters got included by mistake.