### PR TITLE
Fix conf_remap plugin build on macOS

### DIFF
--- a/mk/plugins.mk
+++ b/mk/plugins.mk
@@ -27,6 +27,7 @@ TS_PLUGIN_LD_FLAGS = \
 TS_PLUGIN_CPPFLAGS = \
   -I$(abs_top_srcdir)/include \
   -I$(abs_top_srcdir)/lib \
+  @YAMLCPP_INCLUDES@ \
   @SWOC_INCLUDES@
 
 # Provide a default AM_CPPFLAGS. Automake handles this correctly, but libtool


### PR DESCRIPTION
```
../include/tscpp/util/YamlCfg.h:29:10: fatal error: 'yaml-cpp/yaml.h' file not found
#include <yaml-cpp/yaml.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
gmake[2]: *** [Makefile:6594: conf_remap/conf_remap.lo] Error 1
```

It looks like 6c617ea13016689c6b838e80c4e181008a087a6f  made `conf_reamp.cc` requires <yaml-cpp/yaml.h> by using `tscpp/util/YamlCfg.h`. However, `TS_PLUGIN_CPPFLAGS` doesn't know the path.