### PR TITLE
Remove autoconf headers during CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,16 @@ include(subproject_version)
 subproject_version(YAML_CPP YAMLCPP_LIB_VERSION)
 
 set(rel_cachedir var/trafficserver)
+
+if(EXISTS "${PROJECT_SOURCE_DIR}/include/ink_autoconf.h")
+    message(STATUS "Autoconf build detected in source tree. Removing autoconf headers.")
+endif()
+
+# In-tree autoconf configuration causes duplicate definitions of some symbols
+# in generated headers. If the files don't exist, no error is emitted.
+file(REMOVE "${PROJECT_SOURCE_DIR}/include/tscore/ink_config.h")
+file(REMOVE "${PROJECT_SOURCE_DIR}/include/ink_autoconf.h")
+
 configure_file(configs/storage.config.default.in configs/storage.config.default)
 configure_file(configs/records.yaml.default.in configs/records.yaml.default)
 configure_file(include/tscore/ink_config.h.cmake.in include/tscore/ink_config.h)


### PR DESCRIPTION
The headers cause duplicate symbol warnings if they are in the source tree during a configuration. This should finally put that annoyance to rest.