### PR TITLE
Allow configurable number of accepts per event loop

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -479,12 +479,14 @@ Network
 .. ts:cv:: CONFIG proxy.config.net.additional_accepts INT -1
    :reloadable:
 
-   The maximum number of additional accepts a thread can complete per event loop. When
-   set to -1, a thread will accept connections as long as there are connections
-   waiting in its listening queue. When set to 0, a thread accepts only 1 connection
-   per event loop. When set to any other positive integer x, a thread will
-   accept up to x+1 connections per event loop. Setting to -1 (default) is equivalent
-   to "accept all", and setting to 0 is equivalent to "accept one".
+   This config addresses an issue that can sometimes happen if threads are caught in
+   a net accept while loop, become busy exclusviely accepting connections, and are prevented
+   from doing other work. This can cause an increase in latency and average event
+   loop time. When set to 0, a thread accepts only 1 connection per event loop.
+   When set to any other positive integer x, a thread will accept up to x+1 connections
+   per event loop. When set to -1 (default), a thread will accept connections as long
+   as there are connections waiting in its listening queue.is equivalent to "accept all",
+   and setting to 0 is equivalent to "accept one".
 
 .. ts:cv:: CONFIG proxy.config.net.connections_throttle INT 30000
 

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -476,6 +476,16 @@ Thread Variables
 Network
 =======
 
+.. ts:cv:: CONFIG proxy.config.net.additional_accepts INT -1
+   :reloadable:
+
+   The maximum number of additional accepts a thread can complete per event loop. When
+   set to -1, a thread will accept connections as long as there are connections
+   waiting in its listening queue. When set to 0, a thread accepts only 1 connection
+   per event loop. When set to any other positive integer x, a thread will 
+   accept up to x+1 connections per event loop. Setting to -1 (default) is equivalent
+   to "accept all", and setting to 0 is equivalent to "accept one". 
+
 .. ts:cv:: CONFIG proxy.config.net.connections_throttle INT 30000
 
    The total number of client and origin server connections that the server

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -484,7 +484,7 @@ Network
    waiting in its listening queue. When set to 0, a thread accepts only 1 connection
    per event loop. When set to any other positive integer x, a thread will 
    accept up to x+1 connections per event loop. Setting to -1 (default) is equivalent
-   to "accept all", and setting to 0 is equivalent to "accept one". 
+   to "accept all", and setting to 0 is equivalent to "accept one".
 
 .. ts:cv:: CONFIG proxy.config.net.connections_throttle INT 30000
 

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -482,7 +482,7 @@ Network
    The maximum number of additional accepts a thread can complete per event loop. When
    set to -1, a thread will accept connections as long as there are connections
    waiting in its listening queue. When set to 0, a thread accepts only 1 connection
-   per event loop. When set to any other positive integer x, a thread will 
+   per event loop. When set to any other positive integer x, a thread will
    accept up to x+1 connections per event loop. Setting to -1 (default) is equivalent
    to "accept all", and setting to 0 is equivalent to "accept one".
 

--- a/doc/appendices/command-line/traffic_server.en.rst
+++ b/doc/appendices/command-line/traffic_server.en.rst
@@ -32,8 +32,6 @@ Options
 
 .. option:: -a, --accepts_thread
 
-.. option:: -b, --accept_till_done
-
 .. option:: -B TAGS, --action_tags TAGS
 
 .. option:: --bind_stdout FILE

--- a/iocore/net/NetHandler.cc
+++ b/iocore/net/NetHandler.cc
@@ -576,3 +576,10 @@ NetHandler::remove_from_active_queue(NetEvent *ne)
     --active_queue_size;
   }
 }
+
+int
+NetHandler::get_additional_accepts()
+{
+  int config_value = config.additional_accepts + 1;
+  return (config_value > 0 ? config_value : INT32_MAX - 1);
+}

