### PR TITLE
Convert sprintf to snprintf

### DIFF
--- a/iocore/cache/CachePagesInternal.cc
+++ b/iocore/cache/CachePagesInternal.cc
@@ -139,8 +139,8 @@ ShowCacheInternal::showVolConnections(int event, Event *e)
     // if vc is closed ignore - Ramki 08/30/2000
     if (vc->closed == 1)
       continue;
-    sprintf(nbytes, "%d", vc->vio.nbytes);
-    sprintf(todo, "%d", vc->vio.ntodo());
+    snprintf(nbytes, sizeof(nbytes), "%d", vc->vio.nbytes);
+    snprintf(todo, sizeof(todo), "%d", vc->vio.ntodo());
 
     if (vc->f.frag_type == CACHE_FRAG_TYPE_HTTP && vc->request.valid()) {
       URL *u = vc->request.url_get(&uu);

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -320,7 +320,7 @@ CacheControlHeader::generate() const
   immutable = (_immutable ? ", " HTTP_IMMUTABLE : "");
   max_age   = (_max_age == numeric_limits<unsigned int>::max() ? 315360000 : _max_age); // default is 10 years
 
-  sprintf(line_buf, "Cache-Control: max-age=%u, %s%s\r\n", max_age, publicity, immutable);
+  snprintf(line_buf, sizeof(line_buf), "Cache-Control: max-age=%u, %s%s\r\n", max_age, publicity, immutable);
   return string(line_buf);
 }
 

--- a/plugins/esi/fetcher/HttpDataFetcherImpl.cc
+++ b/plugins/esi/fetcher/HttpDataFetcherImpl.cc
@@ -94,19 +94,22 @@ HttpDataFetcherImpl::addFetchRequest(const string &url, FetchedDataProcessor *ca
   char buff[1024];
   char *http_req;
   int length;
+  size_t req_buf_size = 0;
 
   length = sizeof("GET ") - 1 + url.length() + sizeof(" HTTP/1.0\r\n") - 1 + _headers_str.length() + sizeof("\r\n") - 1;
   if (length < static_cast<int>(sizeof(buff))) {
-    http_req = buff;
+    http_req     = buff;
+    req_buf_size = sizeof(buff);
   } else {
-    http_req = static_cast<char *>(malloc(length + 1));
+    req_buf_size = length + 1;
+    http_req     = static_cast<char *>(malloc(req_buf_size));
     if (http_req == nullptr) {
       TSError("[HttpDataFetcherImpl][%s] malloc %d bytes fail", __FUNCTION__, length + 1);
       return false;
     }
   }
 
-  sprintf(http_req, "GET %s HTTP/1.0\r\n%s\r\n", url.c_str(), _headers_str.c_str());
+  snprintf(http_req, req_buf_size, "GET %s HTTP/1.0\r\n%s\r\n", url.c_str(), _headers_str.c_str());
 
   TSFetchEvent event_ids;
   event_ids.success_event_id = _curr_event_id_base;

--- a/plugins/lua/ts_lua_fetch.c
+++ b/plugins/lua/ts_lua_fetch.c
@@ -375,7 +375,7 @@ ts_lua_fetch_one_item(lua_State *L, const char *url, size_t url_len, ts_lua_fetc
   }
 
   if (body_len > 0 && cl == 0) { // add Content-Length header
-    n = sprintf(buf, "%zu", body_len);
+    n = snprintf(buf, sizeof(buf), "%zu", body_len);
     TSFetchHeaderAdd(fi->fch, TS_MIME_FIELD_CONTENT_LENGTH, TS_MIME_LEN_CONTENT_LENGTH, buf, n);
   }
 

--- a/src/wccp/WccpEndPoint.cc
+++ b/src/wccp/WccpEndPoint.cc
@@ -432,7 +432,7 @@ CacheImpl::GroupData::processUp()
         int pid            = atoi(buffer);
         if (pid > 0) {
           // If the process is still running, it has an entry in the proc file system, (Linux only)
-          sprintf(buffer, "/proc/%d/status", pid);
+          snprintf(buffer, sizeof(buffer), "/proc/%d/status", pid);
           ats_scoped_fd fd2{open(buffer, O_RDONLY)};
           if (fd2 >= 0) {
             zret = true;

--- a/src/wccp/WccpStatic.cc
+++ b/src/wccp/WccpStatic.cc
@@ -84,7 +84,7 @@ ip_addr_to_str(uint32_t addr)
 {
   static char buff[4 * 3 + 3 + 1];
   unsigned char *octet = reinterpret_cast<unsigned char *>(&addr);
-  sprintf(buff, "%d.%d.%d.%d", octet[0], octet[1], octet[2], octet[3]);
+  snprintf(buff, sizeof(buff), "%d.%d.%d.%d", octet[0], octet[1], octet[2], octet[3]);
   return buff;
 }
 


### PR DESCRIPTION
Apple clang version 14.0.3 raised deprecation warnings on some
uses of sprintf.  This patch converts the uses of sprintf to
snprintf.