### PR TITLE
Remove unneeded DEBUG conditionals.

### DIFF
--- a/iocore/eventsystem/I_Action.h
+++ b/iocore/eventsystem/I_Action.h
@@ -123,7 +123,7 @@ public:
     machine.
 
   */
-  int cancelled = false;
+  bool cancelled = false;
 
   /**
     Cancels the asynchronous operation represented by this action.
@@ -141,14 +141,8 @@ public:
   cancel(Continuation *c = nullptr)
   {
     ink_assert(!c || c == continuation);
-#ifdef DEBUG
     ink_assert(!cancelled);
     cancelled = true;
-#else
-    if (!cancelled) {
-      cancelled = true;
-    }
-#endif
   }
 
   /**
@@ -166,14 +160,8 @@ public:
   cancel_action(Continuation *c = nullptr)
   {
     ink_assert(!c || c == continuation);
-#ifdef DEBUG
     ink_assert(!cancelled);
     cancelled = true;
-#else
-    if (!cancelled) {
-      cancelled = true;
-    }
-#endif
   }
 
   Continuation *


### PR DESCRIPTION
ink_assert is already compiled out in non-debug builds, so we don't need to protect assertions with "#if DEBUG". Since we are touching this file, make the type of "cancelled" bool, since it is already treated as if it was.