### PR TITLE
Fix a build issue with autest plugins

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,9 +27,12 @@ function(ADD_AUTEST_PLUGIN _NAME)
                        "$<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INCLUDE_DIRECTORIES>"
     )
   endif()
-  set_target_properties(${_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.libs")
-  set_target_properties(${_NAME} PROPERTIES PREFIX "")
-  set_target_properties(${_NAME} PROPERTIES SUFFIX ".so")
+  set_target_properties(
+    ${_NAME} 
+    PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.libs"
+               PREFIX ""
+               SUFFIX ".so"
+  )
   remove_definitions(-DATS_BUILD) # remove the ATS_BUILD define for plugins to build without issue
 endfunction()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,15 +15,21 @@
 #
 #######################
 
+include(add_atsplugin)
+
 function(ADD_AUTEST_PLUGIN _NAME)
   add_library(${_NAME} MODULE ${ARGN})
-  set_target_properties(
-    ${_NAME}
-    PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.libs"
-               PREFIX ""
-               SUFFIX ".so"
-  )
-  target_link_libraries(${_NAME} PRIVATE ts::tsapi ts::tsutil)
+  if(LINK_PLUGINS AND BUILD_SHARED_LIBS)
+    target_link_libraries(${_NAME} PRIVATE ts::tsapi ts::tsutil)
+  else()
+    target_include_directories(
+      ${_NAME} PRIVATE "$<TARGET_PROPERTY:libswoc::libswoc,INCLUDE_DIRECTORIES>"
+                       "$<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INCLUDE_DIRECTORIES>"
+    )
+  endif()
+  set_target_properties(${_NAME} PROPERTIES PREFIX "")
+  set_target_properties(${_NAME} PROPERTIES SUFFIX ".so")
+  remove_definitions(-DATS_BUILD) # remove the ATS_BUILD define for plugins to build without issue
 endfunction()
 
 add_subdirectory(tools/plugins)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ function(ADD_AUTEST_PLUGIN _NAME)
     )
   endif()
   set_target_properties(
-    ${_NAME} 
+    ${_NAME}
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.libs"
                PREFIX ""
                SUFFIX ".so"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,6 @@ function(ADD_AUTEST_PLUGIN _NAME)
                PREFIX ""
                SUFFIX ".so"
   )
-  remove_definitions(-DATS_BUILD) # remove the ATS_BUILD define for plugins to build without issue
 endfunction()
 
 add_subdirectory(tools/plugins)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ function(ADD_AUTEST_PLUGIN _NAME)
                        "$<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INCLUDE_DIRECTORIES>"
     )
   endif()
+  set_target_properties(${_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.libs")
   set_target_properties(${_NAME} PROPERTIES PREFIX "")
   set_target_properties(${_NAME} PROPERTIES SUFFIX ".so")
   remove_definitions(-DATS_BUILD) # remove the ATS_BUILD define for plugins to build without issue


### PR DESCRIPTION
- Make the logic for autest plugins match ats plugins.
- Allow undefined symbols on Mac builds, to build missing_mangled_definition.