### PR TITLE
Obliterate Stripe::reset_agg_buf_pos

### DIFF
--- a/include/iocore/cache/AggregateWriteBuffer.h
+++ b/include/iocore/cache/AggregateWriteBuffer.h
@@ -53,6 +53,22 @@ public:
   AggregateWriteBuffer(AggregateWriteBuffer &&other)            = delete;
   AggregateWriteBuffer &operator=(AggregateWriteBuffer &&other) = delete;
 
+  /**
+   * Flush the internal buffer to disk.
+   *
+   * This method should be called during shutdown. It must not be called
+   * during regular operation.
+   *
+   * Flushing the buffer only writes the buffer to disk; it does not
+   * modify the contents of the buffer. To reset the buffer, call
+   * reset_buffer_pos().
+   *
+   * @param fd File descriptor to write to.
+   * @param write_pos The offset at which to write the buffer data.
+   * @return Returns true if all bytes were flushed, otherwise false.
+   */
+  bool flush(int fd, off_t write_pos) const;
+
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
   char *get_buffer();
   int get_buffer_pos() const;

--- a/src/iocore/cache/AggregateWriteBuffer.cc
+++ b/src/iocore/cache/AggregateWriteBuffer.cc
@@ -1,0 +1,40 @@
+/** @file
+
+  A brief file description
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "iocore/cache/AggregateWriteBuffer.h"
+
+#include "iocore/aio/AIO_fault_injection.h"
+
+#include "tscore/ink_assert.h"
+#include "tscore/ink_platform.h"
+
+bool
+AggregateWriteBuffer::flush(int fd, off_t write_pos) const
+{
+  int r = pwrite(fd, this->_buffer, this->_buffer_pos, write_pos);
+  if (r != this->_buffer_pos) {
+    ink_assert(!"flushing agg buffer failed");
+    return false;
+  }
+  return true;
+}

--- a/src/iocore/cache/CMakeLists.txt
+++ b/src/iocore/cache/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 add_library(
   inkcache STATIC
+  AggregateWriteBuffer.cc
   Cache.cc
   CacheDir.cc
   CacheDisk.cc

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -997,21 +997,7 @@ sync_cache_dir_on_shutdown()
     // dont worry about the cachevc s in the agg queue
     // directories have not been inserted for these writes
     if (vol->get_agg_buf_pos()) {
-      Dbg(dbg_ctl_cache_dir_sync, "Dir %s: flushing agg buffer first", vol->hash_text.get());
-
-      // set write limit
-      vol->header->agg_pos = vol->header->write_pos + vol->get_agg_buf_pos();
-
-      int r = pwrite(vol->fd, vol->get_agg_buffer(), vol->get_agg_buf_pos(), vol->header->write_pos);
-      if (r != vol->get_agg_buf_pos()) {
-        ink_assert(!"flushing agg buffer failed");
-        continue;
-      }
-      vol->header->last_write_pos  = vol->header->write_pos;
-      vol->header->write_pos      += vol->get_agg_buf_pos();
-      ink_assert(vol->header->write_pos == vol->header->agg_pos);
-      vol->reset_agg_buf_pos();
-      vol->header->write_serial++;
+      vol->flush_aggregate_write_buffer();
     }
 
     if (buflen < dirlen) {

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -997,6 +997,7 @@ sync_cache_dir_on_shutdown()
     // dont worry about the cachevc s in the agg queue
     // directories have not been inserted for these writes
     if (vol->get_agg_buf_pos()) {
+      Dbg(dbg_ctl_cache_dir_sync, "Dir %s: flushing agg buffer first", vol->hash_text.get());
       vol->flush_aggregate_write_buffer();
     }
 

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -43,8 +43,6 @@
 #define STRIPE_MAGIC                 0xF1D0F00D
 #define START_BLOCKS                 16 // 8k, STORE_BLOCK_SIZE
 #define START_POS                    ((off_t)START_BLOCKS * CACHE_BLOCK_SIZE)
-#define AGG_SIZE                     (4 * 1024 * 1024)   // 4MB
-#define AGG_HIGH_WATER               (AGG_SIZE / 2)      // 2MB
 #define EVACUATION_SIZE              (2 * AGG_SIZE)      // 8MB
 #define STRIPE_BLOCK_SIZE            (1024 * 1024 * 128) // 128MB
 #define MIN_STRIPE_SIZE              STRIPE_BLOCK_SIZE
@@ -281,9 +279,10 @@ public:
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
   char *get_agg_buffer();
   int get_agg_buf_pos() const;
-  void reset_agg_buf_pos();
   int get_agg_todo_size() const;
   void add_agg_todo(int size);
+
+  bool flush_aggregate_write_buffer();
 
 private:
   void _clear_init();
@@ -577,12 +576,6 @@ inline int
 Stripe::get_agg_buf_pos() const
 {
   return this->_write_buffer.get_buffer_pos();
-}
-
-inline void
-Stripe::reset_agg_buf_pos()
-{
-  this->_write_buffer.reset_buffer_pos();
 }
 
 inline int

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -32,7 +32,6 @@ namespace
 {
 
 DbgCtl dbg_ctl_cache_init{"cache_init"};
-DbgCtl dbg_ctl_cache_dir_sync{"dir_sync"};
 
 // This is the oldest version number that is still usable.
 short int const CACHE_DB_MAJOR_VERSION_COMPATIBLE = 21;
@@ -922,8 +921,6 @@ Stripe::_init_data()
 bool
 Stripe::flush_aggregate_write_buffer()
 {
-  Dbg(dbg_ctl_cache_dir_sync, "Dir %s: flushing agg buffer first", this->hash_text.get());
-
   // set write limit
   this->header->agg_pos = this->header->write_pos + this->_write_buffer.get_buffer_pos();
 

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -927,9 +927,7 @@ Stripe::flush_aggregate_write_buffer()
   // set write limit
   this->header->agg_pos = this->header->write_pos + this->_write_buffer.get_buffer_pos();
 
-  int r = pwrite(this->fd, this->_write_buffer.get_buffer(), this->_write_buffer.get_buffer_pos(), this->header->write_pos);
-  if (r != this->_write_buffer.get_buffer_pos()) {
-    ink_assert(!"flushing agg buffer failed");
+  if (!this->_write_buffer.flush(this->fd, this->header->write_pos)) {
     return false;
   }
   this->header->last_write_pos  = this->header->write_pos;


### PR DESCRIPTION
There was only one use of `Stripe::reset_agg_buf_pos`, and this gets rid of it by moving the code to flush the aggregate buffer from CacheDir.cc into Stripe.cc and AggregateWriteBuffer.cc.

I also removed two `#define`s from P_CacheVol.h that were supposed to be moved to AggregateWriteBuffer.h, but got left in due to a rebase mistake and were duplicated in both places.