### PR TITLE
trafic_crashlog: Moving the removed ATS backtrace logs.

### DIFF
--- a/cmake/Findunwind.cmake
+++ b/cmake/Findunwind.cmake
@@ -28,8 +28,9 @@
 #     unwind::unwind
 #
 
-find_library(unwind_LIBRARY NAMES unwind)
-find_path(unwind_INCLUDE_DIR NAMES libunwind.h libunwind/libunwind.h)
+find_library(unwind_ptrace_LIBRARY NAMES unwind-ptrace)
+find_library(unwind_generic_LIBRARY NAMES unwind-generic)
+find_path(unwind_INCLUDE_DIR NAMES libunwind.h)
 
 mark_as_advanced(unwind_FOUND unwind_LIBRARY unwind_INCLUDE_DIR)
 
@@ -43,5 +44,5 @@ endif()
 if(unwind_FOUND AND NOT TARGET unwind::unwind)
   add_library(unwind::unwind INTERFACE IMPORTED)
   target_include_directories(unwind::unwind INTERFACE ${unwind_INCLUDE_DIRS})
-  target_link_libraries(unwind::unwind INTERFACE "${unwind_LIBRARY}")
+  target_link_libraries(unwind::unwind INTERFACE "${unwind_ptrace_LIBRARY}" "${unwind_generic_LIBRARY}")
 endif()

--- a/src/traffic_crashlog/CMakeLists.txt
+++ b/src/traffic_crashlog/CMakeLists.txt
@@ -15,8 +15,12 @@
 #
 #######################
 
-add_executable(traffic_crashlog procinfo.cc traffic_crashlog.cc)
+add_executable(traffic_crashlog procinfo.cc backtrace.cc traffic_crashlog.cc)
 
 target_link_libraries(traffic_crashlog PRIVATE ts::inkevent ts::records ts::tscore ts::tsapicore)
+
+if(TS_USE_REMOTE_UNWINDING)
+  target_link_libraries(traffic_crashlog PRIVATE unwind::unwind)
+endif()
 
 install(TARGETS traffic_crashlog)

