### PR TITLE
Abort a read when the disk is known to be bad

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2179,12 +2179,12 @@ CacheVC::handleReadDone(int event, Event *e)
   } else if (is_io_in_progress()) {
     return EVENT_CONT;
   }
+  if (DISK_BAD(vol->disk)) {
+    io.aio_result = -1;
+    Warning("Canceling cache read: disk %s is bad.", vol->hash_text.get());
+    goto Ldone;
+  }
   {
-    if (DISK_BAD(vol->disk)) {
-      io.aio_result = -1;
-      Warning("Canceling cache read: disk %s is bad.", vol->hash_text.get());
-      goto Ldone;
-    }
     MUTEX_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2195,7 +2195,7 @@ CacheVC::handleReadDone(int event, Event *e)
     }
     if (DISK_BAD(vol->disk)) {
       io.aio_result = -1;
-      Warning("Canceling cache read: disk is bad.");
+      Warning("Canceling cache read: disk %s is bad.", vol->hash_text.get());
       goto Ldone;
     }
 

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2180,6 +2180,11 @@ CacheVC::handleReadDone(int event, Event *e)
     return EVENT_CONT;
   }
   {
+    if (DISK_BAD(vol->disk)) {
+      io.aio_result = -1;
+      Warning("Canceling cache read: disk %s is bad.", vol->hash_text.get());
+      goto Ldone;
+    }
     MUTEX_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
@@ -2191,11 +2196,6 @@ CacheVC::handleReadDone(int event, Event *e)
             vol->hash_text.get(), (uint64_t)io.aiocb.aio_offset, (uint64_t)io.aiocb.aio_offset + io.aiocb.aio_nbytes,
             (uint64_t)io.aiocb.aio_offset / 512, (uint64_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) / 512);
       }
-      goto Ldone;
-    }
-    if (DISK_BAD(vol->disk)) {
-      io.aio_result = -1;
-      Warning("Canceling cache read: disk %s is bad.", vol->hash_text.get());
       goto Ldone;
     }
 

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -2193,6 +2193,11 @@ CacheVC::handleReadDone(int event, Event *e)
       }
       goto Ldone;
     }
+    if (DISK_BAD(vol->disk)) {
+      io.aio_result = -1;
+      Warning("Canceling cache read: disk is bad.");
+      goto Ldone;
+    }
 
     doc = reinterpret_cast<Doc *>(buf->data());
     ink_assert(vol->mutex->nthread_holding < 1000);


### PR DESCRIPTION
Reads on a known bad disk can read corrupt cache metadata, which causes a crash.  Abort reads early on a bad disk so that ATS is less likely to crash after a disk is marked bad.