### PR TITLE
Build s3_auth plugin in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ check_symbol_exists(BIO_get_shutdown "openssl/bio.h" HAVE_BIO_GET_SHUTDOWN)
 check_symbol_exists(BIO_meth_get_ctrl "openssl/bio.h" HAVE_BIO_METH_GET_CTRL)
 check_symbol_exists(BIO_meth_get_create "openssl/bio.h" HAVE_BIO_METH_GET_CREATE)
 check_symbol_exists(BIO_meth_get_destroy "openssl/bio.h" HAVE_BIO_METH_GET_DESTROY)
+check_symbol_exists(HMAC_CTX_new "openssl/hmac.h" HAVE_HMAC_CTX_NEW)
 check_symbol_exists(DH_get_2048_256 "openssl/dh.h" TS_USE_GET_DH_2048_256)
 check_symbol_exists(OPENSSL_NO_TLS_3 "openssl/ssl.h" TS_NO_USE_TLS12)
 check_symbol_exists(

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -82,6 +82,7 @@
 #cmakedefine HAVE_BIO_METH_GET_CTRL 1
 #cmakedefine HAVE_BIO_METH_GET_CREATE 1
 #cmakedefine HAVE_BIO_METH_GET_DESTROY 1
+#cmakedefine HAVE_HMAC_CTX_NEW 1
 
 #define SIZEOF_VOIDP @CMAKE_SIZEOF_VOID_P@
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(generator)
 add_subdirectory(header_rewrite)
 add_subdirectory(multiplexer)
 add_subdirectory(prefetch)
+add_subdirectory(s3_auth)
 add_subdirectory(xdebug)
 
 if(HOST_OS STREQUAL "linux")

--- a/plugins/s3_auth/CMakeLists.txt
+++ b/plugins/s3_auth/CMakeLists.txt
@@ -1,0 +1,22 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+project(s3_auth)
+
+add_atsplugin(s3_auth s3_auth.cc aws_auth_v4.cc)
+
+add_subdirectory(unit_tests)

--- a/plugins/s3_auth/unit_tests/CMakeLists.txt
+++ b/plugins/s3_auth/unit_tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_executable(test_s3_auth
+    test_aws_auth_v4.cc
+    "${PROJECT_SOURCE_DIR}/aws_auth_v4.cc"
+)
+
+target_link_libraries(test_s3_auth PRIVATE catch2::catch2)
+
+target_compile_definitions(test_s3_auth PRIVATE AWS_AUTH_V4_UNIT_TEST)
+
+add_test(NAME test_s3_auth COMMAND test_s3_auth)


### PR DESCRIPTION
This builds the s3_auth plugin and its unit test. It adds a configure time check for the HMAC_CTX_new symbol in OpenSSL, because the s3_auth plugin needs to know whether we have it in order to compile without errors.