### PR TITLE
proxy.config.net.per_client.max_connections_in

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -511,18 +511,20 @@ Network
    :reloadable:
 
    The total number of concurrent client connections that |TS| will accept from
-   a given client. Any received connections from a client beyond this limit will
-   be immediately closed.  Once the number of concurrent client connections
-   drops below this configured value, |TS| will begin accepting new connections
-   while the number of concurrent connections remains below this limit. A value
-   of 0 disables the per client concurrent connection limit.
+   a given client IP address. Any received connections from a client beyond this
+   limit will be immediately closed.  Once the number of concurrent client
+   connections drops below this configured value, |TS| will begin accepting new
+   connections from that IP while the number of concurrent connections remains
+   below this limit. A value of 0 disables the per client concurrent connection
+   limit.
 
 .. ts:cv:: CONFIG proxy.config.http.per_client.connection.alert_delay INT 60
    :reloadable:
    :units: seconds
 
-   Throttle alerts per client group to be no more often than this many seconds. Summary
-   data is provided per alert to allow log scrubbing to generate accurate data.
+   Throttle alerts per client IP address to be no more often than this many
+   seconds. Summary data is provided per alert to allow log scrubbing to
+   generate accurate data.
 
 .. ts:cv:: CONFIG proxy.config.net.max_requests_in INT 0
 

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -507,6 +507,23 @@ Network
    between `proxy.config.net.max_connections_in` and `proxy.config.net.max_requests_in`
    is the amount of maximum idle (keepalive) connections |TS| will maintain.
 
+.. ts:cv:: CONFIG proxy.config.net.per_client.max_connections_in INT 0
+   :reloadable:
+
+   The total number of concurrent client connections that |TS| will accept from
+   a given client. Any received connections from a client beyond this limit will
+   be immediately closed.  Once the number of concurrent client connections
+   drops below this configured value, |TS| will begin accepting new connections
+   while the number of concurrent connections remains below this limit. A value
+   of 0 disables the per client concurrent connection limit.
+
+.. ts:cv:: CONFIG proxy.config.http.per_client.connection.alert_delay INT 60
+   :reloadable:
+   :units: seconds
+
+   Throttle alerts per client group to be no more often than this many seconds. Summary
+   data is provided per alert to allow log scrubbing to generate accurate data.
+
 .. ts:cv:: CONFIG proxy.config.net.max_requests_in INT 0
 
    The total number of concurrent requests or active client connections

