### PR TITLE
[Fuzzing] Add fuzzing harness for `HTTP3Frame`

### DIFF
--- a/tests/fuzzing/CMakeLists.txt
+++ b/tests/fuzzing/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(fuzz_json fuzz_json.cc)
 add_executable(fuzz_proxy_protocol fuzz_proxy_protocol.cc)
 add_executable(fuzz_rec_http fuzz_rec_http.cc)
 add_executable(fuzz_yamlcpp fuzz_yamlcpp.cc)
+add_executable(fuzz_http3frame fuzz_http3frame.cc)
 
 target_link_libraries(fuzz_esi PRIVATE esi-common esicore)
 target_link_libraries(fuzz_hpack PRIVATE records tscore hdrs inkevent)
@@ -35,6 +36,8 @@ target_link_libraries(fuzz_json PRIVATE libswoc::libswoc yaml-cpp ts::jsonrpc_pr
 target_link_libraries(fuzz_proxy_protocol PRIVATE inknet inkevent ts::tscore yaml-cpp libswoc::libswoc)
 target_link_libraries(fuzz_rec_http PRIVATE records tscore libswoc::libswoc)
 target_link_libraries(fuzz_yamlcpp PRIVATE yaml-cpp)
+target_link_libraries(fuzz_http3frame PRIVATE ts::http3 ts::tscore)
+target_link_options(fuzz_http3frame PRIVATE "-fuse-ld=lld")
 
 target_sources(
   fuzz_hpack PRIVATE ${CMAKE_SOURCE_DIR}/src/proxy/http2/HTTP2.cc ${CMAKE_SOURCE_DIR}/src/proxy/http2/Http2Frame.cc

--- a/tests/fuzzing/fuzz_http3frame.cc
+++ b/tests/fuzzing/fuzz_http3frame.cc
@@ -29,7 +29,9 @@
 
 #define TEST_THREADS 1
 
-bool DoInitialization() {
+bool
+DoInitialization()
+{
   Layout::create();
   RecProcessInit();
   LibRecordsConfigInit();

--- a/tests/fuzzing/fuzz_http3frame.cc
+++ b/tests/fuzzing/fuzz_http3frame.cc
@@ -1,0 +1,57 @@
+/** @file
+
+   fuzzing proxy/http3frame
+
+   @section license License
+
+   Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+   See the NOTICE file distributed with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance with the License.  You may obtain a
+   copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied. See the License for the specific language governing permissions and limitations under
+   the License.
+*/
+
+#include "proxy/http3/Http3Frame.h"
+#include "proxy/http3/Http3Config.h"
+
+#include "records/RecordsConfig.h"
+#include "tscore/Layout.h"
+
+#define kMinInputLength 8
+#define kMaxInputLength 1024
+
+#define TEST_THREADS 1
+
+bool DoInitialization() {
+  Layout::create();
+  RecProcessInit();
+  LibRecordsConfigInit();
+
+  ink_event_system_init(EVENT_SYSTEM_MODULE_PUBLIC_VERSION);
+  eventProcessor.start(TEST_THREADS);
+  ts::Http3Config::startup();
+
+  return true;
+}
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *input_data, size_t size_data)
+{
+  if (size_data < kMinInputLength || size_data > kMaxInputLength) {
+    return 1;
+  }
+
+  static bool Initialized = DoInitialization();
+
+  Http3FrameFactory frame_factory;
+  frame_factory.fast_create(input_data, size_data);
+
+  return 0;
+}

--- a/tests/fuzzing/oss-fuzz.sh
+++ b/tests/fuzzing/oss-fuzz.sh
@@ -17,6 +17,26 @@
 #  limitations under the License.
 ################################################################################
 
+# install build stuff
+CFLAGS_SAVE="$CFLAGS"
+CXXFLAGS_SAVE="$CXXFLAGS"
+RUSTFLAGS_SAVE="$RUSTFLAGS"
+unset CFLAGS
+unset CXXFLAGS
+unset RUSTFLAGS
+export AFL_NOOPT=1
+
+apt-get install -y libev-dev libjemalloc-dev python2-dev libxml2-dev libpython2-dev libc-ares-dev libsystemd-dev libevent-dev libjansson-dev zlib1g-dev sudo autoconf libtool pkg-config
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=nightly
+export PATH="/root/.cargo/bin:${PATH}"
+
+BASE=/opt $SRC/trafficserver/tools/build_h3_tools.sh
+
+export CFLAGS="${CFLAGS_SAVE}"
+export CXXFLAGS="${CXXFLAGS_SAVE}"
+export RUSTFLAGS="${RUSTFLAGS_SAVE}"
+unset AFL_NOOPT
+
 # don't use __cxa_atexit for coverage sanitizer
 if [[ $SANITIZER = coverage ]]
 then
@@ -30,12 +50,16 @@ then
 fi
 
 mkdir -p build && cd build/
-cmake -DENABLE_POSIX_CAP=OFF -DENABLE_FUZZING=ON -DYAML_BUILD_SHARED_LIBS=OFF -DENABLE_HWLOC=OFF -DENABLE_JEMALLOC=OFF -DENABLE_LUAJIT=OFF ../.
+cmake -DENABLE_POSIX_CAP=OFF -DENABLE_FUZZING=ON -DYAML_BUILD_SHARED_LIBS=OFF -DENABLE_HWLOC=OFF -DENABLE_JEMALLOC=OFF -DENABLE_LUAJIT=OFF -Dquiche_ROOT=/opt/quiche -DENABLE_QUICHE=TRUE -DOPENSSL_INCLUDE_DIR=/opt/boringssl/include -DOPENSSL_ROOT_DIR=/opt/boringssl ../.
 make -j$(nproc) --ignore-errors
 
 cp tests/fuzzing/fuzz_* $OUT/
 cp -r tests/fuzzing/lib/ $OUT/
 cp $SRC/trafficserver/tests/fuzzing/*.zip  $OUT/
+
+cp /opt/boringssl/lib/libssl.so $OUT/lib/
+cp /opt/boringssl/lib/libcrypto.so $OUT/lib/
+cp /opt/quiche/lib/libquiche.so $OUT/lib/
 
 if [[ $SANITIZER = undefined ]]
 then


### PR DESCRIPTION
The `proxy/http3` package isn't covered by fuzz tests at all currently. Since HTTP3 is interfaced directly with the user-agent, it's a prime attack target.

This PR contributes a fuzzing setup for the `HTTP3Frame` parser. In depends on the H3 tools to compile, so we've extended `oss-fuzz.sh` to run the existing utility script.