### PR TITLE
Coverity fixes. CID 1534726 ,  CID 1534745, CID1534723

### DIFF
--- a/plugins/experimental/txn_box/plugin/include/txn_box/accl_util.h
+++ b/plugins/experimental/txn_box/plugin/include/txn_box/accl_util.h
@@ -128,7 +128,7 @@ private:
   /// hold the first element on the entire tree.
   node_type_ptr _head;
   /// this gets incremented on every insert.
-  int32_t _rank_counter;
+  int32_t _rank_counter{0};
   /// recursive memory cleanup function.
   void freeup(Node *n);
   /// clean up function, should deal with all the crap.

--- a/plugins/experimental/txn_box/plugin/include/txn_box/accl_util.h
+++ b/plugins/experimental/txn_box/plugin/include/txn_box/accl_util.h
@@ -65,7 +65,7 @@ template <typename Key, typename Value> class StringTree
     using self_type = Node;
     using ptr_type  = self_type *;
 
-    Node(Key k, Value v, int32_t r = -1) : key{k}, value{v}, rank{r}
+    Node(Key k, Value v, int32_t r = -1) : key{std::move(k)}, value{std::move(v)}, rank{r}
     {
       left  = this;
       right = this;

--- a/plugins/experimental/txn_box/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/txn_box/unit_tests/CMakeLists.txt
@@ -28,7 +28,5 @@ target_link_libraries(
 )
 # After fighting with CMake over the include paths, it's just not worth it to be correct.
 # target_link_libraries should make this work but it doesn't. I can't figure out why.
-# target_include_directories(test_txn_box PRIVATE ../../plugin/include)
 target_include_directories(test_txn_box PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../plugin/include)
-# target_include_directories(test_txn_box PRIVATE ../../plugin/include ${trafficserver_INCLUDE_DIRS})
 add_test(NAME test_txn_box COMMAND test_txn_box)


### PR DESCRIPTION
- CID 1534726  COPY_INSTEAD_OF_MOVE (COPY_INSTEAD_OF_MOVE)
- CID 1534745  COPY_INSTEAD_OF_MOVE (COPY_INSTEAD_OF_MOVE)
- CID 1534723 Uninitialized scalar field