### PR TITLE
Add default toolchain file and adjust RelWithDebInfo flags

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,8 +11,9 @@
       "displayName": "Default build with ninja",
       "description": "Default build using Ninja generator",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build-default",
+      "binaryDir": "${sourceDir}/build-${presetName}",
       "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "cmake/default.toolchain.cmake",
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_COMPILE_WARNING_AS_ERROR": "ON"
       }
@@ -38,14 +39,26 @@
     },
     {
       "name": "release",
+      "inherits": ["default"],
       "displayName": "Release build",
       "description": "Release build with Ninja generator",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF",
-        "CMAKE_INSTALL_PREFIX": "/opt/ats",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
+        "BUILD_EXPERIMENTAL_PLUGINS": "ON"
+      }
+    },
+    {
+      "name": "reldbg",
+      "inherits": ["default"],
+      "displayName": "Release build with debug info",
+      "description": "Release build with Ninja generator and debug info",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-reldbg",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "BUILD_EXPERIMENTAL_PLUGINS": "ON"
       }
     },
@@ -65,7 +78,6 @@
       "displayName": "development",
       "description": "Development Presets",
       "inherits": ["default"],
-      "binaryDir": "${sourceDir}/build-${presetName}",
       "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_COLOR_DIAGNOSTICS": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,7 +45,7 @@
       "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF",
         "BUILD_EXPERIMENTAL_PLUGINS": "ON"
       }
     },
@@ -55,10 +55,8 @@
       "displayName": "Release build with debug info",
       "description": "Release build with Ninja generator and debug info",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build-reldbg",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
         "BUILD_EXPERIMENTAL_PLUGINS": "ON"
       }
     },

--- a/cmake/default.toolchain.cmake
+++ b/cmake/default.toolchain.cmake
@@ -1,0 +1,22 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+# if I strip a Release-With_Debug, I expect to get the same as “Release” --zwoop
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
+    "-O3 -g -DNDEBUG"
+    CACHE STRING ""
+)


### PR DESCRIPTION
Cmake requires changes to the build types and flags to be done in a toolchain file.  This PR introduces that and uses it in the top level presets.  If you aren't using presets (you should use presets) then you must specify the toolchain file on the command line if you want the updated flags: (i.e. `cmake -B build -S. -DCMAKE_TOOLCHAIN_FILE=cmake/default.toolchain.cmake`)

With presets you can just say `cmake --preset reldbg` and you'll be good.  You can also base a user preset on `default` or other that inherits `default` and that will also work.