### PR TITLE
TS_USE_MMAP: mmap+memcopy instead pread+pwrite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1704,6 +1704,15 @@ AS_IF([test "x$enable_linux_native_aio" = "xyes"], [
 AC_MSG_RESULT([$enable_linux_native_aio])
 TS_ARG_ENABLE_VAR([use], [linux_native_aio])
 
+AC_MSG_CHECKING([enable mmap instead read/write])
+AC_ARG_ENABLE([mmap],
+  [AS_HELP_STRING([--enable-mmap], [WARNING this is experimental mmap instead read and write support @<:@default=no@:>@])],
+  [enable_mmap="${enableval}"],
+  [enable_mmap=no]
+)
+AC_MSG_RESULT([$enable_mmap])
+TS_ARG_ENABLE_VAR([use], [mmap])
+
 # Check for hwloc library.
 # If we don't find it, disable checking for header.
 use_hwloc=0

--- a/include/tscore/ink_config.h.in
+++ b/include/tscore/ink_config.h.in
@@ -78,6 +78,7 @@
 #define TS_USE_TLS_SET_CIPHERSUITES @use_tls_set_ciphersuites@
 #define TS_HAS_TLS_KEYLOGGING @has_tls_keylogging@
 #define TS_USE_LINUX_NATIVE_AIO @use_linux_native_aio@
+#define TS_USE_MMAP @use_mmap@
 #define TS_USE_REMOTE_UNWINDING @use_remote_unwinding@
 #define TS_USE_TLS_OCSP @use_tls_ocsp@
 #define TS_HAS_TLS_EARLY_DATA @has_tls_early_data@

--- a/iocore/aio/P_AIO.h
+++ b/iocore/aio/P_AIO.h
@@ -53,7 +53,11 @@ struct AIOCallbackInternal : public AIOCallback {
   AIOCallbackInternal()
   {
     memset((void *)&(this->aiocb), 0, sizeof(this->aiocb));
+#if TS_USE_MMAP
+    this->aiocb.aio_fildes = MAP_FAILED;
+#else
     this->aiocb.aio_fildes = -1;
+#endif
     SET_HANDLER(&AIOCallbackInternal::io_complete);
   }
 };
@@ -96,10 +100,14 @@ struct AIO_Reqs {
   ASLL(AIOCallbackInternal, alink) aio_temp_list;
   ink_mutex aio_mutex;
   ink_cond aio_cond;
-  int index           = 0;  /* position of this struct in the aio_reqs array */
-  int pending         = 0;  /* number of outstanding requests on the disk */
-  int queued          = 0;  /* total number of aio_todo requests */
-  int filedes         = -1; /* the file descriptor for the requests or status IO_NOT_IN_PROGRESS */
+  int index           = 0;          /* position of this struct in the aio_reqs array */
+  int pending         = 0;          /* number of outstanding requests on the disk */
+  int queued          = 0;          /* total number of aio_todo requests */
+#if TS_USE_MMAP
+  void *filedes       = MAP_FAILED; /* the file descriptor for the requests or status IO_NOT_IN_PROGRESS */
+#else
+  int filedes = -1; /* the file descriptor for the requests or status IO_NOT_IN_PROGRESS */
+#endif
   int requests_queued = 0;
 };
 

--- a/iocore/aio/test_AIO.cc
+++ b/iocore/aio/test_AIO.cc
@@ -288,6 +288,9 @@ AIO_Device::do_fd(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     io->aiocb.aio_offset     = seq_read_point;
     io->aiocb.aio_nbytes     = seq_read_size;
     io->aiocb.aio_lio_opcode = LIO_READ;
+#if TS_USE_MMAP
+    io->mutex = mutex;
+#endif
     ink_assert(ink_aio_read(io) >= 0);
     seq_read_point += seq_read_size;
     if (seq_read_point > max_offset) {

--- a/iocore/cache/Cache.cc
+++ b/iocore/cache/Cache.cc
@@ -577,7 +577,7 @@ CacheProcessor::start_internal(int flags)
   ink_assert((int)TS_EVENT_CACHE_SCAN_OPERATION_BLOCKED == (int)CACHE_EVENT_SCAN_OPERATION_BLOCKED);
   ink_assert((int)TS_EVENT_CACHE_SCAN_OPERATION_FAILED == (int)CACHE_EVENT_SCAN_OPERATION_FAILED);
   ink_assert((int)TS_EVENT_CACHE_SCAN_DONE == (int)CACHE_EVENT_SCAN_DONE);
-#if AIO_MODE == AIO_MODE_NATIVE
+#if (AIO_MODE == AIO_MODE_NATIVE) && (!TS_USE_MMAP)
   for (EThread *et : eventProcessor.active_group_threads(ET_NET)) {
     et->diskHandler = new DiskHandler();
     et->schedule_imm(et->diskHandler);
@@ -1218,11 +1218,14 @@ vol_dir_clear(Vol *d)
 {
   size_t dir_len = d->dirlen();
   vol_clear_init(d);
-
+#if TS_USE_MMAP
+  memcpy(static_cast<char *>(d->fd) + d->skip, d->raw_dir, dir_len);
+#else
   if (pwrite(d->fd, d->raw_dir, dir_len, d->skip) < 0) {
     Warning("unable to clear cache directory '%s'", d->hash_text.get());
     return -1;
   }
+#endif
   return 0;
 }
 
@@ -1241,6 +1244,9 @@ Vol::clear_dir()
   io.action           = this;
   io.thread           = AIO_CALLBACK_THREAD_ANY;
   io.then             = nullptr;
+#if TS_USE_MMAP
+  io.mutex = mutex;
+#endif
   ink_assert(ink_aio_write(&io));
   return 0;
 }
@@ -1320,6 +1326,9 @@ Vol::init(char *s, off_t blocks, off_t dir_skip, bool clear)
     aio->then             = (i < 3) ? &(init_info->vol_aio[i + 1]) : nullptr;
   }
 #if AIO_MODE == AIO_MODE_NATIVE
+#if TS_USE_MMAP
+  init_info->vol_aio->mutex = mutex;
+#endif
   ink_assert(ink_aio_readv(init_info->vol_aio));
 #else
   ink_assert(ink_aio_read(init_info->vol_aio));
@@ -1338,7 +1347,11 @@ Vol::handle_dir_clear(int event, void *data)
     if (!op->ok()) {
       Warning("unable to clear cache directory '%s'", hash_text.get());
       disk->incrErrors(op);
+    #if TS_USE_MMAP
+      fd = MAP_FAILED;
+    #else
       fd = -1;
+    #endif
     }
 
     if (op->aiocb.aio_nbytes == dir_len) {
@@ -1347,6 +1360,7 @@ Vol::handle_dir_clear(int event, void *data)
          skip + len */
       op->aiocb.aio_nbytes = ROUND_TO_STORE_BLOCK(sizeof(VolHeaderFooter));
       op->aiocb.aio_offset = skip + dir_len;
+      ink_assert(op->mutex);
       ink_assert(ink_aio_write(op));
       return EVENT_DONE;
     }
@@ -1613,6 +1627,9 @@ Vol::handle_recover_from_data(int event, void * /* data ATS_UNUSED */)
   }
   prev_recover_pos    = recover_pos;
   io.aiocb.aio_offset = recover_pos;
+#if TS_USE_MMAP
+  io.mutex = mutex;
+#endif
   ink_assert(ink_aio_read(&io));
   return EVENT_CONT;
 
@@ -1744,6 +1761,9 @@ Vol::handle_header_read(int event, void *data)
         Note("using directory A for '%s'", hash_text.get());
       }
       io.aiocb.aio_offset = skip;
+#if TS_USE_MMAP
+      io.mutex = mutex;
+#endif
       ink_assert(ink_aio_read(&io));
     }
     // try B
