### PR TITLE
Fix missing PCRE includes in CMake by linking to tscore

### DIFF
--- a/iocore/aio/CMakeLists.txt
+++ b/iocore/aio/CMakeLists.txt
@@ -22,4 +22,4 @@ add_library(ts::aio ALIAS aio)
 target_sources(aio PRIVATE AIO.cc Inline.cc)
 target_include_directories(aio PRIVATE ${CMAKE_SOURCE_DIR}/iocore/eventsystem ${CMAKE_SOURCE_DIR}/iocore/io_uring)
 
-target_link_libraries(aio PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(aio PUBLIC ts::tscore)

--- a/iocore/aio/CMakeLists.txt
+++ b/iocore/aio/CMakeLists.txt
@@ -21,3 +21,5 @@ add_library(ts::aio ALIAS aio)
 
 target_sources(aio PRIVATE AIO.cc Inline.cc)
 target_include_directories(aio PRIVATE ${CMAKE_SOURCE_DIR}/iocore/eventsystem ${CMAKE_SOURCE_DIR}/iocore/io_uring)
+
+target_link_libraries(aio PRIVATE PCRE::PCRE) # transitive

--- a/iocore/cache/CMakeLists.txt
+++ b/iocore/cache/CMakeLists.txt
@@ -53,6 +53,8 @@ target_include_directories(inkcache PRIVATE
 )
 
 target_link_libraries(inkcache
+    PUBLIC
+        ts::tscore
     PRIVATE
         fastlz
         ZLIB::ZLIB
@@ -61,4 +63,3 @@ target_link_libraries(inkcache
 if(HAVE_LZMA_H)
     target_link_libraries(inkcache PRIVATE LibLZMA::LibLZMA)
 endif()
-

--- a/iocore/dns/CMakeLists.txt
+++ b/iocore/dns/CMakeLists.txt
@@ -37,4 +37,4 @@ target_include_directories(inkdns PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
 
-target_link_libraries(inkdns PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(inkdns PUBLIC ts::tscore)

--- a/iocore/dns/CMakeLists.txt
+++ b/iocore/dns/CMakeLists.txt
@@ -36,3 +36,5 @@ target_include_directories(inkdns PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
+
+target_link_libraries(inkdns PRIVATE PCRE::PCRE) # transitive

--- a/iocore/hostdb/CMakeLists.txt
+++ b/iocore/hostdb/CMakeLists.txt
@@ -37,3 +37,5 @@ target_include_directories(inkhostdb PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
+
+target_link_libraries(inkhostdb PRIVATE PCRE::PCRE) # transitive

--- a/iocore/hostdb/CMakeLists.txt
+++ b/iocore/hostdb/CMakeLists.txt
@@ -38,4 +38,4 @@ target_include_directories(inkhostdb PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
 
-target_link_libraries(inkhostdb PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(inkhostdb PUBLIC ts::tscore)

--- a/iocore/io_uring/CMakeLists.txt
+++ b/iocore/io_uring/CMakeLists.txt
@@ -31,10 +31,11 @@ include_directories(
 add_executable(test_iouring
         unit_tests/test_diskIO.cc)
 target_link_libraries(test_iouring
+    PUBLIC
+        ts::tscore
     PRIVATE
         inkuring
         libswoc
-        ts::tscore
         tscpputil
         uring
 )

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -97,7 +97,7 @@ if(BUILD_REGRESSION_TESTING)
     target_sources(inknet PRIVATE NetVCTest.cc)
 endif()
 
-target_link_libraries(inknet PUBLIC inkevent records)
+
 target_compile_options(inknet PUBLIC -Wno-deprecated-declarations)
 target_include_directories(inknet PUBLIC
         ${CMAKE_SOURCE_DIR}/iocore/eventsystem
@@ -116,6 +116,13 @@ target_include_directories(inknet PUBLIC
         ${OPENSSL_INCLUDE_DIRS}
         ${YAML_INCLUDE_DIRS}
         )
+
+target_link_libraries(inknet
+    PUBLIC
+        ts::inkevent
+        ts::records
+        ts::tscore
+)
 
 # Fails to link because of circular dep with proxy (ParentSelection)
 # add_executable(test_net unit_tests/test_ProxyProtocol.cc)

--- a/iocore/utils/CMakeLists.txt
+++ b/iocore/utils/CMakeLists.txt
@@ -31,3 +31,5 @@ target_include_directories(inkutils PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
         )
+
+target_link_libraries(inkutils PRIVATE PCRE::PCRE) # transitive

--- a/iocore/utils/CMakeLists.txt
+++ b/iocore/utils/CMakeLists.txt
@@ -32,4 +32,4 @@ target_include_directories(inkutils PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
         )
 
-target_link_libraries(inkutils PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(inkutils PUBLIC ts::tscore)

--- a/mgmt/config/CMakeLists.txt
+++ b/mgmt/config/CMakeLists.txt
@@ -28,3 +28,5 @@ include_directories(
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${IOCORE_INCLUDE_DIRS}
 )
+
+target_link_libraries(configmanager PUBLIC ts::tscore)

--- a/mgmt/rpc/CMakeLists.txt
+++ b/mgmt/rpc/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(jsonrpc_protocol STATIC
 )
 add_library(ts::jsonrpc_protocol ALIAS jsonrpc_protocol)
 
+target_link_libraries(jsonrpc_protocol PRIVATE PCRE::PCRE) # transitive
+
 add_library(jsonrpc_server STATIC
         server/RPCServer.cc
         server/CommBase.cc
@@ -40,6 +42,8 @@ add_library(jsonrpc_server STATIC
         config/JsonRPCConfig.cc
 )
 add_library(ts::jsonrpc_server ALIAS jsonrpc_server)
+
+target_link_libraries(jsonrpc_server PRIVATE PCRE::PCRE) # transitive
 
 add_library(rpcpublichandlers STATIC
         handlers/common/RecordsUtils.cc
@@ -50,3 +54,5 @@ add_library(rpcpublichandlers STATIC
         handlers/plugins/Plugins.cc
 )
 add_library(ts::rpcpublichandlers ALIAS rpcpublichandlers)
+
+target_link_libraries(rpcpublichandlers PRIVATE PCRE::PCRE) # transitive

--- a/mgmt/rpc/CMakeLists.txt
+++ b/mgmt/rpc/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(jsonrpc_protocol STATIC
 )
 add_library(ts::jsonrpc_protocol ALIAS jsonrpc_protocol)
 
-target_link_libraries(jsonrpc_protocol PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(jsonrpc_protocol PUBLIC ts::tscore)
 
 add_library(jsonrpc_server STATIC
         server/RPCServer.cc
@@ -43,7 +43,7 @@ add_library(jsonrpc_server STATIC
 )
 add_library(ts::jsonrpc_server ALIAS jsonrpc_server)
 
-target_link_libraries(jsonrpc_server PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(jsonrpc_server PUBLIC ts::tscore)
 
 add_library(rpcpublichandlers STATIC
         handlers/common/RecordsUtils.cc
@@ -55,4 +55,4 @@ add_library(rpcpublichandlers STATIC
 )
 add_library(ts::rpcpublichandlers ALIAS rpcpublichandlers)
 
-target_link_libraries(rpcpublichandlers PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(rpcpublichandlers PUBLIC ts::tscore)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,7 +22,6 @@ function(add_atsplugin name)
   target_link_libraries(${name} PRIVATE traffic_server)
   set_target_properties(${name} PROPERTIES PREFIX "")
   set_target_properties(${name} PROPERTIES SUFFIX ".so")
-  set_target_properties(${name} PROPERTIES LINK_FLAGS "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib")
   install(TARGETS ${name} DESTINATION libexec/trafficserver)
 endfunction()
 

--- a/plugins/experimental/slice/CMakeLists.txt
+++ b/plugins/experimental/slice/CMakeLists.txt
@@ -32,7 +32,7 @@ add_atsplugin(slice
     util.cc
 )
 
-target_link_libraries(access_control PRIVATE PCRE::PCRE)
+target_link_libraries(slice PRIVATE ts::tscore)
 
 if(BUILD_TESTING)
     add_subdirectory(unit-tests)

--- a/plugins/s3_auth/CMakeLists.txt
+++ b/plugins/s3_auth/CMakeLists.txt
@@ -19,4 +19,6 @@ project(s3_auth)
 
 add_atsplugin(s3_auth s3_auth.cc aws_auth_v4.cc)
 
+target_link_libraries(s3_auth PRIVATE ts::tscore)
+
 add_subdirectory(unit_tests)

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(proxy PUBLIC
         ${CMAKE_SOURCE_DIR}/lib/yamlcpp/include
         )
 
-target_link_libraries(proxy PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(proxy PUBLIC ts::tscore)
 
 add_subdirectory(hdrs)
 add_subdirectory(shared)

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -58,6 +58,8 @@ target_include_directories(proxy PUBLIC
         ${CMAKE_SOURCE_DIR}/lib/yamlcpp/include
         )
 
+target_link_libraries(proxy PRIVATE PCRE::PCRE) # transitive
+
 add_subdirectory(hdrs)
 add_subdirectory(shared)
 add_subdirectory(http)

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -56,7 +56,7 @@ target_include_directories(http
         ${YAMLCPP_INCLUDE_DIR}
 )
 
-target_link_libraries(http PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(http PUBLIC ts::tscore)
 
 if(TS_USE_QUIC)
     target_link_libraries(http PRIVATE ts::http3)

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -56,6 +56,8 @@ target_include_directories(http
         ${YAMLCPP_INCLUDE_DIR}
 )
 
+target_link_libraries(http PRIVATE PCRE::PCRE) # transitive
+
 if(TS_USE_QUIC)
     target_link_libraries(http PRIVATE ts::http3)
 endif()

--- a/proxy/http/remap/CMakeLists.txt
+++ b/proxy/http/remap/CMakeLists.txt
@@ -43,4 +43,4 @@ target_include_directories(http_remap PRIVATE
         ${YAML_INCLUDE_DIRS}
         )
 
-target_link_libraries(http_remap PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(http_remap PUBLIC ts::tscore)

--- a/proxy/http/remap/CMakeLists.txt
+++ b/proxy/http/remap/CMakeLists.txt
@@ -42,3 +42,5 @@ target_include_directories(http_remap PRIVATE
         ${CMAKE_SOURCE_DIR}/src/records
         ${YAML_INCLUDE_DIRS}
         )
+
+target_link_libraries(http_remap PRIVATE PCRE::PCRE) # transitive

--- a/proxy/http2/CMakeLists.txt
+++ b/proxy/http2/CMakeLists.txt
@@ -36,3 +36,5 @@ target_include_directories(http2 PRIVATE
         ${PROXY_INCLUDE_DIRS}
         ${YAMLCPP_INCLUDE_DIR}
 )
+
+target_link_libraries(http2 PRIVATE PCRE::PCRE) # transitive

--- a/proxy/http2/CMakeLists.txt
+++ b/proxy/http2/CMakeLists.txt
@@ -37,4 +37,4 @@ target_include_directories(http2 PRIVATE
         ${YAMLCPP_INCLUDE_DIR}
 )
 
-target_link_libraries(http2 PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(http2 PUBLIC ts::tscore)

--- a/proxy/logging/CMakeLists.txt
+++ b/proxy/logging/CMakeLists.txt
@@ -40,3 +40,5 @@ target_include_directories(logging PRIVATE
         ${YAML_INCLUDE_DIRS}
         ${SWOC_INCLUDE_DIR}
 )
+
+target_link_libraries(logging PRIVATE PCRE::PCRE) # transitive

--- a/proxy/logging/CMakeLists.txt
+++ b/proxy/logging/CMakeLists.txt
@@ -41,4 +41,4 @@ target_include_directories(logging PRIVATE
         ${SWOC_INCLUDE_DIR}
 )
 
-target_link_libraries(logging PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(logging PUBLIC ts::tscore)

--- a/proxy/shared/CMakeLists.txt
+++ b/proxy/shared/CMakeLists.txt
@@ -24,3 +24,5 @@ target_include_directories(diagsconfig PRIVATE
         ${PROXY_INCLUDE_DIRS}
         ${YAMLCPP_INCLUDE_DIR}
 )
+
+target_link_libraries(diagsconfig PRIVATE PCRE::PCRE) # transitive

--- a/proxy/shared/CMakeLists.txt
+++ b/proxy/shared/CMakeLists.txt
@@ -25,4 +25,4 @@ target_include_directories(diagsconfig PRIVATE
         ${YAMLCPP_INCLUDE_DIR}
 )
 
-target_link_libraries(diagsconfig PRIVATE PCRE::PCRE) # transitive
+target_link_libraries(diagsconfig PUBLIC ts::tscore)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -120,7 +120,7 @@ if(TS_USE_POSIX_CAP)
     target_link_libraries(tscore PUBLIC cap::cap)
 endif()
 
-add_dependencies(tscore ParseRules tscpputil)
+add_dependencies(tscore ParseRules)
 target_include_directories(tscore PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
         ${YAML_INCLUDE_DIRS}

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -115,6 +115,7 @@ else()
     target_sources(tscore PRIVATE HKDF_openssl.cc)
 endif()
 
+target_link_libraries(tscore PUBLIC PCRE::PCRE)
 if(TS_USE_POSIX_CAP)
     target_link_libraries(tscore PUBLIC cap::cap)
 endif()
@@ -167,7 +168,6 @@ target_link_libraries(test_tscore
         yaml-cpp::yaml-cpp
         libswoc
         ${OPENSSL_LIBRARIES}
-        PCRE::PCRE
         resolv
         tscpputil
 )

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -49,6 +49,6 @@ target_link_libraries(tscppapi
     )
 install(TARGETS tscppapi)
 
-if (APPLE)
-    set_target_properties(tscppapi PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-endif(APPLE)
+if(APPLE)
+  target_link_options(tscppapi PRIVATE -undefined dynamic_lookup)
+endif()

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(tscppapi
     PUBLIC
     libswoc
     yaml-cpp::yaml-cpp
-    )
+)
 install(TARGETS tscppapi)
 
 if(APPLE)

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -45,5 +45,10 @@ add_library(ts::tscppapi ALIAS tscppapi)
 target_link_libraries(tscppapi
     PUBLIC
     libswoc
-    yaml-cpp::yaml-cpp)
+    yaml-cpp::yaml-cpp
+    )
 install(TARGETS tscppapi)
+
+if (APPLE)
+    set_target_properties(tscppapi PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+endif(APPLE)

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -26,7 +26,8 @@ target_link_libraries(tscpputil
 	PUBLIC
 		libswoc
 		yaml-cpp::yaml-cpp
-                ts::tscore)
+                ts::tscore
+)
 install(TARGETS tscpputil)
 
 add_executable(test_tscpputil

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(ts::tscpputil ALIAS tscpputil)
 target_link_libraries(tscpputil
 	PUBLIC
 		libswoc
-		yaml-cpp::yaml-cpp)
+		yaml-cpp::yaml-cpp
+                ts::tscore)
 install(TARGETS tscpputil)
 
 add_executable(test_tscpputil


### PR DESCRIPTION
This is a step towards getting the dependency tree fixed. And it fixes the missing pcre includes.