### PR TITLE
lsan suppression files for ImageMagic plugins

### DIFF
--- a/cmake/add_atsplugin.cmake
+++ b/cmake/add_atsplugin.cmake
@@ -47,6 +47,11 @@ function(verify_global_plugin target)
   add_test(NAME verify_global_${target} COMMAND $<TARGET_FILE:traffic_server> -C
                                                 "verify_global_plugin $<TARGET_FILE:${target}>"
   )
+  # Process the optional suppression file parameter.
+  set(suppression_file ${ARGV1})
+  if(suppression_file)
+    set_tests_properties(verify_global_${target} PROPERTIES ENVIRONMENT "LSAN_OPTIONS=suppressions=${suppression_file}")
+  endif()
 endfunction()
 
 if(APPLE)

--- a/plugins/experimental/magick/CMakeLists.txt
+++ b/plugins/experimental/magick/CMakeLists.txt
@@ -19,4 +19,4 @@ add_atsplugin(magick magick.cc)
 
 target_link_libraries(magick PRIVATE ImageMagick::MagickWand ImageMagick::MagickCore ts::tscppapi OpenSSL::Crypto)
 
-verify_global_plugin(magick)
+verify_global_plugin(magick ${CMAKE_CURRENT_SOURCE_DIR}/image_magic_dlopen_leak_suppression.txt)

--- a/plugins/experimental/magick/image_magic_dlopen_leak_suppression.txt
+++ b/plugins/experimental/magick/image_magic_dlopen_leak_suppression.txt
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dlopen of plugins that link with ImageMagick results in ASan reporting a leak
+# for the verify_global tests for those plugins. It has been verified that the
+# plugin itself is not leaking because all other code for the plugin had been
+# commented out so there was nothing to leak in the plugin.
+leak:plugin_dso_load

--- a/plugins/webp_transform/CMakeLists.txt
+++ b/plugins/webp_transform/CMakeLists.txt
@@ -18,4 +18,4 @@
 add_atsplugin(webp_transform ImageTransform.cc)
 target_link_libraries(webp_transform PRIVATE ImageMagick::Magick++ tscppapi)
 
-verify_global_plugin(webp_transform)
+verify_global_plugin(webp_transform ${CMAKE_CURRENT_SOURCE_DIR}/image_magic_dlopen_leak_suppression.txt)

--- a/plugins/webp_transform/image_magic_dlopen_leak_suppression.txt
+++ b/plugins/webp_transform/image_magic_dlopen_leak_suppression.txt
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# dlopen of plugins that link with ImageMagick results in ASan reporting a leak
+# for the verify_global tests for those plugins. It has been verified that the
+# plugin itself is not leaking because all other code for the plugin had been
+# commented out so there was nothing to leak in the plugin.
+leak:plugin_dso_load


### PR DESCRIPTION
ASan reports a leak concerning the ImageMagick library for plugins that link against it. The leak is associated with the ImageMagick library itself as commenting everything out from the ATS plugin, leaving a bare TSPluginInit, still results in the leak report. This patch suppresses the leak report for the library we do not own and for a leak that has not been seen to be any larger than the initialization bytes associated with the library.

