### PR TITLE
Make build_h3_tools.sh more reliable

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -32,7 +32,7 @@ OPENSSL_BRANCH=${OPENSSL_BRANCH:-"openssl-3.1.2+quic"}
 
 # Set these, if desired, to change these to your preferred installation
 # directory
-BASE=${BASE:-"/opt"}
+BASE=${BASE:-"/opt/ats_h3_tools"}
 OPENSSL_BASE=${OPENSSL_BASE:-"${BASE}/openssl-quic"}
 OPENSSL_PREFIX=${OPENSSL_PREFIX:-"${OPENSSL_BASE}-${OPENSSL_BRANCH}"}
 MAKE="make"
@@ -136,6 +136,7 @@ cmake \
 cmake --build build -j ${num_threads}
 sudo cmake --install build
 sudo chmod -R a+rX ${BASE}
+cd ..
 
 # Build quiche
 # Steps borrowed from: https://github.com/apache/trafficserver-ci/blob/main/docker/rockylinux8/Dockerfile


### PR DESCRIPTION
Libraries can't be built correctly when running `build_h3_tools.sh`, had the the following error messages on two boxes (rhel7 and rhel8).
```
chmod: changing permissions of '/opt/sentinelone/rpm_mount': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/.dbenv.lock': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Packages': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Conflictname': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Name': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Basenames': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Group': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Requirename': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Providename': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Obsoletename': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Triggername': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Dirnames': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Installtid': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Sigmd5': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Sha1header': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Filetriggername': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Transfiletriggername': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Recommendname': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Suggestname': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Supplementname': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/Enhancename': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/.rpm.lock': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/__db.001': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/__db.002': Read-only file system
chmod: changing permissions of '/opt/sentinelone/rpm_mount/__db.003': Read-only file system
```