### PR TITLE
CMakePresets: test nuraft on openssl

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -316,7 +316,7 @@
       "inherits": ["branch"],
       "cacheVariables": {
         "ENABLE_AUTEST": "ON",
-        "nuraft_ROOT": "/opt/nuraft-boringssl",
+        "nuraft_ROOT": "/opt",
         "OPENSSL_ROOT_DIR": "/opt/openssl-quic/",
         "quiche_ROOT": "/opt/quiche",
         "ENABLE_QUICHE": "ON"


### PR DESCRIPTION
This changes the openssl branch test to test nuraft built against openssl.