### PR TITLE
Don't make boringssl mandatory when QUIC & quiche is enabled/used.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ endif()
 find_package(PCRE REQUIRED)
 
 include(CheckOpenSSLIsBoringSSL)
+include(CheckOpenSSLIsQuictls)
 find_package(OpenSSL REQUIRED)
 check_openssl_is_boringssl(OPENSSL_IS_BORINGSSL BORINGSSL_VERSION "${OPENSSL_INCLUDE_DIR}")
 
@@ -291,6 +292,7 @@ else()
     message(FATAL_ERROR "OpenSSL version >= ${min_ossl} or BoringSSL required")
   endif()
 endif()
+check_openssl_is_quictls(OPENSSL_IS_QUICTLS "${OPENSSL_INCLUDE_DIR}")
 
 if(OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0")
   set(OPENSSL_IS_OPENSSL3 TRUE)
@@ -317,9 +319,8 @@ if(ENABLE_QUICHE)
 
   set(TS_HAS_QUICHE ${quiche_FOUND})
   set(TS_USE_QUIC ${TS_HAS_QUICHE})
-
-  if(NOT OPENSSL_IS_BORINGSSL)
-    message(FATAL_ERROR "Use of BoringSSL is required if quiche is used.")
+  if(NOT OPENSSL_IS_BORINGSSL AND NOT OPENSSL_IS_QUICTLS)
+    message(FATAL_ERROR "Use of BoringSSL or OPENSSL/QUICTLS is required if quiche is used.")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,14 @@ if(ENABLE_QUICHE)
   if(NOT OPENSSL_IS_BORINGSSL AND NOT OPENSSL_IS_QUICTLS)
     message(FATAL_ERROR "Use of BoringSSL or OPENSSL/QUICTLS is required if quiche is used.")
   endif()
+
+  if(OPENSSL_IS_QUICTLS)
+    # Until we get quictls support integrated with quiche, we just print this message.
+    # Once the above that is done, then we can just validate the version.
+    message(
+      "WARNING - Using quictls requires using a special version of quiche. Make sure quictls is supported in quiche."
+    )
+  endif()
 endif()
 
 find_package(maxminddb) # Header_rewrite experimental/maxmind_acl

--- a/cmake/CheckOpenSSLIsQuictls.cmake
+++ b/cmake/CheckOpenSSLIsQuictls.cmake
@@ -1,0 +1,35 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+function(CHECK_OPENSSL_IS_QUICTLS OUT_VAR OPENSSL_INCLUDE_DIR)
+  set(CHECK_PROGRAM
+      "
+        #include <openssl/quic.h>
+
+        #ifndef OPENSSL_INFO_QUIC
+        #error check failed
+        #endif
+
+        int main() {
+            return 0;
+        }
+        "
+  )
+  set(CMAKE_REQUIRED_INCLUDES "${OPENSSL_INCLUDE_DIR}")
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_compiles("${CHECK_PROGRAM}" ${OUT_VAR})
+endfunction()


### PR DESCRIPTION
If quiche is enabled, then we should allow for openssl/quictls to be used, specially if we have quiche/openssl support.