### PR TITLE
Fix a crash due to bad disks

### DIFF
--- a/iocore/cache/CacheRead.cc
+++ b/iocore/cache/CacheRead.cc
@@ -630,19 +630,20 @@ CacheVC::openReadReadDone(int event, Event *e)
       }
     }
     // fall through for truncated documents
+  Lerror : {
+    // Keep the lock on vol->mutex, for dir_delete.
+    char tmpstring[CRYPTO_HEX_SIZE];
+    if (request.valid()) {
+      int url_length;
+      const char *url_text = request.url_get()->string_get_ref(&url_length);
+      Warning("Document %s truncated, url[%.*s] .. clearing", earliest_key.toHexStr(tmpstring), url_length, url_text);
+    } else {
+      Warning("Document %s truncated .. clearing", earliest_key.toHexStr(tmpstring));
+    }
+    dir_delete(&earliest_key, vol, &earliest_dir);
   }
-Lerror : {
-  char tmpstring[CRYPTO_HEX_SIZE];
-  if (request.valid()) {
-    int url_length;
-    const char *url_text = request.url_get()->string_get_ref(&url_length);
-    Warning("Document %s truncated, url[%.*s] .. clearing", earliest_key.toHexStr(tmpstring), url_length, url_text);
-  } else {
-    Warning("Document %s truncated .. clearing", earliest_key.toHexStr(tmpstring));
   }
-  dir_delete(&earliest_key, vol, &earliest_dir);
   return calluser(VC_EVENT_ERROR);
-}
 Ldone:
   return calluser(VC_EVENT_EOS);
 Lcallreturn:


### PR DESCRIPTION
Hold the volume lock when handling a bad io result so that dir_delete doesn't crash.