### PR TITLE
kbroughton/egress-proxy working forward proxy config

### DIFF
--- a/configs/records.yaml.forward
+++ b/configs/records.yaml.forward
@@ -1,0 +1,226 @@
+##############################################################################
+# *NOTE*: All options covered in this file should be documented in the docs:
+#
+#    https://docs.trafficserver.apache.org/records.yaml
+##############################################################################
+
+ts:
+  accept_threads: 1
+  cache:
+    limits:
+      http:
+
+    
+# https://docs.trafficserver.apache.org/records.yaml#proxy-config-cache-limits-http-max-alts
+        max_alts: 5
+    log:
+      alternate:
+
+# https://docs.trafficserver.apache.org/records.yaml#proxy-config-cache-log-alternate-eviction
+        eviction: 0
+
+# https://docs.trafficserver.apache.org/records.yaml#proxy-config-cache-max-doc-size
+    max_doc_size: 0
+    min_average_object_size: 8000
+
+##############################################################################
+# RAM and disk cache configurations. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#ram-cache
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/storage.config.en.html
+##############################################################################
+    ram_cache:
+      size: -1
+    ram_cache_cutoff: 4194304
+    threads_per_disk: 8
+##############################################################################
+# Debugging. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#diagnostic-logging-configuration
+##############################################################################
+  diags:
+    debug:
+      enabled: 0
+      tags: http|dns
+
+#    https://docs.trafficserver.apache.org/records.yaml#proxy-config-dump-mem-info-frequency
+  dump_mem_info_frequency: 0
+
+##############################################################################
+# Thread configurations. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#thread-variables
+##############################################################################
+  diags:
+    debug:
+      enabled: 0
+      tags: http|dns
+
+  exec_thread:
+    affinity: 1
+    autoconfig:
+      enabled: 1
+      scale: 1.0
+    limit: 2
+
+  http:
+    accept_no_activity_timeout: 120
+    cache:
+      cache_responses_to_cookies: 1
+      cache_urls_that_look_dynamic: 1
+
+##############################################################################
+# Heuristic cache expiration. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#heuristic-expiration
+##############################################################################
+      heuristic_lm_factor: 0.1
+      heuristic_max_lifetime: 86400
+      heuristic_min_lifetime: 3600
+
+##############################################################################
+# Enable / disable HTTP caching. Useful for testing, but also as an
+# overridable (per remap) config
+##############################################################################
+      http: 0
+
+##############################################################################
+# Cache control. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#cache-control
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/cache.config.en.html
+##############################################################################
+      ignore_client_cc_max_age: 1
+
+# https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-cache-required-headers
+      required_headers: 2
+
+# https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-cache-when-to-revalidate
+      when_to_revalidate: 0
+
+##############################################################################
+# Origin server connect attempts. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#origin-server-connect-attempts
+##############################################################################
+    connect_attempts_max_retries: 3
+    connect_attempts_max_retries_dead_server: 1
+    connect_attempts_rr_retries: 3
+    connect_attempts_timeout: 30
+    down_server:
+      cache_time: 60
+    forward:
+      proxy_auth_to_parent: 0
+
+##############################################################################
+# Proxy users variables. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#proxy-user-variables
+##############################################################################
+    insert_client_ip: 1
+
+##############################################################################
+# Via: headers. Docs:
+#     https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-insert-response-via-str
+##############################################################################
+    insert_request_via_str: 1
+    insert_response_via_str: 0
+    insert_squid_x_forwarded_for: 1
+    keep_alive_no_activity_timeout_in: 120
+#    keep_alive_no_activity_timeout_out: 120
+
+##############################################################################
+# Negative response caching, for redirects and errors. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#negative-response-caching
+##############################################################################
+    negative_caching_enabled: 0
+    negative_caching_lifetime: 1800
+    normalize_ae: 1
+
+##############################################################################
+# Parent proxy configuration, in addition to these settings also see parent.config. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#parent-proxy-configuration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/parent.config.en.html
+##############################################################################
+    parent_proxy:
+      retry_time: 300
+
+##############################################################################
+# Security. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#security
+##############################################################################
+    push_method_enabled: 0
+
+##############################################################################
+# Specify server addresses and ports to bind for HTTP and HTTPS. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#proxy.config.http.server_ports
+##############################################################################
+    server_ports: 8080 8080:ipv6
+
+#    https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-slow-log-threshold
+    slow:
+      log:
+        threshold: 0
+
+##############################################################################
+# HTTP connection timeouts (secs). Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#http-connection-timeouts
+##############################################################################
+    transaction_active_timeout_in: 900
+    transaction_active_timeout_out: 0
+    transaction_no_activity_timeout_in: 30
+    transaction_no_activity_timeout_out: 30
+    uncacheable_requests_bypass_parent: 1
+
+##############################################################################
+# Logging Config. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#logging-configuration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/logging.yaml.en.html
+##############################################################################
+  log:
+    auto_delete_rolled_files: 1
+    logging_enabled: 3
+    max_space_mb_for_logs: 25000
+    max_space_mb_headroom: 1000
+    periodic_tasks_interval: 5
+    rolling_enabled: 1
+    rolling_interval_sec: 86400
+    rolling_size_mb: 10
+
+##############################################################################
+# Network. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#network
+##############################################################################
+  net:
+    connections_throttle: 30000
+    default_inactivity_timeout: 86400
+    max_connections_in: 30000
+    max_requests_in: 0
+
+#    https://docs.trafficserver.apache.org/records.yaml#proxy-config-res-track-memory
+  res_track_memory: 0
+
+# https://docs.trafficserver.apache.org/records.yaml#reverse-proxy
+  reverse_proxy:
+    enabled: 0
+  ssl:
+    client:
+      CA:
+        cert:
+          filename: null
+
+##############################################################################
+# SSL Termination. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#client-related-configuration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/ssl_multicert.config.en.html
+##############################################################################
+      verify:
+        server:
+          policy: PERMISSIVE
+          properties: ALL
+  task_threads: 2
+
+##############################################################################
+# These settings control remapping, and if the proxy allows (open) forward proxy or not. Docs:
+#    https://docs.trafficserver.apache.org/records.yaml#url-remap-rules
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/remap.config.en.html
+##############################################################################
+  url_remap:
+    remap_required: 0
+
+# https://docs.trafficserver.apache.org/records.yaml#proxy-config-url-remap-pristine-host-hdr
+    pristine_host_hdr: 0
+#    remap_required: 1


### PR DESCRIPTION
This is working on osx following the setup described [here](https://github.com/Planetkesten/egress-proxy-icap/issues/7) 

test with curl --proxy http://localhost:8080 http://www.testingmcafeesites.com/testcat_al.html