### PR TITLE
Add CentOS to the required builds

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,6 +47,7 @@ github:
           - AuTest 2of4
           - AuTest 3of4
           - Rocky
+          - CentOS
           - Clang-Analyzer
           - Clang-Format
           - CMake


### PR DESCRIPTION
This adds centos:7 builds, which exercises the gcc-8 toolchain, to the required set of PR CI job builds.

It was decided in the summit that we would test centos:7 and the gcc-8 toolchain as a part of CI.