### PR TITLE
Allows the set-body to run as a pseudo remap hook

### DIFF
--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -697,7 +697,7 @@ OperatorSetBody::initialize(Parser &p)
 void
 OperatorSetBody::initialize_hooks()
 {
-  add_allowed_hook(TS_HTTP_READ_RESPONSE_HDR_HOOK);
+  add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
   add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
 }
 


### PR DESCRIPTION
It also eliminates the hook support for read-response, which is too late for this implementaiton of the set-body.