### PR TITLE
UDP-Net: Add support to use SO_TXTIME if available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,15 @@ if(TS_USE_HWLOC)
   )
 endif()
 
+check_symbol_exists(SO_TXTIME "sys/socket.h" SO_TXTIME_FOUND)
+set(CMAKE_EXTRA_INCLUDE_FILES "linux/net_tstamp.h")
+check_type_size("struct sock_txtime" STRUCT_SOCK_TXTIME_FOUND)
+unset(CMAKE_EXTRA_INCLUDE_FILES)
+
+if(SO_TXTIME_FOUND AND STRUCT_SOCK_TXTIME_FOUND)
+  set(HAVE_SO_TXTIME TRUE)
+endif()
+
 option(USE_IOURING "Use experimental io_uring (linux only)" 0)
 if(HAVE_IOURING AND USE_IOURING)
   message(STATUS "Using io_uring")

--- a/include/iocore/net/UDPPacket.h
+++ b/include/iocore/net/UDPPacket.h
@@ -40,6 +40,9 @@ struct UDPPacketInternal {
 
   int        reqGenerationNum = 0;
   ink_hrtime delivery_time    = 0; // when to deliver packet
+#ifdef HAVE_SO_TXTIME
+  struct timespec send_at;
+#endif
 
   Ptr<IOBufferBlock> chain;
   Continuation      *cont = nullptr; // callback on error
@@ -102,7 +105,8 @@ public:
      @param buf IOBufferBlock chain of data to use
      @param segment_size Segment size
   */
-  static UDPPacket *new_UDPPacket(struct sockaddr const *to, ink_hrtime when, Ptr<IOBufferBlock> &buf, uint16_t segment_size = 0);
+  static UDPPacket *new_UDPPacket(struct sockaddr const *to, ink_hrtime when, Ptr<IOBufferBlock> &buf, uint16_t segment_size = 0,
+                                  struct timespec *send_at_hint = nullptr);
 
   /**
      Create a new packet to be delivered to application.

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -69,6 +69,7 @@
 #cmakedefine01 HAVE_STRSIGNAL
 #cmakedefine01 HAVE_SYSINFO
 #cmakedefine01 HAVE_PRCTL
+#cmakedefine HAVE_SO_TXTIME 1
 
 #cmakedefine01 HAVE_HWLOC_OBJ_PU
 

--- a/src/iocore/net/P_QUICPacketHandler.h
+++ b/src/iocore/net/P_QUICPacketHandler.h
@@ -40,7 +40,8 @@ public:
   QUICPacketHandler();
   virtual ~QUICPacketHandler();
 
-  void send_packet(UDPConnection *udp_con, IpEndpoint &addr, Ptr<IOBufferBlock> udp_payload, uint16_t segment_size = 0);
+  void send_packet(UDPConnection *udp_con, IpEndpoint &addr, Ptr<IOBufferBlock> udp_payload, uint16_t segment_size = 0,
+                   struct timespec *send_at_hint = nullptr);
   void close_connection(QUICNetVConnection *conn);
 
 protected:

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -670,6 +670,7 @@ QUICNetVConnection::_handle_write_ready()
 
   Ptr<IOBufferBlock> udp_payload;
   quiche_send_info   send_info;
+  struct timespec    send_at_hint;
   ssize_t            res;
   ssize_t            written = 0;
 
@@ -683,6 +684,13 @@ QUICNetVConnection::_handle_write_ready()
   while (written + max_udp_payload_size <= quantum) {
     res = quiche_conn_send(this->_quiche_con, reinterpret_cast<uint8_t *>(udp_payload->end()) + written, max_udp_payload_size,
                            &send_info);
+
+#ifdef HAVE_SO_TXTIME
+    if (written == 0) {
+      memcpy(&send_at_hint, &send_info.at, sizeof(struct timespec));
+    }
+#endif
+
     if (res > 0) {
       written += res;
     }
@@ -696,7 +704,7 @@ QUICNetVConnection::_handle_write_ready()
     if (static_cast<size_t>(written) > max_udp_payload_size) {
       segment_size = max_udp_payload_size;
     }
-    this->_packet_handler->send_packet(this->_udp_con, this->con.addr, udp_payload, segment_size);
+    this->_packet_handler->send_packet(this->_udp_con, this->con.addr, udp_payload, segment_size, &send_at_hint);
     net_activity(this, this_ethread());
   }
 }

--- a/src/iocore/net/QUICPacketHandler.cc
+++ b/src/iocore/net/QUICPacketHandler.cc
@@ -80,9 +80,10 @@ QUICPacketHandler::close_connection(QUICNetVConnection *conn)
 }
 
 void
-QUICPacketHandler::send_packet(UDPConnection *udp_con, IpEndpoint &addr, Ptr<IOBufferBlock> udp_payload, uint16_t segment_size)
+QUICPacketHandler::send_packet(UDPConnection *udp_con, IpEndpoint &addr, Ptr<IOBufferBlock> udp_payload, uint16_t segment_size,
+                               struct timespec *send_at_hint)
 {
-  UDPPacket *udp_packet = UDPPacket::new_UDPPacket(addr, 0, udp_payload, segment_size);
+  UDPPacket *udp_packet = UDPPacket::new_UDPPacket(addr, 0, udp_payload, segment_size, send_at_hint);
 
   if (dbg_ctl_v.on()) {
     ip_port_text_buffer ipb;


### PR DESCRIPTION
This change uses `SO_TXTIME` to set a hint to schedule transmission of specific packets at specific times, we use the hint given by the `quiche` library when `quiche_conn_send` is invoked.

No confuration needed, cmake will detect if available and use it.