### PR TITLE
Add TSHttpTxnNextHopPortGet, add NEXT-HOP to header rewrite

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -236,6 +236,32 @@ Per-Mapping`_ above.
 The ``<part>`` allows the operand to match against just a component of the URL,
 as documented in `URL Parts`_ below.
 
+NEXT-HOP
+~~~~~~~~
+::
+
+    cond %{NEXT-HOP:<part>} <operand>
+
+Returns next hop current selected parent information.  The following qualifiers
+are supported::
+
+    %{NEXT-HOP:HOST} Name of the current selected parent.
+    %{NEXT-HOP:PORT} Port of the current selected parent.
+
+Note that the ``<part>`` of NEXT-HOP will likely not be available unless
+an origin server connection is attempted at which point it will available
+as part of the ``SEND_REQUEST_HDR_HOOK``.
+
+For example::
+
+    cond %{SEND_RESPONSE_HDR_HOOK} [AND]
+    cond %{NEXT-HOP:HOST} =www.firstparent.com
+        set-header HOST vhost.firstparent.com
+
+    cond %{SEND_RESPONSE_HDR_HOOK} [AND]
+    cond %{NEXT-HOP:HOST} =www.secondparent.com
+        set-header HOST vhost.secondparent.com
+
 GEO
 ~~~
 ::

--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -1962,6 +1962,27 @@ Here is an example:
 
 `TOP <#ts-lua-plugin>`_
 
+ts.server_request.server_addr.get_nexthop_port
+----------------------------------------------
+**syntax:** *ts.server_request.server_addr.get_nexthop_port()*
+
+**context:** function @ TS_LUA_HOOK_SEND_REQUEST_HDR hook point or later
+
+**description**: This function can be used to get the port name of the next hop to the origin server.
+
+The ts.server_request.server_addr.get_nexthop_port function returns the port as an integer .
+
+Here is an example:
+
+::
+
+    function do_global_send_request()
+        port = ts.server_request.server_addr.get_nexthop_port()
+        print(name)             -- test
+    end
+
+`TOP <#ts-lua-plugin>`_
+
 ts.sha256
 ---------
 **syntax:** *digest = ts.sha256(str)*

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopPortGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopPortGet.en.rst
@@ -1,0 +1,42 @@
+.. Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed
+   with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache
+   License, Version 2.0 (the "License"); you may not use this file
+   except in compliance with the License.  You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied.  See the License for the specific language governing
+   permissions and limitations under the License.
+
+.. include:: ../../../common.defs
+
+.. default-domain:: c
+
+TSHttpTxnNextHopPortGet
+***********************
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: const char *TSHttpTxnNextHopPortGet(TSHttpTxn txnp)
+
+Description
+===========
+
+Get the next hop port for transaction :arg:`txnp`.
+
+.. note::
+
+   The pointer is valid only for the current callback. Clients that
+   need to keep the value across callbacks must maintain their own
+   storage.

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopPortGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopPortGet.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: const char *TSHttpTxnNextHopPortGet(TSHttpTxn txnp)
+.. function:: int TSHttpTxnNextHopPortGet(TSHttpTxn txnp)
 
 Description
 ===========

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1491,6 +1491,16 @@ tsapi struct sockaddr const *TSHttpTxnNextHopAddrGet(TSHttpTxn txnp);
 */
 tsapi const char *TSHttpTxnNextHopNameGet(TSHttpTxn txnp);
 
