### PR TITLE
Core implementation of IP categories for ip_allow.yaml

### DIFF
--- a/configs/ip_allow.schema.json
+++ b/configs/ip_allow.schema.json
@@ -22,6 +22,10 @@
       "description": "A range of IP addresses in a single family.",
       "type": "string"
     },
+    "category": {
+      "description": "An IP category representing a set of IP ranges.",
+      "type": "string"
+    },
     "action": {
       "description": "Enforcement action.",
       "type": "string",
@@ -68,6 +72,20 @@
             }
           ]
         },
+        "ip_categories": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/category"
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/category"
+              }
+            }
+          ]
+        },
         "action": {
           "$ref": "#/definitions/action"
         },
@@ -75,7 +93,14 @@
           "$ref": "#/definitions/methods"
         }
       },
-      "required": [ "apply", "ip_addrs", "action" ]
+      "oneOf": [
+        {
+          "required": [ "apply", "ip_addrs", "action" ]
+        },
+        {
+          "required": [ "apply", "ip_categories", "action" ]
+        }
+      ]
     }
   }
 }

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -2090,6 +2090,24 @@ Security
    this value via a :ref:`host_sni_policy<override-host-sni-policy>` attribute.
 
 
+IP Allow
+========
+
+.. ts:cv:: CONFIG proxy.config.cache.ip_allow.filename STRING ip_allow.yaml
+   :reloadable:
+
+   Set the file path for the IP allow configuration file. For details of the use
+   of this file, see :file:`ip_allow.yaml`. If this is a relative path, |TS|
+   loads it relative to the ``SYSCONFDIR`` directory.
+
+.. ts:cv:: CONFIG proxy.config.cache.ip_categories.filename STRING NULL
+   :reloadable:
+
+   Set the file path for the IP allow categories definition file. For details of
+   the use of this file, see :file:`ip_allow.yaml`. If this is a relative path,
+   |TS| loads it relative to the ``SYSCONFDIR`` directory.
+
+
 Cache Control
 =============
 

--- a/doc/admin-guide/files/remap.config.en.rst
+++ b/doc/admin-guide/files/remap.config.en.rst
@@ -428,6 +428,13 @@ This will pass "1" and "2" to plugin1.so and "3" to plugin2.so
 
 .. _remap-config-named-filters:
 
+NextHop Selection Strategies
+============================
+
+You may configure Nexthop or Parent hierarchical caching rules by remap using the
+**@strategy** tag.  See :doc:`../configuration/hierarchical-caching.en` and :doc:`strategies.yaml.en`
+for configuration details and examples.
+
 Acl Filters
 ===========
 
@@ -455,10 +462,13 @@ Examples
 
     map http://foo.example.com/  http://foo.example.com/ @action=allow @src_ip=127.0.0.1 @method=post @method=get @method=head
 
+    map http://foo.example.com/  http://foo.example.com/ @action=allow @src_ip_category=ACME_INTERNAL @method=post @method=get @method=head
+
 Note that these Acl filters will return a 403 response if the resource is restricted.
 
 The difference between ``@src_ip`` and ``@in_ip`` is that the ``@src_ip`` is the client
 ip and the ``in_ip`` is the ip address the client is connecting to (the incoming address).
+``@src_ip_category`` functions like ``ip_category`` described in :file:`ip_allow.yaml`.
 
 Named Filters
 =============
@@ -515,13 +525,6 @@ would be ::
    .activateefilter ip_allow
 
 Note this entirely disables IP Allow checks for those remap rules.
-
-NextHop Selection Strategies
-============================
-
-You may configure Nexthop or Parent hierarchical caching rules by remap using the
-**@strategy** tag.  See :doc:`../configuration/hierarchical-caching.en` and :doc:`strategies.yaml.en`
-for configuration details and examples.
 
 Including Additional Remap Files
 ================================

--- a/include/proxy/http/remap/AclFiltering.h
+++ b/include/proxy/http/remap/AclFiltering.h
@@ -25,8 +25,11 @@
 
 #include "tscore/ink_inet.h"
 
