### PR TITLE
clang-format.sh: format .hpp files

### DIFF
--- a/include/cripts/Bundle.hpp
+++ b/include/cripts/Bundle.hpp
@@ -57,7 +57,7 @@ namespace Bundle
     }
 
   private:
-    std::string _message;
+    std::string        _message;
     Cript::string_view _bundle;
     Cript::string_view _option;
   };

--- a/include/cripts/Bundles/Common.hpp
+++ b/include/cripts/Bundles/Common.hpp
@@ -70,9 +70,9 @@ public:
   void doRemap(Cript::Context *context) override;
 
 private:
-  Cript::string _cc = "";
-  int _dscp         = 0;
-  bool _force_cc    = false;
+  Cript::string _cc       = "";
+  int           _dscp     = 0;
+  bool          _force_cc = false;
 };
 
 } // namespace Bundle

--- a/include/cripts/Bundles/LogsMetrics.hpp
+++ b/include/cripts/Bundles/LogsMetrics.hpp
@@ -76,10 +76,10 @@ public:
   void doRemap(Cript::Context *context) override;
 
 private:
-  Cript::Instance *_inst;       // This Bundle needs the instance for access to the instance metrics
-  Cript::string _label = "";    // Propstats label
-  int _log_sample      = 0;     // Log sampling
-  bool _tcpinfo        = false; // Turn on TCP info logging
+  Cript::Instance *_inst;               // This Bundle needs the instance for access to the instance metrics
+  Cript::string    _label      = "";    // Propstats label
+  int              _log_sample = 0;     // Log sampling
+  bool             _tcpinfo    = false; // Turn on TCP info logging
 };
 
 } // namespace Bundle

--- a/include/cripts/Configs.hpp
+++ b/include/cripts/Configs.hpp
@@ -32,7 +32,7 @@ public:
 
   // Implemented later in Configs.cc
   integer _get(Cript::Context *context) const;
-  void _set(Cript::Context *context, integer value);
+  void    _set(Cript::Context *context, integer value);
 
 private:
   const TSOverridableConfigKey _key;
@@ -46,12 +46,11 @@ public:
 
   // Implemented later in Configs.cc
   float _get(Cript::Context *context) const;
-  void _set(Cript::Context *context, float value);
+  void  _set(Cript::Context *context, float value);
 
 private:
   const TSOverridableConfigKey _key;
 };
-
 
 class Proxy
 {
@@ -63,186 +62,191 @@ private:
   private:
     class Body_Factory
     {
-      public:
-        IntConfig response_suppression_mode{TS_CONFIG_BODY_FACTORY_RESPONSE_SUPPRESSION_MODE};
+    public:
+      IntConfig response_suppression_mode{TS_CONFIG_BODY_FACTORY_RESPONSE_SUPPRESSION_MODE};
     }; // End class Body_Factory
 
-    public:
-      Body_Factory body_factory;
+  public:
+    Body_Factory body_factory;
 
   private:
     class Hostdb
     {
-      public:
+    public:
     }; // End class Hostdb
 
-    public:
-      Hostdb hostdb;
+  public:
+    Hostdb hostdb;
 
   private:
     class Http
     {
-      public:
-        IntConfig allow_half_open{TS_CONFIG_HTTP_ALLOW_HALF_OPEN};
-        IntConfig allow_multi_range{TS_CONFIG_HTTP_ALLOW_MULTI_RANGE};
-        IntConfig anonymize_remove_client_ip{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_CLIENT_IP};
-        IntConfig anonymize_remove_cookie{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_COOKIE};
-        IntConfig anonymize_remove_from{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_FROM};
-        IntConfig anonymize_remove_referer{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_REFERER};
-        IntConfig anonymize_remove_user_agent{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_USER_AGENT};
-        IntConfig attach_server_session_to_client{TS_CONFIG_HTTP_ATTACH_SERVER_SESSION_TO_CLIENT};
-        IntConfig auth_server_session_private{TS_CONFIG_HTTP_AUTH_SERVER_SESSION_PRIVATE};
-        IntConfig background_fill_active_timeout{TS_CONFIG_HTTP_BACKGROUND_FILL_ACTIVE_TIMEOUT};
-        FloatConfig background_fill_completed_threshold{TS_CONFIG_HTTP_BACKGROUND_FILL_COMPLETED_THRESHOLD};
+    public:
+      IntConfig   allow_half_open{TS_CONFIG_HTTP_ALLOW_HALF_OPEN};
+      IntConfig   allow_multi_range{TS_CONFIG_HTTP_ALLOW_MULTI_RANGE};
+      IntConfig   anonymize_remove_client_ip{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_CLIENT_IP};
+      IntConfig   anonymize_remove_cookie{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_COOKIE};
+      IntConfig   anonymize_remove_from{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_FROM};
+      IntConfig   anonymize_remove_referer{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_REFERER};
+      IntConfig   anonymize_remove_user_agent{TS_CONFIG_HTTP_ANONYMIZE_REMOVE_USER_AGENT};
+      IntConfig   attach_server_session_to_client{TS_CONFIG_HTTP_ATTACH_SERVER_SESSION_TO_CLIENT};
+      IntConfig   auth_server_session_private{TS_CONFIG_HTTP_AUTH_SERVER_SESSION_PRIVATE};
+      IntConfig   background_fill_active_timeout{TS_CONFIG_HTTP_BACKGROUND_FILL_ACTIVE_TIMEOUT};
+      FloatConfig background_fill_completed_threshold{TS_CONFIG_HTTP_BACKGROUND_FILL_COMPLETED_THRESHOLD};
+
     private:
       class Cache
       {
-        public:
-          IntConfig cache_responses_to_cookies{TS_CONFIG_HTTP_CACHE_CACHE_RESPONSES_TO_COOKIES};
-          IntConfig cache_urls_that_look_dynamic{TS_CONFIG_HTTP_CACHE_CACHE_URLS_THAT_LOOK_DYNAMIC};
-          IntConfig generation{TS_CONFIG_HTTP_CACHE_GENERATION};
-          IntConfig guaranteed_max_lifetime{TS_CONFIG_HTTP_CACHE_GUARANTEED_MAX_LIFETIME};
-          IntConfig guaranteed_min_lifetime{TS_CONFIG_HTTP_CACHE_GUARANTEED_MIN_LIFETIME};
-          FloatConfig heuristic_lm_factor{TS_CONFIG_HTTP_CACHE_HEURISTIC_LM_FACTOR};
-          IntConfig heuristic_max_lifetime{TS_CONFIG_HTTP_CACHE_HEURISTIC_MAX_LIFETIME};
-          IntConfig heuristic_min_lifetime{TS_CONFIG_HTTP_CACHE_HEURISTIC_MIN_LIFETIME};
-          IntConfig http{TS_CONFIG_HTTP_CACHE_HTTP};
-          IntConfig ignore_accept_charset_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_CHARSET_MISMATCH};
-          IntConfig ignore_accept_encoding_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_ENCODING_MISMATCH};
-          IntConfig ignore_accept_language_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_LANGUAGE_MISMATCH};
-          IntConfig ignore_accept_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_MISMATCH};
-          IntConfig ignore_authentication{TS_CONFIG_HTTP_CACHE_IGNORE_AUTHENTICATION};
-          IntConfig ignore_client_cc_max_age{TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_CC_MAX_AGE};
-          IntConfig ignore_client_no_cache{TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_NO_CACHE};
-          IntConfig ignore_query{TS_CONFIG_HTTP_CACHE_IGNORE_QUERY};
-          IntConfig ignore_server_no_cache{TS_CONFIG_HTTP_CACHE_IGNORE_SERVER_NO_CACHE};
-          IntConfig ims_on_client_no_cache{TS_CONFIG_HTTP_CACHE_IMS_ON_CLIENT_NO_CACHE};
-          IntConfig max_open_read_retries{TS_CONFIG_HTTP_CACHE_MAX_OPEN_READ_RETRIES};
-          IntConfig max_open_write_retries{TS_CONFIG_HTTP_CACHE_MAX_OPEN_WRITE_RETRIES};
-          IntConfig max_open_write_retry_timeout{TS_CONFIG_HTTP_CACHE_MAX_OPEN_WRITE_RETRY_TIMEOUT};
-          IntConfig max_stale_age{TS_CONFIG_HTTP_CACHE_MAX_STALE_AGE};
-          IntConfig open_read_retry_time{TS_CONFIG_HTTP_CACHE_OPEN_READ_RETRY_TIME};
-          IntConfig open_write_fail_action{TS_CONFIG_HTTP_CACHE_OPEN_WRITE_FAIL_ACTION};
+      public:
+        IntConfig   cache_responses_to_cookies{TS_CONFIG_HTTP_CACHE_CACHE_RESPONSES_TO_COOKIES};
+        IntConfig   cache_urls_that_look_dynamic{TS_CONFIG_HTTP_CACHE_CACHE_URLS_THAT_LOOK_DYNAMIC};
+        IntConfig   generation{TS_CONFIG_HTTP_CACHE_GENERATION};
+        IntConfig   guaranteed_max_lifetime{TS_CONFIG_HTTP_CACHE_GUARANTEED_MAX_LIFETIME};
+        IntConfig   guaranteed_min_lifetime{TS_CONFIG_HTTP_CACHE_GUARANTEED_MIN_LIFETIME};
+        FloatConfig heuristic_lm_factor{TS_CONFIG_HTTP_CACHE_HEURISTIC_LM_FACTOR};
+        IntConfig   heuristic_max_lifetime{TS_CONFIG_HTTP_CACHE_HEURISTIC_MAX_LIFETIME};
+        IntConfig   heuristic_min_lifetime{TS_CONFIG_HTTP_CACHE_HEURISTIC_MIN_LIFETIME};
+        IntConfig   http{TS_CONFIG_HTTP_CACHE_HTTP};
+        IntConfig   ignore_accept_charset_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_CHARSET_MISMATCH};
+        IntConfig   ignore_accept_encoding_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_ENCODING_MISMATCH};
+        IntConfig   ignore_accept_language_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_LANGUAGE_MISMATCH};
+        IntConfig   ignore_accept_mismatch{TS_CONFIG_HTTP_CACHE_IGNORE_ACCEPT_MISMATCH};
+        IntConfig   ignore_authentication{TS_CONFIG_HTTP_CACHE_IGNORE_AUTHENTICATION};
+        IntConfig   ignore_client_cc_max_age{TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_CC_MAX_AGE};
+        IntConfig   ignore_client_no_cache{TS_CONFIG_HTTP_CACHE_IGNORE_CLIENT_NO_CACHE};
+        IntConfig   ignore_query{TS_CONFIG_HTTP_CACHE_IGNORE_QUERY};
+        IntConfig   ignore_server_no_cache{TS_CONFIG_HTTP_CACHE_IGNORE_SERVER_NO_CACHE};
+        IntConfig   ims_on_client_no_cache{TS_CONFIG_HTTP_CACHE_IMS_ON_CLIENT_NO_CACHE};
+        IntConfig   max_open_read_retries{TS_CONFIG_HTTP_CACHE_MAX_OPEN_READ_RETRIES};
+        IntConfig   max_open_write_retries{TS_CONFIG_HTTP_CACHE_MAX_OPEN_WRITE_RETRIES};
+        IntConfig   max_open_write_retry_timeout{TS_CONFIG_HTTP_CACHE_MAX_OPEN_WRITE_RETRY_TIMEOUT};
+        IntConfig   max_stale_age{TS_CONFIG_HTTP_CACHE_MAX_STALE_AGE};
+        IntConfig   open_read_retry_time{TS_CONFIG_HTTP_CACHE_OPEN_READ_RETRY_TIME};
+        IntConfig   open_write_fail_action{TS_CONFIG_HTTP_CACHE_OPEN_WRITE_FAIL_ACTION};
+
       private:
         class Range
         {
-          public:
-            IntConfig lookup{TS_CONFIG_HTTP_CACHE_RANGE_LOOKUP};
-            IntConfig write{TS_CONFIG_HTTP_CACHE_RANGE_WRITE};
+        public:
+          IntConfig lookup{TS_CONFIG_HTTP_CACHE_RANGE_LOOKUP};
+          IntConfig write{TS_CONFIG_HTTP_CACHE_RANGE_WRITE};
         }; // End class Range
 
