### PR TITLE
cmake: add even more experimental plugin build support

### DIFF
--- a/plugins/experimental/metalink/CMakeLists.txt
+++ b/plugins/experimental/metalink/CMakeLists.txt
@@ -15,13 +15,6 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(metalink)
-add_subdirectory(traffic_dump)
+add_atsplugin(metalink metalink.cc)
+
+target_link_libraries(metalink PRIVATE OpenSSL::SSL)

--- a/plugins/experimental/money_trace/CMakeLists.txt
+++ b/plugins/experimental/money_trace/CMakeLists.txt
@@ -15,14 +15,4 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(metalink)
-add_subdirectory(money_trace)
-add_subdirectory(traffic_dump)
+add_atsplugin(money_trace money_trace.cc)

--- a/plugins/experimental/mp4/CMakeLists.txt
+++ b/plugins/experimental/mp4/CMakeLists.txt
@@ -15,15 +15,4 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(metalink)
-add_subdirectory(money_trace)
-add_subdirectory(mp4)
-add_subdirectory(traffic_dump)
+add_atsplugin(mp4 mp4.cc mp4_meta.cc)

--- a/plugins/experimental/parent_select/CMakeLists.txt
+++ b/plugins/experimental/parent_select/CMakeLists.txt
@@ -15,16 +15,12 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(metalink)
-add_subdirectory(money_trace)
-add_subdirectory(mp4)
-add_subdirectory(parent_select)
-add_subdirectory(traffic_dump)
+add_atsplugin(parent_select
+    consistenthash.cc
+    consistenthash_config.cc
+    healthstatus.cc
+    parent_select.cc
+    strategy.cc
+)
+
+target_link_libraries(parent_select PRIVATE yaml-cpp::yaml-cpp)

--- a/plugins/experimental/redo_cache_lookup/CMakeLists.txt
+++ b/plugins/experimental/redo_cache_lookup/CMakeLists.txt
@@ -15,17 +15,6 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(metalink)
-add_subdirectory(money_trace)
-add_subdirectory(mp4)
-add_subdirectory(parent_select)
-add_subdirectory(redo_cache_lookup)
-add_subdirectory(traffic_dump)
+add_atsplugin(redo_cache_lookup redo_cache_lookup.cc)
+
+target_link_libraries(redo_cache_lookup PRIVATE ts::tscppapi)

--- a/plugins/experimental/remap_stats/CMakeLists.txt
+++ b/plugins/experimental/remap_stats/CMakeLists.txt
@@ -15,18 +15,6 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(metalink)
-add_subdirectory(money_trace)
-add_subdirectory(mp4)
-add_subdirectory(parent_select)
-add_subdirectory(redo_cache_lookup)
-add_subdirectory(remap_stats)
-add_subdirectory(traffic_dump)
+add_atsplugin(remap_stats remap_stats.cc)
+
+target_link_libraries(remap_stats PRIVATE ts::tscore)

--- a/plugins/experimental/slice/CMakeLists.txt
+++ b/plugins/experimental/slice/CMakeLists.txt
@@ -15,19 +15,25 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(collapsed_forwarding)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(header_freq)
-add_subdirectory(metalink)
-add_subdirectory(money_trace)
-add_subdirectory(mp4)
-add_subdirectory(parent_select)
-add_subdirectory(redo_cache_lookup)
-add_subdirectory(remap_stats)
-add_subdirectory(slice)
-add_subdirectory(traffic_dump)
+project(slice)
+
+add_atsplugin(slice
+    Config.cc
+    ContentRange.cc
+    HttpHeader.cc
+    Range.cc
+    client.cc
+    intercept.cc
+    prefetch.cc
+    response.cc
+    server.cc
+    slice.cc
+    transfer.cc
+    util.cc
+)
+
+target_link_libraries(access_control PRIVATE ${PCRE_LIBRARY})
+
+if(BUILD_TESTING)
+    add_subdirectory(unit-tests)
+endif()

--- a/plugins/experimental/slice/unit-tests/CMakeLists.txt
+++ b/plugins/experimental/slice/unit-tests/CMakeLists.txt
@@ -1,0 +1,55 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_executable(test_content_range
+    test_content_range.cc
+    ${PROJECT_SOURCE_DIR}/ContentRange.cc
+)
+target_compile_definitions(test_content_range PRIVATE UNITTEST)
+target_include_directories(test_content_range PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(test_content_range
+    PRIVATE
+        ${PCRE_LIBRARY}
+        catch2::catch2
+)
+add_test(NAME test_content_range COMMAND test_content_range)
+
+add_executable(test_range
+    test_range.cc
+    ${PROJECT_SOURCE_DIR}/Range.cc
+)
+target_compile_definitions(test_range PRIVATE UNITTEST)
+target_include_directories(test_range PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(test_range
+    PRIVATE
+        ${PCRE_LIBRARY}
+        catch2::catch2
+)
+add_test(NAME test_range COMMAND test_range)
+
+add_executable(test_config
+    test_config.cc
+    ${PROJECT_SOURCE_DIR}/Config.cc
+)
+target_compile_definitions(test_config PRIVATE UNITTEST)
+target_include_directories(test_config PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(test_config
+    PRIVATE
+        ${PCRE_LIBRARY}
+        catch2::catch2
+)
+add_test(NAME test_config COMMAND test_config)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -103,6 +103,10 @@ add_library(tscore STATIC
 )
 add_library(ts::tscore ALIAS tscore)
 
+# Some plugins link against ts::tscore and therefore need it to be compiled as
+# position independent.
+set_target_properties(tscore PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
 if(OPENSSL_IS_BORINGSSL)
     target_sources(tscore PRIVATE HKDF_boringssl.cc)
 elseif(OPENSSL_IS_OPENSSL3)


### PR DESCRIPTION
This patch adds experimental plugin build support to cmake for the following plugins:

* slice
* remap_stats
* redo_cache_lookup
* parent_select
* mp4
* money_trace
* metalink