### PR TITLE
Move APIHook classes to tsapicore

### DIFF
--- a/include/api/APIHook.h
+++ b/include/api/APIHook.h
@@ -1,0 +1,45 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "ts/InkAPIPrivateIOCore.h"
+
+#include "tscore/List.h"
+
+/// A single API hook that can be invoked.
+class APIHook
+{
+public:
+  INKContInternal *m_cont;
+  int invoke(int event, void *edata) const;
+  APIHook *next() const;
+  APIHook *prev() const;
+  LINK(APIHook, m_link);
+
+  // This is like invoke(), but allows for blocking on continuation mutexes.  It is a hack, calling it can block
+  // the calling thread.  Hooks that require this should be reimplemented, modeled on the hook handling in HttpSM.cc .
+  // That is, try to lock the mutex, and reschedule the continuation if the mutex cannot be locked.
+  //
+  int blocking_invoke(int event, void *edata) const;
+};

--- a/include/api/APIHooks.h
+++ b/include/api/APIHooks.h
@@ -1,0 +1,52 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "APIHook.h"
+
+#include "ts/InkAPIPrivateIOCore.h"
+
+#include "tscore/List.h"
+
+/// A collection of API hooks.
+class APIHooks
+{
+public:
+  void append(INKContInternal *cont);
+  /// Get the first hook.
+  APIHook *head() const;
+  /// Remove all hooks.
+  void clear();
+  /// Check if there are no hooks.
+  bool is_empty() const;
+
+private:
+  Que(APIHook, m_link) m_hooks;
+};
+
+inline bool
+APIHooks::is_empty() const
+{
+  return nullptr == m_hooks.head;
+}

--- a/include/api/FeatureAPIHooks.h
+++ b/include/api/FeatureAPIHooks.h
@@ -1,0 +1,154 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "APIHook.h"
+#include "APIHooks.h"
+
+#include "ts/InkAPIPrivateIOCore.h"
+
+#include "tscore/ink_apidefs.h"
+
+/** Container for API hooks for a specific feature.
+
+    This is an array of hook lists, each identified by a numeric identifier (id). Each array element is a list of all
+    hooks for that ID. Adding a hook means adding to the list in the corresponding array element. There is no provision
+    for removing a hook.
+
+    @note The minimum value for a hook ID is zero. Therefore the template parameter @a N_ID should be one more than the
+    maximum hook ID so the valid ids are 0..(N-1) in the standard C array style.
+ */
+template <typename ID, ///< Type of hook ID
+          int N        ///< Number of hooks
+          >
+class FeatureAPIHooks
+{
+public:
+  FeatureAPIHooks();  ///< Constructor (empty container).
+  ~FeatureAPIHooks(); ///< Destructor.
+
+  /// Remove all hooks.
+  void clear();
+  /// Add the hook @a cont to the end of the hooks for @a id.
+  void append(ID id, INKContInternal *cont);
+  /// Get the list of hooks for @a id.
+  APIHook *get(ID id) const;
+  /// @return @c true if @a id is a valid id, @c false otherwise.
+  static bool is_valid(ID id);
+
+  /// Invoke the callbacks for the hook @a id.
+  void invoke(ID id, int event, void *data);
+
+  /// Fast check for any hooks in this container.
+  ///
+  /// @return @c true if any list has at least one hook, @c false if
+  /// all lists have no hooks.
+  bool has_hooks() const;
+
+  /// Check for existence of hooks of a specific @a id.
+  /// @return @c true if any hooks of type @a id are present.
+  bool has_hooks_for(ID id) const;
+
+  /// Get a pointer to the set of hooks for a specific hook @id
+  APIHooks const *operator[](ID id) const;
+
+private:
+  bool m_hooks_p = false; ///< Flag for (not) empty container.
+  /// The array of hooks lists.
+  APIHooks m_hooks[N];
+};
+
+template <typename ID, int N> FeatureAPIHooks<ID, N>::FeatureAPIHooks() {}
+
+template <typename ID, int N> FeatureAPIHooks<ID, N>::~FeatureAPIHooks()
+{
+  this->clear();
+}
+
+// The APIHooks::clear() method can't be inlined (easily), and we end up calling
+// clear() very frequently (it's used in a number of features). A rough estimate
+// is that we may call APIHooks::clear() as much as 230x per transaction (there's
+// 180 additional APIHooks that should be eliminated in a different PR). This
+// code at least avoids calling this function for a majority of the cases.
+// Before this code, APIHooks::clear() would show up as top 5 in perf top.
+template <typename ID, int N>
+void
+FeatureAPIHooks<ID, N>::clear()
+{
+  if (m_hooks_p) {
+    for (auto &h : m_hooks) {
+      if (!h.is_empty()) {
+        h.clear();
+      }
+    }
+    m_hooks_p = false;
+  }
+}
+
+template <typename ID, int N>
+void
+FeatureAPIHooks<ID, N>::append(ID id, INKContInternal *cont)
+{
+  if (is_valid(id)) {
+    m_hooks_p = true;
+    m_hooks[id].append(cont);
+  }
+}
+
+template <typename ID, int N>
+APIHook *
+FeatureAPIHooks<ID, N>::get(ID id) const
+{
+  return likely(is_valid(id)) ? m_hooks[id].head() : nullptr;
+}
+
+template <typename ID, int N>
+APIHooks const *
+FeatureAPIHooks<ID, N>::operator[](ID id) const
+{
+  return likely(is_valid(id)) ? &(m_hooks[id]) : nullptr;
+}
+
+template <typename ID, int N>
+void
+FeatureAPIHooks<ID, N>::invoke(ID id, int event, void *data)
+{
+  if (likely(is_valid(id))) {
+    m_hooks[id].invoke(event, data);
+  }
+}
+
+template <typename ID, int N>
+bool
+FeatureAPIHooks<ID, N>::has_hooks() const
+{
+  return m_hooks_p;
+}
+
+template <typename ID, int N>
+bool
+FeatureAPIHooks<ID, N>::is_valid(ID id)
+{
+  return 0 <= id && id < N;
+}

--- a/include/api/InkAPIInternal.h
+++ b/include/api/InkAPIInternal.h
@@ -33,6 +33,10 @@
 #include "I_Tasks.h"
 #include "Plugin.h"
 
+#include "api/APIHook.h"
+#include "api/APIHooks.h"
+#include "api/FeatureAPIHooks.h"
+
 #include "ts/InkAPIPrivateIOCore.h"
 #include "ts/experimental.h"
 
@@ -102,205 +106,6 @@ struct HttpAltInfo {
   float m_qvalue;
 };
 
