### PR TITLE
uri_signing cmake: clean up unit test cmake and change suggested github repo

### DIFF
--- a/doc/admin-guide/plugins/uri_signing.en.rst
+++ b/doc/admin-guide/plugins/uri_signing.en.rst
@@ -203,7 +203,7 @@ Building
 
 To build from source, you will need these libraries installed:
 
-  - `cjose <https://github.com/cisco/cjose>`_
+  - `cjose <https://github.com/OpenIDC/cjose>`_
   - `jansson <https://github.com/akheron/jansson>`_
   - pcre
   - OpenSSL
@@ -253,7 +253,7 @@ If using local cjose:
 .. code-block:: Bash
 
     cd ${HOME}/git
-    git clone https://github.com/cisco/cjose.git
+    git clone https://github.com/OpenIDC/cjose.git
     cd cjose
     autoreconf -i
     ./configure --with-jansson=${HOME}/git/jansson --disable-shared CC="gcc -fpic"

--- a/plugins/experimental/uri_signing/Makefile.inc
+++ b/plugins/experimental/uri_signing/Makefile.inc
@@ -33,7 +33,7 @@ check_PROGRAMS += experimental/uri_signing/test_uri_signing
 experimental_uri_signing_test_uri_signing_CPPFLAGS = \
     $(AM_CPPFLAGS) \
     -I$(abs_top_srcdir)/lib/catch2 \
-    -DURI_SIGNING_UNIT_TEST \
+    -DUNITTEST \
     -DSRCDIR=\"$(srcdir)\"
 
 experimental_uri_signing_test_uri_signing_LDADD = @LIBJANSSON@ @LIBCJOSE@ @LIBPCRE@ -lm -lcrypto

--- a/plugins/experimental/uri_signing/common.cc
+++ b/plugins/experimental/uri_signing/common.cc
@@ -18,7 +18,7 @@
 
 #include "common.h"
 
-#ifdef URI_SIGNING_UNIT_TEST
+#ifdef UNITTEST
 
 void
 PrintToStdErr(const char *fmt, ...)

--- a/plugins/experimental/uri_signing/common.h
+++ b/plugins/experimental/uri_signing/common.h
@@ -20,7 +20,7 @@
 
 #define PLUGIN_NAME "uri_signing"
 
-#ifdef URI_SIGNING_UNIT_TEST
+#ifdef UNITTEST
 #include <stdio.h>
 #include <stdarg.h>
 

--- a/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
@@ -26,8 +26,6 @@ add_executable(
   ${PROJECT_SOURCE_DIR}/match.cc
   ${PROJECT_SOURCE_DIR}/normalize.cc
   ${PROJECT_SOURCE_DIR}/parse.cc
-  ${PROJECT_SOURCE_DIR}/timing.cc
-  ${PROJECT_SOURCE_DIR}/uri_signing.cc
 )
 target_compile_definitions(uri_signing_test PRIVATE UNITTEST)
 target_include_directories(uri_signing_test PRIVATE ${PROJECT_SOURCE_DIR})

--- a/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   ${PROJECT_SOURCE_DIR}/match.cc
   ${PROJECT_SOURCE_DIR}/normalize.cc
   ${PROJECT_SOURCE_DIR}/parse.cc
+  ${PROJECT_SOURCE_DIR}/timing.cc
 )
 target_compile_definitions(uri_signing_test PRIVATE UNITTEST)
 target_include_directories(uri_signing_test PRIVATE ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Some cmake cleanup and change the suggested source for the cjose repo from the unmaintained cisco to one maintained by openidc.