### PR TITLE
libswoc: version update to 1.5.12

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.5.11")
+set(LIBSWOC_VERSION "1.5.12")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_11
+#define SWOC_VERSION_NS _1_5_12
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 11;
+static constexpr unsigned POINT_VERSION = 12;
 }} // namespace swoc::SWOC_VERSION_NS


### PR DESCRIPTION
I cut a 1.5.12 trafficserver-libswoc release that brings the latter up to the source code that ATS lib/swoc has. This updates the version of our ATS libswoc to reference the trafficserver-libswoc release version.

Note that this is a version-only update. No production changes come with this patch.