### PR TITLE
Convert ENABLE_POSIX_CAP to auto option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ auto_option(MIMALLOC
     DEFAULT OFF
     PACKAGE_DEPENDS mimalloc
 )
+auto_option(POSIX_CAP
+  FEATURE_VAR TS_USE_POSIX_CAP
+  PACKAGE_DEPENDS cap
+  HEADER_DEPENDS "sys/prctl.h"
+)
 auto_option(LUAJIT PACKAGE_DEPENDS LuaJIT)
 auto_option(UNWIND FEATURE_VAR TS_USE_REMOTE_UNWINDING PACKAGE_DEPENDS unwind)
 
@@ -210,20 +215,11 @@ if(brotli_FOUND)
     set(HAVE_BROTLI_ENCODE_H TRUE)
 endif()
 
-if(ENABLE_POSIX_CAP)
-    find_package(cap REQUIRED)
-    set(TS_USE_POSIX_CAP ${cap_FOUND})
-    find_path(PRCTL_HEADER NAMES sys/prctl.h)
-    # just making sure
-    if(NOT PRCTL_HEADER)
-        message(FATAL_ERROR "Have cap but sys/prctl.h not found.")
-    endif()
+if(TS_USE_POSIX_CAP)
+    # These headers must have been found for capabilites to be enabled.
+    set(HAVE_SYS_CAPABILITY_H TRUE)
     set(HAVE_SYS_PRCTL_H TRUE)
-    unset(PRCTL_HEADER)
-else()
-    find_package(cap QUIET)
 endif()
-set(HAVE_SYS_CAPABILITY_H ${cap_FOUND})
 
 find_package(LibLZMA)
 if(LibLZMA_FOUND)

--- a/cmake/AutoOptionHelpers.cmake
+++ b/cmake/AutoOptionHelpers.cmake
@@ -15,6 +15,8 @@
 #
 #######################
 
+include(CheckIncludeFile)
+
 set(GLOBAL_AUTO_OPTION_VARS "")
 
 function(_REGISTER_AUTO_OPTION _NAME _FEATURE_VAR _DESCRIPTION _DEFAULT)
@@ -43,6 +45,16 @@ macro(_CHECK_PACKAGE_DEPENDS _OPTION_VAR _PACKAGE_DEPENDS _FEATURE_VAR)
   foreach(PACKAGE_NAME ${_PACKAGE_DEPENDS})
     find_package(${PACKAGE_NAME} ${STRICTNESS})
     if(NOT ${PACKAGE_NAME}_FOUND)
+      set(${_FEATURE_VAR} FALSE)
+      break()
+    endif()
+  endforeach()
+endmacro()
+
+macro(_CHECK_HEADER_DEPENDS _OPTION_VAR _HEADER_DEPENDS _FEATURE_VAR)
+  foreach(HEADER_NAME ${_HEADER_DEPENDS})
+    check_include_file(${HEADER_NAME} HEADER_FOUND)
+    if(NOT HEADER_FOUND)
       set(${_FEATURE_VAR} FALSE)
       break()
     endif()
@@ -88,7 +100,7 @@ macro(auto_option _FEATURE_NAME)
   cmake_parse_arguments(ARG
     ""
     "DESCRIPTION;DEFAULT;FEATURE_VAR"
-    "PACKAGE_DEPENDS"
+    "PACKAGE_DEPENDS;HEADER_DEPENDS"
     ${ARGN}
   )
 
@@ -114,6 +126,7 @@ macro(auto_option _FEATURE_NAME)
   if(${${OPTION_VAR}} MATCHES "(ON)|(AUTO)|(TRUE)|(1)")
     set(${FEATURE_VAR} TRUE)
     _check_package_depends(${OPTION_VAR} "${ARG_PACKAGE_DEPENDS}" ${FEATURE_VAR})
+    _check_header_depends(${OPTION_VAR} "${ARG_HEADER_DEPENDS}" ${FEATURE_VAR})
   else()
     set(${FEATURE_VAR} FALSE)
   endif()


### PR DESCRIPTION
The capability library is not available by default even on all UNIX systems. Making it an auto option should prevent it from being a pain.