### PR TITLE
Remove unused include from remap_stats

### DIFF
--- a/plugins/remap_stats/remap_stats.cc
+++ b/plugins/remap_stats/remap_stats.cc
@@ -19,7 +19,6 @@
   limitations under the License.
  */
 
-#include "tscore/ink_config.h"
 #include "tscore/ink_defs.h"
 #include "tsutil/ts_bw_format.h"
 


### PR DESCRIPTION
I noticed this was unused while reviewing #11237.