### PR TITLE
LSan: Suppress libssl.so leak for verify_global_magick unit test

### DIFF
--- a/plugins/experimental/magick/image_magic_dlopen_leak_suppression.txt
+++ b/plugins/experimental/magick/image_magic_dlopen_leak_suppression.txt
@@ -20,3 +20,4 @@
 # commented out so there was nothing to leak in the plugin.
 leak:plugin_dso_load
 leak:libquiche.so
+leak:libssl.so


### PR DESCRIPTION
Suppress the leak we're facing on PRB.

```
117/136 Test #114: verify_global_magick ...................***Failed    0.35 sec
[Jun 12 13:10:18.447] traffic_server NOTE: records parsing completed.
[Jun 12 13:10:18.447] traffic_server NOTE: /tmp/ats-quiche/etc/trafficserver/records.yaml finished loading
[Jun 12 13:10:18.460] traffic_server NOTE: Traffic Server is running unprivileged, not switching to user 'nobody'
NOTE: verifying plugin '/home/jenkins/workspace/Github_Builds/rocky/src/build/plugins/experimental/magick/magick.so'...
NOTE: verifying plugin '/home/jenkins/workspace/Github_Builds/rocky/src/build/plugins/experimental/magick/magick.so' Success

=================================================================
==6867==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7fbb3b08d9a7 in __interceptor_malloc (/lib64/libasan.so.6+0xb49a7)
    #1 0x7fbb31796dcc  (/opt/h3-tools-boringssl/boringssl/lib64/libssl.so+0x715dcc)

SUMMARY: AddressSanitizer: 8 byte(s) leaked in 1 allocation(s).
```