### PR TITLE
Update to libswoc 1.5.9

### DIFF
--- a/lib/swoc/include/swoc/Errata.h
+++ b/lib/swoc/include/swoc/Errata.h
@@ -337,26 +337,38 @@ public:
    * @param text Text of the message.
    * @return *this
    *
-   * The error code is set to the default.
    * @a text is localized to @a this and does not need to be persistent.
    * The severity is updated to @a severity if the latter is more severe.
    */
   self_type &note(Severity severity, std::string_view text);
 
+  /** Add an @c Annotation to the top with @a text and local @a severity.
+   * @param severity The local severity.
+   * @return *this
+   *
+   * The annotation uses the format @c AUTOTEXT_SEVERITY with the argument @a severity.
+   * @see AUTOTEXT_SEVERITY
+   */
+  self_type &note(Severity severity);
+
   /** Add an @c Annotation to the top based on error code @a code.
    * @param code Error code.
    * @return *this
    *
-   * The annotation text is constructed as the short, long, and numeric value of @a code.
+   * The annotation uses the format @c AUTOTEXT_CODE with the argument @a ec.
+   * @see AUTOTEXT_CODE
+   *
+   * @note @a ec is used only for formatting, the @c Errata error code is unchanged.
    */
-  self_type &note(code_type const &code);
+  self_type &note(code_type const &ec);
 
   /** Append an @c Annotation to the top based on error code @a code with @a severity.
    * @param severity Local severity.
    * @param code Error code.
    * @return *this
    *
-   * The annotation text is constructed as the short, long, and numeric value of @a code.
+   * The annotation uses the format @c AUTOTEXT_SEVERITY_CODE with the argument @a severity.
+   * @see AUTOTEXT_SEVERITY_CODE
    */
   self_type &note(code_type const &code, Severity severity);
 
@@ -1171,6 +1183,21 @@ Errata::note(std::string_view text) {
 inline Errata &
 Errata::note(Severity severity, std::string_view text) {
   return this->note_s(severity, text);
+}
+
+inline Errata &
+Errata::note(Severity severity) {
+  return this->note(severity, AUTOTEXT_SEVERITY, severity);
+}
+
+inline Errata &
+Errata::note(code_type const &code) {
+  return this->note(AUTOTEXT_CODE, code);
+}
+
+inline Errata &
+Errata::note(code_type const &ec, Severity severity) {
+  return this->note(severity, AUTOTEXT_SEVERITY_CODE, severity, ec);
 }
 
 template <typename... Args>

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -432,6 +432,27 @@ public:
    */
   bool load(std::string_view const &text);
 
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IPAddr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP6Addr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP4Addr const& addr) const;
+
   /// @return The minimum address in the range.
   IPAddr min() const;
 
@@ -445,22 +466,13 @@ public:
   self_type &clear();
 
   /// @return The IPv4 range.
-  IP4Range const &
-  ip4() const {
-    return _range._ip4;
-  }
+  IP4Range const & ip4() const;
 
   /// @return The IPv6 range.
-  IP6Range const &
-  ip6() const {
-    return _range._ip6;
-  }
+  IP6Range const & ip6() const;
 
   /// @return The range family.
-  sa_family_t
-  family() const {
-    return _family;
-  }
+  sa_family_t family() const;
 
   /** Compute the mask for @a this as a network.
    *
@@ -641,6 +653,27 @@ public:
    * @return @c true if this is @a family, @c false if not.
    */
   bool is(sa_family_t family) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IPAddr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP6Addr const& addr) const;
+
+  /** Test if an address is in the range.
+   *
+   * @param addr Address to test.
+   * @return @c true if in @a this range, @c false if not.
+   */
+  bool contains(IP4Addr const& addr) const;
 
   /// @return Reference to the viewed IPv4 range.
   IP4Range const &ip4() const;
@@ -1933,6 +1966,17 @@ IPRange::is_ip6() const {
   return AF_INET6 == _family;
 }
 
