### PR TITLE
Add esi plugin and tests to CMake build

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,4 +27,7 @@ add_subdirectory(fastlz)
 add_subdirectory(swoc)
 set(SWOC_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/lib/swoc/include PARENT_SCOPE)
 
+add_library(catch2::catch2 INTERFACE IMPORTED GLOBAL)
+target_include_directories(catch2::catch2 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/catch2")
+
 install(TARGETS libswoc yaml-cpp fastlz)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(cachekey)
 add_subdirectory(certifier)
 add_subdirectory(compress)
 add_subdirectory(conf_remap)
+add_subdirectory(esi)
 
 add_subdirectory(generator)
 add_subdirectory(xdebug)

--- a/plugins/esi/CMakeLists.txt
+++ b/plugins/esi/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_subdirectory(common)
+add_subdirectory(fetcher)
+add_subdirectory(lib)
+
+add_atsplugin(esi
+    esi.cc
+    serverIntercept.cc
+)
+target_link_libraries(esi PRIVATE esi-common esicore fetcher)
+target_include_directories(esi PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_atsplugin(combo_handler
+    combo_handler.cc
+)
+
+target_link_libraries(combo_handler PRIVATE esicore fetcher)
+target_include_directories(combo_handler PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_subdirectory(test)

--- a/plugins/esi/Makefile.inc
+++ b/plugins/esi/Makefile.inc
@@ -131,7 +131,8 @@ esi_vars_test_CXXFLAGS = $(ESI_CXXFLAGS)
 esi_vars_test_LDADD = esi/libtest.la -lz
 esi_vars_test_SOURCES = esi/test/vars_test.cc
 
-esi_gzip_test_CPPFLAGS = $(ESI_CPPFLAGS)
+esi_gzip_test_CPPFLAGS = $(ESI_CPPFLAGS) \
+        -I$(abs_top_srcdir)/lib/catch2
 esi_gzip_test_CXXFLAGS = $(ESI_CXXFLAGS)
 esi_gzip_test_LDADD = esi/libtest.la -lz
 esi_gzip_test_SOURCES = esi/test/gzip_test.cc

--- a/plugins/esi/common/CMakeLists.txt
+++ b/plugins/esi/common/CMakeLists.txt
@@ -1,0 +1,6 @@
+find_package(ZLIB REQUIRED)
+
+add_library(esi-common DocNode.cc gzip.cc Utils.cc)
+target_link_libraries(esi-common PRIVATE ZLIB::ZLIB)
+target_include_directories(esi-common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+set_target_properties(esi-common PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/plugins/esi/fetcher/CMakeLists.txt
+++ b/plugins/esi/fetcher/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(fetcher HttpDataFetcherImpl.cc)
+target_link_libraries(fetcher PUBLIC esi-common)
+target_include_directories(fetcher PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+set_target_properties(fetcher PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/plugins/esi/lib/CMakeLists.txt
+++ b/plugins/esi/lib/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(esicore
+        EsiGunzip.cc
+        EsiGzip.cc
+        EsiParser.cc
+        EsiProcessor.cc
+        Expression.cc
+        Stats.cc
+        Variables.cc
+)
+target_link_libraries(esicore PUBLIC esi-common fetcher)
+target_include_directories(esicore
+    PUBLIC
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+set_target_properties(esicore PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/plugins/esi/test/CMakeLists.txt
+++ b/plugins/esi/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_library(esitest
+    print_funcs.cc
+    HandlerMap.cc
+    StubIncludeHandler.cc
+    TestHandlerManager.cc
+)
+target_link_libraries(esitest PUBLIC esi-common esicore)
+
+macro(ADD_ESI_TEST NAME)
+    add_executable(${NAME} ${ARGN})
+    target_link_libraries(${NAME} PRIVATE esitest)
+    add_test(NAME ${NAME}_esi COMMAND $<TARGET_FILE:${NAME}>)
+endmacro()
+
+add_esi_test(test_docnode docnode_test.cc)
+target_link_libraries(test_docnode PRIVATE esi-common esicore)
+add_esi_test(test_parser parser_test.cc)
+target_link_libraries(test_parser PRIVATE esi-common esicore)
+add_esi_test(test_processor processor_test.cc)
+target_link_libraries(test_processor PRIVATE esi-common esicore)
+add_esi_test(test_utils utils_test.cc)
+target_link_libraries(test_utils PRIVATE esi-common)
+add_esi_test(test_vars vars_test.cc)
+target_link_libraries(test_vars PRIVATE esi-common esicore)
+add_esi_test(test_gzip gzip_test.cc)
+target_link_libraries(test_gzip PRIVATE catch2::catch2 esi-common)

--- a/plugins/esi/test/gzip_test.cc
+++ b/plugins/esi/test/gzip_test.cc
@@ -21,57 +21,55 @@
   limitations under the License.
  */
 
-#include <iostream>
-#include <cassert>
 #include <string>
 #include <cstring>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
 
 #include "print_funcs.h"
 #include "Utils.h"
 #include "gzip.h"
 
-using std::cout;
-using std::cerr;
-using std::endl;
 using std::string;
 using namespace EsiLib;
 
-int
-main()
+TEST_CASE("test esi plugin - gzip")
 {
   Utils::init(&Debug, &Error);
 
+  SECTION("===================== Test 1")
   {
-    cout << endl << "===================== Test 1" << endl;
     const char expected_cdata[] = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xf3\x48\xcd\xc9\xc9\x57\x08\xcf\x2f\xca\x49\x51\x04\x00"
                                   "\xa3\x1c\x29\x1c\x0c\x00\x00\x00";
     const char expected_data[]  = "Hello World!";
 
     string cdata;
     // check output of gzip
-    assert(gzip(expected_data, 12, cdata));
+    REQUIRE(gzip(expected_data, 12, cdata));
 
     // check the size of compressed data
-    assert(cdata.size() == 32);
+    REQUIRE(cdata.size() == 32);
 
     // check the content of compressed data
-    assert(strncmp(expected_cdata, cdata.c_str(), cdata.size()) == 0);
+    REQUIRE(strncmp(expected_cdata, cdata.c_str(), cdata.size()) == 0);
 
     BufferList buf_list;
     string data;
     // check output of gunzip
-    assert(gunzip(expected_cdata, 32, buf_list));
+    REQUIRE(gunzip(expected_cdata, 32, buf_list));
     data = (buf_list.begin())->data();
+    data = buf_list.front();
 
     // check the size of uncompressed data
-    assert(data.size() == 12);
+    REQUIRE(data.size() == 12);
 
     // check the content of uncompressed data
-    assert(strncmp(expected_data, data.c_str(), data.size()) == 0);
+    CHECK(strncmp(expected_data, data.c_str(), data.size()) == 0);
   }
 
+  SECTION("===================== Test 2")
   {
-    cout << endl << "===================== Test 2" << endl;
     // OS_TYPE (byte[9]) is 0
     const char expected_cdata[] = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00\xf3\x48\xcd\xc9\xc9\x57\x08\xcf\x2f\xca\x49\x51\x04\x00"
                                   "\xa3\x1c\x29\x1c\x0c\x00\x00\x00";
@@ -80,37 +78,32 @@ main()
     BufferList buf_list;
     string data;
     // check output of gunzip
-    assert(gunzip(expected_cdata, 32, buf_list));
+    REQUIRE(gunzip(expected_cdata, 32, buf_list));
     data = (buf_list.begin())->data();
 
     // check the size of uncompressed data
-    assert(data.size() == 12);
+    REQUIRE(data.size() == 12);
 
     // check the content of uncompressed data
-    assert(strncmp(expected_data, data.c_str(), data.size()) == 0);
+    CHECK(strncmp(expected_data, data.c_str(), data.size()) == 0);
   }
 
+  SECTION("invalid compressed data - too short")
   {
-    cout << endl << "===================== Test 3" << endl;
-    // invalid compressed data - too short
     const char expected_cdata[] = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xa3\x1c\x29\x1c\x0c\x00\x00\x00";
 
     BufferList buf_list;
     // check output of gunzip
-    assert(gunzip(expected_cdata, 17, buf_list) == false);
+    CHECK(gunzip(expected_cdata, 17, buf_list) == false);
   }
 
+  SECTION("invalid magic byte")
   {
-    cout << endl << "===================== Test 4" << endl;
-    // invalid magic byte
     const char expected_cdata[] = "\x1f\x8c\x08\x00\x00\x00\x00\x00\x00\x00\xf3\x48\xcd\xc9\xc9\x57\x08\xcf\x2f\xca\x49\x51\x04\x00"
                                   "\xa3\x1c\x29\x1c\x0c\x00\x00\x00";
 
     BufferList buf_list;
     // check output of gunzip
-    assert(gunzip(expected_cdata, 32, buf_list) == false);
+    CHECK(gunzip(expected_cdata, 32, buf_list) == false);
   }
-
-  cout << endl << "All tests passed!" << endl;
-  return 0;
 }


### PR DESCRIPTION
This compiles the esi plugin and registers all its tests with CTest. The functionality of the installed plugin cannot be easily verified because autest does not work with the CMake install yet.