### PR TITLE
Add some proxy/http tests to CMake build

### DIFF
--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -46,7 +46,10 @@ if(BUILD_REGRESSION_TESTING)
     target_sources(http PRIVATE RegressionHttpTransact.cc)
 endif()
 
-target_include_directories(http PRIVATE
+target_include_directories(http
+    PUBLIC
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+    PRIVATE
         ${IOCORE_INCLUDE_DIRS}
         ${PROXY_INCLUDE_DIRS}
         ${CMAKE_SOURCE_DIR}/mgmt
@@ -56,6 +59,10 @@ target_include_directories(http PRIVATE
 
 if(TS_USE_QUIC)
     target_link_libraries(http PRIVATE ts::http3)
+endif()
+
+if(BUILD_TESTING)
+  add_subdirectory(unit_tests)
 endif()
 
 add_subdirectory(remap)

--- a/proxy/http/unit_tests/CMakeLists.txt
+++ b/proxy/http/unit_tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_executable(test_http test_ForwardedConfig.cc test_PreWarm.cc)
+
+# transitive
+target_include_directories(test_http PRIVATE "${PROJECT_SOURCE_DIR}/mgmt")
+
+target_link_libraries(test_http
+    PRIVATE
+        catch2::catch2
+        ts::http
+        ts::inkevent # transitive
+        ts::proxy # transitive
+)
+
+add_test(NAME test_http COMMAND $<TARGET_FILE:test_http>)


### PR DESCRIPTION
This adds test_ForwardedConfig and test_PreWarm to the Catch2 tests that CMake builds. It does not add test_HttpTransact, because it has cyclic dependencies that aren't resolved even by adding it in src/tests.