### PR TITLE
Don't throw exceptions if io_uring cannot be initialized. 

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -561,9 +561,9 @@ prep_read(io_uring_sqe *sqe, AIOCallbackInternal *op)
 void
 prep_readv(io_uring_sqe *sqe, AIOCallbackInternal *op)
 {
-  op->iovec.iov_len  = op->aiocb.aio_nbytes;
-  op->iovec.iov_base = op->aiocb.aio_buf;
-  io_uring_prep_readv(sqe, op->aiocb.aio_fildes, &op->iovec, 1, op->aiocb.aio_offset);
+  op->iov.iov_len  = op->aiocb.aio_nbytes;
+  op->iov.iov_base = op->aiocb.aio_buf;
+  io_uring_prep_readv(sqe, op->aiocb.aio_fildes, &op->iov, 1, op->aiocb.aio_offset);
 }
 
 void
@@ -575,9 +575,9 @@ prep_write(io_uring_sqe *sqe, AIOCallbackInternal *op)
 void
 prep_writev(io_uring_sqe *sqe, AIOCallbackInternal *op)
 {
-  op->iovec.iov_len  = op->aiocb.aio_nbytes;
-  op->iovec.iov_base = op->aiocb.aio_buf;
-  io_uring_prep_writev(sqe, op->aiocb.aio_fildes, &op->iovec, 1, op->aiocb.aio_offset);
+  op->iov.iov_len  = op->aiocb.aio_nbytes;
+  op->iov.iov_base = op->aiocb.aio_buf;
+  io_uring_prep_writev(sqe, op->aiocb.aio_fildes, &op->iov, 1, op->aiocb.aio_offset);
 }
 
 using prep_op = void (*)(io_uring_sqe *, AIOCallbackInternal *);

--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -46,6 +46,12 @@
 // globals
 #if TS_USE_LINUX_IO_URING
 static bool use_io_uring = false;
+
+namespace
+{
+void setup_prep_ops(IOUringContext *);
+}
+
 #endif
 
 /* structure to hold information about each file descriptor */
@@ -221,6 +227,7 @@ ink_aio_init(ts::ModuleVersion v, AIOBackend backend)
     // detect if io_uring is available and can support the required features
     auto *ctx = IOUringContext::local_context();
     if (ctx && ctx->valid()) {
+      setup_prep_ops(ctx);
       use_io_uring = true;
     } else {
       Note("AIO using thread backend as required io_uring ops are not supported");
@@ -542,22 +549,111 @@ AIOThreadInfo::aio_thread_main(AIOThreadInfo *thr_info)
 #if TS_USE_LINUX_IO_URING
 #include "I_IO_URING.h"
 
+namespace
+{
+
+void
+prep_read(io_uring_sqe *sqe, AIOCallbackInternal *op)
+{
+  io_uring_prep_read(sqe, op->aiocb.aio_fildes, op->aiocb.aio_buf, op->aiocb.aio_nbytes, op->aiocb.aio_offset);
+}
+
+void
+prep_readv(io_uring_sqe *sqe, AIOCallbackInternal *op)
+{
+  op->iovec.iov_len  = op->aiocb.aio_nbytes;
+  op->iovec.iov_base = op->aiocb.aio_buf;
+  io_uring_prep_readv(sqe, op->aiocb.aio_fildes, &op->iovec, 1, op->aiocb.aio_offset);
+}
+
+void
+prep_write(io_uring_sqe *sqe, AIOCallbackInternal *op)
+{
+  io_uring_prep_write(sqe, op->aiocb.aio_fildes, op->aiocb.aio_buf, op->aiocb.aio_nbytes, op->aiocb.aio_offset);
+}
+
+void
+prep_writev(io_uring_sqe *sqe, AIOCallbackInternal *op)
+{
+  op->iovec.iov_len  = op->aiocb.aio_nbytes;
+  op->iovec.iov_base = op->aiocb.aio_buf;
+  io_uring_prep_writev(sqe, op->aiocb.aio_fildes, &op->iovec, 1, op->aiocb.aio_offset);
+}
+
+using prep_op = void (*)(io_uring_sqe *, AIOCallbackInternal *);
+
+prep_op prep_ops[] = {
+  nullptr,
+  prep_readv,
+  prep_writev,
+};
+
+void
+setup_prep_ops(IOUringContext *ur)
+{
+  if (!ur->supports_op(IORING_OP_READ)) {
+    prep_ops[LIO_READ]  = prep_readv;
+    prep_ops[LIO_WRITE] = prep_writev;
+  }
+}
+
+void
+io_uring_prep_ops_internal(AIOCallbackInternal *op_in, int op_type)
+{
+  IOUringContext *ur      = IOUringContext::local_context();
+  AIOCallbackInternal *op = op_in;
+  while (op) {
+    op->this_op       = op;
+    io_uring_sqe *sqe = ur->next_sqe(op);
+
+    ink_release_assert(sqe != nullptr);
+
+    prep_ops[op_type](sqe, op);
+
+    op->aiocb.aio_lio_opcode = op_type;
+    if (op->then) {
+      sqe->flags |= IOSQE_IO_LINK;
+    } else if (op->aio_op == nullptr) { // This condition leaves an existing aio_op in place if there is one. (EAGAIN)
+      op->aio_op = static_cast<AIOCallbackInternal *>(op_in);
+    }
+
+    op = static_cast<AIOCallbackInternal *>(op->then);
+  }
+}
+
+} // namespace
+
 void
 AIOCallbackInternal::handle_complete(io_uring_cqe *cqe)
 {
   AIOCallbackInternal *op = this_op;
+
+  // Re-submit the request on EAGAIN.
+  // we might need to re-submit the entire rest of the chain, so just call prep again
+  // The manpage seems to indicate that the rest of the SQEs in the chain will not execute on an error.
+  if (cqe->res == -EAGAIN) {
+    io_uring_prep_ops_internal(op, op->aiocb.aio_lio_opcode);
+    return;
+  }
+
+  // if this was canceled, then we can ignore it.  It was probably resubmitted after an EAGAIN
+  if (cqe->res == -ECANCELED) {
+    return;
+  }
 
   op->aio_result = static_cast<int64_t>(cqe->res);
   op->link.prev  = nullptr;
   op->link.next  = nullptr;
   op->mutex      = op->action.mutex;
 
-  if (op->aiocb.aio_lio_opcode == LIO_WRITE) {
-    aio_num_write.fetch_add(1);
-    aio_bytes_written.fetch_add(op->aiocb.aio_nbytes);
-  } else {
-    aio_num_read.fetch_add(1);
-    aio_bytes_read.fetch_add(op->aiocb.aio_nbytes);
+  if (op->aio_result > 0) {
+    if (op->aiocb.aio_lio_opcode == LIO_WRITE) {
+      aio_num_write.fetch_add(1);
+      aio_bytes_written.fetch_add(op->aiocb.aio_nbytes);
+    } else {
+      aio_num_read.fetch_add(1);
+      aio_bytes_read.fetch_add(op->aiocb.aio_nbytes);
+    }
   }
 
   // the last op in the linked ops will have the original op stored in the aiocb
@@ -573,6 +669,7 @@ AIOCallbackInternal::handle_complete(io_uring_cqe *cqe)
     }
   }
 }
