### PR TITLE
Add nullptr guards in ActivityCop functions

### DIFF
--- a/include/iocore/net/NetTimeout.h
+++ b/include/iocore/net/NetTimeout.h
@@ -219,14 +219,18 @@ template <class T, class List>
 inline void
 ActivityCop<T, List>::start()
 {
-  _event = this_ethread()->schedule_every(this, HRTIME_SECONDS(_freq));
+  if (_event == nullptr) {
+    _event = this_ethread()->schedule_every(this, HRTIME_SECONDS(_freq));
+  }
 }
 
 template <class T, class List>
 inline void
 ActivityCop<T, List>::stop()
 {
-  _event->cancel();
+  if (_event != nullptr) {
+    _event->cancel();
+  }
 }
 
 template <class T, class List>

--- a/include/iocore/net/NetTimeout.h
+++ b/include/iocore/net/NetTimeout.h
@@ -230,6 +230,7 @@ ActivityCop<T, List>::stop()
 {
   if (_event != nullptr) {
     _event->cancel();
+    _event = nullptr;
   }
 }
 


### PR DESCRIPTION
Possible fix of #11265. I still don't get root cause of crash, but checking `_event` might work as workaround. IMO, ASan build will find the root cause.

