### PR TITLE
Fixes Bundles errors, and better checks

### DIFF
--- a/include/cripts/Bundle.hpp
+++ b/include/cripts/Bundle.hpp
@@ -72,6 +72,8 @@ namespace Bundle
     void operator=(const self_type &) = delete;
     virtual ~Base()                   = default;
 
+    virtual const Cript::string &name() const = 0;
+
     void
     needCallback(Cript::Callbacks cb)
     {
@@ -141,16 +143,7 @@ namespace Bundle
 
   protected:
     unsigned _callbacks = 0;
-
   }; // Class Base
-
-  // These are used in the preamble, to see if a function is implemented in a bundle.
-  template <typename T>
-  bool
-  checkDoRemap()
-  {
-    return (std::is_same_v<decltype(&T::doRemap), void (T::*)()>);
-  }
 
 } // namespace Bundle
 

--- a/include/cripts/Bundles/Common.hpp
+++ b/include/cripts/Bundles/Common.hpp
@@ -42,9 +42,15 @@ public:
   {
     auto *entry = new self_type();
 
-    inst.bundles.push_back(entry);
+    inst.addBundle(entry);
 
     return *entry;
+  }
+
+  const Cript::string &
+  name() const override
+  {
+    return _name;
   }
 
   self_type &
@@ -70,9 +76,10 @@ public:
   void doRemap(Cript::Context *context) override;
 
 private:
-  Cript::string _cc       = "";
-  int           _dscp     = 0;
-  bool          _force_cc = false;
+  static const Cript::string _name;
+  Cript::string              _cc       = "";
+  int                        _dscp     = 0;
+  bool                       _force_cc = false;
 };
 
 } // namespace Bundle

--- a/include/cripts/Bundles/LogsMetrics.hpp
+++ b/include/cripts/Bundles/LogsMetrics.hpp
@@ -34,8 +34,6 @@ class LogsMetrics : public Cript::Bundle::Base
   using self_type  = LogsMetrics;
 
 public:
-  using super_type::Base;
-
   LogsMetrics(Cript::Instance *inst) : _inst(inst) {}
 
   static self_type &
@@ -43,9 +41,15 @@ public:
   {
     auto *entry = new self_type(&inst);
 
-    inst.bundles.push_back(entry);
+    inst.addBundle(entry);
 
     return *entry;
+  }
+
+  const Cript::string &
+  name() const override
+  {
+    return _name;
   }
 
   self_type &propstats(const Cript::string_view &label); // In LogsMetrics.cc
@@ -76,10 +80,11 @@ public:
   void doRemap(Cript::Context *context) override;
 
 private:
-  Cript::Instance *_inst;               // This Bundle needs the instance for access to the instance metrics
-  Cript::string    _label      = "";    // Propstats label
-  int              _log_sample = 0;     // Log sampling
-  bool             _tcpinfo    = false; // Turn on TCP info logging
+  static const Cript::string _name;
+  Cript::Instance           *_inst;               // This Bundle needs the instance for access to the instance metrics
+  Cript::string              _label      = "";    // Propstats label
+  int                        _log_sample = 0;     // Log sampling
+  bool                       _tcpinfo    = false; // Turn on TCP info logging
 };
 
 } // namespace Bundle

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -408,7 +408,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 
     for (auto &bundle : inst->bundles) {
       // Collect all the callbacks needed from all bundles, and validate them
-      if (bundle->validate(errors)) {
+      if (!bundle->validate(errors)) {
         inst->needCallback(bundle->callbacks());
       }
     }

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -405,9 +405,7 @@ public:
   void
   erase(const Cript::string_view header)
   {
-    auto p = operator[](header);
-
-    p.clear();
+    operator[](header) = "";
   }
 
   Iterator           begin();

--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -58,6 +58,18 @@ public:
   bool deletePlugin(const Cript::string &tag);
   void initialize(int argc, char *argv[], const char *filename);
 
+  void
+  addBundle(Cript::Bundle::Base *bundle)
+  {
+    for (auto &it : bundles) {
+      if (it->name() == bundle->name()) {
+        TSReleaseAssert(!"Duplicate bundle");
+      }
+    }
+
+    bundles.push_back(bundle);
+  }
+
   // This allows Bundles to require hooks as well.
   void
   needCallback(Cript::Callbacks cb)

--- a/src/cripts/Bundles/Common.cc
+++ b/src/cripts/Bundles/Common.cc
@@ -22,8 +22,8 @@
 
 namespace Bundle
 {
+const Cript::string Common::_name = "Bundle::Common";
 
-// Bundle::Common
 bool
 Common::validate(std::vector<Cript::Bundle::Error> &errors) const
 {
@@ -31,7 +31,7 @@ Common::validate(std::vector<Cript::Bundle::Error> &errors) const
 
   // The .dscp() can only be 0 - 63
   if (_dscp < 0 || _dscp > 63) {
-    errors.emplace_back("dscp must be between 0 and 63", "Common", "dscp");
+    errors.emplace_back("dscp must be between 0 and 63", name(), "dscp");
     failed = true;
   }
 

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -22,8 +22,8 @@
 
 namespace Bundle
 {
+const Cript::string LogsMetrics::_name = "Bundle::LogsMetrics";
 
-// Bundle::LogsMetrics
 namespace
 {
   enum {

--- a/src/cripts/CMakeLists.txt
+++ b/src/cripts/CMakeLists.txt
@@ -45,8 +45,10 @@ set(CRIPTS_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/include/cripts/Urls.hpp
     ${PROJECT_SOURCE_DIR}/include/cripts/UUID.hpp
     ${PROJECT_SOURCE_DIR}/include/cripts/Configs.hpp
-    ${PROJECT_SOURCE_DIR}/include/cripts/Bundles/Common.hpp
-    ${PROJECT_SOURCE_DIR}/include/cripts/Bundles/LogsMetrics.hpp
+)
+
+set(CRIPTS_BUNDLE_HEADERS ${PROJECT_SOURCE_DIR}/include/cripts/Bundles/Common.hpp
+                          ${PROJECT_SOURCE_DIR}/include/cripts/Bundles/LogsMetrics.hpp
 )
 
 add_library(cripts SHARED ${CPP_FILES})
@@ -63,6 +65,9 @@ set_target_properties(
 )
 
 install(TARGETS cripts PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cripts)
+
+# The PUBLIC_HEADER target can't handle include files in a subdirectory, so do those manually.
+install(FILES ${CRIPTS_BUNDLE_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cripts/Bundles)
 
 if(APPLE)
   target_link_options(cripts PRIVATE -undefined dynamic_lookup)


### PR DESCRIPTION
The critical fix here is the check for errors, somehow in the translation from internal to upstream, this check got wrong. This is so severe, that this must be fixed in v10.0.x.

Also, I added some better tracking and checks around the Bundles instantiation, assuring that each bundle is only activated once.