### PR TITLE
9.2.x: yapf: use yapf instead of autopep8

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,421 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+[style]
+based_on_style = yapf
+
+# Align closing bracket with visual indentation.
+align_closing_bracket_with_visual_indent=False
+
+# Allow dictionary keys to exist on multiple lines. For example:
+#
+#   x = {
+#       ('this is the first element of a tuple',
+#        'this is the second element of a tuple'):
+#            value,
+#   }
+allow_multiline_dictionary_keys=True
+
+# Allow lambdas to be formatted on more than one line.
+allow_multiline_lambdas=False
+
+# Allow splitting before a default / named assignment in an argument list.
+allow_split_before_default_or_named_assigns=False
+
+# Allow splits before the dictionary value.
+allow_split_before_dict_value=False
+
+#   Let spacing indicate operator precedence. For example:
+#
+#     a = 1 * 2 + 3 / 4
+#     b = 1 / 2 - 3 * 4
+#     c = (1 + 2) * (3 - 4)
+#     d = (1 - 2) / (3 + 4)
+#     e = 1 * 2 - 3
+#     f = 1 + 2 + 3 + 4
+#
+# will be formatted as follows to indicate precedence:
+#
+#     a = 1*2 + 3/4
+#     b = 1/2 - 3*4
+#     c = (1+2) * (3-4)
+#     d = (1-2) / (3+4)
+#     e = 1*2 - 3
+#     f = 1 + 2 + 3 + 4
+#
+arithmetic_precedence_indication=False
+
+# Number of blank lines surrounding top-level function and class
+# definitions.
+blank_lines_around_top_level_definition=2
+
+# Number of blank lines between top-level imports and variable
+# definitions.
+blank_lines_between_top_level_imports_and_variables=1
+
+# Insert a blank line before a class-level docstring.
+blank_line_before_class_docstring=False
+
+# Insert a blank line before a module docstring.
+blank_line_before_module_docstring=False
+
+# Insert a blank line before a 'def' or 'class' immediately nested
+# within another 'def' or 'class'. For example:
+#
+#   class Foo:
+#                      # <------ this blank line
+#     def method():
+#       pass
+blank_line_before_nested_class_or_def=True
+
+# Do not split consecutive brackets. Only relevant when
+# dedent_closing_brackets is set. For example:
+#
+#    call_func_that_takes_a_dict(
+#        {
+#            'key1': 'value1',
+#            'key2': 'value2',
+#        }
+#    )
+#
+# would reformat to:
+#
+#    call_func_that_takes_a_dict({
+#        'key1': 'value1',
+#        'key2': 'value2',
+#    })
+coalesce_brackets=False
+
+# The column limit.
+column_limit=132
+
+# The style for continuation alignment. Possible values are:
+#
+# - SPACE: Use spaces for continuation alignment. This is default behavior.
+# - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
+#   (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs or
+#   CONTINUATION_INDENT_WIDTH spaces) for continuation alignment.
+# - VALIGN-RIGHT: Vertically align continuation lines to multiple of
+#   INDENT_WIDTH columns. Slightly right (one tab or a few spaces) if
+#   cannot vertically align continuation lines with indent characters.
+continuation_align_style=SPACE
+
+# Indent width used for line continuations.
+continuation_indent_width=4
+
+# Put closing brackets on a separate line, dedented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#   }        # <--- this bracket is dedented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#   )        # <--- this bracket is dedented and on a separate line
+dedent_closing_brackets=False
+
+# Disable the heuristic which places each list element on a separate line
+# if the list is comma-terminated.
+disable_ending_comma_heuristic=False
+
+# Place each dictionary entry onto its own line.
+each_dict_entry_on_separate_line=True
+
+# Require multiline dictionary even if it would normally fit on one line.
+# For example:
+#
+#   config = {
+#       'key1': 'value1'
+#   }
+force_multiline_dict=False
+
+# The regex for an i18n comment. The presence of this comment stops
+# reformatting of that line, because the comments are required to be
+# next to the string they translate.
+i18n_comment=#\..*
+
+# The i18n function call names. The presence of this function stops
+# reformattting on that line, because the string it has cannot be moved
+# away from the i18n comment.
+i18n_function_call=N_, _
+
+# Indent blank lines.
+indent_blank_lines=False
+
+# Put closing brackets on a separate line, indented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#       }        # <--- this bracket is indented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#       )        # <--- this bracket is indented and on a separate line
+indent_closing_brackets=False
+
+# Indent the dictionary value if it cannot fit on the same line as the
+# dictionary key. For example:
+#
+#   config = {
+#       'key1':
+#           'value1',
+#       'key2': value1 +
+#               value2,
+#   }
+indent_dictionary_value=True
+
+# The number of columns to use for indentation.
+indent_width=4
+
+# Join short lines into one line. E.g., single line 'if' statements.
+join_multiple_lines=False
+
+# Do not include spaces around selected binary operators. For example:
+#
+#   1 + 2 * 3 - 4 / 5
+#
+# will be formatted as follows when configured with "*,/":
+#
+#   1 + 2*3 - 4/5
+no_spaces_around_selected_binary_operators=
+
+# Use spaces around default or named assigns.
+spaces_around_default_or_named_assign=False
+
+# Adds a space after the opening '{' and before the ending '}' dict
+# delimiters.
+#
+#   {1: 2}
+#
+# will be formatted as:
+#
+#   { 1: 2 }
+spaces_around_dict_delimiters=False
+
+# Adds a space after the opening '[' and before the ending ']' list
+# delimiters.
+#
+#   [1, 2]
+#
+# will be formatted as:
+#
+#   [ 1, 2 ]
+spaces_around_list_delimiters=False
+
+# Use spaces around the power operator.
+spaces_around_power_operator=False
+
+# Use spaces around the subscript / slice operator.  For example:
+#
+#   my_list[1 : 10 : 2]
+spaces_around_subscript_colon=False
+
+# Adds a space after the opening '(' and before the ending ')' tuple
+# delimiters.
+#
+#   (1, 2, 3)
+#
+# will be formatted as:
+#
+#   ( 1, 2, 3 )
+spaces_around_tuple_delimiters=False
+
+# The number of spaces required before a trailing comment.
+# This can be a single value (representing the number of spaces
+# before each trailing comment) or list of values (representing
+# alignment column values; trailing comments within a block will
+# be aligned to the first column value that is greater than the maximum
+# line length within the block). For example:
+#
+# With spaces_before_comment=5:
+#
+#   1 + 1 # Adding values
+#
+# will be formatted as:
+#
+#   1 + 1     # Adding values <-- 5 spaces between the end of the
+#             # statement and comment
+#
+# With spaces_before_comment=15, 20:
+#
+#   1 + 1 # Adding values
+#   two + two # More adding
+#
+#   longer_statement # This is a longer statement
+#   short # This is a shorter statement
+#
+#   a_very_long_statement_that_extends_beyond_the_final_column # Comment
+#   short # This is a shorter statement
+#
+# will be formatted as:
+#
+#   1 + 1          # Adding values <-- end of line comments in block
+#                  # aligned to col 15
+#   two + two      # More adding
+#
+#   longer_statement    # This is a longer statement <-- end of line
+#                       # comments in block aligned to col 20
+#   short               # This is a shorter statement
+#
+#   a_very_long_statement_that_extends_beyond_the_final_column  # Comment <-- the end of line comments are aligned based on the line length
+#   short                                                       # This is a shorter statement
+#
+spaces_before_comment=2
+
+# Insert a space between the ending comma and closing bracket of a list,
+# etc.
+space_between_ending_comma_and_closing_bracket=False
+
+# Use spaces inside brackets, braces, and parentheses.  For example:
+#
+#   method_call( 1 )
+#   my_dict[ 3 ][ 1 ][ get_index( *args, **kwargs ) ]
+#   my_set = { 1, 2, 3 }
+space_inside_brackets=False
+
+# Split before arguments.
+split_all_comma_separated_values=False
+
+# Split before arguments, but do not split all subexpressions recursively
+# (unless needed).
+split_all_top_level_comma_separated_values=False
+
+# Split before arguments if the argument list is terminated by a
+# comma.
+split_arguments_when_comma_terminated=False
+
+# Set to True to prefer splitting before '+', '-', '*', '/', '//', or '@'
+# rather than after.
+split_before_arithmetic_operator=False
+
+# Set to True to prefer splitting before '&', '|' or '^' rather than
+# after.
+split_before_bitwise_operator=True
+
+# Split before the closing bracket if a list or dict literal doesn't fit on
+# a single line.
+split_before_closing_bracket=True
+
+# Split before a dictionary or set generator (comp_for). For example, note
+# the split before the 'for':
+#
+#   foo = {
+#       variable: 'Hello world, have a nice day!'
+#       for variable in bar if variable != 42
+#   }
+split_before_dict_set_generator=False
+
+# Split before the '.' if we need to split a longer expression:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'.format(a, b, c, d))
+#
+# would reformat to something like:
+#
+#   foo = ('This is a really long string: {}, {}, {}, {}'
+#          .format(a, b, c, d))
+split_before_dot=True
+
+# Split after the opening paren which surrounds an expression if it doesn't
+# fit on a single line.
+split_before_expression_after_opening_paren=True
+
+# If an argument / parameter list is going to be split, then split before
+# the first argument.
+split_before_first_argument=True
+
+# Set to True to prefer splitting before 'and' or 'or' rather than
+# after.
+split_before_logical_operator=False
+
+# Split named assignments onto individual lines.
+split_before_named_assigns=True
+
+# Set to True to split list comprehensions and generators that have
+# non-trivial expressions and multiple clauses before each of these
+# clauses. For example:
+#
+#   result = [
+#       a_long_var + 100 for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+#
+# would reformat to something like:
+#
+#   result = [
+#       a_long_var + 100
+#       for a_long_var in xrange(1000)
+#       if a_long_var % 10]
+split_complex_comprehension=True
+
+# The penalty for splitting right after the opening bracket.
+split_penalty_after_opening_bracket=300
+
+# The penalty for splitting the line after a unary operator.
+split_penalty_after_unary_operator=10000
+
+# The penalty of splitting the line around the '+', '-', '*', '/', '//',
+# `%`, and '@' operators.
+split_penalty_arithmetic_operator=300
+
+# The penalty for splitting right before an if expression.
+split_penalty_before_if_expr=0
+
+# The penalty of splitting the line around the '&', '|', and '^' operators.
+split_penalty_bitwise_operator=300
+
+# The penalty for splitting a list comprehension or generator
+# expression.
+split_penalty_comprehension=2100
+
+# The penalty for characters over the column limit.
+split_penalty_excess_character=7000
+
+# The penalty incurred by adding a line split to the logical line. The
+# more line splits added the higher the penalty.
+split_penalty_for_added_line_split=30
+
+# The penalty of splitting a list of "import as" names. For example:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (long_argument_1,
+#                                                             long_argument_2,
+#                                                             long_argument_3)
+#
+# would reformat to something like:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (
+#       long_argument_1, long_argument_2, long_argument_3)
+split_penalty_import_names=0
+
+# The penalty of splitting the line around the 'and' and 'or' operators.
+split_penalty_logical_operator=300
+
+# Use the Tab character for indentation.
+use_tabs=False
+

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,18 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+lib/*

--- a/Makefile.am
+++ b/Makefile.am
@@ -113,9 +113,9 @@ endif
 rat:
 	java -jar $(top_srcdir)/ci/apache-rat-0.13-SNAPSHOT.jar -E $(top_srcdir)/ci/rat-regex.txt  -d $(top_srcdir)
 
-.PHONY: autopep8
-autopep8:
-	@$(top_srcdir)/tools/autopep8.sh $(top_srcdir)
+.PHONY: yapf
+yapf:
+	@$(top_srcdir)/tools/yapf.sh $(top_srcdir)
 
 #
 # These are rules to make clang-format easy and fast to run. Run it with e.g.
@@ -174,7 +174,7 @@ clang-format-tests:
 # Run the various format targets. perltidy is not included because the user may
 # not have it installed.
 .PHONY: format
-format: clang-format autopep8
+format: clang-format yapf
 
 .PHONY: perltidy
 perltidy:
@@ -200,4 +200,4 @@ help:
 	@echo 'rat              produce a RAT licence compliance report of the source'
 	@echo 'rel-candidate    recreate a signed relelease candidate source package and a signed git tag'
 	@echo 'release          recreate a signed release source package and a signed git tag'
-	@echo 'autopep8         run autopep8 over python files'
+	@echo 'yapf             run yapf over python files'

--- a/contrib/python/compare_RecordsConfigcc.py
+++ b/contrib/python/compare_RecordsConfigcc.py
@@ -102,7 +102,6 @@ if len(defaults) > 0:
     for d in sorted(defaults):
         print("\t%s %s -> %s" % (d, "%s %s" % rc_cc[d], "%s %s" % rc_doc[d]))
 
-
 # Search for stale documentation ...
 stale = [k for k in rc_doc if k not in rc_cc]
 if (len(stale) > 0):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,8 +54,8 @@ sys.path.insert(0, os.path.abspath('.'))
 def setup(app):
     app.add_css_file('override.css')
 
-# -- General configuration -----------------------------------------------------
 
+# -- General configuration -----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -109,7 +109,6 @@ copyright = f'{date.today().year}, dev@trafficserver.apache.org'
 # Extract the version from the configure.ac file with regex so as to
 # work identically when building with Autotools (e.g. $ make html)
 # and without (e.g. on Read the Docs)
-
 
 contents = open('../configure.ac').read()
 match = re.compile(r'm4_define\(\[TS_VERSION_S],\[(.*?)]\)').search(contents)
@@ -182,23 +181,23 @@ pygments_style = 'default'
 #modindex_common_prefix = []
 
 nitpicky = True
-nitpick_ignore = [('c:identifier', 'int64_t'),
-                  ('c:identifier', 'uint64_t'),
-                  ('c:identifier', 'uint8_t'),
-                  ('c:identifier', 'int32_t'),
-                  ('c:identifier', 'size_t'),
-                  ('c:identifier', 'ssize_t'),
-                  ('c:identifier', 'sockaddr'),
-                  ('c:identifier', 'time_t'),
-                  ('cpp:identifier', 'T'),  # template arg
-                  ('cpp:identifier', 'F'),  # template arg
-                  ('cpp:identifier', 'Args'),  # variadic template arg
-                  ('cpp:identifier', 'Rest'),  # variadic template arg
-                  ]
+nitpick_ignore = [
+    ('c:identifier', 'int64_t'),
+    ('c:identifier', 'uint64_t'),
+    ('c:identifier', 'uint8_t'),
+    ('c:identifier', 'int32_t'),
+    ('c:identifier', 'size_t'),
+    ('c:identifier', 'ssize_t'),
+    ('c:identifier', 'sockaddr'),
+    ('c:identifier', 'time_t'),
+    ('cpp:identifier', 'T'),  # template arg
+    ('cpp:identifier', 'F'),  # template arg
+    ('cpp:identifier', 'Args'),  # variadic template arg
+    ('cpp:identifier', 'Rest'),  # variadic template arg
+]
 
 # Autolink issue references.
 # See Customizing the Parser in the docutils.parsers.rst module.
-
 
 # Customize parser.inliner in the only way that Sphinx supports.
 # docutils.parsers.rst.Parser takes an instance of states.Inliner or a
@@ -211,6 +210,7 @@ BaseInliner = states.Inliner
 
 
 class Inliner(states.Inliner):
+
     def init_customizations(self, settings):
         self.__class__ = BaseInliner
         BaseInliner.init_customizations(self, settings)
@@ -219,22 +219,17 @@ class Inliner(states.Inliner):
         # Copied from states.Inliner.init_customizations().
         # In Docutils 0.13 these are locals.
         if not hasattr(self, 'start_string_prefix'):
-            self.start_string_prefix = (u'(^|(?<=\\s|[%s%s]))' %
-                                        (punctuation_chars.openers,
-                                         punctuation_chars.delimiters))
+            self.start_string_prefix = (u'(^|(?<=\\s|[%s%s]))' % (punctuation_chars.openers, punctuation_chars.delimiters))
         if not hasattr(self, 'end_string_suffix'):
-            self.end_string_suffix = (u'($|(?=\\s|[\x00%s%s%s]))' %
-                                      (punctuation_chars.closing_delimiters,
-                                       punctuation_chars.delimiters,
-                                       punctuation_chars.closers))
+            self.end_string_suffix = (
+                u'($|(?=\\s|[\x00%s%s%s]))' %
+                (punctuation_chars.closing_delimiters, punctuation_chars.delimiters, punctuation_chars.closers))
 
         issue = re.compile(
             r'''
       {start_string_prefix}
       TS-\d+
-      {end_string_suffix}'''.format(
-                start_string_prefix=self.start_string_prefix,
-                end_string_suffix=self.end_string_suffix),
+      {end_string_suffix}'''.format(start_string_prefix=self.start_string_prefix, end_string_suffix=self.end_string_suffix),
             re.VERBOSE | re.UNICODE)
 
         self.implicit_dispatch.append((issue, self.issue_reference))
@@ -352,8 +347,7 @@ elif 'latex_paper' in tags:
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'ApacheTrafficServer.tex', u'Apache Traffic Server Documentation',
-     u'dev@trafficserver.apache.org', 'manual'),
+    ('index', 'ApacheTrafficServer.tex', u'Apache Traffic Server Documentation', u'dev@trafficserver.apache.org', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -388,7 +382,6 @@ latex_documents = [
 # documents and includes the same brief description in both the HTML
 # and manual page outputs.
 
-
 # Override ManualPageWriter and ManualPageTranslator in the only way
 # that Sphinx supports
 
@@ -396,6 +389,7 @@ BaseWriter = manpage.ManualPageWriter
 
 
 class ManualPageWriter(BaseWriter):
+
     def translate(self):
         transform = frontmatter.DocTitle(self.document)
 
@@ -427,6 +421,7 @@ BaseTranslator = manpage.ManualPageTranslator
 
 
 class ManualPageTranslator(BaseTranslator):
+
     def __init__(self, builder, *args, **kwds):
         BaseTranslator.__init__(self, builder, *args, **kwds)
 
@@ -443,9 +438,9 @@ manpage.ManualPageTranslator = ManualPageTranslator
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'ApacheTrafficServer', u'Apache Traffic Server Documentation',
-     u'dev@trafficserver.apache.org', 'ApacheTrafficServer', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        'index', 'ApacheTrafficServer', u'Apache Traffic Server Documentation', u'dev@trafficserver.apache.org',
+        'ApacheTrafficServer', 'One line description of project.', 'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/doc/ext/doxygen.py
+++ b/doc/ext/doxygen.py
@@ -44,7 +44,7 @@ def escape(name):
     Partial reimplementation in Python of Doxygen escapeCharsInString()
     """
 
-    return name.replace('_', '__').replace(':', '_1').replace('/', '_2').replace('<', '_3').replace('>', '_4').replace('*', '_5').replace('&', '_6').replace('|', '_7').replace('.', '_8').replace('!', '_9').replace(',', '_00').replace(' ', '_01').replace('{', '_02').replace('}', '_03').replace('?', '_04').replace('^', '_05').replace('%', '_06').replace('(', '_07').replace(')', '_08').replace('+', '_09').replace('=', '_0A').replace('$', '_0B').replace('\\', '_0C')  # nopep8
+    return name.replace('_', '__').replace(':', '_1').replace('/', '_2').replace('<', '_3').replace('>', '_4').replace('*', '_5').replace('&', '_6').replace('|', '_7').replace('.', '_8').replace('!', '_9').replace(',', '_00').replace(' ', '_01').replace('{', '_02').replace('}', '_03').replace('?', '_04').replace('^', '_05').replace('%', '_06').replace('(', '_07').replace(')', '_08').replace('+', '_09').replace('=', '_0A').replace('$', '_0B').replace('\\', '_0C')  # yapf: disable
 
 
 class doctree_resolved:

--- a/doc/ext/doxygen.py
+++ b/doc/ext/doxygen.py
@@ -100,7 +100,9 @@ class doctree_resolved:
                         # Lookup the object in the Doxygen index
                         try:
                             compound, = index.xpath(
-                                'descendant::compound[(not($owner) or name[text() = $owner]) and descendant::name[text() = $name]][1]', owner=signature_owner or owner, name=name)
+                                'descendant::compound[(not($owner) or name[text() = $owner]) and descendant::name[text() = $name]][1]',
+                                owner=signature_owner or owner,
+                                name=name)
 
                         except ValueError:
                             continue
@@ -112,7 +114,7 @@ class doctree_resolved:
                         # An enumvalue has no location
                         memberdef, = cache[filename].xpath(
                             'descendant::compounddef[compoundname[text() = $name]]', name=name) or cache[filename].xpath(
-                            'descendant::memberdef[name[text() = $name] | enumvalue[name[text() = $name]]]', name=name)
+                                'descendant::memberdef[name[text() = $name] | enumvalue[name[text() = $name]]]', name=name)
 
                         # Append the link after the object's signature.
                         # Get the source file and line number from Doxygen and use
@@ -137,8 +139,8 @@ class doctree_resolved:
                         else:
                             refuri = 'http://docs.trafficserver.apache.org/en/latest/' + refuri
 
-                        reference = nodes.reference('', '', emphasis, classes=[
-                                                    'viewcode-link'], reftitle='Source code', refuri=refuri)
+                        reference = nodes.reference(
+                            '', '', emphasis, classes=['viewcode-link'], reftitle='Source code', refuri=refuri)
                         desc_child += reference
 
                         # Style the links
@@ -159,13 +161,15 @@ def setup(app):
 
     else:
         if not etree:
-            app.warn('''Python lxml library not found
+            app.warn(
+                '''Python lxml library not found
   The library is used to add links from an API description to the source
   code for that object.
   Depending on your system, try installing the python-lxml package.''')
 
         if not path.isfile('xml/index.xml'):
-            app.warn('''Doxygen files not found: xml/index.xml
+            app.warn(
+                '''Doxygen files not found: xml/index.xml
   The files are used to add links from an API description to the source
   code for that object.
   Run "$ make doxygen" to generate these XML files.''')

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -15,7 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
     TS Sphinx Directives
     ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -45,6 +44,7 @@ try:
     def is_string_type(s):
         return isinstance(s, basestring)
 except NameError:
+
     def is_string_type(s):
         return isinstance(s, str)
 
@@ -161,6 +161,7 @@ class TSConfVar(std.Target):
 
 
 class TSConfVarRef(XRefRole):
+
     def process_link(self, env, ref_node, explicit_title_p, title, target):
         return title, target
 
@@ -171,18 +172,9 @@ def metrictypes(typename):
 
 def metricunits(unitname):
     return directives.choice(
-        unitname.lower(),
-        ('ratio',
-         'percent',
-         'kbits',
-         'mbits',
-         'bytes',
-         'kbytes',
-         'mbytes',
-         'nanoseconds',
-         'microseconds',
-         'milliseconds',
-         'seconds'))
+        unitname.lower(), (
+            'ratio', 'percent', 'kbits', 'mbits', 'bytes', 'kbytes', 'mbytes', 'nanoseconds', 'microseconds', 'milliseconds',
+            'seconds'))
 
 
 class TSStat(std.Target):
@@ -301,6 +293,7 @@ class TSStat(std.Target):
 
 
 class TSStatRef(XRefRole):
+
     def process_link(self, env, ref_node, explicit_title_p, title, target):
         return title, target
 
@@ -319,15 +312,9 @@ class TrafficServerDomain(Domain):
         'stat': ObjType(_('statistic'), 'stat')
     }
 
-    directives = {
-        'cv': TSConfVar,
-        'stat': TSStat
-    }
+    directives = {'cv': TSConfVar, 'stat': TSStat}
 
-    roles = {
-        'cv': TSConfVarRef(),
-        'stat': TSStatRef()
-    }
+    roles = {'cv': TSConfVarRef(), 'stat': TSStatRef()}
 
     initial_data = {
         'cv': {},  # full name -> docname
@@ -380,6 +367,7 @@ class TrafficServerDomain(Domain):
             for var, doc in self.data['stat'].iteritems():
                 yield var, var, 'stat', doc, var, 1
     except AttributeError:
+
         def get_objects(self):
             for var, doc in self.data['cv'].items():
                 yield var, var, 'cv', doc, var, 1
@@ -388,8 +376,7 @@ class TrafficServerDomain(Domain):
 
 
 # get the branch this documentation is building for in X.X.x form
-REPO_ROOT = os.path.join(os.path.dirname(os.path.dirname(
-    os.environ['DOCUTILSCONFIG'])))
+REPO_ROOT = os.path.join(os.path.dirname(os.path.dirname(os.environ['DOCUTILSCONFIG'])))
 CONFIGURE_AC = os.path.join(REPO_ROOT, 'configure.ac')
 with open(CONFIGURE_AC, 'r') as f:
     contents = f.read()
@@ -398,8 +385,7 @@ with open(CONFIGURE_AC, 'r') as f:
 
 # get the current branch the local repository is on
 REPO_GIT_DIR = os.path.join(REPO_ROOT, ".git")
-git_branch = subprocess.check_output(['git', '--git-dir', REPO_GIT_DIR,
-                                      'rev-parse', '--abbrev-ref', 'HEAD'])
+git_branch = subprocess.check_output(['git', '--git-dir', REPO_GIT_DIR, 'rev-parse', '--abbrev-ref', 'HEAD'])
 
 
 def make_github_link(name, rawtext, text, lineno, inliner, options=None, content=None):
@@ -429,9 +415,7 @@ def make_github_link(name, rawtext, text, lineno, inliner, options=None, content
 
 
 def setup(app):
-    app.add_crossref_type('configfile', 'file',
-                          objname='Configuration file',
-                          indextemplate='pair: %s; Configuration files')
+    app.add_crossref_type('configfile', 'file', objname='Configuration file', indextemplate='pair: %s; Configuration files')
 
     # Very ugly, but as of Sphinx 1.8 it must be done. There is an `override` option to add_crossref_type
     # but it only applies to the directive, not the role (`file` in this case). If this isn't cleared
@@ -440,9 +424,7 @@ def setup(app):
     # names are disjoint sets.
     del app.registry.domain_roles['std']['file']
 
-    app.add_crossref_type('logfile', 'file',
-                          objname='Log file',
-                          indextemplate='pair: %s; Log files')
+    app.add_crossref_type('logfile', 'file', objname='Log file', indextemplate='pair: %s; Log files')
 
     rst.roles.register_generic_role('arg', nodes.emphasis)
     rst.roles.register_generic_role('const', nodes.literal)

--- a/doc/manpages.py
+++ b/doc/manpages.py
@@ -19,68 +19,47 @@ import os
 man_pages = [
     # Add all files in the reference/api directory to the list of manual
     # pages
-    ('developer-guide/api/functions/' + filename[:-4], filename.split('.', 1)[0], filename.split('.', 1)[0] + ' API function', None, '3ts') for filename in os.listdir('developer-guide/api/functions/') if filename != 'index.en.rst' and filename.endswith('.rst')] + [
+    (
+        'developer-guide/api/functions/' + filename[:-4], filename.split(
+            '.', 1)[0], filename.split('.', 1)[0] + ' API function', None, '3ts')
+    for filename in os.listdir('developer-guide/api/functions/')
+    if filename != 'index.en.rst' and filename.endswith('.rst')
+] + [
 
     # Add all files in the appendices/command-line directory to the list
     # of manual pages
-    ('appendices/command-line/traffic_cache_tool.en', 'traffic_cache_tool',
-        u'Traffic Server cache management tool', None, '1'),
-    ('appendices/command-line/traffic_crashlog.en', 'traffic_crashlog',
-        u'Traffic Server crash log helper', None, '8'),
-    ('appendices/command-line/traffic_ctl.en', 'traffic_ctl',
-        u'Traffic Server command line tool', None, '8'),
-    ('appendices/command-line/traffic_layout.en', 'traffic_layout',
-        u'Traffic Server sandbox management tool', None, '1'),
-    ('appendices/command-line/traffic_logcat.en', 'traffic_logcat',
-        u'Traffic Server log spooler', None, '8'),
-    ('appendices/command-line/traffic_logstats.en', 'traffic_logstats',
-        u'Traffic Server analyzer', None, '8'),
-    ('appendices/command-line/traffic_manager.en', 'traffic_manager',
-        u'Traffic Server process manager', None, '8'),
-    ('appendices/command-line/traffic_server.en', 'traffic_server',
-        u'Traffic Server', None, '8'),
-    ('appendices/command-line/traffic_top.en', 'traffic_top',
-        u'Display Traffic Server statistics', None, '1'),
-    ('appendices/command-line/traffic_via.en', 'traffic_via',
-        u'Traffic Server Via header decoder', None, '1'),
-    ('appendices/command-line/traffic_wccp.en', 'traffic_wccp',
-        u'Traffic Server WCCP client', None, '1'),
-    ('appendices/command-line/tspush.en', 'tspush',
-        u'Push objects into the Traffic Server cache', None, '1'),
-    ('appendices/command-line/tsxs.en', 'tsxs',
-        u'Traffic Server plugin tool', None, '1'),
+    ('appendices/command-line/traffic_cache_tool.en', 'traffic_cache_tool', u'Traffic Server cache management tool', None, '1'),
+    ('appendices/command-line/traffic_crashlog.en', 'traffic_crashlog', u'Traffic Server crash log helper', None, '8'),
+    ('appendices/command-line/traffic_ctl.en', 'traffic_ctl', u'Traffic Server command line tool', None, '8'),
+    ('appendices/command-line/traffic_layout.en', 'traffic_layout', u'Traffic Server sandbox management tool', None, '1'),
+    ('appendices/command-line/traffic_logcat.en', 'traffic_logcat', u'Traffic Server log spooler', None, '8'),
+    ('appendices/command-line/traffic_logstats.en', 'traffic_logstats', u'Traffic Server analyzer', None, '8'),
+    ('appendices/command-line/traffic_manager.en', 'traffic_manager', u'Traffic Server process manager', None, '8'),
+    ('appendices/command-line/traffic_server.en', 'traffic_server', u'Traffic Server', None, '8'),
+    ('appendices/command-line/traffic_top.en', 'traffic_top', u'Display Traffic Server statistics', None, '1'),
+    ('appendices/command-line/traffic_via.en', 'traffic_via', u'Traffic Server Via header decoder', None, '1'),
+    ('appendices/command-line/traffic_wccp.en', 'traffic_wccp', u'Traffic Server WCCP client', None, '1'),
+    ('appendices/command-line/tspush.en', 'tspush', u'Push objects into the Traffic Server cache', None, '1'),
+    ('appendices/command-line/tsxs.en', 'tsxs', u'Traffic Server plugin tool', None, '1'),
 
     # Add all files in the admin-guide/files directory to the list
     # of manual pages
-    ('admin-guide/files/cache.config.en', 'cache.config',
-        u'Traffic Server cache configuration file', None, '5'),
-    ('admin-guide/files/hosting.config.en', 'hosting.config',
-        u'Traffic Server domain hosting configuration file', None, '5'),
-    ('admin-guide/files/ip_allow.yaml.en', 'ip_allow.yaml',
-        u'Traffic Server IP access control configuration file', None, '5'),
-    ('admin-guide/files/logging.yaml.en', 'logging.yaml',
-        u'Traffic Server logging configuration file', None, '5'),
-    ('admin-guide/files/parent.config.en', 'parent.config',
-        u'Traffic Server parent cache configuration file', None, '5'),
-    ('admin-guide/files/plugin.config.en', 'plugin.config',
-        u'Traffic Server global plugin configuration file', None, '5'),
-    ('admin-guide/files/records.config.en', 'records.config',
-        u'Traffic Server configuration file', None, '5'),
-    ('admin-guide/files/remap.config.en', 'remap.config',
-        u'Traffic Server remap rules configuration file', None, '5'),
-    ('admin-guide/files/sni.yaml.en', 'sni.yaml',
-        u'Traffic Server sni rules configuration file', None, '5'),
-    ('admin-guide/files/splitdns.config.en', 'splitdns.config',
-        u'Traffic Server split DNS configuration file', None, '5'),
-    ('admin-guide/files/ssl_multicert.config.en', 'ssl_multicert.config',
-        u'Traffic Server SSL certificate configuration file', None, '5'),
-    ('admin-guide/files/storage.config.en', 'storage.config',
-        u'Traffic Server cache storage configuration file', None, '5'),
-    ('admin-guide/files/strategies.yaml.en', 'strategies.yaml',
-        u'Traffic Server cache hierarchy configuration file', None, '5'),
-    ('admin-guide/files/volume.config.en', 'volume.config',
-        u'Traffic Server cache volume configuration file', None, '5'),
-
+    ('admin-guide/files/cache.config.en', 'cache.config', u'Traffic Server cache configuration file', None, '5'),
+    ('admin-guide/files/hosting.config.en', 'hosting.config', u'Traffic Server domain hosting configuration file', None, '5'),
+    ('admin-guide/files/ip_allow.yaml.en', 'ip_allow.yaml', u'Traffic Server IP access control configuration file', None, '5'),
+    ('admin-guide/files/logging.yaml.en', 'logging.yaml', u'Traffic Server logging configuration file', None, '5'),
+    ('admin-guide/files/parent.config.en', 'parent.config', u'Traffic Server parent cache configuration file', None, '5'),
+    ('admin-guide/files/plugin.config.en', 'plugin.config', u'Traffic Server global plugin configuration file', None, '5'),
+    ('admin-guide/files/records.config.en', 'records.config', u'Traffic Server configuration file', None, '5'),
+    ('admin-guide/files/remap.config.en', 'remap.config', u'Traffic Server remap rules configuration file', None, '5'),
+    ('admin-guide/files/sni.yaml.en', 'sni.yaml', u'Traffic Server sni rules configuration file', None, '5'),
+    ('admin-guide/files/splitdns.config.en', 'splitdns.config', u'Traffic Server split DNS configuration file', None, '5'),
+    (
+        'admin-guide/files/ssl_multicert.config.en', 'ssl_multicert.config', u'Traffic Server SSL certificate configuration file',
+        None, '5'),
+    ('admin-guide/files/storage.config.en', 'storage.config', u'Traffic Server cache storage configuration file', None, '5'),
+    ('admin-guide/files/strategies.yaml.en', 'strategies.yaml', u'Traffic Server cache hierarchy configuration file', None, '5'),
+    ('admin-guide/files/volume.config.en', 'volume.config', u'Traffic Server cache volume configuration file', None, '5'),
 ]
 
 if __name__ == '__main__':

--- a/plugins/experimental/ssl_session_reuse/tests/plug-load.test.py
+++ b/plugins/experimental/ssl_session_reuse/tests/plug-load.test.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 Test a basic remap of a http connection
 '''
@@ -40,12 +41,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': f'{pluginName}',
 })
 
-ts.Disk.plugin_config.AddLine(
-    f'# {path}/{pluginName}.so {configFile}'
-)
-ts.Disk.remap_config.AddLine(
-    f'map http://www.example.com http://127.0.0.1:{server.Variables.Port}'
-)
+ts.Disk.plugin_config.AddLine(f'# {path}/{pluginName}.so {configFile}')
+ts.Disk.remap_config.AddLine(f'map http://www.example.com http://127.0.0.1:{server.Variables.Port}')
 
 goldFile = os.path.join(Test.RunDirectory, f"{pluginName}.gold")
 with open(goldFile, 'w+') as jf:

--- a/plugins/experimental/traffic_dump/post_process.py
+++ b/plugins/experimental/traffic_dump/post_process.py
@@ -35,7 +35,6 @@ Server was interrupted mid-connection. This also merges sessions to the same
 client and, by default, formats the output files with human readable spacing.
 '''
 
-
 # Base replay file template with basic elements
 TEMPLATE = json.loads('{"meta": {"version":"1.0"},"sessions":[]}')
 
@@ -264,11 +263,9 @@ def readAndCombine(replay_dir, num_sessions_per_file, indent, fabricate_proxy_re
                 if not connection_time:
                     connection_time = session['start-time']
                 if connection_time:
-                    logging.debug("Omitting session in %s with connection-time: %d: %s",
-                                  replay_file, session['connection-time'], e)
+                    logging.debug("Omitting session in %s with connection-time: %d: %s", replay_file, session['connection-time'], e)
                 else:
-                    logging.debug("Omitting a session in %s, could not find a connection time: %s",
-                                  replay_file, e)
+                    logging.debug("Omitting a session in %s, could not find a connection time: %s", replay_file, e)
                 continue
             sessions.append(session)
             session_count += 1
@@ -335,24 +332,33 @@ def parse_args():
     '''
     parser = argparse.ArgumentParser(description=description)
 
-    parser.add_argument("in_dir", type=str,
-                        help='''The input directory of traffic_dump replay
+    parser.add_argument(
+        "in_dir",
+        type=str,
+        help='''The input directory of traffic_dump replay
                         files.  The expectation is that this will contain
                         sub-directories that themselves contain replay files.
                         This is written to accommodate the directory populated
                         by traffic_dump via the --logdir option.''')
-    parser.add_argument("out_dir", type=str,
-                        help="The output directory of post processed replay files.")
-    parser.add_argument("-n", "--num_sessions", type=int, default=10,
-                        help='''The maximum number of sessions merged into
+    parser.add_argument("out_dir", type=str, help="The output directory of post processed replay files.")
+    parser.add_argument(
+        "-n",
+        "--num_sessions",
+        type=int,
+        default=10,
+        help='''The maximum number of sessions merged into
                         single replay output files. The default is 10.''')
-    parser.add_argument("--no-human-readable", action="store_true",
-                        help='''By default, post processor will generate replay
+    parser.add_argument(
+        "--no-human-readable",
+        action="store_true",
+        help='''By default, post processor will generate replay
                         files that are spaced out in a human readable format.
                         This turns off that behavior and leaves the files as
                         single-line entries.''')
-    parser.add_argument("--no-fabricate-proxy-requests", action="store_true",
-                        help='''By default, post processor will fabricate proxy
+    parser.add_argument(
+        "--no-fabricate-proxy-requests",
+        action="store_true",
+        help='''By default, post processor will fabricate proxy
                         requests and server responses for transactions served
                         out of the proxy. Presumably in replay conditions,
                         these fabricated requests and responses will not hurt
@@ -362,10 +368,8 @@ def parse_args():
                         the server will not know how to reply to these
                         requests. Using this option turns off this fabrication
                         behavior.''')
-    parser.add_argument("-j", "--num_threads", type=int, default=32,
-                        help='''The maximum number of threads to use.''')
-    parser.add_argument("-d", "--debug", action="store_true",
-                        help="Enable debug level logging.")
+    parser.add_argument("-j", "--num_threads", type=int, default=32, help='''The maximum number of threads to use.''')
+    parser.add_argument("-d", "--debug", action="store_true", help="Enable debug level logging.")
     return parser.parse_args()
 
 
@@ -389,10 +393,11 @@ def main():
 
     # Start up the threads.
     for _ in range(nthreads):
-        t = Thread(target=post_process,
-                   args=(args.in_dir, subdir_q, args.out_dir,
-                         args.num_sessions, args.no_human_readable,
-                         not args.no_fabricate_proxy_requests, cnt_q))
+        t = Thread(
+            target=post_process,
+            args=(
+                args.in_dir, subdir_q, args.out_dir, args.num_sessions, args.no_human_readable,
+                not args.no_fabricate_proxy_requests, cnt_q))
         t.start()
         threads.append(t)
 

--- a/plugins/experimental/uri_signing/python_signer/uri_signer.py
+++ b/plugins/experimental/uri_signing/python_signer/uri_signer.py
@@ -27,12 +27,8 @@ from jose import jwt
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--config',
-                        help="Configuration File",
-                        required=True)
-    parser.add_argument('-u', '--uri',
-                        help="URI to sign",
-                        required=True)
+    parser.add_argument('-c', '--config', help="Configuration File", required=True)
+    parser.add_argument('-u', '--uri', help="URI to sign", required=True)
 
     # helpers
     parser.add_argument('--key_index', type=int, nargs=1)

--- a/tests/gold_tests/autest-site/cli_tools.test.ext
+++ b/tests/gold_tests/autest-site/cli_tools.test.ext
@@ -17,7 +17,6 @@ Tools to help with TestRun commands
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 # allows the same command to be repeatedly run in parallel.
 #
 # example usage:
@@ -31,25 +30,18 @@ Tools to help with TestRun commands
 #
 # Note that by default, the Default Process is created in this function.
 
+
 def spawn_commands(self, cmdstr, count, retcode=0, use_default=True):
     ret = []
 
     if use_default:
         count = int(count) - 1
     for cnt in range(0, count):
-        ret.append(
-            self.Processes.Process(
-                name="cmdline-{num}".format(num=cnt),
-                cmdstr=cmdstr,
-                returncode=retcode
-            )
-        )
+        ret.append(self.Processes.Process(name="cmdline-{num}".format(num=cnt), cmdstr=cmdstr, returncode=retcode))
     if use_default:
         self.Processes.Default.Command = cmdstr
         self.Processes.Default.ReturnCode = retcode
-        self.Processes.Default.StartBefore(
-            *ret
-        )
+        self.Processes.Default.StartBefore(*ret)
     return ret
 
 

--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -22,44 +22,33 @@ import re
 
 
 def HasOpenSSLVersion(self, version):
-    output = subprocess.check_output(
-        os.path.join(self.Variables.BINDIR, "traffic_layout") + " info --versions --json", shell=True
-    )
+    output = subprocess.check_output(os.path.join(self.Variables.BINDIR, "traffic_layout") + " info --versions --json", shell=True)
     json_data = output.decode('utf-8')
     openssl_str = json.loads(json_data)['openssl_str']
     exe_ver = re.search(r'\d\.\d\.\d', openssl_str).group(0)
     if exe_ver == '':
         raise ValueError("Error determining version of OpenSSL library needed by traffic_server executable")
-    return self.Condition(
-        lambda: exe_ver >= version,
-        "OpenSSL library version is " + exe_ver + ", must be at least " + version
-    )
+    return self.Condition(lambda: exe_ver >= version, "OpenSSL library version is " + exe_ver + ", must be at least " + version)
 
 
 def IsBoringSSL(self):
-    output = subprocess.check_output(
-        os.path.join(self.Variables.BINDIR, "traffic_layout") + " info --versions --json", shell=True
-    )
+    output = subprocess.check_output(os.path.join(self.Variables.BINDIR, "traffic_layout") + " info --versions --json", shell=True)
     json_data = output.decode('utf-8')
     openssl_str = json.loads(json_data)['openssl_str']
     return self.Condition(
         # OpenSSL 1.1.1 (compatible; BoringSSL)
         lambda: "compatible; BoringSSL" in openssl_str,
-        "SSL library is not BoringSSL"
-    )
+        "SSL library is not BoringSSL")
 
 
 def IsOpenSSL(self):
-    output = subprocess.check_output(
-        os.path.join(self.Variables.BINDIR, "traffic_layout") + " info --versions --json", shell=True
-    )
+    output = subprocess.check_output(os.path.join(self.Variables.BINDIR, "traffic_layout") + " info --versions --json", shell=True)
     json_data = output.decode('utf-8')
     openssl_str = json.loads(json_data)['openssl_str']
     return self.Condition(
         # OpenSSL 1.1.1k  25 Mar 2021
         lambda: "OpenSSL" in openssl_str and "compatible; BoringSSL" not in openssl_str,
-        "SSL library is not OpenSSL"
-    )
+        "SSL library is not OpenSSL")
 
 
 def HasCurlVersion(self, version):
@@ -87,14 +76,11 @@ def HasCurlFeature(self, feature):
                         return True
         return False
 
-    return self.CheckOutput(
-        ['curl', '--version'],
-        default,
-        "Curl needs to support feature: {feature}".format(feature=feature)
-    )
+    return self.CheckOutput(['curl', '--version'], default, "Curl needs to support feature: {feature}".format(feature=feature))
 
 
 def HasCurlOption(self, option):
+
     def default(output):
         tag = option.lower()
         for line in output.splitlines():
@@ -105,21 +91,15 @@ def HasCurlOption(self, option):
                     return True
         return False
 
-    return self.CheckOutput(
-        ['curl', '--help', 'all'],
-        default,
-        "Curl needs to support option: {option}".format(option=option)
-    )
+    return self.CheckOutput(['curl', '--help', 'all'], default, "Curl needs to support option: {option}".format(option=option))
 
 
 def HasATSFeature(self, feature):
 
     val = self.Variables.get(feature, None)
 
-    return self.Condition(
-        lambda: val,
-        "ATS feature not enabled: {feature}".format(feature=feature)
-    )
+    return self.Condition(lambda: val, "ATS feature not enabled: {feature}".format(feature=feature))
+
 
 # test if a plugin exists in the libexec folder
 

--- a/tests/gold_tests/autest-site/curl_header.test.ext
+++ b/tests/gold_tests/autest-site/curl_header.test.ext
@@ -24,20 +24,13 @@ import re
 
 
 class CurlHeader(Tester):
-    def __init__(self,
-                 value,
-                 test_value=None,
-                 kill_on_failure=False,
-                 description_group=None,
-                 description=None):
+
+    def __init__(self, value, test_value=None, kill_on_failure=False, description_group=None, description=None):
 
         self._stack = host.getCurrentStack(1)
 
         if not is_a.Dictionary(value):
-            host.WriteError(
-                "CurlHeader Input: Need to provide a dictionary.",
-                stack=host.getCurrentStack(1)
-            )
+            host.WriteError("CurlHeader Input: Need to provide a dictionary.", stack=host.getCurrentStack(1))
 
         ops = ("equal", "equal_re")
         gold_dict = value
@@ -52,8 +45,7 @@ class CurlHeader(Tester):
             if not isinstance(header, str):
                 host.WriteError(
                     'CurlHeader Input: Unsupported type for header {}. Header needs to be a string.'.format(header),
-                    stack=self._stack
-                )
+                    stack=self._stack)
 
             if target is None or isinstance(target, str):
                 continue
@@ -61,24 +53,28 @@ class CurlHeader(Tester):
                 for op, pos_val in target.items():
                     if op not in ops:
                         host.WriteError(
-                            'CurlHeader Input: Unsupported operation \'{}\' for value at header \'{}\'. The available operations are: {}.'.format(
-                                op, header, ', '.join(ops)), stack=self._stack)
+                            'CurlHeader Input: Unsupported operation \'{}\' for value at header \'{}\'. The available operations are: {}.'
+                            .format(op, header, ', '.join(ops)),
+                            stack=self._stack)
                     elif pos_val is None or isinstance(pos_val, str):
                         continue
                     elif isinstance(pos_val, list):
                         for str_ in pos_val:
                             if not isinstance(str_, str) and str_ is not None:
                                 host.WriteError(
-                                    'CurlHeader Input: Value {} has unsupported type \'{}\' for header \'{}\'. Need to provide a string or None.'.format(
-                                        str_, str_.__class__.__name__, header), stack=self._stack)
+                                    'CurlHeader Input: Value {} has unsupported type \'{}\' for header \'{}\'. Need to provide a string or None.'
+                                    .format(str_, str_.__class__.__name__, header),
+                                    stack=self._stack)
                     else:
                         host.WriteError(
-                            'CurlHeader Input: Value {} has unsupported type \'{}\' for header \'{}\'. Need to provide a string, a list or None for possible curl values.'.format(
-                                pos_val, pos_val.__class__.__name__, header), stack=self._stack)
+                            'CurlHeader Input: Value {} has unsupported type \'{}\' for header \'{}\'. Need to provide a string, a list or None for possible curl values.'
+                            .format(pos_val, pos_val.__class__.__name__, header),
+                            stack=self._stack)
             else:
                 host.WriteError(
-                    'CurlHeader Input: Value {} has unsupported type \'{}\' for header \'{}\'. Need to provide either a string, a dictionary or None.'.format(
-                        target, target.__class__.__name__, header), stack=self._stack)
+                    'CurlHeader Input: Value {} has unsupported type \'{}\' for header \'{}\'. Need to provide either a string, a dictionary or None.'
+                    .format(target, target.__class__.__name__, header),
+                    stack=self._stack)
 
         super(CurlHeader, self).__init__(
             value=value,
@@ -146,9 +142,7 @@ class CurlHeader(Tester):
             if self.KillOnFailure:
                 raise KillOnFailureError
         host.WriteVerbose(
-            ["testers.CurlHeader", "testers"],
-            "{0} - ".format(tester.ResultType.to_color_string(self.Result)),
-            self.Reason)
+            ["testers.CurlHeader", "testers"], "{0} - ".format(tester.ResultType.to_color_string(self.Result)), self.Reason)
 
     # Optional operations to do:
     #       equal: complete string match
@@ -200,8 +194,7 @@ class CurlHeader(Tester):
                             return None
 
             ret = ''
-            ops = {'equal': 'Any of the following strings: ',
-                   'equal_re': 'Any of the following regular expression: '}
+            ops = {'equal': 'Any of the following strings: ', 'equal_re': 'Any of the following regular expression: '}
 
             for op, pos_val in target.items():
                 ret += '    {}: \'{}\'\n'.format(ops[op], '\', \''.join(pos_val)) if isinstance(pos_val, list) \

--- a/tests/gold_tests/autest-site/httpbin.test.ext
+++ b/tests/gold_tests/autest-site/httpbin.test.ext
@@ -19,8 +19,7 @@
 from ports import get_port
 
 
-def MakeHttpBinServer(self, name, ip='127.0.0.1', port=None,
-                      options={}) -> 'Process':
+def MakeHttpBinServer(self, name, ip='127.0.0.1', port=None, options={}) -> 'Process':
     data_dir = os.path.join(self.RunDirectory, name)
     # create Process
     p = self.Processes.Process(name)
@@ -28,10 +27,7 @@ def MakeHttpBinServer(self, name, ip='127.0.0.1', port=None,
         port = get_port(p, "Port")
 
     self._RootRunable.SkipUnless(
-        Condition.HasProgram(
-            "go-httpbin",
-            "go-httpbin needs be installed and in PATH for this extension to run")
-    )
+        Condition.HasProgram("go-httpbin", "go-httpbin needs be installed and in PATH for this extension to run"))
 
     command = f"go-httpbin -host {ip} -port {port} "
     for flag, value in options.items():

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -20,8 +20,7 @@ import sys
 import microserver
 
 if sys.version_info < (3, 6, 0):
-    host.WriteError(
-        "You need python 3.6 or later to run these tests\n", show_stack=False)
+    host.WriteError("You need python 3.6 or later to run these tests\n", show_stack=False)
 
 needed_autest_version = "1.10.4"
 found_autest_version = AuTestVersion()
@@ -31,7 +30,6 @@ if AuTestVersion() < needed_autest_version:
         "Please update AuTest:\n  pipenv --rm && pipenv install\n",
         show_stack=False)
 
-
 needed_microserver_version = "1.0.6"
 found_microserver_version = microserver.__version__
 if found_microserver_version < needed_microserver_version:
@@ -40,14 +38,8 @@ if found_microserver_version < needed_microserver_version:
         "Please update MicroServer:\n  pipenv --rm && pipenv install\n",
         show_stack=False)
 
-Settings.path_argument(["--ats-bin"],
-                       required=True,
-                       help="A user provided directory to ATS bin")
+Settings.path_argument(["--ats-bin"], required=True, help="A user provided directory to ATS bin")
 
-Settings.path_argument(["--build-root"],
-                       required=False,
-                       help="The location of the build root for out of source builds")
+Settings.path_argument(["--build-root"], required=False, help="The location of the build root for out of source builds")
 
-Settings.path_argument(["--proxy-verifier-bin"],
-                       required=False,
-                       help="A location for system proxy-verifier binaries to test with.")
+Settings.path_argument(["--proxy-verifier-bin"], required=False, help="A location for system proxy-verifier binaries to test with.")

--- a/tests/gold_tests/autest-site/ip.test.ext
+++ b/tests/gold_tests/autest-site/ip.test.ext
@@ -17,7 +17,6 @@ Extend Autest with IP-related utilities.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 from ports import get_port
 
 # this forms is for the global process define

--- a/tests/gold_tests/autest-site/microDNS.test.ext
+++ b/tests/gold_tests/autest-site/microDNS.test.ext
@@ -30,6 +30,7 @@ def AddRecord(hostname, list_ip_addr):
     record[hostname] = list_ip_addr
     return record
 
+
 # dict in format {'domain': [IPs]}
 # json file in the same mappings/otherwise format that uDNS takes
 

--- a/tests/gold_tests/autest-site/microserver.test.ext
+++ b/tests/gold_tests/autest-site/microserver.test.ext
@@ -33,6 +33,7 @@ DEFAULT_LOOKUP_KEY = '{PATH}'
 def addMethod(self, testName, request_header, functionName):
     return
 
+
 # creates the full request or response block using headers and message data
 
 
@@ -60,13 +61,11 @@ def getHeaderFieldVal(request_header, field):
 # addResponse adds customized response with respect to request_header. request_header and response_header are both dictionaries
 def addResponse(self, filename, request_header, response_header):
     client_request = Request.fromRequestLine(
-        request_header["headers"],
-        "" if "body" not in request_header else request_header["body"],
+        request_header["headers"], "" if "body" not in request_header else request_header["body"],
         None if "options" not in request_header else request_header["options"])
 
     server_response = Response.fromRequestLine(
-        response_header["headers"],
-        "" if "body" not in response_header else response_header["body"],
+        response_header["headers"], "" if "body" not in response_header else response_header["body"],
         None if "options" not in response_header else response_header["options"])
 
     # timestamp field is left None because that needs to be revised for better implementation
@@ -135,16 +134,10 @@ def uServerUpAndRunning(serverHost, port, isSsl, isIPv6, request, clientcert='',
     try:
         sock.connect((serverHost, port))
     except ConnectionRefusedError:
-        host.WriteDebug(
-            ['uServerUpAndRunning', 'when'],
-            "Connection refused: {0}:{1}".format(
-                serverHost, port))
+        host.WriteDebug(['uServerUpAndRunning', 'when'], "Connection refused: {0}:{1}".format(serverHost, port))
         return False
     except ssl.SSLError as e:
-        host.WriteDebug(
-            ['uServerUpAndRunning', 'when'],
-            "SSL connection error: {0}:{1}:{2}".format(
-                serverHost, port, e))
+        host.WriteDebug(['uServerUpAndRunning', 'when'], "SSL connection error: {0}:{1}:{2}".format(serverHost, port, e))
         return False
 
     sock.sendall(request.encode())
@@ -164,11 +157,7 @@ def uServerUpAndRunning(serverHost, port, isSsl, isIPv6, request, clientcert='',
     if decoded_output == expected_response:
         return True
 
-    host.WriteError('\n'.join([
-        'Got invalid response from microserver:',
-        '----',
-        decoded_output,
-        '----']))
+    host.WriteError('\n'.join(['Got invalid response from microserver:', '----', decoded_output, '----']))
 
 
 AddWhenFunction(uServerUpAndRunning)
@@ -243,12 +232,15 @@ def MakeOriginServer(
     }
 
     # Set up health check.
-    addResponse(p, "healthcheck.json", healthcheck_request, {
-        "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-        "timestamp": "1469733493.993",
-        "body": "imok",
-        "options": {"skipHooks": None}
-    })
+    addResponse(
+        p, "healthcheck.json", healthcheck_request, {
+            "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": "imok",
+            "options": {
+                "skipHooks": None
+            }
+        })
 
     p.Ready = When.uServerUpAndRunning(
         ipaddr,

--- a/tests/gold_tests/autest-site/ordered_set_queue.py
+++ b/tests/gold_tests/autest-site/ordered_set_queue.py
@@ -17,7 +17,6 @@ Implement an OrderedSetQueue
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import collections
 try:
     collectionsAbc = collections.abc
@@ -29,18 +28,18 @@ try:
 except ImportError:
     import Queue
 
-
 #
 # This is borrowed from the following (MIT licensed) recipe:
 # https://code.activestate.com/recipes/576694/
 #
 
+
 class OrderedSet(collectionsAbc.MutableSet):
 
     def __init__(self, iterable=None):
         self.end = end = []
-        end += [None, end, end]         # sentinel node for doubly linked list
-        self.map = {}                   # key --> [key, prev, next]
+        end += [None, end, end]  # sentinel node for doubly linked list
+        self.map = {}  # key --> [key, prev, next]
         if iterable is not None:
             self |= iterable
 

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -45,29 +45,20 @@ proxy_verifer_version = open(proxy_verifer_version_file, "rt").read().strip()
 
 if Arguments.proxy_verifier_bin is not None:
     ENV['VERIFIER_BIN'] = Arguments.proxy_verifier_bin
-    host.WriteVerbose(
-        ['ats'],
-        "Expecting Proxy Verifier to be in user-supplied bin path: ",
-        ENV['VERIFIER_BIN'])
+    host.WriteVerbose(['ats'], "Expecting Proxy Verifier to be in user-supplied bin path: ", ENV['VERIFIER_BIN'])
 else:
     # No Verifier bin path was specified. First see if a Proxy Verifier was
     # unpacked as a part of preparing for this test.
     unpack_bin = os.path.join(test_root, 'proxy-verifier', 'unpack', proxy_verifer_version, 'bin')
     if os.path.exists(os.path.join(unpack_bin, 'verifier-client')):
         ENV['VERIFIER_BIN'] = unpack_bin
-        host.WriteVerbose(
-            ['ats'],
-            "Using locally unpacked Proxy Verifier: ",
-            ENV['VERIFIER_BIN'])
+        host.WriteVerbose(['ats'], "Using locally unpacked Proxy Verifier: ", ENV['VERIFIER_BIN'])
     else:
         # Finally check the PATH.
         path_search = shutil.which('verifier-client')
         if path_search is not None:
             ENV['VERIFIER_BIN'] = dirname(path_search)
-            host.WriteVerbose(
-                ['ats'],
-                "Using Proxy Verifier found in PATH: ",
-                ENV['VERIFIER_BIN'])
+            host.WriteVerbose(['ats'], "Using Proxy Verifier found in PATH: ", ENV['VERIFIER_BIN'])
         else:
             prepare_proxy_verifier_path = os.path.join(test_root, "prepare_proxy_verifier.sh")
             host.WriteError("Could not find Proxy Verifier binaries. "
@@ -82,10 +73,7 @@ if pv_version < required_pv_version:
         f"Proxy Verifier at {verifier_client} is too old. "
         f"Version required: {required_pv_version}, version found: {pv_version}")
 else:
-    host.WriteVerbose(
-        ['ats'],
-        f"Proxy Verifier at {verifier_client} has version: {pv_version}")
-
+    host.WriteVerbose(['ats'], f"Proxy Verifier at {verifier_client} has version: {pv_version}")
 
 if ENV['ATS_BIN'] is not None:
     # Add variables for Tests
@@ -125,12 +113,7 @@ if ENV['ATS_BIN'] is not None:
 
     # this queries tsxs for build flags so we can build code for the tests and get certain
     # useful flags as which openssl to use when we don't use the system version
-    out = {
-        'CPPFLAGS': '',
-        'LIBS': '',
-        'LDFLAGS': '',
-        'CXX': ''
-    }
+    out = {'CPPFLAGS': '', 'LIBS': '', 'LDFLAGS': '', 'CXX': ''}
     if os.path.isfile(tsxs):
         for flag in out.keys():
             try:

--- a/tests/gold_tests/autest-site/traffic_replay.test.ext
+++ b/tests/gold_tests/autest-site/traffic_replay.test.ext
@@ -29,9 +29,7 @@ def Replay(obj, name, replay_dir, key=None, cert=None, conn_type='mixed', option
     ts.addSSLfile(os.path.join(obj.Variables["AtsTestToolsDir"], "microserver", "ssl", "server.pem"))
     ts.addSSLfile(os.path.join(obj.Variables["AtsTestToolsDir"], "microserver", "ssl", "server.crt"))
 
-    ts.Disk.ssl_multicert_config.AddLine(
-        'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.pem'
-    )
+    ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.pem')
 
     # MicroServer setup - NOTE: expand to multiple microserver in future?
     server = obj.MakeOriginServer("server", both=True, lookup_key='{%uuid}')

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -28,20 +28,23 @@ def make_id(s):
 # A mapping from log type to the log name. 'stdout' and 'stderr' are handled
 # specially and are used to indicate the stdout and stderr streams,
 # respectively.
-default_log_data = {
-    'diags': 'diags.log',
-    'error': 'error.log',
-    'manager': 'manager.log'
-}
+default_log_data = {'diags': 'diags.log', 'error': 'error.log', 'manager': 'manager.log'}
 
 # 'block_for_debug', if True, causes traffic_server to run with the --block option enabled, and effectively
 # disables timeouts that could be triggered by running traffic_server under a debugger.
 
 
-def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
-                   enable_tls=False, enable_cache=True, enable_quic=False,
-                   block_for_debug=False, log_data=default_log_data,
-                   use_traffic_out=True):
+def MakeATSProcess(
+        obj,
+        name,
+        command='traffic_server',
+        select_ports=True,
+        enable_tls=False,
+        enable_cache=True,
+        enable_quic=False,
+        block_for_debug=False,
+        log_data=default_log_data,
+        use_traffic_out=True):
     #####################################
     # common locations
 
@@ -141,8 +144,7 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
 
     p.Env['PROXY_CONFIG_BODY_FACTORY_TEMPLATE_SETS_DIR'] = template_dir
     p.Variables.BODY_FACTORY_TEMPLATE_DIR = template_dir
-    p.Setup.Copy(
-        os.path.join(p.Variables.SYSCONFDIR, 'body_factory'), template_dir)
+    p.Setup.Copy(os.path.join(p.Variables.SYSCONFDIR, 'body_factory'), template_dir)
 
     #########################################################
     # setup cache directory
@@ -228,10 +230,8 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
         tmpname = os.path.join(log_dir, fname)
         p.Disk.File(tmpname, id='diags_log')
     # add this test back once we have network namespaces working again
-    p.Disk.diags_log.Content = Testers.ExcludesExpression(
-        "ERROR:", f"Diags log file {fname} should not contain errors")
-    p.Disk.diags_log.Content += Testers.ExcludesExpression(
-        "FATAL:", f"Diags log file {fname} should not contain errors")
+    p.Disk.diags_log.Content = Testers.ExcludesExpression("ERROR:", f"Diags log file {fname} should not contain errors")
+    p.Disk.diags_log.Content += Testers.ExcludesExpression("FATAL:", f"Diags log file {fname} should not contain errors")
     p.Disk.diags_log.Content += Testers.ExcludesExpression(
         "Unrecognized configuration value",
         f"Diags log file {fname} should not contain a warning about an unrecognized configuration")
@@ -353,16 +353,15 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
         # rely upon the cache will not function correctly if ATS starts
         # processing traffic before the cache is ready. Thus we set the
         # wait_for_cache configuration.
-        p.Disk.records_config.update({
-            # Do not accept connections from clients until cache subsystem is
-            # operational.
-            'proxy.config.http.wait_for_cache': 1,
-        })
+        p.Disk.records_config.update(
+            {
+                # Do not accept connections from clients until cache subsystem is
+                # operational.
+                'proxy.config.http.wait_for_cache': 1,
+            })
     else:
         # The user wants the cache to be disabled.
-        p.Disk.records_config.update({
-            'proxy.config.http.cache.http': 0
-        })
+        p.Disk.records_config.update({'proxy.config.http.cache.http': 0})
 
     if enable_quic:
         p.Disk.records_config.update({
@@ -387,11 +386,9 @@ def MakeATSProcess(obj, name, command='traffic_server', select_ports=True,
             'proxy.config.http.server_ports': port_str,
         })
 
-    p.Env['PROXY_CONFIG_PROCESS_MANAGER_MGMT_PORT'] = str(
-        p.Variables.manager_port)
+    p.Env['PROXY_CONFIG_PROCESS_MANAGER_MGMT_PORT'] = str(p.Variables.manager_port)
     p.Env['PROXY_CONFIG_ADMIN_SYNTHETIC_PORT'] = str(p.Variables.admin_port)
-    p.Env['PROXY_CONFIG_ADMIN_AUTOCONF_PORT'] = str(
-        p.Variables.admin_port)  # support pre ATS 6.x
+    p.Env['PROXY_CONFIG_ADMIN_AUTOCONF_PORT'] = str(p.Variables.admin_port)  # support pre ATS 6.x
 
     if 'traffic_manager' in command:
         p.ReturnCode = 2
@@ -419,23 +416,8 @@ class Config(File):
     Class to represent a config file
     '''
 
-    def __init__(self,
-                 runable,
-                 name,
-                 exists=None,
-                 size=None,
-                 content_tester=None,
-                 execute=False,
-                 runtime=True,
-                 content=None):
-        super(Config, self).__init__(
-            runable,
-            name,
-            exists=None,
-            size=None,
-            content_tester=None,
-            execute=False,
-            runtime=True)
+    def __init__(self, runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True, content=None):
+        super(Config, self).__init__(runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True)
 
         self.content = content
         self._added = False
@@ -448,8 +430,7 @@ class Config(File):
         '''
         Write contents to disk
         '''
-        host.WriteVerbosef('ats-config-file', "Writing out file {0}",
-                           self.Name)
+        host.WriteVerbosef('ats-config-file', "Writing out file {0}", self.Name)
         if self.content is not None:
             with open(name, 'w') as f:
                 f.write(self.content)
@@ -484,22 +465,8 @@ class RecordsConfig(Config, dict):
 
     line_template = 'CONFIG {name} {kind} {val}\n'
 
-    def __init__(self,
-                 runable,
-                 name,
-                 exists=None,
-                 size=None,
-                 content_tester=None,
-                 execute=False,
-                 runtime=True):
-        super(RecordsConfig, self).__init__(
-            runable,
-            name,
-            exists=None,
-            size=None,
-            content_tester=None,
-            execute=False,
-            runtime=True)
+    def __init__(self, runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True):
+        super(RecordsConfig, self).__init__(runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True)
         self.WriteCustomOn(self._do_write)
 
     def _do_write(self, name):
@@ -507,15 +474,8 @@ class RecordsConfig(Config, dict):
         if len(self) > 0:
             with open(name, 'w') as f:
                 for name, val in self.items():
-                    f.write(
-                        self.line_template.format(
-                            name=name,
-                            kind=self.reverse_kind_map[type(val)],
-                            val=val)
-                    )
-        return (True,
-                "Writing config file {0}".format(os.path.split(self.Name)[-1]),
-                "Success")
+                    f.write(self.line_template.format(name=name, kind=self.reverse_kind_map[type(val)], val=val))
+        return (True, "Writing config file {0}".format(os.path.split(self.Name)[-1]), "Success")
 
 
 ##########################################################################

--- a/tests/gold_tests/autest-site/trafficserver_plugins.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver_plugins.test.ext
@@ -46,22 +46,15 @@ def prepare_plugin_helper(so_name, tsproc, plugin_args="", copy_plugin=True):
 
     plugin_dir = tsproc.Env['PROXY_CONFIG_PLUGIN_PLUGIN_DIR']
     if copy_plugin:
-        host.WriteVerbose(
-            "prepare_plugin",
-            "Copying down {} into {}.".format(so_name, plugin_dir))
+        host.WriteVerbose("prepare_plugin", "Copying down {} into {}.".format(so_name, plugin_dir))
         tsproc.Setup.Copy(so_name, plugin_dir)
     else:
-        host.WriteVerbose(
-            "prepare_plugin",
-            "Skipping copying {} into {} due to configuration.".format(
-                so_name, plugin_dir))
+        host.WriteVerbose("prepare_plugin", "Skipping copying {} into {} due to configuration.".format(so_name, plugin_dir))
 
     # Add an entry to plugin.config.
     basename = os.path.basename(so_name)
     config_line = "{0} {1}".format(basename, plugin_args)
-    host.WriteVerbose(
-        "prepare_plugin",
-        'Adding line to plugin.config: "{}"'.format(config_line))
+    host.WriteVerbose("prepare_plugin", 'Adding line to plugin.config: "{}"'.format(config_line))
     tsproc.Disk.plugin_config.AddLine(config_line)
 
 
@@ -79,8 +72,7 @@ def prepare_test_plugin(self, so_path, tsproc, plugin_args=""):
         plugin.config.
     """
     if not os.path.exists(so_path):
-        raise ValueError(
-            'PrepareTestPlugin: file does not exist: "{}"'.format(so_path))
+        raise ValueError('PrepareTestPlugin: file does not exist: "{}"'.format(so_path))
 
     prepare_plugin_helper(so_path, tsproc, plugin_args, copy_plugin=True)
 
@@ -99,9 +91,8 @@ def prepare_installed_plugin(self, so_name, tsproc, plugin_args=""):
         plugin.config.
     """
     if os.path.dirname(so_name):
-        raise ValueError(
-            'PrepareInstalledPlugin expects a filename not a path: '
-            '"{}"'.format(so_name))
+        raise ValueError('PrepareInstalledPlugin expects a filename not a path: '
+                         '"{}"'.format(so_name))
     prepare_plugin_helper(so_name, tsproc, plugin_args, copy_plugin=False)
 
 
@@ -110,7 +101,6 @@ PrepareTestPlugin should be used for the test-specific plugins that need to
 be copied down into the sandbox directory.
 """
 ExtendTest(prepare_test_plugin, name="PrepareTestPlugin")
-
 """
 PrepareInstalledPlugin should be used for the plugins installed via Automake
 make install. They are already sym linked into the test directory via the

--- a/tests/gold_tests/autest-site/verifier_client.test.ext
+++ b/tests/gold_tests/autest-site/verifier_client.test.ext
@@ -17,15 +17,24 @@ Implement the Proxy Verifier client extensions.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
 from verifier_common import create_address_argument, substitute_context_in_replay_file
 
 
-def _configure_client(obj, process, name, replay_path, http_ports=None,
-                      https_ports=None, http3_ports=None, keys=None,
-                      ssl_cert='', ca_cert='', verbose=True, other_args='',
-                      context=None):
+def _configure_client(
+        obj,
+        process,
+        name,
+        replay_path,
+        http_ports=None,
+        https_ports=None,
+        http3_ports=None,
+        keys=None,
+        ssl_cert='',
+        ca_cert='',
+        verbose=True,
+        other_args='',
+        context=None):
     """
     Configure the process for running the verifier-client.
 
@@ -91,8 +100,7 @@ def _configure_client(obj, process, name, replay_path, http_ports=None,
 
     if https_ports or http3_ports:
         if ssl_cert == '':
-            ssl_cert = os.path.join(obj.Variables["AtsTestToolsDir"],
-                                    "proxy-verifier", "ssl", "client.pem")
+            ssl_cert = os.path.join(obj.Variables["AtsTestToolsDir"], "proxy-verifier", "ssl", "client.pem")
 
             if not os.path.isfile(ssl_cert):
                 raise ValueError("Tried to use '{}' for --client-cert, but it is not "
@@ -108,8 +116,7 @@ def _configure_client(obj, process, name, replay_path, http_ports=None,
             obj.Variables['tls_secrets_log_path'] = tls_secrets_log_path
 
         if ca_cert == '':
-            ca_cert = os.path.join(obj.Variables["AtsTestToolsDir"],
-                                   "proxy-verifier", "ssl", "ca.pem")
+            ca_cert = os.path.join(obj.Variables["AtsTestToolsDir"], "proxy-verifier", "ssl", "ca.pem")
 
             if not os.path.isfile(ca_cert):
                 raise ValueError("Tried to use '{}' for --ca-certs, but it is not "
@@ -132,14 +139,22 @@ def _configure_client(obj, process, name, replay_path, http_ports=None,
     process.ReturnCode = 0
 
     process.Streams.stdout = Testers.ExcludesExpression(
-        "Violation|Invalid status",
-        "There should be no Proxy Verifier violation errors.")
+        "Violation|Invalid status", "There should be no Proxy Verifier violation errors.")
 
 
-def AddVerifierClientProcess(run, name, replay_path, http_ports=None,
-                             https_ports=None, http3_ports=None, keys=None,
-                             ssl_cert='', ca_cert='', verbose=True, other_args='',
-                             context=None):
+def AddVerifierClientProcess(
+        run,
+        name,
+        replay_path,
+        http_ports=None,
+        https_ports=None,
+        http3_ports=None,
+        keys=None,
+        ssl_cert='',
+        ca_cert='',
+        verbose=True,
+        other_args='',
+        context=None):
     """
     Set the Default process of the test run to a verifier-client Process.
 
@@ -187,9 +202,8 @@ def AddVerifierClientProcess(run, name, replay_path, http_ports=None,
     """
 
     p = run.Processes.Default
-    _configure_client(run, p, name, replay_path, http_ports, https_ports,
-                      http3_ports, keys, ssl_cert, ca_cert, verbose,
-                      other_args, context)
+    _configure_client(
+        run, p, name, replay_path, http_ports, https_ports, http3_ports, keys, ssl_cert, ca_cert, verbose, other_args, context)
     return p
 
 

--- a/tests/gold_tests/autest-site/verifier_server.test.ext
+++ b/tests/gold_tests/autest-site/verifier_server.test.ext
@@ -23,9 +23,19 @@ from ports import get_port
 from verifier_common import create_address_argument, substitute_context_in_replay_file
 
 
-def _configure_server(obj, process, name, replay_path, http_ports=None, https_ports=None,
-                      http3_ports=None, ssl_cert='', ca_cert='', verbose=True,
-                      other_args='', context=None):
+def _configure_server(
+        obj,
+        process,
+        name,
+        replay_path,
+        http_ports=None,
+        https_ports=None,
+        http3_ports=None,
+        ssl_cert='',
+        ca_cert='',
+        verbose=True,
+        other_args='',
+        context=None):
     """
     Configure the provided process to run a verifier-server command.
 
@@ -91,8 +101,7 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
 
     if https_ports or http3_ports:
         if ssl_cert == '':
-            ssl_cert = os.path.join(obj.Variables["AtsTestToolsDir"],
-                                    "proxy-verifier", "ssl", "server.pem")
+            ssl_cert = os.path.join(obj.Variables["AtsTestToolsDir"], "proxy-verifier", "ssl", "server.pem")
 
             if not os.path.isfile(ssl_cert):
                 raise ValueError("Tried to use '{}' for --server-cert, but it is not "
@@ -108,8 +117,7 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
             obj.Variables['tls_secrets_log_path'] = tls_secrets_log_path
 
         if ca_cert == '':
-            ca_cert = os.path.join(obj.Variables["AtsTestToolsDir"],
-                                   "proxy-verifier", "ssl", "ca.pem")
+            ca_cert = os.path.join(obj.Variables["AtsTestToolsDir"], "proxy-verifier", "ssl", "ca.pem")
 
             if not os.path.isfile(ca_cert):
                 raise ValueError("Tried to use '{}' for --ca-certs, but it is not "
@@ -140,14 +148,21 @@ def _configure_server(obj, process, name, replay_path, http_ports=None, https_po
     process.Ready = When.PortOpenv4(process.Variables.http_port)
     process.ReturnCode = 0
 
-    process.Streams.stdout = Testers.ExcludesExpression(
-        "Violation",
-        "There should be no Proxy Verifier violation errors.")
+    process.Streams.stdout = Testers.ExcludesExpression("Violation", "There should be no Proxy Verifier violation errors.")
 
 
-def MakeVerifierServerProcess(test, name, replay_path, http_ports=None,
-                              https_ports=None, http3_ports=None, ssl_cert='',
-                              ca_cert='', verbose=True, other_args='', context=None):
+def MakeVerifierServerProcess(
+        test,
+        name,
+        replay_path,
+        http_ports=None,
+        https_ports=None,
+        http3_ports=None,
+        ssl_cert='',
+        ca_cert='',
+        verbose=True,
+        other_args='',
+        context=None):
     """
     Create a verifier-server process for the Test.
 
@@ -196,14 +211,23 @@ def MakeVerifierServerProcess(test, name, replay_path, http_ports=None,
         KeyError if placeholders are missing from the mapping between context and the replay file.
     """
     server = test.Processes.Process(name)
-    _configure_server(test, server, name, replay_path, http_ports, https_ports,
-                      http3_ports, ssl_cert, ca_cert, verbose, other_args, context)
+    _configure_server(
+        test, server, name, replay_path, http_ports, https_ports, http3_ports, ssl_cert, ca_cert, verbose, other_args, context)
     return server
 
 
-def AddVerifierServerProcess(run, name, replay_path, http_ports=None,
-                             https_ports=None, http3_ports=None, ssl_cert='',
-                             ca_cert='', verbose=True, other_args='', context=None):
+def AddVerifierServerProcess(
+        run,
+        name,
+        replay_path,
+        http_ports=None,
+        https_ports=None,
+        http3_ports=None,
+        ssl_cert='',
+        ca_cert='',
+        verbose=True,
+        other_args='',
+        context=None):
     """
     Create a verifier-server process and configure it for the given TestRun.
 
@@ -217,8 +241,8 @@ def AddVerifierServerProcess(run, name, replay_path, http_ports=None,
     """
 
     server = run.Processes.Process(name)
-    _configure_server(run, server, name, replay_path, http_ports, https_ports,
-                      http3_ports, ssl_cert, ca_cert, verbose, other_args, context)
+    _configure_server(
+        run, server, name, replay_path, http_ports, https_ports, http3_ports, ssl_cert, ca_cert, verbose, other_args, context)
 
     client = run.Processes.Default
     client.StartBefore(server)

--- a/tests/gold_tests/autest-site/when.test.ext
+++ b/tests/gold_tests/autest-site/when.test.ext
@@ -47,9 +47,7 @@ def FileContains(haystack, needle, desired_count=1):
 
     if not os.path.exists(haystack):
         host.WriteDebug(
-            ['FileContains', 'when'],
-            "Testing for file content '{0}' in file '{1}': file does not exist".format(
-                needle, haystack))
+            ['FileContains', 'when'], "Testing for file content '{0}' in file '{1}': file does not exist".format(needle, haystack))
         return False
 
     needle_regex = re.compile(needle)
@@ -60,24 +58,19 @@ def FileContains(haystack, needle, desired_count=1):
             line_count += 1
             if needle_regex.search(line):
                 host.WriteDebug(
-                    ['FileContains', 'when'],
-                    "Found '{0}' in file '{1}' in line: '{2}', line number: {3}".format(
+                    ['FileContains', 'when'], "Found '{0}' in file '{1}' in line: '{2}', line number: {3}".format(
                         needle, haystack, line.rstrip(), line_count))
                 needle_seen_count += 1
 
                 if needle_seen_count >= desired_count:
                     host.WriteDebug(
-                        ['FileContains', 'when'],
-                        "Testing for file content '{0}' in file '{1}', "
-                        "successfully found it the desired {2} times".format(
-                            needle, haystack, needle_seen_count))
+                        ['FileContains', 'when'], "Testing for file content '{0}' in file '{1}', "
+                        "successfully found it the desired {2} times".format(needle, haystack, needle_seen_count))
                     return True
 
         host.WriteDebug(
-            ['FileContains', 'when'],
-            "Testing for file content '{0}' in file '{1}', only seen {2} "
-            "out of the desired {3} times".format(
-                needle, haystack, needle_seen_count, desired_count))
+            ['FileContains', 'when'], "Testing for file content '{0}' in file '{1}', only seen {2} "
+            "out of the desired {3} times".format(needle, haystack, needle_seen_count, desired_count))
 
         return False
 

--- a/tests/gold_tests/basic/deny0.test.py
+++ b/tests/gold_tests/basic/deny0.test.py
@@ -34,14 +34,15 @@ dns = Test.MakeDNServer("dns")
 dns.addRecords(records={HOST1: ['127.0.0.1']})
 
 ts = Test.MakeATSProcess("ts", enable_cache=False)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|redirect',
-    'proxy.config.http.number_of_redirections': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.url_remap.remap_required': 0  # need this so the domain gets a chance to be evaluated through DNS
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|redirect',
+        'proxy.config.http.number_of_redirections': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.url_remap.remap_required': 0  # need this so the domain gets a chance to be evaluated through DNS
+    })
 
 Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir, 'tcp_client.py'))
 
@@ -77,32 +78,36 @@ def buildMetaTest(testName, requestString):
     tr.StillRunningAfter = dns
 
 
-buildMetaTest('RejectInterfaceAnyIpv4',
-              'GET / HTTP/1.1\r\nHost: 0:{port}\r\nConnection: close\r\n\r\n'.format(port=ts.Variables.port))
+buildMetaTest(
+    'RejectInterfaceAnyIpv4', 'GET / HTTP/1.1\r\nHost: 0:{port}\r\nConnection: close\r\n\r\n'.format(port=ts.Variables.port))
 
-
-buildMetaTest('RejectInterfaceAnyIpv6',
-              'GET / HTTP/1.1\r\nHost: [::]:{port}\r\nConnection: close\r\n\r\n'.format(port=ts.Variables.portv6))
-
+buildMetaTest(
+    'RejectInterfaceAnyIpv6', 'GET / HTTP/1.1\r\nHost: [::]:{port}\r\nConnection: close\r\n\r\n'.format(port=ts.Variables.portv6))
 
 # Sets up redirect to IPv4 ANY address
 redirect_request_header = {"headers": "GET /redirect-0 HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
-redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://0:{0}/\r\nConnection: close\r\n\r\n".format(
-    ts.Variables.port), "timestamp": "5678", "body": ""}
+redirect_response_header = {
+    "headers": "HTTP/1.1 302 Found\r\nLocation: http://0:{0}/\r\nConnection: close\r\n\r\n".format(ts.Variables.port),
+    "timestamp": "5678",
+    "body": ""
+}
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
-buildMetaTest('RejectRedirectToInterfaceAnyIpv4',
-              'GET /redirect-0 HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n'.format(host=HOST1, port=redirect_serv.Variables.Port))
-
+buildMetaTest(
+    'RejectRedirectToInterfaceAnyIpv4',
+    'GET /redirect-0 HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n'.format(host=HOST1, port=redirect_serv.Variables.Port))
 
 # Sets up redirect to IPv6 ANY address
 redirect_request_header = {"headers": "GET /redirect-0v6 HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
-redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://[::]:{0}/\r\nConnection: close\r\n\r\n".format(
-    ts.Variables.port), "timestamp": "5678", "body": ""}
+redirect_response_header = {
+    "headers": "HTTP/1.1 302 Found\r\nLocation: http://[::]:{0}/\r\nConnection: close\r\n\r\n".format(ts.Variables.port),
+    "timestamp": "5678",
+    "body": ""
+}
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
-buildMetaTest('RejectRedirectToInterfaceAnyIpv6',
-              'GET /redirect-0v6 HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n'.format(host=HOST1, port=redirect_serv.Variables.Port))
-
+buildMetaTest(
+    'RejectRedirectToInterfaceAnyIpv6',
+    'GET /redirect-0v6 HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n'.format(host=HOST1, port=redirect_serv.Variables.Port))
 
 Test.Setup.Copy(data_path)

--- a/tests/gold_tests/bigobj/bigobj.test.py
+++ b/tests/gold_tests/bigobj/bigobj.test.py
@@ -24,9 +24,7 @@ Test PUSHing an object into the cache and the GETting it with a few variations o
 # by increasing the value of the obj_kilobytes variable below.  (But do not increase it on any shared branch
 # that we do CI runs on.)
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 # push_request and check_ramp are built via `make`. Here we copy the built binary down to the test
 # directory so that the test runs in this file can use it.
@@ -36,24 +34,21 @@ Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'bigobj', 'che
 ts = Test.MakeATSProcess("ts1", enable_tls=True)
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|cache',
-    'proxy.config.http.cache.required_headers': 0,  # No required headers for caching
-    'proxy.config.http.push_method_enabled': 1,
-    'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
-    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
-    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
-    'proxy.config.url_remap.remap_required': 0
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|cache',
+        'proxy.config.http.cache.required_headers': 0,  # No required headers for caching
+        'proxy.config.http.push_method_enabled': 1,
+        'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
+        'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+        'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+        'proxy.config.url_remap.remap_required': 0
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.remap_config.AddLine(
-    'map https://localhost http://localhost'
-)
+ts.Disk.remap_config.AddLine('map https://localhost http://localhost')
 
 # Set up to check the output after the tests have run.
 #
@@ -71,41 +66,35 @@ tr = Test.AddTestRun("PUSH an object to the cache")
 tr.Processes.Default.StartBefore(ts)
 #
 # Put object with URL http://localhost/bigobj in cache using PUSH request.
-tr.Processes.Default.Command = (
-    f'./push_request {obj_kilobytes} | nc localhost {ts.Variables.port}'
-)
+tr.Processes.Default.Command = (f'./push_request {obj_kilobytes} | nc localhost {ts.Variables.port}')
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("GET bigobj: cleartext, HTTP/1.1, IPv4")
 tr.Processes.Default.Command = (
     'curl --verbose --ipv4 --http1.1 --header "Host: localhost"'
     f' http://localhost:{ts.Variables.port}/bigobj 2>> log.txt |'
-    f' ./check_ramp {obj_kilobytes}'
-)
+    f' ./check_ramp {obj_kilobytes}')
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("GET bigobj: TLS, HTTP/1.1, IPv4")
 tr.Processes.Default.Command = (
     'curl --verbose --ipv4 --http1.1 --insecure --header "Host: localhost"'
     f' https://localhost:{ts.Variables.ssl_port}/bigobj 2>> log.txt |'
-    f' ./check_ramp {obj_kilobytes}'
-)
+    f' ./check_ramp {obj_kilobytes}')
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("GET bigobj: TLS, HTTP/2, IPv4")
 tr.Processes.Default.Command = (
     'curl --verbose --ipv4 --http2 --insecure --header "Host: localhost"'
     f' https://localhost:{ts.Variables.ssl_port}/bigobj 2>> log.txt |'
-    f' ./check_ramp {obj_kilobytes}'
-)
+    f' ./check_ramp {obj_kilobytes}')
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("GET bigobj: TLS, HTTP/2, IPv6")
 tr.Processes.Default.Command = (
     'curl --verbose --ipv6 --http2 --insecure --header "Host: localhost"'
     f' https://localhost:{ts.Variables.ssl_portv6}/bigobj 2>> log.txt |'
-    f' ./check_ramp {obj_kilobytes}'
-)
+    f' ./check_ramp {obj_kilobytes}')
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
@@ -117,31 +106,24 @@ tr.Processes.Default.ReturnCode = 0
 ts = Test.MakeATSProcess("ts2", enable_tls=True)
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|cache',
-    'proxy.config.http.cache.required_headers': 0,  # No required headers for caching
-    'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
-    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
-    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
-    'proxy.config.url_remap.remap_required': 0
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|cache',
+        'proxy.config.http.cache.required_headers': 0,  # No required headers for caching
+        'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
+        'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+        'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+        'proxy.config.url_remap.remap_required': 0
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.remap_config.AddLine(
-    'map https://localhost http://localhost'
-)
+ts.Disk.remap_config.AddLine('map https://localhost http://localhost')
 
 tr = Test.AddTestRun("PUSH request is rejected when push_method_enabled is 0")
 tr.Processes.Default.StartBefore(ts)
-tr.Processes.Default.Command = (
-    f'./push_request {obj_kilobytes} | nc localhost {ts.Variables.port}'
-)
+tr.Processes.Default.Command = (f'./push_request {obj_kilobytes} | nc localhost {ts.Variables.port}')
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
-    "403 Access Denied",
-    "The PUSH request should have received a 403 response."
-)
+    "403 Access Denied", "The PUSH request should have received a 403 response.")

--- a/tests/gold_tests/body_factory/http204_response.test.py
+++ b/tests/gold_tests/body_factory/http204_response.test.py
@@ -58,17 +58,12 @@ Description: According to rfc7231 I should not have been sent to you!
 regex_remap_conf_file = "maps.reg"
 
 ts.Disk.remap_config.AddLine(
-    'map http://{0} http://127.0.0.1:{1} @plugin=regex_remap.so @pparam={2} @pparam=no-query-string @pparam=host'
-                    .format(DEFAULT_204_HOST, server.Variables.Port, regex_remap_conf_file)
-)
+    'map http://{0} http://127.0.0.1:{1} @plugin=regex_remap.so @pparam={2} @pparam=no-query-string @pparam=host'.format(
+        DEFAULT_204_HOST, server.Variables.Port, regex_remap_conf_file))
 ts.Disk.remap_config.AddLine(
     'map http://{0} http://127.0.0.1:{1} @plugin=regex_remap.so @pparam={2} @pparam=no-query-string @pparam=host @plugin=conf_remap.so @pparam=proxy.config.body_factory.template_base={0}'
-                    .format(CUSTOM_TEMPLATE_204_HOST, server.Variables.Port, regex_remap_conf_file)
-)
-ts.Disk.MakeConfigFile(regex_remap_conf_file).AddLine(
-    '//.*/ http://127.0.0.1:{0} @status=204'
-    .format(server.Variables.Port)
-)
+    .format(CUSTOM_TEMPLATE_204_HOST, server.Variables.Port, regex_remap_conf_file))
+ts.Disk.MakeConfigFile(regex_remap_conf_file).AddLine('//.*/ http://127.0.0.1:{0} @status=204'.format(server.Variables.Port))
 
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
@@ -81,7 +76,6 @@ defaultTr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1
 defaultTr.Processes.Default.TimeOut = 5  # seconds
 defaultTr.Processes.Default.ReturnCode = 0
 defaultTr.Processes.Default.Streams.stdout = "gold/http-204.gold"
-
 
 customTemplateTr = Test.AddTestRun(f"Test domain {CUSTOM_TEMPLATE_204_HOST}")
 customTemplateTr.StillRunningBefore = ts

--- a/tests/gold_tests/body_factory/http304_response.test.py
+++ b/tests/gold_tests/body_factory/http304_response.test.py
@@ -29,17 +29,12 @@ server = Test.MakeOriginServer("server")
 
 DEFAULT_304_HOST = 'www.default304.test'
 
-
 regex_remap_conf_file = "maps.reg"
 
 ts.Disk.remap_config.AddLine(
-    'map http://{0} http://127.0.0.1:{1} @plugin=regex_remap.so @pparam={2} @pparam=no-query-string @pparam=host'
-                    .format(DEFAULT_304_HOST, server.Variables.Port, regex_remap_conf_file)
-)
-ts.Disk.MakeConfigFile(regex_remap_conf_file).AddLine(
-    '//.*/ http://127.0.0.1:{0} @status=304'
-    .format(server.Variables.Port)
-)
+    'map http://{0} http://127.0.0.1:{1} @plugin=regex_remap.so @pparam={2} @pparam=no-query-string @pparam=host'.format(
+        DEFAULT_304_HOST, server.Variables.Port, regex_remap_conf_file))
+ts.Disk.MakeConfigFile(regex_remap_conf_file).AddLine('//.*/ http://127.0.0.1:{0} @status=304'.format(server.Variables.Port))
 
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')

--- a/tests/gold_tests/body_factory/http_head_no_origin.test.py
+++ b/tests/gold_tests/body_factory/http_head_no_origin.test.py
@@ -29,7 +29,6 @@ server = Test.MakeOriginServer("server")
 
 HOST = 'www.example.test'
 
-
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
 

--- a/tests/gold_tests/body_factory/http_with_origin.test.py
+++ b/tests/gold_tests/body_factory/http_with_origin.test.py
@@ -30,40 +30,40 @@ HOST = 'www.example.test'
 
 server = Test.MakeOriginServer("server")
 
-ts.Disk.remap_config.AddLine(
-    'map http://{0} http://127.0.0.1:{1}'.format(HOST, server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://{0} http://127.0.0.1:{1}'.format(HOST, server.Variables.Port))
 
-server.addResponse("sessionfile.log", {
-    "headers": "HEAD /head200 HTTP/1.1\r\nHost: {0}\r\n\r\n".format(HOST),
-    "timestamp": "1469733493.993",
-    "body": ""
-}, {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-    "timestamp": "1469733493.993",
-    "body": "This body should not be returned for a HEAD request."
-})
+server.addResponse(
+    "sessionfile.log", {
+        "headers": "HEAD /head200 HTTP/1.1\r\nHost: {0}\r\n\r\n".format(HOST),
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "This body should not be returned for a HEAD request."
+    })
 
-server.addResponse("sessionfile.log", {
-    "headers": "GET /get200 HTTP/1.1\r\nHost: {0}\r\n\r\n".format(HOST),
-    "timestamp": "1469733493.993",
-    "body": ""
-}, {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-    "timestamp": "1469733493.993",
-    "body": "This body should be returned for a GET request."
-})
+server.addResponse(
+    "sessionfile.log", {
+        "headers": "GET /get200 HTTP/1.1\r\nHost: {0}\r\n\r\n".format(HOST),
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "This body should be returned for a GET request."
+    })
 
-server.addResponse("sessionfile.log", {
-    "headers": "GET /get304 HTTP/1.1\r\nHost: {0}\r\n\r\n".format(HOST),
-    "timestamp": "1469733493.993",
-    "body": ""
-}, {
-    "headers": "HTTP/1.1 304 Not Modified\r\nConnection: close\r\n\r\n",
-    "timestamp": "1469733493.993",
-    "body": ""
-})
-
+server.addResponse(
+    "sessionfile.log", {
+        "headers": "GET /get304 HTTP/1.1\r\nHost: {0}\r\n\r\n".format(HOST),
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 304 Not Modified\r\nConnection: close\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    })
 
 Test.Setup.Copy(os.path.join(os.pardir, os.pardir, 'tools', 'tcp_client.py'))
 Test.Setup.Copy('data')
@@ -79,7 +79,6 @@ trhead200.Processes.Default.TimeOut = 5  # seconds
 trhead200.Processes.Default.ReturnCode = 0
 trhead200.Processes.Default.Streams.stdout = "gold/http-head-200.gold"
 
-
 trget200 = Test.AddTestRun("Test domain {0}".format(HOST))
 trget200.StillRunningBefore = ts
 trget200.StillRunningBefore = server
@@ -90,7 +89,6 @@ trget200.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 
 trget200.Processes.Default.TimeOut = 5  # seconds
 trget200.Processes.Default.ReturnCode = 0
 trget200.Processes.Default.Streams.stdout = "gold/http-get-200.gold"
-
 
 trget304 = Test.AddTestRun("Test domain {0}".format(HOST))
 trget304.StillRunningBefore = ts

--- a/tests/gold_tests/cache/alternate-caching.test.py
+++ b/tests/gold_tests/cache/alternate-caching.test.py
@@ -25,27 +25,24 @@ Test the alternate caching feature.
 # Verify disabled negative_revalidating behavior.
 #
 ts = Test.MakeATSProcess("ts-alternate-caching")
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|cache',
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|cache',
+        'proxy.config.http.cache.max_stale_age': 6,
+        'proxy.config.cache.select_alternate': 1,
+        'proxy.config.cache.limits.http.max_alts': 4,
 
-    'proxy.config.http.cache.max_stale_age': 6,
-    'proxy.config.cache.select_alternate': 1,
-    'proxy.config.cache.limits.http.max_alts': 4,
-
-    # Try with and without this
-    'proxy.config.http.negative_revalidating_enabled': 1,
-    'proxy.config.http.negative_caching_enabled': 1,
-    'proxy.config.http.negative_caching_lifetime': 30
-
-})
+        # Try with and without this
+        'proxy.config.http.negative_revalidating_enabled': 1,
+        'proxy.config.http.negative_caching_enabled': 1,
+        'proxy.config.http.negative_caching_lifetime': 30
+    })
 tr = Test.AddTestRun("Verify disabled negative revalidating behavior.")
 replay_file = "replay/alternate-caching-update-size.yaml"
 server = tr.AddVerifierServerProcess("server1", replay_file)
 server_port = server.Variables.http_port
 tr.AddVerifierClientProcess("client1", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/cache/background_fill.test.py
+++ b/tests/gold_tests/cache/background_fill.test.py
@@ -19,9 +19,7 @@
 from enum import Enum
 
 Test.Summary = 'Exercise Background Fill'
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2'),
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'),)
 Test.ContinueOnFail = True
 
 
@@ -46,24 +44,23 @@ class BackgroundFillTest:
         self.httpbin = Test.MakeHttpBinServer("httpbin")
 
     def __setupTS(self):
-        self.ts = Test.MakeATSProcess(
-            "ts", select_ports=True, enable_tls=True, enable_cache=True)
+        self.ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_cache=True)
 
         self.ts.addDefaultSSLFiles()
-        self.ts.Disk.ssl_multicert_config.AddLine(
-            "dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key")
+        self.ts.Disk.ssl_multicert_config.AddLine("dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key")
 
-        self.ts.Disk.records_config.update({
-            "proxy.config.http.server_ports": f"{self.ts.Variables.port} {self.ts.Variables.ssl_port}:ssl",
-            'proxy.config.ssl.server.cert.path': f"{self.ts.Variables.SSLDir}",
-            'proxy.config.ssl.server.private_key.path': f"{self.ts.Variables.SSLDir}",
-            "proxy.config.diags.debug.enabled": 1,
-            "proxy.config.diags.debug.tags": "http",
-            "proxy.config.http.background_fill_active_timeout": "0",
-            "proxy.config.http.background_fill_completed_threshold": "0.0",
-            "proxy.config.http.cache.required_headers": 0,  # Force cache
-            "proxy.config.http.insert_response_via_str": 2,
-        })
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.http.server_ports": f"{self.ts.Variables.port} {self.ts.Variables.ssl_port}:ssl",
+                'proxy.config.ssl.server.cert.path': f"{self.ts.Variables.SSLDir}",
+                'proxy.config.ssl.server.private_key.path': f"{self.ts.Variables.SSLDir}",
+                "proxy.config.diags.debug.enabled": 1,
+                "proxy.config.diags.debug.tags": "http",
+                "proxy.config.http.background_fill_active_timeout": "0",
+                "proxy.config.http.background_fill_completed_threshold": "0.0",
+                "proxy.config.http.cache.required_headers": 0,  # Force cache
+                "proxy.config.http.insert_response_via_str": 2,
+            })
 
         self.ts.Disk.remap_config.AddLines([
             f"map / http://127.0.0.1:{self.httpbin.Variables.Port}/",

--- a/tests/gold_tests/cache/cache-control.test.py
+++ b/tests/gold_tests/cache/cache-control.test.py
@@ -30,32 +30,46 @@ server = Test.MakeOriginServer("server")
 # **testname is required**
 testName = ""
 request_header1 = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-response_header1 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-Control: max-age=300\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": "xxx"}
-request_header2 = {"headers": "GET /no_cache_control HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
-response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": "the flinstones"}
-request_header3 = {"headers": "GET /max_age_10sec HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
-response_header3 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-Control: max-age=10,public\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": "yabadabadoo"}
+response_header1 = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-Control: max-age=300\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"
+}
+request_header2 = {
+    "headers": "GET /no_cache_control HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header2 = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "the flinstones"
+}
+request_header3 = {
+    "headers": "GET /max_age_10sec HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header3 = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-Control: max-age=10,public\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "yabadabadoo"
+}
 server.addResponse("sessionlog.json", request_header1, response_header1)
 server.addResponse("sessionlog.json", request_header2, response_header2)
 server.addResponse("sessionlog.json", request_header3, response_header3)
 
 # ATS Configuration
 ts.Disk.plugin_config.AddLine('xdebug.so')
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.response_via_str': 3,
-    'proxy.config.http.insert_age_in_response': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.response_via_str': 3,
+        'proxy.config.http.insert_age_in_response': 0,
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Test 1 - 200 response and cache fill
 tr = Test.AddTestRun()
@@ -114,18 +128,17 @@ tr.StillRunningAfter = ts
 ts = Test.MakeATSProcess("ts-for-proxy-verifier")
 replay_file = "replay/cache-control-max-age.replay.yaml"
 server = Test.MakeVerifierServerProcess("proxy-verifier-server", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.insert_age_in_response': 0,
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
 
-    # Disable ignoring max-age in the client request so we can test that
-    # behavior too.
-    'proxy.config.http.cache.ignore_client_cc_max_age': 0,
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+        # Disable ignoring max-age in the client request so we can test that
+        # behavior too.
+        'proxy.config.http.cache.ignore_client_cc_max_age': 0,
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify correct max-age cache-control behavior.")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/cache/cache-generation-clear.test.py
+++ b/tests/gold_tests/cache/cache-generation-clear.test.py
@@ -41,7 +41,7 @@ ts.Disk.remap_config.AddLines([
     # line 3
     'map /generation2/ http://127.0.0.1/' +
     ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
-    ' @plugin=generator.so'
+    ' @plugin=generator.so',
 ])
 
 objectid = uuid.uuid4()

--- a/tests/gold_tests/cache/cache-generation-clear.test.py
+++ b/tests/gold_tests/cache/cache-generation-clear.test.py
@@ -26,23 +26,23 @@ Test.ContinueOnFail = True
 ts = Test.MakeATSProcess("ts", command="traffic_manager")
 
 # setup some config file for this server
-ts.Disk.records_config.update({
-    'proxy.config.body_factory.enable_customizations': 3,  # enable domain specific body factory
-    'proxy.config.http.cache.generation': -1,  # Start with cache turned off
-    'proxy.config.config_update_interval_ms': 1,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.body_factory.enable_customizations': 3,  # enable domain specific body factory
+        'proxy.config.http.cache.generation': -1,  # Start with cache turned off
+        'proxy.config.config_update_interval_ms': 1,
+    })
 ts.Disk.plugin_config.AddLine('xdebug.so')
-ts.Disk.remap_config.AddLines([
-    'map /default/ http://127.0.0.1/ @plugin=generator.so',
-    # line 2
-    'map /generation1/ http://127.0.0.1/' +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=1' +
-    ' @plugin=generator.so',
-    # line 3
-    'map /generation2/ http://127.0.0.1/' +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
-    ' @plugin=generator.so',
-])
+ts.Disk.remap_config.AddLines(
+    [
+        'map /default/ http://127.0.0.1/ @plugin=generator.so',
+        # line 2
+        'map /generation1/ http://127.0.0.1/' + ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=1' +
+        ' @plugin=generator.so',
+        # line 3
+        'map /generation2/ http://127.0.0.1/' + ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
+        ' @plugin=generator.so',
+    ])
 
 objectid = uuid.uuid4()
 # first test is a miss for default

--- a/tests/gold_tests/cache/cache-generation-disjoint.test.py
+++ b/tests/gold_tests/cache/cache-generation-disjoint.test.py
@@ -43,7 +43,7 @@ ts.Disk.remap_config.AddLines([
     # line 3
     'map /generation2/ http://127.0.0.1/' +
     ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
-    ' @plugin=generator.so'
+    ' @plugin=generator.so',
 ])
 
 objectid = uuid.uuid4()

--- a/tests/gold_tests/cache/cache-generation-disjoint.test.py
+++ b/tests/gold_tests/cache/cache-generation-disjoint.test.py
@@ -27,24 +27,23 @@ Test.ContinueOnFail = True
 ts = Test.MakeATSProcess("ts")
 
 # setup some config file for this server
-ts.Disk.records_config.update({
-    'proxy.config.body_factory.enable_customizations': 3,  # enable domain specific body factory
-    'proxy.config.http.cache.generation': -1,  # Start with cache turned off
-    'proxy.config.config_update_interval_ms': 1,
-
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.body_factory.enable_customizations': 3,  # enable domain specific body factory
+        'proxy.config.http.cache.generation': -1,  # Start with cache turned off
+        'proxy.config.config_update_interval_ms': 1,
+    })
 ts.Disk.plugin_config.AddLine('xdebug.so')
-ts.Disk.remap_config.AddLines([
-    'map /default/ http://127.0.0.1/ @plugin=generator.so',
-    # line 2
-    'map /generation1/ http://127.0.0.1/' +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=1' +
-    ' @plugin=generator.so',
-    # line 3
-    'map /generation2/ http://127.0.0.1/' +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
-    ' @plugin=generator.so',
-])
+ts.Disk.remap_config.AddLines(
+    [
+        'map /default/ http://127.0.0.1/ @plugin=generator.so',
+        # line 2
+        'map /generation1/ http://127.0.0.1/' + ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=1' +
+        ' @plugin=generator.so',
+        # line 3
+        'map /generation2/ http://127.0.0.1/' + ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
+        ' @plugin=generator.so',
+    ])
 
 objectid = uuid.uuid4()
 # first test is a miss for default

--- a/tests/gold_tests/cache/cache-range-response.test.py
+++ b/tests/gold_tests/cache/cache-range-response.test.py
@@ -24,16 +24,15 @@ Verify correct caching behavior for range requests.
 ts = Test.MakeATSProcess("ts")
 replay_file = "replay/cache-range-response.replay.yaml"
 server = Test.MakeVerifierServerProcess("server0", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http.*|cache.*',
-    'proxy.config.http.cache.range.write': 1,
-    'proxy.config.http.cache.when_to_revalidate': 4,
-    'proxy.config.http.insert_response_via_str': 3,
-})
-ts.Disk.remap_config.AddLine(
-    f'map / http://127.0.0.1:{server.Variables.http_port}'
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http.*|cache.*',
+        'proxy.config.http.cache.range.write': 1,
+        'proxy.config.http.cache.when_to_revalidate': 4,
+        'proxy.config.http.insert_response_via_str': 3,
+    })
+ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.http_port}')
 tr = Test.AddTestRun("Verify range request is transformed from a 200 response")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/cache/cache-request-method.test.py
+++ b/tests/gold_tests/cache/cache-request-method.test.py
@@ -26,18 +26,17 @@ Verify correct caching behavior with respect to request method.
 ts = Test.MakeATSProcess("ts")
 replay_file = "replay/post_with_post_caching_disabled.replay.yaml"
 server = Test.MakeVerifierServerProcess("server0", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http.*|cache.*',
-    'proxy.config.http.insert_age_in_response': 0,
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http.*|cache.*',
+        'proxy.config.http.insert_age_in_response': 0,
 
-    # Caching of POST responses is disabled by default. Verify default behavior
-    # by leaving it unconfigured.
-    # 'proxy.config.http.cache.post_method': 0,
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+        # Caching of POST responses is disabled by default. Verify default behavior
+        # by leaving it unconfigured.
+        # 'proxy.config.http.cache.post_method': 0,
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify correct with POST response caching disabled.")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
@@ -48,15 +47,14 @@ tr.AddVerifierClientProcess("client0", replay_file, http_ports=[ts.Variables.por
 ts = Test.MakeATSProcess("ts-cache-post")
 replay_file = "replay/post_with_post_caching_enabled.replay.yaml"
 server = Test.MakeVerifierServerProcess("server1", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http.*|cache.*',
-    'proxy.config.http.insert_age_in_response': 0,
-    'proxy.config.http.cache.post_method': 1,
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http.*|cache.*',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.cache.post_method': 1,
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify correct with POST response caching enabled.")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
@@ -66,14 +64,13 @@ tr.AddVerifierClientProcess("client1", replay_file, http_ports=[ts.Variables.por
 ts = Test.MakeATSProcess("ts-cache-head")
 replay_file = "replay/head_with_get_cached.replay.yaml"
 server = Test.MakeVerifierServerProcess("server2", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http.*|cache.*',
-    'proxy.config.http.insert_age_in_response': 0,
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http.*|cache.*',
+        'proxy.config.http.insert_age_in_response': 0,
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify correct with HEAD response.")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/cache/conditional-get-hit.test.py
+++ b/tests/gold_tests/cache/conditional-get-hit.test.py
@@ -22,19 +22,17 @@ Test conditional get with body drains the body from client"
 '''
 
 ts = Test.MakeATSProcess("ts-conditional-get-caching")
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|cache',
-
-    'proxy.config.http.cache.max_stale_age': 6,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|cache',
+        'proxy.config.http.cache.max_stale_age': 6,
+    })
 tr = Test.AddTestRun("Verify conditional get with cache hit drain client body")
 replay_file = "replay/conditional-get-cache-hit.yaml"
 server = tr.AddVerifierServerProcess("server1", replay_file)
 server_port = server.Variables.http_port
 tr.AddVerifierClientProcess("client1", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
+++ b/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
@@ -29,24 +29,24 @@ ts = Test.MakeATSProcess("ts")
 
 # Setup some config file for this server. Note that setting wait_for_cache to 3
 # will intentionally override the value set in MakeATSProcess.
-ts.Disk.records_config.update({
-    'proxy.config.body_factory.enable_customizations': 3,  # enable domain specific body factory
-    'proxy.config.http.cache.generation': -1,  # Start with cache turned off
-    'proxy.config.config_update_interval_ms': 1,
-    'proxy.config.http.wait_for_cache': 3,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.body_factory.enable_customizations': 3,  # enable domain specific body factory
+        'proxy.config.http.cache.generation': -1,  # Start with cache turned off
+        'proxy.config.config_update_interval_ms': 1,
+        'proxy.config.http.wait_for_cache': 3,
+    })
 ts.Disk.plugin_config.AddLine('xdebug.so')
-ts.Disk.remap_config.AddLines([
-    'map /default/ http://127.0.0.1/ @plugin=generator.so',
-    # line 2
-    'map /generation1/ http://127.0.0.1/' +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=1' +
-    ' @plugin=generator.so',
-    # line 3
-    'map /generation2/ http://127.0.0.1/' +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
-    ' @plugin=generator.so',
-])
+ts.Disk.remap_config.AddLines(
+    [
+        'map /default/ http://127.0.0.1/ @plugin=generator.so',
+        # line 2
+        'map /generation1/ http://127.0.0.1/' + ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=1' +
+        ' @plugin=generator.so',
+        # line 3
+        'map /generation2/ http://127.0.0.1/' + ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
+        ' @plugin=generator.so',
+    ])
 
 objectid = uuid.uuid4()
 # first test is a miss for default

--- a/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
+++ b/tests/gold_tests/cache/disjoint-wait-for-cache.test.py
@@ -45,7 +45,7 @@ ts.Disk.remap_config.AddLines([
     # line 3
     'map /generation2/ http://127.0.0.1/' +
     ' @plugin=conf_remap.so @pparam=proxy.config.http.cache.generation=2' +
-    ' @plugin=generator.so'
+    ' @plugin=generator.so',
 ])
 
 objectid = uuid.uuid4()

--- a/tests/gold_tests/cache/negative-caching.test.py
+++ b/tests/gold_tests/cache/negative-caching.test.py
@@ -27,16 +27,14 @@ Test negative caching.
 ts = Test.MakeATSProcess("ts-disabled")
 replay_file = "replay/negative-caching-disabled.replay.yaml"
 server = Test.MakeVerifierServerProcess("server-disabled", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.insert_age_in_response': 0,
-
-    'proxy.config.http.negative_caching_enabled': 0
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.negative_caching_enabled': 0
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify correct behavior without negative caching enabled.")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
@@ -48,16 +46,14 @@ tr.AddVerifierClientProcess("client-disabled", replay_file, http_ports=[ts.Varia
 ts = Test.MakeATSProcess("ts-default")
 replay_file = "replay/negative-caching-default.replay.yaml"
 server = Test.MakeVerifierServerProcess("server-default", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.insert_age_in_response': 0,
-
-    'proxy.config.http.negative_caching_enabled': 1
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.negative_caching_enabled': 1
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify default negative caching behavior")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
@@ -69,17 +65,15 @@ tr.AddVerifierClientProcess("client-default", replay_file, http_ports=[ts.Variab
 ts = Test.MakeATSProcess("ts-customized")
 replay_file = "replay/negative-caching-customized.replay.yaml"
 server = Test.MakeVerifierServerProcess("server-customized", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.insert_age_in_response': 0,
-
-    'proxy.config.http.negative_caching_enabled': 1,
-    'proxy.config.http.negative_caching_list': "400"
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.negative_caching_enabled': 1,
+        'proxy.config.http.negative_caching_list': "400"
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify customized negative caching list")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
@@ -89,14 +83,14 @@ tr.AddVerifierClientProcess("client-customized", replay_file, http_ports=[ts.Var
 # Verify correct proxy.config.http.negative_caching_lifetime behavior.
 #
 ts = Test.MakeATSProcess("ts-lifetime")
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.insert_age_in_response': 0,
-
-    'proxy.config.http.negative_caching_enabled': 1,
-    'proxy.config.http.negative_caching_lifetime': 2
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.negative_caching_enabled': 1,
+        'proxy.config.http.negative_caching_lifetime': 2
+    })
 # This should all behave the same as the default enabled case above.
 tr = Test.AddTestRun("Add a 404 response to the cache")
 replay_file = "replay/negative-caching-default.replay.yaml"
@@ -105,9 +99,7 @@ server = tr.AddVerifierServerProcess("server-lifetime-no-cc", replay_file)
 # across both.
 server_port = server.Variables.http_port
 tr.AddVerifierClientProcess("client-lifetime-no-cc", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = ts
 
@@ -128,14 +120,14 @@ tr.StillRunningAfter = ts
 # proxy.config.http.negative_caching_lifetime.
 #
 ts = Test.MakeATSProcess("ts-lifetime-2")
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.insert_age_in_response': 0,
-
-    'proxy.config.http.negative_caching_enabled': 1,
-    'proxy.config.http.negative_caching_lifetime': 2
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.negative_caching_enabled': 1,
+        'proxy.config.http.negative_caching_lifetime': 2
+    })
 tr = Test.AddTestRun("Add a 404 response with explicit max-age=300 to the cache")
 replay_file = "replay/negative-caching-300-second-timeout.replay.yaml"
 server = tr.AddVerifierServerProcess("server-lifetime-cc", replay_file)
@@ -143,9 +135,7 @@ server = tr.AddVerifierServerProcess("server-lifetime-cc", replay_file)
 # across both.
 server_port = server.Variables.http_port
 tr.AddVerifierClientProcess("client-lifetime-cc", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = ts
 

--- a/tests/gold_tests/cache/negative-revalidating.test.py
+++ b/tests/gold_tests/cache/negative-revalidating.test.py
@@ -25,22 +25,20 @@ Test the negative revalidating feature.
 # Verify disabled negative_revalidating behavior.
 #
 ts = Test.MakeATSProcess("ts-negative-revalidating-disabled")
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|cache',
-    'proxy.config.http.insert_age_in_response': 0,
-
-    'proxy.config.http.negative_revalidating_enabled': 0,
-    'proxy.config.http.cache.max_stale_age': 6
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|cache',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.negative_revalidating_enabled': 0,
+        'proxy.config.http.cache.max_stale_age': 6
+    })
 tr = Test.AddTestRun("Verify disabled negative revalidating behavior.")
 replay_file = "replay/negative-revalidating-disabled.replay.yaml"
 server = tr.AddVerifierServerProcess("server1", replay_file)
 server_port = server.Variables.http_port
 tr.AddVerifierClientProcess("client1", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = ts
 
@@ -48,23 +46,22 @@ tr.StillRunningAfter = ts
 # Verify enabled negative_revalidating behavior.
 #
 ts = Test.MakeATSProcess("ts-negative-revalidating-enabled")
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|cache',
-    'proxy.config.http.insert_age_in_response': 0,
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|cache',
+        'proxy.config.http.insert_age_in_response': 0,
 
-    # Negative revalidating is on by default. Verify this by leaving out the
-    # following line and expect negative_revalidating to be enabled.
-    # 'proxy.config.http.negative_revalidating_enabled': 1,
-    'proxy.config.http.cache.max_stale_age': 6
-})
+        # Negative revalidating is on by default. Verify this by leaving out the
+        # following line and expect negative_revalidating to be enabled.
+        # 'proxy.config.http.negative_revalidating_enabled': 1,
+        'proxy.config.http.cache.max_stale_age': 6
+    })
 tr = Test.AddTestRun("Verify negative revalidating behavior.")
 replay_file = "replay/negative-revalidating-enabled.replay.yaml"
 server = tr.AddVerifierServerProcess("server2", replay_file)
 server_port = server.Variables.http_port
 tr.AddVerifierClientProcess("client2", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/cache/vary-handling.test.py
+++ b/tests/gold_tests/cache/vary-handling.test.py
@@ -24,17 +24,16 @@ Test correct handling of alternates via the Vary header.
 ts = Test.MakeATSProcess("ts")
 replay_file = "replay/varied_transactions.replay.yaml"
 server = Test.MakeVerifierServerProcess("server", replay_file)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.insert_age_in_response': 0,
-    'proxy.config.cache.limits.http.max_alts': 4,
-    'proxy.config.cache.log.alternate.eviction': 1,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.cache.limits.http.max_alts': 4,
+        'proxy.config.cache.log.alternate.eviction': 1,
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 
 tr = Test.AddTestRun("Run traffic with max_alts behavior when set to 4")
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
@@ -29,22 +29,22 @@ ts = Test.MakeATSProcess("ts1", select_ports=True, enable_tls=False)
 server = Test.MakeOriginServer("server")
 
 testName = ""
-request_header = {"headers": "POST /case1 HTTP/1.1\r\nHost: www.example.com\r\nuuid:1\r\n\r\n",
-                  "timestamp": "1469733493.993",
-                  "body": "stuff"
-                  }
-response_header = {"headers": "HTTP/1.1 200 OK\r\nServer: uServer\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n",
-                   "timestamp": "1469733493.993",
-                   "body": "more stuff"}
+request_header = {
+    "headers": "POST /case1 HTTP/1.1\r\nHost: www.example.com\r\nuuid:1\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "stuff"
+}
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\nServer: uServer\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "more stuff"
+}
 
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 0,
-                               'proxy.config.diags.debug.tags': 'http'})
+ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 0, 'proxy.config.diags.debug.tags': 'http'})
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # HTTP1.1 POST: www.example.com/case1 with gzip transfer-encoding
 tr = Test.AddTestRun()
@@ -84,19 +84,16 @@ class HTTP10Test:
     def setupTS(self):
         self.ts = Test.MakeATSProcess("ts2", enable_tls=True, enable_cache=False)
         self.ts.addDefaultSSLFiles()
-        self.ts.Disk.records_config.update({
-            "proxy.config.diags.debug.enabled": 1,
-            "proxy.config.diags.debug.tags": "http",
-            "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
-        })
-        self.ts.Disk.ssl_multicert_config.AddLine(
-            'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-        )
-        self.ts.Disk.remap_config.AddLine(
-            f"map / http://127.0.0.1:{self.server.Variables.http_port}/",
-        )
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.diags.debug.enabled": 1,
+                "proxy.config.diags.debug.tags": "http",
+                "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
+            })
+        self.ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+        self.ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{self.server.Variables.http_port}/",)
 
     def runChunkedTraffic(self):
         tr = Test.AddTestRun()
@@ -132,37 +129,29 @@ class MalformedChunkHeaderTest:
         # because ATS will close the connection due to the malformed
         # chunk headers.
         self.server.Streams.stdout += Testers.ContainsExpression(
-            "Unexpected chunked content for key 1: too small",
-            "Verify that writing the first response failed.")
+            "Unexpected chunked content for key 1: too small", "Verify that writing the first response failed.")
         self.server.Streams.stdout += Testers.ContainsExpression(
-            "Unexpected chunked content for key 2: too small",
-            "Verify that writing the second response failed.")
+            "Unexpected chunked content for key 2: too small", "Verify that writing the second response failed.")
 
         # ATS should close the connection before any body gets through. "abc"
         # is the body sent by the client for each of these chunked cases.
-        self.server.Streams.stdout += Testers.ExcludesExpression(
-            "abc",
-            "Verify that the body never got through.")
+        self.server.Streams.stdout += Testers.ExcludesExpression("abc", "Verify that the body never got through.")
 
     def setupTS(self):
         self.ts = Test.MakeATSProcess("ts3", enable_tls=True, enable_cache=False)
         self.ts.addDefaultSSLFiles()
-        self.ts.Disk.records_config.update({
-            "proxy.config.diags.debug.enabled": 1,
-            "proxy.config.diags.debug.tags": "http",
-            "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
-        })
-        self.ts.Disk.ssl_multicert_config.AddLine(
-            'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-        )
-        self.ts.Disk.remap_config.AddLine(
-            f"map / http://127.0.0.1:{self.server.Variables.http_port}/",
-        )
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.diags.debug.enabled": 1,
+                "proxy.config.diags.debug.tags": "http",
+                "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
+            })
+        self.ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+        self.ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{self.server.Variables.http_port}/",)
         self.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-            "user agent post chunk decoding error",
-            "Verify that ATS detected a problem parsing a chunk.")
+            "user agent post chunk decoding error", "Verify that ATS detected a problem parsing a chunk.")
 
     def runChunkedTraffic(self):
         tr = Test.AddTestRun()
@@ -189,9 +178,7 @@ class MalformedChunkHeaderTest:
 
         # ATS should close the connection before any body gets through. "def"
         # is the body sent by the server for each of these chunked cases.
-        tr.Processes.Default.Streams.stdout += Testers.ExcludesExpression(
-            "def",
-            "Verify that the body never got through.")
+        tr.Processes.Default.Streams.stdout += Testers.ExcludesExpression("def", "Verify that the body never got through.")
 
     def run(self):
         self.runChunkedTraffic()

--- a/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
@@ -22,8 +22,7 @@ Test interaction of H2 and chunked encoding
 
 Test.SkipUnless(
     Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
-    Condition.HasCurlFeature('http2')
-)
+    Condition.HasCurlFeature('http2'))
 Test.ContinueOnFail = True
 
 Test.GetTcpPort("upstream_port")
@@ -34,24 +33,19 @@ ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map /delay-chunked-response http://127.0.0.1:{0}'.format(Test.Variables.upstream_port)
-)
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(Test.Variables.upstream_port)
-)
+ts.Disk.remap_config.AddLine('map /delay-chunked-response http://127.0.0.1:{0}'.format(Test.Variables.upstream_port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(Test.Variables.upstream_port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Using netcat as a cheap origin server in case 1 so we can insert a delay in sending back the response.
 # Replaced microserver for cases 2 and 3 as well because I was getting python exceptions when running

--- a/tests/gold_tests/command_argument/verify_global_plugin.test.py
+++ b/tests/gold_tests/command_argument/verify_global_plugin.test.py
@@ -58,10 +58,7 @@ tr.Processes.Default.Command = "traffic_server -C 'verify_global_plugin'"
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: verifying a plugin requires a plugin SO file path argument",
-    "Should warn about the need for an SO file argument")
-
-
+    "ERROR: verifying a plugin requires a plugin SO file path argument", "Should warn about the need for an SO file argument")
 """
 TEST: verify_global_plugin should complain if the argument doesn't reference a shared
 object file.
@@ -75,20 +72,14 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: .*No such file or directory",
-    "Should warn about the non-existent SO file argument")
-
-
+    "ERROR: .*No such file or directory", "Should warn about the non-existent SO file argument")
 """
 TEST: verify_global_plugin should complain if the shared object file doesn't
 have the expected Plugin symbols.
 """
 tr = Test.AddTestRun("Verify the requirement of our Plugin API.")
 ts = create_ts_process()
-Test.PrepareTestPlugin(
-    os.path.join(Test.Variables.AtsTestPluginsDir,
-                 'missing_ts_plugin_init.so'),
-    ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'missing_ts_plugin_init.so'), ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = \
     "traffic_server -C 'verify_global_plugin {filename}'".format(
@@ -96,23 +87,15 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: .*unable to find TSPluginInit function in",
-    "Should warn about the need for the TSPluginInit symbol")
-ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "ERROR",
-    "ERROR: .*unable to find TSPluginInit function in")
-
-
+    "ERROR: .*unable to find TSPluginInit function in", "Should warn about the need for the TSPluginInit symbol")
+ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "ERROR: .*unable to find TSPluginInit function in")
 """
 TEST: Verify that passing a remap plugin produces a warning because
 it doesn't have the global plugin symbols.
 """
 tr = Test.AddTestRun("Verify a properly formed plugin works as expected.")
 ts = create_ts_process()
-Test.PrepareTestPlugin(
-    os.path.join(Test.Variables.AtsTestPluginsDir,
-                 'conf_remap_stripped.so'),
-    ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'conf_remap_stripped.so'), ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = \
     "traffic_server -C 'verify_global_plugin {filename}'".format(
@@ -120,23 +103,15 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: .*unable to find TSPluginInit function in",
-    "Should warn about the need for the TSPluginInit symbol")
-ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "ERROR",
-    "ERROR: .*unable to find TSPluginInit function in")
-
-
+    "ERROR: .*unable to find TSPluginInit function in", "Should warn about the need for the TSPluginInit symbol")
+ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "ERROR: .*unable to find TSPluginInit function in")
 """
 TEST: The happy case: a global plugin shared object file is passed as an
 argument that has the definition for the expected Plugin symbols.
 """
 tr = Test.AddTestRun("Verify a properly formed plugin works as expected.")
 ts = create_ts_process()
-Test.PrepareTestPlugin(
-    os.path.join(Test.Variables.AtsTestPluginsDir,
-                 'ssl_hook_test.so'),
-    ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = \
     "traffic_server -C 'verify_global_plugin {filename}'".format(
@@ -144,10 +119,7 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "NOTE: verifying plugin '.*' Success",
-    "Verification should succeed")
-
-
+    "NOTE: verifying plugin '.*' Success", "Verification should succeed")
 """
 TEST: This is a regression test for a shared object file that doesn't have all
 of the required symbols defined because of a malformed interaction between C
@@ -166,8 +138,5 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR:.*unable to load",
-    "Should log failure to load shared object")
-ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "ERROR",
-    "Should log failure to load shared object")
+    "ERROR:.*unable to load", "Should log failure to load shared object")
+ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "Should log failure to load shared object")

--- a/tests/gold_tests/command_argument/verify_remap_plugin.test.py
+++ b/tests/gold_tests/command_argument/verify_remap_plugin.test.py
@@ -58,10 +58,7 @@ tr.Processes.Default.Command = "traffic_server -C 'verify_remap_plugin'"
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: verifying a plugin requires a plugin SO file path argument",
-    "Should warn about the need for an SO file argument")
-
-
+    "ERROR: verifying a plugin requires a plugin SO file path argument", "Should warn about the need for an SO file argument")
 """
 TEST: verify_remap_plugin should complain if the argument doesn't reference a shared
 object file.
@@ -75,20 +72,14 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: .*No such file or directory",
-    "Should warn about the non-existent SO file argument")
-
-
+    "ERROR: .*No such file or directory", "Should warn about the non-existent SO file argument")
 """
 TEST: verify_remap_plugin should complain if the shared object file doesn't
 have the expected Plugin symbols.
 """
 tr = Test.AddTestRun("Verify the requirement of our Plugin API.")
 ts = create_ts_process()
-Test.PrepareTestPlugin(
-    os.path.join(Test.Variables.AtsTestPluginsDir,
-                 'missing_ts_plugin_init.so'),
-    ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'missing_ts_plugin_init.so'), ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = \
     "traffic_server -C 'verify_remap_plugin {filename}'".format(
@@ -96,23 +87,15 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: .*missing required function TSRemapInit",
-    "Should warn about the need for the TSRemapInit symbol")
-ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "ERROR",
-    "ERROR: .*missing required function TSRemapInit")
-
-
+    "ERROR: .*missing required function TSRemapInit", "Should warn about the need for the TSRemapInit symbol")
+ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "ERROR: .*missing required function TSRemapInit")
 """
 TEST: verify_remap_plugin should complain if the plugin has the global
 plugin symbols but not the remap ones.
 """
 tr = Test.AddTestRun("Verify a global plugin argument produces warning.")
 ts = create_ts_process()
-Test.PrepareTestPlugin(
-    os.path.join(Test.Variables.AtsTestPluginsDir,
-                 'ssl_hook_test.so'),
-    ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = \
     "traffic_server -C 'verify_remap_plugin {filename}'".format(
@@ -120,23 +103,15 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 1
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "ERROR: .*missing required function TSRemapInit",
-    "Should warn about the need for the TSRemapInit symbol")
-ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "ERROR",
-    "ERROR: .*missing required function TSRemapInit")
-
-
+    "ERROR: .*missing required function TSRemapInit", "Should warn about the need for the TSRemapInit symbol")
+ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR", "ERROR: .*missing required function TSRemapInit")
 """
 TEST: The happy case: a remap plugin shared object file is passed as an
 argument that has the definition for the expected Plugin symbols.
 """
 tr = Test.AddTestRun("Verify a properly formed plugin works as expected.")
 ts = create_ts_process()
-Test.PrepareTestPlugin(
-    os.path.join(Test.Variables.AtsTestPluginsDir,
-                 'conf_remap_stripped.so'),
-    ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'conf_remap_stripped.so'), ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = \
     "traffic_server -C 'verify_remap_plugin {filename}'".format(
@@ -144,5 +119,4 @@ tr.Processes.Default.Command = \
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-    "NOTE: verifying plugin '.*' Success",
-    "Verification should succeed")
+    "NOTE: verifying plugin '.*' Success", "Verification should succeed")

--- a/tests/gold_tests/connect/connect.test.py
+++ b/tests/gold_tests/connect/connect.test.py
@@ -43,12 +43,13 @@ class ConnectTest:
     def __setupTS(self):
         self.ts = Test.MakeATSProcess("ts", select_ports=True)
 
-        self.ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http',
-            'proxy.config.http.server_ports': f"{self.ts.Variables.port}",
-            'proxy.config.http.connect_ports': f"{self.httpbin.Variables.Port}",
-        })
+        self.ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http',
+                'proxy.config.http.server_ports': f"{self.ts.Variables.port}",
+                'proxy.config.http.connect_ports': f"{self.httpbin.Variables.Port}",
+            })
 
         self.ts.Disk.remap_config.AddLines([
             f"map http://foo.com/ http://127.0.0.1:{self.httpbin.Variables.Port}/",
@@ -63,8 +64,7 @@ logging:
   logs:
     - filename: access
       format: common
-'''.split("\n")
-        )
+'''.split("\n"))
 
     def __checkProcessBefore(self, tr):
         if self.state == self.State.RUNNING:
@@ -96,8 +96,7 @@ logging:
         tr = Test.AddTestRun()
         tr.Processes.Default.Command = (
             os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-            os.path.join(self.ts.Variables.LOGDIR, 'access.log')
-        )
+            os.path.join(self.ts.Variables.LOGDIR, 'access.log'))
         tr.Processes.Default.ReturnCode = 0
 
     def run(self):

--- a/tests/gold_tests/cont_schedule/schedule.test.py
+++ b/tests/gold_tests/cont_schedule/schedule.test.py
@@ -16,7 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
 
 Test.Summary = 'Test TSContSchedule API'
@@ -27,15 +26,16 @@ ts = Test.MakeATSProcess('ts')
 
 Test.testName = 'Test TSContSchedule API'
 
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 32,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'TSContSchedule_test'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 32,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'TSContSchedule_test'
+    })
 
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'cont_schedule.so'), ts, 'thread')

--- a/tests/gold_tests/cont_schedule/schedule_on_pool.test.py
+++ b/tests/gold_tests/cont_schedule/schedule_on_pool.test.py
@@ -16,7 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
 
 Test.Summary = 'Test TSContScheduleOnPool API'
@@ -27,15 +26,16 @@ ts = Test.MakeATSProcess('ts')
 
 Test.testName = 'Test TSContScheduleOnPool API'
 
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 32,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'TSContSchedule_test'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 32,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'TSContSchedule_test'
+    })
 
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'cont_schedule.so'), ts, 'pool')

--- a/tests/gold_tests/cont_schedule/schedule_on_thread.test.py
+++ b/tests/gold_tests/cont_schedule/schedule_on_thread.test.py
@@ -16,7 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
 
 Test.Summary = 'Test TSContScheduleOnThread API'
@@ -27,15 +26,16 @@ ts = Test.MakeATSProcess('ts')
 
 Test.testName = 'Test TSContScheduleOnThread API'
 
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 32,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'TSContSchedule_test'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 32,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'TSContSchedule_test'
+    })
 
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'cont_schedule.so'), ts, 'thread')

--- a/tests/gold_tests/cont_schedule/thread_affinity.test.py
+++ b/tests/gold_tests/cont_schedule/thread_affinity.test.py
@@ -16,7 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
 
 Test.Summary = 'Test TSContThreadAffinity APIs'
@@ -27,15 +26,16 @@ ts = Test.MakeATSProcess('ts')
 
 Test.testName = 'Test TSContThreadAffinity APIs'
 
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 32,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'TSContSchedule_test'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 32,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'TSContSchedule_test'
+    })
 
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'cont_schedule.so'), ts, 'affinity')

--- a/tests/gold_tests/continuations/double.test.py
+++ b/tests/gold_tests/continuations/double.test.py
@@ -18,6 +18,7 @@
 
 import os
 import subprocess
+
 Test.Summary = '''
 Test transactions and sessions for http1, making sure the two continuations catch the same number of hooks.
 '''
@@ -30,16 +31,17 @@ server = Test.MakeOriginServer("server")
 Test.testName = ""
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: double_h2.test\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 # expected response from the origin server
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length:0\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length:0\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
 # add response to the server dictionary
 server.addResponse("sessionfile.log", request_header, response_header)
 
 # add port and remap rule
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
@@ -47,8 +49,7 @@ ts.Disk.records_config.update({
 })
 
 # add plugin to assist with test metrics
-Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir,
-                                    'continuations_verify.so'), ts)
+Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'continuations_verify.so'), ts)
 
 comparator_command = '''
 if test "`traffic_ctl metric get continuations_verify.{0}.close.1 | cut -d ' ' -f 2`" -eq "`traffic_ctl metric get continuations_verify.{0}.close.2 | cut -d ' ' -f 2`" ; then\
@@ -72,8 +73,7 @@ tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = Any(0, 2)
 
 # Execution order is: ts/server, ps(curl cmds), Default Process.
-tr.Processes.Default.StartBefore(
-    server, ready=When.PortOpen(server.Variables.Port))
+tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 ts.StartAfter(*ps)
 server.StartAfter(*ps)
@@ -93,8 +93,7 @@ tr.Processes.Default.Command = (
     "let N=N-1 ; "
     "done ; "
     "echo TIMEOUT ; "
-    "exit 1"
-)
+    "exit 1")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Env = ts.Env
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/dns/dns_down_nameserver.test.py
+++ b/tests/gold_tests/dns/dns_down_nameserver.test.py
@@ -19,7 +19,6 @@ Verify ATS handles down name servers correctly.
 
 from ports import get_port
 
-
 # This value tracks DNS_PRIMARY_RETRY_PERIOD in P_DNSProcessor.h.
 DNS_PRIMARY_RETRY_PERIOD = 5
 
@@ -67,19 +66,21 @@ class DownDNSNameserverTest:
         # the responses come out of the cache without going to the origin.
         self._ts = Test.MakeATSProcess("ts", enable_cache=False)
 
-        self._ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'hostdb|dns',
-            'proxy.config.dns.nameservers': f'127.0.0.1:{self._dns_port}',
-            'proxy.config.dns.resolv_conf': 'NULL'
-        })
+        self._ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'hostdb|dns',
+                'proxy.config.dns.nameservers': f'127.0.0.1:{self._dns_port}',
+                'proxy.config.dns.resolv_conf': 'NULL'
+            })
 
         # Cause a name resolution for each, unique path.
-        self._ts.Disk.remap_config.AddLines([
-            f'map /first/host http://first.host.com:{self._server.Variables.http_port}/',
-            f'map /second/host http://second.host.com:{self._server.Variables.http_port}/',
-            f'map /third/host http://third.host.com:{self._server.Variables.http_port}/',
-        ])
+        self._ts.Disk.remap_config.AddLines(
+            [
+                f'map /first/host http://first.host.com:{self._server.Variables.http_port}/',
+                f'map /second/host http://second.host.com:{self._server.Variables.http_port}/',
+                f'map /third/host http://third.host.com:{self._server.Variables.http_port}/',
+            ])
 
     def _run_transaction(self, start_dns: bool, keyname: str):
         """Run a transaction with the name server reachable.
@@ -99,10 +100,7 @@ class DownDNSNameserverTest:
         self._client_counter += 1
 
         if start_dns:
-            dns = tr.MakeDNServer(
-                f'dns{self._dns_counter}',
-                default='127.0.0.1',
-                port=self._dns_port)
+            dns = tr.MakeDNServer(f'dns{self._dns_counter}', default='127.0.0.1', port=self._dns_port)
             self._dns_counter += 1
             tr.Processes.Default.StartBefore(dns)
 
@@ -113,8 +111,7 @@ class DownDNSNameserverTest:
 
         # Verify that the client tried to send the transaction.
         tr.Processes.Default.Streams.All += Testers.ContainsExpression(
-            f'uuid: {keyname}',
-            f'The client should have sent a transaction with uuid {keyname}')
+            f'uuid: {keyname}', f'The client should have sent a transaction with uuid {keyname}')
 
         # The client will report an error if ATS could not complete the
         # transaction due to DNS resolution issues.
@@ -126,10 +123,7 @@ class DownDNSNameserverTest:
         tr = Test.AddTestRun()
 
         if start_dns:
-            dns = tr.MakeDNServer(
-                f'dns{self._dns_counter}',
-                default='127.0.0.1',
-                port=self._dns_port)
+            dns = tr.MakeDNServer(f'dns{self._dns_counter}', default='127.0.0.1', port=self._dns_port)
             self._dns_counter += 1
             tr.Processes.Default.StartBefore(dns)
 

--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -41,25 +41,24 @@ class DownCachedOriginServerTest:
         """Configure Traffic Server."""
         self._ts = Test.MakeATSProcess("ts", enable_cache=False)
 
-        self._ts.Disk.remap_config.AddLine(
-            f"map / http://resolve.this.com:{self._server.Variables.http_port}/"
-        )
+        self._ts.Disk.remap_config.AddLine(f"map / http://resolve.this.com:{self._server.Variables.http_port}/")
 
-        self._ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'hostdb|dns|http|socket',
-            'proxy.config.http.connect_attempts_max_retries': 0,
-            'proxy.config.http.connect_attempts_rr_retries': 0,
-            'proxy.config.hostdb.fail.timeout': 10,
-            'proxy.config.dns.resolv_conf': 'NULL',
-            'proxy.config.hostdb.ttl_mode': 1,
-            'proxy.config.hostdb.timeout': 2,
-            'proxy.config.hostdb.lookup_timeout': 2,
-            'proxy.config.http.transaction_no_activity_timeout_in': 2,
-            'proxy.config.http.connect_attempts_timeout': 2,
-            'proxy.config.hostdb.host_file.interval': 1,
-            'proxy.config.hostdb.host_file.path': os.path.join(Test.TestDirectory, "hosts_file"),
-        })
+        self._ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'hostdb|dns|http|socket',
+                'proxy.config.http.connect_attempts_max_retries': 0,
+                'proxy.config.http.connect_attempts_rr_retries': 0,
+                'proxy.config.hostdb.fail.timeout': 10,
+                'proxy.config.dns.resolv_conf': 'NULL',
+                'proxy.config.hostdb.ttl_mode': 1,
+                'proxy.config.hostdb.timeout': 2,
+                'proxy.config.hostdb.lookup_timeout': 2,
+                'proxy.config.http.transaction_no_activity_timeout_in': 2,
+                'proxy.config.http.connect_attempts_timeout': 2,
+                'proxy.config.hostdb.host_file.interval': 1,
+                'proxy.config.hostdb.host_file.path': os.path.join(Test.TestDirectory, "hosts_file"),
+            })
 
     # Even when the origin server is down, SM will return a hit-fresh domain from HostDB.
     # After request has failed, SM should mark the IP as down
@@ -70,10 +69,7 @@ class DownCachedOriginServerTest:
         tr.Processes.Default.StartBefore(self._ts)
 
         tr.AddVerifierClientProcess(
-            "client-1",
-            DownCachedOriginServerTest.replay_file,
-            http_ports=[self._ts.Variables.port],
-            other_args='--keys 1')
+            "client-1", DownCachedOriginServerTest.replay_file, http_ports=[self._ts.Variables.port], other_args='--keys 1')
 
     # After host has been marked down from previous test, HostDB should not return
     # the host as available and DNS lookup should fail.
@@ -81,18 +77,14 @@ class DownCachedOriginServerTest:
         tr = Test.AddTestRun()
 
         tr.AddVerifierClientProcess(
-            "client-2",
-            DownCachedOriginServerTest.replay_file,
-            http_ports=[self._ts.Variables.port],
-            other_args='--keys 2')
+            "client-2", DownCachedOriginServerTest.replay_file, http_ports=[self._ts.Variables.port], other_args='--keys 2')
 
     # Verify error log marking host down exists
     def _test_error_log(self):
         tr = Test.AddTestRun()
         tr.Processes.Default.Command = (
             os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-            os.path.join(self._ts.Variables.LOGDIR, 'error.log')
-        )
+            os.path.join(self._ts.Variables.LOGDIR, 'error.log'))
 
         self._ts.Disk.error_log.Content = Testers.ContainsExpression("/dns/mark/down' marking down", "host should be marked down")
         self._ts.Disk.error_log.Content = Testers.ContainsExpression(

--- a/tests/gold_tests/dns/splitdns.test.py
+++ b/tests/gold_tests/dns/splitdns.test.py
@@ -20,6 +20,7 @@ Test.Summary = 'Test Split DNS'
 
 
 class SplitDNSTest:
+
     def __init__(self):
         self.setupDNSServer()
         self.setupOriginServer()
@@ -31,24 +32,21 @@ class SplitDNSTest:
 
     def setupOriginServer(self):
         self.origin_server = Test.MakeOriginServer("origin_server")
-        self.origin_server.addResponse("sessionlog.json",
-                                       {"headers": "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"},
-                                       {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\n\r\n"})
+        self.origin_server.addResponse(
+            "sessionlog.json", {"headers": "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"},
+            {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\n\r\n"})
 
     def setupTS(self):
-        self.ts = Test.MakeATSProcess(
-            "ts", select_ports=True, enable_cache=False)
-        self.ts.Disk.records_config.update({
-            "proxy.config.dns.splitDNS.enabled": 1,
-            "proxy.config.diags.debug.enabled": 1,
-            "proxy.config.diags.debug.tags": "dns|splitdns",
-        })
-        self.ts.Disk.splitdns_config.AddLine(
-            f"dest_domain=foo.ts.a.o named=127.0.0.1:{self.dns.Variables.Port}")
-        self.ts.Disk.remap_config.AddLine(
-            f"map /foo/ http://foo.ts.a.o:{self.origin_server.Variables.Port}/")
-        self.ts.Disk.remap_config.AddLine(
-            f"map /bar/ http://127.0.0.1:{self.origin_server.Variables.Port}/")
+        self.ts = Test.MakeATSProcess("ts", select_ports=True, enable_cache=False)
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.dns.splitDNS.enabled": 1,
+                "proxy.config.diags.debug.enabled": 1,
+                "proxy.config.diags.debug.tags": "dns|splitdns",
+            })
+        self.ts.Disk.splitdns_config.AddLine(f"dest_domain=foo.ts.a.o named=127.0.0.1:{self.dns.Variables.Port}")
+        self.ts.Disk.remap_config.AddLine(f"map /foo/ http://foo.ts.a.o:{self.origin_server.Variables.Port}/")
+        self.ts.Disk.remap_config.AddLine(f"map /bar/ http://127.0.0.1:{self.origin_server.Variables.Port}/")
 
     def addTestCase0(self):
         tr = Test.AddTestRun()

--- a/tests/gold_tests/forward_proxy/forward_proxy.test.py
+++ b/tests/gold_tests/forward_proxy/forward_proxy.test.py
@@ -47,12 +47,10 @@ class ForwardProxyTest:
         ForwardProxyTest._server_counter += 1
         if self._scheme_proto_mismatch_policy in (2, None):
             self.server.Streams.All = Testers.ExcludesExpression(
-                'Received an HTTP/1 request with key 1',
-                'Verify that the server did not receive the request.')
+                'Received an HTTP/1 request with key 1', 'Verify that the server did not receive the request.')
         else:
             self.server.Streams.All = Testers.ContainsExpression(
-                'Received an HTTP/1 request with key 1',
-                'Verify that the server received the request.')
+                'Received an HTTP/1 request with key 1', 'Verify that the server received the request.')
 
     def setupTS(self):
         """Configure the Traffic Server process."""
@@ -61,22 +59,22 @@ class ForwardProxyTest:
         ForwardProxyTest._ts_counter += 1
         self.ts.addDefaultSSLFiles()
         self.ts.Disk.ssl_multicert_config.AddLine("dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key")
-        self.ts.Disk.remap_config.AddLine(
-            f"map / http://127.0.0.1:{self.server.Variables.http_port}/")
+        self.ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{self.server.Variables.http_port}/")
 
-        self.ts.Disk.records_config.update({
-            'proxy.config.ssl.server.cert.path': self.ts.Variables.SSLDir,
-            'proxy.config.ssl.server.private_key.path': self.ts.Variables.SSLDir,
-            'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': "http",
-        })
+        self.ts.Disk.records_config.update(
+            {
+                'proxy.config.ssl.server.cert.path': self.ts.Variables.SSLDir,
+                'proxy.config.ssl.server.private_key.path': self.ts.Variables.SSLDir,
+                'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': "http",
+            })
 
         if self._scheme_proto_mismatch_policy is not None:
-            self.ts.Disk.records_config.update({
-                'proxy.config.ssl.client.scheme_proto_mismatch_policy': self._scheme_proto_mismatch_policy,
-            })
+            self.ts.Disk.records_config.update(
+                {
+                    'proxy.config.ssl.client.scheme_proto_mismatch_policy': self._scheme_proto_mismatch_policy,
+                })
 
     def addProxyHttpsToHttpCase(self):
         """Test ATS as an HTTPS forward proxy behind an HTTP server."""
@@ -93,12 +91,10 @@ class ForwardProxyTest:
 
         if self._scheme_proto_mismatch_policy in (2, None):
             tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-                '< HTTP/1.1 400 Invalid HTTP Request',
-                'Verify that the request was rejected.')
+                '< HTTP/1.1 400 Invalid HTTP Request', 'Verify that the request was rejected.')
         else:
             tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-                '< HTTP/1.1 200 OK',
-                'Verify that curl received a 200 OK response.')
+                '< HTTP/1.1 200 OK', 'Verify that curl received a 200 OK response.')
 
     def run(self):
         """Configure the TestRun instances for this set of tests."""

--- a/tests/gold_tests/h2/h2active_timeout.py
+++ b/tests/gold_tests/h2/h2active_timeout.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 '''
 An h2 client built to trigger active timeout.
 '''
@@ -132,14 +131,9 @@ def makerequest(port: int, path: str, delay: int) -> None:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("port",
-                        type=int,
-                        help="Port to use")
-    parser.add_argument("path",
-                        help="The path to request")
-    parser.add_argument("delay",
-                        type=int,
-                        help="The number of seconds to delay betwen requests in a stream")
+    parser.add_argument("port", type=int, help="Port to use")
+    parser.add_argument("path", help="The path to request")
+    parser.add_argument("delay", type=int, help="The number of seconds to delay betwen requests in a stream")
     args = parser.parse_args()
 
     makerequest(args.port, args.path, args.delay)

--- a/tests/gold_tests/h2/h2client.py
+++ b/tests/gold_tests/h2/h2client.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 '''
 A basic, ad-hoc HTTP/2 client.
 '''
@@ -140,21 +139,11 @@ def makerequest(port: int, path: str, verify_default_body: bool, print_body: boo
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("port",
-                        type=int,
-                        help="Port to use")
-    parser.add_argument("path",
-                        help="The path to request")
-    parser.add_argument("--repeat",
-                        type=int,
-                        default=1,
-                        help="Number of times to repeat the request")
-    parser.add_argument("--verify_default_body",
-                        action="store_true",
-                        help="Verify the default body content: abbb...")
-    parser.add_argument("--print_body",
-                        action="store_true",
-                        help="Print the response body")
+    parser.add_argument("port", type=int, help="Port to use")
+    parser.add_argument("path", help="The path to request")
+    parser.add_argument("--repeat", type=int, default=1, help="Number of times to repeat the request")
+    parser.add_argument("--verify_default_body", action="store_true", help="Verify the default body content: abbb...")
+    parser.add_argument("--print_body", action="store_true", help="Print the response body")
     args = parser.parse_args()
 
     for i in range(args.repeat):

--- a/tests/gold_tests/h2/h2disable.test.py
+++ b/tests/gold_tests/h2/h2disable.test.py
@@ -20,9 +20,7 @@ Test.Summary = '''
 Test disabling H2 on a per domain basis
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
@@ -35,23 +33,21 @@ server.addResponse("sessionlog.json", request_header, response_header)
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.accept_threads': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http|ssl',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.accept_threads': 1
+    })
 
 ts.Disk.sni_yaml.AddLines([
     'sni:',

--- a/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
@@ -20,9 +20,7 @@ Test.Summary = '''
 Test disabling H2 on a per domain basis
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
@@ -35,23 +33,21 @@ server.addResponse("sessionlog.json", request_header, response_header)
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.accept_threads': 0
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http|ssl',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.accept_threads': 0
+    })
 
 ts.Disk.sni_yaml.AddLines([
     'sni:',

--- a/tests/gold_tests/h2/h2enable.test.py
+++ b/tests/gold_tests/h2/h2enable.test.py
@@ -20,9 +20,7 @@ Test.Summary = '''
 Test enabling H2 on a per domain basis
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)
@@ -35,23 +33,21 @@ server.addResponse("sessionlog.json", request_header, response_header)
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Set up port 4444 with HTTP1 only, no HTTP/2
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.http.server_ports': '{0}:ssl:proto=http {1}'.format(ts.Variables.ssl_port, ts.Variables.port)
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http|ssl',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.http.server_ports': '{0}:ssl:proto=http {1}'.format(ts.Variables.ssl_port, ts.Variables.port)
+    })
 
 ts.Disk.sni_yaml.AddLines([
     'sni:',

--- a/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
@@ -20,9 +20,7 @@ Test.Summary = '''
 Test enabling H2 on a per domain basis
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)
@@ -35,23 +33,21 @@ server.addResponse("sessionlog.json", request_header, response_header)
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Set up port 4444 with HTTP1 only, no HTTP/2
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.http.server_ports': '{0}:ssl:proto=http {1}'.format(ts.Variables.ssl_port, ts.Variables.port),
-    'proxy.config.accept_threads': 0
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http|ssl',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.http.server_ports': '{0}:ssl:proto=http {1}'.format(ts.Variables.ssl_port, ts.Variables.port),
+        'proxy.config.accept_threads': 0
+    })
 
 ts.Disk.sni_yaml.AddLines([
     'sni:',

--- a/tests/gold_tests/h2/h2spec.test.py
+++ b/tests/gold_tests/h2/h2spec.test.py
@@ -21,9 +21,7 @@ Test.Summary = '''
 Test HTTP/2 with httpspec
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("h2spec", "h2spec need to be installed on system for this test to work"),
-)
+Test.SkipUnless(Condition.HasProgram("h2spec", "h2spec need to be installed on system for this test to work"),)
 Test.ContinueOnFail = True
 
 # ----
@@ -39,20 +37,17 @@ ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(httpbin.Variables.Port)
-)
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({
-    'proxy.config.http.insert_request_via_str': 1,
-    'proxy.config.http.insert_response_via_str': 1,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http',
-})
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(httpbin.Variables.Port))
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.http.insert_request_via_str': 1,
+        'proxy.config.http.insert_response_via_str': 1,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http',
+    })
 
 # ----
 # Test Cases

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -23,9 +23,7 @@ Test.Summary = '''
 Test a basic remap of a http/2 connection
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 Test.ContinueOnFail = True
 
 # ----
@@ -34,75 +32,97 @@ Test.ContinueOnFail = True
 server = Test.MakeOriginServer("server")
 
 # For Test Case 1 & 5 - /
-server.addResponse("sessionlog.json",
-                   {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": ""})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    })
 
 # For Test Case 2 - /bigfile
 # Add info for the large H2 download test
-server.addResponse("sessionlog.json",
-                   {"headers": "GET /bigfile HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 191414\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": ""})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "GET /bigfile HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers":
+            "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 191414\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    })
 
 # For Test Case 3 - /test2
-server.addResponse("sessionlog.json",
-                   {"headers": "GET /test2 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": ""})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "GET /test2 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    })
 
 # For Test Case 6 - /postchunked
 post_body = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
-server.addResponse("sessionlog.json",
-                   {"headers": "POST /postchunked HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": post_body},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nContent-Length: 10\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "0123456789"})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "POST /postchunked HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": post_body
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nContent-Length: 10\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "0123456789"
+    })
 
 # For Test Case 7 - /bigpostchunked
 # Make a post body that will be split across at least two frames
 big_post_body = "0123456789" * 131070
-server.addResponse("sessionlog.json",
-                   {"headers": "POST /bigpostchunked HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": big_post_body},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nContent-Length: 10\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "0123456789"})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "POST /bigpostchunked HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": big_post_body
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nContent-Length: 10\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "0123456789"
+    })
 
 big_post_body_file = open(os.path.join(Test.RunDirectory, "big_post_body"), "w")
 big_post_body_file.write(big_post_body)
 big_post_body_file.close()
 
 # For Test Case 8 - /huge_resp_hdrs
-server.addResponse("sessionlog.json",
-                   {"headers": "GET /huge_resp_hdrs HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nContent-Length: 6\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "200 OK"})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "GET /huge_resp_hdrs HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nContent-Length: 6\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "200 OK"
+    })
 
 # For Test Case 9 - /status/204
-server.addResponse("sessionlog.json",
-                   {"headers": "GET /status/204 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""},
-                   {"headers": "HTTP/1.1 204 No Content\r\nServer: microserver\r\nConnection: close\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": ""})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "GET /status/204 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 204 No Content\r\nServer: microserver\r\nConnection: close\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    })
 
 # ----
 # Setup ATS
@@ -115,24 +135,20 @@ ts.addDefaultSSLFiles()
 ts.Setup.CopyAs('rules/huge_resp_hdrs.conf', Test.RunDirectory)
 ts.Disk.remap_config.AddLine(
     'map /huge_resp_hdrs http://127.0.0.1:{0}/huge_resp_hdrs @plugin=header_rewrite.so @pparam={1}/huge_resp_hdrs.conf '.format(
-        server.Variables.Port, Test.RunDirectory)
-)
+        server.Variables.Port, Test.RunDirectory))
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http2.active_timeout_in': 3,
-    'proxy.config.http2.max_concurrent_streams_in': 65535,
-})
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.http2.active_timeout_in': 3,
+        'proxy.config.http2.max_concurrent_streams_in': 65535,
+    })
 
 ts.Setup.CopyAs('h2client.py', Test.RunDirectory)
 ts.Setup.CopyAs('h2active_timeout.py', Test.RunDirectory)

--- a/tests/gold_tests/h2/http2_flow_control.test.py
+++ b/tests/gold_tests/h2/http2_flow_control.test.py
@@ -20,7 +20,6 @@ import os
 import re
 from typing import List, Optional
 
-
 Test.Summary = __doc__
 
 
@@ -65,13 +64,11 @@ class Http2FlowControlTest:
 
         self._initial_window_size = initial_window_size
         self._expected_initial_window_size = (
-            initial_window_size if initial_window_size is not None
-            else self._default_initial_window_size)
+            initial_window_size if initial_window_size is not None else self._default_initial_window_size)
 
         self._max_concurrent_streams_in = max_concurrent_streams_in
         self._expected_max_concurrent_streams_in = (
-            max_concurrent_streams_in if max_concurrent_streams_in is not None
-            else self._default_max_concurrent_streams_in)
+            max_concurrent_streams_in if max_concurrent_streams_in is not None else self._default_max_concurrent_streams_in)
 
         self._verify_window_update_frames = verify_window_update_frames
 
@@ -87,30 +84,25 @@ class Http2FlowControlTest:
 
     def _configure_server(self):
         """Configure the test server."""
-        server = Test.MakeVerifierServerProcess(
-            f'server-{Http2FlowControlTest._server_counter}',
-            self._replay_file)
+        server = Test.MakeVerifierServerProcess(f'server-{Http2FlowControlTest._server_counter}', self._replay_file)
         Http2FlowControlTest._server_counter += 1
         return server
 
     def _configure_trafficserver(self):
         """Configure a Traffic Server process."""
-        ts = Test.MakeATSProcess(
-            f'ts-{Http2FlowControlTest._ts_counter}',
-            enable_tls=True,
-            enable_cache=False)
+        ts = Test.MakeATSProcess(f'ts-{Http2FlowControlTest._ts_counter}', enable_tls=True, enable_cache=False)
         Http2FlowControlTest._ts_counter += 1
 
         ts.addDefaultSSLFiles()
-        ts.Disk.records_config.update({
-            'proxy.config.ssl.server.cert.path': f'{ts.Variables.SSLDir}',
-            'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
-            'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-            'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(self._dns.Variables.Port),
-
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http',
-        })
+        ts.Disk.records_config.update(
+            {
+                'proxy.config.ssl.server.cert.path': f'{ts.Variables.SSLDir}',
+                'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
+                'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+                'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(self._dns.Variables.Port),
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http',
+            })
 
         if self._initial_window_size is not None:
             ts.Disk.records_config.update({
@@ -122,13 +114,9 @@ class Http2FlowControlTest:
                 'proxy.config.http2.max_concurrent_streams_in': self._max_concurrent_streams_in,
             })
 
-        ts.Disk.ssl_multicert_config.AddLine(
-            'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-        )
+        ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-        ts.Disk.remap_config.AddLine(
-            f'map / http://127.0.0.1:{self._server.Variables.http_port}'
-        )
+        ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{self._server.Variables.http_port}')
 
         return ts
 
@@ -138,9 +126,7 @@ class Http2FlowControlTest:
         :param tr: The TestRun to associate the client with.
         """
         tr.AddVerifierClientProcess(
-            f'client-{Http2FlowControlTest._client_counter}',
-            self._replay_file,
-            https_ports=[self._ts.Variables.ssl_port])
+            f'client-{Http2FlowControlTest._client_counter}', self._replay_file, https_ports=[self._ts.Variables.ssl_port])
         Http2FlowControlTest._client_counter += 1
 
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
@@ -154,20 +140,16 @@ class Http2FlowControlTest:
 
         if self._verify_window_update_frames:
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 0: {self._expected_initial_window_size}',
-                "Client should receive a session WINDOW_UPDATE.")
+                f'WINDOW_UPDATE.*id 0: {self._expected_initial_window_size}', "Client should receive a session WINDOW_UPDATE.")
 
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 3: {self._expected_initial_window_size}',
-                "Client should receive a stream WINDOW_UPDATE.")
+                f'WINDOW_UPDATE.*id 3: {self._expected_initial_window_size}', "Client should receive a stream WINDOW_UPDATE.")
 
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 5: {self._expected_initial_window_size}',
-                "Client should receive a stream WINDOW_UPDATE.")
+                f'WINDOW_UPDATE.*id 5: {self._expected_initial_window_size}', "Client should receive a stream WINDOW_UPDATE.")
 
             tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-                f'WINDOW_UPDATE.*id 7: {self._expected_initial_window_size}',
-                "Client should receive a stream WINDOW_UPDATE.")
+                f'WINDOW_UPDATE.*id 7: {self._expected_initial_window_size}', "Client should receive a stream WINDOW_UPDATE.")
 
     def run(self):
         """Configure the TestRun."""
@@ -188,19 +170,14 @@ test.run()
 #
 # Configuring max_concurrent_streams_in.
 #
-test = Http2FlowControlTest(
-    description="Configure max_concurrent_streams_in",
-    max_concurrent_streams_in=53)
+test = Http2FlowControlTest(description="Configure max_concurrent_streams_in", max_concurrent_streams_in=53)
 test.run()
 
 #
 # Configuring initial_window_size.
 #
-test = Http2FlowControlTest(
-    description="Configure a large initial_window_size_in",
-    initial_window_size=100123)
+test = Http2FlowControlTest(description="Configure a large initial_window_size_in", initial_window_size=100123)
 test.run()
-
 
 test = Http2FlowControlTest(
     description="Configure a small initial_window_size_in",

--- a/tests/gold_tests/h2/http2_priority.test.py
+++ b/tests/gold_tests/h2/http2_priority.test.py
@@ -32,13 +32,17 @@ Test.ContinueOnFail = True
 server = Test.MakeOriginServer("server")
 
 # Test Case 0:
-server.addResponse("sessionlog.json",
-                   {"headers": "GET /bigfile HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 1048576\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": ""})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "GET /bigfile HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers":
+            "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 1048576\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    })
 
 # ----
 # Setup ATS
@@ -47,20 +51,17 @@ ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_cache=
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({
-    'proxy.config.http2.stream_priority_enabled': 1,
-    'proxy.config.http2.no_activity_timeout_in': 3,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http2',
-})
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.http2.stream_priority_enabled': 1,
+        'proxy.config.http2.no_activity_timeout_in': 3,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http2',
+    })
 
 # ----
 # Test Cases

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -45,21 +45,17 @@ ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_cache=
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(httpbin.Variables.Port)
-)
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({
-    'proxy.config.http.insert_request_via_str': 1,
-    'proxy.config.http.insert_response_via_str': 1,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http2',
-
-})
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(httpbin.Variables.Port))
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.http.insert_request_via_str': 1,
+        'proxy.config.http.insert_response_via_str': 1,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http2',
+    })
 ts.Disk.logging_yaml.AddLines(
     '''
 logging:
@@ -70,8 +66,7 @@ logging:
   logs:
     - filename: access
       format: access
-'''.split("\n")
-)
+'''.split("\n"))
 
 Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'access.log'), exists=True, content='gold/httpbin_access.gold')
 
@@ -129,7 +124,5 @@ test_run.StillRunningAfter = httpbin
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = (
-    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'access.log')
-)
+    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + os.path.join(ts.Variables.LOGDIR, 'access.log'))
 test_run.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/h2/nghttp.test.py
+++ b/tests/gold_tests/h2/nghttp.test.py
@@ -17,13 +17,12 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 Test with nghttp
 '''
 
-Test.SkipUnless(
-    Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
-)
+Test.SkipUnless(Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),)
 Test.ContinueOnFail = True
 
 # ----
@@ -40,29 +39,28 @@ post_body_file.close()
 # ----
 # Setup ATS
 # ----
-ts = Test.MakeATSProcess("ts", select_ports=True,
-                         enable_tls=True, enable_cache=False)
+ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_cache=False)
 
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
 ts.Setup.CopyAs('rules/graceful_shutdown.conf', Test.RunDirectory)
 
-ts.Disk.remap_config.AddLines([
-    'map /httpbin/ http://127.0.0.1:{0}/ @plugin=header_rewrite.so @pparam={1}/graceful_shutdown.conf'.format(
-        httpbin.Variables.Port, Test.RunDirectory)
-])
+ts.Disk.remap_config.AddLines(
+    [
+        'map /httpbin/ http://127.0.0.1:{0}/ @plugin=header_rewrite.so @pparam={1}/graceful_shutdown.conf'.format(
+            httpbin.Variables.Port, Test.RunDirectory)
+    ])
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http2_cs',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir)
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http2_cs',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir)
+    })
 
 # ----
 # Test Cases

--- a/tests/gold_tests/headers/accept_webp.test.py
+++ b/tests/gold_tests/headers/accept_webp.test.py
@@ -29,28 +29,30 @@ server = Test.MakeOriginServer("server")
 
 testName = "accept_webp"
 request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\nAccept: image/webp,image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5\r\n\r\n",
+    "headers":
+        "GET / HTTP/1.1\r\nHost: www.example.com\r\nAccept: image/webp,image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": ""}
+    "body": ""
+}
 response_header = {
     "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: image/webp\r\nCache-Control: max-age=300\r\n",
     "timestamp": "1469733493.993",
-    "body": "xxx"}
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 # ATS Configuration
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http_match',
-    'proxy.config.http.cache.ignore_accept_mismatch': 0,
-    'proxy.config.http.insert_response_via_str': 3,
-    'proxy.config.http.cache.http': 1,
-    'proxy.config.http.wait_for_cache': 1,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http_match',
+        'proxy.config.http.cache.ignore_accept_mismatch': 0,
+        'proxy.config.http.insert_response_via_str': 3,
+        'proxy.config.http.cache.http': 1,
+        'proxy.config.http.wait_for_cache': 1,
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Test 1 - Request with image/webp support from the origin
 tr = Test.AddTestRun()

--- a/tests/gold_tests/headers/cache_and_req_body.test.py
+++ b/tests/gold_tests/headers/cache_and_req_body.test.py
@@ -31,58 +31,91 @@ server = Test.MakeOriginServer("server")
 testName = ""
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nLast-Modified: Tue, 08 May 2018 15:49:41 GMT\r\nCache-Control: max-age=1\r\n\r\n",
+    "headers":
+        "HTTP/1.1 200 OK\r\nConnection: close\r\nLast-Modified: Tue, 08 May 2018 15:49:41 GMT\r\nCache-Control: max-age=1\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": "xxx"}
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 # ATS Configuration
 ts.Disk.plugin_config.AddLine('xdebug.so')
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.response_via_str': 3,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.response_via_str': 3,
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 cache_and_req_body_miss = {
     'Connection': 'keep-alive',
-    'Via': {'equal_re': None},
-    'Server': {'equal_re': '.*'},
-    'X-Cache-Key': {'equal_re': 'http://127.0.0.1.*'},
+    'Via': {
+        'equal_re': None
+    },
+    'Server': {
+        'equal_re': '.*'
+    },
+    'X-Cache-Key': {
+        'equal_re': 'http://127.0.0.1.*'
+    },
     'X-Cache': 'miss',
-    'Last-Modified': {'equal_re': '.*'},
+    'Last-Modified': {
+        'equal_re': '.*'
+    },
     'cache-control': 'max-age=1',
     'Content-Length': '3',
-    'Date': {'equal_re': '.*'},
-    'Age': {'equal_re': '.*'}
+    'Date': {
+        'equal_re': '.*'
+    },
+    'Age': {
+        'equal_re': '.*'
+    }
 }
 
 cache_and_req_body_hit = {
-    'Last-Modified': {'equal_re': '.*'},
+    'Last-Modified': {
+        'equal_re': '.*'
+    },
     'cache-control': 'max-age=1',
     'Content-Length': '3',
-    'Date': {'equal_re': '.*'},
-    'Age': {'equal_re': '.*'},
+    'Date': {
+        'equal_re': '.*'
+    },
+    'Age': {
+        'equal_re': '.*'
+    },
     'Connection': 'keep-alive',
-    'Via': {'equal_re': '.*'},
-    'Server': {'equal_re': '.*'},
+    'Via': {
+        'equal_re': '.*'
+    },
+    'Server': {
+        'equal_re': '.*'
+    },
     'X-Cache': 'hit-fresh',
     'HTTP/1.1 200 OK': ''
 }
 
 cache_and_req_body_hit_close = {
-    'Last-Modified': {'equal_re': '.*'},
+    'Last-Modified': {
+        'equal_re': '.*'
+    },
     'cache-control': 'max-age=1',
     'Content-Length': '3',
-    'Date': {'equal_re': '.*'},
-    'Age': {'equal_re': '.*'},
+    'Date': {
+        'equal_re': '.*'
+    },
+    'Age': {
+        'equal_re': '.*'
+    },
     'Connection': 'close',
-    'Via': {'equal_re': '.*'},
-    'Server': {'equal_re': '.*'},
+    'Via': {
+        'equal_re': '.*'
+    },
+    'Server': {
+        'equal_re': '.*'
+    },
     'X-Cache': 'hit-fresh',
     'HTTP/1.1 200 OK': ''
 }

--- a/tests/gold_tests/headers/cachedIMSRange.test.py
+++ b/tests/gold_tests/headers/cachedIMSRange.test.py
@@ -29,87 +29,108 @@ Test.ContinueOnFail = True
 # lookup_key is to make unique response in origin for header "UID" that will pass in ATS request
 server = Test.MakeOriginServer("server", lookup_key="{%UID}")
 # Initial request
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\nUID: Fill\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
-response_header = {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nLast-Modified: Tue, 08 May 2018 15:49:41 GMT\r\nCache-Control: max-age=1\r\n\r\n",
+request_header = {
+    "headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\nUID: Fill\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": "xxx"}
+    "body": ""
+}
+response_header = {
+    "headers":
+        "HTTP/1.1 200 OK\r\nConnection: close\r\nLast-Modified: Tue, 08 May 2018 15:49:41 GMT\r\nCache-Control: max-age=1\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 # IMS revalidation request
 request_IMS_header = {
     "headers": "GET / HTTP/1.1\r\nUID: IMS\r\nIf-Modified-Since: Tue, 08 May 2018 15:49:41 GMT\r\nHost: www.example.com\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": ""}
-response_IMS_header = {"headers": "HTTP/1.1 304 Not Modified\r\nConnection: close\r\nCache-Control: max-age=1\r\n\r\n",
-                       "timestamp": "1469733493.993", "body": None}
+    "body": ""
+}
+response_IMS_header = {
+    "headers": "HTTP/1.1 304 Not Modified\r\nConnection: close\r\nCache-Control: max-age=1\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": None
+}
 server.addResponse("sessionlog.json", request_IMS_header, response_IMS_header)
 
 # EtagFill
-request_etagfill_header = {"headers": "GET /etag HTTP/1.1\r\nHost: www.example.com\r\nUID: EtagFill\r\n\r\n",
-                           "timestamp": "1469733493.993", "body": None}
+request_etagfill_header = {
+    "headers": "GET /etag HTTP/1.1\r\nHost: www.example.com\r\nUID: EtagFill\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": None
+}
 response_etagfill_header = {
     "headers": "HTTP/1.1 200 OK\r\nETag: myetag\r\nConnection: close\r\nCache-Control: max-age=1\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": "xxx"}
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request_etagfill_header, response_etagfill_header)
 # INM revalidation
-request_INM_header = {"headers": "GET /etag HTTP/1.1\r\nUID: INM\r\nIf-None-Match: myetag\r\nHost: www.example.com\r\n\r\n",
-                      "timestamp": "1469733493.993", "body": None}
+request_INM_header = {
+    "headers": "GET /etag HTTP/1.1\r\nUID: INM\r\nIf-None-Match: myetag\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": None
+}
 response_INM_header = {
     "headers": "HTTP/1.1 304 Not Modified\r\nConnection: close\r\nETag: myetag\r\nCache-Control: max-age=1\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": None}
+    "body": None
+}
 server.addResponse("sessionlog.json", request_INM_header, response_INM_header)
 
 # object changed to 0 byte
-request_noBody_header = {"headers": "GET / HTTP/1.1\r\nUID: noBody\r\nHost: www.example.com\r\n\r\n",
-                         "timestamp": "1469733493.993", "body": ""}
+request_noBody_header = {
+    "headers": "GET / HTTP/1.1\r\nUID: noBody\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_noBody_header = {
     "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\nCache-Control: max-age=3\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": ""}
+    "body": ""
+}
 server.addResponse("sessionlog.json", request_noBody_header, response_noBody_header)
 
 # etag object now is a 404. Yeah, 404s don't usually have Cache-Control, but, ATS's default is to cache 404s for a while.
-request_etagfill_header = {"headers": "GET /etag HTTP/1.1\r\nHost: www.example.com\r\nUID: EtagError\r\n\r\n",
-                           "timestamp": "1469733493.993", "body": None}
+request_etagfill_header = {
+    "headers": "GET /etag HTTP/1.1\r\nHost: www.example.com\r\nUID: EtagError\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": None
+}
 response_etagfill_header = {
     "headers": "HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\nCache-Control: max-age=3\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": ""}
+    "body": ""
+}
 server.addResponse("sessionlog.json", request_etagfill_header, response_etagfill_header)
 
 # ATS Configuration
 ts = Test.MakeATSProcess("ts", enable_tls=True)
 ts.Disk.plugin_config.AddLine('xdebug.so')
 ts.addDefaultSSLFiles()
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.response_via_str': 3,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-})
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.response_via_str': 3,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
 default_304_host = 'www.default304.test'
 regex_remap_conf_file = "maps.reg"
-ts.Disk.remap_config.AddLines([
-    f'map https://{default_304_host}/ http://127.0.0.1:{server.Variables.Port}/ '
-    f'@plugin=regex_remap.so @pparam={regex_remap_conf_file} @pparam=no-query-string @pparam=host',
+ts.Disk.remap_config.AddLines(
+    [
+        f'map https://{default_304_host}/ http://127.0.0.1:{server.Variables.Port}/ '
+        f'@plugin=regex_remap.so @pparam={regex_remap_conf_file} @pparam=no-query-string @pparam=host',
+        f'map http://{default_304_host}/ http://127.0.0.1:{server.Variables.Port}/ '
+        f'@plugin=regex_remap.so @pparam={regex_remap_conf_file} @pparam=no-query-string @pparam=host',
+        f'map / http://127.0.0.1:{server.Variables.Port}',
+    ])
 
-    f'map http://{default_304_host}/ http://127.0.0.1:{server.Variables.Port}/ '
-    f'@plugin=regex_remap.so @pparam={regex_remap_conf_file} @pparam=no-query-string @pparam=host',
-
-    f'map / http://127.0.0.1:{server.Variables.Port}',
-])
-
-ts.Disk.MakeConfigFile(regex_remap_conf_file).AddLine(
-    f'//.*/ http://127.0.0.1:{server.Variables.Port} @status=304'
-)
+ts.Disk.MakeConfigFile(regex_remap_conf_file).AddLine(f'//.*/ http://127.0.0.1:{server.Variables.Port} @status=304')
 
 # Test 0 - Fill a 3 byte object with Last-Modified time into cache.
 tr = Test.AddTestRun()

--- a/tests/gold_tests/headers/domain-blacklist-30x.test.py
+++ b/tests/gold_tests/headers/domain-blacklist-30x.test.py
@@ -34,20 +34,21 @@ REDIRECT_308_HOST = 'www.redirect308.test'
 REDIRECT_0_HOST = 'www.redirect0.test'
 PASSTHRU_HOST = 'www.passthrough.test'
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'header_rewrite|dbg_header_rewrite',
-    'proxy.config.body_factory.enable_logging': 1,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'header_rewrite|dbg_header_rewrite',
+        'proxy.config.body_factory.enable_logging': 1,
+    })
 
-ts.Disk.remap_config.AddLine("""\
+ts.Disk.remap_config.AddLine(
+    """\
 regex_map http://{0}/ http://{0}/ @plugin=header_rewrite.so @pparam=header_rewrite_rules_301.conf
 regex_map http://{1}/ http://{1}/ @plugin=header_rewrite.so @pparam=header_rewrite_rules_302.conf
 regex_map http://{2}/ http://{2}/ @plugin=header_rewrite.so @pparam=header_rewrite_rules_307.conf
 regex_map http://{3}/ http://{3}/ @plugin=header_rewrite.so @pparam=header_rewrite_rules_308.conf
 regex_map http://{4}/ http://{4}/ @plugin=header_rewrite.so @pparam=header_rewrite_rules_0.conf
-""".format(REDIRECT_301_HOST, REDIRECT_302_HOST, REDIRECT_307_HOST, REDIRECT_308_HOST, REDIRECT_0_HOST)
-)
+""".format(REDIRECT_301_HOST, REDIRECT_302_HOST, REDIRECT_307_HOST, REDIRECT_308_HOST, REDIRECT_0_HOST))
 
 for x in (0, 301, 302, 307, 308):
     ts.Disk.MakeConfigFile("header_rewrite_rules_{0}.conf".format(x)).AddLine("""\
@@ -72,7 +73,6 @@ redirect302tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0
 redirect302tr.Processes.Default.TimeOut = 5  # seconds
 redirect302tr.Processes.Default.ReturnCode = 0
 redirect302tr.Processes.Default.Streams.stdout = "redirect302_get.gold"
-
 
 redirect307tr = Test.AddTestRun(f"Test domain {REDIRECT_307_HOST}")
 redirect302tr.StillRunningBefore = ts

--- a/tests/gold_tests/headers/field_name_space.test.py
+++ b/tests/gold_tests/headers/field_name_space.test.py
@@ -28,19 +28,15 @@ ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 
 testName = "field_name_space"
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-    "timestamp": "1469733493.993",
-    "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {
     "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nFoo : 123\r\nFoo: 456\r\n",
     "timestamp": "1469733493.993",
-    "body": "xxx"}
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Test spaces at the end of the field name and before the :
 tr = Test.AddTestRun()

--- a/tests/gold_tests/headers/forwarded.test.py
+++ b/tests/gold_tests/headers/forwarded.test.py
@@ -33,42 +33,50 @@ testName = "FORWARDED"
 
 server = Test.MakeOriginServer("server", options={'--load': os.path.join(Test.TestDirectory, 'forwarded-observer.py')})
 
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.no-oride.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.no-oride.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-none.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.forwarded-none.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.forwarded-for.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-ip.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-for.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-unknown.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-ip.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-server-name.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+server.addResponse("sessionlog.json", request_header, response_header)
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-uuid.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.forwarded-proto.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.forwarded-host.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-unknown.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-connection-compact.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-server-name.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-connection-std.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-by-uuid.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionlog.json", request_header, response_header)
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-proto.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionlog.json", request_header, response_header)
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-host.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionlog.json", request_header, response_header)
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-connection-compact.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionlog.json", request_header, response_header)
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-connection-std.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionlog.json", request_header, response_header)
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-connection-full.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+    "headers": "GET / HTTP/1.1\r\nHost: www.forwarded-connection-full.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 # Set up to check the output after the tests have run.
@@ -81,21 +89,18 @@ def baselineTsSetup(ts):
 
     ts.addDefaultSSLFiles()
 
-    ts.Disk.records_config.update({
-        # 'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.url_remap.pristine_host_hdr': 1,  # Retain Host header in original incoming client request.
-        'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
-        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir)
-    })
+    ts.Disk.records_config.update(
+        {
+            # 'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.url_remap.pristine_host_hdr': 1,  # Retain Host header in original incoming client request.
+            'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
+            'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+            'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir)
+        })
 
-    ts.Disk.ssl_multicert_config.AddLine(
-        'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-    )
+    ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-    ts.Disk.remap_config.AddLine(
-        'map http://www.no-oride.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-    )
+    ts.Disk.remap_config.AddLine('map http://www.no-oride.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 
 # Disable the cache to make sure each request is forwarded to the origin
@@ -106,48 +111,37 @@ baselineTsSetup(ts)
 
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-none.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=none'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=none')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-for.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=for'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=for')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-by-ip.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=ip'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=ip')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-by-unknown.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=unknown'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=unknown')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-by-server-name.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=serverName'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=serverName')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-by-uuid.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=uuid'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=by=uuid')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-proto.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=proto'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=proto')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-host.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=host'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=host')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-connection-compact.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=connection=compact'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=connection=compact')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-connection-std.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=connection=std'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=connection=std')
 ts.Disk.remap_config.AddLine(
     'map http://www.forwarded-connection-full.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=connection=full'
-)
+    ' @plugin=conf_remap.so @pparam=proxy.config.http.insert_forwarded=connection=full')
 
 # Basic HTTP 1.1 -- No Forwarded by default
 tr = Test.AddTestRun()
@@ -157,8 +151,7 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 #
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts.Variables.port)
-)
+    'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 
@@ -166,8 +159,7 @@ def TestHttp1_1(host):
 
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
-        'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://{}'.format(ts.Variables.port, host)
-    )
+        'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://{}'.format(ts.Variables.port, host))
     tr.Processes.Default.ReturnCode = 0
 
 
@@ -196,13 +188,13 @@ ts2 = Test.MakeATSProcess("ts2", command="traffic_manager", enable_tls=True)
 
 baselineTsSetup(ts2)
 
-ts2.Disk.records_config.update({
-    'proxy.config.url_remap.pristine_host_hdr': 1,  # Retain Host header in original incoming client request.
-    'proxy.config.http.insert_forwarded': 'by=uuid'})
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.url_remap.pristine_host_hdr': 1,  # Retain Host header in original incoming client request.
+        'proxy.config.http.insert_forwarded': 'by=uuid'
+    })
 
-ts2.Disk.remap_config.AddLine(
-    'map https://www.no-oride.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts2.Disk.remap_config.AddLine('map https://www.no-oride.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Forwarded header with UUID of 2nd ATS.
 tr = Test.AddTestRun()
@@ -210,16 +202,14 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(Test.Processes.ts2)
 #
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port)
-)
+    'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # Call traffic_ctrl to set insert_forwarded
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'traffic_ctl --debug config set proxy.config.http.insert_forwarded' +
-    ' "for|by=ip|by=unknown|by=servername|by=uuid|proto|host|connection=compact|connection=std|connection=full"'
-)
+    ' "for|by=ip|by=unknown|by=servername|by=uuid|proto|host|connection=compact|connection=std|connection=full"')
 tr.Processes.Default.ForceUseShell = False
 tr.Processes.Default.Env = ts2.Env
 tr.Processes.Default.ReturnCode = 0
@@ -229,52 +219,45 @@ tr = Test.AddTestRun()
 # Delay to give traffic_ctl config change time to take effect.
 tr.DelayStart = 15
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port)
-)
+    'curl --verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # HTTP 1.0
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http1.0 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port)
-)
+    'curl --verbose --ipv4 --http1.0 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # HTTP 1.0 -- Forwarded headers already present
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     "curl --verbose -H 'forwarded:for=0.6.6.6' -H 'forwarded:for=_argh' --ipv4 --http1.0" +
-    " --proxy localhost:{} http://www.no-oride.com".format(ts2.Variables.port)
-)
+    " --proxy localhost:{} http://www.no-oride.com".format(ts2.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # HTTP 2
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl --verbose --ipv4 --http2 --insecure --header "Host: www.no-oride.com"' +
-    ' https://localhost:{}'.format(ts2.Variables.ssl_port)
-)
+    ' https://localhost:{}'.format(ts2.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 
 # TLS
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --http1.1 --insecure --header "Host: www.no-oride.com" https://localhost:{}'
-    .format(ts2.Variables.ssl_port)
-)
+    'curl --verbose --ipv4 --http1.1 --insecure --header "Host: www.no-oride.com" https://localhost:{}'.format(
+        ts2.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 
 # IPv6
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    'curl --verbose --ipv6 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.portv6)
-)
+    'curl --verbose --ipv6 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.portv6))
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl --verbose --ipv6 --http1.1 --insecure --header "Host: www.no-oride.com" https://localhost:{}'.format(
-        ts2.Variables.ssl_portv6)
-)
+        ts2.Variables.ssl_portv6))
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/headers/general-connection-failure-502.test.py
+++ b/tests/gold_tests/headers/general-connection-failure-502.test.py
@@ -28,9 +28,7 @@ ts = Test.MakeATSProcess("ts")
 HOST = 'www.connectfail502.test'
 server = Test.MakeOriginServer("server", ssl=False)  # Reserves a port across autest.
 
-ts.Disk.remap_config.AddLine(
-    'map http://{host} http://{ip}:{uport}'.format(host=HOST, ip='127.0.0.1', uport=server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://{host} http://{ip}:{uport}'.format(host=HOST, ip='127.0.0.1', uport=server.Variables.Port))
 
 Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir, 'tcp_client.py'))
 

--- a/tests/gold_tests/headers/good_request_after_bad.test.py
+++ b/tests/gold_tests/headers/good_request_after_bad.test.py
@@ -25,39 +25,36 @@ Verify that request following a ill-formed request is not processed
 Test.ContinueOnFail = True
 ts = Test.MakeATSProcess("ts", enable_cache=True)
 Test.ContinueOnFail = True
-ts.Disk.records_config.update({'proxy.config.diags.debug.tags': 'http',
-                               'proxy.config.diags.debug.enabled': 0,
-                               'proxy.config.http.strict_uri_parsing': 1
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.http.strict_uri_parsing': 1
+    })
 
 ts2 = Test.MakeATSProcess("ts2", enable_cache=True)
 
-ts2.Disk.records_config.update({'proxy.config.diags.debug.tags': 'http',
-                                'proxy.config.diags.debug.enabled': 0,
-                                'proxy.config.http.strict_uri_parsing': 2
-                                })
-
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.http.strict_uri_parsing': 2
+    })
 
 server = Test.MakeOriginServer("server")
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nLast-Modified: Tue, 08 May 2018 15:49:41 GMT\r\nCache-Control: max-age=1000\r\n\r\n",
+    "headers":
+        "HTTP/1.1 200 OK\r\nConnection: close\r\nLast-Modified: Tue, 08 May 2018 15:49:41 GMT\r\nCache-Control: max-age=1000\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": "xxx"}
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    'map /bob<> http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts2.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts2.Disk.remap_config.AddLine(
-    'map /bob<> http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map /bob<> http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts2.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts2.Disk.remap_config.AddLine('map /bob<> http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 trace_out = Test.Disk.File("trace_curl.txt")
 
@@ -110,7 +107,6 @@ tr.Processes.Default.Command = 'printf "GET / HTTP/1.1\r\nhost: bob\r\ncontent-l
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = 'gold/bad_good_request_header.gold'
 
-
 # TRACE request with a body
 tr = Test.AddTestRun("Trace request with a body")
 tr.Processes.Default.Command = 'printf "TRACE /foo HTTP/1.1\r\nHost: bob\r\nContent-length:2\r\n\r\nokGET / HTTP/1.1\r\nHost: boa\r\n\r\n" | nc  127.0.0.1 {}'.format(
@@ -136,8 +132,7 @@ tr = Test.AddTestRun("Trace request via curl")
 tr.Processes.Default.Command = 'curl -v --http1.1 -X TRACE -k http://127.0.0.1:{}/bar'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    r"HTTP/1.1 501 Unsupported method \('TRACE'\)",
-    "microserver does not support TRACE")
+    r"HTTP/1.1 501 Unsupported method \('TRACE'\)", "microserver does not support TRACE")
 
 # Methods are case sensitive. Verify that "gET" is not confused with "GET".
 tr = Test.AddTestRun("mixed case method")

--- a/tests/gold_tests/headers/hsts.test.py
+++ b/tests/gold_tests/headers/hsts.test.py
@@ -36,30 +36,26 @@ server.addResponse("sessionlog.json", request_header, response_header)
 # ATS Configuration
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.hsts_max_age': 300,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.hsts_max_age': 300,
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map https://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map https://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Test 1 - 200 Response
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Command = (
-    'curl -s -D - --verbose --ipv4 --http1.1 --insecure --header "Host: {0}" https://localhost:{1}'
-    .format('www.example.com', ts.Variables.ssl_port)
-)
+    'curl -s -D - --verbose --ipv4 --http1.1 --insecure --header "Host: {0}" https://localhost:{1}'.format(
+        'www.example.com', ts.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "hsts.200.gold"
 tr.StillRunningAfter = ts
@@ -67,9 +63,8 @@ tr.StillRunningAfter = ts
 # Test 2 - 404 Not Found on Accelerator
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    'curl -s -D - --verbose --ipv4 --http1.1 --insecure --header "Host: {0}" https://localhost:{1}'
-    .format('bad_host', ts.Variables.ssl_port)
-)
+    'curl -s -D - --verbose --ipv4 --http1.1 --insecure --header "Host: {0}" https://localhost:{1}'.format(
+        'bad_host', ts.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "hsts.404.gold"
 tr.StillRunningAfter = server

--- a/tests/gold_tests/headers/http408.test.py
+++ b/tests/gold_tests/headers/http408.test.py
@@ -36,9 +36,7 @@ request_header = {"headers": "GET / HTTP/1.1\r\nHost: {}\r\n\r\n".format(HTTP_40
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts.Disk.remap_config.AddLine(
-    'map http://{0} http://127.0.0.1:{1}'.format(HTTP_408_HOST, server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://{0} http://127.0.0.1:{1}'.format(HTTP_408_HOST, server.Variables.Port))
 
 TIMEOUT = 2
 ts.Disk.records_config.update({

--- a/tests/gold_tests/headers/invalid_range_header.test.py
+++ b/tests/gold_tests/headers/invalid_range_header.test.py
@@ -36,23 +36,21 @@ class InvalidRangeHeaderTest:
 
     def setupTS(self):
         self.ts = Test.MakeATSProcess("ts1")
-        self.ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                                            'proxy.config.diags.debug.tags': 'http',
-                                            'proxy.config.http.cache.http': 1,
-                                            'proxy.config.http.cache.range.write': 1,
-                                            'proxy.config.http.cache.required_headers': 0,
-                                            'proxy.config.http.insert_age_in_response': 0})
-        self.ts.Disk.remap_config.AddLine(
-            f"map / http://127.0.0.1:{self.server.Variables.http_port}/",
-        )
+        self.ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http',
+                'proxy.config.http.cache.http': 1,
+                'proxy.config.http.cache.range.write': 1,
+                'proxy.config.http.cache.required_headers': 0,
+                'proxy.config.http.insert_age_in_response': 0
+            })
+        self.ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{self.server.Variables.http_port}/",)
 
     def runTraffic(self):
         tr = Test.AddTestRun()
         tr.AddVerifierClientProcess(
-            "client1",
-            self.invalidRangeRequestReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+            "client1", self.invalidRangeRequestReplayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -60,11 +58,9 @@ class InvalidRangeHeaderTest:
 
         # verification
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-            r"Received an HTTP/1 416 response for key 2",
-            "Verify that client receives a 416 response")
+            r"Received an HTTP/1 416 response for key 2", "Verify that client receives a 416 response")
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-            r"x-responseheader: failed_response",
-            "Verify that the response came from the server")
+            r"x-responseheader: failed_response", "Verify that the response came from the server")
 
     def run(self):
         self.runTraffic()

--- a/tests/gold_tests/headers/normalize_ae.test.py
+++ b/tests/gold_tests/headers/normalize_ae.test.py
@@ -23,9 +23,7 @@ Test.Summary = '''
 Test normalizations of the Accept-Encoding header field.
 '''
 
-Test.SkipUnless(
-    Condition.HasATSFeature('TS_HAS_BROTLI')
-)
+Test.SkipUnless(Condition.HasATSFeature('TS_HAS_BROTLI'))
 
 Test.ContinueOnFail = True
 
@@ -54,25 +52,19 @@ def baselineTsSetup(ts):
         # 'proxy.config.diags.debug.enabled': 1,
     })
 
-    ts.Disk.remap_config.AddLine(
-        'map http://www.no-oride.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-    )
+    ts.Disk.remap_config.AddLine('map http://www.no-oride.com http://127.0.0.1:{0}'.format(server.Variables.Port))
     ts.Disk.remap_config.AddLine(
         'map http://www.ae-0.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=0'
-    )
+        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=0')
     ts.Disk.remap_config.AddLine(
         'map http://www.ae-1.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=1'
-    )
+        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=1')
     ts.Disk.remap_config.AddLine(
         'map http://www.ae-2.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2'
-    )
+        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2')
     ts.Disk.remap_config.AddLine(
         'map http://www.ae-3.com http://127.0.0.1:{0}'.format(server.Variables.Port) +
-        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=3'
-    )
+        ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=3')
 
 
 baselineTsSetup(ts)

--- a/tests/gold_tests/headers/syntax.test.py
+++ b/tests/gold_tests/headers/syntax.test.py
@@ -33,9 +33,7 @@ request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", 
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Test 0 - 200 Response
 tr = Test.AddTestRun()

--- a/tests/gold_tests/headers/via.test.py
+++ b/tests/gold_tests/headers/via.test.py
@@ -24,10 +24,7 @@ Test.Summary = '''
 Check VIA header for protocol stack data.
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2'),
-    Condition.HasCurlFeature('IPv6')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'), Condition.HasCurlFeature('IPv6'))
 Test.ContinueOnFail = True
 
 # Define default ATS
@@ -44,23 +41,19 @@ server.addResponse("sessionlog.json", request_header, response_header)
 # These should be promoted rather than other tests like this reaching around.
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.http.insert_request_via_str': 4,
-    'proxy.config.http.insert_response_via_str': 4,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.http.insert_request_via_str': 4,
+        'proxy.config.http.insert_response_via_str': 4,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    'map https://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
-)
+    'map https://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Set up to check the output after the tests have run.
 via_log_id = Test.Disk.File("via.log")

--- a/tests/gold_tests/ip_allow/ip_allow.test.py
+++ b/tests/gold_tests/ip_allow/ip_allow.test.py
@@ -24,83 +24,82 @@ Verify ip_allow filtering behavior.
 Test.ContinueOnFail = True
 
 # Define default ATS
-ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True,
-                         enable_tls=True, enable_cache=False)
+ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True, enable_tls=True, enable_cache=False)
 server = Test.MakeOriginServer("server", ssl=True)
 
 testName = ""
 request = {
-    "headers":
-        "GET /get HTTP/1.1\r\n"
-        "Host: www.example.com:80\r\n\r\n",
-        "timestamp": "1469733493.993",
-        "body": ""}
+    "headers": "GET /get HTTP/1.1\r\n"
+               "Host: www.example.com:80\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Content-Length: 3\r\n"
-        "Connection: close\r\n\r\n",
-        "timestamp":
-        "1469733493.993", "body": "xxx"}
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Content-Length: 3\r\n"
+               "Connection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request, response)
 
 # The following shouldn't come to the server, but in the event that there is a
 # bug in ip_allow and they are sent through, have them return a 200 OK. This
 # will fail the match with the gold file which expects a 403.
 request = {
-    "headers":
-        "CONNECT www.example.com:80/connect HTTP/1.1\r\n"
-        "Host: www.example.com:80\r\n\r\n",
-        "timestamp": "1469733493.993",
-        "body": ""}
+    "headers": "CONNECT www.example.com:80/connect HTTP/1.1\r\n"
+               "Host: www.example.com:80\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Content-Length: 3\r\n"
-        "Connection: close\r\n\r\n",
-        "timestamp":
-        "1469733493.993", "body": "xxx"}
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Content-Length: 3\r\n"
+               "Connection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request, response)
 request = {
-    "headers":
-        "PUSH www.example.com:80/h2_push HTTP/2\r\n"
-        "Host: www.example.com:80\r\n\r\n",
-        "timestamp": "1469733493.993",
-        "body": ""}
+    "headers": "PUSH www.example.com:80/h2_push HTTP/2\r\n"
+               "Host: www.example.com:80\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response = {
-    "headers":
-        "HTTP/2 200 OK\r\n"
-        "Content-Length: 3\r\n"
-        "Connection: close\r\n\r\n",
-        "timestamp":
-        "1469733493.993", "body": "xxx"}
+    "headers": "HTTP/2 200 OK\r\n"
+               "Content-Length: 3\r\n"
+               "Connection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request, response)
 
 # Configure TLS for Traffic Server for HTTP/2.
 ts.addDefaultSSLFiles()
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ip-allow',
-    'proxy.config.http.push_method_enabled': 1,
-    'proxy.config.http.connect_ports': '{0}'.format(server.Variables.SSL_Port),
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-    'proxy.config.http2.active_timeout_in': 3,
-    'proxy.config.http2.max_concurrent_streams_in': 65535,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ip-allow',
+        'proxy.config.http.push_method_enabled': 1,
+        'proxy.config.http.connect_ports': '{0}'.format(server.Variables.SSL_Port),
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+        'proxy.config.http2.active_timeout_in': 3,
+        'proxy.config.http2.max_concurrent_streams_in': 65535,
+    })
 
-format_string = ('%<cqtd>-%<cqtt> %<stms> %<ttms> %<chi> %<crc>/%<pssc> %<psql> '
-                 '%<cqhm> %<cquc> %<phr>/%<pqsn> %<psct> %<{Y-RID}pqh> '
-                 '%<{Y-YPCS}pqh> %<{Host}cqh> %<{CHAD}pqh>  '
-                 'sftover=%<{x-safet-overlimit-rules}cqh> sftmat=%<{x-safet-matched-rules}cqh> '
-                 'sftcls=%<{x-safet-classification}cqh> '
-                 'sftbadclf=%<{x-safet-bad-classifiers}cqh> yra=%<{Y-RA}cqh> scheme=%<cqus>')
+format_string = (
+    '%<cqtd>-%<cqtt> %<stms> %<ttms> %<chi> %<crc>/%<pssc> %<psql> '
+    '%<cqhm> %<cquc> %<phr>/%<pqsn> %<psct> %<{Y-RID}pqh> '
+    '%<{Y-YPCS}pqh> %<{Host}cqh> %<{CHAD}pqh>  '
+    'sftover=%<{x-safet-overlimit-rules}cqh> sftmat=%<{x-safet-matched-rules}cqh> '
+    'sftcls=%<{x-safet-classification}cqh> '
+    'sftbadclf=%<{x-safet-bad-classifiers}cqh> yra=%<{Y-RA}cqh> scheme=%<cqus>')
 
 ts.Disk.logging_yaml.AddLines(
     ''' logging:
@@ -110,12 +109,9 @@ ts.Disk.logging_yaml.AddLines(
   logs:
     - filename: squid.log
       format: custom
-'''.format(format_string).split("\n")
-)
+'''.format(format_string).split("\n"))
 
-ts.Disk.remap_config.AddLine(
-    'map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port)
-)
+ts.Disk.remap_config.AddLine('map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
 
 # Note that CONNECT is not in the allowed list.
 ts.Disk.ip_allow_yaml.AddLines(
@@ -129,15 +125,12 @@ ts.Disk.ip_allow_yaml.AddLines(
     action: allow
     methods: [GET, HEAD, POST ]
 
-'''.split("\n")
-)
+'''.split("\n"))
 
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Line 1 denial for 'CONNECT' from 127.0.0.1",
-    "The CONNECT request should be denied by ip_allow")
+    "Line 1 denial for 'CONNECT' from 127.0.0.1", "The CONNECT request should be denied by ip_allow")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Line 1 denial for 'PUSH' from 127.0.0.1",
-    "The PUSH request should be denied by ip_allow")
+    "Line 1 denial for 'PUSH' from 127.0.0.1", "The PUSH request should be denied by ip_allow")
 
 #
 # TEST 1: Perform a GET request. Should be allowed because GET is in the allowlist.
@@ -146,8 +139,8 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.SSL_Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 
-tr.Processes.Default.Command = ('curl --verbose -H "Host: www.example.com" http://localhost:{ts_port}/get'.
-                                format(ts_port=ts.Variables.port))
+tr.Processes.Default.Command = (
+    'curl --verbose -H "Host: www.example.com" http://localhost:{ts_port}/get'.format(ts_port=ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = 'gold/200.gold'
 tr.StillRunningAfter = ts
@@ -158,8 +151,8 @@ tr.StillRunningAfter = server
 # not in the allowlist.
 #
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = ('curl --verbose -X CONNECT -H "Host: localhost" http://localhost:{ts_port}/connect'.
-                                format(ts_port=ts.Variables.port))
+tr.Processes.Default.Command = (
+    'curl --verbose -X CONNECT -H "Host: localhost" http://localhost:{ts_port}/connect'.format(ts_port=ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = 'gold/403.gold'
 tr.StillRunningAfter = ts
@@ -170,8 +163,9 @@ tr.StillRunningAfter = server
 # PUSH is not in the allowlist.
 #
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = ('curl --http2 --verbose -k -X PUSH -H "Host: localhost" https://localhost:{ts_port}/h2_push'.
-                                format(ts_port=ts.Variables.ssl_port))
+tr.Processes.Default.Command = (
+    'curl --http2 --verbose -k -X PUSH -H "Host: localhost" https://localhost:{ts_port}/h2_push'.format(
+        ts_port=ts.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = 'gold/403_h2.gold'
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/logging/all_headers.test.py
+++ b/tests/gold_tests/logging/all_headers.test.py
@@ -32,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: does.not.matter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-control: max-age=85000\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": "xxx"}
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-control: max-age=85000\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.Disk.records_config.update({
@@ -41,9 +44,7 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'http|dns',
 })
 
-ts.Disk.remap_config.AddLine(
-    'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, server.Variables.Port))
 
 # Mix in a numeric log field.  Hopefull this will detect any binary alignment problems.
 #
@@ -56,8 +57,7 @@ logging:
   logs:
     - filename: test_all_headers
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
 # Configure comparison of "sanitized" log file with gold file at end of test.
 #
@@ -80,16 +80,14 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Command = (
-    'curl "http://127.0.0.1:{0}" --user-agent "007" --verbose '.format(ts.Variables.port) + reallyLong()
-)
+    'curl "http://127.0.0.1:{0}" --user-agent "007" --verbose '.format(ts.Variables.port) + reallyLong())
 tr.Processes.Default.ReturnCode = 0
 
 # Repeat same curl, will be answered from the ATS cache.
 #
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    'curl "http://127.0.0.1:{0}" --user-agent "007" --verbose '.format(ts.Variables.port) + reallyLong()
-)
+    'curl "http://127.0.0.1:{0}" --user-agent "007" --verbose '.format(ts.Variables.port) + reallyLong())
 tr.Processes.Default.ReturnCode = 0
 
 # Delay to allow TS to flush report to disk, then "sanitize" generated log.

--- a/tests/gold_tests/logging/custom-log.test.py
+++ b/tests/gold_tests/logging/custom-log.test.py
@@ -23,17 +23,13 @@ Test custom log file format
 '''
 
 # this test depends on Linux specific behavior regarding loopback addresses
-Test.SkipUnless(
-    Condition.IsPlatform("linux")
-)
+Test.SkipUnless(Condition.IsPlatform("linux"))
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts")
 
 # setup some config file for this server
-ts.Disk.remap_config.AddLine(
-    'map / http://www.linkedin.com/ @action=deny'
-)
+ts.Disk.remap_config.AddLine('map / http://www.linkedin.com/ @action=deny')
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -44,62 +40,51 @@ logging:
   logs:
     - filename: test_log_field
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
 # #########################################################################
 # at the end of the different test run a custom log file should exist
 # Because of this we expect the testruns to pass the real test is if the
 # customlog file exists and passes the format check
-Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'test_log_field.log'),
-               exists=True, content='gold/custom.gold')
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'test_log_field.log'), exists=True, content='gold/custom.gold')
 
 # first test is a miss for default
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.1.1.1:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.1.1.1:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.2.2.2:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.2.2.2:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.3.3.3:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.3.3.3:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.3.0.1:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.3.0.1:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.43.2.1:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.43.2.1:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.213.213.132:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.213.213.132:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.123.32.243:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.123.32.243:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = (
     os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'test_log_field.log')
-)
+    os.path.join(ts.Variables.LOGDIR, 'test_log_field.log'))
 test_run.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/logging/log-debug-client-ip.test.py
+++ b/tests/gold_tests/logging/log-debug-client-ip.test.py
@@ -27,30 +27,25 @@ replay_file = "log-filter.replays.yaml"
 server = Test.MakeVerifierServerProcess("server", replay_file)
 nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 2,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.diags.debug.client_ip': '127.0.0.1',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://localhost:{}/'.format(server.Variables.http_port)
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 2,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.diags.debug.client_ip': '127.0.0.1',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+    })
+ts.Disk.remap_config.AddLine('map / http://localhost:{}/'.format(server.Variables.http_port))
 
 # Verify that the various aspects of the expected debug output for the
 # transaction are logged.
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    r"\+ Incoming Request \+",
-    "Make sure the client request information is present.")
+    r"\+ Incoming Request \+", "Make sure the client request information is present.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    r"\+ Proxy's Request after hooks \+",
-    "Make sure the proxy request information is present.")
+    r"\+ Proxy's Request after hooks \+", "Make sure the proxy request information is present.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    r"\+ Incoming O.S. Response \+",
-    "Make sure the server's response information is present.")
+    r"\+ Incoming O.S. Response \+", "Make sure the server's response information is present.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    r"\+ Proxy's Response 2 \+",
-    "Make sure the proxy response information is present.")
+    r"\+ Proxy's Response 2 \+", "Make sure the proxy response information is present.")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/logging/log-field-json.test.py
+++ b/tests/gold_tests/logging/log-field-json.test.py
@@ -28,35 +28,43 @@ server = Test.MakeOriginServer("server")
 request_header = {'timestamp': 100, "headers": "GET /test-1 HTTP/1.1\r\nHost: test-1\r\n\r\n", "body": ""}
 response_header = {
     'timestamp': 100,
-    "headers": "HTTP/1.1 200 OK\r\nTest: 1\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
-    "body": "Test 1"}
+    "headers":
+        "HTTP/1.1 200 OK\r\nTest: 1\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+    "body": "Test 1"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
-server.addResponse("sessionlog.json",
-                   {'timestamp': 101,
-                    "headers": "GET /test-2 HTTP/1.1\r\nHost: test-2\r\n\r\n",
-                    "body": ""},
-                   {'timestamp': 101,
-                       "headers": "HTTP/1.1 200 OK\r\nTest: 2\r\nContent-Type: application/jason\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
-                       "body": "Test 2"})
-server.addResponse("sessionlog.json",
-                   {'timestamp': 102,
-                    "headers": "GET /test-3 HTTP/1.1\r\nHost: test-3\r\n\r\n",
-                    "body": ""},
-                   {'timestamp': 102,
-                       "headers": "HTTP/1.1 200 OK\r\nTest: 3\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
-                       "body": "Test 3"})
+server.addResponse(
+    "sessionlog.json", {
+        'timestamp': 101,
+        "headers": "GET /test-2 HTTP/1.1\r\nHost: test-2\r\n\r\n",
+        "body": ""
+    }, {
+        'timestamp': 101,
+        "headers":
+            "HTTP/1.1 200 OK\r\nTest: 2\r\nContent-Type: application/jason\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+        "body": "Test 2"
+    })
+server.addResponse(
+    "sessionlog.json", {
+        'timestamp': 102,
+        "headers": "GET /test-3 HTTP/1.1\r\nHost: test-3\r\n\r\n",
+        "body": ""
+    }, {
+        'timestamp': 102,
+        "headers": "HTTP/1.1 200 OK\r\nTest: 3\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+        "body": "Test 3"
+    })
 
 nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
-ts.Disk.records_config.update({
-    'proxy.config.net.connections_throttle': 100,
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-    'proxy.config.dns.resolv_conf': 'NULL'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.net.connections_throttle': 100,
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+        'proxy.config.dns.resolv_conf': 'NULL'
+    })
 # setup some config file for this server
-ts.Disk.remap_config.AddLine(
-    'map / http://localhost:{}/'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://localhost:{}/'.format(server.Variables.Port))
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -68,15 +76,13 @@ logging:
   logs:
     - filename: field-json-test
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
 # #########################################################################
 # at the end of the different test run a custom log file should exist
 # Because of this we expect the testruns to pass the real test is if the
 # customlog file exists and passes the format check
-Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'field-json-test.log'),
-               exists=True, content='gold/field-json-test.gold')
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'field-json-test.log'), exists=True, content='gold/field-json-test.gold')
 
 # first test is a miss for default
 tr = Test.AddTestRun()
@@ -86,17 +92,17 @@ tr.Processes.Default.StartBefore(nameserver)
 # Delay on readiness of our ssl ports
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 
-tr.Processes.Default.Command = 'curl --verbose --header "Host: test-1" --header "Foo: ab\td/ef" http://localhost:{0}/test-1' .format(
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-1" --header "Foo: ab\td/ef" http://localhost:{0}/test-1'.format(
     ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" --header "Foo: ab\x1fd/ef" http://localhost:{0}/test-2' .format(
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" --header "Foo: ab\x1fd/ef" http://localhost:{0}/test-2'.format(
     ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl --verbose --header "Host: test-3" --header "Foo: abc\x7fde" http://localhost:{0}/test-3' .format(
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-3" --header "Foo: abc\x7fde" http://localhost:{0}/test-3'.format(
     ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
@@ -104,6 +110,5 @@ tr.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = (
     os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'field-json-test.log')
-)
+    os.path.join(ts.Variables.LOGDIR, 'field-json-test.log'))
 test_run.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/logging/log-field.test.py
+++ b/tests/gold_tests/logging/log-field.test.py
@@ -28,35 +28,43 @@ server = Test.MakeOriginServer("server")
 request_header = {'timestamp': 100, "headers": "GET /test-1 HTTP/1.1\r\nHost: test-1\r\n\r\n", "body": ""}
 response_header = {
     'timestamp': 100,
-    "headers": "HTTP/1.1 200 OK\r\nTest: 1\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
-    "body": "Test 1"}
+    "headers":
+        "HTTP/1.1 200 OK\r\nTest: 1\r\nContent-Type: application/json\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+    "body": "Test 1"
+}
 server.addResponse("sessionlog.json", request_header, response_header)
-server.addResponse("sessionlog.json",
-                   {'timestamp': 101,
-                    "headers": "GET /test-2 HTTP/1.1\r\nHost: test-2\r\n\r\n",
-                    "body": ""},
-                   {'timestamp': 101,
-                       "headers": "HTTP/1.1 200 OK\r\nTest: 2\r\nContent-Type: application/jason\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
-                       "body": "Test 2"})
-server.addResponse("sessionlog.json",
-                   {'timestamp': 102,
-                    "headers": "GET /test-3 HTTP/1.1\r\nHost: test-3\r\n\r\n",
-                    "body": ""},
-                   {'timestamp': 102,
-                       "headers": "HTTP/1.1 200 OK\r\nTest: 3\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
-                       "body": "Test 3"})
+server.addResponse(
+    "sessionlog.json", {
+        'timestamp': 101,
+        "headers": "GET /test-2 HTTP/1.1\r\nHost: test-2\r\n\r\n",
+        "body": ""
+    }, {
+        'timestamp': 101,
+        "headers":
+            "HTTP/1.1 200 OK\r\nTest: 2\r\nContent-Type: application/jason\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+        "body": "Test 2"
+    })
+server.addResponse(
+    "sessionlog.json", {
+        'timestamp': 102,
+        "headers": "GET /test-3 HTTP/1.1\r\nHost: test-3\r\n\r\n",
+        "body": ""
+    }, {
+        'timestamp': 102,
+        "headers": "HTTP/1.1 200 OK\r\nTest: 3\r\nConnection: close\r\nContent-Type: application/json\r\n\r\n",
+        "body": "Test 3"
+    })
 
 nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
-ts.Disk.records_config.update({
-    'proxy.config.net.connections_throttle': 100,
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-    'proxy.config.dns.resolv_conf': 'NULL'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.net.connections_throttle': 100,
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+        'proxy.config.dns.resolv_conf': 'NULL'
+    })
 # setup some config file for this server
-ts.Disk.remap_config.AddLine(
-    'map / http://localhost:{}/'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://localhost:{}/'.format(server.Variables.Port))
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -67,15 +75,13 @@ logging:
   logs:
     - filename: field-test
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
 # #########################################################################
 # at the end of the different test run a custom log file should exist
 # Because of this we expect the testruns to pass the real test is if the
 # customlog file exists and passes the format check
-Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'field-test.log'),
-               exists=True, content='gold/field-test.gold')
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'field-test.log'), exists=True, content='gold/field-test.gold')
 
 # first test is a miss for default
 tr = Test.AddTestRun()
@@ -85,24 +91,19 @@ tr.Processes.Default.StartBefore(nameserver)
 # Delay on readiness of our ssl ports
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 
-tr.Processes.Default.Command = 'curl --verbose --header "Host: test-1" http://localhost:{0}/test-1' .format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-1" http://localhost:{0}/test-1'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" http://localhost:{0}/test-2' .format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" http://localhost:{0}/test-2'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl --verbose --header "Host: test-3" http://localhost:{0}/test-3' .format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-3" http://localhost:{0}/test-3'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = (
-    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'field-test.log')
-)
+    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + os.path.join(ts.Variables.LOGDIR, 'field-test.log'))
 test_run.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/logging/log-filter.test.py
+++ b/tests/gold_tests/logging/log-filter.test.py
@@ -27,18 +27,16 @@ replay_file = "log-filter.replays.yaml"
 server = Test.MakeVerifierServerProcess("server", replay_file)
 nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'log',
-
-    'proxy.config.net.connections_throttle': 100,
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-    'proxy.config.dns.resolv_conf': 'NULL'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'log',
+        'proxy.config.net.connections_throttle': 100,
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+        'proxy.config.dns.resolv_conf': 'NULL'
+    })
 # setup some config file for this server
-ts.Disk.remap_config.AddLine(
-    'map / http://localhost:{}/'.format(server.Variables.http_port)
-)
+ts.Disk.remap_config.AddLine('map / http://localhost:{}/'.format(server.Variables.http_port))
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -72,15 +70,13 @@ logging:
       filters:
       - queryparamescaper_cquuc
       - not_localhost
-'''.split("\n")
-)
+'''.split("\n"))
 
 # #########################################################################
 # at the end of the different test run a custom log file should exist
 # Because of this we expect the testruns to pass the real test is if the
 # customlog file exists and passes the format check
-Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'filter-test.log'),
-               exists=True, content='gold/filter-test.gold')
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'filter-test.log'), exists=True, content='gold/filter-test.gold')
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -91,15 +87,12 @@ tr.AddVerifierClientProcess("client-1", replay_file, http_ports=[ts.Variables.po
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = (
-    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'filter-test.log')
-)
+    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + os.path.join(ts.Variables.LOGDIR, 'filter-test.log'))
 test_run.Processes.Default.ReturnCode = 0
 
 # We already waited for the above, so we don't have to wait for this one.
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = (
     os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 1 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'should-not-be-written.log')
-)
+    os.path.join(ts.Variables.LOGDIR, 'should-not-be-written.log'))
 test_run.Processes.Default.ReturnCode = 1

--- a/tests/gold_tests/logging/log_retention.test.py
+++ b/tests/gold_tests/logging/log_retention.test.py
@@ -90,13 +90,19 @@ class TestLogRetention:
             return cls.__server
 
         server = Test.MakeOriginServer("server")
-        request_header = {"headers": "GET / HTTP/1.1\r\n"
-                          "Host: does.not.matter\r\n\r\n",
-                          "timestamp": "1469733493.993", "body": ""}
-        response_header = {"headers": "HTTP/1.1 200 OK\r\n"
-                           "Connection: close\r\n"
-                           "Cache-control: max-age=85000\r\n\r\n",
-                           "timestamp": "1469733493.993", "body": "xxx"}
+        request_header = {
+            "headers": "GET / HTTP/1.1\r\n"
+                       "Host: does.not.matter\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
+        response_header = {
+            "headers": "HTTP/1.1 200 OK\r\n"
+                       "Connection: close\r\n"
+                       "Cache-control: max-age=85000\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": "xxx"
+        }
         server.addResponse("sessionlog.json", request_header, response_header)
         cls.__server = server
         return cls.__server
@@ -117,31 +123,26 @@ class TestLogRetention:
         self.ts.Disk.records_config.update(combined_records_config)
 
         self.ts.Disk.remap_config.AddLine(
-            'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(
-                self.ts.Variables.port, self.server.Variables.Port)
-        )
+            'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(self.ts.Variables.port, self.server.Variables.Port))
         return self.ts
 
     def get_curl_command(self):
         """
         Generate the appropriate single curl command.
         """
-        return 'curl "http://127.0.0.1:{0}" --verbose'.format(
-            self.ts.Variables.port)
+        return 'curl "http://127.0.0.1:{0}" --verbose'.format(self.ts.Variables.port)
 
     def get_command_to_rotate_once(self):
         """
         Generate the set of curl commands to trigger a log rotate.
         """
-        return 'for i in {{1..2500}}; do curl "http://127.0.0.1:{0}" --verbose; done'.format(
-            self.ts.Variables.port)
+        return 'for i in {{1..2500}}; do curl "http://127.0.0.1:{0}" --verbose; done'.format(self.ts.Variables.port)
 
     def get_command_to_rotate_thrice(self):
         """
         Generate the set of curl commands to trigger a log rotate.
         """
-        return 'for i in {{1..7500}}; do curl "http://127.0.0.1:{0}" --verbose; done'.format(
-            self.ts.Variables.port)
+        return 'for i in {{1..7500}}; do curl "http://127.0.0.1:{0}" --verbose; done'.format(self.ts.Variables.port)
 
 
 #
@@ -157,8 +158,7 @@ twelve_meg_log_space = {
     # Verify that setting a hostname changes the hostname used in rolled logs.
     'proxy.config.log.hostname': specified_hostname,
 }
-test = TestLogRetention(twelve_meg_log_space,
-                        "Verify log rotation and deletion of the configured log file with no min_count.")
+test = TestLogRetention(twelve_meg_log_space, "Verify log rotation and deletion of the configured log file with no min_count.")
 
 # Configure approximately 5 KB entries for a log with no specified min_count.
 test.ts.Disk.logging_yaml.AddLines(
@@ -170,25 +170,20 @@ logging:
   logs:
     - filename: test_deletion
       format: long
-'''.format(prefix="0123456789" * 500).split("\n")
-)
+'''.format(prefix="0123456789" * 500).split("\n"))
 
 # Verify that each log type was registered for auto-deletion.
 test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_deletion.log with min roll count 0",
     "Verify test_deletion.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for error.log with min roll count 0",
-    "Verify error.log auto-delete configuration")
+    "Registering rotated log deletion for error.log with min roll count 0", "Verify error.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for traffic.out with min roll count 0",
-    "Verify traffic.out auto-delete configuration")
+    "Registering rotated log deletion for traffic.out with min roll count 0", "Verify traffic.out auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for diags.log with min roll count 0",
-    "Verify diags.log auto-delete configuration")
+    "Registering rotated log deletion for diags.log with min roll count 0", "Verify diags.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for manager.log with min roll count 0",
-    "Verify manager.log auto-delete configuration")
+    "Registering rotated log deletion for manager.log with min roll count 0", "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_deletion.log_{specified_hostname}.*was auto-deleted.*bytes were reclaimed",
@@ -200,12 +195,10 @@ test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
 
-
 #
 # Test 1: Verify log deletion happens with a min_count of 1.
 #
-test = TestLogRetention(twelve_meg_log_space,
-                        "Verify log rotation and deletion of the configured log file with a min_count of 1.")
+test = TestLogRetention(twelve_meg_log_space, "Verify log rotation and deletion of the configured log file with a min_count of 1.")
 
 # Configure approximately 5 KB entries for a log with no specified min_count.
 test.ts.Disk.logging_yaml.AddLines(
@@ -218,8 +211,7 @@ logging:
     - filename: test_deletion
       rolling_min_count: 1
       format: long
-'''.format(prefix="0123456789" * 500).split("\n")
-)
+'''.format(prefix="0123456789" * 500).split("\n"))
 
 # Verify that each log type was registered for auto-deletion.
 test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
@@ -227,17 +219,13 @@ test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Verify test_deletion.log auto-delete configuration")
 # Only the test_deletion should have its min_count overridden.
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for error.log with min roll count 0",
-    "Verify error.log auto-delete configuration")
+    "Registering rotated log deletion for error.log with min roll count 0", "Verify error.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for traffic.out with min roll count 0",
-    "Verify traffic.out auto-delete configuration")
+    "Registering rotated log deletion for traffic.out with min roll count 0", "Verify traffic.out auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for diags.log with min roll count 0",
-    "Verify diags.log auto-delete configuration")
+    "Registering rotated log deletion for diags.log with min roll count 0", "Verify diags.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for manager.log with min roll count 0",
-    "Verify manager.log auto-delete configuration")
+    "Registering rotated log deletion for manager.log with min roll count 0", "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_deletion.log_{specified_hostname}.*was auto-deleted.*bytes were reclaimed",
@@ -248,12 +236,10 @@ test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
 
-
 #
 # Test 2: Verify log deletion happens for a plugin's logs.
 #
-test = TestLogRetention(twelve_meg_log_space,
-                        "Verify log rotation and deletion of plugin logs.")
+test = TestLogRetention(twelve_meg_log_space, "Verify log rotation and deletion of plugin logs.")
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'test_log_interface.so'), test.ts)
 
 # Verify that the plugin's logs and other core logs were registered for deletion.
@@ -261,21 +247,16 @@ test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_log_interface.log with min roll count 0",
     "Verify test_log_interface.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for error.log with min roll count 0",
-    "Verify error.log auto-delete configuration")
+    "Registering rotated log deletion for error.log with min roll count 0", "Verify error.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for traffic.out with min roll count 0",
-    "Verify traffic.out auto-delete configuration")
+    "Registering rotated log deletion for traffic.out with min roll count 0", "Verify traffic.out auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for diags.log with min roll count 0",
-    "Verify diags.log auto-delete configuration")
+    "Registering rotated log deletion for diags.log with min roll count 0", "Verify diags.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for manager.log with min roll count 0",
-    "Verify manager.log auto-delete configuration")
+    "Registering rotated log deletion for manager.log with min roll count 0", "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "The rolled logfile.*test_log_interface.log_.*was auto-deleted.*bytes were reclaimed",
-    "Verify that space was reclaimed")
+    "The rolled logfile.*test_log_interface.log_.*was auto-deleted.*bytes were reclaimed", "Verify that space was reclaimed")
 
 test.tr.Processes.Default.Command = test.get_command_to_rotate_once()
 test.tr.Processes.Default.ReturnCode = 0
@@ -291,8 +272,7 @@ twenty_two_meg_log_space = {
     'proxy.config.log.max_space_mb_headroom': 2,
     'proxy.config.log.max_space_mb_for_logs': 22,
 }
-test = TestLogRetention(twenty_two_meg_log_space,
-                        "Verify log deletion priority behavior.")
+test = TestLogRetention(twenty_two_meg_log_space, "Verify log deletion priority behavior.")
 
 # Configure approximately 5 KB entries for a log with no specified min_count.
 test.ts.Disk.logging_yaml.AddLines(
@@ -309,8 +289,7 @@ logging:
     - filename: test_high_priority_deletion
       rolling_min_count: 1
       format: long
-'''.format(prefix="0123456789" * 500).split("\n")
-)
+'''.format(prefix="0123456789" * 500).split("\n"))
 
 # Verify that each log type was registered for auto-deletion.
 test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
@@ -321,17 +300,13 @@ test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Verify test_high_priority_deletion.log auto-delete configuration")
 # Only the test_deletion should have its min_count overridden.
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for error.log with min roll count 0",
-    "Verify error.log auto-delete configuration")
+    "Registering rotated log deletion for error.log with min roll count 0", "Verify error.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for traffic.out with min roll count 0",
-    "Verify traffic.out auto-delete configuration")
+    "Registering rotated log deletion for traffic.out with min roll count 0", "Verify traffic.out auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for diags.log with min roll count 0",
-    "Verify diags.log auto-delete configuration")
+    "Registering rotated log deletion for diags.log with min roll count 0", "Verify diags.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for manager.log with min roll count 0",
-    "Verify manager.log auto-delete configuration")
+    "Registering rotated log deletion for manager.log with min roll count 0", "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "The rolled logfile.*test_low_priority_deletion.log_.*was auto-deleted.*bytes were reclaimed",
@@ -358,27 +333,21 @@ various_min_count_overrides = {
     'proxy.config.output.logfile.rolling_min_count': 4,
     'proxy.config.diags.logfile.rolling_min_count': 5,
 }
-test = TestLogRetention(various_min_count_overrides,
-                        "Verify that the various min_count configurations behave as expected")
+test = TestLogRetention(various_min_count_overrides, "Verify that the various min_count configurations behave as expected")
 
 # Only the test_deletion should have its min_count overridden.
 test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "Registering rotated log deletion for error.log with min roll count 3",
-    "Verify error.log auto-delete configuration")
+    "Registering rotated log deletion for error.log with min roll count 3", "Verify error.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for traffic.out with min roll count 4",
-    "Verify traffic.out auto-delete configuration")
+    "Registering rotated log deletion for traffic.out with min roll count 4", "Verify traffic.out auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for diags.log with min roll count 5",
-    "Verify diags.log auto-delete configuration")
+    "Registering rotated log deletion for diags.log with min roll count 5", "Verify diags.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for manager.log with min roll count 5",
-    "Verify manager.log auto-delete configuration")
+    "Registering rotated log deletion for manager.log with min roll count 5", "Verify manager.log auto-delete configuration")
 # In case a future log is added, make sure the developer doesn't forget to
 # set the min count per configuration.
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
-    "Registering .* with min roll count 0",
-    "Verify nothing has a default min roll count of 0 per configuration")
+    "Registering .* with min roll count 0", "Verify nothing has a default min roll count of 0 per configuration")
 
 # This test doesn't require a log rotation. We just verify that the logs communicate
 # the appropriate min_count values above.
@@ -387,18 +356,17 @@ test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
 
-
 #
 # Test 5: Verify log deletion does not happen when it is disabled.
 #
 auto_delete_disabled = twelve_meg_log_space.copy()
-auto_delete_disabled.update({
-    'proxy.config.log.auto_delete_rolled_files': 0,
-    # Verify that setting a hostname changes the hostname used in rolled logs.
-    'proxy.config.log.hostname': 'my_hostname',
-})
-test = TestLogRetention(auto_delete_disabled,
-                        "Verify log deletion does not happen when auto-delet is disabled.")
+auto_delete_disabled.update(
+    {
+        'proxy.config.log.auto_delete_rolled_files': 0,
+        # Verify that setting a hostname changes the hostname used in rolled logs.
+        'proxy.config.log.hostname': 'my_hostname',
+    })
+test = TestLogRetention(auto_delete_disabled, "Verify log deletion does not happen when auto-delet is disabled.")
 
 # Configure approximately 5 KB entries for a log with no specified min_count.
 test.ts.Disk.logging_yaml.AddLines(
@@ -411,8 +379,7 @@ logging:
     - filename: test_deletion
       rolling_min_count: 1
       format: long
-'''.format(prefix="0123456789" * 500).split("\n")
-)
+'''.format(prefix="0123456789" * 500).split("\n"))
 
 # Verify that each log type was registered for auto-deletion.
 test.ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
@@ -420,21 +387,16 @@ test.ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
     "Verify test_deletion.log auto-delete configuration")
 # Only the test_deletion should have its min_count overridden.
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
-    "Registering rotated log deletion for error.log with min roll count 0",
-    "Verify error.log auto-delete configuration")
+    "Registering rotated log deletion for error.log with min roll count 0", "Verify error.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
-    "Registering rotated log deletion for traffic.out with min roll count 0",
-    "Verify traffic.out auto-delete configuration")
+    "Registering rotated log deletion for traffic.out with min roll count 0", "Verify traffic.out auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
-    "Registering rotated log deletion for diags.log with min roll count 0",
-    "Verify diags.log auto-delete configuration")
+    "Registering rotated log deletion for diags.log with min roll count 0", "Verify diags.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
-    "Registering rotated log deletion for manager.log with min roll count 0",
-    "Verify manager.log auto-delete configuration")
+    "Registering rotated log deletion for manager.log with min roll count 0", "Verify manager.log auto-delete configuration")
 # Verify test_deletion was not deleted.
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
-    "The rolled logfile.*test_deletion.log_.*was auto-deleted.*bytes were reclaimed",
-    "Verify that space was reclaimed")
+    "The rolled logfile.*test_deletion.log_.*was auto-deleted.*bytes were reclaimed", "Verify that space was reclaimed")
 
 test.tr.Processes.Default.Command = test.get_command_to_rotate_once()
 test.tr.Processes.Default.ReturnCode = 0
@@ -455,8 +417,7 @@ max_roll_count_of_2 = {
     # This is the configuration under test.
     'proxy.config.log.rolling_max_count': 2,
 }
-test = TestLogRetention(max_roll_count_of_2,
-                        "Verify max_roll_count is respected.")
+test = TestLogRetention(max_roll_count_of_2, "Verify max_roll_count is respected.")
 
 # Configure approximately 5 KB entries for a log with no specified min_count.
 test.ts.Disk.logging_yaml.AddLines(
@@ -468,13 +429,11 @@ logging:
   logs:
     - filename: test_deletion
       format: long
-'''.format(prefix="0123456789" * 500).split("\n")
-)
+'''.format(prefix="0123456789" * 500).split("\n"))
 
 # Verify that trim happened for the rolled file.
 test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "rolled logfile.*test_deletion.log.*old.* was auto-deleted",
-    "Verify test_deletion.log was trimmed")
+    "rolled logfile.*test_deletion.log.*old.* was auto-deleted", "Verify test_deletion.log was trimmed")
 
 test.tr.Processes.Default.Command = test.get_command_to_rotate_thrice()
 test.tr.Processes.Default.ReturnCode = 0
@@ -484,8 +443,7 @@ test.tr.StillRunningAfter = test.server
 #
 # Test 7: Verify log deletion happens after a config reload.
 #
-test = TestLogRetention(twelve_meg_log_space,
-                        "Verify log rotation and deletion after a config reload.")
+test = TestLogRetention(twelve_meg_log_space, "Verify log rotation and deletion after a config reload.")
 
 test.ts.Disk.logging_yaml.AddLines(
     '''
@@ -496,29 +454,23 @@ logging:
   logs:
     - filename: test_deletion
       format: long
-'''.format(prefix="0123456789" * 500).split("\n")
-)
+'''.format(prefix="0123456789" * 500).split("\n"))
 
 # Verify that the plugin's logs and other core logs were registered for deletion.
 test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "Registering rotated log deletion for test_deletion.log with min roll count 0",
     "Verify test_deletion.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for error.log with min roll count 0",
-    "Verify error.log auto-delete configuration")
+    "Registering rotated log deletion for error.log with min roll count 0", "Verify error.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for traffic.out with min roll count 0",
-    "Verify traffic.out auto-delete configuration")
+    "Registering rotated log deletion for traffic.out with min roll count 0", "Verify traffic.out auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for diags.log with min roll count 0",
-    "Verify diags.log auto-delete configuration")
+    "Registering rotated log deletion for diags.log with min roll count 0", "Verify diags.log auto-delete configuration")
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Registering rotated log deletion for manager.log with min roll count 0",
-    "Verify manager.log auto-delete configuration")
+    "Registering rotated log deletion for manager.log with min roll count 0", "Verify manager.log auto-delete configuration")
 # Verify test_deletion was rotated and deleted.
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "The rolled logfile.*test_deletion.log_.*was auto-deleted.*bytes were reclaimed",
-    "Verify that space was reclaimed")
+    "The rolled logfile.*test_deletion.log_.*was auto-deleted.*bytes were reclaimed", "Verify that space was reclaimed")
 
 # Touch logging.yaml so the config reload applies to logging objects.
 test.tr.Processes.Default.Command = "touch " + test.ts.Disk.logging_yaml.AbsRunTimePath

--- a/tests/gold_tests/logging/new_log_flds.test.py
+++ b/tests/gold_tests/logging/new_log_flds.test.py
@@ -23,9 +23,7 @@ Test.Summary = '''
 Test new log fields
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 # ----
 # Setup httpbin Origin Server
@@ -39,27 +37,22 @@ ts = Test.MakeATSProcess("ts", enable_tls=True)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    # 'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-})
+ts.Disk.records_config.update(
+    {
+        # 'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
+
+ts.Disk.remap_config.AddLine('map http://127.0.0.1:{0} http://127.0.0.1:{1}/ip'.format(ts.Variables.port, httpbin.Variables.Port))
 
 ts.Disk.remap_config.AddLine(
-    'map http://127.0.0.1:{0} http://127.0.0.1:{1}/ip'.format(ts.Variables.port, httpbin.Variables.Port)
-)
+    'map https://127.0.0.1:{0} http://127.0.0.1:{1}/ip'.format(ts.Variables.ssl_port, httpbin.Variables.Port))
 
 ts.Disk.remap_config.AddLine(
-    'map https://127.0.0.1:{0} http://127.0.0.1:{1}/ip'.format(ts.Variables.ssl_port, httpbin.Variables.Port)
-)
+    'map https://reallyreallyreallyreallylong.com http://127.0.0.1:{1}/ip'.format(ts.Variables.ssl_port, httpbin.Variables.Port))
 
-ts.Disk.remap_config.AddLine(
-    'map https://reallyreallyreallyreallylong.com http://127.0.0.1:{1}/ip'.format(ts.Variables.ssl_port, httpbin.Variables.Port)
-)
-
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -70,40 +63,33 @@ logging:
   logs:
     - filename: test_new_log_flds
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
 tr = Test.AddTestRun()
 # Delay on readiness of ssl port
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
 #
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" "http://127.0.0.1:{0}" --http1.1 --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl "http://127.0.0.1:{0}" "http://127.0.0.1:{0}" --http1.1 --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    'curl "https://127.0.0.1:{0}" "https://127.0.0.1:{0}" --http2 --insecure --verbose'.format(
-        ts.Variables.ssl_port)
-)
+    'curl "https://127.0.0.1:{0}" "https://127.0.0.1:{0}" --http2 --insecure --verbose'.format(ts.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl "https://reallyreallyreallyreallylong.com:{0}" --http2 --insecure --verbose' +
-    ' --resolve reallyreallyreallyreallylong.com:{0}:127.0.0.1'
-).format(ts.Variables.ssl_port)
+    ' --resolve reallyreallyreallyreallylong.com:{0}:127.0.0.1').format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
@@ -111,8 +97,7 @@ tr.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = (
     os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'test_new_log_flds.log')
-)
+    os.path.join(ts.Variables.LOGDIR, 'test_new_log_flds.log'))
 test_run.Processes.Default.ReturnCode = 0
 
 # Validate generated log.

--- a/tests/gold_tests/logging/new_log_flds_observer.py
+++ b/tests/gold_tests/logging/new_log_flds_observer.py
@@ -47,14 +47,8 @@ for ln in csv.reader(sys.stdin, delimiter=' '):
 
 # Validate contents of report.
 #
-if (ccid[0] != ccid[1] and
-    ccid[1] != ccid[2] and
-    ccid[2] == ccid[3] and
-    ctid[2] != ctid[3] and
-    ccid[3] != ccid[4] and
-    ccid[4] == ccid[5] and
-    ctid[4] != ctid[5] and
-        ccid[5] != ccid[6]):
+if (ccid[0] != ccid[1] and ccid[1] != ccid[2] and ccid[2] == ccid[3] and ctid[2] != ctid[3] and ccid[3] != ccid[4] and
+        ccid[4] == ccid[5] and ctid[4] != ctid[5] and ccid[5] != ccid[6]):
     exit(code=0)
 
 # Failure exit if report was not valid.

--- a/tests/gold_tests/logging/pipe_buffer_is_larger_than.py
+++ b/tests/gold_tests/logging/pipe_buffer_is_larger_than.py
@@ -26,16 +26,11 @@ F_GETPIPE_SZ = 1032  # Linux 2.6.35+
 
 
 def parse_args():
-    parser = parser = argparse.ArgumentParser(
-        description='Verify that a FIFO has a buffer of at least a certain size')
+    parser = parser = argparse.ArgumentParser(description='Verify that a FIFO has a buffer of at least a certain size')
 
-    parser.add_argument(
-        'pipe_name',
-        help='The pipe name upon which to verify the size is large enough.')
+    parser.add_argument('pipe_name', help='The pipe name upon which to verify the size is large enough.')
 
-    parser.add_argument(
-        'minimum_buffer_size',
-        help='The minimu buffer size for the pipe to expect.')
+    parser.add_argument('minimum_buffer_size', help='The minimu buffer size for the pipe to expect.')
 
     return parser.parse_args()
 
@@ -46,14 +41,10 @@ def test_fifo(fifo, minimum_buffer_size):
         buffer_size = fcntl.fcntl(fifo_fd, F_GETPIPE_SZ)
 
         if buffer_size >= int(minimum_buffer_size):
-            print("Success. Size is: {} which is larger than: {}".format(
-                buffer_size,
-                minimum_buffer_size))
+            print("Success. Size is: {} which is larger than: {}".format(buffer_size, minimum_buffer_size))
             return 0
         else:
-            print("Fail. Size is: {} which is smaller than: {}".format(
-                buffer_size,
-                minimum_buffer_size))
+            print("Fail. Size is: {} which is smaller than: {}".format(buffer_size, minimum_buffer_size))
             return 1
     except Exception as e:
         print("Unable to open fifo, error: {}".format(str(e)))

--- a/tests/gold_tests/logging/pqsi-pqsp.test.py
+++ b/tests/gold_tests/logging/pqsi-pqsp.test.py
@@ -26,18 +26,16 @@ ts = Test.MakeATSProcess("ts", enable_cache=False)
 server = Test.MakeOriginServer("server")
 
 request_header = {
-    "headers":
-        "GET /test HTTP/1.1\r\n"
-        "Host: whatever\r\n"
-        "\r\n",
+    "headers": "GET /test HTTP/1.1\r\n"
+               "Host: whatever\r\n"
+               "\r\n",
     "body": "",
     'timestamp': "1469733493.993",
 }
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "\r\n",
     "body": "body\n",
     'timestamp': "1469733493.993",
 }
@@ -45,15 +43,14 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
-ts.Disk.records_config.update({
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.http.cache.http': 1,
-    'proxy.config.http.cache.required_headers': 0,
-})
-ts.Disk.remap_config.AddLine(
-    'map / http://localhost:{}/'.format(server.Variables.Port)
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.http.cache.http': 1,
+        'proxy.config.http.cache.required_headers': 0,
+    })
+ts.Disk.remap_config.AddLine('map / http://localhost:{}/'.format(server.Variables.Port))
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -64,8 +61,7 @@ logging:
   logs:
     - filename: field-test
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -84,9 +80,7 @@ log_filespec = os.path.join(ts.Variables.LOGDIR, 'field-test.log')
 
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = (
-    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + log_filespec
-)
+tr.Processes.Default.Command = (os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + log_filespec)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()

--- a/tests/gold_tests/logging/sigusr2.test.py
+++ b/tests/gold_tests/logging/sigusr2.test.py
@@ -20,7 +20,6 @@ Verify support of external log rotation via SIGUSR2.
 import os
 import sys
 
-
 TRAFFIC_MANAGER_PID_SCRIPT = 'ts_process_handler.py'
 
 
@@ -40,16 +39,17 @@ class Sigusr2Test:
         self._ts_name = "sigusr2_ts{}".format(Sigusr2Test.__ts_counter)
         Sigusr2Test.__ts_counter += 1
         self.ts = Test.MakeATSProcess(self._ts_name, command="traffic_manager")
-        self.ts.Disk.records_config.update({
-            'proxy.config.http.wait_for_cache': 1,
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'log',
-            'proxy.config.log.periodic_tasks_interval': 1,
+        self.ts.Disk.records_config.update(
+            {
+                'proxy.config.http.wait_for_cache': 1,
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'log',
+                'proxy.config.log.periodic_tasks_interval': 1,
 
-            # All log rotation should be handled externally.
-            'proxy.config.log.rolling_enabled': 0,
-            'proxy.config.log.auto_delete_rolled_files': 0,
-        })
+                # All log rotation should be handled externally.
+                'proxy.config.log.rolling_enabled': 0,
+                'proxy.config.log.auto_delete_rolled_files': 0,
+            })
 
         # For this test, more important than the listening port is the existence of the
         # log files. In particular, it can take a few seconds for traffic_manager to
@@ -67,10 +67,9 @@ class Sigusr2Test:
         self.ts.Disk.File(self.rotated_manager_log, id="manager_log_old")
 
         self.ts.Disk.remap_config.AddLine(
-            'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(
-                self.ts.Variables.port, self.server.Variables.Port)
-        )
-        self.ts.Disk.logging_yaml.AddLine('''
+            'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(self.ts.Variables.port, self.server.Variables.Port))
+        self.ts.Disk.logging_yaml.AddLine(
+            '''
             logging:
               formats:
                 - name: has_path
@@ -93,13 +92,19 @@ class Sigusr2Test:
         server = Test.MakeOriginServer("server")
         Sigusr2Test.__server = server
         for path in ['/first', '/second', '/third']:
-            request_header = {"headers": "GET {} HTTP/1.1\r\n"
-                              "Host: does.not.matter\r\n\r\n".format(path),
-                              "timestamp": "1469733493.993", "body": ""}
-            response_header = {"headers": "HTTP/1.1 200 OK\r\n"
-                               "Connection: close\r\n"
-                               "Cache-control: max-age=85000\r\n\r\n",
-                               "timestamp": "1469733493.993", "body": "xxx"}
+            request_header = {
+                "headers": "GET {} HTTP/1.1\r\n"
+                           "Host: does.not.matter\r\n\r\n".format(path),
+                "timestamp": "1469733493.993",
+                "body": ""
+            }
+            response_header = {
+                "headers": "HTTP/1.1 200 OK\r\n"
+                           "Connection: close\r\n"
+                           "Cache-control: max-age=85000\r\n\r\n",
+                "timestamp": "1469733493.993",
+                "body": "xxx"
+            }
             server.addResponse("sessionlog.json", request_header, response_header)
         return server
 
@@ -127,10 +132,9 @@ tr1 = Test.AddTestRun("Verify system logs (manager.log, etc.) can be rotated")
 diags_test = Sigusr2Test()
 
 # Configure our rotation processes.
-rotate_diags_log = tr1.Processes.Process("rotate_diags_log", "mv {} {}".format(
-    diags_test.diags_log, diags_test.rotated_diags_log))
-rotate_manager_log = tr1.Processes.Process("rotate_manager_log", "mv {} {}".format(
-    diags_test.manager_log, diags_test.rotated_manager_log))
+rotate_diags_log = tr1.Processes.Process("rotate_diags_log", "mv {} {}".format(diags_test.diags_log, diags_test.rotated_diags_log))
+rotate_manager_log = tr1.Processes.Process(
+    "rotate_manager_log", "mv {} {}".format(diags_test.manager_log, diags_test.rotated_manager_log))
 
 # Configure the signaling of SIGUSR2 to traffic_manager.
 tr1.Processes.Default.Command = diags_test.get_sigusr2_signal_command()
@@ -147,23 +151,19 @@ tr1.StillRunningAfter = diags_test.server
 # manager.log should have been rotated. Check for the expected content in the
 # old file and the newly created file.
 diags_test.ts.Disk.manager_log_old.Content += Testers.ContainsExpression(
-    "received SIGUSR2, rotating the logs",
-    "manager.log_old should explain that SIGUSR2 was passed to it")
+    "received SIGUSR2, rotating the logs", "manager.log_old should explain that SIGUSR2 was passed to it")
 
 diags_test.ts.Disk.manager_log.Content += Testers.ContainsExpression(
-    "Reseated manager.log",
-    "The new manager.log should indicate the newly opened manager.log")
+    "Reseated manager.log", "The new manager.log should indicate the newly opened manager.log")
 
 # diags.log should have been rotated. The old one had the reference to traffic
 # server running, this new one shouldn't. But it should indicate that the new
 # diags.log was opened.
 diags_test.ts.Disk.diags_log.Content += Testers.ExcludesExpression(
-    "traffic server running",
-    "The new diags.log should not reference the running traffic server")
+    "traffic server running", "The new diags.log should not reference the running traffic server")
 
 diags_test.ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    "Reseated diags.log",
-    "The new diags.log should indicate the newly opened diags.log")
+    "Reseated diags.log", "The new diags.log should indicate the newly opened diags.log")
 
 #
 # Test 2: Verify SIGUSR2 isn't needed for rotated configured logs.
@@ -172,8 +172,7 @@ tr2 = Test.AddTestRun("Verify yaml.log logs can be rotated")
 configured_test = Sigusr2Test()
 
 first_curl = tr2.Processes.Process(
-    "first_curl",
-    'curl "http://127.0.0.1:{0}/first" --verbose'.format(configured_test.ts.Variables.port))
+    "first_curl", 'curl "http://127.0.0.1:{0}/first" --verbose'.format(configured_test.ts.Variables.port))
 # Note that for each of these processes, aside from the final Default one, they
 # are all treated like long-running servers to AuTest. Thus the long sleeps
 # only allow us to wait until the logs get populated with the desired content,
@@ -183,12 +182,11 @@ first_curl_ready = tr2.Processes.Process("first_curl_ready", 'sleep 30')
 first_curl_ready.StartupTimeout = 30
 first_curl_ready.Ready = When.FileContains(configured_test.configured_log, "/first")
 
-rotate_log = tr2.Processes.Process("rotate_log_file", "mv {} {}".format(
-    configured_test.configured_log, configured_test.rotated_configured_log))
+rotate_log = tr2.Processes.Process(
+    "rotate_log_file", "mv {} {}".format(configured_test.configured_log, configured_test.rotated_configured_log))
 
 second_curl = tr2.Processes.Process(
-    "second_curl",
-    'curl "http://127.0.0.1:{0}/second" --verbose'.format(configured_test.ts.Variables.port))
+    "second_curl", 'curl "http://127.0.0.1:{0}/second" --verbose'.format(configured_test.ts.Variables.port))
 
 second_curl_ready = tr2.Processes.Process("second_curl_ready", 'sleep 30')
 # In the autest environment, it can take more than 10 seconds for the log file to be created.
@@ -201,8 +199,7 @@ send_pkill_ready.StartupTimeout = 30
 send_pkill_ready.Ready = When.FileExists(configured_test.configured_log)
 
 third_curl = tr2.Processes.Process(
-    "third_curl",
-    'curl "http://127.0.0.1:{0}/third" --verbose'.format(configured_test.ts.Variables.port))
+    "third_curl", 'curl "http://127.0.0.1:{0}/third" --verbose'.format(configured_test.ts.Variables.port))
 third_curl_ready = tr2.Processes.Process("third_curl_ready", 'sleep 30')
 # In the autest environment, it can take more than 10 seconds for the log file to be created.
 third_curl_ready.StartupTimeout = 30
@@ -232,21 +229,15 @@ tr2.StillRunningAfter = configured_test.ts
 
 # Verify that the logs are in the correct files.
 configured_test.ts.Disk.configured_log.Content += Testers.ExcludesExpression(
-    "/first",
-    "The new test_rotation.log should not have the first GET retrieval in it.")
+    "/first", "The new test_rotation.log should not have the first GET retrieval in it.")
 configured_test.ts.Disk.configured_log.Content += Testers.ExcludesExpression(
-    "/second",
-    "The new test_rotation.log should not have the second GET retrieval in it.")
+    "/second", "The new test_rotation.log should not have the second GET retrieval in it.")
 configured_test.ts.Disk.configured_log.Content += Testers.ContainsExpression(
-    "/third",
-    "The new test_rotation.log should have the third GET retrieval in it.")
+    "/third", "The new test_rotation.log should have the third GET retrieval in it.")
 
 configured_test.ts.Disk.configured_log_old.Content += Testers.ContainsExpression(
-    "/first",
-    "test_rotation.log_old should have the first GET retrieval in it.")
+    "/first", "test_rotation.log_old should have the first GET retrieval in it.")
 configured_test.ts.Disk.configured_log_old.Content += Testers.ContainsExpression(
-    "/second",
-    "test_rotation.log_old should have the second GET retrieval in it.")
+    "/second", "test_rotation.log_old should have the second GET retrieval in it.")
 configured_test.ts.Disk.configured_log_old.Content += Testers.ExcludesExpression(
-    "/third",
-    "test_rotation.log_old should not have the third GET retrieval in it.")
+    "/third", "test_rotation.log_old should not have the third GET retrieval in it.")

--- a/tests/gold_tests/logging/ts_process_handler.py
+++ b/tests/gold_tests/logging/ts_process_handler.py
@@ -79,18 +79,13 @@ def convert_signal_name_to_signal(signal_name):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description='Interact with a Traffic Server process')
+    parser = argparse.ArgumentParser(description='Interact with a Traffic Server process')
     parser.add_argument(
-        'ts_identifier',
-        help='An identifier in the command line for the desired '
+        'ts_identifier', help='An identifier in the command line for the desired '
         'Traffic Server process.')
+    parser.add_argument('--signal', help='Send the given signal to the process.')
     parser.add_argument(
-        '--signal',
-        help='Send the given signal to the process.')
-    parser.add_argument(
-        '--parent', action="store_true", default=False,
-        help='Interact with the parent process of the Traffic Server process')
+        '--parent', action="store_true", default=False, help='Interact with the parent process of the Traffic Server process')
 
     return parser.parse_args()
 
@@ -100,8 +95,7 @@ def main():
     try:
         process = get_desired_process(args.ts_identifier, args.parent)
     except GetPidError as e:
-        print(traceback.format_exception(None, e, e.__traceback__),
-              file=sys.stderr, flush=True)
+        print(traceback.format_exception(None, e, e.__traceback__), file=sys.stderr, flush=True)
         return 1
 
     if args.signal:

--- a/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
@@ -24,11 +24,10 @@ Test next hop selection using strategies.yaml with consistent hashing.
 #
 server = Test.MakeOriginServer("server")
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "Cache-control: max-age=85000\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=85000\r\n"
+               "\r\n",
     "timestamp": "1469733493.993",
     "body": "This is the body.\n"
 }
@@ -52,30 +51,30 @@ num_nh = 8
 ts_nh = []
 for i in range(num_nh):
     ts = Test.MakeATSProcess(f"ts_nh{i}", use_traffic_out=False, command=f"traffic_server 2>nh_trace{i}.log")
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-        'proxy.config.dns.resolv_conf': "NULL",
-    })
-    ts.Disk.remap_config.AddLine(
-        f"map / http://127.0.0.1:{server.Variables.Port}"
-    )
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+            'proxy.config.dns.resolv_conf': "NULL",
+        })
+    ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
     ts_nh.append(ts)
 
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
-    'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.http.uncacheable_requests_bypass_parent': 0,
-    'proxy.config.http.no_dns_just_forward_to_parent': 1,
-    'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
-    'proxy.config.http.parent_proxy.self_detect': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
+        'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.http.uncacheable_requests_bypass_parent': 0,
+        'proxy.config.http.no_dns_just_forward_to_parent': 1,
+        'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
+        'proxy.config.http.parent_proxy.self_detect': 0,
+    })
 
 ts.Disk.File(ts.Variables.CONFIGDIR + "/strategies.yaml", id="strategies", typename="ats:config")
 s = ts.Disk.strategies
@@ -90,17 +89,19 @@ for i in range(num_nh):
     # The health check URL does not seem to be used currently.
     # s.AddLine(f"          health_check_url: http://next_hop{i}:{ts_nh[i].Variables.port}")
     s.AddLine(f"      weight: 1.0")
-s.AddLines([
-    "strategies:",
-    "  - strategy: the-strategy",
-    "    policy: consistent_hash",
-    "    hash_key: path",
-    "    go_direct: false",
-    "    parent_is_proxy: true",
-    "    ignore_self_detect: true",
-    "    groups:",
-    "      - *g1",
-    "    scheme: http",])
+s.AddLines(
+    [
+        "strategies:",
+        "  - strategy: the-strategy",
+        "    policy: consistent_hash",
+        "    hash_key: path",
+        "    go_direct: false",
+        "    parent_is_proxy: true",
+        "    ignore_self_detect: true",
+        "    groups:",
+        "      - *g1",
+        "    scheme: http",
+    ])
 
 # Fallover not currently tested.
 #
@@ -113,9 +114,7 @@ s.AddLines([
 # "      health_check:",
 # "        - passive",])
 
-ts.Disk.remap_config.AddLine(
-    "map http://dummy.com http://not_used @strategy=the-strategy"
-)
+ts.Disk.remap_config.AddLine("map http://dummy.com http://not_used @strategy=the-strategy")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -128,9 +127,7 @@ tr.Processes.Default.ReturnCode = 0
 
 for i in range(num_objects):
     tr = Test.AddTestRun()
-    tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}'
-    )
+    tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "body.gold"
     tr.Processes.Default.ReturnCode = 0
 

--- a/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
@@ -100,7 +100,7 @@ s.AddLines([
     "    ignore_self_detect: true",
     "    groups:",
     "      - *g1",
-    "    scheme: http"])
+    "    scheme: http",])
 
 # Fallover not currently tested.
 #
@@ -111,7 +111,7 @@ s.AddLines([
 # "      response_codes:",
 # "        - 404",
 # "      health_check:",
-# "        - passive"])
+# "        - passive",])
 
 ts.Disk.remap_config.AddLine(
     "map http://dummy.com http://not_used @strategy=the-strategy"

--- a/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
@@ -100,7 +100,7 @@ s.AddLines([
     "    ignore_self_detect: true",
     "    groups:",
     "      - *g1",
-    "    scheme: http"
+    "    scheme: http",
 ])
 
 # Use default fallover config.
@@ -112,7 +112,7 @@ s.AddLines([
 #     "      response_codes:",
 #     "        - 404",
 #     "      health_check:",
-#     "        - passive"
+#     "        - passive",
 # ])
 
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
@@ -24,11 +24,10 @@ Test next hop selection using strategies.yaml with consistent hashing, with fall
 #
 server = Test.MakeOriginServer("server")
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "Cache-control: max-age=85000\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=85000\r\n"
+               "\r\n",
     "timestamp": "1469733493.993",
     "body": "This is the body.\n"
 }
@@ -52,30 +51,30 @@ num_nh = 8
 ts_nh = []
 for i in range(num_nh):
     ts = Test.MakeATSProcess(f"ts_nh{i}")
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-        'proxy.config.dns.resolv_conf': "NULL",
-    })
-    ts.Disk.remap_config.AddLine(
-        f"map / http://127.0.0.1:{server.Variables.Port}"
-    )
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+            'proxy.config.dns.resolv_conf': "NULL",
+        })
+    ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
     ts_nh.append(ts)
 
 ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
-    'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.http.uncacheable_requests_bypass_parent': 0,
-    'proxy.config.http.no_dns_just_forward_to_parent': 1,
-    'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
-    'proxy.config.http.parent_proxy.self_detect': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
+        'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.http.uncacheable_requests_bypass_parent': 0,
+        'proxy.config.http.no_dns_just_forward_to_parent': 1,
+        'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
+        'proxy.config.http.parent_proxy.self_detect': 0,
+    })
 
 ts.Disk.File(ts.Variables.CONFIGDIR + "/strategies.yaml", id="strategies", typename="ats:config")
 s = ts.Disk.strategies
@@ -90,18 +89,19 @@ for i in range(num_nh):
     # The health check URL does not seem to be used currently.
     # s.AddLine(f"          health_check_url: http://next_hop{i}:{ts_nh[i].Variables.port}")
     s.AddLine(f"      weight: 1.0")
-s.AddLines([
-    "strategies:",
-    "  - strategy: the-strategy",
-    "    policy: consistent_hash",
-    "    hash_key: path",
-    "    go_direct: false",
-    "    parent_is_proxy: true",
-    "    ignore_self_detect: true",
-    "    groups:",
-    "      - *g1",
-    "    scheme: http",
-])
+s.AddLines(
+    [
+        "strategies:",
+        "  - strategy: the-strategy",
+        "    policy: consistent_hash",
+        "    hash_key: path",
+        "    go_direct: false",
+        "    parent_is_proxy: true",
+        "    ignore_self_detect: true",
+        "    groups:",
+        "      - *g1",
+        "    scheme: http",
+    ])
 
 # Use default fallover config.
 #
@@ -115,9 +115,7 @@ s.AddLines([
 #     "        - passive",
 # ])
 
-ts.Disk.remap_config.AddLine(
-    "map http://dummy.com http://not_used @strategy=the-strategy"
-)
+ts.Disk.remap_config.AddLine("map http://dummy.com http://not_used @strategy=the-strategy")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -131,9 +129,7 @@ tr.Processes.Default.ReturnCode = 0
 
 for i in range(num_objects):
     tr = Test.AddTestRun()
-    tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}'
-    )
+    tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "body.gold"
     tr.Processes.Default.ReturnCode = 0
 
@@ -145,15 +141,11 @@ tr.Processes.Default.ReturnCode = 0
 
 for i in range(num_objects):
     tr = Test.AddTestRun()
-    tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}'
-    )
+    tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "body.gold"
     tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = (
-    "grep -F PARENT_SPECIFIED trace.log | sed 's/^.*(next_hop) [^ ]* //' | sed 's/[.][0-9]*$$//'"
-)
+tr.Processes.Default.Command = ("grep -F PARENT_SPECIFIED trace.log | sed 's/^.*(next_hop) [^ ]* //' | sed 's/[.][0-9]*$$//'")
 tr.Processes.Default.Streams.stdout = "trace.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/next_hop/strategies_stale/strategies_stale.test.py
+++ b/tests/gold_tests/next_hop/strategies_stale/strategies_stale.test.py
@@ -94,7 +94,7 @@ s.AddLines([
     "    ignore_self_detect: true",
     "    groups:",
     "      - *g1",
-    "    scheme: http"])
+    "    scheme: http",])
 
 # Fallover not currently tested.
 #
@@ -105,7 +105,7 @@ s.AddLines([
 # "      response_codes:",
 # "        - 404",
 # "      health_check:",
-# "        - passive"])
+# "        - passive",])
 
 ts.Disk.remap_config.AddLine(
     "map http://dummy.com http://not_used @strategy=the-strategy"

--- a/tests/gold_tests/next_hop/strategies_stale/strategies_stale.test.py
+++ b/tests/gold_tests/next_hop/strategies_stale/strategies_stale.test.py
@@ -24,11 +24,10 @@ Test next hop selection using strategies.yaml with consistent hashing.
 #
 server = Test.MakeOriginServer("server")
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "Cache-control: max-age=2\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=2\r\n"
+               "\r\n",
     "timestamp": "1469733493.993",
     "body": "This is the body.\n"
 }
@@ -48,29 +47,29 @@ dns = Test.MakeDNServer("dns")
 # Define next hop trafficserver instances.
 #
 ts_nh = Test.MakeATSProcess(f"ts_nh0", use_traffic_out=False, command=f"traffic_server 2>nh_trace.log")
-ts_nh.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-    'proxy.config.dns.resolv_conf': "NULL",
-})
-ts_nh.Disk.remap_config.AddLine(
-    f"map / http://127.0.0.1:{server.Variables.Port}"
-)
+ts_nh.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+        'proxy.config.dns.resolv_conf': "NULL",
+    })
+ts_nh.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
 
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
-    'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
-    'proxy.config.http.cache.http': 1,
-    'proxy.config.http.uncacheable_requests_bypass_parent': 0,
-    'proxy.config.http.no_dns_just_forward_to_parent': 1,
-    'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
-    'proxy.config.http.parent_proxy.self_detect': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
+        'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
+        'proxy.config.http.cache.http': 1,
+        'proxy.config.http.uncacheable_requests_bypass_parent': 0,
+        'proxy.config.http.no_dns_just_forward_to_parent': 1,
+        'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
+        'proxy.config.http.parent_proxy.self_detect': 0,
+    })
 
 ts.Disk.File(ts.Variables.CONFIGDIR + "/strategies.yaml", id="strategies", typename="ats:config")
 s = ts.Disk.strategies
@@ -84,17 +83,19 @@ s.AddLine(f"          port: {ts_nh.Variables.port}")
 # The health check URL does not seem to be used currently.
 # s.AddLine(f"          health_check_url: http://next_hop0:{ts_nh.Variables.port}")
 s.AddLine(f"      weight: 1.0")
-s.AddLines([
-    "strategies:",
-    "  - strategy: the-strategy",
-    "    policy: consistent_hash",
-    "    hash_key: path",
-    "    go_direct: false",
-    "    parent_is_proxy: true",
-    "    ignore_self_detect: true",
-    "    groups:",
-    "      - *g1",
-    "    scheme: http",])
+s.AddLines(
+    [
+        "strategies:",
+        "  - strategy: the-strategy",
+        "    policy: consistent_hash",
+        "    hash_key: path",
+        "    go_direct: false",
+        "    parent_is_proxy: true",
+        "    ignore_self_detect: true",
+        "    groups:",
+        "      - *g1",
+        "    scheme: http",
+    ])
 
 # Fallover not currently tested.
 #
@@ -107,9 +108,7 @@ s.AddLines([
 # "      health_check:",
 # "        - passive",])
 
-ts.Disk.remap_config.AddLine(
-    "map http://dummy.com http://not_used @strategy=the-strategy"
-)
+ts.Disk.remap_config.AddLine("map http://dummy.com http://not_used @strategy=the-strategy")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -120,9 +119,7 @@ tr.Processes.Default.Command = 'echo start TS, HTTP server, DNS server and next 
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = (
-    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj0'
-)
+tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj0')
 tr.Processes.Default.Streams.stdout = "body.gold"
 tr.Processes.Default.ReturnCode = 0
 
@@ -133,9 +130,7 @@ tr.StillRunningAfter = ts
 
 # Request should come back as 200
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = (
-    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj0'
-)
+tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj0')
 tr.Processes.Default.Streams.stdout = "body.gold"
 tr.Processes.Default.ReturnCode = 0
 

--- a/tests/gold_tests/next_hop/zzz_strategies_peer/zzz_strategies_peer.test.py
+++ b/tests/gold_tests/next_hop/zzz_strategies_peer/zzz_strategies_peer.test.py
@@ -27,11 +27,10 @@ Test next hop selection using strategies.yaml with consistent hashing, with peer
 #
 server = Test.MakeOriginServer("server")
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "Cache-control: max-age=85000\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=85000\r\n"
+               "\r\n",
     "timestamp": "1469733493.993",
     "body": "This is the body.\n"
 }
@@ -56,15 +55,14 @@ ts_upstream = []
 for i in range(num_upstream):
     ts = Test.MakeATSProcess(f"ts_upstream{i}")
     dns.addRecords(records={f"ts_upstream{i}": ["127.0.0.1"]})
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-        'proxy.config.dns.resolv_conf': "NULL",
-    })
-    ts.Disk.remap_config.AddLine(
-        f"map / http://127.0.0.1:{server.Variables.Port}"
-    )
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+            'proxy.config.dns.resolv_conf': "NULL",
+        })
+    ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
     ts_upstream.append(ts)
 
 # Define peer trafficserver instances.
@@ -78,18 +76,19 @@ for i in range(num_peer):
     ts = ts_peer[i]
     dns.addRecords(records={f"ts_peer{i}": ["127.0.0.1"]})
 
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb|cachekey',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
-        'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
-        'proxy.config.http.cache.http': 1,
-        'proxy.config.http.cache.required_headers': 0,
-        'proxy.config.http.uncacheable_requests_bypass_parent': 0,
-        'proxy.config.http.no_dns_just_forward_to_parent': 1,
-        'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
-        'proxy.config.http.parent_proxy.self_detect': 1,
-    })
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb|cachekey',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
+            'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
+            'proxy.config.http.cache.http': 1,
+            'proxy.config.http.cache.required_headers': 0,
+            'proxy.config.http.uncacheable_requests_bypass_parent': 0,
+            'proxy.config.http.no_dns_just_forward_to_parent': 1,
+            'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
+            'proxy.config.http.parent_proxy.self_detect': 1,
+        })
 
     ts.Disk.File(ts.Variables.CONFIGDIR + "/strategies.yaml", id="strategies", typename="ats:config")
     s = ts.Disk.strategies
@@ -112,34 +111,36 @@ for i in range(num_peer):
         # The health check URL does not seem to be used currently.
         # s.AddLine(f"          health_check_url: http://ts_upstream{j}:{ts_upstream[j].Variables.port}")
         s.AddLine(f"      weight: 1.0")
-    s.AddLines([
-        "strategies:",
-        "  - strategy: the-strategy",
-        "    policy: consistent_hash",
-        "    hash_key: cache_key",
-        "    go_direct: false",
-        "    parent_is_proxy: true",
-        "    cache_peer_result: false",
-        "    ignore_self_detect: false",
-        "    groups:",
-        "      - *peer_group",
-        "      - *peer_upstream",
-        "    scheme: http",
-        "    failover:",
-        "      ring_mode: peering_ring",
-        f"      self: ts_peer{i}",
-        #"      max_simple_retries: 2",
-        #"      response_codes:",
-        #"        - 404",
-        #"      health_check:",
-        #"        - passive",
-    ])
+    s.AddLines(
+        [
+            "strategies:",
+            "  - strategy: the-strategy",
+            "    policy: consistent_hash",
+            "    hash_key: cache_key",
+            "    go_direct: false",
+            "    parent_is_proxy: true",
+            "    cache_peer_result: false",
+            "    ignore_self_detect: false",
+            "    groups:",
+            "      - *peer_group",
+            "      - *peer_upstream",
+            "    scheme: http",
+            "    failover:",
+            "      ring_mode: peering_ring",
+            f"      self: ts_peer{i}",
+            #"      max_simple_retries: 2",
+            #"      response_codes:",
+            #"        - 404",
+            #"      health_check:",
+            #"        - passive",
+        ])
 
     suffix = " @strategy=the-strategy @plugin=cachekey.so @pparam=--uri-type=remap @pparam=--capture-prefix=/(.*):(.*)/$1/"
-    ts.Disk.remap_config.AddLines([
-        "map http://dummy.com http://not_used" + suffix,
-        "map http://not_used http://also_not_used" + suffix,
-    ])
+    ts.Disk.remap_config.AddLines(
+        [
+            "map http://dummy.com http://not_used" + suffix,
+            "map http://not_used http://also_not_used" + suffix,
+        ])
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -154,8 +155,7 @@ tr.Processes.Default.ReturnCode = 0
 for i in range(num_object):
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts_peer[i % num_peer].Variables.port} http://dummy.com/obj{i}'
-    )
+        f'curl --verbose --proxy 127.0.0.1:{ts_peer[i % num_peer].Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "body.gold"
     tr.Processes.Default.ReturnCode = 0
 
@@ -163,15 +163,13 @@ for i in range(num_object):
     tr = Test.AddTestRun()
     # num_peer must not be a multiple of 3
     tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts_peer[(i * 3) % num_peer].Variables.port} http://dummy.com/obj{i}'
-    )
+        f'curl --verbose --proxy 127.0.0.1:{ts_peer[(i * 3) % num_peer].Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "body.gold"
     tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     "grep -e '^+++' -e '^[A-Z].*TTP/' -e '^.alts. --' -e 'PARENT_SPECIFIED' trace_peer*.log"
-    " | sed 's/^.*(next_hop) [^ ]* //' | sed 's/[.][0-9]*$$//'"
-)
+    " | sed 's/^.*(next_hop) [^ ]* //' | sed 's/[.][0-9]*$$//'")
 tr.Processes.Default.Streams.stdout = "trace.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/null_transform/null_transform.test.py
+++ b/tests/gold_tests/null_transform/null_transform.test.py
@@ -1,4 +1,3 @@
-
 '''
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
@@ -17,14 +16,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 Test.Summary = '''
 Test a basic null transform plugin
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('null_transform.so')
-)
+Test.SkipUnless(Condition.PluginExists('null_transform.so'))
 
 Test.ContinueOnFail = True
 
@@ -33,25 +29,18 @@ ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 
 Test.testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993",
-                  "body": ""
-                  }
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 # Expected response from origin server
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993",
-
-                   "body": "This is expected response."}
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "This is expected response."
+}
 
 # Add response the server dictionary
 server.addResponse("sessionfile.log", request_header, response_header)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'null_transform'
-})
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'null_transform'})
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Load plugin
 Test.PrepareInstalledPlugin('null_transform.so', ts)

--- a/tests/gold_tests/origin_connection/per_server_connection_max.test.py
+++ b/tests/gold_tests/origin_connection/per_server_connection_max.test.py
@@ -17,7 +17,6 @@ Verify the behavior of proxy.config.http.per_server.connection.max.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 Test.Summary = __doc__
 
 
@@ -44,31 +43,26 @@ class PerServerConnectionMaxTest:
     def _configure_trafficserver(self) -> None:
         """Configure Traffic Server to be used in the test."""
         self._ts = Test.MakeATSProcess("ts")
-        self._ts.Disk.remap_config.AddLine(
-            f'map / http://127.0.0.1:{self._server.Variables.http_port}'
-        )
-        self._ts.Disk.records_config.update({
-            'proxy.config.dns.nameservers': f"127.0.0.1:{self._nameserver.Variables.Port}",
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http',
-            'proxy.config.http.per_server.connection.max': self._origin_max_connections,
-        })
+        self._ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{self._server.Variables.http_port}')
+        self._ts.Disk.records_config.update(
+            {
+                'proxy.config.dns.nameservers': f"127.0.0.1:{self._nameserver.Variables.Port}",
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http',
+                'proxy.config.http.per_server.connection.max': self._origin_max_connections,
+            })
         self._ts.Disk.diags_log.Content += Testers.ContainsExpression(
             f'WARNING:.*too many connections:.*limit={self._origin_max_connections}',
             'Verify the user is warned about the connection limit being hit.')
 
     def run(self) -> None:
         """Configure the TestRun."""
-        tr = Test.AddTestRun(
-            'Verify we enforce proxy.config.http.per_server.connection.max')
+        tr = Test.AddTestRun('Verify we enforce proxy.config.http.per_server.connection.max')
         tr.Processes.Default.StartBefore(self._nameserver)
         tr.Processes.Default.StartBefore(self._server)
         tr.Processes.Default.StartBefore(self._ts)
 
-        tr.AddVerifierClientProcess(
-            'client',
-            self._replay_file,
-            http_ports=[self._ts.Variables.port])
+        tr.AddVerifierClientProcess('client', self._replay_file, http_ports=[self._ts.Variables.port])
 
 
 PerServerConnectionMaxTest().run()

--- a/tests/gold_tests/pluginTest/CppDelayTransformation/CppDelayTransformation.test.py
+++ b/tests/gold_tests/pluginTest/CppDelayTransformation/CppDelayTransformation.test.py
@@ -16,38 +16,30 @@
 
 import os
 
-
 Test.Summary = '''
 Test CPPAPI example plugin DelayTransformation
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists("DelayTransformationPlugin.so")
-)
+Test.SkipUnless(Condition.PluginExists("DelayTransformationPlugin.so"))
 
 server = Test.MakeOriginServer("server")
 
 resp_body = "1234567890" "1234567890" "1234567890" "1234567890" "1234567890" "\n"
 
 server.addResponse(
-    "sessionlog.json",
-    {
-        "headers":
-            "GET / HTTP/1.1\r\n"
-            "Host: does_not_matter"
-            "\r\n",
+    "sessionlog.json", {
+        "headers": "GET / HTTP/1.1\r\n"
+                   "Host: does_not_matter"
+                   "\r\n",
         "timestamp": "1469733493.993",
-    },
-    {
-        "headers":
-            "HTTP/1.1 200 OK\r\n"
-            "Connection: close\r\n"
-            f"Content-Length: {len(resp_body)}\r\n"
-            "\r\n",
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\n"
+                   "Connection: close\r\n"
+                   f"Content-Length: {len(resp_body)}\r\n"
+                   "\r\n",
         "timestamp": "1469733493.993",
         "body": resp_body
-    }
-)
+    })
 
 ts = Test.MakeATSProcess("ts")
 
@@ -58,9 +50,7 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.tags': 'delay_transformation',
 })
 
-ts.Disk.remap_config.AddLine(
-    f'map http://xyz/ http://127.0.0.1:{server.Variables.Port}/'
-)
+ts.Disk.remap_config.AddLine(f'map http://xyz/ http://127.0.0.1:{server.Variables.Port}/')
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests.test.py
@@ -40,46 +40,29 @@ ts = Test.MakeATSProcess("ts", command="traffic_server")
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")
 
 # default root
-req_chk = {"headers":
-           "GET / HTTP/1.1\r\n" +
-           "Host: www.example.com\r\n" +
-           "uuid: none\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_chk = {"headers":
-           "HTTP/1.1 200 OK\r\n" +
-           "Connection: close\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionlog.json", req_chk, res_chk)
 
 body = "lets go surfin now"
 
-req_full = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "Accept: */*\r\n" +
-            "uuid: full\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_full = {
+    "headers": "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "uuid: full\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_full = {"headers":
-            "HTTP/1.1 200 OK\r\n" +
-            "Cache-Control: max-age=500\r\n" +
-            "Connection: close\r\n" +
-            'Etag: "path"\r\n' +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_full = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=500\r\n" + "Connection: close\r\n" + 'Etag: "path"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_full, res_full)
 
@@ -88,148 +71,119 @@ bodylen = len(body)
 
 inner_str = "7-15"
 
-req_inner = {"headers":
-             "GET /path HTTP/1.1\r\n" +
-             "Host: www.example.com\r\n" +
-             "Accept: */*\r\n" +
-             "Range: bytes={}\r\n".format(inner_str) +
-             "uuid: inner\r\n" +
-             "\r\n",
-             "timestamp": "1469733493.993",
-             "body": ""
-             }
+req_inner = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "Range: bytes={}\r\n".format(inner_str) +
+        "uuid: inner\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_inner = {"headers":
-             "HTTP/1.1 206 Partial Content\r\n" +
-             "Accept-Ranges: bytes\r\n" +
-             "Cache-Control: max-age=500\r\n" +
-             "Content-Range: bytes {0}/{1}\r\n".format(inner_str, bodylen) +
-             "Connection: close\r\n" +
-             'Etag: "path"\r\n' +
-             "\r\n",
-             "timestamp": "1469733493.993",
-             "body": body[7:15]
-             }
+res_inner = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=500\r\n" +
+        "Content-Range: bytes {0}/{1}\r\n".format(inner_str, bodylen) + "Connection: close\r\n" + 'Etag: "path"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body[7:15]
+}
 
 server.addResponse("sessionlog.json", req_inner, res_inner)
 
 frange_str = "0-"
 
-req_frange = {"headers":
-              "GET /path HTTP/1.1\r\n" +
-              "Host: www.example.com\r\n" +
-              "Accept: */*\r\n" +
-              "Range: bytes={}\r\n".format(frange_str) +
-              "uuid: frange\r\n" +
-              "\r\n",
-              "timestamp": "1469733493.993",
-              "body": ""
-              }
+req_frange = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "Range: bytes={}\r\n".format(frange_str) +
+        "uuid: frange\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_frange = {"headers":
-              "HTTP/1.1 206 Partial Content\r\n" +
-              "Accept-Ranges: bytes\r\n" +
-              "Cache-Control: max-age=500\r\n" +
-              "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
-              "Connection: close\r\n" +
-              'Etag: "path"\r\n' +
-              "\r\n",
-              "timestamp": "1469733493.993",
-              "body": body
-              }
+res_frange = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=500\r\n" +
+        "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) + "Connection: close\r\n" + 'Etag: "path"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_frange, res_frange)
 
 last_str = "-5"
 
-req_last = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "Accept: */*\r\n" +
-            "Range: bytes={}\r\n".format(last_str) +
-            "uuid: last\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_last = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "Range: bytes={}\r\n".format(last_str) +
+        "uuid: last\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_last = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            "Cache-Control: max-age=200\r\n" +
-            "Content-Range: bytes {0}-{1}/{1}\r\n".format(bodylen - 5, bodylen) +
-            "Connection: close\r\n" +
-            'Etag: "path"\r\n' +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body[-5:]
-            }
+res_last = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=200\r\n" +
+        "Content-Range: bytes {0}-{1}/{1}\r\n".format(bodylen - 5, bodylen) + "Connection: close\r\n" + 'Etag: "path"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body[-5:]
+}
 
 server.addResponse("sessionlog.json", req_last, res_last)
 
 pselect_str = "1-10"
 
-req_pselect = {"headers":
-               "GET /path HTTP/1.1\r\n" +
-               "Host: parentselect\r\n" +
-               "Accept: */*\r\n" +
-               "Range: bytes={}\r\n".format(pselect_str) +
-               "uuid: pselect\r\n" +
-               "\r\n",
-               "timestamp": "1469733493.993",
-               "body": ""
-               }
+req_pselect = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: parentselect\r\n" + "Accept: */*\r\n" + "Range: bytes={}\r\n".format(pselect_str) +
+        "uuid: pselect\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_pselect = {"headers":
-               "HTTP/1.1 206 Partial Content\r\n" +
-               "Accept-Ranges: bytes\r\n" +
-               "Cache-Control: max-age=200\r\n" +
-               "Content-Range: bytes {}/19\r\n".format(pselect_str) +
-               "Connection: close\r\n" +
-               'Etag: "path"\r\n' +
-               "\r\n",
-               "timestamp": "1469733493.993",
-               "body": body[1:10]
-               }
+res_pselect = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=200\r\n" +
+        "Content-Range: bytes {}/19\r\n".format(pselect_str) + "Connection: close\r\n" + 'Etag: "path"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body[1:10]
+}
 
 server.addResponse("sessionlog.json", req_pselect, res_pselect)
 
-req_psd = {"headers":
-           "GET /path HTTP/1.1\r\n" +
-           "Host: psd\r\n" +
-           "Accept: */*\r\n" +
-           "Range: bytes={}\r\n".format(pselect_str) +
-           "uuid: pselect\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_psd = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: psd\r\n" + "Accept: */*\r\n" + "Range: bytes={}\r\n".format(pselect_str) +
+        "uuid: pselect\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
 server.addResponse("sessionlog.json", req_psd, res_pselect)
 
 # cache range requests plugin remap
 ts.Setup.CopyAs('reason.conf', Test.RunDirectory)
-ts.Disk.remap_config.AddLines([
-    'map http://www.example.com http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=header_rewrite.so @pparam={}/reason.conf @plugin=cache_range_requests.so'.format(Test.RunDirectory),
+ts.Disk.remap_config.AddLines(
+    [
+        'map http://www.example.com http://127.0.0.1:{}'.format(server.Variables.Port) +
+        ' @plugin=header_rewrite.so @pparam={}/reason.conf @plugin=cache_range_requests.so'.format(Test.RunDirectory),
 
-    # parent select cache key option
-    'map http://parentselect http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=cache_range_requests.so @pparam=--ps-cachekey',
+        # parent select cache key option
+        'map http://parentselect http://127.0.0.1:{}'.format(server.Variables.Port) +
+        ' @plugin=cache_range_requests.so @pparam=--ps-cachekey',
 
-    # deprecated
-    'map http://psd http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=cache_range_requests.so @pparam=ps_mode:cache_key_url',
-])
+        # deprecated
+        'map http://psd http://127.0.0.1:{}'.format(server.Variables.Port) +
+        ' @plugin=cache_range_requests.so @pparam=ps_mode:cache_key_url',
+    ])
 
 # cache debug
 ts.Disk.plugin_config.AddLine('xdebug.so')
 
 # minimal configuration
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cache_range_requests|http',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cache_range_requests|http',
+    })
 
 curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} -H "x-debug: x-cache"'.format(ts.Variables.port)
 

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cache_complete_responses.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cache_complete_responses.test.py
@@ -61,144 +61,105 @@ ts = Test.MakeATSProcess("ts", command="traffic_server")
 server = Test.MakeOriginServer("server", lookup_key="{%UID}")
 
 # default root
-req_chk = {"headers":
-           "GET / HTTP/1.1\r\n" +
-           "Host: www.example.com\r\n" +
-           "uuid: none\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_chk = {"headers":
-           "HTTP/1.1 200 OK\r\n" +
-           "Connection: close\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionlog.json", req_chk, res_chk)
 
-small_req = {"headers":
-             "GET /obj HTTP/1.1\r\n" +
-             "Host: www.example.com\r\n" +
-             "Accept: */*\r\n" +
-             "UID: SMALL\r\n"
-             "\r\n",
-             "timestamp": "1469733493.993",
-             "body": ""
-             }
-
-small_resp = {"headers":
-              "HTTP/1.1 200 OK\r\n" +
-              "Cache-Control: max-age=1\r\n" +
-              "Connection: close\r\n" +
-              'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-              "\r\n",
-              "timestamp": "1469733493.993",
-              "body": small_body
-              }
-
-small_reval_req = {"headers":
-                   "GET /obj HTTP/1.1\r\n" +
-                   "Host: www.example.com\r\n" +
-                   "Accept: */*\r\n" +
-                   "UID: SMALL-INM\r\n"
-                   "\r\n",
-                   "timestamp": "1469733493.993",
-                   "body": ""
-                   }
-
-small_reval_resp = {"headers":
-                    "HTTP/1.1 304 Not Modified\r\n" +
-                    "Cache-Control: max-age=10\r\n" +
-                    "Connection: close\r\n" +
-                    'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-                    "\r\n",
-                    "timestamp": "1469733493.993"
-                    }
-
-slice_req = {"headers":
-             "GET /slice HTTP/1.1\r\n" +
-             "Host: www.example.com\r\n" +
-             "Range: bytes=0-4194303\r\n" +
-             "Accept: */*\r\n" +
-             "UID: SLICE\r\n"
-             "\r\n",
-             "timestamp": "1469733493.993",
-             }
-
-slice_resp = {"headers":
-              "HTTP/1.1 206 Partial Content\r\n" +
-              "Cache-Control: max-age=1\r\n" +
-              "Content-Range: bytes 0-{}/{}\r\n".format(slice_body_len - 1, slice_body_len * 2) + "\r\n" +
-              "Content-Length: {}\r\n".format(slice_body_len) + "\r\n" +
-              "Connection: close\r\n" +
-              'Etag: "872104f4-d6bcaa1e6f979"\r\n' +
-              "\r\n",
-              "timestamp": "1469733493.993",
-              "body": slice_body
-              }
-
-slice_reval_req = {"headers":
-                   "GET /slice HTTP/1.1\r\n" +
-                   "Host: www.example.com\r\n" +
-                   "Accept: */*\r\n" +
-                   "UID: SLICE-INM\r\n"
-                   "\r\n",
-                   "timestamp": "1469733493.993",
-                   "body": ""
-                   }
-
-slice_reval_resp = {"headers":
-                    "HTTP/1.1 304 Not Modified\r\n" +
-                    "Cache-Control: max-age=10\r\n" +
-                    "Connection: close\r\n" +
-                    'Etag: "872104f4-d6bcaa1e6f979"\r\n' +
-                    "\r\n",
-                    "timestamp": "1469733493.993"
-                    }
-
-naieve_req = {"headers":
-              "GET /naieve/obj HTTP/1.1\r\n" +
-              "Host: www.example.com\r\n" +
-              "Accept: */*\r\n" +
-              "UID: NAIEVE\r\n"
-              "\r\n",
-              "timestamp": "1469733493.993",
-              "body": ""
-              }
-
-naieve_resp = {"headers":
-               "HTTP/1.1 200 OK\r\n" +
-               "Cache-Control: max-age=1\r\n" +
-               "Connection: close\r\n" +
-               'Etag: "cad04ff4-56f4bc197ceda"\r\n' +
+small_req = {
+    "headers": "GET /obj HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "UID: SMALL\r\n"
                "\r\n",
-               "timestamp": "1469733493.993",
-               "body": small_body
-               }
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-naieve_reval_req = {"headers":
-                    "GET /naieve/obj HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "Accept: */*\r\n" +
-                    "UID: NAIEVE-INM\r\n"
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""
-                    }
+small_resp = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" + 'Etag: "772102f4-56f4bc1e6d417"\r\n' +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": small_body
+}
 
-naieve_reval_resp = {"headers":
-                     "HTTP/1.1 304 Not Modified\r\n" +
-                     "Cache-Control: max-age=10\r\n" +
-                     "Connection: close\r\n" +
-                     'Etag: "cad04ff4-56f4bc197ceda"\r\n' +
-                     "\r\n",
-                     "timestamp": "1469733493.993"
-                     }
+small_reval_req = {
+    "headers": "GET /obj HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "UID: SMALL-INM\r\n"
+               "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
+small_reval_resp = {
+    "headers":
+        "HTTP/1.1 304 Not Modified\r\n" + "Cache-Control: max-age=10\r\n" + "Connection: close\r\n" +
+        'Etag: "772102f4-56f4bc1e6d417"\r\n' + "\r\n",
+    "timestamp": "1469733493.993"
+}
+
+slice_req = {
+    "headers":
+        "GET /slice HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Range: bytes=0-4194303\r\n" + "Accept: */*\r\n" +
+        "UID: SLICE\r\n"
+        "\r\n",
+    "timestamp": "1469733493.993",
+}
+
+slice_resp = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Cache-Control: max-age=1\r\n" +
+        "Content-Range: bytes 0-{}/{}\r\n".format(slice_body_len - 1, slice_body_len * 2) + "\r\n" +
+        "Content-Length: {}\r\n".format(slice_body_len) + "\r\n" + "Connection: close\r\n" + 'Etag: "872104f4-d6bcaa1e6f979"\r\n' +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": slice_body
+}
+
+slice_reval_req = {
+    "headers": "GET /slice HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "UID: SLICE-INM\r\n"
+               "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+
+slice_reval_resp = {
+    "headers":
+        "HTTP/1.1 304 Not Modified\r\n" + "Cache-Control: max-age=10\r\n" + "Connection: close\r\n" +
+        'Etag: "872104f4-d6bcaa1e6f979"\r\n' + "\r\n",
+    "timestamp": "1469733493.993"
+}
+
+naieve_req = {
+    "headers": "GET /naieve/obj HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "UID: NAIEVE\r\n"
+               "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+
+naieve_resp = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" + 'Etag: "cad04ff4-56f4bc197ceda"\r\n' +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": small_body
+}
+
+naieve_reval_req = {
+    "headers": "GET /naieve/obj HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "UID: NAIEVE-INM\r\n"
+               "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+
+naieve_reval_resp = {
+    "headers":
+        "HTTP/1.1 304 Not Modified\r\n" + "Cache-Control: max-age=10\r\n" + "Connection: close\r\n" +
+        'Etag: "cad04ff4-56f4bc197ceda"\r\n' + "\r\n",
+    "timestamp": "1469733493.993"
+}
 
 server.addResponse("sessionlog.json", small_req, small_resp)
 server.addResponse("sessionlog.json", small_reval_req, small_reval_resp)
@@ -210,27 +171,29 @@ server.addResponse("sessionlog.json", naieve_reval_req, naieve_reval_resp)
 # remap with the cache range requests plugin only
 # this is a "naieve" configuration due to the lack of range normalization performed at remap time by slice
 # this config should only be used if ranges have been reliably normalized by the requestor (either the client itself or a cache)
-ts.Disk.remap_config.AddLines([
-    f'map http://example.com/naieve http://127.0.0.1:{server.Variables.Port}/naieve \\' +
-    ' @plugin=cache_range_requests.so @pparam=--cache-complete-responses',
-])
+ts.Disk.remap_config.AddLines(
+    [
+        f'map http://example.com/naieve http://127.0.0.1:{server.Variables.Port}/naieve \\' +
+        ' @plugin=cache_range_requests.so @pparam=--cache-complete-responses',
+    ])
 
 # remap with slice, cachekey, and the cache range requests plugin to ensure range normalization and cache keys are correct
-ts.Disk.remap_config.AddLines([
-    f'map http://example.com http://127.0.0.1:{server.Variables.Port} \\' +
-    ' @plugin=slice.so @pparam=--blockbytes=4m \\',
-    ' @plugin=cachekey.so @pparam=--key-type=cache_key @pparam=--include-headers=Range @pparam=--remove-all-params=true \\',
-    ' @plugin=cache_range_requests.so @pparam=--no-modify-cachekey @pparam=--cache-complete-responses',
-])
+ts.Disk.remap_config.AddLines(
+    [
+        f'map http://example.com http://127.0.0.1:{server.Variables.Port} \\' + ' @plugin=slice.so @pparam=--blockbytes=4m \\',
+        ' @plugin=cachekey.so @pparam=--key-type=cache_key @pparam=--include-headers=Range @pparam=--remove-all-params=true \\',
+        ' @plugin=cache_range_requests.so @pparam=--no-modify-cachekey @pparam=--cache-complete-responses',
+    ])
 
 # cache debug
 ts.Disk.plugin_config.AddLine('xdebug.so')
 
 # enable debug
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cachekey|cache_range_requests|slice',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cachekey|cache_range_requests|slice',
+    })
 
 # base cURL command
 curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} -H "x-debug: x-cache, x-cache-key"'.format(ts.Variables.port)
@@ -250,8 +213,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss, none", "expected cache miss")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # 1 Test - Fetch /obj with a different range but less than 4MB
@@ -263,8 +225,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh, none", "expected cache hit")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # 2 Test - Revalidate /obj with a different range but less than 4MB
@@ -277,8 +238,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-stale, none", "expected cache hit stale")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # 3 Test - Fetch /obj with a different range but less than 4MB
@@ -290,8 +250,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh, none", "expected cache hit-fresh")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/obj", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # Test round 2: repeat, but ensure we have 206s and matching Content-Range
@@ -304,12 +263,10 @@ ps.Command = curl_and_args + ' -H "UID: SLICE" http://example.com/slice -r 0-500
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 Partial Content")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "Content-Range: bytes 0-5000/8388608",
-    "expected Content-Range: bytes 0-5000/8388608")
+    "Content-Range: bytes 0-5000/8388608", "expected Content-Range: bytes 0-5000/8388608")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss, none", "expected cache miss")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # 5 Test - Fetch /slice with a different range but less than 4MB
@@ -319,12 +276,10 @@ ps.Command = curl_and_args + ' -H "UID: SLICE" http://example.com/slice -r 5001-
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 Partial Content")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "Content-Range: bytes 5001-5999/8388608",
-    "expected Content-Range: bytes 5001-5999/8388608")
+    "Content-Range: bytes 5001-5999/8388608", "expected Content-Range: bytes 5001-5999/8388608")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh, none", "expected cache hit")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # 6 Test - Revalidate /slice with a different range but less than 4MB
@@ -335,12 +290,10 @@ ps.Command = curl_and_args + ' -H "UID: SLICE-INM" http://example.com/slice -r 0
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 Partial Content")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "Content-Range: bytes 0-403/8388608",
-    "expected Content-Range: bytes 0-403/8388608")
+    "Content-Range: bytes 0-403/8388608", "expected Content-Range: bytes 0-403/8388608")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-stale, none", "expected cache hit stale")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # 7 Test - Fetch /slice with a different range but less than 4MB
@@ -350,12 +303,10 @@ ps.Command = curl_and_args + ' -H "UID: SLICE" http://example.com/slice -r 0-399
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("206 Partial Content", "expected 206 Partial Content")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "Content-Range: bytes 0-3999/8388608",
-    "expected Content-Range: bytes 0-3999/8388608")
+    "Content-Range: bytes 0-3999/8388608", "expected Content-Range: bytes 0-3999/8388608")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh, none", "expected cache hit-fresh")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice",
-    "expected cache key with bytes 0-4194303")
+    "X-Cache-Key: /.*?/Range:bytes=0-4194303/slice", "expected cache key with bytes 0-4194303")
 tr.StillRunningAfter = ts
 
 # Test round 3: test behavior of the cache range requests plugin when caching complete ranges *without* the slice and cachekey plugins
@@ -372,8 +323,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000",
-    "expected cache key with bytes 0-5000")
+    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000", "expected cache key with bytes 0-5000")
 tr.StillRunningAfter = ts
 
 # 9 Test - Fetch /naieve/obj with the same Range header
@@ -385,8 +335,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000",
-    "expected cache key with bytes 0-5000")
+    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000", "expected cache key with bytes 0-5000")
 tr.StillRunningAfter = ts
 
 # 10 Test - Revalidate /naieve/obj with the same Range header
@@ -399,8 +348,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-stale", "expected cache hit stale")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000",
-    "expected cache key with bytes 0-5000")
+    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000", "expected cache key with bytes 0-5000")
 tr.StillRunningAfter = ts
 
 # 11 Test - Fetch /naieve/obj with the same Range header
@@ -412,8 +360,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit-fresh")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000",
-    "expected cache key with bytes 0-5000")
+    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000", "expected cache key with bytes 0-5000")
 tr.StillRunningAfter = ts
 
 # 12 Test - Fetch /naieve/obj with a *different* Range header; note the cache key changes and is a miss for the same object
@@ -425,8 +372,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: http://.*?/naieve/obj-bytes=444-777",
-    "expected cache key with bytes 444-777")
+    "X-Cache-Key: http://.*?/naieve/obj-bytes=444-777", "expected cache key with bytes 444-777")
 tr.StillRunningAfter = ts
 
 # 13 Test - Fetch /naieve/obj with the prior Range header; now a cache hit but we've effectively cached /naieve/obj twice
@@ -439,8 +385,7 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit-fresh")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: http://.*?/naieve/obj-bytes=444-777",
-    "expected cache key with bytes 444-777")
+    "X-Cache-Key: http://.*?/naieve/obj-bytes=444-777", "expected cache key with bytes 444-777")
 tr.StillRunningAfter = ts
 
 # 14 Test - Fetch /naieve/obj with the original Range header (0-5000); still a cache hit
@@ -452,6 +397,5 @@ ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 O
 ps.Streams.stdout.Content = Testers.ExcludesExpression("Content-Range:", "expected no Content-Range header")
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit-fresh")
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000",
-    "expected cache key with bytes 0-5000")
+    "X-Cache-Key: http://.*?/naieve/obj-bytes=0-5000", "expected cache key with bytes 0-5000")
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey.test.py
@@ -40,22 +40,13 @@ ts = Test.MakeATSProcess("ts", command="traffic_server")
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")
 
 # default root
-req_chk = {"headers":
-           "GET / HTTP/1.1\r\n" +
-           "Host: www.example.com\r\n" +
-           "uuid: none\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_chk = {"headers":
-           "HTTP/1.1 200 OK\r\n" +
-           "Connection: close\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionlog.json", req_chk, res_chk)
 
@@ -63,94 +54,71 @@ body = "lets go surfin now"
 bodylen = len(body)
 
 # this request should work
-req_full = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "Accept: */*\r\n" +
-            "uuid: full\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_full = {
+    "headers": "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "uuid: full\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_full = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            'Etag: "foo"\r\n' +
-            "Cache-Control: public, max-age=500\r\n" +
-            "Connection: close\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_full = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + 'Etag: "foo"\r\n' +
+        "Cache-Control: public, max-age=500\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_full, res_full)
 
 # this request should work
-req_good = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "Accept: */*\r\n" +
-            "Range: bytes=0-\r\n" +
-            "uuid: range_full\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_good = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "Range: bytes=0-\r\n" +
+        "uuid: range_full\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_good = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            'Etag: "foo"\r\n' +
-            "Cache-Control: public, max-age=500\r\n" +
-            "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
-            "Connection: close\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_good = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + 'Etag: "foo"\r\n' +
+        "Cache-Control: public, max-age=500\r\n" + "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) + "Connection: close\r\n" +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_good, res_good)
 
 # this request should fail with a cache_range_requests asset
-req_fail = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.fail.com\r\n" +
-            "Accept: */*\r\n" +
-            "Range: bytes=0-\r\n" +
-            "uuid: range_fail\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_fail = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: www.fail.com\r\n" + "Accept: */*\r\n" + "Range: bytes=0-\r\n" + "uuid: range_fail\r\n" +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_fail = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            'Etag: "foo"\r\n' +
-            "Cache-Control: public, max-age=500\r\n" +
-            "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
-            "Connection: close\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_fail = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + 'Etag: "foo"\r\n' +
+        "Cache-Control: public, max-age=500\r\n" + "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) + "Connection: close\r\n" +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_fail, res_fail)
 
 # cache range requests plugin remap, working config
 ts.Disk.remap_config.AddLine(
     'map http://www.example.com http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=cachekey.so @pparam=--include-headers=Range' +
-    ' @plugin=cache_range_requests.so @pparam=--no-modify-cachekey',
-)
+    ' @plugin=cachekey.so @pparam=--include-headers=Range' + ' @plugin=cache_range_requests.so @pparam=--no-modify-cachekey',)
 
 # improperly configured cache_range_requests with cachekey
 ts.Disk.remap_config.AddLine(
-    'map http://www.fail.com http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=cachekey.so @pparam=--static-prefix=foo'
-    ' @plugin=cache_range_requests.so',
-)
+    'map http://www.fail.com http://127.0.0.1:{}'.format(server.Variables.Port) + ' @plugin=cachekey.so @pparam=--static-prefix=foo'
+    ' @plugin=cache_range_requests.so',)
 
 # cache debug
 ts.Disk.plugin_config.AddLine('xdebug.so')

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey_global.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_cachekey_global.test.py
@@ -40,22 +40,13 @@ ts = Test.MakeATSProcess("ts", command="traffic_server")
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")
 
 # default root
-req_chk = {"headers":
-           "GET / HTTP/1.1\r\n" +
-           "Host: www.example.com\r\n" +
-           "uuid: none\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_chk = {"headers":
-           "HTTP/1.1 200 OK\r\n" +
-           "Connection: close\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionlog.json", req_chk, res_chk)
 
@@ -63,103 +54,82 @@ body = "lets go surfin now"
 bodylen = len(body)
 
 # this request should work
-req_full = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "Accept: */*\r\n" +
-            "uuid: full\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_full = {
+    "headers": "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "uuid: full\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_full = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            'Etag: "foo"\r\n' +
-            "Cache-Control: public, max-age=500\r\n" +
-            "Connection: close\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_full = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + 'Etag: "foo"\r\n' +
+        "Cache-Control: public, max-age=500\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_full, res_full)
 
 # this request should work
-req_good = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "Accept: */*\r\n" +
-            "Range: bytes=0-\r\n" +
-            "uuid: range_full\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_good = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "Range: bytes=0-\r\n" +
+        "uuid: range_full\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_good = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            'Etag: "foo"\r\n' +
-            "Cache-Control: public, max-age=500\r\n" +
-            "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
-            "Connection: close\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_good = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + 'Etag: "foo"\r\n' +
+        "Cache-Control: public, max-age=500\r\n" + "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) + "Connection: close\r\n" +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_good, res_good)
 
 # this request should fail with a cache_range_requests asset
-req_fail = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.fail.com\r\n" +
-            "Accept: */*\r\n" +
-            "Range: bytes=0-\r\n" +
-            "uuid: range_fail\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_fail = {
+    "headers":
+        "GET /path HTTP/1.1\r\n" + "Host: www.fail.com\r\n" + "Accept: */*\r\n" + "Range: bytes=0-\r\n" + "uuid: range_fail\r\n" +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_fail = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            'Etag: "foo"\r\n' +
-            "Cache-Control: public, max-age=500\r\n" +
-            "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
-            "Connection: close\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_fail = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + 'Etag: "foo"\r\n' +
+        "Cache-Control: public, max-age=500\r\n" + "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) + "Connection: close\r\n" +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_fail, res_fail)
 
 # cache range requests plugin remap, working config
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{}'.format(server.Variables.Port))
 
 # improperly configured cache_range_requests with cachekey
-ts.Disk.remap_config.AddLine(
-    'map http://www.fail.com http://127.0.0.1:{}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://www.fail.com http://127.0.0.1:{}'.format(server.Variables.Port))
 
 # cache debug
-ts.Disk.plugin_config.AddLines([
-    'cachekey.so --include-headers=Range --static-prefix=foo',
-    'cache_range_requests.so --no-modify-cachekey',
-    'xdebug.so',
-])
+ts.Disk.plugin_config.AddLines(
+    [
+        'cachekey.so --include-headers=Range --static-prefix=foo',
+        'cache_range_requests.so --no-modify-cachekey',
+        'xdebug.so',
+    ])
 
 # minimal configuration
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cachekey|cache_range_requests',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cachekey|cache_range_requests',
+    })
 
 curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} -H "x-debug: x-cache-key"'.format(ts.Variables.port)
 
@@ -171,6 +141,5 @@ ps.StartBefore(Test.Processes.ts)
 ps.Command = curl_and_args + ' http://www.example.com/path -r0- -H "uuid: full"'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression(
-    "X-Cache-Key: /foo/Range:bytes=0-/path",
-    "expected cachekey style range request in cachekey")
+    "X-Cache-Key: /foo/Range:bytes=0-/path", "expected cachekey style range request in cachekey")
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ims.test.py
@@ -41,60 +41,43 @@ ts = Test.MakeATSProcess("ts", command="traffic_server")
 server = Test.MakeOriginServer("server")
 
 # default root
-req_chk = {"headers":
-           "GET / HTTP/1.1\r\n" +
-           "Host: www.example.com\r\n" +
-           "uuid: none\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_chk = {"headers":
-           "HTTP/1.1 200 OK\r\n" +
-           "Connection: close\r\n" +
-           "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionlog.json", req_chk, res_chk)
 
 body = "lets go surfin now"
 bodylen = len(body)
 
-req_full = {"headers":
-            "GET /path HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "Accept: */*\r\n" +
-            "Range: bytes=0-\r\n" +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
-            }
+req_full = {
+    "headers": "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "Range: bytes=0-\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-res_full = {"headers":
-            "HTTP/1.1 206 Partial Content\r\n" +
-            "Accept-Ranges: bytes\r\n" +
-            "Cache-Control: max-age=500\r\n" +
-            "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) +
-            "Connection: close\r\n" +
-            'Etag: "772102f4-56f4bc1e6d417"\r\n' +
-            "\r\n",
-            "timestamp": "1469733493.993",
-            "body": body
-            }
+res_full = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=500\r\n" +
+        "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) + "Connection: close\r\n" + 'Etag: "772102f4-56f4bc1e6d417"\r\n' +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
 
 server.addResponse("sessionlog.json", req_full, res_full)
 
 # cache range requests plugin remap
-ts.Disk.remap_config.AddLines([
-    f'map http://ims http://127.0.0.1:{server.Variables.Port}' +
-    ' @plugin=cache_range_requests.so @pparam=--consider-ims',
-    f'map http://imsheader http://127.0.0.1:{server.Variables.Port}' +
-    ' @plugin=cache_range_requests.so @pparam=--consider-ims' +
-    ' @pparam=--ims-header=CrrIms',
-])
+ts.Disk.remap_config.AddLines(
+    [
+        f'map http://ims http://127.0.0.1:{server.Variables.Port}' + ' @plugin=cache_range_requests.so @pparam=--consider-ims',
+        f'map http://imsheader http://127.0.0.1:{server.Variables.Port}' +
+        ' @plugin=cache_range_requests.so @pparam=--consider-ims' + ' @pparam=--ims-header=CrrIms',
+    ])
 
 # cache debug
 ts.Disk.plugin_config.AddLine('xdebug.so')
@@ -116,7 +99,6 @@ ps.Command = curl_and_args + ' http://ims/path -r 0-'
 ps.ReturnCode = 0
 ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss for load")
 tr.StillRunningAfter = ts
-
 
 # test inner range
 # 1 Test - Fetch range into cache

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -63,7 +63,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 
 ts.Disk.remap_config.AddLines([
     'map https://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port),
-    'map https://foo.com https://127.0.0.1:{0}'.format(ts.Variables.s_server_port)
+    'map https://foo.com https://127.0.0.1:{0}'.format(ts.Variables.s_server_port),
 ])
 
 ts.Disk.sni_yaml.AddLines([

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -25,13 +25,11 @@ Test cert_update plugin.
 
 Test.SkipUnless(
     Condition.HasProgram("openssl", "Openssl need to be installed on system for this test to work"),
-    Condition.PluginExists('cert_update.so')
-)
+    Condition.PluginExists('cert_update.so'))
 
 # Set up origin server
 server = Test.MakeOriginServer("server")
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
@@ -47,24 +45,24 @@ ts.addSSLfile("ssl/client2.pem")
 # reserve port, attach it to 'ts' so it is released later
 ports.get_port(ts, 's_server_port')
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cert_update',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cert_update',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server1.pem ssl_key_name=server1.pem'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server1.pem ssl_key_name=server1.pem')
 
-ts.Disk.remap_config.AddLines([
-    'map https://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port),
-    'map https://foo.com https://127.0.0.1:{0}'.format(ts.Variables.s_server_port),
-])
+ts.Disk.remap_config.AddLines(
+    [
+        'map https://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port),
+        'map https://foo.com https://127.0.0.1:{0}'.format(ts.Variables.s_server_port),
+    ])
 
 ts.Disk.sni_yaml.AddLines([
     'sni:',
@@ -81,8 +79,7 @@ tr = Test.AddTestRun("Server-Cert-Pre")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Command = (
-    'curl --verbose --insecure --ipv4 --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}'.format(ts.Variables.ssl_port)
-)
+    'curl --verbose --insecure --ipv4 --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}'.format(ts.Variables.ssl_port))
 tr.Processes.Default.Streams.stderr = "gold/server-cert-pre.gold"
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
@@ -91,8 +88,7 @@ tr.StillRunningAfter = server
 tr = Test.AddTestRun("Server-Cert-Update")
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = (
-    '{0}/traffic_ctl plugin msg cert_update.server {1}/server2.pem'.format(ts.Variables.BINDIR, ts.Variables.SSLDir)
-)
+    '{0}/traffic_ctl plugin msg cert_update.server {1}/server2.pem'.format(ts.Variables.BINDIR, ts.Variables.SSLDir))
 ts.Disk.traffic_out.Content = "gold/update.gold"
 ts.StillRunningAfter = server
 
@@ -109,10 +105,8 @@ ts.StillRunningAfter = server
 # s_server should see client (Traffic Server) as alice.com
 tr = Test.AddTestRun("Client-Cert-Pre")
 s_server = tr.Processes.Process(
-    "s_server",
-    "openssl s_server -www -key {0}/server1.pem -cert {0}/server1.pem -accept {1} -Verify 1 -msg".format(
-        ts.Variables.SSLDir,
-        ts.Variables.s_server_port))
+    "s_server", "openssl s_server -www -key {0}/server1.pem -cert {0}/server1.pem -accept {1} -Verify 1 -msg".format(
+        ts.Variables.SSLDir, ts.Variables.s_server_port))
 s_server.Ready = When.PortReady(ts.Variables.s_server_port)
 tr.Command = 'curl --verbose --insecure --ipv4 --header "Host: foo.com" https://localhost:{}'.format(ts.Variables.ssl_port)
 tr.Processes.Default.StartBefore(s_server)
@@ -125,8 +119,7 @@ tr = Test.AddTestRun("Client-Cert-Update")
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = (
     'mv {0}/client2.pem {0}/client1.pem && {1}/traffic_ctl plugin msg cert_update.client {0}/client1.pem'.format(
-        ts.Variables.SSLDir, ts.Variables.BINDIR)
-)
+        ts.Variables.SSLDir, ts.Variables.BINDIR))
 ts.Disk.traffic_out.Content = "gold/update.gold"
 ts.StillRunningAfter = server
 
@@ -134,10 +127,8 @@ ts.StillRunningAfter = server
 # after use traffic_ctl to update client cert, s_server should see client (Traffic Server) as bob.com
 tr = Test.AddTestRun("Client-Cert-After")
 s_server = tr.Processes.Process(
-    "s_server",
-    "openssl s_server -www -key {0}/server1.pem -cert {0}/server1.pem -accept {1} -Verify 1 -msg".format(
-        ts.Variables.SSLDir,
-        ts.Variables.s_server_port))
+    "s_server", "openssl s_server -www -key {0}/server1.pem -cert {0}/server1.pem -accept {1} -Verify 1 -msg".format(
+        ts.Variables.SSLDir, ts.Variables.s_server_port))
 s_server.Ready = When.PortReady(ts.Variables.s_server_port)
 tr.Processes.Default.Env = ts.Env
 # Move client2.pem to replace client1.pem since cert path matters in client context mapping

--- a/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
+++ b/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
@@ -17,7 +17,6 @@ Test the client_context_dump plugin.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 Test.Summary = '''
 Test client_context_dump plugin
 '''
@@ -31,26 +30,26 @@ ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True, ena
 ts.addSSLfile("ssl/one.com.pem")
 ts.addSSLfile("ssl/two.com.pem")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'client_context_dump',
-    'proxy.config.ssl.server.cert.path': '{}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.cert.path': '{}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.private_key.path': '{}'.format(ts.Variables.SSLDir),
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'client_context_dump',
+        'proxy.config.ssl.server.cert.path': '{}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.cert.path': '{}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.private_key.path': '{}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=one.com.pem ssl_key_name=one.com.pem'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=one.com.pem ssl_key_name=one.com.pem')
 
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: "*one.com"',
-    '  client_cert: "one.com.pem"',
-    '- fqdn: "*two.com"',
-    '  client_cert: "two.com.pem"',
-])
+ts.Disk.sni_yaml.AddLines(
+    [
+        'sni:',
+        '- fqdn: "*one.com"',
+        '  client_cert: "one.com.pem"',
+        '- fqdn: "*two.com"',
+        '  client_cert: "two.com.pem"',
+    ])
 
 # Set up plugin
 Test.PrepareInstalledPlugin('client_context_dump.so', ts)
@@ -72,7 +71,5 @@ p.StartBefore(Test.Processes.ts)
 # Client contexts test
 tr = Test.AddTestRun()
 tr.Processes.Default.Env = ts.Env
-tr.Processes.Default.Command = (
-    '{0}/traffic_ctl plugin msg client_context_dump.t 1'.format(ts.Variables.BINDIR)
-)
+tr.Processes.Default.Command = ('{0}/traffic_ctl plugin msg client_context_dump.t 1'.format(ts.Variables.BINDIR))
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
+++ b/tests/gold_tests/pluginTest/client_context_dump/client_context_dump.test.py
@@ -49,7 +49,7 @@ ts.Disk.sni_yaml.AddLines([
     '- fqdn: "*one.com"',
     '  client_cert: "one.com.pem"',
     '- fqdn: "*two.com"',
-    '  client_cert: "two.com.pem"'
+    '  client_cert: "two.com.pem"',
 ])
 
 # Set up plugin

--- a/tests/gold_tests/pluginTest/combo_handler/combo_handler.test.py
+++ b/tests/gold_tests/pluginTest/combo_handler/combo_handler.test.py
@@ -25,9 +25,7 @@ Test combo_handler plugin
 
 # Skip if plugin not present.
 #
-Test.SkipUnless(
-    Condition.PluginExists('combo_handler.so'),
-)
+Test.SkipUnless(Condition.PluginExists('combo_handler.so'),)
 
 # Function to generate a unique data file path (in the top level of the test's run directory),  put data (in string 'data') into
 # the file, and return the file name.
@@ -43,12 +41,14 @@ def data_file(data):
         f.write(data)
     return file_path
 
+
 # Function to return command (string) to run tcp_client.py tool.  'host' 'port', and 'file_path' are the parameters to tcp_client.
 #
 
 
 def tcp_client_cmd(host, port, file_path):
     return f"{sys.executable} {Test.Variables.AtsTestToolsDir}/tcp_client.py {host} {port} {file_path}"
+
 
 # Function to return command (string) to run tcp_client.py tool.  'host' and 'port' are the first two parameters to tcp_client.
 # 'data' is the data to put in the data file input to tcp_client.
@@ -64,19 +64,15 @@ server = Test.MakeOriginServer("server")
 
 def add_server_obj(content_type, path):
     request_header = {
-        "headers": "GET " + path + " HTTP/1.1\r\n" +
-        "Host: just.any.thing\r\n\r\n",
+        "headers": "GET " + path + " HTTP/1.1\r\n" + "Host: just.any.thing\r\n\r\n",
         "timestamp": "1469733493.993",
         "body": ""
     }
     response_header = {
-        "headers": "HTTP/1.1 200 OK\r\n" +
-        "Connection: close\r\n" +
-        'Etag: "359670651"\r\n' +
-        "Cache-Control: public, max-age=31536000\r\n" +
-        "Accept-Ranges: bytes\r\n" +
-        "Content-Type: " + content_type + "\r\n" +
-        "\r\n",
+        "headers":
+            "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + 'Etag: "359670651"\r\n' +
+            "Cache-Control: public, max-age=31536000\r\n" + "Accept-Ranges: bytes\r\n" + "Content-Type: " + content_type + "\r\n" +
+            "\r\n",
         "timestamp": "1469733493.993",
         "body": "Content for " + path + "\n"
     }
@@ -97,15 +93,9 @@ ts.Disk.records_config.update({
 
 ts.Disk.plugin_config.AddLine("combo_handler.so - - - ctwl.txt")
 
-ts.Disk.remap_config.AddLine(
-    'map http://xyz/ http://127.0.0.1/ @plugin=combo_handler.so'
-)
-ts.Disk.remap_config.AddLine(
-    f'map http://localhost/127.0.0.1/ http://127.0.0.1:{server.Variables.Port}/'
-)
-ts.Disk.remap_config.AddLine(
-    f'map http://localhost/sub/ http://127.0.0.1:{server.Variables.Port}/sub/'
-)
+ts.Disk.remap_config.AddLine('map http://xyz/ http://127.0.0.1/ @plugin=combo_handler.so')
+ts.Disk.remap_config.AddLine(f'map http://localhost/127.0.0.1/ http://127.0.0.1:{server.Variables.Port}/')
+ts.Disk.remap_config.AddLine(f'map http://localhost/sub/ http://127.0.0.1:{server.Variables.Port}/sub/')
 
 # Configure the combo_handler's configuration file.
 ts.Setup.Copy("ctwl.txt", ts.Variables.CONFIGDIR)
@@ -117,23 +107,17 @@ tr.Processes.Default.Command = "echo start stuff"
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = tcp_client("127.0.0.1", ts.Variables.port,
-                                          "GET /admin/v1/combo?obj1&sub:obj2&obj3 HTTP/1.1\n" +
-                                          "Host: xyz\n" +
-                                          "Connection: close\n" +
-                                          "\n"
-                                          )
+tr.Processes.Default.Command = tcp_client(
+    "127.0.0.1", ts.Variables.port,
+    "GET /admin/v1/combo?obj1&sub:obj2&obj3 HTTP/1.1\n" + "Host: xyz\n" + "Connection: close\n" + "\n")
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File("_output/1-tr-Default/stream.all.txt")
 f.Content = "combo_handler_files/tr1.gold"
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = tcp_client("127.0.0.1", ts.Variables.port,
-                                          "GET /admin/v1/combo?obj1&sub:obj2&obj4 HTTP/1.1\n" +
-                                          "Host: xyz\n" +
-                                          "Connection: close\n" +
-                                          "\n"
-                                          )
+tr.Processes.Default.Command = tcp_client(
+    "127.0.0.1", ts.Variables.port,
+    "GET /admin/v1/combo?obj1&sub:obj2&obj4 HTTP/1.1\n" + "Host: xyz\n" + "Connection: close\n" + "\n")
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File("_output/2-tr-Default/stream.all.txt")
 f.Content = "combo_handler_files/tr2.gold"

--- a/tests/gold_tests/pluginTest/compress/compress.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress.test.py
@@ -25,10 +25,7 @@ Test compress plugin
 # Skip if plugins not present.
 #
 Test.SkipUnless(
-    Condition.PluginExists('compress.so'),
-    Condition.PluginExists('conf_remap.so'),
-    Condition.HasATSFeature('TS_HAS_BROTLI')
-)
+    Condition.PluginExists('compress.so'), Condition.PluginExists('conf_remap.so'), Condition.HasATSFeature('TS_HAS_BROTLI'))
 
 server = Test.MakeOriginServer("server", options={'--load': '{}/compress_observer.py'.format(Test.TestDirectory)})
 
@@ -47,28 +44,28 @@ body = body + "lets go surfin now everybodys learnin how"
 
 # expected response from the origin server
 response_header = {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n" +
-    'Etag: "359670651"\r\n' +
-    "Cache-Control: public, max-age=31536000\r\n" +
-    "Accept-Ranges: bytes\r\n" +
-    "Content-Type: text/javascript\r\n" +
-    "\r\n",
+    "headers":
+        "HTTP/1.1 200 OK\r\nConnection: close\r\n" + 'Etag: "359670651"\r\n' + "Cache-Control: public, max-age=31536000\r\n" +
+        "Accept-Ranges: bytes\r\n" + "Content-Type: text/javascript\r\n" + "\r\n",
     "timestamp": "1469733493.993",
     "body": body
 }
 for i in range(3):
     # add request/response to the server dictionary
     request_header = {
-        "headers": "GET /obj{} HTTP/1.1\r\nHost: just.any.thing\r\n\r\n".format(i), "timestamp": "1469733493.993", "body": ""
+        "headers": "GET /obj{} HTTP/1.1\r\nHost: just.any.thing\r\n\r\n".format(i),
+        "timestamp": "1469733493.993",
+        "body": ""
     }
     server.addResponse("sessionfile.log", request_header, response_header)
 
-
 # post for the origin server
 post_request_header = {
-    "headers": "POST /obj3 HTTP/1.1\r\nHost: just.any.thing\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 11\r\n\r\n",
+    "headers":
+        "POST /obj3 HTTP/1.1\r\nHost: just.any.thing\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 11\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": "knock knock"}
+    "body": "knock knock"
+}
 server.addResponse("sessionfile.log", post_request_header, response_header)
 
 
@@ -77,8 +74,7 @@ def curl(ts, idx, encodingList):
         "curl --verbose --proxy http://127.0.0.1:{}".format(ts.Variables.port) +
         " --header 'X-Ats-Compress-Test: {}/{}'".format(idx, encodingList) +
         " --header 'Accept-Encoding: {0}' 'http://ae-{1}/obj{1}'".format(encodingList, idx) +
-        " 2>> compress_long.log ; printf '\n===\n' >> compress_long.log"
-    )
+        " 2>> compress_long.log ; printf '\n===\n' >> compress_long.log")
 
 
 def curl_post(ts, idx, encodingList):
@@ -86,8 +82,7 @@ def curl_post(ts, idx, encodingList):
         "curl --verbose -d 'knock knock' --proxy http://127.0.0.1:{}".format(ts.Variables.port) +
         " --header 'X-Ats-Compress-Test: {}/{}'".format(idx, encodingList) +
         " --header 'Accept-Encoding: {0}' 'http://ae-{1}/obj{1}'".format(encodingList, idx) +
-        " 2>> compress_long.log ; printf '\n===\n' >> compress_long.log"
-    )
+        " 2>> compress_long.log ; printf '\n===\n' >> compress_long.log")
 
 
 waitForServer = True
@@ -96,33 +91,30 @@ waitForTs = True
 
 ts = Test.MakeATSProcess("ts", enable_cache=False)
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'compress',
-    'proxy.config.http.normalize_ae': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'compress',
+        'proxy.config.http.normalize_ae': 0,
+    })
 
 ts.Setup.Copy("compress.config")
 ts.Setup.Copy("compress2.config")
 
 ts.Disk.remap_config.AddLine(
     'map http://ae-0/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory)
-)
+    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory))
 ts.Disk.remap_config.AddLine(
     'map http://ae-1/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
     ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=1' +
-    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory)
-)
+    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory))
 ts.Disk.remap_config.AddLine(
     'map http://ae-2/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
     ' @plugin=conf_remap.so @pparam=proxy.config.http.normalize_ae=2' +
-    ' @plugin=compress.so @pparam={}/compress2.config'.format(Test.RunDirectory)
-)
+    ' @plugin=compress.so @pparam={}/compress2.config'.format(Test.RunDirectory))
 ts.Disk.remap_config.AddLine(
     'map http://ae-3/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory)
-)
+    ' @plugin=compress.so @pparam={}/compress.config'.format(Test.RunDirectory))
 
 for i in range(3):
 
@@ -199,8 +191,8 @@ tr.Processes.Default.Command = curl_post(ts, 3, "gzip")
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    r"tr -d '\r' < compress_long.log | sed 's/\(..*\)\([<>]\)/\1\n\2/' | {0}/greplog.sh > compress_short.log"
-).format(Test.TestDirectory)
+    r"tr -d '\r' < compress_long.log | sed 's/\(..*\)\([<>]\)/\1\n\2/' | {0}/greplog.sh > compress_short.log").format(
+        Test.TestDirectory)
 f = tr.Disk.File("compress_short.log")
 f.Content = "compress.gold"
 

--- a/tests/gold_tests/pluginTest/cookie_remap/bucketcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/bucketcookie.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/bucketconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/bucketconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/bucketconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/bucketconfig.txt')
 
 # Cookie value in bucket
 tr = Test.AddTestRun("cookie value in bucket")

--- a/tests/gold_tests/pluginTest/cookie_remap/collapseslashes.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/collapseslashes.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # and verify it collapsed the double //
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /i/like/cheetos?.done=http://finance.yahoo.com HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /i/like/cheetos?.done=http://finance.yahoo.com HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -44,10 +48,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/collapseconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
@@ -55,8 +60,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/collapseconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/collapseconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/collapseconfig.txt')
 
 tr = Test.AddTestRun("collapse consecutive forward slashes")
 tr.Processes.Default.Command = '''

--- a/tests/gold_tests/pluginTest/cookie_remap/connector.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/connector.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/connectorconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/connectorconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/connectorconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/connectorconfig.txt')
 
 # Positive test case that remaps because all connected operations pass
 tr = Test.AddTestRun("cookie value matches")

--- a/tests/gold_tests/pluginTest/cookie_remap/existscookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/existscookie.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /cookieexists HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /cookieexists HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /cookiedoesntexist HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /cookiedoesntexist HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/existsconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/existsconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/existsconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/existsconfig.txt')
 
 # Positive test case that remaps because cookie exists
 tr = Test.AddTestRun("cookie fpbeta exists")

--- a/tests/gold_tests/pluginTest/cookie_remap/matchcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matchcookie.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /cookiematches?a=1&b=2&c=3 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /cookiematches?a=1&b=2&c=3 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /cookiedoesntmatch?a=1&b=2&c=3 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /cookiedoesntmatch?a=1&b=2&c=3 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/matchconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/matchconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/matchconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/matchconfig.txt')
 
 # Positive test case that remaps because cookie matches
 tr = Test.AddTestRun("cookie value matches")

--- a/tests/gold_tests/pluginTest/cookie_remap/matchuri.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matchuri.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/matchuriconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/matchuriconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/matchuriconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/matchuriconfig.txt')
 
 # Positive test case, URI matches rule
 tr = Test.AddTestRun("URI value matches")

--- a/tests/gold_tests/pluginTest/cookie_remap/matrixparams.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/matrixparams.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -32,26 +33,38 @@ ts = Test.MakeATSProcess("ts")
 # That's why I am not adding any canned request/response
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /eighth/magic;matrix=1/eighth HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /eighth/magic;matrix=1/eighth HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header, response_header)
 
-request_header_2 = {"headers": "GET /eighth/magic;matrix=1/eighth?hello=10 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": ""}
+request_header_2 = {
+    "headers": "GET /eighth/magic;matrix=1/eighth?hello=10 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header_2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header_2, response_header_2)
 
-request_header_3 = {"headers": "GET /tenth/magic/tenth;matrix=2 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": ""}
+request_header_3 = {
+    "headers": "GET /tenth/magic/tenth;matrix=2 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header_3 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header_3, response_header_3)
 
-request_header_4 = {"headers": "GET /tenth/magic/tenth;matrix=2?query=10 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": ""}
+request_header_4 = {
+    "headers": "GET /tenth/magic/tenth;matrix=2?query=10 HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header_4 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header_4, response_header_4)
@@ -59,7 +72,8 @@ server.addResponse("sessionfile.log", request_header_4, response_header_4)
 request_header_5 = {
     "headers": "GET /eleventh/magic;matrix=4/eleventh;matrix=2?query=true HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": ""}
+    "body": ""
+}
 response_header_5 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header_5, response_header_5)
@@ -69,10 +83,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/matrixconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
@@ -80,17 +95,13 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/matrixconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/eighth http://shouldnothit.com/eighth @plugin=cookie_remap.so @pparam=config/matrixconfig.txt'
-)
+    'map http://www.example.com/eighth http://shouldnothit.com/eighth @plugin=cookie_remap.so @pparam=config/matrixconfig.txt')
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/ninth http://shouldnothit.com/ninth @plugin=cookie_remap.so @pparam=config/matrixconfig.txt'
-)
+    'map http://www.example.com/ninth http://shouldnothit.com/ninth @plugin=cookie_remap.so @pparam=config/matrixconfig.txt')
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/tenth http://shouldnothit.com/tenth @plugin=cookie_remap.so @pparam=config/matrixconfig.txt'
-)
+    'map http://www.example.com/tenth http://shouldnothit.com/tenth @plugin=cookie_remap.so @pparam=config/matrixconfig.txt')
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/eleventh http://shouldnothit.com/eleventh @plugin=cookie_remap.so @pparam=config/matrixconfig.txt'
-)
+    'map http://www.example.com/eleventh http://shouldnothit.com/eleventh @plugin=cookie_remap.so @pparam=config/matrixconfig.txt')
 
 tr = Test.AddTestRun("path is substituted")
 tr.Processes.Default.Command = '''

--- a/tests/gold_tests/pluginTest/cookie_remap/notexistscookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/notexistscookie.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /cookiedoesntexist HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /cookiedoesntexist HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /cookieexists HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /cookieexists HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/notexistsconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/notexistsconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/notexistsconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/notexistsconfig.txt')
 
 # Positive test case that remaps because cookie doesn't exist
 tr = Test.AddTestRun("cookie fpbeta doesn't exist")

--- a/tests/gold_tests/pluginTest/cookie_remap/pcollapseslashes.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/pcollapseslashes.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # and verify it collapsed the double //
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /i/like/cheetos?.done=http://finance.yahoo.com HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /i/like/cheetos?.done=http://finance.yahoo.com HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -44,10 +48,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/pcollapseconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
@@ -55,8 +60,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/collapseconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/orig_path http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/collapseconfig.txt'
-)
+    'map http://www.example.com/orig_path http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/collapseconfig.txt')
 
 tr = Test.AddTestRun("collapse consecutive forward slashes")
 tr.Processes.Default.Command = '''

--- a/tests/gold_tests/pluginTest/cookie_remap/psubstitute.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/psubstitute.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -29,28 +30,39 @@ ts = Test.MakeATSProcess("ts")
 
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /photos/search?query=magic HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-
-server.addResponse("sessionfile.log", request_header, response_header)
-
-request_header = {"headers": "GET /photos/search?query=/theunmatchedpath HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-
-server.addResponse("sessionfile.log", request_header, response_header)
-
-request_header = {"headers": "GET /photos/search/magic/foobar HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /photos/search?query=magic HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header, response_header)
 
 request_header = {
-    "headers": "GET /photos/search/cr_substitutions?query=%28http%3A%2F%2Fwww%2Eexample%2Ecom%2Fmagic HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "headers": "GET /photos/search?query=/theunmatchedpath HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
     "timestamp": "1469733493.993",
-    "body": ""}
+    "body": ""
+}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+
+server.addResponse("sessionfile.log", request_header, response_header)
+
+request_header = {
+    "headers": "GET /photos/search/magic/foobar HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+
+server.addResponse("sessionfile.log", request_header, response_header)
+
+request_header = {
+    "headers":
+        "GET /photos/search/cr_substitutions?query=%28http%3A%2F%2Fwww%2Eexample%2Ecom%2Fmagic HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header, response_header)
@@ -60,10 +72,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/psubstituteconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
@@ -71,8 +84,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/substituteconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com/not-used @plugin=cookie_remap.so @pparam=config/substituteconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com/not-used @plugin=cookie_remap.so @pparam=config/substituteconfig.txt')
 
 tr = Test.AddTestRun("Substitute $ppath in the dest query")
 tr.Processes.Default.Command = '''

--- a/tests/gold_tests/pluginTest/cookie_remap/regexcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/regexcookie.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /regexmatches?cookies=oreos-chipsahoy-icecream HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /regexmatches?cookies=oreos-chipsahoy-icecream HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /regexdoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /regexdoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/regexconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/regexconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/regexconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/regexconfig.txt')
 
 # Positive test case that remaps because cookie regex matches
 tr = Test.AddTestRun("cookie regex matches")

--- a/tests/gold_tests/pluginTest/cookie_remap/setstatus.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/setstatus.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -32,17 +33,17 @@ config_path = os.path.join(Test.TestDirectory, "configs/statusconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 ts.Disk.File(ts.Variables.CONFIGDIR + "/statusconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/statusconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com @plugin=cookie_remap.so @pparam=config/statusconfig.txt')
 
 # Plugin sets the HTTP status because first rule matches
 tr = Test.AddTestRun("Sets the status to 205")

--- a/tests/gold_tests/pluginTest/cookie_remap/subcookie.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/subcookie.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -31,8 +32,11 @@ ts = Test.MakeATSProcess("ts")
 # second server is run during second test
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /cookiematches HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -40,8 +44,11 @@ response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "t
 server.addResponse("sessionfile.log", request_header, response_header)
 
 server2 = Test.MakeOriginServer("server2", ip='127.0.0.11')
-request_header2 = {"headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header2 = {
+    "headers": "GET /cookiedoesntmatch HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 # expected response from the origin server
 response_header2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
@@ -53,10 +60,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/subcookie.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 config1 = config1.replace("$ALTPORT", str(server2.Variables.Port))
@@ -65,8 +73,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/subcookie.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/subcookie.txt'
-)
+    'map http://www.example.com http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/subcookie.txt')
 
 # Positive test case that remaps because all connected operations pass
 tr = Test.AddTestRun("cookie value matches")

--- a/tests/gold_tests/pluginTest/cookie_remap/substitute.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/substitute.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 
 '''
@@ -29,20 +30,29 @@ ts = Test.MakeATSProcess("ts")
 
 server = Test.MakeOriginServer("server", ip='127.0.0.10')
 
-request_header = {"headers": "GET /photos/search?query=magic HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {
+    "headers": "GET /photos/search?query=magic HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header, response_header)
 
-request_header_2 = {"headers": "GET /photos/search?query=/theunmatchedpath HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": ""}
+request_header_2 = {
+    "headers": "GET /photos/search?query=/theunmatchedpath HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header_2 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header_2, response_header_2)
 
-request_header_3 = {"headers": "GET /photos/search/magic/foobar HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                    "timestamp": "1469733493.993", "body": ""}
+request_header_3 = {
+    "headers": "GET /photos/search/magic/foobar HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 response_header_3 = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 server.addResponse("sessionfile.log", request_header_3, response_header_3)
@@ -52,10 +62,11 @@ config_path = os.path.join(Test.TestDirectory, "configs/substituteconfig.txt")
 with open(config_path, 'r') as config_file:
     config1 = config_file.read()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cookie_remap.*|http.*|dns.*',
+    })
 
 config1 = config1.replace("$PORT", str(server.Variables.Port))
 
@@ -63,8 +74,7 @@ ts.Disk.File(ts.Variables.CONFIGDIR + "/substituteconfig.txt", id="config1")
 ts.Disk.config1.WriteOn(config1)
 
 ts.Disk.remap_config.AddLine(
-    'map http://www.example.com/magic http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/substituteconfig.txt'
-)
+    'map http://www.example.com/magic http://shouldnothit.com/magic @plugin=cookie_remap.so @pparam=config/substituteconfig.txt')
 
 tr = Test.AddTestRun("Substitute $path in the dest query")
 tr.Processes.Default.Command = '''

--- a/tests/gold_tests/pluginTest/cppapi/cppapi.test.py
+++ b/tests/gold_tests/pluginTest/cppapi/cppapi.test.py
@@ -16,7 +16,6 @@
 
 import os
 
-
 Test.Summary = '''
 Execute plugin with cppapi tests.
 '''

--- a/tests/gold_tests/pluginTest/esi/esi.test.py
+++ b/tests/gold_tests/pluginTest/esi/esi.test.py
@@ -23,9 +23,7 @@ Test.Summary = '''
 Test the ESI plugin.
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('esi.so'),
-)
+Test.SkipUnless(Condition.PluginExists('esi.so'),)
 
 
 class EsiTest():
@@ -33,16 +31,12 @@ class EsiTest():
     A class that encapsulates the configuration and execution of a set of EPI
     test cases.
     """
-
     """ static: The same server Process is used across all tests. """
     _server = None
-
     """ static: A counter to keep the ATS process names unique across tests. """
     _ts_counter = 0
-
     """ static: A counter to keep any output file names unique across tests. """
     _output_counter = 0
-
     """ The ATS process for this set of test cases. """
     _ts = None
 
@@ -69,10 +63,9 @@ class EsiTest():
         # See:
         #   doc/admin-guide/plugins/esi.en.rst
         request_header = {
-            "headers": (
-                "GET /esi.php HTTP/1.1\r\n"
-                "Host: www.example.com\r\n"
-                "Content-Length: 0\r\n\r\n"),
+            "headers": ("GET /esi.php HTTP/1.1\r\n"
+                        "Host: www.example.com\r\n"
+                        "Content-Length: 0\r\n\r\n"),
             "timestamp": "1469733493.993",
             "body": ""
         }
@@ -84,23 +77,23 @@ Hello, <esi:include src="http://www.example.com/date.php"/>
 </html>
 '''
         response_header = {
-            "headers": (
-                "HTTP/1.1 200 OK\r\n"
-                "Content-Type: text/html\r\n"
-                "X-Esi: 1\r\n"
-                "Connection: close\r\n"
-                "Content-Length: {}\r\n"
-                "Cache-Control: max-age=300\r\n"
-                "\r\n".format(len(esi_body))),
+            "headers":
+                (
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Type: text/html\r\n"
+                    "X-Esi: 1\r\n"
+                    "Connection: close\r\n"
+                    "Content-Length: {}\r\n"
+                    "Cache-Control: max-age=300\r\n"
+                    "\r\n".format(len(esi_body))),
             "timestamp": "1469733493.993",
             "body": esi_body
         }
         server.addResponse("sessionfile.log", request_header, response_header)
         request_header = {
-            "headers": (
-                "GET /date.php HTTP/1.1\r\n"
-                "Host: www.example.com\r\n"
-                "Content-Length: 0\r\n\r\n"),
+            "headers": ("GET /date.php HTTP/1.1\r\n"
+                        "Host: www.example.com\r\n"
+                        "Content-Length: 0\r\n\r\n"),
             "timestamp": "1469733493.993",
             "body": ""
         }
@@ -110,34 +103,35 @@ echo date('l jS \of F Y h:i:s A');
 ?>
 '''
         response_header = {
-            "headers": (
-                "HTTP/1.1 200 OK\r\n"
-                "Content-Type: text/html\r\n"
-                "Connection: close\r\n"
-                "Content-Length: {}\r\n"
-                "Cache-Control: max-age=300\r\n"
-                "\r\n".format(len(date_body))),
+            "headers":
+                (
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Type: text/html\r\n"
+                    "Connection: close\r\n"
+                    "Content-Length: {}\r\n"
+                    "Cache-Control: max-age=300\r\n"
+                    "\r\n".format(len(date_body))),
             "timestamp": "1469733493.993",
             "body": date_body
         }
         server.addResponse("sessionfile.log", request_header, response_header)
         # Verify correct functionality with an empty body.
         request_header = {
-            "headers": (
-                "GET /expect_empty_body HTTP/1.1\r\n"
-                "Host: www.example.com\r\n"
-                "Content-Length: 0\r\n\r\n"),
+            "headers": ("GET /expect_empty_body HTTP/1.1\r\n"
+                        "Host: www.example.com\r\n"
+                        "Content-Length: 0\r\n\r\n"),
             "timestamp": "1469733493.993",
             "body": ""
         }
         response_header = {
-            "headers": (
-                "HTTP/1.1 200 OK\r\n"
-                "X-ESI: On\r\n"
-                "Content-Length: 0\r\n"
-                "Connection: close\r\n"
-                "Content-Type: text/html; charset=UTF-8\r\n"
-                "\r\n"),
+            "headers":
+                (
+                    "HTTP/1.1 200 OK\r\n"
+                    "X-ESI: On\r\n"
+                    "Content-Length: 0\r\n"
+                    "Connection: close\r\n"
+                    "Content-Type: text/html; charset=UTF-8\r\n"
+                    "\r\n"),
             "timestamp": "1469733493.993",
             "body": ""
         }
@@ -165,9 +159,7 @@ echo date('l jS \of F Y h:i:s A');
             'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': 'http|plugin_esi',
         })
-        ts.Disk.remap_config.AddLine(
-            'map http://www.example.com/ http://127.0.0.1:{0}'.format(EsiTest._server.Variables.Port)
-        )
+        ts.Disk.remap_config.AddLine('map http://www.example.com/ http://127.0.0.1:{0}'.format(EsiTest._server.Variables.Port))
         ts.Disk.plugin_config.AddLine(plugin_config)
 
         # Create a run to start the ATS process.
@@ -206,9 +198,7 @@ echo date('l jS \of F Y h:i:s A');
         # Test 3: Verify the ESI plugin can gzip a response when the client accepts it.
         tr = Test.AddTestRun("Verify the ESI plugin can gzip a response")
         EsiTest._output_counter += 1
-        unzipped_body_file = os.path.join(
-            tr.RunDirectory,
-            "non_empty_curl_output_{}".format(EsiTest._output_counter))
+        unzipped_body_file = os.path.join(tr.RunDirectory, "non_empty_curl_output_{}".format(EsiTest._output_counter))
         gzipped_body_file = unzipped_body_file + ".gz"
         tr.Processes.Default.Command = \
             ('curl http://127.0.0.1:{0}/esi.php -H"Host: www.example.com" '
@@ -233,9 +223,7 @@ echo date('l jS \of F Y h:i:s A');
         # Test 4: Verify correct handling of a gzipped empty response body.
         tr = Test.AddTestRun("Verify we can handle an empty response.")
         EsiTest._output_counter += 1
-        empty_body_file = os.path.join(
-            tr.RunDirectory,
-            "empty_curl_output_{}".format(EsiTest._output_counter))
+        empty_body_file = os.path.join(tr.RunDirectory, "empty_curl_output_{}".format(EsiTest._output_counter))
         gzipped_empty_body = empty_body_file + ".gz"
         tr.Processes.Default.Command = \
             ('curl http://127.0.0.1:{0}/expect_empty_body -H"Host: www.example.com" '

--- a/tests/gold_tests/pluginTest/esi/esi_304.test.py
+++ b/tests/gold_tests/pluginTest/esi/esi_304.test.py
@@ -23,9 +23,7 @@ Test.Summary = '''
 Test the ESI plugin when origin returns 304 response.
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('esi.so'),
-)
+Test.SkipUnless(Condition.PluginExists('esi.so'),)
 
 
 class EsiTest():
@@ -33,16 +31,12 @@ class EsiTest():
     A class that encapsulates the configuration and execution of a set of ESI
     test cases.
     """
-
     """ static: The same server Process is used across all tests. """
     _server = None
-
     """ static: A counter to keep the ATS process names unique across tests. """
     _ts_counter = 0
-
     """ static: A counter to keep any output file names unique across tests. """
     _output_counter = 0
-
     """ The ATS process for this set of test cases. """
     _ts = None
 
@@ -68,10 +62,7 @@ class EsiTest():
         # Generate the set of ESI responses.
         request_header = {
             "headers":
-            "GET /esi_etag.php HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "uuid: first\r\n" +
-            "Content-Length: 0\r\n\r\n",
+                "GET /esi_etag.php HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: first\r\n" + "Content-Length: 0\r\n\r\n",
             "timestamp": "1469733493.993",
             "body": ""
         }
@@ -83,14 +74,8 @@ Hello, ESI 304 test
 '''
         response_header = {
             "headers":
-            "HTTP/1.1 200 OK\r\n" +
-            "X-Esi: 1\r\n" +
-            "Cache-Control: public, max-age=0\r\n" +
-            'Etag: "esi_304_test"\r\n' +
-            "Content-Type: text/html\r\n" +
-            "Connection: close\r\n" +
-            "Content-Length: {}\r\n".format(len(esi_body)) +
-            "\r\n",
+                "HTTP/1.1 200 OK\r\n" + "X-Esi: 1\r\n" + "Cache-Control: public, max-age=0\r\n" + 'Etag: "esi_304_test"\r\n' +
+                "Content-Type: text/html\r\n" + "Connection: close\r\n" + "Content-Length: {}\r\n".format(len(esi_body)) + "\r\n",
             "timestamp": "1469733493.993",
             "body": esi_body
         }
@@ -98,32 +83,22 @@ Hello, ESI 304 test
 
         request_header = {
             "headers":
-            "GET /esi_etag.php HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "uuid: second\r\n" +
-            'If-None-Match: "esi_304_test"\r\n' +
-            "Content-Length: 0\r\n\r\n",
+                "GET /esi_etag.php HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: second\r\n" +
+                'If-None-Match: "esi_304_test"\r\n' + "Content-Length: 0\r\n\r\n",
             "timestamp": "1469733493.993",
             "body": ""
         }
         response_header = {
             "headers":
-            "HTTP/1.1 304 Not Modified\r\n" +
-            "Content-Type: text/html\r\n" +
-            "Connection: close\r\n" +
-            "Content-Length: 0\r\n" +
-            "\r\n",
+                "HTTP/1.1 304 Not Modified\r\n" + "Content-Type: text/html\r\n" + "Connection: close\r\n" +
+                "Content-Length: 0\r\n" + "\r\n",
             "timestamp": "1469733493.993",
             "body": ""
         }
         server.addResponse("sessionfile.log", request_header, response_header)
 
         request_header = {
-            "headers":
-            "GET /date.php HTTP/1.1\r\n" +
-            "Host: www.example.com\r\n" +
-            "uuid: date\r\n" +
-            "Content-Length: 0\r\n\r\n",
+            "headers": "GET /date.php HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: date\r\n" + "Content-Length: 0\r\n\r\n",
             "timestamp": "1469733493.993",
             "body": ""
         }
@@ -132,11 +107,8 @@ No Date
 '''
         response_header = {
             "headers":
-            "HTTP/1.1 200 OK\r\n" +
-            "Content-Type: text/html\r\n" +
-            "Connection: close\r\n" +
-            "Content-Length: {}\r\n".format(len(date_body)) +
-            "\r\n",
+                "HTTP/1.1 200 OK\r\n" + "Content-Type: text/html\r\n" + "Connection: close\r\n" +
+                "Content-Length: {}\r\n".format(len(date_body)) + "\r\n",
             "timestamp": "1469733493.993",
             "body": date_body
         }
@@ -164,9 +136,7 @@ No Date
             'proxy.config.diags.debug.enabled': 1,
             'proxy.config.diags.debug.tags': 'http|plugin_esi',
         })
-        ts.Disk.remap_config.AddLine(
-            'map http://www.example.com/ http://127.0.0.1:{0}'.format(EsiTest._server.Variables.Port)
-        )
+        ts.Disk.remap_config.AddLine('map http://www.example.com/ http://127.0.0.1:{0}'.format(EsiTest._server.Variables.Port))
         ts.Disk.plugin_config.AddLine(plugin_config)
 
         # Create a run to start the ATS process.

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite.test.py
@@ -38,15 +38,9 @@ ts.Disk.records_config.update({
 })
 # The following rule changes the status code returned from origin server to 303
 ts.Setup.CopyAs('rules/rule.conf', Test.RunDirectory)
-ts.Disk.plugin_config.AddLine(
-    'header_rewrite.so {0}/rule.conf'.format(Test.RunDirectory)
-)
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com:8080 http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.plugin_config.AddLine('header_rewrite.so {0}/rule.conf'.format(Test.RunDirectory))
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map http://www.example.com:8080 http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # call localhost straight
 tr = Test.AddTestRun()

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_cache.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_cache.test.py
@@ -23,16 +23,13 @@ server = Test.MakeOriginServer("server")
 Test.testName = "CACHE"
 
 # Request from client
-request_header = {"headers":
-                  "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993",
-                  "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 # Expected response from the origin server
-response_header = {"headers":
-                   "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-Control: max-age=10,public\r\n\r\n",
-                   "timestamp": "1469733493.993",
-                   "body": "CACHED"}
-
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nCache-Control: max-age=10,public\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "CACHED"
+}
 
 # add request/response
 server.addResponse("sessionlog.log", request_header, response_header)
@@ -45,15 +42,9 @@ ts.Disk.records_config.update({
 # (ie. "hit-fresh", "hit-stale", "miss", "none")
 ts.Setup.CopyAs('rules/rule_add_cache_result_header.conf', Test.RunDirectory)
 
-ts.Disk.plugin_config.AddLine(
-    'header_rewrite.so {0}/rule_add_cache_result_header.conf'.format(Test.RunDirectory)
-)
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.plugin_config.AddLine('header_rewrite.so {0}/rule_add_cache_result_header.conf'.format(Test.RunDirectory))
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Commands to get the following response headers
 # 1. miss (empty cache)
@@ -64,8 +55,7 @@ curlRequest = (
     'curl -s -v -H "Host: www.example.com" http://127.0.0.1:{0};'
     'curl -v -H "Host: www.example.com" http://127.0.0.1:{0};'
     'sleep 15; curl -s -v -H "Host: www.example.com" http://127.0.0.1:{0};'
-    'curl -s -v -H "Host: www.example.com" http://127.0.0.1:{0}'
-)
+    'curl -s -v -H "Host: www.example.com" http://127.0.0.1:{0}')
 
 # Test Case
 tr = Test.AddTestRun()

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_method.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_method.test.py
@@ -35,20 +35,17 @@ response = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestam
 session_file = "sessionfile.log"
 server.addResponse(session_file, request_get, response)
 server.addResponse(session_file, request_delete, response)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'header.*',
-    'proxy.config.http.insert_response_via_str': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'header.*',
+        'proxy.config.http.insert_response_via_str': 0,
+    })
 # The following rule inserts a via header if the request method is a GET or DELETE
 conf_name = "rule_cond_method.conf"
 ts.Setup.CopyAs('rules/{0}'.format(conf_name), Test.RunDirectory)
-ts.Disk.plugin_config.AddLine(
-    'header_rewrite.so {0}/{1}'.format(Test.RunDirectory, conf_name)
-)
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.plugin_config.AddLine('header_rewrite.so {0}/{1}'.format(Test.RunDirectory, conf_name))
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # Test method in READ_REQUEST_HDR_HOOK.
 expected_output = "gold/header_rewrite_cond_method.gold"

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_ssn_txn_count.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_cond_ssn_txn_count.test.py
@@ -23,31 +23,43 @@ server = Test.MakeOriginServer("server")
 Test.testName = "SSN-TXN-COUNT"
 
 # Test SSN-TXN-COUNT condition.
-request_header_hello = {"headers":
-                        "GET /hello HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 0\r\n\r\n",
-                        "timestamp": "1469733493.993", "body": ""}
-response_header_hello = {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
-                         "Content-Length: 0\r\n\r\n",
-                         "timestamp": "1469733493.993", "body": ""}
+request_header_hello = {
+    "headers": "GET /hello HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 0\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header_hello = {
+    "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
+               "Content-Length: 0\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
-request_header_world = {"headers": "GET /world HTTP/1.1\r\nContent-Length: 0\r\n"
-                        "Host: www.example.com\r\n\r\n",
-                        "timestamp": "1469733493.993", "body": "a\r\na\r\na\r\n\r\n"}
-response_header_world = {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
-                         "Connection: close\r\nContent-Length: 0\r\n\r\n",
-                         "timestamp": "1469733493.993", "body": ""}
+request_header_world = {
+    "headers": "GET /world HTTP/1.1\r\nContent-Length: 0\r\n"
+               "Host: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "a\r\na\r\na\r\n\r\n"
+}
+response_header_world = {
+    "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
+               "Connection: close\r\nContent-Length: 0\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
 
 # add request/response
 server.addResponse("sessionlog.log", request_header_hello, response_header_hello)
 server.addResponse("sessionlog.log", request_header_world, response_header_world)
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'header.*',
-    'proxy.config.http.auth_server_session_private': 1,
-    'proxy.config.http.server_session_sharing.pool': 'global',
-    'proxy.config.http.server_session_sharing.match': 'both',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'header.*',
+        'proxy.config.http.auth_server_session_private': 1,
+        'proxy.config.http.server_session_sharing.pool': 'global',
+        'proxy.config.http.server_session_sharing.match': 'both',
+    })
 
 # In case we need this in the future, just remove the comments.
 # ts.Disk.logging_yaml.AddLines(
@@ -78,8 +90,7 @@ curlRequest = (
     # I have to force last one with close connection header, this is also reflected in the response ^.
     # if I do not do this, then the microserver will fail to close and when shutting down the process will
     # fail with -9.
-    'curl -v -H\'Host: www.example.com\' -H\'Connection: close\' http://127.0.0.1:{0}/world'
-)
+    'curl -v -H\'Host: www.example.com\' -H\'Connection: close\' http://127.0.0.1:{0}/world')
 
 tr = Test.AddTestRun("Add connection close header when ssn-txn-count > 2")
 tr.Processes.Default.Command = curlRequest.format(ts.Variables.port)

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_l_value.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_l_value.test.py
@@ -42,15 +42,9 @@ ts.Disk.records_config.update({
 # The following rule adds X-First and X-Last headers
 ts.Setup.CopyAs('rules/rule_l_value.conf', Test.RunDirectory)
 
-ts.Disk.plugin_config.AddLine(
-    'header_rewrite.so {0}/rule_l_value.conf'.format(Test.RunDirectory)
-)
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    'map http://www.example.com:8080 http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.plugin_config.AddLine('header_rewrite.so {0}/rule_l_value.conf'.format(Test.RunDirectory))
+ts.Disk.remap_config.AddLine('map http://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map http://www.example.com:8080 http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 # [L] test
 tr = Test.AddTestRun("Header Rewrite End [L]")

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
@@ -45,24 +45,20 @@ ts.Setup.CopyAs('rules/set_redirect.conf', Test.RunDirectory)
 # This configuration makes use of CLIENT-URL in conditions.
 ts.Disk.remap_config.AddLine(
     'map http://www.example.com/from_path/ https://127.0.0.1:{0}/to_path/ '
-    '@plugin=header_rewrite.so @pparam={1}/rule_client.conf'.format(
-        server.Variables.Port, Test.RunDirectory))
+    '@plugin=header_rewrite.so @pparam={1}/rule_client.conf'.format(server.Variables.Port, Test.RunDirectory))
 ts.Disk.remap_config.AddLine(
     'map http://www.example.com:8080/from_path/ https://127.0.0.1:{0}/to_path/ '
-    '@plugin=header_rewrite.so @pparam={1}/rule_client.conf'.format(
-        server.Variables.Port, Test.RunDirectory))
+    '@plugin=header_rewrite.so @pparam={1}/rule_client.conf'.format(server.Variables.Port, Test.RunDirectory))
 # This configuration makes use of TO-URL in a set-redirect operator.
 ts.Disk.remap_config.AddLine(
     'map http://no_path.com http://no_path.com?name=brian/ '
-    '@plugin=header_rewrite.so @pparam={0}/set_redirect.conf'.format(
-        Test.RunDirectory))
+    '@plugin=header_rewrite.so @pparam={0}/set_redirect.conf'.format(Test.RunDirectory))
 
 # Test CLIENT-URL.
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl --proxy 127.0.0.1:{0} "http://www.example.com/from_path/hello?=foo=bar" '
-    '-H "Proxy-Connection: keep-alive" --verbose'.format(
-        ts.Variables.port))
+    '-H "Proxy-Connection: keep-alive" --verbose'.format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -72,8 +68,7 @@ ts.Disk.traffic_out.Content = "gold/header_rewrite-tag.gold"
 
 # Test TO-URL in a set-redirect operator.
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl --head 127.0.0.1:{0} -H "Host: no_path.com" --verbose'.format(
-    ts.Variables.port)
+tr.Processes.Default.Command = 'curl --head 127.0.0.1:{0} -H "Host: no_path.com" --verbose'.format(ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/set-redirect.gold"
 tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/lua/lua_debug_tags.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_debug_tags.test.py
@@ -22,17 +22,13 @@ Test.Summary = '''
 Test lua is_debug_tag_set functionality
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('tslua.so'),
-)
+Test.SkipUnless(Condition.PluginExists('tslua.so'),)
 
 Test.ContinueOnFail = False
 # Define default ATS
 ts = Test.MakeATSProcess("ts", command="traffic_manager")
 
-ts.Disk.remap_config.AddLine(
-    'map http://test http://127.0.0.1/ @plugin=tslua.so @pparam=tags.lua'
-)
+ts.Disk.remap_config.AddLine('map http://test http://127.0.0.1/ @plugin=tslua.so @pparam=tags.lua')
 
 # Configure the tslua's configuration file.
 ts.Setup.Copy("tags.lua", ts.Variables.CONFIGDIR)

--- a/tests/gold_tests/pluginTest/lua/lua_header_table.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_header_table.test.py
@@ -20,17 +20,13 @@ Test.Summary = '''
 Test lua header table functionality
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('tslua.so'),
-)
+Test.SkipUnless(Condition.PluginExists('tslua.so'),)
 
 Test.ContinueOnFail = True
 # Define default ATS
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.remap_config.AddLine(
-    f"map / http://127.0.0.1 @plugin=tslua.so @pparam=header_table.lua"
-)
+ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1 @plugin=tslua.so @pparam=header_table.lua")
 # Configure the tslua's configuration file.
 ts.Setup.Copy("header_table.lua", ts.Variables.CONFIGDIR)
 

--- a/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_states_stats.test.py
@@ -20,9 +20,7 @@ Test.Summary = '''
 Test lua states and stats functionality
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('tslua.so'),
-)
+Test.SkipUnless(Condition.PluginExists('tslua.so'),)
 
 Test.ContinueOnFail = True
 # Define default ATS
@@ -38,27 +36,27 @@ Test.Setup.Copy("metrics.sh")
 Test.Setup.Copy("lifecycle_stats.sh")
 
 # test to ensure origin server works
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 # add response to the server dictionary
 server.addResponse("sessionfile.log", request_header, response_header)
 
-ts.Disk.remap_config.AddLines({
-    'map / http://127.0.0.1:{}/'.format(server.Variables.Port),
-    'map http://hello http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=tslua.so @pparam={}/hello.lua'.format(Test.RunDirectory)
-})
+ts.Disk.remap_config.AddLines(
+    {
+        'map / http://127.0.0.1:{}/'.format(server.Variables.Port),
+        'map http://hello http://127.0.0.1:{}/'.format(server.Variables.Port) +
+        ' @plugin=tslua.so @pparam={}/hello.lua'.format(Test.RunDirectory)
+    })
 
 ts.Disk.plugin_config.AddLine('tslua.so {}/global.lua'.format(Test.RunDirectory))
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ts_lua',
-    'proxy.config.plugin.lua.max_states': 4,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ts_lua',
+        'proxy.config.plugin.lua.max_states': 4,
+    })
 
 curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} '.format(ts.Variables.port)
 

--- a/tests/gold_tests/pluginTest/lua/lua_watermark.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_watermark.test.py
@@ -22,9 +22,7 @@ Test.Summary = '''
 Test lua functionality
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('tslua.so'),
-)
+Test.SkipUnless(Condition.PluginExists('tslua.so'),)
 
 Test.ContinueOnFail = True
 # Define default ATS
@@ -32,27 +30,19 @@ ts = Test.MakeATSProcess("ts")
 server = Test.MakeOriginServer("server")
 
 Test.testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 # expected response from the origin server
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 # add response to the server dictionary
 server.addResponse("sessionfile.log", request_header, response_header)
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=tslua.so @pparam=watermark.lua'
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{}/'.format(server.Variables.Port) + ' @plugin=tslua.so @pparam=watermark.lua')
 
 # Configure the tslua's configuration file.
 ts.Setup.Copy("watermark.lua", ts.Variables.CONFIGDIR)
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ts_lua'
-})
+ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'ts_lua'})
 
 # Test for watermark debug output
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(r"WMbytes\(31337\)", "Upstream watermark should be properly set")

--- a/tests/gold_tests/pluginTest/money_trace/money_trace.test.py
+++ b/tests/gold_tests/pluginTest/money_trace/money_trace.test.py
@@ -14,15 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import os
+
 Test.Summary = '''
 Test money_trace remap
 '''
 
 # Test description:
 
-Test.SkipUnless(
-    Condition.PluginExists('money_trace.so'),
-)
+Test.SkipUnless(Condition.PluginExists('money_trace.so'),)
 Test.ContinueOnFail = False
 Test.testName = "money_trace remap"
 
@@ -32,41 +31,26 @@ ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
 # configure origin server
 server = Test.MakeOriginServer("server")
 
-req_chk = {"headers":
-           "GET / HTTP/1.1\r\n" + "Host: origin\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
-res_chk = {"headers":
-           "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_chk = {"headers": "GET / HTTP/1.1\r\n" + "Host: origin\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", req_chk, res_chk)
 
-req_hdr = {"headers":
-           "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
-res_hdr = {"headers":
-           "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_hdr = {"headers": "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
+res_hdr = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", req_hdr, res_hdr)
 
-ts.Disk.remap_config.AddLines([
-    f"map http://none/ http://127.0.0.1:{server.Variables.Port}",
-    f"map http://basic/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so",
-    f"map http://header/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--header=mt",
-    f"map http://pregen/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--pregen-header=@pregen",
-    f"map http://pgh/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--header=mt @pparam=--pregen-header=@pregen",
-    f"map http://create/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--create-if-none=true",
-    f"map http://cheader/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--create-if-none=true @pparam=--header=mt",
-    f"map http://cpregen/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--create-if-none=true @pparam=--pregen-header=@pregen",
-    f"map http://passthru/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--passthru=true",
-])
+ts.Disk.remap_config.AddLines(
+    [
+        f"map http://none/ http://127.0.0.1:{server.Variables.Port}",
+        f"map http://basic/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so",
+        f"map http://header/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--header=mt",
+        f"map http://pregen/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--pregen-header=@pregen",
+        f"map http://pgh/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--header=mt @pparam=--pregen-header=@pregen",
+        f"map http://create/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--create-if-none=true",
+        f"map http://cheader/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--create-if-none=true @pparam=--header=mt",
+        f"map http://cpregen/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--create-if-none=true @pparam=--pregen-header=@pregen",
+        f"map http://passthru/ http://127.0.0.1:{server.Variables.Port} @plugin=money_trace.so @pparam=--passthru=true",
+    ])
 
 # minimal configuration
 ts.Disk.records_config.update({
@@ -83,11 +67,9 @@ logging:
   logs:
     - filename: remap
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
-Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'remap.log'),
-               exists=True, content='gold/remap-log.gold')
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'remap.log'), exists=True, content='gold/remap-log.gold')
 
 curl_and_args = f"curl -s -D /dev/stdout -o /dev/stderr -x 127.0.0.1:{ts.Variables.port}"
 
@@ -220,6 +202,4 @@ for trace in trace_strings:
 tr = Test.AddTestRun()
 ps = tr.Processes.Default
 ps.Command = (
-    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'remap.log')
-)
+    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + os.path.join(ts.Variables.LOGDIR, 'remap.log'))

--- a/tests/gold_tests/pluginTest/money_trace/money_trace_global.test.py
+++ b/tests/gold_tests/pluginTest/money_trace/money_trace_global.test.py
@@ -15,6 +15,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 Test money_trace global
 '''
@@ -23,8 +24,7 @@ Test money_trace global
 
 Test.SkipUnless(
     #    Condition.PluginExists('xdebug.so'),
-    Condition.PluginExists('money_trace.so'),
-)
+    Condition.PluginExists('money_trace.so'),)
 Test.ContinueOnFail = False
 Test.testName = "money_trace global"
 
@@ -34,28 +34,12 @@ ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
 # configure origin server
 server = Test.MakeOriginServer("server")
 
-req_chk = {"headers":
-           "GET / HTTP/1.1\r\n" + "Host: origin\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
-res_chk = {"headers":
-           "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_chk = {"headers": "GET / HTTP/1.1\r\n" + "Host: origin\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", req_chk, res_chk)
 
-req_hdr = {"headers":
-           "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
-res_hdr = {"headers":
-           "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
-           "timestamp": "1469733493.993",
-           "body": ""
-           }
+req_hdr = {"headers": "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
+res_hdr = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", req_hdr, res_hdr)
 
 ts.Disk.remap_config.AddLines([
@@ -80,11 +64,9 @@ logging:
   logs:
     - filename: global
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
-Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'global.log'),
-               exists=True, content='gold/global-log.gold')
+Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'global.log'), exists=True, content='gold/global-log.gold')
 
 curl_and_args = f"curl -s -D /dev/stdout -o /dev/stderr -x 127.0.0.1:{ts.Variables.port}"  # -H 'X-Debug: Probe' "
 
@@ -120,7 +102,5 @@ tr.StillRunningAfter = server
 tr = Test.AddTestRun()
 ps = tr.Processes.Default
 ps.Command = (
-    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
-    os.path.join(ts.Variables.LOGDIR, 'global.log')
-)
+    os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' + os.path.join(ts.Variables.LOGDIR, 'global.log'))
 #ps.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
+++ b/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
@@ -22,9 +22,7 @@ Test.Summary = '''
 Test the Multiplexer plugin.
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('multiplexer.so')
-)
+Test.SkipUnless(Condition.PluginExists('multiplexer.so'))
 
 
 class MultiplexerTestBase:
@@ -46,91 +44,74 @@ class MultiplexerTestBase:
     def setupServers(self):
         counter = MultiplexerTestBase.server_counter
         MultiplexerTestBase.server_counter += 1
-        self.server_origin = Test.MakeVerifierServerProcess(
-            f"server_origin_{counter}", self.replay_file)
-        self.server_http = Test.MakeVerifierServerProcess(
-            f"server_http_{counter}", self.multiplexed_host_replay_file)
-        self.server_https = Test.MakeVerifierServerProcess(
-            f"server_https_{counter}", self.multiplexed_host_replay_file)
+        self.server_origin = Test.MakeVerifierServerProcess(f"server_origin_{counter}", self.replay_file)
+        self.server_http = Test.MakeVerifierServerProcess(f"server_http_{counter}", self.multiplexed_host_replay_file)
+        self.server_https = Test.MakeVerifierServerProcess(f"server_https_{counter}", self.multiplexed_host_replay_file)
 
         # The origin should never receive "X-Multiplexer: copy"
         self.server_origin.Streams.All += Testers.ExcludesExpression(
-            'X-Multiplexer: copy',
-            'Verify the original server target never receives a "copy".')
+            'X-Multiplexer: copy', 'Verify the original server target never receives a "copy".')
 
         # Nor should the multiplexed hosts receive an "original" X-Multiplexer value.
         self.server_http.Streams.All += Testers.ExcludesExpression(
-            'X-Multiplexer: original',
-            'Verify the HTTP multiplexed host does not receive an "original".')
+            'X-Multiplexer: original', 'Verify the HTTP multiplexed host does not receive an "original".')
         self.server_https.Streams.All += Testers.ExcludesExpression(
-            'X-Multiplexer: original',
-            'Verify the HTTPS multiplexed host does not receive an "original".')
+            'X-Multiplexer: original', 'Verify the HTTPS multiplexed host does not receive an "original".')
 
         # In addition, the original server should always receive the POST and
         # PUT requests.
         self.server_origin.Streams.All += Testers.ContainsExpression(
-            'uuid: POST',
-            "Verify the client's original target received the POST transaction.")
+            'uuid: POST', "Verify the client's original target received the POST transaction.")
         self.server_origin.Streams.All += Testers.ContainsExpression(
-            'uuid: PUT',
-            "Verify the client's original target received the PUT transaction.")
+            'uuid: PUT', "Verify the client's original target received the PUT transaction.")
 
         # Under all configurations, the GET request should be multiplexed.
         self.server_origin.Streams.All += Testers.ContainsExpression(
-            'X-Multiplexer: original',
-            'Verify the client\'s original target received the "original" request.')
+            'X-Multiplexer: original', 'Verify the client\'s original target received the "original" request.')
         self.server_origin.Streams.All += Testers.ContainsExpression(
-            'uuid: GET',
-            "Verify the client's original target received the GET request.")
+            'uuid: GET', "Verify the client's original target received the GET request.")
 
         self.server_http.Streams.All += Testers.ContainsExpression(
-            'X-Multiplexer: copy',
-            'Verify the HTTP server received a "copy" of the request.')
-        self.server_http.Streams.All += Testers.ContainsExpression(
-            'uuid: GET',
-            "Verify the HTTP server received the GET request.")
+            'X-Multiplexer: copy', 'Verify the HTTP server received a "copy" of the request.')
+        self.server_http.Streams.All += Testers.ContainsExpression('uuid: GET', "Verify the HTTP server received the GET request.")
 
         self.server_https.Streams.All += Testers.ContainsExpression(
-            'X-Multiplexer: copy',
-            'Verify the HTTPS server received a "copy" of the request.')
+            'X-Multiplexer: copy', 'Verify the HTTPS server received a "copy" of the request.')
         self.server_https.Streams.All += Testers.ContainsExpression(
-            'uuid: GET',
-            "Verify the HTTPS server received the GET request.")
+            'uuid: GET', "Verify the HTTPS server received the GET request.")
 
         # Verify that the HTTPS server receives a TLS connection.
         self.server_https.Streams.All += Testers.ContainsExpression(
-            'Finished accept using TLSSession',
-            "Verify the HTTPS was indeed used by the HTTPS server.")
+            'Finished accept using TLSSession', "Verify the HTTPS was indeed used by the HTTPS server.")
 
     def setupTS(self, skip_post):
         counter = MultiplexerTestBase.ts_counter
         MultiplexerTestBase.ts_counter += 1
         self.ts = Test.MakeATSProcess(f"ts_{counter}", enable_tls=True, enable_cache=False)
         self.ts.addDefaultSSLFiles()
-        self.ts.Disk.records_config.update({
-            "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
-
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'multiplexer',
-        })
-        self.ts.Disk.ssl_multicert_config.AddLine(
-            'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-        )
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'multiplexer',
+            })
+        self.ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
         skip_remap_param = ''
         if skip_post:
             skip_remap_param = ' @pparam=proxy.config.multiplexer.skip_post_put=1'
-        self.ts.Disk.remap_config.AddLines([
-            f'map https://origin.server.com https://127.0.0.1:{self.server_origin.Variables.https_port} '
-            f'@plugin=multiplexer.so @pparam=nontls.server.com @pparam=tls.server.com'
-            f'{skip_remap_param}',
+        self.ts.Disk.remap_config.AddLines(
+            [
+                f'map https://origin.server.com https://127.0.0.1:{self.server_origin.Variables.https_port} '
+                f'@plugin=multiplexer.so @pparam=nontls.server.com @pparam=tls.server.com'
+                f'{skip_remap_param}',
 
-            # Now create remap entries for the multiplexed hosts: one that
-            # verifies HTTP, and another that verifies HTTPS.
-            f'map http://nontls.server.com http://127.0.0.1:{self.server_http.Variables.http_port}',
-            f'map http://tls.server.com https://127.0.0.1:{self.server_https.Variables.https_port}',
-        ])
+                # Now create remap entries for the multiplexed hosts: one that
+                # verifies HTTP, and another that verifies HTTPS.
+                f'map http://nontls.server.com http://127.0.0.1:{self.server_http.Variables.http_port}',
+                f'map http://tls.server.com https://127.0.0.1:{self.server_https.Variables.https_port}',
+            ])
 
     def run(self):
         tr = Test.AddTestRun()
@@ -141,10 +122,7 @@ class MultiplexerTestBase:
 
         counter = MultiplexerTestBase.client_counter
         MultiplexerTestBase.client_counter += 1
-        tr.AddVerifierClientProcess(
-            f"client_{counter}",
-            self.replay_file,
-            https_ports=[self.ts.Variables.ssl_port])
+        tr.AddVerifierClientProcess(f"client_{counter}", self.replay_file, https_ports=[self.ts.Variables.ssl_port])
 
 
 class MultiplexerTest(MultiplexerTestBase):
@@ -156,10 +134,7 @@ class MultiplexerTest(MultiplexerTestBase):
     multiplexed_host_replay_file = os.path.join("replays", "multiplexer_copy.replay.yaml")
 
     def __init__(self):
-        super().__init__(
-            MultiplexerTest.replay_file,
-            MultiplexerTest.multiplexed_host_replay_file,
-            skip_post=False)
+        super().__init__(MultiplexerTest.replay_file, MultiplexerTest.multiplexed_host_replay_file, skip_post=False)
 
     def setupServers(self):
         super().setupServers()
@@ -167,19 +142,14 @@ class MultiplexerTest(MultiplexerTestBase):
         # Both of the multiplexed hosts should receive the POST because skip_post
         # is disabled.
         self.server_http.Streams.All += Testers.ContainsExpression(
-            'uuid: POST',
-            "Verify the HTTP server received the POST request.")
+            'uuid: POST', "Verify the HTTP server received the POST request.")
         self.server_https.Streams.All += Testers.ContainsExpression(
-            'uuid: POST',
-            "Verify the HTTPS server received the POST request.")
+            'uuid: POST', "Verify the HTTPS server received the POST request.")
 
         # Same with PUT
-        self.server_http.Streams.All += Testers.ContainsExpression(
-            'uuid: PUT',
-            "Verify the HTTP server received the PUT request.")
+        self.server_http.Streams.All += Testers.ContainsExpression('uuid: PUT', "Verify the HTTP server received the PUT request.")
         self.server_https.Streams.All += Testers.ContainsExpression(
-            'uuid: PUT',
-            "Verify the HTTPS server received the PUT request.")
+            'uuid: PUT', "Verify the HTTPS server received the PUT request.")
 
 
 class MultiplexerSkipPostTest(MultiplexerTestBase):
@@ -191,10 +161,7 @@ class MultiplexerSkipPostTest(MultiplexerTestBase):
     multiplexed_host_replay_file = os.path.join("replays", "multiplexer_copy_skip_post.replay.yaml")
 
     def __init__(self):
-        super().__init__(
-            MultiplexerSkipPostTest.replay_file,
-            MultiplexerSkipPostTest.multiplexed_host_replay_file,
-            skip_post=True)
+        super().__init__(MultiplexerSkipPostTest.replay_file, MultiplexerSkipPostTest.multiplexed_host_replay_file, skip_post=True)
 
     def setupServers(self):
         super().setupServers()
@@ -202,19 +169,15 @@ class MultiplexerSkipPostTest(MultiplexerTestBase):
         # Neither of the multiplexed hosts should receive the POST because skip_post
         # is enabled.
         self.server_http.Streams.All += Testers.ExcludesExpression(
-            'uuid: POST',
-            "Verify the HTTP server did not receive the POST request.")
+            'uuid: POST', "Verify the HTTP server did not receive the POST request.")
         self.server_https.Streams.All += Testers.ExcludesExpression(
-            'uuid: POST',
-            "Verify the HTTPS server did not receive the POST request.")
+            'uuid: POST', "Verify the HTTPS server did not receive the POST request.")
 
         # Same with PUT.
         self.server_http.Streams.All += Testers.ExcludesExpression(
-            'uuid: PUT',
-            "Verify the HTTP server did not receive the PUT request.")
+            'uuid: PUT', "Verify the HTTP server did not receive the PUT request.")
         self.server_https.Streams.All += Testers.ExcludesExpression(
-            'uuid: PUT',
-            "Verify the HTTPS server did not receive the PUT request.")
+            'uuid: PUT', "Verify the HTTPS server did not receive the PUT request.")
 
 
 MultiplexerTest().run()

--- a/tests/gold_tests/pluginTest/parent_select/parent_select.test.py
+++ b/tests/gold_tests/pluginTest/parent_select/parent_select.test.py
@@ -20,20 +20,17 @@ Test.Summary = '''
 Basic parent_select plugin test
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('parent_select.so'),
-)
+Test.SkipUnless(Condition.PluginExists('parent_select.so'),)
 Test.ContinueOnFail = False
 
 # Define and populate MicroServer.
 #
 server = Test.MakeOriginServer("server")
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "Cache-control: max-age=85000\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=85000\r\n"
+               "\r\n",
     "timestamp": "1469733493.993",
     "body": "This is the body.\n"
 }
@@ -57,30 +54,30 @@ num_nh = 8
 ts_nh = []
 for i in range(num_nh):
     ts = Test.MakeATSProcess(f"ts_nh{i}", use_traffic_out=False, command=f"traffic_server 2>nh_trace{i}.log")
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-        'proxy.config.dns.resolv_conf': "NULL",
-    })
-    ts.Disk.remap_config.AddLine(
-        f"map / http://127.0.0.1:{server.Variables.Port}"
-    )
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+            'proxy.config.dns.resolv_conf': "NULL",
+        })
+    ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
     ts_nh.append(ts)
 
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
-    'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.http.uncacheable_requests_bypass_parent': 0,
-    'proxy.config.http.no_dns_just_forward_to_parent': 1,
-    'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
-    'proxy.config.http.parent_proxy.self_detect': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
+        'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.http.uncacheable_requests_bypass_parent': 0,
+        'proxy.config.http.no_dns_just_forward_to_parent': 1,
+        'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
+        'proxy.config.http.parent_proxy.self_detect': 0,
+    })
 
 ts.Disk.File(ts.Variables.CONFIGDIR + "/strategies.yaml", id="strategies", typename="ats:config")
 s = ts.Disk.strategies
@@ -95,17 +92,11 @@ for i in range(num_nh):
     # The health check URL does not seem to be used currently.
     # s.AddLine(f"          health_check_url: http://next_hop{i}:{ts_nh[i].Variables.port}")
     s.AddLine(f"      weight: 1.0")
-s.AddLines([
-    "strategies:",
-    "  - strategy: the-strategy",
-    "    policy: consistent_hash",
-    "    hash_key: path",
-    "    go_direct: false",
-    "    parent_is_proxy: true",
-    "    ignore_self_detect: true",
-    "    groups:",
-    "      - *g1",
-    "    scheme: http"])
+s.AddLines(
+    [
+        "strategies:", "  - strategy: the-strategy", "    policy: consistent_hash", "    hash_key: path", "    go_direct: false",
+        "    parent_is_proxy: true", "    ignore_self_detect: true", "    groups:", "      - *g1", "    scheme: http"
+    ])
 
 # Fallover not currently tested.
 #
@@ -119,8 +110,7 @@ s.AddLines([
 # "        - passive"])
 
 ts.Disk.remap_config.AddLine(
-    "map http://dummy.com http://not_used @plugin=parent_select.so @pparam=" +
-    ts.Variables.CONFIGDIR +
+    "map http://dummy.com http://not_used @plugin=parent_select.so @pparam=" + ts.Variables.CONFIGDIR +
     "/strategies.yaml @pparam=the-strategy")
 
 tr = Test.AddTestRun()
@@ -134,9 +124,7 @@ tr.Processes.Default.ReturnCode = 0
 
 for i in range(num_objects):
     tr = Test.AddTestRun()
-    tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}'
-    )
+    tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "body.gold"
     tr.Processes.Default.ReturnCode = 0
 

--- a/tests/gold_tests/pluginTest/parent_select/parent_select_peer.test.py
+++ b/tests/gold_tests/pluginTest/parent_select/parent_select_peer.test.py
@@ -27,11 +27,10 @@ Test next hop selection using strategies.yaml with consistent hashing, with peer
 #
 server = Test.MakeOriginServer("server")
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "Cache-control: max-age=85000\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=85000\r\n"
+               "\r\n",
     "timestamp": "1469733493.993",
     "body": "This is the body.\n"
 }
@@ -56,15 +55,14 @@ ts_upstream = []
 for i in range(num_upstream):
     ts = Test.MakeATSProcess(f"ts_upstream{i}")
     dns.addRecords(records={f"ts_upstream{i}": ["127.0.0.1"]})
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-        'proxy.config.dns.resolv_conf': "NULL",
-    })
-    ts.Disk.remap_config.AddLine(
-        f"map / http://127.0.0.1:{server.Variables.Port}"
-    )
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+            'proxy.config.dns.resolv_conf': "NULL",
+        })
+    ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
     ts_upstream.append(ts)
 
 # Define peer trafficserver instances.
@@ -78,18 +76,19 @@ for i in range(num_peer):
     ts = ts_peer[i]
     dns.addRecords(records={f"ts_peer{i}": ["127.0.0.1"]})
 
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb|cachekey|pparent_select',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
-        'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
-        'proxy.config.http.cache.http': 1,
-        'proxy.config.http.cache.required_headers': 0,
-        'proxy.config.http.uncacheable_requests_bypass_parent': 0,
-        'proxy.config.http.no_dns_just_forward_to_parent': 1,
-        'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
-        'proxy.config.http.parent_proxy.self_detect': 1,
-    })
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb|cachekey|pparent_select',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
+            'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
+            'proxy.config.http.cache.http': 1,
+            'proxy.config.http.cache.required_headers': 0,
+            'proxy.config.http.uncacheable_requests_bypass_parent': 0,
+            'proxy.config.http.no_dns_just_forward_to_parent': 1,
+            'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
+            'proxy.config.http.parent_proxy.self_detect': 1,
+        })
 
     ts.Disk.File(ts.Variables.CONFIGDIR + "/strategies.yaml", id="strategies", typename="ats:config")
     s = ts.Disk.strategies
@@ -112,34 +111,36 @@ for i in range(num_peer):
         # The health check URL does not seem to be used currently.
         # s.AddLine(f"          health_check_url: http://ts_upstream{j}:{ts_upstream[j].Variables.port}")
         s.AddLine(f"      weight: 1.0")
-    s.AddLines([
-        "strategies:",
-        "  - strategy: the-strategy",
-        "    policy: consistent_hash",
-        "    hash_key: cache_key",
-        "    go_direct: false",
-        "    parent_is_proxy: true",
-        "    cache_peer_result: false",
-        "    ignore_self_detect: false",
-        "    groups:",
-        "      - *peer_group",
-        "      - *peer_upstream",
-        "    scheme: http",
-        "    failover:",
-        "      ring_mode: peering_ring",
-        f"      self: ts_peer{i}",
-        #"      max_simple_retries: 2",
-        #"      response_codes:",
-        #"        - 404",
-        #"      health_check:",
-        #"        - passive",
-    ])
+    s.AddLines(
+        [
+            "strategies:",
+            "  - strategy: the-strategy",
+            "    policy: consistent_hash",
+            "    hash_key: cache_key",
+            "    go_direct: false",
+            "    parent_is_proxy: true",
+            "    cache_peer_result: false",
+            "    ignore_self_detect: false",
+            "    groups:",
+            "      - *peer_group",
+            "      - *peer_upstream",
+            "    scheme: http",
+            "    failover:",
+            "      ring_mode: peering_ring",
+            f"      self: ts_peer{i}",
+            #"      max_simple_retries: 2",
+            #"      response_codes:",
+            #"        - 404",
+            #"      health_check:",
+            #"        - passive",
+        ])
 
     suffix = f" @plugin=parent_select.so @pparam={ts.Variables.CONFIGDIR}/strategies.yaml @pparam=the-strategy @plugin=cachekey.so @pparam=--uri-type=remap @pparam=--capture-prefix=/(.*):(.*)/$1/"
-    ts.Disk.remap_config.AddLines([
-        "map http://dummy.com http://not_used" + suffix,
-        "map http://not_used http://also_not_used" + suffix,
-    ])
+    ts.Disk.remap_config.AddLines(
+        [
+            "map http://dummy.com http://not_used" + suffix,
+            "map http://not_used http://also_not_used" + suffix,
+        ])
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -154,8 +155,7 @@ tr.Processes.Default.ReturnCode = 0
 for i in range(num_object):
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts_peer[i % num_peer].Variables.port} http://dummy.com/obj{i}'
-    )
+        f'curl --verbose --proxy 127.0.0.1:{ts_peer[i % num_peer].Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "peer.body.gold"
     tr.Processes.Default.ReturnCode = 0
 
@@ -163,15 +163,13 @@ for i in range(num_object):
     tr = Test.AddTestRun()
     # num_peer must not be a multiple of 3
     tr.Processes.Default.Command = (
-        f'curl --verbose --proxy 127.0.0.1:{ts_peer[(i * 3) % num_peer].Variables.port} http://dummy.com/obj{i}'
-    )
+        f'curl --verbose --proxy 127.0.0.1:{ts_peer[(i * 3) % num_peer].Variables.port} http://dummy.com/obj{i}')
     tr.Processes.Default.Streams.stdout = "peer.body.gold"
     tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     "grep -e '^+++' -e '^[A-Z].*TTP/' -e '^.alts. --' -e 'PARENT_SPECIFIED' trace_peer*.log"
-    " | sed 's/^.*(pparent_select) [^ ]* //' | sed 's/[.][0-9]*$$//'"
-)
+    " | sed 's/^.*(pparent_select) [^ ]* //' | sed 's/[.][0-9]*$$//'")
 tr.Processes.Default.Streams.stdout = "peer.trace.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/parent_select/parent_select_peer2.test.py
+++ b/tests/gold_tests/pluginTest/parent_select/parent_select_peer2.test.py
@@ -27,11 +27,10 @@ Test next hop using strategies.yaml with consistent hashing, with peering, and n
 #
 server = Test.MakeOriginServer("server")
 response_header = {
-    "headers":
-        "HTTP/1.1 200 OK\r\n"
-        "Connection: close\r\n"
-        "Cache-control: max-age=85000\r\n"
-        "\r\n",
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=85000\r\n"
+               "\r\n",
     "timestamp": "1469733493.993",
     "body": "This is the body.\n"
 }
@@ -56,15 +55,14 @@ ts_upstream = []
 for i in range(num_upstream):
     ts = Test.MakeATSProcess(f"ts_upstream{i}")
     dns.addRecords(records={f"ts_upstream{i}": ["127.0.0.1"]})
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-        'proxy.config.dns.resolv_conf': "NULL",
-    })
-    ts.Disk.remap_config.AddLine(
-        f"map / http://127.0.0.1:{server.Variables.Port}"
-    )
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+            'proxy.config.dns.resolv_conf': "NULL",
+        })
+    ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
     ts_upstream.append(ts)
 
 # Define peer trafficserver instances.
@@ -78,18 +76,19 @@ for i in range(num_peer):
     ts = ts_peer[i]
     dns.addRecords(records={f"ts_peer{i}": ["127.0.0.1"]})
 
-    ts.Disk.records_config.update({
-        'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb|pparent_select',
-        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
-        'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
-        'proxy.config.http.cache.http': 1,
-        'proxy.config.http.cache.required_headers': 0,
-        'proxy.config.http.uncacheable_requests_bypass_parent': 0,
-        'proxy.config.http.no_dns_just_forward_to_parent': 0,
-        'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
-        'proxy.config.http.parent_proxy.self_detect': 1,
-    })
+    ts.Disk.records_config.update(
+        {
+            'proxy.config.diags.debug.enabled': 1,
+            'proxy.config.diags.debug.tags': 'http|dns|parent|next_hop|host_statuses|hostdb|pparent_select',
+            'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",  # Only nameservers if resolv_conf NULL.
+            'proxy.config.dns.resolv_conf': "NULL",  # This defaults to /etc/resvolv.conf (OS namesevers) if not NULL.
+            'proxy.config.http.cache.http': 1,
+            'proxy.config.http.cache.required_headers': 0,
+            'proxy.config.http.uncacheable_requests_bypass_parent': 0,
+            'proxy.config.http.no_dns_just_forward_to_parent': 0,
+            'proxy.config.http.parent_proxy.mark_down_hostdb': 0,
+            'proxy.config.http.parent_proxy.self_detect': 1,
+        })
 
     ts.Disk.File(ts.Variables.CONFIGDIR + "/strategies.yaml", id="strategies", typename="ats:config")
     s = ts.Disk.strategies
@@ -103,33 +102,33 @@ for i in range(num_peer):
         # The health check URL does not seem to be used currently.
         # s.AddLine(f"          health_check_url: http://ts_peer{j}:{ts_peer[j].Variables.port}")
         s.AddLine(f"      weight: 1.0")
-    s.AddLines([
-        "strategies:",
-        "  - strategy: the-strategy",
-        "    policy: consistent_hash",
-        "    hash_key: path",
-        "    go_direct: true",
-        "    parent_is_proxy: true",
-        "    cache_peer_result: false",
-        "    ignore_self_detect: false",
-        "    groups:",
-        "      - *peer_group",
-        "    scheme: http",
-        "    failover:",
-        "      ring_mode: peering_ring",
-        f"      self: ts_peer{i}",
-        #"      max_simple_retries: 2",
-        #"      response_codes:",
-        #"        - 404",
-        #"      health_check:",
-        #"        - passive",
-    ])
+    s.AddLines(
+        [
+            "strategies:",
+            "  - strategy: the-strategy",
+            "    policy: consistent_hash",
+            "    hash_key: path",
+            "    go_direct: true",
+            "    parent_is_proxy: true",
+            "    cache_peer_result: false",
+            "    ignore_self_detect: false",
+            "    groups:",
+            "      - *peer_group",
+            "    scheme: http",
+            "    failover:",
+            "      ring_mode: peering_ring",
+            f"      self: ts_peer{i}",
+            #"      max_simple_retries: 2",
+            #"      response_codes:",
+            #"        - 404",
+            #"      health_check:",
+            #"        - passive",
+        ])
 
     for i in range(num_upstream):
         prefix = f"http://ts_upstream{i}:{ts_upstream[i].Variables.port}/"
         ts.Disk.remap_config.AddLine(
-            f"map {prefix} {prefix} @plugin=parent_select.so @pparam=" +
-            ts.Variables.CONFIGDIR +
+            f"map {prefix} {prefix} @plugin=parent_select.so @pparam=" + ts.Variables.CONFIGDIR +
             "/strategies.yaml @pparam=the-strategy")
 
 tr = Test.AddTestRun()
@@ -166,7 +165,6 @@ for i in range(num_upstream):
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     "grep -e '^+++' -e '^[A-Z].*TTP/' -e '^.alts. --' -e 'PARENT_SPECIFIED' trace_peer*.log"
-    " | sed 's/^.*(pparent_select) [^ ]* //' | sed 's/[.][0-9]*$$//' " + normalize_ports
-)
+    " | sed 's/^.*(pparent_select) [^ ]* //' | sed 's/[.][0-9]*$$//' " + normalize_ports)
 tr.Processes.Default.Streams.stdout = "peer2.trace.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/prefetch_simple/prefetch_simple.test.py
+++ b/tests/gold_tests/pluginTest/prefetch_simple/prefetch_simple.test.py
@@ -27,15 +27,14 @@ for i in range(4):
             f"GET /texts/demo-{i + 1}.txt HTTP/1.1\r\n"
             "Host: does.not.matter\r\n"  # But cannot be omitted.
             "\r\n",
-            "timestamp": "1469733493.993",
-            "body": ""
+        "timestamp": "1469733493.993",
+        "body": ""
     }
     response_header = {
-        "headers":
-            "HTTP/1.1 200 OK\r\n"
-            "Connection: close\r\n"
-            "Cache-control: max-age=85000\r\n"
-            "\r\n",
+        "headers": "HTTP/1.1 200 OK\r\n"
+                   "Connection: close\r\n"
+                   "Cache-control: max-age=85000\r\n"
+                   "\r\n",
         "timestamp": "1469733493.993",
         "body": f"This is the body for demo-{i + 1}.txt.\n"
     }
@@ -44,21 +43,17 @@ for i in range(4):
 dns = Test.MakeDNServer("dns")
 
 ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|prefetch',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
-    'proxy.config.dns.resolv_conf': "NULL",
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|prefetch',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+        'proxy.config.dns.resolv_conf': "NULL",
+    })
 ts.Disk.remap_config.AddLine(
-    f"map http://domain.in http://127.0.0.1:{server.Variables.Port}" +
-    " @plugin=cachekey.so @pparam=--remove-all-params=true"
-    " @plugin=prefetch.so" +
-    " @pparam=--front=true" +
-    " @pparam=--fetch-policy=simple" +
-    r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" +
-    " @pparam=--fetch-count=3"
-)
+    f"map http://domain.in http://127.0.0.1:{server.Variables.Port}" + " @plugin=cachekey.so @pparam=--remove-all-params=true"
+    " @plugin=prefetch.so" + " @pparam=--front=true" + " @pparam=--fetch-policy=simple" +
+    r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" + " @pparam=--fetch-count=3")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
@@ -68,14 +63,10 @@ tr.Processes.Default.Command = 'echo start TS, HTTP server and DNS.'
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = (
-    f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1.txt'
-)
+tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1.txt')
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = (
-    "grep 'GET http://domain.in' trace.log"
-)
+tr.Processes.Default.Command = ("grep 'GET http://domain.in' trace.log")
 tr.Streams.stdout = "prefetch_simple.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -137,7 +137,7 @@ path1_rule = 'path1 {}\n'.format(int(time.time()) + 600)
 
 # Define first revision for when trafficserver starts
 ts.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
-    "# Empty\n"
+    "# Empty\n",
 ])
 
 ts.Disk.remap_config.AddLine(
@@ -190,7 +190,7 @@ tr = Test.AddTestRun("Reload config add path1")
 # happens after the delay.)
 tr.DelayStart = 1
 tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
-    path1_rule
+    path1_rule,
 ])
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
@@ -224,7 +224,7 @@ tr = Test.AddTestRun("Reload config add path2")
 tr.DelayStart = 1
 tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
     path1_rule,
-    'path2 {}\n'.format(int(time.time()) + 700)
+    'path2 {}\n'.format(int(time.time()) + 700),
 ])
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate.test.py
@@ -18,6 +18,7 @@
 
 import os
 import time
+
 Test.Summary = '''
 Test a basic regex_revalidate
 '''
@@ -32,10 +33,7 @@ Test a basic regex_revalidate
 # If the rule disappears from regex_revalidate.conf its still loaded!!
 # A rule's expiry can't be changed after the fact!
 
-Test.SkipUnless(
-    Condition.PluginExists('regex_revalidate.so'),
-    Condition.PluginExists('xdebug.so')
-)
+Test.SkipUnless(Condition.PluginExists('regex_revalidate.so'), Condition.PluginExists('xdebug.so'))
 Test.ContinueOnFail = False
 
 # configure origin server
@@ -48,76 +46,56 @@ Test.testName = "regex_revalidate"
 Test.Setup.Copy("metrics.sh")
 
 # default root
-request_header_0 = {"headers":
-                    "GET / HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": "",
-                    }
+request_header_0 = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_0 = {"headers":
-                     "HTTP/1.1 200 OK\r\n" +
-                     "Connection: close\r\n" +
-                     "Cache-Control: max-age=300\r\n" +
-                     "\r\n",
-                     "timestamp": "1469733493.993",
-                     "body": "xxx",
-                     }
+response_header_0 = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "Cache-Control: max-age=300\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx",
+}
 
 # cache item path1
-request_header_1 = {"headers":
-                    "GET /path1 HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""
-                    }
-response_header_1 = {"headers":
-                     "HTTP/1.1 200 OK\r\n" +
-                     "Connection: close\r\n" +
-                     'Etag: "path1"\r\n' +
-                     "Cache-Control: max-age=600,public\r\n" +
-                     "\r\n",
-                     "timestamp": "1469733493.993",
-                     "body": "abc"
-                     }
+request_header_1 = {
+    "headers": "GET /path1 HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header_1 = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + 'Etag: "path1"\r\n' + "Cache-Control: max-age=600,public\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "abc"
+}
 
 # cache item path1a
-request_header_2 = {"headers":
-                    "GET /path1a HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""
-                    }
-response_header_2 = {"headers":
-                     "HTTP/1.1 200 OK\r\n" +
-                     "Connection: close\r\n" +
-                     'Etag: "path1a"\r\n' +
-                     "Cache-Control: max-age=600,public\r\n" +
-                     "\r\n",
-                     "timestamp": "1469733493.993",
-                     "body": "cde"
-                     }
+request_header_2 = {
+    "headers": "GET /path1a HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header_2 = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + 'Etag: "path1a"\r\n' + "Cache-Control: max-age=600,public\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "cde"
+}
 
 # cache item path2a
-request_header_3 = {"headers":
-                    "GET /path2a HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""
-                    }
-response_header_3 = {"headers":
-                     "HTTP/1.1 200 OK\r\n" +
-                     "Connection: close\r\n" +
-                     'Etag: "path2a"\r\n' +
-                     "Cache-Control: max-age=900,public\r\n" +
-                     "\r\n",
-                     "timestamp": "1469733493.993",
-                     "body": "efg"
-                     }
+request_header_3 = {
+    "headers": "GET /path2a HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header_3 = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + 'Etag: "path2a"\r\n' + "Cache-Control: max-age=900,public\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "efg"
+}
 
 server.addResponse("sessionlog.json", request_header_0, response_header_0)
 server.addResponse("sessionlog.json", request_header_1, response_header_1)
@@ -126,9 +104,7 @@ server.addResponse("sessionlog.json", request_header_3, response_header_3)
 
 # Configure ATS server
 ts.Disk.plugin_config.AddLine('xdebug.so')
-ts.Disk.plugin_config.AddLine(
-    'regex_revalidate.so -d -c regex_revalidate.conf'
-)
+ts.Disk.plugin_config.AddLine('regex_revalidate.so -d -c regex_revalidate.conf')
 
 regex_revalidate_conf_path = os.path.join(ts.Variables.CONFIGDIR, 'regex_revalidate.conf')
 curl_and_args = 'curl -s -D - -v -H "x-debug: x-cache" -H "Host: www.example.com"'
@@ -136,22 +112,22 @@ curl_and_args = 'curl -s -D - -v -H "x-debug: x-cache" -H "Host: www.example.com
 path1_rule = 'path1 {}\n'.format(int(time.time()) + 600)
 
 # Define first revision for when trafficserver starts
-ts.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
-    "# Empty\n",
-])
+ts.Disk.File(
+    regex_revalidate_conf_path, typename="ats:config").AddLines([
+        "# Empty\n",
+    ])
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{}'.format(server.Variables.Port))
 
 # minimal configuration
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|regex_revalidate',
-    #    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.http.insert_age_in_response': 0,
-    'proxy.config.http.response_via_str': 3,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|regex_revalidate',
+        #    'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.response_via_str': 3,
+    })
 
 # 0 Test - Load cache (miss) (path1)
 tr = Test.AddTestRun("Cache miss path1")
@@ -189,9 +165,10 @@ tr = Test.AddTestRun("Reload config add path1")
 # the old is greater than the granularity of the time stamp used.  (The config file write
 # happens after the delay.)
 tr.DelayStart = 1
-tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
-    path1_rule,
-])
+tr.Disk.File(
+    regex_revalidate_conf_path, typename="ats:config").AddLines([
+        path1_rule,
+    ])
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'traffic_ctl config reload'
@@ -222,10 +199,11 @@ tr = Test.AddTestRun("Reload config add path2")
 # the old is greater than the granularity of the time stamp used.  (The config file write
 # happens after the delay.)
 tr.DelayStart = 1
-tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
-    path1_rule,
-    'path2 {}\n'.format(int(time.time()) + 700),
-])
+tr.Disk.File(
+    regex_revalidate_conf_path, typename="ats:config").AddLines([
+        path1_rule,
+        'path2 {}\n'.format(int(time.time()) + 700),
+    ])
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'traffic_ctl config reload'
@@ -259,10 +237,11 @@ tr = Test.AddTestRun("Reload config change path2")
 # the old is greater than the granularity of the time stamp used.  (The config file write
 # happens after the delay.)
 tr.DelayStart = 1
-tr.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLines([
-    path1_rule,
-    'path2 {}\n'.format(int(time.time()) - 100),
-])
+tr.Disk.File(
+    regex_revalidate_conf_path, typename="ats:config").AddLines([
+        path1_rule,
+        'path2 {}\n'.format(int(time.time()) - 100),
+    ])
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = 'traffic_ctl config reload'

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_miss.test.py
@@ -18,6 +18,7 @@
 
 import os
 import time
+
 Test.Summary = '''
 regex_revalidate plugin test, MISS (refetch) functionality
 '''
@@ -26,10 +27,7 @@ regex_revalidate plugin test, MISS (refetch) functionality
 # If MISS tag encountered, should load rule as refetch instead of IMS.
 # If rule switched from MISS to IMS or vice versa, rule should reset.
 
-Test.SkipUnless(
-    Condition.PluginExists('regex_revalidate.so'),
-    Condition.PluginExists('xdebug.so')
-)
+Test.SkipUnless(Condition.PluginExists('regex_revalidate.so'), Condition.PluginExists('xdebug.so'))
 Test.ContinueOnFail = False
 
 # configure origin server
@@ -42,50 +40,37 @@ Test.testName = "regex_revalidate_miss"
 Test.Setup.Copy("metrics_miss.sh")
 
 # default root
-request_header_0 = {"headers":
-                    "GET / HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": "",
-                    }
+request_header_0 = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_0 = {"headers":
-                     "HTTP/1.1 200 OK\r\n" +
-                     "Connection: close\r\n" +
-                     "Cache-Control: max-age=300\r\n" +
-                     "\r\n",
-                     "timestamp": "1469733493.993",
-                     "body": "xxx",
-                     }
+response_header_0 = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "Cache-Control: max-age=300\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx",
+}
 
 # cache item path1
-request_header_1 = {"headers":
-                    "GET /path1 HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""
-                    }
-response_header_1 = {"headers":
-                     "HTTP/1.1 200 OK\r\n" +
-                     "Connection: close\r\n" +
-                     'Etag: "path1"\r\n' +
-                     "Cache-Control: max-age=600,public\r\n" +
-                     "\r\n",
-                     "timestamp": "1469733493.993",
-                     "body": "abc"
-                     }
-
+request_header_1 = {
+    "headers": "GET /path1 HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+response_header_1 = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + 'Etag: "path1"\r\n' + "Cache-Control: max-age=600,public\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "abc"
+}
 
 server.addResponse("sessionlog.json", request_header_0, response_header_0)
 server.addResponse("sessionlog.json", request_header_1, response_header_1)
 
 # Configure ATS server
 ts.Disk.plugin_config.AddLine('xdebug.so')
-ts.Disk.plugin_config.AddLine(
-    'regex_revalidate.so -d -c regex_revalidate.conf -l revalidate.log'
-)
+ts.Disk.plugin_config.AddLine('regex_revalidate.so -d -c regex_revalidate.conf -l revalidate.log')
 
 regex_revalidate_conf_path = os.path.join(ts.Variables.CONFIGDIR, 'regex_revalidate.conf')
 #curl_and_args = 'curl -s -D - -v -H "x-debug: x-cache" -H "Host: www.example.com"'
@@ -93,23 +78,20 @@ regex_revalidate_conf_path = os.path.join(ts.Variables.CONFIGDIR, 'regex_revalid
 path1_rule = 'path1 {}'.format(int(time.time()) + 600)
 
 # Define first revision for when trafficserver starts
-ts.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLine(
-    "# Empty"
-)
+ts.Disk.File(regex_revalidate_conf_path, typename="ats:config").AddLine("# Empty")
 
-ts.Disk.remap_config.AddLine(
-    'map http://ats/ http://127.0.0.1:{}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://ats/ http://127.0.0.1:{}'.format(server.Variables.Port))
 
 # minimal configuration
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'regex_revalidate',
-    'proxy.config.http.insert_age_in_response': 0,
-    'proxy.config.http.response_via_str': 3,
-    'proxy.config.http.cache.http': 1,
-    'proxy.config.http.wait_for_cache': 1,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'regex_revalidate',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.response_via_str': 3,
+        'proxy.config.http.cache.http': 1,
+        'proxy.config.http.wait_for_cache': 1,
+    })
 
 curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x http://127.0.0.1:{}'.format(ts.Variables.port) + ' -H "x-debug: x-cache"'
 

--- a/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_state.test.py
+++ b/tests/gold_tests/pluginTest/regex_revalidate/regex_revalidate_state.test.py
@@ -18,6 +18,7 @@
 
 import os
 import time
+
 Test.Summary = '''
 regex_revalidate plugin test, reload epoch state on ats start
 '''
@@ -26,9 +27,7 @@ regex_revalidate plugin test, reload epoch state on ats start
 # Ensures that that the regex revalidate config file is loaded,
 # then epoch times from the state file are properly merged.
 
-Test.SkipUnless(
-    Condition.PluginExists('regex_revalidate.so')
-)
+Test.SkipUnless(Condition.PluginExists('regex_revalidate.so'))
 Test.ContinueOnFail = False
 
 # configure origin server
@@ -41,22 +40,17 @@ ts = Test.MakeATSProcess("ts", command="traffic_manager")
 testName = "regex_revalidate_state"
 
 # default root
-request_header_0 = {"headers":
-                    "GET / HTTP/1.1\r\n" +
-                    "Host: www.example.com\r\n" +
-                    "\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": "",
-                    }
+request_header_0 = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_0 = {"headers":
-                     "HTTP/1.1 200 OK\r\n" +
-                     "Connection: close\r\n" +
-                     "Cache-Control: max-age=300\r\n" +
-                     "\r\n",
-                     "timestamp": "1469733493.993",
-                     "body": "xxx",
-                     }
+response_header_0 = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "Cache-Control: max-age=300\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "xxx",
+}
 
 server.addResponse("sessionlog.json", request_header_0, response_header_0)
 
@@ -64,9 +58,7 @@ reval_conf_path = os.path.join(ts.Variables.CONFIGDIR, 'reval.conf')
 reval_state_path = os.path.join(Test.Variables.RUNTIMEDIR, 'reval.state')
 
 # Configure ATS server
-ts.Disk.plugin_config.AddLine(
-    f"regex_revalidate.so -d -c reval.conf -l reval.log -f {reval_state_path}"
-)
+ts.Disk.plugin_config.AddLine(f"regex_revalidate.so -d -c reval.conf -l reval.log -f {reval_state_path}")
 
 sep = ' '
 
@@ -84,10 +76,12 @@ path1_rule = sep.join([path1_regex, path1_expiry, path1_type])
 
 # Create gold files
 gold_path_good = reval_state_path + ".good"
-ts.Disk.File(gold_path_good, typename="ats:config").AddLines([
-    sep.join([path0_regex, "``", path0_expiry, path0_type]),
-    sep.join([path1_regex, path1_epoch, path1_expiry, path1_type]),
-])
+ts.Disk.File(
+    gold_path_good, typename="ats:config").AddLines(
+        [
+            sep.join([path0_regex, "``", path0_expiry, path0_type]),
+            sep.join([path1_regex, path1_epoch, path1_expiry, path1_type]),
+        ])
 
 # It seems there's no API for negative gold file matching
 '''
@@ -99,29 +93,31 @@ ts.Disk.File(gold_path_bad, typename="ats:config").AddLines([
 '''
 
 # Create a state file, second line will be discarded and not merged
-ts.Disk.File(reval_state_path, typename="ats:config").AddLines([
-    sep.join([path1_regex, path1_epoch, path1_expiry, path1_type]),
-    sep.join(["dummy", path1_epoch, path1_expiry, path1_type]),
-])
+ts.Disk.File(
+    reval_state_path, typename="ats:config").AddLines(
+        [
+            sep.join([path1_regex, path1_epoch, path1_expiry, path1_type]),
+            sep.join(["dummy", path1_epoch, path1_expiry, path1_type]),
+        ])
 
 # Write out reval.conf file
-ts.Disk.File(reval_conf_path, typename="ats:config").AddLines([
-    path0_rule, path1_rule,
-])
+ts.Disk.File(
+    reval_conf_path, typename="ats:config").AddLines([
+        path0_rule,
+        path1_rule,
+    ])
 
 ts.chownForATSProcess(reval_state_path)
 
-ts.Disk.remap_config.AddLine(
-    f"map http://ats/ http://127.0.0.1:{server.Variables.Port}"
-)
+ts.Disk.remap_config.AddLine(f"map http://ats/ http://127.0.0.1:{server.Variables.Port}")
 
 # minimal configuration
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'regex_revalidate',
-    'proxy.config.http.wait_for_cache': 1,
-})
-
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'regex_revalidate',
+        'proxy.config.http.wait_for_cache': 1,
+    })
 
 # This TestRun creates the state file so it exists when the ts process's Setup
 # logic is run so that it can be chowned at that point.

--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats.test.py
@@ -24,28 +24,23 @@ server = Test.MakeOriginServer("server")
 
 Test.Setup.Copy("metrics.sh")
 
-request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: one\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /argh HTTP/1.1\r\nHost: one\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True)
 
 ts.Disk.plugin_config.AddLine('remap_stats.so')
 
-ts.Disk.remap_config.AddLine(
-    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    "map http://two http://127.0.0.1:{0}".format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine("map http://one http://127.0.0.1:{0}".format(server.Variables.Port))
+ts.Disk.remap_config.AddLine("map http://two http://127.0.0.1:{0}".format(server.Variables.Port))
 
-ts.Disk.records_config.update({
-    'proxy.config.http.transaction_active_timeout_out': 2,
-    'proxy.config.http.transaction_no_activity_timeout_out': 2,
-    'proxy.config.http.connect_attempts_timeout': 2,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.http.transaction_active_timeout_out': 2,
+        'proxy.config.http.transaction_no_activity_timeout_out': 2,
+        'proxy.config.http.connect_attempts_timeout': 2,
+    })
 
 # 0 Test - Curl host One
 tr = Test.AddTestRun("curl host one")

--- a/tests/gold_tests/pluginTest/remap_stats/remap_stats_post.test.py
+++ b/tests/gold_tests/pluginTest/remap_stats/remap_stats_post.test.py
@@ -24,28 +24,23 @@ server = Test.MakeOriginServer("server")
 
 Test.Setup.Copy("metrics_post.sh")
 
-request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: one\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /argh HTTP/1.1\r\nHost: one\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True)
 
 ts.Disk.plugin_config.AddLine('remap_stats.so --post-remap-host')
 
-ts.Disk.remap_config.AddLine(
-    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    "map http://two http://127.0.0.1:{0}".format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine("map http://one http://127.0.0.1:{0}".format(server.Variables.Port))
+ts.Disk.remap_config.AddLine("map http://two http://127.0.0.1:{0}".format(server.Variables.Port))
 
-ts.Disk.records_config.update({
-    'proxy.config.http.transaction_active_timeout_out': 2,
-    'proxy.config.http.transaction_no_activity_timeout_out': 2,
-    'proxy.config.http.connect_attempts_timeout': 2,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.http.transaction_active_timeout_out': 2,
+        'proxy.config.http.transaction_no_activity_timeout_out': 2,
+        'proxy.config.http.connect_attempts_timeout': 2,
+    })
 
 # 0 Test - Curl host One
 tr = Test.AddTestRun("curl host one")

--- a/tests/gold_tests/pluginTest/s3_auth/s3_auth_config.test.py
+++ b/tests/gold_tests/pluginTest/s3_auth/s3_auth_config.test.py
@@ -26,16 +26,13 @@ Test.testName = "s3_auth: config parsing"
 request_header = {
     "headers": "GET /s3-bucket HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
     "timestamp": "1469733493.993",
-    "x-amz-security-token": "hkMsi6/bfHyBKrSeM/H0hoXeyx8z1yZ/mJ0c+B/TqYx=tTJDjnQWtul38Z9iVJjeH1HB4VT2c=2o3yE3o=I9kmFs/lJDR85qWjB8e5asY/WbjyRpbAzmDipQpboIcYnUYg55bxrQFidV/q8gZa5A9MpR3n=op1C0lWjeBqcEJxpevNZxteSQTQfeGsi98Cdf+On=/SINVlKrNhMnmMsDOLMGx1YYt9d4UsRg1jtVrwxL4Vd/F7aHCZySAXKv+1rkhACR023wpa3dhp+xirGJxSO9LWwvcrTdM4xJo4RS8B40tGENOJ1NKixUJxwN/6og58Oft/u==uleR89Ja=7zszK2H7tX3DqmEYNvNDYQh/7VBRe5otghQtPwJzWpXAGk+Vme4hPPM5K6axH2LxipXzRiIV=oxNs0upKNu1FvuzbCQmkQdKQVmXl0344vngngrgN7wkEfrYtmKwICmpAS0cbW9jdSClgziVo4NaFc/hsIfok=4UA3hVtxIdw74lFNXD0RR7HKXkFPLIn85M7peOZsqMUCfO4gxr7KCfabszQQf0YcP/mt79XK50=WrSJG7oUyn+clUySPhlegqHAfT9a50uSK5WiQmOnGNGLF4wDO10sqKN1xRgQbYHPtwL+Ye0EMisvmYA3==kScorTSGaQWyibSWXAvxq9+IVGBYShVJ6S7DmTT=u/2d/fGEge+Xmbxlftza=cxJ=Md=k1Q71Lp6Boa56d7wtYRpK6tXHJ9I/2r7rN1E4OtwkFqb7SfWV3UXwyUrXyaaNPTIbqnAHnbgUGtuU6pgICpfREiIxVqvKBf6ErbxHRmMmAuYKxk5E9Mn6nnbxR4WTniweKYeDv2w39zge/tss+36Moeuio9d2eoyRFqXhq=rUGtDwX3fzXV0wV+dUojxOYQ57GQDl7+68PwHPcX794OIXuGOxBk83lNIYIcYz3Vc7qnGy6tFTz7f6S9+EZuSGN7TY5VKkT2eWye46DebrDF9Nwzs/FVpTzbPD/KGDIBtFIbazglhKoWe9txqb1QW8vFNNVOEhYa+cViO3g8ZmY1wG960US2zsnX5Eg8Q5a4h3+sxaJSJ4ONiXZWJuAgKRQzcrszu+M5C0ZVoCOv1goEgfNJeSm/yFc/3rx8wmeWLIJFtq65B7zF72HRKq1nthHAguaxXr20nguHpKkDpNBDVa=WwuJsbeGI",
+    "x-amz-security-token":
+        "hkMsi6/bfHyBKrSeM/H0hoXeyx8z1yZ/mJ0c+B/TqYx=tTJDjnQWtul38Z9iVJjeH1HB4VT2c=2o3yE3o=I9kmFs/lJDR85qWjB8e5asY/WbjyRpbAzmDipQpboIcYnUYg55bxrQFidV/q8gZa5A9MpR3n=op1C0lWjeBqcEJxpevNZxteSQTQfeGsi98Cdf+On=/SINVlKrNhMnmMsDOLMGx1YYt9d4UsRg1jtVrwxL4Vd/F7aHCZySAXKv+1rkhACR023wpa3dhp+xirGJxSO9LWwvcrTdM4xJo4RS8B40tGENOJ1NKixUJxwN/6og58Oft/u==uleR89Ja=7zszK2H7tX3DqmEYNvNDYQh/7VBRe5otghQtPwJzWpXAGk+Vme4hPPM5K6axH2LxipXzRiIV=oxNs0upKNu1FvuzbCQmkQdKQVmXl0344vngngrgN7wkEfrYtmKwICmpAS0cbW9jdSClgziVo4NaFc/hsIfok=4UA3hVtxIdw74lFNXD0RR7HKXkFPLIn85M7peOZsqMUCfO4gxr7KCfabszQQf0YcP/mt79XK50=WrSJG7oUyn+clUySPhlegqHAfT9a50uSK5WiQmOnGNGLF4wDO10sqKN1xRgQbYHPtwL+Ye0EMisvmYA3==kScorTSGaQWyibSWXAvxq9+IVGBYShVJ6S7DmTT=u/2d/fGEge+Xmbxlftza=cxJ=Md=k1Q71Lp6Boa56d7wtYRpK6tXHJ9I/2r7rN1E4OtwkFqb7SfWV3UXwyUrXyaaNPTIbqnAHnbgUGtuU6pgICpfREiIxVqvKBf6ErbxHRmMmAuYKxk5E9Mn6nnbxR4WTniweKYeDv2w39zge/tss+36Moeuio9d2eoyRFqXhq=rUGtDwX3fzXV0wV+dUojxOYQ57GQDl7+68PwHPcX794OIXuGOxBk83lNIYIcYz3Vc7qnGy6tFTz7f6S9+EZuSGN7TY5VKkT2eWye46DebrDF9Nwzs/FVpTzbPD/KGDIBtFIbazglhKoWe9txqb1QW8vFNNVOEhYa+cViO3g8ZmY1wG960US2zsnX5Eg8Q5a4h3+sxaJSJ4ONiXZWJuAgKRQzcrszu+M5C0ZVoCOv1goEgfNJeSm/yFc/3rx8wmeWLIJFtq65B7zF72HRKq1nthHAguaxXr20nguHpKkDpNBDVa=WwuJsbeGI",
     "body": ""
 }
 
 # desired response form the origin server
-response_header = {
-    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-    "timestamp": "1469733493.993",
-    "body": "success!"
-}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "success!"}
 
 # add request/response
 server.addResponse("sessionlog.log", request_header, response_header)
@@ -50,8 +47,7 @@ ts.Setup.CopyAs('rules/v4-parse-test.test_input', Test.RunDirectory)
 ts.Disk.remap_config.AddLine(
     f'map http://www.example.com http://127.0.0.1:{server.Variables.Port} \
         @plugin=s3_auth.so \
-            @pparam=--config @pparam={Test.RunDirectory}/v4-parse-test.test_input'
-)
+            @pparam=--config @pparam={Test.RunDirectory}/v4-parse-test.test_input')
 
 # Test Case
 tr = Test.AddTestRun()

--- a/tests/gold_tests/pluginTest/server_push_preload/server_push_preload.test.py
+++ b/tests/gold_tests/pluginTest/server_push_preload/server_push_preload.test.py
@@ -22,8 +22,7 @@ Test for server_push_preload plugin
 
 Test.SkipUnless(
     Condition.PluginExists('server_push_preload.so'),
-    Condition.HasProgram("nghttp",
-                         "Nghttp need to be installed on system for this test to work"),
+    Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
 )
 Test.testName = "server_push_preload"
 Test.ContinueOnFail = True
@@ -34,22 +33,36 @@ Test.ContinueOnFail = True
 microserver = Test.MakeOriginServer("microserver")
 
 # index.html
-microserver.addResponse("sessionfile.log",
-                        {"headers": "GET /index.html HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "body": ""},
-                        {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\nLink: </app/style.css>; rel=preload; as=style; nopush\r\nLink: </app/script.js>; rel=preload; as=script\r\n\r\n",
-                         "body": "<html>\r\n<head>\r\n<link rel='stylesheet' type='text/css' href='/app/style.css' />\r\n<script src='/app/script.js'></script>\r\n</head>\r\n<body>\r\nServer Push Preload Test\r\n</body>\r\n</html>\r\n"})
+microserver.addResponse(
+    "sessionfile.log", {
+        "headers": "GET /index.html HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "body": ""
+    }, {
+        "headers":
+            "HTTP/1.1 200 OK\r\nConnection: close\r\nLink: </app/style.css>; rel=preload; as=style; nopush\r\nLink: </app/script.js>; rel=preload; as=script\r\n\r\n",
+        "body":
+            "<html>\r\n<head>\r\n<link rel='stylesheet' type='text/css' href='/app/style.css' />\r\n<script src='/app/script.js'></script>\r\n</head>\r\n<body>\r\nServer Push Preload Test\r\n</body>\r\n</html>\r\n"
+    })
 
 # /app/style.css
-microserver.addResponse("sessionfile.log",
-                        {"headers": "GET /app/style.css HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "body": ""},
-                        {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                         "body": "body { font-weight: bold; }\r\n"})
+microserver.addResponse(
+    "sessionfile.log", {
+        "headers": "GET /app/style.css HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+        "body": "body { font-weight: bold; }\r\n"
+    })
 
 # /app/script.js
-microserver.addResponse("sessionfile.log",
-                        {"headers": "GET /app/script.js HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "body": ""},
-                        {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                         "body": "function do_nothing() { return; }\r\n"})
+microserver.addResponse(
+    "sessionfile.log", {
+        "headers": "GET /app/script.js HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+        "body": ""
+    }, {
+        "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+        "body": "function do_nothing() { return; }\r\n"
+    })
 
 # ----
 # Setup ATS
@@ -58,22 +71,18 @@ ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}/ @plugin=server_push_preload.so'.format(
-        microserver.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}/ @plugin=server_push_preload.so'.format(microserver.Variables.Port))
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http2|server_push_preload',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http2.active_timeout_in': 3,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http2|server_push_preload',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.http2.active_timeout_in': 3,
+    })
 
 # ----
 # Test Cases
@@ -81,11 +90,9 @@ ts.Disk.records_config.update({
 
 # Test Case 0: Server Push by Link header
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = "nghttp -vs --no-dep 'https://127.0.0.1:{0}/index.html'".format(
-    ts.Variables.ssl_port)
+tr.Processes.Default.Command = "nghttp -vs --no-dep 'https://127.0.0.1:{0}/index.html'".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.StartBefore(
-    microserver, ready=When.PortOpen(microserver.Variables.Port))
+tr.Processes.Default.StartBefore(microserver, ready=When.PortOpen(microserver.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stdout = "gold/server_push_preload_0_stdout.gold"
 tr.StillRunningAfter = microserver

--- a/tests/gold_tests/pluginTest/slice/slice.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice.test.py
@@ -25,9 +25,7 @@ Basic slice plugin test
 # Reload remap rule with slice plugin
 # Request content through the slice plugin
 
-Test.SkipUnless(
-    Condition.PluginExists('slice.so'),
-)
+Test.SkipUnless(Condition.PluginExists('slice.so'),)
 Test.ContinueOnFail = False
 
 # configure origin server
@@ -37,59 +35,49 @@ server = Test.MakeOriginServer("server")
 ts = Test.MakeATSProcess("ts", command="traffic_server")
 
 # default root
-request_header_chk = {"headers":
-                      "GET / HTTP/1.1\r\n" +
-                      "Host: ats\r\n" +
-                      "\r\n",
-                      "timestamp": "1469733493.993",
-                      "body": "",
-                      }
+request_header_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: ats\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_chk = {"headers":
-                       "HTTP/1.1 200 OK\r\n" +
-                       "Connection: close\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "",
-                       }
+response_header_chk = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
 server.addResponse("sessionlog.json", request_header_chk, response_header_chk)
 
 block_bytes = 7
 body = "lets go surfin now"
 
-request_header = {"headers":
-                  "GET /path HTTP/1.1\r\n" +
-                  "Host: origin\r\n" +
-                  "\r\n",
-                  "timestamp": "1469733493.993",
-                  "body": "",
-                  }
+request_header = {
+    "headers": "GET /path HTTP/1.1\r\n" + "Host: origin\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header = {"headers":
-                   "HTTP/1.1 200 OK\r\n" +
-                   "Connection: close\r\n" +
-                   'Etag: "path"\r\n' +
-                   "Cache-Control: max-age=500\r\n" +
-                   "\r\n",
-                   "timestamp": "1469733493.993",
-                   "body": body,
-                   }
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + 'Etag: "path"\r\n' + "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body,
+}
 
 server.addResponse("sessionlog.json", request_header, response_header)
 
 curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x http://127.0.0.1:{}'.format(ts.Variables.port)
 
 # set up whole asset fetch into cache
-ts.Disk.remap_config.AddLines([
-    f'map http://preload/ http://127.0.0.1:{server.Variables.Port}',
-    f'map http://slice_only/ http://127.0.0.1:{server.Variables.Port}',
-    f'map http://slice/ http://127.0.0.1:{server.Variables.Port}' +
-    f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}',
-    f'map http://slicehdr/ http://127.0.0.1:{server.Variables.Port}' +
-    f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}' +
-    ' @pparam=--skip-header=SkipSlice',
-])
+ts.Disk.remap_config.AddLines(
+    [
+        f'map http://preload/ http://127.0.0.1:{server.Variables.Port}',
+        f'map http://slice_only/ http://127.0.0.1:{server.Variables.Port}',
+        f'map http://slice/ http://127.0.0.1:{server.Variables.Port}' +
+        f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}',
+        f'map http://slicehdr/ http://127.0.0.1:{server.Variables.Port}' +
+        f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}' + ' @pparam=--skip-header=SkipSlice',
+    ])
 
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 0,

--- a/tests/gold_tests/pluginTest/slice/slice_error.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_error.test.py
@@ -25,9 +25,7 @@ Slice plugin error.log test
 # Reload remap rule with slice plugin
 # Request content through the slice plugin
 
-Test.SkipUnless(
-    Condition.PluginExists('slice.so'),
-)
+Test.SkipUnless(Condition.PluginExists('slice.so'),)
 Test.ContinueOnFail = False
 
 # configure origin server
@@ -39,22 +37,17 @@ ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
 body = "the quick brown fox"  # len 19
 
 # default root
-request_header_chk = {"headers":
-                      "GET / HTTP/1.1\r\n" +
-                      "Host: ats\r\n" +
-                      "Range: bytes=0-\r\n" +
-                      "\r\n",
-                      "timestamp": "1469733493.993",
-                      "body": "",
-                      }
+request_header_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes=0-\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_chk = {"headers":
-                       "HTTP/1.1 206 Partial Content\r\n" +
-                       "Connection: close\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": body,
-                       }
+response_header_chk = {
+    "headers": "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body,
+}
 
 server.addResponse("sessionlog.json", request_header_chk, response_header_chk)
 
@@ -68,217 +61,174 @@ body1 = body[blockbytes:2 * blockbytes]
 
 # Mismatch etag
 
-request_header_etag0 = {"headers":
-                        "GET /etag HTTP/1.1\r\n" +
-                        "Host: ats\r\n" +
-                        "Range: bytes={}\r\n".format(range0) +
-                        "X-Slicer-Info: full content request\r\n" +
-                        "\r\n",
-                        "timestamp": "1469733493.993",
-                        "body": "",
-                        }
+request_header_etag0 = {
+    "headers":
+        "GET /etag HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range0) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_etag0 = {"headers":
-                         "HTTP/1.1 206 Partial Content\r\n" +
-                         "Connection: close\r\n" +
-                         'Etag: "etag0"\r\n' +
-                         "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
-                         "Cache-Control: max-age=500\r\n" +
-                         "\r\n",
-                         "timestamp": "1469733493.993",
-                         "body": body0,
-                         }
+response_header_etag0 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + 'Etag: "etag0"\r\n' +
+        "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) + "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body0,
+}
 
 server.addResponse("sessionlog.json", request_header_etag0, response_header_etag0)
 
-request_header_etag1 = {"headers":
-                        "GET /etag HTTP/1.1\r\n" +
-                        "Host: ats\r\n" +
-                        "Range: bytes={}\r\n".format(range1) +
-                        "X-Slicer-Info: full content request\r\n" +
-                        "\r\n",
-                        "timestamp": "1469733493.993",
-                        "body": "",
-                        }
+request_header_etag1 = {
+    "headers":
+        "GET /etag HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range1) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_etag1 = {"headers":
-                         "HTTP/1.1 206 Partial Content\r\n" +
-                         "Connection: close\r\n" +
-                         'Etag: "etag1"\r\n' +
-                         "Content-Range: bytes {}/{}\r\n".format(range1, len(body)) +
-                         "Cache-Control: max-age=500\r\n" +
-                         "\r\n",
-                         "timestamp": "1469733493.993",
-                         "body": body1,
-                         }
+response_header_etag1 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + 'Etag: "etag1"\r\n' +
+        "Content-Range: bytes {}/{}\r\n".format(range1, len(body)) + "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body1,
+}
 
 server.addResponse("sessionlog.json", request_header_etag1, response_header_etag1)
 
 # mismatch Last-Modified
 
-request_header_lm0 = {"headers":
-                      "GET /lastmodified HTTP/1.1\r\n" +
-                      "Host: ats\r\n" +
-                      "Range: bytes={}\r\n".format(range0) +
-                      "X-Slicer-Info: full content request\r\n" +
-                      "\r\n",
-                      "timestamp": "1469733493.993",
-                      "body": "",
-                      }
+request_header_lm0 = {
+    "headers":
+        "GET /lastmodified HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range0) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_lm0 = {"headers":
-                       "HTTP/1.1 206 Partial Content\r\n" +
-                       "Connection: close\r\n" +
-                       "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" +
-                       "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
-                       "Cache-Control: max-age=500\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": body0,
-                       }
+response_header_lm0 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" +
+        "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) + "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body0,
+}
 
 server.addResponse("sessionlog.json", request_header_lm0, response_header_lm0)
 
-request_header_lm1 = {"headers":
-                      "GET /lastmodified HTTP/1.1\r\n" +
-                      "Host: ats\r\n" +
-                      "Range: bytes={}\r\n".format(range1) +
-                      "X-Slicer-Info: full content request\r\n" +
-                      "\r\n",
-                      "timestamp": "1469733493.993",
-                      "body": "",
-                      }
+request_header_lm1 = {
+    "headers":
+        "GET /lastmodified HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range1) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_lm1 = {"headers":
-                       "HTTP/1.1 206 Partial Content\r\n" +
-                       "Connection: close\r\n" +
-                       "Last-Modified: Tue, 08 Apr 2019 18:00:00 GMT\r\n" +
-                       "Content-Range: bytes {}/{}\r\n".format(range1, len(body)) +
-                       "Cache-Control: max-age=500\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": body1,
-                       }
+response_header_lm1 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + "Last-Modified: Tue, 08 Apr 2019 18:00:00 GMT\r\n" +
+        "Content-Range: bytes {}/{}\r\n".format(range1, len(body)) + "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body1,
+}
 
 server.addResponse("sessionlog.json", request_header_lm1, response_header_lm1)
 
 # non 206 slice block
 
-request_header_n206_0 = {"headers":
-                         "GET /non206 HTTP/1.1\r\n" +
-                         "Host: ats\r\n" +
-                         "Range: bytes={}\r\n".format(range0) +
-                         "X-Slicer-Info: full content request\r\n" +
-                         "\r\n",
-                         "timestamp": "1469733493.993",
-                         "body": "",
-                         }
+request_header_n206_0 = {
+    "headers":
+        "GET /non206 HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range0) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_n206_0 = {"headers":
-                          "HTTP/1.1 206 Partial Content\r\n" +
-                          "Connection: close\r\n" +
-                          'Etag: "etag"\r\n' +
-                          "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" +
-                          "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
-                          "Cache-Control: max-age=500\r\n" +
-                          "\r\n",
-                          "timestamp": "1469733493.993",
-                          "body": body0,
-                          }
+response_header_n206_0 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + 'Etag: "etag"\r\n' +
+        "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" + "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
+        "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body0,
+}
 
 server.addResponse("sessionlog.json", request_header_n206_0, response_header_n206_0)
 
-request_header_n206_1 = {"headers":
-                         "GET /non206 HTTP/1.1\r\n" +
-                         "Host: ats\r\n" +
-                         "Range: bytes={}\r\n".format(range1) +
-                         "X-Slicer-Info: full content request\r\n" +
-                         "\r\n",
-                         "timestamp": "1469733493.993",
-                         "body": "",
-                         }
+request_header_n206_1 = {
+    "headers":
+        "GET /non206 HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range1) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_n206_1 = {"headers":
-                          "HTTP/1.1 502 Bad Gateway\r\n" +
-                          "Connection: close\r\n" +
-                          "\r\n",
-                          "timestamp": "1469733493.993",
-                          "body": body1,
-                          }
+response_header_n206_1 = {
+    "headers": "HTTP/1.1 502 Bad Gateway\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body1,
+}
 
 server.addResponse("sessionlog.json", request_header_n206_1, response_header_n206_1)
 
 # mismatch content-range
 
-request_header_crr0 = {"headers":
-                       "GET /crr HTTP/1.1\r\n" +
-                       "Host: ats\r\n" +
-                       "Range: bytes={}\r\n".format(range0) +
-                       "X-Slicer-Info: full content request\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "",
-                       }
+request_header_crr0 = {
+    "headers":
+        "GET /crr HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range0) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_crr0 = {"headers":
-                        "HTTP/1.1 206 Partial Content\r\n" +
-                        "Connection: close\r\n" +
-                        "Etag: crr\r\n" +
-                        "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
-                        "Cache-Control: max-age=500\r\n" +
-                        "\r\n",
-                        "timestamp": "1469733493.993",
-                        "body": body0,
-                        }
+response_header_crr0 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + "Etag: crr\r\n" +
+        "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) + "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body0,
+}
 
 server.addResponse("sessionlog.json", request_header_crr0, response_header_crr0)
 
-request_header_crr1 = {"headers":
-                       "GET /crr HTTP/1.1\r\n" +
-                       "Host: ats\r\n" +
-                       "Range: bytes={}\r\n".format(range1) +
-                       "X-Slicer-Info: full content request\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "",
-                       }
+request_header_crr1 = {
+    "headers":
+        "GET /crr HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range1) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_crr1 = {"headers":
-                        "HTTP/1.1 206 Partial Content\r\n" +
-                        "Connection: close\r\n" +
-                        "Etag: crr\r\n" +
-                        "Content-Range: bytes {}/{}\r\n".format(range1, len(body) - 1) +
-                        "Cache-Control: max-age=500\r\n" +
-                        "\r\n",
-                        "timestamp": "1469733493.993",
-                        "body": body1,
-                        }
+response_header_crr1 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + "Etag: crr\r\n" +
+        "Content-Range: bytes {}/{}\r\n".format(range1,
+                                                len(body) - 1) + "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body1,
+}
 
 server.addResponse("sessionlog.json", request_header_crr1, response_header_crr1)
 
 # 404 internal block
 
-request_header_internal404_0 = {"headers":
-                                "GET /internal404 HTTP/1.1\r\n" +
-                                "Host: ats\r\n" +
-                                "Range: bytes={}\r\n".format(range0) +
-                                "X-Slicer-Info: full content request\r\n" +
-                                "\r\n",
-                                "timestamp": "1469733493.993",
-                                "body": "",
-                                }
+request_header_internal404_0 = {
+    "headers":
+        "GET /internal404 HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: bytes={}\r\n".format(range0) +
+        "X-Slicer-Info: full content request\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_internal404_0 = {"headers":
-                                 "HTTP/1.1 206 Partial Content\r\n" +
-                                 "Connection: close\r\n" +
-                                 'Etag: "etag"\r\n' +
-                                 "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" +
-                                 "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
-                                 "Cache-Control: max-age=500\r\n" +
-                                 "\r\n",
-                                 "timestamp": "1469733493.993",
-                                 "body": body0,
-                                 }
+response_header_internal404_0 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + 'Etag: "etag"\r\n' +
+        "Last-Modified: Tue, 08 May 2018 15:49:41 GMT\r\n" + "Content-Range: bytes {}/{}\r\n".format(range0, len(body)) +
+        "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body0,
+}
 
 server.addResponse("sessionlog.json", request_header_internal404_0, response_header_internal404_0)
 
@@ -286,9 +236,7 @@ curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x http://127.0.0.1:{}'.f
 
 # set up whole asset fetch into cache
 ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{}'.format(server.Variables.Port) +
-    ' @plugin=slice.so @pparam=--blockbytes-test={}'.format(blockbytes)
-)
+    'map / http://127.0.0.1:{}'.format(server.Variables.Port) + ' @plugin=slice.so @pparam=--blockbytes-test={}'.format(blockbytes))
 
 # minimal configuration
 ts.Disk.records_config.update({
@@ -300,8 +248,8 @@ ts.Disk.records_config.update({
 # taken from the slice plug code
 ts.Disk.diags_log.Content = Testers.ContainsExpression('reason="Mismatch block Etag', "Mismatch block etag")
 ts.Disk.diags_log.Content += Testers.ContainsExpression('reason="Mismatch block Last-Modified', "Mismatch block Last-Modified")
-ts.Disk.diags_log.Content += Testers.ContainsExpression('reason="Mismatch/Bad block Content-Range',
-                                                        "Mismatch/Bad block Content-Range")
+ts.Disk.diags_log.Content += Testers.ContainsExpression(
+    'reason="Mismatch/Bad block Content-Range', "Mismatch/Bad block Content-Range")
 ts.Disk.diags_log.Content += Testers.ContainsExpression('reason="404 internal block response', "404 internal block response")
 
 # 0 Test - Etag mismatch test

--- a/tests/gold_tests/pluginTest/slice/slice_purge.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_purge.test.py
@@ -43,30 +43,30 @@ class SlicePurgeRequestTest:
         self._ts = Test.MakeATSProcess(f"ts_{self._num}", enable_cache=True)
 
         if (self._ref_block):
-            self._ts.Disk.remap_config.AddLines([
-                f"map /ref/block http://127.0.0.1:{self._server.Variables.http_port} \
+            self._ts.Disk.remap_config.AddLines(
+                [
+                    f"map /ref/block http://127.0.0.1:{self._server.Variables.http_port} \
                 @plugin=slice.so @pparam=--blockbytes-test=10 \
                 @plugin=cache_range_requests.so",
-            ])
+                ])
         else:
-            self._ts.Disk.remap_config.AddLines([
-                f"map /ref/block http://127.0.0.1:{self._server.Variables.http_port} \
+            self._ts.Disk.remap_config.AddLines(
+                [
+                    f"map /ref/block http://127.0.0.1:{self._server.Variables.http_port} \
                 @plugin=slice.so @pparam=--blockbytes-test=10 @pparam=--ref-relative \
                 @plugin=cache_range_requests.so",
-            ])
+                ])
 
-        self._ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http|slice|cache_range_requests',
-        })
+        self._ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http|slice|cache_range_requests',
+            })
 
     def slice_purge(self):
         tr = Test.AddTestRun()
 
-        tr.AddVerifierClientProcess(
-            f"client_{self._num}",
-            SlicePurgeRequestTest.replay_file,
-            http_ports=[self._ts.Variables.port])
+        tr.AddVerifierClientProcess(f"client_{self._num}", SlicePurgeRequestTest.replay_file, http_ports=[self._ts.Variables.port])
 
         tr.Processes.Default.StartBefore(self._server)
         tr.Processes.Default.StartBefore(self._ts)
@@ -74,10 +74,7 @@ class SlicePurgeRequestTest:
     def slice_purge_ref(self):
         tr = Test.AddTestRun()
 
-        tr.AddVerifierClientProcess(
-            "client_ref",
-            SlicePurgeRequestTest.replay_ref_file,
-            http_ports=[self._ts.Variables.port])
+        tr.AddVerifierClientProcess("client_ref", SlicePurgeRequestTest.replay_ref_file, http_ports=[self._ts.Variables.port])
 
         tr.Processes.Default.StartBefore(self._server)
         tr.Processes.Default.StartBefore(self._ts)
@@ -85,10 +82,7 @@ class SlicePurgeRequestTest:
     def slice_purge_no_ref(self):
         tr = Test.AddTestRun()
 
-        tr.AddVerifierClientProcess(
-            "client_no_ref",
-            SlicePurgeRequestTest.replay_no_ref_file,
-            http_ports=[self._ts.Variables.port])
+        tr.AddVerifierClientProcess("client_no_ref", SlicePurgeRequestTest.replay_no_ref_file, http_ports=[self._ts.Variables.port])
 
         tr.Processes.Default.StartBefore(self._server)
         tr.Processes.Default.StartBefore(self._ts)

--- a/tests/gold_tests/pluginTest/slice/slice_regex.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_regex.test.py
@@ -25,9 +25,7 @@ slice regex plugin test
 # Reload remap rule with slice plugin
 # Request content through the slice plugin
 
-Test.SkipUnless(
-    Condition.PluginExists('slice.so'),
-)
+Test.SkipUnless(Condition.PluginExists('slice.so'),)
 Test.ContinueOnFail = False
 
 # configure origin server
@@ -37,67 +35,53 @@ server = Test.MakeOriginServer("server")
 ts = Test.MakeATSProcess("ts", command="traffic_server", enable_cache=False)
 
 # default root
-request_header_chk = {"headers":
-                      "GET / HTTP/1.1\r\n" +
-                      "Host: www.example.com\r\n" +
-                      "\r\n",
-                      "timestamp": "1469733493.993",
-                      "body": "",
-                      }
+request_header_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_chk = {"headers":
-                       "HTTP/1.1 200 OK\r\n" +
-                       "Connection: close\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "",
-                       }
+response_header_chk = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
 server.addResponse("sessionlog.json", request_header_chk, response_header_chk)
 
 body = "lets go surfin now"
 
-request_header_txt = {"headers":
-                      "GET /slice.txt HTTP/1.1\r\n" +
-                      "Host: slice\r\n" +
-                      "\r\n",
-                      "timestamp": "1469733493.993",
-                      "body": "",
-                      }
+request_header_txt = {
+    "headers": "GET /slice.txt HTTP/1.1\r\n" + "Host: slice\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_txt = {"headers":
-                       "HTTP/1.1 200 OK\r\n" +
-                       "Connection: close\r\n" +
-                       'Etag: "path"\r\n' +
-                       "Cache-Control: max-age=500\r\n" +
-                       "X-Info: notsliced\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": body,
-                       }
+response_header_txt = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + 'Etag: "path"\r\n' + "Cache-Control: max-age=500\r\n" +
+        "X-Info: notsliced\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body,
+}
 
 server.addResponse("sessionlog.json", request_header_txt, response_header_txt)
 
-request_header_mp4 = {"headers":
-                      "GET /slice.mp4 HTTP/1.1\r\n" +
-                      "Host: sliced\r\n" +
-                      "Range: bytes=0-99\r\n"
-                      "\r\n",
-                      "timestamp": "1469733493.993",
-                      "body": "",
-                      }
+request_header_mp4 = {
+    "headers": "GET /slice.mp4 HTTP/1.1\r\n" + "Host: sliced\r\n" + "Range: bytes=0-99\r\n"
+               "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-response_header_mp4 = {"headers":
-                       "HTTP/1.1 206 Partial Content\r\n" +
-                       "Connection: close\r\n" +
-                       'Etag: "path"\r\n' +
-                       "Content-Range: bytes 0-{}/{}\r\n".format(len(body) - 1, len(body)) +
-                       "Cache-Control: max-age=500\r\n" +
-                       "X-Info: sliced\r\n" +
-                       "\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": body,
-                       }
+response_header_mp4 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Connection: close\r\n" + 'Etag: "path"\r\n' +
+        "Content-Range: bytes 0-{}/{}\r\n".format(len(body) - 1, len(body)) + "Cache-Control: max-age=500\r\n" +
+        "X-Info: sliced\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body,
+}
 
 server.addResponse("sessionlog.json", request_header_mp4, response_header_mp4)
 
@@ -106,28 +90,25 @@ curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} -H "x-deb
 block_bytes = 100
 
 # set up whole asset fetch into cache
-ts.Disk.remap_config.AddLines([
-    'map http://exclude/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=slice.so' +
-    ' @pparam=--blockbytes-test={}'.format(block_bytes) +
-    ' @pparam=--exclude-regex=\\.txt'
-    ' @pparam=--remap-host=sliced',
-    'map http://include/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=slice.so' +
-    ' @pparam=--blockbytes-test={}'.format(block_bytes) +
-    ' @pparam=--include-regex=\\.mp4'
-    ' @pparam=--remap-host=sliced',
-    'map http://sliced/ http://127.0.0.1:{}/'.format(server.Variables.Port),
-])
-
+ts.Disk.remap_config.AddLines(
+    [
+        'map http://exclude/ http://127.0.0.1:{}/'.format(server.Variables.Port) + ' @plugin=slice.so' +
+        ' @pparam=--blockbytes-test={}'.format(block_bytes) + ' @pparam=--exclude-regex=\\.txt'
+        ' @pparam=--remap-host=sliced',
+        'map http://include/ http://127.0.0.1:{}/'.format(server.Variables.Port) + ' @plugin=slice.so' +
+        ' @pparam=--blockbytes-test={}'.format(block_bytes) + ' @pparam=--include-regex=\\.mp4'
+        ' @pparam=--remap-host=sliced',
+        'map http://sliced/ http://127.0.0.1:{}/'.format(server.Variables.Port),
+    ])
 
 # minimal configuration
-ts.Disk.records_config.update({
-    #  'proxy.config.diags.debug.enabled': 1,
-    #  'proxy.config.diags.debug.tags': 'slice',
-    'proxy.config.http.insert_age_in_response': 0,
-    'proxy.config.http.response_via_str': 0,
-})
+ts.Disk.records_config.update(
+    {
+        #  'proxy.config.diags.debug.enabled': 1,
+        #  'proxy.config.diags.debug.tags': 'slice',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.response_via_str': 0,
+    })
 
 # 0 Test - Exclude: ensure txt passes through
 tr = Test.AddTestRun("Exclude - asset passed through")

--- a/tests/gold_tests/pluginTest/slice/slice_rm_range.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_rm_range.test.py
@@ -38,27 +38,26 @@ class SliceStripRangeForHeadRequestTest:
         """Configure Traffic Server."""
         self._ts = Test.MakeATSProcess("ts", enable_cache=False)
 
-        self._ts.Disk.remap_config.AddLines([
-            f"map /no/range http://127.0.0.1:{self._server.Variables.http_port} \
+        self._ts.Disk.remap_config.AddLines(
+            [
+                f"map /no/range http://127.0.0.1:{self._server.Variables.http_port} \
                 @plugin=slice.so @pparam=--blockbytes-test=10 @pparam=--strip-range-for-head \
                 @plugin=cache_range_requests.so",
-            f"map /with/range http://127.0.0.1:{self._server.Variables.http_port} \
+                f"map /with/range http://127.0.0.1:{self._server.Variables.http_port} \
                 @plugin=slice.so @pparam=--blockbytes-test=10 \
                 @plugin=cache_range_requests.so",
-        ])
+            ])
 
-        self._ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http|slice|cache_range_requests',
-        })
+        self._ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http|slice|cache_range_requests',
+            })
 
     def _test_head_request_range_header(self):
         tr = Test.AddTestRun()
 
-        tr.AddVerifierClientProcess(
-            "client",
-            SliceStripRangeForHeadRequestTest.replay_file,
-            http_ports=[self._ts.Variables.port])
+        tr.AddVerifierClientProcess("client", SliceStripRangeForHeadRequestTest.replay_file, http_ports=[self._ts.Variables.port])
 
         tr.Processes.Default.StartBefore(self._server)
         tr.Processes.Default.StartBefore(self._ts)

--- a/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
+++ b/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
@@ -30,8 +30,7 @@ Test.Disk.File('sslheaders.log').Content = 'sslheaders.gold'
 
 server = Test.MakeOriginServer("server", options={'--load': Test.TestDirectory + '/observer.py'})
 
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
@@ -42,37 +41,30 @@ ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 ts.addDefaultSSLFiles()
 # ts.addSSLfile("ssl/signer.pem")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http.server_ports': (
-        'ipv4:{0} ipv4:{1}:proto=http2;http:ssl ipv6:{0} ipv6:{1}:proto=http2;http:ssl'
-        .format(ts.Variables.port, ts.Variables.ssl_port)),
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.http.server_ports':
+            (
+                'ipv4:{0} ipv4:{1}:proto=http2;http:ssl ipv6:{0} ipv6:{1}:proto=http2;http:ssl'.format(
+                    ts.Variables.port, ts.Variables.ssl_port)),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.remap_config.AddLine(
-    'map http://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    'map https://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map http://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map https://bar.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.plugin_config.AddLine(
-    'sslheaders.so SSL-Client-ID=client.subject'
-)
+ts.Disk.plugin_config.AddLine('sslheaders.so SSL-Client-ID=client.subject')
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Command = (
     'curl -H "SSL-Client-ID: My Fake Client ID" --verbose --ipv4 --insecure --header "Host: bar.com"' +
-    ' https://localhost:{}'.format(ts.Variables.ssl_port)
-)
+    ' https://localhost:{}'.format(ts.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
+++ b/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
@@ -40,16 +40,8 @@ cert_path = os.path.join(Test.RunDirectory, 'self_signed.crt')
 key_path = os.path.join(Test.RunDirectory, 'self_signed.key')
 server_list_path = os.path.join(Test.RunDirectory, 'server_list.yaml')
 
-request_header1 = {
-    'headers': 'GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n',
-    'timestamp': '1469733493.993',
-    'body': ''
-}
-response_header1 = {
-    'headers': 'HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n',
-    'timestamp': '1469733493.993',
-    'body': 'curl test'
-}
+request_header1 = {'headers': 'GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n', 'timestamp': '1469733493.993', 'body': ''}
+response_header1 = {'headers': 'HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n', 'timestamp': '1469733493.993', 'body': 'curl test'}
 server.addResponse('sessionlog.json', request_header1, response_header1)
 
 stek_share_conf_path_1 = os.path.join(ts1.Variables.CONFIGDIR, 'stek_share_conf.yaml')
@@ -64,127 +56,202 @@ ts3.Disk.File(stek_share_conf_path_3, id="stek_share_conf_3", typename="ats:conf
 ts4.Disk.File(stek_share_conf_path_4, id="stek_share_conf_4", typename="ats:config")
 ts5.Disk.File(stek_share_conf_path_5, id="stek_share_conf_5", typename="ats:config")
 
-ts1.Disk.stek_share_conf_1.AddLines([
-    'server_id: 1',
-    'address: 127.0.0.1',
-    'port: 10001',
-    'asio_thread_pool_size: 4',
-    'heart_beat_interval: 100',
-    'election_timeout_lower_bound: 200',
-    'election_timeout_upper_bound: 400',
-    'reserved_log_items: 5',
-    'snapshot_distance: 5',
-    'client_req_timeout: 3000',  # this is in milliseconds
-    'key_update_interval: 3600',  # this is in seconds
-    'server_list_file: {0}'.format(server_list_path),
-    'root_cert_file: {0}'.format(cert_path),
-    'server_cert_file: {0}'.format(cert_path),
-    'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
-])
+ts1.Disk.stek_share_conf_1.AddLines(
+    [
+        'server_id: 1',
+        'address: 127.0.0.1',
+        'port: 10001',
+        'asio_thread_pool_size: 4',
+        'heart_beat_interval: 100',
+        'election_timeout_lower_bound: 200',
+        'election_timeout_upper_bound: 400',
+        'reserved_log_items: 5',
+        'snapshot_distance: 5',
+        'client_req_timeout: 3000',  # this is in milliseconds
+        'key_update_interval: 3600',  # this is in seconds
+        'server_list_file: {0}'.format(server_list_path),
+        'root_cert_file: {0}'.format(cert_path),
+        'server_cert_file: {0}'.format(cert_path),
+        'server_key_file: {0}'.format(key_path),
+        'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
+    ])
 
-ts2.Disk.stek_share_conf_2.AddLines([
-    'server_id: 2',
-    'address: 127.0.0.1',
-    'port: 10002',
-    'asio_thread_pool_size: 4',
-    'heart_beat_interval: 100',
-    'election_timeout_lower_bound: 200',
-    'election_timeout_upper_bound: 400',
-    'reserved_log_items: 5',
-    'snapshot_distance: 5',
-    'client_req_timeout: 3000',  # this is in milliseconds
-    'key_update_interval: 3600',  # this is in seconds
-    'server_list_file: {0}'.format(server_list_path),
-    'root_cert_file: {0}'.format(cert_path),
-    'server_cert_file: {0}'.format(cert_path),
-    'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
-])
+ts2.Disk.stek_share_conf_2.AddLines(
+    [
+        'server_id: 2',
+        'address: 127.0.0.1',
+        'port: 10002',
+        'asio_thread_pool_size: 4',
+        'heart_beat_interval: 100',
+        'election_timeout_lower_bound: 200',
+        'election_timeout_upper_bound: 400',
+        'reserved_log_items: 5',
+        'snapshot_distance: 5',
+        'client_req_timeout: 3000',  # this is in milliseconds
+        'key_update_interval: 3600',  # this is in seconds
+        'server_list_file: {0}'.format(server_list_path),
+        'root_cert_file: {0}'.format(cert_path),
+        'server_cert_file: {0}'.format(cert_path),
+        'server_key_file: {0}'.format(key_path),
+        'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
+    ])
 
-ts3.Disk.stek_share_conf_3.AddLines([
-    'server_id: 3',
-    'address: 127.0.0.1',
-    'port: 10003',
-    'asio_thread_pool_size: 4',
-    'heart_beat_interval: 100',
-    'election_timeout_lower_bound: 200',
-    'election_timeout_upper_bound: 400',
-    'reserved_log_items: 5',
-    'snapshot_distance: 5',
-    'client_req_timeout: 3000',  # this is in milliseconds
-    'key_update_interval: 3600',  # this is in seconds
-    'server_list_file: {0}'.format(server_list_path),
-    'root_cert_file: {0}'.format(cert_path),
-    'server_cert_file: {0}'.format(cert_path),
-    'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
-])
+ts3.Disk.stek_share_conf_3.AddLines(
+    [
+        'server_id: 3',
+        'address: 127.0.0.1',
+        'port: 10003',
+        'asio_thread_pool_size: 4',
+        'heart_beat_interval: 100',
+        'election_timeout_lower_bound: 200',
+        'election_timeout_upper_bound: 400',
+        'reserved_log_items: 5',
+        'snapshot_distance: 5',
+        'client_req_timeout: 3000',  # this is in milliseconds
+        'key_update_interval: 3600',  # this is in seconds
+        'server_list_file: {0}'.format(server_list_path),
+        'root_cert_file: {0}'.format(cert_path),
+        'server_cert_file: {0}'.format(cert_path),
+        'server_key_file: {0}'.format(key_path),
+        'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
+    ])
 
-ts4.Disk.stek_share_conf_4.AddLines([
-    'server_id: 4',
-    'address: 127.0.0.1',
-    'port: 10004',
-    'asio_thread_pool_size: 4',
-    'heart_beat_interval: 100',
-    'election_timeout_lower_bound: 200',
-    'election_timeout_upper_bound: 400',
-    'reserved_log_items: 5',
-    'snapshot_distance: 5',
-    'client_req_timeout: 3000',  # this is in milliseconds
-    'key_update_interval: 3600',  # this is in seconds
-    'server_list_file: {0}'.format(server_list_path),
-    'root_cert_file: {0}'.format(cert_path),
-    'server_cert_file: {0}'.format(cert_path),
-    'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
-])
+ts4.Disk.stek_share_conf_4.AddLines(
+    [
+        'server_id: 4',
+        'address: 127.0.0.1',
+        'port: 10004',
+        'asio_thread_pool_size: 4',
+        'heart_beat_interval: 100',
+        'election_timeout_lower_bound: 200',
+        'election_timeout_upper_bound: 400',
+        'reserved_log_items: 5',
+        'snapshot_distance: 5',
+        'client_req_timeout: 3000',  # this is in milliseconds
+        'key_update_interval: 3600',  # this is in seconds
+        'server_list_file: {0}'.format(server_list_path),
+        'root_cert_file: {0}'.format(cert_path),
+        'server_cert_file: {0}'.format(cert_path),
+        'server_key_file: {0}'.format(key_path),
+        'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
+    ])
 
-ts5.Disk.stek_share_conf_5.AddLines([
-    'server_id: 5',
-    'address: 127.0.0.1',
-    'port: 10005',
-    'asio_thread_pool_size: 4',
-    'heart_beat_interval: 100',
-    'election_timeout_lower_bound: 200',
-    'election_timeout_upper_bound: 400',
-    'reserved_log_items: 5',
-    'snapshot_distance: 5',
-    'client_req_timeout: 3000',  # this is in milliseconds
-    'key_update_interval: 3600',  # this is in seconds
-    'server_list_file: {0}'.format(server_list_path),
-    'root_cert_file: {0}'.format(cert_path),
-    'server_cert_file: {0}'.format(cert_path),
-    'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
-])
+ts5.Disk.stek_share_conf_5.AddLines(
+    [
+        'server_id: 5',
+        'address: 127.0.0.1',
+        'port: 10005',
+        'asio_thread_pool_size: 4',
+        'heart_beat_interval: 100',
+        'election_timeout_lower_bound: 200',
+        'election_timeout_upper_bound: 400',
+        'reserved_log_items: 5',
+        'snapshot_distance: 5',
+        'client_req_timeout: 3000',  # this is in milliseconds
+        'key_update_interval: 3600',  # this is in seconds
+        'server_list_file: {0}'.format(server_list_path),
+        'root_cert_file: {0}'.format(cert_path),
+        'server_cert_file: {0}'.format(cert_path),
+        'server_key_file: {0}'.format(key_path),
+        'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
+    ])
 
-ts1.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'stek_share', 'proxy.config.exec_thread.autoconfig': 0, 'proxy.config.exec_thread.limit': 4, 'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.session_cache': 2, 'proxy.config.ssl.session_cache.size': 1024, 'proxy.config.ssl.session_cache.timeout': 7200, 'proxy.config.ssl.session_cache.num_buckets': 16, 'proxy.config.ssl.server.session_ticket.enable': 1, 'proxy.config.ssl.server.cipher_suite':
-                                'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'})
+ts1.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'stek_share',
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.limit': 4,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 1024,
+        'proxy.config.ssl.session_cache.timeout': 7200,
+        'proxy.config.ssl.session_cache.num_buckets': 16,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
+    })
 ts1.Disk.plugin_config.AddLine('stek_share.so {0}'.format(stek_share_conf_path_1))
 ts1.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=self_signed.crt ssl_key_name=self_signed.key')
 ts1.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts2.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'stek_share', 'proxy.config.exec_thread.autoconfig': 0, 'proxy.config.exec_thread.limit': 4, 'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.session_cache': 2, 'proxy.config.ssl.session_cache.size': 1024, 'proxy.config.ssl.session_cache.timeout': 7200, 'proxy.config.ssl.session_cache.num_buckets': 16, 'proxy.config.ssl.server.session_ticket.enable': 1, 'proxy.config.ssl.server.cipher_suite':
-                                'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'})
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'stek_share',
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.limit': 4,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 1024,
+        'proxy.config.ssl.session_cache.timeout': 7200,
+        'proxy.config.ssl.session_cache.num_buckets': 16,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
+    })
 ts2.Disk.plugin_config.AddLine('stek_share.so {0}'.format(stek_share_conf_path_2))
 ts2.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=self_signed.crt ssl_key_name=self_signed.key')
 ts2.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts3.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'stek_share', 'proxy.config.exec_thread.autoconfig': 0, 'proxy.config.exec_thread.limit': 4, 'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.session_cache': 2, 'proxy.config.ssl.session_cache.size': 1024, 'proxy.config.ssl.session_cache.timeout': 7200, 'proxy.config.ssl.session_cache.num_buckets': 16, 'proxy.config.ssl.server.session_ticket.enable': 1, 'proxy.config.ssl.server.cipher_suite':
-                                'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'})
+ts3.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'stek_share',
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.limit': 4,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 1024,
+        'proxy.config.ssl.session_cache.timeout': 7200,
+        'proxy.config.ssl.session_cache.num_buckets': 16,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
+    })
 ts3.Disk.plugin_config.AddLine('stek_share.so {0}'.format(stek_share_conf_path_3))
 ts3.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=self_signed.crt ssl_key_name=self_signed.key')
 ts3.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts4.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'stek_share', 'proxy.config.exec_thread.autoconfig': 0, 'proxy.config.exec_thread.limit': 4, 'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.session_cache': 2, 'proxy.config.ssl.session_cache.size': 1024, 'proxy.config.ssl.session_cache.timeout': 7200, 'proxy.config.ssl.session_cache.num_buckets': 16, 'proxy.config.ssl.server.session_ticket.enable': 1, 'proxy.config.ssl.server.cipher_suite':
-                                'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'})
+ts4.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'stek_share',
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.limit': 4,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 1024,
+        'proxy.config.ssl.session_cache.timeout': 7200,
+        'proxy.config.ssl.session_cache.num_buckets': 16,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
+    })
 ts4.Disk.plugin_config.AddLine('stek_share.so {0}'.format(stek_share_conf_path_4))
 ts4.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=self_signed.crt ssl_key_name=self_signed.key')
 ts4.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts5.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'stek_share', 'proxy.config.exec_thread.autoconfig': 0, 'proxy.config.exec_thread.limit': 4, 'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.session_cache': 2, 'proxy.config.ssl.session_cache.size': 1024, 'proxy.config.ssl.session_cache.timeout': 7200, 'proxy.config.ssl.session_cache.num_buckets': 16, 'proxy.config.ssl.server.session_ticket.enable': 1, 'proxy.config.ssl.server.cipher_suite':
-                                'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'})
+ts5.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'stek_share',
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.limit': 4,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory),
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 1024,
+        'proxy.config.ssl.session_cache.timeout': 7200,
+        'proxy.config.ssl.session_cache.num_buckets': 16,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
+    })
 ts5.Disk.plugin_config.AddLine('stek_share.so {0}'.format(stek_share_conf_path_5))
 ts5.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=self_signed.crt ssl_key_name=self_signed.key')
 ts5.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))

--- a/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
+++ b/tests/gold_tests/pluginTest/stek_share/stek_share.test.py
@@ -80,7 +80,7 @@ ts1.Disk.stek_share_conf_1.AddLines([
     'root_cert_file: {0}'.format(cert_path),
     'server_cert_file: {0}'.format(cert_path),
     'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share'
+    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
 ])
 
 ts2.Disk.stek_share_conf_2.AddLines([
@@ -99,7 +99,7 @@ ts2.Disk.stek_share_conf_2.AddLines([
     'root_cert_file: {0}'.format(cert_path),
     'server_cert_file: {0}'.format(cert_path),
     'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share'
+    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
 ])
 
 ts3.Disk.stek_share_conf_3.AddLines([
@@ -118,7 +118,7 @@ ts3.Disk.stek_share_conf_3.AddLines([
     'root_cert_file: {0}'.format(cert_path),
     'server_cert_file: {0}'.format(cert_path),
     'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share'
+    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
 ])
 
 ts4.Disk.stek_share_conf_4.AddLines([
@@ -137,7 +137,7 @@ ts4.Disk.stek_share_conf_4.AddLines([
     'root_cert_file: {0}'.format(cert_path),
     'server_cert_file: {0}'.format(cert_path),
     'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share'
+    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
 ])
 
 ts5.Disk.stek_share_conf_5.AddLines([
@@ -156,7 +156,7 @@ ts5.Disk.stek_share_conf_5.AddLines([
     'root_cert_file: {0}'.format(cert_path),
     'server_cert_file: {0}'.format(cert_path),
     'server_key_file: {0}'.format(key_path),
-    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share'
+    'cert_verify_str: /C=US/ST=IL/O=Yahoo/OU=Edge/CN=stek-share',
 ])
 
 ts1.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1, 'proxy.config.diags.debug.tags': 'stek_share', 'proxy.config.exec_thread.autoconfig': 0, 'proxy.config.exec_thread.limit': 4, 'proxy.config.ssl.server.cert.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.server.private_key.path': '{0}'.format(Test.RunDirectory), 'proxy.config.ssl.session_cache': 2, 'proxy.config.ssl.session_cache.size': 1024, 'proxy.config.ssl.session_cache.timeout': 7200, 'proxy.config.ssl.session_cache.num_buckets': 16, 'proxy.config.ssl.server.session_ticket.enable': 1, 'proxy.config.ssl.server.cipher_suite':

--- a/tests/gold_tests/pluginTest/test_hooks/hook_add.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/hook_add.test.py
@@ -16,7 +16,6 @@
 
 import os
 
-
 Test.Summary = '''
 Test adding hooks
 '''
@@ -25,33 +24,29 @@ Test.ContinueOnFail = True
 
 server = Test.MakeOriginServer("server")
 
-request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=False, enable_cache=False)
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.tags': 'test',
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.url_remap.remap_required': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.tags': 'test',
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.url_remap.remap_required': 0,
+    })
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'hook_add_plugin.so'), ts)
 
-ts.Disk.remap_config.AddLine(
-    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine("map http://one http://127.0.0.1:{0}".format(server.Variables.Port))
 
 tr = Test.AddTestRun()
 # Probe server port to check if ready.
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 #
-tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --header "Host: one" http://localhost:{0}/argh'.format(ts.Variables.port)
-)
+tr.Processes.Default.Command = ('curl --verbose --ipv4 --header "Host: one" http://localhost:{0}/argh'.format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # Look at the debug output from the plugin

--- a/tests/gold_tests/pluginTest/test_hooks/ssn_start_delay_hook.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/ssn_start_delay_hook.test.py
@@ -16,7 +16,6 @@
 
 import os
 
-
 Test.Summary = '''
 Test adding hooks, and rescheduling the ssn start hook from a non-net thread
 '''
@@ -25,25 +24,23 @@ Test.ContinueOnFail = True
 
 server = Test.MakeOriginServer("server")
 
-request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=False)
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.tags': 'test',
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.url_remap.remap_required': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.tags': 'test',
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.url_remap.remap_required': 0,
+    })
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'hook_add_plugin.so'), ts, '-delay')
 
-ts.Disk.remap_config.AddLine(
-    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine("map http://one http://127.0.0.1:{0}".format(server.Variables.Port))
 
 tr = Test.AddTestRun()
 # Probe server port to check if ready.
@@ -51,9 +48,7 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 # Probe TS cleartext port to check if ready (probing TLS port causes spurious VCONN hook triggers).
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.port))
 #
-tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --header "Host: one" http://localhost:{0}/argh'.format(ts.Variables.port)
-)
+tr.Processes.Default.Command = ('curl --verbose --ipv4 --header "Host: one" http://localhost:{0}/argh'.format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # Look at the debug output from the plugin

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
@@ -28,18 +28,13 @@ Test.SkipUnless(
     Condition.PluginExists('traffic_dump.so'),
     Condition.HasATSFeature('TS_USE_QUIC'),
 )
-Test.SkipIf(
-    Condition.true("Skip this test until the TS_EVENT_HTTP_SSN are supported for QUIC connections."),
-)
+Test.SkipIf(Condition.true("Skip this test until the TS_EVENT_HTTP_SSN are supported for QUIC connections."),)
 
 schema_path = os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema.json')
 
 # Configure the origin server.
 replay_file = "replay/http3.yaml"
-server = Test.MakeVerifierServerProcess(
-    "server", replay_file,
-    ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem")
-
+server = Test.MakeVerifierServerProcess("server", replay_file, ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem")
 
 # Define ATS and configure it.
 ts = Test.MakeATSProcess("ts", enable_tls=True, enable_quic=True)
@@ -50,41 +45,31 @@ ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'traffic_dump|quic',
-    'proxy.config.http.insert_age_in_response': 0,
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'traffic_dump|quic',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.quic.qlog_dir': qlog_dir,
+        'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+        'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.ssl.CA.cert.filename': f'{ts.Variables.SSLDir}/signer.pem',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.http.host_sni_policy': 2,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
-    'proxy.config.quic.qlog_dir': qlog_dir,
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
-    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.ssl.CA.cert.filename': f'{ts.Variables.SSLDir}/signer.pem',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.http.host_sni_policy': 2,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
-
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-
-ts.Disk.remap_config.AddLine(
-    f'map https://www.client_only_tls.com/ http://127.0.0.1:{server.Variables.http_port}'
-)
-ts.Disk.remap_config.AddLine(
-    f'map https://www.tls.com/ https://127.0.0.1:{server.Variables.https_port}'
-)
-ts.Disk.remap_config.AddLine(
-    f'map / http://127.0.0.1:{server.Variables.http_port}'
-)
+ts.Disk.remap_config.AddLine(f'map https://www.client_only_tls.com/ http://127.0.0.1:{server.Variables.http_port}')
+ts.Disk.remap_config.AddLine(f'map https://www.tls.com/ https://127.0.0.1:{server.Variables.https_port}')
+ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.http_port}')
 
 # Configure traffic_dump.
 ts.Disk.plugin_config.AddLine(
     f'traffic_dump.so --logdir {ts_log_dir} --sample 1 --limit 1000000000 '
-    '--sensitive-fields "cookie,set-cookie,x-request-1,x-request-2"'
-)
+    '--sensitive-fields "cookie,set-cookie,x-request-1,x-request-2"')
 # Configure logging of transactions. This is helpful for the cache test below.
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -99,17 +84,14 @@ logging:
 
 # Set up trafficserver expectations.
 ts.Disk.diags_log.Content = Testers.ContainsExpression(
-    "loading plugin.*traffic_dump.so",
-    "Verify the traffic_dump plugin got loaded.")
+    "loading plugin.*traffic_dump.so", "Verify the traffic_dump plugin got loaded.")
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    f"Initialized with log directory: {ts_log_dir}",
-    "Verify traffic_dump initialized with the configured directory.")
+    f"Initialized with log directory: {ts_log_dir}", "Verify traffic_dump initialized with the configured directory.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Initialized with sample pool size of 1 bytes and disk limit of 1000000000 bytes",
     "Verify traffic_dump initialized with the configured disk limit.")
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Finish a session with log file of.*bytes",
-    "Verify traffic_dump sees the end of sessions and accounts for it.")
+    "Finish a session with log file of.*bytes", "Verify traffic_dump sees the end of sessions and accounts for it.")
 
 # Set up the json replay file expectations.
 replay_file_session_1 = os.path.join(ts_log_dir, "127", "0000000000000000")
@@ -119,10 +101,13 @@ ts.Disk.File(replay_file_session_1, exists=True)
 # are run in serial.
 tr = Test.AddTestRun("Run the test traffic.")
 tr.AddVerifierClientProcess(
-    "client", replay_file, http_ports=[ts.Variables.port],
+    "client",
+    replay_file,
+    http_ports=[ts.Variables.port],
     https_ports=[ts.Variables.ssl_port],
     http3_ports=[ts.Variables.ssl_port],
-    ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem",
+    ssl_cert="ssl/server_combined.pem",
+    ca_cert="ssl/signer.pem",
     other_args='--thread-limit 1')
 
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
@@ -24,9 +24,7 @@ Test.Summary = '''
 Verify traffic_dump IP filter functionality.
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('traffic_dump.so'),
-)
+Test.SkipUnless(Condition.PluginExists('traffic_dump.so'),)
 
 # Configure the origin server.
 replay_file = "replay/traffic_dump.yaml"
@@ -51,9 +49,7 @@ def get_common_ats_process(name, plugin_command, replay_exists):
         'proxy.config.diags.debug.enabled': 1,
         'proxy.config.diags.debug.tags': 'traffic_dump',
     })
-    ts.Disk.remap_config.AddLine(
-        f'map / http://127.0.0.1:{server.Variables.http_port}'
-    )
+    ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.http_port}')
     # Configure traffic_dump as specified.
     ts.Disk.plugin_config.AddLine(plugin_command.format(replay_dir))
 
@@ -72,15 +68,10 @@ verify_command_prefix = f'{sys.executable} {verify_replay} {schema}'
 #
 tr = Test.AddTestRun("Verify that -4 matches 127.0.0.1 as expected")
 ts1, ts1_replay_file = get_common_ats_process(
-    "ts1",
-    'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 127.0.0.1',
-    replay_exists=True)
+    "ts1", 'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 127.0.0.1', replay_exists=True)
 ts1.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Filtering to only dump connections with ip: 127.0.0.1",
-    "Verify the IP filter status message.")
-tr.AddVerifierClientProcess(
-    "client0", replay_file, http_ports=[ts1.Variables.port],
-    other_args='--keys 1')
+    "Filtering to only dump connections with ip: 127.0.0.1", "Verify the IP filter status message.")
+tr.AddVerifierClientProcess("client0", replay_file, http_ports=[ts1.Variables.port], other_args='--keys 1')
 
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts1)
@@ -100,15 +91,10 @@ tr.StillRunningAfter = ts1
 #
 tr = Test.AddTestRun("Verify that -4 filters out our non-matching IP as expected")
 ts2, ts2_replay_file = get_common_ats_process(
-    "ts2",
-    'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 1.2.3.4',
-    replay_exists=False)
+    "ts2", 'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 1.2.3.4', replay_exists=False)
 ts2.Disk.traffic_out.Content += Testers.ContainsExpression(
-    "Filtering to only dump connections with ip: 1.2.3.4",
-    "Verify the IP filter status message.")
-tr.AddVerifierClientProcess(
-    "client1", replay_file, http_ports=[ts2.Variables.port],
-    other_args='--keys 1')
+    "Filtering to only dump connections with ip: 1.2.3.4", "Verify the IP filter status message.")
+tr.AddVerifierClientProcess("client1", replay_file, http_ports=[ts2.Variables.port], other_args='--keys 1')
 
 tr.Processes.Default.StartBefore(ts2)
 tr.StillRunningAfter = server
@@ -120,15 +106,10 @@ tr.StillRunningAfter = ts2
 tr = Test.AddTestRun("Verify that -4 detects an invalid IP string")
 invalid_ip = "this_is_not_a_valid_ip_string"
 ts3, ts3_replay_file = get_common_ats_process(
-    "ts3",
-    'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 ' + invalid_ip,
-    replay_exists=False)
+    "ts3", 'traffic_dump.so --logdir {0} --sample 1 --limit 1000000000 -4 ' + invalid_ip, replay_exists=False)
 ts3.Disk.diags_log.Content = Testers.ContainsExpression(
-    f"Problems parsing IP filter address argument: {invalid_ip}",
-    "Verify traffic_dump detects an invalid IPv4 address.")
-tr.AddVerifierClientProcess(
-    "client2", replay_file, http_ports=[ts3.Variables.port],
-    other_args='--keys 1')
+    f"Problems parsing IP filter address argument: {invalid_ip}", "Verify traffic_dump detects an invalid IPv4 address.")
+tr.AddVerifierClientProcess("client2", replay_file, http_ports=[ts3.Variables.port], other_args='--keys 1')
 
 tr.Processes.Default.StartBefore(ts3)
 tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
@@ -59,7 +59,7 @@ ts.Disk.ssl_multicert_config.AddLine(
 )
 
 ts.Disk.remap_config.AddLines([
-    f'map / http://127.0.0.1:{server.Variables.http_port}'
+    f'map / http://127.0.0.1:{server.Variables.http_port}',
 ])
 
 # Configure traffic_dump to dump body bytes (-b).

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
@@ -24,9 +24,7 @@ Test.Summary = '''
 Verify traffic_dump response body functionality.
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('traffic_dump.so'),
-)
+Test.SkipUnless(Condition.PluginExists('traffic_dump.so'),)
 
 # Configure the origin server.
 replay_file = "replay/response_body.yaml"
@@ -40,32 +38,28 @@ ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'traffic_dump',
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'traffic_dump',
+        'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+        'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.ssl.CA.cert.filename': f'{ts.Variables.SSLDir}/signer.pem',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.http.host_sni_policy': 2,
+        'proxy.config.ssl.TLSv1_3': 0,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
-    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
-    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.ssl.CA.cert.filename': f'{ts.Variables.SSLDir}/signer.pem',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.http.host_sni_policy': 2,
-    'proxy.config.ssl.TLSv1_3': 0,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
-
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLines([
     f'map / http://127.0.0.1:{server.Variables.http_port}',
 ])
 
 # Configure traffic_dump to dump body bytes (-b).
-ts.Disk.plugin_config.AddLine(
-    f'traffic_dump.so --logdir {replay_dir} --sample 1 --limit 1000000000 -b'
-)
+ts.Disk.plugin_config.AddLine(f'traffic_dump.so --logdir {replay_dir} --sample 1 --limit 1000000000 -b')
 
 ts_dump_0 = os.path.join(replay_dir, "127", "0000000000000000")
 ts.Disk.File(ts_dump_0, exists=True)
@@ -79,23 +73,23 @@ ts.Disk.File(ts_dump_2, exists=True)
 ts_dump_3 = os.path.join(replay_dir, "127", "0000000000000003")
 ts.Disk.File(ts_dump_3, exists=True)
 
-ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "Dumping body bytes: true",
-    "Verify that dumping body bytes is enabled.")
+ts.Disk.traffic_out.Content = Testers.ContainsExpression("Dumping body bytes: true", "Verify that dumping body bytes is enabled.")
 
 # Run our test traffic.
 tr = Test.AddTestRun("Run the test traffic.")
 tr.AddVerifierClientProcess(
-    "client", replay_file, http_ports=[ts.Variables.port],
+    "client",
+    replay_file,
+    http_ports=[ts.Variables.port],
     https_ports=[ts.Variables.ssl_port],
-    ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem",
+    ssl_cert="ssl/server_combined.pem",
+    ca_cert="ssl/signer.pem",
     other_args='--thread-limit 1')
 
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-
 
 # Common verification variables.
 verify_replay = "verify_replay.py"

--- a/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/verify_replay.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 """
 Verify that a given JSON replay file fulfills basic expectations.
 """
@@ -128,8 +127,7 @@ def verify_client_request_size(replay_json, client_request_size):
         return False
 
     if size != client_request_size:
-        print("Mismatched client-request request size. Expected: {}, received: {}".format(
-            client_request_size, size))
+        print("Mismatched client-request request size. Expected: {}, received: {}".format(client_request_size, size))
         return False
     return True
 
@@ -180,8 +178,9 @@ def verify_protocols_helper(replay_json, expected_protocols, is_client):
             return True
         else:
             host_name = "client" if is_client else "server"
-            print('Unexpected protocol {} stack. Expected: "{}", found: "{}".'.format(
-                host_name, expected_protocols, dumped_protocols))
+            print(
+                'Unexpected protocol {} stack. Expected: "{}", found: "{}".'.format(
+                    host_name, expected_protocols, dumped_protocols))
             return False
     except KeyError:
         print("Could not find {} protocol stack node in the replay file.".format(host_name))
@@ -225,8 +224,7 @@ def verify_tls_features(expected_tls_features, found_tls_features):
             elif expected_value.lower() == "true":
                 expected_value = True
             else:
-                raise ValueError("Cannot convert expected value to a boolean: {}, found: {}".format(
-                    expected_value, found_value))
+                raise ValueError("Cannot convert expected value to a boolean: {}, found: {}".format(expected_value, found_value))
             if found_value == 'true':
                 found_value = True
             elif found_value == 'false':
@@ -238,12 +236,10 @@ def verify_tls_features(expected_tls_features, found_tls_features):
         elif isinstance(found_value, int):
             value_matches = found_value == int(expected_value)
         else:
-            raise ValueError("Cannot determine type of found value: {}".format(
-                found_value))
+            raise ValueError("Cannot determine type of found value: {}".format(found_value))
 
         if not value_matches:
-            print('Mismatched value for "{}", expected "{}", received "{}"'.format(
-                expected_key, expected_value, found_value))
+            print('Mismatched value for "{}", expected "{}", received "{}"'.format(expected_key, expected_value, found_value))
             return False
     return True
 
@@ -256,8 +252,7 @@ def verify_client_tls_features(replay_json, expected_tls_features):
         return False
 
     if not verify_tls_features(expected_tls_features, tls_features):
-        print('Failed to verify client tls features in "{}"'.format(
-            expected_tls_features))
+        print('Failed to verify client tls features in "{}"'.format(expected_tls_features))
         return False
     return True
 
@@ -270,8 +265,7 @@ def verify_server_tls_features(replay_json, expected_tls_features):
         return False
 
     if not verify_tls_features(expected_tls_features, tls_features):
-        print('Failed to verify server tls features in "{}"'.format(
-            expected_tls_features))
+        print('Failed to verify server tls features in "{}"'.format(expected_tls_features))
         return False
     return True
 
@@ -284,8 +278,7 @@ def verify_client_http_version(replay_json, expected_client_http_version):
         return False
 
     if expected_client_http_version != found_version:
-        print('Expected client version of "{}", but found "{}"'.format(
-            expected_client_http_version, found_version))
+        print('Expected client version of "{}", but found "{}"'.format(expected_client_http_version, found_version))
         return False
     return True
 
@@ -314,8 +307,9 @@ def verify_client_request_body_bytes(replay_json, expected_body_bytes):
         return False
 
     if int(proxy_request_body_size) != len(expected_body_bytes):
-        print("Expected the proxy-request content size to be '{0}' but got '{1}'".format(
-            len(expected_body_bytes), proxy_request_body_size))
+        print(
+            "Expected the proxy-request content size to be '{0}' but got '{1}'".format(
+                len(expected_body_bytes), proxy_request_body_size))
         return False
 
     return True
@@ -345,8 +339,9 @@ def verify_proxy_response_body_bytes(replay_json, expected_body_bytes):
         return False
 
     if int(server_response_body_size) != len(expected_body_bytes):
-        print("Expected the server-response content size to be '{0}' but got '{1}'".format(
-            len(expected_body_bytes), server_response_body_size))
+        print(
+            "Expected the server-response content size to be '{0}' but got '{1}'".format(
+                len(expected_body_bytes), server_response_body_size))
         return False
 
     return True
@@ -354,36 +349,21 @@ def verify_proxy_response_body_bytes(replay_json, expected_body_bytes):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("schema_file",
-                        type=argparse.FileType('r'),
-                        help="The schema in which to validate the replay file.")
-    parser.add_argument("replay_file",
-                        type=argparse.FileType('r'),
-                        help="The replay file to validate.")
-    parser.add_argument("--request-target",
-                        help="The request target ('url' element) to expect in the replay file.")
-    parser.add_argument("--client-request-size",
-                        type=int,
-                        help="The expected size value in the client-request node.")
-    parser.add_argument("--sensitive-fields",
-                        action="append",
-                        help="The fields that are considered sensitive and replaced with insensitive values.")
-    parser.add_argument("--client-protocols",
-                        help="The comma-separated sequence of protocols to expect for the client connection.")
-    parser.add_argument("--server-protocols",
-                        help="The comma-separated sequence of protocols to expect for the server connection.")
-    parser.add_argument("--client-tls-features",
-                        help="The TLS values to expect for the client connection.")
-    parser.add_argument("--server-tls-features",
-                        help="The TLS values to expect for the server connection.")
-    parser.add_argument("--client-http-version",
-                        help="The client HTTP version to expect")
-    parser.add_argument("--request_body",
-                        type=str,
-                        help="Verify that the client request has the specified body bytes.")
-    parser.add_argument("--response_body",
-                        type=str,
-                        help="Verify that the proxy response has the specified body bytes.")
+    parser.add_argument("schema_file", type=argparse.FileType('r'), help="The schema in which to validate the replay file.")
+    parser.add_argument("replay_file", type=argparse.FileType('r'), help="The replay file to validate.")
+    parser.add_argument("--request-target", help="The request target ('url' element) to expect in the replay file.")
+    parser.add_argument("--client-request-size", type=int, help="The expected size value in the client-request node.")
+    parser.add_argument(
+        "--sensitive-fields",
+        action="append",
+        help="The fields that are considered sensitive and replaced with insensitive values.")
+    parser.add_argument("--client-protocols", help="The comma-separated sequence of protocols to expect for the client connection.")
+    parser.add_argument("--server-protocols", help="The comma-separated sequence of protocols to expect for the server connection.")
+    parser.add_argument("--client-tls-features", help="The TLS values to expect for the client connection.")
+    parser.add_argument("--server-tls-features", help="The TLS values to expect for the server connection.")
+    parser.add_argument("--client-http-version", help="The client HTTP version to expect")
+    parser.add_argument("--request_body", type=str, help="Verify that the client request has the specified body bytes.")
+    parser.add_argument("--response_body", type=str, help="Verify that the proxy response has the specified body bytes.")
     return parser.parse_args()
 
 

--- a/tests/gold_tests/pluginTest/transform/transaction_data_sink.test.py
+++ b/tests/gold_tests/pluginTest/transform/transaction_data_sink.test.py
@@ -22,30 +22,26 @@ Test.Summary = '''
 Verify transaction data sink.
 '''
 
-Test.SkipUnless(
-    Condition.PluginExists('txn_data_sink.so'),
-)
+Test.SkipUnless(Condition.PluginExists('txn_data_sink.so'),)
 
 replay_file = "transaction-with-body.replays.yaml"
 server = Test.MakeVerifierServerProcess("server", replay_file)
 nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
 ts = Test.MakeATSProcess("ts", enable_cache=False)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'txn_data_sink',
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-})
-ts.Disk.remap_config.AddLine(
-    f'map / http://localhost:{server.Variables.http_port}/'
-)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'txn_data_sink',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+    })
+ts.Disk.remap_config.AddLine(f'map / http://localhost:{server.Variables.http_port}/')
 ts.Disk.plugin_config.AddLine('txn_data_sink.so')
 
 # Verify that the various aspects of the expected debug output for the
 # transaction are logged.
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    '"http1.1_response_body"',
-    "The response body should be printed by the plugin.")
+    '"http1.1_response_body"', "The response body should be printed by the plugin.")
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
@@ -16,27 +16,22 @@
 
 import os
 
-
 Test.Summary = '''
 Test TS API.
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2'),
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'),)
 Test.ContinueOnFail = True
 
 plugin_name = "test_tsapi"
 
 server = Test.MakeOriginServer("server")
 
-request_header = {
-    "headers": "GET / HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "112233"}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-request_header = {
-    "headers": "GET /xYz HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /xYz HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": "445566"}
 server.addResponse("sessionlog.json", request_header, response_header)
 
@@ -50,28 +45,25 @@ Test.Env["OUTPUT_FILE"] = log_file_name
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': f'http|{plugin_name}',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.remap_required': 1,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': f'http|{plugin_name}',
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 rp = os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'pluginTest', 'tsapi', '.libs', f'{plugin_name}.so')
 ts.Setup.Copy(rp, ts.Env['PROXY_CONFIG_PLUGIN_PLUGIN_DIR'])
 
 ts.Disk.remap_config.AddLine(
-    "map http://myhost.test http://127.0.0.1:{0} @plugin={1} @plugin={1}".format(server.Variables.Port, f"{plugin_name}.so")
-)
+    "map http://myhost.test http://127.0.0.1:{0} @plugin={1} @plugin={1}".format(server.Variables.Port, f"{plugin_name}.so"))
 ts.Disk.remap_config.AddLine(
-    "map https://myhost.test:123 http://127.0.0.1:{0} @plugin={1} @plugin={1}".format(server.Variables.Port, f"{plugin_name}.so")
-)
+    "map https://myhost.test:123 http://127.0.0.1:{0} @plugin={1} @plugin={1}".format(server.Variables.Port, f"{plugin_name}.so"))
 
 # For some reason, without this delay, traffic_server cannot reliably open the cleartext port for listening without an
 # error.
@@ -85,22 +77,17 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 #
-tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --header "Host: mYhOsT.teSt" hTtP://loCalhOst:{}/'.format(ts.Variables.port)
-)
+tr.Processes.Default.Command = ('curl --verbose --ipv4 --header "Host: mYhOsT.teSt" hTtP://loCalhOst:{}/'.format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = (
-    'curl --verbose --ipv4 --proxy localhost:{} http://mYhOsT.teSt/xYz'.format(ts.Variables.port)
-)
+tr.Processes.Default.Command = ('curl --verbose --ipv4 --proxy localhost:{} http://mYhOsT.teSt/xYz'.format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl --verbose --ipv4 --http2 --insecure --header ' +
-    '"Host: myhost.test:123" HttPs://LocalHost:{}/'.format(ts.Variables.ssl_port)
-)
+    '"Host: myhost.test:123" HttPs://LocalHost:{}/'.format(ts.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()

--- a/tests/gold_tests/pluginTest/uri_signing/uri_signing.test.py
+++ b/tests/gold_tests/pluginTest/uri_signing/uri_signing.test.py
@@ -28,43 +28,45 @@ Test.SkipUnless(Condition.PluginExists('uri_signing.so'))
 server = Test.MakeOriginServer("server")
 
 # Default origin test
-req_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-              "timestamp": "1469733493.993",
-              "body": "",
-              }
-res_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-              "timestamp": "1469733493.993",
-              "body": "",
-              }
+req_header = {
+    "headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+res_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 server.addResponse("sessionfile.log", req_header, res_header)
 
 # Test case for normal
-req_header = {"headers":
-              "GET /someasset.ts HTTP/1.1\r\nHost: somehost\r\n\r\n",
-              "timestamp": "1469733493.993",
-              "body": "",
-              }
+req_header = {
+    "headers": "GET /someasset.ts HTTP/1.1\r\nHost: somehost\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-res_header = {"headers":
-              "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-              "timestamp": "1469733493.993",
-              "body": "somebody",
-              }
+res_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "somebody",
+}
 
 server.addResponse("sessionfile.log", req_header, res_header)
 
 # Test case for crossdomain
-req_header = {"headers":
-              "GET /crossdomain.xml HTTP/1.1\r\nHost: somehost\r\n\r\n",
-              "timestamp": "1469733493.993",
-              "body": "",
-              }
+req_header = {
+    "headers": "GET /crossdomain.xml HTTP/1.1\r\nHost: somehost\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
 
-res_header = {"headers":
-              "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-              "timestamp": "1469733493.993",
-              "body": "<crossdomain></crossdomain>",
-              }
+res_header = {
+    "headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
+    "timestamp": "1469733493.993",
+    "body": "<crossdomain></crossdomain>",
+}
 
 server.addResponse("sessionfile.log", req_header, res_header)
 
@@ -74,17 +76,17 @@ server.addResponse("sessionfile.log", req_header, res_header)
 ts = Test.MakeATSProcess("ts", enable_cache=False)
 #ts = Test.MakeATSProcess("ts", "traffic_server_valgrind.sh")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'uri_signing|http',
-    #  'proxy.config.diags.debug.tags': 'uri_signing',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'uri_signing|http',
+        #  'proxy.config.diags.debug.tags': 'uri_signing',
+    })
 
 # Use unchanged incoming URL.
 ts.Disk.remap_config.AddLine(
     'map http://somehost/ http://127.0.0.1:{}/'.format(server.Variables.Port) +
-    ' @plugin=uri_signing.so @pparam={}/config.json'.format(Test.RunDirectory)
-)
+    ' @plugin=uri_signing.so @pparam={}/config.json'.format(Test.RunDirectory))
 
 # Install configuration
 ts.Setup.CopyAs('config.json', Test.RunDirectory)
@@ -204,7 +206,6 @@ ps.Streams.stderr = "gold/200.gold"
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
-
 # 12 - Check missing iss from the payload
 tr = Test.AddTestRun("Missing iss field in the payload")
 ps = tr.Processes.Default
@@ -212,7 +213,6 @@ ps.Command = curl_and_args + '"http://somehost/someasset.ts?URISigningPackage=ew
 ps.ReturnCode = 0
 ps.Streams.stderr = "gold/403.gold"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-    "Initial JWT Failure: iss is missing, must be present",
-    "should fail the validation")
+    "Initial JWT Failure: iss is missing, must be present", "should fail the validation")
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/x_cache_info.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/x_cache_info.test.py
@@ -23,30 +23,24 @@ Test xdebug plugin X-Cache-Info header
 server = Test.MakeOriginServer("server")
 started = False
 
-request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.records_config.update({
-    'proxy.config.url_remap.remap_required': 0,
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.url_remap.remap_required': 0,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http'
+    })
 
 ts.Disk.plugin_config.AddLine('xdebug.so')
 
-ts.Disk.remap_config.AddLine(
-    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    "map http://two http://127.0.0.1:{0}".format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    "regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine("map http://one http://127.0.0.1:{0}".format(server.Variables.Port))
+ts.Disk.remap_config.AddLine("map http://two http://127.0.0.1:{0}".format(server.Variables.Port))
+ts.Disk.remap_config.AddLine("regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port))
 
 Test.Setup.Copy(f'{Test.Variables.AtsTestToolsDir}')
 

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/x_effective_url.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/x_effective_url.test.py
@@ -22,14 +22,11 @@ Test xdebug plugin X-Effective header
 
 server = Test.MakeOriginServer("server")
 
-request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-request_header_two = {
-    "headers": "GET /two/argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+request_header_two = {"headers": "GET /two/argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header_two, response_header)
 
 ts = Test.MakeATSProcess("ts")
@@ -41,21 +38,14 @@ ts.Disk.records_config.update({
 
 ts.Disk.plugin_config.AddLine('xdebug.so')
 
-ts.Disk.remap_config.AddLine(
-    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    "map http://two http://127.0.0.1:{0}".format(server.Variables.Port) + "/two"
-)
-ts.Disk.remap_config.AddLine(
-    "regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine("map http://one http://127.0.0.1:{0}".format(server.Variables.Port))
+ts.Disk.remap_config.AddLine("map http://two http://127.0.0.1:{0}".format(server.Variables.Port) + "/two")
+ts.Disk.remap_config.AddLine("regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port))
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(Test.Processes.server)
-tr.Processes.Default.Command = "cp {}/tcp_client.py {}/tcp_client.py".format(
-    Test.Variables.AtsTestToolsDir, Test.RunDirectory)
+tr.Processes.Default.Command = "cp {}/tcp_client.py {}/tcp_client.py".format(Test.Variables.AtsTestToolsDir, Test.RunDirectory)
 tr.Processes.Default.ReturnCode = 0
 
 
@@ -64,8 +54,7 @@ def sendMsg(msgFile):
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
         f"( {sys.executable} {Test.RunDirectory}/tcp_client.py 127.0.0.1 {ts.Variables.port} {Test.TestDirectory}/{msgFile}.in"
-        f" ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  {Test.RunDirectory}/out.log 2>&1 "
-    )
+        f" ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  {Test.RunDirectory}/out.log 2>&1 ")
     tr.Processes.Default.ReturnCode = 0
 
 

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/x_remap.test.py
@@ -22,38 +22,30 @@ Test xdebug plugin X-Remap, Probe and fwd headers
 
 server = Test.MakeOriginServer("server", options={'--load': (Test.TestDirectory + '/x_remap-observer.py')})
 
-request_header = {
-    "headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET /argh HTTP/1.1\r\nHost: doesnotmatter\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.records_config.update({
-    'proxy.config.url_remap.remap_required': 0,
-    'proxy.config.diags.debug.enabled': 0,
-    # 'proxy.config.diags.debug.tags': 'http|xdebug'
-    # 'proxy.config.diags.debug.tags': 'xdebug'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.url_remap.remap_required': 0,
+        'proxy.config.diags.debug.enabled': 0,
+        # 'proxy.config.diags.debug.tags': 'http|xdebug'
+        # 'proxy.config.diags.debug.tags': 'xdebug'
+    })
 
 ts.Disk.plugin_config.AddLine('xdebug.so')
 
-ts.Disk.remap_config.AddLine(
-    "map http://one http://127.0.0.1:{0}".format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    "map http://two http://127.0.0.1:{0}".format(server.Variables.Port)
-)
-ts.Disk.remap_config.AddLine(
-    "regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine("map http://one http://127.0.0.1:{0}".format(server.Variables.Port))
+ts.Disk.remap_config.AddLine("map http://two http://127.0.0.1:{0}".format(server.Variables.Port))
+ts.Disk.remap_config.AddLine("regex_map http://three[0-9]+ http://127.0.0.1:{0}".format(server.Variables.Port))
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(Test.Processes.server)
-tr.Processes.Default.Command = "cp {}/tcp_client.py {}/tcp_client.py".format(
-    Test.Variables.AtsTestToolsDir, Test.RunDirectory)
+tr.Processes.Default.Command = "cp {}/tcp_client.py {}/tcp_client.py".format(Test.Variables.AtsTestToolsDir, Test.RunDirectory)
 tr.Processes.Default.ReturnCode = 0
 
 
@@ -62,8 +54,7 @@ def sendMsg(msgFile):
     tr = Test.AddTestRun()
     tr.Processes.Default.Command = (
         f"( {sys.executable} {Test.RunDirectory}/tcp_client.py 127.0.0.1 {ts.Variables.port} {Test.TestDirectory}/{msgFile}.in"
-        f" ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  {Test.RunDirectory}/out.log 2>&1 "
-    )
+        f" ; echo '======' ) | sed 's/:{server.Variables.Port}/:SERVER_PORT/' >>  {Test.RunDirectory}/out.log 2>&1 ")
     tr.Processes.Default.ReturnCode = 0
 
 

--- a/tests/gold_tests/post/post-continue.test.py
+++ b/tests/gold_tests/post/post-continue.test.py
@@ -25,9 +25,7 @@ Test.Summary = '''
 Test the Expect header in post
 '''
 # Require HTTP/2 enabled Curl
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2'),
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'),)
 Test.ContinueOnFail = True
 
 # ----
@@ -47,32 +45,25 @@ ts2 = Test.MakeATSProcess("ts2", select_ports=True, enable_tls=True, enable_cach
 ts.addDefaultSSLFiles()
 ts2.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-
-})
-ts2.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
-ts2.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts2.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.http.send_100_continue_response': 1
-})
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+    })
+ts2.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
+ts2.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.send_100_continue_response': 1
+    })
 
 big_post_body = "0123456789" * 131070
 big_post_body_file = open(os.path.join(Test.RunDirectory, "big_post_body"), "w")

--- a/tests/gold_tests/post_slow_server/post_slow_server.test.py
+++ b/tests/gold_tests/post_slow_server/post_slow_server.test.py
@@ -24,43 +24,35 @@ Server receives POST, sent by client over HTTP/2, waits 2 minutes, then sends re
 # Because of the 2 minute delay, we don't want to run this test in CI checks.  Comment out this line to run it.
 Test.SkipIf(Condition.true("Test takes too long to run it in CI."))
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 ts = Test.MakeATSProcess("ts", enable_tls=True, enable_cache=False)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http.transaction_no_activity_timeout_out': 150,
-    'proxy.config.http2.no_activity_timeout_in': 150,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.proxy_name': 'Poxy_Proxy',  # This will be the server name.
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.http.transaction_no_activity_timeout_out': 150,
+        'proxy.config.http2.no_activity_timeout_in': 150,
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 Test.GetTcpPort("server_port")
 
-ts.Disk.remap_config.AddLine(
-    'map https://localhost http://localhost:{}'.format(Test.Variables.server_port)
-)
+ts.Disk.remap_config.AddLine('map https://localhost http://localhost:{}'.format(Test.Variables.server_port))
 
-server = Test.Processes.Process(
-    "server", "bash -c '" + Test.TestDirectory + "/server.sh {}'".format(Test.Variables.server_port)
-)
+server = Test.Processes.Process("server", "bash -c '" + Test.TestDirectory + "/server.sh {}'".format(Test.Variables.server_port))
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     'curl --request POST --verbose --ipv4 --http2 --insecure --header "Content-Length: 0"' +
-    " --header 'Host: localhost' https://localhost:{}/xyz >curl.log 2>curl.err".format(ts.Variables.ssl_port)
-)
+    " --header 'Host: localhost' https://localhost:{}/xyz >curl.log 2>curl.err".format(ts.Variables.ssl_port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
@@ -19,13 +19,12 @@
 import sys
 
 Test.Summary = 'Test PROXY Protocol'
-Test.SkipUnless(
-    Condition.HasCurlOption("--haproxy-protocol")
-)
+Test.SkipUnless(Condition.HasCurlOption("--haproxy-protocol"))
 Test.ContinueOnFail = True
 
 
 class ProxyProtocolTest:
+
     def __init__(self):
         self.setupOriginServer()
         self.setupTS()
@@ -43,18 +42,18 @@ class ProxyProtocolTest:
         self.ts.addDefaultSSLFiles()
         self.ts.Disk.ssl_multicert_config.AddLine("dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key")
 
-        self.ts.Disk.remap_config.AddLine(
-            f"map / http://127.0.0.1:{self.httpbin.Variables.Port}/")
+        self.ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{self.httpbin.Variables.Port}/")
 
-        self.ts.Disk.records_config.update({
-            "proxy.config.http.server_ports": f"{self.ts.Variables.port}:pp {self.ts.Variables.ssl_port}:ssl:pp",
-            "proxy.config.http.proxy_protocol_allowlist": "127.0.0.1",
-            "proxy.config.http.insert_forwarded": "for|proto",
-            "proxy.config.ssl.server.cert.path": f"{self.ts.Variables.SSLDir}",
-            "proxy.config.ssl.server.private_key.path": f"{self.ts.Variables.SSLDir}",
-            "proxy.config.diags.debug.enabled": 1,
-            "proxy.config.diags.debug.tags": "proxyprotocol",
-        })
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.http.server_ports": f"{self.ts.Variables.port}:pp {self.ts.Variables.ssl_port}:ssl:pp",
+                "proxy.config.http.proxy_protocol_allowlist": "127.0.0.1",
+                "proxy.config.http.insert_forwarded": "for|proto",
+                "proxy.config.ssl.server.cert.path": f"{self.ts.Variables.SSLDir}",
+                "proxy.config.ssl.server.private_key.path": f"{self.ts.Variables.SSLDir}",
+                "proxy.config.diags.debug.enabled": 1,
+                "proxy.config.diags.debug.tags": "proxyprotocol",
+            })
 
     def addTestCase0(self):
         """

--- a/tests/gold_tests/proxy_protocol/proxy_serve_stale.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_serve_stale.test.py
@@ -17,7 +17,6 @@ Test child proxy serving stale content when parents are exhausted
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 Test.testName = "proxy_serve_stale"
 Test.ContinueOnFail = True
 
@@ -34,41 +33,32 @@ class ProxyServeStaleTest:
         self._configure_ts()
 
     def _configure_server(self):
-        self.server = Test.MakeVerifierServerProcess(
-            "server",
-            self.single_transaction_replay)
-        self.nameserver = Test.MakeDNServer(
-            "dns",
-            default='127.0.0.1')
+        self.server = Test.MakeVerifierServerProcess("server", self.single_transaction_replay)
+        self.nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 
     def _configure_ts(self):
         self.ts_child = Test.MakeATSProcess("ts_child")
         # Config child proxy to route to parent proxy
-        self.ts_child.Disk.records_config.update({
-            'proxy.config.http.push_method_enabled': 1,
-            'proxy.config.http.parent_proxy.fail_threshold': 2,
-            'proxy.config.http.parent_proxy.total_connect_attempts': 1,
-            'proxy.config.http.cache.max_stale_age': 10,
-            'proxy.config.http.parent_proxy.self_detect': 0,
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http|dns|parent_proxy',
-            'proxy.config.dns.nameservers': f"127.0.0.1:{self.nameserver.Variables.Port}",
-        })
+        self.ts_child.Disk.records_config.update(
+            {
+                'proxy.config.http.push_method_enabled': 1,
+                'proxy.config.http.parent_proxy.fail_threshold': 2,
+                'proxy.config.http.parent_proxy.total_connect_attempts': 1,
+                'proxy.config.http.cache.max_stale_age': 10,
+                'proxy.config.http.parent_proxy.self_detect': 0,
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http|dns|parent_proxy',
+                'proxy.config.dns.nameservers': f"127.0.0.1:{self.nameserver.Variables.Port}",
+            })
         self.ts_child.Disk.parent_config.AddLine(
-            f'dest_domain=. parent="{self.ts_parent_hostname}" round_robin=consistent_hash go_direct=false'
-        )
-        self.ts_child.Disk.remap_config.AddLine(
-            f'map / http://localhost:{self.server.Variables.http_port}'
-        )
+            f'dest_domain=. parent="{self.ts_parent_hostname}" round_robin=consistent_hash go_direct=false')
+        self.ts_child.Disk.remap_config.AddLine(f'map / http://localhost:{self.server.Variables.http_port}')
 
     def run(self):
         """Run the test cases."""
 
         tr = Test.AddTestRun()
-        tr.AddVerifierClientProcess(
-            'client',
-            self.single_transaction_replay,
-            http_ports=[self.ts_child.Variables.port])
+        tr.AddVerifierClientProcess('client', self.single_transaction_replay, http_ports=[self.ts_child.Variables.port])
         tr.Processes.Default.ReturnCode = 0
         tr.StillRunningAfter = self.ts_child
         tr.Processes.Default.StartBefore(self.server)

--- a/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_serve_stale_dns_fail.test.py
@@ -27,33 +27,28 @@ server_name = "http://unknown.domain.com/"
 Test.testName = "STALE"
 
 # Config child proxy to route to parent proxy
-ts_child.Disk.records_config.update({
-    'proxy.config.http.push_method_enabled': 1,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.http.cache.max_stale_age': 10,
-    'proxy.config.http.parent_proxy.self_detect': 0,
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-})
+ts_child.Disk.records_config.update(
+    {
+        'proxy.config.http.push_method_enabled': 1,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.http.cache.max_stale_age': 10,
+        'proxy.config.http.parent_proxy.self_detect': 0,
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+    })
 ts_child.Disk.parent_config.AddLine(
-    f'dest_domain=. parent=localhost:{ts_parent.Variables.port} round_robin=consistent_hash go_direct=false'
-)
-ts_child.Disk.remap_config.AddLine(
-    f'map http://localhost:{ts_child.Variables.port} {server_name}'
-)
+    f'dest_domain=. parent=localhost:{ts_parent.Variables.port} round_robin=consistent_hash go_direct=false')
+ts_child.Disk.remap_config.AddLine(f'map http://localhost:{ts_child.Variables.port} {server_name}')
 
 # Configure parent proxy
-ts_parent.Disk.records_config.update({
-    'proxy.config.http.push_method_enabled': 1,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.http.cache.max_stale_age': 10,
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-})
-ts_parent.Disk.remap_config.AddLine(
-    f'map http://localhost:{ts_parent.Variables.port} {server_name}'
-)
-ts_parent.Disk.remap_config.AddLine(
-    f'map {server_name} {server_name}'
-)
+ts_parent.Disk.records_config.update(
+    {
+        'proxy.config.http.push_method_enabled': 1,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.http.cache.max_stale_age': 10,
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+    })
+ts_parent.Disk.remap_config.AddLine(f'map http://localhost:{ts_parent.Variables.port} {server_name}')
+ts_parent.Disk.remap_config.AddLine(f'map {server_name} {server_name}')
 
 # Configure nameserver
 nameserver.addRecords(records={"localhost": ["127.0.0.1"]})
@@ -61,7 +56,6 @@ nameserver.addRecords(records={"localhost": ["127.0.0.1"]})
 # Object to push to proxies
 stale_5 = "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public, max-age=5\n\nCACHED"
 stale_10 = "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public, max-age=10\n\nCACHED"
-
 
 # Testing scenarios
 child_curl_request = (
@@ -73,8 +67,7 @@ child_curl_request = (
     # Test parent serving stale with failed DNS OS lookup
     f'curl -X PUSH -d "{stale_5}" "http://localhost:{ts_parent.Variables.port}";'
     f'sleep 7; curl -s -v http://localhost:{ts_parent.Variables.port};'
-    f'sleep 15; curl -s -v http://localhost:{ts_parent.Variables.port};'
-)
+    f'sleep 15; curl -s -v http://localhost:{ts_parent.Variables.port};')
 
 # Test case for when parent server is down but child proxy can serve cache object
 tr = Test.AddTestRun()

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -31,15 +31,16 @@ redirect_serv = Test.MakeOriginServer("re_server")
 dest_serv = Test.MakeOriginServer("dest_server")
 dns = Test.MakeDNServer("dns")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|redirect',
-    'proxy.config.http.number_of_redirections': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.url_remap.remap_required': 0,  # need this so the domain gets a chance to be evaluated through DNS
-    'proxy.config.http.redirect.actions': 'self:follow',  # redirects to self are not followed by default
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|redirect',
+        'proxy.config.http.number_of_redirections': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.url_remap.remap_required': 0,  # need this so the domain gets a chance to be evaluated through DNS
+        'proxy.config.http.redirect.actions': 'self:follow',  # redirects to self are not followed by default
+    })
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -50,14 +51,16 @@ logging:
   logs:
     - filename: the_log
       format: custom
-'''.split("\n")
-)
+'''.split("\n"))
 
 Test.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir, 'tcp_client.py'))
 
 redirect_request_header = {"headers": "GET /redirect HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
-redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirectDest\r\n\r\n".format(
-    dest_serv.Variables.Port), "timestamp": "5678", "body": ""}
+redirect_response_header = {
+    "headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirectDest\r\n\r\n".format(dest_serv.Variables.Port),
+    "timestamp": "5678",
+    "body": ""
+}
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
 dest_request_header = {"headers": "GET /redirectDest HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "11", "body": ""}
@@ -84,7 +87,6 @@ tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
 tr.Processes.Default.ReturnCode = 0
 
-
 redirect_request_header = {"headers": "GET /redirect-relative-path HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
 redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: /redirect\r\n\r\n", "timestamp": "5678", "body": ""}
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
@@ -106,9 +108,11 @@ tr.StillRunningAfter = dns
 tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
 tr.Processes.Default.ReturnCode = 0
 
-
 redirect_request_header = {
-    "headers": "GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: *\r\n\r\n", "timestamp": "5678", "body": ""}
+    "headers": "GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: *\r\n\r\n",
+    "timestamp": "5678",
+    "body": ""
+}
 redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: redirect\r\n\r\n", "timestamp": "5678", "body": ""}
 redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
@@ -116,7 +120,8 @@ tr = Test.AddTestRun("FollowsRedirectWithRelativeLocationURIMissingLeadingSlash"
 command_path = os.path.join(data_path, tr.Name)
 with open(command_path, 'w') as f:
     f.write(
-        'GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(port=redirect_serv.Variables.Port))
+        'GET /redirect-relative-path-no-leading-slash HTTP/1.1\r\nHost: iwillredirect.test:{port}\r\n\r\n'.format(
+            port=redirect_serv.Variables.Port))
 tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} {command_path} | egrep -v '^(Date: |Server: ATS/)'"
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = redirect_serv
@@ -124,7 +129,6 @@ tr.StillRunningAfter = dest_serv
 tr.StillRunningAfter = dns
 tr.Processes.Default.Streams.stdout = "gold/redirect.gold"
 tr.Processes.Default.ReturnCode = 0
-
 
 for status, phrase in sorted({
         301: 'Moved Permanently',
@@ -137,25 +141,25 @@ for status, phrase in sorted({
 
     redirect_request_header = {
         "headers": ("GET /redirect{0} HTTP/1.1\r\n"
-                    "Host: *\r\n\r\n").
-        format(status),
+                    "Host: *\r\n\r\n").format(status),
         "timestamp": "5678",
-        "body": ""}
+        "body": ""
+    }
     redirect_response_header = {
         "headers": ("HTTP/1.1 {0} {1}\r\n"
                     "Connection: close\r\n"
-                    "Location: /redirect\r\n\r\n").
-        format(status, phrase),
+                    "Location: /redirect\r\n\r\n").format(status, phrase),
         "timestamp": "5678",
-        "body": ""}
+        "body": ""
+    }
     redirect_serv.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
 
     tr = Test.AddTestRun("FollowsRedirect{0}".format(status))
     command_path = os.path.join(data_path, tr.Name)
     with open(command_path, 'w') as f:
-        f.write(('GET /redirect{0} HTTP/1.1\r\n'
-                 'Host: iwillredirect.test:{1}\r\n\r\n').
-                format(status, redirect_serv.Variables.Port))
+        f.write(
+            ('GET /redirect{0} HTTP/1.1\r\n'
+             'Host: iwillredirect.test:{1}\r\n\r\n').format(status, redirect_serv.Variables.Port))
     tr.Processes.Default.Command = f"{sys.executable} tcp_client.py 127.0.0.1 {ts.Variables.port} {command_path} | egrep -v '^(Date: |Server: ATS/)'"
     tr.StillRunningAfter = ts
     tr.StillRunningAfter = redirect_serv
@@ -168,10 +172,7 @@ Test.Setup.Copy('wait_for_log.sh')
 
 tr = Test.AddTestRun("wait_for_log")
 tr.Processes.Default.Command = (
-    './wait_for_log.sh {} {}'.format(
-        os.path.join(ts.Variables.LOGDIR, 'the_log.log'), redirect_serv.Variables.Port
-    )
-)
+    './wait_for_log.sh {} {}'.format(os.path.join(ts.Variables.LOGDIR, 'the_log.log'), redirect_serv.Variables.Port))
 tr.Processes.Default.Streams.stdout = "gold/redirect_log.gold"
 tr.Processes.Default.ReturnCode = 0
 

--- a/tests/gold_tests/redirect/redirect_post.test.py
+++ b/tests/gold_tests/redirect/redirect_post.test.py
@@ -23,9 +23,7 @@ Test basic post redirection
 # TODO figure out how to use this
 MAX_REDIRECT = 99
 
-Test.SkipUnless(
-    Condition.HasProgram("truncate", "truncate need to be installed on system for this test to work")
-)
+Test.SkipUnless(Condition.HasProgram("truncate", "truncate need to be installed on system for this test to work"))
 
 Test.ContinueOnFail = True
 
@@ -34,25 +32,41 @@ redirect_serv1 = Test.MakeOriginServer("re_server1")
 redirect_serv2 = Test.MakeOriginServer("re_server2")
 dest_serv = Test.MakeOriginServer("dest_server")
 
-ts.Disk.records_config.update({
-    'proxy.config.http.number_of_redirections': MAX_REDIRECT,
-    'proxy.config.http.post_copy_size': 919430601,
-    'proxy.config.http.redirect.actions': 'self:follow',  # redirects to self are not followed by default
-    # 'proxy.config.diags.debug.enabled': 1,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.http.number_of_redirections': MAX_REDIRECT,
+        'proxy.config.http.post_copy_size': 919430601,
+        'proxy.config.http.redirect.actions': 'self:follow',  # redirects to self are not followed by default
+        # 'proxy.config.diags.debug.enabled': 1,
+    })
 
 redirect_request_header = {
-    "headers": "POST /redirect1 HTTP/1.1\r\nHost: *\r\nContent-Length: 52428800\r\n\r\n", "timestamp": "5678", "body": ""}
-redirect_response_header = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirect2\r\n\r\n".format(
-    redirect_serv2.Variables.Port), "timestamp": "5678", "body": ""}
+    "headers": "POST /redirect1 HTTP/1.1\r\nHost: *\r\nContent-Length: 52428800\r\n\r\n",
+    "timestamp": "5678",
+    "body": ""
+}
+redirect_response_header = {
+    "headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirect2\r\n\r\n".format(redirect_serv2.Variables.Port),
+    "timestamp": "5678",
+    "body": ""
+}
 
 redirect_request_header2 = {
-    "headers": "POST /redirect2 HTTP/1.1\r\nHost: *\r\nContent-Length: 52428800\r\n\r\n", "timestamp": "5678", "body": ""}
-redirect_response_header2 = {"headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirectDest\r\n\r\n".format(
-    dest_serv.Variables.Port), "timestamp": "5678", "body": ""}
+    "headers": "POST /redirect2 HTTP/1.1\r\nHost: *\r\nContent-Length: 52428800\r\n\r\n",
+    "timestamp": "5678",
+    "body": ""
+}
+redirect_response_header2 = {
+    "headers": "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{0}/redirectDest\r\n\r\n".format(dest_serv.Variables.Port),
+    "timestamp": "5678",
+    "body": ""
+}
 
 dest_request_header = {
-    "headers": "POST /redirectDest HTTP/1.1\r\nHost: *\r\nContent-Length: 52428800\r\n\r\n", "timestamp": "11", "body": ""}
+    "headers": "POST /redirectDest HTTP/1.1\r\nHost: *\r\nContent-Length: 52428800\r\n\r\n",
+    "timestamp": "11",
+    "body": ""
+}
 dest_response_header = {"headers": "HTTP/1.1 204 No Content\r\n\r\n", "timestamp": "22", "body": ""}
 
 redirect_serv1.addResponse("sessionfile.log", redirect_request_header, redirect_response_header)
@@ -60,8 +74,7 @@ redirect_serv2.addResponse("sessionfile.log", redirect_request_header2, redirect
 dest_serv.addResponse("sessionfile.log", dest_request_header, dest_response_header)
 
 ts.Disk.remap_config.AddLine(
-    'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, redirect_serv1.Variables.Port)
-)
+    'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, redirect_serv1.Variables.Port))
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'touch largefile.txt && truncate largefile.txt -s 50M && curl -H "Expect: " -i http://127.0.0.1:{0}/redirect1 -F "filename=@./largefile.txt" && rm -f largefile.txt'.format(

--- a/tests/gold_tests/redirect/redirect_stale.test.py
+++ b/tests/gold_tests/redirect/redirect_stale.test.py
@@ -29,39 +29,44 @@ request_header = {
     'headers': ('GET /obj HTTP/1.1\r\n'
                 'Host: *\r\n\r\n'),
     'timestamp': ArbitraryTimestamp,
-    'body': ''}
+    'body': ''
+}
 response_header = {
     'headers': ('HTTP/1.1 302 Found\r\n'
                 'Location: http://127.0.0.1:{}/obj2\r\n\r\n'.format(server.Variables.Port)),
     'timestamp': ArbitraryTimestamp,
-    'body': ''}
+    'body': ''
+}
 server.addResponse('sessionfile.log', request_header, response_header)
 
 request_header = {
     'headers': ('GET /obj2 HTTP/1.1\r\n'
                 'Host: *\r\n\r\n'),
     'timestamp': ArbitraryTimestamp,
-    'body': ''}
+    'body': ''
+}
 response_header = {
     'headers': ('HTTP/1.1 200 OK\r\n'
                 'X-Obj: obj2\r\n'
                 'Cache-Control: max-age=2\r\n'
                 'Content-Length: 0\r\n\r\n'),
     'timestamp': ArbitraryTimestamp,
-    'body': ''}
+    'body': ''
+}
 server.addResponse('sessionfile.log', request_header, response_header)
 
 ts = Test.MakeATSProcess("ts")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http|dns|cache|redirect',
-    'proxy.config.http.cache.required_headers': 0,  # Only Content-Length header required for caching.
-    'proxy.config.http.push_method_enabled': 1,
-    'proxy.config.url_remap.remap_required': 0,
-    'proxy.config.http.redirect.actions': 'routable:follow,loopback:follow,self:follow',
-    'proxy.config.http.number_of_redirections': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|cache|redirect',
+        'proxy.config.http.cache.required_headers': 0,  # Only Content-Length header required for caching.
+        'proxy.config.http.push_method_enabled': 1,
+        'proxy.config.url_remap.remap_required': 0,
+        'proxy.config.http.redirect.actions': 'routable:follow,loopback:follow,self:follow',
+        'proxy.config.http.number_of_redirections': 1
+    })
 
 # Set up to check the output after the tests have run.
 #
@@ -73,8 +78,7 @@ tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.Command = (
     r"printf 'GET /obj HTTP/1.1\r\nHost: 127.0.0.1:{}\r\n\r\n' | nc localhost {} >> log.txt".format(
-        server.Variables.Port, ts.Variables.port)
-)
+        server.Variables.Port, ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # Wait for the response in cache to become stale, then GET it again.
@@ -82,14 +86,12 @@ tr.Processes.Default.ReturnCode = 0
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
     r"sleep 4 ; printf 'GET /obj HTTP/1.1\r\nHost: 127.0.0.1:{}\r\n\r\n' | nc localhost {} >> log.txt".format(
-        server.Variables.Port, ts.Variables.port)
-)
+        server.Variables.Port, ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 
 # Filter out inconsistent content in test output.
 #
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (
-    r"grep -v -e '^Date: ' -e '^Age: ' -e '^Connection: ' -e '^Server: ATS/' log.txt | tr -d '\r'> log2.txt"
-)
+    r"grep -v -e '^Date: ' -e '^Age: ' -e '^Connection: ' -e '^Server: ATS/' log.txt | tr -d '\r'> log2.txt")
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/remap/conf_remap_float.test.py
+++ b/tests/gold_tests/remap/conf_remap_float.test.py
@@ -14,7 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 Test.Summary = '''
 Test command: traffic_ctl config describe proxy.config.http.background_fill_completed_threshold (YTSATS-3309)
 '''
@@ -22,9 +21,8 @@ Test.testName = 'Float in conf_remap Config Test'
 
 ts = Test.MakeATSProcess("ts", command="traffic_manager", select_ports=True)
 
-ts.Disk.MakeConfigFile('conf_remap.config').AddLines([
-    'CONFIG proxy.config.http.background_fill_completed_threshold FLOAT 0.500000'
-])
+ts.Disk.MakeConfigFile('conf_remap.config').AddLines(
+    ['CONFIG proxy.config.http.background_fill_completed_threshold FLOAT 0.500000'])
 
 ts.Disk.remap_config.AddLine(
     f"map http://cdn.example.com/ http://origin.example.com/ @plugin=conf_remap.so @pparam={Test.RunDirectory}/ts/config/conf_remap.config"

--- a/tests/gold_tests/remap/regex_map.test.py
+++ b/tests/gold_tests/remap/regex_map.test.py
@@ -27,30 +27,27 @@ server = Test.MakeOriginServer("server")
 dns = Test.MakeDNServer("dns", default='127.0.0.1')
 
 Test.testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: zero.one.two.three.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: zero.one.two.three.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionfile.log", request_header, response_header)
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http.*|dns|conf_remap',
-    'proxy.config.http.referer_filter': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.dns.resolv_conf': 'NULL'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http.*|dns|conf_remap',
+        'proxy.config.http.referer_filter': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.dns.resolv_conf': 'NULL'
+    })
 
 ts.Disk.remap_config.AddLine(
     r'regex_map '
     r'http://(.*)?one\.two\.three\.com/ '
-    r'http://$1reactivate.four.five.six.com:{}/'.format(server.Variables.Port)
-)
+    r'http://$1reactivate.four.five.six.com:{}/'.format(server.Variables.Port))
 ts.Disk.remap_config.AddLine(
     r'regex_map '
     r'https://\b(?!(.*one|two|three|four|five|six)).+\b\.seven\.eight\.nine\.com/blah12345.html '
-    r'https://www.example.com:{}/one/two/three/blah12345.html'.format(server.Variables.Port)
-)
+    r'https://www.example.com:{}/one/two/three/blah12345.html'.format(server.Variables.Port))
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl -H"Host: zero.one.two.three.com" http://127.0.0.1:{0}/ --verbose'.format(ts.Variables.port)

--- a/tests/gold_tests/remap/remap_https.test.py
+++ b/tests/gold_tests/remap/remap_https.test.py
@@ -28,44 +28,35 @@ server2 = Test.MakeOriginServer("server2", ssl=True)
 
 # **testname is required**
 testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 # desired response form the origin server
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 server2.addResponse("sessionlog.json", request_header, response_header)
 
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'lm|ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    # enable ssl port
-    'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'lm|ssl',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        # enable ssl port
+        'proxy.config.http.server_ports': '{0} {1}:proto=http2;http:ssl'.format(ts.Variables.port, ts.Variables.ssl_port),
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
+ts.Disk.remap_config.AddLine('map https://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port))
 ts.Disk.remap_config.AddLine(
-    'map https://www.example.com http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+    'map https://www.example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port))
 ts.Disk.remap_config.AddLine(
-    'map https://www.example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
-)
+    'map_with_recv_port https://www.example3.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port))
 ts.Disk.remap_config.AddLine(
-    'map_with_recv_port https://www.example3.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
-)
-ts.Disk.remap_config.AddLine(
-    'map https://www.anotherexample.com https://127.0.0.1:{0}'.format(server2.Variables.SSL_Port, ts.Variables.ssl_port)
-)
+    'map https://www.anotherexample.com https://127.0.0.1:{0}'.format(server2.Variables.SSL_Port, ts.Variables.ssl_port))
 
-
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # call localhost straight
 tr = Test.AddTestRun()
@@ -79,14 +70,12 @@ tr.Processes.Default.Streams.stderr = "gold/remap-hitATS-404.gold"
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 
-
 # www.example.com host
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl --http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com" --verbose'.format(
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-https-200.gold"
-
 
 # www.example.com:80 host
 tr = Test.AddTestRun()

--- a/tests/gold_tests/remap/remap_ip_resolve.test.py
+++ b/tests/gold_tests/remap/remap_ip_resolve.test.py
@@ -1,4 +1,3 @@
-
 '''
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
@@ -30,32 +29,29 @@ server_v6 = Test.MakeOriginServer("server_v6", None, None, '::1', 0)
 dns = Test.MakeDNServer("dns")
 
 Test.testName = ""
-request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n",
-                  "timestamp": "1469733493.993", "body": ""}
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 # expected response from the origin server
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
-                   "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 
 # add response to the server dictionary
 server.addResponse("sessionfile.log", request_header, response_header)
 server_v6.addResponse("sessionfile.log", request_header, response_header)
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http.*|dns|conf_remap',
-    'proxy.config.http.referer_filter': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.hostdb.ip_resolve': 'ipv4'
-})
-
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http.*|dns|conf_remap',
+        'proxy.config.http.referer_filter': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.hostdb.ip_resolve': 'ipv4'
+    })
 
 ts.Disk.remap_config.AddLine(
-    'map http://testDNS.com http://test.ipv4.only.com:{0}  @plugin=conf_remap.so @pparam=proxy.config.hostdb.ip_resolve=ipv6;ipv4;client'.format(
-        server.Variables.Port))
+    'map http://testDNS.com http://test.ipv4.only.com:{0}  @plugin=conf_remap.so @pparam=proxy.config.hostdb.ip_resolve=ipv6;ipv4;client'
+    .format(server.Variables.Port))
 ts.Disk.remap_config.AddLine(
-    'map http://testDNS2.com http://test.ipv6.only.com:{0}  @plugin=conf_remap.so @pparam=proxy.config.hostdb.ip_resolve=ipv6;only'.format(
-        server_v6.Variables.Port))
-
+    'map http://testDNS2.com http://test.ipv6.only.com:{0}  @plugin=conf_remap.so @pparam=proxy.config.hostdb.ip_resolve=ipv6;only'
+    .format(server_v6.Variables.Port))
 
 dns.addRecords(records={"test.ipv4.only.com.": ["127.0.0.1"]})
 dns.addRecords(records={"test.ipv6.only.com": ["127.0.0.1", "::1"]})
@@ -68,7 +64,6 @@ tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stderr = "gold/remap-DNS-200.gold"
 tr.StillRunningAfter = server
-
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = 'curl  --proxy 127.0.0.1:{0} "http://testDNS2.com" --verbose'.format(ts.Variables.port)

--- a/tests/gold_tests/remap/remap_ws.test.py
+++ b/tests/gold_tests/remap/remap_ws.test.py
@@ -26,28 +26,32 @@ ts = Test.MakeATSProcess("ts", enable_tls=True)
 server = Test.MakeOriginServer("server")
 
 testName = "Test WebSocket Remaps"
-request_header = {"headers": "GET /chat HTTP/1.1\r\nHost: www.example.com\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
-                  "body": None}
+request_header = {
+    "headers": "GET /chat HTTP/1.1\r\nHost: www.example.com\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+    "body": None
+}
 response_header = {
-    "headers": "HTTP/1.1 101 OK\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
-    "body": None}
+    "headers":
+        "HTTP/1.1 101 OK\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
+    "body": None
+}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.remap_config.AddLines([
-    'map ws://www.example.com:{1} ws://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.port),
-    'map wss://www.example.com:{1} ws://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port),
-])
+ts.Disk.remap_config.AddLines(
+    [
+        'map ws://www.example.com:{1} ws://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.port),
+        'map wss://www.example.com:{1} ws://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port),
+    ])
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # wss mapping
 tr = Test.AddTestRun()

--- a/tests/gold_tests/remap/remap_ws.test.py
+++ b/tests/gold_tests/remap/remap_ws.test.py
@@ -42,7 +42,7 @@ ts.Disk.records_config.update({
 
 ts.Disk.remap_config.AddLines([
     'map ws://www.example.com:{1} ws://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.port),
-    'map wss://www.example.com:{1} ws://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
+    'map wss://www.example.com:{1} ws://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port),
 ])
 
 ts.Disk.ssl_multicert_config.AddLine(

--- a/tests/gold_tests/runroot/runroot_init.test.py
+++ b/tests/gold_tests/runroot/runroot_init.test.py
@@ -22,8 +22,8 @@ Test.Summary = '''
 Test for init of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
-Test.SkipUnless(Test.Variables.BINDIR.startswith(Test.Variables.PREFIX),
-                "need to guarantee bin path starts with prefix for runroot")
+Test.SkipUnless(
+    Test.Variables.BINDIR.startswith(Test.Variables.PREFIX), "need to guarantee bin path starts with prefix for runroot")
 
 # init from pass in path
 path1 = os.path.join(Test.RunDirectory, "runroot1")

--- a/tests/gold_tests/runroot/runroot_manager.test.py
+++ b/tests/gold_tests/runroot/runroot_manager.test.py
@@ -50,5 +50,5 @@ tr.ChownForATSProcess(trafficserver_dir)
 p = tr.Processes.Default
 p.Command = "$ATS_BIN/traffic_manager --run-root=" + rr_file
 p.RunningEvent.Connect(Testers.Lambda(lambda ev: StopProcess(ev, 10)))
-p.Streams.All = Testers.ContainsExpression("traffic_server: using root directory '" +
-                                           runroot_path + "'", "check if the right runroot is passed down")
+p.Streams.All = Testers.ContainsExpression(
+    "traffic_server: using root directory '" + runroot_path + "'", "check if the right runroot is passed down")

--- a/tests/gold_tests/runroot/runroot_use.test.py
+++ b/tests/gold_tests/runroot/runroot_use.test.py
@@ -22,8 +22,8 @@ Test.Summary = '''
 Test for using of runroot from traffic_layout.
 '''
 Test.ContinueOnFail = True
-Test.SkipUnless(Test.Variables.BINDIR.startswith(Test.Variables.PREFIX),
-                "need to guarantee bin path starts with prefix for runroot")
+Test.SkipUnless(
+    Test.Variables.BINDIR.startswith(Test.Variables.PREFIX), "need to guarantee bin path starts with prefix for runroot")
 
 # create two runroot for testing
 path = os.path.join(Test.RunDirectory, "runroot")

--- a/tests/gold_tests/runroot/runroot_verify.test.py
+++ b/tests/gold_tests/runroot/runroot_verify.test.py
@@ -40,7 +40,6 @@ else:
     # given a custom setup this might work.. or it might not
     logsuffix = logdir
 
-
 # create runroot
 path = os.path.join(Test.RunDirectory, "runroot")
 tr = Test.AddTestRun("Create runroot")

--- a/tests/gold_tests/session_sharing/session_match.test.py
+++ b/tests/gold_tests/session_sharing/session_match.test.py
@@ -32,42 +32,58 @@ class SessionMatchTest:
 
     def setupOriginServer(self):
         self._server = Test.MakeOriginServer("server{counter}".format(counter=self._MyTestCount))
-        request_header = {"headers":
-                          "GET /one HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 0\r\n\r\n",
-                          "timestamp": "1469733493.993", "body": ""}
-        response_header = {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
-                           "Content-Length: 0\r\n\r\n",
-                           "timestamp": "1469733493.993", "body": ""}
+        request_header = {
+            "headers": "GET /one HTTP/1.1\r\nHost: www.example.com\r\nContent-Length: 0\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
+        response_header = {
+            "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
+                       "Content-Length: 0\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
         self._server.addResponse("sessionlog.json", request_header, response_header)
 
-        request_header2 = {"headers": "GET /two HTTP/1.1\r\nContent-Length: 0\r\n"
-                           "Host: www.example.com\r\n\r\n",
-                           "timestamp": "1469733493.993", "body": "a\r\na\r\na\r\n\r\n"}
-        response_header2 = {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
-                            "Content-Length: 0\r\n\r\n",
-                            "timestamp": "1469733493.993", "body": ""}
+        request_header2 = {
+            "headers": "GET /two HTTP/1.1\r\nContent-Length: 0\r\n"
+                       "Host: www.example.com\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": "a\r\na\r\na\r\n\r\n"
+        }
+        response_header2 = {
+            "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
+                       "Content-Length: 0\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
         self._server.addResponse("sessionlog.json", request_header2, response_header2)
 
-        request_header3 = {"headers": "GET /three HTTP/1.1\r\nContent-Length: 0\r\n"
-                           "Host: www.example.com\r\nConnection: close\r\n\r\n",
-                           "timestamp": "1469733493.993", "body": "a\r\na\r\na\r\n\r\n"}
-        response_header3 = {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
-                            "Connection: close\r\nContent-Length: 0\r\n\r\n",
-                            "timestamp": "1469733493.993", "body": ""}
+        request_header3 = {
+            "headers": "GET /three HTTP/1.1\r\nContent-Length: 0\r\n"
+                       "Host: www.example.com\r\nConnection: close\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": "a\r\na\r\na\r\n\r\n"
+        }
+        response_header3 = {
+            "headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\n"
+                       "Connection: close\r\nContent-Length: 0\r\n\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
         self._server.addResponse("sessionlog.json", request_header3, response_header3)
 
     def setupTS(self):
         self._ts = Test.MakeATSProcess("ts{counter}".format(counter=self._MyTestCount))
-        self._ts.Disk.remap_config.AddLine(
-            'map / http://127.0.0.1:{0}'.format(self._server.Variables.Port)
-        )
-        self._ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http',
-            'proxy.config.http.auth_server_session_private': 1,
-            'proxy.config.http.server_session_sharing.pool': 'global',
-            'proxy.config.http.server_session_sharing.match': self._sharingMatchValue,
-        })
+        self._ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(self._server.Variables.Port))
+        self._ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http',
+                'proxy.config.http.auth_server_session_private': 1,
+                'proxy.config.http.server_session_sharing.pool': 'global',
+                'proxy.config.http.server_session_sharing.match': self._sharingMatchValue,
+            })
 
     def _runTraffic(self):
         self._tr.Processes.Default.Command = (
@@ -83,32 +99,24 @@ class SessionMatchTest:
     def runAndExpectSharing(self):
         self._runTraffic()
         self._ts.Disk.traffic_out.Content = Testers.ContainsExpression(
-            "global pool search successful",
-            "Verify that sessions got shared")
+            "global pool search successful", "Verify that sessions got shared")
 
     def runAndExpectNoSharing(self):
         self._runTraffic()
         self._ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
-            "global pool search successful",
-            "Verify that sessions did not get shared")
+            "global pool search successful", "Verify that sessions did not get shared")
 
 
-sessionMatchTest = SessionMatchTest(
-    TestSummary='Test that session sharing works with host matching',
-    sharingMatchValue='host')
+sessionMatchTest = SessionMatchTest(TestSummary='Test that session sharing works with host matching', sharingMatchValue='host')
+sessionMatchTest.runAndExpectSharing()
+
+sessionMatchTest = SessionMatchTest(TestSummary='Test that session sharing works with ip matching', sharingMatchValue='ip')
 sessionMatchTest.runAndExpectSharing()
 
 sessionMatchTest = SessionMatchTest(
-    TestSummary='Test that session sharing works with ip matching',
-    sharingMatchValue='ip')
+    TestSummary='Test that session sharing works with matching both ip and host', sharingMatchValue='both')
 sessionMatchTest.runAndExpectSharing()
 
 sessionMatchTest = SessionMatchTest(
-    TestSummary='Test that session sharing works with matching both ip and host',
-    sharingMatchValue='both')
-sessionMatchTest.runAndExpectSharing()
-
-sessionMatchTest = SessionMatchTest(
-    TestSummary='Test that session sharing is disabled when matching is set to none',
-    sharingMatchValue='none')
+    TestSummary='Test that session sharing is disabled when matching is set to none', sharingMatchValue='none')
 sessionMatchTest.runAndExpectNoSharing()

--- a/tests/gold_tests/shutdown/emergency.test.py
+++ b/tests/gold_tests/shutdown/emergency.test.py
@@ -16,7 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
 
 Test.Summary = 'Test TSEmergency API'
@@ -27,15 +26,16 @@ ts = Test.MakeATSProcess('ts')
 
 Test.testName = 'Emergency Shutdown Test'
 
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 16,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'TSEmergency_test'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 16,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'TSEmergency_test'
+    })
 
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'emergency_shutdown.so'), ts)

--- a/tests/gold_tests/shutdown/fatal.test.py
+++ b/tests/gold_tests/shutdown/fatal.test.py
@@ -16,7 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
 
 Test.Summary = 'Test TSFatal API'
@@ -27,15 +26,16 @@ ts = Test.MakeATSProcess('ts')
 
 Test.testName = 'Fatal Shutdown Test'
 
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 16,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'TSFatal_test'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 16,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'TSFatal_test'
+    })
 
 # Load plugin
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'fatal_shutdown.so'), ts)

--- a/tests/gold_tests/slow_post/http_utils.py
+++ b/tests/gold_tests/slow_post/http_utils.py
@@ -66,10 +66,7 @@ def determine_outstanding_bytes_to_read(read_bytes: bytes) -> int:
     return content_length_value - (len(read_bytes) - end_of_headers)
 
 
-def drain_socket(
-        sock: socket.socket,
-        previously_read_data: bytes,
-        num_bytes_to_drain: int) -> None:
+def drain_socket(sock: socket.socket, previously_read_data: bytes, num_bytes_to_drain: int) -> None:
     """Read the rest of the request.
 
     :param sock: The socket to drain.

--- a/tests/gold_tests/slow_post/quick_server.py
+++ b/tests/gold_tests/slow_post/quick_server.py
@@ -17,9 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from http_utils import (wait_for_headers_complete,
-                        determine_outstanding_bytes_to_read,
-                        drain_socket)
+from http_utils import (wait_for_headers_complete, determine_outstanding_bytes_to_read, drain_socket)
 
 import argparse
 import socket
@@ -29,22 +27,11 @@ import sys
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("address", help="Address to listen on")
+    parser.add_argument("port", type=int, default=8080, help="The port to listen on")
+    parser.add_argument('--drain-request', action='store_true', help="Drain the entire request before closing the connection")
     parser.add_argument(
-        "address",
-        help="Address to listen on")
-    parser.add_argument(
-        "port",
-        type=int,
-        default=8080,
-        help="The port to listen on")
-    parser.add_argument(
-        '--drain-request',
-        action='store_true',
-        help="Drain the entire request before closing the connection")
-    parser.add_argument(
-        '--abort-response-headers',
-        action='store_true',
-        help="Abort the response in the midst of sending the response headers")
+        '--abort-response-headers', action='store_true', help="Abort the response in the midst of sending the response headers")
     return parser.parse_args()
 
 
@@ -80,11 +67,9 @@ def send_response(sock: socket.socket, abort_early: bool) -> None:
     if abort_early:
         response = "HTTP/1."
     else:
-        response = (
-            r"HTTP/1.1 200 OK\r\n"
-            r"Content-Length: 0\r\n"
-            r"\r\n"
-        )
+        response = (r"HTTP/1.1 200 OK\r\n"
+                    r"Content-Length: 0\r\n"
+                    r"\r\n")
     print(f'Sending:\n{response}')
     sock.sendall(response.encode("utf-8"))
 
@@ -116,8 +101,7 @@ def main() -> int:
                     break
 
                 if args.drain_request:
-                    num_bytes_to_drain = determine_outstanding_bytes_to_read(
-                        read_bytes)
+                    num_bytes_to_drain = determine_outstanding_bytes_to_read(read_bytes)
                     print(f'Read {len(read_bytes)} bytes. '
                           f'Draining {num_bytes_to_drain} bytes.')
                     drain_socket(sock, read_bytes, num_bytes_to_drain)

--- a/tests/gold_tests/slow_post/quick_server.test.py
+++ b/tests/gold_tests/slow_post/quick_server.test.py
@@ -19,7 +19,6 @@
 from ports import get_port
 import sys
 
-
 Test.Summary = __doc__
 
 
@@ -51,9 +50,7 @@ class QuickServerTest:
 
         :param tr: The test run to associate with the DNS process with.
         """
-        self._dns = tr.MakeDNServer(
-            f'dns-{QuickServerTest._dns_counter}',
-            default='127.0.0.1')
+        self._dns = tr.MakeDNServer(f'dns-{QuickServerTest._dns_counter}', default='127.0.0.1')
         QuickServerTest._dns_counter += 1
 
     def _configure_server(self, tr: 'TestRun'):
@@ -83,15 +80,14 @@ class QuickServerTest:
         """
         self._ts = tr.MakeATSProcess(f'ts-{QuickServerTest._ts_counter}')
         QuickServerTest._ts_counter += 1
-        self._ts.Disk.remap_config.AddLine(
-            f'map / http://quick.server.com:{self._server.Variables.http_port}'
-        )
-        self._ts.Disk.records_config.update({
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'http|dns|hostdb',
-            'proxy.config.dns.nameservers': f'127.0.0.1:{self._dns.Variables.Port}',
-            'proxy.config.dns.resolv_conf': 'NULL',
-        })
+        self._ts.Disk.remap_config.AddLine(f'map / http://quick.server.com:{self._server.Variables.http_port}')
+        self._ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http|dns|hostdb',
+                'proxy.config.dns.nameservers': f'127.0.0.1:{self._dns.Variables.Port}',
+                'proxy.config.dns.resolv_conf': 'NULL',
+            })
 
     def run(self):
         """Run the test."""
@@ -106,11 +102,9 @@ class QuickServerTest:
         tr.Setup.CopyAs(self._slow_post_client, Test.RunDirectory)
         tr.Setup.CopyAs(self._quick_server, Test.RunDirectory)
 
-        client_command = (
-            f'{sys.executable} {self._slow_post_client} '
-            '127.0.0.1 '
-            f'{self._ts.Variables.port} '
-        )
+        client_command = (f'{sys.executable} {self._slow_post_client} '
+                          '127.0.0.1 '
+                          f'{self._ts.Variables.port} ')
         if not self._should_abort_request:
             client_command += '--finish-request '
         tr.Processes.Default.Command = client_command
@@ -125,8 +119,5 @@ class QuickServerTest:
 for abort_request in [True, False]:
     for drain_request in [True, False]:
         for abort_response_headers in [True, False]:
-            test = QuickServerTest(
-                abort_request,
-                drain_request,
-                abort_response_headers)
+            test = QuickServerTest(abort_request, drain_request, abort_response_headers)
             test.run()

--- a/tests/gold_tests/slow_post/slow_post_client.py
+++ b/tests/gold_tests/slow_post/slow_post_client.py
@@ -17,9 +17,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from http_utils import (wait_for_headers_complete,
-                        determine_outstanding_bytes_to_read,
-                        drain_socket)
+from http_utils import (wait_for_headers_complete, determine_outstanding_bytes_to_read, drain_socket)
 
 import argparse
 import socket
@@ -29,24 +27,15 @@ import sys
 def parse_args() -> argparse.Namespace:
     """Parse the command line arguments."""
     parser = argparse.ArgumentParser()
+    parser.add_argument("proxy_address", help="Address of the proxy to connect to.")
+    parser.add_argument("proxy_port", type=int, help="The port of the proxy to connect to.")
     parser.add_argument(
-        "proxy_address",
-        help="Address of the proxy to connect to.")
-    parser.add_argument(
-        "proxy_port",
-        type=int,
-        help="The port of the proxy to connect to.")
-    parser.add_argument(
-        '-s', '--server-hostname',
+        '-s',
+        '--server-hostname',
         dest="server_hostname",
         default="some.server.com",
         help="The hostname of the server to connect to.")
-    parser.add_argument(
-        "-t", "--send_time",
-        dest="send_time",
-        type=int,
-        default=3,
-        help="The number of seconds to send the POST.")
+    parser.add_argument("-t", "--send_time", dest="send_time", type=int, default=3, help="The number of seconds to send the POST.")
     parser.add_argument(
         '--finish-request',
         dest="finish_request",
@@ -69,11 +58,7 @@ def open_connection(address: str, port: int) -> socket.socket:
     return sock
 
 
-def send_slow_post(
-        sock: socket.socket,
-        server_hostname: str,
-        send_time: int,
-        finish_request: bool) -> None:
+def send_slow_post(sock: socket.socket, server_hostname: str, send_time: int, finish_request: bool) -> None:
     """Send a slow POST request.
 
     :param sock: The socket to send the request on.
@@ -84,11 +69,8 @@ def send_slow_post(
     """
     # Send the POST request.
     host_header = f'Host: {server_hostname}\r\n'.encode()
-    request = (
-        b"POST / HTTP/1.1\r\n"
-        + host_header +
-        b"Transfer-Encoding: chunked\r\n"
-        b"\r\n")
+    request = (b"POST / HTTP/1.1\r\n" + host_header + b"Transfer-Encoding: chunked\r\n"
+               b"\r\n")
     sock.sendall(request)
     print('Sent request headers:')
     print(request.decode())
@@ -128,11 +110,7 @@ def main() -> int:
     print(args)
 
     with open_connection(args.proxy_address, args.proxy_port) as sock:
-        send_slow_post(
-            sock,
-            args.server_hostname,
-            args.send_time,
-            args.finish_request)
+        send_slow_post(sock, args.server_hostname, args.send_time, args.finish_request)
 
         if args.finish_request:
             drain_response(sock)

--- a/tests/gold_tests/slow_post/slow_post_clients.py
+++ b/tests/gold_tests/slow_post/slow_post_clients.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 '''
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
@@ -31,7 +30,7 @@ def gen(slow_time):
 
 
 def slow_post(port, slow_time):
-    requests.post('http://127.0.0.1:{0}/'.format(port, ), data=gen(slow_time))
+    requests.post('http://127.0.0.1:{0}/'.format(port,), data=gen(slow_time))
 
 
 def makerequest(port, connection_limit):
@@ -47,12 +46,8 @@ def makerequest(port, connection_limit):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--port", "-p",
-                        type=int,
-                        help="Port to use")
-    parser.add_argument("--connectionlimit", "-c",
-                        type=int,
-                        help="connection limit")
+    parser.add_argument("--port", "-p", type=int, help="Port to use")
+    parser.add_argument("--connectionlimit", "-c", type=int, help="connection limit")
     args = parser.parse_args()
     makerequest(args.port, args.connectionlimit)
 

--- a/tests/gold_tests/thread_config/check_threads.py
+++ b/tests/gold_tests/thread_config/check_threads.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 '''
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
@@ -111,14 +110,13 @@ def count_threads(ts_path, etnet_threads, accept_threads, task_threads, aio_thre
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--ts-path', type=str, dest='ts_path', help='path to traffic_server binary', required=True)
-    parser.add_argument('-e', '--etnet-threads', type=int, dest='etnet_threads',
-                        help='expected number of ET_NET threads', required=True)
-    parser.add_argument('-a', '--accept-threads', type=int, dest='accept_threads',
-                        help='expected number of ACCEPT threads', required=True)
-    parser.add_argument('-t', '--task-threads', type=int, dest='task_threads',
-                        help='expected number of TASK threads', required=True)
-    parser.add_argument('-c', '--aio-threads', type=int, dest='aio_threads',
-                        help='expected number of AIO threads', required=True)
+    parser.add_argument(
+        '-e', '--etnet-threads', type=int, dest='etnet_threads', help='expected number of ET_NET threads', required=True)
+    parser.add_argument(
+        '-a', '--accept-threads', type=int, dest='accept_threads', help='expected number of ACCEPT threads', required=True)
+    parser.add_argument(
+        '-t', '--task-threads', type=int, dest='task_threads', help='expected number of TASK threads', required=True)
+    parser.add_argument('-c', '--aio-threads', type=int, dest='aio_threads', help='expected number of AIO threads', required=True)
     args = parser.parse_args()
     exit(count_threads(args.ts_path, args.etnet_threads, args.accept_threads, args.task_threads, args.aio_threads))
 

--- a/tests/gold_tests/thread_config/thread_config.test.py
+++ b/tests/gold_tests/thread_config/thread_config.test.py
@@ -22,15 +22,17 @@ Test.Summary = 'Test that Trafficserver starts with different thread configurati
 Test.ContinueOnFail = True
 
 ts = Test.MakeATSProcess('ts-1_exec-0_accept-1_task-1_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 1,
-    'proxy.config.accept_threads': 0,
-    'proxy.config.task_threads': 1,
-    'proxy.config.cache.threads_per_disk': 1,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 1,
+        'proxy.config.accept_threads': 0,
+        'proxy.config.task_threads': 1,
+        'proxy.config.cache.threads_per_disk': 1,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 ts.Setup.CopyAs('check_threads.py', Test.RunDirectory)
 
 tr = Test.AddTestRun()
@@ -40,15 +42,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-1_exec-1_accept-2_task-8_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 1,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.cache.threads_per_disk': 8,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 1,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.cache.threads_per_disk': 8,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -57,15 +61,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-1_exec-10_accept-10_task-32_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 1,
-    'proxy.config.accept_threads': 10,
-    'proxy.config.task_threads': 10,
-    'proxy.config.cache.threads_per_disk': 32,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 1,
+        'proxy.config.accept_threads': 10,
+        'proxy.config.task_threads': 10,
+        'proxy.config.cache.threads_per_disk': 32,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -74,15 +80,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-2_exec-0_accept-1_task-1_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 2,
-    'proxy.config.accept_threads': 0,
-    'proxy.config.task_threads': 1,
-    'proxy.config.cache.threads_per_disk': 1,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 2,
+        'proxy.config.accept_threads': 0,
+        'proxy.config.task_threads': 1,
+        'proxy.config.cache.threads_per_disk': 1,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -91,15 +99,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-2_exec-1_accept-2_task-8_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 2,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.cache.threads_per_disk': 8,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 2,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.cache.threads_per_disk': 8,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -108,15 +118,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-2_exec-10_accept-10_task-32_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 2,
-    'proxy.config.accept_threads': 10,
-    'proxy.config.task_threads': 10,
-    'proxy.config.cache.threads_per_disk': 32,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 2,
+        'proxy.config.accept_threads': 10,
+        'proxy.config.task_threads': 10,
+        'proxy.config.cache.threads_per_disk': 32,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -125,15 +137,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-32_exec-0_accept-1_task-1_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 32,
-    'proxy.config.accept_threads': 0,
-    'proxy.config.task_threads': 1,
-    'proxy.config.cache.threads_per_disk': 1,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 32,
+        'proxy.config.accept_threads': 0,
+        'proxy.config.task_threads': 1,
+        'proxy.config.cache.threads_per_disk': 1,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -142,15 +156,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-32_exec-1_accept-2_task-8_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 32,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.cache.threads_per_disk': 8,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 32,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.cache.threads_per_disk': 8,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -159,15 +175,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-32_exec-10_accept-10_task-32_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 32,
-    'proxy.config.accept_threads': 10,
-    'proxy.config.task_threads': 10,
-    'proxy.config.cache.threads_per_disk': 32,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 32,
+        'proxy.config.accept_threads': 10,
+        'proxy.config.task_threads': 10,
+        'proxy.config.cache.threads_per_disk': 32,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -176,15 +194,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-100_exec-0_accept-1_task-1_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 100,
-    'proxy.config.accept_threads': 0,
-    'proxy.config.task_threads': 1,
-    'proxy.config.cache.threads_per_disk': 1,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 100,
+        'proxy.config.accept_threads': 0,
+        'proxy.config.task_threads': 1,
+        'proxy.config.cache.threads_per_disk': 1,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -193,15 +213,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-100_exec-1_accept-2_task-8_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 100,
-    'proxy.config.accept_threads': 1,
-    'proxy.config.task_threads': 2,
-    'proxy.config.cache.threads_per_disk': 8,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 100,
+        'proxy.config.accept_threads': 1,
+        'proxy.config.task_threads': 2,
+        'proxy.config.cache.threads_per_disk': 8,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']
@@ -210,15 +232,17 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts)
 
 ts = Test.MakeATSProcess('ts-100_exec-10_accept-10_task-32_aio')
-ts.Disk.records_config.update({
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.5,
-    'proxy.config.exec_thread.limit': 100,
-    'proxy.config.accept_threads': 10,
-    'proxy.config.task_threads': 10,
-    'proxy.config.cache.threads_per_disk': 32,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.5,
+        'proxy.config.exec_thread.limit': 100,
+        'proxy.config.accept_threads': 10,
+        'proxy.config.task_threads': 10,
+        'proxy.config.cache.threads_per_disk': 32,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'iocore_thread_start|iocore_net_accept_start'
+    })
 
 tr = Test.AddTestRun()
 TS_ROOT = ts.Env['TS_ROOT']

--- a/tests/gold_tests/timeout/accept_timeout.test.py
+++ b/tests/gold_tests/timeout/accept_timeout.test.py
@@ -19,28 +19,25 @@
 Test.Summary = 'Testing ATS inactivity timeout'
 
 Test.SkipUnless(
-    Condition.HasCurlFeature('http2'),
-    Condition.HasProgram("telnet", "Need telnet to shutdown when server shuts down tcp"),
-    Condition.HasProgram("nc", "Need nc to send data to server")
-)
+    Condition.HasCurlFeature('http2'), Condition.HasProgram("telnet", "Need telnet to shutdown when server shuts down tcp"),
+    Condition.HasProgram("nc", "Need nc to send data to server"))
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 
 ts.addSSLfile("../tls/ssl/server.pem")
 ts.addSSLfile("../tls/ssl/server.key")
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http.transaction_no_activity_timeout_in': 6,
-    'proxy.config.http.accept_no_activity_timeout': 2,
-    'proxy.config.net.default_inactivity_timeout': 10,
-    'proxy.config.net.defer_accept': 0  # Must turn off defer accept to test the raw TCP case
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.http.transaction_no_activity_timeout_in': 6,
+        'proxy.config.http.accept_no_activity_timeout': 2,
+        'proxy.config.net.default_inactivity_timeout': 10,
+        'proxy.config.net.defer_accept': 0  # Must turn off defer accept to test the raw TCP case
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # case 1 TLS with no data
 tr = Test.AddTestRun("tr")

--- a/tests/gold_tests/timeout/active_timeout.test.py
+++ b/tests/gold_tests/timeout/active_timeout.test.py
@@ -18,9 +18,7 @@
 
 Test.Summary = 'Testing ATS active timeout'
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
     ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True, enable_quic=True)
@@ -36,19 +34,17 @@ server.addResponse("sessionfile.log", request_header, response_header)
 ts.addSSLfile("../tls/ssl/server.pem")
 ts.addSSLfile("../tls/ssl/server.key")
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.http.transaction_active_timeout_out': 2,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.remap_required': 1,
+        'proxy.config.http.transaction_active_timeout_out': 2,
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}/'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}/'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 tr = Test.AddTestRun("tr")
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/timeout/conn_timeout.test.py
+++ b/tests/gold_tests/timeout/conn_timeout.test.py
@@ -30,14 +30,15 @@ Test.GetTcpPort("upstream_port")
 
 server4 = Test.MakeOriginServer("server4")
 
-ts.Disk.records_config.update({
-    'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.http.connect_attempts_timeout': 2,
-    'proxy.config.http.connect_attempts_max_retries': 0,
-    'proxy.config.http.transaction_no_activity_timeout_out': 5,
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.url_remap.remap_required': 1,
+        'proxy.config.http.connect_attempts_timeout': 2,
+        'proxy.config.http.connect_attempts_max_retries': 0,
+        'proxy.config.http.transaction_no_activity_timeout_out': 5,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http',
+    })
 
 ts.Disk.remap_config.AddLine('map /blocked http://10.1.1.1:{0}'.format(Test.Variables.blocked_upstream_port))
 ts.Disk.remap_config.AddLine('map /not-blocked http://10.1.1.1:{0}'.format(Test.Variables.upstream_port))
@@ -52,9 +53,7 @@ logging:
     - mode: ascii
       format: testformat
       filename: squid
-'''.split("\n")
-)
-
+'''.split("\n"))
 
 # Set up the network name space.  Requires privilege
 tr = Test.AddTestRun("tr-ns-setup")
@@ -79,7 +78,6 @@ tr.Processes.Default.TimeOut = 4
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     "HTTP/1.1 502 internal error - server connection terminated", "Connect failed")
 
-
 #  Should not catch the connect timeout.  Even though the first bytes are not sent until after the 2 second connect timeout
 #  But before the no-activity timeout
 tr = Test.AddTestRun("tr-delayed")
@@ -88,7 +86,6 @@ tr.Setup.Copy('case1.sh')
 tr.Processes.Default.Command = 'sh ./case1.sh {0} {1}'.format(ts.Variables.port, ts.Variables.upstream_port)
 tr.Processes.Default.TimeOut = 7
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 200", "Connect succeeded")
-
 
 # cleanup the network namespace and virtual network
 tr = Test.AddTestRun("tr-cleanup")

--- a/tests/gold_tests/timeout/inactive_client_timeout.test.py
+++ b/tests/gold_tests/timeout/inactive_client_timeout.test.py
@@ -27,24 +27,24 @@ Test.ContinueOnFail = True
 ts.addSSLfile("../tls/ssl/server.pem")
 ts.addSSLfile("../tls/ssl/server.key")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.http.transaction_no_activity_timeout_in': 2,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.remap_required': 1,
+        'proxy.config.http.transaction_no_activity_timeout_in': 2,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
-ts.Disk.remap_config.AddLines([
-    'map https://www.tls.com/ https://127.0.0.1:{0}'.format(server.Variables.https_port),
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port),
-])
+ts.Disk.remap_config.AddLines(
+    [
+        'map https://www.tls.com/ https://127.0.0.1:{0}'.format(server.Variables.https_port),
+        'map / http://127.0.0.1:{0}'.format(server.Variables.http_port),
+    ])
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 #
 # Test 1: Verify that server delay does not trigger client activity timeout.
@@ -57,8 +57,6 @@ ts.Disk.ssl_multicert_config.AddLine(
 # get applied after the request is sent.  In other words, a slow to respond server should not
 # trigger the client inactivity timeout.
 tr = Test.AddTestRun("Verify that server delay does not trigger client activity timeout.")
-tr.AddVerifierClientProcess(
-    "client", replay_file, http_ports=[ts.Variables.port],
-    https_ports=[ts.Variables.ssl_port])
+tr.AddVerifierClientProcess("client", replay_file, http_ports=[ts.Variables.port], https_ports=[ts.Variables.ssl_port])
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/timeout/inactive_timeout.test.py
+++ b/tests/gold_tests/timeout/inactive_timeout.test.py
@@ -18,9 +18,7 @@
 
 Test.Summary = 'Testing ATS inactivity timeout'
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server", delay=8)
@@ -33,19 +31,17 @@ server.addResponse("sessionfile.log", request_header, response_header)
 ts.addSSLfile("../tls/ssl/server.pem")
 ts.addSSLfile("../tls/ssl/server.key")
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.http.transaction_no_activity_timeout_out': 2,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.remap_required': 1,
+        'proxy.config.http.transaction_no_activity_timeout_out': 2,
+    })
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}/'.format(server.Variables.Port))
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}/'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 tr = Test.AddTestRun("tr")
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/timeout/tls_conn_timeout.test.py
+++ b/tests/gold_tests/timeout/tls_conn_timeout.test.py
@@ -40,16 +40,17 @@ delay_get_connect = Test.Processes.Process(
 delay_get_ttfb = Test.Processes.Process(
     "delay get ttfb", './ssl-delay-server {0} 0 6 server.pem'.format(Test.Variables.get_block_ttfb_port))
 
-ts.Disk.records_config.update({
-    'proxy.config.url_remap.remap_required': 1,
-    'proxy.config.http.connect_attempts_timeout': 1,
-    'proxy.config.http.post_connect_attempts_timeout': 1,
-    'proxy.config.http.connect_attempts_max_retries': 1,
-    'proxy.config.http.transaction_no_activity_timeout_out': 4,
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'http|ssl',
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.url_remap.remap_required': 1,
+        'proxy.config.http.connect_attempts_timeout': 1,
+        'proxy.config.http.post_connect_attempts_timeout': 1,
+        'proxy.config.http.connect_attempts_max_retries': 1,
+        'proxy.config.http.transaction_no_activity_timeout_out': 4,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'http|ssl',
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
 ts.Disk.remap_config.AddLine('map /connect_blocked https://127.0.0.1:{0}'.format(Test.Variables.block_connect_port))
 ts.Disk.remap_config.AddLine('map /ttfb_blocked https://127.0.0.1:{0}'.format(Test.Variables.block_ttfb_port))
@@ -69,8 +70,7 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(delay_post_connect, ready=When.PortOpen(Test.Variables.block_connect_port))
 tr.Processes.Default.Command = 'curl -H"Connection:close" -d "bob" -i http://127.0.0.1:{0}/connect_blocked --tlsv1.2'.format(
     ts.Variables.port)
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "HTTP/1.1 502 connect failed", "Connect failed")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 502 connect failed", "Connect failed")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_post_connect
 tr.StillRunningAfter = Test.Processes.ts
@@ -93,8 +93,7 @@ tr = Test.AddTestRun("tr-blocking-get")
 tr.Processes.Default.StartBefore(delay_get_connect, ready=When.PortOpen(Test.Variables.get_block_connect_port))
 tr.Processes.Default.Command = 'curl -H"Connection:close" -i http://127.0.0.1:{0}/get_connect_blocked --tlsv1.2'.format(
     ts.Variables.port)
-tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "HTTP/1.1 502 connect failed", "Connect failed")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 502 connect failed", "Connect failed")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_get_connect
 
@@ -113,7 +112,6 @@ delay_post_connect.Streams.All = Testers.ContainsExpression(
 delay_post_connect.Streams.All += Testers.ExcludesExpression("TTFB delay", "Should not reach the TTFB delay logic")
 delay_post_ttfb.Streams.All = Testers.ContainsExpression("Accept try", "Should appear one time")
 delay_post_ttfb.Streams.All += Testers.ContainsExpression("TTFB delay", "Should reach the TTFB delay logic")
-
 
 delay_get_connect.Streams.All = Testers.ContainsExpression(
     "Accept try", "Should appear at least two times (may be an extra one due to port ready test)")

--- a/tests/gold_tests/tls/h2_early_decode.py
+++ b/tests/gold_tests/tls/h2_early_decode.py
@@ -15,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 '''
 A simple tool to decode http2 frames for 0-rtt testing.
 '''
@@ -102,6 +101,7 @@ class Http2FrameDefs:
 
 
 class Http2Frame:
+
     def __init__(self, length, frame_type, flags, stream_id):
         self.length = length
         self.frame_type = frame_type
@@ -162,8 +162,7 @@ class Http2Frame:
             error_code = int(self.payload[4:8].hex(), 16)
             debug_data = self.payload[8:].hex()
             return '\nLast Stream ID = 0x{0:08x}\nError Code = 0x{1:08x}\nDebug Data = {2}'.format(
-                last_stream_id, error_code, debug_data
-            )
+                last_stream_id, error_code, debug_data)
         else:
             return '\nError: Frame type mismatch: {0}'.format(Http2FrameDefs.FRAME_TYPES[self.frame_type])
 
@@ -192,8 +191,7 @@ class Http2Frame:
 
     def print(self):
         output = 'Length: {0}\nType: {1}\nFlags: {2}\nStream ID: {3}\nPayload: {4}\n'.format(
-            self.length, Http2FrameDefs.FRAME_TYPES[self.frame_type], self.flags, self.stream_id, self.print_payload()
-        )
+            self.length, Http2FrameDefs.FRAME_TYPES[self.frame_type], self.flags, self.stream_id, self.print_payload())
         if self.decode_error is not None:
             output += self.decode_error + '\n'
         return output
@@ -203,13 +201,13 @@ class Http2Frame:
 
 
 class Decoder:
+
     def read_frame_header(self, data):
         frame = Http2Frame(
             length=int(data[0:3].hex(), 16),
             frame_type=int(data[3:4].hex(), 16),
             flags=int(data[4:5].hex(), 16),
-            stream_id=int(data[5:9].hex(), 16) & Http2FrameDefs.RESERVE_BIT_MASK
-        )
+            stream_id=int(data[5:9].hex(), 16) & Http2FrameDefs.RESERVE_BIT_MASK)
         return frame
 
     def decode(self, data):

--- a/tests/gold_tests/tls/h2_early_gen.py
+++ b/tests/gold_tests/tls/h2_early_gen.py
@@ -15,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 '''
 A simple tool to generate some raw http2 frames for 0-rtt testing.
 '''
@@ -91,8 +90,7 @@ def make_settins_frame(ack=False, empty=False):
         frame_type=TYPE_SETTINGS_FRAME,
         frame_flags=1 if ack else 0,
         frame_stream_id=0,
-        frame_payload=payload
-    )
+        frame_payload=payload)
 
     return frame
 
@@ -102,12 +100,7 @@ def make_window_update_frame():
     payload = bytes.fromhex(payload)
 
     frame = make_frame(
-        frame_length=len(payload),
-        frame_type=TYPE_WINDOW_UPDATE_FRAME,
-        frame_flags=0,
-        frame_stream_id=0,
-        frame_payload=payload
-    )
+        frame_length=len(payload), frame_type=TYPE_WINDOW_UPDATE_FRAME, frame_flags=0, frame_stream_id=0, frame_payload=payload)
     return frame
 
 
@@ -126,12 +119,7 @@ def make_headers_frame(method, path='', stream_id=0x01):
         else:
             headers.append((':path', '/early_post'))
 
-    headers.extend([
-        (':scheme', 'https'),
-        (':authority', '127.0.0.1'),
-        ('host', '127.0.0.1'),
-        ('accept', '*/*')
-    ])
+    headers.extend([(':scheme', 'https'), (':authority', '127.0.0.1'), ('host', '127.0.0.1'), ('accept', '*/*')])
 
     headers_encoded = encode_payload(headers)
 
@@ -140,8 +128,7 @@ def make_headers_frame(method, path='', stream_id=0x01):
         frame_type=TYPE_HEADERS_FRAME,
         frame_flags=HEADERS_FLAG_END_STREAM | HEADERS_FLAG_END_HEADERS,
         frame_stream_id=stream_id,
-        frame_payload=headers_encoded
-    )
+        frame_payload=headers_encoded)
 
     return frame
 
@@ -149,10 +136,7 @@ def make_headers_frame(method, path='', stream_id=0x01):
 def make_h2_req(test):
     h2_req = H2_PREFACE
     if test == 'get' or test == 'post':
-        frames = [
-            make_settins_frame(ack=True),
-            make_headers_frame(test)
-        ]
+        frames = [make_settins_frame(ack=True), make_headers_frame(test)]
         for frame in frames:
             h2_req += frame
     elif test == 'multi1':

--- a/tests/gold_tests/tls/ssl_multicert_loader.test.py
+++ b/tests/gold_tests/tls/ssl_multicert_loader.test.py
@@ -28,20 +28,17 @@ request_header = {"headers": f"GET / HTTP/1.1\r\nHost: {sni_domain}\r\n\r\n", "t
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 server.addResponse("sessionlog.json", request_header, response_header)
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': f'{ts.Variables.SSLDir}',
-    'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': f'{ts.Variables.SSLDir}',
+        'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
+    })
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    f'map / http://127.0.0.1:{server.Variables.Port}'
-)
+ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.Port}')
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 tr = Test.AddTestRun("ensure we can connect for SNI $sni_domain")
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -53,16 +50,16 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 tr.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
 
-
 tr2 = Test.AddTestRun("Update config files")
 # Update the configs
 sslcertpath = ts.Disk.ssl_multicert_config.AbsPath
 
 tr2.Disk.File(sslcertpath, id="ssl_multicert_config", typename="ats:config")
-tr2.Disk.ssl_multicert_config.AddLines([
-    'ssl_cert_name=server_does_not_exist.pem ssl_key_name=server_does_not_exist.key',
-    'dest_ip=* ssl_cert_name=server.pem_doesnotexist ssl_key_name=server.key',
-])
+tr2.Disk.ssl_multicert_config.AddLines(
+    [
+        'ssl_cert_name=server_does_not_exist.pem ssl_key_name=server_does_not_exist.key',
+        'dest_ip=* ssl_cert_name=server.pem_doesnotexist ssl_key_name=server.key',
+    ])
 tr2.StillRunningAfter = ts
 tr2.StillRunningAfter = server
 tr2.Processes.Default.Command = 'echo Updated configs'
@@ -89,7 +86,6 @@ tr3.Processes.Default.ReturnCode = 0
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 tr3.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
 
-
 ##########################################################################
 # Ensure ATS fails/exits when non-existent cert is specified
 # Also, not explicitly setting proxy.config.ssl.server.multicert.exit_on_load_fail
@@ -108,6 +104,5 @@ tr4.Processes.Default.StartBefore(ts2)
 ts2.ReturnCode = 2
 ts2.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
 ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
-    'Traffic Server is fully initialized',
-    'process should fail when invalid certificate specified')
+    'Traffic Server is fully initialized', 'process should fail when invalid certificate specified')
 ts2.Disk.diags_log.Content = Testers.IncludesExpression('FATAL: failed to load SSL certificate file', 'check diags.log"')

--- a/tests/gold_tests/tls/test-0rtt-s_client.py
+++ b/tests/gold_tests/tls/test-0rtt-s_client.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 '''
 '''
 #  Licensed to the Apache Software Foundation (ASF) under one
@@ -35,18 +34,19 @@ def main():
     s_client_cmd_1 = shlex.split(
         'openssl s_client -connect 127.0.0.1:{0} -tls1_3 -quiet -sess_out {1}'.format(ats_port, sess_file_path))
     s_client_cmd_2 = shlex.split(
-        'openssl s_client -connect 127.0.0.1:{0} -tls1_3 -quiet -sess_in {1} -early_data {2}'.format(ats_port, sess_file_path, early_data_file_path))
+        'openssl s_client -connect 127.0.0.1:{0} -tls1_3 -quiet -sess_in {1} -early_data {2}'.format(
+            ats_port, sess_file_path, early_data_file_path))
 
-    create_sess_proc = subprocess.Popen(s_client_cmd_1, env=os.environ.copy(
-    ), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    create_sess_proc = subprocess.Popen(
+        s_client_cmd_1, env=os.environ.copy(), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     try:
         output = create_sess_proc.communicate(timeout=1)[0]
     except subprocess.TimeoutExpired:
         create_sess_proc.kill()
         output = create_sess_proc.communicate()[0]
 
-    reuse_sess_proc = subprocess.Popen(s_client_cmd_2, env=os.environ.copy(
-    ), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    reuse_sess_proc = subprocess.Popen(
+        s_client_cmd_2, env=os.environ.copy(), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     try:
         output = reuse_sess_proc.communicate(timeout=1)[0]
     except subprocess.TimeoutExpired:

--- a/tests/gold_tests/tls/tls.test.py
+++ b/tests/gold_tests/tls/tls.test.py
@@ -48,30 +48,32 @@ for i in range(0, 1000):
     post_body = "{0}0".format(post_body)
 
 # Add info the origin server responses
-server.addResponse("sessionlog.json",
-                   {"headers": header_string,
-                    "timestamp": "1469733493.993",
-                    "body": post_body},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 2\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "ok"})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": header_string,
+        "timestamp": "1469733493.993",
+        "body": post_body
+    }, {
+        "headers":
+            "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 2\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "ok"
+    })
 
 # add ssl materials like key, certificates for the server
 ts.addDefaultSSLFiles()
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.exec_thread.autoconfig.scale': 1.0,
-                               'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl',
-                               })
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl',
+    })
 
 tr = Test.AddTestRun("Run-Test")
 tr.Command = './ssl-post 127.0.0.1 40 {0} {1}'.format(header_count, ts.Variables.ssl_port)

--- a/tests/gold_tests/tls/tls_0rtt_server.test.py
+++ b/tests/gold_tests/tls/tls_0rtt_server.test.py
@@ -30,21 +30,9 @@ Test.SkipUnless(
 ts = Test.MakeATSProcess('ts', enable_tls=True)
 server = Test.MakeOriginServer('server')
 
-request_header1 = {
-    'headers': 'GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n',
-    'timestamp': '1469733493.993',
-    'body': ''
-}
-response_header1 = {
-    'headers': 'HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n',
-    'timestamp': '1469733493.993',
-    'body': 'curl test'
-}
-request_header2 = {
-    'headers': 'GET /early_get HTTP/1.1\r\nHost: www.example.com\r\n\r\n',
-    'timestamp': '1469733493.993',
-    'body': ''
-}
+request_header1 = {'headers': 'GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n', 'timestamp': '1469733493.993', 'body': ''}
+response_header1 = {'headers': 'HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n', 'timestamp': '1469733493.993', 'body': 'curl test'}
+request_header2 = {'headers': 'GET /early_get HTTP/1.1\r\nHost: www.example.com\r\n\r\n', 'timestamp': '1469733493.993', 'body': ''}
 response_header2 = {
     'headers': 'HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n',
     'timestamp': '1469733493.993',
@@ -109,30 +97,28 @@ ts.Setup.Copy('early_h2_post.txt')
 ts.Setup.Copy('early_h2_multi1.txt')
 ts.Setup.Copy('early_h2_multi2.txt')
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'http',
-    'proxy.config.exec_thread.autoconfig': 0,
-    'proxy.config.exec_thread.limit': 8,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 512000,
-    'proxy.config.ssl.session_cache.timeout': 7200,
-    'proxy.config.ssl.session_cache.num_buckets': 32768,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-    'proxy.config.ssl.server.max_early_data': 16384,
-    'proxy.config.ssl.server.allow_early_data_params': 0,
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.exec_thread.autoconfig': 0,
+        'proxy.config.exec_thread.limit': 8,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 512000,
+        'proxy.config.ssl.session_cache.timeout': 7200,
+        'proxy.config.ssl.session_cache.num_buckets': 32768,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.server.max_early_data': 16384,
+        'proxy.config.ssl.server.allow_early_data_params': 0,
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
 tr = Test.AddTestRun('Basic Curl Test')
 tr.Processes.Default.Command = 'curl https://127.0.0.1:{0} -k'.format(ts.Variables.ssl_port)

--- a/tests/gold_tests/tls/tls_bad_alpn.test.py
+++ b/tests/gold_tests/tls/tls_bad_alpn.test.py
@@ -34,16 +34,15 @@ ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
 # Make sure the TS server certs are different from the origin certs
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
 tr = Test.AddTestRun("alpn banana")
 tr.Processes.Default.Command = "openssl s_client -ign_eof -alpn=banana -connect 127.0.0.1:{}".format(ts.Variables.ssl_port)

--- a/tests/gold_tests/tls/tls_check_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection.test.py
@@ -45,7 +45,7 @@ ts.Disk.remap_config.AddLine(
 ts.Disk.ssl_multicert_config.AddLines([
     'dest_ip=127.0.0.1 ssl_cert_name=signed-foo.pem ssl_key_name=signed-foo.key',
     'ssl_cert_name=signed2-bar.pem ssl_key_name=signed-bar.key',
-    'dest_ip=* ssl_cert_name=combo.pem'
+    'dest_ip=* ssl_cert_name=combo.pem',
 ])
 
 # Case 1, global config policy=permissive properties=signature

--- a/tests/gold_tests/tls/tls_check_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection.test.py
@@ -39,26 +39,27 @@ ts.addSSLfile("ssl/signer.pem")
 ts.addSSLfile("ssl/signer.key")
 ts.addSSLfile("ssl/combo.pem")
 
-ts.Disk.remap_config.AddLine(
-    'map / https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map / https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLines([
-    'dest_ip=127.0.0.1 ssl_cert_name=signed-foo.pem ssl_key_name=signed-foo.key',
-    'ssl_cert_name=signed2-bar.pem ssl_key_name=signed-bar.key',
-    'dest_ip=* ssl_cert_name=combo.pem',
-])
+ts.Disk.ssl_multicert_config.AddLines(
+    [
+        'dest_ip=127.0.0.1 ssl_cert_name=signed-foo.pem ssl_key_name=signed-foo.key',
+        'ssl_cert_name=signed2-bar.pem ssl_key_name=signed-bar.key',
+        'dest_ip=* ssl_cert_name=combo.pem',
+    ])
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
 dns.addRecords(records={"foo.com.": ["127.0.0.1"]})
 dns.addRecords(records={"bar.com.": ["127.0.0.1"]})

--- a/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
@@ -37,25 +37,26 @@ ts.addSSLfile("ssl/signer.pem")
 ts.addSSLfile("ssl/signer.key")
 ts.addSSLfile("ssl/combo.pem")
 
-ts.Disk.remap_config.AddLine(
-    'map /stuff https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map /stuff https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLines([
-    'ssl_cert_name=signed-bar.pem ssl_key_name=signed-bar.key',
-    'dest_ip=* ssl_cert_name=combo.pem',
-])
+ts.Disk.ssl_multicert_config.AddLines(
+    [
+        'ssl_cert_name=signed-bar.pem ssl_key_name=signed-bar.key',
+        'dest_ip=* ssl_cert_name=combo.pem',
+    ])
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-    'proxy.config.diags.debug.tags': 'ssl|http|lm',
-    'proxy.config.diags.debug.enabled': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+        'proxy.config.diags.debug.tags': 'ssl|http|lm',
+        'proxy.config.diags.debug.enabled': 1
+    })
 
 # Should receive a bar.com cert issued by first signer
 tr = Test.AddTestRun("bar.com cert signer1")
@@ -80,8 +81,7 @@ tr.ReturnCode = 60
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "unable to get local issuer certificate",
-    "Server certificate not issued by expected signer")
+    "unable to get local issuer certificate", "Server certificate not issued by expected signer")
 
 # Pause a little to ensure mtime will be updated
 tr = Test.AddTestRun("Pause a little to ensure mtime will be different")
@@ -106,17 +106,15 @@ tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("Try with signer 1 again")
 # Wait for the reload to complete
-tr.Processes.Default.StartBefore(server3, ready=When.FileContains(
-    ts.Disk.diags_log.Name, 'ssl_multicert.config finished loading', 2))
+tr.Processes.Default.StartBefore(
+    server3, ready=When.FileContains(ts.Disk.diags_log.Name, 'ssl_multicert.config finished loading', 2))
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl -v --cacert ./signer.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(
     ts.Variables.ssl_port)
 tr.ReturnCode = 60
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
-    "unable to get local issuer certificate",
-    "Server certificate not issued by expected signer")
-
+    "unable to get local issuer certificate", "Server certificate not issued by expected signer")
 
 tr = Test.AddTestRun("Try with signer 2 again")
 tr.Processes.Default.Command = "curl -v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(

--- a/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
@@ -42,7 +42,7 @@ ts.Disk.remap_config.AddLine(
 
 ts.Disk.ssl_multicert_config.AddLines([
     'ssl_cert_name=signed-bar.pem ssl_key_name=signed-bar.key',
-    'dest_ip=* ssl_cert_name=combo.pem'
+    'dest_ip=* ssl_cert_name=combo.pem',
 ])
 
 # Case 1, global config policy=permissive properties=signature

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection.test.py
@@ -52,7 +52,7 @@ ts.Disk.remap_config.AddLine(
 ts.Disk.ssl_multicert_config.AddLines([
     'ssl_cert_name=signed-foo-ec.pem,signed-foo.pem ssl_key_name=signed-foo-ec.key,signed-foo.key',
     'ssl_cert_name=signed-san-ec.pem,signed-san.pem ssl_key_name=signed-san-ec.key,signed-san.key',
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
 ])
 
 # Case 1, global config policy=permissive properties=signature

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection.test.py
@@ -46,28 +46,29 @@ ts.addSSLfile("ssl/signer.key")
 ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
-ts.Disk.remap_config.AddLine(
-    'map / https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map / https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLines([
-    'ssl_cert_name=signed-foo-ec.pem,signed-foo.pem ssl_key_name=signed-foo-ec.key,signed-foo.key',
-    'ssl_cert_name=signed-san-ec.pem,signed-san.pem ssl_key_name=signed-san-ec.key,signed-san.key',
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
-])
+ts.Disk.ssl_multicert_config.AddLines(
+    [
+        'ssl_cert_name=signed-foo-ec.pem,signed-foo.pem ssl_key_name=signed-foo-ec.key,signed-foo.key',
+        'ssl_cert_name=signed-san-ec.pem,signed-san.pem ssl_key_name=signed-san-ec.key,signed-san.key',
+        'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
+    ])
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256',
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.diags.debug.tags': 'ssl',
-    'proxy.config.diags.debug.enabled': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256',
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.diags.debug.tags': 'ssl',
+        'proxy.config.diags.debug.enabled': 1
+    })
 
 dns.addRecords(records={"foo.com.": ["127.0.0.1"]})
 dns.addRecords(records={"bar.com.": ["127.0.0.1"]})

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection2.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection2.test.py
@@ -53,7 +53,7 @@ ts.Disk.remap_config.AddLine(
 ts.Disk.ssl_multicert_config.AddLines([
     'ssl_cert_name=combined-ec.pem,combined.pem',
     'ssl_cert_name=signed-foo-ec.pem,signed-foo.pem',
-    'dest_ip=* ssl_cert_name=signed-san-ec.pem,signed-san.pem'
+    'dest_ip=* ssl_cert_name=signed-san-ec.pem,signed-san.pem',
 ])
 
 # Case 1, global config policy=permissive properties=signature

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection2.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection2.test.py
@@ -47,28 +47,29 @@ ts.addSSLfile("ssl/combined.pem")
 ts.addSSLfile("ssl/signer.pem")
 ts.addSSLfile("ssl/signer.key")
 
-ts.Disk.remap_config.AddLine(
-    'map / https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map / https://foo.com:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLines([
-    'ssl_cert_name=combined-ec.pem,combined.pem',
-    'ssl_cert_name=signed-foo-ec.pem,signed-foo.pem',
-    'dest_ip=* ssl_cert_name=signed-san-ec.pem,signed-san.pem',
-])
+ts.Disk.ssl_multicert_config.AddLines(
+    [
+        'ssl_cert_name=combined-ec.pem,combined.pem',
+        'ssl_cert_name=signed-foo-ec.pem,signed-foo.pem',
+        'dest_ip=* ssl_cert_name=signed-san-ec.pem,signed-san.pem',
+    ])
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '/tmp',  # Faulty key path should not matter, since there are no key files
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256',
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.diags.debug.tags': 'ssl',
-    'proxy.config.diags.debug.enabled': 0
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '/tmp',  # Faulty key path should not matter, since there are no key files
+        'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256',
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.diags.debug.tags': 'ssl',
+        'proxy.config.diags.debug.enabled': 0
+    })
 
 dns.addRecords(records={"foo.com.": ["127.0.0.1"]})
 dns.addRecords(records={"bar.com.": ["127.0.0.1"]})
@@ -98,11 +99,11 @@ with open(os.path.join(Test.TestDirectory, 'ssl', 'signed-san.pem'), 'r') as myf
 with open(os.path.join(Test.TestDirectory, 'ssl', 'combined-ec.pem'), 'r') as myfile:
     file_string = myfile.read()
     cert_end = file_string.find("END CERTIFICATE-----")
-    combo_ec_string = re.escape(file_string[0: cert_end])
+    combo_ec_string = re.escape(file_string[0:cert_end])
 with open(os.path.join(Test.TestDirectory, 'ssl', 'combined.pem'), 'r') as myfile:
     file_string = myfile.read()
     cert_end = file_string.find("END CERTIFICATE-----")
-    combo_rsa_string = re.escape(file_string[0: cert_end])
+    combo_rsa_string = re.escape(file_string[0:cert_end])
 
 # Should receive a EC cert since ATS cipher list prefers EC
 tr = Test.AddTestRun("Default for foo should return EC cert")

--- a/tests/gold_tests/tls/tls_client_cert2.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2.test.py
@@ -24,18 +24,24 @@ Test client certs to origin selected via wildcard names in sni
 ts = Test.MakeATSProcess("ts", command="traffic_server", select_ports=True)
 cafile = "{0}/signer.pem".format(Test.RunDirectory)
 cafile2 = "{0}/signer2.pem".format(Test.RunDirectory)
-server = Test.MakeOriginServer("server",
-                               ssl=True,
-                               options={"--clientCA": cafile,
-                                        "--clientverify": ""},
-                               clientcert="{0}/signed-foo.pem".format(Test.RunDirectory),
-                               clientkey="{0}/signed-foo.key".format(Test.RunDirectory))
-server2 = Test.MakeOriginServer("server2",
-                                ssl=True,
-                                options={"--clientCA": cafile2,
-                                         "--clientverify": ""},
-                                clientcert="{0}/signed2-bar.pem".format(Test.RunDirectory),
-                                clientkey="{0}/signed-bar.key".format(Test.RunDirectory))
+server = Test.MakeOriginServer(
+    "server",
+    ssl=True,
+    options={
+        "--clientCA": cafile,
+        "--clientverify": ""
+    },
+    clientcert="{0}/signed-foo.pem".format(Test.RunDirectory),
+    clientkey="{0}/signed-foo.key".format(Test.RunDirectory))
+server2 = Test.MakeOriginServer(
+    "server2",
+    ssl=True,
+    options={
+        "--clientCA": cafile2,
+        "--clientverify": ""
+    },
+    clientcert="{0}/signed2-bar.pem".format(Test.RunDirectory),
+    clientkey="{0}/signed-bar.key".format(Test.RunDirectory))
 server4 = Test.MakeOriginServer("server4")
 server.Setup.Copy("ssl/signer.pem")
 server.Setup.Copy("ssl/signer2.pem")
@@ -69,41 +75,37 @@ ts.addSSLfile("ssl/signed-bar.pem")
 ts.addSSLfile("ssl/signed2-bar.pem")
 ts.addSSLfile("ssl/signed-bar.key")
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.remap_config.AddLine(
-    'map /case1 https://127.0.0.1:{0}/'.format(server.Variables.SSL_Port)
-)
-ts.Disk.remap_config.AddLine(
-    'map /case2 https://127.0.0.1:{0}/'.format(server2.Variables.SSL_Port)
-)
+ts.Disk.remap_config.AddLine('map /case1 https://127.0.0.1:{0}/'.format(server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map /case2 https://127.0.0.1:{0}/'.format(server2.Variables.SSL_Port))
 
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: bob.bar.com',
-    '  client_cert: signed-bar.pem',
-    '  client_key: signed-bar.key',
-    '- fqdn: bob.*.com',
-    '  client_cert: {0}/combo-signed-foo.pem'.format(ts.Variables.SSLDir),
-    '- fqdn: "*bar.com"',
-    '  client_cert: {0}/signed2-bar.pem'.format(ts.Variables.SSLDir),
-    '  client_key: {0}/signed-bar.key'.format(ts.Variables.SSLDir),
-    '- fqdn: "foo.com"',
-    '  client_cert: {0}/signed2-foo.pem'.format(ts.Variables.SSLDir),
-    '  client_key: {0}/signed-foo.key'.format(ts.Variables.SSLDir),
-])
+ts.Disk.sni_yaml.AddLines(
+    [
+        'sni:',
+        '- fqdn: bob.bar.com',
+        '  client_cert: signed-bar.pem',
+        '  client_key: signed-bar.key',
+        '- fqdn: bob.*.com',
+        '  client_cert: {0}/combo-signed-foo.pem'.format(ts.Variables.SSLDir),
+        '- fqdn: "*bar.com"',
+        '  client_cert: {0}/signed2-bar.pem'.format(ts.Variables.SSLDir),
+        '  client_key: {0}/signed-bar.key'.format(ts.Variables.SSLDir),
+        '- fqdn: "foo.com"',
+        '  client_cert: {0}/signed2-foo.pem'.format(ts.Variables.SSLDir),
+        '  client_key: {0}/signed-foo.key'.format(ts.Variables.SSLDir),
+    ])
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -115,8 +117,7 @@ logging:
     - mode: ascii
       format: testformat
       filename: squid
-'''.split("\n")
-)
+'''.split("\n"))
 
 # Should succeed
 tr = Test.AddTestRun("bob.bar.com to server 1")

--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -17,7 +17,6 @@ Test requiring certificate from user agent
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 Test.Summary = '''
 Test various options for requiring certificate from client for mutual authentication TLS
 '''
@@ -39,37 +38,35 @@ ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.ssl.client.certification_level': 2,
-    'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.TLSv1_3': 0
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.ssl.client.certification_level': 2,
+        'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.TLSv1_3': 0
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Just map everything through to origin.  This test is concentrating on the user-agent side
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}/'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}/'.format(server.Variables.Port))
 
 # Scenario 1:  Default no client cert required.  cert required for bar.com
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: bob.bar.com',
-    '  verify_client: NONE',
-    '- fqdn: "bob.com"',
-    '  verify_client: STRICT',
-    '- fqdn: bob.*.com',
-    '  verify_client: NONE',
-    '- fqdn: "*bar.com"',
-    '  verify_client: STRICT',
-])
+ts.Disk.sni_yaml.AddLines(
+    [
+        'sni:',
+        '- fqdn: bob.bar.com',
+        '  verify_client: NONE',
+        '- fqdn: "bob.com"',
+        '  verify_client: STRICT',
+        '- fqdn: bob.*.com',
+        '  verify_client: NONE',
+        '- fqdn: "*bar.com"',
+        '  verify_client: STRICT',
+    ])
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -81,8 +78,7 @@ logging:
     - mode: ascii
       format: testformat
       filename: squid
-'''.split("\n")
-)
+'''.split("\n"))
 
 # to foo.com w/o client cert.  Should fail
 tr = Test.AddTestRun("Connect to foo.com without cert")
@@ -195,7 +191,6 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case12".format(
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 35
-
 
 # Test that the fqdn's match completely.  bob.com should require client certificate. bob.com.com should not
 tr = Test.AddTestRun("Connect to bob.com without cert, should fail")

--- a/tests/gold_tests/tls/tls_client_verify2.test.py
+++ b/tests/gold_tests/tls/tls_client_verify2.test.py
@@ -37,35 +37,33 @@ ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.ssl.client.certification_level': 0,
-    'proxy.config.ssl.CA.cert.path': '',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir)
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.ssl.client.certification_level': 0,
+        'proxy.config.ssl.CA.cert.path': '',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir)
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Just map everything through to origin.  This test is concentrating on the user-agent side
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}/'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}/'.format(server.Variables.Port))
 
 # Scenario 1:  Default no client cert required.  cert required for bar.com
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: bob.bar.com',
-    '  verify_client: STRICT',
-    '- fqdn: bob.*.com',
-    '  verify_client: STRICT',
-    '- fqdn: "*bar.com"',
-    '  verify_client: NONE',
-])
+ts.Disk.sni_yaml.AddLines(
+    [
+        'sni:',
+        '- fqdn: bob.bar.com',
+        '  verify_client: STRICT',
+        '- fqdn: bob.*.com',
+        '  verify_client: STRICT',
+        '- fqdn: "*bar.com"',
+        '  verify_client: NONE',
+    ])
 
 # to foo.com w/o client cert.  Should succeed
 tr = Test.AddTestRun("Connect to foo.com without cert")

--- a/tests/gold_tests/tls/tls_client_verify3.test.py
+++ b/tests/gold_tests/tls/tls_client_verify3.test.py
@@ -73,7 +73,7 @@ ts.Disk.sni_yaml.AddLines([
     '- fqdn: ccc.com',
     '  verify_client: STRICT',
     '  verify_client_ca_certs:',
-    f'    file: {ts.Variables.SSLDir}/ccc-ca.pem'
+    f'    file: {ts.Variables.SSLDir}/ccc-ca.pem',
 ])
 
 # Success test runs.

--- a/tests/gold_tests/tls/tls_client_verify3.test.py
+++ b/tests/gold_tests/tls/tls_client_verify3.test.py
@@ -17,7 +17,6 @@ Test per SNI server name selection of CA certs for validating cert sent by clien
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 Test.Summary = '''
 Test per SNI server name selection of CA certs for validating cert sent by client.
 '''
@@ -39,42 +38,38 @@ ts.Setup.Copy("ssl/bbb-signed.pem", ts.Variables.SSLDir)
 ts.Setup.Copy("ssl/aaa-ca.pem", ts.Variables.SSLDir)
 ts.Setup.Copy("ssl/ccc-ca.pem", ts.Variables.SSLDir)
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl',
-    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
-    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.ssl.client.certification_level': 2,
-    'proxy.config.ssl.CA.cert.filename': f'{ts.Variables.SSLDir}/aaa-ca.pem',
-    'proxy.config.ssl.TLSv1_3': 0
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl',
+        'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+        'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.ssl.client.certification_level': 2,
+        'proxy.config.ssl.CA.cert.filename': f'{ts.Variables.SSLDir}/aaa-ca.pem',
+        'proxy.config.ssl.TLSv1_3': 0
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'ssl_cert_name=bbb-signed.pem ssl_key_name=bbb-signed.key'
-)
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('ssl_cert_name=bbb-signed.pem ssl_key_name=bbb-signed.key')
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Just map everything through to origin.  This test is concentrating on the user-agent side.
-ts.Disk.remap_config.AddLine(
-    f'map / http://127.0.0.1:{server.Variables.Port}/'
-)
+ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.Port}/')
 
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: bbb.com',
-    '  verify_client: STRICT',
-    '  verify_client_ca_certs: bbb-ca.pem',
-    '- fqdn: bbb-signed',
-    '  verify_client: STRICT',
-    '  verify_client_ca_certs: bbb-ca.pem',
-    '- fqdn: ccc.com',
-    '  verify_client: STRICT',
-    '  verify_client_ca_certs:',
-    f'    file: {ts.Variables.SSLDir}/ccc-ca.pem',
-])
+ts.Disk.sni_yaml.AddLines(
+    [
+        'sni:',
+        '- fqdn: bbb.com',
+        '  verify_client: STRICT',
+        '  verify_client_ca_certs: bbb-ca.pem',
+        '- fqdn: bbb-signed',
+        '  verify_client: STRICT',
+        '  verify_client_ca_certs: bbb-ca.pem',
+        '- fqdn: ccc.com',
+        '  verify_client: STRICT',
+        '  verify_client_ca_certs:',
+        f'    file: {ts.Variables.SSLDir}/ccc-ca.pem',
+    ])
 
 # Success test runs.
 
@@ -84,9 +79,8 @@ tr.Processes.Default.StartBefore(server)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = (
-    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'aaa.com:{0}:127.0.0.1'" +
-    " https://aaa.com:{0}/xyz"
-).format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/aaa-signed")
+    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'aaa.com:{0}:127.0.0.1'" + " https://aaa.com:{0}/xyz").format(
+        ts.Variables.ssl_port, Test.TestDirectory + "/ssl/aaa-signed")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -95,8 +89,7 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = (
     "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'bbb-signed:{0}:127.0.0.1'" +
-    " https://bbb-signed:{0}/xyz"
-).format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/bbb-signed")
+    " https://bbb-signed:{0}/xyz").format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/bbb-signed")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -104,9 +97,8 @@ tr = Test.AddTestRun()
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = (
-    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'ccc.com:{0}:127.0.0.1'" +
-    " https://ccc.com:{0}/xyz"
-).format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/ccc-signed")
+    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'ccc.com:{0}:127.0.0.1'" + " https://ccc.com:{0}/xyz").format(
+        ts.Variables.ssl_port, Test.TestDirectory + "/ssl/ccc-signed")
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -116,25 +108,22 @@ tr = Test.AddTestRun()
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = (
-    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'aaa.com:{0}:127.0.0.1'" +
-    " https://aaa.com:{0}/xyz"
-).format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/bbb-signed")
+    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'aaa.com:{0}:127.0.0.1'" + " https://aaa.com:{0}/xyz").format(
+        ts.Variables.ssl_port, Test.TestDirectory + "/ssl/bbb-signed")
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun()
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = (
-    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'bbb.com:{0}:127.0.0.1'" +
-    " https://bbb.com:{0}/xyz"
-).format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/ccc-signed")
+    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'bbb.com:{0}:127.0.0.1'" + " https://bbb.com:{0}/xyz").format(
+        ts.Variables.ssl_port, Test.TestDirectory + "/ssl/ccc-signed")
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun()
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.Processes.Default.Command = (
-    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'ccc.com:{0}:127.0.0.1'" +
-    " https://ccc.com:{0}/xyz"
-).format(ts.Variables.ssl_port, Test.TestDirectory + "/ssl/aaa-signed")
+    "curl -v -k --tls-max 1.2  --cert {1}.pem --key {1}.key --resolve 'ccc.com:{0}:127.0.0.1'" + " https://ccc.com:{0}/xyz").format(
+        ts.Variables.ssl_port, Test.TestDirectory + "/ssl/aaa-signed")
 tr.Processes.Default.ReturnCode = 35

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -23,9 +23,7 @@ Test TLS protocol offering  based on SNI
 # By default only offer TLSv1_2
 # for special domain foo.com only offer TLSv1 and TLSv1_1
 
-Test.SkipUnless(
-    Condition.HasOpenSSLVersion("1.1.1")
-)
+Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
@@ -42,25 +40,24 @@ ts.addSSLfile("ssl/server.key")
 # Need no remap rules.  Everything should be processed by sni
 
 # Make sure the TS server certs are different from the origin certs
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 cipher_suite = 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2'
 if Condition.HasOpenSSLVersion("3.0.0"):
     cipher_suite += ":@SECLEVEL=0"
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': cipher_suite,
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.ssl.TLSv1': 0,
-    'proxy.config.ssl.TLSv1_1': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.TLSv1_2': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite': cipher_suite,
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.ssl.TLSv1': 0,
+        'proxy.config.ssl.TLSv1_1': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.TLSv1_2': 1
+    })
 
 # foo.com should only offer the older TLS protocols
 # bar.com should terminate.

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -68,7 +68,7 @@ ts.Disk.records_config.update({
 ts.Disk.sni_yaml.AddLines([
     'sni:',
     '- fqdn: foo.com',
-    '  valid_tls_versions_in: [ TLSv1, TLSv1_1 ]'
+    '  valid_tls_versions_in: [ TLSv1, TLSv1_1 ]',
 ])
 
 # Target foo.com for TLSv1_2.  Should fail

--- a/tests/gold_tests/tls/tls_engine.test.py
+++ b/tests/gold_tests/tls/tls_engine.test.py
@@ -16,9 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import os
-
 
 # Someday should add client cert to origin to exercise the
 # engine interface on the other side
@@ -40,55 +38,58 @@ server = Test.MakeOriginServer("server")
 ts.Setup.Copy(os.path.join(Test.Variables.AtsTestPluginsDir, 'async_engine.so'), Test.RunDirectory)
 
 # Add info the origin server responses
-server.addResponse("sessionlog.json",
-                   {"headers": "GET / HTTP/1.1\r\nuuid: basic\r\n\r\n",
-                    "timestamp": "1469733493.993",
-                    "body": ""},
-                   {"headers": "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 2\r\n\r\n",
-                       "timestamp": "1469733493.993",
-                       "body": "ok"})
+server.addResponse(
+    "sessionlog.json", {
+        "headers": "GET / HTTP/1.1\r\nuuid: basic\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }, {
+        "headers":
+            "HTTP/1.1 200 OK\r\nServer: microserver\r\nConnection: close\r\nCache-Control: max-age=3600\r\nContent-Length: 2\r\n\r\n",
+        "timestamp": "1469733493.993",
+        "body": "ok"
+    })
 
 # add ssl materials like key, certificates for the server
 ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.engine.conf_file': '{0}/ts/config/load_engine.cnf'.format(Test.RunDirectory),
-    'proxy.config.ssl.async.handshake.enabled': 1,
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'ssl|http'
-})
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.engine.conf_file': '{0}/ts/config/load_engine.cnf'.format(Test.RunDirectory),
+        'proxy.config.ssl.async.handshake.enabled': 1,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'ssl|http'
+    })
 
-ts.Disk.MakeConfigFile('load_engine.cnf').AddLines([
-    'openssl_conf = openssl_init',
-    '',
-    '[openssl_init]',
-    '',
-    'engines = engine_section',
-    '',
-    '[engine_section]',
-    '',
-    'async = async_section',
-    '',
-    '[async_section]',
-    '',
-    'dynamic_path = {0}/async_engine.so'.format(Test.RunDirectory),
-    '',
-    'engine_id = async-test',
-    '',
-    'default_algorithms = RSA',
-    '',
-    'init = 1',])
+ts.Disk.MakeConfigFile('load_engine.cnf').AddLines(
+    [
+        'openssl_conf = openssl_init',
+        '',
+        '[openssl_init]',
+        '',
+        'engines = engine_section',
+        '',
+        '[engine_section]',
+        '',
+        'async = async_section',
+        '',
+        '[async_section]',
+        '',
+        'dynamic_path = {0}/async_engine.so'.format(Test.RunDirectory),
+        '',
+        'engine_id = async-test',
+        '',
+        'default_algorithms = RSA',
+        '',
+        'init = 1',
+    ])
 
 # Make a basic request.  Hopefully it goes through
 tr = Test.AddTestRun("Run-Test")

--- a/tests/gold_tests/tls/tls_engine.test.py
+++ b/tests/gold_tests/tls/tls_engine.test.py
@@ -88,7 +88,7 @@ ts.Disk.MakeConfigFile('load_engine.cnf').AddLines([
     '',
     'default_algorithms = RSA',
     '',
-    'init = 1'])
+    'init = 1',])
 
 # Make a basic request.  Hopefully it goes through
 tr = Test.AddTestRun("Run-Test")

--- a/tests/gold_tests/tls/tls_forward_nonhttp.test.py
+++ b/tests/gold_tests/tls/tls_forward_nonhttp.test.py
@@ -38,21 +38,20 @@ nameserver = Test.MakeDNServer("dns", default='127.0.0.1')
 # Need no remap rules.  Everything should be processed by sni
 
 # Make sure the TS server certs are different from the origin certs
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.http.connect_ports': '{0} {1}'.format(ts.Variables.ssl_port, ts.Variables.s_client_port),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-    'proxy.config.dns.resolv_conf': 'NULL'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.http.connect_ports': '{0} {1}'.format(ts.Variables.ssl_port, ts.Variables.s_client_port),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
+        'proxy.config.dns.resolv_conf': 'NULL'
+    })
 
 # foo.com should not terminate.  Just tunnel to server_foo
 # bar.com should terminate.  Forward its tcp stream to server_bar

--- a/tests/gold_tests/tls/tls_forward_nonhttp.test.py
+++ b/tests/gold_tests/tls/tls_forward_nonhttp.test.py
@@ -59,7 +59,7 @@ ts.Disk.records_config.update({
 ts.Disk.sni_yaml.AddLines([
     "sni:",
     "- fqdn: bar.com",
-    "  forward_route: localhost:{0}".format(ts.Variables.s_client_port)
+    "  forward_route: localhost:{0}".format(ts.Variables.s_client_port),
 ])
 
 tr = Test.AddTestRun("forward-non-http")

--- a/tests/gold_tests/tls/tls_hooks_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_client_verify.test.py
@@ -36,30 +36,26 @@ ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 
-ts.Disk.records_config.update({
-    # Test looks for debug output from the plugin
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl_client_verify_test',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
-    'proxy.config.url_remap.pristine_host_hdr': 1
-})
+ts.Disk.records_config.update(
+    {
+        # Test looks for debug output from the plugin
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_client_verify_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
+        'proxy.config.url_remap.pristine_host_hdr': 1
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://foo.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port)
-)
+    'map https://foo.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port))
 ts.Disk.remap_config.AddLine(
-    'map https://bar.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port)
-)
+    'map https://bar.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port))
 ts.Disk.remap_config.AddLine(
-    'map https://random.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port)
-)
+    'map https://random.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port))
 
 ts.Disk.sni_yaml.AddLines([
     'sni:',
@@ -84,7 +80,6 @@ tr.Processes.Default.Command = "curl --tls-max 1.2 -k --cert ./signed-foo.pem --
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.all = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-
 
 tr2 = Test.AddTestRun("request bad name")
 tr2.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_hooks_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_verify.test.py
@@ -33,39 +33,32 @@ server.addResponse("sessionlog.json", request_header, response_header)
 ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl_verify_test',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
-    'proxy.config.ssl.client.verify.server.properties': 'NONE',
-    'proxy.config.url_remap.pristine_host_hdr': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_verify_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
+        'proxy.config.ssl.client.verify.server.properties': 'NONE',
+        'proxy.config.url_remap.pristine_host_hdr': 1
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://foo.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port)
-)
+    'map https://foo.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port))
 ts.Disk.remap_config.AddLine(
-    'map https://bar.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port)
-)
+    'map https://bar.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port))
 ts.Disk.remap_config.AddLine(
-    'map https://random.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port)
-)
+    'map https://random.com:{1}/ https://127.0.0.1:{0}'.format(server.Variables.SSL_Port, ts.Variables.ssl_port))
 
-ts.Disk.sni_yaml.AddLine(
-    'sni:')
-ts.Disk.sni_yaml.AddLine(
-    '- fqdn: bar.com')
-ts.Disk.sni_yaml.AddLine(
-    '  verify_server_policy: PERMISSIVE')
+ts.Disk.sni_yaml.AddLine('sni:')
+ts.Disk.sni_yaml.AddLine('- fqdn: bar.com')
+ts.Disk.sni_yaml.AddLine('  verify_server_policy: PERMISSIVE')
 
-Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_verify_test.so'),
-                       ts, '-count=2 -bad=random.com -bad=bar.com')
+Test.PrepareTestPlugin(
+    os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_verify_test.so'), ts, '-count=2 -bad=random.com -bad=bar.com')
 
 tr = Test.AddTestRun("request good name")
 tr.Processes.Default.StartBefore(server)
@@ -75,7 +68,6 @@ tr.StillRunningAfter = server
 tr.Processes.Default.Command = "curl --resolve \"foo.com:{0}:127.0.0.1\" -k  https://foo.com:{0}".format(ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have failed")
-
 
 tr2 = Test.AddTestRun("request bad name")
 tr2.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_keepalive.test.py
+++ b/tests/gold_tests/tls/tls_keepalive.test.py
@@ -23,9 +23,7 @@ Test.Summary = '''
 Verify that the client-side keep alive is honored for TLS and different versions of HTTP
 '''
 
-Test.SkipUnless(
-    Condition.HasCurlFeature('http2')
-)
+Test.SkipUnless(Condition.HasCurlFeature('http2'))
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
@@ -37,21 +35,19 @@ server.addResponse("sessionlog.json", request_header, response_header)
 ts.addSSLfile("ssl/server.pem")
 ts.addSSLfile("ssl/server.key")
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.TLSv1_3': 0,
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.log.max_secs_per_buffer': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.TLSv1_3': 0,
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.log.max_secs_per_buffer': 1
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 ts.Disk.logging_yaml.AddLines(
     '''
@@ -63,8 +59,7 @@ logging:
     - mode: ascii
       format: testformat
       filename: squid
-'''.split("\n")
-)
+'''.split("\n"))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-preaccept=1')
 

--- a/tests/gold_tests/tls/tls_ocsp.test.py
+++ b/tests/gold_tests/tls/tls_ocsp.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import os
+
 Test.Summary = '''
 Test tls server prefetched OCSP responses
 '''
@@ -40,25 +41,23 @@ ts.addSSLfile("ssl/server.ocsp.key")
 ts.addSSLfile("ssl/ocsp_response.der")
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.ocsp.pem ssl_key_name=server.ocsp.key ssl_ocsp_name=ocsp_response.der'
-)
+    'dest_ip=* ssl_cert_name=server.ocsp.pem ssl_key_name=server.ocsp.key ssl_ocsp_name=ocsp_response.der')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cert_chain.filename': 'ca.ocsp.pem',
-    # enable prefetched OCSP responses
-    'proxy.config.ssl.ocsp.response.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.ocsp.enabled': 1,
-    'proxy.config.exec_thread.autoconfig.scale': 1.0
-})
-
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.cert_chain.filename': 'ca.ocsp.pem',
+        # enable prefetched OCSP responses
+        'proxy.config.ssl.ocsp.response.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.ocsp.enabled': 1,
+        'proxy.config.exec_thread.autoconfig.scale': 1.0
+    })
 
 tr = Test.AddTestRun("Check OCSP response using curl")
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/tls/tls_origin_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_origin_session_reuse.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import re
+
 Test.Summary = '''
 Test tls origin session reuse
 '''
@@ -29,16 +30,8 @@ ts4 = Test.MakeATSProcess("ts4", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
 
 # Add info the origin server responses
-request_header = {
-    'headers': 'GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n',
-    'timestamp': '1469733493.993',
-    'body': ''
-}
-response_header = {
-    'headers': 'HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n',
-    'timestamp': '1469733493.993',
-    'body': 'curl test'
-}
+request_header = {'headers': 'GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n', 'timestamp': '1469733493.993', 'body': ''}
+response_header = {'headers': 'HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n', 'timestamp': '1469733493.993', 'body': 'curl test'}
 server.addResponse("sessionlog.json", request_header, response_header)
 
 # add ssl materials like key, certificates for the server
@@ -51,101 +44,92 @@ ts3.addSSLfile("ssl/server.key")
 ts4.addSSLfile("ssl/server.pem")
 ts4.addSSLfile("ssl/server.key")
 
-ts1.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts2.Disk.remap_config.AddLines([
-    'map /reuse_session https://127.0.0.1:{0}'.format(ts1.Variables.ssl_port),
-    'map /remove_oldest https://127.0.1.1:{0}'.format(ts1.Variables.ssl_port),
-])
-ts3.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts4.Disk.remap_config.AddLine(
-    'map / https://127.0.0.1:{0}'.format(ts3.Variables.ssl_port)
-)
+ts1.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts2.Disk.remap_config.AddLines(
+    [
+        'map /reuse_session https://127.0.0.1:{0}'.format(ts1.Variables.ssl_port),
+        'map /remove_oldest https://127.0.1.1:{0}'.format(ts1.Variables.ssl_port),
+    ])
+ts3.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts4.Disk.remap_config.AddLine('map / https://127.0.0.1:{0}'.format(ts3.Variables.ssl_port))
 
-ts1.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts2.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts3.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts4.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts1.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts2.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts3.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts4.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts1.Disk.records_config.update({
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts1.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts1.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-    'proxy.config.ssl.origin_session_cache': 1,
-    'proxy.config.ssl.origin_session_cache.size': 1,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
-ts2.Disk.records_config.update({
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl.origin_session_cache',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts2.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts2.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-    'proxy.config.ssl.origin_session_cache': 1,
-    'proxy.config.ssl.origin_session_cache.size': 1,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
-ts3.Disk.records_config.update({
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts3.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts3.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-    'proxy.config.ssl.origin_session_cache': 1,
-    'proxy.config.ssl.origin_session_cache.size': 1,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
-ts4.Disk.records_config.update({
-    'proxy.config.http.cache.http': 0,
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl.origin_session_cache',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts4.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts4.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-    'proxy.config.ssl.origin_session_cache': 0,
-    'proxy.config.ssl.origin_session_cache.size': 1,
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-})
+ts1.Disk.records_config.update(
+    {
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts1.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts1.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 4096,
+        'proxy.config.ssl.session_cache.num_buckets': 256,
+        'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
+        'proxy.config.ssl.session_cache.timeout': 0,
+        'proxy.config.ssl.session_cache.auto_clear': 1,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.origin_session_cache': 1,
+        'proxy.config.ssl.origin_session_cache.size': 1,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl.origin_session_cache',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts2.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts2.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 4096,
+        'proxy.config.ssl.session_cache.num_buckets': 256,
+        'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
+        'proxy.config.ssl.session_cache.timeout': 0,
+        'proxy.config.ssl.session_cache.auto_clear': 1,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.origin_session_cache': 1,
+        'proxy.config.ssl.origin_session_cache.size': 1,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
+ts3.Disk.records_config.update(
+    {
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts3.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts3.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 4096,
+        'proxy.config.ssl.session_cache.num_buckets': 256,
+        'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
+        'proxy.config.ssl.session_cache.timeout': 0,
+        'proxy.config.ssl.session_cache.auto_clear': 1,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.origin_session_cache': 1,
+        'proxy.config.ssl.origin_session_cache.size': 1,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
+ts4.Disk.records_config.update(
+    {
+        'proxy.config.http.cache.http': 0,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl.origin_session_cache',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts4.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts4.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 4096,
+        'proxy.config.ssl.session_cache.num_buckets': 256,
+        'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
+        'proxy.config.ssl.session_cache.timeout': 0,
+        'proxy.config.ssl.session_cache.auto_clear': 1,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+        'proxy.config.ssl.origin_session_cache': 0,
+        'proxy.config.ssl.origin_session_cache.size': 1,
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
 tr = Test.AddTestRun('new session then reuse')
 tr.Processes.Default.Command = 'curl https://127.0.0.1:{0}/reuse_session -k && curl https://127.0.0.1:{0}/reuse_session -k'.format(

--- a/tests/gold_tests/tls/tls_origin_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_origin_session_reuse.test.py
@@ -56,7 +56,7 @@ ts1.Disk.remap_config.AddLine(
 )
 ts2.Disk.remap_config.AddLines([
     'map /reuse_session https://127.0.0.1:{0}'.format(ts1.Variables.ssl_port),
-    'map /remove_oldest https://127.0.1.1:{0}'.format(ts1.Variables.ssl_port)
+    'map /remove_oldest https://127.0.1.1:{0}'.format(ts1.Variables.ssl_port),
 ])
 ts3.Disk.remap_config.AddLine(
     'map / http://127.0.0.1:{0}'.format(server.Variables.Port)

--- a/tests/gold_tests/tls/tls_session_key_logging.test.py
+++ b/tests/gold_tests/tls/tls_session_key_logging.test.py
@@ -19,7 +19,6 @@ Test TLS secrets logging.
 
 import os
 
-
 Test.Summary = '''
 Test TLS secrets logging.
 '''
@@ -40,8 +39,7 @@ class TlsKeyloggingTest:
     def setupOriginServer(self):
         server_name = f"server_{TlsKeyloggingTest.server_counter}"
         TlsKeyloggingTest.server_counter += 1
-        self.server = Test.MakeVerifierServerProcess(
-            server_name, TlsKeyloggingTest.replay_file)
+        self.server = Test.MakeVerifierServerProcess(server_name, TlsKeyloggingTest.replay_file)
 
     def setupTS(self, enable_secrets_logging):
         ts_name = f"ts_{TlsKeyloggingTest.ts_counter}"
@@ -49,20 +47,16 @@ class TlsKeyloggingTest:
         self.ts = Test.MakeATSProcess(ts_name, enable_tls=True, enable_cache=False)
 
         self.ts.addDefaultSSLFiles()
-        self.ts.Disk.records_config.update({
-            "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
-            "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
-
-            'proxy.config.diags.debug.enabled': 1,
-            'proxy.config.diags.debug.tags': 'ssl_keylog'
-        })
-        self.ts.Disk.ssl_multicert_config.AddLine(
-            'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-        )
-        self.ts.Disk.remap_config.AddLine(
-            f'map / https://127.0.0.1:{self.server.Variables.https_port}'
-        )
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.ssl.server.cert.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.server.private_key.path": f'{self.ts.Variables.SSLDir}',
+                "proxy.config.ssl.client.verify.server.policy": 'PERMISSIVE',
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'ssl_keylog'
+            })
+        self.ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+        self.ts.Disk.remap_config.AddLine(f'map / https://127.0.0.1:{self.server.Variables.https_port}')
 
         keylog_file = os.path.join(self.ts.Variables.LOGDIR, "tls_secrets.txt")
 
@@ -76,8 +70,7 @@ class TlsKeyloggingTest:
             })
 
             self.ts.Disk.diags_log.Content += Testers.ContainsExpression(
-                f"Opened {keylog_file} for TLS key logging",
-                "Verify the user was notified of TLS secrets logging.")
+                f"Opened {keylog_file} for TLS key logging", "Verify the user was notified of TLS secrets logging.")
             self.ts.Disk.File(keylog_file, id="keylog", exists=True)
             # It would be nice to verify the content of certain lines in the
             # keylog file, but the content is dependent upon the particular TLS
@@ -93,10 +86,7 @@ class TlsKeyloggingTest:
 
         client_name = f"client_{TlsKeyloggingTest.client_counter}"
         TlsKeyloggingTest.client_counter += 1
-        tr.AddVerifierClientProcess(
-            client_name,
-            TlsKeyloggingTest.replay_file,
-            https_ports=[self.ts.Variables.ssl_port])
+        tr.AddVerifierClientProcess(client_name, TlsKeyloggingTest.replay_file, https_ports=[self.ts.Variables.ssl_port])
 
 
 TlsKeyloggingTest(enable_secrets_logging=False).run()

--- a/tests/gold_tests/tls/tls_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_session_reuse.test.py
@@ -29,7 +29,6 @@ ts2 = Test.MakeATSProcess("ts2", select_ports=True, enable_tls=True)
 ts3 = Test.MakeATSProcess("ts3", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
 
-
 # Add info the origin server responses
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
 response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -43,65 +42,59 @@ ts2.addSSLfile("ssl/server.key")
 ts3.addSSLfile("ssl/server.pem")
 ts3.addSSLfile("ssl/server.key")
 
-ts1.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts2.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts3.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts1.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts2.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts3.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts1.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts2.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts3.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts1.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts2.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts3.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts1.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts1.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts1.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 0,
-})
-ts2.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts2.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts2.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 2,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-})
-ts3.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts3.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts3.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.session_cache': 0,
-    'proxy.config.ssl.session_cache.size': 4096,
-    'proxy.config.ssl.session_cache.num_buckets': 256,
-    'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
-    'proxy.config.ssl.session_cache.timeout': 0,
-    'proxy.config.ssl.session_cache.auto_clear': 1,
-    'proxy.config.ssl.server.session_ticket.enable': 1,
-})
+ts1.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts1.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts1.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 4096,
+        'proxy.config.ssl.session_cache.num_buckets': 256,
+        'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
+        'proxy.config.ssl.session_cache.timeout': 0,
+        'proxy.config.ssl.session_cache.auto_clear': 1,
+        'proxy.config.ssl.server.session_ticket.enable': 0,
+    })
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts2.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts2.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.session_cache': 2,
+        'proxy.config.ssl.session_cache.size': 4096,
+        'proxy.config.ssl.session_cache.num_buckets': 256,
+        'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
+        'proxy.config.ssl.session_cache.timeout': 0,
+        'proxy.config.ssl.session_cache.auto_clear': 1,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+    })
+ts3.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts3.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts3.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.session_cache': 0,
+        'proxy.config.ssl.session_cache.size': 4096,
+        'proxy.config.ssl.session_cache.num_buckets': 256,
+        'proxy.config.ssl.session_cache.skip_cache_on_bucket_contention': 0,
+        'proxy.config.ssl.session_cache.timeout': 0,
+        'proxy.config.ssl.session_cache.auto_clear': 1,
+        'proxy.config.ssl.server.session_ticket.enable': 1,
+    })
 
 
 def check_session(ev, test):

--- a/tests/gold_tests/tls/tls_ticket.test.py
+++ b/tests/gold_tests/tls/tls_ticket.test.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import re
+
 Test.Summary = '''
 Test tls tickets
 '''
@@ -25,7 +26,6 @@ Test tls tickets
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 ts2 = Test.MakeATSProcess("ts2", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
-
 
 # Add info the origin server responses
 request_header = {"headers": "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -38,35 +38,28 @@ ts.addSSLfile("ssl/server.key")
 ts2.addSSLfile("ssl/server.pem")
 ts2.addSSLfile("ssl/server.key")
 
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
-ts2.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.Port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
+ts2.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
-ts2.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts2.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.server.session_ticket.enable': '1',
-    'proxy.config.ssl.server.ticket_key.filename': '../../file.ticket'
-})
-ts2.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts2.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts2.Variables.SSLDir),
-    'proxy.config.ssl.server.session_ticket.enable': '1',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.server.ticket_key.filename': '../../file.ticket'
-})
-
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.server.session_ticket.enable': '1',
+        'proxy.config.ssl.server.ticket_key.filename': '../../file.ticket'
+    })
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts2.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts2.Variables.SSLDir),
+        'proxy.config.ssl.server.session_ticket.enable': '1',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.server.ticket_key.filename': '../../file.ticket'
+    })
 
 tr = Test.AddTestRun("Create ticket")
 tr.Setup.Copy('file.ticket')

--- a/tests/gold_tests/tls/tls_verify.test.py
+++ b/tests/gold_tests/tls/tls_verify.test.py
@@ -22,18 +22,27 @@ Test tls server certificate verification options
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
-server_foo = Test.MakeOriginServer("server_foo",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-foo.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
-server_bar = Test.MakeOriginServer("server_bar",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-bar.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)})
-server_wild = Test.MakeOriginServer("server_wild",
-                                    ssl=True,
-                                    options={"--key": "{0}/signed-wild.key".format(Test.RunDirectory),
-                                             "--cert": "{0}/signed-wild.pem".format(Test.RunDirectory)})
+server_foo = Test.MakeOriginServer(
+    "server_foo",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-foo.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)
+    })
+server_bar = Test.MakeOriginServer(
+    "server_bar",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-bar.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)
+    })
+server_wild = Test.MakeOriginServer(
+    "server_wild",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-wild.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-wild.pem".format(Test.RunDirectory)
+    })
 server = Test.MakeOriginServer("server", ssl=True)
 
 request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -59,51 +68,44 @@ ts.addSSLfile("ssl/signer.key")
 ts.addSSLfile("ssl/signed-wild.key")
 ts.addSSLfile("ssl/signed-wild.pem")
 
-ts.Disk.remap_config.AddLine(
-    'map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://foo.wild.com/ https://127.0.0.1:{0}'.format(server_wild.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://foo_bar.wild.com/ https://127.0.0.1:{0}'.format(server_wild.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://foo.wild.com/ https://127.0.0.1:{0}'.format(server_wild.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://foo_bar.wild.com/ https://127.0.0.1:{0}'.format(server_wild.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    # set global policy
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-    'proxy.config.ssl.client.verify.server.properties': 'SIGNATURE',
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        # set global policy
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+        'proxy.config.ssl.client.verify.server.properties': 'SIGNATURE',
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.url_remap.pristine_host_hdr': 1
+    })
 
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: bar.com',
-    '  verify_server_policy: ENFORCED',
-    '  verify_server_properties: ALL',
-    '- fqdn: "*.wild.com"',
-    '  verify_server_policy: ENFORCED',
-    '  verify_server_properties: ALL',
-    '- fqdn: bad_bar.com',
-    '  verify_server_policy: ENFORCED',
-    '  verify_server_properties: ALL',
-])
+ts.Disk.sni_yaml.AddLines(
+    [
+        'sni:',
+        '- fqdn: bar.com',
+        '  verify_server_policy: ENFORCED',
+        '  verify_server_properties: ALL',
+        '- fqdn: "*.wild.com"',
+        '  verify_server_policy: ENFORCED',
+        '  verify_server_properties: ALL',
+        '- fqdn: bad_bar.com',
+        '  verify_server_policy: ENFORCED',
+        '  verify_server_properties: ALL',
+    ])
 
 tr = Test.AddTestRun("Permissive-Test")
 tr.Setup.Copy("ssl/signed-foo.key")

--- a/tests/gold_tests/tls/tls_verify.test.py
+++ b/tests/gold_tests/tls/tls_verify.test.py
@@ -102,7 +102,7 @@ ts.Disk.sni_yaml.AddLines([
     '  verify_server_properties: ALL',
     '- fqdn: bad_bar.com',
     '  verify_server_policy: ENFORCED',
-    '  verify_server_properties: ALL'
+    '  verify_server_properties: ALL',
 ])
 
 tr = Test.AddTestRun("Permissive-Test")

--- a/tests/gold_tests/tls/tls_verify2.test.py
+++ b/tests/gold_tests/tls/tls_verify2.test.py
@@ -22,14 +22,20 @@ Test tls server certificate verification options
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
-server_foo = Test.MakeOriginServer("server_foo",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-foo.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
-server_bar = Test.MakeOriginServer("server_bar",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-bar.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)})
+server_foo = Test.MakeOriginServer(
+    "server_foo",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-foo.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)
+    })
+server_bar = Test.MakeOriginServer(
+    "server_bar",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-bar.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)
+    })
 server = Test.MakeOriginServer("server", ssl=True)
 
 request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -52,53 +58,38 @@ ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 ts.addSSLfile("ssl/signer.key")
 
-ts.Disk.remap_config.AddLine(
-    'map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    # set global policy
-    'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
-    'proxy.config.ssl.client.verify.server.properties': 'ALL',
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        # set global policy
+        'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
+        'proxy.config.ssl.client.verify.server.properties': 'ALL',
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.url_remap.pristine_host_hdr': 1
+    })
 
-ts.Disk.sni_yaml.AddLine(
-    'sni:')
-ts.Disk.sni_yaml.AddLine(
-    '- fqdn: bar.com')
-ts.Disk.sni_yaml.AddLine(
-    '  verify_server_policy: PERMISSIVE')
-ts.Disk.sni_yaml.AddLine(
-    '  verify_server_properties: SIGNATURE')
-ts.Disk.sni_yaml.AddLine(
-    '- fqdn: bad_bar.com')
-ts.Disk.sni_yaml.AddLine(
-    '  verify_server_policy: PERMISSIVE')
-ts.Disk.sni_yaml.AddLine(
-    '  verify_server_properties: SIGNATURE')
-ts.Disk.sni_yaml.AddLine(
-    '- fqdn: random.com')
-ts.Disk.sni_yaml.AddLine(
-    '  verify_server_policy: DISABLED')
+ts.Disk.sni_yaml.AddLine('sni:')
+ts.Disk.sni_yaml.AddLine('- fqdn: bar.com')
+ts.Disk.sni_yaml.AddLine('  verify_server_policy: PERMISSIVE')
+ts.Disk.sni_yaml.AddLine('  verify_server_properties: SIGNATURE')
+ts.Disk.sni_yaml.AddLine('- fqdn: bad_bar.com')
+ts.Disk.sni_yaml.AddLine('  verify_server_policy: PERMISSIVE')
+ts.Disk.sni_yaml.AddLine('  verify_server_properties: SIGNATURE')
+ts.Disk.sni_yaml.AddLine('- fqdn: random.com')
+ts.Disk.sni_yaml.AddLine('  verify_server_policy: DISABLED')
 
 tr = Test.AddTestRun("default-enforce")
 tr.Setup.Copy("ssl/signed-foo.key")
@@ -149,7 +140,6 @@ tr6.ReturnCode = 0
 tr6.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr6.StillRunningAfter = server
 tr6.StillRunningAfter = ts
-
 
 # No name checking for the sig-only permissive override for bad_bar
 ts.Disk.diags_log.Content += Testers.ExcludesExpression(

--- a/tests/gold_tests/tls/tls_verify4.test.py
+++ b/tests/gold_tests/tls/tls_verify4.test.py
@@ -23,14 +23,20 @@ Specifically update via traffic_ctl (reloadable)
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", command="traffic_manager", enable_tls=True)
-server_foo = Test.MakeOriginServer("server_foo",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-foo.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
-server_bar = Test.MakeOriginServer("server_bar",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-bar.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)})
+server_foo = Test.MakeOriginServer(
+    "server_foo",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-foo.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)
+    })
+server_bar = Test.MakeOriginServer(
+    "server_bar",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-bar.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)
+    })
 server = Test.MakeOriginServer("server", ssl=True)
 
 request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -53,37 +59,32 @@ ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 ts.addSSLfile("ssl/signer.key")
 
-ts.Disk.remap_config.AddLine(
-    'map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
-    # set global policy
-    'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
-    'proxy.config.ssl.client.verify.server.properties': 'ALL',
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'ssl'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+        # set global policy
+        'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
+        'proxy.config.ssl.client.verify.server.properties': 'ALL',
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'ssl'
+    })
 
 tr = Test.AddTestRun("default-enforce-bad-sig")
 tr.Setup.Copy("ssl/signed-foo.key")
@@ -104,20 +105,22 @@ tr2 = Test.AddTestRun("Update config files")
 recordspath = ts.Disk.records_config.AbsPath
 # recreate the records.config with the cert filename changed
 tr2.Disk.File(recordspath, id="records_config", typename="ats:config:records"),
-tr2.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
-    # set global policy
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-    'proxy.config.ssl.client.verify.server.properties': 'ALL',
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'ssl'
-})
+tr2.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+        # set global policy
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+        'proxy.config.ssl.client.verify.server.properties': 'ALL',
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'ssl'
+    })
 tr2.StillRunningAfter = ts
 tr2.StillRunningAfter = server
 tr2.Processes.Default.Command = 'echo Updated configs'
@@ -146,20 +149,22 @@ tr2 = Test.AddTestRun("Update config files to enforced")
 recordspath = ts.Disk.records_config.AbsPath
 # recreate the records.config with the cert filename changed
 tr2.Disk.File(recordspath, id="records_config", typename="ats:config:records"),
-tr2.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.cipher_suite': 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
-    # set global policy
-    'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
-    'proxy.config.ssl.client.verify.server.properties': 'ALL',
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.diags.debug.enabled': 0,
-    'proxy.config.diags.debug.tags': 'ssl'
-})
+tr2.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.cipher_suite':
+            'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:RC4-SHA:RC4-MD5:AES128-SHA:AES256-SHA:DES-CBC3-SHA!SRP:!DSS:!PSK:!aNULL:!eNULL:!SSLv2',
+        # set global policy
+        'proxy.config.ssl.client.verify.server.policy': 'ENFORCED',
+        'proxy.config.ssl.client.verify.server.properties': 'ALL',
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'ssl'
+    })
 tr2.StillRunningAfter = ts
 tr2.StillRunningAfter = server
 tr2.Processes.Default.Command = 'echo Updated configs to ENFORCED'

--- a/tests/gold_tests/tls/tls_verify_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_base.test.py
@@ -86,7 +86,7 @@ ts.Disk.sni_yaml.AddLines([
     '  verify_server_properties: ALL',
     '- fqdn: bad_bar.com',
     '  verify_server_policy: ENFORCED',
-    '  verify_server_properties: ALL'
+    '  verify_server_properties: ALL',
 ])
 
 tr = Test.AddTestRun("Permissive-Test")

--- a/tests/gold_tests/tls/tls_verify_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_base.test.py
@@ -22,14 +22,20 @@ Test tls server certificate verification options
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
-server_foo = Test.MakeOriginServer("server_foo",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-foo.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
-server_bar = Test.MakeOriginServer("server_bar",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-bar.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)})
+server_foo = Test.MakeOriginServer(
+    "server_foo",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-foo.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)
+    })
+server_bar = Test.MakeOriginServer(
+    "server_bar",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-bar.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)
+    })
 server = Test.MakeOriginServer("server", ssl=True)
 
 request_foo_header = {"headers": "GET / HTTP/1.1\r\nHost: foo.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
@@ -52,42 +58,37 @@ ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 ts.addSSLfile("ssl/signer.key")
 
-ts.Disk.remap_config.AddLine(
-    'map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map / https://127.0.0.1:{0}'.format(server.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_foo.com/ https://127.0.0.1:{0}'.format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map https://bad_bar.com/ https://127.0.0.1:{0}'.format(server_bar.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.client.sni_policy': 'host'
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.client.sni_policy': 'host'
+    })
 
-ts.Disk.sni_yaml.AddLines([
-    'sni:',
-    '- fqdn: bar.com',
-    '  verify_server_policy: ENFORCED',
-    '  verify_server_properties: ALL',
-    '- fqdn: bad_bar.com',
-    '  verify_server_policy: ENFORCED',
-    '  verify_server_properties: ALL',
-])
+ts.Disk.sni_yaml.AddLines(
+    [
+        'sni:',
+        '- fqdn: bar.com',
+        '  verify_server_policy: ENFORCED',
+        '  verify_server_properties: ALL',
+        '- fqdn: bad_bar.com',
+        '  verify_server_policy: ENFORCED',
+        '  verify_server_properties: ALL',
+    ])
 
 tr = Test.AddTestRun("Permissive-Test")
 tr.Setup.Copy("ssl/signed-foo.key")
@@ -110,7 +111,6 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
-
 
 tr2 = Test.AddTestRun("Override-enforcing-Test")
 tr2.Processes.Default.Command = "curl -v -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port)

--- a/tests/gold_tests/tls/tls_verify_override.test.py
+++ b/tests/gold_tests/tls/tls_verify_override.test.py
@@ -22,14 +22,20 @@ Test tls server certificate verification options. Exercise conf_remap
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", select_ports=True)
-server_foo = Test.MakeOriginServer("server_foo",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-foo.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)})
-server_bar = Test.MakeOriginServer("server_bar",
-                                   ssl=True,
-                                   options={"--key": "{0}/signed-bar.key".format(Test.RunDirectory),
-                                            "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)})
+server_foo = Test.MakeOriginServer(
+    "server_foo",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-foo.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-foo.pem".format(Test.RunDirectory)
+    })
+server_bar = Test.MakeOriginServer(
+    "server_bar",
+    ssl=True,
+    options={
+        "--key": "{0}/signed-bar.key".format(Test.RunDirectory),
+        "--cert": "{0}/signed-bar.pem".format(Test.RunDirectory)
+    })
 server = Test.MakeOriginServer("server", ssl=True)
 
 dns = Test.MakeDNServer("dns")
@@ -54,73 +60,68 @@ ts.addSSLfile("ssl/server.key")
 ts.addSSLfile("ssl/signer.pem")
 ts.addSSLfile("ssl/signer.key")
 
+ts.Disk.remap_config.AddLine('map http://foo.com/basictobar https://bar.com:{0}'.format(server_bar.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map http://foo.com/basic https://foo.com:{0}'.format(server_foo.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://foo.com/basictobar https://bar.com:{0}'.format(server_bar.Variables.SSL_Port))
+    'map http://foo.com/override https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'
+    .format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map http://bar.com/basic https://bar.com:{0}'.format(server_foo.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://foo.com/basic https://foo.com:{0}'.format(server_foo.Variables.SSL_Port))
+    'map http://bar.com/overridedisabled https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=DISABLED'
+    .format(server_foo.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://foo.com/override https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'.format(
-        server_foo.Variables.SSL_Port))
+    'map http://bad_bar.com/overridedisabled https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=DISABLED'
+    .format(server_foo.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://bar.com/basic https://bar.com:{0}'.format(server_foo.Variables.SSL_Port))
+    'map http://bar.com/overridesignature https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=SIGNATURE @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'
+    .format(server_foo.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://bar.com/overridedisabled https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=DISABLED'.format(
-        server_foo.Variables.SSL_Port))
+    'map http://bar.com/overridenone https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NONE @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'
+    .format(server_foo.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://bad_bar.com/overridedisabled https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=DISABLED'.format(
-        server_foo.Variables.SSL_Port))
+    'map http://bar.com/overrideenforced https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'
+    .format(server_foo.Variables.SSL_Port))
+ts.Disk.remap_config.AddLine('map /basic https://random.com:{0}'.format(server.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://bar.com/overridesignature https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=SIGNATURE @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'.format(
-        server_foo.Variables.SSL_Port))
+    'map /overrideenforce https://127.0.0.1:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'
+    .format(server.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://bar.com/overridenone https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NONE @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'.format(
-        server_foo.Variables.SSL_Port))
+    'map /overridename  https://127.0.0.1:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME'
+    .format(server.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map http://bar.com/overrideenforced https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'.format(
-        server_foo.Variables.SSL_Port))
+    'map /snipolicyfooremap  https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=remap'
+    .format(server_bar.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map /basic https://random.com:{0}'.format(server.Variables.SSL_Port))
+    'map /snipolicyfoohost  https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=host'
+    .format(server_bar.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map /overrideenforce https://127.0.0.1:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED'.format(
-        server.Variables.SSL_Port))
+    'map /snipolicybarremap  https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=remap'
+    .format(server_bar.Variables.SSL_Port))
 ts.Disk.remap_config.AddLine(
-    'map /overridename  https://127.0.0.1:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME'.format(
-        server.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map /snipolicyfooremap  https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=remap'.format(
-        server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map /snipolicyfoohost  https://foo.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=host'.format(
-        server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map /snipolicybarremap  https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=remap'.format(
-        server_bar.Variables.SSL_Port))
-ts.Disk.remap_config.AddLine(
-    'map /snipolicybarhost  https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=host'.format(
-        server_bar.Variables.SSL_Port))
+    'map /snipolicybarhost  https://bar.com:{0} @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.properties=NAME @plugin=conf_remap.so @pparam=proxy.config.ssl.client.verify.server.policy=ENFORCED @plugin=conf_remap.so @pparam=proxy.config.ssl.client.sni_policy=host'
+    .format(server_bar.Variables.SSL_Port))
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 # Case 1, global config policy=permissive properties=signature
 #         override for foo.com policy=enforced properties=all
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    # set global policy
-    'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-    'proxy.config.ssl.client.verify.server.properties': 'ALL',
-    'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
-    'proxy.config.url_remap.pristine_host_hdr': 1,
-    'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
-    'proxy.config.dns.resolv_conf': 'NULL',
-    'proxy.config.exec_thread.autoconfig.scale': 1.0,
-    'proxy.config.ssl.client.sni_policy': 'remap',
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        # set global policy
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+        'proxy.config.ssl.client.verify.server.properties': 'ALL',
+        'proxy.config.ssl.client.CA.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.CA.cert.filename': 'signer.pem',
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(dns.Variables.Port),
+        'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.exec_thread.autoconfig.scale': 1.0,
+        'proxy.config.ssl.client.sni_policy': 'remap',
+    })
 
 dns.addRecords(records={"foo.com.": ["127.0.0.1"]})
 dns.addRecords(records={"bar.com.": ["127.0.0.1"]})

--- a/tests/gold_tests/tls_hooks/tls_hooks.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks.test.py
@@ -33,21 +33,19 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({
-    'proxy.config.diags.debug.enabled': 1,
-    'proxy.config.diags.debug.tags': 'ssl_hook_test',
-    'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-    'proxy.config.ssl.TLSv1_3': 0,
-})
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.TLSv1_3': 0,
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-preaccept=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks10.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks10.test.py
@@ -32,19 +32,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-cert=1 -i=2')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks11.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks11.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-d=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks12.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks12.test.py
@@ -32,19 +32,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-p=2 -d=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks13.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks13.test.py
@@ -32,19 +32,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} https://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port)
-)
+    'map https://example.com:{0} https://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-out_start=1 -out_close=2')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks14.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks14.test.py
@@ -32,20 +32,19 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} https://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port)
-)
+    'map https://example.com:{0} https://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-out_start_delay=2')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks15.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks15.test.py
@@ -32,19 +32,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} https://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port)
-)
+    'map https://example.com:{0} https://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.SSL_Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-close=2 -out_close=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks16.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks16.test.py
@@ -24,9 +24,7 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.HasOpenSSLVersion("1.1.1")
-)
+Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
@@ -37,19 +35,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
-)
+    'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello_imm=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -24,9 +24,7 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.HasOpenSSLVersion("1.1.1"),
-)
+Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"),)
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
@@ -37,19 +35,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
-)
+    'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello=1 -close=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -24,9 +24,7 @@ Test.Summary = '''
 Test different combinations of TLS handshake hooks to ensure they are applied consistently.
 '''
 
-Test.SkipUnless(
-    Condition.HasOpenSSLVersion("1.1.1"),
-)
+Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"),)
 
 ts = Test.MakeATSProcess("ts", select_ports=True, enable_tls=True)
 server = Test.MakeOriginServer("server")
@@ -37,19 +35,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port)
-)
+    'map https://example.com:{1} http://127.0.0.1:{0}'.format(server.Variables.Port, ts.Variables.ssl_port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-client_hello=2 -close=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks2.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks2.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-sni=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks3.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks3.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-cert=1')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks4.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks4.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-cert=1 -sni=1 -preaccept=1')
 
@@ -65,10 +64,12 @@ certstring = "Cert callback 0"
 ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(snistring), "SNI message appears only once", reflags=re.S | re.M)
 # the preaccept may get triggered twice because the test framework creates a TCP connection before handing off to traffic_server
-ts.Disk.traffic_out.Content += Testers.ContainsExpression(r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(
-    preacceptstring), "Pre accept message appears only once or twice", reflags=re.S | re.M)
-ts.Disk.traffic_out.Content += Testers.ContainsExpression(r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring),
-                                                          "Cert message appears only once", reflags=re.S | re.M)
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+    r"\A(?:(?!{0}).)*{0}.*({0})?(?!.*{0}).*\Z".format(preacceptstring),
+    "Pre accept message appears only once or twice",
+    reflags=re.S | re.M)
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+    r"\A(?:(?!{0}).)*{0}(?!.*{0}).*\Z".format(certstring), "Cert message appears only once", reflags=re.S | re.M)
 
 tr.Processes.Default.TimeOut = 15
 tr.TimeOut = 15

--- a/tests/gold_tests/tls_hooks/tls_hooks6.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks6.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-preaccept=2')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks7.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks7.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-sni=2')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks8.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks8.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-cert=2')
 

--- a/tests/gold_tests/tls_hooks/tls_hooks9.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks9.test.py
@@ -33,19 +33,18 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.records_config.update({'proxy.config.diags.debug.enabled': 1,
-                               'proxy.config.diags.debug.tags': 'ssl_hook_test',
-                               'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
-                               'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
-                               })
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'ssl_hook_test',
+        'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
+        'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
+    })
 
-ts.Disk.ssl_multicert_config.AddLine(
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
-)
+ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
 ts.Disk.remap_config.AddLine(
-    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port)
-)
+    'map https://example.com:{0} http://127.0.0.1:{1}'.format(ts.Variables.ssl_port, server.Variables.Port))
 
 Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, 'ssl_hook_test.so'), ts, '-i=1')
 

--- a/tests/gold_tests/url/uri.test.py
+++ b/tests/gold_tests/url/uri.test.py
@@ -28,14 +28,8 @@ ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'http|cache|url',
 })
-ts.Disk.remap_config.AddLine(
-    'map / http://127.0.0.1:{0}'.format(server.Variables.http_port)
-)
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
 tr = Test.AddTestRun("Verify correct URI parsing behavior.")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
-tr.AddVerifierClientProcess(
-    "client",
-    replay_file,
-    http_ports=[ts.Variables.port],
-    other_args='--thread-limit 1')
+tr.AddVerifierClientProcess("client", replay_file, http_ports=[ts.Variables.port], other_args='--thread-limit 1')

--- a/tests/tools/tcp_client.py
+++ b/tests/tools/tcp_client.py
@@ -53,13 +53,12 @@ to further writes. This is useful to simulate the sending of partial data.
 
 
 def main(argv):
-    parser = argparse.ArgumentParser(description=DESCRIPTION,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('host', help='the target host')
     parser.add_argument('port', type=int, help='the target port')
     parser.add_argument('file', help='the file with content to be sent')
-    parser.add_argument('--delay-after-send', metavar='SECONDS', type=int,
-                        help='after send, delay in seconds before half-close', default=0)
+    parser.add_argument(
+        '--delay-after-send', metavar='SECONDS', type=int, help='after send, delay in seconds before half-close', default=0)
     args = parser.parse_args()
 
     data = ''

--- a/tools/git/pre-commit
+++ b/tools/git/pre-commit
@@ -42,10 +42,10 @@ if [ ! -x "$FORMAT" ]; then
     exit 1
 fi
 
-source "$GIT_TOP/tools/autopep8.sh"
-if [ ! -d ${AUTOPEP8_VENV} ]
+source "$GIT_TOP/tools/yapf.sh"
+if [ ! -d ${YAPF_VENV} ]
 then
-    echo "Run \"make autopep8\""
+    echo "Run \"make yaf\""
     exit 1
 fi
 source ${AUTOPEP8_VENV}/bin/activate
@@ -53,26 +53,27 @@ source ${AUTOPEP8_VENV}/bin/activate
 
 # Where to store the patch
 clang_patch_file=$(mktemp -t clang-format.XXXXXXXXXX)
-autopep8_patch_file=$(mktemp -t autopep8.XXXXXXXXXX)
-trap "rm -f $clang_patch_file $autopep8_patch_file" 0 1 2 3 5 15
+yapf_patch_file=$(mktemp -t yapf.XXXXXXXXXX)
+trap "rm -f $clang_patch_file $yapf_patch_file" 0 1 2 3 5 15
 
 # Loop over all files that are changed, and produce a diff file
+source ${YAPF_VENV}/bin/activate
+REPO_ROOT=$(cd $(dirname $0) && git rev-parse --show-toplevel)
+YAPF_CONFIG=${REPO_ROOT}/.style.yapf
 git diff-index --cached --diff-filter=ACMR --name-only HEAD | grep -vE "lib/yamlcpp" | while read file; do
     case "$file" in
 	*.cc | *.c | *.h | *.h.in)
 	    ${FORMAT} "$file" | diff -u "$file" - >> "$clang_patch_file"
 	    ;;
         # Keep this list of Python extensions the same with the list of
-        # extensions searched for in the toosl/autopep8.sh script.
+        # extensions searched for in the toosl/yapf.sh script.
         *.py | *.cli.ext | *.test.ext)
-            autopep8 \
-                --ignore-local-config \
-                --exclude ${GIT_TOP}/lib/yamlcpp \
-                --max-line-length 132 \
-                --aggressive \
-                --aggressive \
+            yapf \
+                --style ${YAPF_CONFIG} \
+                --parallel \
                 --diff \
-                "$file" >> "$autopep8_patch_file"
+                "$file" >>"$yapf_patch_file"
+            ;;
     esac
 done
 
@@ -87,19 +88,18 @@ else
     echo
 fi
 
-
-if [ -s "$autopep8_patch_file" ] ; then
-    echo "The commit is not accepted because autopep8 reports issues with it."
+if [ -s "$yapf_patch_file" ]; then
+    echo "The commit is not accepted because yapf reports issues with it."
     echo "The easiest way to fix this is to run:"
     echo
-    echo "    $ make autopep8"
+    echo "    $ make yapf"
     exit 1
 else
-    echo "This commit complies with the current autopep8 formatting rules."
+    echo "This commit complies with the current yapf formatting rules."
     echo
 fi
 
 # Cleanup before exit
 deactivate
-rm -f "$clang_patch_file" "$autopep8_patch_file"
+rm -f "$clang_patch_file" "$yapf_patch_file"
 exit 0

--- a/tools/yapf.sh
+++ b/tools/yapf.sh
@@ -1,0 +1,109 @@
+#! /usr/bin/env bash
+#
+#  Simple wrapper to run yapf on a directory.
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Update these VERSION variables with the new desired yapf tag when a new
+# yapf version is desired.
+# See:
+# https://github.com/google/yapf/tags
+YAPF_VERSION="v0.32.0"
+VERSION="yapf 0.32.0"
+
+function main() {
+  # check for python3
+  python3 - << _END_
+import sys
+
+if sys.version_info.major < 3 or sys.version_info.minor < 8:
+    exit(1)
+_END_
+
+  if [ $? = 1 ]; then
+      echo "Python 3.8 or newer is not installed/enabled."
+      exit 1
+  fi
+
+  set -e # exit on error
+
+  if ! type virtualenv >/dev/null 2>/dev/null
+  then
+    pip install -q virtualenv
+  fi
+
+  REPO_ROOT=$(cd $(dirname $0) && git rev-parse --show-toplevel)
+  YAPF_VENV=${YAPF_VENV:-${REPO_ROOT}/.git/fmt/yapf_${YAPF_VERSION}_venv}
+  if [ ! -e ${YAPF_VENV} ]
+  then
+    python3 -m virtualenv ${YAPF_VENV}
+  fi
+  source ${YAPF_VENV}/bin/activate
+
+  pip install -q --upgrade pip
+  pip install -q "yapf==${YAPF_VERSION}"
+
+  ver=$(yapf --version 2>&1)
+  if [ "$ver" != "$VERSION" ]
+  then
+      echo "Wrong version of yapf!"
+      echo "Expected: \"${VERSION}\", got: \"${ver}\""
+      exit 1
+  fi
+
+  DIR=${@:-.}
+
+  # Only run yapf on tracked files. This saves time and possibly avoids
+  # formatting files the user doesn't want formatted.
+  tmp_dir=$(mktemp -d -t tracked-git-files.XXXXXXXXXX)
+  files=${tmp_dir}/git_files.txt
+  files_filtered=${tmp_dir}/git_files_filtered.txt
+  git ls-tree -r HEAD --name-only ${DIR} | grep -vE "lib/yamlcpp" > ${files}
+  # Add to the above any newly added staged files.
+  git diff --cached --name-only --diff-filter=A >> ${files}
+  # Keep this list of Python extensions the same with the list of
+  # extensions searched for in the tools/git/pre-commit hook.
+  grep -E '\.py$|\.cli.ext$|\.test.ext$' ${files} > ${files_filtered}
+  # Prepend the filenames with "./" to make the modified file output consistent
+  # with the clang-format target output.
+  sed -i'.bak' 's:^:\./:' ${files_filtered}
+  rm -f ${files_filtered}.bak
+
+  # Efficiently retrieving modification timestamps in a platform
+  # independent way is challenging. We use find's -newer argument, which
+  # seems to be broadly supported. The following file is created and has a
+  # timestamp just before running yapf. Any file with a timestamp
+  # after this we assume was modified by yapf.
+  start_time_file=${tmp_dir}/format_start.$$
+  touch ${start_time_file}
+  YAPF_CONFIG=${REPO_ROOT}/.style.yapf
+  yapf \
+      --style ${YAPF_CONFIG} \
+      --parallel \
+      --in-place \
+      $(cat ${files_filtered})
+  find $(cat ${files_filtered}) -newer ${start_time_file}
+
+  rm -rf ${tmp_dir}
+  deactivate
+}
+
+if [[ "$(basename -- "$0")" == 'yapf.sh' ]]; then
+  main "$@"
+else
+  YAPF_VENV=${YAPF_VENV:-$(git rev-parse --show-toplevel)/.git/fmt/yapf_${YAPF_VERSION}_venv}
+fi


### PR DESCRIPTION
This applies https://github.com/apache/trafficserver/pull/10860 to 9.2.x. It will help with cherry-picks if we keep the formatting consistent.

---

autopep8 does not support Python 3.12, which is a requirement for moving
to fedora:39. The following ticket has been open without comment from
the development community for 6 weeks:

https://github.com/hhatto/autopep8/issues/712

Transitioning to yapf is easy, and the community behind it seems
stronger. I think moving forward it is a better Python formatter for us.