### PR TITLE
Extract class AggregateWriteBuffer from Stripe

### DIFF
--- a/include/iocore/cache/AggregateWriteBuffer.h
+++ b/include/iocore/cache/AggregateWriteBuffer.h
@@ -1,0 +1,118 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "iocore/eventsystem/Continuation.h"
+
+#include "tscore/ink_memory.h"
+#include "tscore/List.h"
+
+#include <cstring>
+
+#define AGG_SIZE       (4 * 1024 * 1024) // 4MB
+#define AGG_HIGH_WATER (AGG_SIZE / 2)    // 2MB
+
+struct CacheVC;
+
+class AggregateWriteBuffer
+{
+public:
+  AggregateWriteBuffer()
+  {
+    this->buffer = static_cast<char *>(ats_memalign(ats_pagesize(), AGG_SIZE));
+    memset(this->buffer, 0, AGG_SIZE);
+  }
+
+  ~AggregateWriteBuffer() { ats_free(this->buffer); }
+
+  AggregateWriteBuffer(AggregateWriteBuffer const &)            = delete;
+  AggregateWriteBuffer &operator=(AggregateWriteBuffer const &) = delete;
+
+  // move semantics not supported yet to keep things simple
+  AggregateWriteBuffer(AggregateWriteBuffer &&other)            = delete;
+  AggregateWriteBuffer &operator=(AggregateWriteBuffer &&other) = delete;
+
+  Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
+  char *get_buffer();
+  int get_buffer_pos() const;
+  void add_buffer_pos(int size);
+  void seek(int offset);
+  void reset_buffer_pos();
+  int get_bytes_pending_aggregation() const;
+  void add_bytes_pending_aggregation(int size);
+
+private:
+  Queue<CacheVC, Continuation::Link_link> pending_writers;
+  char *buffer                  = nullptr;
+  int bytes_pending_aggregation = 0;
+  int buffer_pos                = 0;
+};
+
+inline Queue<CacheVC, Continuation::Link_link> &
+AggregateWriteBuffer::get_pending_writers()
+{
+  return this->pending_writers;
+}
+
+inline char *
+AggregateWriteBuffer::get_buffer()
+{
+  return this->buffer;
+}
+
+inline int
+AggregateWriteBuffer::get_buffer_pos() const
+{
+  return this->buffer_pos;
+}
+
+inline void
+AggregateWriteBuffer::add_buffer_pos(int size)
+{
+  this->buffer_pos += size;
+}
+
+inline void
+AggregateWriteBuffer::seek(int offset)
+{
+  this->buffer_pos = offset;
+}
+
+inline void
+AggregateWriteBuffer::reset_buffer_pos()
+{
+  this->seek(0);
+}
+
+inline int
+AggregateWriteBuffer::get_bytes_pending_aggregation() const
+{
+  return this->bytes_pending_aggregation;
+}
+
+inline void
+AggregateWriteBuffer::add_bytes_pending_aggregation(int size)
+{
+  this->bytes_pending_aggregation += size;
+}

--- a/include/iocore/cache/AggregateWriteBuffer.h
+++ b/include/iocore/cache/AggregateWriteBuffer.h
@@ -40,11 +40,11 @@ class AggregateWriteBuffer
 public:
   AggregateWriteBuffer()
   {
-    this->buffer = static_cast<char *>(ats_memalign(ats_pagesize(), AGG_SIZE));
-    memset(this->buffer, 0, AGG_SIZE);
+    this->_buffer = static_cast<char *>(ats_memalign(ats_pagesize(), AGG_SIZE));
+    memset(this->_buffer, 0, AGG_SIZE);
   }
 
-  ~AggregateWriteBuffer() { ats_free(this->buffer); }
+  ~AggregateWriteBuffer() { ats_free(this->_buffer); }
 
   AggregateWriteBuffer(AggregateWriteBuffer const &)            = delete;
   AggregateWriteBuffer &operator=(AggregateWriteBuffer const &) = delete;
@@ -63,40 +63,40 @@ public:
   void add_bytes_pending_aggregation(int size);
 
 private:
-  Queue<CacheVC, Continuation::Link_link> pending_writers;
-  char *buffer                  = nullptr;
-  int bytes_pending_aggregation = 0;
-  int buffer_pos                = 0;
+  Queue<CacheVC, Continuation::Link_link> _pending_writers;
+  char *_buffer                  = nullptr;
+  int _bytes_pending_aggregation = 0;
+  int _buffer_pos                = 0;
 };
 
 inline Queue<CacheVC, Continuation::Link_link> &
 AggregateWriteBuffer::get_pending_writers()
 {
-  return this->pending_writers;
+  return this->_pending_writers;
 }
 
 inline char *
 AggregateWriteBuffer::get_buffer()
 {
-  return this->buffer;
+  return this->_buffer;
 }
 
 inline int
 AggregateWriteBuffer::get_buffer_pos() const
 {
-  return this->buffer_pos;
+  return this->_buffer_pos;
 }
 
 inline void
 AggregateWriteBuffer::add_buffer_pos(int size)
 {
-  this->buffer_pos += size;
+  this->_buffer_pos += size;
 }
 
 inline void
 AggregateWriteBuffer::seek(int offset)
 {
-  this->buffer_pos = offset;
+  this->_buffer_pos = offset;
 }
 
 inline void
@@ -108,11 +108,11 @@ AggregateWriteBuffer::reset_buffer_pos()
 inline int
 AggregateWriteBuffer::get_bytes_pending_aggregation() const
 {
-  return this->bytes_pending_aggregation;
+  return this->_bytes_pending_aggregation;
 }
 
 inline void
 AggregateWriteBuffer::add_bytes_pending_aggregation(int size)
 {
-  this->bytes_pending_aggregation += size;
+  this->_bytes_pending_aggregation += size;
 }

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -48,7 +48,7 @@
 
 #include <cstdint>
 
