### PR TITLE
Add missing Openssl depends

### DIFF
--- a/src/cripts/CMakeLists.txt
+++ b/src/cripts/CMakeLists.txt
@@ -27,7 +27,7 @@ file(GLOB CPP_FILES ${PROJECT_SOURCE_DIR}/src/cripts/*.cc ${PROJECT_SOURCE_DIR}/
 add_library(cripts SHARED ${CPP_FILES})
 add_library(ts::cripts ALIAS cripts)
 
-target_link_libraries(cripts libswoc::libswoc fmt::fmt PkgConfig::PCRE2)
+target_link_libraries(cripts libswoc::libswoc fmt::fmt PkgConfig::PCRE2 OpenSSL::Crypto)
 
 set_target_properties(
   cripts


### PR DESCRIPTION
The only item here I am concerned about if if you pull in your own libfmt, by default it does not build a .so, only a static .a. This will lot link as it is not built with -fPic. I am not sure if there is a way to tell this to use a shared library for the fmt library, Other than that this adds the missing depends on OpenSSL.