### PR TITLE
test_QUICLossDetector.cc: Add back get_hrtime()

### DIFF
--- a/iocore/net/quic/test/test_QUICLossDetector.cc
+++ b/iocore/net/quic/test/test_QUICLossDetector.cc
@@ -86,6 +86,7 @@ TEST_CASE("QUICLossDetector_Loss", "[quic]")
       packet->is_ack_eliciting(),
       true,
       packet->size(),
+      ink_get_hrtime(),
       packet->type(),
       {},
       QUICPacketNumberSpace::HANDSHAKE,


### PR DESCRIPTION
This adds back the get_htrime call to the constructor of QUICSentPacketInfo that was accidentally removed in #10163.