--- a/include/iocore/net/ConnectionTracker.h
+++ b/include/iocore/net/ConnectionTracker.h
@@ -47,9 +47,10 @@
 /**
  * Singleton class to keep track of the number of inbound and outbound connections.
  *
- * Outbound connections are divided in to equivalence classes (called "groups" here) based on the
- * session matching setting. Tracking data is stored for each group. Inbound connections always
- * only match on IP.
+ * Outbound connections are divided into equivalence classes called "groups"
+ * here. For outbound connections, groups will vary based on the session
+ * matching configuration.  For inbound connections, a group is always based on
+ * the remote IP address.  Tracking data is stored for each group.
  */
 class ConnectionTracker
 {
@@ -114,14 +115,14 @@ public:
 
     enum class DirectionType { INBOUND, OUTBOUND };
 
-    DirectionType _direction;           ///< Whether the group is for inbound or outbound connections.
-    IpEndpoint _addr;                   ///< Remote IP address.
-    CryptoHash _hash;                   ///< Hash of the FQDN.
-    MatchType _match_type{MATCH_IP};    ///< Type of matching.
-    std::string _fqdn;                  ///< Expanded FQDN, set if matching on FQDN.
-    int _min_keep_alive_conns{0};       /// < Min keep alive conns on this server group
-    Key _key;                           ///< Pre-assembled key which references the following members.
-    std::chrono::seconds &_alert_delay; ///< Alert delay in seconds.
+    DirectionType _direction;                 ///< Whether the group is for inbound or outbound connections.
+    IpEndpoint _addr;                         ///< Remote IP address.
+    CryptoHash _hash;                         ///< Hash of the FQDN.
+    MatchType _match_type{MATCH_IP};          ///< Type of matching.
+    std::string _fqdn;                        ///< Expanded FQDN, set if matching on FQDN.
+    int _min_keep_alive_conns{0};             /// < Min keep alive conns on this server group
+    Key _key;                                 ///< Pre-assembled key which references the following members.
+    std::chrono::seconds const &_alert_delay; ///< A reference to client or server alert_delay depending upon connection direction.
 
     // Counting data.
     std::atomic<int> _count{0};         ///< Number of inbound or outbound connections.

--- a/include/iocore/net/NetHandler.h
+++ b/include/iocore/net/NetHandler.h
@@ -167,6 +167,7 @@ public:
   bool add_to_active_queue(NetEvent *ne);
   void remove_from_active_queue(NetEvent *ne);
   static int get_additional_accepts();
+  static int get_per_client_max_connections_in();
 
   /// Per process initialization logic.
   static void init_for_process();
@@ -236,6 +237,7 @@ private:
   // accept threads are not always on a standard NET thread with a NetHandler
   // that has TS_EVENT_MGMT_UPDATE handling logic.
   static std::atomic<uint32_t> additional_accepts;
+  static std::atomic<uint32_t> per_client_max_connections_in;
 
   void _close_ne(NetEvent *ne, ink_hrtime now, int &handle_event, int &closed, int &total_idle_time, int &total_idle_count);
 

--- a/src/iocore/net/ConnectionTracker.cc
+++ b/src/iocore/net/ConnectionTracker.cc
@@ -288,9 +288,8 @@ ConnectionTracker::Group::should_alert(std::time_t *lat)
 void
 ConnectionTracker::Group::release()
 {
-  if (_count >= 0) {
-    --_count;
-    if (_count == 0) {
+  if (_count > 0) {
+    if (--_count == 0) {
       TableSingleton &table = _direction == DirectionType::INBOUND ? _inbound_table : _outbound_table;
       std::lock_guard<std::mutex> lock(table._mutex); // Table lock
       if (_count > 0) {

--- a/src/iocore/net/Net.cc
+++ b/src/iocore/net/Net.cc
@@ -89,7 +89,9 @@ register_net_stats()
   net_rsb.calls_to_writetonet        = Metrics::Counter::createPtr("proxy.process.net.calls_to_writetonet");
   net_rsb.connections_currently_open = Metrics::Gauge::createPtr("proxy.process.net.connections_currently_open");
   net_rsb.connections_throttled_in   = Metrics::Counter::createPtr("proxy.process.net.connections_throttled_in");
-  net_rsb.connections_throttled_out  = Metrics::Counter::createPtr("proxy.process.net.connections_throttled_out");
+  net_rsb.per_client_connections_throttled_in =
+    Metrics::Counter::createPtr("proxy.process.net.per_client.connections_throttled_in");
+  net_rsb.connections_throttled_out = Metrics::Counter::createPtr("proxy.process.net.connections_throttled_out");
   net_rsb.tunnel_total_client_connections_blind_tcp =
     Metrics::Counter::createPtr("proxy.process.tunnel.total_client_connections_blind_tcp");
   net_rsb.tunnel_current_client_connections_blind_tcp =
@@ -134,6 +136,7 @@ register_net_stats()
   net_rsb.tcp_accept                       = Metrics::Counter::createPtr("proxy.process.tcp.total_accepts");
   net_rsb.write_bytes                      = Metrics::Counter::createPtr("proxy.process.net.write_bytes");
   net_rsb.write_bytes_count                = Metrics::Counter::createPtr("proxy.process.net.write_bytes_count");
+  net_rsb.connection_tracker_table_size    = Metrics::Gauge::createPtr("proxy.process.net.connection_tracker_table_size");
 }
 
 void

--- a/src/iocore/net/P_Net.h
+++ b/src/iocore/net/P_Net.h
@@ -44,6 +44,7 @@ struct NetStatsBlock {
   Metrics::Counter::AtomicType *calls_to_writetonet;
   Metrics::Gauge::AtomicType *connections_currently_open;
   Metrics::Counter::AtomicType *connections_throttled_in;
+  Metrics::Counter::AtomicType *per_client_connections_throttled_in;
   Metrics::Counter::AtomicType *connections_throttled_out;
   Metrics::Counter::AtomicType *default_inactivity_timeout_applied;
   Metrics::Counter::AtomicType *default_inactivity_timeout_count;
@@ -77,6 +78,7 @@ struct NetStatsBlock {
   Metrics::Counter::AtomicType *tcp_accept;
   Metrics::Counter::AtomicType *write_bytes;
   Metrics::Counter::AtomicType *write_bytes_count;
+  Metrics::Gauge::AtomicType *connection_tracker_table_size;
 };
 
 extern NetStatsBlock net_rsb;

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -1031,6 +1031,7 @@ SSLNetVConnection::free_thread(EThread *t)
 
   // close socket fd
   if (con.fd != NO_FD) {
+    release_inbound_connection_tracking();
     Metrics::Gauge::decrement(net_rsb.connections_currently_open);
   }
   con.close();

--- a/src/proxy/http/HttpProxyServerMain.cc
+++ b/src/proxy/http/HttpProxyServerMain.cc
@@ -72,7 +72,7 @@ struct ShowConnectionCount : public ShowCont {
   int
   showHandler(int event, Event *e)
   {
-    CHECK_SHOW(show(ConnectionTracker::to_json_string().c_str()));
+    CHECK_SHOW(show(ConnectionTracker::outbound_to_json_string().c_str()));
     return completeJson(event, e);
   }
 };

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -376,6 +376,10 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.net.max_connections_in", RECD_INT, "30000", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.net.per_client.max_connections_in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.http.per_client.connection.alert_delay", RECD_INT, "60", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.net.max_requests_in", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
 

--- a/tests/gold_tests/client_connection/http2_slow_origins.replay.yaml
+++ b/tests/gold_tests/client_connection/http2_slow_origins.replay.yaml
@@ -1,0 +1,237 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Test Notes:
+# This test makes the server reply slowly over multiple origin connections,
+# allowing client-side connections to build up. This allows us to test our
+# proxy.config.net.per_client.max_connections_in feature. This test assumes that
+# proxy.config.net.per_client.max_connections_in is configured to 3 and assumes
+# the fourth connection will be aborted by ATS.
+#
+# Be aware that Proxy Verifier will perform each of these sessions in parallel,
+# not in serial. Thus, while there are multiple server side delays across the
+# sessions, the delays are not additive. The client side delays are additive
+# though. The replay should take about 3 seconds to complete after the fifth
+# transaction completes.
+
+meta:
+  version: "1.0"
+
+sessions:
+
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /some/path/first ]
+        - [ X-Request, first-request ]
+        - [ uuid, first-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'first-request', as: equal } ]
+
+    server-response:
+      # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+      delay: 2s
+
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ X-Response, first-response ]
+      content:
+        size: 36
+
+    proxy-response:
+      headers:
+        fields:
+        - [ :status, {value: '200', as: equal } ]
+        - [ X-Response, {value: 'first-response', as: equal } ]
+
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /some/path/second ]
+        - [ X-Request, second-request ]
+        - [ uuid, second-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'second-request', as: equal } ]
+
+    server-response:
+      # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+      delay: 2s
+
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ X-Response, second-response ]
+      content:
+        size: 36
+
+    proxy-response:
+      headers:
+        fields:
+        - [ :status, {value: '200', as: equal } ]
+        - [ X-Response, {value: 'second-response', as: equal } ]
+
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /some/path/third ]
+        - [ X-Request, third-request ]
+        - [ uuid, third-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'third-request', as: equal } ]
+
+    server-response:
+      # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+      delay: 2s
+
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ X-Response, third-response ]
+      content:
+        size: 36
+
+    proxy-response:
+      headers:
+        fields:
+        - [ :status, {value: '200', as: equal } ]
+        - [ X-Response, {value: 'third-response', as: equal } ]
+
+
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  # Make sure this is the last attempted transaction by giving the above
+  # three transactions, all executed in parallel, a one second head start.
+  # This connection should be aborted.
+  delay: 1s
+
+  transactions:
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /some/path/fourth ]
+        - [ X-Request, fourth-request ]
+        - [ uuid, fourth-request ]
+
+    # The server should never see this request since ATS will serve a 503
+    # response due to the per_server.connection.max being hit.
+    server-response:
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ X-Response, fourth-response ]
+      content:
+        size: 36
+
+# This one should work because the other transactions should complete.
+# Note that this will delay after the previous 1s delay, so this is really
+# a delay of 3s.
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  delay: 2s
+
+  transactions:
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.example.com ]
+        - [ :path, /some/path/fifth ]
+        - [ X-Request, fifth-request ]
+        - [ uuid, fifth-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'fifth-request', as: equal } ]
+
+    server-response:
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ X-Response, fifth-response ]
+
+    proxy-response:
+      headers:
+        fields:
+        - [ :status, {value: '200', as: equal } ]
+        - [ X-Response, {value: 'fifth-response', as: equal } ]

