### PR TITLE
boringssl: Add a type declaration

### DIFF
--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -53,6 +53,9 @@ extern ClassAllocator<FetchSM> FetchSMAllocator;
 // clang-format off
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#ifndef GENERAL_NAME_it
+DECLARE_ASN1_ITEM(GENERAL_NAME)
+#endif
 // RFC 6960
 using TS_OCSP_CERTID = struct ocsp_cert_id {
   X509_ALGOR *hashAlgorithm;


### PR DESCRIPTION
Some declarations around X509 were moved to an internal header file on recent BoringSSL because they thought those were not used externally.
https://boringssl.googlesource.com/boringssl/+/1a7233d191952cc163133a5ab235a0ab0f31c812

And they realized that some of those were actually used externally and moved those back to a public header.
https://boringssl.googlesource.com/boringssl/+/faac623b09d6b14fbb06fe5150016de78b359eea
https://boringssl.googlesource.com/boringssl/+/538b2a6cf0497cf8bb61ae726a484a3d7a34e54e

However, these commits do not completely revert the removal commit, so there are still missing declarations which we use. This PR adds declarations for the missing ones, and make ATS buildable with the latest BoringSSL (b6e0eba6e62333652290514e51b75b966b27b27c).
