### PR TITLE
HttpSM request tunneling naming updates

### DIFF
--- a/include/iocore/eventsystem/VIO.h
+++ b/include/iocore/eventsystem/VIO.h
@@ -206,6 +206,9 @@ public:
     Internal backpointer to the VConnection for use in the reenable
     functions.
 
+    Despite the name, this may refer to either a client or server side
+    connection.
+
   */
   VConnection *vc_server = nullptr;
 

--- a/include/iocore/net/NetVConnection.h
+++ b/include/iocore/net/NetVConnection.h
@@ -541,7 +541,8 @@ protected:
   bool got_local_addr  = false;
   bool got_remote_addr = false;
 
-  bool is_internal_request  = false;
+  bool is_internal_request = false;
+  /// Indicate whether remapping will be done for this connection.
   bool is_unmanaged_request = false;
   /// Set if this connection is transparent.
   bool is_transparent = false;

--- a/include/proxy/http/Http1ClientSession.h
+++ b/include/proxy/http/Http1ClientSession.h
@@ -99,7 +99,9 @@ private:
     HCS_CLOSED,
   };
 
-  int  magic          = HTTP_CS_MAGIC_DEAD;
+  int magic = HTTP_CS_MAGIC_DEAD;
+
+  /// A monotonically increasing count of all transactions ever handled by the session.
   int  transact_count = 0;
   bool half_close     = false;
   bool conn_decrease  = false;

--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -366,7 +366,6 @@ private:
   int state_http_server_open(int event, void *data);
   int state_raw_http_server_open(int event, void *data);
   int state_send_server_request_header(int event, void *data);
-  int state_acquire_server_read(int event, void *data);
   int state_read_server_response_header(int event, void *data);
 
   // API
@@ -402,7 +401,7 @@ private:
   bool is_prewarm_enabled_or_sni_overridden(const TLSTunnelSupport &tts) const;
   void open_prewarmed_connection();
   void send_origin_throttled_response();
-  void do_setup_post_tunnel(HttpVC_t to_vc_type);
+  void do_setup_client_request_body_tunnel(HttpVC_t to_vc_type);
   void do_cache_prepare_write();
   void do_cache_prepare_write_transform();
   void do_cache_prepare_update();
@@ -507,7 +506,7 @@ public:
   bool    server_ssl_reused               = false;
   bool    server_connection_is_ssl        = false;
   bool    is_waiting_for_full_body        = false;
-  bool    is_using_post_buffer            = false;
+  bool    is_buffering_request_body       = false;
   // hooks_set records whether there are any hooks relevant
   //  to this transaction.  Used to avoid costly calls
   //  do_api_callout_internal()

--- a/src/proxy/http/Http1ClientSession.cc
+++ b/src/proxy/http/Http1ClientSession.cc
@@ -406,7 +406,8 @@ Http1ClientSession::state_keep_alive(int event, void *data)
   return 0;
 }
 
-// Called from the Http1Transaction::release
+// Called from the Http1Transaction::release or at the start of a session for
+// the very first transaction from Http1ClientSession::new_connection.
 void
 Http1ClientSession::release(ProxyTransaction *trans)
 {

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1504,7 +1504,7 @@ HttpTransact::HandleRequest(State *s)
 {
   TxnDbg(dbg_ctl_http_trans, "START HttpTransact::HandleRequest");
 
-  if (!s->state_machine->is_waiting_for_full_body && !s->state_machine->is_using_post_buffer) {
+  if (!s->state_machine->is_waiting_for_full_body && !s->state_machine->is_buffering_request_body) {
     ink_assert(!s->hdr_info.server_request.valid());
 
     Metrics::Counter::increment(http_rsb.incoming_requests);


### PR DESCRIPTION
These are some HttpSM naming and comment changes I made to improve readability while working on request body processing. No functionality is changed with this PR.