### PR TITLE
Remove REC_ConfigReadCounter

### DIFF
--- a/include/records/I_RecCore.h
+++ b/include/records/I_RecCore.h
@@ -262,7 +262,6 @@ void RecConfigWarnIfUnregistered();
 RecInt REC_ConfigReadInteger(const char *name);
 char *REC_ConfigReadString(const char *name);
 RecFloat REC_ConfigReadFloat(const char *name);
-RecCounter REC_ConfigReadCounter(const char *name);
 
 // MGMT2 Marco's -- converting lmgmt->record_data->readXXX
 RecInt REC_readInteger(const char *name, bool *found, bool lock = true);

--- a/src/records/RecCore.cc
+++ b/src/records/RecCore.cc
@@ -1138,14 +1138,6 @@ REC_ConfigReadFloat(const char *name)
   return t;
 }
 
-RecCounter
-REC_ConfigReadCounter(const char *name)
-{
-  RecCounter t = 0;
-  RecGetRecordCounter(name, &t);
-  return t;
-}
-
 //-------------------------------------------------------------------------
 // Backwards compatibility. TODO: Should remove these.
 //-------------------------------------------------------------------------


### PR DESCRIPTION
This closes #10414.

According to a comments, the function is left for backward compatibility and it should be removed, and it's not used.