### PR TITLE
records.yaml -  Rename 'ts' yaml tag to 'records'.

### DIFF
--- a/configs/remap.config.default
+++ b/configs/remap.config.default
@@ -12,7 +12,7 @@
 #  With the default configurations, at least one remap rule is required. This
 #  can be relaxed with the following configuration in records.yaml:
 #
-#  ts:
+#  records:
 #    url_remap:
 #      remap_required: 0
 #
@@ -101,14 +101,14 @@
 #  regular expression strings - 2048.  In order to enable the 'deep linking
 #  protection' feature in Traffic Server, configure records.yaml with:
 #
-#  ts:
+#  records:
 #    http:
 #      referer_filter: 1
 #
 #
 #  In order to enable run-time formatting for redirect0URL, configure
 #
-#  ts:
+#  records:
 #    http:
 #      referer_format_redirect: 1
 #

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -45,14 +45,14 @@ to apply the changes.
 YAML structure
 ==============
 
-All fields are located inside the ``ts`` root node. ATS supports reading multiple documents from
+All fields are located inside the ``records``` root node. ATS supports reading multiple documents from
 the same YAML stream, subsequent documents overrides earlier fields.
 
 
 .. code-block:: yaml
    :linenos:
 
-   ts:
+   records:
      diags:
       debug:
          enabled: 0
@@ -93,7 +93,7 @@ We expect non core records to set the type (!!int, !!float, etc).
 
 .. code-block:: yaml
 
-   ts:
+   records:
       plugin_x:
          my_field_1: !!int '1'
          my_field_2: !!float '1.2'
@@ -159,7 +159,7 @@ value ``my_server``. This means that the name of the |TS| proxy is ``my_server``
    .. code-block:: yaml
       :linenos:
 
-      ts:
+      records:
          proxy_name: my_server
 
 
@@ -168,7 +168,7 @@ If the server name should be ``that_server`` the line would be:
    .. code-block:: yaml
       :linenos:
 
-      ts:
+      records:
          proxy_name: that_server
 
 
@@ -178,7 +178,7 @@ disables the option; a value of ``1`` enables the option.
    .. code-block:: yaml
       :linenos:
 
-      ts:
+      records:
          arm:
             enabled: 0
 
@@ -188,7 +188,7 @@ DNS response to 10 seconds.
    .. code-block:: yaml
       :linenos:
 
-      ts:
+      records:
          hostdb:
             lookup_timeout: 10
 
@@ -197,7 +197,7 @@ In the following example the field sets the field with a ``float`` value.
    .. code-block:: yaml
       :linenos:
 
-      ts:
+      records:
          exec_thread:
             autoconfig:
                scale: 1.0
@@ -209,7 +209,7 @@ prefix.
    .. code-block:: yaml
       :linenos:
 
-      ts:
+      records:
          cache:
             ram_cache:
                size: 64G
@@ -590,7 +590,7 @@ Network
 
    .. code-block:: yaml
 
-      ts:
+      records:
         incoming_ip_to_bind: 192.168.101.18
 
 .. topic:: Example
@@ -600,7 +600,7 @@ Network
 
    .. code-block:: yaml
 
-      ts:
+      records:
         incoming_ip_to_bind: "192.168.101.18 [fc07:192:168:101::17]"
 
 .. ts:cv:: CONFIG proxy.config.outgoing_ip_to_bind STRING 0.0.0.0 [::]
@@ -624,7 +624,7 @@ Network
 
    .. code-block:: yaml
 
-      ts:
+      records:
         outgoing_ip_to_bind: 192.168.101.18
 
 .. topic:: Example
@@ -633,7 +633,7 @@ Network
 
    .. code-block:: yaml
 
-      ts:
+      records:
         outgoing_ip_to_bind: "192.168.101.17 [fc07:192:168:101::17]"
 
 .. ts:cv:: CONFIG proxy.config.net.event_period INT 10
@@ -4644,7 +4644,7 @@ removed in the future without prior notice.
 
    .. code-block:: yaml
 
-      ts:
+      records:
         quic:
           qlog:
             file_base: /my/logs/test1
@@ -5083,7 +5083,7 @@ Sockets
 
    .. code-block:: yaml
 
-      ts:
+      records:
         accept_threads: 0
         exec_thread:
           listen: 1
@@ -5197,7 +5197,7 @@ Sockets
    .. code-block:: yaml
       :linenos:
 
-      ts:
+      records:
         exec_thread:
           autoconfig:
             enabled: 0

--- a/doc/admin-guide/files/remap.config.en.rst
+++ b/doc/admin-guide/files/remap.config.en.rst
@@ -349,7 +349,7 @@ protection' feature in Traffic Server, configure records.yaml with:
    :linenos:
    :emphasize-lines: 3
 
-   ts:
+   records:
      http:
        referer_filter: 1
 
@@ -359,7 +359,7 @@ In order to enable run-time formatting for redirect URL, configure:
    :linenos:
    :emphasize-lines: 3
 
-   ts:
+   records:
      http:
        referer_format_redirect: 1
 

--- a/doc/admin-guide/performance/index.en.rst
+++ b/doc/admin-guide/performance/index.en.rst
@@ -200,7 +200,7 @@ in :file:`records.yaml`.:
 
 .. code-block:: yaml
 
-   ts:
+   records:
      exec_thread:
        affinity: 1
 
@@ -271,7 +271,7 @@ connections without submitting requests.
 
 .. code-block:: yaml
 
-   ts:
+   records:
      http:
        accept_no_activity_timeout: 120
 
@@ -287,7 +287,7 @@ situations where your origin servers stall connections without closing.
 
 .. code-block:: yaml
 
-   ts:
+   records:
      http:
        background_fill_active_timeout: 0
 
@@ -310,7 +310,7 @@ information on when this TTL value will actually be used).
 
 .. code-block:: yaml
 
-   ts:
+   records:
      hostdb:
        lookup_timeout: 30
        timeout: 1440
@@ -330,7 +330,7 @@ keepalive timeout which (if set lower) will likely take precedence.
 
 .. code-block:: yaml
 
-   ts:
+   records:
      http:
        keep_alive_no_activity_timeout_in: 120
        keep_alive_no_activity_timeout_out: 120
@@ -347,7 +347,7 @@ After the connection is established the value of
 
 .. code-block:: yaml
 
-   ts:
+   records:
      http:
        connect_attempts_timeout: 30
 
@@ -360,7 +360,7 @@ idle workloads, you may consider adjusting the polling timeout with
 
 .. code-block:: yaml
 
-   ts:
+   records:
      net:
        poll_timeout: 60
 
@@ -380,7 +380,7 @@ after which a retry will be performed (the delay is configured with
 
 .. code-block:: yaml
 
-   ts:
+   records:
      socks:
        server_connect_timeout: 10
        server_retry_time: 300
@@ -410,7 +410,7 @@ cached in |TS| using :ts:cv:`proxy.config.ssl.session_cache.timeout`.
 
 .. code-block:: yaml
 
-   ts:
+   records:
      ssl:
        handshake_timeout_in: 30
        ocsp:
@@ -457,7 +457,7 @@ values prove somewhat more generally applicable.
 
 .. code-block:: yaml
 
-   ts:
+   records:
      http:
        transaction_active_timeout_in: 900
        transaction_active_timeout_out: 0
@@ -475,7 +475,7 @@ for all WebSocket connections, regardless of their level of activity.
 
 .. code-block:: yaml
 
-   ts:
+   records:
      websocket:
        active_timeout: 3600
        no_activity_timeout: 600
@@ -518,7 +518,7 @@ status code for negative caching can be set with :ts:cv:`proxy.config.http.negat
 
 .. code-block:: yaml
 
