### PR TITLE
Fix 2 HTTP/2 trailing header memory leaks

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2829,6 +2829,7 @@ HttpSM::tunnel_handler_trailer(int event, void *data)
   }
   // Signal the _ua.get_txn() to get ready for a trailer
   _ua.get_txn()->set_expect_send_trailer();
+  tunnel.deallocate_buffers();
   tunnel.reset();
   HttpTunnelProducer *p = tunnel.add_producer(server_entry->vc, nbytes, buf_start, &HttpSM::tunnel_handler_trailer_server,
                                               HT_HTTP_SERVER, "http server trailer");

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -414,6 +414,10 @@ Http2ConnectionState::rcv_headers_frame(const Http2Frame &frame)
                       "header blocks too large");
   }
 
+  if (stream->trailing_header_is_possible()) {
+    // Don't leak the header_blocks from the initial, non-trailing headers.
+    ats_free(stream->header_blocks);
+  }
   stream->header_blocks = static_cast<uint8_t *>(ats_malloc(header_block_fragment_length));
   frame.reader()->memcpy(stream->header_blocks, header_block_fragment_length, header_block_fragment_offset);
 


### PR DESCRIPTION
This addresses two leaks discovered while testing gRPC: one in which the pre-trailer tunnel has to be deallocated when the trailing tunnel is set up, the other in which the header_block memory for the initial headers has to be cleaned up when the new trailing headers are being processed.