### PR TITLE
Fix a compile error in C++20

### DIFF
--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -80,7 +80,7 @@ auto
 make_buffer_size_parser()
 {
   return [l = swoc::Lexicon<int>{
-            {{0, {"128"}},
+            {swoc::Lexicon<int>::Pair{0, {"128"}},
              {1, {"256"}},
              {2, {"512"}},
              {3, {"1k", "1024"}},

--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -80,7 +80,7 @@ auto
 make_buffer_size_parser()
 {
   return [l = swoc::Lexicon<int>{
-            {swoc::Lexicon<int>::Pair{0, {"128"}},
+            {swoc::Lexicon<int>::Definition{0, {"128"}},
              {1, {"256"}},
              {2, {"512"}},
              {3, {"1k", "1024"}},


### PR DESCRIPTION
```
IOBuffer.cc: In function ‘auto make_buffer_size_parser()’:
IOBuffer.cc:99:3: error: call of overloaded ‘Lexicon(<brace-enclosed initializer list>)’ is ambiguous
   99 |   }](swoc::TextView esize) -> std::optional<int> {
      |   ^
In file included from IOBuffer.cc:30:
/home/maskit/src/trafficserver/lib/swoc/include/swoc/Lexicon.h:576:1: note: candidate: ‘swoc::_1_4_6::Lexicon<E>::Lexicon(const std::initializer_list<std::tuple<E, std::basic_string_view<char, std::char_traits<char> > > >&, swoc::_1_4_6::Lexicon<E>::DefaultHandler, swoc::_1_4_6::Lexicon<E>::DefaultHandler) [with E = int; swoc::_1_4_6::Lexicon<E>::DefaultHandler = std::variant<std::monostate, int, std::basic_string_view<char, std::char_traits<char> >, std::function<int(std::basic_string_view<char, std::char_traits<char> >)>, std::function<std::basic_string_view<char, std::char_traits<char> >(int)> >]’
  576 | Lexicon<E>::Lexicon(const std::initializer_list<Pair> &items, DefaultHandler handler_1, DefaultHandler handler_2) {
      | ^~~~~~~~~~
/home/maskit/src/trafficserver/lib/swoc/include/swoc/Lexicon.h:565:1: note: candidate: ‘swoc::_1_4_6::Lexicon<E>::Lexicon(const std::initializer_list<swoc::_1_4_6::Lexicon<E>::Definition>&, swoc::_1_4_6::Lexicon<E>::DefaultHandler, swoc::_1_4_6::Lexicon<E>::DefaultHandler) [with E = int; swoc::_1_4_6::Lexicon<E>::DefaultHandler = std::variant<std::monostate, int, std::basic_string_view<char, std::char_traits<char> >, std::function<int(std::basic_string_view<char, std::char_traits<char> >)>, std::function<std::basic_string_view<char, std::char_traits<char> >(int)> >]’
  565 | Lexicon<E>::Lexicon(const std::initializer_list<Definition> &items, DefaultHandler handler_1, DefaultHandler handler_2) {
      | ^~~~~~~~~~
```