### PR TITLE
Use slice req method type in Data obj

### DIFF
--- a/plugins/slice/Config.h
+++ b/plugins/slice/Config.h
@@ -45,9 +45,8 @@ struct Config {
   int m_paceerrsecs{0};   // -1 disable logging, 0 no pacing, max 60s
   int m_prefetchcount{0}; // 0 disables prefetching
   enum RefType { First, Relative };
-  RefType m_reftype{First};           // reference slice is relative to request
-  const char *m_method_type{nullptr}; // type of header request
-  bool m_head_strip_range{false};     // strip range header for head requests
+  RefType m_reftype{First};       // reference slice is relative to request
+  bool m_head_strip_range{false}; // strip range header for head requests
 
   std::string m_skip_header;
   std::string m_crr_ims_header;
@@ -69,13 +68,6 @@ struct Config {
   hasRegex() const
   {
     return None != m_regex_type;
-  }
-
-  // Check if response only expects header
-  bool
-  onlyHeader() const
-  {
-    return (m_method_type == TS_HTTP_METHOD_HEAD || m_method_type == TS_HTTP_METHOD_PURGE);
   }
 
   // If no null reg, true, otherwise check against regex

--- a/plugins/slice/Data.h
+++ b/plugins/slice/Data.h
@@ -71,6 +71,8 @@ struct Data {
 
   TSHttpStatus m_statustype{TS_HTTP_STATUS_NONE}; // 200 or 206
 
+  const char *m_method_type{nullptr}; // type of header request
+
   Range m_req_range; // converted to half open interval
 
   int64_t m_blocknum{-1};     // block number to work on, -1 bad/stop
@@ -107,6 +109,13 @@ struct Data {
     m_etag[0]         = '\0';
     m_lastmodified[0] = '\0';
     memset(&m_client_ip, 0, sizeof(m_client_ip));
+  }
+
+  // Check if response only expects header
+  bool
+  onlyHeader() const
+  {
+    return (m_method_type == TS_HTTP_METHOD_HEAD || m_method_type == TS_HTTP_METHOD_PURGE);
   }
 
   ~Data()

--- a/plugins/slice/server.cc
+++ b/plugins/slice/server.cc
@@ -109,7 +109,7 @@ handleFirstServerHeader(Data *const data, TSCont const contp)
     // Should run TSVIONSetBytes(output_io, hlen + bodybytes);
     int64_t const hlen = TSHttpHdrLengthGet(header.m_buffer, header.m_lochdr);
     int64_t const clen = contentLengthFrom(header);
-    if (TS_HTTP_STATUS_OK == header.status() && data->m_config->onlyHeader()) {
+    if (TS_HTTP_STATUS_OK == header.status() && data->onlyHeader()) {
       DEBUG_LOG("HEAD/PURGE request stripped Range header: expects 200");
       data->m_bytestosend   = hlen;
       data->m_blockexpected = 0;
@@ -218,7 +218,7 @@ handleFirstServerHeader(Data *const data, TSCont const contp)
   int const hbytes = TSHttpHdrLengthGet(header.m_buffer, header.m_lochdr);
 
   // HEAD request only sends header
-  if (data->m_config->onlyHeader()) {
+  if (data->onlyHeader()) {
     data->m_bytestosend   = hbytes;
     data->m_blockexpected = 0;
   } else {
@@ -362,7 +362,7 @@ handleNextServerHeader(Data *const data, TSCont const contp)
 
   switch (header.status()) {
   case TS_HTTP_STATUS_NOT_FOUND:
-    if (data->m_config->onlyHeader()) {
+    if (data->onlyHeader()) {
       return false;
     }
     // need to reissue reference slice
@@ -372,7 +372,7 @@ handleNextServerHeader(Data *const data, TSCont const contp)
   case TS_HTTP_STATUS_PARTIAL_CONTENT:
     break;
   default:
-    if (data->m_config->onlyHeader() && header.status() == TS_HTTP_STATUS_OK) {
+    if (data->onlyHeader() && header.status() == TS_HTTP_STATUS_OK) {
       return true;
     }
     DEBUG_LOG("Non 206/404 internal block response encountered");
@@ -638,7 +638,7 @@ handle_server_resp(TSCont contp, TSEvent event, Data *const data)
     // corner condition, good source header + 0 length aborted content
     // results in no header being read, just an EOS.
     // trying to delete the upstream will crash ATS (??)
-    if (0 == data->m_blockexpected && !data->m_config->onlyHeader()) {
+    if (0 == data->m_blockexpected && !data->onlyHeader()) {
       shutdown(contp, data); // this will crash if first block
       return;
     }
@@ -671,12 +671,12 @@ handle_server_resp(TSCont contp, TSEvent event, Data *const data)
     // continue processing blocks if more requests need to be made
     // HEAD requests only has one slice block
     if (data->m_req_range.blockIsInside(data->m_config->m_blockbytes, data->m_blocknum) &&
-        data->m_config->m_method_type != TS_HTTP_METHOD_HEAD) {
+        data->m_method_type != TS_HTTP_METHOD_HEAD) {
       // Don't immediately request the next slice if the client
       // isn't keeping up
 
-      bool start_next_block = true;
       if (data->m_dnstream.m_write.isOpen()) {
+        bool start_next_block = true;
         // check throttle condition
         TSVIO const output_vio    = data->m_dnstream.m_write.m_vio;
         int64_t const output_done = TSVIONDoneGet(output_vio);
@@ -685,12 +685,19 @@ handle_server_resp(TSCont contp, TSEvent event, Data *const data)
         int64_t const buffered    = output_sent - output_done;
 
         // for PURGE requests, clients won't request more data (no body content)
-        if (threshout < buffered && !data->m_config->onlyHeader()) {
+        if (threshout < buffered && data->m_method_type != TS_HTTP_METHOD_PURGE) {
           start_next_block = false;
           DEBUG_LOG("%p handle_server_resp: throttling %" PRId64, data, buffered);
         }
-      }
-      if (start_next_block) {
+
+        if (start_next_block) {
+          if (!request_block(contp, data)) {
+            data->m_blockstate = BlockState::Fail;
+            abort(contp, data);
+            return;
+          }
+        }
+      } else if (data->m_method_type == TS_HTTP_METHOD_PURGE) {
         if (!request_block(contp, data)) {
           data->m_blockstate = BlockState::Fail;
           abort(contp, data);

--- a/plugins/slice/slice.cc
+++ b/plugins/slice/slice.cc
@@ -50,9 +50,6 @@ read_request(TSHttpTxn txnp, Config *const config)
         return false;
       }
 
-      // set header method config to only expect header response
-      config->m_method_type = header.method();
-
       if (config->hasRegex()) {
         int urllen         = 0;
         char *const urlstr = TSHttpTxnEffectiveUrlStringGet(txnp, &urllen);
@@ -84,7 +81,8 @@ read_request(TSHttpTxn txnp, Config *const config)
       TSAssert(nullptr != config);
       Data *const data = new Data(config);
 
-      data->m_txnp = txnp;
+      data->m_method_type = header.method();
+      data->m_txnp        = txnp;
 
       // set up feedback connect
       if (AF_INET == ip->sa_family) {

--- a/plugins/slice/util.cc
+++ b/plugins/slice/util.cc
@@ -80,7 +80,7 @@ request_block(TSCont contp, Data *const data)
   HttpHeader header(data->m_req_hdrmgr.m_buffer, data->m_req_hdrmgr.m_lochdr);
 
   // if configured, remove range header from head requests
-  if (data->m_config->m_method_type == TS_HTTP_METHOD_HEAD && data->m_config->m_head_strip_range) {
+  if (data->m_method_type == TS_HTTP_METHOD_HEAD && data->m_config->m_head_strip_range) {
     header.removeKey(TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
   } else {
     // add/set sub range key and add slicer tag


### PR DESCRIPTION
Set `m_method_type` in Data instead of Config since the former is allocated per transaction and the latter is allocated for a single remap instance so the data is shared across transactions.`m_method_type` is specific to a transaction not config definition