### PR TITLE
Python 3.12: Make autest regex strings raw strings

### DIFF
--- a/tests/gold_tests/headers/general-connection-failure-502.test.py
+++ b/tests/gold_tests/headers/general-connection-failure-502.test.py
@@ -42,6 +42,6 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 # Do not start the origin server: We wish to simulate connection refused while hopefully no one else uses this port.
 tr.Processes.Default.Command = \
     (f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} www.connectfail502.test-get.txt | "
-     "sed -e '/^Date: /d' -e '/^Server: ATS\//d'")
+     r"sed -e '/^Date: /d' -e '/^Server: ATS\//d'")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = 'general-connection-failure-502.gold'

--- a/tests/gold_tests/tls/tls_hooks_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_client_verify.test.py
@@ -105,10 +105,10 @@ tr3.Processes.Default.ReturnCode = 35
 tr3.Processes.Default.Streams.all = Testers.ContainsExpression("error", "Curl attempt should have failed")
 
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Client verify callback 0 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")
+    r"Client verify callback 0 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Client verify callback 1 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")
+    r"Client verify callback 1 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Client verify callback 0 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")
+    r"Client verify callback 0 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Client verify callback 1 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")
+    r"Client verify callback 1 [\da-fx]+? - event is good error HS", "verify callback happens 2 times")

--- a/tests/gold_tests/tls/tls_hooks_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_verify.test.py
@@ -102,15 +102,15 @@ ts.Disk.diags_log.Content += Testers.ContainsExpression(
 ts.Disk.diags_log.Content += Testers.ExcludesExpression("SNI=foo.com", "foo.com should not fail in any way")
 
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Server verify callback 0 [\da-fx]+? - event is good SNI=foo.com good HS", "verify callback happens 2 times")
+    r"Server verify callback 0 [\da-fx]+? - event is good SNI=foo.com good HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Server verify callback 1 [\da-fx]+? - event is good SNI=foo.com good HS", "verify callback happens 2 times")
+    r"Server verify callback 1 [\da-fx]+? - event is good SNI=foo.com good HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Server verify callback 0 [\da-fx]+? - event is good SNI=random.com error HS", "verify callback happens 2 times")
+    r"Server verify callback 0 [\da-fx]+? - event is good SNI=random.com error HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Server verify callback 1 [\da-fx]+? - event is good SNI=random.com error HS", "verify callback happens 2 times")
+    r"Server verify callback 1 [\da-fx]+? - event is good SNI=random.com error HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Server verify callback 0 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
+    r"Server verify callback 0 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Server verify callback 1 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
+    r"Server verify callback 1 [\da-fx]+? - event is good SNI=bar.com error HS", "verify callback happens 2 times")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression("Server verify callback SNI APIs match=true", "verify SNI names match")

--- a/tests/gold_tests/tls/tls_verify.test.py
+++ b/tests/gold_tests/tls/tls_verify.test.py
@@ -154,4 +154,4 @@ tr5.StillRunningAfter = ts
 # Over riding the built in ERROR check since we expect tr3 to fail
 ts.Disk.diags_log.Content = Testers.ExcludesExpression("verification failed", "Make sure the signatures didn't fail")
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    "WARNING: SNI \(bad_bar.com\) not in certificate", "Make sure bad_bar name checked failed.")
+    r"WARNING: SNI \(bad_bar.com\) not in certificate", "Make sure bad_bar name checked failed.")

