### PR TITLE
Prefer the __linux__ macro over linux.

### DIFF
--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -146,7 +146,7 @@ struct ifafilt;
 #include <sys/sockio.h>
 #endif
 
-#if defined(linux)
+#if defined(__linux__)
 typedef unsigned int in_addr_t;
 #endif
 
@@ -192,7 +192,7 @@ typedef unsigned int in_addr_t;
 
 // This is a little bit of a hack for now, until MPTCP has landed upstream in Linux land.
 #ifndef MPTCP_ENABLED
-#if defined(linux)
+#if defined(__linux__)
 #define MPTCP_ENABLED 42
 #else
 #define MPTCP_ENABLED 0

--- a/include/tscore/ink_rwlock.h
+++ b/include/tscore/ink_rwlock.h
@@ -40,7 +40,7 @@ void ink_rwlock_destroy(ink_rwlock *rw);
 // Instead of calling ink_rwlock_init(), an ink_rwlock instance can be initialized with one of thsee values.
 //
 ink_rwlock const INK_RWLOCK_INIT = PTHREAD_RWLOCK_INITIALIZER;
-#if defined(linux)
+#if defined(__linux__)
 ink_rwlock const INK_RWLOCK_INIT_NO_WRITER_STARVATION = PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP;
 #else
 // Testing indicates that for MacOS/Darwin and FreeBSD, pthread rwlocks always prevent writer starvation.

--- a/include/tscpp/util/TsSharedMutex.h
+++ b/include/tscpp/util/TsSharedMutex.h
@@ -168,7 +168,7 @@ private:
     }
   }
 
-#if defined(linux)
+#if defined(__linux__)
   // Use the initializer that prevents writer starvation.
   //
   pthread_rwlock_t _lock = PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP;

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -486,7 +486,7 @@ Span::init(const char *path, int64_t size)
   case S_IFBLK:
   case S_IFCHR:
 
-#if defined(linux)
+#if defined(__linux__)
     if (major(sbuf.st_rdev) == RAW_MAJOR && minor(sbuf.st_rdev) == 0) {
       Warning("cache %s '%s' is the raw device control interface", span_file_typename(sbuf.st_mode), path);
       serr = SPAN_ERROR_UNSUPPORTED_DEVTYPE;

--- a/iocore/eventsystem/I_SocketManager.h
+++ b/iocore/eventsystem/I_SocketManager.h
@@ -43,7 +43,7 @@
 #endif
 
 #ifndef MSG_FASTOPEN
-#if defined(linux)
+#if defined(__linux__)
 #define MSG_FASTOPEN 0x20000000
 #else
 #define MSG_FASTOPEN 0

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -528,7 +528,7 @@ check_transient_accept_error(int res)
   if (!last_transient_accept_error || t - last_transient_accept_error > TRANSIENT_ACCEPT_ERROR_MESSAGE_EVERY) {
     last_transient_accept_error = t;
     Warning("accept thread received transient error: errno = %d", -res);
-#if defined(linux)
+#if defined(__linux__)
     if (res == -ENOBUFS || res == -ENFILE)
       Warning("errno : %d consider a memory upgrade", -res);
 #endif

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -475,7 +475,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
       Debug("iocore_net", "received : %s", strerror(errno));
       res = -errno;
       if (res == -EAGAIN || res == -ECONNABORTED
-#if defined(linux)
+#if defined(__linux__)
           || res == -EPIPE
 #endif
       ) {

--- a/mgmt/utils/MgmtSocket.cc
+++ b/mgmt/utils/MgmtSocket.cc
@@ -189,7 +189,7 @@ mgmt_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *errorfds, struc
 // mgmt_select call will still timeout correctly, rather than
 // possibly extending our timeout period by up to
 // MGMT_MAX_TRANSIENT_ERRORS times.
-#if defined(linux)
+#if defined(__linux__)
   int r, retries;
   for (retries = 0; retries < MGMT_MAX_TRANSIENT_ERRORS; retries++) {
     r = ::select(nfds, readfds, writefds, errorfds, timeout);

--- a/proxy/logging/LogBuffer.h
+++ b/proxy/logging/LogBuffer.h
@@ -37,7 +37,7 @@ class LogBufferIterator;
 #define LOG_SEGMENT_COOKIE  0xaceface
 #define LOG_SEGMENT_VERSION 2
 
-#if defined(linux)
+#if defined(__linux__)
 #define LB_DEFAULT_ALIGN 512
 #else
 #define LB_DEFAULT_ALIGN 8

--- a/proxy/logging/LogFormat.cc
+++ b/proxy/logging/LogFormat.cc
@@ -108,7 +108,7 @@ LogFormat::id_from_name(const char *name)
   if (name) {
     CryptoHash hash;
     CryptoContext().hash_immediate(hash, name, static_cast<int>(strlen(name)));
-#if defined(linux)
+#if defined(__linux__)
     /* Mask most significant bit so that return value of this function
      * is not sign extended to be a negative number.
      * This problem is only known to occur on Linux which

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -51,11 +51,11 @@
 #include <list>
 #include <string>
 
-#if !defined(linux)
+#if !defined(__linux__)
 #include <sys/lock.h>
 #endif
 
-#if defined(linux)
+#if defined(__linux__)
 extern "C" int plock(int);
 #else
 #include <sys/filio.h>

--- a/src/tscore/ink_file.cc
+++ b/src/tscore/ink_file.cc
@@ -418,7 +418,7 @@ ink_file_is_mmappable(mode_t st_mode)
     return true;
   }
 
-#if defined(linux)
+#if defined(__linux__)
   // Disks cannot be mmapped.
   if (S_ISBLK(st_mode)) {
     return false;
@@ -458,7 +458,7 @@ ink_file_get_geometry(int fd ATS_UNUSED, ink_device_geometry &geometry)
   errno = ENOTSUP;
 #endif
 
-#elif defined(linux)
+#elif defined(__linux__)
   ioctl_arg_t arg;
 
   // The following set of ioctls work for both block and character devices. You can use the

--- a/src/tscore/ink_memory.cc
+++ b/src/tscore/ink_memory.cc
@@ -37,7 +37,7 @@
 #endif
 
 #include <cassert>
-#if defined(linux)
+#if defined(__linux__)
 // XXX: Shouldn't that be part of CPPFLAGS?
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 600
@@ -154,7 +154,7 @@ ats_msync(caddr_t addr, size_t len, caddr_t end, int flags)
   if ((a + l) > end) {
     l = end - a; // strict limit
   }
-#if defined(linux)
+#if defined(__linux__)
 /* Fix INKqa06500
    Under Linux, msync(..., MS_SYNC) calls are painfully slow, even on
    non-dirty buffers. This is true as of kernel 2.2.12. We sacrifice

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -417,7 +417,7 @@ ink_ns_name_ntop(const u_char *src, char *dst, size_t dstsiz)
  *\li	The root is returned as "."
  *\li	All other domains are returned in non absolute form
  */
-#if defined(linux)
+#if defined(__linux__)
 int
 ns_name_ntop(const u_char *src, char *dst, size_t dstsiz) __THROW
 #else

--- a/tools/http_load/port.h
+++ b/tools/http_load/port.h
@@ -36,7 +36,7 @@
 #elif defined(__NetBSD__)
 #define OS_NetBSD
 #define ARCH "NetBSD"
-#elif defined(linux)
+#elif defined(__linux__)
 #define OS_Linux
 #define ARCH "Linux"
 #else


### PR DESCRIPTION
Depending on the standards mode, GCC may not predefine the "linux" macro. However, "__linux__" is always predefined, so we can use that consistently and reliably.