### PR TITLE
lua plugin: update CMakeLists.txt for ts_lua_vconn.cc

### DIFF
--- a/plugins/lua/CMakeLists.txt
+++ b/plugins/lua/CMakeLists.txt
@@ -23,6 +23,7 @@ add_atsplugin(tslua
     ts_lua_client_response.cc
     ts_lua_context.cc
     ts_lua_hook.cc
+    ts_lua_vconn.cc
     ts_lua_http.cc
     ts_lua_http_intercept.cc
     ts_lua_log.cc


### PR DESCRIPTION
Updating plugins/lua/CMakeLists.txt to build ts_lua_vconn.cc. Otherwise the plugin fails to find the symbols defined in there when the plugin is run.