### PR TITLE
Support gRPC traffic

### DIFF
--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -446,6 +446,7 @@ private:
   void perform_cache_write_action();
   void perform_transform_cache_write_action();
   void setup_blind_tunnel(bool send_response_hdr, IOBufferReader *initial = nullptr);
+  void setup_tunnel_handler_trailer(HttpTunnelProducer *p);
   HttpTunnelProducer *setup_server_transfer_to_transform();
   HttpTunnelProducer *setup_transfer_from_transform();
   HttpTunnelProducer *setup_cache_transfer_to_transform();

--- a/include/proxy/http2/Http2Stream.h
+++ b/include/proxy/http2/Http2Stream.h
@@ -82,7 +82,7 @@ public:
   void set_expect_receive_trailer() override;
 
   Http2ErrorCode decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_table_size);
-  void send_request(Http2ConnectionState &cstate);
+  void send_headers(Http2ConnectionState &cstate);
   void initiating_close();
   bool is_outbound_connection() const;
   bool is_tunneling() const;

--- a/include/proxy/http2/Http2Stream.h
+++ b/include/proxy/http2/Http2Stream.h
@@ -217,6 +217,12 @@ private:
   History<HISTORY_DEFAULT_SIZE> _history;
   Milestones<Http2StreamMilestone, static_cast<size_t>(Http2StreamMilestone::LAST_ENTRY)> _milestones;
 
+  /** Any headers received while this is true are trailing headers.
+   *
+   * This is set to true when processing DATA frames are done. Therefore any
+   * headers seen after that point are trailing headers. The qualification
+   * "possible" is added because the peer may or may not send trailing headers.
+   */
   bool _trailing_header_is_possible = false;
   bool _expect_send_trailer         = false;
   bool _expect_receive_trailer      = false;
@@ -373,7 +379,7 @@ Http2Stream::reset_send_headers()
   this->_send_header.create(HTTP_TYPE_RESPONSE);
 }
 
