### PR TITLE
Fix unused parameters in `traffic_*` utilities

### DIFF
--- a/src/traffic_cache_tool/CacheDefs.cc
+++ b/src/traffic_cache_tool/CacheDefs.cc
@@ -383,7 +383,7 @@ Stripe::vol_init_data()
 }
 
 void
-Stripe::updateLiveData(enum Copy c)
+Stripe::updateLiveData([[maybe_unused]] enum Copy c)
 {
   //  CacheStoreBlocks delta{_meta_pos[c][FOOT] - _meta_pos[c][HEAD]};
   CacheStoreBlocks header_len(0);
@@ -442,7 +442,7 @@ Stripe::stripe_offset(CacheDirEntry *e)
 }
 
 int
-Stripe::dir_probe(CryptoHash *key, CacheDirEntry *result, CacheDirEntry **last_collision)
+Stripe::dir_probe(CryptoHash *key, [[maybe_unused]] CacheDirEntry *result, [[maybe_unused]] CacheDirEntry **last_collision)
 {
   int segment = key->slice32(0) % this->_segments;
   int bucket  = key->slice32(1) % this->_buckets;

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -473,7 +473,7 @@ Cache::loadSpan(swoc::file::path const &path)
 }
 
 Errata
-Cache::loadSpanDirect(swoc::file::path const &path, int vol_idx, const Bytes &size)
+Cache::loadSpanDirect(swoc::file::path const &path, int vol_idx, [[maybe_unused]] const Bytes &size)
 {
   Errata                zret;
   std::unique_ptr<Span> span(new Span(path));
@@ -1022,7 +1022,7 @@ Cache::build_stripe_hash_table()
 }
 
 Stripe *
-Cache::key_to_stripe(CryptoHash *key, const char *hostname, int host_len)
+Cache::key_to_stripe(CryptoHash *key, [[maybe_unused]] const char *hostname, [[maybe_unused]] int host_len)
 {
   uint32_t h = (key->slice32(2) >> DIR_TAG_WIDTH) % STRIPE_HASH_TABLE_SIZE;
   return globalVec_stripe[stripes_hash_table[h]];
@@ -1365,7 +1365,7 @@ Scan_Cache(swoc::file::path const &regex_path)
 }
 
 int
