### PR TITLE
Update the build_h3_tools.sh curl version to 8.7.1

### DIFF
--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -254,7 +254,7 @@ cd ..
 
 # Then curl
 echo "Building curl ..."
-[ ! -d curl ] && git clone --depth 1 -b curl-8_5_0 https://github.com/curl/curl.git
+[ ! -d curl ] && git clone --depth 1 -b curl-8_7_1 https://github.com/curl/curl.git
 cd curl
 # On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
 # The second runs fine.


### PR DESCRIPTION
This updated version fixes IPv6 handling for fedora:40. Without this, the bigobj.test.py IPv6 test fails.