### PR TITLE
Ensure a reason phrase when sending an HTTP/1 response

### DIFF
--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -269,12 +269,12 @@ HttpTransactHeaders::convert_request(HTTPVersion outgoing_ver, HTTPHdr *outgoing
 ////////////////////////////////////////////////////////////////////////
 // Just convert the outgoing response to the appropriate version
 void
-HttpTransactHeaders::convert_response(HTTPVersion outgoing_ver, HTTPHdr *outgoing_response)
+HttpTransactHeaders::convert_response(HTTPVersion outgoing_ver, HTTPHdr *outgoing_response, char const *reason_phrase)
 {
   if (outgoing_ver == HTTPVersion(1, 1)) {
-    convert_to_1_1_response_header(outgoing_response);
+    convert_to_1_1_response_header(outgoing_response, reason_phrase);
   } else if (outgoing_ver == HTTPVersion(1, 0)) {
-    convert_to_1_0_response_header(outgoing_response);
+    convert_to_1_0_response_header(outgoing_response, reason_phrase);
   } else {
     Debug("http_trans", "[HttpTransactHeaders::convert_response]"
                         "Unsupported Version - passing through");
@@ -325,7 +325,7 @@ HttpTransactHeaders::convert_to_1_1_request_header(HTTPHdr *outgoing_request)
 ////////////////////////////////////////////////////////////////////////
 // Take an existing outgoing response header and make it HTTP/1.0
 void
-HttpTransactHeaders::convert_to_1_0_response_header(HTTPHdr *outgoing_response)
+HttpTransactHeaders::convert_to_1_0_response_header(HTTPHdr *outgoing_response, char const *reason_phrase)
 {
   //     // These are required
   //     ink_assert(outgoing_response->status_get());
@@ -333,6 +333,12 @@ HttpTransactHeaders::convert_to_1_0_response_header(HTTPHdr *outgoing_response)
 
   // Set HTTP version to 1.0
   outgoing_response->version_set(HTTPVersion(1, 0));
+
+  // Set reason phrase if passed in.
+  if (reason_phrase != nullptr) {
+    Debug("http_transact_headers", "Setting HTTP/1.0 reason phrase to '%s'", reason_phrase);
+    outgoing_response->reason_set(reason_phrase, strlen(reason_phrase));
+  }
 
   // Keep-Alive?
 
@@ -342,13 +348,19 @@ HttpTransactHeaders::convert_to_1_0_response_header(HTTPHdr *outgoing_response)
 ////////////////////////////////////////////////////////////////////////
 // Take an existing outgoing response header and make it HTTP/1.1
 void
-HttpTransactHeaders::convert_to_1_1_response_header(HTTPHdr *outgoing_response)
+HttpTransactHeaders::convert_to_1_1_response_header(HTTPHdr *outgoing_response, char const *reason_phrase)
 {
   // These are required
   ink_assert(outgoing_response->status_get());
 
   // Set HTTP version to 1.1
   outgoing_response->version_set(HTTPVersion(1, 1));
+
+  // Set reason phrase if passed in.
+  if (reason_phrase != nullptr) {
+    Debug("http_transact_headers", "Setting HTTP/1.1 reason phrase to '%s'", reason_phrase);
+    outgoing_response->reason_set(reason_phrase, strlen(reason_phrase));
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/proxy/http/HttpTransactHeaders.h
+++ b/proxy/http/HttpTransactHeaders.h
@@ -44,11 +44,11 @@ public:
   static void copy_header_fields(HTTPHdr *src_hdr, HTTPHdr *new_hdr, bool retain_proxy_auth_hdrs, ink_time_t date = 0);
 
   static void convert_request(HTTPVersion outgoing_ver, HTTPHdr *outgoing_request);
-  static void convert_response(HTTPVersion outgoing_ver, HTTPHdr *outgoing_response);
+  static void convert_response(HTTPVersion outgoing_ver, HTTPHdr *outgoing_response, char const *reason_phrase = nullptr);
   static void convert_to_1_0_request_header(HTTPHdr *outgoing_request);
   static void convert_to_1_1_request_header(HTTPHdr *outgoing_request);
-  static void convert_to_1_0_response_header(HTTPHdr *outgoing_response);
-  static void convert_to_1_1_response_header(HTTPHdr *outgoing_response);
+  static void convert_to_1_0_response_header(HTTPHdr *outgoing_response, char const *reason_phrase = nullptr);
+  static void convert_to_1_1_response_header(HTTPHdr *outgoing_response, char const *reason_phrase = nullptr);
 
   static ink_time_t calculate_document_age(ink_time_t request_time, ink_time_t response_time, HTTPHdr *base_response,
                                            ink_time_t base_response_date, ink_time_t now);

--- a/tests/gold_tests/h2/replay_h2origin/h1-client-h2-origin.yaml
+++ b/tests/gold_tests/h2/replay_h2origin/h1-client-h2-origin.yaml
@@ -72,8 +72,9 @@ sessions:
             size: 0
 
         proxy-response:
-          version: '2'
+          version: '1.1'
           status: 200
+          reason: OK
           headers:
             encoding: esc_json
             fields:
@@ -142,6 +143,7 @@ sessions:
         proxy-response:
           version: '1.1'
           status: 200
+          reason: OK
           headers:
             encoding: esc_json
             fields:
@@ -220,8 +222,9 @@ sessions:
             size: 0
 
         proxy-response:
-          version: '2'
+          version: '1.1'
           status: 404
+          reason: Not Found
           headers:
             encoding: esc_json
             fields:
@@ -286,8 +289,9 @@ sessions:
             size: 32
 
         proxy-response:
-          version: '2'
+          version: '1.1'
           status: 200
+          reason: OK
           headers:
             encoding: esc_json
             fields:
@@ -353,8 +357,9 @@ sessions:
             size: 1600
 
         proxy-response:
-          version: '2'
+          version: '1.1'
           status: 200
+          reason: OK
           headers:
             encoding: esc_json
             fields:
@@ -422,6 +427,7 @@ sessions:
         proxy-response:
           version: '1.1'
           status: 200
+          reason: OK
           headers:
             encoding: esc_json
             fields:
@@ -489,6 +495,7 @@ sessions:
         proxy-response:
           version: '1.1'
           status: 200
+          reason: OK
           headers:
             encoding: esc_json
             fields:


### PR DESCRIPTION
With an HTTP/1 client and an HTTP/2 origin, responses will come from the
origin without reason phrases because reason phrases are explicitly
removed from the HTTP/2 RFC. When expanding test coverage of reason
phrases it was noticed that when converting responses from HTTP/2 to
HTTP/1 to send toward the client, the reason phrases were empty. This
updates the conversion logic to ensure that HTTP/1 clients receive a
reason phrase.