### PR TITLE
Add stek_share plugin to CMake build

### DIFF
--- a/plugins/experimental/stek_share/CMakeLists.txt
+++ b/plugins/experimental/stek_share/CMakeLists.txt
@@ -15,28 +15,18 @@
 #
 #######################
 
-add_subdirectory(access_control)
-add_subdirectory(cache_fill)
-add_subdirectory(cert_reporting_tool)
-add_subdirectory(cookie_remap)
-add_subdirectory(custom_redirect)
-add_subdirectory(fq_pacing)
-add_subdirectory(geoip_acl)
-add_subdirectory(header_freq)
-add_subdirectory(hook-trace)
-add_subdirectory(http_stats)
-add_subdirectory(icap)
-add_subdirectory(inliner)
-add_subdirectory(maxmind_acl)
-add_subdirectory(memcache)
-add_subdirectory(memory_profile)
-add_subdirectory(money_trace)
-add_subdirectory(mp4)
-add_subdirectory(rate_limit)
-add_subdirectory(redo_cache_lookup)
-add_subdirectory(slice)
-add_subdirectory(stek_share)
-add_subdirectory(stream_editor)
-add_subdirectory(system_stats)
-add_subdirectory(tls_bridge)
-add_subdirectory(url_sig)
+find_package(NuRaft REQUIRED)
+
+add_atsplugin(stek_share
+  common.cc
+  log_store.cc
+  stek_share.cc
+  stek_utils.cc
+)
+
+target_link_libraries(stek_share
+  PRIVATE
+    NuRaft::static_lib
+    OpenSSL::SSL
+    yaml-cpp::yaml-cpp
+)

--- a/plugins/experimental/stek_share/CMakeLists.txt
+++ b/plugins/experimental/stek_share/CMakeLists.txt
@@ -15,18 +15,22 @@
 #
 #######################
 
-find_package(NuRaft REQUIRED)
+find_package(NuRaft QUIET)
 
-add_atsplugin(stek_share
-  common.cc
-  log_store.cc
-  stek_share.cc
-  stek_utils.cc
-)
+if(NuRaft_FOUND)
+  add_atsplugin(stek_share
+    common.cc
+    log_store.cc
+    stek_share.cc
+    stek_utils.cc
+  )
 
-target_link_libraries(stek_share
-  PRIVATE
-    NuRaft::static_lib
-    OpenSSL::SSL
-    yaml-cpp::yaml-cpp
-)
+  target_link_libraries(stek_share
+    PRIVATE
+      NuRaft::static_lib
+      OpenSSL::SSL
+      yaml-cpp::yaml-cpp
+  )
+else()
+  message(STATUS "skipping stek_share plugin (missing NuRaft)")
+endif()


### PR DESCRIPTION
This adds the experimental stek_share plugin. The stek_share plugin will only build if CMake finds NuRaft. This will only work after eBay/NuRaft#462.