### PR TITLE
Fix unused parameters in iocore

### DIFF
--- a/include/iocore/eventsystem/Lock.h
+++ b/include/iocore/eventsystem/Lock.h
@@ -240,7 +240,7 @@ public:
 
   */
   void
-  init(const char * /* name  ATS_UNUSED */ = "UnnamedMutex")
+  init()
   {
     ink_mutex_init(&the_mutex);
   }

--- a/include/iocore/eventsystem/Lock.h
+++ b/include/iocore/eventsystem/Lock.h
@@ -240,7 +240,7 @@ public:
 
   */
   void
-  init(const char *name = "UnnamedMutex")
+  init(const char * /* name  ATS_UNUSED */ = "UnnamedMutex")
   {
     ink_mutex_init(&the_mutex);
   }

--- a/include/iocore/net/NetVConnection.h
+++ b/include/iocore/net/NetVConnection.h
@@ -466,13 +466,13 @@ public:
   }
 
   virtual int
-  populate_protocol(std::string_view *results, int n) const
+  populate_protocol(std::string_view * /* results ATS_UNUSED */, int /* n ATS_UNUSED */) const
   {
     return 0;
   }
 
   virtual const char *
-  protocol_contains(std::string_view prefix) const
+  protocol_contains(std::string_view /* prefix ATS_UNUSED */) const
   {
     return nullptr;
   }

--- a/include/iocore/net/SNIActionItem.h
+++ b/include/iocore/net/SNIActionItem.h
@@ -63,7 +63,8 @@ public:
     the host name to avoid SNI-based policy
   */
   virtual bool
-  TestClientSNIAction(const char *servername, const IpEndpoint &ep, int &policy) const
+  TestClientSNIAction(const char * /* servername ATS_UNUSED */, const IpEndpoint & /* ep ATS_UNUSED */,
+                      int & /* policy ATS_UNUSED */) const
   {
     return false;
   }

--- a/include/iocore/net/TLSALPNSupport.h
+++ b/include/iocore/net/TLSALPNSupport.h
@@ -46,8 +46,8 @@ public:
   void clear();
   bool setSelectedProtocol(const unsigned char *proto, unsigned int len);
 
-  int advertise_next_protocol(SSL *ssl, const unsigned char **out, unsigned *outlen);
-  int select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned inlen);
+  int advertise_next_protocol(const unsigned char **out, unsigned *outlen);
+  int select_next_protocol(const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned inlen);
 
   Continuation *
   endpoint() const

--- a/include/iocore/net/TLSSessionResumptionSupport.h
+++ b/include/iocore/net/TLSSessionResumptionSupport.h
@@ -53,7 +53,7 @@ public:
   ssl_curve_id getSSLCurveNID() const;
 
   SSL_SESSION                 *getSession(SSL *ssl, const unsigned char *id, int len, int *copy);
-  std::shared_ptr<SSL_SESSION> getOriginSession(SSL *ssl, const std::string &lookup_key);
+  std::shared_ptr<SSL_SESSION> getOriginSession(const std::string &lookup_key);
 
 protected:
   void                      clear();
@@ -67,13 +67,13 @@ private:
   int  _sslCurveNID              = NID_undef;
 
 #ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
-  int _setSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
-                             EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx);
+  int _setSessionInformation(ssl_ticket_key_block *keyblock, unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
+                             EVP_MAC_CTX *hctx);
   int _getSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
                              EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx);
 #else
-  int _setSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
-                             EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx);
+  int _setSessionInformation(ssl_ticket_key_block *keyblock, unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
+                             HMAC_CTX *hctx);
   int _getSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname, unsigned char *iv,
                              EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx);
 #endif

--- a/src/iocore/aio/AIO.cc
+++ b/src/iocore/aio/AIO.cc
@@ -103,7 +103,7 @@ ink_aio_set_err_callback(Continuation *callback)
 }
 
 void
-ink_aio_init(ts::ModuleVersion v, AIOBackend backend)
+ink_aio_init(ts::ModuleVersion v, [[maybe_unused]] AIOBackend backend)
 {
   ink_release_assert(v.check(AIO_MODULE_INTERNAL_VERSION));
 

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -1844,7 +1844,8 @@ Cache::key_to_stripe(const CacheKey *key, const char *hostname, int host_len)
 }
 
 int
-FragmentSizeUpdateCb(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data, void *cookie)
+FragmentSizeUpdateCb(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data,
+                     void * /* cookie ATS_UNUSED */)
 {
   if (sizeof(Doc) >= static_cast<size_t>(data.rec_int) || static_cast<size_t>(data.rec_int) - sizeof(Doc) > MAX_FRAG_SIZE) {
     Warning("The fragments size exceed the limitation, ignore: %" PRId64 ", %d", data.rec_int, cache_config_target_fragment_size);
@@ -1971,15 +1972,16 @@ ink_cache_init(ts::ModuleVersion v)
 //----------------------------------------------------------------------------
 Action *
 CacheProcessor::open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request, const HttpConfigAccessor *params,
-                          time_t pin_in_cache, CacheFragType type)
+                          time_t /* pin_in_cache ATS_UNUSED */, CacheFragType type)
 {
   return caches[type]->open_read(cont, &key->hash, request, params, type, key->hostname, key->hostlen);
 }
 
 //----------------------------------------------------------------------------
 Action *
-CacheProcessor::open_write(Continuation *cont, int expected_size, const HttpCacheKey *key, CacheHTTPHdr *request,
-                           CacheHTTPInfo *old_info, time_t pin_in_cache, CacheFragType type)
+CacheProcessor::open_write(Continuation *cont, int /* expected_size ATS_UNUSED */, const HttpCacheKey *key,
+                           CacheHTTPHdr * /* request ATS_UNUSED */, CacheHTTPInfo *old_info, time_t pin_in_cache,
+                           CacheFragType type)
 {
   return caches[type]->open_write(cont, &key->hash, old_info, pin_in_cache, nullptr /* key1 */, type, key->hostname, key->hostlen);
 }

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -1312,7 +1312,7 @@ Learliest:
    Handle a directory delete event in case of some detected corruption.
 */
 int