-        public:
-          Range range;
+      public:
+        Range range;
 
-          IntConfig required_headers{TS_CONFIG_HTTP_CACHE_REQUIRED_HEADERS};
-          IntConfig when_to_revalidate{TS_CONFIG_HTTP_CACHE_WHEN_TO_REVALIDATE};
+        IntConfig required_headers{TS_CONFIG_HTTP_CACHE_REQUIRED_HEADERS};
+        IntConfig when_to_revalidate{TS_CONFIG_HTTP_CACHE_WHEN_TO_REVALIDATE};
       }; // End class Cache
 
-      public:
-        Cache cache;
+    public:
+      Cache cache;
 
     private:
       class Chunking
       {
-        public:
-          IntConfig size{TS_CONFIG_HTTP_CHUNKING_SIZE};
+      public:
+        IntConfig size{TS_CONFIG_HTTP_CHUNKING_SIZE};
       }; // End class Chunking
 
-      public:
-        Chunking chunking;
+    public:
+      Chunking chunking;
 
-        IntConfig chunking_enabled{TS_CONFIG_HTTP_CHUNKING_ENABLED};
+      IntConfig chunking_enabled{TS_CONFIG_HTTP_CHUNKING_ENABLED};
+
     private:
       class Connect
       {
       private:
         class Down
         {
-          public:
-            IntConfig policy{TS_CONFIG_HTTP_CONNECT_DOWN_POLICY};
+        public:
+          IntConfig policy{TS_CONFIG_HTTP_CONNECT_DOWN_POLICY};
         }; // End class Down
 
-        public:
-          Down down;
+      public:
+        Down down;
 
       }; // End class Connect
 
-      public:
-        Connect connect;
+    public:
+      Connect connect;
 
-        IntConfig connect_attempts_max_retries{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_MAX_RETRIES};
-        IntConfig connect_attempts_max_retries_down_server{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_MAX_RETRIES_DOWN_SERVER};
-        IntConfig connect_attempts_rr_retries{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_RR_RETRIES};
-        IntConfig connect_attempts_timeout{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_TIMEOUT};
-        IntConfig default_buffer_size{TS_CONFIG_HTTP_DEFAULT_BUFFER_SIZE};
-        IntConfig default_buffer_water_mark{TS_CONFIG_HTTP_DEFAULT_BUFFER_WATER_MARK};
-        IntConfig doc_in_cache_skip_dns{TS_CONFIG_HTTP_DOC_IN_CACHE_SKIP_DNS};
+      IntConfig connect_attempts_max_retries{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_MAX_RETRIES};
+      IntConfig connect_attempts_max_retries_down_server{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_MAX_RETRIES_DOWN_SERVER};
+      IntConfig connect_attempts_rr_retries{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_RR_RETRIES};
+      IntConfig connect_attempts_timeout{TS_CONFIG_HTTP_CONNECT_ATTEMPTS_TIMEOUT};
+      IntConfig default_buffer_size{TS_CONFIG_HTTP_DEFAULT_BUFFER_SIZE};
+      IntConfig default_buffer_water_mark{TS_CONFIG_HTTP_DEFAULT_BUFFER_WATER_MARK};
+      IntConfig doc_in_cache_skip_dns{TS_CONFIG_HTTP_DOC_IN_CACHE_SKIP_DNS};
+
     private:
       class Down_Server
       {
-        public:
-          IntConfig cache_time{TS_CONFIG_HTTP_DOWN_SERVER_CACHE_TIME};
+      public:
+        IntConfig cache_time{TS_CONFIG_HTTP_DOWN_SERVER_CACHE_TIME};
       }; // End class Down_Server
 
