### PR TITLE
Add support for CONNECT method on HTTP/2 connection

### DIFF
--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -491,7 +491,14 @@ http2_decode_header_blocks(HTTPHdr *hdr, const uint8_t *buf_start, const uint32_
   }
 
   MIMEFieldIter iter;
-  unsigned int expected_pseudo_header_count = is_outbound ? 1 : 4;
+  auto method_field       = hdr->field_find(PSEUDO_HEADER_METHOD.data(), PSEUDO_HEADER_METHOD.size());
+  bool has_connect_method = false;
+  if (method_field) {
+    int method_len;
+    const char *method_value = method_field->value_get(&method_len);
+    has_connect_method       = method_len == HTTP_LEN_CONNECT && strncmp(HTTP_METHOD_CONNECT, method_value, HTTP_LEN_CONNECT) == 0;
+  }
+  unsigned int expected_pseudo_header_count = is_outbound ? 1 : has_connect_method ? 2 : 4;
   unsigned int pseudo_header_count          = 0;
 
   if (is_trailing_header) {
@@ -554,7 +561,7 @@ http2_decode_header_blocks(HTTPHdr *hdr, const uint8_t *buf_start, const uint32_
         return Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR;
       }
     } else {
-      if (hdr->fields_count() >= 4) {
+      if (!has_connect_method && hdr->fields_count() >= 4) {
         if (hdr->field_find(PSEUDO_HEADER_SCHEME.data(), PSEUDO_HEADER_SCHEME.size()) == nullptr ||
             hdr->field_find(PSEUDO_HEADER_METHOD.data(), PSEUDO_HEADER_METHOD.size()) == nullptr ||
             hdr->field_find(PSEUDO_HEADER_PATH.data(), PSEUDO_HEADER_PATH.size()) == nullptr ||
@@ -563,6 +570,16 @@ http2_decode_header_blocks(HTTPHdr *hdr, const uint8_t *buf_start, const uint32_
           // Decoded header field is invalid
           return Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR;
         }
+      } else if (has_connect_method && hdr->fields_count() >= 2) {
+        if (hdr->field_find(PSEUDO_HEADER_SCHEME.data(), PSEUDO_HEADER_SCHEME.size()) != nullptr ||
+            hdr->field_find(PSEUDO_HEADER_METHOD.data(), PSEUDO_HEADER_METHOD.size()) == nullptr ||
+            hdr->field_find(PSEUDO_HEADER_PATH.data(), PSEUDO_HEADER_PATH.size()) != nullptr ||
+            hdr->field_find(PSEUDO_HEADER_AUTHORITY.data(), PSEUDO_HEADER_AUTHORITY.size()) == nullptr ||
+            hdr->field_find(PSEUDO_HEADER_STATUS.data(), PSEUDO_HEADER_STATUS.size()) != nullptr) {
+          // Decoded header field is invalid
+          return Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR;
+        }
+
       } else {
         // Pseudo headers is insufficient
         return Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR;

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -2092,7 +2092,7 @@ Http2ConnectionState::send_a_data_frame(Http2Stream *stream, size_t &payload_len
                    _peer_rwnd, stream->get_peer_rwnd(), payload_length, flags);
 
   Http2DataFrame data(stream->get_id(), flags, resp_reader, payload_length);
-  this->session->xmit(data, flags & HTTP2_FLAGS_DATA_END_STREAM);
+  this->session->xmit(data, stream->is_tunneling() || flags & HTTP2_FLAGS_DATA_END_STREAM);
 
   if (flags & HTTP2_FLAGS_DATA_END_STREAM) {
     Http2StreamDebug(session, stream->get_id(), "END_STREAM");

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -276,6 +276,13 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     }
   }
 
+  // Check whether the request uses CONNECT method
+  int method_len;
+  const char *method = _receive_header.method_get(&method_len);
+  if (method_len == HTTP_LEN_CONNECT && strncmp(method, HTTP_METHOD_CONNECT, HTTP_LEN_CONNECT) == 0) {
+    this->_is_tunneling = true;
+  }
+
   if (this->expect_send_trailer()) {
     // Send read complete to terminate previous data tunnel
     this->read_vio.nbytes = this->read_vio.ndone;
@@ -616,6 +623,12 @@ bool
 Http2Stream::is_outbound_connection() const
 {
   return _is_outbound;
+}
+
+bool
+Http2Stream::is_tunneling() const
+{
+  return _is_tunneling;
 }
 
 /* Replace existing event only if the new event is different than the inprogress event */

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -276,11 +276,13 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     }
   }
 
-  // Check whether the request uses CONNECT method
-  int method_len;
-  const char *method = _receive_header.method_get(&method_len);
-  if (method_len == HTTP_LEN_CONNECT && strncmp(method, HTTP_METHOD_CONNECT, HTTP_LEN_CONNECT) == 0) {
-    this->_is_tunneling = true;
+  if (_receive_header.type_get() == HTTP_TYPE_REQUEST) {
+    // Check whether the request uses CONNECT method
+    int method_len;
+    const char *method = _receive_header.method_get(&method_len);
+    if (method_len == HTTP_LEN_CONNECT && strncmp(method, HTTP_METHOD_CONNECT, HTTP_LEN_CONNECT) == 0) {
+      this->_is_tunneling = true;
+    }
   }
 
   if (this->expect_send_trailer()) {

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -85,6 +85,7 @@ public:
   void send_request(Http2ConnectionState &cstate);
   void initiating_close();
   bool is_outbound_connection() const;
+  bool is_tunneling() const;
   void terminate_if_possible();
   void update_read_request(bool send_update);
   void update_write_request(bool send_update);
@@ -229,6 +230,14 @@ private:
    * session close in which is_outbound is not accessible.
    */
   bool _is_outbound = false;
+
+  /** Whether CONNECT method is used.
+   *
+   * We cannot buffer outgoing data if this stream is used for tunneling (CONNECT method), because we don't know the
+   * protocol used in the tunnel and we cannot expect additional data from (following read event) from the server side
+   * without sending the data ATS currently has.
+   */
+  bool _is_tunneling = false;
 
   /** Whether the stream has been registered with the connection state. */
   bool _registered_stream = true;


### PR DESCRIPTION
This blog post motivated me to implement CONNECT method support.
https://daniel.haxx.se/blog/2023/04/14/curl-speaks-http-2-with-proxy/

```
$ ~/opt/curl/bin/curl -vk --proxy-insecure --proxy-http2 -x https://localhost:8443/ https://www.apache.org/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8443...
* Connected to localhost (127.0.0.1) port 8443 (#0)
* ALPN: offers h2,http/1.1
} [5 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [512 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
{ [15 bytes data]
* TLSv1.3 (IN), TLS handshake, Certificate (11):
{ [1444 bytes data]
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
{ [520 bytes data]
* TLSv1.3 (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* TLSv1.3 (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN: server accepted h2
* Proxy certificate:
*  subject: C=AU; ST=Some-State; O=Internet Widgits Pty Ltd; CN=localhost
*  start date: Apr 16 01:33:15 2023 GMT
*  expire date: Apr 15 01:33:15 2024 GMT
*  issuer: C=AU; ST=Some-State; O=Internet Widgits Pty Ltd; CN=localhost
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* CONNECT tunnel: HTTP/2 negotiated
* Establish HTTP/2 proxy tunnel to www.apache.org:443
} [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [214 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [214 bytes data]
* CONNECT tunnel established, response 200
* CONNECT phase completed
* ALPN: offers h2,http/1.1
} [5 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [512 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
} [1 bytes data]
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
{ [19 bytes data]
* TLSv1.3 (IN), TLS handshake, Certificate (11):
{ [4022 bytes data]
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
{ [264 bytes data]
* TLSv1.3 (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* TLSv1.3 (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=*.apache.org
*  start date: Apr 13 16:56:32 2023 GMT
*  expire date: Jul 12 16:56:31 2023 GMT
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
{ [5 bytes data]
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
{ [161 bytes data]
* using HTTP/2
* h2h3 [:method: GET]
* h2h3 [:path: /]
* h2h3 [:scheme: https]
* h2h3 [:authority: www.apache.org]
* h2h3 [user-agent: curl/8.1.0-DEV]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x55fb74068380)
} [5 bytes data]
> GET / HTTP/2
> Host: www.apache.org
> user-agent: curl/8.1.0-DEV
> accept: */*
>
{ [5 bytes data]
< HTTP/2 200
< server: Apache
< last-modified: Sun, 16 Apr 2023 05:23:20 GMT
< etag: "1195a-5f96d45bc947c"
< cache-control: max-age=3600
< expires: Sun, 16 Apr 2023 06:23:21 GMT
< content-security-policy: default-src 'self' 'unsafe-inline' https://www.apachecon.com/ https://www.google.com/cse/ https://cse.google.com/ https://www.googleapis.com/generate_204 http://*.google.com/generate_204 https://afs.googlesyndication.com/ https://csp.withgoogle.com/ https://www.google.com/images/ https://ssl.gstatic.com/ui/ https://docs.google.com/forms/ https://www.youtube.com/embed/; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cse.google.com/ http://cse.google.com/adsense/search/async-ads.js https://www.google.com/cse/ https://partner.googleadservices.com/; style-src 'self' 'unsafe-inline' https://www.google.com/cse/; frame-ancestors 'none';
< strict-transport-security: max-age=31536000; preload
< content-type: text/html
< via: 1.1 varnish, 1.1 varnish
< accept-ranges: bytes
< date: Sun, 16 Apr 2023 05:50:09 GMT
< age: 1608
< x-served-by: cache-hel1410025-HEL, cache-dfw-kdfw8210029-DFW
< x-cache: HIT, HIT
< x-cache-hits: 4, 1
< x-timer: S1681624210.756756,VS0,VE1
< vary: Accept-Encoding
< content-length: 72026
<
{ [5 bytes data]
100 72026  100 72026    0     0   556k      0 --:--:-- --:--:-- --:--:--  558k
* Connection #0 to host localhost left intact
```