### PR TITLE
Fix logging path for regex_revalidate_state

### DIFF
--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_state.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_state.test.py
@@ -61,7 +61,7 @@ response_header_0 = {"headers":
 server.addResponse("sessionlog.json", request_header_0, response_header_0)
 
 reval_conf_path = os.path.join(ts.Variables.CONFIGDIR, 'reval.conf')
-reval_state_path = os.path.join(Test.Variables.RUNTIMEDIR, 'reval.state')
+reval_state_path = os.path.join(ts.Variables.RUNTIMEDIR, 'reval.state')
 
 # Configure ATS server
 ts.Disk.plugin_config.AddLine(


### PR DESCRIPTION
regex_revalidate_state was failing with me since it was placing the plugin's log file in the subdir corresponding to ats_bin_dir.  In my environment that is /opt/ats and not writable by non-privileged processes.  Adjusting the path to sit in the sandbox directory.