### PR TITLE
Enable loading invalid SSL configuration on first load.

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -562,9 +562,9 @@ SSLCertificateConfig::reconfigure()
     retStatus = false;
   }
 
-  // If there are errors in the certificate configs and we had wanted to exit on error
-  // we won't want to reset the config
-  if (retStatus || !params->configExitOnLoadError) {
+  // If there are errors in the certificate configs force the load anyway if there
+  // is no configuration at all (i.e. this is the initial load).
+  if (retStatus || 0 == configid) {
     configid = configProcessor.set(configid, lookup);
   } else {
     delete lookup;

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2008,7 +2008,8 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup)
   REC_ReadConfigInteger(elevate_setting, "proxy.config.ssl.cert.load_elevated");
   ElevateAccess elevate_access(elevate_setting ? ElevateAccess::FILE_PRIVILEGE : 0);
 
-  line = tokLine(content.data(), &tok_state);
+  bool error_p = false;
+  line         = tokLine(content.data(), &tok_state);
   while (line != nullptr) {
     line_num++;
 
@@ -2031,7 +2032,8 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup)
           // There must be a certificate specified unless the tunnel action is set
           if (sslMultiCertSettings->cert || sslMultiCertSettings->opt != SSLCertContextOption::OPT_TUNNEL) {
             if (!this->_store_ssl_ctx(lookup, sslMultiCertSettings)) {
-              return false;
+              Error("Failed to add certificate from \"%s\"", line);
+              error_p = true;
             }
           } else {
             Warning("No ssl_cert_name specified and no tunnel action set");
@@ -2055,7 +2057,7 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup)
     }
   }
 
-  return true;
+  return !error_p;
 }
 
 // Release SSL_CTX and the associated data. This works for both


### PR DESCRIPTION
This closes #9533.

The problem is the fix to prevent loading bad configurations also prevents the initial load from loading if it's invalid. This means any error at all causes TLS to fail globally. It's interesting that at the end of `SSLMultiCertConfigLoader::load` that notes that a default context must be created, while the code also immediately returns if there's any cert load error. Clearly there's a bit of a conflict. This change

* Don't return early on cert load errors.
* Force load if there isn't already a configuration loaded.

This is not a backport, I'm working on a better fix for ATS 10 but it depends on libswoc and so isn't feasible in 9.2.