### PR TITLE
Allow origins to do TLS renegotiation

### DIFF
--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -89,7 +89,7 @@ typedef enum {
   SSL_HOOK_OP_LAST = SSL_HOOK_OP_TERMINATE ///< End marker value.
 } SslVConnOp;
 
-enum SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHAKE_ERROR };
+enum class SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHAKE_ERROR };
 
 //////////////////////////////////////////////////////////////////
 //
@@ -124,7 +124,7 @@ public:
     return retval;
   }
 
-  int
+  SSLHandshakeStatus
   getSSLHandshakeStatus() const
   {
     return sslHandshakeStatus;
@@ -133,11 +133,11 @@ public:
   bool
   getSSLHandShakeComplete() const override
   {
-    return sslHandshakeStatus != SSL_HANDSHAKE_ONGOING;
+    return sslHandshakeStatus != SSLHandshakeStatus::SSL_HANDSHAKE_ONGOING;
   }
 
   virtual void
-  setSSLHandShakeComplete(enum SSLHandshakeStatus state)
+  setSSLHandShakeComplete(SSLHandshakeStatus state)
   {
     sslHandshakeStatus = state;
   }
@@ -429,7 +429,7 @@ private:
   NetProcessor *_getNetProcessor() override;
   void *_prepareForMigration() override;
 
-  enum SSLHandshakeStatus sslHandshakeStatus = SSL_HANDSHAKE_ONGOING;
+  enum SSLHandshakeStatus sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_ONGOING;
   bool sslClientRenegotiationAbort           = false;
   bool first_ssl_connect                     = true;
   MIOBuffer *handShakeBuffer                 = nullptr;

--- a/iocore/net/P_SSLNetVConnection.h
+++ b/iocore/net/P_SSLNetVConnection.h
@@ -124,6 +124,12 @@ public:
     return retval;
   }
 
