### PR TITLE
Cleanup: Rename d with vol

### DIFF
--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -276,24 +276,24 @@ struct CacheSync : public Continuation {
 
 // Global Functions
 
-void vol_init_dir(Vol *d);
+void vol_init_dir(Vol *vol);
 int dir_probe(const CacheKey *, Vol *, Dir *, Dir **);
-int dir_insert(const CacheKey *key, Vol *d, Dir *to_part);
-int dir_overwrite(const CacheKey *key, Vol *d, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
-int dir_delete(const CacheKey *key, Vol *d, Dir *del);
-int dir_lookaside_probe(const CacheKey *key, Vol *d, Dir *result, EvacuationBlock **eblock);
-int dir_lookaside_insert(EvacuationBlock *b, Vol *d, Dir *to);
-int dir_lookaside_fixup(const CacheKey *key, Vol *d);
-void dir_lookaside_cleanup(Vol *d);
-void dir_lookaside_remove(const CacheKey *key, Vol *d);
-void dir_free_entry(Dir *e, int s, Vol *d);
+int dir_insert(const CacheKey *key, Vol *vol, Dir *to_part);
+int dir_overwrite(const CacheKey *key, Vol *vol, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
+int dir_delete(const CacheKey *key, Vol *vol, Dir *del);
+int dir_lookaside_probe(const CacheKey *key, Vol *vol, Dir *result, EvacuationBlock **eblock);
+int dir_lookaside_insert(EvacuationBlock *b, Vol *vol, Dir *to);
+int dir_lookaside_fixup(const CacheKey *key, Vol *vol);
+void dir_lookaside_cleanup(Vol *vol);
+void dir_lookaside_remove(const CacheKey *key, Vol *vol);
+void dir_free_entry(Dir *e, int s, Vol *vol);
 void dir_sync_init();
-int check_dir(Vol *d);
-void dir_clean_vol(Vol *d);
-void dir_clear_range(off_t start, off_t end, Vol *d);
-int dir_segment_accounted(int s, Vol *d, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
+int check_dir(Vol *vol);
+void dir_clean_vol(Vol *vol);
+void dir_clear_range(off_t start, off_t end, Vol *vol);
+int dir_segment_accounted(int s, Vol *vol, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
                           int *valid = nullptr, int *agg_valid = nullptr, int *avg_size = nullptr);
-uint64_t dir_entries_used(Vol *d);
+uint64_t dir_entries_used(Vol *vol);
 void sync_cache_dir_on_shutdown();
 
 // Global Data

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -548,7 +548,7 @@ extern CacheSync *cacheDirSync;
 // Function Prototypes
 int cache_write(CacheVC *, CacheHTTPInfoVector *);
 int get_alternate_index(CacheHTTPInfoVector *cache_vector, CacheKey key);
-CacheVC *new_DocEvacuator(int nbytes, Vol *d);
+CacheVC *new_DocEvacuator(int nbytes, Vol *vol);
 
 // inline Functions
 
@@ -862,36 +862,36 @@ Vol::close_read_lock(CacheVC *cont)
 }
 
 inline int
-dir_delete_lock(CacheKey *key, Vol *d, ProxyMutex *m, Dir *del)
+dir_delete_lock(CacheKey *key, Vol *vol, ProxyMutex *m, Dir *del)
 {
   EThread *thread = m->thread_holding;
-  CACHE_TRY_LOCK(lock, d->mutex, thread);
+  CACHE_TRY_LOCK(lock, vol->mutex, thread);
   if (!lock.is_locked()) {
     return -1;
   }
-  return dir_delete(key, d, del);
+  return dir_delete(key, vol, del);
 }
 
 inline int
-dir_insert_lock(CacheKey *key, Vol *d, Dir *to_part, ProxyMutex *m)
+dir_insert_lock(CacheKey *key, Vol *vol, Dir *to_part, ProxyMutex *m)
 {
   EThread *thread = m->thread_holding;
-  CACHE_TRY_LOCK(lock, d->mutex, thread);
+  CACHE_TRY_LOCK(lock, vol->mutex, thread);
   if (!lock.is_locked()) {
     return -1;
   }
-  return dir_insert(key, d, to_part);
+  return dir_insert(key, vol, to_part);
 }
 
 inline int
-dir_overwrite_lock(CacheKey *key, Vol *d, Dir *to_part, ProxyMutex *m, Dir *overwrite, bool must_overwrite = true)
+dir_overwrite_lock(CacheKey *key, Vol *vol, Dir *to_part, ProxyMutex *m, Dir *overwrite, bool must_overwrite = true)
 {
   EThread *thread = m->thread_holding;
-  CACHE_TRY_LOCK(lock, d->mutex, thread);
+  CACHE_TRY_LOCK(lock, vol->mutex, thread);
   if (!lock.is_locked()) {
     return -1;
   }
-  return dir_overwrite(key, d, to_part, overwrite, must_overwrite);
+  return dir_overwrite(key, vol, to_part, overwrite, must_overwrite);
 }
 
 void inline rand_CacheKey(CacheKey *next_key, Ptr<ProxyMutex> &mutex)

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -432,8 +432,8 @@ Doc::data()
   return this->hdr() + hlen;
 }
 
-int vol_dir_clear(Vol *d);
-int vol_init(Vol *d, char *s, off_t blocks, off_t skip, bool clear);
+int vol_dir_clear(Vol *vol);
+int vol_init(Vol *vol, char *s, off_t blocks, off_t skip, bool clear);
 
 // inline Functions
 


### PR DESCRIPTION
This is entirely a cosmetic change in the cache subsystem. Change all `Vol *d` arguments to `Vol *vol` for readability.