### PR TITLE
Remove Stripe::get_agg_todo_size

### DIFF
--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -217,7 +217,8 @@ CacheVC::updateVector(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
      agg queue. And if !f.evac_vector && !f.update the alternate->object_size
      is set to vc->total_len
    - f.readers.  If set, assumes that this is an evacuation, so the write
-     is not aborted even if vol->get_agg_todo_size() > agg_write_backlog
+     is not aborted even if
+     stripe->_write_buffer.get_bytes_pending_aggregation() > agg_write_backlog
    - f.evacuator. If this is an evacuation.
    - f.rewrite_resident_alt. The resident alternate is rewritten.
    - f.update. Used only if the write_vector needs to be written to disk.

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -389,7 +389,7 @@ Stripe::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
   Stripe *stripe    = this;
   bool    agg_error = false;
   if (!cont->f.remove) {
-    agg_error = (!cont->f.update && this->get_agg_todo_size() > cache_config_agg_write_backlog);
+    agg_error = (!cont->f.update && this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog);
 #ifdef CACHE_AGG_FAIL_RATE
     agg_error = agg_error || ((uint32_t)mutex->thread_holding->generator.random() < (uint32_t)(UINT_MAX * CACHE_AGG_FAIL_RATE));
 #endif

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -277,7 +277,6 @@ public:
 
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
   int                                      get_agg_buf_pos() const;
-  int                                      get_agg_todo_size() const;
 
   /**
    * Add a virtual connection waiting to write to this stripe.
@@ -549,10 +548,4 @@ inline int
 Stripe::get_agg_buf_pos() const
 {
   return this->_write_buffer.get_buffer_pos();
-}
-
-inline int
-Stripe::get_agg_todo_size() const
-{
-  return this->_write_buffer.get_bytes_pending_aggregation();
 }


### PR DESCRIPTION
The method was only used in one place internally in Stripe.