### PR TITLE
Add parser.cc to header_rewrite sources in CMake

### DIFF
--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -23,6 +23,7 @@ add_atsplugin(header_rewrite
     lulu.cc
     operator.cc
     operators.cc
+    parser.cc
     regex_helper.cc
     resources.cc
     ruleset.cc


### PR DESCRIPTION
The plugin was missing symbols because the source file was missed.