### PR TITLE
MPTCP warnings and clean up

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4965,6 +4965,7 @@ Sockets
         PACKET_TOS (32)
         TCP_NOTSENT_LOWAT (64)
 
+   Note: TCP_FASTOPEN and TCP_NOTSENT_LOWAT socket options not valid when mptcp is enabled
 .. note::
 
    This is a bitmask and you need to decide what bits to set.  Therefore,
@@ -5019,6 +5020,7 @@ Sockets
 .. ts:cv:: CONFIG proxy.config.net.sock_mss_in INT 0
 
    Same as the command line option ``--accept_mss`` that sets the MSS for all incoming requests.
+   Note: TCP_MAXSEG socket option not valid when mptcp is enabled
 
 .. ts:cv:: CONFIG proxy.config.net.sock_packet_mark_in INT 0x0
 

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -183,15 +183,6 @@ using in_addr_t = unsigned int;
        //                 windows-260,etc)
 #endif
 
-// This is a little bit of a hack for now, until MPTCP has landed upstream in Linux land.
-#ifndef MPTCP_ENABLED
-#if defined(__linux__)
-#define MPTCP_ENABLED 42
-#else
-#define MPTCP_ENABLED 0
-#endif
-#endif
-
 // If kernel headers do not support IPPROTO_MPTCP definition
 #ifndef IPPROTO_MPTCP
 #define IPPROTO_MPTCP 262

--- a/src/iocore/net/P_UnixNetVConnection.h
+++ b/src/iocore/net/P_UnixNetVConnection.h
@@ -306,17 +306,6 @@ UnixNetVConnection::set_local_addr()
 inline void
 UnixNetVConnection::set_mptcp_state()
 {
-  int mptcp_enabled      = -1;
-  int mptcp_enabled_size = sizeof(mptcp_enabled);
-
-  if (0 == safe_getsockopt(con.fd, IPPROTO_TCP, MPTCP_ENABLED, (char *)&mptcp_enabled, &mptcp_enabled_size)) {
-    Dbg(_dbg_ctl_socket_mptcp, "MPTCP socket state: %d", mptcp_enabled);
-    mptcp_state = (mptcp_enabled > 0);
-    return;
-  } else {
-    Dbg(_dbg_ctl_socket_mptcp, "MPTCP failed getsockopt(MPTCP_ENABLED): %s", strerror(errno));
-  }
-
 #if defined(HAVE_STRUCT_MPTCP_INFO_SUBFLOWS) && defined(MPTCP_INFO) && MPTCP_INFO == 1
   struct mptcp_info minfo;
   int minfo_len = sizeof(minfo);

--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -102,17 +102,12 @@ SessionProtocolSet DEFAULT_QUIC_SESSION_PROTOCOL_SET;
 static bool
 mptcp_supported()
 {
-  ats_scoped_fd fd(::open("/proc/sys/net/mptcp/mptcp_enabled", O_RDONLY));
-  // Newer kernel mptcp config
-  ats_scoped_fd fd_new(::open("/proc/sys/net/mptcp/enabled", O_RDONLY));
+  ats_scoped_fd fd(::open("/proc/sys/net/mptcp/enabled", O_RDONLY));
   int value = 0;
-  TextBuffer buffer(16);
 
   if (fd > 0) {
+    TextBuffer buffer(16);
     buffer.slurp(fd.get());
-    value = atoi(buffer.bufPtr());
-  } else if (fd_new > 0) {
-    buffer.slurp(fd_new.get());
     value = atoi(buffer.bufPtr());
   }
 


### PR DESCRIPTION
- Remove reference of old MPTCP API
- add warning with TCP socket options that are not supported when MPTCP is enabled
   - provide doc on which sockets are allowed