### PR TITLE
Fixed build issue compiling memcache plugin with io_uring support

### DIFF
--- a/plugins/experimental/memcache/Makefile.inc
+++ b/plugins/experimental/memcache/Makefile.inc
@@ -22,6 +22,7 @@ experimental_memcache_tsmemcache_la_CPPFLAGS = \
   -I$(abs_top_srcdir)/iocore/eventsystem \
   -I$(abs_top_srcdir)/iocore/net \
   -I$(abs_top_srcdir)/iocore/utils \
+  -I$(abs_top_srcdir)/iocore/io_uring \
   -I$(abs_top_srcdir)/include \
   -I$(abs_top_srcdir)/lib
 

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -24,7 +24,6 @@
 #include "tsmemcache.h"
 #include "I_NetVConnection.h"
 #include "I_NetProcessor.h"
-#include "tscore/ink_atomic.h"
 
 /*
   TODO


### PR DESCRIPTION
Removed unneeded header file

make[2]: Entering directory '/home/bcall/dev/apache/trafficserver/build-Linux_gcc/plugins'
  CXX      experimental/memcache/tsmemcache_la-tsmemcache.lo
In file included from /home/bcall/dev/apache/trafficserver/build-Linux_gcc/../iocore/cache/I_Cache.h:28,
                 from ../../plugins/experimental/memcache/tsmemcache.h:28,
                 from ../../plugins/experimental/memcache/tsmemcache.cc:24:
/home/bcall/dev/apache/trafficserver/build-Linux_gcc/../iocore/aio/I_AIO.h:71:10: fatal error: I_IO_URING.h: No such file or directory
   71 | #include "I_IO_URING.h"
      |          ^~~~~~~~~~~~~~