### PR TITLE
fix: require RSRC_CLIENT_REQUEST_HEADERS in ConditionMethod

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -90,6 +90,8 @@ ConditionMethod::initialize(Parser &p)
 
   match->set(p.get_arg());
   _matcher = match;
+
+  require_resources(RSRC_CLIENT_REQUEST_HEADERS);
 }
 
 bool

--- a/tests/gold_tests/pluginTest/header_rewrite/gold/header_rewrite_cond_method.gold
+++ b/tests/gold_tests/pluginTest/header_rewrite/gold/header_rewrite_cond_method.gold
@@ -1,0 +1,8 @@
+``
+> `` http://www.example.com/ HTTP/1.1
+> Host: www.example.com
+``
+< HTTP/1.1 200 OK
+``
+< Via:``
+``

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_method.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_method.test.py
@@ -1,0 +1,73 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test header_rewrite with METHOD conditions and operators.
+'''
+
+Test.ContinueOnFail = True
+# Define default ATS
+ts = Test.MakeATSProcess("ts")
+server = Test.MakeOriginServer("server")
+
+Test.testName = "header_rewrite_method_condition"
+request_get = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_delete = {"headers": "DELETE / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+# expected response from the origin server
+response = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+
+# add response to the server dictionary
+session_file = "sessionfile.log"
+server.addResponse(session_file, request_get, response)
+server.addResponse(session_file, request_delete, response)
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'header.*',
+    'proxy.config.http.insert_response_via_str': 0,
+})
+# The following rule inserts a via header if the request method is a GET or DELETE
+conf_name = "rule_cond_method.conf"
+ts.Setup.CopyAs('rules/{0}'.format(conf_name), Test.RunDirectory)
+ts.Disk.plugin_config.AddLine(
+    'header_rewrite.so {0}/{1}'.format(Test.RunDirectory, conf_name)
+)
+ts.Disk.remap_config.AddLine(
+    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
+)
+
+# Test method in READ_REQUEST_HDR_HOOK.
+expected_output = "gold/header_rewrite_cond_method.gold"
+expected_log = "gold/header_rewrite-tag.gold"
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --proxy 127.0.0.1:{0} "http://www.example.com" -H "Proxy-Connection: keep-alive" --verbose'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.Streams.stderr = expected_output
+tr.StillRunningAfter = server
+ts.Disk.traffic_out.Content = expected_log
+
+# Test method in SEND_REQUEST_HDR_HOOK.
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = 'curl --request DELETE --proxy 127.0.0.1:{0} "http://www.example.com" -H "Proxy-Connection: keep-alive" --verbose'.format(
+    ts.Variables.port)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stderr = expected_output
+tr.StillRunningAfter = server
+ts.Disk.traffic_out.Content = expected_log

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/rule_cond_method.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/rule_cond_method.conf
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cond %{READ_REQUEST_HDR_HOOK}
+cond %{METHOD} =GET
+set-config proxy.config.http.insert_response_via_str 1 [L]
+
+cond %{SEND_REQUEST_HDR_HOOK}
+cond %{METHOD} =DELETE
+set-config proxy.config.http.insert_response_via_str 1 [L]


### PR DESCRIPTION
# Problem
In the header_rewrite plugin, there are some cases where the METHOD condition doesn't work correctly.
The following rewriting rule is one such case.

```
cond %{READ_REQUEST_HDR_HOOK}
cond %{METHOD} =GET
set-config proxy.config.http.insert_response_via_str 1 [L]

cond %{SEND_REQUEST_HDR_HOOK}
cond %{METHOD} =DELETE
set-config proxy.config.http.insert_response_via_str 1 [L]
```

# How to reproduce
Please refer to the test added in this PR.

# Cause
When header rewrite parses each rule, it keeps tabs of the resources required for evaluation. Then during evaluation, it gathers the required resources before applying each rule.

The required resource for the METHOD condition is the client request, used to extract the request method. However, the condition doesn't include the client request in its list of required resources. As a result, the condition will always fail to match because it'll compare the expected method against an empty string.

It's worth mentioning that the condition will sometimes work, though. If some other condition or operator in the same rule requires the client request, the METHOD condition can then obtain the request method. Otherwise, it'll be broken.

Here are some pointers to the relevant bits of code:

This is where the METHOD condition extracts the request method from the client request. It needs res.client_bufp and res.client_hdr_loc to be set beforehand.

https://github.com/apache/trafficserver/blob/fc35742d7143eb29cbc14adc8be782a8e31df52f/plugins/header_rewrite/conditions.cc#L106-L121

This is where resources are gathered during evaluation of each rule. If the RSRC_CLIENT_REQUEST_HEADERS flag is set, then it proceeds to set res.client_bufp and res.client_hdr_loc.

https://github.com/apache/trafficserver/blob/fc35742d7143eb29cbc14adc8be782a8e31df52f/plugins/header_rewrite/header_rewrite.cc#L286
https://github.com/apache/trafficserver/blob/fc35742d7143eb29cbc14adc8be782a8e31df52f/plugins/header_rewrite/resources.cc#L34-L40

This is where the METHOD condition is initialized during the parsing phase. As we can see, it doesn't request access to the client request by setting the RSRC_CLIENT_REQUEST_HEADERS flag.

https://github.com/apache/trafficserver/blob/fc35742d7143eb29cbc14adc8be782a8e31df52f/plugins/header_rewrite/conditions.cc#L85-L93

In contrast, the HEADER condition sets the RSRC_CLIENT_REQUEST_HEADERS flag, enabling access to the client request for any rule that uses the condition. So when used together with the METHOD condition, the METHOD condition would be able to obtain the request method.

https://github.com/apache/trafficserver/blob/fc35742d7143eb29cbc14adc8be782a8e31df52f/plugins/header_rewrite/conditions.cc#L201-L214