### PR TITLE
Handle EOS events during server open

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -1088,6 +1088,7 @@ HttpSM::state_raw_http_server_open(int event, void *data)
     break;
   }
   case VC_EVENT_ERROR:
+  case VC_EVENT_EOS:
   case NET_EVENT_OPEN_FAILED:
     t_state.current.state = HttpTransact::OPEN_RAW_ERROR;
     // use this value just to get around other values
@@ -1806,6 +1807,7 @@ HttpSM::state_http_server_open(int event, void *data)
     t_state.set_connect_fail(ETIMEDOUT);
   /* fallthrough */
   case VC_EVENT_ERROR:
+  case VC_EVENT_EOS:
   case NET_EVENT_OPEN_FAILED: {
     t_state.current.state = HttpTransact::CONNECTION_ERROR;
     t_state.outbound_conn_track_state.clear();


### PR DESCRIPTION
We saw a bunch of aborts happening due to EOS not being handled during `HttpSM::state_http_server_open`, and after some discussion we believe this should be handled the same as a `VC_EVENT_ERROR` case. This is now deployed globally for us. 