### PR TITLE
Export Regex support to plugins.

### DIFF
--- a/include/iocore/net/SSLSNIConfig.h
+++ b/include/iocore/net/SSLSNIConfig.h
@@ -37,6 +37,14 @@
 #include <strings.h>
 #include <memory>
 
+#if __has_include("pcre/pcre.h")
+#include <pcre/pcre.h>
+#elif __has_include("pcre.h")
+#include <pcre.h>
+#else
+#error "Unable to locate PCRE heeader"
+#endif
+
 #include "tscpp/util/ts_ip.h"
 
 #include "iocore/eventsystem/ConfigProcessor.h"

--- a/include/proxy/ControlMatcher.h
+++ b/include/proxy/ControlMatcher.h
@@ -97,6 +97,14 @@
 #include "tscpp/util/Regex.h"
 #include "proxy/hdrs/URL.h"
 
+#if __has_include("pcre/pcre.h")
+#include <pcre/pcre.h>
+#elif __has_include("pcre.h")
+#include <pcre.h>
+#else
+#error "Unable to locate PCRE heeader"
+#endif
+
 #include <swoc/swoc_ip.h>
 
 #ifdef HAVE_CTYPE_H

--- a/include/proxy/ControlMatcher.h
+++ b/include/proxy/ControlMatcher.h
@@ -94,7 +94,7 @@
 #include "tscore/ink_apidefs.h"
 #include "tscore/ink_defs.h"
 #include "proxy/hdrs/HTTP.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "proxy/hdrs/URL.h"
 
 #include <swoc/swoc_ip.h>

--- a/include/proxy/hdrs/HdrToken.h
+++ b/include/proxy/hdrs/HdrToken.h
@@ -30,7 +30,7 @@
 #include "tscore/ink_defs.h"
 #include "tscore/ink_string.h"
 #include "tscore/Allocator.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscore/ink_apidefs.h"
 
 ////////////////////////////////////////////////////////////////////////////

--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -46,7 +46,7 @@
 #include "tscore/ink_platform.h"
 #include "tscore/ink_inet.h"
 #include "tscore/ink_resolver.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscpp/util/ts_bw.h"
 #include "iocore/eventsystem/ConfigProcessor.h"
 #include "iocore/net/ConnectionTracker.h"

--- a/include/proxy/http/remap/UrlMapping.h
+++ b/include/proxy/http/remap/UrlMapping.h
@@ -32,7 +32,7 @@
 #include "proxy/http/remap/RemapHitCount.h"
 #include "proxy/http/remap/RemapPluginInfo.h"
 #include "proxy/http/remap/PluginFactory.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscore/List.h"
 
 class NextHopSelectionStrategy;

--- a/include/proxy/http/remap/UrlMapping.h
+++ b/include/proxy/http/remap/UrlMapping.h
@@ -26,6 +26,14 @@
 
 #include <vector>
 
+#if __has_include("pcre/pcre.h")
+#include <pcre/pcre.h>
+#elif __has_include("pcre.h")
+#include <pcre.h>
+#else
+#error "Unable to locate PCRE heeader"
+#endif
+
 #include "tscore/ink_config.h"
 #include "proxy/http/remap/AclFiltering.h"
 #include "proxy/hdrs/URL.h"

--- a/include/proxy/http/remap/UrlRewrite.h
+++ b/include/proxy/http/remap/UrlRewrite.h
@@ -28,7 +28,7 @@
 #include "proxy/http/remap/UrlMapping.h"
 #include "proxy/http/remap/UrlMappingPathIndex.h"
 #include "proxy/http/HttpTransact.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "proxy/http/remap/PluginFactory.h"
 #include "proxy/http/remap/NextHopStrategyFactory.h"
 

--- a/include/tscore/DiagsTypes.h
+++ b/include/tscore/DiagsTypes.h
@@ -39,7 +39,7 @@
 #include "tscore/ink_apidefs.h"
 #include "tscore/ink_inet.h"
 #include "tscore/ink_mutex.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscore/SourceLocation.h"
 
 #include "tscpp/util/ts_diag_levels.h"

--- a/include/tscore/Regression.h
+++ b/include/tscore/Regression.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "tscore/ink_platform.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscore/Diags.h"
 
 //   Each module should provide one or more regression tests

