### PR TITLE
docs: Fix pipfile package compatible release clause.

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -29,7 +29,7 @@ verify_ssl = true
 # version.
 sphinx = "==6.1.3"
 
-sphinx-rtd-theme = ">=1.*"
+sphinx-rtd-theme = "==1.*"
 sphinxcontrib-jquery = "*"
 sphinxcontrib-plantuml = "*"
 # i18n


### PR DESCRIPTION
For some reason I have this failing locally(rocky8), looking at the docs, this seems the right way to specify the dependency.

```
>= V.N, == V.*
```
as we use a wildcard, then `==` seems the correct way.

https://peps.python.org/pep-0440/#compatible-release