### PR TITLE
Add support for jemalloc in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,10 @@ CHECK_INCLUDE_FILE(arpa/nameser_compat.h HAVE_ARPA_NAMESER_COMPAT_H)
 CHECK_INCLUDE_FILE(siginfo.h HAVE_SIGINFO_H)
 
 # Find libraries
+find_package(jemalloc)
+if(jemalloc_FOUND)
+    set(TS_HAS_JEMALLOC TRUE)
+endif()
 find_package(hwloc)
 if(hwloc_FOUND)
     set(TS_USE_HWLOC TRUE)

--- a/cmake/Findjemalloc.cmake
+++ b/cmake/Findjemalloc.cmake
@@ -1,0 +1,49 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# Findjemalloc.cmake
+#
+# This will define the following variables
+#
+#     jemalloc_FOUND
+#     jemalloc_LIBRARY
+#     jemalloc_INCLUDE_DIRS
+#
+# and the following imported targets
+#
+#     jemalloc::jemalloc
+#
+
+find_library(jemalloc_LIBRARY NAMES jemalloc)
+find_path(jemalloc_INCLUDE_DIR NAMES jemalloc.h PATH_SUFFIXES jemalloc)
+
+mark_as_advanced(jemalloc_FOUND jemalloc_LIBRARY jemalloc_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(jemalloc
+    REQUIRED_VARS jemalloc_LIBRARY jemalloc_INCLUDE_DIR
+)
+
+if(jemalloc_FOUND)
+    set(jemalloc_INCLUDE_DIRS ${jemalloc_INCLUDE_DIR})
+endif()
+
+if(jemalloc_FOUND AND NOT TARGET jemalloc::jemalloc)
+    add_library(jemalloc::jemalloc INTERFACE IMPORTED)
+    target_include_directories(jemalloc::jemalloc INTERFACE ${jemalloc_INCLUDE_DIRS})
+    target_link_libraries(jemalloc::jemalloc INTERFACE ${jemalloc_LIBRARY})
+endif()

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -104,6 +104,7 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 #define TS_MAX_HOST_NAME_LEN @TS_MAX_HOST_NAME_LEN@
 
 /* Feature Flags */
+#cmakedefine01 TS_HAS_JEMALLOC
 #cmakedefine01 TS_USE_EPOLL
 #cmakedefine01 TS_USE_HWLOC
 #cmakedefine01 TS_USE_KQUEUE

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -108,6 +108,7 @@ target_include_directories(tscore PRIVATE
 )
 target_link_libraries(tscore
     PUBLIC
+        $<$<BOOL:TS_HAS_JEMALLOC>:jemalloc::jemalloc>
         $<$<BOOL:TS_USE_HWLOC>:hwloc::hwloc>
         libswoc
         ${OPENSSL_LIBRARIES}


### PR DESCRIPTION
It looks like jemalloc is only included in libtscore. Detecting support of jemalloc is one of the prerequisites for building traffic_layout, which in turn is necessary to run autests.