### PR TITLE
cmake: Add a check for BoringSSL version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,10 +281,20 @@ find_package(PCRE REQUIRED)
 
 include(CheckOpenSSLIsBoringSSL)
 find_package(OpenSSL REQUIRED)
-check_openssl_is_boringssl(OPENSSL_IS_BORINGSSL "${OPENSSL_INCLUDE_DIR}")
+check_openssl_is_boringssl(OPENSSL_IS_BORINGSSL BORINGSSL_VERSION "${OPENSSL_INCLUDE_DIR}")
 
-if(NOT OPENSSL_IS_BORINGSSL AND OPENSSL_VERSION VERSION_LESS "1.1.1")
-  message(FATAL_ERROR "OpenSSL version greater than 1.0.1 or BoringSSL required")
+if(OPENSSL_IS_BORINGSSL)
+  # The consensus is a commit newer than a1843d660b47116207877614af53defa767be46a
+  # The commit that changes API_VERSION to 27 is actually a little bit older than the commit but still a reasonable commit
+  set(min_bssl "27")
+  if(BORINGSSL_VERSION VERSION_LESS "${min_bssl}")
+    message(FATAL_ERROR "BoringSSL API version >= ${min_bssl} or OpenSSL required")
+  endif()
+else()
+  set(min_ossl "1.1.1")
+  if(OPENSSL_VERSION VERSION_LESS "${min_ossl}")
+    message(FATAL_ERROR "OpenSSL version >= ${min_ossl} or BoringSSL required")
+  endif()
 endif()
 
 if(OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0")

--- a/cmake/CheckOpenSSLIsBoringSSL.cmake
+++ b/cmake/CheckOpenSSLIsBoringSSL.cmake
@@ -15,7 +15,7 @@
 #
 #######################
 
-function(CHECK_OPENSSL_IS_BORINGSSL OUT_VAR OPENSSL_INCLUDE_DIR)
+function(CHECK_OPENSSL_IS_BORINGSSL OUT_IS_BORING OUT_VERSION OPENSSL_INCLUDE_DIR)
   set(CHECK_PROGRAM
       "
         #include <openssl/base.h>
@@ -31,5 +31,13 @@ function(CHECK_OPENSSL_IS_BORINGSSL OUT_VAR OPENSSL_INCLUDE_DIR)
   )
   set(CMAKE_REQUIRED_INCLUDES "${OPENSSL_INCLUDE_DIR}")
   include(CheckCXXSourceCompiles)
-  check_cxx_source_compiles("${CHECK_PROGRAM}" ${OUT_VAR})
+  check_cxx_source_compiles("${CHECK_PROGRAM}" ${OUT_IS_BORING})
+  if(${${OUT_IS_BORING}})
+    file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/base.h" version_line REGEX "^#define BORINGSSL_API_VERSION [0-9]+")
+    string(REGEX MATCH "[0-9]+" version ${version_line})
+    set(${OUT_VERSION}
+        ${version}
+        PARENT_SCOPE
+    )
+  endif()
 endfunction()


### PR DESCRIPTION

This is a change for https://lists.apache.org/thread/d6ymfjhpmjogb5stnz92hwhhps909809, which requires using a commit of BoringSSL newer than a1843d660b47116207877614af53defa767be46a.

Checking `BORINGSSL_API_VERSION` doesn't strictly follow the consensus but I think it's still a reasonable way.

```
$ git log --oneline a1843d660b47116207877614af53defa767be46a | head -n 5
a1843d660 Bump the minimum CMake version to 3.12
340fe150b CMake doesn't have an error function
ecb7e9ae5 Require C11 in MSVC too
558960d1e Add support for the new ALPS codepoint <---  This bumped BORINGSSL_API_VERSION
1e3da32f3 Expose curves for ECDH
```