### PR TITLE
ASAN new and free mismatch in stale response plugin

### DIFF
--- a/plugins/experimental/stale_response/stale_response.cc
+++ b/plugins/experimental/stale_response/stale_response.cc
@@ -195,7 +195,7 @@ free_state_info(StateInfo *state)
   // this is a temp pointer do not delete
   // state->cur_save_body
 
-  TSfree(state);
+  delete state;
 }
 
 /*-----------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
```
==408169==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free) on 0x50d000016830
    #0 0x7f45340f5558 in free.part.0 (/lib64/libasan.so.8+0xf5558) (BuildId: 6ac482fdae6aad7cf603c8e6ab3042fb9d4725af)
    #1 0x91c70f in ats_free(void*) /home/bcall/dev/apache/trafficserver/src/tscore/ink_memory.cc:127
    #2 0x7f4533efe30f in TSfree(void*) /home/bcall/dev/apache/trafficserver/src/api/InkAPI.cc:612
    #3 0x7f4514d537b7 in free_state_info /home/bcall/dev/apache/trafficserver/plugins/experimental/stale_response/stale_response.cc:198
    #4 0x7f4514d5ac36 in transaction_handler /home/bcall/dev/apache/trafficserver/plugins/experimental/stale_response/stale_response.cc:815
    #5 0x11e7d31 in INKContInternal::handle_event(int, void*) /home/bcall/dev/apache/trafficserver/src/api/InkContInternal.cc:153
    #6 0x8aa7c6 in Continuation::handleEvent(int, void*) /home/bcall/dev/apache/trafficserver/include/iocore/eventsystem/Continuation.h:228


0x50d000016830 is located 0 bytes inside of 144-byte region [0x50d000016830,0x50d0000168c0)
allocated by thread T11 here:
    #0 0x7f45340f73a8 in operator new(unsigned long) (/lib64/libasan.so.8+0xf73a8) (BuildId: 6ac482fdae6aad7cf603c8e6ab3042fb9d4725af)
    #1 0x7f4514d53365 in create_state_info /home/bcall/dev/apache/trafficserver/plugins/experimental/stale_response/stale_response.cc:141
    #2 0x7f4514d5c032 in read_request_header_handler /home/bcall/dev/apache/trafficserver/plugins/experimental/stale_response/stale_response.cc:979
    #3 0x7f4514d5c6f3 in global_request_header_hook /home/bcall/dev/apache/trafficserver/plugins/experimental/stale_response/stale_response.cc:1023
    #4 0x11e7d31 in INKContInternal::handle_event(int, void*) /home/bcall/dev/apache/trafficserver/src/api/InkContInternal.cc:153
    #5 0x8aa7c6 in Continuation::handleEvent(int, void*) /home/bcall/dev/apache/trafficserver/include/iocore/eventsystem/Continuation.h:228
    #6 0x11eaa29 in APIHook::invoke(int, void*) const /home/bcall/dev/apache/trafficserver/src/api/APIHook.cc:60
```

