### PR TITLE
http3: Propagate edata as well

### DIFF
--- a/include/proxy/http3/Http3Transaction.h
+++ b/include/proxy/http3/Http3Transaction.h
@@ -84,7 +84,7 @@ protected:
   void _schedule_write_complete_event();
   void _unschedule_write_complete_event();
   void _close_write_complete_event(Event *e);
-  void _signal_event(int event);
+  void _signal_event(int event, Event *e);
   void _signal_read_event();
   void _signal_write_event();
   void _delete_if_possible();

--- a/src/proxy/http3/Http3Session.cc
+++ b/src/proxy/http3/Http3Session.cc
@@ -164,7 +164,7 @@ HQSession::main_event_handler(int event, void *edata)
     this->do_io_close();
     for (HQTransaction *t = this->_transaction_list.head; t; t = static_cast<HQTransaction *>(t->link.next)) {
       SCOPED_MUTEX_LOCK(lock, t->mutex, this_ethread());
-      t->handleEvent(event);
+      t->handleEvent(event, edata);
     }
     break;
   }

--- a/src/proxy/http3/Http3Transaction.cc
+++ b/src/proxy/http3/Http3Transaction.cc
@@ -346,15 +346,15 @@ HQTransaction::_close_write_complete_event(Event *e)
 }
 
 void
-HQTransaction::_signal_event(int event)
+HQTransaction::_signal_event(int event, Event *edata)
 {
   if (this->_write_vio.cont) {
     SCOPED_MUTEX_LOCK(lock, this->_write_vio.mutex, this_ethread());
-    this->_write_vio.cont->handleEvent(event);
+    this->_write_vio.cont->handleEvent(event, edata);
   }
   if (this->_read_vio.cont && this->_read_vio.cont != this->_write_vio.cont) {
     SCOPED_MUTEX_LOCK(lock, this->_read_vio.mutex, this_ethread());
-    this->_read_vio.cont->handleEvent(event);
+    this->_read_vio.cont->handleEvent(event, edata);
   }
 }
 
@@ -503,7 +503,7 @@ Http3Transaction::state_stream_open(int event, Event *edata)
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_ACTIVE_TIMEOUT: {
     Http3TransVDebug("%s (%d)", get_vc_event_name(event), event);
-    this->_signal_event(event);
+    this->_signal_event(event, edata);
     break;
   }
   default:


### PR DESCRIPTION
I think this fixes https://github.com/apache/trafficserver/issues/11114.

It seems like `edata` should be a VIO when HttpSM receives INACTIVITY_TIMEOUT event (I confirmed this on H1 connection).