### PR TITLE
Segmentation crash caused by setting unavailable_server_retry_responses in parent.config 

### DIFF
--- a/src/proxy/ParentSelection.cc
+++ b/src/proxy/ParentSelection.cc
@@ -782,7 +782,7 @@ ParentRecord::Init(matcher_line *line_info)
             modulePrefix, line_num);
     delete unavailable_server_retry_responses;
     unavailable_server_retry_responses = nullptr;
-  } else if (unavailable_server_retry_responses == nullptr && (parent_retry & PARENT_RETRY_UNAVAILABLE_SERVER)) {
+  } else if (unavailable_server_retry_responses == nullptr && parent_retry) {
     // initialize UnavailableServerResponseCodes to the default value if unavailable_server_retry is enabled.
     Warning("%s initializing UnavailableServerResponseCodes on line %d to 503 default.", modulePrefix, line_num);
     unavailable_server_retry_responses = new UnavailableServerResponseCodes(nullptr);
@@ -794,7 +794,7 @@ ParentRecord::Init(matcher_line *line_info)
             line_num);
     delete simple_server_retry_responses;
     simple_server_retry_responses = nullptr;
-  } else if (simple_server_retry_responses == nullptr && (parent_retry & PARENT_RETRY_SIMPLE)) {
+  } else if (simple_server_retry_responses == nullptr && parent_retry) {
     // initialize simple server respones codes to the default value if simple_retry is enabled.
     Warning("%s initializing SimpleRetryResponseCodes on line %d to 404 default.", modulePrefix, line_num);
     simple_server_retry_responses = new SimpleRetryResponseCodes(nullptr);

--- a/tests/gold_tests/parent_proxy/parent-retry.test.py
+++ b/tests/gold_tests/parent_proxy/parent-retry.test.py
@@ -1,0 +1,47 @@
+"""
+Test parent_retry config settings
+"""
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.testName = "Test parent_retry settings"
+Test.ContinueOnFail = True
+
+
+class ParentRetryTest:
+    """
+    Test loading parent.config with parent_retry setting enabled
+    """
+    ts_parent_hostname = "localhost:8081"
+
+    def __init__(self):
+        """Initialize the test."""
+        self._configure_ts_child()
+
+    def _configure_ts_child(self):
+        self.ts_child = Test.MakeATSProcess("ts_child")
+        self.ts_child.Disk.parent_config.AddLine(
+            f'dest_domain=. method=get parent="{self.ts_parent_hostname}" parent_retry=unavailable_server_retry unavailable_server_retry_responses="502,503"'
+        )
+
+    def run(self):
+        tr = Test.AddTestRun()
+        tr.Processes.Default.StartBefore(self.ts_child)
+        tr.Processes.Default.Command = 'curl "{}" --verbose'.format(self.ts_child.Variables.port)
+        tr.StillRunningAfter = self.ts_child
+
+
+ParentRetryTest().run()

--- a/tests/gold_tests/parent_proxy/parent-retry.test.py
+++ b/tests/gold_tests/parent_proxy/parent-retry.test.py
@@ -40,7 +40,7 @@ class ParentRetryTest:
     def run(self):
         tr = Test.AddTestRun()
         tr.Processes.Default.StartBefore(self.ts_child)
-        tr.Processes.Default.Command = 'curl "{}" --verbose'.format(self.ts_child.Variables.port)
+        tr.Processes.Default.Command = f'curl "{self.ts_child.Variables.port}" --verbose'
         tr.StillRunningAfter = self.ts_child
 
 


### PR DESCRIPTION
At the moment,  `unavailable_server_retry_responses` and `simple_server_retry_responses` will be nullptr's when parent_retry is enabled and the retry type does not match their type. e.g. parent_retry=SIMPLE_RETRY, `unavailable_server_retry_responses` will be null. But these values are both used in the code no matter what the type is. This has been causing a segmentation fault as the code is trying to use the .contain() method on what is currently a nullptr. This change ensures that they are always initialised with their default values when parent_retry is enabled, irrespective of the retry type.

Should close #11005 