+/** Get the next hop port.
+ *
+    Retrieves the next hop parent port.
+                Returns -1 if not valid.
+
+    @return The port of the next hop for transaction @a txnp.
+
+ */
+tsapi int TSHttpTxnNextHopPortGet(TSHttpTxn txnp);
+
 tsapi TSReturnCode TSHttpTxnClientFdGet(TSHttpTxn txnp, int *fdp);
 tsapi TSReturnCode TSHttpTxnOutgoingAddrSet(TSHttpTxn txnp, struct sockaddr const *addr);
 tsapi TSReturnCode TSHttpTxnOutgoingTransparencySet(TSHttpTxn txnp, int flag);

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -291,7 +291,7 @@ ConditionUrl::append_value(std::string &s, const Resources &res)
     // CLIENT always uses the pristine URL
     TSDebug(PLUGIN_NAME, "   Using the pristine url");
     if (TSHttpTxnPristineUrlGet(res.txnp, &bufp, &url) != TS_SUCCESS) {
-      TSError("[header_rewrite] Error getting the pristine URL");
+      TSError("[%s] Error getting the pristine URL", PLUGIN_NAME);
       return;
     }
   } else if (res._rri != nullptr) {
@@ -307,7 +307,7 @@ ConditionUrl::append_value(std::string &s, const Resources &res)
       TSDebug(PLUGIN_NAME, "   Using the to url");
       url = res._rri->mapToUrl;
     } else {
-      TSError("[header_rewrite] Invalid option value");
+      TSError("[%s] Invalid option value", PLUGIN_NAME);
       return;
     }
   } else {
@@ -315,11 +315,11 @@ ConditionUrl::append_value(std::string &s, const Resources &res)
       bufp           = res.bufp;
       TSMLoc hdr_loc = res.hdr_loc;
       if (TSHttpHdrUrlGet(bufp, hdr_loc, &url) != TS_SUCCESS) {
-        TSError("[header_rewrite] Error getting the URL");
+        TSError("[%s] Error getting the URL", PLUGIN_NAME);
         return;
       }
     } else {
-      TSError("[header_rewrite] Rule not supported at this hook");
+      TSError("[%s] Rule not supported at this hook", PLUGIN_NAME);
       return;
     }
   }
@@ -398,7 +398,7 @@ ConditionDBM::initialize(Parser &p)
     //   TSDebug(PLUGIN_NAME, "Opened DBM file %s", _file.c_str());
     //   _key.set_value(_qualifier.substr(pos + 1));
     // } else {
-    //   TSError("Failed to open DBM file: %s", _file.c_str());
+    //   TSError("[%s] Failed to open DBM file: %s", PLUGIN_NAME, _file.c_str());
     // }
   } else {
     TSError("[%s] Malformed DBM condition", PLUGIN_NAME);
@@ -616,6 +616,7 @@ ConditionIp::append_value(std::string &s, const Resources &res)
     ip_set = (nullptr != getIP(TSHttpTxnServerAddrGet(res.txnp), ip));
     break;
   case IP_QUAL_OUTBOUND:
+    TSDebug(PLUGIN_NAME, "Requesting output ip");
     ip_set = (nullptr != getIP(TSHttpTxnOutgoingAddrGet(res.txnp), ip));
     break;
   }
@@ -1381,4 +1382,55 @@ ConditionCache::append_value(std::string &s, const Resources &res)
 
     s += names[status];
   }
+}
+
+// ConditionNextHop: request header.
+void
+ConditionNextHop::initialize(Parser &p)
+{
+  Condition::initialize(p);
+
+  MatcherType *match = new MatcherType(_cond_op);
+  match->set(p.get_arg());
+  _matcher = match;
+}
+
+void
+ConditionNextHop::set_qualifier(const std::string &q)
+{
+  Condition::set_qualifier(q);
+  TSDebug(PLUGIN_NAME, "\tParsing %%{NEXT-HOP:%s}", q.c_str());
+  _next_hop_qual = parse_next_hop_qualifier(q);
+}
+
+void
+ConditionNextHop::append_value(std::string &s, const Resources &res)
+{
+  switch (_next_hop_qual) {
+  case NEXT_HOP_HOST: {
+    char const *const name = TSHttpTxnNextHopNameGet(res.txnp);
+    if (nullptr != name) {
+      TSDebug(PLUGIN_NAME, "Appending '%s' to evaluation value", name);
+      s.append(name);
+    } else {
+      TSDebug(PLUGIN_NAME, "NextHopName is empty");
+    }
+  } break;
+  case NEXT_HOP_PORT: {
+    int const port = TSHttpTxnNextHopPortGet(res.txnp);
+    TSDebug(PLUGIN_NAME, "Appending '%d' to evaluation value", port);
+    s.append(std::to_string(port));
+  } break;
+  default:
+    TSReleaseAssert(!"All cases should have been handled");
+    break;
+  }
+}
+
+bool
+ConditionNextHop::eval(const Resources &res)
+{
+  std::string s;
+  append_value(s, res);
+  return static_cast<const Matchers<std::string> *>(_matcher)->test(s);
 }

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -604,3 +604,28 @@ public:
 protected:
   bool eval(const Resources &res) override;
 };
