### PR TITLE
TLS early data: logging updates

### DIFF
--- a/iocore/net/P_SNIActionPerformer.h
+++ b/iocore/net/P_SNIActionPerformer.h
@@ -467,6 +467,7 @@ public:
 #if TS_HAS_TLS_EARLY_DATA
     auto ssl_vc = dynamic_cast<SSLNetVConnection *>(snis);
     if (ssl_vc) {
+      Debug("ssl_sni", "Setting server_max_early_data to %u", server_max_early_data);
       ssl_vc->hints_from_sni.server_max_early_data = server_max_early_data;
       const uint32_t EARLY_DATA_DEFAULT_SIZE       = 16384;
       const uint32_t server_recv_max_early_data =

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -455,6 +455,8 @@ private:
     HANDSHAKE_HOOKS_DONE
   } sslHandshakeHookState = HANDSHAKE_HOOKS_PRE;
 
+  static char const *get_ssl_handshake_hook_state_name(SSLHandshakeHookState state);
+
   int64_t redoWriteSize = 0;
 
   X509_STORE_CTX *verify_cert = nullptr;


### PR DESCRIPTION
This patch updates TLS logging by making TLS hook names human readable and adds some early data SNI action logs.