### PR TITLE
http2: change stream state to closed from open if END_STREAM is sent and received

### DIFF
--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -407,7 +407,11 @@ Http2Stream::change_state(uint8_t type, uint8_t flags)
           _state = Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_REMOTE;
         }
       } else if (send_end_stream) {
-        _state = Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_LOCAL;
+        if (receive_end_stream) {
+          _state = Http2StreamState::HTTP2_STREAM_STATE_CLOSED;
+        } else {
+          _state = Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_LOCAL;
+        }
       } else {
         // Do not change state
       }


### PR DESCRIPTION
This corrects the HTTP/2 Stream State transition of origin server side HTTP/2 connection. I'm not sure this makes any impact or not, but this is consistent with client side HTTP/2 connection.

https://github.com/apache/trafficserver/blob/29872c258edd21fb05bec51e5667df2deae2e969/src/proxy/http2/Http2Stream.cc#L402-L408

https://datatracker.ietf.org/doc/html/rfc9113#name-stream-states