### PR TITLE
Use large IOBufferBlock only on sending DATA frame

### DIFF
--- a/include/proxy/http2/HTTP2.h
+++ b/include/proxy/http2/HTTP2.h
@@ -434,6 +434,7 @@ public:
   static uint32_t stream_slow_log_threshold;
   static uint32_t header_table_size_limit;
   static uint32_t write_buffer_block_size;
+  static int64_t  write_buffer_block_size_index;
   static float    write_size_threshold;
   static uint32_t write_time_threshold;
   static uint32_t buffer_water_mark;

--- a/src/proxy/http2/HTTP2.cc
+++ b/src/proxy/http2/HTTP2.cc
@@ -496,6 +496,7 @@ uint32_t Http2::con_slow_log_threshold             = 0;
 uint32_t Http2::stream_slow_log_threshold          = 0;
 uint32_t Http2::header_table_size_limit            = 65536;
 uint32_t Http2::write_buffer_block_size            = 262144;
+int64_t  Http2::write_buffer_block_size_index      = BUFFER_SIZE_INDEX_256K;
 float    Http2::write_size_threshold               = 0.5;
 uint32_t Http2::write_time_threshold               = 100;
 uint32_t Http2::buffer_water_mark                  = 0;
@@ -555,6 +556,8 @@ Http2::init()
   REC_EstablishStaticConfigFloat(write_size_threshold, "proxy.config.http2.write_size_threshold");
   REC_EstablishStaticConfigInt32U(write_time_threshold, "proxy.config.http2.write_time_threshold");
   REC_EstablishStaticConfigInt32U(buffer_water_mark, "proxy.config.http2.default_buffer_water_mark");
+
+  write_buffer_block_size_index = iobuffer_size_to_index(Http2::write_buffer_block_size, MAX_BUFFER_SIZE_INDEX);
 
   // If any settings is broken, ATS should not start
   ink_release_assert(http2_settings_parameter_is_valid({HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, max_concurrent_streams_in}));

--- a/src/proxy/http2/Http2ClientSession.cc
+++ b/src/proxy/http2/Http2ClientSession.cc
@@ -114,9 +114,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   this->read_buffer->water_mark = connection_state.local_settings.get(HTTP2_SETTINGS_MAX_FRAME_SIZE);
   this->_read_buffer_reader     = reader ? reader : this->read_buffer->alloc_reader();
 
-  // This block size is the buffer size that we pass to SSLWriteBuffer
-  auto buffer_block_size_index = iobuffer_size_to_index(Http2::write_buffer_block_size, MAX_BUFFER_SIZE_INDEX);
-  this->write_buffer           = new_MIOBuffer(buffer_block_size_index);
+  this->write_buffer = new_MIOBuffer(HTTP2_HEADER_BUFFER_SIZE_INDEX);
 
   uint32_t buffer_water_mark;
   if (auto snis = this->_vc->get_service<TLSSNISupport>(); snis && snis->hints_from_sni.http2_buffer_water_mark.has_value()) {
@@ -127,7 +125,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   this->write_buffer->water_mark = buffer_water_mark;
 
   this->_write_buffer_reader  = this->write_buffer->alloc_reader();
-  this->_write_size_threshold = index_to_buffer_size(buffer_block_size_index) * Http2::write_size_threshold;
+  this->_write_size_threshold = index_to_buffer_size(Http2::write_buffer_block_size_index) * Http2::write_size_threshold;
 
   this->_handle_if_ssl(new_vc);
 


### PR DESCRIPTION
Prior to the change, when HTTP/2 connection is created, the `write_buffer` is allocated with `http2.write_buffer_block_size` (default value is 256KB). However, only DATA frame needs such large buffer.