### PR TITLE
Fixed asan issue with global SSLAPIHooks not being deleted on shutdown

### DIFF
--- a/src/iocore/net/SSLAPIHooks.cc
+++ b/src/iocore/net/SSLAPIHooks.cc
@@ -25,15 +25,6 @@
 
 SSLAPIHooks *g_ssl_hooks = nullptr;
 
-namespace
-{
-// structure to delete the global hooks
-struct GlobalHooksDeleter {
-  ~GlobalHooksDeleter() { delete g_ssl_hooks; }
-};
-} // namespace
-GlobalHooksDeleter g_hooks_deleter;
-
 void
 init_global_ssl_hooks()
 {

--- a/src/iocore/net/SSLAPIHooks.cc
+++ b/src/iocore/net/SSLAPIHooks.cc
@@ -25,8 +25,19 @@
 
 SSLAPIHooks *g_ssl_hooks = nullptr;
 
+namespace
+{
+// structure to delete the global hooks
+struct GlobalHooksDeleter {
+  ~GlobalHooksDeleter() { delete g_ssl_hooks; }
+};
+} // namespace
+GlobalHooksDeleter g_hooks_deleter;
+
 void
 init_global_ssl_hooks()
 {
-  g_ssl_hooks = new SSLAPIHooks;
+  if (g_ssl_hooks == nullptr) {
+    g_ssl_hooks = new SSLAPIHooks;
+  }
 }


### PR DESCRIPTION
I didn't see where `g_ssl_hooks` was being deleted on shutdown and it was reporting this as a leak in asan.

I also saw in the unit tests `init_global_ssl_hooks()` was being called multiple times.  I added a check to make sure `g_ssl_hooks` was not being overridden.

