### PR TITLE
ink_ink_get_hrtime -> ink_get_hrtime

### DIFF
--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -152,7 +152,7 @@ public:
 
   AIOTestData() : Continuation(new_ProxyMutex()), num_req(0), num_temp(0), num_queue(0)
   {
-    start = ink_ink_get_hrtime();
+    start = ink_get_hrtime();
     SET_HANDLER(&AIOTestData::ink_aio_stats);
   }
 };

--- a/src/records/test_RecProcess.i
+++ b/src/records/test_RecProcess.i
@@ -342,7 +342,7 @@ struct RawStatCont:public Continuation
     RecFloat stat_a, stat_d, stat_e;
     // comments out here
 
-    hr_start = ink_ink_get_hrtime();
+    hr_start = ink_get_hrtime();
 
     // test_raw_stat_a should have around 16000 in it (avg of rand())
     RecIncrRawStat(g_rsb, mutex->thread_holding, (int) MY_STAT_A, rand());
@@ -494,7 +494,7 @@ struct RawStatCont:public Continuation
     ink_atomic_increment(&g_count, 1);
 
     // test_raw_stat_e should have the time it takes to run this function
-    hr_finish = ink_ink_get_hrtime();
+    hr_finish = ink_get_hrtime();
     RecIncrRawStat(g_rsb, mutex->thread_holding, (int) MY_STAT_E, hr_finish - hr_start);
 
     return 0;


### PR DESCRIPTION
Fixing a typo that occured a couple times in referencing ink_get_hrtime.