### PR TITLE
IP: Change DNS nameserver code to use libswoc.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,11 +27,11 @@ AlignConsecutiveMacros:
   AcrossComments:  false
   AlignCompound:   false
   PadOperators:    true
-AlignConsecutiveShortCaseStatements:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCaseColons: false
+#AlignConsecutiveShortCaseStatements:
+#  Enabled:         false
+#  AcrossEmptyLines: false
+#  AcrossComments:  false
+#  AlignCaseColons: false
 AlignEscapedNewlines: Left
 AlignOperands:   Align
 AlignTrailingComments:
@@ -212,7 +212,7 @@ SpacesInContainerLiterals: true
 SpacesInLineCommentPrefix:
   Minimum:         1
   Maximum:         -1
-SpacesInParens:  Never
+#SpacesInParens:  Never
 SpacesInParensOptions:
   InCStyleCasts:   false
   InConditionalStatements: false

--- a/include/iocore/dns/DNSProcessor.h
+++ b/include/iocore/dns/DNSProcessor.h
@@ -158,8 +158,8 @@ struct DNSProcessor : public Processor {
   EThread *thread     = nullptr;
   DNSHandler *handler = nullptr;
   ts_imp_res_state l_res;
-  IpEndpoint local_ipv6;
-  IpEndpoint local_ipv4;
+  swoc::IPAddr local_ipv6;
+  swoc::IPAddr local_ipv4;
 
   /** Internal implementation for all getXbyY methods.
       For host resolution queries pass @c T_A for @a type. It will be adjusted

--- a/include/tscore/ink_resolver.h
+++ b/include/tscore/ink_resolver.h
@@ -69,9 +69,9 @@
 #pragma once
 
 #include <swoc/IPEndpoint.h>
+#include <swoc/IPSrv.h>
 
 #include "tscore/ink_platform.h"
-// #include "tscore/ink_inet.h"
 
 #include <resolv.h>
 #include <arpa/nameser.h>
@@ -259,11 +259,11 @@ struct ts_imp_res_state {
 #else
   u_long options = 0; /*%< option flags - see below. */
 #endif
-  int nscount = 0;                         /*%< number of name servers */
-  swoc::IPEndpoint nsaddr_list[INK_MAXNS]; /*%< address/port of name server */
-  u_short id                  = 0;         /*%< current message id */
-  char *dnsrch[MAXDNSRCH + 1] = {0};       /*%< components of domain to search */
-  char defdname[256]          = {0};       /*%< default domain (deprecated) */
+  int nscount = 0;                    /*%< number of name servers */
+  swoc::IPSrv nsaddr_list[INK_MAXNS]; /*%< address/port of name server */
+  u_short id                  = 0;    /*%< current message id */
+  char *dnsrch[MAXDNSRCH + 1] = {0};  /*%< components of domain to search */
+  char defdname[256]          = {0};  /*%< default domain (deprecated) */
 #ifdef sun
   unsigned pfcode = 0; /*%< RES_PRF_ flags - see below. */
 #else

--- a/lib/swoc/include/swoc/Errata.h
+++ b/lib/swoc/include/swoc/Errata.h
@@ -337,26 +337,38 @@ public:
    * @param text Text of the message.
    * @return *this
    *
-   * The error code is set to the default.
    * @a text is localized to @a this and does not need to be persistent.
    * The severity is updated to @a severity if the latter is more severe.
    */
   self_type &note(Severity severity, std::string_view text);
 
+  /** Add an @c Annotation to the top with @a text and local @a severity.
+   * @param severity The local severity.
+   * @return *this
+   *
+   * The annotation uses the format @c AUTOTEXT_SEVERITY with the argument @a severity.
+   * @see AUTOTEXT_SEVERITY
+   */
+  self_type &note(Severity severity);
+
   /** Add an @c Annotation to the top based on error code @a code.
    * @param code Error code.
    * @return *this
    *
-   * The annotation text is constructed as the short, long, and numeric value of @a code.
+   * The annotation uses the format @c AUTOTEXT_CODE with the argument @a ec.
+   * @see AUTOTEXT_CODE
+   *
+   * @note @a ec is used only for formatting, the @c Errata error code is unchanged.
    */
-  self_type &note(code_type const &code);
+  self_type &note(code_type const &ec);
 
   /** Append an @c Annotation to the top based on error code @a code with @a severity.
    * @param severity Local severity.
    * @param code Error code.
    * @return *this
    *
-   * The annotation text is constructed as the short, long, and numeric value of @a code.
+   * The annotation uses the format @c AUTOTEXT_SEVERITY_CODE with the argument @a severity.
+   * @see AUTOTEXT_SEVERITY_CODE
    */
   self_type &note(code_type const &code, Severity severity);
 
@@ -1171,6 +1183,21 @@ Errata::note(std::string_view text) {
 inline Errata &
 Errata::note(Severity severity, std::string_view text) {
   return this->note_s(severity, text);
+}
+
+inline Errata &
+Errata::note(Severity severity) {
+  return this->note(severity, AUTOTEXT_SEVERITY, severity);
+}
+
+inline Errata &
+Errata::note(code_type const &code) {
+  return this->note(AUTOTEXT_CODE, code);
+}
+
+inline Errata &
+Errata::note(code_type const &ec, Severity severity) {
+  return this->note(severity, AUTOTEXT_SEVERITY_CODE, severity, ec);
 }
 
 template <typename... Args>

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -432,6 +432,27 @@ public:
    */
   bool load(std::string_view const &text);
 
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IPAddr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP6Addr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP4Addr const& addr) const;
+
   /// @return The minimum address in the range.
   IPAddr min() const;
 
@@ -445,22 +466,13 @@ public:
   self_type &clear();
 
   /// @return The IPv4 range.
-  IP4Range const &
-  ip4() const {
-    return _range._ip4;
-  }
+  IP4Range const & ip4() const;
 
   /// @return The IPv6 range.
-  IP6Range const &
-  ip6() const {
-    return _range._ip6;
-  }
+  IP6Range const & ip6() const;
 
   /// @return The range family.
-  sa_family_t
-  family() const {
-    return _family;
-  }
+  sa_family_t family() const;
 
   /** Compute the mask for @a this as a network.
    *
@@ -641,6 +653,27 @@ public:
    * @return @c true if this is @a family, @c false if not.
    */
   bool is(sa_family_t family) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IPAddr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP6Addr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP4Addr const& addr) const;
 
   /// @return Reference to the viewed IPv4 range.
   IP4Range const &ip4() const;