--- a/tests/gold_tests/client_connection/http_slow_origins.replay.yaml
+++ b/tests/gold_tests/client_connection/http_slow_origins.replay.yaml
@@ -1,0 +1,206 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Test Notes:
+# This test makes the server reply slowly over multiple origin connections,
+# allowing client-side connections to build up. This allows us to test our
+# proxy.config.net.per_client.max_connections_in feature. This test assumes that
+# proxy.config.net.per_client.max_connections_in is configured to 3 and assumes
+# the fourth connection will be aborted by ATS.
+#
+# Be aware that Proxy Verifier will perform each of these sessions in parallel,
+# not in serial. Thus, while there are multiple server side delays across the
+# sessions, the delays are not additive. The client side delays are additive
+# though. The replay should take about 3 seconds to complete after the fifth
+# transaction completes.
+
+meta:
+  version: "1.0"
+sessions:
+
+- transactions:
+
+  - client-request:
+      method: GET
+      url: /some/path/first
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, first-request ]
+        - [ uuid, first-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'first-request', as: equal } ]
+
+    server-response:
+        # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+        delay: 2s
+
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 36 ]
+          - [ X-Response, first-response ]
+          - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'first-response', as: equal } ]
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /some/path/second
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, second-request ]
+        - [ uuid, second-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'second-request', as: equal } ]
+
+    server-response:
+        # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+        delay: 2s
+
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 36 ]
+          - [ X-Response, second-response ]
+          - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'second-response', as: equal } ]
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /some/path/third
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, third-request ]
+        - [ uuid, third-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'third-request', as: equal } ]
+
+    server-response:
+        # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+        delay: 2s
+
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 36 ]
+          - [ X-Response, third-response ]
+          - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'third-response', as: equal } ]
+
+
+# Make sure this is the last attempted transaction by giving the above
+# three transactions, all executed in parallel, a one second head start.
+# This connection should be aborted.
+- delay: 1s
+
+  transactions:
+
+  - client-request:
+      method: GET
+      url: /some/path/fourth
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, fourth-request ]
+        - [ uuid, fourth-request ]
+
+    # The server should never see this request since ATS will serve a 503
+    # response due to the per_server.connection.max being hit.
+    server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 36 ]
+          - [ X-Response, fourth-response ]
+          - [ Connection, close ]
+
+# This one should work because the other transactions should complete.
+# Note that this will delay after the previous 1s delay, so this is really
+# a delay of 3s.
+- delay: 2s
+
+  transactions:
+  - client-request:
+      method: GET
+      url: /some/path/fifth
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, fifth-request ]
+        - [ uuid, fifth-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'fifth-request', as: equal } ]
+
+    server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 36 ]
+          - [ X-Response, fifth-response ]
+          - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'fifth-response', as: equal } ]
+

