### PR TITLE
In VIA header, cW means a fresh Read While Write cache hit

### DIFF
--- a/src/traffic_via/traffic_via.cc
+++ b/src/traffic_via/traffic_via.cc
@@ -133,6 +133,7 @@ standardViaLookup(char flag)
     viaTable->viaData[static_cast<unsigned char>('H')] = "in cache, fresh (a cache \"HIT\")";
     viaTable->viaData[static_cast<unsigned char>('S')] = "in cache, stale (a cache \"MISS\")";
     viaTable->viaData[static_cast<unsigned char>('R')] = "in cache, fresh Ram hit (a cache \"HIT\")";
+    viaTable->viaData[static_cast<unsigned char>('W')] = "in cache, fresh Read While Write (a cache \"HIT\")";
     viaTable->viaData[static_cast<unsigned char>('M')] = "miss (a cache \"MISS\")";
     viaTable->viaData[static_cast<unsigned char>(' ')] = "no cache lookup";
     break;

--- a/tools/traffic_via/traffic_via.pl
+++ b/tools/traffic_via/traffic_via.pl
@@ -54,6 +54,7 @@ my @proxy_header_array = (
             'H' => "in cache, fresh (a cache \"HIT\")",
             'S' => "in cache, stale (a cache \"MISS\")",
             'R' => "in cache, fresh Ram hit (a cache \"HIT\")",
+            'W' => "in cache, fresh Read While Write (a cache \"HIT\")",
             'M' => "miss (a cache \"MISS\")",
             ' ' => "no cache lookup",
         },


### PR DESCRIPTION
Updating `traffic_via` to be able to recognize Read While Write.

i.e. 

```
Via header is [cWs f ], Length is 6
Via Header Details:
Result of Traffic Server cache lookup for URL          :Invalid sequence   <<<<< this should not say "Invalid sequence"
Response information received from origin server       :no server connection needed
Result of document write-to-cache:                     :no cache write performed
```