### PR TITLE
Require PCRE and clean up usage in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ if(LibLZMA_FOUND)
         set(HAVE_LZMA_H TRUE)
 endif()
 
-find_package(PCRE)
+find_package(PCRE REQUIRED)
 
 include(CheckOpenSSLIsBoringSSL)
 find_package(OpenSSL)
@@ -326,7 +326,6 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
 include_directories(
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_BINARY_DIR}/include
-        ${PCRE_INCLUDE_DIRS}
 )
 
 if (OPENSSL_FOUND)

--- a/cmake/FindPCRE.cmake
+++ b/cmake/FindPCRE.cmake
@@ -15,20 +15,37 @@
 #
 #######################
 
+# FindPCRE.cmake
+#
+# This will define the following variables
+#
+#     PCRE_FOUND
+#     PCRE_LIBRARIES
+#     PCRE_INCLUDE_DIRS
+#
+# and the following imported targets
+#
+#     PCRE::PCRE
+#
 
-find_path(PCRE_INCLUDE_DIR NAMES pcre.h PATH_SUFFIXES pcre)
+
+find_path(PCRE_INCLUDE_DIR NAMES pcre.h)# PATH_SUFFIXES pcre)
 find_library(PCRE_LIBRARY NAMES pcre)
 
-message(PCRE_INCLUDE_DIR=${PCRE_INCLUDE_DIR})
-message(PCRE_LIBRARY=${PCRE_LIBRARY})
+mark_as_advanced(PCRE_FOUND PCRE_LIBRARY PCRE_INCLUDE_DIR)
 
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE DEFAULT_MSG PCRE_LIBRARY PCRE_INCLUDE_DIR)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PCRE
+    REQUIRED_VARS PCRE_INCLUDE_DIR PCRE_LIBRARY
+)
 
 if(PCRE_FOUND)
-    SET(PCRE_LIBRARIES ${PCRE_LIBRARY})
-    SET(PCRE_INCLUDE_DIRS ${PCRE_INCLUDE_DIR})
-else(PCRE_FOUND)
-    SET(PCRE_LIBRARIES)
-    SET(PCRE_INCLUDE_DIRS)
-endif(PCRE_FOUND)
+    set(PCRE_INCLUDE_DIRS "${PCRE_INCLUDE_DIR}")
+    set(PCRE_LIBRARIES "${PCRE_LIBRARY}")
+endif()
+
+if(PCRE_FOUND AND NOT TARGET PCRE::PCRE)
+    add_library(PCRE::PCRE INTERFACE IMPORTED)
+    target_include_directories(PCRE::PCRE INTERFACE ${PCRE_INCLUDE_DIRS})
+    target_link_libraries(PCRE::PCRE INTERFACE "${PCRE_LIBRARY}")
+endif()

--- a/iocore/eventsystem/CMakeLists.txt
+++ b/iocore/eventsystem/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(inkevent
     PRIVATE
         libswoc
         ${OPENSSL_LIBRARIES} # transitive
-        ${PCRE_LIBRARIES} # transitive
+        PCRE::PCRE # transitive
         resolv # transitive
         tscpputil # transitive
         yaml-cpp::yaml-cpp # transitive

--- a/plugins/cachekey/CMakeLists.txt
+++ b/plugins/cachekey/CMakeLists.txt
@@ -22,3 +22,5 @@ add_atsplugin(cachekey
         pattern.cc
         plugin.cc
 )
+
+target_link_libraries(cachekey PRIVATE PCRE::PCRE)

--- a/plugins/experimental/access_control/CMakeLists.txt
+++ b/plugins/experimental/access_control/CMakeLists.txt
@@ -29,7 +29,7 @@ add_atsplugin(access_control
 
 target_link_libraries(access_control
     PRIVATE
-        ${PCRE_LIBRARY}
+        PCRE::PCRE
         OpenSSL::SSL
         OpenSSL::Crypto
 )

--- a/plugins/experimental/cookie_remap/CMakeLists.txt
+++ b/plugins/experimental/cookie_remap/CMakeLists.txt
@@ -23,7 +23,11 @@ add_atsplugin(cookie_remap
     strip.cc
 )
 
-target_link_libraries(cookie_remap PRIVATE yaml-cpp::yaml-cpp)
+target_link_libraries(cookie_remap
+    PRIVATE
+        PCRE::PCRE
+        yaml-cpp::yaml-cpp
+)
 
 if(BUILD_TESTING)
     add_executable(test_cookiejar

--- a/plugins/experimental/slice/CMakeLists.txt
+++ b/plugins/experimental/slice/CMakeLists.txt
@@ -32,7 +32,7 @@ add_atsplugin(slice
     util.cc
 )
 
-target_link_libraries(access_control PRIVATE ${PCRE_LIBRARY})
+target_link_libraries(access_control PRIVATE PCRE::PCRE)
 
 if(BUILD_TESTING)
     add_subdirectory(unit-tests)

--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -33,6 +33,8 @@ add_atsplugin(header_rewrite
 
 add_library(header_rewrite_parser STATIC parser.cc)
 
+target_link_libraries(header_rewrite PRIVATE PCRE::PCRE)
+
 find_package(maxminddb QUIET)
 
 if(maxminddb_FOUND)

--- a/plugins/prefetch/CMakeLists.txt
+++ b/plugins/prefetch/CMakeLists.txt
@@ -30,4 +30,6 @@ add_atsplugin(prefetch
     plugin.cc
 )
 
+target_link_libraries(prefetch PRIVATE PCRE::PCRE)
+
 add_subdirectory(test)

--- a/plugins/regex_remap/CMakeLists.txt
+++ b/plugins/regex_remap/CMakeLists.txt
@@ -16,3 +16,5 @@
 #######################
 
 add_atsplugin(regex_remap regex_remap.cc)
+
+target_link_libraries(regex_remap PRIVATE PCRE::PCRE)

--- a/plugins/regex_revalidate/CMakeLists.txt
+++ b/plugins/regex_revalidate/CMakeLists.txt
@@ -19,4 +19,4 @@ add_atsplugin(regex_revalidate regex_revalidate.c)
 
 target_include_directories(regex_revalidate PRIVATE "${PROJECT_SOURCE_DIR}/include")
 
-target_link_libraries(regex_revalidate PRIVATE "${PCRE_LIBRARY}")
+target_link_libraries(regex_revalidate PRIVATE PCRE::PCRE)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -167,7 +167,7 @@ target_link_libraries(test_tscore
         yaml-cpp::yaml-cpp
         libswoc
         ${OPENSSL_LIBRARIES}
-        ${PCRE_LIBRARIES}
+        PCRE::PCRE
         resolv
         tscpputil
 )


### PR DESCRIPTION
This makes PCRE REQUIRED, and moves from variables to using a PCRE::PCRE target. It also removes the global PCRE include, providing better encapsulation and making the dependencies explicit.