### PR TITLE
Check the calling thread of Ethread::schedule_local

### DIFF
--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -205,6 +205,10 @@ EThread::schedule_local(Event *e)
   // The continuation that gets scheduled later is not always the
   // client VC, it can be HttpCacheSM etc. so save the flags
   e->continuation->control_flags.set_flags(get_cont_flags().get_flags());
+
+  // If you need to schedule an event from a different thread, use Ethread::schedule_imm/at/in/every functions
+  ink_release_assert(this == this_ethread());
+
   EventQueueExternal.enqueue_local(e);
   return e;
 }


### PR DESCRIPTION
We faced an issue with calling the `Ethread::schedule_imm_local` function from a different thread. (In this case, `Ethread::schedule_imm` should be called.) The function calls ` Ethread::schedule_local`, and it's modify the `ProtectedQueue::localQueue`. So the calling thread has to be `this_ethread()`.

The symptom of the issue is failing the assertion in the `Continuation::handleEvent()`, and the event mutex is `nullptr`.

```
fatal: ./I_Continuation.h:234: failed assertion `!mutex || mutex->thread_holding == this_ethread()`
```

This assertion might cause some crashes, but all of them need to be fixed.