--- a/tests/gold_tests/tls/tls_verify2.test.py
+++ b/tests/gold_tests/tls/tls_verify2.test.py
@@ -153,13 +153,13 @@ tr6.StillRunningAfter = ts
 
 # No name checking for the sig-only permissive override for bad_bar
 ts.Disk.diags_log.Content += Testers.ExcludesExpression(
-    "WARNING: SNI \(bad_bar.com\) not in certificate", "bad_bar name checked should be skipped.")
+    r"WARNING: SNI \(bad_bar.com\) not in certificate", "bad_bar name checked should be skipped.")
 ts.Disk.diags_log.Content = Testers.ExcludesExpression(
-    "WARNING: SNI \(foo.com\) not in certificate", "foo name checked should be skipped.")
+    r"WARNING: SNI \(foo.com\) not in certificate", "foo name checked should be skipped.")
 # No checking for the self-signed on random.com.  No messages
 ts.Disk.diags_log.Content += Testers.ExcludesExpression(
-    "WARNING: Core server certificate verification failed for \(random.com\)", "signature check for random.com should be skipped")
+    r"WARNING: Core server certificate verification failed for \(random.com\)", "signature check for random.com should be skipped")
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    "WARNING: Core server certificate verification failed for \(random2.com\)", "signature check for random.com should fail'")
+    r"WARNING: Core server certificate verification failed for \(random2.com\)", "signature check for random.com should fail'")
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    "WARNING: SNI \(bad_foo.com\) not in certificate", "bad_foo name checked should be checked.")
+    r"WARNING: SNI \(bad_foo.com\) not in certificate", "bad_foo name checked should be checked.")

--- a/tests/gold_tests/tls/tls_verify3.test.py
+++ b/tests/gold_tests/tls/tls_verify3.test.py
@@ -144,7 +144,7 @@ tr3.StillRunningAfter = ts
 
 # Over riding the built in ERROR check since we expect tr3 to fail
 ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "WARNING: SNI \(bob.bar.com\) not in certificate", "Make sure bob.bar name checked failed.")
+    r"WARNING: SNI \(bob.bar.com\) not in certificate", "Make sure bob.bar name checked failed.")
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
     r"WARNING: Core server certificate verification failed for \(my.foo.com\). Action=Continue",
     "Make sure default permissive action takes")

--- a/tests/gold_tests/tls/tls_verify4.test.py
+++ b/tests/gold_tests/tls/tls_verify4.test.py
@@ -185,6 +185,6 @@ tragain.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not
 
 # No name checking for the sig-only permissive override for bad_bar
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    "Core server certificate verification failed for \(random3.com\). Action=Continue", "Permissive can connect")
+    r"Core server certificate verification failed for \(random3.com\). Action=Continue", "Permissive can connect")
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    "Core server certificate verification failed for \(random2.com\). Action=Terminate", "Enforced cannot connect")
+    r"Core server certificate verification failed for \(random2.com\). Action=Terminate", "Enforced cannot connect")

--- a/tests/gold_tests/tls/tls_verify_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_base.test.py
@@ -129,6 +129,6 @@ tr3.StillRunningAfter = ts
 
 # Over riding the built in ERROR check since we expect tr3 to fail
 ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "WARNING: SNI \(bad_bar.com\) not in certificate. Action=Terminate", "Make sure bad_bar name checked failed.")
+    r"WARNING: SNI \(bad_bar.com\) not in certificate. Action=Terminate", "Make sure bad_bar name checked failed.")
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    "WARNING: SNI \(random.com\) not in certificate. Action=Continue ", "Permissive failure for random")
+    r"WARNING: SNI \(random.com\) not in certificate. Action=Continue ", "Permissive failure for random")

--- a/tests/gold_tests/tls/tls_verify_not_pristine.test.py
+++ b/tests/gold_tests/tls/tls_verify_not_pristine.test.py
@@ -98,5 +98,5 @@ tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Con
 
 # Over riding the built in ERROR check since we expect tr3 to fail
 ts.Disk.diags_log.Content = Testers.ExcludesExpression("verification failed", "Make sure the signatures didn't fail")
-ts.Disk.diags_log.Content += Testers.ContainsExpression("WARNING: SNI \(bar.com\) not in certificate",
+ts.Disk.diags_log.Content += Testers.ContainsExpression(r"WARNING: SNI \(bar.com\) not in certificate",
                                                         "Make sure bad_bar name checked failed.")

--- a/tests/gold_tests/tls/tls_verify_override.test.py
+++ b/tests/gold_tests/tls/tls_verify_override.test.py
@@ -268,4 +268,4 @@ ts.Disk.diags_log.Content += Testers.ContainsExpression(
     "Failure on missing name for bar.com")
 # See if the explicitly set default sni_policy of remap works.
 ts.Disk.diags_log.Content += Testers.ExcludesExpression(
-    "WARNING: SNI \(foo.com\) not in certificate. Action=Continue", "Warning on missing name for foo.com")
+    r"WARNING: SNI \(foo.com\) not in certificate. Action=Continue", "Warning on missing name for foo.com")