--- a/tests/gold_tests/client_connection/https_slow_origins.replay.yaml
+++ b/tests/gold_tests/client_connection/https_slow_origins.replay.yaml
@@ -1,0 +1,239 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Test Notes:
+# This test makes the server reply slowly over multiple origin connections,
+# allowing client-side connections to build up. This allows us to test our
+# proxy.config.net.per_client.max_connections_in feature. This test assumes that
+# proxy.config.net.per_client.max_connections_in is configured to 3 and assumes
+# the fourth connection will be aborted by ATS.
+#
+# Be aware that Proxy Verifier will perform each of these sessions in parallel,
+# not in serial. Thus, while there are multiple server side delays across the
+# sessions, the delays are not additive. The client side delays are additive
+# though. The replay should take about 3 seconds to complete after the fifth
+# transaction completes.
+
+meta:
+  version: "1.0"
+
+sessions:
+
+- protocol:
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      method: GET
+      url: /some/path/first
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, first-request ]
+        - [ uuid, first-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'first-request', as: equal } ]
+
+    server-response:
+      # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+      delay: 2s
+
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 36 ]
+        - [ X-Response, first-response ]
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'first-response', as: equal } ]
+
+- protocol:
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      method: GET
+      url: /some/path/second
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, second-request ]
+        - [ uuid, second-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'second-request', as: equal } ]
+
+    server-response:
+      # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+      delay: 2s
+
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 36 ]
+        - [ X-Response, second-response ]
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'second-response', as: equal } ]
+
+- protocol:
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  - client-request:
+      method: GET
+      url: /some/path/third
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, third-request ]
+        - [ uuid, third-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'third-request', as: equal } ]
+
+    server-response:
+      # Delay for 2 seconds so that this origin connection will exist for 2 seconds.
+      delay: 2s
+
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 36 ]
+        - [ X-Response, third-response ]
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'third-response', as: equal } ]
+
+
+- protocol:
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  # Make sure this is the last attempted transaction by giving the above
+  # three transactions, all executed in parallel, a one second head start.
+  # This connection should be aborted.
+  delay: 1s
+
+  transactions:
+
+  - client-request:
+      method: GET
+      url: /some/path/fourth
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, fourth-request ]
+        - [ uuid, fourth-request ]
+
+    # The server should never see this request since ATS will serve a 503
+    # response due to the per_server.connection.max being hit.
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 36 ]
+        - [ X-Response, fourth-response ]
+        - [ Connection, close ]
+
+# This one should work because the other transactions should complete.
+# Note that this will delay after the previous 1s delay, so this is really
+# a delay of 3s.
+- protocol:
+  - name: tls
+    sni: test_sni
+  - name: tcp
+  - name: ip
+
+  delay: 2s
+
+  transactions:
+
+  - client-request:
+      method: GET
+      url: /some/path/fifth
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, fifth-request ]
+        - [ uuid, fifth-request ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request, {value: 'fifth-request', as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 36 ]
+        - [ X-Response, fifth-response ]
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, {value: 'fifth-response', as: equal } ]

