### PR TITLE
Fix warnings from clang 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,7 +565,7 @@ add_subdirectory(lib)
 # there are warnings, we can't do anything about it.
 # Note: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON will turn warnings into errors.
 add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter)
-add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override>")
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override;-Wno-vla-extension>")
 add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wno-format-truncation;-Wno-stringop-overflow>")
 
 if(NOT EXTERNAL_YAML_CPP)

--- a/plugins/experimental/inliner/ts.cc
+++ b/plugins/experimental/inliner/ts.cc
@@ -307,7 +307,7 @@ namespace io
     const Node::Result result  = data_->process(operation->buffer_);
     operation->bytes_         += result.first;
     operation->process();
-    if (result.second && data_.unique()) {
+    if (result.second && data_.use_count() == 1) {
       data_.reset();
     }
   }
@@ -448,7 +448,7 @@ namespace io
       assert(*it != nullptr);
       const Node::Result result  = (*it)->process(b);
       length                    += result.first;
-      if (!result.second || !it->unique()) {
+      if (!result.second || it->use_count() != 1) {
         break;
       }
     }

--- a/plugins/experimental/txn_box/plugin/include/txn_box/common.h
+++ b/plugins/experimental/txn_box/plugin/include/txn_box/common.h
@@ -198,10 +198,10 @@ indexed_init_list(GENERATOR &&g)
 }
 
 template <typename GENERATOR, size_t... IDX>
-constexpr std::array<std::result_of_t<GENERATOR(size_t)>, sizeof...(IDX)>
+constexpr std::array<std::invoke_result_t<GENERATOR, size_t>, sizeof...(IDX)>
 indexed_array(GENERATOR &&g, std::index_sequence<IDX...> &&)
 {
-  return std::array<std::result_of_t<GENERATOR(size_t)>, sizeof...(IDX)>{g(IDX)...};
+  return std::array<std::invoke_result_t<GENERATOR, size_t>, sizeof...(IDX)>{g(IDX)...};
 }
 template <size_t N, typename GENERATOR>
 constexpr std::array<std::result_of_t<GENERATOR(size_t)>, N>


### PR DESCRIPTION
This addresses the warnings generated by clang 18. 

# For Review
There are two classes of warnings addressed by this PR. The fixes are kept as separate commits in this PR with some details in the commit comments explaining the change.