### PR TITLE
autoconf: Add lib flags for the quiche build test.

### DIFF
--- a/build/quiche.m4
+++ b/build/quiche.m4
@@ -63,7 +63,7 @@ if test "$has_quiche" != "0"; then
     TS_ADDTO_RPATH(${quiche_ldflags})
   fi
 
-  AC_CHECK_LIB([quiche], quiche_connect, [quiche_have_libs=1])
+  AC_CHECK_LIB([quiche], quiche_connect, [quiche_have_libs=1], [], [$OPENSSL_LIBS])
   if test "$quiche_have_libs" != "0"; then
     AC_CHECK_HEADERS(quiche.h, [quiche_have_headers=1])
   fi
@@ -80,7 +80,7 @@ fi
 ],
 [
 AC_CHECK_HEADER([quiche.h], [], [has_quiche=0])
-AC_CHECK_LIB([quiche], quiche_connect, [:], [has_quiche=0])
+AC_CHECK_LIB([quiche], quiche_connect, [:], [has_quiche=0], [$OPENSSL_LIBS])
 ])
 
 AM_CONDITIONAL([USE_QUICHE], [test $has_quiche -eq 1])

--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -38,6 +38,7 @@ LDFLAGS=${LDFLAGS:-"-Wl,-rpath,${OPENSSL_PREFIX}/lib"}
 
 if [ -e /etc/redhat-release ]; then
     MAKE="gmake"
+    TMP_QUICHE_BSSL_PATH="${BASE}/boringssl/lib64"
     echo "+-------------------------------------------------------------------------+"
     echo "| You probably need to run this, or something like this, for your system: |"
     echo "|                                                                         |"
@@ -50,6 +51,7 @@ if [ -e /etc/redhat-release ]; then
     echo
     echo
 elif [ -e /etc/debian_version ]; then
+    TMP_QUICHE_BSSL_PATH="${BASE}/boringssl/lib"
     echo "+-------------------------------------------------------------------------+"
     echo "| You probably need to run this, or something like this, for your system: |"
     echo "|                                                                         |"
@@ -61,6 +63,10 @@ elif [ -e /etc/debian_version ]; then
     echo "+-------------------------------------------------------------------------+"
     echo
     echo
+fi
+
+if [ -z ${QUICHE_BSSL_PATH+x} ]; then
+   QUICHE_BSSL_PATH=${TMP_QUICHE_BSSL_PATH:-"${BASE}/boringssl/lib"}
 fi
 
 set -x
@@ -122,7 +128,7 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone --recursive https://github.com/cloudflare/quiche.git
 cd quiche
-QUICHE_BSSL_PATH=${BASE}/boringssl QUICHE_BSSL_LINK_KIND=dylib cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
+QUICHE_BSSL_PATH=${QUICHE_BSSL_PATH} QUICHE_BSSL_LINK_KIND=dylib cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
 sudo mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 sudo mkdir -p ${QUICHE_BASE}/include
 sudo cp target/release/libquiche.a ${QUICHE_BASE}/lib/


### PR DESCRIPTION
More likely we need this to get the test build passing and have quiche properly detected.
