### PR TITLE
Get Stripe::aggWrite into a test harness

### DIFF
--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -26,6 +26,8 @@
 #include "iocore/cache/AggregateWriteBuffer.h"
 #include "iocore/cache/CacheEvacuateDocVC.h"
 
+// These macros allow two incrementing unsigned values x and y to maintain
+// their ordering when one of them overflows, given that the values stay close to each other.
 #define UINT_WRAP_LTE(_x, _y) (((_y) - (_x)) < INT_MAX)  // exploit overflow
 #define UINT_WRAP_GTE(_x, _y) (((_x) - (_y)) < INT_MAX)  // exploit overflow
 #define UINT_WRAP_LT(_x, _y)  (((_x) - (_y)) >= INT_MAX) // exploit overflow

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -176,10 +176,8 @@ attach_tmpfile_to_stripe(Stripe &stripe)
 // We can't return a stripe from this function because the copy
 // and move constructors are deleted.
 static void
-init_stripe_for_writing(Stripe &stripe, StripteHeaderFooter &header)
+init_stripe_for_writing(Stripe &stripe, StripteHeaderFooter &header, CacheVol &cache_vol)
 {
-  // These things are needed for the metrics increments in agg_copy.
-  CacheVol cache_vol;
   stripe.cache_vol                                = &cache_vol;
   cache_rsb.write_backlog_failure                 = Metrics::Counter::createPtr("unit_test.write.backlog.failure");
   stripe.cache_vol->vol_rsb.write_backlog_failure = Metrics::Counter::createPtr("unit_test.write.backlog.failure");
@@ -266,7 +264,8 @@ TEST_CASE("aggWrite behavior")
 {
   Stripe stripe;
   StripteHeaderFooter header;
-  init_stripe_for_writing(stripe, header);
+  CacheVol cache_vol;
+  init_stripe_for_writing(stripe, header, cache_vol);
   WaitingVC vc{&stripe};
   vc.set_write_len(1);
   vc.set_agg_len(stripe.round_to_approx_size(vc.write_len + vc.header_len + vc.frag_len));

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -264,7 +264,7 @@ TEST_CASE("aggWrite behavior")
   {
     header.agg_pos = 0;
     {
-      CACHE_TRY_LOCK(lock, stripe.mutex, this_ethread());
+      SCOPED_MUTEX_LOCK(lock, stripe.mutex, this_ethread());
       stripe.aggWrite(0, 0);
     }
     // The virtual connection's callback should be called after aggWrite.
@@ -288,7 +288,7 @@ TEST_CASE("aggWrite behavior")
     header.write_serial = 10;
 
     {
-      CACHE_TRY_LOCK(lock, stripe.mutex, this_ethread());
+      SCOPED_MUTEX_LOCK(lock, stripe.mutex, this_ethread());
       stripe.aggWrite(0, 0);
     }
 

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -278,7 +278,7 @@ TEST_CASE("aggWrite behavior")
     header.agg_pos = 0;
     {
       SCOPED_MUTEX_LOCK(lock, stripe.mutex, this_ethread());
-      stripe.aggWrite(0, 0);
+      stripe.aggWrite(EVENT_NONE, 0);
     }
     vc.wait_for_callback();
     CHECK(0 == header.agg_pos);
@@ -294,7 +294,7 @@ TEST_CASE("aggWrite behavior")
     header.write_serial = 10;
     {
       SCOPED_MUTEX_LOCK(lock, stripe.mutex, this_ethread());
-      stripe.aggWrite(0, 0);
+      stripe.aggWrite(EVENT_NONE, 0);
     }
     vc.wait_for_callback();
     // We don't check here what bytes were written. In fact according

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -270,10 +270,12 @@ TEST_CASE("aggWrite behavior")
     // The virtual connection's callback should be called after aggWrite.
     // If we don't wait for it, it could come after the connection object
     // is freed and cause and invalid memory access.
+    notifier.lock();
     while (vc.calls < 1) {
-      notifier.lock();
       notifier.wait();
     }
+    notifier.unlock();
+
     CHECK(0 == header.agg_pos);
   }
 
@@ -292,10 +294,12 @@ TEST_CASE("aggWrite behavior")
       stripe.aggWrite(0, 0);
     }
 
+    notifier.lock();
     while (vc.calls < 1) {
-      notifier.lock();
       notifier.wait();
     }
+    notifier.unlock();
+
     // We don't check here what bytes were written. In fact according
     // to valgrind it's writing uninitialized parts of the aggregation
     // buffer, but that's OK because in this SECTION we only care that

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -231,7 +231,7 @@ TEST_CASE("aggWrite behavior")
   // I just picked values that happen to work.
   stripe.sector_size = 256;
   stripe.skip        = 0;
-  stripe.len         = 1024;
+  stripe.len         = 600000000000000;
   stripe.segments    = 1;
   stripe.buckets     = 4;
   stripe.start       = stripe.skip + 2 * stripe.dirlen();
@@ -242,7 +242,7 @@ TEST_CASE("aggWrite behavior")
   memset(static_cast<void *>(stripe.evacuate), 0, 2024);
 
   StripteHeaderFooter header;
-  header.write_pos = 0;
+  header.write_pos = 50000;
   header.agg_pos   = 1;
   stripe.header    = &header;
   attach_tmpfile_to_stripe(stripe);
@@ -256,7 +256,6 @@ TEST_CASE("aggWrite behavior")
   vc.set_write_len(1);
   vc.set_agg_len(stripe.round_to_approx_size(vc.write_len + vc.header_len + vc.frag_len));
 
-  stripe.len = vc.agg_len + header.write_pos + 1;
   stripe.add_writer(&vc);
 
   SECTION("Given the aggregation buffer is only partially full and no sync, "


### PR DESCRIPTION
This demonstrates how to set up and perform a working write to disk on a Stripe. The data is written to a tmpfile that the test holds the file stream pointer to, so it should be possible to inspect and verify the written data. The test does not do this, but having this example may be useful. This commit also adds a comment to describe the purpose of some macros in CacheWrite.cc.