### PR TITLE
9.2.x: Add back push_method_enabled enforcement

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -906,6 +906,13 @@ HttpSM::state_read_client_request_header(int event, void *data)
       }
     }
 
+    if (t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_PUSH &&
+        t_state.http_config_param->push_method_enabled == 0) {
+      SMDebug("http", "Rejecting PUSH request because push_method_enabled is 0.");
+      call_transact_and_set_next_state(HttpTransact::Forbidden);
+      return 0;
+    }
+
     // Call to ensure the content-length and transfer_encoding elements in client_request are filled in
     HttpTransact::set_client_request_state(&t_state, &t_state.hdr_info.client_request);
 

--- a/tests/gold_tests/bigobj/bigobj.test.py
+++ b/tests/gold_tests/bigobj/bigobj.test.py
@@ -33,7 +33,7 @@ Test.SkipUnless(
 Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'bigobj', 'push_request'))
 Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'bigobj', 'check_ramp'))
 
-ts = Test.MakeATSProcess("ts", enable_tls=True)
+ts = Test.MakeATSProcess("ts1", enable_tls=True)
 ts.addDefaultSSLFiles()
 
 ts.Disk.records_config.update({
@@ -42,8 +42,8 @@ ts.Disk.records_config.update({
     'proxy.config.http.cache.required_headers': 0,  # No required headers for caching
     'proxy.config.http.push_method_enabled': 1,
     'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
     'proxy.config.url_remap.remap_required': 0
 })
 
@@ -66,56 +66,82 @@ log_id.Content = "log2.gold"
 #
 obj_kilobytes = 10 * 1024
 
-tr = Test.AddTestRun()
+tr = Test.AddTestRun("PUSH an object to the cache")
 # Delay on readiness of TS IPv4 ssl port
-tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.StartBefore(ts)
 #
 # Put object with URL http://localhost/bigobj in cache using PUSH request.
 tr.Processes.Default.Command = (
-    './push_request {} | nc localhost {}'.format(obj_kilobytes, ts.Variables.port)
+    f'./push_request {obj_kilobytes} | nc localhost {ts.Variables.port}'
 )
 tr.Processes.Default.ReturnCode = 0
 
-# GET bigobj -- cleartext, HTTP 1.1, IPv4
-#
-tr = Test.AddTestRun()
+tr = Test.AddTestRun("GET bigobj: cleartext, HTTP/1.1, IPv4")
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http1.1 --header "Host: localhost"' +
-    ' http://localhost:{}/bigobj 2>> log.txt | ./check_ramp {}'
-    .format(ts.Variables.port, obj_kilobytes)
+    'curl --verbose --ipv4 --http1.1 --header "Host: localhost"'
+    f' http://localhost:{ts.Variables.port}/bigobj 2>> log.txt |'
+    f' ./check_ramp {obj_kilobytes}'
 )
 tr.Processes.Default.ReturnCode = 0
 
-# GET bigobj -- TLS, HTTP 1.1, IPv4
-#
-tr = Test.AddTestRun()
+tr = Test.AddTestRun("GET bigobj: TLS, HTTP/1.1, IPv4")
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http1.1 --insecure --header "Host: localhost"' +
-    ' https://localhost:{}/bigobj 2>> log.txt | ./check_ramp {}'
-    .format(ts.Variables.ssl_port, obj_kilobytes)
+    'curl --verbose --ipv4 --http1.1 --insecure --header "Host: localhost"'
+    f' https://localhost:{ts.Variables.ssl_port}/bigobj 2>> log.txt |'
+    f' ./check_ramp {obj_kilobytes}'
 )
 tr.Processes.Default.ReturnCode = 0
 
-# GET bigobj -- TLS, HTTP 2, IPv4
-#
-tr = Test.AddTestRun()
+tr = Test.AddTestRun("GET bigobj: TLS, HTTP/2, IPv4")
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http2 --insecure --header "Host: localhost"' +
-    ' https://localhost:{}/bigobj 2>> log.txt | ./check_ramp {}'
-    .format(ts.Variables.ssl_port, obj_kilobytes)
+    'curl --verbose --ipv4 --http2 --insecure --header "Host: localhost"'
+    f' https://localhost:{ts.Variables.ssl_port}/bigobj 2>> log.txt |'
+    f' ./check_ramp {obj_kilobytes}'
 )
 tr.Processes.Default.ReturnCode = 0
 
