### PR TITLE
sslhdr library needs public ssl

### DIFF
--- a/plugins/experimental/sslheaders/CMakeLists.txt
+++ b/plugins/experimental/sslheaders/CMakeLists.txt
@@ -16,7 +16,7 @@
 #######################
 
 add_library(sslhdr STATIC expand.cc util.cc)
-target_link_libraries(sslhdr PRIVATE OpenSSL::SSL)
+target_link_libraries(sslhdr PUBLIC OpenSSL::SSL)
 set_target_properties(sslhdr PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_TESTING)

--- a/plugins/experimental/sslheaders/CMakeLists.txt
+++ b/plugins/experimental/sslheaders/CMakeLists.txt
@@ -16,14 +16,14 @@
 #######################
 
 add_library(sslhdr STATIC expand.cc util.cc)
-target_link_libraries(sslhdr PUBLIC OpenSSL::SSL)
+target_link_libraries(sslhdr PRIVATE OpenSSL::SSL)
 set_target_properties(sslhdr PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_TESTING)
   add_executable(test_sslhdr unit_tests/unit_test_main.cc unit_tests/test_sslheaders.cc)
-  target_link_libraries(test_sslhdr PRIVATE sslhdr catch2::catch2)
+  target_link_libraries(test_sslhdr PRIVATE sslhdr catch2::catch2 OpenSSL::SSL)
 endif()
 
 
 add_atsplugin(sslheaders sslheaders.cc)
-target_link_libraries(sslheaders PRIVATE sslhdr)
+target_link_libraries(sslheaders PRIVATE sslhdr OpenSSL::SSL)


### PR DESCRIPTION
This fixes some cases where the test for the sslheaders plugin can't find openssl headers.