### PR TITLE
Arena; avoid use of temporary.

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -5721,7 +5721,7 @@ HttpSM::mark_host_failure(ResolveInfo *info, ts_time time_down)
       if (++info->active->fail_count >= t_state.txn_conf->connect_attempts_rr_retries) {
         if (info->active) {
           if (info->active->last_failure.load() == TS_TIME_ZERO) {
-            char *url_str = t_state.hdr_info.client_request.url_string_get(&t_state.arena, nullptr);
+            char *url_str = t_state.hdr_info.client_request.url_string_get_ref(nullptr);
             int host_len;
             const char *host_name_ptr = t_state.unmapped_url.host_get(&host_len);
             std::string_view host_name{host_name_ptr, size_t(host_len)};
@@ -5729,10 +5729,6 @@ HttpSM::mark_host_failure(ResolveInfo *info, ts_time time_down)
                           swoc::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr, host_name,
                           swoc::bwf::FirstOf(url_str, "<none>"));
             Log::error("%s", error_bw_buffer.c_str());
-
-            if (url_str) {
-              t_state.arena.str_free(url_str);
-            }
           }
           info->active->last_failure = time_down;
           SMDbg(dbg_ctl_http, "hostdb update marking IP: %s as down",


### PR DESCRIPTION
I can't see any need for the temporary, when the reference can be used (since it is used only for the debug message). Further, `url_string_get` prints the URL into the heap also, so either it's already there and it's faster to use it, or it will be generated.