### PR TITLE
Fix event queue corruption on PreWarmManager::reconfigure

### DIFF
--- a/proxy/http/PreWarmManager.cc
+++ b/proxy/http/PreWarmManager.cc
@@ -993,7 +993,7 @@ PreWarmManager::reconfigure_prewarming_on_threads()
     if (ethread->prewarm_queue == nullptr) {
       ethread->prewarm_queue = new PreWarmQueue();
     }
-    ethread->schedule_imm_local(ethread->prewarm_queue);
+    ethread->schedule_imm(ethread->prewarm_queue);
   }
 }
 


### PR DESCRIPTION
One of the cases of #9691.