-  ts:
+  records:
     http:
       negative_caching_enabled: 1
       negative_caching_lifetime: 10

--- a/doc/admin-guide/plugins/conf_remap.en.rst
+++ b/doc/admin-guide/plugins/conf_remap.en.rst
@@ -95,7 +95,7 @@ should mirror how configuration directives are written in :file:`records.yaml`:
 
 .. code-block:: yaml
 
-   ts:
+   records:
      url_remap:
        pristine_host_hdr: 1
 

--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -157,7 +157,7 @@ adding a configuration option to records.yaml.
    :linenos:
    :emphasize-lines: 4
 
-   ts:
+   records:
       plugin:
         lua:
           max_states: 64
@@ -316,7 +316,7 @@ We should write this TAG in :ts:cv:`proxy.config.diags.debug.tags` in records.ya
    :linenos:
    :emphasize-lines: 4
 
-   ts:
+   records:
      diags:
        debug:
          tags: TAG

--- a/doc/admin-guide/plugins/url_sig.en.rst
+++ b/doc/admin-guide/plugins/url_sig.en.rst
@@ -288,7 +288,7 @@ for :ts:cv:`proxy.config.diags.debug.enabled` and
 
 .. code-block:: yaml
 
-   ts:
+   records:
      diags:
        debug:
          enabled: 1

