### PR TITLE
Add automatic detection of ccache for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,9 @@ find_package(PCRE)
 include(FindOpenSSL)
 find_package(OpenSSL)
 
+# Find ccache
+include(find_ccache)
+
 # Check for IO faculties
 check_symbol_exists(epoll_create "sys/epoll.h" TS_USE_EPOLL)
 check_symbol_exists(kqueue "sys/event.h" TS_USE_KQUEUE)

--- a/cmake/find_ccache.cmake
+++ b/cmake/find_ccache.cmake
@@ -15,9 +15,10 @@
 #
 #######################
 
-option(AUTO_CCACHE "Use ccache to speed up rebuilds" ON)
+option(ENABLE_CCACHE "Use ccache to speed up rebuilds" ON)
 find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM AND ${AUTO_CCACHE})
+if(CCACHE_PROGRAM AND ${ENABLE_CCACHE})
   message(STATUS "Using ${CCACHE_PROGRAM} as compiler launcher")
   set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()

--- a/cmake/find_ccache.cmake
+++ b/cmake/find_ccache.cmake
@@ -1,0 +1,23 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+option(AUTO_CCACHE "Use ccache to speed up rebuilds" ON)
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM AND ${AUTO_CCACHE})
+  message(STATUS "Using ${CCACHE_PROGRAM} as compiler launcher")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()


### PR DESCRIPTION
Builds time change from about 20 seconds to 3.5 seconds.

Without ccache:
```
13:57:06 zeus:(cmake_ccache)~/dev/apache/trafficserver/target$ time ninja
[0/2] Re-checking globbed directories...
[497/497] Linking CXX executable src/traffic_server/traffic_server

real	0m19.219s
user	7m50.807s
sys	0m53.087s
```

With ccache:
```
13:53:11 zeus:(cmake_ccache)~/dev/apache/trafficserver/target$ time ninja
[0/2] Re-checking globbed directories...
[497/497] Linking CXX executable src/traffic_server/traffic_server

real	0m3.525s
user	0m9.939s
sys	0m4.739s
```