### PR TITLE
Fix race condition causing interleaved logs 

### DIFF
--- a/doc/developer-guide/api/functions/TSMimeHdrPrint.en.rst
+++ b/doc/developer-guide/api/functions/TSMimeHdrPrint.en.rst
@@ -28,10 +28,10 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSMimeHdrPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp)
+.. function:: void TSMimeHdrPrint(TSMLoc offset, TSIOBuffer iobufp)
 
 Description
 ===========
 
-Formats the MIME header located at :arg:`hdr_loc` within :arg:`bufp` into the
+Formats the MIME header located at :arg:`hdr_loc` into the
 :cpp:type:`TSIOBuffer` :arg:`iobufp`.

--- a/example/plugins/c-api/cache_scan/cache_scan.cc
+++ b/example/plugins/c-api/cache_scan/cache_scan.cc
@@ -144,7 +144,7 @@ handle_scan(TSCont contp, TSEvent event, void *edata)
     // print the response headers
     TSCacheHttpInfoRespGet(cache_infop, &resp_bufp, &resp_hdr_loc);
     cstate->total_bytes += TSMimeHdrLengthGet(resp_bufp, resp_hdr_loc);
-    TSMimeHdrPrint(resp_bufp, resp_hdr_loc, cstate->resp_buffer);
+    TSMimeHdrPrint(resp_hdr_loc, cstate->resp_buffer);
     TSHandleMLocRelease(resp_bufp, TS_NULL_MLOC, resp_hdr_loc);
 
     cstate->total_bytes += TSIOBufferWrite(cstate->resp_buffer, s2, sizeof(s2) - 1);

--- a/example/plugins/c-api/output_header/output_header.cc
+++ b/example/plugins/c-api/output_header/output_header.cc
@@ -74,7 +74,7 @@ handle_dns(TSHttpTxn txnp, TSCont contp ATS_UNUSED)
   /* This will print  just MIMEFields and not
      the http request line */
   Dbg(dbg_ctl, "Printing the hdrs ... ");
