### PR TITLE
Use string copy for the SNI server name.

### DIFF
--- a/proxy/private/SSLProxySession.cc
+++ b/proxy/private/SSLProxySession.cc
@@ -21,8 +21,6 @@
   limitations under the License.
  */
 
-#include <cstring>
-
 #include "SSLProxySession.h"
 #include "I_EventSystem.h"
 #include "I_NetVConnection.h"
@@ -32,13 +30,10 @@ void
 SSLProxySession::init(NetVConnection const &new_vc)
 {
   if (dynamic_cast<const TLSSNISupport *>(&new_vc) != nullptr) {
-    char const *name = new_vc.get_server_name();
-    int length       = std::strlen(name) + 1;
-    if (length > 1) {
-      char *n = new char[length];
-      std::memcpy(n, name, length);
-      _client_sni_server_name.reset(n);
+    if (char const *name = new_vc.get_server_name()) {
+      _client_sni_server_name.assign(name);
     }
   }
+
   _client_provided_cert = new_vc.peer_provided_cert();
 }

--- a/proxy/private/SSLProxySession.h
+++ b/proxy/private/SSLProxySession.h
@@ -23,8 +23,7 @@
 
 #pragma once
 
-#include <memory>
-#include <string_view>
+#include <string>
 
 class NetVConnection;
 
@@ -36,7 +35,7 @@ public:
   char const *
   client_sni_server_name() const
   {
-    return _client_sni_server_name.get();
+    return _client_sni_server_name.empty() ? nullptr : _client_sni_server_name.c_str();
   }
 
   bool
@@ -48,6 +47,6 @@ public:
   void init(NetVConnection const &new_vc);
 
 private:
-  std::unique_ptr<char[]> _client_sni_server_name;
+  std::string _client_sni_server_name;
   bool _client_provided_cert = false;
 };


### PR DESCRIPTION
Since the server name is a string, we don't need to manually copy, we can just copy it into a std::string.