### PR TITLE
CI: have rocky and fedora builds use curl in /opt

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -150,6 +150,8 @@
         "OPENSSL_ROOT_DIR": "/opt/boringssl",
         "quiche_ROOT": "/opt/quiche",
         "CMAKE_INSTALL_PREFIX": "/tmp/ats-quiche",
+        "opentelemetry_ROOT": "/opt",
+        "CURL_ROOT": "/opt",
         "ENABLE_QUICHE": true
       }
     },
@@ -161,6 +163,7 @@
       "cacheVariables": {
         "OPENSSL_ROOT_DIR": "/opt/openssl-quic",
         "opentelemetry_ROOT": "/opt",
+        "CURL_ROOT": "/opt",
         "ENABLE_CRIPTS": true
       }
     },
@@ -170,6 +173,7 @@
       "description": "CI Pipeline config for Fedora Linux compiled with c++20",
       "inherits": ["ci"],
       "cacheVariables": {
+        "CURL_ROOT": "/opt",
         "CMAKE_CXX_STANDARD": "20"
       }
     },
@@ -181,6 +185,7 @@
       "cacheVariables": {
         "OPENSSL_ROOT_DIR": "/opt/boringssl",
         "quiche_ROOT": "/opt/quiche",
+        "CURL_ROOT": "/opt",
         "CMAKE_INSTALL_PREFIX": "/tmp/ats-quiche",
         "ENABLE_QUICHE": true
       }


### PR DESCRIPTION
The rocky and fedora CI Docker images have curl built from tools/build_h3_tools.sh installed in /opt. This updates the CMakePresets.json for those presets to point to that curl.