### PR TITLE
doc: max_rst_stream_frames_per_minute defaults to 200

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4550,7 +4550,7 @@ HTTP/2 Configuration
    This limit only will be enforced if :ts:cv:`proxy.config.http2.stream_priority_enabled`
    is set to 1.
 
-.. ts:cv:: CONFIG proxy.config.http2.max_rst_stream_frames_per_minute INT 14
+.. ts:cv:: CONFIG proxy.config.http2.max_rst_stream_frames_per_minute INT 200
    :reloadable:
 
    Specifies how many RST_STREAM frames |TS| receives for a minute at maximum.


### PR DESCRIPTION
This tweaks our documentation to list the default value of proxy.config.http2.max_rst_stream_frames_per_minute to be the correct 200 default value rather than 14, which was probably copy and pasted from the max_settings_frames defaults.