### PR TITLE
OpenSSL 3.0 tls autest updates

### DIFF
--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -840,7 +840,9 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
       break;
     }
     case SSL_ERROR_SYSCALL:
-      num_really_written = -errno;
+      // SSL_ERROR_SYSCALL is an IO error. errno is likely 0, so set EPIPE, as
+      // we do with SSL_ERROR_SSL below, to indicate a connection error.
+      num_really_written = -EPIPE;
       SSL_INCREMENT_DYN_STAT(ssl_error_syscall);
       Debug("ssl.error", "SSL_write-SSL_ERROR_SYSCALL");
       break;

--- a/tests/gold_tests/tls/tls.test.py
+++ b/tests/gold_tests/tls/tls.test.py
@@ -69,6 +69,8 @@ ts.Disk.ssl_multicert_config.AddLine(
 ts.Disk.records_config.update({'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
                                'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
                                'proxy.config.exec_thread.autoconfig.scale': 1.0,
+                               'proxy.config.diags.debug.enabled': 1,
+                               'proxy.config.diags.debug.tags': 'ssl',
                                })
 
 tr = Test.AddTestRun("Run-Test")

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -71,28 +71,32 @@ ts.Disk.sni_yaml.AddLines([
 tr = Test.AddTestRun("foo.com TLSv1_2")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.Processes.Default.Command = "curl -v --tls-max 1.2 --tlsv1.2 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
+# Newer versions of OpenSSL further restrict the ciphers they accept. Setting
+# the security level to 0 "retains compatibility with previous versions of
+# OpenSSL." See:
+# https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
 # Target foo.com for TLSv1.  Should succeed
 tr = Test.AddTestRun("foo.com TLSv1")
-tr.Processes.Default.Command = "curl -v --tls-max 1.0 --tlsv1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 
 # Target bar.com for TLSv1.  Should fail
 tr = Test.AddTestRun("bar.com TLSv1")
-tr.Processes.Default.Command = "curl -v --tls-max 1.0 --tlsv1 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
 # Target bar.com for TLSv1_2.  Should succeed
 tr = Test.AddTestRun("bar.com TLSv1_2")
-tr.Processes.Default.Command = "curl -v --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_client_versions_minmax.test.py
+++ b/tests/gold_tests/tls/tls_client_versions_minmax.test.py
@@ -75,35 +75,39 @@ ts.Disk.sni_yaml.AddLines([
 tr = Test.AddTestRun("foo.com TLSv1_2")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.Processes.Default.Command = "curl -v --tls-max 1.2 --tlsv1.2 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
+# Newer versions of OpenSSL further restrict the ciphers they accept. Setting
+# the security level to 0 "retains compatibility with previous versions of
+# OpenSSL." See:
+# https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
 # Target foo.com for TLSv1.  Should succeed
 tr = Test.AddTestRun("foo.com TLSv1")
-tr.Processes.Default.Command = "curl -v --tls-max 1.0 --tlsv1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 
 # Target foo.com for TLSv1_1.  Should succeed
 tr = Test.AddTestRun("foo.com TLSv1_1")
-tr.Processes.Default.Command = "curl -v --tls-max 1.1 --tlsv1.1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.1 --tlsv1.1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 
 # Target bar.com for TLSv1.  Should fail
 tr = Test.AddTestRun("bar.com TLSv1")
-tr.Processes.Default.Command = "curl -v --tls-max 1.0 --tlsv1 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
 # Target bar.com for TLSv1_2.  Should succeed
 tr = Test.AddTestRun("bar.com TLSv1_2")
-tr.Processes.Default.Command = "curl -v --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
+tr.Processes.Default.Command = "curl -v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts


### PR DESCRIPTION
This updates the curl invocations for the tls_client_versions and tls_client_versions_minmax autests so that it will run with the updated OpenSSL 3.0 which is more strict. This avoids the issue by toning down curl's security level to 0. A future PR should assess our proxy.config.ssl.server.cipher_suite configurations and update accordingly.

This also fixes a crash that tls.test.py found for OpenSSL 3.0 in which
SSLNetVConnection::load_buffer_and_write should return a non-zero in the
event of SSL_ERROR_SYSCALL.