### PR TITLE
Use ts::Metrics for PreWarm stats

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4203,10 +4203,6 @@ SNI Routing
 
    Enable :ref:`pre-warming-tls-tunnel`. The feature is disabled by default.
 
-.. ts:cv:: CONFIG proxy.config.tunnel.prewarm.max_stats_size INT 100
-
-   Max size of :ref:`dynamic stats for Pre-warming TLS Tunnel <pre-warming-tls-tunnel-stats>`.
-
 .. ts:cv:: CONFIG proxy.config.tunnel.prewarm.algorithm INT 2
 
    Version of pre-warming algorithm.

--- a/iocore/net/PreWarmManager.cc
+++ b/iocore/net/PreWarmManager.cc
@@ -29,6 +29,7 @@
 #include "P_VConnection.h"
 #include "I_NetProcessor.h"
 
+#include "api/Metrics.h"
 #include "tscore/ink_time.h"
 #include "tscpp/util/PostScript.h"
 
@@ -83,21 +84,16 @@ parse_authority(std::string &fqdn, int32_t &port, std::string_view authority)
 //
 constexpr std::string_view STAT_NAME_PREFIX = "proxy.process.tunnel.prewarm"sv;
 
-struct StatEntry {
-  std::string_view name;
-  RecRawStatSyncCb cb;
-};
-
 // the order is the same as PreWarm::Stat
 // clang-format off
-constexpr StatEntry STAT_ENTRIES[] = {
-  {"current_init"sv, RecRawStatSyncSum},
-  {"current_open"sv, RecRawStatSyncSum},
-  {"total_hit"sv, RecRawStatSyncSum},
-  {"total_miss"sv, RecRawStatSyncSum},
-  {"total_handshake_time"sv, RecRawStatSyncSum},
-  {"total_handshake_count"sv, RecRawStatSyncSum},
-  {"total_retry"sv, RecRawStatSyncSum},
+constexpr std::string_view STAT_ENTRIES[] = {
+  "current_init"sv,
+  "current_open"sv,
+  "total_hit"sv,
+  "total_miss"sv,
+  "total_handshake_time"sv,
+  "total_handshake_count"sv,
+  "total_retry"sv,
 };
 // clang-format on
 
@@ -140,7 +136,9 @@ PreWarmSM::retry()
 
   ink_hrtime delay = HRTIME_SECONDS(1 << _retry_counter);
   ++_retry_counter;
-  prewarmManager.stats.increment(_stats_ids->at(static_cast<int>(PreWarm::Stat::RETRY)), 1);
+
+  ts::Metrics &intm = ts::Metrics::getInstance();
+  intm.increment(_stats_ids->at(static_cast<int>(PreWarm::Stat::RETRY)));
 
   EThread *ethread = this_ethread();
   _retry_event     = ethread->schedule_in_local(this, delay, EVENT_IMMEDIATE);
@@ -630,8 +628,9 @@ PreWarmSM::_record_handshake_time()
     return;
   }
 
-  prewarmManager.stats.increment(_stats_ids->at(static_cast<int>(PreWarm::Stat::HANDSHAKE_TIME)), duration);
-  prewarmManager.stats.increment(_stats_ids->at(static_cast<int>(PreWarm::Stat::HANDSHAKE_COUNT)), 1);
+  ts::Metrics &intm = ts::Metrics::getInstance();
+  intm.increment(_stats_ids->at(static_cast<int>(PreWarm::Stat::HANDSHAKE_TIME)), duration);
+  intm.increment(_stats_ids->at(static_cast<int>(PreWarm::Stat::HANDSHAKE_COUNT)));
 }
 
 ////
