### PR TITLE
Changes for C++20

### DIFF
--- a/include/tscore/List.h
+++ b/include/tscore/List.h
@@ -337,10 +337,10 @@ template <class C, class L = typename C::Link_link> struct DLL {
     self_type operator++(int);
 
     /// Equality.
-    bool operator==(self_type const &that);
+    bool operator==(self_type const &that) const;
 
     /// Inequality.
-    bool operator!=(self_type const &that);
+    bool operator!=(self_type const &that) const;
 
   protected:
     const_iterator(C *spot) : _spot(spot) {}
@@ -515,14 +515,14 @@ DLL<C, L>::const_iterator::operator++(int) -> self_type
 
 template <class C, class L>
 bool
-DLL<C, L>::const_iterator::operator==(DLL::const_iterator::self_type const &that)
+DLL<C, L>::const_iterator::operator==(DLL::const_iterator::self_type const &that) const
 {
   return _spot == that._spot;
 }
 
 template <class C, class L>
 bool
-DLL<C, L>::const_iterator::operator!=(DLL::const_iterator::self_type const &that)
+DLL<C, L>::const_iterator::operator!=(DLL::const_iterator::self_type const &that) const
 {
   return _spot != that._spot;
 }

--- a/include/tscore/Ptr.h
+++ b/include/tscore/Ptr.h
@@ -120,7 +120,7 @@ public:
   }
 
   bool
-  operator==(const Ptr<T> &p)
+  operator==(const Ptr<T> &p) const
   {
     return (m_ptr == p.m_ptr);
   }

--- a/iocore/eventsystem/I_IOBuffer.h
+++ b/iocore/eventsystem/I_IOBuffer.h
@@ -1411,7 +1411,7 @@ IOBufferChain::operator=(self_type const &that)
 inline IOBufferChain &
 IOBufferChain::operator+=(self_type const &that)
 {
-  if (nullptr == _head)
+  if (_head == nullptr)
     *this = that;
   else {
     _tail->next  = that._head;

--- a/plugins/s3_auth/aws_auth_v4_wrap.h
+++ b/plugins/s3_auth/aws_auth_v4_wrap.h
@@ -62,12 +62,12 @@ public:
     return tmp;
   }
   bool
-  operator!=(const HeaderIterator &it)
+  operator!=(const HeaderIterator &it) const
   {
     return _bufp != it._bufp || _hdrs != it._hdrs || _field != it._field;
   }
   bool
-  operator==(const HeaderIterator &it)
+  operator==(const HeaderIterator &it) const
   {
     return _bufp == it._bufp && _hdrs == it._hdrs && _field == it._field;
   }

--- a/proxy/hdrs/MIME.h
+++ b/proxy/hdrs/MIME.h
@@ -275,8 +275,8 @@ struct MIMEHdrImpl : public HdrHeapObjImpl {
     self_type &operator++();
     self_type operator++(int);
 
-    bool operator==(self_type const &that);
-    bool operator!=(self_type const &that);
+    bool operator==(self_type const &that) const;
+    bool operator!=(self_type const &that) const;
 
   protected:
     MIMEFieldBlockImpl *_block = nullptr; ///< Current block.
@@ -384,13 +384,13 @@ MIMEHdrImpl::iterator::operator->() -> pointer
 }
 
 inline bool
-MIMEHdrImpl::iterator::operator==(const self_type &that)
+MIMEHdrImpl::iterator::operator==(const self_type &that) const
 {
   return _block == that._block && _slot == that._slot;
 }
 
 inline bool
-MIMEHdrImpl::iterator::operator!=(const self_type &that)
+MIMEHdrImpl::iterator::operator!=(const self_type &that) const
 {
   return _block != that._block || _slot != that._slot;
 }


### PR DESCRIPTION
At a minimum this makes Apple clang happy.
```
$ clang++ --version
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.4.0
```