### PR TITLE
cache_range test performance improvement

### DIFF
--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cache_complete_responses.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cache_complete_responses.test.py
@@ -49,14 +49,10 @@ Test.testName = "cache_range_requests_cache_200s"
 
 # Generate bodies for our responses
 small_body_len = 10000
-small_body = ''
-for i in range(small_body_len):
-    small_body += 'x'
+small_body = 'x' * small_body_len
 
 slice_body_len = 4 * 1024 * 1024
-slice_body = ''
-for i in range(slice_body_len):
-    slice_body += 'x'
+slice_body = 'x' * slice_body_len
 
 # Define and configure ATS
 ts = Test.MakeATSProcess("ts")


### PR DESCRIPTION
cache_range_requests_cache_complete_responses.test.py had a for loop where it appended a single character to a string 4 million times. This is exceedingly slow in Python as it needed to reallocate, copy, and append with each iteration. This patched version reduces the time to a fraction of a second instead of multiple minutes (4 minutes on my system).