### PR TITLE
Persist bad disks

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -2488,6 +2488,29 @@ Cache Control
    used from the asynchronous IO threads when IO finishes and the ``CacheVC`` lock or stripe lock is
    required.
 
+.. ts::cv:: CONFIG proxy.config.cache.max_disk_errors INT 5
+
+   Cache disks sometimes fail due to hardware problems.  |TS| keeps count of
+   the number of times it encounters I/O errors when accessing each cache disk.
+   If the number of errors on a disk reaches this setting, |TS| removes that
+   disk from the cache.
+
+   Note that the count of errors is kept in memory, and is reset to zero when
+   |TS| is restarted.  By default, |TS| will not remember which cache disk has
+   been removed in this way when it restarts.  If you wish to change this behavior
+   and prevent known bad disks from re-joining the cache upon restart, change
+   the setting :ts:cv:`proxy.config.cache.persist_bad_disks`.
+
+.. ts::cv:: CONFIG proxy.config.cache.persist_bad_disks INT 0
+
+   When enabled (``1``), |TS| will remember which cache disks have been
+   marked as failed through :ts:cv:`proxy.config.cache.max_disk_errors`,
+   even after a restart.  A list of known bad cache disks is written to
+   ``localstatedir/known_bad_disks``.  If you replace the known bad disks,
+   delete this file so that |TS| will use it in the cache again.
+
+   When disabled (``0``), |TS| will ignore the ``known_bad_disks`` file.
+
 RAM Cache
 =========
 

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -2477,7 +2477,7 @@ Cache Control
    write vector. For further details on cache write vectors, refer to the
    developer documentation for :cpp:class:`CacheVC`.
 
-.. ts::cv:: CONFIG proxy.config.cache.mutex_retry_delay INT 2
+.. ts:cv:: CONFIG proxy.config.cache.mutex_retry_delay INT 2
    :reloadable:
    :units: milliseconds
 
@@ -2488,7 +2488,7 @@ Cache Control
    used from the asynchronous IO threads when IO finishes and the ``CacheVC`` lock or stripe lock is
    required.
 
-.. ts::cv:: CONFIG proxy.config.cache.max_disk_errors INT 5
+.. ts:cv:: CONFIG proxy.config.cache.max_disk_errors INT 5
 
    Cache disks sometimes fail due to hardware problems.  |TS| keeps count of
    the number of times it encounters I/O errors when accessing each cache disk.
@@ -2501,15 +2501,17 @@ Cache Control
    and prevent known bad disks from re-joining the cache upon restart, change
    the setting :ts:cv:`proxy.config.cache.persist_bad_disks`.
 
-.. ts::cv:: CONFIG proxy.config.cache.persist_bad_disks INT 0
+.. ts:cv:: CONFIG proxy.config.cache.persist_bad_disks INT 0
 
    When enabled (``1``), |TS| will remember which cache disks have been
    marked as failed through :ts:cv:`proxy.config.cache.max_disk_errors`,
    even after a restart.  A list of known bad cache disks is written to
-   ``localstatedir/known_bad_disks``.  If you replace the known bad disks,
-   delete this file so that |TS| will use it in the cache again.
+   ``localstatedir/known_bad_disks.txt``.  If you replace the known bad disks,
+   delete this file so that |TS| will use them in the cache again.
 
-   When disabled (``0``), |TS| will ignore the ``known_bad_disks`` file.
+   When disabled (``0``), |TS| will ignore ``known_bad_disks.txt``.
+
+   This feature is disabled by default.
 
 RAM Cache
 =========

--- a/include/tscore/Filenames.h
+++ b/include/tscore/Filenames.h
@@ -47,6 +47,7 @@ namespace filename
   // Various other file names
   constexpr const char *RECORDS_STATS = "records.snap";
   constexpr const char *HOST_RECORDS  = "host_records.yaml";
+  constexpr const char *BAD_DISKS     = "bad_disks";
 
 } // namespace filename
 } // namespace ts

--- a/include/tscore/Filenames.h
+++ b/include/tscore/Filenames.h
@@ -47,7 +47,7 @@ namespace filename
   // Various other file names
   constexpr const char *RECORDS_STATS = "records.snap";
   constexpr const char *HOST_RECORDS  = "host_records.yaml";
-  constexpr const char *BAD_DISKS     = "bad_disks";
+  constexpr const char *BAD_DISKS     = "bad_disks.txt";
 
 } // namespace filename
 } // namespace ts

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -27,6 +27,7 @@
 #include "P_CacheTest.h"
 
 #include "tscore/Filenames.h"
+#include "tscore/Layout.h"
 
 #include "../../records/P_RecProcess.h"
 
@@ -35,6 +36,11 @@
 #endif
 
 #include <atomic>
