### PR TITLE
Remove HAVE_CPIO_H build var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,6 @@ include(CheckTypeSize)
 include(CheckSourceCompiles)
 include(CheckStructHasMember)
 
-check_include_file(cpio.h HAVE_CPIO_H)
 check_include_file(dlfcn.h HAVE_DLFCN_H)
 check_include_file(float.h HAVE_FLOAT_H)
 check_include_file(stdlib.h HAVE_STDLIB_H)

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -36,7 +36,6 @@
 #cmakedefine HAVE_CLOCK_GETTIME 1
 #cmakedefine HAVE_CURSES_H 1
 #cmakedefine HAVE_CURL 1
-#cmakedefine HAVE_CPIO_H 1
 #cmakedefine HAVE_NCURSES_H 1
 #cmakedefine HAVE_NCURSES_CURSES_H 1
 #cmakedefine HAVE_NCURSES_NCURSES_H 1

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -126,7 +126,7 @@ struct ifafilt;
 #include <alloca.h>
 #endif
 
-#ifdef HAVE_CPIO_H
+#if __has_include(<cpio.h>)
 #include <cpio.h>
 #if defined(MAGIC)
 #undef MAGIC

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -126,13 +126,6 @@ struct ifafilt;
 #include <alloca.h>
 #endif
 
-#if __has_include(<cpio.h>)
-#include <cpio.h>
-#if defined(MAGIC)
-#undef MAGIC
-#endif
-#endif
-
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif


### PR DESCRIPTION
It appears that `HAVE_CPIO_H` was used to undefine `cpio.h`'s `MAGIC` global variable. While examining our code, it appears that we also declare `MAGIC` but namespace it properly, meaning that it is unlikely that we will see a conflict. Compiling this code shows no shadowing warnings. 

No code in TS directly includes `cpio.h` 