### PR TITLE
coverity 1497349: use after free

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -486,15 +486,16 @@ SSLConfigParams::initialize()
   // ++++++++++++++++++++++++ Client part ++++++++++++++++++++
   client_verify_depth = 7;
 
-  char *verify_server = nullptr;
-  REC_ReadConfigStringAlloc(verify_server, "proxy.config.ssl.client.verify.server.policy");
-  this->SetServerPolicy(verify_server);
-  ats_free(verify_server);
+  char *verify_server_policy = nullptr;
+  REC_ReadConfigStringAlloc(verify_server_policy, "proxy.config.ssl.client.verify.server.policy");
+  this->SetServerPolicy(verify_server_policy);
+  ats_free(verify_server_policy);
   REC_RegisterConfigUpdateFunc("proxy.config.ssl.client.verify.server.policy", UpdateServerPolicy, nullptr);
 
-  REC_ReadConfigStringAlloc(verify_server, "proxy.config.ssl.client.verify.server.properties");
-  this->SetServerPolicyProperties(verify_server);
-  ats_free(verify_server);
+  char *verify_server_properties = nullptr;
+  REC_ReadConfigStringAlloc(verify_server_properties, "proxy.config.ssl.client.verify.server.properties");
+  this->SetServerPolicyProperties(verify_server_properties);
+  ats_free(verify_server_properties);
   REC_RegisterConfigUpdateFunc("proxy.config.ssl.client.verify.server.properties", UpdateServerPolicyProperties, nullptr);
 
   ssl_client_cert_filename = nullptr;


### PR DESCRIPTION
Switched to use a unique name instead of freeing the pointer and reuseing the old variable name.  Looks like a false positive.