### PR TITLE
Fix clang 16 warnings

### DIFF
--- a/example/plugins/c-api/query_remap/query_remap.c
+++ b/example/plugins/c-api/query_remap/query_remap.c
@@ -41,7 +41,7 @@ typedef struct _query_remap_info {
   int num_hosts;
 } query_remap_info;
 
-int
+TSReturnCode
 TSRemapInit(TSRemapInterface *api_info ATS_UNUSED, char *errbuf ATS_UNUSED, int errbuf_size ATS_UNUSED)
 {
   /* Called at TS startup. Nothing needed for this plugin */
@@ -49,7 +49,7 @@ TSRemapInit(TSRemapInterface *api_info ATS_UNUSED, char *errbuf ATS_UNUSED, int 
   return 0;
 }
 
-int
+TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf ATS_UNUSED, int errbuf_size ATS_UNUSED)
 {
   /* Called for each remap rule using this plugin. The parameters are parsed here */

--- a/example/plugins/cpp-api/websocket/WSBuffer.h
+++ b/example/plugins/cpp-api/websocket/WSBuffer.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 enum ws_frametype {

--- a/iocore/net/quic/QUICPacket.h
+++ b/iocore/net/quic/QUICPacket.h
@@ -206,8 +206,16 @@ public:
   QUICConnectionId source_cid() const;
   virtual QUICVersion version() const;
 
+  // Explicitly tell the compiler that we intentionally want both the
+  // QUICPacketR::type and the following static type. Otherwise it warns
+  // that we might have accidentally not formed our signatures correctly
+  // via a `-Werror=overloaded-virtual` warning.
+  using QUICPacketR::type;
   static bool type(QUICPacketType &type, const uint8_t *packet, size_t packet_len);
   static bool version(QUICVersion &version, const uint8_t *packet, size_t packet_len);
+
+  // Again, address a `-Werror=overloaded-virtual` warning.
+  using QUICPacket::key_phase;
   static bool key_phase(QUICKeyPhase &key_phase, const uint8_t *packet, size_t packet_len);
   static bool length(size_t &length, uint8_t &length_field_len, size_t &length_field_offset, const uint8_t *packet,
                      size_t packet_len);

--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -40,7 +40,14 @@
 #include <openssl/pem.h>
 
 #if MAGICK_VERSION > 6
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
 #include <MagickWand/MagickWand.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #else
 #include <wand/MagickWand.h>
 #endif

--- a/plugins/experimental/webp_transform/ImageTransform.cc
+++ b/plugins/experimental/webp_transform/ImageTransform.cc
@@ -28,12 +28,13 @@
 #include "tscpp/api/Logger.h"
 #include "tscpp/api/Stat.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-override"
+#pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
 #include <Magick++.h>
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/plugins/experimental/webp_transform/ImageTransform.cc
+++ b/plugins/experimental/webp_transform/ImageTransform.cc
@@ -30,7 +30,9 @@
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
 #pragma GCC diagnostic ignored "-Wtype-limits"
 #endif
 #include <Magick++.h>

--- a/tests/gold_tests/pluginTest/TSVConnFd/TSVConnFd.cc
+++ b/tests/gold_tests/pluginTest/TSVConnFd/TSVConnFd.cc
@@ -20,6 +20,7 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <cstdlib>
 #include <atomic>
 


### PR DESCRIPTION
fedora:38 is scheduled to use clang 16. This fixes the non-libswoc warnings that clang raised by clang 16. https://github.com/SolidWallOfCode/libswoc/pull/84 addresses the libswoc warning which we'll pull in via a separate PR.