### PR TITLE
Build binaries for bigobj AuTest

### DIFF
--- a/tests/gold_tests/bigobj/CMakeLists.txt
+++ b/tests/gold_tests/bigobj/CMakeLists.txt
@@ -15,5 +15,18 @@
 #
 #######################
 
-add_subdirectory(gold_tests/bigobj)
-add_subdirectory(gold_tests/pluginTest/TSVConnFd)
+add_executable(check_ramp check_ramp.c)
+
+set_property(
+  TARGET check_ramp
+  PROPERTY RUNTIME_OUTPUT_DIRECTORY
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+add_executable(push_request push_request.c)
+
+set_property(
+  TARGET push_request
+  PROPERTY RUNTIME_OUTPUT_DIRECTORY
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+)


### PR DESCRIPTION
This builds the 2 binaries needed for the bigojb AuTest. It places them in the source tree (ugh) where the AuTest expects to find them.