### PR TITLE
wasm: fix missing initializer build error

### DIFF
--- a/plugins/experimental/wasm/lib/src/wamr/wamr.cc
+++ b/plugins/experimental/wasm/lib/src/wamr/wamr.cc
@@ -338,7 +338,7 @@ bool Wamr::link(std::string_view /*debug_name*/) {
     return false;
   }
 
-  wasm_extern_vec_t imports_vec = {imports.size(), imports.data(), imports.size()};
+  wasm_extern_vec_t imports_vec = {imports.size(), imports.data(), imports.size(), sizeof(wasm_extern_t*), nullptr};
   instance_ = wasm_instance_new(store_.get(), module_.get(), &imports_vec, nullptr);
   if (instance_ == nullptr) {
     fail(FailState::UnableToInitializeCode, "Failed to create new Wasm instance");


### PR DESCRIPTION
This addresses the following build error in the wasm plugin:

```
/usr/bin/ccache /usr/lib64/ccache/c++ -DDEBUG -DOPENSSL_API_COMPAT=10002 -DOPENSSL_IS_OPENSSL3 -DPACKAGE_NAME="\"Apache Traffic Server\"" -DPACKAGE_VERSION=\"10.1.0\" -D_DEBUG -Dlinux -I/home/bneradt/src/ts_asf_master_build_proxy_wasm/inclu de -I/home/bneradt/src/ts_asf_master_build_proxy_wasm/build/include -I/home/bneradt/src/ts_asf_master_build_proxy_wasm/plugins/experimental/wasm/lib -isystem /opt/include -pthread -g -std=c++20 -fPIC -fdiagnostics-color=always -Wno-invalid- offsetof -pipe -Wall -Wextra -Wno-unused-parameter -Wno-noexcept-type -Wsuggest-override -Wno-vla-extension -Wno-format-truncation -Wno-stringop-overflow -Werror -MD -MT plugins/experimental/wasm/lib/CMakeFiles/wasmlib.dir/src/wamr/wamr.cc. o -MF plugins/experimental/wasm/lib/CMakeFiles/wasmlib.dir/src/wamr/wamr.cc.o.d -o plugins/experimental/wasm/lib/CMakeFiles/wasmlib.dir/src/wamr/wamr.cc.o -c /home/bneradt/src/ts_asf_master_build_proxy_wasm/plugins/experimental/wasm/lib/src /wamr/wamr.cc
/home/bneradt/src/ts_asf_master_build_proxy_wasm/plugins/experimental/wasm/lib/src/wamr/wamr.cc: In member function ‘virtual bool proxy_wasm::wamr::Wamr::link(std::string_view)’: /home/bneradt/src/ts_asf_master_build_proxy_wasm/plugins/experimental/wasm/lib/src/wamr/wamr.cc:341:84: error: invalid application of ‘sizeof’ to incomplete type ‘wasm_extern_t’
  341 |   wasm_extern_vec_t imports_vec = {imports.size(), imports.data(), imports.size(), sizeof(wasm_extern_t)};
      |                                                                                    ^~~~~~~~~~~~~~~~~~~~~
```

This is currently not seen because we don't currently have wasm plugin cmake build support. A future commit will add this, but we have to fix this error first.