### PR TITLE
http3: Fix a crash on READ_READY event for QPACK

### DIFF
--- a/src/proxy/http3/QPACK.cc
+++ b/src/proxy/http3/QPACK.cc
@@ -211,6 +211,7 @@ QPACK::event_handler(int event, Event *data)
     break;
   case VC_EVENT_EOS:
     adapter->clear_eos_event(data);
+    ret = EVENT_DONE;
     break;
   default:
     ret = EVENT_DONE;

--- a/src/proxy/http3/QPACK.cc
+++ b/src/proxy/http3/QPACK.cc
@@ -188,21 +188,29 @@ QPACK::on_stream_close(QUICStream &stream)
 int
 QPACK::event_handler(int event, Event *data)
 {
-  VIO *vio = reinterpret_cast<VIO *>(data);
+  VIO *vio                     = reinterpret_cast<VIO *>(data->cookie);
+  QUICStreamVCAdapter *adapter = static_cast<QUICStreamVCAdapter *>(vio->vc_server);
   int ret;
 
   switch (event) {
   case VC_EVENT_READ_READY:
+    adapter->clear_read_ready_event(data);
     ret = this->_on_read_ready(vio);
     break;
   case VC_EVENT_READ_COMPLETE:
+    adapter->clear_read_complete_event(data);
     ret = EVENT_DONE;
     break;
   case VC_EVENT_WRITE_READY:
+    adapter->clear_write_ready_event(data);
     ret = this->_on_write_ready(vio);
     break;
   case VC_EVENT_WRITE_COMPLETE:
+    adapter->clear_write_complete_event(data);
     ret = EVENT_DONE;
+    break;
+  case VC_EVENT_EOS:
+    adapter->clear_eos_event(data);
     break;
   default:
     ret = EVENT_DONE;


### PR DESCRIPTION
I think this fixes #11115. It seems like #10851, which is nothing wrong, woke up a sleeping bug.

The event handler in QPACK uses the second parameter `data` as a pointer for VIO, but if you look at the event handler in Http3App, it uses `data->cookie` instead. This is probably the reason the VIO has odd values.

https://github.com/apache/trafficserver/blob/36ff81f909aa026c0cedd021d1a6d3b4052ef716/src/proxy/http3/Http3App.cc#L131-L153