### PR TITLE
Define DEBUG and _DEBUG in CMake Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(DEBUG _DEBUG)
+endif()
+
 # ATS uses "unix" for variable names.  Make sure its not defined
 remove_definitions(-Dunix)
 


### PR DESCRIPTION
Our debug asserts weren't working because these debug symbols weren't defined when using a Debug configuration.