### PR TITLE
stek_share: fix osx builds for undefined symbols

### DIFF
--- a/plugins/experimental/stek_share/CMakeLists.txt
+++ b/plugins/experimental/stek_share/CMakeLists.txt
@@ -22,3 +22,8 @@ if(nuraft_FOUND)
 else()
   message(STATUS "skipping stek_share plugin (missing nuraft)")
 endif()
+
+# This was added by add_atsplugin, but one of the modules above must be overriding it.
+if(APPLE)
+  set(CMAKE_MODULE_LINKER_FLAGS "-undefined dynamic_lookup")
+endif()


### PR DESCRIPTION
The add_atsplugin cmake function attempts to add `-undefined dynamic_lookup` for osx builds, but that is being overridden for the stek_share module. This adds it back in explicitly for that plugin. This fixes the stek_share builds for osx.