--- a/include/tscpp/util/Regex.h
+++ b/include/tscpp/util/Regex.h
@@ -30,14 +30,6 @@
 
 #include "swoc/MemSpan.h"
 
-#if __has_include("pcre/pcre.h")
-#include <pcre/pcre.h>
-#elif __has_include("pcre.h")
-#include <pcre.h>
-#else
-#error "Unable to locate PCRE heeader"
-#endif
-
 /// Match flags for regular expression evaluation.
 enum REFlags {
   RE_CASE_INSENSITIVE = 0x0001, ///< Ignore case (default: case sensitive).
@@ -110,8 +102,12 @@ public:
   int get_capture_count();
 
 private:
-  pcre *regex             = nullptr;
-  pcre_extra *regex_extra = nullptr;
+  // @internal - Because the PCRE header is badly done, we can't forward declare the PCRE
+  // enough to use as pointers. For some reason the header defines in name only a struct and
+  // then aliases it to the standard name, rather than simply declare the latter in name only.
+  // The goal is completely wrap PCRE and not include that header in client code.
+  void *regex       = nullptr; ///< Compiled expression.
+  void *regex_extra = nullptr; ///< Extra information about the expression.
 };
 
 /** Deterministic Finite state Automata container.

--- a/include/tscpp/util/Regex.h
+++ b/include/tscpp/util/Regex.h
@@ -28,12 +28,14 @@
 #include <vector>
 #include <memory>
 
-#include "tscore/ink_config.h"
+#include "swoc/MemSpan.h"
 
-#ifdef HAVE_PCRE_PCRE_H
+#if __has_include("pcre/pcre.h")
 #include <pcre/pcre.h>
-#else
+#elif __has_include("pcre.h")
 #include <pcre.h>
+#else
+#error "Unable to locate PCRE heeader"
 #endif
 
 /// Match flags for regular expression evaluation.
@@ -89,6 +91,20 @@ public:
    * be a multiple of 3 and at least three times the number of desired capture groups.
    */
   bool exec(std::string_view const &str, int *ovector, int ovecsize) const;
+
+  /** Execute the regular expression.
+   *
+   * @param str String to match against.
+   * @param ovector Capture results.
+   * @param ovecsize Number of elements in @a ovector.
+   * @return @c true if the pattern matched, @a false if not.
+   *
+   * It is safe to call this method concurrently on the same instance of @a this.
+   *
+   * Each capture group takes 3 elements of @a ovector, therefore @a ovecsize must
+   * be a multiple of 3 and at least three times the number of desired capture groups.
+   */
+  bool exec(std::string_view str, swoc::MemSpan<int> groups) const;
 
   /// @return The number of groups captured in the last call to @c exec.
   int get_capture_count();

--- a/plugins/experimental/tls_bridge/tls_bridge.cc
+++ b/plugins/experimental/tls_bridge/tls_bridge.cc
@@ -21,7 +21,7 @@
 
 #include "ts/ts.h"
 #include "swoc/TextView.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 
 using swoc::TextView;
 

--- a/src/iocore/cache/CachePages.cc
+++ b/src/iocore/cache/CachePages.cc
@@ -26,6 +26,15 @@
 #include "proxy/Show.h"
 #include "iocore/eventsystem/Tasks.h"
 #include "proxy/CacheControl.h"
