### PR TITLE
prefetch: widen evaluations from 32 to 64 bits

### DIFF
--- a/doc/admin-guide/plugins/prefetch.en.rst
+++ b/doc/admin-guide/plugins/prefetch.en.rst
@@ -163,8 +163,8 @@ the following URLs will be requested to be prefetched ::
 Note ``--fetch-path-pattern`` is a PCRE regex/capture pattern and
 ``{$2+2}`` is a mechanism to calculate the next path by adding or
 subtracting integer numbers.  The operands will be treated as unsigned
-32-bit integers.  Invalid numbers are treated as zeroes, and numbers
-too large will be interpreted as 2\ :sup:`32`\ -1.  If subtraction results in
+64-bit integers.  Invalid numbers are treated as zeroes, and numbers
+too large will be interpreted as 2\ :sup:`64`\ -1.  If subtraction results in
 a negative number, 0 is returned instead.  An output width may be
 specified with an integer followed by a colon, e.g. ``{8:$2+2}``,
 causing the resulting number to be padded with leading zeroes if it

--- a/doc/admin-guide/plugins/prefetch.en.rst
+++ b/doc/admin-guide/plugins/prefetch.en.rst
@@ -163,12 +163,28 @@ the following URLs will be requested to be prefetched ::
 Note ``--fetch-path-pattern`` is a PCRE regex/capture pattern and
 ``{$2+2}`` is a mechanism to calculate the next path by adding or
 subtracting integer numbers.  The operands will be treated as unsigned
-64-bit integers.  Invalid numbers are treated as zeroes, and numbers
-too large will be interpreted as 2\ :sup:`64`\ -1.  If subtraction results in
+32-bit integers.  Invalid numbers are treated as zeroes, and numbers
+too large will be interpreted as 2\ :sup:`32`\ -1.  If subtraction results in
 a negative number, 0 is returned instead.  An output width may be
 specified with an integer followed by a colon, e.g. ``{8:$2+2}``,
 causing the resulting number to be padded with leading zeroes if it
 has fewer digits than the width.
+
+To allow larger numbers, the following parameter is supported ::
+
+  @pparam=--fetch-overflow=64
+
+This treats the operands as unsigned 64-bit integers. Numbers too
+large will be interpreted as 2\ :sup:`64`\ -1. Note in this case that
+adds between 2 very large numbers might result in overflow.
+
+To allow arbitrary numbers, the following parameter is supported ::
+
+  @pparam=--fetch-overflow=bignum
+
+Additionally bytewise decimal string add/subtract is supported which
+allows arbitrary big numbers. The regex must use \d+ to ensure that
+only digits are passed in the string.
 
 CMCD (Common Media Client Data) CMCD-Request header with nor field
 ------------------------------------------------------------------

--- a/plugins/prefetch/configs.cc
+++ b/plugins/prefetch/configs.cc
@@ -46,6 +46,39 @@ isTrue(const char *arg)
   return (0 == strncasecmp("true", arg, 4) || 0 == strncasecmp("1", arg, 1) || 0 == strncasecmp("yes", arg, 3));
 }
 
+static String
+fetchOverflowString(const EvalPolicy policy)
+{
+  switch (policy) {
+  case EvalPolicy::Overflow64:
+    return "64";
+    break;
+  case EvalPolicy::Bignum:
+    return "Bignum";
+    break;
+  default:
+    return "32";
+    break;
+  }
+}
+
+static bool
+iequals(const StringView lhs, const StringView rhs)
+{
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(),
+                    [](const char a, const char b) { return tolower(a) == tolower(b); });
+}
+
+void
+PrefetchConfig::setFetchOverflow(const char *optarg)
+{
+  if (StringView("64") == optarg) {
+    _fetchOverflow = EvalPolicy::Overflow64;
+  } else if (iequals("bignum", optarg)) {
+    _fetchOverflow = EvalPolicy::Bignum;
+  }
+}
+
 /**
  * @brief initializes plugin configuration.
  * @param argc number of plugin parameters
@@ -69,6 +102,7 @@ PrefetchConfig::init(int argc, char *argv[])
     {const_cast<char *>("metrics-prefix"),     optional_argument, nullptr, 'm'},
     {const_cast<char *>("exact-match"),        optional_argument, nullptr, 'y'},
     {const_cast<char *>("log-name"),           optional_argument, nullptr, 'l'},
+    {const_cast<char *>("fetch-overflow"),     optional_argument, nullptr, 'o'},
     {nullptr,                                  0,                 nullptr, 0  },
   };
 
@@ -134,6 +168,10 @@ PrefetchConfig::init(int argc, char *argv[])
       setFetchMax(optarg);
       break;
 
+    case 'o': /* --fetch-overflow */
+      setFetchOverflow(optarg);
+      break;
+
     case 'r': /* --replace-host */
       setReplaceHost(optarg);
       break;
