### PR TITLE
Remove HAVE_FLOAT_H build var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,6 @@ include(CheckSourceCompiles)
 include(CheckStructHasMember)
 
 check_include_file(dlfcn.h HAVE_DLFCN_H)
-check_include_file(float.h HAVE_FLOAT_H)
 check_include_file(stdlib.h HAVE_STDLIB_H)
 check_include_file(stdint.h HAVE_STDINT_H)
 check_include_file(ifaddrs.h HAVE_IFADDRS_H)

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -40,7 +40,6 @@
 #cmakedefine HAVE_NCURSES_CURSES_H 1
 #cmakedefine HAVE_NCURSES_NCURSES_H 1
 #cmakedefine HAVE_DLFCN_H 1
-#cmakedefine HAVE_FLOAT_H 1
 #cmakedefine HAVE_LZMA_H 1
 #cmakedefine HAVE_STDLIB_H 1
 #cmakedefine HAVE_STDINT_H 1

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -161,9 +161,7 @@ using in_addr_t = unsigned int;
 #include <dlfcn.h>
 #endif
 
-#ifdef HAVE_FLOAT_H
 #include <float.h> // NOLINT(modernize-deprecated-headers)
-#endif
 
 #ifdef HAVE_SYS_SYSMACROS_H
 #include <sys/sysmacros.h>


### PR DESCRIPTION
Replace automake-style `HAVE_INCLUDE_H` compile flags with `#if __has_include` preprocessor directives.

This PR does so for `float.h` (which should always exist as a standard header, and thus all guards are removed). 