### PR TITLE
9.2.x: Fix a crash triggered by invalid range header

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3105,7 +3105,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
           // this late.
           TxnDebug("http_seq", "Out-of-order Range request - tunneling");
           s->cache_info.action = CACHE_DO_NO_ACTION;
-          if (s->force_dns) {
+          if (s->force_dns || s->dns_info.lookup_success) {
             HandleCacheOpenReadMiss(s); // DNS is already completed no need of doing DNS
           } else {
             CallOSDNSLookup(s);

--- a/tests/gold_tests/headers/invalid_range_header.test.py
+++ b/tests/gold_tests/headers/invalid_range_header.test.py
@@ -1,0 +1,73 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Test invalid values in range header
+'''
+Test.ContinueOnFail = True
+
+
+class InvalidRangeHeaderTest:
+    invalidRangeRequestReplayFile = "replays/invalid_range_request.replay.yaml"
+
+    def __init__(self):
+        self.setupOriginServer()
+        self.setupTS()
+
+    def setupOriginServer(self):
+        self.server = Test.MakeVerifierServerProcess("verifier-server1", self.invalidRangeRequestReplayFile)
+
+    def setupTS(self):
+        self.ts = Test.MakeATSProcess("ts1")
+        self.ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
+                                            'proxy.config.diags.debug.tags': 'http',
+                                            'proxy.config.http.cache.http': 1,
+                                            'proxy.config.http.cache.range.write': 1,
+                                            'proxy.config.http.cache.required_headers': 0,
+                                            'proxy.config.http.insert_age_in_response': 0})
+        self.ts.Disk.remap_config.AddLine(
+            f"map / http://127.0.0.1:{self.server.Variables.http_port}/",
+        )
+
+    def runTraffic(self):
+        tr = Test.AddTestRun()
+        tr.AddVerifierClientProcess(
+            "client1",
+            self.invalidRangeRequestReplayFile,
+            http_ports=[self.ts.Variables.port],
+            other_args='--thread-limit 1')
+        tr.Processes.Default.StartBefore(self.server)
+        tr.Processes.Default.StartBefore(self.ts)
+        tr.StillRunningAfter = self.server
+        tr.StillRunningAfter = self.ts
+
+        # verification
+        tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+            r"Received an HTTP/1 416 response for key 2",
+            "Verify that client receives a 416 response")
+        tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+            r"x-responseheader: failed_response",
+            "Verify that the response came from the server")
+
+    def run(self):
+        self.runTraffic()
+
+
+InvalidRangeHeaderTest().run()

--- a/tests/gold_tests/headers/replays/invalid_range_request.replay.yaml
+++ b/tests/gold_tests/headers/replays/invalid_range_request.replay.yaml
@@ -1,0 +1,57 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+  # Populate cache entry
+  - transactions:
+      - client-request:
+          method: "GET"
+          version: "1.1"
+          url: /range/1024
+          headers:
+            fields:
+              - [Host, stack-overflow-example.com]
+              - [uuid, 1]
+
+        server-response:
+          status: 200
+          headers:
+            fields:
+              - [Content-Length, 1024]
+              - [Content-Range, "bytes 0-1023/1024"]
+  - transactions:
+      - client-request:
+          # Give ATS enough time to populate the cache.
+          delay: 100ms
+          method: "GET"
+          version: "1.1"
+          url: /range/1024
+          headers:
+            fields:
+              - [Host, stack-overflow-example.com]
+              # Invalid range request
+              - [Range, bytes=100-20]
+              - [uuid, 2]
+
+        server-response:
+          status: 416
+          reason: Range Not Satisfiable
+          headers:
+            fields:
+              - [X-ResponseHeader, failed_response]


### PR DESCRIPTION
This fixes #9265 for 9.2.x. 

ATS crashes when the client requests an object with an invalid range header for an item that would otherwise be served from the cache. This PR adds an Autest to reproduce this and fixes code to prevent the crash.