### PR TITLE
libswoc: fix unresolved function type for transform_view_of.

### DIFF
--- a/lib/swoc/include/swoc/Lexicon.h
+++ b/lib/swoc/include/swoc/Lexicon.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <array>
 #include <variant>
+#include <ctype.h>
 
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveHashMap.h"
@@ -567,7 +568,7 @@ Lexicon<E>::Item::ValueLinkage::key_of(Item *item) {
 template <typename E>
 uint32_t
 Lexicon<E>::Item::NameLinkage::hash_of(std::string_view s) {
-  return Hash32FNV1a().hash_immediate(transform_view_of(&toupper, s));
+  return Hash32FNV1a().hash_immediate(transform_view_of(&::toupper, s));
 }
 
 template <typename E>


### PR DESCRIPTION
On some compilers this was showing an error as they  weren't able to decude the right function/type.

```
include/swoc/Lexicon.h:570:39: error: no matching function for call to 'transform_view_of'
  return Hash32FNV1a().hash_immediate(transform_view_of(&toupper, s));
                                      ^~~~~~~~~~~~~~~~~
include/swoc/TextView.h:1933:1: note: candidate template ignored: couldn't infer template argument 'X'
transform_view_of(X const &xf, V const &src) {
^
include/swoc/TextView.h:2065:1: note: candidate function template not viable: requires single argument 'v', but 2 arguments were provided
transform_view_of(V const &v) {
...
```
This has been failing internally for Y!.

---
**Note**: I'll update trafficserver-libswoc as well