### PR TITLE
Set SIZEOF_VOIDP in CMake build

### DIFF
--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -79,6 +79,8 @@
 #cmakedefine HAVE_BIO_METH_GET_CREATE 1
 #cmakedefine HAVE_BIO_METH_GET_DESTROY 1
 
+#define SIZEOF_VOIDP @CMAKE_SIZEOF_VOID_P@
+
 /* TODO(cmcfarlen): make this configurable */
 #define TS_PKGSYSUSER "@pkgsysuser@"
 #define TS_PKGSYSGROUP "@pkgsysgroup@"


### PR DESCRIPTION
This sets SIZEOF_VOIDP to the value of CMAKE_SIZEOF_VOID_P, which is determined by a try_compile [cmake.org].