### PR TITLE
For vscode users, automatically use ms-vscode.cmake-tools

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -59,7 +59,8 @@
             "compilerPath": "/usr/bin/clang",
             "cStandard": "c11",
             "cppStandard": "c++17",
-            "compilerArgs": []
+            "compilerArgs": [],
+            "configurationProvider": "ms-vscode.cmake-tools"
         },
         {
             "name": "Linux",


### PR DESCRIPTION
As we move to CMake by default, perhaps it would be useful for VSCode users to automatically set the configuration provider to `ms-vscode.cmake-tools`? 

@dragon512 