### PR TITLE
TS API - Add support for checking the YAML-CPP version used in the core.

### DIFF
--- a/doc/developer-guide/api/functions/TSYAMLCompatibilityCheck.en.rst
+++ b/doc/developer-guide/api/functions/TSYAMLCompatibilityCheck.en.rst
@@ -1,0 +1,70 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSYAMLCompatibilityCheck
+************************
+
+Get the YAML-CPP library version used in core
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+   #include <ts/ts.h>
+
+.. c:var::  const char* TS_YAML_CPP_CORE_VERSION;
+.. c:var::  int TS_YAML_CPP_CORE_VERSION_LEN;
+.. function:: TSReturnCode TSYAMLCompatibilityCheck(const char *yamlcpp_lib_version, int yamlcpp_lib_len);
+
+Description
+===========
+
+There could be a mismatch between YAML-CPP versions used in Core and  Plugins, if a particular Plugin uses a TS API
+that have a ``TSYaml`` type in their signature then they should make sure they use the same version to avoid any binary
+compatibility issue. This API is supplied to let Plugins perform this check.
+
+:var:`TS_YAML_CPP_CORE_VERSION` Can be used to read the YAML-CPP version used in core.
+:var:`TS_YAML_CPP_CORE_VERSION_LEN` Size of the string representation of the YAML-CPP version.
+:type:`TSYAMLCompatibilityCheck` Checks the passed YAML-CPP library version against the used(built) in core.
+:arg:`yamlcpp_lib_version` should be a string with the yaml-cpp library version the plugin is using. A null terminated string is
+expected.
+:arg:`yamlcpp_lib_len` size of the passed string. If yamlcpp_lib_len is -1 then TSYAMLCompatibilityCheck() assumes that value is
+null-terminated. Otherwise, the length of the string value is taken to be length.
+
+
+Example:
+
+   .. code-block:: cpp
+
+         #include <ts/ts.h>
+
+         std::string_view my_yaml_version {"0.7.0"};
+         if (TSYAMLCompatibilityCheck(my_yaml_version.c_str(), my_yaml_version.size()) != TS_SUCCESS) {
+            TSDebug("my_plugin", "Error: %.*s  is used in core.", TS_YAML_CPP_CORE_VERSION_LEN, TS_YAML_CPP_CORE_VERSION);
+         }
+
+
+Return Values
+=============
+
+
+:c:func:`TSYAMLCompatibilityCheck` Returns :const:`TS_SUCCESS` if no issues, :const:`TS_ERROR` if the :arg:`yamlcpp_lib_version`
+was not set, or the ``yamlcpp`` version does not match with the one used in the core.

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -1473,6 +1473,10 @@ namespace ts
 }
 #endif
 
+// YAML-CPP core version
+extern tsapi const char *TS_YAML_CPP_CORE_VERSION;
+extern tsapi int TS_YAML_CPP_CORE_VERSION_LEN;
+
 // JSONRPC 2.0 related interface.
 typedef struct tsapi_rpcproviderhandle *TSRPCProviderHandle;
 typedef struct tsapi_yaml *TSYaml;

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -2741,6 +2741,19 @@ tsapi bool TSHttpTxnCntlGet(TSHttpTxn txnp, TSHttpCntlType ctrl);
 tsapi TSReturnCode TSHttpTxnCntlSet(TSHttpTxn txnp, TSHttpCntlType ctrl, bool data);
 
 /**
+ * Check the passed YAML-CPP library version against the used(built) in core.
+ *
+ * @note This API uses @c TS_YAML_CPP_CORE_VERSION to check the internal YAML-CPP version string.
+ *
+ * @param yamlcpp_lib_version a string with the yamlcpp library version.
+ * @param yamlcpp_lib_len The length of the yamlcpp_lib_len string. If yamlcpp_lib_len is -1 then TSYAMLCompatibilityCheck() assumes
+ * that value is null-terminated. Otherwise, the length of the string value is taken to be length.
+ * @return TS_ERROR if the yamlcpp_lib_version was not set, or the yamlcpp version does not match with
+ * the one used internally in TS_SUCCESS
+ */
+tsapi TSReturnCode TSYAMLCompatibilityCheck(const char *yamlcpp_lib_version, int yamlcpp_lib_len);
+
+/**
  * JSONRPC callback signature for method calls.
  */
 typedef void (*TSRPCMethodCb)(const char *id, TSYaml params);

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -9157,3 +9157,32 @@ REGRESSION_TEST(SDK_API_TSStatCreate)(RegressionTest *test, int level, int *psta
 
   box.check(expected >= value, "TSStatIntGet(%s) gave %" PRId64 ", expected at least %" PRId64, name, value, expected);
 }
+
+REGRESSION_TEST(SDK_API_TSYAML)(RegressionTest *test, int level, int *pstatus)
+{
+  TestBox box(test, pstatus);
+
+  box = REGRESSION_TEST_PASSED;
+
+  if (TSYAMLCompatibilityCheck(TS_YAML_CPP_CORE_VERSION, TS_YAML_CPP_CORE_VERSION_LEN) != TS_SUCCESS) {
+    SDK_RPRINT(test, "TSYAMLCompatibilityCheck", "TestCase1", TC_FAIL,
+               "Compatibility check failed. Shoulnd't fail as the test is using the core version");
+    *pstatus = REGRESSION_TEST_FAILED;
+    return;
+  } else {
+    SDK_RPRINT(test, "TSYAMLCompatibilityCheck", "TestCase1", TC_PASS, "ok");
+  }
+
+  std::string_view some_plugin_yaml_version{"0.6.3"};
+  if (TSYAMLCompatibilityCheck(some_plugin_yaml_version.data(), some_plugin_yaml_version.size()) != TS_ERROR) {
+    SDK_RPRINT(test, "TSYAMLCompatibilityCheck", "TestCase2", TC_FAIL,
+               "Compatibility check OK, it shouldn't be ok. Version %s passed, %.*s in code", some_plugin_yaml_version.data(),
+               TS_YAML_CPP_CORE_VERSION_LEN, TS_YAML_CPP_CORE_VERSION);
+    *pstatus = REGRESSION_TEST_FAILED;
+    return;
+  } else {
+    SDK_RPRINT(test, "TSYAMLCompatibilityCheck", "TestCase2", TC_PASS, "ok");
+  }
+
+  *pstatus = REGRESSION_TEST_PASSED;
+}


### PR DESCRIPTION
This will be handy for several reasons:

1 - Avoid binary compatibility issues: Make sure that any plugin using a TS API with a `TSYaml` as part of their signature runs the same YAML-CPP version as in core.
2 - if any JSONRPC Plugin handler wants to make sure they have the same yaml version as in core(before registering by TSRPCRegister, or even after using the constants) so they can avoid issues.