### PR TITLE
logcat/CMakeLists: add inkevent as library dependency

### DIFF
--- a/src/traffic_logcat/CMakeLists.txt
+++ b/src/traffic_logcat/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
           ts::http
           ts::tsapicore
           ts::diagsconfig
+          ts::inkevent
           ts::configmanager
           libswoc
 )


### PR DESCRIPTION
This should fix the failing branch builds on various linux distributions (ie: debian11/gcc/release)