### PR TITLE
Do not set @SECLEVEL with boringssl

### DIFF
--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -46,10 +46,14 @@ ts.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
 )
 
+cipher_suite = 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2'
+if Condition.HasOpenSSLVersion("3.0.0"):
+    cipher_suite += ":@SECLEVEL=0"
+
 ts.Disk.records_config.update({
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2:@SECLEVEL=0',
+    'proxy.config.ssl.server.cipher_suite': cipher_suite,
     'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.url_remap.pristine_host_hdr': 1,
     'proxy.config.ssl.TLSv1': 0,


### PR DESCRIPTION
An AuTest filed with boringssl. It looks like boringssl doesn't like the change for the openssl 3.0 (#9753).

```
file /tmp/_sandbox/tls_client_versions/ts/log/diags.log : Diags log file diags.log should not contain errors - Failed
             Reason: Contents of /tmp/_sandbox/tls_client_versions/ts/log/diags.log contains expression: "ERROR:"
                Details:
                  [Jul  6 02:15:55.834] traffic_server ERROR: SSL::140521672264768:error:1000009e:SSL routines:OPENSSL_internal:INVALID_COMMAND:/opt/boringssl/ssl/ssl_cipher.cc:1108 : 21
                  [Jul  6 02:15:55.834] traffic_server ERROR: invalid cipher suite in records.config : 22
                  [Jul  6 02:15:55.834] traffic_server ERROR: SSL::140521672264768:error:1000009e:SSL routines:OPENSSL_internal:INVALID_COMMAND:/opt/boringssl/ssl/ssl_cipher.cc:1108 : 23
                  [Jul  6 02:15:55.834] traffic_server ERROR: invalid cipher suite in records.config : 24
                  [Jul  6 02:15:55.865] [ET_NET 8] ERROR: SSL::140521545656064:error:100000b9:SSL routines:OPENSSL_internal:NULL_SSL_CTX:/opt/boringssl/ssl/ssl_lib.cc:633: peer address is 127.0.0.1 : 45
                  [Jul  6 02:15:55.865] [ET_NET 8] ERROR: failed to create SSL server session : 46
                  [Jul  6 02:15:55.978] [ET_NET 9] ERROR: SSL::140521544603392:error:100000b9:SSL routines:OPENSSL_internal:NULL_SSL_CTX:/opt/boringssl/ssl/ssl_lib.cc:633: peer address is 127.0.0.1 : 47
                  [Jul  6 02:15:55.978] [ET_NET 9] ERROR: failed to create SSL server session : 48
```