### PR TITLE
Remove unused http headers from Cache.cc

### DIFF
--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -30,9 +30,6 @@
 #include "tscore/I_Layout.h"
 #include "tscore/Filenames.h"
 
-#include "HttpTransactCache.h"
-#include "HttpSM.h"
-#include "HttpCacheSM.h"
 #include "api/InkAPIInternal.h"
 
 #include "tscore/hugepages.h"


### PR DESCRIPTION
While examining the dependency structure I came across this. Those includes have been there for a very long time and are no longer needed.