+inline sa_family_t IPRange::family() const {
+  return _family;
+}
+inline IP4Range const& IPRange::ip4() const {
+  return _range._ip4;
+}
+
+inline IP6Range const& IPRange::ip6() const {
+  return _range._ip6;
+}
+
 inline auto
 IPRangeView::clear() -> self_type & {
   _family = AF_UNSPEC;
@@ -1957,6 +2001,26 @@ IPRangeView::is_ip6() const {
 inline bool
 IPRangeView::is(sa_family_t f) const {
   return f == _family;
+}
+
+inline bool IPRange::contains(IPAddr const & addr) const {
+  if (addr.family() != _family) {
+    return false;
+  }
+  if (this->ip4()) {
+    return _range._ip4.contains(addr.ip4());
+  } else if (this->is_ip6()) {
+    return _range._ip6.contains(addr.ip6());
+  }
+  return false;
+}
+
+inline bool IPRange::contains(IP6Addr const & addr) const {
+  return this->is_ip6() && _range._ip6.contains(addr);
+}
+
+inline bool IPRange::contains(IP4Addr const & addr) const {
+  return this->is_ip4() && _range._ip4.contains(addr);
 }
 
 inline IP4Range const &
@@ -2001,6 +2065,24 @@ IPRangeView::min() const {
 inline IPAddr
 IPRangeView::max() const {
   return AF_INET == _family ? _raw._4->max() : AF_INET6 == _family ? _raw._6->max() : IPAddr::INVALID;
+}
+
+inline bool IPRangeView::contains(IPAddr const& addr) const {
+  if (_family != addr.family()) {
+    return false;
+  }
+  return (_family == addr.family() ) &&
+         ( ( this->is_ip4() && _raw._4->contains(addr.ip4()) ) ||
+           ( this->is_ip6() && _raw._6->contains(addr.ip6()) )
+         );
+}
+
+inline bool IPRangeView::contains(IP6Addr const& addr) const {
+  return this->is_ip6() && _raw._6->contains(addr);
+}
+
+inline bool IPRangeView::contains(IP4Addr const& addr) const {
+  return this->is_ip4() && _raw._4->contains(addr);
 }
 
 // +++ IPNet +++

--- a/lib/swoc/include/swoc/IPSrv.h
+++ b/lib/swoc/include/swoc/IPSrv.h
@@ -85,29 +85,29 @@ public:
    */
   bool load(swoc::TextView text);
 
-  /** Change the address.
+  /** Assign an IPv4 address.
    *
    * @param addr Address to assign.
    * @return @a this
    */
   self_type &assign(IP4Addr const &addr);
 
-  /** Change the host_order_port.
+  /** Assign a port.
    *
-   * @param port Port to assign.
+   * @param port Port to assign (host order)
    * @return @a this.
    */
   self_type &assign(in_port_t port);
 
-  /** Change the address and port.
+  /** Assign an address and port.
    *
    * @param addr Address to assign.
-   * @param port Port to assign.
+   * @param port Port to assign (host order).
    * @return @a this
    */
   self_type &assign(IP4Addr const &addr, in_port_t port);
 
-  /** Change the address and port.
+  /** Assign an address and port from an IPv4 socket address.
    *
    * @param s A socket address.
    * @return @a this
@@ -116,7 +116,7 @@ public:
 
 protected:
   IP4Addr _addr;       ///< Address.
-  in_port_t _port = 0; ///< Port.
+  in_port_t _port = 0; ///< Port [host order].
 };
 
 /// An IPv6 address and host_order_port, modeled on an SRV type for DNS.
@@ -193,17 +193,17 @@ public:
    */
   self_type &assign(IP6Addr const &addr);
 
-  /** Change the host_order_port.
+  /** Assign a port.
    *
-   * @param port Port to assign.
+   * @param port Port [host order].
    * @return @a this.
    */
   self_type &assign(in_port_t port);
 
-  /** Change the address and host_order_port.
+  /** Assign an address and port.
    *
-   * @param addr Address to assign.
-   * @param port Port to assign.
+   * @param addr Address.
+   * @param port Port [host order].
    * @return @a this
    */
   self_type &assign(IP6Addr const &addr, in_port_t port);
@@ -217,7 +217,7 @@ public:
 
 protected:
   IP6Addr _addr;       ///< Address.
-  in_port_t _port = 0; ///< Port.
+  in_port_t _port = 0; ///< Port [host order]
 };
 
 /// An IP address and host_order_port, modeled on an SRV type for DNS.
@@ -228,11 +228,17 @@ private:
 public:
   IPSrv() = default; ///< Default constructor.
   explicit IPSrv(IP4Addr addr, in_port_t port = 0) : _srv(IP4Srv{addr, port}), _family(addr.family()) {}
+  /// Construct for IPv6 address and port.
   explicit IPSrv(IP6Addr addr, in_port_t port = 0) : _srv(IP6Srv{addr, port}), _family(addr.family()) {}
+  /// Construct from generic address and port.
   explicit IPSrv(IPAddr addr, in_port_t port = 0);
+  /// Construct from socket address.
   explicit IPSrv(sockaddr const *sa);
+  /// Construct IPv4 service from socket address.
   explicit IPSrv(sockaddr_in const *s);
+  /// Construct IPv6 service from socket address.
   explicit IPSrv(sockaddr_in6 const *s);
+  /// Construct from Endpoint.
   explicit IPSrv(IPEndpoint const &ep);
 
   /** Construct from a string.
@@ -259,21 +265,17 @@ public:
   /// @return The protocol of the current value.
   constexpr sa_family_t family() const;
 
+  /// @return @c true if this is a valid service, @c false if not.
+  bool is_valid() const;
   /// @return @c true if the data is IPv4, @c false if not.
   bool is_ip4() const;
   /// @return @c true if hte data is IPv6, @c false if not.
   bool is_ip6() const;
 
   /// @return The IPv4 data.
-  IP4Srv const &
-  ip4() const {
-    return _srv._ip4;
-  }
+  IP4Srv const & ip4() const;
   /// @return The IPv6 data.
-  IP6Srv const &
-  ip6() const {
-    return _srv._ip6;
-  }
+  IP6Srv const & ip6() const;
 
   /** Change the address.
    *
@@ -289,88 +291,91 @@ public:
    */
   self_type &assign(IP6Addr const &addr);
 
-  /** Change the address.
+  /** Assign an address.
    *
-   * @param addr Address to assign.
+   * @param addr Address.
    * @return @a this
    *
-   * If @a addr isn't valid then no assignment is made.
+   * If @a addr isn't valid then no assignment is made, otherwise the family is changed to that of
+   * @a addr.
    */
   self_type &assign(IPAddr const &addr);
 
-  /** Change the host_order_port.
+  /** Assign port.
    *
-   * @param port Port in host order.
+   * @param port Port [host order].
    * @return @a this.
    */
   self_type &assign(in_port_t port);
 
-  /** Change the address and port.
+  /** Assign an IPv4 address and port.
    *
-   * @param addr Address to assign.
-   * @param port Port to assign.
+   * @param addr Address.
+   * @param port Port [host order].
    * @return @a this
    */
   self_type &assign(IP4Addr const &addr, in_port_t port);
 
-  /** Change the address and port.
+  /** Assign an IPv6 address and port.
    *
-   * @param addr Address to assign.
-   * @param port Port to assign.
+   * @param addr Address.
+   * @param port Port [host order].
    * @return @a this
    */
   self_type &assign(IP6Addr const &addr, in_port_t port);
 
-  /** Change the address and port.
+  /** Assogm address amd [prt/
    *
    * @param sa Socket address.
    * @return @a this
+   *
+   * The assignment is ignored if @a sa is not a valid IP family, otherwise the family is changed
+   * to that of @a sa.
    */
   self_type &assign(sockaddr const *sa);
 
-  /** Change the address and port.
+  /** Assign an IPv4 address and port.
    *
    * @param s Socket address.
    * @return @a this
    */
   self_type &assign(sockaddr_in const *s);
 
-  /** Change the address and port.
+  /** Assign an IPv6 address and port.
    *
    * @param s Socket address.
    * @return @a this
    */
   self_type &assign(sockaddr_in6 const *s);
 
-  /** Change the address and host_order_port.
+  /** Assign an address and port.
    *
-   * @param addr Address to assign.
-   * @param port Port to assign.
+   * @param addr Address.
+   * @param port Port [host order].
    * @return @a this
    *
-   * If @a addr isn't valid then no assignment is made.
+   * If @a addr isn't valid then no assignment is made, otherwise the family is changed to match
+   * @a addr.
    */
   self_type &assign(IPAddr const &addr, in_port_t port);
 
+  /// Copy assignment.
   self_type &operator=(self_type const &that) = default;
+  /// Assign from IPv4.
   self_type &operator=(IP4Srv const &that);
+  /// Assign from IPv6.
   self_type &operator=(IP6Srv const &that);
-  self_type &
-  operator=(sockaddr const *sa) {
-    return this->assign(sa);
-  }
-  self_type &
-  operator=(sockaddr_in const *s) {
-    return this->assign(s);
-  }
-  self_type &
-  operator=(sockaddr_in6 const *s) {
-    return this->assign(s);
-  }
+  /// Assign from generic socket address.
+  self_type & operator=(sockaddr const *sa);
+  /// Assign from IPv4 socket address.
+  self_type & operator=(sockaddr_in const *s);
+  /// Assign from IPv6 socket address.
+  self_type & operator=(sockaddr_in6 const *s);
 
 protected:
   /// Family specialized data.
   union data {
+    std::monostate _nil; ///< Nil / invalid state.
     IP4Srv _ip4; ///< IPv4 address (host)
     IP6Srv _ip6; ///< IPv6 address (host)
 
@@ -555,17 +560,40 @@ inline IPAddr
 IPSrv::addr() const {
   return _srv.addr(_family);
 }
+
 inline constexpr sa_family_t
 IPSrv::family() const {
   return _family;
 }
+
+inline bool IPSrv::is_valid() const { return AF_INET == _family || AF_INET6 == _family; }
+
 inline bool
 IPSrv::is_ip4() const {
   return _family == AF_INET;
 }
+
 inline bool
 IPSrv::is_ip6() const {
   return _family == AF_INET6;
+}
+
+inline IP4Srv const& IPSrv::ip4() const {
+  return _srv._ip4;
+}
+
+inline IP6Srv const& IPSrv::ip6() const {
+  return _srv._ip6;
+}
+
+inline constexpr in_port_t
+IPSrv::host_order_port() const {
+  return _srv.port(_family);
+}
+
+inline in_port_t
+IPSrv::network_order_port() const {
+  return ntohs(_srv.port(_family));
 }
 
 inline auto
@@ -656,14 +684,16 @@ IPSrv::assign(sockaddr_in6 const *s) -> self_type & {
   return *this;
 }
 
-inline constexpr in_port_t
-IPSrv::host_order_port() const {
-  return _srv.port(_family);
+inline IPSrv::self_type & IPSrv::operator=(sockaddr const *sa) {
+  return this->assign(sa);
 }
 
-inline in_port_t
-IPSrv::network_order_port() const {
-  return ntohs(_srv.port(_family));
+inline IPSrv::self_type & IPSrv::operator=(sockaddr_in const *s) {
+  return this->assign(s);
+}
+
+inline IPSrv::self_type & IPSrv::operator=(sockaddr_in6 const *s) {
+  return this->assign(s);
 }
 
 inline IPAddr
@@ -675,6 +705,7 @@ constexpr inline in_port_t
 IPSrv::data::port(sa_family_t f) const {
   return (f == AF_INET) ? _ip4.host_order_port() : (f == AF_INET6) ? _ip6.host_order_port() : 0;
 }
+
 // --- Independent comparisons.
 
 inline bool

--- a/lib/swoc/include/swoc/TextView.h
+++ b/lib/swoc/include/swoc/TextView.h
@@ -1057,15 +1057,15 @@ uintmax_t svtou(TextView src, TextView *parsed = nullptr, int base = 0);
 template <int RADIX>
 uintmax_t
 svto_radix(TextView &src) {
-  static_assert(0 < RADIX && RADIX <= 36, "Radix must be in the range 1..36");
+  static_assert(1 <= RADIX && RADIX <= 36, "Radix must be in the range 2..36");
   static constexpr auto MAX            = std::numeric_limits<uintmax_t>::max();
   static constexpr auto OVERFLOW_LIMIT = MAX / RADIX;
   uintmax_t zret                       = 0;
-  int8_t v;
+  uintmax_t v;
   while (src.size() && (0 <= (v = swoc::svtoi_convert[uint8_t(*src)])) && v < RADIX) {
     // Tweaked for performance - need to check range after @a RADIX multiply.
     ++src; // Update view iff the character is parsed.
-    if (zret <= OVERFLOW_LIMIT && uintmax_t(v) <= MAX - (zret *= RADIX)) {
+    if (zret <= OVERFLOW_LIMIT && v <= (MAX - (zret *= RADIX)) ) {
       zret += v;
     } else {
       zret = MAX; // clamp to max - once set will always hit this case for subsequent input.

--- a/lib/swoc/include/swoc/swoc_ip_util.h
+++ b/lib/swoc/include/swoc/swoc_ip_util.h
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Network Geographics 2014
+/** @file
+   Shared utilities for IP address classes.
+ */
+
+#pragma once
+#include <netinet/in.h>
+
+#include "swoc/swoc_version.h"
+
+// These have to be global namespace, unfortunately.
+inline bool
+operator==(in6_addr const& lhs, in6_addr const& rhs) {
+  return 0 == memcmp(&lhs, &rhs, sizeof(in6_addr));
+}
+
+inline bool
+operator!=(in6_addr const& lhs, in6_addr const& rhs) {
+  return 0 != memcmp(&lhs, &rhs, sizeof(in6_addr));
+}
+
+namespace swoc { inline namespace SWOC_VERSION_NS {
+
+/// Internal IP address utilities.
+namespace ip {
+
+inline bool is_loopback_host_order(in_addr_t addr) {
+  return (addr & 0xFF000000) == 0x7F000000;
+}
+
+inline bool is_link_local_host_order(in_addr_t addr) {
+  return (addr & 0xFFFF0000) == 0xA9FE0000; // 169.254.0.0/16
+}
+
+inline bool is_multicast_host_order(in_addr_t addr) {
+  return IN_MULTICAST(addr);
+}
+
+inline bool is_private_host_order(in_addr_t addr) {
+  return (((addr & 0xFF000000) == 0x0A000000) || // 10.0.0.0/8
+          ((addr & 0xFFC00000) == 0x64400000) || // 100.64.0.0/10
+          ((addr & 0xFFF00000) == 0xAC100000) || // 172.16.0.0/12
+          ((addr & 0xFFFF0000) == 0xC0A80000)    // 192.168.0.0/16
+  );
+}
+
+// There really is no "host order" for IPv6, so only the network order utilities are defined.
+// @c IP6Addr uses an idiosyncratic ordering for performance, not really useful to expose to
+// clients.
+
+inline bool is_loopback_network_order(in6_addr const& addr) {
+  return addr == in6addr_loopback;
+}
+
+inline bool is_multicast_network_order(in6_addr const& addr) {
+  return addr.s6_addr[0] == 0xFF;
+}
+
+inline bool is_link_local_network_order(in6_addr const& addr) {
+  return addr.s6_addr[0] == 0xFE && (addr.s6_addr[1] & 0xC0) == 0x80; // fe80::/10
+}
+
+inline bool is_private_network_order(in6_addr const& addr) {
+  return (addr.s6_addr[0] & 0xFE) == 0xFC; // fc00::/7
+}
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+inline bool is_loopback_network_order(in_addr_t addr) {
+  return (addr & 0xFF) == 0x7F;
+}
+
+inline bool is_private_network_order(in_addr_t addr) {
+  return (((addr & 0xFF) == 0x0A) || // 10.0.0.0/8
+          ((addr & 0xC0FF) == 0x4064) || // 100.64.0.0/10
+          ((addr & 0xF0FF) == 0x10AC) || // 172.16.0.0/12
+          ((addr & 0xFFFF) == 0xA8C0)    // 192.168.0.0/16
+  );
+}
+
+inline bool is_link_local_network_order(in_addr_t addr) {
+  return (addr & 0xFFFF) == 0xFEA9; // 169.254.0.0/16
+}
+
+inline bool is_multicast_network_order(in_addr_t addr) {
+  return (addr & 0xF0) == 0xE0;
+}
+
+#else
+
+inline bool is_loopback_network_order(in_addr_t addr) {
+  return is_loopback_host_order(addr);
+}
+
+inline bool is_link_local_network_order(inaddr_t addr) {
+  return is_link_local_host_order(addr);
+}
+
+inline bool is_private_network_order(in_addr_t addr) {
+  return is_link_local_host_order(addr);
+}
+
+inline bool is_multicast_network_order(in_addr_t addr) {
+  return is_multicast_host_order(addr);
+}
+
+#endif
+
+/** Check if the address in a socket address is a loopback address..
+ * @return @c true if so, @c false if not.
+ */
+inline bool is_loopback(sockaddr const * sa) {
+  return ( sa->sa_family == AF_INET && is_loopback_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_loopback_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+/** Check if the address in a socket address is multicast.
+ * @return @c true if so, @c false if not.
+ */
+inline bool is_multicast(sockaddr const * sa) {
+  return ( sa->sa_family == AF_INET && is_multicast_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_multicast_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+/** Check if the IP address in a socket address is link local.
+ * @return @c true if link local, @c false if not.
+ */
+inline bool is_link_local(sockaddr const* sa) {
+  return ( sa->sa_family == AF_INET && is_link_local_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_link_local_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+/** Check if the IP address in a socket address is private (non-routable)
+ * @return @c true if private, @c false if not.
+ */
+inline bool is_private(sockaddr const* sa) {
+  return ( sa->sa_family == AF_INET && is_private_network_order(reinterpret_cast<sockaddr_in const *>(sa)->sin_addr.s_addr)) ||
+         ( sa->sa_family == AF_INET6 && is_private_network_order(reinterpret_cast<sockaddr_in6 const *>(sa)->sin6_addr))
+         ;
+}
+
+} // hnamespace ip
+
+}} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_8
+#define SWOC_VERSION_NS _1_5_9
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 8;
+static constexpr unsigned POINT_VERSION = 9;
 }} // namespace swoc::SWOC_VERSION_NS

--- a/lib/swoc/src/Errata.cc
+++ b/lib/swoc/src/Errata.cc
@@ -61,16 +61,6 @@ Errata::sink() {
   return *this;
 }
 
-Errata &
-Errata::note(code_type const &code) {
-  return this->note("{}"_sv, code);
-}
-
-Errata &
-Errata::note(code_type const &code, Severity severity) {
-  return this->note(severity, "{}"_sv, code);
-}
-
 Errata::Data *
 Errata::data() {
   if (!_data) {
@@ -78,6 +68,11 @@ Errata::data() {
     _data = arena.make<Data>(std::move(arena));
   }
   return _data;
+}
+
+MemSpan<char>
+Errata::alloc(size_t n) {
+  return this->data()->_arena.alloc(n).rebind<char>();
 }
 
 Errata &
@@ -99,11 +94,6 @@ Errata::note_localized(std::string_view const &text, std::optional<Severity> sev
   auto *n = d->_arena.make<Annotation>(text, severity);
   d->_notes.append(n);
   return *this;
-}
-
-MemSpan<char>
-Errata::alloc(size_t n) {
-  return this->data()->_arena.alloc(n).rebind<char>();
 }
 
 Errata &


### PR DESCRIPTION
This is in preparation for some significant ATS updates, including

* Avoiding `ats_ip_copy`
* Final removal of the old `Errata`
* Replacement of `Arena` by `MemArena`.

Release notes:

Just in time for the holidays, a new release of libSWOC! This is a bit bigger than other recent point releases due to increased integration in ATS.

* Fixed possible overflow bug in `svtoi`.
* IP networking support
  * Generalization of network category (multicast, private, etc.).
  * Better endian handling.
  * Added some missing / unimplemented methods.
* Errata: Auto text support for error codes in constructor and `note` method.
* MemArena - support `discard` allocated spans.

Fixes #10934 