### PR TITLE
Move some logic from CacheVC to Stripe and AggregateWriteBuffer

### DIFF
--- a/include/iocore/cache/AggregateWriteBuffer.h
+++ b/include/iocore/cache/AggregateWriteBuffer.h
@@ -78,7 +78,7 @@ public:
    * @param offset: Byte offset to begin copying at.
    * @param nbytes: Number of bytes to copy.
    */
-  void copy_from(char *dest, int offset, size_t nbytes);
+  void copy_from(char *dest, int offset, size_t nbytes) const;
 
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
   char *get_buffer();

--- a/include/iocore/cache/AggregateWriteBuffer.h
+++ b/include/iocore/cache/AggregateWriteBuffer.h
@@ -69,6 +69,17 @@ public:
    */
   bool flush(int fd, off_t write_pos) const;
 
+  /**
+   * Copy part of the buffer.
+   *
+   * The range of bytes to copy must fit within the written buffer.
+   *
+   * @param dest: The destination buffer.
+   * @param offset: Byte offset to begin copying at.
+   * @param nbytes: Number of bytes to copy.
+   */
+  void copy_from(char *dest, int offset, size_t nbytes);
+
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
   char *get_buffer();
   int get_buffer_pos() const;

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -141,6 +141,7 @@ struct CacheVC : public CacheVConnection {
 
   int handleReadDone(int event, Event *e);
   int handleRead(int event, Event *e);
+  bool check_ram_cache();
   int do_read_call(CacheKey *akey);
   int handleWrite(int event, Event *e);
   int handleWriteLock(int event, Event *e);

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -141,9 +141,9 @@ struct CacheVC : public CacheVConnection {
 
   int handleReadDone(int event, Event *e);
   int handleRead(int event, Event *e);
-  bool check_ram_cache();
-  bool check_last_open_read_call();
-  bool check_aggregation_buffer();
+  bool load_from_ram_cache();
+  bool load_from_last_open_read_call();
+  bool load_from_aggregation_buffer();
   int do_read_call(CacheKey *akey);
   int handleWrite(int event, Event *e);
   int handleWriteLock(int event, Event *e);

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -142,6 +142,7 @@ struct CacheVC : public CacheVConnection {
   int handleReadDone(int event, Event *e);
   int handleRead(int event, Event *e);
   bool check_ram_cache();
+  bool check_last_open_read_call();
   int do_read_call(CacheKey *akey);
   int handleWrite(int event, Event *e);
   int handleWriteLock(int event, Event *e);

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -143,6 +143,7 @@ struct CacheVC : public CacheVConnection {
   int handleRead(int event, Event *e);
   bool check_ram_cache();
   bool check_last_open_read_call();
+  bool check_aggregation_buffer();
   int do_read_call(CacheKey *akey);
   int handleWrite(int event, Event *e);
   int handleWriteLock(int event, Event *e);

--- a/src/iocore/cache/AggregateWriteBuffer.cc
+++ b/src/iocore/cache/AggregateWriteBuffer.cc
@@ -42,7 +42,7 @@ AggregateWriteBuffer::flush(int fd, off_t write_pos) const
 }
 
 void
-AggregateWriteBuffer::copy_from(char *dest, int offset, size_t nbytes)
+AggregateWriteBuffer::copy_from(char *dest, int offset, size_t nbytes) const
 {
   ink_assert((offset + nbytes) <= (unsigned)this->_buffer_pos);
   memcpy(dest, this->_buffer + offset, nbytes);

--- a/src/iocore/cache/AggregateWriteBuffer.cc
+++ b/src/iocore/cache/AggregateWriteBuffer.cc
@@ -28,6 +28,8 @@
 #include "tscore/ink_assert.h"
 #include "tscore/ink_platform.h"
 
+#include <cstring>
+
 bool
 AggregateWriteBuffer::flush(int fd, off_t write_pos) const
 {
@@ -37,4 +39,11 @@ AggregateWriteBuffer::flush(int fd, off_t write_pos) const
     return false;
   }
   return true;
+}
+
+void
+AggregateWriteBuffer::copy_from(char *dest, int offset, size_t nbytes)
+{
+  ink_assert((offset + nbytes) <= (unsigned)this->_buffer_pos);
+  memcpy(dest, this->_buffer + offset, nbytes);
 }

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -549,7 +549,7 @@ CacheVC::load_from_aggregation_buffer()
   char *doc = this->buf->data();
   [[maybe_unused]] bool success = this->stripe->copy_from_aggregate_write_buffer(doc, dir, this->io.aiocb.aio_nbytes);
   // We already confirmed that the copy was valid, so it should not fail.
-  assert(success);
+  ink_assert(success);
   return true;
 }
 

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -545,12 +545,11 @@ CacheVC::check_aggregation_buffer()
     return false;
   }
 
-  this->buf      = new_IOBufferData(iobuffer_size_to_index(this->io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-  int agg_offset = this->stripe->vol_offset(&this->dir) - this->stripe->header->write_pos;
-  ink_assert((agg_offset + this->io.aiocb.aio_nbytes) <= (unsigned)this->stripe->get_agg_buf_pos());
+  this->buf = new_IOBufferData(iobuffer_size_to_index(this->io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
   char *doc = this->buf->data();
-  char *agg = this->stripe->get_agg_buffer() + agg_offset;
-  memcpy(doc, agg, this->io.aiocb.aio_nbytes);
+  [[maybe_unused]] bool success = this->stripe->copy_from_aggregate_write_buffer(doc, dir, this->io.aiocb.aio_nbytes);
+  // We already confirmed that the copy was valid, so it should not fail.
+  assert(success);
   return true;
 }
 

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -541,16 +541,17 @@ CacheVC::check_last_open_read_call()
 bool
 CacheVC::check_aggregation_buffer()
 {
-  if (dir_agg_buf_valid(this->stripe, &this->dir)) {
-    int agg_offset = this->stripe->vol_offset(&this->dir) - this->stripe->header->write_pos;
-    this->buf      = new_IOBufferData(iobuffer_size_to_index(this->io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
-    ink_assert((agg_offset + this->io.aiocb.aio_nbytes) <= (unsigned)this->stripe->get_agg_buf_pos());
-    char *doc = this->buf->data();
-    char *agg = this->stripe->get_agg_buffer() + agg_offset;
-    memcpy(doc, agg, this->io.aiocb.aio_nbytes);
-    return true;
+  if (!dir_agg_buf_valid(this->stripe, &this->dir)) {
+    return false;
   }
-  return false;
+
+  int agg_offset = this->stripe->vol_offset(&this->dir) - this->stripe->header->write_pos;
+  this->buf      = new_IOBufferData(iobuffer_size_to_index(this->io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
+  ink_assert((agg_offset + this->io.aiocb.aio_nbytes) <= (unsigned)this->stripe->get_agg_buf_pos());
+  char *doc = this->buf->data();
+  char *agg = this->stripe->get_agg_buffer() + agg_offset;
+  memcpy(doc, agg, this->io.aiocb.aio_nbytes);
+  return true;
 }
 
 int

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -545,8 +545,8 @@ CacheVC::check_aggregation_buffer()
     return false;
   }
 
-  int agg_offset = this->stripe->vol_offset(&this->dir) - this->stripe->header->write_pos;
   this->buf      = new_IOBufferData(iobuffer_size_to_index(this->io.aiocb.aio_nbytes, MAX_BUFFER_SIZE_INDEX), MEMALIGNED);
+  int agg_offset = this->stripe->vol_offset(&this->dir) - this->stripe->header->write_pos;
   ink_assert((agg_offset + this->io.aiocb.aio_nbytes) <= (unsigned)this->stripe->get_agg_buf_pos());
   char *doc = this->buf->data();
   char *agg = this->stripe->get_agg_buffer() + agg_offset;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -277,7 +277,6 @@ public:
   }
 
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
-  char *get_agg_buffer();
   int get_agg_buf_pos() const;
   int get_agg_todo_size() const;
 
@@ -300,6 +299,20 @@ public:
    */
   bool add_writer(CacheVC *vc);
   bool flush_aggregate_write_buffer();
+
+  /**
+   * Retrieve a document from the aggregate write buffer.
+   *
+   * This is used to speed up reads by copying from the in-memory write buffer
+   * instead of reading from disk. If the document is not in the write buffer,
+   * nothing will be copied.
+   *
+   * @param dir: The directory entry for the desired document.
+   * @param dest: The destination buffer where the document will be copied to.
+   * @param nbytes: The size of the document (number of bytes to copy).
+   * @return Returns true if the document was copied, false otherwise.
+   */
+  bool copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes);
 
 private:
   void _clear_init();
@@ -583,12 +596,6 @@ inline Queue<CacheVC, Continuation::Link_link> &
 Stripe::get_pending_writers()
 {
   return this->_write_buffer.get_pending_writers();
-}
-
-inline char *
-Stripe::get_agg_buffer()
-{
-  return this->_write_buffer.get_buffer();
 }
 
 inline int

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -312,7 +312,7 @@ public:
    * @param nbytes: The size of the document (number of bytes to copy).
    * @return Returns true if the document was copied, false otherwise.
    */
-  bool copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes);
+  bool copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes) const;
 
 private:
   void _clear_init();

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -974,8 +974,6 @@ Stripe::copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes)
   }
 
   int agg_offset = this->vol_offset(&dir) - this->header->write_pos;
-  // Assert number of bytes to copy does not overflow the buffer.
-  ink_assert((agg_offset + nbytes) <= (unsigned)this->_write_buffer.get_buffer_pos());
-  memcpy(dest, this->_write_buffer.get_buffer() + agg_offset, nbytes);
+  this->_write_buffer.copy_from(dest, agg_offset, nbytes);
   return true;
 }

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -967,7 +967,7 @@ Stripe::flush_aggregate_write_buffer()
 }
 
 bool
-Stripe::copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes)
+Stripe::copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes) const
 {
   if (!dir_agg_buf_valid(this, &dir)) {
     return false;


### PR DESCRIPTION
 This breaks up some of `handleRead` into smaller methods and moves the logic for copying out of the aggregate write buffer to the classes responsible for that buffer.

There was a check to make sure that data was only copied from the aggregate write buffer if the requested data was available. I left the old check because it avoids allocating a new buffer if the data is unavailable, and I also duplicated it in `Stripe::copy_from_aggregate_write_buffer` for safety. I thought it would be better to have it in and take it out if it negatively impacts performance than not to have it and find out it would have been useful. I have not benchmarked this.

The order of the parameters of `Stripe::copy_from_aggregate_write_buffer` and `AggregateWriteBuffer::copy_from` was chosen to reflect the order of the `memcpy` parameters. This does not mean I like the way `memcpy` chose to do it, I just thought it might help consistency. :)

This is part of a chain of PRs to remove all the getters I added to `Stripe`, in order to encapsulate the aggregate write buffer properly. This PR removes `Stripe::get_agg_buffer`.