### PR TITLE
Add missing source file to http3 target

### DIFF
--- a/proxy/http3/CMakeLists.txt
+++ b/proxy/http3/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(http3 STATIC
     Http3HeaderFramer.cc
     Http3DataFramer.cc
     Http3HeaderVIOAdaptor.cc
+    Http3ProtocolEnforcer.cc
     Http3StreamDataVIOAdaptor.cc
     QPACK.cc
 )


### PR DESCRIPTION
Someone added a source file before the quiche support got merged for CMake, so CMake no longer builds with quiche in master.