### PR TITLE
Use of uninitialized variables reported by oss-fuzz

### DIFF
--- a/src/tscore/Regex.cc
+++ b/src/tscore/Regex.cc
@@ -55,10 +55,10 @@ Regex::Regex(Regex &&that) noexcept : regex(that.regex), regex_extra(that.regex_
 bool
 Regex::compile(const char *pattern, const unsigned flags)
 {
-  const char *error;
-  int erroffset;
-  int options    = 0;
-  int study_opts = 0;
+  const char *error = NULL;
+  int erroffset     = 0;
+  int options       = 0;
+  int study_opts    = 0;
 
   if (regex) {
     return false;

--- a/src/tscore/Regex.cc
+++ b/src/tscore/Regex.cc
@@ -55,7 +55,7 @@ Regex::Regex(Regex &&that) noexcept : regex(that.regex), regex_extra(that.regex_
 bool
 Regex::compile(const char *pattern, const unsigned flags)
 {
-  const char *error = NULL;
+  const char *error = nullptr;
   int erroffset     = 0;
   int options       = 0;
   int study_opts    = 0;


### PR DESCRIPTION
oss-fuzz test case reported a problem with variables not initialized before use 

https://oss-fuzz.com/testcase-detail/5739350995107840

```
==42095==WARNING: MemorySanitizer: use-of-uninitialized-value
  | #0 0x7c89163834b3 in compile trafficserver/src/tscore/Regex.cc:76:7
  | #1 0x7c89163834b3 in DFA::build(std::__1::basic_string_view<char, std::__1::char_traits<char> > const&, unsigned int) trafficserver/src/tscore/Regex.cc:149:12
  | #2 0x7c891638474a in DFA::compile(char const**, int, unsigned int) trafficserver/src/tscore/Regex.cc:179:11
  | #3 0x574541 in hdrtoken_init() trafficserver/proxy/hdrs/HdrToken.cc:446:24
  | #4 0x578e3a in mime_init() trafficserver/proxy/hdrs/MIME.cc:670:5
  | #5 0x542aba in http_init() trafficserver/proxy/hdrs/HTTP.cc:169:5
  | #6 0x5413f3 in LLVMFuzzerTestOneInput trafficserver/fuzzer/FuzzHTTP.cc:28:5
  | #7 0x44aaa3 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
  | #8 0x436202 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
  | #9 0x43baac in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
  | #10 0x464fe2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
  | #11 0x7c891584f082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/libc-start.c:308:16
  | #12 0x42c3cd in _start
 

```
