### PR TITLE
Fix unused parameters in `tsutil`

### DIFF
--- a/include/tsutil/ts_unit_parser.h
+++ b/include/tsutil/ts_unit_parser.h
@@ -94,7 +94,7 @@ inline UnitParser::UnitParser(UnitParser::Units &&units, bool unit_required_p) n
 }
 
 inline UnitParser::self_type &
-UnitParser::unit_required(bool flag)
+UnitParser::unit_required([[maybe_unused]] bool flag)
 {
   _unit_required_p = false;
   return *this;

--- a/src/tsutil/DbgCtl.cc
+++ b/src/tsutil/DbgCtl.cc
@@ -338,7 +338,7 @@ struct DiagTimestamp {
 };
 
 swoc::BufferWriter &
-bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, DiagTimestamp const &ts)
+bwformat(swoc::BufferWriter &w, [[maybe_unused]] swoc::bwf::Spec const &spec, DiagTimestamp const &ts)
 {
   auto                        epoch = std::chrono::system_clock::to_time_t(ts.ts);
   swoc::LocalBufferWriter<48> lw;

--- a/src/tsutil/YamlCfg.cc
+++ b/src/tsutil/YamlCfg.cc
@@ -84,7 +84,7 @@ namespace Yaml
 namespace swoc
 {
 BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, YAML::Mark const &mark)
+bwformat(BufferWriter &w, [[maybe_unused]] bwf::Spec const &spec, YAML::Mark const &mark)
 {
   return w.print("Line {}", mark.line);
 }

--- a/src/tsutil/unit_tests/test_PostScript.cc
+++ b/src/tsutil/unit_tests/test_PostScript.cc
@@ -47,6 +47,8 @@ void
 f2(double a)
 {
   ++f2Called;
+
+  REQUIRE(a == 4.0);
 }
 
 void
@@ -65,7 +67,7 @@ TEST_CASE("PostScript", "[PSC]")
   {
     int           *p = &dummy;
     ts::PostScript g1([&]() -> void { f1(1, 2.0, p, dummy); });
-    ts::PostScript g2([=]() -> void { f2(4); });
+    ts::PostScript g2([=]() -> void { f2(4.0); });
     ts::PostScript g3([=]() -> void { f3(5, 6.0); });
 
     g2.release();

--- a/src/tsutil/unit_tests/test_ts_meta.cc
+++ b/src/tsutil/unit_tests/test_ts_meta.cc
@@ -80,7 +80,7 @@ namespace
 {
 template <typename T>
 auto
-detect(T &&t, ts::meta::CaseTag<0>) -> std::string_view
+detect([[maybe_unused]] T &&t, ts::meta::CaseTag<0>) -> std::string_view
 {
   return "none";
 }


### PR DESCRIPTION
I got the liberty of slightly modifying the code in `tsutil/unit_tests/test_PostScript.cc`, instead of using `[[maybe_unused]]`, just to be consistent with the other test functions.

These changes are related to the discussion [here](https://github.com/apache/trafficserver/issues/11377).

fixes https://github.com/apache/trafficserver/issues/11377