### PR TITLE
libswoc: Update to 1.5.2 - bring in TextView teaks for PR 9980.

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.5.1")
+set(LIBSWOC_VERSION "1.5.2")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.

--- a/lib/swoc/Makefile.am
+++ b/lib/swoc/Makefile.am
@@ -22,7 +22,7 @@ library_includedir=$(includedir)/swoc
 
 AM_CPPFLAGS += @SWOC_INCLUDES@
 
-libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.5.1
+libtsswoc_la_LDFLAGS = @AM_LDFLAGS@ -no-undefined -release 1.5.2
 libtsswoc_la_SOURCES = \
 	src/ArenaWriter.cc  src/bw_format.cc  src/bw_ip_format.cc  src/Errata.cc  src/MemArena.cc  src/RBTree.cc  src/swoc_file.cc  src/swoc_ip.cc  src/TextView.cc src/string_view_util.cc
 

--- a/lib/swoc/include/swoc/MemSpan.h
+++ b/lib/swoc/include/swoc/MemSpan.h
@@ -1500,6 +1500,12 @@ MemSpan<void>::rebind() const -> self_type {
   return *this;
 }
 
+template <>
+inline auto
+MemSpan<void>::rebind() const -> MemSpan<void const> {
+  return { _ptr, _size };
+}
+
 template <typename U> U *
 MemSpan<void>::as_ptr() const {
   if (_size != sizeof(U)) {

--- a/lib/swoc/include/swoc/TextView.h
+++ b/lib/swoc/include/swoc/TextView.h
@@ -24,6 +24,14 @@
 #include "swoc/swoc_version.h"
 #include "swoc/string_view_util.h"
 
+// For no apparent reason, g++ 11 complains about array bound violations with either suffix_at or
+// assign, the error message is too vague for me to be sure - it doesn't even provide the location of
+// the method invocation. I've been using g++ 12 for development and I don't see that error.
+#if __GNUC__ == 11
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 namespace swoc { inline namespace SWOC_VERSION_NS {
 
 class TextView;
@@ -72,6 +80,33 @@ public:
    * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
    */
   constexpr TextView(char const *ptr, size_t n) noexcept;
+
+  /** Construct from pointer and size.
+   *
+   * @param ptr Pointer to first character.
+   * @param n Number of characters.
+   */
+  constexpr TextView(char const *ptr, unsigned n) noexcept;
+
+  /** Construct from pointer and size.
+   *
+   * @param ptr Pointer to first character.
+   * @param n Number of characters.
+   *
+   * If @a n is negative then @c ptr is presumed to be a C string and checked for length. If @c ptr
+   * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
+   */
+  constexpr TextView(char const *ptr, ssize_t n) noexcept;
+
+  /** Construct from pointer and size.
+   *
+   * @param ptr Pointer to first character.
+   * @param n Number of characters.
+   *
+   * If @a n is negative then @c ptr is presumed to be a C string and checked for length. If @c ptr
+   * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
+   */
+  constexpr TextView(char const *ptr, int n) noexcept;
 
   /** Construct from a half open range [first, last).
    *
@@ -188,7 +223,14 @@ public:
    */
   self_type &assign(char const * & c_str);
 
-  /// Explicitly set the start @a ptr and size @a n of the view.
+  /** Assign from a pointer and size.
+   *
+   * @param ptr Pointer to first character of the view.
+   * @param n Length of the view.
+   * @return @a this
+   *
+   * if @a n is @a npos then @c strlen is used determine the size of the view.
+   */
   self_type &assign(char const *ptr, size_t n);
 
   /** Assign the half open view [ @a b , @a e ) to @a this
@@ -549,6 +591,9 @@ public:
    *
    * The returned prefix is removed from @a this. That prefix may be empty if the first character
    * does not satisfy @a pred.
+   *
+   * @note This is very similar to @c ltrim_if but returns the removed text instead of the modified
+   * view.
    */
   template <typename F> self_type clip_prefix_of(F const &pred);
 
@@ -731,6 +776,9 @@ public:
    *
    * The returned suffix is removed from @a this. That suffix may be empty if the last character
    * does not satisfy @a pred.
+   *
+   * @note This is very similar to @c rtrim_if but returns the removed text instead of the modified
+   * view.
    */
   template <typename F> self_type clip_suffix_of(F const &pred);
 
@@ -863,6 +911,15 @@ public:
     }
   };
 
+  /// Support for containers that need case insensitive comparisons between views.
+  struct CaselessEqual {
+    /// @return @c true if the view contants are equal when compared without regard to case.
+    bool
+    operator()(self_type const& lhs, self_type const& rhs) const noexcept {
+      return lhs.size() == rhs.size() && 0 == strcasecmp(lhs, rhs);
+    }
+  };
+
   /** A pointer to the first byte.
    *
    * @return Address of the first byte of the view.
@@ -950,7 +1007,7 @@ uintmax_t svtou(TextView src, TextView *parsed = nullptr, int base = 0);
  */
 template <int RADIX>
 uintmax_t
-svto_radix(swoc::TextView &src) {
+svto_radix(TextView &src) {
   static_assert(0 < RADIX && RADIX <= 36, "Radix must be in the range 1..36");
   static constexpr auto MAX = std::numeric_limits<uintmax_t>::max();
   static constexpr auto OVERFLOW_LIMIT = MAX / RADIX;
@@ -972,7 +1029,7 @@ svto_radix(swoc::TextView &src) {
 /// @see svto_radix(swoc::TextView &src)
 template <int N>
 uintmax_t
-svto_radix(swoc::TextView &&src) {
+svto_radix(TextView &&src) {
   return svto_radix<N>(src);
 }
 
@@ -989,7 +1046,7 @@ svto_radix(swoc::TextView &&src) {
  * the closest epsilon. It's more than sufficient for use in configurations, but possibly
  * not for high precision work.
  */
-double svtod(swoc::TextView text, swoc::TextView *parsed = nullptr);
+double svtod(TextView text, TextView *parsed = nullptr);
 // ----------------------------------------------------------
 // Inline implementations.
 // Note: Why, you may ask, do I use @c TextView::self_type for return type instead of the
@@ -999,8 +1056,15 @@ double svtod(swoc::TextView text, swoc::TextView *parsed = nullptr);
 // === TextView Implementation ===
 /// @cond TextView_INTERNAL
 // Doxygen doesn't match these up well due to various type and template issues.
+// @internal If there is more than one overload for numeric types, it's easy to get ambiguity. The only
+// fix, unfortunately, is lots of overloads to cover the ambiguous cases.
 inline constexpr TextView::TextView(const char *ptr, size_t n) noexcept
   : super_type(ptr, n == npos ? (ptr ? ::strlen(ptr) : 0) : n) {}
+inline constexpr TextView::TextView(const char *ptr, unsigned n) noexcept : super_type(ptr, size_t(n)) {}
+inline constexpr TextView::TextView(const char *ptr, ssize_t n) noexcept
+  : super_type(ptr, n < 0 ? (ptr ? ::strlen(ptr) : 0) : size_t(n)) {}
+inline constexpr TextView::TextView(const char *ptr, int n) noexcept
+  : super_type(ptr, n < 0 ? (ptr ? ::strlen(ptr) : 0) : size_t(n)) {}
 inline constexpr TextView::TextView(std::nullptr_t) noexcept : super_type(nullptr, 0) {}
 inline TextView::TextView(std::string const &str) noexcept : super_type(str) {}
 inline constexpr TextView::TextView(super_type const &that) noexcept : super_type(that) {}
@@ -1101,7 +1165,7 @@ TextView::assign(const std::string &s) -> self_type & {
 
 inline TextView &
 TextView::assign(char const *ptr, size_t n) {
-  *this = super_type(ptr, n);
+  *this = super_type(ptr, n == npos ? ( ptr ? ::strlen(ptr) : 0) : n);
   return *this;
 }
 
@@ -1989,3 +2053,7 @@ template <> struct hash<swoc::TextView> {
 /// @endcond
 
 } // namespace std
+
+#if __GNUC__ == 11
+#  pragma GCC diagnostic pop
+#endif

--- a/lib/swoc/include/swoc/bwf_base.h
+++ b/lib/swoc/include/swoc/bwf_base.h
@@ -969,7 +969,24 @@ BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr);
  * The format is by default "N:ptr" where N is the size and ptr is a hex formatter pointer. If the
  * format is "x" or "X" the span content is dumped as contiguous hex.
  */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void const> const &span);
+
+/** Format a generic (void) memory span.
+ *
+ * @param w Output
+ * @param spec Format specifier.
+ * @param span Span to format.
+ * @return @a w
+ *
+ * The format is by default "N:ptr" where N is the size and ptr is a hex formatter pointer. If the
+ * format is "x" or "X" the span content is dumped as contiguous hex.
+ *
+ * @internal Overload to avoid unfortunate ambiguities when constructing the span from other spans.
+ * in particular @c MemSpan<char> vs. @c TextView.
+ */
+inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span) {
+  return bwformat(w, spec, span.rebind<void const>());
+}
 
 template <typename T>
 BufferWriter &
@@ -980,7 +997,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<T> const &span) {
   if (spec._prec <= 0) {
     s._prec = sizeof(T);
   }
-  return bwformat(w, s, span.template rebind<void>());
+  return bwformat(w, s, span.template rebind<void const>());
 }
 
 template <size_t N>
@@ -1280,4 +1297,16 @@ As_Hex(T const &t) {
  */
 BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::HexDump const &hex);
 
+/** Format a buffer writer.
+ *
+ * @param w Output buffer,
+ * @param spec Format specifier.
+ * @param ww Input buffer
+ * @return @a w
+ *
+ * This treats @a ww as a view and prints it as text.
+ */
+inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, BufferWriter const& ww) {
+  return bwformat(w, spec, TextView(ww));
+}
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_1
+#define SWOC_VERSION_NS _1_5_2
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 1;
+static constexpr unsigned POINT_VERSION = 2;
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/src/bw_format.cc
+++ b/lib/swoc/src/bw_format.cc
@@ -709,11 +709,11 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::HexDump const &hex) {
 }
 
 BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span) {
+bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void const> const &span) {
   if ('x' == spec._type || 'X' == spec._type) {
     const char *digits =  ('X' == spec._type) ? bwf::UPPER_DIGITS : bwf::LOWER_DIGITS;
     size_t block       = spec._prec > 0 ? spec._prec : span.size();
-    TextView view{span.rebind<char>()};
+    TextView view{span.rebind<char const>()};
     bool space_p = false;
     while (view) {
       if (space_p)


### PR DESCRIPTION
While working on #9980 a few tweaks to `TextView` were made to make the update easier. This imports those changes.