### PR TITLE
Remove noisy retransmit Note messages

### DIFF
--- a/src/proxy/http2/Http2CommonSession.cc
+++ b/src/proxy/http2/Http2CommonSession.cc
@@ -159,7 +159,6 @@ Http2CommonSession::xmit(const Http2TxFrame &frame, bool flush)
     if (this->_pending_sending_data_size >= this->_write_size_threshold) {
       flush = true;
     } else {
-      Note("Calling schedule_transmit because write threshold is not exceeded.");
       // Observe that schedule_transmit will only schedule the first time we
       // don't flush because the threshold is not met.
       this->connection_state.schedule_retransmit(HRTIME_MSECONDS(Http2::write_time_threshold));

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -1489,7 +1489,6 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
   case HTTP2_SESSION_EVENT_XMIT: {
     REMEMBER(event, this->recursion);
     SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
-    Note("Flushing due to XMIT event");
     this->session->flush();
   } break;
 
@@ -2100,8 +2099,6 @@ Http2ConnectionState::schedule_retransmit(ink_hrtime t)
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
 
   if (retransmit_event == nullptr) {
-    Note("Scheduling retransmit in %" PRId64 "ms", t / HRTIME_MSECOND);
-
     SET_HANDLER(&Http2ConnectionState::main_event_handler);
     retransmit_event = this_ethread()->schedule_in((Continuation *)this, t, HTTP2_SESSION_EVENT_XMIT);
   }


### PR DESCRIPTION
When working on the patch for #11143, I accidentally left in some Note log messages that should have been cleaned up before I merged in the changes. This removes those noisy Note messages.