### PR TITLE
Fix problem with the negation in TextView/libswoc

### DIFF
--- a/lib/swoc/src/TextView.cc
+++ b/lib/swoc/src/TextView.cc
@@ -63,7 +63,12 @@ svtoi(TextView src, TextView *out, int base) {
         out->assign(start, parsed.data_end());
       }
       if (neg) {
-        zret = -intmax_t(std::min<uintmax_t>(n, ABS_MIN));
+        uintmax_t temp = std::min<uintmax_t>(n, ABS_MIN);
+        if (temp == ABS_MIN) {
+          zret = std::numeric_limits<intmax_t>::min();
+        } else {
+          zret = -intmax_t(temp);
+        }
       } else {
         zret = std::min(n, ABS_MAX);
       }


### PR DESCRIPTION
ABS_MIN is 9223372036854775808
intmax_t(ABS_MIN) is -9223372036854775808
negation of that is overflow for intmax_t data type with max value of 9223372036854775807
And I think that's not the intention as well. 

So I need to make this change.
