### PR TITLE
Add configuration for UDP poll timeout

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4837,6 +4837,14 @@ removed in the future without prior notice.
 UDP Configuration
 =====================
 
+.. ts:cv:: CONFIG proxy.config.udp.poll_timeout INT 100
+   :units: milliseconds
+
+   This is the timeout for listening UDP connections to ``epoll_wait()`` on
+   Linux platforms, and to ``kevent()`` on BSD type OSs. The default value is
+   100. See :ts:cv:`proxy.config.net.poll_timeout` for general information on
+   poll_timeout.
+
 .. ts:cv:: CONFIG proxy.config.udp.threads INT 0
 
    Specifies the number of UDP threads to run. By default 0 threads are dedicated to UDP,

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -144,6 +144,7 @@ UDPPacket::free()
 UDPNetProcessorInternal udpNetInternal;
 UDPNetProcessor &udpNet = udpNetInternal;
 
+int g_udp_pollTimeout;
 int32_t g_udp_periodicCleanupSlots;
 int32_t g_udp_periodicFreeCancelledPkts;
 int32_t g_udp_numSendRetries;
@@ -172,9 +173,10 @@ initialize_thread_for_udp_net(EThread *thread)
 
   PollCont *upc       = get_UDPPollCont(thread);
   PollDescriptor *upd = upc->pollDescriptor;
-  // due to ET_UDP is really simple, it should sleep for a long time
-  // TODO: fixed size
-  upc->poll_timeout = 100;
+
+  REC_ReadConfigInteger(g_udp_pollTimeout, "proxy.config.udp.poll_timeout");
+  upc->poll_timeout = g_udp_pollTimeout;
+
   // This variable controls how often we cleanup the cancelled packets.
   // If it is set to 0, then cleanup never occurs.
   REC_ReadConfigInt32(g_udp_periodicFreeCancelledPkts, "proxy.config.udp.free_cancelled_pkts_sec");

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -254,6 +254,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.udp.send_retries", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.udp.poll_timeout", RECD_INT, "100", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.udp.threads", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.udp.enable_gso", RECD_INT, "1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}


### PR DESCRIPTION
Add proxy.config.udp.poll_timeout with a default value of 100. Default value and value of 10 are verified with autest.

Closes #4634