### PR TITLE
Move sandbox path into runtime directory

### DIFF
--- a/tests/gold_tests/jsonrpc/plugins/jsonrpc_plugin_handler_test.cc
+++ b/tests/gold_tests/jsonrpc/plugins/jsonrpc_plugin_handler_test.cc
@@ -163,7 +163,7 @@ CB_handle_rpc_io_call(TSCont contp, TSEvent event, void *data)
 
   // Basic stuffs here.
   // We open the file if exist, we update/add the host in the structure. For simplicity we do not delete anything.
-  fs::path sandbox  = fs::current_path();
+  fs::path sandbox  = fs::current_path() / "runtime";
   fs::path dumpFile = sandbox / "my_test_plugin_dump.yaml";
   bool newFile{false};
   if (!fs::exists(dumpFile)) {


### PR DESCRIPTION
In some autest setups the basic_plugin_handler fails due to not being able to write out its state file.  This PR updates the path to be in the traffic server `runtime` directory which seems to always be writable (for me, so far).

What say you @brbzull0?