### PR TITLE
Standardize maxminddb package_find()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,9 @@ if(ENABLE_QUICHE)
   endif()
 endif()
 
+# for the plugin system
+find_package(maxminddb)  # Header_rewrite experimental/maxmind_acl
+
 if(ENABLE_ASAN)
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)

--- a/plugins/experimental/maxmind_acl/CMakeLists.txt
+++ b/plugins/experimental/maxmind_acl/CMakeLists.txt
@@ -15,10 +15,14 @@
 #
 #######################
 
-add_atsplugin(maxmind_acl maxmind_acl.cc mmdb.cc)
+if(maxminddb_FOUND)
 
-target_include_directories(maxmind_acl PRIVATE ${PCRE_INCLUDE_DIR})
+  add_atsplugin(maxmind_acl maxmind_acl.cc mmdb.cc)
 
-find_package(maxminddb REQUIRED)
+  target_include_directories(maxmind_acl PRIVATE ${PCRE_INCLUDE_DIR})
 
-target_link_libraries(maxmind_acl PRIVATE libswoc yaml-cpp::yaml-cpp maxminddb::maxminddb)
+  target_link_libraries(maxmind_acl PRIVATE libswoc yaml-cpp::yaml-cpp maxminddb::maxminddb)
+
+else()
+  message(STATUS "skipping maxmind_acl plugin (missing maxminddb)")
+endif()

--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -36,8 +36,6 @@ add_library(header_rewrite_parser STATIC parser.cc)
 
 target_link_libraries(header_rewrite PRIVATE PCRE::PCRE libswoc)
 
-find_package(maxminddb QUIET)
-
 if(maxminddb_FOUND)
   target_sources(header_rewrite PRIVATE conditions_geo_maxmind.cc)
   target_link_libraries(header_rewrite PRIVATE maxminddb::maxminddb)


### PR DESCRIPTION
Allow plugin to build if required library exists
