### PR TITLE
clang-analyzer fixes for clang14 (#10055)

### DIFF
--- a/iocore/net/NetEvent.h
+++ b/iocore/net/NetEvent.h
@@ -37,7 +37,7 @@ public:
   virtual ~NetEvent() {}
   virtual void net_read_io(NetHandler *nh, EThread *lthread)  = 0;
   virtual void net_write_io(NetHandler *nh, EThread *lthread) = 0;
-  virtual void free(EThread *t)                               = 0;
+  virtual void free_thread(EThread *t)                        = 0;
 
   // since we want this class to be independent from VConnection, Continutaion. There should be
   // a pure virtual function which connect sub class and NetHandler.

--- a/iocore/net/P_QUICNetVConnection.h
+++ b/iocore/net/P_QUICNetVConnection.h
@@ -177,7 +177,7 @@ public:
   int state_connection_closed(int event, Event *data);
   void start();
   void remove_connection_ids();
-  void free(EThread *t) override;
+  void free_thread(EThread *t) override;
   void free() override;
   void destroy(EThread *t);
 

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -106,7 +106,7 @@ class SSLNetVConnection : public UnixNetVConnection,
 public:
   int sslStartHandShake(int event, int &err) override;
   void clear() override;
-  void free(EThread *t) override;
+  void free_thread(EThread *t) override;
 
   bool
   trackFirstHandshake() override

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -187,7 +187,7 @@ public:
   // NetEvent
   virtual void net_read_io(NetHandler *nh, EThread *lthread) override;
   virtual void net_write_io(NetHandler *nh, EThread *lthread) override;
-  virtual void free(EThread *t) override;
+  virtual void free_thread(EThread *t) override;
   virtual int
   close() override
   {

--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -122,7 +122,7 @@ QUICNetProcessor::connect_re(Continuation *cont, sockaddr const *remote_addr, Ne
   Action *status;
   bool result = udpNet.CreateUDPSocket(&fd, remote_addr, &status, *opt);
   if (!result) {
-    vc->free(t);
+    vc->free_thread(t);
     return status;
   }
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -358,7 +358,7 @@ QUICNetVConnection::acceptEvent(int event, Event *e)
 
   // Send this NetVC to NetHandler and start to polling read & write event.
   if (h->startIO(this) < 0) {
-    free(t);
+    this->free_thread(t);
     return EVENT_DONE;
   }
 
@@ -402,7 +402,7 @@ QUICNetVConnection::startEvent(int event, Event *e)
   if (!action_.cancelled) {
     this->connectUp(e->ethread, NO_FD);
   } else {
-    this->free(e->ethread);
+    this->free_thread(e->ethread);
   }
 
   return EVENT_DONE;
@@ -491,7 +491,7 @@ QUICNetVConnection::start()
 }
 
 void
-QUICNetVConnection::free(EThread *t)
+QUICNetVConnection::free_thread(EThread *t)
 {
   QUICConDebug("Free connection");
 
@@ -524,7 +524,7 @@ QUICNetVConnection::free(EThread *t)
 void
 QUICNetVConnection::free()
 {
-  this->free(this_ethread());
+  this->free_thread(this_ethread());
 }
 
 // called by ET_UDP
@@ -1018,7 +1018,7 @@ QUICNetVConnection::state_connection_closed(int event, Event *data)
     if (this->nh) {
       this->nh->free_netevent(this);
     } else {
-      this->free(this->mutex->thread_holding);
+      this->free_thread(this->mutex->thread_holding);
     }
     break;
   }

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -981,7 +981,7 @@ SSLNetVConnection::clear()
   super::clear();
 }
 void
-SSLNetVConnection::free(EThread *t)
+SSLNetVConnection::free_thread(EThread *t)
 {
   ink_release_assert(t == this_ethread());
 

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -364,7 +364,7 @@ NetHandler::free_netevent(NetEvent *ne)
   // Release ne from NetHandler
   stopIO(ne);
   // Clear and deallocate ne
-  ne->free(t);
+  ne->free_thread(t);
 }
 
 //

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -639,7 +639,7 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
   // FIXME: the nh must not nullptr.
   ink_assert(nh);
 
-  // The vio continuations will be cleared in ::clear called from ::free
+  // The vio continuations will be cleared in ::clear called from ::free_thread
   read.enabled    = 0;
   write.enabled   = 0;
   read.vio.nbytes = 0;
@@ -678,7 +678,7 @@ UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
     if (nh) {
       nh->free_netevent(this);
     } else {
-      this->free(t);
+      this->free_thread(t);
     }
   }
 }