-enum APIHookScope {
-  API_HOOK_SCOPE_NONE,
-  API_HOOK_SCOPE_GLOBAL,
-  API_HOOK_SCOPE_LOCAL,
-};
-
-/// A single API hook that can be invoked.
-class APIHook
-{
-public:
-  INKContInternal *m_cont;
-  int invoke(int event, void *edata) const;
-  APIHook *next() const;
-  APIHook *prev() const;
-  LINK(APIHook, m_link);
-
-  // This is like invoke(), but allows for blocking on continuation mutexes.  It is a hack, calling it can block
-  // the calling thread.  Hooks that require this should be reimplemented, modeled on the hook handling in HttpSM.cc .
-  // That is, try to lock the mutex, and reschedule the continuation if the mutex cannot be locked.
-  //
-  int blocking_invoke(int event, void *edata) const;
-};
-
-/// A collection of API hooks.
-class APIHooks
-{
-public:
-  void append(INKContInternal *cont);
-  /// Get the first hook.
-  APIHook *head() const;
-  /// Remove all hooks.
-  void clear();
-  /// Check if there are no hooks.
-  bool is_empty() const;
-
-private:
-  Que(APIHook, m_link) m_hooks;
-};
-
-inline bool
-APIHooks::is_empty() const
-{
-  return nullptr == m_hooks.head;
-}
-
-/** Container for API hooks for a specific feature.
-
-    This is an array of hook lists, each identified by a numeric identifier (id). Each array element is a list of all
-    hooks for that ID. Adding a hook means adding to the list in the corresponding array element. There is no provision
-    for removing a hook.
-
-    @note The minimum value for a hook ID is zero. Therefore the template parameter @a N_ID should be one more than the
-    maximum hook ID so the valid ids are 0..(N-1) in the standard C array style.
- */
-template <typename ID, ///< Type of hook ID
-          int N        ///< Number of hooks
-          >
-class FeatureAPIHooks
-{
-public:
-  FeatureAPIHooks();  ///< Constructor (empty container).
-  ~FeatureAPIHooks(); ///< Destructor.
-
-  /// Remove all hooks.
-  void clear();
-  /// Add the hook @a cont to the end of the hooks for @a id.
-  void append(ID id, INKContInternal *cont);
-  /// Get the list of hooks for @a id.
-  APIHook *get(ID id) const;
-  /// @return @c true if @a id is a valid id, @c false otherwise.
-  static bool is_valid(ID id);
-
-  /// Invoke the callbacks for the hook @a id.
-  void invoke(ID id, int event, void *data);
-
-  /// Fast check for any hooks in this container.
-  ///
-  /// @return @c true if any list has at least one hook, @c false if
-  /// all lists have no hooks.
-  bool has_hooks() const;
-
-  /// Check for existence of hooks of a specific @a id.
-  /// @return @c true if any hooks of type @a id are present.
-  bool has_hooks_for(ID id) const;
-
-  /// Get a pointer to the set of hooks for a specific hook @id
-  APIHooks const *operator[](ID id) const;
-
-private:
-  bool m_hooks_p = false; ///< Flag for (not) empty container.
-  /// The array of hooks lists.
-  APIHooks m_hooks[N];
-};
-
-template <typename ID, int N> FeatureAPIHooks<ID, N>::FeatureAPIHooks() {}
-
-template <typename ID, int N> FeatureAPIHooks<ID, N>::~FeatureAPIHooks()
-{
-  this->clear();
-}
-
-// The APIHooks::clear() method can't be inlined (easily), and we end up calling
-// clear() very frequently (it's used in a number of features). A rough estimate
-// is that we may call APIHooks::clear() as much as 230x per transaction (there's
-// 180 additional APIHooks that should be eliminated in a different PR). This
-// code at least avoids calling this function for a majority of the cases.
-// Before this code, APIHooks::clear() would show up as top 5 in perf top.
-template <typename ID, int N>
-void
-FeatureAPIHooks<ID, N>::clear()
-{
-  if (m_hooks_p) {
-    for (auto &h : m_hooks) {
-      if (!h.is_empty()) {
-        h.clear();
-      }
-    }
-    m_hooks_p = false;
-  }
-}
-
-template <typename ID, int N>
-void
-FeatureAPIHooks<ID, N>::append(ID id, INKContInternal *cont)
-{
-  if (is_valid(id)) {
-    m_hooks_p = true;
-    m_hooks[id].append(cont);
-  }
-}
-
-template <typename ID, int N>
-APIHook *
-FeatureAPIHooks<ID, N>::get(ID id) const
-{
-  return likely(is_valid(id)) ? m_hooks[id].head() : nullptr;
-}
-
-template <typename ID, int N>
-APIHooks const *
-FeatureAPIHooks<ID, N>::operator[](ID id) const
-{
-  return likely(is_valid(id)) ? &(m_hooks[id]) : nullptr;
-}
-
-template <typename ID, int N>
-void
-FeatureAPIHooks<ID, N>::invoke(ID id, int event, void *data)
-{
-  if (likely(is_valid(id))) {
-    m_hooks[id].invoke(event, data);
-  }
-}
-
-template <typename ID, int N>
-bool
-FeatureAPIHooks<ID, N>::has_hooks() const
-{
-  return m_hooks_p;
-}
-
-template <typename ID, int N>
-bool
-FeatureAPIHooks<ID, N>::is_valid(ID id)
-{
-  return 0 <= id && id < N;
-}
-
-class HttpAPIHooks : public FeatureAPIHooks<TSHttpHookID, TS_HTTP_LAST_HOOK>
-{
-};
-
-class TSSslHookInternalID
-{
-public:
-  explicit constexpr TSSslHookInternalID(TSHttpHookID id) : _id(id - TS_SSL_FIRST_HOOK) {}
-
-  constexpr
-  operator int() const
-  {
-    return _id;
-  }
-
-  static const int NUM = TS_SSL_LAST_HOOK - TS_SSL_FIRST_HOOK + 1;
-
-  constexpr bool
-  is_in_bounds() const
-  {
-    return (_id >= 0) && (_id < NUM);
-  }
-
-private:
-  const int _id;
-};
-
-class SslAPIHooks : public FeatureAPIHooks<TSSslHookInternalID, TSSslHookInternalID::NUM>
-{
-};
-
 class LifecycleAPIHooks : public FeatureAPIHooks<TSLifecycleHookID, TS_LIFECYCLE_LAST_HOOK>
 {
 };
@@ -349,6 +154,8 @@ public:
 private:
   std::unordered_map<std::string, INKContInternal *> cb_table;
 };
