### PR TITLE
Http2ConnectionState::restart_receiving: check for closed peer

### DIFF
--- a/src/proxy/http2/Http2CommonSession.cc
+++ b/src/proxy/http2/Http2CommonSession.cc
@@ -419,6 +419,9 @@ Http2CommonSession::do_process_frame_read(int event, VIO *vio, bool inside_frame
 bool
 Http2CommonSession::_should_do_something_else()
 {
+  if (this->get_proxy_session()->is_peer_closed()) {
+    return false;
+  }
   if (this->_interrupt_reading_frames) {
     this->_interrupt_reading_frames = false;
     return true;

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -1905,6 +1905,10 @@ Http2ConnectionState::restart_streams()
 void
 Http2ConnectionState::restart_receiving(Http2Stream *stream)
 {
+  if (this->session->get_proxy_session()->is_peer_closed()) {
+    // Cannot restart a closed connection.
+    return;
+  }
   // Connection level WINDOW UPDATE
   uint32_t const configured_session_window = this->_get_configured_receive_session_window_size();
   uint32_t const min_session_window =


### PR DESCRIPTION
I noticed a crash in obtaining the peer's session window in which the session's netvc was nullptr. Digging into the backtrace, this seems to have occurred because restart_receiving was called for a closed session. This patch addresses this by handling this situation.

---

I ran this over the weekend in production and the box was stable.