### PR TITLE
ensure dns lookup happens after dns_info.lookup_name changes

### DIFF
--- a/include/iocore/hostdb/HostDBProcessor.h
+++ b/include/iocore/hostdb/HostDBProcessor.h
@@ -863,7 +863,8 @@ ResolveInfo::set_active(std::nullptr_t)
 inline bool
 ResolveInfo::set_upstream_address(sockaddr const *sa)
 {
-  return resolved_p = addr.assign(sa).isValid();
+  resolved_p = addr.assign(sa).isValid();
+  return resolved_p;
 }
 
 inline void

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -547,7 +547,9 @@ update_dns_info(ResolveInfo *dns, HttpTransact::CurrentInfo *from)
 {
   dns->looking_up  = from->request_to;
   dns->lookup_name = from->server->name;
-  dns->resolved_p  = false;
+  if (dns->os_addr_style != ResolveInfo::OS_Addr::USE_API) {
+    dns->resolved_p = false;
+  }
 }
 
 inline static HTTPHdr *

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -547,6 +547,7 @@ update_dns_info(ResolveInfo *dns, HttpTransact::CurrentInfo *from)
 {
   dns->looking_up  = from->request_to;
   dns->lookup_name = from->server->name;
+  dns->resolved_p  = false;
 }
 
 inline static HTTPHdr *
@@ -5720,6 +5721,7 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
   /////////////////////////////////////////////
   s->dns_info.looking_up  = ResolveInfo::ORIGIN_SERVER;
   s->dns_info.lookup_name = s->server_info.name;
+  s->dns_info.resolved_p  = false;
 }
 
 void

--- a/tests/gold_tests/next_hop/parent_config/parent_config_dest_ip.test.py
+++ b/tests/gold_tests/next_hop/parent_config/parent_config_dest_ip.test.py
@@ -1,0 +1,125 @@
+'''
+Verify ATS parent.config dest_ip dns bug fix.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Verify ATS parent_config with dest_ip=...
+'''
+
+# Create origin
+origin = Test.MakeOriginServer("origin")
+
+# default root
+request_header_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: ats\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+response_header_chk = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+origin.addResponse("sessionlog.json", request_header_chk, response_header_chk)
+
+request_header = {
+    "headers":
+        f"GET /foo.txt HTTP/1.1\r\n"
+        "Host: does.not.matter\r\n"  # But cant be omitted
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+
+response_header = {
+    "headers": "HTTP/1.1 200 OK\r\n"
+               "Connection: close\r\n"
+               "Cache-control: max-age=60\r\n"
+               "\r\n",
+    "timestamp": "1469733493.993",
+    "body": f"This is the body for foo.txt\n"
+}
+origin.addResponse("sessionlog.json", request_header, response_header)
+
+# Configure DNS for cache layering
+dns = Test.MakeDNServer("dns")
+dns.addRecords(records={f"origin": ["127.0.0.1"]})
+dns.addRecords(records={f"ts1": ["127.0.0.1"]})
+dns.addRecords(records={f"ts0": ["127.0.0.1"]})
+dns.addRecords(records={f"foo.bar": ["142.250.72.14"]})  # google.com
+
+# Configure Traffic Server Mid
+ts1 = Test.MakeATSProcess("ts1")
+ts1.Disk.remap_config.AddLine(f"map / http://origin:{origin.Variables.Port}")
+
+ts1.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|hostdb|parent',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+        'proxy.config.dns.resolv_conf': "NULL",
+        'proxy.config.hostdb.lookup_timeout': 2,
+        'proxy.config.http.connect_attempts_timeout': 1,
+        'proxy.config.http.parent_proxy.self_detect': 0,
+        'proxy.config.http.insert_response_via_str': 1,
+        'proxy.config.proxy_name': 'ts1',
+    })
+
+# Configure Traffic Server Edge
+ts0 = Test.MakeATSProcess("ts0")
+ts0.Disk.remap_config.AddLine("map http://foo.bar http://foo.bar")
+
+ts0.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|hostdb|parent',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+        'proxy.config.dns.resolv_conf': "NULL",
+        'proxy.config.hostdb.lookup_timeout': 2,
+        'proxy.config.http.connect_attempts_timeout': 1,
+        'proxy.config.http.parent_proxy.self_detect': 0,
+        'proxy.config.http.insert_response_via_str': 1,
+        'proxy.config.proxy_name': 'ts0',
+    })
+
+ts0.Disk.parent_config.AddLines(
+    [
+        f"dest_ip=93.184.216.34 port=80 go_direct=true",  # example.com
+        f'dest_host=foo.bar port=80 parent="ts1:{ts1.Variables.port}|1;" go_direct="false" parent_is_proxy="true"',
+    ])
+
+# Start everything up
+tr = Test.AddTestRun("init")
+tr.Processes.Default.StartBefore(origin)
+tr.Processes.Default.StartBefore(dns)
+tr.Processes.Default.StartBefore(ts0)
+tr.Processes.Default.StartBefore(ts1)
+tr.Processes.Default.Command = 'echo start TS, TSH_N, HTTP origin and DNS.'
+tr.Processes.Default.ReturnCode = 0
+
+curl_and_args = f"curl -s -D /dev/stdout -o /dev/stderr -x http://127.0.0.1:{ts0.Variables.port}"
+
+# Request asset that goes through the layers
+tr = Test.AddTestRun("request")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://foo.bar/foo.txt'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("Via:.* ts1 .* ts0 ", "expected via header")
+tr.StillRunningAfter = ts0


### PR DESCRIPTION
Found this bug with ats master on a server that has `dest_ip=xxxx` in one of the parent.config lines.  In this case all parent.config primary/secondary parents are being assigned the fqdn's ip address.

This bug was introduced with ats master dns rewrite where ats92's dns_info's lookup_success and srv_lookup_success were collapsed into a single 'resolved_p' boolean (part of HttpTransact).