### PR TITLE
IP: Adjust ats_force_order_by_family parameters for less type dependency

### DIFF
--- a/include/tscore/ink_resolver.h
+++ b/include/tscore/ink_resolver.h
@@ -195,7 +195,7 @@ extern void parse_host_res_preference(const char *value,            ///< [in] Co
 /// Configure the preference order to hold only what's from the client address.
 /// @addr[in] client's address.
 /// @order[out] Order to update
-extern void ats_force_order_by_family(sockaddr const *addr, HostResPreferenceOrder order);
+extern void ats_force_order_by_family(sa_family_t family, HostResPreferenceOrder order);
 
 // Domain resolution priority for origin.
 struct HostResData {

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -3748,7 +3748,7 @@ HttpTransact::handle_response_from_server(State *s)
         // Force host resolution to have the same family as the client.
         // Because this is a transparent connection, we can't switch address
         // families - that is locked in by the client source address.
-        ats_force_order_by_family(&s->current.server->dst_addr.sa, s->my_txn_conf().host_res_data.order);
+        ats_force_order_by_family(s->current.server->dst_addr.family(), s->my_txn_conf().host_res_data.order);
         return CallOSDNSLookup(s);
       } else {
         if ((s->txn_conf->connect_attempts_rr_retries > 0) &&

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -550,12 +550,12 @@ ats_host_res_from(int family, HostResPreferenceOrder const &order)
 }
 
 void
-ats_force_order_by_family(sockaddr const *addr, HostResPreferenceOrder order)
+ats_force_order_by_family(sa_family_t family, HostResPreferenceOrder order)
 {
   HostResPreferenceOrder::size_type pos{0};
-  if (ats_is_ip6(addr)) {
+  if (AF_INET6 == family) {
     order[pos++] = HOST_RES_PREFER_IPV6;
-  } else if (ats_is_ip4(addr)) {
+  } else if (AF_INET == family) {
     order[pos++] = HOST_RES_PREFER_IPV4;
   }
   for (; pos < order.size(); pos++) {


### PR DESCRIPTION
This avoids issue with type skew for IP address support. The full `IpEndpoint` isn't needed and changing that to `sa_family_t` means the function can be used with either without causing a long chain of other changes when switch to `swoc::IPEndpoint`.