### PR TITLE
qpack: Don't block decoding if Required Insert Count is zero

### DIFF
--- a/src/proxy/http3/QPACK.cc
+++ b/src/proxy/http3/QPACK.cc
@@ -267,7 +267,7 @@ QPACK::decode(uint64_t stream_id, const uint8_t *header_block, size_t header_blo
   }
   uint16_t largest_reference = tmp;
 
-  if (this->_dynamic_table.is_empty() || this->_dynamic_table.largest_index() < largest_reference) {
+  if (largest_reference != 0 && (this->_dynamic_table.is_empty() || this->_dynamic_table.largest_index() < largest_reference)) {
     // Blocked
     if (this->_add_to_blocked_list(
           new DecodeRequest(largest_reference, thread, cont, stream_id, header_block, header_block_len, hdr))) {


### PR DESCRIPTION
#11054 wasn't enough. If Required Insert Count is zero, we can start decoding immediately.

https://datatracker.ietf.org/doc/html/rfc9204#section-2.1.2-2

> For a field section encoded with no references to the dynamic table, the Required Insert Count is zero.