### PR TITLE
Add basic check for pcre2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ if(LibLZMA_FOUND)
 endif()
 
 find_package(PCRE REQUIRED)
+find_package(PCRE2 COMPONENTS 8BIT)
 
 include(CheckOpenSSLIsBoringSSL)
 include(CheckOpenSSLIsQuictls)


### PR DESCRIPTION
Allows this to be reported correctly when we are configuring cmake.

once @bryancall adds official pcre2 fixes, this check will want to be tweaked to allow us to pick prce1 or pcre2 but not both at the same time.

This should help with the work with txn_box @brbzull0 is working on and the official pcre2  support @bryancall is working on