### PR TITLE
Remove unnecessary nc to fix u22 test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,6 @@ function(ADD_AUTEST_PLUGIN _NAME)
 endfunction()
 
 add_subdirectory(tools/plugins)
-add_subdirectory(gold_tests/bigobj)
 add_subdirectory(gold_tests/chunked_encoding)
 add_subdirectory(gold_tests/continuations/plugins)
 add_subdirectory(gold_tests/jsonrpc/plugins)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ function(ADD_AUTEST_PLUGIN _NAME)
 endfunction()
 
 add_subdirectory(tools/plugins)
+add_subdirectory(gold_tests/bigojb)
 add_subdirectory(gold_tests/chunked_encoding)
 add_subdirectory(gold_tests/continuations/plugins)
 add_subdirectory(gold_tests/jsonrpc/plugins)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ function(ADD_AUTEST_PLUGIN _NAME)
 endfunction()
 
 add_subdirectory(tools/plugins)
-add_subdirectory(gold_tests/bigojb)
+add_subdirectory(gold_tests/bigobj)
 add_subdirectory(gold_tests/chunked_encoding)
 add_subdirectory(gold_tests/continuations/plugins)
 add_subdirectory(gold_tests/jsonrpc/plugins)

--- a/tests/gold_tests/headers/cache_and_req_body.test.py
+++ b/tests/gold_tests/headers/cache_and_req_body.test.py
@@ -99,8 +99,8 @@ tr.StillRunningAfter = ts
 
 # Test 2 - 200 cached response and using netcat
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = "printf 'GET / HTTP/1.1\r\n''x-debug: x-cache,x-cache-key,via\r\n''Host: www.example.com\r\n''\r\n'|nc 127.0.0.1 -w 1 {port}".format(
-    port=ts.Variables.port)
+tr.Processes.Default.Command = 'curl -s -D - -v --ipv4 --http1.1 -H "x-debug: x-cache,x-cache-key,via" -H "Host: www.example.com" http://localhost:{}'.format(
+    ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.CurlHeader(cache_and_req_body_hit)
 tr.StillRunningAfter = ts


### PR DESCRIPTION
Replaced use of nc with curl.  Without that change, the following test case would not emit any data when run on ubuntu22.