### PR TITLE
Allow specifying multiple port ranges in sni.yaml

### DIFF
--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -27,7 +27,7 @@ Description
 
 This file is used to configure aspects of TLS connection handling for both inbound and outbound
 connections. With the exception of ``host_sni_policy`` (see the description below), the configuration is driven by the SNI values provided by the inbound connection. The
-file consists of a set of configuration items, each identified by an SNI value and optionally a port range (``fqdn``, ``inbound_port_range``).
+file consists of a set of configuration items, each identified by an SNI value and optionally a sequence of port ranges (``fqdn``, ``inbound_port_ranges``).
 When an inbound TLS connection is made, the SNI value from the TLS negotiation is matched against
 the items specified by this file and if there is a match, the values specified in that item override
 the defaults. This is done during the inbound connection processing; some outbound properties
@@ -59,19 +59,21 @@ Key                       Direction Meaning
 ========================= ========= ========================================================================================
 fqdn                      Both      Fully Qualified Domain Name.
 
-inbound_port_range        Inbound   The port range for the inbound connection in the form ``port`` or
+inbound_port_ranges       Inbound   The port ranges for the inbound connection in the form ``port`` or
                                     ``min-max``.
 
                                     For example:
 
-                                       ``443``
+                                       .. code-block:: yaml
 
-                                    would match all requests with an SNI for example.com on port 443, and
+                                       sni:
+                                         - fqdn: example.com
+                                           inbound_port_ranges:
+                                           - 443
+                                           - 8080-8086
 
-                                       ``443-446``
-
-                                    would match requests with an SNI for example.com on ports 443 to 446, inclusive.
-                                    By default this is all ports.
+                                    would match all requests with an SNI for example.com on port 443, and on ports
+                                    8080 through 8086 inclusive.
 
 ========================= ========= ========================================================================================
 

--- a/doc/admin-guide/files/sni.yaml.en.rst
+++ b/doc/admin-guide/files/sni.yaml.en.rst
@@ -27,7 +27,7 @@ Description
 
 This file is used to configure aspects of TLS connection handling for both inbound and outbound
 connections. With the exception of ``host_sni_policy`` (see the description below), the configuration is driven by the SNI values provided by the inbound connection. The
-file consists of a set of configuration items, each identified by an SNI value and optionally a sequence of port ranges (``fqdn``, ``inbound_port_ranges``).
+file consists of a set of configuration items, each identified by an SNI value and optionally one or more port ranges (``fqdn``, ``inbound_port_ranges``).
 When an inbound TLS connection is made, the SNI value from the TLS negotiation is matched against
 the items specified by this file and if there is a match, the values specified in that item override
 the defaults. This is done during the inbound connection processing; some outbound properties
@@ -71,9 +71,13 @@ inbound_port_ranges       Inbound   The port ranges for the inbound connection i
                                            inbound_port_ranges:
                                            - 443
                                            - 8080-8086
+                                         - fqdn: other.com
+                                           inbound_port_ranges: 443
 
                                     would match all requests with an SNI for example.com on port 443, and on ports
-                                    8080 through 8086 inclusive.
+                                    8080 through 8086 inclusive, and all
+                                    requests with an SNI for other.com on port
+                                    443
 
 ========================= ========= ========================================================================================
 

