### PR TITLE
build: remove the SOCKS_WITH_TS build condition

### DIFF
--- a/iocore/net/I_Socks.h
+++ b/iocore/net/I_Socks.h
@@ -23,12 +23,6 @@
 
 #pragma once
 
-/*When this is being compiled with TS, we enable more features the use
-  non modularized stuff. namely:
-  ip_ranges and multiple socks server support.
-*/
-#define SOCKS_WITH_TS
-
 #define SOCKS_DEFAULT_VERSION 0 // defined the configuration variable
 #define SOCKS4_VERSION        4
 #define SOCKS5_VERSION        5

--- a/iocore/net/P_Socks.h
+++ b/iocore/net/P_Socks.h
@@ -30,9 +30,7 @@
 #include "I_Socks.h"
 #include "tscpp/util/ts_errata.h"
 
-#ifdef SOCKS_WITH_TS
 #include "ParentSelection.h"
-#endif
 
 enum {
   // types of events for Socks auth handlers
@@ -57,21 +55,9 @@ struct socks_conf_struct {
   int accept_port          = 0;
   unsigned short http_port = 1080;
 
-#ifdef SOCKS_WITH_TS
   swoc::IPRangeSet ip_addrs;
-#endif
 
-#ifndef SOCKS_WITH_TS
-  IpEndpoint server_addr;
-#endif
-
-  socks_conf_struct()
-
-  {
-#if !defined(SOCKS_WITH_TS)
-    memset(&server_addr, 0, sizeof(server_addr));
-#endif
-  }
+  socks_conf_struct() {}
 };
 
 extern struct socks_conf_struct *g_socks_conf_stuff;
@@ -124,12 +110,10 @@ struct SocksEntry : public Continuation {
   SocksAuthHandler auth_handler = nullptr;
   unsigned char socks_cmd       = NORMAL_SOCKS;
 
-#ifdef SOCKS_WITH_TS
   // socks server selection:
   ParentConfigParams *server_params = nullptr;
   HttpRequestData req_data; // We dont use any http specific fields.
   ParentResult server_result;
-#endif
 
   int startEvent(int event, void *data);
   int mainEvent(int event, void *data);

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -193,16 +193,15 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
   }
 
   vc->set_context(NET_VCONNECTION_OUT);
-  bool using_socks = (socks_conf_stuff->socks_needed && opt->socks_support != NO_SOCKS
-#ifdef SOCKS_WITH_TS
-                      && (opt->socks_version != SOCKS_DEFAULT_VERSION ||
-                          /* This implies we are tunnelling.
-                           * we need to connect using socks server even
-                           * if this ip is in no_socks list.
-                           */
-                          !socks_conf_stuff->ip_addrs.contains(swoc::IPAddr(target)))
-#endif
-  );
+
+  const bool using_socks = (socks_conf_stuff->socks_needed && opt->socks_support != NO_SOCKS &&
+                            (opt->socks_version != SOCKS_DEFAULT_VERSION ||
+                             /* This implies we are tunnelling.
+                              * we need to connect using socks server even
+                              * if this ip is in no_socks list.
+                              */
+                             !socks_conf_stuff->ip_addrs.contains(swoc::IPAddr(target))));
+
   SocksEntry *socksEntry = nullptr;
 
   vc->id          = net_next_connection_number();


### PR DESCRIPTION
The SOCKS_WITH_TS define is hardcoded to true, and there's no way to alter that in the build. Remove it, on the assumption that this is a legacy olden days configuration.