### PR TITLE
[9.2.x] Fix GCC 14.0.1 -std=c++20 build failures (#11189)

### DIFF
--- a/include/tscpp/util/TextView.h
+++ b/include/tscpp/util/TextView.h
@@ -621,7 +621,7 @@ svto_radix(ts::TextView &src)
   static_assert(0 < N && N <= 36, "Radix must be in the range 1..36");
   uintmax_t zret{0};
   uintmax_t v;
-  while (src.size() && (0 <= (v = ts::svtoi_convert[static_cast<unsigned char>(*src)])) && v < N) {
+  while (src.size() && ((v = ts::svtoi_convert[static_cast<unsigned char>(*src)]) < N)) {
     auto n = zret * N + v;
     if (n < zret) { // overflow / wrap
       return std::numeric_limits<uintmax_t>::max();

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -67,7 +67,7 @@ protected:
 template <class T> class Matchers : public Matcher
 {
 public:
-  explicit Matchers<T>(const MatcherOps op) : Matcher(op), _data() {}
+  explicit Matchers(const MatcherOps op) : Matcher(op), _data() {}
   // Getters / setters
   const T &
   get() const
@@ -218,7 +218,7 @@ private:
 template <> class Matchers<const sockaddr *> : public Matcher
 {
 public:
-  explicit Matchers<const sockaddr *>(const MatcherOps op) : Matcher(op) {}
+  explicit Matchers(const MatcherOps op) : Matcher(op) {}
 
   void
   set(const std::string &data)

--- a/src/tscore/HostLookup.cc
+++ b/src/tscore/HostLookup.cc
@@ -33,6 +33,7 @@
 #include "tscore/HostLookup.h"
 #include "tscpp/util/TextView.h"
 
+#include <algorithm>
 #include <string_view>
 #include <array>
 #include <memory>


### PR DESCRIPTION
Backport #11189 for fedora 40 build.

----

* comparison of unsigned expression in ‘>= 0’ is always true

lib/swoc/include/swoc/TextView.h: In instantiation of ‘uintmax_t swoc::_1_5_11::svto_radix(TextView&) [with int RADIX = 16; uintmax_t = long unsigned int]’:
lib/swoc/include/swoc/TextView.h:1082:23:   required from ‘uintmax_t swoc::_1_5_11::svto_radix(TextView&&) [with int N = 16; uintmax_t = long unsigned int]’
lib/swoc/include/swoc/TextView.h:1065:27: error:  1082 |   return svto_radix<N>(src);
lib/swoc/include/swoc/TextView.h:1065:27: error:       |          ~~~~~~~~~~~~~^~~~~
lib/swoc/src/bw_format.cc:928:28:   required from here
lib/swoc/include/swoc/TextView.h:1065:27: error:   928 |     auto b = svto_radix<16>(span.clip_prefix(2).rebind<char const>());
lib/swoc/include/swoc/TextView.h:1065:27: error:       |              ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/swoc/include/swoc/TextView.h:1065:27: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
 1065 |   while (src.size() && (0 <= (v = swoc::svtoi_convert[uint8_t(*src)])) && v < RADIX) {
      |                        ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

Second warning:

src/tscore/HostLookup.cc: In member function ‘void CharIndex::Insert(std::string_view, HostBranch*)’: src/tscore/HostLookup.cc:304:12: error: ‘any_of’ is not a member of ‘std’
  304 |   if (std::any_of(match_data.begin(), match_data.end(), [](unsigned char c) { return asciiToTable[c] == 255; })) {
      |            ^~~~~~
src/tscore/HostLookup.cc: In member function ‘HostBranch* CharIndex::Lookup(std::string_view)’:
src/tscore/HostLookup.cc:351:12: error: ‘any_of’ is not a member of ‘std’
  351 |   if (std::any_of(match_data.begin(), match_data.end(), [](unsigned char c) { return asciiToTable[c] == 255; })) {
      |            ^~~~~~

* ‘any_of’ is not a member of ‘std’

src/tscore/HostLookup.cc: In member function ‘void CharIndex::Insert(std::string_view, HostBranch*)’: src/tscore/HostLookup.cc:304:12: error: ‘any_of’ is not a member of ‘std’
  304 |   if (std::any_of(match_data.begin(), match_data.end(), [](unsigned char c) { return asciiToTable[c] == 255; })) {
      |            ^~~~~~
src/tscore/HostLookup.cc: In member function ‘HostBranch* CharIndex::Lookup(std::string_view)’:
src/tscore/HostLookup.cc:351:12: error: ‘any_of’ is not a member of ‘std’
  351 |   if (std::any_of(match_data.begin(), match_data.end(), [](unsigned char c) { return asciiToTable[c] == 255; })) {
      |            ^~~~~~

* error: template-id not allowed for constructor in C++20

plugins/header_rewrite/matcher.h:71:23: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
   71 |   explicit Matchers<T>(const MatcherOps op) : Matcher(op), _data() {}
      |                       ^
plugins/header_rewrite/matcher.h:71:23: note: remove the ‘< >’
/home/bneradt/src/ts_asf_master_fix_std_20_build_failure/plugins/header_rewrite/matcher.h:222:38: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
  222 |   explicit Matchers<const sockaddr *>(const MatcherOps op) : Matcher(op) {}
      |                                      ^
/home/bneradt/src/ts_asf_master_fix_std_20_build_failure/plugins/header_rewrite/matcher.h:222:38: note: remove the ‘< >’

(cherry picked from commit 6a9e39d6bb666a7849f5d414d230776dba543a02)

Conflicts:
	lib/swoc/include/swoc/TextView.h
	src/tscore/HostLookup.cc