### PR TITLE
Add transparent proxy support to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,17 @@ option(ENABLE_POSIX_CAP
 )
 option(ENABLE_PROFILER "Use gperftools profiler (default OFF)")
 option(ENABLE_TCMALLOC "Use TCMalloc (default OFF)")
+set(ENABLE_TPROXY
+    "AUTO"
+    CACHE
+    STRING
+    "Use TPROXY to enable connection transparency. (default AUTO)
+        'AUTO' for local system default,
+        'NO', to disable,
+        'FORCE' to use built in default,
+        'X' where X is a number to use as the IP_TRANSPARENT sockopt,
+        anything else to enable."
+)
 option(ENABLE_UNWIND   "Use libunwind if found on system (default ON)" ON)
 option(ENABLE_WCCP     "Use WCCP v2 (default OFF)")
 set(TS_MAX_HOST_NAME_LEN 256 CACHE STRING "Max host name length (default 256)")
@@ -66,7 +77,6 @@ set(TS_VERSION_STRING TS_VERSION_S)
 set(TS_VERSION_NUMBER TS_VERSION_N)
 
 set(TS_HAS_WCCP ${ENABLE_WCCP})
-
 
 # Check include files
 include(CheckIncludeFile)
@@ -166,6 +176,7 @@ endif()
 find_package(ZLIB REQUIRED)
 
 include(Check128BitCas)
+include(ConfigureTransparentProxy)
 
 # Find ccache
 include(find_ccache)

--- a/cmake/ConfigureTransparentProxy.cmake
+++ b/cmake/ConfigureTransparentProxy.cmake
@@ -67,7 +67,9 @@ else()
     if(ENABLE_TPROXY STREQUAL "AUTO")
         set(TS_USE_TPROXY FALSE)
     else()
-        message(FATAL_ERROR "ENABLE_TPROXY on but sockopt value not found")
+        message(FATAL_ERROR
+            "ENABLE_TPROXY on but IP_TRANSPARENT symbol not found"
+        )
     endif()
 endif()
 

--- a/cmake/ConfigureTransparentProxy.cmake
+++ b/cmake/ConfigureTransparentProxy.cmake
@@ -1,0 +1,74 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# ConfigureTransparentProxy.cmake
+#
+# The following variables should be set
+#
+#     ENABLE_TPROXY to one of AUTO, NO, or a number
+#     TS_USE_POSIX_CAP to a boolean value
+#
+# This will define the following variables
+#
+#     TS_USE_TPROXY
+#     TS_IP_TRANSPARENT
+#
+
+set(TS_IP_TRANSPARENT 0)
+
+if(ENABLE_TPROXY STREQUAL "NO")
+    set(TS_USE_TPROXY FALSE)
+    return()
+endif()
+
+if(NOT TS_USE_POSIX_CAP)
+    if(ENABLE_TPROXY STREQUAL "AUTO")
+        set(TS_USE_TPROXY FALSE)
+    else()
+        message(FATAL_ERROR "ENABLE_TPROXY requires POSIX capabilities.")
+    endif()
+    return()
+endif()
+
+if(ENABLE_TPROXY STREQUAL "FORCE")
+    set(TS_USE_TPROXY TRUE)
+    set(TS_IP_TRANSPARENT 19)
+    return()
+endif()
+
+if(ENABLE_TPROXY MATCHES "([0-9]+)")
+    set(TS_USE_TPROXY TRUE)
+    set(TS_IP_TRANSPARENT ${CMAKE_MATCH_1})
+    return()
+endif()
+
+# If the read fails, it will print out a confusing error. This
+# is to make it clear why the error is happening in that case.
+message("ENABLE_TPROXY enabled, looking for value in /usr/include/linux/in.h")
+file(READ "/usr/include/linux/in.h" HEADER_CONTENTS)
+if(HEADER_CONTENTS MATCHES "#define[ \t]+IP_TRANSPARENT[ \t]+([0-9]+)")
+    set(TS_USE_TPROXY TRUE)
+    set(TS_IP_TRANSPARENT ${CMAKE_MATCH_1})
+else()
+    if(ENABLE_TPROXY STREQUAL "AUTO")
+        set(TS_USE_TPROXY FALSE)
+    else()
+        message(FATAL_ERROR "ENABLE_TPROXY on but sockopt value not found")
+    endif()
+endif()
+
+unset(HEADER_CONTENTS)

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -107,6 +107,7 @@
 
 /* Build definitions */
 const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
+#define TS_IP_TRANSPARENT @TS_IP_TRANSPARENT@
 #define TS_MAX_HOST_NAME_LEN @TS_MAX_HOST_NAME_LEN@
 
 /* Feature Flags */
@@ -132,6 +133,7 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 #cmakedefine01 TS_USE_REMOTE_UNWINDING
 #cmakedefine01 TS_USE_SET_RBIO
 #cmakedefine01 TS_USE_TLS13
+#cmakedefine01 TS_USE_TPROXY
 
 #define TS_BUILD_CANONICAL_HOST "@CMAKE_HOST@"
 


### PR DESCRIPTION
This adds a new option that defaults to AUTO: ENABLE_TPROXY. The option has a number of permissible settings which are explained in the option's documentation string.