### PR TITLE
Remove obsolete signals check.

### DIFF
--- a/include/tscore/signals.h
+++ b/include/tscore/signals.h
@@ -46,10 +46,3 @@ bool signal_is_crash(int signo);
 
 // Test whether the signal is masked.
 bool signal_is_masked(int signo);
-
-// Test whether the signal is being handled by the given handler.
-bool signal_check_handler(int signo, signal_handler_t handler);
-
-// Start a thread to test whether signals have the expected handler. Apparently useful for
-// finding pthread bugs in some version of DEC Unix.
-void signal_start_check_thread(signal_handler_t handler);


### PR DESCRIPTION
Remove obsolete code that verifies a DEC Unix libc bug. This code was never called and it's pretty unlikely people still use DEC Unix.