### PR TITLE
Fix netcat usage for accept_timeout test

### DIFF
--- a/tests/gold_tests/timeout/accept_timeout.test.py
+++ b/tests/gold_tests/timeout/accept_timeout.test.py
@@ -30,6 +30,8 @@ ts.addSSLfile("../tls/ssl/server.pem")
 ts.addSSLfile("../tls/ssl/server.key")
 
 ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'http',
     'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
     'proxy.config.http.transaction_no_activity_timeout_in': 6,

--- a/tests/gold_tests/timeout/accept_timeout.test.py
+++ b/tests/gold_tests/timeout/accept_timeout.test.py
@@ -65,6 +65,6 @@ tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Accept timeou
 # case 4 TCP with incomplete request header
 tr4 = Test.AddTestRun("tr")
 tr4.Setup.Copy("create_request.sh")
-tr4.Processes.Default.Command = 'sh  ./time_client.sh \'nc -c ./create_request.sh 127.0.0.1 {0}\''.format(ts.Variables.port)
+tr4.Processes.Default.Command = 'sh  ./time_client.sh "sh ./create_request.sh {0}"'.format(ts.Variables.port)
 tr4.Processes.Default.Streams.stdout = Testers.ContainsExpression(
     "Transaction inactivity timeout", "Request should fail with transaction inactivity timeout")

--- a/tests/gold_tests/timeout/accept_timeout.test.py
+++ b/tests/gold_tests/timeout/accept_timeout.test.py
@@ -70,3 +70,4 @@ tr4.Setup.Copy("create_request.sh")
 tr4.Processes.Default.Command = 'sh  ./time_client.sh "sh ./create_request.sh {0}"'.format(ts.Variables.port)
 tr4.Processes.Default.Streams.stdout = Testers.ContainsExpression(
     "Transaction inactivity timeout", "Request should fail with transaction inactivity timeout")
+tr4.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -16,5 +16,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-(printf "GET / HTTP/1.1" |  nc -w 11 127.0.0.1 $1)
+# Different vresions of nc have different wait options,
+# so falling back to shell
+printf "GET / HTTP/1.1" | nc 127.0.0.1 $1 &
+targetPID=$!
+count=11
+while [ $count -gt 0 ]
+do
+	sleep 1
+	output=`ps uax | grep $targetPID | grep "nc "`
+	if [ -z "$output" ] # process is gone
+	then
+		exit 0
+	fi
+	count=`expr $count - 1`
+done
+kill $targetPID
 

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -24,7 +24,7 @@ request() {
 	printf "GET / HTTP/1.1"
 }
 
-ncat 
+ncat
 if [ $? -le 1 ]
 then
 	request | ncat -i 11 127.0.0.1 $1 &

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -21,6 +21,7 @@
 printf "GET / HTTP/1.1" | nc 127.0.0.1 $1 &
 targetPID=$!
 count=11
+echo PID is *${targetPID}
 while [ $count -gt 0 ]
 do
 	sleep 1

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -16,5 +16,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-(printf "GET / HTTP/1.1" |  nc -w 11 127.0.0.1 $1) 
+(printf "GET / HTTP/1.1" |  nc -w 11 127.0.0.1 $1)
 

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -18,8 +18,22 @@
 
 # Different vresions of nc have different wait options,
 # so falling back to shell
-printf "GET / HTTP/1.1" | nc 127.0.0.1 $1 &
-targetPID=$!
+
+# Send part of the request and then stop
+request() {
+	printf "GET / HTTP/1.1"
+}
+
+ncat 
+if [ $? -le 1 ]
+then
+	request | ncat -i 11 127.0.0.1 $1 &
+	targetPID=$!
+else
+	request | nc -w 11 127.0.0.1 $1 &
+	targetPID=$!
+fi
+
 count=11
 echo PID is *${targetPID}
 while [ $count -gt 0 ]
@@ -27,7 +41,7 @@ do
 	sleep 1
 	output=`ps uax | grep $targetPID | grep "nc "`
 	output0=`ps uax | grep $targetPID`
-	echo "Out for $stargetPID is $output or $output0"
+	echo "Out for $targetPID is $output or $output0"
 	if [ -z "$output" ] # process is gone
 	then
 		exit 0

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -41,7 +41,7 @@ echo PID is *${targetPID}
 while [ $count -gt 0 ]
 do
 	sleep 1
-	output=`ps uax | grep $targetPID | grep "$nc_name "
+	output=`ps uax | grep $targetPID | grep "$nc_name "`
 	output0=`ps uax | grep $targetPID`
 	echo "Out for $targetPID is $output or $output0"
 	if [ -z "$output" ] # process is gone

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -25,6 +25,8 @@ while [ $count -gt 0 ]
 do
 	sleep 1
 	output=`ps uax | grep $targetPID | grep "nc "`
+	output0=`ps uax | grep $targetPID`
+	echo "Out for $stargetPID is $output or $output0"
 	if [ -z "$output" ] # process is gone
 	then
 		exit 0

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -16,5 +16,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-printf GET / HTTP/1.1
-sleep 11
+(printf "GET / HTTP/1.1" |  nc -w 11 127.0.0.1 $1) 
+

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -25,19 +25,22 @@ request() {
 }
 
 nc_name="nc"
-ncat
+ncat --help
 if [ $? -le 1 ]
 then
-	request | ncat -i 11 127.0.0.1 $1 &
-	targetPID=$!
 	nc_name="ncat"
+	request | ncat -i 11 127.0.0.1 $1 &
 else
 	request | nc -w 11 127.0.0.1 $1 &
-	targetPID=$!
 fi
+targetPID=$!
 
 count=11
 echo PID is *${targetPID}
+output=`ps uax | grep $targetPID | grep "$nc_name "`
+output0=`ps uax | grep $targetPID`
+echo "Out for $targetPID is $output or $output0"
+
 while [ $count -gt 0 ]
 do
 	sleep 1

--- a/tests/gold_tests/timeout/create_request.sh
+++ b/tests/gold_tests/timeout/create_request.sh
@@ -24,11 +24,13 @@ request() {
 	printf "GET / HTTP/1.1"
 }
 
+nc_name="nc"
 ncat
 if [ $? -le 1 ]
 then
 	request | ncat -i 11 127.0.0.1 $1 &
 	targetPID=$!
+	nc_name="ncat"
 else
 	request | nc -w 11 127.0.0.1 $1 &
 	targetPID=$!
@@ -39,7 +41,7 @@ echo PID is *${targetPID}
 while [ $count -gt 0 ]
 do
 	sleep 1
-	output=`ps uax | grep $targetPID | grep "nc "`
+	output=`ps uax | grep $targetPID | grep "$nc_name "
 	output0=`ps uax | grep $targetPID`
 	echo "Out for $targetPID is $output or $output0"
 	if [ -z "$output" ] # process is gone

--- a/tests/gold_tests/timeout/time_client.sh
+++ b/tests/gold_tests/timeout/time_client.sh
@@ -13,10 +13,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+date
 start=`date +%s`
 $1
 end=`date +%s`
+date
 
 runtime=$((end-start))
 echo $runtime

--- a/tests/gold_tests/timeout/time_client.sh
+++ b/tests/gold_tests/timeout/time_client.sh
@@ -20,7 +20,7 @@ end=`date +%s`
 
 runtime=$((end-start))
 echo $runtime
-if [ $runtime -lt 6 ]
+if [ $runtime -lt 5 ]
 then
   echo "Accept timeout $runtime"
   exit 0


### PR DESCRIPTION
Adjust to use the reduced argument list for netcat that is available in the ubuntu 22 image.