### PR TITLE
Remove inkevent dependency from records

### DIFF
--- a/src/proxy/logging/CMakeLists.txt
+++ b/src/proxy/logging/CMakeLists.txt
@@ -41,12 +41,12 @@ target_link_libraries(logging PUBLIC ts::inkevent ts::inkutils ts::http ts::hdrs
 if(BUILD_TESTING)
   add_executable(test_LogUtils LogUtils.cc unit-tests/test_LogUtils.cc)
   target_compile_definitions(test_LogUtils PRIVATE TEST_LOG_UTILS)
-  target_link_libraries(test_LogUtils tscore records catch2::catch2)
+  target_link_libraries(test_LogUtils tscore ts::inkevent records catch2::catch2)
   add_test(NAME test_LogUtils COMMAND test_LogUtils)
 
   add_executable(test_RolledLogDeleter LogUtils.cc RolledLogDeleter.cc unit-tests/test_LogUtils.cc)
   target_compile_definitions(test_RolledLogDeleter PRIVATE TEST_LOG_UTILS)
-  target_link_libraries(test_RolledLogDeleter tscore records catch2::catch2)
+  target_link_libraries(test_RolledLogDeleter tscore ts::inkevent records catch2::catch2)
   add_test(NAME test_RolledLogDeleter COMMAND test_RolledLogDeleter)
 endif()
 

--- a/src/records/CMakeLists.txt
+++ b/src/records/CMakeLists.txt
@@ -35,17 +35,19 @@ add_library(ts::records ALIAS records)
 
 target_link_libraries(
   records
-  PUBLIC ts::inkevent ts::tscore yaml-cpp::yaml-cpp
+  PUBLIC ts::tscore yaml-cpp::yaml-cpp
   PRIVATE ts::tsutil
 )
 
 if(BUILD_TESTING)
   add_executable(test_records unit_tests/unit_test_main.cc unit_tests/test_RecHttp.cc)
-  target_link_libraries(test_records PRIVATE records catch2::catch2 tscore libswoc::libswoc)
+  target_link_libraries(test_records PRIVATE records catch2::catch2 ts::tscore libswoc::libswoc)
   add_test(NAME test_records COMMAND test_records)
 
   add_executable(test_records_on_eventsystem unit_tests/unit_test_main_on_eventsystem.cc)
-  target_link_libraries(test_records_on_eventsystem PRIVATE records catch2::catch2 tscore libswoc::libswoc)
+  target_link_libraries(
+    test_records_on_eventsystem PRIVATE records catch2::catch2 ts::inkevent ts::tscore libswoc::libswoc
+  )
   add_test(NAME test_records_on_eventsystem COMMAND test_records_on_eventsystem)
 endif()
 


### PR DESCRIPTION
There is no real dependency anymore - we do not need to link inkevent into records.