### PR TITLE
Pass unused length parameter in HeaderField::append function

### DIFF
--- a/src/tscpp/api/Headers.cc
+++ b/src/tscpp/api/Headers.cc
@@ -310,7 +310,7 @@ bool
 HeaderField::append(const char *value, int length)
 {
   return (TSMimeHdrFieldValueStringInsert(iter_.state_->mloc_container_->hdr_buf_, iter_.state_->mloc_container_->hdr_loc_,
-                                          iter_.state_->mloc_container_->field_loc_, -1, value, -1) == TS_SUCCESS);
+                                          iter_.state_->mloc_container_->field_loc_, -1, value, length) == TS_SUCCESS);
 }
 
 bool


### PR DESCRIPTION
The parameter is passed to the TSMimeHdrFieldValueStringInsert instead of the current -1.
The latter causes `strlen(value)` instead `length` bytes to be inserted.
Related [issue](https://github.com/apache/trafficserver/issues/11395).