### PR TITLE
CMakePresets: add opentelemetry_ROOT with CURL_ROOT

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -173,6 +173,7 @@
       "description": "CI Pipeline config for Fedora Linux compiled with c++20",
       "inherits": ["ci"],
       "cacheVariables": {
+        "opentelemetry_ROOT": "/opt",
         "CURL_ROOT": "/opt",
         "CMAKE_CXX_STANDARD": "20"
       }
@@ -185,6 +186,7 @@
       "cacheVariables": {
         "OPENSSL_ROOT_DIR": "/opt/boringssl",
         "quiche_ROOT": "/opt/quiche",
+        "opentelemetry_ROOT": "/opt",
         "CURL_ROOT": "/opt",
         "CMAKE_INSTALL_PREFIX": "/tmp/ats-quiche",
         "ENABLE_QUICHE": true


### PR DESCRIPTION
CURL_ROOT is only useful if opentelemetry_ROOT is set. Having the former without the latter causes a warning. This will address the warning and also get more otel_tracer build coverage.