### PR TITLE
CMakePresets: -DENABLE_PROBES for ci-fedora

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -160,6 +160,7 @@
       "description": "CI Pipeline config for Fedora Linux",
       "inherits": ["ci"],
       "cacheVariables": {
+        "ENABLE_PROBES": "ON",
         "OPENSSL_ROOT_DIR": "/opt/openssl-quic",
         "opentelemetry_ROOT": "/opt",
         "CURL_ROOT": "/opt",


### PR DESCRIPTION
Run fedora builds (including the autests) with ATS SystemTap probes enabled.