### PR TITLE
Rename VOL macros to STRIPE

### DIFF
--- a/doc/developer-guide/cache-architecture/cache-initialization.en.rst
+++ b/doc/developer-guide/cache-architecture/cache-initialization.en.rst
@@ -84,10 +84,10 @@ stripes to be assigned are in :member:`CacheHostRecord::vols`.
 An indirect index mapping is created to account for stripes that are not available. The total size
 of the stripes is computed at the same time. The :code:`forvol` and :code:`getvol` arrays are used
 for debugging, they are not essential to the assignment setup. :code:`rtable_entries` is filled with
-stripe size divided by :code:`VOL_HASH_ALLOC_SIZE`. These values are used to determine the number of
+stripe size divided by :code:`STRIPE_HASH_ALLOC_SIZE`. These values are used to determine the number of
 assignment slots given to each stripe. For each stripe a seed for a 32 bit pseudo random number
 generator is created based on stripe properties. Another array of pairs of value and stripe index is
-filled using these. For each :code:`VOL_HASH_ALLOC_SIZE` amount of space in a stripe, a pair is
+filled using these. For each :code:`STRIPE_HASH_ALLOC_SIZE` amount of space in a stripe, a pair is
 generated containing the stripe index and the next random number from that stripe's generator. This
 array is then sorted in ascending order.
 
@@ -97,7 +97,7 @@ array is then sorted in ascending order.
    <http://random.org>`__ is used.
 
 The result is sampled in sections, the size of the sections selected to yield
-:code:`VOL_HASH_TABLE_SIZE` sections. For each section the sample value is the midpoint of the
+:code:`STRIPE_HASH_TABLE_SIZE` sections. For each section the sample value is the midpoint of the
 section.For the example, the number of sections is set to 17 (because the number of sections should
 be a prime number). This yields 17 sections each of width 15 with a sample value equal to 7 more
 than the initial value. The results of applying this to the :code:`rtable` is

--- a/doc/developer-guide/cache-architecture/data-structures.en.rst
+++ b/doc/developer-guide/cache-architecture/data-structures.en.rst
@@ -306,7 +306,7 @@ Data Structures
 
    .. member:: unsigned int magic
 
-      Container for a magic value, ``VOL_MAGIC``, to indicate the instance is valid.
+      Container for a magic value, ``STRIPE_MAGIC``, to indicate the instance is valid.
 
    .. member:: VersionNumber version
 
@@ -467,7 +467,7 @@ Data Structures
       Compute the stripe (:code:`Stripe *`) for a cache :arg:`key` and :arg:`host`. The :arg:`host` is
       used to find the appropriate :class:`CacheHostRecord` instance. From there the stripe
       assignment slot is determined by taking bits 64..83 (20 bits) of the cache :arg:`key` modulo
-      the stripe assignment array count (:code:`VOL_HASH_TABLE_SIZE`). These bits are the third 32
+      the stripe assignment array count (:code:`STRIPE_HASH_TABLE_SIZE`). These bits are the third 32
       bit slice of the :arg:`key` less the bottom :code:`DIR_TAG_WIDTH` (12) bits.
 
 .. rubric:: Footnotes

--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -474,7 +474,7 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   // See what the difference is
   int to = 0, from = 0;
   int then = 0, now = 0;
