### PR TITLE
Handle VC_EVENT_EOS in more places

### DIFF
--- a/src/iocore/net/QUICNextProtocolAccept.cc
+++ b/src/iocore/net/QUICNextProtocolAccept.cc
@@ -41,6 +41,7 @@ quic_netvc_cast(int event, void *edata)
     return dynamic_cast<QUICNetVConnection *>(ptr.vc);
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_READ_COMPLETE:
+  case VC_EVENT_EOS:
   case VC_EVENT_ERROR:
     ptr.vio = static_cast<VIO *>(edata);
     return dynamic_cast<QUICNetVConnection *>(ptr.vio->vc_server);

--- a/src/iocore/net/SSLNextProtocolAccept.cc
+++ b/src/iocore/net/SSLNextProtocolAccept.cc
@@ -53,6 +53,7 @@ ssl_netvc_cast(int event, void *edata)
     return dynamic_cast<SSLNetVConnection *>(ptr.vc);
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_READ_COMPLETE:
+  case VC_EVENT_EOS:
   case VC_EVENT_ERROR:
     ptr.vio = static_cast<VIO *>(edata);
     return dynamic_cast<SSLNetVConnection *>(ptr.vio->vc_server);

--- a/src/proxy/Transform.cc
+++ b/src/proxy/Transform.cc
@@ -641,7 +641,6 @@ NullTransform::handle_event(int event, void *edata)
     case VC_EVENT_ERROR:
       m_write_vio.cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
       break;
-    case VC_EVENT_EOS:
     case VC_EVENT_WRITE_COMPLETE:
       ink_assert(m_output_vio == (VIO *)edata);
 
@@ -803,7 +802,6 @@ RangeTransform::handle_event(int event, void *edata)
         m_write_vio.cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
       }
       break;
-    case VC_EVENT_EOS:
     case VC_EVENT_WRITE_COMPLETE:
       ink_assert(m_output_vio == (VIO *)edata);
       m_output_vc->do_io_shutdown(IO_SHUTDOWN_WRITE);

--- a/src/proxy/Transform.cc
+++ b/src/proxy/Transform.cc
@@ -641,6 +641,7 @@ NullTransform::handle_event(int event, void *edata)
     case VC_EVENT_ERROR:
       m_write_vio.cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
       break;
+    case VC_EVENT_EOS:
     case VC_EVENT_WRITE_COMPLETE:
       ink_assert(m_output_vio == (VIO *)edata);
 
@@ -802,6 +803,7 @@ RangeTransform::handle_event(int event, void *edata)
         m_write_vio.cont->handleEvent(VC_EVENT_ERROR, &m_write_vio);
       }
       break;
+    case VC_EVENT_EOS:
     case VC_EVENT_WRITE_COMPLETE:
       ink_assert(m_output_vio == (VIO *)edata);
       m_output_vc->do_io_shutdown(IO_SHUTDOWN_WRITE);

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -1231,6 +1231,7 @@ HttpSM::state_common_wait_for_transform_read(HttpTransformInfo *t_info, HttpSMHa
     }
   // FALLTHROUGH
   case VC_EVENT_ERROR:
+  case VC_EVENT_EOS:
   case VC_EVENT_INACTIVITY_TIMEOUT:
     // Transform VC sends NULL on error conditions
     if (!c) {


### PR DESCRIPTION
This adds the handling of VC_EVENT_EOS to a few handlers that did handle VC_EVENT_ERROR but not EOS. This is a follow up from a review comment in #11346. See:

https://github.com/apache/trafficserver/pull/11346#issuecomment-2112949224