### PR TITLE
Regex: fix memory leak if the match buffer is too small

### DIFF
--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -67,7 +67,7 @@ private:
   constexpr static uint32_t DEFAULT_MATCHES = 10;
   static void *malloc(size_t size, void *caller);
   std::string_view _subject;
-  char _buffer[24 + 96 + 16 * DEFAULT_MATCHES]; // 24 bytes for the general context, 96 bytes overhead, 16 bytes per match.
+  char _buffer[24 + 96 + 28 * DEFAULT_MATCHES]; // 24 bytes for the general context, 96 bytes overhead, 28 bytes per match.
   size_t _buffer_bytes_used = 0;
   int32_t _size             = 0;
 

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -21,13 +21,13 @@
   limitations under the License.
  */
 
-#include "tsutil/Regex.h"
+#include <tsutil/Regex.h>
+#include <tsutil/Assert.h>
 
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
 
 #include <array>
-#include <assert.h>
 #include <vector>
 #include <mutex>
 
@@ -172,15 +172,14 @@ RegexMatches::RegexMatches(uint32_t size)
   pcre2_general_context *ctx = pcre2_general_context_create(
     &RegexMatches::malloc, [](void *, void *) -> void {}, static_cast<void *>(this));
 
-
   pcre2_match_data *match_data = pcre2_match_data_create(size, ctx);
   if (match_data == nullptr) {
     // buffer was too small, allocate from heap
+    debug_assert("Buffer too small, allocating from heap");
     match_data = pcre2_match_data_create(size, RegexContext::get_instance()->get_general_context());
   }
 
   _MatchData::set(_match_data, match_data);
-
 }
 
 //----------------------------------------------------------------------------
@@ -388,7 +387,7 @@ DFA::build(const std::string_view pattern, unsigned flags)
 int32_t
 DFA::compile(std::string_view pattern, unsigned flags)
 {
-  assert(_patterns.empty());
+  release_assert(_patterns.empty());
   this->build(pattern, flags);
   return _patterns.size();
 }

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -175,7 +175,7 @@ RegexMatches::RegexMatches(uint32_t size)
   pcre2_match_data *match_data = pcre2_match_data_create(size, ctx);
   if (match_data == nullptr) {
     // buffer was too small, allocate from heap
-    debug_assert("Buffer too small, allocating from heap");
+    debug_assert_message(false, "RegexMatches data buffer too small, increase the buffer size in Regex.h");
     match_data = pcre2_match_data_create(size, RegexContext::get_instance()->get_general_context());
   }
 

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -179,4 +179,12 @@ TEST_CASE("Regex", "[libts][Regex]")
     REQUIRE(r.compile(R"(bar)") == true);
     REQUIRE(r.exec("bar") == true);
   }
+
+  // test with matches set to 100
+  {
+    Regex r;
+    RegexMatches matches(100);
+    REQUIRE(r.compile(R"(foo)") == true);
+    REQUIRE(r.exec("foo", matches) == 1);
+  }
 }

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -180,11 +180,13 @@ TEST_CASE("Regex", "[libts][Regex]")
     REQUIRE(r.exec("bar") == true);
   }
 
-  // test with matches set to 100
+// test with matches set to 100, don't run the test in debug mode or the test will abort with a message to increase the buffer size
+#ifndef DEBUG
   {
     Regex r;
     RegexMatches matches(100);
     REQUIRE(r.compile(R"(foo)") == true);
     REQUIRE(r.exec("foo", matches) == 1);
   }
+#endif
 }


### PR DESCRIPTION
Other versions of pcre2 needed a different buffer size for matches and Regex was using `malloc()`, but not keeping track of when do `free()`.

I changed the way we fall back to using `malloc()` and pcre2 will keep track of which `free()` function to use when freeing.

I also added a unit test that will force the use of `malloc()` for the matches buffer and increased the calculation of the internal buffer, so older versions of pcre2 wont need to `malloc()`.