### PR TITLE
Add a pristine option for strategies peering

### DIFF
--- a/configs/strategies.schema.json
+++ b/configs/strategies.schema.json
@@ -169,6 +169,10 @@
                     "type": "boolean",
                     "description": "cache or do not cache proxy peer responses when using a peering ring mode and consistent hashing"
                 },
+		"use_pristine": {
+		    "type": "boolean",
+                    "description": "use the pristine (pre-remap) url when going to a peer cache in a peering ring"
+                },
                 "groups": {
                     "type": "array",
                     "description": "the groups of hosts assigned to the strategy",

--- a/proxy/ParentSelection.h
+++ b/proxy/ParentSelection.h
@@ -191,6 +191,7 @@ struct ParentResult {
   int port;
   bool retry;
   bool chash_init[MAX_GROUP_RINGS] = {false};
+  bool use_pristine                = false;
   TSHostStatus first_choice_status = TSHostStatus::TS_HOST_STATUS_INIT;
   bool do_not_cache_response       = false;
 

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -1842,7 +1842,6 @@ HttpTransact::PPDNSLookup(State *s)
   //  parents, check to see if we've already built our request
   if (!s->hdr_info.server_request.valid()) {
     build_request(s, &s->hdr_info.client_request, &s->hdr_info.server_request, s->current.server->http_version);
-
     // Take care of deferred (issue revalidate) work in building
     //   the request
     if (s->pending_work != nullptr) {
@@ -7749,8 +7748,8 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
   ink_assert(outgoing_version != HTTP_0_9);
 
   // HttpTransactHeaders::convert_request(outgoing_version, outgoing_request); // commented out this idea
-
   URL *url = outgoing_request->url_get();
+
   // Remove fragment from upstream URL
   url->fragment_set(nullptr, 0);
 
@@ -7788,6 +7787,13 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
     // cannot deal with absolute URLs.
     TxnDebug("http_trans", "removing host name from url");
     HttpTransactHeaders::remove_host_name_from_url(outgoing_request);
+  }
+
+  // If we are going to a peer cache and want to use the pristine URL, get it from the base request
+  if (s->parent_result.use_pristine) {
+    int tmp_len   = 0;
+    auto tmp_char = s->unmapped_url.host_get(&tmp_len);
+    outgoing_request->url_get()->host_set(tmp_char, tmp_len);
   }
 
   // If the response is most likely not cacheable, eg, request with Authorization,

--- a/proxy/http/remap/NextHopSelectionStrategy.cc
+++ b/proxy/http/remap/NextHopSelectionStrategy.cc
@@ -86,6 +86,10 @@ NextHopSelectionStrategy::NextHopSelectionStrategy(const std::string_view &name,
       host_override = n["host_override"].as<bool>();
     }
 
+    if (n["use_pristine"]) {
+      use_pristine = n["use_pristine"].as<bool>();
+    }
+
     // failover node.
     YAML::Node failover_node_n = n["failover"];
     if (failover_node_n) {

--- a/proxy/http/remap/NextHopSelectionStrategy.h
+++ b/proxy/http/remap/NextHopSelectionStrategy.h
@@ -214,6 +214,7 @@ public:
   bool ignore_self_detect  = false;
   bool cache_peer_result   = true;
   bool host_override       = false;
+  bool use_pristine        = false;
   NHPolicyType policy_type = NH_UNDEFINED;
   NHSchemeType scheme      = NH_SCHEME_NONE;
   NHRingMode ring_mode     = NH_ALTERNATE_RING;


### PR DESCRIPTION
Adds a `use_pristine` option to the strategies configuration. Currently when using peering we use the post-remap URL which does not work for peering as then all peers have to have remaps of each other in order to handle the new fqdn. This option replaces it with the original pristine URL requested by the client so all peers can maintain the same set of remaps