--- a/tests/gold_tests/client_connection/per_client_connection_max.test.py
+++ b/tests/gold_tests/client_connection/per_client_connection_max.test.py
@@ -1,0 +1,219 @@
+'''
+Verify the behavior of proxy.config.net.per_client.connection.max.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from enum import Enum
+
+Test.Summary = __doc__
+
+
+class Protocol(Enum):
+    HTTP = 1
+    HTTPS = 2
+    HTTP2 = 3
+
+    @classmethod
+    def to_str(cls, protocol: int) -> str:
+        """Convert the protocol to a string.
+
+        :param protocol: The protocol to convert.
+        :return: The string representation of the protocol.
+        """
+        if protocol == cls.HTTP:
+            return 'http'
+        elif protocol == cls.HTTPS:
+            return 'https'
+        elif protocol == cls.HTTP2:
+            return 'http2'
+        else:
+            raise ValueError(f'Unknown protocol: {protocol}')
+
+
+class PerClientConnectionMaxTest:
+    """Define an object to test our max client connection behavior."""
+
+    _dns_counter: int = 0
+    _server_counter: int = 0
+    _ts_counter: int = 0
+    _client_counter: int = 0
+    _max_client_connections: int = 3
+    _protocol_to_replay_file = {
+        Protocol.HTTP: 'http_slow_origins.replay.yaml',
+        Protocol.HTTPS: 'https_slow_origins.replay.yaml',
+        Protocol.HTTP2: 'http2_slow_origins.replay.yaml',
+    }
+
+    def __init__(self, protocol: int) -> None:
+        """Configure the test processes in preparation for the TestRun.
+
+        :param protocol: The protocol to test.
+        """
+        self._protocol = protocol
+        protocol_string = Protocol.to_str(protocol)
+        self._replay_file = self._protocol_to_replay_file[protocol]
+        tr = Test.AddTestRun(
+            f'proxy.config.net.per_client.connection.max: {protocol_string}')
+        self._configure_dns(tr)
+        self._configure_server(tr)
+        self._configure_trafficserver()
+        self._configure_client(tr)
+        self._verify_metrics()
+
+    def _configure_dns(self, tr: 'TestRun') -> None:
+        """Configure a nameserver for the test.
+
+        :param tr: The TestRun to add the nameserver to.
+        """
+        name = f'dns{PerClientConnectionMaxTest._dns_counter}'
+        self._dns = tr.MakeDNServer(name, default='127.0.0.1')
+        PerClientConnectionMaxTest._dns_counter += 1
+
+    def _configure_server(self, tr: 'TestRun') -> None:
+        """Configure the server to be used in the test.
+
+        :param tr: The TestRun to add the server to.
+        """
+        name = f'server{PerClientConnectionMaxTest._server_counter}'
+        self._server = tr.AddVerifierServerProcess(name, self._replay_file)
+        PerClientConnectionMaxTest._server_counter += 1
+        self._server.Streams.All += Testers.ContainsExpression(
+            "first-request",
+            "Verify the first request should have been received.")
+        self._server.Streams.All += Testers.ContainsExpression(
+            "second-request",
+            "Verify the second request should have been received.")
+        self._server.Streams.All += Testers.ContainsExpression(
+            "third-request",
+            "Verify the third request should have been received.")
+        self._server.Streams.All += Testers.ContainsExpression(
+            "fifth-request",
+            "Verify the fifth request should have been received.")
+
+        # The fourth request should be blocked due to too many connections.
+        self._server.Streams.All += Testers.ExcludesExpression(
+            "fourth-request",
+            "Verify the fourth request should not be received.")
+
+    def _configure_trafficserver(self) -> None:
+        """Configure Traffic Server to be used in the test."""
+        # Associate ATS with the Test so that metrics can be verified.
+        name = f'ts{PerClientConnectionMaxTest._ts_counter}'
+        self._ts = Test.MakeATSProcess(name, enable_cache=False, enable_tls=True)
+        PerClientConnectionMaxTest._ts_counter += 1
+        self._ts.addDefaultSSLFiles()
+        self._ts.Disk.ssl_multicert_config.AddLine(
+            'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+        )
+        if self._protocol == Protocol.HTTP:
+            server_port = self._server.Variables.http_port
+            scheme = 'http'
+        else:
+            server_port = self._server.Variables.https_port
+            scheme = 'https'
+        self._ts.Disk.remap_config.AddLine(
+            f'map / {scheme}://127.0.0.1:{server_port}'
+        )
+        self._ts.Disk.records_config.update({
+            'proxy.config.ssl.server.cert.path': self._ts.Variables.SSLDir,
+            'proxy.config.ssl.server.private_key.path': self._ts.Variables.SSLDir,
+            'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+
+            'proxy.config.dns.nameservers': f"127.0.0.1:{self._dns.Variables.Port}",
+            'proxy.config.dns.resolv_conf': 'NULL',
+
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'socket|http|net_queue|iocore_net|conn_track',
+
+            'proxy.config.net.per_client.max_connections_in': self._max_client_connections,
+            # Disable keep-alive so we close the client connections when the
+            # transactions are done. This allows us to verify cleanup is working
+            # per the ConnectionTracker metrics.
+            'proxy.config.http.keep_alive_enabled_in': 0,
+        })
+        self._ts.Disk.diags_log.Content += Testers.ContainsExpression(
+            f'WARNING:.*too many connections:.*limit={self._max_client_connections}',
+            'Verify the user is warned about the connection limit being hit.')
+
+    def _configure_client(self, tr: 'TestRun') -> None:
+        """Configure the TestRun.
+
+        :param tr: The TestRun to add the client to.
+        """
+        name = f'client{PerClientConnectionMaxTest._client_counter}'
+        p = tr.AddVerifierClientProcess(
+            name,
+            self._replay_file,
+            http_ports=[self._ts.Variables.port],
+            https_ports=[self._ts.Variables.ssl_port])
+        PerClientConnectionMaxTest._client_counter += 1
+
+        p.StartBefore(self._dns)
+        p.StartBefore(self._server)
+        p.StartBefore(self._ts)
+
+        # Because the fourth connection will be aborted, the client will have a
+        # non-zero return code.
+        p.ReturnCode = 1
+        p.Streams.All += Testers.ContainsExpression(
+            "first-request",
+            "Verify the first request should have been received.")
+        p.Streams.All += Testers.ContainsExpression(
+            "second-request",
+            "Verify the second request should have been received.")
+        p.Streams.All += Testers.ContainsExpression(
+            "third-request",
+            "Verify the third request should have been received.")
+        p.Streams.All += Testers.ContainsExpression(
+            "fifth-request",
+            "Verify the fifth request should have been received.")
+        if self._protocol == Protocol.HTTP:
+            p.Streams.All += Testers.ContainsExpression(
+                "The peer closed the connection while reading.",
+                "A connection should be closed due to too many client connections.")
+            p.Streams.All += Testers.ContainsExpression(
+                "Failed HTTP/1 transaction with key: fourth-request",
+                "The fourth request should fail.")
+        else:
+            p.Streams.All += Testers.ContainsExpression(
+                "ECONNRESET: Connection reset by peer",
+                "A connection should be closed due to too many client connections.")
+            p.Streams.All += Testers.ExcludesExpression(
+                "fourth-request",
+                "The fourth request should fail.")
+
+    def _verify_metrics(self) -> None:
+        """Verify the per client connection metrics."""
+        tr = Test.AddTestRun("Verify the per client connection metrics.")
+        tr.Processes.Default.Env = self._ts.Env
+        tr.Processes.Default.Command = (
+            'traffic_ctl metric get '
+            'proxy.process.net.per_client.connections_throttled_in '
+            'proxy.process.net.connection_tracker_table_size'
+        )
+        tr.Processes.Default.ReturnCode = 0
+        tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+            'proxy.process.net.per_client.connections_throttled_in 1',
+            'Verify the per client throttled metric is correct.')
+        tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+            'proxy.process.net.connection_tracker_table_size 0',
+            'Verify the table was cleaned up correctly.')
+
+
+PerClientConnectionMaxTest(Protocol.HTTP)
+PerClientConnectionMaxTest(Protocol.HTTPS)
+PerClientConnectionMaxTest(Protocol.HTTP2)


### PR DESCRIPTION
This implements proxy.config.net.per_client.max_connections_in which
allows the user to configure a per client IP incoming maximum number of
concurrent connections. This is the client-side analogue to
proxy.config.http.per_server.connection.max.
