### PR TITLE
Avoid arena temporary.

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1480,7 +1480,6 @@ HttpTransact::handleIfRedirect(State *s)
   answer = request_url_remap_redirect(&s->hdr_info.client_request, &redirect_url, s->state_machine->m_remap);
   if ((answer == PERMANENT_REDIRECT) || (answer == TEMPORARY_REDIRECT)) {
     s->remap_redirect = redirect_url.string_get_ref(nullptr);
-    redirect_url.destroy();
     if (answer == TEMPORARY_REDIRECT) {
       if ((s->client_info).http_version == HTTP_1_1) {
         build_error_response(s, HTTP_STATUS_TEMPORARY_REDIRECT, "Redirect", "redirect#moved_temporarily");
@@ -1491,6 +1490,7 @@ HttpTransact::handleIfRedirect(State *s)
       build_error_response(s, HTTP_STATUS_MOVED_PERMANENTLY, "Redirect", "redirect#moved_permanently");
     }
     s->remap_redirect = nullptr;
+    redirect_url.destroy();
     return true;
   }
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1479,9 +1479,7 @@ HttpTransact::handleIfRedirect(State *s)
 
   answer = request_url_remap_redirect(&s->hdr_info.client_request, &redirect_url, s->state_machine->m_remap);
   if ((answer == PERMANENT_REDIRECT) || (answer == TEMPORARY_REDIRECT)) {
-    int remap_redirect_len;
-
-    s->remap_redirect = redirect_url.string_get(&s->arena, &remap_redirect_len);
+    s->remap_redirect = redirect_url.string_get_ref(nullptr);
     redirect_url.destroy();
     if (answer == TEMPORARY_REDIRECT) {
       if ((s->client_info).http_version == HTTP_1_1) {
@@ -1492,7 +1490,6 @@ HttpTransact::handleIfRedirect(State *s)
     } else {
       build_error_response(s, HTTP_STATUS_MOVED_PERMANENTLY, "Redirect", "redirect#moved_permanently");
     }
-    s->arena.str_free(s->remap_redirect);
     s->remap_redirect = nullptr;
     return true;
   }


### PR DESCRIPTION
This PR is a continuation of #10947 with one additional commit.

> The use of an arena temporary creates complexity for no gain. It might appear to avoid putting a cached copy of the URL string on the heap, but that copy still happens. The longer term fix is to a cleaner interface for printing in to an arena rather than the quite convoluted current mechanisms.

co-author: @SolidWallOfCode