### PR TITLE
Remove socket option globals.

### DIFF
--- a/include/tscore/ink_defs.h
+++ b/include/tscore/ink_defs.h
@@ -71,9 +71,6 @@ countof(const T (&)[N])
 #define countof(x) ((unsigned)(sizeof(x) / sizeof((x)[0])))
 #endif
 
-#define SOCKOPT_ON  ((char *)&on)
-#define SOCKOPT_OFF ((char *)&off)
-
 #ifndef ABS
 #define ABS(x) (((x) < 0) ? (-(x)) : (x))
 #endif
@@ -92,11 +89,6 @@ countof(const T (&)[N])
 #endif
 
 #define MAX_ALPN_STRING 30
-
-/* Variables
- */
-extern int off;
-extern int on;
 
 /* Functions
  */

--- a/include/tscore/ink_sock.h
+++ b/include/tscore/ink_sock.h
@@ -30,16 +30,29 @@
 #pragma once
 
 #include "tscore/ink_platform.h"
-#include "tscore/ink_defs.h"
-
 #include "tscore/ink_apidefs.h"
 
-int safe_setsockopt(int s, int level, int optname, const void *optval, int optlevel);
-int safe_getsockopt(int s, int level, int optname, void *optval, int *optlevel);
 int safe_bind(int s, struct sockaddr const *name, int namelen);
 int safe_listen(int s, int backlog);
 int safe_getsockname(int s, struct sockaddr *name, int *namelen);
 int safe_getpeername(int s, struct sockaddr *name, int *namelen);
