### PR TITLE
Fix TLS tunneling

### DIFF
--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -1507,7 +1507,10 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
 #elif SSL_ERROR_WANT_X509_LOOKUP
   case SSL_ERROR_WANT_X509_LOOKUP:
 #endif
-#if defined(SSL_ERROR_WANT_SNI_RESOLVE) || defined(SSL_ERROR_WANT_X509_LOOKUP)
+#ifdef SSL_ERROR_PENDING_CERTIFICATE
+  case SSL_ERROR_PENDING_CERTIFICATE:
+#endif
+#if defined(SSL_ERROR_WANT_SNI_RESOLVE) || defined(SSL_ERROR_WANT_X509_LOOKUP) || defined(SSL_ERROR_PENDING_CERTIFICATE)
     if (this->attributes == HttpProxyPort::TRANSPORT_BLIND_TUNNEL || SSL_HOOK_OP_TUNNEL == hookOpRequested) {
       this->attributes   = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
       sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_ONGOING;


### PR DESCRIPTION
This fixes some of autest failures that are tracked on https://github.com/apache/trafficserver/issues/10999.

I'm not sure if it was broken on master/10.0 or it has been broken since 9.x. The 9.2.x branch has less tests, but autest passes even with BoringSSL on the branch.