### PR TITLE
Update XPACK.cc - initialize the table after allocation to avoid bad access

### DIFF
--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -217,7 +217,8 @@ xpack_encode_string(uint8_t *buf_start, const uint8_t *buf_end, const char *valu
 XpackDynamicTable::XpackDynamicTable(uint32_t size) : _maximum_size(size), _available(size), _max_entries(size), _storage(size)
 {
   XPACKDebug("Dynamic table size: %u", size);
-  this->_entries      = static_cast<struct XpackDynamicTableEntry *>(ats_malloc(sizeof(struct XpackDynamicTableEntry) * size));
+  this->_entries = static_cast<struct XpackDynamicTableEntry *>(ats_malloc(sizeof(struct XpackDynamicTableEntry) * size));
+  memset(static_cast<void *>(this->_entries), 0, sizeof(struct XpackDynamicTableEntry) * size);
   this->_entries_head = size - 1;
   this->_entries_tail = size - 1;
 }


### PR DESCRIPTION
Let's determine if we need this after fixing #11287 and whether fuzzing complains on other code path