### PR TITLE
Apple Clang: missing_mangled_definition undefined symbol

### DIFF
--- a/tests/tools/plugins/CMakeLists.txt
+++ b/tests/tools/plugins/CMakeLists.txt
@@ -22,7 +22,13 @@ add_autest_plugin(custom204plugin custom204plugin.cc)
 add_autest_plugin(emergency_shutdown emergency_shutdown.cc)
 add_autest_plugin(fatal_shutdown fatal_shutdown.cc)
 add_autest_plugin(hook_add_plugin hook_add_plugin.cc)
+
 add_autest_plugin(missing_mangled_definition missing_mangled_definition_c.c missing_mangled_definition_cpp.cc)
+if(APPLE)
+  # The missing symbol is the point to this test.
+  set(CMAKE_MODULE_LINKER_FLAGS "-undefined dynamic_lookup")
+endif()
+
 add_autest_plugin(missing_ts_plugin_init missing_ts_plugin_init.cc)
 add_autest_plugin(ssl_client_verify_test ssl_client_verify_test.cc)
 add_autest_plugin(ssl_hook_test ssl_hook_test.cc)


### PR DESCRIPTION
The missing_mangled_definition tests a scenario in which there is a missing symbol. The verify_global_plugin test exercises this mistake. This patch tells Apple clang that this missing symbol is intentional so that the build works as expected.