### PR TITLE
CMAKE_INSTALL_FULL_LOGDIR and CMAKE_INSTALL_FULL_CACHEDIR

### DIFF
--- a/cmake/layout.cmake
+++ b/cmake/layout.cmake
@@ -62,8 +62,20 @@ set(CMAKE_INSTALL_LOGDIR
     "${CMAKE_INSTALL_LOCALSTATEDIR}/log/trafficserver"
     CACHE STRING "logdir"
 )
+# Since CMAKE_INSTALL_LOGDIR is custom, GNUInstallDirs doesn't know to creat a
+# FULL version of it automatically for us.
+set(CMAKE_INSTALL_FULL_LOGDIR
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LOGDIR}"
+    CACHE STRING "full logdir"
+)
 set(CMAKE_INSTALL_CACHEDIR
     "${CMAKE_INSTALL_LOCALSTATEDIR}/trafficserver"
     CACHE STRING "cachedir"
+)
+# Since CMAKE_INSTALL_CACHEDIR is custom, GNUInstallDirs doesn't know to creat a
+# FULL version of it automatically for us.
+set(CMAKE_INSTALL_FULL_CACHEDIR
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_CACHEDIR}"
+    CACHE STRING "full cachedir"
 )
 include(GNUInstallDirs)


### PR DESCRIPTION
We use the FULL versions of CMAKE_INSTALL_LOGDIR and CMAKE_INSTALL_CACHEDIR, but GNUInstallDirs doens't know about these since they are custom for us and therefore doesn't automatically create them. This explicitly sets the values of these.