### PR TITLE
LSan: Fix leak of test_Metrics

### DIFF
--- a/include/api/Metrics.h
+++ b/include/api/Metrics.h
@@ -63,7 +63,12 @@ public:
   Metrics &operator=(Metrics &&)          = delete;
   Metrics(Metrics &&)                     = delete;
 
-  virtual ~Metrics() = default;
+  virtual ~Metrics()
+  {
+    for (size_t i = 0; i <= _cur_blob; ++i) {
+      delete _blobs[i];
+    }
+  }
 
   Metrics()
   {


### PR DESCRIPTION
```
=================================================================
==62119==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 245760 byte(s) in 3 object(s) allocated from:
    #0 0x111067fed in wrap__Znwm+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xeefed) (BuildId: 7be29bc853af3228b5ae02c6da2408ac2400000010000000000a0a0000000d00)
    #1 0x11009150e in ts::Metrics::Metrics() Metrics.h:70
    #2 0x11008f254 in ts::Metrics::Metrics() Metrics.h:69
    #3 0x10ffe85ff in C_A_T_C_H_T_E_S_T_0() test_Metrics.cc:31
    #4 0x10ffaccb2 in Catch::TestInvokerAsFunction::invoke() const catch.hpp:14328
    #5 0x10ff955ee in Catch::TestCase::invoke() const catch.hpp:14167
    #6 0x10ff953de in Catch::RunContext::invokeActiveTestCase() catch.hpp:13027
    #7 0x10ff8ead8 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:13000
    #8 0x10ff8c8a7 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12761
    #9 0x10ff9d109 in Catch::(anonymous namespace)::TestGroup::execute() catch.hpp:13354
    #10 0x10ff9bba6 in Catch::Session::runInternal() catch.hpp:13560
    #11 0x10ff9b5b2 in Catch::Session::run() catch.hpp:13516
    #12 0x10ffe7aaf in int Catch::Session::run<char>(int, char const* const*) catch.hpp:13238
    #13 0x10ffe77d5 in main catch.hpp:17533
    #14 0x7ff80261d41e in start+0x76e (dyld:x86_64+0xfffffffffff6e41e) (BuildId: 5db85b72c63a318291e55c942ec30e4832000000200000000100000000040d00)

Indirect leak of 96 byte(s) in 3 object(s) allocated from:
    #0 0x111067fed in wrap__Znwm+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xeefed) (BuildId: 7be29bc853af3228b5ae02c6da2408ac2400000010000000000a0a0000000d00)
    #1 0x110ab679b in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__init(char const*, unsigned long)+0x3b (libc++.1.0.dylib:x86_64+0x1c79b) (BuildId: fab5e9606110320cb4e6fad86d49580d32000000200000000100000000000d00)
    #2 0x11077a97e in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string<std::__1::basic_string_view<char, std::__1::char_traits<char>>, void>(std::__1::basic_string_view<char, std::__1::char_traits<char>> const&) string:2266
    #3 0x11077123c in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string<std::__1::basic_string_view<char, std::__1::char_traits<char>>, void>(std::__1::basic_string_view<char, std::__1::char_traits<char>> const&) string:2264
    #4 0x11077071a in ts::Metrics::newMetric(std::__1::basic_string_view<char, std::__1::char_traits<char>>) Metrics.cc:66
    #5 0x1100916ba in ts::Metrics::Metrics() Metrics.h:72
    #6 0x11008f254 in ts::Metrics::Metrics() Metrics.h:69
    #7 0x10ffe85ff in C_A_T_C_H_T_E_S_T_0() test_Metrics.cc:31
    #8 0x10ffaccb2 in Catch::TestInvokerAsFunction::invoke() const catch.hpp:14328
    #9 0x10ff955ee in Catch::TestCase::invoke() const catch.hpp:14167
    #10 0x10ff953de in Catch::RunContext::invokeActiveTestCase() catch.hpp:13027
    #11 0x10ff8ead8 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:13000
    #12 0x10ff8c8a7 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12761
    #13 0x10ff9d109 in Catch::(anonymous namespace)::TestGroup::execute() catch.hpp:13354
    #14 0x10ff9bba6 in Catch::Session::runInternal() catch.hpp:13560
    #15 0x10ff9b5b2 in Catch::Session::run() catch.hpp:13516
    #16 0x10ffe7aaf in int Catch::Session::run<char>(int, char const* const*) catch.hpp:13238
    #17 0x10ffe77d5 in main catch.hpp:17533
    #18 0x7ff80261d41e in start+0x76e (dyld:x86_64+0xfffffffffff6e41e) (BuildId: 5db85b72c63a318291e55c942ec30e4832000000200000000100000000040d00)

SUMMARY: AddressSanitizer: 245856 byte(s) leaked in 6 allocation(s).
```

It looks like the allocated `MetricStorage` are not deleted.

