### PR TITLE
Require use of BoringSSL if Quiche is used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1447,12 +1447,16 @@ TS_CHECK_LUAJIT
 # Check for optional quiche library
 TS_CHECK_QUICHE
 if test "${has_quiche}" = "1"; then
+if test "$openssl_is_boringssl" = "1" ; then
 enable_quic=yes
 ## Doing these again for Quiche
 AM_CONDITIONAL([ENABLE_QUIC], [test "x$enable_quic" = "xyes"])
 TS_ARG_ENABLE_VAR([use], [quic])
 AC_SUBST(use_quic)
 AC_SUBST(has_quiche)
+else
+  AC_MSG_ERROR([Use of BoringSSL is required if Quiche is used.])
+fi
 fi
 
 # Check for optional WAVM library


### PR DESCRIPTION
#9347 will require this. We can remove this commit if Quiche supports OpenSSL in the future.