### PR TITLE
fix: consider the case where m_start_time is 0 in BaseLogFile::roll

### DIFF
--- a/src/tscore/BaseLogFile.cc
+++ b/src/tscore/BaseLogFile.cc
@@ -160,7 +160,7 @@ BaseLogFile::roll(long interval_start, long interval_end)
     if (interval_start == 0) {
       start = m_start_time;
     } else {
-      start = (m_start_time < interval_start) ? m_start_time : interval_start;
+      start = (m_start_time > 0 && m_start_time < interval_start) ? m_start_time : interval_start;
     }
   }
   log_log_trace("in BaseLogFile::roll(..), start = %ld, m_start_time = %ld, interval_start = %ld\n", start, m_start_time,


### PR DESCRIPTION
# Problem
In the second and subsequent log rolling, the start date of the log file name is set to "19700101" when all of the following conditions are met.
* proxy.config.log.rolling_allow_empty is set to 1
* there is no writing to the log file

# How to reproduce
1. Set the following configuration to records.yaml
```
  log:
    rolling_enabled: 1
    rolling_interval_sec: 60
    rolling_allow_empty: 1
```
2. Set the following configuration to logging.yaml
```
---
logging:
  formats:
  - name: sample
    format: "%<cqtd> %<cqtt> %<cquuc> %<crc>"
  logs:
  - mode: ascii
    filename: access
    format: sample
```
3. Launch Traffic Server
4. After waiting a few minutes, the following logs are created
```
access.log_{hostname}.20230413.09h19m45s-20230413.09h20m00s.old
access.log_{hostname}.19700101.09h00m00s-20230413.09h21m00s.old
access.log_{hostname}.19700101.09h00m00s-20230413.09h22m00s.old
access.log_{hostname}.19700101.09h00m00s-20230413.09h23m00s.old
access.log_{hostname}.19700101.09h00m00s-20230413.09h24m00s.old
access.log_{hostname}.19700101.09h00m00s-20230413.09h25m00s.old
```

# Cause
After the log rolling, m_start_time is reset and never been updated if there is no writing to the log file.
https://github.com/apache/trafficserver/blob/fc0690bdb407871ca2ae5c309553fe9925bb586f/src/tscore/BaseLogFile.cc#L199
https://github.com/apache/trafficserver/blob/fc0690bdb407871ca2ae5c309553fe9925bb586f/proxy/logging/LogFile.cc#L441

So,  the start date of the log file name is set to "19700101" because it isn't checked whether m_start_time is 0 in BaseLogFile::roll.
