### PR TITLE
Clean up the insertion of documents into the aggregate write buffer

### DIFF
--- a/src/iocore/cache/AggregateWriteBuffer.cc
+++ b/src/iocore/cache/AggregateWriteBuffer.cc
@@ -39,7 +39,7 @@ AggregateWriteBuffer::add(Doc const *doc, int approx_size)
 {
   std::memcpy(this->_buffer + this->_buffer_pos, doc, doc->len);
   this->_buffer_pos += approx_size;
-  this->add_bytes_pending_aggregation(approx_size);
+  this->add_bytes_pending_aggregation(-approx_size);
 }
 
 Doc *

--- a/src/iocore/cache/AggregateWriteBuffer.cc
+++ b/src/iocore/cache/AggregateWriteBuffer.cc
@@ -21,7 +21,11 @@
   limitations under the License.
  */
 
-#include "iocore/cache/AggregateWriteBuffer.h"
+#include "P_CacheInternal.h"
+#include "P_CacheDir.h"
+#include "P_CacheDoc.h"
+#include "AggregateWriteBuffer.h"
+#include "iocore/cache/CacheDefs.h"
 
 #include "iocore/aio/AIO_fault_injection.h"
 
@@ -29,6 +33,15 @@
 #include "tscore/ink_platform.h"
 
 #include <cstring>
+
+Doc *
+AggregateWriteBuffer::emplace(int approx_size)
+{
+  Doc *result{new (this->_buffer + this->_buffer_pos) Doc};
+  this->_buffer_pos += approx_size;
+  this->add_bytes_pending_aggregation(-approx_size);
+  return result;
+}
 
 bool
 AggregateWriteBuffer::flush(int fd, off_t write_pos) const

--- a/src/iocore/cache/AggregateWriteBuffer.cc
+++ b/src/iocore/cache/AggregateWriteBuffer.cc
@@ -34,6 +34,14 @@
 
 #include <cstring>
 
