### PR TITLE
Add assert of CacheDisk is not nullptr

### DIFF
--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -1266,7 +1266,8 @@ cplist_init()
 {
   cp_list_len = 0;
   for (int i = 0; i < gndisks; i++) {
-    CacheDisk *d    = gdisks[i];
+    CacheDisk *d = gdisks[i];
+    ink_assert(d != nullptr);
     DiskStripe **dp = d->disk_vols;
     for (unsigned int j = 0; j < d->header->num_volumes; j++) {
       ink_assert(dp[j]->dpb_queue.head);


### PR DESCRIPTION
To make clang-analyer happy.

We faced odd warning report with clang-analyer at https://github.com/apache/trafficserver/pull/10694. 

```
analyze-build: INFO: /Users/masaori/src/github.com/apache/trafficserver-asf-master/src/iocore/cache/Cache.cc:1271:20: warning: Access to field 'disk_vols' results in a dereference of a null pointer (loaded from variable 'd') [core.NullDereference]
analyze-build: INFO:  1271 |     DiskVol **dp = d->disk_vols;
```

If I run clang-analyer against the master branch with below change locally, it also reports the same. My guess is the Metircs related change made clang-analyzer confused.

```
diff --git a/src/iocore/cache/Cache.cc b/src/iocore/cache/Cache.cc
index 2679611f9..95e878f66 100644
--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -511,9 +511,9 @@ CacheProcessor::diskInitialized()

   /* Practically just took all bad_disks offline so update the stats. */
   // ToDo: These don't get update on the per-volume metrics :-/
-  Metrics::write(cache_rsb.span_offline, bad_disks);
-  Metrics::decrement(cache_rsb.span_failing, bad_disks);
-  Metrics::write(cache_rsb.span_online, gndisks);
+  // Metrics::write(cache_rsb.span_offline, bad_disks);
+  // Metrics::decrement(cache_rsb.span_failing, bad_disks);
+  // Metrics::write(cache_rsb.span_online, gndisks);

   /* create the cachevol list only if num volumes are greater than 0. */
   if (config_volumes.num_volumes == 0) {
```

As @ywkaras suggested in the PR, the warning is gone with this assert.

/cc @zwoop 