### PR TITLE
tests: minor autest script fixes

### DIFF
--- a/tests/autest.sh
+++ b/tests/autest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # vim: sw=4:ts=4:softtabstop=4:ai:et
 
 #  Licensed to the Apache Software Foundation (ASF) under one
@@ -17,18 +17,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
 fail()
 {
     echo $1
     exit 1
 }
+
+cd "$SCRIPT_DIR"
+
 ./prepare_proxy_verifier.sh || fail "Failed to install Proxy Verifier."
-pushd $(dirname $0) > /dev/null
 export PYTHONPATH=$(pwd):$PYTHONPATH
 ./test-env-check.sh || fail "Failed Python environment checks."
 # this is for rhel or centos systems
 echo "Environment config finished. Running AuTest..."
-pipenv run autest "$@" -D gold_tests
-ret=$?
-popd > /dev/null
-exit $ret
+exec pipenv run autest "$@" -D gold_tests

--- a/tests/prepare_proxy_verifier.sh
+++ b/tests/prepare_proxy_verifier.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 # vim: sw=4:ts=4:softtabstop=4:ai:et
 
 #  Licensed to the Apache Software Foundation (ASF) under one

--- a/tests/test-env-check.sh
+++ b/tests/test-env-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -26,18 +26,9 @@ _END_
 
 if [ $? = 1 ]; then
     echo "Python 3.6 or newer is not installed/enabled."
-    return
+    exit 1
 else
     echo "Python 3.6 or newer detected!"
-fi
-
-# check for python development header -- for autest
-python3-config &> /dev/null
-if [ $? = 1 ]; then
-    echo "python3-dev/devel detected!"
-else
-    echo "python3-dev/devel is not installed. "
-    return
 fi
 
 # check for pipenv
@@ -53,4 +44,5 @@ if [ $? -eq 0 ]; then
     fi
 else
     echo "pipenv is not installed/enabled. "
+    exit 1
 fi


### PR DESCRIPTION
* switch to the tests directory before trying to run scripts from it
* don't check for the unnecessary Python devel tools
* exit if Python isn't available
* use the preferred bash, not the (obsolete on macOS) one in /bin