@@ -178,6 +216,8 @@ PrefetchConfig::finalize()
   PrefetchDebug("fetch policy parameters: %s", _fetchPolicy.c_str());
   PrefetchDebug("fetch count: %d", _fetchCount);
   PrefetchDebug("fetch concurrently max: %d", _fetchMax);
+  String fostr = fetchOverflowString(_fetchOverflow);
+  PrefetchDebug("fetch overflow: %.*s", (int)fostr.length(), fostr.data());
   PrefetchDebug("replace host name: %s", _replaceHost.c_str());
   PrefetchDebug("name space: %s", _namespace.c_str());
   PrefetchDebug("log name: %s", _logName.c_str());

--- a/plugins/prefetch/configs.h
+++ b/plugins/prefetch/configs.h
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "common.h"
+#include "evaluate.h"
 #include "pattern.h"
 
 /**
@@ -141,6 +142,14 @@ public:
     return _fetchMax;
   }
 
+  void setFetchOverflow(const char *optarg);
+
+  EvalPolicy
+  getFetchOverflow() const
+  {
+    return _fetchOverflow;
+  }
+
   void
   setNameSpace(const char *optarg)
   {
@@ -210,10 +219,11 @@ private:
   std::string _metricsPrefix;
   std::string _logName;
   std::string _queryKey;
-  unsigned _fetchCount = 1;
-  unsigned _fetchMax   = 0;
-  bool _front          = false;
-  bool _exactMatch     = false;
-  bool _cmcd_nor       = false;
+  unsigned _fetchCount      = 1;
+  unsigned _fetchMax        = 0;
+  EvalPolicy _fetchOverflow = EvalPolicy::Overflow32;
+  bool _front               = false;
+  bool _exactMatch          = false;
+  bool _cmcd_nor            = false;
   MultiPattern _nextPaths;
 };

--- a/plugins/prefetch/evaluate.cc
+++ b/plugins/prefetch/evaluate.cc
@@ -59,7 +59,7 @@ evaluate(const String &v)
   pos             = stmt.find_first_of("+-");
 
   if (String::npos == pos) {
-    uint32_t tmp;
+    uint64_t tmp;
     std::istringstream iss(stmt);
     iss >> tmp;
     result = tmp;
@@ -68,16 +68,16 @@ evaluate(const String &v)
   } else {
     String leftOperand = stmt.substr(0, pos);
     std::istringstream liss(leftOperand);
-    uint32_t a;
+    uint64_t a;
     liss >> a;
 
     String rightOperand = stmt.substr(pos + 1);
     std::istringstream riss(rightOperand);
-    uint32_t b;
+    uint64_t b;
     riss >> b;
 
     if ('+' == stmt[pos]) {
-      result = static_cast<uint64_t>(a) + static_cast<uint64_t>(b);
+      result = a + b;
     } else {
       if (a <= b) {
         result = 0;

--- a/plugins/prefetch/evaluate.cc
+++ b/plugins/prefetch/evaluate.cc
@@ -22,11 +22,205 @@
  */
 
 #include "evaluate.h"
+#include <charconv>
 #include <sstream>
 #include <istream>
 #include <iomanip>
 #include <cstdint>
 #include <cinttypes>