--- a/iocore/net/NetHandler.cc
+++ b/iocore/net/NetHandler.cc
@@ -131,6 +131,9 @@ NetHandler::update_nethandler_config(const char *str, RecDataT, RecData data, vo
   } else if (name == "proxy.config.net.default_inactivity_timeout"sv) {
     updated_member = &NetHandler::global_config.default_inactivity_timeout;
     Debug("net_queue", "proxy.config.net.default_inactivity_timeout updated to %" PRId64, data.rec_int);
+  } else if (name == "proxy.config.net.additional_accepts"sv) {
+    updated_member = &NetHandler::global_config.additional_accepts;
+    Debug("net_queue", "proxy.config.net.additional_accepts updated to %" PRId64, data.rec_int);
   }
 
   if (updated_member) {
@@ -166,6 +169,7 @@ NetHandler::init_for_process()
   REC_ReadConfigInt32(global_config.transaction_no_activity_timeout_in, "proxy.config.net.transaction_no_activity_timeout_in");
   REC_ReadConfigInt32(global_config.keep_alive_no_activity_timeout_in, "proxy.config.net.keep_alive_no_activity_timeout_in");
   REC_ReadConfigInt32(global_config.default_inactivity_timeout, "proxy.config.net.default_inactivity_timeout");
+  REC_ReadConfigInt32(global_config.additional_accepts, "proxy.config.net.additional_accepts");
 
   RecRegisterConfigUpdateCb("proxy.config.net.max_connections_in", update_nethandler_config, nullptr);
   RecRegisterConfigUpdateCb("proxy.config.net.max_requests_in", update_nethandler_config, nullptr);
@@ -173,6 +177,7 @@ NetHandler::init_for_process()
   RecRegisterConfigUpdateCb("proxy.config.net.transaction_no_activity_timeout_in", update_nethandler_config, nullptr);
   RecRegisterConfigUpdateCb("proxy.config.net.keep_alive_no_activity_timeout_in", update_nethandler_config, nullptr);
   RecRegisterConfigUpdateCb("proxy.config.net.default_inactivity_timeout", update_nethandler_config, nullptr);
+  RecRegisterConfigUpdateCb("proxy.config.net.additional_accepts", update_nethandler_config, nullptr);
 
   Debug("net_queue", "proxy.config.net.max_connections_in updated to %d", global_config.max_connections_in);
   Debug("net_queue", "proxy.config.net.max_requests_in updated to %d", global_config.max_requests_in);
@@ -182,6 +187,7 @@ NetHandler::init_for_process()
   Debug("net_queue", "proxy.config.net.keep_alive_no_activity_timeout_in updated to %d",
         global_config.keep_alive_no_activity_timeout_in);
   Debug("net_queue", "proxy.config.net.default_inactivity_timeout updated to %d", global_config.default_inactivity_timeout);
+  Debug("net_queue", "proxy.config.net.additional_accepts updated to %d", global_config.additional_accepts);
 }
 
 //

--- a/iocore/net/NetHandler.h
+++ b/iocore/net/NetHandler.h
@@ -165,6 +165,7 @@ public:
   void remove_from_keep_alive_queue(NetEvent *ne);
   bool add_to_active_queue(NetEvent *ne);
   void remove_from_active_queue(NetEvent *ne);
+  int get_additional_accepts();
 
   /// Per process initialization logic.
   static void init_for_process();

--- a/iocore/net/NetHandler.h
+++ b/iocore/net/NetHandler.h
@@ -115,6 +115,7 @@ public:
     uint32_t transaction_no_activity_timeout_in = 0;
     uint32_t keep_alive_no_activity_timeout_in  = 0;
     uint32_t default_inactivity_timeout         = 0;
