### PR TITLE
Remove global symbols for zero hashes.

### DIFF
--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "tscpp/util/ts_bw_format.h"
+#include "ink_memory.h"
 #include <openssl/evp.h>
 #include <string_view>
 
@@ -63,7 +64,7 @@ union CryptoHash {
   bool
   operator==(CryptoHash const &that) const
   {
-    return memcmp(this, &that, sizeof(*this)) == 0;
+    return ::memcmp(this, &that, sizeof(*this)) == 0;
   }
 
   /// Equality - bitwise identical.
@@ -90,6 +91,7 @@ union CryptoHash {
   {
     return u64[i];
   }
+
   /// Access 64 bit slice.
   /// @note Identical to @ operator[] but included for symmetry.
   uint64_t
@@ -107,9 +109,20 @@ union CryptoHash {
 
   /// Fast conversion to hex in fixed sized string.
   char *toHexStr(char buffer[(CRYPTO_HASH_SIZE * 2) + 1]) const;
-};
 
-extern CryptoHash const CRYPTO_HASH_ZERO;
+  bool
+  is_zero() const
+  {
+    constexpr uint8_t z64[sizeof(u64)] = {0};
+    return ::memcmp(u64, z64, sizeof(z64)) == 0;
+  }
+
+  void
+  clear()
+  {
+    ink_zero(u64);
+  }
+};
 
 class CryptoContext
 {
@@ -137,6 +150,7 @@ public:
   };
 
   CryptoContext();
+
   /// Update the hash with @a data of @a length bytes.
   bool update(void const *data, int length);
 
@@ -199,4 +213,3 @@ swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec,
 
 using ts::CryptoHash;
 using ts::CryptoContext;
-using ts::CRYPTO_HASH_ZERO;

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -86,14 +86,14 @@ int cache_config_read_while_writer_max_retries = 10;
 
 // Globals
 
-RecRawStatBlock *cache_rsb          = nullptr;
-Cache *theCache                     = nullptr;
-CacheDisk **gdisks                  = nullptr;
-int gndisks                         = 0;
-std::atomic<int> initialize_disk    = 0;
-Cache *caches[NUM_CACHE_FRAG_TYPES] = {nullptr};
-CacheSync *cacheDirSync             = nullptr;
-Store theCacheStore;
+RecRawStatBlock *cache_rsb              = nullptr;
+Cache *theCache                         = nullptr;
+CacheDisk **gdisks                      = nullptr;
+int gndisks                             = 0;
+static std::atomic<int> initialize_disk = 0;
+Cache *caches[NUM_CACHE_FRAG_TYPES]     = {nullptr};
+CacheSync *cacheDirSync                 = nullptr;
+static Store theCacheStore;
 int CacheProcessor::initialized          = CACHE_INITIALIZING;
 uint32_t CacheProcessor::cache_ready     = 0;
 int CacheProcessor::start_done           = 0;
@@ -110,7 +110,6 @@ ClassAllocator<EvacuationBlock> evacuationBlockAllocator("evacuationBlock");
 ClassAllocator<CacheRemoveCont> cacheRemoveContAllocator("cacheRemoveCont");
 ClassAllocator<EvacuationKey> evacuationKeyAllocator("evacuationKey");
 int CacheVC::size_to_init = -1;
-CacheKey zero_key;
 
 namespace
 {

--- a/iocore/cache/CacheHttp.cc
+++ b/iocore/cache/CacheHttp.cc
@@ -149,7 +149,7 @@ CacheHTTPInfoVector::print(char *buffer, size_t buf_size, bool temps)
         }
       }
 
