### PR TITLE
8.1.x: Fix a crash triggered by invalid range header

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -2820,7 +2820,7 @@ HttpTransact::build_response_from_cache(State *s, HTTPWarningCode warning_code)
           // this late.
           TxnDebug("http_seq", "[HttpTransact::HandleCacheOpenReadHit] Out-of-order Range request - tunneling");
           s->cache_info.action = CACHE_DO_NO_ACTION;
-          if (s->force_dns) {
+          if (s->force_dns || s->dns_info.lookup_success) {
             HandleCacheOpenReadMiss(s); // DNS is already completed no need of doing DNS
           } else {
             CallOSDNSLookup(s);


### PR DESCRIPTION
ATS crashes when the client requests an object with an invalid range header for an item that would otherwise be served from the cache. This PR fixes code to prevent the crash.