### PR TITLE
cmake: -Wall -Wextra flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,13 @@ if (OPENSSL_FOUND)
 endif(OPENSSL_FOUND)
 
 add_subdirectory(lib)
+
+# Keep this after lib because lib is made up of third party libraries, so if
+# there are warnings, we can't do anything about it.
+# Note: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON will turn warnings into errors.
+add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow)
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override>")
+
 include_directories(
         ${CMAKE_SOURCE_DIR}/lib/swoc/include
         ${YAML_CPP_SOURCE_DIR}/include

--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -34,6 +34,7 @@
 
 #include "tscore/I_Version.h"
 #include "tscpp/util/TsSharedMutex.h"
+#include <cstdint>
 #include <unistd.h>
 
 #define REFCOUNT_CACHE_EVENT_SYNC REFCOUNT_CACHE_EVENT_EVENTS_START
@@ -137,7 +138,7 @@ struct RefCountCacheLinkage {
   {
     return key;
   }
-  static key_type
+  static uint64_t
   key_of(value_type *v)
   {
     return v->meta.key;

--- a/proxy/http3/Http3Frame.cc
+++ b/proxy/http3/Http3Frame.cc
@@ -66,7 +66,11 @@ Http3Frame::Http3Frame(const uint8_t *buf, size_t buf_len)
 {
   // Type
   size_t type_field_length = 0;
-  int ret                  = QUICVariableInt::decode(reinterpret_cast<uint64_t &>(this->_type), type_field_length, buf, buf_len);
+  uint64_t type            = 0;
+  // Ideally we'd simply pass this->_type to decode, but arm compilers complain with:
+  // error: dereferencing type-punned pointer will break strict-aliasing rules
+  int ret     = QUICVariableInt::decode(type, type_field_length, buf, buf_len);
+  this->_type = static_cast<Http3FrameType>(type);
   ink_assert(ret != 1);
 
   // Length

--- a/src/tscpp/util/unit_tests/test_IntrusiveDList.cc
+++ b/src/tscpp/util/unit_tests/test_IntrusiveDList.cc
@@ -284,7 +284,7 @@ TEST_CASE("IntrusiveDList", "[libtscpputil][IntrusiveDList]")
   REQUIRE(list.tail()->_payload == "trailer");
 
   PrivateThingList priv_list;
-  for (int i = 1; i <= 23; ++i) {
+  for (std::size_t i = 1; i <= 23; ++i) {
     std::string name;
     swoc::bwprint(name, "Item {}", i);
     priv_list.append(new PrivateThing(name));


### PR DESCRIPTION
This turns on -Wall -Wextra. Our practice with autoconf before and with
cmake here is to enable -Werror via the commandline,
-DCMAKE_COMPILE_WARNING_AS_ERROR=ON in this case.