@@ -1753,6 +1773,9 @@ Vol::handle_header_read(int event, void *data)
         Note("using directory B for '%s'", hash_text.get());
       }
       io.aiocb.aio_offset = skip + this->dirlen();
+#if TS_USE_MMAP
+      io.mutex = mutex;
+#endif
       ink_assert(ink_aio_read(&io));
     } else {
       Note("no good directory, clearing '%s' since sync_serials on both A and B copies are invalid", hash_text.get());
@@ -1780,7 +1803,11 @@ Vol::dir_init_done(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
     ink_assert(!gvol[vol_no]);
     gvol[vol_no] = this;
     SET_HANDLER(&Vol::aggWrite);
+#if TS_USE_MMAP
+    cache->vol_initialized(fd != MAP_FAILED);
+#else
     cache->vol_initialized(fd != -1);
+#endif
     return EVENT_DONE;
   }
 }
@@ -2348,6 +2375,9 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   io.action        = this;
   io.thread        = mutex->thread_holding->tt == DEDICATED ? AIO_CALLBACK_THREAD_ANY : mutex->thread_holding;
   SET_HANDLER(&CacheVC::handleReadDone);
+#if TS_USE_MMAP
+  io.mutex = mutex;
+#endif
   ink_assert(ink_aio_read(&io) >= 0);
   CACHE_DEBUG_INCREMENT_DYN_STAT(cache_pread_count_stat);
   return EVENT_CONT;

