### PR TITLE
Revert "Make OSX and FreeBSD not required temporarily (#10237)"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -57,9 +57,8 @@ github:
           - Fedora
           - RAT
           - Ubuntu
-          # Add these back once connectivity to them is restored.
-          #- OSX
-          #- FreeBSD
+          - OSX
+          - FreeBSD
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1


### PR DESCRIPTION
This reverts commit 28d1d18c5105537567c55ab751d054dda07309c8.

OSX and FreeBSD connectivity is back up, so we should make these required for merging again.