### PR TITLE
Update to autest version 1.10.3

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -26,7 +26,7 @@ pyflakes = "*"
 [packages]
 
 # Keep init.cli.ext updated with this required autest version.
-autest = "==1.10.2"
+autest = "==1.10.3"
 
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
 h2 = "*"

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -23,7 +23,7 @@ if sys.version_info < (3, 6, 0):
     host.WriteError(
         "You need python 3.6 or later to run these tests\n", show_stack=False)
 
-needed_autest_version = "1.10.0"
+needed_autest_version = "1.10.3"
 found_autest_version = AuTestVersion()
 if AuTestVersion() < needed_autest_version:
     host.WriteError(


### PR DESCRIPTION
1.10.3 updates IPv6 port selection logic so it works on systems where /etc/hosts doesn't have localhost associated with v6 addresses. This happens not infrequently on recent Ubuntu releases.