### PR TITLE
records.yaml  - conf_remap update to use records.yaml as input files.

### DIFF
--- a/doc/admin-guide/plugins/conf_remap.en.rst
+++ b/doc/admin-guide/plugins/conf_remap.en.rst
@@ -89,8 +89,8 @@ sync across all the remapping rules over time.
 
 Instead of specifying the directives and their values in :file:`remap.config`
 as you do with the in-line method, you place all the affected directives in a
-separate text file. The location and name is entirely up to you, but we'll use
-`/etc/trafficserver/cdn_conf_remap.config` here. The contents of this file
+separate YAML file. The location and name is entirely up to you, but we'll use
+`/etc/trafficserver/cdn_conf_remap.yaml` here. The contents of this file
 should mirror how configuration directives are written in :file:`records.yaml`:
 
 .. code-block:: yaml
@@ -103,7 +103,7 @@ Your :file:`remap.config` will then contain remapping rules that point to this
 external file::
 
     map http://cdn.example.com/ http://some-server.example.com \
-        @plugin=conf_remap.so @pparam=/etc/trafficserver/cdn_conf_remap.config
+        @plugin=conf_remap.so @pparam=/etc/trafficserver/cdn_conf_remap.yaml
 
 Your external configuration may contain as many directives as you wish.
 
@@ -122,3 +122,4 @@ For more information about the implementation of overridable configuration
 directives, you may consult the developer's documentation for
 :ref:`ts-overridable-config`.
 
+Also if moving from a legacy config format, please have a look at :ref:`rec-config-to-yaml`.

--- a/plugins/conf_remap/conf_remap.cc
+++ b/plugins/conf_remap/conf_remap.cc
@@ -164,7 +164,7 @@ scalar_node_handler(const TSYAMLRecCfgFieldData *cfg, void *data)
   RemapConfigs::Item *item = &ctx.items[*ctx.current];
 
   auto type = try_deduce_type(value);
