### PR TITLE
Refactor and rename restart metrics

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/cache.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/cache.en.rst
@@ -22,11 +22,6 @@
 Cache
 *****
 
-.. ts:stat:: global proxy.node.cache.contents.num_docs integer
-   :ungathered:
-
-   Represents the number of documents currently residing in the cache.
-
 .. ts:stat:: global proxy.process.cache_total_hits counter
 
    Represents the total number of cache lookups which have been satisfied by

--- a/doc/admin-guide/monitoring/statistics/core/general.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/general.en.rst
@@ -26,12 +26,12 @@ General
 
    Human-readable version number string for the currently running |TS| instance.
 
-.. ts:stat:: global proxy.node.config.reconfigure_required integer
+.. ts:stat:: global proxy.process.proxy.reconfigure_required integer
    :type: flag
 
-.. ts:stat:: global proxy.node.config.reconfigure_time integer
+.. ts:stat:: global proxy.process.proxy.reconfigure_time integer
 
-.. ts:stat:: global proxy.node.config.restart_required.proxy integer
+.. ts:stat:: global proxy.process.proxy.restart_required integer
    :type: flag
 
 .. ts:stat:: global proxy.node.hostname_FQ string ats-host.example.com
@@ -42,19 +42,11 @@ General
 
    The hostname only, without domain, for the host on which |TS| is running.
 
-.. ts:stat:: global proxy.node.proxy_running integer
-   :type: flag
-
-   Indicates whether any form of HTTP proxying is currently enabled in the
-   running instance of |TS|.
-
-.. ts:stat:: global proxy.node.restarts.proxy.cache_ready_time integer
+.. ts:stat:: global proxy.process.proxy.cache_ready_time integer
    :type: gauge
    :units: seconds
 
-.. ts:stat:: global proxy.node.restarts.proxy.restart_count integer
-.. ts:stat:: global proxy.node.restarts.proxy.start_time integer
-.. ts:stat:: global proxy.node.restarts.proxy.stop_time integer
+.. ts:stat:: global proxy.process.proxy.start_time integer
 .. ts:stat:: global proxy.process.user_agent_total_bytes integer
 .. ts:stat:: global proxy.process.http.tunnels integer
 .. ts:stat:: global proxy.process.update.fails integer

--- a/doc/admin-guide/monitoring/statistics/core/general.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/general.en.rst
@@ -34,14 +34,6 @@ General
 .. ts:stat:: global proxy.process.proxy.restart_required integer
    :type: flag
 
-.. ts:stat:: global proxy.node.hostname_FQ string ats-host.example.com
-
-   Fully-qualified domain name for the host on which |TS| is running.
-
-.. ts:stat:: global proxy.node.hostname string ats-host
-
-   The hostname only, without domain, for the host on which |TS| is running.
-
 .. ts:stat:: global proxy.process.proxy.cache_ready_time integer
    :type: gauge
    :units: seconds

--- a/doc/admin-guide/monitoring/statistics/core/hierarchical.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/hierarchical.en.rst
@@ -26,10 +26,6 @@ Hierarchical Cache
    :type: counter
    :units: bytes
 
-.. ts:stat:: global proxy.node.http.parent_proxy_total_response_bytes integer
-   :type: counter
-   :units: bytes
-
 .. ts:stat:: global proxy.process.http.current_parent_proxy_connections integer
    :type: counter
 
@@ -47,4 +43,3 @@ Hierarchical Cache
 
 .. ts:stat:: global proxy.process.http.total_parent_proxy_connections integer
    :type: counter
-

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -186,7 +186,7 @@ Display the current value of a configuration record.
    modified since the previous configuration load, this command is a no-op.
 
    The timestamp of the last reconfiguration event (in seconds since epoch) is published in the
-   `proxy.node.config.reconfigure_time` metric.
+   `proxy.process.proxy.reconfigure_time` metric.
 
 .. program:: traffic_ctl config
 .. option:: set RECORD VALUE

--- a/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
@@ -965,7 +965,7 @@ The response will contain the default `success_response`  or a proper rpc error,
 
 Validation:
 
-You can request for the record `proxy.node.config.reconfigure_time` which will be updated with the time of the requested update.
+You can request for the record `proxy.process.proxy.reconfigure_time` which will be updated with the time of the requested update.
 
 
 .. _jsonrpc-api-management-metrics:

--- a/doc/locale/ja/LC_MESSAGES/admin-guide/monitoring/statistics/core/bandwidth.en.po
+++ b/doc/locale/ja/LC_MESSAGES/admin-guide/monitoring/statistics/core/bandwidth.en.po
@@ -38,13 +38,6 @@ msgid ""
 "cache hits, over the previous 10 seconds,"
 msgstr ""
 
-#: ../../admin-guide/monitoring/statistics/core/bandwidth.en.rst:54
-msgid ""
-"The difference of :ts:stat:`proxy.process.user_agent_total_bytes` and :ts:stat:"
-"`proxy.process.origin_server_total_bytes`, divided by :ts:stat:`proxy.node."
-"user_agent_total_bytes`."
-msgstr ""
-
 #: ../../admin-guide/monitoring/statistics/core/bandwidth.en.rst:58
 msgid ""
 "Represents the ratio of bytes served to user agents which were satisfied by "

--- a/doc/locale/ja/LC_MESSAGES/appendices/command-line/traffic_ctl.en.po
+++ b/doc/locale/ja/LC_MESSAGES/appendices/command-line/traffic_ctl.en.po
@@ -185,7 +185,7 @@ msgstr ""
 #: ../../../appendices/command-line/traffic_ctl.en.rst:151
 msgid ""
 "The timestamp of the last reconfiguration event (in seconds since epoch) is "
-"published in the `proxy.node.config.reconfigure_time` metric."
+"published in the `proxy.process.proxy.reconfigure_time` metric."
 msgstr ""
 
 #: ../../../appendices/command-line/traffic_ctl.en.rst:158

--- a/include/api/Metrics.h
+++ b/include/api/Metrics.h
@@ -76,7 +76,7 @@ public:
   {
     _blobs[0] = new MetricStorage();
     ink_release_assert(_blobs[0]);
-    ink_release_assert(0 == newMetric("proxy.node.api.metrics.bad_id")); // Reserve slot 0 for errors, this should always be 0
+    ink_release_assert(0 == newMetric("proxy.process.api.metrics.bad_id")); // Reserve slot 0 for errors, this should always be 0
   }
 
   // Singleton

--- a/include/tscore/TSSystemState.h
+++ b/include/tscore/TSSystemState.h
@@ -57,7 +57,7 @@ public:
     return unlikely(_instance().event_system_shut_down);
   }
 
-  // Keeps track if the server is in draining state, follows the proxy.node.config.draining metric.
+  // Keeps track if the server is in draining state, follows the proxy.process.proxy.draining metric.
   //
   static bool
   is_draining()

--- a/mgmt/rpc/handlers/config/Configuration.cc
+++ b/mgmt/rpc/handlers/config/Configuration.cc
@@ -192,9 +192,9 @@ reload_config(std::string_view const &id, YAML::Node const &params)
   // If any callback was register(TSMgmtUpdateRegister) for config notifications, then it will be eventually notify.
   FileManager::instance().invokeConfigPluginCallbacks();
   // save config time.
-  RecSetRecordInt("proxy.node.config.reconfigure_time", time(nullptr), REC_SOURCE_DEFAULT);
+  RecSetRecordInt("proxy.process.proxy.reconfigure_time", time(nullptr), REC_SOURCE_DEFAULT);
   // TODO: we may not need this any more
-  RecSetRecordInt("proxy.node.config.reconfigure_required", 0, REC_SOURCE_DEFAULT);
+  RecSetRecordInt("proxy.process.proxy.reconfigure_required", 0, REC_SOURCE_DEFAULT);
 
   return resp;
 }

