### PR TITLE
traffic_top: avoid abort when rpc node is not available.

### DIFF
--- a/src/traffic_top/stats.h
+++ b/src/traffic_top/stats.h
@@ -278,7 +278,7 @@ public:
     lookup_table.insert(make_pair("client_dyn_ka", LookupItem("Dynamic KA", "ka_total", "ka_count", 3)));
   }
 
-  void
+  bool
   getStats()
   {
     if (_url == "") {
@@ -306,7 +306,7 @@ public:
       // query the rpc node.
       if (auto const &error = fetch_and_fill_stats(request, _stats); !error.empty()) {
         fprintf(stderr, "Error getting stats from the RPC node:\n%s", error.c_str());
-        abort();
+        return false;
       }
       _old_time  = _now;
       _now       = now;
@@ -361,6 +361,7 @@ public:
       }
 #endif
     }
+    return true;
   }
 
   int64_t

--- a/src/traffic_top/traffic_top.cc
+++ b/src/traffic_top/traffic_top.cc
@@ -414,7 +414,10 @@ main(int argc, const char **argv)
   }
 
   Stats stats(url);
-  stats.getStats();
+  if (!stats.getStats()) {
+    return 2;
+  }
+
   const string &host = stats.getHost();
 
   initscr();
@@ -482,7 +485,9 @@ main(int argc, const char **argv)
     case 'a':
       absolute = stats.toggleAbsolute();
     }
-    stats.getStats();
+    if (!stats.getStats()) {
+      goto quit;
+    }
     clear();
   }
 


### PR DESCRIPTION
This way, `traffic_top` will just display the error when the node is not avialable.