-# GET bigobj -- TLS, HTTP 2, IPv6
-#
-tr = Test.AddTestRun()
+tr = Test.AddTestRun("GET bigobj: TLS, HTTP/2, IPv6")
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv6 --http2 --insecure --header "Host: localhost"' +
-    ' https://localhost:{}/bigobj 2>> log.txt | ./check_ramp {}'
-    .format(ts.Variables.ssl_portv6, obj_kilobytes)
+    'curl --verbose --ipv6 --http2 --insecure --header "Host: localhost"'
+    f' https://localhost:{ts.Variables.ssl_portv6}/bigobj 2>> log.txt |'
+    f' ./check_ramp {obj_kilobytes}'
 )
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = "sed 's/0</0\\\n</' log.txt | grep -F 200 | grep -F HTTP > log2.txt"
 tr.Processes.Default.ReturnCode = 0
+
+# Verify that PUSH requests are rejected when push_method_enabled is 0 (the
+# default configuration).
+ts = Test.MakeATSProcess("ts2", enable_tls=True)
+ts.addDefaultSSLFiles()
+
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http|dns|cache',
+    'proxy.config.http.cache.required_headers': 0,  # No required headers for caching
+    'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
+    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+    'proxy.config.url_remap.remap_required': 0
+})
+
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)
+
+ts.Disk.remap_config.AddLine(
+    'map https://localhost http://localhost'
+)
+
+tr = Test.AddTestRun("PUSH request is rejected when push_method_enabled is 0")
+tr.Processes.Default.StartBefore(ts)
+tr.Processes.Default.Command = (
+    f'./push_request {obj_kilobytes} | nc localhost {ts.Variables.port}'
+)
+tr.Processes.Default.ReturnCode = 1
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    "403 Access Denied",
+    "The PUSH request should have received a 403 response."
+)

--- a/tests/gold_tests/ip_allow/ip_allow.test.py
+++ b/tests/gold_tests/ip_allow/ip_allow.test.py
@@ -86,6 +86,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'ip-allow',
+    'proxy.config.http.push_method_enabled': 1,
     'proxy.config.http.connect_ports': '{0}'.format(server.Variables.SSL_Port),
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),

--- a/tests/gold_tests/proxy_protocol/proxy_serve_stale.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_serve_stale.test.py
@@ -45,6 +45,7 @@ class ProxyServeStaleTest:
         self.ts_child = Test.MakeATSProcess("ts_child")
         # Config child proxy to route to parent proxy
         self.ts_child.Disk.records_config.update({
+            'proxy.config.http.push_method_enabled': 1,
             'proxy.config.http.parent_proxy.fail_threshold': 2,
             'proxy.config.http.parent_proxy.total_connect_attempts': 1,
             'proxy.config.http.cache.max_stale_age': 10,

--- a/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
@@ -28,6 +28,7 @@ Test.testName = "STALE"
 
 # Config child proxy to route to parent proxy
 ts_child.Disk.records_config.update({
+    'proxy.config.http.push_method_enabled': 1,
     'proxy.config.url_remap.pristine_host_hdr': 1,
     'proxy.config.http.cache.max_stale_age': 10,
     'proxy.config.http.parent_proxy.self_detect': 0,
@@ -42,6 +43,7 @@ ts_child.Disk.remap_config.AddLine(
 
 # Configure parent proxy
 ts_parent.Disk.records_config.update({
+    'proxy.config.http.push_method_enabled': 1,
     'proxy.config.url_remap.pristine_host_hdr': 1,
     'proxy.config.http.cache.max_stale_age': 10,
     'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",


### PR DESCRIPTION
proxy.config.http.push_method_enabled. This adds back the enforcemenent of this configuration so that hosts can only PUSH when proxy.config.http.push_method_enabled is 1.