### PR TITLE
cmake: add a format custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,7 +399,7 @@ add_clang_format_target(tests)
 
 add_custom_target(clang-format
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMENT "formatting all files"
+        COMMENT "formatting all C++ files"
         DEPENDS ${CLANG_FORMAT_TARGETS}
         VERBATIM
         )
@@ -408,6 +408,12 @@ add_custom_target(autopep8 ${CMAKE_SOURCE_DIR}/tools/autopep8.sh ${CMAKE_SOURCE_
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "formatting python files"
         VERBATIM
+        )
+
+# Add a format target that depends upon both clang-format and autopep8.
+add_custom_target(format
+        DEPENDS clang-format autopep8
+        COMMENT "formatting all files"
         )
 
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,9 +20,14 @@
 # yamlcpp shadows a bunch of variables but we don't want to hear bout it
 add_compile_options(-Wno-shadow)
 set(BUILD_SHARED_LIBS 1)
+
+# Turning CLANG_FORMAT off causes yamlcpp to not add its format target which
+# otherwise conflicts with our format target.
+set(YAML_CPP_CLANG_FORMAT_EXE OFF)
 set(YAML_CPP_INSTALL ON)
 add_subdirectory(yamlcpp)
 set(YAML_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/lib/yamlcpp/include PARENT_SCOPE)
+
 add_subdirectory(fastlz)
 add_subdirectory(swoc)
 set(SWOC_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/lib/swoc/include PARENT_SCOPE)


### PR DESCRIPTION
This adds a top-level format custom target that runs both clang-format and autopep8.