### PR TITLE
Check CMakeLists.txt files in RAT

### DIFF
--- a/ci/rat-regex.txt
+++ b/ci/rat-regex.txt
@@ -9,7 +9,7 @@
 ^libtool$
 ^blib$
 ^stamp-h1$
-.*\.txt$
+.*(?<!CMakeLists)\.txt$
 .*\.cfg$
 .*\.in$
 .*\.dot$

--- a/plugins/esi/CMakeLists.txt
+++ b/plugins/esi/CMakeLists.txt
@@ -1,3 +1,20 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
 add_subdirectory(common)
 add_subdirectory(fetcher)
 add_subdirectory(lib)

--- a/plugins/esi/common/CMakeLists.txt
+++ b/plugins/esi/common/CMakeLists.txt
@@ -1,3 +1,20 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
 add_library(esi-common DocNode.cc gzip.cc Utils.cc)
 target_link_libraries(esi-common PRIVATE ZLIB::ZLIB)
 target_include_directories(esi-common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/plugins/esi/fetcher/CMakeLists.txt
+++ b/plugins/esi/fetcher/CMakeLists.txt
@@ -1,3 +1,20 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
 add_library(fetcher HttpDataFetcherImpl.cc)
 target_link_libraries(fetcher PUBLIC esi-common)
 target_include_directories(fetcher PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/plugins/esi/lib/CMakeLists.txt
+++ b/plugins/esi/lib/CMakeLists.txt
@@ -1,3 +1,20 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
 add_library(esicore
         EsiGunzip.cc
         EsiGzip.cc

--- a/plugins/esi/test/CMakeLists.txt
+++ b/plugins/esi/test/CMakeLists.txt
@@ -1,3 +1,20 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
 add_library(esitest
     print_funcs.cc
     HandlerMap.cc


### PR DESCRIPTION
This uses a negative lookbehind to exclude CMakeLists.txt from the sweeping .txt exclusion in RAT.