### PR TITLE
Coverity 1518564: Out-of-bounds write in fq_pacing plugin

### DIFF
--- a/plugins/experimental/fq_pacing/fq_pacing.cc
+++ b/plugins/experimental/fq_pacing/fq_pacing.cc
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 static const char *PLUGIN_NAME = "fq_pacing";
 

--- a/plugins/experimental/fq_pacing/fq_pacing.cc
+++ b/plugins/experimental/fq_pacing/fq_pacing.cc
@@ -26,6 +26,7 @@
 #include <ts/remap_version.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <fcntl.h>
 
 static const char *PLUGIN_NAME = "fq_pacing";
 
@@ -56,21 +57,21 @@ safe_setsockopt(int s, int level, int optname, char *optval, int optlevel)
 static int
 fq_is_default_qdisc()
 {
-  TSFile  f         = nullptr;
-  ssize_t s         = 0;
+  int     fd        = -1;
+  ssize_t bytes     = 0;
   char    buffer[5] = {};
   int     rc        = 0;
 
-  f = TSfopen("/proc/sys/net/core/default_qdisc", "r");
-  if (!f) {
+  fd = open("/proc/sys/net/core/default_qdisc", O_RDONLY);
+  if (fd < 0) {
     return 0;
   }
 
-  s = TSfread(f, buffer, sizeof(buffer) - 1);
-  if (s > 0) {
-    buffer[s] = 0;
+  bytes = read(fd, buffer, sizeof(buffer) - 1);
+  if (bytes > 0) {
+    buffer[bytes] = 0;
   } else {
-    TSfclose(f);
+    close(fd);
     return 0;
   }
 
@@ -79,7 +80,7 @@ fq_is_default_qdisc()
   }
 
   rc = (strncmp(buffer, "fq", sizeof(buffer)) == 0);
-  TSfclose(f);
+  close(fd);
   return (rc);
 }
 


### PR DESCRIPTION
I believe this is a false-positive and `TSfread` shouldn't return a value larger than the buffer size.    However, we should just use `open, read, close` instead of our hacky buffered file reading in our APIs.  We are only reading 4 bytes anyways.