### PR TITLE
Fix OCSP detection during build (9.2.x)

### DIFF
--- a/build/crypto.m4
+++ b/build/crypto.m4
@@ -276,16 +276,23 @@ dnl
 dnl Since OpenSSL 1.1.0
 dnl
 AC_DEFUN([TS_CHECK_CRYPTO_OCSP], [
+  enable_tls_ocsp=yes
   _ocsp_saved_LIBS=$LIBS
 
   TS_ADDTO(LIBS, [$OPENSSL_LIBS])
-  AC_CHECK_HEADERS(openssl/ocsp.h, [ocsp_have_headers=1], [enable_tls_ocsp=no])
+  AC_LINK_IFELSE(
+  [
+    AC_LANG_PROGRAM([[
+#include <openssl/ocsp.h>
+    ]],
+    [[
+OCSP_sendreq_new(NULL, NULL, NULL, 0);
+OCSP_REQ_CTX_add1_header(NULL, NULL, NULL);
+OCSP_REQ_CTX_set1_req(NULL, NULL);
+    ]])
+  ], [], [enable_tls_ocsp=no])
 
-  if test "$ocsp_have_headers" == "1"; then
-    AC_CHECK_FUNCS(OCSP_sendreq_new OCSP_REQ_CTX_add1_header OCSP_REQ_CTX_set1_req, [enable_tls_ocsp=yes], [enable_tls_ocsp=no])
-
-    LIBS=$_ocsp_saved_LIBS
-  fi
+  LIBS=$_ocsp_saved_LIBS
 
   AC_MSG_CHECKING(whether OCSP is supported)
   AC_MSG_RESULT([$enable_tls_ocsp])


### PR DESCRIPTION
The configure script fails to detect OCSP support when building ATS with OpenSSL 3.0.

This isn't a problem in the `master` branch, which copied OpenSSL's OCSP code into ATS itself in #9624. However, this remains a problem on existing releases and downstream packages seem to be affected by it. Here's a list of the few I checked:

- Alpine
- Debian 12
- Fedora 37
- Homebrew
- Nixpkgs

This happens because OpenSSL 3.0 made changes to its APIs that affected how ATS detects OCSP support. ATS checks the existence of a few functions, including `OCSP_REQ_CTX_add1_header` and `OCSP_REQ_CTX_set1_req`, by attempting to link to them using `AC_CHECK_FUNCS`. In OpenSSL 3.0, these functions were turned into macros making them uneligible for detection with `AC_CHECK_FUNCS`.

This change fixes that problem by instead using `AC_LANG_PROGRAM` to check that code using the aforementioned functions compile. This approach works for OpenSSL both before and after 3.0.
