### PR TITLE
Rename Http2FrequencyCounter to FrequencyCounter

### DIFF
--- a/include/proxy/http2/Http2ConnectionState.h
+++ b/include/proxy/http2/Http2ConnectionState.h
@@ -32,7 +32,7 @@
 #include "proxy/http2/HPACK.h"
 #include "proxy/http2/Http2Stream.h"
 #include "proxy/http2/Http2DependencyTree.h"
-#include "proxy/http2/Http2FrequencyCounter.h"
+#include "tscore/FrequencyCounter.h"
 
 class Http2CommonSession;
 class Http2Frame;
@@ -325,11 +325,11 @@ private:
   std::array<size_t, 5> _recent_rwnd_increment = {SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX, SIZE_MAX};
   int _recent_rwnd_increment_index             = 0;
 
-  Http2FrequencyCounter _received_settings_counter;
-  Http2FrequencyCounter _received_settings_frame_counter;
-  Http2FrequencyCounter _received_ping_frame_counter;
-  Http2FrequencyCounter _received_priority_frame_counter;
-  Http2FrequencyCounter _received_rst_stream_frame_counter;
+  FrequencyCounter _received_settings_counter;
+  FrequencyCounter _received_settings_frame_counter;
+  FrequencyCounter _received_ping_frame_counter;
+  FrequencyCounter _received_priority_frame_counter;
+  FrequencyCounter _received_rst_stream_frame_counter;
 
   /** Records the various settings for each SETTINGS frame that we've sent.
    *

--- a/include/tscore/FrequencyCounter.h
+++ b/include/tscore/FrequencyCounter.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Http2FrequencyCounter
+  FrequencyCounter
 
   @section license License
 
@@ -26,12 +26,12 @@
 #include <cstdint>
 #include "iocore/eventsystem/EventSystem.h"
 
-class Http2FrequencyCounter
+class FrequencyCounter
 {
 public:
   void increment(uint16_t amount = 1);
   uint32_t get_count();
-  virtual ~Http2FrequencyCounter() {}
+  virtual ~FrequencyCounter() {}
 
 protected:
   uint16_t _count[2]      = {0};

--- a/src/proxy/http2/CMakeLists.txt
+++ b/src/proxy/http2/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(
   Http2CommonSession.cc
   Http2ConnectionState.cc
   Http2DebugNames.cc
-  Http2FrequencyCounter.cc
   Http2Stream.cc
   Http2SessionAccept.cc
   Http2ServerSession.cc
@@ -56,10 +55,6 @@ if(BUILD_TESTING)
   add_executable(test_Http2DependencyTree unit_tests/test_Http2DependencyTree.cc)
   target_link_libraries(test_Http2DependencyTree PRIVATE catch2::catch2 tscore libswoc::libswoc)
   add_test(NAME test_Http2DependencyTree COMMAND test_Http2DependencyTree)
-
-  add_executable(test_Http2FrequencyCounter Http2FrequencyCounter.cc unit_tests/test_Http2FrequencyCounter.cc)
-  target_link_libraries(test_Http2FrequencyCounter PRIVATE catch2::catch2 tscore inkevent libswoc::libswoc)
-  add_test(NAME test_Http2FrequencyCounter COMMAND test_Http2FrequencyCounter)
 
   add_executable(test_HPACK test_HPACK.cc HPACK.cc)
   target_link_libraries(test_HPACK PRIVATE tscore hdrs inkevent)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -181,9 +181,10 @@ if(BUILD_TESTING)
             OpenSSL::Crypto
             OpenSSL::SSL
             catch2::catch2
+            inkevent
   )
   if(TS_USE_HWLOC)
-    target_link_libraries(test_tscore PRIVATE hwloc::hwloc inkevent)
+    target_link_libraries(test_tscore PRIVATE hwloc::hwloc)
   endif()
 
   add_test(NAME test_tscore COMMAND $<TARGET_FILE:test_tscore>)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -183,7 +183,7 @@ if(BUILD_TESTING)
             catch2::catch2
   )
   if(TS_USE_HWLOC)
-    target_link_libraries(test_tscore PRIVATE hwloc::hwloc)
+    target_link_libraries(test_tscore PRIVATE hwloc::hwloc inkevent)
   endif()
 
   add_test(NAME test_tscore COMMAND $<TARGET_FILE:test_tscore>)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(
   Errata.cc
   EventNotify.cc
   Extendible.cc
+  FrequencyCounter.cc
   Hash.cc
   HashFNV.cc
   HashSip.cc
@@ -147,6 +148,7 @@ if(BUILD_TESTING)
     unit_tests/test_Errata.cc
     unit_tests/test_Extendible.cc
     unit_tests/test_Encoding.cc
+    unit_tests/test_FrequencyCounter.cc
     unit_tests/test_HKDF.cc
     unit_tests/test_Histogram.cc
     unit_tests/test_History.cc

--- a/src/tscore/FrequencyCounter.cc
+++ b/src/tscore/FrequencyCounter.cc
@@ -1,6 +1,6 @@
 /** @file
 
-  Http2FrequencyCounter
+  FrequencyCounter
 
   @section license License
 
@@ -21,10 +21,10 @@
   limitations under the License.
  */
 
-#include "proxy/http2/Http2FrequencyCounter.h"
+#include "tscore/FrequencyCounter.h"
 
 void
-Http2FrequencyCounter::increment(uint16_t amount)
+FrequencyCounter::increment(uint16_t amount)
 {
   ink_hrtime hrtime_sec = this->_ink_get_hrtime();
   uint8_t counter_index = ((hrtime_sec % 60) >= 30);
@@ -49,13 +49,13 @@ Http2FrequencyCounter::increment(uint16_t amount)
 }
 
 uint32_t
-Http2FrequencyCounter::get_count()
+FrequencyCounter::get_count()
 {
   return this->_count[0] + this->_count[1];
 }
 
 ink_hrtime
-Http2FrequencyCounter::_ink_get_hrtime()
+FrequencyCounter::_ink_get_hrtime()
 {
   return ink_hrtime_to_sec(ink_get_hrtime());
 }

--- a/src/tscore/unit_tests/test_FrequencyCounter.cc
+++ b/src/tscore/unit_tests/test_FrequencyCounter.cc
@@ -1,6 +1,6 @@
 /** @file
 
-    Unit tests for Http2FrequencyCounter
+    Unit tests for FrequencyCounter
 
     @section license License
 
@@ -20,12 +20,11 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-#define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
-#include "proxy/http2/Http2FrequencyCounter.h"
+#include "tscore/FrequencyCounter.h"
 
-class TestHttp2FrequencyCounter : public Http2FrequencyCounter
+class TestFrequencyCounter : public FrequencyCounter
 {
 public:
   void
@@ -47,9 +46,9 @@ private:
   ink_hrtime _now = 0;
 };
 
-TEST_CASE("Http2FrequencyCounter_basic", "[http2][Http2FrequencyCounter]")
+TEST_CASE("FrequencyCounter_basic", "[FrequencyCounter]")
 {
-  TestHttp2FrequencyCounter counter;
+  TestFrequencyCounter counter;
 
   SECTION("basic")
   {


### PR DESCRIPTION
Frame counts need to be counted on HTTP/3 connections as well. This PR moves the frequency counter class into `tscore` from `proxy/http2`. It should be applicable for other counters.