### PR TITLE
cleanup: Resolve some of dependencies on private headers (records)

### DIFF
--- a/include/records/RecordsConfig.h
+++ b/include/records/RecordsConfig.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <string_view>
 #include "RecDefs.h"
 
 // This is to manage the librecords table sizes. Not awesome, but better than the earlier recompiling of ATS requirement...

--- a/include/records/RecordsConfig.h
+++ b/include/records/RecordsConfig.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "../../src/records/P_RecCore.h"
+#include "RecDefs.h"
 
 // This is to manage the librecords table sizes. Not awesome, but better than the earlier recompiling of ATS requirement...
 extern int max_records_entries;

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -55,6 +55,8 @@
 #include "../iocore/hostdb/P_HostDB.h"
 #include "../iocore/cache/P_Cache.h"
 #include "records/RecCore.h"
+#include "../records/P_RecCore.h"
+#include "../records/P_RecDefs.h"
 #include "../iocore/net/P_SSLConfig.h"
 #include "../iocore/net/P_SSLClientUtils.h"
 #include "iocore/net/ConnectionTracker.h"

--- a/src/mgmt/rpc/handlers/common/RecordsUtils.cc
+++ b/src/mgmt/rpc/handlers/common/RecordsUtils.cc
@@ -18,12 +18,12 @@
   limitations under the License.
 */
 
-#include "mgmt/rpc/handlers/common/RecordsUtils.h"
+#include "RecordsUtils.h"
 
 #include <system_error>
 #include <string>
 
-#include "mgmt/rpc/handlers/common/convert.h"
+#include "convert.h"
 #include "../../../../records/P_RecCore.h"
 #include "tscore/Tokenizer.h"
 

--- a/src/mgmt/rpc/handlers/common/RecordsUtils.h
+++ b/src/mgmt/rpc/handlers/common/RecordsUtils.h
@@ -24,11 +24,9 @@
 
 #include "tsutil/ts_errata.h"
 
-#include "mgmt/rpc/handlers/common/convert.h"
 #include "mgmt/rpc/handlers/common/ErrorUtils.h"
 
 #include "records/RecCore.h"
-#include "../../../../../src/records/P_RecCore.h"
 #include "tscore/Diags.h"
 
 #include <yaml-cpp/yaml.h>

--- a/src/mgmt/rpc/handlers/common/convert.h
+++ b/src/mgmt/rpc/handlers/common/convert.h
@@ -29,7 +29,7 @@
 
 #include "shared/overridable_txn_vars.h"
 
-#include "mgmt/rpc/handlers/common/RecordsUtils.h"
+#include "RecordsUtils.h"
 
 ///
 /// @brief Namespace to group all the names used for key access to the yaml lookup nodes.

--- a/src/mgmt/rpc/handlers/config/Configuration.cc
+++ b/src/mgmt/rpc/handlers/config/Configuration.cc
@@ -28,7 +28,7 @@
 
 #include "mgmt/config/FileManager.h"
 
-#include "mgmt/rpc/handlers/common/RecordsUtils.h"
+#include "../common/RecordsUtils.h"
 #include "tsutil/Metrics.h"
 
 namespace utils = rpc::handlers::records::utils;

--- a/src/mgmt/rpc/handlers/records/Records.cc
+++ b/src/mgmt/rpc/handlers/records/Records.cc
@@ -23,7 +23,7 @@
 #include <string>
 #include <string_view>
 
-#include "mgmt/rpc/handlers/common/RecordsUtils.h"
+#include "../common/RecordsUtils.h"
 // #include "common/yaml/codecs.h"
 ///
 /// @brief Local definitions to map requests and responsponses(not fully supported yet) to custom structures. All this definitions

--- a/src/records/RecordsConfigUtils.cc
+++ b/src/records/RecordsConfigUtils.cc
@@ -22,7 +22,9 @@
  */
 
 #include "tscore/ink_config.h"
+#include "records/RecCore.h"
 #include "records/RecordsConfig.h"
+#include "P_RecUtils.h"
 
 //-------------------------------------------------------------------------
 // LibRecordsConfigInit

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -23,6 +23,8 @@
 
 #include <fcntl.h>
 #include <openssl/crypto.h>
+#include <swoc/BufferWriter.h>
+#include <swoc/bwf_base.h>
 #include "tscore/Layout.h"
 #include "tscore/Filenames.h"
 #include "records/RecProcess.h"

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -78,6 +78,7 @@ extern "C" int plock(int);
 #include "../iocore/dns/P_SplitDNS.h"
 #include "../iocore/hostdb/P_HostDB.h"
 #include "../iocore/cache/P_Cache.h"
+#include "../records/P_RecCore.h"
 #include "tscore/Layout.h"
 #include "iocore/utils/Machine.h"
 #include "records/RecordsConfig.h"


### PR DESCRIPTION
I could keep RecordsUtils.h and convert.h under include/ to avoid referring to  a parent directory like `#include "../common/RecordsUtils.h"`, but they are only used in src/mgmt/ after all. I'm not sure if we want to avoid the cross-submodule reference.