@@ -1933,6 +1966,17 @@ IPRange::is_ip6() const {
   return AF_INET6 == _family;
 }
 
+inline sa_family_t IPRange::family() const {
+  return _family;
+}
+inline IP4Range const& IPRange::ip4() const {
+  return _range._ip4;
+}
+
+inline IP6Range const& IPRange::ip6() const {
+  return _range._ip6;
+}
+
 inline auto
 IPRangeView::clear() -> self_type & {
   _family = AF_UNSPEC;
@@ -1957,6 +2001,26 @@ IPRangeView::is_ip6() const {
 inline bool
 IPRangeView::is(sa_family_t f) const {
   return f == _family;
+}
+
+inline bool IPRange::contains(IPAddr const & addr) const {
+  if (addr.family() != _family) {
+    return false;
+  }
+  if (this->ip4()) {
+    return _range._ip4.contains(addr.ip4());
+  } else if (this->is_ip6()) {
+    return _range._ip6.contains(addr.ip6());
+  }
+  return false;
+}
+
+inline bool IPRange::contains(IP6Addr const & addr) const {
+  return this->is_ip6() && _range._ip6.contains(addr);
+}
+
+inline bool IPRange::contains(IP4Addr const & addr) const {
+  return this->is_ip4() && _range._ip4.contains(addr);
 }
 
 inline IP4Range const &
@@ -2001,6 +2065,24 @@ IPRangeView::min() const {
 inline IPAddr
 IPRangeView::max() const {
   return AF_INET == _family ? _raw._4->max() : AF_INET6 == _family ? _raw._6->max() : IPAddr::INVALID;
+}
+
+inline bool IPRangeView::contains(IPAddr const& addr) const {
+  if (_family != addr.family()) {
+    return false;
+  }
+  return (_family == addr.family() ) &&
+         ( ( this->is_ip4() && _raw._4->contains(addr.ip4()) ) ||
+           ( this->is_ip6() && _raw._6->contains(addr.ip6()) )
+         );
+}
+
+inline bool IPRangeView::contains(IP6Addr const& addr) const {
+  return this->is_ip6() && _raw._6->contains(addr);
+}
+
+inline bool IPRangeView::contains(IP4Addr const& addr) const {
+  return this->is_ip4() && _raw._4->contains(addr);
 }
 
 // +++ IPNet +++

--- a/lib/swoc/include/swoc/TextView.h
+++ b/lib/swoc/include/swoc/TextView.h
@@ -1057,15 +1057,15 @@ uintmax_t svtou(TextView src, TextView *parsed = nullptr, int base = 0);
 template <int RADIX>
 uintmax_t
 svto_radix(TextView &src) {
-  static_assert(0 < RADIX && RADIX <= 36, "Radix must be in the range 1..36");
+  static_assert(1 <= RADIX && RADIX <= 36, "Radix must be in the range 2..36");
   static constexpr auto MAX            = std::numeric_limits<uintmax_t>::max();
   static constexpr auto OVERFLOW_LIMIT = MAX / RADIX;
   uintmax_t zret                       = 0;
-  int8_t v;
+  uintmax_t v;
   while (src.size() && (0 <= (v = swoc::svtoi_convert[uint8_t(*src)])) && v < RADIX) {
     // Tweaked for performance - need to check range after @a RADIX multiply.
     ++src; // Update view iff the character is parsed.
-    if (zret <= OVERFLOW_LIMIT && uintmax_t(v) <= MAX - (zret *= RADIX)) {
+    if (zret <= OVERFLOW_LIMIT && v <= (MAX - (zret *= RADIX)) ) {
       zret += v;
     } else {
       zret = MAX; // clamp to max - once set will always hit this case for subsequent input.

--- a/lib/swoc/include/swoc/swoc_ip_util.h
+++ b/lib/swoc/include/swoc/swoc_ip_util.h
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Network Geographics 2014
+/** @file
+   Shared utilities for IP address classes.
+ */
+
+#pragma once
+#include <netinet/in.h>
+
+#include "swoc/swoc_version.h"
+
+// These have to be global namespace, unfortunately.
+inline bool
+operator==(in6_addr const& lhs, in6_addr const& rhs) {
+  return 0 == memcmp(&lhs, &rhs, sizeof(in6_addr));
+}
+
+inline bool
+operator!=(in6_addr const& lhs, in6_addr const& rhs) {
+  return 0 != memcmp(&lhs, &rhs, sizeof(in6_addr));
+}
+
+namespace swoc { inline namespace SWOC_VERSION_NS {
+
+/// Internal IP address utilities.
+namespace ip {
+
+inline bool is_loopback_host_order(in_addr_t addr) {
+  return (addr & 0xFF000000) == 0x7F000000;
+}
+
+inline bool is_link_local_host_order(in_addr_t addr) {
+  return (addr & 0xFFFF0000) == 0xA9FE0000; // 169.254.0.0/16
+}
+
+inline bool is_multicast_host_order(in_addr_t addr) {
+  return IN_MULTICAST(addr);
+}
+
+inline bool is_private_host_order(in_addr_t addr) {
+  return (((addr & 0xFF000000) == 0x0A000000) || // 10.0.0.0/8
+          ((addr & 0xFFC00000) == 0x64400000) || // 100.64.0.0/10
+          ((addr & 0xFFF00000) == 0xAC100000) || // 172.16.0.0/12
+          ((addr & 0xFFFF0000) == 0xC0A80000)    // 192.168.0.0/16
+  );
+}
+
+// There really is no "host order" for IPv6, so only the network order utilities are defined.
+// @c IP6Addr uses an idiosyncratic ordering for performance, not really useful to expose to
+// clients.
+
+inline bool is_loopback_network_order(in6_addr const& addr) {
+  return addr == in6addr_loopback;
+}
+
+inline bool is_multicast_network_order(in6_addr const& addr) {
+  return addr.s6_addr[0] == 0xFF;
+}
+
+inline bool is_link_local_network_order(in6_addr const& addr) {
+  return addr.s6_addr[0] == 0xFE && (addr.s6_addr[1] & 0xC0) == 0x80; // fe80::/10
+}
+
+inline bool is_private_network_order(in6_addr const& addr) {
+  return (addr.s6_addr[0] & 0xFE) == 0xFC; // fc00::/7
+}
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+inline bool is_loopback_network_order(in_addr_t addr) {
+  return (addr & 0xFF) == 0x7F;
+}
+
+inline bool is_private_network_order(in_addr_t addr) {
+  return (((addr & 0xFF) == 0x0A) || // 10.0.0.0/8
+          ((addr & 0xC0FF) == 0x4064) || // 100.64.0.0/10
+          ((addr & 0xF0FF) == 0x10AC) || // 172.16.0.0/12
+          ((addr & 0xFFFF) == 0xA8C0)    // 192.168.0.0/16
+  );
+}
+
+inline bool is_link_local_network_order(in_addr_t addr) {
+  return (addr & 0xFFFF) == 0xFEA9; // 169.254.0.0/16
+}
+
+inline bool is_multicast_network_order(in_addr_t addr) {
+  return (addr & 0xF0) == 0xE0;
+}
+
+#else
+
+inline bool is_loopback_network_order(in_addr_t addr) {
+  return is_loopback_host_order(addr);
+}
+
+inline bool is_link_local_network_order(inaddr_t addr) {
+  return is_link_local_host_order(addr);
+}
+
+inline bool is_private_network_order(in_addr_t addr) {
+  return is_link_local_host_order(addr);
+}
+
+inline bool is_multicast_network_order(in_addr_t addr) {
+  return is_multicast_host_order(addr);
+}
+
+#endif
+
+/** Check if the address in a socket address is a loopback address..
+ * @return @c true if so, @c false if not.
+ */
+inline bool is_loopback(sockaddr const * sa) {
+  return ( sa->sa_family == AF_INET && is_loopback_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_loopback_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+/** Check if the address in a socket address is multicast.
+ * @return @c true if so, @c false if not.
+ */
+inline bool is_multicast(sockaddr const * sa) {
+  return ( sa->sa_family == AF_INET && is_multicast_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_multicast_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+/** Check if the IP address in a socket address is link local.
+ * @return @c true if link local, @c false if not.
+ */
+inline bool is_link_local(sockaddr const* sa) {
+  return ( sa->sa_family == AF_INET && is_link_local_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_link_local_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+/** Check if the IP address in a socket address is private (non-routable)
+ * @return @c true if private, @c false if not.
+ */
+inline bool is_private(sockaddr const* sa) {
+  return ( sa->sa_family == AF_INET && is_private_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_private_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+} // hnamespace ip
+
+}} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_8
+#define SWOC_VERSION_NS _1_5_9
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 8;
+static constexpr unsigned POINT_VERSION = 9;
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/src/Errata.cc
+++ b/lib/swoc/src/Errata.cc
@@ -61,16 +61,6 @@ Errata::sink() {
   return *this;
 }
 
-Errata &
-Errata::note(code_type const &code) {
-  return this->note("{}"_sv, code);
-}
-
-Errata &
-Errata::note(code_type const &code, Severity severity) {
-  return this->note(severity, "{}"_sv, code);
-}
-
 Errata::Data *
 Errata::data() {
   if (!_data) {
@@ -78,6 +68,11 @@ Errata::data() {
     _data = arena.make<Data>(std::move(arena));
   }
   return _data;
+}
+
+MemSpan<char>
+Errata::alloc(size_t n) {
+  return this->data()->_arena.alloc(n).rebind<char>();
 }
 
 Errata &
@@ -99,11 +94,6 @@ Errata::note_localized(std::string_view const &text, std::optional<Severity> sev
   auto *n = d->_arena.make<Annotation>(text, severity);
   d->_notes.append(n);
   return *this;
-}
-
-MemSpan<char>
-Errata::alloc(size_t n) {
-  return this->data()->_arena.alloc(n).rebind<char>();
 }
 
 Errata &

--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -452,7 +452,7 @@ DNSEntry::init(DNSQueryData target, int qtype_arg, Continuation *acont, DNSProce
  */
 
 void
-DNSHandler::open_cons(swoc::IPEndpoint const &target, bool failed, int icon)
+DNSHandler::open_cons(swoc::IPSrv const &target, bool failed, int icon)
 {
   if (dns_conn_mode != DNS_CONN_MODE::TCP_ONLY) {
     open_con(target, failed, icon, false);
@@ -470,7 +470,7 @@ DNSHandler::reset_tcp_conn(int ndx)
 {
   Metrics::Counter::increment(dns_rsb.tcp_reset);
   tcpcon[ndx].close();
-  return open_con(&m_res->nsaddr_list[ndx].sa, true, ndx, true);
+  return open_con(m_res->nsaddr_list[ndx], true, ndx, true);
 }
 
 /**
@@ -488,7 +488,7 @@ DNSHandler::reset_tcp_conn(int ndx)
       open connection to target.
 */
 bool
-DNSHandler::open_con(swoc::IPEndpoint const &target, bool failed, int icon, bool over_tcp)
+DNSHandler::open_con(swoc::IPSrv const &target, bool failed, int icon, bool over_tcp)
 {
   PollDescriptor *pd = get_PollDescriptor(dnsProcessor.thread);
   bool ret           = false;

--- a/src/iocore/dns/P_DNSProcessor.h
+++ b/src/iocore/dns/P_DNSProcessor.h
@@ -245,8 +245,8 @@ struct DNSHandler : public Continuation {
   int startEvent_sdns(int event, Event *e);
   int mainEvent(int event, Event *e);
 
-  void open_cons(swoc::IPEndpoint const &target, bool failed = false, int icon = 0);
-  bool open_con(swoc::IPEndpoint const &target, bool failed = false, int icon = 0, bool over_tcp = false);
+  void open_cons(swoc::IPSrv const &target, bool failed = false, int icon = 0);
+  bool open_con(swoc::IPSrv const &target, bool failed = false, int icon = 0, bool over_tcp = false);
   void failover();
   void rr_failure(int ndx);
   void recover();
@@ -296,7 +296,7 @@ private:
    A record for an single server
    -------------------------------------------------------------- */
 struct DNSServer {
-  std::array<swoc::IPEndpoint, MAXNS> x_server_ip;
+  std::array<swoc::IPSrv, MAXNS> x_server_ip;
   char x_dns_ip_line[MAXDNAME * 2];
 
   char x_def_domain[MAXDNAME];

--- a/src/iocore/dns/SplitDNS.cc
+++ b/src/iocore/dns/SplitDNS.cc
@@ -349,11 +349,12 @@ SplitDNSRecord::ProcessDNSHosts(char *val)
       *tmp = 0;
     }
 
-    if (0 != ats_ip_pton(current, &m_servers.x_server_ip[i].sa)) {
+    swoc::IPAddr addr;
+    if (!addr.load(current)) {
       return "invalid IP address given for a DNS server";
     }
 
-    ats_ip_port_cast(&m_servers.x_server_ip[i].sa) = htons(port ? port : NAMESERVER_PORT);
+    m_servers.x_server_ip[i].assign(addr, port ? port : NAMESERVER_PORT);
 
     if ((MAXDNAME * 2 - 1) > totsz) {
       sz = strlen(current);
@@ -477,7 +478,7 @@ SplitDNSRecord::Init(matcher_line *line_info)
     }
   }
 
-  if (!ats_is_ip(&m_servers.x_server_ip[0].sa)) {
+  if (!m_servers.x_server_ip[0].is_valid()) {
     return Result::failure("%s No server specified in %s at line %d", modulePrefix, ts::filename::SPLITDNS, line_num);
   }
 

--- a/src/iocore/dns/SplitDNS.cc
+++ b/src/iocore/dns/SplitDNS.cc
@@ -484,7 +484,6 @@ SplitDNSRecord::Init(matcher_line *line_info)
   DNSHandler *dnsH  = new DNSHandler;
   ink_res_state res = new ts_imp_res_state;
 
-  memset(res, 0, sizeof(ts_imp_res_state));
   if ((-1 == ink_res_init(res, m_servers.x_server_ip, m_dnsSrvr_cnt, dns_search, m_servers.x_def_domain,
                           m_servers.x_domain_srch_list, nullptr))) {
     char ab[INET6_ADDRPORTSTRLEN];
@@ -494,7 +493,7 @@ SplitDNSRecord::Init(matcher_line *line_info)
 
   dnsH->m_res = res;
   dnsH->mutex = SplitDNSConfig::dnsHandler_mutex;
-  ats_ip_invalidate(&dnsH->ip.sa); // Mark to use default DNS.
+  dnsH->ip.invalidate(); // Mark to use default DNS.
 
   m_servers.x_dnsH = dnsH;
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -3748,7 +3748,7 @@ HttpTransact::handle_response_from_server(State *s)
         // Force host resolution to have the same family as the client.
         // Because this is a transparent connection, we can't switch address
         // families - that is locked in by the client source address.
-        ats_force_order_by_family(&s->current.server->dst_addr.sa, s->my_txn_conf().host_res_data.order);
+        ats_force_order_by_family(s->current.server->dst_addr.family(), s->my_txn_conf().host_res_data.order);
         return CallOSDNSLookup(s);
       } else {
         if ((s->txn_conf->connect_attempts_rr_retries > 0) &&

--- a/src/tscore/ink_res_mkquery.cc
+++ b/src/tscore/ink_res_mkquery.cc
@@ -550,12 +550,12 @@ ats_host_res_from(int family, HostResPreferenceOrder const &order)
 }
 
 void
-ats_force_order_by_family(sockaddr const *addr, HostResPreferenceOrder order)
+ats_force_order_by_family(sa_family_t family, HostResPreferenceOrder order)
 {
   HostResPreferenceOrder::size_type pos{0};
-  if (ats_is_ip6(addr)) {
+  if (AF_INET6 == family) {
     order[pos++] = HOST_RES_PREFER_IPV6;
-  } else if (ats_is_ip4(addr)) {
+  } else if (AF_INET == family) {
     order[pos++] = HOST_RES_PREFER_IPV4;
   }
   for (; pos < order.size(); pos++) {


### PR DESCRIPTION
Part of a coverity effort to remove `ats_ip_copy`. Primarily this involves moving from `sockaddr` to `IPEndpoint`. Some of the code
uses the obsolete `IpEndpoint` (a precursor to `swoc::IPEndpoint`).

This depends on libswoc 1.5.9, which has many improvements in the IP support code driven by this effort.