### PR TITLE
Use PRIu64 for stream id

### DIFF
--- a/proxy/http3/Http3App.cc
+++ b/proxy/http3/Http3App.cc
@@ -221,13 +221,13 @@ Http3App::_handle_uni_stream_on_read_ready(int /* event */, VIO *vio)
     } else if (this->_control_stream_id != adapter->stream().id()) {
       error = std::make_unique<Http3Error>(Http3ErrorClass::CONNECTION, Http3ErrorCode::H3_STREAM_CREATION_ERROR,
                                            "Only one control stream per peer is permitted");
-      Debug("http3", "CONTROL stream [%lu] error: %hu, %s", this->_control_stream_id, error->get_code(), error->msg);
+      Debug("http3", "CONTROL stream [%" PRIu64 "] error: %hu, %s", this->_control_stream_id, error->get_code(), error->msg);
       break;
     }
     uint64_t nread = 0;
     error          = this->_control_stream_dispatcher.on_read_ready(adapter->stream().id(), type, *vio->get_reader(), nread);
     if (error && error->cls != Http3ErrorClass::UNDEFINED) {
-      Debug("http3", "CONTROL stream [%lu] error: %hu, %s", this->_control_stream_id, error->get_code(), error->msg);
+      Debug("http3", "CONTROL stream [%" PRIu64 "] error: %hu, %s", this->_control_stream_id, error->get_code(), error->msg);
     }
     // The sender MUST NOT close the control stream, and the receiver MUST NOT request that the sender close the control stream.
     // If either control stream is closed at any point, this MUST be treated as a connection error of type
@@ -237,7 +237,7 @@ Http3App::_handle_uni_stream_on_read_ready(int /* event */, VIO *vio)
   case Http3StreamType::PUSH: {
     error =
       std::make_unique<Http3Error>(Http3ErrorClass::CONNECTION, Http3ErrorCode::H3_STREAM_CREATION_ERROR, "Only servers can push");
-    Debug("http3", "PUSH stream [%lu] error: %hu, %s", adapter->stream().id(), error->get_code(), error->msg);
+    Debug("http3", "PUSH stream [%" PRIu64 "] error: %hu, %s", adapter->stream().id(), error->get_code(), error->msg);
     // if a server receives a client-initiated push stream, this MUST be treated as a connection error of type
     // H3_STREAM_CREATION_ERROR
     break;
@@ -252,7 +252,7 @@ Http3App::_handle_uni_stream_on_read_ready(int /* event */, VIO *vio)
     // processing. If reading is aborted, the recipient SHOULD use the H3_STREAM_CREATION_ERROR error code or a reserved error code
     // (Section 8.1). The recipient MUST NOT consider unknown stream types to be a connection error of any kind.
     error = std::make_unique<Http3Error>(Http3ErrorClass::STREAM, Http3ErrorCode::H3_STREAM_CREATION_ERROR, "Stream type unkown");
-    Debug("http3", "UNKNOWN stream [%lu] error: %hu, %s", adapter->stream().id(), error->get_code(), error->msg);
+    Debug("http3", "UNKNOWN stream [%" PRIu64 "] error: %hu, %s", adapter->stream().id(), error->get_code(), error->msg);
     break;
   }
   default:


### PR DESCRIPTION
```
Http3App.cc:224:61: error: format specifies type 'unsigned long' but the argument has type 'QUICStreamId' (aka 'unsigned long long') [-Werror,-Wformat]
      Debug("http3", "CONTROL stream [%lu] error: %hu, %s", this->_control_stream_id, error->get_code(), error->msg);
                                      ~~~                   ^~~~~~~~~~~~~~~~~~~~~~~~
                                      %llu
../../include/tscore/Diags.h:194:29: note: expanded from macro 'Debug'
        DbgPrint(Debug_ctl, __VA_ARGS__); \
                            ^~~~~~~~~~~
../../include/ts/DbgCtl.h:139:90: note: expanded from macro 'DbgPrint'
#define DbgPrint(CTL, ...) (DbgCtl::print((CTL).tag(), __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__))
                                                                                         ^~~~~~~~~~~
Http3App.cc:230:61: error: format specifies type 'unsigned long' but the argument has type 'QUICStreamId' (aka 'unsigned long long') [-Werror,-Wformat]
      Debug("http3", "CONTROL stream [%lu] error: %hu, %s", this->_control_stream_id, error->get_code(), error->msg);
                                      ~~~                   ^~~~~~~~~~~~~~~~~~~~~~~~
                                      %llu
../../include/tscore/Diags.h:194:29: note: expanded from macro 'Debug'
        DbgPrint(Debug_ctl, __VA_ARGS__); \
                            ^~~~~~~~~~~
../../include/ts/DbgCtl.h:139:90: note: expanded from macro 'DbgPrint'
#define DbgPrint(CTL, ...) (DbgCtl::print((CTL).tag(), __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__))
                                                                                         ^~~~~~~~~~~
Http3App.cc:240:56: error: format specifies type 'unsigned long' but the argument has type 'QUICStreamId' (aka 'unsigned long long') [-Werror,-Wformat]
    Debug("http3", "PUSH stream [%lu] error: %hu, %s", adapter->stream().id(), error->get_code(), error->msg);
                                 ~~~                   ^~~~~~~~~~~~~~~~~~~~~~
                                 %llu
../../include/tscore/Diags.h:194:29: note: expanded from macro 'Debug'
        DbgPrint(Debug_ctl, __VA_ARGS__); \
                            ^~~~~~~~~~~
../../include/ts/DbgCtl.h:139:90: note: expanded from macro 'DbgPrint'
#define DbgPrint(CTL, ...) (DbgCtl::print((CTL).tag(), __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__))
                                                                                         ^~~~~~~~~~~
Http3App.cc:255:59: error: format specifies type 'unsigned long' but the argument has type 'QUICStreamId' (aka 'unsigned long long') [-Werror,-Wformat]
    Debug("http3", "UNKNOWN stream [%lu] error: %hu, %s", adapter->stream().id(), error->get_code(), error->msg);
                                    ~~~                   ^~~~~~~~~~~~~~~~~~~~~~
                                    %llu
../../include/tscore/Diags.h:194:29: note: expanded from macro 'Debug'
        DbgPrint(Debug_ctl, __VA_ARGS__); \
                            ^~~~~~~~~~~
../../include/ts/DbgCtl.h:139:90: note: expanded from macro 'DbgPrint'
#define DbgPrint(CTL, ...) (DbgCtl::print((CTL).tag(), __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__))
                                                                                         ^~~~~~~~~~~
4 errors generated.
```