--- a/mgmt/rpc/handlers/server/Server.cc
+++ b/mgmt/rpc/handlers/server/Server.cc
@@ -64,7 +64,7 @@ static bool
 is_server_draining()
 {
   RecInt draining = 0;
-  if (RecGetRecordInt("proxy.node.config.draining", &draining) != REC_ERR_OKAY) {
+  if (RecGetRecordInt("proxy.config.draining", &draining) != REC_ERR_OKAY) {
     return false;
   }
   return draining != 0;
@@ -73,7 +73,7 @@ is_server_draining()
 static void inline set_server_drain(bool drain)
 {
   TSSystemState::drain(drain);
-  RecSetRecordInt("proxy.node.config.draining", TSSystemState::is_draining() ? 1 : 0, REC_SOURCE_DEFAULT);
+  RecSetRecordInt("proxy.config.draining", TSSystemState::is_draining() ? 1 : 0, REC_SOURCE_DEFAULT);
 }
 
 ts::Rv<YAML::Node>

--- a/mgmt/rpc/handlers/server/Server.cc
+++ b/mgmt/rpc/handlers/server/Server.cc
@@ -63,17 +63,20 @@ namespace err = rpc::handlers::errors;
 static bool
 is_server_draining()
 {
-  RecInt draining = 0;
-  if (RecGetRecordInt("proxy.config.draining", &draining) != REC_ERR_OKAY) {
-    return false;
-  }
-  return draining != 0;
+  ts::Metrics &intm    = ts::Metrics::getInstance();
+  static auto drain_id = intm.lookup("proxy.process.proxy.draining");
+
+  return (intm[drain_id] != 0);
 }
 
-static void inline set_server_drain(bool drain)
+static void
+set_server_drain(bool drain)
 {
+  ts::Metrics &intm    = ts::Metrics::getInstance();
+  static auto drain_id = intm.lookup("proxy.process.proxy.draining");
+
   TSSystemState::drain(drain);
-  RecSetRecordInt("proxy.config.draining", TSSystemState::is_draining() ? 1 : 0, REC_SOURCE_DEFAULT);
+  intm[drain_id] = TSSystemState::is_draining() ? 1 : 0;
 }
 
 ts::Rv<YAML::Node>

--- a/plugins/lua/ts_lua_util.cc
+++ b/plugins/lua/ts_lua_util.cc
@@ -213,7 +213,7 @@ ts_lua_script_registered(lua_State *L, char *script)
   // first check the reconfigure_time for the script. if it is not found, then it is new
   // if it matches the current reconfigure_time, then it is loaded already
   // And we return the conf pointer of it. Otherwise it can be loaded again.
-  if (TS_SUCCESS == TSMgmtIntGet("proxy.node.config.reconfigure_time", &curr_time)) {
+  if (TS_SUCCESS == TSMgmtIntGet("proxy.process.proxy.reconfigure_time", &curr_time)) {
     lua_pushliteral(L, "__scriptTime");
     lua_pushstring(L, script);
     lua_concat(L, 2);
@@ -260,7 +260,7 @@ ts_lua_script_register(lua_State *L, char *script, ts_lua_instance_conf *conf)
   TSDebug(TS_LUA_DEBUG_TAG, "[%s] registering script [%s]", __FUNCTION__, script);
 
   // we recorded the script reconfigure_time and its conf pointer in registry
-  if (TS_SUCCESS == TSMgmtIntGet("proxy.node.config.reconfigure_time", &time)) {
+  if (TS_SUCCESS == TSMgmtIntGet("proxy.process.proxy.reconfigure_time", &time)) {
     lua_pushliteral(L, "__scriptTime");
     lua_pushstring(L, script);
     lua_concat(L, 2);

--- a/src/api/test_Metrics.cc
+++ b/src/api/test_Metrics.cc
@@ -34,7 +34,7 @@ TEST_CASE("Metrics", "[libtsapi][Metrics]")
   {
     auto [name, value] = *m.begin();
     REQUIRE(value == 0);
-    REQUIRE(name == "proxy.node.api.metrics.bad_id");
+    REQUIRE(name == "proxy.process.api.metrics.bad_id");
 
     REQUIRE(m.begin() != m.end());
     REQUIRE(++m.begin() == m.end());

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -1240,20 +1240,6 @@ static const RecordElement RecordsConfig[] =
   {RECT_CONFIG, "proxy.config.plugin.load_elevated", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_READ_ONLY}
   ,
 
-  //##############################################################################
-  //#
-  //# Local Manager Specific Records File
-  //#
-  //# <RECORD-TYPE> <NAME> <TYPE> <VALUE (till end of line)>
-  //#
-  //# *NOTE*: All NODE Records must be placed continuously!
-  //#
-  //# Add NODE       Records Here
-  //##############################################################################
-  {RECT_NODE, "proxy.node.hostname_FQ", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
-  {RECT_NODE, "proxy.node.hostname", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
   //#
   //# SSL parent proxying info
   //#

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -1255,17 +1255,6 @@ static const RecordElement RecordsConfig[] =
   {RECT_NODE, "proxy.node.hostname", RECD_STRING, nullptr, RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   //#
-  //# Restart Stats
-  //#
-  {RECT_NODE, "proxy.node.restarts.proxy.start_time", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
-  {RECT_NODE, "proxy.node.restarts.proxy.cache_ready_time", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
-  {RECT_NODE, "proxy.node.restarts.proxy.stop_time", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
-  {RECT_NODE, "proxy.node.restarts.proxy.restart_count", RECD_INT, "0", RECU_NULL, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
-  ,
-  //#
   //# SSL parent proxying info
   //#
   //# Set the value of this variable to 1 if this node

--- a/src/traffic_ctl/CtrlPrinters.cc
+++ b/src/traffic_ctl/CtrlPrinters.cc
@@ -215,13 +215,13 @@ ConfigStatusPrinter::write_output(YAML::Node const &result)
       recordName = recordInfo.name;
       if (recordName == "proxy.process.version.server.long") {
         std::cout << "Version: " << recordInfo.currentValue << "\n";
-      } else if (recordName == "proxy.node.restarts.proxy.start_time") {
+      } else if (recordName == "proxy.process.proxy.start_time") {
         std::cout << swoc::bwprint(text, "{}: {}\n", "Started at", FloatDate(recordInfo.currentValue, "%a %d %b %Y %H:%M:%S"));
-      } else if (recordName == "proxy.node.config.reconfigure_time") {
+      } else if (recordName == "proxy.process.proxy.reconfigure_time") {
         std::cout << swoc::bwprint(text, "{}: {}\n", "Reconfigured at", FloatDate(recordInfo.currentValue, "%a %d %b %Y %H:%M:%S"));
-      } else if (recordName == "proxy.node.config.reconfigure_required") {
+      } else if (recordName == "proxy.process.proxy.reconfigure_required") {
         std::cout << "Reconfigure required: " << ((recordInfo.currentValue == "1") ? "yes" : "no") << "\n";
-      } else if (recordName == "proxy.node.config.restart_required.proxy") {
+      } else if (recordName == "proxy.process.proxy.restart_required") {
         std::cout << "Restart required: " << ((recordInfo.currentValue == "1") ? "yes" : "no") << "\n";
       }
     }

--- a/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
@@ -244,8 +244,8 @@ struct ConfigStatusRequest : shared::rpc::RecordLookupRequest {
   ConfigStatusRequest() : super()
   {
     static const std::array<std::string, 5> statusFieldsNames = {
-      "proxy.process.version.server.long", "proxy.node.restarts.proxy.start_time", "proxy.node.config.reconfigure_time",
-      "proxy.node.config.reconfigure_required", "proxy.node.config.restart_required.proxy"};
+      "proxy.process.version.server.long", "proxy.process.proxy.start_time", "proxy.process.proxy.reconfigure_time",
+      "proxy.process.proxy.reconfigure_required", "proxy.process.proxy.restart_required"};
     for (auto &&recordName : statusFieldsNames) {
       super::emplace_rec(recordName, shared::rpc::NOT_REGEX, shared::rpc::METRIC_REC_TYPES);
     }

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -270,6 +270,9 @@ public:
   int
   periodic(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   {
+    ts::Metrics &intm    = ts::Metrics::getInstance();
+    static auto drain_id = intm.lookup("proxy.process.proxy.draining");
+
     if (signal_received[SIGUSR1]) {
       signal_received[SIGUSR1] = false;
 
@@ -306,10 +309,7 @@ public:
 
       RecInt timeout = 0;
       if (RecGetRecordInt("proxy.config.stop.shutdown_timeout", &timeout) == REC_ERR_OKAY && timeout) {
-        ts::Metrics &intm = ts::Metrics::getInstance();
-        auto id           = intm.lookup("proxy.process.proxy.draining");
-
-        intm[id] = 1;
+        intm[drain_id] = 1;
         TSSystemState::drain(true);
         // Close listening sockets here only if TS is running standalone
         RecInt close_sockets = 0;
@@ -1852,11 +1852,11 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   id       = intm.newMetric("proxy.process.proxy.start_time");
   intm[id] = time(nullptr);
   // These all gets initialied to 0
-  id = intm.newMetric("proxy.process.proxy.reconfigure_required");
-  id = intm.newMetric("proxy.process.proxy.restart_required");
-  id = intm.newMetric("proxy.process.proxy.draining");
+  intm.newMetric("proxy.process.proxy.reconfigure_required");
+  intm.newMetric("proxy.process.proxy.restart_required");
+  intm.newMetric("proxy.process.proxy.draining");
   // This gets updated later (in the callback)
-  id = intm.newMetric("proxy.process.proxy.cache_ready_time");
+  intm.newMetric("proxy.process.proxy.cache_ready_time");
 
   // init huge pages
   int enabled;


### PR DESCRIPTION
Much of this is remnants from when we had traffic_manager. So this PR will remove a few metrics that either makes no sense, or have simply stopped being updated already. A few gets a new name, because we don't track "restarts" any more.