### PR TITLE
Fix acl_remap bug

### DIFF
--- a/src/proxy/http/remap/RemapConfig.cc
+++ b/src/proxy/http/remap/RemapConfig.cc
@@ -130,22 +130,24 @@ process_filter_opt(url_mapping *mp, const BUILD_TABLE_INFO *bti, char *errStrBuf
       ;
     }
     errStr = remap_validate_filter_args(rpp, (const char **)bti->argv, bti->argc, errStrBuf, errStrBufSize);
-    for (rp = bti->rules_list; rp; rp = rp->next) {
+  }
+
+  for (rp = bti->rules_list; rp; rp = rp->next) {
+    for (rpp = &mp->filter; *rpp; rpp = &((*rpp)->next)) {
+      ;
+    }
+    if (rp->active_queue_flag) {
+      Dbg(dbg_ctl_url_rewrite, "[process_filter_opt] Add active main filter \"%s\" (argc=%d)",
+          rp->filter_name ? rp->filter_name : "<nullptr>", rp->argc);
       for (rpp = &mp->filter; *rpp; rpp = &((*rpp)->next)) {
         ;
       }
-      if (rp->active_queue_flag) {
-        Dbg(dbg_ctl_url_rewrite, "[process_filter_opt] Add active main filter \"%s\" (argc=%d)",
-            rp->filter_name ? rp->filter_name : "<nullptr>", rp->argc);
-        for (rpp = &mp->filter; *rpp; rpp = &((*rpp)->next)) {
-          ;
-        }
-        if ((errStr = remap_validate_filter_args(rpp, (const char **)rp->argv, rp->argc, errStrBuf, errStrBufSize)) != nullptr) {
-          break;
-        }
+      if ((errStr = remap_validate_filter_args(rpp, (const char **)rp->argv, rp->argc, errStrBuf, errStrBufSize)) != nullptr) {
+        break;
       }
     }
   }
+
   // Set the ip allow flag for this rule to the current ip allow flag state
   mp->ip_allow_check_enabled_p = bti->ip_allow_check_enabled_p;
 

--- a/tests/gold_tests/remap/deny_head_post.replay.yaml
+++ b/tests/gold_tests/remap/deny_head_post.replay.yaml
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# This expects a remap.config that allows GET and POST, but denies all other
+# This expects a remap.config that denies HEAD and POST, but allows all other
 # methods.
 
 meta:
@@ -82,3 +82,19 @@ sessions:
 
     proxy-response:
       status: 403
+
+  - client-request:
+      method: "DELETE"
+      version: "1.1"
+      url: /test/ip_allow/test_delete
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, delete ]
+        - [ X-Request, delete ]
+        - [ Content-Length, 0 ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/remap/get_head_post.replay.yaml
+++ b/tests/gold_tests/remap/get_head_post.replay.yaml
@@ -1,0 +1,84 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# This expects a remap.config that allows GET and POST, but denies all other
+# methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, get ]
+        - [ X-Request, get ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  - client-request:
+      method: "HEAD"
+      version: "1.1"
+      url: /test/ip_allow/test_head
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, head ]
+        - [ X-Request, head ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 403
+
+  # POST rejected
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /test/ip_allow/test_post
+      headers:
+        fields:
+        - [Content-Length, 10]
+        - [ uuid, post ]
+        - [ X-Request, post ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 403

--- a/tests/gold_tests/remap/remap_acl.test.py
+++ b/tests/gold_tests/remap/remap_acl.test.py
@@ -140,19 +140,6 @@ ip_allow:
       - GET
 '''
 
-IP_ALLOW_MINIMUM = f'''
-ip_categories:
-  - name: ACME_LOCAL
-    ip_addrs: 127.0.0.1
-  - name: ACME_EXTERNAL
-    ip_addrs: 5.6.7.8
-
-ip_allow:
-  - apply: in
-    ip_addrs: 0/0
-    action: allow
-'''
-
 test_ip_allow_optional_methods = Test_remap_acl(
     "Verify non-allowed methods are blocked.",
     replay_file='remap_acl_get_post_allowed.replay.yaml',
@@ -311,10 +298,10 @@ test_ip_allow_optional_methods = Test_remap_acl(
     expected_responses=[200, 403, 403, 403, 403])
 
 test_named_acl_deny = Test_remap_acl(
-    "Verify we can deny all but allow in a named acl.",
-    replay_file='get_head_post.replay.yaml',
-    ip_allow_content=IP_ALLOW_MINIMUM,
+    "Verify a named ACL is applied if an in-line ACL is absent.",
+    replay_file='deny_head_post.replay.yaml',
+    ip_allow_content=IP_ALLOW_CONTENT,
     deactivate_ip_allow=False,
     acl_configuration='',
     named_acls=[('deny', '@action=deny @method=HEAD @method=POST')],
-    expected_responses=[200, 403, 403])
+    expected_responses=[200, 403, 403, 403])

--- a/tests/gold_tests/remap/remap_acl.test.py
+++ b/tests/gold_tests/remap/remap_acl.test.py
@@ -140,6 +140,19 @@ ip_allow:
       - GET
 '''
 
+IP_ALLOW_MINIMUM = f'''
+ip_categories:
+  - name: ACME_LOCAL
+    ip_addrs: 127.0.0.1
+  - name: ACME_EXTERNAL
+    ip_addrs: 5.6.7.8
+
+ip_allow:
+  - apply: in
+    ip_addrs: 0/0
+    action: allow
+'''
+
 test_ip_allow_optional_methods = Test_remap_acl(
     "Verify non-allowed methods are blocked.",
     replay_file='remap_acl_get_post_allowed.replay.yaml',
@@ -296,3 +309,12 @@ test_ip_allow_optional_methods = Test_remap_acl(
     acl_configuration='@action=allow @in_ip=3.4.5.6 @method=GET @method=POST',
     named_acls=[],
     expected_responses=[200, 403, 403, 403, 403])
+
+test_named_acl_deny = Test_remap_acl(
+    "Verify we can deny all but allow in a named acl.",
+    replay_file='get_head_post.replay.yaml',
+    ip_allow_content=IP_ALLOW_MINIMUM,
+    deactivate_ip_allow=False,
+    acl_configuration='',
+    named_acls=[('deny', '@action=deny @method=HEAD @method=POST')],
+    expected_responses=[200, 403, 403])


### PR DESCRIPTION
The acl remap rules are described in [1]. Namely:

> 1. A remap.config ACL line for an individual remap rule.
> 2. All named ACLs in remap.config.
> 3. Rules as specified in ip_allow.yaml.

This commit fixes a bug that would cause (2) to not be processed if there was no entry in (1).

[1] src/proxy/http/remap/RemapConfig.cc:123