### PR TITLE
IPRange.h: resolve compiler error about dangling pointer to temporary

### DIFF
--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -1985,7 +1985,13 @@ IPRangeView::clear() -> self_type & {
 
 inline bool
 IPRangeView::empty() const {
-  return AF_INET6 == _family ? _raw._6->empty() : AF_INET == _family ? _raw._4->empty() : true;
+  if (AF_INET6 == _family) {
+    return _raw._6->empty();
+  } else if (AF_INET == _family) {
+    return _raw._4->empty();
+  } else {
+    return true;
+  }
 }
 
 inline bool

--- a/plugins/experimental/txn_box/plugin/src/ip_space.cc
+++ b/plugins/experimental/txn_box/plugin/src/ip_space.cc
@@ -907,10 +907,10 @@ Mod_ip_space::operator()(Context &ctx, feature_type_for<IP_ADDR> addr)
   }
   Feature value{FeatureView::Literal("")};
   if (active._space) {
-    auto &&[range, payload] = *active._space->space.find(addr);
-    active._row             = range.empty() ? nullptr : &payload;
-    active._addr            = addr;
-    active._drtv            = drtv;
+    auto [range, payload] = *active._space->space.find(addr);
+    active._row           = range.empty() ? nullptr : &payload;
+    active._addr          = addr;
+    active._drtv          = drtv;
 
     // Current active data.
     auto *store = Txb_IP_Space::ctx_active_info(ctx);


### PR DESCRIPTION
This should resolve the compiler error in some of the branch builds and on my local machine with gcc 13.