### PR TITLE
Revert "Coverity 1497378: Use of 32-bit time_t in CacheVC (#10857)"

### DIFF
--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -273,7 +273,7 @@ struct CacheVC : public CacheVConnection {
   Event *trigger;
   CacheKey *read_key;
   ContinuationHandler save_handler;
-  time_t pin_in_cache;
+  uint32_t pin_in_cache;
   ink_hrtime start_time;
   int op_type; // Index into the metrics array for this operation, rather than a CacheOpType (fewer casts)
   int recursive;

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -1579,7 +1579,8 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   c->f.overwrite      = (options & CACHE_WRITE_OPT_OVERWRITE) != 0;
   c->f.close_complete = (options & CACHE_WRITE_OPT_CLOSE_COMPLETE) != 0;
   c->f.sync           = (options & CACHE_WRITE_OPT_SYNC) == CACHE_WRITE_OPT_SYNC;
-  c->pin_in_cache     = apin_in_cache;
+  // coverity[Y2K38_SAFETY:FALSE]
+  c->pin_in_cache = static_cast<uint32_t>(apin_in_cache);
 
   if ((res = c->stripe->open_write_lock(c, false, 1)) > 0) {
     // document currently being written, abort
@@ -1680,7 +1681,8 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
 
   Metrics::Gauge::increment(cache_rsb.status[c->op_type].active);
   Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.status[c->op_type].active);
-  c->pin_in_cache = apin_in_cache;
+  // coverity[Y2K38_SAFETY:FALSE]
+  c->pin_in_cache = static_cast<uint32_t>(apin_in_cache);
 
   {
     CACHE_TRY_LOCK(lock, c->stripe->mutex, cont->mutex->thread_holding);


### PR DESCRIPTION
On 64 bit systems, time_t (which is an unsigned long) is generally a 64 bit value. We therefore may not change the type of pin_in_cache from an explicit 32 bit value to a 64 bit one without introducing a cache inconsistency in ATS 10. Since the community is a hard pass on introducing an inconsistency for this release, we have to revert this change.

This reverts commit 6b896f43bef38c42d574d8bc89293766e0dbc94f.