### PR TITLE
9.2.x: apply yapf to log-field-json.test.py

### DIFF
--- a/tests/gold_tests/logging/log-field-json.test.py
+++ b/tests/gold_tests/logging/log-field-json.test.py
@@ -107,7 +107,7 @@ tr.Processes.Default.Command = 'curl --verbose --header "Host: test-3" --header 
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" --header "Foo: ab\x80d/ef" http://localhost:{0}/test-4' .format(
+tr.Processes.Default.Command = 'curl --verbose --header "Host: test-2" --header "Foo: ab\x80d/ef" http://localhost:{0}/test-4'.format(
     ts.Variables.port)
 tr.Processes.Default.ReturnCode = 0
 


### PR DESCRIPTION
Somehow the 9.2.x branch has a unformatted log-field-json.test.py file. This applies the yapf target to the source files in the branch.