### PR TITLE
Make Cripts buildable on Fedora 39

### DIFF
--- a/include/cripts/Files.hpp
+++ b/include/cripts/Files.hpp
@@ -43,7 +43,7 @@ namespace Line
     void operator=(const Reader &) = delete;
 
     explicit Reader(const std::string &path) : _path(path), _stream{path} {}
-    explicit Reader(const Cript::string_view path) : _path(path), _stream{path} {}
+    explicit Reader(const Cript::string_view path) : _path(path), _stream{_path} {}
 
     operator Cript::string() { return line(); }
 

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -104,10 +104,10 @@ namespace List
 
   public:
     Method() = delete;
-    explicit Method(Header::Method method) { push_back(method); }
+    explicit Method(Header::Method method) : std::vector<Header::Method>() { push_back(method); }
     void operator=(const Method &) = delete;
 
-    Method(Method const &method) { insert(end(), std::begin(method), std::end(method)); }
+    Method(Method const &method) : std::vector<Header::Method>() { insert(end(), std::begin(method), std::end(method)); }
 
     Method(const std::initializer_list<Method> &list)
     {

--- a/src/cripts/Instance.cc
+++ b/src/cripts/Instance.cc
@@ -46,7 +46,10 @@ Cript::Instance::initialize(int argc, char *argv[], const char *filename)
     plugin_debug_tag = plugin_debug_tag.substr(slash + 1, period - slash - 1);
   }
 
+#pragma push_macro("set")
+#undef set
   dbg_ctl_cript.set(plugin_debug_tag.c_str());
+#pragma pop_macro("set")
   TSDebug("Cript", "Switching instance debug tag to %s", plugin_debug_tag.c_str());
 }
 

--- a/src/cripts/Instance.cc
+++ b/src/cripts/Instance.cc
@@ -46,10 +46,7 @@ Cript::Instance::initialize(int argc, char *argv[], const char *filename)
     plugin_debug_tag = plugin_debug_tag.substr(slash + 1, period - slash - 1);
   }
 
-#pragma push_macro("set")
-#undef set
   dbg_ctl_cript.set(plugin_debug_tag.c_str());
-#pragma pop_macro("set")
   TSDebug("Cript", "Switching instance debug tag to %s", plugin_debug_tag.c_str());
 }
 


### PR DESCRIPTION
Tested with GCC 13.2.1 on Fedora 39.