### PR TITLE
Several fixes around the H3 and QUICHE build.

### DIFF
--- a/iocore/net/quic/Makefile.am
+++ b/iocore/net/quic/Makefile.am
@@ -62,6 +62,8 @@ test_MTHashTable_LDADD = \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.a \
 	$(top_builddir)/src/tscpp/util/libtscpputil.la \
+	$(LIBPCRE) \
+	$(LIBCAP) \
 	@SWOC_LIBS@ @OPENSSL_LIBS@
 
 test_MTHashTable_SOURCES = test_MTHashTable.cc

--- a/m4/quiche.m4
+++ b/m4/quiche.m4
@@ -58,7 +58,7 @@ if test "$has_quiche" != "0"; then
   quiche_have_libs=0
   if test "$quiche_base_dir" != "/usr"; then
     TS_ADDTO(CPPFLAGS, [-I${quiche_include}])
-    TS_ADDTO(LDFLAGS, [-L${quiche_ldflags} -rpath ${quiche_ldflags}])
+    TS_ADDTO(LDFLAGS, [-L${quiche_ldflags} -Wl,-rpath,${quiche_ldflags}])
     TS_ADDTO(LIBS, [-lquiche])
     TS_ADDTO_RPATH(${quiche_ldflags})
   fi

--- a/proxy/http3/Makefile.am
+++ b/proxy/http3/Makefile.am
@@ -72,10 +72,11 @@ test_LDADD = \
   $(top_builddir)/iocore/net/TLSKeyLogger.o \
   $(top_builddir)/iocore/eventsystem/libinkevent.a \
   $(top_builddir)/src/records/librecords_p.a \
-  $(top_builddir)/src/tscore/libtscore.a \
   $(top_builddir)/src/tscpp/util/libtscpputil.la \
   $(top_builddir)/proxy/hdrs/libhdrs.a \
-  @LIBPCRE@ \
+  $(top_builddir)/src/tscore/libtscore.a \
+	@LIBPCRE@ \
+	@LIBCAP@ \
   @OPENSSL_LIBS@ \
   @HWLOC_LIBS@ @SWOC_LIBS@
 

--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -143,6 +143,11 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone --recursive https://github.com/cloudflare/quiche.git
 cd quiche
+# Latest quiche commits breaks our code so we build from the last commit
+# we know it works, in this case this commit includes the rpath fix commit
+# for quiche. https://github.com/cloudflare/quiche/pull/1508
+# Why does the latest break our code? -> https://github.com/cloudflare/quiche/pull/1537
+git checkout a1b212761c6cc0b77b9121cdc313e507daf6deb3
 QUICHE_BSSL_PATH=${QUICHE_BSSL_PATH} QUICHE_BSSL_LINK_KIND=dylib cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
 sudo mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 sudo mkdir -p ${QUICHE_BASE}/include


### PR DESCRIPTION
This PR tackles a few issues:

1 - ATS wasn't built with quiche. (TS_HAS_QUICHE=0)

Fixing the `rpath`  in the  `quiche.m4` solves this issue as the autoconf now successfully detects quiche, so it does define the macro we need.

2 - Build with the latest quiche.
This was a problem because quiche introduced [this](https://github.com/cloudflare/quiche/pull/1537) change which was incompatible with our code.

**This is a short term solution, the proper fix is to update our code to the latest API** This is tracked [here](https://github.com/apache/trafficserver/issues/9800)


```bash
Environment config finished. Running AuTest...
Running Test qlog_quiche:..... Passed
Running Test quic_no_activity_timeout:... Passed
Running Test quic_poll_timeout:.. Passed

Generating Report: --------------
Total of 3 test
  Unknown: 0
  Exception: 0
  Failed: 0
  Warning: 0
  Skipped: 0
  Passed: 3

```

3 - There were few issues when building h3 related to the new libtscore archive. 