### PR TITLE
Refactors rate_limit plugin with YAML configurations

### DIFF
--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -123,30 +123,33 @@ configuration file. The basic use is as::
 
 
 The YAML configuration can have the following format, where the varies sections
-and nodes are documented below::
-   selector:
-   - sni: test1.example.com
-     limit: 1000
-     queue:
-       size: 1000
-      max-age: 30
-     metrics:
-       tag: example.com
-       prefix: ddos
-     ip-rep: main
-   - sni: test2.example.com
-    limit: 100
+and nodes are documented below.
 
-   ip-rep:
-     - name: main
-       buckets: 10
-       size: 15
-       percentage: 90
-       max-age: 300
-       perma-block:
-         limit: 100
-         threshold: 1
-         max-age: 1800
+   .. code-block:: yaml
+
+      selector:
+         - sni: test1.example.com
+            limit: 1000
+            queue:
+               size: 1000
+               max-age: 30
+            metrics:
+               tag: example.com
+               prefix: ddos
+            ip-rep: main
+         - sni: test2.example.com
+            aliases: [test3.example.com, test4.example.com]
+            limit: 100
+      ip-rep:
+         - name: main
+            buckets: 10
+            size: 15
+            percentage: 90
+            max-age: 300
+            perma-block:
+               limit: 100
+               threshold: 1
+               max-age: 1800
 
 For the top level `selector` node, the following options are available:
 
@@ -157,6 +160,10 @@ For the top level `selector` node, the following options are available:
 .. option:: limit
 
    The maximum number of active client transactions.
+
+.. option:: aliases
+
+      A list of aliases for the SNI, which will also be matched by this rate limiter.
 
 .. option:: ip-rep
 
@@ -179,13 +186,13 @@ For the top level `selector` node, the following options are available:
 
 .. option:: metrics
 
-      This is an optional node, which can be used to configure the metrics for
-      this rate limiter. If not specified, no metrics will be added.
+   This is an optional node, which can be used to configure the metrics for
+   this rate limiter. If not specified, no metrics will be added.
 
-      The metrics node can include a `tag` and a `prefix` option. The tag is
-      default to the SNI, and the prefix is default to ``plugin.rate_limiter``.
+   The metrics node can include a `tag` and a `prefix` option. The tag is
+   default to the SNI, and the prefix is default to ``plugin.rate_limiter``.
 
-The ip-rep node is used to configure the IP reputation system, there can be
+The `ip-rep`` node is used to configure the IP reputation system, there can be
 zero, one or many IP reputation setups. Each setup is configured with a name,
 and the following options:
 

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -193,7 +193,7 @@ For the top level `selector` node, the following options are available:
    default to ``UINT_MAX``, which is essentially unlimited. The max-age is
    default to ``0``, which means no age limit.
 
-   No queue is enable without this configuration directive, but it can also be
+   No queue is enabled without this configuration directive, but it can also be
    disabled explicitly if the size is set to ``0``.
 
 .. option:: metrics

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -137,6 +137,7 @@ and nodes are documented below.
                tag: example.com
                prefix: ddos
             ip-rep: main
+            exclude: internal
          - sni: test2.example.com
             aliases: [test3.example.com, test4.example.com]
             limit: 100
@@ -150,6 +151,12 @@ and nodes are documented below.
                limit: 100
                threshold: 1
                max-age: 1800
+      lists:
+         - name: internal
+            cidr:
+               - 10.0.0.0/8
+               - 192.168.0.0/16
+
 
 For the top level `selector` node, the following options are available:
 
@@ -169,6 +176,11 @@ For the top level `selector` node, the following options are available:
 
       The name of the IP reputation node to use for this rate limiter. If not
       specified, the IP reputation system is not used for this rate limiter.
+
+.. option:: exclude
+
+      A list of IP CIDR ranges to exclude from any rate limiting. Any IP matching
+      this list will not be rate limited, even if the SNI matches.
 
 .. option:: queue
 
@@ -192,9 +204,24 @@ For the top level `selector` node, the following options are available:
    The metrics node can include a `tag` and a `prefix` option. The tag is
    default to the SNI, and the prefix is default to ``plugin.rate_limiter``.
 
+The `lists` node is used to configure IP lists, which can be used to exclude
+certain address ranges from the rate limiting. The following options are used:
+
+.. option:: name
+
+   The name of the IP reputation setup, used to refer to it from the rate limiters.
+
+.. option:: cidr
+
+   A list of CIDR ranges to add to this rule. The format is e.g. `10.0.0.0/8`.
+
 The `ip-rep`` node is used to configure the IP reputation system, there can be
 zero, one or many IP reputation setups. Each setup is configured with a name,
 and the following options:
+
+.. option:: name
+
+   The name of the IP reputation setup, used to refer to it from the rate limiters.
 
 .. option:: buckets
 

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -122,7 +122,7 @@ configuration file. The basic use is as::
     :ts:cv:`proxy.config.http.keep_alive_no_activity_timeout_in`.
 
 
-The YAML configuration can have the following format, where the varies sections
+The YAML configuration can have the following format, where the various sections
 and nodes are documented below.
 
    .. code-block:: yaml
@@ -194,7 +194,7 @@ For the top level `selector` node, the following options are available:
    default to ``0``, which means no age limit.
 
    No queue is enable without this configuration directive, but it can also be
-   disable explicitly if the size is set to ``0``.
+   disabled explicitly if the size is set to ``0``.
 
 .. option:: metrics
 

--- a/plugins/experimental/rate_limit/CMakeLists.txt
+++ b/plugins/experimental/rate_limit/CMakeLists.txt
@@ -15,6 +15,8 @@
 #
 #######################
 
