### PR TITLE
Fix connect test for ubuntu22

### DIFF
--- a/tests/gold_tests/connect/gold/connect_0_stderr.gold
+++ b/tests/gold_tests/connect/gold/connect_0_stderr.gold
@@ -1,5 +1,5 @@
 ``
-* Connected to 127.0.0.1 (127.0.0.1) port ``
+* Connected to `` (127.0.0.1) port ``
 ``
 * Establish HTTP proxy tunnel to foo.com:80
 > CONNECT foo.com:80 HTTP/1.1


### PR DESCRIPTION
Slight output difference between the curl on redhat and the curl on u22.  u22 prints (nil) if there is no hostname.  It appears that the redhat curl prints the ip address gain.  Adding wildcard to avoid the difference in the gold file.