### PR TITLE
List all includes explicitly in dns headers

### DIFF
--- a/include/iocore/dns/DNSProcessor.h
+++ b/include/iocore/dns/DNSProcessor.h
@@ -23,9 +23,22 @@
 
 #pragma once
 
-#include "tscore/ink_resolver.h"
-#include "iocore/eventsystem/EventSystem.h"
 #include "iocore/dns/SRV.h"
+
+#include "iocore/eventsystem/Action.h"
+#include "iocore/eventsystem/Continuation.h"
+#include "iocore/eventsystem/EThread.h"
+#include "iocore/eventsystem/Event.h"
+#include "iocore/eventsystem/Processor.h"
+
+#include "tscore/ink_config.h"
+#include "tscore/ink_inet.h"
+#include "tscore/ink_platform.h"
+#include "tscore/ink_resolver.h"
+#include "tscore/Version.h"
+
+#include <cstdint>
+#include <string_view>
 
 // Events
 #define DNS_EVENT_LOOKUP DNS_EVENT_EVENTS_START

--- a/include/iocore/dns/SRV.h
+++ b/include/iocore/dns/SRV.h
@@ -23,10 +23,10 @@
 
 #pragma once
 
-#include <vector>
 #include "tscore/ink_platform.h"
 
-struct HostDBInfo;
+#include <cstdlib>
+#include <vector>
 
 #define RAND_INV_RANGE(r) ((int)((RAND_MAX + 1) / (r)))
 

--- a/include/iocore/dns/SplitDNSProcessor.h
+++ b/include/iocore/dns/SplitDNSProcessor.h
@@ -30,6 +30,11 @@
 
 #pragma once
 
+#include "iocore/eventsystem/ConfigProcessor.h"
+#include "iocore/eventsystem/Lock.h"
+
+#include "tscore/Ptr.h"
+
 struct SplitDNS;
 
 /* --------------------------------------------------------------

--- a/src/iocore/dns/CMakeLists.txt
+++ b/src/iocore/dns/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(ts::inkdns ALIAS inkdns)
 target_include_directories(
   inkdns
   PUBLIC "${PROJECT_SOURCE_DIR}/include"
-  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/src/iocore/net"
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
 target_link_libraries(

--- a/src/iocore/dns/CMakeLists.txt
+++ b/src/iocore/dns/CMakeLists.txt
@@ -18,4 +18,15 @@
 add_library(inkdns STATIC DNS.cc DNSConnection.cc DNSEventIO.cc Inline.cc SplitDNS.cc)
 add_library(ts::inkdns ALIAS inkdns)
 
-target_link_libraries(inkdns PUBLIC ts::inkevent ts::inkhostdb ts::proxy ts::tscore)
+target_include_directories(
+  inkdns
+  PUBLIC "${PROJECT_SOURCE_DIR}/include"
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/src/iocore/net"
+)
+
+target_link_libraries(
+  inkdns
+  PUBLIC libswoc ts::inkevent ts::inkhostdb
+         #ts::inknet cyclic dependency
+         ts::proxy ts::tsapicore ts::tscore
+)

--- a/src/iocore/dns/P_DNSConnection.h
+++ b/src/iocore/dns/P_DNSConnection.h
@@ -33,6 +33,13 @@
 #include "iocore/dns/DNSEventIO.h"
 #include "iocore/dns/DNSProcessor.h"
 
+#include "tscore/ink_platform.h"
+#include "tscore/ink_rand.h"
+#include "tscore/List.h"
+#include "tscore/Ptr.h"
+
+#include <swoc/IPEndpoint.h>
+
 //
 // Connection
 //

--- a/src/iocore/dns/P_DNSProcessor.h
+++ b/src/iocore/dns/P_DNSProcessor.h
@@ -23,9 +23,32 @@
 
 #pragma once
 
-#include "iocore/eventsystem/EventSystem.h"
-#include "tscore/PendingAction.h"
+#include "iocore/dns/DNSProcessor.h"
+#include "P_DNSConnection.h"
+
+#include "iocore/eventsystem/Action.h"
+#include "iocore/eventsystem/Continuation.h"
+#include "iocore/eventsystem/EThread.h"
+#include "iocore/eventsystem/Event.h"
+
 #include "api/Metrics.h"
+
+#include "tscore/ink_apidefs.h"
+#include "tscore/ink_hrtime.h"
+#include "tscore/ink_inet.h"
+#include "tscore/ink_platform.h"
+#include "tscore/ink_rand.h"
+#include "tscore/ink_resolver.h"
+#include "tscore/List.h"
+#include "tscore/PendingAction.h"
+#include "tscore/Ptr.h"
+
+#include "ts/DbgCtl.h"
+
+#include <swoc/IPEndpoint.h>
+
+#include <cstdint>
+#include <cstring>
 
 using ts::Metrics;
 

--- a/src/iocore/dns/P_SplitDNSProcessor.h
+++ b/src/iocore/dns/P_SplitDNSProcessor.h
@@ -30,10 +30,22 @@
 
 #pragma once
 
+#include "iocore/dns/SplitDNSProcessor.h"
+#include "P_DNSProcessor.h"
+
+#include "proxy/ControlBase.h"
+#include "proxy/ControlMatcher.h"
+
 #include "iocore/eventsystem/ConfigProcessor.h"
 
-#include "proxy/ControlMatcher.h"
 #include "tscore/HostLookup.h"
+#include "tscore/ink_apidefs.h"
+#include "tscore/ink_assert.h"
+#include "tscore/ink_platform.h"
+
+#include <swoc/TextView.h>
+
+#include <cstdint>
 
 /* ---------------------------
    forward declarations ...


### PR DESCRIPTION
This follows the 'include what you use' principle for all the headers in dns. The source files remain unchanged - I did the headers first because they get included by other components, and I ran into missing declarations very quickly when I started to write unit tests. ~~All the dns headers now use include paths relative to include/ as @zwoop has championed, with the exception of P_ headers.~~ (done across all of ATS by @lzx404243 🎉)

Note: inkdns has a public dependency on a private header in inknet, but we can't link that directly because the cyclic dependency causes linking problems with RegressionSM.