+project(rate_limit)
+
 add_atsplugin(
   rate_limit
   ip_reputation.cc
@@ -24,4 +26,9 @@ add_atsplugin(
   txn_limiter.cc
   utilities.cc
 )
-target_link_libraries(rate_limit PRIVATE OpenSSL::SSL)
+
+target_link_libraries(rate_limit
+    PRIVATE
+        yaml-cpp::yaml-cpp
+        OpenSSL::SSL
+)

--- a/plugins/experimental/rate_limit/CMakeLists.txt
+++ b/plugins/experimental/rate_limit/CMakeLists.txt
@@ -29,6 +29,7 @@ add_atsplugin(
 
 target_link_libraries(rate_limit
     PRIVATE
+        libswoc
         yaml-cpp::yaml-cpp
         OpenSSL::SSL
 )

--- a/plugins/experimental/rate_limit/CMakeLists.txt
+++ b/plugins/experimental/rate_limit/CMakeLists.txt
@@ -25,11 +25,7 @@ add_atsplugin(
   sni_selector.cc
   txn_limiter.cc
   utilities.cc
+  lists.cc
 )
 
-target_link_libraries(rate_limit
-    PRIVATE
-        libswoc
-        yaml-cpp::yaml-cpp
-        OpenSSL::SSL
-)
+target_link_libraries(rate_limit PRIVATE libswoc yaml-cpp::yaml-cpp OpenSSL::SSL)

--- a/plugins/experimental/rate_limit/Makefile.inc
+++ b/plugins/experimental/rate_limit/Makefile.inc
@@ -22,6 +22,7 @@ experimental_rate_limit_rate_limit_la_SOURCES = \
     experimental/rate_limit/sni_limiter.cc \
     experimental/rate_limit/sni_selector.cc \
     experimental/rate_limit/ip_reputation.cc \
+    experimental/rate_limit/lists.cc \
     experimental/rate_limit/utilities.cc
 
 experimental_rate_limit_rate_limit_la_LDFLAGS = \

--- a/plugins/experimental/rate_limit/Makefile.inc
+++ b/plugins/experimental/rate_limit/Makefile.inc
@@ -23,3 +23,8 @@ experimental_rate_limit_rate_limit_la_SOURCES = \
     experimental/rate_limit/sni_selector.cc \
     experimental/rate_limit/ip_reputation.cc \
     experimental/rate_limit/utilities.cc
+
+experimental_rate_limit_rate_limit_la_LDFLAGS = \
+    $(AM_LDFLAGS)
+
+AM_CPPFLAGS += @YAMLCPP_INCLUDES@

--- a/plugins/experimental/rate_limit/ip_reputation.cc
+++ b/plugins/experimental/rate_limit/ip_reputation.cc
@@ -34,12 +34,12 @@ SieveLru::hasher(const sockaddr *sock)
 {
   switch (sock->sa_family) {
   case AF_INET: {
-    const sockaddr_in *sa = reinterpret_cast<const sockaddr_in *>(sock);
+    const auto *sa = reinterpret_cast<const sockaddr_in *>(sock);
 
     return (0xffffffff00000000 | sa->sin_addr.s_addr);
   } break;
   case AF_INET6: {
-    const sockaddr_in6 *sa6 = reinterpret_cast<const sockaddr_in6 *>(sock);
+    const auto *sa6 = reinterpret_cast<const sockaddr_in6 *>(sock);
 
     return (*reinterpret_cast<uint64_t const *>(sa6->sin6_addr.s6_addr) ^
             *reinterpret_cast<uint64_t const *>(sa6->sin6_addr.s6_addr + sizeof(uint64_t)));
@@ -302,8 +302,7 @@ SieveLru::dump()
     long long cnt = 0, sum = 0;
     auto lru = _buckets[i];
 
-    std::cout << std::endl
-              << "Dumping bucket " << i << " (size=" << lru->size() << ", max_size=" << lru->max_size() << ")" << std::endl;
+    std::cout << '\n' << "Dumping bucket " << i << " (size=" << lru->size() << ", max_size=" << lru->max_size() << ")" << '\n';
     for (auto &it : *lru) {
       auto &[key, count, bucket, added] = it;
 
@@ -316,7 +315,7 @@ SieveLru::dump()
 #endif
     }
 
-    std::cout << "\tAverage count=" << (cnt > 0 ? sum / cnt : 0) << std::endl;
+    std::cout << "\tAverage count=" << (cnt > 0 ? sum / cnt : 0) << '\n';
   }
   TSMutexUnlock(_lock);
 }

--- a/plugins/experimental/rate_limit/ip_reputation.cc
+++ b/plugins/experimental/rate_limit/ip_reputation.cc
@@ -78,36 +78,52 @@ SieveLru::hasher(const std::string &ip, u_short family) // Mostly a convenience 
   return 0; // Probably can't happen, but have to return something
 }
 
-// Initialize the Sieve LRU object
-void
-SieveLru::initialize(std::string_view name, uint32_t num_buckets, uint32_t size, uint32_t percentage, std::chrono::seconds max_age)
+bool
+SieveLru::parseYaml(const YAML::Node &node)
 {
-  TSMutexLock(_lock);
-  TSAssert(!_initialized);             // Don't allow it to be initialized more than once!
-  TSReleaseAssert(size > num_buckets); // Otherwise we can't half the bucket sizes
-
-  _name        = name;
-  _num_buckets = num_buckets;
-  _size        = size;
-  _percentage  = percentage;
-  _max_age     = max_age;
-
-  uint32_t cur_size = pow(2, 1 + _size - num_buckets);
-
-  _map.reserve(pow(2, size + 2));     // Allow for all the sieve LRUs, and extra room for the allow list
-  _buckets.reserve(_num_buckets + 2); // Two extra buckets, for the block list and allow list
-
-  // Create the other buckets, in smaller and smaller sizes (power of 2)
-  for (uint32_t i = lastBucket(); i <= entryBucket(); ++i) {
-    _buckets[i]  = new SieveBucket(cur_size);
-    cur_size    *= 2;
+  if (node["buckets"]) {
+    _num_buckets = node["buckets"].as<uint32_t>();
   }
 
-  _buckets[blockBucket()] = new SieveBucket(cur_size / 2); // Block LRU, same size as entry bucket
-  _buckets[allowBucket()] = new SieveBucket(0);            // Allow LRU, this is unlimited
+  if (node["size"]) {
+    _size = node["size"].as<uint32_t>();
+  }
 
-  _initialized = true;
-  TSMutexUnlock(_lock);
+  if (node["percentage"]) {
+    _percentage = node["percentage"].as<uint32_t>();
+  }
+
+  if (node["max_age"]) {
+    _max_age = std::chrono::seconds(node["max_age"].as<uint32_t>());
+  }
+
+  if (node["perma-block"]) {
+    const YAML::Node &perma = node["perma-block"];
+
+    if (perma.IsMap()) {
+      if (perma["limit"]) {
+        _permablock_limit = perma["limit"].as<uint32_t>();
+      }
+
+      if (perma["threshold"]) {
+        _permablock_threshold = perma["threshold"].as<uint32_t>();
+      }
+
+      if (perma["max_age"]) {
+        _permablock_max_age = std::chrono::seconds(perma["max_age"].as<uint32_t>());
+      }
+    } else {
+      TSError("[%s] The perma-block node must be a map", PLUGIN_NAME);
+      return false;
+    }
+  }
+
+  Dbg(dbg_ctl, "Loaded IP-Reputation rule: %s(%u, %u, %u, %lld)", _name.c_str(), _num_buckets, _size, _percentage,
+      _max_age.count());
+  Dbg(dbg_ctl, "\twith perma-block rule: %s(%u, %u, %lld)", _name.c_str(), _permablock_limit, _permablock_threshold,
+      _permablock_max_age.count());
+
+  return true;
 }
 
 // Increment the count for an element (will be created / added if new).
@@ -131,7 +147,8 @@ SieveLru::increment(KeyClass key)
       _map.erase(l_key);
       *last = {key, 1, entryBucket(), SystemClock::now()};
     } else {
-      // Create a new entry, the date is not used now (unless perma blocked), but could be useful for aging out stale elements.
+      // Create a new entry, the date is not used now (unless perma blocked), but could be useful for aging out stale
+      // elements.
       lru->push_front({key, 1, entryBucket(), SystemClock::now()});
     }
     _map[key] = lru->begin();

--- a/plugins/experimental/rate_limit/ip_reputation.cc
+++ b/plugins/experimental/rate_limit/ip_reputation.cc
@@ -130,10 +130,10 @@ SieveLru::parseYaml(const YAML::Node &node)
   }
   _buckets[blockBucket()] = new SieveBucket(cur_size / 2); // Block LRU, same size as entry bucket
 
-  Dbg(dbg_ctl, "Loaded IP-Reputation rule: %s(%u, %u, %u, %lld)", _name.c_str(), _num_buckets, _size, _percentage,
-      _max_age.count());
-  Dbg(dbg_ctl, "\twith perma-block rule: %s(%u, %u, %lld)", _name.c_str(), _permablock_limit, _permablock_threshold,
-      _permablock_max_age.count());
+  Dbg(dbg_ctl, "Loaded IP-Reputation rule: %s(%u, %u, %u, %ld)", _name.c_str(), _num_buckets, _size, _percentage,
+      static_cast<long>(_max_age.count()));
+  Dbg(dbg_ctl, "\twith perma-block rule: %s(%u, %u, %ld)", _name.c_str(), _permablock_limit, _permablock_threshold,
+      static_cast<long>(_permablock_max_age.count()));
 
   return true;
 }

