### PR TITLE
9.2.x: Make sure that the thread local time is updated timely (#10163)

### DIFF
--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -4865,6 +4865,13 @@ Sockets
    ``2`` Tracks IO Buffer Memory and OpenSSL Memory allocations and releases
    ===== ======================================================================
 
+.. ts:cv:: CONFIG proxy.config.system_clock INT 0
+
+   *For advanced users only*. This allows to specify the underlying system clock
+   used by ATS. The default is ``CLOCK_REALTIME`` (``0``), but a higher performance
+   option could be ``CLOCK_REALTIME_COARSE`` (``5``). See ``clock_gettime(2)`` for
+   more details. On Linux, these definitions can be found in ``<linux/time.h>``.
+
 .. ts:cv:: CONFIG proxy.config.allocator.dontdump_iobuffers INT 1
 
    Enable (1) the exclusion of IO buffers from core files when ATS crashes on supported

--- a/include/tscore/ink_hrtime.h
+++ b/include/tscore/ink_hrtime.h
@@ -224,12 +224,14 @@ ink_hrtime_to_timeval(ink_hrtime t)
    which translates to (365 + 0.25)369*24*60*60 seconds   */
 #define NT_TIMEBASE_DIFFERENCE_100NSECS 116444736000000000i64
 
+extern int gSystemClock; // 0 == CLOCK_REALTIME, the default
+
 static inline ink_hrtime
-ink_get_hrtime_internal()
+ink_get_hrtime()
 {
 #if defined(freebsd) || HAVE_CLOCK_GETTIME
   timespec ts;
-  clock_gettime(CLOCK_REALTIME, &ts);
+  clock_gettime(static_cast<clockid_t>(gSystemClock), &ts);
   return ink_hrtime_from_timespec(&ts);
 #else
   timeval tv;
@@ -241,13 +243,13 @@ ink_get_hrtime_internal()
 static inline struct timeval
 ink_gettimeofday()
 {
-  return ink_hrtime_to_timeval(ink_get_hrtime_internal());
+  return ink_hrtime_to_timeval(ink_get_hrtime());
 }
 
 static inline int
 ink_time()
 {
-  return (int)ink_hrtime_to_sec(ink_get_hrtime_internal());
+  return (int)ink_hrtime_to_sec(ink_get_hrtime());
 }
 
 static inline int

--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -73,7 +73,7 @@ aio_stats_cb(const char * /* name ATS_UNUSED */, RecDataT data_type, RecData *da
   int64_t new_val = 0;
   int64_t diff    = 0;
   int64_t count, sum;
-  ink_hrtime now = Thread::get_hrtime();
+  ink_hrtime now = ink_get_hrtime();
   // The RecGetGlobalXXX stat functions are cheaper than the
   // RecGetXXX functions. The Global ones are expensive
   // for increments and decrements. But for AIO stats we
@@ -118,7 +118,7 @@ static AIOTestData *data;
 int
 AIOTestData::ink_aio_stats(int event, void *d)
 {
-  ink_hrtime now   = Thread::get_hrtime();
+  ink_hrtime now   = ink_get_hrtime();
   double time_msec = (double)(now - start) / (double)HRTIME_MSECOND;
   int i            = (aio_reqs[0] == nullptr) ? 1 : 0;
   for (; i < num_filedes; ++i)
@@ -487,7 +487,7 @@ aio_thread_main(void *arg)
       }
       ink_mutex_acquire(&my_aio_req->aio_mutex);
     } while (true);
-    timespec timedwait_msec = ink_hrtime_to_timespec(Thread::get_hrtime_updated() + HRTIME_MSECONDS(net_config_poll_timeout));
+    timespec timedwait_msec = ink_hrtime_to_timespec(ink_get_hrtime() + HRTIME_MSECONDS(net_config_poll_timeout));
     ink_cond_timedwait(&my_aio_req->aio_cond, &my_aio_req->aio_mutex, &timedwait_msec);
   }
   return nullptr;

--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -253,11 +253,11 @@ int
 AIO_Device::do_fd(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
   if (!time_start) {
-    time_start = Thread::get_hrtime();
+    time_start = ink_get_hrtime();
     fprintf(stderr, "Starting the aio_testing \n");
   }
-  if ((Thread::get_hrtime() - time_start) > (run_time * HRTIME_SECOND)) {
-    time_end = Thread::get_hrtime();
+  if ((ink_get_hrtime() - time_start) > (run_time * HRTIME_SECOND)) {
+    time_end = ink_get_hrtime();
     ink_atomic_increment(&n_accessors, -1);
     if (n_accessors <= 0) {
       dump_summary();

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -1104,7 +1104,7 @@ Lrestart:
     }
 
     if (!vol->dir_sync_in_progress) {
-      start_time = Thread::get_hrtime();
+      start_time = ink_get_hrtime();
     }
 
     // recompute hit_evacuate_window
@@ -1186,7 +1186,7 @@ Lrestart:
     } else {
       vol->dir_sync_in_progress = false;
       CACHE_INCREMENT_DYN_STAT(cache_directory_sync_count_stat);
-      CACHE_SUM_DYN_STAT(cache_directory_sync_time_stat, Thread::get_hrtime() - start_time);
+      CACHE_SUM_DYN_STAT(cache_directory_sync_time_stat, ink_get_hrtime() - start_time);
       start_time = 0;
       goto Ldone;
     }
@@ -1500,19 +1500,19 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
   // test insert-delete
   rprintf(t, "insert-delete test\n");
   regress_rand_init(13);
-  ttime = Thread::get_hrtime_updated();
+  ttime = ink_get_hrtime();
   for (i = 0; i < newfree; i++) {
     regress_rand_CacheKey(&key);
     dir_insert(&key, d, &dir);
   }
-  uint64_t us = (Thread::get_hrtime_updated() - ttime) / HRTIME_USECOND;
+  uint64_t us = (ink_get_hrtime() - ttime) / HRTIME_USECOND;
   // On windows us is sometimes 0. I don't know why.
   // printout the insert rate only if its not 0
   if (us) {
     rprintf(t, "insert rate = %d / second\n", static_cast<int>((newfree * static_cast<uint64_t>(1000000)) / us));
   }
   regress_rand_init(13);
-  ttime = Thread::get_hrtime_updated();
+  ttime = ink_get_hrtime();
   for (i = 0; i < newfree; i++) {
     Dir *last_collision = nullptr;
     regress_rand_CacheKey(&key);
@@ -1520,7 +1520,7 @@ EXCLUSIVE_REGRESSION_TEST(Cache_dir)(RegressionTest *t, int /* atype ATS_UNUSED 
       ret = REGRESSION_TEST_FAILED;
     }
   }
-  us = (Thread::get_hrtime_updated() - ttime) / HRTIME_USECOND;
+  us = (ink_get_hrtime() - ttime) / HRTIME_USECOND;
   // On windows us is sometimes 0. I don't know why.
   // printout the probe rate only if its not 0
   if (us) {

--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -307,7 +307,7 @@ CacheVC::openReadFromWriter(int event, Event *e)
     // before the open_write, but the reader could not get the volume
     // lock. If we don't reset the clock here, we won't choose any writer
     // and hence fail the read request.
-    start_time                = Thread::get_hrtime();
+    start_time                = ink_get_hrtime();
     f.read_from_writer_called = 1;
   }
   cancel_trigger();

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -207,7 +207,7 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
    - total_len. The total number of bytes for the document so far.
      Doc->total_len and alternate's total len is set to this value.
    - first_key. Doc's first_key is set to this value.
-   - pin_in_cache. Doc's pinned value is set to this + Thread::get_hrtime().
+   - pin_in_cache. Doc's pinned value is set to this + ink_get_hrtime().
    - earliest_key. If f.use_first_key, Doc's key is set to this value.
    - key. If !f.use_first_key, Doc's key is set to this value.
    - blocks. Used only if write_len is set. Data to be written
@@ -680,7 +680,7 @@ Vol::evacuateDocReadDone(int event, Event *e)
   if (!b) {
     goto Ldone;
   }
-  if ((b->f.pinned && !b->readers) && doc->pinned < static_cast<uint32_t>(Thread::get_hrtime() / HRTIME_SECOND)) {
+  if ((b->f.pinned && !b->readers) && doc->pinned < static_cast<uint32_t>(ink_get_hrtime() / HRTIME_SECOND)) {
     goto Ldone;
   }
 
@@ -817,7 +817,7 @@ agg_copy(char *p, CacheVC *vc)
     doc->checksum                        = DOC_NO_CHECKSUM;
     if (vc->pin_in_cache) {
       dir_set_pinned(&vc->dir, 1);
-      doc->pinned = static_cast<uint32_t>(Thread::get_hrtime() / HRTIME_SECOND) + vc->pin_in_cache;
+      doc->pinned = static_cast<uint32_t>(ink_get_hrtime() / HRTIME_SECOND) + vc->pin_in_cache;
     } else {
       dir_set_pinned(&vc->dir, 0);
       doc->pinned = 0;

--- a/iocore/cache/P_CacheInternal.h
+++ b/iocore/cache/P_CacheInternal.h
@@ -562,7 +562,7 @@ new_CacheVC(Continuation *cont)
   c->vector.data.data = &c->vector.data.fast_data[0];
   c->_action          = cont;
   c->mutex            = cont->mutex;
-  c->start_time       = Thread::get_hrtime();
+  c->start_time       = ink_get_hrtime();
   c->setThreadAffinity(t);
   ink_assert(c->trigger == nullptr);
   Debug("cache_new", "new %p", c);

--- a/iocore/cache/P_CacheTest.h
+++ b/iocore/cache/P_CacheTest.h
@@ -95,7 +95,7 @@ struct CacheTestSM : public RegressionSM {
   void
   make_request()
   {
-    start_time = Thread::get_hrtime();
+    start_time = ink_get_hrtime();
     make_request_internal();
   }
   virtual void make_request_internal() = 0;

--- a/iocore/dns/DNS.cc
+++ b/iocore/dns/DNS.cc
@@ -412,7 +412,7 @@ DNSEntry::init(DNSQueryData target, int qtype_arg, Continuation *acont, DNSProce
       qtype = T_AAAA;
     }
   }
-  submit_time   = Thread::get_hrtime();
+  submit_time   = ink_get_hrtime();
   action        = acont;
   submit_thread = acont->mutex->thread_holding;
 
@@ -688,7 +688,7 @@ DNSHandler::retry_named(int ndx, ink_hrtime t, bool reopen)
 void
 DNSHandler::try_primary_named(bool reopen)
 {
-  ink_hrtime t = Thread::get_hrtime();
+  ink_hrtime t = ink_get_hrtime();
   if (reopen && ((t - last_primary_reopen) > DNS_PRIMARY_REOPEN_PERIOD)) {
     Debug("dns", "try_primary_named: reopening primary DNS connection");
     last_primary_reopen = t;
@@ -990,7 +990,7 @@ DNSHandler::mainEvent(int event, Event *e)
     if (DNS_CONN_MODE::TCP_RETRY == dns_conn_mode) {
       check_and_reset_tcp_conn();
     }
-    ink_hrtime t = Thread::get_hrtime();
+    ink_hrtime t = ink_get_hrtime();
     if (t - last_primary_retry > DNS_PRIMARY_RETRY_PERIOD) {
       for (int i = 0; i < n_con; i++) {
         if (ns_down[i]) {
@@ -1218,7 +1218,7 @@ write_dns_event(DNSHandler *h, DNSEntry *e, bool over_tcp)
   ++h->in_flight;
   DNS_INCREMENT_DYN_STAT(dns_in_flight_stat);
 
-  e->send_time = Thread::get_hrtime();
+  e->send_time = ink_get_hrtime();
 
   if (e->timeout) {
     e->timeout->cancel();
@@ -1393,9 +1393,9 @@ dns_result(DNSHandler *h, DNSEntry *e, HostEnt *ent, bool retry, bool tcp_retry)
   }
   if (!cancelled) {
     if (!ent || !ent->good) {
-      DNS_SUM_DYN_STAT(dns_fail_time_stat, Thread::get_hrtime() - e->submit_time);
+      DNS_SUM_DYN_STAT(dns_fail_time_stat, ink_get_hrtime() - e->submit_time);
     } else {
-      DNS_SUM_DYN_STAT(dns_success_time_stat, Thread::get_hrtime() - e->submit_time);
+      DNS_SUM_DYN_STAT(dns_success_time_stat, ink_get_hrtime() - e->submit_time);
     }
   }
 
@@ -1543,7 +1543,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
   --(handler->in_flight);
   DNS_DECREMENT_DYN_STAT(dns_in_flight_stat);
 
-  DNS_SUM_DYN_STAT(dns_response_time_stat, Thread::get_hrtime() - e->send_time);
+  DNS_SUM_DYN_STAT(dns_response_time_stat, ink_get_hrtime() - e->send_time);
 
   // retrying over TCP when truncated is set
   if (dns_conn_mode == DNS_CONN_MODE::TCP_RETRY && h->tc == 1) {

--- a/iocore/dns/P_DNSProcessor.h
+++ b/iocore/dns/P_DNSProcessor.h
@@ -203,7 +203,7 @@ struct DNSHandler : public Continuation {
     ++failover_number[name_server];
     Debug("dns", "sent_one: failover_number for resolver %d is %d", name_server, failover_number[name_server]);
     if (failover_number[name_server] >= dns_failover_number && !crossed_failover_number[name_server])
-      crossed_failover_number[name_server] = Thread::get_hrtime();
+      crossed_failover_number[name_server] = ink_get_hrtime();
   }
 
   bool
@@ -212,17 +212,17 @@ struct DNSHandler : public Continuation {
     if (is_debug_tag_set("dns")) {
       Debug("dns", "failover_now: Considering immediate failover, target time is %" PRId64 "",
             (ink_hrtime)HRTIME_SECONDS(dns_failover_period));
-      Debug("dns", "\tdelta time is %" PRId64 "", (Thread::get_hrtime() - crossed_failover_number[i]));
+      Debug("dns", "\tdelta time is %" PRId64 "", (ink_get_hrtime() - crossed_failover_number[i]));
     }
-    return ns_down[i] || (crossed_failover_number[i] &&
-                          ((Thread::get_hrtime() - crossed_failover_number[i]) > HRTIME_SECONDS(dns_failover_period)));
+    return ns_down[i] ||
+           (crossed_failover_number[i] && ((ink_get_hrtime() - crossed_failover_number[i]) > HRTIME_SECONDS(dns_failover_period)));
   }
 
   bool
   failover_soon(int i)
   {
     return ns_down[i] || (crossed_failover_number[i] &&
-                          ((Thread::get_hrtime() - crossed_failover_number[i]) >
+                          ((ink_get_hrtime() - crossed_failover_number[i]) >
                            (HRTIME_SECONDS(dns_failover_try_period + failover_soon_number[i] * FAILOVER_SOON_RETRY))));
   }
 

--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -291,7 +291,7 @@ public:
 
   Event *schedule_local(Event *e);
 
-  InkRand generator = static_cast<uint64_t>(Thread::get_hrtime_updated() ^ reinterpret_cast<uintptr_t>(this));
+  InkRand generator = static_cast<uint64_t>(ink_get_hrtime() ^ reinterpret_cast<uintptr_t>(this));
 
   /*-------------------------------------------------------*\
   |  UNIX Interface                                         |
@@ -366,7 +366,7 @@ public:
     int
     waitForActivity(ink_hrtime timeout) override
     {
-      _q.wait(Thread::get_hrtime() + timeout);
+      _q.wait(ink_get_hrtime() + timeout);
       return 0;
     }
     void

--- a/iocore/eventsystem/I_Lock.h
+++ b/iocore/eventsystem/I_Lock.h
@@ -277,7 +277,7 @@ Mutex_trylock(
 #ifdef DEBUG
     m->srcloc    = location;
     m->handler   = ahandler;
-    m->hold_time = Thread::get_hrtime();
+    m->hold_time = ink_get_hrtime();
 #ifdef MAX_LOCK_TAKEN
     m->taken++;
 #endif // MAX_LOCK_TAKEN
@@ -324,7 +324,7 @@ Mutex_lock(
 #ifdef DEBUG
     m->srcloc    = location;
     m->handler   = ahandler;
-    m->hold_time = Thread::get_hrtime();
+    m->hold_time = ink_get_hrtime();
 #ifdef MAX_LOCK_TAKEN
     m->taken++;
 #endif // MAX_LOCK_TAKEN
@@ -363,7 +363,7 @@ Mutex_unlock(ProxyMutex *m, EThread *t)
     m->nthread_holding--;
     if (!m->nthread_holding) {
 #ifdef DEBUG
-      if (Thread::get_hrtime() - m->hold_time > MAX_LOCK_TIME)
+      if (ink_get_hrtime() - m->hold_time > MAX_LOCK_TIME)
         lock_holding(m->srcloc, m->handler);
 #ifdef MAX_LOCK_TAKEN
       if (m->taken > MAX_LOCK_TAKEN)

--- a/iocore/eventsystem/I_Thread.h
+++ b/iocore/eventsystem/I_Thread.h
@@ -159,16 +159,6 @@ public:
 
       @note The cached copy is thread local which means each thread need to update the cached copy by itself.
   */
-  static ink_hrtime get_hrtime();
-
-  /** Get the operating system high resolution time.
-
-      Get the current time at high resolution from the operating system.  This is more expensive
-      than @c get_hrtime and should be used only where very precise timing is required.
-
-      @note This also updates the cached time.
-  */
-  static ink_hrtime get_hrtime_updated();
 
   Thread(const Thread &) = delete;
   Thread &operator=(const Thread &) = delete;
@@ -176,20 +166,6 @@ public:
 
 protected:
   Thread();
-
-  static thread_local ink_hrtime cur_time;
 };
 
 extern Thread *this_thread();
-
-TS_INLINE ink_hrtime
-Thread::get_hrtime()
-{
-  return cur_time;
-}
-
-TS_INLINE ink_hrtime
-Thread::get_hrtime_updated()
-{
-  return cur_time = ink_get_hrtime_internal();
-}

--- a/iocore/eventsystem/PQ-List.cc
+++ b/iocore/eventsystem/PQ-List.cc
@@ -25,7 +25,7 @@
 
 PriorityEventQueue::PriorityEventQueue()
 {
-  last_check_time    = Thread::get_hrtime_updated();
+  last_check_time    = ink_get_hrtime();
   last_check_buckets = last_check_time / PQ_BUCKET_TIME(0);
 }
 

--- a/iocore/eventsystem/P_UnixEThread.h
+++ b/iocore/eventsystem/P_UnixEThread.h
@@ -75,7 +75,7 @@ EThread::schedule_in(Continuation *cont, ink_hrtime t, int callback_event, void 
 
   e->callback_event = callback_event;
   e->cookie         = cookie;
-  return schedule(e->init(cont, get_hrtime() + t, 0));
+  return schedule(e->init(cont, ink_get_hrtime() + t, 0));
 }
 
 TS_INLINE Event *
@@ -92,7 +92,7 @@ EThread::schedule_every(Continuation *cont, ink_hrtime t, int callback_event, vo
   if (t < 0) {
     return schedule(e->init(cont, t, t));
   } else {
-    return schedule(e->init(cont, get_hrtime() + t, t));
+    return schedule(e->init(cont, ink_get_hrtime() + t, t));
   }
 }
 
@@ -164,7 +164,7 @@ EThread::schedule_in_local(Continuation *cont, ink_hrtime t, int callback_event,
 
   e->callback_event = callback_event;
   e->cookie         = cookie;
-  return schedule_local(e->init(cont, get_hrtime() + t, 0));
+  return schedule_local(e->init(cont, ink_get_hrtime() + t, 0));
 }
 
 TS_INLINE Event *
@@ -181,7 +181,7 @@ EThread::schedule_every_local(Continuation *cont, ink_hrtime t, int callback_eve
   if (t < 0) {
     return schedule_local(e->init(cont, t, t));
   } else {
-    return schedule_local(e->init(cont, get_hrtime() + t, t));
+    return schedule_local(e->init(cont, ink_get_hrtime() + t, t));
   }
 }
 

--- a/iocore/eventsystem/P_UnixEventProcessor.h
+++ b/iocore/eventsystem/P_UnixEventProcessor.h
@@ -133,7 +133,7 @@ EventProcessor::schedule_imm(Continuation *cont, EventType et, int callback_even
 
   ink_assert(et < MAX_EVENT_TYPES);
 #ifdef ENABLE_TIME_TRACE
-  e->start_time = Thread::get_hrtime();
+  e->start_time = ink_get_hrtime();
 #endif
 
 #ifdef ENABLE_EVENT_TRACKER
@@ -175,7 +175,7 @@ EventProcessor::schedule_in(Continuation *cont, ink_hrtime t, EventType et, int 
 
   e->callback_event = callback_event;
   e->cookie         = cookie;
-  return schedule(e->init(cont, Thread::get_hrtime() + t, 0), et);
+  return schedule(e->init(cont, ink_get_hrtime() + t, 0), et);
 }
 
 TS_INLINE Event *
@@ -195,6 +195,6 @@ EventProcessor::schedule_every(Continuation *cont, ink_hrtime t, EventType et, i
   if (t < 0) {
     return schedule(e->init(cont, t, t), et);
   } else {
-    return schedule(e->init(cont, Thread::get_hrtime() + t, t), et);
+    return schedule(e->init(cont, ink_get_hrtime() + t, t), et);
   }
 }

--- a/iocore/eventsystem/Thread.cc
+++ b/iocore/eventsystem/Thread.cc
@@ -34,7 +34,6 @@
 // Common Interface impl                     //
 ///////////////////////////////////////////////
 
-thread_local ink_hrtime Thread::cur_time = ink_get_hrtime_internal();
 thread_local Thread *Thread::this_thread_ptr;
 
 Thread::Thread()

--- a/iocore/eventsystem/UnixEvent.cc
+++ b/iocore/eventsystem/UnixEvent.cc
@@ -76,7 +76,7 @@ Event::schedule_in(ink_hrtime atimeout_in, int acallback_event)
   if (in_the_priority_queue) {
     ethread->EventQueue.remove(this);
   }
-  timeout_at = Thread::get_hrtime() + atimeout_in;
+  timeout_at = ink_get_hrtime() + atimeout_in;
   period     = 0;
   immediate  = false;
   mutex      = continuation->mutex;
@@ -97,7 +97,7 @@ Event::schedule_every(ink_hrtime aperiod, int acallback_event)
   if (aperiod < 0) {
     timeout_at = aperiod;
   } else {
-    timeout_at = Thread::get_hrtime() + aperiod;
+    timeout_at = ink_get_hrtime() + aperiod;
   }
   period    = aperiod;
   immediate = false;

--- a/iocore/hostdb/HostDB.cc
+++ b/iocore/hostdb/HostDB.cc
@@ -276,7 +276,7 @@ HostDBBackgroundTask::HostDBBackgroundTask(int frequency) : Continuation(new_Pro
 int
 HostDBBackgroundTask::wait_event(int, void *)
 {
-  ink_hrtime next_sync = HRTIME_SECONDS(this->frequency) - (Thread::get_hrtime() - start_time);
+  ink_hrtime next_sync = HRTIME_SECONDS(this->frequency) - (ink_get_hrtime() - start_time);
 
   SET_HANDLER(&HostDBBackgroundTask::sync_event);
   if (next_sync > HRTIME_MSECONDS(100)) {
@@ -296,7 +296,7 @@ struct HostDBSync : public HostDBBackgroundTask {
   sync_event(int, void *) override
   {
     SET_HANDLER(&HostDBSync::wait_event);
-    start_time = Thread::get_hrtime();
+    start_time = ink_get_hrtime();
 
     new RefCountCacheSerializer<HostDBInfo>(this, hostDBProcessor.cache()->refcountcache, this->frequency, this->storage_path,
                                             this->full_path);

--- a/iocore/hostdb/P_RefCountCacheSerializer.h
+++ b/iocore/hostdb/P_RefCountCacheSerializer.h
@@ -89,7 +89,7 @@ RefCountCacheSerializer<C>::RefCountCacheSerializer(Continuation *acont, RefCoun
     dirname(std::move(dirname)),
     filename(std::move(filename)),
     time_per_partition(HRTIME_SECONDS(frequency) / cc->partition_count()),
-    start(Thread::get_hrtime()),
+    start(ink_get_hrtime()),
     total_items(0),
     total_size(0),
     rsb(cc->get_rsb())
@@ -155,7 +155,7 @@ template <class C>
 int
 RefCountCacheSerializer<C>::write_partition(int /* event */, Event *e)
 {
-  int curr_time = Thread::get_hrtime() / HRTIME_SECOND;
+  int curr_time = ink_get_hrtime() / HRTIME_SECOND;
 
   // write the partition to disk
   // for item in this->partitionItems
@@ -198,7 +198,7 @@ RefCountCacheSerializer<C>::write_partition(int /* event */, Event *e)
   SET_HANDLER(&RefCountCacheSerializer::pause_event);
 
   // Figure out how much time we spent
-  ink_hrtime elapsed          = Thread::get_hrtime() - this->start;
+  ink_hrtime elapsed          = ink_get_hrtime() - this->start;
   ink_hrtime expected_elapsed = (this->partition * this->time_per_partition);
 
   // If we were quicker than our pace-- lets reschedule in the future
@@ -299,7 +299,7 @@ RefCountCacheSerializer<C>::finalize_sync()
   this->fd = -1;
 
   if (this->rsb) {
-    RecSetRawStatCount(this->rsb, refcountcache_last_sync_time, Thread::get_hrtime() / HRTIME_SECOND);
+    RecSetRawStatCount(this->rsb, refcountcache_last_sync_time, ink_get_hrtime() / HRTIME_SECOND);
     RecSetRawStatCount(this->rsb, refcountcache_last_total_items, this->total_items);
     RecSetRawStatCount(this->rsb, refcountcache_last_total_size, this->total_size);
   }

--- a/iocore/net/I_UDPPacket.h
+++ b/iocore/net/I_UDPPacket.h
@@ -71,7 +71,7 @@ public:
 
 
    @param to  address of where to send packet
-   @param when ink_hrtime relative to ink_get_hrtime_internal()
+   @param when ink_hrtime relative to ink_get_hrtime()
    @param buf if !nullptr, then len bytes copied from buf and made into packet.
    @param len # of bytes to copy from buf
  */
@@ -82,7 +82,7 @@ extern UDPPacket *new_UDPPacket(struct sockaddr const *to, ink_hrtime when = 0, 
 
 
    @param to  address of where to send packet
-   @param when ink_hrtime relative to ink_get_hrtime_internal()
+   @param when ink_hrtime relative to ink_get_hrtime()
    @param block if !nullptr, then the IOBufferBlock chain of data to use
    for packet
    @param len # of bytes to reference from block

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -52,8 +52,8 @@ test_certlookup_SOURCES = \
 
 test_certlookup_LDADD = \
 	@OPENSSL_LIBS@ \
-	$(top_builddir)/src/tscore/libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/iocore/eventsystem/libinkevent.a \
+	$(top_builddir)/src/tscore/libtscore.la $(top_builddir)/src/tscpp/util/libtscpputil.la \
 	$(top_builddir)/proxy/ParentSelectionStrategy.o \
 	@YAMLCPP_LIBS@
 

--- a/iocore/net/NetTimeout.h
+++ b/iocore/net/NetTimeout.h
@@ -99,7 +99,7 @@ NetTimeout::set_active_timeout(ink_hrtime timeout_in)
   }
 
   _active_timeout_in      = timeout_in;
-  _next_active_timeout_at = Thread::get_hrtime() + timeout_in;
+  _next_active_timeout_at = ink_get_hrtime() + timeout_in;
 }
 
 inline void
@@ -110,7 +110,7 @@ NetTimeout::set_inactive_timeout(ink_hrtime timeout_in)
   }
 
   _inactive_timeout_in      = timeout_in;
-  _next_inactive_timeout_at = Thread::get_hrtime() + timeout_in;
+  _next_inactive_timeout_at = ink_get_hrtime() + timeout_in;
 }
 
 inline void
@@ -134,7 +134,7 @@ NetTimeout::reset_active_timeout()
     return;
   }
 
-  _next_active_timeout_at = Thread::get_hrtime() + _active_timeout_in;
+  _next_active_timeout_at = ink_get_hrtime() + _active_timeout_in;
 }
 
 inline void
@@ -144,7 +144,7 @@ NetTimeout::reset_inactive_timeout()
     return;
   }
 
-  _next_inactive_timeout_at = Thread::get_hrtime() + _inactive_timeout_in;
+  _next_inactive_timeout_at = ink_get_hrtime() + _inactive_timeout_in;
 }
 
 inline bool
@@ -203,7 +203,7 @@ NetTimeout::update_inactivity()
     return;
   }
 
-  _next_inactive_timeout_at = Thread::get_hrtime() + _inactive_timeout_in;
+  _next_inactive_timeout_at = ink_get_hrtime() + _inactive_timeout_in;
 }
 
 //
@@ -233,7 +233,7 @@ template <class T, class List>
 inline int
 ActivityCop<T, List>::check_activity(int /* event */, Event *e)
 {
-  ink_hrtime now = Thread::get_hrtime();
+  ink_hrtime now = ink_get_hrtime();
 
   // Traverse list & check inactivity or activity
   T *t = _list->head;

--- a/iocore/net/OCSPStapling.cc
+++ b/iocore/net/OCSPStapling.cc
@@ -380,7 +380,7 @@ query_responder(BIO *b, const char *host, const char *path, const char *user_age
   OCSP_REQ_CTX *ctx;
   int rv;
 
-  start = Thread::get_hrtime();
+  start = ink_get_hrtime();
   end   = ink_hrtime_add(start, ink_hrtime_from_sec(req_timeout));
 
   ctx = OCSP_sendreq_new(b, path, nullptr, -1);
@@ -393,7 +393,7 @@ query_responder(BIO *b, const char *host, const char *path, const char *user_age
   do {
     rv = OCSP_sendreq_nbio(&resp, ctx);
     ink_hrtime_sleep(HRTIME_MSECONDS(1));
-  } while ((rv == -1) && BIO_should_retry(b) && (Thread::get_hrtime() < end));
+  } while ((rv == -1) && BIO_should_retry(b) && (ink_get_hrtime() < end));
 
   OCSP_REQ_CTX_free(ctx);
 

--- a/iocore/net/P_UDPNet.h
+++ b/iocore/net/P_UDPNet.h
@@ -78,7 +78,7 @@ public:
   init()
   {
     now_slot       = 0;
-    ink_hrtime now = ink_get_hrtime_internal();
+    ink_hrtime now = ink_get_hrtime();
     int i          = now_slot;
     int j          = 0;
     while (j < N_SLOTS) {

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -429,7 +429,7 @@ net_connections_to_throttle(ThrottleType t)
 TS_INLINE void
 check_shedding_warning()
 {
-  ink_hrtime t = Thread::get_hrtime();
+  ink_hrtime t = ink_get_hrtime();
   if (t - last_shedding_warning > NET_THROTTLE_MESSAGE_EVERY) {
     last_shedding_warning = t;
     RecSignalWarning(REC_SIGNAL_SYSTEM_ERROR, "number of connections reaching shedding limit");
@@ -450,7 +450,7 @@ check_net_throttle(ThrottleType t)
 TS_INLINE void
 check_throttle_warning(ThrottleType type)
 {
-  ink_hrtime t = Thread::get_hrtime();
+  ink_hrtime t = ink_get_hrtime();
   if (t - last_throttle_warning > NET_THROTTLE_MESSAGE_EVERY) {
     last_throttle_warning = t;
     int connections       = net_connections_to_throttle(type);
@@ -526,7 +526,7 @@ accept_error_seriousness(int res)
 TS_INLINE void
 check_transient_accept_error(int res)
 {
-  ink_hrtime t = Thread::get_hrtime();
+  ink_hrtime t = ink_get_hrtime();
   if (!last_transient_accept_error || t - last_transient_accept_error > TRANSIENT_ACCEPT_ERROR_MESSAGE_EVERY) {
     last_transient_accept_error = t;
     Warning("accept thread received transient error: errno = %d", -res);

--- a/iocore/net/P_UnixNetVConnection.h
+++ b/iocore/net/P_UnixNetVConnection.h
@@ -338,7 +338,7 @@ UnixNetVConnection::set_active_timeout(ink_hrtime timeout_in)
 {
   Debug("socket", "Set active timeout=%" PRId64 ", NetVC=%p", timeout_in, this);
   active_timeout_in        = timeout_in;
-  next_activity_timeout_at = (active_timeout_in > 0) ? Thread::get_hrtime() + timeout_in : 0;
+  next_activity_timeout_at = (active_timeout_in > 0) ? ink_get_hrtime() + timeout_in : 0;
 }
 
 inline void

--- a/iocore/net/QUICNetProcessor.cc
+++ b/iocore/net/QUICNetProcessor.cc
@@ -157,7 +157,7 @@ QUICNetProcessor::connect_re(Continuation *cont, sockaddr const *remote_addr, Ne
   vc->id = net_next_connection_number();
   vc->set_context(NET_VCONNECTION_OUT);
   vc->con.setRemote(remote_addr);
-  vc->submit_time = Thread::get_hrtime();
+  vc->submit_time = ink_get_hrtime();
   vc->mutex       = cont->mutex;
   vc->action_     = cont;
 

--- a/iocore/net/QUICNetVConnection.cc
+++ b/iocore/net/QUICNetVConnection.cc
@@ -1520,7 +1520,7 @@ QUICNetVConnection::_state_common_send_packet()
         this->_context->trigger(QUICContext::CallbackEvent::PACKET_SEND, packet.get());
 
         packet_info->packet_number = packet->packet_number();
-        packet_info->time_sent     = Thread::get_hrtime();
+        packet_info->time_sent     = ink_get_hrtime();
         packet_info->ack_eliciting = packet->is_ack_eliciting();
         packet_info->in_flight     = true;
         if (packet_info->ack_eliciting) {

--- a/iocore/net/QUICPacketHandler.cc
+++ b/iocore/net/QUICPacketHandler.cc
@@ -361,7 +361,7 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
              &this->_rtable, &this->_ctable);
     vc->id = net_next_connection_number();
     vc->con.move(con);
-    vc->submit_time = Thread::get_hrtime();
+    vc->submit_time = ink_get_hrtime();
     vc->thread      = eth;
     vc->mutex       = new_ProxyMutex();
     vc->action_     = *this->action_;

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -621,7 +621,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
       readSignalError(nh, err);
     } else if (ret == SSL_HANDSHAKE_WANT_READ || ret == SSL_HANDSHAKE_WANT_ACCEPT) {
       if (SSLConfigParams::ssl_handshake_timeout_in > 0) {
-        double handshake_time = (static_cast<double>(Thread::get_hrtime() - this->get_tls_handshake_begin_time()) / 1000000000);
+        double handshake_time = (static_cast<double>(ink_get_hrtime() - this->get_tls_handshake_begin_time()) / 1000000000);
         Debug("ssl", "ssl handshake for vc %p, took %.3f seconds, configured handshake_timer: %d", this, handshake_time,
               SSLConfigParams::ssl_handshake_timeout_in);
         if (handshake_time > SSLConfigParams::ssl_handshake_timeout_in) {
@@ -763,7 +763,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
   // Dynamic TLS record sizing
   ink_hrtime now = 0;
   if (SSLConfigParams::ssl_maxrecord == -1) {
-    now                       = Thread::get_hrtime_updated();
+    now                       = ink_get_hrtime();
     int msec_since_last_write = ink_hrtime_diff_msec(now, sslLastWriteTime);
 
     if (msec_since_last_write > SSL_DEF_TLS_RECORD_MSEC_THRESHOLD) {

--- a/iocore/net/TLSBasicSupport.cc
+++ b/iocore/net/TLSBasicSupport.cc
@@ -120,13 +120,13 @@ TLSBasicSupport::get_tls_handshake_end_time() const
 void
 TLSBasicSupport::_record_tls_handshake_begin_time()
 {
-  this->_tls_handshake_begin_time = Thread::get_hrtime();
+  this->_tls_handshake_begin_time = ink_get_hrtime();
 }
 
 void
 TLSBasicSupport::_record_tls_handshake_end_time()
 {
-  this->_tls_handshake_end_time       = Thread::get_hrtime();
+  this->_tls_handshake_end_time       = ink_get_hrtime();
   const ink_hrtime ssl_handshake_time = this->_tls_handshake_end_time - this->_tls_handshake_begin_time;
 
   Debug("ssl", "ssl handshake time:%" PRId64, ssl_handshake_time);

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -50,7 +50,7 @@ public:
   check_inactivity(int event, Event *e)
   {
     (void)event;
-    ink_hrtime now = Thread::get_hrtime();
+    ink_hrtime now = ink_get_hrtime();
     NetHandler &nh = *get_NetHandler(this_ethread());
 
     Debug("inactivity_cop_check", "Checking inactivity on Thread-ID #%d", this_ethread()->id);
@@ -587,7 +587,7 @@ NetHandler::manage_active_queue(NetEvent *enabling_ne, bool ignore_queue_size = 
     return true;
   }
 
-  ink_hrtime now = Thread::get_hrtime();
+  ink_hrtime now = ink_get_hrtime();
 
   // loop over the non-active connections and try to close them
   NetEvent *ne         = active_queue.head;
@@ -634,7 +634,7 @@ void
 NetHandler::manage_keep_alive_queue()
 {
   uint32_t total_connections_in = active_queue_size + keep_alive_queue_size;
-  ink_hrtime now                = Thread::get_hrtime();
+  ink_hrtime now                = ink_get_hrtime();
 
   Debug("v_net_queue", "max_connections_per_thread_in: %d total_connections_in: %d active_queue_size: %d keep_alive_queue_size: %d",
         max_connections_per_thread_in, total_connections_in, active_queue_size, keep_alive_queue_size);

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -88,7 +88,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
     vc->id = net_next_connection_number();
     vc->con.move(con);
     vc->set_remote_addr(con.addr);
-    vc->submit_time = Thread::get_hrtime();
+    vc->submit_time = ink_get_hrtime();
     vc->action_     = *na->action_;
     vc->set_is_transparent(na->opt.f_inbound_transparent);
     vc->set_is_proxy_protocol(na->opt.f_proxy_protocol);
@@ -344,7 +344,7 @@ NetAccept::do_blocking_accept(EThread *t)
     vc->id = net_next_connection_number();
     vc->con.move(con);
     vc->set_remote_addr(con.addr);
-    vc->submit_time = Thread::get_hrtime();
+    vc->submit_time = ink_get_hrtime();
     vc->action_     = *action_;
     vc->set_is_transparent(opt.f_inbound_transparent);
     vc->set_is_proxy_protocol(opt.f_proxy_protocol);
@@ -497,7 +497,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
     vc->id = net_next_connection_number();
     vc->con.move(con);
     vc->set_remote_addr(con.addr);
-    vc->submit_time = Thread::get_hrtime();
+    vc->submit_time = ink_get_hrtime();
     vc->action_     = *action_;
     vc->set_is_transparent(opt.f_inbound_transparent);
     vc->set_is_proxy_protocol(opt.f_proxy_protocol);

--- a/iocore/net/UnixNetPages.cc
+++ b/iocore/net/UnixNetPages.cc
@@ -60,7 +60,7 @@ struct ShowNet : public ShowCont {
       return EVENT_DONE;
     }
 
-    ink_hrtime now = Thread::get_hrtime();
+    ink_hrtime now = ink_get_hrtime();
     forl_LL(NetEvent, ne, nh->open_list)
     {
       auto vc = dynamic_cast<UnixNetVConnection *>(ne);

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -206,7 +206,7 @@ UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target
   SocksEntry *socksEntry = nullptr;
 
   vc->id          = net_next_connection_number();
-  vc->submit_time = Thread::get_hrtime();
+  vc->submit_time = ink_get_hrtime();
   vc->mutex       = cont->mutex;
   Action *result  = &vc->action_;
   // Copy target to con.addr,

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -66,7 +66,7 @@ net_activity(UnixNetVConnection *vc, EThread *thread)
   Debug("socket", "net_activity updating inactivity %" PRId64 ", NetVC=%p", vc->inactivity_timeout_in, vc);
   (void)thread;
   if (vc->inactivity_timeout_in) {
-    vc->next_inactivity_timeout_at = Thread::get_hrtime() + vc->inactivity_timeout_in;
+    vc->next_inactivity_timeout_at = ink_get_hrtime() + vc->inactivity_timeout_in;
   } else {
     vc->next_inactivity_timeout_at = 0;
   }
@@ -842,7 +842,7 @@ UnixNetVConnection::set_enabled(VIO *vio)
   ink_release_assert(!closed);
   STATE_FROM_VIO(vio)->enabled = 1;
   if (!next_inactivity_timeout_at && inactivity_timeout_in) {
-    next_inactivity_timeout_at = Thread::get_hrtime() + inactivity_timeout_in;
+    next_inactivity_timeout_at = ink_get_hrtime() + inactivity_timeout_in;
   }
 }
 
@@ -1321,7 +1321,7 @@ UnixNetVConnection::set_inactivity_timeout(ink_hrtime timeout_in)
 {
   Debug("socket", "Set inactive timeout=%" PRId64 ", for NetVC=%p", timeout_in, this);
   inactivity_timeout_in      = timeout_in;
-  next_inactivity_timeout_at = (timeout_in > 0) ? Thread::get_hrtime() + inactivity_timeout_in : 0;
+  next_inactivity_timeout_at = (timeout_in > 0) ? ink_get_hrtime() + inactivity_timeout_in : 0;
 }
 
 TS_INLINE void
@@ -1330,7 +1330,7 @@ UnixNetVConnection::set_default_inactivity_timeout(ink_hrtime timeout_in)
   Debug("socket", "Set default inactive timeout=%" PRId64 ", for NetVC=%p", timeout_in, this);
   inactivity_timeout_in      = 0;
   default_inactivity_timeout = true;
-  next_inactivity_timeout_at = Thread::get_hrtime() + timeout_in;
+  next_inactivity_timeout_at = ink_get_hrtime() + timeout_in;
 }
 
 TS_INLINE bool

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -859,7 +859,7 @@ void
 UDPQueue::service(UDPNetHandler *nh)
 {
   (void)nh;
-  ink_hrtime now     = Thread::get_hrtime_updated();
+  ink_hrtime now     = ink_get_hrtime();
   uint64_t timeSpent = 0;
   uint64_t pktSendStartTime;
   ink_hrtime pktSendTime;
@@ -905,8 +905,8 @@ void
 UDPQueue::SendPackets()
 {
   UDPPacketInternal *p;
-  static ink_hrtime lastCleanupTime = Thread::get_hrtime_updated();
-  ink_hrtime now                    = Thread::get_hrtime_updated();
+  static ink_hrtime lastCleanupTime = ink_get_hrtime();
+  ink_hrtime now                    = ink_get_hrtime();
   ink_hrtime send_threshold_time    = now + SLOT_TIME;
   int32_t bytesThisSlot = INT_MAX, bytesUsed = 0;
   int32_t bytesThisPipe, sentOne;
@@ -945,7 +945,7 @@ sendPackets:
 
   if ((bytesThisSlot > 0) && sentOne) {
     // redistribute the slack...
-    now = Thread::get_hrtime_updated();
+    now = ink_get_hrtime();
     if (pipeInfo.firstPacket(now) == nullptr) {
       pipeInfo.advanceNow(now);
     }
@@ -1033,7 +1033,7 @@ net_signal_hook_callback(EThread *thread)
 
 UDPNetHandler::UDPNetHandler()
 {
-  nextCheck = Thread::get_hrtime_updated() + HRTIME_MSECONDS(1000);
+  nextCheck = ink_get_hrtime() + HRTIME_MSECONDS(1000);
   lastCheck = 0;
   SET_HANDLER(&UDPNetHandler::startNetEvent);
 }
@@ -1122,7 +1122,7 @@ UDPNetHandler::waitForActivity(ink_hrtime timeout)
   } // end for
 
   // remove dead UDP connections
-  ink_hrtime now = Thread::get_hrtime_updated();
+  ink_hrtime now = ink_get_hrtime();
   if (now >= nextCheck) {
     forl_LL(UnixUDPConnection, xuc, open_list)
     {
@@ -1133,7 +1133,7 @@ UDPNetHandler::waitForActivity(ink_hrtime timeout)
         xuc->Release();
       }
     }
-    nextCheck = Thread::get_hrtime_updated() + HRTIME_MSECONDS(1000);
+    nextCheck = ink_get_hrtime() + HRTIME_MSECONDS(1000);
   }
   // service UDPConnections with data ready for callback.
   Que(UnixUDPConnection, callback_link) q = udp_callbacks;

--- a/iocore/net/quic/QUICAckFrameCreator.cc
+++ b/iocore/net/quic/QUICAckFrameCreator.cc
@@ -174,12 +174,12 @@ void
 QUICAckFrameManager::QUICAckFrameCreator::push_back(QUICPacketNumber packet_number, size_t size, bool ack_only)
 {
   if (packet_number == 0 || packet_number > this->_largest_ack_number) {
-    this->_largest_ack_received_time = Thread::get_hrtime();
+    this->_largest_ack_received_time = ink_get_hrtime();
     this->_largest_ack_number        = packet_number;
   }
 
   if (!this->_latest_packet_received_time) {
-    this->_latest_packet_received_time = Thread::get_hrtime();
+    this->_latest_packet_received_time = ink_get_hrtime();
   }
 
   // unorder packet should send ack immediately to accelerate the recovery
@@ -332,7 +332,7 @@ uint64_t
 QUICAckFrameManager::QUICAckFrameCreator::_calculate_delay()
 {
   // Ack delay is in microseconds and scaled
-  ink_hrtime now             = Thread::get_hrtime();
+  ink_hrtime now             = ink_get_hrtime();
   uint64_t delay             = (now - this->_largest_ack_received_time) / 1000;
   uint8_t ack_delay_exponent = 3;
   if (this->_pn_space != QUICPacketNumberSpace::INITIAL && this->_pn_space != QUICPacketNumberSpace::HANDSHAKE) {
@@ -351,7 +351,7 @@ bool
 QUICAckFrameManager::QUICAckFrameCreator::is_ack_frame_ready()
 {
   if (this->_available && this->_has_new_data && !this->_packet_numbers.empty() &&
-      this->_latest_packet_received_time + this->_max_ack_delay * HRTIME_MSECOND <= Thread::get_hrtime()) {
+      this->_latest_packet_received_time + this->_max_ack_delay * HRTIME_MSECOND <= ink_get_hrtime()) {
     // when we has new data and the data is available to send (not ack only). and we delay for too much time. Send it out
     this->_should_send = true;
   }

--- a/iocore/net/quic/QUICFlowController.cc
+++ b/iocore/net/quic/QUICFlowController.cc
@@ -30,7 +30,7 @@
 void
 QUICRateAnalyzer::update(QUICOffset offset)
 {
-  ink_hrtime now = Thread::get_hrtime();
+  ink_hrtime now = ink_get_hrtime();
   if (offset > 0 && now > this->_start_time) {
     this->_rate = static_cast<double>(offset) / (now - this->_start_time);
   }

--- a/iocore/net/quic/QUICFlowController.h
+++ b/iocore/net/quic/QUICFlowController.h
@@ -37,7 +37,7 @@ public:
 
 private:
   double _rate           = 0.0;
-  ink_hrtime _start_time = Thread::get_hrtime();
+  ink_hrtime _start_time = ink_get_hrtime();
 };
 
 class QUICFlowController : public QUICFrameGenerator

--- a/iocore/net/quic/QUICLossDetector.cc
+++ b/iocore/net/quic/QUICLossDetector.cc
@@ -71,7 +71,7 @@ QUICLossDetector::event_handler(int event, Event *edata)
 {
   switch (event) {
   case EVENT_INTERVAL: {
-    if (this->_loss_detection_alarm_at <= Thread::get_hrtime()) {
+    if (this->_loss_detection_alarm_at <= ink_get_hrtime()) {
       this->_loss_detection_alarm_at = 0;
       this->_on_loss_detection_timeout();
     }
@@ -254,7 +254,7 @@ QUICLossDetector::_on_ack_received(const QUICAckFrame &ack_frame, QUICPacketNumb
   //  ack-eliciting, update the RTT.
   const auto &largest_acked = newly_acked_packets[0];
   if (largest_acked->packet_number == ack_frame.largest_acknowledged() && this->_include_ack_eliciting(newly_acked_packets)) {
-    ink_hrtime latest_rtt = Thread::get_hrtime() - largest_acked->time_sent;
+    ink_hrtime latest_rtt = ink_get_hrtime() - largest_acked->time_sent;
     // _latest_rtt is nanosecond but ack_frame.ack_delay is microsecond and scaled
     ink_hrtime ack_delay = 0;
     if (pn_space == QUICPacketNumberSpace::APPLICATION_DATA) {
@@ -338,10 +338,10 @@ QUICLossDetector::_get_pto_time_and_space(QUICPacketNumberSpace &space)
     ink_assert(!this->_peer_completed_address_validation());
     if (this->_context.connection_info()->has_keys_for(QUICPacketNumberSpace::HANDSHAKE)) {
       space = QUICPacketNumberSpace::HANDSHAKE;
-      return Thread::get_hrtime() + duration;
+      return ink_get_hrtime() + duration;
     } else {
       space = QUICPacketNumberSpace::INITIAL;
-      return Thread::get_hrtime() + duration;
+      return ink_get_hrtime() + duration;
     }
   }
   ink_hrtime pto_timeout          = INT64_MAX;
@@ -398,7 +398,7 @@ QUICLossDetector::_set_loss_detection_timer()
   if (earliest_loss_time != 0) {
     update_timer(earliest_loss_time);
     QUICLDDebug("[%s] time threshold loss detection timer: %" PRId64 "ms", QUICDebugNames::pn_space(pn_space),
-                (this->_loss_detection_alarm_at - Thread::get_hrtime()) / HRTIME_MSECOND);
+                (this->_loss_detection_alarm_at - ink_get_hrtime()) / HRTIME_MSECOND);
     return;
   }
 
@@ -492,7 +492,7 @@ QUICLossDetector::_detect_and_remove_lost_packets(QUICPacketNumberSpace pn_space
   loss_delay = std::max(loss_delay, this->_rtt_measure->k_granularity());
 
   // Packets sent before this time are deemed lost.
-  ink_hrtime lost_send_time = Thread::get_hrtime() - loss_delay;
+  ink_hrtime lost_send_time = ink_get_hrtime() - loss_delay;
 
   // Packets with packet numbers before this are deemed lost.
   //  QUICPacketNumber lost_pn = this->_largest_acked_packet[static_cast<int>(pn_space)] - this->_k_packet_threshold;

--- a/iocore/net/quic/QUICNewRenoCongestionController.cc
+++ b/iocore/net/quic/QUICNewRenoCongestionController.cc
@@ -117,7 +117,7 @@ QUICNewRenoCongestionController::_congestion_event(ink_hrtime sent_time)
   // Start a new congestion event if packet was sent after the
   // start of the previous congestion recovery period.
   if (!this->_in_congestion_recovery(sent_time)) {
-    this->_congestion_recovery_start_time = Thread::get_hrtime();
+    this->_congestion_recovery_start_time = ink_get_hrtime();
     this->_congestion_window *= this->_k_loss_reduction_factor;
     this->_congestion_window = std::max(this->_congestion_window, this->_k_minimum_window);
     this->_ssthresh          = this->_congestion_window;

--- a/iocore/net/quic/QUICPathManager.cc
+++ b/iocore/net/quic/QUICPathManager.cc
@@ -37,7 +37,7 @@ QUICPathManagerImpl::open_new_path(const QUICPath &path, ink_hrtime timeout_in)
   }
   this->_current_path = path;
   this->_path_validator.validate(path);
-  this->_verify_timeout_at = Thread::get_hrtime() + timeout_in;
+  this->_verify_timeout_at = ink_get_hrtime() + timeout_in;
 }
 
 void
@@ -55,7 +55,7 @@ QUICPathManagerImpl::_check_verify_timeout()
       // Address validation succeeded
       this->_verify_timeout_at = 0;
       this->_previous_path     = {{}, {}};
-    } else if (this->_verify_timeout_at < Thread::get_hrtime()) {
+    } else if (this->_verify_timeout_at < ink_get_hrtime()) {
       // Address validation failed
       QUICDebug("Switching back to the previous path");
       this->_current_path      = this->_previous_path;

--- a/iocore/net/quic/QUICTokenCreator.cc
+++ b/iocore/net/quic/QUICTokenCreator.cc
@@ -49,7 +49,7 @@ QUICTokenCreator::generate_frame(uint8_t *buf, QUICEncryptionLevel level, uint64
   if (this->_context->connection_info()->direction() == NET_VCONNECTION_IN) {
     // TODO Make expiration period configurable
     QUICResumptionToken token(this->_context->connection_info()->five_tuple().source(),
-                              this->_context->connection_info()->connection_id(), Thread::get_hrtime() + HRTIME_HOURS(24));
+                              this->_context->connection_info()->connection_id(), ink_get_hrtime() + HRTIME_HOURS(24));
     frame = QUICFrameFactory::create_new_token_frame(buf, token, this->_issue_frame_id(), this);
     if (frame) {
       if (frame->size() < maximum_frame_size) {

--- a/iocore/net/quic/QUICTypes.cc
+++ b/iocore/net/quic/QUICTypes.cc
@@ -345,7 +345,7 @@ bool
 QUICResumptionToken::is_valid(const IpEndpoint &src) const
 {
   QUICResumptionToken x(src, this->cid(), this->expire_time() << 30);
-  return *this == x && this->expire_time() >= (Thread::get_hrtime() >> 30);
+  return *this == x && this->expire_time() >= (ink_get_hrtime() >> 30);
 }
 
 const QUICConnectionId

--- a/iocore/net/quic/qlog/QLog.h
+++ b/iocore/net/quic/qlog/QLog.h
@@ -47,7 +47,7 @@ public:
   };
 
   Trace(const std::string &odcid, const std::string &title = "", const std::string &desc = "")
-    : _reference_time(Thread::get_hrtime()), _odcid(odcid)
+    : _reference_time(ink_get_hrtime()), _odcid(odcid)
   {
   }
 
@@ -96,7 +96,7 @@ public:
   void encode(YAML::Node &node);
 
 private:
-  int64_t _reference_time = Thread::get_hrtime();
+  int64_t _reference_time = ink_get_hrtime();
   std::string _odcid;
   std::string _title;
   std::string _desc;

--- a/iocore/net/quic/qlog/QLogEvent.h
+++ b/iocore/net/quic/qlog/QLogEvent.h
@@ -48,7 +48,7 @@ public:
   };
 
 protected:
-  ink_hrtime _time = Thread::get_hrtime();
+  ink_hrtime _time = ink_get_hrtime();
 };
 
 using QLogEventUPtr = std::unique_ptr<QLogEvent>;

--- a/iocore/net/quic/test/test_QUICAckFrameCreator.cc
+++ b/iocore/net/quic/test/test_QUICAckFrameCreator.cc
@@ -169,7 +169,6 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
 
   SECTION("QUIC delay too much time", "[quic]")
   {
-    Thread::get_hrtime_updated();
     QUICAckFrameManager ack_manager;
 
     QUICEncryptionLevel level = QUICEncryptionLevel::ONE_RTT;
@@ -177,7 +176,6 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
     CHECK(ack_manager.will_generate_frame(level, 0, true, 0) == false);
 
     sleep(1);
-    Thread::get_hrtime_updated();
     ack_manager.update(level, 1, 1, false);
     CHECK(ack_manager.will_generate_frame(level, 0, true, 0) == true);
   }
@@ -209,7 +207,6 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
     CHECK(ack_manager.will_generate_frame(level, 0, true, 0) == false);
 
     sleep(1);
-    Thread::get_hrtime_updated();
     CHECK(ack_manager.will_generate_frame(level, 0, true, 0) == true);
   }
 
@@ -231,7 +228,6 @@ TEST_CASE("QUICAckFrameManager should send", "[quic]")
 
     // Delay due to some reason, the frame is not valued any more, but still valued
     sleep(1);
-    Thread::get_hrtime_updated();
     CHECK(ack_manager.will_generate_frame(level, 0, true, 0) == true);
     ack_frame = ack_manager.generate_frame(frame_buf, level, UINT16_MAX, UINT16_MAX, 0, 0);
     frame     = static_cast<QUICAckFrame *>(ack_frame);
@@ -293,8 +289,6 @@ TEST_CASE("QUICAckFrameManager_QUICAckFrameCreator", "[quic]")
   CHECK(packet_numbers.largest_ack_number() == 0);
   CHECK(packet_numbers.largest_ack_received_time() == 0);
 
-  Thread::get_hrtime_updated();
-
   packet_numbers.push_back(3, 2, false);
   CHECK(packet_numbers.size() == 1);
   CHECK(packet_numbers.largest_ack_number() == 3);
@@ -302,21 +296,15 @@ TEST_CASE("QUICAckFrameManager_QUICAckFrameCreator", "[quic]")
   ink_hrtime ti = packet_numbers.largest_ack_received_time();
   CHECK(packet_numbers.largest_ack_received_time() != 0);
 
-  Thread::get_hrtime_updated();
-
   packet_numbers.push_back(2, 2, false);
   CHECK(packet_numbers.size() == 2);
   CHECK(packet_numbers.largest_ack_number() == 3);
   CHECK(packet_numbers.largest_ack_received_time() == ti);
 
-  Thread::get_hrtime_updated();
-
   packet_numbers.push_back(10, 2, false);
   CHECK(packet_numbers.size() == 3);
   CHECK(packet_numbers.largest_ack_number() == 10);
   CHECK(packet_numbers.largest_ack_received_time() > ti);
-
-  Thread::get_hrtime_updated();
 
   packet_numbers.clear();
   CHECK(packet_numbers.size() == 0);

--- a/iocore/net/quic/test/test_QUICFlowController.cc
+++ b/iocore/net/quic/test/test_QUICFlowController.cc
@@ -104,7 +104,6 @@ TEST_CASE("QUICFlowController_Local_Connection", "[quic]")
   CHECK(fc.current_offset() == 1024);
   CHECK(fc.current_limit() == 1024);
   CHECK(ret == 0);
-  Thread::get_hrtime_updated();
 
   // Exceed limit
   ret = fc.update(1280);
@@ -288,7 +287,6 @@ TEST_CASE("QUICFlowController_Local_Stream", "[quic]")
   CHECK(fc.current_offset() == 1024);
   CHECK(fc.current_limit() == 1024);
   CHECK(ret == 0);
-  Thread::get_hrtime_updated();
 
   // Exceed limit
   ret = fc.update(1280);

--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -86,7 +86,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
       packet->is_ack_eliciting(),
       true,
       packet->size(),
-      Thread::get_hrtime(),
+      ink_get_hrtime(),
       packet->type(),
       {},
       QUICPacketNumberSpace::HANDSHAKE,
@@ -187,7 +187,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet1->is_ack_eliciting(),
                                                                           true,
                                                                           packet1->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet1->type(),
                                                                           {},
                                                                           pn_space}));
@@ -195,7 +195,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet2->is_ack_eliciting(),
                                                                           true,
                                                                           packet2->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet2->type(),
                                                                           {},
                                                                           pn_space}));
@@ -203,7 +203,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet3->is_ack_eliciting(),
                                                                           true,
                                                                           packet3->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet3->type(),
                                                                           {},
                                                                           pn_space}));
@@ -211,7 +211,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet4->is_ack_eliciting(),
                                                                           true,
                                                                           packet4->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet4->type(),
                                                                           {},
                                                                           pn_space}));
@@ -219,7 +219,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet5->is_ack_eliciting(),
                                                                           true,
                                                                           packet5->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet5->type(),
                                                                           {},
                                                                           pn_space}));
@@ -227,7 +227,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet6->is_ack_eliciting(),
                                                                           true,
                                                                           packet6->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet6->type(),
                                                                           {},
                                                                           pn_space}));
@@ -235,7 +235,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet6->is_ack_eliciting(),
                                                                           true,
                                                                           packet7->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet7->type(),
                                                                           {},
                                                                           pn_space}));
@@ -243,7 +243,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet6->is_ack_eliciting(),
                                                                           true,
                                                                           packet8->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet8->type(),
                                                                           {},
                                                                           pn_space}));
@@ -251,7 +251,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet6->is_ack_eliciting(),
                                                                           true,
                                                                           packet9->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet9->type(),
                                                                           {},
                                                                           pn_space}));
@@ -259,7 +259,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
                                                                           packet10->is_ack_eliciting(),
                                                                           true,
                                                                           packet10->size(),
-                                                                          Thread::get_hrtime(),
+                                                                          ink_get_hrtime(),
                                                                           packet10->type(),
                                                                           {},
                                                                           pn_space}));