+
+int safe_setsockopt(int s, int level, int optname, const void *optval, int optlen);
+int safe_getsockopt(int s, int level, int optname, void *optval, int *optlen);
+
+static inline int
+setsockopt_on(int s, int level, int optname)
+{
+  int on = 1;
+  return safe_setsockopt(s, level, optname, &on, sizeof(on));
+}
+
+static inline int
+setsockopt_off(int s, int level, int optname)
+{
+  int on = 0;
+  return safe_setsockopt(s, level, optname, &on, sizeof(on));
+}
 
 /** Repeat write calls to fd until all len bytes are written.
  *

--- a/iocore/dns/DNSConnection.cc
+++ b/iocore/dns/DNSConnection.cc
@@ -31,6 +31,7 @@
 #include "P_DNS.h"
 #include "P_DNSConnection.h"
 #include "P_DNSProcessor.h"
+#include "tscore/ink_sock.h"
 
 #define SET_TCP_NO_DELAY
 #define SET_NO_LINGER
@@ -175,7 +176,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
 // cannot do this after connection on non-blocking connect
 #ifdef SET_TCP_NO_DELAY
   if (opt._use_tcp) {
-    if ((res = safe_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, SOCKOPT_ON, sizeof(int))) < 0) {
+    if ((res = setsockopt_on(fd, IPPROTO_TCP, TCP_NODELAY)) < 0) {
       goto Lerror;
     }
   }
@@ -185,7 +186,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
 #endif
 #ifdef SET_SO_KEEPALIVE
   // enables 2 hour inactivity probes, also may fix IRIX FIN_WAIT_2 leak
-  if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, SOCKOPT_ON, sizeof(int))) < 0) {
+  if ((res = setsockopt_on(fd, SOL_SOCKET, SO_KEEPALIVE)) < 0) {
     goto Lerror;
   }
 #endif

--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -210,33 +210,31 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
     }
   }
 
-  if (ats_is_ip6(&addr) && safe_setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, SOCKOPT_ON, sizeof(int)) < 0) {
+  if (ats_is_ip6(&addr) && setsockopt_on(fd, IPPROTO_IPV6, IPV6_V6ONLY) < 0) {
     goto Lerror;
   }
 
-  if (safe_setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, SOCKOPT_ON, sizeof(int)) < 0) {
+  if (setsockopt_on(fd, SOL_SOCKET, SO_REUSEADDR) < 0) {
     goto Lerror;
   }
   REC_ReadConfigInteger(listen_per_thread, "proxy.config.exec_thread.listen");
   if (listen_per_thread == 1) {
-    if (safe_setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, SOCKOPT_ON, sizeof(int)) < 0) {
+    if (setsockopt_on(fd, SOL_SOCKET, SO_REUSEPORT) < 0) {
       goto Lerror;
     }
 #ifdef SO_REUSEPORT_LB
-    if (safe_setsockopt(fd, SOL_SOCKET, SO_REUSEPORT_LB, SOCKOPT_ON, sizeof(int)) < 0) {
+    if (setsockopt_on(fd, SOL_SOCKET, SO_REUSEPORT_LB) < 0) {
       goto Lerror;
     }
 #endif
   }
 
-  if ((opt.sockopt_flags & NetVCOptions::SOCK_OPT_NO_DELAY) &&
-      safe_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, SOCKOPT_ON, sizeof(int)) < 0) {
+  if ((opt.sockopt_flags & NetVCOptions::SOCK_OPT_NO_DELAY) && setsockopt_on(fd, IPPROTO_TCP, TCP_NODELAY) < 0) {
     goto Lerror;
   }
 
   // enables 2 hour inactivity probes, also may fix IRIX FIN_WAIT_2 leak
-  if ((opt.sockopt_flags & NetVCOptions::SOCK_OPT_KEEP_ALIVE) &&
-      safe_setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, SOCKOPT_ON, sizeof(int)) < 0) {
+  if ((opt.sockopt_flags & NetVCOptions::SOCK_OPT_KEEP_ALIVE) && setsockopt_on(fd, SOL_SOCKET, SO_KEEPALIVE) < 0) {
     goto Lerror;
   }
 
@@ -250,7 +248,7 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
   if (opt.f_inbound_transparent) {
 #if TS_USE_TPROXY
     Debug("http_tproxy", "Listen port inbound transparency enabled.");
-    if (safe_setsockopt(fd, SOL_IP, TS_IP_TRANSPARENT, SOCKOPT_ON, sizeof(int)) < 0) {
+    if (setsockopt_on(fd, SOL_IP, TS_IP_TRANSPARENT) < 0) {
       Fatal("[Server::listen] Unable to set transparent socket option [%d] %s\n", errno, strerror(errno));
     }
 #else
@@ -272,7 +270,7 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
 
   if (opt.f_mptcp) {
 #if MPTCP_ENABLED
-    if (safe_setsockopt(fd, IPPROTO_TCP, MPTCP_ENABLED, SOCKOPT_ON, sizeof(int)) < 0) {
+    if (setsockopt_on(fd, IPPROTO_TCP, MPTCP_ENABLED) < 0) {
       Error("[Server::listen] Unable to enable MPTCP socket-option [%d] %s\n", errno, strerror(errno));
       goto Lerror;
     }

--- a/src/tscore/ink_defs.cc
+++ b/src/tscore/ink_defs.cc
@@ -32,9 +32,6 @@
 
 #include <unistd.h>
 
-int off = 0;
-int on  = 1;
-
 int
 ink_login_name_max()
 {

--- a/src/tscore/ink_sock.cc
+++ b/src/tscore/ink_sock.cc
@@ -59,21 +59,21 @@ check_valid_sockaddr(sockaddr *sa, char *file, int line)
 #endif
 
 int
-safe_setsockopt(int s, int level, int optname, const void *optval, int optlevel)
+safe_setsockopt(int s, int level, int optname, const void *optval, int optlen)
 {
   int r;
   do {
-    r = setsockopt(s, level, optname, optval, optlevel);
+    r = setsockopt(s, level, optname, optval, optlen);
   } while (r < 0 && (errno == EAGAIN || errno == EINTR));
   return r;
 }
 
 int
-safe_getsockopt(int s, int level, int optname, void *optval, int *optlevel)
+safe_getsockopt(int s, int level, int optname, void *optval, int *optlen)
 {
   int r;
   do {
-    r = getsockopt(s, level, optname, optval, reinterpret_cast<socklen_t *>(optlevel));
+    r = getsockopt(s, level, optname, optval, reinterpret_cast<socklen_t *>(optlen));
   } while (r < 0 && (errno == EAGAIN || errno == EINTR));
   return r;
 }
@@ -328,7 +328,7 @@ bind_unix_domain_socket(const char *path, mode_t mode)
   socklen = strlen(sockaddr.sun_path) + sizeof(sockaddr.sun_family);
 #endif
 
-  if (safe_setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, SOCKOPT_ON, sizeof(int)) < 0) {
+  if (setsockopt_on(sockfd, SOL_SOCKET, SO_REUSEADDR) < 0) {
     goto fail;
   }
 


### PR DESCRIPTION
Remove the SOCKOPT_ON and SOCKOPT_OFF globals. These weren't used consistently and cand easily be replaced by a helper function. Apply the new helper function everywhere that toggles socket options on.