--- a/plugins/experimental/rate_limit/ip_reputation.h
+++ b/plugins/experimental/rate_limit/ip_reputation.h
@@ -31,7 +31,9 @@
 #include <chrono>
 #include <arpa/inet.h>
 
+#include <yaml-cpp/yaml.h>
 #include "ts/ts.h"
+#include "utilities.h"
 
 namespace IpReputation
 {
@@ -86,11 +88,7 @@ class SieveLru
 public:
   SieveLru() = delete;
 
-  SieveLru(std::string_view name, uint32_t num_buckets, uint32_t size, uint32_t percentage, std::chrono::seconds max_age)
-    : _lock(TSMutexCreate())
-  {
-    initialize(name, num_buckets, size, percentage, max_age);
-  }
+  SieveLru(std::string_view name) : _lock(TSMutexCreate()) { _name = name; }
 
   ~SieveLru()
   {
@@ -99,16 +97,7 @@ public:
     }
   }
 
-  void initialize(std::string_view name, uint32_t num_buckets = 10, uint32_t size = 15, uint32_t percentage = 90,
-                  std::chrono::seconds max_age = std::chrono::seconds::zero());
-
-  void
-  initializePerma(uint32_t limit, uint32_t threshold, std::chrono::seconds max_age = std::chrono::seconds::zero())
-  {
-    _permablock_limit     = limit;
-    _permablock_threshold = threshold;
-    _permablock_max_age   = max_age;
-  }
+  bool parseYaml(const YAML::Node &node);
 
   // Return value is the bucket (0 .. num_buckets) that the IP is in, and the
   // current count of "hits". The lookup version is similar, except it doesn't

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -169,7 +169,7 @@ public:
   bool
   full() const
   {
-    return (_size == max_queue);
+    return (_size >= max_queue);
   }
 
   void
@@ -225,9 +225,9 @@ public:
   }
 
   // ToDo: Probably should be made private...
-  std::string name                  = "";         // The name/descr (e.g. SNI name) of this limiter
-  uint32_t limit                    = 100;        // Arbitrary default, probably should be a required config
-  uint32_t max_queue                = UINT32_MAX; // No queue limit, but if set will give an immediate error if at max
+  std::string name                  = "";                                // The name/descr (e.g. SNI name) of this limiter
+  uint32_t limit                    = 100;                               // Arbitrary default, probably should be a required config
+  uint32_t max_queue                = 0;                                 // No queue by default
   std::chrono::milliseconds max_age = std::chrono::milliseconds::zero(); // Max age (ms) in the queue
 
 private:

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <string>
 #include <climits>
+#include <mutex>
 
 #include "tscore/ink_config.h"
 #include "ts/ts.h"
@@ -126,7 +127,7 @@ public:
 
     for (int i = 0; i < RATE_LIMITER_METRIC_MAX; i++) {
       size_t const metricsz = metric_prefix.length() + strlen(suffixes[i]) + 2; // padding for dot+terminator
-      char *const metric    = (char *)TSmalloc(metricsz);
+      char *const metric    = static_cast<char *>(TSmalloc(metricsz));
       snprintf(metric, metricsz, "%s.%s", metric_prefix.data(), suffixes[i]);
 
       _metrics[i] = TS_ERROR;
@@ -244,7 +245,7 @@ public:
   }
 
   const std::string &
-  name()
+  name() const
   {
     return _name;
   }

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -28,7 +28,7 @@
 #include "ts/ts.h"
 #include "utilities.h"
 
-constexpr auto QUEUE_DELAY_TIME = std::chrono::milliseconds{200}; // Examine the queue every 200ms
+constexpr auto QUEUE_DELAY_TIME = std::chrono::milliseconds{300}; // Examine the queue every 300ms
 using QueueTime                 = std::chrono::time_point<std::chrono::system_clock>;
 
 enum { RATE_LIMITER_TYPE_SNI = 0, RATE_LIMITER_TYPE_REMAP, RATE_LIMITER_TYPE_MAX };

