### PR TITLE
Improve the TSMgmtUpdateRegister with an optional file name

### DIFF
--- a/doc/developer-guide/api/functions/TSMgmtUpdateRegister.en.rst
+++ b/doc/developer-guide/api/functions/TSMgmtUpdateRegister.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSMgmtUpdateRegister(TSCont contp, const char * plugin_name)
+.. function:: void TSMgmtUpdateRegister(TSCont contp, const char *plugin_name, const char *plugin_file_name=nullptr)
 
 Description
 ===========

--- a/include/api/InkAPIInternal.h
+++ b/include/api/InkAPIInternal.h
@@ -41,6 +41,7 @@
 #include "ts/experimental.h"
 
 #include <typeinfo>
+#include <filesystem>
 
 /* Some defines that might be candidates for configurable settings later.
  */
@@ -143,12 +144,12 @@ public:
   ConfigUpdateCbTable();
   ~ConfigUpdateCbTable();
 
-  void insert(INKContInternal *contp, const char *name);
-  void invoke(const char *name);
+  void insert(INKContInternal *contp, const char *name, const char *file_name = nullptr);
+  void invoke();
   void invoke(INKContInternal *contp);
 
 private:
-  std::unordered_map<std::string, INKContInternal *> cb_table;
+  std::unordered_map<std::string, std::tuple<INKContInternal *, std::string, std::filesystem::file_time_type>> cb_table;
 };
 
 #include "HttpAPIHooks.h"

--- a/include/api/InkAPIInternal.h
+++ b/include/api/InkAPIInternal.h
@@ -37,11 +37,11 @@
 #include "api/APIHooks.h"
 #include "api/FeatureAPIHooks.h"
 
+#include "swoc/swoc_file.h"
 #include "ts/InkAPIPrivateIOCore.h"
 #include "ts/experimental.h"
 
 #include <typeinfo>
-#include <filesystem>
 
 /* Some defines that might be candidates for configurable settings later.
  */
@@ -149,7 +149,7 @@ public:
   void invoke(INKContInternal *contp);
 
 private:
-  std::unordered_map<std::string, std::tuple<INKContInternal *, std::string, std::filesystem::file_time_type>> cb_table;
+  std::unordered_map<std::string, std::tuple<INKContInternal *, swoc::file::path, swoc::file::file_time_type>> cb_table;
 };
 
 #include "HttpAPIHooks.h"

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1255,7 +1255,7 @@ namespace c
 
   /* --------------------------------------------------------------------------
      Management */
-  void TSMgmtUpdateRegister(TSCont contp, const char *plugin_name);
+  void TSMgmtUpdateRegister(TSCont contp, const char *plugin_name, const char *plugin_file_name = nullptr);
   TSReturnCode TSMgmtIntGet(const char *var_name, TSMgmtInt *result);
   TSReturnCode TSMgmtCounterGet(const char *var_name, TSMgmtCounter *result);
   TSReturnCode TSMgmtFloatGet(const char *var_name, TSMgmtFloat *result);

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -4096,12 +4096,12 @@ tsapi::c::TSConfigDataGet(TSConfig configp)
 ////////////////////////////////////////////////////////////////////
 
 void
-tsapi::c::TSMgmtUpdateRegister(TSCont contp, const char *plugin_name)
+tsapi::c::TSMgmtUpdateRegister(TSCont contp, const char *plugin_name, const char *plugin_file_name)
 {
   sdk_assert(sdk_sanity_check_iocore_structure(contp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)plugin_name) == TS_SUCCESS);
 
-  global_config_cbs->insert((INKContInternal *)contp, plugin_name);
+  global_config_cbs->insert((INKContInternal *)contp, plugin_name, plugin_file_name);
 }
 
 TSReturnCode

--- a/src/mgmt/config/FileManager.cc
+++ b/src/mgmt/config/FileManager.cc
@@ -193,9 +193,8 @@ void
 FileManager::invokeConfigPluginCallbacks()
 {
   Debug("filemanager", "invoke plugin callbacks");
-  static const std::string_view s{"*"};
   if (_pluginCallbackList) {
-    _pluginCallbackList->invoke(s.data());
+    _pluginCallbackList->invoke();
   }
 }
 


### PR DESCRIPTION
Providing this filename makes the update registry keep track of file changes automatically. When used, the continuation provided will only be called if changes to the configuration file is detected.

Also, this eliminates the superflous code for calling a named plugin reload. That code is never used, and I don't like having code there "just because", when nothing uses it.