+  int
+  getSSLHandshakeStatus() const
+  {
+    return sslHandshakeStatus;
+  }
+
   bool
   getSSLHandShakeComplete() const override
   {

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -127,7 +127,9 @@ verify_callback(int signature_ok, X509_STORE_CTX *ctx)
   netvc->set_verify_cert(ctx);
   netvc->callHooks(TS_EVENT_SSL_VERIFY_SERVER);
   netvc->set_verify_cert(nullptr);
-  if (netvc->getSSLHandShakeComplete()) { // hook moved the handshake state to terminal
+
+  if (netvc->getSSLHandshakeStatus() == SSLHandshakeStatus::SSL_HANDSHAKE_ERROR) {
+    // Verify server hook failed and set the status to SSL_HANDSHAKE_ERROR
     unsigned char *sni_name;
     char buff[INET6_ADDRSTRLEN];
     if (netvc->options.sni_servername) {

--- a/iocore/net/SSLClientUtils.cc
+++ b/iocore/net/SSLClientUtils.cc
@@ -127,19 +127,7 @@ verify_callback(int signature_ok, X509_STORE_CTX *ctx)
   netvc->set_verify_cert(ctx);
   netvc->callHooks(TS_EVENT_SSL_VERIFY_SERVER);
   netvc->set_verify_cert(nullptr);
-  if (netvc->getSSLHandShakeComplete()) { // hook moved the handshake state to terminal
-    unsigned char *sni_name;
-    char buff[INET6_ADDRSTRLEN];
-    if (netvc->options.sni_servername) {
-      sni_name = reinterpret_cast<unsigned char *>(netvc->options.sni_servername.get());
-    } else {
-      sni_name = reinterpret_cast<unsigned char *>(buff);
-      ats_ip_ntop(netvc->get_remote_addr(), buff, INET6_ADDRSTRLEN);
-    }
-    Warning("TS_EVENT_SSL_VERIFY_SERVER plugin failed the origin certificate check for %s.  Action=%s SNI=%s",
-            netvc->options.ssl_servername.get(), enforce_mode ? "Terminate" : "Continue", sni_name);
-    return !enforce_mode;
-  }
+
   // Made it this far.  All is good
   return true;
 }

--- a/iocore/net/SSLNetVConnection.cc
+++ b/iocore/net/SSLNetVConnection.cc
@@ -607,7 +607,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
         // the client hello message back into the standard read.vio
         // so it will get forwarded onto the origin server
         if (!this->getSSLHandShakeComplete()) {
-          this->sslHandshakeStatus = SSL_HANDSHAKE_DONE;
+          this->sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
 
           // Copy over all data already read in during the SSL_accept
           // (the client hello message)
@@ -986,7 +986,7 @@ SSLNetVConnection::clear()
   TLSTunnelSupport::_clear();
   TLSCertSwitchSupport::_clear();
 
-  sslHandshakeStatus          = SSL_HANDSHAKE_ONGOING;
+  sslHandshakeStatus          = SSLHandshakeStatus::SSL_HANDSHAKE_ONGOING;
   sslLastWriteTime            = 0;
   sslTotalBytesSent           = 0;
   sslClientRenegotiationAbort = false;
@@ -1079,7 +1079,7 @@ SSLNetVConnection::sslStartHandShake(int event, int &err)
       if (cc && SSLCertContextOption::OPT_TUNNEL == cc->opt) {
         if (this->is_transparent) {
           this->attributes   = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
-          sslHandshakeStatus = SSL_HANDSHAKE_DONE;
+          sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
           SSL_free(this->ssl);
           this->ssl = nullptr;
           return EVENT_DONE;
@@ -1268,7 +1268,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
     // over the buffered handshake packets to the O.S.
     return EVENT_DONE;
   } else if (SSL_HOOK_OP_TERMINATE == hookOpRequested) {
-    sslHandshakeStatus = SSL_HANDSHAKE_DONE;
+    sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
     return EVENT_DONE;
   }
 
@@ -1348,7 +1348,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
     if (getTransparentPassThrough() && buf && *buf != SSL_OP_HANDSHAKE) {
       SSLVCDebug(this, "Data does not look like SSL handshake, starting blind tunnel");
       this->attributes   = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
-      sslHandshakeStatus = SSL_HANDSHAKE_ONGOING;
+      sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_ONGOING;
       return EVENT_CONT;
     }
   }
@@ -1370,7 +1370,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
       }
     }
 
-    sslHandshakeStatus = SSL_HANDSHAKE_DONE;
+    sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
 
     if (this->get_tls_handshake_begin_time()) {
       this->_record_tls_handshake_end_time();
@@ -1446,7 +1446,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
 #if defined(SSL_ERROR_WANT_SNI_RESOLVE) || defined(SSL_ERROR_WANT_X509_LOOKUP)
     if (this->attributes == HttpProxyPort::TRANSPORT_BLIND_TUNNEL || SSL_HOOK_OP_TUNNEL == hookOpRequested) {
       this->attributes   = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
-      sslHandshakeStatus = SSL_HANDSHAKE_ONGOING;
+      sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_ONGOING;
       return EVENT_CONT;
     } else {
       //  Stopping for some other reason, perhaps loading certificate
@@ -1578,7 +1578,7 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
 
     SSL_INCREMENT_DYN_STAT(ssl_total_success_handshake_count_out_stat);
 
-    sslHandshakeStatus = SSL_HANDSHAKE_DONE;
+    sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
     return EVENT_DONE;
 
   case SSL_ERROR_WANT_WRITE:
@@ -1645,7 +1645,7 @@ SSLNetVConnection::reenable(NetHandler *nh, int event)
 
   // Mark as error to stop the Handshake
   if (event == TS_EVENT_ERROR) {
-    sslHandshakeStatus = SSL_HANDSHAKE_ERROR;
+    sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_ERROR;
   }
 
   switch (sslHandshakeHookState) {
@@ -1914,7 +1914,7 @@ SSLNetVConnection::populate(Connection &con, Continuation *c, void *arg)
   this->ssl = static_cast<SSL *>(arg);
   // Maybe bring over the stats?
 
-  sslHandshakeStatus = SSL_HANDSHAKE_DONE;
+  sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
   this->_bindSSLObject();
   return EVENT_DONE;
 }
@@ -2041,7 +2041,7 @@ SSLNetVConnection::_lookupContextByName(const std::string &servername, SSLCertCo
 
   if (cc && ctx && SSLCertContextOption::OPT_TUNNEL == cc->opt && this->get_is_transparent()) {
     this->attributes = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
-    this->setSSLHandShakeComplete(SSL_HANDSHAKE_DONE);
+    this->setSSLHandShakeComplete(SSLHandshakeStatus::SSL_HANDSHAKE_DONE);
     return nullptr;
   } else {
     return ctx;


### PR DESCRIPTION
Ran into an issue where IIS will do a TLS renegotiation after the first request is made.  Since the handshake has already been completed it is failing this check.

CI has a test for TS_SSL_VERIFY_SERVER_HOOK and I will see if this change breaks that functionality.

Discussion about IIS: https://security.stackexchange.com/questions/24554/should-i-use-ssl-tls-renegotiation