### PR TITLE
Stabilize autest tls_hooks17

### DIFF
--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -51,7 +51,7 @@ ts.Disk.remap_config.AddLine(
     'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
 )
 
-Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello=1')
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello=1 -close=1')
 
 tr = Test.AddTestRun("Test one delayed client hello hook")
 tr.Processes.Default.StartBefore(server)


### PR DESCRIPTION
The test crashes on a couple of environments
```
0   traffic_server                      0x00000001005156c4 _Z19crash_logger_invokeiP9__siginfoPv + 456
1   libsystem_platform.dylib            0x0000000199b4aa84 _sigtramp + 56
2   libc++abi.dylib                     0x0000000199ad5c3c __dynamic_cast + 176
3   libc++abi.dylib                     0x0000000199ad5c3c __dynamic_cast + 176
4   traffic_server                      0x000000010060fd60 TSVConnReenableEx + 392
5   traffic_server                      0x000000010060fbcc TSVConnReenable + 28
6   ssl_hook_test.so                    0x00000001099a4bbc _Z11ReenableSSLP10tsapi_cont7TSEventPv + 108
7   traffic_server                      0x00000001005af7fc _ZN15INKContInternal12handle_eventEiPv + 1680
8   traffic_server                      0x000000010051b8d0 _ZN12Continuation11handleEventEiPv + 412
9   traffic_server                      0x000000010168cbc0 _ZN7EThread13process_eventEP5Eventi + 1348
10  traffic_server                      0x000000010168e62c _ZN7EThread15execute_regularEv + 2176
11  traffic_server                      0x000000010168fd80 _ZN7EThread7executeEv + 1208
12  traffic_server                      0x000000010168a5b8 _ZL21spawn_thread_internalPv + 448
13  libsystem_pthread.dylib             0x0000000199b1bfa8 _pthread_start + 148
14  libsystem_pthread.dylib             0x0000000199b16da0 thread_start + 8
```

It looks like the cause is the same as https://github.com/apache/trafficserver/pull/9454