### PR TITLE
Export traffic_server symbols

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
 function(add_atsplugin name)
   add_library(${name} MODULE ${ARGN})
+  target_link_libraries(${name} PRIVATE traffic_server)
   set_target_properties(${name} PROPERTIES PREFIX "")
   set_target_properties(${name} PROPERTIES SUFFIX ".so")
   set_target_properties(${name} PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib")

--- a/src/traffic_server/CMakeLists.txt
+++ b/src/traffic_server/CMakeLists.txt
@@ -81,4 +81,6 @@ if (TS_USE_LINUX_NATIVE_AIO)
     target_link_libraries(traffic_server aio)
 endif (TS_USE_LINUX_NATIVE_AIO)
 
+set_target_properties(traffic_server PROPERTIES ENABLE_EXPORTS ON)
+
 install(TARGETS traffic_server)


### PR DESCRIPTION
This is a temporary fix until we can separate the API from the traffic_server executable. It sets the ENABLE_EXPORTS property on the traffic_server target to export its symbols, and "links" all the plugins to it. On Linux, this "linking" does nothing of interest. On Mac, the -bundle_loader flag will be added.

Closes #9848.