### PR TITLE
Fix some warnings from libswoc when building on FreeBSD 13.1.

### DIFF
--- a/lib/swoc/unit_tests/ex_bw_format.cc
+++ b/lib/swoc/unit_tests/ex_bw_format.cc
@@ -463,8 +463,6 @@ C_Format::capture(BufferWriter &, Spec const &spec, std::any const &value) {
 // C_Format parsing
 bool
 C_Format::operator()(std::string_view &literal, Spec &spec) {
-  TextView parsed;
-
   // clean up any old business from a previous specifier.
   if (_prec_p) {
     spec._type = Spec::CAPTURE_TYPE;

--- a/lib/swoc/unit_tests/test_TextView.cc
+++ b/lib/swoc/unit_tests/test_TextView.cc
@@ -22,10 +22,8 @@ TEST_CASE("TextView Constructor", "[libswoc][TextView]") {
   static const std::string base = "Evil Dave Rulez!";
   unsigned ux                   = base.size();
   TextView tv(base);
-  TextView a{"Evil Dave Rulez"};
   TextView b{base.data(), base.size()};
   TextView c{std::string_view(base)};
-  constexpr TextView d{"Grigor!"sv};
   TextView e{base.data(), 15};
   TextView f(base.data(), 15);
   TextView u{base.data(), ux};
@@ -188,7 +186,6 @@ TEST_CASE("TextView Affixes", "[libswoc][TextView]") {
   TextView tv3 = "abcdefg:gfedcba";
   left         = tv3;
   right        = left.split_suffix_at(";:,");
-  TextView pre{tv3}, post{pre.split_suffix(7)};
   REQUIRE(right.size() == 7);
   REQUIRE(left.size() == 7);
   REQUIRE(left == "abcdefg");

--- a/lib/swoc/unit_tests/test_bw_format.cc
+++ b/lib/swoc/unit_tests/test_bw_format.cc
@@ -38,7 +38,6 @@ TEST_CASE("bwprint basics", "[bwprint]") {
   swoc::LocalBufferWriter<256> bw;
   std::string_view fmt1{"Some text"sv};
   swoc::bwf::Format fmt2("left >{0:<9}< right >{0:>9}< center >{0:^9}<");
-  std::string_view text{"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"};
   static const swoc::bwf::Format bad_arg_fmt{"{{BAD_ARG_INDEX:{} of {}}}"};
 
   bw.print(fmt1);

--- a/lib/swoc/unit_tests/test_ip.cc
+++ b/lib/swoc/unit_tests/test_ip.cc
@@ -1251,7 +1251,6 @@ TEST_CASE("IPSpace Edge", "[libswoc][ipspace][edge]") {
   auto spot = cspace.find(a1);
   static_assert(std::is_same_v<Space::const_iterator, decltype(spot)>);
   auto &v1 = *spot;
-  auto &p1 = get<1>(v1);
 
   auto const iter = cspace.find(a1);
   if (auto &&[r, p] = *iter; !r.empty()) {

--- a/lib/swoc/unit_tests/test_range.cc
+++ b/lib/swoc/unit_tests/test_range.cc
@@ -13,7 +13,6 @@ using namespace swoc::literals;
 
 using range_t = swoc::DiscreteRange<unsigned>;
 TEST_CASE("Discrete Range", "[libswoc][range]") {
-  range_t none; // empty range.
   range_t single{56};
   range_t r1{56, 100};
   range_t r2{101, 200};


### PR DESCRIPTION
```
FreeBSD 13.1-RELEASE-p8 GENERIC amd64
FreeBSD clang version 13.0.0 (git@github.com:llvm/llvm-project.git llvmorg-13.0.0-0-gd7b669b3a303)
```