### PR TITLE
Reuse arena for header compression

### DIFF
--- a/include/proxy/http2/HPACK.h
+++ b/include/proxy/http2/HPACK.h
@@ -126,6 +126,9 @@ public:
   uint32_t size() const;
   void update_maximum_size(uint32_t new_size);
 
+  // Temporal buffer for internal use but it has to be public because many functions are not members of this class.
+  Arena arena;
+
 private:
   XpackDynamicTable _dynamic_table;
 };

--- a/include/proxy/http3/QPACK.h
+++ b/include/proxy/http3/QPACK.h
@@ -282,4 +282,7 @@ private:
   MIOBuffer *_decoder_stream_sending_instructions;
   IOBufferReader *_encoder_stream_sending_instructions_reader;
   IOBufferReader *_decoder_stream_sending_instructions_reader;
+
+  // Temporal buffer
+  Arena _arena;
 };


### PR DESCRIPTION
Having an arena in each function is wasteful and it's effectively allocating memory at all the places on every call. One arena for each connection should be enough.