### PR TITLE
http3: Don't use chunked encoding unnecessarily

### DIFF
--- a/include/iocore/net/quic/QUICStream.h
+++ b/include/iocore/net/quic/QUICStream.h
@@ -51,6 +51,7 @@ public:
   const QUICConnectionInfoProvider *connection_info();
   QUICStreamDirection direction() const;
   bool is_bidirectional() const;
+  bool has_no_more_data() const;
 
   QUICOffset final_offset() const;
 
@@ -82,6 +83,7 @@ protected:
   QUICStreamAdapter *_adapter                  = nullptr;
   uint64_t _received_bytes                     = 0;
   uint64_t _sent_bytes                         = 0;
+  bool _has_no_more_data                       = false;
 };
 
 class QUICStreamStateListener

--- a/src/iocore/net/quic/QUICStream.cc
+++ b/src/iocore/net/quic/QUICStream.cc
@@ -55,6 +55,12 @@ QUICStream::is_bidirectional() const
   return ((this->_id & 0x03) < 0x02);
 }
 
+bool
+QUICStream::has_no_more_data() const
+{
+  return this->_has_no_more_data;
+}
+
 void
 QUICStream::set_io_adapter(QUICStreamAdapter *adapter)
 {
@@ -98,6 +104,7 @@ QUICStream::receive_data(quiche_conn *quiche_con)
     this->_adapter->write(this->_received_bytes, buf, read_len, fin);
     this->_received_bytes += read_len;
   }
+  this->_has_no_more_data = quiche_conn_stream_finished(quiche_con, this->_id);
 
   this->_adapter->encourge_read();
 }

--- a/src/proxy/http3/Http3Transaction.cc
+++ b/src/proxy/http3/Http3Transaction.cc
@@ -603,8 +603,8 @@ Http3Transaction::_process_write_vio()
 bool
 Http3Transaction::has_request_body(int64_t content_length, bool is_chunked_set) const
 {
-  // Has body if Content-Length != 0
-  if (content_length != 0) {
+  // Has body if Content-Length != 0 (content_length can be -1 if it's undefined)
+  if (content_length > 0) {
     return true;
   }
 
@@ -614,10 +614,9 @@ Http3Transaction::has_request_body(int64_t content_length, bool is_chunked_set) 
   }
 
   // No body if stream is already closed and DATA frame is not received yet
-  // TODO stream state
-  // if () {
-  //   return false;
-  // }
+  if (this->_info.adapter.stream().has_no_more_data()) {
+    return false;
+  }
 
   // No body if trailing header is received and DATA frame is not received yet
   // TODO trailing header


### PR DESCRIPTION
HTTP/3 request was handled as chunked internally because of an incomplete check.