### PR TITLE
Move system stats to be a c++ plugin to be able to use time functions

### DIFF
--- a/plugins/experimental/system_stats/Makefile.inc
+++ b/plugins/experimental/system_stats/Makefile.inc
@@ -17,4 +17,6 @@
 pkglib_LTLIBRARIES += experimental/system_stats/system_stats.la
 
 experimental_system_stats_system_stats_la_SOURCES = \
-experimental/system_stats/system_stats.c
+experimental/system_stats/system_stats.cc
+
+experimental_system_stats_system_stats_la_CXXFLAGS = $(AM_CXXFLAGS)


### PR DESCRIPTION
We want to add a timestamp to when system stats were injected because this runs on the stat sync interval. This then gives a timeframe for external calculations since stats can be requested at any time but only updated on intervals