-#include <string>
+#include "swoc/IPAddr.h"
+
 #include <set>
+#include <string>
+#include <string_view>
 #include <vector>
 
 // ===============================================================================
@@ -51,11 +54,33 @@ struct src_ip_info_t {
 
   /// @return @c true if @a ip is inside @a this range.
   bool
-  contains(IpEndpoint const &ip)
+  contains(IpEndpoint const &ip) const
   {
     IpAddr addr{ip};
     return addr.cmp(start) >= 0 && addr.cmp(end) <= 0;
   }
+};
+
+struct src_ip_category_info_t {
+  std::string category; ///< The IP category for this remap rule.
+  bool invert = false;  ///< Should we "invert" the meaning of these IP categories ("not in categories")
+
+  void
+  reset()
+  {
+    category.clear();
+    invert = false;
+  }
+
+  /// @return @c true if @a ip is inside @a this categories.
+  bool
+  contains(IpEndpoint const &ip) const
+  {
+    return ask_ip_allow_about_category(category, swoc::IPAddr{ip});
+  }
+
+private:
+  bool ask_ip_allow_about_category(std::string const &category, swoc::IPAddr const &addr) const;
 };
 
 /**
@@ -71,6 +96,7 @@ public:
   char *filter_name     = nullptr; // optional filter name
   unsigned int allow_flag : 1,     // action allow deny
     src_ip_valid          : 1,     // src_ip range valid
+    src_ip_category_valid : 1,     // src_ip range valid
     in_ip_valid           : 1,
     active_queue_flag     : 1, // filter is in active state (used by .useflt directive)
     internal              : 1; // filter internal HTTP requests
@@ -89,6 +115,9 @@ public:
   // src_ip
   int src_ip_cnt; // how many valid src_ip rules we have
   src_ip_info_t src_ip_array[ACL_FILTER_MAX_SRC_IP];
+
+  int src_ip_category_cnt = 0; // how many valid src_ip rules we have
+  src_ip_category_info_t src_ip_category_array[ACL_FILTER_MAX_SRC_IP];
 
   // in_ip
   int in_ip_cnt; // how many valid dest_ip rules we have

--- a/include/proxy/http/remap/RemapConfig.h
+++ b/include/proxy/http/remap/RemapConfig.h
@@ -35,13 +35,15 @@ class UrlRewrite;
 #define REMAP_OPTFLG_PPARAM           0x0004u     /* "pparam=" option (per remap plugin option) */
 #define REMAP_OPTFLG_METHOD           0x0008u     /* "method=" option (used for ACL filtering) */
 #define REMAP_OPTFLG_SRC_IP           0x0010u     /* "src_ip=" option (used for ACL filtering) */
-#define REMAP_OPTFLG_ACTION           0x0020u     /* "action=" option (used for ACL filtering) */
-#define REMAP_OPTFLG_INTERNAL         0x0040u     /* only allow internal requests to hit this remap */
-#define REMAP_OPTFLG_IN_IP            0x0080u     /* "in_ip=" option (used for ACL filtering)*/
-#define REMAP_OPTFLG_STRATEGY         0x0100u     /* "strategy=" the name of the nexthop selection strategy */
+#define REMAP_OPTFLG_SRC_IP_CATEGORY  0x0020u     /* "src_ip_category=" option (used for ACL filtering) */
+#define REMAP_OPTFLG_ACTION           0x0040u     /* "action=" option (used for ACL filtering) */
+#define REMAP_OPTFLG_INTERNAL         0x0080u     /* only allow internal requests to hit this remap */
+#define REMAP_OPTFLG_IN_IP            0x0100u     /* "in_ip=" option (used for ACL filtering)*/
+#define REMAP_OPTFLG_STRATEGY         0x0200u     /* "strategy=" the name of the nexthop selection strategy */
 #define REMAP_OPTFLG_MAP_ID           0x0800u     /* associate a map ID with this rule */
