### PR TITLE
New API Metrics, and start of a libtsapi.so structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ src/tscore/test_tscore
 src/tscpp/util/test_tscpputil
 src/records/test_librecords
 src/records/test_librecords_on_eventsystem
+src/api/test_Metrics
 lib/perl/lib/Apache/TS.pm
 
 iocore/net/test_certlookup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,7 @@ configure_file(include/ts/apidefs.h.in include/ts/apidefs.h)
 
 enable_testing()
 
+add_subdirectory(src/api)
 add_subdirectory(src/tscpp/util)
 add_subdirectory(src/tscpp/api)
 add_subdirectory(src/tscore)

--- a/configure.ac
+++ b/configure.ac
@@ -2400,6 +2400,7 @@ AC_CONFIG_FILES([
   src/tscpp/util/Makefile
   src/tscore/Makefile
   src/records/Makefile
+  src/api/Makefile
   tools/Makefile
   tools/trafficserver.pc
   tools/tsxs

--- a/configure.ac
+++ b/configure.ac
@@ -1187,8 +1187,8 @@ AC_MSG_NOTICE([Build for host OS: $host_os, arch: $host_cpu, optimization: $host
 # Add hardening options to flags
 AS_IF([test "x${enable_hardening}" = "xyes"], [
   TS_ADDTO(AM_CPPFLAGS, [-D_FORTIFY_SOURCE=2])
-  TS_ADDTO(AM_CXXFLAGS, [-fPIE -fstack-protector])
-  TS_ADDTO(AM_CFLAGS, [-fPIE -fstack-protector])
+  TS_ADDTO(AM_CXXFLAGS, [-fstack-protector])
+  TS_ADDTO(AM_CFLAGS, [-fstack-protector])
   AS_CASE("$host_os_def",
     [linux], [TS_ADDTO(AM_LDFLAGS, [-pie -Wl,-z,relro -Wl,-z,now])]
   )

--- a/configure.ac
+++ b/configure.ac
@@ -1187,8 +1187,8 @@ AC_MSG_NOTICE([Build for host OS: $host_os, arch: $host_cpu, optimization: $host
 # Add hardening options to flags
 AS_IF([test "x${enable_hardening}" = "xyes"], [
   TS_ADDTO(AM_CPPFLAGS, [-D_FORTIFY_SOURCE=2])
-  TS_ADDTO(AM_CXXFLAGS, [-fstack-protector])
-  TS_ADDTO(AM_CFLAGS, [-fstack-protector])
+  TS_ADDTO(AM_CXXFLAGS, [-fPIE -fstack-protector])
+  TS_ADDTO(AM_CFLAGS, [-fPIE -fstack-protector])
   AS_CASE("$host_os_def",
     [linux], [TS_ADDTO(AM_LDFLAGS, [-pie -Wl,-z,relro -Wl,-z,now])]
   )

--- a/include/api/Metrics.h
+++ b/include/api/Metrics.h
@@ -122,7 +122,7 @@ public:
   {
   public:
     using iterator_category = std::input_iterator_tag;
-    using value_type        = std::tuple<std::string_view, AtomicType::value_type>;
+    using value_type        = std::tuple<std::string_view, int64_t>;
     using difference_type   = ptrdiff_t;
     using pointer           = value_type *;
     using reference         = value_type &;

--- a/include/api/Metrics.h
+++ b/include/api/Metrics.h
@@ -1,0 +1,223 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+#include <unordered_map>
+#include <tuple>
+#include <mutex>
+#include <thread>
+#include <atomic>
+#include <cstdint>
+
+#include "tscore/ink_assert.h"
+
+namespace ts
+{
+class Metrics
+{
+private:
+  using self_type  = Metrics;
+  using IdType     = int32_t; // Could be a tuple, but one way or another, they have to be combined to an int32_t.
+  using AtomicType = std::atomic<int64_t>;
+
+public:
+  static constexpr uint16_t METRICS_MAX_BLOBS = 8192;
+  static constexpr uint16_t METRICS_MAX_SIZE  = 2048;                               // For a total of 16M metrics
+  static constexpr IdType NOT_FOUND           = std::numeric_limits<IdType>::min(); // <16-bit,16-bit> = <blob-index,offset>
+
+private:
+  using NameAndId       = std::tuple<std::string, IdType>;
+  using NameContainer   = std::array<NameAndId, METRICS_MAX_SIZE>;
+  using AtomicContainer = std::array<AtomicType, METRICS_MAX_SIZE>;
+  using MetricStorage   = std::tuple<NameContainer, AtomicContainer>;
+  using MetricBlobs     = std::array<MetricStorage *, METRICS_MAX_BLOBS>;
+  using LookupTable     = std::unordered_map<std::string_view, IdType>;
+
+public:
+  Metrics(const self_type &)              = delete;
+  self_type &operator=(const self_type &) = delete;
+  Metrics &operator=(Metrics &&)          = delete;
+  Metrics(Metrics &&)                     = delete;
+
+  virtual ~Metrics() = default;
+
+  Metrics()
+  {
+    _blobs[0] = new MetricStorage();
+    ink_release_assert(_blobs[0]);
+    ink_release_assert(0 == newMetric("proxy.node.api.metrics.bad_id")); // Reserve slot 0 for errors, this should always be 0
+  }
+
+  // Singleton
+  static Metrics &getInstance();
+
+  // Yes, we don't return objects here, but rather ID's and atomic's directly. Treat
+  // the std::atomic<int64_t> as the underlying class for a single metric, and be happy.
+  IdType newMetric(const std::string_view name);
+  IdType lookup(const std::string_view name) const;
+  AtomicType *lookup(IdType id, std::string_view *name = nullptr) const;
+
+  AtomicType &
+  operator[](IdType id)
+  {
+    return *lookup(id);
+  }
+
+  IdType
+  operator[](const std::string_view name) const
+  {
+    return lookup(name);
+  }
+
+  int64_t
+  increment(IdType id, uint64_t val = 1)
+  {
+    auto metric = lookup(id);
+
+    return (metric ? metric->fetch_add(val) : NOT_FOUND);
+  }
+
+  // ToDo: Do we even need these inc/dec functions?
+  int64_t
+  decrement(IdType id, uint64_t val = 1)
+  {
+    auto metric = lookup(id);
+
+    return (metric ? metric->fetch_sub(val) : NOT_FOUND);
+  }
+
+  std::string_view name(IdType id) const;
+
+  bool
+  valid(IdType id) const
+  {
+    auto [blob, entry] = _splitID(id);
+
+    return (id >= 0 && ((blob < _cur_blob && entry < METRICS_MAX_SIZE) || (blob == _cur_blob && entry <= _cur_off)));
+  }
+
+  class iterator
+  {
+  public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type        = std::tuple<std::string_view, AtomicType::value_type>;
+    using difference_type   = ptrdiff_t;
+    using pointer           = value_type *;
+    using reference         = value_type &;
+
+    iterator(const Metrics &m, IdType pos) : _metrics(m), _it(pos) {}
+
+    iterator &
+    operator++()
+    {
+      next();
+
+      return *this;
+    }
+
+    iterator
+    operator++(int)
+    {
+      iterator result = *this;
+
+      next();
+
+      return result;
+    }
+
+    value_type
+    operator*() const
+    {
+      std::string_view name;
+      auto metric = _metrics.lookup(_it, &name);
+
+      return std::make_tuple(name, metric->load());
+    }
+
+    bool
+    operator==(const iterator &o) const
+    {
+      return _it == o._it && std::addressof(_metrics) == std::addressof(o._metrics);
+    }
+
+    bool
+    operator!=(const iterator &o) const
+    {
+      return _it != o._it || std::addressof(_metrics) != std::addressof(o._metrics);
+    }
+
+  private:
+    void next();
+
+    const Metrics &_metrics;
+    IdType _it;
+  };
+
+  iterator
+  begin() const
+  {
+    return iterator(*this, 0);
+  }
+
+  iterator
+  end() const
+  {
+    _mutex.lock();
+    int16_t blob   = _cur_blob;
+    int16_t offset = _cur_off;
+    _mutex.unlock();
+
+    return iterator(*this, _makeId(blob, offset));
+  }
+
+private:
+  static constexpr std::tuple<uint16_t, uint16_t>
+  _splitID(IdType value)
+  {
+    return std::make_tuple(static_cast<uint16_t>(value >> 16), static_cast<uint16_t>(value & 0xFFFF));
+  }
+
+  static constexpr IdType
+  _makeId(uint16_t blob, uint16_t offset)
+  {
+    return (blob << 16 | offset);
+  }
+
+  static constexpr IdType
+  _makeId(std::tuple<uint16_t, uint16_t> id)
+  {
+    return _makeId(std::get<0>(id), std::get<1>(id));
+  }
+
+  void _addBlob();
+
+  mutable std::mutex _mutex;
+  LookupTable _lookups;
+  MetricBlobs _blobs;
+  uint16_t _cur_blob = 0;
+  uint16_t _cur_off  = 0;
+}; // class Metrics
+
+} // namespace ts

--- a/include/api/Metrics.h
+++ b/include/api/Metrics.h
@@ -194,6 +194,18 @@ public:
     return iterator(*this, _makeId(blob, offset));
   }
 
+  iterator
+  find(const std::string_view name) const
+  {
+    auto id = lookup(name);
+
+    if (id == NOT_FOUND) {
+      return end();
+    } else {
+      return iterator(*this, id);
+    }
+  }
+
 private:
   static constexpr std::tuple<uint16_t, uint16_t>
   _splitID(IdType value)

--- a/include/api/Metrics.h
+++ b/include/api/Metrics.h
@@ -30,6 +30,8 @@
 #include <thread>
 #include <atomic>
 #include <cstdint>
+#include <string>
+#include <string_view>
 
 #include "tscore/ink_assert.h"
 

--- a/include/records/I_RecordsConfig.h
+++ b/include/records/I_RecordsConfig.h
@@ -25,9 +25,6 @@
 
 #include "records/P_RecCore.h"
 
-// This is to manage the librecords table sizes. Not awesome, but better than the earlier recompiling of ATS requirement...
-extern int max_records_entries;
-
 enum RecordRequiredType {
   RR_NULL,    // config is _not_ required to be defined in records.yaml
   RR_REQUIRED // config _is_ required to be defined in record.config

--- a/include/records/P_RecCore.h
+++ b/include/records/P_RecCore.h
@@ -37,7 +37,7 @@
 #include <swoc/Errata.h>
 
 // records, record hash-table, and hash-table rwlock
-extern RecRecord *g_records;
+extern RecRecord g_records[REC_MAX_RECORDS];
 extern std::unordered_map<std::string, RecRecord *> g_records_ht;
 extern ink_rwlock g_records_rwlock;
 extern int g_num_records;

--- a/include/records/P_RecDefs.h
+++ b/include/records/P_RecDefs.h
@@ -27,12 +27,10 @@
 
 #define REC_MESSAGE_ELE_MAGIC 0xF00DF00D
 
-// We need at least this many internal record entries for our configurations and metrics. Any
-// additional slots in librecords will be allocated to the plugin metrics. These should be
-// updated if we change the internal librecords size significantly.
-#define REC_INTERNAL_RECORDS    1100
-#define REC_DEFAULT_API_RECORDS 1400
-
+// We need at least this many internal record entries for our configurations and metrics.
+// This may need adjustments if we make significant additions to librecords. Note that
+// plugins are using their own metrics systems.
+#define REC_MAX_RECORDS               1500
 #define REC_CONFIG_UPDATE_INTERVAL_MS 3000
 #define REC_REMOTE_SYNC_INTERVAL_MS   5000
 

--- a/iocore/aio/Makefile.am
+++ b/iocore/aio/Makefile.am
@@ -56,6 +56,7 @@ test_AIO_LDADD = \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ @YAMLCPP_LIBS@ @LIBPCRE@ @LIBCAP@
 

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -98,7 +98,6 @@ test_LDADD = \
 	$(top_builddir)/proxy/shared/libdiagsconfig.a \
 	$(top_builddir)/iocore/utils/libinkutils.a \
 	$(top_builddir)/iocore/aio/libinkaio.a \
-	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscore/libtscore.a \

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -98,7 +98,9 @@ test_LDADD = \
 	$(top_builddir)/proxy/shared/libdiagsconfig.a \
 	$(top_builddir)/iocore/utils/libinkutils.a \
 	$(top_builddir)/iocore/aio/libinkaio.a \
+	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/records/librecords_p.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/lib/fastlz/libfastlz.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \

--- a/iocore/eventsystem/Makefile.am
+++ b/iocore/eventsystem/Makefile.am
@@ -97,6 +97,7 @@ test_LD_ADD = \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@HWLOC_LIBS@ @SWOC_LIBS@ @YAMLCPP_LIBS@ @LIBPCRE@ @LIBCAP@
 

--- a/iocore/hostdb/Makefile.am
+++ b/iocore/hostdb/Makefile.am
@@ -67,6 +67,7 @@ test_LD_ADD = \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ @YAMLCPP_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @LIBCAP@
 

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -51,17 +51,13 @@ test_certlookup_SOURCES = \
 	SSLCertLookup.cc
 
 test_certlookup_LDADD = \
-	@OPENSSL_LIBS@ \
-<<<<<<< HEAD
-	$(top_builddir)/src/tscore/libtscore.a $(top_builddir)/src/tscpp/util/libtscpputil.la \
-=======
-	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
->>>>>>> b6a133f27 (Fixes make check)
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@YAMLCPP_LIBS@ \
 	@SWOC_LIBS@ \
+	@OPENSSL_LIBS@ \
 	@LIBPCRE@ \
 	@LIBCAP@
 
@@ -88,11 +84,10 @@ test_UDPNet_LDADD = \
 	libinknet.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
-	$(top_builddir)/src/api/libtsapi.la \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/src/tscore/libtscore.a
+	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@ @SWOC_LIBS@ @LIBPCRE@ @LIBCAP@
 if ENABLE_QUIC
@@ -132,12 +127,8 @@ test_libinknet_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
-<<<<<<< HEAD
 	$(top_builddir)/src/tscore/libtscore.a \
-=======
-	$(top_builddir)/src/tscore/libtscore.la \
 	$(top_builddir)/src/api/libtsapi.la \
->>>>>>> b6a133f27 (Fixes make check)
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@ @SWOC_LIBS@ @LIBCAP@

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -52,7 +52,12 @@ test_certlookup_SOURCES = \
 
 test_certlookup_LDADD = \
 	@OPENSSL_LIBS@ \
+<<<<<<< HEAD
 	$(top_builddir)/src/tscore/libtscore.a $(top_builddir)/src/tscpp/util/libtscpputil.la \
+=======
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+>>>>>>> b6a133f27 (Fixes make check)
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@YAMLCPP_LIBS@ \
@@ -83,8 +88,11 @@ test_UDPNet_LDADD = \
 	libinknet.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
+	$(top_builddir)/src/api/libtsapi.la \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/src/tscore/libtscore.a $(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/tscore/libtscore.a
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@ @SWOC_LIBS@ @LIBPCRE@ @LIBCAP@
 if ENABLE_QUIC
@@ -124,7 +132,12 @@ test_libinknet_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
+<<<<<<< HEAD
 	$(top_builddir)/src/tscore/libtscore.a \
+=======
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/api/libtsapi.la \
+>>>>>>> b6a133f27 (Fixes make check)
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@HWLOC_LIBS@ @OPENSSL_LIBS@ @LIBPCRE@ @YAMLCPP_LIBS@ @SWOC_LIBS@ @LIBCAP@

--- a/mgmt/rpc/Makefile.am
+++ b/mgmt/rpc/Makefile.am
@@ -104,6 +104,7 @@ test_jsonrpcserver_LDADD = \
 	libjsonrpc_protocol.la \
 	libjsonrpc_server.la \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \

--- a/mgmt/rpc/Makefile.am
+++ b/mgmt/rpc/Makefile.am
@@ -103,10 +103,10 @@ test_jsonrpcserver_SOURCES = \
 test_jsonrpcserver_LDADD = \
 	libjsonrpc_protocol.la \
 	libjsonrpc_server.la \
-	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/src/tscore/libtscore.a \
 	@YAMLCPP_LIBS@ @HWLOC_LIBS@  @SWOC_LIBS@ @YAMLCPP_LIBS@ @LIBPCRE@ @LIBCAP@

--- a/mgmt/rpc/Makefile.am
+++ b/mgmt/rpc/Makefile.am
@@ -103,7 +103,7 @@ test_jsonrpcserver_SOURCES = \
 test_jsonrpcserver_LDADD = \
 	libjsonrpc_protocol.la \
 	libjsonrpc_server.la \
-	$(top_builddir)/src/api/libtsapi.la \
+	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/api/libtsapi.la \

--- a/plugins/experimental/remap_stats/remap_stats.cc
+++ b/plugins/experimental/remap_stats/remap_stats.cc
@@ -46,9 +46,6 @@ struct config_t {
   int txn_slot{-1};
 };
 
-// From "core".... sigh, but we need it for now at least.
-extern int max_records_entries;
-
 namespace
 {
 void

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -85,6 +85,7 @@ test_proxy_hdrs_SOURCES = \
 test_proxy_hdrs_LDFLAGS = @AM_LDFLAGS@ @SWOC_LDFLAGS@ @YAMLCPP_LDFLAGS@ @OPENSSL_LDFLAGS@
 test_proxy_hdrs_LDADD = \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
@@ -100,6 +101,8 @@ test_hdr_heap_SOURCES = \
 
 test_hdr_heap_LDADD = \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
+	$(top_builddir)/src/api/libtsapi.la \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -89,6 +89,7 @@ test_proxy_hdrs_LDADD = \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/api/libtsapi.la \
 	@SWOC_LIBS@ @YAMLCPP_LIBS@ @HWLOC_LIBS@ @LIBPCRE@ @OPENSSL_LIBS@ @LIBCAP@
 
 test_hdr_heap_CPPFLAGS = $(AM_CPPFLAGS) \
@@ -104,6 +105,7 @@ test_hdr_heap_LDADD = \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/api/libtsapi.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ \
 	@LIBPCRE@ @OPENSSL_LIBS@ @LIBCAP@
 

--- a/proxy/hdrs/Makefile.am
+++ b/proxy/hdrs/Makefile.am
@@ -85,7 +85,6 @@ test_proxy_hdrs_SOURCES = \
 test_proxy_hdrs_LDFLAGS = @AM_LDFLAGS@ @SWOC_LDFLAGS@ @YAMLCPP_LDFLAGS@ @OPENSSL_LDFLAGS@
 test_proxy_hdrs_LDADD = \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
@@ -101,8 +100,6 @@ test_hdr_heap_SOURCES = \
 
 test_hdr_heap_LDADD = \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/src/api/libtsapi.la \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -104,6 +104,11 @@ test_proxy_http_SOURCES = \
 	HttpBodyFactory.h
 
 test_proxy_http_LDADD = \
+<<<<<<< HEAD
+=======
+	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/api/libtsapi.la \
+>>>>>>> b6a133f27 (Fixes make check)
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/proxy/logging/liblogging.a \
 	$(top_builddir)/src/records/librecords_p.a \

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -107,7 +107,6 @@ test_proxy_http_LDADD = \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/proxy/logging/liblogging.a \
 	$(top_builddir)/src/records/librecords_p.a \
-	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/iocore/utils/libinkutils.a \
 	$(top_builddir)/src/tscore/libtscore.a \

--- a/proxy/http/Makefile.am
+++ b/proxy/http/Makefile.am
@@ -104,17 +104,14 @@ test_proxy_http_SOURCES = \
 	HttpBodyFactory.h
 
 test_proxy_http_LDADD = \
-<<<<<<< HEAD
-=======
-	$(top_builddir)/src/tscore/libtscore.la \
-	$(top_builddir)/src/api/libtsapi.la \
->>>>>>> b6a133f27 (Fixes make check)
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/proxy/logging/liblogging.a \
 	$(top_builddir)/src/records/librecords_p.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/iocore/utils/libinkutils.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ \
 	@LIBCAP@ \
@@ -163,6 +160,7 @@ test_HttpTransact_LDADD  =  \
 	$(top_builddir)/iocore/net/libinknet.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	-lz -llzma -lcrypto -lresolv -lssl \
 	@LIBPCRE@ @HWLOC_LIBS@ @SWOC_LIBS@ @YAMLCPP_LIBS@ @LIBCAP@

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -134,14 +134,15 @@ test_NextHopStrategyFactory_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopStrategyFactory_LDADD = \
-<<<<<<< HEAD
-=======
-  $(top_builddir)/src/tscore/libtscore.la \
   $(top_builddir)/src/api/libtsapi.la \
->>>>>>> b6a133f27 (Fixes make check)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
+  $(top_builddir)/proxy/hdrs/libhdrs.a \
+  $(top_builddir)/iocore/eventsystem/libinkevent.a \
+  $(top_builddir)/src/records/librecords_p.a \
+  $(top_builddir)/src/api/libtsapi.la \
+  $(top_builddir)/proxy/logging/liblogging.a \
   $(top_builddir)/iocore/utils/libinkutils.a \
   $(top_builddir)/src/tscore/libtscore.a \
   $(top_builddir)/proxy/logging/liblogging.a \
@@ -176,11 +177,15 @@ test_NextHopRoundRobin_LDADD = \
 <<<<<<< HEAD
 =======
   $(top_builddir)/src/tscore/libtscore.la \
+<<<<<<< HEAD
   $(top_builddir)/src/api/libtsapi.la \
 >>>>>>> b6a133f27 (Fixes make check)
+=======
+>>>>>>> b2c0a316d (More Makefile fixes)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
+  $(top_builddir)/src/api/libtsapi.la \
   $(top_builddir)/proxy/logging/liblogging.a \
   $(top_builddir)/iocore/utils/libinkutils.a \
   $(top_builddir)/src/tscore/libtscore.a \
@@ -215,11 +220,15 @@ test_NextHopConsistentHash_LDADD = \
 <<<<<<< HEAD
 =======
   $(top_builddir)/src/tscore/libtscore.la \
+<<<<<<< HEAD
   $(top_builddir)/src/api/libtsapi.la \
 >>>>>>> b6a133f27 (Fixes make check)
+=======
+>>>>>>> b2c0a316d (More Makefile fixes)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
+  $(top_builddir)/src/api/libtsapi.la \
   $(top_builddir)/proxy/logging/liblogging.a \
   $(top_builddir)/iocore/utils/libinkutils.a \
   $(top_builddir)/src/tscore/libtscore.a \

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -68,6 +68,7 @@ libhttp_remap_a_SOURCES = \
 COMMON_PLUGINDSO_LDADDS = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -139,11 +139,6 @@ test_NextHopStrategyFactory_LDADD = \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
-  $(top_builddir)/proxy/hdrs/libhdrs.a \
-  $(top_builddir)/iocore/eventsystem/libinkevent.a \
-  $(top_builddir)/src/records/librecords_p.a \
-  $(top_builddir)/src/api/libtsapi.la \
-  $(top_builddir)/proxy/logging/liblogging.a \
   $(top_builddir)/iocore/utils/libinkutils.a \
   $(top_builddir)/src/tscore/libtscore.a \
   $(top_builddir)/proxy/logging/liblogging.a \
@@ -175,14 +170,6 @@ test_NextHopRoundRobin_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopRoundRobin_LDADD = \
-<<<<<<< HEAD
-=======
-  $(top_builddir)/src/tscore/libtscore.la \
-<<<<<<< HEAD
-  $(top_builddir)/src/api/libtsapi.la \
->>>>>>> b6a133f27 (Fixes make check)
-=======
->>>>>>> b2c0a316d (More Makefile fixes)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
@@ -218,14 +205,6 @@ test_NextHopConsistentHash_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopConsistentHash_LDADD = \
-<<<<<<< HEAD
-=======
-  $(top_builddir)/src/tscore/libtscore.la \
-<<<<<<< HEAD
-  $(top_builddir)/src/api/libtsapi.la \
->>>>>>> b6a133f27 (Fixes make check)
-=======
->>>>>>> b2c0a316d (More Makefile fixes)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
@@ -272,6 +251,7 @@ pkglib_LTLIBRARIES = \
 	unit-tests/plugin_missing_init.la \
 	unit-tests/plugin_missing_newinstance.la \
 	unit-tests/plugin_testing_calls.la
+
 unit_tests_plugin_v1_la_SOURCES = unit-tests/plugin_misc_cb.cc
 unit_tests_plugin_v1_la_LDFLAGS = $(DSO_LDFLAGS)
 unit_tests_plugin_v1_la_CPPFLAGS = -DPLUGINDSOVER=1 $(AM_CPPFLAGS)

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -135,10 +135,10 @@ test_NextHopStrategyFactory_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopStrategyFactory_LDADD = \
-  $(top_builddir)/src/api/libtsapi.la \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
+  $(top_builddir)/src/api/libtsapi.la \
   $(top_builddir)/iocore/utils/libinkutils.a \
   $(top_builddir)/src/tscore/libtscore.a \
   $(top_builddir)/proxy/logging/liblogging.a \

--- a/proxy/http/remap/Makefile.am
+++ b/proxy/http/remap/Makefile.am
@@ -134,6 +134,11 @@ test_NextHopStrategyFactory_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopStrategyFactory_LDADD = \
+<<<<<<< HEAD
+=======
+  $(top_builddir)/src/tscore/libtscore.la \
+  $(top_builddir)/src/api/libtsapi.la \
+>>>>>>> b6a133f27 (Fixes make check)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
@@ -168,6 +173,11 @@ test_NextHopRoundRobin_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopRoundRobin_LDADD = \
+<<<<<<< HEAD
+=======
+  $(top_builddir)/src/tscore/libtscore.la \
+  $(top_builddir)/src/api/libtsapi.la \
+>>>>>>> b6a133f27 (Fixes make check)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
@@ -202,6 +212,11 @@ test_NextHopConsistentHash_CPPFLAGS = \
 	@YAMLCPP_INCLUDES@
 
 test_NextHopConsistentHash_LDADD = \
+<<<<<<< HEAD
+=======
+  $(top_builddir)/src/tscore/libtscore.la \
+  $(top_builddir)/src/api/libtsapi.la \
+>>>>>>> b6a133f27 (Fixes make check)
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \

--- a/proxy/http/unit_tests/CMakeLists.txt
+++ b/proxy/http/unit_tests/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(test_http
     PRIVATE
         catch2::catch2
         ts::http
+        ts::tsapi
         ts::hdrs # transitive
         logging # transitive
         http_remap # transitive

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -72,6 +72,7 @@ test_libhttp2_LDADD = \
 	Http2Frame.o \
 	HPACK.o \
 	$(top_builddir)/src/records/librecords_p.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
@@ -125,11 +126,13 @@ test_Http2FrequencyCounter_SOURCES = \
 
 test_HPACK_LDADD = \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
-	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ @LIBPCRE@ @OPENSSL_LIBS@ @YAMLCPP_LIBS@ @LIBCAP@
 
 test_HPACK_SOURCES = \

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -130,8 +130,6 @@ test_HPACK_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/api/libtsapi.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ @LIBPCRE@ @OPENSSL_LIBS@ @YAMLCPP_LIBS@ @LIBCAP@
 

--- a/proxy/http2/Makefile.am
+++ b/proxy/http2/Makefile.am
@@ -125,6 +125,7 @@ test_Http2FrequencyCounter_SOURCES = \
 
 test_HPACK_LDADD = \
 	$(top_builddir)/proxy/hdrs/libhdrs.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \

--- a/proxy/http3/Makefile.am
+++ b/proxy/http3/Makefile.am
@@ -72,6 +72,7 @@ test_LDADD = \
   $(top_builddir)/iocore/net/TLSKeyLogger.o \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
+  $(top_builddir)/src/api/libtsapi.la \
   $(top_builddir)/src/tscpp/util/libtscpputil.la \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
   $(top_builddir)/src/tscore/libtscore.a \

--- a/proxy/logging/unit-tests/benchmark_LogObject.cc
+++ b/proxy/logging/unit-tests/benchmark_LogObject.cc
@@ -31,7 +31,7 @@ benchmark_LogObject_CPPFLAGS = \
        $(AM_CPPFLAGS) \
        -I$(abs_top_srcdir)/tests/include
 benchmark_LogObject_LDADD = \
-       $(top_builddir)/src/tscore/libtscore.la \
+       $(top_builddir)/src/tscore/libtscore.a \
        $(top_builddir)/src/tscpp/util/libtscpputil.la \
        $(top_builddir)/iocore/eventsystem/libinkevent.a \
        $(top_builddir)/proxy/logging/liblogging.a \

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -25,8 +25,6 @@ add_executable(test_Metrics
         test_Metrics.cc
         )
 
-target_link_libraries(tsapi PUBLIC ts::tscore)
-
 target_link_libraries(test_Metrics PRIVATE tsapi tscore)
 target_include_directories(test_Metrics PRIVATE ${CMAKE_SOURCE_DIR}/include ${CATCH_INCLUDE_DIR})
 

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,0 +1,26 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_library(tsapi SHARED Metrics.cc)
+
+add_executable(test_Metrics
+        test_Metrics.cc
+        )
+target_link_libraries(test_Metrics PRIVATE tsapi tscore)
+target_include_directories(test_Metrics PRIVATE ${CMAKE_SOURCE_DIR}/include ${CATCH_INCLUDE_DIR})
+
+add_test(NAME test_Metrics COMMAND $<TARGET_FILE:test_Metrics>)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -16,6 +16,10 @@
 #######################
 
 add_library(tsapi SHARED Metrics.cc)
+add_library(ts::tsapi ALIAS tsapi)
+
+install(TARGETS tsapi)
+
 
 add_executable(test_Metrics
         test_Metrics.cc

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -24,6 +24,9 @@ install(TARGETS tsapi)
 add_executable(test_Metrics
         test_Metrics.cc
         )
+
+target_link_libraries(tsapi PUBLIC ts::tscore)
+
 target_link_libraries(test_Metrics PRIVATE tsapi tscore)
 target_include_directories(test_Metrics PRIVATE ${CMAKE_SOURCE_DIR}/include ${CATCH_INCLUDE_DIR})
 

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -32,7 +32,7 @@ AM_CPPFLAGS += \
 libtsapi_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -version-info @TS_LIBTOOL_VERSION@ @SWOC_LDFLAGS@
 
 libtsapi_la_LIBADD = \
-    $(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscore/libtscore.la \
 	@SWOC_LIBS@
 
 
@@ -44,7 +44,9 @@ test_Metrics_SOURCES = test_Metrics.cc
 test_Metrics_CPPFLAGS = $(AM_CPPFLAGS)\
 	-I$(abs_top_srcdir)/lib/catch2
 
-test_Metrics_LDADD = libtsapi.la
+test_Metrics_LDADD = \
+	$(top_builddir)/src/tscore/libtscore.la \
+	libtsapi.la
 
 
 clang-tidy-local: $(DIST_SOURCES)

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -18,6 +18,10 @@
 
 include $(top_srcdir)/mk/tidy.mk
 
+check_PROGRAMS = test_Metrics
+
+TESTS = $(check_PROGRAMS)
+
 lib_LTLIBRARIES = libtsapi.la
 
 AM_CPPFLAGS += \
@@ -34,6 +38,14 @@ libtsapi_la_LIBADD = \
 
 libtsapi_la_SOURCES = \
 	Metrics.cc
+
+test_Metrics_SOURCES = test_Metrics.cc
+
+test_Metrics_CPPFLAGS = $(AM_CPPFLAGS)\
+	-I$(abs_top_srcdir)/lib/catch2
+
+test_Metrics_LDADD = libtsapi.la
+
 
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -21,6 +21,7 @@ include $(top_srcdir)/mk/tidy.mk
 lib_LTLIBRARIES = libtsapi.la
 
 AM_CPPFLAGS += \
+	-I$(abs_top_srcdir)/include \
 	@SWOC_INCLUDES@ \
 	$(TS_INCLUDES)
 

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -32,7 +32,7 @@ AM_CPPFLAGS += \
 libtsapi_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -version-info @TS_LIBTOOL_VERSION@ @SWOC_LDFLAGS@
 
 libtsapi_la_LIBADD = \
-	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscore/libtscore.a \
 	@SWOC_LIBS@
 
 
@@ -45,7 +45,7 @@ test_Metrics_CPPFLAGS = $(AM_CPPFLAGS)\
 	-I$(abs_top_srcdir)/lib/catch2
 
 test_Metrics_LDADD = \
-	$(top_builddir)/src/tscore/libtscore.la \
+	$(top_builddir)/src/tscore/libtscore.a \
 	libtsapi.la
 
 

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -1,3 +1,4 @@
+# libts Makefile.am
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -17,28 +18,21 @@
 
 include $(top_srcdir)/mk/tidy.mk
 
-bin_PROGRAMS =
-check_PROGRAMS =
-TESTS =
-lib_LTLIBRARIES =
-noinst_PROGRAMS =
+lib_LTLIBRARIES = libtsapi.la
 
-SUBDIRS = tscpp/api api
+AM_CPPFLAGS += \
+	@SWOC_INCLUDES@ \
+	$(TS_INCLUDES)
 
-if BUILD_WCCP
-SUBDIRS += wccp
-include traffic_wccp/Makefile.inc
-endif
+libtsapi_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -version-info @TS_LIBTOOL_VERSION@ @SWOC_LDFLAGS@
 
-include traffic_cache_tool/Makefile.inc
-include traffic_via/Makefile.inc
-include traffic_top/Makefile.inc
-include traffic_server/Makefile.inc
-include traffic_logstats/Makefile.inc
-include traffic_crashlog/Makefile.inc
-include traffic_layout/Makefile.inc
-include traffic_logcat/Makefile.inc
-include traffic_ctl/Makefile.inc
+libtsapi_la_LIBADD = \
+    $(top_builddir)/src/tscore/libtscore.la \
+	@SWOC_LIBS@
+
+
+libtsapi_la_SOURCES = \
+	Metrics.cc
 
 clang-tidy-local: $(DIST_SOURCES)
 	$(CXX_Clang_Tidy)

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -29,10 +29,9 @@ AM_CPPFLAGS += \
 	@SWOC_INCLUDES@ \
 	$(TS_INCLUDES)
 
-libtsapi_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -version-info @TS_LIBTOOL_VERSION@ @SWOC_LDFLAGS@
+libtsapi_la_LDFLAGS = @AM_LDFLAGS@ -version-info @TS_LIBTOOL_VERSION@ @SWOC_LDFLAGS@
 
 libtsapi_la_LIBADD = \
-	$(top_builddir)/src/tscore/libtscore.a \
 	@SWOC_LIBS@
 
 

--- a/src/api/Metrics.cc
+++ b/src/api/Metrics.cc
@@ -21,7 +21,6 @@
   limitations under the License.
  */
 
-#include "ts/ts.h"
 #include "api/Metrics.h"
 
 namespace ts

--- a/src/api/Metrics.cc
+++ b/src/api/Metrics.cc
@@ -1,0 +1,140 @@
+/** @file
+
+  The implementations of the Metrics API class.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "ts/ts.h"
+#include "api/Metrics.h"
+
+namespace ts
+{
+
+// This is the singleton instance of the metrics class.
+Metrics &
+Metrics::getInstance()
+{
+  static ts::Metrics _instance;
+
+  return _instance;
+}
+
+void
+Metrics::_addBlob() // The mutex must be held before calling this!
+{
+  auto blob = new Metrics::MetricStorage();
+
+  ink_assert(blob);
+  ink_assert(_cur_blob < Metrics::METRICS_MAX_BLOBS);
+
+  _blobs[++_cur_blob] = blob;
+  _cur_off            = 0;
+}
+
+Metrics::IdType
+Metrics::newMetric(std::string_view name)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto it = _lookups.find(name);
+
+  if (it != _lookups.end()) {
+    return it->second;
+  }
+
+  Metrics::IdType id                = _makeId(_cur_blob, _cur_off);
+  Metrics::MetricStorage *blob      = _blobs[_cur_blob];
+  Metrics::NameContainer &names     = std::get<0>(*blob);
+  Metrics::AtomicContainer &atomics = std::get<1>(*blob);
+
+  atomics[_cur_off].store(0);
+  names[_cur_off] = std::make_tuple(std::string(name), id);
+  _lookups.emplace(std::get<0>(names[_cur_off]), id);
+
+  if (++_cur_off >= Metrics::METRICS_MAX_SIZE) {
+    _addBlob(); // This resets _cur_off to 0 as well
+  }
+
+  return id;
+}
+
+Metrics::IdType
+Metrics::lookup(const std::string_view name) const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto it = _lookups.find(name);
+
+  if (it != _lookups.end()) {
+    return it->second;
+  }
+
+  return NOT_FOUND;
+}
+
+Metrics::AtomicType *
+Metrics::lookup(IdType id, std::string_view *name) const
+{
+  auto [blob_ix, offset]       = _splitID(id);
+  Metrics::MetricStorage *blob = _blobs[blob_ix];
+
+  // Do a sanity check on the ID, to make sure we don't index outside of the realm of possibility.
+  if (!blob || (blob_ix == _cur_blob && offset > _cur_off)) {
+    blob   = _blobs[0];
+    offset = 0;
+  }
+
+  if (name) {
+    *name = std::get<0>(std::get<0>(*blob)[offset]);
+  }
+
+  return &((std::get<1>(*blob)[offset]));
+}
+
+std::string_view
+Metrics::name(Metrics::IdType id) const
+{
+  auto [blob_ix, offset]       = _splitID(id);
+  Metrics::MetricStorage *blob = _blobs[blob_ix];
+
+  // Do a sanity check on the ID, to make sure we don't index outside of the realm of possibility.
+  if (!blob || (blob_ix == _cur_blob && offset > _cur_off)) {
+    blob   = _blobs[0];
+    offset = 0;
+  }
+
+  const std::string &result = std::get<0>(std::get<0>(*blob)[offset]);
+
+  return result;
+}
+
+// Iterator implementation
+void
+Metrics::iterator::next()
+{
+  auto [blob, offset] = _metrics._splitID(_it);
+
+  if (++offset == METRICS_MAX_SIZE) {
+    ++blob;
+    offset = 0;
+  }
+
+  _it = _makeId(blob, offset);
+}
+
+} // namespace ts

--- a/src/api/test_Metrics.cc
+++ b/src/api/test_Metrics.cc
@@ -34,7 +34,7 @@ TEST_CASE("Metrics", "[libtsapi][Metrics]")
   {
     auto [name, value] = *m.begin();
     REQUIRE(value == 0);
-    REQUIRE(name == "proxy.node.bad_id.metrics");
+    REQUIRE(name == "proxy.node.api.metrics.bad_id");
 
     REQUIRE(m.begin() != m.end());
     REQUIRE(++m.begin() == m.end());
@@ -49,27 +49,17 @@ TEST_CASE("Metrics", "[libtsapi][Metrics]")
     auto fooid = m.newMetric("foo");
 
     REQUIRE(fooid == 1);
-    REQUIRE(m.get_name(fooid) == "foo");
+    REQUIRE(m.name(fooid) == "foo");
 
-    REQUIRE(m.get(fooid) == 0);
+    REQUIRE(m[fooid].load() == 0);
     m.increment(fooid);
-    REQUIRE(m.get(fooid) == 1);
+    REQUIRE(m[fooid].load() == 1);
   }
 
   SECTION("operator[]")
   {
     m[0].store(42);
 
-    REQUIRE(m.get(0) == 42);
-  }
-
-  SECTION("dump")
-  {
-    m.recordsDump([](RecT, void *, int, const char *name, int value, RecData *) { printf("Fooo: %s: %d\n", name, value); },
-                  nullptr);
-
-    for (auto [name, metric] : m) {
-      std::cout << name << ": " << metric << "\n";
-    }
+    REQUIRE(m[0].load() == 42);
   }
 }

--- a/src/api/test_Metrics.cc
+++ b/src/api/test_Metrics.cc
@@ -1,0 +1,75 @@
+/** @file
+
+    TextView unit tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "api/Metrics.h"
+
+TEST_CASE("Metrics", "[libtsapi][Metrics]")
+{
+  ts::Metrics m;
+
+  SECTION("iterator")
+  {
+    auto [name, value] = *m.begin();
+    REQUIRE(value == 0);
+    REQUIRE(name == "proxy.node.bad_id.metrics");
+
+    REQUIRE(m.begin() != m.end());
+    REQUIRE(++m.begin() == m.end());
+
+    auto it = m.begin();
+    it++;
+    REQUIRE(it == m.end());
+  }
+
+  SECTION("New metric")
+  {
+    auto fooid = m.newMetric("foo");
+
+    REQUIRE(fooid == 1);
+    REQUIRE(m.get_name(fooid) == "foo");
+
+    REQUIRE(m.get(fooid) == 0);
+    m.increment(fooid);
+    REQUIRE(m.get(fooid) == 1);
+  }
+
+  SECTION("operator[]")
+  {
+    m[0].store(42);
+
+    REQUIRE(m.get(0) == 42);
+  }
+
+  SECTION("dump")
+  {
+    m.recordsDump([](RecT, void *, int, const char *name, int value, RecData *) { printf("Fooo: %s: %d\n", name, value); },
+                  nullptr);
+
+    for (auto [name, metric] : m) {
+      std::cout << name << ": " << metric << "\n";
+    }
+  }
+}

--- a/src/records/Makefile.am
+++ b/src/records/Makefile.am
@@ -72,6 +72,7 @@ test_librecords_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ @LIBCAP@ @YAMLCPP_LIBS@ @LIBPCRE@ @OPENSSL_LIBS@
 
 test_librecords_on_eventsystem_CPPFLAGS = $(AM_CPPFLAGS)\
@@ -86,6 +87,7 @@ test_librecords_on_eventsystem_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	@HWLOC_LIBS@ @LIBCAP@ @YAMLCPP_LIBS@ @SWOC_LIBS@ @LIBPCRE@ @OPENSSL_LIBS@
 
 clang-tidy-local: $(sort $(DIST_SOURCES))

--- a/src/records/RecCore.cc
+++ b/src/records/RecCore.cc
@@ -34,14 +34,11 @@
 #include "records/P_RecUtils.h"
 #include "tscore/I_Layout.h"
 #include "tscpp/util/ts_errata.h"
-
-// This is needed to manage the size of the librecords record. It can't be static, because it needs to be modified
-// and used (read) from several binaries / modules.
-int max_records_entries = REC_INTERNAL_RECORDS + REC_DEFAULT_API_RECORDS;
+#include "api/Metrics.h"
 
 static bool g_initialized = false;
 
-RecRecord *g_records = nullptr;
+RecRecord g_records[REC_MAX_RECORDS];
 std::unordered_map<std::string, RecRecord *> g_records_ht;
 ink_rwlock g_records_rwlock;
 int g_num_records = 0;
@@ -204,9 +201,6 @@ RecCoreInit(Diags *_diags)
   RecConfigFileInit();
 
   g_num_records = 0;
-
-  // initialize record array for our internal stats (this can be reallocated later)
-  g_records = static_cast<RecRecord *>(ats_malloc(max_records_entries * sizeof(RecRecord)));
 
   // initialize record rwlock
   ink_rwlock_init(&g_records_rwlock);
@@ -1060,6 +1054,15 @@ RecDumpRecords(RecT rec_type, RecDumpEntryCb callback, void *edata)
       rec_mutex_acquire(&(r->lock));
       callback(r->rec_type, edata, r->registered, r->name, r->data_type, &r->data);
       rec_mutex_release(&(r->lock));
+    }
+  }
+  // Also dump the new ts::Metrics if asked for
+  if (rec_type & TS_RECORDTYPE_PLUGIN) {
+    RecData datum;
+
+    for (auto &&[name, val] : ts::Metrics::getInstance()) {
+      datum.rec_int = val;
+      callback(RECT_PLUGIN, edata, true, name.data(), TS_RECORDDATATYPE_INT, &datum);
     }
   }
 }

--- a/src/records/RecCore.cc
+++ b/src/records/RecCore.cc
@@ -1057,7 +1057,7 @@ RecDumpRecords(RecT rec_type, RecDumpEntryCb callback, void *edata)
     }
   }
   // Also dump the new ts::Metrics if asked for
-  if (rec_type & TS_RECORDTYPE_PLUGIN) {
+  if (rec_type & RECT_PLUGIN) {
     RecData datum;
 
     for (auto &&[name, val] : ts::Metrics::getInstance()) {

--- a/src/records/RecUtils.cc
+++ b/src/records/RecUtils.cc
@@ -50,8 +50,8 @@ RecRecordFree(RecRecord *r)
 RecRecord *
 RecAlloc(RecT rec_type, const char *name, RecDataT data_type)
 {
-  if (g_num_records >= max_records_entries) {
-    Warning("too many stats/configs, please increase max_records_entries using the --maxRecords command line option");
+  if (g_num_records >= REC_MAX_RECORDS) {
+    Warning("too many stats/configs, please report a bug to dev@trafficserver.apache.org");
     return nullptr;
   }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -46,7 +46,9 @@ link_libraries(
         inkcache
         fastlz
         aio
+        records
         tscore
+        tsapi
         tscpputil
         proxy
         inknet

--- a/src/traffic_crashlog/CMakeLists.txt
+++ b/src/traffic_crashlog/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(traffic_crashlog
         ts::inkevent
         ts::records
         ts::tscore
+        ts::tsapi
 )
 
 install(TARGETS traffic_crashlog)

--- a/src/traffic_crashlog/Makefile.inc
+++ b/src/traffic_crashlog/Makefile.inc
@@ -41,4 +41,5 @@ traffic_crashlog_traffic_crashlog_LDADD = \
 	$(top_builddir)/iocore/net/libinknet.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/api/libtsapi.la \
 	@HWLOC_LIBS@ @SWOC_LIBS@ @YAMLCPP_LIBS@ @LIBPCRE@ @LIBCAP@

--- a/src/traffic_layout/CMakeLists.txt
+++ b/src/traffic_layout/CMakeLists.txt
@@ -28,6 +28,10 @@ target_link_libraries(traffic_layout
         ts::records
         OpenSSL::Crypto
         yaml-cpp::yaml-cpp
+        ts::tscore
+        ts::tsapi
+        PCRE::PCRE
+        ${OPENSSL_LIBRARY}
 )
 
 if(TS_USE_HWLOC)

--- a/src/traffic_layout/Makefile.inc
+++ b/src/traffic_layout/Makefile.inc
@@ -45,4 +45,5 @@ traffic_layout_traffic_layout_LDADD = \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/api/libtsapi.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ @YAMLCPP_LIBS@ @LIBLZMA@ @LIBPCRE@ @LIBCAP@

--- a/src/traffic_logcat/Makefile.inc
+++ b/src/traffic_logcat/Makefile.inc
@@ -46,6 +46,10 @@ traffic_logcat_traffic_logcat_LDADD = \
 	$(top_builddir)/iocore/utils/libinkutils.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+    $(top_builddir)/mgmt/utils/libutils_p.la \
+    $(top_builddir)/src/api/libtsapi.la
+
+traffic_logcat_traffic_logcat_LDADD += \
 	@SWOC_LIBS@ @HWLOC_LIBS@ \
 	@YAMLCPP_LIBS@ @LIBPCRE@ @OPENSSL_LIBS@ @LIBCAP@ \
 	@LIBPROFILER@ -lm

--- a/src/traffic_logcat/Makefile.inc
+++ b/src/traffic_logcat/Makefile.inc
@@ -46,10 +46,7 @@ traffic_logcat_traffic_logcat_LDADD = \
 	$(top_builddir)/iocore/utils/libinkutils.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-    $(top_builddir)/mgmt/utils/libutils_p.la \
-    $(top_builddir)/src/api/libtsapi.la
-
-traffic_logcat_traffic_logcat_LDADD += \
+	$(top_builddir)/src/api/libtsapi.la \
 	@SWOC_LIBS@ @HWLOC_LIBS@ \
 	@YAMLCPP_LIBS@ @LIBPCRE@ @OPENSSL_LIBS@ @LIBCAP@ \
 	@LIBPROFILER@ -lm

--- a/src/traffic_logstats/Makefile.inc
+++ b/src/traffic_logstats/Makefile.inc
@@ -58,3 +58,11 @@ traffic_logstats_traffic_logstats_LDADD = \
 	@YAMLCPP_LIBS@ \
 	@LIBCAP@ \
 	@LIBPROFILER@ -lm
+    $(top_builddir)/mgmt/utils/libutils_p.la \
+    $(top_builddir)/src/api/libtsapi.la
+
+traffic_logstats_traffic_logstats_LDADD += \
+  @SWOC_LIBS@ \
+  @HWLOC_LIBS@ \
+  @YAMLCPP_LIBS@ \
+  @LIBPROFILER@ -lm

--- a/src/traffic_logstats/Makefile.inc
+++ b/src/traffic_logstats/Makefile.inc
@@ -50,19 +50,12 @@ traffic_logstats_traffic_logstats_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/iocore/utils/libinkutils.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	@OPENSSL_LIBS@ \
 	@SWOC_LIBS@ \
 	@HWLOC_LIBS@ \
-	@OPENSSL_LIBS@ \
+	@LIBCAP@ \
 	@LIBPCRE@ \
 	@YAMLCPP_LIBS@ \
-	@LIBCAP@ \
 	@LIBPROFILER@ -lm
-    $(top_builddir)/mgmt/utils/libutils_p.la \
-    $(top_builddir)/src/api/libtsapi.la
-
-traffic_logstats_traffic_logstats_LDADD += \
-  @SWOC_LIBS@ \
-  @HWLOC_LIBS@ \
-  @YAMLCPP_LIBS@ \
-  @LIBPROFILER@ -lm

--- a/src/traffic_server/CMakeLists.txt
+++ b/src/traffic_server/CMakeLists.txt
@@ -35,6 +35,7 @@ target_include_directories(traffic_server PRIVATE
 target_link_libraries(traffic_server
     PRIVATE
         ts::tscore
+        ts::tsapi
         ts::http
         ts::http_remap
         ts::http2

--- a/src/traffic_server/Makefile.inc
+++ b/src/traffic_server/Makefile.inc
@@ -78,8 +78,6 @@ traffic_server_traffic_server_LDADD = \
 	$(top_builddir)/iocore/cache/libinkcache.a \
 	$(top_builddir)/lib/fastlz/libfastlz.a \
 	$(top_builddir)/iocore/aio/libinkaio.a \
-	$(top_builddir)/src/tscore/libtscore.a \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/proxy/libproxy.a \
 	$(top_builddir)/iocore/net/libinknet.a \

--- a/src/traffic_server/Makefile.inc
+++ b/src/traffic_server/Makefile.inc
@@ -78,6 +78,9 @@ traffic_server_traffic_server_LDADD = \
 	$(top_builddir)/iocore/cache/libinkcache.a \
 	$(top_builddir)/lib/fastlz/libfastlz.a \
 	$(top_builddir)/iocore/aio/libinkaio.a \
+	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/proxy/libproxy.a \
 	$(top_builddir)/iocore/net/libinknet.a \
 	$(top_builddir)/src/records/librecords_p.a \

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -207,8 +207,6 @@ static ArgumentDescription argument_descriptions[] = {
   {"disable_freelist",  'f', "Disable the freelist memory allocator",                                                               "T",     &cmd_disable_freelist,           "PROXY_DPRINTF_LEVEL",     nullptr},
   {"disable_pfreelist", 'F', "Disable the freelist memory allocator in ProxyAllocator",                                             "T",     &cmd_disable_pfreelist,
    "PROXY_DPRINTF_LEVEL",                                                                                                                                                                                nullptr},
-  {"maxRecords",        'm', "Max number of librecords metrics and configurations (default & minimum: 1600)",                       "I",     &max_records_entries,
-   "PROXY_MAX_RECORDS",                                                                                                                                                                                  nullptr},
 
 #if TS_HAS_TESTS
   {"regression",        'R', "Regression Level (quick:1..long:3)",                                                                  "I",     &regression_level,               "PROXY_REGRESSION",        nullptr},

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -34,6 +34,7 @@ TESTS = $(check_PROGRAMS)
 noinst_LIBRARIES = libtscore.a
 
 AM_CPPFLAGS += \
+	-fPIC -DPIC \
 	@SWOC_INCLUDES@ \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/lib \

--- a/src/tscore/Makefile.am
+++ b/src/tscore/Makefile.am
@@ -34,7 +34,6 @@ TESTS = $(check_PROGRAMS)
 noinst_LIBRARIES = libtscore.a
 
 AM_CPPFLAGS += \
-	-fPIC -DPIC \
 	@SWOC_INCLUDES@ \
 	-I$(abs_top_srcdir)/include \
 	-I$(abs_top_srcdir)/lib \

--- a/tools/benchmark/Makefile.am
+++ b/tools/benchmark/Makefile.am
@@ -49,6 +49,7 @@ benchmark_LD_ADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/records/librecords_p.a \
 	$(top_builddir)/src/tscore/libtscore.a \
+	$(top_builddir)/src/api/libtsapi.la \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
 	@HWLOC_LIBS@ \
     @LIBPCRE@ \


### PR DESCRIPTION
The new API metrics are backwards compatible with previous APIs, since the old API wraps these new APIs. New plugins / code could chose to use the Metrics.h API directly.

Work to be finished here includes

   1. Decide what goes into include/api ? Do we have one new include file to #include all the include/api/*.h files?

   2. What should be moved to src/api and include/api.

Lost in this merge is all the work from Chris McFarlen. Thanks!

Co-Author: Chris McFarlen <chris@mcfarlen.us>