### PR TITLE
Add tr-allow-plain

### DIFF
--- a/include/records/I_RecHttp.h
+++ b/include/records/I_RecHttp.h
@@ -264,6 +264,8 @@ public:
   bool m_outbound_transparent_p = false;
   // True if transparent pass-through is enabled on this port.
   bool m_transparent_passthrough = false;
+  // True if transparent allow-plain is enabled on this port.
+  bool m_transparent_allow_plain = false;
   /// True if MPTCP is enabled on this port.
   bool m_mptcp = false;
   /// Local address for inbound connections (listen address).
@@ -422,6 +424,7 @@ public:
   static const char *const OPT_TRANSPARENT_OUTBOUND;    ///< Outbound transparent.
   static const char *const OPT_TRANSPARENT_FULL;        ///< Full transparency.
   static const char *const OPT_TRANSPARENT_PASSTHROUGH; ///< Pass-through non-HTTP.
+  static const char *const OPT_TRANSPARENT_ALLOW_PLAIN; ///< Backup to plain HTTP.
   static const char *const OPT_SSL;                     ///< SSL (experimental)
   static const char *const OPT_QUIC;                    ///< QUIC (experimental)
   static const char *const OPT_PROXY_PROTO;             ///< Proxy Protocol

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -168,10 +168,22 @@ public:
     return transparentPassThrough;
   }
 
+  bool
+  getTransparentAllowPlain() const
+  {
+    return transparentAllowPlain;
+  }
+
   void
   setTransparentPassThrough(bool val)
   {
     transparentPassThrough = val;
+  }
+
+  void
+  setTransparentAllowPlain(bool val)
+  {
+    transparentAllowPlain = val;
   }
 
   // Copy up here so we overload but don't override
@@ -432,6 +444,7 @@ private:
   int handShakeBioStored                     = 0;
 
   bool transparentPassThrough = false;
+  bool transparentAllowPlain  = false;
 
   int sent_cert = 0;
 
@@ -476,6 +489,8 @@ private:
   void _make_ssl_connection(SSL_CTX *ctx);
   void _bindSSLObject();
   void _unbindSSLObject();
+  UnixNetVConnection *_migrateFromSSL();
+  void _propagateHandShakeBuffer(UnixNetVConnection *target, EThread *t);
 
   int _ssl_read_from_net(EThread *lthread, int64_t &ret);
   ssl_error_t _ssl_read_buffer(void *buf, int64_t nbytes, int64_t &nread);

--- a/iocore/net/P_SSLNextProtocolAccept.h
+++ b/iocore/net/P_SSLNextProtocolAccept.h
@@ -33,7 +33,7 @@
 class SSLNextProtocolAccept : public SessionAccept
 {
 public:
-  SSLNextProtocolAccept(Continuation *, bool);
+  SSLNextProtocolAccept(Continuation *, bool, bool);
   ~SSLNextProtocolAccept() override;
 
   bool accept(NetVConnection *, MIOBuffer *, IOBufferReader *) override;
@@ -60,6 +60,7 @@ private:
   SSLNextProtocolSet protoset;
   SessionProtocolSet protoenabled;
   bool transparent_passthrough;
+  bool transparent_allow_plain;
 
   friend struct SSLNextProtocolTrampoline;
 };

--- a/proxy/ProtocolProbeSessionAccept.cc
+++ b/proxy/ProtocolProbeSessionAccept.cc
@@ -170,8 +170,14 @@ ProtocolProbeSessionAccept::mainEvent(int event, void *data)
     ink_assert(data);
 
     VIO *vio;
-    NetVConnection *netvc          = static_cast<NetVConnection *>(data);
-    ProtocolProbeTrampoline *probe = new ProtocolProbeTrampoline(this, netvc->mutex, nullptr, nullptr);
+    NetVConnection *netvc = static_cast<NetVConnection *>(data);
+    ProtocolProbeTrampoline *probe;
+    UnixNetVConnection *unix_netvc = dynamic_cast<UnixNetVConnection *>(netvc);
+    if (unix_netvc != nullptr && unix_netvc->read.vio.get_writer() != nullptr) {
+      probe = new ProtocolProbeTrampoline(this, netvc->mutex, unix_netvc->read.vio.get_writer(), unix_netvc->read.vio.get_reader());
+    } else {
+      probe = new ProtocolProbeTrampoline(this, netvc->mutex, nullptr, nullptr);
+    }
 
     // The connection has completed, set the accept inactivity timeout here to watch over the difference between the
     // connection set up and the first transaction..

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -227,7 +227,7 @@ MakeHttpProxyAcceptor(HttpProxyAcceptor &acceptor, HttpProxyPort &port, unsigned
   ProtocolSessionCreateMap.insert({TS_ALPN_PROTOCOL_INDEX_HTTP_1_1, create_h1_server_session});
 
   if (port.isSSL()) {
-    SSLNextProtocolAccept *ssl = new SSLNextProtocolAccept(probe, port.m_transparent_passthrough);
+    SSLNextProtocolAccept *ssl = new SSLNextProtocolAccept(probe, port.m_transparent_passthrough, port.m_transparent_allow_plain);
 
     // ALPN selects the first server-offered protocol,
     // so make sure that we offer the newest protocol first.


### PR DESCRIPTION
This is the implementation of what I suggested on the ats-dev list "[api] Add tr-try-plain port descriptor".  With this code change if a port has tr-allow-plain and ssl, a connection that does not look like TLS will get converted to a UnixNetVConnection and try to process as non-TLS HTTP.

I have an implementation running over 9.1.3 using the tr-pass port descriptor. The conversion of the SSLNetVConnection to UnixNetVConnection works.

I need to write an autest for this. I was going to first write a transparent mode test, but I guess this feature strictly speaking does not need transparent mode although that is likely the case where this would be most likely used.