+void
+AggregateWriteBuffer::add(Doc const *doc, int approx_size)
+{
+  std::memcpy(this->_buffer + this->_buffer_pos, doc, doc->len);
+  this->_buffer_pos += approx_size;
+  this->add_bytes_pending_aggregation(approx_size);
+}
+
 Doc *
 AggregateWriteBuffer::emplace(int approx_size)
 {

--- a/src/iocore/cache/AggregateWriteBuffer.h
+++ b/src/iocore/cache/AggregateWriteBuffer.h
@@ -74,8 +74,7 @@ public:
    * overrun the buffer.
    *
    * The buffer position will be updated to the end of the document's data
-   * and the document length will be subtracted from the bytes pending
-   * aggregation.
+   * and approx_size will be subtracted from the bytes pending aggregation.
    *
    * @param document: A pointer to the document to add to the buffer. It must
    *   have a correct len field, and its headers and data must follow it. This
@@ -96,8 +95,7 @@ public:
    * condition is not met, the new document may overrun the buffer.
    *
    * The buffer position will be updated to the end of the document's data
-   * and the document length will be subtracted from the bytes pending
-   * aggregation.
+   * and approx_size will be subtracted from the bytes pending aggregation.
    *
    * The new document will be uninitialized.
    *

--- a/src/iocore/cache/AggregateWriteBuffer.h
+++ b/src/iocore/cache/AggregateWriteBuffer.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "P_CacheDoc.h"
+
 #include "iocore/eventsystem/Continuation.h"
 
 #include "tscore/ink_memory.h"
@@ -59,6 +61,27 @@ public:
    * @return Returns true if the buffer is empty, otherwise false.
    */
   bool is_empty() const;
+
+  /**
+   * Create a new document in the buffer.
+   *
+   * This method may only be called if there is space at the current
+   * buffer position for the document. Use reset_buffer_pos or add_buffer_pos
+   * to set the position in the buffer before calling this method. If this
+   * condition is not met, the new document may overrun the buffer.
+   *
+   * The buffer position will be updated to the end of the document's data
+   * and the document length will be subtracted from the bytes pending
+   * aggregation.
+   *
+   * The new document will be uninitialized.
+   *
+   * @param approx_size The approximate size of all headers and data as
+   *   determined by Stripe::round_to_approx_size. The document may not need
+   *   this much space.
+   * @return Returns a non-owning pointer to the new document.
+   */
+  Doc *emplace(int approx_size);
 
   /**
    * Flush the internal buffer to disk.

--- a/src/iocore/cache/AggregateWriteBuffer.h
+++ b/src/iocore/cache/AggregateWriteBuffer.h
@@ -63,6 +63,31 @@ public:
   bool is_empty() const;
 
   /**
+   * Add a new document to the buffer.
+   *
+   * This method copies the provided document into the buffer.
+   *
+   * This method may only be called if there is space at the current
+   * buffer position for the document, and the document has a correct len
+   * field. Use reset_buffer_pos to reset to the beginning of the buffer
+   * when it gets full. If this condition is not met, the new document may
+   * overrun the buffer.
+   *
+   * The buffer position will be updated to the end of the document's data
+   * and the document length will be subtracted from the bytes pending
+   * aggregation.
+   *
+   * @param document: A pointer to the document to add to the buffer. It must
+   *   have a correct len field, and its headers and data must follow it. This
+   *   requires a pointer to a full document buffer - not just the Doc struct.
+   * @param approx_size The approximate size of all headers and data as
+   *   determined by Stripe::round_to_approx_size. The document may not need
+   *   this much space.
+   *
+   */
+  void add(Doc const *document, int approx_size);
+
+  /**
    * Create a new document in the buffer.
    *
    * This method may only be called if there is space at the current

--- a/src/iocore/cache/AggregateWriteBuffer.h
+++ b/src/iocore/cache/AggregateWriteBuffer.h
@@ -91,8 +91,8 @@ public:
    * Create a new document in the buffer.
    *
    * This method may only be called if there is space at the current
-   * buffer position for the document. Use reset_buffer_pos or add_buffer_pos
-   * to set the position in the buffer before calling this method. If this
+   * buffer position for the document. Use reset_buffer_pos to reset
+   * to the beginning of the buffer when it gets full. If this
    * condition is not met, the new document may overrun the buffer.
    *
    * The buffer position will be updated to the end of the document's data
@@ -138,7 +138,6 @@ public:
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
   char                                    *get_buffer();
   int                                      get_buffer_pos() const;
-  void                                     add_buffer_pos(int size);
   void                                     seek(int offset);
   void                                     reset_buffer_pos();
   int                                      get_bytes_pending_aggregation() const;
@@ -167,12 +166,6 @@ inline int
 AggregateWriteBuffer::get_buffer_pos() const
 {
   return this->_buffer_pos;
-}
-
-inline void
-AggregateWriteBuffer::add_buffer_pos(int size)
-{
-  this->_buffer_pos += size;
 }
 
 inline void

--- a/src/iocore/cache/CMakeLists.txt
+++ b/src/iocore/cache/CMakeLists.txt
@@ -86,6 +86,7 @@ if(BUILD_TESTING)
   add_cache_test(Update_S_to_L unit_tests/test_Update_S_to_L.cc)
   add_cache_test(Update_Header unit_tests/test_Update_header.cc)
   add_cache_test(CacheStripe unit_tests/test_Stripe.cc)
+  add_cache_test(CacheAggregateWriteBuffer unit_tests/test_AggregateWriteBuffer.cc)
 
 endif()
 

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -786,7 +786,7 @@ agg_copy(char *p, CacheVC *vc)
     doc->sync_serial  = vc->stripe->header->sync_serial;
     doc->write_serial = vc->stripe->header->write_serial;
 
-    memcpy(p, doc, doc->len);
+    this->_write_buffer.add(doc, l);
 
     vc->dir = vc->overwrite_dir;
     dir_set_offset(&vc->dir, vc->stripe->offset_to_vol_offset(o));

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -637,11 +637,10 @@ Stripe::evac_range(off_t low, off_t high, int evac_phase)
   return 0;
 }
 
-static int
-agg_copy(char *p, CacheVC *vc)
+int
+Stripe::agg_copy(CacheVC *vc)
 {
-  Stripe *stripe = vc->stripe;
-  off_t   o      = stripe->header->write_pos + stripe->get_agg_buf_pos();
+  off_t o = this->header->write_pos + this->get_agg_buf_pos();
 
   if (!vc->f.evacuator) {
     uint32_t       len         = vc->write_len + vc->header_len + vc->frag_len + sizeof(Doc);
@@ -650,12 +649,12 @@ agg_copy(char *p, CacheVC *vc)
 
     uint32_t len = vc->write_len + vc->header_len + vc->frag_len + sizeof(Doc);
     ink_assert(vc->frag_type != CACHE_FRAG_TYPE_HTTP || len != sizeof(Doc));
-    ink_assert(stripe->round_to_approx_size(len) == vc->agg_len);
+    ink_assert(this->round_to_approx_size(len) == vc->agg_len);
     // update copy of directory entry for this document
     dir_set_approx_size(&vc->dir, vc->agg_len);
-    dir_set_offset(&vc->dir, stripe->offset_to_vol_offset(o));
-    ink_assert(stripe->vol_offset(&vc->dir) < (stripe->skip + stripe->len));
-    dir_set_phase(&vc->dir, stripe->header->phase);
+    dir_set_offset(&vc->dir, this->offset_to_vol_offset(o));
+    ink_assert(this->vol_offset(&vc->dir) < (this->skip + this->len));
+    dir_set_phase(&vc->dir, this->header->phase);
 
     // fill in document header
     doc->magic       = DOC_MAGIC;
@@ -667,8 +666,8 @@ agg_copy(char *p, CacheVC *vc)
     doc->unused      = 0; // force this for forward compatibility.
     doc->total_len   = vc->total_len;
     doc->first_key   = vc->first_key;
-    doc->sync_serial = stripe->header->sync_serial;
-    vc->write_serial = doc->write_serial = stripe->header->write_serial;
+    doc->sync_serial = this->header->sync_serial;
+    vc->write_serial = doc->write_serial = this->header->write_serial;
     doc->checksum                        = DOC_NO_CHECKSUM;
     if (vc->pin_in_cache) {
       dir_set_pinned(&vc->dir, 1);
@@ -732,13 +731,13 @@ agg_copy(char *p, CacheVC *vc)
     // move data
     if (vc->write_len) {
       {
-        ProxyMutex *mutex ATS_UNUSED = vc->stripe->mutex.get();
+        ProxyMutex *mutex ATS_UNUSED = this->mutex.get();
         ink_assert(mutex->thread_holding == this_ethread());
 
 // ToDo: Why are these for debug only ?
 #ifdef DEBUG
         Metrics::Counter::increment(cache_rsb.write_backlog_failure);
-        Metrics::Counter::increment(stripe->cache_vol->vol_rsb.write_backlog_failure);
+        Metrics::Counter::increment(this->cache_vol->vol_rsb.write_backlog_failure);
 #endif
       }
       if (vc->f.rewrite_resident_alt) {
@@ -776,21 +775,21 @@ agg_copy(char *p, CacheVC *vc)
   } else {
     // for evacuated documents, copy the data, and update directory
     Doc *doc = reinterpret_cast<Doc *>(vc->buf->data());
-    int  l   = vc->stripe->round_to_approx_size(doc->len);
+    int  l   = this->round_to_approx_size(doc->len);
 
 #ifdef DEBUG
     Metrics::Counter::increment(cache_rsb.gc_frags_evacuated);
-    Metrics::Counter::increment(stripe->cache_vol->vol_rsb.gc_frags_evacuated);
+    Metrics::Counter::increment(this->cache_vol->vol_rsb.gc_frags_evacuated);
 #endif
 
-    doc->sync_serial  = vc->stripe->header->sync_serial;
-    doc->write_serial = vc->stripe->header->write_serial;
+    doc->sync_serial  = this->header->sync_serial;
+    doc->write_serial = this->header->write_serial;
 
     this->_write_buffer.add(doc, l);
 
     vc->dir = vc->overwrite_dir;
-    dir_set_offset(&vc->dir, vc->stripe->offset_to_vol_offset(o));
-    dir_set_phase(&vc->dir, vc->stripe->header->phase);
+    dir_set_offset(&vc->dir, this->offset_to_vol_offset(o));
+    dir_set_phase(&vc->dir, this->header->phase);
     return l;
   }
 }
@@ -990,7 +989,7 @@ Stripe::aggregate_pending_writes(Queue<CacheVC, Continuation::Link_link> &tocall
     }
     DDbg(dbg_ctl_agg_read, "copying: %d, %" PRIu64 ", key: %d", this->_write_buffer.get_buffer_pos(),
          this->header->write_pos + this->_write_buffer.get_buffer_pos(), c->first_key.slice32(0));
-    int wrotelen = agg_copy(this->_write_buffer.get_buffer() + this->_write_buffer.get_buffer_pos(), c);
+    [[maybe_unused]] int wrotelen = this->agg_copy(c);
     ink_assert(writelen == wrotelen);
     this->_write_buffer.add_bytes_pending_aggregation(-writelen);
     this->_write_buffer.add_buffer_pos(writelen);

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -647,7 +647,6 @@ Stripe::agg_copy(CacheVC *vc)
     Doc           *doc         = this->_write_buffer.emplace(this->round_to_approx_size(len));
     IOBufferBlock *res_alt_blk = nullptr;
 
-    uint32_t len = vc->write_len + vc->header_len + vc->frag_len + sizeof(Doc);
     ink_assert(vc->frag_type != CACHE_FRAG_TYPE_HTTP || len != sizeof(Doc));
     ink_assert(this->round_to_approx_size(len) == vc->agg_len);
     // update copy of directory entry for this document
@@ -991,8 +990,6 @@ Stripe::aggregate_pending_writes(Queue<CacheVC, Continuation::Link_link> &tocall
          this->header->write_pos + this->_write_buffer.get_buffer_pos(), c->first_key.slice32(0));
     [[maybe_unused]] int wrotelen = this->agg_copy(c);
     ink_assert(writelen == wrotelen);
-    this->_write_buffer.add_bytes_pending_aggregation(-writelen);
-    this->_write_buffer.add_buffer_pos(writelen);
     CacheVC *n = (CacheVC *)c->link.next;
     this->_write_buffer.get_pending_writers().dequeue();
     if (c->f.sync && c->f.use_first_key) {

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -638,7 +638,7 @@ Stripe::evac_range(off_t low, off_t high, int evac_phase)
 }
 
 int
-Stripe::agg_copy(CacheVC *vc)
+Stripe::_agg_copy(CacheVC *vc)
 {
   off_t o = this->header->write_pos + this->get_agg_buf_pos();
 
@@ -988,7 +988,7 @@ Stripe::aggregate_pending_writes(Queue<CacheVC, Continuation::Link_link> &tocall
     }
     DDbg(dbg_ctl_agg_read, "copying: %d, %" PRIu64 ", key: %d", this->_write_buffer.get_buffer_pos(),
          this->header->write_pos + this->_write_buffer.get_buffer_pos(), c->first_key.slice32(0));
-    [[maybe_unused]] int wrotelen = this->agg_copy(c);
+    [[maybe_unused]] int wrotelen = this->_agg_copy(c);
     ink_assert(writelen == wrotelen);
     CacheVC *n = (CacheVC *)c->link.next;
     this->_write_buffer.get_pending_writers().dequeue();

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -23,7 +23,7 @@
 
 #include "P_Cache.h"
 #include "P_CacheDoc.h"
-#include "iocore/cache/AggregateWriteBuffer.h"
+#include "AggregateWriteBuffer.h"
 #include "CacheEvacuateDocVC.h"
 
 // These macros allow two incrementing unsigned values x and y to maintain
@@ -644,7 +644,8 @@ agg_copy(char *p, CacheVC *vc)
   off_t   o      = stripe->header->write_pos + stripe->get_agg_buf_pos();
 
   if (!vc->f.evacuator) {
-    Doc           *doc         = reinterpret_cast<Doc *>(p);
+    uint32_t       len         = vc->write_len + vc->header_len + vc->frag_len + sizeof(Doc);
+    Doc           *doc         = this->_write_buffer.emplace(this->round_to_approx_size(len));
     IOBufferBlock *res_alt_blk = nullptr;
 
     uint32_t len = vc->write_len + vc->header_len + vc->frag_len + sizeof(Doc);

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -329,7 +329,7 @@ private:
   void _init_dir();
   void _init_data_internal();
   void _init_data();
-  int  agg_copy(CacheVC *vc);
+  int  _agg_copy(CacheVC *vc);
   bool flush_aggregate_write_buffer();
 
   AggregateWriteBuffer _write_buffer;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -329,6 +329,7 @@ private:
   void _init_dir();
   void _init_data_internal();
   void _init_data();
+  int  agg_copy(CacheVC *vc);
   bool flush_aggregate_write_buffer();
 
   AggregateWriteBuffer _write_buffer;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -27,7 +27,7 @@
 #include "P_CacheDoc.h"
 #include "P_CacheStats.h"
 #include "P_RamCache.h"
-#include "iocore/cache/AggregateWriteBuffer.h"
+#include "AggregateWriteBuffer.h"
 
 #include "iocore/eventsystem/EThread.h"
 

--- a/src/iocore/cache/unit_tests/test_AggregateWriteBuffer.cc
+++ b/src/iocore/cache/unit_tests/test_AggregateWriteBuffer.cc
@@ -1,0 +1,52 @@
+/** @file
+
+  Unit tests for AggregateWriteBuffer
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "main.h"
+
+int  cache_vols           = 1;
+bool reuse_existing_cache = false;
+
+// This is a regression test for a bug caught in review. The RegressionSM
+// suite did not catch it. Issues related to this would manifest only after
+// the cache wraps around, because add() is only used by evacuators.
+TEST_CASE("Given 10 bytes are pending to the buffer, "
+          "when we add a document with an approximate size of 10, "
+          "then there should be 0 bytes pending.")
+{
+  AggregateWriteBuffer write_buffer;
+  Doc                  doc;
+  doc.len = sizeof(Doc);
+  write_buffer.add_bytes_pending_aggregation(10);
+  write_buffer.add(&doc, 10);
+  CHECK(0 == write_buffer.get_bytes_pending_aggregation());
+}
+
+TEST_CASE("Given 10 bytes are pending to the buffer, "
+          "when we emplace a document with an approximate size of 10, "
+          "then there should be 0 bytes pending.")
+{
+  AggregateWriteBuffer write_buffer;
+  write_buffer.add_bytes_pending_aggregation(10);
+  write_buffer.emplace(10);
+  CHECK(0 == write_buffer.get_bytes_pending_aggregation());
+}


### PR DESCRIPTION
This is a short preamble to refactoring agg_copy, but I'm PRing it separately because it mostly touches `AggregateWriteBuffer` and I'm more confident in the change. It moves `agg_copy` to `Stripe::agg_copy` and adds two new methods to `AggregateWriteBuffer`: `add` and `emplace`. The implementation of `emplace` uses placement new to create the document instead of a reinterpret cast because this is precisely what it's designed for and makes the intent crystal clear.

The two new methods also adjust the buffer position and the number of bytes pending copy. This puts directly related logic together that was previously spread out across hundreds of lines.

The `AggregateWriteBuffer::add_buffer_pos` method has been removed, improving encapsulation and simplifying the interface.

This also moves AggregateWriteBuffer.cc and AggregateWriteBuffer.h to src/ instead of include/ because it's an internal detail at this point, not part of the public interface.