+
+#include "HttpAPIHooks.h"
 
 class HttpHookState
 {
@@ -403,7 +210,5 @@ HttpHookState::id() const
 
 void api_init();
 
-extern HttpAPIHooks *http_global_hooks;
 extern LifecycleAPIHooks *lifecycle_hooks;
-extern SslAPIHooks *ssl_hooks;
 extern ConfigUpdateCbTable *global_config_cbs;

--- a/include/api/InkAPIInternal.h
+++ b/include/api/InkAPIInternal.h
@@ -106,10 +106,6 @@ struct HttpAltInfo {
   float m_qvalue;
 };
 
-class LifecycleAPIHooks : public FeatureAPIHooks<TSLifecycleHookID, TS_LIFECYCLE_LAST_HOOK>
-{
-};
-
 class ConfigUpdateCallback : public Continuation
 {
 public:
@@ -210,5 +206,4 @@ HttpHookState::id() const
 
 void api_init();
 
-extern LifecycleAPIHooks *lifecycle_hooks;
 extern ConfigUpdateCbTable *global_config_cbs;

--- a/include/api/LifecycleAPIHooks.h
+++ b/include/api/LifecycleAPIHooks.h
@@ -1,0 +1,35 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "FeatureAPIHooks.h"
+
+#include "ts/apidefs.h"
+
+class LifecycleAPIHooks : public FeatureAPIHooks<TSLifecycleHookID, TS_LIFECYCLE_LAST_HOOK>
+{
+};
+
+// there is no corresponding deinit; we leak the resource on shutdown
+void init_global_lifecycle_hooks();
+
+extern LifecycleAPIHooks *g_lifecycle_hooks;

--- a/iocore/cache/CMakeLists.txt
+++ b/iocore/cache/CMakeLists.txt
@@ -55,6 +55,8 @@ target_include_directories(inkcache
 target_link_libraries(inkcache
     PUBLIC
         ts::aio
+        ts::hdrs
+        ts::http
         ts::inkevent
         ts::tscore
     PRIVATE

--- a/iocore/cache/test/main.cc
+++ b/iocore/cache/test/main.cc
@@ -23,6 +23,9 @@
 
 #include "tscore/ink_config.h"
 #include <string_view>
+#include "HttpAPIHooks.h"
+#include "SSLAPIHooks.h"
+
 #define CATCH_CONFIG_MAIN
 #include "main.h"
 
@@ -136,6 +139,9 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
     LibRecordsConfigInit();
     ink_net_init(ts::ModuleVersion(1, 0, ts::ModuleVersion::PRIVATE));
     ink_assert(GLOBAL_DATA != nullptr);
+
+    init_global_http_hooks();
+    init_global_ssl_hooks();
 
     statPagesManager.init(); // mutex needs to be initialized before calling netProcessor.init
     netProcessor.init();

--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -48,3 +48,38 @@ HttpHookState::getNext()
 }
 
 LifecycleAPIHooks *lifecycle_hooks = nullptr;
+
+namespace tsapi::c
+{
+TSVConn
+TSHttpConnectWithPluginId(sockaddr const *addr, const char *tag, int64_t id)
+{
+  return TSVConn{};
+}
+
+int TS_MIME_LEN_CONTENT_LENGTH           = 0;
+const char *TS_MIME_FIELD_CONTENT_LENGTH = "";
+
+TSIOBufferBlock
+TSIOBufferReaderStart(TSIOBufferReader readerp)
+{
+  return TSIOBufferBlock{};
+}
+
+TSIOBufferBlock
+TSIOBufferBlockNext(TSIOBufferBlock blockp)
+{
+  return TSIOBufferBlock{};
+}
+
+const char *
+TSIOBufferBlockReadStart(TSIOBufferBlock blockp, TSIOBufferReader readerp, int64_t *avail)
+{
+  return "";
+}
+
+void
+TSIOBufferReaderConsume(TSIOBufferReader readerp, int64_t nbytes)
+{
+}
+} // namespace tsapi::c

--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -47,8 +47,6 @@ HttpHookState::getNext()
   return nullptr;
 }
 
-LifecycleAPIHooks *lifecycle_hooks = nullptr;
-
 namespace tsapi::c
 {
 TSVConn

--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -21,47 +21,13 @@
   limitations under the License.
  */
 
+#include "SSLAPIHooks.h"
+
 #include "tscore/I_Version.h"
 
 AppVersionInfo appVersionInfo;
 
-#include "api/InkAPIInternal.h"
-void
-APIHooks::append(INKContInternal *cont)
-{
-}
-
-int
-APIHook::invoke(int, void *) const
-{
-  ink_assert(false);
-  return 0;
-}
-
-int
-APIHook::blocking_invoke(int, void *) const
-{
-  ink_assert(false);
-  return 0;
-}
-
-APIHook *
-APIHook::next() const
-{
-  ink_assert(false);
-  return nullptr;
-}
-
-APIHook *
-APIHooks::head() const
-{
-  return nullptr;
-}
-
-void
-APIHooks::clear()
-{
-}
+#include "api/FetchSM.h"
 
 void
 HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
@@ -79,12 +45,8 @@ HttpHookState::getNext()
   return nullptr;
 }
 
-HttpAPIHooks *http_global_hooks        = nullptr;
-SslAPIHooks *ssl_hooks                 = nullptr;
-LifecycleAPIHooks *lifecycle_hooks     = nullptr;
-ConfigUpdateCbTable *global_config_cbs = nullptr;
+LifecycleAPIHooks *lifecycle_hooks = nullptr;
 
-#include "api/FetchSM.h"
 ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
 void
 FetchSM::ext_launch()

--- a/iocore/cache/test/stub.cc
+++ b/iocore/cache/test/stub.cc
@@ -23,11 +23,13 @@
 
 #include "SSLAPIHooks.h"
 
+#include "api/InkAPIInternal.h"
+
+#include "HttpAPIHooks.h"
+
 #include "tscore/I_Version.h"
 
 AppVersionInfo appVersionInfo;
-
-#include "api/FetchSM.h"
 
 void
 HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
@@ -46,39 +48,3 @@ HttpHookState::getNext()
 }
 
 LifecycleAPIHooks *lifecycle_hooks = nullptr;
-
-ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
-void
-FetchSM::ext_launch()
-{
-}
-void
-FetchSM::ext_destroy()
-{
-}
-ssize_t
-FetchSM::ext_read_data(char *, unsigned long)
-{
-  return 0;
-}
-void
-FetchSM::ext_add_header(char const *, int, char const *, int)
-{
-}
-void
-FetchSM::ext_write_data(void const *, unsigned long)
-{
-}
-void *
-FetchSM::ext_get_user_data()
-{
-  return nullptr;
-}
-void
-FetchSM::ext_set_user_data(void *)
-{
-}
-void
-FetchSM::ext_init(Continuation *, char const *, char const *, char const *, sockaddr const *, int)
-{
-}

--- a/iocore/eventsystem/CMakeLists.txt
+++ b/iocore/eventsystem/CMakeLists.txt
@@ -50,6 +50,11 @@ target_link_libraries(inkevent
         yaml-cpp::yaml-cpp # transitive
 )
 
+set_target_properties(inkevent
+    PROPERTIES
+        POSITION_INDEPENDENT_CODE TRUE
+)
+
 if(TS_USE_HWLOC)
         target_link_libraries(inkevent PRIVATE hwloc::hwloc)
 endif()

--- a/iocore/eventsystem/CMakeLists.txt
+++ b/iocore/eventsystem/CMakeLists.txt
@@ -50,11 +50,6 @@ target_link_libraries(inkevent
         yaml-cpp::yaml-cpp # transitive
 )
 
-set_target_properties(inkevent
-    PROPERTIES
-        POSITION_INDEPENDENT_CODE TRUE
-)
-
 if(TS_USE_HWLOC)
         target_link_libraries(inkevent PRIVATE hwloc::hwloc)
 endif()

--- a/iocore/hostdb/CMakeLists.txt
+++ b/iocore/hostdb/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(inkhostdb
 target_link_libraries(inkhostdb
     PUBLIC
         ts::inkcache
+        ts::inkdns
         ts::inkevent
         ts::tscore
     PRIVATE

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(inknet STATIC
         ProxyProtocol.cc
         ReadWriteEventIO.cc
         Socks.cc
+        SSLAPIHooks.cc
         SSLCertLookup.cc
         SSLClientCoordinator.cc
         SSLClientUtils.cc

--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -127,6 +127,7 @@ target_link_libraries(inknet
         OpenSSL::Crypto
         OpenSSL::SSL
     PRIVATE
+        ts::tsapicore
         yaml-cpp::yaml-cpp
 )
 

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -208,6 +208,8 @@ libinknet_a_SOURCES = \
 	ReadWriteEventIO.h \
 	ReadWriteEventIO.cc \
 	Socks.cc \
+	SSLAPIHooks.h \
+	SSLAPIHooks.cc \
 	SSLCertLookup.cc \
 	SSLClientCoordinator.cc \
 	SSLClientUtils.cc \

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -28,6 +28,7 @@
 
 ************************************************************************/
 
+#include "SSLAPIHooks.h"
 #include "P_Net.h"
 #include <utility>
 
@@ -120,6 +121,7 @@ ink_net_init(ts::ModuleVersion version)
   if (!init_called) {
     configure_net();
     register_net_stats();
+    init_global_ssl_hooks();
   }
 
   init_called = 1;

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -49,8 +49,6 @@
 
 #pragma once
 
-#include "I_NetProcessor.h"
-
 #include "tscore/ink_platform.h"
 
 struct NetVCOptions;

--- a/iocore/net/P_Connection.h
+++ b/iocore/net/P_Connection.h
@@ -49,6 +49,8 @@
 
 #pragma once
 
+#include "I_NetProcessor.h"
+
 #include "tscore/ink_platform.h"
 
 struct NetVCOptions;

--- a/iocore/net/SSLAPIHooks.cc
+++ b/iocore/net/SSLAPIHooks.cc
@@ -1,0 +1,32 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "SSLAPIHooks.h"
+
+SSLAPIHooks *g_ssl_hooks = nullptr;
+
+void
+init_global_ssl_hooks()
+{
+  g_ssl_hooks = new SSLAPIHooks;
+}

--- a/iocore/net/SSLAPIHooks.h
+++ b/iocore/net/SSLAPIHooks.h
@@ -1,0 +1,56 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "api/FeatureAPIHooks.h"
+
+#include "ts/apidefs.h"
+
+class TSSslHookInternalID
+{
+public:
+  explicit constexpr TSSslHookInternalID(TSHttpHookID id) : _id(id - TS_SSL_FIRST_HOOK) {}
+
+  constexpr operator int() const { return _id; }
+
+  static const int NUM = TS_SSL_LAST_HOOK - TS_SSL_FIRST_HOOK + 1;
+
+  constexpr bool
+  is_in_bounds() const
+  {
+    return (_id >= 0) && (_id < NUM);
+  }
+
+private:
+  const int _id;
+};
+
+class SSLAPIHooks : public FeatureAPIHooks<TSSslHookInternalID, TSSslHookInternalID::NUM>
+{
+};
+
+// there is no corresponding deinit; we leak the resource on shutdown
+void init_global_ssl_hooks();
+
+extern SSLAPIHooks *g_ssl_hooks;

--- a/iocore/net/SSLAPIHooks.h
+++ b/iocore/net/SSLAPIHooks.h
@@ -32,7 +32,11 @@ class TSSslHookInternalID
 public:
   explicit constexpr TSSslHookInternalID(TSHttpHookID id) : _id(id - TS_SSL_FIRST_HOOK) {}
 
-  constexpr operator int() const { return _id; }
+  constexpr
+  operator int() const
+  {
+    return _id;
+  }
 
   static const int NUM = TS_SSL_LAST_HOOK - TS_SSL_FIRST_HOOK + 1;
 

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -39,6 +39,7 @@
 #include "P_SSLClientUtils.h"
 #include "P_SSLNetVConnection.h"
 #include "BIO_fastopen.h"
+#include "SSLAPIHooks.h"
 #include "SSLStats.h"
 #include "P_ALPNSupport.h"
 
@@ -1265,7 +1266,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
     Metrics::increment(ssl_rsb.total_attempts_handshake_count_in);
     if (!curHook) {
       Dbg(dbg_ctl_ssl, "Initialize preaccept curHook from NULL");
-      curHook = ssl_hooks->get(TSSslHookInternalID(TS_VCONN_START_HOOK));
+      curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_VCONN_START_HOOK));
     } else {
       curHook = curHook->next();
     }
@@ -1567,7 +1568,7 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
     Metrics::increment(ssl_rsb.total_attempts_handshake_count_out);
     if (!curHook) {
       Dbg(dbg_ctl_ssl, "Initialize outbound connect curHook from NULL");
-      curHook = ssl_hooks->get(TSSslHookInternalID(TS_VCONN_OUTBOUND_START_HOOK));
+      curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_VCONN_OUTBOUND_START_HOOK));
     } else {
       curHook = curHook->next();
     }
