### PR TITLE
Add libloader plugin to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 add_compile_definitions(${HOST_OS} PACKAGE_NAME="ats" PACKAGE_VERSION="${TS_VERSION_STRING}")
-add_compile_options(-Wno-invalid-offsetof)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
 
 # Common includes for everyone
 include_directories(

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -43,6 +43,7 @@ add_subdirectory(esi)
 
 add_subdirectory(generator)
 add_subdirectory(header_rewrite)
+add_subdirectory(libloader)
 add_subdirectory(multiplexer)
 add_subdirectory(xdebug)
 

--- a/plugins/healthchecks/CMakeLists.txt
+++ b/plugins/healthchecks/CMakeLists.txt
@@ -15,10 +15,4 @@
 #
 #######################
 
-# GCC warns that -Wno-invalid-offset, set in top-level CMakeLists.txt,
-# is invalid for C language
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
-
 add_atsplugin(healthchecks healthchecks.c)
-
-target_compile_options(healthchecks PRIVATE -Wall -Wextra)

--- a/plugins/libloader/CMakeLists.txt
+++ b/plugins/libloader/CMakeLists.txt
@@ -19,6 +19,8 @@
 # is invalid for C language
 set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
 
-add_atsplugin(healthchecks healthchecks.c)
+add_atsplugin(libloader libloader.c)
 
-target_compile_options(healthchecks PRIVATE -Wall -Wextra)
+target_include_directories(libloader PRIVATE "${CMAKE_SOURCE_DIR}/include/ts")
+
+target_compile_options(libloader PRIVATE -Wall -Wextra)

--- a/plugins/libloader/CMakeLists.txt
+++ b/plugins/libloader/CMakeLists.txt
@@ -15,12 +15,6 @@
 #
 #######################
 
-# GCC warns that -Wno-invalid-offset, set in top-level CMakeLists.txt,
-# is invalid for C language
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
-
 add_atsplugin(libloader libloader.c)
 
 target_include_directories(libloader PRIVATE "${CMAKE_SOURCE_DIR}/include/ts")
-
-target_compile_options(libloader PRIVATE -Wall -Wextra)


### PR DESCRIPTION
This builds the libloader plugin with CMake, and fixes a typo in a comment in healthchecks/CMakeLists.txt which I copied part of for these changes.