### PR TITLE
Fix pipelined chunked parsing.

### DIFF
--- a/tests/gold_tests/pipeline/pipeline.test.py
+++ b/tests/gold_tests/pipeline/pipeline.test.py
@@ -1,0 +1,105 @@
+'''Test a pipelined chunked encoded request.'''
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from ports import get_port
+import sys
+
+Test.Summary = '''Test a pipelined chunked encoded request.'''
+
+
+class TestPipelining:
+    """Verify that a pipelined chunked encoded request is handled correctly."""
+
+    _client_script: str = 'pipeline_client.py'
+    _server_script: str = 'pipeline_server.py'
+
+    def __init__(self) -> None:
+        """Configure the TestRun."""
+        tr = Test.AddTestRun('Test a pipelined chunked encoded request.')
+        tr.TimeOut = 10
+        self._configure_dns(tr)
+        self._configure_server(tr)
+        self._configure_traffic_server(tr)
+        self._configure_client(tr)
+
+    def _configure_dns(self, tr: 'TestRun') -> 'Process':
+        """Configure the DNS.
+
+        :param tr: The test run to associate with the DNS process with.
+        :return: The DNS process.
+        """
+        dns = tr.MakeDNServer('dns', default='127.0.0.1')
+        self._dns = dns
+        return dns
+
+    def _configure_server(self, tr: 'TestRun') -> 'Process':
+        """Configure the origin server.
+
+        :param tr: The test run to associate with the origin server with.
+        :return: The origin server process.
+        """
+        server = tr.Processes.Process('server')
+        tr.Setup.Copy(self._server_script)
+        port = get_port(server, "http_port")
+        server.Command = f'{sys.executable} {self._server_script} 127.0.0.1 {port} '
+        server.ReturnCode = 0
+        server.Ready = When.PortOpenv4(port)
+        server.Streams.All += Testers.ContainsExpression('/first', 'Should receive the first request')
+        server.Streams.All += Testers.ContainsExpression('/second', 'Should receive the second request')
+        server.Streams.All += Testers.ContainsExpression('/third', 'Should receive the third request')
+        self._server = server
+        return server
+
+    def _configure_traffic_server(self, tr: 'TestRun') -> 'Process':
+        """Configure ATS.
+
+        :param tr: The test run to associate with the ATS process with.
+        :return: The ATS process.
+        """
+        ts = tr.MakeATSProcess('ts', enable_cache=False)
+        self._ts = ts
+        ts.Disk.remap_config.AddLine(f'map / http://backend.server.com:{self._server.Variables.http_port}')
+        ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http',
+                'proxy.config.dns.nameservers': f'127.0.0.1:{self._dns.Variables.Port}',
+                'proxy.config.dns.resolv_conf': 'NULL',
+            })
+        return ts
+
+    def _configure_client(self, tr: 'TestRun') -> 'Process':
+        """Configure the client.
+
+        :param tr: The test run to associate with the client process with.
+        :return: The client process.
+        """
+        client = tr.Processes.Default
+        tr.Setup.Copy(self._client_script)
+        client.Command = (f'{sys.executable} {self._client_script} 127.0.0.1 {self._ts.Variables.port} '
+                          'server.com server.com')
+        client.ReturnCode = 0
+        client.Streams.All += Testers.ContainsExpression('X-Response: first', "Should receive the origin's first response.")
+        client.Streams.All += Testers.ContainsExpression('X-Response: second', "Should receive the origin's second response.")
+        client.Streams.All += Testers.ContainsExpression('X-Response: third', "Should receive the origin's third response.")
+        client.StartBefore(self._dns)
+        client.StartBefore(self._server)
+        client.StartBefore(self._ts)
+
+
+TestPipelining()

