### PR TITLE
Give a chance to send a response before receiving next request on H2

### DIFF
--- a/proxy/http2/Http2CommonSession.cc
+++ b/proxy/http2/Http2CommonSession.cc
@@ -406,8 +406,18 @@ Http2CommonSession::do_process_frame_read(int event, VIO *vio, bool inside_frame
 bool
 Http2CommonSession::_should_do_something_else()
 {
+  if (this->_interrupt_reading_frames) {
+    this->_interrupt_reading_frames = false;
+    return true;
+  }
   // Do something else every 128 incoming frames if connection state isn't closed
   return (this->_n_frame_read & 0x7F) == 0 && !connection_state.is_state_closed();
+}
+
+void
+Http2CommonSession::interrupt_reading_frames()
+{
+  this->_interrupt_reading_frames = true;
 }
 
 int64_t

--- a/proxy/http2/Http2CommonSession.h
+++ b/proxy/http2/Http2CommonSession.h
@@ -114,6 +114,8 @@ public:
 
   virtual void set_no_activity_timeout() = 0;
 
+  void interrupt_reading_frames();
+
   ///////////////////
   // Variables
   Http2ConnectionState connection_state;
@@ -166,6 +168,9 @@ protected:
 
   int64_t read_from_early_data   = 0;
   bool cur_frame_from_early_data = false;
+
+private:
+  bool _interrupt_reading_frames = false;
 };
 
 ///////////////////////////////////////////////

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -487,6 +487,8 @@ Http2ConnectionState::rcv_headers_frame(const Http2Frame &frame)
         stream->send_request(*this);
       }
     }
+    // Give a chance to send response before reading next frame.
+    this->session->interrupt_reading_frames();
   } else {
     // NOTE: Expect CONTINUATION Frame. Do NOT change state of stream or decode
     // Header Blocks.
@@ -1047,6 +1049,8 @@ Http2ConnectionState::rcv_continuation_frame(const Http2Frame &frame)
     stream->new_transaction(frame.is_from_early_data());
     // Send request header to SM
     stream->send_request(*this);
+    // Give a chance to send response before reading next frame.
+    this->session->interrupt_reading_frames();
   } else {
     // NOTE: Expect another CONTINUATION Frame. Do nothing.
     Http2StreamDebug(this->session, stream_id, "No END_HEADERS flag, expecting CONTINUATION frame");

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
@@ -52,3 +52,21 @@ sessions:
         encoding: plain
         data: server_test
         verify: {as: equal}
+
+  # Unrelated request just to keep the connection open
+  - client-request:
+      delay: 1s
+      frames:
+      - HEADERS:
+          headers:
+            fields:
+            - [:method, GET]
+            - [:scheme, https]
+            - [:authority, example.data.com]
+            - [:path, /a/path]
+            - [uuid, 2]
+
+    server-response:
+      headers:
+        fields:
+        - [:status, 200]

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
@@ -9,6 +9,7 @@ sessions:
   - name: tcp
   - name: ip
     version: 4
+  keep-connection-open: 2s
   transactions:
   - client-request:
       frames:
@@ -52,21 +53,3 @@ sessions:
         encoding: plain
         data: server_test
         verify: {as: equal}
-
-  # Unrelated request just to keep the connection open
-  - client-request:
-      delay: 1s
-      frames:
-      - HEADERS:
-          headers:
-            fields:
-            - [:method, GET]
-            - [:scheme, https]
-            - [:authority, example.data.com]
-            - [:path, /a/path]
-            - [uuid, 2]
-
-    server-response:
-      headers:
-        fields:
-        - [:status, 200]

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
@@ -52,3 +52,21 @@ sessions:
         encoding: plain
         data: server_test
         verify: {as: equal}
+
+  # Unrelated request just to keep the connection open
+  - client-request:
+      delay: 1s
+      frames:
+      - HEADERS:
+          headers:
+            fields:
+            - [:method, GET]
+            - [:scheme, https]
+            - [:authority, example.data.com]
+            - [:path, /a/path]
+            - [uuid, 2]
+
+    server-response:
+      headers:
+        fields:
+        - [:status, 200]

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
@@ -9,6 +9,7 @@ sessions:
   - name: tcp
   - name: ip
     version: 4
+  keep-connection-open: 2s
   transactions:
   - client-request:
       frames:
@@ -52,21 +53,3 @@ sessions:
         encoding: plain
         data: server_test
         verify: {as: equal}
-
-  # Unrelated request just to keep the connection open
-  - client-request:
-      delay: 1s
-      frames:
-      - HEADERS:
-          headers:
-            fields:
-            - [:method, GET]
-            - [:scheme, https]
-            - [:authority, example.data.com]
-            - [:path, /a/path]
-            - [uuid, 2]
-
-    server-response:
-      headers:
-        fields:
-        - [:status, 200]


### PR DESCRIPTION
ATS keeps reading H2 frames until either it reads all data in the receive buffer or it processes 128 H2 frames. This is not great if a client sends many requests at once. The first request will not be responded until ATS finishes/stops reading incoming frames, and that leads to a long TTFB. This also means ATS does not fully utilize a connection. ATS should be able to read following frames while response data is being transferred by Kernel/NIC.

This PR extends `Http2CommonSession::_should_do_something_else`, so ATS can stop reading frames regardless of the number of frames it read. I added `Http2CommonSession::interrupt_reading_frames()`, and by calling it after `Http2Stream::send_request`, ATS can get a chance to send response data before reading following H2 frames.


This benchmark was done on my laptop so rps and tps fluctuate and unreliable, but I can consistently see lower TTFB.

`h2load -n 3000 -m 100 -c 10 "https://localhost:8443/256k"`

Before
```
finished in 739.71ms, 4055.66 req/s, 1014.56MB/s
requests: 3000 total, 3000 started, 3000 done, 3000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 3000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 750.47MB (786929450) total, 37.20KB (38090) headers (space savings 96.20%), 750.00MB (786432000) data
                     min         max         mean         sd        +/- sd
time for request:    34.20ms    364.11ms    192.23ms     75.67ms    72.47%
time for connect:    11.43ms     67.43ms     40.86ms     18.82ms    60.00%
time to 1st byte:   103.09ms    284.44ms    188.50ms     58.36ms    60.00%
req/s           :     405.98      458.36      432.78       16.96    60.00%
```

After
```
finished in 736.39ms, 4073.92 req/s, 1019.12MB/s
requests: 3000 total, 3000 started, 3000 done, 3000 succeeded, 0 failed, 0 errored, 0 timeout
status codes: 3000 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 750.47MB (786929450) total, 37.20KB (38090) headers (space savings 96.20%), 750.00MB (786432000) data
                     min         max         mean         sd        +/- sd
time for request:    14.43ms    371.40ms    200.59ms     66.48ms    75.73%
time for connect:     9.19ms     66.73ms     39.34ms     19.22ms    60.00%
time to 1st byte:    67.39ms    103.57ms     75.14ms     14.92ms    80.00%
req/s           :     407.46      517.14      458.63       36.60    60.00%
```

And this is from production. A service that makes a lot of concurrent requests. Download time per host within a same pop, and the first row is the host with this change.
<img width="865" alt="image" src="https://github.com/apache/trafficserver/assets/153144/fdd99784-16bb-4e71-99b6-02c5fb45f598">
