### PR TITLE
replace net_config_poll_timeout with EThread::default_wait_interval_ms

### DIFF
--- a/iocore/aio/AIO.cc
+++ b/iocore/aio/AIO.cc
@@ -541,7 +541,7 @@ AIOThreadInfo::aio_thread_main(AIOThreadInfo *thr_info)
       }
       ink_mutex_acquire(&my_aio_req->aio_mutex);
     } while (true);
-    timespec timedwait_msec = ink_hrtime_to_timespec(ink_get_hrtime() + HRTIME_MSECONDS(net_config_poll_timeout));
+    timespec timedwait_msec = ink_hrtime_to_timespec(ink_get_hrtime() + HRTIME_MSECONDS(EThread::default_wait_interval_ms));
     ink_cond_timedwait(&my_aio_req->aio_cond, &my_aio_req->aio_mutex, &timedwait_msec);
   }
   return nullptr;

--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -33,9 +33,6 @@
 using std::cout;
 using std::endl;
 
-// Necessary for AIO
-int net_config_poll_timeout = 10;
-
 #include "diags.i"
 
 #define MAX_DISK_THREADS 200

--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -87,6 +87,16 @@ class EThread : public Thread
 {
 public:
   static thread_local EThread *this_ethread_ptr;
+
+  /** Default wait interval for polling or delaying
+
+      This used to be known as net_config_poll_timeout, but was being used
+      (and externed) through the codebase so was causing problems with linking.
+
+      It is still configured as "proxy.config.net.poll_timeout" for now
+   */
+  static int default_wait_interval_ms;
+
   /** Handler for tail of event loop.
 
       The event loop should not spin. To avoid that a tail handler is called to block for a limited time.

--- a/iocore/eventsystem/I_SocketManager.h
+++ b/iocore/eventsystem/I_SocketManager.h
@@ -50,8 +50,6 @@
 #endif
 #endif
 
-extern int net_config_poll_timeout;
-
 #define SOCKET int
 
 /** Utility namespace for socket operations.

--- a/iocore/eventsystem/UnixEThread.cc
+++ b/iocore/eventsystem/UnixEThread.cc
@@ -62,6 +62,7 @@ int thread_max_heartbeat_mseconds = THREAD_MAX_HEARTBEAT_MSECONDS;
 // own independent data. All (and only) the threads created in the Event
 // Subsystem have this data.
 thread_local EThread *EThread::this_ethread_ptr;
+int EThread::default_wait_interval_ms = 10;
 
 void
 EThread::set_specific()

--- a/iocore/net/I_Net.h
+++ b/iocore/net/I_Net.h
@@ -55,7 +55,6 @@ static constexpr ts::ModuleVersion NET_SYSTEM_MODULE_PUBLIC_VERSION(1, 0, ts::Mo
 static constexpr int NO_FD = -1;
 
 // All in milli-seconds
-extern int net_config_poll_timeout;
 extern int net_event_period;
 extern int net_accept_period;
 extern int net_retry_delay;

--- a/iocore/net/Net.cc
+++ b/iocore/net/Net.cc
@@ -34,11 +34,10 @@
 RecRawStatBlock *net_rsb = nullptr;
 
 // All in milli-seconds
-int net_config_poll_timeout = -1; // This will get set via either command line or records.yaml.
-int net_event_period        = 10;
-int net_accept_period       = 10;
-int net_retry_delay         = 10;
-int net_throttle_delay      = 50; /* milliseconds */
+int net_event_period   = 10;
+int net_accept_period  = 10;
+int net_retry_delay    = 10;
+int net_throttle_delay = 50; /* milliseconds */
 
 // For the in/out congestion control: ToDo: this probably would be better as ports: specifications
 std::string_view net_ccp_in;

--- a/iocore/net/PollCont.cc
+++ b/iocore/net/PollCont.cc
@@ -74,7 +74,7 @@ PollCont::do_poll(ink_hrtime timeout)
     } else if (timeout >= 0) {
       poll_timeout = ink_hrtime_to_msec(timeout);
     } else {
-      poll_timeout = net_config_poll_timeout;
+      poll_timeout = EThread::default_wait_interval_ms;
     }
   }
 // wait for fd's to trigger, or don't wait if timeout is 0

--- a/iocore/net/PollCont.h
+++ b/iocore/net/PollCont.h
@@ -35,8 +35,8 @@ struct PollCont : public Continuation {
   PollDescriptor *nextPollDescriptor;
   int poll_timeout;
 
-  PollCont(Ptr<ProxyMutex> &m, int pt = net_config_poll_timeout);
-  PollCont(Ptr<ProxyMutex> &m, NetHandler *nh, int pt = net_config_poll_timeout);
+  PollCont(Ptr<ProxyMutex> &m, int pt = EThread::default_wait_interval_ms);
+  PollCont(Ptr<ProxyMutex> &m, NetHandler *nh, int pt = EThread::default_wait_interval_ms);
   ~PollCont() override;
   int pollEvent(int, Event *);
   void do_poll(ink_hrtime timeout);

--- a/iocore/net/UnixUDPNet.cc
+++ b/iocore/net/UnixUDPNet.cc
@@ -1736,7 +1736,7 @@ int
 UDPNetHandler::mainNetEvent(int event, Event *e)
 {
   ink_assert(trigger_event == e && event == EVENT_POLL);
-  return this->waitForActivity(net_config_poll_timeout);
+  return this->waitForActivity(EThread::default_wait_interval_ms);
 }
 
 int

--- a/iocore/net/test_I_UDPNet.cc
+++ b/iocore/net/test_I_UDPNet.cc
@@ -133,7 +133,6 @@ udp_echo_server()
 
   Thread *main_thread = new EThread();
   main_thread->set_specific();
-  net_config_poll_timeout = 10;
 
   init_diags("udp-.*", nullptr);
   ink_event_system_init(EVENT_SYSTEM_MODULE_PUBLIC_VERSION);

--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -93,7 +93,6 @@ main(int argc, const char **argv)
 
   Thread *main_thread = new EThread;
   main_thread->set_specific();
-  net_config_poll_timeout = 10;
   ink_net_init(ts::ModuleVersion(1, 0, ts::ModuleVersion::PRIVATE));
 
   SSLInitializeLibrary();

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2023,14 +2023,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   // This has some special semantics, in that providing this configuration on
   // command line has higher priority than what is set in records.yaml.
   if (-1 != poll_timeout) {
-    net_config_poll_timeout = poll_timeout;
+    EThread::default_wait_interval_ms = poll_timeout;
   } else {
-    REC_ReadConfigInteger(net_config_poll_timeout, "proxy.config.net.poll_timeout");
+    REC_ReadConfigInteger(EThread::default_wait_interval_ms, "proxy.config.net.poll_timeout");
   }
 
   // This shouldn't happen, but lets make sure we run somewhat reasonable.
-  if (net_config_poll_timeout < 0) {
-    net_config_poll_timeout = 10; // Default value for all platform.
+  if (EThread::default_wait_interval_ms < 0) {
+    EThread::default_wait_interval_ms = 10; // Default value for all platform.
   }
 
   REC_ReadConfigInteger(thread_max_heartbeat_mseconds, "proxy.config.thread.max_heartbeat_mseconds");


### PR DESCRIPTION
`net_config_poll_timeout` was causing unfortunate dependency issues.  Moving this to be an EThread concern makes sense to me, but I didn't change the configuration to match since its an internal detail that was already spread out past the definition.