### PR TITLE
Shutdown tests: update backing sleep command to 10

### DIFF
--- a/tests/gold_tests/remap/remap_load_empty_failure.test.py
+++ b/tests/gold_tests/remap/remap_load_empty_failure.test.py
@@ -33,7 +33,7 @@ tr = Test.AddTestRun("test")
 # before it detects the log message. So we add a separate process that waits
 # upon the log message.
 watcher = Test.Processes.Process("watcher")
-watcher.Command = "sleep 1"
+watcher.Command = "sleep 10"
 watcher.Ready = When.FileContains(ts.Disk.diags_log.Name, "remap.config failed to load")
 watcher.StartBefore(ts)
 

--- a/tests/gold_tests/shutdown/emergency.test.py
+++ b/tests/gold_tests/shutdown/emergency.test.py
@@ -47,7 +47,7 @@ tr = Test.AddTestRun()
 # before it detects the log message. So we add a separate process that waits
 # upon the log message.
 watcher = Test.Processes.Process("watcher")
-watcher.Command = "sleep 1"
+watcher.Command = "sleep 10"
 watcher.Ready = When.FileContains(ts.Disk.diags_log.Name, "testing emergency shutdown")
 watcher.StartBefore(ts)
 

--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -47,7 +47,7 @@ tr = Test.AddTestRun()
 # before it detects the log message. So we add a separate process that waits
 # upon the log message.
 watcher = Test.Processes.Process("watcher")
-watcher.Command = "sleep 1"
+watcher.Command = "sleep 10"
 watcher.Ready = When.FileContains(ts.Disk.diags_log.Name, "testing fatal shutdown")
 watcher.StartBefore(ts)
 


### PR DESCRIPTION
The Ready conditions for some await processes waited upon the existence of a log entry before continuing. This works fine, but the process behind some of them was a 1 second sleep. If the sleep finished before the file existed, which should be rare for these tests but possible, the test would fail because the process finished before the process was "ready". This updates the backing sleep commands to 10 second sleeps which should afford plenty of time for the watch processes to see their file content. This may make these tests more reliable in CI.