### PR TITLE
Update ACCEPT thread configurations

### DIFF
--- a/include/iocore/net/NetHandler.h
+++ b/include/iocore/net/NetHandler.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "iocore/eventsystem/Continuation.h"
 #include "iocore/eventsystem/EThread.h"
 #include "iocore/net/NetEvent.h"
@@ -115,7 +117,6 @@ public:
     uint32_t transaction_no_activity_timeout_in = 0;
     uint32_t keep_alive_no_activity_timeout_in  = 0;
     uint32_t default_inactivity_timeout         = 0;
-    uint32_t additional_accepts                 = 0;
 
     /** Return the address of the first value in this struct.
 
@@ -165,7 +166,7 @@ public:
   void remove_from_keep_alive_queue(NetEvent *ne);
   bool add_to_active_queue(NetEvent *ne);
   void remove_from_active_queue(NetEvent *ne);
-  int get_additional_accepts();
+  static int get_additional_accepts();
 
   /// Per process initialization logic.
   static void init_for_process();
@@ -229,6 +230,13 @@ public:
   inline static DbgCtl dbg_ctl_iocore_net{"iocore_net"};
 
 private:
+  // The following settings are used potentially by accept threads. These are
+  // shared across threads via std::atomic rather than being pulled through a
+  // TS_EVENT_MGMT_UPDATE event like with the Config settings above because
+  // accept threads are not always on a standard NET thread with a NetHandler
+  // that has TS_EVENT_MGMT_UPDATE handling logic.
+  static std::atomic<uint32_t> additional_accepts;
+
   void _close_ne(NetEvent *ne, ink_hrtime now, int &handle_event, int &closed, int &total_idle_time, int &total_idle_count);
 
   /// Static method used as the callback for runtime configuration updates.

--- a/src/iocore/net/NetHandler.cc
+++ b/src/iocore/net/NetHandler.cc
@@ -34,6 +34,8 @@
 
 using namespace std::literals;
 
+std::atomic<uint32_t> NetHandler::additional_accepts{0};
+
 // NetHandler method definitions
 
 NetHandler::NetHandler() : Continuation(nullptr)
@@ -132,7 +134,7 @@ NetHandler::update_nethandler_config(const char *str, RecDataT, RecData data, vo
     updated_member = &NetHandler::global_config.default_inactivity_timeout;
     Debug("net_queue", "proxy.config.net.default_inactivity_timeout updated to %" PRId64, data.rec_int);
   } else if (name == "proxy.config.net.additional_accepts"sv) {
-    updated_member = &NetHandler::global_config.additional_accepts;
+    NetHandler::additional_accepts.store(data.rec_int, std::memory_order_relaxed);
     Debug("net_queue", "proxy.config.net.additional_accepts updated to %" PRId64, data.rec_int);
   }
 
@@ -169,7 +171,12 @@ NetHandler::init_for_process()
   REC_ReadConfigInt32(global_config.transaction_no_activity_timeout_in, "proxy.config.net.transaction_no_activity_timeout_in");
   REC_ReadConfigInt32(global_config.keep_alive_no_activity_timeout_in, "proxy.config.net.keep_alive_no_activity_timeout_in");
   REC_ReadConfigInt32(global_config.default_inactivity_timeout, "proxy.config.net.default_inactivity_timeout");
-  REC_ReadConfigInt32(global_config.additional_accepts, "proxy.config.net.additional_accepts");
+
+  // Atomic configurations.
+  uint32_t val = 0;
+
+  REC_ReadConfigInt32(val, "proxy.config.net.additional_accepts");
+  additional_accepts.store(val, std::memory_order_relaxed);
 
   RecRegisterConfigUpdateCb("proxy.config.net.max_connections_in", update_nethandler_config, nullptr);
   RecRegisterConfigUpdateCb("proxy.config.net.max_requests_in", update_nethandler_config, nullptr);
@@ -187,7 +194,7 @@ NetHandler::init_for_process()
   Debug("net_queue", "proxy.config.net.keep_alive_no_activity_timeout_in updated to %d",
         global_config.keep_alive_no_activity_timeout_in);
   Debug("net_queue", "proxy.config.net.default_inactivity_timeout updated to %d", global_config.default_inactivity_timeout);
-  Debug("net_queue", "proxy.config.net.additional_accepts updated to %d", global_config.additional_accepts);
+  Debug("net_queue", "proxy.config.net.additional_accepts updated to %d", additional_accepts.load(std::memory_order_relaxed));
 }
 
 //
@@ -580,6 +587,6 @@ NetHandler::remove_from_active_queue(NetEvent *ne)
 int
 NetHandler::get_additional_accepts()
 {
-  int config_value = config.additional_accepts + 1;
+  int config_value = additional_accepts.load(std::memory_order_relaxed) + 1;
   return (config_value > 0 ? config_value : INT32_MAX - 1);
 }

--- a/src/iocore/net/UnixNetAccept.cc
+++ b/src/iocore/net/UnixNetAccept.cc
@@ -54,8 +54,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
   UnixNetVConnection *vc = nullptr;
   Connection con;
 
-  EThread *t             = e->ethread;
-  int additional_accepts = get_NetHandler(t)->get_additional_accepts();
+  int additional_accepts = NetHandler::get_additional_accepts();
 
   if (!blockable) {
     if (!MUTEX_TAKE_TRY_LOCK(na->action_->mutex, e->ethread)) {
@@ -303,7 +302,7 @@ NetAccept::do_blocking_accept(EThread *t)
   con.sock_type = SOCK_STREAM;
 
   int count              = 0;
-  int additional_accepts = get_NetHandler(t)->get_additional_accepts();
+  int additional_accepts = NetHandler::get_additional_accepts();
 
   // do-while for accepting all the connections
   // added by YTS Team, yamsat
@@ -447,7 +446,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
   int count              = 0;
   EThread *t             = e->ethread;
   NetHandler *h          = get_NetHandler(t);
-  int additional_accepts = h->get_additional_accepts();
+  int additional_accepts = NetHandler::get_additional_accepts();
 
   do {
     socklen_t sz = sizeof(con.addr);


### PR DESCRIPTION
Before this change, ACCEPT NetHandler instances would not have their configurations updated, leaving them at their initialized defaults (usually 0). This should fix things for get_additional_accepts calls.