### PR TITLE
Update links in records.yaml to be valid

### DIFF
--- a/configs/records.yaml.default.in
+++ b/configs/records.yaml.default.in
@@ -1,7 +1,7 @@
 ##############################################################################
 # *NOTE*: All options covered in this file should be documented in the docs:
 #
-#    https://docs.trafficserver.apache.org/records.yaml
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html
 ##############################################################################
 
 ts:
@@ -10,21 +10,21 @@ ts:
     limits:
       http:
 
-# https://docs.trafficserver.apache.org/records.yaml#proxy-config-cache-limits-http-max-alts
+# https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-cache-limits-http-max-alts
         max_alts: 5
     log:
       alternate:
 
-# https://docs.trafficserver.apache.org/records.yaml#proxy-config-cache-log-alternate-eviction
+# https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-cache-log-alternate-eviction
         eviction: 0
 
-# https://docs.trafficserver.apache.org/records.yaml#proxy-config-cache-max-doc-size
+# https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-cache-max-doc-size
     max_doc_size: 0
     min_average_object_size: 8000
 
 ##############################################################################
 # RAM and disk cache configurations. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#ram-cache
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#ram-cache
 #    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/storage.config.en.html
 ##############################################################################
     ram_cache:
@@ -33,19 +33,19 @@ ts:
     threads_per_disk: 8
 ##############################################################################
 # Debugging. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#diagnostic-logging-configuration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#diagnostic-logging-configuration
 ##############################################################################
   diags:
     debug:
       enabled: 0
       tags: http|dns
 
-#    https://docs.trafficserver.apache.org/records.yaml#proxy-config-dump-mem-info-frequency
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-dump-mem-info-frequency
   dump_mem_info_frequency: 0
 
 ##############################################################################
 # Thread configurations. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#thread-variables
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#thread-variables
 ##############################################################################
   exec_thread:
     affinity: 1
@@ -61,7 +61,7 @@ ts:
 
 ##############################################################################
 # Heuristic cache expiration. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#heuristic-expiration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#heuristic-expiration
 ##############################################################################
       heuristic_lm_factor: 0.1
       heuristic_max_lifetime: 86400
@@ -75,20 +75,20 @@ ts:
 
 ##############################################################################
 # Cache control. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#cache-control
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#cache-control
 #    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/cache.config.en.html
 ##############################################################################
       ignore_client_cc_max_age: 1
 
-# https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-cache-required-headers
+# https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-http-cache-required-headers
       required_headers: 2
 
-# https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-cache-when-to-revalidate
+# https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-http-cache-when-to-revalidate
       when_to_revalidate: 0
 
 ##############################################################################
 # Origin server connect attempts. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#origin-server-connect-attempts
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#origin-server-connect-attempts
 ##############################################################################
     connect_attempts_max_retries: 3
     connect_attempts_max_retries_down_server: 1
@@ -101,13 +101,13 @@ ts:
 
 ##############################################################################
 # Proxy users variables. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#proxy-user-variables
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-user-variables
 ##############################################################################
     insert_client_ip: 1
 
 ##############################################################################
 # Via: headers. Docs:
-#     https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-insert-response-via-str
+#     https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-http-insert-response-via-str
 ##############################################################################
     insert_request_via_str: 1
     insert_response_via_str: 0
@@ -117,7 +117,7 @@ ts:
 
 ##############################################################################
 # Negative response caching, for redirects and errors. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#negative-response-caching
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#negative-response-caching
 ##############################################################################
     negative_caching_enabled: 0
     negative_caching_lifetime: 1800
@@ -125,7 +125,7 @@ ts:
 
 ##############################################################################
 # Parent proxy configuration, in addition to these settings also see parent.config. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#parent-proxy-configuration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#parent-proxy-configuration
 #    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/parent.config.en.html
 ##############################################################################
     parent_proxy:
@@ -133,24 +133,24 @@ ts:
 
 ##############################################################################
 # Security. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#security
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#security
 ##############################################################################
     push_method_enabled: 0
 
 ##############################################################################
 # Specify server addresses and ports to bind for HTTP and HTTPS. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#proxy.config.http.server_ports
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy.config.http.server_ports
 ##############################################################################
     server_ports: 8080 8080:ipv6
 
-#    https://docs.trafficserver.apache.org/records.yaml#proxy-config-http-slow-log-threshold
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-http-slow-log-threshold
     slow:
       log:
         threshold: 0
 
 ##############################################################################
 # HTTP connection timeouts (secs). Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#http-connection-timeouts
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#http-connection-timeouts
 ##############################################################################
     transaction_active_timeout_in: 900
     transaction_active_timeout_out: 0
@@ -160,7 +160,7 @@ ts:
 
 ##############################################################################
 # Logging Config. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#logging-configuration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#logging-configuration
 #    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/logging.yaml.en.html
 ##############################################################################
   log:
@@ -175,7 +175,7 @@ ts:
 
 ##############################################################################
 # Network. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#network
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#network
 ##############################################################################
   net:
     connections_throttle: 30000
@@ -183,10 +183,10 @@ ts:
     max_connections_in: 30000
     max_requests_in: 0
 
-#    https://docs.trafficserver.apache.org/records.yaml#proxy-config-res-track-memory
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-res-track-memory
   res_track_memory: 0
 
-# https://docs.trafficserver.apache.org/records.yaml#reverse-proxy
+# https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#reverse-proxy
   reverse_proxy:
     enabled: 1
   ssl:
@@ -197,7 +197,7 @@ ts:
 
 ##############################################################################
 # SSL Termination. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#client-related-configuration
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#client-related-configuration
 #    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/ssl_multicert.config.en.html
 ##############################################################################
       verify:
@@ -208,11 +208,11 @@ ts:
 
 ##############################################################################
 # These settings control remapping, and if the proxy allows (open) forward proxy or not. Docs:
-#    https://docs.trafficserver.apache.org/records.yaml#url-remap-rules
+#    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#url-remap-rules
 #    https://docs.trafficserver.apache.org/en/latest/admin-guide/files/remap.config.en.html
 ##############################################################################
   url_remap:
 
-# https://docs.trafficserver.apache.org/records.yaml#proxy-config-url-remap-pristine-host-hdr
+# https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.yaml.en.html#proxy-config-url-remap-pristine-host-hdr
     pristine_host_hdr: 0
     remap_required: 1


### PR DESCRIPTION
Currently most of the links in records.yaml do not work and lead nowhere. Updating them to the new url structure.