@@ -1842,7 +1843,7 @@ SSLNetVConnection::callHooks(TSEvent eventId)
   case HANDSHAKE_HOOKS_CLIENT_HELLO:
   case HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE:
     if (!curHook) {
-      curHook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_CLIENT_HELLO_HOOK));
+      curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_CLIENT_HELLO_HOOK));
     } else {
       curHook = curHook->next();
     }
@@ -1856,14 +1857,14 @@ SSLNetVConnection::callHooks(TSEvent eventId)
     // The server verify event addresses ATS to origin handshake
     // All the other events are for client to ATS
     if (!curHook) {
-      curHook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_VERIFY_SERVER_HOOK));
+      curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_VERIFY_SERVER_HOOK));
     } else {
       curHook = curHook->next();
     }
     break;
   case HANDSHAKE_HOOKS_SNI:
     if (!curHook) {
-      curHook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_SERVERNAME_HOOK));
+      curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_SERVERNAME_HOOK));
     } else {
       curHook = curHook->next();
     }
@@ -1874,7 +1875,7 @@ SSLNetVConnection::callHooks(TSEvent eventId)
   case HANDSHAKE_HOOKS_CERT:
   case HANDSHAKE_HOOKS_CERT_INVOKE:
     if (!curHook) {
-      curHook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_CERT_HOOK));
+      curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_CERT_HOOK));
     } else {
       curHook = curHook->next();
     }
@@ -1887,7 +1888,7 @@ SSLNetVConnection::callHooks(TSEvent eventId)
   case HANDSHAKE_HOOKS_CLIENT_CERT:
   case HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE:
     if (!curHook) {
-      curHook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_VERIFY_CLIENT_HOOK));
+      curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_VERIFY_CLIENT_HOOK));
     } else {
       curHook = curHook->next();
     }
