### PR TITLE
Change remap filter behavior to match ip_allow.yaml

### DIFF
--- a/doc/admin-guide/files/remap.config.en.rst
+++ b/doc/admin-guide/files/remap.config.en.rst
@@ -433,7 +433,12 @@ Acl Filters
 
 Acl filters can be created to control access of specific remap lines. The markup
 is very similar to that of :file:`ip_allow.yaml`, with slight changes to
-accommodate remap markup
+accommodate remap markup.
+
+**Note:** As of ATS v10.x, these filters are applied just as :file:`ip_allow.yaml`,
+this means once a filter matches the request, the action for that rule takes effect.
+In previous versions, all filters for a remap rule were evaluated, and the ``deny``
+action took priority.
 
 Examples
 --------


### PR DESCRIPTION
This could possibly be considered a bug, but certainly it's not a great behavior as it was. Before this patch, filters (as defined and used with .definefilter and .activatefilter), are always all evaluated, with a priority towards deny.

ip_allow.yaml however works by evaluating only filters up until one matches, and whatever action has triggered, is used.

This patch changes these remap filters to follow the behavior of ip_allow.yaml. First filter that matches is applied, and evaluation of filters stops.

I would really have liked to see this in 9.2.x, but I'm not so sure that it's a good idea since it does also break compatibility even if we consider this a bug.