### PR TITLE
Clean up certifier plugin debug messages.

### DIFF
--- a/tests/gold_tests/pluginTest/certifier/certifier.test.py
+++ b/tests/gold_tests/pluginTest/certifier/certifier.test.py
@@ -64,7 +64,7 @@ class DynamicCertTest:
             f'certifier.so -s {os.path.join(self.certPathDest, "store")} -m 1000 -c {os.path.join(self.certPathDest, "ca.cert")} -k {os.path.join(self.certPathDest, "ca.key")} -r {os.path.join(self.certPathDest, "ca-serial.txt")}')
         # Verify logs for dynamic generation of certs
         self.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-            "Creating shadow certs",
+            "creating shadow certs",
             "Verify the certifier plugin generates the certificate dynamically.")
 
     def runHTTPSTraffic(self):
@@ -148,7 +148,8 @@ class ReuseExistingCertTest:
             f'certifier.so -s {os.path.join(self.certPathDest, "store")} -m 1000 -c {os.path.join(self.certPathDest, "ca.cert")} -k {os.path.join(self.certPathDest, "ca.key")} -r {os.path.join(self.certPathDest, "ca-serial.txt")}')
         # Verify logs for reusing existing cert
         self.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-            "Reuse existing cert and context for www.tls.com", "Should reuse the existing certificate")
+            "reusing existing cert and context for www.tls.com",
+            "Should reuse the existing certificate")
 
     def runHTTPSTraffic(self):
         tr = Test.AddTestRun("Test dynamic generation of certs")


### PR DESCRIPTION
The certifier plugin manually write out the function name in debug messages, and these were wrong in some cases. Clean this up to use __func__ and a more consistent message format. Remove the "t" mode from fopen call, which is a Windows-ism.