--- a/iocore/cache/CacheDir.cc
+++ b/iocore/cache/CacheDir.cc
@@ -32,6 +32,12 @@
 #endif
 #include "tscore/ink_stack_trace.h"
 
+#if TS_USE_MMAP
+#define PRI_FD "%p"
+#else
+#define PRI_FD "%i"
+#endif
+
 #define CACHE_INC_DIR_USED(_m)                            \
   do {                                                    \
     ProxyMutex *mutex = _m.get();                         \
@@ -569,8 +575,8 @@ Lagain:
           goto Lcont;
         }
         if (dir_valid(d, e)) {
-          DDebug("dir_probe_hit", "found %X %X vol %d bucket %d boffset %" PRId64 "", key->slice32(0), key->slice32(1), d->fd, b,
-                 dir_offset(e));
+          DDebug("dir_probe_hit", "found %X %X vol " PRI_FD " bucket %d boffset %" PRId64 "", key->slice32(0), key->slice32(1),
+                 d->fd, b, dir_offset(e));
           dir_assign(result, e);
           *last_collision = e;
           ink_assert(dir_offset(e) * CACHE_BLOCK_SIZE < d->len);
@@ -594,7 +600,7 @@ Lagain:
     collision = nullptr;
     goto Lagain;
   }
-  DDebug("dir_probe_miss", "missed %X %X on vol %d bucket %d at %p", key->slice32(0), key->slice32(1), d->fd, b, seg);
+  DDebug("dir_probe_miss", "missed %X %X on vol " PRI_FD " bucket %d at %p", key->slice32(0), key->slice32(1), d->fd, b, seg);
   CHECK_DIR(d);
   return 0;
 }
@@ -658,8 +664,8 @@ Lfill:
   dir_assign_data(e, to_part);
   dir_set_tag(e, key->slice32(2));
   ink_assert(d->vol_offset(e) < (d->skip + d->len));
-  DDebug("dir_insert", "insert %p %X into vol %d bucket %d at %p tag %X %X boffset %" PRId64 "", e, key->slice32(0), d->fd, bi, e,
-         key->slice32(1), dir_tag(e), dir_offset(e));
+  DDebug("dir_insert", "insert %p %X into vol " PRI_FD " bucket %d at %p tag %X %X boffset %" PRId64 "", e, key->slice32(0), d->fd,
+         bi, e, key->slice32(1), dir_tag(e), dir_offset(e));
   CHECK_DIR(d);
   d->header->dirty = 1;
   CACHE_INC_DIR_USED(d->mutex);
@@ -745,8 +751,8 @@ Lfill:
   dir_assign_data(e, dir);
   dir_set_tag(e, t);
   ink_assert(d->vol_offset(e) < d->skip + d->len);
-  DDebug("dir_overwrite", "overwrite %p %X into vol %d bucket %d at %p tag %X %X boffset %" PRId64 "", e, key->slice32(0), d->fd,
-         bi, e, t, dir_tag(e), dir_offset(e));
+  DDebug("dir_overwrite", "overwrite %p %X into vol " PRI_FD " bucket %d at %p tag %X %X boffset %" PRId64 "", e, key->slice32(0),
+         d->fd, bi, e, t, dir_tag(e), dir_offset(e));
   CHECK_DIR(d);
   d->header->dirty = 1;
   return res;
@@ -911,7 +917,11 @@ dir_sync_init()
 }
 
 void
+#if TS_USE_MMAP
+CacheSync::aio_write(ink_aiocb::aio_mmap &fd, char *b, int n, off_t o)
+#else
 CacheSync::aio_write(int fd, char *b, int n, off_t o)
