### PR TITLE
-fno-strict-aliasing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,7 +579,9 @@ add_subdirectory(lib)
 # there are warnings, we can't do anything about it.
 # Note: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON will turn warnings into errors.
 add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter)
-add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override;-Wno-vla-extension>")
+add_compile_options(
+  "$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override;-Wno-vla-extension;-fno-strict-aliasing>"
+)
 add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wno-format-truncation;-Wno-stringop-overflow>")
 
 if(NOT EXTERNAL_YAML_CPP)


### PR DESCRIPTION
Our ATS 9.x builds via Automake generally built with -fno-strict-aliasing. This updates our CMake configuration to do the same. This can avoid hard to debug runtime bugs from optimization.