### PR TITLE
Fix the libloader plugin makefile.

### DIFF
--- a/plugins/libloader/Makefile.inc
+++ b/plugins/libloader/Makefile.inc
@@ -17,5 +17,5 @@
 pkglib_LTLIBRARIES += libloader/libloader.la
 
 libloader_libloader_la_SOURCES = \
-	libloader/libloader.c
+	libloader/libloader.c \
 	libloader/libloader.h


### PR DESCRIPTION
The dangling header name doesn't break the build now, but since automake moves statements around, perturbing things by adding a new plugin can lead to invalid build rules.