### PR TITLE
Add QUICSupport as a NetVC service

### DIFF
--- a/iocore/net/CMakeLists.txt
+++ b/iocore/net/CMakeLists.txt
@@ -88,6 +88,7 @@ if(TS_USE_QUIC)
             QUICNetVConnection_quiche.cc
             QUICNextProtocolAccept_quiche.cc
             QUICPacketHandler_quiche.cc
+            QUICSupport.cc
     )
 
     target_link_libraries(inknet

--- a/iocore/net/I_NetVConnection.h
+++ b/iocore/net/I_NetVConnection.h
@@ -530,6 +530,7 @@ protected:
     TLS_SNI,
     TLS_SessionResumption,
     TLS_Tunnel,
+    QUIC,
     N_SERVICES,
   };
 
@@ -685,4 +686,18 @@ inline void
 NetVConnection::_set_service(TLSTunnelSupport *instance)
 {
   this->_set_service(NetVConnection::Service::TLS_Tunnel, instance);
+}
+
+class QUICSupport;
+template <>
+inline QUICSupport *
+NetVConnection::get_service() const
+{
+  return static_cast<QUICSupport *>(this->_get_service(NetVConnection::Service::QUIC));
+}
+template <>
+inline void
+NetVConnection::_set_service(QUICSupport *instance)
+{
+  this->_set_service(NetVConnection::Service::QUIC, instance);
 }

--- a/iocore/net/Makefile.am
+++ b/iocore/net/Makefile.am
@@ -263,7 +263,8 @@ libinknet_a_SOURCES += \
 	QUICNetProcessor_quiche.cc \
 	QUICNetVConnection_quiche.cc \
 	QUICNextProtocolAccept_quiche.cc \
-	QUICPacketHandler_quiche.cc
+	QUICPacketHandler_quiche.cc \
+	QUICSupport.cc
 endif
 
 if BUILD_TESTS

--- a/iocore/net/P_QUICNetVConnection_quiche.h
+++ b/iocore/net/P_QUICNetVConnection_quiche.h
@@ -42,6 +42,7 @@
 #include "TLSSessionResumptionSupport.h"
 #include "TLSSNISupport.h"
 #include "TLSCertSwitchSupport.h"
+#include "QUICSupport.h"
 #include "tscore/ink_apidefs.h"
 #include "tscore/List.h"
 
@@ -65,7 +66,8 @@ class QUICNetVConnection : public UnixNetVConnection,
                            public TLSSNISupport,
                            public TLSSessionResumptionSupport,
                            public TLSCertSwitchSupport,
-                           public TLSBasicSupport
+                           public TLSBasicSupport,
+                           public QUICSupport
 {
   using super = UnixNetVConnection; ///< Parent type.
 
@@ -136,6 +138,9 @@ public:
   // QUICConnection (QUICFrameHandler)
   std::vector<QUICFrameType> interests() override;
   QUICConnectionErrorUPtr handle_frame(QUICEncryptionLevel level, const QUICFrame &frame) override;
+
+  // QUICSupport
+  QUICConnection *get_quic_connection() override;
 
   // QUICNetVConnection
   int in_closed_queue = 0;

--- a/iocore/net/QUICNetVConnection_quiche.cc
+++ b/iocore/net/QUICNetVConnection_quiche.cc
@@ -527,6 +527,7 @@ QUICNetVConnection::_bindSSLObject()
   TLSSessionResumptionSupport::bind(this->_ssl, this);
   TLSSNISupport::bind(this->_ssl, this);
   TLSCertSwitchSupport::bind(this->_ssl, this);
+  QUICSupport::bind(this->_ssl, this);
 }
 
 void
@@ -537,6 +538,7 @@ QUICNetVConnection::_unbindSSLObject()
   TLSSessionResumptionSupport::unbind(this->_ssl);
   TLSSNISupport::unbind(this->_ssl);
   TLSCertSwitchSupport::unbind(this->_ssl);
+  QUICSupport::unbind(this->_ssl);
 }
 
 void
