### PR TITLE
Unrequire remap rules for OCSP

### DIFF
--- a/include/ts/experimental.h
+++ b/include/ts/experimental.h
@@ -47,7 +47,8 @@ typedef enum {
   TS_FETCH_FLAGS_STREAM               = 1 << 1, // enable stream IO
   TS_FETCH_FLAGS_DECHUNK              = 1 << 2, // dechunk body content
   TS_FETCH_FLAGS_NEWLOCK              = 1 << 3, // allocate new lock for fetch sm
-  TS_FETCH_FLAGS_NOT_INTERNAL_REQUEST = 1 << 4  // Allow this fetch to be created as a non-internal request.
+  TS_FETCH_FLAGS_NOT_INTERNAL_REQUEST = 1 << 4, // Allow this fetch to be created as a non-internal request.
+  TS_FETCH_FLAGS_SKIP_REMAP           = 1 << 5, // Skip remapping and allow requesting arbitary URL
 } TSFetchFlags;
 
 /* Forward declaration of in_addr, any user of these APIs should probably

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -419,6 +419,18 @@ public:
     is_internal_request = val;
   }
 
+  bool
+  is_unmanaged() const
+  {
+    return _is_unmanaged;
+  }
+
+  void
+  set_unmanaged(bool val)
+  {
+    _is_unmanaged = val;
+  }
+
   /// Get the transparency state.
   bool
   get_is_transparent() const
@@ -529,6 +541,7 @@ protected:
   bool got_remote_addr = false;
 
   bool is_internal_request = false;
+  bool _is_unmanaged       = false;
   /// Set if this connection is transparent.
   bool is_transparent = false;
   /// Set if proxy protocol is enabled

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -420,15 +420,15 @@ public:
   }
 
   bool
-  is_unmanaged() const
+  get_is_unmanaged_request() const
   {
-    return _is_unmanaged;
+    return is_unmanaged_request;
   }
 
   void
-  set_unmanaged(bool val)
+  set_is_unmanaged_request(bool val = false)
   {
-    _is_unmanaged = val;
+    is_unmanaged_request = val;
   }
 
   /// Get the transparency state.
@@ -540,8 +540,8 @@ protected:
   bool got_local_addr  = false;
   bool got_remote_addr = false;
 
-  bool is_internal_request = false;
-  bool _is_unmanaged       = false;
+  bool is_internal_request  = false;
+  bool is_unmanaged_request = false;
   /// Set if this connection is transparent.
   bool is_transparent = false;
   /// Set if proxy protocol is enabled

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -309,9 +309,9 @@ public:
 
     this->_fsm = FetchSMAllocator.alloc();
     if (use_post) {
-      this->_fsm->ext_init(this, "POST", uri, "HTTP/1.1", reinterpret_cast<sockaddr *>(&sin), 0);
+      this->_fsm->ext_init(this, "POST", uri, "HTTP/1.1", reinterpret_cast<sockaddr *>(&sin), TS_FETCH_FLAGS_SKIP_REMAP);
     } else {
-      this->_fsm->ext_init(this, "GET", uri, "HTTP/1.1", reinterpret_cast<sockaddr *>(&sin), 0);
+      this->_fsm->ext_init(this, "GET", uri, "HTTP/1.1", reinterpret_cast<sockaddr *>(&sin), TS_FETCH_FLAGS_SKIP_REMAP);
     }
   }
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -409,6 +409,7 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc)
   }
 
   t_state.setup_per_txn_configs();
+  t_state.api_skip_all_remapping = netvc->is_unmanaged();
 
   ink_assert(_ua.get_txn()->get_proxy_ssn());
   ink_assert(_ua.get_txn()->get_proxy_ssn()->accept_options);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -409,7 +409,7 @@ HttpSM::attach_client_session(ProxyTransaction *client_vc)
   }
 
   t_state.setup_per_txn_configs();
-  t_state.api_skip_all_remapping = netvc->is_unmanaged();
+  t_state.api_skip_all_remapping = netvc->get_is_unmanaged_request();
 
   ink_assert(_ua.get_txn()->get_proxy_ssn());
   ink_assert(_ua.get_txn()->get_proxy_ssn()->accept_options);

--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -94,7 +94,7 @@ FetchSM::httpConnect()
 
   if (fetch_flags & TS_FETCH_FLAGS_SKIP_REMAP) {
     PluginVC *other_side = reinterpret_cast<PluginVC *>(http_vc)->get_other_side();
-    other_side->set_unmanaged(true);
+    other_side->set_is_unmanaged_request(true);
   }
 
   read_vio  = http_vc->do_io_read(this, INT64_MAX, resp_buffer);

--- a/src/traffic_server/FetchSM.cc
+++ b/src/traffic_server/FetchSM.cc
@@ -92,6 +92,11 @@ FetchSM::httpConnect()
     }
   }
 
+  if (fetch_flags & TS_FETCH_FLAGS_SKIP_REMAP) {
+    PluginVC *other_side = reinterpret_cast<PluginVC *>(http_vc)->get_other_side();
+    other_side->set_unmanaged(true);
+  }
+
   read_vio  = http_vc->do_io_read(this, INT64_MAX, resp_buffer);
   write_vio = http_vc->do_io_write(this, getReqLen() + req_content_length, req_reader);
 }


### PR DESCRIPTION
The change to use FetchSM for OCSP requests (#9591) unintentionally made ATS rely on remap rules, and that effectively broke OCSP if a user sets `remap_required` to 1. To recover the original behavior which does not rely on remap rules, this introduces a new flag for FetchSM, `TS_FETCH_FLAGS_SKIP_REMAP`, and the flag enables skipping remap on a transaction initiated by `FetchSM` even if `remap_required` is set to 1.

Since the flag is part of TS API, this also enables plugins to make HTTP requests for other servers without remap rules (if FetchSM is used).