### PR TITLE
Eliminate unreachable code covered by switch default

### DIFF
--- a/plugins/experimental/access_control/plugin.cc
+++ b/plugins/experimental/access_control/plugin.cc
@@ -77,7 +77,6 @@ getEventName(TSEvent event)
   default:
     return "UNHANDLED";
   }
-  return "UNHANDLED";
 }
 
 /**

--- a/plugins/experimental/cache_fill/cache_fill.cc
+++ b/plugins/experimental/cache_fill/cache_fill.cc
@@ -60,7 +60,6 @@ getCacheLookupResultName(TSCacheLookupResult result)
     return "UNKNOWN_CACHE_LOOKUP_EVENT";
     break;
   }
-  return "UNKNOWN_CACHE_LOOKUP_EVENT";
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/plugins/healthchecks/healthchecks.cc
+++ b/plugins/healthchecks/healthchecks.cc
@@ -211,6 +211,7 @@ hc_thread(void *data ATS_UNUSED)
     if (len >= 0) {
       int i = 0;
 
+      /* coverity[ -tainted_data] */
       while (i < len) {
         struct inotify_event *event = (struct inotify_event *)&buffer[i];
         HCFileInfo *finfo           = g_config;

--- a/plugins/prefetch/plugin.cc
+++ b/plugins/prefetch/plugin.cc
@@ -76,7 +76,6 @@ getEventName(TSEvent event)
   default:
     return "UNHANDLED";
   }
-  return "UNHANDLED";
 }
 
 static const char *
@@ -99,7 +98,6 @@ getCacheLookupResultName(TSCacheLookupResult result)
     return "UNKNOWN_CACHE_LOOKUP_EVENT";
     break;
   }
-  return "UNKNOWN_CACHE_LOOKUP_EVENT";
 }
 
 /**


### PR DESCRIPTION
This fixes #10361 and #10337