### PR TITLE
ConnectionTracker: Remove queue implementation

### DIFF
--- a/include/iocore/net/ConnectionTracker.h
+++ b/include/iocore/net/ConnectionTracker.h
@@ -169,10 +169,6 @@ public:
     int reserve();
     /// Release a connection reservation.
     void release();
-    /// Reserve a queue / retry slot.
-    int enqueue();
-    /// Release a block
-    void dequeue();
     /// Note blocking a transaction.
     void blocked();
     /// Clear all reservations.
@@ -355,27 +351,10 @@ ConnectionTracker::TxnState::drop()
   return std::move(_g);
 }
 
-inline int
-ConnectionTracker::TxnState::enqueue()
-{
-  _queued_p = true;
-  return ++_g->_in_queue;
-}
-
-inline void
-ConnectionTracker::TxnState::dequeue()
-{
-  if (_queued_p) {
-    _queued_p = false;
-    --_g->_in_queue;
-  }
-}
-
 inline void
 ConnectionTracker::TxnState::clear()
 {
   if (_g) {
-    this->dequeue();
     this->release();
     _g = nullptr;
   }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -5884,9 +5884,6 @@ HttpSM::handle_post_failure()
 void
 HttpSM::handle_http_server_open()
 {
-  // The request is now not queued. This is important because server retries reuse the t_state.
-  t_state.outbound_conn_track_state.dequeue();
-
   // [bwyatt] applying per-transaction OS netVC options here
   //          IFF they differ from the netVC's current options.
   //          This should keep this from being redundant on a


### PR DESCRIPTION
Connection count queueing functionality was removed via #7302. This removes some dead code that was still associated with that now-removed feature.