### PR TITLE
Fix fuzz build by commenting out http3frame fuzz test with ubsan

### DIFF
--- a/tests/fuzzing/oss-fuzz.sh
+++ b/tests/fuzzing/oss-fuzz.sh
@@ -65,4 +65,5 @@ if [[ $SANITIZER = undefined ]]
 then
     rm -f $OUT/fuzz_http
     rm -f $OUT/fuzz_hpack
+    rm -f $OUT/fuzz_http3frame
 fi


### PR DESCRIPTION
Somehow the ubsan build for http3frame fuzz test is not compiling right.
Commenting it out for now to make the rest of the build work.