### PR TITLE
Fix crash on config reload with BoringSSL

### DIFF
--- a/iocore/net/SSLConfig.cc
+++ b/iocore/net/SSLConfig.cc
@@ -952,7 +952,8 @@ SSLConfigParams::getCTX(const std::string &client_cert, const std::string &key_f
           SSLError("failed to attach client chain certificate from %s", client_cert.c_str());
           goto fail;
         }
-        X509_free(cert);
+        // Do not free cert becasue SSL_CTX_add_extra_chain_cert takes ownership of cert if it succeeds, unlike
+        // SSL_CTX_use_certificate.
         cert = PEM_read_bio_X509(biop, nullptr, nullptr, nullptr);
       }
 


### PR DESCRIPTION
ATS crashed due to double free if it reloads a cert file that contains chained certs.

According to BoringSSL documentation,

> SSL_CTX_add_extra_chain_cert calls SSL_CTX_add0_chain_cert.

and

> SSL_CTX_add0_chain_cert appends x509 to ctx's certificate chain. On success, it returns one and takes ownership of x509. Otherwise, it returns zero.
OPENSSL_EXPORT int SSL_CTX_add0_chain_cert(SSL_CTX *ctx, X509 *x509);

So we cannot free cert here.

It kinda made sense before https://github.com/apache/trafficserver/pull/9177 because we used to call `SSL_CTX_use_certificate` here instead (which is incorrect as the PR explains) and `SSL_CTX_use_certificate` does not seem like to take ownership according to BoringSSL documentation.

> SSL_CTX_use_certificate sets ctx's leaf certificate to x509. It returns one on success and zero on failure.


I checked OpenSSL's implementation and it looks like OpenSSL takes ownership too.  The behavior is the same, but BoringSSL aborts during the second free because of internal sanity check. I don't think we need `ifdef` for BoringSSL.