### PR TITLE
Don't build traffic_quic command

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,11 +40,5 @@ include traffic_layout/Makefile.inc
 include traffic_logcat/Makefile.inc
 include traffic_ctl/Makefile.inc
 
-
-
-if ENABLE_QUIC
-include traffic_quic/Makefile.inc
-endif
-
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)


### PR DESCRIPTION
It worked with the original QUIC impl, but has not been maintained after we start using Quiche. The code is left for reference purpose.