### PR TITLE
build_h3_tools: fix path navigation

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -124,7 +124,7 @@ cmake \
 
 ${MAKE} -j ${num_threads}
 sudo ${MAKE} install
-cd ..
+cd ../..
 
 # Build quiche
 # Steps borrowed from: https://github.com/apache/trafficserver-ci/blob/main/docker/rockylinux8/Dockerfile


### PR DESCRIPTION
After changing into boringssl, we then create a build directory and change into that. So, once done building boringssl, we have to go up two directories. Otherwise the rest of the git clones are inside the boringssl repo.