### PR TITLE
Python 3.12: add h2 dependencies to autest Pipfile

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -29,7 +29,11 @@ pyflakes = "*"
 autest = "==1.10.4"
 
 traffic-replay = "*" # this should install TRLib, MicroServer, MicroDNS, Traffic-Replay
+
 h2 = "*"
+hyperframe = "*"
+hpack = "*"
+
 dnslib = "*"
 # These are likely to be available via yum/dnf or apt-get
 requests = "*"


### PR DESCRIPTION
When testing with Python 3.12, the autests that used the h2 package failed because the Pipenv didn't pull in the hyperframe and hpack dependencies. This explicitly pulls those dependencies in via the autest Pipfile.