### PR TITLE
find PkgConfig earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ execute_process(
 
 # Options
 include(AutoOptionHelpers)
+find_package(PkgConfig)
 auto_option(HWLOC FEATURE_VAR TS_USE_HWLOC PACKAGE_DEPENDS hwloc)
 auto_option(
   JEMALLOC


### PR DESCRIPTION
I found that some combinations of setting will error on pkg-config checks.  This will find pkgconfig earlier to prevent that from happening.  (i.e. set ENABLE_MAGICK=false)