-  for (int i = 0; i < VOL_HASH_TABLE_SIZE; ++i) {
+  for (int i = 0; i < STRIPE_HASH_TABLE_SIZE; ++i) {
     if (hr1.vol_hash_table[i] == sample_idx) {
       ++then;
     }
@@ -492,7 +492,7 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   rprintf(t,
           "Cache stability difference - "
           "delta = %d of %d : %d to, %d from, originally %d slots, now %d slots (net gain = %d/%d)\n",
-          to + from, VOL_HASH_TABLE_SIZE, to, from, then, now, now - then, to - from);
+          to + from, STRIPE_HASH_TABLE_SIZE, to, from, then, now, now - then, to - from);
   *pstatus = REGRESSION_TEST_PASSED;
 
   hr1.vols = nullptr;

--- a/src/iocore/cache/P_CacheDisk.h
+++ b/src/iocore/cache/P_CacheDisk.h
@@ -34,14 +34,7 @@ extern int cache_config_max_disk_errors;
 #define SET_DISK_BAD(_x)       (_x->num_errors = cache_config_max_disk_errors)
 #define SET_DISK_OKAY(_x)      (_x->num_errors = 0)
 
-#define VOL_BLOCK_SIZE                (1024 * 1024 * 128)
-#define MIN_VOL_SIZE                  VOL_BLOCK_SIZE
-#define ROUND_DOWN_TO_VOL_BLOCK(_x)   (((_x) & ~(VOL_BLOCK_SIZE - 1)))
-#define VOL_BLOCK_SHIFT               27
-#define ROUND_DOWN_TO_STORE_BLOCK(_x) (((_x) >> STORE_BLOCK_SHIFT) << STORE_BLOCK_SHIFT)
-
-#define STORE_BLOCKS_PER_VOL (VOL_BLOCK_SIZE / STORE_BLOCK_SIZE)
-#define DISK_HEADER_MAGIC    0xABCD1237
+#define DISK_HEADER_MAGIC 0xABCD1237
 
 /* each disk vol block has a corresponding Stripe object */
 struct CacheDisk;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -38,21 +38,22 @@
 #define ROUND_TO_SECTOR(_p, _x)  INK_ALIGN((_x), _p->sector_size)
 #define ROUND_TO(_x, _y)         INK_ALIGN((_x), (_y))
 
-// Stripe (volumes)
-#define VOL_MAGIC                    0xF1D0F00D
+// Stripe
+#define STRIPE_MAGIC                 0xF1D0F00D
 #define START_BLOCKS                 16 // 8k, STORE_BLOCK_SIZE
 #define START_POS                    ((off_t)START_BLOCKS * CACHE_BLOCK_SIZE)
-#define AGG_SIZE                     (4 * 1024 * 1024) // 4MB
-#define AGG_HIGH_WATER               (AGG_SIZE / 2)    // 2MB
-#define EVACUATION_SIZE              (2 * AGG_SIZE)    // 8MB
-#define MAX_VOL_SIZE                 ((off_t)512 * 1024 * 1024 * 1024 * 1024)
-#define MAX_VOL_BLOCKS               (MAX_VOL_SIZE / CACHE_BLOCK_SIZE)
-#define MAX_FRAG_SIZE                (AGG_SIZE - sizeof(Doc)) // true max
+#define AGG_SIZE                     (4 * 1024 * 1024)   // 4MB
+#define AGG_HIGH_WATER               (AGG_SIZE / 2)      // 2MB
+#define EVACUATION_SIZE              (2 * AGG_SIZE)      // 8MB
+#define STRIPE_BLOCK_SIZE            (1024 * 1024 * 128) // 128MB
+#define MIN_STRIPE_SIZE              STRIPE_BLOCK_SIZE
+#define MAX_STRIPE_SIZE              ((off_t)512 * 1024 * 1024 * 1024 * 1024) // 512TB
+#define MAX_FRAG_SIZE                (AGG_SIZE - sizeof(Doc))                 // true max
 #define LEAVE_FREE                   DEFAULT_MAX_BUFFER_SIZE
 #define PIN_SCAN_EVERY               16 // scan every 1/16 of disk
-#define VOL_HASH_TABLE_SIZE          32707
-#define VOL_HASH_EMPTY               0xFFFF
-#define VOL_HASH_ALLOC_SIZE          (8 * 1024 * 1024) // one chance per this unit
+#define STRIPE_HASH_TABLE_SIZE       32707
+#define STRIPE_HASH_EMPTY            0xFFFF
+#define STRIPE_HASH_ALLOC_SIZE       (8 * 1024 * 1024) // one chance per this unit
 #define LOOKASIDE_SIZE               256
 #define EVACUATION_BUCKET_SIZE       (2 * EVACUATION_SIZE) // 16MB
 #define RECOVERY_SIZE                EVACUATION_SIZE       // 8MB
@@ -60,6 +61,7 @@
 #define AIO_AGG_WRITE_IN_PROGRESS    -2
 #define AUTO_SIZE_RAM_CACHE          -1                      // 1-1 with directory size
 #define DEFAULT_TARGET_FRAGMENT_SIZE (1048576 - sizeof(Doc)) // 1MB
+#define STORE_BLOCKS_PER_STRIPE      (STRIPE_BLOCK_SIZE / STORE_BLOCK_SIZE)
 
 #define dir_offset_evac_bucket(_o) (_o / (EVACUATION_BUCKET_SIZE / CACHE_BLOCK_SIZE))
 #define dir_evac_bucket(_e)        dir_offset_evac_bucket(dir_offset(_e))

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -192,7 +192,7 @@ Stripe::init(char *s, off_t blocks, off_t dir_skip, bool clear)
   dir_skip = ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip));
   path     = ats_strdup(s);
   len      = blocks * STORE_BLOCK_SIZE;
