### PR TITLE
Adjust gold file to deal curl case differences

### DIFF
--- a/tests/gold_tests/h2/gold/httpbin_0_stderr.gold
+++ b/tests/gold_tests/h2/gold/httpbin_0_stderr.gold
@@ -1,12 +1,12 @@
 ``
 > GET /get HTTP/2
 > Host: ``
-> User-Agent: curl/``
-> Accept: */*
+> ``ser-Agent: curl/``
+> ``ccept: */*
 ``
 < HTTP/2 200 ``
 ``
-< content-type: application/json; encoding=utf-8
+< content-type: application/json; ``=utf-8
 < date: ``
 < content-length: ``
 < age: ``


### PR DESCRIPTION
Evidently the versions of curl differ between ubuntu22 and redhat.