### PR TITLE
Improve redirect handling

### DIFF
--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -258,6 +258,7 @@ public:
 
   bool is_private() const;
   bool is_redirect_required();
+  bool is_redirect_required_for_status(HTTPStatus *status);
 
   /// Get the protocol stack for the inbound (client, user agent) connection.
   /// @arg result [out] Array to store the results

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -6260,6 +6260,11 @@ HttpTransact::is_response_cacheable(State *s, HTTPHdr *request, HTTPHdr *respons
     return false;
   }
 
+  // don't cache a 302 when a redirect is being chased
+  if (response_code == HTTP_STATUS_MOVED_TEMPORARILY && s->state_machine->is_redirect_required_for_status(&response_code)) {
+    return false;
+  }
+
   // check if cache control overrides default cacheability
   int indicator;
   indicator = response_cacheable_indicated_by_cc(response, s->cache_control.ignore_server_no_cache);

--- a/tests/gold_tests/redirect/redirect_post.test.py
+++ b/tests/gold_tests/redirect/redirect_post.test.py
@@ -78,7 +78,7 @@ ts.Disk.remap_config.AddLine(
     'map http://127.0.0.1:{0} http://127.0.0.1:{1}'.format(ts.Variables.port, redirect_serv1.Variables.Port))
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'touch largefile.txt && truncate largefile.txt -s 50M && curl -H "Expect: " -i http://127.0.0.1:{0}/redirect1 -F "filename=@./largefile.txt" && rm -f largefile.txt'.format(
+tr.Processes.Default.Command = 'touch largefile.txt && truncate -s 50M largefile.txt && curl -H "Expect: " -i http://127.0.0.1:{0}/redirect1 -F "filename=@./largefile.txt" && rm -f largefile.txt'.format(
     ts.Variables.port)
 tr.Processes.Default.StartBefore(ts)
 tr.Processes.Default.StartBefore(redirect_serv1)


### PR DESCRIPTION
* Do not permit a 302 to be cached if a redirect is in progress.
* Could be more permissive if we remove the check for `HTTP_STATUS_MOVED_TEMPORARILY` in `HttpTransact::is_response_cacheable()`
* Refactor HttpSM::is_redirect_required() to make it easier to call when state is incomplete
* May address issue #10955

