### PR TITLE
background fetch plugin docs for origins that can't do range requests

### DIFF
--- a/doc/admin-guide/plugins/background_fetch.en.rst
+++ b/doc/admin-guide/plugins/background_fetch.en.rst
@@ -95,7 +95,19 @@ Dealing with origins that don't support range requests
 The background fetch plugin will not properly work if an origin does
 not support range requests and returns a 200 instead of a 206.
 
-In this case header rewrites can be used to force the plugin to trigger::
+In this case header rewrites can be used to force the background fetch
+to trigger.
+
+given a remap.config line like::
+
+    map <source> <dest> \
+        ... \
+        @plugin=header_rewrite.so @pparam=hdr_rw_prev.config \
+        @plugin=background_fetch.config @pparam=bg_fetch.config \
+        @plugin=header_rewrite.so @pparam=hdr_rw_next.config \
+        ...
+
+hdr_rw_prev.config::
 
     cond %{READ_RESPONSE_HDR_HOOK}
     cond %{CLIENT-HEADER:Range} = "" [NOT]
@@ -103,9 +115,14 @@ In this case header rewrites can be used to force the plugin to trigger::
     set-status 206
     set-header @Was200 true
 
-    cond %{SEND_RESPONSE_HDR_HOOK}
+hdr_rw_next.config::
+
+    cond %{READ_RESPONSE_HDR_HOOK}
     cond %{HEADER:@Was200} = "" [NOT]
     set-status 200
+
+Will cause a 200 parent/origin response from a client range request to trigger
+a background fetch.
 
 Future additions
 ----------------

--- a/doc/admin-guide/plugins/background_fetch.en.rst
+++ b/doc/admin-guide/plugins/background_fetch.en.rst
@@ -89,6 +89,24 @@ below on the remap line::
 
    @plugin=background_fetch.so @pparam=<config-file>
 
+Dealing with origins that don't support range requests
+------------------------------------------------------
+
+The background fetch plugin will not properly work if an origin does
+not support range requests and returns a 200 instead of a 206.
+
+In this case header rewrites can be used to force the plugin to trigger::
+
+    cond %{READ_RESPONSE_HDR_HOOK}
+    cond %{CLIENT-HEADER:Range} = "" [NOT]
+    cond %{STATUS} = 200
+    set-status 206
+    set-header @Was200 true
+
+    cond %{SEND_RESPONSE_HDR_HOOK}
+    cond %{HEADER:@Was200} = "" [NOT]
+    set-status 200
+
 Future additions
 ----------------
 


### PR DESCRIPTION
Add header rewrite example in the docs for how to force bg fetch to trigger in case origins
reply with '200' to a range request.

fixes: #7974 