### PR TITLE
Fix unused parameters in tscore

### DIFF
--- a/include/tscore/Allocator.h
+++ b/include/tscore/Allocator.h
@@ -188,16 +188,16 @@ public:
     @param chunk_size number of units to be allocated if free pool is empty.
     @param alignment of objects must be a power of 2.
   */
-  MallocAllocator(const char *name, unsigned int element_size, unsigned int chunk_size = 128, unsigned int alignment = 8,
-                  bool use_hugepages = false)
+  MallocAllocator([[maybe_unused]] const char *name, unsigned int element_size, [[maybe_unused]] unsigned int chunk_size = 128,
+                  unsigned int alignment = 8, [[maybe_unused]] bool use_hugepages = false)
     : element_size(element_size), alignment(alignment), advice(0)
   {
   }
 
   /** Re-initialize the parameters of the allocator. */
   void
-  re_init(const char *name, unsigned int element_size, unsigned int chunk_size, unsigned int alignment, bool use_hugepages,
-          int advice)
+  re_init([[maybe_unused]] const char *name, unsigned int element_size, [[maybe_unused]] unsigned int chunk_size,
+          unsigned int alignment, [[maybe_unused]] bool use_hugepages, int advice)
   {
     this->element_size = element_size;
     this->alignment    = alignment;

--- a/include/tscore/Allocator.h
+++ b/include/tscore/Allocator.h
@@ -188,16 +188,16 @@ public:
     @param chunk_size number of units to be allocated if free pool is empty.
     @param alignment of objects must be a power of 2.
   */
-  MallocAllocator([[maybe_unused]] const char *name, unsigned int element_size, [[maybe_unused]] unsigned int chunk_size = 128,
-                  unsigned int alignment = 8, [[maybe_unused]] bool use_hugepages = false)
+  MallocAllocator(const char * /* name ATS_UNUSED */, unsigned int element_size, unsigned int /* chunk_size  ATS_UNUSED */ = 128,
+                  unsigned int alignment = 8, bool /* use_hugepages  ATS_UNUSED */ = false)
     : element_size(element_size), alignment(alignment), advice(0)
   {
   }
 
   /** Re-initialize the parameters of the allocator. */
   void
-  re_init([[maybe_unused]] const char *name, unsigned int element_size, [[maybe_unused]] unsigned int chunk_size,
-          unsigned int alignment, [[maybe_unused]] bool use_hugepages, int advice)
+  re_init(const char * /* name ATS_UNUSED */, unsigned int element_size, unsigned int /* chunk_size ATS_UNUSED */,
+          unsigned int alignment, bool /* use_hugepages ATS_UNUSED */, int advice)
   {
     this->element_size = element_size;
     this->alignment    = alignment;

--- a/include/tscore/Extendible.h
+++ b/include/tscore/Extendible.h
@@ -306,14 +306,14 @@ namespace details
 
   template <typename Derived_t, typename Field_t>
   Field_t const &
-  fieldGet(void const *fld_ptr, [[maybe_unused]] FieldId<Derived_t, Field_t> const &field)
+  fieldGet(void const *fld_ptr, FieldId<Derived_t, Field_t> const & /* field ATS_UNUSED */)
   {
     return *static_cast<Field_t const *>(fld_ptr);
   }
 
   template <typename Derived_t, typename Field_t>
   Field_t &
-  fieldSet(void *fld_ptr, [[maybe_unused]] FieldId<Derived_t, Field_t> const &field)
+  fieldSet(void *fld_ptr, FieldId<Derived_t, Field_t> const & /* field ATS_UNUSED */)
   {
     return *static_cast<Field_t *>(fld_ptr);
   }

--- a/include/tscore/Extendible.h
+++ b/include/tscore/Extendible.h
@@ -54,11 +54,11 @@
 //////////////////////////////////////////
 /// SUPPORT MACRO
 #define DEF_EXT_NEW_DEL(cls)               \
-  void *operator new(size_t sz)            \
+  void *operator new(size_t)               \
   {                                        \
     return ats_malloc(ext::sizeOf<cls>()); \
   }                                        \
-  void *operator new(size_t sz, void *ptr) \
+  void *operator new(size_t, void *ptr)    \
   {                                        \
     return ptr;                            \
   }                                        \
@@ -306,14 +306,14 @@ namespace details
 
   template <typename Derived_t, typename Field_t>
   Field_t const &
-  fieldGet(void const *fld_ptr, FieldId<Derived_t, Field_t> const &field)
+  fieldGet(void const *fld_ptr, [[maybe_unused]] FieldId<Derived_t, Field_t> const &field)
   {
     return *static_cast<Field_t const *>(fld_ptr);
   }
 
   template <typename Derived_t, typename Field_t>
   Field_t &
-  fieldSet(void *fld_ptr, FieldId<Derived_t, Field_t> const &field)
+  fieldSet(void *fld_ptr, [[maybe_unused]] FieldId<Derived_t, Field_t> const &field)
   {
     return *static_cast<Field_t *>(fld_ptr);
   }

--- a/src/tscore/ArgParser.cc
+++ b/src/tscore/ArgParser.cc
@@ -232,7 +232,8 @@ ArgParser::Command::Command(std::string const &name, std::string const &descript
 
 // check if this is a valid option before adding
 void
-ArgParser::Command::check_option(std::string const &long_option, std::string const &short_option, std::string const &key) const
+ArgParser::Command::check_option(std::string const &long_option, std::string const &short_option,
+                                 [[maybe_unused]] std::string const &key) const
 {
   if (long_option.size() < 3 || long_option[0] != '-' || long_option[1] != '-') {
     // invalid name
@@ -256,7 +257,7 @@ ArgParser::Command::check_option(std::string const &long_option, std::string con
 
 // check if this is a valid command before adding
 void
-ArgParser::Command::check_command(std::string const &name, std::string const &key) const
+ArgParser::Command::check_command(std::string const &name, [[maybe_unused]] std::string const &key) const
 {
   if (name.empty()) {
     // invalid name

--- a/src/tscore/ArgParser.cc
+++ b/src/tscore/ArgParser.cc
@@ -233,7 +233,7 @@ ArgParser::Command::Command(std::string const &name, std::string const &descript
 // check if this is a valid option before adding
 void
 ArgParser::Command::check_option(std::string const &long_option, std::string const &short_option,
-                                 [[maybe_unused]] std::string const &key) const
+                                 std::string const & /* key ATS_UNUSED */) const
 {
   if (long_option.size() < 3 || long_option[0] != '-' || long_option[1] != '-') {
     // invalid name
@@ -257,7 +257,7 @@ ArgParser::Command::check_option(std::string const &long_option, std::string con
 
 // check if this is a valid command before adding
 void
-ArgParser::Command::check_command(std::string const &name, [[maybe_unused]] std::string const &key) const
+ArgParser::Command::check_command(std::string const &name, std::string const & /* key ATS_UNUSED */) const
 {
   if (name.empty()) {
     // invalid name

--- a/src/tscore/ink_memory.cc
+++ b/src/tscore/ink_memory.cc
@@ -193,7 +193,7 @@ ats_mlock(caddr_t addr, size_t len)
 }
 
 void *
-ats_track_malloc(size_t size, uint64_t *stat)
+ats_track_malloc(size_t size, [[maybe_unused]] uint64_t *stat)
 {
   void *ptr = ats_malloc(size);
 #ifdef HAVE_MALLOC_USABLE_SIZE
@@ -203,7 +203,7 @@ ats_track_malloc(size_t size, uint64_t *stat)
 }
 
 void *
-ats_track_realloc(void *ptr, size_t size, uint64_t *alloc_stat, uint64_t *free_stat)
+ats_track_realloc(void *ptr, size_t size, [[maybe_unused]] uint64_t *alloc_stat, [[maybe_unused]] uint64_t *free_stat)
 {
 #ifdef HAVE_MALLOC_USABLE_SIZE
   const size_t old_size = malloc_usable_size(ptr);
@@ -222,7 +222,7 @@ ats_track_realloc(void *ptr, size_t size, uint64_t *alloc_stat, uint64_t *free_s
 }
 
 void
-ats_track_free(void *ptr, uint64_t *stat)
+ats_track_free(void *ptr, [[maybe_unused]] uint64_t *stat)
 {
   if (ptr == nullptr) {
     return;

--- a/src/tscore/ink_queue.cc
+++ b/src/tscore/ink_queue.cc
@@ -362,7 +362,7 @@ ink_freelist_free_bulk(InkFreeList *f, void *head, void *tail, size_t num_item)
 }
 
 static void
-freelist_bulkfree(InkFreeList *f, void *head, void *tail, size_t num_item)
+freelist_bulkfree(InkFreeList *f, void *head, void *tail, [[maybe_unused]] size_t num_item)
 {
   void **adr_of_next = ADDRESS_OF_NEXT(tail, 0);
   head_p h;


### PR DESCRIPTION
Add `[[maybe_unused]]` to unused parameters in the `tscore` functionality