### PR TITLE
txn_box ramp autest reliability improvements

### DIFF
--- a/tests/gold_tests/pluginTest/txn_box/ramp/ramp.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/ramp/ramp.replay.yaml
@@ -7,7 +7,9 @@ meta:
       select:
       - lt: 300
         do:
-          ua-req-host: "ex.two"
+        - ua-req-url-host: "ex.two"
+        - ua-req-url-port: {server_port}
+        - ua-req-scheme: "http"
 
   blocks:
   - base_request: &base_request


### PR DESCRIPTION
This updates the ramp test to actually ramp traffic to a dedicated
"staging" server. It also reduces the number of transactions to 100.
Both of these changes makes the test more reliable against spurious
connection issues that caused the test to be flakey, especially in CI.
    
Fixes: #11131