### PR TITLE
Fixed logically dead code

### DIFF
--- a/plugins/experimental/access_control/access_control.cc
+++ b/plugins/experimental/access_control/access_control.cc
@@ -200,7 +200,7 @@ KvpAccessToken::parse(const StringView token)
       return _state = INVALID_SYNTAX;
     }
     StringView key   = kvp.substr(0, equalsign);
-    StringView value = equalsign != kvp.npos ? kvp.substr(equalsign + 1) : "";
+    StringView value = kvp.substr(equalsign + 1);
 
     DEBUG_OUT("kvp:'" << kvp << "', key:'" << key << "', value:'" << value << "'");
 


### PR DESCRIPTION
CID 1508856: Logically dead code #10432

In `access_control.cc`:

```cpp
197    size_t equalsign = kvp.find(_tokenConfig.kvDelimiter);
   	cond_cannot_single: Condition 18446744073709551615UL == equalsign, taking false branch. Now the value of equalsign cannot be equal to -1.
198    if (kvp.npos == equalsign) {
199      ERROR_OUT("invalid key-value-pair, missing key-value delimiter");
200      return _state = INVALID_SYNTAX;
201    }
202    StringView key   = kvp.substr(0, equalsign);
   	cannot_single: At condition equalsign != 18446744073709551615UL, the value of equalsign cannot be equal to -1.
   	dead_error_condition: The condition equalsign != 18446744073709551615UL must be true.

CID 1508856 (#1 of 1): Logically dead code (DEADCODE)
dead_error_line: Execution cannot reach this statement: <temporary>.basic_string_vi....
203    StringView value = equalsign != kvp.npos ? kvp.substr(equalsign + 1) : "";
