### PR TITLE
Cleanup: Remove deprecated MUTEX_TAKE_LOCK_FOR

### DIFF
--- a/include/iocore/eventsystem/Lock.h
+++ b/include/iocore/eventsystem/Lock.h
@@ -111,11 +111,9 @@
 #endif
 
 #ifdef DEBUG
-#define MUTEX_TAKE_LOCK(_m, _t)         Mutex_lock(MakeSourceLocation(), (char *)nullptr, _m, _t)
-#define MUTEX_TAKE_LOCK_FOR(_m, _t, _c) Mutex_lock(MakeSourceLocation(), nullptr, _m, _t)
+#define MUTEX_TAKE_LOCK(_m, _t) Mutex_lock(MakeSourceLocation(), (char *)nullptr, _m, _t)
 #else
-#define MUTEX_TAKE_LOCK(_m, _t)         Mutex_lock(_m, _t)
-#define MUTEX_TAKE_LOCK_FOR(_m, _t, _c) Mutex_lock(_m, _t)
+#define MUTEX_TAKE_LOCK(_m, _t) Mutex_lock(_m, _t)
 #endif // DEBUG
 
 #define MUTEX_UNTAKE_LOCK(_m, _t) Mutex_unlock(_m, _t)

--- a/src/iocore/eventsystem/UnixEThread.cc
+++ b/src/iocore/eventsystem/UnixEThread.cc
@@ -32,6 +32,7 @@
 //
 /////////////////////////////////////////////////////////////////////
 #include "P_EventSystem.h"
+#include "iocore/eventsystem/Lock.h"
 
 #if HAVE_EVENTFD
 #include <sys/eventfd.h>
@@ -328,9 +329,10 @@ EThread::execute()
   // Do the start event first.
   // coverity[lock]
   if (start_event) {
-    MUTEX_TAKE_LOCK_FOR(start_event->mutex, this, start_event->continuation);
-    start_event->continuation->handleEvent(EVENT_IMMEDIATE, start_event);
-    MUTEX_UNTAKE_LOCK(start_event->mutex, this);
+    {
+      SCOPED_MUTEX_LOCK(lock, start_event->mutex, this);
+      start_event->continuation->handleEvent(EVENT_IMMEDIATE, start_event);
+    }
     free_event(start_event);
     start_event = nullptr;
   }


### PR DESCRIPTION
`MUTEX_TAKE_LOCK_FOR` is one of deprecated macros in the Lock.h. The given continuation is unused and `SCOPED_MUTEX_LOCK` can replace this.