### PR TITLE
Remove Http3NoError allocations

### DIFF
--- a/proxy/http3/Http3App.cc
+++ b/proxy/http3/Http3App.cc
@@ -192,7 +192,7 @@ Http3App::create_uni_stream(QUICStreamId &new_stream_id, Http3StreamType type)
 void
 Http3App::_handle_uni_stream_on_read_ready(int /* event */, VIO *vio)
 {
-  Http3ErrorUPtr error = Http3ErrorUPtr(new Http3NoError());
+  Http3ErrorUPtr error = Http3ErrorUPtr(nullptr);
   Http3StreamType type;
   QUICStreamVCAdapter *adapter = static_cast<QUICStreamVCAdapter *>(vio->vc_server);
   auto it                      = this->_remote_uni_stream_map.find(adapter->stream().id());
@@ -390,7 +390,7 @@ Http3SettingsHandler::handle_frame(std::shared_ptr<const Http3Frame> frame, int3
 
   if (!settings_frame) {
     // make error
-    return Http3ErrorUPtr(new Http3NoError());
+    return Http3ErrorUPtr(nullptr);
   }
 
   if (settings_frame->is_valid()) {
@@ -426,7 +426,7 @@ Http3SettingsHandler::handle_frame(std::shared_ptr<const Http3Frame> frame, int3
     Debug("http3", "SETTINGS_NUM_PLACEHOLDERS: %" PRId64, num_placeholders);
   }
 
-  return Http3ErrorUPtr(new Http3NoError());
+  return Http3ErrorUPtr(nullptr);
 }
 
 //

--- a/proxy/http3/Http3FrameCollector.cc
+++ b/proxy/http3/Http3FrameCollector.cc
@@ -47,7 +47,7 @@ Http3FrameCollector::on_write_ready(QUICStreamId stream_id, MIOBuffer &writer, s
     all_done &= g->is_done();
   }
 
-  return Http3ErrorUPtr(new Http3NoError());
+  return Http3ErrorUPtr(nullptr);
 }
 
 void

--- a/proxy/http3/Http3FrameDispatcher.cc
+++ b/proxy/http3/Http3FrameDispatcher.cc
@@ -44,7 +44,7 @@ Http3ErrorUPtr
 Http3FrameDispatcher::on_read_ready(QUICStreamId stream_id, Http3StreamType stream_type, IOBufferReader &reader, uint64_t &nread)
 {
   std::shared_ptr<const Http3Frame> frame(nullptr);
-  Http3ErrorUPtr error = Http3ErrorUPtr(new Http3NoError());
+  Http3ErrorUPtr error = Http3ErrorUPtr(nullptr);
   nread                = 0;
   uint32_t frame_count = 0;
 
@@ -108,7 +108,7 @@ Http3FrameDispatcher::on_read_ready(QUICStreamId stream_id, Http3StreamType stre
       std::vector<Http3FrameHandler *> handlers = this->_handlers[static_cast<uint8_t>(type)];
       for (auto h : handlers) {
         error = h->handle_frame(frame, frame_count - 1, stream_type);
-        if (error->cls != Http3ErrorClass::NONE) {
+        if (error && error->cls != Http3ErrorClass::NONE) {
           return error;
         }
       }

--- a/proxy/http3/Http3HeaderVIOAdaptor.cc
+++ b/proxy/http3/Http3HeaderVIOAdaptor.cc
@@ -65,7 +65,7 @@ Http3HeaderVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame, int
     ink_abort("should not be here");
   }
 
-  return Http3ErrorUPtr(new Http3NoError());
+  return Http3ErrorUPtr(nullptr);
 }
 
 bool

--- a/proxy/http3/Http3ProtocolEnforcer.cc
+++ b/proxy/http3/Http3ProtocolEnforcer.cc
@@ -37,7 +37,7 @@ Http3ProtocolEnforcer::interests()
 Http3ErrorUPtr
 Http3ProtocolEnforcer::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq, Http3StreamType s_type)
 {
-  Http3ErrorUPtr error  = Http3ErrorUPtr(new Http3NoError());
+  Http3ErrorUPtr error  = Http3ErrorUPtr(nullptr);
   Http3FrameType f_type = frame->type();
   if (s_type == Http3StreamType::CONTROL) {
     if (frame_seq == 0 && f_type != Http3FrameType::SETTINGS) {

--- a/proxy/http3/Http3StreamDataVIOAdaptor.cc
+++ b/proxy/http3/Http3StreamDataVIOAdaptor.cc
@@ -48,7 +48,7 @@ Http3StreamDataVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame,
   this->_buffer->write(dframe->payload(), dframe->payload_length());
   this->_total_data_length += dframe->payload_length();
 
-  return Http3ErrorUPtr(new Http3NoError());
+  return Http3ErrorUPtr(nullptr);
 }
 
 void

--- a/proxy/http3/Http3Types.h
+++ b/proxy/http3/Http3Types.h
@@ -113,12 +113,6 @@ protected:
     : cls(Http3ErrorClass::APPLICATION), app_error_code(error_code), msg(error_msg){};
 };
 
-class Http3NoError : public Http3Error
-{
-public:
-  Http3NoError() : Http3Error() {}
-};
-
 class Http3ConnectionError : public Http3Error
 {
 public:
@@ -142,6 +136,4 @@ public:
   Http3Stream *stream;
 };
 
-using Http3ErrorUPtr           = std::unique_ptr<Http3Error>;
-using Http3ConnectionErrorUPtr = std::unique_ptr<Http3ConnectionError>;
-using Http3StreamErrorUPtr     = std::unique_ptr<Http3StreamError>;
+using Http3ErrorUPtr = std::unique_ptr<Http3Error>;

--- a/proxy/http3/test/Mock.h
+++ b/proxy/http3/test/Mock.h
@@ -42,6 +42,6 @@ public:
   handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t /* frame_seq */, Http3StreamType /* s_type */) override
   {
     this->total_frame_received++;
-    return Http3ErrorUPtr(new Http3NoError());
+    return Http3ErrorUPtr(nullptr);
   }
 };

