### PR TITLE
Do not overwrite the error code of GOAWAY frame

### DIFF
--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -837,7 +837,7 @@ Http2ConnectionState::rcv_goaway_frame(const Http2Frame &frame)
 {
   Http2Goaway goaway;
   char buf[HTTP2_GOAWAY_LEN];
-  unsigned nbytes               = 0;
+  char *end;
   const Http2StreamId stream_id = frame.header().streamid;
 
   Http2StreamDebug(this->session, stream_id, "Received GOAWAY frame");
@@ -849,18 +849,11 @@ Http2ConnectionState::rcv_goaway_frame(const Http2Frame &frame)
                       "goaway id non-zero");
   }
 
-  while (nbytes < frame.header().length) {
-    unsigned read_bytes = read_rcv_buffer(buf, sizeof(buf), nbytes, frame);
+  end = frame.reader()->memcpy(buf, sizeof(buf), 0);
 
-    if (nbytes == HTTP2_GOAWAY_LEN) {
-      // Read Last-Stream-ID and Error Code
-      if (!http2_parse_goaway(make_iovec(buf, read_bytes), goaway)) {
-        return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
-                          "goaway failed parse");
-      }
-    } else {
-      // TODO: Parse additional debug data
-    }
+  if (!http2_parse_goaway(make_iovec(buf, end - buf), goaway)) {
+    return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
+                      "goaway failed parse");
   }
 
   Http2StreamDebug(this->session, stream_id, "GOAWAY: last stream id=%d, error code=%d", goaway.last_streamid,


### PR DESCRIPTION
We've been seeing some strange error codes being logged with H2 traffic, such as this one `S20666169` (where `S` stands for session).

Turns out when ATS processes GOAWAY frames, it overwrote error code with `Additional Debug Data` (https://datatracker.ietf.org/doc/html/rfc7540#section-6.8). This patch fixes the issue.