-      public:
-        Down_Server down_server;
+    public:
+      Down_Server down_server;
 
     private:
       class Flow_Control
       {
-        public:
-          IntConfig enabled{TS_CONFIG_HTTP_FLOW_CONTROL_ENABLED};
-          IntConfig high_water{TS_CONFIG_HTTP_FLOW_CONTROL_HIGH_WATER_MARK};
-          IntConfig low_water{TS_CONFIG_HTTP_FLOW_CONTROL_LOW_WATER_MARK};
+      public:
+        IntConfig enabled{TS_CONFIG_HTTP_FLOW_CONTROL_ENABLED};
+        IntConfig high_water{TS_CONFIG_HTTP_FLOW_CONTROL_HIGH_WATER_MARK};
+        IntConfig low_water{TS_CONFIG_HTTP_FLOW_CONTROL_LOW_WATER_MARK};
       }; // End class Flow_Control
 
-      public:
-        Flow_Control flow_control;
+    public:
+      Flow_Control flow_control;
 
     private:
       class Forward
       {
-        public:
-          IntConfig proxy_auth_to_parent{TS_CONFIG_HTTP_FORWARD_PROXY_AUTH_TO_PARENT};
+      public:
+        IntConfig proxy_auth_to_parent{TS_CONFIG_HTTP_FORWARD_PROXY_AUTH_TO_PARENT};
       }; // End class Forward
 
-      public:
-        Forward forward;
+    public:
+      Forward forward;
 
-        IntConfig forward_connect_method{TS_CONFIG_HTTP_FORWARD_CONNECT_METHOD};
-        IntConfig insert_age_in_response{TS_CONFIG_HTTP_INSERT_AGE_IN_RESPONSE};
-        IntConfig insert_client_ip{TS_CONFIG_HTTP_ANONYMIZE_INSERT_CLIENT_IP};
-        IntConfig insert_request_via_str{TS_CONFIG_HTTP_INSERT_REQUEST_VIA_STR};
-        IntConfig insert_response_via_str{TS_CONFIG_HTTP_INSERT_RESPONSE_VIA_STR};
-        IntConfig insert_squid_x_forwarded_for{TS_CONFIG_HTTP_INSERT_SQUID_X_FORWARDED_FOR};
-        IntConfig keep_alive_enabled_in{TS_CONFIG_HTTP_KEEP_ALIVE_ENABLED_IN};
-        IntConfig keep_alive_enabled_out{TS_CONFIG_HTTP_KEEP_ALIVE_ENABLED_OUT};
-        IntConfig keep_alive_no_activity_timeout_in{TS_CONFIG_HTTP_KEEP_ALIVE_NO_ACTIVITY_TIMEOUT_IN};
-        IntConfig keep_alive_no_activity_timeout_out{TS_CONFIG_HTTP_KEEP_ALIVE_NO_ACTIVITY_TIMEOUT_OUT};
-        IntConfig keep_alive_post_out{TS_CONFIG_HTTP_KEEP_ALIVE_POST_OUT};
-        IntConfig max_proxy_cycles{TS_CONFIG_HTTP_MAX_PROXY_CYCLES};
-        IntConfig negative_caching_enabled{TS_CONFIG_HTTP_NEGATIVE_CACHING_ENABLED};
-        IntConfig negative_caching_lifetime{TS_CONFIG_HTTP_NEGATIVE_CACHING_LIFETIME};
-        IntConfig negative_revalidating_enabled{TS_CONFIG_HTTP_NEGATIVE_REVALIDATING_ENABLED};
-        IntConfig negative_revalidating_lifetime{TS_CONFIG_HTTP_NEGATIVE_REVALIDATING_LIFETIME};
-        IntConfig no_dns_just_forward_to_parent{TS_CONFIG_HTTP_NO_DNS_JUST_FORWARD_TO_PARENT};
-        IntConfig normalize_ae{TS_CONFIG_HTTP_NORMALIZE_AE};
-        IntConfig number_of_redirections{TS_CONFIG_HTTP_NUMBER_OF_REDIRECTIONS};
+      IntConfig forward_connect_method{TS_CONFIG_HTTP_FORWARD_CONNECT_METHOD};
+      IntConfig insert_age_in_response{TS_CONFIG_HTTP_INSERT_AGE_IN_RESPONSE};
+      IntConfig insert_client_ip{TS_CONFIG_HTTP_ANONYMIZE_INSERT_CLIENT_IP};
+      IntConfig insert_request_via_str{TS_CONFIG_HTTP_INSERT_REQUEST_VIA_STR};
+      IntConfig insert_response_via_str{TS_CONFIG_HTTP_INSERT_RESPONSE_VIA_STR};
+      IntConfig insert_squid_x_forwarded_for{TS_CONFIG_HTTP_INSERT_SQUID_X_FORWARDED_FOR};
+      IntConfig keep_alive_enabled_in{TS_CONFIG_HTTP_KEEP_ALIVE_ENABLED_IN};
+      IntConfig keep_alive_enabled_out{TS_CONFIG_HTTP_KEEP_ALIVE_ENABLED_OUT};
+      IntConfig keep_alive_no_activity_timeout_in{TS_CONFIG_HTTP_KEEP_ALIVE_NO_ACTIVITY_TIMEOUT_IN};
+      IntConfig keep_alive_no_activity_timeout_out{TS_CONFIG_HTTP_KEEP_ALIVE_NO_ACTIVITY_TIMEOUT_OUT};
+      IntConfig keep_alive_post_out{TS_CONFIG_HTTP_KEEP_ALIVE_POST_OUT};
+      IntConfig max_proxy_cycles{TS_CONFIG_HTTP_MAX_PROXY_CYCLES};
+      IntConfig negative_caching_enabled{TS_CONFIG_HTTP_NEGATIVE_CACHING_ENABLED};
+      IntConfig negative_caching_lifetime{TS_CONFIG_HTTP_NEGATIVE_CACHING_LIFETIME};
+      IntConfig negative_revalidating_enabled{TS_CONFIG_HTTP_NEGATIVE_REVALIDATING_ENABLED};
+      IntConfig negative_revalidating_lifetime{TS_CONFIG_HTTP_NEGATIVE_REVALIDATING_LIFETIME};
+      IntConfig no_dns_just_forward_to_parent{TS_CONFIG_HTTP_NO_DNS_JUST_FORWARD_TO_PARENT};
+      IntConfig normalize_ae{TS_CONFIG_HTTP_NORMALIZE_AE};
+      IntConfig number_of_redirections{TS_CONFIG_HTTP_NUMBER_OF_REDIRECTIONS};
+
     private:
       class Parent_Proxy
       {
-        public:
-          IntConfig disable_parent_markdowns{TS_CONFIG_HTTP_DISABLE_PARENT_MARKDOWNS};
-          IntConfig enable_parent_timeout_markdowns{TS_CONFIG_HTTP_ENABLE_PARENT_TIMEOUT_MARKDOWNS};
-          IntConfig fail_threshold{TS_CONFIG_HTTP_PARENT_PROXY_FAIL_THRESHOLD};
-          IntConfig mark_down_hostdb{TS_CONFIG_PARENT_FAILURES_UPDATE_HOSTDB};
-          IntConfig per_parent_connect_attempts{TS_CONFIG_HTTP_PER_PARENT_CONNECT_ATTEMPTS};
-          IntConfig retry_time{TS_CONFIG_HTTP_PARENT_PROXY_RETRY_TIME};
-          IntConfig total_connect_attempts{TS_CONFIG_HTTP_PARENT_PROXY_TOTAL_CONNECT_ATTEMPTS};
+      public:
+        IntConfig disable_parent_markdowns{TS_CONFIG_HTTP_DISABLE_PARENT_MARKDOWNS};
+        IntConfig enable_parent_timeout_markdowns{TS_CONFIG_HTTP_ENABLE_PARENT_TIMEOUT_MARKDOWNS};
+        IntConfig fail_threshold{TS_CONFIG_HTTP_PARENT_PROXY_FAIL_THRESHOLD};
+        IntConfig mark_down_hostdb{TS_CONFIG_PARENT_FAILURES_UPDATE_HOSTDB};
+        IntConfig per_parent_connect_attempts{TS_CONFIG_HTTP_PER_PARENT_CONNECT_ATTEMPTS};
+        IntConfig retry_time{TS_CONFIG_HTTP_PARENT_PROXY_RETRY_TIME};
+        IntConfig total_connect_attempts{TS_CONFIG_HTTP_PARENT_PROXY_TOTAL_CONNECT_ATTEMPTS};
       }; // End class Parent_Proxy
 
