### PR TITLE
Fix for building on Rocky Linux 8

### DIFF
--- a/src/iocore/cache/Store.cc
+++ b/src/iocore/cache/Store.cc
@@ -30,7 +30,7 @@
 #include "tscore/SimpleTokenizer.h"
 #include "tscore/runroot.h"
 
-#if __has_include(<linux/major.h>)
+#if defined(__linux__)
 #include <linux/major.h>
 #endif
 


### PR DESCRIPTION
__has_include isn't working switchiing to check if __linux__ is defined

This is breaking the Coverity builds and is needed for the ATS 10 Hackathon