### PR TITLE
Unify Dynamic Table implementation

### DIFF
--- a/include/proxy/http2/HPACK.h
+++ b/include/proxy/http2/HPACK.h
@@ -107,39 +107,6 @@ private:
   MIMEHdrImpl *_mh;
 };
 
-// [RFC 7541] 2.3.2. Dynamic Table
-class HpackDynamicTable
-{
-public:
-  explicit HpackDynamicTable(uint32_t size);
-  ~HpackDynamicTable();
-
-  // noncopyable
-  HpackDynamicTable(HpackDynamicTable &)                  = delete;
-  HpackDynamicTable &operator=(const HpackDynamicTable &) = delete;
-
-  const MIMEField *get_header_field(uint32_t index) const;
-  void add_header_field(const HpackHeaderField &header);
-
-  HpackLookupResult lookup(const HpackHeaderField &header) const;
-  uint32_t maximum_size() const;
-  uint32_t size() const;
-  void update_maximum_size(uint32_t new_size);
-
-  uint32_t length() const;
-
-private:
-  void _evict_overflowed_entries();
-  void _mime_hdr_gc();
-
-  uint32_t _current_size = 0;
-  uint32_t _maximum_size = 0;
-
-  MIMEHdr *_mhdr     = nullptr;
-  MIMEHdr *_mhdr_old = nullptr;
-  std::deque<MIMEField *> _headers;
-};
-
 // [RFC 7541] 2.3. Indexing Table
 class HpackIndexingTable
 {
@@ -160,7 +127,7 @@ public:
   void update_maximum_size(uint32_t new_size);
 
 private:
-  HpackDynamicTable _dynamic_table;
+  XpackDynamicTable _dynamic_table;
 };
 
 // Low level interfaces

--- a/src/proxy/hdrs/CMakeLists.txt
+++ b/src/proxy/hdrs/CMakeLists.txt
@@ -54,7 +54,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_proxy_hdrs PRIVATE ts::hdrs ts::tscore ts::inkevent catch2::catch2)
   add_test(NAME test_proxy_hdrs COMMAND test_proxy_hdrs)
 
-  add_executable(test_proxy_hdrs_xpack XPACK.cc HuffmanCodec.cc unit_tests/test_XPACK.cc)
+  add_executable(test_proxy_hdrs_xpack unit_tests/test_XPACK.cc)
   target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::hdrs ts::tscore ts::tsutil libswoc catch2::catch2)
   add_test(NAME test_proxy_hdrs_xpack COMMAND test_proxy_hdrs_xpack)
 endif()

--- a/src/proxy/hdrs/CMakeLists.txt
+++ b/src/proxy/hdrs/CMakeLists.txt
@@ -55,6 +55,6 @@ if(BUILD_TESTING)
   add_test(NAME test_proxy_hdrs COMMAND test_proxy_hdrs)
 
   add_executable(test_proxy_hdrs_xpack XPACK.cc HuffmanCodec.cc unit_tests/test_XPACK.cc)
-  target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::tscore ts::tsutil libswoc catch2::catch2)
+  target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::hdrs ts::tscore ts::tsutil libswoc catch2::catch2)
   add_test(NAME test_proxy_hdrs_xpack COMMAND test_proxy_hdrs_xpack)
 endif()

--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -471,8 +471,8 @@ XpackDynamicTable::_make_space(uint64_t required_size)
   uint32_t freed = 0;
   uint32_t tail  = (this->_entries_tail + 1) % this->_max_entries;
 
