### PR TITLE
Move find_package() to root build file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,12 @@ check_include_file(siginfo.h HAVE_SIGINFO_H)
 check_include_file(endian.h HAVE_ENDIAN_H)
 
 # Find libraries
+if(ENABLE_CRIPTS)
+  # needed for cripts
+  # however this might become a general requirement
+  find_package(fmt 8.1 REQUIRED)
+endif()
+
 find_package(Backtrace)
 if(Backtrace_FOUND)
   set(TS_HAS_BACKTRACE TRUE)

--- a/src/cripts/CMakeLists.txt
+++ b/src/cripts/CMakeLists.txt
@@ -19,7 +19,6 @@
 
 # We use fmt with cripts, contrary to ATS / libswoc. We also require PCRE2 and not PCRE,
 # but hopefully ATS will migrate to PCRE2 soon.
-find_package(fmt 8.1 REQUIRED)
 pkg_check_modules(PCRE2 REQUIRED IMPORTED_TARGET libpcre2-8)
 
 # The source files, globbed so we can drop in local / custom Bundles and extensions.


### PR DESCRIPTION
This is basically clean up to make sure we can easily see what packages are needed as a whole in trafficserver
fmt as a library was also discussed as a general library to be used going forward