### PR TITLE
Add support for direct header passing

### DIFF
--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -56,6 +56,10 @@ public:
   virtual bool expect_receive_trailer() const;
   virtual void set_expect_receive_trailer();
 
+  virtual bool supports_direct_header_passing() const;
+  virtual bool is_parsed_receive_header_ready() const;
+  virtual const HTTPHdr *parsed_receive_header() const;
+
   // Implement VConnection interface.
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
   VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
@@ -289,6 +293,24 @@ ProxyTransaction::cancel_active_timeout()
   if (_proxy_ssn) {
     _proxy_ssn->cancel_active_timeout();
   }
+}
+
+inline bool
+ProxyTransaction::supports_direct_header_passing() const
+{
+  return false;
+}
+
+inline bool
+ProxyTransaction::is_parsed_receive_header_ready() const
+{
+  return false;
+}
+
+inline const HTTPHdr *
+ProxyTransaction::parsed_receive_header() const
+{
+  return nullptr;
 }
 
 // See if we need to schedule on the primary thread for the transaction or change the thread that is associated with the VC.


### PR DESCRIPTION
This is for #5230. HttpSM only reads/writes HTTP request/response from/to VConnection. Although it's simple, it requires that the input/output format is text based HTTP/1.1 form. It works fine for H1, but not H2 and H3. The interface disables propagating information that cannot be transformed into HTTP/1.1 form (e.g. header sensitivity). Also, it's wasteful to marshal HTTPHdr and parse the text data again (An H2 or H3 transaction has a HTTPHdr as a result of HPACK/QPACK decoding).

This PR adds a new interface to pass/receive HTTPHdr instance to bypass header marshaling. A subclass of ProxyTransaction needs to overwrite `supports_direct_header_passing()` to use the new interface.