### PR TITLE
Add SO_INCOMING_CPU support to net.sock_option_flag_in

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -5055,9 +5055,11 @@ Sockets
         PACKET_MARK (16)
         PACKET_TOS (32)
         TCP_NOTSENT_LOWAT (64)
+        INCOMING_CPU (128)
 
    Note: If MPTCP is enabled, TCP_NODELAY is only supported on Linux kernels 5.17+. TCP_FASTOPEN
    and TCP_NOTSENT_LOWAT socket options are currently not supported.
+
 .. note::
 
    This is a bitmask and you need to decide what bits to set.  Therefore,
@@ -5068,6 +5070,20 @@ Sockets
 
    To allow TCP Fast Open for client sockets on Linux, bit 2 of
    the ``net.ipv4.tcp_fastopen`` sysctl must be set.
+
+.. note::
+
+   As for SO_INCOMING_CPU, using it with SO_REUSEPORT and exec_thread affinity 4 is recommended.
+
+   .. code-block:: yaml
+
+      ts:
+        accept_threads: 0
+        exec_thread:
+          listen: 1
+          affinity: 4
+        net:
+         sock_option_flag_in: 0x80
 
 .. ts:cv:: CONFIG proxy.config.net.sock_send_buffer_size_out INT 0
    :overridable:

--- a/include/iocore/eventsystem/EThread.h
+++ b/include/iocore/eventsystem/EThread.h
@@ -34,6 +34,10 @@
 #include "iocore/eventsystem/ProtectedQueue.h"
 #include "tsutil/Histogram.h"
 
+#if TS_USE_HWLOC
+#include <hwloc.h>
+#endif
+
 // TODO: This would be much nicer to have "run-time" configurable (or something)
 #define PER_THREAD_DATA (1024 * 1024)
 
@@ -333,9 +337,15 @@ public:
 
   static constexpr int NO_ETHREAD_ID = -1;
   int                  id            = NO_ETHREAD_ID;
-  unsigned int         event_types   = 0;
-  bool                 is_event_type(EventType et);
-  void                 set_event_type(EventType et);
+
+#if TS_USE_HWLOC
+  hwloc_obj_t hwloc_obj = nullptr;
+#endif
+
+  unsigned int event_types = 0;
+
+  bool is_event_type(EventType et);
+  void set_event_type(EventType et);
 
   // Private Interface
 

--- a/include/iocore/eventsystem/EThread.h
+++ b/include/iocore/eventsystem/EThread.h
@@ -35,7 +35,8 @@
 #include "tsutil/Histogram.h"
 
 #if TS_USE_HWLOC
-#include <hwloc.h>
+struct hwloc_obj;
+using hwloc_obj_t = hwloc_obj *;
 #endif
 
 // TODO: This would be much nicer to have "run-time" configurable (or something)

--- a/include/iocore/net/NetVCOptions.h
+++ b/include/iocore/net/NetVCOptions.h
@@ -145,6 +145,8 @@ struct NetVCOptions {
   static uint32_t const SOCK_OPT_PACKET_TOS = 32;
   /// Value for TCP_NOTSENT_LOWAT @c sockopt_flags
   static uint32_t const SOCK_OPT_TCP_NOTSENT_LOWAT = 64;
+  /// Value for SO_INCOMING_CPU @c sockopt_flags
+  static uint32_t const SOCK_OPT_INCOMING_CPU = 128;
 
   uint32_t packet_mark;
   uint32_t packet_tos;

--- a/src/iocore/eventsystem/UnixEventProcessor.cc
+++ b/src/iocore/eventsystem/UnixEventProcessor.cc
@@ -266,6 +266,8 @@ ThreadAffinityInitializer::set_affinity(int, Event *)
   if (obj_count > 0) {
     // Get our `obj` instance with index based on the thread number we are on.
     hwloc_obj_t obj = hwloc_get_obj_by_type(ink_get_topology(), obj_type, t->id % obj_count);
+    t->hwloc_obj    = obj;
+
 #if HWLOC_API_VERSION >= 0x00010100
     int   cpu_mask_len = hwloc_bitmap_snprintf(nullptr, 0, obj->cpuset) + 1;
     char *cpu_mask     = static_cast<char *>(alloca(cpu_mask_len));

--- a/src/iocore/net/Connection.cc
+++ b/src/iocore/net/Connection.cc
@@ -34,6 +34,10 @@
 #include "tscore/ink_platform.h"
 #include "tscore/ink_sock.h"
 
+#if TS_USE_HWLOC
+#include <hwloc.h>
+#endif
+
 #ifdef SO_ACCEPTFILTER
 #include <sys/param.h>
 #include <sys/linker.h>


### PR DESCRIPTION
Address #5165.

Add a option (128) for `SO_INCOMING_CPU` to the `proxy.config.net.sock_option_flag_in`.

# Background

There was a bug with SO_REUSEPORT since v4.6. But it's fixed by v6.2 and some distros backported it.
Now we can use SO_INCOMING_CPU, SO_REUSEPORT and CPU Affinity 4 for perfect locality.

https://github.com/torvalds/linux/commit/b261eda84ec136240a9ca753389853a3a1bccca2

# Ref.

        SO_INCOMING_CPU (gettable since Linux 3.19, settable since Linux 4.4)

              Sets or gets the CPU affinity of a socket.  Expects an
              integer flag.

                  int cpu = 1;
                  setsockopt(fd, SOL_SOCKET, SO_INCOMING_CPU, &cpu,
                             sizeof(cpu));

              Because all of the packets for a single stream (i.e., all
              packets for the same 4-tuple) arrive on the single RX
              queue that is associated with a particular CPU, the
              typical use case is to employ one listening process per RX
              queue, with the incoming flow being handled by a listener
              on the same CPU that is handling the RX queue.  This
              provides optimal NUMA behavior and keeps CPU caches hot.
              
https://www.man7.org/linux/man-pages/man7/socket.7.html