### PR TITLE
cmake: Link pcre2 to src/api

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -23,7 +23,7 @@ set(TSAPI_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/ts/ts.h ${PROJECT_SOURCE_
                          ${PROJECT_SOURCE_DIR}/include/ts/TsException.h ${PROJECT_BINARY_DIR}/include/ts/apidefs.h
 )
 
-target_link_libraries(tsapi PRIVATE libswoc::libswoc yaml-cpp::yaml-cpp PCRE::PCRE OpenSSL::SSL)
+target_link_libraries(tsapi PRIVATE libswoc::libswoc yaml-cpp::yaml-cpp PCRE::PCRE PkgConfig::PCRE2 OpenSSL::SSL)
 set_target_properties(tsapi PROPERTIES PUBLIC_HEADER "${TSAPI_PUBLIC_HEADERS}")
 
 # Items common between api and other ts libraries


### PR DESCRIPTION
I get this error without the change.
```
[ 69%] Building CXX object src/api/CMakeFiles/tsapi.dir/InkAPI.cc.o
In file included from /Users/mkitajo/src/github.com/trafficserver/src/api/InkAPI.cc:32:
In file included from /Users/mkitajo/src/github.com/trafficserver/include/tscore/Encoding.h:23:
In file included from /Users/mkitajo/src/github.com/trafficserver/include/tscore/Diags.h:38:
In file included from /Users/mkitajo/src/github.com/trafficserver/include/tscore/DiagsTypes.h:45:
/Users/mkitajo/src/github.com/trafficserver/include/tsutil/Regex.h:32:10: fatal error: 'pcre2.h' file not found
#include <pcre2.h>
         ^~~~~~~~~
1 error generated.
```