### PR TITLE
Fix GCC 14.0.1 -std=c++20 build failures

### DIFF
--- a/lib/swoc/include/swoc/TextView.h
+++ b/lib/swoc/include/swoc/TextView.h
@@ -1062,7 +1062,7 @@ svto_radix(TextView &src) {
   static constexpr auto OVERFLOW_LIMIT = MAX / RADIX;
   uintmax_t zret                       = 0;
   uintmax_t v;
-  while (src.size() && (0 <= (v = swoc::svtoi_convert[uint8_t(*src)])) && v < RADIX) {
+  while (src.size() && ((v = swoc::svtoi_convert[uint8_t(*src)]) < RADIX)) {
     // Tweaked for performance - need to check range after @a RADIX multiply.
     ++src; // Update view iff the character is parsed.
     if (zret <= OVERFLOW_LIMIT && v <= (MAX - (zret *= RADIX)) ) {

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -68,7 +68,7 @@ protected:
 template <class T> class Matchers : public Matcher
 {
 public:
-  explicit Matchers<T>(const MatcherOps op) : Matcher(op), _data() {}
+  explicit Matchers(const MatcherOps op) : Matcher(op), _data() {}
   // Getters / setters
   const T &
   get() const
@@ -219,7 +219,7 @@ private:
 template <> class Matchers<const sockaddr *> : public Matcher
 {
 public:
-  explicit Matchers<const sockaddr *>(const MatcherOps op) : Matcher(op) {}
+  explicit Matchers(const MatcherOps op) : Matcher(op) {}
 
   void
   set(const std::string &data)

--- a/src/tscore/HostLookup.cc
+++ b/src/tscore/HostLookup.cc
@@ -28,6 +28,7 @@
  *
  ****************************************************************************/
 
+#include <algorithm>
 #include <string_view>
 #include <array>
 #include <memory>


### PR DESCRIPTION
fedora:40 uses GCC 14.0.1, and this compiler issues some new errors and warnings that previous compilers didn't when building with -std=c++20. This fixes those compiler errors and warnings.

# For Review

I kept the commits for each warning separate in this PR. Please see those commit comments to see what warning or error is being addressed by each commit.