### PR TITLE
cmake: Add tsutil/Assert.h to public headers

### DIFF
--- a/src/tsutil/CMakeLists.txt
+++ b/src/tsutil/CMakeLists.txt
@@ -16,6 +16,7 @@
 #######################
 
 set(TSUTIL_PUBLIC_HEADERS
+    ${PROJECT_SOURCE_DIR}/include/tsutil/Assert.h
     ${PROJECT_SOURCE_DIR}/include/tsutil/Metrics.h
     ${PROJECT_SOURCE_DIR}/include/tsutil/SourceLocation.h
     ${PROJECT_SOURCE_DIR}/include/tsutil/DbgCtl.h


### PR DESCRIPTION
I suppose `tsutil/Assert.h` belongs to public headers since it is included from `tsutil/TsSharedMutex.h` which also belongs to public headers.