### PR TITLE
cmake: build the traffic_dump plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ execute_process(COMMAND uname -n OUTPUT_VARIABLE BUILD_MACHINE OUTPUT_STRIP_TRAI
 
 # Options
 option(BUILD_REGRESSION_TESTING "Build regression tests (default ON)" ON)
+option(BUILD_EXPERIMENTAL_PLUGINS "Build the experimental plugins (default OFF)")
 set(DEFAULT_STACK_SIZE 1048576 CACHE STRING "Default stack size (default 1048576)")
 option(ENABLE_FAST_SDK "Use fast SDK APIs (default OFF)")
 option(ENABLE_JEMALLOC "Use jemalloc (default OFF)")

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -59,6 +59,10 @@ if(ENABLE_LUAJIT)
     add_subdirectory(lua)
 endif()
 
+if(BUILD_EXPERIMENTAL_PLUGINS)
+    add_subdirectory(experimental)
+endif()
+
 if(HOST_OS STREQUAL "linux")
     add_subdirectory(healthchecks)
 endif()

--- a/plugins/experimental/CMakeLists.txt
+++ b/plugins/experimental/CMakeLists.txt
@@ -1,0 +1,18 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_subdirectory(traffic_dump)

--- a/plugins/experimental/traffic_dump/CMakeLists.txt
+++ b/plugins/experimental/traffic_dump/CMakeLists.txt
@@ -1,0 +1,37 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+project(traffic_dump)
+
+add_atsplugin(traffic_dump
+    json_utils.cc
+    session_data.cc
+    traffic_dump.cc
+    transaction_data.cc
+)
+
+target_include_directories(traffic_dump PRIVATE "${PROJECT_SOURCE_DIR}/include")
+
+target_link_libraries(traffic_dump
+    PRIVATE
+        libswoc
+        "${OPENSSL_SSL_LIBRARY}"
+)
+
+if(BUILD_TESTING)
+    add_subdirectory(unit_tests)
+endif()

--- a/plugins/experimental/traffic_dump/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/traffic_dump/unit_tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_executable(test_traffic_dump
+    unit_test_main.cc
+    test_json_utils.cc
+    test_sensitive_fields.cc
+    "${PROJECT_SOURCE_DIR}/json_utils.cc"
+)
+
+target_include_directories(test_traffic_dump PRIVATE "${PROJECT_SOURCE_DIR}")
+target_link_libraries(test_traffic_dump PRIVATE catch2::catch2)
+
+add_test(NAME test_traffic_dump COMMAND test_traffic_dump)


### PR DESCRIPTION
This adds the building of the Traffic Dump plugin to our cmake configuration. This is the first experiemental plugin that is being added to our cmake configuration.