### PR TITLE
min_keep_alive_conns -> _min_keep_alive_conns;

### DIFF
--- a/include/iocore/net/ConnectionTracker.h
+++ b/include/iocore/net/ConnectionTracker.h
@@ -107,12 +107,12 @@ public:
       MatchType const &_match_type; ///< Type of matching.
     };
 
-    IpEndpoint _addr;         ///< Remote IP address.
-    CryptoHash _hash;         ///< Hash of the FQDN.
-    MatchType _match_type;    ///< Type of matching.
-    std::string _fqdn;        ///< Expanded FQDN, set if matching on FQDN.
-    int min_keep_alive_conns; /// < Min keep alive conns on this server group
-    Key _key;                 ///< Pre-assembled key which references the following members.
+    IpEndpoint _addr;          ///< Remote IP address.
+    CryptoHash _hash;          ///< Hash of the FQDN.
+    MatchType _match_type;     ///< Type of matching.
+    std::string _fqdn;         ///< Expanded FQDN, set if matching on FQDN.
+    int _min_keep_alive_conns; /// < Min keep alive conns on this server group
+    Key _key;                  ///< Pre-assembled key which references the following members.
 
     // Counting data.
     std::atomic<int> _count{0};         ///< Number of outbound connections.
@@ -285,7 +285,7 @@ ConnectionTracker::instance()
 }
 
 inline ConnectionTracker::Group::Group(Key const &key, std::string_view fqdn, int min_keep_alive)
-  : _hash(key._hash), _match_type(key._match_type), min_keep_alive_conns(min_keep_alive), _key{_addr, _hash, _match_type}
+  : _hash(key._hash), _match_type(key._match_type), _min_keep_alive_conns(min_keep_alive), _key{_addr, _hash, _match_type}
 {
   // store the host name if relevant.
   if (MATCH_HOST == _match_type || MATCH_BOTH == _match_type) {

--- a/src/proxy/http/HttpSessionManager.cc
+++ b/src/proxy/http/HttpSessionManager.cc
@@ -264,8 +264,8 @@ ServerSessionPool::eventHandler(int event, void *data)
       // origin, then reset the timeouts on our end and do not close the connection
       if ((event == VC_EVENT_INACTIVITY_TIMEOUT || event == VC_EVENT_ACTIVE_TIMEOUT) && s->state == PoolableSession::KA_POOLED &&
           s->conn_track_group) {
-        Debug("http_ss", "s->conn_track_group->min_keep_alive_conns : %d", s->conn_track_group->min_keep_alive_conns);
-        bool connection_count_below_min = s->conn_track_group->_count <= s->conn_track_group->min_keep_alive_conns;
+        Debug("http_ss", "s->conn_track_group->min_keep_alive_conns : %d", s->conn_track_group->_min_keep_alive_conns);
+        bool connection_count_below_min = s->conn_track_group->_count <= s->conn_track_group->_min_keep_alive_conns;
 
         if (connection_count_below_min) {
           Debug("http_ss",


### PR DESCRIPTION
This makes the naming of the Group members consistent by giving prefacing min_keep_alive_conns with an underscore.