-CacheVC::openReadDirDelete(int event, Event *e)
+CacheVC::openReadDirDelete(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
   MUTEX_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
   if (!lock.is_locked()) {

--- a/src/iocore/cache/RamCacheLRU.cc
+++ b/src/iocore/cache/RamCacheLRU.cc
@@ -179,7 +179,7 @@ RamCacheLRU::remove(RamCacheLRUEntry *e)
 
 // ignore 'copy' since we don't touch the data
 int
-RamCacheLRU::put(CryptoHash *key, IOBufferData *data, uint32_t /* len ATS_UNUSED */, bool, uint64_t auxkey)
+RamCacheLRU::put(CryptoHash *key, IOBufferData *data, [[maybe_unused]] uint32_t len, bool, uint64_t auxkey)
 {
   if (!max_bytes) {
     return 0;

--- a/src/iocore/cache/RamCacheLRU.cc
+++ b/src/iocore/cache/RamCacheLRU.cc
@@ -179,7 +179,7 @@ RamCacheLRU::remove(RamCacheLRUEntry *e)
 
 // ignore 'copy' since we don't touch the data
 int
-RamCacheLRU::put(CryptoHash *key, IOBufferData *data, uint32_t len, bool, uint64_t auxkey)
+RamCacheLRU::put(CryptoHash *key, IOBufferData *data, uint32_t /* len ATS_UNUSED */, bool, uint64_t auxkey)
 {
   if (!max_bytes) {
     return 0;

--- a/src/iocore/cache/unit_tests/CacheTestHandler.cc
+++ b/src/iocore/cache/unit_tests/CacheTestHandler.cc
@@ -81,7 +81,7 @@ CacheTestHandler::handle_cache_event(int event, CacheTestBase *base)
 }
 
 int
-CacheTestHandler::start_test(int event, void *e)
+CacheTestHandler::start_test(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */)
 {
   this_ethread()->schedule_imm(this->_wt);
   return 0;

--- a/src/iocore/cache/unit_tests/CacheTestHandler.h
+++ b/src/iocore/cache/unit_tests/CacheTestHandler.h
@@ -86,14 +86,14 @@ public:
   ~TerminalTest() { TEST_DONE(); }
 
   int
-  terminal_event(int event, void *e)
+  terminal_event(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */)
   {
     delete this;
     return 0;
   }
 
   void
-  handle_cache_event(int event, CacheTestBase *e) override
+  handle_cache_event(int /* event ATS_UNUSED */, CacheTestBase * /* e ATS_UNUSED */) override
   {
     delete this;
   }

--- a/src/iocore/cache/unit_tests/main.cc
+++ b/src/iocore/cache/unit_tests/main.cc
@@ -162,7 +162,7 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
 CATCH_REGISTER_LISTENER(EventProcessorListener);
 
 void
-init_cache(size_t size, const char *name)
+init_cache(size_t /* size ATS_UNUSED */, const char * /* name ATS_UNUSED */)
 {
   ink_cache_init(ts::ModuleVersion(1, 0, ts::ModuleVersion::PRIVATE));
   cacheProcessor.start();
@@ -284,7 +284,7 @@ CacheWriteTest::do_io_write(size_t size)
 }
 
 int
-CacheWriteTest::start_test(int event, void *e)
+CacheWriteTest::start_test(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */)
 {
   Dbg(dbg_ctl_cache_test, "start write test");
 
@@ -354,7 +354,7 @@ CacheReadTest::do_io_read(size_t size)
 }
 
 int
-CacheReadTest::start_test(int event, void *e)
+CacheReadTest::start_test(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */)
 {
   Dbg(dbg_ctl_cache_test, "start read test");
   HttpCacheKey key;

--- a/src/iocore/cache/unit_tests/main.h
+++ b/src/iocore/cache/unit_tests/main.h
@@ -141,7 +141,7 @@ public:
   }
 
   int
-  terminal_event(int event, void *e)
+  terminal_event(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */)
   {
     delete this;
     return 0;
@@ -163,13 +163,13 @@ public:
   }
 
   virtual void
-  do_io_read(size_t size = 0)
+  do_io_read(size_t /* size  ATS_UNUSED */ = 0)
   {
     REQUIRE(!"should not be called");
   }
 
   virtual void
-  do_io_write(size_t size = 0)
+  do_io_write(size_t /* size  ATS_UNUSED */ = 0)
   {
     REQUIRE(!"should not be called");
   }

--- a/src/iocore/cache/unit_tests/stub.cc
+++ b/src/iocore/cache/unit_tests/stub.cc
@@ -28,7 +28,8 @@
 #include "proxy/HttpAPIHooks.h"
 
 void
-HttpHookState::init(TSHttpHookID id, HttpAPIHooks const *global, HttpAPIHooks const *ssn, HttpAPIHooks const *txn)
+HttpHookState::init(TSHttpHookID /* id ATS_UNUSED */, HttpAPIHooks const * /* global ATS_UNUSED */,
+                    HttpAPIHooks const * /* ssn ATS_UNUSED */, HttpAPIHooks const * /* txn ATS_UNUSED */)
 {
 }
 
@@ -44,7 +45,7 @@ HttpHookState::getNext()
 }
 
 TSVConn
-TSHttpConnectWithPluginId(sockaddr const *addr, const char *tag, int64_t id)
+TSHttpConnectWithPluginId(sockaddr const * /* addr ATS_UNUSED */, const char * /* tag ATS_UNUSED */, int64_t /* id ATS_UNUSED */)
 {
   return TSVConn{};
 }
@@ -53,25 +54,26 @@ int         TS_MIME_LEN_CONTENT_LENGTH   = 0;
 const char *TS_MIME_FIELD_CONTENT_LENGTH = "";
 
 TSIOBufferBlock
-TSIOBufferReaderStart(TSIOBufferReader readerp)
+TSIOBufferReaderStart(TSIOBufferReader /* readerp ATS_UNUSED */)
 {
   return TSIOBufferBlock{};
 }
 
 TSIOBufferBlock
-TSIOBufferBlockNext(TSIOBufferBlock blockp)
+TSIOBufferBlockNext(TSIOBufferBlock /* blockp ATS_UNUSED */)
 {
   return TSIOBufferBlock{};
 }
 
 const char *
-TSIOBufferBlockReadStart(TSIOBufferBlock blockp, TSIOBufferReader readerp, int64_t *avail)
+TSIOBufferBlockReadStart(TSIOBufferBlock /* blockp ATS_UNUSED */, TSIOBufferReader /* readerp ATS_UNUSED */,
+                         int64_t * /* avail ATS_UNUSED */)
 {
   return "";
 }
 
 void
-TSIOBufferReaderConsume(TSIOBufferReader readerp, int64_t nbytes)
+TSIOBufferReaderConsume(TSIOBufferReader /* readerp ATS_UNUSED */, int64_t /* nbytes ATS_UNUSED */)
 {
 }
 

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S.cc
@@ -41,7 +41,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -109,7 +109,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_wt);
@@ -167,7 +167,7 @@ class CacheAltInit : public CacheInit
 public:
   CacheAltInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler    *h    = new CacheTestHandler(LARGE_FILE, "http://www.scw11.com");
     CacheAltTest_L_to_S *ls   = new CacheAltTest_L_to_S(SMALL_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_L.cc
@@ -52,7 +52,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -105,7 +105,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -113,7 +113,7 @@ public:
   }
 
   void
-  handle_cache_event(int event, CacheTestBase *base) override
+  handle_cache_event(int event, CacheTestBase * /* base ATS_UNUSED */) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -166,7 +166,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_wt);
@@ -235,7 +235,7 @@ class CacheAltInit : public CacheInit
 public:
   CacheAltInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler             *h     = new CacheTestHandler(LARGE_FILE, "http://www.scw11.com");
     CacheAltTest_L_to_S_remove_L *ls    = new CacheAltTest_L_to_S_remove_L(SMALL_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_S.cc
@@ -45,7 +45,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -106,7 +106,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -114,7 +114,7 @@ public:
   }
 
   void
-  handle_cache_event(int event, CacheTestBase *base) override
+  handle_cache_event(int event, CacheTestBase * /* base ATS_UNUSED */) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -167,7 +167,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_wt);
@@ -236,7 +236,7 @@ class CacheAltInit : public CacheInit
 public:
   CacheAltInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler             *h     = new CacheTestHandler(LARGE_FILE, "http://www.scw11.com");
     CacheAltTest_L_to_S_remove_S *ls    = new CacheAltTest_L_to_S_remove_S(SMALL_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L.cc
@@ -41,7 +41,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -109,7 +109,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_wt);
@@ -169,7 +169,7 @@ class CacheAltInit : public CacheInit
 public:
   CacheAltInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler    *h    = new CacheTestHandler(SMALL_FILE, "http://www.scw11.com");
     CacheAltTest_L_to_S *ls   = new CacheAltTest_L_to_S(LARGE_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_L.cc
@@ -45,7 +45,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -106,7 +106,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     // sleep for a while to wait for writer close
@@ -115,7 +115,7 @@ public:
   }
 
   void
-  handle_cache_event(int event, CacheTestBase *base) override
+  handle_cache_event(int event, CacheTestBase * /* base ATS_UNUSED */) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -168,7 +168,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_wt);
@@ -239,7 +239,7 @@ class CacheAltInit : public CacheInit
 public:
   CacheAltInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler             *h     = new CacheTestHandler(SMALL_FILE, "http://www.scw11.com");
     CacheAltTest_S_to_L_remove_L *ls    = new CacheAltTest_S_to_L_remove_L(LARGE_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_S.cc
@@ -52,7 +52,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -105,7 +105,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -113,7 +113,7 @@ public:
   }
 
   void
-  handle_cache_event(int event, CacheTestBase *base) override
+  handle_cache_event(int event, CacheTestBase * /* base ATS_UNUSED */) override
   {
     switch (event) {
     case CACHE_EVENT_OPEN_READ_FAILED:
@@ -166,7 +166,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_wt);
@@ -237,7 +237,7 @@ class CacheAltInit : public CacheInit
 public:
   CacheAltInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler               *h     = new CacheTestHandler(SMALL_FILE, "http://www.scw11.com");
     test_Alternate_S_to_L_remove_S *ls    = new test_Alternate_S_to_L_remove_S(LARGE_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Cache.cc
+++ b/src/iocore/cache/unit_tests/test_Cache.cc
@@ -34,7 +34,7 @@ class CacheCommInit : public CacheInit
 public:
   CacheCommInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler *h  = new CacheTestHandler(LARGE_FILE);
     CacheTestHandler *h2 = new CacheTestHandler(SMALL_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -73,7 +73,7 @@ class CacheDirTest : public CacheInit
 {
 public:
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     ink_hrtime ttime;
 

--- a/src/iocore/cache/unit_tests/test_CacheVol.cc
+++ b/src/iocore/cache/unit_tests/test_CacheVol.cc
@@ -366,7 +366,7 @@ class CacheVolTest : public CacheInit
 {
 public:
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     // Test
     ClearCacheVolList(&cp_list, cp_list_len);

--- a/src/iocore/cache/unit_tests/test_Populated_Cache.cc
+++ b/src/iocore/cache/unit_tests/test_Populated_Cache.cc
@@ -34,7 +34,7 @@ class CacheCommInit : public CacheInit
 public:
   CacheCommInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler *h  = new CacheTestHandler(LARGE_FILE, "http://www.example.com");
     CacheTestHandler *h2 = new CacheTestHandler(SMALL_FILE, "http://www.scw12.com");

--- a/src/iocore/cache/unit_tests/test_RWW.cc
+++ b/src/iocore/cache/unit_tests/test_RWW.cc
@@ -102,7 +102,7 @@ protected:
 };
 
 int
-CacheRWWTest::start_test(int event, void *e)
+CacheRWWTest::start_test(int event, void * /* e ATS_UNUSED */)
 {
   REQUIRE(event == EVENT_IMMEDIATE);
   this_ethread()->schedule_imm(this->_wt);
@@ -402,7 +402,7 @@ class CacheRWWCacheInit : public CacheInit
 public:
   CacheRWWCacheInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheRWWTest      *crww     = new CacheRWWTest(LARGE_FILE);
     CacheRWWErrorTest *crww_l   = new CacheRWWErrorTest(LARGE_FILE, "http://www.scw22.com/");

--- a/src/iocore/cache/unit_tests/test_Update_L_to_S.cc
+++ b/src/iocore/cache/unit_tests/test_Update_L_to_S.cc
@@ -41,7 +41,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -85,7 +85,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -132,7 +132,7 @@ class CacheUpdateInit : public CacheInit
 public:
   CacheUpdateInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler     *h      = new CacheTestHandler(LARGE_FILE, "http://www.scw11.com");
     CacheUpdate_L_to_S   *update = new CacheUpdate_L_to_S(LARGE_FILE, SMALL_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Update_S_to_L.cc
+++ b/src/iocore/cache/unit_tests/test_Update_S_to_L.cc
@@ -41,7 +41,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -87,7 +87,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -134,7 +134,7 @@ class CacheUpdateInit : public CacheInit
 public:
   CacheUpdateInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler     *h      = new CacheTestHandler(SMALL_FILE, "http://www.scw11.com");
     CacheUpdate_S_to_L   *update = new CacheUpdate_S_to_L(SMALL_FILE, LARGE_FILE, "http://www.scw11.com");

--- a/src/iocore/cache/unit_tests/test_Update_header.cc
+++ b/src/iocore/cache/unit_tests/test_Update_header.cc
@@ -47,7 +47,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -118,7 +118,7 @@ public:
   }
 
   int
-  start_test(int event, void *e)
+  start_test(int event, void * /* e ATS_UNUSED */)
   {
     REQUIRE(event == EVENT_IMMEDIATE);
     this_ethread()->schedule_imm(this->_rt);
@@ -161,7 +161,7 @@ class CacheUpdateInit : public CacheInit
 public:
   CacheUpdateInit() {}
   int
-  cache_init_success_callback(int event, void *e) override
+  cache_init_success_callback(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */) override
   {
     CacheTestHandler     *h      = new CacheTestHandler(LARGE_FILE, "http://www.scw11.com");
     CacheUpdateHeader    *update = new CacheUpdateHeader(LARGE_FILE, "http://www.scw11.com");

--- a/src/iocore/dns/DNSEventIO.cc
+++ b/src/iocore/dns/DNSEventIO.cc
@@ -29,7 +29,7 @@ DNSEventIO::start(EventLoop l, int fd, int events)
 }
 
 void
-DNSEventIO::process_event(int flags)
+DNSEventIO::process_event(int /* flags ATS_UNUSED */)
 {
   _c.trigger(); // Make sure the DNSHandler for this con knows we triggered
   refresh(EVENTIO_READ);

--- a/src/iocore/eventsystem/MIOBufferWriter.cc
+++ b/src/iocore/eventsystem/MIOBufferWriter.cc
@@ -76,7 +76,7 @@ MIOBufferWriter::operator>>(std::ostream &stream) const
 }
 
 ssize_t
-MIOBufferWriter::operator>>(int fd) const
+MIOBufferWriter::operator>>(int /* fd ATS_UNUSED */) const
 {
   return 0;
 }

--- a/src/iocore/eventsystem/unit_tests/test_EventSystem.cc
+++ b/src/iocore/eventsystem/unit_tests/test_EventSystem.cc
@@ -85,7 +85,7 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase;
 
   void
-  testRunStarting(Catch::TestRunInfo const &testRunInfo) override
+  testRunStarting(Catch::TestRunInfo const & /* testRunInfo ATS_UNUSED */) override
   {
     Layout::create();
     init_diags("", nullptr);

--- a/src/iocore/eventsystem/unit_tests/test_IOBuffer.cc
+++ b/src/iocore/eventsystem/unit_tests/test_IOBuffer.cc
@@ -379,7 +379,7 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase;
 
   void
-  testRunStarting(Catch::TestRunInfo const &testRunInfo) override
+  testRunStarting(Catch::TestRunInfo const & /* testRunInfo ATS_UNUSED */) override
   {
     Layout::create();
     init_diags("", nullptr);

--- a/src/iocore/eventsystem/unit_tests/test_MIOBufferWriter.cc
+++ b/src/iocore/eventsystem/unit_tests/test_MIOBufferWriter.cc
@@ -194,7 +194,7 @@ TEST_CASE("MIOBufferWriter", "[MIOBW]")
 }
 
 void
-_ink_assert(const char *a, const char *f, int l)
+_ink_assert(const char * /* a ATS_UNUSED */, const char * /* f ATS_UNUSED */, int /* l ATS_UNUSED */)
 {
   // Coverity is confused and thinks this _ink_assert is the one used in traffic_server
   // coverity[UNCAUGHT_EXCEPT:FALSE]

--- a/src/iocore/net/ALPNSupport.cc
+++ b/src/iocore/net/ALPNSupport.cc
@@ -88,7 +88,7 @@ ALPNSupport::setSelectedProtocol(const unsigned char *proto, unsigned int len)
 }
 
 int
-ALPNSupport::advertise_next_protocol(SSL * /* ssl ATS_UNUSED */, const unsigned char **out, unsigned *outlen)
+ALPNSupport::advertise_next_protocol(const unsigned char **out, unsigned *outlen)
 {
   if (this->getNPN(out, outlen)) {
     // Successful return tells OpenSSL to advertise.
@@ -98,8 +98,7 @@ ALPNSupport::advertise_next_protocol(SSL * /* ssl ATS_UNUSED */, const unsigned 
 }
 
 int
-ALPNSupport::select_next_protocol(SSL * /* ssl ATS_UNUSED */, const unsigned char **out, unsigned char *outlen,
-                                  const unsigned char *in, unsigned inlen)
+ALPNSupport::select_next_protocol(const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned inlen)
 {
   const unsigned char *npnptr  = nullptr;
   unsigned int         npnsize = 0;

--- a/src/iocore/net/ALPNSupport.cc
+++ b/src/iocore/net/ALPNSupport.cc
@@ -88,7 +88,7 @@ ALPNSupport::setSelectedProtocol(const unsigned char *proto, unsigned int len)
 }
 
 int
-ALPNSupport::advertise_next_protocol(SSL *ssl, const unsigned char **out, unsigned *outlen)
+ALPNSupport::advertise_next_protocol(SSL * /* ssl ATS_UNUSED */, const unsigned char **out, unsigned *outlen)
 {
   if (this->getNPN(out, outlen)) {
     // Successful return tells OpenSSL to advertise.
@@ -98,8 +98,8 @@ ALPNSupport::advertise_next_protocol(SSL *ssl, const unsigned char **out, unsign
 }
 
 int
-ALPNSupport::select_next_protocol(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
-                                  unsigned inlen)
+ALPNSupport::select_next_protocol(SSL * /* ssl ATS_UNUSED */, const unsigned char **out, unsigned char *outlen,
+                                  const unsigned char *in, unsigned inlen)
 {
   const unsigned char *npnptr  = nullptr;
   unsigned int         npnsize = 0;

--- a/src/iocore/net/AsyncSignalEventIO.cc
+++ b/src/iocore/net/AsyncSignalEventIO.cc
@@ -33,7 +33,7 @@ AsyncSignalEventIO::start(EventLoop l, int fd, int events)
 }
 
 void
-AsyncSignalEventIO::process_event(int flags)
+AsyncSignalEventIO::process_event(int /* flags ATS_UNUSED */)
 {
   [[maybe_unused]] ssize_t ret;
 #if HAVE_EVENTFD

--- a/src/iocore/net/Connection.cc
+++ b/src/iocore/net/Connection.cc
@@ -261,7 +261,6 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
     Dbg(dbg_ctl_iocore_thread, "SO_INCOMING_CPU - fd=%d cpu=%d", fd, cpu);
   }
 #endif
-
   if ((opt.sockopt_flags & NetVCOptions::SOCK_OPT_NO_DELAY) && setsockopt_on(fd, IPPROTO_TCP, TCP_NODELAY) < 0) {
     goto Lerror;
   }
@@ -336,7 +335,7 @@ Lerror:
 }
 
 int
-Server::setup_fd_after_listen(const NetProcessor::AcceptOptions &opt)
+Server::setup_fd_after_listen([[maybe_unused]] const NetProcessor::AcceptOptions &opt)
 {
 #ifdef SO_ACCEPTFILTER
   // SO_ACCEPTFILTER needs to be set **after** listen

--- a/src/iocore/net/ConnectionTracker.cc
+++ b/src/iocore/net/ConnectionTracker.cc
@@ -85,7 +85,7 @@ static_assert(ConnectionTracker::Group::Clock::period::den >= 1000);
 namespace
 {
 bool
-Config_Update_Conntrack_Min(const char *name, RecDataT dtype, RecData data, void *cookie)
+Config_Update_Conntrack_Min(const char * /* name ATS_UNUSED */, RecDataT dtype, RecData data, void *cookie)
 {
   auto config = static_cast<ConnectionTracker::TxnConfig *>(cookie);
 
@@ -97,7 +97,7 @@ Config_Update_Conntrack_Min(const char *name, RecDataT dtype, RecData data, void
 }
 
 bool
-Config_Update_Conntrack_Max(const char *name, RecDataT dtype, RecData data, void *cookie)
+Config_Update_Conntrack_Max(const char * /* name ATS_UNUSED */, RecDataT dtype, RecData data, void *cookie)
 {
   auto config = static_cast<ConnectionTracker::TxnConfig *>(cookie);
 
@@ -109,7 +109,7 @@ Config_Update_Conntrack_Max(const char *name, RecDataT dtype, RecData data, void
 }
 
 bool
-Config_Update_Conntrack_Match(const char *name, RecDataT dtype, RecData data, void *cookie)
+Config_Update_Conntrack_Match(const char * /* name ATS_UNUSED */, RecDataT dtype, RecData data, void *cookie)
 {
   auto config = static_cast<ConnectionTracker::TxnConfig *>(cookie);
 
@@ -129,8 +129,8 @@ Config_Update_Conntrack_Match(const char *name, RecDataT dtype, RecData data, vo
 }
 
 bool
-Config_Update_Conntrack_Server_Alert_Delay_Helper(const char *name, RecDataT dtype, RecData data, void *cookie,
-                                                  std::chrono::seconds &alert_delay)
+Config_Update_Conntrack_Server_Alert_Delay_Helper(const char * /* name ATS_UNUSED */, RecDataT dtype, RecData data,
+                                                  void * /* cookie ATS_UNUSED */, std::chrono::seconds &alert_delay)
 {
   if (RECD_INT == dtype && data.rec_int >= 0) {
     alert_delay = std::chrono::seconds(data.rec_int);
@@ -464,7 +464,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, ConnectionTracker::MatchType ty
 }
 
 BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, ConnectionTracker::Group::Key const &key)
+bwformat(BufferWriter &w, bwf::Spec const & /* spec ATS_UNUSED */, ConnectionTracker::Group::Key const &key)
 {
   switch (key._match_type) {
   case ConnectionTracker::MATCH_BOTH:
@@ -484,7 +484,7 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, ConnectionTracker::Group::Key c
 }
 
 BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, ConnectionTracker::Group const &g)
+bwformat(BufferWriter &w, bwf::Spec const & /* spec ATS_UNUSED */, ConnectionTracker::Group const &g)
 {
   switch (g._match_type) {
   case ConnectionTracker::MATCH_BOTH:

--- a/src/iocore/net/NetAcceptEventIO.cc
+++ b/src/iocore/net/NetAcceptEventIO.cc
@@ -31,7 +31,7 @@ NetAcceptEventIO::start(EventLoop l, NetAccept *na, int events)
   return start_common(l, _na->server.fd, events);
 }
 void
-NetAcceptEventIO::process_event(int flags)
+NetAcceptEventIO::process_event(int /* flags ATS_UNUSED */)
 {
   this_ethread()->schedule_imm(_na);
 }

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -299,7 +299,7 @@ public:
   }
 
   int
-  event_handler(int event, Event *e)
+  event_handler(int event, Event * /* e ATS_UNUSED */)
   {
     if (event == TS_EVENT_IMMEDIATE) {
       this->fetch();

--- a/src/iocore/net/P_TLSKeyLogger.h
+++ b/src/iocore/net/P_TLSKeyLogger.h
@@ -54,7 +54,7 @@ public:
    * @param[in] line The line to place in the keylog file.
    */
   static void
-  ssl_keylog_cb(const SSL *ssl, const char *line)
+  ssl_keylog_cb(const SSL * /* ssl ATS_UNUSED */, const char *line)
   {
     instance().log(line);
   }

--- a/src/iocore/net/SNIActionPerformer.cc
+++ b/src/iocore/net/SNIActionPerformer.cc
@@ -42,7 +42,7 @@ DbgCtl dbg_ctl_ssl_sni{"ssl_sni"};
 } // end anonymous namespace
 
 int
-ControlQUIC::SNIAction(SSL &ssl, const Context &ctx) const
+ControlQUIC::SNIAction([[maybe_unused]] SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
 #if TS_USE_QUIC == 1
   if (enable_quic) {
@@ -68,7 +68,7 @@ ControlQUIC::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-ControlH2::SNIAction(SSL &ssl, const Context &ctx) const
+ControlH2::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   auto snis  = TLSSNISupport::getInstance(&ssl);
   auto alpns = ALPNSupport::getInstance(&ssl);
@@ -89,7 +89,7 @@ ControlH2::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-HTTP2BufferWaterMark::SNIAction(SSL &ssl, const Context &ctx) const
+HTTP2BufferWaterMark::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (auto snis = TLSSNISupport::getInstance(&ssl)) {
     snis->hints_from_sni.http2_buffer_water_mark = value;
@@ -98,7 +98,7 @@ HTTP2BufferWaterMark::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-HTTP2InitialWindowSizeIn::SNIAction(SSL &ssl, const Context &ctx) const
+HTTP2InitialWindowSizeIn::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (auto snis = TLSSNISupport::getInstance(&ssl)) {
     snis->hints_from_sni.http2_initial_window_size_in = value;
@@ -107,7 +107,7 @@ HTTP2InitialWindowSizeIn::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-HTTP2MaxSettingsFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
+HTTP2MaxSettingsFramesPerMinute::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (auto snis = TLSSNISupport::getInstance(&ssl)) {
     snis->hints_from_sni.http2_max_settings_frames_per_minute = value;
@@ -116,7 +116,7 @@ HTTP2MaxSettingsFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-HTTP2MaxPingFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
+HTTP2MaxPingFramesPerMinute::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (auto snis = TLSSNISupport::getInstance(&ssl)) {
     snis->hints_from_sni.http2_max_ping_frames_per_minute = value;
@@ -125,7 +125,7 @@ HTTP2MaxPingFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-HTTP2MaxPriorityFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
+HTTP2MaxPriorityFramesPerMinute::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (auto snis = TLSSNISupport::getInstance(&ssl)) {
     snis->hints_from_sni.http2_max_priority_frames_per_minute = value;
@@ -134,7 +134,7 @@ HTTP2MaxPriorityFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-HTTP2MaxRstStreamFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
+HTTP2MaxRstStreamFramesPerMinute::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (auto snis = TLSSNISupport::getInstance(&ssl)) {
     snis->hints_from_sni.http2_max_rst_stream_frames_per_minute = value;
@@ -143,7 +143,7 @@ HTTP2MaxRstStreamFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-HTTP2MaxContinuationFramesPerMinute::SNIAction(SSL &ssl, const Context &ctx) const
+HTTP2MaxContinuationFramesPerMinute::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (auto snis = TLSSNISupport::getInstance(&ssl)) {
     snis->hints_from_sni.http2_max_continuation_frames_per_minute = value;
@@ -293,7 +293,7 @@ TunnelDestination::replace_match_groups(std::string_view dst, const ActionItem::
 }
 
 int
-VerifyClient::SNIAction(SSL &ssl, const Context &ctx) const
+VerifyClient::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   auto snis   = TLSSNISupport::getInstance(&ssl);
   auto ssl_vc = SSLNetVCAccess(&ssl);
@@ -312,21 +312,23 @@ VerifyClient::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 bool
-VerifyClient::TestClientSNIAction(const char *servername, const IpEndpoint &ep, int &policy) const
+VerifyClient::TestClientSNIAction(const char * /* servername ATS_UNUSED */, const IpEndpoint & /* ep ATS_UNUSED */,
+                                  int & /* policy ATS_UNUSED */) const
 {
   // This action is triggered by a SNI if it was set
   return true;
 }
 
 int
-HostSniPolicy::SNIAction(SSL &ssl, const Context &ctx) const
+HostSniPolicy::SNIAction(SSL & /* ssl ATS_UNUSED */, const Context & /* ctx ATS_UNUSED */) const
 {
   // On action this doesn't do anything
   return SSL_TLSEXT_ERR_OK;
 }
 
 bool
-HostSniPolicy::TestClientSNIAction(const char *servername, const IpEndpoint &ep, int &in_policy) const
+HostSniPolicy::TestClientSNIAction(const char * /* servername ATS_UNUSED */, const IpEndpoint & /* ep ATS_UNUSED */,
+                                   int &in_policy) const
 {
   // Update the policy when testing
   in_policy = this->policy;
@@ -340,7 +342,7 @@ TLSValidProtocols::TLSValidProtocols(unsigned long protocols) : unset(false), pr
 }
 
 int
-TLSValidProtocols::SNIAction(SSL &ssl, const Context & /* ctx */) const
+TLSValidProtocols::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   auto snis = TLSSNISupport::getInstance(&ssl);
   auto tbs  = TLSBasicSupport::getInstance(&ssl);
@@ -403,7 +405,7 @@ SNI_IpAllow::load(swoc::TextView content, swoc::TextView server_name)
 }
 
 int
-SNI_IpAllow::SNIAction(SSL &ssl, ActionItem::Context const &ctx) const
+SNI_IpAllow::SNIAction(SSL &ssl, ActionItem::Context const & /* ctx ATS_UNUSED */) const
 {
   // i.e, ip filtering is not required
   if (ip_addrs.count() == 0) {
@@ -425,13 +427,14 @@ SNI_IpAllow::SNIAction(SSL &ssl, ActionItem::Context const &ctx) const
 }
 
 bool
-SNI_IpAllow::TestClientSNIAction(char const *servrername, IpEndpoint const &ep, int &policy) const
+SNI_IpAllow::TestClientSNIAction(char const * /* servrername ATS_UNUSED */, IpEndpoint const &ep,
+                                 int & /* policy ATS_UNUSED */) const
 {
   return ip_addrs.contains(swoc::IPAddr(ep));
 }
 
 int
-OutboundSNIPolicy::SNIAction(SSL &ssl, const Context &ctx) const
+OutboundSNIPolicy::SNIAction(SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
   if (!policy.empty()) {
     if (auto snis = TLSSNISupport::getInstance(&ssl)) {
@@ -442,7 +445,7 @@ OutboundSNIPolicy::SNIAction(SSL &ssl, const Context &ctx) const
 }
 
 int
-ServerMaxEarlyData::SNIAction(SSL &ssl, const Context &ctx) const
+ServerMaxEarlyData::SNIAction([[maybe_unused]] SSL &ssl, const Context & /* ctx ATS_UNUSED */) const
 {
 #if TS_HAS_TLS_EARLY_DATA
   auto snis = TLSSNISupport::getInstance(&ssl);

--- a/src/iocore/net/SNIActionPerformer.h
+++ b/src/iocore/net/SNIActionPerformer.h
@@ -43,7 +43,7 @@ public:
 #if TS_USE_QUIC == 1
   ControlQUIC(bool turn_on) : enable_quic(turn_on) {}
 #else
-  ControlQUIC(bool turn_on) {}
+  ControlQUIC(bool /* turn_on ATS_UNUSED */) {}
 #endif
   ~ControlQUIC() override {}
 

--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -283,7 +283,7 @@ SSLCertLookup::~SSLCertLookup()
 }
 
 SSLCertContext *
-SSLCertLookup::find(const std::string &address, SSLCertContextType ctxType) const
+SSLCertLookup::find(const std::string &address, [[maybe_unused]] SSLCertContextType ctxType) const
 {
 #ifdef OPENSSL_IS_BORINGSSL
   // If the context is EC supportable, try finding that first.

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -199,7 +199,8 @@ set_paths_helper(const char *path, const char *filename, char **final_path, char
 }
 
 int
-UpdateServerPolicy(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data, void *cookie)
+UpdateServerPolicy(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data,
+                   void * /* cookie ATS_UNUSED */)
 {
   SSLConfigParams *params        = SSLConfig::acquire();
   char            *verify_server = data.rec_string;
@@ -213,7 +214,8 @@ UpdateServerPolicy(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS
 }
 
 int
-UpdateServerPolicyProperties(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data, void *cookie)
+UpdateServerPolicyProperties(const char * /* name ATS_UNUSED */, RecDataT /* data_type ATS_UNUSED */, RecData data,
+                             void * /* cookie ATS_UNUSED */)
 {
   SSLConfigParams *params        = SSLConfig::acquire();
   char            *verify_server = data.rec_string;

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -2452,7 +2452,7 @@ SSLNetVConnection::_ssl_connect()
 
         Dbg(dbg_ctl_ssl_origin_session_cache, "origin session cache lookup key = %s", lookup_key.c_str());
 
-        std::shared_ptr<SSL_SESSION> shared_sess = this->getOriginSession(ssl, lookup_key);
+        std::shared_ptr<SSL_SESSION> shared_sess = this->getOriginSession(lookup_key);
 
         if (shared_sess && SSL_set_session(ssl, shared_sess.get())) {
           // Keep a reference of this shared pointer in the connection

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -243,7 +243,7 @@ ssl_new_cached_session(SSL *ssl, SSL_SESSION *sess)
 }
 
 static void
-ssl_rm_cached_session(SSL_CTX *ctx, SSL_SESSION *sess)
+ssl_rm_cached_session(SSL_CTX * /* ctx ATS_UNUSED */, SSL_SESSION *sess)
 {
 #ifdef TLS1_3_VERSION
   if (SSL_SESSION_get_protocol_version(sess) == TLS1_3_VERSION) {
@@ -377,7 +377,7 @@ ssl_client_hello_callback(const SSL_CLIENT_HELLO *client_hello)
  * Return 1 on success, 0 on error, or -1 to pause, -2 to retry
  */
 static int
-ssl_cert_callback(SSL *ssl, void *arg)
+ssl_cert_callback(SSL *ssl, [[maybe_unused]] void *arg)
 {
   TLSCertSwitchSupport *tcss     = TLSCertSwitchSupport::getInstance(ssl);
   SSLNetVConnection    *sslnetvc = dynamic_cast<SSLNetVConnection *>(tcss);
@@ -578,7 +578,7 @@ SSLMultiCertConfigLoader::_enable_ktls(SSL_CTX *ctx)
 }
 
 bool
-SSLMultiCertConfigLoader::_enable_early_data(SSL_CTX *ctx)
+SSLMultiCertConfigLoader::_enable_early_data([[maybe_unused]] SSL_CTX *ctx)
 {
 #if TS_HAS_TLS_EARLY_DATA
   if (SSLConfigParams::server_max_early_data > 0) {
@@ -946,7 +946,8 @@ SSLMultiCertConfigLoader::default_server_ssl_ctx()
 }
 
 static bool
-SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams *params, const char *keyPath, const char *secret_data, int secret_data_len)
+SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams * /* params ATS_UNUSED */, const char *keyPath, const char *secret_data,
+                     int secret_data_len)
 {
   EVP_PKEY *pkey = nullptr;
 #if HAVE_ENGINE_GET_DEFAULT_RSA && HAVE_ENGINE_LOAD_PRIVATE_KEY

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -488,7 +488,7 @@ ssl_next_protos_advertised_callback(SSL *ssl, const unsigned char **out, unsigne
 
   ink_assert(alpns);
   if (alpns) {
-    return alpns->advertise_next_protocol(ssl, out, outlen);
+    return alpns->advertise_next_protocol(out, outlen);
   }
 
   return SSL_TLSEXT_ERR_NOACK;
@@ -502,7 +502,7 @@ ssl_alpn_select_callback(SSL *ssl, const unsigned char **out, unsigned char *out
 
   ink_assert(alpns);
   if (alpns) {
-    return alpns->select_next_protocol(ssl, out, outlen, in, inlen);
+    return alpns->select_next_protocol(out, outlen, in, inlen);
   }
 
   return SSL_TLSEXT_ERR_NOACK;
@@ -946,8 +946,7 @@ SSLMultiCertConfigLoader::default_server_ssl_ctx()
 }
 
 static bool
-SSLPrivateKeyHandler(SSL_CTX *ctx, const SSLConfigParams * /* params ATS_UNUSED */, const char *keyPath, const char *secret_data,
-                     int secret_data_len)
+SSLPrivateKeyHandler(SSL_CTX *ctx, const char *keyPath, const char *secret_data, int secret_data_len)
 {
   EVP_PKEY *pkey = nullptr;
 #if HAVE_ENGINE_GET_DEFAULT_RSA && HAVE_ENGINE_LOAD_PRIVATE_KEY
@@ -2407,7 +2406,7 @@ SSLMultiCertConfigLoader::load_certs(SSL_CTX *ctx, const std::vector<std::string
       Dbg(dbg_ctl_ssl_load, "empty private key for public key %s", cert_names_list[i].c_str());
       secret_key_data = secret_data;
     }
-    if (!SSLPrivateKeyHandler(ctx, params, keyPath.c_str(), secret_key_data.data(), secret_key_data.size())) {
+    if (!SSLPrivateKeyHandler(ctx, keyPath.c_str(), secret_key_data.data(), secret_key_data.size())) {
       SSLError("failed to load certificate: %s of length %ld with key path: %s", cert_names_list[i].c_str(), secret_key_data.size(),
                keyPath.empty() ? "[empty key path]" : keyPath.c_str());
       return false;

--- a/src/iocore/net/TLSSNISupport.cc
+++ b/src/iocore/net/TLSSNISupport.cc
@@ -92,7 +92,7 @@ void
 #ifdef OPENSSL_IS_BORINGSSL
 TLSSNISupport::on_client_hello(const SSL_CLIENT_HELLO *client_hello)
 #else
-TLSSNISupport::on_client_hello(SSL *ssl, int *al, void *arg)
+TLSSNISupport::on_client_hello(SSL *ssl, int * /* al ATS_UNUSED */, void * /* arg ATS_UNUSED */)
 #endif
 {
   const char          *servername = nullptr;
@@ -135,7 +135,7 @@ TLSSNISupport::on_client_hello(SSL *ssl, int *al, void *arg)
 #endif
 
 void
-TLSSNISupport::on_servername(SSL *ssl, int *al, void *arg)
+TLSSNISupport::on_servername(SSL *ssl, int * /* al ATS_UNUSED */, void * /* arg ATS_UNUSED */)
 {
   this->_fire_ssl_servername_event();
 

--- a/src/iocore/net/TLSSessionResumptionSupport.cc
+++ b/src/iocore/net/TLSSessionResumptionSupport.cc
@@ -191,7 +191,7 @@ TLSSessionResumptionSupport::getSession(SSL *ssl, const unsigned char *id, int l
 }
 
 std::shared_ptr<SSL_SESSION>
-TLSSessionResumptionSupport::getOriginSession(SSL *ssl, const std::string &lookup_key)
+TLSSessionResumptionSupport::getOriginSession(SSL * /* ssl ATS_UNUSED */, const std::string &lookup_key)
 {
   ssl_curve_id                 curve       = 0;
   std::shared_ptr<SSL_SESSION> shared_sess = origin_sess_cache->get_session(lookup_key, &curve);
@@ -221,12 +221,14 @@ TLSSessionResumptionSupport::clear()
 
 #ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
 int
-TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname,
-                                                    unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx)
+TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, SSL * /* ssl ATS_UNUSED */,
+                                                    unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
+                                                    EVP_MAC_CTX *hctx)
 #else
 int
-TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname,
-                                                    unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx)
+TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, SSL * /* ssl ATS_UNUSED */,
+                                                    unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
+                                                    HMAC_CTX *hctx)
 #endif
 {
   const ssl_ticket_key_t &most_recent_key = keyblock->keys[0];
@@ -260,12 +262,14 @@ TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblo
 
 #ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
 int
-TLSSessionResumptionSupport::_getSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname,
-                                                    unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx)
+TLSSessionResumptionSupport::_getSessionInformation(ssl_ticket_key_block *keyblock, [[maybe_unused]] SSL *ssl,
+                                                    unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
+                                                    EVP_MAC_CTX *hctx)
 #else
 int
-TLSSessionResumptionSupport::_getSessionInformation(ssl_ticket_key_block *keyblock, SSL *ssl, unsigned char *keyname,
-                                                    unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx)
+TLSSessionResumptionSupport::_getSessionInformation(ssl_ticket_key_block *keyblock, [[maybe_unused]] SSL *ssl,
+                                                    unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
+                                                    HMAC_CTX *hctx)
 #endif
 {
   for (unsigned i = 0; i < keyblock->num_keys; ++i) {

--- a/src/iocore/net/TLSSessionResumptionSupport.cc
+++ b/src/iocore/net/TLSSessionResumptionSupport.cc
@@ -116,7 +116,7 @@ TLSSessionResumptionSupport::processSessionTicket(SSL *ssl, unsigned char *keyna
   ink_release_assert(keyblock != nullptr && keyblock->num_keys > 0);
 
   if (enc == 1) {
-    return this->_setSessionInformation(keyblock, ssl, keyname, iv, cipher_ctx, hctx);
+    return this->_setSessionInformation(keyblock, keyname, iv, cipher_ctx, hctx);
   } else if (enc == 0) {
     return this->_getSessionInformation(keyblock, ssl, keyname, iv, cipher_ctx, hctx);
   }
@@ -191,7 +191,7 @@ TLSSessionResumptionSupport::getSession(SSL *ssl, const unsigned char *id, int l
 }
 
 std::shared_ptr<SSL_SESSION>
-TLSSessionResumptionSupport::getOriginSession(SSL * /* ssl ATS_UNUSED */, const std::string &lookup_key)
+TLSSessionResumptionSupport::getOriginSession(const std::string &lookup_key)
 {
   ssl_curve_id                 curve       = 0;
   std::shared_ptr<SSL_SESSION> shared_sess = origin_sess_cache->get_session(lookup_key, &curve);
@@ -221,14 +221,12 @@ TLSSessionResumptionSupport::clear()
 
 #ifdef HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB
 int
-TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, SSL * /* ssl ATS_UNUSED */,
-                                                    unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
-                                                    EVP_MAC_CTX *hctx)
+TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, unsigned char *keyname, unsigned char *iv,
+                                                    EVP_CIPHER_CTX *cipher_ctx, EVP_MAC_CTX *hctx)
 #else
 int
-TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, SSL * /* ssl ATS_UNUSED */,
-                                                    unsigned char *keyname, unsigned char *iv, EVP_CIPHER_CTX *cipher_ctx,
-                                                    HMAC_CTX *hctx)
+TLSSessionResumptionSupport::_setSessionInformation(ssl_ticket_key_block *keyblock, unsigned char *keyname, unsigned char *iv,
+                                                    EVP_CIPHER_CTX *cipher_ctx, HMAC_CTX *hctx)
 #endif
 {
   const ssl_ticket_key_t &most_recent_key = keyblock->keys[0];

--- a/src/iocore/net/UnixNetAccept.cc
+++ b/src/iocore/net/UnixNetAccept.cc
@@ -252,7 +252,7 @@ NetAccept::init_accept(EThread *t)
 }
 
 int
-NetAccept::accept_per_thread(int event, void *ep)
+NetAccept::accept_per_thread(int /* event ATS_UNUSED */, void * /* ep ATS_UNUSED */)
 {
   int listen_per_thread = 0;
   REC_ReadConfigInteger(listen_per_thread, "proxy.config.exec_thread.listen");

--- a/src/iocore/net/UnixNetVConnection.cc
+++ b/src/iocore/net/UnixNetVConnection.cc
@@ -1021,7 +1021,7 @@ UnixNetVConnection::startEvent(int /* event ATS_UNUSED */, Event *e)
 }
 
 int
-UnixNetVConnection::acceptEvent(int event, Event *e)
+UnixNetVConnection::acceptEvent(int /* event ATS_UNUSED */, Event *e)
 {
   EThread    *t = (e == nullptr) ? this_ethread() : e->ethread;
   NetHandler *h = get_NetHandler(t);
@@ -1135,7 +1135,7 @@ UnixNetVConnection::mainEvent(int event, Event *e)
 }
 
 int
-UnixNetVConnection::populate(Connection &con_in, Continuation *c, void *arg)
+UnixNetVConnection::populate(Connection &con_in, Continuation *c, void * /* arg ATS_UNUSED */)
 {
   this->con.move(con_in);
   this->mutex  = c->mutex;

--- a/src/iocore/net/YamlSNIConfig.cc
+++ b/src/iocore/net/YamlSNIConfig.cc
@@ -520,7 +520,7 @@ std::array<std::function<std::string(std::string_view,            // destination
   TunnelDestination::fix_destination = {
 
     // Replace wildcards with matched groups.
-    [](std::string_view destination, size_t var_start_pos, const Context &ctx, SSLNetVConnection *,
+    [](std::string_view destination, size_t /* var_start_pos ATS_UNUSED */, const Context &ctx, SSLNetVConnection *,
        bool &port_is_dynamic) -> std::string {
       port_is_dynamic = false;
       if ((destination.find_first_of('$') != std::string::npos) && ctx._fqdn_wildcard_captured_groups) {
@@ -532,7 +532,7 @@ std::array<std::function<std::string(std::string_view,            // destination
     },
 
     // Use local port for the tunnel.
-    [](std::string_view destination, size_t var_start_pos, const Context &ctx, SSLNetVConnection *vc,
+    [](std::string_view destination, size_t var_start_pos, const Context & /* ctx ATS_UNUSED */, SSLNetVConnection *vc,
        bool &port_is_dynamic) -> std::string {
       port_is_dynamic = true;
       if (vc) {
@@ -547,7 +547,7 @@ std::array<std::function<std::string(std::string_view,            // destination
     },
 
     // Use the Proxy Protocol port for the tunnel.
-    [](std::string_view destination, size_t var_start_pos, const Context &ctx, SSLNetVConnection *vc,
+    [](std::string_view destination, size_t var_start_pos, const Context & /* ctx ATS_UNUSED */, SSLNetVConnection *vc,
        bool &port_is_dynamic) -> std::string {
       port_is_dynamic = true;
       if (vc) {

--- a/src/iocore/utils/OneWayMultiTunnel.cc
+++ b/src/iocore/utils/OneWayMultiTunnel.cc
@@ -226,7 +226,7 @@ OneWayMultiTunnel::startEvent(int event, void *data)
 }
 
 void
-OneWayMultiTunnel::close_target_vio(int result, VIO *vio)
+OneWayMultiTunnel::close_target_vio(int /* result ATS_UNUSED */, VIO *vio)
 {
   for (int i = 0; i < n_vioTargets; i++) {
     VIO *v = vioTargets[i];


### PR DESCRIPTION
Use `/* name ATS_UNUSED */` for fully unused parameters.
Use `[[maybe_unused]]` for conditionally unused parameters.

This pull request is part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377) the `-Wno-unused-parameter` warning suppression.