### PR TITLE
Fix ip_allow optional methods specification

### DIFF
--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -401,9 +401,9 @@ IpAllow::YAMLLoadEntry(const YAML::Node &entry)
   } else {
     return swoc::Errata(ERRATA_ERROR, "{} {} - item ignored, required '{}' key not found.", this, entry.Mark(), YAML_TAG_IP_ADDRS);
   }
-
-  if (node = entry[YAML_TAG_METHODS]; node) {
-    if (auto errata = this->YAMLLoadMethod(node, *record); !errata.is_ok()) {
+  if (auto methodNode = entry[YAML_TAG_METHODS]) {
+    // methods are specified.
+    if (auto errata = this->YAMLLoadMethod(methodNode, *record); !errata.is_ok()) {
       return errata;
     }
   } else {

--- a/proxy/IPAllow.cc
+++ b/proxy/IPAllow.cc
@@ -401,6 +401,7 @@ IpAllow::YAMLLoadEntry(const YAML::Node &entry)
   } else {
     return swoc::Errata(ERRATA_ERROR, "{} {} - item ignored, required '{}' key not found.", this, entry.Mark(), YAML_TAG_IP_ADDRS);
   }
+
   if (auto methodNode = entry[YAML_TAG_METHODS]) {
     // methods are specified.
     if (auto errata = this->YAMLLoadMethod(methodNode, *record); !errata.is_ok()) {

--- a/tests/gold_tests/ip_allow/replays/https_multiple_methods.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_multiple_methods.replay.yaml
@@ -1,0 +1,109 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# The replay file executes various HTTP requests to verify the ip_allow policy
+# applies by default to all methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+
+  # GET
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, 1 ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  # PUSH
+  - client-request:
+      method: "PUSH"
+      version: "1.1"
+      url: /test/ip_allow/test_put
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, push ]
+        - [ X-Request, push ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    # Doesn't matter as the server should not get the request.
+    <<: *standard_response
+
+    # Verify that ATS confirmed that the PUSH was successful, which it does
+    # with a 201 response.
+    proxy-response:
+      status: 201
+
+  # POST
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: "/test/ip_allow/test_post"
+      headers:
+        fields:
+          - [Host, www.tls.com]
+          - [Content-Length, 10]
+          - [uuid, post]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  transactions:
+  # CONNECT
+  - client-request:
+      method: CONNECT
+      version: "1.1"
+      url: www.example.com:80
+      headers:
+        fields:
+          - [uuid, connect]
+          - [Host, www.example.com:80]
+    # This is a CONNECT request so it should not reach the origin server
+    <<: *standard_response
+
+    # ATS returns a 200 responses to client when it establishes a tunnel
+    # between the client and server
+    proxy-response:
+      status: 200


### PR DESCRIPTION
According to doc, the `methods` field is optional so the following should be a valid ip_allow config which allows all HTTP methods:
```yaml
ip_allow:
  - apply: in
    ip_addrs: 0/0
    action: allow
```
However, ATS reports an error when parsing it. 

The root cause is that yaml-cpp returns an invalid node for non-existent keys, which is fine, but it throws an exception when assigning the invalid node to another node. This PR prevents this and adds a test to exercise this case.
