### PR TITLE
Pass HTTPHdr directly on H3 transaction

### DIFF
--- a/proxy/ProxyTransaction.h
+++ b/proxy/ProxyTransaction.h
@@ -56,6 +56,10 @@ public:
   virtual bool expect_receive_trailer() const;
   virtual void set_expect_receive_trailer();
 
+  virtual bool supports_direct_header_passing() const;
+  virtual bool is_parsed_receive_header_ready() const;
+  virtual const HTTPHdr *parsed_receive_header() const;
+
   // Implement VConnection interface.
   VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
   VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = nullptr,
@@ -289,6 +293,24 @@ ProxyTransaction::cancel_active_timeout()
   if (_proxy_ssn) {
     _proxy_ssn->cancel_active_timeout();
   }
+}
+
+inline bool
+ProxyTransaction::supports_direct_header_passing() const
+{
+  return false;
+}
+
+inline bool
+ProxyTransaction::is_parsed_receive_header_ready() const
+{
+  return false;
+}
+
+inline const HTTPHdr *
+ProxyTransaction::parsed_receive_header() const
+{
+  return nullptr;
 }
 
 // See if we need to schedule on the primary thread for the transaction or change the thread that is associated with the VC.

--- a/proxy/http3/Http3HeaderFramer.h
+++ b/proxy/http3/Http3HeaderFramer.h
@@ -32,12 +32,11 @@
 #include "Http3Frame.h"
 
 class Http3Transaction;
-class VIO;
 
 class Http3HeaderFramer : public Http3FrameGenerator
 {
 public:
-  Http3HeaderFramer(Http3Transaction *transaction, VIO *source, QPACK *qpack, uint64_t stream_id);
+  Http3HeaderFramer(Http3Transaction *transaction, QPACK *qpack, uint64_t stream_id);
   ~Http3HeaderFramer();
 
   // Http3FrameGenerator
@@ -46,7 +45,6 @@ public:
 
 private:
   Http3Transaction *_transaction       = nullptr;
-  VIO *_source_vio                     = nullptr;
   QPACK *_qpack                        = nullptr;
   MIOBuffer *_header_block             = nullptr;
   IOBufferReader *_header_block_reader = nullptr;

--- a/proxy/http3/Http3HeaderVIOAdaptor.h
+++ b/proxy/http3/Http3HeaderVIOAdaptor.h
@@ -30,7 +30,7 @@
 class Http3HeaderVIOAdaptor : public Continuation, public Http3FrameHandler
 {
 public:
-  Http3HeaderVIOAdaptor(VIO *sink, HTTPType http_type, QPACK *qpack, uint64_t stream_id);
+  Http3HeaderVIOAdaptor(HTTPType http_type, QPACK *qpack, uint64_t stream_id);
   ~Http3HeaderVIOAdaptor();
 
   // Http3FrameHandler
@@ -38,10 +38,10 @@ public:
   Http3ErrorUPtr handle_frame(std::shared_ptr<const Http3Frame> frame) override;
 
   bool is_complete();
+  const HTTPHdr *get_header();
   int event_handler(int event, Event *data);
 
 private:
-  VIO *_sink_vio      = nullptr;
   QPACK *_qpack       = nullptr;
   uint64_t _stream_id = 0;
   bool _is_complete   = false;

--- a/proxy/http3/Http3StreamDataVIOAdaptor.cc
+++ b/proxy/http3/Http3StreamDataVIOAdaptor.cc
@@ -52,3 +52,9 @@ Http3StreamDataVIOAdaptor::finalize()
 {
   this->_sink_vio->nbytes = this->_total_data_length;
 }
+
+bool
+Http3StreamDataVIOAdaptor::has_data() const
+{
+  return this->_total_data_length > 0;
+}

--- a/proxy/http3/Http3StreamDataVIOAdaptor.h
+++ b/proxy/http3/Http3StreamDataVIOAdaptor.h
@@ -38,6 +38,7 @@ public:
 
   // Http3StreamDataVIOAdaptor
   void finalize();
+  bool has_data() const;
 
 private:
   VIO *_sink_vio             = nullptr;

--- a/proxy/http3/Http3Transaction.h
+++ b/proxy/http3/Http3Transaction.h
@@ -46,7 +46,7 @@ public:
   HQTransaction(HQSession *session, QUICStreamVCAdapter::IOInfo &info);
   virtual ~HQTransaction();
 
-  // Implement ProxyClienTransaction interface
+  // Implement ProxyTransaction interface
   void set_active_timeout(ink_hrtime timeout_in) override;
   void set_inactivity_timeout(ink_hrtime timeout_in) override;
   void cancel_inactivity_timeout() override;
@@ -98,6 +98,12 @@ public:
   Http3Transaction(Http3Session *session, QUICStreamVCAdapter::IOInfo &info);
   virtual ~Http3Transaction();
 
+  // ProxyTransaction
+  virtual bool supports_direct_header_passing() const override;
+  virtual bool is_parsed_receive_header_ready() const override;
+  virtual const HTTPHdr *parsed_receive_header() const override;
+
+  // HQTransaction
   int state_stream_open(int event, void *data) override;
   int state_stream_closed(int event, void *data) override;
 


### PR DESCRIPTION
The first commit is #9730, and the second commit is to use the new interface for H3.

This also enables POST request on H3.