### PR TITLE
Fix build issue with c++20 and gcc 8.3

### DIFF
--- a/iocore/eventsystem/IOBuffer.cc
+++ b/iocore/eventsystem/IOBuffer.cc
@@ -80,6 +80,7 @@ auto
 make_buffer_size_parser()
 {
   return [l = swoc::Lexicon<int>{
+    swoc::Lexicon<int>::with_multi{
             {{0, {"128"}},
              {1, {"256"}},
              {2, {"512"}},
@@ -96,58 +97,59 @@ make_buffer_size_parser()
              {13, {"1M", "1024k"}},
              {14, {"2M", "2048k"}}},
             -1
-  }](swoc::TextView esize) -> std::optional<int> {
-    int result = l[esize];
-    if (result == -1) {
-      return std::nullopt;
-    }
-    return result;
-  };
+  }](swoc::TextView esize) -> std::optional<int>
+    {
+      int result = l[esize];
+      if (result == -1) {
+        return std::nullopt;
+      }
+      return result;
+    };
 }
 
 bool
 parse_buffer_chunk_sizes(const char *chunk_sizes_string, int chunk_sizes[DEFAULT_BUFFER_SIZES])
 {
-  const swoc::TextView delimiters(", ");
-  if (chunk_sizes_string != nullptr) {
-    swoc::TextView src(chunk_sizes_string, swoc::TextView::npos);
-    auto parser = make_buffer_size_parser();
-    int n       = 0;
-    while (!src.empty()) {
-      swoc::TextView token{src.take_prefix_at(delimiters)};
+    const swoc::TextView delimiters(", ");
+    if (chunk_sizes_string != nullptr) {
+      swoc::TextView src(chunk_sizes_string, swoc::TextView::npos);
+      auto parser = make_buffer_size_parser();
+      int n       = 0;
+      while (!src.empty()) {
+        swoc::TextView token{src.take_prefix_at(delimiters)};
 
-      swoc::TextView esize = token.take_prefix_at(':');
-      if (!token.empty()) {
-        auto parsed = parser(esize);
-        if (parsed) {
-          n = *parsed;
+        swoc::TextView esize = token.take_prefix_at(':');
+        if (!token.empty()) {
+          auto parsed = parser(esize);
+          if (parsed) {
+            n = *parsed;
+          } else {
+            Error("Failed to parse size for %.*s", static_cast<int>(esize.size()), esize.data());
+            return false;
+          }
         } else {
-          Error("Failed to parse size for %.*s", static_cast<int>(esize.size()), esize.data());
+          // element didn't have a colon so its just a chunk size
+          token = esize;
+        }
+
+        // Check if n goes out of bounds
+        if (n >= DEFAULT_BUFFER_SIZES) {
+          Error("Invalid IO buffer chunk sizes string");
           return false;
         }
-      } else {
-        // element didn't have a colon so its just a chunk size
-        token = esize;
-      }
 
-      // Check if n goes out of bounds
-      if (n >= DEFAULT_BUFFER_SIZES) {
-        Error("Invalid IO buffer chunk sizes string");
-        return false;
-      }
+        auto x = swoc::svto_radix<10>(token);
+        if (token.empty() && x != std::numeric_limits<decltype(x)>::max()) {
+          chunk_sizes[n++] = x;
+        } else {
+          Error("Failed to parse chunk size");
+          return false;
+        }
 
-      auto x = swoc::svto_radix<10>(token);
-      if (token.empty() && x != std::numeric_limits<decltype(x)>::max()) {
-        chunk_sizes[n++] = x;
-      } else {
-        Error("Failed to parse chunk size");
-        return false;
+        src.ltrim(delimiters);
       }
-
-      src.ltrim(delimiters);
     }
-  }
-  return true;
+    return true;
 }
 
 //
@@ -156,92 +158,92 @@ parse_buffer_chunk_sizes(const char *chunk_sizes_string, int chunk_sizes[DEFAULT
 int64_t
 MIOBuffer::write(const void *abuf, int64_t alen)
 {
-  const char *buf = static_cast<const char *>(abuf);
-  int64_t len     = alen;
-  while (len) {
-    if (!_writer) {
-      add_block();
-    }
-    int64_t f = _writer->write_avail();
-    f         = f < len ? f : len;
-    if (f > 0) {
-      ::memcpy(_writer->end(), buf, f);
-      _writer->fill(f);
-      buf += f;
-      len -= f;
-    }
-    if (len) {
-      if (!_writer->next) {
+    const char *buf = static_cast<const char *>(abuf);
+    int64_t len     = alen;
+    while (len) {
+      if (!_writer) {
         add_block();
-      } else {
-        _writer = _writer->next;
+      }
+      int64_t f = _writer->write_avail();
+      f         = f < len ? f : len;
+      if (f > 0) {
+        ::memcpy(_writer->end(), buf, f);
+        _writer->fill(f);
+        buf += f;
+        len -= f;
+      }
+      if (len) {
+        if (!_writer->next) {
+          add_block();
+        } else {
+          _writer = _writer->next;
+        }
       }
     }
-  }
-  return alen;
+    return alen;
 }
 
 int64_t
 MIOBuffer::write(IOBufferReader *r, int64_t len, int64_t offset)
 {
-  return this->write(r->block.get(), len, offset + r->start_offset);
+    return this->write(r->block.get(), len, offset + r->start_offset);
 }
 
 int64_t
 MIOBuffer::write(IOBufferChain const *chain, int64_t len, int64_t offset)
 {
-  return this->write(chain->head(), std::min(len, chain->length()), offset);
+    return this->write(chain->head(), std::min(len, chain->length()), offset);
 }
 
 int64_t
 MIOBuffer::write(IOBufferBlock const *b, int64_t alen, int64_t offset)
 {
-  int64_t len = alen;
+    int64_t len = alen;
 
-  while (b && len > 0) {
-    int64_t max_bytes  = b->read_avail();
-    max_bytes         -= offset;
-    if (max_bytes <= 0) {
-      offset = -max_bytes;
-      b      = b->next.get();
-      continue;
+    while (b && len > 0) {
+      int64_t max_bytes  = b->read_avail();
+      max_bytes         -= offset;
+      if (max_bytes <= 0) {
+        offset = -max_bytes;
+        b      = b->next.get();
+        continue;
+      }
+      int64_t bytes;
+      if (len >= max_bytes) {
+        bytes = max_bytes;
+      } else {
+        bytes = len;
+      }
+      IOBufferBlock *bb  = b->clone();
+      bb->_start        += offset;
+      bb->_buf_end = bb->_end = bb->_start + bytes;
+      append_block(bb);
+      offset  = 0;
+      len    -= bytes;
+      b       = b->next.get();
     }
-    int64_t bytes;
-    if (len >= max_bytes) {
-      bytes = max_bytes;
-    } else {
-      bytes = len;
-    }
-    IOBufferBlock *bb  = b->clone();
-    bb->_start        += offset;
-    bb->_buf_end = bb->_end = bb->_start + bytes;
-    append_block(bb);
-    offset  = 0;
-    len    -= bytes;
-    b       = b->next.get();
-  }
 
-  return alen - len;
+    return alen - len;
 }
 
 bool
 MIOBuffer::is_max_read_avail_more_than(int64_t size)
 {
-  bool no_reader = true;
-  for (auto &reader : this->readers) {
-    if (reader.allocated()) {
-      if (reader.is_read_avail_more_than(size)) {
-        return true;
+    bool no_reader = true;
+    for (auto &reader : this->readers) {
+      if (reader.allocated()) {
+        if (reader.is_read_avail_more_than(size)) {
+          return true;
+        }
+        no_reader = false;
       }
-      no_reader = false;
     }
-  }
 
-  if (no_reader && this->_writer) {
-    return (this->_writer->read_avail() > size);
-  }
+    if (no_reader && this->_writer) {
+      return (this->_writer->read_avail() > size);
+    }
 
-  return false;
+    return false;
 }
 
 //
@@ -250,90 +252,90 @@ MIOBuffer::is_max_read_avail_more_than(int64_t size)
 int64_t
 IOBufferReader::read(void *ab, int64_t len)
 {
-  char *b       = static_cast<char *>(ab);
-  int64_t n     = len;
-  int64_t l     = block_read_avail();
-  int64_t bytes = 0;
+    char *b       = static_cast<char *>(ab);
+    int64_t n     = len;
+    int64_t l     = block_read_avail();
+    int64_t bytes = 0;
 
-  while (n && l) {
-    if (n < l) {
-      l = n;
+    while (n && l) {
+      if (n < l) {
+        l = n;
+      }
+      ::memcpy(b, start(), l);
+      consume(l);
+      b     += l;
+      n     -= l;
+      bytes += l;
+      l      = block_read_avail();
     }
-    ::memcpy(b, start(), l);
-    consume(l);
-    b     += l;
-    n     -= l;
-    bytes += l;
-    l      = block_read_avail();
-  }
-  return bytes;
+    return bytes;
 }
 
 // TODO: I don't think this method is used anywhere, so perhaps get rid of it ?
 int64_t
 IOBufferReader::memchr(char c, int64_t len, int64_t offset)
 {
-  IOBufferBlock *b  = block.get();
-  offset           += start_offset;
-  int64_t o         = offset;
+    IOBufferBlock *b  = block.get();
+    offset           += start_offset;
+    int64_t o         = offset;
 
-  while (b && len) {
-    int64_t max_bytes  = b->read_avail();
-    max_bytes         -= offset;
-    if (max_bytes <= 0) {
-      offset = -max_bytes;
-      b      = b->next.get();
-      continue;
+    while (b && len) {
+      int64_t max_bytes  = b->read_avail();
+      max_bytes         -= offset;
+      if (max_bytes <= 0) {
+        offset = -max_bytes;
+        b      = b->next.get();
+        continue;
+      }
+      int64_t bytes;
+      if (len < 0 || len >= max_bytes) {
+        bytes = max_bytes;
+      } else {
+        bytes = len;
+      }
+      char *s = b->start() + offset;
+      char *p = static_cast<char *>(::memchr(s, c, bytes));
+      if (p) {
+        return static_cast<int64_t>(o - start_offset + p - s);
+      }
+      o      += bytes;
+      len    -= bytes;
+      b       = b->next.get();
+      offset  = 0;
     }
-    int64_t bytes;
-    if (len < 0 || len >= max_bytes) {
-      bytes = max_bytes;
-    } else {
-      bytes = len;
-    }
-    char *s = b->start() + offset;
-    char *p = static_cast<char *>(::memchr(s, c, bytes));
-    if (p) {
-      return static_cast<int64_t>(o - start_offset + p - s);
-    }
-    o      += bytes;
-    len    -= bytes;
-    b       = b->next.get();
-    offset  = 0;
-  }
 
-  return -1;
+    return -1;
 }
 
 char *
 IOBufferReader::memcpy(void *ap, int64_t len, int64_t offset)
 {
-  char *p           = static_cast<char *>(ap);
-  IOBufferBlock *b  = block.get();
-  offset           += start_offset;
+    char *p           = static_cast<char *>(ap);
+    IOBufferBlock *b  = block.get();
+    offset           += start_offset;
 
-  while (b && len) {
-    int64_t max_bytes  = b->read_avail();
-    max_bytes         -= offset;
-    if (max_bytes <= 0) {
-      offset = -max_bytes;
-      b      = b->next.get();
-      continue;
+    while (b && len) {
+      int64_t max_bytes  = b->read_avail();
+      max_bytes         -= offset;
+      if (max_bytes <= 0) {
+        offset = -max_bytes;
+        b      = b->next.get();
+        continue;
+      }
+      int64_t bytes;
+      if (len < 0 || len >= max_bytes) {
+        bytes = max_bytes;
+      } else {
+        bytes = len;
+      }
+      ::memcpy(p, b->start() + offset, bytes);
+      p      += bytes;
+      len    -= bytes;
+      b       = b->next.get();
+      offset  = 0;
     }
-    int64_t bytes;
-    if (len < 0 || len >= max_bytes) {
-      bytes = max_bytes;
-    } else {
-      bytes = len;
-    }
-    ::memcpy(p, b->start() + offset, bytes);
-    p      += bytes;
-    len    -= bytes;
-    b       = b->next.get();
-    offset  = 0;
-  }
 
-  return p;
+    return p;
 }
 
 //
@@ -342,86 +344,86 @@ IOBufferReader::memcpy(void *ap, int64_t len, int64_t offset)
 int64_t
 IOBufferChain::write(IOBufferBlock *blocks, int64_t length, int64_t offset)
 {
-  int64_t n = length;
+    int64_t n = length;
 
-  while (blocks && n > 0) {
-    int64_t block_bytes = blocks->read_avail();
-    if (block_bytes <= offset) { // skip the entire block
-      offset -= block_bytes;
-    } else {
-      int64_t bytes     = std::min(n, block_bytes - offset);
-      IOBufferBlock *bb = blocks->clone();
-      if (offset) {
-        bb->consume(offset);
-        block_bytes -= offset; // bytes really available to use.
-        offset       = 0;
+    while (blocks && n > 0) {
+      int64_t block_bytes = blocks->read_avail();
+      if (block_bytes <= offset) { // skip the entire block
+        offset -= block_bytes;
+      } else {
+        int64_t bytes     = std::min(n, block_bytes - offset);
+        IOBufferBlock *bb = blocks->clone();
+        if (offset) {
+          bb->consume(offset);
+          block_bytes -= offset; // bytes really available to use.
+          offset       = 0;
+        }
+        if (block_bytes > n) {
+          bb->_end -= (block_bytes - n);
+        }
+        // Attach the cloned block since its data will be kept.
+        this->append(bb);
+        n -= bytes;
       }
-      if (block_bytes > n) {
-        bb->_end -= (block_bytes - n);
-      }
-      // Attach the cloned block since its data will be kept.
-      this->append(bb);
-      n -= bytes;
+      blocks = blocks->next.get();
     }
-    blocks = blocks->next.get();
-  }
 
-  length -= n; // actual bytes written to chain.
-  _len   += length;
-  return length;
+    length -= n; // actual bytes written to chain.
+    _len   += length;
+    return length;
 }
 
 int64_t
 IOBufferChain::write(IOBufferData *data, int64_t length, int64_t offset)
 {
-  int64_t zret     = 0;
-  IOBufferBlock *b = new_IOBufferBlock();
+    int64_t zret     = 0;
+    IOBufferBlock *b = new_IOBufferBlock();
 
-  if (length < 0) {
-    length = 0;
-  }
+    if (length < 0) {
+      length = 0;
+    }
 
-  b->set(data, length, offset);
-  this->append(b);
+    b->set(data, length, offset);
+    this->append(b);
 
-  zret  = b->read_avail();
-  _len += zret;
-  return zret;
+    zret  = b->read_avail();
+    _len += zret;
+    return zret;
 }
 
 void
 IOBufferChain::append(IOBufferBlock *block)
 {
-  if (nullptr == _tail) {
-    _head = block;
-    _tail = block;
-  } else {
-    _tail->next = block;
-    _tail       = block;
-  }
+    if (nullptr == _tail) {
+      _head = block;
+      _tail = block;
+    } else {
+      _tail->next = block;
+      _tail       = block;
+    }
 }
 
 int64_t
 IOBufferChain::consume(int64_t size)
 {
-  int64_t zret = 0;
-  int64_t bytes;
-  size = std::min(size, _len);
+    int64_t zret = 0;
+    int64_t bytes;
+    size = std::min(size, _len);
 
-  while (_head != nullptr && size > 0 && (bytes = _head->read_avail()) > 0) {
-    if (size >= bytes) {
-      _head  = _head->next;
-      zret  += bytes;
-      size  -= bytes;
-    } else {
-      _head->consume(size);
-      zret += size;
-      size  = 0;
+    while (_head != nullptr && size > 0 && (bytes = _head->read_avail()) > 0) {
+      if (size >= bytes) {
+        _head  = _head->next;
+        zret  += bytes;
+        size  -= bytes;
+      } else {
+        _head->consume(size);
+        zret += size;
+        size  = 0;
+      }
     }
-  }
-  _len -= zret;
-  if (_head == nullptr || _len == 0) {
-    _head = nullptr, _tail = nullptr, _len = 0;
-  }
-  return zret;
+    _len -= zret;
+    if (_head == nullptr || _len == 0) {
+      _head = nullptr, _tail = nullptr, _len = 0;
+    }
+    return zret;
 }


### PR DESCRIPTION
did `make clang-format` that is why the diff is so big.

The real fix is line 83. the addition of `swoc::Lexicon<int>::with_multi{`