### PR TITLE
Add CMake to the required PR CI builds

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,6 +48,7 @@ github:
           - Rocky
           - Clang-Analyzer
           - Clang-Format
+          - CMake
           - Debian
           - Docs
           - Fedora


### PR DESCRIPTION
This adds the CMake build to the list of required PR CI builds. This
ensures that the CMake build is always run on PRs, and that a PR
cannot be merged until the CMake build passes.