### PR TITLE
Cleanup ink_thread.h of wrong BSD checks assuming missing pthread functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,12 +234,6 @@ if(brotli_FOUND)
   set(HAVE_BROTLI_ENCODE_H TRUE)
 endif()
 
-if(TS_USE_POSIX_CAP)
-  # These headers must have been found for capabilites to be enabled.
-  set(HAVE_SYS_CAPABILITY_H TRUE)
-  set(HAVE_SYS_PRCTL_H TRUE)
-endif()
-
 find_package(LibLZMA)
 if(LibLZMA_FOUND)
   set(HAVE_LZMA_H TRUE)
@@ -384,6 +378,7 @@ check_symbol_exists(strlcat string.h HAVE_STRLCAT)
 check_symbol_exists(strlcpy string.h HAVE_STRLCPY)
 check_symbol_exists(strsignal string.h HAVE_STRSIGNAL)
 check_symbol_exists(sysinfo sys/sysinfo.h HAVE_SYSINFO)
+check_symbol_exists(prctl "sys/prctl.h" HAVE_PRCTL)
 if(TS_USE_HWLOC)
   check_source_compiles(
     C "#include <hwloc.h>

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -42,8 +42,6 @@
 #cmakedefine HAVE_LZMA_H 1
 #cmakedefine HAVE_IFADDRS_H 1
 #cmakedefine HAVE_LINUX_HDREG_H 1
-#cmakedefine HAVE_SYS_CAPABILITY_H 1
-#cmakedefine HAVE_SYS_PRCTL_H 1
 #cmakedefine HAVE_MALLOC_USABLE_SIZE 1
 #cmakedefine HAVE_MCHECK_PEDANTIC 1
 #cmakedefine HAVE_POSIX_FADVISE 1
@@ -71,6 +69,7 @@
 #cmakedefine01 HAVE_STRLCPY
 #cmakedefine01 HAVE_STRSIGNAL
 #cmakedefine01 HAVE_SYSINFO
+#cmakedefine01 HAVE_PRCTL
 
 #cmakedefine01 HAVE_HWLOC_OBJ_PU
 

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -125,7 +125,7 @@ using in_addr_t = unsigned int;
 #include <sys/sysmacros.h>
 #endif
 
-#ifdef HAVE_SYS_PRCTL_H
+#if __has_include(<sys/prctl.h>)
 #include <sys/prctl.h>
 #endif
 

--- a/include/tscore/ink_thread.h
+++ b/include/tscore/ink_thread.h
@@ -46,7 +46,7 @@
 #include <pthread_np.h>
 #endif
 
-#if __has_include(<sys/prctl.h>) && defined(PR_SET_NAME)
+#if __has_include(<sys/prctl.h>)
 #include <sys/prctl.h>
 #endif
 
@@ -270,7 +270,7 @@ ink_set_thread_name(const char *name ATS_UNUSED)
   pthread_setname_np(pthread_self(), name);
 #elif defined(HAVE_PTHREAD_SET_NAME_NP_2)
   pthread_set_name_np(pthread_self(), name);
-#elif HAVE_PRCTL
+#elif HAVE_PRCTL && defined(PR_SET_NAME)
   prctl(PR_SET_NAME, name, 0, 0, 0);
 #endif
 }
@@ -282,7 +282,7 @@ ink_get_thread_name(char *name, size_t len)
   pthread_getname_np(pthread_self(), name, len);
 #elif defined(HAVE_PTHREAD_GET_NAME_NP)
   pthread_get_name_np(pthread_self(), name, len);
-#elif HAVE_PRCTL
+#elif HAVE_PRCTL && defined(PR_GET_NAME)
   prctl(PR_GET_NAME, name, 0, 0, 0);
 #else
   snprintf(name, len, "0x%" PRIx64, (uint64_t)ink_thread_self());

--- a/include/tscore/ink_thread.h
+++ b/include/tscore/ink_thread.h
@@ -270,7 +270,7 @@ ink_set_thread_name(const char *name ATS_UNUSED)
   pthread_setname_np(pthread_self(), name);
 #elif defined(HAVE_PTHREAD_SET_NAME_NP_2)
   pthread_set_name_np(pthread_self(), name);
-#elif defined(HAVE_SYS_PRCTL_H) && defined(PR_SET_NAME)
+#elif HAVE_PRCTL
   prctl(PR_SET_NAME, name, 0, 0, 0);
 #endif
 }
@@ -282,7 +282,7 @@ ink_get_thread_name(char *name, size_t len)
   pthread_getname_np(pthread_self(), name, len);
 #elif defined(HAVE_PTHREAD_GET_NAME_NP)
   pthread_get_name_np(pthread_self(), name, len);
-#elif defined(HAVE_SYS_PRCTL_H) && defined(PR_GET_NAME)
+#elif HAVE_PRCTL
   prctl(PR_GET_NAME, name, 0, 0, 0);
 #else
   snprintf(name, len, "0x%" PRIx64, (uint64_t)ink_thread_self());

--- a/src/tscore/ink_memory.cc
+++ b/src/tscore/ink_memory.cc
@@ -33,7 +33,7 @@
 #include <mimalloc-override.h>
 #endif
 
-#if !defined(kfreebsd) && defined(freebsd)
+#if __has_include(<malloc_np.h>)
 #include <malloc_np.h> // for malloc_usable_size
 #endif
 

--- a/src/tscore/ink_mutex.cc
+++ b/src/tscore/ink_mutex.cc
@@ -35,7 +35,7 @@ public:
   x_pthread_mutexattr_t()
   {
     pthread_mutexattr_init(&attr);
-#if DEBUG && HAVE_PTHREAD_MUTEXATTR_SETTYPE
+#if DEBUG
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
 #endif
   }

--- a/src/tsutil/DbgCtl.cc
+++ b/src/tsutil/DbgCtl.cc
@@ -346,7 +346,7 @@ struct DiagThreadname {
     pthread_getname_np(pthread_self(), name, sizeof(name));
 #elif defined(HAVE_PTHREAD_GET_NAME_NP)
     pthread_get_name_np(pthread_self(), name, sizeof(name));
-#elif defined(HAVE_SYS_PRCTL_H) && defined(PR_GET_NAME)
+#elif defined(HAVE_PRCTL) && defined(PR_GET_NAME)
     prctl(PR_GET_NAME, name, 0, 0, 0);
 #else
     snprintf(name, sizeof(name), "0x%" PRIx64, (uint64_t)pthread_self());


### PR DESCRIPTION
Commit https://github.com/apache/trafficserver/commit/26c408071d6a559bfb30da8a67854a4e888cfb71 attempted to replace some FreeBSD pthread function checks with function checking. This was reverted in https://github.com/apache/trafficserver/commit/012df52981084d3cd82d1e8aa87074683dd22594 as feature detection should be done via autoconf (or now, CMake). 

However, every remotely recent version of FreeBSD has the pthread functions in question. There seems to be no reason to bother to check for `pthread_cancel` or `pthread_getschedparam`. 

In doing this, this allows us to remove `HAVE_SYS_CAPABILITY_H` and `HAVE_SYS_PRCTL_H`, replacing them with `__has_include` directives. We also introduce a direct `HAVE_PRCTL` feature check to replace the implied existence of it in `HAVE_SYS_PRCTL_H`. 

In addition, the merge of #10823 into #11029 dropped a fix in which `HAVE_PTHREAD_MUTEXATTR_SETTYPE` was removed but not what called it. `pthread_mutexattr_settype` is available on every modern operating system supporting pthread; we should no longer need to check for its existence. 