-
+  TSDebug(PLUGIN_NAME, "### deduced type %d for %s", type, cfg->record_name);
   // If we detected a type but it's different from the one registered with the in ATS, then we ignore it.
   if (type != TS_RECORDDATATYPE_NULL && expected_type != type) {
     TSError("%s", swoc::bwprint(text, "[{}] '{}' variable type mismatch, expected {}, got {}", PLUGIN_NAME, cfg->record_name,
@@ -173,8 +173,8 @@ scalar_node_handler(const TSYAMLRecCfgFieldData *cfg, void *data)
     return TS_ERROR; // Ignore the field
   }
 
-  // We use the expected type. If no type set or the time did match, then it's
-  // safe to use the expected type.
+  // If no type set or the type did match, then we assume it's safe to use the
+  // expected type.
   try {
     switch (expected_type) {
     case TS_RECORDDATATYPE_INT:
@@ -182,7 +182,7 @@ scalar_node_handler(const TSYAMLRecCfgFieldData *cfg, void *data)
       break;
     case TS_RECORDDATATYPE_STRING: {
       std::string str = value.as<std::string>();
-      if (str == "NULL") {
+      if (value.IsNull() || str == "NULL") {
         item->_data.rec_string = nullptr;
         item->_data_len        = 0;
       } else {

--- a/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
+++ b/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
@@ -1,0 +1,173 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test conf_remap using a yaml file.
+'''
+
+Test.ContinueOnFail = True
+
+
+class conf_remap_yaml_load_test:
+    """Test conf_remap using a yaml file."""
+
+    client_counter: int = 0
+    ts_counter: int = 0
+    server_counter: int = 0
+
+    def __init__(self, name: str, gold_file="", remap_filename="", remap_content=""):
+        """Initialize the test.
+        :param name: The name of the test.
+        :param gold_file: Gold file to be checked.
+        :param remap_filename: Remap yaml filename.
+        :param remap_content: remap yaml file content.
+        """
+        self.name = name
+        self.gold_file = gold_file
+        self._remap_filename = remap_filename
+        self._remap_content = remap_content
+
+    def _configure_server(self, tr: 'TestRun'):
+        """Configure the server.
+
+        :param tr: The TestRun object to associate the server process with.
+        """
+        server = Test.MakeOriginServer(f"server-{conf_remap_yaml_load_test.ts_counter}", lookup_key="{%Host}{PATH}")
+        request_header2 = {"headers": "GET /test HTTP/1.1\r\nHost: www.testexample.com\r\n\r\n",
+                           "timestamp": "1469733493.993", "body": ""}
+        response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+                            "timestamp": "1469733493.993", "body": ""}
+
+        server.addResponse("sessionfile.log", request_header2, response_header2)
+        conf_remap_yaml_load_test.server_counter += 1
+        self._server = server
+
+    def _configure_traffic_server(self, tr: 'TestRun'):
+        """Configure Traffic Server.
+
+        :param tr: The TestRun object to associate the ts process with.
+        """
+        ts = Test.MakeATSProcess(f"ts-{conf_remap_yaml_load_test.ts_counter}")
+
+        conf_remap_yaml_load_test.ts_counter += 1
+        ts.Disk.records_config.update(
+            '''
+            diags:
+                debug:
+                    enabled: 1
+                    tags: conf_remap
+            dns:
+                resolv_conf: NULL
+            http:
+                referer_filter: 1
+            url_remap:
+                pristine_host_hdr: 0 # make sure is 0
+
+        '''
+        )
+        self._ts = ts
+
+    def run(self, diags_fail_exp="", ts_retcode=0):
+        """Run the test.
+        :param diags_fail_exp: Text to be included to validate the error.
+        :param ts_retcode: Expected return code from TS.
+        """
+        tr = Test.AddTestRun(self.name)
+        self._configure_server(tr)
+        self._configure_traffic_server(tr)
+
+        tr.Processes.Default.StartBefore(self._server)
+        tr.Processes.Default.StartBefore(self._ts)
+
+        self._ts.ReturnCode = ts_retcode
+
+        if ts_retcode > 0:  # we could have errors logged and yet, we still want to move on.
+            self._ts.Ready = 0
+
+        if diags_fail_exp != "":
+            # some error logs will be written to the diags.
+            self._ts.Disk.diags_log.Content = Testers.IncludesExpression(
+                diags_fail_exp, "Have a look.")
+        else:
+            tr.Processes.Default.ReturnCode = 0
+
+        if self.gold_file:
+            tr.Processes.Default.Streams.stderr = self.gold_file
+
+        if self._remap_filename != "" and self._remap_content != "":
+            self._ts.Disk.MakeConfigFile(self._remap_filename).update(self._remap_content)
+            self._ts.Disk.remap_config.AddLine(
+                f'map http://www.testexample.com/ http://127.0.0.1:{self._server.Variables.Port} @plugin=conf_remap.so @pparam={self._remap_filename}'
+            )
+
+        tr.Processes.Default.Command = 'curl --proxy 127.0.0.1:{0} "http://www.testexample.com/test" -H "Host: www.testexample.com" --verbose'.format(
+            self._ts.Variables.port)
+        conf_remap_yaml_load_test.client_counter += 1
+
+
+test0 = conf_remap_yaml_load_test(
+    "Test success",
+    gold_file="gold/200OK_test.gold",
+    remap_filename="testexample_remap.yaml",
+    remap_content='''
+    ts:
+      url_remap:
+        pristine_host_hdr: 1
+    '''
+)
+test0.run()
+
+test1 = conf_remap_yaml_load_test(
+    "Test mismatch type",
+    remap_filename="mismatch_field_type_remap.yaml",
+    remap_content='''
+    ts:
+      url_remap:
+        pristine_host_hdr: !!float '1'
+    '''
+)
+test1.run(diags_fail_exp="'proxy.config.url_remap.pristine_host_hdr' variable type mismatch", ts_retcode=33)
+
+test2 = conf_remap_yaml_load_test(
+    "Test invalid variable",
+    remap_filename="invalid1_field_type_remap.yaml",
+    remap_content='''
+    ts:
+      plugin:
+        dynamic_reload_mode: 1
+    '''
+)
+
+test2.run(diags_fail_exp="'proxy.config.plugin.dynamic_reload_mode' is not a configuration variable or cannot be overridden", ts_retcode=33)
+
+
+# We let the conf_remap parse two fields, only one is valid, we expect ATS to start and the invalid fields ignored.
+test3 = conf_remap_yaml_load_test(
+    "Test success",
+    gold_file="gold/200OK_test.gold",
+    remap_filename="testexample2_remap.yaml",
+    remap_content='''
+    ts:
+      plugin:
+        dynamic_reload_mode: 1
+
+      url_remap:
+        pristine_host_hdr: 1
+    '''
+)
+test3.run(diags_fail_exp="'proxy.config.plugin.dynamic_reload_mode' is not a configuration variable or cannot be overridden")

--- a/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
+++ b/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
@@ -171,3 +171,19 @@ test3 = conf_remap_yaml_load_test(
     '''
 )
 test3.run(diags_fail_exp="'proxy.config.plugin.dynamic_reload_mode' is not a configuration variable or cannot be overridden")
+
+
+# Check null values
+test4 = conf_remap_yaml_load_test(
+    "Test success - with NULL variable",
+    gold_file="gold/200OK_test.gold",
+    remap_filename="testexample_remap.yaml",
+    remap_content='''
+    ts:
+      url_remap:
+        pristine_host_hdr: 1
+      hostdb:
+        ip_resolve: "NULL" # We want to make sure this gets read as it should. "NULL" could be the value of this field.
+    '''
+)
+test4.run()

--- a/tests/gold_tests/remap/conf_remap_float.test.py
+++ b/tests/gold_tests/remap/conf_remap_float.test.py
@@ -22,12 +22,16 @@ Test.testName = 'Float in conf_remap Config Test'
 
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.MakeConfigFile('conf_remap.config').AddLines([
-    'CONFIG proxy.config.http.background_fill_completed_threshold FLOAT 0.500000'
-])
+ts.Disk.MakeConfigFile('conf_remap.yaml').update(
+    '''
+ts:
+  http:
+    background_fill_completed_threshold: !!float '0.5'
+'''
+)
 
 ts.Disk.remap_config.AddLine(
-    f"map http://cdn.example.com/ http://origin.example.com/ @plugin=conf_remap.so @pparam={Test.RunDirectory}/ts/config/conf_remap.config"
+    f"map http://cdn.example.com/ http://origin.example.com/ @plugin=conf_remap.so @pparam={Test.RunDirectory}/ts/config/conf_remap.yaml"
 )
 
 tr = Test.AddTestRun("traffic_ctl command")

--- a/tests/gold_tests/remap/gold/200OK_test.gold
+++ b/tests/gold_tests/remap/gold/200OK_test.gold
@@ -1,0 +1,13 @@
+``
+> GET http://www.testexample.com/test``
+> Host: www.testexample.com``
+> User-Agent: curl/``
+> Accept: */*
+``
+< HTTP/1.1 200 OK
+< Date: ``
+< Age: ``
+< Transfer-Encoding: chunked
+< Proxy-Connection: keep-alive
+< Server: ATS/``
+``


### PR DESCRIPTION
A follow up from the conversion from `records.config` to `records.yaml`, now this PR updates the `conf_remap`  plugin to use YAML files as input files. That is beside the inline variable style which **does not change** the plugin can now parse `YAML` files.
The plugin does not support `.config` files for config variables anymore, `YAML` should be used instead.

This PR does not change the internal conf_remap structure as it just replaces the legacy config parsing by usintg `TSRecYAMLConfigParse` API.

Autest is also updated and a new one is introduced.

IMPORTANT:
With this change, `conf_remap` plugin will not take legacy config record files as input files. **only YAML** meaning that we should use the convert [tool](https://docs.trafficserver.apache.org/en/latest/admin-guide/tools/converting-records-to-yaml.en.html) to translate whatever we have.