### PR TITLE
Fix inkaio/cache/hostdb dependency tree for CMake

### DIFF
--- a/iocore/aio/CMakeLists.txt
+++ b/iocore/aio/CMakeLists.txt
@@ -20,7 +20,12 @@ add_library(aio STATIC)
 add_library(ts::aio ALIAS aio)
 
 target_sources(aio PRIVATE AIO.cc Inline.cc)
-target_include_directories(aio PRIVATE ${CMAKE_SOURCE_DIR}/iocore/io_uring)
+target_include_directories(aio
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/iocore/io_uring
+)
 
 target_link_libraries(aio
     PUBLIC

--- a/iocore/cache/CMakeLists.txt
+++ b/iocore/cache/CMakeLists.txt
@@ -35,14 +35,16 @@ add_library(ts::inkcache ALIAS inkcache)
 
 if(BUILD_REGRESSION_TESTING)
     target_sources(inkcache PRIVATE CacheTest.cc)
+    target_link_libraries(inkcache PRIVATE ts::proxy)
 endif()
 
-target_include_directories(inkcache PRIVATE
+target_include_directories(inkcache
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/iocore/cache
+    PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/dns
-        ${CMAKE_SOURCE_DIR}/iocore/aio
         ${CMAKE_SOURCE_DIR}/iocore/net
-        ${CMAKE_SOURCE_DIR}/iocore/cache
         ${CMAKE_SOURCE_DIR}/iocore/hostdb
         ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http
@@ -53,6 +55,7 @@ target_include_directories(inkcache PRIVATE
 
 target_link_libraries(inkcache
     PUBLIC
+        ts::aio
         ts::inkevent
         ts::tscore
     PRIVATE

--- a/iocore/dns/CMakeLists.txt
+++ b/iocore/dns/CMakeLists.txt
@@ -27,10 +27,7 @@ add_library(ts::inkdns ALIAS inkdns)
 target_include_directories(inkdns PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
-        ${CMAKE_SOURCE_DIR}/iocore/aio
         ${CMAKE_SOURCE_DIR}/iocore/net
-        ${CMAKE_SOURCE_DIR}/iocore/cache
-        ${CMAKE_SOURCE_DIR}/iocore/hostdb
         ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
@@ -38,6 +35,8 @@ target_include_directories(inkdns PRIVATE
 
 target_link_libraries(inkdns
     PUBLIC
+        ts::inkcache
         ts::inkevent
+        ts::inkhostdb
         ts::tscore
 )

--- a/iocore/hostdb/CMakeLists.txt
+++ b/iocore/hostdb/CMakeLists.txt
@@ -25,13 +25,13 @@ add_library(inkhostdb STATIC
 )
 add_library(ts::inkhostdb ALIAS inkhostdb)
 
-target_include_directories(inkhostdb PRIVATE
+target_include_directories(inkhostdb
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/iocore/hostdb
+    PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/dns
-        ${CMAKE_SOURCE_DIR}/iocore/aio
         ${CMAKE_SOURCE_DIR}/iocore/net
-        ${CMAKE_SOURCE_DIR}/iocore/cache
-        ${CMAKE_SOURCE_DIR}/iocore/hostdb
         ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
@@ -39,6 +39,7 @@ target_include_directories(inkhostdb PRIVATE
 
 target_link_libraries(inkhostdb
     PUBLIC
+        ts::inkcache
         ts::inkevent
         ts::tscore
 )

--- a/iocore/io_uring/CMakeLists.txt
+++ b/iocore/io_uring/CMakeLists.txt
@@ -20,11 +20,9 @@ add_library(inkuring STATIC
 )
 include_directories(
         ${CMAKE_SOURCE_DIR}/iocore/dns
-        ${CMAKE_SOURCE_DIR}/iocore/aio
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/net
         ${CMAKE_SOURCE_DIR}/iocore/cache
-        ${CMAKE_SOURCE_DIR}/iocore/hostdb
 )
 
 add_executable(test_iouring

--- a/iocore/utils/CMakeLists.txt
+++ b/iocore/utils/CMakeLists.txt
@@ -22,9 +22,7 @@ add_library(ts::inkutils ALIAS inkutils)
 
 target_include_directories(inkutils PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/dns
-        ${CMAKE_SOURCE_DIR}/iocore/aio
         ${CMAKE_SOURCE_DIR}/iocore/net
-        ${CMAKE_SOURCE_DIR}/iocore/cache
         ${CMAKE_SOURCE_DIR}/iocore/hostdb
         ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http

--- a/mgmt/rpc/CMakeLists.txt
+++ b/mgmt/rpc/CMakeLists.txt
@@ -55,4 +55,9 @@ add_library(rpcpublichandlers STATIC
 )
 add_library(ts::rpcpublichandlers ALIAS rpcpublichandlers)
 
-target_link_libraries(rpcpublichandlers PUBLIC ts::tscore)
+target_link_libraries(rpcpublichandlers
+    PUBLIC
+        ts::tscore
+    PRIVATE
+        ts::inkcache
+)

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -60,8 +60,11 @@ target_include_directories(proxy PUBLIC
 
 target_link_libraries(proxy
     PUBLIC
+        ts::inkcache
         ts::inkevent
         ts::tscore
+    PRIVATE
+        ts::inkutils
 )
 
 add_subdirectory(hdrs)

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -60,7 +60,11 @@ target_include_directories(http
 target_link_libraries(http
     PUBLIC
         ts::inkevent
+        ts::inkhostdb
         ts::tscore
+    PRIVATE
+        ts::inkcache
+        ts::inkutils
 )
 
 if(TS_USE_QUIC)

--- a/proxy/http/remap/CMakeLists.txt
+++ b/proxy/http/remap/CMakeLists.txt
@@ -47,5 +47,6 @@ target_link_libraries(http_remap
         ts::tscore
     PRIVATE
         ts::inkevent
+        ts::inkutils
         yaml-cpp::yaml-cpp
 )

--- a/proxy/http/unit_tests/CMakeLists.txt
+++ b/proxy/http/unit_tests/CMakeLists.txt
@@ -36,17 +36,11 @@ target_link_libraries(test_http
         catch2::catch2
         ts::http
         ts::hdrs # transitive
-        ts::inkutils # transitive
-        inkcache # transitive
-        inkhostdb # transitive
         logging # transitive
-        ts::inkevent # transitive
         ts::proxy # transitive
         http_remap # transitive
         ts::proxy # transitive
-        aio # transitive
         inkdns # transitive
-        fastlz # transitive
         ts::inknet
 )
 

--- a/proxy/http2/CMakeLists.txt
+++ b/proxy/http2/CMakeLists.txt
@@ -41,4 +41,6 @@ target_link_libraries(http2
     PUBLIC
         ts::inkevent
         ts::tscore
+    PRIVATE
+        ts::inkutils
 )

--- a/proxy/logging/CMakeLists.txt
+++ b/proxy/logging/CMakeLists.txt
@@ -43,6 +43,7 @@ target_include_directories(logging PRIVATE
 target_link_libraries(logging
     PUBLIC
         ts::inkevent
+        ts::inkutils
         ts::tscore
         yaml-cpp::yaml-cpp
 )


### PR DESCRIPTION
This corrects the dependency tree for inkaio, inkcache, and inkhostdb and removes some # transitive dependencies from targets.
![viz](https://github.com/apache/trafficserver/assets/41302989/2405c130-2c38-45db-8002-4e8795dce04e)