+#endif
 {
   io.aiocb.aio_fildes = fd;
   io.aiocb.aio_offset = o;
@@ -993,8 +1003,13 @@ sync_cache_dir_on_shutdown()
 
       // set write limit
       d->header->agg_pos = d->header->write_pos + d->agg_buf_pos;
-
+#if TS_USE_MMAP
+      int r = d->agg_buf_pos;
+      ink_assert(static_cast<char *>(d->fd) + d->header->write_pos + d->agg_buf_pos <= d->fd.last);
+      memcpy(static_cast<char *>(d->fd.first) + d->header->write_pos, d->agg_buffer, d->agg_buf_pos);
+#else
       int r = pwrite(d->fd, d->agg_buffer, d->agg_buf_pos, d->header->write_pos);
+#endif
       if (r != d->agg_buf_pos) {
         ink_assert(!"flushing agg buffer failed");
         continue;
@@ -1037,7 +1052,12 @@ sync_cache_dir_on_shutdown()
     memcpy(buf, d->raw_dir, dirlen);
     size_t B    = d->header->sync_serial & 1;
     off_t start = d->skip + (B ? dirlen : 0);
-    B           = pwrite(d->fd, buf, dirlen, start);
+#if TS_USE_MMAP
+    B = dirlen;
+    memcpy(static_cast<char *>(d->fd) + start, buf, dirlen);
+#else
+    B = pwrite(d->fd, buf, dirlen, start);
+#endif
     ink_assert(B == dirlen);
     Debug("cache_dir_sync", "done syncing dir for vol %s", d->hash_text.get());
   }

--- a/iocore/cache/CacheVol.cc
+++ b/iocore/cache/CacheVol.cc
@@ -378,6 +378,9 @@ Lread:
     io.aiocb.aio_nbytes = vol->skip + vol->len - io.aiocb.aio_offset;
   }
   offset = 0;
+#if TS_USE_MMAP
+  io.mutex = mutex;
+#endif
   ink_assert(ink_aio_read(&io) >= 0);
   Debug("cache_scan_truss", "read %p:scanObject %" PRId64 " %zu", this, (int64_t)io.aiocb.aio_offset, (size_t)io.aiocb.aio_nbytes);
   return EVENT_CONT;

--- a/iocore/cache/CacheWrite.cc
+++ b/iocore/cache/CacheWrite.cc
@@ -776,6 +776,9 @@ Vol::evac_range(off_t low, off_t high, int evac_phase)
       io.thread        = AIO_CALLBACK_THREAD_ANY;
       DDebug("cache_evac", "evac_range evacuating %X %d", (int)dir_tag(&first->dir), (int)dir_offset(&first->dir));
       SET_HANDLER(&Vol::evacuateDocReadDone);
+#if TS_USE_MMAP
+      io.mutex = mutex;
+#endif
       ink_assert(ink_aio_read(&io) >= 0);
       return -1;
     }

--- a/iocore/cache/P_CacheDir.h
+++ b/iocore/cache/P_CacheDir.h
@@ -267,8 +267,11 @@ struct CacheSync : public Continuation {
   Event *trigger        = nullptr;
   ink_hrtime start_time = 0;
   int mainEvent(int event, Event *e);
+#if TS_USE_MMAP
+  void aio_write(ink_aiocb::aio_mmap &fd, char *b, int n, off_t o);
+#else
   void aio_write(int fd, char *b, int n, off_t o);
-
+#endif
   CacheSync() : Continuation(new_ProxyMutex()) { SET_HANDLER(&CacheSync::mainEvent); }
 };
 

