### PR TITLE
Fix PROXY protocol out with tls

### DIFF
--- a/proxy/http/ConnectingEntry.cc
+++ b/proxy/http/ConnectingEntry.cc
@@ -52,6 +52,9 @@ ConnectingEntry::state_http_server_open(int event, void *data)
     ink_release_assert(!connect_sms.empty());
     HttpSM *prime_connect_sm = *(connect_sms.begin());
 
+    // Perform a zero-byte read to ensure this function can be called back for
+    // VC_EVENT_READ_COMPLETE after the handshake is complete.
+    netvc->do_io_read(this, 0, _netvc_reader->mbuf);
     int64_t nbytes = 1;
     if (is_no_plugin_tunnel && prime_connect_sm->t_state.txn_conf->proxy_protocol_out >= 0) {
       nbytes = do_outbound_proxy_protocol(_netvc_reader->mbuf, vc, ua_txn->get_netvc(),

--- a/tests/gold_tests/post_slow_server/gold/post_slow_server_max_requests_in_0_stderr.gold
+++ b/tests/gold_tests/post_slow_server/gold/post_slow_server_max_requests_in_0_stderr.gold
@@ -1,5 +1,5 @@
 ``
 > POST / HTTP/1.1
 ``
-< HTTP/1.1 502 Connection refused
+< HTTP/1.1 502 Broken pipe
 ``

--- a/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
@@ -242,9 +242,9 @@ class ProxyProtocolOutTest:
 ProxyProtocolInTest().run()
 
 # non-tunnling HTTP to origin
-ProxyProtocolOutTest(pp_version=-1, is_tunnel=False).run()
-ProxyProtocolOutTest(pp_version=1, is_tunnel=False).run()
-ProxyProtocolOutTest(pp_version=2, is_tunnel=False).run()
+ProxyProtocolOutTest(pp_version=-1, is_tunnel=False, is_tls_to_origin=False).run()
+ProxyProtocolOutTest(pp_version=1, is_tunnel=False, is_tls_to_origin=False).run()
+ProxyProtocolOutTest(pp_version=2, is_tunnel=False, is_tls_to_origin=False).run()
 # non-tunnling HTTPS to origin
 ProxyProtocolOutTest(pp_version=-1, is_tunnel=False, is_tls_to_origin=True).run()
 ProxyProtocolOutTest(pp_version=1, is_tunnel=False, is_tls_to_origin=True).run()

--- a/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
@@ -108,11 +108,12 @@ class ProxyProtocolOutTest:
     _ts_counter = 0
     _pp_out_replay_file = "replay/proxy_protocol_out.replay.yaml"
 
-    def __init__(self, pp_version: int, is_tunnel: bool) -> None:
+    def __init__(self, pp_version: int, is_tunnel: bool, is_tls_to_origin: bool = False) -> None:
         """Initialize a ProxyProtocolOutTest.
 
         :param pp_version: The Proxy Protocol version to use (1 or 2).
         :param is_tunnel: Whether ATS should tunnel to the origin.
+        :param is_tls: Whether ATS should connect to the origin via TLS.
         """
 
         if pp_version not in (-1, 1, 2):
@@ -120,6 +121,7 @@ class ProxyProtocolOutTest:
                 f'Invalid Proxy Protocol version (not 1 or 2): {pp_version}')
         self._pp_version = pp_version
         self._is_tunnel = is_tunnel
+        self._is_tls_to_origin = is_tls_to_origin
 
     def setupOriginServer(self) -> None:
         """Configure the origin server.
@@ -150,9 +152,11 @@ class ProxyProtocolOutTest:
         self._ts.Disk.ssl_multicert_config.AddLine(
             "dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key"
         )
-
+        scheme = 'https' if self._is_tls_to_origin else 'http'
+        server_port = self._server.Variables.https_port if self._is_tls_to_origin else self._server.Variables.http_port
         self._ts.Disk.remap_config.AddLine(
-            f"map / http://backend.pp.origin.com:{self._server.Variables.http_port}/")
+            f"map / {scheme}://backend.pp.origin.com:{server_port}/"
+        )
 
         self._ts.Disk.records_config.update({
             "proxy.config.ssl.server.cert.path": f"{self._ts.Variables.SSLDir}",
@@ -212,6 +216,8 @@ class ProxyProtocolOutTest:
             description += "with blind tunneling"
         else:
             description += "without blind tunneling"
+            if self._is_tls_to_origin:
+                description += " on TLS connection to origin"
         tr = Test.AddTestRun(description)
 
         self.setupDNS(tr)
@@ -235,8 +241,14 @@ class ProxyProtocolOutTest:
 
 ProxyProtocolInTest().run()
 
+# non-tunnling HTTP to origin
 ProxyProtocolOutTest(pp_version=-1, is_tunnel=False).run()
 ProxyProtocolOutTest(pp_version=1, is_tunnel=False).run()
 ProxyProtocolOutTest(pp_version=2, is_tunnel=False).run()
+# non-tunnling HTTPS to origin
+ProxyProtocolOutTest(pp_version=-1, is_tunnel=False, is_tls_to_origin=True).run()
+ProxyProtocolOutTest(pp_version=1, is_tunnel=False, is_tls_to_origin=True).run()
+ProxyProtocolOutTest(pp_version=2, is_tunnel=False, is_tls_to_origin=True).run()
+# tunneling
 ProxyProtocolOutTest(pp_version=1, is_tunnel=True).run()
 ProxyProtocolOutTest(pp_version=2, is_tunnel=True).run()


### PR DESCRIPTION
While updating the PROXY protocol tests, I observe the https connections to the origin would hang when PROXY protocol out is enabled in ATS. This PR addresses this.

### root cause

After the #9366 changes, the logic of kicking off state machine is in `ConnectingEntry` and is triggered by callbacks upon one of `VC_EVENT_READ_COMPLETE`, `VC_EVENT_WRITE_READY` or `VC_EVENT_WRITE_COMPLETE` events.  The root cause of the hang has to do with none of these events is triggered:
* Without PROXY protocol enabled, the `VC_EVENT_WRITE_READY` is triggered and the connection flows. However when PROXY protocol out is enabled, as PROXY protocol data is sent before ssl handshake,  the accounting of `vio.nbytes` and `vio.done`changed , leading to `VC_EVENT_WRITE_READY` not being triggered. 
* `VC_EVENT_READ_COMPLETE` is not triggered because `vio` read is not enabled. Prior to #9366, `attach_server_session()` enables vio read and is called prior to the handshake. After #9366, this is called after the handshake so the `vio` read is disabled during the handshake. As read is disabled, the `VC_EVENT_READ_COMPLETE` can't be signaled to the handler.

This PR adds a 0-byte read so the `vio` read is enabled and `ConnectingEntry::state_http_server_open()` handler can be signaled and called back with the `VC_EVENT_READ_COMPLETE` event. 