### PR TITLE
Avoid unnecessary (multi-core) writes of Thread::cur_time.

### DIFF
--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -34,7 +34,7 @@
 // Common Interface impl                     //
 ///////////////////////////////////////////////
 
-thread_local ink_hrtime Thread::cur_time = ink_get_hrtime_internal();
+ink_hrtime Thread::cur_time = ink_get_hrtime_internal();
 thread_local Thread *Thread::this_thread_ptr;
 
 Thread::Thread()


### PR DESCRIPTION
This variable is used frequently in most threads.  By avoiding unnecessary writes of it, locks of its cache line in (all) per-core caches are reduced.  This should reduce CPU core stalls.  The variable thus does not need to be thread_local.