### PR TITLE
H3 build tools. Fix missing include detected on Fedora 40.

### DIFF
--- a/tools/build_boringssl_h3_tools.sh
+++ b/tools/build_boringssl_h3_tools.sh
@@ -237,7 +237,7 @@ fi
 ./configure \
   --prefix=${BASE} \
   PKG_CONFIG_PATH=${BASE}/lib/pkgconfig \
-  CFLAGS="${CFLAGS}" \
+  CFLAGS="${CFLAGS} -I${BORINGSSL_PATH}/include" \
   CXXFLAGS="${CXXFLAGS} -I${BORINGSSL_PATH}/include" \
   LDFLAGS="${LDFLAGS}" \
   OPENSSL_LIBS="-lcrypto -lssl -L${BORINGSSL_LIB_PATH}" \


### PR DESCRIPTION
 We found out that on Fedora40 the build script was failing building one of the tools(nghttp2) because of a missing include. This adds the missing include line.