### PR TITLE
Reenable management control for TS logging

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2172,7 +2172,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     }
 
     // initialize logging (after event and net processor)
-    Log::init(Log::NO_REMOTE_MANAGEMENT);
+    Log::init();
 
     (void)parsePluginConfig();
 


### PR DESCRIPTION
We observed that `logging.yaml` is not reloading with `traffic_ctl config reload`. This PR removes the`Log::NO_REMOTE_MANAGEMENT` flag passed when initializing the logging module, so that the update callbacks are registered. 

This fixes #10850.