@@ -306,11 +306,11 @@ TEST_CASE("QUICLossDetector_HugeGap", "[quic]")
   MockQUICCongestionController cc;
   QUICLossDetector detector(context, &cc, &rtt_measure, &pinger, &padder);
 
-  auto t1           = Thread::get_hrtime();
+  auto t1           = ink_get_hrtime();
   QUICAckFrame *ack = QUICFrameFactory::create_ack_frame(frame_buf, 100000000, 100, 10000000);
   ack->ack_block_section()->add_ack_block({20000000, 30000000});
   detector.handle_frame(QUICEncryptionLevel::INITIAL, *ack);
-  auto t2 = Thread::get_hrtime();
+  auto t2 = ink_get_hrtime();
   CHECK(t2 - t1 < HRTIME_MSECONDS(100));
   ack->~QUICAckFrame();
 }

--- a/iocore/net/quic/test/test_QUICType.cc
+++ b/iocore/net/quic/test/test_QUICType.cc
@@ -133,7 +133,7 @@ TEST_CASE("QUICType", "[quic]")
                          0x19, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27};
     QUICConnectionId cid(cid_buf, sizeof(cid_buf));
 
-    ink_hrtime expire_date = Thread::get_hrtime() + (3 * HRTIME_DAY);
+    ink_hrtime expire_date = ink_get_hrtime() + (3 * HRTIME_DAY);
 
     QUICResumptionToken token1(ep, cid, expire_date);
     QUICResumptionToken token2(token1.buf(), token1.length());

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -77,6 +77,9 @@ static const RecordElement RecordsConfig[] =
   //# 0 = disable (seconds)
   {RECT_CONFIG, "proxy.config.dump_mem_info_frequency", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  //# 0 == CLOCK_REALTIME, change carefully
+  {RECT_CONFIG, "proxy.config.system_clock", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-9]+", RECA_NULL}
+  ,
   //# 0 = disable
   {RECT_CONFIG, "proxy.config.http_ui_enabled", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, "[0-3]", RECA_NULL}
   ,

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -444,7 +444,7 @@ MC::cache_read_event(int event, void *data)
       goto Lfail;
     }
     {
-      ink_hrtime t = Thread::get_hrtime();
+      ink_hrtime t = ink_get_hrtime();
       if ((static_cast<ink_hrtime>(rcache_header->settime)) <= last_flush ||
           t >= (static_cast<ink_hrtime>(rcache_header->settime)) + HRTIME_SECONDS(rcache_header->exptime)) {
         goto Lfail;
@@ -777,7 +777,7 @@ MC::ascii_set_event(int event, void *data)
       if (header.nkey != wcache_header->nkey || hlen < static_cast<int>(sizeof(MCCacheHeader) + wcache_header->nkey)) {
         goto Lfail;
       }
-      ink_hrtime t = Thread::get_hrtime();
+      ink_hrtime t = ink_get_hrtime();
       if ((static_cast<ink_hrtime>(wcache_header->settime)) <= last_flush ||
           t >= (static_cast<ink_hrtime>(wcache_header->settime)) + HRTIME_SECONDS(wcache_header->exptime)) {
         goto Lstale;
@@ -792,7 +792,7 @@ MC::ascii_set_event(int event, void *data)
       }
     }
     memcpy(tmp_cache_header_key, key, header.nkey);
-    header.settime = Thread::get_hrtime();
+    header.settime = ink_get_hrtime();
     if (exptime) {
       if (exptime > REALTIME_MAXDELTA) {
         if (HRTIME_SECONDS(exptime) <= (static_cast<ink_hrtime>(header.settime))) {
@@ -937,7 +937,7 @@ MC::ascii_incr_decr_event(int event, void *data)
         if (header.nkey != wcache_header->nkey || hlen < static_cast<int>(sizeof(MCCacheHeader) + wcache_header->nkey)) {
           goto Lfail;
         }
-        ink_hrtime t = Thread::get_hrtime();
+        ink_hrtime t = ink_get_hrtime();
         if ((static_cast<ink_hrtime>(wcache_header->settime)) <= last_flush ||
             t >= (static_cast<ink_hrtime>(wcache_header->settime)) + HRTIME_SECONDS(wcache_header->exptime)) {
           goto Lfail;
@@ -946,7 +946,7 @@ MC::ascii_incr_decr_event(int event, void *data)
         goto Lfail;
       }
       memcpy(tmp_cache_header_key, key, header.nkey);
-      header.settime = Thread::get_hrtime();
+      header.settime = ink_get_hrtime();
       if (exptime) {
         if (exptime > REALTIME_MAXDELTA) {
           if (HRTIME_SECONDS(exptime) <= (static_cast<ink_hrtime>(header.settime))) {
@@ -1385,7 +1385,7 @@ MC::read_ascii_from_client_event(int event, void *data)
       GET_NUM(time_offset);
     }
     f.noreply                 = is_noreply(&s, e);
-    ink_hrtime new_last_flush = Thread::get_hrtime() + HRTIME_SECONDS(time_offset);
+    ink_hrtime new_last_flush = ink_get_hrtime() + HRTIME_SECONDS(time_offset);
 #if __WORDSIZE == 64
     last_flush = new_last_flush; // this will be atomic for native word size
 #else

--- a/plugins/experimental/uri_signing/jwt.c
+++ b/plugins/experimental/uri_signing/jwt.c
@@ -85,6 +85,7 @@ double
 now(void)
 {
   struct timespec t;
+
   if (!clock_gettime(CLOCK_REALTIME, &t)) {
     return (double)t.tv_sec + 1.0e-9 * (double)t.tv_nsec;
   }

--- a/proxy/Milestones.h
+++ b/proxy/Milestones.h
@@ -53,7 +53,7 @@ public:
   mark(T ms)
   {
     if (this->_milestones[static_cast<size_t>(ms)] == 0) {
-      this->_milestones[static_cast<size_t>(ms)] = Thread::get_hrtime();
+      this->_milestones[static_cast<size_t>(ms)] = ink_get_hrtime();
     }
   }
 

--- a/proxy/PluginVC.cc
+++ b/proxy/PluginVC.cc
@@ -205,7 +205,7 @@ PluginVC::main_handler(int event, void *data)
   if (call_event == active_event) {
     process_timeout(&active_event, VC_EVENT_ACTIVE_TIMEOUT);
   } else if (call_event == inactive_event) {
-    if (inactive_timeout_at && inactive_timeout_at < Thread::get_hrtime()) {
+    if (inactive_timeout_at && inactive_timeout_at < ink_get_hrtime()) {
       process_timeout(&inactive_event, VC_EVENT_INACTIVITY_TIMEOUT);
     }
   } else {
@@ -743,7 +743,7 @@ PluginVC::update_inactive_time()
   if (inactive_event && inactive_timeout) {
     // inactive_event->cancel();
     // inactive_event = eventProcessor.schedule_in(this, inactive_timeout);
-    inactive_timeout_at = Thread::get_hrtime() + inactive_timeout;
+    inactive_timeout_at = ink_get_hrtime() + inactive_timeout;
   }
 }
 
@@ -800,7 +800,7 @@ PluginVC::set_inactivity_timeout(ink_hrtime timeout_in)
 {
   inactive_timeout = timeout_in;
   if (inactive_timeout != 0) {
-    inactive_timeout_at = Thread::get_hrtime() + inactive_timeout;
+    inactive_timeout_at = ink_get_hrtime() + inactive_timeout;
     if (inactive_event == nullptr) {
       inactive_event = eventProcessor.schedule_every(this, HRTIME_SECONDS(1));
     }

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -368,7 +368,7 @@ HttpSM::destroy()
 void
 HttpSM::init(bool from_early_data)
 {
-  milestones[TS_MILESTONE_SM_START] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_SM_START] = ink_get_hrtime();
 
   _from_early_data = from_early_data;
 
@@ -502,7 +502,7 @@ HttpSM::start_sub_sm()
 void
 HttpSM::attach_client_session(ProxyTransaction *client_vc)
 {
-  milestones[TS_MILESTONE_UA_BEGIN] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_UA_BEGIN] = ink_get_hrtime();
   ink_assert(client_vc != nullptr);
 
   NetVConnection *netvc = client_vc->get_netvc();
@@ -726,7 +726,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
   //   the accept timeout by the ProxyTransaction
   //
   if ((ua_txn->get_remote_reader()->read_avail() > 0) && (client_request_hdr_bytes == 0)) {
-    milestones[TS_MILESTONE_UA_FIRST_READ] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_UA_FIRST_READ] = ink_get_hrtime();
     ua_txn->set_inactivity_timeout(HRTIME_SECONDS(t_state.txn_conf->transaction_no_activity_timeout_in));
   }
   /////////////////////
@@ -793,7 +793,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
     }
     http_parser_clear(&http_parser);
     ua_entry->vc_handler                         = &HttpSM::state_watch_for_client_abort;
-    milestones[TS_MILESTONE_UA_READ_HEADER_DONE] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_UA_READ_HEADER_DONE] = ink_get_hrtime();
   }
 
   switch (state) {
@@ -1038,7 +1038,7 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
     if (ua_entry->read_vio) {
       ua_entry->read_vio->nbytes = ua_entry->read_vio->ndone;
     }
-    milestones[TS_MILESTONE_UA_CLOSE] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_UA_CLOSE] = ink_get_hrtime();
     set_ua_abort(HttpTransact::ABORTED, event);
 
     terminate_sm = true;
@@ -1186,7 +1186,7 @@ HttpSM::state_read_push_response_header(int event, void *data)
     // Disable further IO
     ua_entry->read_vio->nbytes = ua_entry->read_vio->ndone;
     http_parser_clear(&http_parser);
-    milestones[TS_MILESTONE_SERVER_READ_HEADER_DONE] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_SERVER_READ_HEADER_DONE] = ink_get_hrtime();
   }
 
   switch (state) {
@@ -1220,7 +1220,7 @@ HttpSM::state_raw_http_server_open(int event, void *data)
 {
   STATE_ENTER(&HttpSM::state_raw_http_server_open, event);
   ink_assert(server_entry == nullptr);
-  milestones[TS_MILESTONE_SERVER_CONNECT_END] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_SERVER_CONNECT_END] = ink_get_hrtime();
   NetVConnection *netvc                       = nullptr;
 
   pending_action = nullptr;
@@ -1552,7 +1552,7 @@ plugins required to work with sni_routing.
 
       // Have a mutex but didn't get the lock, reschedule
       if (!lock.is_locked()) {
-        api_timer = -Thread::get_hrtime_updated();
+        api_timer = -ink_get_hrtime();
         HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_api_callout);
         ink_assert(pending_action == nullptr);
         pending_action = mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(10));
@@ -1567,13 +1567,13 @@ plugins required to work with sni_routing.
       cur_hook = nullptr;
 
       if (!api_timer) {
-        api_timer = Thread::get_hrtime();
+        api_timer = ink_get_hrtime();
       }
 
       hook->invoke(TS_EVENT_HTTP_READ_REQUEST_HDR + cur_hook_id, this);
       if (api_timer > 0) { // true if the hook did not call TxnReenable()
         this->milestone_update_api_time();
-        api_timer = -Thread::get_hrtime(); // set in order to track non-active callout duration
+        api_timer = -ink_get_hrtime(); // set in order to track non-active callout duration
         // which means that if we get back from the invoke with api_timer < 0 we're already
         // tracking a non-complete callout from a chain so just let it ride. It will get cleaned
         // up in state_api_callback when the plugin re-enables this transaction.
@@ -1882,7 +1882,7 @@ HttpSM::state_http_server_open(int event, void *data)
   if (event != NET_EVENT_OPEN) {
     pending_action = nullptr;
   }
-  milestones[TS_MILESTONE_SERVER_CONNECT_END] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_SERVER_CONNECT_END] = ink_get_hrtime();
 
   switch (event) {
   case NET_EVENT_OPEN: {
@@ -2036,7 +2036,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
   //   the connect timeout when we set up to read the header
   //
   if (server_response_hdr_bytes == 0) {
-    milestones[TS_MILESTONE_SERVER_FIRST_READ] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_SERVER_FIRST_READ] = ink_get_hrtime();
 
     server_txn->set_inactivity_timeout(get_server_inactivity_timeout());
 
@@ -2070,7 +2070,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
     // Disable further IO
     server_entry->read_vio->nbytes = server_entry->read_vio->ndone;
     http_parser_clear(&http_parser);
-    milestones[TS_MILESTONE_SERVER_READ_HEADER_DONE] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_SERVER_READ_HEADER_DONE] = ink_get_hrtime();
 
     // If there is a post body in transit, give up on it
     if (tunnel.is_tunnel_alive()) {
@@ -2370,7 +2370,7 @@ HttpSM::process_hostdb_info(HostDBInfo *r)
     ink_assert(!t_state.host_db_info.round_robin);
   }
 
-  milestones[TS_MILESTONE_DNS_LOOKUP_END] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_DNS_LOOKUP_END] = ink_get_hrtime();
 
   if (is_debug_tag_set("http_timeout")) {
     if (t_state.api_txn_dns_timeout_value != -1) {
@@ -2561,7 +2561,7 @@ HttpSM::state_cache_open_write(int event, void *data)
     }
   }
 
-  milestones[TS_MILESTONE_CACHE_OPEN_WRITE_END] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_CACHE_OPEN_WRITE_END] = ink_get_hrtime();
   pending_action                                = nullptr;
 
   switch (event) {
@@ -2721,7 +2721,7 @@ HttpSM::state_cache_open_read(int event, void *data)
     break;
   }
 
-  milestones[TS_MILESTONE_CACHE_OPEN_READ_END] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_CACHE_OPEN_READ_END] = ink_get_hrtime();
 
   return 0;
 }
@@ -3090,7 +3090,7 @@ HttpSM::tunnel_handler_server(int event, HttpTunnelProducer *p)
   // TS_MILESTONE_SERVER_CONNECT is set (non-zero), lest certain time
   // statistics are calculated from epoch time.
   if (0 != milestones[TS_MILESTONE_SERVER_CONNECT]) {
-    milestones[TS_MILESTONE_SERVER_CLOSE] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_SERVER_CLOSE] = ink_get_hrtime();
   }
 
   bool close_connection = false;
