### PR TITLE
QUIC: Ignore default_inactivity_timeout in favour of proxy.config.quic.no_activity_timeout_in.

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -526,6 +526,9 @@ Network
 
    See :ref:`admin-performance-timeouts` for more discussion on |TS| timeouts.
 
+   Note that for QUIC this will be ignored and ``proxy.config.quic.no_activity_timeout_in``
+   should be used instead.
+
 .. ts:cv:: CONFIG proxy.config.net.inactivity_check_frequency INT 1
 
    How frequent (in seconds) to check for inactive connections. If you deal
@@ -4492,6 +4495,11 @@ removed in the future without prior notice.
    The max idle timeout in milliseconds.
    This value will be advertised as ``idle_timeout`` Transport Parameter.
    Transport Parameter.
+
+   .. important::
+
+      QUIC ignores any settings for ``proxy.config.net.default_inactivity_timeout`` and only
+      honors the ``proxy.config.quic.no_activity_timeout_in``.
 
 .. ts:cv:: CONFIG proxy.config.quic.no_activity_timeout_out INT 30000
    :reloadable:

--- a/tests/gold_tests/timeout/quic_no_activity_timeout.test.py
+++ b/tests/gold_tests/timeout/quic_no_activity_timeout.test.py
@@ -125,15 +125,11 @@ test1 = Test_quic_no_activity_timeout(
     gold_file="gold/quic_no_activity_timeout.gold")
 test1.run(check_for_max_idle_timeout=True)
 
-##
-# The following tests is commented out as if we have a smaller default_inactivity_timeout
-# happening before the configured max_idle_timeout in quiche we will end up crashing.
-# The following should be uncommented once the bug is fixed.
-#
-
-# test2 = Test_quic_no_activity_timeout(
-#     "Test quic ts.quic.no_activity_timeout_in(max_idle_timeout_, default_inactivity_timeout should kick in first.",
-#     replay_keys="delay5s",
-#     no_activity_timeout_in=6800,
-#     extra_recs={'proxy.config.net.default_inactivity_timeout': 1})
-# test2.run()
+# QUIC Ignores the default_inactivity_timeout config, so the ts.quic.no_activity_timeout_in
+# should be honor
+test2 = Test_quic_no_activity_timeout(
+    "Ignoring default_inactivity_timeout and use the ts.quic.no_activity_timeout_in instead",
+    replay_keys="delay5s",
+    no_activity_timeout_in=3000,
+    extra_recs={'proxy.config.net.default_inactivity_timeout': 1})
+test2.run(check_for_max_idle_timeout=True)


### PR DESCRIPTION
We will be using only  QUIC transport parameter `idle_timeout`(`proxy.config.quic.no_activity_timeout_in`) and ignoring the `default_inactivity_timeout`.