### PR TITLE
untangle fds_limit global

### DIFF
--- a/include/tscore/ink_sys_control.h
+++ b/include/tscore/ink_sys_control.h
@@ -25,5 +25,7 @@
 
 #include <sys/resource.h>
 
+rlim_t ink_get_fds_limit();
+void ink_set_fds_limit(rlim_t);
 rlim_t ink_max_out_rlimit(int which);
 rlim_t ink_get_max_files();

--- a/iocore/net/P_UnixNet.h
+++ b/iocore/net/P_UnixNet.h
@@ -43,6 +43,7 @@
 #include "P_UnixNetVConnection.h"
 #include "P_UnixPollDescriptor.h"
 #include <limits>
+#include "tscore/ink_sys_control.h"
 
 NetHandler *get_NetHandler(EThread *t);
 PollCont *get_PollCont(EThread *t);
@@ -57,7 +58,6 @@ extern ink_hrtime emergency_throttle_time;
 extern int net_connections_throttle;
 extern bool net_memory_throttle;
 extern int fds_throttle;
-extern int fds_limit;
 extern ink_hrtime last_transient_accept_error;
 
 //
@@ -145,7 +145,7 @@ change_net_connections_throttle(const char *token, RecDataT data_type, RecData v
   (void)data_type;
   (void)value;
   (void)data;
-  int throttle = fds_limit - THROTTLE_FD_HEADROOM;
+  int throttle = ink_get_fds_limit() - THROTTLE_FD_HEADROOM;
   if (fds_throttle == 0) {
     net_connections_throttle = fds_throttle;
   } else if (fds_throttle < 0) {

--- a/iocore/net/UnixNet.cc
+++ b/iocore/net/UnixNet.cc
@@ -35,7 +35,6 @@ ink_hrtime last_shedding_warning;
 int net_connections_throttle;
 bool net_memory_throttle = false;
 int fds_throttle;
-int fds_limit = 8000;
 ink_hrtime last_transient_accept_error;
 
 NetHandler::Config NetHandler::global_config;

--- a/proxy/logging/LogStandalone.cc
+++ b/proxy/logging/LogStandalone.cc
@@ -43,9 +43,6 @@
 
 #define LOG_FILENAME_SIZE 255
 
-// Globals the rest of the system depends on.
-int fds_limit;
-
 static char error_tags[1024]  = "";
 static char action_tags[1024] = "";
 
@@ -67,7 +64,7 @@ logging_crash_handler(int signo, siginfo_t *info, void *ptr)
 static void
 init_system(bool notify_syslog)
 {
-  fds_limit = ink_max_out_rlimit(RLIMIT_NOFILE);
+  ink_set_fds_limit(ink_max_out_rlimit(RLIMIT_NOFILE));
 
   signal_register_crash_handler(logging_crash_handler);
   if (notify_syslog) {

--- a/src/records/CMakeLists.txt
+++ b/src/records/CMakeLists.txt
@@ -45,4 +45,6 @@ target_link_libraries(records
         ts::inkevent
         ts::tscore
         yaml-cpp::yaml-cpp
+    PRIVATE
+        ts::tsapi
 )

--- a/src/tscore/ink_sys_control.cc
+++ b/src/tscore/ink_sys_control.cc
@@ -28,6 +28,23 @@
 #include "tscore/ink_sys_control.h"
 #include "tscore/Diags.h"
 
+namespace
+{
+rlim_t global_fds_limit = 8000;
+}
+
+rlim_t
+ink_get_fds_limit()
+{
+  return global_fds_limit;
+}
+
+void
+ink_set_fds_limit(rlim_t limit)
+{
+  global_fds_limit = limit;
+}
+
 rlim_t
 ink_max_out_rlimit(int which)
 {


### PR DESCRIPTION
The `fds_limit` extern is causing the issues that global variables typically do.  This PR cleans that up by using a function to access the value in a much more reasonable place in the dependency chain.