--- a/doc/admin-guide/security/index.en.rst
+++ b/doc/admin-guide/security/index.en.rst
@@ -113,7 +113,7 @@ Client/|TS| connections, you must do the following:
 
    .. code-block:: yaml
 
-     ts:
+     records:
        ssl:
          server:
            cert:
@@ -140,7 +140,7 @@ Client/|TS| connections, you must do the following:
 
    .. code-block:: yaml
 
-      ts:
+      records:
         ssl:
           client:
             certification_level: 0
@@ -162,7 +162,7 @@ Client/|TS| connections, you must do the following:
 
    .. code-block:: yaml
 
-      ts:
+      records:
         ssl:
           CA:
             cert:
@@ -231,7 +231,7 @@ and origin server connections, you must do the following:
 
    .. code-block:: yaml
 
-      ts:
+      records:
         ssl:
           client:
             cert:
@@ -245,7 +245,7 @@ and origin server connections, you must do the following:
 
    .. code-block:: yaml
 
-      ts:
+      records:
         ssl:
           client:
             private_key:
@@ -259,7 +259,7 @@ and origin server connections, you must do the following:
 
 .. code-block:: yaml
 
-   ts:
+   records:
      ssl:
        client:
          verify:
@@ -273,7 +273,7 @@ and origin server connections, you must do the following:
 
 .. code-block:: yaml
 
-   ts:
+   records:
      ssl:
        client:
          CA:
@@ -389,7 +389,7 @@ To configure Split DNS:
 
 .. code-block:: yaml
 
-   ts:
+   records:
      dns:
        splitDNS:
          enabled: 1

--- a/doc/admin-guide/tools/converting-records-to-yaml.en.rst
+++ b/doc/admin-guide/tools/converting-records-to-yaml.en.rst
@@ -33,10 +33,12 @@ New YAML structure
 ==================
 
 
-#. We are introducing a root node ``ts`` for the :file:`records.yaml`, so all existing records
-will belong to the new ``ts`` node.
-#. From the current ``records.config`` structure we have dropped the prefix ``proxy.config``
-and ``proxy.local`` and use the rest to build a YAML structure.
+A YAML node ``records``` is the main root node for the :file:`records.yaml`, so all existing records
+will belong to this ``records``` node.
+
+From the current ``records.config`` structure we have dropped the prefix ``proxy.config``
+and ``proxy.local`` and use what's left on the variable name to build a YAML structure, always
+below the ``records`` node.
 
 The logic around this is basically to walk down the record name separated by the dots and build
 a new YAML map from each name, so for instance, with the following records:
@@ -61,7 +63,7 @@ the following:
 .. code-block:: yaml
    :linenos:
 
-      ts:
+   records:
       accept_threads: 1
       cache:
          threads_per_disk: 8
