### PR TITLE
10.0.x: Fix some doc generation warnings (#11370)

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1378,7 +1378,7 @@ the client where the requested data was served from.::
    set-header ATS-SRVR-UUID %{ID:UNIQUE}
 
 Apply rate limiting for some select requests
-------------------------------------
+--------------------------------------------
 
 This rule will conditiionally, based on the client request headers, apply rate
 limiting to the request.::

--- a/doc/admin-guide/plugins/txn_box/reference.en.rst
+++ b/doc/admin-guide/plugins/txn_box/reference.en.rst
@@ -33,7 +33,7 @@ Glossary
 .. glossary::
    :sorted:
 
-   transaction
+   transaction (txn_box)
       A :term:`request` and the corresponding :term:`response`.
 
    request

--- a/doc/developer-guide/api/functions/TSActionCancel.en.rst
+++ b/doc/developer-guide/api/functions/TSActionCancel.en.rst
@@ -16,7 +16,7 @@
 
 .. include:: ../../../common.defs
 
-.. default-domain:: c
+.. default-domain:: cpp
 
 TSActionCancel
 **************

--- a/doc/developer-guide/api/functions/TSContScheduleEveryOnPool.en.rst
+++ b/doc/developer-guide/api/functions/TSContScheduleEveryOnPool.en.rst
@@ -16,7 +16,7 @@
 
 .. include:: ../../../common.defs
 
-.. default-domain:: c
+.. default-domain:: cpp
 
 TSContScheduleEveryOnPool
 *************************

--- a/doc/developer-guide/api/functions/TSContScheduleOnThread.en.rst
+++ b/doc/developer-guide/api/functions/TSContScheduleOnThread.en.rst
@@ -16,7 +16,7 @@
 
 .. include:: ../../../common.defs
 
-.. default-domain:: c
+.. default-domain:: cpp
 
 TSContScheduleOnThread
 **********************

--- a/doc/developer-guide/api/functions/TSHttpTxnResponseActionSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnResponseActionSet.en.rst
@@ -41,7 +41,7 @@ Therefore, plugins which set the ResponseAction to retry
 must also un-set it after the subsequent success or failure,
 or ATS will retry forever!
 
-The passed *action must not be null, and is copied and may be
+The passed *action* must not be null, and is copied and may be
 destroyed after this call returns.
 
 Callers must maintain owernship of action.hostname,

--- a/doc/developer-guide/cripts/cripts-matcher.en.rst
+++ b/doc/developer-guide/cripts/cripts-matcher.en.rst
@@ -73,7 +73,7 @@ All matchers have the following functions:
 Function                       Description
 ============================   ====================================================================
 ``match()``                    Match the given string against the matcher.
-``contains()`                  Another name for ``match()``
+``contains()``                 Another name for ``match()``
 ``add()``                      Add another element to the matcher (can not be used with ``static``)
 ============================   ====================================================================
 

--- a/doc/developer-guide/plugins/actions/index.en.rst
+++ b/doc/developer-guide/plugins/actions/index.en.rst
@@ -173,5 +173,5 @@ cancel the action. The following sample code implements this:
 
 The action functions are:
 
--  :c:func:`TSActionCancel`
--  :c:func:`TSActionDone`
+-  :cpp:func:`TSActionCancel`
+-  :cpp:func:`TSActionDone`


### PR DESCRIPTION
This fixes the various warnings that come from the initial phase of reading the doc files. There are still some warnings during the writing the output phase.

(cherry picked from commit d31a40fecb19f80ae8b7ddbb2ff0efecc57bf7f9)

Conflicts:
      doc/developer-guide/api/functions/TSContScheduleEveryOnEntirePool.en.rst
      doc/developer-guide/api/functions/TSContScheduleOnEntirePool.en.rst