### PR TITLE
multiplexer: set up transforms for PUT requests

### DIFF
--- a/plugins/multiplexer/ats-multiplexer.cc
+++ b/plugins/multiplexer/ats-multiplexer.cc
@@ -143,7 +143,8 @@ DoRemap(const Instance &i, TSHttpTxn t)
     generateRequests(i.origins, buffer, location, requests);
     assert(requests.size() == i.origins.size());
 
-    if (length == TS_HTTP_LEN_POST && memcmp(TS_HTTP_METHOD_POST, method, TS_HTTP_LEN_POST) == 0) {
+    if ((length == TS_HTTP_LEN_POST && memcmp(TS_HTTP_METHOD_POST, method, TS_HTTP_LEN_POST) == 0) ||
+        (length == TS_HTTP_LEN_PUT && memcmp(TS_HTTP_METHOD_PUT, method, TS_HTTP_LEN_PUT) == 0)) {
       const TSVConn vconnection = TSTransformCreate(handlePost, t);
       assert(vconnection != nullptr);
       TSContDataSet(vconnection, new PostState(requests));


### PR DESCRIPTION
Without this change, multiplexer handling of PUT requests only work for very small bodies. This sets up the transform for PUT like we do for POST. A future commit for large PUT/POST bodies will contain a test for this. In the meantime, this at least connects up the transform for PUT requests.