### PR TITLE
Add Errata support to YAML configuration support (promoted from IPAllow)

### DIFF
--- a/include/tscpp/util/YamlCfg.h
+++ b/include/tscpp/util/YamlCfg.h
@@ -27,6 +27,7 @@
 #include <string_view>
 
 #include <yaml-cpp/yaml.h>
+#include <swoc/bwf_fwd.h>
 
 namespace ts
 {
@@ -81,3 +82,9 @@ namespace Yaml
 
 } // end namespace Yaml
 } // end namespace ts
+
+namespace swoc
+{
+// This needs to be in namespace "swoc" or "YAML" or ADL doesn't find the overload.
+extern BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, YAML::Mark const &mark);
+} // namespace swoc

--- a/src/proxy/IPAllow.cc
+++ b/src/proxy/IPAllow.cc
@@ -36,7 +36,7 @@
 #include "swoc/bwf_ex.h"
 #include "swoc/bwf_ip.h"
 
-#include "yaml-cpp/yaml.h"
+#include "tscpp/util/YamlCfg.h"
 
 using swoc::TextView;
 
@@ -49,13 +49,6 @@ BufferWriter &
 bwformat(BufferWriter &w, Spec const &spec, IpAllow const *obj)
 {
   return w.print("{}[{}]", obj->MODULE_NAME, obj->get_config_file().c_str());
-}
-
-// This needs to be in namespace "swoc" or "YAML" or ADL doesn't find the overload.
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, YAML::Mark const &mark)
-{
-  return w.print("Line {}", mark.line);
 }
 
 } // namespace swoc

--- a/src/tscpp/util/YamlCfg.cc
+++ b/src/tscpp/util/YamlCfg.cc
@@ -26,6 +26,8 @@
 #include <algorithm>
 #include <string>
 
+#include <tscpp/util/ts_bw_format.h>
+
 #include <tscore/ink_assert.h>
 
 namespace ts
@@ -81,3 +83,13 @@ namespace Yaml
 
 } // end namespace Yaml
 } // end namespace ts
+
+// This needs to be in namespace "swoc" or "YAML" or ADL doesn't find the overload.
+namespace swoc
+{
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, YAML::Mark const &mark)
+{
+  return w.print("Line {}", mark.line);
+}
+} // namespace swoc


### PR DESCRIPTION
Support printing `YAML::Mark` in `Errata` instances, which makes parsing error reporting easier.