@@ -194,7 +196,7 @@ Expect non core records to set the type (!!int, !!float, etc).
 
 .. code-block:: bash
 
-   ts:
+   records:
       plugin_x:
          my_field_1: !!int '1'
          my_field_2: !!float '1.2'
@@ -223,7 +225,7 @@ non core records, for instance:
    $ convert2yaml.py -f records.config -o records.yaml -t float,int
 
    $ cat records.yaml
-   ts:
+   records:
       http:
          my_own_record_1: !!float '1.0'
          my_own_record_2: !!int '1'

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -230,12 +230,12 @@ Display the current value of a configuration record.
 
       $ traffic_ctl config set proxy.config.diags.debug.enabled 1 -c records.yaml
       $ cat records.yaml
-      ts:
+      records:
       ...
       # Document modified by traffic_ctl Mon Feb 13 23:07:15 2023
       #
       ---
-      ts:
+      records:
          diags:
             debug:
                enabled: 1
@@ -261,7 +261,7 @@ Display the current value of a configuration record.
          # Document modified by traffic_ctl Mon Feb 13 23:07:15 2023
          #
          ---
-         ts:
+         records:
             some:
                plugin:
                   config:

--- a/doc/developer-guide/api/functions/TSRecYAMLConfigParse.en.rst
+++ b/doc/developer-guide/api/functions/TSRecYAMLConfigParse.en.rst
@@ -86,7 +86,7 @@ Example:
 
    .. code-block:: yaml
 
-      ts:
+      records:
         plugin_x:
           field_1: 1
           data:

--- a/doc/developer-guide/cripts/cripts-overview.en.rst
+++ b/doc/developer-guide/cripts/cripts-overview.en.rst
@@ -74,7 +74,7 @@ The first step is to set the plugin.compiler_path in the records.yaml file. For 
 
 .. code-block:: yaml
 
-   ts:
+   records:
      plugin:
        compiler_path: /opt/ats/bin/compiler.sh
 

