### PR TITLE
Fix typo in block_errors documentation

### DIFF
--- a/doc/admin-guide/plugins/block_errors.en.rst
+++ b/doc/admin-guide/plugins/block_errors.en.rst
@@ -59,7 +59,7 @@ The plugin can be configured at run time using the `traffic_ctl` command.  The f
 - ``block_errors.error_limit``: Set the error limit.  Takes a single argument, the number of errors allowed before blocking the client.
 - ``block_errors.timeout``: Set the block timeout.  Takes a single argument, the number of minutes to block the client.
 - ``block_errors.shutdown``: Set the shutdown mode.  Takes a single argument, 0 to downgrade to HTTP/1.1, 1 to close the connection.
-- ``block_errors.enable``: Enable or disable the plugin.  Takes a single argument, 0 to disable, 1 to enable.
+- ``block_errors.enabled``: Enable or disable the plugin.  Takes a single argument, 0 to disable, 1 to enable.
 
 Example Run Time Configuration
 ==============================
@@ -70,4 +70,4 @@ Example Run Time Configuration
 
     traffic_ctl plugin msg block_errors.shutdown 1
 
-    traffic_ctl plugin msg block_errors.enable 1
+    traffic_ctl plugin msg block_errors.enabled 1


### PR DESCRIPTION
https://github.com/apache/trafficserver/blob/6c03b168ae244db87c2bb32090671301d378ea08/plugins/experimental/block_errors/block_errors.cc#L48