### PR TITLE
Restores the traffic_server option for --maxRecords

### DIFF
--- a/include/records/I_RecordsConfig.h
+++ b/include/records/I_RecordsConfig.h
@@ -25,6 +25,9 @@
 
 #include "records/P_RecCore.h"
 
+// This is to manage the librecords table sizes. Not awesome, but better than the earlier recompiling of ATS requirement...
+extern int max_records_entries;
+
 enum RecordRequiredType {
   RR_NULL,    // config is _not_ required to be defined in records.yaml
   RR_REQUIRED // config _is_ required to be defined in record.config

--- a/include/records/P_RecCore.h
+++ b/include/records/P_RecCore.h
@@ -37,7 +37,7 @@
 #include <swoc/Errata.h>
 
 // records, record hash-table, and hash-table rwlock
-extern RecRecord g_records[REC_MAX_RECORDS];
+extern RecRecord *g_records;
 extern std::unordered_map<std::string, RecRecord *> g_records_ht;
 extern ink_rwlock g_records_rwlock;
 extern int g_num_records;

--- a/include/records/P_RecDefs.h
+++ b/include/records/P_RecDefs.h
@@ -30,7 +30,7 @@
 // We need at least this many internal record entries for our configurations and metrics.
 // This may need adjustments if we make significant additions to librecords. Note that
 // plugins are using their own metrics systems.
-#define REC_MAX_RECORDS               1500
+#define REC_MAX_RECORDS               2048
 #define REC_CONFIG_UPDATE_INTERVAL_MS 3000
 #define REC_REMOTE_SYNC_INTERVAL_MS   5000
 

--- a/src/records/RecCore.cc
+++ b/src/records/RecCore.cc
@@ -36,9 +36,13 @@
 #include "tscpp/util/ts_errata.h"
 #include "api/Metrics.h"
 
+// This is needed to manage the size of the librecords record. It can't be static, because it needs to be modified
+// and used (read) from several binaries / modules.
+int max_records_entries = REC_MAX_RECORDS;
+
 static bool g_initialized = false;
 
-RecRecord g_records[REC_MAX_RECORDS];
+RecRecord *g_records = nullptr;
 std::unordered_map<std::string, RecRecord *> g_records_ht;
 ink_rwlock g_records_rwlock;
 int g_num_records = 0;
@@ -201,6 +205,9 @@ RecCoreInit(Diags *_diags)
   RecConfigFileInit();
 
   g_num_records = 0;
+
+  // initialize record array for our internal stats (this can be reallocated later)
+  g_records = static_cast<RecRecord *>(ats_malloc(max_records_entries * sizeof(RecRecord)));
 
   // initialize record rwlock
   ink_rwlock_init(&g_records_rwlock);

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -206,6 +206,8 @@ static ArgumentDescription argument_descriptions[] = {
   {"disable_freelist",  'f', "Disable the freelist memory allocator",                                                               "T",     &cmd_disable_freelist,           "PROXY_DPRINTF_LEVEL",     nullptr},
   {"disable_pfreelist", 'F', "Disable the freelist memory allocator in ProxyAllocator",                                             "T",     &cmd_disable_pfreelist,
    "PROXY_DPRINTF_LEVEL",                                                                                                                                                                                nullptr},
+  {"maxRecords",        'm', "Max number of librecords metrics and configurations (default & minimum: 2048)",                       "I",     &max_records_entries,
+   "PROXY_MAX_RECORDS",                                                                                                                                                                                  nullptr},
 
 #if TS_HAS_TESTS
   {"regression",        'R', "Regression Level (quick:1..long:3)",                                                                  "I",     &regression_level,               "PROXY_REGRESSION",        nullptr},


### PR DESCRIPTION
We will need this at least through ATS v10, until some things such as the parent state (up / down) is removed from librecords.