### PR TITLE
clear up plugin string usage ambiguities reported by gcc

### DIFF
--- a/plugins/cachekey/cachekey.cc
+++ b/plugins/cachekey/cachekey.cc
@@ -223,7 +223,7 @@ getCanonicalUrl(TSMBuffer buf, TSMLoc url, bool canonicalPrefix, bool provideDef
   } else {
     if (provideDefaultKey) {
       /* return the key default - results in '/host/port' */
-      canonicalUrl.assign("/").append(host).append("/").append(port);
+      canonicalUrl.assign(1, '/').append(host).append("/").append(port);
     } else {
       /* return regex input string - results in 'host:port' (use-case kept for compatibility reasons) */
       canonicalUrl.assign(host).append(":").append(port);

--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -117,12 +117,15 @@ public:
     memset(_metrics, 0, sizeof(_metrics));
 
     std::string metric_prefix = prefix;
-    metric_prefix.append("." + std::string(types[type]));
+    metric_prefix.push_back('.');
+    metric_prefix.append(types[type]);
 
     if (!tag.empty()) {
-      metric_prefix.append("." + tag);
+      metric_prefix.push_back('.');
+      metric_prefix.append(tag);
     } else if (!name().empty()) {
-      metric_prefix.append("." + name());
+      metric_prefix.push_back('.');
+      metric_prefix.append(name());
     }
 
     for (int i = 0; i < RATE_LIMITER_METRIC_MAX; i++) {

--- a/plugins/experimental/rate_limit/utilities.cc
+++ b/plugins/experimental/rate_limit/utilities.cc
@@ -109,7 +109,8 @@ getDescriptionFromUrl(const char *url)
     // only append the port when it is non-standard
     if (!(strncmp(s, TS_URL_SCHEME_HTTP, scheme_len) == 0 && port == 80) &&
         !(strncmp(s, TS_URL_SCHEME_HTTPS, scheme_len) == 0 && port == 443)) {
-      description.append(":" + std::to_string(port));
+      description.push_back(':');
+      description.append(std::to_string(port));
     }
   }
 

--- a/plugins/prefetch/evaluate.cc
+++ b/plugins/prefetch/evaluate.cc
@@ -164,7 +164,7 @@ sub(StringView const lhs, StringView const rhs)
 
   // if result would have been negative.
   if (borrow) {
-    result = "0";
+    result = std::string{"0"};
   }
 
   return result;

--- a/plugins/traffic_dump/json_utils.cc
+++ b/plugins/traffic_dump/json_utils.cc
@@ -142,19 +142,19 @@ namespace traffic_dump
 std::string
 json_entry(std::string_view name, std::string_view value)
 {
-  return "\"" + escape_json(name) + "\":\"" + escape_json(value) + "\"";
+  return std::string{"\""} + escape_json(name) + "\":\"" + escape_json(value) + "\"";
 }
 
 std::string
 json_entry(std::string_view name, char const *value, int64_t size)
 {
-  return "\"" + escape_json(name) + "\":\"" + escape_json(value, size) + "\"";
+  return std::string{"\""} + escape_json(name) + "\":\"" + escape_json(value, size) + "\"";
 }
 
 std::string
 json_entry_array(std::string_view name, std::string_view value)
 {
-  return "[\"" + escape_json(name) + "\",\"" + escape_json(value) + "\"]";
+  return std::string{"[\""} + escape_json(name) + "\",\"" + escape_json(value) + "\"]";
 }
 
 std::string

--- a/plugins/traffic_dump/session_data.cc
+++ b/plugins/traffic_dump/session_data.cc
@@ -365,8 +365,8 @@ SessionData::write_transaction_to_disk(std::string_view content)
     // Prepend a comma.
     std::string with_comma;
     with_comma.reserve(content.size() + 1);
-    with_comma.insert(0, ",");
-    with_comma.insert(1, content);
+    with_comma.push_back(',');
+    with_comma.append(content);
     result = write_to_disk_no_lock(with_comma);
   } else {
     result                        = write_to_disk_no_lock(content);

--- a/plugins/traffic_dump/transaction_data.cc
+++ b/plugins/traffic_dump/transaction_data.cc
@@ -218,7 +218,7 @@ TransactionData::write_message_node_no_content(TSMBuffer &buffer, TSMLoc &hdr_lo
     // 3. "method":(string)
     cp = TSHttpHdrMethodGet(buffer, hdr_loc, &len);
     Dbg(dbg_ctl, "write_message_node(): found method %.*s ", len, cp);
-    result += "," + traffic_dump::json_entry("method", cp, len);
+    result += ',' + traffic_dump::json_entry("method", cp, len);
 
     // 4. "url"
     cp = TSUrlHostGet(buffer, url_loc, &len);


### PR DESCRIPTION
This clears up some warnings with CI gcc-12 release branch builds.
tested with ubuntu:23.04 CI image with gcc/release combination.