### PR TITLE
libswoc: Remove unused variables. Part 2.

### DIFF
--- a/lib/swoc/unit_tests/test_TextView.cc
+++ b/lib/swoc/unit_tests/test_TextView.cc
@@ -400,7 +400,6 @@ TEST_CASE("TextView Affixes", "[libswoc][TextView]") {
 
   // Checking that constexpr works for this constructor as long as npos isn't used.
   static constexpr TextView ctv2{"http://delain.nl/albums/Interlude.html", 38};
-  TextView ctv4{"http://delain.nl/albums/Interlude.html", 38};
   // This doesn't compile because it causes strlen to be called which isn't constexpr compatible.
   // static constexpr TextView ctv3 {"http://delain.nl/albums/Interlude.html", TextView::npos};
   // This works because it's not constexpr.

--- a/lib/swoc/unit_tests/test_ip.cc
+++ b/lib/swoc/unit_tests/test_ip.cc
@@ -1250,7 +1250,6 @@ TEST_CASE("IPSpace Edge", "[libswoc][ipspace][edge]") {
 
   auto spot = cspace.find(a1);
   static_assert(std::is_same_v<Space::const_iterator, decltype(spot)>);
-  auto &v1 = *spot;
 
   auto const iter = cspace.find(a1);
   if (auto &&[r, p] = *iter; !r.empty()) {


### PR DESCRIPTION
Missed this two from my previous PR.
Found while building on FreeBSD 13.