### PR TITLE
Depend upon the Format job instead of Clang-Format

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -50,7 +50,7 @@ github:
           - Rocky
           - CentOS
           - Clang-Analyzer
-          - Clang-Format
+          - Format
           - Debian
           - Docs
           - Fedora


### PR DESCRIPTION
Historically, our format CI job has been called clang-format, but that is now confusing since that job tests autopep8 and now cmake-format in addition to clang-format. Renaming it to simply "Format" now.