### PR TITLE
Break the circular dependency between iocore and tscore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ lib/perl/lib/Apache/TS.pm
 iocore/net/test_certlookup
 iocore/net/test_UDPNet
 iocore/net/test_libinknet
-iocore/net/quic/test_QUIC*
+iocore/net/quic/test_*
 iocore/aio/test_AIO
 iocore/eventsystem/test_IOBuffer
 iocore/eventsystem/test_EventSystem

--- a/iocore/net/quic/MTHashTable.h
+++ b/iocore/net/quic/MTHashTable.h
@@ -23,7 +23,7 @@
 
 /****************************************************************************
 
-  MT_hashtable.h
+  MTHashTable.h
 
   Multithread Safe Hash table implementation
 

--- a/iocore/net/quic/Makefile.am
+++ b/iocore/net/quic/Makefile.am
@@ -54,6 +54,20 @@ libquic_a_SOURCES = \
 # Check Programs
 #
 
+check_PROGRAMS := test_MTHashTable
+
+test_MTHashTable_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I$(abs_top_srcdir)/tests/include
+
+test_MTHashTable_LDADD = \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	@SWOC_LIBS@ @OPENSSL_LIBS@
+
+test_MTHashTable_SOURCES = test_MTHashTable.cc
+
 TESTS = $(check_PROGRAMS)
 
 #

--- a/iocore/net/quic/QUICConnectionTable.h
+++ b/iocore/net/quic/QUICConnectionTable.h
@@ -25,7 +25,7 @@
 
 #include "QUICTypes.h"
 #include "QUICConnection.h"
-#include "tscore/MT_hashtable.h"
+#include "MTHashTable.h"
 
 class QUICConnectionTable
 {

--- a/iocore/net/quic/test_MTHashTable.cc
+++ b/iocore/net/quic/test_MTHashTable.cc
@@ -20,12 +20,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-#include <cstdint>
-#include "tscore/ink_platform.h"
-#include "P_EventSystem.h"
-#include "tscore/MT_hashtable.h"
-#include "I_Lock.h"
+
+#define CATCH_CONFIG_MAIN
 #include <catch.hpp>
+
+#include "P_EventSystem.h"
+#include "MTHashTable.h"
 
 // -------------
 // --- TESTS ---

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -123,7 +123,6 @@ add_executable(test_tscore
         unit_tests/test_IntrusivePtr.cc
         unit_tests/test_List.cc
         unit_tests/test_MMH.cc
-        unit_tests/test_MT_hashtable.cc
         unit_tests/test_ParseRules.cc
         unit_tests/test_PluginUserArgs.cc
         unit_tests/test_PriorityQueue.cc
@@ -140,7 +139,7 @@ add_executable(test_tscore
         unit_tests/test_scoped_resource.cc
         unit_tests/unit_test_main.cc
 )
-target_link_libraries(test_tscore PRIVATE tscore inkevent records_p libswoc)
-target_include_directories(test_tscore PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/iocore/eventsystem ${CATCH_INCLUDE_DIR})
+target_link_libraries(test_tscore PRIVATE tscore libswoc)
+target_include_directories(test_tscore PRIVATE ${CMAKE_SOURCE_DIR}/include ${CATCH_INCLUDE_DIR})
 
 install(TARGETS tscore)

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -34,8 +34,7 @@ TESTS = $(check_PROGRAMS)
 lib_LTLIBRARIES = libtscore.la
 
 AM_CPPFLAGS += \
-	$(iocore_include_dirs) \
-        @SWOC_INCLUDES@ \
+	@SWOC_INCLUDES@ \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/lib \
 	$(TS_INCLUDES) \
@@ -164,7 +163,7 @@ test_tscore_CPPFLAGS = $(AM_CPPFLAGS)\
 	-I$(abs_top_srcdir)/tests/include
 
 test_tscore_CXXFLAGS = -Wno-array-bounds $(AM_CXXFLAGS)
-test_tscore_LDADD = libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la $(top_builddir)/iocore/eventsystem/libinkevent.a @SWOC_LIBS@ @OPENSSL_LIBS@
+test_tscore_LDADD = libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la @SWOC_LIBS@ @OPENSSL_LIBS@
 test_tscore_SOURCES = \
 	unit_tests/unit_test_main.cc \
 	unit_tests/test_AcidPtr.cc \
@@ -183,7 +182,6 @@ test_tscore_SOURCES = \
 	unit_tests/test_IntrusivePtr.cc \
 	unit_tests/test_layout.cc \
 	unit_tests/test_List.cc \
-	unit_tests/test_MT_hashtable.cc \
 	unit_tests/test_ParseRules.cc \
 	unit_tests/test_PluginUserArgs.cc \
 	unit_tests/test_PriorityQueue.cc \


### PR DESCRIPTION
The re-introduction of the MTHashTable class created a dependency from tscore to iocore, since it uses proxy mutexes, which are tightly coupled to the event system. We can break this circular dependency by moving the class into the QUIC library as an implementation detail, since that already depends on the event system

This fixes #9768.