### PR TITLE
traffic_top: Allow traffic_top to be running while TS is down.

### DIFF
--- a/src/traffic_top/stats.h
+++ b/src/traffic_top/stats.h
@@ -353,7 +353,7 @@ public:
         if (key == "total_time") {
           old = old / 10000000;
         }
-        value = (value - old) / _time_diff;
+        value = _time_diff ? (value - old) / _time_diff : 0;
       }
     } else if (type == 3 || type == 4) {
       double numerator   = 0;


### PR DESCRIPTION
We can now have `traffic_top` running even when TS is down,  there is now a status message to know that `traffic_top` is connecting to the host.

![traffic_top2](https://github.com/apache/trafficserver/assets/16683788/06ccf4f5-d8a8-4806-9fd3-fc80b844318f)

Note the :arrow_up:  `connecting`  string at the bottom of the panel. Once connected, the hostname will be set in the bottom panel.
