### PR TITLE
stek_share: fix memcp usage

### DIFF
--- a/plugins/experimental/stek_share/state_machine.h
+++ b/plugins/experimental/stek_share/state_machine.h
@@ -80,7 +80,7 @@ public:
 
     received_stek_ = false;
 
-    if (std::memcmp(curr_stek, &stek_, SSL_TICKET_KEY_SIZE != 0)) {
+    if (std::memcmp(curr_stek, &stek_, SSL_TICKET_KEY_SIZE) != 0) {
       std::memcpy(curr_stek, &stek_, SSL_TICKET_KEY_SIZE);
       return true;
     }


### PR DESCRIPTION
A closing parenthesis was out of place in a memcmp in the stek_share plugin. This fixes the closing of the memcmp.