### PR TITLE
Update magick plugin to OpenSSL 1.1.1 API

### DIFF
--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -237,12 +237,13 @@ verify(const byte *const msg, const size_t mlen, const byte *const sig, const si
     return false;
   }
 
-  const int rc = EVP_DigestVerify(evp.context, sig, slen, msg, mlen);
-  if (1 == rc) {
+  if (const int rc = EVP_DigestVerify(evp.context, sig, slen, msg, mlen); 1 == rc) {
     return true;
-  } else if (0 == rc) {
-    return false;
   } else {
+    // The OpenSSL 1.1.1 API distinguishes between a verification failure and a
+    // more serious error with a specific return value for the former, but we
+    // have collapsed them into one case because we don't do any special
+    // handling for serious errors.
     ssl_error();
     return false;
   }

--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -237,7 +237,7 @@ verify(const byte *const msg, const size_t mlen, const byte *const sig, const si
     return false;
   }
 
-  if (const int rc = EVP_DigestVerify(evp.context, sig, slen, msg, mlen); 1 == rc) {
+  const int rc = EVP_DigestVerify(evp.context, sig, slen, msg, mlen);
   if (1 == rc) {
     return true;
   } else if (0 == rc) {

--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -209,7 +209,7 @@ static void
 ssl_error()
 {
   if (unsigned long error_code{ERR_get_error()}; 0 != error_code) {
-    if (char const *reason{ERR_lib_error_string(error_code)}; NULL == reason) {
+    if (char const *reason{ERR_reason_error_string(error_code)}; NULL == reason) {
       Dbg(dbg_ctl, "SSL error: error code %lu", error_code);
     } else {
       Dbg(dbg_ctl, "SSL error: %s", reason);
@@ -237,7 +237,7 @@ verify(const byte *const msg, const size_t mlen, const byte *const sig, const si
     return false;
   }
 
-  const int rc = EVP_DigestVerify(evp.context, sig, slen, msg, mlen);
+  if (const int rc = EVP_DigestVerify(evp.context, sig, slen, msg, mlen); 1 == rc) {
   if (1 == rc) {
     return true;
   } else if (0 == rc) {

--- a/plugins/experimental/magick/magick.cc
+++ b/plugins/experimental/magick/magick.cc
@@ -176,10 +176,10 @@ struct EVPContext {
   ~EVPContext()
   {
     assert(nullptr != context);
-    EVP_MD_CTX_destroy(context);
+    EVP_MD_CTX_free(context);
   }
 
-  EVPContext() : context(EVP_MD_CTX_create()) { assert(nullptr != context); }
+  EVPContext() : context(EVP_MD_CTX_new()) { assert(nullptr != context); }
 };
 
 struct EVPKey {
@@ -226,19 +226,17 @@ verify(const byte *const msg, const size_t mlen, const byte *const sig, const si
     }
   }
 
-  {
-    const int rc = EVP_DigestVerifyUpdate(evp.context, msg, mlen);
-    assert(1 == rc);
-    if (1 != rc) {
-      return false;
-    }
-  }
-
   ERR_clear_error();
 
   {
-    const int rc = EVP_DigestVerifyFinal(evp.context, sig, slen);
-    return 1 == rc;
+    const int rc = EVP_DigestVerify(evp.context, sig, slen, msg, mlen);
+    if (1 == rc) {
+      return true;
+    } else if (0 == rc) {
+      return false;
+    } else {
+      return false;
+    }
   }
 
   return false;


### PR DESCRIPTION
The functions `EVP_MD_CTX_create` and `EVP_MD_CTX_destroy` were renamed to `EVP_MD_CTX_new` and `EVP_MD_CTX_free` in OpenSSL 1.1.0. This renames them in the magick plugin accordingly. This also replaces the individual calls to `EVP_DigestVerifyUpdate` and `EVP_DigestVerifyFinal` with a single call to `EVP_DigestVerify` which is available in OpenSSL 1.1.1.