-  TSMimeHdrPrint(bufp, hdr_loc, output_buffer);
+  TSMimeHdrPrint(hdr_loc, output_buffer);
 
   if (TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc) == TS_ERROR) {
     Dbg(dbg_ctl, "non-fatal: error releasing MLoc");

--- a/include/proxy/hdrs/HTTP.h
+++ b/include/proxy/hdrs/HTTP.h
@@ -506,7 +506,7 @@ public:
 
   int unmarshal(char *buf, int len, RefCountObj *block_ref);
 
-  int print(char *buf, int bufsize, int *bufindex, int *dumpoffset);
+  int print(char *buf, int bufsize, int *bufindex, int *dumpoffset) const;
 
   int length_get() const;
 
@@ -761,7 +761,7 @@ HTTPHdr::copy_shallow(const HTTPHdr *hdr)
   -------------------------------------------------------------------------*/
 
 inline int
-HTTPHdr::print(char *buf, int bufsize, int *bufindex, int *dumpoffset)
+HTTPHdr::print(char *buf, int bufsize, int *bufindex, int *dumpoffset) const
 {
   ink_assert(valid());
   return http_hdr_print(m_http, buf, bufsize, bufindex, dumpoffset);

--- a/include/proxy/hdrs/HTTP.h
+++ b/include/proxy/hdrs/HTTP.h
@@ -428,7 +428,7 @@ void         http_hdr_init(HdrHeap *heap, HTTPHdrImpl *hh, HTTPType polarity, HT
 HTTPHdrImpl *http_hdr_clone(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HdrHeap *d_heap);
 void         http_hdr_copy_onto(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HTTPHdrImpl *d_hh, HdrHeap *d_heap, bool inherit_strs);
 
-int http_hdr_print(HTTPHdrImpl *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
+int http_hdr_print(HTTPHdrImpl const *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
 
 void http_hdr_describe(HdrHeapObjImpl *obj, bool recurse = true);
 

--- a/include/proxy/hdrs/HTTP.h
+++ b/include/proxy/hdrs/HTTP.h
@@ -428,7 +428,7 @@ void         http_hdr_init(HdrHeap *heap, HTTPHdrImpl *hh, HTTPType polarity, HT
 HTTPHdrImpl *http_hdr_clone(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HdrHeap *d_heap);
 void         http_hdr_copy_onto(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HTTPHdrImpl *d_hh, HdrHeap *d_heap, bool inherit_strs);
 
-int http_hdr_print(HdrHeap * /* heap ATS_UNUSED */, HTTPHdrImpl *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
+int http_hdr_print(HTTPHdrImpl *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
 
 void http_hdr_describe(HdrHeapObjImpl *obj, bool recurse = true);
 
@@ -764,7 +764,7 @@ inline int
 HTTPHdr::print(char *buf, int bufsize, int *bufindex, int *dumpoffset)
 {
   ink_assert(valid());
-  return http_hdr_print(m_heap, m_http, buf, bufsize, bufindex, dumpoffset);
+  return http_hdr_print(m_http, buf, bufsize, bufindex, dumpoffset);
 }
 
 /*-------------------------------------------------------------------------

--- a/include/proxy/hdrs/HTTP.h
+++ b/include/proxy/hdrs/HTTP.h
@@ -428,7 +428,7 @@ void         http_hdr_init(HdrHeap *heap, HTTPHdrImpl *hh, HTTPType polarity, HT
 HTTPHdrImpl *http_hdr_clone(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HdrHeap *d_heap);
 void         http_hdr_copy_onto(HTTPHdrImpl *s_hh, HdrHeap *s_heap, HTTPHdrImpl *d_hh, HdrHeap *d_heap, bool inherit_strs);
 
-int http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
+int http_hdr_print(HdrHeap * /* heap ATS_UNUSED */, HTTPHdrImpl *hh, char *buf, int bufsize, int *bufindex, int *dumpoffset);
 
 void http_hdr_describe(HdrHeapObjImpl *obj, bool recurse = true);
 

--- a/include/proxy/hdrs/HTTP.h
+++ b/include/proxy/hdrs/HTTP.h
@@ -1068,7 +1068,7 @@ HTTPHdr::url_set(const char *str, int length)
   -------------------------------------------------------------------------*/
 
 inline HTTPStatus
-http_hdr_status_get(HTTPHdrImpl *hh)
+http_hdr_status_get(HTTPHdrImpl const *hh)
 {
   ink_assert(hh->m_polarity == HTTP_TYPE_RESPONSE);
   return (HTTPStatus)hh->u.resp.m_status;

--- a/include/proxy/hdrs/MIME.h
+++ b/include/proxy/hdrs/MIME.h
@@ -903,8 +903,7 @@ ParseResult mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh
 void mime_hdr_describe(HdrHeapObjImpl *raw, bool recurse);
 void mime_field_block_describe(HdrHeapObjImpl *raw, bool recurse);
 
-int mime_hdr_print(HdrHeap *heap, MIMEHdrImpl *mh, char *buf_start, int buf_length, int *buf_index_inout,
-                   int *buf_chars_to_skip_inout);
+int mime_hdr_print(MIMEHdrImpl *mh, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout);
 int mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout,
                    int *buf_chars_to_skip_inout);
 int mime_mem_print_lc(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout,
@@ -1409,7 +1408,7 @@ MIMEHdr::presence(uint64_t mask) const
 inline int
 MIMEHdr::print(char *buf, int bufsize, int *bufindex, int *chars_to_skip)
 {
-  return mime_hdr_print(m_heap, m_mime, buf, bufsize, bufindex, chars_to_skip);
+  return mime_hdr_print(m_mime, buf, bufsize, bufindex, chars_to_skip);
 }
 
 /*-------------------------------------------------------------------------

--- a/include/proxy/hdrs/MIME.h
+++ b/include/proxy/hdrs/MIME.h
@@ -903,12 +903,12 @@ ParseResult mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh
 void mime_hdr_describe(HdrHeapObjImpl *raw, bool recurse);
 void mime_field_block_describe(HdrHeapObjImpl *raw, bool recurse);
 
-int mime_hdr_print(MIMEHdrImpl *mh, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout);
+int mime_hdr_print(MIMEHdrImpl const *mh, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout);
 int mime_mem_print(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout,
                    int *buf_chars_to_skip_inout);
 int mime_mem_print_lc(const char *src_d, int src_l, char *buf_start, int buf_length, int *buf_index_inout,
                       int *buf_chars_to_skip_inout);
-int mime_field_print(MIMEField *field, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout);
+int mime_field_print(MIMEField const *field, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout);
 
 const char *mime_str_u16_set(HdrHeap *heap, const char *s_str, int s_len, const char **d_str, uint16_t *d_len, bool must_copy);
 

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -69,8 +69,8 @@ s_dump_header(HTTPHdr const *hdr, std::string &out)
     // the use of tmp is precautionary to make sure our logic
     // doesn't break in case it does change in some circumstance.
     int tmp{offset};
-    done     = hdr->print(b, 4096, &used, &tmp);
-    offset  += used;
+    done    = hdr->print(b, 4096, &used, &tmp);
+    offset += used;
     out.append(b, used);
   } while (0 == done);
 }

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -69,17 +69,16 @@ s_dump_header(HTTPHdr const *hdr, std::string &out)
     // the use of tmp is precautionary to make sure our logic
     // doesn't break in case it does change in some circumstance.
     int tmp{offset};
-    done     = hdr->print(b, 4095, &used, &tmp);
+    done     = hdr->print(b, 4096, &used, &tmp);
     offset  += used;
-    b[used]  = '\0';
-    out.append(b);
+    out.append(b, used);
   } while (0 == done);
 }
 
 inline void
 dump_header(DbgCtl const &ctl, HTTPHdr const *hdr, std::int64_t sm_id, std::string_view description)
 {
-  if (true) {
+  if (ctl.on()) {
     std::string output;
     output.append("+++++++++ ");
     output.append(description);

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -88,6 +88,8 @@ dump_header(DbgCtl const &ctl, HTTPHdr const *hdr, std::int64_t sm_id, std::stri
     output.push_back('\n');
     if (hdr->valid()) {
       s_dump_header(hdr, output);
+    } else {
+      output.append("Invalid header!\n");
     }
     // We make a single call to fprintf so that the output does not get
     // interleaved with output from other threads performing I/O.

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -25,6 +25,7 @@
 
 #include <cstddef>
 
+#include "tsutil/DbgCtl.h"
 #include "tscore/ink_assert.h"
 #include "tscore/ink_platform.h"
 #include "iocore/hostdb/HostDB.h"
@@ -45,31 +46,55 @@
 #include "proxy/ProxySession.h"
 #include "tscore/MgmtDefs.h"
 
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <string_view>
+
 #define HTTP_OUR_VIA_MAX_LENGTH 1024 // 512-bytes for hostname+via string, 512-bytes for the debug info
 
 #define HTTP_RELEASE_ASSERT(X) ink_release_assert(X)
 
-#define DUMP_HEADER(C, H, I, S)                                 \
-  {                                                             \
-    if ((C).on()) {                                             \
-      fprintf(stderr, "+++++++++ %s +++++++++\n", S);           \
-      fprintf(stderr, "-- State Machine Id: %" PRId64 "\n", I); \
-      char b[4096];                                             \
-      int  used, tmp, offset;                                   \
-      int  done;                                                \
-      offset = 0;                                               \
-      if ((H)->valid()) {                                       \
-        do {                                                    \
-          used     = 0;                                         \
-          tmp      = offset;                                    \
-          done     = (H)->print(b, 4095, &used, &tmp);          \
-          offset  += used;                                      \
-          b[used]  = '\0';                                      \
-          fprintf(stderr, "%s", b);                             \
-        } while (!done);                                        \
-      }                                                         \
-    }                                                           \
+inline void
+s_dump_header(HTTPHdr const *hdr, std::string &out)
+{
+  int offset{0};
+  int done{0};
+  do {
+    int  used{0};
+    char b[4096];
+    // The buffer offset is taken non-const and it is apparently
+    // modified in some code path, but in my testing it does
+    // not change, it seems. Since we manually bump the offset,
+    // the use of tmp is precautionary to make sure our logic
+    // doesn't break in case it does change in some circumstance.
+    int tmp{offset};
+    done     = hdr->print(b, 4095, &used, &tmp);
+    offset  += used;
+    b[used]  = '\0';
+    out.append(b);
+  } while (0 == done);
+}
+
+inline void
+dump_header(DbgCtl const &ctl, HTTPHdr const *hdr, std::int64_t sm_id, std::string_view description)
+{
+  if (true) {
+    std::string output;
+    output.append("+++++++++ ");
+    output.append(description);
+    output.append(" +++++++++\n");
+    output.append("-- State Machine Id: ");
+    output.append(std::to_string(sm_id));
+    output.push_back('\n');
+    if (hdr->valid()) {
+      s_dump_header(hdr, output);
+    }
+    // We make a single call to fprintf so that the output does not get
+    // interleaved with output from other threads performing I/O.
+    fprintf(stderr, "%s", output.c_str());
   }
+}
 
 using ink_time_t = time_t;
 

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -879,16 +879,14 @@ TSReturnCode TSMimeHdrClone(TSMBuffer dest_bufp, TSMBuffer src_bufp, TSMLoc src_
 TSReturnCode TSMimeHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_offset, TSMBuffer src_bufp, TSMLoc src_offset);
 
 /**
-    Formats the MIME header located at hdr_loc within bufp into the
+    Formats the MIME header located at hdr_loc into the
     TSIOBuffer iobufp.
 
-    @param bufp marshal buffer containing the header to be copied to
-      an TSIOBuffer.
-    @param offset
+    @param offset The offset of the header to be copied to a TSIOBuffer.
     @param iobufp target TSIOBuffer.
 
  */
-void TSMimeHdrPrint(TSMBuffer bufp, TSMLoc offset, TSIOBuffer iobufp);
+void TSMimeHdrPrint(TSMLoc offset, TSIOBuffer iobufp);
 
 /**
     Parses a MIME header. The MIME header must have already been

--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -388,7 +388,7 @@ cont_bg_fetch(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
         break;
       }
       Dbg(Bg_dbg_ctl, "Starting background fetch, replaying:");
-      dump_headers(data->mbuf, data->hdr_loc);
+      dump_headers(data->hdr_loc);
     }
 
     // Setup the NetVC for background fetch

--- a/plugins/background_fetch/headers.cc
+++ b/plugins/background_fetch/headers.cc
@@ -95,14 +95,14 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
 ///////////////////////////////////////////////////////////////////////////
 // Dump a header on stderr, useful together with Dbg().
 void
-dump_headers(TSMBuffer bufp, TSMLoc hdr_loc)
+dump_headers(TSMLoc hdr_loc)
 {
   TSIOBuffer       output_buffer = TSIOBufferCreate();
   TSIOBufferReader reader        = TSIOBufferReaderAlloc(output_buffer);
   int64_t          block_avail   = 0;
 
   /* This will print  just MIMEFields and not the http request line */
-  TSMimeHdrPrint(bufp, hdr_loc, output_buffer);
+  TSMimeHdrPrint(hdr_loc, output_buffer);
 
   /* We need to loop over all the buffer blocks, there can be more than 1 */
   TSIOBufferBlock block = TSIOBufferReaderStart(reader);

--- a/plugins/background_fetch/headers.h
+++ b/plugins/background_fetch/headers.h
@@ -26,4 +26,4 @@
 
 int  remove_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 bool set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const char *val, int val_len);
-void dump_headers(TSMBuffer bufp, TSMLoc hdr_loc);
+void dump_headers(TSMLoc hdr_loc);

--- a/plugins/experimental/cache_fill/background_fetch.cc
+++ b/plugins/experimental/cache_fill/background_fetch.cc
@@ -93,7 +93,7 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const ch
 ///////////////////////////////////////////////////////////////////////////
 // Dump a header on stderr, useful together with Dbg().
 static void
-dump_headers(TSMBuffer bufp, TSMLoc hdr_loc)
+dump_headers(TSMLoc hdr_loc)
 {
   TSIOBuffer       output_buffer;
   TSIOBufferReader reader;
@@ -104,7 +104,7 @@ dump_headers(TSMBuffer bufp, TSMLoc hdr_loc)
   reader        = TSIOBufferReaderAlloc(output_buffer);
 
   /* This will print  just MIMEFields and not the http request line */
-  TSMimeHdrPrint(bufp, hdr_loc, output_buffer);
+  TSMimeHdrPrint(hdr_loc, output_buffer);
 
   /* We need to loop over all the buffer blocks, there can be more than 1 */
   block = TSIOBufferReaderStart(reader);
@@ -241,7 +241,7 @@ cont_bg_fetch(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
         break;
       }
       Dbg(dbg_ctl, "Starting background fetch, replaying:");
-      dump_headers(data->mbuf, data->hdr_loc);
+      dump_headers(data->hdr_loc);
     }
 
     // Setup the NetVC for background fetch

--- a/plugins/experimental/stale_response/CacheUpdate.cc
+++ b/plugins/experimental/stale_response/CacheUpdate.cc
@@ -44,7 +44,7 @@ const int  SERVER_INTERCEPT_HEADER_LEN = sizeof(SERVER_INTERCEPT_HEADER) - 1;
 
 /*-----------------------------------------------------------------------------------------------*/
 static char *
-convert_mime_hdr_to_string(TSMBuffer bufp, TSMLoc hdr_loc)
+convert_mime_hdr_to_string(TSMLoc hdr_loc)
 {
   TSIOBuffer       output_buffer;
   TSIOBufferReader reader;
@@ -67,7 +67,7 @@ convert_mime_hdr_to_string(TSMBuffer bufp, TSMLoc hdr_loc)
 
   /* This will print  just MIMEFields and not
      the http request line */
-  TSMimeHdrPrint(bufp, hdr_loc, output_buffer);
+  TSMimeHdrPrint(hdr_loc, output_buffer);
 
   /* Find out how the big the complete header is by
      seeing the total bytes in the buffer.  We need to
@@ -341,7 +341,7 @@ intercept_fetch_the_url(StateInfo *state)
   get_request.append(tmpStr, 8);
   get_request.append("\r\n");
 
-  char *allReqHeaders = convert_mime_hdr_to_string(state->req_info->http_hdr_buf, state->req_info->http_hdr_loc);
+  char *allReqHeaders = convert_mime_hdr_to_string(state->req_info->http_hdr_loc);
   get_request.append(allReqHeaders);
   TSfree(allReqHeaders);
   get_request.append("\r\n");

--- a/plugins/prefetch/fetch.cc
+++ b/plugins/prefetch/fetch.cc
@@ -690,7 +690,7 @@ BgFetch::handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
         break;
       }
       PrefetchDebug("Starting background fetch.");
-      dumpHeaders(fetch->_mbuf, fetch->_headerLoc);
+      dumpHeaders(fetch->_headerLoc);
     }
 
     // Setup the NetVC for background fetch

--- a/plugins/prefetch/headers.cc
+++ b/plugins/prefetch/headers.cc
@@ -178,11 +178,10 @@ setHeader(TSMBuffer bufp, TSMLoc hdrLoc, const char *header, int headerlen, cons
  *
  * Useful together with Dbg().
  *
- * @param bufp request's buffer
  * @param hdrLoc request's header location
  */
 void
-dumpHeaders(TSMBuffer bufp, TSMLoc hdrLoc)
+dumpHeaders(TSMLoc hdrLoc)
 {
   TSIOBuffer       output_buffer;
   TSIOBufferReader reader;
@@ -194,7 +193,7 @@ dumpHeaders(TSMBuffer bufp, TSMLoc hdrLoc)
   reader        = TSIOBufferReaderAlloc(output_buffer);
 
   /* This will print  just MIMEFields and not the http request line */
-  TSMimeHdrPrint(bufp, hdrLoc, output_buffer);
+  TSMimeHdrPrint(hdrLoc, output_buffer);
 
   /* We need to loop over all the buffer blocks, there can be more than 1 */
   block = TSIOBufferReaderStart(reader);

--- a/plugins/prefetch/headers.h
+++ b/plugins/prefetch/headers.h
@@ -28,4 +28,4 @@ bool  headerExist(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len);
 char *getHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int headerlen, char *value, int *valuelen);
 
 bool setHeader(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len, const char *val, int val_len);
-void dumpHeaders(TSMBuffer bufp, TSMLoc hdr_loc);
+void dumpHeaders(TSMLoc hdr_loc);

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -1524,12 +1524,12 @@ TSMimeHdrPrint(TSMBuffer bufp, TSMLoc obj, TSIOBuffer iobufp)
   sdk_assert((sdk_sanity_check_mime_hdr_handle(obj) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_iocore_structure(iobufp) == TS_SUCCESS);
 
-  MIMEHdrImpl   *mh = _hdr_mloc_to_mime_hdr_impl(obj);
-  MIOBuffer     *b  = (MIOBuffer *)iobufp;
-  IOBufferBlock *blk;
-  int            bufindex;
-  int            tmp, dumpoffset = 0;
-  int            done;
+  MIMEHdrImpl const *mh = _hdr_mloc_to_mime_hdr_impl(obj);
+  MIOBuffer         *b  = (MIOBuffer *)iobufp;
+  IOBufferBlock     *blk;
+  int                bufindex;
+  int                tmp, dumpoffset = 0;
+  int                done;
 
   do {
     blk = b->get_current_block();

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -1516,11 +1516,8 @@ TSMimeHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_obj, TSMBuffer src_bufp, TSMLoc s
 }
 
 void
-TSMimeHdrPrint(TSMBuffer bufp, TSMLoc obj, TSIOBuffer iobufp)
+TSMimeHdrPrint(TSMLoc obj, TSIOBuffer iobufp)
 {
-  // The bufp argument is no longer used, but the assert is left in to verify
-  // the preconditon so that the API contract is not inadvertantly changed.
-  sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert((sdk_sanity_check_mime_hdr_handle(obj) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_iocore_structure(iobufp) == TS_SUCCESS);
 

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -1518,13 +1518,14 @@ TSMimeHdrCopy(TSMBuffer dest_bufp, TSMLoc dest_obj, TSMBuffer src_bufp, TSMLoc s
 void
 TSMimeHdrPrint(TSMBuffer bufp, TSMLoc obj, TSIOBuffer iobufp)
 {
+  // The bufp argument is no longer used, but the assert is left in to verify
+  // the preconditon so that the API contract is not inadvertantly changed.
   sdk_assert(sdk_sanity_check_mbuffer(bufp) == TS_SUCCESS);
   sdk_assert((sdk_sanity_check_mime_hdr_handle(obj) == TS_SUCCESS) || (sdk_sanity_check_http_hdr_handle(obj) == TS_SUCCESS));
   sdk_assert(sdk_sanity_check_iocore_structure(iobufp) == TS_SUCCESS);
 
-  HdrHeap       *heap = ((HdrHeapSDKHandle *)bufp)->m_heap;
-  MIMEHdrImpl   *mh   = _hdr_mloc_to_mime_hdr_impl(obj);
-  MIOBuffer     *b    = (MIOBuffer *)iobufp;
+  MIMEHdrImpl   *mh = _hdr_mloc_to_mime_hdr_impl(obj);
+  MIOBuffer     *b  = (MIOBuffer *)iobufp;
   IOBufferBlock *blk;
   int            bufindex;
   int            tmp, dumpoffset = 0;
@@ -1539,7 +1540,7 @@ TSMimeHdrPrint(TSMBuffer bufp, TSMLoc obj, TSIOBuffer iobufp)
 
     bufindex = 0;
     tmp      = dumpoffset;
-    done     = mime_hdr_print(heap, mh, blk->end(), blk->write_avail(), &bufindex, &tmp);
+    done     = mime_hdr_print(mh, blk->end(), blk->write_avail(), &bufindex, &tmp);
 
     dumpoffset += bufindex;
     b->fill(bufindex);

--- a/src/proxy/hdrs/HTTP.cc
+++ b/src/proxy/hdrs/HTTP.cc
@@ -429,7 +429,7 @@ http_version_print(const HTTPVersion &version, char *buf, int bufsize, int *bufi
   -------------------------------------------------------------------------*/
 
 int
-http_hdr_print(HTTPHdrImpl *hdr, char *buf, int bufsize, int *bufindex, int *dumpoffset)
+http_hdr_print(HTTPHdrImpl const *hdr, char *buf, int bufsize, int *bufindex, int *dumpoffset)
 {
 #define TRY(x) \
   if (!x)      \

--- a/src/proxy/hdrs/HTTP.cc
+++ b/src/proxy/hdrs/HTTP.cc
@@ -429,7 +429,7 @@ http_version_print(const HTTPVersion &version, char *buf, int bufsize, int *bufi
   -------------------------------------------------------------------------*/
 
 int
-http_hdr_print(HdrHeap * /* heap ATS_UNUSED */, HTTPHdrImpl *hdr, char *buf, int bufsize, int *bufindex, int *dumpoffset)
+http_hdr_print(HTTPHdrImpl *hdr, char *buf, int bufsize, int *bufindex, int *dumpoffset)
 {
 #define TRY(x) \
   if (!x)      \

--- a/src/proxy/hdrs/HTTP.cc
+++ b/src/proxy/hdrs/HTTP.cc
@@ -429,7 +429,7 @@ http_version_print(const HTTPVersion &version, char *buf, int bufsize, int *bufi
   -------------------------------------------------------------------------*/
 
 int
-http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hdr, char *buf, int bufsize, int *bufindex, int *dumpoffset)
+http_hdr_print(HdrHeap * /* heap ATS_UNUSED */, HTTPHdrImpl *hdr, char *buf, int bufsize, int *bufindex, int *dumpoffset)
 {
 #define TRY(x) \
   if (!x)      \
@@ -484,7 +484,7 @@ http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hdr, char *buf, int bufsize, int *buf
         TRY(mime_mem_print("\r\n", 2, buf, bufsize, bufindex, dumpoffset));
       }
 
-      TRY(mime_hdr_print(heap, hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
+      TRY(mime_hdr_print(hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
 
     } else {
       TRY(mime_mem_print(hdr->u.req.m_ptr_method, hdr->u.req.m_len_method, buf, bufsize, bufindex, dumpoffset));
@@ -500,7 +500,7 @@ http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hdr, char *buf, int bufsize, int *buf
 
       TRY(mime_mem_print("\r\n", 2, buf, bufsize, bufindex, dumpoffset));
 
-      TRY(mime_hdr_print(heap, hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
+      TRY(mime_hdr_print(hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
     }
 
   } else { //  hdr->m_polarity == HTTP_TYPE_RESPONSE
@@ -540,7 +540,7 @@ http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hdr, char *buf, int bufsize, int *buf
         TRY(mime_mem_print("\r\n", 2, buf, bufsize, bufindex, dumpoffset));
       }
 
-      TRY(mime_hdr_print(heap, hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
+      TRY(mime_hdr_print(hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
 
     } else {
       TRY(http_version_print(hdr->m_version, buf, bufsize, bufindex, dumpoffset));
@@ -559,7 +559,7 @@ http_hdr_print(HdrHeap *heap, HTTPHdrImpl *hdr, char *buf, int bufsize, int *buf
 
       TRY(mime_mem_print("\r\n", 2, buf, bufsize, bufindex, dumpoffset));
 
-      TRY(mime_hdr_print(heap, hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
+      TRY(mime_hdr_print(hdr->m_fields_impl, buf, bufsize, bufindex, dumpoffset));
     }
   }
 

--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -2710,11 +2710,11 @@ mime_field_block_describe(HdrHeapObjImpl *raw, bool /* recurse ATS_UNUSED */)
 }
 
 int
-mime_hdr_print(MIMEHdrImpl *mh, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
+mime_hdr_print(MIMEHdrImpl const *mh, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
 {
-  MIMEFieldBlockImpl *fblock;
-  MIMEField          *field;
-  uint32_t            index;
+  MIMEFieldBlockImpl const *fblock;
+  MIMEField const          *field;
+  uint32_t                  index;
 
 #define SIMPLE_MIME_HDR_PRINT
 #ifdef SIMPLE_MIME_HDR_PRINT
@@ -2824,7 +2824,7 @@ mime_mem_print_lc(const char *src_d, int src_l, char *buf_start, int buf_length,
 }
 
 int
-mime_field_print(MIMEField *field, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
+mime_field_print(MIMEField const *field, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
 {
 #define TRY(x) \
   if (!x)      \

--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -2710,8 +2710,7 @@ mime_field_block_describe(HdrHeapObjImpl *raw, bool /* recurse ATS_UNUSED */)
 }
 
 int
-mime_hdr_print(HdrHeap * /* heap ATS_UNUSED */, MIMEHdrImpl *mh, char *buf_start, int buf_length, int *buf_index_inout,
-               int *buf_chars_to_skip_inout)
+mime_hdr_print(MIMEHdrImpl *mh, char *buf_start, int buf_length, int *buf_index_inout, int *buf_chars_to_skip_inout)
 {
   MIMEFieldBlockImpl *fblock;
   MIMEField          *field;

--- a/src/proxy/hdrs/unit_tests/test_HdrUtils.cc
+++ b/src/proxy/hdrs/unit_tests/test_HdrUtils.cc
@@ -158,7 +158,7 @@ TEST_CASE("HdrUtils 2", "[proxy][hdrutils]")
 
   int  idx   = 0;
   int  skip  = 0;
-  auto parse = mime_hdr_print(heap, mime.m_mime, buff, static_cast<int>(sizeof(buff)), &idx, &skip);
+  auto parse = mime_hdr_print(mime.m_mime, buff, static_cast<int>(sizeof(buff)), &idx, &skip);
   REQUIRE(parse != 0);
   REQUIRE(idx == static_cast<int>(text.size()));
   REQUIRE(0 == memcmp(swoc::TextView(buff, idx), text));
@@ -201,7 +201,7 @@ TEST_CASE("HdrUtils 3", "[proxy][hdrutils]")
 
   int  idx   = 0;
   int  skip  = 0;
-  auto parse = mime_hdr_print(heap, mime.m_mime, buff, static_cast<int>(sizeof(buff)), &idx, &skip);
+  auto parse = mime_hdr_print(mime.m_mime, buff, static_cast<int>(sizeof(buff)), &idx, &skip);
   REQUIRE(parse != 0);
   REQUIRE(idx == static_cast<int>(text.size()));
   REQUIRE(0 == memcmp(swoc::TextView(buff, idx), text));

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -6599,7 +6599,7 @@ HttpSM::setup_server_send_request()
     t_state.hdr_info.server_request.value_set_int64(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH, msg_len);
   }
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, &(t_state.hdr_info.server_request), sm_id, "Proxy's Request after hooks");
+  dump_header(dbg_ctl_http_hdrs, &(t_state.hdr_info.server_request), sm_id, "Proxy's Request after hooks");
 
   // We need a reader so bytes don't fall off the end of
   //  the buffer
@@ -8483,7 +8483,7 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
     }
   }
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, &t_state.hdr_info.client_request, sm_id, "Framed Client Request..checking");
+  dump_header(dbg_ctl_http_hdrs, &t_state.hdr_info.client_request, sm_id, "Framed Client Request..checking");
 }
 
 void

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1022,7 +1022,7 @@ HttpTransact::StartRemapRequest(State *s)
     TxnDbg(dbg_ctl_http_trans, "Before Remapping:");
     obj_describe(s->hdr_info.client_request.m_http, true);
   }
-  DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.client_request, s->state_machine_id(), "Incoming Request");
+  dump_header(dbg_ctl_http_hdrs, &s->hdr_info.client_request, s->state_machine_id(), "Incoming Request");
 
   if (s->http_config_param->referer_filter_enabled) {
     s->filter_mask = URL_REMAP_FILTER_REFERER;
@@ -2264,9 +2264,9 @@ HttpTransact::HandlePushResponseHdr(State *s)
   s->hdr_info.server_request.method_set(HTTP_METHOD_GET, HTTP_LEN_GET);
   s->hdr_info.server_request.value_set("X-Inktomi-Source", 16, "http PUSH", 9);
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.server_response, s->state_machine_id(), "Pushed Response Header");
+  dump_header(dbg_ctl_http_hdrs, &s->hdr_info.server_response, s->state_machine_id(), "Pushed Response Header");
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Generated Request Header");
+  dump_header(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Generated Request Header");
 
   s->response_received_time = s->request_sent_time = ink_local_time();
 
@@ -2447,7 +2447,7 @@ HttpTransact::issue_revalidate(State *s)
     // the client has the right credentials
     // this cache action is just to get us into the hcoofsr function
     s->cache_info.action = CACHE_DO_UPDATE;
-    DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Proxy's Request (Conditionalized)");
+    dump_header(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Proxy's Request (Conditionalized)");
     return;
   }
 
@@ -2520,7 +2520,7 @@ HttpTransact::issue_revalidate(State *s)
       if (str) {
         s->hdr_info.server_request.value_set(MIME_FIELD_IF_MODIFIED_SINCE, MIME_LEN_IF_MODIFIED_SINCE, str, length);
       }
-      DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Proxy's Request (Conditionalized)");
+      dump_header(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Proxy's Request (Conditionalized)");
     }
     // if Etag exists, also add if-non-match header
     if (c_resp->presence(MIME_PRESENCE_ETAG) && (s->hdr_info.server_request.method_get_wksidx() == HTTP_WKSIDX_GET ||
@@ -2534,7 +2534,7 @@ HttpTransact::issue_revalidate(State *s)
         }
         s->hdr_info.server_request.value_set(MIME_FIELD_IF_NONE_MATCH, MIME_LEN_IF_NONE_MATCH, etag, length);
       }
-      DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Proxy's Request (Conditionalized)");
+      dump_header(dbg_ctl_http_hdrs, &s->hdr_info.server_request, s->state_machine_id(), "Proxy's Request (Conditionalized)");
     }
     break;
   case HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION: // 203
@@ -3430,7 +3430,7 @@ HttpTransact::HandleResponse(State *s)
   s->current.now = s->response_received_time;
 
   TxnDbg(dbg_ctl_http_trans, "response_received_time: %" PRId64, (int64_t)s->response_received_time);
-  DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.server_response, s->state_machine_id(), "Incoming O.S. Response");
+  dump_header(dbg_ctl_http_hdrs, &s->hdr_info.server_response, s->state_machine_id(), "Incoming O.S. Response");
 
   Metrics::Counter::increment(http_rsb.incoming_responses);
 
@@ -4074,7 +4074,7 @@ HttpTransact::build_response_copy(State *s, HTTPHdr *base_response, HTTPHdr *out
   HttpTransactHeaders::convert_response(outgoing_version, outgoing_response); // http version conversion
   HttpTransactHeaders::add_server_header_to_response(s->txn_conf, outgoing_response);
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, outgoing_response, s->state_machine_id(), "Proxy's Response");
+  dump_header(dbg_ctl_http_hdrs, outgoing_response, s->state_machine_id(), "Proxy's Response");
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -4616,7 +4616,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
                                                  warn_text, strlen(warn_text));
     }
 
-    DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.client_response, s->state_machine_id(), "Proxy's Response (Client Conditionals)");
+    dump_header(dbg_ctl_http_hdrs, &s->hdr_info.client_response, s->state_machine_id(), "Proxy's Response (Client Conditionals)");
     return;
   }
   // all other responses (not 304, 412, 416) are handled here
@@ -4839,7 +4839,7 @@ HttpTransact::handle_transform_ready(State *s)
   s->pre_transform_source = s->source;
   s->source               = SOURCE_TRANSFORM;
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.transform_response, s->state_machine_id(), "Header From Transform");
+  dump_header(dbg_ctl_http_hdrs, &s->hdr_info.transform_response, s->state_machine_id(), "Header From Transform");
 
   build_response(s, &s->hdr_info.transform_response, &s->hdr_info.client_response, s->client_info.http_version);
 
@@ -4887,7 +4887,7 @@ HttpTransact::set_header_for_transform(State *s, HTTPHdr *base_header)
   //   in the chain
   s->hdr_info.transform_response.field_delete(MIME_FIELD_CONTENT_LENGTH, MIME_LEN_CONTENT_LENGTH);
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, &s->hdr_info.transform_response, s->state_machine_id(), "Header To Transform");
+  dump_header(dbg_ctl_http_hdrs, &s->hdr_info.transform_response, s->state_machine_id(), "Header To Transform");
 }
 
 void
@@ -4947,7 +4947,7 @@ HttpTransact::set_headers_for_cache_write(State *s, HTTPInfo *cache_info, HTTPHd
     cache_info->response_get()->field_delete(MIME_FIELD_WWW_AUTHENTICATE, MIME_LEN_WWW_AUTHENTICATE);
   }
 
-  DUMP_HEADER(dbg_ctl_http_hdrs, cache_info->request_get(), s->state_machine_id(), "Cached Request Hdr");
+  dump_header(dbg_ctl_http_hdrs, cache_info->request_get(), s->state_machine_id(), "Cached Request Hdr");
 }
 
 void
@@ -7770,7 +7770,7 @@ HttpTransact::build_request(State *s, HTTPHdr *base_request, HTTPHdr *outgoing_r
   ink_assert(s->request_sent_time >= s->response_received_time);
 
   TxnDbg(dbg_ctl_http_trans, "request_sent_time: %" PRId64, (int64_t)s->request_sent_time);
-  DUMP_HEADER(dbg_ctl_http_hdrs, outgoing_request, s->state_machine_id(), "Proxy's Request");
+  dump_header(dbg_ctl_http_hdrs, outgoing_request, s->state_machine_id(), "Proxy's Request");
 
   Metrics::Counter::increment(http_rsb.outgoing_requests);
 }
@@ -7943,10 +7943,10 @@ HttpTransact::build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing
 
   if (dbg_ctl_http_hdrs.on()) {
     if (base_response) {
-      DUMP_HEADER(dbg_ctl_http_hdrs, base_response, s->state_machine_id(), "Base Header for Building Response");
+      dump_header(dbg_ctl_http_hdrs, base_response, s->state_machine_id(), "Base Header for Building Response");
     }
 
-    DUMP_HEADER(dbg_ctl_http_hdrs, outgoing_response, s->state_machine_id(), "Proxy's Response 2");
+    dump_header(dbg_ctl_http_hdrs, outgoing_response, s->state_machine_id(), "Proxy's Response 2");
   }
 
   return;


### PR DESCRIPTION
The output of the `DUMP_HEADER` macro was being written in multiple calls to
fprintf() that raced with other logging, resulting in interleaved output that
intermittently failed the ja3_fingerprint AuTest on CI. Whether other AuTest
failures were related to the same issue is unknown at this point.

This fixes the race condition by batching the calls to a single fprintf() call.
This also refactors the macro to two inline functions. In a benchmark using an
expanded version of the headers in the HttpTransact tests, a 60% speedup was
measured over the macro if all the header data fit in the buffer. In the worst
case that the buffer could only hold a byte at a time, the speedup was 80%.
The benchmark was compiled with -O3 and stderr was piped to /dev/null.

These were the headers used for the benchmark:
```
  header input1[] = {
    {"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "111111111111111111111111"},
    {"BBB",                               "222"                     },
    {"CCC",                               "333"                     },
    {"DDD",                               "333"                     },
    {"EEE",                               "333"                     },
    {"FFF",                               "333"                     },
    {"GGG",                               "333"                     },
    {"HHH",                               "333"                     },
    {"III",                               "333"                     },
    {"JJJ",                               "333"                     },
    {"KKK",                               "333"                     },
  };
```

This fixes https://github.com/apache/trafficserver/issues/11431.