### PR TITLE
Revert "coverity 1497413: Use of 32-bit time_t (#9556)"

### DIFF
--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -275,7 +275,7 @@ struct CacheVC : public CacheVConnection {
   Event *trigger;
   CacheKey *read_key;
   ContinuationHandler save_handler;
-  time_t pin_in_cache;
+  uint32_t pin_in_cache;
   ink_hrtime start_time;
   int op_type; // Index into the metrics array for this operation, rather than a CacheOpType (fewer casts)
   int recursive;

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -541,7 +541,8 @@ Vol::evacuateDocReadDone(int event, Event *e)
   if (!b) {
     goto Ldone;
   }
-  if ((b->f.pinned && !b->readers) && doc->pinned < static_cast<time_t>(ink_get_hrtime() / HRTIME_SECOND)) {
+  // coverity[Y2K38_SAFETY:FALSE]
+  if ((b->f.pinned && !b->readers) && doc->pinned < static_cast<uint32_t>(ink_get_hrtime() / HRTIME_SECOND)) {
     goto Ldone;
   }
 
@@ -678,7 +679,8 @@ agg_copy(char *p, CacheVC *vc)
     doc->checksum                        = DOC_NO_CHECKSUM;
     if (vc->pin_in_cache) {
       dir_set_pinned(&vc->dir, 1);
-      doc->pinned = static_cast<time_t>(ink_get_hrtime() / HRTIME_SECOND) + vc->pin_in_cache;
+      // coverity[Y2K38_SAFETY:FALSE]
+      doc->pinned = static_cast<uint32_t>(ink_get_hrtime() / HRTIME_SECOND) + vc->pin_in_cache;
     } else {
       dir_set_pinned(&vc->dir, 0);
       doc->pinned = 0;
@@ -1581,7 +1583,8 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   c->f.overwrite      = (options & CACHE_WRITE_OPT_OVERWRITE) != 0;
   c->f.close_complete = (options & CACHE_WRITE_OPT_CLOSE_COMPLETE) != 0;
   c->f.sync           = (options & CACHE_WRITE_OPT_SYNC) == CACHE_WRITE_OPT_SYNC;
-  c->pin_in_cache     = apin_in_cache;
+  // coverity[Y2K38_SAFETY:FALSE]
+  c->pin_in_cache = static_cast<uint32_t>(apin_in_cache);
 
   if ((res = c->vol->open_write_lock(c, false, 1)) > 0) {
     // document currently being written, abort
@@ -1683,7 +1686,8 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
 
   Metrics::increment(cache_rsb.status[c->op_type].active);
   Metrics::increment(vol->cache_vol->vol_rsb.status[c->op_type].active);
-  c->pin_in_cache = apin_in_cache;
+  // coverity[Y2K38_SAFETY:FALSE]
+  c->pin_in_cache = static_cast<uint32_t>(apin_in_cache);
 
   {
     CACHE_TRY_LOCK(lock, c->vol->mutex, cont->mutex->thread_holding);

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -303,8 +303,8 @@ struct Doc {
   uint32_t unused   : 8; ///< Unused, forced to zero.
   uint32_t sync_serial;
   uint32_t write_serial;
+  uint32_t pinned; ///< pinned until - CAVEAT: use uint32_t instead of time_t for the cache compatibility
   uint32_t checksum;
-  time_t pinned; // pinned until
 #if TS_ENABLE_FIPS == 1
   CryptoHash key; ///< Key for this doc.
 #endif


### PR DESCRIPTION
This reverts commit 822172a339bc7fcbcabb6a9ebb2df4433b3bf8bc.

Conflicts:
	include/iocore/cache/CacheVC.h
	src/iocore/cache/CacheWrite.cc
	src/iocore/cache/P_CacheInternal.h

----

Fix #9821