### PR TITLE
Remove header files generated by autotools automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,16 @@ endif()
 
 set(rel_cachedir var/trafficserver)
 
+if(EXISTS "${PROJECT_SOURCE_DIR}/include/ink_autoconf.h")
+  message(STATUS "Autoconf build detected in source tree. Removing autoconf headers.")
+endif()
+
+# In-tree autoconf configuration causes duplicate definitions of some symbols
+# in generated headers. If the files don't exist, no error is emitted.
+file(REMOVE "${PROJECT_SOURCE_DIR}/include/tscore/ink_config.h")
+file(REMOVE "${PROJECT_SOURCE_DIR}/include/ts/apidefs.h")
+file(REMOVE "${PROJECT_SOURCE_DIR}/include/ink_autoconf.h")
+
 configure_file(configs/storage.config.default.in configs/storage.config.default)
 configure_file(configs/records.yaml.default.in configs/records.yaml.default)
 configure_file(include/tscore/ink_config.h.cmake.in include/tscore/ink_config.h)


### PR DESCRIPTION
We removed this code on #10794 when we removed the support for autotools on master, but this is actually still helpful if people switch back and forth between 9.x and master.

The original code only removed `ink_config.h` and `ink_autoconf.h` but it should probably remove `apidefs.h` as well.