### PR TITLE
fix hostdb.host_file.interval to be set at reconfig time

### DIFF
--- a/src/iocore/hostdb/P_HostDBProcessor.h
+++ b/src/iocore/hostdb/P_HostDBProcessor.h
@@ -235,9 +235,6 @@ struct HostDBContinuation : public Continuation {
   int retryEvent(int event, Event *e);
   int setbyEvent(int event, Event *e);
 
-  // update the host file config variables
-  void updateHostFileConfig();
-
   /// Recompute the hash and update ancillary values.
   void refresh_hash();
   void do_dns();


### PR DESCRIPTION
This fixes an issue where shortening the check interval would require waiting for the current interval to expire before the value was updated.