### PR TITLE
Add ENABLE_CLANG_TIDY option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE -DATS_BUILD)
 
 include(layout)
+include(ClangTidy)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_compile_definitions(DEBUG _DEBUG)

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -28,14 +28,17 @@
 # }
 # ```
 
+if(ENABLE_CLANG_TIDY)
+  find_program(
+    CLANG_TIDY_EXE
+    NAMES "clang-tidy"
+    HINTS ${CLANG_TIDY_PATH}
+  )
+endif()
+
+
 function(clang_tidy_check target)
   if(ENABLE_CLANG_TIDY)
-    find_program(
-      CLANG_TIDY_EXE
-      NAMES "clang-tidy"
-      HINTS ${CLANG_TIDY_PATH}
-    )
-
     set_target_properties(${target} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};${CLANG_TIDY_OPTS};")
   endif()
 endfunction()

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,0 +1,41 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# ClangTidy.cmake
+#
+# This adds a function to enable clang-tidy to the target. The .clang-tidy config file is refered in default.
+#
+# - e.g.
+# ```
+# "cacheVariables": {
+#   "ENABLE_CLANG_TIDY": true,
+#   "CLANG_TIDY_PATH": "/opt/homebrew/opt/llvm/bin/"
+#   "CLANG_TIDY_OPTS": "--warnings-as-errors=*"
+# }
+# ```
+
+function(clang_tidy_check target)
+  if(ENABLE_CLANG_TIDY)
+    find_program(
+      CLANG_TIDY_EXE
+      NAMES "clang-tidy"
+      HINTS ${CLANG_TIDY_PATH}
+    )
+
+    set_target_properties(${target} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};${CLANG_TIDY_OPTS};")
+  endif()
+endfunction()

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -24,20 +24,36 @@
 # "cacheVariables": {
 #   "ENABLE_CLANG_TIDY": true,
 #   "CLANG_TIDY_PATH": "/opt/homebrew/opt/llvm/bin/"
-#   "CLANG_TIDY_OPTS": "--warnings-as-errors=*"
+#   "CLANG_TIDY_OPTS": "--fix;--warnings-as-errors=*"
 # }
 # ```
 
 if(ENABLE_CLANG_TIDY)
+  # Find clang-tidy program
   find_program(
     CLANG_TIDY_EXE
     NAMES "clang-tidy"
     HINTS ${CLANG_TIDY_PATH}
   )
+
+  # Add options if there
+  #
+  # CAVEAT: the option should not end with semi-colon. You'll see below error.
+  # ```
+  # error: unable to handle compilation, expected exactly one compiler job in '' [clang-diagnostic-error]
+  # ```
+  if(NOT "${CLANG_TIDY_OPTS}" STREQUAL "")
+    string(REGEX REPLACE ";$" "$" CLANG_TIDY_OPTS_TRIMMED ${CLANG_TIDY_OPTS})
+    string(APPEND CLANG_TIDY_EXE ";${CLANG_TIDY_OPTS_TRIMMED}")
+  endif()
+
+  message(STATUS "Enable clang-tidy - ${CLANG_TIDY_EXE}")
 endif()
 
 function(clang_tidy_check target)
-  if(ENABLE_CLANG_TIDY)
-    set_target_properties(${target} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};${CLANG_TIDY_OPTS};")
+  if(NOT ENABLE_CLANG_TIDY)
+    return()
   endif()
+
+  set_target_properties(${target} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endfunction()

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -36,7 +36,6 @@ if(ENABLE_CLANG_TIDY)
   )
 endif()
 
-
 function(clang_tidy_check target)
   if(ENABLE_CLANG_TIDY)
     set_target_properties(${target} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE};${CLANG_TIDY_OPTS};")

