### PR TITLE
Check CXXSTD to use a specified C++ standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -667,26 +667,49 @@ CXXFLAGS="${_ts_saved_CXXFLAGS}"
 # All compilers we support have 'gnu99' as an available C standard
 TS_ADDTO(AM_CFLAGS, [-std=gnu99])
 
+AC_ARG_VAR(CXXSTD, [C++ standard version])
+if test "x${CXXSTD}" = "x"; then
+  CXXSTD="17"
+fi
+case $CXXSTD in
+  17)
+    cxxver="201703L"
+    ;;
+  20)
+    AC_MSG_NOTICE([Unsupported standard version $CXXSTD])
+    cxxver="202002L"
+    ;;
+  23)
+    AC_MSG_NOTICE([Unsupported standard version $CXXSTD])
+    cxxver="202100L"
+    ;;
+  *)
+    AC_MSG_WARN([Unrecognized standard version $CXXSTD])
+    CXXSTD="17"
+    cxxver="201703L"
+    ;;
+esac
+
 ac_save_CXX="$CXX"
-CXX="$CXX -std=c++17"
+CXX="$CXX -std=c++$CXXSTD"
 AC_LANG_PUSH(C++)
-AC_MSG_CHECKING([whether $CXX supports -std=c++17])
+AC_MSG_CHECKING([whether $CXX supports -std=c++$CXXSTD])
 AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([
-#if __cplusplus < 201703L
-#error "This is not C++17"
+#if __cplusplus < $cxxver
+#error "This is not C++$CXXSTD"
 #endif
     ], []
     )], [
     AC_MSG_RESULT(yes)
     ], [
     AC_MSG_RESULT(no)
-    AC_MSG_ERROR([*** A compiler with support for -std=c++17 is required.])
+    AC_MSG_ERROR([*** A compiler with support for -std=c++$CXXSTD is required.])
 ])
 AC_LANG_POP
 CXX="$ac_save_CXX"
 
-TS_ADDTO(AM_CXXFLAGS, [-std=c++17])
+TS_ADDTO(AM_CXXFLAGS, [-std=c++$CXXSTD])
 
 dnl AC_PROG_SED is only available from version 2.6 (released in 2003). CentosOS
 dnl 5.9 still has an ancient version, but we have macros that require


### PR DESCRIPTION
This allows compiling ATS in a different C++ standard version without modifying configure.ac. It's useful while transitioning to a new version.