### PR TITLE
Honor BUILD_SHARED_LIBS for tscore.

### DIFF
--- a/plugins/esi/common/CMakeLists.txt
+++ b/plugins/esi/common/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 #######################
 
-add_library(esi-common DocNode.cc gzip.cc Utils.cc)
+add_library(esi-common STATIC DocNode.cc gzip.cc Utils.cc)
 target_link_libraries(esi-common PRIVATE ZLIB::ZLIB libswoc)
 target_include_directories(esi-common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(esi-common PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/plugins/esi/fetcher/CMakeLists.txt
+++ b/plugins/esi/fetcher/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 #######################
 
-add_library(fetcher HttpDataFetcherImpl.cc)
+add_library(fetcher STATIC HttpDataFetcherImpl.cc)
 target_link_libraries(fetcher PUBLIC esi-common)
 target_include_directories(fetcher PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(fetcher PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/plugins/esi/lib/CMakeLists.txt
+++ b/plugins/esi/lib/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 #######################
 
-add_library(esicore
+add_library(esicore STATIC
         EsiGunzip.cc
         EsiGzip.cc
         EsiParser.cc

--- a/plugins/esi/test/CMakeLists.txt
+++ b/plugins/esi/test/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 #######################
 
-add_library(esitest
+add_library(esitest STATIC
     HandlerMap.cc
     StubIncludeHandler.cc
     TestHandlerManager.cc

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -29,7 +29,7 @@ add_custom_command(
 
 add_custom_target(ParseRules ALL DEPENDS ParseRulesCType ParseRulesCTypeToUpper ParseRulesCTypeToLower)
 
-add_library(tscore STATIC
+add_library(tscore
         AcidPtr.cc
         AcidPtr.cc
         Arena.cc
@@ -119,6 +119,8 @@ target_link_libraries(tscore
         PCRE::PCRE
         libswoc
         yaml-cpp::yaml-cpp
+    PRIVATE
+        resolv
 )
 
 if(TS_USE_POSIX_CAP)


### PR DESCRIPTION
This change will build `tscore` as a shared library if `BUILD_SHARED_LIBS` is set to `ON`.  By default this will be built statically.  We can add more libraries to honor this settings, but libraries cannot be shared if they have circular deps(pretty much every other library) so we'll have to work through that if we want to expand this.

