### PR TITLE
cmake: chown some paths at install time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,12 @@ add_custom_target(
 # Create an empty directories for ATS runtime
 install(DIRECTORY DESTINATION ${CMAKE_INSTALL_LOGDIR})
 install(DIRECTORY DESTINATION ${CMAKE_INSTALL_RUNSTATEDIR})
+install(DIRECTORY DESTINATION ${CMAKE_INSTALL_CACHEDIR})
+
+install(CODE "set(OWNER_USER ${TS_PKGSYSUSER})")
+install(CODE "set(OWNER_GROUP ${TS_PKGSYSGROUP})")
+install(CODE "set(CHOWN_DIRS ${CMAKE_INSTALL_LOGDIR} ${CMAKE_INSTALL_RUNSTATEDIR} ${CMAKE_INSTALL_CACHEDIR})")
+install(SCRIPT cmake/post_install.cmake)
 
 # Display build summary
 include(CMakePrintHelpers)

--- a/cmake/post_install.cmake
+++ b/cmake/post_install.cmake
@@ -1,0 +1,26 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+if($ENV{USER} STREQUAL root)
+  foreach(DIR ${CHOWN_DIRS})
+    message(STATUS "Changing ${DIR} ownership to ${OWNER_USER}:${OWNER_GROUP}")
+    execute_process(
+      COMMAND chown ${OWNER_USER}:${OWNER_GROUP} "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/${DIR}"
+    )
+  endforeach()
+
+endif()

--- a/cmake/post_install.cmake
+++ b/cmake/post_install.cmake
@@ -15,7 +15,7 @@
 #
 #######################
 
-if($ENV{USER} STREQUAL root)
+if("$ENV{USER}" STREQUAL root)
   foreach(DIR ${CHOWN_DIRS})
     message(STATUS "Changing ${DIR} ownership to ${OWNER_USER}:${OWNER_GROUP}")
     execute_process(


### PR DESCRIPTION
If the install user is root, this PR will chown the log, runstate and cache dirs to be owned by the configured ATS user.

This will "do the right thing" if you are installing as root and the runtime user in records.yaml is the same as the default one specified at configure time (i.e. `WITH_USER`).  If this is not the case, then manual intervention will still be required and in fact will be annoying since installs will overwrite the ownership.

This is really only a convenience for manual installs run as root.  Package maintainers will still have to ensure permissions are correct for whatever user actually runs ATS. If you install and run as your normal user as a developer, this should not affect that workflow.

