### PR TITLE
Change unable to bind or listen to a fatal error

### DIFF
--- a/iocore/net/Connection.cc
+++ b/iocore/net/Connection.cc
@@ -388,6 +388,6 @@ Lerror:
     fd = NO_FD;
   }
 
-  Error("Could not bind or listen to port %d (error: %d)", ats_ip_port_host_order(&addr), res);
+  Fatal("Could not bind or listen to port %d (error: %d)", ats_ip_port_host_order(&addr), res);
   return res;
 }


### PR DESCRIPTION
I had a test server running on port 8080 for a month and didn't even notice when testing and running ATS because it would start up just find and run on other ports.  Unless you look at the log users wouldn't notice that ATS had an issue not binding or listening to specific ports.  

It is better to fail fast and make sure binding issues are fixed before running ATS in a misconfigured state.