### PR TITLE
Adds a new hash_url directive to strategies

### DIFF
--- a/configs/strategies.schema.json
+++ b/configs/strategies.schema.json
@@ -136,6 +136,15 @@
                       "consistent_hash"
                     ]
                 },
+                "hash_url": {
+                  "type": "string",
+                  "description": "when using consistent_hash, this specifies the chosen URL for the hash",
+                  "enum": [
+                    "request",
+                    "cache",
+                    "parent"
+                  ]
+                },
                 "hash_key": {
                   "type": "string",
                   "description": "when using consistent_hash, this specifies the chosen key used for the hash",

--- a/doc/admin-guide/files/strategies.yaml.en.rst
+++ b/doc/admin-guide/files/strategies.yaml.en.rst
@@ -182,8 +182,17 @@ Each **strategy** in the list may using the following parameters:
    #. **path**: (**default**) Creates a hash over the path portion of the request URL.
    #. **path+query**: Same as **path** but adds the **query string** in the request URL.
    #. **path+fragment**: Same as **path** but adds the fragment portion of the URL.
-   #. **cache_key**: Uses the hash key from the **cachekey** plugin.  defaults to **path** if the **cachekey** plugin is not configured on the **remap**.
+   #. **cache_key**: Deprecated, use the URL designation instead.
    #. **url**: Creates a hash from the entire request url.
+
+- **hash_url**: The specific URL to use for the **hash_key**. If the specified URL type does
+  not have a value (e.g. not set by an API), we default back to the reqeust URL. Use one of:
+
+   #. **request**: (**default**) Use the client request URL.
+   #. **cache**: Use the cache key URL as set via the APIs :c:func:`TSHttpTxnCacheLookupUrlSet()`
+      or :c:func:`TSCacheUrlSet()`. This would likely be set using a plugin such as **cachekey**.
+   #. **parent**: Use the parent URL as set via the API :c:func:`TSHttpTxnParentSelectionUrlSet`.
+      This again is likely set via an existing plugin such as the **cachekey** plugin.
 
 - **go_direct**: A boolean value indicating whether a transaction may bypass proxies and go direct to the origin. Defaults to **true**
 - **parent_is_proxy**: A boolean value which indicates if the groups of hosts are proxy caches or origins.  **true** (default) means all the hosts used in the remap are |TS| caches.  **false** means the hosts are origins that the next hop strategies may use for load balancing and/or failover.
@@ -238,7 +247,8 @@ Example:
           - passive
     - strategy: 'strategy-2'
       policy: rr_strict
-      hash_key: cache_key
+      hash_url: cache
+      hash_key: path+query
       go_direct: true
       groups:
         - *g1

--- a/doc/admin-guide/files/strategies.yaml.en.rst
+++ b/doc/admin-guide/files/strategies.yaml.en.rst
@@ -185,6 +185,13 @@ Each **strategy** in the list may using the following parameters:
    #. **cache_key**: Deprecated, use the URL designation instead.
    #. **url**: Creates a hash from the entire request url.
 
+  To get the same behaviour as the old **cache_key** directive, you would use the following YAML:
+
+  .. code-block:: yaml
+
+     hash_url: parent
+     hash_key: url
+
 - **hash_url**: The specific URL to use for the **hash_key**. If the specified URL type does
   not have a value (e.g. not set by an API), we default back to the reqeust URL. Use one of:
 

--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -67,10 +67,9 @@ ParentConsistentHash::getPathHash(HttpRequestData *hrdata, ATSHash64 *h)
 {
   const char *url_string_ref = nullptr;
   int len;
-  URL *url = hrdata->hdr->url_get();
+  URL *ps_url = nullptr;
 
   // Use over-ride URL from HttpTransact::State's cache_info.parent_selection_url, if present.
-  URL *ps_url = nullptr;
   if (hrdata->cache_info_parent_selection_url) {
     ps_url = *(hrdata->cache_info_parent_selection_url);
     if (ps_url) {
@@ -85,16 +84,18 @@ ParentConsistentHash::getPathHash(HttpRequestData *hrdata, ATSHash64 *h)
     }
   }
 
+  ps_url = hrdata->hdr->url_get();
+
   // Always hash on '/' because paths returned by ATS are always stripped of it
   h->update("/", 1);
 
-  url_string_ref = url->path_get(&len);
+  url_string_ref = ps_url->path_get(&len);
   if (url_string_ref) {
     h->update(url_string_ref, len);
   }
 
   if (!ignore_query) {
-    url_string_ref = url->query_get(&len);
+    url_string_ref = ps_url->query_get(&len);
     if (url_string_ref) {
       h->update("?", 1);
       h->update(url_string_ref, len);

--- a/proxy/http/remap/NextHopConsistentHash.cc
+++ b/proxy/http/remap/NextHopConsistentHash.cc
@@ -237,15 +237,15 @@ NextHopConsistentHash::getHashKey(uint64_t sm_id, const HttpRequestData &hrdata,
   // use the cache key created by the TSCacheUrlSet() API (e.g. the cachekey plugin)
   // ToDo: Deprecated in 10.0.x, remove in 11.0.0
   case NH_CACHE_HASH_KEY:
-    url = *(hrdata.cache_info_parent_selection_url);
-    if (url) {
+    if (hrdata.cache_info_parent_selection_url && *(hrdata.cache_info_parent_selection_url)) {
+      url            = *(hrdata.cache_info_parent_selection_url);
       url_string_ref = url->string_get_ref(&len);
       if (url_string_ref && len > 0) {
         NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] using parent selection over-ride string:'%.*s'.", sm_id, len, url_string_ref);
         h->update(url_string_ref, len);
       }
     } else {
-      url            = hrdata.hdr->url_get();
+      // URL defaults to hrdata.hdr->url_get() above
       url_string_ref = url->path_get(&len);
       h->update("/", 1);
       if (url_string_ref && len > 0) {

--- a/proxy/http/remap/NextHopConsistentHash.cc
+++ b/proxy/http/remap/NextHopConsistentHash.cc
@@ -36,6 +36,11 @@ constexpr std::string_view hash_key_path_query    = "path+query";
 constexpr std::string_view hash_key_path_fragment = "path+fragment";
 constexpr std::string_view hash_key_cache         = "cache_key";
 
+// hash_url strings
+constexpr std::string_view hash_url_request = "request";
+constexpr std::string_view hash_url_cache   = "cache";
+constexpr std::string_view hash_url_parent  = "parent";
+
 static bool
 isWrapped(std::vector<bool> &wrap_around, uint32_t groups)
 {
@@ -89,6 +94,26 @@ NextHopConsistentHash::NextHopConsistentHash(const std::string_view name, const 
   ATSHash64Sip24 hash;
 
   try {
+    if (n["hash_url"]) {
+      auto hash_url_val = n["hash_url"].Scalar();
+      if (hash_url_val == hash_url_request) {
+        hash_url = NH_HASH_URL_REQUEST;
+      } else if (hash_url_val == hash_url_cache) {
+        hash_url = NH_HASH_URL_CACHE;
+      } else if (hash_url_val == hash_url_parent) {
+        hash_url = NH_HASH_URL_PARENT;
+      } else {
+        hash_url = NH_HASH_URL_REQUEST;
+        NH_Note("Invalid 'hash_url' value, '%s', for the strategy named '%s', using default '%s'.", hash_url_val.c_str(),
+                strategy_name.c_str(), hash_url_request.data());
+      }
+    }
+  } catch (std::exception &ex) {
+    throw std::invalid_argument("Error parsing the strategy named '" + strategy_name + "' due to '" + ex.what() +
+                                "', this strategy will be ignored.");
+  }
+
+  try {
     if (n["hash_key"]) {
       auto hash_key_val = n["hash_key"].Scalar();
       if (hash_key_val == hash_key_url) {
@@ -102,6 +127,7 @@ NextHopConsistentHash::NextHopConsistentHash(const std::string_view name, const 
       } else if (hash_key_val == hash_key_path_fragment) {
         hash_key = NH_PATH_FRAGMENT_HASH_KEY;
       } else if (hash_key_val == hash_key_cache) {
+        // ToDo: Deprecated in 10.0.x, remove in 11.0.0
         hash_key = NH_CACHE_HASH_KEY;
       } else {
         hash_key = NH_PATH_HASH_KEY;
@@ -142,10 +168,29 @@ NextHopConsistentHash::NextHopConsistentHash(const std::string_view name, const 
 uint64_t
 NextHopConsistentHash::getHashKey(uint64_t sm_id, const HttpRequestData &hrdata, ATSHash64 *h)
 {
-  URL *url                   = hrdata.hdr->url_get();
-  URL *ps_url                = nullptr;
+  URL *url                   = nullptr;
   int len                    = 0;
   const char *url_string_ref = nullptr;
+
+  switch (hash_url) {
+  case NH_HASH_URL_REQUEST:
+    break;
+  case NH_HASH_URL_CACHE:
+    if (hrdata.cache_info_lookup_url) {
+      url = *(hrdata.cache_info_lookup_url);
+    }
+    break;
+  case NH_HASH_URL_PARENT:
+    if (hrdata.cache_info_parent_selection_url) {
+      url = *(hrdata.cache_info_parent_selection_url);
+    }
+    break;
+  }
+
+  // Make sure we default to the request URL if nothing else worked
+  if (!url) {
+    url = hrdata.hdr->url_get();
+  }
 
   // calculate a hash using the selected config.
   switch (hash_key) {
@@ -189,16 +234,18 @@ NextHopConsistentHash::getHashKey(uint64_t sm_id, const HttpRequestData &hrdata,
       h->update(url_string_ref, len);
     }
     break;
-  // use the cache key created by the cache-key plugin.
+  // use the cache key created by the TSCacheUrlSet() API (e.g. the cachekey plugin)
+  // ToDo: Deprecated in 10.0.x, remove in 11.0.0
   case NH_CACHE_HASH_KEY:
-    ps_url = *(hrdata.cache_info_parent_selection_url);
-    if (ps_url) {
-      url_string_ref = ps_url->string_get_ref(&len);
+    url = *(hrdata.cache_info_parent_selection_url);
+    if (url) {
+      url_string_ref = url->string_get_ref(&len);
       if (url_string_ref && len > 0) {
         NH_Debug(NH_DEBUG_TAG, "[%" PRIu64 "] using parent selection over-ride string:'%.*s'.", sm_id, len, url_string_ref);
         h->update(url_string_ref, len);
       }
     } else {
+      url            = hrdata.hdr->url_get();
       url_string_ref = url->path_get(&len);
       h->update("/", 1);
       if (url_string_ref && len > 0) {

--- a/proxy/http/remap/NextHopConsistentHash.h
+++ b/proxy/http/remap/NextHopConsistentHash.h
@@ -34,8 +34,10 @@ enum NHHashKeyType {
   NH_PATH_HASH_KEY, // default, consistent hash uses the request url path
   NH_PATH_QUERY_HASH_KEY,
   NH_PATH_FRAGMENT_HASH_KEY,
-  NH_CACHE_HASH_KEY
+  NH_CACHE_HASH_KEY // ToDo: Deprecated in 10.0.0, remove in 11.0.0
 };
+
+enum NHHashUrlType { NH_HASH_URL_REQUEST = 0, NH_HASH_URL_CACHE, NH_HASH_URL_PARENT };
 
 class NextHopConsistentHash : public NextHopSelectionStrategy
 {
@@ -45,6 +47,7 @@ class NextHopConsistentHash : public NextHopSelectionStrategy
 
 public:
   NHHashKeyType hash_key = NH_PATH_HASH_KEY;
+  NHHashUrlType hash_url = NH_HASH_URL_REQUEST;
 
   NextHopConsistentHash() = delete;
   NextHopConsistentHash(const std::string_view name, const NHPolicyType &policy, ts::Yaml::Map &n);

--- a/proxy/http/remap/unit-tests/combined.yaml
+++ b/proxy/http/remap/unit-tests/combined.yaml
@@ -157,7 +157,8 @@ strategies:
         - active
   - strategy: "mid-tier-midwest"
     policy: consistent_hash
-    hash_key: cache_key
+    hash_url: parent
+    hash_key: url
     go_direct: true
     parent_is_proxy: false # next hop hosts  are origin servers
     groups:

--- a/proxy/http/remap/unit-tests/consistent-hash-tests.yaml
+++ b/proxy/http/remap/unit-tests/consistent-hash-tests.yaml
@@ -28,6 +28,7 @@
 strategies:
   - strategy: "consistent-hash-1"
     policy: consistent_hash
+    hash_url: request
     hash_key: path
     groups:
       - &g1
@@ -172,6 +173,7 @@ strategies:
   - strategy: "ignore-self-detect-false"
     policy: consistent_hash
     ignore_self_detect: false
+    hash_url: cache
     hash_key: path
     groups:
       - &g1

--- a/proxy/http/remap/unit-tests/test_NextHopStrategyFactory.cc
+++ b/proxy/http/remap/unit-tests/test_NextHopStrategyFactory.cc
@@ -704,7 +704,7 @@ SCENARIO("factory tests loading yaml configs", "[loadConfig]")
         // the hash_key was set properly.
         NextHopConsistentHash *ptr = static_cast<NextHopConsistentHash *>(strategy.get());
         REQUIRE(ptr != nullptr);
-        CHECK(ptr->hash_key == NH_CACHE_HASH_KEY);
+        CHECK(ptr->hash_key == NH_URL_HASH_KEY);
 
         CHECK(strategy->go_direct == true);
         CHECK(strategy->scheme == NH_SCHEME_HTTPS);


### PR DESCRIPTION
In addition, this deprecates the old hash_key: cache_key directive. Not only is it replaces with this feature, the existing implementation is confusing because it's not the cache-key that's hashed on. It's the URL as set with TSHttpTxnParentSelectionUrlSet().