--- a/plugins/experimental/rate_limit/lists.cc
+++ b/plugins/experimental/rate_limit/lists.cc
@@ -25,8 +25,8 @@ List::IP::parseYaml(const YAML::Node &node)
   const YAML::Node &cidr = node["cidr"];
 
   if (cidr && cidr.IsSequence()) {
-    for (size_t i = 0; i < cidr.size(); ++i) {
-      std::string str = cidr[i].as<std::string>();
+    for (const auto &i : cidr) {
+      auto str = i.as<std::string>();
 
       Dbg(dbg_ctl, "Adding CIDR %s to List %s", str.c_str(), _name.c_str());
       add(str);

--- a/plugins/experimental/rate_limit/lists.cc
+++ b/plugins/experimental/rate_limit/lists.cc
@@ -15,21 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
 
-#include <string>
-#include <chrono>
+#include "utilities.h"
+#include "lists.h"
 
-#include "ts/ts.h"
-
-constexpr char const PLUGIN_NAME[] = "rate_limit";
-
-void delayHeader(TSHttpTxn txnp, const std::string &header, std::chrono::milliseconds delay);
-void retryAfter(TSHttpTxn txnp, unsigned retry);
-std::string getDescriptionFromUrl(const char *url);
-
-namespace rate_limit_ns
+bool
+List::IP::parseYaml(const YAML::Node &node)
 {
-extern DbgCtl dbg_ctl;
+  const YAML::Node &cidr = node["cidr"];
+
+  if (cidr && cidr.IsSequence()) {
+    for (size_t i = 0; i < cidr.size(); ++i) {
+      std::string str = cidr[i].as<std::string>();
+
+      Dbg(dbg_ctl, "Adding CIDR %s to List %s", str.c_str(), _name.c_str());
+      add(str);
+    }
+  } else {
+    TSError("[%s] No 'cidr' list found in Lists rule %s", PLUGIN_NAME, name().c_str());
+    return false;
+  }
+
+  return true;
 }
-using namespace rate_limit_ns;

--- a/plugins/experimental/rate_limit/lists.h
+++ b/plugins/experimental/rate_limit/lists.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string.h>
+
+#include <swoc/swoc_ip.h>
+#include <yaml-cpp/yaml.h>
+
+#include "ts/ts.h"
+
+// ToDo: Maybe in the future this should be a template class, but for now it's a simple
+// subclass wrapper over swoc::IPRangeSet.
+namespace List
+{
+class IP : public swoc::IPRangeSet
+{
+  using self_type = IP;
+
+public:
+  explicit IP(std::string &name) : _name(name) {}
+
+  IP()                                    = delete;
+  IP(self_type &&)                        = delete;
+  self_type &operator=(const self_type &) = delete;
+  self_type &operator=(self_type &&)      = delete;
+
+  void
+  add(std::string &str)
+  {
+    if (swoc::IPRange r; r.load(str)) {
+      mark(r);
+    } else {
+      TSReleaseAssert("Bad IP range");
+    }
+  }
+
+  bool parseYaml(const YAML::Node &node);
+
+  const std::string &
+  name() const
+  {
+    return _name;
+  }
+
+private:
+  std::string _name;
+
+}; // class IpList
+
+} // namespace List

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -55,16 +55,7 @@ TSPluginInit(int argc, const char *argv[])
   if (argc == 2) {
     // Make sure we start the global SNI selector before we do anything else.
     // This selector can be replaced later, during configuration reload.
-    SniSelector::startup();
-
-    auto selector = SniSelector::instance(); // Assure that we don't delete this until config reload
-
-    if (selector->yamlParser(argv[1])) {
-      selector->setupQueueCont(); // Start the queue processing continuation if needed
-    } else {
-      selector->release();
-      TSFatal("[%s] Failed to parse YAML file '%s'", PLUGIN_NAME, argv[1]);
-    }
+    SniSelector::startup(argv[1]);
   } else {
     TSError("[%s] Usage: rate_limit.so <config.yaml>", PLUGIN_NAME);
   }

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -63,7 +63,7 @@ TSPluginInit(int argc, const char *argv[])
       selector->setupQueueCont(); // Start the queue processing continuation if needed
     } else {
       selector->release();
-      TSFatal("[%s] Failed to parse YAML file '%s'", PLUGIN_NAME, argv[0]);
+      TSFatal("[%s] Failed to parse YAML file '%s'", PLUGIN_NAME, argv[1]);
     }
   } else {
     TSError("[%s] Usage: rate_limit.so <config.yaml>", PLUGIN_NAME);
@@ -90,7 +90,7 @@ TSRemapDeleteInstance(void *ih)
 TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
-  TxnRateLimiter *limiter = new TxnRateLimiter();
+  auto *limiter = new TxnRateLimiter();
 
   // set the name based on the pristine remap URL prior to advancing the pointer below
   limiter->setName(getDescriptionFromUrl(argv[0]));
@@ -116,7 +116,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 TSRemapStatus
 TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 {
-  TxnRateLimiter *limiter = static_cast<TxnRateLimiter *>(ih);
+  auto *limiter = static_cast<TxnRateLimiter *>(ih);
 
   if (limiter) {
     if (!limiter->reserve()) {

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -93,7 +93,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
   TxnRateLimiter *limiter = new TxnRateLimiter();
 
   // set the name based on the pristine remap URL prior to advancing the pointer below
-  limiter->name = getDescriptionFromUrl(argv[0]);
+  limiter->setName(getDescriptionFromUrl(argv[0]));
 
   // argv contains the "to" and "from" URLs. Skip the first so that the
   // second one poses as the program name.
@@ -104,8 +104,8 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
   limiter->initialize(argc, const_cast<const char **>(argv));
   *ih = static_cast<void *>(limiter);
 
-  Dbg(dbg_ctl, "Added active_in limiter rule (limit=%u, queue=%u, max-age=%ldms, error=%u)", limiter->limit, limiter->max_queue,
-      static_cast<long>(limiter->max_age.count()), limiter->error);
+  Dbg(dbg_ctl, "Added active_in limiter rule (limit=%u, queue=%u, max-age=%ldms, error=%u)", limiter->limit(), limiter->max_queue(),
+      static_cast<long>(limiter->max_age().count()), limiter->error());
 
   return TS_SUCCESS;
 }
@@ -120,9 +120,9 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   if (limiter) {
     if (!limiter->reserve()) {
-      if (!limiter->max_queue || limiter->full()) {
+      if (!limiter->max_queue() || limiter->full()) {
         // We are running at limit, and the queue has reached max capacity, give back an error and be done.
-        TSHttpTxnStatusSet(txnp, static_cast<TSHttpStatus>(limiter->error));
+        TSHttpTxnStatusSet(txnp, static_cast<TSHttpStatus>(limiter->error()));
         limiter->setupTxnCont(txnp, TS_HTTP_SEND_RESPONSE_HDR_HOOK);
         Dbg(dbg_ctl, "Rejecting request, we're at capacity and queue is full");
       } else {

--- a/plugins/experimental/rate_limit/sni_limiter.cc
+++ b/plugins/experimental/rate_limit/sni_limiter.cc
@@ -33,7 +33,7 @@ SniRateLimiter::parseYaml(const YAML::Node &node)
   super_type::parseYaml(node);
 
   if (node["ip-rep"]) {
-    std::string ipr_name = node["ip-rep"].as<std::string>();
+    auto ipr_name = node["ip-rep"].as<std::string>();
 
     if (!(_iprep = _selector->findIpRep(ipr_name))) {
       TSError("[%s] IP Reputation name (%s) not found for SNI=%s", PLUGIN_NAME, ipr_name.c_str(), name().c_str());
@@ -43,7 +43,7 @@ SniRateLimiter::parseYaml(const YAML::Node &node)
 
   // ToDo: It's unfortunate, but the selector holds the lists (and the ip-reps), so the lookup has to happen here ... :/.
   if (node["exclude"]) {
-    std::string excl_name = node["exclude"].as<std::string>();
+    auto excl_name = node["exclude"].as<std::string>();
 
     if (!(_exclude = _selector->findList(excl_name))) {
       TSError("[%s] IP Reputation name (%s) not found for SNI=%s", PLUGIN_NAME, excl_name.c_str(), name().c_str());
@@ -63,7 +63,7 @@ SniRateLimiter::parseYaml(const YAML::Node &node)
 int
 sni_limit_cont(TSCont contp, TSEvent event, void *edata)
 {
-  TSVConn vc = static_cast<TSVConn>(edata);
+  auto vc = static_cast<TSVConn>(edata);
 
   switch (event) {
   case TS_EVENT_SSL_CLIENT_HELLO: {
@@ -156,7 +156,7 @@ sni_limit_cont(TSCont contp, TSEvent event, void *edata)
   } break;
 
   case TS_EVENT_VCONN_CLOSE: {
-    SniRateLimiter *limiter = static_cast<SniRateLimiter *>(TSUserArgGet(vc, gVCIdx));
+    auto *limiter = static_cast<SniRateLimiter *>(TSUserArgGet(vc, gVCIdx));
 
     if (limiter) {
       TSUserArgSet(vc, gVCIdx, nullptr);

--- a/plugins/experimental/rate_limit/sni_limiter.cc
+++ b/plugins/experimental/rate_limit/sni_limiter.cc
@@ -30,11 +30,7 @@ int gVCIdx = -1;
 bool
 SniRateLimiter::parseYaml(const YAML::Node &node)
 {
-  if (node["limit"]) {
-    _limit = node["limit"].as<uint32_t>();
-  } else {
-    // ToDo: Should we require the limit ?
-  }
+  super_type::parseYaml(node);
 
   if (node["ip-rep"]) {
     std::string ipr_name = node["ip-rep"].as<std::string>();
@@ -44,28 +40,6 @@ SniRateLimiter::parseYaml(const YAML::Node &node)
       return false;
     }
   }
-
-  const YAML::Node &queue = node["queue"];
-
-  // If enabled, we default to UINT32_MAX, but the object default is still 0 (no queue)
-  if (queue) {
-    _max_queue = queue["size"] ? queue["size"].as<uint32_t>() : UINT32_MAX;
-
-    if (queue["max_age"]) {
-      _max_age = std::chrono::seconds(queue["max_age"].as<uint32_t>());
-    }
-
-    const YAML::Node &metrics = node["metrics"];
-
-    if (metrics) {
-      std::string prefix = metrics["prefix"] ? metrics["prefix"].as<std::string>() : RATE_LIMITER_METRIC_PREFIX;
-      std::string tag    = metrics["tag"] ? metrics["tag"].as<std::string>() : name();
-
-      Dbg(dbg_ctl, "Metrics for selector rule: %s(%s, %s)", name().c_str(), prefix.c_str(), tag.c_str());
-      initializeMetrics(RATE_LIMITER_TYPE_SNI, prefix, tag);
-    }
-  }
-
   Dbg(dbg_ctl, "Loaded selector rule: %s(%u, %u, %ld)", name().c_str(), limit(), max_queue(), static_cast<long>(max_age().count()));
 
   return true;

--- a/plugins/experimental/rate_limit/sni_limiter.cc
+++ b/plugins/experimental/rate_limit/sni_limiter.cc
@@ -25,8 +25,7 @@
 #include "sni_limiter.h"
 
 // This holds the VC user arg index for the SNI limiters.
-int gVCIdx                = -1;
-SniSelector *gSNISelector = nullptr;
+int gVCIdx = -1;
 
 bool
 SniRateLimiter::parseYaml(const YAML::Node &node)
@@ -86,8 +85,8 @@ sni_limit_cont(TSCont contp, TSEvent event, void *edata)
   case TS_EVENT_SSL_CLIENT_HELLO: {
     int len;
     const char *server_name = TSVConnSslSniGet(vc, &len);
-    std::string_view sni_name(server_name, len);
-    SniSelector *selector   = gSNISelector->acquire();
+    const std::string sni_name(server_name, len);
+    SniSelector *selector   = SniSelector::instance();
     SniRateLimiter *limiter = selector->findSNI(sni_name);
 
     if (limiter) {
@@ -96,7 +95,7 @@ sni_limit_cont(TSCont contp, TSEvent event, void *edata)
         const sockaddr *sock = TSNetVConnRemoteAddrGet(vc);
         int32_t pressure     = limiter->pressure();
 
-        Dbg(dbg_ctl, "CLIENT_HELLO on %.*s, pressure=%d", static_cast<int>(sni_name.length()), sni_name.data(), pressure);
+        Dbg(dbg_ctl, "CLIENT_HELLO on %s, pressure=%d", sni_name.c_str(), pressure);
 
         // Dbg(dbg_ctl, "IP Reputation: pressure is currently %d", pressure);
 

--- a/plugins/experimental/rate_limit/sni_limiter.h
+++ b/plugins/experimental/rate_limit/sni_limiter.h
@@ -30,9 +30,15 @@ class SniSelector;
 //
 class SniRateLimiter : public RateLimiter<TSVConn>
 {
+  using self_type = SniRateLimiter;
+
 public:
-  SniRateLimiter() = delete;
-  SniRateLimiter(std::string_view sni, SniSelector *sel) : selector(sel) { name = sni; }
+  SniRateLimiter()                        = delete;
+  SniRateLimiter(self_type &&)            = delete;
+  self_type &operator=(const self_type &) = delete;
+  self_type &operator=(self_type &&)      = delete;
+
+  SniRateLimiter(std::string &sni, SniSelector *sel) : selector(sel) { name = sni; }
 
   bool parseYaml(const YAML::Node &node);
 

--- a/plugins/experimental/rate_limit/sni_limiter.h
+++ b/plugins/experimental/rate_limit/sni_limiter.h
@@ -20,6 +20,7 @@
 #include "limiter.h"
 #include "ip_reputation.h"
 #include "ts/ts.h"
+#include <yaml-cpp/yaml.h>
 
 int sni_limit_cont(TSCont contp, TSEvent event, void *edata);
 
@@ -30,7 +31,8 @@ class SniSelector;
 //
 class SniRateLimiter : public RateLimiter<TSVConn>
 {
-  using self_type = SniRateLimiter;
+  using super_type = RateLimiter<TSVConn>;
+  using self_type  = SniRateLimiter;
 
 public:
   SniRateLimiter()                        = delete;

--- a/plugins/experimental/rate_limit/sni_limiter.h
+++ b/plugins/experimental/rate_limit/sni_limiter.h
@@ -38,7 +38,7 @@ public:
   self_type &operator=(const self_type &) = delete;
   self_type &operator=(self_type &&)      = delete;
 
-  SniRateLimiter(std::string &sni, SniSelector *sel) : selector(sel) { name = sni; }
+  SniRateLimiter(std::string &sni, SniSelector *sel) : _selector(sel) { setName(sni); }
 
   bool parseYaml(const YAML::Node &node);
 
@@ -47,18 +47,31 @@ public:
   int32_t
   pressure() const
   {
-    int32_t p = ((active() / static_cast<float>(limit) * 100) - iprep->percentage()) / (100 - iprep->percentage()) *
-                (iprep->numBuckets() + 1);
+    int32_t p = ((active() / static_cast<float>(limit()) * 100) - _iprep->percentage()) / (100 - _iprep->percentage()) *
+                (_iprep->numBuckets() + 1);
 
-    return (p >= static_cast<int32_t>(iprep->numBuckets()) ? iprep->numBuckets() : p);
+    return (p >= static_cast<int32_t>(_iprep->numBuckets()) ? _iprep->numBuckets() : p);
   }
 
   void
   addIPReputation(IpReputation::SieveLru *iprep)
   {
-    this->iprep = iprep;
+    this->_iprep = iprep;
   }
 
-  SniSelector *selector         = nullptr; // The selector we belong to
-  IpReputation::SieveLru *iprep = nullptr; // IP reputation for this SNI (if any)
+  IpReputation::SieveLru *
+  iprep() const
+  {
+    return _iprep;
+  }
+
+  SniSelector *
+  selector() const
+  {
+    return _selector;
+  }
+
+private:
+  SniSelector *_selector         = nullptr; // The selector we belong to
+  IpReputation::SieveLru *_iprep = nullptr; // IP reputation for this SNI (if any)
 };

--- a/plugins/experimental/rate_limit/sni_limiter.h
+++ b/plugins/experimental/rate_limit/sni_limiter.h
@@ -44,7 +44,7 @@ public:
 
   SniRateLimiter(std::string &sni, SniSelector *sel) : _selector(sel) { setName(sni); }
 
-  bool parseYaml(const YAML::Node &node);
+  bool parseYaml(const YAML::Node &node) override;
 
   // Calculate the pressure, which is either a negative number (ignore), or a number 0-<buckets>.
   // 0 == block only perma-blocks.

--- a/plugins/experimental/rate_limit/sni_limiter.h
+++ b/plugins/experimental/rate_limit/sni_limiter.h
@@ -17,10 +17,12 @@
  */
 #pragma once
 
-#include "limiter.h"
-#include "ip_reputation.h"
 #include "ts/ts.h"
 #include <yaml-cpp/yaml.h>
+
+#include "limiter.h"
+#include "ip_reputation.h"
+#include "lists.h"
 
 int sni_limit_cont(TSCont contp, TSEvent event, void *edata);
 
@@ -67,6 +69,12 @@ public:
     return _iprep;
   }
 
+  List::IP *
+  exclude() const
+  {
+    return _exclude;
+  }
+
   SniSelector *
   selector() const
   {
@@ -76,4 +84,5 @@ public:
 private:
   SniSelector *_selector         = nullptr; // The selector we belong to
   IpReputation::SieveLru *_iprep = nullptr; // IP reputation for this SNI (if any)
+  List::IP *_exclude             = nullptr; // The list of IPs to exclude (if any). ToDo: belongs in limiter.h :-/.
 };

--- a/plugins/experimental/rate_limit/sni_limiter.h
+++ b/plugins/experimental/rate_limit/sni_limiter.h
@@ -34,6 +34,8 @@ public:
   SniRateLimiter() = delete;
   SniRateLimiter(std::string_view sni, SniSelector *sel) : selector(sel) { name = sni; }
 
+  bool parseYaml(const YAML::Node &node);
+
   // Calculate the pressure, which is either a negative number (ignore), or a number 0-<buckets>.
   // 0 == block only perma-blocks.
   int32_t

--- a/plugins/experimental/rate_limit/sni_selector.cc
+++ b/plugins/experimental/rate_limit/sni_selector.cc
@@ -283,5 +283,7 @@ SniSelector::startup()
   auto config_cont = TSContCreate(sni_config_cont, TSMutexCreate());
 
   TSReleaseAssert(config_cont);
-  TSContScheduleEveryOnPool(config_cont, std::chrono::milliseconds{10000}.count(), TS_THREAD_POOL_TASK);
+  // ToDo: Should we make schedule reloads configurable?
+  // TSContScheduleEveryOnPool(config_cont, std::chrono::milliseconds{10000}.count(), TS_THREAD_POOL_TASK);
+  TSMgmtUpdateRegister(config_cont, PLUGIN_NAME);
 }

--- a/plugins/experimental/rate_limit/sni_selector.cc
+++ b/plugins/experimental/rate_limit/sni_selector.cc
@@ -95,7 +95,7 @@ SniSelector::yamlParser(std::string yaml_file)
         auto limiter = new SniRateLimiter(name, this);
 
         if (limiter->parseYaml(sni)) {
-          if (name == "*") {
+          if (name == "*" || name == "default") {
             _default = limiter;
           } else {
             addLimiter(limiter);
@@ -197,7 +197,7 @@ sni_queue_cont(TSCont cont, TSEvent event, void *edata)
       }
 
       // Kill any queued VCs if they are too old
-      if (limiter->size() > 0 && limiter->max_age > std::chrono::milliseconds::zero()) {
+      if (limiter->size() > 0 && limiter->max_age() > std::chrono::milliseconds::zero()) {
         now = std::chrono::system_clock::now(); // Update the "now", for some extra accuracy
 
         while (limiter->size() > 0 && limiter->hasOldEntity(now)) {

--- a/plugins/experimental/rate_limit/sni_selector.cc
+++ b/plugins/experimental/rate_limit/sni_selector.cc
@@ -95,7 +95,11 @@ SniSelector::yamlParser(std::string yaml_file)
         auto limiter = new SniRateLimiter(name, this);
 
         if (limiter->parseYaml(sni)) {
-          addLimiter(limiter);
+          if (name == "*") {
+            _default = limiter;
+          } else {
+            addLimiter(limiter);
+          }
 
           // Add aliases, if any
           const YAML::Node &aliases = sni["aliases"];

--- a/plugins/experimental/rate_limit/sni_selector.h
+++ b/plugins/experimental/rate_limit/sni_selector.h
@@ -25,14 +25,50 @@
 #include "ts/ts.h"
 #include "utilities.h"
 #include "sni_limiter.h"
+#include "ip_reputation.h"
+
+// This is the list of things (CIDR's) to exclude from blocking etc.
+// ToDo: This has to be finished
+class ListType
+{
+  const std::string_view
+  name() const
+  {
+    return _name;
+  }
+
+  std::string _name; // Name of the list
+};
 
 ///////////////////////////////////////////////////////////////////////////////
-// SNI based limiter selector
+// SNI based limiter selector, this will have one single instance globally.
 //
 class SniSelector
 {
 public:
-  using Limiters = std::unordered_map<std::string_view, SniRateLimiter *>;
+  using Limiters      = std::unordered_map<std::string_view, SniRateLimiter *>;
+  using Lists         = std::vector<ListType *>;
+  using IPReputations = std::vector<IpReputation::SieveLru *>;
+
+  SniSelector()          = default;
+  virtual ~SniSelector() = default; // ToDo: This has to clean stuff up
+
+  bool yamlParser(const std::string yaml_file);
+
+  SniSelector *
+  acquire()
+  {
+    ++_leases;
+    return this;
+  }
+
+  void
+  release()
+  {
+    if (0 == --_leases) {
+      delete this;
+    }
+  }
 
   Limiters &
   limiters()
@@ -40,16 +76,30 @@ public:
     return _limiters;
   }
 
-  size_t factory(const char *sni_list, int argc, const char *argv[]);
+  void
+  addIPReputation(IpReputation::SieveLru *iprep)
+  {
+    _reputations.emplace_back(iprep);
+  }
+
+  void
+  addLimiter(SniRateLimiter *limiter)
+  {
+    _needs_queue_cont = (limiter->max_queue > 0);
+    _limiters.emplace(limiter->name, limiter);
+  }
   void setupQueueCont();
 
-  SniRateLimiter *find(std::string_view sni);
-  bool insert(std::string_view sni, SniRateLimiter *limiter);
-  bool erase(std::string_view sni);
+  IpReputation::SieveLru *findIpRep(std::string_view name);
+  SniRateLimiter *findSNI(std::string_view sni);
 
 private:
+  std::string _yaml_file;
   bool _needs_queue_cont = false;
-  TSCont _queue_cont     = nullptr; // Continuation processing the queue periodically
-  TSAction _action       = nullptr; // The action associated with the queue continuation, needed to shut it down
-  Limiters _limiters;
+  TSCont _queue_cont     = nullptr;  // Continuation processing the queue periodically
+  TSAction _action       = nullptr;  // The action associated with the queue continuation, needed to shut it down
+  Limiters _limiters;                // The SNI limiters
+  IPReputations _reputations;        // IP-Reputation rules
+  Lists _lists;                      // Exclude lists (things not to block)
+  std::atomic<uint32_t> _leases = 0; // Number of leases we have on the current selector
 };

--- a/plugins/experimental/rate_limit/sni_selector.h
+++ b/plugins/experimental/rate_limit/sni_selector.h
@@ -134,8 +134,8 @@ public:
   void
   addLimiter(SniRateLimiter *limiter)
   {
-    _needs_queue_cont = (limiter->max_queue > 0);
-    _limiters.emplace(limiter->name, std::forward_as_tuple(true, limiter));
+    _needs_queue_cont = (limiter->max_queue() > 0);
+    _limiters.emplace(limiter->name(), std::forward_as_tuple(true, limiter));
   }
 
   void

--- a/plugins/experimental/rate_limit/sni_selector.h
+++ b/plugins/experimental/rate_limit/sni_selector.h
@@ -60,6 +60,7 @@ public:
       delete iprep;
     }
 
+    delete _default;
     for (auto &limiter : _limiters) {
       auto &[owner, ptr] = limiter.second;
 
@@ -109,7 +110,7 @@ public:
   {
     auto iter = _limiters.find(sni);
 
-    return ((iter != _limiters.end()) ? std::get<1>(iter->second) : nullptr);
+    return ((iter != _limiters.end()) ? std::get<1>(iter->second) : _default);
   }
 
   const std::string &
@@ -153,11 +154,12 @@ private:
   std::string _yaml_file;
   std::filesystem::file_time_type _yaml_last_write; // Last time the yaml file was written to
   bool _needs_queue_cont = false;
-  TSCont _queue_cont     = nullptr;  // Continuation processing the queue periodically
-  TSAction _queue_action = nullptr;  // The action associated with the queue continuation, needed to shut it down
-  Limiters _limiters;                // The SNI limiters
-  IPReputations _reputations;        // IP-Reputation rules
-  std::atomic<uint32_t> _leases = 0; // Number of leases we have on the current selector, start with one
+  TSCont _queue_cont     = nullptr;   // Continuation processing the queue periodically
+  TSAction _queue_action = nullptr;   // The action associated with the queue continuation, needed to shut it down
+  Limiters _limiters;                 // The SNI limiters
+  SniRateLimiter *_default = nullptr; // Default limiter, if any
+  IPReputations _reputations;         // IP-Reputation rules
+  std::atomic<uint32_t> _leases = 0;  // Number of leases we have on the current selector, start with one
 
   static std::atomic<self_type *> _instance; // Holds the singleton instance, initialized in the .cc file
 };

--- a/plugins/experimental/rate_limit/sni_selector.h
+++ b/plugins/experimental/rate_limit/sni_selector.h
@@ -182,7 +182,7 @@ public:
   }
 
   void setupQueueCont();
-  bool yamlParser(const std::string yaml_file);
+  bool yamlParser(const std::string &yaml_file);
 
   static void startup();
 

--- a/plugins/experimental/rate_limit/sni_selector.h
+++ b/plugins/experimental/rate_limit/sni_selector.h
@@ -21,7 +21,6 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <filesystem>
 #include <atomic>
 
 #include "ts/ts.h"
@@ -138,12 +137,6 @@ public:
     return _yaml_file;
   }
 
-  std::filesystem::file_time_type
-  yamlLastWrite() const
-  {
-    return _yaml_last_write;
-  }
-
   void
   addIPReputation(IpReputation::SieveLru *iprep)
   {
@@ -184,11 +177,10 @@ public:
   void setupQueueCont();
   bool yamlParser(const std::string &yaml_file);
 
-  static void startup();
+  static void startup(const std::string &yaml_file);
 
 private:
   std::string _yaml_file;
-  std::filesystem::file_time_type _yaml_last_write; // Last time the yaml file was written to
   bool _needs_queue_cont = false;
   TSCont _queue_cont     = nullptr;   // Continuation processing the queue periodically
   TSAction _queue_action = nullptr;   // The action associated with the queue continuation, needed to shut it down

--- a/plugins/experimental/rate_limit/txn_limiter.cc
+++ b/plugins/experimental/rate_limit/txn_limiter.cc
@@ -28,7 +28,7 @@
 static int
 txn_limit_cont(TSCont cont, TSEvent event, void *edata)
 {
-  TxnRateLimiter *limiter = static_cast<TxnRateLimiter *>(TSContDataGet(cont));
+  auto *limiter = static_cast<TxnRateLimiter *>(TSContDataGet(cont));
 
   switch (event) {
   case TS_EVENT_HTTP_TXN_CLOSE:
@@ -63,8 +63,8 @@ txn_limit_cont(TSCont cont, TSEvent event, void *edata)
 static int
 txn_queue_cont(TSCont cont, TSEvent event, void *edata)
 {
-  TxnRateLimiter *limiter = static_cast<TxnRateLimiter *>(TSContDataGet(cont));
-  QueueTime now           = std::chrono::system_clock::now(); // Only do this once per "loop"
+  auto *limiter = static_cast<TxnRateLimiter *>(TSContDataGet(cont));
+  QueueTime now = std::chrono::system_clock::now(); // Only do this once per "loop"
 
   // Try to enable some queued txns (if any) if there are slots available
   while (limiter->size() > 0 && limiter->reserve()) {

--- a/plugins/experimental/rate_limit/txn_limiter.cc
+++ b/plugins/experimental/rate_limit/txn_limiter.cc
@@ -45,7 +45,7 @@ txn_limit_cont(TSCont cont, TSEvent event, void *edata)
     break;
 
   case TS_EVENT_HTTP_SEND_RESPONSE_HDR: // This is only applicable when we set an error in remap
-    retryAfter(static_cast<TSHttpTxn>(edata), limiter->retry);
+    retryAfter(static_cast<TSHttpTxn>(edata), limiter->retry());
     TSContDestroy(cont); // We are done with this continuation now
     TSHttpTxnReenable(static_cast<TSHttpTxn>(edata), TS_EVENT_HTTP_CONTINUE);
     limiter->incrementMetric(RATE_LIMITER_METRIC_REJECTED);
@@ -71,7 +71,7 @@ txn_queue_cont(TSCont cont, TSEvent event, void *edata)
     auto [txnp, contp, start_time]  = limiter->pop();
     std::chrono::milliseconds delay = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time);
 
-    delayHeader(txnp, limiter->header, delay);
+    delayHeader(txnp, limiter->header(), delay);
     Dbg(dbg_ctl, "Enabling queued txn after %ldms", static_cast<long>(delay.count()));
     // Since this was a delayed transaction, we need to add the TXN_CLOSE hook to free the slot when done
     TSHttpTxnHookAdd(txnp, TS_HTTP_TXN_CLOSE_HOOK, contp);
@@ -80,7 +80,7 @@ txn_queue_cont(TSCont cont, TSEvent event, void *edata)
   }
 
   // Kill any queued txns if they are too old
-  if (limiter->size() > 0 && limiter->max_age > std::chrono::milliseconds::zero()) {
+  if (limiter->size() > 0 && limiter->max_age() > std::chrono::milliseconds::zero()) {
     now = std::chrono::system_clock::now(); // Update the "now", for some extra accuracy
 
     while (limiter->size() > 0 && limiter->hasOldEntity(now)) {
@@ -88,9 +88,9 @@ txn_queue_cont(TSCont cont, TSEvent event, void *edata)
       auto [txnp, contp, start_time] = limiter->pop();
       std::chrono::milliseconds age  = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time);
 
-      delayHeader(txnp, limiter->header, age);
+      delayHeader(txnp, limiter->header(), age);
       Dbg(dbg_ctl, "Queued TXN is too old (%ldms), erroring out", static_cast<long>(age.count()));
-      TSHttpTxnStatusSet(txnp, static_cast<TSHttpStatus>(limiter->error));
+      TSHttpTxnStatusSet(txnp, static_cast<TSHttpStatus>(limiter->error()));
       TSHttpTxnHookAdd(txnp, TS_HTTP_SEND_RESPONSE_HDR_HOOK, contp);
       TSHttpTxnReenable(txnp, TS_EVENT_HTTP_ERROR);
       limiter->incrementMetric(RATE_LIMITER_METRIC_EXPIRED);
@@ -127,22 +127,22 @@ TxnRateLimiter::initialize(int argc, const char *argv[])
 
     switch (opt) {
     case 'l':
-      this->limit = strtol(optarg, nullptr, 10);
+      this->_limit = strtol(optarg, nullptr, 10);
       break;
     case 'q':
-      this->max_queue = strtol(optarg, nullptr, 10);
+      this->_max_queue = strtol(optarg, nullptr, 10);
       break;
     case 'e':
-      this->error = strtol(optarg, nullptr, 10);
+      this->_error = strtol(optarg, nullptr, 10);
       break;
     case 'r':
-      this->retry = strtol(optarg, nullptr, 10);
+      this->_retry = strtol(optarg, nullptr, 10);
       break;
     case 'm':
-      this->max_age = std::chrono::milliseconds(strtol(optarg, nullptr, 10));
+      this->_max_age = std::chrono::milliseconds(strtol(optarg, nullptr, 10));
       break;
     case 'h':
-      this->header = optarg;
+      this->_header = optarg;
       break;
     case 'p':
       prefix = optarg;
@@ -156,7 +156,7 @@ TxnRateLimiter::initialize(int argc, const char *argv[])
     }
   }
 
-  if (this->max_queue > 0) {
+  if (this->max_queue() > 0) {
     _queue_cont = TSContCreate(txn_queue_cont, TSMutexCreate());
     TSReleaseAssert(_queue_cont);
     TSContDataSet(_queue_cont, this);

--- a/plugins/experimental/rate_limit/txn_limiter.h
+++ b/plugins/experimental/rate_limit/txn_limiter.h
@@ -39,11 +39,29 @@ public:
   void setupTxnCont(TSHttpTxn txnp, TSHttpHookID hook);
   bool initialize(int argc, const char *argv[]);
 
-  std::string header = "";  // Header to put the latency metrics in, e.g. @RateLimit-Delay
-  unsigned error     = 429; // Error code when we decide not to allow a txn to be processed (e.g. queue full)
-  unsigned retry     = 0;   // If > 0, we will also send a Retry-After: header with this retry value
+  const std::string &
+  header() const
+  {
+    return _header;
+  }
+
+  unsigned
+  error() const
+  {
+    return _error;
+  }
+
+  unsigned
+  retry() const
+  {
+    return _retry;
+  }
 
 private:
+  std::string _header = "";  // Header to put the latency metrics in, e.g. @RateLimit-Delay
+  unsigned _error     = 429; // Error code when we decide not to allow a txn to be processed (e.g. queue full)
+  unsigned _retry     = 0;   // If > 0, we will also send a Retry-After: header with this retry value
+
   TSCont _queue_cont = nullptr; // Continuation processing the queue periodically
   TSAction _action   = nullptr; // The action associated with the queue continuation, needed to shut it down
 };

--- a/plugins/experimental/rate_limit/utilities.cc
+++ b/plugins/experimental/rate_limit/utilities.cc
@@ -31,7 +31,7 @@ DbgCtl dbg_ctl{PLUGIN_NAME};
 // for logging, and other types of metrics.
 //
 void
-delayHeader(TSHttpTxn txnp, std::string &header, std::chrono::milliseconds delay)
+delayHeader(TSHttpTxn txnp, const std::string &header, std::chrono::milliseconds delay)
 {
   if (header.size() > 0) {
     TSMLoc hdr_loc   = nullptr;

--- a/plugins/experimental/rate_limit/utilities.h
+++ b/plugins/experimental/rate_limit/utilities.h
@@ -23,7 +23,7 @@
 
 constexpr char const PLUGIN_NAME[] = "rate_limit";
 
-void delayHeader(TSHttpTxn txnp, std::string &header, std::chrono::milliseconds delay);
+void delayHeader(TSHttpTxn txnp, const std::string &header, std::chrono::milliseconds delay);
 void retryAfter(TSHttpTxn txnp, unsigned retry);
 std::string getDescriptionFromUrl(const char *url);
 

--- a/plugins/experimental/rate_limit/utilities.h
+++ b/plugins/experimental/rate_limit/utilities.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <string>
-#include <string_view>
 #include <chrono>
 #include <openssl/ssl.h>
 


### PR DESCRIPTION
Besides majorly refactoring a lot of the global plugin code, this PR makes the following changes:

* YAML configuration
* Reloadable configurations (even as a global)
* SNI aliases (one rate limiter can apply to many SNIs)
* The IP reputation objects are now shareable for many SNIs. This means an attacker can circumvent the reputation by spreading the DDoS traffic across many SNIs.
