### PR TITLE
UDP/QUIC: Make sure quiche gets the entire rx buffer from the udp packet.

### DIFF
--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -73,6 +73,7 @@ public:
   UDPConnection *getConnection();
   IOBufferBlock *getIOBlockChain();
   int64_t getPktLength();
+  uint8_t *get_entire_chain_buffer(size_t *buf_len);
 
   /**
      Add IOBufferBlock (chain) to end of packet.
@@ -114,6 +115,7 @@ public:
 private:
   SLINK(UDPPacket, alink); // atomic link
   UDPPacketInternal p;
+  ats_unique_buf _payload{nullptr};
 };
 
 // Inline definitions

--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -345,10 +345,8 @@ QUICNetVConnection::reset_quic_connection()
 void
 QUICNetVConnection::handle_received_packet(UDPPacket *packet)
 {
-  IOBufferBlock *block = packet->getIOBlockChain();
-  uint8_t *buf         = reinterpret_cast<uint8_t *>(block->buf());
-  uint64_t buf_len     = block->size();
-
+  size_t buf_len{0};
+  uint8_t *buf = packet->get_entire_chain_buffer(&buf_len);
   net_activity(this, this_ethread());
   quiche_recv_info recv_info = {
     &packet->from.sa,

--- a/iocore/net/QUICPacketHandler_quiche.cc
+++ b/iocore/net/QUICPacketHandler_quiche.cc
@@ -190,10 +190,8 @@ QUICPacketHandlerIn::_get_continuation()
 void
 QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
 {
-  // Assumption: udp_packet has only one IOBufferBlock
-  IOBufferBlock *block = udp_packet->getIOBlockChain();
-  const uint8_t *buf   = reinterpret_cast<uint8_t *>(block->buf());
-  uint64_t buf_len     = block->size();
+  uint64_t buf_len{0};
+  uint8_t *buf = udp_packet->get_entire_chain_buffer(&buf_len);
 
   constexpr int MAX_TOKEN_LEN             = 1200;
   constexpr int DEFAULT_MAX_DATAGRAM_SIZE = 1350;


### PR DESCRIPTION
It seems that it was only getting the first slice of the entire chain. Currently each of the iov buffer size is hardcoded to 2k, if happens that we need to fit more than 2k inside the buffer the current code will only hand over the first part of the chain which will make QUICHE to complain as the data is incomplete.

This change makes sure that quiche gets the entire buffer by building the entire buffer together.

Issue can be reproduced by including the ` --max-udp-payload-size 3k` in the `h2load` tool. Actually, any size above 2k should hit the issue.
example:
```bash
/opt/bin/h2load -n 1 -c 1 --npn-list=h3 -H="my-hn1: test01" https://<server-ip>:4443/cache/1000 --max-udp-payload-size 3k
```

FYI: For now this seems fine but as soon as we introduce GRO this will more likely to change.