### PR TITLE
Make OSX and FreeBSD not required temporarily

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -57,8 +57,9 @@ github:
           - Fedora
           - RAT
           - Ubuntu
-          - OSX
-          - FreeBSD
+          # Add these back once connectivity to them is restored.
+          #- OSX
+          #- FreeBSD
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1


### PR DESCRIPTION
We'll make these builds not required for now until connectivity to them is restored.