### PR TITLE
Fix cqpv log field value on H3 connections

### DIFF
--- a/proxy/http3/Http3Session.cc
+++ b/proxy/http3/Http3Session.cc
@@ -61,7 +61,7 @@ HQSession::remove_transaction(HQTransaction *trans)
 const char *
 HQSession::get_protocol_string() const
 {
-  return this->_protocol_string;
+  return "";
 }
 
 int
@@ -199,6 +199,12 @@ void
 Http3Session::decrement_current_active_connections_stat()
 {
   // TODO Implement stats
+}
+
+const char *
+Http3Session::get_protocol_string() const
+{
+  return "http/3";
 }
 
 QPACK *

--- a/proxy/http3/Http3Session.h
+++ b/proxy/http3/Http3Session.h
@@ -77,6 +77,9 @@ public:
   void increment_current_active_connections_stat() override;
   void decrement_current_active_connections_stat() override;
 
+  // Implement ProxySession interface
+  const char *get_protocol_string() const override;
+
   QPACK *local_qpack();
   QPACK *remote_qpack();
 


### PR DESCRIPTION
`cqpv` field is a human readable protocol name such as "http/1.1" and "http/2", but "h3",  which is ALPN ID, was logged on H3 connections.