### PR TITLE
9.2.x Stabilize 92x emergency and fatal autests

### DIFF
--- a/tests/gold_tests/shutdown/emergency.test.py
+++ b/tests/gold_tests/shutdown/emergency.test.py
@@ -45,7 +45,9 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Emergency Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
+tr.Timeout = 5
+
 ts.ReturnCode = 33
-ts.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
+ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing emergency shutdown")
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing emergency shutdown', 'should contain "testing emergency shutdown"')

--- a/tests/gold_tests/shutdown/emergency.test.py
+++ b/tests/gold_tests/shutdown/emergency.test.py
@@ -40,14 +40,23 @@ ts.Disk.records_config.update({
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'emergency_shutdown.so'), ts)
 
-# www.example.com Host
 tr = Test.AddTestRun()
+
+# We have to wait upon TS to emit the expected log message, but it cannot be
+# the ts Ready criteria because autest might detect the process going away
+# before it detects the log message. So we add a separate process that waits
+# upon the log message.
+watcher = Test.Processes.Process("watcher")
+watcher.Command = "sleep 1"
+watcher.Ready = When.FileContains(ts.Disk.diags_log.Name, "testing emergency shutdown")
+watcher.StartBefore(ts)
+
 tr.Processes.Default.Command = 'printf "Emergency Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.StartBefore(ts)
-tr.Timeout = 5
+tr.Processes.Default.StartBefore(watcher)
 
+tr.Timeout = 5
 ts.ReturnCode = 33
-ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing emergency shutdown")
+ts.Ready = 0
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing emergency shutdown', 'should contain "testing emergency shutdown"')

--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -45,7 +45,9 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'printf "Fatal Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
+tr.Timeout = 5
+
 ts.ReturnCode = 70
-ts.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
+ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing fatal shutdown")
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing fatal shutdown', 'should contain "testing fatal shutdown"')

--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -40,14 +40,23 @@ ts.Disk.records_config.update({
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'fatal_shutdown.so'), ts)
 
-# www.example.com Host
 tr = Test.AddTestRun()
+
+# We have to wait upon TS to emit the expected log message, but it cannot be
+# the ts Ready criteria because autest might detect the process going away
+# before it detects the log message. So we add a separate process that waits
+# upon the log message.
+watcher = Test.Processes.Process("watcher")
+watcher.Command = "sleep 1"
+watcher.Ready = When.FileContains(ts.Disk.diags_log.Name, "testing fatal shutdown")
+watcher.StartBefore(ts)
+
 tr.Processes.Default.Command = 'printf "Fatal Shutdown Test"'
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.StartBefore(ts)
-tr.Timeout = 5
+tr.Processes.Default.StartBefore(watcher)
 
+tr.Timeout = 5
 ts.ReturnCode = 70
-ts.Ready = When.FileContains(ts.Disk.traffic_out.Name, "testing fatal shutdown")
+ts.Ready = 0
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression('failed to shutdown', 'should NOT contain "failed to shutdown"')
 ts.Disk.diags_log.Content = Testers.IncludesExpression('testing fatal shutdown', 'should contain "testing fatal shutdown"')


### PR DESCRIPTION
Make the emergency and fatal autests more reliable by improving their Ready conditions.

This is a cherry-pick from master of the following two PRs:

* #9372
* #9391

(cherry picked from commit c175aa45c29124ab01af8f1efa1222fca8ff41c8)
(cherry picked from commit 086501cb58d7b872e955b49de952b554ba7b5685)
