### PR TITLE
Fix tls_bridge plugin build

### DIFF
--- a/plugins/experimental/tls_bridge/CMakeLists.txt
+++ b/plugins/experimental/tls_bridge/CMakeLists.txt
@@ -17,6 +17,6 @@
 
 add_atsplugin(tls_bridge tls_bridge.cc)
 
-target_link_libraries(tls_bridge PRIVATE libswoc::libswoc PCRE::PCRE # transitive
+target_link_libraries(tls_bridge PRIVATE libswoc::libswoc PCRE::PCRE PkgConfig::PCRE2 # transitive
 )
 verify_global_plugin(tls_bridge)


### PR DESCRIPTION
In my dev env (Homebrew LLVM-17.0.6 on macOS Sonoma 14.4.1), I faced below build error.

```
[938/982] Building CXX object plugins/experimental/tls_bridge/CMakeFiles/tls_bridge.dir/tls_bridge.cc.o
FAILED: plugins/experimental/tls_bridge/CMakeFiles/tls_bridge.dir/tls_bridge.cc.o
/opt/homebrew/opt/llvm/bin/clang++ -DDEBUG -DOPENSSL_API_COMPAT=10002 -DOPENSSL_IS_OPENSSL3 -DPACKAGE_NAME="\"Apache Traffic Server\"" -DPACKAGE_VERSION=\"10.1.0\" -D_DEBUG -Ddarwin -Dtls_bridge_EXPORTS -I/Users/masaori/src/github.com/apache/trafficserver-asf-master/include -I/Users/masaori/src/github.com/apache/trafficserver-asf-master/build-asf-master-debug/include -I/Users/masaori/src/github.com/apache/trafficserver-asf-master/lib/swoc/include -I/Users/masaori/src/github.com/apache/trafficserver-asf-master/lib/yamlcpp/include -I/Users/masaori/src/github.com/apache/trafficserver-asf-master/lib/yamlcpp/src -isystem /opt/homebrew/include/jemalloc -isystem /opt/homebrew/opt/pcre/include -g -std=c++20 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -fPIC -Wno-invalid-offsetof -pipe -Wall -Wextra -Wno-unused-parameter -Wno-noexcept-type -Wsuggest-override -Wno-vla-extension -Werror -MD -MT plugins/experimental/tls_bridge/CMakeFiles/tls_bridge.dir/tls_bridge.cc.o -MF plugins/experimental/tls_bridge/CMakeFiles/tls_bridge.dir/tls_bridge.cc.o.d -o plugins/experimental/tls_bridge/CMakeFiles/tls_bridge.dir/tls_bridge.cc.o -c /Users/masaori/src/github.com/apache/trafficserver-asf-master/plugins/experimental/tls_bridge/tls_bridge.cc
In file included from /Users/masaori/src/github.com/apache/trafficserver-asf-master/plugins/experimental/tls_bridge/tls_bridge.cc:24:
/Users/masaori/src/github.com/apache/trafficserver-asf-master/include/tsutil/Regex.h:32:10: fatal error: 'pcre2.h' file not found
   32 | #include <pcre2.h>
      |          ^~~~~~~~~
1 error generated.
```