### PR TITLE
TSFile - remove from background_fetch plugin

### DIFF
--- a/doc/admin-guide/plugins/background_fetch.en.rst
+++ b/doc/admin-guide/plugins/background_fetch.en.rst
@@ -73,6 +73,8 @@ The contents of the config-file could be as below::
    exclude Content-Type text
    exclude X-Foo-Bar text
    exclude Content-Length <1000
+   exclude Client-IP 127.0.0.1
+   include Client-IP 10.0.0.0/16
 
 .. important::
 

--- a/plugins/background_fetch/CMakeLists.txt
+++ b/plugins/background_fetch/CMakeLists.txt
@@ -16,4 +16,4 @@
 #######################
 
 add_atsplugin(background_fetch background_fetch.cc configs.cc headers.cc rules.cc)
-target_link_libraries(background_fetch PRIVATE libswoc::libswoc ts::tscpputil)
+target_link_libraries(background_fetch PRIVATE libswoc::libswoc ts::tsutil)

--- a/plugins/background_fetch/CMakeLists.txt
+++ b/plugins/background_fetch/CMakeLists.txt
@@ -16,3 +16,4 @@
 #######################
 
 add_atsplugin(background_fetch background_fetch.cc configs.cc headers.cc rules.cc)
+target_link_libraries(background_fetch PRIVATE libswoc::libswoc ts::tscpputil)

--- a/plugins/background_fetch/configs.cc
+++ b/plugins/background_fetch/configs.cc
@@ -25,6 +25,7 @@
 #include <getopt.h>
 #include <cstdio>
 #include <memory.h>
+#include <sys/socket.h>
 
 #include "configs.h"
 

--- a/plugins/background_fetch/configs.cc
+++ b/plugins/background_fetch/configs.cc
@@ -30,7 +30,7 @@
 
 #include <swoc/TextView.h>
 #include <swoc/swoc_file.h>
-#include <tscpp/util/ts_bw_format.h>
+#include <tsutil/ts_bw_format.h>
 
 using namespace swoc::literals;
 

--- a/plugins/background_fetch/configs.cc
+++ b/plugins/background_fetch/configs.cc
@@ -25,7 +25,6 @@
 #include <getopt.h>
 #include <cstdio>
 #include <memory.h>
-#include <sys/socket.h>
 
 #include "configs.h"
 

--- a/plugins/background_fetch/configs.h
+++ b/plugins/background_fetch/configs.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <list>
 #include <memory>
+#include <sys/socket.h>
 
 #include "rules.h"
 

--- a/plugins/background_fetch/configs.h
+++ b/plugins/background_fetch/configs.h
@@ -27,6 +27,8 @@
 #include <cstdlib>
 #include <atomic>
 #include <string>
+#include <list>
+#include <memory>
 
 #include "rules.h"
 
@@ -41,11 +43,12 @@ extern DbgCtl Bg_dbg_ctl;
 class BgFetchConfig
 {
 public:
+  using list_type = std::list<BgFetchRule>;
+
   explicit BgFetchConfig(TSCont cont) : _cont(cont) { TSContDataSet(cont, static_cast<void *>(this)); }
 
   ~BgFetchConfig()
   {
-    delete _rules;
     if (_cont) {
       TSContDestroy(_cont);
     }
@@ -53,7 +56,7 @@ public:
 
   bool parseOptions(int argc, const char *argv[]);
 
-  BgFetchRule *
+  list_type const &
   getRules() const
   {
     return _rules;
@@ -83,8 +86,8 @@ public:
   bool bgFetchAllowed(TSHttpTxn txnp) const;
 
 private:
-  TSCont _cont        = nullptr;
-  BgFetchRule *_rules = nullptr;
-  bool _allow_304     = false;
+  TSCont _cont = nullptr;
+  list_type _rules;
+  bool _allow_304 = false;
   std::string _log_file;
 };

--- a/plugins/background_fetch/configs.h
+++ b/plugins/background_fetch/configs.h
@@ -35,7 +35,7 @@
 // Constants
 const char PLUGIN_NAME[] = "background_fetch";
 
-extern DbgCtl Bg_dbg_ctl;
+static DbgCtl Bg_dbg_ctl{PLUGIN_NAME};
 
 ///////////////////////////////////////////////////////////////////////////
 // This holds one complete background fetch rule

--- a/plugins/background_fetch/rules.cc
+++ b/plugins/background_fetch/rules.cc
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <string_view>
 #include <cstring>
+#include <sys/socket.h>
 
 #include <swoc/IPEndpoint.h>
 #include <swoc/swoc_meta.h>

--- a/plugins/background_fetch/rules.cc
+++ b/plugins/background_fetch/rules.cc
@@ -32,8 +32,8 @@
 #include "configs.h"
 #include "rules.h"
 
-#include "tscpp/util/ts_bw_format.h"
-#include "tscpp/util/ts_ip.h"
+#include "tsutil/ts_bw_format.h"
+#include "tsutil/ts_ip.h"
 
 ///////////////////////////////////////////////////////////////////////////
 // These are little helper functions for the main rules evaluator.

--- a/plugins/background_fetch/rules.h
+++ b/plugins/background_fetch/rules.h
@@ -28,6 +28,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <variant>
+#include <sys/socket.h>
 
 #include <swoc/TextView.h>
 #include <swoc/IPRange.h>


### PR DESCRIPTION
TSFile and related plugin API are being deprecated. This removes those from the background_fetch plugin, along with some other clean up.

This replaces #10909, attribution should go to @SolidWallOfCode who is the main contributor of this code (and included in the contributors list)

Co-authored-by: Alan M. Carroll <amc@apache.org>