### PR TITLE
Make Dir parameters const in all Stripe methods

### DIFF
--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -297,7 +297,7 @@ iobufferblock_memcpy(char *p, int len, IOBufferBlock *ab, int offset)
 }
 
 EvacuationBlock *
-Stripe::force_evacuate_head(Dir *evac_dir, int pinned)
+Stripe::force_evacuate_head(Dir const *evac_dir, int pinned)
 {
   auto bucket = dir_evac_bucket(evac_dir);
   if (!evac_bucket_valid(bucket)) {

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -251,8 +251,8 @@ public:
   void scan_for_pinned_documents();
   void evacuate_cleanup_blocks(int i);
   void evacuate_cleanup();
-  EvacuationBlock *force_evacuate_head(Dir *dir, int pinned);
-  int within_hit_evacuate_window(Dir *dir) const;
+  EvacuationBlock *force_evacuate_head(Dir const *dir, int pinned);
+  int within_hit_evacuate_window(Dir const *dir) const;
   uint32_t round_to_approx_size(uint32_t l) const;
 
   // inline functions
@@ -260,14 +260,14 @@ public:
   int direntries() const;        // total number of dir entries
   Dir *dir_segment(int s) const; // returns the first dir in the segment s
   size_t dirlen() const;         // calculates the total length of header, directories and footer
-  int vol_out_of_phase_valid(Dir *e) const;
+  int vol_out_of_phase_valid(Dir const *e) const;
 
-  int vol_out_of_phase_agg_valid(Dir *e) const;
-  int vol_out_of_phase_write_valid(Dir *e) const;
-  int vol_in_phase_valid(Dir *e) const;
-  int vol_in_phase_agg_buf_valid(Dir *e) const;
+  int vol_out_of_phase_agg_valid(Dir const *e) const;
+  int vol_out_of_phase_write_valid(Dir const *e) const;
+  int vol_in_phase_valid(Dir const *e) const;
+  int vol_in_phase_agg_buf_valid(Dir const *e) const;
 
-  off_t vol_offset(Dir *e) const;
+  off_t vol_offset(Dir const *e) const;
   off_t offset_to_vol_offset(off_t pos) const;
   off_t vol_offset_to_offset(off_t pos) const;
   off_t vol_relative_length(off_t start_offset) const;
@@ -326,7 +326,7 @@ public:
    * @param nbytes: The size of the document (number of bytes to copy).
    * @return Returns true if the document was copied, false otherwise.
    */
-  bool copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes) const;
+  bool copy_from_aggregate_write_buffer(char *dest, Dir const &dir, size_t nbytes) const;
 
 private:
   void _clear_init();
@@ -430,31 +430,31 @@ Stripe::direntries() const
 }
 
 inline int
-Stripe::vol_out_of_phase_valid(Dir *e) const
+Stripe::vol_out_of_phase_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Stripe::vol_out_of_phase_agg_valid(Dir *e) const
+Stripe::vol_out_of_phase_agg_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start + AGG_SIZE) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Stripe::vol_out_of_phase_write_valid(Dir *e) const
+Stripe::vol_out_of_phase_write_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->write_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Stripe::vol_in_phase_valid(Dir *e) const
+Stripe::vol_in_phase_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 < ((this->header->write_pos + this->_write_buffer.get_buffer_pos() - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline off_t
-Stripe::vol_offset(Dir *e) const
+Stripe::vol_offset(Dir const *e) const
 {
   return this->start + (off_t)dir_offset(e) * CACHE_BLOCK_SIZE - CACHE_BLOCK_SIZE;
 }
@@ -472,7 +472,7 @@ Stripe::vol_offset_to_offset(off_t pos) const
 }
 
 inline int
-Stripe::vol_in_phase_agg_buf_valid(Dir *e) const
+Stripe::vol_in_phase_agg_buf_valid(Dir const *e) const
 {
   return (this->vol_offset(e) >= this->header->write_pos &&
           this->vol_offset(e) < (this->header->write_pos + this->_write_buffer.get_buffer_pos()));
@@ -518,7 +518,7 @@ Doc::data()
 // inline Functions
 
 inline EvacuationBlock *
-evacuation_block_exists(Dir *dir, Stripe *stripe)
+evacuation_block_exists(Dir const *dir, Stripe *stripe)
 {
   auto bucket = dir_evac_bucket(dir);
   if (stripe->evac_bucket_valid(bucket)) {
@@ -571,7 +571,7 @@ Stripe::open_read(const CryptoHash *key) const
 }
 
 inline int
-Stripe::within_hit_evacuate_window(Dir *xdir) const
+Stripe::within_hit_evacuate_window(Dir const *xdir) const
 {
   off_t oft       = dir_offset(xdir) - 1;
   off_t write_off = (header->write_pos + AGG_SIZE - start) / CACHE_BLOCK_SIZE;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -1019,7 +1019,7 @@ Stripe::flush_aggregate_write_buffer()
 }
 
 bool
-Stripe::copy_from_aggregate_write_buffer(char *dest, Dir &dir, size_t nbytes) const
+Stripe::copy_from_aggregate_write_buffer(char *dest, Dir const &dir, size_t nbytes) const
 {
   if (!dir_agg_buf_valid(this, &dir)) {
     return false;


### PR DESCRIPTION
I noticed while extracting methods and moving them to Stripe that I could not mark the Dir parameter const. This is a followup to fix that issue and apply const to all the Dir parameters in Stripe methods. This makes the code more explicit and also helps the compiler generate performant assembly.