### PR TITLE
Adjust ReturnCode for MakeATSProcess on ubuntu22

### DIFF
--- a/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch/strategies_ch.test.py
@@ -59,6 +59,7 @@ for i in range(num_nh):
             'proxy.config.dns.resolv_conf': "NULL",
         })
     ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
+    ts.ReturnCode = Any(0, -2)
     ts_nh.append(ts)
 
 ts = Test.MakeATSProcess("ts")

--- a/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
+++ b/tests/gold_tests/next_hop/strategies_ch2/strategies_ch2.test.py
@@ -62,6 +62,7 @@ for i in range(num_nh):
     ts_nh.append(ts)
 
 ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
+ts.ReturnCode = Any(0, -2)
 
 ts.Disk.records_config.update(
     {

--- a/tests/gold_tests/next_hop/strategies_stale/strategies_stale.test.py
+++ b/tests/gold_tests/next_hop/strategies_stale/strategies_stale.test.py
@@ -55,6 +55,7 @@ ts_nh.Disk.records_config.update(
         'proxy.config.dns.resolv_conf': "NULL",
     })
 ts_nh.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
+ts_nh.ReturnCode = Any(0, -2)
 
 ts = Test.MakeATSProcess("ts")
 

--- a/tests/gold_tests/next_hop/zzz_strategies_peer/zzz_strategies_peer.test.py
+++ b/tests/gold_tests/next_hop/zzz_strategies_peer/zzz_strategies_peer.test.py
@@ -71,6 +71,7 @@ num_peer = 8
 ts_peer = []
 for i in range(num_peer):
     ts = Test.MakeATSProcess(f"ts_peer{i}", use_traffic_out=False, command=f"traffic_server 2> trace_peer{i}.log")
+    ts.ReturnCode = Any(0, -2)
     ts_peer.append(ts)
 for i in range(num_peer):
     ts = ts_peer[i]

--- a/tests/gold_tests/next_hop/zzz_strategies_peer2/zzz_strategies_peer2.test.py
+++ b/tests/gold_tests/next_hop/zzz_strategies_peer2/zzz_strategies_peer2.test.py
@@ -71,6 +71,7 @@ num_peer = 8
 ts_peer = []
 for i in range(num_peer):
     ts = Test.MakeATSProcess(f"ts_peer{i}", use_traffic_out=False, command=f"traffic_server 2> trace_peer{i}.log")
+    ts.ReturnCode = Any(0, -2)
     ts_peer.append(ts)
 for i in range(num_peer):
     ts = ts_peer[i]

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.test.py
@@ -57,6 +57,7 @@ ts.Disk.remap_config.AddLine(
     f"map http://domain.in http://127.0.0.1:{server.Variables.Port}" + " @plugin=cachekey.so @pparam=--remove-all-params=true"
     " @plugin=prefetch.so" + " @pparam=--front=true" + " @pparam=--fetch-policy=simple" +
     r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" + " @pparam=--fetch-count=3" + " @pparam=--fetch-overflow=bignum")
+ts.ReturnCode = Any(0, -2)
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.test.py
@@ -54,6 +54,7 @@ ts.Disk.remap_config.AddLine(
     f"map http://domain.in http://127.0.0.1:{server.Variables.Port}" + " @plugin=cachekey.so @pparam=--remove-all-params=true"
     " @plugin=prefetch.so" + " @pparam=--front=true" + " @pparam=--fetch-policy=simple" +
     r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" + " @pparam=--fetch-count=3" + " @pparam=--fetch-overflow=64")
+ts.ReturnCode = Any(0, -2)
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_simple.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_simple.test.py
@@ -54,6 +54,7 @@ ts.Disk.remap_config.AddLine(
     f"map http://domain.in http://127.0.0.1:{server.Variables.Port}" + " @plugin=cachekey.so @pparam=--remove-all-params=true"
     " @plugin=prefetch.so" + " @pparam=--front=true" + " @pparam=--fetch-policy=simple" +
     r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(.*)/$1{$2+1}$3/" + " @pparam=--fetch-count=3")
+ts.ReturnCode = Any(0, -2)
 
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)


### PR DESCRIPTION
Not sure this is the correct solution, but I was testing the hypothesis that the returncode -2 only appeared when MakeATSProcess is created with an explicit command argument that redirects stderr.

With these changes the tests listed in the issue pass on my ubuntu22 system. But we may want to adjust how the python infrastructure reports the exit codes, assuming that is adjustable.

This closes #10881