### PR TITLE
Fix KeyEqual param for ConnectingIpPool declaration

### DIFF
--- a/proxy/http/ConnectingEntry.h
+++ b/proxy/http/ConnectingEntry.h
@@ -70,7 +70,7 @@ struct IpHelper {
   }
 };
 
-using ConnectingIpPool = std::unordered_multimap<IpEndpoint, ConnectingEntry *, IpHelper>;
+using ConnectingIpPool = std::unordered_multimap<IpEndpoint, ConnectingEntry *, IpHelper, IpHelper>;
 
 /** Represents the set of connections to an origin. */
 class ConnectingPool


### PR DESCRIPTION
the 4th parameter, `KeyEqual`, is missing in ConnectingIpPool declaration, which may lead to the comparison of two `IpEndpoint` object won't work as we expected. That is, the default one is unlikely to work with `sockaddr` type.
In another way, IpHelper contains the compare operator for IpEndpoint type, so IpHelper should be used as the KeyEqual parameter of ConnectingIpPool declaration.