### PR TITLE
Fix parent proxy connection stat overcounting

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -1717,8 +1717,12 @@ HttpSM::create_server_txn(PoolableSession *new_session)
     server_txn->attach_transaction(this);
     if (t_state.current.request_to == ResolveInfo::PARENT_PROXY) {
       new_session->to_parent_proxy = true;
-      Metrics::Gauge::increment(http_rsb.current_parent_proxy_connections);
-      Metrics::Counter::increment(http_rsb.total_parent_proxy_connections);
+      if (server_txn->get_proxy_ssn()->get_transact_count() == 1) {
+        // These are connection-level metrics, so only increment them for the
+        // first transaction lest they get overcounted.
+        Metrics::Gauge::increment(http_rsb.current_parent_proxy_connections);
+        Metrics::Counter::increment(http_rsb.total_parent_proxy_connections);
+      }
     } else {
       new_session->to_parent_proxy = false;
     }


### PR DESCRIPTION
The proxy.process.http.current_parent_proxy_connections and proxy.process.http.total_parent_proxy_connections stats are each incremented in create_server_txn, which is a fine place to increment them, but this assumes that each server transaction is associated with a single origin connection. This is not the case when sessions are reused. This fixes the counting by only incrementing these stats for the very first transaction in the session.