### PR TITLE
Remove unused getbyxxx methods from DNSProcessor

### DIFF
--- a/include/iocore/dns/DNSProcessor.h
+++ b/include/iocore/dns/DNSProcessor.h
@@ -121,8 +121,11 @@ struct DNSProcessor : public Processor {
   // NOTE: the HostEnt *block is freed when the function returns
   //
 
+  // To avoid lifetime issues, the name will be copied out of the view's
+  // buffer before the query is scheduled.
   Action *gethostbyname(Continuation *cont, std::string_view name, Options const &opt);
   Action *getSRVbyname(Continuation *cont, std::string_view name, Options const &opt);
+
   Action *gethostbyaddr(Continuation *cont, IpAddr const *ip, Options const &opt);
 
   // Processor API

--- a/include/iocore/dns/DNSProcessor.h
+++ b/include/iocore/dns/DNSProcessor.h
@@ -121,9 +121,7 @@ struct DNSProcessor : public Processor {
   // NOTE: the HostEnt *block is freed when the function returns
   //
 
-  Action *gethostbyname(Continuation *cont, const char *name, Options const &opt);
   Action *gethostbyname(Continuation *cont, std::string_view name, Options const &opt);
-  Action *getSRVbyname(Continuation *cont, const char *name, Options const &opt);
   Action *getSRVbyname(Continuation *cont, std::string_view name, Options const &opt);
   Action *gethostbyaddr(Continuation *cont, IpAddr const *ip, Options const &opt);
 
@@ -169,21 +167,9 @@ extern DNSProcessor dnsProcessor;
 //
 
 inline Action *
-DNSProcessor::getSRVbyname(Continuation *cont, const char *name, Options const &opt)
-{
-  return getby(std::string_view(name), T_SRV, cont, opt);
-}
-
-inline Action *
 DNSProcessor::getSRVbyname(Continuation *cont, std::string_view name, Options const &opt)
 {
   return getby(name, T_SRV, cont, opt);
-}
-
-inline Action *
-DNSProcessor::gethostbyname(Continuation *cont, const char *name, Options const &opt)
-{
-  return getby(std::string_view(name), T_A, cont, opt);
 }
 
 inline Action *


### PR DESCRIPTION
These old methods that used const char* are superceded by the ones that use std::string_view.