### PR TITLE
9.2.x: Autest updates for recent versions of curl

### DIFF
--- a/tests/gold_tests/connect/gold/connect_0_stderr.gold
+++ b/tests/gold_tests/connect/gold/connect_0_stderr.gold
@@ -9,7 +9,7 @@
 < HTTP/1.1 200 OK
 ``
 <``
-* Proxy replied 200 to CONNECT request
+`` CONNECT ``
 ``
 > GET /get HTTP/1.1
 > Host: foo.com

--- a/tests/gold_tests/h2/h2enable.test.py
+++ b/tests/gold_tests/h2/h2enable.test.py
@@ -71,7 +71,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.TimeOut = 5
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Using HTTP2", "Curl should negotiate HTTP2")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2", "Curl should negotiate HTTP2")
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do negotiate h2")
@@ -82,7 +82,7 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ContainsExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do negotiate h2")
@@ -93,5 +93,5 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ContainsExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5

--- a/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
@@ -70,7 +70,7 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.TimeOut = 5
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Using HTTP2", "Curl should negotiate HTTP2")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2", "Curl should negotiate HTTP2")
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do negotiate h2")
@@ -80,7 +80,7 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ContainsExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do negotiate h2")
@@ -91,5 +91,5 @@ tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-tr2.Processes.Default.Streams.All += Testers.ContainsExpression("Using HTTP2", "Curl should not negotiate HTTP2")
+tr2.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2", "Curl should not negotiate HTTP2")
 tr2.TimeOut = 5

--- a/tests/gold_tests/proxy_protocol/gold/test_case_0_stderr.gold
+++ b/tests/gold_tests/proxy_protocol/gold/test_case_0_stderr.gold
@@ -1,5 +1,4 @@
 ``
-> PROXY TCP4 127.0.0.1 127.0.0.1 ``
 > GET /get HTTP/1.1
 > Host: localhost:``
 > User-Agent: curl/``

--- a/tests/gold_tests/proxy_protocol/gold/test_case_1_stderr.gold
+++ b/tests/gold_tests/proxy_protocol/gold/test_case_1_stderr.gold
@@ -1,5 +1,4 @@
 ``
-> PROXY TCP4 127.0.0.1 127.0.0.1 ``
 > GET /get HTTP/1.1
 > Host: localhost:``
 > User-Agent: curl/``


### PR DESCRIPTION
Recent versions of curl have updated output. This patch updates the autest expectations for this new output.

---

This is a backport of https://github.com/apache/trafficserver/pull/9651