### PR TITLE
http2: close stream on sending RST_STREAM

### DIFF
--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -1437,6 +1437,12 @@ Http2ConnectionState::rcv_frame(const Http2Frame *frame)
               client_ip, session->get_connection_id(), stream_id, error.msg);
       }
       this->send_rst_stream_frame(stream_id, error.code);
+
+      // start closing stream on stream error
+      if (Http2Stream *stream = find_stream(stream_id); stream != nullptr) {
+        ink_assert(stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_CLOSED);
+        stream->initiating_close();
+      }
     }
   }
 }


### PR DESCRIPTION
When ATS receives HTTP/2 frame, sometimes stream error happens - e.g. malformed request. In such case, ATS sends RST_STREAM frame and make the stream state closed, but the stream is still in the `Http2ConnectionState::stream_list` and treat as active stream. It's possible that this makes miscalculation of current active stream number. 