### PR TITLE
Python 3.12: add charset-nomalizer to tests/Pipfile

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -36,6 +36,8 @@ requests = "*"
 gunicorn = "*"
 psutil = "*"
 
+charset-normalizer = "*"
+
 # Keep init.cli.ext updated with this required microserver version.
 microserver = ">=1.0.6"
 


### PR DESCRIPTION
The slow_post.test.py autest has a Python test client that has a dependency upon charset-nomalizer that needs to be explicitly added in Python 3.12. This adds that dependency to the tests/Pipfile.