@@ -1897,14 +1898,14 @@ SSLNetVConnection::callHooks(TSEvent eventId)
     if (eventId == TS_EVENT_VCONN_CLOSE) {
       sslHandshakeHookState = HANDSHAKE_HOOKS_DONE;
       if (curHook == nullptr) {
-        curHook = ssl_hooks->get(TSSslHookInternalID(TS_VCONN_CLOSE_HOOK));
+        curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_VCONN_CLOSE_HOOK));
       } else {
         curHook = curHook->next();
       }
     } else if (eventId == TS_EVENT_VCONN_OUTBOUND_CLOSE) {
       sslHandshakeHookState = HANDSHAKE_HOOKS_DONE;
       if (curHook == nullptr) {
-        curHook = ssl_hooks->get(TSSslHookInternalID(TS_VCONN_OUTBOUND_CLOSE_HOOK));
+        curHook = g_ssl_hooks->get(TSSslHookInternalID(TS_VCONN_OUTBOUND_CLOSE_HOOK));
       } else {
         curHook = curHook->next();
       }

--- a/iocore/net/SSLSecret.cc
+++ b/iocore/net/SSLSecret.cc
@@ -21,7 +21,8 @@
 
 #include "swoc/swoc_file.h"
 
-#include "api/InkAPIInternal.h" // Added to include the ssl_hook and lifestyle_hook definitions
+#include "api/LifecycleAPIHooks.h"
+
 #include "P_SSLConfig.h"
 
 #include <utility>
@@ -44,7 +45,7 @@ SSLSecret::loadSecret(const std::string &name1, const std::string &name2, std::s
 {
   // Call the load secret hooks
   //
-  class APIHook *curHook = lifecycle_hooks->get(TS_LIFECYCLE_SSL_SECRET_HOOK);
+  class APIHook *curHook = g_lifecycle_hooks->get(TS_LIFECYCLE_SSL_SECRET_HOOK);
   TSSecretID secret_name;
   secret_name.cert_name     = name1.data();
   secret_name.cert_name_len = name1.size();

--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -42,6 +42,7 @@
 #include "P_TLSKeyLogger.h"
 #include "BoringSSLUtils.h"
 #include "ProxyProtocol.h"
+#include "SSLAPIHooks.h"
 #include "SSLSessionCache.h"
 #include "SSLSessionTicket.h"
 #include "SSLDynlock.h"
@@ -228,7 +229,7 @@ ssl_new_cached_session(SSL *ssl, SSL_SESSION *sess)
   session_cache->insertSession(sid, sess, ssl);
 
   // Call hook after new session is created
-  APIHook *hook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_SESSION_HOOK));
+  APIHook *hook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_SESSION_HOOK));
   while (hook) {
     hook->invoke(TS_EVENT_SSL_SESSION_NEW, &sid);
     hook = hook->m_link.next;
@@ -251,7 +252,7 @@ ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess)
   SSLSessionID sid(id, len);
 
   // Call hook before session is removed
-  APIHook *hook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_SESSION_HOOK));
+  APIHook *hook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_SESSION_HOOK));
   while (hook) {
     hook->invoke(TS_EVENT_SSL_SESSION_REMOVE, &sid);
     hook = hook->m_link.next;

--- a/iocore/net/TLSSessionResumptionSupport.cc
+++ b/iocore/net/TLSSessionResumptionSupport.cc
@@ -25,6 +25,7 @@
 // Check if the ticket_key callback #define is available, and if so, enable session tickets.
 
 #include "TLSSessionResumptionSupport.h"
+#include "SSLAPIHooks.h"
 
 #include "P_SSLConfig.h"
 #include "SSLStats.h"
@@ -150,7 +151,7 @@ TLSSessionResumptionSupport::getSession(SSL *ssl, const unsigned char *id, int l
     }
   }
 
-  APIHook *hook = ssl_hooks->get(TSSslHookInternalID(TS_SSL_SESSION_HOOK));
+  APIHook *hook = g_ssl_hooks->get(TSSslHookInternalID(TS_SSL_SESSION_HOOK));
   while (hook) {
     hook->invoke(TS_EVENT_SSL_SESSION_GET, &sid);
     hook = hook->m_link.next;

--- a/iocore/net/libinknet_stub.cc
+++ b/iocore/net/libinknet_stub.cc
@@ -67,7 +67,7 @@ ParentConfigParams::nextParent(HttpRequestData *, ParentResult *, unsigned int, 
   ink_assert(false);
 }
 
-#include "InkAPIInternal.h"
+#include "api/InkAPIInternal.h"
 #include "ControlMatcher.h"
 char *
 HttpRequestData::get_string()

--- a/iocore/net/libinknet_stub.cc
+++ b/iocore/net/libinknet_stub.cc
@@ -97,7 +97,6 @@ HttpRequestData::get_client_ip()
   return nullptr;
 }
 
-LifecycleAPIHooks *lifecycle_hooks = nullptr;
 StatPagesManager statPagesManager;
 
 #include "PreWarmManager.h"

--- a/iocore/net/libinknet_stub.cc
+++ b/iocore/net/libinknet_stub.cc
@@ -67,42 +67,7 @@ ParentConfigParams::nextParent(HttpRequestData *, ParentResult *, unsigned int, 
   ink_assert(false);
 }
 
-#include "api/InkAPIInternal.h"
-int
-APIHook::invoke(int, void *) const
-{
-  ink_assert(false);
-  return 0;
-}
-
-int
-APIHook::blocking_invoke(int, void *) const
-{
-  ink_assert(false);
-  return 0;
-}
-
-APIHook *
-APIHook::next() const
-{
-  ink_assert(false);
-  return nullptr;
-}
-
-APIHook *
-APIHook::prev() const
-{
-  ink_assert(false);
-  return nullptr;
-}
-
-APIHook *
-APIHooks::head() const
-{
-  ink_assert(false);
-  return nullptr;
-}
-
+#include "InkAPIInternal.h"
 #include "ControlMatcher.h"
 char *
 HttpRequestData::get_string()
@@ -132,7 +97,6 @@ HttpRequestData::get_client_ip()
   return nullptr;
 }
 
-SslAPIHooks *ssl_hooks             = nullptr;
 LifecycleAPIHooks *lifecycle_hooks = nullptr;
 StatPagesManager statPagesManager;
 

--- a/iocore/net/unit_tests/unit_test_main.cc
+++ b/iocore/net/unit_tests/unit_test_main.cc
@@ -26,6 +26,7 @@
 #include "I_Thread.h"
 #include "P_SSLConfig.h"
 #include "records/I_RecordsConfig.h"
+#include "SSLAPIHooks.h"
 #include "tscore/BaseLogFile.h"
 #include "tscore/Diags.h"
 #include "tscore/I_Layout.h"
@@ -56,6 +57,7 @@ public:
     main_thread->set_specific();
 
     SSLConfig::startup();
+    init_global_ssl_hooks();
   }
 
   void

