### PR TITLE
edits to remove compiler warnings/errors for the osx build

### DIFF
--- a/include/tscore/Ptr.h
+++ b/include/tscore/Ptr.h
@@ -264,14 +264,14 @@ Ptr<T>::operator=(const Ptr<T> &src)
 
 template <typename T>
 inline bool
-operator==(std::nullptr_t, Ptr<T> const &rhs)
+operator==(nullptr_t, Ptr<T> const &rhs)
 {
   return rhs.get() == nullptr;
 }
 
 template <typename T>
 inline bool
-operator!=(std::nullptr_t, Ptr<T> const &rhs)
+operator!=(nullptr_t, Ptr<T> const &rhs)
 {
   return rhs.get() != nullptr;
 }

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2895,7 +2895,6 @@ cplist_reconfigure()
       }
 
       int64_t size_to_alloc = size_in_blocks - cp->size;
-      int disk_full         = 0;
       for (int i = 0; (i < gndisks) && size_to_alloc; i++) {
         int disk_no = sorted_vols[i];
         ink_assert(cp->disk_vols[sorted_vols[gndisks - 1]]);
@@ -2927,10 +2926,6 @@ cplist_reconfigure()
             break;
           }
         } while ((size_diff > 0));
-
-        if (!dpb) {
-          disk_full++;
-        }
 
         size_to_alloc = size_in_blocks - cp->size;
       }

--- a/iocore/cache/Store.cc
+++ b/iocore/cache/Store.cc
@@ -319,7 +319,6 @@ Result
 Store::read_config()
 {
   int n_dsstore   = 0;
-  int ln          = 0;
   int i           = 0;
   const char *err = nullptr;
   Span *sd = nullptr, *cur = nullptr;
@@ -342,9 +341,6 @@ Store::read_config()
   while ((len = ink_file_fd_readline(fd, sizeof(line), line)) > 0) {
     const char *path;
     const char *seed = nullptr;
-    // update lines
-
-    ++ln;
 
     // Because the SimpleTokenizer is a bit too simple, we have to normalize whitespace.
     for (char *spot = line, *limit = line + len; spot < limit; ++spot) {


### PR DESCRIPTION
Fixes for warnings/errors generated by the osx compiler during a CI build.