### PR TITLE
wasm plugin: Add build support

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -164,6 +164,7 @@
         "OPENSSL_ROOT_DIR": "/opt/openssl-quic",
         "opentelemetry_ROOT": "/opt",
         "CURL_ROOT": "/opt",
+        "wamr_ROOT": "/opt",
         "ENABLE_CRIPTS": true
       }
     },
@@ -175,6 +176,7 @@
       "cacheVariables": {
         "opentelemetry_ROOT": "/opt",
         "CURL_ROOT": "/opt",
+        "wamr_ROOT": "/opt",
         "CMAKE_CXX_STANDARD": "20"
       }
     },
@@ -188,6 +190,7 @@
         "quiche_ROOT": "/opt/quiche",
         "opentelemetry_ROOT": "/opt",
         "CURL_ROOT": "/opt",
+        "wamr_ROOT": "/opt",
         "CMAKE_INSTALL_PREFIX": "/tmp/ats-quiche",
         "ENABLE_QUICHE": true
       }

--- a/cmake/ExperimentalPlugins.cmake
+++ b/cmake/ExperimentalPlugins.cmake
@@ -74,5 +74,16 @@ auto_option(
   DEFAULT
   ${_DEFAULT}
 )
+auto_option(
+  WASM
+  FEATURE_VAR
+  BUILD_WASM
+  WITH_SUBDIRECTORY
+  plugins/experimental/wasm
+  PACKAGE_DEPENDS
+  wamr
+  DEFAULT
+  ${_DEFAULT}
+)
 
 unset(_DEFAULT)

--- a/plugins/experimental/wasm/CMakeLists.txt
+++ b/plugins/experimental/wasm/CMakeLists.txt
@@ -1,0 +1,22 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+add_subdirectory(lib)
+
+add_atsplugin(wasm ats_context.cc ats_wasm.cc wasm_main.cc)
+target_link_libraries(wasm PRIVATE wasmlib wamr::wamr)
+verify_global_plugin(wasm)

--- a/plugins/experimental/wasm/lib/CMakeLists.txt
+++ b/plugins/experimental/wasm/lib/CMakeLists.txt
@@ -1,0 +1,40 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+
+set(CC_FILES
+    src/bytecode_util.cc
+    src/context.cc
+    src/exports.cc
+    src/shared_data.cc
+    src/shared_queue.cc
+    src/hash.cc
+    src/signature_util.cc
+    src/vm_id_handle.cc
+    src/pairs_util.cc
+    src/wasm.cc
+)
+if(wamr_FOUND)
+  list(APPEND CC_FILES src/wamr/wamr.cc)
+endif()
+
+add_library(wasmlib STATIC ${CC_FILES})
+if(wamr_FOUND)
+  target_link_libraries(wasmlib PUBLIC wamr::wamr)
+endif()
+
+target_include_directories(wasmlib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+set_target_properties(wasmlib PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
# Draft status

#11257 fixes a build issue in wasm that has to land before building the wasm plugin will succeed. I'll mark this as a draft until that lands.

## Description

Initial commits of plugin/experimental/wasm on master had automake build support. When we transitioned to cmake we temporarilly dropped the automake files, leaving cmake support to a future commit. This is that future commit.