### PR TITLE
Revert "Bump minimum CMake version from 3.20 to 3.26"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 #######################
 
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.20)
 project(ats VERSION 10.0.0)
 
 set(TS_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
Reverts apache/trafficserver#10053

We'll change this to a range from 3.20-3.26 since we decided to keep support for at least 3.20 to maintain support for older OS's.