+
+// Next Hop
+class ConditionNextHop : public Condition
+{
+  using MatcherType = Matchers<std::string>;
+
+public:
+  enum HostType { NAME, PORT };
+
+  explicit ConditionNextHop() { TSDebug(PLUGIN_NAME_DBG, "Calling CTOR for ConditionNextHop"); }
+
+  // noncopyable
+  ConditionNextHop(const ConditionNextHop &) = delete;
+  void operator=(const ConditionNextHop &)   = delete;
+
+  void initialize(Parser &p) override;
+  void set_qualifier(const std::string &q) override;
+  void append_value(std::string &s, const Resources &res) override;
+
+protected:
+  bool eval(const Resources &res) override;
+
+private:
+  NextHopQualifiers _next_hop_qual = NEXT_HOP_NONE;
+};

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -157,6 +157,8 @@ condition_factory(const std::string &cond)
     c = new ConditionTcpInfo();
   } else if (c_name == "CACHE") {
     c = new ConditionCache();
+  } else if (c_name == "NEXT-HOP") { // This condition adapts to the hook
+    c = new ConditionNextHop();
   } else {
     TSError("[%s] Unknown condition %s", PLUGIN_NAME, c_name.c_str());
     return nullptr;

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -359,7 +359,7 @@ TSPluginInit(int argc, const char *argv[])
       TSDebug(PLUGIN_NAME, "Successfully loaded global config file %s", argv[i]);
       got_config = true;
     } else {
-      TSError("[header_rewrite] failed to parse configuration file %s", argv[i]);
+      TSError("[%s] failed to parse configuration file %s", PLUGIN_NAME, argv[i]);
     }
   }
 

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1089,8 +1089,9 @@ OperatorSetHttpCntl::initialize_hooks()
 }
 
 // This is only for the debug statement, and must be in sync with TSHttpCntlType in apidefs.h.in
-static const char *const HttpCntls[] = {"LOGGING",         "INTERCEPT_RETRY", "RESP_CACHEABLE", "REQ_CACHEABLE",
-                                        "SERVER_NO_STORE", "TXN_DEBUG",       "SKIP_REMAP"};
+static const char *const HttpCntls[] = {
+  "LOGGING", "INTERCEPT_RETRY", "RESP_CACHEABLE", "REQ_CACHEABLE", "SERVER_NO_STORE", "TXN_DEBUG", "SKIP_REMAP",
+};
 void
 OperatorSetHttpCntl::exec(const Resources &res) const
 {

--- a/plugins/header_rewrite/resources.cc
+++ b/plugins/header_rewrite/resources.cc
@@ -56,6 +56,7 @@ Resources::gather(const ResourceIDs ids, TSHttpHookID hook)
     break;
 
   case TS_HTTP_SEND_REQUEST_HDR_HOOK:
+    TSDebug(PLUGIN_NAME, "Processing TS_HTTP_SEND_REQUEST_HDR_HOOK");
     // Read request headers to server
     if (ids & RSRC_SERVER_REQUEST_HEADERS) {
       TSDebug(PLUGIN_NAME, "\tAdding TXN server request header buffers");

--- a/plugins/header_rewrite/statement.cc
+++ b/plugins/header_rewrite/statement.cc
@@ -73,6 +73,23 @@ Statement::initialize_hooks()
   add_allowed_hook(TS_HTTP_TXN_CLOSE_HOOK);
 }
 
+// Parse NextHop qualifiers
+NextHopQualifiers
+Statement::parse_next_hop_qualifier(const std::string &q) const
+{
+  NextHopQualifiers qual = NEXT_HOP_NONE;
+
+  if (q == "HOST") {
+    qual = NEXT_HOP_HOST;
+  } else if (q == "PORT") {
+    qual = NEXT_HOP_PORT;
+  } else {
+    TSError("[%s] Invalid NextHop() qualifier: %s", PLUGIN_NAME, q.c_str());
+  }
+
+  return qual;
+}
+
 // Parse URL qualifiers, this one is special since it's used in a few places.
 UrlQualifiers
 Statement::parse_url_qualifier(const std::string &q) const

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -41,7 +41,13 @@ enum UrlQualifiers {
   URL_QUAL_QUERY,
   URL_QUAL_MATRIX,
   URL_QUAL_SCHEME,
-  URL_QUAL_URL
+  URL_QUAL_URL,
+};
+
+enum NextHopQualifiers {
+  NEXT_HOP_NONE,
+  NEXT_HOP_HOST,
+  NEXT_HOP_PORT,
 };
 
 // NOW data
@@ -53,7 +59,7 @@ enum NowQualifiers {
   NOW_QUAL_HOUR,
   NOW_QUAL_MINUTE,
   NOW_QUAL_WEEKDAY,
-  NOW_QUAL_YEARDAY
+  NOW_QUAL_YEARDAY,
 };
 
 // GEO data
@@ -146,6 +152,7 @@ protected:
   virtual void initialize_hooks();
 
   UrlQualifiers parse_url_qualifier(const std::string &q) const;
+  NextHopQualifiers parse_next_hop_qualifier(const std::string &q) const;
 
   void
   require_resources(const ResourceIDs ids)

--- a/plugins/lua/ts_lua_server_request.c
+++ b/plugins/lua/ts_lua_server_request.c
@@ -84,6 +84,7 @@ static int ts_lua_server_request_server_addr_get_outgoing_port(lua_State *L);
 static int ts_lua_server_request_server_addr_set_outgoing_addr(lua_State *L);
 static int ts_lua_server_request_server_addr_get_nexthop_addr(lua_State *L);
 static int ts_lua_server_request_server_addr_get_nexthop_name(lua_State *L);
+static int ts_lua_server_request_server_addr_get_nexthop_port(lua_State *L);
 
 void
 ts_lua_inject_server_request_api(lua_State *L)
@@ -140,6 +141,9 @@ ts_lua_inject_server_request_server_addr_api(lua_State *L)
 
   lua_pushcfunction(L, ts_lua_server_request_server_addr_get_nexthop_name);
   lua_setfield(L, -2, "get_nexthop_name");
+
+  lua_pushcfunction(L, ts_lua_server_request_server_addr_get_nexthop_port);
+  lua_setfield(L, -2, "get_nexthop_port");
 
   lua_setfield(L, -2, "server_addr");
 
@@ -968,6 +972,18 @@ ts_lua_server_request_server_addr_get_nexthop_name(lua_State *L)
   } else {
     lua_pushstring(L, name);
   }
