### PR TITLE
Adjust nc usage in fix-post-early-return test

### DIFF
--- a/tests/gold_tests/post/delay_client.sh
+++ b/tests/gold_tests/post/delay_client.sh
@@ -1,0 +1,25 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+request ()
+{
+  printf "POST /four HTTP/1.1\r\nHost: bob\r\nContent-Length: 20\r\n\r\n1234567890"
+  sleep 4
+  printf "0123456789"
+}
+
+outfile=$2
+request | nc 127.0.0.1 $1 > "$outfile"

--- a/tests/gold_tests/post/delay_client2.sh
+++ b/tests/gold_tests/post/delay_client2.sh
@@ -1,0 +1,27 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+request ()
+{
+  printf "POST /five HTTP/1.1\r\nHost: bob\r\nContent-Length: 20\r\n\r\n"
+  sleep 1
+  printf "1234567890"
+  sleep 4
+  printf "0123456789"
+}
+
+outfile=$2
+request | nc 127.0.0.1 $1 > "$outfile"

--- a/tests/gold_tests/post/delay_client3.sh
+++ b/tests/gold_tests/post/delay_client3.sh
@@ -1,0 +1,26 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+request ()
+{
+  printf "POST /six HTTP/1.1\r\nHost: bob\r\nContent-Length: 20\r\n\r\n"
+  printf "1234567890"
+  sleep 4
+  printf "0123456789"
+}
+
+outfile=$2
+request | nc 127.0.0.1 $1 > "$outfile"

