### PR TITLE
Cleanup: Remove unimplemented event handlers from CacheVC

### DIFF
--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -166,7 +166,6 @@ struct CacheVC : public CacheVConnection {
   int openWriteCloseHead(int event, Event *e);
   int openWriteCloseDataDone(int event, Event *e);
   int openWriteClose(int event, Event *e);
-  int openWriteRemoveVector(int event, Event *e);
   int openWriteWriteDone(int event, Event *e);
   int openWriteOverwrite(int event, Event *e);
   int openWriteMain(int event, Event *e);
@@ -174,8 +173,6 @@ struct CacheVC : public CacheVConnection {
   int openWriteStartBegin(int event, Event *e);
 
   int updateVector(int event, Event *e);
-  int updateReadDone(int event, Event *e);
-  int updateVecWrite(int event, Event *e);
 
   int removeEvent(int event, Event *e);
 

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -1674,8 +1674,7 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
        close
        c) Delete an alternate
        The vector may need to be deleted (if there was only one alternate) or
-       rewritten (if there were more than one alternate). The deletion of the
-       vector is done in openWriteRemoveVector.
+       rewritten (if there were more than one alternate).
        HTTP OPERATIONS
        open_write with info set
        close


### PR DESCRIPTION
These event handlers are declared but don't have implementations.