### PR TITLE
cmake: Install include files

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -38,4 +38,4 @@ set(SWOC_INCLUDE_DIR
 add_library(catch2::catch2 INTERFACE IMPORTED GLOBAL)
 target_include_directories(catch2::catch2 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/catch2")
 
-install(TARGETS libswoc fastlz)
+install(TARGETS fastlz)

--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -5,46 +5,51 @@ set(LIBSWOC_VERSION "1.5.5")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.
-set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "directory for libraries" FORCE)
+set(CMAKE_INSTALL_LIBDIR
+    "lib"
+    CACHE STRING "directory for libraries" FORCE
+)
 include(GNUInstallDirs)
 include(CMakeDependentOption)
 
-cmake_dependent_option(LIBSWOC_INSTALL
-    "Enable generation of libswoc install targets" ON
-    "NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT" OFF)
+cmake_dependent_option(
+  LIBSWOC_INSTALL "Enable generation of libswoc install targets" ON "NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT"
+  OFF
+)
 
 set(HEADER_FILES
-    include/swoc/swoc_version.h
-    include/swoc/ArenaWriter.h
-    include/swoc/BufferWriter.h
-    include/swoc/bwf_base.h
-    include/swoc/bwf_ex.h
-    include/swoc/bwf_ip.h
-    include/swoc/bwf_std.h
-    include/swoc/DiscreteRange.h
-    include/swoc/Errata.h
-    include/swoc/IntrusiveDList.h
-    include/swoc/IntrusiveHashMap.h
-    include/swoc/swoc_ip.h
-    include/swoc/IPEndpoint.h
-    include/swoc/IPAddr.h
-    include/swoc/IPSrv.h
-    include/swoc/IPRange.h
-    include/swoc/Lexicon.h
-    include/swoc/MemArena.h
-    include/swoc/MemSpan.h
-    include/swoc/Scalar.h
-    include/swoc/TextView.h
-    include/swoc/swoc_file.h
-    include/swoc/swoc_meta.h
-    include/swoc/string_view.h
-    include/swoc/Vectray.h
-    )
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/ArenaWriter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/BufferWriter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/DiscreteRange.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/Errata.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/HashFNV.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/IPAddr.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/IPEndpoint.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/IPRange.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/IPSrv.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/IntrusiveDList.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/IntrusiveHashMap.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/Lexicon.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/MemArena.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/MemSpan.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/RBTree.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/Scalar.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/TextView.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/Vectray.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/bwf_base.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/bwf_ex.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/bwf_fwd.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/bwf_ip.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/bwf_std.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/string_view_util.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/swoc_file.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/swoc_ip.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/swoc_meta.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/swoc/swoc_version.h
+)
 
 # These are external but required.
-set(EXTERNAL_HEADER_FILES
-    include/swoc/ext/HashFNV.h
-)
+set(EXTERNAL_HEADER_FILES include/swoc/ext/HashFNV.h)
 
 set(CC_FILES
     src/bw_format.cc
@@ -57,39 +62,59 @@ set(CC_FILES
     src/swoc_file.cc
     src/TextView.cc
     src/string_view_util.cc
-    )
+)
 
 add_library(libswoc SHARED ${CC_FILES})
-set_target_properties(libswoc PROPERTIES OUTPUT_NAME swoc-${LIBSWOC_VERSION})
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(libswoc PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic -Wshadow)
+set_target_properties(libswoc PROPERTIES OUTPUT_NAME swoc-${LIBSWOC_VERSION} PUBLIC_HEADER "${HEADER_FILES}")
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+  target_compile_options(
+    libswoc
+    PRIVATE -fPIC
+            -Wall
+            -Wextra
+            -Werror
+            -Wnon-virtual-dtor
+            -Wpedantic
+            -Wshadow
+  )
 endif()
 
 add_library(libswoc-static STATIC ${CC_FILES})
-set_target_properties(libswoc-static PROPERTIES OUTPUT_NAME swoc-static-${LIBSWOC_VERSION})
-if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(libswoc-static PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic -Wshadow)
+set_target_properties(
+  libswoc-static PROPERTIES OUTPUT_NAME swoc-static-${LIBSWOC_VERSION} PUBLIC_HEADER "${HEADER_FILES}"
+)
+if(CMAKE_COMPILER_IS_GNUCXX)
+  target_compile_options(
+    libswoc-static
+    PRIVATE -fPIC
+            -Wall
+            -Wextra
+            -Werror
+            -Wnon-virtual-dtor
+            -Wpedantic
+            -Wshadow
+  )
 endif()
 
 # Not quite sure how this works, but I think it generates one of two paths depending on the context.
 # That is, the generator functions return non-empty strings only in the corresponding context.
