### PR TITLE
Check for TLS1.3 in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,12 @@ include(find_ccache)
 
 # Check for IO faculties
 check_symbol_exists(IN6_IS_ADDR_UNSPECIFIED "netinet/in.h" TS_HAS_IN6_IS_ADDR_UNSPECIFIED)
+check_symbol_exists(TLS1_3_VERSION "${OPENSSL_INCLUDE_DIR}/openssl/ssl.h" TS_USE_TLS13)
+check_symbol_exists(OPENSSL_NO_TLS1_3 "${OPENSSL_INCLUDE_DIR}/ssl.h" TS_NO_USE_TLS13)
+if(TS_NO_USE_TLS13)
+    set(TS_USE_TLS13 FALSE CACHE)
+endif()
+
 check_symbol_exists(epoll_create "sys/epoll.h" TS_USE_EPOLL)
 check_symbol_exists(kqueue "sys/event.h" TS_USE_KQUEUE)
 set(CMAKE_REQUIRED_LIBRARIES uring)

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -117,6 +117,7 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 #cmakedefine01 TS_USE_LINUX_IO_URING
 #cmakedefine01 TS_USE_LINUX_NATIVE_AIO
 #cmakedefine01 TS_USE_SET_RBIO
+#cmakedefine01 TS_USE_TLS13
 #cmakedefine01 TS_USE_DIAGS
 #cmakedefine01 TS_USE_GET_DH_2048_256
 


### PR DESCRIPTION
This sets the CMake variable TS_USE_TLS13 appropriately.