### PR TITLE
ConectionTracker: remove include dep in proxy/http

### DIFF
--- a/include/iocore/net/ConnectionTracker.h
+++ b/include/iocore/net/ConnectionTracker.h
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <tuple>
 #include <mutex>
+#include "records/RecCore.h"
 #include "tscore/ink_platform.h"
 #include "tscore/ink_config.h"
 #include "tscore/ink_mutex.h"
@@ -221,8 +222,9 @@ public:
    *
    * @param config The storage for the global configuration data.
    * @param txn The storage for the default per transaction data.
+   * @param config_cb The callback to invoke when a configuration is updated.
    */
-  static void config_init(GlobalConfig *global, TxnConfig *txn);
+  static void config_init(GlobalConfig *global, TxnConfig *txn, RecConfigUpdateCb const &config_cb);
 
   /// Tag used for debugging output.
   static constexpr char const *const DEBUG_TAG{"conn_track"};

--- a/include/records/RecCore.h
+++ b/include/records/RecCore.h
@@ -121,7 +121,32 @@ RecErrT RecLinkConfigCounter(const char *name, RecCounter *rec_counter);
 RecErrT RecLinkConfigString(const char *name, RecString *rec_string);
 RecErrT RecLinkConfigByte(const char *name, RecByte *rec_byte);
 
-RecErrT RecRegisterConfigUpdateCb(const char *name, RecConfigUpdateCb update_cb, void *cookie);
+RecErrT RecRegisterConfigUpdateCb(const char *name, RecConfigUpdateCb const &update_cb, void *cookie);
+
+/** Enable a dynamic configuration variable.
+ *
+ * @param name Configuration var name.
+ * @param record_cb Callback to do the actual update of the master record.
+ * @param config_cb Callback to invoke when the configuration variable is updated.
+ * @param cookie Extra data for @a cb
+ *
+ * The purpose of this is to unite the different ways and times a configuration variable needs
+ * to be loaded. These are
+ * - Process start.
+ * - Dynamic update.
+ * - Plugin API update.
+ *
+ * @a record_cb is expected to perform the update. It must return a @c bool which is
+ * - @c true if the value was changed.
+ * - @c false if the value was not changed.
+ *
+ * Based on that, a run time configuration update is triggered or not.
+ *
+ * In addition, this invokes @a record_cb and passes it the information in the configuration variable
+ * global table in order to perform the initial loading of the value. No update is triggered for
+ * that call as it is not needed.
+ */
+void Enable_Config_Var(std::string_view const &name, RecContextCb record_cb, RecConfigUpdateCb const &config_cb, void *cookie);
 
 //-------------------------------------------------------------------------
 // Record Reading/Writing

--- a/include/records/RecDefs.h
+++ b/include/records/RecDefs.h
@@ -27,6 +27,8 @@
 #include "tscore/ink_rwlock.h"
 #include "records/RecMutex.h"
 
+#include <functional>
+
 //-------------------------------------------------------------------------
 // Error Values
 //-------------------------------------------------------------------------
