### PR TITLE
Remove dependency of ProxyMutex from rand_CacheKey

### DIFF
--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -298,13 +298,11 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
     return;
   }
 
-  EThread *thread = this_ethread();
-
   CACHE_SM(t, write_test, { cacheProcessor.open_write(this, &key, CACHE_FRAG_TYPE_NONE, 100, CACHE_WRITE_OPT_SYNC); });
   write_test.expect_initial_event = CACHE_EVENT_OPEN_WRITE;
   write_test.expect_event         = VC_EVENT_WRITE_COMPLETE;
   write_test.nbytes               = 100;
-  rand_CacheKey(&write_test.key, thread->mutex);
+  rand_CacheKey(&write_test.key);
 
   CACHE_SM(t, lookup_test, { cacheProcessor.lookup(this, &key); });
   lookup_test.expect_event = CACHE_EVENT_LOOKUP;
@@ -330,7 +328,7 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
 
   CACHE_SM(t, remove_fail_test, { cacheProcessor.remove(this, &key); });
   remove_fail_test.expect_event = CACHE_EVENT_REMOVE_FAILED;
-  rand_CacheKey(&remove_fail_test.key, thread->mutex);
+  rand_CacheKey(&remove_fail_test.key);
 
   CACHE_SM(
     t, replace_write_test,
@@ -343,7 +341,7 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   replace_write_test.expect_initial_event = CACHE_EVENT_OPEN_WRITE;
   replace_write_test.expect_event         = VC_EVENT_WRITE_COMPLETE;
   replace_write_test.nbytes               = 100;
-  rand_CacheKey(&replace_write_test.key, thread->mutex);
+  rand_CacheKey(&replace_write_test.key);
 
   CACHE_SM(
     t, replace_test,
@@ -387,7 +385,7 @@ EXCLUSIVE_REGRESSION_TEST(cache)(RegressionTest *t, int /* atype ATS_UNUSED */, 
   large_write_test.expect_initial_event = CACHE_EVENT_OPEN_WRITE;
   large_write_test.expect_event         = VC_EVENT_WRITE_COMPLETE;
   large_write_test.nbytes               = 10000000;
-  rand_CacheKey(&large_write_test.key, thread->mutex);
+  rand_CacheKey(&large_write_test.key);
 
   CACHE_SM(
     t, pread_test, { cacheProcessor.open_read(this, &key); } int open_read_callout() override {

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -692,7 +692,7 @@ agg_copy(char *p, CacheVC *vc)
       } else { // the vector is being written by itself
         if (vc->earliest_key.is_zero()) {
           do {
-            rand_CacheKey(&doc->key, vc->vol->mutex);
+            rand_CacheKey(&doc->key);
           } while (DIR_MASK_TAG(doc->key.slice32(2)) == DIR_MASK_TAG(vc->first_key.slice32(2)));
         } else {
           prev_CacheKey(&doc->key, &vc->earliest_key);
@@ -1576,7 +1576,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
      or the earliest_key based on the dir_tag.
    */
   do {
-    rand_CacheKey(&c->key, cont->mutex);
+    rand_CacheKey(&c->key);
   } while (DIR_MASK_TAG(c->key.slice32(2)) == DIR_MASK_TAG(c->first_key.slice32(2)));
   c->earliest_key     = c->key;
   c->info             = nullptr;
@@ -1637,7 +1637,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
      or the earliest_key based on the dir_tag.
    */
   do {
-    rand_CacheKey(&c->key, cont->mutex);
+    rand_CacheKey(&c->key);
   } while (DIR_MASK_TAG(c->key.slice32(2)) == DIR_MASK_TAG(c->first_key.slice32(2)));
   c->earliest_key = c->key;
   c->frag_type    = CACHE_FRAG_TYPE_HTTP;

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "iocore/eventsystem/Continuation.h"
 #include "tscore/ink_platform.h"
 #include "tscore/InkErrno.h"
 
@@ -508,10 +509,11 @@ dir_overwrite_lock(CacheKey *key, Stripe *vol, Dir *to_part, ProxyMutex *m, Dir 
   return dir_overwrite(key, vol, to_part, overwrite, must_overwrite);
 }
 
-void inline rand_CacheKey(CacheKey *next_key, Ptr<ProxyMutex> &mutex)
+void inline rand_CacheKey(CacheKey *next_key)
 {
-  next_key->b[0] = mutex->thread_holding->generator.random();
-  next_key->b[1] = mutex->thread_holding->generator.random();
+  EThread *ethread = this_ethread();
+  next_key->b[0]   = ethread->generator.random();
+  next_key->b[1]   = ethread->generator.random();
 }
 
 extern const uint8_t CacheKey_next_table[256];

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -100,7 +100,7 @@ public:
     vol->header->agg_pos = vol->header->write_pos += 1024;
 
     CacheKey key;
-    rand_CacheKey(&key, thread->mutex);
+    rand_CacheKey(&key);
 
     int s    = key.slice32(0) % vol->segments, i, j;
     Dir *seg = vol->dir_segment(s);
@@ -167,7 +167,7 @@ public:
     for (int ntimes = 0; ntimes < 10; ntimes++) {
 #ifdef LOOP_CHECK_MODE
       // dir_probe in bucket with loop
-      rand_CacheKey(&key, thread->mutex);
+      rand_CacheKey(&key);
       s1 = key.slice32(0) % vol->segments;
       b1 = key.slice32(1) % vol->buckets;
       dir_corrupt_bucket(dir_bucket(b1, vol->dir_segment(s1)), s1, vol);
@@ -175,7 +175,7 @@ public:
       Dir *last_collision = 0;
       dir_probe(&key, vol, &dir, &last_collision);
 
-      rand_CacheKey(&key, thread->mutex);
+      rand_CacheKey(&key);
       s1 = key.slice32(0) % vol->segments;
       b1 = key.slice32(1) % vol->buckets;
       dir_corrupt_bucket(dir_bucket(b1, vol->dir_segment(s1)), s1, vol);
@@ -184,7 +184,7 @@ public:
       dir_probe(&key, vol, &dir, &last_collision);
 
       // dir_overwrite in bucket with loop
-      rand_CacheKey(&key, thread->mutex);
+      rand_CacheKey(&key);
       s1 = key.slice32(0) % vol->segments;
       b1 = key.slice32(1) % vol->buckets;
       CacheKey key1;
@@ -198,7 +198,7 @@ public:
       dir_corrupt_bucket(dir_bucket(b1, vol->dir_segment(s1)), s1, vol);
       dir_overwrite(&key, vol, &dir, &dir, 1);
 
-      rand_CacheKey(&key, thread->mutex);
+      rand_CacheKey(&key);
       s1       = key.slice32(0) % vol->segments;
       b1       = key.slice32(1) % vol->buckets;
       key.b[1] = 23;
@@ -206,14 +206,14 @@ public:
       dir_corrupt_bucket(dir_bucket(b1, vol->dir_segment(s1)), s1, vol);
       dir_overwrite(&key, vol, &dir, &dir, 0);
 
-      rand_CacheKey(&key, thread->mutex);
+      rand_CacheKey(&key);
       s1        = key.slice32(0) % vol->segments;
       Dir *seg1 = vol->dir_segment(s1);
       // dir_freelist_length in freelist with loop
       dir_corrupt_bucket(dir_from_offset(vol->header->freelist[s], seg1), s1, vol);
       dir_freelist_length(vol, s1);
 
-      rand_CacheKey(&key, thread->mutex);
+      rand_CacheKey(&key);
       s1 = key.slice32(0) % vol->segments;
       b1 = key.slice32(1) % vol->buckets;
       // dir_bucket_length in bucket with loop
@@ -222,7 +222,7 @@ public:
       CHECK(check_dir(vol));
 #else
       // test corruption detection
-      rand_CacheKey(&key, thread->mutex);
+      rand_CacheKey(&key);
       s1 = key.slice32(0) % vol->segments;
       b1 = key.slice32(1) % vol->buckets;
 


### PR DESCRIPTION
The `rand_CacheKey` takes `Ptr<ProxyMutex> &` as second argument, but the function does nothing with the mutex.
What the function need is access to the random number generator of the EThread.