### PR TITLE
generate svg files from uml for docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -29,6 +29,49 @@ configure_file(ext/traffic-server.cmake.in.py ext/traffic-server.py)
 configure_file(conf.cmake.in.py conf.py)
 configure_file(manpages.cmake.in.py manpages.py)
 
+# copy static directory to build
+add_custom_target(
+  generate_docs_setup
+  COMMENT "Copy static files to build directory"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+          ${CMAKE_CURRENT_SOURCE_DIR}/static
+          ${CMAKE_CURRENT_BINARY_DIR}/static
+)
+
+# generate svg files from uml files
+set(UML_FILES
+  uml/JsonRPCManager.uml
+  uml/TLS-Bridge-Messages.uml
+  uml/TLS-Bridge-Plugin.uml
+  uml/hdr-heap-class.plantuml
+  uml/hdr-heap-str-alloc.plantuml
+  uml/host-resolve.plantuml
+  uml/l4-basic-sequence.uml
+  uml/l4-example-cdn-layout.uml
+  uml/l4-pre-warming-overview.uml
+  uml/l4-sni-routing-seq.uml
+  uml/l4-tcp-routing.uml
+  uml/traffic_ctl-class-diagram.uml
+  uml/url_rewrite.plantuml
+)
+# unfortunately, sphinx can't look else for files than its source directory
+# so these files must be create in the source tree
+foreach(UML ${UML_FILES})
+  cmake_path(GET UML STEM uml_name)
+  list(APPEND SVG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/uml/images/${uml_name}.svg)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/uml/images/${uml_name}.svg
+    COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_JAR} -o ${CMAKE_CURRENT_SOURCE_DIR}/uml/images -tsvg ${CMAKE_CURRENT_SOURCE_DIR}/${UML}
+    DEPENDS ${UML}
+    VERBATIM
+  )
+endforeach()
+add_custom_target(
+  generate_svg_from_uml
+  DEPENDS
+  ${SVG_FILES}
+)
+
 # Docs are built with python so we need a target to setup pipenv
 set(RUNPIPENV PIPENV_PIPFILE=${CMAKE_CURRENT_SOURCE_DIR}/Pipfile ${PipEnv})
 add_custom_command(
@@ -44,9 +87,10 @@ add_custom_target(
   COMMAND ${RUNPIPENV} run python ${CMAKE_CURRENT_SOURCE_DIR}/checkvers.py --check-version
   COMMAND ${RUNPIPENV} run python -m sphinx -c ${CMAKE_CURRENT_BINARY_DIR} -b html ${CMAKE_CURRENT_SOURCE_DIR}
           ${CMAKE_CURRENT_BINARY_DIR}/docbuild/html
-  DEPENDS Pipfile.lock
+  DEPENDS generate_docs_setup generate_svg_from_uml Pipfile.lock
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
 #add_custom_command(
 #    TARGET generate_docs
 #    POST_BUILD


### PR DESCRIPTION
@bneradt noticed the cmake docs build was missing some images.  This PR generates the `svg` files from `uml` so they can be included in the docs.