--- a/doc/developer-guide/debugging/debug-tags.en.rst
+++ b/doc/developer-guide/debugging/debug-tags.en.rst
@@ -49,7 +49,7 @@ Sets the following variables in :file:`records.yaml` (in the Traffic Server
 
 .. code-block:: yaml
 
-   ts:
+   records:
      diags:
        debug:
          enabled: 1

--- a/doc/developer-guide/debugging/memory-leaks.en.rst
+++ b/doc/developer-guide/debugging/memory-leaks.en.rst
@@ -28,7 +28,7 @@ related to memory - you can use memory dump information. Enable
 
 .. code-block:: yaml
 
-   ts:
+   records:
      dump_mem_info_frequency: value
 
 This causes Traffic Server to dump memory information to ``traffic.out``
@@ -37,7 +37,7 @@ disabled.
 
 .. code-block:: yaml
 
-   ts:
+   records:
      res_track_memory: value
 
 

--- a/doc/developer-guide/plugins/example-plugins/tls_bridge.en.rst
+++ b/doc/developer-guide/plugins/example-plugins/tls_bridge.en.rst
@@ -76,7 +76,7 @@ useful case.
    :linenos:
    :emphasize-lines: 4
 
-   ts:
+   records:
       http:
          cache:
             http: 0
@@ -90,7 +90,7 @@ useful case.
       :linenos:
       :emphasize-lines: 3
 
-      ts:
+      records:
       http:
          server_ports: 4443:ssl
 
@@ -102,7 +102,7 @@ useful case.
       :linenos:
       :emphasize-lines: 3
 
-      ts:
+      records:
          http:
             connect_ports: 4443
 
@@ -117,7 +117,7 @@ useful case.
       :linenos:
       :emphasize-lines: 3
 
-      ts:
+      records:
         url_remap:
            remap_required: 0
 
@@ -149,7 +149,7 @@ useful case.
       :linenos:
       :emphasize-lines: 6
 
-      ts:
+      records:
          ssl:
             client:
                verify:
@@ -164,7 +164,7 @@ useful case.
       :linenos:
       :emphasize-lines: 6
 
-      ts:
+      records:
          ssl:
             client:
                CA:
@@ -178,7 +178,7 @@ useful case.
       :linenos:
       :emphasize-lines: 5-6
 
-      ts:
+      records:
          ssl:
             client:
                cert:
@@ -192,7 +192,7 @@ useful case.
       :linenos:
       :emphasize-lines: 4
 
-      ts:
+      records:
          ssl:
             client:
                certification_level: 2

--- a/doc/ext/traffic-server.cmake.in.py
+++ b/doc/ext/traffic-server.cmake.in.py
@@ -223,7 +223,7 @@ class TSConfVar(std.Target):
         code_block_title = None
         if 'legacy' not in self.options:
             code_block = self.__generate_code(cv_name, cv_default, cv_type)
-            code_block_title = sphinx.addnodes.compact_paragraph(text="yaml-rep:")
+            code_block_title = sphinx.addnodes.compact_paragraph(text="yaml:")
             self.add_name(code_block_title)
             self.add_name(code_block)
 

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -141,7 +141,7 @@ class TSConfVar(std.Target):
 
         # Build the object
         add_object(config, name, cv_default, cv_type)
-        ts['ts'] = config
+        ts['records'] = config
         code = get_code(ts)
         literal = nodes.literal_block(code, code)
         literal['linenos'] = True
@@ -223,7 +223,7 @@ class TSConfVar(std.Target):
         code_block_title = None
         if 'legacy' not in self.options:
             code_block = self.__generate_code(cv_name, cv_default, cv_type)
-            code_block_title = sphinx.addnodes.compact_paragraph(text="yaml-rep:")
+            code_block_title = sphinx.addnodes.compact_paragraph(text="yaml:")
             self.add_name(code_block_title)
             self.add_name(code_block)
 

--- a/doc/getting-started/index.en.rst
+++ b/doc/getting-started/index.en.rst
@@ -241,7 +241,7 @@ settings have been configured as shown below:
 
 .. code-block:: yaml
 
-  ts:
+  records:
     http:
       cache:
         http: 1
@@ -380,7 +380,7 @@ entries:
 
 .. code-block:: yaml
 
-  ts:
+  records:
     http:
       cache:
         http: 1
@@ -431,7 +431,7 @@ forward proxy:
 
 .. code-block:: yaml
 
-   ts:
+   records:
      http:
        cache:
          http: 1
@@ -451,7 +451,7 @@ should be explicitly disabled:
 
 .. code-block:: yaml
 
-   ts:
+   records:
      reverse_proxy:
        enabled: 0
 

--- a/include/records/RecYAMLDecoder.h
+++ b/include/records/RecYAMLDecoder.h
@@ -53,7 +53,7 @@ void SetRecordFromYAMLNode(const CfgNode &field, swoc::Errata &errata);
 swoc::Errata RecYAMLConfigFileParse(const char *path, RecYAMLNodeHandler handler);
 
 ///
-/// @brief This function parses the YAML root node ("ts") and convert each field
+/// @brief This function parses the YAML root node ("records") and convert each field
 ///        into a record style object.
 ///
 /// As we keep the internal records without a change we should rebuild each records name
@@ -62,7 +62,7 @@ swoc::Errata RecYAMLConfigFileParse(const char *path, RecYAMLNodeHandler handler
 ///
 /// Example:
 ///
-/// ts:
+/// records:
 ///   exec_thread:
 ///       autoconfig:
 ///         scale: 1.0
@@ -77,7 +77,7 @@ swoc::Errata RecYAMLConfigFileParse(const char *path, RecYAMLNodeHandler handler
 /// @note This function is separated from RecYAMLConfigFileParse as this can also be called
 ///       independently, i.e.: From a RPC handler.
 ///
-/// @param root Top YAML node, it should contain the "ts" element.
+/// @param root Top YAML node, it should contain the "records" element.
 /// @param handle Callback that will process each parsed node.
 /// @param lock true if we want this function to lock g_records_rwlock. If you are locking already,
 ///             then leave it as false.

--- a/plugins/experimental/url_sig/README
+++ b/plugins/experimental/url_sig/README
@@ -27,7 +27,7 @@ Edge cache debugging
 	To enable the TSDebug verbose logging, change records.yaml to have:
 
   ```yaml
-  ts:
+  records:
     diags:
       debug:
         enabled: 1

--- a/src/records/RecYAMLDecoder.cc
+++ b/src/records/RecYAMLDecoder.cc
@@ -40,7 +40,7 @@ static std::array<std::string_view, 5> Node_Type_to_Str{
 namespace
 {
 constexpr std::string_view CONFIG_RECORD_PREFIX{"proxy.config"};
-const inline std::string   RECORD_YAML_ROOT_STR{"ts"};
+const inline std::string   RECORD_YAML_ROOT_STR{"records"};
 
 } // namespace
 
@@ -154,7 +154,7 @@ ParseRecordsFromYAML(YAML::Node root, RecYAMLNodeHandler handler, bool lock /*fa
       detail::flatten_node({n.first, n.second, CONFIG_RECORD_PREFIX}, handler, errata);
     }
   } else {
-    return swoc::Errata(ERRATA_NOTE, "'ts' root key not present or no fields to read.");
+    return swoc::Errata(ERRATA_NOTE, "'records' root key not present or no fields to read.");
   }
 
   return errata;

--- a/src/traffic_ctl/FileConfigCommand.cc
+++ b/src/traffic_ctl/FileConfigCommand.cc
@@ -30,27 +30,27 @@
 namespace
 {
 constexpr std::string_view PREFIX{"proxy.config."};
-constexpr std::string_view TS_PREFIX{"ts."};
+constexpr std::string_view TS_PREFIX{"records."};
 
 constexpr bool                    CREATE_IF_NOT_EXIST{true};
 constexpr bool                    DO_NOT_CREATE_IF_NOT_EXIST{false};
 const std::pair<bool, YAML::Node> NOT_FOUND{false, {}};
 
-/// We support either passing variables with the prefix 'proxy.config.' or 'ts.'
-/// Internally we need to use 'ts.variable' as the root node starts with 'ts' for records
+/// We support either passing variables with the prefix 'proxy.config.' or 'records.'
+/// Internally we need to use 'records.variable' as the root node starts with 'records' for records
 /// configs.
 std::string
 amend_variable_name(swoc::TextView variable)
 {
   std::string var{TS_PREFIX};
   // If the variable is prefixed with "proxy.config" we will remove it and replace it
-  // with the records "ts." root name.
+  // with the records "records." root name.
   if (swoc::TextView{variable}.starts_with(PREFIX)) {
     var += variable.substr(PREFIX.size());
     return var;
   }
 
-  // you may be using "ts." already or some other name maybe for a different file.
+  // you may be using "records." already or some other name maybe for a different file.
   // we expect either `ts` or `proxy.config`
   return {variable.data(), variable.size()};
 }

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -563,7 +563,7 @@ class YAMLFile(File):
 class RecordsYAML(YAMLFile):
 
     def __init__(self, runable, name, exists=None, size=None, content_tester=None, execute=False, runtime=True):
-        super(RecordsYAML, self).__init__(runable, name, exists, size, content_tester, execute, runtime, root_tag="ts")
+        super(RecordsYAML, self).__init__(runable, name, exists, size, content_tester, execute, runtime, root_tag="records")
 
     def _make_obj_from_legacy_record(self, config, var, value):
         '''

--- a/tests/gold_tests/records/gold/full_records.yaml
+++ b/tests/gold_tests/records/gold/full_records.yaml
@@ -1,4 +1,4 @@
-ts:
+records:
   accept_threads: 1
   allocator:
     dontdump_iobuffers: 1

--- a/tests/gold_tests/records/gold/records.yaml.cold_test0.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test0.gold
@@ -1,9 +1,9 @@
-ts:
+records:
 ``
 # Document modified by traffic_ctl ``
 #``
 ---
-ts:
+records:
   diags:
     debug:
       tags: http

--- a/tests/gold_tests/records/gold/records.yaml.cold_test2.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test2.gold
@@ -1,9 +1,9 @@
-ts:
+records:
 ``
 # Document modified by traffic_ctl ``
 #``
 ---
-ts:
+records:
   diags:
     debug:
       tags: http

--- a/tests/gold_tests/records/gold/records.yaml.cold_test4.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test4.gold
@@ -1,9 +1,9 @@
-ts:
+records:
 ``
 # Document modified by traffic_ctl ``
 #``
 ---
-ts:
+records:
   cache:
     limits:
       http:

--- a/tests/gold_tests/records/gold/records.yaml.cold_test5.gold
+++ b/tests/gold_tests/records/gold/records.yaml.cold_test5.gold
@@ -1,7 +1,7 @@
 # Document modified by traffic_ctl ``
 #``
 ---
-ts:
+records:
   cache:
     limits:
       http:

--- a/tests/gold_tests/records/gold/renamed_records.yaml
+++ b/tests/gold_tests/records/gold/renamed_records.yaml
@@ -1,4 +1,4 @@
-ts:
+records:
   exec_thread:
     autoconfig:
       enabled: 1

--- a/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
+++ b/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
@@ -125,7 +125,7 @@ test0 = conf_remap_yaml_load_test(
     gold_file="gold/200OK_test.gold",
     remap_filename="testexample_remap.yaml",
     remap_content='''
-    ts:
+    records:
       url_remap:
         pristine_host_hdr: 1
     ''')
@@ -135,7 +135,7 @@ test1 = conf_remap_yaml_load_test(
     "Test mismatch type",
     remap_filename="mismatch_field_type_remap.yaml",
     remap_content='''
-    ts:
+    records:
       url_remap:
         pristine_host_hdr: !!float '1'
     ''')
@@ -145,7 +145,7 @@ test2 = conf_remap_yaml_load_test(
     "Test invalid variable",
     remap_filename="invalid1_field_type_remap.yaml",
     remap_content='''
-    ts:
+    records:
       plugin:
         dynamic_reload_mode: 1
     ''')
@@ -160,7 +160,7 @@ test3 = conf_remap_yaml_load_test(
     gold_file="gold/200OK_test.gold",
     remap_filename="testexample2_remap.yaml",
     remap_content='''
-    ts:
+    records:
       plugin:
         dynamic_reload_mode: 1
 
@@ -175,7 +175,7 @@ test4 = conf_remap_yaml_load_test(
     gold_file="gold/200OK_test.gold",
     remap_filename="testexample_remap.yaml",
     remap_content='''
-    ts:
+    records:
       url_remap:
         pristine_host_hdr: 1
       hostdb:

--- a/tests/gold_tests/remap/conf_remap_float.test.py
+++ b/tests/gold_tests/remap/conf_remap_float.test.py
@@ -22,7 +22,7 @@ Test.testName = 'Float in conf_remap Config Test'
 ts = Test.MakeATSProcess("ts")
 
 ts.Disk.MakeConfigFile('conf_remap.yaml').update('''
-ts:
+records:
   http:
     background_fill_completed_threshold: !!float '0.5'
 ''')

--- a/tools/records/convert2yaml.py
+++ b/tools/records/convert2yaml.py
@@ -274,7 +274,7 @@ def handle_file_input(args):
             idx = idx + 1
 
     ts = {}
-    ts['ts'] = config
+    ts['records'] = config
 
     if args.schema:
         err = validate_schema(ts, args.schema)


### PR DESCRIPTION
This apply to `records.yaml` and `conf_remap` plugin that uses input files.