### PR TITLE
Work around a GCC bug for __sync_val_compare_and_swap on ARMv8.1+

### DIFF
--- a/include/tscore/ink_queue.h
+++ b/include/tscore/ink_queue.h
@@ -59,10 +59,10 @@ void ink_queue_load_64(void *dst, void *src);
 
 // passing a const volatile value of 0 works around a gcc bug
 #if TS_HAS_128BIT_CAS
-#define INK_QUEUE_LD(dst, src)                                                       \
-  const volatile __int128_t x = 0;                                                   \
-  do {                                                                               \
-    *(__int128_t *)&(dst) = __sync_val_compare_and_swap((__int128_t *)&(src), 0, x); \
+#define INK_QUEUE_LD(dst, src)                                                                     \
+  do {                                                                                             \
+    const volatile __int128_t iqld0 = 0;                                                           \
+    *(__int128_t *)&(dst)           = __sync_val_compare_and_swap((__int128_t *)&(src), 0, iqld0); \
   } while (0)
 #else
 #define INK_QUEUE_LD(dst, src) INK_QUEUE_LD64(dst, src)

--- a/include/tscore/ink_queue.h
+++ b/include/tscore/ink_queue.h
@@ -57,10 +57,12 @@ void ink_queue_load_64(void *dst, void *src);
 #define INK_QUEUE_LD64(dst, src) (ink_queue_load_64((void *)&(dst), (void *)&(src)))
 #endif
 
+// passing a const volatile value of 0 works around a gcc bug
 #if TS_HAS_128BIT_CAS
 #define INK_QUEUE_LD(dst, src)                                                       \
+  const volatile __int128_t x = 0;                                                   \
   do {                                                                               \
-    *(__int128_t *)&(dst) = __sync_val_compare_and_swap((__int128_t *)&(src), 0, 0); \
+    *(__int128_t *)&(dst) = __sync_val_compare_and_swap((__int128_t *)&(src), 0, x); \
   } while (0)
 #else
 #define INK_QUEUE_LD(dst, src) INK_QUEUE_LD64(dst, src)


### PR DESCRIPTION
While trying to build trafficserver on gcc with `-march=armv8.1-a` (or newer) I discovered a bug in gcc in which it fails to compile `__sync_val_compare_and_swap (type *ptr, type oldval, type newval)` if `newval == 0`. 

I have examples on Godbolt showing the test failure: https://godbolt.org/z/a8d6oa4K6

I am able to replicate this issue on every release of gcc since 8.5.0. This issue does not appear with clang. 

We do have a CMake guard that should have prevented this issue by not activating that code path: https://github.com/apache/trafficserver/blob/b70e3d1ac8c3723a37f1c1beba12e4f6ee3a0364/cmake/Check128BitCas.cmake

However, its `newval == 10`, which would not trigger the issue. 

This PR works around the bug and tested to work with optimization flags `-O1` through `-O3` but _not_ `-Ox`. 