### PR TITLE
Make remap API compatibility checks consistent.

### DIFF
--- a/example/plugins/c-api/remap/remap.cc
+++ b/example/plugins/c-api/remap/remap.cc
@@ -148,8 +148,9 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
                                     static_cast<int>(api_info->size), static_cast<int>(sizeof(TSRemapInterface)));
     }
     if (unlikely(api_info->tsremap_version < TSREMAP_VERSION)) {
-      return store_my_error_message(TS_ERROR, errbuf, errbuf_size, "Incorrect API version %d.%d", (api_info->tsremap_version >> 16),
-                                    (api_info->tsremap_version & 0xffff));
+      return store_my_error_message(TS_ERROR, errbuf, errbuf_size, "Incorrect API version %d.%d",
+                                    static_cast<int>(api_info->tsremap_version >> 16),
+                                    static_cast<int>(api_info->tsremap_version & 0xffff));
     }
 
     if (pthread_mutex_init(&remap_plugin_global_mutex, nullptr) ||

--- a/include/ts/Makefile.am
+++ b/include/ts/Makefile.am
@@ -26,4 +26,5 @@ library_include_HEADERS = \
 	parentselectdefs.h
 
 noinst_HEADERS = \
-	InkAPIPrivateIOCore.h
+	InkAPIPrivateIOCore.h \
+	remap_version.h

--- a/include/ts/remap_version.h
+++ b/include/ts/remap_version.h
@@ -1,0 +1,43 @@
+/** @file
+
+  Remap API version check.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#define CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errlen)                                                                  \
+  do {                                                                                                                           \
+    if (api_info == nullptr) {                                                                                                   \
+      snprintf(errbuf, errlen, "Missing TSRemapInterface argument");                                                             \
+      return TS_ERROR;                                                                                                           \
+    }                                                                                                                            \
+    if (api_info->size < sizeof(TSRemapInterface)) {                                                                             \
+      snprintf(errbuf, errlen, "Incorrect size (%zu) of TSRemapInterface structure, expected %zu",                               \
+               static_cast<size_t>(api_info->size), sizeof(TSRemapInterface));                                                   \
+      return TS_ERROR;                                                                                                           \
+    }                                                                                                                            \
+    if (api_info->tsremap_version < TSREMAP_VERSION) {                                                                           \
+      snprintf(errbuf, errlen, "Incorrect API version %d.%d, expected %d.%d", static_cast<int>(api_info->tsremap_version >> 16), \
+               static_cast<int>(api_info->tsremap_version & 0xffff), static_cast<int>(TSREMAP_VMAJOR),                           \
+               static_cast<int>(TSREMAP_VMINOR));                                                                                \
+      return TS_ERROR;                                                                                                           \
+    }                                                                                                                            \
+  } while (0)

--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -34,6 +34,7 @@
 
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 #include "headers.h"
 #include "rules.h"
 #include "configs.h"
@@ -594,18 +595,7 @@ TSPluginInit(int argc, const char *argv[])
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  TSDebug(PLUGIN_NAME, "background fetch remap init");
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "background fetch remap is successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/cache_promote/cache_promote.cc
+++ b/plugins/cache_promote/cache_promote.cc
@@ -20,6 +20,7 @@
 
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 
 #include "policy_manager.h"
 #include "configs.h"
@@ -115,16 +116,7 @@ cont_handle_policy(TSCont contp, TSEvent event, void *edata)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (api_info->size < sizeof(TSRemapInterface)) {
-    strncpy(errbuf, "[tsremap_init] - Incorrect size of TSRemapInterface structure", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[tsremap_init] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
 
   // Reserve a TXN slot for storing the calculated URL hash key
   if (TS_SUCCESS != TSUserArgIndexReserve(TS_USER_ARGS_TXN, PLUGIN_NAME, "cache_promote URL hash key", &TXN_ARG_IDX)) {

--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -28,6 +28,7 @@
 
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 
 #include <cinttypes>
 #include <cstdio>
@@ -629,17 +630,7 @@ transaction_handler(TSCont contp, TSEvent event, void *edata)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   DEBUG_LOG("cache_range_requests remap is successfully initialized.");
   return TS_SUCCESS;
 }

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -37,6 +37,7 @@
 #include "misc.h"
 #include "configuration.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 
 using namespace std;
 using namespace Gzip;
@@ -1048,17 +1049,7 @@ TSPluginInit(int argc, const char *argv[])
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   info("The compress plugin is successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/experimental/cache_fill/cache_fill.cc
+++ b/plugins/experimental/cache_fill/cache_fill.cc
@@ -37,6 +37,7 @@
 
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 #include "background_fetch.h"
 
 static const char *
@@ -135,18 +136,7 @@ cont_handle_cache(TSCont contp, TSEvent event, void *edata)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  TSDebug(PLUGIN_NAME, "cache fill remap init");
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "cache fill remap is successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/experimental/fq_pacing/fq_pacing.cc
+++ b/plugins/experimental/fq_pacing/fq_pacing.cc
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <ts/ts.h>
 #include <ts/remap.h>
+#include <ts/remap_version.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 
@@ -97,21 +98,7 @@ TSPluginInit(int argc, const char *argv[])
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[fq_pacing] - Invalid TSRemapInterface argument", (size_t)(errbuf_size - 1));
-    return TS_ERROR;
-  }
-
-  if (api_info->size < sizeof(TSRemapInterface)) {
-    strncpy(errbuf, "[TSRemapInit] - Incorrect size of TSRemapInterface structure", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size - 1, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
 
   if (!fq_is_default_qdisc()) {
     snprintf(errbuf, errbuf_size - 1, "[TSRemapInit] - fq qdisc is not active");

--- a/plugins/experimental/geoip_acl/geoip_acl.cc
+++ b/plugins/experimental/geoip_acl/geoip_acl.cc
@@ -22,6 +22,7 @@
 //
 #include <ts/ts.h>
 #include <ts/remap.h>
+#include <ts/remap_version.h>
 #include <cstdio>
 #include <cstring>
 
@@ -34,17 +35,7 @@
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (api_info->size < sizeof(TSRemapInterface)) {
-    strncpy(errbuf, "[tsremap_init] - Incorrect size of TSRemapInterface structure", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[tsremap_init] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   if (Acl::init()) {
     TSDebug(PLUGIN_NAME, "remap plugin is successfully initialized");
     return TS_SUCCESS; /* success */

--- a/plugins/experimental/maxmind_acl/maxmind_acl.cc
+++ b/plugins/experimental/maxmind_acl/maxmind_acl.cc
@@ -17,6 +17,7 @@
 */
 
 #include "mmdb.h"
+#include "ts/remap_version.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Initialize the plugin as a remap plugin.
@@ -24,17 +25,7 @@
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (api_info->size < sizeof(TSRemapInterface)) {
-    strncpy(errbuf, "[tsremap_init] - Incorrect size of TSRemapInterface structure", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[tsremap_init] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "remap plugin is successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/experimental/money_trace/money_trace.cc
+++ b/plugins/experimental/money_trace/money_trace.cc
@@ -20,6 +20,7 @@
 #include "tscpp/util/ts_bw_format.h"
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 
 #include <getopt.h>
 #include <string_view>
@@ -544,17 +545,7 @@ global_request_header_hook(TSCont const contp, TSEvent const event, void *const 
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   LOG_DEBUG("money_trace remap is successfully initialized.");
 
   return TS_SUCCESS;

--- a/plugins/experimental/parent_select/parent_select.cc
+++ b/plugins/experimental/parent_select/parent_select.cc
@@ -34,6 +34,7 @@
 #include "ts/ts.h"
 #include "ts/remap.h"
 #include "ts/parentselectdefs.h"
+#include "ts/remap_version.h"
 
 #include "consistenthash_config.h"
 #include "strategy.h"
@@ -233,21 +234,7 @@ handle_hook(TSCont contp, TSEvent event, void *edata)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  TSDebug(PLUGIN_NAME, "TSRemapInit calling");
-
-  // TODO add ATS API Version check here, to bail if ATS doesn't support the version necessary for strategy plugins
-
-  if (!api_info) {
-    strncpy(errbuf, "[tsstrategy_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSStrategyInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "Remap successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -21,6 +21,7 @@
 
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 #include "tscore/ink_config.h"
 #include "txn_limiter.h"
 #include "utilities.h"
@@ -92,17 +93,7 @@ TSPluginInit(int argc, const char *argv[])
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size - 1, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "plugin is successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/experimental/uri_signing/uri_signing.cc
+++ b/plugins/experimental/uri_signing/uri_signing.cc
@@ -23,6 +23,7 @@
 #include "timing.h"
 
 #include <ts/remap.h>
+#include <ts/remap_version.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,18 +36,7 @@
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", (size_t)(errbuf_size - 1));
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
-  TSDebug(PLUGIN_NAME, "plugin is successfully initialized");
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   return TS_SUCCESS;
 }
 

--- a/plugins/experimental/url_sig/url_sig.cc
+++ b/plugins/experimental/url_sig/url_sig.cc
@@ -49,6 +49,7 @@
 
 #include <ts/ts.h>
 #include <ts/remap.h>
+#include <ts/remap_version.h>
 
 static const char PLUGIN_NAME[] = "url_sig";
 
@@ -88,17 +89,7 @@ free_cfg(struct config *cfg)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    snprintf(errbuf, errbuf_size, "[tsremap_init] - Invalid TSRemapInterface argument");
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "plugin is successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -24,6 +24,7 @@
 
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 
 #include "parser.h"
 #include "ruleset.h"
@@ -386,22 +387,7 @@ TSPluginInit(int argc, const char *argv[])
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[TSRemapInit] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->size < sizeof(TSRemapInterface)) {
-    strncpy(errbuf, "[TSRemapInit] - Incorrect size of TSRemapInterface structure", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "Remap plugin is successfully initialized");
 
   return TS_SUCCESS;

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -22,6 +22,7 @@
 */
 #include "ts/ts.h"
 #include "ts/remap.h"
+#include "ts/remap_version.h"
 
 #include <sys/types.h>
 #include <cstdio>
@@ -644,17 +645,7 @@ struct RemapInstance {
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "Plugin is successfully initialized");
   return TS_SUCCESS;
 }

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -46,6 +46,7 @@
 
 #include <ts/ts.h>
 #include <ts/remap.h>
+#include <ts/remap_version.h>
 #include <tscpp/util/TsSharedMutex.h>
 #include "tscore/ink_config.h"
 #include "swoc/TextView.h"
@@ -1093,17 +1094,7 @@ config_reloader(TSCont cont, TSEvent event, void *edata)
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[tsremap_init] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
-
+  CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   TSDebug(PLUGIN_NAME, "plugin is successfully initialized");
   return TS_SUCCESS;
 }

--- a/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
@@ -260,13 +260,9 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
   TSDbg(dbg_ctl, "TSRemapInit()");
 
-  TSReleaseAssert(api_info && errbuf && errbuf_size);
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    std::snprintf(errbuf, errbuf_size, "Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-                  (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
+  TSReleaseAssert(api_info != nullptr);
+  TSReleaseAssert(api_info->size == sizeof(TSRemapInterface));
+  TSReleaseAssert(api_info->tsremap_version == TSREMAP_VERSION);
 
   const char *fileSpec = std::getenv("OUTPUT_FILE");
 

--- a/tests/tools/plugins/user_args.cc
+++ b/tests/tools/plugins/user_args.cc
@@ -130,21 +130,9 @@ TSPluginInit(int argc, const char *argv[])
 TSReturnCode
 TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
-  if (!api_info) {
-    strncpy(errbuf, "[TSRemapInit] - Invalid TSRemapInterface argument", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->size < sizeof(TSRemapInterface)) {
-    strncpy(errbuf, "[TSRemapInit] - Incorrect size of TSRemapInterface structure", errbuf_size - 1);
-    return TS_ERROR;
-  }
-
-  if (api_info->tsremap_version < TSREMAP_VERSION) {
-    snprintf(errbuf, errbuf_size, "[TSRemapInit] - Incorrect API version %ld.%ld", api_info->tsremap_version >> 16,
-             (api_info->tsremap_version & 0xffff));
-    return TS_ERROR;
-  }
+  TSReleaseAssert(api_info != nullptr);
+  TSReleaseAssert(api_info->size == sizeof(TSRemapInterface));
+  TSReleaseAssert(api_info->tsremap_version == TSREMAP_VERSION);
 
   return TS_SUCCESS;
 }


### PR DESCRIPTION
Use an internal macro to make all the remap API compatibility checks consistent. For test plugins, where there's no risk of incompatibility, just assert that the API is compatible.

This fixes #10222.