### PR TITLE
CMake: Fix binaryDir of presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 
 # common directory name for out-of-tree CMake builds
-build
+build*
 
 Makefile
 Makefile-pl

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,7 +33,7 @@
       "displayName": "development",
       "description": "Development Presets",
       "inherits": ["default"],
-      "binaryDir": "${sourceDir}/cmake-build-${presetName}",
+      "binaryDir": "${sourceDir}/build-${presetName}",
       "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
@@ -67,7 +67,7 @@
       "displayName": "CI defaults",
       "description": "Defaults for CI Pipeline builds",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/cmake-ci",
+      "binaryDir": "${sourceDir}/build-ci",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Here is an example user preset:
       "name": "mydev",
       "displayName": "my development",
       "description": "My Development Presets",
-      "binaryDir": "${sourceDir}/cmake-build-dev-clang",
+      "binaryDir": "${sourceDir}/build-dev-clang",
       "inherits": ["clang", "dev"],
       "cacheVariables": {
         "CMAKE_INSTALL_PREFIX": "/opt/ats-cmake",


### PR DESCRIPTION
Consistency with other presets and `.gitignore`.

https://github.com/apache/trafficserver/blob/78506e0f2d2f9632c65f93c06b0fb50c7e72444a/CMakePresets.json#L36
https://github.com/apache/trafficserver/blob/78506e0f2d2f9632c65f93c06b0fb50c7e72444a/CMakePresets.json#L70
https://github.com/apache/trafficserver/blob/78506e0f2d2f9632c65f93c06b0fb50c7e72444a/.gitignore#L209

----

Update: now the prefix is `build-` as @JosiahWI suggested.