-// Check entire DATA payload length if content-length: header is exist
+// Check entire DATA payload length if content-length: header exists
 inline void
 Http2Stream::increment_data_length(uint64_t length)
 {

--- a/include/tscore/ink_string++.h
+++ b/include/tscore/ink_string++.h
@@ -32,6 +32,7 @@
 
 #pragma once
 #include <cstdio>
+#include <cstring>
 #include <strings.h>
 
 /***********************************************************************

--- a/src/proxy/hdrs/HdrToken.cc
+++ b/src/proxy/hdrs/HdrToken.cc
@@ -230,9 +230,6 @@ static HdrTokenFieldInfo _hdrtoken_strs_field_initializers[] = {
   {"Strict-Transport-Security", MIME_SLOTID_NONE,                MIME_PRESENCE_NONE,                (HTIF_MULTVALS)                              },
   {"Subject",                   MIME_SLOTID_NONE,                MIME_PRESENCE_SUBJECT,             HTIF_NONE                                    },
   {"Summary",                   MIME_SLOTID_NONE,                MIME_PRESENCE_SUMMARY,             HTIF_NONE                                    },
- // TODO: In the past we have observed issues with having hop-by-hop in here
-  // for gRPC. We plan to work on gRPC in a future. We should experiment with
-  // this and verify that it works as expected.
   {"TE",                        MIME_SLOTID_TE,                  MIME_PRESENCE_TE,                  (HTIF_COMMAS | HTIF_MULTVALS | HTIF_HOPBYHOP)},
   {"Transfer-Encoding",         MIME_SLOTID_TRANSFER_ENCODING,   MIME_PRESENCE_TRANSFER_ENCODING,
    (HTIF_COMMAS | HTIF_MULTVALS | HTIF_HOPBYHOP)                                                                                                 },

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2790,13 +2790,11 @@ HttpSM::setup_tunnel_handler_trailer(HttpTunnelProducer *p)
   SMDbg(dbg_ctl_http, "Wait for the trailing header");
 
   // Swap out the default hander to set up the new tunnel for the trailer exchange.
-
   HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::tunnel_handler_trailer);
   if (_ua.get_txn()) {
     _ua.get_txn()->set_expect_send_trailer();
   }
   tunnel.local_finish_all(p);
-  SMDebug("http", "[%" PRId64 "] wait for that trailing header", sm_id);
 }
 
 int

--- a/src/proxy/http/HttpTransactHeaders.cc
+++ b/src/proxy/http/HttpTransactHeaders.cc
@@ -26,7 +26,6 @@
 #include <array>
 #include <string_view>
 
-#include "MIME.h"
 #include "tscore/ink_platform.h"
 
 #include "proxy/http/HttpTransact.h"
@@ -34,6 +33,7 @@
 #include "proxy/hdrs/HTTP.h"
 #include "proxy/hdrs/HdrUtils.h"
 #include "proxy/hdrs/HttpCompat.h"
+#include "proxy/hdrs/MIME.h"
 #include "proxy/http/HttpSM.h"
 #include "proxy/PoolableSession.h"
 

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -475,16 +475,16 @@ Http2ConnectionState::rcv_headers_frame(const Http2Frame &frame)
       stream->mark_milestone(Http2StreamMilestone::START_TXN);
       stream->new_transaction(frame.is_from_early_data());
       // Send request header to SM
-      stream->send_request(*this);
+      stream->send_headers(*this);
     } else {
       // If this is a trailer, first signal to the SM that the body is done
       if (stream->trailing_header_is_possible()) {
         stream->set_expect_receive_trailer();
         // Propagate the  trailer header
-        stream->send_request(*this);
+        stream->send_headers(*this);
       } else {
         // Propagate the response
-        stream->send_request(*this);
+        stream->send_headers(*this);
       }
     }
     // Give a chance to send response before reading next frame.
@@ -1061,7 +1061,7 @@ Http2ConnectionState::rcv_continuation_frame(const Http2Frame &frame)
     // "from_early_data" flag from the associated HEADERS frame.
     stream->new_transaction(frame.is_from_early_data());
     // Send request header to SM
-    stream->send_request(*this);
+    stream->send_headers(*this);
     // Give a chance to send response before reading next frame.
     this->session->interrupt_reading_frames();
   } else {
@@ -2433,7 +2433,7 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   stream->set_receive_headers(hdr);
   stream->new_transaction();
   stream->receive_end_stream = true; // No more data with the request
-  stream->send_request(*this);
+  stream->send_headers(*this);
 
   return true;
 }

--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -285,11 +285,14 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     }
   }
 
-  if (this->expect_send_trailer()) {
+  // moved this after converting and writing the headers
+  // because this code killed the stream and its buffers in
+  // tunnel kill_all, causing ats to crash
+  /*if (this->expect_receive_trailer()) {
     // Send read complete to terminate previous data tunnel
     this->read_vio.nbytes = this->read_vio.ndone;
     this->signal_read_event(VC_EVENT_READ_COMPLETE);
-  }
+  }*/
 
   ink_release_assert(this->_sm != nullptr);
   this->_http_sm_id = this->_sm->sm_id;
@@ -315,7 +318,7 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
     }
   } while (!done);
 
