### PR TITLE
Adds TSHttpTxnErrorBodyGet() corresponding to the Set

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnErrorBodySet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnErrorBodySet.en.rst
@@ -39,3 +39,24 @@ Note that both string arguments must be allocated with :c:func:`TSmalloc` or
 :c:func:`TSstrdup`.  The :arg:`mimetype` is optional, and if not provided it
 defaults to :literal:`text/html`. Sending an empty string would prevent setting
 a content type header (but that is not advised).
+
+
+TSHttpTxnErrorBodyGet
+*********************
+
+Gets the error body as set above.
+
+Synopsis
+========
+
+.. code-block:: cpp
+
+    #include <ts/ts.h>
+
+.. function:: char * TSHttpTxnErrorBodyGet(TSHttpTxn txnp, size_t *buflength, char **mimetype)
+
+Description
+===========
+
+This is the getter version for the above setter. The :arg:`mimetype` and the :arg:`buflength`
+arguments can be :const:`nullptr` if the caller is not interested in the mimetype or the length.

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1603,6 +1603,16 @@ TSReturnCode TSHttpTxnServerPacketDscpSet(TSHttpTxn txnp, int dscp);
 void TSHttpTxnErrorBodySet(TSHttpTxn txnp, char *buf, size_t buflength, char *mimetype);
 
 /**
+   Retrives the error body, if any, from a transaction. This would be a body as set
+   via the API body.
+
+   @param txnp HTTP transaction whose parent proxy to get.
+   @param buflength Optional outpu pointer to the length of the body message.
+   @param mimetype Optional output pointer to the MIME type of the response.
+*/
+char *TSHttpTxnErrorBodyGet(TSHttpTxn txnp, size_t *buflength, char **mimetype);
+
+/**
     Retrieves the parent proxy hostname and port, if parent
     proxying is enabled. If parent proxying is not enabled,
     TSHttpTxnParentProxyGet() sets hostname to nullptr and port to -1.

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -4848,6 +4848,25 @@ TSHttpTxnErrorBodySet(TSHttpTxn txnp, char *buf, size_t buflength, char *mimetyp
   s->internal_msg_buffer_type = mimetype;
 }
 
+char *
+TSHttpTxnErrorBodyGet(TSHttpTxn txnp, size_t *buflength, char **mimetype)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  HttpSM *sm             = (HttpSM *)txnp;
+  HttpTransact::State *s = &(sm->t_state);
+
+  if (buflength) {
+    *buflength = s->internal_msg_buffer_size;
+  }
+
+  if (mimetype) {
+    *mimetype = s->internal_msg_buffer_type;
+  }
+
+  return s->internal_msg_buffer;
+}
+
 void
 TSHttpTxnServerRequestBodySet(TSHttpTxn txnp, char *buf, int64_t buflength)
 {


### PR DESCRIPTION
One use case here (a separate PR) is that a plugin like header_rewrite  (or Cripts / TxnBox) can now check if the error body has been set in a plugin agnostic way (so can set it it one plugin, check in another). For header_rewrite, this actually would allow the set-body operator to work even when the request is read from cache or going to origin (thanks Jasmine).