-      public:
-        Parent_Proxy parent_proxy;
+    public:
+      Parent_Proxy parent_proxy;
 
     private:
       class Post
@@ -253,38 +257,39 @@ private:
         private:
           class Content_Length
           {
-            public:
-              IntConfig enabled{TS_CONFIG_HTTP_POST_CHECK_CONTENT_LENGTH_ENABLED};
+          public:
+            IntConfig enabled{TS_CONFIG_HTTP_POST_CHECK_CONTENT_LENGTH_ENABLED};
           }; // End class Content_Length
 
-          public:
-            Content_Length content_length;
+        public:
+          Content_Length content_length;
 
         }; // End class Check
 
-        public:
-          Check check;
+      public:
+        Check check;
 
       }; // End class Post
 
-      public:
-        Post post;
+    public:
+      Post post;
 
-        IntConfig proxy_protocol_out{TS_CONFIG_HTTP_PROXY_PROTOCOL_OUT};
-        IntConfig redirect_use_orig_cache_key{TS_CONFIG_HTTP_REDIRECT_USE_ORIG_CACHE_KEY};
-        IntConfig request_buffer_enabled{TS_CONFIG_HTTP_REQUEST_BUFFER_ENABLED};
-        IntConfig request_header_max_size{TS_CONFIG_HTTP_REQUEST_HEADER_MAX_SIZE};
-        IntConfig response_header_max_size{TS_CONFIG_HTTP_RESPONSE_HEADER_MAX_SIZE};
-        IntConfig response_server_enabled{TS_CONFIG_HTTP_RESPONSE_SERVER_ENABLED};
-        IntConfig send_http11_requests{TS_CONFIG_HTTP_SEND_HTTP11_REQUESTS};
+      IntConfig proxy_protocol_out{TS_CONFIG_HTTP_PROXY_PROTOCOL_OUT};
+      IntConfig redirect_use_orig_cache_key{TS_CONFIG_HTTP_REDIRECT_USE_ORIG_CACHE_KEY};
+      IntConfig request_buffer_enabled{TS_CONFIG_HTTP_REQUEST_BUFFER_ENABLED};
+      IntConfig request_header_max_size{TS_CONFIG_HTTP_REQUEST_HEADER_MAX_SIZE};
+      IntConfig response_header_max_size{TS_CONFIG_HTTP_RESPONSE_HEADER_MAX_SIZE};
+      IntConfig response_server_enabled{TS_CONFIG_HTTP_RESPONSE_SERVER_ENABLED};
+      IntConfig send_http11_requests{TS_CONFIG_HTTP_SEND_HTTP11_REQUESTS};
+
     private:
       class Server_Session_Sharing
       {
-        public:
+      public:
       }; // End class Server_Session_Sharing
 
-      public:
-        Server_Session_Sharing server_session_sharing;
+    public:
+      Server_Session_Sharing server_session_sharing;
 
     private:
       class Slow
@@ -292,43 +297,43 @@ private:
       private:
         class Log
         {
-          public:
-            IntConfig threshold{TS_CONFIG_HTTP_SLOW_LOG_THRESHOLD};
+        public:
+          IntConfig threshold{TS_CONFIG_HTTP_SLOW_LOG_THRESHOLD};
         }; // End class Log
 
-        public:
-          Log log;
+      public:
+        Log log;
 
       }; // End class Slow
 
-      public:
-        Slow slow;
+    public:
+      Slow slow;
 
-        IntConfig transaction_active_timeout_in{TS_CONFIG_HTTP_TRANSACTION_ACTIVE_TIMEOUT_IN};
-        IntConfig transaction_active_timeout_out{TS_CONFIG_HTTP_TRANSACTION_ACTIVE_TIMEOUT_OUT};
-        IntConfig transaction_no_activity_timeout_in{TS_CONFIG_HTTP_TRANSACTION_NO_ACTIVITY_TIMEOUT_IN};
-        IntConfig transaction_no_activity_timeout_out{TS_CONFIG_HTTP_TRANSACTION_NO_ACTIVITY_TIMEOUT_OUT};
-        IntConfig uncacheable_requests_bypass_parent{TS_CONFIG_HTTP_UNCACHEABLE_REQUESTS_BYPASS_PARENT};
+      IntConfig transaction_active_timeout_in{TS_CONFIG_HTTP_TRANSACTION_ACTIVE_TIMEOUT_IN};
+      IntConfig transaction_active_timeout_out{TS_CONFIG_HTTP_TRANSACTION_ACTIVE_TIMEOUT_OUT};
+      IntConfig transaction_no_activity_timeout_in{TS_CONFIG_HTTP_TRANSACTION_NO_ACTIVITY_TIMEOUT_IN};
+      IntConfig transaction_no_activity_timeout_out{TS_CONFIG_HTTP_TRANSACTION_NO_ACTIVITY_TIMEOUT_OUT};
+      IntConfig uncacheable_requests_bypass_parent{TS_CONFIG_HTTP_UNCACHEABLE_REQUESTS_BYPASS_PARENT};
     }; // End class Http
 
-    public:
-      Http http;
+  public:
+    Http http;
 
   private:
     class Net
     {
-      public:
-        IntConfig default_inactivity_timeout{TS_CONFIG_NET_DEFAULT_INACTIVITY_TIMEOUT};
-        IntConfig sock_notsent_lowat{TS_CONFIG_NET_SOCK_NOTSENT_LOWAT};
-        IntConfig sock_option_flag_out{TS_CONFIG_NET_SOCK_OPTION_FLAG_OUT};
-        IntConfig sock_packet_mark_out{TS_CONFIG_NET_SOCK_PACKET_MARK_OUT};
-        IntConfig sock_packet_tos_out{TS_CONFIG_NET_SOCK_PACKET_TOS_OUT};
-        IntConfig sock_recv_buffer_size_out{TS_CONFIG_NET_SOCK_RECV_BUFFER_SIZE_OUT};
-        IntConfig sock_send_buffer_size_out{TS_CONFIG_NET_SOCK_SEND_BUFFER_SIZE_OUT};
+    public:
+      IntConfig default_inactivity_timeout{TS_CONFIG_NET_DEFAULT_INACTIVITY_TIMEOUT};
+      IntConfig sock_notsent_lowat{TS_CONFIG_NET_SOCK_NOTSENT_LOWAT};
+      IntConfig sock_option_flag_out{TS_CONFIG_NET_SOCK_OPTION_FLAG_OUT};
+      IntConfig sock_packet_mark_out{TS_CONFIG_NET_SOCK_PACKET_MARK_OUT};
+      IntConfig sock_packet_tos_out{TS_CONFIG_NET_SOCK_PACKET_TOS_OUT};
+      IntConfig sock_recv_buffer_size_out{TS_CONFIG_NET_SOCK_RECV_BUFFER_SIZE_OUT};
+      IntConfig sock_send_buffer_size_out{TS_CONFIG_NET_SOCK_SEND_BUFFER_SIZE_OUT};
     }; // End class Net
 
-    public:
-      Net net;
+  public:
+    Net net;
 
   private:
     class Plugin