--- a/tests/gold_tests/pipeline/pipeline_client.py
+++ b/tests/gold_tests/pipeline/pipeline_client.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""A client that sends three pipelined GET requests."""
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import socket
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("proxy_address", metavar="proxy-address", help="Address of the proxy to connect to.")
+    parser.add_argument("proxy_port", metavar="proxy-port", type=int, help="The port of the proxy to connect to.")
+    parser.add_argument('first_hostname', metavar='first-hostname', help='The Host header field value of the first request.')
+    parser.add_argument('second_hostname', metavar='second-hostname', help='The Host header field value of the second request.')
+    return parser.parse_args()
+
+
+def open_connection(address: str, port: int) -> socket.socket:
+    """Open a connection to the desired host.
+
+    :param address: The address of the host to connect to.
+    :param port: The port of the host to connect to.
+    :return: The socket connected to the host.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((address, port))
+    print(f'Connected to {address}:{port}')
+    return sock
+
+
+def write_pipelined_requests(sock: socket.socket, first_hostname: str, second_hostname: str) -> None:
+    """Write three pipelined requests to the socket.
+
+    :param sock: The socket to write to.
+    :param first_hostname: The Host header field value of the first request.
+    :param second_hostname: The Host header field value of the second request.
+    """
+    first_request = f'GET /first HTTP/1.1\r\nHost: {first_hostname}\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n'
+    second_request = f'GET /second HTTP/1.1\r\nHost: {first_hostname}\r\nContent-Length: 5\r\n\r\n12345'
+    third_request = f'GET /third HTTP/1.1\r\nHost: {second_hostname}\r\nContent-Length: 0\r\n\r\n'
+    pipelined_requests = first_request + second_request + third_request
+    print(
+        f'Sending three pipelined requests: {len(first_request)} bytes, {len(second_request)} bytes, and {len(third_request)}  bytes:'
+    )
+    print(pipelined_requests)
+    sock.sendall(pipelined_requests.encode())
+    print()
+
+
+def wait_for_responses(sock: socket.socket, num_responses: int) -> bytes:
+    """Wait for the responses to be complete.
+
+    :param sock: The socket to read from.
+    :param num_responses: The number of responses to wait for.
+    :returns: The bytes read off the socket.
+    """
+    responses = b""
+    while True:
+        data = sock.recv(1024)
+        if not data:
+            print("Socket closed.")
+            break
+        print(f'Received:\n{data}')
+        responses += data
+        if responses.count(b"\r\n\r\n") == num_responses:
+            break
+    return responses
+
+
+def main() -> int:
+    """Send the pipelined requests."""
+    args = parse_args()
+    with open_connection(args.proxy_address, args.proxy_port) as s:
+        write_pipelined_requests(s, args.first_hostname, args.second_hostname)
+        print("Waiting for responses...")
+        responses = wait_for_responses(s, 3)
+    print()
+    print(f'Received responses:\n{responses.decode()}')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gold_tests/pipeline/pipeline_server.py
+++ b/tests/gold_tests/pipeline/pipeline_server.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""A server that receives possibly pipelined requests."""
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import socket
+import sys
+"""A flag indicating whether all three requests have been received."""
+done_with_all_requests: bool = False
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the command line arguments.
+
+    :returns: The parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("address", help="Address to listen on.")
+    parser.add_argument("port", type=int, help="The port to listen on.")
+    return parser.parse_args()
+
+
+def get_listening_socket(address: str, port: int) -> socket.socket:
+    """Create a listening socket.
+
+    :param address: The address to listen on.
+    :param port: The port to listen on.
+    :returns: A listening socket.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((address, port))
+    sock.listen(1)
+    return sock
+
+
+def accept_connection(sock: socket.socket) -> socket.socket:
+    """Accept a connection.
+
+    :param sock: The socket to accept a connection on.
+    :returns: The accepted socket.
+    """
+    return sock.accept()[0]
+
+
+def receive_requests(sock: socket.socket) -> None:
+    """Receive three requests from the client.
+
+    :param sock: The socket to read from.
+    """
+    global done_with_all_requests
+
+    all_received_data: bytes = b""
+    this_request: bytes = b""
+    first_response_bytes: bytes = b'HTTP/1.1 200 OK\r\nX-Response: first\r\nContent-Length: 0\r\n\r\n'
+    second_response_bytes: bytes = b'HTTP/1.1 200 OK\r\nX-Response: second\r\nContent-Length: 0\r\n\r\n'
+    third_response_bytes: bytes = b'HTTP/1.1 200 OK\r\nX-Response: third\r\nContent-Length: 0\r\n\r\n'
+    processing_first_request: bool = True
+    processing_second_request: bool = False
+    processing_third_request: bool = False
+    end_of_first_request: bytes = b'\r\n0\r\n\r\n'
+    end_of_second_request: bytes = b'12345'
+    end_of_third_request: bytes = b'\r\n\r\n'
+    while not done_with_all_requests:
+        data = sock.recv(1024)
+        if not data:
+            print("Socket closed.")
+            break
+        print(f'Received:')
+        print(data)
+        this_request += data
+        all_received_data += data
+        while not done_with_all_requests:
+            if processing_first_request:
+                end_of_request_index = this_request.find(end_of_first_request)
+                if end_of_request_index == -1:
+                    # Need more data.
+                    break
+                print('  Received the first request:')
+                print(f'  {this_request[:end_of_request_index + len(end_of_first_request)]}')
+                processing_first_request = False
+                processing_second_request = True
+                # Remove the first request from the buffer.
+                this_request = this_request[end_of_request_index + len(end_of_first_request):]
+                print('  Sending response to the first request:')
+                print(f'  {first_response_bytes}')
+                print()
+                sock.sendall(first_response_bytes)
+                continue
+
+            elif processing_second_request:
+                end_of_request_index = this_request.find(end_of_second_request)
+                if end_of_request_index == -1:
+                    # Need more data.
+                    break
+                print('  Received the second request:')
+                print(f'  {this_request[:end_of_request_index + len(end_of_second_request)]}')
+                processing_second_request = False
+                processing_third_request = True
+                # Remove the second request from the buffer.
+                this_request = this_request[end_of_request_index + len(end_of_second_request):]
+                print('  Sending response to the second request:')
+                print(f'  {second_response_bytes}')
+                print()
+                sock.sendall(second_response_bytes)
+                continue
+
+            elif processing_third_request:
+                end_of_request_index = this_request.find(end_of_third_request)
+                if end_of_request_index == -1:
+                    # Need more data.
+                    break
+                print('  Received the third request:')
+                print(f'  {this_request[:end_of_request_index + len(end_of_third_request)]}')
+                processing_third_request = False
+                # Remove the third request from the buffer.
+                this_request = this_request[end_of_request_index + len(end_of_third_request):]
+                print('  Sending response to the third request:')
+                print(f'  {third_response_bytes}')
+                print()
+                sock.sendall(third_response_bytes)
+                done_with_all_requests = True
+                break
+    return all_received_data
+
+
+def _run_server_inside_try(address: str, port: int) -> int:
+    """Run the server to handle the pipelined requests.
+
+    :param address: The address to listen on.
+    :param port: The port to listen on.
+    :return: 0 on success, 1 on failure (appropriate for the command line return
+    code).
+    """
+    with get_listening_socket(address, port) as listening_sock:
+        print(f"Listening on {address}:{port}")
+
+        read_bytes: bytes = b""
+        while len(read_bytes) == 0:
+            print('Waiting for a connection.')
+            with accept_connection(listening_sock) as sock:
+                read_bytes = receive_requests(sock)
+                if len(read_bytes) == 0:
+                    # This is probably the PortOpenv4 test. Try again.
+                    print("No bytes read on this connection. Trying again.")
+                    sock.close()
+                    continue
+
+
+def run_server(address: str, port: int) -> int:
+    """Run the server to handle the pipelined requests.
+
+    :param address: The address to listen on.
+    :param port: The port to listen on.
+    :return: 0 on success, 1 on failure (appropriate for the command line return
+    code).
+    """
+
+    try:
+        ret = _run_server_inside_try(address, port)
+    except KeyboardInterrupt:
+        print('Handling KeyboardInterrupt.')
+
+    return 0 if done_with_all_requests else 1
+
+
+def main() -> int:
+    """Receive pipelined requests."""
+    args = parse_args()
+    ret = run_server(args.address, args.port)
+
+    print(f'Done. All requests were received: {done_with_all_requests}')
+    return ret
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
For chunked bodies, we overly aggressively consumed bytes from the client side reader buffer, causing us to drop a potentially future pipelined request after the chunked body. This fixes how we consume chunked body bytes so that a pipelined request is not dropped.

---

Making a draft for now while I figure out how to address the buffered request use case that the `body_buffer` test fails on.