### PR TITLE
header_rewrite: add debug to accompany parse_line errors

### DIFF
--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -180,7 +180,12 @@ RulesConfig::parse_config(const std::string &fname, TSHttpHookID default_hook)
     Parser p;
 
     // Tokenize and parse this line
-    if (!p.parse_line(line) || p.empty()) {
+    if (!p.parse_line(line)) {
+      Dbg(dbg_ctl, "Error parsing line '%s'", line.c_str());
+      continue;
+    }
+
+    if (p.empty()) {
       continue;
     }
 

--- a/plugins/header_rewrite/value.cc
+++ b/plugins/header_rewrite/value.cc
@@ -60,6 +60,7 @@ Value::set_value(const std::string &val)
             tcond_val->initialize(parser);
           } else {
             // TODO: should we produce error here?
+            Dbg(dbg_ctl, "Error parsing value '%s'", _value.c_str());
           }
         }
       } else {


### PR DESCRIPTION
If there's an error while parsing a line of a header rewrite file TSError is invoked.  This PR also adds a Dbg() call to help figure out which header rewrites actually have the error in the case that errors go to diags.log and debug goes to another file.

Since parser.cc is used in a catch test the debug has to be put in functions that call into it.