### PR TITLE
Don't include headers in proxy/http from iocore/cache

### DIFF
--- a/include/iocore/cache/HttpTransactCache.h
+++ b/include/iocore/cache/HttpTransactCache.h
@@ -65,6 +65,9 @@ public:
   static float calculate_quality_of_accept_encoding_match(MIMEField *accept_field, MIMEField *content_field,
                                                           MIMEField *cached_accept_field = nullptr);
 
+  static ink_time_t calculate_document_age(ink_time_t request_time, ink_time_t response_time, HTTPHdr *base_response,
+                                           ink_time_t base_response_date, ink_time_t now);
+
   // 'encoding_identifier' is a nul-terminated string.
   static bool match_content_encoding(MIMEField *accept_field, const char *encoding_identifier);
 

--- a/include/proxy/http/HttpTransactHeaders.h
+++ b/include/proxy/http/HttpTransactHeaders.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "proxy/http/HttpTransact.h"
+
 #define ink_time_t time_t
 
 extern int nstrhex(char *d, unsigned int i);
@@ -50,8 +52,6 @@ public:
   static void convert_to_1_0_response_header(HTTPHdr *outgoing_response, char const *reason_phrase = nullptr);
   static void convert_to_1_1_response_header(HTTPHdr *outgoing_response, char const *reason_phrase = nullptr);
 
-  static ink_time_t calculate_document_age(ink_time_t request_time, ink_time_t response_time, HTTPHdr *base_response,
-                                           ink_time_t base_response_date, ink_time_t now);
   static bool does_server_allow_response_to_be_stored(HTTPHdr *resp, bool does_server_allow_response_to_be_stored);
   static bool downgrade_request(bool *origin_server_keep_alive, HTTPHdr *outgoing_request);
   static bool is_method_safe(int method);

--- a/src/iocore/cache/unit_tests/main.cc
+++ b/src/iocore/cache/unit_tests/main.cc
@@ -366,3 +366,43 @@ CacheReadTest::start_test(int event, void *e)
 }
 
 constexpr size_t WRITE_LIMIT = 1024 * 3;
+
+/************ STUB ******************/
+
+#include "api/FetchSM.h"
+ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+void
+FetchSM::ext_launch()
+{
+}
+void
+FetchSM::ext_destroy()
+{
+}
+ssize_t
+FetchSM::ext_read_data(char *, unsigned long)
+{
+  return 0;
+}
+void
+FetchSM::ext_add_header(char const *, int, char const *, int)
+{
+}
+void
+FetchSM::ext_write_data(void const *, unsigned long)
+{
+}
+void *
+FetchSM::ext_get_user_data()
+{
+  return nullptr;
+}
+void
+FetchSM::ext_set_user_data(void *)
+{
+}
+void
+FetchSM::ext_init(Continuation *, char const *, char const *, char const *, sockaddr const *, int)
+{
+}
+ChunkedHandler::ChunkedHandler() {}

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -5994,9 +5994,9 @@ HttpTransact::is_stale_cache_response_returnable(State *s)
   }
   // See how old the document really is.  We don't want create a
   //   stale content museum of documents that are no longer available
-  time_t current_age = HttpTransactHeaders::calculate_document_age(s->cache_info.object_read->request_sent_time_get(),
-                                                                   s->cache_info.object_read->response_received_time_get(),
-                                                                   cached_response, cached_response->get_date(), s->current.now);
+  time_t current_age = HttpTransactCache::calculate_document_age(s->cache_info.object_read->request_sent_time_get(),
+                                                                 s->cache_info.object_read->response_received_time_get(),
+                                                                 cached_response, cached_response->get_date(), s->current.now);
   // Negative age is overflow
   if ((current_age < 0) || (current_age > s->txn_conf->cache_max_stale_age)) {
     TxnDebug("http_trans", "document age is too large %" PRId64, (int64_t)current_age);
@@ -7347,8 +7347,8 @@ HttpTransact::what_is_document_freshness(State *s, HTTPHdr *client_request, HTTP
   fresh_limit   = calculate_document_freshness_limit(s, cached_obj_response, response_date, &heuristic);
   ink_assert(fresh_limit >= 0);
 
-  current_age = HttpTransactHeaders::calculate_document_age(s->request_sent_time, s->response_received_time, cached_obj_response,
-                                                            response_date, s->current.now);
+  current_age = HttpTransactCache::calculate_document_age(s->request_sent_time, s->response_received_time, cached_obj_response,
+                                                          response_date, s->current.now);
 
   // First check overflow status
   // Second if current_age is under the max, use the smaller value


### PR DESCRIPTION
#10711 removed the necessity of linking libhttp, but I found header files are still included and inline functions make some magic.

To not include the header files, this PR moves `calculate_document_age` from `HttpTransactHeaders` to `HttpTransactCache` which has other calculation functions.


There is actually one more place that includes a header file in proxy/http
```
$ git grep "#include" src/iocore/cache | grep "proxy/http"
src/iocore/cache/CacheRead.cc:#include "proxy/http/HttpCacheSM.h" //Added to get the scope of HttpCacheSM object.
```
And it's used here
https://github.com/apache/trafficserver/blob/48333c8bc13102b4d3b570bfb25e8d1109f373e9/src/iocore/cache/CacheRead.cc#L171-L172
I'll try to remove this on another PR to make this one simple. -> Made it #10721