--- a/src/traffic_crashlog/backtrace.cc
+++ b/src/traffic_crashlog/backtrace.cc
@@ -1,0 +1,208 @@
+/** @file
+
+  backtrace.cc
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+/****************************************************************************
+
+  backtrace.cc
+
+  Functions to generate backtrace from a TS process.
+
+ ****************************************************************************/
+#include "tscore/ink_config.h"
+
+#if TS_USE_REMOTE_UNWINDING
+#include "tscore/Diags.h"
+
+#include "tscore/TextBuffer.h"
+#include <string.h>
+#include <libunwind.h>
+#include <libunwind-ptrace.h>
+#include <sys/ptrace.h>
+#include <cxxabi.h>
+#include <vector>
+
+namespace
+{
+using threadlist = std::vector<pid_t>;
+
+static threadlist
+threads_for_process(pid_t proc)
+{
+  DIR *dir             = nullptr;
+  struct dirent *entry = nullptr;
+
+  char path[64];
+  threadlist threads;
+
+  if (snprintf(path, sizeof(path), "/proc/%ld/task", static_cast<long>(proc)) >= static_cast<int>(sizeof(path))) {
+    goto done;
+  }
+
+  dir = opendir(path);
+  if (dir == nullptr) {
+    goto done;
+  }
+
+  while ((entry = readdir(dir))) {
+    pid_t threadid;
+
+    if (isdot(entry->d_name) || isdotdot(entry->d_name)) {
+      continue;
+    }
+
+    threadid = strtol(entry->d_name, nullptr, 10);
+    if (threadid > 0) {
+      threads.push_back(threadid);
+      Debug("backtrace", "found thread %ld\n", (long)threadid);
+    }
+  }
+
+done:
+  if (dir) {
+    closedir(dir);
+  }
+
+  return threads;
+}
+
+static void
+backtrace_for_thread(pid_t threadid, TextBuffer &text)
+{
+  int status;
+  unw_addr_space_t addr_space = nullptr;
+  unw_cursor_t cursor;
+  void *ap       = nullptr;
+  pid_t target   = -1;
+  unsigned level = 0;
+
+  // First, attach to the child, causing it to stop.
+  status = ptrace(PTRACE_ATTACH, threadid, 0, 0);
+  if (status < 0) {
+    Debug("backtrace", "ptrace(ATTACH, %ld) -> %s (%d)\n", (long)threadid, strerror(errno), errno);
+    return;
+  }
+
+  // Wait for it to stop (XXX should be a timed wait ...)
+  target = waitpid(threadid, &status, __WALL | WUNTRACED);
+  Debug("backtrace", "waited for target %ld, found PID %ld, %s\n", (long)threadid, (long)target,
+        WIFSTOPPED(status) ? "STOPPED" : "???");
+  if (target < 0) {
+    goto done;
+  }
+
+  ap = _UPT_create(threadid);
+  Debug("backtrace", "created UPT %p", ap);
+  if (ap == nullptr) {
+    goto done;
+  }
+
+  addr_space = unw_create_addr_space(&_UPT_accessors, 0 /* byteorder */);
+  Debug("backtrace", "created address space %p\n", addr_space);
+  if (addr_space == nullptr) {
+    goto done;
+  }
+
+  status = unw_init_remote(&cursor, addr_space, ap);
+  Debug("backtrace", "unw_init_remote(...) -> %d\n", status);
+  if (status != 0) {
+    goto done;
+  }
+
+  while (unw_step(&cursor) > 0) {
+    unw_word_t ip;
+    unw_word_t offset;
+    char buf[256];
+
+    unw_get_reg(&cursor, UNW_REG_IP, &ip);
+
+    if (unw_get_proc_name(&cursor, buf, sizeof(buf), &offset) == 0) {
+      int status;
+      char *name = abi::__cxa_demangle(buf, nullptr, nullptr, &status);
+      text.format("%-4u 0x%016llx %s + %p\n", level, static_cast<unsigned long long>(ip), name ? name : buf, (void *)offset);
+      free(name);
+    } else {
+      text.format("%-4u 0x%016llx 0x0 + %p\n", level, static_cast<unsigned long long>(ip), (void *)offset);
+    }
+
+    ++level;
+  }
+
+done:
+  if (addr_space) {
+    unw_destroy_addr_space(addr_space);
+  }
+
+  if (ap) {
+    _UPT_destroy(ap);
+  }
+
+  status = ptrace(PTRACE_DETACH, target, NULL, NULL);
+  Debug("backtrace", "ptrace(DETACH, %ld) -> %d (errno %d)\n", (long)target, status, errno);
+}
+} // namespace
+int
+ServerBacktrace(unsigned /* options */, int pid, char **trace)
+{
+  *trace = nullptr;
+
+  threadlist threads(threads_for_process(pid));
+  TextBuffer text(0);
+
+  Debug("backtrace", "tracing %zd threads for traffic_server PID %ld\n", threads.size(), (long)pid);
+
+  for (auto threadid : threads) {
+    Debug("backtrace", "tracing thread %ld\n", (long)threadid);
+    // Get the thread name using /proc/PID/comm
+    ats_scoped_fd fd;
+    char threadname[128];
+
+    snprintf(threadname, sizeof(threadname), "/proc/%ld/comm", static_cast<long>(threadid));
+    fd = open(threadname, O_RDONLY);
+    if (fd >= 0) {
+      text.format("Thread %ld, ", static_cast<long>(threadid));
+      text.readFromFD(fd);
+      text.chomp();
+    } else {
+      text.format("Thread %ld", static_cast<long>(threadid));
+    }
+
+    text.format(":\n");
+
+    backtrace_for_thread(threadid, text);
+    text.format("\n");
+  }
+
+  *trace = text.release();
+  return 0;
+}
+
+#else /* TS_USE_REMOTE_UNWINDING */
+
+int
+ServerBacktrace(unsigned /* options */, int pid, char **trace)
+{
+  *trace = nullptr;
+  return -1;
+}
+
+#endif


