### PR TITLE
Add support for POSIX Cap in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ execute_process(COMMAND uname -n OUTPUT_VARIABLE BUILD_MACHINE OUTPUT_STRIP_TRAI
 
 # Options
 set(DEFAULT_STACK_SIZE 1048576 CACHE STRING "Default stack size (default 1048576)")
+option(ENABLE_POSIX_CAP
+    "Use POSIX capabilities, turn OFF to use id switching. (default ON)"
+    ON
+)
 option(ENABLE_JEMALLOC "Use jemalloc (default OFF)")
 option(ENABLE_MIMALLOC "Use mimalloc (default OFF)")
 option(ENABLE_PROFILER "Use gperftools profiler (default OFF)")
@@ -101,6 +105,21 @@ find_package(brotli)
 if(brotli_FOUND)
     set(HAVE_BROTLI_ENCODE_H TRUE)
 endif()
+
+if(ENABLE_POSIX_CAP)
+    find_package(cap REQUIRED)
+    set(TS_USE_POSIX_CAP ${cap_FOUND})
+    find_path(PRCTL_HEADER NAMES sys/prctl.h)
+    # just making sure
+    if(NOT PRCTL_HEADER)
+        message(FATAL_ERROR "Have cap but sys/prctl.h not found.")
+    endif()
+    set(HAVE_SYS_PRCTL_H TRUE)
+    unset(PRCTL_HEADER)
+else()
+    find_package(cap QUIET)
+endif()
+set(HAVE_SYS_CAPABILITY_H ${cap_FOUND})
 
 find_package(hwloc)
 if(hwloc_FOUND)

--- a/cmake/Findcap.cmake
+++ b/cmake/Findcap.cmake
@@ -1,0 +1,49 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# Findcap.cmake
+#
+# This will define the following variables
+#
+#     cap_FOUND
+#     cap_LIBRARY
+#     cap_INCLUDE_DIRS
+#
+# and the following imported targets
+#
+#     cap::cap
+#
+
+find_library(cap_LIBRARY NAMES cap)
+find_path(cap_INCLUDE_DIR NAMES sys/capability.h)
+
+mark_as_advanced(cap_FOUND cap_LIBRARY cap_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cap
+    REQUIRED_VARS cap_LIBRARY cap_INCLUDE_DIR
+)
+
+if(cap_FOUND)
+    set(cap_INCLUDE_DIRS ${cap_INCLUDE_DIR})
+endif()
+
+if(cap_FOUND AND NOT TARGET cap::cap)
+    add_library(cap::cap INTERFACE IMPORTED)
+    target_include_directories(cap::cap INTERFACE ${cap_INCLUDE_DIRS})
+    target_link_libraries(cap::cap INTERFACE ${cap_LIBRARY})
+endif()

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -44,7 +44,9 @@
 #cmakedefine HAVE_LINUX_MAJOR_H 1
 #cmakedefine HAVE_SYS_DISK_H 1
 #cmakedefine HAVE_SYS_DISKLABEL_H 1
+#cmakedefine HAVE_SYS_CAPABILITY_H 1
 #cmakedefine HAVE_SYS_IOCTL_H 1
+#cmakedefine HAVE_SYS_PRCTL_H 1
 #cmakedefine HAVE_SYS_TYPES_H 1
 #cmakedefine HAVE_SYS_STAT_H 1
 #cmakedefine HAVE_SYS_STATVFS_H 1
@@ -114,15 +116,16 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 #cmakedefine01 TS_HAS_JEMALLOC
 #cmakedefine01 TS_HAS_TCMALLOC
 #cmakedefine01 TS_HAS_PROFILER
+#cmakedefine01 TS_USE_DIAGS
 #cmakedefine01 TS_USE_EPOLL
+#cmakedefine01 TS_USE_GET_DH_2048_256
 #cmakedefine01 TS_USE_HWLOC
 #cmakedefine01 TS_USE_KQUEUE
 #cmakedefine01 TS_USE_LINUX_IO_URING
 #cmakedefine01 TS_USE_LINUX_NATIVE_AIO
+#cmakedefine01 TS_USE_POSIX_CAP
 #cmakedefine01 TS_USE_SET_RBIO
 #cmakedefine01 TS_USE_TLS13
-#cmakedefine01 TS_USE_DIAGS
-#cmakedefine01 TS_USE_GET_DH_2048_256
 
 #define TS_BUILD_CANONICAL_HOST "@CMAKE_HOST@"
 

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -64,7 +64,7 @@ add_library(inknet STATIC
         SSLDynlock.cc
         SNIActionPerformer.cc
         )
-target_link_libraries(inknet inkevent records_p)
+target_link_libraries(inknet PUBLIC inkevent records_p)
 target_compile_options(inknet PUBLIC -Wno-deprecated-declarations)
 target_include_directories(inknet PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/eventsystem
@@ -85,6 +85,9 @@ target_include_directories(inknet PRIVATE
         ${OPENSSL_INCLUDE_DIRS}
         ${YAML_INCLUDE_DIRS}
         )
+if(TS_USE_POSIX_CAP)
+    target_link_libraries(inknet PUBLIC cap::cap)
+endif()
 
 # Fails to link because of circular dep with proxy (ParentSelection)
 # add_executable(test_net unit_tests/test_ProxyProtocol.cc)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -122,6 +122,9 @@ endif()
 if(TS_HAS_128BIT_CAS AND TS_NEEDS_MCX16_FOR_CAS)
     target_compile_options(tscore PUBLIC "-mcx16")
 endif()
+if(TS_USE_POSIX_CAP)
+    target_link_libraries(tscore PUBLIC cap::cap)
+endif()
 
 add_executable(test_tscore
         unit_tests/test_AcidPtr.cc


### PR DESCRIPTION
This adds a new CMake option that is ON by default: ENABLE_POSIX_CAP. If POSIX cap is not found, the configure step will fail and the user must disable the feature explicitly.