### PR TITLE
LSan: Suppress memory leak report of RegressionTest_UDPNet_echo

### DIFF
--- a/ci/asan_leak_suppression/regression.txt
+++ b/ci/asan_leak_suppression/regression.txt
@@ -17,3 +17,4 @@ leak:RegressionTest_Hdrs
 leak:RegressionTest_SDK_API_TSPortDescriptor
 leak:RegressionTest_HostDBProcessor
 leak:RegressionTest_DNS
+leak:RegressionTest_UDPNet_echo

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -36,6 +36,7 @@ AM_CPPFLAGS += \
 	@SWOC_INCLUDES@
 
 TESTS = $(check_PROGRAMS)
+TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=$(abs_top_srcdir)/ci/asan_leak_suppression/regression.txt
 
 check_PROGRAMS = test_certlookup test_UDPNet test_libinknet
 noinst_LIBRARIES = libinknet.a


### PR DESCRIPTION
LSan (llvm-16 on mac os) reports a memory leak of `/iocore/net/test_UDPNet`. It looks like an object is not freed when a forked process is killed.
I want to leave it instead of going deeper because this is just a unit test.

https://github.com/apache/trafficserver/blob/15207bb3471b4f489ab3beff5757e4cc05b31167/iocore/net/test_I_UDPNet.cc#L202

```
» ASAN_OPTIONS=detect_leaks=1 ./test_UDPNet
test_UDPNet(65668,0x7ff8602f1640) malloc: nano zone abandoned due to inability to reserve vm space.
REGRESSION_TEST initialization begun
REGRESSION TEST UDPNet_echo started
Echo Server port: 51992
[Jul 20 15:52:42.026] [ET_NET 0] DEBUG: <UnixUDPNet.cc:437 (read_single_message_from_net)> (udp-read) Received 6 bytes. gso_size 0 (No GRO)
[Jul 20 15:52:42.027] [ET_NET 0] DEBUG: <UnixUDPNet.cc:458 (read_single_message_from_net)> (udp-read) Creating packet
[Jul 20 15:52:42.028] [ET_NET 0] DEBUG: <UnixUDPNet.cc:473 (read_single_message_from_net)> (udp-read) read 1 at a time
[Jul 20 15:52:42.028] [ET_NET 0] DEBUG: <UnixUDPNet.cc:1293 (service)> (udp-send) Adding 0x62b000005f60
[Jul 20 15:52:42.028] [ET_NET 0] DEBUG: <UnixUDPNet.cc:1397 (SendUDPPacket)> (udp-send) Sending 0x62b000005f60

=================================================================
==65682==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x11191b882 in wrap_calloc+0xa2 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xdf882) (BuildId: 7be29bc853af3228b5ae02c6da2408ac2400000010000000000a0a0000000d00)
    #1 0x7ff828a60d0a in os_map_64_init+0x5c (libsystem_collections.dylib:x86_64+0x2d0a) (BuildId: c68f647b326234a3ae5edb56aec1062732000000200000000100000000040d00)
    #2 0x7ff81fcea1e2 in _notify_fork_child+0xdd (libsystem_notify.dylib:x86_64+0x71e2) (BuildId: 38b11ee013453b659185d05225771f5132000000200000000100000000040d00)
    #3 0x7ff828a79c7c in libSystem_atfork_child+0x39 (libSystem.B.dylib:x86_64+0x1c7c) (BuildId: fd8316cd05243e5fa1e53a662dd5f12f32000000200000000100000000040d00)
    #4 0x7ff81cae2597 in fork+0x53 (libsystem_c.dylib:x86_64+0x26597) (BuildId: 5ca0d0cffcdd3180af7bf137fe1e7aca32000000200000000100000000040d00)
    #5 0x10fe8372f in RegressionTest_UDPNet_echo(RegressionTest*, int, int*) test_I_UDPNet.cc:202
    #6 0x11015caf7 in RegressionTest::run(char const*, int)+0x307 (test_UDPNet:x86_64+0x1002e0af7) (BuildId: 48db3a74d4143684a46b99299b30f69c32000000200000000100000000000d00)
    #7 0x10fe83d74 in main test_I_UDPNet.cc:233
    #8 0x7ff81c8bb41e in start+0x76e (dyld:x86_64+0xfffffffffff6e41e) (BuildId: 5db85b72c63a318291e55c942ec30e4832000000200000000100000000040d00)
...
SUMMARY: AddressSanitizer: 4096 byte(s) leaked in 14 allocation(s).
UDP Echo Server exit failure    
```