### PR TITLE
Fixed differences between cmake rc files and autotools

### DIFF
--- a/rc/CMakeLists.txt
+++ b/rc/CMakeLists.txt
@@ -15,17 +15,17 @@
 #
 #######################
 
-set(PACKAGE_NAME "trafficserver")
+set(PACKAGE_NAME "Apache Traffic Server")
 set(PACKAGE_VERSION ${TS_VERSION_STRING})
 set(PACKAGE_BUGREPORT "dev@trafficserver.apache.org")
 
 # TODO: Use layouts
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exp_bindir ${CMAKE_INSTALL_PREFIX}/bin)
-set(exp_runtimedir ${CMAKE_INSTALL_PREFIX}/var)
-set(exp_logdir ${CMAKE_INSTALL_PREFIX}/log)
+set(exp_runtimedir ${CMAKE_INSTALL_PREFIX}/var/trafficserver)
+set(exp_logdir ${CMAKE_INSTALL_PREFIX}/var/log/trafficserver)
 set(pkgsysuser ${TS_PKGSYSUSER})
-set(pkgsysgroupe ${TS_PKGSYSGROUP})
+set(pkgsysgroup ${TS_PKGSYSGROUP})
 
 configure_file(trafficserver.in trafficserver @ONLY)
 configure_file(trafficserver.conf.in trafficserver.conf @ONLY)


### PR DESCRIPTION
Diff of the two scripts (cmake and autotools generated) before this PR:
```
09:08:47 zeus:(master)~/dev/apache/trafficserver/build$ diff /opt/ats/bin/trafficserver /tmp/trafficserver.autotools
46c46
< TS_PACKAGE_NAME="trafficserver"
---
> TS_PACKAGE_NAME="Apache Traffic Server"
117c117
< TS_PIDFILE=${TS_PIDFILE:-$TS_BASE/opt/ats/var/server.lock}
---
> TS_PIDFILE=${TS_PIDFILE:-$TS_BASE/opt/ats/var/trafficserver/server.lock}
121c121
< STDOUTLOG=${STDOUTLOG:-$TS_BASE/opt/ats/log/traffic.out}
---
> STDOUTLOG=${STDOUTLOG:-$TS_BASE/opt/ats/var/log/trafficserver/traffic.out}
123c123
< STDERRLOG=${STDERRLOG:-$TS_BASE/opt/ats/log/traffic.out}
---
> STDERRLOG=${STDERRLOG:-$TS_BASE/opt/ats/var/log/trafficserver/traffic.out}
182,184c182,184
< if [ ! -d $TS_BASE/opt/ats/var ]; then
< 	mkdir -p $TS_BASE/opt/ats/var
< 	chown nobody: $TS_BASE/opt/ats/var
---
> if [ ! -d $TS_BASE/opt/ats/var/trafficserver ]; then
> 	mkdir -p $TS_BASE/opt/ats/var/trafficserver
> 	chown nobody:nobody $TS_BASE/opt/ats/var/trafficserver
```