### PR TITLE
rate_limit: Set initialized flag of SieveLru when loading yaml is done

### DIFF
--- a/plugins/experimental/rate_limit/ip_reputation.cc
+++ b/plugins/experimental/rate_limit/ip_reputation.cc
@@ -135,6 +135,8 @@ SieveLru::parseYaml(const YAML::Node &node)
   Dbg(dbg_ctl, "\twith perma-block rule: %s(%u, %u, %ld)", _name.c_str(), _permablock_limit, _permablock_threshold,
       static_cast<long>(_permablock_max_age.count()));
 
+  _initialized = true;
+
   return true;
 }
 


### PR DESCRIPTION
The rate_limit plugin keep saying "no IP reputation" with any config. It looks like the `SieveLru::_initialized` flag never be true.

```
DIAG: <sni_limiter.cc:126 (sni_limit_cont)> (rate_limit) CLIENT_HELLO on localhost, no IP reputation
```