### PR TITLE
Assigning variables in asserts in the example intercept plugin

### DIFF
--- a/example/plugins/c-api/intercept/intercept.cc
+++ b/example/plugins/c-api/intercept/intercept.cc
@@ -91,8 +91,11 @@ struct InterceptIOChannel {
   read(TSVConn vc, TSCont contp)
   {
     TSReleaseAssert(this->vio == nullptr);
-    TSReleaseAssert((this->iobuf = TSIOBufferCreate()));
-    TSReleaseAssert((this->reader = TSIOBufferReaderAlloc(this->iobuf)));
+
+    this->iobuf = TSIOBufferCreate();
+    TSReleaseAssert(this->iobuf);
+    this->reader = TSIOBufferReaderAlloc(this->iobuf);
+    TSReleaseAssert(this->reader);
 
     this->vio = TSVConnRead(vc, contp, this->iobuf, INT64_MAX);
   }
@@ -101,8 +104,10 @@ struct InterceptIOChannel {
   write(TSVConn vc, TSCont contp)
   {
     TSReleaseAssert(this->vio == nullptr);
-    TSReleaseAssert((this->iobuf = TSIOBufferCreate()));
-    TSReleaseAssert((this->reader = TSIOBufferReaderAlloc(this->iobuf)));
+    this->iobuf = TSIOBufferCreate();
+    TSReleaseAssert(this->iobuf);
+    this->reader = TSIOBufferReaderAlloc(this->iobuf);
+    TSReleaseAssert(this->reader);
 
     this->vio = TSVConnWrite(vc, contp, this->reader, INT64_MAX);
   }
@@ -205,9 +210,9 @@ union argument_type {
 static TSCont
 InterceptContCreate(TSEventFunc hook, TSMutex mutexp, void *data)
 {
-  TSCont contp;
+  TSCont contp = TSContCreate(hook, mutexp);
+  TSReleaseAssert(contp);
 
-  TSReleaseAssert((contp = TSContCreate(hook, mutexp)));
   TSContDataSet(contp, data);
   return contp;
 }


### PR DESCRIPTION
Coverity 1518611: Side effect in assertion
Coverity 1518597: Side effect in assertion
Coverity 1518596: Side effect in assertion
Coverity 1518595: Side effect in assertion
Coverity 1518570: Side effect in assertion

This closes #10333 
This closes #10341
This closes #10342
This closes #10343 
This closes #10362 
