### PR TITLE
CMake: Make sure pthread is available when checking for some of the library functions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ if(HAVE_IOURING AND USE_IOURING)
   set(TS_USE_LINUX_IO_URING 1)
 endif(HAVE_IOURING AND USE_IOURING)
 
+list(APPEND CMAKE_REQUIRED_LIBRARIES pthread)
 check_symbol_exists(pthread_getname_np pthread.h HAVE_PTHREAD_GETNAME_NP)
 check_symbol_exists(pthread_get_name_np pthread.h HAVE_PTHREAD_GET_NAME_NP)
 
@@ -435,7 +436,7 @@ check_source_compiles(
   C "#include <pthread.h>
   void main() { pthread_set_name_np(0, \"name\"); }" HAVE_PTHREAD_SET_NAME_NP_2
 )
-
+list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES pthread)
 # Check ssl functionality
 list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
 list(APPEND CMAKE_REQUIRED_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})


### PR DESCRIPTION
At least in my ubuntu 20.04(probably in others as well) `check_symbol_exists` seems not to detect the passed funcions to get the thread name. This is fine unless you need the thread name in the logs, like some of the  [autest](https://github.com/apache/trafficserver/blob/a49c20acb710939893c23e50f77608b0815470d5/tests/gold_tests/timeout/quic_poll_timeout.test.py#L68).

With this change, symbols gets detected and the proper macro variable is set and [used](https://github.com/apache/trafficserver/blob/a49c20acb710939893c23e50f77608b0815470d5/src/tsutil/DbgCtl.cc#L345-L353).

master/quic Ci was reporting this to be an issue on the above autest.
