### PR TITLE
Build stats_over_http plugin in CMake build

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -48,6 +48,7 @@ add_subdirectory(multiplexer)
 add_subdirectory(prefetch)
 add_subdirectory(regex_remap)
 add_subdirectory(s3_auth)
+add_subdirectory(stats_over_http)
 add_subdirectory(xdebug)
 
 if(HOST_OS STREQUAL "linux")

--- a/plugins/stats_over_http/CMakeLists.txt
+++ b/plugins/stats_over_http/CMakeLists.txt
@@ -1,0 +1,26 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_atsplugin(stats_over_http stats_over_http.cc)
+
+target_include_directories(stats_over_http PRIVATE "${PROJECT_SOURCE_DIR}/include/")
+
+target_link_libraries(stats_over_http PRIVATE libswoc)
+
+if(HAVE_BROTLI_ENCODE_H)
+        target_link_libraries(stats_over_http PRIVATE brotli::brotlienc)
+endif()

--- a/plugins/stats_over_http/stats_over_http.cc
+++ b/plugins/stats_over_http/stats_over_http.cc
@@ -48,7 +48,7 @@
 
 #include <tscpp/util/ts_ip.h>
 
-#include "ink_autoconf.h"
+#include "tscore/ink_config.h"
 #if HAVE_BROTLI_ENCODE_H
 #include <brotli/encode.h>
 #endif


### PR DESCRIPTION
I also changed an include from ink_autoconf.h to ink_config.h. The stats_over_http AuTest passes