### PR TITLE
Replace nonstandard darwin platform detection

### DIFF
--- a/include/tscore/ink_endian.h
+++ b/include/tscore/ink_endian.h
@@ -38,7 +38,7 @@
 #include <sys/byteorder.h>
 #endif
 
-#if defined(darwin)
+#if (defined(__APPLE__) && defined(__MACH__))
 #include <libkern/OSByteOrder.h>
 inline uint64_t
 be64toh(uint64_t x)

--- a/include/tscore/ink_platform.h
+++ b/include/tscore/ink_platform.h
@@ -128,7 +128,7 @@ using in_addr_t = unsigned int;
 #include <sys/sysinfo.h>
 #endif
 
-#if defined(darwin) || defined(freebsd)
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(freebsd)
 #ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif

--- a/include/tscore/ink_thread.h
+++ b/include/tscore/ink_thread.h
@@ -60,7 +60,7 @@ using ink_thread_key = pthread_key_t;
 
 // Darwin has a sem_init stub that returns ENOSYS. Rather than bodge around doing runtime
 // detection, just emulate on Darwin.
-#if defined(darwin)
+#if (defined(__APPLE__) && defined(__MACH__))
 #define TS_EMULATE_ANON_SEMAPHORES 1
 #endif
 

--- a/src/iocore/net/UnixUDPNet.cc
+++ b/src/iocore/net/UnixUDPNet.cc
@@ -29,7 +29,7 @@
 
  ****************************************************************************/
 
-#if defined(darwin)
+#if (defined(__APPLE__) && defined(__MACH__))
 /* This is for IPV6_PKTINFO and IPV6_RECVPKTINFO */
 #define __APPLE_USE_RFC_3542
 #endif

--- a/src/iocore/net/test_certlookup.cc
+++ b/src/iocore/net/test_certlookup.cc
@@ -234,7 +234,7 @@ main(int argc, const char **argv)
   ink_freelists_dump(stdout);
 
 // On Darwin, fail the tests if we have any memory leaks.
-#if defined(darwin)
+#if (defined(__APPLE__) && defined(__MACH__))
   if (system("xcrun leaks test_certlookup") != 0) {
     RegressionTest::final_status = REGRESSION_TEST_FAILED;
   }

--- a/src/proxy/Plugin.cc
+++ b/src/proxy/Plugin.cc
@@ -170,7 +170,7 @@ single_plugin_init(int argc, char *argv[], bool validateOnly)
     plugin_reg_current->plugin_path = ats_strdup(path);
     plugin_reg_current->dlh         = handle;
 
-#if (!defined(kfreebsd) && defined(freebsd)) || defined(darwin)
+#if (!defined(kfreebsd) && defined(freebsd)) || (defined(__APPLE__) && defined(__MACH__))
     optreset = 1;
 #endif
 #if defined(__GLIBC__)

--- a/src/proxy/http/remap/PluginDso.cc
+++ b/src/proxy/http/remap/PluginDso.cc
@@ -104,7 +104,7 @@ PluginDso::load(std::string &error)
       PluginDebug(_tag, "plugin '%s' modification time %ld", _configPath.c_str(), ts_clock::to_time_t(_mtime));
 
       /* Now attempt to load the plugin DSO */
-#if defined(darwin)
+#if (defined(__APPLE__) && defined(__MACH__))
       if (!dlopen_preflight(_runtimePath.c_str()) || (_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW | RTLD_LOCAL)) == nullptr) {
 #else
       if ((_dlh = dlopen(_runtimePath.c_str(), RTLD_NOW | RTLD_LOCAL)) == nullptr) {

--- a/src/proxy/http/remap/RemapPluginInfo.cc
+++ b/src/proxy/http/remap/RemapPluginInfo.cc
@@ -175,7 +175,7 @@ RemapPluginInfo::initInstance(int argc, char **argv, void **ih, std::string &err
   ink_zero(tmpbuf);
 
   if (new_instance_cb) {
-#if defined(freebsd) || defined(darwin)
+#if defined(freebsd) || (defined(__APPLE__) && defined(__MACH__))
     optreset = 1;
 #endif
 #if defined(__GLIBC__)

--- a/src/traffic_layout/engine.cc
+++ b/src/traffic_layout/engine.cc
@@ -547,7 +547,7 @@ check_directory_permission(const char *path)
   return true;
 }
 
-#if defined(darwin)
+#if (defined(__APPLE__) && defined(__MACH__))
 // on Darwin, getgrouplist() takes int.
 using gid_type = int;
 #else

--- a/src/tscore/ink_file.cc
+++ b/src/tscore/ink_file.cc
@@ -434,7 +434,7 @@ ink_file_get_geometry(int fd ATS_UNUSED, ink_device_geometry &geometry)
 {
   ink_zero(geometry);
 
-#if defined(freebsd) || defined(darwin) || defined(openbsd)
+#if defined(freebsd) || (defined(__APPLE__) && defined(__MACH__)) || defined(openbsd)
   ioctl_arg_t arg ATS_UNUSED;
 
 // These IOCTLs are standard across the BSD family; Darwin has a different set though.

--- a/src/tscore/ink_sock.cc
+++ b/src/tscore/ink_sock.cc
@@ -325,7 +325,7 @@ bind_unix_domain_socket(const char *path, mode_t mode)
   sockaddr.sun_family = AF_UNIX;
   ink_strlcpy(sockaddr.sun_path, path, sizeof(sockaddr.sun_path));
 
-#if defined(darwin) || defined(freebsd)
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(freebsd)
   socklen = sizeof(struct sockaddr_un);
 #else
   socklen = strlen(sockaddr.sun_path) + sizeof(sockaddr.sun_family);

--- a/src/tscore/ink_sys_control.cc
+++ b/src/tscore/ink_sys_control.cc
@@ -58,7 +58,7 @@ ink_max_out_rlimit(int which)
 
   ink_release_assert(getrlimit(MAGIC_CAST(which), &rl) >= 0);
   if (rl.rlim_cur != rl.rlim_max) {
-#if defined(darwin)
+#if (defined(__APPLE__) && defined(__MACH__))
     if (which == RLIMIT_NOFILE) {
       rl.rlim_cur = (OPEN_MAX < rl.rlim_max) ? OPEN_MAX : rl.rlim_max;
     } else {


### PR DESCRIPTION
We do not a few feature checks for operating systems using deprecated flags. This replaces the nonstandard `darwin` with `__APPLE__` ⋀ `__MACH__`.

A future PR will do so for FreeBSD and OpenBSD. 