### PR TITLE
Added Autest for H2 CONNECT and fix a crash triggered by the test

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4119,6 +4119,11 @@ HttpSM::tunnel_handler_ssl_producer(int event, HttpTunnelProducer *p)
   STATE_ENTER(&HttpSM::tunnel_handler_ssl_producer, event);
 
   switch (event) {
+  case VC_EVENT_READ_READY:
+    // This event is triggered when receiving DATA frames without the END_STREAM
+    // flag set in a HTTP/2 CONNECT request. Breaking as there are more DATA
+    // frames to come.
+    break;
   case VC_EVENT_READ_COMPLETE:
     // This event is triggered during an HTTP/2 CONNECT request when a DATA
     // frame with the END_STREAM flag set is received, indicating the end of the
@@ -4154,11 +4159,6 @@ HttpSM::tunnel_handler_ssl_producer(int event, HttpTunnelProducer *p)
         tunnel.close_vc(p->self_consumer->producer);
       }
     }
-    break;
-  case VC_EVENT_READ_READY:
-    // This event is triggered when receiving DATA frames without the END_STREAM
-    // flag set in a HTTP/2 CONNECT request. Breaking as there are more DATA
-    // frames to come.
     break;
   case HTTP_TUNNEL_EVENT_PRECOMPLETE:
   // We should never get these event since we don't know

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4119,6 +4119,11 @@ HttpSM::tunnel_handler_ssl_producer(int event, HttpTunnelProducer *p)
   STATE_ENTER(&HttpSM::tunnel_handler_ssl_producer, event);
 
   switch (event) {
+  case VC_EVENT_READ_COMPLETE:
+    // This event is triggered during an HTTP/2 CONNECT request when a DATA
+    // frame with the END_STREAM flag set is received, indicating the end of the
+    // stream.
+    [[fallthrough]];
   case VC_EVENT_EOS:
     // The write side of this connection is still alive
     //  so half-close the read
@@ -4150,7 +4155,11 @@ HttpSM::tunnel_handler_ssl_producer(int event, HttpTunnelProducer *p)
       }
     }
     break;
-  case VC_EVENT_READ_COMPLETE:
+  case VC_EVENT_READ_READY:
+    // This event is triggered when receiving DATA frames without the END_STREAM
+    // flag set in a HTTP/2 CONNECT request. Breaking as there are more DATA
+    // frames to come.
+    break;
   case HTTP_TUNNEL_EVENT_PRECOMPLETE:
   // We should never get these event since we don't know
   //  how long the stream is

--- a/tests/gold_tests/connect/replays/connect_h2.replay.yaml
+++ b/tests/gold_tests/connect/replays/connect_h2.replay.yaml
@@ -1,0 +1,61 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# This replay file executes a HTTP/2 CONNECT request, whose DATA frame contains
+# a tunnelled HTTP/1 GET request.
+#
+meta:
+  version: "1.0"
+
+sessions:
+  - protocol:
+      - name: http
+        version: 2
+      - name: tls
+        sni: www.example.com
+      - name: tcp
+      - name: ip
+
+    transactions:
+      - client-request:
+          frames:
+            - HEADERS:
+                headers:
+                  fields:
+                    - [:method, CONNECT]
+                    - [:authority, www.example.com:80]
+                    - [uuid, 1]
+                    - [test, connect-request]
+            - DATA:
+                content:
+                  encoding: plain
+                  data: "GET /get HTTP/1.1\r\nuuid: 1\r\ntest: real-request\r\n\r\n"
+        # This is the server response for the tunnelled HTTP/1 request rather
+        # than for the CONNECT request.
+        server-response:
+          status: 200
+          reason: OK
+          content:
+            encoding: plain
+            data: response_to_tunnelled_request
+            size: 29
+        # Verify the client receives the response for the tunneled GET request
+        # from the origin server.
+        proxy-response:
+          status: 200
+          content:
+            verify: { value: "response_to_tunnelled_request", as: contains }


### PR DESCRIPTION
In #9616, @maskit wrote an H2 CONNECT Autest but couldn't include that in the final PR because of a Proxy Verifier issue. 
Now that the Proxy Verifier issue is resolved,  the Autest is added in this PR(with a few tweaks).

ATS crashes with the new test executing HTTP/2 tunneling traffic. This PR also includes a fix to resolve that.