### PR TITLE
cmake/Findluajit: don't require luajit_LIBRARY_DIRS for rockylinux builds

### DIFF
--- a/cmake/Findluajit.cmake
+++ b/cmake/Findluajit.cmake
@@ -32,7 +32,7 @@ pkg_check_modules(luajit luajit)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   luajit
-  REQUIRED_VARS luajit_INCLUDE_DIRS luajit_LINK_LIBRARIES luajit_LIBRARIES luajit_LIBRARY_DIRS
+  REQUIRED_VARS luajit_INCLUDE_DIRS luajit_LINK_LIBRARIES luajit_LIBRARIES
   HANDLE_COMPONENTS
 )
 
@@ -43,6 +43,8 @@ endif()
 if(luajit_FOUND AND NOT TARGET luajit::luajit)
   add_library(luajit::luajit INTERFACE IMPORTED)
   target_include_directories(luajit::luajit INTERFACE ${luajit_INCLUDE_DIRS})
-  target_link_directories(luajit::luajit INTERFACE ${luajit_LIBRARY_DIRS})
+  if(luajit_LIBRARY_DIRS)
+    target_link_directories(luajit::luajit INTERFACE ${luajit_LIBRARY_DIRS})
+  endif()
   target_link_libraries(luajit::luajit INTERFACE ${luajit_LIBRARIES})
 endif()


### PR DESCRIPTION
Currently branch builds for rockylinux 8&9 are failing to build the lua plugin with error:

```
-- Checking for module 'luajit'
--   Found luajit, version 2.1.0-beta3
-- Could NOT find luajit (missing: luajit_LIBRARY_DIRS)
```

This change should resolve this and allow cmake to look in /usr/lib64