### PR TITLE
Remove unused length parameter in the `plugin/multiplexer/dispatch.cc`

### DIFF
--- a/plugins/multiplexer/dispatch.cc
+++ b/plugins/multiplexer/dispatch.cc
@@ -130,7 +130,7 @@ read(const TSIOBufferReader &r, std::string &o, int64_t l = 0)
 }
 
 uint64_t
-read(const TSIOBuffer &b, std::string &o, const int64_t l = 0)
+read(const TSIOBuffer &b, std::string &o)
 {
   TSIOBufferReader reader = TSIOBufferReaderAlloc(b);
   const uint64_t   length = read(reader, o);


### PR DESCRIPTION
This change removes unused `l` parameter passed to `read` function used only internally in `plugin/multiplexer/dispatch.cc`.
The change has been discussed [here](https://github.com/apache/trafficserver/issues/11374).


fixes https://github.com/apache/trafficserver/issues/11374