### PR TITLE
Fix compiler warning when using GCC 13.2

### DIFF
--- a/src/proxy/http3/Http3App.cc
+++ b/src/proxy/http3/Http3App.cc
@@ -79,7 +79,7 @@ Http3App::~Http3App()
 void
 Http3App::start()
 {
-  QUICStreamId            stream_id;
+  QUICStreamId            stream_id{};
   QUICConnectionErrorUPtr error;
 
   error = this->create_uni_stream(stream_id, Http3StreamType::CONTROL);


### PR DESCRIPTION


```
warning: ‘stream_id’ is used uninitialized [-Wuninitialized] QUICConnectionErrorUPtr error = this->_qc->stream_manager()->create_uni_stream(new_stream_id); 
Http3App.cc: In member function ‘virtual void Http3App::start()’: ttp3App.cc:82:27: note: ‘stream_id’ was declared here
   QUICStreamId            stream_id;
                            ^~~~~~~~~
```