### PR TITLE
Make traffic_cache_tool fail for directory spans.

### DIFF
--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -701,15 +701,18 @@ Span::load()
   auto fs = swoc::file::status(_path, ec);
 
   if (!swoc::file::is_readable(_path)) {
-    zret = Errata(make_errno_code(EPERM), R"("{}" is not readable.)", _path);
-  } else if (swoc::file::is_char_device(fs) || swoc::file::is_block_device(fs)) {
-    zret = this->loadDevice();
-  } else if (swoc::file::is_dir(fs)) {
-    zret.note("Directory support not yet available");
-  } else {
-    zret = Errata(make_errno_code(EBADF), R"("{}" is not a valid file type)", _path);
+    return Errata(make_errno_code(EPERM), R"("{}" is not readable.)", _path);
   }
-  return zret;
+
+  if (swoc::file::is_char_device(fs) || swoc::file::is_block_device(fs)) {
+    return this->loadDevice();
+  }
+
+  if (swoc::file::is_dir(fs)) {
+    return Errata("Directory support not yet available");
+  }
+
+  return Errata(make_errno_code(EBADF), R"("{}" is not a valid file type)", _path);
 }
 
 Errata


### PR DESCRIPTION
traffic_cache_tool doesn't support specifying the span as a directory, but neither does it fail and report an error. Fix the span loader to report an error in this case, rather than an Errata note, which is ignored.