### PR TITLE
Add header_rewrite plugin to CMake build

### DIFF
--- a/cmake/Findmaxminddb.cmake
+++ b/cmake/Findmaxminddb.cmake
@@ -1,0 +1,52 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# Findmaxminddb.cmake
+#
+# This will define the following variables
+#
+#     maxminddb_FOUND
+#     maxminddb_LIBRARY
+#     maxminddb_INCLUDE_DIRS
+#
+# and the following imported targets
+#
+#     maxminddb::maxminddb
+#
+
+# maxminddb exports their own config since maxminddb-1.5.0, but it isn't
+# present in the OpenSUSE libmaxminddb-devel-1.7.1 package and maybe others.
+
+find_library(maxminddb_LIBRARY NAMES maxminddb)
+find_path(maxminddb_INCLUDE_DIR NAMES maxminddb.h)
+
+mark_as_advanced(maxminddb_FOUND maxminddb_LIBRARY maxminddb_INCLUDE_DIR)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(maxminddb
+    REQUIRED_VARS maxminddb_LIBRARY maxminddb_INCLUDE_DIR
+)
+
+if(maxminddb_FOUND)
+    set(maxminddb_INCLUDE_DIRS ${maxminddb_INCLUDE_DIR})
+endif()
+
+if(maxminddb_FOUND AND NOT TARGET maxminddb::maxminddb)
+    add_library(maxminddb::maxminddb INTERFACE IMPORTED)
+    target_include_directories(maxminddb::maxminddb INTERFACE ${maxminddb_INCLUDE_DIRS})
+    target_link_libraries(maxminddb::maxminddb INTERFACE "${maxminddb_LIBRARY}")
+endif()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -39,5 +39,7 @@ add_subdirectory(compress)
 add_subdirectory(conf_remap)
 add_subdirectory(esi)
 
+add_subdirectory(header_rewrite)
+
 add_subdirectory(generator)
 add_subdirectory(xdebug)

--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -1,0 +1,55 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_atsplugin(header_rewrite
+    condition.cc
+    conditions.cc
+    factory.cc
+    header_rewrite.cc
+    lulu.cc
+    operator.cc
+    operators.cc
+    regex_helper.cc
+    resources.cc
+    ruleset.cc
+    statement.cc
+    value.cc
+)
+
+add_library(header_rewrite_parser STATIC parser.cc)
+
+find_package(maxminddb QUIET)
+
+if(maxminddb_FOUND)
+    target_sources(header_rewrite PRIVATE conditions_geo_maxmind.cc)
+    target_link_libraries(header_rewrite PRIVATE maxminddb::maxminddb)
+endif()
+
+add_executable(test_header_rewrite header_rewrite_test.cc)
+
+if(BUILD_TESTING)
+    add_test(
+        NAME test_header_rewrite
+        COMMAND $<TARGET_FILE:test_header_rewrite>
+    )
+
+    target_link_libraries(test_header_rewrite PRIVATE header_rewrite_parser)
+
+    if(maxminddb_FOUND)
+        target_link_libraries(test_header_rewrite PRIVATE maxminddb::maxminddb)
+    endif()
+endif()


### PR DESCRIPTION
This builds the header_rewrite plugin and registers its associated test with CTest. I had to add a Find module for maxminddb as well, because the official config file was not installed on my system, and maybe others. I did not look for GeoIP1, because it reached EOL in May, 2022, and maxminddb is the newer replacement.