### PR TITLE
Fix ttmsh log field

### DIFF
--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -898,10 +898,10 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("ttms", field);
 
-  field = new LogField("transfer_time_ms_hex", "ttmh", LogField::sINT, &LogAccess::marshal_transfer_time_ms,
+  field = new LogField("transfer_time_ms_hex", "ttmsh", LogField::sINT, &LogAccess::marshal_transfer_time_ms,
                        &LogAccess::unmarshal_int_to_str_hex);
   global_field_list.add(field, false);
-  field_symbol_hash.emplace("ttmh", field);
+  field_symbol_hash.emplace("ttmsh", field);
 
   field = new LogField("transfer_time_ms_fractional", "ttmsf", LogField::sINT, &LogAccess::marshal_transfer_time_ms,
                        &LogAccess::unmarshal_ttmsf);


### PR DESCRIPTION
Log field `ttmsh` has never worked. The documentation says `ttmsh` but the implementation is `ttmh`. It's hex version of `ttms`, so `ttmsh` is correct.

https://docs.trafficserver.apache.org/en/latest/admin-guide/logging/formatting.en.html#timestamps-and-durations