### PR TITLE
Remove HAVE_ALLOCA_H build var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,6 @@ include(CheckTypeSize)
 include(CheckSourceCompiles)
 include(CheckStructHasMember)
 
-check_include_file(alloca.h HAVE_ALLOCA_H)
 check_include_file(cpio.h HAVE_CPIO_H)
 check_include_file(dlfcn.h HAVE_DLFCN_H)
 check_include_file(float.h HAVE_FLOAT_H)

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -32,7 +32,6 @@
 #cmakedefine BUILD_GROUP "@BUILD_GROUP@"
 #define BUILD_NUMBER "@BUILD_NUMBER@"
 
-#cmakedefine HAVE_ALLOCA_H 1
 #cmakedefine HAVE_BROTLI_ENCODE_H 1
 #cmakedefine HAVE_CLOCK_GETTIME 1
 #cmakedefine HAVE_CURSES_H 1

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -122,7 +122,7 @@ struct ifafilt;
 #ifdef HAVE_VALUES_H
 #include <values.h>
 #endif
-#ifdef HAVE_ALLOCA_H
+#if __has_include(<alloca.h>)
 #include <alloca.h>
 #endif
 

--- a/src/iocore/eventsystem/UnixEventProcessor.cc
+++ b/src/iocore/eventsystem/UnixEventProcessor.cc
@@ -24,7 +24,7 @@
 #include "P_EventSystem.h"
 #include <sched.h>
 #if TS_USE_HWLOC
-#if HAVE_ALLOCA_H
+#if __has_include(<alloca.h>)
 #include <alloca.h>
 #endif
 #include <hwloc.h>


### PR DESCRIPTION
Replace automake-style `HAVE_INCLUDE_H` compile flags with `#if __has_include` preprocessor directives.

This PR does so for `alloca.h` 