### PR TITLE
Rename Vol to Stripe

### DIFF
--- a/doc/developer-guide/cache-architecture/architecture.en.rst
+++ b/doc/developer-guide/cache-architecture/architecture.en.rst
@@ -126,7 +126,7 @@ span of bytes. Internally each stripe is treated almost entirely independently.
 The data structures described in this section are duplicated for each stripe.
 
 Internally the term *volume* is used for these stripes and implemented primarily
-in :cpp:class:`Vol`. What a user thinks of as a volume (and what this document
+in :cpp:class:`Stripe`. What a user thinks of as a volume (and what this document
 calls a *cache volume*) is represented by :cpp:class:`CacheVol`.
 
 .. note::
@@ -259,7 +259,7 @@ Storage Layout
 The storage layout is the stripe metadata followed by cached content. The
 metadata consists of three parts: the stripe header, the directory, and the
 stripe footer. The metadata is stored twice. The header and the footer are
-instances of :cpp:class:`VolHeaderFooter`. This is a stub structure which can
+instances of :cpp:class:`StripeHeaderFooter`. This is a stub structure which can
 have a trailing variable sized array. This array is used as the segment free
 list roots in the directory. Each contains the segment index of the first
 element of the free list for the segment. The footer is a copy of the header
@@ -292,14 +292,14 @@ data length
    there are at least three different metrics (bytes, cache blocks, store
    blocks) used in various places.
 
-The header for a stripe is a variably sized instance of :class:`VolHeaderFooter`.
+The header for a stripe is a variably sized instance of :class:`StripeHeaderFooter`.
 The variable trailing section contains the head indices of the directory entry
 free lists for the segments.
 
 .. figure:: images/stripe-header.svg
    :align: center
 
-The trailing :member:`VolHeaderFooter::freelist` array overlays the disk storage with
+The trailing :member:`StripeHeaderFooter::freelist` array overlays the disk storage with
 an entry for every segment, even though the array is declared to have length `1`.
 Each free list entry is a 16 bit value that is the index of the first directory entry
 in the free list for that segment. E.g. :code:`freelist[4]` is the index of the
@@ -505,7 +505,7 @@ Disk Failure
 
 The cache is designed to be relatively resistant to disk failures. Because each
 :term:`storage unit` in each :term:`cache volume` is mostly independent, the
-loss of a disk simply means that the corresponding :cpp:class:`Vol` instances
+loss of a disk simply means that the corresponding :cpp:class:`Stripe` instances
 (one per cache volume that uses the storage unit) becomes unusable. The primary
 issue is updating the volume assignment table to both preserve assignments for
 objects on still operational volumes while distributing the assignments from the
@@ -778,7 +778,7 @@ The basic steps to a cache lookup are:
 
 #. The cache stripe is determined (based on the cache key).
 
-   The :term:`cache key` is used as a hash key in to an array of :cpp:class:`Vol` instances by
+   The :term:`cache key` is used as a hash key in to an array of :cpp:class:`Stripe` instances by
    :func:`Cache::key_to_vol`. The construction and arrangement of this array is the essence of how
    volumes are assigned.
 
@@ -939,7 +939,7 @@ Aggregation Buffer
 ------------------
 
 Disk writes to cache are handled through an *aggregation buffer*. There is one
-for each :cpp:class:`Vol` instance. To minimize the number of system calls data
+for each :cpp:class:`Stripe` instance. To minimize the number of system calls data
 is written to disk in units of roughly :ref:`target fragment size <target-fragment-size>`
 bytes. The algorithm used is simple: data is piled up in the aggregation buffer
 until no more will fit without going over the target fragment size, at which
@@ -974,7 +974,7 @@ In some cases this is not acceptable and the object is *evacuated* by reading
 it from the cache and then writing it back to cache which moves the physical
 storage of the object from in front of the write cursor to behind the write
 cursor. Objects that are evacuated are handled in this way based on data in
-stripe data structures (attached to the :cpp:class:`Vol` instance).
+stripe data structures (attached to the :cpp:class:`Stripe` instance).
 
 Evacuation data structures are defined by dividing up the volume content into
 a disjoint and contiguous set of regions of ``EVACUATION_BUCKET_SIZE`` bytes.

--- a/doc/developer-guide/cache-architecture/architecture.en.rst
+++ b/doc/developer-guide/cache-architecture/architecture.en.rst
@@ -280,11 +280,11 @@ start
    The offset for the start of the content, after the stripe metadata.
 
 length
-   Total number of bytes in the stripe. :cpp:member:`Vol::len`.
+   Total number of bytes in the stripe. :cpp:member:`Stripe::len`.
 
 data length
    Total number of blocks in the stripe available for content storage.
-   :cpp:member:`Vol::data_blocks`.
+   :cpp:member:`Stripe::data_blocks`.
 
 .. note::
 
@@ -978,7 +978,7 @@ stripe data structures (attached to the :cpp:class:`Vol` instance).
 
 Evacuation data structures are defined by dividing up the volume content into
 a disjoint and contiguous set of regions of ``EVACUATION_BUCKET_SIZE`` bytes.
-The :cpp:member:`Vol::evacuate` member is an array with an element for each
+The :cpp:member:`Stripe::evacuate` member is an array with an element for each
 evacuation region. Each element is a doubly linked list of :cpp:class:`EvacuationBlock`
 instances. Each instance contains a :cpp:class:`Dir` that specifies the fragment
 to evacuate. It is assumed that an evacuation block is placed in the evacuation
@@ -1004,14 +1004,14 @@ if the count goes to zero. If the ``EvacuationBlock`` already exists with a
 count of zero, the count is not modified and the number of readers is not
 tracked, so the evacuation is valid as long as the object exists.
 
-Evacuation is driven by cache writes, essentially in :cpp:member:`Vol::aggWrite`.
+Evacuation is driven by cache writes, essentially in :cpp:member:`Stripe::aggWrite`.
 This method processes the pending cache virtual connections that are trying to
 write to the stripe. Some of these may be evacuation virtual connections. If so
 then the completion callback for that virtual connection is called as the data
 is put in to the aggregation buffer.
 
 When no more cache virtual connections can be processed (due to an empty queue
-or the aggregation buffer filling) then :cpp:member:`Vol::evac_range` is called
+or the aggregation buffer filling) then :cpp:member:`Stripe::evac_range` is called
 to clear the range to be overwritten plus an additional :c:macro:`EVACUATION_SIZE`
 range. The buckets covering that range are checked. If there are any items in
 the buckets a new cache virtual connection (a *doc evacuator*) is created and
@@ -1021,7 +1021,7 @@ the read completes it is checked for validity and if valid, the cache virtual
 connection for it is placed at the front of the write queue for the stripe and
 the write aggregation resumed.
 
-Before doing a write, the method :cpp:member:`Vol::evac_range()` is called to
+Before doing a write, the method :cpp:member:`Stripe::evac_range()` is called to
 start an evacuation. If any fragments are found in the buckets in the range the
 earliest such fragment (smallest offset, closest to the write cursor) is
 selected and read from disk and the aggregation buffer write is suspended. The

--- a/doc/developer-guide/cache-architecture/core-cache-functions.en.rst
+++ b/doc/developer-guide/cache-architecture/core-cache-functions.en.rst
@@ -96,7 +96,7 @@ Core Cache Types
 Core Cache Functions
 ====================
 
-.. cpp:function:: int dir_probe(const CacheKey * key, Vol * d, Dir * result, Dir ** last_collision)
+.. cpp:function:: int dir_probe(const CacheKey * key, Stripe * d, Dir * result, Dir ** last_collision)
 
   Probe the stripe directory for a candidate directory entry.
 

--- a/doc/developer-guide/cache-architecture/data-structures.en.rst
+++ b/doc/developer-guide/cache-architecture/data-structures.en.rst
@@ -27,9 +27,9 @@ Data Structures
 
    hide empty members
 
-   CacheHostRecord *-- "*" Stripe : Vol >
+   CacheHostRecord *-- "*" Stripe : stripe >
    CacheHostRecord *-- "*" CacheVol : cp >
-   CacheVol *-- "*" Stripe : Vol >
+   CacheVol *-- "*" Stripe : stripe >
 
 .. var:: size_t STORE_BLOCK_SIZE = 8192
 

--- a/doc/developer-guide/cache-architecture/data-structures.en.rst
+++ b/doc/developer-guide/cache-architecture/data-structures.en.rst
@@ -58,7 +58,7 @@ Data Structures
 
       The cache volumes that are part of this cache host record.
 
-   .. member:: Vol ** vols
+   .. member:: Stripe ** vols
 
       The stripes that are part of the cache volumes. This is the union over the stripes of
       :member:`CacheHostRecord::cp`
@@ -462,7 +462,7 @@ Data Structures
       A generic class:`CacheHostRecord` that contains all cache volumes that are not explicitly
       assigned in :file:`hosting.config`.
 
