### PR TITLE
Restore derived metrics using new metrics

### DIFF
--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -507,15 +507,32 @@ public:
 
   }; // class Counter
 
+  /**
+   * Derive metrics by summing a set of other metrics.
+   *
+   */
   class Derived
   {
   public:
     struct DerivedMetricSpec {
-      std::string_view                                                                              derived_name;
-      std::initializer_list<std::variant<Metrics::AtomicType *, Metrics::IdType, std::string_view>> derived_from;
+      using MetricSpec = std::variant<Metrics::AtomicType *, Metrics::IdType, std::string_view>;
+      std::string_view                  derived_name;
+      std::initializer_list<MetricSpec> derived_from;
     };
 
+    /**
+     * Create new metrics derived from existing metrics.
+     *
+     * This function will create new metrics from a list of existing metrics.  The existing metric can
+     * be specified by name, id or a pointer to the metric.
+     */
     static void derive(const std::initializer_list<DerivedMetricSpec> &metrics);
+
+    /**
+     * Update derived metrics.
+     *
+     * This static function should be called periodically to update derived metrics.
+     */
     static void update_derived();
   };
 

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <variant>
 
 #include "swoc/MemSpan.h"
 
@@ -505,6 +506,18 @@ public:
     }
 
   }; // class Counter
+
+  class Derived
+  {
+  public:
+    struct DerivedMetricSpec {
+      std::string_view derived_name;
+      std::initializer_list<std::variant<Metrics::AtomicType *, Metrics::IdType, std::string_view>> derived_from;
+    };
+
+    static void derive(const std::initializer_list<DerivedMetricSpec> &metrics);
+    static void update_derived();
+  };
 
 }; // class Metrics
 

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -511,7 +511,7 @@ public:
   {
   public:
     struct DerivedMetricSpec {
-      std::string_view derived_name;
+      std::string_view                                                                              derived_name;
       std::initializer_list<std::variant<Metrics::AtomicType *, Metrics::IdType, std::string_view>> derived_from;
     };
 

--- a/src/iocore/eventsystem/RecProcess.cc
+++ b/src/iocore/eventsystem/RecProcess.cc
@@ -23,6 +23,7 @@
 
 #include "tscore/ink_platform.h"
 #include "tscore/EventNotify.h"
+#include "tsutil/Metrics.h"
 
 #include "iocore/eventsystem/Tasks.h"
 
@@ -89,6 +90,8 @@ struct raw_stat_sync_cont : public Continuation {
   {
     RecExecRawStatSyncCbs();
     Dbg(dbg_ctl_statsproc, "raw_stat_sync_cont() processed");
+
+    ts::Metrics::Derived::update_derived();
 
     return EVENT_CONT;
   }

--- a/src/iocore/eventsystem/RecProcess.cc
+++ b/src/iocore/eventsystem/RecProcess.cc
@@ -91,6 +91,7 @@ struct raw_stat_sync_cont : public Continuation {
     RecExecRawStatSyncCbs();
     Dbg(dbg_ctl_statsproc, "raw_stat_sync_cont() processed");
 
+    // This needs to be called periodically even after the old metrics sync is removed
     ts::Metrics::Derived::update_derived();
 
     return EVENT_CONT;

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -544,6 +544,48 @@ register_stat_callbacks()
     Metrics::Counter::createPtr("proxy.process.http.user_agent_response_header_total_size");
   http_rsb.websocket_current_active_client_connections =
     Metrics::Gauge::createPtr("proxy.process.http.websocket.current_active_client_connections");
+
+  Metrics::Derived::derive({
+  // Total bytes of client request body + headers
+    {"proxy.process.http.user_agent_total_request_bytes",
+     {http_rsb.user_agent_request_document_total_size, http_rsb.user_agent_request_header_total_size}                                           },
+ // Total bytes of client response body + headers
+    {"proxy.process.http.user_agent_total_response_bytes",
+     {http_rsb.user_agent_response_document_total_size, http_rsb.user_agent_response_header_total_size}                                         },
+ // Total bytes of origin server request body + headers
+    {"proxy.process.http.origin_server_total_request_bytes",
+     {http_rsb.origin_server_request_document_total_size, http_rsb.origin_server_request_header_total_size}                                     },
+ // Total bytes of origin server response body + headers
+    {"proxy.process.http.origin_server_total_response_bytes",
+     {http_rsb.origin_server_response_document_total_size, http_rsb.origin_server_response_header_total_size}                                   },
+ // Total bytes of client request and response (total traffic to and from clients)
+    {"proxy.process.user_agent_total_bytes",
+     {"proxy.process.http.user_agent_total_request_bytes", "proxy.process.http.user_agent_total_response_bytes"}                                },
+ // Total bytes of origin/parent request and response
+    {"proxy.process.origin_server_total_bytes",
+     {"proxy.process.http.origin_server_total_request_bytes", "proxy.process.http.origin_server_total_response_bytes",
+      http_rsb.parent_proxy_request_total_bytes, http_rsb.parent_proxy_response_total_bytes}                                                    },
+ // Total requests which are cache hits
+    {"proxy.process.cache_total_hits",
+     {http_rsb.cache_hit_fresh, http_rsb.cache_hit_reval, http_rsb.cache_hit_ims, http_rsb.cache_hit_stale_served}                              },
+ // Total requests which are cache misses
+    {"proxy.process.cache_total_misses",
+     {http_rsb.cache_miss_cold, http_rsb.cache_miss_changed, http_rsb.cache_miss_client_no_cache, http_rsb.cache_miss_ims,
+      http_rsb.cache_miss_uncacheable}                                                                                                          },
+ // Total of all server connections (sum of origins and parent connections)
+    {"proxy.process.current_server_connections",              {http_rsb.current_server_connections, http_rsb.current_parent_proxy_connections}  },
+ // Total requests, both hits and misses (this is slightly superfluous, but assures correct percentage calculations)
+    {"proxy.process.cache_total_requests",                    {"proxy.process.cache_total_hits", "proxy.process.cache_total_misses"}            },
+ // Total cache requests bytes which are cache hits
+    {"proxy.process.cache_total_hits_bytes",
+     {http_rsb.tcp_hit_user_agent_bytes, http_rsb.tcp_refresh_hit_user_agent_bytes, http_rsb.tcp_ims_hit_user_agent_bytes}                      },
+ // Total cache requests bytes which are cache misses
+    {"proxy.process.cache_total_misses_bytes",
+     {http_rsb.tcp_miss_user_agent_bytes, http_rsb.tcp_expired_miss_user_agent_bytes, http_rsb.tcp_refresh_miss_user_agent_bytes,
+      http_rsb.tcp_ims_miss_user_agent_bytes}                                                                                                   },
+ // Total request bytes, both hits and misses
+    {"proxy.process.cache_total_bytes",                       {"proxy.process.cache_total_hits_bytes", "proxy.process.cache_total_misses_bytes"}}
+  });
 }
 
 static bool

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -546,44 +546,44 @@ register_stat_callbacks()
     Metrics::Gauge::createPtr("proxy.process.http.websocket.current_active_client_connections");
 
   Metrics::Derived::derive({
-  // Total bytes of client request body + headers
+    // Total bytes of client request body + headers
     {"proxy.process.http.user_agent_total_request_bytes",
      {http_rsb.user_agent_request_document_total_size, http_rsb.user_agent_request_header_total_size}                                           },
- // Total bytes of client response body + headers
+    // Total bytes of client response body + headers
     {"proxy.process.http.user_agent_total_response_bytes",
      {http_rsb.user_agent_response_document_total_size, http_rsb.user_agent_response_header_total_size}                                         },
- // Total bytes of origin server request body + headers
+    // Total bytes of origin server request body + headers
     {"proxy.process.http.origin_server_total_request_bytes",
      {http_rsb.origin_server_request_document_total_size, http_rsb.origin_server_request_header_total_size}                                     },
- // Total bytes of origin server response body + headers
+    // Total bytes of origin server response body + headers
     {"proxy.process.http.origin_server_total_response_bytes",
      {http_rsb.origin_server_response_document_total_size, http_rsb.origin_server_response_header_total_size}                                   },
- // Total bytes of client request and response (total traffic to and from clients)
+    // Total bytes of client request and response (total traffic to and from clients)
     {"proxy.process.user_agent_total_bytes",
      {"proxy.process.http.user_agent_total_request_bytes", "proxy.process.http.user_agent_total_response_bytes"}                                },
- // Total bytes of origin/parent request and response
+    // Total bytes of origin/parent request and response
     {"proxy.process.origin_server_total_bytes",
      {"proxy.process.http.origin_server_total_request_bytes", "proxy.process.http.origin_server_total_response_bytes",
       http_rsb.parent_proxy_request_total_bytes, http_rsb.parent_proxy_response_total_bytes}                                                    },
- // Total requests which are cache hits
+    // Total requests which are cache hits
     {"proxy.process.cache_total_hits",
      {http_rsb.cache_hit_fresh, http_rsb.cache_hit_reval, http_rsb.cache_hit_ims, http_rsb.cache_hit_stale_served}                              },
- // Total requests which are cache misses
+    // Total requests which are cache misses
     {"proxy.process.cache_total_misses",
      {http_rsb.cache_miss_cold, http_rsb.cache_miss_changed, http_rsb.cache_miss_client_no_cache, http_rsb.cache_miss_ims,
       http_rsb.cache_miss_uncacheable}                                                                                                          },
- // Total of all server connections (sum of origins and parent connections)
+    // Total of all server connections (sum of origins and parent connections)
     {"proxy.process.current_server_connections",              {http_rsb.current_server_connections, http_rsb.current_parent_proxy_connections}  },
- // Total requests, both hits and misses (this is slightly superfluous, but assures correct percentage calculations)
+    // Total requests, both hits and misses (this is slightly superfluous, but assures correct percentage calculations)
     {"proxy.process.cache_total_requests",                    {"proxy.process.cache_total_hits", "proxy.process.cache_total_misses"}            },
- // Total cache requests bytes which are cache hits
+    // Total cache requests bytes which are cache hits
     {"proxy.process.cache_total_hits_bytes",
      {http_rsb.tcp_hit_user_agent_bytes, http_rsb.tcp_refresh_hit_user_agent_bytes, http_rsb.tcp_ims_hit_user_agent_bytes}                      },
- // Total cache requests bytes which are cache misses
+    // Total cache requests bytes which are cache misses
     {"proxy.process.cache_total_misses_bytes",
      {http_rsb.tcp_miss_user_agent_bytes, http_rsb.tcp_expired_miss_user_agent_bytes, http_rsb.tcp_refresh_miss_user_agent_bytes,
       http_rsb.tcp_ims_miss_user_agent_bytes}                                                                                                   },
- // Total request bytes, both hits and misses
+    // Total request bytes, both hits and misses
     {"proxy.process.cache_total_bytes",                       {"proxy.process.cache_total_hits_bytes", "proxy.process.cache_total_misses_bytes"}}
   });
 }

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -220,8 +220,10 @@ namespace details
     {
       auto &instance = Metrics::instance();
       std::lock_guard l(metrics_lock);
+
       for (auto &m : metrics) {
         int64_t sum = 0;
+
         for (auto d : m.derived_from) {
           sum += d->load();
         }

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -207,18 +207,18 @@ Metrics::iterator::next()
 namespace details
 {
   struct DerivedMetric {
-    Metrics::IdType metric;
+    Metrics::IdType                    metric;
     std::vector<Metrics::AtomicType *> derived_from;
   };
 
   struct DerivativeMetrics {
     std::vector<DerivedMetric> metrics;
-    std::mutex metrics_lock;
+    std::mutex                 metrics_lock;
 
     void
     update()
     {
-      auto &instance = Metrics::instance();
+      auto           &instance = Metrics::instance();
       std::lock_guard l(metrics_lock);
 
       for (auto &m : metrics) {

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -219,6 +219,7 @@ namespace details
     update()
     {
       auto &instance = Metrics::instance();
+      std::lock_guard l(metrics_lock);
       for (auto &m : metrics) {
         int64_t sum = 0;
         for (auto d : m.derived_from) {


### PR DESCRIPTION
traffic_manager used to manage some derived metrics (metrics calculated from other metrics).  This code was removed with traffic_manager.  This PR restores that functionality and the removed metrics.