### PR TITLE
polite_hook_wait logging updates

### DIFF
--- a/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.test.py
+++ b/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.test.py
@@ -38,7 +38,7 @@ ts = Test.MakeATSProcess("ts", enable_cache=False, block_for_debug=False)
 ts.Disk.records_config.update({
     'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
     'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.diags.debug.enabled': 3,
+    'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': f'{plugin_name}',
 })
 


### PR DESCRIPTION
The polite_hook_wait.test.py autest frequently fails in the CI jenkins jobs due to a hang loading the polite_hook_wait plugin. The CI debug logs are empty in these situations. This patch adds more logs and switches the logging mechanism to TSDebug in the hopes that this provides us more information. We can revert this patch or parts of this patch later once we figure out what is going wrong.