### PR TITLE
tools/jtest: use @SWOC_LIBS@

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -38,7 +38,7 @@ noinst_PROGRAMS = jtest/jtest
 endif
 
 jtest_jtest_SOURCES = jtest/jtest.cc
-jtest_jtest_LDADD = $(top_builddir)/src/tscore/libtscore.a $(top_builddir)/src/tscpp/util/libtscpputil.la $(top_builddir)/lib/swoc/libtsswoc.la -lssl -lcrypto
+jtest_jtest_LDADD = $(top_builddir)/src/tscore/libtscore.a $(top_builddir)/src/tscpp/util/libtscpputil.la @SWOC_LIBS@ -lssl -lcrypto
 
 if BUILD_HTTP_LOAD
 


### PR DESCRIPTION
The tools/Makefile.am should reference @SWOC_LIBS@ instead of a hardcoded path in the working tree to support --with-libswoc.