### PR TITLE
Increase BUFSIZE to modern sizing

### DIFF
--- a/proxy/hdrs/URL.cc
+++ b/proxy/hdrs/URL.cc
@@ -1757,7 +1757,7 @@ memcpy_tolower(char *d, const char *s, int n)
   }
 }
 
-#define BUFSIZE 512
+#define BUFSIZE 4096
 
 // fast path for CryptoHash, HTTP, no user/password/params/query,
 // no buffer overflow, no unescaping needed


### PR DESCRIPTION
This BUFSIZE, in URL.cc, is used exclusively for allocating buffers on the stack. The problem with keeping it small is that URLs larger than the current 512 bytes can never use the fast path. Granted, odds are that you would be using query parameters for this, but it seems safe and generally better to increase this to 4K (with no risk).