### PR TITLE
Coverity 1523647: No virtual destructor

### DIFF
--- a/include/proxy/http/HttpBodyFactory.h
+++ b/include/proxy/http/HttpBodyFactory.h
@@ -110,9 +110,14 @@ public:
 //
 ////////////////////////////////////////////////////////////////////////
 
-struct HttpBodySetRawData {
+class HttpBodySetRawData
+{
+public:
   using TemplateTable = std::unordered_map<std::string, HttpBodyTemplate *>;
-  unsigned int magic  = 0;
+
+  virtual ~HttpBodySetRawData() {}
+
+  unsigned int magic = 0;
   char *set_name;
   char *content_language;
   char *content_charset;


### PR DESCRIPTION
`HttpBodySet` inherits `HttpBodySetRawData` and we have `HttpBodySet` has a destructor but `HttpBodySetRawData` doesn't have a virtual destructor.