@@ -179,6 +181,8 @@ struct RecRawStatBlock {
 //-------------------------------------------------------------------------
 // RecCore Callback Types
 //-------------------------------------------------------------------------
-using RecConfigUpdateCb = int (*)(const char *, RecDataT, RecData, void *);
+
+using RecConfigUpdateCb = std::function<int(const char *, RecDataT, RecData, void *)>;
 using RecStatUpdateFunc = int (*)(const char *, RecDataT, RecData *, RecRawStatBlock *, int, void *);
 using RecRawStatSyncCb  = int (*)(const char *, RecDataT, RecData *, RecRawStatBlock *, int);
+using RecContextCb      = bool(const char *, RecDataT, RecData, void *);

--- a/src/iocore/net/ConnectionTracker.cc
+++ b/src/iocore/net/ConnectionTracker.cc
@@ -24,13 +24,11 @@
 #include <algorithm>
 #include <deque>
 #include "iocore/net/ConnectionTracker.h"
+#include "records/RecCore.h"
 #include "tscpp/util/ts_bw_format.h"
 #include "../../records/P_RecDefs.h"
-#include "proxy/http/HttpConfig.h"
 
 using namespace std::literals;
-
-extern void Enable_Config_Var(std::string_view const &name, bool (*cb)(const char *, RecDataT, RecData, void *), void *cookie);
 
 ConnectionTracker::Imp ConnectionTracker::_imp;
 
@@ -143,15 +141,15 @@ Config_Update_Conntrack_Alert_Delay(const char *name, RecDataT dtype, RecData da
 } // namespace
 
 void
-ConnectionTracker::config_init(GlobalConfig *global, TxnConfig *txn)
+ConnectionTracker::config_init(GlobalConfig *global, TxnConfig *txn, RecConfigUpdateCb const &config_cb)
 {
   _global_config = global; // remember this for later retrieval.
                            // Per transaction lookup must be done at call time because it changes.
 
-  Enable_Config_Var(CONFIG_SERVER_VAR_MIN, &Config_Update_Conntrack_Min, txn);
-  Enable_Config_Var(CONFIG_SERVER_VAR_MAX, &Config_Update_Conntrack_Max, txn);
-  Enable_Config_Var(CONFIG_SERVER_VAR_MATCH, &Config_Update_Conntrack_Match, txn);
-  Enable_Config_Var(CONFIG_SERVER_VAR_ALERT_DELAY, &Config_Update_Conntrack_Alert_Delay, global);
+  Enable_Config_Var(CONFIG_SERVER_VAR_MIN, &Config_Update_Conntrack_Min, config_cb, txn);
+  Enable_Config_Var(CONFIG_SERVER_VAR_MAX, &Config_Update_Conntrack_Max, config_cb, txn);
+  Enable_Config_Var(CONFIG_SERVER_VAR_MATCH, &Config_Update_Conntrack_Match, config_cb, txn);
+  Enable_Config_Var(CONFIG_SERVER_VAR_ALERT_DELAY, &Config_Update_Conntrack_Alert_Delay, config_cb, global);
 }
 
 ConnectionTracker::TxnState

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -199,65 +199,6 @@ http_config_cb(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNU
   return 0;
 }
 
-/** Enable a dynamic configuration variable.
- *
- * @param name Configuration var name.
- * @param cb Callback to do the actual update of the master record.
- * @param cookie Extra data for @a cb
- *
- * The purpose of this is to unite the different ways and times a configuration variable needs
- * to be loaded. These are
- * - Process start.
- * - Dynamic update.
- * - Plugin API update.
- *
- * @a cb is expected to perform the update. It must return a @c bool which is
- * - @c true if the value was changed.
- * - @c false if the value was not changed.
- *
- * Based on that, a run time configuration update is triggered or not.
- *
- * In addition, this invokes @a cb and passes it the information in the configuration variable
- * global table in order to perform the initial loading of the value. No update is triggered for
- * that call as it is not needed.
- *
- */
-void
-Enable_Config_Var(std::string_view const &name, bool (*cb)(const char *, RecDataT, RecData, void *), void *cookie)
-{
-  // Must use this indirection because the API requires a pure function, therefore no values can
-  // be bound in the lambda. Instead this is needed to pass in the data for both the lambda and
-  // the actual callback.
-  using Context = std::tuple<decltype(cb), void *>;
-
-  // To deal with process termination cleanup, store the context instances in a deque where
-  // tail insertion doesn't invalidate pointers. These persist until process shutdown.
-  static std::deque<Context> storage;
-
-  Context &ctx = storage.emplace_back(cb, cookie);
-  // Register the call back - this handles external updates.
-  RecRegisterConfigUpdateCb(
-    name.data(),
-    [](const char *name, RecDataT dtype, RecData data, void *ctx) -> int {
-      auto &&[cb, cookie] = *static_cast<Context *>(ctx);
-      if ((*cb)(name, dtype, data, cookie)) {
-        http_config_cb(name, dtype, data, cookie); // signal runtime config update.
-      }
-      return REC_ERR_OKAY;
-    },
-    &ctx);
-
-  // Use the record to do the initial data load.
-  // Look it up and call the updater @a cb on that data.
-  RecLookupRecord(
-    name.data(),
-    [](RecRecord const *r, void *ctx) -> void {
-      auto &&[cb, cookie] = *static_cast<Context *>(ctx);
-      (*cb)(r->name, r->data_type, r->data, cookie);
-    },
-    &ctx);
-}
-
 // [amc] Not sure which is uglier, this switch or having a micro-function for each var.
 // Oh, how I long for when we can use C++eleventy lambdas without compiler problems!
 // I think for 5.0 when the BC stuff is yanked, we should probably revert this to independent callbacks.
@@ -690,7 +631,7 @@ template <typename V> struct ConfigDuration {
   void
   Enable(std::string_view name)
   {
-    Enable_Config_Var(name, &self_type::callback, _var);
+    Enable_Config_Var(name, &self_type::callback, http_config_cb, _var);
   }
 };
 
@@ -994,7 +935,7 @@ HttpConfig::startup()
   HttpEstablishStaticConfigStringAlloc(c.oride.ssl_client_alpn_protocols, "proxy.config.ssl.client.alpn_protocols");
   HttpEstablishStaticConfigByte(c.scheme_proto_mismatch_policy, "proxy.config.ssl.client.scheme_proto_mismatch_policy");
 
-  ConnectionTracker::config_init(&c.global_connection_tracker_config, &c.oride.connection_tracker_config);
+  ConnectionTracker::config_init(&c.global_connection_tracker_config, &c.oride.connection_tracker_config, http_config_cb);
 
   MUTEX_TRY_LOCK(lock, http_config_cont->mutex, this_ethread());
   if (!lock.is_locked()) {

--- a/src/records/P_RecCore.cc
+++ b/src/records/P_RecCore.cc
@@ -438,7 +438,7 @@ RecExecConfigUpdateCbs(unsigned int update_required_type)
       if ((r->config_meta.update_required & update_required_type) && (r->config_meta.update_cb_list)) {
         RecConfigUpdateCbList *cur_callback = nullptr;
         for (cur_callback = r->config_meta.update_cb_list; cur_callback; cur_callback = cur_callback->next) {
-          (*(cur_callback->update_cb))(r->name, r->data_type, r->data, cur_callback->update_cookie);
+          cur_callback->update_cb(r->name, r->data_type, r->data, cur_callback->update_cookie);
         }
         r->config_meta.update_required = r->config_meta.update_required & ~update_required_type;
       }

--- a/src/records/P_RecDefs.h
+++ b/src/records/P_RecDefs.h
@@ -56,10 +56,16 @@ enum RecEntryT {
   RECE_RECORD,
 };
 
-using RecConfigUpdateCbList = struct RecConfigCbList_t {
+struct RecConfigUpdateCbList {
+  RecConfigUpdateCbList() {}
+  RecConfigUpdateCbList(RecConfigUpdateCb const &update_cb, void *update_cookie)
+    : update_cb(update_cb), update_cookie(update_cookie)
+  {
+  }
+
   RecConfigUpdateCb update_cb;
-  void *update_cookie;
-  struct RecConfigCbList_t *next;
+  void *update_cookie         = nullptr;
+  RecConfigUpdateCbList *next = nullptr;
 };
 
 using RecStatUpdateFuncList = struct RecStatUpdateFuncList_t {


### PR DESCRIPTION
I moved ConnectionTracker to iocore/net, but I missed that I accidentally brought in a dependency upon proxh/http to iocore through the extern Enable_Config_Var. This patch removes the explicit include dependency and updates the unit tests that had a link time undefined symbol error for Enable_Config_Var.