### PR TITLE
Add tscore to access_control dependencies

### DIFF
--- a/plugins/experimental/access_control/CMakeLists.txt
+++ b/plugins/experimental/access_control/CMakeLists.txt
@@ -28,7 +28,7 @@ add_atsplugin(
   utils.cc
 )
 
-target_link_libraries(access_control PRIVATE PCRE::PCRE OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(access_control PRIVATE PCRE::PCRE OpenSSL::SSL OpenSSL::Crypto ts::tscore)
 
 if(BUILD_TESTING)
   add_subdirectory(unit_tests)


### PR DESCRIPTION
This makes the ats_base64_decode symbol visible to the access_control plugin. This symbol is not part of the API, so access_control should not be using it, or it should be promoted to the API. This commit does not solve that; it only fixes it to work like it did before.