### PR TITLE
Fix quic_no_activity_timeout test

### DIFF
--- a/tests/gold_tests/timeout/quic_no_activity_timeout.test.py
+++ b/tests/gold_tests/timeout/quic_no_activity_timeout.test.py
@@ -101,7 +101,7 @@ class Test_quic_no_activity_timeout:
 
         if check_for_max_idle_timeout:
             tr.Processes.Default.ReturnCode = 1  # timeout
-            self._ts.Disk.traffic_out.All = Testers.IncludesExpression(
+            self._ts.Disk.traffic_out.Content += Testers.IncludesExpression(
                 "QUIC Idle timeout detected", "We should detect the timeout.")
         else:
             tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
The test improperly assigned an IncludesExpression to traffic_out.All instead of traffic_out.Content, so it was not getting checked.