### PR TITLE
Python3.8: fix list type hints

### DIFF
--- a/tests/gold_tests/ip_allow/ip_category.test.py
+++ b/tests/gold_tests/ip_allow/ip_category.test.py
@@ -20,6 +20,8 @@ Verify IP allow ip_category behavior.
 import os
 import re
 
+from typing import List
+
 Test.Summary = '''
 Verify IP allow ip_category behavior.
 '''
@@ -28,7 +30,7 @@ Verify IP allow ip_category behavior.
 class CategoryFile:
     """Encapsulate the various ip_category.yaml contents."""
 
-    contents: list['CategoryFile'] = []
+    contents: List['CategoryFile'] = []
     parent_directory: str = Test.RunDirectory
     _index: int = 0
 
@@ -126,7 +128,7 @@ class Test_ip_category:
 
     def __init__(
             self, name: str, replay_file: str, ip_allow_config: str, ip_category_config: 'CategoryFile', acl_configuration: str,
-            expected_responses: list[int]):
+            expected_responses: List[int]):
         """Initialize the test.
 
         :param name: The name of the test.

--- a/tests/gold_tests/remap/remap_acl.test.py
+++ b/tests/gold_tests/remap/remap_acl.test.py
@@ -35,7 +35,7 @@ class Test_remap_acl:
 
     def __init__(
             self, name: str, replay_file: str, ip_allow_content: str, deactivate_ip_allow: bool, acl_configuration: str,
-            named_acls: List[Tuple[str, str]], expected_responses: list[int]):
+            named_acls: List[Tuple[str, str]], expected_responses: List[int]):
         """Initialize the test.
 
         :param name: The name of the test.


### PR DESCRIPTION
The `list` type hint works for recent Python versions, but not for older ones. This uses `typing.List` instead as that is backwards compatible.