-      if (temps || !(data[i].alternate.object_key_get() == zero_key)) {
+      if (temps || !(data[i].alternate.object_key_get().is_zero())) {
         snprintf(p, buf_size, "[%d %s]", data[i].alternate.id_get(), CacheKey(data[i].alternate.object_key_get()).toHexStr(buf));
         tmp       = strlen(p);
         p        += tmp;

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -971,7 +971,8 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
           // that it inserted
           od->first_dir   = first_dir;
           od->writing_vec = true;
-          earliest_key    = zero_key;
+
+          earliest_key.clear();
 
           // set up this VC as a alternate delete write_vc
           vio.op          = VIO::WRITE;

--- a/iocore/cache/CacheVol.cc
+++ b/iocore/cache/CacheVol.cc
@@ -333,15 +333,17 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         cacheProcessor.remove(this, &doc->first_key, CACHE_FRAG_TYPE_HTTP, hname, hlen);
         return EVENT_CONT;
       } else {
-        offset          = reinterpret_cast<char *>(doc) - buf->data();
-        write_len       = 0;
-        frag_type       = CACHE_FRAG_TYPE_HTTP;
-        f.use_first_key = 1;
-        f.evac_vector   = 1;
-        first_key = key   = doc->first_key;
+        offset            = reinterpret_cast<char *>(doc) - buf->data();
+        write_len         = 0;
+        frag_type         = CACHE_FRAG_TYPE_HTTP;
+        f.use_first_key   = 1;
+        f.evac_vector     = 1;
         alternate_index   = CACHE_ALT_REMOVED;
-        earliest_key      = zero_key;
         writer_lock_retry = 0;
+
+        first_key = key = doc->first_key;
+        earliest_key.clear();
+
         SET_HANDLER(&CacheVC::scanOpenWrite);
         return scanOpenWrite(EVENT_NONE, nullptr);
       }

--- a/iocore/cache/I_Store.h
+++ b/iocore/cache/I_Store.h
@@ -96,11 +96,13 @@ public:
   {
     return is_mmapable_internal;
   }
+
   void
   set_mmapable(bool s)
   {
     is_mmapable_internal = s;
   }
+
   int64_t
   size() const
   {

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -543,7 +543,6 @@ struct CacheRemoveCont : public Continuation {
 
 // Global Data
 extern ClassAllocator<CacheVC> cacheVConnectionAllocator;
-extern CacheKey zero_key;
 extern CacheSync *cacheDirSync;
 // Function Prototypes
 int cache_write(CacheVC *, CacheHTTPInfoVector *);

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -132,8 +132,6 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
 };
 CATCH_REGISTER_LISTENER(EventProcessorListener);
 
-extern Store theCacheStore;
-
 void
 init_cache(size_t size, const char *name)
 {

--- a/proxy/PoolableSession.h
+++ b/proxy/PoolableSession.h
@@ -234,7 +234,7 @@ PoolableSession::release_outbound_connection_tracking()
 inline void
 PoolableSession::attach_hostname(const char *hostname)
 {
-  if (CRYPTO_HASH_ZERO == hostname_hash) {
+  if (hostname_hash.is_zero()) {
     CryptoContext().hash_immediate(hostname_hash, (unsigned char *)hostname, strlen(hostname));
   }
 }

--- a/proxy/http/HttpTransactCache.cc
+++ b/proxy/http/HttpTransactCache.cc
@@ -195,7 +195,7 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
     HTTPHdr *cached_request  = obj->request_get();
     HTTPHdr *cached_response = obj->response_get();
 
-    if (!(obj->object_key_get() == zero_key)) {
+    if (!(obj->object_key_get().is_zero())) {
       ink_assert(cached_request->valid());
       ink_assert(cached_response->valid());
 

--- a/src/tscore/CryptoHash.cc
+++ b/src/tscore/CryptoHash.cc
@@ -37,8 +37,6 @@ CryptoContext::HashType CryptoContext::Setting = CryptoContext::SHA256;
 CryptoContext::HashType CryptoContext::Setting = CryptoContext::MD5;
 #endif
 
-ts::CryptoHash const ts::CRYPTO_HASH_ZERO; // default constructed is correct.
-
 CryptoContext::CryptoContext()
 {
   switch (Setting) {


### PR DESCRIPTION
Remove the two global symbols for zero-value crypto hashes, and replace them with inline member functions. This is 2 less global symbols, and improves code readability (though marginally).