--- a/cmake/add_atsplugin.cmake
+++ b/cmake/add_atsplugin.cmake
@@ -24,6 +24,7 @@ function(add_atsplugin name)
   set_target_properties(${name} PROPERTIES SUFFIX ".so")
   remove_definitions(-DATS_BUILD) # remove the ATS_BUILD define for plugins to build without issue
   install(TARGETS ${name} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+  clang_tidy_check(${name})
 endfunction()
 
 function(verify_remap_plugin target)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -60,3 +60,5 @@ install(
 if(APPLE)
   target_link_options(tsapi PRIVATE -undefined dynamic_lookup)
 endif()
+
+clang_tidy_check(tsapi)

--- a/src/cripts/CMakeLists.txt
+++ b/src/cripts/CMakeLists.txt
@@ -79,3 +79,5 @@ add_custom_target(
   DEPENDS ${PROJECT_SOURCE_DIR}/src/shared/overridable_txn_vars.cc ${PROJECT_SOURCE_DIR}/tools/cripts/genconfig.py
   VERBATIM
 )
+
+clang_tidy_check(cripts)

--- a/src/iocore/aio/CMakeLists.txt
+++ b/src/iocore/aio/CMakeLists.txt
@@ -34,3 +34,5 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/iocore/aio
   )
 endif()
+
+clang_tidy_check(aio)

--- a/src/iocore/cache/CMakeLists.txt
+++ b/src/iocore/cache/CMakeLists.txt
@@ -87,3 +87,5 @@ if(BUILD_TESTING)
   add_cache_test(Update_Header unit_tests/test_Update_header.cc)
 
 endif()
+
+clang_tidy_check(inkcache)

--- a/src/iocore/dns/CMakeLists.txt
+++ b/src/iocore/dns/CMakeLists.txt
@@ -30,3 +30,5 @@ target_link_libraries(
          #ts::inknet cyclic dependency
          ts::proxy ts::tsutil ts::tscore
 )
+
+clang_tidy_check(inkdns)

--- a/src/iocore/eventsystem/CMakeLists.txt
+++ b/src/iocore/eventsystem/CMakeLists.txt
@@ -64,3 +64,5 @@ if(BUILD_TESTING)
   add_test(NAME test_MIOBufferWriter COMMAND test_MIOBufferWriter)
 
 endif()
+
+clang_tidy_check(inkevent)

--- a/src/iocore/hostdb/CMakeLists.txt
+++ b/src/iocore/hostdb/CMakeLists.txt
@@ -19,3 +19,5 @@ add_library(inkhostdb STATIC HostDB.cc Inline.cc RefCountCache.cc HostFile.cc Ho
 add_library(ts::inkhostdb ALIAS inkhostdb)
 
 target_link_libraries(inkhostdb PUBLIC ts::inkdns ts::inkevent ts::tscore)
+
+clang_tidy_check(inkhostdb)

--- a/src/iocore/io_uring/CMakeLists.txt
+++ b/src/iocore/io_uring/CMakeLists.txt
@@ -32,3 +32,5 @@ if(BUILD_TESTING)
 
   add_test(NAME test_iouring COMMAND $<TARGET_FILE:test_iouring>)
 endif()
+
+clang_tidy_check(inkuring)

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -125,3 +125,5 @@ if(BUILD_TESTING)
   target_compile_definitions(test_net PRIVATE LIBINKNET_UNIT_TEST_DIR=${LIBINKNET_UNIT_TEST_DIR})
   add_test(NAME test_net COMMAND test_net)
 endif()
+
+clang_tidy_check(inknet)

--- a/src/iocore/utils/CMakeLists.txt
+++ b/src/iocore/utils/CMakeLists.txt
@@ -19,3 +19,5 @@ add_library(inkutils STATIC Machine.cc OneWayMultiTunnel.cc OneWayTunnel.cc)
 add_library(ts::inkutils ALIAS inkutils)
 
 target_link_libraries(inkutils PUBLIC ts::inkevent ts::tscore)
+
+clang_tidy_check(inkutils)

--- a/src/mgmt/config/CMakeLists.txt
+++ b/src/mgmt/config/CMakeLists.txt
@@ -23,3 +23,5 @@ target_link_libraries(
   PUBLIC ts::tscore
   PRIVATE ts::proxy
 )
+
+clang_tidy_check(configmanager)

--- a/src/mgmt/rpc/CMakeLists.txt
+++ b/src/mgmt/rpc/CMakeLists.txt
@@ -61,3 +61,5 @@ if(BUILD_TESTING)
   target_link_libraries(test_jsonrpcserver catch2::catch2 ts::jsonrpc_server ts::inkevent libswoc::libswoc)
   add_test(NAME test_jsonrpcserver COMMAND test_jsonrpcserver)
 endif()
+
+clang_tidy_check(jsonrpc_protocol)

--- a/src/proxy/CMakeLists.txt
+++ b/src/proxy/CMakeLists.txt
@@ -59,3 +59,5 @@ add_subdirectory(logging)
 if(TS_USE_QUIC)
   add_subdirectory(http3)
 endif()
+
+clang_tidy_check(proxy)

--- a/src/proxy/hdrs/CMakeLists.txt
+++ b/src/proxy/hdrs/CMakeLists.txt
@@ -58,3 +58,5 @@ if(BUILD_TESTING)
   target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::hdrs ts::tscore ts::tsutil libswoc catch2::catch2)
   add_test(NAME test_proxy_hdrs_xpack COMMAND test_proxy_hdrs_xpack)
 endif()
+
+clang_tidy_check(hdrs)

--- a/src/proxy/http/CMakeLists.txt
+++ b/src/proxy/http/CMakeLists.txt
@@ -69,3 +69,5 @@ if(BUILD_TESTING)
   target_link_libraries(test_proxy_http PRIVATE catch2::catch2 hdrs tscore inkevent proxy logging)
   add_test(NAME test_proxy_http COMMAND test_proxy_http)
 endif(BUILD_TESTING)
+
+clang_tidy_check(http)

--- a/src/proxy/http2/CMakeLists.txt
+++ b/src/proxy/http2/CMakeLists.txt
@@ -60,3 +60,5 @@ if(BUILD_TESTING)
   target_link_libraries(test_HPACK PRIVATE tscore hdrs inkevent)
   add_test(NAME test_HPACK COMMAND test_HPACK -i ${CMAKE_CURRENT_SOURCE_DIR}/hpack-tests -o ./results)
 endif()
+
+clang_tidy_check(http2)

--- a/src/proxy/http3/CMakeLists.txt
+++ b/src/proxy/http3/CMakeLists.txt
@@ -83,3 +83,5 @@ target_link_libraries(
           ts::tscore
 )
 add_test(NAME test_qpack COMMAND test_qpack)
+
+clang_tidy_check(http3)

--- a/src/proxy/logging/CMakeLists.txt
+++ b/src/proxy/logging/CMakeLists.txt
@@ -49,3 +49,5 @@ if(BUILD_TESTING)
   target_link_libraries(test_RolledLogDeleter tscore records catch2::catch2)
   add_test(NAME test_RolledLogDeleter COMMAND test_RolledLogDeleter)
 endif()
+
+clang_tidy_check(logging)

--- a/src/records/CMakeLists.txt
+++ b/src/records/CMakeLists.txt
@@ -48,3 +48,5 @@ if(BUILD_TESTING)
   target_link_libraries(test_records_on_eventsystem PRIVATE records catch2::catch2 tscore libswoc::libswoc)
   add_test(NAME test_records_on_eventsystem COMMAND test_records_on_eventsystem)
 endif()
+
+clang_tidy_check(records)

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -19,3 +19,5 @@ add_library(overridable_txn_vars STATIC overridable_txn_vars.cc)
 add_library(ts::overridable_txn_vars ALIAS overridable_txn_vars)
 
 target_link_libraries(overridable_txn_vars PRIVATE ts::inknet)
+
+clang_tidy_check(overridable_txn_vars)

--- a/src/traffic_cache_tool/CMakeLists.txt
+++ b/src/traffic_cache_tool/CMakeLists.txt
@@ -19,3 +19,5 @@ add_executable(traffic_cache_tool CacheDefs.cc CacheTool.cc CacheScan.cc)
 
 target_link_libraries(traffic_cache_tool PRIVATE ts::tscore libswoc::libswoc ts::tsutil)
 install(TARGETS traffic_cache_tool)
+
+clang_tidy_check(traffic_cache_tool)

--- a/src/traffic_crashlog/CMakeLists.txt
+++ b/src/traffic_crashlog/CMakeLists.txt
@@ -24,3 +24,5 @@ if(TS_USE_REMOTE_UNWINDING)
 endif()
 
 install(TARGETS traffic_crashlog)
+
+clang_tidy_check(traffic_crashlog)

--- a/src/traffic_ctl/CMakeLists.txt
+++ b/src/traffic_ctl/CMakeLists.txt
@@ -23,3 +23,5 @@ add_executable(
 target_link_libraries(traffic_ctl ts::tscore libswoc::libswoc yaml-cpp::yaml-cpp ts::tsutil)
 
 install(TARGETS traffic_ctl)
+
+clang_tidy_check(traffic_ctl)

--- a/src/traffic_layout/CMakeLists.txt
+++ b/src/traffic_layout/CMakeLists.txt
@@ -32,3 +32,5 @@ if(HAVE_BROTLI_ENCODE_H)
 endif()
 
 install(TARGETS traffic_layout)
+
+clang_tidy_check(traffic_layout)

--- a/src/traffic_logcat/CMakeLists.txt
+++ b/src/traffic_logcat/CMakeLists.txt
@@ -18,3 +18,5 @@
 add_executable(traffic_logcat logcat.cc)
 target_link_libraries(traffic_logcat PRIVATE ts::logging ts::tscore ts::diagsconfig ts::inkevent)
 install(TARGETS traffic_logcat)
+
+clang_tidy_check(traffic_logcat)

--- a/src/traffic_logstats/CMakeLists.txt
+++ b/src/traffic_logstats/CMakeLists.txt
@@ -33,3 +33,5 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
   )
 endif()
+
+clang_tidy_check(traffic_logstats)

--- a/src/traffic_server/CMakeLists.txt
+++ b/src/traffic_server/CMakeLists.txt
@@ -65,3 +65,5 @@ endif(TS_USE_LINUX_IO_URING)
 set_target_properties(traffic_server PROPERTIES ENABLE_EXPORTS ON)
 
 install(TARGETS traffic_server)
+
+clang_tidy_check(traffic_server)

--- a/src/traffic_top/CMakeLists.txt
+++ b/src/traffic_top/CMakeLists.txt
@@ -19,3 +19,5 @@ add_executable(traffic_top traffic_top.cc ${CMAKE_SOURCE_DIR}/src/shared/rpc/IPC
 target_include_directories(traffic_top PRIVATE ${CURSES_INCLUDE_DIRS})
 target_link_libraries(traffic_top PRIVATE ts::tscore ts::inkevent libswoc::libswoc ${CURSES_LIBRARIES})
 install(TARGETS traffic_top)
+
+clang_tidy_check(traffic_top)

--- a/src/traffic_via/CMakeLists.txt
+++ b/src/traffic_via/CMakeLists.txt
@@ -19,6 +19,8 @@ add_executable(traffic_via traffic_via.cc)
 target_link_libraries(traffic_via ts::tscore libswoc::libswoc ts::tsutil)
 install(TARGETS traffic_via)
 
+clang_tidy_check(traffic_via)
+
 if(BUILD_TESTING)
   # Odd test to maintain compatibility with autotools.  This could be better.
   add_test(

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -98,7 +98,6 @@ add_library(
 )
 add_library(ts::tscore ALIAS tscore)
 
-include(ClangTidy)
 clang_tidy_check(tscore)
 
 # Some plugins link against ts::tscore and therefore need it to be compiled as

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -98,6 +98,9 @@ add_library(
 )
 add_library(ts::tscore ALIAS tscore)
 
+include(ClangTidy)
+clang_tidy_check(tscore)
+
 # Some plugins link against ts::tscore and therefore need it to be compiled as
 # position independent.
 set_target_properties(tscore PROPERTIES POSITION_INDEPENDENT_CODE TRUE)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -98,8 +98,6 @@ add_library(
 )
 add_library(ts::tscore ALIAS tscore)
 
-clang_tidy_check(tscore)
-
 # Some plugins link against ts::tscore and therefore need it to be compiled as
 # position independent.
 set_target_properties(tscore PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
@@ -191,3 +189,5 @@ if(BUILD_TESTING)
 
   add_test(NAME test_tscore COMMAND $<TARGET_FILE:test_tscore>)
 endif()
+
+clang_tidy_check(tscore)

--- a/src/tscpp/api/CMakeLists.txt
+++ b/src/tscpp/api/CMakeLists.txt
@@ -82,3 +82,5 @@ set(TSCPP_API_PUBLIC_HEADERS
 set_target_properties(tscppapi PROPERTIES PUBLIC_HEADER "${TSCPP_API_PUBLIC_HEADERS}")
 
 install(TARGETS tscppapi PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tscpp/api)
+
+clang_tidy_check(tscppapi)

--- a/src/tsutil/CMakeLists.txt
+++ b/src/tsutil/CMakeLists.txt
@@ -61,6 +61,9 @@ install(
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tsutil
 )
 
+include(ClangTidy)
+clang_tidy_check(tsutil)
+
 if(BUILD_TESTING)
   add_executable(
     test_tsutil

--- a/src/tsutil/CMakeLists.txt
+++ b/src/tsutil/CMakeLists.txt
@@ -61,7 +61,6 @@ install(
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tsutil
 )
 
-include(ClangTidy)
 clang_tidy_check(tsutil)
 
 if(BUILD_TESTING)

--- a/src/tsutil/CMakeLists.txt
+++ b/src/tsutil/CMakeLists.txt
@@ -61,8 +61,6 @@ install(
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tsutil
 )
 
-clang_tidy_check(tsutil)
-
 if(BUILD_TESTING)
   add_executable(
     test_tsutil
@@ -80,3 +78,5 @@ if(BUILD_TESTING)
 
   add_test(NAME test_tsutil COMMAND $<TARGET_FILE:test_tsutil>)
 endif()
+
+clang_tidy_check(tsutil)


### PR DESCRIPTION
CMake has a property called `<LANG>_CLANG_TIDY`.  This adds a function, `clang_tidy_check`, that set the property to the target if `ENABLE_CLANG_TIDY` is true. If it's enabled, `clang-tidy` check the rule in the `.clang-tidy` file when the target is compiled. 

https://cmake.org/cmake/help/v3.29/prop_tgt/LANG_CLANG_TIDY.html

The option is slightly different from what we used to have with auto tools, `make clang-tidy`, but this looks straight forward with cmake. 
