### PR TITLE
Fixed h2spec 6.4.3 test (#10584)

### DIFF
--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -521,6 +521,13 @@ rcv_rst_stream_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
                       "reset access stream with invalid id");
   }
 
+  // A RST_STREAM frame with a length other than 4 octets MUST be treated
+  // as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.
+  if (frame.header().length != HTTP2_RST_STREAM_LEN) {
+    return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_FRAME_SIZE_ERROR,
+                      "reset frame wrong length");
+  }
+
   Http2Stream *stream = cstate.find_stream(stream_id);
   if (stream == nullptr) {
     if (cstate.is_valid_streamid(stream_id)) {
@@ -529,13 +536,6 @@ rcv_rst_stream_frame(Http2ConnectionState &cstate, const Http2Frame &frame)
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "reset frame bad id stream not found");
     }
-  }
-
-  // A RST_STREAM frame with a length other than 4 octets MUST be treated
-  // as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.
-  if (frame.header().length != HTTP2_RST_STREAM_LEN) {
-    return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_FRAME_SIZE_ERROR,
-                      "reset frame wrong length");
   }
 
   // Update RST_STREAM frame count per minute


### PR DESCRIPTION
Should respond with FRAME_SIZE_ERROR when receiving reset frame of incorrect size before looking to see if the stream exists.

(cherry picked from commit bb951e905e7844f304e6635a84acbd0734aed251)

 Conflicts:
	proxy/http2/Http2ConnectionState.cc