### PR TITLE
Always load initial SSL configuration.

### DIFF
--- a/include/tscpp/util/ts_errata.h
+++ b/include/tscpp/util/ts_errata.h
@@ -39,3 +39,6 @@ static constexpr swoc::Errata::Severity ERRATA_EMERGENCY{DL_Emergency};
 static constexpr std::array<swoc::TextView, 9> Severity_Names{
   {"Diag", "Debug", "Status", "Note", "Warn", "Error", "Fatal", "Alert", "Emergency"}
 };
+
+// Temporary string for formatting.
+inline thread_local std::string bw_dbg;

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -29,6 +29,8 @@
 #endif
 #include <openssl/ssl.h>
 
+#include "tscpp/util/ts_errata.h"
+
 #include "tscore/ink_config.h"
 #include "tscore/Diags.h"
 #include "records/I_RecCore.h"
@@ -77,7 +79,7 @@ public:
   SSLMultiCertConfigLoader(const SSLConfigParams *p) : _params(p) {}
   virtual ~SSLMultiCertConfigLoader(){};
 
-  bool load(SSLCertLookup *lookup);
+  swoc::Errata load(SSLCertLookup *lookup);
 
   virtual SSL_CTX *default_server_ssl_ctx();
 

--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -578,9 +578,9 @@ SSLCertificateConfig::reconfigure()
     retStatus = false;
   }
 
-  // If there are errors in the certificate configs and we had wanted to exit on error
-  // we won't want to reset the config
-  if (retStatus) {
+  // If the load succeeded, load it. If there is no current configuration, load even a broken
+  // config so that a bad initial load doesn't completely disable TLS.
+  if (retStatus || configid == 0) {
     configid = configProcessor.set(configid, lookup);
   } else {
     delete lookup;

--- a/src/traffic_server/CMakeLists.txt
+++ b/src/traffic_server/CMakeLists.txt
@@ -63,3 +63,4 @@ target_link_libraries(traffic_server
 if (TS_USE_LINUX_IO_URING)
     target_link_libraries(traffic_server inkuring uring)
 endif (TS_USE_LINUX_IO_URING)
+


### PR DESCRIPTION
See #9533. 

The fix to prevent reloading a broken configuration also prevents loading an initial configuration if that is invalid. This means a single expired certificate can block TLS globally. To fix this,

* Certificate load errors are gathered, rather than causing an immediate return.
* The previous enables the default TLS context to be created every time, as noted in the existing comments.
* The first configuration load is forced to succeed so that if the process won't exit on error, at least some semblance of configuration is available.