### PR TITLE
Allow slice plugin to purge requests

### DIFF
--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -292,6 +292,21 @@ is faster since it does not visit any slices outside those needed to
 fulfill a request.  However this may still cause problems if the
 requested range was calculated from a newer version of the asset.
 
+Purge Requests
+--------------
+
+The slice plugin supports PURGE requests, discarding the requested object from cache.
+If a range is given in the client request, only the slice blocks from the
+requested range will be purged (if in cache). If not, all of the blocks will be discarded
+from the cache.
+
+If a block receives a 404, indicating the requested block to be purged is not in the cache,
+slice will not continue to purge the following blocks.
+
+The functionality works with `--ref-relative` both enabled and disabled. If `--ref-relative` is
+disabled (using slice 0 as the reference block), requesting to PURGE a block that does not have
+slice 0 in its range will still PURGE the slice 0 block, as the reference block is always processed.
+
 Important Notes
 ===============
 

--- a/plugins/experimental/slice/Config.h
+++ b/plugins/experimental/slice/Config.h
@@ -45,9 +45,9 @@ struct Config {
   int m_paceerrsecs{0};   // -1 disable logging, 0 no pacing, max 60s
   int m_prefetchcount{0}; // 0 disables prefetching
   enum RefType { First, Relative };
-  RefType m_reftype{First};       // reference slice is relative to request
-  bool m_head_req{false};         // HEAD request
-  bool m_head_strip_range{false}; // strip range header for head requests
+  RefType m_reftype{First};           // reference slice is relative to request
+  const char *m_method_type{nullptr}; // type of header request
+  bool m_head_strip_range{false};     // strip range header for head requests
 
   std::string m_skip_header;
   std::string m_crr_ims_header;
@@ -69,6 +69,13 @@ struct Config {
   hasRegex() const
   {
     return None != m_regex_type;
+  }
+
+  // Check if response only expects header
+  bool
+  onlyHeader() const
+  {
+    return (m_method_type == TS_HTTP_METHOD_HEAD || m_method_type == TS_HTTP_METHOD_PURGE);
   }
 
   // If no null reg, true, otherwise check against regex

--- a/plugins/experimental/slice/slice.cc
+++ b/plugins/experimental/slice/slice.cc
@@ -41,7 +41,7 @@ read_request(TSHttpTxn txnp, Config *const config)
   hdrmgr.populateFrom(txnp, TSHttpTxnClientReqGet);
   HttpHeader const header(hdrmgr.m_buffer, hdrmgr.m_lochdr);
 
-  if (TS_HTTP_METHOD_GET == header.method() || TS_HTTP_METHOD_HEAD == header.method()) {
+  if (TS_HTTP_METHOD_GET == header.method() || TS_HTTP_METHOD_HEAD == header.method() || TS_HTTP_METHOD_PURGE == header.method()) {
     if (!header.hasKey(config->m_skip_header.data(), config->m_skip_header.size())) {
       // check if any previous plugin has monkeyed with the transaction status
       TSHttpStatus const txnstat = TSHttpTxnStatusGet(txnp);
@@ -50,8 +50,8 @@ read_request(TSHttpTxn txnp, Config *const config)
         return false;
       }
 
-      // set HEAD config to only expect header response
-      config->m_head_req = (TS_HTTP_METHOD_HEAD == header.method());
+      // set header method config to only expect header response
+      config->m_method_type = header.method();
 
       if (config->hasRegex()) {
         int urllen         = 0;

--- a/plugins/experimental/slice/transfer.h
+++ b/plugins/experimental/slice/transfer.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "Data.h"
+#include "Config.h"
 
 /** Functions to deal with the connection to the client.
  * Body content transfers are handled by the client.

--- a/plugins/experimental/slice/util.cc
+++ b/plugins/experimental/slice/util.cc
@@ -80,7 +80,7 @@ request_block(TSCont contp, Data *const data)
   HttpHeader header(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);
 
   // if configured, remove range header from head requests
-  if (data->m_config->m_head_req && data->m_config->m_head_strip_range) {
+  if (data->m_config->m_method_type == TS_HTTP_METHOD_HEAD && data->m_config->m_head_strip_range) {
     header.removeKey(TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
   } else {
     // add/set sub range key and add slicer tag

--- a/tests/gold_tests/pluginTest/slice/replay/slice_purge.replay.yaml
+++ b/tests/gold_tests/pluginTest/slice/replay/slice_purge.replay.yaml
@@ -1,0 +1,136 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ uuid, 1 ]
+          - [ Range, bytes=0-9 ]
+    server-response:
+      status: 206
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 10 ]
+          - [ Content-Range, { value: "bytes 0-9/16", as: equal}]
+          - [ Cache-Control, max-age=300 ]
+          - [ X-Response, cached_response ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: "10", as: equal} ]
+          - [ Content-Range, { value: "bytes 0-9/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ uuid, 2 ]
+          - [ Range, bytes=10-19 ]
+    server-response:
+      status: 206
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 6 ]
+          - [ Content-Range, { value: "bytes 10-15/16", as: equal}]
+          - [ Cache-Control, max-age=300 ]
+          - [ X-Response, cached_response ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: "6", as: equal} ]
+          - [ Content-Range, { value: "bytes 10-15/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ Range, bytes=10-15 ]
+          - [ uuid, 3 ]
+    server-response:
+      status: 500
+      headers:
+        fields:
+          - [ Content-Length, 0 ]
+          - [ X-Response, internal_server_error ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Range, { value: "bytes 10-15/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]
+
+  - client-request:
+      method: "PURGE"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ uuid, 4 ]
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 0 ]
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: "0", as: equal} ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ Range, bytes=10-15 ]
+          - [ uuid, 5 ]
+    server-response:
+      status: 404
+      headers:
+        fields:
+          - [ Content-Length, 0 ]
+          - [ X-Response, internal_server_error ]
+    proxy-response:
+      status: 404
+      headers:
+        fields:
+          - [ Content-Length, { value: "0", as: equal} ]
+          - [ X-Response, { value: internal_server_error, as: equal} ]

--- a/tests/gold_tests/pluginTest/slice/replay/slice_purge_no_ref.replay.yaml
+++ b/tests/gold_tests/pluginTest/slice/replay/slice_purge_no_ref.replay.yaml
@@ -1,0 +1,115 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ uuid, 1 ]
+          - [ Range, bytes=0-9 ]
+    server-response:
+      status: 206
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 10 ]
+          - [ Content-Range, { value: "bytes 0-9/16", as: equal}]
+          - [ Cache-Control, max-age=300 ]
+          - [ X-Response, cached_response ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: "10", as: equal} ]
+          - [ Content-Range, { value: "bytes 0-9/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ uuid, 2 ]
+          - [ Range, bytes=10-19 ]
+    server-response:
+      status: 206
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 6 ]
+          - [ Content-Range, { value: "bytes 10-15/16", as: equal}]
+          - [ Cache-Control, max-age=300 ]
+          - [ X-Response, cached_response ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: "6", as: equal} ]
+          - [ Content-Range, { value: "bytes 10-15/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]
+
+  - client-request:
+      method: "PURGE"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ Range, bytes=10-15 ]
+          - [ uuid, 3 ]
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 0 ]
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: "0", as: equal} ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ Range, bytes=0-5 ]
+          - [ uuid, 4 ]
+    server-response:
+      status: 404
+      headers:
+        fields:
+          - [ Content-Length, 0 ]
+          - [ X-Response, internal_server_error ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Range, { value: "bytes 0-5/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]

--- a/tests/gold_tests/pluginTest/slice/replay/slice_purge_ref.replay.yaml
+++ b/tests/gold_tests/pluginTest/slice/replay/slice_purge_ref.replay.yaml
@@ -1,0 +1,115 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ uuid, 1 ]
+          - [ Range, bytes=0-9 ]
+    server-response:
+      status: 206
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 10 ]
+          - [ Content-Range, { value: "bytes 0-9/16", as: equal}]
+          - [ Cache-Control, max-age=300 ]
+          - [ X-Response, cached_response ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: "10", as: equal} ]
+          - [ Content-Range, { value: "bytes 0-9/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ uuid, 2 ]
+          - [ Range, bytes=10-19 ]
+    server-response:
+      status: 206
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 6 ]
+          - [ Content-Range, { value: "bytes 10-15/16", as: equal}]
+          - [ Cache-Control, max-age=300 ]
+          - [ X-Response, cached_response ]
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: "6", as: equal} ]
+          - [ Content-Range, { value: "bytes 10-15/16", as: equal}]
+          - [ X-Response, { value: cached_response, as: equal} ]
+
+  - client-request:
+      method: "PURGE"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ Range, bytes=10-15 ]
+          - [ uuid, 3 ]
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+          - [ Content-Length, 0 ]
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: "0", as: equal} ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /ref/block
+      headers:
+        fields:
+          - [ Host, example.com ]
+          - [ Range, bytes=0-9 ]
+          - [ uuid, 5 ]
+    server-response:
+      status: 404
+      headers:
+        fields:
+          - [ Content-Length, 0 ]
+          - [ X-Response, internal_server_error ]
+    proxy-response:
+      status: 404
+      headers:
+        fields:
+          - [ Content-Length, { value: "0", as: equal} ]
+          - [ X-Response, { value: internal_server_error, as: equal} ]

--- a/tests/gold_tests/pluginTest/slice/slice_purge.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_purge.test.py
@@ -1,0 +1,100 @@
+'''
+Verify ATS slice plugin config accepts PURGE requests
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Verify ATS slice plugin config accepts PURGE requests
+'''
+Test.SkipUnless(
+    Condition.PluginExists('slice.so'),
+    Condition.PluginExists('cache_range_requests.so'),
+)
+
+
+class SlicePurgeRequestTest:
+    replay_file = "replay/slice_purge.replay.yaml"
+    replay_ref_file = "replay/slice_purge_ref.replay.yaml"
+    replay_no_ref_file = "replay/slice_purge_no_ref.replay.yaml"
+
+    def __init__(self, ref_block, num):
+        """Initialize the Test processes for the test runs."""
+        self._ref_block = ref_block
+        self._num = num
+        self._server = Test.MakeVerifierServerProcess(f"server_{self._num}", SlicePurgeRequestTest.replay_file)
+        self._configure_trafficserver()
+
+    def _configure_trafficserver(self):
+        """Configure Traffic Server."""
+        self._ts = Test.MakeATSProcess(f"ts_{self._num}", enable_cache=True)
+
+        if (self._ref_block):
+            self._ts.Disk.remap_config.AddLines([
+                f"map /ref/block http://127.0.0.1:{self._server.Variables.http_port} \
+                @plugin=slice.so @pparam=--blockbytes-test=10 \
+                @plugin=cache_range_requests.so",
+            ])
+        else:
+            self._ts.Disk.remap_config.AddLines([
+                f"map /ref/block http://127.0.0.1:{self._server.Variables.http_port} \
+                @plugin=slice.so @pparam=--blockbytes-test=10 @pparam=--ref-relative \
+                @plugin=cache_range_requests.so",
+            ])
+
+        self._ts.Disk.records_config.update({
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|slice|cache_range_requests',
+        })
+
+    def slice_purge(self):
+        tr = Test.AddTestRun()
+
+        tr.AddVerifierClientProcess(
+            f"client_{self._num}",
+            SlicePurgeRequestTest.replay_file,
+            http_ports=[self._ts.Variables.port])
+
+        tr.Processes.Default.StartBefore(self._server)
+        tr.Processes.Default.StartBefore(self._ts)
+
+    def slice_purge_ref(self):
+        tr = Test.AddTestRun()
+
+        tr.AddVerifierClientProcess(
+            "client_ref",
+            SlicePurgeRequestTest.replay_ref_file,
+            http_ports=[self._ts.Variables.port])
+
+        tr.Processes.Default.StartBefore(self._server)
+        tr.Processes.Default.StartBefore(self._ts)
+
+    def slice_purge_no_ref(self):
+        tr = Test.AddTestRun()
+
+        tr.AddVerifierClientProcess(
+            "client_no_ref",
+            SlicePurgeRequestTest.replay_no_ref_file,
+            http_ports=[self._ts.Variables.port])
+
+        tr.Processes.Default.StartBefore(self._server)
+        tr.Processes.Default.StartBefore(self._ts)
+
+
+SlicePurgeRequestTest(True, 0).slice_purge()
+SlicePurgeRequestTest(True, 1).slice_purge_ref()
+SlicePurgeRequestTest(False, 2).slice_purge()
+SlicePurgeRequestTest(False, 3).slice_purge_no_ref()


### PR DESCRIPTION
Allow purge requests when slice plugin is enabled
- respects `ref-relative` config, purging ref block (slice 0) if processed
    - autests check both behaviors
- will stop purging remaining blocks when 404 (not found in cache) is received 