### PR TITLE
Update curl library references to CURL

### DIFF
--- a/cmake/ExperimentalPlugins.cmake
+++ b/cmake/ExperimentalPlugins.cmake
@@ -70,7 +70,7 @@ auto_option(
   PACKAGE_DEPENDS
   opentelemetry
   Protobuf
-  curl
+  CURL
   DEFAULT
   ${_DEFAULT}
 )

--- a/plugins/experimental/otel_tracer/CMakeLists.txt
+++ b/plugins/experimental/otel_tracer/CMakeLists.txt
@@ -16,5 +16,5 @@
 #######################
 
 add_atsplugin(otel_tracer otel_tracer.cc)
-target_link_libraries(otel_tracer PRIVATE opentelemetry::opentelemetry protobuf::libprotobuf curl::curl)
+target_link_libraries(otel_tracer PRIVATE opentelemetry::opentelemetry protobuf::libprotobuf CURL::libcurl)
 verify_global_plugin(otel_tracer)


### PR DESCRIPTION
The cmake builtin FindCURL module looks for CURL and CURL::libcurl. This updates our references to curl, via our Open Telemetry plugin, to reference CURL the way FindCURL expects. I verified I can reference our CI's version of curl in /opt via -DCURL_ROOT=/opt with these updates.