-  while (required_size > this->_available + freed) {
-    if (this->is_empty()) {
+  while (required_size > freed) {
+    if (this->_entries_head < tail) {
       break;
     }
     if (this->_entries[tail].ref_count) {

--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -369,18 +369,22 @@ XpackDynamicTable::insert_entry(const std::string_view name, const std::string_v
 const XpackLookupResult
 XpackDynamicTable::duplicate_entry(uint32_t current_index)
 {
-  const char *name;
-  size_t name_len;
-  const char *value;
-  size_t value_len;
+  const char *name  = nullptr;
+  size_t name_len   = 0;
+  const char *value = nullptr;
+  size_t value_len  = 0;
   char *duped_name;
   char *duped_value;
 
-  this->lookup(current_index, &name, &name_len, &value, &value_len);
+  XpackLookupResult result = this->lookup(current_index, &name, &name_len, &value, &value_len);
+  if (result.match_type != XpackLookupResult::MatchType::EXACT) {
+    return result;
+  }
+
   // We need to dup name and value to avoid memcpy-param-overlap
-  duped_name                     = ats_strndup(name, name_len);
-  duped_value                    = ats_strndup(value, value_len);
-  const XpackLookupResult result = this->insert_entry(duped_name, name_len, duped_value, value_len);
+  duped_name  = ats_strndup(name, name_len);
+  duped_value = ats_strndup(value, value_len);
+  result      = this->insert_entry(duped_name, name_len, duped_value, value_len);
   ats_free(duped_name);
   ats_free(duped_value);
 

--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -335,7 +335,7 @@ XpackDynamicTable::insert_entry(const char *name, size_t name_len, const char *v
   // Make enough space to insert a new entry
   uint64_t required_size = static_cast<uint64_t>(name_len) + static_cast<uint64_t>(value_len) + ADDITIONAL_32_BYTES;
   if (required_size > this->_available) {
-    if (!this->_make_space(required_size)) {
+    if (!this->_make_space(required_size - this->_available)) {
       // We can't insert a new entry because some stream(s) refer an entry that need to be evicted or the header is too big to
       // store. This is fine with HPACK, but not with QPACK.
       return {UINT32_C(0), XpackLookupResult::MatchType::NONE};

--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -245,7 +245,7 @@ XpackDynamicTable::lookup(uint32_t index, const char **name, size_t *name_len, c
     return {0, XpackLookupResult::MatchType::NONE};
   }
 
-  if (index < this->_entries[this->_entries_tail + 1].index) {
+  if (index < this->_entries[(this->_entries_tail + 1) % this->_max_entries].index) {
     // The index is invalid
     return {0, XpackLookupResult::MatchType::NONE};
   }

--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -230,7 +230,7 @@ XpackDynamicTable::~XpackDynamicTable()
   }
 }
 
-inline const XpackLookupResult
+const XpackLookupResult
 XpackDynamicTable::lookup(uint32_t index, const char **name, size_t *name_len, const char **value, size_t *value_len) const
 {
   XPACKDebug("Lookup entry: abs_index=%u", index);

--- a/src/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/src/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -125,4 +125,186 @@ TEST_CASE("XPACK_String", "[xpack]")
       REQUIRE(memcmp(actual, i.raw_string, actual_len) == 0);
     }
   }
+
+  SECTION("Dynamic Table")
+  {
+    constexpr uint16_t MAX_SIZE = 128;
+    XpackDynamicTable dt(MAX_SIZE);
+    XpackLookupResult result;
+    const char *name  = nullptr;
+    size_t name_len   = 0;
+    const char *value = nullptr;
+    size_t value_len  = 0;
+
+    // Check the initial state
+    REQUIRE(dt.size() == 0);
+    REQUIRE(dt.maximum_size() == MAX_SIZE);
+    REQUIRE(dt.is_empty());
+    REQUIRE(dt.count() == 0);
+    result = dt.lookup(0, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(MAX_SIZE - 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(MAX_SIZE, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(MAX_SIZE + 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+
+    // Insdert one entry
+    dt.insert_entry("name1", "value1");
+    REQUIRE(dt.size() == strlen("name1") + strlen("value1") + 32);
+    REQUIRE(dt.maximum_size() == MAX_SIZE);
+    REQUIRE(dt.count() == 1);
+    REQUIRE(dt.largest_index() == 0);
+    result = dt.lookup(0, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name1"));
+    REQUIRE(memcmp(name, "name1", name_len) == 0);
+    REQUIRE(value_len == strlen("value1"));
+    REQUIRE(memcmp(value, "value1", value_len) == 0);
+    result = dt.lookup(dt.largest_index() + 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+
+    result = dt.lookup(MAX_SIZE - 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(MAX_SIZE, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(MAX_SIZE + 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+
+    // Insdert one more entry
+    dt.insert_entry("name2", "value2");
+    REQUIRE(dt.size() == strlen("name1") + strlen("value1") + 32 + strlen("name2") + strlen("value2") + 32);
+    REQUIRE(dt.maximum_size() == MAX_SIZE);
+    REQUIRE(dt.count() == 2);
+    REQUIRE(dt.largest_index() == 1);
+    result = dt.lookup(0, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name1"));
+    REQUIRE(memcmp(name, "name1", name_len) == 0);
+    REQUIRE(value_len == strlen("value1"));
+    REQUIRE(memcmp(value, "value1", value_len) == 0);
+    result = dt.lookup(1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name2"));
+    REQUIRE(memcmp(name, "name2", name_len) == 0);
+    REQUIRE(value_len == strlen("value2"));
+    REQUIRE(memcmp(value, "value2", value_len) == 0);
+    result = dt.lookup(dt.largest_index() + 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup_relative(0, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name2"));
+    REQUIRE(memcmp(name, "name2", name_len) == 0);
+    REQUIRE(value_len == strlen("value2"));
+    REQUIRE(memcmp(value, "value2", value_len) == 0);
+    result = dt.lookup_relative(1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name1"));
+    REQUIRE(memcmp(name, "name1", name_len) == 0);
+    REQUIRE(value_len == strlen("value1"));
+    REQUIRE(memcmp(value, "value1", value_len) == 0);
+    result = dt.lookup(MAX_SIZE - 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(MAX_SIZE, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(MAX_SIZE + 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+
+    // Insdert one more entry (this should evict the first entry)
+    dt.insert_entry("name3", "value3");
+    REQUIRE(dt.size() == strlen("name2") + strlen("value2") + 32 + strlen("name3") + strlen("value3") + 32);
+    REQUIRE(dt.maximum_size() == MAX_SIZE);
+    REQUIRE(dt.count() == 2);
+    REQUIRE(dt.largest_index() == 2);
+    result = dt.lookup(0, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name2"));
+    REQUIRE(memcmp(name, "name2", name_len) == 0);
+    REQUIRE(value_len == strlen("value2"));
+    REQUIRE(memcmp(value, "value2", value_len) == 0);
+    result = dt.lookup(2, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name3"));
+    REQUIRE(memcmp(name, "name3", name_len) == 0);
+    REQUIRE(value_len == strlen("value3"));
+    REQUIRE(memcmp(value, "value3", value_len) == 0);
+    result = dt.lookup(dt.largest_index() + 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup_relative(0, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name3"));
+    REQUIRE(memcmp(name, "name3", name_len) == 0);
+    REQUIRE(value_len == strlen("value3"));
+    REQUIRE(memcmp(value, "value3", value_len) == 0);
+    result = dt.lookup_relative(1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name2"));
+    REQUIRE(memcmp(name, "name2", name_len) == 0);
+    REQUIRE(value_len == strlen("value2"));
+    REQUIRE(memcmp(value, "value2", value_len) == 0);
+
+    // Insdert one more entry (this should evict all existing entries)
+    dt.insert_entry("name4-1234567890123456789012345", "value4-9876543210987654321098765");
+    REQUIRE(dt.size() == strlen("name4-1234567890123456789012345") + strlen("value4-9876543210987654321098765") + 32);
+    REQUIRE(dt.maximum_size() == MAX_SIZE);
+    REQUIRE(dt.count() == 1);
+    REQUIRE(dt.largest_index() == 3);
+    result = dt.lookup(3, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name4-1234567890123456789012345"));
+    REQUIRE(memcmp(name, "name4-1234567890123456789012345", name_len) == 0);
+    REQUIRE(value_len == strlen("value4-9876543210987654321098765"));
+    REQUIRE(memcmp(value, "value4-9876543210987654321098765", value_len) == 0);
+    result = dt.lookup(dt.largest_index() - 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(dt.largest_index(), &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    result = dt.lookup(dt.largest_index() + 1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+
+    // Update the maximum size (this should not evict anything)
+    size_t current_size = dt.size();
+    dt.update_maximum_size(current_size);
+    REQUIRE(dt.size() == current_size);
+    REQUIRE(dt.maximum_size() == current_size);
+    REQUIRE(dt.count() == 1);
+    REQUIRE(dt.largest_index() == 3);
+    result = dt.lookup(3, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::EXACT);
+    REQUIRE(name_len == strlen("name4-1234567890123456789012345"));
+    REQUIRE(memcmp(name, "name4-1234567890123456789012345", name_len) == 0);
+    REQUIRE(value_len == strlen("value4-9876543210987654321098765"));
+    REQUIRE(memcmp(value, "value4-9876543210987654321098765", value_len) == 0);
+
+    // Update the maximum size (this should evict everything)
+    dt.update_maximum_size(0);
+    REQUIRE(dt.size() == 0);
+    REQUIRE(dt.maximum_size() == 0);
+    REQUIRE(dt.is_empty());
+    REQUIRE(dt.count() == 0);
+    result = dt.lookup(1, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+    result = dt.lookup(2, &name, &name_len, &value, &value_len);
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+
+    // Reset the maximum size
+    dt.update_maximum_size(4096);
+    REQUIRE(dt.size() == 0);
+    REQUIRE(dt.maximum_size() == 4096);
+    REQUIRE(dt.is_empty());
+    REQUIRE(dt.count() == 0);
+
+    // Insert an oversided item
+    dt.insert_entry("name1", "value1");              // This should be evicted
+    dt.insert_entry("", UINT32_MAX, "", UINT32_MAX); // This should not even cause a buffer over run
+    REQUIRE(dt.size() == 0);
+    REQUIRE(dt.maximum_size() == 4096);
+    REQUIRE(dt.is_empty());
+    REQUIRE(dt.count() == 0);
+  }
 }

--- a/src/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/src/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -152,7 +152,7 @@ TEST_CASE("XPACK_String", "[xpack]")
     result = dt.lookup(MAX_SIZE + 1, &name, &name_len, &value, &value_len);
     REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
 
-    // Insdert one entry
+    // Insert one entry
     dt.insert_entry("name1", "value1");
     REQUIRE(dt.size() == strlen("name1") + strlen("value1") + 32);
     REQUIRE(dt.maximum_size() == MAX_SIZE);
@@ -174,7 +174,7 @@ TEST_CASE("XPACK_String", "[xpack]")
     result = dt.lookup(MAX_SIZE + 1, &name, &name_len, &value, &value_len);
     REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
 
-    // Insdert one more entry
+    // Insert one more entry
     dt.insert_entry("name2", "value2");
     REQUIRE(dt.size() == strlen("name1") + strlen("value1") + 32 + strlen("name2") + strlen("value2") + 32);
     REQUIRE(dt.maximum_size() == MAX_SIZE);
@@ -213,7 +213,7 @@ TEST_CASE("XPACK_String", "[xpack]")
     result = dt.lookup(MAX_SIZE + 1, &name, &name_len, &value, &value_len);
     REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
 
-    // Insdert one more entry (this should evict the first entry)
+    // Insert one more entry (this should evict the first entry)
     dt.insert_entry("name3", "value3");
     REQUIRE(dt.size() == strlen("name2") + strlen("value2") + 32 + strlen("name3") + strlen("value3") + 32);
     REQUIRE(dt.maximum_size() == MAX_SIZE);
@@ -248,7 +248,7 @@ TEST_CASE("XPACK_String", "[xpack]")
     REQUIRE(value_len == strlen("value2"));
     REQUIRE(memcmp(value, "value2", value_len) == 0);
 
-    // Insdert one more entry (this should evict all existing entries)
+    // Insert one more entry (this should evict all existing entries)
     dt.insert_entry("name4-1234567890123456789012345", "value4-9876543210987654321098765");
     REQUIRE(dt.size() == strlen("name4-1234567890123456789012345") + strlen("value4-9876543210987654321098765") + 32);
     REQUIRE(dt.maximum_size() == MAX_SIZE);

--- a/src/proxy/http2/HPACK.cc
+++ b/src/proxy/http2/HPACK.cc
@@ -382,7 +382,7 @@ HpackIndexingTable::size() const
 void
 HpackIndexingTable::update_maximum_size(uint32_t new_size)
 {
-  _dynamic_table.update_maximum_size(static_cast<uint16_t>(new_size));
+  _dynamic_table.update_maximum_size(new_size);
 }
 
 //

--- a/src/proxy/http2/HPACK.cc
+++ b/src/proxy/http2/HPACK.cc
@@ -338,14 +338,16 @@ HpackIndexingTable::get_header_field(uint32_t index, MIMEFieldWrapper &field) co
     // static table
     field.name_set(STATIC_TABLE[index].name.data(), STATIC_TABLE[index].name.size());
     field.value_set(STATIC_TABLE[index].value.data(), STATIC_TABLE[index].value.size());
-  } else if (index < TS_HPACK_STATIC_TABLE_ENTRY_NUM + _dynamic_table.largest_index()) {
+  } else if (index < (TS_HPACK_STATIC_TABLE_ENTRY_NUM + _dynamic_table.count())) {
     // dynamic table
     size_t name_len, value_len;
     const char *name;
     const char *value;
 
     auto result = _dynamic_table.lookup_relative(index - TS_HPACK_STATIC_TABLE_ENTRY_NUM, &name, &name_len, &value, &value_len);
-    ink_assert(result.match_type == XpackLookupResult::MatchType::EXACT);
+    if (result.match_type != XpackLookupResult::MatchType::EXACT) {
+      return HPACK_ERROR_COMPRESSION_ERROR;
+    }
 
     field.name_set(name, name_len);
     field.value_set(value, value_len);

--- a/src/proxy/http2/HPACK.cc
+++ b/src/proxy/http2/HPACK.cc
@@ -196,21 +196,6 @@ constexpr HpackHeaderField STATIC_TABLE[] = {
 constexpr std::string_view HPACK_HDR_FIELD_COOKIE        = STATIC_TABLE[TS_HPACK_STATIC_TABLE_COOKIE].name;
 constexpr std::string_view HPACK_HDR_FIELD_AUTHORIZATION = STATIC_TABLE[TS_HPACK_STATIC_TABLE_AUTHORIZATION].name;
 
-/**
-  Threshold for total HdrHeap size which used by HPAK Dynamic Table.
-  The HdrHeap is filled by MIMEHdrImpl and MIMEFieldBlockImpl like below.
-  This threshold allow to allocate 3 HdrHeap at maximum.
-
-                     +------------------+-----------------------------+
-   HdrHeap 1 (2048): | MIMEHdrImpl(592) | MIMEFieldBlockImpl(528) x 2 |
-                     +------------------+-----------------------------+--...--+
-   HdrHeap 2 (4096): | MIMEFieldBlockImpl(528) x 7                            |
-                     +------------------------------------------------+--...--+--...--+
-   HdrHeap 3 (8192): | MIMEFieldBlockImpl(528) x 15                                   |
-                     +------------------------------------------------+--...--+--...--+
-*/
-static constexpr uint32_t HPACK_HDR_HEAP_THRESHOLD = sizeof(MIMEHdrImpl) + sizeof(MIMEFieldBlockImpl) * (2 + 7 + 15);
-
 //
 // Local functions
 //
@@ -235,24 +220,6 @@ match(const char *s1, int s1_len, const char *s2, int s2_len)
   }
 
   if (memcmp(s1, s2, s1_len) != 0) {
-    return false;
-  }
-
-  return true;
-}
-
-static inline bool
-match_ignore_case(const char *s1, int s1_len, const char *s2, int s2_len)
-{
-  if (s1_len != s2_len) {
-    return false;
-  }
-
-  if (s1 == s2) {
-    return true;
-  }
-
-  if (strncasecmp(s1, s2, s1_len) != 0) {
     return false;
   }
 
@@ -350,8 +317,10 @@ HpackIndexingTable::lookup(const HpackHeaderField &header) const
   }
 
   // dynamic table
-  if (HpackLookupResult dt_result = this->_dynamic_table.lookup(header); dt_result.match_type == HpackMatch::EXACT) {
-    return dt_result;
+  if (XpackLookupResult dt_result = this->_dynamic_table.lookup_relative(header.name, header.value);
+      dt_result.match_type == XpackLookupResult::MatchType::EXACT) {
+    return {static_cast<uint32_t>(TS_HPACK_STATIC_TABLE_ENTRY_NUM + dt_result.index), HpackIndex::DYNAMIC,
+            static_cast<HpackMatch>(dt_result.match_type)};
   }
 
   return result;
@@ -369,13 +338,14 @@ HpackIndexingTable::get_header_field(uint32_t index, MIMEFieldWrapper &field) co
     // static table
     field.name_set(STATIC_TABLE[index].name.data(), STATIC_TABLE[index].name.size());
     field.value_set(STATIC_TABLE[index].value.data(), STATIC_TABLE[index].value.size());
-  } else if (index < TS_HPACK_STATIC_TABLE_ENTRY_NUM + _dynamic_table.length()) {
+  } else if (index < TS_HPACK_STATIC_TABLE_ENTRY_NUM + _dynamic_table.largest_index()) {
     // dynamic table
-    const MIMEField *m_field = _dynamic_table.get_header_field(index - TS_HPACK_STATIC_TABLE_ENTRY_NUM);
+    size_t name_len, value_len;
+    const char *name;
+    const char *value;
 
-    int name_len, value_len;
-    const char *name  = m_field->name_get(&name_len);
-    const char *value = m_field->value_get(&value_len);
+    auto result = _dynamic_table.lookup_relative(index - TS_HPACK_STATIC_TABLE_ENTRY_NUM, &name, &name_len, &value, &value_len);
+    ink_assert(result.match_type == XpackLookupResult::MatchType::EXACT);
 
     field.name_set(name, name_len);
     field.value_set(value, value_len);
@@ -392,7 +362,7 @@ HpackIndexingTable::get_header_field(uint32_t index, MIMEFieldWrapper &field) co
 void
 HpackIndexingTable::add_header_field(const HpackHeaderField &header)
 {
-  _dynamic_table.add_header_field(header);
+  _dynamic_table.insert_entry(header.name, header.value);
 }
 
 uint32_t
@@ -410,184 +380,7 @@ HpackIndexingTable::size() const
 void
 HpackIndexingTable::update_maximum_size(uint32_t new_size)
 {
-  _dynamic_table.update_maximum_size(new_size);
-}
-
-//
-// HpackDynamicTable
-//
-HpackDynamicTable::HpackDynamicTable(uint32_t size) : _maximum_size(size)
-{
-  _mhdr = new MIMEHdr();
-  _mhdr->create();
-}
-
-HpackDynamicTable::~HpackDynamicTable()
-{
-  this->_headers.clear();
-
-  this->_mhdr->fields_clear();
-  this->_mhdr->destroy();
-  delete this->_mhdr;
-
-  if (this->_mhdr_old != nullptr) {
-    this->_mhdr_old->fields_clear();
-    this->_mhdr_old->destroy();
-    delete this->_mhdr_old;
-  }
-}
-
-const MIMEField *
-HpackDynamicTable::get_header_field(uint32_t index) const
-{
-  return this->_headers.at(index);
-}
-
-void
-HpackDynamicTable::add_header_field(const HpackHeaderField &header)
-{
-  uint32_t header_size = ADDITIONAL_OCTETS + header.name.size() + header.value.size();
-
-  if (header_size > _maximum_size) {
-    // [RFC 7541] 4.4. Entry Eviction When Adding New Entries
-    // It is not an error to attempt to add an entry that is larger than
-    // the maximum size; an attempt to add an entry larger than the entire
-    // table causes the table to be emptied of all existing entries.
-    this->_headers.clear();
-    this->_mhdr->fields_clear();
-
-    if (this->_mhdr_old) {
-      this->_mhdr_old->fields_clear();
-      this->_mhdr_old->destroy();
-      delete this->_mhdr_old;
-      this->_mhdr_old = nullptr;
-    }
-
-    this->_current_size = 0;
-  } else {
-    this->_current_size += header_size;
-    this->_evict_overflowed_entries();
-
-    MIMEField *new_field = this->_mhdr->field_create(header.name.data(), header.name.size());
-    new_field->value_set(this->_mhdr->m_heap, this->_mhdr->m_mime, header.value.data(), header.value.size());
-    this->_mhdr->field_attach(new_field);
-    this->_headers.push_front(new_field);
-  }
-}
-
-HpackLookupResult
-HpackDynamicTable::lookup(const HpackHeaderField &header) const
-{
-  HpackLookupResult result;
-  const unsigned int entry_num = TS_HPACK_STATIC_TABLE_ENTRY_NUM + this->length();
-
-  for (unsigned int index = TS_HPACK_STATIC_TABLE_ENTRY_NUM; index < entry_num; ++index) {
-    const MIMEField *m_field = this->_headers.at(index - TS_HPACK_STATIC_TABLE_ENTRY_NUM);
-    std::string_view name    = m_field->name_get();
-    std::string_view value   = m_field->value_get();
-
-    // Check whether name (and value) are matched
-    if (match_ignore_case(header.name.data(), header.name.length(), name.data(), name.length())) {
-      if (match(header.value.data(), header.value.length(), value.data(), value.length())) {
-        result.index      = index;
-        result.index_type = HpackIndex::DYNAMIC;
-        result.match_type = HpackMatch::EXACT;
-        break;
-      } else if (!result.index) {
-        result.index      = index;
-        result.index_type = HpackIndex::DYNAMIC;
-        result.match_type = HpackMatch::NAME;
-      }
-    }
-  }
-
-  return result;
-}
-
-uint32_t
-HpackDynamicTable::maximum_size() const
-{
-  return _maximum_size;
-}
-
-uint32_t
-HpackDynamicTable::size() const
-{
-  return _current_size;
-}
-
-//
-// [RFC 7541] 4.3. Entry Eviction when Header Table Size Changes
-//
-// Whenever the maximum size for the header table is reduced, entries
-// are evicted from the end of the header table until the size of the
-// header table is less than or equal to the maximum size.
-//
-void
-HpackDynamicTable::update_maximum_size(uint32_t new_size)
-{
-  this->_maximum_size = new_size;
-  this->_evict_overflowed_entries();
-}
-
-uint32_t
-HpackDynamicTable::length() const
-{
-  return this->_headers.size();
-}
-
-void
-HpackDynamicTable::_evict_overflowed_entries()
-{
-  if (this->_current_size <= this->_maximum_size) {
-    // Do nothing
-    return;
-  }
-
-  while (!this->_headers.empty()) {
-    auto h = this->_headers.back();
-    int name_len, value_len;
-    h->name_get(&name_len);
-    h->value_get(&value_len);
-
-    this->_current_size -= ADDITIONAL_OCTETS + name_len + value_len;
-
-    if (this->_mhdr_old && this->_mhdr_old->fields_count() != 0) {
-      this->_mhdr_old->field_delete(h, false);
-    } else {
-      this->_mhdr->field_delete(h, false);
-    }
-
-    this->_headers.pop_back();
-
-    if (this->_current_size <= this->_maximum_size) {
-      break;
-    }
-  }
-
-  this->_mime_hdr_gc();
-}
-
-/**
-   When HdrHeap size of current MIMEHdr exceeds the threshold, allocate new MIMEHdr and HdrHeap.
-   The old MIMEHdr and HdrHeap will be freed, when all MIMEFiled are deleted by HPACK Entry Eviction.
- */
-void
-HpackDynamicTable::_mime_hdr_gc()
-{
-  if (this->_mhdr_old == nullptr) {
-    if (this->_mhdr->m_heap->total_used_size() >= HPACK_HDR_HEAP_THRESHOLD) {
-      this->_mhdr_old = this->_mhdr;
-      this->_mhdr     = new MIMEHdr();
-      this->_mhdr->create();
-    }
-  } else {
-    if (this->_mhdr_old->fields_count() == 0) {
-      this->_mhdr_old->destroy();
-      delete this->_mhdr_old;
-      this->_mhdr_old = nullptr;
-    }
-  }
+  _dynamic_table.update_maximum_size(static_cast<uint16_t>(new_size));
 }
 
 //


### PR DESCRIPTION
This closes #10056.

We have had two Dynamic Table implementations, one for HPACK and the other for QPACK. This PR basically removes the one for HPACK, and move the one for QPACK into `proxy/hdr` so that they can use the same implementation.

While I'm testing it with HPACK, I found a couple of bugs in the new dynamic table implementation and I fixed them (we couldn't find it because QPACK has never worked and we disabled it on the docs server).

The one for HPACK uses HTTPHdr structure under the hood, and it has been troublesome because of the performance and its specialized interface which doesn't suit the Dynamic Table use case.