### PR TITLE
Fix SSLAPIHooks::g_ssl_hooks memory leak

### DIFF
--- a/include/iocore/net/SSLAPIHooks.h
+++ b/include/iocore/net/SSLAPIHooks.h
@@ -27,6 +27,8 @@
 
 #include "ts/apidefs.h"
 
+#include <memory>
+
 class TSSslHookInternalID
 {
 public:
@@ -57,4 +59,4 @@ class SSLAPIHooks : public FeatureAPIHooks<TSSslHookInternalID, TSSslHookInterna
 // there is no corresponding deinit; we leak the resource on shutdown
 void init_global_ssl_hooks();
 
-extern SSLAPIHooks *g_ssl_hooks;
+extern std::unique_ptr<SSLAPIHooks> g_ssl_hooks;

--- a/src/iocore/net/SSLAPIHooks.cc
+++ b/src/iocore/net/SSLAPIHooks.cc
@@ -22,11 +22,12 @@
  */
 
 #include "iocore/net/SSLAPIHooks.h"
+#include <memory>
 
-SSLAPIHooks *g_ssl_hooks = nullptr;
+std::unique_ptr<SSLAPIHooks> g_ssl_hooks;
 
 void
 init_global_ssl_hooks()
 {
-  g_ssl_hooks = new SSLAPIHooks;
+  g_ssl_hooks = std::make_unique<SSLAPIHooks>();
 }


### PR DESCRIPTION
It's a one-time global, but ASan reported this as a leak because we new'd it but didn't free it. Solving this by wrapping it in a unique_ptr.