### PR DESCRIPTION
Moving the removed ATS backtrace logs from traffic_manager to traffic_crashlog.


```
Version:            Traffic Server 10.0.0
System Version:     Linux x86_64 #83~20.04.1-Ubuntu SMP Wed Jun 21 20:23:31 UTC 2023 5.15.0-76-generic
Date:               Fri, 17 Nov 2023 10:42:12 +0100

No target signal information

No target CPU registers

Thread 721278, [TS_MAIN]:
0    0x000055b8be517318 crash_logger_invoke(int, siginfo_t*, void*) + 0xab
1    0x00007f48c8a69420 funlockfile + 0x60
2    0x00007f48c893e23f clock_nanosleep + 0xdf
3    0x00007f48c8943ec7 nanosleep + 0x17
4    0x00007f48c8943dfe sleep + 0x3e
5    0x000055b8be52ce11 main + 0x2242
6    0x00007f48c8885083 __libc_start_main + 0xf3
7    0x000055b8be51677e _start + 0x2e

Thread 721280, traffic_server:
0    0x000055b8be98a485 bool (anonymous namespace)::poll_on_socket<rpc::comm::IPCSocketServer::poll_for_new_client(std::chrono::duration<long, std::ratio<1l, 1000l> >) const::{lambda(int)#1}&>(rpc::comm::IPCSocketServer::poll_for_new_client(std::chrono::duration<long, std::ratio<1l, 1000l> >) const::{lambda(int)#1}&, std::chrono::duration<long, std::ratio<1l, 1000l> >, int) + 0x51
1    0x000055b8be988e48 rpc::comm::IPCSocketServer::poll_for_new_client(std::chrono::duration<long, std::ratio<1l, 1000l> >) const + 0x48
2    0x000055b8be988f5b rpc::comm::IPCSocketServer::run() + 0xc5
3    0x000055b8be9872b8 rpc::RPCServer::run_thread(void*) + 0x6a
4    0x00007f48c8a5d609 start_thread + 0xd9
5    0x00007f48c8980133 clone + 0x43

Thread 721281, [ET_NET 0]:
0    0x000055b8be930fe3 PollCont::do_poll(long) + 0x157
1    0x000055b8be92dbfa NetHandler::waitForActivity(long) + 0x92
2    0x000055b8be973f24 EThread::execute_regular() + 0x446
3    0x000055b8be9740b1 EThread::execute() + 0xe3
4    0x000055b8be972b76 spawn_thread_internal(void*) + 0x81
5    0x00007f48c8a5d609 start_thread + 0xd9
6    0x00007f48c8980133 clone + 0x43

Thread 721282, [ET_TASK 0]:
0    0x000055b8be971de3 ink_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, timespec*) + 0x2b
1    0x000055b8be972010 ProtectedQueue::wait(long) + 0x86
2    0x000055b8be97464e EThread::DefaultTailHandler::waitForActivity(long) + 0x34
3    0x000055b8be973f24 EThread::execute_regular() + 0x446
4    0x000055b8be9740b1 EThread::execute() + 0xe3
5    0x000055b8be972b76 spawn_thread_internal(void*) + 0x81
6    0x00007f48c8a5d609 start_thread + 0xd9
7    0x00007f48c8980133 clone + 0x43

Thread 721283, [ET_TASK 1]:
0    0x000055b8be971de3 ink_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, timespec*) + 0x2b
1    0x000055b8be972010 ProtectedQueue::wait(long) + 0x86
2    0x000055b8be97464e EThread::DefaultTailHandler::waitForActivity(long) + 0x34
3    0x000055b8be973f24 EThread::execute_regular() + 0x446
4    0x000055b8be9740b1 EThread::execute() + 0xe3
5    0x000055b8be972b76 spawn_thread_internal(void*) + 0x81
6    0x00007f48c8a5d609 start_thread + 0xd9
7    0x00007f48c8980133 clone + 0x43
...
```