### PR TITLE
Restore IntrusiveHashMap insert code from tscore (ats92)

### DIFF
--- a/lib/swoc/include/swoc/IntrusiveHashMap.h
+++ b/lib/swoc/include/swoc/IntrusiveHashMap.h
@@ -514,15 +514,6 @@ IntrusiveHashMap<H>::insert(value_type *v) {
     if (spot != bucket->_v) {
       mixed_p = true; // found some other key, it's going to be mixed.
     }
-    if (spot != limit) {
-      // If an equal key was found, walk past those to insert at the upper end of the range.
-      do {
-        spot = H::next_ptr(spot);
-      } while (spot != limit && H::equal(key, H::key_of(spot)));
-      if (spot != limit) { // something not equal past last equivalent, it's going to be mixed.
-        mixed_p = true;
-      }
-    }
 
     _list.insert_before(spot, v);
     if (spot == bucket->_v) { // added before the bucket start, update the start.


### PR DESCRIPTION
This removes an extra snippet of code added with the libswoc implementation of IntrusiveHashMap which causes a noticeable performance hit (expansion of the critical section) when inserting items into the session pool.  Specific test case used saw on average an increase of about 6x in the HttpSessionManager critical sections.

The change introduced with libswoc (not documented in any checkin) appends the new item to the bucket list, which was not done with the tscore (ats92) version.