### PR TITLE
Confine some warning flags to GNU compiler builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,8 +339,9 @@ add_subdirectory(lib)
 # Keep this after lib because lib is made up of third party libraries, so if
 # there are warnings, we can't do anything about it.
 # Note: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON will turn warnings into errors.
-add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter -Wno-format-truncation -Wno-cast-function-type -Wno-stringop-overflow)
+add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter -Wno-cast-function-type)
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override>")
+add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wno-format-truncation;-Wno-stringop-overflow>")
 
 include_directories(
         ${CMAKE_SOURCE_DIR}/lib/swoc/include


### PR DESCRIPTION
This fixes some Clang warnings about warning flags not being recognized by only setting -Wno-format-truncation and -Wno-stringop-overflow for the GNU compiler.