### PR TITLE
CacheVC::openWriteCloseDir: fix metric array indexing

### DIFF
--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -1048,8 +1048,8 @@ CacheVC::openWriteCloseDir(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED *
   if ((closed == 1) && (total_len > 0 || f.allow_empty_doc)) {
     DDbg(dbg_ctl_cache_stats, "Fragment = %d", fragment);
 
-    Metrics::increment(cache_rsb.fragment_document_count[std::max(fragment, 2)]);
-    Metrics::increment(vol->cache_vol->vol_rsb.fragment_document_count[std::max(fragment, 2)]);
+    Metrics::increment(cache_rsb.fragment_document_count[std::clamp(fragment, 0, 2)]);
+    Metrics::increment(vol->cache_vol->vol_rsb.fragment_document_count[std::clamp(fragment, 0, 2)]);
   }
   if (f.close_complete) {
     recursive++;


### PR DESCRIPTION
The fragment_document_count is an array of size 3. Our logic for accessing it was supposed to clamp indexing into it between values 0 through 2, but accidentally allowed indexing outside of that range. This resulted in an out of bounds index into random memory. This fixes the logic to properly clamp to the appropriate values.

For reference here's the old logic before our recent Metrics change:
https://github.com/apache/trafficserver/pull/10175/files#diff-6ac65bcc29d9196567a0bbff3c7aa6705ebb7a6041f4a5706b6b475202d4934dL1200