### PR TITLE
Fix build issue with Ubuntu 20.04 using clang

### DIFF
--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -56,7 +56,7 @@ parse_format(ts::Arguments *args)
   BasePrinter::Options::OutputFormat val{BasePrinter::Options::OutputFormat::NOT_SET};
 
   if (auto data = args->get("format"); data) {
-    StringToOutputFormatMap::const_iterator search = _Fmt_str_to_enum.find({data.value()});
+    StringToOutputFormatMap::const_iterator search = _Fmt_str_to_enum.find(data.value());
     if (search != std::end(_Fmt_str_to_enum)) {
       val = search->second;
     }


### PR DESCRIPTION
```
traffic_ctl/CtrlCommands.cc:59:71: error: no matching member function for call to 'find'
    StringToOutputFormatMap::const_iterator search = _Fmt_str_to_enum.find({data.value()});
                                                     ~~~~~~~~~~~~~~~~~^~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unordered_map.h:924:7: note: candidate function not viable: cannot convert initializer list argument to 'const std::unordered_map<std::basic_string_view<char, std::char_traits<char> >, BasePrinter::Options::OutputFormat, std::hash<std::string_view>, std::equal_to<std::basic_string_view<char, std::char_traits<char> > >, std::allocator<std::pair<const std::basic_string_view<char, std::char_traits<char> >, BasePrinter::Options::OutputFormat> > >::key_type' (aka 'const std::basic_string_view<char, std::char_traits<char> >')
      find(const key_type& __x) const
      ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unordered_map.h:920:7: note: candidate function not viable: 'this' argument has type 'const (anonymous namespace)::StringToOutputFormatMap' (aka 'const unordered_map<basic_string_view<char>, BasePrinter::Options::OutputFormat>'), but method is not marked const
      find(const key_type& __x)
      ^

```