### PR TITLE
tools: use a private directory to build H3 dependencies

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -21,6 +21,12 @@
 
 set -e
 
+WORKDIR="$(mktemp -d)"
+readonly WORKDIR
+
+cd "${WORKDIR}"
+echo "Building H3 dependencies in ${WORKDIR} ..."
+
 # Update this as the draft we support updates.
 OPENSSL_BRANCH=${OPENSSL_BRANCH:-"OpenSSL_1_1_1t+quic"}
 


### PR DESCRIPTION
Build H3 dependencies using a private work directory. This prevents dependencies being splatted into the current directory if the build is interrupted or fails.