### PR TITLE
libswoc: Update to 1.4.9.

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.4.6")
+set(LIBSWOC_VERSION "1.4.9")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.

--- a/lib/swoc/Makefile.am
+++ b/lib/swoc/Makefile.am
@@ -22,7 +22,7 @@ library_includedir=$(includedir)/swoc
 
 AM_CPPFLAGS += @SWOC_INCLUDES@
 
-libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.4.6
+libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.4.9
 libtsswoc_la_SOURCES = \
 	src/ArenaWriter.cc  src/bw_format.cc  src/bw_ip_format.cc  src/Errata.cc  src/MemArena.cc  src/RBTree.cc  src/swoc_file.cc  src/swoc_ip.cc  src/TextView.cc src/string_view_util.cc
 

--- a/lib/swoc/include/swoc/Errata.h
+++ b/lib/swoc/include/swoc/Errata.h
@@ -160,7 +160,7 @@ public:
 
 protected:
   using self_type = Errata; ///< Self reference type.
-  /// Storage type for list of messages.
+  /// Storage, for list of messages.
   /// Internally the vector is accessed backwards, in order to make it LIFO.
   using Container = IntrusiveDList<Annotation::Linkage>;
 
@@ -210,13 +210,61 @@ public:
   self_type &operator                         =(self_type &&that); ///< Move assignment.
   ~Errata();                                                       ///< Destructor.
 
-  // Note based constructors.
+  /** Construct with a severity.
+   *
+   * @param severity Severity.
+   *
+   * No annotations are created.
+   */
   explicit Errata(Severity severity);
-  Errata(code_type const &type, Severity severity, std::string_view const &text);
+
+  /** Constructor.
+   *
+   * @param code Error code.
+   * @param severity Severity.
+   * @param text Annotation text.
+   *
+   * Constructs with error @a code and @a severity. An annotation with @a text.
+   */
+  Errata(code_type const &code, Severity severity, std::string_view const &text);
+
+  /** Constructor.
+   *
+   * @param severity Severity.
+   * @param text Annotation text.
+   *
+   * Constructs with @a severity and an annotation with @a text.
+   */
   Errata(Severity severity, std::string_view const &text);
-  Errata(code_type const &type, std::string_view const &text);
+
+  /** Constructor.
+   *
+   * @param code Error code.
+   * @param text
+   *
+   * Construct with error @a code and an annotation with @a text.
+   */
+  Errata(code_type const &code, std::string_view const &text);
+
+  /** Constructor.
+   *
+   * @param text Annotation text.
+   */
   explicit Errata(std::string_view const &text);
-  template <typename... Args> Errata(code_type const &type, Severity severity, std::string_view fmt, Args &&... args);
+
+  /** Constructor.
+   *
+   * @tparam Args Format argument types.
+   * @param code Error code.
+   * @param severity Severity.
+   * @param fmt Annotation format.
+   * @param args Annotation format arguments.
+   *
+   * Cosntructs with error @a code and @a severity and an formatted annotation.
+   */
+  template <typename... Args> Errata(code_type const &code, Severity severity, std::string_view fmt, Args &&... args);
+
+
   template <typename... Args> Errata(code_type const &type, std::string_view fmt, Args &&... args);
   template <typename... Args> Errata(Severity severity, std::string_view fmt, Args &&... args);
   template <typename... Args> explicit Errata(std::string_view fmt, Args &&... args);
@@ -401,12 +449,10 @@ public:
    */
   bool is_ok() const;
 
+  /// @return If there is top level severity.
   bool has_severity() const { return _data && _data->_severity.has_value(); }
 
-  /** Get the maximum severity of the messages in the erratum.
-   *
-   * @return Max severity for all messages.
-   */
+  /// @return Top level severity.
   Severity severity() const;
 
   /** Set the @a severity.
@@ -843,7 +889,7 @@ public:
    *
    * @return @a true if the value is valid / OK, @c false otherwise.
    */
-  inline bool is_ok() const;
+  bool is_ok() const;
 
   /// Clear the errata.
   self_type &clear();
@@ -941,7 +987,7 @@ inline Errata::Errata(const code_type &code, Severity severity) {
   d->_code     = code;
 }
 
