### PR TITLE
Add Remap ACL table test

### DIFF
--- a/tests/gold_tests/remap/base.replay.yaml
+++ b/tests/gold_tests/remap/base.replay.yaml
@@ -1,0 +1,51 @@
+meta:
+  version: '1.0'
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tls
+    sni: test_sni
+  transactions:
+  - client-request:
+      headers:
+        fields:
+        - - Content-Length
+          - 0
+        - - uuid
+          - get
+        - - X-Request
+          - get
+      method: GET
+      url: /test/ip_allow/test_get
+      version: '1.1'
+    proxy-response:
+      status: 200
+    server-response:
+      headers:
+        fields:
+        - - Content-Length
+          - 20
+      reason: OK
+      status: 200
+  - client-request:
+      headers:
+        fields:
+        - - Content-Length
+          - 10
+        - - uuid
+          - post
+        - - X-Request
+          - post
+      method: POST
+      url: /test/ip_allow/test_post
+      version: '1.1'
+    proxy-response:
+      status: 200
+    server-response:
+      headers:
+        fields:
+        - - Content-Length
+          - 20
+      reason: OK
+      status: 200


### PR DESCRIPTION
This change adds a table test that tests every combination of ACLs, namely:

1. remap.config inline rule
2. named ACLs in remap.config.
3. ip_allow.yaml.

It tests the expected response for a GET request (explicity denied or allowed in the test) and a POST (implicitly denied or allowed by the GET rule)

The current test implementation is optimised for minimal code changes. Because of this a new server is started for each test. Because of this the new tests alone will add 1m20s to the total autest testing time.

This could be optimised if we feel that this style of test is worth considering.