### PR TITLE
Fix CMake build to install traffic_ctl target

### DIFF
--- a/src/traffic_ctl/CMakeLists.txt
+++ b/src/traffic_ctl/CMakeLists.txt
@@ -35,4 +35,4 @@ target_link_libraries(traffic_ctl
         libswoc
         )
 
-install(TARGETS traffic_server)
+install(TARGETS traffic_ctl)


### PR DESCRIPTION
The CMakeLists in src/traffic_ctl was erroneously installing the traffic_server target instead of the traffic_ctl target.