### PR TITLE
Cleanup: remove ts::buffer from HostDB.

### DIFF
--- a/iocore/hostdb/P_HostDBProcessor.h
+++ b/iocore/hostdb/P_HostDBProcessor.h
@@ -35,7 +35,6 @@
 #include "I_HostDBProcessor.h"
 #include "P_RefCountCache.h"
 #include "tscore/PendingAction.h"
-#include "tscore/TsBuffer.h"
 
 //
 // Data


### PR DESCRIPTION
Included but not used, apparently.