### PR TITLE
Use EMERGENCY instead of FATAL for some certificate loading errors

### DIFF
--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -550,7 +550,7 @@ SSLConfigParams::initialize()
   }
   // Can't get SSL client context.
   if (this->clientCertExitOnLoadError) {
-    Fatal("Can't initialize the SSL client, HTTPS in remap rules will not function");
+    Emergency("Can't initialize the SSL client, HTTPS in remap rules will not function");
   } else {
     SSLError("Can't initialize the SSL client, HTTPS in remap rules will not function");
   }
@@ -637,7 +637,7 @@ SSLCertificateConfig::startup()
   // proxy.config.ssl.server.multicert.exit_on_load_fail is true
   SSLConfig::scoped_config params;
   if (!reconfigure() && params->configExitOnLoadError) {
-    Fatal("failed to load SSL certificate file, %s", params->configFilePath);
+    Emergency("failed to load SSL certificate file, %s", params->configFilePath);
   }
 
   return true;

--- a/tests/gold_tests/tls/exit_on_cert_load_fail.test.py
+++ b/tests/gold_tests/tls/exit_on_cert_load_fail.test.py
@@ -85,9 +85,9 @@ class Test_exit_on_cert_load_fail:
         self._ts.Disk.diags_log.Content = Testers.ContainsExpression("ERROR:", "These tests should have error logs.")
 
         if self.enable_exit_on_load:
-            self._ts.ReturnCode = 70
+            self._ts.ReturnCode = 33
             self._ts.Disk.diags_log.Content += Testers.ContainsExpression(
-                "FATAL: ", "Failure loading the certs results in a fatal error.")
+                "EMERGENCY: ", "Failure loading the certs results in an emergency error.")
             self._ts.Disk.diags_log.Content += Testers.ExcludesExpression(
                 "Traffic Server is fully initialized", "Traffic Server should exit upon the load failure.")
         else:

--- a/tests/gold_tests/tls/ssl_multicert_loader.test.py
+++ b/tests/gold_tests/tls/ssl_multicert_loader.test.py
@@ -102,8 +102,8 @@ tr4.Processes.Default.Command = 'echo Waiting'
 tr4.Processes.Default.ReturnCode = 0
 tr4.Processes.Default.StartBefore(ts2)
 
-ts2.ReturnCode = 70  # ink_fatal will exit with EX_SOFTWARE.
+ts2.ReturnCode = 33  # ink_emergency will exit with UNRECOVERABLE_EXIT.
 ts2.Ready = 0  # Need this to be 0 because we are testing shutdown, this is to make autest not think ats went away for a bad reason.
 ts2.Disk.traffic_out.Content = Testers.ExcludesExpression(
     'Traffic Server is fully initialized', 'process should fail when invalid certificate specified')
-ts2.Disk.diags_log.Content = Testers.IncludesExpression('FATAL: failed to load SSL certificate file', 'check diags.log"')
+ts2.Disk.diags_log.Content = Testers.IncludesExpression('EMERGENCY: failed to load SSL certificate file', 'check diags.log"')


### PR DESCRIPTION
@ywkaras  suggested in #10958 that it'd be better to use `EMERGENCY` for these errors. 

This PR updates that for both the client and server cert load failures. The corresponding Autest is updated also.