### PR TITLE
Add support for tunnel route config that has both match group and port variable

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -176,7 +176,7 @@ tunnel_route              Inbound   Destination as an FQDN and port, separated b
                                     Protocol <proxy-protocol>` for more information on Proxy Protocol and how it is
                                     configured for |TS|.
 
-                                    Note that the match group number can be used in combination with the ``{inbound_local_port}`` and ``{proxy_protocol_port}`` literal strings.
+                                    Note that only one of the ``{inbound_local_port}`` and ``{proxy_protocol_port}`` literal strings can be specified. The match group number can be used in combination with either one of those.
 
                                     For each of these tunnel targets, unless the port is explicitly specified in the target
                                     (e.g., if the port is derived from the Proxy Protocol header), the port must be

--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -176,6 +176,8 @@ tunnel_route              Inbound   Destination as an FQDN and port, separated b
                                     Protocol <proxy-protocol>` for more information on Proxy Protocol and how it is
                                     configured for |TS|.
 
+                                    Note that the match group number can be used in combination with the ``{inbound_local_port}`` and ``{proxy_protocol_port}`` literal strings.
+
                                     For each of these tunnel targets, unless the port is explicitly specified in the target
                                     (e.g., if the port is derived from the Proxy Protocol header), the port must be
                                     specified in the :ts:cv:`proxy.config.http.connect_ports` configuration in order for

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -41,7 +41,6 @@
 
 #include "tscore/ink_inet.h"
 
-#include <sys/types.h>
 #include <vector>
 
 class ControlH2 : public ActionItem

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -118,10 +118,12 @@ public:
     if (has_recv_port_var && has_pp_port_var) {
       Error("Invalid destination \"%.*s\" in SNI configuration - Only one port variable can be specified.",
             static_cast<int>(destination.size()), destination.data());
-    } else if (has_recv_port_var || has_pp_port_var) {
-      // Specified only one of the port variables.
-      fnArrIndexes.push_back(has_recv_port_var ? OpId::MAP_WITH_RECV_PORT : OpId::MAP_WITH_PROXY_PROTOCOL_PORT);
-      var_start_pos = has_recv_port_var ? recv_port_start_pos : pp_port_start_pos;
+    } else if (has_recv_port_var) {
+      fnArrIndexes.push_back(OpId::MAP_WITH_RECV_PORT);
+      var_start_pos = recv_port_start_pos;
+    } else if (has_pp_port_var) {
+      fnArrIndexes.push_back(OpId::MAP_WITH_PROXY_PROTOCOL_PORT);
+      var_start_pos = pp_port_start_pos;
     }
     // Check for match groups as well.
     if (destination.find_first_of('$') != std::string::npos) {

--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -241,10 +241,10 @@ private:
   YamlSNIConfig::TunnelPreWarm tunnel_prewarm = YamlSNIConfig::TunnelPreWarm::UNSET;
   const std::vector<int> &alpn_ids;
 
-  // The indexes of the mapping functions that need to be called. On
-  // creation, we decide which functions need to be called, add the
-  // coressponding indexes and then we call those functions with the relevant
-  // data.
+  /** The indexes of the mapping functions that need to be called. On
+  creation, we decide which functions need to be called, add the coressponding
+  indexes and then we call those functions with the relevant data.
+  */
   std::vector<OpId> fnArrIndexes;
 
   /// tunnel_route destination callback array.


### PR DESCRIPTION
This PR adds support for the `tunnel_route` configuration that contains both the regex match group number and the port variable specification, such as the following
```
- fqdn: "node.*.example.com"
  tunnel_route: "backend.$1.example.com:{proxy_protocol_port}"
```
Prior to this PR, only one of the match group specification or port variable specification can be used in the `tunnel_route` configuration.