### PR TITLE
Initialize HistoryEntry array

### DIFF
--- a/include/tscore/History.h
+++ b/include/tscore/History.h
@@ -74,7 +74,7 @@ public:
   }
 
 private:
-  HistoryEntry history[Count];
+  HistoryEntry history[Count] = {};
 
   unsigned int history_pos = 0;
 };


### PR DESCRIPTION
I noticed `Http2CommonSession::_history` has some entries from old session. The `HistoryEntry` should be initialized.

https://github.com/apache/trafficserver/blob/f6ad241eb4e87a92b5c5f21b91b5538c60574368/include/proxy/http2/Http2CommonSession.h#L162