### PR TITLE
Restore alignment for structs stored in cache

### DIFF
--- a/include/proxy/hdrs/HTTP.h
+++ b/include/proxy/hdrs/HTTP.h
@@ -480,19 +480,19 @@ class HTTPHdr : public MIMEHdr
 public:
   HTTPHdrImpl *m_http = nullptr;
   mutable URL m_url_cached;
-  mutable bool m_100_continue_required = false; ///< Whether 100_continue is in the Expect header.
-  mutable bool m_target_in_url         = false; ///< Whether host name and port are in the URL.
+  mutable MIMEField *m_host_mime       = nullptr;
+  mutable int m_host_length            = 0;     ///< Length of hostname.
+  mutable int m_port                   = 0;     ///< Target port.
   mutable bool m_target_cached         = false; ///< Whether host name and port are cached.
-  mutable bool early_data              = false;
+  mutable bool m_target_in_url         = false; ///< Whether host name and port are in the URL.
+  mutable bool m_100_continue_required = false; ///< Whether 100_continue is in the Expect header.
   /// Set if the port was effectively specified in the header.
   /// @c true if the target (in the URL or the HOST field) also specified
   /// a port. That is, @c true if whatever source had the target host
   /// also had a port, @c false otherwise.
   mutable bool m_port_in_header = false;
 
-  mutable int m_port             = 0; ///< Target port.
-  mutable int m_host_length      = 0; ///< Length of hostname.
-  mutable MIMEField *m_host_mime = nullptr;
+  mutable bool early_data = false;
 
   HTTPHdr() = default; // Force the creation of the default constructor
 

--- a/include/proxy/hdrs/HdrHeap.h
+++ b/include/proxy/hdrs/HdrHeap.h
@@ -271,13 +271,11 @@ public:
   void dump_heap(int len = -1);
 
   uint32_t m_magic;
-  bool m_writeable;
   char *m_free_start;
   char *m_data_start;
   uint32_t m_size;
 
-  // HdrBuf heap pointers
-  uint32_t m_free_size;
+  bool m_writeable;
 
   // Overflow block ptr
   //   Overflow blocks are necessary because we can
@@ -287,6 +285,9 @@ public:
   //    header on them, although only first block can
   //    point to string heaps
   HdrHeap *m_next;
+
+  // HdrBuf heap pointers
+  uint32_t m_free_size;
 
   int demote_rw_str_heap();
   void coalesce_str_heaps(int incoming_size = 0);
@@ -330,8 +331,8 @@ public:
 
   // String Heap access
   Ptr<HdrStrHeap> m_read_write_heap;
-  int m_lost_string_space;
   StrHeapDesc m_ronly_heap[HDR_BUF_RONLY_HEAPS];
+  int m_lost_string_space;
 };
 
 static constexpr HdrHeapMarshalBlocks HDR_HEAP_HDR_SIZE{swoc::round_up(sizeof(HdrHeap))};


### PR DESCRIPTION
PR #9481 changed the alignment on structs that are stored in cache.  This breaks the cache.