### PR TITLE
Coverity 1518572: Uninitialized pointer field

### DIFF
--- a/src/traffic_cache_tool/CacheScan.h
+++ b/src/traffic_cache_tool/CacheScan.h
@@ -39,8 +39,8 @@ namespace ct
 {
 class CacheScan
 {
-  Stripe *stripe;
-  url_matcher *u_matcher;
+  Stripe *stripe         = nullptr;
+  url_matcher *u_matcher = nullptr;
 
 public:
   CacheScan(Stripe *str, swoc::file::path const &path) : stripe(str)


### PR DESCRIPTION
Uninitialized pointers in traffic_cache_tool class CacheScan