### PR TITLE
Add check for config existence before cont creation

### DIFF
--- a/plugins/stats_over_http/stats_over_http.cc
+++ b/plugins/stats_over_http/stats_over_http.cc
@@ -737,9 +737,12 @@ init:
   TSHttpHookAdd(TS_HTTP_READ_REQUEST_HDR_HOOK, main_cont);
 
   /* Create continuation for management updates to re-read config file */
-  config_cont = TSContCreate(config_handler, TSMutexCreate());
-  TSContDataSet(config_cont, (void *)config_holder);
-  TSMgmtUpdateRegister(config_cont, PLUGIN_NAME);
+  if (config_holder->config_path != nullptr) {
+    config_cont = TSContCreate(config_handler, TSMutexCreate());
+    TSContDataSet(config_cont, (void *)config_holder);
+    TSMgmtUpdateRegister(config_cont, PLUGIN_NAME);
+  }
+
   Dbg(dbg_ctl, "stats module registered with path %s", config_holder->config->stats_path.c_str());
 
 done:


### PR DESCRIPTION
Checks if a config path is set to monitor for a config file, if not set dont create the mgmt cont

closes #10658 