### PR TITLE
Allow query parameters to erase() 'all but'

### DIFF
--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -426,20 +426,19 @@ public:
     Cript::string      operator+=(Cript::string_view add);
     Parameter          operator[](Cript::string_view param);
     void               erase(Cript::string_view param);
-
-    void
-    erase(std::initializer_list<Cript::string_view> list)
-    {
-      for (auto &it : list) {
-        erase(it);
-      }
-    }
+    void               erase(std::initializer_list<Cript::string_view> list, bool keep = false);
 
     void
     erase()
     {
       operator=("");
       _size = 0;
+    }
+
+    void
+    keep(std::initializer_list<Cript::string_view> list)
+    {
+      erase(list, true);
     }
 
     void

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -332,6 +332,37 @@ Url::Query::erase(Cript::string_view param)
 }
 
 void
+Url::Query::erase(std::initializer_list<Cript::string_view> list, bool keep)
+{
+  if (keep) {
+    // Make sure the hash and vector are populated
+    _parser();
+
+    for (auto viter = _ordered.begin(); viter != _ordered.end();) {
+      if (list.end() == std::find(list.begin(), list.end(), *viter)) {
+        auto iter = _hashed.find(*viter);
+
+        TSReleaseAssert(iter != _hashed.end());
+        _size -= iter->second.size(); // Size of the erased value
+        _size -= viter->size();       // Length of the erased key
+        _hashed.erase(iter);
+        viter     = _ordered.erase(viter);
+        _modified = true;
+      } else {
+        ++viter;
+      }
+    }
+    if (_ordered.size() == 0) {
+      reset();
+    }
+  } else {
+    for (auto &it : list) {
+      erase(it);
+    }
+  }
+}
+
+void
 Url::Query::reset()
 {
   Component::reset();

--- a/src/cripts/tests/query_test.cc
+++ b/src/cripts/tests/query_test.cc
@@ -1,0 +1,52 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#include <cripts/Preamble.hpp>
+
+// We do this so we can have one Cript for multiple remaps
+do_create_instance()
+{
+  if (instance.size() > 0) {
+    instance.data[0] = integer(AsString(instance.data[0]));
+  } else {
+    instance.data[0] = 0;
+  }
+}
+
+do_remap()
+{
+  borrow url = Client::URL::get();
+
+  switch (AsInteger(instance.data[0])) {
+  case 0:
+    url.query.erase({"foo", "bar"}, true);
+    break;
+  case 1:
+    url.query.erase({"foo", "bar"});
+    break;
+  case 2:
+    url.query.keep({"foo", "bar"});
+    break;
+  default:
+    break;
+  }
+
+  url.query.flush();
+  CDebug("Query: {}", url.query);
+}
+
+#include <cripts/Epilogue.hpp>


### PR DESCRIPTION
The optional boolean flag argument reverses the list semantics (erase all but the listed query parameters). E.g.

```
do_remap()
{
  borrow url = Client::URL::get();

  url.query.erase({"foo", "bar"}, true);
}
```

Which will remove all query parameters, except **foo** and  **bar**. Alternatively, as a convenience, keep() was also added:

```
do_remap()
{
  borrow url = Client::URL::get();

  url.query.keep({"foo", "bar"});
}
```


