### PR TITLE
Fix proxy dependency tree in CMake build

### DIFF
--- a/iocore/cache/CMakeLists.txt
+++ b/iocore/cache/CMakeLists.txt
@@ -46,7 +46,6 @@ target_include_directories(inkcache
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/net
         ${CMAKE_SOURCE_DIR}/iocore/hostdb
-        ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/http/remap
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
@@ -59,6 +58,7 @@ target_link_libraries(inkcache
         ts::inkevent
         ts::tscore
     PRIVATE
+        ts::proxy
         fastlz
         ZLIB::ZLIB
 )

--- a/iocore/dns/CMakeLists.txt
+++ b/iocore/dns/CMakeLists.txt
@@ -28,7 +28,6 @@ target_include_directories(inkdns PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/net
-        ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
@@ -38,5 +37,6 @@ target_link_libraries(inkdns
         ts::inkcache
         ts::inkevent
         ts::inkhostdb
+        ts::proxy
         ts::tscore
 )

--- a/iocore/hostdb/CMakeLists.txt
+++ b/iocore/hostdb/CMakeLists.txt
@@ -32,7 +32,6 @@ target_include_directories(inkhostdb
         ${CMAKE_SOURCE_DIR}/iocore/io_uring
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/net
-        ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
 )
@@ -42,4 +41,6 @@ target_link_libraries(inkhostdb
         ts::inkcache
         ts::inkevent
         ts::tscore
+    PRIVATE
+        ts::proxy
 )

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -106,7 +106,6 @@ target_include_directories(inknet PUBLIC
         ${CMAKE_SOURCE_DIR}/iocore/net
         ${CMAKE_SOURCE_DIR}/iocore/cache
         ${CMAKE_SOURCE_DIR}/iocore/hostdb
-        ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
         ${CMAKE_SOURCE_DIR}/proxy/shared
         ${CMAKE_SOURCE_DIR}/proxy/http
@@ -117,6 +116,7 @@ target_include_directories(inknet PUBLIC
 target_link_libraries(inknet
     PUBLIC
         ts::inkevent
+        ts::proxy
         ts::records
         ts::tscore
         OpenSSL::Crypto

--- a/iocore/utils/CMakeLists.txt
+++ b/iocore/utils/CMakeLists.txt
@@ -24,7 +24,6 @@ target_include_directories(inkutils PRIVATE
         ${CMAKE_SOURCE_DIR}/iocore/dns
         ${CMAKE_SOURCE_DIR}/iocore/net
         ${CMAKE_SOURCE_DIR}/iocore/hostdb
-        ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
         )

--- a/mgmt/config/CMakeLists.txt
+++ b/mgmt/config/CMakeLists.txt
@@ -23,10 +23,14 @@ add_library(ts::configmanager ALIAS configmanager)
 
 include_directories(
         ${CMAKE_SOURCE_DIR}/mgmt
-        ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
         ${CMAKE_SOURCE_DIR}/proxy/http
         ${IOCORE_INCLUDE_DIRS}
 )
 
-target_link_libraries(configmanager PUBLIC ts::tscore)
+target_link_libraries(configmanager
+    PUBLIC
+        ts::tscore
+    PRIVATE
+        ts::proxy
+)

--- a/mgmt/rpc/CMakeLists.txt
+++ b/mgmt/rpc/CMakeLists.txt
@@ -20,7 +20,6 @@ include_directories(
         ${CMAKE_SOURCE_DIR}/mgmt/rpc
         ${IOCORE_INCLUDE_DIRS}
         ${CMAKE_SOURCE_DIR}/lib
-        ${CMAKE_SOURCE_DIR}/proxy
         ${CMAKE_SOURCE_DIR}/proxy/hdrs
         ${CMAKE_SOURCE_DIR}/proxy/http
 
@@ -60,4 +59,5 @@ target_link_libraries(rpcpublichandlers
         ts::tscore
     PRIVATE
         ts::inkcache
+        ts::proxy
 )

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(http
     PUBLIC
         ts::inkevent
         ts::inkhostdb
+        ts::proxy
         ts::tscore
     PRIVATE
         ts::inkcache

--- a/proxy/http/remap/CMakeLists.txt
+++ b/proxy/http/remap/CMakeLists.txt
@@ -44,6 +44,7 @@ target_include_directories(http_remap PRIVATE
 
 target_link_libraries(http_remap
     PUBLIC
+        ts::proxy
         ts::tscore
     PRIVATE
         ts::inkevent

--- a/proxy/http/unit_tests/CMakeLists.txt
+++ b/proxy/http/unit_tests/CMakeLists.txt
@@ -37,9 +37,8 @@ target_link_libraries(test_http
         ts::http
         ts::hdrs # transitive
         logging # transitive
-        ts::proxy # transitive
         http_remap # transitive
-        ts::proxy # transitive
+        ts::proxy
         inkdns # transitive
         ts::inknet
 )

--- a/proxy/http2/CMakeLists.txt
+++ b/proxy/http2/CMakeLists.txt
@@ -40,6 +40,7 @@ target_include_directories(http2 PRIVATE
 target_link_libraries(http2
     PUBLIC
         ts::inkevent
+        ts::proxy
         ts::tscore
     PRIVATE
         ts::inkutils

--- a/proxy/logging/CMakeLists.txt
+++ b/proxy/logging/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(logging
     PUBLIC
         ts::inkevent
         ts::inkutils
+        ts::proxy
         ts::tscore
         yaml-cpp::yaml-cpp
 )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ macro(add_cache_test name)
             ${CMAKE_SOURCE_DIR}/iocore/cache/test/stub.cc
             ${CMAKE_SOURCE_DIR}/iocore/cache/test/CacheTestHandler.cc
             ${ARGN})
+    target_link_libraries(${name} PRIVATE ts::proxy)
     add_test(NAME test_cache_${name} COMMAND $<TARGET_FILE:${name}>)
 endmacro()
 
@@ -71,6 +72,7 @@ macro(add_net_test name)
     add_executable(${name}
             ${CMAKE_SOURCE_DIR}/iocore/net/libinknet_stub.cc
             ${ARGN})
+    target_link_libraries(${name} PRIVATE ts::proxy)
     add_test(NAME test_cache_${name} COMMAND $<TARGET_FILE:${name}>)
 endmacro()
 
@@ -78,6 +80,7 @@ macro(add_stubbed_test name)
     add_executable(${name}
             ${CMAKE_SOURCE_DIR}/iocore/cache/test/stub.cc
             ${ARGN})
+    target_link_libraries(${name} PRIVATE ts::proxy)
     add_test(NAME test_stubbed_${name} COMMAND $<TARGET_FILE:${name}>)
 endmacro()
 


### PR DESCRIPTION
![viz](https://github.com/apache/trafficserver/assets/41302989/d02c450d-b82a-4e28-878e-95f7735524ce)
