### PR TITLE
Allow to bulk allocate span's of Metrics

### DIFF
--- a/include/api/Metrics.h
+++ b/include/api/Metrics.h
@@ -34,6 +34,8 @@
 #include <string>
 #include <string_view>
 
+#include "swoc/MemSpan.h"
+
 #include "tscore/ink_assert.h"
 
 namespace ts
@@ -44,8 +46,9 @@ private:
   using self_type = Metrics;
 
 public:
-  using IntType = std::atomic<int64_t>;
-  using IdType  = int32_t; // Could be a tuple, but one way or another, they have to be combined to an int32_t.
+  using IntType     = std::atomic<int64_t>;
+  using IdType      = int32_t; // Could be a tuple, but one way or another, they have to be combined to an int32_t.
+  using SpanIntType = swoc::MemSpan<IntType>;
 
   static constexpr uint16_t METRICS_MAX_BLOBS = 8192;
   static constexpr uint16_t METRICS_MAX_SIZE  = 2048;                               // For a total of 16M metrics
@@ -86,6 +89,7 @@ public:
   // Yes, we don't return objects here, but rather ID's and atomic's directly. Treat
   // the std::atomic<int64_t> as the underlying class for a single metric, and be happy.
   IdType newMetric(const std::string_view name);
+  SpanIntType newMetricSpan(size_t size, IdType *id = nullptr);
   IdType lookup(const std::string_view name) const;
   IntType *lookup(IdType id, std::string_view *name = nullptr) const;
 
@@ -105,6 +109,8 @@ public:
   {
     return lookup(newMetric(name));
   }
+
+  bool rename(IdType id, const std::string_view name);
 
   IntType &
   operator[](IdType id)

--- a/src/api/test_Metrics.cc
+++ b/src/api/test_Metrics.cc
@@ -63,6 +63,29 @@ TEST_CASE("Metrics", "[libtsapi][Metrics]")
     REQUIRE(m[0].load() == 42);
   }
 
+  SECTION("Span allocation")
+  {
+    ts::Metrics::IdType span_id;
+    auto fooid = m.newMetric("foo"); // To see that span_id gets to 2
+    auto span  = m.newMetricSpan(17, &span_id);
+
+    REQUIRE(span.size() == 17);
+    REQUIRE(fooid == 1);
+    REQUIRE(span_id == 2);
+
+    m.rename(span_id + 0, "span.0");
+    m.rename(span_id + 1, "span.1");
+    m.rename(span_id + 2, "span.2");
+    REQUIRE(m.name(fooid) == "foo");
+    REQUIRE(m.name(span_id + 0) == "span.0");
+    REQUIRE(m.name(span_id + 1) == "span.1");
+    REQUIRE(m.name(span_id + 2) == "span.2");
+    m.rename(fooid, "foo-new");
+    REQUIRE(m.name(fooid) == "foo-new");
+    REQUIRE(m.lookup("foo") == ts::Metrics::NOT_FOUND);
+    REQUIRE(m.lookup("foo-new") == fooid);
+  }
+
   SECTION("lookup")
   {
     auto nm = m.lookupPtr("notametric");


### PR DESCRIPTION
The use case here is that a (modified) Histogram class can actually continue to use a contiguous "span" of Metrics, without changing or affecting the performance of the Histogram class. In addition, this avoids having to copy (periodically, currently every 5s) the Histogram data to the metrics storage.

Co-Author (aka Major Blame): AMC