### PR TITLE
Add support for TCMalloc in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,9 @@ CHECK_INCLUDE_FILE(arpa/nameser_compat.h HAVE_ARPA_NAMESER_COMPAT_H)
 CHECK_INCLUDE_FILE(siginfo.h HAVE_SIGINFO_H)
 
 # Find libraries
-find_package(jemalloc)
-if(jemalloc_FOUND)
-    set(TS_HAS_JEMALLOC TRUE)
+find_package(TSMallocReplacement QUIET MODULE)
+if(TSMallocReplacement_FOUND)
+    link_libraries(ts::TSMallocReplacement)
 endif()
 find_package(hwloc)
 if(hwloc_FOUND)

--- a/cmake/FindTCMalloc.cmake
+++ b/cmake/FindTCMalloc.cmake
@@ -1,0 +1,42 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# FindTCMalloc.cmake
+#
+# This will define the following variables
+#
+#     TCMalloc_FOUND
+#     TCMalloc_LIBRARY
+#
+# and the following imported targets
+#
+#     TCMalloc::TCMalloc
+#
+
+# libtcmalloc.so symlink not created on OpenSUSE Leap 15.4
+find_library(TCMalloc_LIBRARY NAMES libtcmalloc libtcmalloc.so.4 PATHS)
+message(STATUS ${TCMalloc_LIBRARY})
+
+mark_as_advanced(TCMalloc_FOUND TCMalloc_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TCMalloc REQUIRED_VARS TCMalloc_LIBRARY)
+
+if(TCMalloc_FOUND AND NOT TARGET TCMalloc::TCMalloc)
+    add_library(TCMalloc::TCMalloc INTERFACE IMPORTED)
+    target_link_libraries(TCMalloc::TCMalloc INTERFACE "${TCMalloc_LIBRARY}")
+endif()

--- a/cmake/FindTCMalloc.cmake
+++ b/cmake/FindTCMalloc.cmake
@@ -28,8 +28,7 @@
 #
 
 # libtcmalloc.so symlink not created on OpenSUSE Leap 15.4
-find_library(TCMalloc_LIBRARY NAMES libtcmalloc libtcmalloc.so.4 PATHS)
-message(STATUS ${TCMalloc_LIBRARY})
+find_library(TCMalloc_LIBRARY NAMES libtcmalloc libtcmalloc.so.4)
 
 mark_as_advanced(TCMalloc_FOUND TCMalloc_LIBRARY)
 

--- a/cmake/FindTSMallocReplacement.cmake
+++ b/cmake/FindTSMallocReplacement.cmake
@@ -1,0 +1,73 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# FindTSMallocReplacement.cmake
+#
+# This will define the following variables
+#
+#     TSMallocReplacement_FOUND
+#     TSMallocReplacement_LIBRARY
+#     TS_HAS_MALLOC_REPLACEMENT
+#     TS_HAS_JEMALLOC
+#     TS_HAS_TCMALLOC
+#
+# and the following imported targets
+#
+#     ts::TSMallocReplacement
+#
+
+find_package(jemalloc QUIET)
+set(TS_HAS_JEMALLOC ${jemalloc_FOUND})
+
+find_package(TCMalloc QUIET)
+set(TS_HAS_TCMALLOC ${TCMalloc_FOUND})
+
+if(TS_HAS_JEMALLOC OR TS_HAS_TCMALLOC)
+    set(TS_HAS_MALLOC_REPLACEMENT TRUE)
+endif()
+
+if(TS_HAS_JEMALLOC AND TS_HAS_TCMALLOC)
+    message(FATAL_ERROR "Cannot build with both jemalloc and TCMalloc.")
+endif()
+
+if(TS_HAS_JEMALLOC)
+    set(TSMallocReplacement_LIBRARY "${jemalloc_LIBRARY}")
+elseif(TS_HAS_TCMALLOC)
+    set(TSMallocReplacement_LIBRARY "${TCMalloc_LIBRARY}")
+endif()
+
+mark_as_advanced(TSMallocReplacement_FOUND TS_HAS_MALLOC_REPLACEMENT)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TSMallocReplacement
+    REQUIRED_VARS TS_HAS_MALLOC_REPLACEMENT
+)
+
+if(TSMallocReplacement_FOUND AND NOT TARGET ts::TSMallocReplacement)
+    add_library(ts::TSMallocReplacement INTERFACE IMPORTED)
+    if(TS_HAS_JEMALLOC)
+        target_link_libraries(ts::TSMallocReplacement
+            INTERFACE
+                jemalloc::jemalloc
+        )
+    elseif(TS_HAS_TCMALLOC)
+        target_link_libraries(ts::TSMallocReplacement
+            INTERFACE
+                TCMalloc::TCMalloc
+        )
+    endif()
+endif()

--- a/cmake/FindTSMallocReplacement.cmake
+++ b/cmake/FindTSMallocReplacement.cmake
@@ -20,7 +20,6 @@
 # This will define the following variables
 #
 #     TSMallocReplacement_FOUND
-#     TSMallocReplacement_LIBRARY
 #     TS_HAS_MALLOC_REPLACEMENT
 #     TS_HAS_JEMALLOC
 #     TS_HAS_TCMALLOC
@@ -42,12 +41,6 @@ endif()
 
 if(TS_HAS_JEMALLOC AND TS_HAS_TCMALLOC)
     message(FATAL_ERROR "Cannot build with both jemalloc and TCMalloc.")
-endif()
-
-if(TS_HAS_JEMALLOC)
-    set(TSMallocReplacement_LIBRARY "${jemalloc_LIBRARY}")
-elseif(TS_HAS_TCMALLOC)
-    set(TSMallocReplacement_LIBRARY "${TCMalloc_LIBRARY}")
 endif()
 
 mark_as_advanced(TSMallocReplacement_FOUND TS_HAS_MALLOC_REPLACEMENT)

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -105,6 +105,7 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 
 /* Feature Flags */
 #cmakedefine01 TS_HAS_JEMALLOC
+#cmakedefine01 TS_HAS_TCMALLOC
 #cmakedefine01 TS_USE_EPOLL
 #cmakedefine01 TS_USE_HWLOC
 #cmakedefine01 TS_USE_KQUEUE

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -116,9 +116,6 @@ target_link_libraries(tscore
     PRIVATE
         yaml-cpp::yaml-cpp
 )
-if(TS_HAS_JEMALLOC)
-    target_link_libraries(tscore PUBLIC jemalloc::jemalloc)
-endif()
 if(TS_USE_HWLOC)
     target_link_libraries(tscore PUBLIC hwloc::hwloc)
 endif()


### PR DESCRIPTION
This abstracts some of the logic for finding a malloc replacement so that either jemalloc or TCMalloc can be used, and mimalloc support added easily at a later point. It also fixes some incorrect generator expression usage. If jemalloc and TCMalloc are both found, an error will be issued. It looks like this is what the autotools build does.