### PR TITLE
CMakePresets: branch-quiche: use boringssl nuraft

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -294,6 +294,7 @@
       "inherits": ["branch"],
       "cacheVariables": {
         "ENABLE_AUTEST": "ON",
+        "nuraft_ROOT": "/opt/nuraft-boringssl",
         "OPENSSL_ROOT_DIR": "/opt/boringssl",
         "quiche_ROOT": "/opt/quiche",
         "ENABLE_QUICHE": true


### PR DESCRIPTION
The standard quiche build uses boringssl, so the NuRaft for the STEK plugin must be the NuRaft built against boringssl.