### PR TITLE
Update Http3Frame.cc - fix Use-of-uninitialized-value error

### DIFF
--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -285,7 +285,7 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
       this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
     }
-    
+
     size_t   value_len  = QUICVariableInt::size(buf + len);
     uint64_t value      = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
     len                += value_len;

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -280,10 +280,20 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
     size_t   id_len  = QUICVariableInt::size(buf + len);
     uint16_t id      = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
     len             += id_len;
-
+    if (len > buf_len) {
+      this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
+      this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
+      break;
+    }  
+    
     size_t   value_len  = QUICVariableInt::size(buf + len);
     uint64_t value      = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
     len                += value_len;
+    if (len > buf_len) {
+      this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
+      this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
+      break;
+    }  
 
     // Ignore any SETTINGS identifier it does not understand.
     bool ignore = true;

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -278,22 +278,22 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
     }
 
     size_t   id_len  = QUICVariableInt::size(buf + len);
-    uint16_t id      = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
-    len             += id_len;
-    if (len > buf_len) {
-      this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
-      this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
+    if ((len + id_len) >= buf_len) { // if the id is larger than the buffer or at the boundary of the buffer (i.e. no value), it is invalid
+      this->_error_code    = Http3ErrorCode::H3_SETTINGS_ERROR;
+      this->_error_reason  = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
     }
+    uint16_t id  = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
+    len         += id_len;
 
     size_t   value_len  = QUICVariableInt::size(buf + len);
-    uint64_t value      = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
-    len                += value_len;
-    if (len > buf_len) {
-      this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
-      this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
+    if ((len + value_len) > buf_len) {
+      this->_error_code    = Http3ErrorCode::H3_SETTINGS_ERROR;
+      this->_error_reason  = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
     }
+    uint64_t value  = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
+    len            += value_len;
 
     // Ignore any SETTINGS identifier it does not understand.
     bool ignore = true;

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -284,7 +284,7 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
       this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
       this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
-    }  
+    }
     
     size_t   value_len  = QUICVariableInt::size(buf + len);
     uint64_t value      = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
@@ -293,7 +293,7 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
       this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
       this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
-    }  
+    }
 
     // Ignore any SETTINGS identifier it does not understand.
     bool ignore = true;

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -277,19 +277,20 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
       break;
     }
 
-    size_t   id_len  = QUICVariableInt::size(buf + len);
-    if ((len + id_len) >= buf_len) { // if the id is larger than the buffer or at the boundary of the buffer (i.e. no value), it is invalid
-      this->_error_code    = Http3ErrorCode::H3_SETTINGS_ERROR;
-      this->_error_reason  = reinterpret_cast<const char *>("invalid SETTINGS frame");
+    size_t id_len  = QUICVariableInt::size(buf + len);
+    if ((len + id_len) >=
+        buf_len) { // if the id is larger than the buffer or at the boundary of the buffer (i.e. no value), it is invalid
+      this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
+      this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
     }
     uint16_t id  = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
     len         += id_len;
 
-    size_t   value_len  = QUICVariableInt::size(buf + len);
+    size_t value_len  = QUICVariableInt::size(buf + len);
     if ((len + value_len) > buf_len) {
-      this->_error_code    = Http3ErrorCode::H3_SETTINGS_ERROR;
-      this->_error_reason  = reinterpret_cast<const char *>("invalid SETTINGS frame");
+      this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
+      this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
     }
     uint64_t value  = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -277,7 +277,7 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
       break;
     }
 
-    size_t id_len  = QUICVariableInt::size(buf + len);
+    size_t id_len = QUICVariableInt::size(buf + len);
     if ((len + id_len) >=
         buf_len) { // if the id is larger than the buffer or at the boundary of the buffer (i.e. no value), it is invalid
       this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
@@ -287,7 +287,7 @@ Http3SettingsFrame::Http3SettingsFrame(const uint8_t *buf, size_t buf_len, uint3
     uint16_t id  = QUICIntUtil::read_QUICVariableInt(buf + len, buf_len - len);
     len         += id_len;
 
-    size_t value_len  = QUICVariableInt::size(buf + len);
+    size_t value_len = QUICVariableInt::size(buf + len);
     if ((len + value_len) > buf_len) {
       this->_error_code   = Http3ErrorCode::H3_SETTINGS_ERROR;
       this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");


### PR DESCRIPTION
Fuzzing reveals a use-of-uninitialized-pointer-field case

https://oss-fuzz.com/testcase-detail/6159793621368832

I think this should fix the problem