### PR TITLE
Don't send "None" as a server name

### DIFF
--- a/tests/gold_tests/tls/test-0rtt-s_client.py
+++ b/tests/gold_tests/tls/test-0rtt-s_client.py
@@ -37,7 +37,7 @@ def main():
     sess_file_path = os.path.join(args.run_dir, 'sess.dat')
     early_data_file_path = os.path.join(args.run_dir, 'early_{0}_{1}.txt'.format(args.http_ver, args.test_name))
 
-    if args.sni != '':
+    if args.sni != '' and args.sni is not None:
         sni_str = '-servername {0}'.format(args.sni)
     else:
         sni_str = ''


### PR DESCRIPTION
"None" is sent as a server name if `args` doesn't have `sni`. I don't think it's intentional.