### PR TITLE
Fix case where 206 could be returned for range revalidates

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4869,7 +4869,6 @@ HttpSM::do_range_setup_if_necessary()
           // If only one range entry and pread is capable, no need transform range
           t_state.range_setup = HttpTransact::RANGE_NOT_TRANSFORM_REQUESTED;
         } else {
-          Dbg(dbg_ctl_http_range, "Well, we are here...");
           do_transform = true;
         }
       }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4858,14 +4858,18 @@ HttpSM::do_range_setup_if_necessary()
         }
       } else {
         // if revalidating and cache is stale we want to transform
-        if (t_state.cache_info.action == HttpTransact::CACHE_DO_REPLACE &&
-            t_state.hdr_info.server_response.status_get() == HTTP_STATUS_OK) {
-          Dbg(dbg_ctl_http_range, "Serving transform after stale cache re-serve");
-          do_transform = true;
+        if (t_state.cache_info.action == HttpTransact::CACHE_DO_REPLACE) {
+          if (t_state.hdr_info.server_response.status_get() == HTTP_STATUS_OK) {
+            Dbg(dbg_ctl_http_range, "Serving transform after stale cache re-serve");
+            do_transform = true;
+          } else {
+            Dbg(dbg_ctl_http_range, "Not transforming after revalidate");
+          }
         } else if (cache_sm.cache_read_vc && cache_sm.cache_read_vc->is_pread_capable()) {
           // If only one range entry and pread is capable, no need transform range
           t_state.range_setup = HttpTransact::RANGE_NOT_TRANSFORM_REQUESTED;
         } else {
+          Dbg(dbg_ctl_http_range, "Well, we are here...");
           do_transform = true;
         }
       }

--- a/tests/gold_tests/cache/replay/cache-range-response.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-range-response.replay.yaml
@@ -111,3 +111,23 @@ sessions:
             fields:
               - [ Content-Range, { value: "bytes 0-10/100", as: equal}]
               - [ Via, { value: "uIcSsSfUpSeN:t cCSp sS", as: contains }]
+      # Revalidate and replace still returns appropriate server error
+      - client-request:
+          method: "GET"
+          version: "1.1"
+          url: /some/path
+          headers:
+            fields:
+              - [ Host, example.com ]
+              - [ uuid, 5 ]
+              - [ Range, bytes=0-10 ]
+              - [ If-Modified-Since, "Wed, 16 Mar 2022 22:52:09 GMT"]
+        server-response:
+          status: 404
+          reason: Not Found
+          headers:
+            fields:
+              - [ Content-Length, 10 ]
+              - [ Cache-Control, max-age=300 ]
+        proxy-response:
+          status: 404


### PR DESCRIPTION
If a client asks for a range request for a cached object that when re-validated the server returns an error, then ATS would return a 206.

