### PR TITLE
Add quiche openssl lib to LDFLAGS

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -247,7 +247,7 @@ fi
   PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
   CFLAGS="${CFLAGS}" \
   CXXFLAGS="${CXXFLAGS}" \
-  LDFLAGS="${LDFLAGS}" \
+  LDFLAGS="${LDFLAGS} -L${OPENSSL_LIB}" \
   --enable-http3 \
   ${ENABLE_APP}
 ${MAKE} -j ${num_threads}


### PR DESCRIPTION
Building in my ubuntu 20.04 VM I ran into an issue where due to the order of the -L directives the build kept trying to pull openssl from the system library locations first, rather than the specified path before the library link. Adding the quiche openssl location to the LDFLAGS ensured it showed up first in the library locations and allowed the build to complete