-struct Stripe;
+class Stripe;
 class HttpConfigAccessor;
 
 struct CacheVC : public CacheVConnection {

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -996,21 +996,21 @@ sync_cache_dir_on_shutdown()
     // check if we have data in the agg buffer
     // dont worry about the cachevc s in the agg queue
     // directories have not been inserted for these writes
-    if (vol->agg_buf_pos) {
+    if (vol->get_agg_buf_pos()) {
       Dbg(dbg_ctl_cache_dir_sync, "Dir %s: flushing agg buffer first", vol->hash_text.get());
 
       // set write limit
-      vol->header->agg_pos = vol->header->write_pos + vol->agg_buf_pos;
+      vol->header->agg_pos = vol->header->write_pos + vol->get_agg_buf_pos();
 
-      int r = pwrite(vol->fd, vol->agg_buffer, vol->agg_buf_pos, vol->header->write_pos);
-      if (r != vol->agg_buf_pos) {
+      int r = pwrite(vol->fd, vol->get_agg_buffer(), vol->get_agg_buf_pos(), vol->header->write_pos);
+      if (r != vol->get_agg_buf_pos()) {
         ink_assert(!"flushing agg buffer failed");
         continue;
       }
       vol->header->last_write_pos  = vol->header->write_pos;
-      vol->header->write_pos      += vol->agg_buf_pos;
+      vol->header->write_pos      += vol->get_agg_buf_pos();
       ink_assert(vol->header->write_pos == vol->header->agg_pos);
-      vol->agg_buf_pos = 0;
+      vol->reset_agg_buf_pos();
       vol->header->write_serial++;
     }
 
@@ -1136,7 +1136,7 @@ Lrestart:
         Dbg(dbg_ctl_cache_dir_sync, "Dir %s not dirty", vol->hash_text.get());
         goto Ldone;
       }
-      if (vol->is_io_in_progress() || vol->agg_buf_pos) {
+      if (vol->is_io_in_progress() || vol->get_agg_buf_pos()) {
         Dbg(dbg_ctl_cache_dir_sync, "Dir %s: waiting for agg buffer", vol->hash_text.get());
         vol->dir_sync_waiting = true;
         if (!vol->is_io_in_progress()) {

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -490,9 +490,9 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   if (dir_agg_buf_valid(vol, &dir)) {
     int agg_offset = vol->vol_offset(&dir) - vol->header->write_pos;
     buf            = new_IOBufferData(iobuffer_size_to_index(io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-    ink_assert((agg_offset + io.aiocb.aio_nbytes) <= (unsigned)vol->agg_buf_pos);
+    ink_assert((agg_offset + io.aiocb.aio_nbytes) <= (unsigned)vol->get_agg_buf_pos());
     char *doc = buf->data();
-    char *agg = vol->agg_buffer + agg_offset;
+    char *agg = vol->get_agg_buffer() + agg_offset;
     memcpy(doc, agg, io.aiocb.aio_nbytes);
     io.aio_result = io.aiocb.aio_nbytes;
     SET_HANDLER(&CacheVC::handleReadDone);

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -31,7 +31,7 @@
 // aio
 #include "iocore/aio/AIO.h"
 
-struct Stripe;
+class Stripe;
 struct InterimCacheVol;
 struct CacheVC;
 class CacheEvacuateDocVC;

--- a/src/iocore/cache/P_CacheHosting.h
+++ b/src/iocore/cache/P_CacheHosting.h
@@ -30,7 +30,7 @@
 
 #define CACHE_MEM_FREE_TIMEOUT HRTIME_SECONDS(1)
 
-struct Stripe;
+class Stripe;
 struct CacheVol;
 
 struct CacheHostResult;

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -372,7 +372,7 @@ Stripe::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
   Stripe *vol    = this;
   bool agg_error = false;
   if (!cont->f.remove) {
-    agg_error = (!cont->f.update && agg_todo_size > cache_config_agg_write_backlog);
+    agg_error = (!cont->f.update && this->get_agg_todo_size() > cache_config_agg_write_backlog);
 #ifdef CACHE_AGG_FAIL_RATE
     agg_error = agg_error || ((uint32_t)mutex->thread_holding->generator.random() < (uint32_t)(UINT_MAX * CACHE_AGG_FAIL_RATE));
 #endif
@@ -546,7 +546,7 @@ CacheRemoveCont::event_handler(int event, void *data)
 }
 
 struct CacheHostRecord;
-struct Stripe;
+class Stripe;
 class CacheHostTable;
 
 struct Cache {

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -26,6 +26,7 @@
 #include "P_CacheDir.h"
 #include "P_CacheStats.h"
 #include "P_RamCache.h"
+#include "iocore/cache/AggregateWriteBuffer.h"
 
 #include "tscore/CryptoHash.h"
 
@@ -75,7 +76,7 @@
 #define DOC_NO_CHECKSUM ((uint32_t)0xA0B0C0D0)
 
 struct Cache;
-struct Stripe;
+class Stripe;
 struct CacheDisk;
 struct StripeInitInfo;
 struct DiskStripe;
@@ -127,7 +128,9 @@ struct EvacuationBlock {
   LINK(EvacuationBlock, link);
 };
 
-struct Stripe : public Continuation {
+class Stripe : public Continuation
+{
+public:
   char *path = nullptr;
   ats_scoped_str hash_text;
   CryptoHash hash_id;
@@ -149,11 +152,7 @@ struct Stripe : public Continuation {
   int hit_evacuate_window     = 0;
   AIOCallbackInternal io;
 
-  Queue<CacheVC, Continuation::Link_link> agg;
   Queue<CacheVC, Continuation::Link_link> sync;
-  char *agg_buffer  = nullptr;
-  int agg_todo_size = 0;
-  int agg_buf_pos   = 0;
 
   Event *trigger = nullptr;
 
@@ -276,18 +275,23 @@ struct Stripe : public Continuation {
   Stripe() : Continuation(new_ProxyMutex())
   {
     open_dir.mutex = mutex;
-    agg_buffer     = (char *)ats_memalign(ats_pagesize(), AGG_SIZE);
-    memset(agg_buffer, 0, AGG_SIZE);
     SET_HANDLER(&Stripe::aggWrite);
   }
 
-  ~Stripe() override { ats_free(agg_buffer); }
+  Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
+  char *get_agg_buffer();
+  int get_agg_buf_pos() const;
+  void reset_agg_buf_pos();
+  int get_agg_todo_size() const;
+  void add_agg_todo(int size);
 
 private:
   void _clear_init();
   void _init_dir();
   void _init_data_internal();
   void _init_data();
+
+  AggregateWriteBuffer write_buffer;
 };
 
 struct AIO_failure_handler : public Continuation {
@@ -402,7 +406,7 @@ Stripe::vol_out_of_phase_write_valid(Dir *e) const
 inline int
 Stripe::vol_in_phase_valid(Dir *e) const
 {
-  return (dir_offset(e) - 1 < ((this->header->write_pos + this->agg_buf_pos - this->start) / CACHE_BLOCK_SIZE));
+  return (dir_offset(e) - 1 < ((this->header->write_pos + this->write_buffer.get_buffer_pos() - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline off_t
@@ -426,7 +430,8 @@ Stripe::vol_offset_to_offset(off_t pos) const
 inline int
 Stripe::vol_in_phase_agg_buf_valid(Dir *e) const
 {
-  return (this->vol_offset(e) >= this->header->write_pos && this->vol_offset(e) < (this->header->write_pos + this->agg_buf_pos));
+  return (this->vol_offset(e) >= this->header->write_pos &&
+          this->vol_offset(e) < (this->header->write_pos + this->write_buffer.get_buffer_pos()));
 }
 
 // length of the partition not including the offset of location 0.
@@ -554,4 +559,40 @@ inline void
 Stripe::set_io_not_in_progress()
 {
   io.aiocb.aio_fildes = AIO_NOT_IN_PROGRESS;
+}
+
+inline Queue<CacheVC, Continuation::Link_link> &
+Stripe::get_pending_writers()
+{
+  return this->write_buffer.get_pending_writers();
+}
+
+inline char *
+Stripe::get_agg_buffer()
+{
+  return this->write_buffer.get_buffer();
+}
+
+inline int
+Stripe::get_agg_buf_pos() const
+{
+  return this->write_buffer.get_buffer_pos();
+}
+
+inline void
+Stripe::reset_agg_buf_pos()
+{
+  this->write_buffer.reset_buffer_pos();
+}
+
+inline int
+Stripe::get_agg_todo_size() const
+{
+  return this->write_buffer.get_bytes_pending_aggregation();
+}
+
+inline void
+Stripe::add_agg_todo(int size)
+{
+  this->write_buffer.add_bytes_pending_aggregation(size);
 }

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -291,7 +291,7 @@ private:
   void _init_data_internal();
   void _init_data();
 
-  AggregateWriteBuffer write_buffer;
+  AggregateWriteBuffer _write_buffer;
 };
 
 struct AIO_failure_handler : public Continuation {
@@ -406,7 +406,7 @@ Stripe::vol_out_of_phase_write_valid(Dir *e) const
 inline int
 Stripe::vol_in_phase_valid(Dir *e) const
 {
-  return (dir_offset(e) - 1 < ((this->header->write_pos + this->write_buffer.get_buffer_pos() - this->start) / CACHE_BLOCK_SIZE));
+  return (dir_offset(e) - 1 < ((this->header->write_pos + this->_write_buffer.get_buffer_pos() - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline off_t
@@ -431,7 +431,7 @@ inline int
 Stripe::vol_in_phase_agg_buf_valid(Dir *e) const
 {
   return (this->vol_offset(e) >= this->header->write_pos &&
-          this->vol_offset(e) < (this->header->write_pos + this->write_buffer.get_buffer_pos()));
+          this->vol_offset(e) < (this->header->write_pos + this->_write_buffer.get_buffer_pos()));
 }
 
 // length of the partition not including the offset of location 0.
@@ -564,35 +564,35 @@ Stripe::set_io_not_in_progress()
 inline Queue<CacheVC, Continuation::Link_link> &
 Stripe::get_pending_writers()
 {
-  return this->write_buffer.get_pending_writers();
+  return this->_write_buffer.get_pending_writers();
 }
 
 inline char *
 Stripe::get_agg_buffer()
 {
-  return this->write_buffer.get_buffer();
+  return this->_write_buffer.get_buffer();
 }
 
 inline int
 Stripe::get_agg_buf_pos() const
 {
-  return this->write_buffer.get_buffer_pos();
+  return this->_write_buffer.get_buffer_pos();
 }
 
 inline void
 Stripe::reset_agg_buf_pos()
 {
-  this->write_buffer.reset_buffer_pos();
+  this->_write_buffer.reset_buffer_pos();
 }
 
 inline int
 Stripe::get_agg_todo_size() const
 {
-  return this->write_buffer.get_bytes_pending_aggregation();
+  return this->_write_buffer.get_bytes_pending_aggregation();
 }
 
 inline void
 Stripe::add_agg_todo(int size)
 {
-  this->write_buffer.add_bytes_pending_aggregation(size);
+  this->_write_buffer.add_bytes_pending_aggregation(size);
 }


### PR DESCRIPTION
This encapsulates the `agg_` fields of `Stripe` in a new class. This is in preparation to move all the aggregation behavior into this new class, including the behavior to enqueue virtual connections and update the number of bytes waiting to be written to the buffer, which is currently being done by the virtual connections themselves.

Note: `Stripe` does not use its own getters to access aggregate buffer, but calls the getters on the `AggregateWriteBuffer` itself. This is because I want to get rid of as many of the getters on `Stripe` as possible.