### PR TITLE
Don't use std::min when we don't care which value is smaller

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -1728,7 +1728,7 @@ Http2ConnectionState::restart_streams()
     // Call send_response_body() for each streams
     while (s != end) {
       Http2Stream *next = static_cast<Http2Stream *>(s->link.next ? s->link.next : stream_list.head);
-      if (std::min(this->get_peer_rwnd(), s->get_peer_rwnd()) > 0) {
+      if (this->get_peer_rwnd() > 0 && s->get_peer_rwnd() > 0) {
         SCOPED_MUTEX_LOCK(lock, s->mutex, this_ethread());
         s->restart_sending();
       }
@@ -1738,7 +1738,7 @@ Http2ConnectionState::restart_streams()
 
     // The above stopped at end, so we need to call send_response_body() one
     // last time for the stream pointed to by end.
-    if (std::min(this->get_peer_rwnd(), s->get_peer_rwnd()) > 0) {
+    if (this->get_peer_rwnd() > 0 && s->get_peer_rwnd() > 0) {
       SCOPED_MUTEX_LOCK(lock, s->mutex, this_ethread());
       s->restart_sending();
     }


### PR DESCRIPTION
I found that `std::min` is unnecessarily used in `Http2ConnectionState::restart_stream()`. This is a tiny optimization but we don't care which value is smaller here, and it doesn't look like the use of `std::min`  contributes to readability either.

`h2load -n 20000 -m 1 -c 1  "https://localhost:8443/256k"`

<img width="1421" alt="image" src="https://github.com/apache/trafficserver/assets/153144/3bcfa7c6-8115-4131-9982-a80e4b5f4cac">