### PR TITLE
Add VIA RWW cache result as acceptable for an IMS_HIT

### DIFF
--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -520,7 +520,8 @@ HttpTransactHeaders::generate_and_set_squid_codes(HTTPHdr *header, char *via_str
 
   else {
     if (via_string[VIA_CLIENT_REQUEST] == VIA_CLIENT_IMS) {
-      if ((via_string[VIA_CACHE_RESULT] == VIA_IN_CACHE_FRESH) || (via_string[VIA_CACHE_RESULT] == VIA_IN_RAM_CACHE_FRESH)) {
+      if ((via_string[VIA_CACHE_RESULT] == VIA_IN_CACHE_FRESH) || (via_string[VIA_CACHE_RESULT] == VIA_IN_RAM_CACHE_FRESH) ||
+          (via_string[VIA_CACHE_RESULT] == VIA_IN_CACHE_RWW_HIT)) {
         log_code = SQUID_LOG_TCP_IMS_HIT;
       } else {
         if (via_string[VIA_CACHE_RESULT] == VIA_IN_CACHE_STALE && via_string[VIA_SERVER_RESULT] == VIA_SERVER_NOT_MODIFIED) {


### PR DESCRIPTION
We had seen an increase in IMS_MISS with 9.2 on our test machines, but the results were still coming out of cache. I believe this is why. The new RWW_HIT wasnt being factored in as a viable hit for an IMS_HIT. So while data still came out of cache this would skew stats to make it look like there were more IMS_MISS than there actually are.

closes #9128 