### PR TITLE
Coverity 1534725: Uninitialized scalar variable

### DIFF
--- a/plugins/experimental/txn_box/plugin/src/ip_space.cc
+++ b/plugins/experimental/txn_box/plugin/src/ip_space.cc
@@ -599,6 +599,7 @@ Do_ip_space_define::define_column(Config &cfg, YAML::Node node)
   }
   col._idx        = _cols.size();
   col._row_offset = _row_size;
+  col._row_size   = 0;
   switch (col._type) {
   default:
     break; // shouldn't happen.


### PR DESCRIPTION
Coverity complaining `col._row_size` not initialized but that's only when `col._type` hits default case (which comment implies shouldn't happen). Can also add `col._row_size = 0` to just default case