### PR TITLE
Fix yaml-cpp dependency tree for CMake build

### DIFF
--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -113,8 +113,7 @@ target_include_directories(inknet PUBLIC
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/http/remap
         ${CMAKE_SOURCE_DIR}/src/traffic_server
-        ${YAML_INCLUDE_DIRS}
-        )
+)
 
 target_link_libraries(inknet
     PUBLIC
@@ -123,6 +122,8 @@ target_link_libraries(inknet
         ts::tscore
         OpenSSL::Crypto
         OpenSSL::SSL
+    PRIVATE
+        yaml-cpp::yaml-cpp
 )
 
 # Fails to link because of circular dep with proxy (ParentSelection)

--- a/proxy/http/remap/CMakeLists.txt
+++ b/proxy/http/remap/CMakeLists.txt
@@ -40,7 +40,11 @@ target_include_directories(http_remap PRIVATE
         ${IOCORE_INCLUDE_DIRS}
         ${PROXY_INCLUDE_DIRS}
         ${CMAKE_SOURCE_DIR}/src/records
-        ${YAML_INCLUDE_DIRS}
         )
 
-target_link_libraries(http_remap PUBLIC ts::tscore)
+target_link_libraries(http_remap
+    PUBLIC
+        ts::tscore
+    PRIVATE
+        yaml-cpp::yaml-cpp
+)

--- a/proxy/logging/CMakeLists.txt
+++ b/proxy/logging/CMakeLists.txt
@@ -37,8 +37,11 @@ add_library(ts::logging ALIAS logging)
 target_include_directories(logging PRIVATE
         ${IOCORE_INCLUDE_DIRS}
         ${PROXY_INCLUDE_DIRS}
-        ${YAML_INCLUDE_DIRS}
         ${SWOC_INCLUDE_DIR}
 )
 
-target_link_libraries(logging PUBLIC ts::tscore)
+target_link_libraries(logging
+    PUBLIC
+        ts::tscore
+        yaml-cpp::yaml-cpp
+)

--- a/src/records/CMakeLists.txt
+++ b/src/records/CMakeLists.txt
@@ -41,4 +41,8 @@ target_include_directories(records
         "${CMAKE_SOURCE_DIR}/iocore/utils"
 )
 
-target_link_libraries(records PUBLIC ts::tscore)
+target_link_libraries(records
+    PUBLIC
+        ts::tscore
+        yaml-cpp::yaml-cpp
+)

--- a/src/traffic_ctl/CMakeLists.txt
+++ b/src/traffic_ctl/CMakeLists.txt
@@ -29,9 +29,9 @@ target_include_directories(traffic_ctl PRIVATE
         ${CMAKE_SOURCE_DIR}/mgmt
         )
 target_link_libraries(traffic_ctl
-        tscore
-        yaml-cpp
+        ts::tscore
         libswoc
-        )
+        yaml-cpp::yaml-cpp
+)
 
 install(TARGETS traffic_ctl)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -116,9 +116,11 @@ else()
 endif()
 
 target_link_libraries(tscore
-  PUBLIC
-    OpenSSL::Crypto
-    PCRE::PCRE
+    PUBLIC
+        OpenSSL::Crypto
+        PCRE::PCRE
+    PRIVATE
+        yaml-cpp::yaml-cpp
 )
 
 if(TS_USE_POSIX_CAP)
@@ -128,7 +130,6 @@ endif()
 add_dependencies(tscore ParseRules)
 target_include_directories(tscore PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}
-        ${YAML_INCLUDE_DIRS}
 )
 if(TS_HAS_128BIT_CAS AND TS_NEEDS_MCX16_FOR_CAS)
     target_compile_options(tscore PUBLIC "-mcx16")


### PR DESCRIPTION
This declares yaml-cpp dependencies where they belong and resolves a "# transitive" dependency on inkevent.

![viz](https://github.com/apache/trafficserver/assets/41302989/2722c08c-5c18-4ea5-a77e-980b785a0af1)
