### PR TITLE
Added namespace fmt to function call format_to in Cripts

### DIFF
--- a/include/cripts/Crypto.hpp
+++ b/include/cripts/Crypto.hpp
@@ -264,7 +264,7 @@ template <> struct formatter<Crypto::SHA256> {
   auto
   format(Crypto::SHA256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", sha.hex());
+    return fmt::format_to(ctx.out(), "{}", sha.hex());
   }
 };
 
@@ -279,7 +279,7 @@ template <> struct formatter<Crypto::SHA512> {
   auto
   format(Crypto::SHA512 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", sha.hex());
+    return fmt::format_to(ctx.out(), "{}", sha.hex());
   }
 };
 
@@ -294,7 +294,7 @@ template <> struct formatter<Crypto::AES256> {
   auto
   format(Crypto::AES256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", Crypto::Base64::encode(sha.message()));
+    return fmt::format_to(ctx.out(), "{}", Crypto::Base64::encode(sha.message()));
   }
 };
 

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -571,7 +571,7 @@ template <> struct formatter<Header::Method> {
   auto
   format(Header::Method &method, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", method.getSV());
+    return fmt::format_to(ctx.out(), "{}", method.getSV());
   }
 };
 
@@ -586,7 +586,7 @@ template <> struct formatter<Header::String> {
   auto
   format(Header::String &str, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", str.getSV());
+    return fmt::format_to(ctx.out(), "{}", str.getSV());
   }
 };
 
@@ -601,7 +601,7 @@ template <> struct formatter<Header::Name> {
   auto
   format(Header::Name &name, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", name.getSV());
+    return fmt::format_to(ctx.out(), "{}", name.getSV());
   }
 };
 

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -574,7 +574,7 @@ template <> struct formatter<Versions> {
   auto
   format(Versions &version, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", version.getSV());
+    return fmt::format_to(ctx.out(), "{}", version.getSV());
   }
 };
 
@@ -589,7 +589,7 @@ template <> struct formatter<Versions::Major> {
   auto
   format(Versions::Major &major, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", integer(major));
+    return fmt::format_to(ctx.out(), "{}", integer(major));
   }
 };
 
@@ -604,7 +604,7 @@ template <> struct formatter<Versions::Minor> {
   auto
   format(Versions::Minor &minor, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", integer(minor));
+    return fmt::format_to(ctx.out(), "{}", integer(minor));
   }
 };
 
@@ -619,7 +619,7 @@ template <> struct formatter<Versions::Patch> {
   auto
   format(Versions::Patch &patch, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", integer(patch));
+    return fmt::format_to(ctx.out(), "{}", integer(patch));
   }
 };
 
@@ -634,7 +634,7 @@ template <> struct formatter<TSHttpStatus> {
   auto
   format(const TSHttpStatus &stat, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", static_cast<int>(stat));
+    return fmt::format_to(ctx.out(), "{}", static_cast<int>(stat));
   }
 };
 
@@ -649,7 +649,7 @@ template <> struct formatter<Cript::StringViewWrapper> {
   auto
   format(const Cript::StringViewWrapper &sv, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", sv.getSV());
+    return fmt::format_to(ctx.out(), "{}", sv.getSV());
   }
 };
 

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -138,7 +138,7 @@ template <> struct formatter<Time::Local> {
   auto
   format(Time::Local &time, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", time.epoch());
+    return fmt::format_to(ctx.out(), "{}", time.epoch());
   }
 };
 } // namespace fmt

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -663,7 +663,7 @@ template <> struct formatter<Url::Scheme> {
   auto
   format(Url::Scheme &scheme, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", scheme.getSV());
+    return fmt::format_to(ctx.out(), "{}", scheme.getSV());
   }
 };
 
@@ -678,7 +678,7 @@ template <> struct formatter<Url::Host> {
   auto
   format(Url::Host &host, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", host.getSV());
+    return fmt::format_to(ctx.out(), "{}", host.getSV());
   }
 };
 
@@ -693,7 +693,7 @@ template <> struct formatter<Url::Port> {
   auto
   format(Url::Port &port, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", integer(port));
+    return fmt::format_to(ctx.out(), "{}", integer(port));
   }
 };
 
@@ -708,7 +708,7 @@ template <> struct formatter<Url::Path::String> {
   auto
   format(Url::Path::String &path, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", path.getSV());
+    return fmt::format_to(ctx.out(), "{}", path.getSV());
   }
 };
 
@@ -723,7 +723,7 @@ template <> struct formatter<Url::Path> {
   auto
   format(Url::Path &path, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", path.getSV());
+    return fmt::format_to(ctx.out(), "{}", path.getSV());
   }
 };
 
@@ -738,7 +738,7 @@ template <> struct formatter<Url::Query::Parameter> {
   auto
   format(Url::Query::Parameter &param, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", param.getSV());
+    return fmt::format_to(ctx.out(), "{}", param.getSV());
   }
 };
 
@@ -753,7 +753,7 @@ template <> struct formatter<Url::Query> {
   auto
   format(Url::Query &query, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return format_to(ctx.out(), "{}", query.getSV());
+    return fmt::format_to(ctx.out(), "{}", query.getSV());
   }
 };
 


### PR DESCRIPTION
This fixes the build on Fedora 39, on my server.