### PR TITLE
stek_share: fix pthread_t print format warning

### DIFF
--- a/plugins/experimental/stek_share/stek_share.cc
+++ b/plugins/experimental/stek_share/stek_share.cc
@@ -422,7 +422,7 @@ stek_updater(void *arg)
   ::pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);
   ::pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, nullptr);
 
-  Dbg(dbg_ctl, "Starting STEK updater thread: %lu", ::pthread_self());
+  Dbg(dbg_ctl, "Starting STEK updater thread");
 
   while (!plugin_threads.is_shut_down()) {
     ssl_ticket_key_t curr_stek;
@@ -538,7 +538,7 @@ stek_updater(void *arg)
     stek_share_server.config_reloading = false;
   }
 
-  Dbg(dbg_ctl, "Stopping STEK updater thread: %lu", ::pthread_self());
+  Dbg(dbg_ctl, "Stopping STEK updater thread");
 
   return nullptr;
 }


### PR DESCRIPTION
For osx, pthread_t is a void* type rather than an int type. Thus on these systems a warning was emitting about an inappropriate format specifier for the pointer type argument. Talking with Fei, it looks like we can simply remove that ID because it's not that helpful to have it in the debug output.