### PR TITLE
Fedora 40: update autest output expectations

### DIFF
--- a/tests/gold_tests/pluginTest/certifier/certifier.test.py
+++ b/tests/gold_tests/pluginTest/certifier/certifier.test.py
@@ -81,7 +81,7 @@ class DynamicCertTest:
         tr.Processes.Default.ReturnCode = 0
         # Verify certificate content
         tr.Processes.Default.Streams.All += Testers.ContainsExpression(
-            "Subject: CN = www.tls.com", "Subject should match the host in the request")
+            "Subject: CN ?= ?www.tls.com", "Subject should match the host in the request")
         tr.Processes.Default.Streams.All += Testers.ContainsExpression(
             r"X509v3 extensions:\n.*X509v3 Subject Alternative Name:.*\n.*DNS:www.tls.com",
             "Should contain the SAN extension",

--- a/tests/gold_tests/pluginTest/compress/compress.gold
+++ b/tests/gold_tests/pluginTest/compress/compress.gold
@@ -14,7 +14,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/br
@@ -39,7 +39,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-1/obj1 HTTP/1.1
 > X-Ats-Compress-Test: 1/gzip
@@ -48,7 +48,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-1/obj1 HTTP/1.1
 > X-Ats-Compress-Test: 1/br
@@ -80,7 +80,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-2/obj2 HTTP/1.1
 > X-Ats-Compress-Test: 2/br
@@ -105,7 +105,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=0.666x
@@ -114,7 +114,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=#0.666
@@ -123,7 +123,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip; Q = 0.666
@@ -132,7 +132,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/gzip;q=0.0
@@ -148,7 +148,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/aaa, gzip;q=0.666, bbb
@@ -157,7 +157,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > GET http://ae-0/obj0 HTTP/1.1
 > X-Ats-Compress-Test: 0/ br ; q=0.666, bbb
@@ -175,7 +175,7 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===
 > POST http://ae-3/obj3 HTTP/1.1
 > X-Ats-Compress-Test: 3/gzip
@@ -184,5 +184,5 @@
 < Content-Type: text/javascript
 < Content-Encoding: gzip
 < Vary: Accept-Encoding
-< Content-Length: 71
+< Content-Length: 7``
 ===

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection.test.py
@@ -124,7 +124,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_ec_string, "Should select EC cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 
 # Should receive a RSA cert
 tr = Test.AddTestRun("Only offer RSA ciphers, should receive RSA cert")
@@ -134,7 +134,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_rsa_string, "Should select RSA cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 
 # Should receive a RSA cert
 tr = Test.AddTestRun("rsa.com only in rsa cert")
@@ -144,7 +144,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_rsa_string, "Should select RSA cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 
 # Should receive a EC cert
 tr = Test.AddTestRun("ec.com only in ec cert")
@@ -154,4 +154,4 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_ec_string, "Should select EC cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection2.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection2.test.py
@@ -135,7 +135,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_ec_string, "Should select EC cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 
 # Should receive a RSA cert
 tr = Test.AddTestRun("Only offer RSA ciphers, should receive RSA cert")
@@ -145,7 +145,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_rsa_string, "Should select RSA cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 
 # Should receive a RSA cert
 tr = Test.AddTestRun("rsa.com only in rsa cert")
@@ -155,7 +155,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_rsa_string, "Should select RSA cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 
 # Should receive a EC cert
 tr = Test.AddTestRun("ec.com only in ec cert")
@@ -165,7 +165,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(san_ec_string, "Should select EC cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 
 # Should receive a EC cert
 tr = Test.AddTestRun("Default for combined.com should return EC cert")
@@ -175,7 +175,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(combo_ec_string, "Should select EC cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = combined.com", "Should select combined pem")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?combined.com", "Should select combined pem")
 
 # Should receive a RSA cert
 tr = Test.AddTestRun("Only offer RSA ciphers, should receive RSA cert")
@@ -185,4 +185,4 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(combo_rsa_string, "Should select RSA cert", reflags=re.S | re.M)
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = combined.com", "Should select combined pem")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?combined.com", "Should select combined pem")

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection_plugin.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection_plugin.test.py
@@ -111,7 +111,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: ECDSA", "Should select EC cert")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
 # Should receive a RSA cert
@@ -122,7 +122,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
 # Should receive a RSA cert
@@ -133,7 +133,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
 # Should receive a EC cert
@@ -144,7 +144,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: ECDSA", "Should select EC cert")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = group.com", "Should select a group SAN")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
 # Copy in a new version of the foo.com cert.  Replace it with the version
@@ -170,7 +170,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = foo.com", "Should select foo.com")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?foo.com", "Should select foo.com")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("unable to verify the first certificate", "Different signer")
 
 tr = Test.AddTestRun("Only offer RSA ciphers, should receive RSA cert with correct CA")
@@ -180,7 +180,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = foo.com", "Should select foo.com")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?foo.com", "Should select foo.com")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
 # The EC case should be unchanged
@@ -191,5 +191,5 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: ECDSA", "Should select EC cert")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN = foo.com", "Should select foo.com")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?foo.com", "Should select foo.com")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")


### PR DESCRIPTION
The fedora:40 gzip version compresses to a different size. This impacts the compress.test.py autest. I verified that the compressed content can be expanded correctly by previous versions of gzip going back to CentOS:7.

The fedora:40 openssl library prints the common name (CN) without spaces around CN. This updates test output expectations accordingly.