--- a/iocore/cache/P_CacheDisk.h
+++ b/iocore/cache/P_CacheDisk.h
@@ -88,15 +88,19 @@ struct CacheDisk : public Continuation {
   off_t skip              = 0;
   off_t num_usable_blocks = 0;
   int hw_sector_size      = 0;
-  int fd                  = -1;
-  off_t free_space        = 0;
-  off_t wasted_space      = 0;
-  DiskVol **disk_vols     = nullptr;
-  DiskVol *free_blocks    = nullptr;
-  int num_errors          = 0;
-  int cleared             = 0;
-  bool read_only_p        = false;
-  bool online             = true; /* flag marking cache disk online or offline (because of too many failures or by the operator). */
+#if TS_USE_MMAP
+  ink_aiocb::aio_mmap fd = {MAP_FAILED, nullptr};
+#else
+  int fd = -1;
+#endif
+  off_t free_space     = 0;
+  off_t wasted_space   = 0;
+  DiskVol **disk_vols  = nullptr;
+  DiskVol *free_blocks = nullptr;
+  int num_errors       = 0;
+  int cleared          = 0;
+  bool read_only_p     = false;
+  bool online          = true; /* flag marking cache disk online or offline (because of too many failures or by the operator). */
 
   // Extra configuration values
   int forced_volume_num = -1;      ///< Volume number for this disk.

--- a/iocore/cache/P_CacheVol.h
+++ b/iocore/cache/P_CacheVol.h
@@ -51,8 +51,13 @@
 #define LOOKASIDE_SIZE 256
 #define EVACUATION_BUCKET_SIZE (2 * EVACUATION_SIZE) // 16MB
 #define RECOVERY_SIZE EVACUATION_SIZE                // 8MB
+#if TS_USE_MMAP
+#define AIO_NOT_IN_PROGRESS reinterpret_cast<void *>(-1)
+#define AIO_AGG_WRITE_IN_PROGRESS reinterpret_cast<void *>(-2)
+#else
 #define AIO_NOT_IN_PROGRESS -1
 #define AIO_AGG_WRITE_IN_PROGRESS -2
+#endif
 #define AUTO_SIZE_RAM_CACHE -1                               // 1-1 with directory size
 #define DEFAULT_TARGET_FRAGMENT_SIZE (1048576 - sizeof(Doc)) // 1MB
 
@@ -123,8 +128,11 @@ struct Vol : public Continuation {
   char *path = nullptr;
   ats_scoped_str hash_text;
   CryptoHash hash_id;
+#if TS_USE_MMAP
+  ink_aiocb::aio_mmap fd = {MAP_FAILED, nullptr};
+#else
   int fd = -1;
-
+#endif
   char *raw_dir           = nullptr;
   Dir *dir                = nullptr;
   VolHeaderFooter *header = nullptr;

--- a/iocore/eventsystem/I_EThread.h
+++ b/iocore/eventsystem/I_EThread.h
@@ -308,10 +308,10 @@ public:
 
   /** Block of memory to allocate thread specific data e.g. stat system arrays. */
   char thread_private[PER_THREAD_DATA];
-
+#if !TS_USE_MMAP
   /** Private Data for the Disk Processor. */
   DiskHandler *diskHandler = nullptr;
-
+#endif
   /** Private Data for AIO. */
   Que(Continuation, link) aio_ops;
 

--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -8562,7 +8562,11 @@ TSHttpTxnClientStreamPriorityGet(TSHttpTxn txnp, TSHttpPriority *priority)
 }
 
 TSReturnCode
+#if TS_USE_MMAP
+TSAIORead(ink_aiocb::aio_mmap &fd, off_t offset, char *buf, size_t buffSize, TSCont contp)
+#else
 TSAIORead(int fd, off_t offset, char *buf, size_t buffSize, TSCont contp)
+#endif
 {
   sdk_assert(sdk_sanity_check_iocore_structure(contp) == TS_SUCCESS);
 
@@ -8580,7 +8584,9 @@ TSAIORead(int fd, off_t offset, char *buf, size_t buffSize, TSCont contp)
   pAIO->aiocb.aio_buf = buf;
   pAIO->action        = pCont;
   pAIO->thread        = pCont->mutex->thread_holding;
-
+#if TS_USE_MMAP
+  pAIO->mutex = pCont->mutex;
+#endif
   if (ink_aio_read(pAIO, 1) == 1) {
     return TS_SUCCESS;
   }
@@ -8603,7 +8609,11 @@ TSAIONBytesGet(TSAIOCallback data)
 }
 
 TSReturnCode
+#if TS_USE_MMAP
+TSAIOWrite(ink_aiocb::aio_mmap &fd, off_t offset, char *buf, const size_t bufSize, TSCont contp)
+#else
 TSAIOWrite(int fd, off_t offset, char *buf, const size_t bufSize, TSCont contp)
+#endif
 {
   sdk_assert(sdk_sanity_check_iocore_structure(contp) == TS_SUCCESS);
 


### PR DESCRIPTION
Allows for only-in-memory caching for usecases where such behavior is needed (i.e. Live Video caching). It maps storage directly into user space memory, so reads and writes are being done by a memcpy (without calls to io).


apt install libaio-dev
autoreconf -if
./configure --enable-mmap --enable-experimental-linux-native-aio
./configure --enable-mmap