### PR TITLE
Bump minimum CMake version from 3.20 to 3.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 #######################
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.26)
 project(ats VERSION 10.0.0)
 
 set(TS_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
Kitware's FindImageMagick module provides imported targets since version 3.26. One of the experimental plugins depends on ImageMagick, so it would be nice to have those imported targets available.