### PR TITLE
Make Cripts buildable with BoringSSL

### DIFF
--- a/src/cripts/Crypto.cc
+++ b/src/cripts/Crypto.cc
@@ -170,7 +170,7 @@ Crypto::detail::Cipher::_initialize()
 
   TSAssert(_ctx == nullptr);
   TSReleaseAssert(_cipher != nullptr);
-  TSReleaseAssert(_key_len == EVP_CIPHER_key_length(_cipher)); // Make sure the crypto key was correct size
+  TSReleaseAssert(_key_len == static_cast<int>(EVP_CIPHER_key_length(_cipher))); // Make sure the crypto key was correct size
 
   memset(iv, 0, sizeof(iv)); // The IV is always '0x0'
   _ctx = EVP_CIPHER_CTX_new();


### PR DESCRIPTION
The type of return value is different on BoringSSL (int vs uint).
```
Crypto.cc:173:28: error: comparison of integers of different signs: 'int' and 'unsigned int' [-Werror,-Wsign-compare]
  TSReleaseAssert(_key_len == EVP_CIPHER_key_length(_cipher)); // Make sure the crypto key was correct size
                  ~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../include/ts/ts.h:313:38: note: expanded from macro 'TSReleaseAssert'
#define TSReleaseAssert(EX) ((void)((EX) ? (void)0 : _TSReleaseAssert(#EX, __FILE__, __LINE__)))
                                     ^~
1 error generated.
```