### PR TITLE
build_h3_tools.sh: Remove an unneeded dir check

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -102,9 +102,7 @@ if [ ! -d boringssl ]; then
   cd ..
 fi
 cd boringssl
-if [ ! -d build ]; then
-  mkdir -p build
-fi
+mkdir -p build
 cd build
 cmake \
   -DGO_EXECUTABLE=${GO_BINARY_PATH} \


### PR DESCRIPTION
Remove an unneeded dir check before mkdir -p in build_h3_tools.sh