### PR TITLE
Fix a build error

### DIFF
--- a/src/iocore/net/quic/QUICTypes.cc
+++ b/src/iocore/net/quic/QUICTypes.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 
 #include "iocore/net/quic/QUICTypes.h"
 #include "iocore/net/quic/QUICIntUtil.h"


### PR DESCRIPTION
Before #10986 sstream was indirectly included by tscore/Errata.h but now it's not with libswoc.