### PR TITLE
Fix connect failure count

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -5765,10 +5765,10 @@ HttpSM::mark_host_failure(ResolveInfo *info, ts_time time_down)
           SMDebug("http", "hostdb increment IP failcount %s to %d",
                   ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)), info->active->fail_count.load());
         }
-      } else { // Clear the failure
-        info->active->fail_count   = 0;
-        info->active->last_failure = time_down;
       }
+    } else { // Clear the failure
+      info->active->fail_count   = 0;
+      info->active->last_failure = time_down;
     }
   }
 #ifdef DEBUG


### PR DESCRIPTION
If you look at the code on 9.2.x, the code is basically:
```
if (time_down) {

} else {  // Clear the failure
  info->app.http_data.fail_count   = 0;
  info->app.http_data.last_failure = time_down;
}
```
but on master it's like
```
if (time_down != TS_TIME_ZERO) {
  if (++count < max_retry) {

  } else {  // Clear the failure
    info->app.http_data.fail_count   = 0;
    info->app.http_data.last_failure = time_down;
  }
}
```
So the counter never reaches max_retry.

The code on 9.2.x:
https://github.com/apache/trafficserver/blob/6ffbdab2906e15a1a6bab7288e6afbcac48808aa/proxy/http/HttpSM.cc#L5615-L5643