### PR TITLE
Drop support for old quiche

### DIFF
--- a/build/quiche.m4
+++ b/build/quiche.m4
@@ -70,7 +70,6 @@ if test "$has_quiche" != "0"; then
   if test "$quiche_have_headers" != "0"; then
     AC_SUBST([QUICHE_LIB], [-lquiche])
     AC_SUBST([QUICHE_CFLAGS], [-I${quiche_include}])
-    AC_CHECK_FUNCS([quiche_config_set_active_connection_id_limit])
   else
     has_quiche=0
     CPPFLAGS=$saved_cppflags

--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -334,10 +334,8 @@ QUICNetVConnection::handle_received_packet(UDPPacket *packet)
   quiche_recv_info recv_info = {
     &packet->from.sa,
     static_cast<socklen_t>(packet->from.isIp4() ? sizeof(packet->from.sin) : sizeof(packet->from.sin6)),
-#ifdef HAVE_QUICHE_CONFIG_SET_ACTIVE_CONNECTION_ID_LIMIT
     &packet->to.sa,
     static_cast<socklen_t>(packet->to.isIp4() ? sizeof(packet->to.sin) : sizeof(packet->to.sin6)),
-#endif
   };
 
   ssize_t done = quiche_conn_recv(this->_quiche_con, buf, buf_len, &recv_info);

--- a/iocore/net/QUICPacketHandler_quiche.cc
+++ b/iocore/net/QUICPacketHandler_quiche.cc
@@ -274,13 +274,10 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
     }
 
     QUICConnectionId new_cid;
-    quiche_conn *quiche_con =
-      quiche_accept(new_cid, new_cid.length(), retry_token.original_dcid(), retry_token.original_dcid().length(),
-#ifdef HAVE_QUICHE_CONFIG_SET_ACTIVE_CONNECTION_ID_LIMIT
-                    &udp_packet->to.sa, udp_packet->to.isIp4() ? sizeof(udp_packet->to.sin) : sizeof(udp_packet->to.sin6),
-#endif
-                    &udp_packet->from.sa, udp_packet->from.isIp4() ? sizeof(udp_packet->from.sin) : sizeof(udp_packet->from.sin6),
-                    &this->_quiche_config);
+    quiche_conn *quiche_con = quiche_accept(
+      new_cid, new_cid.length(), retry_token.original_dcid(), retry_token.original_dcid().length(), &udp_packet->to.sa,
+      udp_packet->to.isIp4() ? sizeof(udp_packet->to.sin) : sizeof(udp_packet->to.sin6), &udp_packet->from.sa,
+      udp_packet->from.isIp4() ? sizeof(udp_packet->from.sin) : sizeof(udp_packet->from.sin6), &this->_quiche_config);
 
     if (params->get_qlog_file_base_name() != nullptr) {
       char qlog_filepath[PATH_MAX];


### PR DESCRIPTION
This just removes `HAVE_QUICHE_CONFIG_SET_ACTIVE_CONNECTION_ID_LIMIT` which is to support old versions of Quiche.