### PR TITLE
Update build_h3_tools to use OpenSSL 3.0

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -28,7 +28,7 @@ cd "${WORKDIR}"
 echo "Building H3 dependencies in ${WORKDIR} ..."
 
 # Update this as the draft we support updates.
-OPENSSL_BRANCH=${OPENSSL_BRANCH:-"OpenSSL_1_1_1u+quic"}
+OPENSSL_BRANCH=${OPENSSL_BRANCH:-"openssl-3.0.9+quic"}
 
 # Set these, if desired, to change these to your preferred installation
 # directory


### PR DESCRIPTION
After merging #9753 and #9937, all autests should run when ATS is built against OpenSSL 3.0. This updates the build_h3_tools.sh to OpenSSL 3.0 from 1.1.1.