### PR TITLE
Clarify cache_config_agg_write_backlog

### DIFF
--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -289,9 +289,9 @@ public:
    *   - Adding a Doc to the virtual connection header would exceed the
    *       maximum fragment size.
    *   - vc->f.readers is not set (this virtual connection is not an evacuator),
-   *       the internal aggregation buffer is full, the writes waiting to be
-   *       aggregated exceed the maximum backlog, and the virtual connection
-   *       has a non-zero write length.
+   *       is full, the writes waiting to be aggregated exceed the maximum
+   *       backlog plus the space in the aggregatation buffer, and the virtual
+   *       connection has a non-zero write length.
    *
    * @param vc: The virtual connection.
    * @return: Returns true if the operation was successfull, otherwise false.

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -289,8 +289,9 @@ public:
    *   - Adding a Doc to the virtual connection header would exceed the
    *       maximum fragment size.
    *   - vc->f.readers is not set (this virtual connection is not an evacuator),
-   *       the writes waiting to be aggregated exceed the maximum backlog,
-   *       and the virtual connection has a non-zero write length.
+   *       the internal aggregation buffer is full, the writes waiting to be
+   *       aggregated exceed the maximum backlog, and the virtual connection
+   *       has a non-zero write length.
    *
    * @param vc: The virtual connection.
    * @return: Returns true if the operation was successfull, otherwise false.

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -936,8 +936,7 @@ Stripe::add_writer(CacheVC *vc)
   this->_write_buffer.add_bytes_pending_aggregation(vc->agg_len);
   bool agg_error =
     (vc->agg_len > AGG_SIZE || vc->header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
-     (!vc->f.readers && (this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog + AGG_SIZE) &&
-      vc->write_len));
+     (!vc->f.readers && (this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog) && vc->write_len));
 #ifdef CACHE_AGG_FAIL_RATE
   agg_error = agg_error || ((uint32_t)vc->mutex->thread_holding->generator.random() < (uint32_t)(UINT_MAX * CACHE_AGG_FAIL_RATE));
 #endif

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -934,6 +934,15 @@ Stripe::add_writer(CacheVC *vc)
 {
   ink_assert(vc);
   this->_write_buffer.add_bytes_pending_aggregation(vc->agg_len);
+  // [jv] An extra AGG_SIZE is added to the backlog here, but not in
+  //  open_write, at the time I'm writing this comment. I venture to
+  //  guess that because the stripe lock may be released between
+  //  open_write and add_writer (I have checked this), the number of
+  //  bytes pending aggregation lags and is inaccurate. Therefore the
+  //  check in open_write is too permissive, and once we get to add_writer
+  //  and update our bytes pending, we may discover we have more backlog
+  //  than we thought we did. The solution to the problem was to permit
+  //  an aggregation buffer extra of backlog here. That's my analysis.
   bool agg_error =
     (vc->agg_len > AGG_SIZE || vc->header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
      (!vc->f.readers && (this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog + AGG_SIZE) &&

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -934,15 +934,15 @@ Stripe::add_writer(CacheVC *vc)
 {
   ink_assert(vc);
   this->_write_buffer.add_bytes_pending_aggregation(vc->agg_len);
-  // [jv] An extra AGG_SIZE is added to the backlog here, but not in
-  //  open_write, at the time I'm writing this comment. I venture to
-  //  guess that because the stripe lock may be released between
-  //  open_write and add_writer (I have checked this), the number of
-  //  bytes pending aggregation lags and is inaccurate. Therefore the
-  //  check in open_write is too permissive, and once we get to add_writer
-  //  and update our bytes pending, we may discover we have more backlog
-  //  than we thought we did. The solution to the problem was to permit
-  //  an aggregation buffer extra of backlog here. That's my analysis.
+  // An extra AGG_SIZE is added to the backlog here, but not in
+  // open_write, at the time I'm writing this comment. I venture to
+  // guess that because the stripe lock may be released between
+  // open_write and add_writer (I have checked this), the number of
+  // bytes pending aggregation lags and is inaccurate. Therefore the
+  // check in open_write is too permissive, and once we get to add_writer
+  // and update our bytes pending, we may discover we have more backlog
+  // than we thought we did. The solution to the problem was to permit
+  // an aggregation buffer extra of backlog here. That's my analysis.
   bool agg_error =
     (vc->agg_len > AGG_SIZE || vc->header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
      (!vc->f.readers && (this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog + AGG_SIZE) &&

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -936,7 +936,8 @@ Stripe::add_writer(CacheVC *vc)
   this->_write_buffer.add_bytes_pending_aggregation(vc->agg_len);
   bool agg_error =
     (vc->agg_len > AGG_SIZE || vc->header_len + sizeof(Doc) > MAX_FRAG_SIZE ||
-     (!vc->f.readers && (this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog) && vc->write_len));
+     (!vc->f.readers && (this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog + AGG_SIZE) &&
+      vc->write_len));
 #ifdef CACHE_AGG_FAIL_RATE
   agg_error = agg_error || ((uint32_t)vc->mutex->thread_holding->generator.random() < (uint32_t)(UINT_MAX * CACHE_AGG_FAIL_RATE));
 #endif


### PR DESCRIPTION
The global `cache_config_agg_write_backlog` is defined as `2 * AGG_SIZE`. There was an extra `+ AGG_SIZE` in `add_writer` with no comment; this goes back all the way to the original first GitHub commit. This could be a quick hack someone put in to fix an issue. If we need to avoid changing this, I'd like to add a comment explaining what I learned about it. There is another place in the code where `cache_config_agg_write_backlog` is used, in `Stripe::open_write`, and in that place there is no extra `+ AGG_SIZE`. Maybe the `+ AGG_SIZE` is missing in the other place and should be added, but in that case, I think it would make more sense to just define `cache_config_agg_write_backlog` as `3 * AGG_SIZE`. This is why I think it was intended to be used without the extra `+ AGG_SIZE`.