### PR TITLE
Coverity 1528667: Use of 32-bit time_t in mime_days_since_epoch_to_mdy_slowcase

### DIFF
--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -2971,8 +2971,11 @@ mime_days_since_epoch_to_mdy_slowcase(time_t days_since_jan_1_1970, int *m_retur
     mday  = d - days[month] - 1;
     year += 1900;
 
+    // coverity[Y2K38_SAFETY:FALSE]
     *m_return = month;
+    // coverity[Y2K38_SAFETY:FALSE]
     *d_return = mday;
+    // coverity[Y2K38_SAFETY:FALSE]
     *y_return = year;
   }
 }


### PR DESCRIPTION
Ignore false positives

This function modifies the time_t values to calculate the month, day, and year and assigns the time_t to an int.  Since the month, day, and year values will be less than the max of an int it is a false positive.