@@ -336,21 +341,22 @@ private:
     private:
       class Vc
       {
-        public:
-          IntConfig default_buffer_index{TS_CONFIG_PLUGIN_VC_DEFAULT_BUFFER_INDEX};
-          IntConfig default_buffer_water_mark{TS_CONFIG_PLUGIN_VC_DEFAULT_BUFFER_WATER_MARK};
+      public:
+        IntConfig default_buffer_index{TS_CONFIG_PLUGIN_VC_DEFAULT_BUFFER_INDEX};
+        IntConfig default_buffer_water_mark{TS_CONFIG_PLUGIN_VC_DEFAULT_BUFFER_WATER_MARK};
       }; // End class Vc
 
-      public:
-        Vc vc;
+    public:
+      Vc vc;
 
     }; // End class Plugin
 
-    public:
-      Plugin plugin;
+  public:
+    Plugin plugin;
 
-    public:
-      IntConfig srv_enabled{TS_CONFIG_SRV_ENABLED};
+  public:
+    IntConfig srv_enabled{TS_CONFIG_SRV_ENABLED};
+
   private:
     class Ssl
     {
@@ -363,35 +369,35 @@ private:
         private:
           class Cert
           {
-            public:
+          public:
           }; // End class Cert
-
-          public:
-            Cert cert;
-
-        }; // End class Ca
-
-        public:
-          Ca CA;
-
-        public:
-      private:
-        class Cert
-        {
-          public:
-        }; // End class Cert
 
         public:
           Cert cert;
 
+        }; // End class Ca
+
+      public:
+        Ca CA;
+
+      public:
+      private:
+        class Cert
+        {
+        public:
+        }; // End class Cert
+
+      public:
+        Cert cert;
+
       private:
         class Private_Key
         {
-          public:
+        public:
         }; // End class Private_Key
 
-        public:
-          Private_Key private_key;
+      public:
+        Private_Key private_key;
 
       private:
         class Verify
@@ -399,55 +405,54 @@ private:
         private:
           class Server
           {
-            public:
+          public:
           }; // End class Server
 
-          public:
-            Server server;
+        public:
+          Server server;
 
         }; // End class Verify
 
-        public:
-          Verify verify;
+      public:
+        Verify verify;
 
       }; // End class Client
 
-      public:
-        Client client;
-
-      public:
-        IntConfig hsts_include_subdomains{TS_CONFIG_SSL_HSTS_INCLUDE_SUBDOMAINS};
-        IntConfig hsts_max_age{TS_CONFIG_SSL_HSTS_MAX_AGE};
-    }; // End class Ssl
+    public:
+      Client client;
 
     public:
-      Ssl ssl;
+      IntConfig hsts_include_subdomains{TS_CONFIG_SSL_HSTS_INCLUDE_SUBDOMAINS};
+      IntConfig hsts_max_age{TS_CONFIG_SSL_HSTS_MAX_AGE};
+    }; // End class Ssl
+
+  public:
+    Ssl ssl;
 
   private:
     class Url_Remap
     {
-      public:
-        IntConfig pristine_host_hdr{TS_CONFIG_URL_REMAP_PRISTINE_HOST_HDR};
+    public:
+      IntConfig pristine_host_hdr{TS_CONFIG_URL_REMAP_PRISTINE_HOST_HDR};
     }; // End class Url_Remap
 
-    public:
-      Url_Remap url_remap;
+  public:
+    Url_Remap url_remap;
 
   private:
     class Websocket
     {
-      public:
-        IntConfig active_timeout{TS_CONFIG_WEBSOCKET_ACTIVE_TIMEOUT};
-        IntConfig no_activity_timeout{TS_CONFIG_WEBSOCKET_NO_ACTIVITY_TIMEOUT};
+    public:
+      IntConfig active_timeout{TS_CONFIG_WEBSOCKET_ACTIVE_TIMEOUT};
+      IntConfig no_activity_timeout{TS_CONFIG_WEBSOCKET_NO_ACTIVITY_TIMEOUT};
     }; // End class Websocket
 
-    public:
-      Websocket websocket;
+  public:
+    Websocket websocket;
 
   }; // End class Config
 
-  public:
-    Config config;
+public:
+  Config config;
 
 }; // End class Proxy
-

--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -54,10 +54,10 @@ public:
   }
 
   uint64_t hasher(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
-  bool sample(double rate, uint32_t seed = 0, unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
+  bool     sample(double rate, uint32_t seed = 0, unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
 
 private:
-  char _str[INET6_ADDRSTRLEN + 1];
+  char     _str[INET6_ADDRSTRLEN + 1];
   uint64_t _hash    = 0;
   uint16_t _sampler = 0;
 };
@@ -91,7 +91,7 @@ class ConnBase
 
   private:
     ConnBase *_owner = nullptr;
-    integer _val     = -1;
+    integer   _val   = -1;
 
   }; // End class ConnBase::Dscp
 
@@ -133,7 +133,7 @@ class ConnBase
 
   private:
     ConnBase *_owner = nullptr;
-    uint32_t _val    = Off;
+    uint32_t  _val   = Off;
 
   }; // End class ConnBase::Pacing
 
@@ -192,7 +192,7 @@ class ConnBase
 
   private:
     ConnBase *_owner = nullptr;
-    integer _val     = -1;
+    integer   _val   = -1;
 
   }; // End class ConnBase::Mark
 
@@ -264,7 +264,7 @@ class ConnBase
     }
 
     struct tcp_info info;
-    socklen_t info_len = sizeof(info);
+    socklen_t       info_len = sizeof(info);
 
 #else
     integer
@@ -296,8 +296,8 @@ class ConnBase
   private:
     void initialize();
 
-    ConnBase *_owner = nullptr;
-    bool _ready      = false;
+    ConnBase     *_owner = nullptr;
+    bool          _ready = false;
     Cript::string _logging; // Storage for the logformat of the tcpinfo
 
   }; // End class ConnBase::TcpInfo
@@ -335,23 +335,23 @@ public:
     return TSHttpTxnIsInternal(_state->txnp);
   }
 
-  [[nodiscard]] virtual int count() const = 0;
-  virtual void setDscp(int val)           = 0;
-  virtual void setMark(int val)           = 0;
-  Dscp dscp;
-  Congestion congestion;
-  TcpInfo tcpinfo;
-  Geo geo;
-  Pacing pacing;
-  Mark mark;
+  [[nodiscard]] virtual int count() const    = 0;
+  virtual void              setDscp(int val) = 0;
+  virtual void              setMark(int val) = 0;
+  Dscp                      dscp;
+  Congestion                congestion;
+  TcpInfo                   tcpinfo;
+  Geo                       geo;
+  Pacing                    pacing;
+  Mark                      mark;
 
   Cript::string_view string(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
 
 protected:
-  Cript::Transaction *_state     = nullptr;
+  Cript::Transaction    *_state  = nullptr;
   struct sockaddr const *_socket = nullptr;
-  TSVConn _vc                    = nullptr;
-  char _str[INET6_ADDRSTRLEN + 1];
+  TSVConn                _vc     = nullptr;
+  char                   _str[INET6_ADDRSTRLEN + 1];
 
 }; // End class ConnBase
 
@@ -368,8 +368,8 @@ public:
   void operator=(const Connection &) = delete;
   Connection(const Connection &)     = delete;
 
-  [[nodiscard]] int fd() const override;
-  [[nodiscard]] int count() const override;
+  [[nodiscard]] int  fd() const override;
+  [[nodiscard]] int  count() const override;
   static Connection &_get(Cript::Context *context);
 
   void
@@ -400,8 +400,8 @@ public:
   void operator=(const Connection &) = delete;
   Connection(const Connection &)     = delete;
 
-  [[nodiscard]] int fd() const override;
-  [[nodiscard]] int count() const override;
+  [[nodiscard]] int  fd() const override;
+  [[nodiscard]] int  count() const override;
   static Connection &_get(Cript::Context *context);
 
   void

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -100,11 +100,11 @@ public:
   }
 
   // These fields are preserving the parameters as setup in DoRemap()
-  Cript::Transaction state;
+  Cript::Transaction                       state;
   std::array<DataType, CONTEXT_DATA_SLOTS> data;
