### PR TITLE
Fix libunwind findpackage script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,14 +314,6 @@ elseif(TS_HAS_MIMALLOC)
   link_libraries(mimalloc)
 endif()
 
-if(ENABLE_UNWIND)
-  find_package(unwind)
-  if(unwind_FOUND)
-    link_libraries(unwind::unwind)
-  endif()
-  set(TS_USE_REMOTE_UNWINDING ${unwind_FOUND})
-endif()
-
 if(ENABLE_QUICHE)
   find_package(quiche REQUIRED)
 

--- a/cmake/Findunwind.cmake
+++ b/cmake/Findunwind.cmake
@@ -29,7 +29,7 @@
 #
 
 find_library(unwind_LIBRARY NAMES unwind)
-find_path(unwind_INCLUDE_DIR NAMES unwind.h)
+find_path(unwind_INCLUDE_DIR NAMES libunwind.h libunwind/libunwind.h)
 
 mark_as_advanced(unwind_FOUND unwind_LIBRARY unwind_INCLUDE_DIR)
 


### PR DESCRIPTION
Fixed unwind find package script.
Remove old enable_unwind cmake.

This can be enabled with `ENABLE_UNWIND`
