### PR TITLE
Fix typo in autopep8.sh

### DIFF
--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -18,7 +18,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# Update theese VERSION variables with the new desired autopep8 tag when a new
+# Update these VERSION variables with the new desired autopep8 tag when a new
 # autopep8 version is desired.
 # See:
 # https://github.com/hhatto/autopep8/tags


### PR DESCRIPTION
This typo was introduced by #10746. I was about to post my review requesting this change, but @cmcfarlen approved and @bneradt merged before I submitted.