### PR TITLE
Remove the need of `-Wno-stringop-overflow` warning suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,7 +600,7 @@ add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter)
 add_compile_options(
   "$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override;-Wno-vla-extension;-fno-strict-aliasing>"
 )
-add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wno-format-truncation;-Wno-stringop-overflow>")
+add_compile_options("$<$<CXX_COMPILER_ID:GNU>:-Wno-format-truncation>")
 
 if(NOT EXTERNAL_YAML_CPP)
   include(subproject_version)

--- a/lib/swoc/unit_tests/CMakeLists.txt
+++ b/lib/swoc/unit_tests/CMakeLists.txt
@@ -39,7 +39,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
             -Werror
             -Wno-unused-parameter
             -Wno-format-truncation
-            -Wno-stringop-overflow
             -Wno-invalid-offsetof
   )
   # stop the compiler from complaining about unused variable in structured binding

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -758,7 +758,7 @@ str_concat(char *dst, size_t dst_len, const char *src, size_t src_len)
   size_t to_copy = std::min(dst_len, src_len);
 
   if (to_copy > 0) {
-    strncat(dst, src, to_copy);
+    TSstrlcat(dst, src, to_copy);
   }
 
   return to_copy;

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -1169,8 +1169,8 @@ make_url_for_get(TS_OCSP_REQUEST *req, const char *base_url)
 
   // Append '/' if base_url does not end with it
   if (url->buf()[url->size() - 1] != '/') {
-    strncat(url->end(), "/", 1);
-    url->fill(1);
+    written = ink_strlcat(url->end(), "/", url->write_avail());
+    url->fill(written);
   }
 
   written = ink_strlcat(url->end(), ocsp_escaped, url->write_avail());


### PR DESCRIPTION
The problem was that GCC complained for possibly incorrect usage of `strncat` due to the last argument being equal to the source string length. The last argument of `strncat` is supposed to be the remaining free space in the destination buffer.
Replaced the usage of `strncat` with the ATS function `ink_strlcat`.
More info about this can be found in [this issue](https://github.com/apache/trafficserver/issues/11343)