### PR TITLE
Fix external libswoc builds

### DIFF
--- a/cmake/add_atsplugin.cmake
+++ b/cmake/add_atsplugin.cmake
@@ -23,8 +23,10 @@ function(add_atsplugin name)
     target_link_libraries(${name} PRIVATE ts::tsapi ts::tsutil)
   else()
     target_include_directories(
-      ${name} PRIVATE "$<TARGET_PROPERTY:libswoc::libswoc,INCLUDE_DIRECTORIES>"
-                      "$<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INCLUDE_DIRECTORIES>"
+      ${name}
+      PRIVATE "$<TARGET_PROPERTY:libswoc::libswoc,INCLUDE_DIRECTORIES>"
+              "$<TARGET_PROPERTY:libswoc::libswoc,INTERFACE_INCLUDE_DIRECTORIES>"
+              "$<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INCLUDE_DIRECTORIES>"
     )
   endif()
   set_target_properties(${name} PROPERTIES PREFIX "")

--- a/src/proxy/hdrs/CMakeLists.txt
+++ b/src/proxy/hdrs/CMakeLists.txt
@@ -51,11 +51,11 @@ if(BUILD_TESTING)
     unit_tests/test_URL.cc
     unit_tests/unit_test_main.cc
   )
-  target_link_libraries(test_proxy_hdrs PRIVATE ts::hdrs ts::tscore ts::inkevent catch2::catch2)
+  target_link_libraries(test_proxy_hdrs PRIVATE ts::hdrs ts::tscore ts::inkevent libswoc::libswoc catch2::catch2)
   add_test(NAME test_proxy_hdrs COMMAND test_proxy_hdrs)
 
   add_executable(test_proxy_hdrs_xpack unit_tests/test_XPACK.cc)
-  target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::hdrs ts::tscore ts::tsutil libswoc catch2::catch2)
+  target_link_libraries(test_proxy_hdrs_xpack PRIVATE ts::hdrs ts::tscore ts::tsutil libswoc::libswoc catch2::catch2)
   add_test(NAME test_proxy_hdrs_xpack COMMAND test_proxy_hdrs_xpack)
 endif()
 


### PR DESCRIPTION
This fixes builds against external libswoc rather than the local ATS lib/swoc code.