-#define REMAP_OPTFLG_INVERT           0x80000000u /* "invert" the rule (for src_ip at least) */
-#define REMAP_OPTFLG_ALL_FILTERS      (REMAP_OPTFLG_METHOD | REMAP_OPTFLG_SRC_IP | REMAP_OPTFLG_ACTION | REMAP_OPTFLG_INTERNAL)
+#define REMAP_OPTFLG_INVERT           0x80000000u /* "invert" the rule (for src_ip and src_ip_category at least) */
+#define REMAP_OPTFLG_ALL_FILTERS \
+  (REMAP_OPTFLG_METHOD | REMAP_OPTFLG_SRC_IP | REMAP_OPTFLG_SRC_IP_CATEGORY | REMAP_OPTFLG_ACTION | REMAP_OPTFLG_INTERNAL)
 
 struct BUILD_TABLE_INFO {
   BUILD_TABLE_INFO();

--- a/include/tscore/Filenames.h
+++ b/include/tscore/Filenames.h
@@ -34,6 +34,7 @@ namespace filename
   constexpr const char *LOGGING       = "logging.yaml";
   constexpr const char *CACHE         = "cache.config";
   constexpr const char *IP_ALLOW      = "ip_allow.yaml";
+  constexpr const char *IP_CATEGORIES = "ip_categories.yaml";
   constexpr const char *HOSTING       = "hosting.config";
   constexpr const char *SOCKS         = "socks.config";
   constexpr const char *PARENT        = "parent.config";

--- a/src/mgmt/config/AddConfigFilesHere.cc
+++ b/src/mgmt/config/AddConfigFilesHere.cc
@@ -70,6 +70,7 @@ initializeRegistry()
   registerFile(ts::filename::RECORDS, ts::filename::RECORDS, NOT_REQUIRED);
   registerFile("proxy.config.cache.control.filename", ts::filename::CACHE, NOT_REQUIRED);
   registerFile("proxy.config.cache.ip_allow.filename", ts::filename::IP_ALLOW, NOT_REQUIRED);
+  registerFile("proxy.config.cache.ip_categories.filename", ts::filename::IP_CATEGORIES, NOT_REQUIRED);
   registerFile("proxy.config.http.parent_proxy.file", ts::filename::PARENT, NOT_REQUIRED);
   registerFile("proxy.config.url_remap.filename", ts::filename::REMAP, NOT_REQUIRED);
   registerFile("", ts::filename::VOLUME, NOT_REQUIRED);

--- a/src/proxy/http/remap/AclFiltering.cc
+++ b/src/proxy/http/remap/AclFiltering.cc
@@ -22,7 +22,19 @@
  */
 
 #include "proxy/http/remap/AclFiltering.h"
+
 #include "proxy/hdrs/HTTP.h"
+#include "proxy/IPAllow.h"
+
+// ===============================================================================
+//                           src_ip_category_info_t
+// ===============================================================================
+
+bool
+src_ip_category_info_t::ask_ip_allow_about_category(std::string const &category, swoc::IPAddr const &addr) const
+{
+  return IpAllow::ip_category_contains_addr(category, addr);
+}
 
 // ===============================================================================
 //                              acl_filter_rule
@@ -42,6 +54,9 @@ acl_filter_rule::reset()
   nonstandard_methods.clear();
   for (i = (src_ip_cnt = 0); i < ACL_FILTER_MAX_SRC_IP; i++) {
     src_ip_array[i].reset();
+  }
+  for (i = (src_ip_category_cnt = 0); i < ACL_FILTER_MAX_SRC_IP; i++) {
+    src_ip_category_array[i].reset();
   }
   src_ip_valid = 0;
   for (i = (in_ip_cnt = 0); i < ACL_FILTER_MAX_IN_IP; i++) {
@@ -112,6 +127,11 @@ acl_filter_rule::print()
   for (i = 0; i < src_ip_cnt; i++) {
     ip_text_buffer b1, b2;
     printf("%s - %s, ", src_ip_array[i].start.toString(b1, sizeof(b1)), src_ip_array[i].end.toString(b2, sizeof(b2)));
+  }
+  printf("\n");
+  printf("src_ip_category_cnt=%d\n", src_ip_category_cnt);
+  for (i = 0; i < src_ip_category_cnt; i++) {
+    printf("%s, ", src_ip_category_array[i].category.c_str());
   }
   printf("\n");
   printf("in_ip_cnt=%d\n", in_ip_cnt);

--- a/src/proxy/http/remap/UrlRewrite.cc
+++ b/src/proxy/http/remap/UrlRewrite.cc
@@ -444,8 +444,25 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, url_mapping *map)
         }
       }
 