--- a/tests/gold_tests/tls/tls_verify_override_sni.test.py
+++ b/tests/gold_tests/tls/tls_verify_override_sni.test.py
@@ -145,6 +145,6 @@ tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Con
 
 # Over riding the built in ERROR check since we expect some cases to fail
 ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "WARNING: SNI \(bar.com\) not in certificate. Action=Continue server=bar.com", "Warning for mismatch name not enforcing")
+    r"WARNING: SNI \(bar.com\) not in certificate. Action=Continue server=bar.com", "Warning for mismatch name not enforcing")
 ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    " WARNING: SNI \(bar.com\) not in certificate. Action=Terminate server=bar.com", "Warning for enforcing mismatch")
+    r" WARNING: SNI \(bar.com\) not in certificate. Action=Terminate server=bar.com", "Warning for enforcing mismatch")

--- a/tests/gold_tests/tls_hooks/tls_hooks16.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks16.test.py
@@ -66,7 +66,7 @@ ts.Disk.traffic_out.Content = "gold/ts-client-hello-1.gold"
 
 snistring = "Client Hello callback 0"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -66,7 +66,7 @@ ts.Disk.traffic_out.Content = "gold/ts-client-hello-delayed-1.gold"
 
 snistring = "Client Hello callback 0"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "Client Hello message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -67,9 +67,9 @@ ts.Disk.traffic_out.Content = "gold/ts-client-hello-2.gold"
 certstring0 = "Client Hello callback 0"
 certstring1 = "Client Hello callback 1"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks2.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks2.test.py
@@ -62,7 +62,7 @@ ts.Disk.traffic_out.Content = "gold/ts-sni-1.gold"
 
 snistring = "SNI callback 0"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks3.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks3.test.py
@@ -62,7 +62,7 @@ ts.Disk.traffic_out.Content = "gold/ts-cert-1.gold"
 
 certstring = "Cert callback 0"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring), "Cert message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring), "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks4.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks4.test.py
@@ -63,11 +63,11 @@ snistring = "SNI callback 0"
 preacceptstring = "Pre accept callback 0"
 certstring = "Cert callback 0"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
 # the preaccept may get triggered twice because the test framework creates a TCP connection before handing off to traffic_server
-ts.Disk.traffic_out.Content += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(
     preacceptstring), "Pre accept message appears only once or twice", reflags=re.S | re.M)
-ts.Disk.traffic_out.Content += Testers.ContainsExpression("\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring),
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring),
                                                           "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks7.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks7.test.py
@@ -63,9 +63,9 @@ ts.Disk.traffic_out.Content = "gold/ts-sni-2.gold"
 snistring0 = "SNI callback 0"
 snistring1 = "SNI callback 1"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring0), "SNI message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring0), "SNI message appears only once", reflags=re.S | re.M)
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring1), "SNI message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring1), "SNI message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks8.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks8.test.py
@@ -63,9 +63,9 @@ ts.Disk.traffic_out.Content = "gold/ts-cert-2.gold"
 certstring0 = "Cert callback 0"
 certstring1 = "Cert callback 1"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring1), "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks9.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks9.test.py
@@ -62,6 +62,6 @@ ts.Disk.traffic_out.Content = "gold/ts-cert-im-1.gold"
 
 certstring0 = "Cert callback 0"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring0), "Cert message appears only once", reflags=re.S | re.M)
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15


### PR DESCRIPTION
Python 3.12 makes the use of unexpected escape sequences a SyntaxError. This is simply avoided by making these regexes, which are intentional and passed down to other modules or shell commands, raw character sequences so that Python doesn't incorrectly try to interpret them.