+
+namespace
+{
+
+inline char
+tonum(char ch)
+{
+  return ch - '0';
+}
+
+inline char
+tochar(char ch)
+{
+  return ch + '0';
+}
+
+constexpr StringView const svzero{"0"};
+constexpr char const *const digits = "0123456789";
+
+inline bool
+is_valid_digits(const StringView val)
+{
+  return val.npos != val.find_first_of(digits);
+}
+
+// both strings should have all digits
+String
+add(StringView const lhs, StringView const rhs)
+{
+  String result("0");
+
+  StringView other;
+  if (lhs.length() < rhs.length()) {
+    other = lhs;
+    result.append(rhs);
+  } else {
+    other = rhs;
+    result.append(lhs);
+  }
+
+  bool carry = false;
+
+  auto itr = result.rbegin();
+  auto ito = other.crbegin();
+
+  while (ito != other.crend()) {
+    char val = tonum(*itr) + tonum(*ito);
+    if (carry) {
+      ++val;
+    }
+    if (val < 10) {
+      carry = false;
+    } else {
+      val   -= 10;
+      carry  = true;
+    }
+
+    *itr = tochar(val);
+
+    ++itr;
+    ++ito;
+  }
+
+  while (result.rend() != itr && carry) {
+    char val = tonum(*itr) + 1;
+    if (val < 10) {
+      carry = false;
+    } else {
+      val   -= 10;
+      carry  = true;
+    }
+
+    *itr = tochar(val);
+    ++itr;
+  }
+
+  return result;
+}
+
+String
+sub(StringView const lhs, StringView const rhs)
+{
+  String result;
+
+  // ensure result length gte rhs length
+  if (lhs.length() < rhs.length()) {
+    result.append(rhs.length() - lhs.length(), '0');
+    result.append(lhs);
+  } else {
+    result = lhs;
+  }
+
+  PrefetchDebug("sub init result: '%s', rhs: '%.*s'", result.c_str(), (int)rhs.length(), rhs.data());
+
+  bool borrow = false;
+
+  // top and bottom of subtraction
+  auto itr = result.rbegin();
+  auto itb = rhs.crbegin();
+
+  while (result.rend() != itr && rhs.crend() != itb) {
+    char val = tonum(*itr) - tonum(*itb);
+    if (borrow) {
+      --val;
+    }
+    if (val < 0) {
+      borrow  = true;
+      val    += 10;
+    } else {
+      borrow = false;
+    }
+
+    *itr = tochar(val);
+
+    ++itr;
+    ++itb;
+  }
+
+  // keep pushing borrow
+  while (result.rend() != itr && borrow) {
+    char val = tonum(*itr) - 1;
+    if (val < 0) {
+      borrow  = true;
+      val    += 10;
+    } else {
+      borrow = false;
+    }
+
+    *itr = tochar(val);
+    ++itr;
+  }
+
+  PrefetchDebug("sub result: '%s', borrow: '%s'", result.c_str(), borrow ? "true" : "false");
+
+  // if result would have been negative.
+  if (borrow) {
+    result = "0";
+  }
+
+  return result;
+}
+
+String
+evaluateBignum(const StringView view)
+{
+  String result("0");
+
+  StringView v = view;
+
+  uint32_t fwide            = 0;
+  StringView::size_type pos = v.find_first_of(':');
+  if (v.npos != pos) {
+    std::from_chars(v.begin(), v.begin() + pos, fwide);
+    PrefetchDebug("statement: '%.*s', formatting length: %" PRIu32, (int)pos, v.data(), fwide);
+    v = v.substr(pos + 1);
+  }
+
+  pos = v.find_first_of("+-");
+  if (v.npos == pos) {
+    if (is_valid_digits(v)) {
+      result.assign(v);
+    }
+  } else {
+    StringView vleft = v.substr(0, pos);
+    if (!is_valid_digits(vleft)) {
+      vleft = svzero;
+    }
+    StringView vrite = v.substr(pos + 1);
+    if (!is_valid_digits(vrite)) {
+      vrite = svzero;
+    }
+    if ('+' == v[pos]) {
+      PrefetchDebug("Adding %.*s and %.*s", (int)vleft.length(), vleft.data(), (int)vrite.length(), vrite.data());
+      result = add(vleft, vrite);
+    } else {
+      PrefetchDebug("Subbing %.*s and %.*s", (int)vleft.length(), vleft.data(), (int)vrite.length(), vrite.data());
+      result = sub(vleft, vrite);
+    }
+  }
+
+  // wipe out leading zeros
+  while (1 < result.length() && fwide < result.length() && '0' == result.front()) {
+    result.erase(0, 1);
+  }
+
+  // Left pad out with zeros
+  if (result.length() < fwide) {
+    result.insert(0, fwide - result.length(), '0');
+  }
+
+  return result;
+}
+} // namespace
 
 /**
  * @brief Evaluate a math addition or subtraction expression.
@@ -35,60 +229,88 @@
  * @return string containing the result, i.e. "7"
  */
 String
