### PR TITLE
Add option to build regression tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ execute_process(COMMAND id -ng OUTPUT_VARIABLE BUILD_GROUP OUTPUT_STRIP_TRAILING
 execute_process(COMMAND uname -n OUTPUT_VARIABLE BUILD_MACHINE OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 # Options
+option(BUILD_REGRESSION_TESTING "Build regression tests (default ON)" ON)
 set(DEFAULT_STACK_SIZE 1048576 CACHE STRING "Default stack size (default 1048576)")
 option(ENABLE_FAST_SDK "Use fast SDK APIs (default OFF)")
 option(ENABLE_JEMALLOC "Use jemalloc (default OFF)")
@@ -207,6 +208,7 @@ check_symbol_exists(SSL_CTX_set_tlsext_ticket_key_cb openssl/ssl.h HAVE_SSL_CTX_
 set(CATCH_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/lib/catch2)
 
 include(CTest)
+set(TS_HAS_TESTS ${BUILD_REGRESSION_TESTING})
 
 message("Configuring for ${HOST_OS}")
 

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -115,6 +115,7 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 #cmakedefine01 TS_HAS_IN6_IS_ADDR_UNSPECIFIED
 #cmakedefine01 TS_HAS_JEMALLOC
 #cmakedefine01 TS_HAS_TCMALLOC
+#cmakedefine01 TS_HAS_TESTS
 #cmakedefine01 TS_HAS_PROFILER
 #cmakedefine01 TS_USE_DIAGS
 #cmakedefine01 TS_USE_EPOLL

--- a/iocore/cache/CMakeLists.txt
+++ b/iocore/cache/CMakeLists.txt
@@ -31,6 +31,9 @@ add_library(inkcache STATIC
     RamCacheLRU.cc
     Store.cc
 )
+if(BUILD_REGRESSION_TESTING)
+    target_sources(inkcache PRIVATE CacheTest.cc)
+endif()
 target_link_libraries(inkcache PRIVATE ZLIB::ZLIB)
 if(HAVE_LZMA_H)
     target_link_libraries(inkcache PRIVATE LibLZMA::LibLZMA)

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -64,6 +64,9 @@ add_library(inknet STATIC
         SSLDynlock.cc
         SNIActionPerformer.cc
         )
+if(BUILD_REGRESSION_TESTING)
+    target_sources(inknet PRIVATE NetVCTest.cc)
+endif()
 target_link_libraries(inknet PUBLIC inkevent records_p)
 target_compile_options(inknet PUBLIC -Wno-deprecated-declarations)
 target_include_directories(inknet PRIVATE

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -35,7 +35,9 @@ add_library(proxy STATIC
         StatPages.cc
         Transform.cc
 )
-
+if(BUILD_REGRESSION_TESTING)
+    target_sources(proxy PRIVATE RegressionSM.cc)
+endif()
 set(PROXY_INCLUDE_DIRS
         ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -40,6 +40,10 @@ add_library(http STATIC
         PreWarmConfig.cc
         PreWarmManager.cc
 )
+if(BUILD_REGRESSION_TESTING)
+    target_sources(http PRIVATE RegressionHttpTransact.cc)
+endif()
+
 target_include_directories(http PRIVATE
         ${IOCORE_INCLUDE_DIRS}
         ${PROXY_INCLUDE_DIRS}


### PR DESCRIPTION
This adds a new option that defaults to ON: BUILD_REGRESSION_TESTING. Because the regression tests are part of the traffic_server binary, this is independent from the BUILD_TESTING option added by CTest, which builds separate test binaries.