### PR TITLE
Wasm plugin: Upgrade to the latest proxy-wasm-cpp-host and remove reference to WAVM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1441,9 +1441,6 @@ AC_SUBST(use_quic)
 AC_SUBST(has_quiche)
 AM_CONDITIONAL([ENABLE_QUIC], [test "x$enable_quic" = "xyes"])
 
-# Check for optional WAVM library
-TS_CHECK_WAVM
-
 #
 # Enable experimental/uri_signing plugin
 # This is here, instead of above, because it needs to know if PCRE is available.

--- a/doc/admin-guide/plugins/wasm.en.rst
+++ b/doc/admin-guide/plugins/wasm.en.rst
@@ -36,7 +36,7 @@ How it Works
 
 The plugin uses the library and header files from the Proxy-Wasm project.
 
-* https://github.com/proxy-wasm/proxy-wasm-cpp-host/tree/72ce32f7b11f9190edf874028255e1309e41690f
+* https://github.com/proxy-wasm/proxy-wasm-cpp-host/tree/b7e690703c7f26707438a2f1ebd7c197bc8f0296
 * https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/tree/fd0be8405db25de0264bdb78fae3a82668c03782
 
 Proxy-Wasm in turn uses an underlying WebAssembly runtime to execute the WebAssembly module. (Currently only WAMR and
@@ -56,9 +56,9 @@ Compiling the Plugin
 
 ::
 
-  wget https://github.com/bytecodealliance/wasm-micro-runtime/archive/c3d66f916ef8093e5c8cacf3329ed968f807cf58.tar.gz
-  tar zxvf c3d66f916ef8093e5c8cacf3329ed968f807cf58.tar.gz
-  cd wasm-micro-runtime-c3d66f916ef8093e5c8cacf3329ed968f807cf58
+  wget https://github.com/bytecodealliance/wasm-micro-runtime/archive/refs/tags/WAMR-1.2.1.tar.gz
+  tar zxvf WAMR-1.2.1.tar.gz
+  cd wasm-micro-runtime-WAMR-1.2.1
   cp core/iwasm/include/* /usr/local/include/
   cd product-mini/platforms/linux
   mkdir build
@@ -71,13 +71,14 @@ Compiling the Plugin
 
 ::
 
-  wget https://github.com/WasmEdge/WasmEdge/archive/refs/tags/proxy-wasm/0.11.2.tar.gz
-  tar zxvf 0.11.2.tar.gz
-  cd WasmEdge-proxy-wasm-0.11.2/utils
+  wget https://github.com/WasmEdge/WasmEdge/archive/refs/tags/proxy-wasm/0.13.1.tar.gz
+  tar zxvf 0.13.1.tar.gz
+  cd WasmEdge-proxy-wasm-0.13.1/utils
   ./install.sh
 
 * Copy contents from ~/.wasmedge/include to /usr/local/include
 * Copy contents from ~/.wasmedge/lib to /usr/local/lib
+* The installation script will make changes to your environment variables. You can comment those out for now before compiling the plugin.
 
 **Configure ATS to compile with experimental plugins**
 

--- a/plugins/experimental/wasm/Makefile.inc
+++ b/plugins/experimental/wasm/Makefile.inc
@@ -55,6 +55,8 @@ experimental_wasm_wasm_la_SOURCES = \
     experimental/wasm/lib/include/proxy-wasm/shared_data.h \
     experimental/wasm/lib/src/shared_queue.cc \
     experimental/wasm/lib/include/proxy-wasm/shared_queue.h \
+    experimental/wasm/lib/src/hash.cc \
+    experimental/wasm/lib/src/hash.h \
     experimental/wasm/lib/src/signature_util.cc \
     experimental/wasm/lib/include/proxy-wasm/signature_util.h \
     experimental/wasm/lib/src/vm_id_handle.cc \

--- a/plugins/experimental/wasm/lib/include/proxy-wasm/context.h
+++ b/plugins/experimental/wasm/lib/include/proxy-wasm/context.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "include/proxy-wasm/context_interface.h"
@@ -53,8 +54,7 @@ struct PluginBase {
              std::string_view key)
       : name_(std::string(name)), root_id_(std::string(root_id)), vm_id_(std::string(vm_id)),
         engine_(std::string(engine)), plugin_configuration_(plugin_configuration),
-        fail_open_(fail_open),
-        key_(root_id_ + "||" + plugin_configuration_ + "||" + std::string(key)),
+        fail_open_(fail_open), key_(makePluginKey(root_id, plugin_configuration, key)),
         log_prefix_(makeLogPrefix()) {}
 
   const std::string name_;
@@ -69,6 +69,8 @@ struct PluginBase {
 
 private:
   std::string makeLogPrefix() const;
+  static std::string makePluginKey(std::string_view root_id, std::string_view plugin_configuration,
+                                   std::string_view key);
 
   const std::string key_;
   const std::string log_prefix_;

--- a/plugins/experimental/wasm/lib/include/proxy-wasm/wasm.h
+++ b/plugins/experimental/wasm/lib/include/proxy-wasm/wasm.h
@@ -337,6 +337,7 @@ public:
 
 protected:
   std::shared_ptr<WasmBase> wasm_base_;
+  std::unordered_map<std::string, bool> plugin_canary_cache_;
 };
 
 std::string makeVmKey(std::string_view vm_id, std::string_view configuration,

--- a/plugins/experimental/wasm/lib/src/context.cc
+++ b/plugins/experimental/wasm/lib/src/context.cc
@@ -22,6 +22,7 @@
 
 #include "include/proxy-wasm/context.h"
 #include "include/proxy-wasm/wasm.h"
+#include "src/hash.h"
 #include "src/shared_data.h"
 #include "src/shared_queue.h"
 
@@ -83,6 +84,11 @@ std::string PluginBase::makeLogPrefix() const {
     prefix = prefix + " " + std::string(vm_id_);
   }
   return prefix;
+}
+
+std::string PluginBase::makePluginKey(std::string_view root_id,
+                                      std::string_view plugin_configuration, std::string_view key) {
+  return Sha256String({root_id, "||", plugin_configuration, "||", key});
 }
 
 ContextBase::ContextBase() : parent_context_(this) {}

--- a/plugins/experimental/wasm/lib/src/hash.cc
+++ b/plugins/experimental/wasm/lib/src/hash.cc
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/hash.h"
+
+#include <string>
+#include <vector>
+
+#include <openssl/sha.h>
+
+namespace proxy_wasm {
+
+namespace {
+
+std::string BytesToHex(const std::vector<uint8_t> &bytes) {
+  static const char *const hex = "0123456789ABCDEF";
+  std::string result;
+  result.reserve(bytes.size() * 2);
+  for (auto byte : bytes) {
+    result.push_back(hex[byte >> 4]);
+    result.push_back(hex[byte & 0xf]);
+  }
+  return result;
+}
+
+} // namespace
+
+std::vector<uint8_t> Sha256(const std::vector<std::string_view> &parts) {
+  uint8_t sha256[SHA256_DIGEST_LENGTH];
+  SHA256_CTX sha_ctx;
+  SHA256_Init(&sha_ctx);
+  for (auto part : parts) {
+    SHA256_Update(&sha_ctx, part.data(), part.size());
+  }
+  SHA256_Final(sha256, &sha_ctx);
+  return std::vector<uint8_t>(std::begin(sha256), std::end(sha256));
+}
+
+std::string Sha256String(const std::vector<std::string_view> &parts) {
+  return BytesToHex(Sha256(parts));
+}
+
+} // namespace proxy_wasm

--- a/plugins/experimental/wasm/lib/src/hash.h
+++ b/plugins/experimental/wasm/lib/src/hash.h
@@ -1,0 +1,27 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <openssl/sha.h>
+
+namespace proxy_wasm {
+
+std::vector<uint8_t> Sha256(const std::vector<std::string_view> &parts);
+std::string Sha256String(const std::vector<std::string_view> &parts);
+
+} // namespace proxy_wasm


### PR DESCRIPTION
Please note all things under plugins/experimental/wasm/lib/ are coming from proxy-wasm external repos