### PR TITLE
Build regex_remap plugin in CMake build

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory(header_rewrite)
 add_subdirectory(libloader)
 add_subdirectory(multiplexer)
 add_subdirectory(prefetch)
+add_subdirectory(regex_remap)
 add_subdirectory(s3_auth)
 add_subdirectory(xdebug)
 

--- a/plugins/regex_remap/CMakeLists.txt
+++ b/plugins/regex_remap/CMakeLists.txt
@@ -1,0 +1,18 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_atsplugin(regex_remap regex_remap.cc)


### PR DESCRIPTION
This builds the regex_remap plugin, which some AuTests require.