### PR TITLE
Add missing ts::records dep to block_errors plugin

### DIFF
--- a/plugins/experimental/block_errors/CMakeLists.txt
+++ b/plugins/experimental/block_errors/CMakeLists.txt
@@ -19,4 +19,4 @@ project(block_errors)
 
 add_atsplugin(block_errors block_errors.cc)
 
-target_link_libraries(block_errors PRIVATE libswoc::libswoc)
+target_link_libraries(block_errors PRIVATE libswoc::libswoc ts::records)


### PR DESCRIPTION
This makes the symbol TS_ALPN_PROTOCOL_HTTP_2_0, which is defined in the records library, visible to the block_errors plugin. Just like #10968, this is not a good long term fix.

This may not be the right change for the moment. `TS_ALPN_PROTOCOL_HTTP_2_0` is declared in `apidefs.h` and looks like it's supposed to be part of the API.