### PR TITLE
Strictly follow Content-Length header ABNF rule (#10144)

### DIFF
--- a/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -45,7 +45,7 @@ TEST_CASE("HdrTestHttpParse", "[proxy][hdrtest]")
     int expected_result;
     int expected_bytes_consumed;
   };
-  static const std::array<Test, 23> tests = {{
+  static const std::array<Test, 26> tests = {{
     {"GET /index.html HTTP/1.0\r\n", PARSE_RESULT_DONE, 26},
     {"GET /index.html HTTP/1.0\r\n\r\n***BODY****", PARSE_RESULT_DONE, 28},
     {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n\r\n***BODY****", PARSE_RESULT_DONE, 48},
@@ -66,6 +66,9 @@ TEST_CASE("HdrTestHttpParse", "[proxy][hdrtest]")
     {"GET /index.html HTTP/1.0\r\nUser-Agent: foobar\r\n", PARSE_RESULT_DONE, 46},
     {"GET /index.html HTTP/1.0\r\n", PARSE_RESULT_DONE, 26},
     {"GET /index.html hTTP/1.0\r\n", PARSE_RESULT_ERROR, 26},
+    {"POST /index.html HTTP/1.0\r\nContent-Length: 0\r\n\r\n", PARSE_RESULT_DONE, 48},
+    {"POST /index.html HTTP/1.0\r\nContent-Length: \r\n\r\n", PARSE_RESULT_ERROR, 47},
+    {"POST /index.html HTTP/1.0\r\nContent-Length:\r\n\r\n", PARSE_RESULT_ERROR, 46},
     {"CONNECT foo.example HTTP/1.1\r\n", PARSE_RESULT_DONE, 30},
     {"GET foo.example HTTP/1.1\r\n", PARSE_RESULT_ERROR, 26},
     {"", PARSE_RESULT_ERROR, 0},


### PR DESCRIPTION
Backport #10144 to the 9.2.x branch.

----

- Replace content-length value type from const char * to std::string_view

(cherry picked from commit f9aa1e0adb7d23cb9d9dd4fb421b80a24654ae85)

Conflicts:
	proxy/hdrs/unit_tests/test_Hdrs.cc