### PR TITLE
parent selection coverity driven fixes

### DIFF
--- a/proxy/ParentConsistentHash.cc
+++ b/proxy/ParentConsistentHash.cc
@@ -233,8 +233,8 @@ ParentConsistentHash::selectParent(bool first_call, ParentResult *result, Reques
       // check if the host is retryable.  It's retryable if the retry window has elapsed
       // and the global host status is HOST_STATUS_UP
       if (pRec && !pRec->available.load() && host_stat == TS_HOST_STATUS_UP) {
-        Debug("parent_select", "Parent.failedAt = %u, retry = %u, xact_start = %u", static_cast<unsigned>(pRec->failedAt.load()),
-              static_cast<unsigned>(retry_time), static_cast<unsigned>(request_info->xact_start));
+        Debug("parent_select", "Parent.failedAt = %jd, retry = %u, xact_start = %jd", pRec->failedAt.load(), retry_time,
+              request_info->xact_start);
         if ((pRec->failedAt.load() + retry_time) < request_info->xact_start) {
           parentRetry = true;
           // make sure that the proper state is recorded in the result structure

--- a/proxy/ParentSelection.cc
+++ b/proxy/ParentSelection.cc
@@ -560,7 +560,6 @@ ParentRecord::ProcessParents(char *val, bool isPrimary)
         this->secondary_parents[i].name = this->secondary_parents[i].hash_string;
       }
     }
-    tmp3 = nullptr;
   }
 
   if (isPrimary) {
@@ -805,7 +804,7 @@ ParentRecord::Init(matcher_line *line_info)
     // record SCHEME modifier if present.
     // NULL if not present
     this->scheme = this->getSchemeModText();
-    if (this->scheme != nullptr) {
+    if (this->scheme != nullptr && this->parents != nullptr) {
       // update parent entries' schemes
       for (int j = 0; j < num_parents; j++) {
         this->parents[j].scheme = this->scheme;

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -327,9 +327,9 @@ private:
 };
 
 struct ParentSelectionPolicy {
-  int32_t ParentRetryTime;
-  int32_t ParentEnable;
-  int32_t FailThreshold;
+  int32_t ParentRetryTime = 0;
+  int32_t ParentEnable    = 0;
+  int32_t FailThreshold   = 0;
   ParentSelectionPolicy();
 };
 


### PR DESCRIPTION
Coverity 1497257: Use of 32-bit time_t (Y2K38_SAFETY)
Coverity 1021963: Dereference after null check (FORWARD_NULL)
Coverity 1497443: Uninitialized scalar field (UNINIT_CTOR)
Coverity 1512730: Unused value (UNUSED_VALUE)