-inline Errata::Errata(const code_type &type, Severity severity, const std::string_view &text) : Errata(type, severity) {
+inline Errata::Errata(const code_type &code, Severity severity, const std::string_view &text) : Errata(code, severity) {
   this->note(text);
 }
 

--- a/lib/swoc/include/swoc/IPEndpoint.h
+++ b/lib/swoc/include/swoc/IPEndpoint.h
@@ -136,13 +136,21 @@ union IPEndpoint {
   /// Assign from IP address.
   self_type &assign(IPAddr const &addr);
 
+  [[deprecated("Use IPSrv")]] self_type &assign(IPAddr const& addr, in_port_t port);
+
   /// Assign from IPv4 address.
   self_type &assign(IP4Addr const& addr);
 
   /// Assign from IPv4 address.
   self_type &assign(IP6Addr const& addr);
 
-  /// Assign from IP service (address and port).
+  /// Assign from IPv4 service.
+  self_type &assign(IP4Srv const& srv);
+
+  /// Assign from IPv6 service.
+  self_type &assign(IP6Srv const& srv);
+
+  /// Assign from IP service.
   self_type &assign(IPSrv const& srv);
 
   /// Copy to @a sa.

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -924,7 +924,25 @@ public:
     /// @return A pointer to the referent.
     value_type const *operator->() const;
 
+    /** The range for the iterator.
+     *
+     * @return Iterator range.
+     *
+     * @note If the iterator is not valid the returned range will be empty.
+     */
     IPRange const& range() const;
+
+    /** The payload for the iterator.
+     *
+     * @return The payload.
+     *
+     * @note This yields undetermined results for invalid iterators. Always check for validity befure
+     * using this method.
+     *
+     * @note It is not possible to retrieve a modifiable payload because that can break the internal
+     * invariant that adjcent ranges always have different payloads.
+     */
+    PAYLOAD const& payload() const;
 
     /// Equality
     bool operator==(self_type const &that) const;
@@ -1211,7 +1229,7 @@ public:
   /// Remove all addresses in the set.
   void clear();
 
-  /// Constant iterator for iteration over ranges.
+  /// Bidirectional constant iterator for iteration over ranges.
   class const_iterator {
     using self_type = const_iterator; ///< Self reference type.
     using super_type = Space::const_iterator;
@@ -1426,6 +1444,10 @@ IPSpace<PAYLOAD>::const_iterator::operator->() const -> value_type const * {
 template <typename PAYLOAD>
 IPRange const &
 IPSpace<PAYLOAD>::const_iterator::range() const { return std::get<0>(_value); }
+
+template <typename PAYLOAD>
+PAYLOAD const &
+IPSpace<PAYLOAD>::const_iterator::payload() const { return std::get<1>(_value); }
 
 /* Bit of subtlety with equality - although it seems that if @a _iter_4 is valid, it doesn't matter
  * where @a _iter6 is (because it is really the iterator location that's being checked), it's

--- a/lib/swoc/include/swoc/TextView.h
+++ b/lib/swoc/include/swoc/TextView.h
@@ -13,6 +13,7 @@
 
 #pragma once
 #include <bitset>
+#include <cstdint>
 #include <iosfwd>
 #include <memory.h>
 #include <string>

--- a/lib/swoc/include/swoc/bwf_base.h
+++ b/lib/swoc/include/swoc/bwf_base.h
@@ -1174,11 +1174,10 @@ auto
 FixedBufferWriter::print_v(bwf::Format const &fmt, std::tuple<Args...> const &args) -> self_type & {
   return static_cast<self_type &>(this->super_type::print_v(fmt, args));
 }
-
 /// @endcond
 
 // Special case support for @c Scalar, because @c Scalar is a base utility for some other utilities
-// there can be some unpleasant cirularities if @c Scalar includes BufferWriter formatting. If the
+// there can be some unpleasant circularities if @c Scalar includes BufferWriter formatting. If the
 // support is here then it's fine because anything using BWF for @c Scalar must include this header.
 template <intmax_t N, typename C, typename T> class Scalar;
 namespace detail {

--- a/lib/swoc/include/swoc/string_view_util.h
+++ b/lib/swoc/include/swoc/string_view_util.h
@@ -11,6 +11,7 @@
 #include <memory.h>
 #include <string>
 #include <string_view>
+#include <memory>
 #include <limits>
 
 /** Compare views with ordering, ignoring case.

--- a/lib/swoc/include/swoc/swoc_file.h
+++ b/lib/swoc/include/swoc/swoc_file.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <unistd.h>
 #include <sys/stat.h>
 
 #include <string>
@@ -19,6 +20,56 @@
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 namespace file {
+
+using file_time_type = std::chrono::system_clock::time_point;
+
+enum class file_type : signed char {
+  none = 0, not_found = -1, regular = 1, directory = 2, symlink = 3,
+  block = 4, character = 5, fifo = 6, socket = 7, unknown = 8
+};
+
+/// Invalid file descriptor.
+static constexpr int NO_FD = -1;
+
+/// Scoped container for a file descriptor.
+struct unique_fd {
+  using self_type = unique_fd; ///< Self reference type.
+
+  /** Construct with file descriptor.
+   *
+   * @param fd File descriptor.
+   *
+   * The instance takes owernship of the file descriptor.
+   */
+  explicit unique_fd(int fd) : _fd(fd) {}
+
+  /// Non-copyable.
+  unique_fd(self_type const &) = delete;
+
+  /** Move construction.
+   *
+   * @param that Source instance.
+   *
+   * Ownership is from from @Wa that to @a this.
+   */
+  unique_fd(self_type && that) : _fd(that._fd) { that._fd = NO_FD; }
+
+  /// Close the file dscriptor.
+  ~unique_fd() { if (_fd != NO_FD) { ::close(_fd); _fd = NO_FD; }; }
+
+  /** Release ownership of the file descriptor.
+   *
+   * @return The file descriptor.
+   */
+  int release() { auto zret = _fd; _fd = NO_FD; return zret; }
+
+  /// Implicitly convert to file descriptor.
+  operator int() const { return _fd; }
+
+protected:
+  int _fd = NO_FD;
+};
+
 /** Utility class for file system paths.
  */
 class path {
@@ -42,7 +93,6 @@ public:
 
   /// Construct from a string view.
   path(std::string_view src);
-  //  template < typename ... Args > explicit path(std::string_view base, Args... rest);
 
   /// Move from an existing string
   path(std::string &&that);
@@ -88,11 +138,28 @@ public:
   /// Path of the parent.
   self_type parent_path() const;
 
+  /// @return Path excluding the root path, if nay.
+  self_type relative_path() const;
+
+  /** Filename part of the path.
+   *
+   * @param p Path.
+   * @return
+   */
+  self_type filename() const;
+
   /// Access the path explicitly.
   char const *c_str() const;
 
   /// The path as a string.
   std::string const &string() const;
+
+  /** Reserve space in the path.
+   *
+   * @param n Number of bytes to reserve.
+   * @return @a this.
+   */
+  self_type & reserve(size_t n);
 
   /// A view of the path.
   swoc::TextView view() const;
@@ -105,19 +172,30 @@ protected:
 class file_status {
   using self_type = file_status;
 
+public:
+  /// @return File type as an enumeration.
+  file_type type() const;
+
+  /// @return raw file mode data.
+  mode_t mode() const;
+
 protected:
   struct ::stat _stat; ///< File information.
+  file_type _type = file_type::none;
+
+  void init();
 
   friend self_type status(const path &file, std::error_code &ec) noexcept;
   friend int file_type(const self_type &);
-  friend off_t file_size(const self_type &);
-  friend bool is_regular_file(const file_status &);
-  friend bool is_dir(const file_status &);
-  friend bool is_char_device(const file_status &);
-  friend bool is_block_device(const file_status &);
-  friend std::chrono::system_clock::time_point modify_time(file_status const &fs);
-  friend std::chrono::system_clock::time_point access_time(file_status const &fs);
-  friend std::chrono::system_clock::time_point status_time(file_status const &fs);
+  friend uintmax_t file_size(const self_type &);
+  friend bool is_regular_file(const self_type &);
+  friend bool is_dir(const self_type &);
+  friend bool is_char_device(const self_type &);
+  friend bool is_block_device(const self_type &);
+  friend bool exists(const self_type &);
+  friend file_time_type last_write_time(file_status const &fs);
+  friend file_time_type access_time(file_status const &fs);
+  friend file_time_type status_time(file_status const &fs);
 };
 
 /** Get the status of the file at @a p.
@@ -132,7 +210,7 @@ file_status status(const path &file, std::error_code &ec) noexcept;
 // These are separate because they are not part of std::filesystem::path.
 
 /// Return the file type value.
-int file_type(const file_status &fs);
+[[deprecated("Use file_status::type")]] int file_type(const file_status &fs);
 
 /// Check if the path is to a regular file.
 bool is_regular_file(const file_status &fs);
@@ -147,10 +225,16 @@ bool is_char_device(const file_status &fs);
 bool is_block_device(const file_status &fs);
 
 /// Size of the file or block device.
-off_t file_size(const file_status &fs);
+uintmax_t file_size(const file_status &fs);
 
 /// Check if file is readable.
 bool is_readable(const path &s);
+
+/// Check if path exists.
+bool exists(const path &p);
+
+/// Check if path exists.
+bool exists(const file_status &fs);
 
 /** Convert to absolute path.
  *
@@ -164,12 +248,80 @@ bool is_readable(const path &s);
  */
 path absolute(path const &src, std::error_code &ec);
 
+/// Directory location suitable for temporary files
+path temp_directory_path();
+
+/// Current working directory.
+path current_path();
+
+/// @return Canonicalized absolute pathname
+path canonical(const path &p, std::error_code &ec);
+
+/** Create directory.
+ *
+ * @param p Path to directory.
+ * @param ec Error code return.
+ * @param mode Permissions for created directory.
+ * @return @c true if @a p was created, @c false otherwise.
+ *
+ * @note Not fully implemented.
+ */
+bool create_directory(const path &p, std::error_code &ec, mode_t mode = 0775) noexcept;
+
+/** Create directories.
+ *
+ * @param p Path to directory.
+ * @param ec Error code return.
+ * @param mode Permissions for created directories.
+ * @return @c true if @a p was created, @c false otherwise.
+ *
+ * @note Not fully implemented.
+ */
+bool create_directories(const path &p, std::error_code &ec, mode_t mode = 0775) noexcept;
+
+/** Copy files.
+ *
+ * @param from Source file
+ * @param to Destination file.
+ * @param ec Error code return.
+ * @return @c true if @a from was copied, @c false on error.
+*
+* @note Not fully implemented.
+ */
+bool copy(const path &from, const path &to, std::error_code &ec);
+
+/** Remove a file or empty directory.
+ *
+ * @param path Target.
+ * @param ec Error return.
+ * @return @c true if the operation succeeded, @c false if @a ec has an error code.
+ */
+bool remove(const path &path, std::error_code &ec);
+
+/** Remove a file or a directory and all nested files.
+ *
+ * @param path Target.
+ * @param ec Error return.
+ * @return Number of items removed.
+ */
+uintmax_t remove_all(const path &path, std::error_code &ec);
+
 /// @return The modified time for @a fs.
-std::chrono::system_clock::time_point modify_time(file_status const &fs);
+[[deprecated("See last_write_time")]] file_time_type modify_time(file_status const &fs);
+/// @return The modified time for @a fs.
+file_time_type last_write_time(file_status const &fs);
+
+/** Modification time.
+ *
+ * @param p Path to target.
+ * @return Time of last modification, or @c file_time_type::min() on error.
+ */
+file_time_type last_write_time(path const& p, std::error_code &ec);
+
 /// @return The access time for @a fs.
-std::chrono::system_clock::time_point access_time(file_status const &fs);
+file_time_type access_time(file_status const &fs);
 /// @return The status change time for @a fs.
-std::chrono::system_clock::time_point status_time(file_status const &fs);
+file_time_type status_time(file_status const &fs);
 
 /** Load the file at @a p into a @c std::string.
  *
@@ -273,6 +425,12 @@ operator/(const path &lhs, std::string_view rhs) {
   return path(lhs) /= rhs;
 }
 
+inline auto
+path::reserve(size_t n) -> self_type & {
+  _path.reserve(n);
+  return *this;
+}
+
 /** Combine two strings as file paths.
  *
  * @return A @c path with the combined path.
@@ -282,6 +440,40 @@ operator/(path &&lhs, std::string_view rhs) {
   return path(std::move(lhs)) /= rhs;
 }
 
+// Can remove "enum" after the function @c file_type is removed.
+inline enum file_type file_status::type() const { return _type; }
+
+inline mode_t file_status::mode() const { return _stat.st_mode; }
+
+inline bool
+is_char_device(const file_status &fs) {
+  return fs._type == file_type::character;
+}
+
+inline bool
+is_block_device(const file_status &fs) {
+  return fs._type == file_type::block;
+}
+
+inline bool
+is_regular_file(const file_status &fs) {
+  return fs._type == file_type::regular;
+}
+
+inline bool
+is_dir(const file_status &fs) {
+  return fs._type == file_type::directory;
+}
+
+inline bool
+exists(const file_status &fs) {
+  return fs._type != file_type::none && fs._type != file_type::not_found;
+}
+
+inline file_time_type
+modify_time(file_status const &fs) {
+  return last_write_time(fs);
+}
 } // namespace file
 
 class BufferWriter;

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_4_6
+#define SWOC_VERSION_NS _1_4_9
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 4;
-static constexpr unsigned POINT_VERSION = 6;
+static constexpr unsigned POINT_VERSION = 9;
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/src/swoc_file.cc
+++ b/lib/swoc/src/swoc_file.cc
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 // Copyright Apache Software Foundation 2019
 /** @file
 
     Minimalist version of std::filesystem.
  */
 
+#include <variant>
+
 #include <fcntl.h>
 #include <unistd.h>
+#include <dirent.h>
 #include "swoc/swoc_file.h"
 #include "swoc/bwf_base.h"
 
@@ -14,11 +18,25 @@ using namespace swoc::literals;
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 namespace file {
+
 path
 path::parent_path() const {
   TextView parent{_path};
   parent.split_suffix_at(SEPARATOR);
   return parent ? parent : "/"_tv;
+}
+
+path
+path::relative_path() const {
+  if (!_path.empty() && _path.front() == SEPARATOR) {
+    return _path.substr(1);
+  }
+  return *this;
+}
+
+auto path::filename() const -> self_type {
+  auto const idx = _path.find_last_of(SEPARATOR);
+  return idx == std::string::npos ? self_type(_path) : _path.substr(idx + 1);
 }
 
 path &
@@ -39,13 +57,30 @@ path::operator/=(std::string_view that) {
   return *this;
 }
 
+void file_status::init() {
+  switch (_stat.st_mode & S_IFMT) {
+  case S_IFREG : _type = file_type::regular; break;
+  case S_IFDIR : _type = file_type::directory; break;
+  case S_IFLNK : _type = file_type::symlink; break;
+  case S_IFBLK : _type = file_type::block; break;
+  case S_IFCHR : _type = file_type::character; break;
+  case S_IFIFO : _type = file_type::fifo; break;
+  case S_IFSOCK : _type = file_type::socket; break;
+  default: _type = file_type::unknown; break;
+  }
+}
+
 file_status
 status(path const &file, std::error_code &ec) noexcept {
   file_status zret;
   if (::stat(file.c_str(), &zret._stat) >= 0) {
     ec.clear();
+    zret.init();
   } else {
     ec = std::error_code(errno, std::system_category());
+    if (errno == ENOENT) {
+      zret._type = file_type::not_found;
+    }
   }
   return zret;
 }
@@ -55,29 +90,16 @@ file_type(const file_status &fs) {
   return fs._stat.st_mode & S_IFMT;
 }
 
-off_t
+uintmax_t
 file_size(const file_status &fs) {
   return fs._stat.st_size;
 }
 
 bool
-is_char_device(const file_status &fs) {
-  return file_type(fs) == S_IFCHR;
-}
-
-bool
-is_block_device(const file_status &fs) {
-  return file_type(fs) == S_IFBLK;
-}
-
-bool
-is_regular_file(const file_status &fs) {
-  return file_type(fs) == S_IFREG;
-}
-
-bool
-is_dir(const file_status &fs) {
-  return file_type(fs) == S_IFDIR;
+exists(const path &p) {
+  std::error_code ec;
+  auto fs = status(p, ec);
+  return exists(fs);
 }
 
 path
@@ -104,8 +126,8 @@ absolute(path const &src, std::error_code &ec) {
 }
 
 namespace {
-inline std::chrono::system_clock::time_point
-chrono_cast(timespec const &ts) {
+
+inline file_time_type chrono_cast(timespec const &ts) {
   using namespace std::chrono;
   return system_clock::time_point{duration_cast<system_clock::duration>(seconds{ts.tv_sec} + nanoseconds{ts.tv_nsec})};
 }
@@ -150,19 +172,28 @@ c_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_ctimespec) {
 
 } // namespace
 
-std::chrono::system_clock::time_point
-modify_time(file_status const &fs) {
+file_time_type
+last_write_time(file_status const &fs) {
   return chrono_cast(m_time(fs._stat, meta::CaseArg));
 }
 
-std::chrono::system_clock::time_point
+file_time_type
 access_time(file_status const &fs) {
   return chrono_cast(a_time(fs._stat, meta::CaseArg));
 }
 
-std::chrono::system_clock::time_point
+file_time_type
 status_time(file_status const &fs) {
   return chrono_cast(c_time(fs._stat, meta::CaseArg));
+}
+
+file_time_type
+last_write_time(path const& p, std::error_code &ec) {
+  auto fs = status(p, ec);
+  if (ec) {
+    return file_time_type::min();
+  }
+  return last_write_time(fs);
 }
 
 bool
@@ -170,26 +201,252 @@ is_readable(const path &p) {
   return 0 == access(p.c_str(), R_OK);
 }
 
+path
+temp_directory_path()
+{
+  /* ISO/IEC 9945 (POSIX): The path supplied by the first environment variable found in the list TMPDIR, TMP, TEMP, TEMPDIR.
+   * If none of these are found, "/tmp"
+   * */
+  for ( char const * tp : { "TMPDIR", "TMP", "TEMPDIR" }) {
+    if (auto v = ::getenv(tp) ; v) {
+      return path(v);
+    }
+  }
+  return path("/tmp");
+}
+
+path
+current_path()
+{
+  char buff[PATH_MAX+1];
+  if (auto p = ::getcwd(buff, sizeof(buff)) ; p) {
+    return path{buff};
+#if !__FreeBSD__ && ! __APPLE__ // Freakin' Apple and FreeBSD.
+  } else if (ERANGE == errno) {
+    swoc::unique_malloc<char> raw{::get_current_dir_name()};
+    return path{ raw.get() };
+#endif
+  }
+  return {};
+}
+
+path
+canonical(const path &p, std::error_code &ec)
+{
+  if (p.empty()) {
+    ec = std::error_code(EINVAL, std::system_category());
+    return {};
+  }
+
+  char buf[PATH_MAX + 1];
+
+  if (auto rp = ::realpath(p.c_str(), buf) ; rp) {
+    return path{rp};
+  }
+
+  if (auto rp = ::realpath(p.c_str(), nullptr) ; rp) {
+    return path{rp};
+  }
+
+  ec = std::error_code(errno, std::system_category());
+  return {};
+}
+
+bool create_directory(const path &path, std::error_code &ec, mode_t mode) noexcept {
+  if (path.empty()) {
+    ec = std::error_code(EINVAL, std::system_category());
+    return false;
+  }
+
+  ec.clear();
+  if (::mkdir(path.c_str(), mode) != 0) {
+    if (EEXIST == errno) {
+      std::error_code local_ec;
+      auto fs = status(path, local_ec);
+      if (!local_ec && is_dir(fs)) {
+        return true;
+      }
+    }
+    ec = std::error_code(errno, std::system_category());
+    return false;
+  }
+  return true;
+}
+
+bool
+create_directories(const path &p, std::error_code &ec, mode_t mode) noexcept
+{
+  TextView text(p.string());
+
+  if (text.empty()) {
+    ec = std::error_code(EINVAL, std::system_category());
+    return false;
+  }
+
+  path path;
+
+  if (text.front() == path::SEPARATOR) {
+    path = text.prefix(1); // copy leading separator.
+    ++text;
+    if (!text) {
+      ec.clear();
+      return true; // Tried to create root directory, it's already tehre.
+    }
+  }
+
+  path.reserve(p.string().size());
+
+  while (text) {
+    auto elt = text.take_prefix_at(path::SEPARATOR);
+    path /= elt;
+    if (!create_directory(path, ec, mode)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool
+copy(const path &from, const path &to, std::error_code &ec)
+{
+  static constexpr size_t BUF_SIZE = 65536;
+  std::error_code local_ec;
+  char buf[BUF_SIZE];
+  swoc::MemSpan span{buf};
+
+  if (from.empty() || to.empty()) {
+    ec = std::error_code(EINVAL, std::system_category());
+    return false;
+  }
+
+  ec.clear();
+
+  unique_fd src_fd{::open(from.c_str(), O_RDONLY)};
+  if (NO_FD == src_fd) {
+    ec = std::error_code(errno, std::system_category());
+    return false;
+  }
+  auto src_fs = file::status(from, local_ec);
+
+  path final_to;
+  if (auto fs = file::status(to, local_ec) ; !(local_ec && ENOENT == local_ec.value()) && is_dir(fs)) {
+    final_to        = to / from.filename();
+  } else {
+    final_to = to;
+  }
+
+  unique_fd dst_fd{::open(final_to.c_str(), O_WRONLY | O_CREAT, src_fs.mode())};
+  if (NO_FD == dst_fd) {
+    ec = std::error_code(errno, std::system_category());
+    return false;
+  }
+
+  while (true) {
+    if ( auto n = read(src_fd, span.data(), span.size()) ; n > 0 ) {
+      if (::write(dst_fd, span.data(), n) < n) {
+        ec = std::error_code(errno, std::system_category());
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+
+  return true;
+}
+
+uintmax_t
+remove_all(const path &p, std::error_code &ec)
+{
+  DIR *dir;
+  struct dirent *entry;
+  std::error_code err;
+  uintmax_t zret = 0;
+
+  struct ::stat s;
+  if (p.empty()) {
+    ec = std::error_code(EINVAL, std::system_category());
+    return zret;
+  } else if (::stat(p.c_str(), &s) < 0) {
+    ec = std::error_code(errno, std::system_category());
+    return zret;
+  } else if (S_ISREG(s.st_mode)) { // regular file, try to remove it!
+    if (unlink(p.c_str()) != 0) {
+      ec = std::error_code(errno, std::system_category());
+    } else {
+      ++zret;
+    }
+    return zret;
+  } else if (!S_ISDIR(s.st_mode)) { // not a directory
+    ec = std::error_code(ENOTDIR, std::system_category());
+    return zret;
+  }
+  // Invariant - @a p is a directory.
+
+  // recursively remove nested files and directories
+  if (nullptr == (dir = opendir(p.c_str()))) {
+    ec = std::error_code(errno, std::system_category());
+    return zret;
+  }
+
+  auto child = p; // Minimize string allocations / re-allocations.
+  while (nullptr != (entry = readdir(dir))) {
+    if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
+      continue;
+    }
+    child = p;
+    child /= entry->d_name;
+    zret += remove_all(child, ec);
+  }
+
+  if (0 != rmdir(p.c_str())) {
+    ec = std::error_code(errno, std::system_category());
+  }
+  ++zret;
+
+  closedir(dir);
+  return zret;
+}
+
+bool remove(path const& p, std::error_code &ec) {
+  struct ::stat fs;
+  if (p.empty()) {
+    ec = std::error_code(EINVAL, std::system_category());
+  } else if (::stat(p.c_str(), &fs) < 0) {
+    ec = std::error_code(errno, std::system_category());
+  } else if (S_ISREG(fs.st_mode)) { // regular file, try to remove it!
+    if (unlink(p.c_str()) != 0) {
+      ec = std::error_code(errno, std::system_category());
+    }
+  } else if (S_ISDIR(fs.st_mode)) { // not a directory
+    if (rmdir(p.c_str()) != 0) {
+      ec = std::error_code(errno, std::system_category());
+    }
+  } else {
+    ec = std::error_code(EINVAL, std::system_category());
+  }
+  return !ec;
+}
+
 std::string
 load(const path &p, std::error_code &ec) {
   std::string zret;
-  int fd(::open(p.c_str(), O_RDONLY));
   ec.clear();
-  if (fd < 0) {
+  if (unique_fd fd(::open(p.c_str(), O_RDONLY)) ; fd < 0) {
     ec = std::error_code(errno, std::system_category());
   } else {
     struct stat info;
     if (0 != ::fstat(fd, &info)) {
       ec = std::error_code(errno, std::system_category());
     } else {
-      int n = info.st_size;
+      auto n = info.st_size;
       zret.resize(n);
-      auto read_len = ::read(fd, const_cast<char *>(zret.data()), n);
+      auto read_len = ::read(fd, zret.data(), n);
       if (read_len < n) {
         ec = std::error_code(errno, std::system_category());
       }
     }
-    ::close(fd);
   }
   return zret;
 }

--- a/lib/swoc/src/swoc_ip.cc
+++ b/lib/swoc/src/swoc_ip.cc
@@ -103,25 +103,41 @@ IPEndpoint::assign(IPAddr const &src) {
 }
 
 IPEndpoint &
-IPEndpoint::assign(IPSrv const &src) {
-  switch (src.family()) {
-  case AF_INET:
-    memset(&sa4, 0, sizeof sa4);
-    sa4.sin_family      = AF_INET;
-    sa4.sin_addr.s_addr = src.ip4().addr().network_order();
-    sa4.sin_port        = src.network_order_port();
-    Set_Sockaddr_Len(&sa4);
-    break;
-  case AF_INET6:
-    memset(&sa6, 0, sizeof sa6);
-    sa6.sin6_family = AF_INET6;
-    sa6.sin6_addr   = src.ip6().addr().network_order();
-    sa6.sin6_port   = src.network_order_port();
-    Set_Sockaddr_Len(&sa6);
-    break;
-  default:
-    memset(&sa, 0, sizeof sa);
-    sa.sa_family = AF_UNSPEC;
+IPEndpoint::assign(IPAddr const& addr, in_port_t port) {
+  if (addr.is_ip4()) {
+    this->assign(IP4Srv(addr.ip4(), port));
+  } else if (addr.is_ip6()) {
+    this->assign(IP6Srv(addr.ip6(), port));
+  }
+  return *this;
+}
+
+IPEndpoint &
+IPEndpoint::assign(IP4Srv const &src) {
+  memset(&sa4, 0, sizeof sa4);
+  sa4.sin_family      = AF_INET;
+  sa4.sin_addr.s_addr = src.addr().network_order();
+  sa4.sin_port        = src.network_order_port();
+  Set_Sockaddr_Len(&sa4);
+  return *this;
+}
+
+IPEndpoint &
+IPEndpoint::assign(IP6Srv const &src) {
+  memset(&sa6, 0, sizeof sa6);
+  sa6.sin6_family = AF_INET6;
+  sa6.sin6_addr   = src.addr().network_order();
+  sa6.sin6_port   = src.network_order_port();
+  Set_Sockaddr_Len(&sa6);
+  return *this;
+}
+
+IPEndpoint &
+IPEndpoint::assign(IPSrv const &srv) {
+  if (srv.is_ip4()) {
+    return this->assign(srv.ip4());
+  } else if (srv.is_ip6()) {
+    return this->assign(srv.ip6());
   }
   return *this;
 }


### PR DESCRIPTION
Many improvement tweaks.

* Added all functions from `ts::file` to `swoc::file`, improved compliance with `std::filesystem`.
* Direct access to `IPSpace` payload from iterator.
* More `MemSpan` constructors.
* Improved API for `Errata`.