-  TSCont default_cont     = nullptr;
-  TSRemapRequestInfo *rri = nullptr;
-  Cript::Instance &p_instance; // p_ == public_, since we can't use "instance"
+  TSCont                                   default_cont = nullptr;
+  TSRemapRequestInfo                      *rri          = nullptr;
+  Cript::Instance                         &p_instance; // p_ == public_, since we can't use "instance"
 
   // These are private, but needs to be visible to our friend classes that
   // depends on the Context.
@@ -131,20 +131,20 @@ private:
 
   // These are "pre-allocated", but not initialized. They will be initialized
   // when used via a factory.
-  Client::Response _client_resp_header;
-  Client::Request _client_req_header;
+  Client::Response   _client_resp_header;
+  Client::Request    _client_req_header;
   Client::Connection _client_conn;
-  Client::URL _client_url;
-  Pristine::URL _pristine_url;
-  Server::Response _server_resp_header;
-  Server::Request _server_req_header;
+  Client::URL        _client_url;
+  Pristine::URL      _pristine_url;
+  Server::Response   _server_resp_header;
+  Server::Request    _server_req_header;
   Server::Connection _server_conn;
-  Cache::URL _cache_url;
-  Parent::URL _parent_url;
+  Cache::URL         _cache_url;
+  Parent::URL        _parent_url;
 
   // For the thread_local freelist
   static thread_local self_type *_contexts;
-  self_type *_next = nullptr;
+  self_type                     *_next = nullptr;
 }; // End class Context
 
 } // namespace Cript

--- a/include/cripts/Crypto.hpp
+++ b/include/cripts/Crypto.hpp
@@ -96,7 +96,7 @@ namespace detail
   protected:
     // Size for the bigest digest
     unsigned char _hash[EVP_MAX_MD_SIZE] = {};
-    size_t _length                       = EVP_MAX_MD_SIZE;
+    size_t        _length                = EVP_MAX_MD_SIZE;
 
   }; // End class Crypto::Digest;
 
@@ -110,7 +110,7 @@ namespace detail
 
     ~Cipher() { EVP_CIPHER_CTX_free(_ctx); }
 
-    virtual void encrypt(Cript::string_view str);
+    virtual void               encrypt(Cript::string_view str);
     virtual Cript::string_view finalize();
 
     operator Cript::string_view() const { return {_message}; }
@@ -134,12 +134,12 @@ namespace detail
     Cipher(const unsigned char *key, int len) : _key_len(len) { memcpy(_key, key, len); }
     virtual void _initialize();
 
-    Cript::string _message;
-    unsigned char _key[EVP_MAX_KEY_LENGTH];
-    int _key_len              = 0;
-    int _length               = 0;
-    EVP_CIPHER_CTX *_ctx      = nullptr;
-    const EVP_CIPHER *_cipher = nullptr;
+    Cript::string     _message;
+    unsigned char     _key[EVP_MAX_KEY_LENGTH];
+    int               _key_len = 0;
+    int               _length  = 0;
+    EVP_CIPHER_CTX   *_ctx     = nullptr;
+    const EVP_CIPHER *_cipher  = nullptr;
 
   }; // End class Cipher
 

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -236,7 +236,7 @@ wrap_delete_instance(T *context, bool execute, CaseTag<0>) -> bool
 int
 default_cont(TSCont contp, TSEvent event, void *edata)
 {
-  auto txnp     = static_cast<TSHttpTxn>(edata);
+  auto  txnp    = static_cast<TSHttpTxn>(edata);
   auto *context = static_cast<Cript::Context *>(TSContDataGet(contp));
 
   context->reset(); // Clears the cached handles to internal ATS data (mloc's etc.)
@@ -376,7 +376,7 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 
   // This is to check, and call, the Cript's do_init() if provided.
   // Note that the context here is not a Cript context, but rather tha API info
-  extern void global_initialization();
+  extern void           global_initialization();
   extern pthread_once_t init_once_control;
 
   pthread_once(&init_once_control, global_initialization);
@@ -395,9 +395,9 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
-  auto *inst = new Cript::Instance(argc, argv);
+  auto                  *inst = new Cript::Instance(argc, argv);
   Cript::InstanceContext context(*inst);
-  bool needs_create_instance = wrap_create_instance(&context, false, CaseArg);
+  bool                   needs_create_instance = wrap_create_instance(&context, false, CaseArg);
 
   if (needs_create_instance) {
     wrap_create_instance(&context, true, CaseArg);
@@ -442,9 +442,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 void
 TSRemapDeleteInstance(void *ih)
 {
-  auto inst = static_cast<Cript::Instance *>(ih);
+  auto                   inst = static_cast<Cript::Instance *>(ih);
   Cript::InstanceContext context(*inst);
-  bool needs_delete_instance = wrap_delete_instance(&context, false, CaseArg);
+  bool                   needs_delete_instance = wrap_delete_instance(&context, false, CaseArg);
 
   if (needs_delete_instance) {
     wrap_delete_instance(&context, true, CaseArg);
@@ -458,7 +458,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 {
   // Check to see if we need to setup future hooks with a continuation. This
   // should only happen once.
-  static bool cript_needs_do_remap = wrap_do_remap(static_cast<Cript::Context *>(nullptr), false, CaseArg);
+  static bool     cript_needs_do_remap = wrap_do_remap(static_cast<Cript::Context *>(nullptr), false, CaseArg);
   static unsigned cript_enabled_hooks =
     (wrap_post_remap(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_POST_REMAP : 0) |
     (wrap_send_response(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_SEND_RESPONSE : 0) |
@@ -467,11 +467,11 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
     (wrap_cache_lookup(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_CACHE_LOOKUP : 0) |
     (wrap_txn_close(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_TXN_CLOSE : 0);
 
-  TSHttpSsn ssnp    = TSHttpTxnSsnGet(txnp);
-  auto *inst        = static_cast<Cript::Instance *>(ih);
-  auto bundle_cbs   = inst->callbacks();
-  auto *context     = Cript::Context::factory(txnp, ssnp, rri, *inst);
-  bool keep_context = false;
+  TSHttpSsn ssnp         = TSHttpTxnSsnGet(txnp);
+  auto     *inst         = static_cast<Cript::Instance *>(ih);
+  auto      bundle_cbs   = inst->callbacks();
+  auto     *context      = Cript::Context::factory(txnp, ssnp, rri, *inst);
+  bool      keep_context = false;
 
   context->state.hook          = TS_HTTP_READ_REQUEST_HDR_HOOK; // Not quite true
   context->state.enabled_hooks = (cript_enabled_hooks | bundle_cbs);

--- a/include/cripts/Error.hpp
+++ b/include/cripts/Error.hpp
@@ -113,6 +113,6 @@ public:
 
 private:
   Message _message;
-  Status _status;
-  bool _failed = false;
+  Status  _status;
+  bool    _failed = false;
 };

--- a/include/cripts/Files.hpp
+++ b/include/cripts/Files.hpp
@@ -60,7 +60,7 @@ namespace Line
     }
 
   private:
-    File::Path _path;
+    File::Path    _path;
     std::ifstream _stream;
   }; // namespace Reader
 

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -49,7 +49,7 @@ public:
   private:
     friend class Header;
 
-    Header *_owner       = nullptr;
+    Header      *_owner  = nullptr;
     TSHttpStatus _status = TS_HTTP_STATUS_NONE;
 
   }; // End class Header::Status
@@ -160,7 +160,7 @@ public:
   private:
     friend class Header;
 
-    Header *_owner = nullptr;
+    Header            *_owner = nullptr;
     Cript::string_view _method;
 
   }; // End class Header::Method
@@ -201,7 +201,7 @@ public:
     }
 
   private:
-    Header *_owner = nullptr;
+    Header            *_owner = nullptr;
     Cript::string_view _cache;
 
   }; // Class Header::CacheStatus
@@ -261,8 +261,8 @@ public:
     }
 
   private:
-    Header *_owner    = nullptr;
-    TSMLoc _field_loc = nullptr;
+    Header            *_owner     = nullptr;
+    TSMLoc             _field_loc = nullptr;
     Cript::string_view _name;
 
   }; // Class Header::String
