### PR TITLE
http3: Propagate events from QUICNetVC

### DIFF
--- a/include/proxy/http3/Http3Session.h
+++ b/include/proxy/http3/Http3Session.h
@@ -37,8 +37,6 @@ public:
   virtual ~HQSession();
 
   // Implement VConnection interface
-  VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = nullptr) override;
-  VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0, bool owner = false) override;
   void do_io_close(int lerrno = -1) override;
   void do_io_shutdown(ShutdownHowTo_t howto) override;
   void reenable(VIO *vio) override;
@@ -63,6 +61,8 @@ private:
   Queue<HQTransaction> _transaction_list;
 
   char _protocol_string[16];
+
+  int main_event_handler(int, void *);
 };
 
 class Http3Session : public HQSession

--- a/include/proxy/http3/Http3Transaction.h
+++ b/include/proxy/http3/Http3Transaction.h
@@ -84,6 +84,7 @@ protected:
   void _schedule_write_complete_event();
   void _unschedule_write_complete_event();
   void _close_write_complete_event(Event *e);
+  void _signal_event(int event);
   void _signal_read_event();
   void _signal_write_event();
   void _delete_if_possible();

--- a/src/iocore/net/P_QUICNetVConnection.h
+++ b/src/iocore/net/P_QUICNetVConnection.h
@@ -204,6 +204,8 @@ private:
   void _handle_write_ready();
   void _handle_interval();
 
+  void _propagate_event(int event);
+
   void _switch_to_established_state();
 
   bool _handshake_completed = false;

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -259,12 +259,14 @@ QUICNetVConnection::_start_application()
 void
 QUICNetVConnection::_propagate_event(int event)
 {
+  QUICConVDebug("Propagating: %d", event);
   if (this->read.vio.cont && this->read.vio.mutex == this->read.vio.cont->mutex) {
     this->read.vio.cont->handleEvent(event, &this->read.vio);
   } else if (this->write.vio.cont && this->write.vio.mutex == this->write.vio.cont->mutex) {
     this->write.vio.cont->handleEvent(event, &this->write.vio);
   } else {
     // Proxy Session does not exist
+    QUICConVDebug("Session does not exist");
   }
 }
 

--- a/src/proxy/http3/Http3Transaction.cc
+++ b/src/proxy/http3/Http3Transaction.cc
@@ -345,6 +345,19 @@ HQTransaction::_close_write_complete_event(Event *e)
   }
 }
 
+void
+HQTransaction::_signal_event(int event)
+{
+  if (this->_write_vio.cont) {
+    SCOPED_MUTEX_LOCK(lock, this->_write_vio.mutex, this_ethread());
+    this->_write_vio.cont->handleEvent(event);
+  }
+  if (this->_read_vio.cont && this->_read_vio.cont != this->_write_vio.cont) {
+    SCOPED_MUTEX_LOCK(lock, this->_read_vio.mutex, this_ethread());
+    this->_read_vio.cont->handleEvent(event);
+  }
+}
+
 /**
  * @brief Signal event to this->_read_vio.cont
  */
@@ -490,6 +503,7 @@ Http3Transaction::state_stream_open(int event, Event *edata)
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_ACTIVE_TIMEOUT: {
     Http3TransVDebug("%s (%d)", get_vc_event_name(event), event);
+    this->_signal_event(event);
     break;
   }
   default:


### PR DESCRIPTION
This is for #9392 and #9783. The crash (assertion failure) happens because transactions are not deleted due to lack of event propagation. This PR add a mechanism to propagate events such as INACTIVE_TIMEOUT from QUICNetVC to Http3Transaction through Http3Session.

The event handlers may need to handle other events and may also need to do different things for each event, but this change should prevent the crash at least.