+
+#if __has_include("pcre/pcre.h")
+#include <pcre/pcre.h>
+#elif __has_include("pcre.h")
+#include <pcre.h>
+#else
+#error "Unable to locate PCRE heeader"
+#endif
+
 namespace
 {
 

--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -26,7 +26,7 @@
 #include "tscore/ink_config.h"
 #include "tscore/Layout.h"
 #include "tscore/MatcherUtils.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscore/Trie.h"
 #include "tscore/ink_config.h"
 

--- a/src/mgmt/rpc/CMakeLists.txt
+++ b/src/mgmt/rpc/CMakeLists.txt
@@ -26,7 +26,7 @@ set_target_properties(jsonrpc_protocol PROPERTIES POSITION_INDEPENDENT_CODE TRUE
 
 target_link_libraries(
   jsonrpc_protocol
-  PUBLIC ts::tscore
+  PUBLIC tscpputil ts::tscore
   PRIVATE ts::tsapicore
 )
 

--- a/src/mgmt/rpc/handlers/common/RecordsUtils.cc
+++ b/src/mgmt/rpc/handlers/common/RecordsUtils.cc
@@ -17,6 +17,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+
+#if __has_include("pcre/pcre.h")
+#include <pcre/pcre.h>
+#elif __has_include("pcre.h")
+#include <pcre.h>
+#else
+#error "Unable to locate PCRE heeader"
+#endif
+
 #include "mgmt/rpc/handlers/common/RecordsUtils.h"
 
 #include <system_error>

--- a/src/proxy/CacheControl.cc
+++ b/src/proxy/CacheControl.cc
@@ -39,7 +39,7 @@
 #include "proxy/hdrs/HTTP.h"
 #include "proxy/http/HttpConfig.h"
 #include "../iocore/cache/P_Cache.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 
 static const char modulePrefix[] = "[CacheControl]";
 

--- a/src/proxy/hdrs/CMakeLists.txt
+++ b/src/proxy/hdrs/CMakeLists.txt
@@ -55,6 +55,6 @@ if(BUILD_TESTING)
   add_test(NAME test_proxy_hdrs COMMAND test_proxy_hdrs)
 
   add_executable(test_proxy_hdrs_xpack XPACK.cc HuffmanCodec.cc unit_tests/test_XPACK.cc)
-  target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::tscore ts::tsapicore libswoc catch2::catch2)
+  target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::tscore ts::tsapicore tscpputil libswoc catch2::catch2)
   add_test(NAME test_proxy_hdrs_xpack COMMAND test_proxy_hdrs_xpack)
 endif()

