### PR TITLE
ts_lua_transform: input_reader may be used uninitialized

### DIFF
--- a/plugins/lua/ts_lua_transform.cc
+++ b/plugins/lua/ts_lua_transform.cc
@@ -59,7 +59,7 @@ static int
 ts_lua_client_handler(TSCont contp, ts_lua_http_transform_ctx *transform_ctx, TSEvent event, int n)
 {
   TSVIO input_vio;
-  TSIOBufferReader input_reader;
+  TSIOBufferReader input_reader = nullptr;
   TSIOBufferBlock blk;
   int64_t toread, towrite, blk_len, upstream_done, input_avail, input_wm_bytes;
   const char *start;
@@ -286,7 +286,7 @@ ts_lua_transform_handler(TSCont contp, ts_lua_http_transform_ctx *transform_ctx,
 {
   TSVConn output_conn;
   TSVIO input_vio;
-  TSIOBufferReader input_reader;
+  TSIOBufferReader input_reader = nullptr;
   TSIOBufferBlock blk;
   int64_t toread, towrite, blk_len, upstream_done, input_avail, input_wm_bytes, l;
   const char *start;


### PR DESCRIPTION
Fix:

```
plugins/lua/ts_lua_transform.cc: In function ‘int ts_lua_client_entry(tsapi::c::TSCont, tsapi::c::TSEvent, void*)’:
plugins/lua/ts_lua_transform.cc:136:28: error: ‘input_reader’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  136 |     TSIOBufferReaderConsume(input_reader, input_avail);
      |     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
plugins/lua/ts_lua_transform.cc:62:20: note: ‘input_reader’ was declared here
   62 |   TSIOBufferReader input_reader;
      |                    ^~~~~~~~~~~~
mv -f esi/.deps/esi_la-esi.Tpo esi/.deps/esi_la-esi.Plo
plugins/lua/ts_lua_transform.cc: In function ‘int ts_lua_transform_entry(tsapi::c::TSCont, tsapi::c::TSEvent, void*)’:
plugins/lua/ts_lua_transform.cc:373:28: error: ‘input_reader’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  373 |     TSIOBufferReaderConsume(input_reader, input_avail);
      |     ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
plugins/lua/ts_lua_transform.cc:289:20: note: ‘input_reader’ was declared here
  289 |   TSIOBufferReader input_reader;
      |                    ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [Makefile:6725: lua/tslua_la-ts_lua_transform.lo] Error 1
```