### PR TITLE
Remove the useless std::vector calls in plugin_agents_cleanup.

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7421,25 +7421,19 @@ HttpSM::plugin_agents_cleanup()
   // the VC table and cleaned up there. This handles the case where
   // something went wrong early.
   if (!has_active_response_plugin_agents) {
-    std::vector<APIHook *> agent_lists;
-    agent_lists.push_back(txn_hook_get(TS_HTTP_RESPONSE_CLIENT_HOOK));
-    for (auto &agent : agent_lists) {
-      while (agent) {
-        INKVConnInternal *contp = static_cast<INKVConnInternal *>(agent->m_cont);
-        contp->do_io_close();
-        agent = agent->next();
-      }
+    APIHook *agent = txn_hook_get(TS_HTTP_RESPONSE_CLIENT_HOOK);
+    while (agent) {
+      INKVConnInternal *contp = static_cast<INKVConnInternal *>(agent->m_cont);
+      contp->do_io_close();
+      agent = agent->next();
     }
   }
   if (!has_active_request_plugin_agents) {
-    std::vector<APIHook *> agent_lists;
-    agent_lists.push_back(txn_hook_get(TS_HTTP_REQUEST_CLIENT_HOOK));
-    for (auto &agent : agent_lists) {
-      while (agent) {
-        INKVConnInternal *contp = static_cast<INKVConnInternal *>(agent->m_cont);
-        contp->do_io_close();
-        agent = agent->next();
-      }
+    APIHook *agent = txn_hook_get(TS_HTTP_REQUEST_CLIENT_HOOK);
+    while (agent) {
+      INKVConnInternal *contp = static_cast<INKVConnInternal *>(agent->m_cont);
+      contp->do_io_close();
+      agent = agent->next();
     }
   }
 }


### PR DESCRIPTION
@maskit observed that there is an unneccesary use of vectors in HttpSM::plugin_agents_cleanup. I had in mind using the vector to reduce the duplicated logic across the request/response hooks, but that never got implemented and using that doesn't add much value, if any. I'll simply remove the use of the vectors to simplify the code.

---
# For Reviewer

Selecting "Hide whitespace" diff configuration makes this easier to read.