### PR TITLE
CID 1518143: String not null terminated money_trace plugin

### DIFF
--- a/plugins/experimental/money_trace/money_trace.cc
+++ b/plugins/experimental/money_trace/money_trace.cc
@@ -236,7 +236,7 @@ create_trace(TSHttpTxn const txnp)
         bwriter.write(spanid);
         bwriter.print("{}", TSHttpTxnIdGet(txnp));
 
-        header.assign(bwriter.view());
+        header = std::string{bwriter.view()};
       } else {
         LOG_ERROR("Error getting uuid string");
       }


### PR DESCRIPTION
Fix: #10193

bufferwriter.view() assign to std::string.