### PR TITLE
Update HTTP3 test to use hostname instead of numeric address.

### DIFF
--- a/tests/gold_tests/timeout/active_timeout.test.py
+++ b/tests/gold_tests/timeout/active_timeout.test.py
@@ -62,5 +62,5 @@ tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Time
 
 if Condition.HasATSFeature('TS_HAS_QUICHE') and Condition.HasCurlFeature('http3'):
     tr4 = Test.AddTestRun("tr")
-    tr4.Processes.Default.Command = 'curl -k -i --http3 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port)
+    tr4.Processes.Default.Command = 'curl -k -i --http3 https://localhost:{0}/file'.format(ts.Variables.ssl_port)
     tr4.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")


### PR DESCRIPTION
Curl was sending an invalid SNI as the SNI [extension](https://datatracker.ietf.org/doc/html/rfc9114#section-3.2-2) is not necesary when the host is numeric.

This fixes this particular test in the  quiche ci build.