### PR TITLE
traffic_ctl: metric monitor. Handle SIGINT to drop collected stats.

### DIFF
--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -325,6 +325,9 @@ traffic_ctl metric
    Display the current value of the specified metric(s) using an interval time
    and a count value. Use ``-i`` to set the interval time between requests, and
    ``-c`` to set the number of requests the program will send in total per metric.
+   The program will terminate execution after requesting <count> metrics.
+   If ``count=0`` is passed or ``count`` is not specified then the program should be terminated
+   by SIGINT.
    Note that the metric will display `+` or `-` depending on the value of the last
    metric and the current being shown, if current is greater, then  `+` will be
    added beside the metric value, `-` if the last value is less than current,
@@ -345,7 +348,7 @@ traffic_ctl metric
       proxy.process.eventloop.time.min.10s: 4011194
       proxy.process.eventloop.time.min.10s: 4011194
       proxy.process.eventloop.time.min.10s: 4018669 +
-      --- metric monitor statistics ---
+      --- metric monitor statistics(10) ---
       ┌ proxy.process.eventloop.time.min.10s
       └─ min/avg/max = 4011194/4017498/4025085
 

--- a/src/traffic_ctl/CtrlCommands.h
+++ b/src/traffic_ctl/CtrlCommands.h
@@ -72,6 +72,10 @@ public:
   ///        If @c _invoked_func is not properly set, the function will throw @c logic_error
   virtual void execute();
 
+  /// @brief This variable is used to mark if a Signal was flagged by the application. Default value is 0 and the signal number
+  ///        should be set when the signal is handled.
+  static std::atomic_int Signal_Flagged;
+
 protected:
   /// @brief The whole design is that the command will execute the @c _invoked_func once invoked. This function ptr should be
   ///        set by the appropriated derived class base on the passed parameters. The derived class have the option to override


### PR DESCRIPTION
The idea is to handle the interrupt signal(Ctrl+C) if you just cancel the metric monitor command, this will basically work as the ping command where as soon as you SIGINT then you get the data collected so far.  This also exposes a shared flag to capture the handled signal.

![traffic_monitor](https://user-images.githubusercontent.com/16683788/229138725-93f1cc62-1465-4144-9878-ad44debcd524.gif)
