### PR TITLE
Add OTHER to TLS cipher metrics

### DIFF
--- a/iocore/net/SSLStats.h
+++ b/iocore/net/SSLStats.h
@@ -121,3 +121,5 @@ extern std::unordered_map<std::string, intptr_t> cipher_map;
 
 // Initialize SSL statistics.
 void SSLInitializeStatistics();
+
+const std::string SSL_CIPHER_STAT_OTHER = "OTHER";

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1118,9 +1118,12 @@ ssl_callback_info(const SSL *ssl, int where, int ret)
     if (cipher) {
       const char *cipherName = SSL_CIPHER_get_name(cipher);
       // lookup index of stat by name and incr count
-      if (auto it = cipher_map.find(cipherName); it != cipher_map.end()) {
-        SSL_INCREMENT_DYN_STAT((intptr_t)it->second);
+      auto it = cipher_map.find(cipherName);
+      if (it == cipher_map.end()) {
+        it = cipher_map.find(SSL_CIPHER_STAT_OTHER);
+        ink_assert(it != cipher_map.end());
       }
+      SSL_INCREMENT_DYN_STAT((intptr_t)it->second);
     }
   }
 }


### PR DESCRIPTION
Use of ciphers that are not listed on the default context (of a SSL library) are not counted. This patch adds proxy.process.ssl.cipher.user_agent.OTHER to count it.

https://github.com/apache/trafficserver/blob/15ffe764bac69957627aece42085cc71ea3c6901/iocore/net/SSLStats.cc#L230-L233

We might want to have a setting that is not dynamic to allow configuring which ciphers to count, but we'd probably want to have OTHER anyway. At a minimum, this makes it possible to compare the metrics from multiple hosts that use different SSL libraries (i.e. different default cipher lists).