### PR TITLE
Remove Stripe::add_agg_todo

### DIFF
--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -282,6 +282,7 @@ public:
   int get_agg_todo_size() const;
   void add_agg_todo(int size);
 
+  bool add_writer(CacheVC *vc);
   bool flush_aggregate_write_buffer();
 
 private:

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -919,6 +919,31 @@ Stripe::_init_data()
 }
 
 bool
+Stripe::add_writer(CacheVC *vc)
+{
+  ink_assert(vc);
+  this->add_agg_todo(vc->agg_len);
+  bool agg_error = (vc->agg_len > AGG_SIZE || vc->header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
+                    (!vc->f.readers && (this->get_agg_todo_size() > cache_config_agg_write_backlog + AGG_SIZE) && vc->write_len));
+#ifdef CACHE_AGG_FAIL_RATE
+  agg_error = agg_error || ((uint32_t)vc->mutex->thread_holding->generator.random() < (uint32_t)(UINT_MAX * CACHE_AGG_FAIL_RATE));
+#endif
+
+  if (agg_error) {
+    this->add_agg_todo(-vc->agg_len);
+  } else {
+    ink_assert(vc->agg_len <= AGG_SIZE);
+    if (vc->f.evac_vector) {
+      this->get_pending_writers().push(vc);
+    } else {
+      this->get_pending_writers().enqueue(vc);
+    }
+  }
+
+  return !agg_error;
+}
+
+bool
 Stripe::flush_aggregate_write_buffer()
 {
   // set write limit

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -922,15 +922,17 @@ bool
 Stripe::add_writer(CacheVC *vc)
 {
   ink_assert(vc);
-  this->add_agg_todo(vc->agg_len);
-  bool agg_error = (vc->agg_len > AGG_SIZE || vc->header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
-                    (!vc->f.readers && (this->get_agg_todo_size() > cache_config_agg_write_backlog + AGG_SIZE) && vc->write_len));
+  this->_write_buffer.add_bytes_pending_aggregation(vc->agg_len);
+  bool agg_error =
+    (vc->agg_len > AGG_SIZE || vc->header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
+     (!vc->f.readers && (this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog + AGG_SIZE) &&
+      vc->write_len));
 #ifdef CACHE_AGG_FAIL_RATE
   agg_error = agg_error || ((uint32_t)vc->mutex->thread_holding->generator.random() < (uint32_t)(UINT_MAX * CACHE_AGG_FAIL_RATE));
 #endif
 
   if (agg_error) {
-    this->add_agg_todo(-vc->agg_len);
+    this->_write_buffer.add_bytes_pending_aggregation(-vc->agg_len);
   } else {
     ink_assert(vc->agg_len <= AGG_SIZE);
     if (vc->f.evac_vector) {


### PR DESCRIPTION
I could not find a way to do this without moving any logic around. I changed the logic as minimally as possible and split it into 3 commits as follows:
- The first commit reorders some of the logic to split it apart and prepare part of it to be extracted to a new method.
- The second commit does the extraction.
- The third commit cleans up to remove duplication and get rid of `Stripe::add_agg_todo`.

The logic change was quite limited and straightforward, so I don't think this one is very risky, but please review carefully anyway. One oddity here is `CACHE_AGG_FAIL_RATE`. Is this define still used by anyone for testing? Should we be testing with it?