### PR TITLE
cmake: Fix CMAKE_INSTALL_CACHEDIR STRING value

### DIFF
--- a/cmake/layout.cmake
+++ b/cmake/layout.cmake
@@ -65,6 +65,6 @@ set(CMAKE_INSTALL_LOGDIR
 )
 set(CMAKE_INSTALL_CACHEDIR
   "${CMAKE_INSTALL_LOCALSTATEDIR}/trafficserver"
-    CACHE STRING "logdir"
+    CACHE STRING "cachedir"
 )
 include(GNUInstallDirs)


### PR DESCRIPTION
I suppose it is a leftover after copy-and-paste from `CMAKE_INSTALL_LOGDIR` above.
