### PR TITLE
CMake: use --git-common-dir to find the git dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,11 +649,13 @@ if(ENABLE_BENCHMARKS)
   add_subdirectory(tools/benchmark)
 endif()
 
+set(GIT_COMMON_DIR git rev-parse --git-common-dir)
+
 add_custom_target(
   clang-format-install
   COMMAND ${CMAKE_SOURCE_DIR}/tools/clang-format.sh --install
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  BYPRODUCTS ${CMAKE_SOURCE_DIR}/.git/fmt/.clang-format-installed
+  BYPRODUCTS ${GIT_COMMON_DIR}/fmt/.clang-format-installed
   COMMENT "Installing clang-format"
   VERBATIM
 )

--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -39,7 +39,8 @@ function main() {
     pip install -q virtualenv
   fi
 
-  AUTOPEP8_VENV=${AUTOPEP8_VENV:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
+  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
+  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_COMMON_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
   if [ ! -e ${AUTOPEP8_VENV} ]
   then
     virtualenv ${AUTOPEP8_VENV}
@@ -101,5 +102,6 @@ function main() {
 if [[ "$(basename -- "$0")" == 'autopep8.sh' ]]; then
   main "$@"
 else
-  AUTOPEP8_VENV=${AUTOPEP8_VENV:-$(git rev-parse --show-toplevel)/.git/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_COMMON_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
 fi

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -23,7 +23,9 @@ PKGDATE="20230928"
 
 function main() {
   set -e # exit on error
-  ROOT=${ROOT:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
+
+  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
   # The presence of this file indicates clang-format was successfully installed.
   INSTALLED_SENTINEL=${ROOT}/.clang-format-installed
 
@@ -117,5 +119,6 @@ EOF
 if [[ "$(basename -- "$0")" == 'clang-format.sh' ]]; then
   main "$@"
 else
-  ROOT=${ROOT:-$(git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
 fi

--- a/tools/cmake-format.sh
+++ b/tools/cmake-format.sh
@@ -33,7 +33,8 @@ function main() {
     pip install -q virtualenv
   fi
 
-  CMAKE_FORMAT_VENV=${CMAKE_FORMAT_VENV:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/cmake_format_${CMAKE_FORMAT_VERSION}_venv}
+  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
+  CMAKE_FORMAT_VENV=${CMAKE_FORMAT_VENV:-${GIT_COMMON_DIR}/fmt/cmake_format_${CMAKE_FORMAT_VERSION}_venv}
   if [ ! -e ${CMAKE_FORMAT_VENV} ]
   then
     virtualenv ${CMAKE_FORMAT_VENV}
@@ -85,5 +86,6 @@ function main() {
 if [[ "$(basename -- "$0")" == 'cmake-format.sh' ]]; then
   main "$@"
 else
-  CMAKE_FORMAT_VENV=${CMAKE_FORMAT_VENV:-$(git rev-parse --show-toplevel)/.git/fmt/cmake_format_${CMAKE_FORMAT_VERSION}_venv}
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+  CMAKE_FORMAT_VENV=${CMAKE_FORMAT_VENV:-${GIT_COMMON_DIR}/fmt/cmake_format_${CMAKE_FORMAT_VERSION}_venv}
 fi

--- a/tools/yapf.sh
+++ b/tools/yapf.sh
@@ -47,7 +47,8 @@ _END_
   fi
 
   REPO_ROOT=$(cd $(dirname $0) && git rev-parse --show-toplevel)
-  YAPF_VENV=${YAPF_VENV:-${REPO_ROOT}/.git/fmt/yapf_${YAPF_VERSION}_venv}
+  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
+  YAPF_VENV=${YAPF_VENV:-${GIT_COMMON_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
   if [ ! -e ${YAPF_VENV} ]
   then
     python3 -m virtualenv ${YAPF_VENV}
@@ -105,5 +106,6 @@ _END_
 if [[ "$(basename -- "$0")" == 'yapf.sh' ]]; then
   main "$@"
 else
-  YAPF_VENV=${YAPF_VENV:-$(git rev-parse --show-toplevel)/.git/fmt/yapf_${YAPF_VERSION}_venv}
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+  YAPF_VENV=${YAPF_VENV:-${GIT_COMMON_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
 fi


### PR DESCRIPTION
Prior to the change, cmake format target didn't work under git worktree directories. Because the `$(git rev-parse --show-toplevel)/.git` is the git directory of the current worktree directory. It's not the git "common" directory that has formatters.

If you're not using git worktree, this change has no impact. 

# Details with example
```
$ git worktree list
/src/apache/trafficserver         e2ff288e0 [master]  ///< original repo
/src/apache/trafficserver-dev     e7c152da6 [dev]     ///< worktree

# under the /src/apache/trafficserver-dev dir

$ cmake --build build-dev -t format
...
[0/9] Installing clang-formatninja: error: mkdir(/src/apache/trafficserver-dev/.git/fmt): Not a directory

ninja: build stopped: .

$ git rev-parse --show-toplevel
/src/apache/trafficserver-dev 

$ cat .git
gitdir: /src/trafficserver/.git/worktrees/trafficserver-dev

$ git rev-parse --git-common-dir
/src/apache/trafficserver/.git
```

# Refs.
> --show-toplevel
Show the (by default, absolute) path of the top-level directory of the working tree. If there is no working tree, report an error.

> --git-common-dir
Show $GIT_COMMON_DIR if defined, else $GIT_DIR.

https://git-scm.com/docs/git-rev-parse
https://git-scm.com/docs/git-worktree