-  ink_assert(len <= MAX_VOL_SIZE);
+  ink_assert(len <= MAX_STRIPE_SIZE);
   skip             = dir_skip;
   prev_recover_pos = 0;
 
@@ -298,12 +298,12 @@ Stripe::handle_dir_read(int event, void *data)
     }
   }
 
-  if (!(header->magic == VOL_MAGIC && footer->magic == VOL_MAGIC && CACHE_DB_MAJOR_VERSION_COMPATIBLE <= header->version._major &&
-        header->version._major <= CACHE_DB_MAJOR_VERSION)) {
+  if (!(header->magic == STRIPE_MAGIC && footer->magic == STRIPE_MAGIC &&
+        CACHE_DB_MAJOR_VERSION_COMPATIBLE <= header->version._major && header->version._major <= CACHE_DB_MAJOR_VERSION)) {
     Warning("bad footer in cache directory for '%s', clearing", hash_text.get());
-    Note("VOL_MAGIC %d\n header magic: %d\n footer_magic %d\n CACHE_DB_MAJOR_VERSION_COMPATIBLE %d\n major version %d\n"
+    Note("STRIPE_MAGIC %d\n header magic: %d\n footer_magic %d\n CACHE_DB_MAJOR_VERSION_COMPATIBLE %d\n major version %d\n"
          "CACHE_DB_MAJOR_VERSION %d\n",
-         VOL_MAGIC, header->magic, footer->magic, CACHE_DB_MAJOR_VERSION_COMPATIBLE, header->version._major,
+         STRIPE_MAGIC, header->magic, footer->magic, CACHE_DB_MAJOR_VERSION_COMPATIBLE, header->version._major,
          CACHE_DB_MAJOR_VERSION);
     Note("clearing cache directory '%s'", hash_text.get());
     clear_dir_aio();
@@ -871,7 +871,7 @@ Stripe::_clear_init()
   size_t dir_len = this->dirlen();
   memset(this->raw_dir, 0, dir_len);
   this->_init_dir();
-  this->header->magic          = VOL_MAGIC;
+  this->header->magic          = STRIPE_MAGIC;
   this->header->version._major = CACHE_DB_MAJOR_VERSION;
   this->header->version._minor = CACHE_DB_MINOR_VERSION;
   this->scan_pos = this->header->agg_pos = this->header->write_pos = this->start;

--- a/src/iocore/cache/unit_tests/test_CacheVol.cc
+++ b/src/iocore/cache/unit_tests/test_CacheVol.cc
@@ -52,6 +52,7 @@ DbgCtl dbg_ctl_cache_vol_test{"cache_vol_test"};
 /* Test the cache volume with different configurations */
 #define MEGS_128              (128 * 1024 * 1024)
 #define ROUND_TO_VOL_SIZE(_x) (((_x) + (MEGS_128 - 1)) & ~(MEGS_128 - 1))
+
 static int configs = 4;
 
 Queue<CacheVol> saved_cp_list;
@@ -78,12 +79,12 @@ create_config(int num)
     for (i = 0; i < gndisks; i++) {
       CacheDisk *d = gdisks[i];
       int blocks   = d->num_usable_blocks;
-      if (blocks < STORE_BLOCKS_PER_VOL) {
+      if (blocks < STORE_BLOCKS_PER_STRIPE) {
         Warning("Cannot run Cache_vol regression: not enough disk space");
         return 0;
       }
       /* create 128 MB volumes */
-      for (; blocks >= STORE_BLOCKS_PER_VOL; blocks -= STORE_BLOCKS_PER_VOL) {
+      for (; blocks >= STORE_BLOCKS_PER_STRIPE; blocks -= STORE_BLOCKS_PER_STRIPE) {
         if (vol_num > 255) {
           break;
         }
@@ -111,8 +112,8 @@ create_config(int num)
     for (i = 0; i < gndisks; i++) {
       off_t vol_blocks = gdisks[i]->num_usable_blocks;
       /* round down the blocks to the nearest
-         multiple of STORE_BLOCKS_PER_VOL */
-      vol_blocks   = (vol_blocks / STORE_BLOCKS_PER_VOL) * STORE_BLOCKS_PER_VOL;
+         multiple of STORE_BLOCKS_PER_STRIPE */
+      vol_blocks   = (vol_blocks / STORE_BLOCKS_PER_STRIPE) * STORE_BLOCKS_PER_STRIPE;
       total_space += vol_blocks;
     }
 
@@ -157,8 +158,8 @@ create_config(int num)
     for (i = 0; i < gndisks; i++) {
       off_t vol_blocks = gdisks[i]->num_usable_blocks;
       /* round down the blocks to the nearest
-         multiple of STORE_BLOCKS_PER_VOL */
-      vol_blocks   = (vol_blocks / STORE_BLOCKS_PER_VOL) * STORE_BLOCKS_PER_VOL;
+         multiple of STORE_BLOCKS_PER_STRIPE */
+      vol_blocks   = (vol_blocks / STORE_BLOCKS_PER_STRIPE) * STORE_BLOCKS_PER_STRIPE;
       total_space += vol_blocks;
 
       if (num == 2) {
@@ -177,8 +178,8 @@ create_config(int num)
       if (vol_num > 255) {
         break;
       }
-      off_t modu = MAX_VOL_SIZE;
-      if (total_space < (MAX_VOL_SIZE >> STORE_BLOCK_SHIFT)) {
+      off_t modu = MAX_STRIPE_SIZE;
+      if (total_space < (MAX_STRIPE_SIZE >> STORE_BLOCK_SHIFT)) {
         modu = total_space * STORE_BLOCK_SIZE;
       }
 

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -356,18 +356,18 @@ using ts::CacheStripeDescriptor;
 using ts::CacheDirEntry;
 using ts::Doc;
 
-constexpr int ESTIMATED_OBJECT_SIZE     = 8000;
-constexpr int DEFAULT_HW_SECTOR_SIZE    = 512;
-constexpr int VOL_HASH_TABLE_SIZE       = 32707;
-constexpr unsigned short VOL_HASH_EMPTY = 65535;
-constexpr int DIR_TAG_WIDTH             = 12;
-constexpr int DIR_DEPTH                 = 4;
-constexpr int SIZEOF_DIR                = 10;
-constexpr int MAX_ENTRIES_PER_SEGMENT   = (1 << 16);
-constexpr int DIR_SIZE_WIDTH            = 6;
-constexpr int DIR_BLOCK_SIZES           = 4;
-constexpr int CACHE_BLOCK_SHIFT         = 9;
-constexpr int CACHE_BLOCK_SIZE          = (1 << CACHE_BLOCK_SHIFT); // 512, smallest sector size
+constexpr int ESTIMATED_OBJECT_SIZE        = 8000;
+constexpr int DEFAULT_HW_SECTOR_SIZE       = 512;
+constexpr int STRIPE_HASH_TABLE_SIZE       = 32707;
+constexpr unsigned short STRIPE_HASH_EMPTY = 65535;
+constexpr int DIR_TAG_WIDTH                = 12;
+constexpr int DIR_DEPTH                    = 4;
+constexpr int SIZEOF_DIR                   = 10;
+constexpr int MAX_ENTRIES_PER_SEGMENT      = (1 << 16);
+constexpr int DIR_SIZE_WIDTH               = 6;
+constexpr int DIR_BLOCK_SIZES              = 4;
+constexpr int CACHE_BLOCK_SHIFT            = 9;
+constexpr int CACHE_BLOCK_SIZE             = (1 << CACHE_BLOCK_SHIFT); // 512, smallest sector size
 
 namespace ct
 {


### PR DESCRIPTION
Part of #10628.

- Rename VOL macros to STRIPE
- Move STRIPE related macros from `P_DiskCache.h` to `P_CacheVol.h`
- Remove unused macros.