### PR TITLE
Reload hosting.config on TASK thread

### DIFF
--- a/iocore/cache/CacheHosting.cc
+++ b/iocore/cache/CacheHosting.cc
@@ -239,7 +239,7 @@ CacheHostTable::config_callback(const char * /* name ATS_UNUSED */, RecDataT /* 
                                 RecData /* data ATS_UNUSED */, void *cookie)
 {
   ReplaceablePtr<CacheHostTable> *ppt = static_cast<ReplaceablePtr<CacheHostTable> *>(cookie);
-  eventProcessor.schedule_imm(new CacheHostTableConfig(ppt));
+  eventProcessor.schedule_imm(new CacheHostTableConfig(ppt), ET_TASK);
   return 0;
 }
 


### PR DESCRIPTION
@c-taylor found reloading the hosting.config is running the ET_NET thread.

```
[ET_NET 5] NOTE: hosting.config loading ...
```