### PR TITLE
Rename vol to stripe (defined in the CacheVC.h)

### DIFF
--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -109,8 +109,8 @@ struct CacheVC : public CacheVConnection {
   int
   get_volume_number() const override
   {
-    if (vol && vol->cache_vol) {
-      return vol->cache_vol->vol_number;
+    if (stripe && stripe->cache_vol) {
+      return stripe->cache_vol->vol_number;
     }
 
     return -1;
@@ -119,8 +119,8 @@ struct CacheVC : public CacheVConnection {
   const char *
   get_disk_path() const override
   {
-    if (vol && vol->disk) {
-      return vol->disk->path;
+    if (stripe && stripe->disk) {
+      return stripe->disk->path;
     }
 
     return nullptr;
@@ -176,7 +176,7 @@ struct CacheVC : public CacheVConnection {
 
   int removeEvent(int event, Event *e);
 
-  int scanVol(int event, Event *e);
+  int scanStripe(int event, Event *e);
   int scanObject(int event, Event *e);
   int scanUpdateDone(int event, Event *e);
   int scanOpenWrite(int event, Event *e);
@@ -265,7 +265,7 @@ struct CacheVC : public CacheVConnection {
   uint32_t write_len;    // for communicating with agg_copy
   uint32_t agg_len;      // for communicating with aggWrite
   uint32_t write_serial; // serial of the final write for SYNC
-  Stripe *vol;
+  Stripe *stripe;
   Dir *last_collision;
   Event *trigger;
   CacheKey *read_key;
@@ -320,7 +320,7 @@ struct CacheVC : public CacheVConnection {
   };
   // BTF optimization used to skip reading stuff in cache partition that doesn't contain any
   // dir entries.
-  char *scan_vol_map;
+  char *scan_stripe_map;
   // BTF fix to handle objects that overlapped over two different reads,
   // this is how much we need to back up the buffer to get the start of the overlapping object.
   off_t scan_fix_buffer_offset;

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -1202,7 +1202,7 @@ Cache::lookup(Continuation *cont, const CacheKey *key, CacheFragType type, const
   c->first_key = c->key = *key;
   c->frag_type          = type;
   c->f.lookup           = 1;
-  c->vol                = stripe;
+  c->stripe             = stripe;
   c->last_collision     = nullptr;
 
   if (c->handleEvent(EVENT_INTERVAL, nullptr) == EVENT_CONT) {
@@ -1242,7 +1242,7 @@ Cache::remove(Continuation *cont, const CacheKey *key, CacheFragType type, const
   Metrics::Gauge::increment(cache_rsb.status[c->op_type].active);
   Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.status[c->op_type].active);
   c->first_key = c->key = *key;
-  c->vol                = stripe;
+  c->stripe             = stripe;
   c->dir                = result;
   c->f.remove           = 1;
 

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -73,7 +73,7 @@ OpenDir::OpenDir()
 int
 OpenDir::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
 {
-  ink_assert(cont->vol->mutex->thread_holding == this_ethread());
+  ink_assert(cont->stripe->mutex->thread_holding == this_ethread());
   unsigned int h = cont->first_key.slice32(0);
   int b          = h % OPEN_DIR_BUCKETS;
   for (OpenDirEntry *d = bucket[b].head; d; d = d->link.next) {
@@ -135,7 +135,7 @@ OpenDir::signal_readers(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 int
 OpenDir::close_write(CacheVC *cont)
 {
-  ink_assert(cont->vol->mutex->thread_holding == this_ethread());
+  ink_assert(cont->stripe->mutex->thread_holding == this_ethread());
   cont->od->writers.remove(cont);
   cont->od->num_writers--;
   if (!cont->od->writers.head) {
@@ -167,10 +167,10 @@ OpenDir::open_read(const CryptoHash *key) const
 int
 OpenDirEntry::wait(CacheVC *cont, int msec)
 {
-  ink_assert(cont->vol->mutex->thread_holding == this_ethread());
+  ink_assert(cont->stripe->mutex->thread_holding == this_ethread());
   cont->f.open_read_timeout = 1;
   ink_assert(!cont->trigger);
-  cont->trigger = cont->vol->mutex->thread_holding->schedule_in_local(cont, HRTIME_MSECONDS(msec));
+  cont->trigger = cont->stripe->mutex->thread_holding->schedule_in_local(cont, HRTIME_MSECONDS(msec));
   readers.push(cont);
   return EVENT_CONT;
 }

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -347,35 +347,35 @@ CacheVC::handleReadDone(int event, Event *e)
   } else if (is_io_in_progress()) {
     return EVENT_CONT;
   }
-  if (DISK_BAD(vol->disk)) {
+  if (DISK_BAD(stripe->disk)) {
     io.aio_result = -1;
-    Error("Canceling cache read: disk %s is bad.", vol->hash_text.get());
+    Error("Canceling cache read: disk %s is bad.", stripe->hash_text.get());
     goto Ldone;
   }
   {
-    MUTEX_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    MUTEX_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
     }
-    if ((!dir_valid(vol, &dir)) || (!io.ok())) {
+    if ((!dir_valid(stripe, &dir)) || (!io.ok())) {
       if (!io.ok()) {
         Dbg(dbg_ctl_cache_disk_error, "Read error on disk %s\n \
 	    read range : [%" PRIu64 " - %" PRIu64 " bytes]  [%" PRIu64 " - %" PRIu64 " blocks] \n",
-            vol->hash_text.get(), (uint64_t)io.aiocb.aio_offset, (uint64_t)io.aiocb.aio_offset + io.aiocb.aio_nbytes,
+            stripe->hash_text.get(), (uint64_t)io.aiocb.aio_offset, (uint64_t)io.aiocb.aio_offset + io.aiocb.aio_nbytes,
             (uint64_t)io.aiocb.aio_offset / 512, (uint64_t)(io.aiocb.aio_offset + io.aiocb.aio_nbytes) / 512);
       }
       goto Ldone;
     }
 
     doc = reinterpret_cast<Doc *>(buf->data());
-    ink_assert(vol->mutex->nthread_holding < 1000);
+    ink_assert(stripe->mutex->nthread_holding < 1000);
     ink_assert(doc->magic == DOC_MAGIC);
 
     if (ts::VersionNumber(doc->v_major, doc->v_minor) > CACHE_DB_VERSION) {
       // future version, count as corrupted
       doc->magic = DOC_CORRUPT;
       Dbg(dbg_ctl_cache_bc, "Object is future version %d:%d - disk %s - doc id = %" PRIx64 ":%" PRIx64 "", doc->v_major,
-          doc->v_minor, vol->hash_text.get(), read_key->slice64(0), read_key->slice64(1));
+          doc->v_minor, stripe->hash_text.get(), read_key->slice64(0), read_key->slice64(1));
       goto Ldone;
     }
 
@@ -413,7 +413,7 @@ CacheVC::handleReadDone(int event, Event *e)
         ink_assert(checksum == doc->checksum);
         if (checksum != doc->checksum) {
           Note("cache: checksum error for [%" PRIu64 " %" PRIu64 "] len %d, hlen %d, disk %s, offset %" PRIu64 " size %zu",
-               doc->first_key.b[0], doc->first_key.b[1], doc->len, doc->hlen, vol->path, (uint64_t)io.aiocb.aio_offset,
+               doc->first_key.b[0], doc->first_key.b[1], doc->len, doc->hlen, stripe->path, (uint64_t)io.aiocb.aio_offset,
                (size_t)io.aiocb.aio_nbytes);
           doc->magic = DOC_CORRUPT;
           okay       = 0;
@@ -442,15 +442,15 @@ CacheVC::handleReadDone(int event, Event *e)
            (doc_len && static_cast<int64_t>(doc_len) < cache_config_ram_cache_cutoff) || !cache_config_ram_cache_cutoff);
         if (cutoff_check && !f.doc_from_ram_cache) {
           uint64_t o = dir_offset(&dir);
-          vol->ram_cache->put(read_key, buf.get(), doc->len, http_copy_hdr, o);
+          stripe->ram_cache->put(read_key, buf.get(), doc->len, http_copy_hdr, o);
         }
         if (!doc_len) {
           // keep a pointer to it. In case the state machine decides to
           // update this document, we don't have to read it back in memory
           // again
-          vol->first_fragment_key    = *read_key;
-          vol->first_fragment_offset = dir_offset(&dir);
-          vol->first_fragment_data   = buf;
+          stripe->first_fragment_key    = *read_key;
+          stripe->first_fragment_offset = dir_offset(&dir);
+          stripe->first_fragment_data   = buf;
         }
       } // end VIO::READ check
       // If it could be compressed, unmarshal after
@@ -473,36 +473,36 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   f.doc_from_ram_cache = false;
 
   // check ram cache
-  ink_assert(vol->mutex->thread_holding == this_ethread());
+  ink_assert(stripe->mutex->thread_holding == this_ethread());
   int64_t o           = dir_offset(&dir);
-  int ram_hit_state   = vol->ram_cache->get(read_key, &buf, static_cast<uint64_t>(o));
+  int ram_hit_state   = stripe->ram_cache->get(read_key, &buf, static_cast<uint64_t>(o));
   f.compressed_in_ram = (ram_hit_state > RAM_HIT_COMPRESS_NONE) ? 1 : 0;
   if (ram_hit_state >= RAM_HIT_COMPRESS_NONE) {
     goto LramHit;
   }
 
   // check if it was read in the last open_read call
-  if (*read_key == vol->first_fragment_key && dir_offset(&dir) == vol->first_fragment_offset) {
-    buf = vol->first_fragment_data;
+  if (*read_key == stripe->first_fragment_key && dir_offset(&dir) == stripe->first_fragment_offset) {
+    buf = stripe->first_fragment_data;
     goto LmemHit;
   }
   // see if its in the aggregation buffer
-  if (dir_agg_buf_valid(vol, &dir)) {
-    int agg_offset = vol->vol_offset(&dir) - vol->header->write_pos;
+  if (dir_agg_buf_valid(stripe, &dir)) {
+    int agg_offset = stripe->vol_offset(&dir) - stripe->header->write_pos;
     buf            = new_IOBufferData(iobuffer_size_to_index(io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-    ink_assert((agg_offset + io.aiocb.aio_nbytes) <= (unsigned)vol->get_agg_buf_pos());
+    ink_assert((agg_offset + io.aiocb.aio_nbytes) <= (unsigned)stripe->get_agg_buf_pos());
     char *doc = buf->data();
-    char *agg = vol->get_agg_buffer() + agg_offset;
+    char *agg = stripe->get_agg_buffer() + agg_offset;
     memcpy(doc, agg, io.aiocb.aio_nbytes);
     io.aio_result = io.aiocb.aio_nbytes;
     SET_HANDLER(&CacheVC::handleReadDone);
     return EVENT_RETURN;
   }
 
-  io.aiocb.aio_fildes = vol->fd;
-  io.aiocb.aio_offset = vol->vol_offset(&dir);
-  if (static_cast<off_t>(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > static_cast<off_t>(vol->skip + vol->len)) {
-    io.aiocb.aio_nbytes = vol->skip + vol->len - io.aiocb.aio_offset;
+  io.aiocb.aio_fildes = stripe->fd;
+  io.aiocb.aio_offset = stripe->vol_offset(&dir);
+  if (static_cast<off_t>(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > static_cast<off_t>(stripe->skip + stripe->len)) {
+    io.aiocb.aio_nbytes = stripe->skip + stripe->len - io.aiocb.aio_offset;
   }
   buf              = new_IOBufferData(iobuffer_size_to_index(io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
   io.aiocb.aio_buf = buf->data();
@@ -514,7 +514,7 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 // ToDo: Why are these for debug only ??
 #if DEBUG
   Metrics::Counter::increment(cache_rsb.pread_count);
-  Metrics::Counter::increment(vol->cache_vol->vol_rsb.pread_count);
+  Metrics::Counter::increment(stripe->cache_vol->vol_rsb.pread_count);
 #endif
 
   return EVENT_CONT;
@@ -541,21 +541,21 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   cancel_trigger();
   set_io_not_in_progress();
   {
-    MUTEX_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    MUTEX_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
     }
     if (_action.cancelled) {
       if (od) {
-        vol->close_write(this);
+        stripe->close_write(this);
         od = nullptr;
       }
       goto Lfree;
     }
     if (!f.remove_aborted_writers) {
-      if (vol->open_write(this, true, 1)) {
+      if (stripe->open_write(this, true, 1)) {
         // writer  exists
-        od = vol->open_read(&key);
+        od = stripe->open_read(&key);
         ink_release_assert(od);
         od->dont_update_directory = true;
         od                        = nullptr;
@@ -569,7 +569,7 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     if (!buf) {
       goto Lcollision;
     }
-    if (!dir_valid(vol, &dir)) {
+    if (!dir_valid(stripe, &dir)) {
       last_collision = nullptr;
       goto Lcollision;
     }
@@ -583,9 +583,9 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       /* should be first_key not key..right?? */
       if (doc->first_key == key) {
         ink_assert(doc->magic == DOC_MAGIC);
-        if (dir_delete(&key, vol, &dir) > 0) {
+        if (dir_delete(&key, stripe, &dir) > 0) {
           if (od) {
-            vol->close_write(this);
+            stripe->close_write(this);
           }
           od = nullptr;
           goto Lremoved;
@@ -595,7 +595,7 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
   Lcollision:
     // check for collision
-    if (dir_probe(&key, vol, &dir, &last_collision) > 0) {
+    if (dir_probe(&key, stripe, &dir, &last_collision) > 0) {
       int ret = do_read_call(&key);
       if (ret == EVENT_RETURN) {
         goto Lread;
@@ -604,12 +604,12 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
   Ldone:
     Metrics::Counter::increment(cache_rsb.status[static_cast<int>(CacheOpType::Remove)].failure);
-    Metrics::Counter::increment(vol->cache_vol->vol_rsb.status[static_cast<int>(CacheOpType::Remove)].failure);
+    Metrics::Counter::increment(stripe->cache_vol->vol_rsb.status[static_cast<int>(CacheOpType::Remove)].failure);
     if (od) {
-      vol->close_write(this);
+      stripe->close_write(this);
     }
   }
-  ink_assert(!vol || this_ethread() != vol->mutex->thread_holding);
+  ink_assert(!stripe || this_ethread() != stripe->mutex->thread_holding);
   _action.continuation->handleEvent(CACHE_EVENT_REMOVE_FAILED, (void *)-ECACHE_NO_DOC);
   goto Lfree;
 Lremoved:
@@ -619,9 +619,9 @@ Lfree:
 }
 
 int
-CacheVC::scanVol(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
+CacheVC::scanStripe(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
-  Dbg(dbg_ctl_cache_scan_truss, "inside %p:scanVol", this);
+  Dbg(dbg_ctl_cache_scan_truss, "%p", this);
   if (_action.cancelled) {
     return free_CacheVC(this);
   }
@@ -637,15 +637,15 @@ CacheVC::scanVol(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
   }
 
-  if (!vol) {
+  if (!stripe) {
     if (!rec->num_vols) {
       goto Ldone;
     }
-    vol = rec->stripes[0];
+    stripe = rec->stripes[0];
   } else {
     for (int i = 0; i < rec->num_vols - 1; i++) {
-      if (vol == rec->stripes[i]) {
-        vol = rec->stripes[i + 1];
+      if (stripe == rec->stripes[i]) {
+        stripe = rec->stripes[i + 1];
         goto Lcont;
       }
     }
@@ -680,7 +680,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     return free_CacheVC(this);
   }
 
-  CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+  CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
   if (!lock.is_locked()) {
     Dbg(dbg_ctl_cache_scan_truss, "delay %p:scanObject", this);
     mutex->thread_holding->schedule_in_local(this, HRTIME_MSECONDS(cache_config_mutex_retry_delay));
@@ -689,9 +689,9 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
   if (!fragment) { // initialize for first read
     fragment            = 1;
-    scan_vol_map        = make_vol_map(vol);
-    io.aiocb.aio_offset = next_in_map(vol, scan_vol_map, vol->vol_offset_to_offset(0));
-    if (io.aiocb.aio_offset >= static_cast<off_t>(vol->skip + vol->len)) {
+    scan_stripe_map     = make_vol_map(stripe);
+    io.aiocb.aio_offset = next_in_map(stripe, scan_stripe_map, stripe->vol_offset_to_offset(0));
+    if (io.aiocb.aio_offset >= static_cast<off_t>(stripe->skip + stripe->len)) {
       goto Lnext_vol;
     }
     io.aiocb.aio_nbytes = SCAN_BUF_SIZE;
@@ -721,7 +721,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
          static_cast<off_t>(io.aiocb.aio_nbytes)) {
     might_need_overlap_read = false;
     doc                     = reinterpret_cast<Doc *>(reinterpret_cast<char *>(doc) + next_object_len);
-    next_object_len         = vol->round_to_approx_size(doc->len);
+    next_object_len         = stripe->round_to_approx_size(doc->len);
     int i;
     bool changed;
 
@@ -737,11 +737,11 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 
     last_collision = nullptr;
     while (true) {
-      if (!dir_probe(&doc->first_key, vol, &dir, &last_collision)) {
+      if (!dir_probe(&doc->first_key, stripe, &dir, &last_collision)) {
         goto Lskip;
       }
-      if (!dir_agg_valid(vol, &dir) || !dir_head(&dir) ||
-          (vol->vol_offset(&dir) != io.aiocb.aio_offset + (reinterpret_cast<char *>(doc) - buf->data()))) {
+      if (!dir_agg_valid(stripe, &dir) || !dir_head(&dir) ||
+          (stripe->vol_offset(&dir) != io.aiocb.aio_offset + (reinterpret_cast<char *>(doc) - buf->data()))) {
         continue;
       }
       break;
@@ -783,7 +783,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       // verify that the earliest block exists, reducing 'false hit' callbacks
       if (!(key == doc->key)) {
         last_collision = nullptr;
-        if (!dir_probe(&key, vol, &earliest_dir, &last_collision)) {
+        if (!dir_probe(&key, stripe, &earliest_dir, &last_collision)) {
           continue;
         }
       }
@@ -860,24 +860,24 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   } else { // Normal case, where we ended on a object boundary.
     io.aiocb.aio_offset += (reinterpret_cast<char *>(doc) - buf->data()) + next_object_len;
     Dbg(dbg_ctl_cache_scan_truss, "next %p:scanObject %" PRId64, this, (int64_t)io.aiocb.aio_offset);
-    io.aiocb.aio_offset = next_in_map(vol, scan_vol_map, io.aiocb.aio_offset);
+    io.aiocb.aio_offset = next_in_map(stripe, scan_stripe_map, io.aiocb.aio_offset);
     Dbg(dbg_ctl_cache_scan_truss, "next_in_map %p:scanObject %" PRId64, this, (int64_t)io.aiocb.aio_offset);
     io.aiocb.aio_nbytes    = SCAN_BUF_SIZE;
     io.aiocb.aio_buf       = buf->data();
     scan_fix_buffer_offset = 0;
   }
 
-  if (io.aiocb.aio_offset >= vol->skip + vol->len) {
+  if (io.aiocb.aio_offset >= stripe->skip + stripe->len) {
   Lnext_vol:
-    SET_HANDLER(&CacheVC::scanVol);
+    SET_HANDLER(&CacheVC::scanStripe);
     eventProcessor.schedule_in(this, HRTIME_MSECONDS(scan_msec_delay));
     return EVENT_CONT;
   }
 
 Lread:
-  io.aiocb.aio_fildes = vol->fd;
-  if (static_cast<off_t>(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > static_cast<off_t>(vol->skip + vol->len)) {
-    io.aiocb.aio_nbytes = vol->skip + vol->len - io.aiocb.aio_offset;
+  io.aiocb.aio_fildes = stripe->fd;
+  if (static_cast<off_t>(io.aiocb.aio_offset + io.aiocb.aio_nbytes) > static_cast<off_t>(stripe->skip + stripe->len)) {
+    io.aiocb.aio_nbytes = stripe->skip + stripe->len - io.aiocb.aio_offset;
   }
   offset = 0;
   ink_assert(ink_aio_read(&io) >= 0);
@@ -922,14 +922,14 @@ CacheVC::scanOpenWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   }
   int ret = 0;
   {
-    CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
-      Dbg(dbg_ctl_cache_scan, "vol->mutex %p:scanOpenWrite", this);
+      Dbg(dbg_ctl_cache_scan, "stripe->mutex %p:scanOpenWrite", this);
       VC_SCHED_LOCK_RETRY();
     }
 
     Dbg(dbg_ctl_cache_scan, "trying for writer lock");
-    if (vol->open_write(this, false, 1)) {
+    if (stripe->open_write(this, false, 1)) {
       writer_lock_retry++;
       SET_HANDLER(&CacheVC::scanOpenWrite);
       mutex->thread_holding->schedule_in_local(this, scan_msec_delay);
@@ -950,7 +950,7 @@ CacheVC::scanOpenWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     Dir *l = nullptr;
     Dir d;
     Doc *doc = reinterpret_cast<Doc *>(buf->data() + offset);
-    offset   = reinterpret_cast<char *>(doc) - buf->data() + vol->round_to_approx_size(doc->len);
+    offset   = reinterpret_cast<char *>(doc) - buf->data() + stripe->round_to_approx_size(doc->len);
     // if the doc contains some data, then we need to create
     // a new directory entry for this fragment. Remember the
     // offset and the key in earliest_key
@@ -963,8 +963,8 @@ CacheVC::scanOpenWrite(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
 
     while (true) {
-      if (!dir_probe(&first_key, vol, &d, &l)) {
-        vol->close_write(this);
+      if (!dir_probe(&first_key, stripe, &d, &l)) {
+        stripe->close_write(this);
         _action.continuation->handleEvent(CACHE_EVENT_SCAN_OPERATION_FAILED, nullptr);
         SET_HANDLER(&CacheVC::scanObject);
         return handleEvent(EVENT_IMMEDIATE, nullptr);
@@ -997,16 +997,16 @@ CacheVC::scanUpdateDone(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   Dbg(dbg_ctl_cache_scan_truss, "inside %p:scanUpdateDone", this);
   cancel_trigger();
   // get volume lock
-  CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+  CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
   if (lock.is_locked()) {
     // insert a directory entry for the previous fragment
-    dir_overwrite(&first_key, vol, &dir, &od->first_dir, false);
+    dir_overwrite(&first_key, stripe, &dir, &od->first_dir, false);
     if (od->move_resident_alt) {
-      dir_insert(&od->single_doc_key, vol, &od->single_doc_dir);
+      dir_insert(&od->single_doc_key, stripe, &od->single_doc_dir);
     }
-    ink_assert(vol->open_read(&first_key));
+    ink_assert(stripe->open_read(&first_key));
     ink_assert(this->od);
-    vol->close_write(this);
+    stripe->close_write(this);
     SET_HANDLER(&CacheVC::scanObject);
     return handleEvent(EVENT_IMMEDIATE, nullptr);
   } else {

--- a/src/iocore/cache/CacheVol.cc
+++ b/src/iocore/cache/CacheVol.cc
@@ -41,7 +41,7 @@ Cache::scan(Continuation *cont, const char *hostname, int host_len, int KB_per_s
   }
 
   CacheVC *c = new_CacheVC(cont);
-  c->vol     = nullptr;
+  c->stripe  = nullptr;
   /* do we need to make a copy */
   c->hostname        = const_cast<char *>(hostname);
   c->host_len        = host_len;
@@ -49,7 +49,7 @@ Cache::scan(Continuation *cont, const char *hostname, int host_len, int KB_per_s
   c->buf             = new_IOBufferData(BUFFER_SIZE_FOR_XMALLOC(SCAN_BUF_SIZE), MEMALIGNED);
   c->scan_msec_delay = (SCAN_BUF_SIZE / KB_per_second);
   c->offset          = 0;
-  SET_CONTINUATION_HANDLER(c, &CacheVC::scanVol);
+  SET_CONTINUATION_HANDLER(c, &CacheVC::scanStripe);
   eventProcessor.schedule_in(c, HRTIME_MSECONDS(c->scan_msec_delay));
   cont->handleEvent(CACHE_EVENT_SCAN, c);
   return &c->_action;

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -83,7 +83,7 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   }
   int ret = 0;
   {
-    CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked() || od->writing_vec) {
       VC_SCHED_LOCK_RETRY();
     }
@@ -101,7 +101,7 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
           write_vector->remove(alternate_index, true);
           alternate_index = CACHE_ALT_REMOVED;
           if (!write_vector->count()) {
-            dir_delete(&first_key, vol, &od->first_dir);
+            dir_delete(&first_key, stripe, &od->first_dir);
           }
         }
         // the alternate is not there any more. somebody might have
@@ -247,10 +247,10 @@ CacheVC::handleWrite(int event, Event * /* e ATS_UNUSED */)
 
   set_agg_write_in_progress();
   POP_HANDLER;
-  agg_len = vol->round_to_approx_size(write_len + header_len + frag_len + sizeof(Doc));
-  vol->add_agg_todo(agg_len);
+  agg_len = stripe->round_to_approx_size(write_len + header_len + frag_len + sizeof(Doc));
+  stripe->add_agg_todo(agg_len);
   bool agg_error = (agg_len > AGG_SIZE || header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
-                    (!f.readers && (vol->get_agg_todo_size() > cache_config_agg_write_backlog + AGG_SIZE) && write_len));
+                    (!f.readers && (stripe->get_agg_todo_size() > cache_config_agg_write_backlog + AGG_SIZE) && write_len));
 #ifdef CACHE_AGG_FAIL_RATE
   agg_error = agg_error || ((uint32_t)mutex->thread_holding->generator.random() < (uint32_t)(UINT_MAX * CACHE_AGG_FAIL_RATE));
 #endif
@@ -259,10 +259,10 @@ CacheVC::handleWrite(int event, Event * /* e ATS_UNUSED */)
 
   if (agg_error || max_doc_error) {
     Metrics::Counter::increment(cache_rsb.write_backlog_failure);
-    Metrics::Counter::increment(vol->cache_vol->vol_rsb.write_backlog_failure);
+    Metrics::Counter::increment(stripe->cache_vol->vol_rsb.write_backlog_failure);
     Metrics::Counter::increment(cache_rsb.status[op_type].failure);
-    Metrics::Counter::increment(vol->cache_vol->vol_rsb.status[op_type].failure);
-    vol->add_agg_todo(-agg_len);
+    Metrics::Counter::increment(stripe->cache_vol->vol_rsb.status[op_type].failure);
+    stripe->add_agg_todo(-agg_len);
     io.aio_result = AIO_SOFT_FAILURE;
     if (event == EVENT_CALL) {
       return EVENT_RETURN;
@@ -271,12 +271,12 @@ CacheVC::handleWrite(int event, Event * /* e ATS_UNUSED */)
   }
   ink_assert(agg_len <= AGG_SIZE);
   if (f.evac_vector) {
-    vol->get_pending_writers().push(this);
+    stripe->get_pending_writers().push(this);
   } else {
-    vol->get_pending_writers().enqueue(this);
+    stripe->get_pending_writers().enqueue(this);
   }
-  if (!vol->is_io_in_progress()) {
-    return vol->aggWrite(event, this);
+  if (!stripe->is_io_in_progress()) {
+    return stripe->aggWrite(event, this);
   }
   return EVENT_CONT;
 }
@@ -445,7 +445,7 @@ new_DocEvacuator(int nbytes, Stripe *stripe)
   Metrics::Gauge::increment(cache_rsb.status[c->op_type].active);
   Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.status[c->op_type].active);
   c->buf         = new_IOBufferData(iobuffer_size_to_index(nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-  c->vol         = stripe;
+  c->stripe      = stripe;
   c->f.evacuator = 1;
   c->earliest_key.clear();
   SET_CONTINUATION_HANDLER(c, &CacheEvacuateDocVC::evacuateDocDone);
@@ -649,7 +649,7 @@ Stripe::evac_range(off_t low, off_t high, int evac_phase)
 static int
 agg_copy(char *p, CacheVC *vc)
 {
-  Stripe *stripe = vc->vol;
+  Stripe *stripe = vc->stripe;
   off_t o        = stripe->header->write_pos + stripe->get_agg_buf_pos();
 
   if (!vc->f.evacuator) {
@@ -740,7 +740,7 @@ agg_copy(char *p, CacheVC *vc)
     // move data
     if (vc->write_len) {
       {
-        ProxyMutex *mutex ATS_UNUSED = vc->vol->mutex.get();
+        ProxyMutex *mutex ATS_UNUSED = vc->stripe->mutex.get();
         ink_assert(mutex->thread_holding == this_ethread());
 
 // ToDo: Why are these for debug only ?
@@ -784,21 +784,21 @@ agg_copy(char *p, CacheVC *vc)
   } else {
     // for evacuated documents, copy the data, and update directory
     Doc *doc = reinterpret_cast<Doc *>(vc->buf->data());
-    int l    = vc->vol->round_to_approx_size(doc->len);
+    int l    = vc->stripe->round_to_approx_size(doc->len);
 
 #ifdef DEBUG
     Metrics::Counter::increment(cache_rsb.gc_frags_evacuated);
     Metrics::Counter::increment(stripe->cache_vol->vol_rsb.gc_frags_evacuated);
 #endif
 
-    doc->sync_serial  = vc->vol->header->sync_serial;
-    doc->write_serial = vc->vol->header->write_serial;
+    doc->sync_serial  = vc->stripe->header->sync_serial;
+    doc->write_serial = vc->stripe->header->write_serial;
 
     memcpy(p, doc, doc->len);
 
     vc->dir = vc->overwrite_dir;
-    dir_set_offset(&vc->dir, vc->vol->offset_to_vol_offset(o));
-    dir_set_phase(&vc->dir, vc->vol->header->phase);
+    dir_set_offset(&vc->dir, vc->stripe->offset_to_vol_offset(o));
+    dir_set_phase(&vc->dir, vc->stripe->header->phase);
     return l;
   }
 }
@@ -1024,15 +1024,15 @@ CacheVC::openWriteCloseDir(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED *
 {
   cancel_trigger();
   {
-    CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       SET_HANDLER(&CacheVC::openWriteCloseDir);
       ink_assert(!is_io_in_progress());
       VC_SCHED_LOCK_RETRY();
     }
-    vol->close_write(this);
+    stripe->close_write(this);
     if (closed < 0 && fragment) {
-      dir_delete(&earliest_key, vol, &earliest_dir);
+      dir_delete(&earliest_key, stripe, &earliest_dir);
     }
   }
   if (dbg_ctl_cache_update.on()) {
@@ -1059,11 +1059,11 @@ CacheVC::openWriteCloseDir(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED *
     DDbg(dbg_ctl_cache_stats, "Fragment = %d", fragment);
 
     Metrics::Counter::increment(cache_rsb.fragment_document_count[std::clamp(fragment, 0, 2)]);
-    Metrics::Counter::increment(vol->cache_vol->vol_rsb.fragment_document_count[std::clamp(fragment, 0, 2)]);
+    Metrics::Counter::increment(stripe->cache_vol->vol_rsb.fragment_document_count[std::clamp(fragment, 0, 2)]);
   }
   if (f.close_complete) {
     recursive++;
-    ink_assert(!vol || this_ethread() != vol->mutex->thread_holding);
+    ink_assert(!stripe || this_ethread() != stripe->mutex->thread_holding);
     vio.cont->handleEvent(VC_EVENT_WRITE_COMPLETE, (void *)&vio);
     recursive--;
   }
@@ -1079,7 +1079,7 @@ CacheVC::openWriteCloseHeadDone(int event, Event *e)
     return EVENT_CONT;
   }
   {
-    CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       VC_LOCK_RETRY_EVENT();
     }
@@ -1090,14 +1090,14 @@ CacheVC::openWriteCloseHeadDone(int event, Event *e)
     ink_assert(f.use_first_key);
     if (!od->dont_update_directory) {
       if (dir_is_empty(&od->first_dir)) {
-        dir_insert(&first_key, vol, &dir);
+        dir_insert(&first_key, stripe, &dir);
       } else {
         // multiple fragment vector write
-        dir_overwrite(&first_key, vol, &dir, &od->first_dir, false);
+        dir_overwrite(&first_key, stripe, &dir, &od->first_dir, false);
         // insert moved resident alternate
         if (od->move_resident_alt) {
-          if (dir_valid(vol, &od->single_doc_dir)) {
-            dir_insert(&od->single_doc_key, vol, &od->single_doc_dir);
+          if (dir_valid(stripe, &od->single_doc_dir)) {
+            dir_insert(&od->single_doc_key, stripe, &od->single_doc_dir);
           }
           od->move_resident_alt = false;
         }
@@ -1158,7 +1158,7 @@ CacheVC::openWriteCloseDataDone(int event, Event *e)
     return openWriteCloseDir(event, e);
   }
   {
-    CACHE_TRY_LOCK(lock, vol->mutex, this_ethread());
+    CACHE_TRY_LOCK(lock, stripe->mutex, this_ethread());
     if (!lock.is_locked()) {
       VC_LOCK_RETRY_EVENT();
     }
@@ -1174,7 +1174,7 @@ CacheVC::openWriteCloseDataDone(int event, Event *e)
     }
     fragment++;
     write_pos += write_len;
-    dir_insert(&key, vol, &dir);
+    dir_insert(&key, stripe, &dir);
     blocks = iobufferblock_skip(blocks.get(), &offset, &length, write_len);
     next_CacheKey(&key, &key);
     if (length) {
@@ -1252,7 +1252,7 @@ CacheVC::openWriteWriteDone(int event, Event *e)
     return calluser(VC_EVENT_ERROR);
   }
   {
-    CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       VC_LOCK_RETRY_EVENT();
     }
@@ -1270,7 +1270,7 @@ CacheVC::openWriteWriteDone(int event, Event *e)
     }
     ++fragment;
     write_pos += write_len;
-    dir_insert(&key, vol, &dir);
+    dir_insert(&key, stripe, &dir);
     DDbg(dbg_ctl_cache_insert, "WriteDone: %X, %X, %d", key.slice32(0), first_key.slice32(0), write_len);
     blocks = iobufferblock_skip(blocks.get(), &offset, &length, write_len);
     next_CacheKey(&key, &key);
@@ -1393,11 +1393,11 @@ CacheVC::openWriteOverwrite(int event, Event *e)
     goto Ldone;
   }
 Lcollision: {
-  CACHE_TRY_LOCK(lock, vol->mutex, this_ethread());
+  CACHE_TRY_LOCK(lock, stripe->mutex, this_ethread());
   if (!lock.is_locked()) {
     VC_LOCK_RETRY_EVENT();
   }
-  int res = dir_probe(&first_key, vol, &dir, &last_collision);
+  int res = dir_probe(&first_key, stripe, &dir, &last_collision);
   if (res > 0) {
     if ((res = do_read_call(&first_key)) == EVENT_RETURN) {
       goto Lcallreturn;
@@ -1426,7 +1426,7 @@ CacheVC::openWriteStartDone(int event, Event *e)
     set_io_not_in_progress();
   }
   {
-    CACHE_TRY_LOCK(lock, vol->mutex, mutex->thread_holding);
+    CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked()) {
       VC_LOCK_RETRY_EVENT();
     }
@@ -1447,9 +1447,9 @@ CacheVC::openWriteStartDone(int event, Event *e)
          We need to start afresh from the beginning by setting last_collision
          to nullptr.
        */
-      if (!dir_valid(vol, &dir)) {
+      if (!dir_valid(stripe, &dir)) {
         DDbg(dbg_ctl_cache_write, "OpenReadStartDone: Dir not valid: Write Head: %" PRId64 ", Dir: %" PRId64,
-             (int64_t)vol->offset_to_vol_offset(vol->header->write_pos), dir_offset(&dir));
+             (int64_t)stripe->offset_to_vol_offset(stripe->header->write_pos), dir_offset(&dir));
         last_collision = nullptr;
         goto Lcollision;
       }
@@ -1478,7 +1478,7 @@ CacheVC::openWriteStartDone(int event, Event *e)
   Lcollision:
     int if_writers = ((uintptr_t)info == CACHE_ALLOW_MULTIPLE_WRITES);
     if (!od) {
-      if ((err = vol->open_write(this, if_writers, cache_config_http_max_alts > 1 ? cache_config_http_max_alts : 0)) > 0) {
+      if ((err = stripe->open_write(this, if_writers, cache_config_http_max_alts > 1 ? cache_config_http_max_alts : 0)) > 0) {
         goto Lfailure;
       }
       if (od->has_multiple_writers()) {
@@ -1488,7 +1488,7 @@ CacheVC::openWriteStartDone(int event, Event *e)
       }
     }
     // check for collision
-    if (dir_probe(&first_key, vol, &dir, &last_collision)) {
+    if (dir_probe(&first_key, stripe, &dir, &last_collision)) {
       od->reading_vec = true;
       int ret         = do_read_call(&first_key);
       if (ret == EVENT_RETURN) {
@@ -1511,7 +1511,7 @@ Lsuccess:
 
 Lfailure:
   Metrics::Counter::increment(cache_rsb.status[op_type].failure);
-  Metrics::Counter::increment(vol->cache_vol->vol_rsb.status[op_type].failure);
+  Metrics::Counter::increment(stripe->cache_vol->vol_rsb.status[op_type].failure);
   _action.continuation->handleEvent(CACHE_EVENT_OPEN_WRITE_FAILED, (void *)-err);
 Lcancel:
   if (od) {
@@ -1533,9 +1533,9 @@ CacheVC::openWriteStartBegin(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED
   if (_action.cancelled) {
     return free_CacheVC(this);
   }
-  if (((err = vol->open_write_lock(this, false, 1)) > 0)) {
+  if (((err = stripe->open_write_lock(this, false, 1)) > 0)) {
     Metrics::Counter::increment(cache_rsb.status[op_type].failure);
-    Metrics::Counter::increment(vol->cache_vol->vol_rsb.status[op_type].failure);
+    Metrics::Counter::increment(stripe->cache_vol->vol_rsb.status[op_type].failure);
     free_CacheVC(this);
     _action.continuation->handleEvent(CACHE_EVENT_OPEN_WRITE_FAILED, (void *)-err);
     return EVENT_DONE;
@@ -1570,8 +1570,8 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   SCOPED_MUTEX_LOCK(lock, c->mutex, this_ethread());
   c->vio.op      = VIO::WRITE;
   c->op_type     = static_cast<int>(CacheOpType::Write);
-  c->vol         = key_to_vol(key, hostname, host_len);
-  Stripe *stripe = c->vol;
+  c->stripe      = key_to_vol(key, hostname, host_len);
+  Stripe *stripe = c->stripe;
   Metrics::Gauge::increment(cache_rsb.status[c->op_type].active);
   Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.status[c->op_type].active);
   c->first_key = c->key = *key;
@@ -1594,7 +1594,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   // coverity[Y2K38_SAFETY:FALSE]
   c->pin_in_cache = static_cast<uint32_t>(apin_in_cache);
 
-  if ((res = c->vol->open_write_lock(c, false, 1)) > 0) {
+  if ((res = c->stripe->open_write_lock(c, false, 1)) > 0) {
     // document currently being written, abort
     Metrics::Counter::increment(cache_rsb.status[c->op_type].failure);
     Metrics::Counter::increment(stripe->cache_vol->vol_rsb.status[c->op_type].failure);
@@ -1649,8 +1649,8 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
   } while (DIR_MASK_TAG(c->key.slice32(2)) == DIR_MASK_TAG(c->first_key.slice32(2)));
   c->earliest_key = c->key;
   c->frag_type    = CACHE_FRAG_TYPE_HTTP;
-  c->vol          = key_to_vol(key, hostname, host_len);
-  Stripe *stripe  = c->vol;
+  c->stripe       = key_to_vol(key, hostname, host_len);
+  Stripe *stripe  = c->stripe;
   c->info         = info;
   if (c->info && (uintptr_t)info != CACHE_ALLOW_MULTIPLE_WRITES) {
     /*
@@ -1697,9 +1697,9 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
   c->pin_in_cache = static_cast<uint32_t>(apin_in_cache);
 
   {
-    CACHE_TRY_LOCK(lock, c->vol->mutex, cont->mutex->thread_holding);
+    CACHE_TRY_LOCK(lock, c->stripe->mutex, cont->mutex->thread_holding);
     if (lock.is_locked()) {
-      if ((err = c->vol->open_write(c, if_writers, cache_config_http_max_alts > 1 ? cache_config_http_max_alts : 0)) > 0) {
+      if ((err = c->stripe->open_write(c, if_writers, cache_config_http_max_alts > 1 ? cache_config_http_max_alts : 0)) > 0) {
         goto Lfailure;
       }
       // If there are multiple writers, then this one cannot be an update.
@@ -1708,7 +1708,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
       if (c->od->has_multiple_writers()) {
         goto Lmiss;
       }
-      if (!dir_probe(key, c->vol, &c->dir, &c->last_collision)) {
+      if (!dir_probe(key, c->stripe, &c->dir, &c->last_collision)) {
         if (c->f.update) {
           // fail update because vector has been GC'd
           // This situation can also arise in openWriteStartDone

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_L.cc
@@ -223,10 +223,10 @@ public:
   {
     CacheKey key        = {};
     Dir *last_collision = nullptr;
-    SCOPED_MUTEX_LOCK(lock, vc->vol->mutex, this->mutex->thread_holding);
+    SCOPED_MUTEX_LOCK(lock, vc->stripe->mutex, this->mutex->thread_holding);
     vc->vector.data[0].alternate.object_key_get(&key);
-    REQUIRE(dir_probe(&key, vc->vol, &dir, &last_collision) != 0);
-    REQUIRE(dir_delete(&key, vc->vol, &dir));
+    REQUIRE(dir_probe(&key, vc->stripe, &dir, &last_collision) != 0);
+    REQUIRE(dir_delete(&key, vc->stripe, &dir));
   }
 };
 

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_S.cc
@@ -224,10 +224,10 @@ public:
   {
     CacheKey key        = {};
     Dir *last_collision = nullptr;
-    SCOPED_MUTEX_LOCK(lock, vc->vol->mutex, this->mutex->thread_holding);
+    SCOPED_MUTEX_LOCK(lock, vc->stripe->mutex, this->mutex->thread_holding);
     vc->vector.data[1].alternate.object_key_get(&key);
-    REQUIRE(dir_probe(&key, vc->vol, &dir, &last_collision) != 0);
-    REQUIRE(dir_delete(&key, vc->vol, &dir));
+    REQUIRE(dir_probe(&key, vc->stripe, &dir, &last_collision) != 0);
+    REQUIRE(dir_delete(&key, vc->stripe, &dir));
   }
 };
 

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_L.cc
@@ -227,10 +227,10 @@ public:
   {
     CacheKey key        = {};
     Dir *last_collision = nullptr;
-    SCOPED_MUTEX_LOCK(lock, vc->vol->mutex, this->mutex->thread_holding);
+    SCOPED_MUTEX_LOCK(lock, vc->stripe->mutex, this->mutex->thread_holding);
     vc->vector.data[1].alternate.object_key_get(&key);
-    REQUIRE(dir_probe(&key, vc->vol, &dir, &last_collision) != 0);
-    REQUIRE(dir_delete(&key, vc->vol, &dir));
+    REQUIRE(dir_probe(&key, vc->stripe, &dir, &last_collision) != 0);
+    REQUIRE(dir_delete(&key, vc->stripe, &dir));
   }
 };
 

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_S.cc
@@ -225,10 +225,10 @@ public:
   {
     CacheKey key        = {};
     Dir *last_collision = nullptr;
-    SCOPED_MUTEX_LOCK(lock, vc->vol->mutex, this->mutex->thread_holding);
+    SCOPED_MUTEX_LOCK(lock, vc->stripe->mutex, this->mutex->thread_holding);
     vc->vector.data[0].alternate.object_key_get(&key);
-    REQUIRE(dir_probe(&key, vc->vol, &dir, &last_collision) != 0);
-    REQUIRE(dir_delete(&key, vc->vol, &dir));
+    REQUIRE(dir_probe(&key, vc->stripe, &dir, &last_collision) != 0);
+    REQUIRE(dir_delete(&key, vc->stripe, &dir));
   }
 };
 


### PR DESCRIPTION
Part of #10628. 

Main changes are renaming members of CacheVC.

```
Stripe *vol;
int scanVol(int event, Event *e);
char *scan_vol_map;
```

to

```
Stripe *stripe;
int scanStripe(int event, Event *e);
char *scan_stripe_map;
```