### PR TITLE
Build prefetch plugin and test in CMake build

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -44,6 +44,7 @@ add_subdirectory(esi)
 add_subdirectory(generator)
 add_subdirectory(header_rewrite)
 add_subdirectory(multiplexer)
+add_subdirectory(prefetch)
 add_subdirectory(xdebug)
 
 if(HOST_OS STREQUAL "linux")

--- a/plugins/prefetch/CMakeLists.txt
+++ b/plugins/prefetch/CMakeLists.txt
@@ -1,0 +1,33 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+project(prefetch)
+
+add_atsplugin(prefetch
+    common.cc
+    configs.cc
+    evaluate.cc
+    fetch.cc
+    fetch_policy.cc
+    fetch_policy_simple.cc
+    fetch_policy_lru.cc
+    headers.cc
+    pattern.cc
+    plugin.cc
+)
+
+add_subdirectory(test)

--- a/plugins/prefetch/test/CMakeLists.txt
+++ b/plugins/prefetch/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_executable(test_evaluate
+    test_evaluate.cc
+    "${PROJECT_SOURCE_DIR}/common.cc"
+    "${PROJECT_SOURCE_DIR}/evaluate.cc"
+)
+
+target_link_libraries(test_evaluate PRIVATE catch2::catch2)
+
+target_compile_definitions(test_evaluate PRIVATE PREFETCH_UNIT_TEST)
+
+add_test(NAME test_evaluate COMMAND test_evaluate)


### PR DESCRIPTION
This builds the prefetch plugin and its Catch2 unit test. It introduces a new project() directive for convenience; the test executable can refer to source files relative to the plugin root.