@@ -3364,7 +3364,7 @@ HttpSM::tunnel_handler_ua(int event, HttpTunnelConsumer *c)
 
   STATE_ENTER(&HttpSM::tunnel_handler_ua, event);
   ink_assert(c->vc == ua_txn);
-  milestones[TS_MILESTONE_UA_CLOSE] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_UA_CLOSE] = ink_get_hrtime();
 
   switch (event) {
   case VC_EVENT_EOS:
@@ -4268,7 +4268,7 @@ HttpSM::do_hostdb_lookup()
   ink_assert(t_state.dns_info.lookup_name != nullptr);
   ink_assert(pending_action == nullptr);
 
-  milestones[TS_MILESTONE_DNS_LOOKUP_BEGIN] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_DNS_LOOKUP_BEGIN] = ink_get_hrtime();
 
   // If directed to not look up fqdns then mark as resolved
   if (t_state.http_config_param->no_dns_forward_to_parent && t_state.parent_result.result == PARENT_UNDEFINED) {
@@ -4813,7 +4813,7 @@ HttpSM::do_cache_lookup_and_read()
 
   HTTP_INCREMENT_DYN_STAT(http_cache_lookups_stat);
 
-  milestones[TS_MILESTONE_CACHE_OPEN_READ_BEGIN] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_CACHE_OPEN_READ_BEGIN] = ink_get_hrtime();
   t_state.cache_lookup_result                    = HttpTransact::CACHE_LOOKUP_NONE;
   t_state.cache_info.lookup_count++;
   // YTS Team, yamsat Plugin
