### PR TITLE
fix: check whether a protocol is enabled during the length calculation in create_npn_advertisement

### DIFF
--- a/iocore/net/SSLNextProtocolSet.cc
+++ b/iocore/net/SSLNextProtocolSet.cc
@@ -54,8 +54,10 @@ SSLNextProtocolSet::create_npn_advertisement(const SessionProtocolSet &enabled, 
   *len = 0;
 
   for (ep = endpoints.head; ep != nullptr; ep = endpoints.next(ep)) {
-    ink_release_assert((strlen(ep->protocol) > 0));
-    *len += (strlen(ep->protocol) + 1);
+    if (enabled.contains(globalSessionProtocolNameRegistry.toIndex(swoc::TextView{ep->protocol, strlen(ep->protocol)}))) {
+      ink_release_assert((strlen(ep->protocol) > 0));
+      *len += (strlen(ep->protocol) + 1);
+    }
   }
 
   *npn = advertised = static_cast<unsigned char *>(ats_malloc(*len));


### PR DESCRIPTION
# Problem
If the following conditions are met, an issue occurs where ATS sends an invalid Server Hello during the TLS handshake:
* Next Protocol Negotiation (NPN) extension is used.
* HTTP/2 is disabled in sni.yaml.

# How to reproduce
1. Add the following remap to the remap.config:
```
map https://cdn.example.com/ http://example.com
```
2. Add the following configuration to the sni.yaml:
```
sni:
  - fqdn: cdn.example.com
    http2: off
```
3. Launch Traffic Server.
4. Execute the following command:
```
openssl s_client \
  -connect localhost:443 \
  -servername cdn.example.com \
  -tls1_2 \
  -nextprotoneg http/2,http/1.1 \
  -CAfile /etc/pki/tls/certs/ca-bundle.crt \
  </dev/null \
| grep error
```

If reproduced, the following error will be displayed:
```
140451424151360:error:1423506E:SSL routines:ssl_next_proto_validate:bad extension:ssl/statem/extensions_clnt.c:1565:
```

# Cause
The issue is caused by ATS setting a length of the NPN string greater than the actual length in the NPN extension.
For example, when HTTP/2 is disabled in sni.yaml, the NPN string should be `8http/1.18http/1.0` and its length should be 18, but ATS sets the length as 21.

Here are some pointers to the relevant bits of code:

The `ssl_next_protos_advertised_callback` function is responsible for setting the NPN string and its length.
https://github.com/apache/trafficserver/blob/adac6166442d64807cefe7978c8badcaf9f6ee2c/iocore/net/SSLUtils.cc#L1611-L1616

The NPN string is stored in the `ALPNSupport::npn`, and its length is stored in the `ALPNSupport::npnsz`.
https://github.com/apache/trafficserver/blob/adac6166442d64807cefe7978c8badcaf9f6ee2c/iocore/net/SSLUtils.cc#L479-L490
https://github.com/apache/trafficserver/blob/adac6166442d64807cefe7978c8badcaf9f6ee2c/iocore/net/ALPNSupport.cc#L84-L87
https://github.com/apache/trafficserver/blob/adac6166442d64807cefe7978c8badcaf9f6ee2c/iocore/net/P_ALPNSupport.h#L58-L63

The values of `ALPNSupport::npn` and `ALPNSupport::npnsz` are set in the `SSLNextProtocolSet::create_npn_advertisement` function.
https://github.com/apache/trafficserver/blob/adac6166442d64807cefe7978c8badcaf9f6ee2c/iocore/net/ALPNSupport.cc#L126

In `SSLNextProtocolSet::create_npn_advertisement`, it is checked whether each protocol is enabled when setting the value for `ALPNSupport::npn`.
https://github.com/apache/trafficserver/blob/adac6166442d64807cefe7978c8badcaf9f6ee2c/iocore/net/SSLNextProtocolSet.cc#L66-L71

However, when setting the value for `ALPNSupport::npnsz`, it isn't checked whether each protocol is enabled.
https://github.com/apache/trafficserver/blob/adac6166442d64807cefe7978c8badcaf9f6ee2c/iocore/net/SSLNextProtocolSet.cc#L56-L59

As a result, when HTTP/2 is disabled in sni.yaml, the value excluding HTTP/2 is set for `ALPNSupport::npn`, but the value including HTTP/2 is set for `ALPNSupport::npnsz`.
Therefore, the length of the NPN string is greater than the actual length.