+#include <unordered_set>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <filesystem>
 
 constexpr ts::VersionNumber CACHE_DB_VERSION(CACHE_DB_MAJOR_VERSION, CACHE_DB_MINOR_VERSION);
 
@@ -67,6 +73,7 @@ int cache_config_read_while_writer             = 0;
 int cache_config_mutex_retry_delay             = 2;
 int cache_read_while_writer_retry_delay        = 50;
 int cache_config_read_while_writer_max_retries = 10;
+bool cache_config_persist_bad_disks            = false;
 
 // Globals
 
@@ -94,6 +101,7 @@ ClassAllocator<CacheEvacuateDocVC> cacheEvacuateDocVConnectionAllocator("cacheEv
 ClassAllocator<EvacuationBlock> evacuationBlockAllocator("evacuationBlock");
 ClassAllocator<CacheRemoveCont> cacheRemoveContAllocator("cacheRemoveCont");
 ClassAllocator<EvacuationKey> evacuationKeyAllocator("evacuationKey");
+std::unordered_set<std::string> known_bad_disks;
 
 namespace
 {
@@ -334,6 +342,15 @@ CacheProcessor::start_internal(int flags)
     if (!sd->file_pathname) {
       ink_strlcat(paths[gndisks], "/cache.db", PATH_NAME_MAX);
       opts |= O_CREAT;
+    }
+
+    // Check if the disk is known to be bad
+    if (cache_config_persist_bad_disks && !known_bad_disks.empty()) {
+      if (known_bad_disks.find(paths[gndisks]) != known_bad_disks.end()) {
+        Note("%s is a known bad disk.  Skipping.", paths[gndisks]);
+        Metrics::Gauge::increment(cache_rsb.span_offline);
+        continue;
+      }
     }
 
 #ifdef O_DIRECT
@@ -984,6 +1001,32 @@ Cache::vol_initialized(bool result)
   }
 }
 
+static void
+persist_bad_disks()
+{
+  std::filesystem::path localstatedir{Layout::get()->localstatedir};
+  std::filesystem::path bad_disks_path{localstatedir / ts::filename::BAD_DISKS};
+  std::error_code ec;
+  std::filesystem::create_directories(bad_disks_path.parent_path(), ec);
+  if (ec) {
+    Error("Error creating directory for bad disks file: %s (%s)", bad_disks_path.c_str(), ec.message().c_str());
+    return;
+  }
+
+  std::fstream bad_disks_file{bad_disks_path.c_str(), bad_disks_file.out};
+  if (bad_disks_file.good()) {
+    for (const std::string &path : known_bad_disks) {
+      bad_disks_file << path << std::endl;
+      if (bad_disks_file.fail()) {
+        Error("Error writing known bad disks file: %s", bad_disks_path.c_str());
+        break;
+      }
+    }
+  } else {
+    Error("Failed to open file to persist bad disks: %s", bad_disks_path.c_str());
+  }
+}
+
 /** Set the state of a disk programmatically.
  */
 bool
@@ -1044,6 +1087,11 @@ CacheProcessor::mark_storage_offline(CacheDisk *d, ///< Target disk
         Warning("all volumes for http cache are corrupt, http cache disabled");
       }
     }
+  }
+
+  if (cache_config_persist_bad_disks) {
+    known_bad_disks.insert(d->path);
+    persist_bad_disks();
   }
 
   return zret;

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -74,6 +74,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.cache.max_disk_errors", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.cache.persist_bad_disks", RECD_INT, "0", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[01]", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.output.logfile.name", RECD_STRING, "traffic.out", RECU_RESTART_TM, RR_REQUIRED, RECC_NULL, nullptr,
    RECA_NULL}
   ,

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -159,6 +159,7 @@ produce_layout(bool json)
   print_var("RUNTIMEDIR", RecConfigReadRuntimeDir(), json);
   print_var("PLUGINDIR", RecConfigReadPluginDir(), json);
   print_var("INCLUDEDIR", Layout::get()->includedir, json);
+  print_var("LOCALSTATEDIR", Layout::get()->localstatedir, json);
 
   print_var(ts::filename::RECORDS, RecConfigReadConfigPath(nullptr, ts::filename::RECORDS), json);
   print_var(ts::filename::REMAP, RecConfigReadConfigPath("proxy.config.url_remap.filename"), json);


### PR DESCRIPTION
Add a config option to have traffic server remember which disks are bad.  Previously, cache disks that were determined to be bad at runtime were forgotten upon restart.  This could cause corrupt cache metadata to be loaded from disk, leading to crashes, or slowdowns when accessing the known bad disk.

If the option is turned on, bad disks are remembered until the `known_bad_disks` file is edited or deleted.  If the system administrator replaces the disks, they need to perform this manual step.  Because of this requirement, this option is off by default.