@@ -349,9 +349,9 @@ public:
     }
 
   private:
-    Name _view     = nullptr;
-    uint32_t _tag  = 0;
-    Header *_owner = nullptr;
+    Name     _view  = nullptr;
+    uint32_t _tag   = 0;
+    Header  *_owner = nullptr;
 
     static const Iterator _end;
   }; // Class Header::iterator
@@ -410,7 +410,7 @@ public:
     p.clear();
   }
 
-  Iterator begin();
+  Iterator           begin();
   Cript::string_view iterate(); // This is a little helper for the iterators
 
   [[nodiscard]] Iterator
@@ -419,17 +419,17 @@ public:
     return Iterator::end(); // Static end iterator. ToDo: Does this have any value over making a new one always?
   }
 
-  Status status;
-  Reason reason;
-  Body body;
+  Status      status;
+  Reason      reason;
+  Body        body;
   CacheStatus cache;
 
 protected:
-  TSMBuffer _bufp            = nullptr;
-  TSMLoc _hdr_loc            = nullptr;
-  Cript::Transaction *_state = nullptr; // Pointer into the owning Context's State
-  TSMLoc _iterator_loc       = nullptr;
-  uint32_t _iterator_tag     = 0; // This is used to assure that we don't have more than one active iterator on a header
+  TSMBuffer           _bufp         = nullptr;
+  TSMLoc              _hdr_loc      = nullptr;
+  Cript::Transaction *_state        = nullptr; // Pointer into the owning Context's State
+  TSMLoc              _iterator_loc = nullptr;
+  uint32_t            _iterator_tag = 0; // This is used to assure that we don't have more than one active iterator on a header
 
 }; // End class Header
 

--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -112,19 +112,19 @@ public:
     }
   }
 
-  std::array<DataType, 32> data;
-  Cript::string to_url;
-  Cript::string from_url;
-  Cript::string plugin_debug_tag;
+  std::array<DataType, 32>                       data;
+  Cript::string                                  to_url;
+  Cript::string                                  from_url;
+  Cript::string                                  plugin_debug_tag;
   std::unordered_map<std::string, Plugin::Remap> plugins;
-  Cript::MetricStorage metrics{8};
-  std::vector<Cript::Bundle::Base *> bundles;
+  Cript::MetricStorage                           metrics{8};
+  std::vector<Cript::Bundle::Base *>             bundles;
 
 private:
-  size_t _size        = 0;
-  bool _failed        = false;
+  size_t   _size      = 0;
+  bool     _failed    = false;
   unsigned _callbacks = 0;
-  DbgCtl dbg_ctl_cript;
+  DbgCtl   dbg_ctl_cript;
 }; // End class Instance
 
 // A little wrapper / hack to make the do_create_instance take what looks like a context.

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -391,12 +391,12 @@ template <std::size_t N> struct isStatic<char[N]> : std::true_type {
 };
 
 // Some helper functions, in the Cript:: generic namespace
-int random(int max);
+int                             random(int max);
 std::vector<Cript::string_view> splitter(Cript::string_view input, char delim);
-Cript::string hex(const Cript::string &str);
-Cript::string hex(Cript::string_view sv);
-Cript::string unhex(const Cript::string &str);
-Cript::string unhex(Cript::string_view sv);
+Cript::string                   hex(const Cript::string &str);
+Cript::string                   hex(Cript::string_view sv);
+Cript::string                   unhex(const Cript::string &str);
+Cript::string                   unhex(Cript::string_view sv);
 
 } // namespace Cript
 
@@ -435,10 +435,10 @@ class Control
 
 public:
   Cache cache;
-  Base logging{TS_HTTP_CNTL_LOGGING_MODE};
-  Base intercept{TS_HTTP_CNTL_INTERCEPT_RETRY_MODE};
-  Base debug{TS_HTTP_CNTL_TXN_DEBUG};
-  Base remap{TS_HTTP_CNTL_SKIP_REMAPPING};
+  Base  logging{TS_HTTP_CNTL_LOGGING_MODE};
+  Base  intercept{TS_HTTP_CNTL_INTERCEPT_RETRY_MODE};
+  Base  debug{TS_HTTP_CNTL_TXN_DEBUG};
+  Base  remap{TS_HTTP_CNTL_SKIP_REMAPPING};
 
 }; // End class Control
 

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -198,12 +198,12 @@ public:
     static void *malloc(PCRE2_SIZE size, void *context);
 
   private:
-    RegexEntries::size_type _match = 0; // The index into the regex vector that match, starting at 1 for the first regex
-    pcre2_match_data *_data        = nullptr;
-    PCRE2_SIZE *_ovector           = nullptr;
-    PCRE2_SIZE _ctx_ix             = 0;
-    std::byte _ctx_data[24 * 2 + 96 + 16 * MAX_CAPTURES];
-    Cript::string_view _subject;
+    RegexEntries::size_type _match   = 0; // The index into the regex vector that match, starting at 1 for the first regex
+    pcre2_match_data       *_data    = nullptr;
+    PCRE2_SIZE             *_ovector = nullptr;
+    PCRE2_SIZE              _ctx_ix  = 0;
+    std::byte               _ctx_data[24 * 2 + 96 + 16 * MAX_CAPTURES];
+    Cript::string_view      _subject;
   };
 
   PCRE() = default;
@@ -220,7 +220,7 @@ public:
 
   ~PCRE();
 
-  void add(Cript::string_view regex, uint32_t options = 0, bool jit = true);
+  void   add(Cript::string_view regex, uint32_t options = 0, bool jit = true);
   Result contains(Cript::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0);
 
   Result

--- a/include/cripts/Metrics.hpp
+++ b/include/cripts/Metrics.hpp
@@ -108,8 +108,8 @@ protected:
 
 private:
   ts::Metrics::AtomicType *_metric = nullptr;
-  Cript::string _name              = "unknown";
-  detail::MetricID _id             = ts::Metrics::NOT_FOUND;
+  Cript::string            _name   = "unknown";
+  detail::MetricID         _id     = ts::Metrics::NOT_FOUND;
 }; // class BaseMetrics
 
 } // namespace detail
@@ -146,7 +146,7 @@ public:
   create(const Cript::string_view &name)
   {
     auto *ret = new self_type(name);
-    auto id   = ts::Metrics::Counter::create(name);
+    auto  id  = ts::Metrics::Counter::create(name);
 
     ret->_initialize(id);
 
@@ -167,7 +167,7 @@ public:
   create(const Cript::string_view &name)
   {
     auto *ret = new self_type(name);
-    auto id   = ts::Metrics::Gauge::create(name);
+    auto  id  = ts::Metrics::Gauge::create(name);
 
     ret->_initialize(id);
 

--- a/include/cripts/Plugins.hpp
+++ b/include/cripts/Plugins.hpp
@@ -54,7 +54,7 @@ public:
 
 private:
   RemapPluginInst *_plugin = nullptr;
-  bool _valid              = false;
+  bool             _valid  = false;
 }; // End class Plugin::Remap
 
 } // namespace Plugin

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -60,13 +60,13 @@
 #include "cripts/Plugins.hpp"
 
 // This is to make using these more convenient
-using fmt::format;
 using Cript::string;
+using fmt::format;
 
 // This needs to be last
 #include "cripts/Context.hpp"
 
 // These are globals, making certain operations nice and convenient, without wasting plugin space
-extern Proxy proxy;      // Access to all overridable configurations
-extern Control control;  // Access to the HTTP control mechanism
+extern Proxy    proxy;   // Access to all overridable configurations
+extern Control  control; // Access to the HTTP control mechanism
 extern Versions version; // Access to the ATS version information

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -94,8 +94,8 @@ public:
   }
 
 protected:
-  std::time_t _now = std::time(nullptr);
-  std::tm _result  = {};
+  std::time_t _now    = std::time(nullptr);
+  std::tm     _result = {};
 };
 } // namespace detail
 