-target_include_directories(libswoc-static
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
-    )
+target_include_directories(
+  libswoc-static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+)
 
-target_include_directories(libswoc
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
-    )
-
+target_include_directories(
+  libswoc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+)
 
 # Alledgedly this makes the targets "importable from the build directory" but I see no evidence of that.
 # AFAICT the file isn't created at all even with this enabled.
 #export(TARGETS libswoc FILE libswoc-config.cmake)
 
-set(CLANG_DIRS )
+set(CLANG_DIRS)
 
-set_target_properties(libswoc-static PROPERTIES CLANG_FORMAT_DIRS "${PROJECT_SOURCE_DIR}/src;${PROJECT_SOURCE_DIR}/include")
+set_target_properties(
+  libswoc-static PROPERTIES CLANG_FORMAT_DIRS "${PROJECT_SOURCE_DIR}/src;${PROJECT_SOURCE_DIR}/include"
+)
+
+install(TARGETS libswoc PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/swoc)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(tsapi SHARED InkAPI.cc InkIOCoreAPI.cc)
 add_library(ts::tsapi ALIAS tsapi)
 target_include_directories(
   tsapi
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
   PRIVATE # private headers
           ${CMAKE_SOURCE_DIR}/src/iocore/eventsystem
           ${CMAKE_SOURCE_DIR}/src/iocore/net
@@ -28,7 +29,20 @@ target_include_directories(
           ${CMAKE_SOURCE_DIR}/src/iocore/aio
           ${CMAKE_SOURCE_DIR}/src/proxy/
 )
+
+set(TSAPI_PUBLIC_HEADERS
+    ${CMAKE_SOURCE_DIR}/include/ts/ts.h
+    ${CMAKE_SOURCE_DIR}/include/ts/remap.h
+    ${CMAKE_SOURCE_DIR}/include/ts/DbgCtl.h
+    ${CMAKE_SOURCE_DIR}/include/ts/TsException.h
+    ${CMAKE_SOURCE_DIR}/include/ts/parentselectdefs.h
+    ${CMAKE_SOURCE_DIR}/include/ts/parentselectdefs.h
+    ${CMAKE_BINARY_DIR}/include/ts/apidefs.h
+    ${CMAKE_SOURCE_DIR}/include/ts/experimental.h
+)
+
 target_link_libraries(tsapi PRIVATE ts::tscore)
+set_target_properties(tsapi PROPERTIES PUBLIC_HEADER "${TSAPI_PUBLIC_HEADERS}")
 
 add_library(
   tsapicore STATIC
@@ -54,7 +68,7 @@ set_target_properties(tsapicore PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 include_directories(${IOCORE_INCLUDE_DIRS} ${PROXY_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include/mgmt)
 
-install(TARGETS tsapi)
+install(TARGETS tsapi PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ts)
 
 if(APPLE)
   target_link_options(tsapi PRIVATE -undefined dynamic_lookup)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -31,14 +31,14 @@ target_include_directories(
 )
 
 set(TSAPI_PUBLIC_HEADERS
-    ${CMAKE_SOURCE_DIR}/include/ts/ts.h
-    ${CMAKE_SOURCE_DIR}/include/ts/remap.h
-    ${CMAKE_SOURCE_DIR}/include/ts/DbgCtl.h
-    ${CMAKE_SOURCE_DIR}/include/ts/TsException.h
-    ${CMAKE_SOURCE_DIR}/include/ts/parentselectdefs.h
-    ${CMAKE_SOURCE_DIR}/include/ts/parentselectdefs.h
-    ${CMAKE_BINARY_DIR}/include/ts/apidefs.h
-    ${CMAKE_SOURCE_DIR}/include/ts/experimental.h
+  ${PROJECT_SOURCE_DIR}/include/ts/ts.h
+  ${PROJECT_SOURCE_DIR}/include/ts/remap.h
+  ${PROJECT_SOURCE_DIR}/include/ts/DbgCtl.h
+  ${PROJECT_SOURCE_DIR}/include/ts/TsException.h
+  ${PROJECT_SOURCE_DIR}/include/ts/parentselectdefs.h
+  ${PROJECT_SOURCE_DIR}/include/ts/parentselectdefs.h
+  ${PROJECT_BINARY_DIR}/include/ts/apidefs.h
+  ${PROJECT_SOURCE_DIR}/include/ts/experimental.h
 )
 
 target_link_libraries(tsapi PRIVATE ts::tscore)

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -44,8 +44,42 @@ add_library(
 )
 add_library(ts::tscppapi ALIAS tscppapi)
 target_link_libraries(tscppapi PUBLIC libswoc yaml-cpp::yaml-cpp)
-install(TARGETS tscppapi)
 
 if(APPLE)
   target_link_options(tscppapi PRIVATE -undefined dynamic_lookup)
 endif()
+
+set(TSCPP_API_PUBLIC_HEADERS
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Async.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/AsyncHttpFetch.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/AsyncTimer.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/CaseInsensitiveStringComparator.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Cleanup.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/ClientRequest.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Continuation.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/GlobalPlugin.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/GzipDeflateTransformation.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/GzipInflateTransformation.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Headers.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpMethod.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpStatus.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpVersion.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/InterceptPlugin.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Logger.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Plugin.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/PluginInit.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/RemapPlugin.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Request.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Response.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Stat.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Transaction.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/TransactionPlugin.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/TransformationPlugin.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Url.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/noncopyable.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/api/utils.h
+)
+set_target_properties(tscppapi PROPERTIES PUBLIC_HEADER "${TSCPP_API_PUBLIC_HEADERS}")
+
+install(TARGETS tscppapi
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tscpp/api)

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -19,23 +19,23 @@ add_library(tscpputil SHARED ts_bwf.cc ts_ip.cc ts_diags.cc YamlCfg.cc ts_unit_p
 add_library(ts::tscpputil ALIAS tscpputil)
 target_link_libraries(tscpputil PUBLIC libswoc yaml-cpp::yaml-cpp ts::tscore)
 set(TSCPPUTIL_PUBLIC_HEADERS
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Bravo.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Convert.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/DenseThreadId.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Histogram.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/LocalBuffer.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/PostScript.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Strerror.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/TsSharedMutex.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/YamlCfg.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_bw.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_bw_format.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_diag_levels.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_errata.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_ip.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_meta.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_time_parser.h
-    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_unit_parser.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Bravo.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Convert.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/DenseThreadId.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Histogram.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/LocalBuffer.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/PostScript.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Strerror.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/TsSharedMutex.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/YamlCfg.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_bw.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_bw_format.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_diag_levels.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_errata.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_ip.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_meta.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_time_parser.h
+  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_unit_parser.h
 )
 set_target_properties(tscpputil PROPERTIES PUBLIC_HEADER "${TSCPPUTIL_PUBLIC_HEADERS}")
 

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -18,7 +18,28 @@
 add_library(tscpputil SHARED ts_bwf.cc ts_ip.cc ts_diags.cc YamlCfg.cc ts_unit_parser.cc)
 add_library(ts::tscpputil ALIAS tscpputil)
 target_link_libraries(tscpputil PUBLIC libswoc yaml-cpp::yaml-cpp ts::tscore)
-install(TARGETS tscpputil)
+set(TSCPPUTIL_PUBLIC_HEADERS
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Bravo.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Convert.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/DenseThreadId.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Histogram.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/LocalBuffer.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/PostScript.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/Strerror.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/TsSharedMutex.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/YamlCfg.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_bw.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_bw_format.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_diag_levels.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_errata.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_ip.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_meta.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_time_parser.h
+    ${CMAKE_SOURCE_DIR}/include/tscpp/util/ts_unit_parser.h
+)
+set_target_properties(tscpputil PROPERTIES PUBLIC_HEADER "${TSCPPUTIL_PUBLIC_HEADERS}")
+
+install(TARGETS tscpputil PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tscpp/util)
 
 if(BUILD_TESTING)
   add_executable(


### PR DESCRIPTION
This installs the include files based on what is installed from autotools.

I moved the install target for libswoc into libswoc's CMakeLists.txt.  That file has deviated from libswoc upstream substantially, so I also ran cmake-format on it.

There doesn't seem to be consensus on the best way to setup header files for installation, so I just picked one that wasn't overly complicated.  The bare minimum is to set a PUBLIC_HEADER property on the target and then specify a destination for the same on the install target.  There is a target_include_directories component, but it has more to do with exporting cmake scripts for other projects to consume.  That task will be a different PR so that aspect will likely need adjustment.

Edit: I added `tscpp/api` as well