### PR TITLE
Search for and link profiler in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ execute_process(COMMAND id -ng OUTPUT_VARIABLE BUILD_GROUP OUTPUT_STRIP_TRAILING
 execute_process(COMMAND uname -n OUTPUT_VARIABLE BUILD_MACHINE OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Options
+option(ENABLE_PROFILER "Use gperftools profiler (default OFF)")
 set(DEFAULT_STACK_SIZE 1048576 CACHE STRING "Default stack size (default 1048576)")
 set(TS_MAX_HOST_NAME_LEN 256 CACHE STRING "Max host name length (default 256)")
 set(TS_USE_SET_RBIO 1 CACHE STRING "Use openssl set_rbio (default 1)")
@@ -108,8 +109,8 @@ find_package(PCRE)
 include(FindOpenSSL)
 find_package(OpenSSL)
 
-find_package(profiler)
-if(profiler_FOUND)
+if(ENABLE_PROFILER)
+    find_package(profiler REQUIRED)
     set(TS_HAS_PROFILER TRUE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,25 +88,36 @@ CHECK_INCLUDE_FILE(arpa/nameser_compat.h HAVE_ARPA_NAMESER_COMPAT_H)
 CHECK_INCLUDE_FILE(siginfo.h HAVE_SIGINFO_H)
 
 # Find libraries
-find_package(TSMallocReplacement QUIET MODULE)
-if(TSMallocReplacement_FOUND)
-    link_libraries(ts::TSMallocReplacement)
-endif()
 find_package(brotli)
 if(brotli_FOUND)
     set(HAVE_BROTLI_ENCODE_H TRUE)
 endif()
+
 find_package(hwloc)
 if(hwloc_FOUND)
     set(TS_USE_HWLOC TRUE)
 endif()
+
 find_package(LibLZMA)
 if(LibLZMA_FOUND)
         set(HAVE_LZMA_H TRUE)
 endif()
+
 find_package(PCRE)
+
 include(FindOpenSSL)
 find_package(OpenSSL)
+
+find_package(profiler)
+if(profiler_FOUND)
+    set(TS_HAS_PROFILER TRUE)
+endif()
+
+find_package(TSMallocReplacement QUIET MODULE)
+if(TSMallocReplacement_FOUND)
+    link_libraries(ts::TSMallocReplacement)
+endif()
+
 find_package(ZLIB REQUIRED)
 
 # Find ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ find_package(OpenSSL)
 
 if(ENABLE_PROFILER)
     find_package(profiler REQUIRED)
-    set(TS_HAS_PROFILER TRUE)
+    set(TS_HAS_PROFILER ${profiler_FOUND})
 endif()
 
 find_package(TSMallocReplacement QUIET MODULE)

--- a/cmake/FindTSMallocReplacement.cmake
+++ b/cmake/FindTSMallocReplacement.cmake
@@ -60,7 +60,7 @@ if(TSMallocReplacement_FOUND AND NOT TARGET ts::TSMallocReplacement)
     elseif(TS_HAS_TCMALLOC)
         target_link_libraries(ts::TSMallocReplacement
             INTERFACE
-                TCMalloc::TCMalloc
+                gperftools::TCMalloc
         )
     endif()
 endif()

--- a/cmake/Findprofiler.cmake
+++ b/cmake/Findprofiler.cmake
@@ -15,27 +15,35 @@
 #
 #######################
 
-# FindTCMalloc.cmake
+# Findprofiler.cmake
 #
 # This will define the following variables
 #
-#     TCMalloc_FOUND
-#     TCMalloc_LIBRARY
+#     profiler_FOUND
+#     profiler_LIBRARY
+#     profiler_INCLUDE_DIRS
 #
 # and the following imported targets
 #
-#     TCMalloc::TCMalloc
+#     profiler::profiler
 #
 
-# libtcmalloc.so symlink not created on OpenSUSE Leap 15.4
-find_library(TCMalloc_LIBRARY NAMES libtcmalloc libtcmalloc.so.4)
+find_library(profiler_LIBRARY NAMES profiler)
+find_path(profiler_INCLUDE_DIR NAMES profiler.h PATH_SUFFIXES gperftools)
 
-mark_as_advanced(TCMalloc_FOUND TCMalloc_LIBRARY)
+mark_as_advanced(profiler_FOUND profiler_LIBRARY profiler_INCLUDE_DIR)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(TCMalloc REQUIRED_VARS TCMalloc_LIBRARY)
+find_package_handle_standard_args(profiler
+    REQUIRED_VARS profiler_LIBRARY profiler_INCLUDE_DIR
+)
 
-if(TCMalloc_FOUND AND NOT TARGET TCMalloc::TCMalloc)
-    add_library(gperftools::TCMalloc INTERFACE IMPORTED)
-    target_link_libraries(gperftools::TCMalloc INTERFACE "${TCMalloc_LIBRARY}")
+if(profiler_FOUND)
+    set(profiler_INCLUDE_DIRS ${profiler_INCLUDE_DIR})
+endif()
+
+if(profiler_FOUND AND NOT TARGET profiler::profiler)
+    add_library(gperftools::profiler INTERFACE IMPORTED)
+    target_include_directories(gperftools::profiler INTERFACE "${profiler_INCLUDE_DIRS}")
+    target_link_libraries(gperftools::profiler INTERFACE "${profiler_LIBRARY}")
 endif()

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -108,6 +108,7 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 /* Feature Flags */
 #cmakedefine01 TS_HAS_JEMALLOC
 #cmakedefine01 TS_HAS_TCMALLOC
+#cmakedefine01 TS_HAS_PROFILER
 #cmakedefine01 TS_USE_EPOLL
 #cmakedefine01 TS_USE_HWLOC
 #cmakedefine01 TS_USE_KQUEUE

--- a/src/traffic_server/CMakeLists.txt
+++ b/src/traffic_server/CMakeLists.txt
@@ -34,6 +34,7 @@ target_include_directories(traffic_server PRIVATE
         ${CMAKE_SOURCE_DIR}/mgmt/utils
 )
 target_link_libraries(traffic_server
+    PRIVATE
         http
         http_remap
         http2
@@ -59,7 +60,11 @@ target_link_libraries(traffic_server
         jsonrpc_protocol
         jsonrpc_server
         rpcpublichandlers
-        )
+)
+
+if(TS_HAS_PROFILER)
+    target_link_libraries(traffic_server PRIVATE gperftools::profiler)
+endif()
 
 if (TS_USE_LINUX_IO_URING)
     target_link_libraries(traffic_server inkuring uring)


### PR DESCRIPTION
This looks for the gperftools profiler and links it if found. It also puts both profiler and TCMalloc targets under the gperftools namespace.