### PR TITLE
Add version range up to CMake 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 #######################
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20..3.27)
 project(ats VERSION 10.0.0)
 
 set(TS_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
Specifying a version range ensures that our build is compatible with NEW policies in future CMake versions, and therefore won't unexpectedly break when we increase our mininum version. It is fine to use a CMake version newer than the upper end of our version range, but we should keep the range updated as newer versions become available. We should use a latest CMake on at least one CI run.