@@ -732,6 +734,12 @@ bool
 QUICNetVConnection::support_sni() const
 {
   return true;
+}
+
+QUICConnection *
+QUICNetVConnection::get_quic_connection()
+{
+  return static_cast<QUICConnection *>(this);
 }
 
 SSL *

--- a/iocore/net/QUICSupport.cc
+++ b/iocore/net/QUICSupport.cc
@@ -1,0 +1,59 @@
+/** @file
+
+  TLSSBasicSupport.cc provides implementations for
+  QUICSupport methods
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "QUICSupport.h"
+
+int QUICSupport::_ex_data_index = -1;
+
+void
+QUICSupport::initialize()
+{
+  ink_assert(_ex_data_index == -1);
+  if (_ex_data_index == -1) {
+    _ex_data_index = SSL_get_ex_new_index(0, (void *)"QUICSupport index", nullptr, nullptr, nullptr);
+  }
+}
+
+QUICSupport *
+QUICSupport::getInstance(SSL *ssl)
+{
+  return static_cast<QUICSupport *>(SSL_get_ex_data(ssl, _ex_data_index));
+}
+
+void
+QUICSupport::bind(SSL *ssl, QUICSupport *srs)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, srs);
+}
+
+void
+QUICSupport::unbind(SSL *ssl)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, nullptr);
+}
+
+void
+QUICSupport::clear()
+{
+}

--- a/iocore/net/QUICSupport.h
+++ b/iocore/net/QUICSupport.h
@@ -1,0 +1,47 @@
+/** @file
+
+  QUICSupport
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <openssl/ssl.h>
+
+#include "quic/QUICConnection.h"
+
+class QUICSupport
+{
+public:
+  virtual ~QUICSupport() = default;
+
+  static void initialize();
+  static QUICSupport *getInstance(SSL *ssl);
+  static void bind(SSL *ssl, QUICSupport *srs);
+  static void unbind(SSL *ssl);
+
+  virtual QUICConnection *get_quic_connection() = 0;
+
+protected:
+  void clear();
+
+private:
+  static int _ex_data_index;
+};

--- a/iocore/net/SNIActionPerformer.cc
+++ b/iocore/net/SNIActionPerformer.cc
@@ -41,7 +41,7 @@ ControlQUIC::SNIAction(SSL &ssl, const Context &ctx) const
   }
 
   // This action is only available for QUIC connections
-  if (dynamic_cast<QUICNetVConnection *>(SSLNetVCAccess(&ssl)) == nullptr) {
+  if (QUICSupport::getInstance(&ssl) == nullptr) {
     return SSL_TLSEXT_ERR_OK;
   }
 

--- a/proxy/http3/Http09App.cc
+++ b/proxy/http3/Http09App.cc
@@ -27,7 +27,7 @@
 
 #include "P_Net.h"
 #include "P_VConnection.h"
-#include "P_QUICNetVConnection.h"
+#include "QUICStreamManager.h"
 #include "QUICDebugNames.h"
 #include "QUICStreamVCAdapter.h"
 
@@ -37,8 +37,9 @@
 static constexpr char debug_tag[]   = "quic_simple_app";
 static constexpr char debug_tag_v[] = "v_quic_simple_app";
 
-Http09App::Http09App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options)
-  : QUICApplication(client_vc)
+Http09App::Http09App(NetVConnection *client_vc, QUICConnection *qc, IpAllow::ACL &&session_acl,
+                     const HttpSessionAccept::Options &options)
+  : QUICApplication(qc)
 {
   this->_ssn                 = new Http09Session(client_vc);
   this->_ssn->acl            = std::move(session_acl);

--- a/proxy/http3/Http09App.h
+++ b/proxy/http3/Http09App.h
@@ -30,7 +30,6 @@
 #include "QUICApplication.h"
 #include "QUICStreamVCAdapter.h"
 
-class QUICNetVConnection;
 class Http09Session;
 
 /**
@@ -42,7 +41,7 @@ class Http09Session;
 class Http09App : public QUICApplication
 {
 public:
-  Http09App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options);
+  Http09App(NetVConnection *client_vc, QUICConnection *qc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options);
   ~Http09App();
 
   void on_new_stream(QUICStream &stream) override;

--- a/proxy/http3/Http3App.cc
+++ b/proxy/http3/Http3App.cc
@@ -29,7 +29,7 @@
 
 #include "P_Net.h"
 #include "P_VConnection.h"
-#include "P_QUICNetVConnection.h"
+#include "QUICStreamManager.h"
 #include "QUICStreamVCAdapter.h"
 
 #include "Http3.h"
@@ -43,8 +43,9 @@
 static constexpr char debug_tag[]   = "http3";
 static constexpr char debug_tag_v[] = "v_http3";
 
-Http3App::Http3App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options)
-  : QUICApplication(client_vc)
+Http3App::Http3App(NetVConnection *client_vc, QUICConnection *qc, IpAllow::ACL &&session_acl,
+                   const HttpSessionAccept::Options &options)
+  : QUICApplication(qc)
 {
   this->_ssn                 = new Http3Session(client_vc);
   this->_ssn->acl            = std::move(session_acl);

--- a/proxy/http3/Http3App.h
+++ b/proxy/http3/Http3App.h
@@ -38,7 +38,6 @@
 #include "Http3FrameGenerator.h"
 #include "Http3FrameHandler.h"
 
-class QUICNetVConnection;
 class Http3Session;
 
 /**
@@ -48,7 +47,7 @@ class Http3Session;
 class Http3App : public QUICApplication
 {
 public:
-  Http3App(QUICNetVConnection *client_vc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options);
+  Http3App(NetVConnection *client_vc, QUICConnection *qc, IpAllow::ACL &&session_acl, const HttpSessionAccept::Options &options);
   virtual ~Http3App();
 
   void on_new_stream(QUICStream &stream) override;

--- a/proxy/http3/Http3Transaction.cc
+++ b/proxy/http3/Http3Transaction.cc
@@ -22,7 +22,7 @@
  */
 
 #include "Http3Transaction.h"
