### PR TITLE
http2: Set SSN active on create_stream

### DIFF
--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -1786,6 +1786,7 @@ Http2ConnectionState::create_stream(Http2StreamId new_id, Http2Error &error)
 
   // Clear the session timeout.  Let the transaction timeouts reign
   session->get_proxy_session()->cancel_inactivity_timeout();
+  session->get_proxy_session()->set_session_active();
 
   return new_stream;
 }


### PR DESCRIPTION
Prior to the change, if a HTTP/2 stream is open on a session, but it doesn't make new transaction by some reason, the inactivity timeout of the connection never get fired. 

Current ATS v10.0.x cancels inactivity timeout of proxy session in the `Http2ConnectionState::create_stream` (introduced by 7d5e673309b985d8e699328d58b55e2df89e861b). We need to get back the session inactivity timeout when all streams are gone, but there is a activity check of proxy session. To pass the check, we need to make the proxy session active.

https://github.com/apache/trafficserver/blob/66940f5768641b22dd36e7ae172fa72dcacdcb11/src/proxy/http2/Http2ConnectionState.cc#L1994-L1998