### PR TITLE
cleanup cript example. add missing function

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -17,6 +17,8 @@
 
 # It might be better if this is a subproject
 
+include(add_atsplugin)
+
 add_subdirectory(plugins)
 if(ENABLE_CRIPTS)
   add_subdirectory(cripts)

--- a/example/cripts/CMakeLists.txt
+++ b/example/cripts/CMakeLists.txt
@@ -22,6 +22,7 @@ foreach(EXA ${CRIPTS_EXAMPLES})
   get_filename_component(EXA ${EXA} NAME_WLE)
   add_atsplugin(cripts_${EXA} ${EXA}.cc)
   target_link_libraries(cripts_${EXA} PRIVATE ts::cripts)
+  verify_remap_plugin(cripts_${EXA})
 endforeach()
 
 # This is a hack, but useful to run clang-tidy across all of Cripts

--- a/src/cripts/CMakeLists.txt
+++ b/src/cripts/CMakeLists.txt
@@ -52,7 +52,7 @@ set(CRIPTS_PUBLIC_HEADERS
 add_library(cripts SHARED ${CPP_FILES})
 add_library(ts::cripts ALIAS cripts)
 
-target_link_libraries(cripts PUBLIC libswoc::libswoc fmt::fmt PkgConfig::PCRE2 OpenSSL::Crypto ts::tsapi)
+target_link_libraries(cripts PUBLIC libswoc::libswoc fmt::fmt PkgConfig::PCRE2 OpenSSL::Crypto)
 set_target_properties(cripts PROPERTIES PUBLIC_HEADER "${CRIPTS_PUBLIC_HEADERS}")
 
 set_target_properties(

--- a/src/cripts/Lulu.cc
+++ b/src/cripts/Lulu.cc
@@ -166,6 +166,12 @@ Cript::string::split(char delim) const &
   return details::splitter<Cript::string_view>(*this, delim);
 }
 
+std::vector<Cript::string_view>
+Cript::splitter(Cript::string_view input, char delim)
+{
+  return {};
+}
+
 bool
 Control::Base::_get(Cript::Context *context) const
 {


### PR DESCRIPTION
This should fix the build issues with macOS and also allow the example cript plugin to pass verify.