### PR TITLE
cleanup asan odr violations

### DIFF
--- a/plugins/background_fetch/CMakeLists.txt
+++ b/plugins/background_fetch/CMakeLists.txt
@@ -16,5 +16,5 @@
 #######################
 
 add_atsplugin(background_fetch background_fetch.cc configs.cc headers.cc rules.cc)
-target_link_libraries(background_fetch PRIVATE libswoc::libswoc ts::tsutil)
+target_link_libraries(background_fetch PRIVATE libswoc::libswoc)
 verify_global_plugin(background_fetch)

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -70,7 +70,7 @@ const int BROTLI_LGW               = 16;
 
 static const char *global_hidden_header_name = nullptr;
 
-static TSMutex compress_config_mutex = TSMutexCreate();
+static TSMutex compress_config_mutex = nullptr;
 
 // Current global configuration, and the previous one (for cleanup)
 Configuration *cur_config  = nullptr;
@@ -1017,6 +1017,7 @@ void
 TSPluginInit(int argc, const char *argv[])
 {
   const char *config_path = nullptr;
+  compress_config_mutex   = TSMutexCreate();
 
   if (argc > 2) {
     fatal("the compress plugin does not accept more than 1 plugin argument");

--- a/plugins/experimental/sslheaders/CMakeLists.txt
+++ b/plugins/experimental/sslheaders/CMakeLists.txt
@@ -16,7 +16,8 @@
 #######################
 
 add_library(sslhdr STATIC expand.cc util.cc)
-target_link_libraries(sslhdr PRIVATE OpenSSL::SSL libswoc::libswoc)
+target_link_libraries(sslhdr PRIVATE OpenSSL::SSL libswoc::libswoc # transitive
+)
 set_target_properties(sslhdr PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_TESTING)

--- a/plugins/experimental/sslheaders/CMakeLists.txt
+++ b/plugins/experimental/sslheaders/CMakeLists.txt
@@ -16,7 +16,7 @@
 #######################
 
 add_library(sslhdr STATIC expand.cc util.cc)
-target_link_libraries(sslhdr PRIVATE OpenSSL::SSL ts::tsutil)
+target_link_libraries(sslhdr PRIVATE OpenSSL::SSL)
 set_target_properties(sslhdr PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_TESTING)

--- a/plugins/experimental/sslheaders/CMakeLists.txt
+++ b/plugins/experimental/sslheaders/CMakeLists.txt
@@ -16,7 +16,7 @@
 #######################
 
 add_library(sslhdr STATIC expand.cc util.cc)
-target_link_libraries(sslhdr PRIVATE OpenSSL::SSL)
+target_link_libraries(sslhdr PRIVATE OpenSSL::SSL libswoc::libswoc)
 set_target_properties(sslhdr PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_TESTING)

--- a/plugins/experimental/tls_bridge/CMakeLists.txt
+++ b/plugins/experimental/tls_bridge/CMakeLists.txt
@@ -17,5 +17,6 @@
 
 add_atsplugin(tls_bridge tls_bridge.cc)
 
-target_link_libraries(tls_bridge PRIVATE libswoc::libswoc PCRE::PCRE)
+target_link_libraries(tls_bridge PRIVATE libswoc::libswoc PCRE::PCRE # transitive
+)
 verify_global_plugin(tls_bridge)

--- a/plugins/experimental/tls_bridge/CMakeLists.txt
+++ b/plugins/experimental/tls_bridge/CMakeLists.txt
@@ -17,5 +17,5 @@
 
 add_atsplugin(tls_bridge tls_bridge.cc)
 
-target_link_libraries(tls_bridge PRIVATE libswoc::libswoc)
+target_link_libraries(tls_bridge PRIVATE libswoc::libswoc PCRE::PCRE)
 verify_global_plugin(tls_bridge)

--- a/plugins/experimental/tls_bridge/CMakeLists.txt
+++ b/plugins/experimental/tls_bridge/CMakeLists.txt
@@ -17,5 +17,5 @@
 
 add_atsplugin(tls_bridge tls_bridge.cc)
 
-target_link_libraries(tls_bridge PRIVATE ts::tsutil libswoc::libswoc)
+target_link_libraries(tls_bridge PRIVATE libswoc::libswoc)
 verify_global_plugin(tls_bridge)

--- a/plugins/remap_stats/CMakeLists.txt
+++ b/plugins/remap_stats/CMakeLists.txt
@@ -17,5 +17,4 @@
 
 add_atsplugin(remap_stats remap_stats.cc)
 
-target_link_libraries(remap_stats PRIVATE ts::tscore)
 verify_global_plugin(remap_stats)

--- a/plugins/slice/CMakeLists.txt
+++ b/plugins/slice/CMakeLists.txt
@@ -33,8 +33,6 @@ add_atsplugin(
   util.cc
 )
 
-target_link_libraries(slice PRIVATE ts::tscore)
-
 if(BUILD_TESTING)
   add_subdirectory(unit-tests)
 endif()

--- a/plugins/slice/CMakeLists.txt
+++ b/plugins/slice/CMakeLists.txt
@@ -33,6 +33,7 @@ add_atsplugin(
   util.cc
 )
 
+target_link_libraries(slice PRIVATE PCRE::PCRE)
 if(BUILD_TESTING)
   add_subdirectory(unit-tests)
 endif()


### PR DESCRIPTION
linking ts::tsutil in a plugin with create ODR violations with DbgCtl globals.

The fix in compress.cc will still leak at shutdown, but the asan complaint was in the verify plugin which doesn't call TSPluginInit.   I'm not sure how to run code at plugin "unload" to clean up.