### PR TITLE
Initialize signature in aws plugin, for Coverity

### DIFF
--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -740,7 +740,7 @@ AwsAuthV4::getAuthorizationHeader()
   std::cout << "<StringToSign>" << stringToSign << "</StringToSign>" << std::endl;
 #endif
 
-  char signature[EVP_MAX_MD_SIZE];
+  char signature[EVP_MAX_MD_SIZE] = "";
   size_t signatureLen =
     getSignature(_awsSecretAccessKey, _awsSecretAccessKeyLen, awsRegion.c_str(), awsRegion.length(), _awsService, _awsServiceLen,
                  _dateTime, 8, stringToSign.c_str(), stringToSign.length(), signature, EVP_MAX_MD_SIZE);


### PR DESCRIPTION
Coverity 1497384: Uninitialized scalar variable (UNINIT)