### PR TITLE
Remove TS_HAS_LIBZ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 find_package(PCRE)
 include(FindOpenSSL)
 find_package(OpenSSL)
+find_package(ZLIB REQUIRED)
 
 # Find ccache
 include(find_ccache)

--- a/doc/developer-guide/testing/blackbox-testing.en.rst
+++ b/doc/developer-guide/testing/blackbox-testing.en.rst
@@ -234,7 +234,6 @@ Condition Testing
     - ``Condition.HasATSFeature(feature)``
         This function tests TrafficServer for possible features it has been compiled with. Current features you can test for are:
 
-        - TS_HAS_LIBZ
         - TS_HAS_LZMA
         - TS_HAS_PIPE_BUFFER_SIZE_CONFIG
         - TS_HAS_JEMALLOC

--- a/iocore/cache/CMakeLists.txt
+++ b/iocore/cache/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(inkcache STATIC
     RamCacheLRU.cc
     Store.cc
 )
+target_link_libraries(inkcache PRIVATE ZLIB::ZLIB)
 target_include_directories(inkcache PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/eventsystem
         ${CMAKE_SOURCE_DIR}/iocore/io_uring

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -1037,9 +1037,6 @@ CacheProcessor::cacheInitialized()
       case CACHE_COMPRESSION_FASTLZ:
         break;
       case CACHE_COMPRESSION_LIBZ:
-#ifndef HAVE_ZLIB_H
-        Fatal("libz not available for RAM cache compression");
-#endif
         break;
       case CACHE_COMPRESSION_LIBLZMA:
 #ifndef HAVE_LZMA_H

--- a/iocore/cache/RamCacheCLFUS.cc
+++ b/iocore/cache/RamCacheCLFUS.cc
@@ -27,9 +27,7 @@
 #include "P_Cache.h"
 #include "I_Tasks.h"
 #include "fastlz/fastlz.h"
-#ifdef HAVE_ZLIB_H
 #include <zlib.h>
-#endif
 #ifdef HAVE_LZMA_H
 #include <lzma.h>
 #endif
@@ -157,9 +155,7 @@ RamCacheCLFUSCompressor::mainEvent(int /* event ATS_UNUSED */, Event *e)
   case CACHE_COMPRESSION_FASTLZ:
     break;
   case CACHE_COMPRESSION_LIBZ:
-#ifndef HAVE_ZLIB_H
     Warning("libz not available for RAM cache compression");
-#endif
     break;
   case CACHE_COMPRESSION_LIBLZMA:
 #ifndef HAVE_LZMA_H
@@ -278,7 +274,6 @@ RamCacheCLFUS::get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint64_t auxkey
             ram_hit_state = RAM_HIT_COMPRESS_FASTLZ;
             break;
           }
-#ifdef HAVE_ZLIB_H
           case CACHE_COMPRESSION_LIBZ: {
             uLongf l = e->len;
             if (Z_OK !=
@@ -288,7 +283,6 @@ RamCacheCLFUS::get(CryptoHash *key, Ptr<IOBufferData> *ret_data, uint64_t auxkey
             ram_hit_state = RAM_HIT_COMPRESS_LIBZ;
             break;
           }
-#endif
 #ifdef HAVE_LZMA_H
           case CACHE_COMPRESSION_LIBLZMA: {
             size_t l = static_cast<size_t>(e->len), ipos = 0, opos = 0;
@@ -454,11 +448,9 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
       case CACHE_COMPRESSION_FASTLZ:
         l = static_cast<uint32_t>(static_cast<double>(e->len) * 1.05 + 66);
         break;
-#ifdef HAVE_ZLIB_H
       case CACHE_COMPRESSION_LIBZ:
         l = static_cast<uint32_t>(compressBound(e->len));
         break;
-#endif
 #ifdef HAVE_LZMA_H
       case CACHE_COMPRESSION_LIBLZMA:
         l = e->len;
@@ -483,7 +475,6 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
           failed = true;
         }
         break;
-#ifdef HAVE_ZLIB_H
       case CACHE_COMPRESSION_LIBZ: {
         uLongf ll = l;
         if ((Z_OK != compress(reinterpret_cast<Bytef *>(b), &ll, reinterpret_cast<Bytef *>(edata->data()), elen))) {
@@ -492,7 +483,6 @@ RamCacheCLFUS::compress_entries(EThread *thread, int do_at_most)
         l = static_cast<int>(ll);
         break;
       }
-#endif
 #ifdef HAVE_LZMA_H
       case CACHE_COMPRESSION_LIBLZMA: {
         size_t pos = 0, ll = l;

--- a/plugins/esi/common/CMakeLists.txt
+++ b/plugins/esi/common/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(ZLIB REQUIRED)
-
 add_library(esi-common DocNode.cc gzip.cc Utils.cc)
 target_link_libraries(esi-common PRIVATE ZLIB::ZLIB)
 target_include_directories(esi-common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -35,9 +35,7 @@
 #include <hwloc.h>
 #endif
 
-#if HAVE_ZLIB_H
 #include <zlib.h>
-#endif
 
 #if HAVE_LZMA_H
 #include <lzma.h>
@@ -79,11 +77,6 @@ produce_features(bool json)
   print_feature("BUILD_PERSON", BUILD_PERSON, json);
   print_feature("BUILD_GROUP", BUILD_GROUP, json);
   print_feature("BUILD_NUMBER", BUILD_NUMBER, json);
-#if HAVE_ZLIB_H
-  print_feature("TS_HAS_LIBZ", 1, json);
-#else
-  print_feature("TS_HAS_LIBZ", 0, json);
-#endif
 #if HAVE_LZMA_H
   print_feature("TS_HAS_LZMA", 1, json);
 #else
@@ -187,6 +180,7 @@ produce_versions(bool json)
     printf("{\n");
   }
 
+  print_var("libz", LBW().print("{}", ZLIB_VERSION).view(), json);
   print_var("openssl", LBW().print("{:#x}", OPENSSL_VERSION_NUMBER).view(), json);
   print_var("openssl_str", LBW().print(OPENSSL_VERSION_TEXT).view(), json);
   print_var("pcre", LBW().print("{}.{}", PCRE_MAJOR, PCRE_MINOR).view(), json);
@@ -196,11 +190,6 @@ produce_versions(bool json)
   print_var("hwloc.run", LBW().print("{:#x}", hwloc_get_api_version()).view(), json);
 #else
   print_var("hwloc", undef, json);
-#endif
-#if HAVE_ZLIB_H
-  print_var("libz", LBW().print("{}", ZLIB_VERSION).view(), json);
-#else
-  print_var("libz", undef, json);
 #endif
 #if HAVE_LZMA_H
   print_var("lzma", LBW().print("{}", LZMA_VERSION_STRING).view(), json);

--- a/tests/README.md
+++ b/tests/README.md
@@ -293,7 +293,6 @@ ts.Disk.remap_config.AddLine(
  * feature - The feature to test for
 
  This function tests for Traffic server for possible feature it has been compiled with. Current Features you can test for are:
- * TS_HAS_LIBZ
  * TS_HAS_LZMA
  * TS_HAS_PIPE_BUFFER_SIZE_CONFIG
  * TS_HAS_JEMALLOC


### PR DESCRIPTION
Zlib is required to compile ATS. We don't need to keep this option around.