### PR TITLE
Fix DbgCtl reference that got cherry-picked into 9.2.x

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -2439,7 +2439,7 @@ SSLMultiCertConfigLoader::load_certs(SSL_CTX *ctx, const std::vector<std::string
     }
 
     if (secret_key_data.empty()) {
-      Dbg(dbg_ctl_ssl_load, "empty private key for public key %s", cert_names_list[i].c_str());
+      Debug("ssl_load", "empty private key for public key %s", cert_names_list[i].c_str());
       secret_key_data = secret_data;
     }
     if (!SSLPrivateKeyHandler(ctx, params, keyPath.c_str(), secret_key_data.data(), secret_key_data.size())) {


### PR DESCRIPTION
9.2.x doesn't have DbgCtl yet, but we cherry-picked a patch from master that references it. This fixes the log to a standard Debug reference instead to fix the 9.2.x build. This was introduced via #10054.