+      if (match && rp->src_ip_category_valid) {
+        Debug("url_rewrite", "match was true and we have specified an src_ip_category field");
+        match = false;
+        for (int j = 0; j < rp->src_ip_category_cnt && !match; j++) {
+          bool in_category = rp->src_ip_category_array[j].contains(s->client_info.src_addr);
+          if (rp->src_ip_category_array[j].invert) {
+            if (!in_category) {
+              match = true;
+            }
+          } else {
+            if (in_category) {
+              match = true;
+            }
+          }
+        }
+      }
+
       if (match && rp->in_ip_valid) {
-        Debug("url_rewrite", "match was true and we have specified a in_ip field");
+        Debug("url_rewrite", "match was true and we have specified an in_ip field");
         match = false;
         for (int j = 0; j < rp->in_ip_cnt && !match; j++) {
           IpEndpoint incoming_addr;

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -795,6 +795,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.cache.ip_allow.filename", RECD_STRING, ts::filename::IP_ALLOW, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.cache.ip_categories.filename", RECD_STRING, "", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.cache.hosting_filename", RECD_STRING, ts::filename::HOSTING, RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.cache.volume_filename", RECD_STRING, ts::filename::VOLUME, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2188,6 +2188,10 @@ main(int /* argc ATS_UNUSED */, const char **argv)
       pluginInitCheck.notify_one();
     }
 
+    if (IpAllow::has_no_rules()) {
+      Error("No ip_allow.yaml entries found.  All requests will be denied!");
+    }
+
     SSLConfigParams::init_ssl_ctx_cb  = init_ssl_ctx_callback;
     SSLConfigParams::load_ssl_file_cb = load_ssl_file_callback;
     sslNetProcessor.start(-1, stacksize);

--- a/tests/gold_tests/ip_allow/ip_category.test.py
+++ b/tests/gold_tests/ip_allow/ip_category.test.py
@@ -1,0 +1,326 @@
+'''
+Verify IP allow ip_category behavior.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import re
+
+Test.Summary = '''
+Verify IP allow ip_category behavior.
+'''
+
+
+class CategoryFile:
+    """Encapsulate the various ip_category.yaml contents."""
+
+    contents: list['CategoryFile'] = []
+    parent_directory: str = Test.RunDirectory
+    _index: int = 0
+
+    def __init__(self, content: str):
+        """Initialize the object.
+
+        :param content: The content of the ip_category.yaml file.
+        """
+        self._content = content
+        self._index = len(CategoryFile.contents)
+        self._filename = os.path.join(CategoryFile.parent_directory, f'categories{self._index}.yaml')
+        CategoryFile.contents.append(self)
+
+    def _write(self):
+        with open(self._filename, 'w') as f:
+            f.write(self._content)
+
+    def get_path(self):
+        return self._filename
+
+    @classmethod
+    def write_all(cls):
+        for content in cls.contents:
+            content._write()
+
+
+localhost_is_internal_and_external = CategoryFile(
+    '''
+ip_categories:
+  - name: ACME_INTERNAL
+    ip_addrs: 127.0.0.1
+  - name: ACME_EXTERNAL
+    ip_addrs: 127.0.0.1
+  - name: ACME_ALL
+    ip_addrs: 127.0.0.1
+  - name: ALL
+    ip_addrs: 127.0.0.1
+''')
+
+localhost_is_external = CategoryFile(
+    '''
+ip_categories:
+  - name: ACME_INTERNAL
+    ip_addrs: 1.2.3.4
+  - name: ACME_REMAP_EXTERNAL
+    ip_addrs: 127.0.0.1
+  - name: ACME_EXTERNAL
+    ip_addrs: 127.0.0.1
+  - name: ACME_ALL
+    ip_addrs:
+      - 1.2.3.4
+      - 127.0.0.1
+  - name: ALL
+    ip_addrs:
+      - 1.2.3.4
+      - 127.0.0.1
+''')
+
+localhost_is_neither = CategoryFile(
+    '''
+ip_categories:
+  - name: ACME_INTERNAL
+    ip_addrs: 1.2.3.4
+  - name: ACME_EXTERNAL
+    ip_addrs: 1.2.3.4
+  - name: ACME_ALL
+    ip_addrs: 1.2.3.4
+  - name: ALL
+    ip_addrs:
+      - 1.2.3.4
+      - 127.0.0.1
+''')
+
+# Keep this below the above content instantiations.
+CategoryFile.write_all()
+
+
+class Test_ip_category:
+    """Configure a test to verify ip_category behavior."""
+
+    _client_counter: int = 0
+    _ts_is_started: bool = False
+    _reload_server_is_started: bool = False
+    _server_is_started: bool = False
+    _reload_counter: int = 0
+
+    _ts: 'TestProcess' = None
+    _server: 'TestProcess' = None
+    _reload_server: 'TestProcess' = None
+
+    _categories_filename: str = f'{Test.RunDirectory}/categories.yaml'
+    _category_files_are_written: bool = False
+
+    _server_replay = 'replays/https_categories_server.replay.yaml'
+
+    def __init__(
+            self, name: str, replay_file: str, ip_allow_config: str, ip_category_config: 'CategoryFile', acl_configuration: str,
+            expected_responses: list[int]):
+        """Initialize the test.
+
+        :param name: The name of the test.
+        :param replay_file: The replay file to be used.
+        :param ip_allow_config: The ip_allow configuration to be used.
+        :param ip_category_config: The ip_category.yaml configuration to be used.
+        :param acl_configuration: The ACL configuration to be used.
+        :param expect_responses: The in-order expected responses from the proxy.
+        """
+        self._replay_file = replay_file
+        self._ip_allow_config = ip_allow_config
+        self._acl_configuration = acl_configuration
+        self._expected_responses = expected_responses
+
+        self._update_categories_file(ip_category_config)
+        self._update_remap_with_acl()
+
+        self._configure_server()
+        self._configure_traffic_server()
+
+        tr = Test.AddTestRun(name)
+        self._configure_client(tr)
+
+    def _update_remap_with_acl(self) -> None:
+        """Update the remap.config file with the ACL configuration."""
+        if Test_ip_category._ts:
+            if self._acl_configuration:
+                tr = Test.AddTestRun(f"remap.config file update with acl: {self._acl_configuration}")
+                p = tr.Processes.Default
+                destination = os.path.join(Test_ip_category._ts.Variables.CONFIGDIR, 'remap.config')
+                common = f'map / http://127.0.0.1:{Test_ip_category._server.Variables.http_port} '
+                p.Command = f'echo {common} {self._acl_configuration} > {destination}; cat {destination}'
+                p.ReturnCode = 0
+            else:
+                tr = Test.AddTestRun(f"remap.config file update with no acl")
+                p = tr.Processes.Default
+                destination = os.path.join(Test_ip_category._ts.Variables.CONFIGDIR, 'remap.config')
+                common = f'map / http://127.0.0.1:{Test_ip_category._server.Variables.http_port} '
+                p.Command = f'echo {common} > {destination}; cat {destination}'
+                p.ReturnCode = 0
+
+    def _update_categories_file(self, category_content: 'CategoryFile') -> None:
+        """Update the categories file.
+
+        :param category_content: The content of the categories file.
+        """
+        tr = Test.AddTestRun(f"Categories file update: {category_content.get_path()}")
+        p = tr.Processes.Default
+        destination = Test_ip_category._categories_filename
+        p.Command = f'cp {category_content.get_path()} {destination}; cat {destination}; ls -ltr {destination}'
+        p.ReturnCode = 0
+
+    def _configure_server(self) -> None:
+        """Configure the server."""
+        if Test_ip_category._server:
+            # All test runs share a single server instance.
+            return
+        server = Test.MakeVerifierServerProcess(f"server", self._server_replay)
+        Test_ip_category._server = server
+
+    def _configure_traffic_server(self) -> None:
+        """Configure Traffic Server."""
+
+        if Test_ip_category._ts:
+            # All test runs share a single Traffic Server instance.
+
+            # Reload the ip_allow.yaml file.
+            ts = Test_ip_category._ts
+            tr = Test.AddTestRun(f"Reload the configuration file.")
+            Test_ip_category._reload_counter += 1
+            p = tr.Processes.Process(f"reload-{Test_ip_category._reload_counter}")
+            # The sleep is added to give time for the reload to happen.
+            p.Command = 'traffic_ctl config reload; sleep 30'
+            p.Env = ts.Env
+            # Killing the sleep can result in a -2 return code.
+            p.ReturnCode = Any(0, -2)
+            p.Ready = When.FileContains(
+                ts.Disk.diags_log.Name, "ip_allow.yaml finished loading", 1 + Test_ip_category._reload_counter)
+            p.Timeout = 20
+            tr.StillRunningAfter = ts
+            tr.Processes.Default.StartBefore(p)
+            tr.Processes.Default.Command = 'echo "waiting upon traffic server to reload"'
+            tr.TimeOut = 20
+
+            return
+        ts = Test.MakeATSProcess("ts", enable_cache=False, enable_tls=True)
+        Test_ip_category._ts = ts
+
+        ts.addDefaultSSLFiles()
+        ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+        ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http|ip_allow',
+                'proxy.config.cache.ip_categories.filename': Test_ip_category._categories_filename,
+                'proxy.config.http.push_method_enabled': 1,
+                'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+                'proxy.config.quic.no_activity_timeout_in': 0,
+                'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+                'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+                'proxy.config.http.connect_ports': Test_ip_category._server.Variables.http_port,
+            })
+
+        ts.Disk.remap_config.AddLine(
+            f'map / http://127.0.0.1:{Test_ip_category._server.Variables.http_port} {self._acl_configuration}')
+        ts.Disk.ip_allow_yaml.AddLines(self._ip_allow_config.split("\n"))
+
+    def _configure_client(self, tr: 'TestRun') -> None:
+        """Run the test.
+
+        :param tr: The TestRun object to associate the client process with.
+        """
+
+        if not Test_ip_category._server_is_started:
+            tr.Processes.Default.StartBefore(Test_ip_category._server)
+            Test_ip_category._server_is_started = True
+        if not Test_ip_category._ts_is_started:
+            tr.Processes.Default.StartBefore(Test_ip_category._ts)
+            Test_ip_category._ts_is_started = True
+
+        p = tr.AddVerifierClientProcess(
+            f'client-{Test_ip_category._client_counter}', self._replay_file, https_ports=[Test_ip_category._ts.Variables.ssl_port])
+        Test_ip_category._client_counter += 1
+
+        if self._expected_responses:
+            codes = [str(code) for code in self._expected_responses]
+            p.Streams.stdout += Testers.ContainsExpression(
+                '.*'.join(codes), "Verifying the expected order of responses", reflags=re.DOTALL | re.MULTILINE)
+        else:
+            # If there are no expected responses, expect the Warning about the rejected ip.
+            self._ts.Disk.diags_log.Content += Testers.ContainsExpression(
+                "client '127.0.0.1' prohibited by ip-allow policy", "Verify the client rejection warning message.")
+
+            # Also, the client will complain about the broken connections.
+            p.ReturnCode = 1
+
+
+IP_ALLOW_CONTENT = f'''
+ip_allow:
+  - apply: in
+    ip_categories: ACME_INTERNAL
+    action: allow
+    methods:
+      - GET
+      - HEAD
+      - POST
+      - PUSH
+  - apply: in
+    ip_categories: ACME_EXTERNAL
+    action: allow
+    methods:
+      - GET
+      - HEAD
+  - apply: in
+    ip_categories: ACME_ALL
+    action: allow
+    methods:
+      - HEAD
+  - apply: in
+    ip_categories: ALL
+    action: deny
+'''
+
+test_ip_allow_optional_methods = Test_ip_category(
+    "IP Category: INTERNAL",
+    replay_file='replays/https_categories_internal.replay.yaml',
+    ip_allow_config=IP_ALLOW_CONTENT,
+    ip_category_config=localhost_is_internal_and_external,
+    acl_configuration='',
+    expected_responses=[200, 200, 400, 403])
+
+test_ip_allow_optional_methods = Test_ip_category(
+    "IP Category: EXTERNAL",
+    replay_file='replays/https_categories_external.replay.yaml',
+    ip_allow_config=IP_ALLOW_CONTENT,
+    ip_category_config=localhost_is_external,
+    acl_configuration='',
+    expected_responses=[200, 403, 403])
+
+# Because all requests are outright rejected for 127.0.0.1, ATS will
+# reject all incoming transactions and not even give a 403 response.
+test_ip_allow_optional_methods = Test_ip_category(
+    "IP Category: ALL",
+    replay_file='replays/https_categories_all.replay.yaml',
+    ip_allow_config=IP_ALLOW_CONTENT,
+    ip_category_config=localhost_is_neither,
+    acl_configuration='',
+    expected_responses=None)
+
+# Deny GET as well via remap.config ACL.
+test_ip_allow_optional_methods = Test_ip_category(
+    "IP Category: INTERNAL",
+    replay_file='replays/https_categories_external_remap.replay.yaml',
+    ip_allow_config=IP_ALLOW_CONTENT,
+    ip_category_config=localhost_is_external,
+    acl_configuration='@action=deny @src_ip_category=ACME_REMAP_EXTERNAL @method=GET',
+    expected_responses=[403, 403, 403])

--- a/tests/gold_tests/ip_allow/replays/https_categories_all.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_all.replay.yaml
@@ -1,0 +1,94 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# The replay file executes various HTTP requests to verify the ip_allow policy
+# applies by default to all methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+
+  # GET rejected
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, get ]
+        - [ X-Request, get ]
+
+    # Shouldn't be used.
+    <<: *standard_response
+
+    proxy-response:
+      status: 403
+
+  # POST rejected
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /test/ip_allow/test_post
+      headers:
+        fields:
+        - [Content-Length, 10]
+        - [ uuid, post ]
+        - [ X-Request, post ]
+
+    # Shouldn't be used.
+    <<: *standard_response
+
+    proxy-response:
+      status: 403
+
+  # PUSH rejected
+  - client-request:
+      method: "PUSH"
+      version: "1.1"
+      url: /test/ip_allow/test_push
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, push ]
+        - [ X-Request, push ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    <<: *standard_response
+
+    # Verify that ATS confirmed that the PUSH was successful, which it does
+    # with a 201 response.
+    proxy-response:
+      status: 403

--- a/tests/gold_tests/ip_allow/replays/https_categories_external.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_external.replay.yaml
@@ -1,0 +1,92 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# The replay file executes various HTTP requests to verify the ip_allow policy
+# applies by default to all methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+
+  # GET allowed
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, get ]
+        - [ X-Request, get ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  # POST rejected
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /test/ip_allow/test_post
+      headers:
+        fields:
+        - [Content-Length, 10]
+        - [ uuid, post ]
+        - [ X-Request, post ]
+
+    # Shouldn't be used.
+    <<: *standard_response
+
+    proxy-response:
+      status: 403
+
+  # PUSH rejected
+  - client-request:
+      method: "PUSH"
+      version: "1.1"
+      url: /test/ip_allow/test_push
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, push ]
+        - [ X-Request, push ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    <<: *standard_response
+
+    # Verify that ATS rejected the PUSH.
+    proxy-response:
+      status: 403

--- a/tests/gold_tests/ip_allow/replays/https_categories_external_remap.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_external_remap.replay.yaml
@@ -1,0 +1,92 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# The replay file executes various HTTP requests to verify the ip_allow policy
+# applies by default to all methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, get ]
+        - [ X-Request, get ]
+
+    <<: *standard_response
+
+    # Even GET is now blocked via remap ACL.
+    proxy-response:
+      status: 403
+
+  # POST rejected
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /test/ip_allow/test_post
+      headers:
+        fields:
+        - [Content-Length, 10]
+        - [ uuid, post ]
+        - [ X-Request, post ]
+
+    # Shouldn't be used.
+    <<: *standard_response
+
+    proxy-response:
+      status: 403
+
+  # PUSH rejected
+  - client-request:
+      method: "PUSH"
+      version: "1.1"
+      url: /test/ip_allow/test_push
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, push ]
+        - [ X-Request, push ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    <<: *standard_response
+
+    # Verify that ATS rejected the PUSH.
+    proxy-response:
+      status: 403

--- a/tests/gold_tests/ip_allow/replays/https_categories_internal.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_internal.replay.yaml
@@ -1,0 +1,106 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Assume everything is allowed by default.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+
+  # GET allowed
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, get ]
+        - [ X-Request, get ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  # POST allowed
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /test/ip_allow/test_post
+      headers:
+        fields:
+        - [Content-Length, 10]
+        - [ uuid, post ]
+        - [ X-Request, post ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  # PUSH allowed
+  - client-request:
+      method: "PUSH"
+      version: "1.1"
+      url: /test/ip_allow/test_push
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, push ]
+        - [ X-Request, push ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    <<: *standard_response
+
+    # Cacching is off, but a 400 still indicates that ATS processed it.
+    proxy-response:
+      status: 400
+
+  # DELETE is not allowed even for internal.
+  - client-request:
+      method: "DELETE"
+      version: "1.1"
+      url: /test/ip_allow/test_delete
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, delete ]
+        - [ X-Request, delete ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 403

--- a/tests/gold_tests/ip_allow/replays/https_categories_server.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_server.replay.yaml
@@ -1,0 +1,94 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# The replay file executes various HTTP requests to verify the ip_allow policy
+# applies by default to all methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+
+  # GET rejected
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, get ]
+        - [ X-Request, get ]
+
+    # Shouldn't be used.
+    <<: *standard_response
+
+    proxy-response:
+      status: 403
+
+  # POST rejected
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /test/ip_allow/test_post
+      headers:
+        fields:
+        - [Content-Length, 10]
+        - [ uuid, post ]
+        - [ X-Request, post ]
+
+    # Shouldn't be used.
+    <<: *standard_response
+
+    proxy-response:
+      status: 403
+
+  # PUSH rejected
+  - client-request:
+      method: "PUSH"
+      version: "1.1"
+      url: /test/ip_allow/test_push
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, push ]
+        - [ X-Request, push ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    <<: *standard_response
+
+    # Verify that ATS confirmed that the PUSH was successful, which it does
+    # with a 201 response.
+    proxy-response:
+      status: 403


### PR DESCRIPTION
Adds the ip_category feature for ip_allow.yaml so that users can specify arbitrary IP descriptions like the following:

```yaml
  ip_allow:
    - apply: in
      ip_category: ACME_INTERNAL
      action: allow
      methods:
        - GET
        - HEAD
        - POST
        - PUSH
        - DELETE
```

IP categories are defined via an `ip_categories` root node or through a file configured via proxy.config.cache.ip_categories.filename.