### PR TITLE
Don't link overridable_txn_vars.o twice

### DIFF
--- a/mgmt/rpc/Makefile.am
+++ b/mgmt/rpc/Makefile.am
@@ -149,7 +149,6 @@ librpcpublichandlers_la_SOURCES = \
 # for building.
 # We have also added a proper cleaning for it.
 shared_overridable_txn_vars_SOURCES = overridable_txn_vars.cc
-nodist_librpcpublichandlers_la_SOURCES = $(shared_overridable_txn_vars_SOURCES)
 
 shared_rpc_ipc_client_SOURCES = IPCSocketClient.cc
 


### PR DESCRIPTION
I see this link error on my Mac. I'm not sure why this error suddenly came up, but I guess some recent commits changed something.
```
Making all in rpc
/bin/sh ../../libtool  --tag=CXX   --mode=link ccache c++ -std=c++20 -g -pipe -Wall -Qunused-arguments -Wextra -Wno-unused-parameter -O3 -fno-strict-aliasing -Werror -Wno-invalid-offsetof -fno-omit-frame-pointer -fsanitize=address  -R/Users/mkitajo/opt/boringssl/lib -R/opt/homebrew/Cellar/pcre/8.45/lib -R/Users/mkitajo/opt/quiche/lib -L/Users/mkitajo/opt/boringssl/lib -L/opt/homebrew/Cellar/pcre/8.45/lib -L/Users/mkitajo/opt/quiche/lib -rpath /Users/mkitajo/opt/quiche/lib -o librpcpublichandlers.la  handlers/common/RecordsUtils.lo handlers/config/Configuration.lo handlers/records/Records.lo handlers/storage/Storage.lo handlers/server/Server.lo handlers/plugins/Plugins.lo overridable_txn_vars.lo overridable_txn_vars.lo  -lquiche
libtool: link: c++ -dynamiclib -Wl,-undefined -Wl,dynamic_lookup -o .libs/librpcpublichandlers.0.dylib  handlers/common/.libs/RecordsUtils.o handlers/config/.libs/Configuration.o handlers/records/.libs/Records.o handlers/storage/.libs/Storage.o handlers/server/.libs/Server.o handlers/plugins/.libs/Plugins.o .libs/overridable_txn_vars.o .libs/overridable_txn_vars.o   -L/Users/mkitajo/opt/boringssl/lib -L/opt/homebrew/Cellar/pcre/8.45/lib -L/Users/mkitajo/opt/quiche/lib -lquiche  -g -O3 -fsanitize=address   -install_name  /Users/mkitajo/opt/quiche/lib/librpcpublichandlers.0.dylib -compatibility_version 1 -current_version 1.0 -Wl,-single_module
duplicate symbol 'ts::Overridable_Txn_Vars' in:
    .libs/overridable_txn_vars.o
ld: 1 duplicate symbol for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

There is `.libs/overridable_txn_vars.o .libs/overridable_txn_vars.o` in the command line.

The Makefile has below.
```
am__objects_4 = overridable_txn_vars.lo
am_librpcpublichandlers_la_OBJECTS = $(am__objects_3) $(am__objects_4)
nodist_librpcpublichandlers_la_OBJECTS = $(am__objects_4)
librpcpublichandlers_la_OBJECTS =  \
        $(am_librpcpublichandlers_la_OBJECTS) \
        $(nodist_librpcpublichandlers_la_OBJECTS)
```