### PR TITLE
Define BIO macros in ink_ssl.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,12 @@ endif(HAVE_IOURING AND USE_IOURING)
 list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
 list(APPEND CMAKE_REQUIRED_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
 check_symbol_exists(BIO_meth_new "openssl/bio.h" HAVE_BIO_METH_NEW)
+check_symbol_exists(BIO_set_data "openssl/bio.h" HAVE_BIO_SET_DATA)
+check_symbol_exists(BIO_get_data "openssl/bio.h" HAVE_BIO_GET_DATA)
+check_symbol_exists(BIO_get_shutdown "openssl/bio.h" HAVE_BIO_GET_SHUTDOWN)
+check_symbol_exists(BIO_meth_get_ctrl "openssl/bio.h" HAVE_BIO_METH_GET_CTRL)
+check_symbol_exists(BIO_meth_get_create "openssl/bio.h" HAVE_BIO_METH_GET_CREATE)
+check_symbol_exists(BIO_meth_get_destroy "openssl/bio.h" HAVE_BIO_METH_GET_DESTROY)
 check_symbol_exists(DH_get_2048_256 "openssl/dh.h" TS_USE_GET_DH_2048_256)
 
 # Catch2 for tests

--- a/configure.ac
+++ b/configure.ac
@@ -1325,6 +1325,12 @@ TS_ADDTO([LIBS], ["$OPENSSL_LIBS"])
 
 AC_CHECK_FUNCS([ \
   BIO_meth_new \
+  BIO_set_data \
+  BIO_get_data \
+  BIO_get_shutdown \
+  BIO_meth_get_ctrl \
+  BIO_meth_get_create \
+  BIO_meth_get_destroy \
   BIO_sock_non_fatal_error \
   CRYPTO_set_mem_functions \
   HMAC_CTX_new \
@@ -1338,19 +1344,6 @@ AC_CHECK_FUNCS([ \
 
 AC_CHECK_FUNC([ASN1_STRING_get0_data], [],
               [AC_DEFINE([ASN1_STRING_get0_data], [ASN1_STRING_data], [Added in OpenSSL 1.1])])
-
-AC_CHECK_FUNC([BIO_set_data], [],
-              [AC_DEFINE([BIO_set_data(a, _ptr)], [((a)->ptr = (_ptr))], [Added in OpenSSL 1.1])])
-AC_CHECK_FUNC([BIO_get_data], [],
-              [AC_DEFINE([BIO_get_data(a)], [((a)->ptr)], [Added in OpenSSL 1.1])])
-AC_CHECK_FUNC([BIO_get_shutdown], [],
-              [AC_DEFINE([BIO_get_shutdown(a)], [((a)->shutdown)], [Added in OpenSSL 1.1])])
-AC_CHECK_FUNC([BIO_meth_get_ctrl], [],
-              [AC_DEFINE([BIO_meth_get_ctrl(biom)], [((biom)->ctrl)], [Added in OpenSSL 1.1])])
-AC_CHECK_FUNC([BIO_meth_get_create], [],
-              [AC_DEFINE([BIO_meth_get_create(biom)], [((biom)->create)], [Added in OpenSSL 1.1])])
-AC_CHECK_FUNC([BIO_meth_get_destroy], [],
-              [AC_DEFINE([BIO_meth_get_destroy(biom)], [((biom)->destroy)], [Added in OpenSSL 1.1])])
 
 AC_CHECK_FUNC([EVP_MD_CTX_new], [],
               [AC_DEFINE([EVP_MD_CTX_new], [EVP_MD_CTX_create], [Renamed in OpenSSL 1.1])])

--- a/include/tscore/ink_ssl.h
+++ b/include/tscore/ink_ssl.h
@@ -1,0 +1,29 @@
+#if HAVE_BIO_SET_DATA == 0
+#define HAVE_BIO_SET_DATA     1
+#define BIO_set_data(a, _ptr) ((a)->ptr = (_ptr))
+#endif
+
+#if HAVE_BIO_GET_DATA == 0
+#define HAVE_BIO_GET_DATA 1
+#define BIO_get_data(a)   ((a)->ptr)
+#endif
+
+#if HAVE_BIO_GET_SHUTDOWN == 0
+#define HAVE_BIO_GET_SHUTDOWN 1
+#define BIO_get_shutdown(a)   ((a)->shutdown)
+#endif
+
+#if HAVE_BIO_METH_GET_CTRL == 0
+#define HAVE_BIO_METH_GET_CTRL  1
+#define BIO_meth_get_ctrl(biom) ((biom)->ctrl)
+#endif
+
+#if HAVE_BIO_METH_GET_CREATE == 0
+#define HAVE_BIO_METH_GET_CREATE  1
+#define BIO_meth_get_create(biom) ((biom)->create)
+#endif
+
+#if HAVE_BIO_METH_GET_DESTROY == 0
+#define HAVE_BIO_METH_GET_DESTROY  1
+#define BIO_meth_get_destroy(biom) ((biom)->destroy)
+#endif

--- a/iocore/eventsystem/CMakeLists.txt
+++ b/iocore/eventsystem/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(inkevent SHARED
         UnixEvent.cc
         UnixEventProcessor.cc
         ConfigProcessor.cc
-        RecRawStatsImpl.cc)
+        RecRawStatsImpl.cc
+        RecProcess.cc)
 target_include_directories(inkevent PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(inkevent ${PCRE_LIBRARIES} ${OPENSSL_LIBRARIES} yaml-cpp::yaml-cpp tscpputil resolv libswoc tscore records_p)

--- a/iocore/net/BIO_fastopen.h
+++ b/iocore/net/BIO_fastopen.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <openssl/bio.h>
+#include "tscore/ink_ssl.h"
 
 // Return a BIO_METHOD for a socket BIO that implements TCP Fast Open.
 const BIO_METHOD *BIO_s_fastopen();

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(inknet STATIC
         SSLUtils.cc
         OCSPStapling.cc
         TLSBasicSupport.cc
+        TLSCertSwitchSupport.cc
         TLSEarlyDataSupport.cc
         TLSKeyLogger.cc
         TLSSessionResumptionSupport.cc
@@ -61,8 +62,8 @@ add_library(inknet STATIC
         UnixUDPConnection.cc
         UnixUDPNet.cc
         SSLDynlock.cc
-	SNIActionPerformer.cc
-)
+        SNIActionPerformer.cc
+        )
 target_link_libraries(inknet inkevent records_p)
 target_compile_options(inknet PUBLIC -Wno-deprecated-declarations)
 target_include_directories(inknet PRIVATE
@@ -81,7 +82,7 @@ target_include_directories(inknet PRIVATE
         ${CMAKE_SOURCE_DIR}/mgmt/utils
         ${OPENSSL_INCLUDE_DIRS}
         ${YAML_INCLUDE_DIRS}
-)
+        )
 
 # Fails to link because of circular dep with proxy (ParentSelection)
 # add_executable(test_net unit_tests/test_ProxyProtocol.cc)

--- a/src/traffic_server/CMakeLists.txt
+++ b/src/traffic_server/CMakeLists.txt
@@ -25,8 +25,7 @@ add_executable(traffic_server
         SocksProxy.cc
         traffic_server.cc
         RpcAdminPubHandlers.cc
-        ${CMAKE_SOURCE_DIR}/src/shared/overridable_txn_vars.cc
-        RecProcess.h)
+        ${CMAKE_SOURCE_DIR}/src/shared/overridable_txn_vars.cc)
 target_include_directories(traffic_server PRIVATE
         ${IOCORE_INCLUDE_DIRS}
         ${PROXY_INCLUDE_DIRS}


### PR DESCRIPTION
Defining macros by AC_CHECK_FUNC is not CMake friendly. Only check the availability on configure / CMake and define actual macros in a header file.