-  if (bufindex == 0) {
+  if (dumpoffset == 0) {
     // No data to signal read event
     return;
   }
@@ -323,11 +326,28 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
   // Is the _sm ready to process the header?
   if (this->read_vio.nbytes > 0) {
     if (this->receive_end_stream) {
-      this->read_vio.nbytes = bufindex;
-      this->read_vio.ndone  = bufindex;
+      // this is dangerous, the _sm has possibly not read
+      // the data yet, so we end up with a mismatch if there
+      // is something async in between
+      // better would be to get the actual difference between
+      // the start of the headers and the actual position in
+      // the buffer for the ndone part.
+      // during testing we have not seen any issues
+      this->read_vio.nbytes = this->read_vio.ndone + dumpoffset;
       if (this->is_outbound_connection()) {
+        // This is a response trailer
+        // We don't set ndone, because the VC_EVENT_EOS will
+        // first flush the remaining content to consumers,
+        // after which the TUNNEL_EVENT_DONE will be fired
+        // and the trailer handler will be set up
+        // The trailer handler will read the buffer, and not
+        // get its content from the VIO
+        // This can break if the implementation
+        // changes
         this->signal_read_event(VC_EVENT_EOS);
       } else {
+        // not tested client trailing headers
+        this->read_vio.ndone = this->read_vio.nbytes;
         this->signal_read_event(VC_EVENT_READ_COMPLETE);
       }
     } else {

--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -260,7 +260,7 @@ Http2Stream::decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_ta
 }
 
 void
-Http2Stream::send_request(Http2ConnectionState &cstate)
+Http2Stream::send_headers(Http2ConnectionState &cstate)
 {
   if (closed) {
     return;
@@ -270,7 +270,7 @@ Http2Stream::send_request(Http2ConnectionState &cstate)
   // Convert header to HTTP/1.1 format. Trailing headers need no conversion
   // because they, by definition, do not contain pseudo headers.
   if (this->trailing_header_is_possible()) {
-    Http2StreamDebug("trailing header: Skipping send_request initializtion.");
+    Http2StreamDebug("trailing header: Skipping send_headers initialization.");
   } else {
     if (http2_convert_header_from_2_to_1_1(&_receive_header) == PARSE_RESULT_ERROR) {
       Http2StreamDebug("Error converting HTTP/2 headers to HTTP/1.1.");

--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -49,5 +49,9 @@ jsonschema = "*"
 python-jose = "*"
 pyyaml ="*"
 
+# For the grpc tests.
+grpcio = "*"
+grpcio-tools = "*"
+
 [requires]
 python_version = "3"

--- a/tests/gold_tests/h2/grpc/grpc.test.py
+++ b/tests/gold_tests/h2/grpc/grpc.test.py
@@ -53,23 +53,20 @@ class TestGrpc():
         self._ts.addDefaultSSLFiles()
         self._ts.Disk.ssl_multicert_config.AddLine("dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key")
 
-        self._ts.Disk.remap_config.AddLine(
-            f"map / https://example.com:{server_port}/")
+        self._ts.Disk.remap_config.AddLine(f"map / https://example.com:{server_port}/")
 
-        self._ts.Disk.records_config.update({
-            "proxy.config.ssl.server.cert.path": self._ts.Variables.SSLDir,
-            "proxy.config.ssl.server.private_key.path": self._ts.Variables.SSLDir,
-
-            'proxy.config.ssl.client.alpn_protocols': 'h2,http/1.1',
-            'proxy.config.http.server_session_sharing.pool': 'thread',
-            'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-
-            'proxy.config.dns.nameservers': f"127.0.0.1:{dns_port}",
-            'proxy.config.dns.resolv_conf': "NULL",
-
-            "proxy.config.diags.debug.enabled": 1,
-            "proxy.config.diags.debug.tags": "http",
-        })
+        self._ts.Disk.records_config.update(
+            {
+                "proxy.config.ssl.server.cert.path": self._ts.Variables.SSLDir,
+                "proxy.config.ssl.server.private_key.path": self._ts.Variables.SSLDir,
+                'proxy.config.ssl.client.alpn_protocols': 'h2,http/1.1',
+                'proxy.config.http.server_session_sharing.pool': 'thread',
+                'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+                'proxy.config.dns.nameservers': f"127.0.0.1:{dns_port}",
+                'proxy.config.dns.resolv_conf': "NULL",
+                "proxy.config.diags.debug.enabled": 1,
+                "proxy.config.diags.debug.tags": "http",
+            })
         return self._ts
 
     def _configure_grpc_server(self, tr: 'TestRun') -> 'Process':
@@ -87,10 +84,8 @@ class TestGrpc():
         self._server.Setup.Copy(server_key)
 
         port = get_port(self._server, 'port')
-        command = (
-            f'{sys.executable} {tr.RunDirectory}/grpc_server.py {port} '
-            'server.pem server.key'
-        )
+        command = (f'{sys.executable} {tr.RunDirectory}/grpc_server.py {port} '
+                   'server.pem server.key')
         self._server.Command = command
         self._server.ReturnCode = 0
         return self._server
@@ -105,10 +100,8 @@ class TestGrpc():
         ts_cert = os.path.join(self._ts.Variables.SSLDir, 'server.pem')
         # The cert is for example.com, so we must use that domain.
         hostname = 'example.com'
-        command = (
-            f'{sys.executable} {tr.RunDirectory}/grpc_client.py '
-            f'{hostname} {proxy_port} {ts_cert}'
-        )
+        command = (f'{sys.executable} {tr.RunDirectory}/grpc_client.py '
+                   f'{hostname} {proxy_port} {ts_cert}')
         tr.Processes.Default.Command = command
         tr.Processes.Default.ReturnCode = 0
 
@@ -118,8 +111,7 @@ class TestGrpc():
         tr.Setup.Copy('simple.proto')
         command = (
             f'{sys.executable} -m grpc_tools.protoc -I{tr.RunDirectory} '
-            f'--python_out={tr.RunDirectory} --grpc_python_out={tr.RunDirectory} simple.proto'
-        )
+            f'--python_out={tr.RunDirectory} --grpc_python_out={tr.RunDirectory} simple.proto')
         tr.Processes.Default.Command = command
         pb2_file = os.path.join(tr.RunDirectory, 'simple_pb2.py')
         tr.Disk.File(pb2_file, id='pb2', exists=True)

--- a/tests/gold_tests/h2/grpc/grpc.test.py
+++ b/tests/gold_tests/h2/grpc/grpc.test.py
@@ -1,0 +1,151 @@
+"""Test basic gRPC traffic."""
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+from ports import get_port
+import sys
+
+
+class TestGrpc():
+    """Test basic gRPC traffic."""
+
+    def __init__(self, description: str):
+        """Configure a TestRun for gRPC traffic.
+
+        :param description: The description for the test runs.
+        """
+        self._description = description
+
+    def _configure_dns(self, tr: 'TestRun') -> 'Process':
+        """Configure a locally running MicroDNS server.
+
+        :param tr: The TestRun with which to associate the MicroDNS server.
+        :return: The MicroDNS server process.
+        """
+        self._dns = tr.MakeDNServer("dns", default=['127.0.0.1'])
+        return self._dns
+
+    def _configure_traffic_server(self, tr: 'TestRun', dns_port: int, server_port: int) -> 'Process':
+        """Configure the traffic server process.
+
+        :param tr: The TestRun with which to associate the traffic server.
+        :param dns_port: The MicroDNS server port that traffic server should connect to.
+        :param server_port: The gRPC server port that traffic server should connect to.
+        :return: The traffic server process.
+        """
+        self._ts = tr.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
+
+        self._ts.addDefaultSSLFiles()
+        self._ts.Disk.ssl_multicert_config.AddLine("dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key")
+
+        self._ts.Disk.remap_config.AddLine(
+            f"map / https://example.com:{server_port}/")
+
+        self._ts.Disk.records_config.update({
+            "proxy.config.ssl.server.cert.path": self._ts.Variables.SSLDir,
+            "proxy.config.ssl.server.private_key.path": self._ts.Variables.SSLDir,
+
+            'proxy.config.ssl.client.alpn_protocols': 'h2,http/1.1',
+            'proxy.config.http.server_session_sharing.pool': 'thread',
+            'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns_port}",
+            'proxy.config.dns.resolv_conf': "NULL",
+
+            "proxy.config.diags.debug.enabled": 1,
+            "proxy.config.diags.debug.tags": "http",
+        })
+        return self._ts
+
+    def _configure_grpc_server(self, tr: 'TestRun') -> 'Process':
+        """Start the gRPC server.
+
+        :param tr: The TestRun with which to associate the gRPC server.
+        :return: The gRPC server process.
+        """
+        tr.Setup.Copy('grpc_server.py')
+        self._server = tr.Processes.Process('server')
+
+        server_pem = os.path.join(Test.Variables.AtsTestToolsDir, "ssl", "server.pem")
+        server_key = os.path.join(Test.Variables.AtsTestToolsDir, "ssl", "server.key")
+        self._server.Setup.Copy(server_pem)
+        self._server.Setup.Copy(server_key)
+
+        port = get_port(self._server, 'port')
+        command = (
+            f'{sys.executable} {tr.RunDirectory}/grpc_server.py {port} '
+            'server.pem server.key'
+        )
+        self._server.Command = command
+        self._server.ReturnCode = 0
+        return self._server
+
+    def _configure_grpc_client(self, tr: 'TestRun', proxy_port: int) -> None:
+        """Start the gRPC client.
+
+        :param tr: The TestRun with which to associate the gRPC client.
+        :param proxy_port: The proxy_port to which to connect.
+        """
+        tr.Setup.Copy('grpc_client.py')
+        ts_cert = os.path.join(self._ts.Variables.SSLDir, 'server.pem')
+        # The cert is for example.com, so we must use that domain.
+        hostname = 'example.com'
+        command = (
+            f'{sys.executable} {tr.RunDirectory}/grpc_client.py '
+            f'{hostname} {proxy_port} {ts_cert}'
+        )
+        tr.Processes.Default.Command = command
+        tr.Processes.Default.ReturnCode = 0
+
+    def _compile_protobuf_files(self) -> None:
+        """Compile the protobuf files."""
+        tr = Test.AddTestRun(f'{self._description}: compile the protobuf files.')
+        tr.Setup.Copy('simple.proto')
+        command = (
+            f'{sys.executable} -m grpc_tools.protoc -I{tr.RunDirectory} '
+            f'--python_out={tr.RunDirectory} --grpc_python_out={tr.RunDirectory} simple.proto'
+        )
+        tr.Processes.Default.Command = command
+        pb2_file = os.path.join(tr.RunDirectory, 'simple_pb2.py')
+        tr.Disk.File(pb2_file, id='pb2', exists=True)
+
+        pb2_grpc_file = os.path.join(tr.RunDirectory, 'simple_pb2_grpc.py')
+        tr.Disk.File(pb2_grpc_file, id='pb2_grpc', exists=True)
+
+    def _run_test_traffic(self) -> None:
+        """Configure the TestRun for the client and servers."""
+        tr = Test.AddTestRun(f'{self._description}: run the gRPC traffic.')
+
+        dns = self._configure_dns(tr)
+        server = self._configure_grpc_server(tr)
+        ts = self._configure_traffic_server(tr, dns.Variables.Port, server.Variables.port)
+
+        tr.Processes.Default.StartBefore(dns)
+        tr.Processes.Default.StartBefore(server)
+        tr.Processes.Default.StartBefore(ts)
+
+        self._configure_grpc_client(tr, ts.Variables.ssl_port)
+
+    def run(self) -> None:
+        """Configure the various test runs for the gRPC test."""
+        self._compile_protobuf_files()
+        self._run_test_traffic()
+
+
+test = TestGrpc("Test basic gRPC traffic")
+test.run()

--- a/tests/gold_tests/h2/grpc/grpc_client.py
+++ b/tests/gold_tests/h2/grpc/grpc_client.py
@@ -49,18 +49,10 @@ def run_grpc_client(hostname: str, proxy_port: int, proxy_cert: bytes) -> int:
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        'hostname',
-        help='The hostname to which to connect.')
+    parser.add_argument('hostname', help='The hostname to which to connect.')
 
-    parser.add_argument(
-        'proxy_port',
-        type=int,
-        help='The ATS port to which to connect.')
-    parser.add_argument(
-        'proxy_cert',
-        type=argparse.FileType('rb'),
-        help='The public TLS certificate to use.')
+    parser.add_argument('proxy_port', type=int, help='The ATS port to which to connect.')
+    parser.add_argument('proxy_cert', type=argparse.FileType('rb'), help='The public TLS certificate to use.')
     return parser.parse_args()
 
 

--- a/tests/gold_tests/h2/grpc/grpc_client.py
+++ b/tests/gold_tests/h2/grpc/grpc_client.py
@@ -1,0 +1,82 @@
+"""A gRPC client."""
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import grpc
+import os
+import sys
+
+import simple_pb2
+import simple_pb2_grpc
+
+
+def run_grpc_client(hostname: str, proxy_port: int, proxy_cert: bytes) -> int:
+    """Run the gRPC client.
+
+    :param hostname: The hostname to which to connect.
+    :param proxy_port: The ATS port to which to connect.
+    :param proxy_cert: The public TLS certificate to verify ATS against.
+    :return: The exit code.
+    """
+    credentials = grpc.ssl_channel_credentials(root_certificates=proxy_cert)
+    channel_options = (('grpc.ssl_target_name_override', hostname),)
+    destination_endpoint = f'127.0.0.1:{proxy_port}'
+    channel = grpc.secure_channel(destination_endpoint, credentials, options=channel_options)
+    print(f'Connecting to: {destination_endpoint}')
+    stub = simple_pb2_grpc.SimpleStub(channel)
+
+    message = simple_pb2.SimpleRequest(message="Client request message")
+    response = stub.SimpleMethod(message)
+    print(f'Response received from server: {response.message}')
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'hostname',
+        help='The hostname to which to connect.')
+
+    parser.add_argument(
+        'proxy_port',
+        type=int,
+        help='The ATS port to which to connect.')
+    parser.add_argument(
+        'proxy_cert',
+        type=argparse.FileType('rb'),
+        help='The public TLS certificate to use.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the main entry point for the gRPC client.
+
+    :return: The exit code.
+    """
+    args = parse_args()
+
+    try:
+        return run_grpc_client(args.hostname, args.proxy_port, args.proxy_cert.read())
+    except grpc.RpcError as e:
+        print(f'RPC failed with code {e.code()}: {e.details()}')
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/gold_tests/h2/grpc/grpc_server.py
+++ b/tests/gold_tests/h2/grpc/grpc_server.py
@@ -62,18 +62,9 @@ def run_grpc_server(port: int, server_cert: str, server_key: str) -> int:
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        'port',
-        type=int,
-        help='The port on which to listen.')
-    parser.add_argument(
-        'server_crt',
-        type=argparse.FileType('rb'),
-        help="The public TLS certificate to use.")
-    parser.add_argument(
-        'server_key',
-        type=argparse.FileType('rb'),
-        help="The private TLS key to use.")
+    parser.add_argument('port', type=int, help='The port on which to listen.')
+    parser.add_argument('server_crt', type=argparse.FileType('rb'), help="The public TLS certificate to use.")
+    parser.add_argument('server_key', type=argparse.FileType('rb'), help="The private TLS key to use.")
     return parser.parse_args()
 
 

--- a/tests/gold_tests/h2/grpc/grpc_server.py
+++ b/tests/gold_tests/h2/grpc/grpc_server.py
@@ -1,0 +1,90 @@
+"""A gRPC server."""
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from concurrent import futures
+import grpc
+import sys
+import time
+
+import simple_pb2
+import simple_pb2_grpc
+
+
+class SimpleServicer(simple_pb2_grpc.SimpleServicer):
+    """A gRPC servicer."""
+
+    def SimpleMethod(self, request, context):
+        """An example gRPC method."""
+        print(f'Request received from client: {request.message}')
+        response = simple_pb2.SimpleResponse(message=f"Echo: {request.message}")
+        return response
+
+
+def run_grpc_server(port: int, server_cert: str, server_key: str) -> int:
+    """Run the gRPC server.
+
+    :param port: The port on which to listen.
+    :param server_cert: The public TLS certificate to use.
+    :param server_key: The private TLS key to use.
+    :return: The exit code.
+    """
+    credentials = grpc.ssl_server_credentials([(server_key, server_cert)])
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    simple_pb2_grpc.add_SimpleServicer_to_server(SimpleServicer(), server)
+    server_endpoint = f'127.0.0.1:{port}'
+    server.add_secure_port(server_endpoint, credentials)
+    print(f'Listening on: {server_endpoint}')
+    server.start()
+    try:
+        server.wait_for_termination()
+    except KeyboardInterrupt:
+        print("Keyboard interrupt received, exiting.")
+        return 0
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'port',
+        type=int,
+        help='The port on which to listen.')
+    parser.add_argument(
+        'server_crt',
+        type=argparse.FileType('rb'),
+        help="The public TLS certificate to use.")
+    parser.add_argument(
+        'server_key',
+        type=argparse.FileType('rb'),
+        help="The private TLS key to use.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the main entry point for the gRPC server.
+
+    :return: The exit code.
+    """
+    args = parse_args()
+    return run_grpc_server(args.port, args.server_crt.read(), args.server_key.read())
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/gold_tests/h2/grpc/simple.proto
+++ b/tests/gold_tests/h2/grpc/simple.proto
@@ -1,0 +1,38 @@
+/** @file
+
+  The gRPC protocol buffer definition for the gRPC autest.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+syntax = "proto3";
+
+package simple;
+
+service Simple {
+    rpc SimpleMethod(SimpleRequest) returns (SimpleResponse) {}
+}
+
+message SimpleRequest {
+    string message = 1;
+}
+
+message SimpleResponse {
+    string message = 1;
+}


### PR DESCRIPTION
Now that we support HTTP/2 to origin, we can now support gRPC traffic end to end. This PR is made up of three patches:

1. A new gRPC autest.
2. Updates from @keesspoelstra to support tunneling HTTP/2 trailers.
3. A patch to preserve the "te: trailers" header which the server requires in order to transmit gRPC traffic.
4. A rename of `Http2Stream::send_request` to `send_headers` since the function processes both request and response headers so the original name was confusing.