### PR TITLE
Make NetDbg available on releaes builds

### DIFF
--- a/src/iocore/net/P_Net.h
+++ b/src/iocore/net/P_Net.h
@@ -103,9 +103,4 @@ extern NetStatsBlock net_rsb;
 
 static constexpr ts::ModuleVersion NET_SYSTEM_MODULE_INTERNAL_VERSION(NET_SYSTEM_MODULE_PUBLIC_VERSION, ts::ModuleVersion::PRIVATE);
 
-// For very verbose iocore debugging.
-#ifndef DEBUG
-#define NetDbg(dbg_ctl, fmt, ...)
-#else
 #define NetDbg(dbg_ctl, fmt, ...) Dbg(dbg_ctl, fmt, ##__VA_ARGS__)
-#endif

--- a/src/iocore/net/PollCont.cc
+++ b/src/iocore/net/PollCont.cc
@@ -27,12 +27,8 @@
 
 namespace
 {
-#ifdef DEBUG
-
 DbgCtl dbg_ctl_iocore_net_poll{"iocore_net_poll"};
 DbgCtl dbg_ctl_v_iocore_net_poll{"v_iocore_net_poll"};
-
-#endif
 } // end anonymous namespace
 
 PollCont::PollCont(Ptr<ProxyMutex> &m, int pt)


### PR DESCRIPTION
Autest quic_poll_timeout fails on release builds because the test relies on the debug output.