### PR TITLE
cmake-format target and pre-commit hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -682,10 +682,18 @@ add_custom_target(
   VERBATIM
 )
 
-# Add a format target that depends upon both clang-format and autopep8.
+add_custom_target(
+  cmake-format
+  ${CMAKE_SOURCE_DIR}/tools/cmake-format.sh ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMENT "formatting CMakeLists.txt files"
+  VERBATIM
+)
+
+# Add a format target that runs all the formatters.
 add_custom_target(
   format
-  DEPENDS clang-format autopep8
+  DEPENDS clang-format autopep8 cmake-format
   COMMENT "formatting all files"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,9 +329,8 @@ if(ENABLE_QUICHE)
 endif()
 
 # for the plugin system
-find_package(nuraft)  # experimental stek_share
-find_package(maxminddb)  # Header_rewrite experimental/maxmind_acl
-
+find_package(nuraft) # experimental stek_share
+find_package(maxminddb) # Header_rewrite experimental/maxmind_acl
 
 if(ENABLE_ASAN)
   add_compile_options(-fsanitize=address)
@@ -624,7 +623,10 @@ if(ENABLE_EXAMPLE)
 endif()
 
 if(ENABLE_DOCS)
-  set(DOC_LANG en CACHE STRING "Document language option")
+  set(DOC_LANG
+      en
+      CACHE STRING "Document language option"
+  )
   add_subdirectory(doc)
 endif()
 add_subdirectory(rc)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -33,26 +33,24 @@ configure_file(manpages.cmake.in.py manpages.py)
 add_custom_target(
   generate_docs_setup
   COMMENT "Copy static files to build directory"
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-          ${CMAKE_CURRENT_SOURCE_DIR}/static
-          ${CMAKE_CURRENT_BINARY_DIR}/static
+  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/static ${CMAKE_CURRENT_BINARY_DIR}/static
 )
 
 # generate svg files from uml files
 set(UML_FILES
-  uml/JsonRPCManager.uml
-  uml/TLS-Bridge-Messages.uml
-  uml/TLS-Bridge-Plugin.uml
-  uml/hdr-heap-class.plantuml
-  uml/hdr-heap-str-alloc.plantuml
-  uml/host-resolve.plantuml
-  uml/l4-basic-sequence.uml
-  uml/l4-example-cdn-layout.uml
-  uml/l4-pre-warming-overview.uml
-  uml/l4-sni-routing-seq.uml
-  uml/l4-tcp-routing.uml
-  uml/traffic_ctl-class-diagram.uml
-  uml/url_rewrite.plantuml
+    uml/JsonRPCManager.uml
+    uml/TLS-Bridge-Messages.uml
+    uml/TLS-Bridge-Plugin.uml
+    uml/hdr-heap-class.plantuml
+    uml/hdr-heap-str-alloc.plantuml
+    uml/host-resolve.plantuml
+    uml/l4-basic-sequence.uml
+    uml/l4-example-cdn-layout.uml
+    uml/l4-pre-warming-overview.uml
+    uml/l4-sni-routing-seq.uml
+    uml/l4-tcp-routing.uml
+    uml/traffic_ctl-class-diagram.uml
+    uml/url_rewrite.plantuml
 )
 # unfortunately, sphinx can't look else for files than its source directory
 # so these files must be create in the source tree
@@ -61,16 +59,13 @@ foreach(UML ${UML_FILES})
   list(APPEND SVG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/uml/images/${uml_name}.svg)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/uml/images/${uml_name}.svg
-    COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_JAR} -o ${CMAKE_CURRENT_SOURCE_DIR}/uml/images -tsvg ${CMAKE_CURRENT_SOURCE_DIR}/${UML}
+    COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_JAR} -o ${CMAKE_CURRENT_SOURCE_DIR}/uml/images -tsvg
+            ${CMAKE_CURRENT_SOURCE_DIR}/${UML}
     DEPENDS ${UML}
     VERBATIM
   )
 endforeach()