@@ -691,6 +690,8 @@ PreWarmQueue::state_running(int event, void *data)
 {
   switch (event) {
   case EVENT_INTERVAL: {
+    ts::Metrics &intm = ts::Metrics::getInstance();
+
     for (auto &[dst, info] : _map) {
       // mentain queues
       _delete_closed_sm(info.init_list);
@@ -704,10 +705,10 @@ PreWarmQueue::state_running(int event, void *data)
             dst->port, (int)dst->type, dst->alpn_index, info.stat.miss, info.stat.hit, (int)info.init_list->size(),
             (int)info.open_list->size());
 
-      prewarmManager.stats.set_sum(info.stats_ids->at(static_cast<int>(PreWarm::Stat::INIT_LIST_SIZE)), info.init_list->size());
-      prewarmManager.stats.set_sum(info.stats_ids->at(static_cast<int>(PreWarm::Stat::OPEN_LIST_SIZE)), info.open_list->size());
-      prewarmManager.stats.increment(info.stats_ids->at(static_cast<int>(PreWarm::Stat::HIT)), info.stat.hit);
-      prewarmManager.stats.increment(info.stats_ids->at(static_cast<int>(PreWarm::Stat::MISS)), info.stat.miss);
+      intm.write(info.stats_ids->at(static_cast<int>(PreWarm::Stat::INIT_LIST_SIZE)), info.init_list->size());
+      intm.write(info.stats_ids->at(static_cast<int>(PreWarm::Stat::OPEN_LIST_SIZE)), info.open_list->size());
+      intm.increment(info.stats_ids->at(static_cast<int>(PreWarm::Stat::HIT)), info.stat.hit);
+      intm.increment(info.stats_ids->at(static_cast<int>(PreWarm::Stat::MISS)), info.stat.miss);
 
       // clear PreWarmQueue::Stat
       info.stat.miss = 0;
@@ -901,6 +902,7 @@ PreWarmQueue::_reconfigure()
   const PreWarm::StatsIdMap &new_stats_id_map = prewarmManager.get_stats_id_map();
 
   Map new_map;
+  ts::Metrics &intm = ts::Metrics::getInstance();
 
   for (auto &entry : new_conf_list) {
     const PreWarm::SPtrConstDst &dst = entry.first;
@@ -930,8 +932,8 @@ PreWarmQueue::_reconfigure()
   // free unexisting entries
   for (auto &[dst, info] : _map) {
     if (auto entry = new_conf_list.find(dst); entry == new_conf_list.end()) {
-      prewarmManager.stats.set_sum(info.stats_ids->at(static_cast<int>(PreWarm::Stat::INIT_LIST_SIZE)), 0);
-      prewarmManager.stats.set_sum(info.stats_ids->at(static_cast<int>(PreWarm::Stat::OPEN_LIST_SIZE)), 0);
+      intm.write(info.stats_ids->at(static_cast<int>(PreWarm::Stat::INIT_LIST_SIZE)), 0);
+      intm.write(info.stats_ids->at(static_cast<int>(PreWarm::Stat::OPEN_LIST_SIZE)), 0);
 
       _make_queue_empty(info.init_list);
       delete info.init_list;
@@ -1029,10 +1031,6 @@ PreWarmManager::reconfigure()
   }
 
   if (is_prewarm_enabled) {
-    if (!stats.is_allocated()) {
-      stats.init(prewarm_conf->max_stats_size);
-    }
-
     _parsed_conf.clear();
     _parse_sni_conf(_parsed_conf, sni_conf);
     _register_stats(_parsed_conf);
@@ -1134,6 +1132,8 @@ PreWarmManager::_register_stats(const PreWarm::ParsedSNIConf &parsed_conf)
 {
   int stats_counter = 0;
 
+  ts::Metrics &intm = ts::Metrics::getInstance();
+
   for (auto &entry : parsed_conf) {
     const PreWarm::SPtrConstDst &dst = entry.first;
 
@@ -1145,19 +1145,18 @@ PreWarmManager::_register_stats(const PreWarm::ParsedSNIConf &parsed_conf)
         std::string_view alpn_name = alpn_name_for_stat(dst->alpn_index);
 
         snprintf(name, sizeof(name), "%s.%.*s:%d.tls.%s.%s", STAT_NAME_PREFIX.data(), static_cast<int>(dst->host.size()),
-                 dst->host.data(), dst->port, alpn_name.data(), STAT_ENTRIES[j].name.data());
+                 dst->host.data(), dst->port, alpn_name.data(), STAT_ENTRIES[j].data());
       } else {
         snprintf(name, sizeof(name), "%s.%.*s:%d.%s.%s", STAT_NAME_PREFIX.data(), static_cast<int>(dst->host.size()),
-                 dst->host.data(), dst->port, (dst->type == SNIRoutingType::PARTIAL_BLIND) ? "tls" : "tcp",
-                 STAT_ENTRIES[j].name.data());
+                 dst->host.data(), dst->port, (dst->type == SNIRoutingType::PARTIAL_BLIND) ? "tls" : "tcp", STAT_ENTRIES[j].data());
       }
 
-      int stats_id = stats.find(name);
-      if (stats_id < 0) {
-        stats_id = stats.create(RECT_PROCESS, name, RECD_INT, STAT_ENTRIES[j].cb);
+      ts::Metrics::IdType stats_id = intm.lookup(name);
+
+      if (stats_id == ts::Metrics::NOT_FOUND) {
+        stats_id = intm.newMetric(name);
 
         if (stats_id < 0) {
-          // proxy.config.tunnel.prewarm.max_stats_size is enough?
           Error("couldn't register stat name=%s", name);
         } else {
           ++stats_counter;

--- a/iocore/net/PreWarmManager.h
+++ b/iocore/net/PreWarmManager.h
@@ -136,7 +136,7 @@ enum class Stat {
   LAST_ENTRY,
 };
 
-using StatsIds          = std::array<ts::Metrics::IdType, static_cast<size_t>(PreWarm::Stat::LAST_ENTRY)>;
+using StatsIds          = std::array<ts::Metrics::IntType *, static_cast<size_t>(PreWarm::Stat::LAST_ENTRY)>;
 using SPtrConstStatsIds = std::shared_ptr<const StatsIds>;
 using StatsIdMap        = std::unordered_map<SPtrConstDst, SPtrConstStatsIds, DstHash, DstKeyEqual>;
 

--- a/iocore/net/PreWarmManager.h
+++ b/iocore/net/PreWarmManager.h
@@ -32,8 +32,8 @@
 #include "NetTimeout.h"
 #include "Milestones.h"
 
+#include "api/Metrics.h"
 #include "records/I_RecHttp.h"
-#include "records/DynamicStats.h"
 
 #include <map>
 #include <unordered_map>
@@ -136,7 +136,7 @@ enum class Stat {
   LAST_ENTRY,
 };
 
-using StatsIds          = std::array<int, static_cast<size_t>(PreWarm::Stat::LAST_ENTRY)>;
+using StatsIds          = std::array<ts::Metrics::IdType, static_cast<size_t>(PreWarm::Stat::LAST_ENTRY)>;
 using SPtrConstStatsIds = std::shared_ptr<const StatsIds>;
 using StatsIdMap        = std::unordered_map<SPtrConstDst, SPtrConstStatsIds, DstHash, DstKeyEqual>;
 
@@ -247,7 +247,7 @@ class PreWarmQueue : public Continuation
 {
 public:
   PreWarmQueue();
-  ~PreWarmQueue();
+  ~PreWarmQueue() override;
 
   // States
   int state_init(int event, void *data);
@@ -322,11 +322,6 @@ public:
   // References
   const PreWarm::ParsedSNIConf &get_parsed_conf() const;
   const PreWarm::StatsIdMap &get_stats_id_map() const;
-
-  ////
-  // Variables
-  //
-  DynamicStats stats;
 
 private:
   void _parse_sni_conf(PreWarm::ParsedSNIConf &parsed_conf, const SNIConfigParams *sni_conf) const;

--- a/proxy/http/PreWarmConfig.cc
+++ b/proxy/http/PreWarmConfig.cc
@@ -31,7 +31,6 @@ PreWarmConfigParams::PreWarmConfigParams()
 {
   // RECU_RESTART_TS
   REC_EstablishStaticConfigByte(enabled, "proxy.config.tunnel.prewarm.enabled");
-  REC_EstablishStaticConfigInteger(max_stats_size, "proxy.config.tunnel.prewarm.max_stats_size");
 
   // RECU_DYNAMIC
   REC_ReadConfigInteger(event_period, "proxy.config.tunnel.prewarm.event_period");

--- a/proxy/http/PreWarmConfig.h
+++ b/proxy/http/PreWarmConfig.h
@@ -31,10 +31,9 @@ struct PreWarmConfigParams : public ConfigInfo {
   PreWarmConfigParams &operator=(const HttpConfigParams &) = delete;
 
   // Config Params
-  int8_t enabled         = 0;
-  int8_t algorithm       = 0;
-  int64_t event_period   = 0;
-  int64_t max_stats_size = 0;
+  int8_t enabled       = 0;
+  int8_t algorithm     = 0;
+  int64_t event_period = 0;
 };
 
 class PreWarmConfig

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -947,8 +947,6 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.tunnel.prewarm.enabled", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.tunnel.prewarm.max_stats_size", RECD_INT, "100", RECU_RESTART_TS, RR_NULL, RECC_INT, "[5-65536]", RECA_NULL}
-  ,
   {RECT_CONFIG, "proxy.config.tunnel.prewarm.event_period", RECD_INT, "1000", RECU_DYNAMIC, RR_NULL, RECC_INT, "[10-3600000]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.tunnel.prewarm.algorithm", RECD_INT, "2", RECU_DYNAMIC, RR_NULL, RECC_INT, "[1-2]", RECA_NULL}

--- a/tests/gold_tests/records/gold/full_records.yaml
+++ b/tests/gold_tests/records/gold/full_records.yaml
@@ -585,7 +585,6 @@ ts:
       algorithm: 2
       enabled: 0
       event_period: 1000
-      max_stats_size: 100
   udp:
     enable_gso: 0
     free_cancelled_pkts_sec: 10

--- a/tests/gold_tests/records/legacy_config/full_records.config
+++ b/tests/gold_tests/records/legacy_config/full_records.config
@@ -305,7 +305,6 @@ CONFIG proxy.config.hostdb.host_file.path STRING nullptr
 CONFIG proxy.config.hostdb.host_file.interval INT 86400
 CONFIG proxy.config.tunnel.activity_check_period INT 0
 CONFIG proxy.config.tunnel.prewarm INT 0
-CONFIG proxy.config.tunnel.prewarm.max_stats_size INT 100
 CONFIG proxy.config.tunnel.prewarm.event_period INT 1000
 CONFIG proxy.config.tunnel.prewarm.algorithm INT 2
 CONFIG proxy.config.http.connect_ports STRING 443


### PR DESCRIPTION
Address #10463. Main change is getting rid of `DynamicStats stats` from `PreWarmManager` and directly accessing metrics via `ts::Metrics`.

~~Requires #10464.~~