--- a/proxy/http3/test/test_Http3FrameDispatcher.cc
+++ b/proxy/http3/test/test_Http3FrameDispatcher.cc
@@ -47,7 +47,7 @@ TEST_CASE("Http3FrameHandler dispatch", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
@@ -56,7 +56,7 @@ TEST_CASE("Http3FrameHandler dispatch", "[http3]")
     CHECK(nread == 0);
 
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::UNKNOWN, *reader, nread);
-    CHECK(error->app_error_code == Http3ErrorCode::H3_NO_ERROR);
+    CHECK(!error);
     CHECK(handler.total_frame_received == 1);
     CHECK(nread == 12);
   }
@@ -95,7 +95,7 @@ TEST_CASE("control stream tests", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
@@ -104,6 +104,7 @@ TEST_CASE("control stream tests", "[http3]")
     CHECK(nread == 0);
 
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::CONTROL, *reader, nread);
+    REQUIRE(error);
     CHECK(error->app_error_code == Http3ErrorCode::H3_FRAME_UNEXPECTED);
     CHECK(handler.total_frame_received == 1);
     CHECK(nread == sizeof(input));
@@ -135,7 +136,7 @@ TEST_CASE("control stream tests", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
@@ -144,6 +145,7 @@ TEST_CASE("control stream tests", "[http3]")
     CHECK(nread == 0);
 
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::CONTROL, *reader, nread);
+    REQUIRE(error);
     CHECK(error->app_error_code == Http3ErrorCode::H3_MISSING_SETTINGS);
     CHECK(handler.total_frame_received == 0);
     CHECK(nread == 3);
@@ -173,7 +175,7 @@ TEST_CASE("control stream tests", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
@@ -182,6 +184,7 @@ TEST_CASE("control stream tests", "[http3]")
     CHECK(nread == 0);
 
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::CONTROL, *reader, nread);
+    REQUIRE(error);
     CHECK(error->app_error_code == Http3ErrorCode::H3_FRAME_UNEXPECTED);
     CHECK(handler.total_frame_received == 1);
     CHECK(nread == sizeof(input));
@@ -211,7 +214,7 @@ TEST_CASE("control stream tests", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
@@ -220,6 +223,7 @@ TEST_CASE("control stream tests", "[http3]")
     CHECK(nread == 0);
 
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::CONTROL, *reader, nread);
+    REQUIRE(error);
     CHECK(error->app_error_code == Http3ErrorCode::H3_FRAME_UNEXPECTED);
     CHECK(handler.total_frame_received == 1);
     CHECK(nread == sizeof(input));
@@ -249,7 +253,7 @@ TEST_CASE("control stream tests", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
@@ -258,6 +262,7 @@ TEST_CASE("control stream tests", "[http3]")
     CHECK(nread == 0);
 
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::CONTROL, *reader, nread);
+    REQUIRE(error);
     CHECK(error->app_error_code == Http3ErrorCode::H3_FRAME_UNEXPECTED);
     CHECK(handler.total_frame_received == 1);
     CHECK(nread == sizeof(input));
@@ -277,13 +282,13 @@ TEST_CASE("ignore unknown frames", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
     CHECK(nread == 0);
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::UNKNOWN, *reader, nread);
-    CHECK(error->app_error_code == Http3ErrorCode::H3_NO_ERROR);
+    CHECK(!error);
     CHECK(nread == 0);
   }
 }
@@ -308,7 +313,7 @@ TEST_CASE("Reserved frame type not allowed", "[http3]")
     MIOBuffer *buf         = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
     IOBufferReader *reader = buf->alloc_reader();
     uint64_t nread         = 0;
-    Http3ErrorUPtr error   = Http3ErrorUPtr(new Http3NoError());
+    Http3ErrorUPtr error   = Http3ErrorUPtr(nullptr);
 
     buf->write(input, sizeof(input));
 
@@ -317,6 +322,7 @@ TEST_CASE("Reserved frame type not allowed", "[http3]")
     CHECK(nread == 0);
 
     error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::UNKNOWN, *reader, nread);
+    REQUIRE(error);
     CHECK(error->app_error_code == Http3ErrorCode::H3_FRAME_UNEXPECTED);
     CHECK(handler.total_frame_received == 0);
     CHECK(nread == 12);


### PR DESCRIPTION
The Http3Error mechanism is written around dynamic polymorphism, with Http3Error as the base class and a few child classes for specifc types of errors. One of those was Http3NoError. It was observed that the frequent allocations for Http3NoError in many places was wasteful, so this patch removes those allocations by instead returning nullptr instead and removes the Http3NoError class since it is no longer used.

Fixes #9992