### PR TITLE
Don't statically link libtsutil.a into core plugins.

### DIFF
--- a/cmake/add_atsplugin.cmake
+++ b/cmake/add_atsplugin.cmake
@@ -19,7 +19,7 @@ set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
 function(add_atsplugin name)
   add_library(${name} MODULE ${ARGN})
-  target_link_libraries(${name} PRIVATE ts::tsapi ts::tsutil)
+  target_link_libraries(${name} PRIVATE ts::tsapi libswoc::libswoc yaml-cpp::yaml-cpp)
   set_target_properties(${name} PROPERTIES PREFIX "")
   set_target_properties(${name} PROPERTIES SUFFIX ".so")
   install(TARGETS ${name} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/src/tsutil/CMakeLists.txt
+++ b/src/tsutil/CMakeLists.txt
@@ -38,26 +38,29 @@ set(TSUTIL_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/include/tsutil/ts_time_parser.h
     ${PROJECT_SOURCE_DIR}/include/tsutil/ts_unit_parser.h
 )
-add_library(
-  tsutil
-  Assert.cc
-  Metrics.cc
-  DbgCtl.cc
-  SourceLocation.cc
-  ts_diags.cc
-  ts_ip.cc
-  YamlCfg.cc
-  ts_unit_parser.cc
-  Regex.cc
+set(TSUTIL_SOURCE_FILES
+    Assert.cc
+    Metrics.cc
+    DbgCtl.cc
+    SourceLocation.cc
+    ts_diags.cc
+    ts_ip.cc
+    YamlCfg.cc
+    ts_unit_parser.cc
+    Regex.cc
 )
+add_library(tsutil ${TSUTIL_SOURCE_FILES})
 add_library(ts::tsutil ALIAS tsutil)
 set_target_properties(tsutil PROPERTIES POSITION_INDEPENDENT_CODE TRUE PUBLIC_HEADER "${TSUTIL_PUBLIC_HEADERS}")
 target_link_libraries(tsutil PUBLIC libswoc::libswoc yaml-cpp::yaml-cpp PCRE::PCRE)
+add_library(tsutil_link_dummy SHARED ${TSUTIL_SOURCE_FILES})
+add_library(ts::tsutil_link_dummy ALIAS tsutil_link_dummy)
+set_target_properties(tsutil_link_dummy PROPERTIES PUBLIC_HEADER "${TSUTIL_PUBLIC_HEADERS}")
+target_link_libraries(tsutil_link_dummy PUBLIC libswoc::libswoc yaml-cpp::yaml-cpp PCRE::PCRE)
 
 install(
-  TARGETS tsutil
+  TARGETS tsutil_link_dummy
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tsutil
 )
 


### PR DESCRIPTION
Two equivalent libraries are now created, libtsutil.a and libtsutil_link_dummy.so, with the same code and symbol content.  Non-core plugins can be linked with libtsutil_link_dummy.so, with the --no-undefined ld option.  The drawback is, for dlopen() to successfully load the plugin, it will require the presence of libtsutil_link_dummy.so.  But, the symbols in libtsutil_link_dummy.so don't seem to be used, because they are satisfied by symbols from core TS.  I tested this (on Red Hat 8) by substituting a random .so for libtsutil_link_dummy.so, before successfully loading the xdebug.so plugin.

I checked for an option in ld to resolve symbols for the link in a .so, without creating a dependency on it.  But I could not find any such option.