### PR TITLE
Fix tunnel_transform.cc build for cmake

### DIFF
--- a/tests/tools/plugins/CMakeLists.txt
+++ b/tests/tools/plugins/CMakeLists.txt
@@ -39,6 +39,7 @@ add_autest_plugin(test_log_interface test_log_interface.cc)
 add_autest_plugin(user_args user_args.cc)
 add_autest_plugin(async_engine async_engine.c)
 add_autest_plugin(hook_tunnel_plugin hook_tunnel_plugin.cc)
+add_autest_plugin(tunnel_transform tunnel_transform.cc)
 
 target_link_libraries(continuations_verify PRIVATE OpenSSL::SSL)
 target_link_libraries(ssl_client_verify_test PRIVATE OpenSSL::SSL)


### PR DESCRIPTION
This updates the tests/tools/plugins/CMakeLists.txt for the new tunnel_transform.cc plugin.