+
+  return 1;
+}
+
+static int
+ts_lua_server_request_server_addr_get_nexthop_port(lua_State *L)
+{
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+  const int port = TSHttpTxnNextHopPortGet(http_ctx->txnp);
+  lua_pushnumber(L, port);
 
   return 1;
 }

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -5925,6 +5925,20 @@ TSHttpTxnNextHopNameGet(TSHttpTxn txnp)
   return sm->t_state.current.server->name;
 }
 
+int
+TSHttpTxnNextHopPortGet(TSHttpTxn txnp)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  auto sm = reinterpret_cast<HttpSM const *>(txnp);
+  /**
+   * Return -1 if the server structure is not yet constructed.
+   */
+  if (nullptr == sm->t_state.current.server) {
+    return -1;
+  }
+  return sm->t_state.current.server->dst_addr.host_order_port();
+}
+
 TSReturnCode
 TSHttpTxnOutgoingTransparencySet(TSHttpTxn txnp, int flag)
 {

--- a/src/traffic_server/InkAPITest.cc
+++ b/src/traffic_server/InkAPITest.cc
@@ -3054,6 +3054,8 @@ struct SocketTest {
   bool test_server_req_get;
   bool test_server_resp_get;
   bool test_next_hop_ip_get;
+  bool test_next_hop_name_get;
+  bool test_next_hop_port_get;
   bool test_client_protocol_stack_get;
   bool test_client_protocol_stack_contains;
 
@@ -3172,6 +3174,60 @@ checkHttpTxnNextHopIPGet(SocketTest *test, void *data)
     test->test_next_hop_ip_get = false;
     SDK_RPRINT(test->regtest, "TSHttpTxnNextHopIPGet", "TestCase1", TC_FAIL, "Value's Mismatch [expected %0.8x got %0.8x]",
                actual_ip, nexthopip);
+  }
+
+  return TS_EVENT_CONTINUE;
+}
+
+// This func is called by us from mytest_handler to check for TSHttpTxnNextHopNameGet
+static int
+checkHttpTxnNextHopNameGet(SocketTest *test, void *data)
+{
+  TSHttpTxn txnp = static_cast<TSHttpTxn>(data);
+
+  constexpr char const *const exp = "127.0.0.1";
+
+  char const *const name = TSHttpTxnNextHopNameGet(txnp);
+  if (nullptr == name) {
+    test->test_next_hop_name_get = false;
+    SDK_RPRINT(test->regtest, "TSHttpTxnNextHopNameGet", "TestCase1", TC_FAIL, "TSHttpTxnNextHopNameGet returns null/empty host");
+    return TS_EVENT_CONTINUE;
+  }
+
+  if (std::string_view(name) == exp) {
+    test->test_next_hop_name_get = true;
+    SDK_RPRINT(test->regtest, "TSHttpTxnNextHopNameGet", "TestCase1", TC_PASS, "ok");
+  } else {
+    test->test_next_hop_name_get = false;
+    SDK_RPRINT(test->regtest, "TSHttpTxnNextHopNameGet", "TestCase1", TC_FAIL, "Value's Mismatch [expected '%s', got '%s'", exp,
+               name);
+  }
+
+  return TS_EVENT_CONTINUE;
+}
+
+// This func is called by us from mytest_handler to check for TSHttpTxnNextHopPortGet
+static int
+checkHttpTxnNextHopPortGet(SocketTest *test, void *data)
+{
+  TSHttpTxn txnp = static_cast<TSHttpTxn>(data);
+
+  constexpr int const exp = SYNSERVER_LISTEN_PORT;
+
+  int const port = TSHttpTxnNextHopPortGet(txnp);
+  if (port <= 0) {
+    test->test_next_hop_port_get = false;
+    SDK_RPRINT(test->regtest, "TSHttpTxnNextHopPortGet", "TestCase1", TC_FAIL, "TSHttpTxnNextHopPortGet returns '%d'", port);
+    return TS_EVENT_CONTINUE;
+  }
+
+  if (port == exp) {
+    test->test_next_hop_port_get = true;
+    SDK_RPRINT(test->regtest, "TSHttpTxnNextHopPortGet", "TestCase1", TC_PASS, "ok");
+  } else {
+    test->test_next_hop_port_get = false;
+    SDK_RPRINT(test->regtest, "TSHttpTxnNextHopPortGet", "TestCase1", TC_FAIL, "Value's Mismatch [expected '%d', got '%d'", exp,
+               port);
   }
 
   return TS_EVENT_CONTINUE;
@@ -3459,6 +3515,8 @@ mytest_handler(TSCont contp, TSEvent event, void *data)
 
     checkHttpTxnServerReqGet(test, data);
     checkHttpTxnNextHopIPGet(test, data);
+    checkHttpTxnNextHopNameGet(test, data);
+    checkHttpTxnNextHopPortGet(test, data);
     checkHttpTxnClientProtocolStackContains(test, data);
     checkHttpTxnClientProtocolStackGet(test, data);
 
@@ -3526,7 +3584,8 @@ mytest_handler(TSCont contp, TSEvent event, void *data)
       if ((test->test_client_ip_get != true) || (test->test_client_incoming_port_get != true) ||
           (test->test_client_remote_port_get != true) || (test->test_client_req_get != true) ||
           (test->test_client_resp_get != true) || (test->test_server_ip_get != true) || (test->test_server_req_get != true) ||
-          (test->test_server_resp_get != true) || (test->test_next_hop_ip_get != true)) {
+          (test->test_server_resp_get != true) || (test->test_next_hop_ip_get != true) || (test->test_next_hop_name_get != true) ||
+          (test->test_next_hop_port_get != true)) {
         *(test->pstatus) = REGRESSION_TEST_FAILED;
       }
       // transaction is over. clean up.
@@ -3568,6 +3627,8 @@ EXCLUSIVE_REGRESSION_TEST(SDK_API_HttpHookAdd)(RegressionTest *test, int /* atyp
   socktest->test_server_req_get           = false;
   socktest->test_server_resp_get          = false;
   socktest->test_next_hop_ip_get          = false;
+  socktest->test_next_hop_name_get        = false;
+  socktest->test_next_hop_port_get        = false;
   socktest->magic                         = MAGIC_ALIVE;
   TSContDataSet(cont, socktest);
 


### PR DESCRIPTION
This adds TSHttpTxnNextHopPortGet in addition to TSHttpTxnNextHopNameGet and adds to header_rewrite as %{NEXT-HOP:HOST} and %{NEXT-HOP:PORT} for SEND_REQUEST_HDR_HOOK.