### PR TITLE
CMake: Add "nice" file to contain persistent options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Makefile.in
 .idea
 
 CMakeUserPresets.json
+CMakeLists.nice
 
 # clangd language server files.
 /compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 
 include(layout)
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.nice")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.nice")
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_compile_definitions(DEBUG _DEBUG)
 endif()

--- a/INSTALL
+++ b/INSTALL
@@ -37,6 +37,14 @@ To install:
 * The easiest way to find all of the configuration flags
   for Traffic Server is to run `ccmake build`
 
+* For convience, if there a file named "CMakeLists.nice" in the source
+  directory, it will be loaded early in the loading of "CMakeList.txt".
+  This enables local modifications that don't have to be passed on the
+  command line or IDE. For instance if this is put in that file then
+  the install directory will be set to "/opt/ts".
+
+    set(CMAKE_INSTALL_PREFIX "/opt/ts")
+
 
 By default the build will use the highest level of compiler
 optimization. To alter this, specify the Release build type:


### PR DESCRIPTION
The point of this is to be similar to "config.nice", that is a file that

* Is not checked in and is local to every checkout.
* Sets build options.
* Is easily copied between directories / hosts.

The file "CMakeLists.nice" is checked for and loaded if present. This enables doing this like
```
set(CMAKE_INSTALL_PREFIX "/opt/ts")
```
to set the install prefix. I think this is awesome because I can copy this file around and set options without having to fiddle with my IDE or command line options.