### PR TITLE
LSan: Fix memory leak of test_HostFile

### DIFF
--- a/iocore/hostdb/test_HostFile.cc
+++ b/iocore/hostdb/test_HostFile.cc
@@ -173,4 +173,5 @@ HostDBRecord::alloc(ts::TextView query_name, unsigned int rr_count, size_t srv_n
 void
 HostDBRecord::free()
 {
+  delete this;
 }


### PR DESCRIPTION
```
» ASAN_OPTIONS=detect_leaks=1 ./test_HostFile
test_HostFile(37129,0x7ff8602f1640) malloc: nano zone abandoned due to inability to reserve vm space.
===============================================================================
All tests passed (18 assertions in 1 test case)


=================================================================
==37129==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2928 byte(s) in 24 object(s) allocated from:
    #0 0x1056954ad in wrap_malloc+0x9d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xdf4ad) (BuildId: 7be29bc853af3228b5ae02c6da2408ac2400000010000000000a0a0000000d00)
    #1 0x1043d4dfa in HostDBRecord::alloc(ts::TextView, unsigned int, unsigned long) test_HostFile.cc:149
    #2 0x1044940de in ParseHostFile(swoc::_1_5_2::file::path const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l>>) HostFile.cc:128
    #3 0x1043cdcfd in C_A_T_C_H_T_E_S_T_0() test_HostFile.cc:61
    #4 0x10435d768 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:13000
    #5 0x10435b2ed in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12761
    #6 0x10436fc0f in Catch::Session::runInternal() catch.hpp:13560
    #7 0x10436d585 in Catch::Session::run() catch.hpp:13516
    #8 0x1043cc85c in main catch.hpp:17533
    #9 0x7ff81c8bb41e in start+0x76e (dyld:x86_64+0xfffffffffff6e41e) (BuildId: 5db85b72c63a318291e55c942ec30e4832000000200000000100000000040d00)

Direct leak of 768 byte(s) in 6 object(s) allocated from:
    #0 0x1056954ad in wrap_malloc+0x9d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xdf4ad) (BuildId: 7be29bc853af3228b5ae02c6da2408ac2400000010000000000a0a0000000d00)
    #1 0x1043d4dfa in HostDBRecord::alloc(ts::TextView, unsigned int, unsigned long) test_HostFile.cc:149
    #2 0x1044944fa in ParseHostFile(swoc::_1_5_2::file::path const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l>>) HostFile.cc:133
    #3 0x1043cdcfd in C_A_T_C_H_T_E_S_T_0() test_HostFile.cc:61
    #4 0x10435d768 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:13000
    #5 0x10435b2ed in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12761
    #6 0x10436fc0f in Catch::Session::runInternal() catch.hpp:13560
    #7 0x10436d585 in Catch::Session::run() catch.hpp:13516
    #8 0x1043cc85c in main catch.hpp:17533
    #9 0x7ff81c8bb41e in start+0x76e (dyld:x86_64+0xfffffffffff6e41e) (BuildId: 5db85b72c63a318291e55c942ec30e4832000000200000000100000000040d00)

SUMMARY: AddressSanitizer: 3696 byte(s) leaked in 30 allocation(s).
```