### PR TITLE
LSan: Fix memory leak of test_EventSystem

### DIFF
--- a/iocore/eventsystem/unit_tests/test_EventSystem.cc
+++ b/iocore/eventsystem/unit_tests/test_EventSystem.cc
@@ -71,10 +71,10 @@ TEST_CASE("EventSystem", "[iocore]")
     }
   };
 
-  alarm_printer *alrm    = new alarm_printer(new_ProxyMutex());
-  process_killer *killer = new process_killer(new_ProxyMutex());
-  eventProcessor.schedule_in(killer, HRTIME_SECONDS(10));
-  eventProcessor.schedule_every(alrm, HRTIME_SECONDS(1));
+  alarm_printer alrm{new_ProxyMutex()};
+  process_killer killer{new_ProxyMutex()};
+  eventProcessor.schedule_in(&killer, HRTIME_SECONDS(10));
+  eventProcessor.schedule_every(&alrm, HRTIME_SECONDS(1));
 
   while (!TSSystemState::is_event_system_shut_down()) {
     sleep(1);


### PR DESCRIPTION
```
=================================================================
==33346==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x106105fed in wrap__Znwm+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xeefed) (BuildId: 7be29bc853af3228b5ae02c6da2408ac2400000010000000000a0a000
0000d00)
    #1 0x10461d817 in C_A_T_C_H_T_E_S_T_0() test_EventSystem.cc:75
    #2 0x1045e2912 in Catch::TestInvokerAsFunction::invoke() const catch.hpp:14328
    #3 0x1045cb24e in Catch::TestCase::invoke() const catch.hpp:14167
    #4 0x1045cb03e in Catch::RunContext::invokeActiveTestCase() catch.hpp:13027
    #5 0x1045c4738 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic
_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:13000
    #6 0x1045c2507 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12761
    #7 0x1045d2d69 in Catch::(anonymous namespace)::TestGroup::execute() catch.hpp:13354
    #8 0x1045d1806 in Catch::Session::runInternal() catch.hpp:13560
    #9 0x1045d1212 in Catch::Session::run() catch.hpp:13516
    #10 0x10461d70f in int Catch::Session::run<char>(int, char const* const*) catch.hpp:13238
    #11 0x10461d435 in main catch.hpp:17533
    #12 0x7ff80261d41e in start+0x76e (dyld:x86_64+0xfffffffffff6e41e) (BuildId: 5db85b72c63a318291e55c942ec30e4832000000200000000100000000040d00)

SUMMARY: AddressSanitizer: 72 byte(s) leaked in 1 allocation(s).
```