### PR TITLE
Fixed HTTP method metrics not updating

### DIFF
--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -697,6 +697,7 @@ public:
     bool already_downgraded           = false;
     bool transparent_passthrough      = false;
     bool range_in_cache               = false;
+    bool is_method_stats_incremented  = false;
 
     /// True if the response is cacheable because of negative caching configuration.
     ///
@@ -1111,6 +1112,7 @@ public:
   static void client_result_stat(State *s, ink_hrtime total_time, ink_hrtime request_process_time);
   static void delete_warning_value(HTTPHdr *to_warn, HTTPWarningCode warning_code);
   static bool is_connection_collapse_checks_success(State *s); // YTS Team, yamsat
+  static void update_method_stat(int method);
 };
 
 using TransactEntryFunc_t = void (*)(HttpTransact::State *);

--- a/tests/gold_tests/h2/gold/http-request-method-metrics.gold
+++ b/tests/gold_tests/h2/gold/http-request-method-metrics.gold
@@ -1,0 +1,3 @@
+proxy.process.http.get_requests 4
+proxy.process.http.post_requests 10
+proxy.process.http.put_requests 0

--- a/tests/gold_tests/h2/h2origin.test.py
+++ b/tests/gold_tests/h2/h2origin.test.py
@@ -97,3 +97,18 @@ ts.Disk.squid_log.Content += Testers.ContainsExpression(" [5-9] http/2 http/2", 
 ts.Disk.squid_log.Content += Testers.ExcludesExpression(" [5-9] http/1.1 http/2", "cases 5-11 request http/2")
 ts.Disk.squid_log.Content += Testers.ContainsExpression(" 1[0-1] http/2 http/2", "cases 5-11 request http/2")
 ts.Disk.squid_log.Content += Testers.ExcludesExpression(" 1[0-1] http/1.1 http/2", "cases 5-11 request http/2")
+
+tr = Test.AddTestRun("Test HTTP method Metrics")
+tr.Processes.Default.Command = (
+    f"{Test.Variables.AtsTestToolsDir}/stdout_wait" +
+    " 'traffic_ctl metric get" +
+    " proxy.process.http.get_requests" +
+    " proxy.process.http.post_requests" +
+    " proxy.process.http.put_requests'" +
+    f" {Test.TestDirectory}/gold/http-request-method-metrics.gold"
+)
+# Need to copy over the environment so traffic_ctl knows where to find the unix
+# domain socket
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -203,7 +203,7 @@ tr.StillRunningAfter = ts
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"CONNECT tunnel://backend.incoming.port.com:{ts.Variables.ssl_port} HTTP/1.1",
     "Verify a CONNECT request is handled")
-ts.Disk.traffic_out.Content += Testers.ContainsExpression("HTTP/1.1 400 Direct self loop detected", "The loop should be detected")
+ts.Disk.traffic_out.Content += Testers.ContainsExpression("HTTP/1.1 400 Cycle Detected", "The loop should be detected")
 
 tr = Test.AddTestRun("test {proxy_protocol_port}")
 tr.Setup.Copy('proxy_protocol_client.py')
@@ -257,7 +257,7 @@ ts.Disk.traffic_out.Content += Testers.ContainsExpression(
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"CONNECT tunnel://backend.wildcard.with.incoming.port.com:{ts.Variables.ssl_port} HTTP/1.1",
     "Verify a CONNECT request is handled")
-ts.Disk.traffic_out.Content += Testers.ContainsExpression("HTTP/1.1 400 Direct self loop detected", "The loop should be detected")
+ts.Disk.traffic_out.Content += Testers.ContainsExpression("HTTP/1.1 400 Cycle Detected", "The loop should be detected")
 
 tr = Test.AddTestRun("test wildcard with proxy_protocol_port")
 tr.Setup.Copy('proxy_protocol_client.py')


### PR DESCRIPTION
Currently, the HTTP request method metrics such as `proxy.process.http.get_requests` are not updating properly for non-tunneled traffic. This PR fixes this and added some test coverage.

In addition, while I am here, I cleaned up the redundant call to `build_error_response()` in `HttpTransact::SelfLoop`, as this is already called right before in `HttpTransact::will_this_request_self_loop()`, with the same arguments but more informative reason phrase. 