+    uint32_t additional_accepts = 0;
 
     /** Return the address of the first value in this struct.
 

--- a/iocore/net/NetHandler.h
+++ b/iocore/net/NetHandler.h
@@ -115,7 +115,7 @@ public:
     uint32_t transaction_no_activity_timeout_in = 0;
     uint32_t keep_alive_no_activity_timeout_in  = 0;
     uint32_t default_inactivity_timeout         = 0;
-    uint32_t additional_accepts = 0;
+    uint32_t additional_accepts                 = 0;
 
     /** Return the address of the first value in this struct.
 

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -121,7 +121,6 @@ struct NetAccept : public Continuation {
   explicit NetAccept(const NetProcessor::AcceptOptions &);
   ~NetAccept() override { action_ = nullptr; }
 
-  static int accept_till_done;
 };
 
 extern Ptr<ProxyMutex> naVecMutex;

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -120,7 +120,6 @@ struct NetAccept : public Continuation {
 
   explicit NetAccept(const NetProcessor::AcceptOptions &);
   ~NetAccept() override { action_ = nullptr; }
-
 };
 
 extern Ptr<ProxyMutex> naVecMutex;

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -88,7 +88,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
       goto Ldone; // note: @a con will clean up the socket when it goes out of scope.
     }
 
-    ++count;
+    count++;
     Metrics::increment(net_rsb.connections_currently_open);
     vc->id = net_next_connection_number();
     vc->con.move(con);
@@ -355,12 +355,8 @@ NetAccept::do_blocking_accept(EThread *t)
       return -1;
     }
 
-<<<<<<< HEAD
-    Metrics::increment(net_rsb.connections_currently_open);
     count++;
-=======
-    NET_SUM_GLOBAL_DYN_STAT(net_connections_currently_open_stat, 1);
->>>>>>> 98d516134 (addressing comments)
+    Metrics::increment(net_rsb.connections_currently_open);
     vc->id = net_next_connection_number();
     vc->con.move(con);
     vc->set_remote_addr(con.addr);
@@ -513,10 +509,10 @@ NetAccept::acceptFastEvent(int event, void *ep)
       goto Lerror;
     }
 
-    count++;
     vc = (UnixNetVConnection *)this->getNetProcessor()->allocate_vc(e->ethread);
     ink_release_assert(vc);
 
+    count++;
     Metrics::increment(net_rsb.connections_currently_open);
     vc->id = net_next_connection_number();
     vc->con.move(con);

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -563,7 +563,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     vc = nullptr;
   } while (count <= additional_accepts);
 
- Ldone:
+Ldone:
   // if we stop looping as a result of hitting the accept limit,
   // resechedule accepting to the end of the thread event queue
   // for the goal of fairness between accepting and other work

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -57,7 +57,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
   EThread *t             = e->ethread;
   NetHandler *handler    = get_NetHandler(t);
   int config_value       = handler->config.additional_accepts;
-  int additional_accepts = config_value >= 0 ? config_value : INT32_MAX;
+  int additional_accepts = config_value >= 0 ? config_value : INT32_MAX - 1;
 
   if (!blockable) {
     if (!MUTEX_TAKE_TRY_LOCK(na->action_->mutex, e->ethread)) {
@@ -307,7 +307,7 @@ NetAccept::do_blocking_accept(EThread *t)
   int count              = 0;
   NetHandler *handler    = get_NetHandler(t);
   int config_value       = handler->config.additional_accepts;
-  int additional_accepts = config_value >= 0 ? config_value : INT32_MAX;
+  int additional_accepts = config_value >= 0 ? config_value : INT32_MAX - 1;
 
   // do-while for accepting all the connections
   // added by YTS Team, yamsat
@@ -460,7 +460,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
   EThread *t             = e->ethread;
   NetHandler *handler    = get_NetHandler(t);
   int config_value       = handler->config.additional_accepts;
-  int additional_accepts = config_value >= 0 ? config_value : INT32_MAX;
+  int additional_accepts = config_value >= 0 ? config_value : INT32_MAX - 1;
 
   do {
     socklen_t sz = sizeof(con.addr);

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -714,6 +714,9 @@ static const RecordElement RecordsConfig[] =
   //# Net Subsystem
   //#
   //##############################################################################
+
+  {RECT_CONFIG, "proxy.config.net.additional_accepts", RECD_INT, "-1", RECU_DYNAMIC, RR_NULL, RECC_INT, "^-1|[0-9]+$", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.net.connections_throttle", RECD_INT, "30000", RECU_RESTART_TS, RR_REQUIRED, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.net.listen_backlog", RECD_INT, "-1", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -200,7 +200,6 @@ static ArgumentDescription argument_descriptions[] = {
   {"net_threads",       'n', "Number of Net Threads",                                                                               "I",     &num_of_net_threads,             "PROXY_NET_THREADS",       nullptr},
   {"udp_threads",       'U', "Number of UDP Threads",                                                                               "I",     &num_of_udp_threads,             "PROXY_UDP_THREADS",       nullptr},
   {"accept_thread",     'a', "Use an Accept Thread",                                                                                "T",     &num_accept_threads,             "PROXY_ACCEPT_THREAD",     nullptr},
-  {"accept_till_done",  'b', "Accept Till Done",                                                                                    "T",     &NetAccept::accept_till_done,    "PROXY_ACCEPT_TILL_DONE",  nullptr},
   {"httpport",          'p', "Port descriptor for HTTP Accept",                                                                     "S*",    &http_accept_port_descriptor,    "PROXY_HTTP_ACCEPT_PORT",  nullptr},
   {"disable_freelist",  'f', "Disable the freelist memory allocator",                                                               "T",     &cmd_disable_freelist,           "PROXY_DPRINTF_LEVEL",     nullptr},
   {"disable_pfreelist", 'F', "Disable the freelist memory allocator in ProxyAllocator",                                             "T",     &cmd_disable_pfreelist,


### PR DESCRIPTION
Relevant Issue: https://github.com/apache/trafficserver/issues/9681

Remove the `accept_till_done` global variable, and introduce a replacement reloadable variable `proxy.config.net.additional_accepts` to control how many connections can be accepted per thread, per event loop.

If `additional_accepts = -1`, (the default setting) there will be (effectively) no restriction as to how many connections can be accepted per thread. The variable will be set to INT32_MAX - 1. This is equivalent to setting `accept_till_done = 1` today.

If `additional_accepts = 0`, only 1 connection will be accepted per event loop. This is equivalent to setting `accept_till_done = 0` today.

If `additional_accepts = x`, then a thread may accept up to x additional connections per event loop, per thread. Thus, the maximum number of connections that could be accepted is x+1.

p.s. Naming suggestions for the variable are also welcome