### PR TITLE
xpack: Fix division by zero error

### DIFF
--- a/include/proxy/hdrs/XPACK.h
+++ b/include/proxy/hdrs/XPACK.h
@@ -112,4 +112,9 @@ private:
    * Passing a value more than UINT32_MAX evicts every entry and return false.
    */
   bool _make_space(uint64_t required_size);
+
+  /**
+   * Calcurates the index number for _entries, which is a kind of circular buffer.
+   */
+  uint32_t _calc_index(uint32_t base, int64_t offset) const;
 };

--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -250,7 +250,7 @@ XpackDynamicTable::lookup(uint32_t index, const char **name, size_t *name_len, c
     return {0, XpackLookupResult::MatchType::NONE};
   }
 
-  uint32_t pos = this->_calc_index(this->_entries_head, -(this->_entries[this->_entries_head].index - index));
+  uint32_t pos = this->_calc_index(this->_entries_head, index - this->_entries[this->_entries_head].index);
   *name_len    = this->_entries[pos].name_len;
   *value_len   = this->_entries[pos].value_len;
   this->_storage.read(this->_entries[pos].offset, name, *name_len, value, *value_len);

--- a/src/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/src/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -126,6 +126,19 @@ TEST_CASE("XPACK_String", "[xpack]")
     }
   }
 
+  SECTION("Zero-size Dynamic Table")
+  {
+    XpackDynamicTable dt(0);
+    XpackLookupResult result;
+
+    REQUIRE(dt.size() == 0);
+    REQUIRE(dt.maximum_size() == 0);
+    REQUIRE(dt.is_empty());
+    REQUIRE(dt.count() == 0);
+    result = dt.lookup("", "");
+    REQUIRE(result.match_type == XpackLookupResult::MatchType::NONE);
+  }
+
   SECTION("Dynamic Table")
   {
     constexpr uint16_t MAX_SIZE = 128;


### PR DESCRIPTION
This fixes #11089. The error only happens when the size of a dynamic table is set to 0. It's not a common case but the crash can happen on H2 as well if ATS is configured not to use HPACK Dynamic Table at all.

The new test case does not crash on my box because the behavior of division-by-zero is undefined, but I think it's still nice to have.