### PR TITLE
Do not add content-length for status 204 cache

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6748,7 +6748,9 @@ HttpTransact::handle_content_length_header(State *s, HTTPHdr *header, HTTPHdr *b
         change_response_header_because_of_range_request(s, header);
         s->hdr_info.trust_response_cl = true;
       } else {
-        header->set_content_length(cl);
+        if (!(s->source == SOURCE_CACHE && header->status_get() == HTTP_STATUS_NO_CONTENT)) {
+          header->set_content_length(cl);
+        }
         s->hdr_info.trust_response_cl = true;
       }
     } else {

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -6748,7 +6748,7 @@ HttpTransact::handle_content_length_header(State *s, HTTPHdr *header, HTTPHdr *b
         change_response_header_because_of_range_request(s, header);
         s->hdr_info.trust_response_cl = true;
       } else {
-        if (!(s->source == SOURCE_CACHE && header->status_get() == HTTP_STATUS_NO_CONTENT)) {
+        if (header->status_get() != HTTP_STATUS_NO_CONTENT) {
           header->set_content_length(cl);
         }
         s->hdr_info.trust_response_cl = true;


### PR DESCRIPTION
In master and version 9.2.1, content-length header is added when serving the cache with status 204 No Content.
It seems caused by [Make 204 cacheable again by maskit · Pull Request #9333 · apache/trafficserver](https://github.com/apache/trafficserver/pull/9333).

With this pull request, content-length is not added when serving the cache with status 204 No Content.

I made test cases at https://github.com/hnakamur/atstest-go.

* The test log *with this fix* is at [log/atsmasterfix-test.log](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/atsmasterfix-test.log) and there is no content-length in the status 204 response from the cache: [log/atsmasterfix-test.log#L35-L41](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/atsmasterfix-test.log#L35-L41).
* The test log *without this fix* is at [log/atsmaster-test.log](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/atsmaster-test.log) and there is content-length in the status 204 response from the cache: [log/atsmaster-test.log#L40](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/atsmaster-test.log#L40).

(Note aside: the response headers in above logs are sorted alphabetically so the order is not same as the received response).

I also made the same fix for trafficserver version 9.2.1 at https://github.com/hnakamur/trafficserver/tree/9_2_1_dont_add_content_length_for_status_204_cache

* The test log with this fix is at [log/ats921fix-test.log](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/ats921fix-test.log) and there is no content-length in the status 204 response from the cache: [log/ats921fix-test.log#L35-L41](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/ats921fix-test.log#L35-L41).
* The test log without this fix is at [log/ats921-test.log](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/ats921-test.log) and there is content-length in the status 204 response from the cache: [log/ats921-test.log#L40](https://github.com/hnakamur/atstest-go/blob/4c2f9228d05ecfe37486f023503910f6be7e5892/log/ats921-test.log#L40).


https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-8

> A server MUST NOT send a Content-Length header field in any response with a status code of [1xx (Informational)](https://www.rfc-editor.org/rfc/rfc9110.html#status.1xx) or [204 (No Content)](https://www.rfc-editor.org/rfc/rfc9110.html#status.204). A server MUST NOT send a Content-Length header field in any [2xx (Successful)](https://www.rfc-editor.org/rfc/rfc9110.html#status.2xx) response to a CONNECT request ([Section 9.3.6](https://www.rfc-editor.org/rfc/rfc9110.html#CONNECT)).
