### PR TITLE
Converting typedef aliases to using aliases

### DIFF
--- a/example/plugins/cpp-api/websocket/WSBuffer.h
+++ b/example/plugins/cpp-api/websocket/WSBuffer.h
@@ -34,7 +34,7 @@ enum ws_frametype {
   WS_FRAME_PING         = 0x9,
   WS_FRAME_PONG         = 0xA
 };
-typedef enum ws_frametype WS_FRAMETYPE;
+using WS_FRAMETYPE = enum ws_frametype;
 
 #define WS_RSV1      0x40
 #define WS_RSV2      0x20

--- a/include/records/I_RecCore.h
+++ b/include/records/I_RecCore.h
@@ -40,7 +40,7 @@ int RecSetDiags(Diags *diags);
 //-------------------------------------------------------------------------
 // Config File Parsing
 //-------------------------------------------------------------------------
-typedef void (*RecConfigEntryCallback)(RecT rec_type, RecDataT data_type, const char *name, const char *value, RecSourceT source);
+using RecConfigEntryCallback = void (*)(RecT, RecDataT, const char *, const char *, RecSourceT);
 
 void RecConfigFileInit();
 int RecConfigFileParse(const char *path, RecConfigEntryCallback handler);
@@ -154,7 +154,7 @@ RecErrT RecGetRecordBool(const char *name, RecBool *rec_byte, bool lock = true);
 //------------------------------------------------------------------------
 // Record Attributes Reading
 //------------------------------------------------------------------------
-typedef void (*RecLookupCallback)(const RecRecord *, void *);
+using RecLookupCallback = void (*)(const RecRecord *, void *);
 
 RecErrT RecLookupRecord(const char *name, RecLookupCallback callback, void *data, bool lock = true);
 RecErrT RecLookupMatchingRecords(unsigned rec_type, const char *match, RecLookupCallback callback, void *data, bool lock = true);

