### PR TITLE
AuTest: Make ja3_fingerprint test stable

### DIFF
--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-client.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-client.gold
@@ -1,6 +1,4 @@
 +++++++++ Incoming Request +++++++++
-``
-+++++++++ Incoming Request +++++++++
 -- State Machine Id``
 POST ``
 Host: ``


### PR DESCRIPTION
Prior to the change, the `ja3_fingerprint` assumes that a POST request appears as second request. However, the order of debug logs can be flipped between `[ET_NET 0]` and `[ET_NET 1]` sometimes.

```
[root@8fb34f178adf tests]# grep "+++++++++ Incoming Request +++++++++" -A 7 -B 1 /tmp/sandbox/ja3_fingerprint/ts0/log/traffic.out
[Apr  9 07:09:58.488] [ET_NET 1] DIAG: <MIME.cc:2701 (mime_field_block_describe)> (http)
+++++++++ Incoming Request +++++++++
-- State Machine Id: 0
POST https://http2.server.com/some/path/http2 HTTP/1.1
Host: http2.server.com
Content-Type: image/jpeg
uuid: http2-request
x-request: http2-request

--
[Apr  9 07:09:58.489] [ET_NET 0] DIAG: <MIME.cc:2701 (mime_field_block_describe)> (http)
+++++++++ Incoming Request +++++++++
-- State Machine Id: 1
GET https:///some/path/https HTTP/1.1
host: https.server.com
content-length: 0
x-request: https-request
uuid: https-request
```