### PR TITLE
Fix compile error with debug output in stek_share.cc.

### DIFF
--- a/plugins/experimental/stek_share/stek_share.cc
+++ b/plugins/experimental/stek_share/stek_share.cc
@@ -40,6 +40,8 @@
 
 using raft_result = nuraft::cmd_result<nuraft::ptr<nuraft::buffer>>;
 
+static DbgCtl dbg_ctl{PLUGIN_NAME};
+
 PluginThreads plugin_threads;
 
 static STEKShareServer stek_share_server;


### PR DESCRIPTION
Because the stek_share plugin is not built in any PR check, a compile error in this plugin made it into the master branch. The nuraft library has to be installed and found by cmake for the stek_share plugin to build.