### PR TITLE
Use FetchSM for OCSP HTTP requests

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -282,7 +282,7 @@ AC_DEFUN([TS_CHECK_CRYPTO_OCSP], [
   AC_CHECK_HEADERS(openssl/ocsp.h, [ocsp_have_headers=1], [enable_tls_ocsp=no])
 
   if test "$ocsp_have_headers" == "1"; then
-    AC_CHECK_FUNCS(OCSP_sendreq_new OCSP_REQ_CTX_add1_header OCSP_REQ_CTX_set1_req, [enable_tls_ocsp=yes], [enable_tls_ocsp=no])
+    AC_CHECK_FUNCS(OCSP_response_status, [enable_tls_ocsp=yes], [enable_tls_ocsp=no])
 
     LIBS=$_ocsp_saved_LIBS
   fi

--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -284,3 +284,40 @@ INKContInternal::free()
 INKVConnInternal::INKVConnInternal() : INKContInternal() {}
 
 INKVConnInternal::INKVConnInternal(TSEventFunc funcp, TSMutex mutexp) : INKContInternal(funcp, mutexp) {}
+
+#include "../src/traffic_server/FetchSM.h"
+ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+void
+FetchSM::ext_launch()
+{
+}
+void
+FetchSM::ext_destroy()
+{
+}
+ssize_t
+FetchSM::ext_read_data(char *, unsigned long)
+{
+  return 0;
+}
+void
+FetchSM::ext_add_header(char const *, int, char const *, int)
+{
+}
+void
+FetchSM::ext_write_data(void const *, unsigned long)
+{
+}
+void *
+FetchSM::ext_get_user_data()
+{
+  return nullptr;
+}
+void
+FetchSM::ext_set_user_data(void *)
+{
+}
+void
+FetchSM::ext_init(Continuation *, char const *, char const *, char const *, sockaddr const *, int)
+{
+}

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -30,6 +30,8 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/mgmt \
 	-I$(abs_top_srcdir)/mgmt/utils \
 	-I$(abs_top_srcdir)/proxy/http \
+	-I$(abs_top_srcdir)/proxy/http/remap \
+	-I$(abs_top_srcdir)/src/traffic_server \
 	$(TS_INCLUDES) \
 	@OPENSSL_INCLUDES@ \
 	@BORINGOCSP_INCLUDES@ \

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -186,7 +186,7 @@ public:
   get_response_body(int *len)
   {
     SCOPED_MUTEX_LOCK(lock, mutex, this_ethread());
-    char *buf = static_cast<char *>(malloc(MAX_RESP_LEN));
+    char *buf = static_cast<char *>(ats_malloc(MAX_RESP_LEN));
     *len      = this->_fsm->ext_read_data(buf, MAX_RESP_LEN);
     return reinterpret_cast<unsigned char *>(buf);
   }
@@ -562,12 +562,12 @@ query_responder(const char *uri, const char *user_agent, OCSP_REQUEST *req, int 
   if (httpreq.is_success()) {
     // Parse the response
     int len;
-    const unsigned char *res = httpreq.get_response_body(&len);
-    const unsigned char *p   = res;
-    resp                     = reinterpret_cast<OCSP_RESPONSE *>(ASN1_item_d2i(nullptr, &p, len, ASN1_ITEM_rptr(OCSP_RESPONSE)));
+    unsigned char *res     = httpreq.get_response_body(&len);
+    const unsigned char *p = res;
+    resp                   = reinterpret_cast<OCSP_RESPONSE *>(ASN1_item_d2i(nullptr, &p, len, ASN1_ITEM_rptr(OCSP_RESPONSE)));
 
     if (resp) {
-      free(res);
+      ats_free(res);
       return resp;
     }
 
@@ -577,7 +577,7 @@ query_responder(const char *uri, const char *user_agent, OCSP_REQUEST *req, int 
       Error("failed to parse a response from OCSP server; uri=%s len=%d data=%02x%02x%02x%02x%02x...", uri, len, res[0], res[1],
             res[2], res[3], res[4]);
     }
-    free(res);
+    ats_free(res);
     return nullptr;
   }
 

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -540,7 +540,10 @@ query_responder(const char *uri, const char *user_agent, OCSP_REQUEST *req, int 
 
   // Content-Type, Content-Length, Request Body
   if (use_post) {
-    httpreq.set_body("application/ocsp-request", ASN1_ITEM_rptr(OCSP_REQUEST), (const ASN1_VALUE *)req);
+    if (httpreq.set_body("application/ocsp-request", ASN1_ITEM_rptr(OCSP_REQUEST), (const ASN1_VALUE *)req) != 1) {
+      Error("failed to make a request for OCSP server; uri=%s", uri);
+      return nullptr;
+    }
   }
 
   // Send request

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -567,6 +567,7 @@ query_responder(const char *uri, const char *user_agent, OCSP_REQUEST *req, int 
     resp                     = reinterpret_cast<OCSP_RESPONSE *>(ASN1_item_d2i(nullptr, &p, len, ASN1_ITEM_rptr(OCSP_RESPONSE)));
 
     if (resp) {
+      free(res);
       return resp;
     }
 
@@ -576,6 +577,7 @@ query_responder(const char *uri, const char *user_agent, OCSP_REQUEST *req, int 
       Error("failed to parse a response from OCSP server; uri=%s len=%d data=%02x%02x%02x%02x%02x...", uri, len, res[0], res[1],
             res[2], res[3], res[4]);
     }
+    free(res);
     return nullptr;
   }
 

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -85,11 +85,11 @@ public:
       this->fetch();
     } else {
       auto fsm = reinterpret_cast<FetchSM *>(e);
-      auto ctx = reinterpret_cast<HTTPRequest *>(fsm->ext_get_user_data());
+      auto req = reinterpret_cast<HTTPRequest *>(fsm->ext_get_user_data());
       if (event == TS_FETCH_EVENT_EXT_BODY_DONE) {
-        ctx->set_done();
+        req->set_done();
       } else if (event == TS_EVENT_ERROR) {
-        ctx->set_error();
+        req->set_error();
       }
     }
 

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -44,6 +44,11 @@
 // so 10K should be more than enough.
 #define MAX_STAPLING_DER 10240
 
+extern ClassAllocator<FetchSM> FetchSMAllocator;
+
+namespace
+{
+
 // Cached info stored in SSL_CTX ex_info
 struct certinfo {
   unsigned char idx[20]; // Index in session cache SHA1 hash of certificate
@@ -58,8 +63,6 @@ struct certinfo {
   bool is_expire;
   time_t expire_time;
 };
-
-extern ClassAllocator<FetchSM> FetchSMAllocator;
 
 class HTTPRequest : public Continuation
 {
@@ -194,6 +197,8 @@ private:
   int _req_body_len        = 0;
   int _result              = 0;
 };
+
+} // End of namespace
 
 /*
  * In the case of multiple certificates associated with a SSL_CTX, we must store a map

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -525,13 +525,12 @@ query_responder(const char *uri, const char *user_agent, OCSP_REQUEST *req, int 
   httpreq.set_request_line(use_post, uri);
 
   // Host header
-  HdrHeap *heap = new_HdrHeap();
-  heap->init();
-  URL url;
-  url.create(heap);
-  url.parse(uri, strlen(uri));
-  int host_len;
-  const char *host = url.host_get(&host_len);
+  const char *host  = strstr(uri, "://") + 3;
+  const char *slash = strchr(host, '/');
+  if (slash == nullptr) {
+    slash = host + strlen(host);
+  }
+  int host_len = slash - host;
   httpreq.add_header("Host", 4, host, host_len);
 
   // User-Agent header

--- a/iocore/net/libinknet_stub.cc
+++ b/iocore/net/libinknet_stub.cc
@@ -155,3 +155,42 @@ PreWarmManager::reconfigure()
 }
 
 PreWarmManager prewarmManager;
+
+#include "../src/traffic_server/FetchSM.h"
+ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+void
+FetchSM::ext_launch()
+{
+}
+void
+FetchSM::ext_destroy()
+{
+}
+ssize_t
+FetchSM::ext_read_data(char *, unsigned long)
+{
+  return 0;
+}
+void
+FetchSM::ext_add_header(char const *, int, char const *, int)
+{
+}
+void
+FetchSM::ext_write_data(void const *, unsigned long)
+{
+}
+void *
+FetchSM::ext_get_user_data()
+{
+  return nullptr;
+}
+void
+FetchSM::ext_set_user_data(void *)
+{
+}
+void
+FetchSM::ext_init(Continuation *, char const *, char const *, char const *, sockaddr const *, int)
+{
+}
+
+ChunkedHandler::ChunkedHandler() {}

--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -347,3 +347,40 @@ PreWarmManager::reconfigure()
 }
 
 PreWarmManager prewarmManager;
+
+#include "../src/traffic_server/FetchSM.h"
+ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+void
+FetchSM::ext_launch()
+{
+}
+void
+FetchSM::ext_destroy()
+{
+}
+ssize_t
+FetchSM::ext_read_data(char *, unsigned long)
+{
+  return 0;
+}
+void
+FetchSM::ext_add_header(char const *, int, char const *, int)
+{
+}
+void
+FetchSM::ext_write_data(void const *, unsigned long)
+{
+}
+void *
+FetchSM::ext_get_user_data()
+{
+  return nullptr;
+}
+void
+FetchSM::ext_set_user_data(void *)
+{
+}
+void
+FetchSM::ext_init(Continuation *, char const *, char const *, char const *, sockaddr const *, int)
+{
+}

--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -53,7 +53,9 @@ FetchSM::cleanUp()
   client_response_hdr.destroy();
   ats_free(client_response);
   cont_mutex.clear();
-  http_vc->do_io_close();
+  if (http_vc) {
+    http_vc->do_io_close();
+  }
   FetchSMAllocator.free(this);
 }
 
@@ -66,6 +68,15 @@ FetchSM::httpConnect()
 
   Debug(DEBUG_TAG, "[%s] calling httpconnect write pi=%p tag=%s id=%" PRId64, __FUNCTION__, pi, tag, id);
   http_vc = reinterpret_cast<PluginVC *>(TSHttpConnectWithPluginId(&_addr.sa, tag, id));
+  if (http_vc == nullptr) {
+    Debug(DEBUG_TAG, "Not ready to use");
+    if (fetch_flags & TS_FETCH_FLAGS_STREAM) {
+      return InvokePluginExt(TS_EVENT_ERROR);
+    }
+    InvokePlugin(callback_events.failure_event_id, nullptr);
+    cleanUp();
+    return;
+  }
 
   /*
    * TS-2906: We need a way to unset internal request when using FetchSM, the use case for this
@@ -649,6 +660,9 @@ FetchSM::ext_launch()
 void
 FetchSM::ext_write_data(const void *data, size_t len)
 {
+  if (write_vio == nullptr) {
+    return;
+  }
   if (fetch_flags & TS_FETCH_FLAGS_NEWLOCK) {
     MUTEX_TAKE_LOCK(mutex, this_ethread());
   }

--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -70,10 +70,12 @@ FetchSM::httpConnect()
   http_vc = reinterpret_cast<PluginVC *>(TSHttpConnectWithPluginId(&_addr.sa, tag, id));
   if (http_vc == nullptr) {
     Debug(DEBUG_TAG, "Not ready to use");
-    if (fetch_flags & TS_FETCH_FLAGS_STREAM) {
-      return InvokePluginExt(TS_EVENT_ERROR);
+    if (contp) {
+      if (fetch_flags & TS_FETCH_FLAGS_STREAM) {
+        return InvokePluginExt(TS_EVENT_ERROR);
+      }
+      InvokePlugin(callback_events.failure_event_id, nullptr);
     }
-    InvokePlugin(callback_events.failure_event_id, nullptr);
     cleanUp();
     return;
   }


### PR DESCRIPTION
This is a step to support OCSP, without boringocsp library that has never been open sourced.

ATS has been using `OCSP_REQ_CTX` and related functions, which make HTTP requests for OCSP, but many of them were deprecated on OpenSSL 3.0 and they are unavailable on BoringSSL. On this PR, I replaced those functions with ATS's FetchSM and functions that are available on BoringSSL.

It still doesn't work with BoringSSL because there are still other functions only available on OpenSSL. I'm going to replace them on next PR.

Changes on FetchSM are needed because OCSP stuff basically runs on ET_OCSP thread and the requests can be made before FetchSM gets ready. It should not affect existing plugins because those won't run until everything is initialized.