### PR TITLE
CI osx and fedora: -DENABLE_CRIPTS

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -136,7 +136,10 @@
       "displayName": "CI OSX",
       "description": "CI Pipeline config for OSX",
       "inherits": ["ci"],
-      "generator": "Unix Makefiles"
+      "generator": "Unix Makefiles",
+      "cacheVariables": {
+        "ENABLE_CRIPTS": true
+      }
     },
     {
       "name": "ci-rocky",
@@ -157,7 +160,8 @@
       "inherits": ["ci"],
       "cacheVariables": {
         "OPENSSL_ROOT_DIR": "/opt/openssl-quic",
-        "opentelemetry_ROOT": "/opt"
+        "opentelemetry_ROOT": "/opt",
+        "ENABLE_CRIPTS": true
       }
     },
     {


### PR DESCRIPTION
Update the CMakePresets.json to build cripts in CI for fedora:39 and osx.