@@ -4874,7 +4874,7 @@ HttpSM::do_cache_delete_all_alts(Continuation *cont)
 inline void
 HttpSM::do_cache_prepare_write()
 {
-  milestones[TS_MILESTONE_CACHE_OPEN_WRITE_BEGIN] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_CACHE_OPEN_WRITE_BEGIN] = ink_get_hrtime();
   do_cache_prepare_action(&cache_sm, t_state.cache_info.object_read, true);
 }
 
@@ -5096,7 +5096,7 @@ HttpSM::do_http_server_open(bool raw)
   SMDebug("http_seq", "Sending request to server");
 
   // set the server first connect milestone here in case we return in the plugin_tunnel case that follows
-  milestones[TS_MILESTONE_SERVER_CONNECT] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_SERVER_CONNECT] = ink_get_hrtime();
   if (milestones[TS_MILESTONE_SERVER_FIRST_CONNECT] == 0) {
     milestones[TS_MILESTONE_SERVER_FIRST_CONNECT] = milestones[TS_MILESTONE_SERVER_CONNECT];
   }
@@ -5541,7 +5541,7 @@ HttpSM::do_api_callout_internal()
     break;
   case HttpTransact::SM_ACTION_API_SEND_RESPONSE_HDR:
     cur_hook_id                             = TS_HTTP_SEND_RESPONSE_HDR_HOOK;
