### PR TITLE
Remove reduntant link of ts:: libraries in plugins

### DIFF
--- a/cmake/ExperimentalPlugins.cmake
+++ b/cmake/ExperimentalPlugins.cmake
@@ -27,6 +27,8 @@ else()
   set(_DEFAULT OFF)
 endif()
 
+include(add_atsplugin)
+
 auto_option(
   MAXMIND_ACL
   FEATURE_VAR

--- a/plugins/experimental/access_control/CMakeLists.txt
+++ b/plugins/experimental/access_control/CMakeLists.txt
@@ -28,7 +28,7 @@ add_atsplugin(
   utils.cc
 )
 
-target_link_libraries(access_control PRIVATE PCRE::PCRE OpenSSL::SSL OpenSSL::Crypto ts::tscore)
+target_link_libraries(access_control PRIVATE PCRE::PCRE OpenSSL::SSL OpenSSL::Crypto)
 
 verify_remap_plugin(access_control)
 

--- a/plugins/experimental/maxmind_acl/CMakeLists.txt
+++ b/plugins/experimental/maxmind_acl/CMakeLists.txt
@@ -20,7 +20,7 @@ if(maxminddb_FOUND)
   add_atsplugin(maxmind_acl maxmind_acl.cc mmdb.cc)
 
   target_link_libraries(
-    maxmind_acl PRIVATE libswoc::libswoc ts::tsapi ts::tsutil yaml-cpp::yaml-cpp maxminddb::maxminddb PCRE::PCRE
+    maxmind_acl PRIVATE libswoc::libswoc ts::tsapi yaml-cpp::yaml-cpp maxminddb::maxminddb PCRE::PCRE
   )
 
   verify_remap_plugin(maxmind_acl)

--- a/plugins/experimental/sslheaders/CMakeLists.txt
+++ b/plugins/experimental/sslheaders/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties(sslhdr PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_TESTING)
   add_executable(test_sslhdr unit_tests/unit_test_main.cc unit_tests/test_sslheaders.cc)
-  target_link_libraries(test_sslhdr PRIVATE sslhdr catch2::catch2 OpenSSL::SSL ts::tsutil)
+  target_link_libraries(test_sslhdr PRIVATE sslhdr catch2::catch2 OpenSSL::SSL libswoc::libswoc)
 endif()
 
 add_atsplugin(sslheaders sslheaders.cc)

--- a/plugins/s3_auth/CMakeLists.txt
+++ b/plugins/s3_auth/CMakeLists.txt
@@ -19,7 +19,7 @@ project(s3_auth)
 
 add_atsplugin(s3_auth s3_auth.cc aws_auth_v4.cc)
 
-target_link_libraries(s3_auth PRIVATE ts::tscore OpenSSL::Crypto)
+target_link_libraries(s3_auth PRIVATE OpenSSL::Crypto)
 
 verify_remap_plugin(s3_auth)
 


### PR DESCRIPTION
This fixes the building of plugins that redundantly link with ATS core libraries. If plugins link with ts::tsutil while ATS core also links with ts::tsutil, for example, then not only is this unnecessary, but it also results in ODR issues because those symbols will exist via both the ATS and the plugin invocations.