### PR TITLE
Make magick plugin buildable with BoringSSL

### DIFF
--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -184,19 +184,12 @@ struct EVPKey {
   EVPKey() : key(EVP_PKEY_new()) { assert(nullptr != key); }
 
   bool
-  assign(char *k) const
+  assign(RSA *k) const
   {
     assert(nullptr != k);
     const int rc = EVP_PKEY_assign_RSA(key, k);
     assert(1 == rc);
     return 1 == rc;
-  }
-
-  template <typename T>
-  bool
-  assign(T &t)
-  {
-    return assign(reinterpret_cast<char *>(t));
   }
 };
 


### PR DESCRIPTION
BoringSSL's `EVP_PKEY_assign_RSA` doesn't accept `char *`.

I don't see any reason to have the template.