### PR TITLE
build_h3_tools: use openssl-3.1

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -28,7 +28,7 @@ cd "${WORKDIR}"
 echo "Building H3 dependencies in ${WORKDIR} ..."
 
 # Update this as the draft we support updates.
-OPENSSL_BRANCH=${OPENSSL_BRANCH:-"openssl-3.0.9+quic"}
+OPENSSL_BRANCH=${OPENSSL_BRANCH:-"openssl-3.1.0+quic+locks"}
 
 # Set these, if desired, to change these to your preferred installation
 # directory


### PR DESCRIPTION
OpenSSL 3.1 has multiple performance improvements over 3.0.

---
I ran the autests locally with ATS built against this and they all passed.