### PR TITLE
make alternate tests wait a multiple of cache_config_mutex_retry_delay

### DIFF
--- a/iocore/cache/test/test_Alternate_S_to_L_remove_L.cc
+++ b/iocore/cache/test/test_Alternate_S_to_L_remove_L.cc
@@ -187,7 +187,7 @@ public:
       this->_wt = nullptr;
       // to make sure writer successfully write the final doc done. we need to schedule
       // to wait for some while. This time should be large than cache_config_mutex_retry_delay
-      this_ethread()->schedule_in(this->_rt, HRTIME_SECONDS(3));
+      this_ethread()->schedule_in(this->_rt, 4 * HRTIME_SECONDS(cache_config_mutex_retry_delay));
       break;
     case CACHE_EVENT_OPEN_READ:
       base->do_io_read();

--- a/iocore/cache/test/test_Alternate_S_to_L_remove_S.cc
+++ b/iocore/cache/test/test_Alternate_S_to_L_remove_S.cc
@@ -185,7 +185,7 @@ public:
       this->_wt = nullptr;
       // to make sure writer successfully write the final doc done. we need to schedule
       // to wait for some while. This time should be large than cache_config_mutex_retry_delay
-      this_ethread()->schedule_in(this->_rt, HRTIME_SECONDS(3));
+      this_ethread()->schedule_in(this->_rt, 4 * HRTIME_SECONDS(cache_config_mutex_retry_delay));
       break;
     case CACHE_EVENT_OPEN_READ:
       base->do_io_read();


### PR DESCRIPTION
This changes the wait time for the alternate catch tests to be a multiple of cache_config_mutex_retry_delay instead of a hard 3 seconds.  A better solution would be to add notification or pollable status regarding cache write state.