--- a/tests/gold_tests/post/post-early-return.test.py
+++ b/tests/gold_tests/post/post-early-return.test.py
@@ -26,7 +26,12 @@ Test a case when the origin returns before the post is completed
 '''
 Test.ContinueOnFail = True
 
-Test.GetTcpPort("upstream_port")
+Test.GetTcpPort("upstream_port1")
+Test.GetTcpPort("upstream_port2")
+Test.GetTcpPort("upstream_port3")
+Test.GetTcpPort("upstream_port4")
+Test.GetTcpPort("upstream_port5")
+Test.GetTcpPort("upstream_port6")
 
 # ----
 # Setup ATS
@@ -36,9 +41,14 @@ ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(Test.Variables.upstream_port)
-)
+ts.Disk.remap_config.AddLines([
+    'map /one http://127.0.0.1:{0}'.format(Test.Variables.upstream_port1),
+    'map /two http://127.0.0.1:{0}'.format(Test.Variables.upstream_port2),
+    'map /three http://127.0.0.1:{0}'.format(Test.Variables.upstream_port3),
+    'map /four http://127.0.0.1:{0}'.format(Test.Variables.upstream_port4),
+    'map /five http://127.0.0.1:{0}'.format(Test.Variables.upstream_port5),
+    'map /six http://127.0.0.1:{0}'.format(Test.Variables.upstream_port6),
+])
 ts.Disk.ssl_multicert_config.AddLine(
     'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
 )
@@ -50,6 +60,19 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'http',
 })
 
+server1 = Test.Processes.Process("server1", "bash -c '" + Test.TestDirectory +
+                                 "/server1.sh {} outserver1'".format(Test.Variables.upstream_port1))
+server2 = Test.Processes.Process("server1", "bash -c '" + Test.TestDirectory +
+                                 "/server1.sh {} outserver1'".format(Test.Variables.upstream_port2))
+server3 = Test.Processes.Process("server1", "bash -c '" + Test.TestDirectory +
+                                 "/server1.sh {} outserver1'".format(Test.Variables.upstream_port3))
+server4 = Test.Processes.Process("server1", "bash -c '" + Test.TestDirectory +
+                                 "/server1.sh {} outserver1'".format(Test.Variables.upstream_port4))
+server5 = Test.Processes.Process("server1", "bash -c '" + Test.TestDirectory +
+                                 "/server1.sh {} outserver1'".format(Test.Variables.upstream_port5))
+server6 = Test.Processes.Process("server1", "bash -c '" + Test.TestDirectory +
+                                 "/server1.sh {} outserver1'".format(Test.Variables.upstream_port6))
+
 big_post_body = "0123456789" * 231070
 big_post_body_file = open(os.path.join(Test.RunDirectory, "big_post_body"), "w")
 big_post_body_file.write(big_post_body)
@@ -59,22 +82,25 @@ big_post_body_file.close()
 # The third case has an explicit multi-second sleep which ensures the early response path is exercised
 test_run = Test.AddTestRun("http1.1 Post with small body early return")
 test_run.Processes.Default.StartBefore(Test.Processes.ts)
-test_run.Processes.Default.Command = '(nc -o output --sh-exec \'printf \"HTTP/1.1 420 Be Calm\r\nContent-Length: 0\r\n\r\n\"; sleep 1\' -l 127.0.0.1 {} & ) ; sleep 1 ; curl -v -o /dev/null --http1.1 -d "small body" -k https://127.0.0.1:{}/post'.format(
-    Test.Variables.upstream_port, ts.Variables.ssl_port)
+test_run.Processes.Default.StartBefore(server1)
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http1.1 -d "small body" -k https://127.0.0.1:{}/one'.format(
+    ts.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 420 Be Calm", "Receive the early response")
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0
 
 test_run = Test.AddTestRun("http1.1 Post with large body early return")
-test_run.Processes.Default.Command = '(nc -o output2 --sh-exec \'printf \"HTTP/1.1 420 Be Calm\r\nContent-Length: 0\r\n\r\n\"; sleep 1\' -l 127.0.0.1 {} & ) ; sleep 1 ; curl -H "Expect:" -v -o /dev/null --http1.1 -d @big_post_body -k https://127.0.0.1:{}/post'.format(Test.Variables.upstream_port,
-                                                                                                                                                                                                                                                                            ts.Variables.ssl_port)
+test_run.Processes.Default.StartBefore(server2)
+test_run.Processes.Default.Command = 'curl -H "Expect:" -v -o /dev/null --http1.1 -d @big_post_body -k https://127.0.0.1:{}/two'.format(
+    ts.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 420 Be Calm", "Receive the early response")
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0
 
 test_run = Test.AddTestRun("http2 Post with large body, small window and early return")
-test_run.Processes.Default.Command = '(nc -o output2 --sh-exec \'printf \"HTTP/1.1 420 Be Calm\r\nContent-Length: 0\r\n\r\n\"; sleep 1\' -l 127.0.0.1 {} & ) ; sleep 1 ; curl -v -o /dev/null --http2 -d @big_post_body -k https://127.0.0.1:{}/post-http2'.format(
-    Test.Variables.upstream_port, ts.Variables.ssl_port)
+test_run.Processes.Default.StartBefore(server3)
+test_run.Processes.Default.Command = 'curl -v -o /dev/null --http2 -d @big_post_body -k https://127.0.0.1:{}/three'.format(
+    ts.Variables.ssl_port)
 test_run.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 420", "Receive the early response")
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0
@@ -95,19 +121,22 @@ client_out3.Content += Testers.ContainsExpression("HTTP/1.1 420 Be Calm", "Recei
 client_out3.Content += Testers.ContainsExpression("Connection: close", "ATS marks the client connection to close")
 
 test_run = Test.AddTestRun("http1.1 Post with paused body")
-test_run.Processes.Default.Command = '(nc -o output3 --sh-exec \'printf \"HTTP/1.1 420 Be Calm\r\nContent-Length: 0\r\n\r\n\"; sleep 1\' -l 127.0.0.1 {} & ) ; sleep 1 ; nc -o clientout --sh-exec \' printf \"POST /post HTTP/1.1\r\nHost: bob\r\nContent-Length: 20\r\n\r\n1234567890\"; sleep 4; printf \"0123456789\"\' 127.0.0.1 {}'.format(Test.Variables.upstream_port,
-                                                                                                                                                                                                                                                                                                                                                 ts.Variables.port)
+test_run.Processes.Default.StartBefore(server4)
+test_run.Setup.Copy("delay_client.sh")
+test_run.Processes.Default.Command = "sh ./delay_client.sh {} clientout".format(ts.Variables.port)
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0
 
 test_run = Test.AddTestRun("http1.1 Post with delayed and paused body")
-test_run.Processes.Default.Command = '(nc -o output3 --sh-exec \'printf \"HTTP/1.1 420 Be Calm\r\nContent-Length: 0\r\n\r\n\"; sleep 1\' -l 127.0.0.1 {} & ) ; sleep 1 ; nc -o clientout3 --sh-exec \' printf \"POST /post HTTP/1.1\r\nHost: bob\r\nContent-Length: 20\r\n\r\n\"; sleep 1; printf \"1234567890\"; sleep 4; printf \"0123456789\"\' 127.0.0.1 {}'.format(Test.Variables.upstream_port,
-                                                                                                                                                                                                                                                                                                                                                                        ts.Variables.port)
+test_run.Processes.Default.StartBefore(server5)
+test_run.Setup.Copy("delay_client2.sh")
+test_run.Processes.Default.Command = "sh ./delay_client2.sh {} clientout2".format(ts.Variables.port)
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0
 
 test_run = Test.AddTestRun("http1.1 Post with paused body and no delay on server")
-test_run.Processes.Default.Command = '(nc -o output4 --sh-exec \'printf \"HTTP/1.1 420 Be Calm\r\nContent-Length: 0\r\n\r\n\"\' -l 127.0.0.1 {} & ) ; sleep 1 ; nc -o clientout2 --sh-exec \' printf \"POST /post HTTP/1.1\r\nHost: bob\r\nContent-Length: 20\r\n\r\n1234567890\"; sleep 4; printf \"0123456789\"\' 127.0.0.1 {}'.format(Test.Variables.upstream_port,
-                                                                                                                                                                                                                                                                                                                                         ts.Variables.port)
+test_run.Processes.Default.StartBefore(server6)
+test_run.Setup.Copy("delay_client3.sh")
+test_run.Processes.Default.Command = "sh ./delay_client3.sh {} clientout3".format(ts.Variables.port)
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/post/server1.sh
+++ b/tests/gold_tests/post/server1.sh
@@ -1,0 +1,41 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# A very simple cleartext server for one HTTP transaction.  Does no validation of the Request message.
+# Sends a fixed response message
+
+
+response ()
+{
+  # Wait for end of Request message.
+  #
+  while (( 1 == 1 ))
+  do
+    if [[ -f $outfile ]] ; then
+      if tr '\r\n' '=!' < $outfile | grep '=!=!' > /dev/null
+      then
+        break;
+      fi
+    fi
+    sleep 1
+  done
+
+
+  printf "HTTP/1.1 420 Be Calm\r\nContent-Length: 0\r\n\r\n"
+
+}
+outfile=$2
+response | nc -l $1 > "$outfile"


### PR DESCRIPTION
Fixing post-early-return test to use the base options of netcat so it will work on ubuntu22 as well.