### PR TITLE
Fix editor config for makefiles.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -43,9 +43,10 @@ charset = utf-8
 [*.sh]
 indent_size = 4
 # Makefile's
-[*.am]
+[{*.am,*.mk,Makefile.inc}]
 trim_trailing_whitespace = false
 indent_style = tab
+indent_size = 8
 [*.rst]
 max_line_length = 80
 indent_size = 3


### PR DESCRIPTION
Add Makefile.inc and *.mk patterns to the editor config and ensure that they follow standard Make rules - tabs with width 8.