-   .. function:: Vol * key_to_vol(const char * key, const char * host, int host_len)
+   .. function:: Stripe * key_to_vol(const char * key, const char * host, int host_len)
 
       Compute the stripe (:code:`Vol*`) for a cache :arg:`key` and :arg:`host`. The :arg:`host` is
       used to find the appropriate :class:`CacheHostRecord` instance. From there the stripe

--- a/doc/developer-guide/cache-architecture/data-structures.en.rst
+++ b/doc/developer-guide/cache-architecture/data-structures.en.rst
@@ -272,18 +272,18 @@ Data Structures
 
       The number of volume blocks in the span.
 
-   .. member:: DiskVolBlock vol_info[1]
+   .. member:: DiskStripeBlock vol_info[1]
 
       A flexible array. The actual length of this array is :code:`num_diskvol_blks` and each element describes
       a span block.
 
-.. class:: DiskVolBlock
+.. class:: DiskStripeBlock
 
-   A description of a span stripe (Vol) block . This is a serialized data structure.
+   A description of a span stripe (Stripe) block . This is a serialized data structure.
 
    .. member:: uint64_t offset
 
-      Offset in the span of the start of the span stripe (Vol) block, in bytes.
+      Offset in the span of the start of the span stripe (Stripe) block, in bytes.
 
    .. member:: uint64_t len
 
@@ -350,21 +350,21 @@ Data Structures
       for a segment, in the same order as the segments in the directory.
 
 
-.. class:: DiskVolBlockQueue
+.. class:: DiskStripeBlockQueue
 
-   .. member:: DiskVolBlock* b
+   .. member:: DiskStripeBlock* b
 
    .. member:: int new_block
 
-      Indicates if this is a new stripe rather than an existing one. In case a stripe is new ATS decides to clear that stripe(:class:`Vol`)
+      Indicates if this is a new stripe rather than an existing one. In case a stripe is new ATS decides to clear that stripe(:class:`Stripe`)
 
-   .. member:: LINK<DiskVolBlockQueue> link
+   .. member:: LINK<DiskStripeBlockQueue> link
 
 
-.. class:: DiskVol
+.. class:: DiskStripe
 
    Describes the Disk that contains the stripe identified by vol_number. This class also contains the queue
-   containing all the DiskVolBlock
+   containing all the DiskStripeBlock
 
    .. member:: int num_volblocks
 
@@ -382,7 +382,7 @@ Data Structures
 
       The disk containing the stripe
 
-   .. member:: Queue<DiskVolBlockQueue> dpb_queue
+   .. member:: Queue<DiskStripeBlockQueue> dpb_queue
 
 .. enum:: CacheType
 
@@ -407,13 +407,13 @@ Data Structures
 
    .. member:: int num_vols
 
-      Number of stripes(:class:`Vol`) contained in this volume
+      Number of stripes(:class:`Stripe`) contained in this volume
 
-   .. member:: Vol** vols
+   .. member:: Stripe** vols
 
-      :class:`Vol` represents a single stripe in the disk. vols contains all the stripes this volume is made up of
+      :class:`Stripe` represents a single stripe in the disk. vols contains all the stripes this volume is made up of
 
-   .. member:: DiskVol** disk_vols
+   .. member:: DiskStripe** disk_vols
 
       disk_vols contain references to the disks of all the stripes in this volume
 
@@ -464,7 +464,7 @@ Data Structures
 
    .. function:: Stripe * key_to_vol(const char * key, const char * host, int host_len)
 
-      Compute the stripe (:code:`Vol*`) for a cache :arg:`key` and :arg:`host`. The :arg:`host` is
+      Compute the stripe (:code:`Stripe *`) for a cache :arg:`key` and :arg:`host`. The :arg:`host` is
       used to find the appropriate :class:`CacheHostRecord` instance. From there the stripe
       assignment slot is determined by taking bits 64..83 (20 bits) of the cache :arg:`key` modulo
       the stripe assignment array count (:code:`VOL_HASH_TABLE_SIZE`). These bits are the third 32

--- a/doc/developer-guide/cache-architecture/data-structures.en.rst
+++ b/doc/developer-guide/cache-architecture/data-structures.en.rst
@@ -133,7 +133,7 @@ Data Structures
 
    * Timestamps for request and response from :term:`origin server`.
 
-.. class:: Vol
+.. class:: Stripe
 
    This represents a :term:`storage unit` inside a :term:`cache volume`.
 
@@ -302,7 +302,7 @@ Data Structures
       In use or free flag - set if the span block is not in use by a cache volume.
 
 
-.. class:: VolHeaderFooter
+.. class:: StripeHeaderFooter
 
    .. member:: unsigned int magic
 
@@ -372,7 +372,7 @@ Data Structures
 
    .. member:: int vol_number
 
-      Identification number of the stripe (:class:`Vol`)
+      Identification number of the stripe (:class:`Stripe`)
 
    .. member:: uint64_t size
 

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -48,7 +48,7 @@
 
 #include <cstdint>
 