-    milestones[TS_MILESTONE_UA_BEGIN_WRITE] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_UA_BEGIN_WRITE] = ink_get_hrtime();
     break;
   case HttpTransact::SM_ACTION_API_SM_SHUTDOWN:
     if (callout_state == HTTP_API_IN_CALLOUT || callout_state == HTTP_API_DEFERED_SERVER_ERROR) {
@@ -6441,7 +6441,7 @@ HttpSM::setup_server_send_request()
     server_request_body_bytes = msg_len;
   }
 
-  milestones[TS_MILESTONE_SERVER_BEGIN_WRITE] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_SERVER_BEGIN_WRITE] = ink_get_hrtime();
   server_entry->write_vio                     = server_entry->vc->do_io_write(this, hdr_length, buf_start);
 
   // Make sure the VC is using correct timeouts.  We may be reusing a previously used server session
@@ -7096,7 +7096,7 @@ HttpSM::setup_blind_tunnel(bool send_response_hdr, IOBufferReader *initial)
   IOBufferReader *r_from = from_ua_buf->alloc_reader();
   IOBufferReader *r_to   = to_ua_buf->alloc_reader();
 
-  milestones[TS_MILESTONE_SERVER_BEGIN_WRITE] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_SERVER_BEGIN_WRITE] = ink_get_hrtime();
   if (send_response_hdr) {
     client_response_hdr_bytes = write_response_header_into_buffer(&t_state.hdr_info.client_response, to_ua_buf);
     if (initial && initial->read_avail()) {
@@ -7352,7 +7352,7 @@ HttpSM::kill_this()
 void
 HttpSM::update_stats()
 {
-  milestones[TS_MILESTONE_SM_FINISH] = Thread::get_hrtime();
+  milestones[TS_MILESTONE_SM_FINISH] = ink_get_hrtime();
 
   if (is_action_tag_set("bad_length_state_dump")) {
     if (t_state.hdr_info.client_response.valid() && t_state.hdr_info.client_response.status_get() == HTTP_STATUS_OK) {
@@ -7381,7 +7381,7 @@ HttpSM::update_stats()
   // ua_close will not be assigned properly in some exceptional situation.
   // TODO: Assign ua_close with suitable value when HttpTunnel terminates abnormally.
   if (milestones[TS_MILESTONE_UA_CLOSE] == 0 && milestones[TS_MILESTONE_UA_READ_HEADER_DONE] > 0) {
-    milestones[TS_MILESTONE_UA_CLOSE] = Thread::get_hrtime();
+    milestones[TS_MILESTONE_UA_CLOSE] = ink_get_hrtime();
   }
 
   // request_process_time  = The time after the header is parsed to the completion of the transaction
@@ -8591,7 +8591,7 @@ HttpSM::milestone_update_api_time()
     if (!active) {
       api_timer = -api_timer;
     }
-    delta     = Thread::get_hrtime_updated() - api_timer;
+    delta     = ink_get_hrtime() - api_timer;
     api_timer = 0;
     // Zero or negative time is a problem because we want to signal *something* happened
     // vs. no API activity at all. This can happen due to graininess or real time

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -8310,7 +8310,7 @@ HttpTransact::get_error_string(int erno)
 ink_time_t
 ink_local_time()
 {
-  return Thread::get_hrtime() / HRTIME_SECOND;
+  return ink_get_hrtime() / HRTIME_SECOND;
 }
 
 //
@@ -8320,7 +8320,7 @@ ink_local_time()
 void
 HttpTransact::milestone_start_api_time(State *s)
 {
-  s->state_machine->api_timer = Thread::get_hrtime_updated();
+  s->state_machine->api_timer = ink_get_hrtime();
 }
 
 void

--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -1715,7 +1715,7 @@ HttpTunnel::internal_error()
 void
 HttpTunnel::mark_tls_tunnel_active()
 {
-  _tls_tunnel_last_update = Thread::get_hrtime();
+  _tls_tunnel_last_update = ink_get_hrtime();
 
   if (_tls_tunnel_active) {
     return;
@@ -1766,7 +1766,7 @@ HttpTunnel::_is_tls_tunnel_active() const
   // This should not be called if period is 0
   ink_release_assert(period > 0);
 
-  ink_hrtime now = Thread::get_hrtime();
+  ink_hrtime now = ink_get_hrtime();
 
   Debug("http_tunnel", "now=%" PRId64 " last_update=%" PRId64, now, _tls_tunnel_last_update);
 

--- a/proxy/http/PreWarmManager.cc
+++ b/proxy/http/PreWarmManager.cc
@@ -311,7 +311,7 @@ PreWarmSM::state_dns_lookup(int event, void *data)
       if (rr) {
         char srv_hostname[MAXDNAME] = {0};
 
-        ink_hrtime now = Thread::get_hrtime();
+        ink_hrtime now = ink_get_hrtime();
         srv = rr->select_best_srv(srv_hostname, &mutex->thread_holding->generator, ink_hrtime_to_sec(now), DOWN_SERVER_TIMEOUT);
         hostname = std::string_view(srv_hostname);
 

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -202,7 +202,7 @@ Http2ClientSession::main_event_handler(int event, void *edata)
   case VC_EVENT_WRITE_READY:
   case VC_EVENT_WRITE_COMPLETE:
     this->connection_state.restart_streams();
-    if ((Thread::get_hrtime() >= this->_write_buffer_last_flush + HRTIME_MSECONDS(this->_write_time_threshold))) {
+    if ((ink_get_hrtime() >= this->_write_buffer_last_flush + HRTIME_MSECONDS(this->_write_time_threshold))) {
       this->flush();
     }
     retval = 0;

--- a/proxy/http2/Http2CommonSession.cc
+++ b/proxy/http2/Http2CommonSession.cc
@@ -173,7 +173,7 @@ Http2CommonSession::flush()
 {
   if (this->_pending_sending_data_size > 0) {
     this->_pending_sending_data_size = 0;
-    this->_write_buffer_last_flush   = Thread::get_hrtime();
+    this->_write_buffer_last_flush   = ink_get_hrtime();
     write_reenable();
   }
 }

--- a/proxy/http2/Http2FrequencyCounter.cc
+++ b/proxy/http2/Http2FrequencyCounter.cc
@@ -26,7 +26,7 @@
 void
 Http2FrequencyCounter::increment(uint16_t amount)
 {
-  ink_hrtime hrtime_sec = this->_get_hrtime();
+  ink_hrtime hrtime_sec = this->_ink_get_hrtime();
   uint8_t counter_index = ((hrtime_sec % 60) >= 30);
   uint8_t last_index    = ((this->_last_update % 60) >= 30);
 
@@ -55,7 +55,7 @@ Http2FrequencyCounter::get_count()
 }
 
 ink_hrtime
-Http2FrequencyCounter::_get_hrtime()
+Http2FrequencyCounter::_ink_get_hrtime()
 {
-  return ink_hrtime_to_sec(Thread::get_hrtime());
+  return ink_hrtime_to_sec(ink_get_hrtime());
 }

--- a/proxy/http2/Http2FrequencyCounter.h
+++ b/proxy/http2/Http2FrequencyCounter.h
@@ -38,5 +38,5 @@ protected:
   ink_hrtime _last_update = 0;
 
 private:
-  virtual ink_hrtime _get_hrtime();
+  virtual ink_hrtime _ink_get_hrtime();
 };

--- a/proxy/http2/unit_tests/test_Http2FrequencyCounter.cc
+++ b/proxy/http2/unit_tests/test_Http2FrequencyCounter.cc
@@ -39,7 +39,7 @@ public:
 
 private:
   ink_hrtime
-  _get_hrtime() override
+  _ink_get_hrtime() override
   {
     return this->_now;
   }
@@ -59,14 +59,14 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
     counter.increment(2);
     REQUIRE(counter.get_count() == 3);
 
-    ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
+    ink_hrtime now = ink_hrtime_to_sec(ink_get_hrtime());
     counter.set_internal_state(now, now - 10, 1, 2);
     REQUIRE(counter.get_count() == 3);
   }
 
   SECTION("Update at 0")
   {
-    ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
+    ink_hrtime now = ink_hrtime_to_sec(ink_get_hrtime());
     now -= now % 60;
 
     counter.set_internal_state(now, now - 5, 1, 2);
@@ -104,7 +104,7 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
 
   SECTION("Update at 10")
   {
-    ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
+    ink_hrtime now = ink_hrtime_to_sec(ink_get_hrtime());
     now -= now % 60;
     now += 10;
 
@@ -143,7 +143,7 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
 
   SECTION("Update at 30")
   {
-    ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
+    ink_hrtime now = ink_hrtime_to_sec(ink_get_hrtime());
     now -= now % 60;
     now += 30;
 
@@ -182,7 +182,7 @@ TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
 
   SECTION("Update at 40")
   {
-    ink_hrtime now = ink_hrtime_to_sec(Thread::get_hrtime_updated());
+    ink_hrtime now = ink_hrtime_to_sec(ink_get_hrtime());
     now -= now % 60;
     now += 40;
 

--- a/proxy/logging/Log.cc
+++ b/proxy/logging/Log.cc
@@ -1433,11 +1433,11 @@ Log::flush_thread_main(void * /* args ATS_UNUSED */)
 
     // Time to work on periodic events??
     //
-    now = Thread::get_hrtime_updated() / HRTIME_SECOND;
+    now = ink_get_hrtime() / HRTIME_SECOND;
     if (now >= last_time + periodic_tasks_interval) {
       Debug("log-preproc", "periodic tasks for %" PRId64, (int64_t)now);
       periodic_tasks(now);
-      last_time = Thread::get_hrtime() / HRTIME_SECOND;
+      last_time = ink_get_hrtime() / HRTIME_SECOND;
     }
 
     // wait for more work; a spurious wake-up is ok since we'll just

--- a/proxy/logging/LogObject.cc
+++ b/proxy/logging/LogObject.cc
@@ -1330,7 +1330,7 @@ REGRESSION_TEST(LogObjectManager_Transfer)(RegressionTest *t, int /* atype ATS_U
     box.check(mgr2.get_num_objects() == 4, "Testing that manager 2 has 4 objects");
 
     rprintf(t, "running Log::periodoc_tasks()\n");
-    Log::periodic_tasks(Thread::get_hrtime() / HRTIME_SECOND);
+    Log::periodic_tasks(ink_get_hrtime() / HRTIME_SECOND);
     rprintf(t, "Log::periodoc_tasks() done\n");
   }
 

--- a/proxy/logging/Makefile.am
+++ b/proxy/logging/Makefile.am
@@ -83,9 +83,9 @@ test_LogUtils_SOURCES = \
 	unit-tests/test_LogUtils.cc
 
 test_LogUtils_LDADD = \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.la \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a
+	$(top_builddir)/src/tscpp/util/libtscpputil.la
 
 test_RolledLogDeleter_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -98,9 +98,9 @@ test_RolledLogDeleter_SOURCES = \
 	unit-tests/test_RolledLogDeleter.cc
 
 test_RolledLogDeleter_LDADD = \
+	$(top_builddir)/iocore/eventsystem/libinkevent.a \
 	$(top_builddir)/src/tscore/libtscore.la \
-	$(top_builddir)/src/tscpp/util/libtscpputil.la \
-	$(top_builddir)/iocore/eventsystem/libinkevent.a
+	$(top_builddir)/src/tscpp/util/libtscpputil.la
 
 clang-tidy-local: $(liblogging_a_SOURCES) $(EXTRA_DIST)
 	$(CXX_Clang_Tidy)

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1917,7 +1917,7 @@ TSdrandom()
 ink_hrtime
 TShrtime()
 {
-  return Thread::get_hrtime();
+  return ink_get_hrtime();
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -7245,7 +7245,7 @@ TSVConnFdCreate(int fd)
   vc->action_ = &a;
 
   vc->id          = net_next_connection_number();
-  vc->submit_time = Thread::get_hrtime();
+  vc->submit_time = ink_get_hrtime();
   vc->mutex       = new_ProxyMutex();
   vc->set_is_transparent(false);
   vc->set_context(NET_VCONNECTION_OUT);

--- a/src/traffic_server/InkIOCoreAPI.cc
+++ b/src/traffic_server/InkIOCoreAPI.cc
@@ -427,7 +427,7 @@ TSVIOMutexGet(TSVIO viop)
 ink_hrtime
 INKBasedTimeGet()
 {
-  return Thread::get_hrtime();
+  return ink_get_hrtime();
 }
 
 /* UDP Connection Interface */

--- a/src/tscore/EventNotify.cc
+++ b/src/tscore/EventNotify.cc
@@ -140,7 +140,7 @@ EventNotify::timedwait(int timeout) // milliseconds
 #else
   ink_timestruc abstime;
 
-  abstime = ink_hrtime_to_timespec(ink_get_hrtime_internal() + HRTIME_SECONDS(timeout));
+  abstime = ink_hrtime_to_timespec(ink_get_hrtime() + HRTIME_SECONDS(timeout));
   return ink_cond_timedwait(&m_cond, &m_mutex, &abstime);
 #endif
 }

--- a/tools/jtest/jtest.cc
+++ b/tools/jtest/jtest.cc
@@ -646,7 +646,7 @@ fast(int sock, int speed, int d)
 static ink_hrtime
 elapsed_from_start(int sock)
 {
-  ink_hrtime timenow = ink_get_hrtime_internal();
+  ink_hrtime timenow = ink_get_hrtime();
   return ink_hrtime_diff_msec(timenow, fd[sock].start);
 }
 
@@ -1788,7 +1788,7 @@ poll_loop()
   }
   pollfd pfd[POLL_GROUP_SIZE];
   int ip = 0;
-  now    = ink_get_hrtime_internal();
+  now    = ink_get_hrtime();
   for (int i = 0; i <= last_fd; i++) {
     if (fd[i].fd > 0 && (!fd[i].ready || now >= fd[i].ready)) {
       pfd[ip].fd      = i;
@@ -2409,7 +2409,7 @@ read_response(int sock)
     new_tbytes += err;
     fd[sock].req_pos += err;
     fd[sock].bytes += err;
-    fd[sock].active = ink_get_hrtime_internal();
+    fd[sock].active = ink_get_hrtime();
     int total_read  = fd[sock].req_pos;
     char *p         = fd[sock].req_header;
     char *cl        = nullptr;
@@ -2609,7 +2609,7 @@ read_response(int sock)
     if (fd[sock].length != INT_MAX) {
       fd[sock].length -= err;
     }
-    fd[sock].active = ink_get_hrtime_internal();
+    fd[sock].active = ink_get_hrtime();
     if (verbose) {
       printf("read %d got %d togo %d %d %d\n", sock, err, fd[sock].length, fd[sock].keepalive, fd[sock].drop_after_CL);
     }
@@ -2625,7 +2625,7 @@ Ldone:
   if (!fd[sock].client_abort && !(server_abort_rate > 0) && fd[sock].length && fd[sock].length != INT_MAX) {
     if (verbose || verbose_errors) {
       printf("bad length %d wanted %d after %d ms: '%s'\n", fd[sock].response_length - fd[sock].length, fd[sock].response_length,
-             (int)((ink_get_hrtime_internal() - fd[sock].active) / HRTIME_MSECOND), fd[sock].base_url);
+             (int)((ink_get_hrtime() - fd[sock].active) / HRTIME_MSECOND), fd[sock].base_url);
     }
     return read_response_error(sock);
   }
@@ -2683,7 +2683,7 @@ write_request(int sock)
     new_tbytes += err;
     total_client_request_bytes += err;
     fd[sock].req_pos += err;
-    fd[sock].active = ink_get_hrtime_internal();
+    fd[sock].active = ink_get_hrtime();
 
     if (fd[sock].req_pos >= fd[sock].length) {
       if (verbose) {
@@ -2726,7 +2726,7 @@ write_request(int sock)
     new_tbytes += err;
     total_client_request_bytes += err;
     fd[sock].req_pos += err;
-    fd[sock].active = ink_get_hrtime_internal();
+    fd[sock].active = ink_get_hrtime();
 
     if (fd[sock].req_pos >= fd[sock].post_size) {
       if (verbose) {
@@ -3232,7 +3232,7 @@ void
 interval_report()
 {
   static int here = 0;
-  now             = ink_get_hrtime_internal();
+  now             = ink_get_hrtime();
   if (!(here++ % 20)) {
     printf(" con  new     ops   1B  lat      bytes/per     svrs  new  ops      total   time  err\n");
   }
@@ -3673,7 +3673,7 @@ main(int argc __attribute__((unused)), const char *argv[])
     printf("maximum of %d connections\n", max_fds);
   }
   signal(SIGPIPE, SIG_IGN);
-  start_time = now = ink_get_hrtime_internal();
+  start_time = now = ink_get_hrtime();
 
   urls_mode = n_file_arguments || *urls_file;
   nclients  = client_rate ? 0 : nclients;


### PR DESCRIPTION
* Make sure that the thread local time is updated timely

* Remove dead TSC code from the dark ages

* Adds a new configuration option, and defaults to CLOCK_REALTIME

(cherry picked from commit ba467a8a4887d5b7b41831439542e2c5d508cd58)