### PR TITLE
RegexContext instance created in the heap for each thread is leaked.

### DIFF
--- a/include/tscore/DiagsTypes.h
+++ b/include/tscore/DiagsTypes.h
@@ -156,6 +156,8 @@ public:
     return unlikely(this->on(mode)) && tag_activated(tag, mode);
   }
 
+  void cons_thread_local() override;
+
   /////////////////////////////////////
   // low-level tag inquiry functions //
   /////////////////////////////////////

--- a/include/tsutil/DbgCtl.h
+++ b/include/tsutil/DbgCtl.h
@@ -45,6 +45,14 @@ public:
   virtual void print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocation *loc, const char *format_string,
                         va_list ap) const              = 0;
 
+  // Trigger the construction of all statically allocated thread_local variables used by the instance of the derived
+  // class, which have non-trivial destructors.  This is necessary to avoid a potential deadlock condition when loading
+  // a plugin.
+  virtual void
+  cons_thread_local()
+  {
+  }
+
   static DebugInterface *get_instance();
   static void set_instance(DebugInterface *);
 

--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -134,6 +134,8 @@ public:
   /// @return The number of capture groups in the compiled pattern.
   int get_capture_count();
 
+  static void cons_thread_local();
+
 private:
   // @internal - Because the PCRE header is badly done, we can't forward declare the PCRE
   // enough to use as pointers. For some reason the header defines in name only a struct and

--- a/src/tscore/Diags.cc
+++ b/src/tscore/Diags.cc
@@ -314,6 +314,12 @@ Diags::print_va(const char *debug_tag, DiagsLevel diags_level, const SourceLocat
 #endif
 }
 
+void
+Diags::cons_thread_local()
+{
+  Regex::cons_thread_local();
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 //      bool Diags::tag_activated(char * tag, DiagsTagType mode)


### PR DESCRIPTION
Damien found by running an ASAN build that the RegexContext instance created in the heap for each thread is leaked. The thread_local RegexContextCleanup variables are never constructed becasue they are never referenced in any thread.

The solution is a different approach to avoiding deadlock when loading plugins with statically allocated DbgCtl instances.  Construction of thread_locals is avoided while the DbgCtl registry mutex is locked.