### PR TITLE
Use the specified `length` characters of the key in `Headers::count`

### DIFF
--- a/include/tscpp/api/Headers.h
+++ b/include/tscpp/api/Headers.h
@@ -91,6 +91,12 @@ public:
    * Case insensitive comparison of this HeaderFieldName
    * @return true if the two strings are equal.
    */
+  bool operator==(std::string_view field_name);
+
+  /**
+   * Case insensitive comparison of this HeaderFieldName
+   * @return true if the two strings are equal.
+   */
   bool operator==(const std::string &field_name);
 
   /**
@@ -98,6 +104,12 @@ public:
    * @return true if the two strings are not equal.
    */
   bool operator!=(const char *field_name);
+
+  /**
+   * Case insensitive comparison of this HeaderFieldName
+   * @return true if the two strings are not equal.
+   */
+  bool operator!=(std::string_view field_name);
 
   /**
    * Case insensitive comparison of this HeaderFieldName
@@ -345,6 +357,13 @@ public:
    */
   bool operator==(const char *field_name) const;
 
+  /**
+   * Compares the name of the header field only (not the values).
+   * @note This is a case insensitive comparison.
+   * @return true if the name is equal (case insensitive comparison).
+   */
+  bool operator==(std::string_view field_name) const;
+
   /** Compares the name of the header field only (not the values).
    * @note This is a case insensitive comparison.
    * @return true if the name is equal (case insensitive comparison).
@@ -356,6 +375,12 @@ public:
    * @return true if the name is NOT equal (case insensitive comparison).
    */
   bool operator!=(const char *field_name) const;
+
+  /** Compares the name of the header field only (not the values).
+   * @note This is a case insensitive comparison.
+   * @return true if the name is NOT equal (case insensitive comparison).
+   */
+  bool operator!=(std::string_view field_name) const;
 
   /** Compares the name of the header field only (not the values).
    * @note This is a case insensitive comparison.

--- a/src/tscpp/api/Headers.cc
+++ b/src/tscpp/api/Headers.cc
@@ -80,6 +80,12 @@ HeaderFieldName::operator==(const char *field_name)
 }
 
 bool
+HeaderFieldName::operator==(std::string_view field_name)
+{
+  return (name_.size() == field_name.size()) && (::strncasecmp(name_.data(), field_name.data(), name_.size()) == 0);
+}
+
+bool
 HeaderFieldName::operator==(const std::string &field_name)
 {
   return operator==(field_name.c_str());
@@ -87,6 +93,12 @@ HeaderFieldName::operator==(const std::string &field_name)
 
 bool
 HeaderFieldName::operator!=(const char *field_name)
+{
+  return !operator==(field_name);
+}
+
+bool
+HeaderFieldName::operator!=(std::string_view field_name)
 {
   return !operator==(field_name);
 }
@@ -327,6 +339,13 @@ HeaderField::operator==(const char *field_name) const
 }
 
 bool
+HeaderField::operator==(std::string_view field_name) const
+{
+  HeaderFieldName nm = name();
+  return (nm.length() == field_name.size()) && (::strncasecmp(nm.c_str(), field_name.data(), field_name.size()) == 0);
+}
+
+bool
 HeaderField::operator==(const std::string &field_name) const
 {
   return operator==(field_name.c_str());
@@ -334,6 +353,12 @@ HeaderField::operator==(const std::string &field_name) const
 
 bool
 HeaderField::operator!=(const char *field_name) const
+{
+  return !operator==(field_name);
+}
+
+bool
+HeaderField::operator!=(std::string_view field_name) const
 {
   return !operator==(field_name);
 }
@@ -593,9 +618,11 @@ Headers::erase(const char *key, int length)
 Headers::size_type
 Headers::count(const char *key, int length)
 {
-  size_type ret_count = 0;
+  size_type        ret_count = 0;
+  size_t           len       = (length < 0) ? strlen(key) : length;
+  std::string_view key_name(key, len);
   for (header_field_iterator it = begin(); it != end(); ++it) {
-    if ((*it).name() == key) {
+    if ((*it).name() == key_name) {
       ret_count++;
     }
   }


### PR DESCRIPTION
The `length` parameters in the `Headers::count` was not taken into account. This lead to the case insensitive comparison being executed on the whole `key`, assuming it's null terminated, than on `length` number of bytes.
This change is related to the discussion [here](https://github.com/apache/trafficserver/issues/11377): the unused `length` parameter is reported when the warning suppression is removed.

I tried to keep to minimum the related changes in the other classes in the `Headers.cc` although the whole functionality there could be done in a better way (IMO):
- the needless string copying here and there can be removed
- the const correctness of the functions can be improved/fixed
- the iterator interface can be improved
- operators between the classes can be reused and/or generated by the compiler (in C++ 20).
- some functions/operators for implict casting should be removed (IMO) because this "convenience" have the price of hiding heap allocations

Last, this check in `Headers::count`
```
if ((*it).name() == key_name)
```
can be done like this:
```
if (*it == key_name)
```
generates a bit better assembly for the whole function: 10 lines shorter where GCC just seem to shuffle some more registers around. 
On the whole I preferred to keep it the related changes to as few as possible because the core issue leading to this is the unused `length` parameter.
Not all of the added operators in the `Headers` functionality are needed for this fix but I added them for consistency.