### PR TITLE
Deprecate the support for NPN

### DIFF
--- a/doc/admin-guide/configuration/session-protocol.en.rst
+++ b/doc/admin-guide/configuration/session-protocol.en.rst
@@ -42,7 +42,9 @@ protocols:
 
 Each proxy port can be configured in :ts:cv:`proxy.config.http.server_ports`
 to support a subset of these session protocols. For TLS enabled connections this
-configuration controls which protocols are offered by NPN. Protocol sniffing is
+configuration controls which protocols are offered by ALPN and NPN. Protocol sniffing is
 use for non-TLS proxy ports to determine which protocol is being used by the
 client. If the detected protocol is not supported for that proxy port the
 connection is dropped.
+
+Support for NPN is deprecated, and it will be removed on a future release.

--- a/doc/developer-guide/api/functions/TSHttpConnectPlugin.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpConnectPlugin.en.rst
@@ -75,7 +75,7 @@ The H2 implementation uses this to correlate client sessions
 with H2 streams. Each client connection is assigned a distinct
 numeric identifier. This is passed in the options structure via
 the member variable `id` to the :c:func:`TSHttpConnectPlugin` function.
-The :arg:`tag` is selected to be the NPN string for the client session
+The :arg:`tag` is selected to be the ALPN (or NPN) string for the client session
 protocol, e.g. "h2". Log post processing can then count the number of
 connections for the various supported protocols and the number of H2
 virtual streams for each real client connection to Traffic Server.

--- a/doc/developer-guide/api/functions/TSHttpConnectWithPluginId.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpConnectWithPluginId.en.rst
@@ -98,7 +98,7 @@ The H2 implementation uses this to correlate client sessions
 with H2 streams. Each client connection is assigned a distinct
 numeric identifier. This is passed as the :arg:`id` to
 :c:func:`TSHttpConnectWithPluginId`. The :arg:`tag` is selected
-to be the NPN string for the client session protocol, e.g.
+to be the ALPN (or NPN) string for the client session protocol, e.g.
 "h2". Log post processing can then count the number of connections for the
 various supported protocols and the number of H2 virtual streams for each
 real client connection to Traffic Server.


### PR DESCRIPTION
There are only a few places that mention NPN on the documentation. Although we should state the deprecation on the release note, this commit ensures that we have it recorded on our commit log at a minimum.