### PR TITLE
Detect SSL_CTX_set_keylog_callback in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,8 +213,6 @@ check_symbol_exists(IN6_IS_ADDR_UNSPECIFIED "netinet/in.h" TS_HAS_IN6_IS_ADDR_UN
 check_symbol_exists(IP_TOS "netinet/ip.h" TS_HAS_IP_TOS)
 check_symbol_exists(SO_MARK "sys/socket.h" TS_HAS_SO_MARK)
 check_symbol_exists(SO_PEERCRED "sys/socket.h" TS_HAS_SO_PEERCRED)
-check_symbol_exists(TLS1_3_VERSION "${OPENSSL_INCLUDE_DIR}/openssl/ssl.h" TS_USE_TLS13)
-check_symbol_exists(OPENSSL_NO_TLS1_3 "${OPENSSL_INCLUDE_DIR}/openssl/ssl.h" TS_NO_USE_TLS13)
 if(TS_NO_USE_TLS13)
     set(TS_USE_TLS13 FALSE CACHE)
 endif()
@@ -257,8 +255,18 @@ check_symbol_exists(BIO_meth_get_ctrl "openssl/bio.h" HAVE_BIO_METH_GET_CTRL)
 check_symbol_exists(BIO_meth_get_create "openssl/bio.h" HAVE_BIO_METH_GET_CREATE)
 check_symbol_exists(BIO_meth_get_destroy "openssl/bio.h" HAVE_BIO_METH_GET_DESTROY)
 check_symbol_exists(DH_get_2048_256 "openssl/dh.h" TS_USE_GET_DH_2048_256)
-check_symbol_exists(SSL_CTX_set_keylog_callback openssl/ssl.h TS_HAS_TLS_KEYLOGGING)
-check_symbol_exists(SSL_CTX_set_tlsext_ticket_key_cb openssl/ssl.h HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_CB)
+check_symbol_exists(OPENSSL_NO_TLS_3 "openssl/ssl.h" TS_NO_USE_TLS12)
+check_symbol_exists(
+    SSL_CTX_set_keylog_callback
+    "openssl/ssl.h"
+    TS_HAS_TLS_KEYLOGGING
+)
+check_symbol_exists(
+    SSL_CTX_set_tlsext_ticket_key_cb
+    "openssl/ssl.h"
+    HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_CB
+)
+check_symbol_exists(TLS1_3_VERSION "openssl/ssl.h" TS_USE_TLS13)
 
 # Catch2 for tests
 set(CATCH_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/lib/catch2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,10 @@ endif(HAVE_LIBAIO AND USE_LIBAIO)
 
 # Check ssl functionality
 list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
-list(APPEND CMAKE_REQUIRED_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+list(APPEND CMAKE_REQUIRED_LIBRARIES
+    ${OPENSSL_SSL_LIBRARY}
+    ${OPENSSL_CRYPTO_LIBRARY}
+)
 check_symbol_exists(BIO_meth_new "openssl/bio.h" HAVE_BIO_METH_NEW)
 check_symbol_exists(BIO_set_data "openssl/bio.h" HAVE_BIO_SET_DATA)
 check_symbol_exists(BIO_get_data "openssl/bio.h" HAVE_BIO_GET_DATA)
@@ -254,6 +257,7 @@ check_symbol_exists(BIO_meth_get_ctrl "openssl/bio.h" HAVE_BIO_METH_GET_CTRL)
 check_symbol_exists(BIO_meth_get_create "openssl/bio.h" HAVE_BIO_METH_GET_CREATE)
 check_symbol_exists(BIO_meth_get_destroy "openssl/bio.h" HAVE_BIO_METH_GET_DESTROY)
 check_symbol_exists(DH_get_2048_256 "openssl/dh.h" TS_USE_GET_DH_2048_256)
+check_symbol_exists(SSL_CTX_set_keylog_callback openssl/ssl.h TS_HAS_TLS_KEYLOGGING)
 check_symbol_exists(SSL_CTX_set_tlsext_ticket_key_cb openssl/ssl.h HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_CB)
 
 # Catch2 for tests

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -73,6 +73,7 @@
 #cmakedefine01 HAVE_EVENTFD
 
 #cmakedefine01 HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_CB
+#cmakedefine01 TS_HAS_TLS_KEYLOGGING
 
 #cmakedefine HAVE_BIO_METH_NEW 1
 #cmakedefine HAVE_BIO_SET_DATA 1


### PR DESCRIPTION
This looks for the symbol SSL_CTX_set_keylog_callback declared in ssl.h and defined in libssl.so. It defines the TS_HAS_TLS_KEYLOGGING appropriately so that we can run autests on TLS features, since the autests assume that TLS keylogging is enabled.