### PR TITLE
ASan: Fix alloc-dealloc-mismatch of test_HostFile

### DIFF
--- a/iocore/hostdb/test_HostFile.cc
+++ b/iocore/hostdb/test_HostFile.cc
@@ -175,5 +175,5 @@ HostDBRecord::alloc(swoc::TextView query_name, unsigned int rr_count, size_t srv
 void
 HostDBRecord::free()
 {
-  delete this;
+  std::free(this);
 }


### PR DESCRIPTION
Fix for the `rockylinux:8 clang release asan` job.
```
FAIL: test_HostFile
===================

=================================================================
==54435==ERROR: AddressSanitizer: alloc-dealloc-mismatch (malloc vs operator delete) on 0x60c0000007c0
    #0 0x565328  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x565328) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #1 0x70c940  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x70c940) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #2 0x62698a  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x62698a) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #3 0x5bbfdb  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5bbfdb) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #4 0x5b929d  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5b929d) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #5 0x5cd30a  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5cd30a) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #6 0x5ca2a5  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5ca2a5) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #7 0x61f42d  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x61f42d) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #8 0x7f0403648d84  (/lib64/libc.so.6+0x3ad84) (BuildId: 31f2a86084da882dfe4ecc1fe2a9eca8ce9416fd)
    #9 0x4709fd  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x4709fd) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)

0x60c0000007c0 is located 0 bytes inside of 120-byte region [0x60c0000007c0,0x60c000000838)
allocated by thread T0 here:
    #0 0x5153c8  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5153c8) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #1 0x629cf1  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x629cf1) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #2 0x707a80  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x707a80) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #3 0x620156  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x620156) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #4 0x5bbfdb  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5bbfdb) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #5 0x5b929d  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5b929d) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #6 0x5cd30a  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5cd30a) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #7 0x5ca2a5  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x5ca2a5) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #8 0x61f42d  (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x61f42d) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5)
    #9 0x7f0403648d84  (/lib64/libc.so.6+0x3ad84) (BuildId: 31f2a86084da882dfe4ecc1fe2a9eca8ce9416fd)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/home/jenkins/workspace/master/os_build/src/iocore/hostdb/.libs/lt-test_HostFile+0x565328) (BuildId: b4762282b88e37acdbeccc7a51eb2db07c5884b5) 
==54435==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==54435==ABORTING
FAIL test_HostFile (exit status: 1)
```
https://ci.trafficserver.apache.org/job/master/job/os_build/18949/console