### PR TITLE
Fix OpenSSL dependency tree for CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ endif()
 find_package(PCRE REQUIRED)
 
 include(CheckOpenSSLIsBoringSSL)
-find_package(OpenSSL)
+find_package(OpenSSL REQUIRED)
 check_openssl_is_boringssl(OPENSSL_IS_BORINGSSL "${OPENSSL_INCLUDE_DIR}")
 
 if(OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0")
@@ -327,11 +327,6 @@ include_directories(
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_BINARY_DIR}/include
 )
-
-if (OPENSSL_FOUND)
-    include_directories(${OPENSSL_INCLUDE_DIR})
-    link_libraries(${OPENSSL_CRYPTO_LIBRARY})
-endif(OPENSSL_FOUND)
 
 add_subdirectory(lib)
 

--- a/iocore/eventsystem/CMakeLists.txt
+++ b/iocore/eventsystem/CMakeLists.txt
@@ -45,8 +45,6 @@ target_link_libraries(inkevent
         ts::tscore
     PRIVATE
         libswoc
-        ${OPENSSL_LIBRARIES} # transitive
-        PCRE::PCRE # transitive
         resolv # transitive
         tscpputil # transitive
         yaml-cpp::yaml-cpp # transitive

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -113,7 +113,6 @@ target_include_directories(inknet PUBLIC
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/http/remap
         ${CMAKE_SOURCE_DIR}/src/traffic_server
-        ${OPENSSL_INCLUDE_DIRS}
         ${YAML_INCLUDE_DIRS}
         )
 
@@ -122,6 +121,8 @@ target_link_libraries(inknet
         ts::inkevent
         ts::records
         ts::tscore
+        OpenSSL::Crypto
+        OpenSSL::SSL
 )
 
 # Fails to link because of circular dep with proxy (ParentSelection)

--- a/iocore/net/quic/CMakeLists.txt
+++ b/iocore/net/quic/CMakeLists.txt
@@ -39,7 +39,8 @@ target_link_libraries(quic
     PUBLIC
         inkevent
         inknet
-        ${OPENSSL_LIBRARY}
         quiche::quiche
         ts::tscore
+        OpenSSL::Crypto
+        OpenSSL::SSL
 )

--- a/plugins/cache_promote/CMakeLists.txt
+++ b/plugins/cache_promote/CMakeLists.txt
@@ -22,3 +22,5 @@ add_atsplugin(cache_promote
         lru_policy.cc
         policy_manager.cc
 )
+
+target_link_libraries(cache_promote PRIVATE OpenSSL::Crypto)

--- a/plugins/certifier/CMakeLists.txt
+++ b/plugins/certifier/CMakeLists.txt
@@ -16,3 +16,9 @@
 #######################
 
 add_atsplugin(certifier certifier.cc)
+
+target_link_libraries(certifier
+    PRIVATE
+        OpenSSL::Crypto
+        OpenSSL::SSL
+)

--- a/plugins/lua/CMakeLists.txt
+++ b/plugins/lua/CMakeLists.txt
@@ -49,4 +49,8 @@ add_atsplugin(tslua
 
 target_include_directories(tslua PRIVATE "${PROJECT_SOURCE_DIR}/include")
 
-target_link_libraries(tslua PRIVATE LuaJIT::LuaJIT)
+target_link_libraries(tslua
+    PRIVATE
+        LuaJIT::LuaJIT
+        OpenSSL::Crypto
+)

--- a/plugins/prefetch/CMakeLists.txt
+++ b/plugins/prefetch/CMakeLists.txt
@@ -30,6 +30,10 @@ add_atsplugin(prefetch
     plugin.cc
 )
 
-target_link_libraries(prefetch PRIVATE PCRE::PCRE)
+target_link_libraries(prefetch
+    PRIVATE
+        OpenSSL::Crypto
+        PCRE::PCRE
+)
 
 add_subdirectory(test)

--- a/plugins/s3_auth/CMakeLists.txt
+++ b/plugins/s3_auth/CMakeLists.txt
@@ -19,6 +19,6 @@ project(s3_auth)
 
 add_atsplugin(s3_auth s3_auth.cc aws_auth_v4.cc)
 
-target_link_libraries(s3_auth PRIVATE ts::tscore)
+target_link_libraries(s3_auth PRIVATE ts::tscore OpenSSL::Crypto)
 
 add_subdirectory(unit_tests)

--- a/plugins/s3_auth/unit_tests/CMakeLists.txt
+++ b/plugins/s3_auth/unit_tests/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(test_s3_auth
     "${PROJECT_SOURCE_DIR}/aws_auth_v4.cc"
 )
 
-target_link_libraries(test_s3_auth PRIVATE catch2::catch2)
+target_link_libraries(test_s3_auth PRIVATE catch2::catch2 OpenSSL::Crypto)
 
 target_compile_definitions(test_s3_auth PRIVATE AWS_AUTH_V4_UNIT_TEST)
 

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(http
         ${IOCORE_INCLUDE_DIRS}
         ${PROXY_INCLUDE_DIRS}
         ${YAMLCPP_INCLUDE_DIR}
+        OpenSSL::SSL
 )
 
 target_link_libraries(http PUBLIC ts::tscore)

--- a/src/traffic_layout/CMakeLists.txt
+++ b/src/traffic_layout/CMakeLists.txt
@@ -22,16 +22,11 @@ add_executable(traffic_layout
     traffic_layout.cc
 )
 
-target_include_directories(traffic_layout
-    PRIVATE
-        ${OPENSSL_INCLUDE_DIRS}
-)
-
 target_link_libraries(traffic_layout
     PRIVATE
         ts::inkevent
-        ${OPENSSL_LIBRARY}
         ts::records
+        OpenSSL::Crypto
         yaml-cpp::yaml-cpp
 )
 

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -115,7 +115,12 @@ else()
     target_sources(tscore PRIVATE HKDF_openssl.cc)
 endif()
 
-target_link_libraries(tscore PUBLIC PCRE::PCRE)
+target_link_libraries(tscore
+  PUBLIC
+    OpenSSL::Crypto
+    PCRE::PCRE
+)
+
 if(TS_USE_POSIX_CAP)
     target_link_libraries(tscore PUBLIC cap::cap)
 endif()
@@ -164,12 +169,12 @@ add_executable(test_tscore
 target_link_libraries(test_tscore
     PRIVATE
         libswoc
-        tscore
+        ts::tscore
         yaml-cpp::yaml-cpp
-        libswoc
-        ${OPENSSL_LIBRARIES}
         resolv
-        tscpputil
+        ts::tscpputil
+        OpenSSL::Crypto
+        OpenSSL::SSL
 )
 if(TS_USE_HWLOC)
     target_link_libraries(test_tscore PRIVATE hwloc::hwloc)

--- a/src/wccp/CMakeLists.txt
+++ b/src/wccp/CMakeLists.txt
@@ -20,6 +20,12 @@ add_library(wccp SHARED
 	WccpConfig.cc  WccpEndPoint.cc  WccpMsg.cc  WccpStatic.cc
 )
 
-target_link_libraries(wccp PRIVATE libswoc tscore yaml-cpp::yaml-cpp)
+target_link_libraries(wccp
+    PRIVATE
+        ts::tscore
+        libswoc
+        OpenSSL::Crypto
+        yaml-cpp::yaml-cpp
+)
 
 install(TARGETS wccp)

--- a/tests/gold_tests/chunked_encoding/CMakeLists.txt
+++ b/tests/gold_tests/chunked_encoding/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 add_executable(smuggle-client smuggle-client.c)
 
-target_link_libraries(smuggle-client PRIVATE "${OPENSSL_SSL_LIBRARY}")
+target_link_libraries(smuggle-client PRIVATE OpenSSL::SSL)
 
 set_property(
     TARGET smuggle-client


### PR DESCRIPTION
This removes the global dependency on OpenSSL libraries by specifying them per target. This avoids linking some targets against OpenSSL that do not need it and helps clean up the dependency tree.

![viz](https://github.com/apache/trafficserver/assets/41302989/2a5f2712-4c2a-4a7e-ae30-09f22a5d16db)
