### PR TITLE
Build TSVConnFD.so and place in correct directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,7 @@ if(ENABLE_WCCP)
     add_subdirectory(src/traffic_wccp)
 endif()
 add_subdirectory(src/tests)
+add_subdirectory(tests)
 add_subdirectory(plugins)
 add_subdirectory(configs)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_subdirectory(gold_tests/pluginTest/TSVConnFd)

--- a/tests/gold_tests/pluginTest/TSVConnFd/CMakeLists.txt
+++ b/tests/gold_tests/pluginTest/TSVConnFd/CMakeLists.txt
@@ -1,0 +1,23 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_library(TSVConnFd SHARED TSVConnFd.cc)
+
+set_target_properties(TSVConnFd PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.libs"
+    PREFIX ""
+)


### PR DESCRIPTION
This builds TSVConnFD.so for the TSVConnFD AuTest. That AuTest now passes on the CMake build, whereas it was failing prior to this change.