### PR TITLE
Fix external yaml-cpp builds

### DIFF
--- a/cmake/add_atsplugin.cmake
+++ b/cmake/add_atsplugin.cmake
@@ -27,6 +27,7 @@ function(add_atsplugin name)
       PRIVATE "$<TARGET_PROPERTY:libswoc::libswoc,INCLUDE_DIRECTORIES>"
               "$<TARGET_PROPERTY:libswoc::libswoc,INTERFACE_INCLUDE_DIRECTORIES>"
               "$<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INCLUDE_DIRECTORIES>"
+              "$<TARGET_PROPERTY:yaml-cpp::yaml-cpp,INTERFACE_INCLUDE_DIRECTORIES>"
     )
   endif()
   set_target_properties(${name} PROPERTIES PREFIX "")


### PR DESCRIPTION
This fixes builds when a user builds yaml-cpp externally via:

-DEXTERNAL_YAML_CPP=ON -Dyaml-cpp_ROOT=<yaml-cpp-path>