### PR TITLE
Remove the CMake build requirement

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -51,7 +51,6 @@ github:
           - CentOS
           - Clang-Analyzer
           - Clang-Format
-          - CMake
           - Debian
           - Docs
           - Fedora


### PR DESCRIPTION
CI builds all things cmake now, so having a separate cmake job is redundant. Removing it as a requirement.