### PR TITLE
cmake: add some experimental plugins

### DIFF
--- a/plugins/experimental/access_control/CMakeLists.txt
+++ b/plugins/experimental/access_control/CMakeLists.txt
@@ -15,5 +15,25 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(traffic_dump)
+project(access_control)
+
+add_atsplugin(access_control
+    access_control.cc
+    common.cc
+    config.cc
+    headers.cc
+    pattern.cc
+    plugin.cc
+    utils.cc
+)
+
+target_link_libraries(access_control
+    PRIVATE
+        ${PCRE_LIBRARY}
+        OpenSSL::SSL
+        OpenSSL::Crypto
+)
+
+if(BUILD_TESTING)
+    add_subdirectory(unit_tests)
+endif()

--- a/plugins/experimental/access_control/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/access_control/unit_tests/CMakeLists.txt
@@ -15,5 +15,26 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(traffic_dump)
+add_executable(test_access_control
+    test_access_control.cc
+    test_utils.cc
+    ${PROJECT_SOURCE_DIR}/access_control.cc
+    ${PROJECT_SOURCE_DIR}/common.cc
+    ${PROJECT_SOURCE_DIR}/utils.cc
+)
+
+target_include_directories(test_access_control
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(test_access_control
+    PRIVATE
+        ts::tscore
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        catch2::catch2
+)
+target_compile_definitions(test_access_control PRIVATE ACCESS_CONTROL_UNIT_TEST)
+
+add_test(NAME test_access_control COMMAND test_access_control)

--- a/plugins/experimental/access_control/utils.cc
+++ b/plugins/experimental/access_control/utils.cc
@@ -30,7 +30,7 @@
 #include "common.h"
 #include "utils.h"
 #include "tscore/ink_base64.h"
-#include "ink_autoconf.h"
+#include "tscore/ink_config.h"
 
 /* ******* Encoding/Decoding functions ******* */
 

--- a/plugins/experimental/cache_fill/CMakeLists.txt
+++ b/plugins/experimental/cache_fill/CMakeLists.txt
@@ -15,6 +15,4 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(traffic_dump)
+add_atsplugin(cache_fill background_fetch.cc cache_fill.cc)

--- a/plugins/experimental/cert_reporting_tool/CMakeLists.txt
+++ b/plugins/experimental/cert_reporting_tool/CMakeLists.txt
@@ -15,7 +15,11 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(traffic_dump)
+project(cert_reporting_tool)
+
+add_atsplugin(cert_reporting_tool cert_reporting_tool.cc)
+
+target_link_libraries(cert_reporting_tool
+    PRIVATE
+        OpenSSL::SSL
+)

--- a/plugins/experimental/collapsed_forwarding/CMakeLists.txt
+++ b/plugins/experimental/collapsed_forwarding/CMakeLists.txt
@@ -15,8 +15,4 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(traffic_dump)
+add_atsplugin(collapsed_forwarding collapsed_forwarding.cc)

--- a/plugins/experimental/cookie_remap/CMakeLists.txt
+++ b/plugins/experimental/cookie_remap/CMakeLists.txt
@@ -15,9 +15,26 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(traffic_dump)
+project(cookie_remap)
+
+add_atsplugin(cookie_remap
+    cookie_remap.cc
+    cookiejar.cc
+    strip.cc
+)
+
+target_link_libraries(cookie_remap PRIVATE yaml-cpp::yaml-cpp)
+
+if(BUILD_TESTING)
+    add_executable(test_cookiejar
+        test_cookiejar.cc
+        strip.cc
+        cookiejar.cc
+    )
+
+    target_include_directories(test_cookiejar PRIVATE "${PROJECT_SOURCE_DIR}")
+
+    target_link_libraries(test_cookiejar PRIVATE catch2::catch2)
+
+    add_test(NAME test_cookiejar COMMAND test_cookiejar)
+endif()

--- a/plugins/experimental/custom_redirect/CMakeLists.txt
+++ b/plugins/experimental/custom_redirect/CMakeLists.txt
@@ -15,10 +15,4 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(traffic_dump)
+add_atsplugin(custom_redirect custom_redirect.cc)

--- a/plugins/experimental/fq_pacing/CMakeLists.txt
+++ b/plugins/experimental/fq_pacing/CMakeLists.txt
@@ -15,11 +15,4 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(traffic_dump)
+add_atsplugin(fq_pacing fq_pacing.c)

--- a/plugins/experimental/header_freq/CMakeLists.txt
+++ b/plugins/experimental/header_freq/CMakeLists.txt
@@ -15,12 +15,4 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(traffic_dump)
+add_atsplugin(header_freq header_freq.cc)

--- a/plugins/experimental/traffic_dump/CMakeLists.txt
+++ b/plugins/experimental/traffic_dump/CMakeLists.txt
@@ -24,12 +24,10 @@ add_atsplugin(traffic_dump
     transaction_data.cc
 )
 
-target_include_directories(traffic_dump PRIVATE "${PROJECT_SOURCE_DIR}/include")
-
 target_link_libraries(traffic_dump
     PRIVATE
         libswoc
-        "${OPENSSL_SSL_LIBRARY}"
+        OpenSSL::SSL
 )
 
 if(BUILD_TESTING)

--- a/plugins/experimental/traffic_dump/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/traffic_dump/unit_tests/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(test_traffic_dump
     unit_test_main.cc
     test_json_utils.cc
     test_sensitive_fields.cc
-    "${PROJECT_SOURCE_DIR}/json_utils.cc"
+    ${PROJECT_SOURCE_DIR}/json_utils.cc
 )
 
 target_include_directories(test_traffic_dump PRIVATE "${PROJECT_SOURCE_DIR}")


### PR DESCRIPTION
Adds cmake build support for the following experimental plugins:

* header_freq
* fq_pacing
* custom_redirect
* cookie_remap
* collapsed_forwarding
* cert_reporting_tool
* cache_fill
* access_control