### PR TITLE
cmake: disable in-source builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@
 #
 #######################
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(FATAL_ERROR "In source builds are disabled.  Use a preset, -B or run from a different directory")
+endif()
+
 cmake_minimum_required(VERSION 3.20..3.27)
 project(ats VERSION 10.0.0)
 


### PR DESCRIPTION
This disables builds in the source directory.  This might be controversial, but this will prevent accidentally (or purposefully) generating the build in the source directory.  CMake can make a big mess and in-source builds can cause strange issue with generated code surprisingly being included from the source directory rather than the build directory.