### PR TITLE
Preserve unmapped url regardless of need for remapping

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -4363,9 +4363,6 @@ HttpSM::do_remap_request(bool run_inline)
 
   check_sni_host();
 
-  // Preserve effective url before remap
-  t_state.unmapped_url.create(t_state.hdr_info.client_request.url_get()->m_heap);
-  t_state.unmapped_url.copy(t_state.hdr_info.client_request.url_get());
   // Depending on a variety of factors the HOST field may or may not have been promoted to the
   // client request URL. The unmapped URL should always have that promotion done. If the HOST field
   // is not already there, promote it only in the unmapped_url. This avoids breaking any logic that

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -958,6 +958,10 @@ HttpTransact::HandleBlindTunnel(State *s)
 void
 HttpTransact::StartRemapRequest(State *s)
 {
+  // Preserve effective url before remap, regardless of actual need for remap
+  s->unmapped_url.create(s->hdr_info.client_request.url_get()->m_heap);
+  s->unmapped_url.copy(s->hdr_info.client_request.url_get());
+
   if (s->api_skip_all_remapping) {
     TxnDebug("http_trans", "API request to skip remapping");
 


### PR DESCRIPTION
https://github.com/apache/trafficserver/pull/10146 discovered that marking a parent host down causes a crash if a request is set to skip remapping. Not only OCSP requests but also any requests that skip remapping can cause the crash.

```
(lldb) bt
* thread #3, name = '[ET_NET 0]', stop reason = signal SIGABRT
  * frame #0: 0x000000018c190764 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x000000018c1c7c28 libsystem_pthread.dylib`pthread_kill + 288
    frame #2: 0x000000018c0d5ae8 libsystem_c.dylib`abort + 180
    frame #3: 0x0000000101060878 traffic_server`ink_abort(message_format="%s:%d: failed assertion `%s`") at ink_error.cc:99:3
    frame #4: 0x00000001010555bc traffic_server`_ink_assert(expression="valid()", file="/Users/mkitajo/src/github.com/trafficserver/proxy/hdrs/URL.h", line=595) at ink_assert.cc:37:3
    frame #5: 0x00000001000b17c0 traffic_server`URL::host_get(this=0x0000000113017718, length=0x000000010af12760) at URL.h:595:3
    frame #6: 0x000000010038cbcc traffic_server`HttpSM::mark_host_failure(this=0x0000000113016ae0, info=0x0000000113016cb8, time_down=ts_time @ 0x000000010af126a0) at HttpSM.cc:5750:62
    frame #7: 0x000000010038b824 traffic_server`HttpSM::do_hostdb_update_if_necessary(this=0x0000000113016ae0) at HttpSM.cc:4532:11
    frame #8: 0x00000001004771e4 traffic_server`HttpTransact::handle_server_connection_not_open(s=0x0000000113016be8) at HttpTransact.cc:3899:21
    frame #9: 0x000000010048ca78 traffic_server`HttpTransact::handle_response_from_server(s=0x0000000113016be8) at HttpTransact.cc:3799:7
    frame #10: 0x0000000100452034 traffic_server`HttpTransact::HandleResponse(s=0x0000000113016be8) at HttpTransact.cc:3450:5
```
The backtrace above shows ink_abort but a real crash happens on production (non-debug build).