### PR TITLE
Fix cmake test for 128 bit CAS.

### DIFF
--- a/cmake/Check128BitCas.cmake
+++ b/cmake/Check128BitCas.cmake
@@ -25,13 +25,10 @@
 
 set(CHECK_PROGRAM
     "
-    int
-    main()
+    int main(void)
     {
         __int128_t x = 0;
-        __sync_bool_compare_and_swap(&x,0,10);
-
-        return 0;
+        return __sync_bool_compare_and_swap(&x,0,10);
     }
     "
 )
@@ -41,7 +38,7 @@ check_c_source_compiles("${CHECK_PROGRAM}" TS_HAS_128BIT_CAS)
 
 if(NOT TS_HAS_128BIT_CAS)
     unset(TS_HAS_128BIT_CAS CACHE)
-    set(CMAKE_REQUIRED_FLAGS "-Werror" "-mcx16")
+    set(CMAKE_REQUIRED_FLAGS "-Werror -mcx16")
     check_c_source_compiles("${CHECK_PROGRAM}" TS_HAS_128BIT_CAS)
     set(NEED_MCX16 ${TS_HAS_128BIT_CAS})
     unset(CMAKE_REQUIRED_FLAGS)


### PR DESCRIPTION
The cmake check_c_source_compiles() function seems to want to successfully link as well as compile the sample code.

https://godbolt.org/z/oGGcGY7Gn

https://stackoverflow.com/questions/62391538/how-can-i-link-sync-bool-compare-and-swap-16