### PR TITLE
Prevent crash triggered by use-after-free of HttpSM

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -7394,9 +7394,8 @@ HttpSM::kill_this()
     if (_netvc) {
       _netvc->do_io_close();
       free_MIOBuffer(_netvc_read_buffer);
-    } else if (server_txn == nullptr) {
-      this->cancel_pending_server_connection();
     }
+    this->cancel_pending_server_connection();
 
     // It possible that a plugin added transform hook
     //   but the hook never executed due to a client abort


### PR DESCRIPTION
This fixes #10455, a crash triggered by a use-after-free of HttpSM.