-add_custom_target(
-  generate_svg_from_uml
-  DEPENDS
-  ${SVG_FILES}
-)
+add_custom_target(generate_svg_from_uml DEPENDS ${SVG_FILES})
 
 # Docs are built with python so we need a target to setup pipenv
 set(RUNPIPENV PIPENV_PIPFILE=${CMAKE_CURRENT_SOURCE_DIR}/Pipfile ${PipEnv})

--- a/plugins/experimental/uri_signing/CMakeLists.txt
+++ b/plugins/experimental/uri_signing/CMakeLists.txt
@@ -32,10 +32,8 @@ add_atsplugin(
 
 target_link_libraries(
   uri_signing
-  PRIVATE
-  cjose::cjose
-  PUBLIC
-  jansson::jansson
+  PRIVATE cjose::cjose
+  PUBLIC jansson::jansson
 )
 
 if(BUILD_TESTING)

--- a/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
@@ -34,18 +34,17 @@ target_compile_definitions(uri_signing_test PRIVATE UNITTEST)
 target_include_directories(uri_signing_test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(
   uri_signing_test
-  PRIVATE
-  catch2::catch2
-  jansson::jansson
-  cjose::cjose
-  ts::tsapi
-  ts::http
-  ts::hdrs
-  ts::proxy
-  ts::configmanager
-  ts::logging
-  ts::inknet
-  OpenSSL::SSL
-  OpenSSL::Crypto
+  PRIVATE catch2::catch2
+          jansson::jansson
+          cjose::cjose
+          ts::tsapi
+          ts::http
+          ts::hdrs
+          ts::proxy
+          ts::configmanager
+          ts::logging
+          ts::inknet
+          OpenSSL::SSL
+          OpenSSL::Crypto
 )
 add_test(NAME uri_signing_test COMMAND uri_signing_test)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -55,9 +55,7 @@ if(APPLE)
 endif()
 
 if(BUILD_TESTING)
-  add_executable(test_ApiCore
-    unit_tests/test_Metrics.cc
-  )
+  add_executable(test_ApiCore unit_tests/test_Metrics.cc)
 
   target_link_libraries(test_ApiCore PRIVATE tsapicore tscore catch2::catch2)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -67,11 +67,20 @@ macro(add_cache_test name)
 endmacro()
 
 macro(add_net_test name)
-  add_executable(${name}
-    ${CMAKE_SOURCE_DIR}/src/iocore/net/libinknet_stub.cc
-    ${CMAKE_SOURCE_DIR}/src/shared/overridable_txn_vars.cc
-    ${ARGN})
-  target_link_libraries(${name} PRIVATE ts::tsapicore ts::inknet ts::configmanager ts::tsapi ts::inknet ts::http ts::configmanager)
+  add_executable(
+    ${name} ${CMAKE_SOURCE_DIR}/src/iocore/net/libinknet_stub.cc ${CMAKE_SOURCE_DIR}/src/shared/overridable_txn_vars.cc
+            ${ARGN}
+  )
+  target_link_libraries(
+    ${name}
+    PRIVATE ts::tsapicore
+            ts::inknet
+            ts::configmanager
+            ts::tsapi
+            ts::inknet
+            ts::http
+            ts::configmanager
+  )
   add_test(NAME test_cache_${name} COMMAND $<TARGET_FILE:${name}>)
 endmacro()
 
@@ -136,7 +145,10 @@ set(LIBINKNET_UNIT_TEST_DIR "${CMAKE_SOURCE_DIR}/src/iocore/net/unit_tests")
 target_compile_definitions(test_net PRIVATE LIBINKNET_UNIT_TEST_DIR=${LIBINKNET_UNIT_TEST_DIR})
 target_link_libraries(test_net PRIVATE hdrs proxy ts::tsapicore)
 
-add_stubbed_test(EventSystem ${CMAKE_SOURCE_DIR}/src/iocore/net/NetVCTest.cc ${CMAKE_SOURCE_DIR}/src/iocore/eventsystem/unit_tests/test_EventSystem.cc)
+add_stubbed_test(
+  EventSystem ${CMAKE_SOURCE_DIR}/src/iocore/net/NetVCTest.cc
+  ${CMAKE_SOURCE_DIR}/src/iocore/eventsystem/unit_tests/test_EventSystem.cc
+)
 target_link_libraries(EventSystem PRIVATE ts::inknet)
 add_stubbed_test(IOBuffer ${CMAKE_SOURCE_DIR}/src/iocore/eventsystem/unit_tests/test_IOBuffer.cc)
 

--- a/src/traffic_server/CMakeLists.txt
+++ b/src/traffic_server/CMakeLists.txt
@@ -15,9 +15,7 @@
 #
 #######################
 
-add_executable(
-  traffic_server Crash.cc EventName.cc SocksProxy.cc traffic_server.cc RpcAdminPubHandlers.cc
-)
+add_executable(traffic_server Crash.cc EventName.cc SocksProxy.cc traffic_server.cc RpcAdminPubHandlers.cc)
 target_link_libraries(
   traffic_server
   PRIVATE ts::tscore

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -50,36 +50,35 @@ if(APPLE)
 endif()
 
 set(TSCPP_API_PUBLIC_HEADERS
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Async.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/AsyncHttpFetch.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/AsyncTimer.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/CaseInsensitiveStringComparator.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Cleanup.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/ClientRequest.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Continuation.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/GlobalPlugin.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/GzipDeflateTransformation.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/GzipInflateTransformation.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Headers.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpMethod.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpStatus.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpVersion.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/InterceptPlugin.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Logger.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Plugin.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/PluginInit.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/RemapPlugin.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Request.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Response.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Stat.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Transaction.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/TransactionPlugin.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/TransformationPlugin.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/Url.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/noncopyable.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/api/utils.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Async.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/AsyncHttpFetch.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/AsyncTimer.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/CaseInsensitiveStringComparator.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Cleanup.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/ClientRequest.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Continuation.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/GlobalPlugin.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/GzipDeflateTransformation.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/GzipInflateTransformation.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Headers.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpMethod.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpStatus.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/HttpVersion.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/InterceptPlugin.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Logger.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Plugin.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/PluginInit.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/RemapPlugin.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Request.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Response.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Stat.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Transaction.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/TransactionPlugin.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/TransformationPlugin.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/Url.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/noncopyable.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/api/utils.h
 )
 set_target_properties(tscppapi PROPERTIES PUBLIC_HEADER "${TSCPP_API_PUBLIC_HEADERS}")
 
-install(TARGETS tscppapi
-  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tscpp/api)
+install(TARGETS tscppapi PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tscpp/api)

--- a/src/tscpp/util/CMakeLists.txt
+++ b/src/tscpp/util/CMakeLists.txt
@@ -19,23 +19,23 @@ add_library(tscpputil SHARED ts_bwf.cc ts_ip.cc ts_diags.cc YamlCfg.cc ts_unit_p
 add_library(ts::tscpputil ALIAS tscpputil)
 target_link_libraries(tscpputil PUBLIC libswoc yaml-cpp::yaml-cpp ts::tscore)
 set(TSCPPUTIL_PUBLIC_HEADERS
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Bravo.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Convert.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/DenseThreadId.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Histogram.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/LocalBuffer.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/PostScript.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/Strerror.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/TsSharedMutex.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/YamlCfg.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_bw.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_bw_format.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_diag_levels.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_errata.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_ip.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_meta.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_time_parser.h
-  ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_unit_parser.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/Bravo.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/Convert.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/DenseThreadId.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/Histogram.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/LocalBuffer.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/PostScript.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/Strerror.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/TsSharedMutex.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/YamlCfg.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_bw.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_bw_format.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_diag_levels.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_errata.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_ip.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_meta.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_time_parser.h
+    ${PROJECT_SOURCE_DIR}/include/tscpp/util/ts_unit_parser.h
 )
 set_target_properties(tscpputil PROPERTIES PUBLIC_HEADER "${TSCPPUTIL_PUBLIC_HEADERS}")
 

--- a/tools/git/pre-commit
+++ b/tools/git/pre-commit
@@ -45,18 +45,25 @@ fi
 
 source "$GIT_TOP/tools/autopep8.sh"
 if [ ! -d ${AUTOPEP8_VENV} ]; then
-    echo "Run \"make autopep8\""
+    echo "Run \"cmake --build <build_dir> --target autopep8\""
     exit 1
 fi
-source ${AUTOPEP8_VENV}/bin/activate
+
+source "$GIT_TOP/tools/cmake-format.sh"
+if [ ! -d ${CMAKE_FORMAT_VENV} ]; then
+    echo "Run \"cmake --build <build_dir> --target autopep8\""
+    exit 1
+fi
 
 # Where to store the patch
 clang_patch_file=$(mktemp -t clang-format.XXXXXXXXXX)
 autopep8_patch_file=$(mktemp -t autopep8.XXXXXXXXXX)
-trap "rm -f $clang_patch_file $autopep8_patch_file" 0 1 2 3 5 15
+cmake_format_patch_file=$(mktemp -t cmake-format.XXXXXXXXXX)
+trap "rm -f $clang_patch_file $autopep8_patch_file $cmake_format_patch_file" 0 1 2 3 5 15
 
 # Loop over all files that are changed, and produce a diff file
-git diff-index --cached --diff-filter=ACMR --name-only HEAD | grep -vE "lib/(yamlcpp|swoc)" | while read file; do
+source ${AUTOPEP8_VENV}/bin/activate
+git diff-index --cached --diff-filter=ACMR --name-only HEAD | grep -vE "lib/(catch2|fastlz|swoc|yamlcpp)" | while read file; do
     case "$file" in
     *.cc | *.c | *.h | *.h.in)
         ${FORMAT} "$file" | diff -u "$file" - >>"$clang_patch_file"
@@ -75,12 +82,20 @@ git diff-index --cached --diff-filter=ACMR --name-only HEAD | grep -vE "lib/(yam
         ;;
     esac
 done
+deactivate
+
+# Now repeat the above for CMakeLists.txt files.
+source ${CMAKE_FORMAT_VENV}/bin/activate
+git diff-index --cached --diff-filter=ACMR --name-only HEAD | grep CMakeLists.txt | grep -vE "lib/(catch2|fastlz|swoc|yamlcpp)" | while read file; do
+    cmake-format "$file" | diff -u "$file" - >>"$cmake_format_patch_file"
+done
+deactivate
 
 if [ -s "$clang_patch_file" ]; then
     echo "The commit is not accepted, because clang-format does not match current"
     echo "requirements. Easiest to fix this is to run:"
     echo
-    echo "    $ make -j clang-format"
+    echo "    $ cmake --build <build_dir> --target format"
     exit 1
 else
     echo "This commit complies with the current clang-format indentation rules."
@@ -91,14 +106,24 @@ if [ -s "$autopep8_patch_file" ]; then
     echo "The commit is not accepted because autopep8 reports issues with it."
     echo "The easiest way to fix this is to run:"
     echo
-    echo "    $ make autopep8"
+    echo "    $ cmake --build <build_dir> --target format"
     exit 1
 else
     echo "This commit complies with the current autopep8 formatting rules."
     echo
 fi
 
+if [ -s "$cmake_format_patch_file" ]; then
+    echo "The commit is not accepted because cmake-format reports issues with it."
+    echo "The easiest way to fix this is to run:"
+    echo
+    echo "    $ cmake --build <build_dir> --target format"
+    exit 1
+else
+    echo "This commit complies with the current cmake-format formatting rules."
+    echo
+fi
+
 # Cleanup before exit
-deactivate
 rm -f "$clang_patch_file" "$autopep8_patch_file"
 exit 0


### PR DESCRIPTION
This adds the cmake-format cmake target as well as updates the
pre-commit hook to check cmake-format on changed files.

This also has, as a separate commit, the cmake-format changes applied to our repo.