### PR TITLE
Remove the `-Wno-stringop-overflow` warning suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,7 +600,7 @@ add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter)
 add_compile_options(
   "$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override;-Wno-vla-extension;-fno-strict-aliasing>"
 )
-add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wno-format-truncation;-Wno-stringop-overflow>")
+add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wno-format-truncation>")
 
 if(NOT EXTERNAL_YAML_CPP)
   include(subproject_version)

--- a/lib/swoc/unit_tests/CMakeLists.txt
+++ b/lib/swoc/unit_tests/CMakeLists.txt
@@ -39,7 +39,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
             -Werror
             -Wno-unused-parameter
             -Wno-format-truncation
-            -Wno-stringop-overflow
             -Wno-invalid-offsetof
   )
   # stop the compiler from complaining about unused variable in structured binding

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -1169,8 +1169,8 @@ make_url_for_get(TS_OCSP_REQUEST *req, const char *base_url)
 
   // Append '/' if base_url does not end with it
   if (url->buf()[url->size() - 1] != '/') {
-    strncat(url->end(), "/", 1);
-    url->fill(1);
+    written = ink_strlcat(url->end(), "/", url->write_avail());
+    url->fill(written);
   }
 
   written = ink_strlcat(url->end(), ocsp_escaped, url->write_avail());

--- a/src/iocore/net/UnixUDPNet.cc
+++ b/src/iocore/net/UnixUDPNet.cc
@@ -97,7 +97,7 @@ UDPPacket::new_UDPPacket(struct sockaddr const *to, ink_hrtime when, Ptr<IOBuffe
   p->p.segment_size = segment_size;
 #ifdef HAVE_SO_TXTIME
   if (send_at_hint) {
-    memcpy(&p->p.send_at, &send_at_hint, sizeof(struct timespec));
+    memcpy(&p->p.send_at, send_at_hint, sizeof(struct timespec));
   }
 #endif
   return p;


### PR DESCRIPTION
The  `-Wstringop-overflow` warning was caused by single usage of `strncat` function.
The problem was that GCC complained for possibly incorrect usage of `strncat` due to the last argument being equal to the source string length. The last argument of strncat is supposed to be the remaining free space in the destination buffer.
Replaced the usage of `strncat` with the ATS function `ink_strlcat`.
More info about this can be found in [this ATS issue](https://github.com/apache/trafficserver/issues/11343)