--- a/include/records/I_RecDefs.h
+++ b/include/records/I_RecDefs.h
@@ -40,13 +40,13 @@ enum RecErrT {
 //-------------------------------------------------------------------------
 #define RecStringNull nullptr
 
-typedef int64_t RecInt;
-typedef float RecFloat;
-typedef char *RecString;
-typedef const char *RecStringConst;
-typedef int64_t RecCounter;
-typedef int8_t RecByte;
-typedef bool RecBool;
+using RecInt         = int64_t;
+using RecFloat       = float;
+using RecString      = char *;
+using RecStringConst = const char *;
+using RecCounter     = int64_t;
+using RecByte        = int8_t;
+using RecBool        = bool;
 
 enum RecT {
   RECT_NULL    = 0x00,
@@ -178,6 +178,6 @@ struct RecRawStatBlock {
 //-------------------------------------------------------------------------
 // RecCore Callback Types
 //-------------------------------------------------------------------------
-typedef int (*RecConfigUpdateCb)(const char *name, RecDataT data_type, RecData data, void *cookie);
-typedef int (*RecStatUpdateFunc)(const char *name, RecDataT data_type, RecData *data, RecRawStatBlock *rsb, int id, void *cookie);
-typedef int (*RecRawStatSyncCb)(const char *name, RecDataT data_type, RecData *data, RecRawStatBlock *rsb, int id);
+using RecConfigUpdateCb = int (*)(const char *, RecDataT, RecData, void *);
+using RecStatUpdateFunc = int (*)(const char *, RecDataT, RecData *, RecRawStatBlock *, int, void *);
+using RecRawStatSyncCb  = int (*)(const char *, RecDataT, RecData *, RecRawStatBlock *, int);

--- a/include/records/I_RecHttp.h
+++ b/include/records/I_RecHttp.h
@@ -243,10 +243,10 @@ extern SessionProtocolNameRegistry globalSessionProtocolNameRegistry;
  */
 struct HttpProxyPort {
 private:
-  typedef HttpProxyPort self; ///< Self reference type.
+  using self = HttpProxyPort; ///< Self reference type.
 public:
   /// Explicitly supported collection of proxy ports.
-  typedef std::vector<self> Group;
+  using Group = std::vector<self>;
 
   /// Type of transport on the connection.
   enum TransportType {

--- a/include/records/I_RecordsConfig.h
+++ b/include/records/I_RecordsConfig.h
@@ -46,7 +46,7 @@ struct RecordElement {
   RecAccessT access; // access level of the record
 };
 
-typedef void (*RecordElementCallback)(const RecordElement *, void *);
+using RecordElementCallback = void (*)(const RecordElement *, void *);
 void RecordsConfigIterate(RecordElementCallback, void *);
 
 void LibRecordsConfigInit(); // initializes RecordsConfigIndex

--- a/include/records/P_RecDefs.h
+++ b/include/records/P_RecDefs.h
@@ -58,19 +58,19 @@ enum RecEntryT {
   RECE_RECORD,
 };
 
-typedef struct RecConfigCbList_t {
+using RecConfigUpdateCbList = struct RecConfigCbList_t {
   RecConfigUpdateCb update_cb;
   void *update_cookie;
   struct RecConfigCbList_t *next;
-} RecConfigUpdateCbList;
+};
 
-typedef struct RecStatUpdateFuncList_t {
+using RecStatUpdateFuncList = struct RecStatUpdateFuncList_t {
   RecRawStatBlock *rsb;
   int id;
   RecStatUpdateFunc update_func;
   void *update_cookie;
   struct RecStatUpdateFuncList_t *next;
-} RecStatUpdateFuncList;
+};
 
 struct RecStatMeta {
   RecRawStat data_raw;
@@ -142,8 +142,8 @@ struct RecMessageItr {
   int next;
 };
 
-typedef RecMessageHdr RecMessage;
+using RecMessage = RecMessageHdr;
 
-typedef void (*RecDumpEntryCb)(RecT rec_type, void *edata, int registered, const char *name, int data_type, RecData *datum);
+using RecDumpEntryCb = void (*)(RecT, void *, int, const char *, int, RecData *);
 
-typedef RecErrT (*RecMessageRecvCb)(RecMessage *msg, RecMessageT msg_type, void *cookie);
+using RecMessageRecvCb = RecErrT (*)(RecMessage *, RecMessageT, void *);

--- a/include/records/P_RecFile.h
+++ b/include/records/P_RecFile.h
@@ -28,7 +28,7 @@
 //-------------------------------------------------------------------------
 
 #define REC_HANDLE_INVALID -1
-typedef int RecHandle;
+using RecHandle = int;
 
 static constexpr unsigned VERSION_HDR_SIZE = 5;
 //-------------------------------------------------------------------------

--- a/include/tscore/BaseLogFile.h
+++ b/include/tscore/BaseLogFile.h
@@ -47,13 +47,13 @@
   0 // change this to 1 to enable debug messages
     // TODO find a way to enable this from autotools
 
-typedef enum {
+using LogLogPriorityLevel = enum {
   LL_Debug = 0, // process does not die
   LL_Note,      // process does not die
   LL_Warning,   // process does not die
   LL_Error,     // process does not die
   LL_Fatal,     // causes process termination
-} LogLogPriorityLevel;
+};
 
 #define log_log_trace(...)                         \
   do {                                             \

--- a/include/tscore/BaseLogFile.h
+++ b/include/tscore/BaseLogFile.h
@@ -47,13 +47,13 @@
   0 // change this to 1 to enable debug messages
     // TODO find a way to enable this from autotools
 
-using LogLogPriorityLevel = enum {
+typedef enum {
   LL_Debug = 0, // process does not die
   LL_Note,      // process does not die
   LL_Warning,   // process does not die
   LL_Error,     // process does not die
   LL_Fatal,     // causes process termination
-};
+} LogLogPriorityLevel;
 
 #define log_log_trace(...)                         \
   do {                                             \

--- a/include/tscore/ConsistentHash.h
+++ b/include/tscore/ConsistentHash.h
@@ -38,7 +38,7 @@ struct ATSConsistentHashNode {
 
 std::ostream &operator<<(std::ostream &os, ATSConsistentHashNode &thing);
 
-typedef std::map<uint64_t, ATSConsistentHashNode *>::iterator ATSConsistentHashIter;
+using ATSConsistentHashIter = std::map<uint64_t, ATSConsistentHashNode *>::iterator;
 
 /*
   TSConsistentHash requires a TSHash64 object

--- a/include/tscore/DiagsTypes.h
+++ b/include/tscore/DiagsTypes.h
@@ -73,7 +73,7 @@ enum DiagsShowLocation { SHOW_LOCATION_NONE = 0, SHOW_LOCATION_DEBUG, SHOW_LOCAT
 
 // Cleanup Function Prototype - Called before ink_fatal to
 //   cleanup process state
-typedef void (*DiagsCleanupFunc)();
+using DiagsCleanupFunc = void (*)();
 
 class DiagsConfigState
 {

--- a/include/tscore/Errata.h
+++ b/include/tscore/Errata.h
@@ -85,13 +85,13 @@ protected:
   /// Implementation class.
   struct Data;
   /// Handle for implementation class instance.
-  typedef IntrusivePtr<Data> ImpPtr;
+  using ImpPtr = IntrusivePtr<Data>;
 
 public:
-  typedef Errata self; /// Self reference type.
+  using self = Errata; /// Self reference type.
 
   /// Message ID.
-  typedef NumericType<unsigned int, struct MsgIdTag> Id;
+  using Id = NumericType<unsigned int, struct MsgIdTag>;
 
   /* Tag / level / code severity.
      This is intended for clients to use to provide additional
@@ -99,18 +99,18 @@ public:
      is a common use.
 
   */
-  typedef NumericType<unsigned int, struct CodeTag> Code;
+  using Code = NumericType<unsigned int, struct CodeTag>;
   struct Message;
 
-  typedef std::deque<Message> Container; ///< Storage type for messages.
+  using Container = std::deque<Message>; ///< Storage type for messages.
   // We iterate backwards to look like a stack.
-  //    typedef Container::reverse_iterator iterator; ///< Message iteration.
+  //    using iterator = Container::reverse_iterator; ///< Message iteration.
   /// Message const iteration.
-  //    typedef Container::const_reverse_iterator const_iterator;
+  //    using const_iterator = Container::const_reverse_iterator;
   /// Reverse message iteration.
-  //    typedef Container::iterator reverse_iterator;
+  //    using reverse_iterator = Container::iterator;
   /// Reverse constant message iteration.
-  //    typedef Container::const_iterator const_reverse_iterator;
+  //    using const_reverse_iterator = Container::const_iterator;
 
   /// Default constructor - empty errata, very fast.
   Errata();
@@ -288,8 +288,8 @@ public:
   class Sink : public IntrusivePtrCounter
   {
   public:
-    typedef Sink self;                 ///< Self reference type.
-    typedef IntrusivePtr<self> Handle; ///< Handle type.
+    using self   = Sink;               ///< Self reference type.
+    using Handle = IntrusivePtr<self>; ///< Handle type.
 
     /// Handle an abandoned errata.
     virtual void operator()(Errata const &) const = 0;
@@ -301,7 +301,7 @@ public:
   static void registerSink(Sink::Handle const &s);
 
   /// Register a function as a sink.
-  typedef void (*SinkHandlerFunction)(Errata const &);
+  using SinkHandlerFunction = void (*)(Errata const &);
 
   // Wrapper class to support registering functions as sinks.
   struct SinkFunctionWrapper : public Sink {
@@ -374,7 +374,7 @@ extern std::ostream &operator<<(std::ostream &os, Errata const &stat);
 
 /// Storage for a single message.
 struct Errata::Message {
-  typedef Message self; ///< Self reference type.
+  using self = Message; ///< Self reference type.
 
   /// Default constructor.
   /// The message has Id = 0, default code,  and empty text.
@@ -447,7 +447,7 @@ struct Errata::Message {
   static Code Default_Code;
 
   /// Type for overriding success message test.
-  typedef bool (*SuccessTest)(Message const &m);
+  using SuccessTest = bool (*)(Message const &m);
 
   /** Success message test.
 
@@ -488,7 +488,7 @@ struct Errata::Message {
     mainly because the client can't see this class so we can't
 */
 struct Errata::Data : public IntrusivePtrCounter {
-  typedef Data self; ///< Self reference type.
+  using self = Data; ///< Self reference type.
 
   //! Default constructor.
   Data();
@@ -517,8 +517,8 @@ struct Errata::Data : public IntrusivePtrCounter {
 class Errata::iterator : public Errata::Container::reverse_iterator
 {
 public:
-  typedef iterator self;                             ///< Self reference type.
-  typedef Errata::Container::reverse_iterator super; ///< Parent type.
+  using self  = iterator;                            ///< Self reference type.
+  using super = Errata::Container::reverse_iterator; ///< Parent type.
   iterator();                                        ///< Default constructor.
   /// Copy constructor.
   iterator(self const &that ///< Source instance.
@@ -540,8 +540,8 @@ public:
 class Errata::const_iterator : public Errata::Container::const_reverse_iterator
 {
 public:
-  typedef const_iterator self;                             ///< Self reference type.
-  typedef Errata::Container::const_reverse_iterator super; ///< Parent type.
+  using self  = const_iterator;                            ///< Self reference type.
+  using super = Errata::Container::const_reverse_iterator; ///< Parent type.
   const_iterator();                                        ///< Default constructor.
   /// Copy constructor.
   const_iterator(self const &that ///< Source instance.
@@ -601,9 +601,9 @@ struct RvBase {
     asynchronously.
  */
 template <typename R> struct Rv : public RvBase {
-  typedef Rv self;      ///< Standard self reference type.
-  typedef RvBase super; ///< Standard super class reference type.
-  typedef R Result;     ///< Type of result value.
+  using self   = Rv;     ///< Standard self reference type.
+  using super  = RvBase; ///< Standard super class reference type.
+  using Result = R;      ///< Type of result value.
 
   Result _result; ///< The actual result of the function.
 

--- a/include/tscore/Extendible.h
+++ b/include/tscore/Extendible.h
@@ -98,9 +98,9 @@ public:
 // C API
 
 // context (internally FieldDesc*)
-typedef void const *ExtFieldContext;
-typedef void *DerivedPtr;
-typedef void *FieldPtr;
+using ExtFieldContext = const void *;
+using DerivedPtr      = void *;
+using FieldPtr        = void *;
 
 FieldPtr ExtFieldPtr(DerivedPtr derived, ExtFieldContext field_context, int *size = nullptr);
 

--- a/include/tscore/ParseRules.h
+++ b/include/tscore/ParseRules.h
@@ -31,7 +31,7 @@
 #include "tscore/ink_defs.h"
 #include "tscore/ink_apidefs.h"
 
-typedef unsigned int CTypeResult;
+using CTypeResult = unsigned int;
 
 // Set this to 0 to disable SI
 // decimal multipliers

--- a/include/tscore/RbTree.h
+++ b/include/tscore/RbTree.h
@@ -33,20 +33,20 @@ namespace detail
       duplication.
   */
   struct RBNode {
-    typedef RBNode self; ///< self reference type
+    using self = RBNode; ///< self reference type
 
     /// Node colors
-    typedef enum {
+    using Color = enum {
       RED,
       BLACK,
-    } Color;
+    };
 
     /// Directional constants
-    typedef enum {
+    using Direction = enum {
       NONE,
       LEFT,
       RIGHT,
-    } Direction;
+    };
 
     /// Get a child by direction.
     /// @return The child in the direction @a d if it exists,

--- a/include/tscore/Regression.h
+++ b/include/tscore/Regression.h
@@ -62,7 +62,7 @@
 
 struct RegressionTest;
 
-typedef void TestFunction(RegressionTest *t, int type, int *status);
+using TestFunction = void(RegressionTest *, int, int *);
 
 struct RegressionTest {
   const char *name;

--- a/include/tscore/TestBox.h
+++ b/include/tscore/TestBox.h
@@ -34,7 +34,7 @@ namespace
     be passed repeated.
 */
 struct TestBox {
-  typedef TestBox self;  ///< Self reference type.
+  using self = TestBox;  ///< Self reference type.
   RegressionTest *_test; ///< The test object.
   int *_status;          ///< Current status pointer.
 

--- a/include/tscore/TsBuffer.h
+++ b/include/tscore/TsBuffer.h
@@ -44,8 +44,8 @@ struct ConstBuffer;
     empty @c Buffer use @c Buffer(0).
  */
 struct Buffer {
-  typedef Buffer self; ///< Self reference type.
-  typedef bool (self::*pseudo_bool)() const;
+  using self        = Buffer; ///< Self reference type.
+  using pseudo_bool = bool (self::*)() const;
 
   char *_ptr   = nullptr; ///< Pointer to base of memory chunk.
   size_t _size = 0;       ///< Size of memory chunk.
@@ -124,8 +124,8 @@ struct Buffer {
     A convenience class because we pass this kind of pair frequently.
  */
 struct ConstBuffer {
-  typedef ConstBuffer self; ///< Self reference type.
-  typedef bool (self::*pseudo_bool)() const;
+  using self        = ConstBuffer; ///< Self reference type.
+  using pseudo_bool = bool (self::*)() const;
 
   char const *_ptr = nullptr; ///< Pointer to base of memory chunk.
   size_t _size     = 0;       ///< Size of memory chunk.
@@ -504,5 +504,5 @@ ConstBuffer::clip(char const *p)
 
 } // namespace ts
 
-typedef ts::Buffer TsBuffer;
-typedef ts::ConstBuffer TsConstBuffer;
+using TsBuffer      = ts::Buffer;
+using TsConstBuffer = ts::ConstBuffer;

--- a/include/tscore/ink_cap.h
+++ b/include/tscore/ink_cap.h
@@ -75,13 +75,13 @@ void ImpersonateUserID(uid_t user, ImpersonationLevel level);
 class ElevateAccess
 {
 public:
-  typedef enum {
+  using privilege_level = enum {
     FILE_PRIVILEGE     = 0x1u, ///< Access filesystem objects with privilege
     TRACE_PRIVILEGE    = 0x2u, ///< Trace other processes with privilege
     LOW_PORT_PRIVILEGE = 0x4u, ///< Bind to privilege ports.
     OWNER_PRIVILEGE    = 0x8u  ///< Bypass permission checks on operations that normally require
                                ///  filesystem UID & process UID to match
-  } privilege_level;
+  };
 
   ElevateAccess(unsigned level = FILE_PRIVILEGE);
   ~ElevateAccess();

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -95,7 +95,7 @@ struct IpAddr; // forward declare.
 
  */
 union IpEndpoint {
-  typedef IpEndpoint self; ///< Self reference type.
+  using self = IpEndpoint; ///< Self reference type.
 
   struct sockaddr sa;       ///< Generic address.
   struct sockaddr_in sin;   ///< IPv4
@@ -1027,9 +1027,9 @@ ats_ip_ntop(IpEndpoint const *addr, ///< Address.
 /// Buffer size sufficient for IPv6 address and port.
 static size_t const INET6_ADDRPORTSTRLEN = INET6_ADDRSTRLEN + 6;
 /// Convenience type for address formatting.
-typedef char ip_text_buffer[INET6_ADDRSTRLEN];
+using ip_text_buffer = char[INET6_ADDRSTRLEN];
 /// Convenience type for address formatting.
-typedef char ip_port_text_buffer[INET6_ADDRPORTSTRLEN];
+using ip_port_text_buffer = char[INET6_ADDRPORTSTRLEN];
 
 /** Write a null terminated string for @a addr to @a dst with port.
     A buffer of size INET6_ADDRPORTSTRLEN suffices, including a terminating nul.
@@ -1166,7 +1166,7 @@ int ats_ip_to_hex(sockaddr const *addr, ///< Address to convert. Must be IP.
     @note This is not easily used as an address for system calls.
 */
 struct IpAddr {
-  typedef IpAddr self; ///< Self reference type.
+  using self = IpAddr; ///< Self reference type.
 
   /// Default construct (invalid address).
   IpAddr() {}

--- a/include/tscore/ink_memory.h
+++ b/include/tscore/ink_memory.h
@@ -290,9 +290,9 @@ template <typename TRAITS ///< Traits object.
 class ats_scoped_resource
 {
 public:
-  typedef TRAITS Traits;                          ///< Make template arg available.
-  typedef typename TRAITS::value_type value_type; ///< Import value type.
-  typedef ats_scoped_resource self;               ///< Self reference type.
+  using Traits     = TRAITS;                      ///< Make template arg available.
+  using value_type = typename TRAITS::value_type; ///< Import value type.
+  using self       = ats_scoped_resource;         ///< Self reference type.
 
 public:
   /// Default constructor - an empty container.
@@ -392,7 +392,7 @@ namespace detail
 /** Traits for @c ats_scoped_resource for file descriptors.
  */
 struct SCOPED_FD_TRAITS {
-  typedef int value_type;
+  using value_type = int;
   static int
   initValue()
   {
@@ -415,8 +415,8 @@ struct SCOPED_FD_TRAITS {
 class ats_scoped_fd : public ats_scoped_resource<detail::SCOPED_FD_TRAITS>
 {
 public:
-  typedef ats_scoped_resource<detail::SCOPED_FD_TRAITS> super_type; ///< Super type.
-  typedef ats_scoped_fd self_type;                                  ///< Self reference type.
+  using super_type = ats_scoped_resource<detail::SCOPED_FD_TRAITS>; ///< Super type.
+  using self_type  = ats_scoped_fd;                                 ///< Self reference type.
 
   /// Default constructor - an empty container.
   ats_scoped_fd() : super_type() {}
@@ -453,7 +453,7 @@ namespace detail
 template <typename T ///< Underlying type (not the pointer type).
           >
 struct SCOPED_MALLOC_TRAITS {
-  typedef T *value_type;
+  using value_type = T *;
   static T *
   initValue()
   {
@@ -475,7 +475,7 @@ struct SCOPED_MALLOC_TRAITS {
 template <typename T ///< Underlying type - not the pointer type.
           >
 struct SCOPED_OBJECT_TRAITS {
-  typedef T *value_type;
+  using value_type = T *;
   static T *
   initValue()
   {
@@ -575,8 +575,8 @@ template <typename T ///< Underlying (not pointer) type.
 class ats_scoped_mem : public ats_scoped_resource<detail::SCOPED_MALLOC_TRAITS<T>>
 {
 public:
-  typedef ats_scoped_resource<detail::SCOPED_MALLOC_TRAITS<T>> super; ///< Super type.
-  typedef ats_scoped_mem self;                                        ///< Self reference.
+  using super = ats_scoped_resource<detail::SCOPED_MALLOC_TRAITS<T>>; ///< Super type.
+  using self  = ats_scoped_mem;                                       ///< Self reference.
 
   self &
   operator=(T *ptr)

--- a/include/tscore/ink_mutex.h
+++ b/include/tscore/ink_mutex.h
@@ -37,7 +37,7 @@
 
 #include <pthread.h>
 #include <cstdlib>
-typedef pthread_mutex_t ink_mutex;
+using ink_mutex = pthread_mutex_t;
 
 void ink_mutex_init(ink_mutex *m);
 void ink_mutex_destroy(ink_mutex *m);

--- a/include/tscore/ink_resolver.h
+++ b/include/tscore/ink_resolver.h
@@ -274,7 +274,7 @@ struct ts_imp_res_state {
   unsigned _pad;                /*%< make _u 64 bit aligned */
   uint16_t _nstimes[INK_MAXNS]; /*%< ms. */
 };
-typedef ts_imp_res_state *ink_res_state;
+using ink_res_state = ts_imp_res_state *;
 
 int ink_res_init(ink_res_state, IpEndpoint const *pHostList, size_t pHostListSize, int dnsSearch, const char *pDefDomain = nullptr,
                  const char *pSearchList = nullptr, const char *pResolvConf = nullptr);

--- a/include/tscore/runroot.h
+++ b/include/tscore/runroot.h
@@ -47,7 +47,7 @@ const std::string LAYOUT_MANDIR        = "mandir";
 const std::string LAYOUT_INFODIR       = "infodir";
 const std::string LAYOUT_CACHEDIR      = "cachedir";
 
-typedef std::unordered_map<std::string, std::string> RunrootMapType;
+using RunrootMapType = std::unordered_map<std::string, std::string>;
 
 // some checks for directory exist or is it a directory
 // this is a temporary approach and will be replaced

--- a/include/tscpp/api/Headers.h
+++ b/include/tscpp/api/Headers.h
@@ -45,7 +45,7 @@ private:
   std::string name_;
 
 public:
-  typedef std::string::size_type size_type;
+  using size_type = std::string::size_type;
 
   /**
    * Constructor: build a new HeaderField name with the given string
@@ -244,8 +244,8 @@ private:
   HeaderField(const header_field_iterator &iter) : iter_(iter) {}
 
 public:
-  typedef unsigned int size_type;
-  typedef header_field_value_iterator iterator;
+  using size_type = unsigned int;
+  using iterator  = header_field_value_iterator;
 
   ~HeaderField();
 
@@ -435,8 +435,8 @@ public:
    */
   bool isInitialized() const;
 
-  typedef unsigned int size_type;
-  typedef header_field_iterator iterator;
+  using size_type = unsigned int;
+  using iterator  = header_field_iterator;
 
   /**
    * Check if the headers are empty

--- a/include/wccp/Wccp.h
+++ b/include/wccp/Wccp.h
@@ -97,7 +97,7 @@ struct ServiceConstants {
 class ServiceGroup : public ServiceConstants
 {
 public:
-  typedef ServiceGroup self; ///< Self reference type.
+  using self = ServiceGroup; ///< Self reference type.
 
   /// Type of service.
   enum Type : uint8_t {
@@ -214,8 +214,8 @@ enum SecurityOption {
 class EndPoint
 {
 public:
-  typedef EndPoint self; ///< Self reference type.
-  typedef Impl ImplType; ///< Implementation type.
+  using self     = EndPoint; ///< Self reference type.
+  using ImplType = Impl;     ///< Implementation type.
 
   /** Set the identifying IP address.
       This is also used as the address for the socket.
@@ -283,9 +283,9 @@ protected:
 class Cache : public EndPoint
 {
 public:
-  typedef Cache self;         ///< Self reference type.
-  typedef EndPoint super;     ///< Parent type.
-  typedef CacheImpl ImplType; ///< Implementation type.
+  using self     = Cache;     ///< Self reference type.
+  using super    = EndPoint;  ///< Parent type.
+  using ImplType = CacheImpl; ///< Implementation type.
 
   class Service;
 
@@ -345,7 +345,7 @@ protected:
 class Cache::Service : public ServiceConstants
 {
 public:
-  typedef Service self; ///< Self reference type.
+  using self = Service; ///< Self reference type.
 
   /// Default constructor (invalid reference).
   Service();
@@ -380,9 +380,9 @@ private:
 class Router : public EndPoint
 {
 public:
-  typedef Router self;         ///< Self reference type.
-  typedef EndPoint super;      ///< Parent type.
-  typedef RouterImpl ImplType; ///< Implementation type.
+  using self     = Router;     ///< Self reference type.
+  using super    = EndPoint;   ///< Parent type.
+  using ImplType = RouterImpl; ///< Implementation type.
 
   /// Default constructor
   Router();

--- a/iocore/aio/I_AIO.h
+++ b/iocore/aio/I_AIO.h
@@ -59,8 +59,8 @@ static constexpr ts::ModuleVersion AIO_MODULE_PUBLIC_VERSION(1, 0, ts::ModuleVer
 
 #define MAX_AIO_EVENTS 1024
 
-typedef struct iocb ink_aiocb;
-typedef struct io_event ink_io_event_t;
+using ink_aiocb      = struct iocb;
+using ink_io_event_t = struct io_event;
 
 // XXX hokey old-school compatibility with ink_aiocb.h ...
 #define aio_nbytes u.c.nbytes

--- a/iocore/cache/I_Cache.h
+++ b/iocore/cache/I_Cache.h
@@ -55,9 +55,9 @@ class URL;
 class HTTPHdr;
 class HTTPInfo;
 
-typedef HTTPHdr CacheHTTPHdr;
-typedef URL CacheURL;
-typedef HTTPInfo CacheHTTPInfo;
+using CacheHTTPHdr  = HTTPHdr;
+using CacheURL      = URL;
+using CacheHTTPInfo = HTTPInfo;
 
 struct CacheProcessor : public Processor {
   CacheProcessor()
@@ -120,7 +120,7 @@ struct CacheProcessor : public Processor {
   static bool IsCacheReady(CacheFragType type);
 
   /// Type for callback function.
-  typedef void (*CALLBACK_FUNC)();
+  using CALLBACK_FUNC = void (*)();
   /** Lifecycle callback.
 
       The function @a cb is called after cache initialization has

--- a/iocore/cache/I_CacheDefs.h
+++ b/iocore/cache/I_CacheDefs.h
@@ -122,7 +122,7 @@ enum CacheFragType {
   NUM_CACHE_FRAG_TYPES     = 4
 };
 
-typedef CryptoHash CacheKey;
+using CacheKey = CryptoHash;
 
 struct HttpCacheKey {
   int hostlen;

--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -111,7 +111,7 @@ struct CacheVC;
 #define OPEN_DIR_BUCKETS 256
 
 struct EvacuationBlock;
-typedef uint32_t DirInfo;
+using DirInfo = uint32_t;
 
 // Cache Directory
 

--- a/iocore/cache/P_CacheHosting.h
+++ b/iocore/cache/P_CacheHosting.h
@@ -259,7 +259,7 @@ private:
 };
 
 struct CacheHostTableConfig;
-typedef int (CacheHostTableConfig::*CacheHostTabHandler)(int, void *);
+using CacheHostTabHandler = int (CacheHostTableConfig::*)(int, void *);
 struct CacheHostTableConfig : public Continuation {
   CacheHostTableConfig(ReplaceablePtr<CacheHostTable> *appt) : Continuation(nullptr), ppt(appt)
   {

--- a/iocore/cache/P_CacheHttp.h
+++ b/iocore/cache/P_CacheHttp.h
@@ -27,9 +27,9 @@
 #include "HTTP.h"
 #include "URL.h"
 
-typedef URL CacheURL;
-typedef HTTPHdr CacheHTTPHdr;
-typedef HTTPInfo CacheHTTPInfo;
+using CacheURL      = URL;
+using CacheHTTPHdr  = HTTPHdr;
+using CacheHTTPInfo = HTTPInfo;
 
 #define OFFSET_BITS 24
 enum {

--- a/iocore/dns/P_DNSConnection.h
+++ b/iocore/dns/P_DNSConnection.h
@@ -42,7 +42,7 @@ enum class DNS_CONN_MODE { UDP_ONLY, TCP_RETRY, TCP_ONLY };
 struct DNSConnection {
   /// Options for connecting.
   struct Options {
-    typedef Options self; ///< Self reference type.
+    using self = Options; ///< Self reference type.
 
     /// Connection is done non-blocking.
     /// Default: @c true.

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -147,7 +147,7 @@ struct DNSEntry : public Continuation {
   }
 };
 
-typedef int (DNSEntry::*DNSEntryHandler)(int, void *);
+using DNSEntryHandler = int (DNSEntry::*)(int, void *);
 
 struct DNSEntry;
 

--- a/iocore/dns/P_SplitDNSProcessor.h
+++ b/iocore/dns/P_SplitDNSProcessor.h
@@ -32,6 +32,7 @@
 
 #include "ConfigProcessor.h"
 
+#include "ControlMatcher.h"
 #include "tscore/HostLookup.h"
 
 /* ---------------------------
@@ -54,7 +55,7 @@ enum DNSResultType {
   DNS_SRVR_FAIL,
 };
 
-typedef ControlMatcher<SplitDNSRecord, SplitDNSResult> DNS_table;
+using DNS_table = ControlMatcher<SplitDNSRecord, SplitDNSResult>;
 
 /* --------------------------------------------------------------
    **                struct SplitDNSResult

--- a/iocore/eventsystem/ConfigProcessor.h
+++ b/iocore/eventsystem/ConfigProcessor.h
@@ -31,7 +31,7 @@ class ProxyMutex;
 
 #define MAX_CONFIGS 100
 
-typedef RefCountObj ConfigInfo;
+using ConfigInfo = RefCountObj;
 
 class ConfigProcessor
 {

--- a/iocore/eventsystem/I_Continuation.h
+++ b/iocore/eventsystem/I_Continuation.h
@@ -61,7 +61,7 @@ extern EThread *this_event_thread();
 #define CONTINUATION_DONE 0
 #define CONTINUATION_CONT 1
 
-typedef int (Continuation::*ContinuationHandler)(int event, void *data);
+using ContinuationHandler = int (Continuation::*)(int, void *);
 
 // Convert event handler pointer fp to type ContinuationHandler, but with a compiler error if class C is not
 // derived from the class Continuation.

--- a/iocore/eventsystem/I_Event.h
+++ b/iocore/eventsystem/I_Event.h
@@ -91,7 +91,7 @@
 // define misc events here
 #define ONE_WAY_TUNNEL_EVENT_PEER_CLOSE (SIMPLE_EVENT_EVENTS_START + 1)
 
-typedef int EventType;
+using EventType           = int;
 const int ET_CALL         = 0;
 const int MAX_EVENT_TYPES = 8; // conservative, these are dynamically allocated
 

--- a/iocore/eventsystem/I_EventProcessor.h
+++ b/iocore/eventsystem/I_EventProcessor.h
@@ -376,7 +376,7 @@ private:
   /// Used to generate a callback at the start of thread execution.
   class ThreadInit : public Continuation
   {
-    typedef ThreadInit self;
+    using self = ThreadInit;
     EventProcessor *_evp;
 
   public:

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -123,7 +123,7 @@
 /////////////////////////////////////
 
 class EThread;
-typedef EThread *EThreadPtr;
+using EThreadPtr = EThread *;
 
 #if DEBUG
 extern void lock_waiting(const SourceLocation &, const char *handler);

--- a/iocore/eventsystem/P_Freer.h
+++ b/iocore/eventsystem/P_Freer.h
@@ -84,7 +84,7 @@ new_FreeCaller(C *ap, ink_hrtime t)
 }
 
 struct FreerContinuation;
-typedef int (FreerContinuation::*FreerContHandler)(int, void *);
+using FreerContHandler = int (FreerContinuation::*)(int, void *);
 
 struct FreerContinuation : public Continuation {
   void *p;

--- a/iocore/hostdb/I_HostDBProcessor.h
+++ b/iocore/hostdb/I_HostDBProcessor.h
@@ -675,7 +675,7 @@ struct HostDBProcessor : public Processor {
 
   /// Optional parameters for getby...
   struct Options {
-    typedef Options self;                                  ///< Self reference type.
+    using self                  = Options;                 ///< Self reference type.
     int port                    = 0;                       ///< Target service port (default 0 -> don't care)
     int flags                   = HOSTDB_DO_NOT_FORCE_DNS; ///< Processing flags (default HOSTDB_DO_NOT_FORCE_DNS)
     int timeout                 = 0;                       ///< Timeout value (default 0 -> default timeout)

--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -195,7 +195,7 @@ struct SplitDNS;
     This handles both the host name and raw address cases.
 */
 struct HostDBHash {
-  typedef HostDBHash self; ///< Self reference type.
+  using self = HostDBHash; ///< Self reference type.
 
   CryptoHash hash; ///< The hash value.
 

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -44,7 +44,7 @@ public:
   /** Options for @c accept.
    */
   struct AcceptOptions {
-    typedef AcceptOptions self; ///< Self reference type.
+    using self = AcceptOptions; ///< Self reference type.
 
     /// Port on which to listen.
     /// 0 => don't care, which is useful if the socket is already bound.

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -47,11 +47,11 @@
 #define SSL_EVENT_CLIENT 1
 
 // Indicator the context for a NetVConnection
-typedef enum {
+using NetVConnectionContext_t = enum {
   NET_VCONNECTION_UNSET = 0,
   NET_VCONNECTION_IN,  // Client <--> ATS, Client-Side
   NET_VCONNECTION_OUT, // ATS <--> Server, Server-Side
-} NetVConnectionContext_t;
+};
 
 /** Holds client options for NetVConnection.
 
@@ -69,7 +69,7 @@ typedef enum {
     that protocol. If it's not an IP protocol, IPv4 will be used.
 */
 struct NetVCOptions {
-  typedef NetVCOptions self; ///< Self reference type.
+  using self = NetVCOptions; ///< Self reference type.
 
   /// Values for valid IP protocols.
   enum ip_protocol_t {

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -47,11 +47,11 @@
 #define SSL_EVENT_CLIENT 1
 
 // Indicator the context for a NetVConnection
-using NetVConnectionContext_t = enum {
+typedef enum {
   NET_VCONNECTION_UNSET = 0,
   NET_VCONNECTION_IN,  // Client <--> ATS, Client-Side
   NET_VCONNECTION_OUT, // ATS <--> Server, Server-Side
-};
+} NetVConnectionContext_t;
 
 /** Holds client options for NetVConnection.
 

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -50,8 +50,8 @@ class SSLNextProtocolAccept;
 //   Accepts as many connections as possible, returning the number accepted
 //   or -1 to stop accepting.
 //
-typedef int(AcceptFunction)(NetAccept *na, void *e, bool blockable);
-typedef AcceptFunction *AcceptFunctionPtr;
+using AcceptFunction    = int()(NetAccept *na, void *e, bool blockable);
+using AcceptFunctionPtr = AcceptFunction *;
 AcceptFunction net_accept;
 
 class UnixNetVConnection;

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -50,7 +50,7 @@ class SSLNextProtocolAccept;
 //   Accepts as many connections as possible, returning the number accepted
 //   or -1 to stop accepting.
 //
-using AcceptFunction    = int()(NetAccept *na, void *e, bool blockable);
+typedef int(AcceptFunction)(NetAccept *na, void *e, bool blockable);
 using AcceptFunctionPtr = AcceptFunction *;
 AcceptFunction net_accept;
 

--- a/iocore/net/P_QUICNet.h
+++ b/iocore/net/P_QUICNet.h
@@ -33,7 +33,7 @@
 #include "P_QUICNetVConnection.h"
 
 class NetHandler;
-typedef int (NetHandler::*NetContHandler)(int, void *);
+using NetContHandler = int (NetHandler::*)(int, void *);
 
 void initialize_thread_for_quic_net(EThread *thread);
 

--- a/iocore/net/P_QUICNetVConnection_native.h
+++ b/iocore/net/P_QUICNetVConnection_native.h
@@ -395,6 +395,6 @@ private:
   std::shared_ptr<QLog::QLogListener> _qlog;
 };
 
-typedef int (QUICNetVConnection::*QUICNetVConnHandler)(int, void *);
+using QUICNetVConnHandler = int (QUICNetVConnection::*)(int, void *);
 
 extern ClassAllocator<QUICNetVConnection> quicNetVCAllocator;

--- a/iocore/net/P_SSLConfig.h
+++ b/iocore/net/P_SSLConfig.h
@@ -57,8 +57,8 @@ struct ssl_ticket_key_block;
 // configuration file.
 /////////////////////////////////////////////////////////////
 
-typedef void (*init_ssl_ctx_func)(void *, bool);
-typedef void (*load_ssl_file_func)(const char *);
+using init_ssl_ctx_func  = void (*)(void *, bool);
+using load_ssl_file_func = void (*)(const char *);
 
 struct SSLConfigParams : public ConfigInfo {
   enum SSL_SESSION_CACHE_MODE {
@@ -203,7 +203,7 @@ struct SSLConfig {
   static int get_config_index();
   static int get_loading_config_index();
   static void commit_config_id();
-  typedef ConfigProcessor::scoped_config<SSLConfig, SSLConfigParams> scoped_config;
+  using scoped_config = ConfigProcessor::scoped_config<SSLConfig, SSLConfigParams>;
 
 private:
   static int config_index;
@@ -216,7 +216,7 @@ struct SSLCertificateConfig {
   static SSLCertLookup *acquire();
   static void release(SSLCertLookup *params);
 
-  typedef ConfigProcessor::scoped_config<SSLCertificateConfig, SSLCertLookup> scoped_config;
+  using scoped_config = ConfigProcessor::scoped_config<SSLCertificateConfig, SSLCertLookup>;
 
 private:
   static int configid;
@@ -252,7 +252,7 @@ struct SSLTicketKeyConfig {
     }
   }
 
-  typedef ConfigProcessor::scoped_config<SSLTicketKeyConfig, SSLTicketParams> scoped_config;
+  using scoped_config = ConfigProcessor::scoped_config<SSLTicketKeyConfig, SSLTicketParams>;
 
 private:
   static int configid;

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -82,12 +82,12 @@
 
 struct SSLCertLookup;
 
-using SslVConnOp = enum {
+typedef enum {
   SSL_HOOK_OP_DEFAULT,                     ///< Null / initialization value. Do normal processing.
   SSL_HOOK_OP_TUNNEL,                      ///< Switch to blind tunnel
   SSL_HOOK_OP_TERMINATE,                   ///< Termination connection / transaction.
   SSL_HOOK_OP_LAST = SSL_HOOK_OP_TERMINATE ///< End marker value.
-};
+} SslVConnOp;
 
 enum SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHAKE_ERROR };
 
@@ -107,7 +107,7 @@ class SSLNetVConnection : public UnixNetVConnection,
                           public TLSCertSwitchSupport,
                           public TLSBasicSupport
 {
-  using super = UnixNetVConnection; ///< Parent type.
+  typedef UnixNetVConnection super; ///< Parent type.
 
 public:
   int sslStartHandShake(int event, int &err) override;
@@ -484,6 +484,6 @@ private:
   ssl_error_t _ssl_accept();
 };
 
-using SSLNetVConnHandler = int (SSLNetVConnection::*)(int, void *);
+typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);
 
 extern ClassAllocator<SSLNetVConnection> sslNetVCAllocator;

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -82,12 +82,12 @@
 
 struct SSLCertLookup;
 
-typedef enum {
+using SslVConnOp = enum {
   SSL_HOOK_OP_DEFAULT,                     ///< Null / initialization value. Do normal processing.
   SSL_HOOK_OP_TUNNEL,                      ///< Switch to blind tunnel
   SSL_HOOK_OP_TERMINATE,                   ///< Termination connection / transaction.
   SSL_HOOK_OP_LAST = SSL_HOOK_OP_TERMINATE ///< End marker value.
-} SslVConnOp;
+};
 
 enum SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHAKE_ERROR };
 
@@ -107,7 +107,7 @@ class SSLNetVConnection : public UnixNetVConnection,
                           public TLSCertSwitchSupport,
                           public TLSBasicSupport
 {
-  typedef UnixNetVConnection super; ///< Parent type.
+  using super = UnixNetVConnection; ///< Parent type.
 
 public:
   int sslStartHandShake(int event, int &err) override;
@@ -484,6 +484,6 @@ private:
   ssl_error_t _ssl_accept();
 };
 
-typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);
+using SSLNetVConnHandler = int (SSLNetVConnection::*)(int, void *);
 
 extern ClassAllocator<SSLNetVConnection> sslNetVCAllocator;

--- a/iocore/net/P_SSLNextProtocolSet.h
+++ b/iocore/net/P_SSLNextProtocolSet.h
@@ -50,7 +50,7 @@ public:
     Continuation *endpoint;
     LINK(NextProtocolEndpoint, link);
 
-    typedef DLL<NextProtocolEndpoint> list_type;
+    using list_type = DLL<NextProtocolEndpoint>;
   };
 
   // noncopyable

--- a/iocore/net/P_SSLUtils.h
+++ b/iocore/net/P_SSLUtils.h
@@ -42,12 +42,12 @@
 struct SSLConfigParams;
 class SSLNetVConnection;
 
-typedef int ssl_error_t;
+using ssl_error_t = int;
 
 #ifndef OPENSSL_IS_BORINGSSL
-typedef int ssl_curve_id;
+using ssl_curve_id = int;
 #else
-typedef uint16_t ssl_curve_id;
+using ssl_curve_id = uint16_t;
 #endif
 
 // Return the SSL Curve ID associated to the specified SSL connection

--- a/iocore/net/P_Socks.h
+++ b/iocore/net/P_Socks.h
@@ -85,7 +85,7 @@ swoc::Errata loadSocksIPAddrs(swoc::TextView content, socks_conf_struct *socks_s
 // umm.. the following typedef should take _its own_ type as one of the args
 // not possible with C
 // Right now just use a generic fn ptr and hide casting in an inline fn.
-typedef int (*SocksAuthHandler)(int event, unsigned char *buf, void (**h_ptr)(void));
+using SocksAuthHandler = int (*)(int, unsigned char *, void (**)());
 
 TS_INLINE int
 invokeSocksAuthHandler(SocksAuthHandler &h, int arg1, unsigned char *arg2)
@@ -99,7 +99,7 @@ int socks5PasswdAuthHandler(int event, unsigned char *p, void (**)(void));
 int socks5ServerAuthHandler(int event, unsigned char *p, void (**)(void));
 
 class UnixNetVConnection;
-typedef UnixNetVConnection SocksNetVC;
+using SocksNetVC = UnixNetVConnection;
 
 struct SocksEntry : public Continuation {
   MIOBuffer *buf         = nullptr;
@@ -144,7 +144,7 @@ struct SocksEntry : public Continuation {
   }
 };
 
-typedef int (SocksEntry::*SocksEntryHandler)(int, void *);
+using SocksEntryHandler = int (SocksEntry::*)(int, void *);
 
 extern ClassAllocator<SocksEntry> socksAllocator;
 

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -66,7 +66,7 @@
 #endif
 
 struct PollDescriptor;
-typedef PollDescriptor *EventLoop;
+using EventLoop = PollDescriptor *;
 
 class NetEvent;
 class UnixUDPConnection;
@@ -140,8 +140,8 @@ struct EventIO {
 
 class NetEvent;
 class NetHandler;
-typedef int (NetHandler::*NetContHandler)(int, void *);
-typedef unsigned int uint32;
+using NetContHandler = int (NetHandler::*)(int, void *);
+using uint32         = unsigned int;
 
 extern ink_hrtime last_throttle_warning;
 extern ink_hrtime last_shedding_warning;

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -232,7 +232,7 @@ private:
 
 extern ClassAllocator<UnixNetVConnection> netVCAllocator;
 
-typedef int (UnixNetVConnection::*NetVConnHandler)(int, void *);
+using NetVConnHandler = int (UnixNetVConnection::*)(int, void *);
 
 inline void
 UnixNetVConnection::set_remote_addr()

--- a/iocore/net/P_UnixPollDescriptor.h
+++ b/iocore/net/P_UnixPollDescriptor.h
@@ -42,7 +42,7 @@
 
 #define POLL_DESCRIPTOR_SIZE 32768
 
-typedef struct pollfd Pollfd;
+using Pollfd = struct pollfd;
 
 struct PollDescriptor {
   int result; // result of poll

--- a/iocore/utils/I_OneWayTunnel.h
+++ b/iocore/utils/I_OneWayTunnel.h
@@ -42,7 +42,7 @@
 
 #define ONE_WAY_TUNNEL_CLOSE_ALL nullptr
 
-typedef void (*Transform_fn)(MIOBufferAccessor &in_buf, MIOBufferAccessor &out_buf);
+using Transform_fn = void (*)(MIOBufferAccessor &, MIOBufferAccessor &);
 
 /**
   A generic state machine that connects two virtual connections. A

--- a/mgmt/MgmtDefs.h
+++ b/mgmt/MgmtDefs.h
@@ -33,11 +33,11 @@
 #include "swoc/MemSpan.h"
 #include "tscpp/util/TextView.h"
 
-typedef int64_t MgmtIntCounter;
-typedef int64_t MgmtInt;
-typedef int8_t MgmtByte;
-typedef float MgmtFloat;
-typedef char *MgmtString;
+using MgmtIntCounter = int64_t;
+using MgmtInt        = int64_t;
+using MgmtByte       = int8_t;
+using MgmtFloat      = float;
+using MgmtString     = char *;
 
 /// Management callback signature.
 /// The memory span is the message payload for the callback.

--- a/plugins/cachekey/common.h
+++ b/plugins/cachekey/common.h
@@ -31,11 +31,11 @@
 #include <list>
 #include <vector>
 
-typedef std::string String;
-typedef std::string_view StringView;
-typedef std::set<std::string> StringSet;
-typedef std::list<std::string> StringList;
-typedef std::vector<std::string> StringVector;
+using String       = std::string;
+using StringView   = std::string_view;
+using StringSet    = std::set<std::string>;
+using StringList   = std::list<std::string>;
+using StringVector = std::vector<std::string>;
 
 #ifdef CACHEKEY_UNIT_TEST
 #include <stdio.h>

--- a/plugins/cachekey/configs.h
+++ b/plugins/cachekey/configs.h
@@ -41,7 +41,7 @@ enum CacheKeyKeyType {
 const char *getCacheKeyUriTypeName(CacheKeyUriType type);
 const char *getCacheKeyKeyTypeName(CacheKeyKeyType type);
 
-typedef std::set<CacheKeyKeyType> CacheKeyKeyTypeSet;
+using CacheKeyKeyTypeSet = std::set<CacheKeyKeyType>;
 
 /**
  * @brief Plug-in configuration elements (query / headers / cookies).

--- a/plugins/compress/configuration.h
+++ b/plugins/compress/configuration.h
@@ -32,7 +32,7 @@
 
 namespace Gzip
 {
-typedef std::vector<std::string> StringContainer;
+using StringContainer = std::vector<std::string>;
 
 enum CompressionAlgorithm {
   ALGORITHM_DEFAULT = 0,
@@ -155,7 +155,7 @@ private:
                                                        TS_HTTP_STATUS_NOT_MODIFIED};
 };
 
-typedef std::vector<HostConfiguration *> HostContainer;
+using HostContainer = std::vector<HostConfiguration *>;
 
 class Configuration : private atscppapi::noncopyable
 {

--- a/plugins/compress/misc.h
+++ b/plugins/compress/misc.h
@@ -61,7 +61,7 @@ enum transform_state {
 };
 
 #if HAVE_BROTLI_ENCODE_H
-typedef struct {
+using b_stream = struct {
   BrotliEncoderState *br;
   uint8_t *next_in;
   size_t avail_in;
@@ -69,10 +69,10 @@ typedef struct {
   size_t avail_out;
   size_t total_in;
   size_t total_out;
-} b_stream;
+};
 #endif
 
-typedef struct {
+using Data = struct {
   TSHttpTxn txn;
   HostConfiguration *hc;
   TSVIO downstream_vio;
@@ -86,7 +86,7 @@ typedef struct {
 #if HAVE_BROTLI_ENCODE_H
   b_stream bstrm;
 #endif
-} Data;
+};
 
 voidpf gzip_alloc(voidpf opaque, uInt items, uInt size);
 void gzip_free(voidpf opaque, voidpf address);

--- a/plugins/esi/fetcher/HttpDataFetcherImpl.h
+++ b/plugins/esi/fetcher/HttpDataFetcherImpl.h
@@ -105,7 +105,7 @@ private:
   TSCont _contp;
   char _debug_tag[64];
 
-  typedef std::list<FetchedDataProcessor *> CallbackObjectList;
+  using CallbackObjectList = std::list<FetchedDataProcessor *>;
 
   // used to track a request that was made
   struct RequestData {
@@ -122,10 +122,10 @@ private:
     RequestData() {}
   };
 
-  typedef __gnu_cxx::hash_map<std::string, RequestData, EsiLib::StringHasher> UrlToContentMap;
+  using UrlToContentMap = __gnu_cxx::hash_map<std::string, RequestData, EsiLib::StringHasher>;
   UrlToContentMap _pages;
 
-  typedef std::vector<UrlToContentMap::iterator> IteratorArray;
+  using IteratorArray = std::vector<UrlToContentMap::iterator>;
   IteratorArray _page_entry_lookup; // used to map event ids to requests
 
   int _n_pending_requests;

--- a/plugins/esi/lib/Attribute.h
+++ b/plugins/esi/lib/Attribute.h
@@ -36,5 +36,5 @@ struct Attribute {
     : name(n), name_len(n_len), value(v), value_len(v_len){};
 };
 
-typedef std::list<Attribute> AttributeList;
+using AttributeList = std::list<Attribute>;
 }; // namespace EsiLib

--- a/plugins/esi/lib/ComponentBase.h
+++ b/plugins/esi/lib/ComponentBase.h
@@ -34,8 +34,8 @@ namespace EsiLib
 class ComponentBase
 {
 public:
-  typedef void (*Debug)(const char *, const char *, ...);
-  typedef void (*Error)(const char *, ...);
+  using Debug = void (*)(const char *, const char *, ...);
+  using Error = void (*)(const char *, ...);
 
 protected:
   ComponentBase(const char *debug_tag, Debug debug_func, Error error_func) : _debugLog(debug_func), _errorLog(error_func)

--- a/plugins/esi/lib/EsiProcessor.h
+++ b/plugins/esi/lib/EsiProcessor.h
@@ -163,7 +163,7 @@ private:
     TryBlock(EsiLib::DocNodeList &att, EsiLib::DocNodeList &exc, EsiLib::DocNodeList::iterator p)
       : attempt_nodes(att), except_nodes(exc), pos(p){};
   };
-  typedef std::list<TryBlock> TryBlockList;
+  using TryBlockList = std::list<TryBlock>;
   TryBlockList _try_blocks;
   int _n_try_blocks_processed;
 
@@ -171,7 +171,7 @@ private:
 
   static const char *INCLUDE_DATA_ID_ATTR;
 
-  typedef std::map<std::string, EsiLib::SpecialIncludeHandler *> IncludeHandlerMap;
+  using IncludeHandlerMap = std::map<std::string, EsiLib::SpecialIncludeHandler *>;
   IncludeHandlerMap _include_handlers;
 
   void

--- a/plugins/esi/lib/HandlerManager.h
+++ b/plugins/esi/lib/HandlerManager.h
@@ -48,7 +48,7 @@ public:
   ~HandlerManager() override;
 
 private:
-  typedef std::map<std::string, SpecialIncludeHandlerCreator> FunctionHandleMap;
+  using FunctionHandleMap = std::map<std::string, SpecialIncludeHandlerCreator>;
 
   struct ModuleHandles {
     void *object;
@@ -56,7 +56,7 @@ private:
     ModuleHandles(void *o = nullptr, SpecialIncludeHandlerCreator f = nullptr) : object(o), function(f){};
   };
 
-  typedef std::map<std::string, ModuleHandles> ModuleHandleMap;
+  using ModuleHandleMap = std::map<std::string, ModuleHandles>;
 
   FunctionHandleMap _id_to_function_map;
   ModuleHandleMap _path_to_module_map;

--- a/plugins/esi/lib/HttpHeader.h
+++ b/plugins/esi/lib/HttpHeader.h
@@ -36,5 +36,5 @@ struct HttpHeader {
     : name(n), name_len(n_len), value(v), value_len(v_len){};
 };
 
-typedef std::list<HttpHeader> HttpHeaderList;
+using HttpHeaderList = std::list<HttpHeader>;
 }; // namespace EsiLib

--- a/plugins/esi/lib/IncludeHandlerFactory.h
+++ b/plugins/esi/lib/IncludeHandlerFactory.h
@@ -39,6 +39,5 @@ EsiLib::SpecialIncludeHandler *createSpecialIncludeHandler(EsiLib::Variables &es
 
 namespace EsiLib
 {
-typedef SpecialIncludeHandler *(*SpecialIncludeHandlerCreator)(Variables &esi_vars, Expression &esi_expr, HttpDataFetcher &fetcher,
-                                                               const std::string &id);
+using SpecialIncludeHandlerCreator = SpecialIncludeHandler *(*)(Variables &, Expression &, HttpDataFetcher &, const std::string &);
 };

--- a/plugins/esi/lib/StringHash.h
+++ b/plugins/esi/lib/StringHash.h
@@ -36,7 +36,7 @@ struct StringHasher {
   };
 };
 
-typedef __gnu_cxx::hash_map<std::string, std::string, StringHasher> StringHash;
+using StringHash = __gnu_cxx::hash_map<std::string, std::string, StringHasher>;
 
 template <typename T> class StringKeyHash : public __gnu_cxx::hash_map<std::string, T, StringHasher>
 {

--- a/plugins/esi/lib/Utils.h
+++ b/plugins/esi/lib/Utils.h
@@ -101,8 +101,8 @@ namespace Utils
     parseAttributes(data.data(), data.size(), attr_list, pair_separators);
   }
 
-  typedef std::map<std::string, std::string> KeyValueMap;
-  typedef std::list<std::string> HeaderValueList;
+  using KeyValueMap     = std::map<std::string, std::string>;
+  using HeaderValueList = std::list<std::string>;
 
   // parses given lines (assumes <key><whitespace><value> format) and
   // stores them in supplied map; Lines beginning with '#' are ignored

--- a/plugins/esi/lib/gzip.h
+++ b/plugins/esi/lib/gzip.h
@@ -47,7 +47,7 @@ struct ByteBlock {
   ByteBlock(const char *d = nullptr, int d_len = 0) : data(d), data_len(d_len){};
 };
 
-typedef std::list<ByteBlock> ByteBlockList;
+using ByteBlockList = std::list<ByteBlock>;
 
 bool gzip(const ByteBlockList &blocks, std::string &cdata);
 
@@ -59,7 +59,7 @@ gzip(const char *data, int data_len, std::string &cdata)
   return gzip(blocks, cdata);
 }
 
-typedef std::list<std::string> BufferList;
+using BufferList = std::list<std::string>;
 
 bool gunzip(const char *data, int data_len, BufferList &buf_list);
 } // namespace EsiLib

--- a/plugins/esi/test/HandlerMap.h
+++ b/plugins/esi/test/HandlerMap.h
@@ -28,6 +28,6 @@
 
 #include "StubIncludeHandler.h"
 
-typedef std::map<std::string, StubIncludeHandler *> HandlerMap;
+using HandlerMap = std::map<std::string, StubIncludeHandler *>;
 
 extern HandlerMap gHandlerMap;

--- a/plugins/esi/test/sampleProb.cc
+++ b/plugins/esi/test/sampleProb.cc
@@ -73,7 +73,7 @@ public:
   int _windowPassed;
 };
 
-typedef std::map<std::string, class FailureInfo *> FailureData;
+using FailureData = std::map<std::string, class FailureInfo *>;
 
 void
 registerSuccFail(string URL, FailureData &data, bool isSuccess)

--- a/plugins/experimental/access_control/common.h
+++ b/plugins/experimental/access_control/common.h
@@ -34,12 +34,12 @@
 #include <sstream>
 #include <iostream>
 
-typedef std::string String;
-typedef std::string_view StringView;
-typedef std::set<std::string> StringSet;
-typedef std::list<std::string> StringList;
-typedef std::vector<std::string> StringVector;
-typedef std::map<std::string, std::string> StringMap;
+using String       = std::string;
+using StringView   = std::string_view;
+using StringSet    = std::set<std::string>;
+using StringList   = std::list<std::string>;
+using StringVector = std::vector<std::string>;
+using StringMap    = std::map<std::string, std::string>;
 
 #ifdef ACCESS_CONTROL_UNIT_TEST
 #include <stdio.h>

--- a/plugins/experimental/cache_fill/background_fetch.h
+++ b/plugins/experimental/cache_fill/background_fetch.h
@@ -40,8 +40,8 @@
 #include "ts/ts.h"
 #include "ts/remap.h"
 
-typedef std::unordered_map<std::string, bool> OutstandingRequests;
-const char PLUGIN_NAME[] = "cache_fill";
+using OutstandingRequests = std::unordered_map<std::string, bool>;
+const char PLUGIN_NAME[]  = "cache_fill";
 
 class BgFetchState
 {

--- a/plugins/experimental/fastcgi/src/Profiler.h
+++ b/plugins/experimental/fastcgi/src/Profiler.h
@@ -131,7 +131,7 @@ class Profiler
 {
 public:
   // The storage of profiles
-  typedef std::vector<Profile> ProfileContainer;
+  using ProfileContainer = std::vector<Profile>;
 
   // Empty constructor
   Profiler() : record_enabled_(false) {}

--- a/plugins/experimental/fastcgi/src/ats_fcgi_client.h
+++ b/plugins/experimental/fastcgi/src/ats_fcgi_client.h
@@ -35,7 +35,7 @@
 #define BYTE_2(x) ((x) >> 16 & 0xff)
 #define BYTE_3(x) ((x) >> 24 | 0x80)
 
-typedef unsigned char uchar;
+using uchar = unsigned char;
 
 #define PRINT_OPAQUE_STRUCT(p) print_mem((p), sizeof(*(p)))
 
@@ -47,7 +47,7 @@ namespace ats_plugin
 {
 using namespace atscppapi;
 
-typedef enum {
+using FCGI_State = enum {
   fcgi_state_version = 0,
   fcgi_state_type,
   fcgi_state_request_id_hi,
@@ -60,7 +60,7 @@ typedef enum {
   fcgi_state_content_proc,
   fcgi_state_padding,
   fcgi_state_done
-} FCGI_State;
+};
 
 struct FCGIClientState;
 

--- a/plugins/experimental/fastcgi/src/fcgi_config.h
+++ b/plugins/experimental/fastcgi/src/fcgi_config.h
@@ -31,7 +31,7 @@
 #pragma once
 namespace ats_plugin
 {
-typedef enum {
+using FcgiConfigKey = enum {
   fcgiEnabled,
   fcgiHostname,
   fcgiServerIp,
@@ -43,8 +43,8 @@ typedef enum {
   fcgiMaxConnections,
   fcgiMaxRequests,
   fcgiRequestQueueSize
-} FcgiConfigKey;
-typedef enum {
+};
+using FcgiParamKey = enum {
   gatewayInterface,
   serverSoftware,
   queryString,
@@ -62,10 +62,10 @@ typedef enum {
   serverAddr,
   serverPort,
   serverName
-} FcgiParamKey;
+};
 
-typedef std::map<uint32_t, int8_t> UintMap;
-typedef std::map<std::string, std::string> FCGIParams;
+using UintMap    = std::map<uint32_t, int8_t>;
+using FCGIParams = std::map<std::string, std::string>;
 
 class FcgiPluginConfig
 {

--- a/plugins/experimental/fastcgi/src/fcgi_protocol.h
+++ b/plugins/experimental/fastcgi/src/fcgi_protocol.h
@@ -25,7 +25,7 @@
 
 #define FCGI_LISTENSOCK_FILENO 0
 
-typedef struct {
+using FCGI_Header = struct {
   unsigned char version;
   unsigned char type;
   unsigned char requestIdB1;
@@ -34,7 +34,7 @@ typedef struct {
   unsigned char contentLengthB0;
   unsigned char paddingLength;
   unsigned char reserved;
-} FCGI_Header;
+};
 
 #define FCGI_MAX_LENGTH 0xffff
 
@@ -70,17 +70,17 @@ typedef struct {
  */
 #define FCGI_NULL_REQUEST_ID 0
 
-typedef struct {
+using FCGI_BeginRequestBody = struct {
   unsigned char roleB1;
   unsigned char roleB0;
   unsigned char flags;
   unsigned char reserved[5];
-} FCGI_BeginRequestBody;
+};
 
-typedef struct {
+using FCGI_BeginRequest = struct {
   FCGI_Header *header;
   FCGI_BeginRequestBody *body;
-} FCGI_BeginRequest;
+};
 
 /*
  * Mask for flags component of FCGI_BeginRequestBody
@@ -94,19 +94,19 @@ typedef struct {
 #define FCGI_AUTHORIZER 2
 #define FCGI_FILTER     3
 
-typedef struct {
+using FCGI_EndRequestBody = struct {
   unsigned char appStatusB3;
   unsigned char appStatusB2;
   unsigned char appStatusB1;
   unsigned char appStatusB0;
   unsigned char protocolStatus;
   unsigned char reserved[3];
-} FCGI_EndRequestBody;
+};
 
-typedef struct {
+using FCGI_EndRequest = struct {
   FCGI_Header header;
   FCGI_EndRequestBody body;
-} FCGI_EndRequest;
+};
 
 /*
  * Values for protocolStatus component of FCGI_EndRequestBody
@@ -123,12 +123,12 @@ typedef struct {
 #define FCGI_MAX_REQS   "FCGI_MAX_REQS"
 #define FCGI_MPXS_CONNS "FCGI_MPXS_CONNS"
 
-typedef struct {
+using FCGI_UnknownTypeBody = struct {
   unsigned char type;
   unsigned char reserved[7];
-} FCGI_UnknownTypeBody;
+};
 
-typedef struct {
+using FCGI_UnknownTypeRequest = struct {
   FCGI_Header header;
   FCGI_UnknownTypeBody body;
-} FCGI_UnknownTypeRequest;
+};

--- a/plugins/experimental/geoip_acl/acl.h
+++ b/plugins/experimental/geoip_acl/acl.h
@@ -38,9 +38,9 @@
 
 #if HAVE_GEOIP_H
 #include <GeoIP.h>
-typedef GeoIP *GeoDBHandle;
+using GeoDBHandle = GeoIP *;
 #else  /* !HAVE_GEOIP_H */
-typedef void *GeoDBHandle;
+using GeoDBHandle = void *;
 #endif /* HAVE_GEOIP_H */
 
 // See http://www.iso.org/iso/english_country_names_and_code_elements

--- a/plugins/experimental/inliner/cache.h
+++ b/plugins/experimental/inliner/cache.h
@@ -60,7 +60,7 @@ namespace cache
   };
 
   template <class T> struct Read {
-    typedef Read<T> Self;
+    using Self = Read<T>;
 
     T t_;
 

--- a/plugins/experimental/inliner/fetcher.h
+++ b/plugins/experimental/inliner/fetcher.h
@@ -92,7 +92,7 @@ struct HttpParser {
 };
 
 template <class T> struct HttpTransaction {
-  typedef HttpTransaction<T> Self;
+  using Self = HttpTransaction<T>;
 
   bool parsingHeaders_;
   bool abort_;
@@ -301,7 +301,7 @@ template <class T>
 bool
 get(const std::string &a, io::IO *const i, const int64_t l, const T &t, const int64_t ti = 0)
 {
-  typedef HttpTransaction<T> Transaction;
+  using Transaction = HttpTransaction<T>;
   struct sockaddr_in socket;
   socket.sin_family = AF_INET;
   socket.sin_port   = 80;

--- a/plugins/experimental/inliner/html-parser.h
+++ b/plugins/experimental/inliner/html-parser.h
@@ -31,8 +31,8 @@ namespace ats
 {
 namespace inliner
 {
-  typedef std::pair<std::string, std::string> Pair;
-  typedef std::vector<Pair> AttributeVector;
+  using Pair            = std::pair<std::string, std::string>;
+  using AttributeVector = std::vector<Pair>;
 
   struct Attributes : AttributeVector {
     operator std::string() const;

--- a/plugins/experimental/inliner/png.h
+++ b/plugins/experimental/inliner/png.h
@@ -33,8 +33,8 @@ namespace ats
 namespace inliner
 {
   struct PNG {
-    typedef std::vector<char> Content;
-    typedef Content::const_iterator Iterator;
+    using Content  = std::vector<char>;
+    using Iterator = Content::const_iterator;
 
     static const uint32_t HEADER_SIZE = 8;
 

--- a/plugins/experimental/inliner/ts.h
+++ b/plugins/experimental/inliner/ts.h
@@ -110,8 +110,8 @@ namespace io
 
   struct WriteOperation;
 
-  typedef std::shared_ptr<WriteOperation> WriteOperationPointer;
-  typedef std::weak_ptr<WriteOperation> WriteOperationWeakPointer;
+  using WriteOperationPointer     = std::shared_ptr<WriteOperation>;
+  using WriteOperationWeakPointer = std::weak_ptr<WriteOperation>;
 
   struct Lock {
     const TSMutex mutex_ = nullptr;
@@ -174,17 +174,17 @@ namespace io
   };
 
   struct Node;
-  typedef std::shared_ptr<Node> NodePointer;
-  typedef std::list<NodePointer> Nodes;
+  using NodePointer = std::shared_ptr<Node>;
+  using Nodes       = std::list<NodePointer>;
 
   struct IOSink;
-  typedef std::shared_ptr<IOSink> IOSinkPointer;
+  using IOSinkPointer = std::shared_ptr<IOSink>;
 
   struct Sink;
-  typedef std::shared_ptr<Sink> SinkPointer;
+  using SinkPointer = std::shared_ptr<Sink>;
 
   struct Data;
-  typedef std::shared_ptr<Data> DataPointer;
+  using DataPointer = std::shared_ptr<Data>;
 
   struct IOSink : std::enable_shared_from_this<IOSink> {
     WriteOperationWeakPointer operation_;
@@ -225,7 +225,7 @@ namespace io
   };
 
   struct Node {
-    typedef std::pair<size_t, bool> Result;
+    using Result = std::pair<size_t, bool>;
     IOSinkPointer ioSink_;
     virtual ~Node() {}
     virtual Node::Result process(const TSIOBuffer) = 0;

--- a/plugins/experimental/inliner/util.h
+++ b/plugins/experimental/inliner/util.h
@@ -27,5 +27,5 @@
 
 namespace util
 {
-typedef std::vector<char> Buffer;
+using Buffer = std::vector<char>;
 } // namespace util

--- a/plugins/experimental/inliner/vconnection.h
+++ b/plugins/experimental/inliner/vconnection.h
@@ -35,7 +35,7 @@ namespace io
   {
     template <class T> class Read
     {
-      typedef Read<T> Self;
+      using Self = Read<T>;
       TSVConn vconnection_;
       io::IO in_;
       T t_;

--- a/plugins/experimental/maxmind_acl/mmdb.h
+++ b/plugins/experimental/maxmind_acl/mmdb.h
@@ -47,11 +47,11 @@
 #define PLUGIN_NAME  "maxmind_acl"
 #define CONFIG_TMOUT 60000
 
-using plugin_regex = struct {
+typedef struct {
   std::string _regex_s;
   pcre *_rex;
   pcre_extra *_extra;
-};
+} plugin_regex;
 
 using ipstate = enum { ALLOW_IP, DENY_IP, UNKNOWN_IP };
 

--- a/plugins/experimental/maxmind_acl/mmdb.h
+++ b/plugins/experimental/maxmind_acl/mmdb.h
@@ -47,13 +47,13 @@
 #define PLUGIN_NAME  "maxmind_acl"
 #define CONFIG_TMOUT 60000
 
-typedef struct {
+using plugin_regex = struct {
   std::string _regex_s;
   pcre *_rex;
   pcre_extra *_extra;
-} plugin_regex;
+};
 
-typedef enum { ALLOW_IP, DENY_IP, UNKNOWN_IP } ipstate;
+using ipstate = enum { ALLOW_IP, DENY_IP, UNKNOWN_IP };
 
 // Base class for all ACLs
 class Acl

--- a/plugins/experimental/mp4/mp4_meta.h
+++ b/plugins/experimental/mp4/mp4_meta.h
@@ -64,7 +64,7 @@
   ((u_char *)(p))[6] = (u_char)((n) >> 8);            \
   ((u_char *)(p))[7] = (u_char)(n)
 
-typedef enum {
+using TSMp4AtomID = enum {
   MP4_TRAK_ATOM = 0,
   MP4_TKHD_ATOM,
   MP4_MDIA_ATOM,
@@ -92,20 +92,20 @@ typedef enum {
   MP4_CO64_ATOM,
   MP4_CO64_DATA,
   MP4_LAST_ATOM = MP4_CO64_DATA
-} TSMp4AtomID;
+};
 
-typedef struct {
+using mp4_atom_header = struct {
   u_char size[4];
   u_char name[4];
-} mp4_atom_header;
+};
 
-typedef struct {
+using mp4_atom_header64 = struct {
   u_char size[4];
   u_char name[4];
   u_char size64[8];
-} mp4_atom_header64;
+};
 
-typedef struct {
+using mp4_mvhd_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -125,9 +125,9 @@ typedef struct {
   u_char selection_duration[4];
   u_char current_time[4];
   u_char next_track_id[4];
-} mp4_mvhd_atom;
+};
 
-typedef struct {
+using mp4_mvhd64_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -147,9 +147,9 @@ typedef struct {
   u_char selection_duration[4];
   u_char current_time[4];
   u_char next_track_id[4];
-} mp4_mvhd64_atom;
+};
 
-typedef struct {
+using mp4_tkhd_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -167,9 +167,9 @@ typedef struct {
   u_char matrix[36];
   u_char width[4];
   u_char height[4];
-} mp4_tkhd_atom;
+};
 
-typedef struct {
+using mp4_tkhd64_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -187,9 +187,9 @@ typedef struct {
   u_char matrix[36];
   u_char width[4];
   u_char height[4];
-} mp4_tkhd64_atom;
+};
 
-typedef struct {
+using mp4_mdhd_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -200,9 +200,9 @@ typedef struct {
   u_char duration[4];
   u_char language[2];
   u_char quality[2];
-} mp4_mdhd_atom;
+};
 
-typedef struct {
+using mp4_mdhd64_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -213,9 +213,9 @@ typedef struct {
   u_char duration[8];
   u_char language[2];
   u_char quality[2];
-} mp4_mdhd64_atom;
+};
 
-typedef struct {
+using mp4_stsd_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -224,88 +224,88 @@ typedef struct {
 
   u_char media_size[4];
   u_char media_name[4];
-} mp4_stsd_atom;
+};
 
-typedef struct {
+using mp4_stts_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-} mp4_stts_atom;
+};
 
-typedef struct {
+using mp4_stts_entry = struct {
   u_char count[4];
   u_char duration[4];
-} mp4_stts_entry;
+};
 
-typedef struct {
+using mp4_stss_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-} mp4_stss_atom;
+};
 
-typedef struct {
+using mp4_ctts_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-} mp4_ctts_atom;
+};
 
-typedef struct {
+using mp4_ctts_entry = struct {
   u_char count[4];
   u_char offset[4];
-} mp4_ctts_entry;
+};
 
-typedef struct {
+using mp4_stsc_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-} mp4_stsc_atom;
+};
 
-typedef struct {
+using mp4_stsc_entry = struct {
   u_char chunk[4];
   u_char samples[4];
   u_char id[4];
-} mp4_stsc_entry;
+};
 
-typedef struct {
+using mp4_stsz_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char uniform_size[4];
   u_char entries[4];
-} mp4_stsz_atom;
+};
 
-typedef struct {
+using mp4_stco_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-} mp4_stco_atom;
+};
 
-typedef struct {
+using mp4_co64_atom = struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-} mp4_co64_atom;
+};
 
 class Mp4Meta;
-typedef int (Mp4Meta::*Mp4AtomHandler)(int64_t atom_header_size, int64_t atom_data_size);
+using Mp4AtomHandler = int (Mp4Meta::*)(int64_t, int64_t);
 
-typedef struct {
+using mp4_atom_handler = struct {
   const char *name;
   Mp4AtomHandler handler;
-} mp4_atom_handler;
+};
 
 class BufferHandle
 {

--- a/plugins/experimental/mp4/mp4_meta.h
+++ b/plugins/experimental/mp4/mp4_meta.h
@@ -64,7 +64,7 @@
   ((u_char *)(p))[6] = (u_char)((n) >> 8);            \
   ((u_char *)(p))[7] = (u_char)(n)
 
-using TSMp4AtomID = enum {
+typedef enum {
   MP4_TRAK_ATOM = 0,
   MP4_TKHD_ATOM,
   MP4_MDIA_ATOM,
@@ -92,20 +92,20 @@ using TSMp4AtomID = enum {
   MP4_CO64_ATOM,
   MP4_CO64_DATA,
   MP4_LAST_ATOM = MP4_CO64_DATA
-};
+} TSMp4AtomID;
 
-using mp4_atom_header = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
-};
+} mp4_atom_header;
 
-using mp4_atom_header64 = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char size64[8];
-};
+} mp4_atom_header64;
 
-using mp4_mvhd_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -125,9 +125,9 @@ using mp4_mvhd_atom = struct {
   u_char selection_duration[4];
   u_char current_time[4];
   u_char next_track_id[4];
-};
+} mp4_mvhd_atom;
 
-using mp4_mvhd64_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -147,9 +147,9 @@ using mp4_mvhd64_atom = struct {
   u_char selection_duration[4];
   u_char current_time[4];
   u_char next_track_id[4];
-};
+} mp4_mvhd64_atom;
 
-using mp4_tkhd_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -167,9 +167,9 @@ using mp4_tkhd_atom = struct {
   u_char matrix[36];
   u_char width[4];
   u_char height[4];
-};
+} mp4_tkhd_atom;
 
-using mp4_tkhd64_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -187,9 +187,9 @@ using mp4_tkhd64_atom = struct {
   u_char matrix[36];
   u_char width[4];
   u_char height[4];
-};
+} mp4_tkhd64_atom;
 
-using mp4_mdhd_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -200,9 +200,9 @@ using mp4_mdhd_atom = struct {
   u_char duration[4];
   u_char language[2];
   u_char quality[2];
-};
+} mp4_mdhd_atom;
 
-using mp4_mdhd64_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -213,9 +213,9 @@ using mp4_mdhd64_atom = struct {
   u_char duration[8];
   u_char language[2];
   u_char quality[2];
-};
+} mp4_mdhd64_atom;
 
-using mp4_stsd_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
@@ -224,88 +224,88 @@ using mp4_stsd_atom = struct {
 
   u_char media_size[4];
   u_char media_name[4];
-};
+} mp4_stsd_atom;
 
-using mp4_stts_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-};
+} mp4_stts_atom;
 
-using mp4_stts_entry = struct {
+typedef struct {
   u_char count[4];
   u_char duration[4];
-};
+} mp4_stts_entry;
 
-using mp4_stss_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-};
+} mp4_stss_atom;
 
-using mp4_ctts_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-};
+} mp4_ctts_atom;
 
-using mp4_ctts_entry = struct {
+typedef struct {
   u_char count[4];
   u_char offset[4];
-};
+} mp4_ctts_entry;
 
-using mp4_stsc_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-};
+} mp4_stsc_atom;
 
-using mp4_stsc_entry = struct {
+typedef struct {
   u_char chunk[4];
   u_char samples[4];
   u_char id[4];
-};
+} mp4_stsc_entry;
 
-using mp4_stsz_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char uniform_size[4];
   u_char entries[4];
-};
+} mp4_stsz_atom;
 
-using mp4_stco_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-};
+} mp4_stco_atom;
 
-using mp4_co64_atom = struct {
+typedef struct {
   u_char size[4];
   u_char name[4];
   u_char version[1];
   u_char flags[3];
   u_char entries[4];
-};
+} mp4_co64_atom;
 
 class Mp4Meta;
 using Mp4AtomHandler = int (Mp4Meta::*)(int64_t, int64_t);
 
-using mp4_atom_handler = struct {
+typedef struct {
   const char *name;
   Mp4AtomHandler handler;
-};
+} mp4_atom_handler;
 
 class BufferHandle
 {

--- a/plugins/experimental/parent_select/consistenthash_config.h
+++ b/plugins/experimental/parent_select/consistenthash_config.h
@@ -24,7 +24,7 @@
 
 class TSNextHopSelectionStrategy;
 
-typedef std::map<std::string, std::shared_ptr<TSNextHopSelectionStrategy>, std::less<>> strategies_map;
+using strategies_map = std::map<std::string, std::shared_ptr<TSNextHopSelectionStrategy>, std::less<>>;
 
 void clearStrategiesCache(void);
 strategies_map createStrategiesFromFile(const char *file);

--- a/plugins/experimental/parent_select/healthstatus.h
+++ b/plugins/experimental/parent_select/healthstatus.h
@@ -29,13 +29,13 @@ struct PLHostRecord;
 
 enum PLNHCmd { PL_NH_MARK_UP, PL_NH_MARK_DOWN };
 
-typedef enum {
+using PLNHParentResultType = enum {
   PL_NH_PARENT_UNDEFINED,
   PL_NH_PARENT_DIRECT,
   PL_NH_PARENT_SPECIFIED,
   PL_NH_PARENT_AGENT,
   PL_NH_PARENT_FAIL,
-} PLNHParentResultType;
+};
 
 struct PLStatusTxn {
   PLNHParentResultType result = PL_NH_PARENT_UNDEFINED;

--- a/plugins/experimental/parent_select/healthstatus.h
+++ b/plugins/experimental/parent_select/healthstatus.h
@@ -29,13 +29,13 @@ struct PLHostRecord;
 
 enum PLNHCmd { PL_NH_MARK_UP, PL_NH_MARK_DOWN };
 
-using PLNHParentResultType = enum {
+typedef enum {
   PL_NH_PARENT_UNDEFINED,
   PL_NH_PARENT_DIRECT,
   PL_NH_PARENT_SPECIFIED,
   PL_NH_PARENT_AGENT,
   PL_NH_PARENT_FAIL,
-};
+} PLNHParentResultType;
 
 struct PLStatusTxn {
   PLNHParentResultType result = PL_NH_PARENT_UNDEFINED;

--- a/plugins/experimental/slice/HttpHeader.h
+++ b/plugins/experimental/slice/HttpHeader.h
@@ -74,7 +74,7 @@ struct HttpHeader {
 
   bool setUrl(TSMBuffer const bufurl, TSMLoc const locurl);
 
-  typedef char const *(*CharPtrGetFunc)(TSMBuffer, TSMLoc, int *);
+  using CharPtrGetFunc = const char *(*)(TSMBuffer, TSMLoc, int *);
 
   // request method TS_HTTP_METHOD_*
   char const *
@@ -163,7 +163,7 @@ struct TxnHdrMgr {
     }
   }
 
-  typedef TSReturnCode (*HeaderGetFunc)(TSHttpTxn, TSMBuffer *, TSMLoc *);
+  using HeaderGetFunc = TSReturnCode (*)(TSHttpTxn, TSMBuffer *, TSMLoc *);
   /** use one of the following:
     TSHttpTxnClientReqGet
     TSHttpTxnClientRespGet
@@ -215,7 +215,7 @@ struct HdrMgr {
     }
   }
 
-  typedef TSParseResult (*HeaderParseFunc)(TSHttpParser, TSMBuffer, TSMLoc, char const **, char const *);
+  using HeaderParseFunc = TSParseResult (*)(TSHttpParser, TSMBuffer, TSMLoc, const char **, const char *);
 
   /** Clear/create the parser before calling this and don't
    use the parser on another header until done with this one.

--- a/plugins/experimental/slice/slice_test.cc
+++ b/plugins/experimental/slice/slice_test.cc
@@ -166,7 +166,7 @@ testParseRange()
 }
 
 struct Tests {
-  typedef std::string (*TestFunc)();
+  using TestFunc = std::string (*)();
   std::vector<std::pair<TestFunc, char const *>> funcs;
 
   void

--- a/plugins/experimental/slice/unit-tests/slice_test.cc
+++ b/plugins/experimental/slice/unit-tests/slice_test.cc
@@ -152,7 +152,7 @@ testParseRange()
 }
 
 struct Tests {
-  typedef std::string (*TestFunc)();
+  using TestFunc = std::string (*)();
   std::vector<std::pair<TestFunc, char const *>> funcs;
 
   void

--- a/plugins/experimental/ssl_session_reuse/src/message.h
+++ b/plugins/experimental/ssl_session_reuse/src/message.h
@@ -28,7 +28,7 @@
 
 #include "redis_endpoint.h"
 
-typedef struct message {
+using Message = struct message {
   std::string channel;
   std::string data;
   bool cleanup;
@@ -38,4 +38,4 @@ typedef struct message {
   message(const struct message &m) : channel(m.channel), data(m.data), cleanup(m.cleanup), hosts_tried(m.hosts_tried) {}
   message(const std::string &c, const std::string &d, bool quit = false) : channel(c), data(d), cleanup(quit) {}
   virtual ~message() {}
-} Message;
+};

--- a/plugins/experimental/ssl_session_reuse/src/publisher.h
+++ b/plugins/experimental/ssl_session_reuse/src/publisher.h
@@ -45,7 +45,7 @@ struct RedisContextDeleter {
   }
 };
 
-typedef std::unique_ptr<::redisContext, RedisContextDeleter> RedisContextPtr;
+using RedisContextPtr = std::unique_ptr<::redisContext, RedisContextDeleter>;
 
 class RedisPublisher
 {

--- a/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
+++ b/plugins/experimental/ssl_session_reuse/src/redis_endpoint.h
@@ -28,22 +28,20 @@
 
 #include "globals.h"
 
-typedef struct redis_endpoint {
+using RedisEndpoint = struct redis_endpoint {
   std::string m_hostname;
   int m_port;
 
   redis_endpoint() : m_hostname(cDefaultRedisHost), m_port(cDefaultRedisPort) {}
   redis_endpoint(const std::string &endpoint_spec);
+};
 
-} RedisEndpoint;
-
-typedef struct redis_endpoint_compare {
+using RedisEndpointCompare = struct redis_endpoint_compare {
   bool
   operator()(const RedisEndpoint &lhs, const RedisEndpoint &rhs) const
   {
     return lhs.m_hostname < rhs.m_hostname || (lhs.m_hostname == rhs.m_hostname && lhs.m_port < rhs.m_port);
   }
-
-} RedisEndpointCompare;
+};
 
 void addto_endpoint_vector(std::vector<RedisEndpoint> &endpoints, const std::string &endpoint_str);

--- a/plugins/experimental/sslheaders/sslheaders.h
+++ b/plugins/experimental/sslheaders/sslheaders.h
@@ -25,8 +25,8 @@
 #include <string>
 
 extern "C" {
-typedef struct x509_st X509;
-typedef struct bio_st BIO;
+using X509 = struct x509_st;
+using BIO  = struct bio_st;
 }
 
 #define PLUGIN_NAME "sslheaders"
@@ -77,7 +77,7 @@ struct SslHdrExpansion {
 };
 
 struct SslHdrInstance {
-  typedef std::vector<SslHdrExpansion> expansion_list;
+  using expansion_list = std::vector<SslHdrExpansion>;
 
   SslHdrInstance();
   ~SslHdrInstance();

--- a/plugins/experimental/stek_share/stek_utils.h
+++ b/plugins/experimental/stek_share/stek_utils.h
@@ -31,12 +31,12 @@
 
 #define SSL_KEY_LEN 16
 
-typedef struct ssl_ticket_key // a STEK
+using ssl_ticket_key_t = struct ssl_ticket_key // a STEK
 {
   unsigned char key_name[SSL_KEY_LEN]; // tickets use this name to identify who encrypted
   unsigned char hmac_secret[SSL_KEY_LEN];
   unsigned char aes_key[SSL_KEY_LEN];
-} ssl_ticket_key_t;
+};
 
 #define SSL_TICKET_KEY_SIZE sizeof(ssl_ticket_key_t)
 

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -90,7 +90,7 @@ protected:
 // Check the HTTP return status
 class ConditionStatus : public Condition
 {
-  typedef Matchers<TSHttpStatus> MatcherType;
+  using MatcherType = Matchers<TSHttpStatus>;
 
 public:
   ConditionStatus() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionStatus"); }
@@ -110,7 +110,7 @@ protected:
 // Check the HTTP method
 class ConditionMethod : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
+  using MatcherType = Matchers<std::string>;
 
 public:
   ConditionMethod() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionMethod"); }
@@ -129,7 +129,7 @@ protected:
 // Random 0 to (N-1)
 class ConditionRandom : public Condition
 {
-  typedef Matchers<unsigned int> MatcherType;
+  using MatcherType = Matchers<unsigned int>;
 
 public:
   ConditionRandom() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionRandom"); }
@@ -173,7 +173,7 @@ private:
 // cookie(name)
 class ConditionCookie : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
+  using MatcherType = Matchers<std::string>;
 
 public:
   ConditionCookie() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionCookie"); }
@@ -244,7 +244,7 @@ private:
 // header
 class ConditionHeader : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
+  using MatcherType = Matchers<std::string>;
 
 public:
   explicit ConditionHeader(bool client = false) : _client(client)
@@ -269,7 +269,7 @@ private:
 // url
 class ConditionUrl : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
+  using MatcherType = Matchers<std::string>;
 
 public:
   enum UrlType { CLIENT, URL, FROM, TO };
@@ -295,7 +295,7 @@ private:
 // DBM lookups
 class ConditionDBM : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
+  using MatcherType = Matchers<std::string>;
 
 public:
   ConditionDBM()
@@ -333,7 +333,7 @@ private:
 
 class ConditionInternalTxn : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
+  using MatcherType = Matchers<std::string>;
 
 public:
   void
@@ -347,8 +347,8 @@ protected:
 
 class ConditionIp : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
-  typedef Matchers<const sockaddr *> MatcherTypeIp;
+  using MatcherType   = Matchers<std::string>;
+  using MatcherTypeIp = Matchers<const sockaddr *>;
 
 public:
   explicit ConditionIp() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionIp"); };
@@ -371,7 +371,7 @@ private:
 // Transact Count
 class ConditionTransactCount : public Condition
 {
-  typedef Matchers<int> MatcherType;
+  using MatcherType = Matchers<int>;
 
 public:
   ConditionTransactCount() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionTransactCount"); }
@@ -390,7 +390,7 @@ protected:
 // now: Keeping track of current time / day / hour etc.
 class ConditionNow : public Condition
 {
-  typedef Matchers<int64_t> MatcherType;
+  using MatcherType = Matchers<int64_t>;
 
 public:
   explicit ConditionNow() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionNow"); }
@@ -529,7 +529,7 @@ private:
 
 class ConditionStringLiteral : public Condition
 {
-  typedef Matchers<std::string> MatcherType;
+  using MatcherType = Matchers<std::string>;
 
 public:
   explicit ConditionStringLiteral(const std::string &v);
@@ -550,7 +550,7 @@ private:
 // Single Session Transaction Count
 class ConditionSessionTransactCount : public Condition
 {
-  typedef Matchers<int> MatcherType;
+  using MatcherType = Matchers<int>;
 
 public:
   ConditionSessionTransactCount() { TSDebug(PLUGIN_NAME_DBG, "ConditionSessionTransactCount()"); }
@@ -569,7 +569,7 @@ protected:
 // Tcp Info
 class ConditionTcpInfo : public Condition
 {
-  typedef Matchers<int> MatcherType;
+  using MatcherType = Matchers<int>;
 
 public:
   ConditionTcpInfo() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionTcpInfo"); }

--- a/plugins/multiplexer/dispatch.h
+++ b/plugins/multiplexer/dispatch.h
@@ -66,7 +66,7 @@ struct Statistics {
   int size; // average
 };
 
-typedef std::vector<std::string> Origins;
+using Origins = std::vector<std::string>;
 
 struct Request {
   std::string host;
@@ -79,7 +79,7 @@ struct Request {
   Request &operator=(const Request &);
 };
 
-typedef std::vector<Request> Requests;
+using Requests = std::vector<Request>;
 
 struct Instance {
   Origins origins;

--- a/plugins/multiplexer/fetcher.h
+++ b/plugins/multiplexer/fetcher.h
@@ -71,7 +71,7 @@ struct HttpParser {
 };
 
 template <class T> struct HttpTransaction {
-  typedef HttpTransaction<T> Self;
+  using Self = HttpTransaction<T>;
 
   bool parsingHeaders_;
   bool abort_;
@@ -282,7 +282,7 @@ template <class T>
 bool
 get(const std::string &a, io::IO *const i, const int64_t l, const T &t, const int64_t ti = 0)
 {
-  typedef HttpTransaction<T> Transaction;
+  using Transaction = HttpTransaction<T>;
   struct sockaddr_in socket;
   socket.sin_family = AF_INET;
   socket.sin_port   = 80;

--- a/plugins/prefetch/common.h
+++ b/plugins/prefetch/common.h
@@ -30,11 +30,11 @@
 #include <string>
 #include <vector>
 
-typedef std::string String;
-typedef std::string_view StringView;
-typedef std::set<std::string> StringSet;
-typedef std::list<std::string> StringList;
-typedef std::vector<std::string> StringVector;
+using String       = std::string;
+using StringView   = std::string_view;
+using StringSet    = std::set<std::string>;
+using StringList   = std::list<std::string>;
+using StringVector = std::vector<std::string>;
 
 #ifdef PREFETCH_UNIT_TEST
 #include <assert.h>

--- a/plugins/prefetch/fetch_policy_lru.h
+++ b/plugins/prefetch/fetch_policy_lru.h
@@ -78,10 +78,10 @@ struct LruHashHasher {
   }
 };
 
-typedef LruHash LruEntry;
-typedef std::list<LruEntry> LruList;
-typedef std::unordered_map<const LruHash *, LruList::iterator, LruHashHasher, LruHashHasher> LruMap;
-typedef LruMap::iterator LruMapIterator;
+using LruEntry       = LruHash;
+using LruList        = std::list<LruEntry>;
+using LruMap         = std::unordered_map<const LruHash *, LruList::iterator, LruHashHasher, LruHashHasher>;
+using LruMapIterator = LruMap::iterator;
 
 static LruEntry NULL_LRU_ENTRY; // Used to create an "empty" new LRUEntry
 

--- a/plugins/s3_auth/aws_auth_v4.h
+++ b/plugins/s3_auth/aws_auth_v4.h
@@ -33,10 +33,10 @@
 
 #include <ts/ts.h>
 
-typedef std::string String;
-typedef std::set<std::string> StringSet;
-typedef std::map<std::string, std::string> StringMap;
-typedef std::multimap<std::string, std::string> HeaderMultiMap;
+using String         = std::string;
+using StringSet      = std::set<std::string>;
+using StringMap      = std::map<std::string, std::string>;
+using HeaderMultiMap = std::multimap<std::string, std::string>;
 
 class HeaderIterator;
 

--- a/proxy/ControlBase.h
+++ b/proxy/ControlBase.h
@@ -91,7 +91,7 @@ protected:
   const char *getSchemeModText() const;
 
 private:
-  typedef std::vector<Modifier *> Array;
+  using Array = std::vector<Modifier *>;
   Array _mods;
   const char *ProcessSrcIp(char *val, void **opaque_ptr);
   const char *ProcessTimeOfDay(char *val, void **opaque_ptr);

--- a/proxy/ControlMatcher.h
+++ b/proxy/ControlMatcher.h
@@ -171,7 +171,7 @@ protected:
 
 template <class Data, class MatchResult> class UrlMatcher : protected BaseMatcher<Data>
 {
-  typedef BaseMatcher<Data> super;
+  using super = BaseMatcher<Data>;
 
 public:
   UrlMatcher(const char *name, const char *filename);
@@ -197,7 +197,7 @@ private:
 
 template <class Data, class MatchResult> class RegexMatcher : protected BaseMatcher<Data>
 {
-  typedef BaseMatcher<Data> super;
+  using super = BaseMatcher<Data>;
 
 public:
   RegexMatcher(const char *name, const char *filename);
@@ -222,7 +222,7 @@ protected:
 
 template <class Data, class MatchResult> class HostRegexMatcher : public RegexMatcher<Data, MatchResult>
 {
-  typedef BaseMatcher<Data> super;
+  using super = BaseMatcher<Data>;
 
 public:
   HostRegexMatcher(const char *name, const char *filename);
@@ -237,7 +237,7 @@ public:
 
 template <class Data, class MatchResult> class HostMatcher : protected BaseMatcher<Data>
 {
-  typedef BaseMatcher<Data> super;
+  using super = BaseMatcher<Data>;
 
 public:
   HostMatcher(const char *name, const char *filename);
@@ -268,7 +268,7 @@ private:
 
 template <class Data, class MatchResult> class IpMatcher : protected BaseMatcher<Data>
 {
-  typedef BaseMatcher<Data> super;
+  using super = BaseMatcher<Data>;
 
 public:
   IpMatcher(const char *name, const char *filename);

--- a/proxy/InkAPIInternal.h
+++ b/proxy/InkAPIInternal.h
@@ -40,7 +40,7 @@
 
 /* Some defines that might be candidates for configurable settings later.
  */
-typedef int8_t TSMgmtByte; // Not for external use
+using TSMgmtByte = int8_t; // Not for external use
 
 /* ****** Cache Structure ********* */
 

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -124,7 +124,7 @@ public:
   char hash_string[MAXDNAME + 1];
 };
 
-typedef ControlMatcher<ParentRecord, ParentResult> P_table;
+using P_table = ControlMatcher<ParentRecord, ParentResult>;
 
 // class ParentRecord : public ControlBase
 //

--- a/proxy/Plugin.h
+++ b/proxy/Plugin.h
@@ -26,7 +26,7 @@
 #include <string>
 #include "tscore/List.h"
 
-typedef enum { RELOAD_OFF, RELOAD_ON, RELOAD_COUNT } PluginDynamicReloadMode;
+using PluginDynamicReloadMode = enum { RELOAD_OFF, RELOAD_ON, RELOAD_COUNT };
 
 // read records.yaml to parse plugin related configs
 void parsePluginConfig();

--- a/proxy/Show.h
+++ b/proxy/Show.h
@@ -35,7 +35,7 @@
 #define STREQ_PREFIX(_x, _s) (!strncasecmp(_x, _s, sizeof(_s) - 1))
 
 struct ShowCont;
-typedef int (ShowCont::*ShowContEventHandler)(int event, Event *data);
+using ShowContEventHandler = int (ShowCont::*)(int, Event *);
 struct ShowCont : public Continuation {
 private:
   char *buf, *start, *ebuf;

--- a/proxy/StatPages.h
+++ b/proxy/StatPages.h
@@ -61,7 +61,7 @@
 #define STAT_PAGE_SUCCESS STAT_PAGES_EVENTS_START + 0
 #define STAT_PAGE_FAILURE STAT_PAGES_EVENTS_START + 1
 
-typedef Action *(*StatPagesFunc)(Continuation *cont, HTTPHdr *header);
+using StatPagesFunc = Action *(*)(Continuation *, HTTPHdr *);
 
 struct StatPageData {
   char *data = nullptr;

--- a/proxy/Transform.h
+++ b/proxy/Transform.h
@@ -29,12 +29,12 @@
 
 #define TRANSFORM_READ_READY (TRANSFORM_EVENTS_START + 0)
 
-typedef struct _RangeRecord {
+using RangeRecord = struct _RangeRecord {
   _RangeRecord() {}
   int64_t _start     = -1;
   int64_t _end       = -1;
   int64_t _done_byte = -1;
-} RangeRecord;
+};
 
 class TransformProcessor
 {

--- a/proxy/hdrs/HTTP.h
+++ b/proxy/hdrs/HTTP.h
@@ -1284,7 +1284,7 @@ struct HTTPCacheAlt {
   /// @note This is one less than the number of fragments.
   int m_frag_offset_count = 0;
   /// Type of offset for a fragment.
-  typedef uint64_t FragOffset;
+  using FragOffset = uint64_t;
   /// Table of fragment offsets.
   /// @note The offsets are forward looking so that frag[0] is the
   /// first byte past the end of fragment 0 which is also the first
@@ -1309,7 +1309,7 @@ struct HTTPCacheAlt {
 class HTTPInfo
 {
 public:
-  typedef HTTPCacheAlt::FragOffset FragOffset; ///< Import type.
+  using FragOffset = HTTPCacheAlt::FragOffset; ///< Import type.
 
   HTTPCacheAlt *m_alt = nullptr;
 

--- a/proxy/hdrs/URL.h
+++ b/proxy/hdrs/URL.h
@@ -32,7 +32,7 @@
 
 #include "tscore/ink_apidefs.h"
 
-typedef int64_t cache_generation_t;
+using cache_generation_t = int64_t;
 
 enum URLType {
   URL_TYPE_NONE,

--- a/proxy/http/Http1ClientSession.h
+++ b/proxy/http/Http1ClientSession.h
@@ -51,7 +51,7 @@ class HttpSM;
 class Http1ClientSession : public ProxySession
 {
 public:
-  typedef ProxySession super; ///< Parent type.
+  using super = ProxySession; ///< Parent type.
   Http1ClientSession();
   ~Http1ClientSession() = default;
 

--- a/proxy/http/HttpProxyAPIEnums.h
+++ b/proxy/http/HttpProxyAPIEnums.h
@@ -30,7 +30,7 @@
 #pragma once
 
 /// Server session sharing values - match
-using TSServerSessionSharingMatchType = enum {
+typedef enum {
   TS_SERVER_SESSION_SHARING_MATCH_IP,
   TS_SERVER_SESSION_SHARING_MATCH_HOSTONLY,
   TS_SERVER_SESSION_SHARING_MATCH_HOSTSNISYNC,
@@ -39,20 +39,20 @@ using TSServerSessionSharingMatchType = enum {
   TS_SERVER_SESSION_SHARING_MATCH_NONE,
   TS_SERVER_SESSION_SHARING_MATCH_BOTH,
   TS_SERVER_SESSION_SHARING_MATCH_HOST,
-};
+} TSServerSessionSharingMatchType;
 
-using TSServerSessionSharingMatchMask = enum {
+typedef enum {
   TS_SERVER_SESSION_SHARING_MATCH_MASK_NONE        = 0,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_IP          = 0x1,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTONLY    = 0x2,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTSNISYNC = 0x4,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_SNI         = 0x8,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_CERT        = 0x10
-};
+} TSServerSessionSharingMatchMask;
 
 /// Server session sharing values - pool
-using TSServerSessionSharingPoolType = enum {
+typedef enum {
   TS_SERVER_SESSION_SHARING_POOL_GLOBAL,
   TS_SERVER_SESSION_SHARING_POOL_THREAD,
   TS_SERVER_SESSION_SHARING_POOL_HYBRID
-};
+} TSServerSessionSharingPoolType;

--- a/proxy/http/HttpProxyAPIEnums.h
+++ b/proxy/http/HttpProxyAPIEnums.h
@@ -30,7 +30,7 @@
 #pragma once
 
 /// Server session sharing values - match
-typedef enum {
+using TSServerSessionSharingMatchType = enum {
   TS_SERVER_SESSION_SHARING_MATCH_IP,
   TS_SERVER_SESSION_SHARING_MATCH_HOSTONLY,
   TS_SERVER_SESSION_SHARING_MATCH_HOSTSNISYNC,
@@ -39,20 +39,20 @@ typedef enum {
   TS_SERVER_SESSION_SHARING_MATCH_NONE,
   TS_SERVER_SESSION_SHARING_MATCH_BOTH,
   TS_SERVER_SESSION_SHARING_MATCH_HOST,
-} TSServerSessionSharingMatchType;
+};
 
-typedef enum {
+using TSServerSessionSharingMatchMask = enum {
   TS_SERVER_SESSION_SHARING_MATCH_MASK_NONE        = 0,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_IP          = 0x1,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTONLY    = 0x2,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_HOSTSNISYNC = 0x4,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_SNI         = 0x8,
   TS_SERVER_SESSION_SHARING_MATCH_MASK_CERT        = 0x10
-} TSServerSessionSharingMatchMask;
+};
 
 /// Server session sharing values - pool
-typedef enum {
+using TSServerSessionSharingPoolType = enum {
   TS_SERVER_SESSION_SHARING_POOL_GLOBAL,
   TS_SERVER_SESSION_SHARING_POOL_THREAD,
   TS_SERVER_SESSION_SHARING_POOL_HYBRID
-} TSServerSessionSharingPoolType;
+};

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -99,7 +99,7 @@ static const int boundary_size   = 2 + sizeof("RANGE_SEPARATOR") - 1 + 2;
 static const char *str_100_continue_response = "HTTP/1.1 100 Continue\r\n\r\n";
 static const int len_100_continue_response   = strlen(str_100_continue_response);
 
-// Handy typedef for short (single line) message generation.
+// Handy alias for short (single line) message generation.
 using lbw = ts::LocalBufferWriter<256>;
 
 namespace

--- a/proxy/http/HttpSM.h
+++ b/proxy/http/HttpSM.h
@@ -68,7 +68,7 @@ class AuthHttpAdapter;
 class PreWarmSM;
 
 class HttpSM;
-typedef int (HttpSM::*HttpSMHandler)(int event, void *data);
+using HttpSMHandler = int (HttpSM::*)(int, void *);
 
 enum HttpVC_t {
   HTTP_UNKNOWN = 0,

--- a/proxy/http/HttpSessionAccept.h
+++ b/proxy/http/HttpSessionAccept.h
@@ -54,7 +54,7 @@ namespace detail
 class HttpSessionAcceptOptions
 {
 private:
-  typedef HttpSessionAcceptOptions self; ///< Self reference type.
+  using self = HttpSessionAcceptOptions; ///< Self reference type.
 public:
   HttpSessionAcceptOptions();
 
@@ -169,12 +169,12 @@ HttpSessionAcceptOptions::setSessionProtocolPreference(SessionProtocolSet const 
 class HttpSessionAccept : public SessionAccept, private detail::HttpSessionAcceptOptions
 {
 private:
-  typedef HttpSessionAccept self; ///< Self reference type.
+  using self = HttpSessionAccept; ///< Self reference type.
 public:
   /** Construction options.
       Provide an easier to remember typedef for clients.
   */
-  typedef detail::HttpSessionAcceptOptions Options;
+  using Options = detail::HttpSessionAcceptOptions;
 
   /** Default constructor.
       @internal We don't use a static default options object because of

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -576,39 +576,40 @@ public:
     ServerState_t state                          = STATE_UNDEFINED;
     class Attempts
     {
-      return _v;
-    }
+    public:
+      Attempts()                 = default;
+      Attempts(Attempts const &) = delete;
 
-    void
-    maximize(MgmtInt configured_connect_attempts_max_retries)
-    {
-      ink_assert(_v <= configured_connect_attempts_max_retries);
-      if (_v < configured_connect_attempts_max_retries) {
-        ink_assert(0 == _saved_v);
-        _saved_v = _v;
-        _v       = configured_connect_attempts_max_retries;
+      unsigned
+      get() const
+      {
+        return _v;
       }
-    }
 
-    void
-    clear()
-    {
-      _v       = 0;
-      _saved_v = 0;
-    }
+      void
+      maximize(MgmtInt configured_connect_attempts_max_retries)
+      {
+        ink_assert(_v <= configured_connect_attempts_max_retries);
+        if (_v < configured_connect_attempts_max_retries) {
+          ink_assert(0 == _saved_v);
+          _saved_v = _v;
+          _v       = configured_connect_attempts_max_retries;
+        }
+      }
 
-    void
-    increment(MgmtInt configured_connect_attempts_max_retries)
-    {
-      ++_v;
-      ink_assert(_v <= configured_connect_attempts_max_retries);
-    }
+      void
+      clear()
+      {
+        _v       = 0;
+        _saved_v = 0;
+      }
 
-    unsigned
-    saved() const
-    {
-      return _saved_v ? _saved_v : _v;
-    }
+      void
+      increment(MgmtInt configured_connect_attempts_max_retries)
+      {
+        ++_v;
+        ink_assert(_v <= configured_connect_attempts_max_retries);
+      }
 
       unsigned
       saved() const

--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -71,7 +71,7 @@
     }                                                           \
   }
 
-typedef time_t ink_time_t;
+using ink_time_t = time_t;
 
 struct HttpConfigParams;
 class HttpSM;
@@ -469,9 +469,9 @@ public:
   };
 
   struct State;
-  typedef void (*TransactFunc_t)(HttpTransact::State *);
+  using TransactFunc_t = void (*)(HttpTransact::State *);
 
-  typedef struct _CacheDirectives {
+  using CacheDirectives = struct _CacheDirectives {
     bool does_client_permit_lookup      = true;
     bool does_client_permit_storing     = true;
     bool does_client_permit_dns_storing = true;
@@ -481,9 +481,9 @@ public:
     bool does_server_permit_storing     = true;
 
     _CacheDirectives() {}
-  } CacheDirectives;
+  };
 
-  typedef struct _CacheLookupInfo {
+  using CacheLookupInfo = struct _CacheLookupInfo {
     HttpTransact::CacheAction_t action           = CACHE_DO_UNDEFINED;
     HttpTransact::CacheAction_t transform_action = CACHE_DO_UNDEFINED;
 
@@ -506,14 +506,14 @@ public:
     URL parent_selection_url_storage;
 
     _CacheLookupInfo() {}
-  } CacheLookupInfo;
+  };
 
-  typedef struct _RedirectInfo {
+  using RedirectInfo = struct _RedirectInfo {
     bool redirect_in_process = false;
     URL original_url;
 
     _RedirectInfo() {}
-  } RedirectInfo;
+  };
 
   struct ConnectionAttributes {
     HTTPVersion http_version;
@@ -568,7 +568,7 @@ public:
     }
   };
 
-  typedef struct _CurrentInfo {
+  using CurrentInfo = struct _CurrentInfo {
     ProxyMode_t mode                             = UNDEFINED_MODE;
     ResolveInfo::UpstreamResolveStyle request_to = ResolveInfo::UNDEFINED_LOOKUP;
     ConnectionAttributes *server                 = nullptr;
@@ -576,40 +576,39 @@ public:
     ServerState_t state                          = STATE_UNDEFINED;
     class Attempts
     {
-    public:
-      Attempts()                 = default;
-      Attempts(Attempts const &) = delete;
+      return _v;
+    }
 
-      unsigned
-      get() const
-      {
-        return _v;
+    void
+    maximize(MgmtInt configured_connect_attempts_max_retries)
+    {
+      ink_assert(_v <= configured_connect_attempts_max_retries);
+      if (_v < configured_connect_attempts_max_retries) {
+        ink_assert(0 == _saved_v);
+        _saved_v = _v;
+        _v       = configured_connect_attempts_max_retries;
       }
+    }
 
-      void
-      maximize(MgmtInt configured_connect_attempts_max_retries)
-      {
-        ink_assert(_v <= configured_connect_attempts_max_retries);
-        if (_v < configured_connect_attempts_max_retries) {
-          ink_assert(0 == _saved_v);
-          _saved_v = _v;
-          _v       = configured_connect_attempts_max_retries;
-        }
-      }
+    void
+    clear()
+    {
+      _v       = 0;
+      _saved_v = 0;
+    }
 
-      void
-      clear()
-      {
-        _v       = 0;
-        _saved_v = 0;
-      }
+    void
+    increment(MgmtInt configured_connect_attempts_max_retries)
+    {
+      ++_v;
+      ink_assert(_v <= configured_connect_attempts_max_retries);
+    }
 
-      void
-      increment(MgmtInt configured_connect_attempts_max_retries)
-      {
-        ++_v;
-        ink_assert(_v <= configured_connect_attempts_max_retries);
-      }
+    unsigned
+    saved() const
+    {
+      return _saved_v ? _saved_v : _v;
+    }
 
       unsigned
       saved() const
@@ -627,13 +626,12 @@ public:
 
     _CurrentInfo()                     = default;
     _CurrentInfo(_CurrentInfo const &) = delete;
-
-  } CurrentInfo;
+  };
 
   // Conversion handling for DNS host resolution type.
   static const MgmtConverter HOST_RES_CONV;
 
-  typedef struct _HeaderInfo {
+  using HeaderInfo = struct _HeaderInfo {
     HTTPHdr client_request;
     HTTPHdr client_response;
     HTTPHdr server_request;
@@ -650,23 +648,23 @@ public:
     bool extension_method           = false;
 
     _HeaderInfo() {}
-  } HeaderInfo;
+  };
 
-  typedef struct _SquidLogInfo {
+  using SquidLogInfo = struct _SquidLogInfo {
     SquidLogCode log_code          = SQUID_LOG_ERR_UNKNOWN;
     SquidSubcode subcode           = SQUID_SUBCODE_EMPTY;
     SquidHierarchyCode hier_code   = SQUID_HIER_EMPTY;
     SquidHitMissCode hit_miss_code = SQUID_MISS_NONE;
 
     _SquidLogInfo() {}
-  } SquidLogInfo;
+  };
 
-  typedef struct _ResponseAction {
+  using ResponseAction = struct _ResponseAction {
     bool handled = false;
     TSResponseAction action;
 
     _ResponseAction() {}
-  } ResponseAction;
+  };
 
   struct State {
     HttpSM *state_machine = nullptr;
@@ -1105,7 +1103,7 @@ public:
   static bool is_connection_collapse_checks_success(State *s); // YTS Team, yamsat
 };
 
-typedef void (*TransactEntryFunc_t)(HttpTransact::State *s);
+using TransactEntryFunc_t = void (*)(HttpTransact::State *);
 
 /* The spec says about message body the following:
  *

--- a/proxy/http/HttpTunnel.h
+++ b/proxy/http/HttpTunnel.h
@@ -59,12 +59,12 @@
 struct HttpTunnelProducer;
 class HttpSM;
 class HttpPagesHandler;
-typedef int (HttpSM::*HttpSMHandler)(int event, void *data);
+using HttpSMHandler = int (HttpSM::*)(int, void *);
 
 struct HttpTunnelConsumer;
 struct HttpTunnelProducer;
-typedef int (HttpSM::*HttpProducerHandler)(int event, HttpTunnelProducer *p);
-typedef int (HttpSM::*HttpConsumerHandler)(int event, HttpTunnelConsumer *c);
+using HttpProducerHandler = int (HttpSM::*)(int, HttpTunnelProducer *);
+using HttpConsumerHandler = int (HttpSM::*)(int, HttpTunnelConsumer *);
 
 enum HttpTunnelType_t { HT_HTTP_SERVER, HT_HTTP_CLIENT, HT_CACHE_READ, HT_CACHE_WRITE, HT_TRANSFORM, HT_STATIC, HT_BUFFER_READ };
 

--- a/proxy/http/remap/AclFiltering.h
+++ b/proxy/http/remap/AclFiltering.h
@@ -83,7 +83,7 @@ public:
   bool method_restriction_enabled;
   std::vector<bool> standard_method_lookup;
 
-  typedef std::set<std::string> MethodMap;
+  using MethodMap = std::set<std::string>;
   MethodMap nonstandard_methods;
 
   // src_ip

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -76,6 +76,6 @@ unsigned long remap_check_option(const char **argv, int argc, unsigned long find
 
 bool remap_parse_config(const char *path, UrlRewrite *rewrite);
 
-typedef void (*load_remap_file_func)(const char *, const char *);
+using load_remap_file_func = void (*)(const char *, const char *);
 
 extern load_remap_file_func load_remap_file_cb;

--- a/proxy/http/remap/UrlMappingPathIndex.h
+++ b/proxy/http/remap/UrlMappingPathIndex.h
@@ -41,7 +41,7 @@ public:
   std::string PrintUrlMappingPathIndex() const;
 
 private:
-  typedef Trie<url_mapping> UrlMappingTrie;
+  using UrlMappingTrie = Trie<url_mapping>;
 
   struct UrlMappingTrieKey {
     int scheme_wks_idx;
@@ -58,7 +58,7 @@ private:
     }
   };
 
-  typedef std::map<UrlMappingTrieKey, UrlMappingTrie *> UrlMappingGroup;
+  using UrlMappingGroup = std::map<UrlMappingTrieKey, UrlMappingTrie *>;
   UrlMappingGroup m_tries;
 
   // make copy-constructor and assignment operator private

--- a/proxy/http/remap/UrlRewrite.h
+++ b/proxy/http/remap/UrlRewrite.h
@@ -140,7 +140,7 @@ public:
     LINK(RegexMapping, link);
   };
 
-  typedef Queue<RegexMapping> RegexMappingList;
+  using RegexMappingList = Queue<RegexMapping>;
 
   struct MappingsStore {
     std::unique_ptr<URLTable> hash_lookup;

--- a/proxy/http/remap/unit-tests/plugin_testing_common.h
+++ b/proxy/http/remap/unit-tests/plugin_testing_common.h
@@ -90,7 +90,7 @@ public:
 extern "C" {
 #endif /* __cplusplus */
 
-typedef void *GetPluginDebugObjectFunction(void);
+using GetPluginDebugObjectFunction = void *();
 GetPluginDebugObjectFunction getPluginDebugObjectTest;
 
 #define PluginDebug(category, fmt, ...) \

--- a/proxy/http2/HPACK.h
+++ b/proxy/http2/HPACK.h
@@ -178,7 +178,7 @@ int64_t update_dynamic_table_size(const uint8_t *buf_start, const uint8_t *buf_e
                                   uint32_t maximum_table_size);
 
 // High level interfaces
-typedef HpackIndexingTable HpackHandle;
+using HpackHandle = HpackIndexingTable;
 int64_t hpack_decode_header_block(HpackHandle &handle, HTTPHdr *hdr, const uint8_t *in_buf, const size_t in_buf_len,
                                   uint32_t max_header_size, uint32_t maximum_table_size);
 int64_t hpack_encode_header_block(HpackHandle &handle, uint8_t *out_buf, const size_t out_buf_len, HTTPHdr *hdr,

--- a/proxy/logging/LogField.h
+++ b/proxy/logging/LogField.h
@@ -79,11 +79,11 @@ struct LogSlice {
 class LogField
 {
 public:
-  typedef int (LogAccess::*MarshalFunc)(char *buf);
-  typedef int (*UnmarshalFunc)(char **buf, char *dest, int len);
-  typedef int (*UnmarshalFuncWithSlice)(char **buf, char *dest, int len, LogSlice *slice, LogEscapeType escape_type);
-  typedef int (*UnmarshalFuncWithMap)(char **buf, char *dest, int len, const Ptr<LogFieldAliasMap> &map);
-  typedef void (LogAccess::*SetFunc)(char *buf, int len);
+  using MarshalFunc            = int (LogAccess::*)(char *);
+  using UnmarshalFunc          = int (*)(char **, char *, int);
+  using UnmarshalFuncWithSlice = int (*)(char **, char *, int, LogSlice *, LogEscapeType);
+  using UnmarshalFuncWithMap   = int (*)(char **, char *, int, const Ptr<LogFieldAliasMap> &);
+  using SetFunc                = void (LogAccess::*)(char *, int);
 
   using VarUnmarshalFuncSliceOnly = std::variant<UnmarshalFunc, UnmarshalFuncWithSlice>;
   using VarUnmarshalFunc          = std::variant<decltype(nullptr), UnmarshalFunc, UnmarshalFuncWithSlice, UnmarshalFuncWithMap>;

--- a/proxy/logging/LogFieldAliasMap.h
+++ b/proxy/logging/LogFieldAliasMap.h
@@ -78,7 +78,7 @@ public:
   // The problem using the correct type is that the init method is
   // vararg. To make that work, we must use the "generic" int.
 
-  typedef int64_t IntType;
+  using IntType = int64_t;
   enum {
     ALL_OK = 0,
     INVALID_INT,

--- a/proxy/logging/LogFilter.h
+++ b/proxy/logging/LogFilter.h
@@ -152,7 +152,7 @@ private:
 
   // note: OperatorFunction's must return 0 (zero) if condition is satisfied
   // (as strcmp does)
-  typedef int (*OperatorFunction)(const char *, const char *);
+  using OperatorFunction = int (*)(const char *, const char *);
 
   static int
   _isSubstring(const char *s0, const char *s1)

--- a/proxy/logging/LogObject.h
+++ b/proxy/logging/LogObject.h
@@ -334,7 +334,7 @@ public:
   };
 
 private:
-  typedef std::vector<LogObject *> LogObjectList;
+  using LogObjectList = std::vector<LogObject *>;
 
   LogObjectList _objects;    // array of configured objects
   LogObjectList _APIobjects; // array of API objects

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -483,7 +483,7 @@ struct Stripe {
     Bytes _skip;  ///< # of bytes not valid at the start of the first block.
     Bytes _clip;  ///< # of bytes not valid at the end of the last block.
 
-    typedef std::vector<MemSpan<void>> Chain;
+    using Chain = std::vector<MemSpan<void>>;
     Chain _chain; ///< Chain of blocks.
 
     ~Chunk();

--- a/src/tscore/unit_tests/test_MMH.cc
+++ b/src/tscore/unit_tests/test_MMH.cc
@@ -44,7 +44,7 @@ xxcompar(const void *a, const void *b)
   return 0;
 }
 
-typedef uint32_t i4_t[4];
+using i4_t = uint32_t[4];
 i4_t *xxh;
 double *xf;
 

--- a/src/wccp/WccpConfig.cc
+++ b/src/wccp/WccpConfig.cc
@@ -68,7 +68,7 @@ struct CfgString {
   std::string m_text; ///< Text value of the option.
   bool m_found;       ///< String was found.
 };
-typedef std::vector<CfgString> CfgOpts;
+using CfgOpts = std::vector<CfgString>;
 
 #define N_OPTS(x) (sizeof(x) / sizeof(*x))
 

--- a/src/wccp/WccpLocal.h
+++ b/src/wccp/WccpLocal.h
@@ -100,8 +100,8 @@ static int const PARSE_DATA_OVERRUN = 10;
 class MsgBuffer : protected ts::Buffer
 {
 public:
-  typedef MsgBuffer self;   ///< Self reference type.
-  typedef ts::Buffer super; ///< Parent type.
+  using self  = MsgBuffer;  ///< Self reference type.
+  using super = ts::Buffer; ///< Parent type.
 
   MsgBuffer(); ///< Default construct empty buffer.
   /// Construct from ATS buffer.
@@ -177,7 +177,7 @@ enum CompType {
 /// Router Identity.
 /// Data is stored in host order. This structure is not used publicly.
 struct RouterId {
-  typedef RouterId self; ///< Self reference type.
+  using self = RouterId; ///< Self reference type.
 
   RouterId(); ///< Default constructor.
   /// Construct from address and sequence number.
@@ -199,9 +199,9 @@ struct RouterId {
 class RouterIdElt : protected RouterId
 {
 protected:
-  typedef RouterId super; ///< Parent type.
+  using super = RouterId; ///< Parent type.
 public:
-  typedef RouterIdElt self; ///< Self reference type.
+  using self = RouterIdElt; ///< Self reference type.
 
   /// Default constructor, members zero initialized.
   RouterIdElt();
@@ -228,7 +228,7 @@ public:
 class AssignmentKeyElt
 {
 public:
-  typedef AssignmentKeyElt self; ///< Self reference type.
+  using self = AssignmentKeyElt; ///< Self reference type.
 
   AssignmentKeyElt(); ///< Default constructor. No member initialization.
   /// Construct from address and sequence number.
@@ -254,8 +254,8 @@ protected:
 class RouterAssignElt : public RouterIdElt
 {
 public:
-  typedef RouterAssignElt self; ///< Self reference type.
-  typedef RouterIdElt super;    ///< Parent type.
+  using self  = RouterAssignElt; ///< Self reference type.
+  using super = RouterIdElt;     ///< Parent type.
 
   /// Default constructor, members zero initialized.
   RouterAssignElt();
@@ -281,7 +281,7 @@ protected:
 class RouterAssignListElt
 {
 public:
-  typedef RouterAssignListElt self; ///< Self reference type.
+  using self = RouterAssignListElt; ///< Self reference type.
 
   /// Default constructor - @b no initialization.
   RouterAssignListElt();
@@ -329,7 +329,7 @@ protected:
 class CapabilityElt
 {
 public:
-  typedef CapabilityElt self; ///< Self reference type.
+  using self = CapabilityElt; ///< Self reference type.
 
   /// Capability types.
   enum Type : uint16_t {
@@ -366,7 +366,7 @@ protected:
 class MaskElt
 {
 public:
-  typedef MaskElt self; ///< Self reference type.
+  using self = MaskElt; ///< Self reference type.
 
   /// Default constructor - @b no initialization.
   MaskElt();
@@ -408,7 +408,7 @@ protected:
 class ValueElt
 {
 public:
-  typedef ValueElt self; ///< Self reference type.
+  using self = ValueElt; ///< Self reference type.
 
   /// Default constructor - @b no initialization.
   ValueElt();
@@ -448,7 +448,7 @@ protected:
 class MaskValueSetElt
 {
 public:
-  typedef MaskValueSetElt self; ///< Self reference type.
+  using self = MaskValueSetElt; ///< Self reference type.
 
   MaskValueSetElt(); ///< Default constructor.
   /// Construct from address and sequence number.
@@ -514,7 +514,7 @@ protected:
 class HashAssignElt
 {
 public:
-  typedef HashAssignElt self; ///< Self reference type.
+  using self = HashAssignElt; ///< Self reference type.
 
   /// Hash assignment bucket.
   struct Bucket {
@@ -581,12 +581,12 @@ protected:
 class MaskAssignElt
 {
 public:
-  typedef MaskAssignElt self; ///< Self reference type.
+  using self = MaskAssignElt; ///< Self reference type.
 
   /** A minimalist insert iterator.
    */
   struct appender {
-    typedef appender self; ///< Self reference type.
+    using self = appender; ///< Self reference type.
     /// Get pointer to current set.
     MaskValueSetElt *operator->();
     /// Append a new mask/value set.
@@ -656,7 +656,7 @@ class CacheIdElt
   friend class CacheIdBox;
 
 public:
-  typedef CacheIdElt self; ///< Self reference type.
+  using self = CacheIdElt; ///< Self reference type.
 
   /// Hash revision (protocol required).
   static uint16_t const HASH_REVISION = 0;
@@ -712,10 +712,10 @@ class CacheHashIdElt : public CacheIdElt
   friend class CacheIdBox;
 
 public:
-  typedef CacheHashIdElt self; ///< Self reference type.
-  typedef CacheIdElt super;    ///< Parent type.
+  using self  = CacheHashIdElt; ///< Self reference type.
+  using super = CacheIdElt;     ///< Parent type.
   /// Container for hash assignment.
-  typedef uint8_t HashBuckets[N_BUCKETS >> 3];
+  using HashBuckets = uint8_t[N_BUCKETS >> 3];
   /// @name Accessors
   //@{
   bool getBucket(int idx) const; ///< Get bucket state at index @a idx.
@@ -755,8 +755,8 @@ class CacheMaskIdElt : public CacheIdElt
   friend class CacheIdBox;
 
 public:
-  typedef CacheMaskIdElt self; ///< Self reference type.
-  typedef CacheIdElt super;    ///< Parent type.
+  using self  = CacheMaskIdElt; ///< Self reference type.
+  using super = CacheIdElt;     ///< Parent type.
   /// @name Accessors
   //@{
   uint16_t getWeight() const;  ///< Get weight field.
@@ -786,7 +786,7 @@ protected:
 class CacheIdBox
 {
 public:
-  typedef CacheIdBox self; ///< Self reference type.
+  using self = CacheIdBox; ///< Self reference type.
 
   /// Default constructor.
   CacheIdBox() = default;
@@ -871,7 +871,7 @@ protected:
 class ComponentBase
 {
 public:
-  typedef ComponentBase self; ///< Self reference type.
+  using self = ComponentBase; ///< Self reference type.
   /// Default constructor.
   ComponentBase() = default;
   /// Check for not present.
@@ -887,8 +887,8 @@ protected:
 class MsgHeaderComp : public ComponentBase
 {
 public:
-  typedef MsgHeaderComp self;  ///< Self reference type.
-  typedef ComponentBase super; ///< Parent type.
+  using self  = MsgHeaderComp; ///< Self reference type.
+  using super = ComponentBase; ///< Parent type.
 
   /// Sect 5.5:  Message Header
   /// Serialized layout of message header.
@@ -985,16 +985,16 @@ struct CompWithHeader : public ComponentBase {
 class SecurityComp : public CompWithHeader<SecurityComp>
 {
 public:
-  typedef SecurityComp self;          ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = SecurityComp;         ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
   /// Specify the type for this component.
   static CompType const COMP_TYPE = SECURITY_INFO;
 
   /// Import security option type.
-  typedef SecurityOption Option;
+  using Option = SecurityOption;
 
   static size_t const KEY_SIZE = 8;
-  typedef char Key[KEY_SIZE];
+  using Key                    = char[KEY_SIZE];
 
   /// Raw memory layout, no security.
   struct RawNone : public super::raw_t {
@@ -1006,7 +1006,7 @@ public:
     /// Size of MD5 hash (in bytes).
     static size_t const HASH_SIZE = 16;
     /// Storage for MD5 hash.
-    typedef uint8_t HashData[HASH_SIZE];
+    using HashData = uint8_t[HASH_SIZE];
     /// MD5 hash value.
     HashData m_data;
   };
@@ -1063,8 +1063,8 @@ protected:
 class ServiceComp : public CompWithHeader<ServiceComp>
 {
 public:
-  typedef ServiceComp self;           ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = ServiceComp;          ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Specify the type for this component.
   static CompType const COMP_TYPE = SERVICE_INFO;
@@ -1151,8 +1151,8 @@ protected:
 class RouterIdComp : public CompWithHeader<RouterIdComp>
 {
 public:
-  typedef RouterIdComp self;          ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = RouterIdComp;         ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Specify the type for this component.
   static CompType const COMP_TYPE = ROUTER_ID_INFO;
@@ -1237,8 +1237,8 @@ public:
 class CacheIdComp : public CompWithHeader<CacheIdComp>
 {
 public:
-  typedef CacheIdComp self;           ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = CacheIdComp;          ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = CACHE_ID_INFO;
@@ -1292,8 +1292,8 @@ protected:
 class RouterViewComp : public CompWithHeader<RouterViewComp>
 {
 public:
-  typedef RouterViewComp self;        ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = RouterViewComp;       ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = RTR_VIEW_INFO;
@@ -1381,8 +1381,8 @@ protected:
 class CacheViewComp : public CompWithHeader<CacheViewComp>
 {
 public:
-  typedef CacheViewComp self;         ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = CacheViewComp;        ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = CACHE_VIEW_INFO;
@@ -1457,8 +1457,8 @@ protected:
 class AssignInfoComp : public CompWithHeader<AssignInfoComp>
 {
 public:
-  typedef AssignInfoComp self;        ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = AssignInfoComp;       ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = REDIRECT_ASSIGNMENT;
@@ -1469,7 +1469,7 @@ public:
     AssignmentKeyElt m_key;        ///< Assignment key data.
     RouterAssignListElt m_routers; ///< Routers.
   };
-  typedef HashAssignElt::Bucket Bucket; ///< Import type.
+  using Bucket = HashAssignElt::Bucket; ///< Import type.
 
   /// @name Accessors
   //@{
@@ -1543,8 +1543,8 @@ protected:
 class CapComp : public CompWithHeader<CapComp>
 {
 public:
-  typedef CapComp self;               ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = CapComp;              ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = CAPABILITY_INFO;
@@ -1618,8 +1618,8 @@ protected:
 class AltAssignComp : public CompWithHeader<AltAssignComp>
 {
 public:
-  typedef AltAssignComp self;         ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = AltAssignComp;        ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = ALT_ASSIGNMENT;
@@ -1686,8 +1686,8 @@ protected:
 class AltHashAssignComp : public AltAssignComp
 {
 public:
-  typedef AltHashAssignComp self; ///< Self reference type.
-  typedef AltAssignComp super;    ///< Parent type.
+  using self  = AltHashAssignComp; ///< Self reference type.
+  using super = AltAssignComp;     ///< Parent type.
 
   /// @name Accessors
   //@{
@@ -1727,8 +1727,8 @@ protected:
 class AltMaskAssignComp : public AltAssignComp
 {
 public:
-  typedef AltMaskAssignComp self; ///< Self reference type.
-  typedef AltAssignComp super;    ///< Parent type.
+  using self  = AltMaskAssignComp; ///< Self reference type.
+  using super = AltAssignComp;     ///< Parent type.
 
   /// Force virtual destructor.
   virtual ~AltMaskAssignComp() {}
@@ -1750,8 +1750,8 @@ protected:
 class CmdComp : public CompWithHeader<CmdComp>
 {
 public:
-  typedef CmdComp self;               ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = CmdComp;              ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = COMMAND_EXTENSION;
@@ -1799,8 +1799,8 @@ public:
 class AssignMapComp : public CompWithHeader<AssignMapComp>
 {
 public:
-  typedef AssignMapComp self;         ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = AssignMapComp;        ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = ASSIGN_MAP;
@@ -1834,8 +1834,8 @@ public:
 class QueryComp : public CompWithHeader<QueryComp>
 {
 public:
-  typedef QueryComp self;             ///< Self reference type.
-  typedef CompWithHeader<self> super; ///< Parent type.
+  using self  = QueryComp;            ///< Self reference type.
+  using super = CompWithHeader<self>; ///< Parent type.
 
   /// Component type ID for this component.
   static CompType const COMP_TYPE = QUERY_INFO;
@@ -1908,11 +1908,11 @@ namespace detail
   class Assignment
   {
   public:
-    typedef Assignment self;      ///< Self reference type.
-    typedef AssignmentKeyElt Key; ///< Import assignment key type.
+    using self = Assignment;       ///< Self reference type.
+    using Key  = AssignmentKeyElt; ///< Import assignment key type.
     /// Import assignment bucket definition.
     /// @internal Just one byte, no serialization issues.
-    typedef AssignInfoComp::Bucket Bucket;
+    using Bucket = AssignInfoComp::Bucket;
 
     /// Default constructor. Initialization to empty state.
     Assignment();
@@ -1975,7 +1975,7 @@ namespace detail
   {
     /// Common service group data.
     struct GroupData {
-      typedef GroupData self; ///< Self reference type.
+      using self = GroupData; ///< Self reference type.
 
       ServiceGroup m_svc;           ///< The service definition.
       uint32_t m_generation    = 0; ///< Generation value (change number).
@@ -2043,7 +2043,7 @@ protected:
 class HereIAmMsg : public BaseMsg
 {
 public:
-  typedef HereIAmMsg self; ///< Self reference type.
+  using self = HereIAmMsg; ///< Self reference type.
 
   /** Fill in the basic message structure.
       This expects @c setBuffer to have already been called
@@ -2076,7 +2076,7 @@ public:
 class ISeeYouMsg : public BaseMsg
 {
 public:
-  typedef ISeeYouMsg self; ///< Self reference type.
+  using self = ISeeYouMsg; ///< Self reference type.
 
   /// Fill out message structure.
   /// Router ID and view data must be filled in separately.
@@ -2109,7 +2109,7 @@ public:
 class RedirectAssignMsg : public BaseMsg
 {
 public:
-  typedef RedirectAssignMsg self; ///< Self reference type.
+  using self = RedirectAssignMsg; ///< Self reference type.
 
   /** Fill in the basic message structure.
       This expects @c setBuffer to have already been called
@@ -2136,7 +2136,7 @@ public:
 class RemovalQueryMsg : public BaseMsg
 {
 public:
-  typedef RemovalQueryMsg self; ///< Self reference type.
+  using self = RemovalQueryMsg; ///< Self reference type.
 
   /** Fill in the basic message structure.
       This expects @c setBuffer to have already been called
@@ -2162,7 +2162,7 @@ public:
 // ------------------------------------------------------
 /// Last packet information.
 struct PacketStamp {
-  typedef PacketStamp self; ///< Self reference type.
+  using self = PacketStamp; ///< Self reference type.
 
   PacketStamp(); ///< Default constructor (zero elements).
   /// Set the @a time and @a generation.
@@ -2191,10 +2191,10 @@ class Impl : public ts::IntrusivePtrCounter
   friend class EndPoint;
 
 public:
-  typedef Impl self; ///< Self reference type.
+  using self = Impl; ///< Self reference type.
 
   /// Import detail struct.
-  typedef detail::endpoint::GroupData GroupData;
+  using GroupData = detail::endpoint::GroupData;
 
   /// Default constructor.
   Impl() = default;
@@ -2342,17 +2342,17 @@ namespace detail
     };
 
     /// Storage type for known caches.
-    typedef std::vector<CacheData> CacheBag;
+    using CacheBag = std::vector<CacheData>;
     /// Storage type for known routers.
-    typedef std::vector<RouterData> RouterBag;
+    using RouterBag = std::vector<RouterData>;
 
     /** Cache's view of a service group.
         This stores the internal accounting information, it is not the
         serialized form.
     */
     struct GroupData : public endpoint::GroupData {
-      typedef GroupData self;            ///< Self reference type.
-      typedef endpoint::GroupData super; ///< Parent type.
+      using self  = GroupData;           ///< Self reference type.
+      using super = endpoint::GroupData; ///< Parent type.
 
       /// Cache identity of this cache.
       CacheIdBox m_id;
@@ -2449,16 +2449,16 @@ namespace detail
 class CacheImpl : public Impl
 {
 public:
-  typedef CacheImpl self; ///< Self reference type.
-  typedef Impl super;     ///< Parent type.
+  using self  = CacheImpl; ///< Self reference type.
+  using super = Impl;      ///< Parent type.
 
   // Import details
-  typedef detail::cache::SeedRouter SeedRouter;
-  typedef detail::cache::CacheData CacheData;
-  typedef detail::cache::RouterData RouterData;
-  typedef detail::cache::GroupData GroupData;
-  typedef detail::cache::CacheBag CacheBag;
-  typedef detail::cache::RouterBag RouterBag;
+  using SeedRouter = detail::cache::SeedRouter;
+  using CacheData  = detail::cache::CacheData;
+  using RouterData = detail::cache::RouterData;
+  using GroupData  = detail::cache::GroupData;
+  using CacheBag   = detail::cache::CacheBag;
+  using RouterBag  = detail::cache::RouterBag;
 
   /** Define a service group.
       If no service is defined for the ID in @a svc, it is created.
@@ -2528,7 +2528,7 @@ protected:
                                 ) override;
 
   /// Map Service Group ID to Service Group Data.
-  typedef std::map<uint8_t, GroupData> GroupMap;
+  using GroupMap = std::map<uint8_t, GroupData>;
   /// Active service groups.
   GroupMap m_groups;
 
@@ -2572,7 +2572,7 @@ namespace detail
 
     /// Router's view of other routers.
     struct RouterData {
-      typedef RouterData self; ///< Self reference type.
+      using self = RouterData; ///< Self reference type.
 
       /// Identifying IP address of router.
       uint32_t m_addr;
@@ -2586,9 +2586,9 @@ namespace detail
     };
 
     /// Storage type for known caches.
-    typedef std::vector<CacheData> CacheBag;
+    using CacheBag = std::vector<CacheData>;
     /// Storage type for known routers.
-    typedef std::vector<RouterData> RouterBag;
+    using RouterBag = std::vector<RouterData>;
 
     /** A router's view of a service group.
 
@@ -2596,8 +2596,8 @@ namespace detail
         serialized form.
     */
     struct GroupData : public detail::endpoint::GroupData {
-      typedef GroupData self;                    ///< Self reference type.
-      typedef detail::endpoint::GroupData super; ///< Parent type.
+      using self  = GroupData;                   ///< Self reference type.
+      using super = detail::endpoint::GroupData; ///< Parent type.
 
       GroupData(); ///< Default constructor.
 
@@ -2621,14 +2621,14 @@ namespace detail
 class RouterImpl : public Impl
 {
 public:
-  typedef RouterImpl self; ///< Self reference type.
-  typedef Impl super;      ///< Parent type.
+  using self  = RouterImpl; ///< Self reference type.
+  using super = Impl;       ///< Parent type.
   // Import details
-  typedef detail::router::CacheData CacheData;
-  typedef detail::router::RouterData RouterData;
-  typedef detail::router::GroupData GroupData;
-  typedef detail::router::CacheBag CacheBag;
-  typedef detail::router::RouterBag RouterBag;
+  using CacheData  = detail::router::CacheData;
+  using RouterData = detail::router::RouterData;
+  using GroupData  = detail::router::GroupData;
+  using CacheBag   = detail::router::CacheBag;
+  using RouterBag  = detail::router::RouterBag;
 
   /// Process HERE_I_AM message.
   ts::Errata handleHereIAm(IpHeader const &header, ///< IP packet data.
@@ -2659,7 +2659,7 @@ protected:
   );
 
   /// Map Service Group ID to Service Group Data.
-  typedef std::map<uint8_t, GroupData> GroupMap;
+  using GroupMap = std::map<uint8_t, GroupData>;
   /// Active service groups.
   GroupMap m_groups;
 };

--- a/src/wccp/WccpMeta.h
+++ b/src/wccp/WccpMeta.h
@@ -34,7 +34,7 @@ namespace ts
 // This creates the actual error, depending on whether X has a valid
 // nest type Result.
 template <typename X> struct TEST_RESULT {
-  typedef typename X::Result type;
+  using type = typename X::Result;
 };
 
 // Bool checking - a base template then specializations to succeed or
@@ -43,7 +43,7 @@ template <bool VALUE> struct TEST_BOOL {
 };
 // Successful test defines Result.
 template <> struct TEST_BOOL<true> {
-  typedef int Result;
+  using Result = int;
 };
 // Failing test does not define Result.
 template <> struct TEST_BOOL<false> {
@@ -157,7 +157,7 @@ template <typename Elt,  ///< Element type.
           typename Value ///< Member value type.
           >
 struct MethodPredicate {
-  typedef Value (Elt::*MethodPtr)() const;
+  using MethodPtr = Value (Elt::*)() const;
   Value const &m_value; ///< Value to test against.
   MethodPtr m_mptr;     ///< Pointer to method returning value.
   MethodPredicate(MethodPtr mptr, Value const &v) : m_value(v), m_mptr(mptr) {}

--- a/tests/tools/plugins/ssntxnorder_verify.cc
+++ b/tests/tools/plugins/ssntxnorder_verify.cc
@@ -51,13 +51,13 @@ thread_local int ssn_balance = 0; // +1 on SSN_START, -1 on SSN_CLOSE
 
 // Metadata for active transactions. Stored upon start to persist improper
 // closing behavior.
-typedef struct started_txn {
+using started_txn = struct started_txn {
   uint64_t id;
   TSHttpTxn txnp;
   TSHttpSsn ssnp;                      // enclosing session
   started_txn(uint64_t id) : id(id) {} // used for lookup on id
   started_txn(uint64_t id, TSHttpTxn txnp, TSHttpSsn ssnp) : id(id), txnp(txnp), ssnp(ssnp) {}
-} started_txn;
+};
 
 // Comparator functor for transactions. Compare by ID.
 struct txn_compare {

--- a/tests/tools/plugins/user_args.cc
+++ b/tests/tools/plugins/user_args.cc
@@ -26,10 +26,10 @@
 #include <cstring>
 #include <cstdio>
 
-typedef struct {
+using ArgIndexes = struct {
   int TXN, SSN, VCONN, GLB;
   TSCont contp;
-} ArgIndexes;
+};
 
 const char *PLUGIN_NAME = "user_args_test";
 ArgIndexes gIX;

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -122,8 +122,8 @@ enum FTP_MODE {
   FTP_PASV,
 };
 
-typedef int (*accept_fn_t)(int);
-typedef int (*poll_cb)(int);
+using accept_fn_t = int (*)(int);
+using poll_cb     = int (*)(int);
 
 static int read_request(int sock);
 static int write_request(int sock);


### PR DESCRIPTION
using aliases are pretty universally preferred over typedefs. Modern
editors complain about them which is distracting. This is a pass through
all typedefs, changing the non-c uses of them to using aliases.