### PR TITLE
Suppress leak of pcre_jit_stack_alloc for unit tests

### DIFF
--- a/ci/asan_leak_suppression/unit_tests.txt
+++ b/ci/asan_leak_suppression/unit_tests.txt
@@ -4,3 +4,5 @@ leak:libcrypto.so.1.1
 leak:CRYPTO_malloc
 leak:CRYPTO_realloc
 leak:ConsCell
+# PR#10295
+leak:pcre_jit_stack_alloc

--- a/iocore/cache/Makefile.am
+++ b/iocore/cache/Makefile.am
@@ -64,6 +64,7 @@ libinkcache_a_SOURCES += \
 endif
 
 TESTS = $(check_PROGRAMS)
+TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=$(abs_top_srcdir)/ci/asan_leak_suppression/unit_tests.txt
 
 test_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/mgmt/rpc/Makefile.am
+++ b/mgmt/rpc/Makefile.am
@@ -32,6 +32,7 @@ check_PROGRAMS = test_jsonrpc test_jsonrpcserver
 
 
 TESTS = $(check_PROGRAMS)
+TESTS_ENVIRONMENT = LSAN_OPTIONS=suppressions=$(abs_top_srcdir)/ci/asan_leak_suppression/unit_tests.txt
 
 ###########################################################################################
 # Protocol library only, no transport.


### PR DESCRIPTION
Workaround fix for #10295.