### PR TITLE
Clean up some of Cripts strings with modern libSWOC

### DIFF
--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -158,6 +158,10 @@ do_remap()
   CDebug("Path[1] is {}", url.path[1]);
   CDebug("Query is {}", url.query);
 
+  auto testing_trim = url.path.trim();
+
+  CDebug("Trimmed path is {}", testing_trim);
+
   if (url.query["foo"] > 100) {
     CDebug("Query[foo] is > 100");
   }

--- a/include/cripts/Error.hpp
+++ b/include/cripts/Error.hpp
@@ -41,7 +41,7 @@ public:
 
     static void _set(Cript::Context *context, const Cript::string_view msg);
 
-    [[nodiscard]] Cript::StringViewWrapper
+    [[nodiscard]] Cript::string_view
     message() const
     {
       return {_message.c_str(), _message.size()};

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -164,10 +164,10 @@ public:
       return matched();
     }
 
-    Cript::StringViewWrapper
+    Cript::string_view
     operator[](size_t ix) const
     {
-      Cript::StringViewWrapper ret;
+      Cript::string_view ret;
 
       if ((count() > ix) && _ovector) {
         ret = {_subject.substr(_ovector[ix * 2], _ovector[ix * 2 + 1] - _ovector[ix * 2])};

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -86,37 +86,37 @@ class Url
 
     // This is not ideal, but best way I can think of for now to mixin the Cript::string_view mixin class
     // Remember to add things here when added to the Lulu.hpp file for the mixin class... :/
-    Cript::StringViewWrapper &
+    Cript::string_view &
     ltrim(char c)
     {
       return _data.ltrim(c);
     }
 
-    Cript::StringViewWrapper &
+    Cript::string_view &
     rtrim(char c)
     {
       return _data.rtrim(c);
     }
 
-    Cript::StringViewWrapper &
+    Cript::string_view &
     trim(char c)
     {
       return _data.trim(c);
     }
 
-    Cript::StringViewWrapper &
+    Cript::string_view &
     ltrim(const char *chars = " \t\r\n")
     {
       return _data.ltrim(chars);
     }
 
-    Cript::StringViewWrapper &
+    Cript::string_view &
     rtrim(const char *chars = " \t\r\n")
     {
       return _data.rtrim(chars);
     }
 
-    Cript::StringViewWrapper &
+    Cript::string_view &
     trim(const char *chars = " \t")
     {
       return _data.trim(chars);
@@ -141,7 +141,7 @@ class Url
     }
 
   protected:
-    mutable Cript::StringViewWrapper _data;
+    mutable Cript::string_view _data;
     Url *_owner  = nullptr;
     bool _loaded = false;
 


### PR DESCRIPTION
With the introduction of libswoc into ATS 10, we can now rely on the newer versions of TextView, rather than the crippled old versions in ATS v9.2.x.