-#include "P_QUICNetVConnection.h"
+#include "QUICSupport.h"
 
 #include "QUICDebugNames.h"
 
@@ -33,14 +33,14 @@
 #include "Http3DataFramer.h"
 #include "HttpSM.h"
 
-#define Http3TransDebug(fmt, ...)                                                                                            \
-  Debug("http3_trans", "[%s] [%" PRIx32 "] " fmt,                                                                            \
-        static_cast<QUICConnection *>(reinterpret_cast<QUICNetVConnection *>(this->_proxy_ssn->get_netvc()))->cids().data(), \
+#define NetVC2QUICCon(netvc) netvc->get_service<QUICSupport>()->get_quic_connection()
+
+#define Http3TransDebug(fmt, ...)                                                                              \
+  Debug("http3_trans", "[%s] [%" PRIx32 "] " fmt, NetVC2QUICCon(this->_proxy_ssn->get_netvc())->cids().data(), \
         this->get_transaction_id(), ##__VA_ARGS__)
 
-#define Http3TransVDebug(fmt, ...)                                                                                           \
-  Debug("v_http3_trans", "[%s] [%" PRIx32 "] " fmt,                                                                          \
-        static_cast<QUICConnection *>(reinterpret_cast<QUICNetVConnection *>(this->_proxy_ssn->get_netvc()))->cids().data(), \
+#define Http3TransVDebug(fmt, ...)                                                                               \
+  Debug("v_http3_trans", "[%s] [%" PRIx32 "] " fmt, NetVC2QUICCon(this->_proxy_ssn->get_netvc())->cids().data(), \
         this->get_transaction_id(), ##__VA_ARGS__)
 
 // static void


### PR DESCRIPTION
Trying to catch the trend. This removes `#include <P_QUICNetVConnection.h>` from `proxy/`, and use more abstract `QUICSupport.h` instead.