### PR TITLE
SSLConfig: free temporary ALPN string

### DIFF
--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -366,6 +366,7 @@ SSLConfigParams::initialize()
   if (clientALPNProtocols) {
     this->alpn_protocols_array_size = MAX_ALPN_STRING;
     convert_alpn_to_wire_format(clientALPNProtocols, this->alpn_protocols_array, this->alpn_protocols_array_size);
+    ats_free(clientALPNProtocols);
   }
 
 #ifdef SSL_OP_CIPHER_SERVER_PREFERENCE


### PR DESCRIPTION
We allocate a temporary string for the user's client-side ALPN configuration, but don't free it after using it. This frees the string after we're done with it.