### PR TITLE
XPACK: Fix a ats_malloc/delete mismatch

### DIFF
--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -225,7 +225,7 @@ XpackDynamicTable::XpackDynamicTable(uint32_t size) : _maximum_size(size), _avai
 XpackDynamicTable::~XpackDynamicTable()
 {
   if (this->_entries) {
-    delete this->_entries;
+    ats_free(this->_entries);
     this->_entries = nullptr;
   }
 }


### PR DESCRIPTION
An ASan run showed that in XpackDynamicTable we used ats_malloc for the table entries, but then delete it in the destructor. This fixes that mismatch.