@@ -1019,7 +1019,7 @@ UnixNetVConnection::acceptEvent(int event, Event *e)
 
   // Send this NetVC to NetHandler and start to polling read & write event.
   if (h->startIO(this) < 0) {
-    free(t);
+    this->free_thread(t);
     return EVENT_DONE;
   }
 
@@ -1241,7 +1241,7 @@ fail:
   if (nullptr != nh) {
     nh->free_netevent(this);
   } else {
-    this->free(t);
+    this->free_thread(t);
   }
   return CONNECT_FAILURE;
 }
@@ -1288,7 +1288,7 @@ UnixNetVConnection::clear()
 }
 
 void
-UnixNetVConnection::free(EThread *t)
+UnixNetVConnection::free_thread(EThread *t)
 {
   ink_release_assert(t == this_ethread());
 

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -8161,13 +8161,13 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
       // The redirect URL did not begin with a slash, so we parsed some or all
       // of the relative URI path as the host.
       // Prepend a slash and parse again.
-      char redirect_url_leading_slash[arg_redirect_len + 1];
+      std::string redirect_url_leading_slash(arg_redirect_len + 1, '\0');
       redirect_url_leading_slash[0] = '/';
       if (arg_redirect_len > 0) {
-        memcpy(redirect_url_leading_slash + 1, arg_redirect_url, arg_redirect_len);
+        memcpy(redirect_url_leading_slash.data() + 1, arg_redirect_url, arg_redirect_len);
       }
       url_nuke_proxy_stuff(redirectUrl.m_url_impl);
-      redirectUrl.parse(redirect_url_leading_slash, arg_redirect_len + 1);
+      redirectUrl.parse(redirect_url_leading_slash.c_str(), arg_redirect_len + 1);
     }
   }
 

--- a/src/tscore/ArgParser.cc
+++ b/src/tscore/ArgParser.cc
@@ -418,7 +418,8 @@ ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args, int inde
         ArgParser::Option cur_option = it->second;
         // handle environment variable
         if (!cur_option.envvar.empty()) {
-          ret.set_env(cur_option.key, getenv(cur_option.envvar.c_str()) ? getenv(cur_option.envvar.c_str()) : "");
+          const char *const env = getenv(cur_option.envvar.c_str());
+          ret.set_env(cur_option.key, nullptr != env ? env : "");
         }
         ret.append_arg(cur_option.key, value);
         check_map[cur_option.long_option] += 1;
@@ -462,7 +463,8 @@ ArgParser::Command::append_option_data(Arguments &ret, AP_StrVec &args, int inde
         }
         // handle environment variable
         if (!cur_option.envvar.empty()) {
-          ret.set_env(cur_option.key, getenv(cur_option.envvar.c_str()) ? getenv(cur_option.envvar.c_str()) : "");
+          const char *const env = getenv(cur_option.envvar.c_str());
+          ret.set_env(cur_option.key, nullptr != env ? env : "");
         }
       }
     }
@@ -507,7 +509,8 @@ ArgParser::Command::parse(Arguments &ret, AP_StrVec &args)
       }
       // set ENV var
       if (!_envvar.empty()) {
-        ret.set_env(_key, getenv(_envvar.c_str()) ? getenv(_envvar.c_str()) : "");
+        const char *const env = getenv(_envvar.c_str());
+        ret.set_env(_key, nullptr != env ? env : "");
       }
       break;
     }

--- a/src/tscore/Layout.cc
+++ b/src/tscore/Layout.cc
@@ -155,7 +155,8 @@ Layout::Layout(std::string_view const _prefix)
     std::string path;
     int len;
     if (getenv("TS_ROOT") != nullptr) {
-      std::string env_path(getenv("TS_ROOT"));
+      const char *const env = getenv("TS_ROOT");
+      std::string env_path(nullptr != env ? env : "");
       len = env_path.size();
       if ((len + 1) > PATH_NAME_MAX) {
         ink_fatal("TS_ROOT environment variable is too big: %d, max %d\n", len, PATH_NAME_MAX - 1);


### PR DESCRIPTION
Backport #10055 to the 9.2.x branch to pass clang-analyzer check.

----

* clang-analyzer fixes for clang14

* rename NetEvent::free to NetEvent::free_thread for clang-analyzer's sake

---------

Co-authored-by: Brian Olsen <bolsen149@comcast.com>
(cherry picked from commit 15207bb3471b4f489ab3beff5757e4cc05b31167)

Conflicts:
	iocore/net/NetHandler.cc
	iocore/net/P_QUICNetVConnection_quiche.h
	iocore/net/QUICNetProcessor_quiche.cc
	iocore/net/QUICNetVConnection_quiche.cc
	iocore/net/UnixNet.cc