### PR TITLE
remove odd include paths

### DIFF
--- a/plugins/experimental/stek_share/CMakeLists.txt
+++ b/plugins/experimental/stek_share/CMakeLists.txt
@@ -18,7 +18,6 @@
 if(nuraft_FOUND)
   add_atsplugin(stek_share common.cc log_store.cc stek_share.cc stek_utils.cc)
 
-  target_include_directories(stek_share PRIVATE nuraft::nuraft OpenSSL::SSL yaml-cpp::yaml-cpp)
   target_link_libraries(stek_share PRIVATE nuraft::nuraft OpenSSL::SSL yaml-cpp::yaml-cpp)
 else()
   message(STATUS "skipping stek_share plugin (missing nuraft)")

--- a/src/proxy/http/CMakeLists.txt
+++ b/src/proxy/http/CMakeLists.txt
@@ -45,8 +45,6 @@ if(BUILD_REGRESSION_TESTING)
   target_sources(http PRIVATE RegressionHttpTransact.cc)
 endif()
 
-target_include_directories(http PRIVATE ${YAMLCPP_INCLUDE_DIR} OpenSSL::SSL)
-
 target_link_libraries(
   http
   PUBLIC ts::inkevent ts::inkhostdb ts::proxy ts::tsapicore ts::tscore


### PR DESCRIPTION
This addresses some odd build paths I was finding in the build.

for example `-Iplugins/experimental/stek_share/nuraft::nuraft`

CMake seems to be adding the path correctly without adding the `target_include_directories()` call

