### PR TITLE
ipspace: introduce intermediate temporary to restore the structed bining decl

### DIFF
--- a/plugins/experimental/txn_box/plugin/src/ip_space.cc
+++ b/plugins/experimental/txn_box/plugin/src/ip_space.cc
@@ -907,10 +907,11 @@ Mod_ip_space::operator()(Context &ctx, feature_type_for<IP_ADDR> addr)
   }
   Feature value{FeatureView::Literal("")};
   if (active._space) {
-    auto [range, payload] = *active._space->space.find(addr);
-    active._row           = range.empty() ? nullptr : &payload;
-    active._addr          = addr;
-    active._drtv          = drtv;
+    auto iter               = active._space->space.find(addr);
+    auto &&[range, payload] = *iter;
+    active._row             = range.empty() ? nullptr : &payload;
+    active._addr            = addr;
+    active._drtv            = drtv;
 
     // Current active data.
     auto *store = Txb_IP_Space::ctx_active_info(ctx);


### PR DESCRIPTION
An attempt to avoid the copy penalty of the previous PR #11090 