+
 #endif
 
 int
@@ -580,27 +677,7 @@ ink_aio_read(AIOCallback *op_in, int fromAPI)
 {
 #if TS_USE_LINUX_IO_URING
   if (use_io_uring) {
-    IOUringContext *ur      = IOUringContext::local_context();
-    AIOCallbackInternal *op = static_cast<AIOCallbackInternal *>(op_in);
-    while (op) {
-      op->this_op       = op;
-      io_uring_sqe *sqe = ur->next_sqe(op);
-      if (ur->supports_op(IORING_OP_READ)) {
-        io_uring_prep_read(sqe, op->aiocb.aio_fildes, op->aiocb.aio_buf, op->aiocb.aio_nbytes, op->aiocb.aio_offset);
-      } else {
-        op->iovec.iov_len  = op->aiocb.aio_nbytes;
-        op->iovec.iov_base = op->aiocb.aio_buf;
-        io_uring_prep_readv(sqe, op->aiocb.aio_fildes, &op->iovec, 1, op->aiocb.aio_offset);
-      }
-      op->aiocb.aio_lio_opcode = LIO_READ;
-      if (op->then) {
-        sqe->flags |= IOSQE_IO_LINK;
-      } else {
-        op->aio_op = static_cast<AIOCallbackInternal *>(op_in);
-      }
-
-      op = static_cast<AIOCallbackInternal *>(op->then);
-    }
+    io_uring_prep_ops_internal(static_cast<AIOCallbackInternal *>(op_in), LIO_READ);
     return 1;
   }
 #endif
@@ -615,27 +692,7 @@ ink_aio_write(AIOCallback *op_in, int fromAPI)
 {
 #if TS_USE_LINUX_IO_URING
   if (use_io_uring) {
-    IOUringContext *ur      = IOUringContext::local_context();
-    AIOCallbackInternal *op = static_cast<AIOCallbackInternal *>(op_in);
-    while (op) {
-      op->this_op       = op;
-      io_uring_sqe *sqe = ur->next_sqe(op);
-      if (ur->supports_op(IORING_OP_WRITE)) {
-        io_uring_prep_write(sqe, op->aiocb.aio_fildes, op->aiocb.aio_buf, op->aiocb.aio_nbytes, op->aiocb.aio_offset);
-      } else {
-        op->iovec.iov_len  = op->aiocb.aio_nbytes;
-        op->iovec.iov_base = op->aiocb.aio_buf;
-        io_uring_prep_writev(sqe, op->aiocb.aio_fildes, &op->iovec, 1, op->aiocb.aio_offset);
-      }
-      op->aiocb.aio_lio_opcode = LIO_WRITE;
-      if (op->then) {
-        sqe->flags |= IOSQE_IO_LINK;
-      } else {
-        op->aio_op = static_cast<AIOCallbackInternal *>(op_in);
-      }
-
-      op = static_cast<AIOCallbackInternal *>(op->then);
-    }
+    io_uring_prep_ops_internal(static_cast<AIOCallbackInternal *>(op_in), LIO_WRITE);
     return 1;
   }
 #endif

--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -133,7 +133,7 @@ AIOCallbackInternal::io_complete(int event, void *data)
     err_op->action               = aio_err_callbck;
     eventProcessor.schedule_imm(err_op);
   }
-  if (!action.cancelled) {
+  if (!action.cancelled && action.continuation) {
     action.continuation->handleEvent(AIO_EVENT_DONE, this);
   }
   return EVENT_DONE;

--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -92,7 +92,7 @@ struct AIOCallbackInternal : public AIOCallback {
   ink_hrtime sleep_time = 0;
   SLINK(AIOCallbackInternal, alink); /* for AIO_Reqs::aio_temp_list */
 #if TS_USE_LINUX_IO_URING
-  iovec iovec                  = {}; // this is to support older kernels that only support readv/writev
+  iovec iov                    = {}; // this is to support older kernels that only support readv/writev
   AIOCallbackInternal *this_op = nullptr;
   AIOCallbackInternal *aio_op  = nullptr;
 

--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -92,6 +92,7 @@ struct AIOCallbackInternal : public AIOCallback {
   ink_hrtime sleep_time = 0;
   SLINK(AIOCallbackInternal, alink); /* for AIO_Reqs::aio_temp_list */
 #if TS_USE_LINUX_IO_URING
+  iovec iovec                  = {}; // this is to support older kernels that only support readv/writev
   AIOCallbackInternal *this_op = nullptr;
   AIOCallbackInternal *aio_op  = nullptr;
 

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -67,6 +67,32 @@ test_done()
 
 const char *GLOBAL_DATA = static_cast<char *>(ats_malloc(10 * 1024 * 1024 + 3)); // 10M
 
+#if TS_USE_LINUX_IO_URING
+
+class IOUringLoopTailHandler : public EThread::LoopTailHandler
+{
+public:
+  int
+  waitForActivity(ink_hrtime timeout) override
+  {
+    IOUringContext::local_context()->submit_and_wait(timeout);
+
+    return 0;
+  }
+  /** Unblock.
+
+  This is required to unblock (wake up) the block created by calling @a cb.
+      */
+  void
+  signalActivity() override
+  {
+  }
+
+  ~IOUringLoopTailHandler() override {}
+} uring_handler;
+
+#endif
+
 struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase; // inherit constructor
 
@@ -95,6 +121,10 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
     EThread *thread = new EThread();
     thread->set_specific();
     init_buffer_allocators(0);
+
+#if TS_USE_LINUX_IO_URING
+    thread->set_tail_handler(&uring_handler);
+#endif
 
     std::string src_dir       = std::string(TS_ABS_TOP_SRCDIR) + "/iocore/cache/test";
     Layout::get()->sysconfdir = src_dir;

--- a/iocore/io_uring/I_IO_URING.h
+++ b/iocore/io_uring/I_IO_URING.h
@@ -76,6 +76,12 @@ public:
   static void set_main_queue(IOUringContext *);
   static int get_main_queue_fd();
 
+  bool
+  valid()
+  {
+    return ring.ring_fd > 0;
+  }
+
 private:
   io_uring ring         = {};
   io_uring_probe *probe = nullptr;

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2070,9 +2070,13 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 
 #if TS_USE_LINUX_IO_URING == 1
   IOUringContext *ur = IOUringContext::local_context();
-  IOUringContext::set_main_queue(ur);
-  auto [bounded, unbounded] = ur->get_wq_max_workers();
-  Note("io_uring: WQ workers - bounded = %d, unbounded = %d", bounded, unbounded);
+  if (ur->valid()) {
+    IOUringContext::set_main_queue(ur);
+    auto [bounded, unbounded] = ur->get_wq_max_workers();
+    Note("io_uring: WQ workers - bounded = %d, unbounded = %d", bounded, unbounded);
+  } else {
+    Note("io_uring: Not supported");
+  }
 #endif
 
   // !! ET_NET threads start here !!
@@ -2278,7 +2282,11 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 
   while (!TSSystemState::is_event_system_shut_down()) {
 #if TS_USE_LINUX_IO_URING == 1
-    ur->submit_and_wait(1 * HRTIME_SECOND);
+    if (ur->valid()) {
+      ur->submit_and_wait(1 * HRTIME_SECOND);
+    } else {
+      sleep(1);
+    }
 #else
     sleep(1);
 #endif


### PR DESCRIPTION
If the kernel doesn't support io_uring, but it's compiled in, we would throw an exception and crash ATS.  This PR just marks the ring bad and provides a function to check if io_uring is valid.  This way ATS can respond at runtime and fallback to non io_uring code.