--- a/include/cripts/Transaction.hpp
+++ b/include/cripts/Transaction.hpp
@@ -52,13 +52,13 @@ public:
   // This is crucial, we have to get the Txn pointer early on and preserve it.
   TSHttpTxn txnp;
   TSHttpSsn ssnp;
-  Error error;
-  Context *context; // Back to the owning context
+  Error     error;
+  Context  *context; // Back to the owning context
 
   // Keep track of which hook we're currently in. ToDo: Do we still need this with the
   // tests being moved out to the linter?
-  TSHttpHookID hook      = TS_HTTP_LAST_HOOK;
-  unsigned enabled_hooks = 0; // Which hooks are enabled, other than the mandatory ones
+  TSHttpHookID hook          = TS_HTTP_LAST_HOOK;
+  unsigned     enabled_hooks = 0; // Which hooks are enabled, other than the mandatory ones
 
   [[nodiscard]] bool
   aborted() const

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -142,8 +142,8 @@ class Url
 
   protected:
     mutable Cript::string_view _data;
-    Url *_owner  = nullptr;
-    bool _loaded = false;
+    Url                       *_owner  = nullptr;
+    bool                       _loaded = false;
 
   }; // End class Url::Component
 
@@ -160,7 +160,7 @@ public:
   public:
     Scheme() = default;
     Cript::string_view getSV() override;
-    self_type operator=(Cript::string_view scheme);
+    self_type          operator=(Cript::string_view scheme);
 
   }; // End class Url::Scheme
 
@@ -174,7 +174,7 @@ public:
   public:
     Host() = default;
     Cript::string_view getSV() override;
-    self_type operator=(Cript::string_view host);
+    self_type          operator=(Cript::string_view host);
 
   }; // End class Url::Host
 
@@ -199,8 +199,8 @@ public:
     self_type
     operator=(Cript::string_view str)
     {
-      uint32_t port = 80;
-      auto result   = std::from_chars(str.data(), str.data() + str.size(), port);
+      uint32_t port   = 80;
+      auto     result = std::from_chars(str.data(), str.data() + str.size(), port);
 
       if (result.ec != std::errc::invalid_argument) {
         return *this;
@@ -210,8 +210,8 @@ public:
     }
 
   private:
-    Url *_owner   = nullptr;
-    integer _port = -1;
+    Url    *_owner = nullptr;
+    integer _port  = -1;
   }; // End class Url::Port
 
   class Path : public Component
@@ -273,8 +273,8 @@ public:
         _ix    = ix;
       }
 
-      Path *_owner            = nullptr;
-      Segments::size_type _ix = 0;
+      Path               *_owner = nullptr;
+      Segments::size_type _ix    = 0;
 
     }; // End class Url::Path::String
 
@@ -286,9 +286,9 @@ public:
     void reset() override;
 
     Cript::string_view getSV() override;
-    Cript::string operator+=(Cript::string_view add);
-    self_type operator=(Cript::string_view path);
-    String operator[](Segments::size_type ix);
+    Cript::string      operator+=(Cript::string_view add);
+    self_type          operator=(Cript::string_view path);
+    String             operator[](Segments::size_type ix);
 
     void
     erase(Segments::size_type ix)
@@ -325,9 +325,9 @@ public:
   private:
     void _parser();
 
-    bool _modified = false;
-    Segments _segments;                 // Lazy loading on this
-    Cript::string _storage;             // Used when recombining the segments into a full path
+    bool                     _modified = false;
+    Segments                 _segments; // Lazy loading on this
+    Cript::string            _storage;  // Used when recombining the segments into a full path
     Cript::string::size_type _size = 0; // Mostly a guestimate for managing _storage
 
   }; // End class Url::Path
@@ -402,7 +402,7 @@ public:
         _owner = owner;
       }
 
-      Query *_owner = nullptr;
+      Query             *_owner = nullptr;
       Cript::string_view _name;
 
     }; // End class Url::Query::Parameter
@@ -422,10 +422,10 @@ public:
     void reset() override;
 
     Cript::string_view getSV() override;
-    self_type operator=(Cript::string_view query);
-    Cript::string operator+=(Cript::string_view add);
-    Parameter operator[](Cript::string_view param);
-    void erase(Cript::string_view param);
+    self_type          operator=(Cript::string_view query);
+    Cript::string      operator+=(Cript::string_view add);
+    Parameter          operator[](Cript::string_view param);
+    void               erase(Cript::string_view param);
 
     void
     erase(std::initializer_list<Cript::string_view> list)
@@ -469,9 +469,9 @@ public:
   private:
     void _parser();
 
-    bool _modified = false;
+    bool          _modified = false;
     OrderedParams _ordered;             // Ordered vector of all parameters, can be sorted etc.
-    HashParams _hashed;                 // Unordered map to go from "name" to the query parameter
+    HashParams    _hashed;              // Unordered map to go from "name" to the query parameter
     Cript::string _storage;             // Used when recombining the query params into a
                                         // full query string
     Cript::string::size_type _size = 0; // Mostly a guesttimate
@@ -519,11 +519,11 @@ public:
   // Getters / setters for the full URL
   Cript::string url() const;
 
-  Host host;
+  Host   host;
   Scheme scheme;
-  Path path;
-  Query query;
-  Port port;
+  Path   path;
+  Query  query;
+  Port   port;
 
 protected:
   void
@@ -533,13 +533,13 @@ protected:
     host._owner = path._owner = scheme._owner = query._owner = port._owner = this;
   }
 
-  TSMBuffer _bufp = nullptr;            // These two gets setup via initializing, pointing
-                                        // to appropriate headers
-  TSMLoc _hdr_loc            = nullptr; // Do not release any of this within the URL classes!
-  TSMLoc _urlp               = nullptr; // This is owned by us.
-  Cript::Transaction *_state = nullptr; // Pointer into the owning Context's State
-  bool _modified             = false;   // We have pending changes on the path components or
-                                        // query parameters?
+  TSMBuffer _bufp = nullptr;               // These two gets setup via initializing, pointing
+                                           // to appropriate headers
+  TSMLoc              _hdr_loc  = nullptr; // Do not release any of this within the URL classes!
+  TSMLoc              _urlp     = nullptr; // This is owned by us.
+  Cript::Transaction *_state    = nullptr; // Pointer into the owning Context's State
+  bool                _modified = false;   // We have pending changes on the path components or
+                                           // query parameters?
 
 }; // End class Url
 
@@ -582,7 +582,7 @@ public:
   }
 
   static URL &_get(Cript::Context *context);
-  bool _update(Cript::Context *context);
+  bool        _update(Cript::Context *context);
 
 private:
   void _initialize(Cript::Context *context);
@@ -604,7 +604,7 @@ public:
   void operator=(const URL &) = delete;
 
   static URL &_get(Cript::Context *context);
-  bool _update(Cript::Context *context);
+  bool        _update(Cript::Context *context);
 
 private:
   void
@@ -633,7 +633,7 @@ public:
   void operator=(const URL &) = delete;
 
   static URL &_get(Cript::Context *context);
-  bool _update(Cript::Context *context);
+  bool        _update(Cript::Context *context);
 
 private:
   void

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -100,7 +100,7 @@ EOF
   start_time_file=$(mktemp -t clang-format-start-time.XXXXXXXXXX)
   touch ${start_time_file}
 
-  target_files=$(find $DIR -iname \*.[ch] -o -iname \*.cc -o -iname \*.h.in | grep -vE 'lib/(catch2|fastlz|swoc|yamlcpp)')
+  target_files=$(find $DIR -iname \*.[ch] -o -iname \*.cc -o -iname \*.h.in -o -iname \*.hpp | grep -vE 'lib/(catch2|fastlz|swoc|yamlcpp)')
   for file in ${target_files}; do
     # The ink_autoconf.h and ink_autoconf.h.in files are generated files,
     # so they do not need to be re-formatted by clang-format. Doing so


### PR DESCRIPTION
Cripts' header files have .hpp extensions. This extends clang-format.sh to format .hpp files.