### PR TITLE
libswoc: Update IntrusvieHashMap in Http connection tracking.

### DIFF
--- a/proxy/http/HttpConnectionCount.h
+++ b/proxy/http/HttpConnectionCount.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "swoc/IntrusiveHashMap.h"
+
 #include <string_view>
 #include <chrono>
 #include <atomic>
@@ -33,7 +35,6 @@
 #include "tscore/ink_config.h"
 #include "tscore/ink_mutex.h"
 #include "tscore/ink_inet.h"
-#include "tscore/IntrusiveHashMap.h"
 #include "tscore/Diags.h"
 #include "tscore/CryptoHash.h"
 #include "tscore/BufferWriterForward.h"
@@ -267,8 +268,8 @@ protected:
 
   /// Internal implementation class instance.
   struct Imp {
-    IntrusiveHashMap<Linkage> _table; ///< Hash table of upstream groups.
-    std::mutex _mutex;                ///< Lock for insert & find.
+    swoc::IntrusiveHashMap<Linkage> _table; ///< Hash table of upstream groups.
+    std::mutex _mutex;                      ///< Lock for insert & find.
   };
   static Imp _imp;
 


### PR DESCRIPTION
Update old `IntrusiveHashMap` to libswoc version.