Here's the leak report this suppression file addresses:

    =================================================================
    ==18362==ERROR: LeakSanitizer: detected memory leaks
  
    Direct leak of 96 byte(s) in 1 object(s) allocated from:
        #0 0xffff9cf05218 in calloc (/lib64/libasan.so.8+0xc5218) (BuildId: f2ca9839b9f761d63a77efcab29bcdd4b221f3a9)
        #1 0xffff8db8273c  (<unknown module>)
        #2 0xffff8db81108  (<unknown module>)
        #3 0xffff8db811d0  (<unknown module>)
        #4 0xffff9d53fee8 in call_init /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-init.c:74
        #5 0xffff9d53fee8 in call_init /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-init.c:26
        #6 0xffff9d540008 in _dl_init /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-init.c:121
        #7 0xffff9d53c68c in __GI__dl_catch_exception /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:211
        #8 0xffff9d5461c0 in dl_open_worker /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-open.c:829
        #9 0xffff9d53c614 in __GI__dl_catch_exception /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:237
        #10 0xffff9d5465fc in _dl_open /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-open.c:905
        #11 0xffff9bbfbef4 in dlopen_doit (/lib64/libc.so.6+0x8bef4) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #12 0xffff9d53c614 in __GI__dl_catch_exception /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:237
        #13 0xffff9d53c73c in _dl_catch_error /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:256
        #14 0xffff9bbfb924 in _dlerror_run (/lib64/libc.so.6+0x8b924) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #15 0xffff9bbfbfec in dlopen@GLIBC_2.17 (/lib64/libc.so.6+0x8bfec) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #16 0xffff9cea7bc4 in __interceptor_dlopen.part.0 (/lib64/libasan.so.8+0x67bc4) (BuildId: f2ca9839b9f761d63a77efcab29bcdd4b221f3a9)
        #17 0xfdcc88 in plugin_dso_load(char const*, void*&, void*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/proxy/Plugin.cc:104
        #18 0x8bdab4 in try_loading_plugin /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1019
        #19 0x8be954 in verify_plugin_helper /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1078
        #20 0x8beac8 in cmd_verify_global_plugin /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1097
        #21 0x8bf354 in cmd_mode /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1270
        #22 0x8c57e0 in main /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:2122
        #23 0xffff9bba09d8 in __libc_start_call_main (/lib64/libc.so.6+0x309d8) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #24 0xffff9bba0aac in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x30aac) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #25 0x89346c in _start (/home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/build/src/traffic_server/traffic_server+0x89346c) (BuildId: d86c4e46554f342afeb32ab378ad7f99940d848a)
  
    Direct leak of 8 byte(s) in 1 object(s) allocated from:
        #0 0xffff9cf057b0 in malloc (/lib64/libasan.so.8+0xc57b0) (BuildId: f2ca9839b9f761d63a77efcab29bcdd4b221f3a9)
        #1 0xffff8db826f4  (<unknown module>)
        #2 0xffff8db96758  (<unknown module>)
        #3 0xffff8db811b0  (<unknown module>)
        #4 0xffff9d53fee8 in call_init /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-init.c:74
        #5 0xffff9d53fee8 in call_init /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-init.c:26
        #6 0xffff9d540008 in _dl_init /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-init.c:121
        #7 0xffff9d53c68c in __GI__dl_catch_exception /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:211
        #8 0xffff9d5461c0 in dl_open_worker /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-open.c:829
        #9 0xffff9d53c614 in __GI__dl_catch_exception /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:237
        #10 0xffff9d5465fc in _dl_open /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-open.c:905
        #11 0xffff9bbfbef4 in dlopen_doit (/lib64/libc.so.6+0x8bef4) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #12 0xffff9d53c614 in __GI__dl_catch_exception /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:237
        #13 0xffff9d53c73c in _dl_catch_error /usr/src/debug/glibc-2.38-17.fc39.aarch64/elf/dl-catch.c:256
        #14 0xffff9bbfb924 in _dlerror_run (/lib64/libc.so.6+0x8b924) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #15 0xffff9bbfbfec in dlopen@GLIBC_2.17 (/lib64/libc.so.6+0x8bfec) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #16 0xffff9cea7bc4 in __interceptor_dlopen.part.0 (/lib64/libasan.so.8+0x67bc4) (BuildId: f2ca9839b9f761d63a77efcab29bcdd4b221f3a9)
        #17 0xfdcc88 in plugin_dso_load(char const*, void*&, void*&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/proxy/Plugin.cc:104
        #18 0x8bdab4 in try_loading_plugin /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1019
        #19 0x8be954 in verify_plugin_helper /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1078
        #20 0x8beac8 in cmd_verify_global_plugin /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1097
        #21 0x8bf354 in cmd_mode /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:1270
        #22 0x8c57e0 in main /home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/src/traffic_server/traffic_server.cc:2122
        #23 0xffff9bba09d8 in __libc_start_call_main (/lib64/libc.so.6+0x309d8) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #24 0xffff9bba0aac in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x30aac) (BuildId: 4b1e6ff6c35f7fc7bd309e5e5a1f981e2515e4f0)
        #25 0x89346c in _start (/home/bneradt/src/ts_asf_master_address_asan_unit_test_issues/build/src/traffic_server/traffic_server+0x89346c) (BuildId: d86c4e46554f342afeb32ab378ad7f99940d848a)
  
    SUMMARY: AddressSanitizer: 104 byte(s) leaked in 2 allocation(s).