### PR TITLE
UDP GRO spport

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1390,7 +1390,7 @@ AC_CHECK_FUNCS([clock_gettime kqueue epoll_ctl posix_fadvise posix_madvise posix
 AC_CHECK_FUNCS([port_create strlcpy strlcat sysconf sysctlbyname getpagesize])
 AC_CHECK_FUNCS([getreuid getresuid getresgid setreuid setresuid getpeereid getpeerucred])
 AC_CHECK_FUNCS([strsignal psignal psiginfo accept4])
-AC_CHECK_FUNCS([sendmmsg])
+AC_CHECK_FUNCS([sendmmsg recvmmsg])
 
 # Check for eventfd() and sys/eventfd.h (both must exist ...)
 AC_CHECK_HEADERS([sys/eventfd.h], [

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4865,6 +4865,11 @@ UDP Configuration
    and disables it automatically if it causes send errors.
 
 
+.. ts:cv:: CONFIG proxy.config.udp.enable_gro INT 1
+
+   Enables (``1``) or disables (``0``) UDP GRO. When enabled, |TS| will try to use it
+   when reading the UDP socket.
+
 Plug-in Configuration
 =====================
 

--- a/iocore/eventsystem/I_SocketManager.h
+++ b/iocore/eventsystem/I_SocketManager.h
@@ -82,6 +82,9 @@ int64_t pwrite(int fd, void *buf, int len, off_t offset, char *tag = nullptr);
 int send(int fd, void *buf, int len, int flags);
 int sendto(int fd, void *buf, int len, int flags, struct sockaddr const *to, int tolen);
 int sendmsg(int fd, struct msghdr *m, int flags, void *pOLP = nullptr);
+#ifdef HAVE_RECVMMSG
+int recvmmsg(int fd, struct mmsghdr *msgvec, int vlen, int flags, struct timespec *timeout, void *pOLP = nullptr);
+#endif
 int64_t lseek(int fd, off_t offset, int whence);
 int fsync(int fildes);
 int poll(struct pollfd *fds, unsigned long nfds, int timeout);

--- a/iocore/eventsystem/P_UnixSocketManager.h
+++ b/iocore/eventsystem/P_UnixSocketManager.h
@@ -119,6 +119,21 @@ SocketManager::recvmsg(int fd, struct msghdr *m, int flags, void * /* pOLP ATS_U
   return r;
 }
 
+#ifdef HAVE_RECVMMSG
+TS_INLINE int
+SocketManager::recvmmsg(int fd, struct mmsghdr *msgvec, int vlen, int flags, struct timespec *timeout, void * /* pOLP ATS_UNUSED */)
+{
+  int r;
+  do {
+    if (unlikely((r = ::recvmmsg(fd, msgvec, vlen, flags, timeout)) < 0)) {
+      r = -errno;
+      // EINVAL can ocur if timeout is invalid.
+    }
+  } while (r == -EINTR);
+  return r;
+}
+#endif
+
 TS_INLINE int64_t
 SocketManager::write(int fd, void *buf, int size, void * /* pOLP ATS_UNUSED */)
 {

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -110,7 +110,7 @@ public:
      Create a new packet to be delivered to application.
      Internal function only
   */
-  static UDPPacket *new_incoming_UDPPacket(struct sockaddr *from, struct sockaddr *to, Ptr<IOBufferBlock> &block);
+  static UDPPacket *new_incoming_UDPPacket(struct sockaddr *from, struct sockaddr *to, Ptr<IOBufferBlock> block);
 
 private:
   SLINK(UDPPacket, alink); // atomic link

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -53,6 +53,10 @@ public:
 
   off_t pollCont_offset;
   off_t udpNetHandler_offset;
+
+private:
+  void read_single_message_from_net(UDPNetHandler *nh, UDPConnection *uc);
+  void read_multiple_messages_from_net(UDPNetHandler *nh, UDPConnection *xuc);
 };
 
 extern UDPNetProcessorInternal udpNetInternal;

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -309,6 +309,11 @@ void initialize_thread_for_udp_net(EThread *thread);
 class UDPNetHandler : public Continuation, public EThread::LoopTailHandler
 {
 public:
+  struct Cfg {
+    // Segmentation offload.
+    bool enable_gso{true};
+    bool enable_gro{true};
+  };
   // engine for outgoing packets
   UDPQueue udpOutQueue;
 
@@ -332,7 +337,13 @@ public:
   int waitForActivity(ink_hrtime timeout) override;
   void signalActivity() override;
 
-  UDPNetHandler(bool enable_gso);
+  UDPNetHandler(Cfg &&cfg);
+
+  // GRO
+  bool is_gro_enabled() const;
+
+private:
+  Cfg _cfg; // Note: may not be the best place to put this, but for now is ok.
 };
 
 struct PollCont;

--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -347,6 +347,7 @@ QUICNetVConnection::handle_received_packet(UDPPacket *packet)
 {
   size_t buf_len{0};
   uint8_t *buf = packet->get_entire_chain_buffer(&buf_len);
+
   net_activity(this, this_ethread());
   quiche_recv_info recv_info = {
     &packet->from.sa,

--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -347,7 +347,6 @@ QUICNetVConnection::handle_received_packet(UDPPacket *packet)
 {
   size_t buf_len{0};
   uint8_t *buf = packet->get_entire_chain_buffer(&buf_len);
-
   net_activity(this, this_ethread());
   quiche_recv_info recv_info = {
     &packet->from.sa,

--- a/iocore/net/QUICPacketHandler_quiche.cc
+++ b/iocore/net/QUICPacketHandler_quiche.cc
@@ -207,7 +207,7 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
   int rc = quiche_header_info(buf, buf_len, QUICConnectionId::SCID_LEN, &version, &type, scid, &scid_len, dcid, &dcid_len, token,
                               &token_len);
   if (rc < 0) {
-    QUICDebug("Ignore packet - failed to parse header");
+    QUICDebug("Ignore packet - failed to parse header: '%d'", rc);
     udp_packet->free();
     return;
   }

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -37,10 +37,15 @@
 #include "P_Net.h"
 #include "P_UDPNet.h"
 
-#include "netinet/udp.h"
+#include <math.h>
+#include <netinet/udp.h>
 #ifndef UDP_SEGMENT
 // This is needed because old glibc may not have the constant even if Kernel supports it.
 #define UDP_SEGMENT 103
+#endif
+
+#ifndef UDP_GRO
+#define UDP_GRO 104
 #endif
 
 using UDPNetContHandler = int (UDPNetHandler::*)(int, void *);
@@ -70,7 +75,7 @@ UDPPacket::new_UDPPacket(struct sockaddr const *to, ink_hrtime when, Ptr<IOBuffe
 }
 
 UDPPacket *
-UDPPacket::new_incoming_UDPPacket(struct sockaddr *from, struct sockaddr *to, Ptr<IOBufferBlock> &block)
+UDPPacket::new_incoming_UDPPacket(struct sockaddr *from, struct sockaddr *to, Ptr<IOBufferBlock> block)
 {
   UDPPacket *p = udpPacketAllocator.alloc();
 
@@ -147,8 +152,6 @@ UDPPacket::get_entire_chain_buffer(size_t *buf_len)
   if (this->_payload == nullptr) {
     IOBufferBlock *block = this->getIOBlockChain();
 
-    // No need to allocate, we will use the first slice. With the current slice size
-    // 2048 more likely we will using this block most of the time.
     if (block && block->next.get() == nullptr) {
       *buf_len = this->getPktLength();
       return reinterpret_cast<uint8_t *>(block->buf());
@@ -180,6 +183,12 @@ int32_t g_udp_periodicCleanupSlots;
 int32_t g_udp_periodicFreeCancelledPkts;
 int32_t g_udp_numSendRetries;
 
+namespace
+{
+// We'd need to set some flags in case some of the config is enabled. So we have
+// this object as global.
+UDPNetHandler::Cfg G_udp_config;
+} // namespace
 //
 // Public functions
 // See header for documentation
@@ -190,12 +199,23 @@ sockaddr_in6 G_bwGrapherLoc;
 void
 initialize_thread_for_udp_net(EThread *thread)
 {
-  int enable_gso;
+  int enable_gso, enable_gro;
   REC_ReadConfigInteger(enable_gso, "proxy.config.udp.enable_gso");
+  REC_ReadConfigInteger(enable_gro, "proxy.config.udp.enable_gro");
 
   UDPNetHandler *nh = get_UDPNetHandler(thread);
 
-  new (reinterpret_cast<ink_dummy_for_new *>(nh)) UDPNetHandler(enable_gso);
+  UDPNetHandler::Cfg cfg{static_cast<bool>(enable_gso), static_cast<bool>(enable_gro)};
+
+  G_udp_config = cfg; // keep a global copy.
+  new (reinterpret_cast<ink_dummy_for_new *>(nh)) UDPNetHandler(std::move(cfg));
+
+#ifndef SOL_UDP
+  if (G_udp_config.enable_gro) {
+    Warning("Attempted to use UDP GRO per configuration, but it is unavailable");
+  }
+#endif
+
   new (reinterpret_cast<ink_dummy_for_new *>(get_UDPPollCont(thread))) PollCont(thread->mutex);
   // The UDPNetHandler cannot be accessed across EThreads.
   // Because the UDPNetHandler should be called back immediately after UDPPollCont.
@@ -256,6 +276,42 @@ UDPNetProcessorInternal::start(int n_upd_threads, size_t stacksize)
   return 0;
 }
 
+namespace
+{
+bool
+get_ip_address_from_cmsg(struct cmsghdr *cmsg, sockaddr_in6 *toaddr)
+{
+#ifdef IP_PKTINFO
+  if (IP_PKTINFO == cmsg->cmsg_type) {
+    if (cmsg->cmsg_level == IPPROTO_IP) {
+      struct in_pktinfo *pktinfo                               = reinterpret_cast<struct in_pktinfo *>(CMSG_DATA(cmsg));
+      reinterpret_cast<sockaddr_in *>(toaddr)->sin_addr.s_addr = pktinfo->ipi_addr.s_addr;
+    }
+    return true;
+  }
+#endif
+#ifdef IP_RECVDSTADDR
+  if (IP_RECVDSTADDR == cmsg->cmsg_type) {
+    if (cmsg->cmsg_level == IPPROTO_IP) {
+      struct in_addr *addr                                     = reinterpret_cast<struct in_addr *>(CMSG_DATA(cmsg));
+      reinterpret_cast<sockaddr_in *>(toaddr)->sin_addr.s_addr = addr->s_addr;
+    }
+    return true;
+  }
+#endif
+#if defined(IPV6_PKTINFO) || defined(IPV6_RECVPKTINFO)
+  if (IPV6_PKTINFO == cmsg->cmsg_type) { // IPV6_RECVPKTINFO uses IPV6_PKTINFO too
+    if (cmsg->cmsg_level == IPPROTO_IPV6) {
+      struct in6_pktinfo *pktinfo = reinterpret_cast<struct in6_pktinfo *>(CMSG_DATA(cmsg));
+      memcpy(toaddr->sin6_addr.s6_addr, &pktinfo->ipi6_addr, 16);
+    }
+    return true;
+  }
+#endif
+  return false;
+}
+} // namespace
+
 void
 UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc)
 {
@@ -266,7 +322,9 @@ UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc
   int64_t r;
   int iters         = 0;
   unsigned max_niov = 32;
-
+#ifdef SOL_UDP
+  int64_t gso_size{0};
+#endif
   struct msghdr msg;
   Ptr<IOBufferBlock> chain, next_chain;
   struct iovec tiovec[max_niov];
@@ -305,14 +363,32 @@ UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc
     // build struct msghdr
     sockaddr_in6 fromaddr;
     sockaddr_in6 toaddr;
-    int toaddr_len = sizeof(toaddr);
-    char *cbuf[1024];
-    msg.msg_name       = &fromaddr;
-    msg.msg_namelen    = sizeof(fromaddr);
-    msg.msg_iov        = tiovec;
-    msg.msg_iovlen     = niov;
-    msg.msg_control    = cbuf;
-    msg.msg_controllen = sizeof(cbuf);
+    int toaddr_len  = sizeof(toaddr);
+    msg.msg_name    = &fromaddr;
+    msg.msg_namelen = sizeof(fromaddr);
+    msg.msg_iov     = tiovec;
+    msg.msg_iovlen  = niov;
+
+    static const size_t cmsg_size
+    {
+      CMSG_SPACE(sizeof(int))
+#ifdef IP_PKTINFO
+      +CMSG_SPACE(sizeof(struct in_pktinfo))
+#endif
+#if defined(IPV6_PKTINFO) || defined(IPV6_RECVPKTINFO)
+        + CMSG_SPACE(sizeof(struct in6_pktinfo))
+#endif
+#ifdef IP_RECVDSTADDR
+        + CMSG_SPACE(sizeof(struct in_addr))
+#endif
+#ifdef UDP_GRO
+        + CMSG_SPACE(sizeof(uint16_t))
+#endif
+    };
+
+    char control[cmsg_size] = {0};
+    msg.msg_control         = control;
+    msg.msg_controllen      = cmsg_size;
 
     // receive data by recvmsg
     r = SocketManager::recvmsg(uc->getFd(), &msg, 0);
@@ -326,61 +402,55 @@ UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc
       Debug("udp-read", "The UDP packet is truncated");
     }
 
-    // fill the IOBufferBlock chain
-    int64_t saved = r;
-    b             = chain.get();
-    while (b && saved > 0) {
-      if (saved > buffer_size) {
-        b->fill(buffer_size);
-        saved -= buffer_size;
-        b      = b->next.get();
-      } else {
-        b->fill(saved);
-        saved      = 0;
-        next_chain = b->next.get();
-        b->next    = nullptr;
-      }
-    }
-
     safe_getsockname(xuc->getFd(), reinterpret_cast<struct sockaddr *>(&toaddr), &toaddr_len);
     for (auto cmsg = CMSG_FIRSTHDR(&msg); cmsg != nullptr; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
-      switch (cmsg->cmsg_type) {
-#ifdef IP_PKTINFO
-      case IP_PKTINFO:
-        if (cmsg->cmsg_level == IPPROTO_IP) {
-          struct in_pktinfo *pktinfo                                = reinterpret_cast<struct in_pktinfo *>(CMSG_DATA(cmsg));
-          reinterpret_cast<sockaddr_in *>(&toaddr)->sin_addr.s_addr = pktinfo->ipi_addr.s_addr;
-        }
+      if (get_ip_address_from_cmsg(cmsg, &toaddr)) {
         break;
-#endif
-#ifdef IP_RECVDSTADDR
-      case IP_RECVDSTADDR:
-        if (cmsg->cmsg_level == IPPROTO_IP) {
-          struct in_addr *addr                                      = reinterpret_cast<struct in_addr *>(CMSG_DATA(cmsg));
-          reinterpret_cast<sockaddr_in *>(&toaddr)->sin_addr.s_addr = addr->s_addr;
-        }
-        break;
-#endif
-#if defined(IPV6_PKTINFO) || defined(IPV6_RECVPKTINFO)
-      case IPV6_PKTINFO: // IPV6_RECVPKTINFO uses IPV6_PKTINFO too
-        if (cmsg->cmsg_level == IPPROTO_IPV6) {
-          struct in6_pktinfo *pktinfo = reinterpret_cast<struct in6_pktinfo *>(CMSG_DATA(cmsg));
-          memcpy(toaddr.sin6_addr.s6_addr, &pktinfo->ipi6_addr, 16);
-        }
-        break;
-#endif
       }
+#ifdef SOL_UDP
+      if (UDP_GRO == cmsg->cmsg_type) {
+        if (nh->is_gro_enabled()) {
+          gso_size = *reinterpret_cast<uint16_t *>(CMSG_DATA(cmsg));
+        }
+        break;
+      }
+#endif
     }
 
-    // create packet
-    UDPPacket *p = UDPPacket::new_incoming_UDPPacket(ats_ip_sa_cast(&fromaddr), ats_ip_sa_cast(&toaddr), chain);
-    p->setConnection(uc);
-    // queue onto the UDPConnection
-    uc->inQueue.push(p);
+    int const parts = gso_size ? static_cast<int>(ceil(static_cast<double>(r) / static_cast<double>(gso_size))) : 1;
+    Debug("udp-read", "Received %ld bytes. gso_size %ld. Ready to process the payload in %d parts(%s)", r, gso_size, parts,
+          (parts > 1 ? "GRO" : "No GRO"));
+    int64_t total_remaining = r;
 
-    // reload the unused block
-    chain      = next_chain;
-    next_chain = nullptr;
+    for (auto f = 0; f < parts; f++) {
+      b                     = chain.get();
+      int64_t this_packet_r = gso_size ? std::min(gso_size, total_remaining) : total_remaining;
+      while (b && this_packet_r > 0) {
+        if (this_packet_r > buffer_size) {
+          b->fill(buffer_size);
+          total_remaining -= this_packet_r;
+          this_packet_r   -= buffer_size;
+          b                = b->next.get();
+        } else {
+          b->fill(this_packet_r);
+          total_remaining -= this_packet_r;
+          this_packet_r    = 0;
+          next_chain       = b->next.get();
+          b->next          = nullptr;
+        }
+      }
+      Debug("udp-read", "Creating packet");
+      // create packet
+      UDPPacket *p = UDPPacket::new_incoming_UDPPacket(ats_ip_sa_cast(&fromaddr), ats_ip_sa_cast(&toaddr), chain);
+      p->setConnection(uc);
+      // queue onto the UDPConnection
+      uc->inQueue.push(p);
+
+      // reload the unused block
+      chain      = next_chain;
+      next_chain = nullptr;
+    }
+
     iters++;
   } while (r > 0);
   if (iters >= 1) {
@@ -883,7 +953,7 @@ UDPNetProcessor::UDPBind(Continuation *cont, sockaddr const *addr, int fd, int s
   bool need_bind     = true;
 
   if (fd == -1) {
-    if ((res = SocketManager::socket(addr->sa_family, SOCK_DGRAM, 0)) < 0) {
+    if ((res = SocketManager::socket(addr->sa_family, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
       goto Lerror;
     }
     fd = res;
@@ -930,6 +1000,17 @@ UDPNetProcessor::UDPBind(Continuation *cont, sockaddr const *addr, int fd, int s
     }
   }
 
+#ifdef SOL_UDP
+  if (G_udp_config.enable_gro) {
+    int gro = 1;
+    if (safe_setsockopt(fd, IPPROTO_UDP, UDP_GRO, (char *)&gro, sizeof(gro)) == 0) {
+      Debug("udpnet", "setsockopt UDP_GRO ok");
+    } else {
+      Debug("udpnet", "setsockopt UDP_GRO. errno=%d", errno);
+    }
+  }
+#endif
+
   // If this is a class D address (i.e. multicast address), use REUSEADDR.
   if (ats_is_ip_multicast(addr)) {
     int enable_reuseaddr = 1;
@@ -960,6 +1041,7 @@ UDPNetProcessor::UDPBind(Continuation *cont, sockaddr const *addr, int fd, int s
     goto Lerror;
   }
 
+  // check this for GRO
   if (recv_bufsize) {
     if (unlikely(SocketManager::set_rcvbuf_size(fd, recv_bufsize))) {
       Debug("udpnet", "set_dnsbuf_size(%d) failed", recv_bufsize);
@@ -1452,11 +1534,20 @@ net_signal_hook_callback(EThread *thread)
 #endif
 }
 
-UDPNetHandler::UDPNetHandler(bool enable_gso) : udpOutQueue(enable_gso)
+UDPNetHandler::UDPNetHandler(Cfg &&cfg) : udpOutQueue(cfg.enable_gso), _cfg{std::move(cfg)}
 {
   nextCheck = Thread::get_hrtime_updated() + HRTIME_MSECONDS(1000);
   lastCheck = 0;
   SET_HANDLER(&UDPNetHandler::startNetEvent);
+}
+
+bool
+UDPNetHandler::is_gro_enabled() const
+{
+#ifndef SOL_UDP
+  return false;
+#endif
+  return this->_cfg.enable_gro;
 }
 
 int

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -260,7 +260,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.udp.enable_gso", RECD_INT, "1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-
+  {RECT_CONFIG, "proxy.config.udp.enable_gro", RECD_INT, "1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   //##############################################################################
   //#
   //# Alarm Configuration


### PR DESCRIPTION
**WIP** 
I will leave this as draft as I still need to :
- Make another look to the code and improve some stuffs.
- Ammend some stuffs and run some more tests and update the description, I still need to tweak some stuffs but the idea would be this.
- Make sure I have all CI green in the meantime.
**WIP** 

### Descrition

This PR adds support for UDP GRO when reading the socket using `recvm(m)gsg`.  This PR also includes support for `recvmmsg` when it is available by the OS.

There is now a new configuration variable:

```yaml
# records.yaml
ts:
  udp:
    enable_gro: 1 # Enabled by default.
```
----

### Notes

All the tests were done using GET only and setting the h2load parameter to `--max-udp-payload-size=2k`.

|Feature       |Total # Req | # Clients | # recvmmsg | # recvmsg |
|--------------|------------|-----------|------------|-----------|
| recvmmsg+gro | 100k       | 100       |      22834 | 0         |
| recvmmsg     | 100k       | 100       |      23501 | 0         |
| recvmsg+gro  | 100k       | 100       |       | 247970         |
| recvmmsg     | 100k       | 100       |       | 249097         |


As I didn't see much of a difference between having GRO enabled or disabled I did run a test with debug
enabled and I was able to count how many packets came with the GRO set in the ancillary data. 
Then I realized why I wasn't actually seeing much difference, not too many packets were spliced by the kernel.

Packets with (No GRO/GRO) = Number of times that ATS detected a packet with spliced with GRO.

|Feature       |Total # Req | # Clients | # recvmmsg | # recvmsg | # Packets with (No GRO/GRO)  | GRO % |
|--------------|------------|-----------|------------|-----------|---------------|-------|
| recvmmsg+gro | 100k       | 100       |     13929  | 0         |    223080 / **180** | 0.8% |
| recvmsg+gro  | 100k       | 100       |      0| 278718         |    231760 / **34484** | 14% |



**Using recvmmsg reduced the number of syscall significantly**


This is what I used for this tests:


**bpftrace**

```bash
bpftrace -e 'tracepoint:syscalls:sys_enter_recvm* { @[comm, probe] = count();  }' 
```
**h2load**
```bash
/opt/bin/h2load -n 100000 -c 100 --npn-list=h3 URL --max-udp-payload-size=2k
```

I was using only **GET** requests with around 15 header with about 80 bytes each.
I have not tried POST yet which I believe will give us better insights.


