### PR TITLE
Fixes some compiler warnings

### DIFF
--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -88,7 +88,7 @@ DbgCtl dbg_ctl_cache_reenable{"cache_reenable"};
 #define USELESS_REENABLES          // allow them for now
 // #define VERIFY_JTEST_DATA
 
-extern int cache_config_ram_cache_cutoff;
+extern int64_t cache_config_ram_cache_cutoff;
 
 /* Next block with some data in it in this partition.  Returns end of partition if no more
  * locations.


### PR DESCRIPTION
This seems to happen with LLVM 17 and enabling LTO with ` -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`.

One of them is legitimately wrong, and the other one is kinda harmless, but seems reasonable to not allow that big of allocations.