### PR TITLE
http3: Add missing declaration

### DIFF
--- a/include/proxy/http3/Http3Transaction.h
+++ b/include/proxy/http3/Http3Transaction.h
@@ -69,6 +69,9 @@ public:
   virtual int state_stream_closed(int event, Event *data) = 0;
   NetVConnectionContext_t direction() const;
 
+  // For Queue from tscore/Link.h
+  LINK(HQTransaction, link);
+
 protected:
   virtual int64_t _process_read_vio()  = 0;
   virtual int64_t _process_write_vio() = 0;


### PR DESCRIPTION
This may fix #11113.

The crash doesn't make sense at all. `HQSession` was iterating over `_transaction_list`, and touched a freed transaction. That's the use-after-free. And the objects in the list are `HQTransaction (Http3Transaction)`. The odd thing is that `HQTransaction::~HQTransaction` calls `HQSession::remove_transaction` to remove itself from the list. So the list should never contains freed transactions.

One thing I found is that the type of the list is `Queue` (from tscore/List.h) and it expects its items to have a member variable declared by `LINK` macro, and `HQTransaction` doesn't have it. This might have broken the list and caused the crash. This PR adds the LINK.