### PR TITLE
Fix race of shutdown & retry of CacheDir unit test

### DIFF
--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#include "Event.h"
 #include "main.h"
 
 #include "P_CacheDir.h"
@@ -74,21 +75,6 @@ public:
   int
   cache_init_success_callback(int event, void *e) override
   {
-    // Test
-    _run();
-
-    // Teardown
-    TerminalTest *tt = new TerminalTest;
-    this_ethread()->schedule_imm(tt);
-    delete this;
-
-    return 0;
-  }
-
-private:
-  void
-  _run()
-  {
     ink_hrtime ttime;
 
     REQUIRE(CacheProcessor::IsCacheEnabled() == CACHE_INITIALIZED);
@@ -99,7 +85,7 @@ private:
     MUTEX_TRY_LOCK(lock, vol->mutex, thread);
     if (!lock.is_locked()) {
       CONT_SCHED_LOCK_RETRY(this);
-      return;
+      return EVENT_DONE;
     }
 
     vol_dir_clear(vol);
@@ -250,6 +236,12 @@ private:
 #endif
     }
     vol_dir_clear(vol);
+
+    // Teardown
+    test_done();
+    delete this;
+
+    return EVENT_DONE;
   }
 };
 


### PR DESCRIPTION
Fix #10657. 

The `cache_init_success_callback` can be called twice when the try-lock is failed and retry event is scheduled. It can be cause of double free. 

To fix this, we should delete CacheDirTest  only if all test is done. Also, I thought we need `TerminalTest` continuation to shutdown the test, but it looks like we can just call `test_done()` function directly.