### PR TITLE
RPC client: Increase message buffer size.

### DIFF
--- a/include/shared/rpc/IPCSocketClient.h
+++ b/include/shared/rpc/IPCSocketClient.h
@@ -27,7 +27,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-#include <tscore/BufferWriter.h>
+#include <swoc/BufferWriter.h>
 
 namespace shared::rpc
 {
@@ -57,7 +57,7 @@ struct IPCSocketClient {
   self_reference send(std::string_view data);
 
   /// Read all the content from the socket till the passed buffer is full.
-  ReadStatus read_all(ts::FixedBufferWriter &bw);
+  ReadStatus read_all(swoc::FixedBufferWriter &bw);
 
   /// Closes the socket.
   void

--- a/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -33,7 +33,7 @@
 
 #include "swoc/swoc_file.h"
 
-#include <tscore/BufferWriter.h>
+#include <swoc/BufferWriter.h>
 #include "ts/ts.h"
 
 #include "rpc/jsonrpc/JsonRPC.h"
@@ -190,7 +190,7 @@ struct ScopedLocalSocket : shared::rpc::IPCSocketClient {
   std::string
   read()
   {
-    ts::LocalBufferWriter<32000> bw;
+    swoc::LocalBufferWriter<32000> bw;
     auto ret = super::read_all(bw);
     if (ret == ReadStatus::NO_ERROR) {
       return {bw.data(), bw.size()};
@@ -201,7 +201,7 @@ struct ScopedLocalSocket : shared::rpc::IPCSocketClient {
   std::string
   query(std::string_view msg)
   {
-    ts::LocalBufferWriter<32000> bw;
+    swoc::LocalBufferWriter<32000> bw;
     auto ret = connect().send(msg).read_all(bw);
     if (ret == ReadStatus::NO_ERROR) {
       return {bw.data(), bw.size()};

--- a/src/shared/rpc/IPCSocketClient.cc
+++ b/src/shared/rpc/IPCSocketClient.cc
@@ -61,7 +61,7 @@ IPCSocketClient ::send(std::string_view data)
 }
 
 IPCSocketClient::ReadStatus
-IPCSocketClient::read_all(ts::FixedBufferWriter &bw)
+IPCSocketClient::read_all(swoc::FixedBufferWriter &bw)
 {
   if (this->is_closed()) {
     // we had a failure.
@@ -69,10 +69,10 @@ IPCSocketClient::read_all(ts::FixedBufferWriter &bw)
   }
   ReadStatus readStatus{ReadStatus::UNKNOWN};
   while (bw.remaining()) {
-    swoc::MemSpan<char> span{bw.auxBuffer(), bw.remaining()};
+    swoc::MemSpan<char> span{bw.aux_data(), bw.remaining()};
     const ssize_t ret = ::read(_sock, span.data(), span.size());
     if (ret > 0) {
-      bw.fill(ret);
+      bw.commit(ret);
       if (bw.remaining() > 0) { // some space available.
         continue;
       } else {


### PR DESCRIPTION
We need this to be bigger to eventually allocate a bigger number of records/metrics.

We are running some tests where the metrics are quite a large number and this current buffer isn't enough. 

This have only affect in traffic_ctl and traffic_top. 
