### PR TITLE
Updates for the new go-httpbin v2.6.0 release.

### DIFF
--- a/tests/gold_tests/h2/gold/httpbin_1_stderr.gold
+++ b/tests/gold_tests/h2/gold/httpbin_1_stderr.gold
@@ -6,9 +6,8 @@
 ``
 < HTTP/2 200 ``
 ``
-< content-type: application/octet-stream
+< content-length: 0
 < date: ``
-< content-length: ``
 < age: ``
 < via: ``ApacheTrafficServer/``
 < server: ATS/``

--- a/tests/gold_tests/h2/gold/httpbin_access.gold
+++ b/tests/gold_tests/h2/gold/httpbin_access.gold
@@ -1,4 +1,4 @@
 [``] GET http://127.0.0.1:``/get HTTP/1.1 http/2 `` `` TCP_MISS 200 ``
-[``] GET http://127.0.0.1:``/bytes/0 HTTP/1.1 http/2 `` `` TCP_MISS 200 1
+[``] GET http://127.0.0.1:``/bytes/0 HTTP/1.1 http/2 `` `` TCP_MISS 200 0
 [``] GET http://127.0.0.1:``/stream-bytes/102400?seed=0 HTTP/1.1 http/2 `` `` TCP_MISS 200 102400
 ``

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -97,8 +97,7 @@ test_run.Processes.Default.Streams.stderr = Testers.GoldFile("gold/httpbin_0_std
 test_run.StillRunningAfter = httpbin
 
 # Test Case 1: Attempt an empty response body.
-# Note: go-httpbin incorrectly returns a body of 1 byte instead of 0 bytes.
-# https://github.com/mccutchen/go-httpbin/issues/112
+# This test case requires go-httpbin@v2.6.0 or later.
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = 'curl -vs -k --http2 https://127.0.0.1:{0}/bytes/0'.format(ts.Variables.ssl_port)
 test_run.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
go-httpbin@v2.6.0 fixes /bytes/0 to actually return 0 bytes. This patch
accommodates our autests for that fix and any other behavioral changes.