--- a/src/proxy/hdrs/HdrToken.cc
+++ b/src/proxy/hdrs/HdrToken.cc
@@ -30,7 +30,7 @@
 #include "proxy/hdrs/HTTP.h"
 #include "proxy/hdrs/HdrToken.h"
 #include "proxy/hdrs/MIME.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "proxy/hdrs/URL.h"
 
 /*

--- a/src/proxy/hdrs/test_urlhash.cc
+++ b/src/proxy/hdrs/test_urlhash.cc
@@ -27,7 +27,7 @@
 #include "tscore/Arena.h"
 #include "proxy/hdrs/HTTP.h"
 #include "proxy/hdrs/MIME.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "proxy/hdrs/URL.h"
 #include "proxy/hdrs/HttpCompat.h"
 

--- a/src/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/src/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -29,7 +29,7 @@
 #include <cstdio>
 #include <memory>
 
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscore/ink_time.h"
 #include "tscore/Random.h"
 #include "tscpp/util/PostScript.h"

--- a/src/traffic_cache_tool/CMakeLists.txt
+++ b/src/traffic_cache_tool/CMakeLists.txt
@@ -17,5 +17,5 @@
 
 add_executable(traffic_cache_tool CacheDefs.cc CacheTool.cc CacheScan.cc)
 
-target_link_libraries(traffic_cache_tool PRIVATE ts::tscore libswoc ts::tsapicore)
+target_link_libraries(traffic_cache_tool PRIVATE tscpputil ts::tscore libswoc ts::tsapicore)
 install(TARGETS traffic_cache_tool)

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -34,7 +34,7 @@
 
 #include "tscore/Version.h"
 #include "tscore/ink_memory.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "tscore/ink_file.h"
 #include "tscore/CryptoHash.h"
 

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -31,6 +31,14 @@
 #include "info.h"
 #include "iocore/eventsystem/RecProcess.h"
 
+#if __has_include("pcre/pcre.h")
+#include <pcre/pcre.h>
+#elif __has_include("pcre.h")
+#include <pcre.h>
+#else
+#error "Unable to locate PCRE heeader"
+#endif
+
 #if TS_USE_HWLOC
 #include <hwloc.h>
 #endif

--- a/src/traffic_via/traffic_via.cc
+++ b/src/traffic_via/traffic_via.cc
@@ -28,7 +28,7 @@
 #include <cstring>
 #include <iostream>
 #include <string_view>
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 
 /// XXX Use DFA or Regex wrappers?
 #ifdef HAVE_PCRE_PCRE_H

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -54,7 +54,6 @@ add_library(
   MatcherUtils.cc
   ParseRules.cc
   Random.cc
-  Regex.cc
   Regression.cc
   SourceLocation.cc
   TextBuffer.cc
@@ -150,7 +149,6 @@ if(BUILD_TESTING)
     unit_tests/test_PriorityQueue.cc
     unit_tests/test_Ptr.cc
     unit_tests/test_Random.cc
-    unit_tests/test_Regex.cc
     unit_tests/test_Throttler.cc
     unit_tests/test_Tokenizer.cc
     unit_tests/test_arena.cc

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 add_library(tscpputil SHARED ts_bwf.cc ts_ip.cc ts_diags.cc YamlCfg.cc ts_unit_parser.cc Regex.cc)
 add_library(ts::tscpputil ALIAS tscpputil)
-target_link_libraries(tscpputil PUBLIC pcre libswoc yaml-cpp::yaml-cpp)
+target_link_libraries(tscpputil PUBLIC PCRE::PCRE libswoc yaml-cpp::yaml-cpp)
 set(TSCPPUTIL_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/Bravo.h
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/Convert.h

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -15,9 +15,9 @@
 #
 #######################
 
-add_library(tscpputil SHARED ts_bwf.cc ts_ip.cc ts_diags.cc YamlCfg.cc ts_unit_parser.cc)
+add_library(tscpputil SHARED ts_bwf.cc ts_ip.cc ts_diags.cc YamlCfg.cc ts_unit_parser.cc Regex.cc)
 add_library(ts::tscpputil ALIAS tscpputil)
-target_link_libraries(tscpputil PUBLIC libswoc yaml-cpp::yaml-cpp ts::tscore)
+target_link_libraries(tscpputil PUBLIC pcre libswoc yaml-cpp::yaml-cpp)
 set(TSCPPUTIL_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/Bravo.h
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/Convert.h
@@ -26,6 +26,7 @@ set(TSCPPUTIL_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/LocalBuffer.h
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/PostScript.h
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/Strerror.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/Regex.h
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/TsSharedMutex.h
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/YamlCfg.h
     ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_bw.h
@@ -43,8 +44,14 @@ install(TARGETS tscpputil PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
 
 if(BUILD_TESTING)
   add_executable(
-    test_tscpputil unit_tests/test_LocalBuffer.cc unit_tests/test_PostScript.cc unit_tests/test_Strerror.cc
-                   unit_tests/test_ts_meta.cc unit_tests/test_time_parser.cc unit_tests/unit_test_main.cc
+    test_tscpputil
+    unit_tests/test_LocalBuffer.cc
+    unit_tests/test_PostScript.cc
+    unit_tests/test_Strerror.cc
+    unit_tests/test_Regex.cc
+    unit_tests/test_ts_meta.cc
+    unit_tests/test_time_parser.cc
+    unit_tests/unit_test_main.cc
   )
   target_link_libraries(test_tscpputil PRIVATE tscpputil libswoc catch2::catch2)
 

--- a/src/tscpp/util/Regex.cc
+++ b/src/tscpp/util/Regex.cc
@@ -26,15 +26,13 @@
 #include <array>
 #include <assert.h>
 
-#include "tscore/ink_memory.h" // ats_pagesize()
-
-#if __has_include("pcre/pcre.h")
+#if __has_include(<pcre/pcre.h>)
 #include <pcre/pcre.h>
-#elif __has_include("pcre.h")
-#include <pcre.h>
 #else
-#error "Unable to locate PCRE heeader"
+#include <pcre.h>
 #endif
+
+#include "tscore/ink_memory.h" // ats_pagesize()
 
 namespace
 {

--- a/src/tscpp/util/unit_tests/test_Regex.cc
+++ b/src/tscpp/util/unit_tests/test_Regex.cc
@@ -25,7 +25,7 @@
 
 #include "tscore/ink_assert.h"
 #include "tscore/ink_defs.h"
-#include "tscore/Regex.h"
+#include "tscpp/util/Regex.h"
 #include "catch.hpp"
 
 struct subject_match_t {


### PR DESCRIPTION
Basically move to "tscpp/util" and then update the includes.

Remove core dependencies from regex.