### PR TITLE
Add escalate plugin to CMake build

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -38,14 +38,14 @@ add_subdirectory(cachekey)
 add_subdirectory(certifier)
 add_subdirectory(compress)
 add_subdirectory(conf_remap)
+add_subdirectory(escalate)
 add_subdirectory(esi)
 
-add_subdirectory(header_rewrite)
-
 add_subdirectory(generator)
+add_subdirectory(header_rewrite)
+add_subdirectory(xdebug)
 
 if(HOST_OS STREQUAL "linux")
-add_subdirectory(healthchecks)
+    add_subdirectory(healthchecks)
 endif()
 
-add_subdirectory(xdebug)

--- a/plugins/escalate/CMakeLists.txt
+++ b/plugins/escalate/CMakeLists.txt
@@ -1,0 +1,20 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_atsplugin(escalate escalate.cc)
+
+target_include_directories(escalate PRIVATE "${CMAKE_SOURCE_DIR}/include/ts")


### PR DESCRIPTION
This builds the escalate plugin with CMake and improves the style in plugins/CMakeLists a little bit.