### PR TITLE
Clarify VCONN_CLOSE serialization in developer docs

### DIFF
--- a/doc/developer-guide/plugins/hooks-and-transactions/ssl-hooks.en.rst
+++ b/doc/developer-guide/plugins/hooks-and-transactions/ssl-hooks.en.rst
@@ -66,6 +66,9 @@ TS_VCONN_CLOSE_HOOK
 This hook is invoked after the SSL handshake is done and when the IO is closing. The TSVConnArgs
 should be cleaned up here. A callback at this point must re-enable.
 
+This hook will not be invoked until all HTTP session and transaction hooks have
+completed.
+
 TS_SSL_CLIENT_HELLO_HOOK
 ------------------------
 


### PR DESCRIPTION
Plugins may want to use both TLS and HTTP hooks without a mutex. An example of this is the ja3_fingerprint, which has a possible race condition between the `VCONN_CLOSE` hook and HTTP hooks according to the current documentation. However, these events happen on the same thread and are thus serialized. This updates the documentation to clarify that the current behavior is guaranteed.