### PR TITLE
RPC plugin handler: Add check for the lifecycle hooks.

### DIFF
--- a/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
@@ -1366,6 +1366,7 @@ Description
 Interact with plugins. Send a message to plugins. All plugins that have hooked the ``TSLifecycleHookID::TS_LIFECYCLE_MSG_HOOK`` will receive a callback for that hook.
 The :arg:`tag` and :arg:`data` will be available to the plugin hook processing. It is expected that plugins will use :arg:`tag` to select relevant messages and determine the format of the :arg:`data`.
 
+
 Parameters
 ~~~~~~~~~~
 
@@ -1381,6 +1382,24 @@ Result
 ~~~~~~
 
 The response will contain the default `success_response`  or an error. :ref:`jsonrpc-node-errors`.
+
+If plugins are not yet ready to handle any messages, then the following error will be set:
+
+.. code-block:: json
+
+   {
+      "error": {
+         "code": 9,
+         "message": "Error during execution",
+         "data": [
+            {
+            "code": 5000,
+            "message": "Plugin is not yet ready to handle any messages."
+            }
+         ]
+      }
+   }
+
 
 Examples
 ~~~~~~~~

--- a/mgmt/rpc/handlers/plugins/Plugins.cc
+++ b/mgmt/rpc/handlers/plugins/Plugins.cc
@@ -33,6 +33,7 @@ struct PluginMsgInfo {
   std::string data;
   std::string tag;
 };
+
 } // namespace
 namespace YAML
 {
@@ -58,6 +59,12 @@ namespace err = rpc::handlers::errors;
 ts::Rv<YAML::Node>
 plugin_send_basic_msg(std::string_view const &id, YAML::Node const &params)
 {
+  // The rpc could be ready before plugins are initialized.
+  // We make sure it is ready.
+  if (!lifecycle_hooks) {
+    return err::make_errata(err::Codes::PLUGIN, "Plugin is not yet ready to handle any messages.");
+  }
+
   ts::Rv<YAML::Node> resp;
   try {
     // keep the data.


### PR DESCRIPTION
It could be that someone may fire a message before plugins are ready to handle any message, so we add a check to avoid any issues and inform the caller about the situation.

```bash
$ traffic_ctl plugin msg test
Server Error found:
[9] Error during execution
- [5000] Plugin is not yet ready to handle any messages.
```