--- a/iocore/net/SSLSNIConfig.h
+++ b/iocore/net/SSLSNIConfig.h
@@ -71,7 +71,7 @@ struct NamedElement {
   void set_glob_name(std::string name);
   void set_regex_name(const std::string &regex_name);
 
-  ts::port_range_t ports{1, ts::MAX_PORT_VALUE};
+  std::vector<ts::port_range_t> inbound_port_ranges;
 
   std::unique_ptr<pcre, PcreFreer> match;
 };

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -220,12 +220,12 @@ template <> struct convert<YamlSNIConfig::Item> {
     if (!min) {
       min = port_view;
     }
-    auto const &max{port_view};
+    auto max{port_view};
 
     swoc::TextView parsed_min;
-    long min_port{swoc::svtoi(min, &parsed_min)};
+    auto min_port{swoc::svtoi(min, &parsed_min)};
     swoc::TextView parsed_max;
-    long max_port{swoc::svtoi(max, &parsed_max)};
+    auto max_port{swoc::svtoi(max, &parsed_max)};
     if (parsed_min != min || min_port < 1 || parsed_max != max || max_port > std::numeric_limits<in_port_t>::max() ||
         max_port < min_port) {
       throw YAML::ParserException(node.Mark(), swoc::bwprint(ts::bw_dbg, "bad port range: {}-{}", min, max));

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -239,7 +239,7 @@ template <> struct convert<YamlSNIConfig::Item> {
   {
     std::vector<ts::port_range_t> result;
     for (Node const &port_range : port_ranges) {
-      result.emplace_back(std::move(parse_single_inbound_port_range(port_range, port_range.Scalar())));
+      result.emplace_back(parse_single_inbound_port_range(port_range, port_range.Scalar()));
     }
 
     return result;
@@ -262,7 +262,7 @@ template <> struct convert<YamlSNIConfig::Item> {
     }
 
     if (node[TS_inbound_port_ranges]) {
-      item.inbound_port_ranges = std::move(parse_inbound_port_ranges_sequence(node[TS_inbound_port_ranges]));
+      item.inbound_port_ranges = parse_inbound_port_ranges_sequence(node[TS_inbound_port_ranges]);
     } else {
       item.inbound_port_ranges.emplace_back(1, ts::MAX_PORT_VALUE);
     }

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -235,7 +235,7 @@ template <> struct convert<YamlSNIConfig::Item> {
   }
 
   static std::vector<ts::port_range_t>
-  parse_inbound_port_ranges(Node const &node)
+  parse_delimited_inbound_port_ranges(Node const &node)
   {
     std::vector<ts::port_range_t> result;
     swoc::TextView ranges_view{node[TS_inbound_port_range].Scalar()};
@@ -265,7 +265,7 @@ template <> struct convert<YamlSNIConfig::Item> {
     }
 
     if (node[TS_inbound_port_range]) {
-      item.port_ranges = std::move(parse_inbound_port_ranges(node));
+      item.port_ranges = std::move(parse_delimited_inbound_port_ranges(node));
     } else {
       item.port_ranges.emplace_back(1, ts::MAX_PORT_VALUE);
     }

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -179,7 +179,7 @@ TsEnumDescriptor TLS_PROTOCOLS_DESCRIPTOR = {
 };
 
 std::set<std::string> valid_sni_config_keys = {TS_fqdn,
-                                               TS_inbound_port_range,
+                                               TS_inbound_port_ranges,
                                                TS_verify_client,
                                                TS_verify_client_ca_certs,
                                                TS_tunnel_route,
@@ -238,7 +238,7 @@ template <> struct convert<YamlSNIConfig::Item> {
   parse_delimited_inbound_port_ranges(Node const &node)
   {
     std::vector<ts::port_range_t> result;
-    swoc::TextView ranges_view{node[TS_inbound_port_range].Scalar()};
+    swoc::TextView ranges_view{node[TS_inbound_port_ranges].Scalar()};
     for (auto port_view{ranges_view.split_prefix_at(',')}; !port_view.empty(); port_view = ranges_view.split_prefix_at(',')) {
       result.emplace_back(std::move(parse_single_inbound_port_range(node, port_view)));
     }
@@ -264,7 +264,7 @@ template <> struct convert<YamlSNIConfig::Item> {
       return false; // servername must be present
     }
 
-    if (node[TS_inbound_port_range]) {
+    if (node[TS_inbound_port_ranges]) {
       item.inbound_port_ranges = std::move(parse_delimited_inbound_port_ranges(node));
     } else {
       item.inbound_port_ranges.emplace_back(1, ts::MAX_PORT_VALUE);

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -235,11 +235,15 @@ template <> struct convert<YamlSNIConfig::Item> {
   }
 
   static std::vector<ts::port_range_t>
-  parse_inbound_port_ranges_sequence(Node const &port_ranges)
+  parse_inbound_port_ranges(Node const &port_ranges)
   {
     std::vector<ts::port_range_t> result;
-    for (Node const &port_range : port_ranges) {
-      result.emplace_back(parse_single_inbound_port_range(port_range, port_range.Scalar()));
+    if (port_ranges.IsSequence()) {
+      for (Node const &port_range : port_ranges) {
+        result.emplace_back(parse_single_inbound_port_range(port_range, port_range.Scalar()));
+      }
+    } else {
+      result.emplace_back(parse_single_inbound_port_range(port_ranges, port_ranges.Scalar()));
     }
 
     return result;
@@ -262,7 +266,7 @@ template <> struct convert<YamlSNIConfig::Item> {
     }
 
     if (node[TS_inbound_port_ranges]) {
-      item.inbound_port_ranges = parse_inbound_port_ranges_sequence(node[TS_inbound_port_ranges]);
+      item.inbound_port_ranges = parse_inbound_port_ranges(node[TS_inbound_port_ranges]);
     } else {
       item.inbound_port_ranges.emplace_back(1, ts::MAX_PORT_VALUE);
     }

--- a/iocore/net/YamlSNIConfig.cc
+++ b/iocore/net/YamlSNIConfig.cc
@@ -265,11 +265,10 @@ template <> struct convert<YamlSNIConfig::Item> {
     }
 
     if (node[TS_inbound_port_range]) {
-      item.port_ranges = std::move(parse_delimited_inbound_port_ranges(node));
+      item.inbound_port_ranges = std::move(parse_delimited_inbound_port_ranges(node));
     } else {
-      item.port_ranges.emplace_back(1, ts::MAX_PORT_VALUE);
+      item.inbound_port_ranges.emplace_back(1, ts::MAX_PORT_VALUE);
     }
-    item.port_range = item.port_ranges[0];
     if (node[TS_http2]) {
       item.offer_h2 = node[TS_http2].as<bool>();
     }

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -81,6 +81,7 @@ struct YamlSNIConfig {
     std::string fqdn;
 
     ts::port_range_t port_range{1, ts::MAX_PORT_VALUE};
+    std::vector<ts::port_range_t> port_ranges{};
 
     std::optional<bool> offer_h2;   // Has no value by default, so do not initialize!
     std::optional<bool> offer_quic; // Has no value by default, so do not initialize!

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -38,7 +38,7 @@
 
 #define TSDECL(id) constexpr char TS_##id[] = #id
 TSDECL(fqdn);
-TSDECL(inbound_port_range);
+TSDECL(inbound_port_ranges);
 TSDECL(verify_client);
 TSDECL(verify_client_ca_certs);
 TSDECL(tunnel_route);

--- a/iocore/net/YamlSNIConfig.h
+++ b/iocore/net/YamlSNIConfig.h
@@ -80,8 +80,7 @@ struct YamlSNIConfig {
   struct Item {
     std::string fqdn;
 
-    ts::port_range_t port_range{1, ts::MAX_PORT_VALUE};
-    std::vector<ts::port_range_t> port_ranges{};
+    std::vector<ts::port_range_t> inbound_port_ranges;
 
     std::optional<bool> offer_h2;   // Has no value by default, so do not initialize!
     std::optional<bool> offer_quic; // Has no value by default, so do not initialize!

--- a/iocore/net/unit_tests/sni_conf_test.yaml
+++ b/iocore/net/unit_tests/sni_conf_test.yaml
@@ -17,9 +17,9 @@
 sni:
 - fqdn: allports.com
 - fqdn: someport.com
-  inbound_port_range: 1-433,480-488
+  inbound_port_ranges: 1-433,480-488
   http2: true
 - fqdn: someport.com
-  inbound_port_range: 8080-65535
+  inbound_port_ranges: 8080-65535
 - fqdn: oneport.com
-  inbound_port_range: 433
+  inbound_port_ranges: 433

--- a/iocore/net/unit_tests/sni_conf_test.yaml
+++ b/iocore/net/unit_tests/sni_conf_test.yaml
@@ -17,9 +17,13 @@
 sni:
 - fqdn: allports.com
 - fqdn: someport.com
-  inbound_port_ranges: 1-433,480-488
+  inbound_port_ranges:
+  - 1-433
+  - 480-488
   http2: true
 - fqdn: someport.com
-  inbound_port_ranges: 8080-65535
+  inbound_port_ranges:
+  - 8080-65535
 - fqdn: oneport.com
-  inbound_port_ranges: 433
+  inbound_port_ranges:
+  - 433

--- a/iocore/net/unit_tests/sni_conf_test.yaml
+++ b/iocore/net/unit_tests/sni_conf_test.yaml
@@ -17,7 +17,7 @@
 sni:
 - fqdn: allports.com
 - fqdn: someport.com
-  inbound_port_range: 1-433
+  inbound_port_range: 1-433,480-488
   http2: true
 - fqdn: someport.com
   inbound_port_range: 8080-65535

--- a/iocore/net/unit_tests/sni_conf_test.yaml
+++ b/iocore/net/unit_tests/sni_conf_test.yaml
@@ -22,8 +22,6 @@ sni:
   - 480-488
   http2: true
 - fqdn: someport.com
-  inbound_port_ranges:
-  - 8080-65535
+  inbound_port_ranges: 8080-65535
 - fqdn: oneport.com
-  inbound_port_ranges:
-  - 433
+  inbound_port_ranges: 433

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_0-1.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_0-1.yaml
@@ -16,4 +16,5 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_ranges: 0-1
+  inbound_port_ranges:
+  - 0-1

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_0-1.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_0-1.yaml
@@ -16,4 +16,4 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_range: 0-1
+  inbound_port_ranges: 0-1

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_1-yowzers2.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_1-yowzers2.yaml
@@ -16,4 +16,5 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_ranges: 1-yowzers2
+  inbound_port_ranges:
+  - 1-yowzers2

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_1-yowzers2.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_1-yowzers2.yaml
@@ -16,4 +16,4 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_range: 1-yowzers2
+  inbound_port_ranges: 1-yowzers2

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_3-.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_3-.yaml
@@ -16,4 +16,4 @@
 
 sni:
 - fqdn: missingport.com
-  inbound_port_range: 1-2,3-
+  inbound_port_ranges: 1-2,3-

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_3-.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_3-.yaml
@@ -16,4 +16,6 @@
 
 sni:
 - fqdn: missingport.com
-  inbound_port_ranges: 1-2,3-
+  inbound_port_ranges:
+  - 3-
+  - 1-2

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_3-.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_3-.yaml
@@ -1,0 +1,19 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+sni:
+- fqdn: missingport.com
+  inbound_port_range: 1-2,3-

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_65535-65536.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_65535-65536.yaml
@@ -16,4 +16,4 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_range: 65535-65536
+  inbound_port_ranges: 65535-65536

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_65535-65536.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_65535-65536.yaml
@@ -16,4 +16,5 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_ranges: 65535-65536
+  inbound_port_ranges:
+  - 65535-65536

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_8080-433.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_8080-433.yaml
@@ -16,4 +16,4 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_range: 8080-433
+  inbound_port_ranges: 8080-433

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_8080-433.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_8080-433.yaml
@@ -16,4 +16,5 @@
 
 sni:
 - fqdn: badport.com
-  inbound_port_ranges: 8080-433
+  inbound_port_ranges:
+  - 8080-433

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_yowzers-1.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_yowzers-1.yaml
@@ -16,4 +16,4 @@
 
 sni:
 - fqdn: notaport.com
-  inbound_port_range: yowzers-1
+  inbound_port_ranges: yowzers-1

--- a/iocore/net/unit_tests/sni_conf_test_bad_port_yowzers-1.yaml
+++ b/iocore/net/unit_tests/sni_conf_test_bad_port_yowzers-1.yaml
@@ -16,4 +16,5 @@
 
 sni:
 - fqdn: notaport.com
-  inbound_port_ranges: yowzers-1
+  inbound_port_ranges:
+  - yowzers-1

--- a/iocore/net/unit_tests/test_SSLSNIConfig.cc
+++ b/iocore/net/unit_tests/test_SSLSNIConfig.cc
@@ -98,4 +98,11 @@ TEST_CASE("Test SSLSNIConfig")
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 2);
   }
+
+  SECTION("The config matches an SNI for someport:482")
+  {
+    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 482)};
+    REQUIRE(actions.first);
+    REQUIRE(actions.first->size() == 3);
+  }
 }

--- a/iocore/net/unit_tests/test_YamlSNIConfig.cc
+++ b/iocore/net/unit_tests/test_YamlSNIConfig.cc
@@ -108,7 +108,7 @@ TEST_CASE("YamlConfig handles bad ports appropriately.")
 {
   YamlSNIConfig conf{};
 
-  std::string port_str{GENERATE("0-1", "65535-65536", "8080-433", "yowzers-1", "1-yowzers2")};
+  std::string port_str{GENERATE("0-1", "65535-65536", "8080-433", "yowzers-1", "1-yowzers2", "3-")};
 
   std::string filepath;
   swoc::bwprint(filepath, "{}/sni_conf_test_bad_port_{}.yaml", _XSTR(LIBINKNET_UNIT_TEST_DIR), port_str);

--- a/iocore/net/unit_tests/test_YamlSNIConfig.cc
+++ b/iocore/net/unit_tests/test_YamlSNIConfig.cc
@@ -41,8 +41,8 @@
 static void
 check_port_range(const YamlSNIConfig::Item &item, in_port_t min_expected, in_port_t max_expected)
 {
-  CHECK(item.port_ranges.at(0).min() == min_expected);
-  CHECK(item.port_ranges.at(0).max() == max_expected);
+  CHECK(item.inbound_port_ranges.at(0).min() == min_expected);
+  CHECK(item.inbound_port_ranges.at(0).max() == max_expected);
 }
 
 TEST_CASE("YamlSNIConfig sets port ranges appropriately")
@@ -93,14 +93,14 @@ TEST_CASE("YamlSNIConfig sets port ranges appropriately")
   SECTION("If multiple port ranges were specified, all of them should be checked.")
   {
     auto const &item{conf.items[1]};
-    CHECK(item.port_ranges.at(1).min() == 480);
-    CHECK(item.port_ranges.at(1).max() == 488);
+    CHECK(item.inbound_port_ranges.at(1).min() == 480);
+    CHECK(item.inbound_port_ranges.at(1).max() == 488);
   }
 
   SECTION("If one port range was specified, "
           "there should only be one port range.")
   {
-    CHECK(conf.items[2].port_ranges.size() == 1);
+    CHECK(conf.items[2].inbound_port_ranges.size() == 1);
   }
 }
 

--- a/iocore/net/unit_tests/test_YamlSNIConfig.cc
+++ b/iocore/net/unit_tests/test_YamlSNIConfig.cc
@@ -118,6 +118,6 @@ TEST_CASE("YamlConfig handles bad ports appropriately.")
   errorstream << zret;
 
   std::string expected;
-  swoc::bwprint(expected, "1 [1]: yaml-cpp: error at line 18, column 9: bad port range: {}\n", port_str);
+  swoc::bwprint(expected, "1 [1]: yaml-cpp: error at line 20, column 5: bad port range: {}\n", port_str);
   CHECK(errorstream.str() == expected);
 }

--- a/iocore/net/unit_tests/test_YamlSNIConfig.cc
+++ b/iocore/net/unit_tests/test_YamlSNIConfig.cc
@@ -41,8 +41,8 @@
 static void
 check_port_range(const YamlSNIConfig::Item &item, in_port_t min_expected, in_port_t max_expected)
 {
-  CHECK(item.port_range.min() == min_expected);
-  CHECK(item.port_range.max() == max_expected);
+  CHECK(item.port_ranges.at(0).min() == min_expected);
+  CHECK(item.port_ranges.at(0).max() == max_expected);
 }
 
 TEST_CASE("YamlSNIConfig sets port ranges appropriately")
@@ -88,6 +88,19 @@ TEST_CASE("YamlSNIConfig sets port ranges appropriately")
   {
     auto const &item{conf.items[0]};
     CHECK(item.fqdn == "allports.com");
+  }
+
+  SECTION("If multiple port ranges were specified, all of them should be checked.")
+  {
+    auto const &item{conf.items[1]};
+    CHECK(item.port_ranges.at(1).min() == 480);
+    CHECK(item.port_ranges.at(1).max() == 488);
+  }
+
+  SECTION("If one port range was specified, "
+          "there should only be one port range.")
+  {
+    CHECK(conf.items[2].port_ranges.size() == 1);
   }
 }
 

--- a/tests/gold_tests/tls/tls_sni_with_port.test.py
+++ b/tests/gold_tests/tls/tls_sni_with_port.test.py
@@ -125,8 +125,7 @@ class TestSNIWithPort:
         ts.Disk.sni_yaml.AddLines([
             "sni:",
             "- fqdn: yay.example.com",
-            "  inbound_port_ranges:",
-            f"  - {self._port_one}-{self._port_one}",
+            f"  inbound_port_ranges: {self._port_one}-{self._port_one}",
             f"  tunnel_route: localhost:{server_one.Variables.https_port}",
             "- fqdn: yay.example.com",
             "  inbound_port_ranges:",


### PR DESCRIPTION
This changes sni.yaml parsing to allow multiple port ranges.

Before:
```yaml
sni:
- fqdn: example.com
  inbound_port_range: 443-446
```

After:
```yaml
sni:
- fqdn: example.com
  inbound_port_ranges:
  - 443-446
  - 8080
- fqdn: other.com
  inbound_port_ranges: 443
  ```
  
  Test cases and documentation have been updated to reflect the change, and parts of the parsing and AuTest have been refactored.
  
  TODO:
  
  - [x] Consider overlapping ranges (would probably indicate a mistake, but permitted for now as it doesn't do any harm)
  - [x] Double check behavior of invalid ranges where `min` is greater than `max` (already tested 😄)
  - [x] Consider allowing both a sequence or a scalar value for `inbound_port_ranges`. (implemented)