### PR TITLE
stek_share: resize instead of reserve

### DIFF
--- a/plugins/experimental/stek_share/common.cc
+++ b/plugins/experimental/stek_share/common.cc
@@ -36,7 +36,7 @@ std::string
 hex_str(std::string const &str)
 {
   std::string hex_str;
-  hex_str.reserve(str.size() * 2);
+  hex_str.resize(str.size() * 2);
   for (unsigned long int i = 0; i < str.size(); ++i) {
     unsigned char c    = str.at(i);
     hex_str[i * 2]     = hex_chars[(c & 0xF0) >> 4];


### PR DESCRIPTION
stek_share indexes into an offset on a string that it reserved space for, but indexing past size() is undefined behavior. This would result in crashing on some systems. reszing adjusts the length which satisfies the indexing requirement.