### PR TITLE
Fix TS_HTTP_REQUEST_TRANSFORM_HOOK Tunnel Processing

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6054,8 +6054,8 @@ HttpSM::handle_http_server_open()
 
     int method = t_state.hdr_info.server_request.method_get_wksidx();
     if (method != HTTP_WKSIDX_TRACE &&
-        server_txn->has_request_body(t_state.hdr_info.response_content_length,
-                                     t_state.server_info.transfer_encoding == HttpTransact::CHUNKED_ENCODING) &&
+        server_txn->has_request_body(t_state.hdr_info.request_content_length,
+                                     t_state.client_info.transfer_encoding == HttpTransact::CHUNKED_ENCODING) &&
         do_post_transform_open()) {
       do_setup_post_tunnel(HTTP_TRANSFORM_VC); /* This doesn't seem quite right.  Should be sending the request header */
     } else {

--- a/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
+++ b/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
@@ -113,7 +113,7 @@ class MultiplexerTestBase:
             "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
 
             'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'multiplexer',
+            'proxy.config.diags.debug.tags': 'http|multiplexer',
         })
         self.ts.Disk.ssl_multicert_config.AddLine(
             'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
@@ -172,6 +172,12 @@ class MultiplexerTest(MultiplexerTestBase):
         self.server_https.Streams.All += Testers.ContainsExpression(
             'uuid: POST',
             "Verify the HTTPS server received the POST request.")
+        self.server_http.Streams.All += Testers.ContainsExpression(
+            'x-response: second',
+            "Verify the HTTP server sent the POST response.")
+        self.server_https.Streams.All += Testers.ContainsExpression(
+            'x-response: second',
+            "Verify the HTTPS server sent the POST response.")
 
         # Same with PUT
         self.server_http.Streams.All += Testers.ContainsExpression(


### PR DESCRIPTION
This fixes a bug in client request processing for transform tunnels. Without this fix, the transform request tunnel was not created for requests with a body which made it so that request transform plugins were not dispatched to for the various events concerning requests with a body.