### PR TITLE
Version update: libswoc 1.5.11

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.5.5")
+set(LIBSWOC_VERSION "1.5.11")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_9
+#define SWOC_VERSION_NS _1_5_11
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 9;
+static constexpr unsigned POINT_VERSION = 11;
 }} // namespace swoc::SWOC_VERSION_NS


### PR DESCRIPTION
I pulled in our ATS libswoc patches into apache/trafficserver-libswoc and cut a 1.5.11 release with that. This updates just the version we have internally to match that release. The code between both ATS libswoc and trafficserver-libswoc are now identical with
1.5.11