-struct Vol;
+struct Stripe;
 
 struct CacheVC : public CacheVConnection {
   CacheVC();
@@ -270,7 +270,7 @@ struct CacheVC : public CacheVConnection {
   uint32_t write_len;    // for communicating with agg_copy
   uint32_t agg_len;      // for communicating with aggWrite
   uint32_t write_serial; // serial of the final write for SYNC
-  Vol *vol;
+  Stripe *vol;
   Dir *last_collision;
   Event *trigger;
   CacheKey *read_key;

--- a/src/iocore/cache/CMakeLists.txt
+++ b/src/iocore/cache/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(
   RamCacheCLFUS.cc
   RamCacheLRU.cc
   Store.cc
-  Vol.cc
+  Stripe.cc
 )
 add_library(ts::inkcache ALIAS inkcache)
 

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -1196,7 +1196,7 @@ Cache::lookup(Continuation *cont, const CacheKey *key, CacheFragType type, const
   }
 
   Stripe *vol = key_to_vol(key, hostname, host_len);
-  CacheVC *c = new_CacheVC(cont);
+  CacheVC *c  = new_CacheVC(cont);
   SET_CONTINUATION_HANDLER(c, &CacheVC::openReadStartHead);
   c->vio.op  = VIO::READ;
   c->op_type = static_cast<int>(CacheOpType::Lookup);

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -213,7 +213,7 @@ dir_bucket_loop_check(Dir *start_dir, Dir *seg)
 // adds all the directory entries
 // in a segment to the segment freelist
 void
-dir_init_segment(int s, Vol *vol)
+dir_init_segment(int s, Stripe *vol)
 {
   vol->header->freelist[s] = 0;
   Dir *seg                 = vol->dir_segment(s);
@@ -230,7 +230,7 @@ dir_init_segment(int s, Vol *vol)
 // break the infinite loop in directory entries
 // Note : abuse of the token bit in dir entries
 int
-dir_bucket_loop_fix(Dir *start_dir, int s, Vol *vol)
+dir_bucket_loop_fix(Dir *start_dir, int s, Stripe *vol)
 {
   if (!dir_bucket_loop_check(start_dir, vol->dir_segment(s))) {
     Warning("Dir loop exists, clearing segment %d", s);
@@ -241,7 +241,7 @@ dir_bucket_loop_fix(Dir *start_dir, int s, Vol *vol)
 }
 
 int
-dir_freelist_length(Vol *vol, int s)
+dir_freelist_length(Stripe *vol, int s)
 {
   int free = 0;
   Dir *seg = vol->dir_segment(s);
@@ -257,7 +257,7 @@ dir_freelist_length(Vol *vol, int s)
 }
 
 int
-dir_bucket_length(Dir *b, int s, Vol *vol)
+dir_bucket_length(Dir *b, int s, Stripe *vol)
 {
   Dir *e   = b;
   int i    = 0;
@@ -277,7 +277,7 @@ dir_bucket_length(Dir *b, int s, Vol *vol)
 }
 
 int
-check_dir(Vol *vol)
+check_dir(Stripe *vol)
 {
   int i, s;
   Dbg(dbg_ctl_cache_check_dir, "inside check dir");
@@ -300,7 +300,7 @@ check_dir(Vol *vol)
 }
 
 inline void
-unlink_from_freelist(Dir *e, int s, Vol *vol)
+unlink_from_freelist(Dir *e, int s, Stripe *vol)
 {
   Dir *seg = vol->dir_segment(s);
   Dir *p   = dir_from_offset(dir_prev(e), seg);
@@ -316,7 +316,7 @@ unlink_from_freelist(Dir *e, int s, Vol *vol)
 }
 
 inline Dir *
-dir_delete_entry(Dir *e, Dir *p, int s, Vol *vol)
+dir_delete_entry(Dir *e, Dir *p, int s, Stripe *vol)
 {
   Dir *seg           = vol->dir_segment(s);
   int no             = dir_next(e);
@@ -346,7 +346,7 @@ dir_delete_entry(Dir *e, Dir *p, int s, Vol *vol)
 }
 
 inline void
-dir_clean_bucket(Dir *b, int s, Vol *vol)
+dir_clean_bucket(Dir *b, int s, Stripe *vol)
 {
   Dir *e = b, *p = nullptr;
   Dir *seg = vol->dir_segment(s);
@@ -379,7 +379,7 @@ dir_clean_bucket(Dir *b, int s, Vol *vol)
 }
 
 void
-dir_clean_segment(int s, Vol *vol)
+dir_clean_segment(int s, Stripe *vol)
 {
   Dir *seg = vol->dir_segment(s);
   for (int64_t i = 0; i < vol->buckets; i++) {
@@ -389,7 +389,7 @@ dir_clean_segment(int s, Vol *vol)
 }
 
 void
-dir_clean_vol(Vol *vol)
+dir_clean_vol(Stripe *vol)
 {
   for (int64_t i = 0; i < vol->segments; i++) {
     dir_clean_segment(i, vol);
@@ -398,7 +398,7 @@ dir_clean_vol(Vol *vol)
 }
 
 void
-dir_clear_range(off_t start, off_t end, Vol *vol)
+dir_clear_range(off_t start, off_t end, Stripe *vol)
 {
   for (off_t i = 0; i < vol->buckets * DIR_DEPTH * vol->segments; i++) {
     Dir *e = dir_index(vol, i);
@@ -425,7 +425,7 @@ check_bucket_not_contains(Dir *b, Dir *e, Dir *seg)
 }
 
 void
-freelist_clean(int s, Vol *vol)
+freelist_clean(int s, Stripe *vol)
 {
   dir_clean_segment(s, vol);
   if (vol->header->freelist[s]) {
@@ -449,7 +449,7 @@ freelist_clean(int s, Vol *vol)
 }
 
 inline Dir *
-freelist_pop(int s, Vol *vol)
+freelist_pop(int s, Stripe *vol)
 {
   Dir *seg = vol->dir_segment(s);
   Dir *e   = dir_from_offset(vol->header->freelist[s], seg);
@@ -471,7 +471,7 @@ freelist_pop(int s, Vol *vol)
 }
 
 int
-dir_segment_accounted(int s, Vol *vol, int offby, int *f, int *u, int *et, int *v, int *av, int *as)
+dir_segment_accounted(int s, Stripe *vol, int offby, int *f, int *u, int *et, int *v, int *av, int *as)
 {
   int free = dir_freelist_length(vol, s);
   int used = 0, empty = 0;
@@ -524,7 +524,7 @@ dir_segment_accounted(int s, Vol *vol, int offby, int *f, int *u, int *et, int *
 }
 
 void
-dir_free_entry(Dir *e, int s, Vol *vol)
+dir_free_entry(Dir *e, int s, Stripe *vol)
 {
   Dir *seg        = vol->dir_segment(s);
   unsigned int fo = vol->header->freelist[s];
@@ -537,7 +537,7 @@ dir_free_entry(Dir *e, int s, Vol *vol)
 }
 
 int
-dir_probe(const CacheKey *key, Vol *vol, Dir *result, Dir **last_collision)
+dir_probe(const CacheKey *key, Stripe *vol, Dir *result, Dir **last_collision)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int s    = key->slice32(0) % vol->segments;
@@ -606,7 +606,7 @@ Lagain:
 }
 
 int
-dir_insert(const CacheKey *key, Vol *vol, Dir *to_part)
+dir_insert(const CacheKey *key, Stripe *vol, Dir *to_part)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int s  = key->slice32(0) % vol->segments, l;
@@ -674,7 +674,7 @@ Lfill:
 }
 
 int
-dir_overwrite(const CacheKey *key, Vol *vol, Dir *dir, Dir *overwrite, bool must_overwrite)
+dir_overwrite(const CacheKey *key, Stripe *vol, Dir *dir, Dir *overwrite, bool must_overwrite)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int s          = key->slice32(0) % vol->segments, l;
@@ -761,7 +761,7 @@ Lfill:
 }
 
 int
-dir_delete(const CacheKey *key, Vol *vol, Dir *del)
+dir_delete(const CacheKey *key, Stripe *vol, Dir *del)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int s    = key->slice32(0) % vol->segments;
@@ -801,7 +801,7 @@ dir_delete(const CacheKey *key, Vol *vol, Dir *del)
 // Lookaside Cache
 
 int
-dir_lookaside_probe(const CacheKey *key, Vol *vol, Dir *result, EvacuationBlock **eblock)
+dir_lookaside_probe(const CacheKey *key, Stripe *vol, Dir *result, EvacuationBlock **eblock)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int i              = key->slice32(3) % LOOKASIDE_SIZE;
@@ -824,7 +824,7 @@ dir_lookaside_probe(const CacheKey *key, Vol *vol, Dir *result, EvacuationBlock 
 }
 
 int
-dir_lookaside_insert(EvacuationBlock *eblock, Vol *vol, Dir *to)
+dir_lookaside_insert(EvacuationBlock *eblock, Stripe *vol, Dir *to)
 {
   CacheKey *key = &eblock->evac_frags.earliest_key;
   DDbg(dbg_ctl_dir_lookaside, "insert %X %X, offset %d phase %d", key->slice32(0), key->slice32(1), (int)dir_offset(to),
@@ -843,7 +843,7 @@ dir_lookaside_insert(EvacuationBlock *eblock, Vol *vol, Dir *to)
 }
 
 int
-dir_lookaside_fixup(const CacheKey *key, Vol *vol)
+dir_lookaside_fixup(const CacheKey *key, Stripe *vol)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int i              = key->slice32(3) % LOOKASIDE_SIZE;
@@ -866,7 +866,7 @@ dir_lookaside_fixup(const CacheKey *key, Vol *vol)
 }
 
 void
-dir_lookaside_cleanup(Vol *vol)
+dir_lookaside_cleanup(Stripe *vol)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   for (auto &i : vol->lookaside) {
@@ -889,7 +889,7 @@ dir_lookaside_cleanup(Vol *vol)
 }
 
 void
-dir_lookaside_remove(const CacheKey *key, Vol *vol)
+dir_lookaside_remove(const CacheKey *key, Stripe *vol)
 {
   ink_assert(vol->mutex->thread_holding == this_ethread());
   int i              = key->slice32(3) % LOOKASIDE_SIZE;
@@ -931,7 +931,7 @@ CacheSync::aio_write(int fd, char *b, int n, off_t o)
 }
 
 uint64_t
-dir_entries_used(Vol *vol)
+dir_entries_used(Stripe *vol)
 {
   uint64_t full  = 0;
   uint64_t sfull = 0;
@@ -978,7 +978,7 @@ sync_cache_dir_on_shutdown()
     // dont release the volume's lock, there could
     // be another aggWrite in progress
     MUTEX_TAKE_LOCK(gvol[i]->mutex, t);
-    Vol *vol = gvol[i];
+    Stripe *vol = gvol[i];
 
     if (DISK_BAD(vol->disk)) {
       Dbg(dbg_ctl_cache_dir_sync, "Dir %s: ignoring -- bad disk", vol->hash_text.get());
@@ -1090,7 +1090,7 @@ Lrestart:
     return EVENT_CONT;
   }
 
-  Vol *vol = gvol[vol_idx]; // must be named "vol" to make STAT macros work.
+  Stripe *vol = gvol[vol_idx]; // must be named "vol" to make STAT macros work.
 
   if (event == AIO_EVENT_DONE) {
     // AIO Thread
@@ -1122,7 +1122,7 @@ Lrestart:
       goto Ldone;
     }
 
-    int headerlen = ROUND_TO_STORE_BLOCK(sizeof(VolHeaderFooter));
+    int headerlen = ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
     size_t dirlen = vol->dirlen();
     if (!writepos) {
       // start

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -363,7 +363,7 @@ dir_clean_bucket(Dir *b, int s, Stripe *vol)
 #endif
     if (!dir_valid(vol, e) || !dir_offset(e)) {
       if (dbg_ctl_dir_clean.on()) {
-        Dbg(dbg_ctl_dir_clean, "cleaning Vol:%s: %p tag %X boffset %" PRId64 " b %p p %p bucket len %d", vol->hash_text.get(), e,
+        Dbg(dbg_ctl_dir_clean, "cleaning Stripe:%s: %p tag %X boffset %" PRId64 " b %p p %p bucket len %d", vol->hash_text.get(), e,
             dir_tag(e), dir_offset(e), b, p, dir_bucket_length(b, s, vol));
       }
       if (dir_offset(e)) {

--- a/src/iocore/cache/CacheHosting.cc
+++ b/src/iocore/cache/CacheHosting.cc
@@ -441,7 +441,7 @@ CacheHostRecord::Init(CacheType typ)
     Warning("error: No volumes found for Cache Type %d", type);
     return -1;
   }
-  vols        = static_cast<Vol **>(ats_malloc(num_vols * sizeof(Vol *)));
+  vols        = static_cast<Stripe **>(ats_malloc(num_vols * sizeof(Stripe *)));
   int counter = 0;
   for (i = 0; i < num_cachevols; i++) {
     CacheVol *cachep1 = cp[i];
@@ -563,7 +563,7 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
   if (!num_vols) {
     return -1;
   }
-  vols        = static_cast<Vol **>(ats_malloc(num_vols * sizeof(Vol *)));
+  vols        = static_cast<Stripe **>(ats_malloc(num_vols * sizeof(Stripe *)));
   int counter = 0;
   for (i = 0; i < num_cachevols; i++) {
     CacheVol *cachep = cp[i];

--- a/src/iocore/cache/CachePagesInternal.cc
+++ b/src/iocore/cache/CachePagesInternal.cc
@@ -51,7 +51,7 @@ struct ShowCacheInternal : public ShowCont {
 extern ShowCacheInternal *theshowcacheInternal;
 Action *register_ShowCacheInternal(Continuation *c, HTTPHdr *h);
 
-extern Vol **gvol;
+extern Stripe **gvol;
 
 // Stat Pages
 ShowCacheInternal *theshowcacheInternal = nullptr;
@@ -194,7 +194,7 @@ ShowCacheInternal::showEvacuations(int event, Event *e)
 int
 ShowCacheInternal::showVolEvacuations(int event, Event *e)
 {
-  Vol *p = gvol[vol_index];
+  Stripe *p = gvol[vol_index];
   CACHE_TRY_LOCK(lock, p->mutex, mutex->thread_holding);
   if (!lock.is_locked()) {
     CONT_SCHED_LOCK_RETRY_RET(this);
@@ -251,7 +251,7 @@ ShowCacheInternal::showVolumes(int event, Event *e)
 int
 ShowCacheInternal::showVolVolumes(int event, Event *e)
 {
-  Vol *p = gvol[vol_index];
+  Stripe *p = gvol[vol_index];
   CACHE_TRY_LOCK(lock, p->mutex, mutex->thread_holding);
   if (!lock.is_locked()) {
     CONT_SCHED_LOCK_RETRY_RET(this);
@@ -309,7 +309,7 @@ ShowCacheInternal::showSegments(int event, Event *e)
 int
 ShowCacheInternal::showSegSegment(int event, Event *e)
 {
-  Vol *p = gvol[vol_index];
+  Stripe *p = gvol[vol_index];
   CACHE_TRY_LOCK(lock, p->mutex, mutex->thread_holding);
   if (!lock.is_locked()) {
     CONT_SCHED_LOCK_RETRY_RET(this);

--- a/src/iocore/cache/CachePagesInternal.cc
+++ b/src/iocore/cache/CachePagesInternal.cc
@@ -154,7 +154,7 @@ ShowCacheInternal::showVolConnections(int event, Event *e)
       vc->key.string(url);
     CHECK_SHOW(show("<tr>"
                     "<td>%s</td>" // operation
-                    "<td>%s</td>" // Vol
+                    "<td>%s</td>" // Stripe
                     "<td>%s</td>" // URL/Hash
                     "<td>%d</td>"
                     "<td>%s</td>"

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -49,7 +49,7 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheFragType type, co
   }
   ink_assert(caches[type] == this);
 
-  Vol *vol = key_to_vol(key, hostname, host_len);
+  Stripe *vol = key_to_vol(key, hostname, host_len);
   Dir result, *last_collision = nullptr;
   ProxyMutex *mutex = cont->mutex.get();
   OpenDirEntry *od  = nullptr;
@@ -117,7 +117,7 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
   }
   ink_assert(caches[type] == this);
 
-  Vol *vol = key_to_vol(key, hostname, host_len);
+  Stripe *vol = key_to_vol(key, hostname, host_len);
   Dir result, *last_collision = nullptr;
   ProxyMutex *mutex = cont->mutex.get();
   OpenDirEntry *od  = nullptr;

--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -434,10 +434,10 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   static uint64_t DEFAULT_STRIPE_SIZE = 1024ULL * 1024 * 1024 * 911; // 911G
   CacheDisk disk;                                                    // Only need one because it's just checked for failure.
   CacheHostRecord hr1, hr2;
-  Vol *sample;
+  Stripe *sample;
   static int const sample_idx = 16;
-  Vol vols[MAX_VOLS];
-  Vol *vol_ptrs[MAX_VOLS]; // array of pointers.
+  Stripe vols[MAX_VOLS];
+  Stripe *vol_ptrs[MAX_VOLS]; // array of pointers.
   char buff[2048];
 
   // Only run at the highest levels.
@@ -552,7 +552,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
 {
   bool pass = true;
   CacheKey key;
-  Vol *vol = theCache->key_to_vol(&key, "example.com", sizeof("example.com") - 1);
+  Stripe *vol = theCache->key_to_vol(&key, "example.com", sizeof("example.com") - 1);
   std::vector<Ptr<IOBufferData>> data;
 
   cache->init(cache_size, vol);

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -93,7 +93,7 @@ extern int cache_config_ram_cache_cutoff;
 /* Next block with some data in it in this partition.  Returns end of partition if no more
  * locations.
  *
- * d - Vol
+ * d - Stripe
  * vol_map - precalculated map
  * offset - offset to start looking at (and data at this location has not been read yet). */
 static off_t

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -120,7 +120,7 @@ int dir_bucket_loop_fix(Dir *start_dir, int s, Stripe *vol);
 // when we are asked about the highest interesting offset.
 /* Make map of what blocks in partition are used.
  *
- * d - Vol to make a map of. */
+ * d - Stripe to make a map of. */
 static char *
 make_vol_map(Stripe *vol)
 {

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -97,7 +97,7 @@ extern int cache_config_ram_cache_cutoff;
  * vol_map - precalculated map
  * offset - offset to start looking at (and data at this location has not been read yet). */
 static off_t
-next_in_map(Vol *vol, char *vol_map, off_t offset)
+next_in_map(Stripe *vol, char *vol_map, off_t offset)
 {
   off_t start_offset = vol->vol_offset_to_offset(0);
   off_t new_off      = (offset - start_offset);
@@ -113,7 +113,7 @@ next_in_map(Vol *vol, char *vol_map, off_t offset)
 }
 
 // Function in CacheDir.cc that we need for make_vol_map().
-int dir_bucket_loop_fix(Dir *start_dir, int s, Vol *vol);
+int dir_bucket_loop_fix(Dir *start_dir, int s, Stripe *vol);
 
 // TODO: If we used a bit vector, we could make a smaller map structure.
 // TODO: If we saved a high water mark we could have a smaller buf, and avoid searching it
@@ -122,7 +122,7 @@ int dir_bucket_loop_fix(Dir *start_dir, int s, Vol *vol);
  *
  * d - Vol to make a map of. */
 static char *
-make_vol_map(Vol *vol)
+make_vol_map(Stripe *vol)
 {
   // Map will be one byte for each SCAN_BUF_SIZE bytes.
   off_t start_offset = vol->vol_offset_to_offset(0);

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -648,7 +648,7 @@ static int
 agg_copy(char *p, CacheVC *vc)
 {
   Stripe *vol = vc->vol;
-  off_t o  = vol->header->write_pos + vol->agg_buf_pos;
+  off_t o     = vol->header->write_pos + vol->agg_buf_pos;
 
   if (!vc->f.evacuator) {
     Doc *doc                   = reinterpret_cast<Doc *>(p);
@@ -1558,9 +1558,9 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   intptr_t res = 0;
   CacheVC *c   = new_CacheVC(cont);
   SCOPED_MUTEX_LOCK(lock, c->mutex, this_ethread());
-  c->vio.op  = VIO::WRITE;
-  c->op_type = static_cast<int>(CacheOpType::Write);
-  c->vol     = key_to_vol(key, hostname, host_len);
+  c->vio.op   = VIO::WRITE;
+  c->op_type  = static_cast<int>(CacheOpType::Write);
+  c->vol      = key_to_vol(key, hostname, host_len);
   Stripe *vol = c->vol;
   Metrics::increment(cache_rsb.status[c->op_type].active);
   Metrics::increment(vol->cache_vol->vol_rsb.status[c->op_type].active);

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -308,7 +308,7 @@ iobufferblock_memcpy(char *p, int len, IOBufferBlock *ab, int offset)
 }
 
 EvacuationBlock *
-Vol::force_evacuate_head(Dir *evac_dir, int pinned)
+Stripe::force_evacuate_head(Dir *evac_dir, int pinned)
 {
   auto bucket = dir_evac_bucket(evac_dir);
   if (!evac_bucket_valid(bucket)) {
@@ -339,7 +339,7 @@ Vol::force_evacuate_head(Dir *evac_dir, int pinned)
 }
 
 void
-Vol::scan_for_pinned_documents()
+Stripe::scan_for_pinned_documents()
 {
   if (cache_config_permit_pinning) {
     // we can't evacuate anything between header->write_pos and
@@ -375,7 +375,7 @@ Vol::scan_for_pinned_documents()
    eventProcessor.schedule_xxx().
    */
 int
-Vol::aggWriteDone(int event, Event *e)
+Stripe::aggWriteDone(int event, Event *e)
 {
   cancel_trigger();
 
@@ -437,7 +437,7 @@ Vol::aggWriteDone(int event, Event *e)
 }
 
 CacheEvacuateDocVC *
-new_DocEvacuator(int nbytes, Vol *vol)
+new_DocEvacuator(int nbytes, Stripe *vol)
 {
   CacheEvacuateDocVC *c = new_CacheEvacuateDocVC(vol);
   c->op_type            = static_cast<int>(CacheOpType::Evacuate);
@@ -452,7 +452,7 @@ new_DocEvacuator(int nbytes, Vol *vol)
 }
 
 static int
-evacuate_fragments(CacheKey *key, CacheKey *earliest_key, int force, Vol *vol)
+evacuate_fragments(CacheKey *key, CacheKey *earliest_key, int force, Stripe *vol)
 {
   Dir dir, *last_collision = nullptr;
   int i = 0;
@@ -489,7 +489,7 @@ evacuate_fragments(CacheKey *key, CacheKey *earliest_key, int force, Vol *vol)
 }
 
 int
-Vol::evacuateWrite(CacheEvacuateDocVC *evacuator, int event, Event *e)
+Stripe::evacuateWrite(CacheEvacuateDocVC *evacuator, int event, Event *e)
 {
   // push to front of aggregation write list, so it is written first
 
@@ -507,7 +507,7 @@ Vol::evacuateWrite(CacheEvacuateDocVC *evacuator, int event, Event *e)
 }
 
 int
-Vol::evacuateDocReadDone(int event, Event *e)
+Stripe::evacuateDocReadDone(int event, Event *e)
 {
   cancel_trigger();
   if (event != AIO_EVENT_DONE) {
@@ -600,7 +600,7 @@ Ldone:
 }
 
 int
-Vol::evac_range(off_t low, off_t high, int evac_phase)
+Stripe::evac_range(off_t low, off_t high, int evac_phase)
 {
   off_t s = this->offset_to_vol_offset(low);
   off_t e = this->offset_to_vol_offset(high);
@@ -636,7 +636,7 @@ Vol::evac_range(off_t low, off_t high, int evac_phase)
       io.action        = this;
       io.thread        = AIO_CALLBACK_THREAD_ANY;
       DDbg(dbg_ctl_cache_evac, "evac_range evacuating %X %d", (int)dir_tag(&first->dir), (int)dir_offset(&first->dir));
-      SET_HANDLER(&Vol::evacuateDocReadDone);
+      SET_HANDLER(&Stripe::evacuateDocReadDone);
       ink_assert(ink_aio_read(&io) >= 0);
       return -1;
     }
@@ -647,7 +647,7 @@ Vol::evac_range(off_t low, off_t high, int evac_phase)
 static int
 agg_copy(char *p, CacheVC *vc)
 {
-  Vol *vol = vc->vol;
+  Stripe *vol = vc->vol;
   off_t o  = vol->header->write_pos + vol->agg_buf_pos;
 
   if (!vc->f.evacuator) {
@@ -801,7 +801,7 @@ agg_copy(char *p, CacheVC *vc)
 }
 
 inline void
-Vol::evacuate_cleanup_blocks(int i)
+Stripe::evacuate_cleanup_blocks(int i)
 {
   EvacuationBlock *b = evac_bucket_valid(i) ? evacuate[i].head : nullptr;
   while (b) {
@@ -819,7 +819,7 @@ Vol::evacuate_cleanup_blocks(int i)
 }
 
 void
-Vol::evacuate_cleanup()
+Stripe::evacuate_cleanup()
 {
   int64_t eo = ((header->write_pos - start) / CACHE_BLOCK_SIZE) + 1;
   int64_t e  = dir_offset_evac_bucket(eo);
@@ -850,7 +850,7 @@ Vol::evacuate_cleanup()
 }
 
 void
-Vol::periodic_scan()
+Stripe::periodic_scan()
 {
   evacuate_cleanup();
   scan_for_pinned_documents();
@@ -861,7 +861,7 @@ Vol::periodic_scan()
 }
 
 void
-Vol::agg_wrap()
+Stripe::agg_wrap()
 {
   header->write_pos = start;
   header->phase     = !header->phase;
@@ -871,7 +871,7 @@ Vol::agg_wrap()
   dir_lookaside_cleanup(this);
   dir_clean_vol(this);
   {
-    Vol *vol = this;
+    Stripe *vol = this;
     Metrics::increment(cache_rsb.directory_wrap);
     Metrics::increment(vol->cache_vol->vol_rsb.directory_wrap);
     Note("Cache volume %d on disk '%s' wraps around", vol->cache_vol->vol_number, vol->hash_text.get());
@@ -887,7 +887,7 @@ Vol::agg_wrap()
    the eventProcessor to schedule events
 */
 int
-Vol::aggWrite(int event, void * /* e ATS_UNUSED */)
+Stripe::aggWrite(int event, void * /* e ATS_UNUSED */)
 {
   ink_assert(!is_io_in_progress());
 
@@ -994,7 +994,7 @@ Lagain:
     for reads proceed independently.
    */
   io.thread = AIO_CALLBACK_THREAD_AIO;
-  SET_HANDLER(&Vol::aggWriteDone);
+  SET_HANDLER(&Stripe::aggWriteDone);
   ink_aio_write(&io);
 
 Lwait:
@@ -1561,7 +1561,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   c->vio.op  = VIO::WRITE;
   c->op_type = static_cast<int>(CacheOpType::Write);
   c->vol     = key_to_vol(key, hostname, host_len);
-  Vol *vol   = c->vol;
+  Stripe *vol = c->vol;
   Metrics::increment(cache_rsb.status[c->op_type].active);
   Metrics::increment(vol->cache_vol->vol_rsb.status[c->op_type].active);
   c->first_key = c->key = *key;
@@ -1639,7 +1639,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
   c->earliest_key = c->key;
   c->frag_type    = CACHE_FRAG_TYPE_HTTP;
   c->vol          = key_to_vol(key, hostname, host_len);
-  Vol *vol        = c->vol;
+  Stripe *vol     = c->vol;
   c->info         = info;
   if (c->info && (uintptr_t)info != CACHE_ALLOW_MULTIPLE_WRITES) {
     /*

--- a/src/iocore/cache/Makefile.am
+++ b/src/iocore/cache/Makefile.am
@@ -61,7 +61,7 @@ libinkcache_a_SOURCES = \
 	RamCacheCLFUS.cc \
 	RamCacheLRU.cc \
 	Store.cc \
-	Vol.cc
+	Stripe.cc
 
 if BUILD_TESTS
 libinkcache_a_SOURCES += \

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -31,7 +31,7 @@
 // aio
 #include "iocore/aio/AIO.h"
 
-struct Vol;
+struct Stripe;
 struct InterimCacheVol;
 struct CacheVC;
 class CacheEvacuateDocVC;
@@ -203,7 +203,7 @@ struct Dir {
 // INKqa11166 - Cache can not store 2 HTTP alternates simultaneously.
 // To allow this, move the vector from the CacheVC to the OpenDirEntry.
 // Each CacheVC now maintains a pointer to this vector. Adding/Deleting
-// alternates from this vector is done under the Vol::lock. The alternate
+// alternates from this vector is done under the Stripe::lock. The alternate
 // is deleted/inserted into the vector just before writing the vector disk
 // (CacheVC::updateVector).
 LINK_FORWARD_DECLARATION(CacheVC, opendir_link) // forward declaration
@@ -264,29 +264,29 @@ struct CacheSync : public Continuation {
 
 // Global Functions
 
-int dir_probe(const CacheKey *, Vol *, Dir *, Dir **);
-int dir_insert(const CacheKey *key, Vol *vol, Dir *to_part);
-int dir_overwrite(const CacheKey *key, Vol *vol, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
-int dir_delete(const CacheKey *key, Vol *vol, Dir *del);
-int dir_lookaside_probe(const CacheKey *key, Vol *vol, Dir *result, EvacuationBlock **eblock);
-int dir_lookaside_insert(EvacuationBlock *b, Vol *vol, Dir *to);
-int dir_lookaside_fixup(const CacheKey *key, Vol *vol);
-void dir_lookaside_cleanup(Vol *vol);
-void dir_lookaside_remove(const CacheKey *key, Vol *vol);
-void dir_free_entry(Dir *e, int s, Vol *vol);
+int dir_probe(const CacheKey *, Stripe *, Dir *, Dir **);
+int dir_insert(const CacheKey *key, Stripe *vol, Dir *to_part);
+int dir_overwrite(const CacheKey *key, Stripe *vol, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
+int dir_delete(const CacheKey *key, Stripe *vol, Dir *del);
+int dir_lookaside_probe(const CacheKey *key, Stripe *vol, Dir *result, EvacuationBlock **eblock);
+int dir_lookaside_insert(EvacuationBlock *b, Stripe *vol, Dir *to);
+int dir_lookaside_fixup(const CacheKey *key, Stripe *vol);
+void dir_lookaside_cleanup(Stripe *vol);
+void dir_lookaside_remove(const CacheKey *key, Stripe *vol);
+void dir_free_entry(Dir *e, int s, Stripe *vol);
 void dir_sync_init();
-int check_dir(Vol *vol);
-void dir_clean_vol(Vol *vol);
-void dir_clear_range(off_t start, off_t end, Vol *vol);
-int dir_segment_accounted(int s, Vol *vol, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
+int check_dir(Stripe *vol);
+void dir_clean_vol(Stripe *vol);
+void dir_clear_range(off_t start, off_t end, Stripe *vol);
+int dir_segment_accounted(int s, Stripe *vol, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
                           int *valid = nullptr, int *agg_valid = nullptr, int *avg_size = nullptr);
-uint64_t dir_entries_used(Vol *vol);
+uint64_t dir_entries_used(Stripe *vol);
 void sync_cache_dir_on_shutdown();
-int dir_freelist_length(Vol *vol, int s);
+int dir_freelist_length(Stripe *vol, int s);
 
-int dir_bucket_length(Dir *b, int s, Vol *vol);
-int dir_freelist_length(Vol *vol, int s);
-void dir_clean_segment(int s, Vol *vol);
+int dir_bucket_length(Dir *b, int s, Stripe *vol);
+int dir_freelist_length(Stripe *vol, int s);
+void dir_clean_segment(int s, Stripe *vol);
 
 // Inline Functions
 

--- a/src/iocore/cache/P_CacheDisk.h
+++ b/src/iocore/cache/P_CacheDisk.h
@@ -43,7 +43,7 @@ extern int cache_config_max_disk_errors;
 #define STORE_BLOCKS_PER_VOL (VOL_BLOCK_SIZE / STORE_BLOCK_SIZE)
 #define DISK_HEADER_MAGIC    0xABCD1237
 
-/* each disk vol block has a corresponding Vol object */
+/* each disk vol block has a corresponding Stripe object */
 struct CacheDisk;
 
 struct DiskStripeBlock {

--- a/src/iocore/cache/P_CacheDisk.h
+++ b/src/iocore/cache/P_CacheDisk.h
@@ -46,7 +46,7 @@ extern int cache_config_max_disk_errors;
 /* each disk vol block has a corresponding Vol object */
 struct CacheDisk;
 
-struct DiskVolBlock {
+struct DiskStripeBlock {
   uint64_t offset; // offset in bytes from the start of the disk
   uint64_t len;    // length in store blocks
   int number;
@@ -54,30 +54,30 @@ struct DiskVolBlock {
   unsigned int free : 1;
 };
 
-struct DiskVolBlockQueue {
-  DiskVolBlock *b = nullptr;
-  int new_block   = 0; /* whether an existing vol or a new one */
-  LINK(DiskVolBlockQueue, link);
+struct DiskStripeBlockQueue {
+  DiskStripeBlock *b = nullptr;
+  int new_block      = 0; /* whether an existing vol or a new one */
+  LINK(DiskStripeBlockQueue, link);
 
-  DiskVolBlockQueue() {}
+  DiskStripeBlockQueue() {}
 };
 
-struct DiskVol {
+struct DiskStripe {
   int num_volblocks; /* number of disk volume blocks in this volume */
   int vol_number;    /* the volume number of this volume */
   uint64_t size;     /* size in store blocks */
   CacheDisk *disk;
-  Queue<DiskVolBlockQueue> dpb_queue;
+  Queue<DiskStripeBlockQueue> dpb_queue;
 };
 
 struct DiskHeader {
   unsigned int magic;
-  unsigned int num_volumes;      /* number of discrete volumes (DiskVol) */
+  unsigned int num_volumes;      /* number of discrete volumes (DiskStripe) */
   unsigned int num_free;         /* number of disk volume blocks free */
   unsigned int num_used;         /* number of disk volume blocks in use */
   unsigned int num_diskvol_blks; /* number of disk volume blocks */
   uint64_t num_blocks;
-  DiskVolBlock vol_info[1];
+  DiskStripeBlock vol_info[1];
 };
 
 struct CacheDisk : public Continuation {
@@ -93,8 +93,8 @@ struct CacheDisk : public Continuation {
   int fd                  = -1;
   off_t free_space        = 0;
   off_t wasted_space      = 0;
-  DiskVol **disk_vols     = nullptr;
-  DiskVol *free_blocks    = nullptr;
+  DiskStripe **disk_vols  = nullptr;
+  DiskStripe *free_blocks = nullptr;
   int num_errors          = 0;
   int cleared             = 0;
   bool read_only_p        = false;
@@ -116,10 +116,10 @@ struct CacheDisk : public Continuation {
   int openDone(int event, void *data);
   int sync();
   int syncDone(int event, void *data);
-  DiskVolBlock *create_volume(int number, off_t size, int scheme);
+  DiskStripeBlock *create_volume(int number, off_t size, int scheme);
   int delete_volume(int number);
   int delete_all_volumes();
   void update_header();
-  DiskVol *get_diskvol(int vol_number);
+  DiskStripe *get_diskvol(int vol_number);
   void incrErrors(const AIOCallback *io);
 };

--- a/src/iocore/cache/P_CacheHosting.h
+++ b/src/iocore/cache/P_CacheHosting.h
@@ -30,7 +30,7 @@
 
 #define CACHE_MEM_FREE_TIMEOUT HRTIME_SECONDS(1)
 
-struct Vol;
+struct Stripe;
 struct CacheVol;
 
 struct CacheHostResult;
@@ -51,7 +51,7 @@ struct CacheHostRecord {
   }
 
   CacheType type                 = CACHE_NONE_TYPE;
-  Vol **vols                     = nullptr;
+  Stripe **vols                  = nullptr;
   int num_vols                   = 0;
   unsigned short *vol_hash_table = nullptr;
   CacheVol **cp                  = nullptr;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -131,20 +131,20 @@ struct Stripe : public Continuation {
   CryptoHash hash_id;
   int fd = -1;
 
-  char *raw_dir           = nullptr;
-  Dir *dir                = nullptr;
+  char *raw_dir               = nullptr;
+  Dir *dir                    = nullptr;
   StripteHeaderFooter *header = nullptr;
   StripteHeaderFooter *footer = nullptr;
-  int segments            = 0;
-  off_t buckets           = 0;
-  off_t recover_pos       = 0;
-  off_t prev_recover_pos  = 0;
-  off_t scan_pos          = 0;
-  off_t skip              = 0; // start of headers
-  off_t start             = 0; // start of data
-  off_t len               = 0;
-  off_t data_blocks       = 0;
-  int hit_evacuate_window = 0;
+  int segments                = 0;
+  off_t buckets               = 0;
+  off_t recover_pos           = 0;
+  off_t prev_recover_pos      = 0;
+  off_t scan_pos              = 0;
+  off_t skip                  = 0; // start of headers
+  off_t start                 = 0; // start of data
+  off_t len                   = 0;
+  off_t data_blocks           = 0;
+  int hit_evacuate_window     = 0;
   AIOCallbackInternal io;
 
   Queue<CacheVC, Continuation::Link_link> agg;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -38,7 +38,7 @@
 #define ROUND_TO_SECTOR(_p, _x)  INK_ALIGN((_x), _p->sector_size)
 #define ROUND_TO(_x, _y)         INK_ALIGN((_x), (_y))
 
-// Vol (volumes)
+// Stripe (volumes)
 #define VOL_MAGIC                    0xF1D0F00D
 #define START_BLOCKS                 16 // 8k, STORE_BLOCK_SIZE
 #define START_POS                    ((off_t)START_BLOCKS * CACHE_BLOCK_SIZE)
@@ -73,14 +73,14 @@
 #define DOC_NO_CHECKSUM ((uint32_t)0xA0B0C0D0)
 
 struct Cache;
-struct Vol;
+struct Stripe;
 struct CacheDisk;
-struct VolInitInfo;
+struct StripeInitInfo;
 struct DiskVol;
 struct CacheVol;
 class CacheEvacuateDocVC;
 
-struct VolHeaderFooter {
+struct StripteHeaderFooter {
   unsigned int magic;
   ts::VersionNumber version;
   time_t create_time;
@@ -125,7 +125,7 @@ struct EvacuationBlock {
   LINK(EvacuationBlock, link);
 };
 
-struct Vol : public Continuation {
+struct Stripe : public Continuation {
   char *path = nullptr;
   ats_scoped_str hash_text;
   CryptoHash hash_id;
@@ -133,8 +133,8 @@ struct Vol : public Continuation {
 
   char *raw_dir           = nullptr;
   Dir *dir                = nullptr;
-  VolHeaderFooter *header = nullptr;
-  VolHeaderFooter *footer = nullptr;
+  StripteHeaderFooter *header = nullptr;
+  StripteHeaderFooter *footer = nullptr;
   int segments            = 0;
   off_t buckets           = 0;
   off_t recover_pos       = 0;
@@ -163,7 +163,7 @@ struct Vol : public Continuation {
   DLL<EvacuationBlock> lookaside[LOOKASIDE_SIZE];
   CacheEvacuateDocVC *doc_evacuator = nullptr;
 
-  VolInitInfo *init_info = nullptr;
+  StripeInitInfo *init_info = nullptr;
 
   CacheDisk *disk            = nullptr;
   Cache *cache               = nullptr;
@@ -250,15 +250,15 @@ struct Vol : public Continuation {
   off_t vol_offset_to_offset(off_t pos) const;
   off_t vol_relative_length(off_t start_offset) const;
 
-  Vol() : Continuation(new_ProxyMutex())
+  Stripe() : Continuation(new_ProxyMutex())
   {
     open_dir.mutex = mutex;
     agg_buffer     = (char *)ats_memalign(ats_pagesize(), AGG_SIZE);
     memset(agg_buffer, 0, AGG_SIZE);
-    SET_HANDLER(&Vol::aggWrite);
+    SET_HANDLER(&Stripe::aggWrite);
   }
 
-  ~Vol() override { ats_free(agg_buffer); }
+  ~Stripe() override { ats_free(agg_buffer); }
 };
 
 struct AIO_failure_handler : public Continuation {
@@ -273,7 +273,7 @@ struct CacheVol {
   off_t size            = 0;
   int num_vols          = 0;
   bool ramcache_enabled = true;
-  Vol **vols            = nullptr;
+  Stripe **vols         = nullptr;
   DiskVol **disk_vols   = nullptr;
   LINK(CacheVol, link);
   // per volume stats
@@ -318,7 +318,7 @@ struct Doc {
 
 // Global Data
 
-extern Vol **gvol;
+extern Stripe **gvol;
 extern std::atomic<int> gnvol;
 extern ClassAllocator<OpenDirEntry> openDirEntryAllocator;
 extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;
@@ -328,81 +328,81 @@ extern unsigned short *vol_hash_table;
 // inline Functions
 
 inline int
-Vol::headerlen() const
+Stripe::headerlen() const
 {
-  return ROUND_TO_STORE_BLOCK(sizeof(VolHeaderFooter) + sizeof(uint16_t) * (this->segments - 1));
+  return ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter) + sizeof(uint16_t) * (this->segments - 1));
 }
 
 inline Dir *
-Vol::dir_segment(int s) const
+Stripe::dir_segment(int s) const
 {
   return (Dir *)(((char *)this->dir) + (s * this->buckets) * DIR_DEPTH * SIZEOF_DIR);
 }
 
 inline size_t
-Vol::dirlen() const
+Stripe::dirlen() const
 {
   return this->headerlen() + ROUND_TO_STORE_BLOCK(((size_t)this->buckets) * DIR_DEPTH * this->segments * SIZEOF_DIR) +
-         ROUND_TO_STORE_BLOCK(sizeof(VolHeaderFooter));
+         ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
 }
 
 inline int
-Vol::direntries() const
+Stripe::direntries() const
 {
   return this->buckets * DIR_DEPTH * this->segments;
 }
 
 inline int
-Vol::vol_out_of_phase_valid(Dir *e) const
+Stripe::vol_out_of_phase_valid(Dir *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Vol::vol_out_of_phase_agg_valid(Dir *e) const
+Stripe::vol_out_of_phase_agg_valid(Dir *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start + AGG_SIZE) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Vol::vol_out_of_phase_write_valid(Dir *e) const
+Stripe::vol_out_of_phase_write_valid(Dir *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->write_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Vol::vol_in_phase_valid(Dir *e) const
+Stripe::vol_in_phase_valid(Dir *e) const
 {
   return (dir_offset(e) - 1 < ((this->header->write_pos + this->agg_buf_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline off_t
-Vol::vol_offset(Dir *e) const
+Stripe::vol_offset(Dir *e) const
 {
   return this->start + (off_t)dir_offset(e) * CACHE_BLOCK_SIZE - CACHE_BLOCK_SIZE;
 }
 
 inline off_t
-Vol::offset_to_vol_offset(off_t pos) const
+Stripe::offset_to_vol_offset(off_t pos) const
 {
   return ((pos - this->start + CACHE_BLOCK_SIZE) / CACHE_BLOCK_SIZE);
 }
 
 inline off_t
-Vol::vol_offset_to_offset(off_t pos) const
+Stripe::vol_offset_to_offset(off_t pos) const
 {
   return this->start + pos * CACHE_BLOCK_SIZE - CACHE_BLOCK_SIZE;
 }
 
 inline int
-Vol::vol_in_phase_agg_buf_valid(Dir *e) const
+Stripe::vol_in_phase_agg_buf_valid(Dir *e) const
 {
   return (this->vol_offset(e) >= this->header->write_pos && this->vol_offset(e) < (this->header->write_pos + this->agg_buf_pos));
 }
 
 // length of the partition not including the offset of location 0.
 inline off_t
-Vol::vol_relative_length(off_t start_offset) const
+Stripe::vol_relative_length(off_t start_offset) const
 {
   return (this->len + this->skip) - start_offset;
 }
@@ -437,13 +437,13 @@ Doc::data()
   return this->hdr() + hlen;
 }
 
-int vol_dir_clear(Vol *vol);
-int vol_init(Vol *vol, char *s, off_t blocks, off_t skip, bool clear);
+int vol_dir_clear(Stripe *vol);
+int vol_init(Stripe *vol, char *s, off_t blocks, off_t skip, bool clear);
 
 // inline Functions
 
 inline EvacuationBlock *
-evacuation_block_exists(Dir *dir, Vol *p)
+evacuation_block_exists(Dir *dir, Stripe *p)
 {
   auto bucket = dir_evac_bucket(dir);
   if (p->evac_bucket_valid(bucket)) {
@@ -456,7 +456,7 @@ evacuation_block_exists(Dir *dir, Vol *p)
 }
 
 inline void
-Vol::cancel_trigger()
+Stripe::cancel_trigger()
 {
   if (trigger) {
     trigger->cancel_action();
@@ -488,13 +488,13 @@ free_EvacuationBlock(EvacuationBlock *b, EThread *t)
 }
 
 inline OpenDirEntry *
-Vol::open_read(const CryptoHash *key) const
+Stripe::open_read(const CryptoHash *key) const
 {
   return open_dir.open_read(key);
 }
 
 inline int
-Vol::within_hit_evacuate_window(Dir *xdir) const
+Stripe::within_hit_evacuate_window(Dir *xdir) const
 {
   off_t oft       = dir_offset(xdir) - 1;
   off_t write_off = (header->write_pos + AGG_SIZE - start) / CACHE_BLOCK_SIZE;
@@ -506,26 +506,26 @@ Vol::within_hit_evacuate_window(Dir *xdir) const
 }
 
 inline uint32_t
-Vol::round_to_approx_size(uint32_t l) const
+Stripe::round_to_approx_size(uint32_t l) const
 {
   uint32_t ll = round_to_approx_dir_size(l);
   return ROUND_TO_SECTOR(this, ll);
 }
 
 inline bool
-Vol::evac_bucket_valid(off_t bucket) const
+Stripe::evac_bucket_valid(off_t bucket) const
 {
   return (bucket >= 0 && bucket < evacuate_size);
 }
 
 inline int
-Vol::is_io_in_progress() const
+Stripe::is_io_in_progress() const
 {
   return io.aiocb.aio_fildes != AIO_NOT_IN_PROGRESS;
 }
 
 inline void
-Vol::set_io_not_in_progress()
+Stripe::set_io_not_in_progress()
 {
   io.aiocb.aio_fildes = AIO_NOT_IN_PROGRESS;
 }

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -76,7 +76,7 @@ struct Cache;
 struct Stripe;
 struct CacheDisk;
 struct StripeInitInfo;
-struct DiskVol;
+struct DiskStripe;
 struct CacheVol;
 class CacheEvacuateDocVC;
 
@@ -268,13 +268,13 @@ struct AIO_failure_handler : public Continuation {
 };
 
 struct CacheVol {
-  int vol_number        = -1;
-  int scheme            = 0;
-  off_t size            = 0;
-  int num_vols          = 0;
-  bool ramcache_enabled = true;
-  Stripe **vols         = nullptr;
-  DiskVol **disk_vols   = nullptr;
+  int vol_number         = -1;
+  int scheme             = 0;
+  off_t size             = 0;
+  int num_vols           = 0;
+  bool ramcache_enabled  = true;
+  Stripe **vols          = nullptr;
+  DiskStripe **disk_vols = nullptr;
   LINK(CacheVol, link);
   // per volume stats
   CacheStatsBlock vol_rsb;

--- a/src/iocore/cache/P_RamCache.h
+++ b/src/iocore/cache/P_RamCache.h
@@ -36,7 +36,7 @@ public:
   virtual int fixup(const CryptoHash *key, uint64_t old_auxkey, uint64_t new_auxkey)                         = 0;
   virtual int64_t size() const                                                                               = 0;
 
-  virtual void init(int64_t max_bytes, Vol *vol) = 0;
+  virtual void init(int64_t max_bytes, Stripe *vol) = 0;
   virtual ~RamCache(){};
 };
 

--- a/src/iocore/cache/RamCacheCLFUS.cc
+++ b/src/iocore/cache/RamCacheCLFUS.cc
@@ -90,12 +90,12 @@ public:
   int fixup(const CryptoHash *key, uint64_t old_auxkey, uint64_t new_auxkey) override;
   int64_t size() const override;
 
-  void init(int64_t max_bytes, Vol *vol) override;
+  void init(int64_t max_bytes, Stripe *vol) override;
 
   void compress_entries(EThread *thread, int do_at_most = INT_MAX);
 
   // TODO move it to private.
-  Vol *vol = nullptr; // for stats
+  Stripe *vol = nullptr; // for stats
 private:
   int64_t _max_bytes = 0;
   int64_t _bytes     = 0;
@@ -203,7 +203,7 @@ RamCacheCLFUS::_resize_hashtable()
 }
 
 void
-RamCacheCLFUS::init(int64_t abytes, Vol *avol)
+RamCacheCLFUS::init(int64_t abytes, Stripe *avol)
 {
   ink_assert(avol != nullptr);
   vol              = avol;

--- a/src/iocore/cache/RamCacheLRU.cc
+++ b/src/iocore/cache/RamCacheLRU.cc
@@ -44,7 +44,7 @@ struct RamCacheLRU : public RamCache {
   int fixup(const CryptoHash *key, uint64_t old_auxkey, uint64_t new_auxkey) override;
   int64_t size() const override;
 
-  void init(int64_t max_bytes, Vol *vol) override;
+  void init(int64_t max_bytes, Stripe *vol) override;
 
   // private
   uint16_t *seen = nullptr;
@@ -52,7 +52,7 @@ struct RamCacheLRU : public RamCache {
   DList(RamCacheLRUEntry, hash_link) *bucket = nullptr;
   int nbuckets                               = 0;
   int ibuckets                               = 0;
-  Vol *vol                                   = nullptr;
+  Stripe *vol                                = nullptr;
 
   void resize_hashtable();
   RamCacheLRUEntry *remove(RamCacheLRUEntry *e);
@@ -116,7 +116,7 @@ RamCacheLRU::resize_hashtable()
 }
 
 void
-RamCacheLRU::init(int64_t abytes, Vol *avol)
+RamCacheLRU::init(int64_t abytes, Stripe *avol)
 {
   vol       = avol;
   max_bytes = abytes;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -140,7 +140,7 @@ struct StripeInitInfo {
 };
 
 ////
-// Vol
+// Stripe
 //
 
 int

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -54,7 +54,7 @@ regress_rand_CacheKey(const CacheKey *key)
 }
 
 void
-dir_corrupt_bucket(Dir *b, int s, Vol *vol)
+dir_corrupt_bucket(Dir *b, int s, Stripe *vol)
 {
   int l    = (static_cast<int>(dir_bucket_length(b, s, vol) * ts::Random::drandom()));
   Dir *e   = b;
@@ -80,7 +80,7 @@ public:
     REQUIRE(CacheProcessor::IsCacheEnabled() == CACHE_INITIALIZED);
     REQUIRE(gnvol >= 1);
 
-    Vol *vol        = gvol[0];
+    Stripe *vol     = gvol[0];
     EThread *thread = this_ethread();
     MUTEX_TRY_LOCK(lock, vol->mutex, thread);
     if (!lock.is_locked()) {

--- a/src/iocore/cache/unit_tests/test_CacheVol.cc
+++ b/src/iocore/cache/unit_tests/test_CacheVol.cc
@@ -254,14 +254,14 @@ execute_and_verify()
         int m_vols = 0;
         for (d_no = 0; d_no < gndisks; d_no++) {
           if (cachep->disk_vols[d_no]) {
-            DiskVol *dp = cachep->disk_vols[d_no];
-            // DiskVols and CacheVols should match
+            DiskStripe *dp = cachep->disk_vols[d_no];
+            // DiskStripes and CacheVols should match
             REQUIRE(dp->vol_number == cachep->vol_number);
 
             /* check the diskvolblock queue */
-            DiskVolBlockQueue *dpbq = dp->dpb_queue.head;
+            DiskStripeBlockQueue *dpbq = dp->dpb_queue.head;
             while (dpbq) {
-              // DiskVol and DiskVolBlocks should match
+              // DiskStripe and DiskStripeBlocks should match
               REQUIRE(dpbq->b->number == cachep->vol_number);
               dpbq = dpbq->link.next;
             }
@@ -269,7 +269,7 @@ execute_and_verify()
             m_vols += dp->num_volblocks;
           }
         }
-        // Num volumes in CacheVol and DiskVol should match
+        // Num volumes in CacheVol and DiskStripe should match
         REQUIRE(m_vols == cachep->num_vols);
 
         matched++;

--- a/src/iocore/cache/unit_tests/test_CacheVol.cc
+++ b/src/iocore/cache/unit_tests/test_CacheVol.cc
@@ -285,9 +285,10 @@ execute_and_verify()
   for (int i = 0; i < gndisks; i++) {
     CacheDisk *d = gdisks[i];
     if (dbg_ctl_cache_hosting.on()) {
-      Dbg(dbg_ctl_cache_hosting, "Disk: %d: Vol Blocks: %u: Free space: %" PRIu64, i, d->header->num_diskvol_blks, d->free_space);
+      Dbg(dbg_ctl_cache_hosting, "Disk: %d: Stripe Blocks: %u: Free space: %" PRIu64, i, d->header->num_diskvol_blks,
+          d->free_space);
       for (int j = 0; j < static_cast<int>(d->header->num_volumes); j++) {
-        Dbg(dbg_ctl_cache_hosting, "\tVol: %d Size: %" PRIu64, d->disk_vols[j]->vol_number, d->disk_vols[j]->size);
+        Dbg(dbg_ctl_cache_hosting, "\tStripe: %d Size: %" PRIu64, d->disk_vols[j]->vol_number, d->disk_vols[j]->size);
       }
       for (int j = 0; j < static_cast<int>(d->header->num_diskvol_blks); j++) {
         Dbg(dbg_ctl_cache_hosting, "\tBlock No: %d Size: %" PRIu64 " Free: %u", d->header->vol_info[j].number,

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -109,7 +109,7 @@ public:
 
     @note Serializable.
 
-    @internal nee @c DiskVolBlock
+    @internal nee @c DiskStripeBlock
  */
 struct CacheStripeDescriptor {
   Bytes offset;         // offset of start of stripe from start of span.
@@ -128,7 +128,7 @@ struct CacheStripeDescriptor {
 struct SpanHeader {
   static constexpr uint32_t MAGIC = 0xABCD1237;
   uint32_t magic;
-  uint32_t num_volumes;      /* number of discrete volumes (DiskVol) */
+  uint32_t num_volumes;      /* number of discrete volumes (DiskStripe) */
   uint32_t num_free;         /* number of disk volume blocks free */
   uint32_t num_used;         /* number of disk volume blocks in use */
   uint32_t num_diskvol_blks; /* number of disk volume blocks */

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -139,7 +139,7 @@ struct SpanHeader {
 
 /** Stripe data, serialized format.
 
-    @internal nee VolHeadFooter
+    @internal StripeHeaderFooter
  */
 // the counterpart of this structure in ATS is called StripeHeaderFooter
 class StripeMeta

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -141,7 +141,7 @@ struct SpanHeader {
 
     @internal nee VolHeadFooter
  */
-// the counterpart of this structure in ATS is called VolHeaderFooter
+// the counterpart of this structure in ATS is called StripeHeaderFooter
 class StripeMeta
 {
 public:


### PR DESCRIPTION
Part of #10628. 

The main change is renaming below struct(s) 
```
struct Vol;
struct VolInitInfo;
struct VolHeaderFooter;

struct DiskVol;
struct DiskVolBlock;
struct DiskVolBlockQueue;
```
to

```
struct Stripe;
struct StripeInitInfo;
struct StripeHeaderFooter;

struct DiskStripe;
struct DiskStripeBlock;
struct DiskStripeBlockQueue;
```

Almost all of changes are done by running "Rename Symbol" on VSCode (powered by clangd?)

Renaming arguments (like `vol` or `d`) and functions (like `vol_init_data`) will be done in other following PRs.