### PR TITLE
Add ssrc and surc log fields for server simple/unavail retry counts.

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -192,8 +192,9 @@ cccs  Proxy Cache    Cache collapsed connection success;
 Connections and Transactions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _sta:
 .. _sca:
+.. _surc:
+.. _ssrc:
 .. _sstc:
 .. _ccid:
 .. _ctid:
@@ -206,10 +207,10 @@ transactions between |TS| proxies and origin servers.
 ===== ============== ==================================================================
 Field Source         Description
 ===== ============== ==================================================================
-purc  Proxy          Parent unavailable retry count within the current transaction by |TS|
-psrc  Proxy          Parent simple server retry count within the current transaction by |TS|
 sca   Proxy          Number of attempts within the current transaction by |TS|
                      in connecting to the origin server.
+surc  Proxy          Parent unavailable retry count within the current transaction by |TS|.
+ssrc  Proxy          Parent simple server retry count within the current transaction by |TS|.
 sstc  Proxy          Number of transactions between the |TS| proxy and the origin
                      server from a single session. Any value greater than zero
                      indicates connection reuse.

--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -192,6 +192,7 @@ cccs  Proxy Cache    Cache collapsed connection success;
 Connections and Transactions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _sta:
 .. _sca:
 .. _sstc:
 .. _ccid:
@@ -205,6 +206,8 @@ transactions between |TS| proxies and origin servers.
 ===== ============== ==================================================================
 Field Source         Description
 ===== ============== ==================================================================
+purc  Proxy          Parent unavailable retry count within the current transaction by |TS|
+psrc  Proxy          Parent simple server retry count within the current transaction by |TS|
 sca   Proxy          Number of attempts within the current transaction by |TS|
                      in connecting to the origin server.
 sstc  Proxy          Number of transactions between the |TS| proxy and the origin

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -831,15 +831,15 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("sstc", field);
 
-  field = new LogField("parent_unavailable_retry_count", "purc", LogField::sINT, &LogAccess::marshal_parent_unavailable_retry_count,
+  field = new LogField("server_unavailable_retry_count", "surc", LogField::sINT, &LogAccess::marshal_server_unavailable_retry_count,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);
-  field_symbol_hash.emplace("purc", field);
+  field_symbol_hash.emplace("surc", field);
 
-  field = new LogField("parent_simple_retry_count", "psrc", LogField::sINT, &LogAccess::marshal_parent_simple_retry_count,
+  field = new LogField("server_simple_retry_count", "ssrc", LogField::sINT, &LogAccess::marshal_server_simple_retry_count,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);
-  field_symbol_hash.emplace("psrc", field);
+  field_symbol_hash.emplace("ssrc", field);
 
   field = new LogField("server_connect_attempts", "sca", LogField::sINT, &LogAccess::marshal_server_connect_attempts,
                        &LogAccess::unmarshal_int_to_str);

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -831,6 +831,16 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("sstc", field);
 
+  field = new LogField("parent_unavailable_retry_count", "purc", LogField::sINT, &LogAccess::marshal_parent_unavailable_retry_count,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("purc", field);
+
+  field = new LogField("parent_simple_retry_count", "psrc", LogField::sINT, &LogAccess::marshal_parent_simple_retry_count,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("psrc", field);
+
   field = new LogField("server_connect_attempts", "sca", LogField::sINT, &LogAccess::marshal_server_connect_attempts,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -2630,7 +2630,7 @@ LogAccess::marshal_server_transact_count(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::marshal_parent_simple_retry_count(char *buf)
+LogAccess::marshal_server_simple_retry_count(char *buf)
 {
   if (buf) {
     const int64_t attempts = m_http_sm->t_state.current.simple_retry_attempts;
@@ -2643,7 +2643,7 @@ LogAccess::marshal_parent_simple_retry_count(char *buf)
   -------------------------------------------------------------------------*/
 
 int
-LogAccess::marshal_parent_unavailable_retry_count(char *buf)
+LogAccess::marshal_server_unavailable_retry_count(char *buf)
 {
   if (buf) {
     const int64_t attempts = m_http_sm->t_state.current.unavailable_server_retry_attempts;

--- a/proxy/logging/LogAccess.cc
+++ b/proxy/logging/LogAccess.cc
@@ -2630,6 +2630,32 @@ LogAccess::marshal_server_transact_count(char *buf)
   -------------------------------------------------------------------------*/
 
 int
+LogAccess::marshal_parent_simple_retry_count(char *buf)
+{
+  if (buf) {
+    const int64_t attempts = m_http_sm->t_state.current.simple_retry_attempts;
+    marshal_int(buf, attempts);
+  }
+  return INK_MIN_ALIGN;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
+LogAccess::marshal_parent_unavailable_retry_count(char *buf)
+{
+  if (buf) {
+    const int64_t attempts = m_http_sm->t_state.current.unavailable_server_retry_attempts;
+    marshal_int(buf, attempts);
+  }
+  return INK_MIN_ALIGN;
+}
+
+/*-------------------------------------------------------------------------
+  -------------------------------------------------------------------------*/
+
+int
 LogAccess::marshal_server_connect_attempts(char *buf)
 {
   if (buf) {

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -195,18 +195,20 @@ public:
   //
   // server -> proxy fields
   //
-  int marshal_server_host_ip(char *);                // INT
-  int marshal_server_host_name(char *);              // STR
-  int marshal_server_resp_status_code(char *);       // INT
-  int marshal_server_resp_squid_len(char *);         // INT
-  int marshal_server_resp_content_len(char *);       // INT
-  int marshal_server_resp_header_len(char *);        // INT
-  int marshal_server_resp_http_version(char *);      // INT
-  int marshal_server_resp_time_ms(char *);           // INT
-  int marshal_server_resp_time_s(char *);            // INT
-  int marshal_server_transact_count(char *);         // INT
-  int marshal_server_connect_attempts(char *);       // INT
-  int marshal_server_resp_all_header_fields(char *); // STR
+  int marshal_server_host_ip(char *);                 // INT
+  int marshal_server_host_name(char *);               // STR
+  int marshal_server_resp_status_code(char *);        // INT
+  int marshal_server_resp_squid_len(char *);          // INT
+  int marshal_server_resp_content_len(char *);        // INT
+  int marshal_server_resp_header_len(char *);         // INT
+  int marshal_server_resp_http_version(char *);       // INT
+  int marshal_server_resp_time_ms(char *);            // INT
+  int marshal_server_resp_time_s(char *);             // INT
+  int marshal_server_transact_count(char *);          // INT
+  int marshal_parent_simple_retry_count(char *);      // INT
+  int marshal_parent_unavailable_retry_count(char *); // INT
+  int marshal_server_connect_attempts(char *);        // INT
+  int marshal_server_resp_all_header_fields(char *);  // STR
 
   //
   // cache -> client fields

--- a/proxy/logging/LogAccess.h
+++ b/proxy/logging/LogAccess.h
@@ -205,8 +205,8 @@ public:
   int marshal_server_resp_time_ms(char *);            // INT
   int marshal_server_resp_time_s(char *);             // INT
   int marshal_server_transact_count(char *);          // INT
-  int marshal_parent_simple_retry_count(char *);      // INT
-  int marshal_parent_unavailable_retry_count(char *); // INT
+  int marshal_server_simple_retry_count(char *);      // INT
+  int marshal_server_unavailable_retry_count(char *); // INT
   int marshal_server_connect_attempts(char *);        // INT
   int marshal_server_resp_all_header_fields(char *);  // STR
 


### PR DESCRIPTION
This will allow us to log parent (server) retries per transaction in logging.yaml.