### PR TITLE
http2: Track scheduled events

### DIFF
--- a/include/proxy/http2/Http2ConnectionState.h
+++ b/include/proxy/http2/Http2ConnectionState.h
@@ -393,8 +393,6 @@ private:
   //     "If the END_HEADERS bit is not set, this frame MUST be followed by
   //     another CONTINUATION frame."
   Http2StreamId continued_stream_id = 0;
-  bool _priority_scheduled          = false;
-  bool _data_scheduled              = false;
   bool fini_received                = false;
   bool in_destroy                   = false;
   int recursion                     = 0;
@@ -403,6 +401,8 @@ private:
   Event *shutdown_cont_event        = nullptr;
   Event *fini_event                 = nullptr;
   Event *zombie_event               = nullptr;
+  Event *_priority_event            = nullptr;
+  Event *_data_event                = nullptr;
   Event *retransmit_event           = nullptr;
 
   uint32_t configured_max_settings_frames_per_minute     = 0;

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -1573,6 +1573,10 @@ Http2ConnectionState::state_closed(int event, void *edata)
     ink_release_assert(zombie_event == nullptr);
   } else if (edata == fini_event) {
     fini_event = nullptr;
+  } else if (edata == _priority_event) {
+    _priority_event = nullptr;
+  } else if (edata == _data_event) {
+    _data_event = nullptr;
   } else if (edata == shutdown_cont_event) {
     shutdown_cont_event = nullptr;
   } else if (edata == retransmit_event) {


### PR DESCRIPTION
Possible fix of #11260. Scheduled events should be tracked and canceled by destructor. Otherwise, scheduled events will be fired to the freed continuation.