### PR TITLE
Add CMAKE_COLOR_DIAGNOSTICS to the dev preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,6 +68,7 @@
       "binaryDir": "${sourceDir}/build-${presetName}",
       "generator": "Ninja",
       "cacheVariables": {
+        "CMAKE_COLOR_DIAGNOSTICS": "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "CMAKE_INSTALL_PREFIX": "/tmp/ats-dev"
       }


### PR DESCRIPTION
I would like pretty colors in Ninja's build output. 