### PR TITLE
tls_verify4: Use traffic_manager for config reload

### DIFF
--- a/tests/gold_tests/tls/tls_verify4.test.py
+++ b/tests/gold_tests/tls/tls_verify4.test.py
@@ -22,7 +22,7 @@ Specifically update via traffic_ctl (reloadable)
 '''
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
+ts = Test.MakeATSProcess("ts", command="traffic_manager", enable_tls=True)
 server_foo = Test.MakeOriginServer("server_foo",
                                    ssl=True,
                                    options={"--key": "{0}/signed-foo.key".format(Test.RunDirectory),


### PR DESCRIPTION
The tls_verify4.test.py was cherry-picked from master wherein `traffic_ctl config reload` works via the traffic_server process. That is not supported in 9.2.x. We need to use traffic_manager instead. This patch updates the test to start traffic_manager.

---

The tls_verify4.test.py is a new test which was cherry-pick'd in from master via:
https://github.com/apache/trafficserver/pull/9572

It works on master fine, but needs this patch to work on 9.2.x.