### PR TITLE
fix race condition with session thread migration

### DIFF
--- a/src/iocore/net/EventIO.cc
+++ b/src/iocore/net/EventIO.cc
@@ -64,7 +64,10 @@ EventIO::modify(int e)
     return 0;
   }
 
-  ink_assert(event_loop);
+  if (nullptr == event_loop) {
+    return 1;
+  }
+
 #if TS_USE_EPOLL && !defined(USE_EDGE_TRIGGER)
   struct epoll_event ev;
   memset(&ev, 0, sizeof(ev));
@@ -117,7 +120,10 @@ EventIO::refresh(int e)
     return 0;
   }
 
-  ink_assert(event_loop);
+  if (nullptr == event_loop) {
+    return 1;
+  }
+
 #if TS_USE_KQUEUE && defined(USE_EDGE_TRIGGER)
   e = e & events;
   struct kevent ev[2];

--- a/src/iocore/net/EventIO.cc
+++ b/src/iocore/net/EventIO.cc
@@ -64,6 +64,7 @@ EventIO::modify(int e)
     return 0;
   }
 
+  // Session migration may result in this condition.
   if (nullptr == event_loop) {
     return 1;
   }
@@ -120,6 +121,7 @@ EventIO::refresh(int e)
     return 0;
   }
 
+  // Session migration may result in this condition.
   if (nullptr == event_loop) {
     return 1;
   }

--- a/src/iocore/net/UnixNetVConnection.cc
+++ b/src/iocore/net/UnixNetVConnection.cc
@@ -1373,12 +1373,6 @@ UnixNetVConnection::migrateToCurrentThread(Continuation *cont, EThread *t)
 
   void *arg = this->_prepareForMigration();
 
-  // Do_io_close will signal the VC to be freed on the original thread
-  // Since we moved the con context, the fd will not be closed
-  // Go ahead and remove the fd from the original thread's epoll structure, so it is not
-  // processed on two threads simultaneously
-  this->ep.stop();
-
   // Create new VC:
   UnixNetVConnection *newvc = static_cast<UnixNetVConnection *>(this->_getNetProcessor()->allocate_vc(t));
   ink_assert(newvc != nullptr);


### PR DESCRIPTION
This is a fix for a race condition (found and debugged in ats92) when a session is taken from the session pool and migrated to another thread.  This is with GLOBAL session pools.  There are still rare cases where events are still leaking through to the VC in the pre-migrated thread causing various different asserts.

This PR moves thread migration out of the session manager acquire critical section and locks and stops events on the original thread netvc during migration.  Global (and likely hybrid) pool performance is improved in this case.

Initial testing using test case verifies that ats master crashes (quickly and a lot) without the patch and runs fine the patch.

Will test in prod for stability.

should close #9690 

Also related to: https://github.com/apache/trafficserver/issues/9689