### PR TITLE
Remove HAVE_ARPA_*_H build vars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,9 +237,7 @@ check_include_file(netinet/tcp.h HAVE_NETINET_TCP_H)
 check_include_file(netinet/ip.h HAVE_NETINET_IP_H)
 check_include_file(netinet/ip_icmp.h HAVE_NETINET_IP_ICMP_H)
 check_include_file(netdb.h HAVE_NETDB_H)
-check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
-check_include_file(arpa/nameser.h HAVE_ARPA_NAMESER_H)
-check_include_file(arpa/nameser_compat.h HAVE_ARPA_NAMESER_COMPAT_H)
+check_include_file(endian.h HAVE_ENDIAN_H)
 
 # Find libraries
 if(ENABLE_CRIPTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,9 @@ check_include_file(netinet/tcp.h HAVE_NETINET_TCP_H)
 check_include_file(netinet/ip.h HAVE_NETINET_IP_H)
 check_include_file(netinet/ip_icmp.h HAVE_NETINET_IP_ICMP_H)
 check_include_file(netdb.h HAVE_NETDB_H)
-check_include_file(endian.h HAVE_ENDIAN_H)
+check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
+check_include_file(arpa/nameser.h HAVE_ARPA_NAMESER_H)
+check_include_file(arpa/nameser_compat.h HAVE_ARPA_NAMESER_COMPAT_H)
 
 # Find libraries
 if(ENABLE_CRIPTS)

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -67,9 +67,7 @@
 #cmakedefine HAVE_NETINET_IP_ICMP_H 1
 #cmakedefine HAVE_NETINET_IP_H 1
 #cmakedefine HAVE_NETDB_H 1
-#cmakedefine HAVE_ARPA_INET_H 1
-#cmakedefine HAVE_ARPA_NAMESER_H 1
-#cmakedefine HAVE_ARPA_NAMESER_COMPAT_H 1
+#cmakedefine HAVE_ENDIAN_H 1
 #cmakedefine HAVE_MALLOC_USABLE_SIZE 1
 #cmakedefine HAVE_MCHECK_PEDANTIC 1
 #cmakedefine HAVE_POSIX_FADVISE 1

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -67,7 +67,9 @@
 #cmakedefine HAVE_NETINET_IP_ICMP_H 1
 #cmakedefine HAVE_NETINET_IP_H 1
 #cmakedefine HAVE_NETDB_H 1
-#cmakedefine HAVE_ENDIAN_H 1
+#cmakedefine HAVE_ARPA_INET_H 1
+#cmakedefine HAVE_ARPA_NAMESER_H 1
+#cmakedefine HAVE_ARPA_NAMESER_COMPAT_H 1
 #cmakedefine HAVE_MALLOC_USABLE_SIZE 1
 #cmakedefine HAVE_MCHECK_PEDANTIC 1
 #cmakedefine HAVE_POSIX_FADVISE 1

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -86,15 +86,9 @@ struct ifafilt;
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
-#ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
-#endif
-#ifdef HAVE_ARPA_NAMESER_H
 #include <arpa/nameser.h>
-#endif
-#ifdef HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
-#endif
 
 #include <signal.h> // NOLINT(modernize-deprecated-headers)
 

--- a/src/tscore/ink_res_init.cc
+++ b/src/tscore/ink_res_init.cc
@@ -76,9 +76,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
-#ifdef HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
-#endif
 #include <cstdio>
 #include <cctype>
 #include <resolv.h>

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -71,9 +71,7 @@
 #include <sys/param.h>
 #include <netinet/in.h>
 #include <arpa/nameser.h>
-#ifdef HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
-#endif
 #include <netdb.h>
 #include <resolv.h>
 #include <cstdio>


### PR DESCRIPTION
Replace automake-style `HAVE_INCLUDE_H` compile flags with `#if __has_include` preprocessor directives.

This PR does so for `arpa/*.h`  (which should always exist as UNIX standard internet headers, and thus all guards are removed). 