### PR TITLE
Fix ASan build on macos

### DIFF
--- a/src/iocore/net/libinknet_stub.cc
+++ b/src/iocore/net/libinknet_stub.cc
@@ -61,5 +61,3 @@ void
 FetchSM::ext_init(Continuation *, char const *, char const *, char const *, sockaddr const *, int)
 {
 }
-
-ChunkedHandler::ChunkedHandler() {}


### PR DESCRIPTION
In my dev env (Homebrew LLVM-17.0.6 on macOS Sonoma 14.4.1), I faced below error with ASan build.
It's a bit odd that I saw this error only if I enable ASan. Let's see what ci says.

```
[3/317] Linking CXX executable src/iocore/net/test_net
FAILED: src/iocore/net/test_net
: && /opt/homebrew/opt/llvm/bin/clang++ -g -fsanitize=address,undefined -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names -L/opt/homebrew/opt/llvm/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++ src/iocore/net/CMakeFiles/test_net.dir/libinknet_stub.cc.o src/iocore/net/CMakeFiles/test_net.dir/NetVCTest.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/test_ProxyProtocol.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/test_SSLSNIConfig.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/test_YamlSNIConfig.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/unit_test_main.cc.o -o src/iocore/net/test_net  -Wl,-rpath,/Users/masaori/src/github.com/apache/trafficserver-asf-master-work-3/build-asf-master-asan/lib/yamlcpp -Wl,-rpath,/Users/masaori/src/github.com/apache/trafficserver-asf-master-work-3/build-asf-master-asan/lib/swoc  src/iocore/net/libinknet.a  src/proxy/libproxy.a  src/api/libtsapibackend.a  src/iocore/cache/libinkcache.a  src/mgmt/rpc/librpcpublichandlers.a  src/proxy/http/libhttp.a  src/shared/liboverridable_txn_vars.a  src/iocore/hostdb/libinkhostdb.a  src/proxy/http2/libhttp2.a  src/proxy/http/remap/libhttp_remap.a  src/proxy/logging/liblogging.a  src/iocore/dns/libinkdns.a  src/iocore/net/libinknet.a  src/proxy/libproxy.a  src/api/libtsapibackend.a  src/iocore/cache/libinkcache.a  src/mgmt/rpc/librpcpublichandlers.a  src/proxy/http/libhttp.a  src/shared/liboverridable_txn_vars.a  src/iocore/hostdb/libinkhostdb.a  src/proxy/http2/libhttp2.a  src/proxy/http/remap/libhttp_remap.a  src/proxy/logging/liblogging.a  src/iocore/dns/libinkdns.a  /opt/homebrew/opt/openssl@3/lib/libssl.dylib  src/mgmt/rpc/libjsonrpc_protocol.a  src/iocore/aio/libaio.a  lib/fastlz/libfastlz.a  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libz.tbd  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/liblzma.tbd  src/iocore/utils/libinkutils.a  src/proxy/hdrs/libhdrs.a  src/iocore/eventsystem/libinkevent.a  src/records/librecords.a  src/iocore/eventsystem/libinkevent.a  src/records/librecords.a  src/tscore/libtscore.a  /opt/homebrew/opt/openssl@3/lib/libcrypto.dylib  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libresolv.tbd  /opt/homebrew/lib/libhwloc.dylib  /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/lib/libpcre.tbd  src/tsutil/libtsutil.a  lib/yamlcpp/libyaml-cppd.0.8.0.dylib  /opt/homebrew/Cellar/pcre2/10.43/lib/libpcre2-8.dylib  lib/swoc/libswoc-1.5.11.dylib  /opt/homebrew/lib/libjemalloc.dylib && :
ld: warning: ignoring duplicate libraries: 'src/api/libtsapibackend.a', 'src/iocore/cache/libinkcache.a', 'src/iocore/dns/libinkdns.a', 'src/iocore/eventsystem/libinkevent.a', 'src/iocore/hostdb/libinkhostdb.a', 'src/iocore/net/libinknet.a', 'src/mgmt/rpc/librpcpublichandlers.a', 'src/proxy/http/libhttp.a', 'src/proxy/http/remap/libhttp_remap.a', 'src/proxy/http2/libhttp2.a', 'src/proxy/libproxy.a', 'src/proxy/logging/liblogging.a', 'src/records/librecords.a', 'src/shared/liboverridable_txn_vars.a'
duplicate symbol '__ZN14ChunkedHandlerC2Ev' in:
    /Users/masaori/src/github.com/apache/trafficserver-asf-master-work-3/build-asf-master-asan/src/iocore/net/CMakeFiles/test_net.dir/libinknet_stub.cc.o
    src/proxy/http/libhttp.a[16](HttpTunnel.cc.o)
duplicate symbol '__ZN14ChunkedHandlerC1Ev' in:
    /Users/masaori/src/github.com/apache/trafficserver-asf-master-work-3/build-asf-master-asan/src/iocore/net/CMakeFiles/test_net.dir/libinknet_stub.cc.o
    src/proxy/http/libhttp.a[16](HttpTunnel.cc.o)
ld: 2 duplicate symbols
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```