### PR TITLE
clang-analyzer: Negative Length Array in HttpSM

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -8260,7 +8260,7 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
       // The redirect URL did not begin with a slash, so we parsed some or all
       // of the relative URI path as the host.
       // Prepend a slash and parse again.
-      char redirect_url_leading_slash[arg_redirect_len + 1];
+      char redirect_url_leading_slash[arg_redirect_len >= 0 ? arg_redirect_len + 1 : 1];
       redirect_url_leading_slash[0] = '/';
       if (arg_redirect_len > 0) {
         memcpy(redirect_url_leading_slash + 1, arg_redirect_url, arg_redirect_len);


### PR DESCRIPTION
clang-analyzer reports that Declared variable-length array (VLA) has negative size.

https://ci.trafficserver.apache.org/job/Github_Builds/job/clang-analyzer/2052/artifact/output/10067/2023-07-19-195456-12360-1/report-a011f5.html#EndPath