### PR TITLE
Copy tsapicore library into /lib

### DIFF
--- a/tests/fuzzing/CMakeLists.txt
+++ b/tests/fuzzing/CMakeLists.txt
@@ -49,5 +49,6 @@ add_custom_command(
   POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:libswoc> ${CMAKE_CURRENT_BINARY_DIR}/lib/
   COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:ts::tsapi> ${CMAKE_CURRENT_BINARY_DIR}/lib/
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:ts::tsapicore> ${CMAKE_CURRENT_BINARY_DIR}/lib/
   COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:ts::tscpputil> ${CMAKE_CURRENT_BINARY_DIR}/lib/
 )


### PR DESCRIPTION
Follow-up to https://github.com/apache/trafficserver/pull/10889. Running fuzz tests throws `error while loading shared libraries: libtsapicore.so: cannot open shared object file: No such file or director`. This is because `tsapicore` is a shared library now, and it needs to be copied into the `/lib` directory of fuzz tests.

This should fix the fuzzing build (broken since yesterday, take a look at [today](https://storage.googleapis.com/oss-fuzz-coverage/trafficserver/reports/20231213/linux/src/trafficserver/tests/fuzzing/report.html) vs [yesterday](https://storage.googleapis.com/oss-fuzz-coverage/trafficserver/reports/20231212/linux/src/trafficserver/tests/fuzzing/report.html))