### PR TITLE
Fix inkevent dependency tree for CMake build

### DIFF
--- a/iocore/aio/CMakeLists.txt
+++ b/iocore/aio/CMakeLists.txt
@@ -20,6 +20,10 @@ add_library(aio STATIC)
 add_library(ts::aio ALIAS aio)
 
 target_sources(aio PRIVATE AIO.cc Inline.cc)
-target_include_directories(aio PRIVATE ${CMAKE_SOURCE_DIR}/iocore/eventsystem ${CMAKE_SOURCE_DIR}/iocore/io_uring)
+target_include_directories(aio PRIVATE ${CMAKE_SOURCE_DIR}/iocore/io_uring)
 
-target_link_libraries(aio PUBLIC ts::tscore)
+target_link_libraries(aio
+    PUBLIC
+        ts::inkevent
+        ts::tscore
+)

--- a/iocore/cache/CMakeLists.txt
+++ b/iocore/cache/CMakeLists.txt
@@ -38,7 +38,6 @@ if(BUILD_REGRESSION_TESTING)
 endif()
 
 target_include_directories(inkcache PRIVATE
-        ${CMAKE_SOURCE_DIR}/iocore/eventsystem
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/aio
@@ -54,6 +53,7 @@ target_include_directories(inkcache PRIVATE
 
 target_link_libraries(inkcache
     PUBLIC
+        ts::inkevent
         ts::tscore
     PRIVATE
         fastlz

--- a/iocore/dns/CMakeLists.txt
+++ b/iocore/dns/CMakeLists.txt
@@ -25,7 +25,6 @@ add_library(inkdns STATIC
 add_library(ts::inkdns ALIAS inkdns)
 
 target_include_directories(inkdns PRIVATE
-        ${CMAKE_SOURCE_DIR}/iocore/eventsystem
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/aio
@@ -37,4 +36,8 @@ target_include_directories(inkdns PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
 
-target_link_libraries(inkdns PUBLIC ts::tscore)
+target_link_libraries(inkdns
+    PUBLIC
+        ts::inkevent
+        ts::tscore
+)

--- a/iocore/hostdb/CMakeLists.txt
+++ b/iocore/hostdb/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(inkhostdb STATIC
 add_library(ts::inkhostdb ALIAS inkhostdb)
 
 target_include_directories(inkhostdb PRIVATE
-        ${CMAKE_SOURCE_DIR}/iocore/eventsystem
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/aio
@@ -38,4 +37,8 @@ target_include_directories(inkhostdb PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
 
-target_link_libraries(inkhostdb PUBLIC ts::tscore)
+target_link_libraries(inkhostdb
+    PUBLIC
+        ts::inkevent
+        ts::tscore
+)

--- a/iocore/io_uring/CMakeLists.txt
+++ b/iocore/io_uring/CMakeLists.txt
@@ -19,7 +19,6 @@ add_library(inkuring STATIC
         io_uring.cc
 )
 include_directories(
-        ${CMAKE_SOURCE_DIR}/iocore/eventsystem
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/aio
         ${CMAKE_SOURCE_DIR}/iocore/io_uring

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -100,7 +100,6 @@ endif()
 
 target_compile_options(inknet PUBLIC -Wno-deprecated-declarations)
 target_include_directories(inknet PUBLIC
-        ${CMAKE_SOURCE_DIR}/iocore/eventsystem
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/aio

--- a/iocore/net/quic/CMakeLists.txt
+++ b/iocore/net/quic/CMakeLists.txt
@@ -37,10 +37,10 @@ target_include_directories(quic PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 target_link_libraries(quic
     PUBLIC
-        inkevent
-        inknet
-        quiche::quiche
+        ts::inkevent
+        ts::inknet
         ts::tscore
         OpenSSL::Crypto
         OpenSSL::SSL
+        quiche::quiche
 )

--- a/iocore/utils/CMakeLists.txt
+++ b/iocore/utils/CMakeLists.txt
@@ -21,7 +21,6 @@ add_library(ts::inkutils ALIAS inkutils)
 
 
 target_include_directories(inkutils PRIVATE
-        ${CMAKE_SOURCE_DIR}/iocore/eventsystem
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/aio
         ${CMAKE_SOURCE_DIR}/iocore/net
@@ -32,4 +31,8 @@ target_include_directories(inkutils PRIVATE
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
         )
 
-target_link_libraries(inkutils PUBLIC ts::tscore)
+target_link_libraries(inkutils
+    PUBLIC
+        ts::inkevent
+        ts::tscore
+)

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -58,7 +58,11 @@ target_include_directories(proxy PUBLIC
         ${CMAKE_SOURCE_DIR}/lib/yamlcpp/include
         )
 
-target_link_libraries(proxy PUBLIC ts::tscore)
+target_link_libraries(proxy
+    PUBLIC
+        ts::inkevent
+        ts::tscore
+)
 
 add_subdirectory(hdrs)
 add_subdirectory(shared)

--- a/proxy/hdrs/CMakeLists.txt
+++ b/proxy/hdrs/CMakeLists.txt
@@ -42,4 +42,6 @@ target_link_libraries(hdrs
     PUBLIC
         libswoc
         ts::tscore
+    PRIVATE
+        ts::inkevent
 )

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -57,7 +57,11 @@ target_include_directories(http
         OpenSSL::SSL
 )
 
-target_link_libraries(http PUBLIC ts::tscore)
+target_link_libraries(http
+    PUBLIC
+        ts::inkevent
+        ts::tscore
+)
 
 if(TS_USE_QUIC)
     target_link_libraries(http PRIVATE ts::http3)

--- a/proxy/http/remap/CMakeLists.txt
+++ b/proxy/http/remap/CMakeLists.txt
@@ -46,5 +46,6 @@ target_link_libraries(http_remap
     PUBLIC
         ts::tscore
     PRIVATE
+        ts::inkevent
         yaml-cpp::yaml-cpp
 )

--- a/proxy/http2/CMakeLists.txt
+++ b/proxy/http2/CMakeLists.txt
@@ -37,4 +37,8 @@ target_include_directories(http2 PRIVATE
         ${YAMLCPP_INCLUDE_DIR}
 )
 
-target_link_libraries(http2 PUBLIC ts::tscore)
+target_link_libraries(http2
+    PUBLIC
+        ts::inkevent
+        ts::tscore
+)

--- a/proxy/logging/CMakeLists.txt
+++ b/proxy/logging/CMakeLists.txt
@@ -42,6 +42,7 @@ target_include_directories(logging PRIVATE
 
 target_link_libraries(logging
     PUBLIC
+        ts::inkevent
         ts::tscore
         yaml-cpp::yaml-cpp
 )

--- a/src/records/CMakeLists.txt
+++ b/src/records/CMakeLists.txt
@@ -35,7 +35,6 @@ add_library(ts::records ALIAS records)
 target_include_directories(records
     PUBLIC
         "${PROJECT_SOURCE_DIR}/include"
-        "${CMAKE_SOURCE_DIR}/iocore/eventsystem"
     PRIVATE
         "${CMAKE_SOURCE_DIR}/mgmt"
         "${CMAKE_SOURCE_DIR}/iocore/utils"
@@ -43,6 +42,7 @@ target_include_directories(records
 
 target_link_libraries(records
     PUBLIC
+        ts::inkevent
         ts::tscore
         yaml-cpp::yaml-cpp
 )

--- a/src/traffic_crashlog/CMakeLists.txt
+++ b/src/traffic_crashlog/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(traffic_crashlog procinfo.cc traffic_crashlog.cc)
 
 target_link_libraries(traffic_crashlog
     PRIVATE
-        ts::inkevent # transitive
+        ts::inkevent
         ts::records
         ts::tscore
 )


### PR DESCRIPTION
This declares an explicit dependency on inkevent for all its direct dependents, and removes redundant includes. IOCORE_INCLUDE_DIRS is left untouched, because some targets have transitive dependencies on inkevent, but don't have the usage requirement on the direct dependency declared.
![viz](https://github.com/apache/trafficserver/assets/41302989/67befa04-c552-4447-af84-c02f6c635d02)
