### PR TITLE
Remove flask from tests/Pipfile

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -43,7 +43,5 @@ jsonschema = "*"
 python-jose = "*"
 pyyaml ="*"
 
-flask = "==2.1.3"
-
 [requires]
 python_version = "3"


### PR DESCRIPTION
flask was needed for httpbin. Now that we've removed our httpbin dependency in favor of the maintained go-httpbin, flask is not longer needed in the pip virtual environment for autests.