### PR TITLE
Fix a bug in OCSP update with dual cert configuration

### DIFF
--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -1256,33 +1256,40 @@ ocsp_update()
   time_t current_time;
 
   SSLCertificateConfig::scoped_config certLookup;
-  const unsigned ctxCount = certLookup ? certLookup->count() : 0;
 
   Debug("ssl_ocsp", "updating OCSP data");
-  for (unsigned i = 0; i < ctxCount; i++) {
-    SSLCertContext *cc = certLookup->get(i);
-    if (cc) {
-      ctx = cc->getCtx();
-      if (ctx) {
-        certinfo *cinf    = nullptr;
-        certinfo_map *map = stapling_get_cert_info(ctx.get());
-        if (map) {
-          // Walk over all certs associated with this CTX
-          for (auto &iter : *map) {
-            cinf = iter.second;
-            ink_mutex_acquire(&cinf->stapling_mutex);
-            current_time = time(nullptr);
-            if (cinf->resp_derlen == 0 || cinf->is_expire || cinf->expire_time < current_time) {
-              ink_mutex_release(&cinf->stapling_mutex);
-              if (stapling_refresh_response(cinf, &resp)) {
-                Debug("ssl_ocsp", "Successfully refreshed OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
-                Metrics::Counter::increment(ssl_rsb.ocsp_refreshed_cert);
+#ifndef OPENSSL_IS_BORINGSSL
+  const SSLCertContextType ctxTypes[] = {SSLCertContextType::GENERIC};
+#else
+  const SSLCertContextType ctxTypes[] = {SSLCertContextType::RSA, SSLCertContextType::EC};
+#endif
+  for (auto &ctxType : ctxTypes) {
+    const unsigned ctxCount = certLookup ? certLookup->count() : 0;
+    for (unsigned i = 0; i < ctxCount; i++) {
+      SSLCertContext *cc = certLookup->get(i, ctxType);
+      if (cc) {
+        ctx = cc->getCtx();
+        if (ctx) {
+          certinfo *cinf    = nullptr;
+          certinfo_map *map = stapling_get_cert_info(ctx.get());
+          if (map) {
+            // Walk over all certs associated with this CTX
+            for (auto &iter : *map) {
+              cinf = iter.second;
+              ink_mutex_acquire(&cinf->stapling_mutex);
+              current_time = time(nullptr);
+              if (cinf->resp_derlen == 0 || cinf->is_expire || cinf->expire_time < current_time) {
+                ink_mutex_release(&cinf->stapling_mutex);
+                if (stapling_refresh_response(cinf, &resp)) {
+                  Debug("ssl_ocsp", "Successfully refreshed OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
+                  Metrics::Counter::increment(ssl_rsb.ocsp_refreshed_cert);
+                } else {
+                  Error("Failed to refresh OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
+                  Metrics::Counter::increment(ssl_rsb.ocsp_refresh_cert_failure);
+                }
               } else {
-                Error("Failed to refresh OCSP for %s certificate. url=%s", cinf->certname, cinf->uri);
-                Metrics::Counter::increment(ssl_rsb.ocsp_refresh_cert_failure);
+                ink_mutex_release(&cinf->stapling_mutex);
               }
-            } else {
-              ink_mutex_release(&cinf->stapling_mutex);
             }
           }
         }

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -1263,7 +1263,7 @@ ocsp_update()
 #else
   const SSLCertContextType ctxTypes[] = {SSLCertContextType::RSA, SSLCertContextType::EC};
 #endif
-  for (auto &ctxType : ctxTypes) {
+  for (const auto &ctxType : ctxTypes) {
     const unsigned ctxCount = certLookup ? certLookup->count() : 0;
     for (unsigned i = 0; i < ctxCount; i++) {
       SSLCertContext *cc = certLookup->get(i, ctxType);

--- a/src/iocore/net/P_SSLCertLookup.h
+++ b/src/iocore/net/P_SSLCertLookup.h
@@ -166,8 +166,8 @@ struct SSLCertLookup : public ConfigInfo {
     return ssl_default.get();
   }
 
-  unsigned count() const;
-  SSLCertContext *get(unsigned i) const;
+  unsigned count(SSLCertContextType ctxType = SSLCertContextType::GENERIC) const;
+  SSLCertContext *get(unsigned i, SSLCertContextType ctxType = SSLCertContextType::GENERIC) const;
 
   void register_cert_secrets(std::vector<std::string> const &cert_secrets, std::set<std::string> &lookup_names);
   void getPolicies(const std::string &secret_name, std::set<shared_SSLMultiCertConfigParams> &policies) const;

--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -371,15 +371,31 @@ SSLCertLookup::insert(const IpEndpoint &address, SSLCertContext const &cc)
 }
 
 unsigned
-SSLCertLookup::count() const
+SSLCertLookup::count(SSLCertContextType ctxType) const
 {
-  return ssl_storage->count();
+  switch (ctxType) {
+  case SSLCertContextType::EC:
+#ifdef OPENSSL_IS_BORINGSSL
+    return ec_storage->count();
+#endif
+  case SSLCertContextType::RSA:
+  default:
+    return ssl_storage->count();
+  }
 }
 
 SSLCertContext *
-SSLCertLookup::get(unsigned i) const
+SSLCertLookup::get(unsigned i, SSLCertContextType ctxType) const
 {
-  return ssl_storage->get(i);
+  switch (ctxType) {
+  case SSLCertContextType::EC:
+#ifdef OPENSSL_IS_BORINGSSL
+    return ec_storage->get(i);
+#endif
+  case SSLCertContextType::RSA:
+  default:
+    return ssl_storage->get(i);
+  }
 }
 
 void

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -2456,12 +2456,12 @@ SSLMultiCertConfigLoader::load_certs(SSL_CTX *ctx, const std::vector<std::string
       if (sslMultCertSettings->ocsp_response) {
         const char *ocsp_response_name = data.ocsp_list[i].c_str();
         std::string completeOCSPResponsePath(Layout::relative_to(params->ssl_ocsp_response_path_only, ocsp_response_name));
-        if (!ssl_stapling_init_cert(ctx, cert, data.cert_names_list[i].c_str(), completeOCSPResponsePath.c_str())) {
-          Warning("failed to configure SSL_CTX for OCSP Stapling info for certificate at %s", data.cert_names_list[i].c_str());
+        if (!ssl_stapling_init_cert(ctx, cert, cert_names_list[i].c_str(), completeOCSPResponsePath.c_str())) {
+          Warning("failed to configure SSL_CTX for OCSP Stapling info for certificate at %s", cert_names_list[i].c_str());
         }
       } else {
-        if (!ssl_stapling_init_cert(ctx, cert, data.cert_names_list[i].c_str(), nullptr)) {
-          Warning("failed to configure SSL_CTX for OCSP Stapling info for certificate at %s", data.cert_names_list[i].c_str());
+        if (!ssl_stapling_init_cert(ctx, cert, cert_names_list[i].c_str(), nullptr)) {
+          Warning("failed to configure SSL_CTX for OCSP Stapling info for certificate at %s", cert_names_list[i].c_str());
         }
       }
     }


### PR DESCRIPTION
ATS uses two cert storages (one for RSA, the other for EC) because BoringSSL does not natively support dual certs, unlike OpenSSL. It works fine in terms of selecting a cert for a connection, but I found OCSP status update only uses the storage for RSA.

This PR surrounds the existing code by a loop that iterates over certification types in an array to cover all certs in the both storages. Hiding whitespace changes makes the diff easy to read.

Also, the change for SSLUtils is for a logging issue. It always printed a filename for either RSA or EC cert if dual certs is configured.