### PR TITLE
multiplexer: debug logging and variable name updates

### DIFF
--- a/plugins/multiplexer/ats-multiplexer.cc
+++ b/plugins/multiplexer/ats-multiplexer.cc
@@ -35,6 +35,8 @@
 #error Please define a PLUGIN_TAG before including this file.
 #endif
 
+using multiplexer_ns::dbg_ctl;
+
 // 1s
 const size_t DEFAULT_TIMEOUT = 1000000000000;
 

--- a/plugins/multiplexer/dispatch.cc
+++ b/plugins/multiplexer/dispatch.cc
@@ -31,6 +31,8 @@
 #error Please define a PLUGIN_TAG before including this file.
 #endif
 
+using multiplexer_ns::dbg_ctl;
+
 extern Statistics statistics;
 
 size_t timeout;
@@ -229,6 +231,7 @@ generateRequests(const Origins &o, const TSMBuffer buffer, const TSMLoc location
     const std::string &host = *iterator;
     assert(!host.empty());
     request.hostHeader(host);
+    Dbg(dbg_ctl, "Preparing request for \"%s\"", host.c_str());
     r.push_back(Request(host, buffer, location));
   }
 }

--- a/plugins/multiplexer/fetcher.cc
+++ b/plugins/multiplexer/fetcher.cc
@@ -37,6 +37,7 @@ HttpParser::destroyParser()
 bool
 HttpParser::parse(io::IO &io)
 {
+  using multiplexer_ns::dbg_ctl;
   if (parsed_) {
     return true;
   }
@@ -62,8 +63,3 @@ HttpParser::parse(io::IO &io)
 }
 
 } // namespace ats
-
-namespace multiplexer_ns
-{
-DbgCtl dbg_ctl{PLUGIN_TAG};
-}

--- a/plugins/multiplexer/fetcher.h
+++ b/plugins/multiplexer/fetcher.h
@@ -39,12 +39,6 @@
 
 #define unlikely(x) __builtin_expect((x), 0)
 
-namespace multiplexer_ns
-{
-extern DbgCtl dbg_ctl;
-}
-using namespace multiplexer_ns;
-
 namespace ats
 {
 struct HttpParser {
@@ -181,6 +175,8 @@ template <class T> struct HttpTransaction {
   static int
   handle(TSCont c, TSEvent e, void *data)
   {
+    using multiplexer_ns::dbg_ctl;
+
     Self *const self = static_cast<Self *const>(TSContDataGet(c));
     assert(self != NULL);
     switch (e) {
@@ -288,6 +284,7 @@ template <class T>
 bool
 get(const std::string &a, io::IO *const i, const int64_t l, const T &t, const int64_t ti = 0)
 {
+  using multiplexer_ns::dbg_ctl;
   using Transaction = HttpTransaction<T>;
   struct sockaddr_in socket;
   socket.sin_family = AF_INET;

--- a/plugins/multiplexer/post.h
+++ b/plugins/multiplexer/post.h
@@ -30,9 +30,10 @@
 struct PostState {
   Requests requests;
 
-  TSIOBuffer buffer;
-  TSIOBufferReader reader;
-  TSVIO vio;
+  TSIOBuffer origin_buffer;
+  TSIOBufferReader clone_reader;
+  /// The VIO for the original (non-clone) origin.
+  TSVIO output_vio;
 
   ~PostState();
   PostState(Requests &);

--- a/plugins/multiplexer/ts.cc
+++ b/plugins/multiplexer/ts.cc
@@ -37,3 +37,8 @@ namespace io
 
 } // namespace io
 } // namespace ats
+
+namespace multiplexer_ns
+{
+DbgCtl dbg_ctl{PLUGIN_TAG};
+}

--- a/plugins/multiplexer/ts.h
+++ b/plugins/multiplexer/ts.h
@@ -31,6 +31,11 @@
 #include <string>
 #include <ts/ts.h>
 
+namespace multiplexer_ns
+{
+extern DbgCtl dbg_ctl;
+}
+
 namespace ats
 {
 namespace io


### PR DESCRIPTION
This is a multiplexer cleanup PR that adds debug logging to post.cc and updates variable names for the transform in order to make their purpose explicit (for the origin, for a copy, etc.). In post.cc, for instance, both the incoming and outgoing VIO were named `vio`, with the difference being whether it was called off of the state `s` variable or as a local variable. This updates the names to clarify the purpose of each.

Other than logging changes, this patch makes no functional change to multiplexer.