-main(int argc, const char *argv[])
+main([[maybe_unused]] int argc, const char *argv[])
 {
   swoc::file::path input_url_file;
   std::string      inputFile;

--- a/src/traffic_crashlog/backtrace.cc
+++ b/src/traffic_crashlog/backtrace.cc
@@ -199,7 +199,7 @@ ServerBacktrace(unsigned /* options */, int pid, char **trace)
 #else /* TS_USE_REMOTE_UNWINDING */
 
 int
-ServerBacktrace([[maybe_unused]] unsigned options, [[maybe_unused]] int pid:, char **trace)
+ServerBacktrace([[maybe_unused]] unsigned options, [[maybe_unused]] int pid, char **trace)
 {
   *trace = nullptr;
   return -1;

--- a/src/traffic_crashlog/backtrace.cc
+++ b/src/traffic_crashlog/backtrace.cc
@@ -199,7 +199,7 @@ ServerBacktrace(unsigned /* options */, int pid, char **trace)
 #else /* TS_USE_REMOTE_UNWINDING */
 
 int
-ServerBacktrace(unsigned /* options */, int pid, char **trace)
+ServerBacktrace([[maybe_unused]] unsigned options, [[maybe_unused]] int pid:, char **trace)
 {
   *trace = nullptr;
   return -1;

--- a/src/traffic_ctl/CtrlPrinters.cc
+++ b/src/traffic_ctl/CtrlPrinters.cc
@@ -155,7 +155,7 @@ DiffConfigPrinter::write_output(YAML::Node const &result)
 }
 //------------------------------------------------------------------------------------------------------------------------------------
 void
-ConfigReloadPrinter::write_output(YAML::Node const &result)
+ConfigReloadPrinter::write_output([[maybe_unused]] YAML::Node const &result)
 {
 }
 //------------------------------------------------------------------------------------------------------------------------------------
@@ -293,7 +293,7 @@ GetHostStatusPrinter::write_output(YAML::Node const &result)
 
 //------------------------------------------------------------------------------------------------------------------------------------
 void
-SetHostStatusPrinter::write_output(YAML::Node const &result)
+SetHostStatusPrinter::write_output([[maybe_unused]] YAML::Node const &result)
 {
   // do nothing.
 }

--- a/src/traffic_ctl/CtrlPrinters.h
+++ b/src/traffic_ctl/CtrlPrinters.h
@@ -143,7 +143,7 @@ BasePrinter::is_records_format() const
 class GenericPrinter : public BasePrinter
 {
   void
-  write_output(YAML::Node const &result) override
+  write_output([[maybe_unused]] YAML::Node const &result) override
   {
     /* muted */
   }

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -62,7 +62,7 @@ signal_register_handler(int signal_num, signal_handler_t handle_signal)
 } // namespace
 
 int
-main(int argc, const char **argv)
+main([[maybe_unused]] int argc, const char **argv)
 {
   ts::ArgParser parser;
 

--- a/src/traffic_layout/engine.cc
+++ b/src/traffic_layout/engine.cc
@@ -152,7 +152,7 @@ path_handler(const std::string &path, bool run_flag, const std::string &command)
 
 // check if there is any directory inside empty_check_directory to see if it is empty or not
 static int
-check_directory_empty(const char *path, const struct stat *s, int flag)
+check_directory_empty(const char *path, [[maybe_unused]] const struct stat *s, int flag)
 {
   return std::string(path) != empty_check_directory ? -1 : 0;
 }

--- a/src/traffic_layout/file_system.cc
+++ b/src/traffic_layout/file_system.cc
@@ -96,7 +96,7 @@ create_directory(const std::string &dir)
 }
 
 static int
-remove_function(const char *path, const struct stat *s, int flag, struct FTW *f)
+remove_function(const char *path, [[maybe_unused]] const struct stat *s, int flag, [[maybe_unused]] struct FTW *f)
 {
   int (*rm_func)(const char *);
 
@@ -115,7 +115,7 @@ remove_function(const char *path, const struct stat *s, int flag, struct FTW *f)
 }
 
 static int
-remove_inside_function(const char *path, const struct stat *s, int flag, struct FTW *f)
+remove_inside_function(const char *path, [[maybe_unused]] const struct stat *s, int flag, [[maybe_unused]] struct FTW *f)
 {
   std::string path_to_remove = path;
   if (path_to_remove != remove_path) {

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -28,7 +28,7 @@
 using namespace std::literals;
 
 int
-main(int argc, const char **argv)
+main([[maybe_unused]] int argc, const char **argv)
 {
   LayoutEngine engine;
 

--- a/src/traffic_logstats/logstats.cc
+++ b/src/traffic_logstats/logstats.cc
@@ -1222,8 +1222,8 @@ find_or_create_stats(const char *key)
 ///////////////////////////////////////////////////////////////////////////////
 // Update the stats
 void
-update_stats(OriginStats *o_stats, const HTTPMethod method, URLScheme scheme, int http_code, int size, int result, int hier,
-             int elapsed, bool ipv6)
+update_stats(OriginStats *o_stats, const HTTPMethod method, URLScheme scheme, int http_code, int size, int result,
+             [[maybe_unused]] int hier, int elapsed, bool ipv6)
 {
   update_results_elapsed(&totals, result, elapsed, size);
   update_codes(&totals, http_code, size);
@@ -1956,7 +1956,7 @@ format_elapsed_line(const char *desc, const ElapsedStats &stat, bool json, bool 
 }
 
 void
-format_detail_header(const char *desc, bool concise = false)
+format_detail_header(const char *desc, [[maybe_unused]] bool concise = false)
 {
   std::cout << std::left << std::setw(29) << desc;
   std::cout << std::right << std::setw(15) << "Count" << std::setw(11) << "Percent";

--- a/src/traffic_server/SocksProxy.cc
+++ b/src/traffic_server/SocksProxy.cc
@@ -324,7 +324,7 @@ SocksProxy::state_read_client_request(int event, void *data)
 }
 
 int
-SocksProxy::state_read_socks4_client_request(int event, void *data)
+SocksProxy::state_read_socks4_client_request([[maybe_unused]] int event, [[maybe_unused]] void *data)
 {
   ink_assert(state == SOCKS_ACCEPT);
 
@@ -360,7 +360,7 @@ SocksProxy::state_read_socks4_client_request(int event, void *data)
 }
 
 int
-SocksProxy::state_read_socks5_client_auth_methods(int event, void *data)
+SocksProxy::state_read_socks5_client_auth_methods([[maybe_unused]] int event, [[maybe_unused]] void *data)
 {
   int64_t        n;
   unsigned char *p;
@@ -410,7 +410,7 @@ SocksProxy::state_read_socks5_client_auth_methods(int event, void *data)
 }
 
 int
-SocksProxy::state_send_socks5_auth_method(int event, void *data)
+SocksProxy::state_send_socks5_auth_method(int event, [[maybe_unused]] void *data)
 {
   ink_assert(state == SOCKS_ACCEPT);
   switch (event) {
@@ -435,7 +435,7 @@ SocksProxy::state_send_socks5_auth_method(int event, void *data)
 }
 
 int
-SocksProxy::state_read_socks5_client_request(int event, void *data)
+SocksProxy::state_read_socks5_client_request(int event, [[maybe_unused]] void *data)
 {
   int64_t        n;
   unsigned char *p;
@@ -545,7 +545,7 @@ SocksProxy::parse_socks_client_request(unsigned char *p)
 }
 
 int
-SocksProxy::state_handing_over_http_request(int event, void *data)
+SocksProxy::state_handing_over_http_request(int event, [[maybe_unused]] void *data)
 {
   int ret = EVENT_DONE;
 
@@ -580,7 +580,7 @@ SocksProxy::state_handing_over_http_request(int event, void *data)
 }
 
 int
-SocksProxy::state_send_socks_reply(int event, void *data)
+SocksProxy::state_send_socks_reply(int event, [[maybe_unused]] void *data)
 {
   int ret = EVENT_DONE;
 

--- a/src/traffic_top/traffic_top.cc
+++ b/src/traffic_top/traffic_top.cc
@@ -377,7 +377,7 @@ char reconnecting_animation[4] = {'|', '/', '-', '\\'};
 
 //----------------------------------------------------------------------------
 int
-main(int argc, const char **argv)
+main([[maybe_unused]] int argc, const char **argv)
 {
   static const char USAGE[] = "Usage: traffic_top [-s seconds]";
 


### PR DESCRIPTION
Add `[[maybe_unused]]` for the unused function parameters.
These changes are related to the discussion [here](https://github.com/apache/trafficserver/issues/11377).