### PR TITLE
AuTest: Make ja3_fingerprint test more stable

### DIFF
--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-client.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-client.gold
@@ -1,6 +1,6 @@
 +++++++++ Incoming Request +++++++++
 -- State Machine Id``
-GET ``
+GET https:///some/path/https``
 host: ``
 content-length: ``
 x-request: ``

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-proxy.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-proxy.gold
@@ -1,8 +1,6 @@
 +++++++++ Proxy's Request after hooks +++++++++
-``
-+++++++++ Proxy's Request after hooks +++++++++
 -- State Machine Id``
-POST ``
+POST /some/path/http2``
 Host: ``
 Content-Type: ``
 uuid: ``

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-client.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-client.gold
@@ -1,6 +1,6 @@
 +++++++++ Incoming Request +++++++++
 -- State Machine Id``
-POST ``
+POST https://http2.server.com/some/path/http2``
 Host: ``
 Content-Type: ``
 uuid: ``

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-proxy.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-proxy.gold
@@ -1,8 +1,6 @@
 +++++++++ Proxy's Request after hooks +++++++++
-``
-+++++++++ Proxy's Request after hooks +++++++++
 -- State Machine Id``
-POST ``
+POST /some/path/http2``
 Host: ``
 Content-Type: ``
 uuid: ``


### PR DESCRIPTION
Following https://github.com/apache/trafficserver/pull/11230. It looks like the debug log flipping happens in other cases.
Also, setting path helps AuTest to find the right lines.