### PR TITLE
Cleanup: Rename gvol to gstripes

### DIFF
--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -248,11 +248,11 @@ struct OpenDir : public Continuation {
 };
 
 struct CacheSync : public Continuation {
-  int vol_idx    = 0;
-  char *buf      = nullptr;
-  size_t buflen  = 0;
-  bool buf_huge  = false;
-  off_t writepos = 0;
+  int stripe_index = 0;
+  char *buf        = nullptr;
+  size_t buflen    = 0;
+  bool buf_huge    = false;
+  off_t writepos   = 0;
   AIOCallbackInternal io;
   Event *trigger        = nullptr;
   ink_hrtime start_time = 0;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -350,8 +350,8 @@ struct Doc {
 
 // Global Data
 
-extern Stripe **gvol;
-extern std::atomic<int> gnvol;
+extern Stripe **gstripes;
+extern std::atomic<int> gnstripes;
 extern ClassAllocator<OpenDirEntry> openDirEntryAllocator;
 extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;
 extern ClassAllocator<EvacuationKey> evacuationKeyAllocator;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -693,9 +693,9 @@ Stripe::dir_init_done(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
     eventProcessor.schedule_in(this, HRTIME_MSECONDS(5), ET_CALL);
     return EVENT_CONT;
   } else {
-    int vol_no = gnvol++;
-    ink_assert(!gvol[vol_no]);
-    gvol[vol_no] = this;
+    int i = gnstripes++;
+    ink_assert(!gstripes[i]);
+    gstripes[i] = this;
     SET_HANDLER(&Stripe::aggWrite);
     cache->vol_initialized(fd != -1);
     return EVENT_DONE;

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -78,9 +78,9 @@ public:
     ink_hrtime ttime;
 
     REQUIRE(CacheProcessor::IsCacheEnabled() == CACHE_INITIALIZED);
-    REQUIRE(gnvol >= 1);
+    REQUIRE(gnstripes >= 1);
 
-    Stripe *stripe  = gvol[0];
+    Stripe *stripe  = gstripes[0];
     EThread *thread = this_ethread();
     MUTEX_TRY_LOCK(lock, stripe->mutex, thread);
     if (!lock.is_locked()) {

--- a/src/iocore/cache/unit_tests/test_CacheVol.cc
+++ b/src/iocore/cache/unit_tests/test_CacheVol.cc
@@ -58,7 +58,7 @@ static int configs = 4;
 Queue<CacheVol> saved_cp_list;
 int saved_cp_list_len;
 ConfigVolumes saved_config_volumes;
-int saved_gnvol;
+int saved_gnstripes;
 
 int ClearConfigVol(ConfigVolumes *configp);
 int ClearCacheVolList(Queue<CacheVol> *cpl, int len);
@@ -342,10 +342,10 @@ save_state()
   saved_cp_list     = cp_list;
   saved_cp_list_len = cp_list_len;
   memcpy(&saved_config_volumes, &config_volumes, sizeof(ConfigVolumes));
-  saved_gnvol = gnvol;
+  saved_gnstripes = gnstripes;
   memset(static_cast<void *>(&cp_list), 0, sizeof(Queue<CacheVol>));
   memset(static_cast<void *>(&config_volumes), 0, sizeof(ConfigVolumes));
-  gnvol = 0;
+  gnstripes = 0;
 }
 
 void
@@ -354,7 +354,7 @@ restore_state()
   cp_list     = saved_cp_list;
   cp_list_len = saved_cp_list_len;
   memcpy(&config_volumes, &saved_config_volumes, sizeof(ConfigVolumes));
-  gnvol = saved_gnvol;
+  gnstripes = saved_gnstripes;
 }
 } // end anonymous namespace
 


### PR DESCRIPTION
Part of #10628.

- Rename global variables
  - `Stripe **gvol` -> `Strip **gstripes`
  - `std::atomic<int> gnvol` -> `std::atomic<int> gnstripes`

- Rename related local variables.