### PR TITLE
Fix dl_load_lock and DbgCtl deadlock

### DIFF
--- a/iocore/eventsystem/UnixEventProcessor.cc
+++ b/iocore/eventsystem/UnixEventProcessor.cc
@@ -477,6 +477,12 @@ EventProcessor::spawn_event_threads(EventType ev_type, int n_threads, size_t sta
 void
 EventProcessor::initThreadState(EThread *t)
 {
+  // #10129: Initialize DbgCtl early on so that we process the PCRE regex before
+  // we load plugins. Otherwise, PCRE compilation on first use will try to grab
+  // the dl_load_lock, which might race and deadlock with our dlopen calls for
+  // plugins.
+  DbgCtl::update();
+
   // Run all thread type initialization continuations that match the event types for this thread.
   for (int i = 0; i < MAX_EVENT_TYPES; ++i) {
     if (t->is_event_type(i)) {

--- a/src/tscore/DbgCtl.cc
+++ b/src/tscore/DbgCtl.cc
@@ -129,6 +129,7 @@ DbgCtl::_new_reference(char const *tag)
   TSDbgCtl ctl;
 
   ctl.tag = tag;
+  ctl.on  = diags() && diags()->tag_activated(tag, DiagsTagType_Debug);
 
   // DbgCtl instances may be declared as static objects in the destructors of objects not destoyed till program exit.
   // So, we must handle the case where the construction of such instances of DbgCtl overlaps with the destruction of
@@ -155,7 +156,6 @@ DbgCtl::_new_reference(char const *tag)
     std::memcpy(t, tag, sz + 1);
     ctl.tag = t;
   }
-  ctl.on = diags() && diags()->tag_activated(tag, DiagsTagType_Debug);
 
   auto res = d.set.insert(ctl);
 


### PR DESCRIPTION
This patch addresses a deadlock between the flushing thread and loading a plugin with DbgCtl configured. The lock would happen like so:

* The flushing thread would grab a lock for the DbgCtl::_RegistryAccessor::_mtx mutex through one of its Debug log messages.
* Meanwhile, the traffic_server main thread will load plugins via dlopen. dlopen implicitly grabs the dl_load_lock.
* The flushing thread would then process the debug tag via PCRE which, on first invocation for the thread, would try to grab the dl_load_lock. This however, is held by the thread loading the plugin.
* The plugin would then try to initialize its DbgCtl and try to grab a lock for the DbgCtl::_RegistryAccessor::_mtx. This however is held by the flushing thread.

This deadlock is addressed by ensuring that the flushing thread, as well as other threads, initialize their PCRE jit storage before plugins are loaded.

Fixes #10129