--- a/mgmt/rpc/CMakeLists.txt
+++ b/mgmt/rpc/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(rpcpublichandlers
     PRIVATE
         ts::inkcache
         ts::proxy
+        ts::tsapicore
 )
 
 add_executable(test_jsonrpc

--- a/mgmt/rpc/handlers/plugins/Plugins.cc
+++ b/mgmt/rpc/handlers/plugins/Plugins.cc
@@ -21,7 +21,7 @@
 #include "Plugins.h"
 #include "rpc/handlers/common/ErrorUtils.h"
 
-#include "api/InkAPIInternal.h"
+#include "api/LifecycleAPIHooks.h"
 
 namespace
 {
@@ -61,7 +61,7 @@ plugin_send_basic_msg(std::string_view const &id, YAML::Node const &params)
 {
   // The rpc could be ready before plugins are initialized.
   // We make sure it is ready.
-  if (!lifecycle_hooks) {
+  if (!g_lifecycle_hooks) {
     return err::make_errata(err::Codes::PLUGIN, "Plugin is not yet ready to handle any messages.");
   }
 
@@ -75,7 +75,7 @@ plugin_send_basic_msg(std::string_view const &id, YAML::Node const &params)
     msg.data      = info.data.data();
     msg.data_size = info.data.size();
 
-    APIHook *hook = lifecycle_hooks->get(TS_LIFECYCLE_MSG_HOOK);
+    APIHook *hook = g_lifecycle_hooks->get(TS_LIFECYCLE_MSG_HOOK);
 
     while (hook) {
       TSPluginMsg tmp(msg); // Just to make sure plugins don't mess this up for others.

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(proxy STATIC
         CacheControl.cc
         ControlBase.cc
         ControlMatcher.cc
-	    HostStatus.cc
+        HostStatus.cc
+        HttpAPIHooks.cc
         IPAllow.cc
         ParentConsistentHash.cc
         ParentRoundRobin.cc
@@ -64,6 +65,7 @@ target_link_libraries(proxy
     PUBLIC
         ts::inkcache
         ts::inkevent
+        ts::tsapicore
         ts::tscore
     PRIVATE
         ts::inkutils

--- a/proxy/CMakeLists.txt
+++ b/proxy/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(proxy
         ts::tsapicore
         ts::tscore
     PRIVATE
+        ts::jsonrpc_protocol
         ts::inkutils
 )
 

--- a/proxy/HttpAPIHooks.cc
+++ b/proxy/HttpAPIHooks.cc
@@ -1,0 +1,32 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "HttpAPIHooks.h"
+
+HttpAPIHooks *http_global_hooks = nullptr;
+
+void
+init_global_http_hooks()
+{
+  http_global_hooks = new HttpAPIHooks;
+}

--- a/proxy/HttpAPIHooks.h
+++ b/proxy/HttpAPIHooks.h
@@ -1,0 +1,37 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "api/FeatureAPIHooks.h"
+
+#include "ts/apidefs.h"
+
+class HttpAPIHooks : public FeatureAPIHooks<TSHttpHookID, TS_HTTP_LAST_HOOK>
+{
+};
+
+// there is no corresponding deinit; we leak the resource on shutdown
+void init_global_http_hooks();
+
+extern HttpAPIHooks *http_global_hooks;

--- a/proxy/Makefile.am
+++ b/proxy/Makefile.am
@@ -55,6 +55,8 @@ libproxy_a_SOURCES = \
 	ControlMatcher.h \
 	HostStatus.cc \
 	HostStatus.h \
+	HttpAPIHooks.cc \
+	HttpAPIHooks.h \
 	IPAllow.cc \
 	IPAllow.h \
 	ParentConsistentHash.cc \

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -64,6 +64,8 @@ target_link_libraries(http
         ts::tsapicore
         ts::tscore
     PRIVATE
+        ts::http2
+        ts::http_remap
         ts::inkcache
         ts::inkutils
 )

--- a/proxy/http/CMakeLists.txt
+++ b/proxy/http/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(http
         ts::inkevent
         ts::inkhostdb
         ts::proxy
+        ts::tsapicore
         ts::tscore
     PRIVATE
         ts::inkcache

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#include "api/LifecycleAPIHooks.h"
 #include "tscore/ink_config.h"
 #include "P_Net.h"
 #include "HttpConfig.h"
@@ -366,7 +367,7 @@ start_HttpProxyServer()
   statPagesManager.register_http("remap_hits", register_ShowRemapHitCount);
 
   // Alert plugins that connections will be accepted.
-  APIHook *hook = lifecycle_hooks->get(TS_LIFECYCLE_PORTS_READY_HOOK);
+  APIHook *hook = g_lifecycle_hooks->get(TS_LIFECYCLE_PORTS_READY_HOOK);
   while (hook) {
     hook->invoke(TS_EVENT_LIFECYCLE_PORTS_READY, nullptr);
     hook = hook->next();

--- a/proxy/http/remap/CMakeLists.txt
+++ b/proxy/http/remap/CMakeLists.txt
@@ -36,7 +36,10 @@ add_library(http_remap STATIC
 )
 add_library(ts::http_remap ALIAS http_remap)
 
-target_include_directories(http_remap PRIVATE
+target_include_directories(http_remap
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE
         ${IOCORE_INCLUDE_DIRS}
         ${PROXY_INCLUDE_DIRS}
         ${CMAKE_SOURCE_DIR}/src/records

--- a/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
+++ b/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
@@ -60,10 +60,6 @@ HttpCacheAction::cancel(Continuation *c)
 {
 }
 PostDataBuffers::~PostDataBuffers() {}
-void
-APIHooks::clear()
-{
-}
 
 HttpTunnel::HttpTunnel() {}
 HttpCacheSM::HttpCacheSM() {}

--- a/src/api/APIHook.cc
+++ b/src/api/APIHook.cc
@@ -1,0 +1,76 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "api/APIHook.h"
+
+#include "ts/apidefs.h"
+
+#include "tscore/ink_assert.h"
+#include "tscore/ink_atomic.h"
+
+// inkevent
+#include "I_Event.h"
+#include "I_Lock.h"
+
+APIHook *
+APIHook::next() const
+{
+  return m_link.next;
+}
+
+APIHook *
+APIHook::prev() const
+{
+  return m_link.prev;
+}
+
+int
+APIHook::invoke(int event, void *edata) const
+{
+  if (event == EVENT_IMMEDIATE || event == EVENT_INTERVAL || event == TS_EVENT_HTTP_TXN_CLOSE) {
+    if (ink_atomic_increment((int *)&m_cont->m_event_count, 1) < 0) {
+      ink_assert(!"not reached");
+    }
+  }
+  WEAK_MUTEX_TRY_LOCK(lock, m_cont->mutex, this_ethread());
+  if (!lock.is_locked()) {
+    // If we cannot get the lock, the caller needs to restructure to handle rescheduling
+    ink_release_assert(0);
+  }
+  return m_cont->handleEvent(event, edata);
+  return 0;
+}
+
+int
+APIHook::blocking_invoke(int event, void *edata) const
+{
+  if (event == EVENT_IMMEDIATE || event == EVENT_INTERVAL || event == TS_EVENT_HTTP_TXN_CLOSE) {
+    if (ink_atomic_increment((int *)&m_cont->m_event_count, 1) < 0) {
+      ink_assert(!"not reached");
+    }
+  }
+
+  WEAK_SCOPED_MUTEX_LOCK(lock, m_cont->mutex, this_ethread());
+
+  return m_cont->handleEvent(event, edata);
+}

--- a/src/api/APIHooks.cc
+++ b/src/api/APIHooks.cc
@@ -1,0 +1,58 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "api/APIHooks.h"
+
+#include "tscore/Allocator.h"
+
+// inkevent
+#include "I_ProxyAllocator.h"
+#include "I_Thread.h"
+
+static ClassAllocator<APIHook> apiHookAllocator("apiHookAllocator");
+
+APIHook *
+APIHooks::head() const
+{
+  return m_hooks.head;
+}
+
+void
+APIHooks::append(INKContInternal *cont)
+{
+  APIHook *api_hook;
+
+  api_hook         = THREAD_ALLOC(apiHookAllocator, this_thread());
+  api_hook->m_cont = cont;
+
+  m_hooks.enqueue(api_hook);
+}
+
+void
+APIHooks::clear()
+{
+  APIHook *hook;
+  while (nullptr != (hook = m_hooks.pop())) {
+    THREAD_FREE(hook, apiHookAllocator, this_thread());
+  }
+}

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(ts::tsapi ALIAS tsapi)
 target_link_libraries(tsapi PRIVATE ts::tscore)
 
 add_library(tsapicore STATIC
+  APIHook.cc
+  APIHooks.cc
   Metrics.cc
   ConfigUpdateCbTable.cc
   InkContInternal.cc
@@ -36,6 +38,15 @@ include_directories(
   ${IOCORE_INCLUDE_DIRS}
   ${PROXY_INCLUDE_DIRS}
   ${CMAKE_SOURCE_DIR}/mgmt
+)
+
+target_link_libraries(tsapi
+    PUBLIC
+        ts::inkcache # transitive via ts/InkAPIPrivateIOCore
+        ts::tsapicore
+        ts::tscore
+    PRIVATE
+        ts::inkevent
 )
 
 install(TARGETS tsapi)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -40,15 +40,6 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/mgmt
 )
 
-target_link_libraries(tsapi
-    PUBLIC
-        ts::inkcache # transitive via ts/InkAPIPrivateIOCore
-        ts::tsapicore
-        ts::tscore
-    PRIVATE
-        ts::inkevent
-)
-
 install(TARGETS tsapi)
 
 if(APPLE)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(tsapicore STATIC
   InkContInternal.cc
   InkVConnInternal.cc
   FetchSM.cc
+  LifecycleAPIHooks.cc
 )
 add_library(ts::tsapicore ALIAS tsapicore)
 target_link_libraries(tsapicore PRIVATE ts::tscore)

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -44,6 +44,7 @@
 #include "ProxySession.h"
 #include "Http2ClientSession.h"
 #include "PoolableSession.h"
+#include "HttpAPIHooks.h"
 #include "HttpSM.h"
 #include "HttpConfig.h"
 #include "P_Net.h"
@@ -55,6 +56,7 @@
 #include "records/I_RecCore.h"
 #include "P_SSLConfig.h"
 #include "P_SSLClientUtils.h"
+#include "SSLAPIHooks.h"
 #include "SSLDiags.h"
 #include "SSLInternal.h"
 #include "TLSBasicSupport.h"
@@ -391,8 +393,6 @@ namespace c
 } // end namespace c
 } // end namespace tsapi
 
-HttpAPIHooks *http_global_hooks        = nullptr;
-SslAPIHooks *ssl_hooks                 = nullptr;
 LifecycleAPIHooks *lifecycle_hooks     = nullptr;
 ConfigUpdateCbTable *global_config_cbs = nullptr;
 static ts::Metrics &global_api_metrics = ts::Metrics::getInstance();
@@ -1047,73 +1047,6 @@ FileImpl::fgets(char *buf, size_t length)
 // APIHook, APIHooks, HttpAPIHooks, HttpHookState
 //
 ////////////////////////////////////////////////////////////////////
-APIHook *
-APIHook::next() const
-{
-  return m_link.next;
-}
-
-APIHook *
-APIHook::prev() const
-{
-  return m_link.prev;
-}
-
-int
-APIHook::invoke(int event, void *edata) const
-{
-  if (event == EVENT_IMMEDIATE || event == EVENT_INTERVAL || event == TS_EVENT_HTTP_TXN_CLOSE) {
-    if (ink_atomic_increment((int *)&m_cont->m_event_count, 1) < 0) {
-      ink_assert(!"not reached");
-    }
-  }
-  WEAK_MUTEX_TRY_LOCK(lock, m_cont->mutex, this_ethread());
-  if (!lock.is_locked()) {
-    // If we cannot get the lock, the caller needs to restructure to handle rescheduling
-    ink_release_assert(0);
-  }
-  return m_cont->handleEvent(event, edata);
-}
-
-int
-APIHook::blocking_invoke(int event, void *edata) const
-{
-  if (event == EVENT_IMMEDIATE || event == EVENT_INTERVAL || event == TS_EVENT_HTTP_TXN_CLOSE) {
-    if (ink_atomic_increment((int *)&m_cont->m_event_count, 1) < 0) {
-      ink_assert(!"not reached");
-    }
-  }
-
-  WEAK_SCOPED_MUTEX_LOCK(lock, m_cont->mutex, this_ethread());
-
-  return m_cont->handleEvent(event, edata);
-}
-
-APIHook *
-APIHooks::head() const
-{
-  return m_hooks.head;
-}
-
-void
-APIHooks::append(INKContInternal *cont)
-{
-  APIHook *api_hook;
-
-  api_hook         = THREAD_ALLOC(apiHookAllocator, this_thread());
-  api_hook->m_cont = cont;
-
-  m_hooks.enqueue(api_hook);
-}
-
-void
-APIHooks::clear()
-{
-  APIHook *hook;
-  while (nullptr != (hook = m_hooks.pop())) {
-    THREAD_FREE(hook, apiHookAllocator, this_thread());
-  }
-}
 
 void
 HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
@@ -1458,8 +1391,8 @@ api_init()
     TS_HTTP_LEN_PUBLIC           = HTTP_LEN_PUBLIC;
     TS_HTTP_LEN_S_MAXAGE         = HTTP_LEN_S_MAXAGE;
 
-    http_global_hooks = new HttpAPIHooks;
-    ssl_hooks         = new SslAPIHooks;
+    init_global_http_hooks();
+    init_global_ssl_hooks();
     lifecycle_hooks   = new LifecycleAPIHooks;
     global_config_cbs = new ConfigUpdateCbTable;
 
@@ -4551,7 +4484,7 @@ tsapi::c::TSHttpHookAdd(TSHttpHookID id, TSCont contp)
 
   TSSslHookInternalID internalId{id};
   if (internalId.is_in_bounds()) {
-    ssl_hooks->append(internalId, icontp);
+    g_ssl_hooks->append(internalId, icontp);
   } else { // Follow through the regular HTTP hook framework
     http_global_hooks->append(id, icontp);
   }

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -68,6 +68,7 @@
 #include "HttpSessionAccept.h"
 #include "PluginVC.h"
 #include "api/FetchSM.h"
+#include "api/LifecycleAPIHooks.h"
 #include "HttpDebugNames.h"
 #include "I_AIO.h"
 #include "I_Tasks.h"
@@ -393,7 +394,6 @@ namespace c
 } // end namespace c
 } // end namespace tsapi
 
-LifecycleAPIHooks *lifecycle_hooks     = nullptr;
 ConfigUpdateCbTable *global_config_cbs = nullptr;
 static ts::Metrics &global_api_metrics = ts::Metrics::getInstance();
 
@@ -1393,7 +1393,7 @@ api_init()
 
     init_global_http_hooks();
     init_global_ssl_hooks();
-    lifecycle_hooks   = new LifecycleAPIHooks;
+    init_global_lifecycle_hooks();
     global_config_cbs = new ConfigUpdateCbTable;
 
     // Setup the version string for returning to plugins
@@ -4496,7 +4496,7 @@ tsapi::c::TSLifecycleHookAdd(TSLifecycleHookID id, TSCont contp)
   sdk_assert(sdk_sanity_check_continuation(contp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_lifecycle_hook_id(id) == TS_SUCCESS);
 
-  lifecycle_hooks->append(id, (INKContInternal *)contp);
+  g_lifecycle_hooks->append(id, (INKContInternal *)contp);
 }
 
 /* HTTP sessions */

--- a/src/api/LifecycleAPIHooks.cc
+++ b/src/api/LifecycleAPIHooks.cc
@@ -1,0 +1,32 @@
+/** @file
+
+  Internal SDK stuff
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "api/LifecycleAPIHooks.h"
+
+LifecycleAPIHooks *g_lifecycle_hooks = nullptr;
+
+void
+init_global_lifecycle_hooks()
+{
+  g_lifecycle_hooks = new LifecycleAPIHooks;
+}

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -35,8 +35,13 @@ AM_CPPFLAGS += \
 	-I$(abs_top_srcdir)/proxy/http2 \
 	-I$(abs_top_srcdir)/proxy/http/remap \
 	-I$(abs_top_srcdir)/proxy/logging \
-    -I$(abs_top_srcdir)/mgmt/rpc \
-    -I$(abs_top_srcdir)/mgmt/ \
+	-I$(abs_top_srcdir)/mgmt/rpc \
+	-I$(abs_top_srcdir)/mgmt/ \
+	-I$(abs_top_srcdir)/iocore/eventsystem \
+	-I$(abs_top_srcdir)/iocore/cache \
+	-I$(abs_top_srcdir)/iocore/aio \
+	-I$(abs_top_srcdir)/iocore/net \
+	-I$(abs_top_srcdir)/iocore/dns \
 	@SWOC_INCLUDES@ \
 	@YAMLCPP_INCLUDES@ \
 	$(TS_INCLUDES)
@@ -59,6 +64,8 @@ endif
 # libtsapicore.a
 
 libtsapicore_a_SOURCES = \
+	APIHook.cc \
+	APIHooks.cc \
 	Metrics.cc \
 	ConfigUpdateCbTable.cc \
 	InkContInternal.cc \

--- a/src/api/Makefile.am
+++ b/src/api/Makefile.am
@@ -70,7 +70,8 @@ libtsapicore_a_SOURCES = \
 	ConfigUpdateCbTable.cc \
 	InkContInternal.cc \
 	InkVConnInternal.cc \
-	FetchSM.cc
+	FetchSM.cc \
+	LifecycleAPIHooks.cc
 
 test_Metrics_SOURCES = test_Metrics.cc
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ macro(add_cache_test name)
             ${CMAKE_SOURCE_DIR}/iocore/cache/test/stub.cc
             ${CMAKE_SOURCE_DIR}/iocore/cache/test/CacheTestHandler.cc
             ${ARGN})
-    target_link_libraries(${name} PRIVATE ts::inknet ts::proxy ts::tsapi ts::tsapicore)
+    target_link_libraries(${name} PRIVATE ts::inknet ts::proxy ts::tsapicore)
     add_test(NAME test_cache_${name} COMMAND $<TARGET_FILE:${name}>)
 endmacro()
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ macro(add_cache_test name)
             ${CMAKE_SOURCE_DIR}/iocore/cache/test/stub.cc
             ${CMAKE_SOURCE_DIR}/iocore/cache/test/CacheTestHandler.cc
             ${ARGN})
-    target_link_libraries(${name} PRIVATE ts::proxy)
+    target_link_libraries(${name} PRIVATE ts::inknet ts::proxy ts::tsapi ts::tsapicore)
     add_test(NAME test_cache_${name} COMMAND $<TARGET_FILE:${name}>)
 endmacro()
 
@@ -75,7 +75,6 @@ macro(add_net_test name)
     add_executable(${name}
             ${CMAKE_SOURCE_DIR}/iocore/net/libinknet_stub.cc
             ${ARGN})
-    target_link_libraries(${name} PRIVATE ts::proxy)
     add_test(NAME test_cache_${name} COMMAND $<TARGET_FILE:${name}>)
 endmacro()
 

--- a/src/traffic_logcat/CMakeLists.txt
+++ b/src/traffic_logcat/CMakeLists.txt
@@ -15,6 +15,20 @@
 #
 #######################
 
-add_executable(traffic_logcat logcat.cc)
-target_link_libraries(traffic_logcat PRIVATE ts::tscore ts::proxy ts::logging ts::hdrs ts::tsapicore ts::diagsconfig libswoc)
+add_executable(traffic_logcat
+  ${PROJECT_SOURCE_DIR}/src/shared/overridable_txn_vars.cc
+  logcat.cc
+)
+target_link_libraries(traffic_logcat
+  PRIVATE
+    ts::tsapi
+    ts::proxy
+    ts::inknet
+    ts::logging
+    ts::hdrs
+    ts::tsapicore
+    ts::diagsconfig
+    ts::configmanager
+    libswoc
+)
 install(TARGETS traffic_logcat)


### PR DESCRIPTION
This is the second of three parts of a refactoring to break out FeatureAPIHooks, making it possible to unit test hook callbacks.

This moves APIHook, APIHooks, and FeatureAPIHooks to tsapi. It also moves the global ssl hooks to inknet, and the global http tooks to proxy. This removes the definitions of all those classes from the various stubs (in inknet, inkcache, and http_remap).

The diff is pretty large, but there are very few source changes. Licenses and includes were added, and the global ssl hooks were renamed from `ssl_hooks` to `g_ssl_hooks`. Similar changes were made for the http and lifecycle hooks, which I placed in proxy and tsapicore respectively. I also added functions to iocore, proxy, and tsapicore to initialize their respective global hooks.

EDIT: There won't be a third part. This already finishes everything I wanted to refactor.