### PR TITLE
Fix misuse of unique_ptr.release.

### DIFF
--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -136,7 +136,7 @@ UDPPacket::free()
   p.conn = nullptr;
 
   if (this->_payload) {
-    _payload.release();
+    _payload.reset();
   }
   udpPacketAllocator.free(this);
 }


### PR DESCRIPTION
The idea was to release the used memory not to release ownership which would create a leak.