### PR TITLE
OCSP update: fix ctxCount to be specific about the type

### DIFF
--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -1267,7 +1267,7 @@ ocsp_update()
   const SSLCertContextType ctxTypes[] = {SSLCertContextType::RSA, SSLCertContextType::EC};
 #endif
   for (const auto &ctxType : ctxTypes) {
-    const unsigned ctxCount = certLookup ? certLookup->count() : 0;
+    const unsigned ctxCount = certLookup ? certLookup->count(ctxType) : 0;
     for (unsigned i = 0; i < ctxCount; i++) {
       SSLCertContext *cc = certLookup->get(i, ctxType);
       if (cc) {


### PR DESCRIPTION
When OCSP calculates the number of contexts for each type, it has to limit the lookup based upon type applicable to the type it is processing.