### PR TITLE
set compile definition to turn on maxminddb

### DIFF
--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
 )
 
 if(maxminddb_FOUND)
+  target_compile_definitions(header_rewrite PUBLIC TS_USE_HRW_MAXMINDDB=1)
   target_sources(header_rewrite PRIVATE conditions_geo_maxmind.cc)
   target_link_libraries(header_rewrite PRIVATE maxminddb::maxminddb)
 endif()


### PR DESCRIPTION
This was causing errors to show up in the logs since no geo service was available.