### PR TITLE
Adding host URL to NextHop Strategies debug message during host mark down.

### DIFF
--- a/proxy/http/remap/NextHopHealthStatus.cc
+++ b/proxy/http/remap/NextHopHealthStatus.cc
@@ -76,6 +76,7 @@ NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int 
   int64_t fail_threshold  = sm->t_state.txn_conf->parent_fail_threshold;
   int64_t retry_time      = sm->t_state.txn_conf->parent_retry_time;
   uint32_t new_fail_count = 0;
+  const char *host         = sm->t_state.request_data.get_host();
 
   // make sure we're called back with a result structure for a parent
   // that is being retried.
@@ -123,7 +124,9 @@ NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int 
           new_fail_count = h->failCount += 1;
         }
       } // end lock guard
-      NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", h->hostname.c_str());
+
+      NH_Note("[%" PRId64 "] NextHop %s marked as down %s for request %s", sm_id, (result.retry) ? "retry" : "initially",
+              h->hostname.c_str(), host);
     } else {
       // if the last failure was outside the retry window, set the failcount to 1 and failedAt to now.
       { // lock guard

--- a/proxy/http/remap/NextHopHealthStatus.cc
+++ b/proxy/http/remap/NextHopHealthStatus.cc
@@ -124,12 +124,9 @@ NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int 
           new_fail_count = h->failCount += 1;
         }
       } // end lock guard
-      if (host == nullptr) {
-        NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", h->hostname.c_str());
-      } else {
-        NH_Note("[%" PRId64 "] NextHop %s marked as down %s for request %s", sm_id, (result.retry) ? "retry" : "initially",
-                h->hostname.c_str(), host);
-      }
+
+      NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", host ? host: "(null)");
+      
     } else {
       // if the last failure was outside the retry window, set the failcount to 1 and failedAt to now.
       { // lock guard

--- a/proxy/http/remap/NextHopHealthStatus.cc
+++ b/proxy/http/remap/NextHopHealthStatus.cc
@@ -124,9 +124,12 @@ NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int 
           new_fail_count = h->failCount += 1;
         }
       } // end lock guard
-
-      NH_Note("[%" PRId64 "] NextHop %s marked as down %s for request %s", sm_id, (result.retry) ? "retry" : "initially",
-              h->hostname.c_str(), host);
+      if (host == nullptr) {
+        NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", h->hostname.c_str());
+      } else {
+        NH_Note("[%" PRId64 "] NextHop %s marked as down %s for request %s", sm_id, (result.retry) ? "retry" : "initially",
+                h->hostname.c_str(), host);
+      }
     } else {
       // if the last failure was outside the retry window, set the failcount to 1 and failedAt to now.
       { // lock guard

--- a/proxy/http/remap/NextHopHealthStatus.cc
+++ b/proxy/http/remap/NextHopHealthStatus.cc
@@ -125,8 +125,8 @@ NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int 
         }
       } // end lock guard
 
-      NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", host ? host: "(null)");
-      
+      NH_Note("[%" PRId64 "] NextHop %s marked as down %s", sm_id, (result.retry) ? "retry" : "initially", host ? host : "(null)");
+
     } else {
       // if the last failure was outside the retry window, set the failcount to 1 and failedAt to now.
       { // lock guard

--- a/proxy/http/remap/NextHopHealthStatus.cc
+++ b/proxy/http/remap/NextHopHealthStatus.cc
@@ -76,7 +76,7 @@ NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int 
   int64_t fail_threshold  = sm->t_state.txn_conf->parent_fail_threshold;
   int64_t retry_time      = sm->t_state.txn_conf->parent_retry_time;
   uint32_t new_fail_count = 0;
-  const char *host         = sm->t_state.request_data.get_host();
+  const char *host        = sm->t_state.request_data.get_host();
 
   // make sure we're called back with a result structure for a parent
   // that is being retried.


### PR DESCRIPTION
This adds a more verbose debug line for when ATS is determining the next hop while using strategies and marks a host down.
This feature was requested by #8050.

Example log line:
`[Jul  3 09:49:57.824] [ET_NET 9] NOTE: [0] NextHop initially marked as down p1.example.com for request example.com`