### PR TITLE
cmake: Add -fPIC when checking for symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,7 @@ include(ConfigureTransparentProxy)
 include(find_ccache)
 
 # Check for IO faculties
+set(CMAKE_REQUIRED_FLAGS -fPIC)
 check_symbol_exists(IN6_IS_ADDR_UNSPECIFIED "netinet/in.h" TS_HAS_IN6_IS_ADDR_UNSPECIFIED)
 check_symbol_exists(IP_TOS "netinet/ip.h" TS_HAS_IP_TOS)
 check_symbol_exists(SO_MARK "sys/socket.h" TS_HAS_SO_MARK)
@@ -465,6 +466,7 @@ check_symbol_exists(SSL_get_all_async_fds openssl/ssl.h TS_USE_TLS_ASYNC)
 check_symbol_exists(TLS1_3_VERSION "openssl/ssl.h" TS_USE_TLS13)
 check_symbol_exists(MD5_Init "openssl/md5.h" HAVE_MD5_INIT)
 check_symbol_exists(sysctlbyname "sys/sysctl.h" HAVE_SYSCTLBYNAME)
+unset(CMAKE_REQUIRED_FLAGS)
 
 set(HAVE_SSL_READ_EARLY_DATA ${TS_HAS_TLS_EARLY_DATA})
 


### PR DESCRIPTION
I noticed that on ubuntu:23:04 with ci-ubuntu, the symbol checks for getresuid and the like were failing because the compilation of the simple programs to check the symbols failed with complaints saying that the code had to be compiled with PIC enabled. This caused cmake to incorrectly think that these symbols didn't exist when in fact they did. Adding -fPIC for the symbol checks fixed this.