### PR TITLE
CID 1513224: Cleanup dl handle while testing a plugin

### DIFF
--- a/proxy/Plugin.cc
+++ b/proxy/Plugin.cc
@@ -114,6 +114,8 @@ plugin_dso_load(const char *path, void *&handle, void *&init, std::string &error
   if (!init) {
     error.assign("unable to find TSPluginInit function in '").append(path).append("': ").append(dlerror());
     Error("%s", error.c_str());
+    dlclose(handle);
+    handle = nullptr;
     return false;
   }
 

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -994,6 +994,11 @@ enum class plugin_type_t {
 
 /** Attempt to load a plugin shared object file.
  *
+ * Note that this function is only used to load plugins for the purpose of
+ * verifying that they are valid plugins. It is not used to load plugins for
+ * normal operation. Any loaded plugin will be closed immediately after loading
+ * it.
+ *
  * @param[in] plugin_type The type of plugin for which to create a PluginInfo.
  * @param[in] plugin_path The path to the plugin's shared object file.
  * @param[out] error Some description of why the plugin failed to load if
@@ -1002,12 +1007,18 @@ enum class plugin_type_t {
  * @return True if the plugin loaded successfully, false otherwise.
  */
 static bool
-load_plugin(plugin_type_t plugin_type, const fs::path &plugin_path, std::string &error)
+try_loading_plugin(plugin_type_t plugin_type, const fs::path &plugin_path, std::string &error)
 {
   switch (plugin_type) {
   case plugin_type_t::GLOBAL: {
-    void *handle, *initptr;
-    return plugin_dso_load(plugin_path.c_str(), handle, initptr, error);
+    void *handle             = nullptr;
+    void *initptr            = nullptr;
+    bool const plugin_loaded = plugin_dso_load(plugin_path.c_str(), handle, initptr, error);
+    if (handle != nullptr) {
+      dlclose(handle);
+      handle = nullptr;
+    }
+    return plugin_loaded;
   }
   case plugin_type_t::REMAP: {
     auto temporary_directory  = fs::temp_directory_path();
@@ -1061,7 +1072,7 @@ verify_plugin_helper(char *args, plugin_type_t plugin_type)
 
   auto ret = CMD_OK;
   std::string error;
-  if (load_plugin(plugin_type, plugin_path, error)) {
+  if (try_loading_plugin(plugin_type, plugin_path, error)) {
     fprintf(stderr, "NOTE: verifying plugin '%s' Success\n", plugin_filename);
   } else {
     fprintf(stderr, "ERROR: verifying plugin '%s' Fail: %s\n", plugin_filename, error.c_str());


### PR DESCRIPTION
traffic_server has a mechanism to test whether a shared object file satisfies some basic symbol requirements of a plugin. This mechanism loaded that shared object file but never closed the resources. This addresses that by calling dlclose if the load is successful.

Fixes: #10020