### PR TITLE
Coverity 1497426: Unintentional integer overflow

### DIFF
--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -123,7 +123,7 @@ xpack_encode_integer(uint8_t *buf_start, const uint8_t *buf_end, uint64_t value,
   // Preserve the first n bits
   uint8_t prefix = *buf_start & (0xFF << n);
 
-  if (value < (static_cast<uint64_t>(1 << n) - 1)) {
+  if (value < (static_cast<uint64_t>(UINT64_C(1) << n) - 1)) {
     *(p++) = value;
   } else {
     *(p++)  = (1 << n) - 1;


### PR DESCRIPTION
> overflow_before_widen: Potentially overflowing expression 1 << n with type int (32 bits, signed) is evaluated using 32-bit arithmetic, and then used in a context that expects an expression of type uint64_t (64 bits, unsigned).
>   	To avoid overflow, cast 1 to type uint64_t.