### PR TITLE
Fix remap_inc test for systems with dash

### DIFF
--- a/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
+++ b/tests/gold_tests/traffic_ctl/remap_inc/remap_inc.test.py
@@ -74,8 +74,8 @@ tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
 
 tr = Test.AddTestRun("Get response from generator")
-tr.Processes.Default.Command = (
-    f'test $$(curl --proxy 127.0.0.1:{ts.Variables.port} http://example.four/nocache/5 | wc -c) == 5'
-)
+tr.Processes.Default.Command = f'curl --proxy 127.0.0.1:{ts.Variables.port} http://example.four/nocache/5'
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("xxxxx", "Contains generated text")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("xxxxxx", "Not too much data")


### PR DESCRIPTION
Removed the non-basic shell code test. Will not run with /bin/sh == dash on ubuntu 22.  Replaced the check with content checks on the output.