-evaluate(const String &v)
+evaluate(const StringView view, const EvalPolicy policy)
 {
-  if (v.empty()) {
+  if (view.empty()) {
     return String("");
   }
 
+  // short circuit
+  if (policy == EvalPolicy::Bignum) {
+    return evaluateBignum(view);
+  }
+
+  StringView v = view;
+
   /* Find out if width is specified (hence leading zeros are required if the width is bigger then the result width) */
   String stmt;
-  uint32_t len = 0;
-  size_t pos   = v.find_first_of(':');
-  if (String::npos != pos) {
+  uint32_t len              = 0;
+  StringView::size_type pos = v.find_first_of(':');
+  if (v.npos != pos) {
     stmt.assign(v.substr(0, pos));
     std::istringstream iss(stmt);
     iss >> len;
-    stmt.assign(v.substr(pos + 1));
-  } else {
-    stmt.assign(v);
+    v = v.substr(pos + 1);
   }
   PrefetchDebug("statement: '%s', formatting length: %" PRIu32, stmt.c_str(), len);
 
   uint64_t result = 0;
-  pos             = stmt.find_first_of("+-");
+  pos             = v.find_first_of("+-");
 
-  if (String::npos == pos) {
-    uint64_t tmp;
+  if (v.npos == pos) {
+    stmt.assign(v.substr(0, pos));
     std::istringstream iss(stmt);
-    iss >> tmp;
-    result = tmp;
+
+    if (policy == EvalPolicy::Overflow64) {
+      iss >> result;
+    } else {
+      uint32_t tmp32;
+      iss >> tmp32;
+      result = tmp32;
+    }
 
     PrefetchDebug("Single-operand expression: %s -> %" PRIu64, stmt.c_str(), result);
   } else {
-    String leftOperand = stmt.substr(0, pos);
+    const String leftOperand(v.substr(0, pos));
     std::istringstream liss(leftOperand);
-    uint64_t a;
-    liss >> a;
+    uint64_t a64 = 0;
 
-    String rightOperand = stmt.substr(pos + 1);
-    std::istringstream riss(rightOperand);
-    uint64_t b;
-    riss >> b;
-
-    if ('+' == stmt[pos]) {
-      result = a + b;
+    if (policy == EvalPolicy::Overflow64) {
+      liss >> a64;
     } else {
-      if (a <= b) {
+      uint32_t a32;
+      liss >> a32;
+      a64 = a32;
+    }
+    PrefetchDebug("Left-operand expression: %s -> %" PRIu64, leftOperand.c_str(), a64);
+
+    const String rightOperand(v.substr(pos + 1));
+    std::istringstream riss(rightOperand);
+    uint64_t b64 = 0;
+
+    if (policy == EvalPolicy::Overflow64) {
+      riss >> b64;
+    } else {
+      uint32_t b32;
+      riss >> b32;
+      b64 = b32;
+    }
+
+    PrefetchDebug("Right-operand expression: %s -> %" PRIu64, rightOperand.c_str(), b64);
+
+    if ('+' == v[pos]) {
+      result = a64 + b64;
+    } else {
+      if (a64 <= b64) {
         result = 0;
       } else {
-        result = a - b;
+        result = a64 - b64;
       }
     }
   }
 
   std::ostringstream convert;
   convert << std::setw(len) << std::setfill('0') << result;
-  PrefetchDebug("evaluation of '%s' resulted in '%s'", v.c_str(), convert.str().c_str());
+  PrefetchDebug("evaluation of '%.*s' resulted in '%s'", (int)view.length(), view.data(), convert.str().c_str());
   return convert.str();
 }

--- a/plugins/prefetch/evaluate.h
+++ b/plugins/prefetch/evaluate.h
@@ -24,4 +24,10 @@
 #pragma once
 #include "common.h"
 
-String evaluate(const String &v);
+enum EvalPolicy {
+  Overflow32 = 0,
+  Overflow64,
+  Bignum,
+};
+
+String evaluate(const StringView v, const EvalPolicy policy = Overflow32);

--- a/plugins/prefetch/plugin.cc
+++ b/plugins/prefetch/plugin.cc
@@ -186,7 +186,7 @@ public:
  * @return void
  */
 static void
-expand(String &s)
+expand(String &s, const EvalPolicy oflow)
 {
   size_t cur = 0;
   while (String::npos != cur) {
@@ -194,7 +194,7 @@ expand(String &s)
     size_t stop  = s.find_first_of('}', start);
 
     if (String::npos != start && String::npos != stop) {
-      s.replace(start, stop - start + 1, evaluate(s.substr(start + 1, stop - start - 1)));
+      s.replace(start, stop - start + 1, evaluate(s.substr(start + 1, stop - start - 1), oflow));
       cur = stop + 1;
     } else {
       cur = stop;
@@ -637,7 +637,7 @@ contHandleFetch(const TSCont contp, TSEvent event, void *edata)
 
               if (config.getNextPath().replace(workingPath, expandedPath)) {
                 PrefetchDebug("replaced: %s", expandedPath.c_str());
-                expand(expandedPath);
+                expand(expandedPath, config.getFetchOverflow());
                 PrefetchDebug("expanded: %s cachekey: %s", expandedPath.c_str(), data->_cachekey.c_str());
 
                 BgFetch::schedule(state, config, /* askPermission */ false, reqBuffer, reqHdrLoc, txnp, expandedPath.c_str(),

--- a/plugins/prefetch/test/test_evaluate.cc
+++ b/plugins/prefetch/test/test_evaluate.cc
@@ -24,43 +24,78 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 #include "../evaluate.h"
+#include <limits>
 
 TEST_CASE("Basic computation works", "[evaluate]")
 {
   REQUIRE(evaluate("1+3") == "4");
   REQUIRE(evaluate("5-2") == "3");
+  REQUIRE(evaluate("1+3", EvalPolicy::Bignum) == "4");
+  REQUIRE(evaluate("5-2", EvalPolicy::Bignum) == "3");
 }
 
 TEST_CASE("Empty expression", "[empty]")
 {
   REQUIRE(evaluate("") == "");
+  REQUIRE(evaluate("", EvalPolicy::Bignum) == "");
 }
 
 TEST_CASE("64-bit result works", "[evaluate64]")
 {
-  REQUIRE(evaluate("4294967295+4294967295") == "8589934590");
+  const uint32_t max32  = std::numeric_limits<uint32_t>::max();
+  const String max32str = std::to_string(max32);
+  REQUIRE(evaluate(max32str + "+" + max32str) == "8589934590");
+
+  const uint64_t max32_64 = max32;
+  const String addedstr   = std::to_string(2 * max32_64);
+  REQUIRE(evaluate(max32str + "+" + max32str, EvalPolicy::Bignum) == addedstr);
 }
 
-TEST_CASE("Larger number saturation", "[saturation]")
+TEST_CASE("Larger number 32-bit saturation", "[saturation]")
 {
-  REQUIRE(evaluate("3842948374928374982374982374") == "18446744073709551615");
-  REQUIRE(evaluate("3248739487239847298374738924-18446744073709551615") == "0");
+  const uint32_t max32  = std::numeric_limits<uint32_t>::max();
+  const String max32str = std::to_string(max32);
+  REQUIRE(evaluate("3842948374928374982374982374") == max32str);
+  REQUIRE(evaluate("3248739487239847298374738924-" + max32str) == "0");
+}
+
+TEST_CASE("Larger number 64-bit saturation", "[saturation]")
+{
+  const uint64_t max64  = std::numeric_limits<uint64_t>::max();
+  const String max64str = std::to_string(max64);
+  REQUIRE(evaluate("3842948374928374982374982374", EvalPolicy::Overflow64) == max64str);
+  REQUIRE(evaluate("3248739487239847298374738924-" + max64str, EvalPolicy::Overflow64) == "0");
+}
+
+TEST_CASE("Larger number bignum no saturation", "[saturation]")
+{
+  REQUIRE(evaluate("3842948374928374982374982374+6842948374928374982374982374", EvalPolicy::Bignum) ==
+          "10685896749856749964749964748");
+  REQUIRE(evaluate("3248739487239847298374738924-3248739487239847298374738923", EvalPolicy::Bignum) == "1");
+  REQUIRE(evaluate("1000000000000000000000000000-1", EvalPolicy::Bignum) == "999999999999999999999999999");
 }
 
 TEST_CASE("Negative subtraction", "[negative]")
 {
   REQUIRE(evaluate("24-498739847") == "0");
+  REQUIRE(evaluate("24-498739847", EvalPolicy::Overflow64) == "0");
+  REQUIRE(evaluate("24-498739847", EvalPolicy::Bignum) == "0");
 }
 
 TEST_CASE("Treat invalid number as zero", "[invalid]")
 {
   REQUIRE(evaluate("foobar") == "0");
+  REQUIRE(evaluate("foobar", EvalPolicy::Bignum) == "0");
   REQUIRE(evaluate("foo+bar") == "0");
+  REQUIRE(evaluate("foobar+bar", EvalPolicy::Bignum) == "0");
   REQUIRE(evaluate("3+bar") == "3");
+  REQUIRE(evaluate("3+bar", EvalPolicy::Bignum) == "3");
 }
 
 TEST_CASE("Padding with leading zeroes", "[padding]")
 {
   REQUIRE(evaluate("5:1+2") == "00003");
+  REQUIRE(evaluate("5:1+2", EvalPolicy::Bignum) == "00003");
   REQUIRE(evaluate("2:123+123") == "246");
+  REQUIRE(evaluate("2:123+123", EvalPolicy::Bignum) == "246");
 }

--- a/plugins/prefetch/test/test_evaluate.cc
+++ b/plugins/prefetch/test/test_evaluate.cc
@@ -43,8 +43,8 @@ TEST_CASE("64-bit result works", "[evaluate64]")
 
 TEST_CASE("Larger number saturation", "[saturation]")
 {
-  REQUIRE(evaluate("3842948374928374982374982374") == "4294967295");
-  REQUIRE(evaluate("3248739487239847298374738924-4294967295") == "0");
+  REQUIRE(evaluate("3842948374928374982374982374") == "18446744073709551615");
+  REQUIRE(evaluate("3248739487239847298374738924-18446744073709551615") == "0");
 }
 
 TEST_CASE("Negative subtraction", "[negative]")

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.gold
@@ -1,0 +1,4 @@
+GET http://domain.in/texts/demo-3842948374928374982374982374.txt HTTP/1.1
+GET http://domain.in/texts/demo-3842948374928374982374982375.txt HTTP/1.1
+GET http://domain.in/texts/demo-3842948374928374982374982376.txt HTTP/1.1
+GET http://domain.in/texts/demo-3842948374928374982374982377.txt HTTP/1.1

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.test.py
@@ -17,11 +17,13 @@
 #  limitations under the License.
 
 Test.Summary = '''
-Test prefetch.so plugin (simple mode).
+Test prefetch.so plugin (simple overflow64 mode).
 '''
 
 server = Test.MakeOriginServer("server")
-for i in list(range(1, 1 + 3)):
+vals = ["3842948374928374982374982374", "3842948374928374982374982375",
+        "3842948374928374982374982376", "3842948374928374982374982377"]
+for i in vals:
     request_header = {
         "headers":
             f"GET /texts/demo-{i}.txt HTTP/1.1\r\n"
@@ -57,7 +59,8 @@ ts.Disk.remap_config.AddLine(
     " @pparam=--front=true" +
     " @pparam=--fetch-policy=simple" +
     r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" +
-    " @pparam=--fetch-count=3"
+    " @pparam=--fetch-count=3" +
+    " @pparam=--fetch-overflow=bignum"
 )
 
 tr = Test.AddTestRun()
@@ -69,7 +72,7 @@ tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1.txt'
+    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-3842948374928374982374982374.txt'
 )
 tr.Processes.Default.ReturnCode = 0
 
@@ -77,5 +80,5 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     "grep 'GET http://domain.in' trace.log"
 )
-tr.Streams.stdout = "prefetch_simple.gold"
+tr.Streams.stdout = "prefetch_bignum.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.gold
@@ -1,0 +1,4 @@
+GET http://domain.in/texts/demo-3594967639391.txt HTTP/1.1
+GET http://domain.in/texts/demo-3594967639392.txt HTTP/1.1
+GET http://domain.in/texts/demo-3594967639393.txt HTTP/1.1
+GET http://domain.in/texts/demo-3594967639394.txt HTTP/1.1

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.test.py
@@ -17,11 +17,11 @@
 #  limitations under the License.
 
 Test.Summary = '''
-Test prefetch.so plugin (simple mode).
+Test prefetch.so plugin (simple overflow64 mode).
 '''
 
 server = Test.MakeOriginServer("server")
-for i in list(range(1, 1 + 3)):
+for i in list(range(3594967639391, 3594967639391 + 3)):
     request_header = {
         "headers":
             f"GET /texts/demo-{i}.txt HTTP/1.1\r\n"
@@ -57,7 +57,8 @@ ts.Disk.remap_config.AddLine(
     " @pparam=--front=true" +
     " @pparam=--fetch-policy=simple" +
     r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" +
-    " @pparam=--fetch-count=3"
+    " @pparam=--fetch-count=3" +
+    " @pparam=--fetch-overflow=64"
 )
 
 tr = Test.AddTestRun()
@@ -69,7 +70,7 @@ tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1.txt'
+    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-3594967639391.txt'
 )
 tr.Processes.Default.ReturnCode = 0
 
@@ -77,5 +78,5 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     "grep 'GET http://domain.in' trace.log"
 )
-tr.Streams.stdout = "prefetch_simple.gold"
+tr.Streams.stdout = "prefetch_overflow.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_simple.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_simple.gold
@@ -2,3 +2,7 @@ GET http://domain.in/texts/demo-1.txt HTTP/1.1
 GET http://domain.in/texts/demo-2.txt HTTP/1.1
 GET http://domain.in/texts/demo-3.txt HTTP/1.1
 GET http://domain.in/texts/demo-4.txt HTTP/1.1
+GET http://domain.in/texts/demo-3594967639391.txt HTTP/1.1
+GET http://domain.in/texts/demo-3594967639392.txt HTTP/1.1
+GET http://domain.in/texts/demo-3594967639393.txt HTTP/1.1
+GET http://domain.in/texts/demo-3594967639394.txt HTTP/1.1

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_simple.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_simple.gold
@@ -2,7 +2,3 @@ GET http://domain.in/texts/demo-1.txt HTTP/1.1
 GET http://domain.in/texts/demo-2.txt HTTP/1.1
 GET http://domain.in/texts/demo-3.txt HTTP/1.1
 GET http://domain.in/texts/demo-4.txt HTTP/1.1
-GET http://domain.in/texts/demo-3594967639391.txt HTTP/1.1
-GET http://domain.in/texts/demo-3594967639392.txt HTTP/1.1
-GET http://domain.in/texts/demo-3594967639393.txt HTTP/1.1
-GET http://domain.in/texts/demo-3594967639394.txt HTTP/1.1

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_simple.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_simple.test.py
@@ -21,10 +21,10 @@ Test prefetch.so plugin (simple mode).
 '''
 
 server = Test.MakeOriginServer("server")
-for i in range(4):
+for i in list(range(1, 1 + 3)) + list(range(3594967639391, 3594967639391 + 3)):
     request_header = {
         "headers":
-            f"GET /texts/demo-{i + 1}.txt HTTP/1.1\r\n"
+            f"GET /texts/demo-{i}.txt HTTP/1.1\r\n"
             "Host: does.not.matter\r\n"  # But cannot be omitted.
             "\r\n",
             "timestamp": "1469733493.993",
@@ -37,7 +37,7 @@ for i in range(4):
             "Cache-control: max-age=85000\r\n"
             "\r\n",
         "timestamp": "1469733493.993",
-        "body": f"This is the body for demo-{i + 1}.txt.\n"
+        "body": f"This is the body for demo-{i}.txt.\n"
     }
     server.addResponse("sessionlog.json", request_header, response_header)
 
@@ -70,6 +70,13 @@ tr.Processes.Default.ReturnCode = 0
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1.txt'
+)
+tr.Processes.Default.ReturnCode = 0
+
+# check for 32bit overflow
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = (
+    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-3594967639391.txt'
 )
 tr.Processes.Default.ReturnCode = 0
 


### PR DESCRIPTION
useful when someone wants to use grossly huge numbers for segment indices.