### PR TITLE
Fix esi-fetcher-plugin libswoc include issue

### DIFF
--- a/plugins/esi/fetcher/CMakeLists.txt
+++ b/plugins/esi/fetcher/CMakeLists.txt
@@ -16,6 +16,6 @@
 #######################
 
 add_library(fetcher STATIC HttpDataFetcherImpl.cc)
-target_link_libraries(fetcher PUBLIC esi-common libswoc)
-target_include_directories(fetcher PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(fetcher PUBLIC esi-common libswoc::libswoc)
+target_include_directories(fetcher PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${libswoc_INCLUDE_DIRS}")
 set_target_properties(fetcher PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/plugins/esi/fetcher/CMakeLists.txt
+++ b/plugins/esi/fetcher/CMakeLists.txt
@@ -17,5 +17,5 @@
 
 add_library(fetcher STATIC HttpDataFetcherImpl.cc)
 target_link_libraries(fetcher PUBLIC esi-common libswoc::libswoc)
-target_include_directories(fetcher PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${libswoc_INCLUDE_DIRS}")
+target_include_directories(fetcher PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 set_target_properties(fetcher PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
We discovered some linking issues with use of an external libswoc; this fully qualifies inclusion so that internal or external should be usable. 