### PR TITLE
Add support for recvmmsg and UDP GRO

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1390,7 +1390,7 @@ AC_CHECK_FUNCS([clock_gettime kqueue epoll_ctl posix_fadvise posix_madvise posix
 AC_CHECK_FUNCS([port_create strlcpy strlcat sysconf sysctlbyname getpagesize])
 AC_CHECK_FUNCS([getreuid getresuid getresgid setreuid setresuid getpeereid getpeerucred])
 AC_CHECK_FUNCS([strsignal psignal psiginfo accept4])
-AC_CHECK_FUNCS([sendmmsg])
+AC_CHECK_FUNCS([sendmmsg recvmmsg])
 
 # Check for eventfd() and sys/eventfd.h (both must exist ...)
 AC_CHECK_HEADERS([sys/eventfd.h], [

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4877,6 +4877,11 @@ UDP Configuration
    and disables it automatically if it causes send errors.
 
 
+.. ts:cv:: CONFIG proxy.config.udp.enable_gro INT 1
+
+   Enables (``1``) or disables (``0``) UDP GRO. When enabled, |TS| will try to use it
+   when reading the UDP socket.
+
 Plug-in Configuration
 =====================
 

--- a/iocore/eventsystem/I_SocketManager.h
+++ b/iocore/eventsystem/I_SocketManager.h
@@ -82,6 +82,9 @@ int64_t pwrite(int fd, void *buf, int len, off_t offset, char *tag = nullptr);
 int send(int fd, void *buf, int len, int flags);
 int sendto(int fd, void *buf, int len, int flags, struct sockaddr const *to, int tolen);
 int sendmsg(int fd, struct msghdr *m, int flags, void *pOLP = nullptr);
+#ifdef HAVE_RECVMMSG
+int recvmmsg(int fd, struct mmsghdr *msgvec, int vlen, int flags, struct timespec *timeout, void *pOLP = nullptr);
+#endif
 int64_t lseek(int fd, off_t offset, int whence);
 int fsync(int fildes);
 int poll(struct pollfd *fds, unsigned long nfds, int timeout);

--- a/iocore/eventsystem/P_UnixSocketManager.h
+++ b/iocore/eventsystem/P_UnixSocketManager.h
@@ -119,6 +119,21 @@ SocketManager::recvmsg(int fd, struct msghdr *m, int flags, void * /* pOLP ATS_U
   return r;
 }
 
+#ifdef HAVE_RECVMMSG
+TS_INLINE int
+SocketManager::recvmmsg(int fd, struct mmsghdr *msgvec, int vlen, int flags, struct timespec *timeout, void * /* pOLP ATS_UNUSED */)
+{
+  int r;
+  do {
+    if (unlikely((r = ::recvmmsg(fd, msgvec, vlen, flags, timeout)) < 0)) {
+      r = -errno;
+      // EINVAL can ocur if timeout is invalid.
+    }
+  } while (r == -EINTR);
+  return r;
+}
+#endif
+
 TS_INLINE int64_t
 SocketManager::write(int fd, void *buf, int size, void * /* pOLP ATS_UNUSED */)
 {

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -110,7 +110,7 @@ public:
      Create a new packet to be delivered to application.
      Internal function only
   */
-  static UDPPacket *new_incoming_UDPPacket(struct sockaddr *from, struct sockaddr *to, Ptr<IOBufferBlock> &block);
+  static UDPPacket *new_incoming_UDPPacket(struct sockaddr *from, struct sockaddr *to, Ptr<IOBufferBlock> block);
 
 private:
   SLINK(UDPPacket, alink); // atomic link

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -310,6 +310,11 @@ void initialize_thread_for_udp_net(EThread *thread);
 class UDPNetHandler : public Continuation, public EThread::LoopTailHandler
 {
 public:
+  struct Cfg {
+    // Segmentation offload.
+    bool enable_gso{true};
+    bool enable_gro{true};
+  };
   // engine for outgoing packets
   UDPQueue udpOutQueue;
 
@@ -333,7 +338,13 @@ public:
   int waitForActivity(ink_hrtime timeout) override;
   void signalActivity() override;
 
-  UDPNetHandler(bool enable_gso);
+  UDPNetHandler(Cfg &&cfg);
+
+  // GRO
+  bool is_gro_enabled() const;
+
+private:
+  Cfg _cfg; // Note: may not be the best place to put this, but for now is ok.
 };
 
 static inline PollCont *

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -54,6 +54,10 @@ public:
 
   off_t pollCont_offset;
   off_t udpNetHandler_offset;
+
+private:
+  void read_single_message_from_net(UDPNetHandler *nh, UDPConnection *uc);
+  void read_multiple_messages_from_net(UDPNetHandler *nh, UDPConnection *xuc);
 };
 
 extern UDPNetProcessorInternal udpNetInternal;

--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -349,7 +349,6 @@ QUICNetVConnection::handle_received_packet(UDPPacket *packet)
 {
   size_t buf_len{0};
   uint8_t *buf = packet->get_entire_chain_buffer(&buf_len);
-
   net_activity(this, this_ethread());
   quiche_recv_info recv_info = {
     &packet->from.sa,

--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -349,6 +349,7 @@ QUICNetVConnection::handle_received_packet(UDPPacket *packet)
 {
   size_t buf_len{0};
   uint8_t *buf = packet->get_entire_chain_buffer(&buf_len);
+
   net_activity(this, this_ethread());
   quiche_recv_info recv_info = {
     &packet->from.sa,

--- a/iocore/net/QUICPacketHandler_quiche.cc
+++ b/iocore/net/QUICPacketHandler_quiche.cc
@@ -207,7 +207,7 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
   int rc = quiche_header_info(buf, buf_len, QUICConnectionId::SCID_LEN, &version, &type, scid, &scid_len, dcid, &dcid_len, token,
                               &token_len);
   if (rc < 0) {
-    QUICDebug("Ignore packet - failed to parse header");
+    QUICDebug("Ignore packet - failed to parse header: '%d'", rc);
     udp_packet->free();
     return;
   }

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -1717,8 +1717,9 @@ UDPNetHandler::is_gro_enabled() const
 {
 #ifndef SOL_UDP
   return false;
-#endif
+#else
   return this->_cfg.enable_gro;
+#endif
 }
 
 int

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -37,6 +37,7 @@
 #include "P_DNSConnection.h"
 #include "P_Net.h"
 #include "P_UDPNet.h"
+#include "tscore/ink_inet.h"
 
 #include "tscore/ink_sock.h"
 #include <math.h>
@@ -54,6 +55,13 @@ using UDPNetContHandler = int (UDPNetHandler::*)(int, void *);
 
 ClassAllocator<UDPPacket> udpPacketAllocator("udpPacketAllocator");
 EventType ET_UDP;
+
+namespace
+{
+#ifdef HAVE_RECVMMSG
+const uint32_t MAX_RECEIVE_MSG_PER_CALL{16}; //< VLEN parameter for the recvmmsg call.
+#endif
+}; // namespace
 
 UDPPacket *
 UDPPacket::new_UDPPacket()
@@ -312,10 +320,40 @@ get_ip_address_from_cmsg(struct cmsghdr *cmsg, sockaddr_in6 *toaddr)
 #endif
   return false;
 }
+
+unsigned int
+build_iovec_block_chain(unsigned max_niov, int64_t size_index, Ptr<IOBufferBlock> &chain, struct iovec *out_tiovec)
+{
+  unsigned int niov;
+  IOBufferBlock *b, *last;
+
+  // build struct iov
+  // reuse the block in chain if available
+  b    = chain.get();
+  last = nullptr;
+  for (niov = 0; niov < max_niov; niov++) {
+    if (b == nullptr) {
+      b = new_IOBufferBlock();
+      b->alloc(size_index);
+      if (last == nullptr) {
+        chain = b;
+      } else {
+        last->next = b;
+      }
+    }
+
+    out_tiovec[niov].iov_base = b->buf();
+    out_tiovec[niov].iov_len  = b->block_size();
+
+    last = b;
+    b    = b->next.get();
+  }
+  return niov;
+}
 } // namespace
 
 void
-UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc)
+UDPNetProcessorInternal::read_single_message_from_net(UDPNetHandler *nh, UDPConnection *xuc)
 {
   UnixUDPConnection *uc = (UnixUDPConnection *)xuc;
 
@@ -324,9 +362,7 @@ UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc
   int64_t r;
   int iters         = 0;
   unsigned max_niov = 32;
-#ifdef SOL_UDP
-  int64_t gso_size{0};
-#endif
+  int64_t gso_size{0}; // in case is available.
   struct msghdr msg;
   Ptr<IOBufferBlock> chain, next_chain;
   struct iovec tiovec[max_niov];
@@ -337,30 +373,7 @@ UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc
   // And there is 8 octets in 'User Datagram Header' which means the max length of payload is no more than 65527 bytes.
   do {
     // create IOBufferBlock chain to receive data
-    unsigned int niov;
-    IOBufferBlock *b, *last;
-
-    // build struct iov
-    // reuse the block in chain if available
-    b    = chain.get();
-    last = nullptr;
-    for (niov = 0; niov < max_niov; niov++) {
-      if (b == nullptr) {
-        b = new_IOBufferBlock();
-        b->alloc(size_index);
-        if (last == nullptr) {
-          chain = b;
-        } else {
-          last->next = b;
-        }
-      }
-
-      tiovec[niov].iov_base = b->buf();
-      tiovec[niov].iov_len  = b->block_size();
-
-      last = b;
-      b    = b->next.get();
-    }
+    unsigned int niov = build_iovec_block_chain(max_niov, size_index, chain, tiovec);
 
     // build struct msghdr
     sockaddr_in6 fromaddr;
@@ -419,26 +432,25 @@ UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc
 #endif
     }
 
+    // If we got the gso size, then we need to find out in how many parts this was spliced.
     int const parts = gso_size ? static_cast<int>(ceil(static_cast<double>(r) / static_cast<double>(gso_size))) : 1;
-    Debug("udp-read", "Received %ld bytes. gso_size %ld. Ready to process the payload in %d parts(%s)", r, gso_size, parts,
-          (parts > 1 ? "GRO" : "No GRO"));
-    int64_t total_remaining = r;
+    Debug("udp-read", "Received %lld bytes. gso_size %lld. Ready to process the payload in %d parts(%s)", static_cast<long long>(r),
+          static_cast<long long>(gso_size), parts, (parts > 1 ? "GRO" : "No GRO"));
 
-    for (auto f = 0; f < parts; f++) {
-      b                     = chain.get();
-      int64_t this_packet_r = gso_size ? std::min(gso_size, total_remaining) : total_remaining;
-      while (b && this_packet_r > 0) {
+    IOBufferBlock *block;
+    for (auto part = 0; part < parts; part++) {
+      block                 = chain.get();
+      int64_t this_packet_r = gso_size ? std::min(gso_size, r) : r;
+      while (block && this_packet_r > 0) {
         if (this_packet_r > buffer_size) {
-          b->fill(buffer_size);
-          total_remaining -= this_packet_r;
-          this_packet_r   -= buffer_size;
-          b                = b->next.get();
+          block->fill(buffer_size);
+          this_packet_r -= buffer_size;
+          block          = block->next.get();
         } else {
-          b->fill(this_packet_r);
-          total_remaining -= this_packet_r;
-          this_packet_r    = 0;
-          next_chain       = b->next.get();
-          b->next          = nullptr;
+          block->fill(this_packet_r);
+          this_packet_r = 0;
+          next_chain    = block->next.get();
+          block->next   = nullptr;
         }
       }
       Debug("udp-read", "Creating packet");
@@ -466,6 +478,169 @@ UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc
     nh->udp_callbacks.enqueue(uc);
     uc->onCallbackQueue = 1;
   }
+}
+
+#ifdef HAVE_RECVMMSG
+void
+UDPNetProcessorInternal::read_multiple_messages_from_net(UDPNetHandler *nh, UDPConnection *xuc)
+{
+  UnixUDPConnection *uc = (UnixUDPConnection *)xuc;
+
+  std::array<Ptr<IOBufferBlock>, MAX_RECEIVE_MSG_PER_CALL> buffer_chain;
+  unsigned max_niov = 32;
+  int64_t gso_size{0}; // In case is available
+
+  struct mmsghdr mmsg[MAX_RECEIVE_MSG_PER_CALL];
+  struct iovec tiovec[MAX_RECEIVE_MSG_PER_CALL][max_niov];
+
+  // Addresses
+  sockaddr_in6 fromaddr[MAX_RECEIVE_MSG_PER_CALL];
+  sockaddr_in6 toaddr[MAX_RECEIVE_MSG_PER_CALL];
+  int toaddr_len = sizeof(toaddr);
+
+  size_t total_bytes_read{0};
+
+  static const size_t cmsg_size
+  {
+    CMSG_SPACE(sizeof(int))
+#ifdef IP_PKTINFO
+    +CMSG_SPACE(sizeof(struct in_pktinfo))
+#endif
+#if defined(IPV6_PKTINFO) || defined(IPV6_RECVPKTINFO)
+      + CMSG_SPACE(sizeof(struct in6_pktinfo))
+#endif
+#ifdef IP_RECVDSTADDR
+      + CMSG_SPACE(sizeof(struct in_addr))
+#endif
+#ifdef UDP_GRO
+      + CMSG_SPACE(sizeof(uint16_t))
+#endif
+  };
+
+  // Ancillary data.
+  char control[MAX_RECEIVE_MSG_PER_CALL][cmsg_size];
+
+  int64_t size_index  = BUFFER_SIZE_INDEX_2K;
+  int64_t buffer_size = BUFFER_SIZE_FOR_INDEX(size_index);
+  // The max length of receive buffer is 32 * buffer_size (2048) = 65536 bytes.
+  // Because the 'UDP Length' is type of uint16_t defined in RFC 768.
+  // And there is 8 octets in 'User Datagram Header' which means the max length of payload is no more than 65527 bytes.
+
+  for (uint32_t msg_num = 0; msg_num < MAX_RECEIVE_MSG_PER_CALL; msg_num++) {
+    // build each block chain.
+    unsigned int niov = build_iovec_block_chain(max_niov, size_index, buffer_chain[msg_num], tiovec[msg_num]);
+
+    mmsg[msg_num].msg_hdr.msg_iov     = tiovec[msg_num];
+    mmsg[msg_num].msg_hdr.msg_iovlen  = niov;
+    mmsg[msg_num].msg_hdr.msg_name    = &fromaddr[msg_num];
+    mmsg[msg_num].msg_hdr.msg_namelen = sizeof(fromaddr[msg_num]);
+    memset(control[msg_num], 0, cmsg_size);
+    mmsg[msg_num].msg_hdr.msg_control    = control[msg_num];
+    mmsg[msg_num].msg_hdr.msg_controllen = cmsg_size;
+  }
+
+  const int return_val = SocketManager::recvmmsg(uc->getFd(), mmsg, MAX_RECEIVE_MSG_PER_CALL, MSG_WAITFORONE, nullptr);
+
+  if (return_val <= 0) {
+    Debug("udp-read", "Done. recvmmsg() ret is %d, errno %s", return_val, strerror(errno));
+    return;
+  }
+  Debug("udp-read", "recvmmsg() read %d packets", return_val);
+
+  Ptr<IOBufferBlock> chain, next_chain;
+  for (auto packet_num = 0; packet_num < return_val; packet_num++) {
+    gso_size = 0;
+
+    Debug("udp-read", "Processing message %d from a total of %d", packet_num, return_val);
+    struct msghdr &mhdr = mmsg[packet_num].msg_hdr;
+
+    if (mhdr.msg_flags & MSG_TRUNC) {
+      Debug("udp-read", "The UDP packet is truncated");
+      break;
+    }
+
+    if (mhdr.msg_namelen <= 0) {
+      Debug("udp-read", "Unable to get remote address from recvmmsg() for fd: %d", uc->getFd());
+      return;
+    }
+
+    safe_getsockname(xuc->getFd(), reinterpret_cast<struct sockaddr *>(&toaddr[packet_num]), &toaddr_len);
+    if (mhdr.msg_controllen > 0) {
+      for (auto cmsg = CMSG_FIRSTHDR(&mhdr); cmsg != nullptr; cmsg = CMSG_NXTHDR(&mhdr, cmsg)) {
+        if (get_ip_address_from_cmsg(cmsg, &toaddr[packet_num])) {
+          break;
+        }
+#ifdef SOL_UDP
+        if (UDP_GRO == cmsg->cmsg_type) {
+          if (nh->is_gro_enabled()) {
+            gso_size = *reinterpret_cast<uint16_t *>(CMSG_DATA(cmsg));
+          }
+          break;
+        }
+#endif
+      }
+    }
+
+    const int64_t received  = mmsg[packet_num].msg_len;
+    total_bytes_read       += received;
+
+    // If we got the gso size, then we need to find out in how many parts this was spliced.
+    int const parts = gso_size ? static_cast<int>(ceil(static_cast<double>(received) / static_cast<double>(gso_size))) : 1;
+
+    Debug("udp-read", "Received %lld bytes. gso_size %lld. Ready to process the payload in %d parts(%s)",
+          static_cast<long long>(received), static_cast<long long>(gso_size), parts, (parts > 1 ? "GRO" : "No GRO"));
+
+    auto chain = buffer_chain[packet_num];
+    IOBufferBlock *block;
+    for (auto part = 0; part < parts; part++) {
+      block                 = chain.get();
+      int64_t this_packet_r = gso_size ? std::min(gso_size, received) : received;
+      while (block && this_packet_r > 0) {
+        if (this_packet_r > buffer_size) {
+          block->fill(buffer_size);
+          this_packet_r -= buffer_size;
+          block          = block->next.get();
+        } else {
+          block->fill(this_packet_r);
+          this_packet_r = 0;
+          next_chain    = block->next.get();
+          block->next   = nullptr;
+        }
+      }
+
+      // create packet
+      UDPPacket *p =
+        UDPPacket::new_incoming_UDPPacket(ats_ip_sa_cast(&fromaddr[packet_num]), ats_ip_sa_cast(&toaddr[packet_num]), chain);
+      p->setConnection(uc);
+      // queue onto the UDPConnection
+      uc->inQueue.push(p);
+
+      // reload the unused block
+      chain      = next_chain;
+      next_chain = nullptr;
+    }
+  }
+  Debug("udp-read", "Total bytes read %ld from %d packets.", total_bytes_read, return_val);
+
+  // if not already on to-be-called-back queue, then add it.
+  if (!uc->onCallbackQueue) {
+    ink_assert(uc->callback_link.next == nullptr);
+    ink_assert(uc->callback_link.prev == nullptr);
+    uc->AddRef();
+    nh->udp_callbacks.enqueue(uc);
+    uc->onCallbackQueue = 1;
+  }
+}
+#endif
+
+void
+UDPNetProcessorInternal::udp_read_from_net(UDPNetHandler *nh, UDPConnection *xuc)
+{
+#if HAVE_RECVMMSG
+  read_multiple_messages_from_net(nh, xuc);
+#else
+  read_single_message_from_net(nh, xuc);
+#endif
 }
 
 int
@@ -953,7 +1128,7 @@ UDPNetProcessor::UDPBind(Continuation *cont, sockaddr const *addr, int fd, int s
   bool need_bind     = true;
 
   if (fd == -1) {
-    if ((res = SocketManager::socket(addr->sa_family, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+    if ((res = SocketManager::socket(addr->sa_family, SOCK_DGRAM, 0)) < 0) {
       goto Lerror;
     }
     fd = res;

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -260,7 +260,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.udp.enable_gso", RECD_INT, "1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-
+  {RECT_CONFIG, "proxy.config.udp.enable_gro", RECD_INT, "1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   //##############################################################################
   //#
   //# Alarm Configuration


### PR DESCRIPTION
### Descrition

This PR adds support for UDP GRO when reading the socket using `recvm(m)sg`,  also includes support for `recvmmsg` when it is available by the OS.

There is now a new configuration variable:

```yaml
# records.yaml
ts:
  udp:
    enable_gro: 1 # Enabled by default.
```
----

### Notes

All the tests were done using GET only and setting the h2load parameter to `--max-udp-payload-size=2k`.

|Feature       |Total # Req | # Clients | # recvmmsg | # recvmsg |
|--------------|------------|-----------|------------|-----------|
| recvmmsg+gro | 100k       | 100       |      22834 | 0         |
| recvmmsg     | 100k       | 100       |      23501 | 0         |
| recvmsg+gro  | 100k       | 100       |       | 247970         |
| recvmmsg     | 100k       | 100       |       | 249097         |


As I didn't see much of a difference between having GRO enabled or disabled I did run a test with debug
enabled and I was able to count how many packets came with the GRO set in the ancillary data. 
Then I realized why I wasn't actually seeing much difference, not too many packets were spliced by the kernel.

Packets with (No GRO/GRO) = Number of times that ATS detected a packet with spliced with GRO.

|Feature       |Total # Req | # Clients | # recvmmsg | # recvmsg | # Packets with (No GRO/GRO)  | GRO % |
|--------------|------------|-----------|------------|-----------|---------------|-------|
| recvmmsg+gro | 100k       | 100       |     13929  | 0         |    223080 / **180** | 0.8% |
| recvmsg+gro  | 100k       | 100       |      0| 278718         |    231760 / **34484** | 14% |



**Using recvmmsg reduced the number of syscall significantly**


This is what I used for this tests:


**bpftrace**

```bash
bpftrace -e 'tracepoint:syscalls:sys_enter_recvm* { @[comm, probe] = count();  }' 
```
**h2load**
```bash
/opt/bin/h2load -n 100000 -c 100 --npn-list=h3 URL --max-udp-payload-size=2k
```

I was using only **GET** requests with around 15 header with about 80 bytes each.
I have not tried POST yet which I believe will give us better insights.

I tested this on `Ubuntu 20.04` and `FreeBSD 13.1`. All figures here are from a tests on Ubuntu. 
This was tested on `FreeBSD 13.1` which does not support GSO/GRO to make sure the functionallity works the same.


