### PR TITLE
Fix unused function parameters in the plugins functionality

### DIFF
--- a/plugins/cache_promote/policy.h
+++ b/plugins/cache_promote/policy.h
@@ -77,7 +77,7 @@ public:
   }
 
   virtual bool
-  parseOption(int opt, char *optarg)
+  parseOption(int /* opt ATS_UNUSED */, char * /* optarg ATS_UNUSED */)
   {
     return false;
   }
@@ -90,7 +90,7 @@ public:
 
   // Cleanup any internal state / memory that may be in use
   virtual void
-  cleanup(TSHttpTxn txnp)
+  cleanup(TSHttpTxn /* txnp ATS_UNUSED */)
   {
   }
 
@@ -102,7 +102,7 @@ public:
   }
 
   virtual void
-  addBytes(TSHttpTxn txnp)
+  addBytes(TSHttpTxn /* txnp ATS_UNUSED */)
   {
   }
 

--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -188,7 +188,7 @@ delete_pluginconfig(pluginconfig *const pc)
  * Entry point when used as a global plugin.
  */
 int
-handle_read_request_header(TSCont txn_contp, TSEvent event, void *edata)
+handle_read_request_header(TSCont /* txn_contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
 

--- a/plugins/cachekey/plugin.cc
+++ b/plugins/cachekey/plugin.cc
@@ -78,7 +78,7 @@ setCacheKey(TSHttpTxn txn, Configs *config, TSRemapRequestInfo *rri = nullptr)
 }
 
 static int
-contSetCachekey(TSCont contp, TSEvent event, void *edata)
+contSetCachekey(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSHttpTxn txn = static_cast<TSHttpTxn>(edata);
 
@@ -130,7 +130,7 @@ TSPluginInit(int argc, const char *argv[])
  * @return always TS_SUCCESS.
  */
 TSReturnCode
-TSRemapInit(TSRemapInterface *apiInfo, char *errBuf, int erroBufSize)
+TSRemapInit(TSRemapInterface * /* apiInfo ATS_UNUSED */, char * /* errBuf ATS_UNUSED */, int /* erroBufSize ATS_UNUSED */)
 {
   return TS_SUCCESS;
 }
@@ -147,7 +147,7 @@ TSRemapInit(TSRemapInterface *apiInfo, char *errBuf, int erroBufSize)
  * @return TS_SUCCES if success or TS_ERROR if failure
  */
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **instance, char *errBuf, int errBufSize)
+TSRemapNewInstance(int argc, char *argv[], void **instance, char * /* errBuf ATS_UNUSED */, int /* errBufSize ATS_UNUSED */)
 {
   Configs *config = new Configs();
   if (nullptr != config && config->init(argc, const_cast<const char **>(argv), /* perRemapConfig */ true)) {

--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -395,7 +395,7 @@ mkcrt(const std::string &commonName, int serial)
 }
 
 static int
-shadow_cert_generator(TSCont contp, TSEvent event, void *edata)
+shadow_cert_generator(TSCont contp, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   const char *servername = reinterpret_cast<const char *>(TSContDataGet(contp));
   std::string commonName(servername);
@@ -523,7 +523,7 @@ shadow_cert_generator(TSCont contp, TSEvent event, void *edata)
 
 /// Callback at TS_SSL_CERT_HOOK, generate/look up shadow certificates based on SNI/FQDN
 static int
-cert_retriever(TSCont contp, TSEvent event, void *edata)
+cert_retriever(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSVConn         ssl_vc     = reinterpret_cast<TSVConn>(edata);
   TSSslConnection sslobj     = TSVConnSslConnectionGet(ssl_vc);

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -1061,7 +1061,7 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 }
 
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **instance, char *errbuf, int errbuf_size)
+TSRemapNewInstance(int argc, char *argv[], void **instance, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   info("Instantiating a new compress plugin remap rule");
   info("Reading config from file = %s", argv[2]);
@@ -1094,7 +1094,7 @@ TSRemapDeleteInstance(void *instance)
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   if (nullptr == instance) {
     info("No Rules configured, falling back to default");

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -1215,7 +1215,7 @@ writeErrorResponse(InterceptData &int_data, int &n_bytes_written)
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void * /* ih ATS_UNUSED */, TSHttpTxn rh, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   TSUserArgSet(rh, arg_idx, (void *)1); /* Save for later hooks */
   return TSREMAP_NO_REMAP;              /* Continue with next remap plugin in chain */
@@ -1250,7 +1250,8 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 }
 
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size)
+TSRemapNewInstance(int /* argc ATS_UNUSED */, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */,
+                   int /* errbuf_size ATS_UNUSED */)
 {
   *ih = nullptr;
 
@@ -1259,7 +1260,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_s
 }
 
 void
-TSRemapDeleteInstance(void *ih)
+TSRemapDeleteInstance(void * /* ih ATS_UNUSED */)
 {
   return;
 }

--- a/plugins/esi/test/TestHttpDataFetcher.h
+++ b/plugins/esi/test/TestHttpDataFetcher.h
@@ -32,14 +32,15 @@ class TestHttpDataFetcher : public HttpDataFetcher
 public:
   TestHttpDataFetcher() {}
   bool
-  addFetchRequest(const std::string &url, FetchedDataProcessor *callback_obj = nullptr) override
+  addFetchRequest(const std::string & /* url ATS_UNUSED */,
+                  FetchedDataProcessor * /* callback_obj  ATS_UNUSED */ = nullptr) override
   {
     ++_n_pending_requests;
     return true;
   }
 
   DataStatus
-  getRequestStatus(const std::string &url) const override
+  getRequestStatus(const std::string & /* url ATS_UNUSED */) const override
   {
     if (_return_data) {
       return STATUS_DATA_AVAILABLE;

--- a/plugins/experimental/access_control/plugin.cc
+++ b/plugins/experimental/access_control/plugin.cc
@@ -100,7 +100,7 @@ public:
  * @return always TS_SUCCESS.
  */
 TSReturnCode
-TSRemapInit(TSRemapInterface *apiInfo, char *errBuf, int erroBufSize)
+TSRemapInit(TSRemapInterface * /* apiInfo ATS_UNUSED */, char * /* errBuf ATS_UNUSED */, int /* erroBufSize ATS_UNUSED */)
 {
   return TS_SUCCESS;
 }
@@ -117,7 +117,7 @@ TSRemapInit(TSRemapInterface *apiInfo, char *errBuf, int erroBufSize)
  * @return TS_SUCCES if success or TS_ERROR if failure
  */
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **instance, char *errBuf, int errBufSize)
+TSRemapNewInstance(int argc, char *argv[], void **instance, char * /* errBuf ATS_UNUSED */, int /* errBufSize ATS_UNUSED */)
 {
   AccessControlConfig *config = new AccessControlConfig();
   if (nullptr != config && config->init(argc, argv)) {
@@ -229,7 +229,7 @@ nextDuplicate(TSMBuffer buffer, TSMLoc hdr, TSMLoc field)
  * @note Add the cookies to "hier-part" (RFC 3986), always sort them in the cache key.
  */
 bool
-getCookieByName(TSHttpTxn txn, TSMBuffer buf, TSMLoc hdrs, const String &cookieName, String &cookieValue)
+getCookieByName(TSHttpTxn /* txn ATS_UNUSED */, TSMBuffer buf, TSMLoc hdrs, const String &cookieName, String &cookieValue)
 {
   TSMLoc field;
 

--- a/plugins/experimental/access_control/utils.cc
+++ b/plugins/experimental/access_control/utils.cc
@@ -200,7 +200,7 @@ cryptoErrStr(char *buffer, size_t bufferLen)
  */
 size_t
 cryptoMessageDigestGet(const char *digestType, const char *data, size_t dataLen, const char *key, size_t keyLen, char *out,
-                       size_t outLen)
+                       size_t /* outLen ATS_UNUSED */)
 {
 #ifndef HAVE_HMAC_CTX_NEW
   HMAC_CTX ctx[1];
@@ -288,7 +288,7 @@ cryptoBase64EncodedSize(size_t decodedSize)
  * @return output buffer size
  */
 size_t
-cryptoBase64DecodeSize(const char *encoded, size_t encodedLen)
+cryptoBase64DecodeSize(const char * /* encoded ATS_UNUSED */, size_t encodedLen)
 {
   return ats_base64_decode_dstlen(encodedLen);
 }

--- a/plugins/experimental/block_errors/block_errors.cc
+++ b/plugins/experimental/block_errors/block_errors.cc
@@ -37,7 +37,7 @@ static bool     enabled             = true;
 
 //-------------------------------------------------------------------------
 static int
-msg_hook(TSCont *contp, TSEvent event, void *edata)
+msg_hook(TSCont * /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSPluginMsg     *msg = static_cast<TSPluginMsg *>(edata);
   std::string_view tag(static_cast<const char *>(msg->tag));
@@ -151,7 +151,7 @@ IPTable ip_table;
 
 //-------------------------------------------------------------------------
 static int
-handle_start_hook(TSCont *contp, TSEvent event, void *edata)
+handle_start_hook(TSCont * /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   Dbg(dbg_ctl, "handle_start_hook");
   auto vconn = static_cast<TSVConn>(edata);
@@ -209,7 +209,7 @@ struct Errors {
 
 //-------------------------------------------------------------------------
 static int
-handle_close_hook(TSCont *contp, TSEvent event, void *edata)
+handle_close_hook(TSCont * /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   Dbg(dbg_ctl, "handle_close_hook");
   auto txnp = static_cast<TSHttpTxn>(edata);
@@ -255,7 +255,7 @@ handle_close_hook(TSCont *contp, TSEvent event, void *edata)
 
 //-------------------------------------------------------------------------
 static int
-clean_table(TSCont *contp, TSEvent event, void *edata)
+clean_table(TSCont * /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   ip_table.clean();
   return 0;

--- a/plugins/experimental/cache_fill/cache_fill.cc
+++ b/plugins/experimental/cache_fill/cache_fill.cc
@@ -108,7 +108,7 @@ cont_check_cacheable(TSHttpTxn txnp)
 // if a background fetch is allowed for this request
 //
 static int
-cont_handle_cache(TSCont contp, TSEvent event, void *edata)
+cont_handle_cache(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
   if (TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE == event) {
@@ -147,7 +147,8 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 // We don't have any specific "instances" here, at least not yet.
 //
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf */, int /* errbuf_size */)
+TSRemapNewInstance(int /* argc ATS_UNUSED */, char ** /* argv ATS_UNUSED */, void **ih, char * /* errbuf ATS_UNUSED */,
+                   int /* errbuf_size ATS_UNUSED */)
 {
   TSCont cont = TSContCreate(cont_handle_cache, nullptr);
   *ih         = cont;

--- a/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
+++ b/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
@@ -171,7 +171,7 @@ CB_context_dump(TSCont, TSEvent, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/plugins/experimental/cookie_remap/cookie_remap.cc
+++ b/plugins/experimental/cookie_remap/cookie_remap.cc
@@ -896,7 +896,7 @@ using OpsQueue = std::vector<const op *>;
 //----------------------------------------------------------------------------
 // init
 TSReturnCode
-TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+TSRemapInit(TSRemapInterface * /* api_info ATS_UNUSED */, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   return TS_SUCCESS;
 }
@@ -904,7 +904,7 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 //----------------------------------------------------------------------------
 // initialization of structures from config parameters
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size)
+TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   if (argc != 3) {
     TSError("arguments not equal to 3: %d", argc);

--- a/plugins/experimental/fq_pacing/fq_pacing.cc
+++ b/plugins/experimental/fq_pacing/fq_pacing.cc
@@ -86,7 +86,7 @@ fq_is_default_qdisc()
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 
@@ -171,7 +171,7 @@ TSRemapDeleteInstance(void *instance)
 }
 
 static int
-reset_pacing_cont(TSCont contp, TSEvent event, void *edata)
+reset_pacing_cont(TSCont contp, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSHttpTxn txnp     = static_cast<TSHttpTxn>(edata);
   auto      txn_data = static_cast<fq_pacing_cont_t *>(TSContDataGet(contp));
@@ -197,7 +197,7 @@ reset_pacing_cont(TSCont contp, TSEvent event, void *edata)
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   if (TSHttpTxnClientProtocolStackContains(txnp, TS_PROTO_TAG_HTTP_2_0) != nullptr) {
     Dbg(dbg_ctl, "Skipping plugin execution for HTTP/2 requests");

--- a/plugins/experimental/geoip_acl/acl.cc
+++ b/plugins/experimental/geoip_acl/acl.cc
@@ -95,13 +95,13 @@ Acl::init()
 }
 
 int
-Acl::country_id_by_code(const std::string &str) const
+Acl::country_id_by_code(const std::string & /* str ATS_UNUSED */) const
 {
   return -1;
 }
 
 int
-Acl::country_id_by_addr(const sockaddr *addr) const
+Acl::country_id_by_addr(const sockaddr * /* addr ATS_UNUSED */) const
 {
   return -1;
 }

--- a/plugins/experimental/header_freq/header_freq.cc
+++ b/plugins/experimental/header_freq/header_freq.cc
@@ -103,7 +103,7 @@ Log_Data(std::ostream &ss)
  * the origin headers.
  */
 int
-CB_Command_Log(TSCont contp, TSEvent event, void *edata)
+CB_Command_Log(TSCont contp, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   std::string *command = static_cast<std::string *>(TSContDataGet(contp));
   if (nullptr == command) {
@@ -224,7 +224,7 @@ handle_header_event(TSHttpTxn txnp, TSEvent event, CountMap_t &freq_map)
  * SEND_RESPONSE_HDR hooks.
  */
 int
-header_handle_hook(TSCont contp, TSEvent event, void *edata)
+header_handle_hook(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp    = reinterpret_cast<TSHttpTxn>(edata);
   int       ret_val = TS_SUCCESS;
@@ -251,7 +251,7 @@ header_handle_hook(TSCont contp, TSEvent event, void *edata)
  * header stats.
  */
 int
-msg_handle_hook(TSCont contp, TSEvent event, void *edata)
+msg_handle_hook(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   switch (event) {
   case TS_EVENT_LIFECYCLE_MSG: // Handle external command
@@ -286,7 +286,7 @@ msg_handle_hook(TSCont contp, TSEvent event, void *edata)
 
 /// Registration entry point for plugin.
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   Dbg(dbg_ctl_init, "initializing plugin");
 

--- a/plugins/experimental/hook-trace/hook-trace.cc
+++ b/plugins/experimental/hook-trace/hook-trace.cc
@@ -35,7 +35,7 @@ countof(const T (&)[N])
 }
 
 static int
-HttpHookTracer(TSCont contp, TSEvent event, void *edata)
+HttpHookTracer(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   union {
     TSHttpTxn     txn;
@@ -124,7 +124,7 @@ HttpHookTracer(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-LifecycleHookTracer(TSCont contp, TSEvent event, void *edata)
+LifecycleHookTracer(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   switch (event) {
   case TS_EVENT_LIFECYCLE_PORTS_INITIALIZED:

--- a/plugins/experimental/http_stats/http_stats.cc
+++ b/plugins/experimental/http_stats/http_stats.cc
@@ -244,7 +244,7 @@ HeaderFieldStringSet(const HTTPStatsHttpHeader &http, const char *field_name, in
 }
 
 static TSReturnCode
-WriteResponseHeader(HTTPStatsRequest *trq, TSCont /* contp ATS_UNUSED */, TSHttpStatus status)
+WriteResponseHeader(HTTPStatsRequest *trq, TSHttpStatus status)
 {
   HTTPStatsHttpHeader response;
 
@@ -403,7 +403,7 @@ HTTPStatsInterceptHook(TSCont contp, TSEvent event, void *edata)
         cdata.trq->writeio.write(TSVIOVConnGet(arg.vio), contp);
         TSVIONBytesSet(cdata.trq->writeio.vio, 0);
 
-        if (WriteResponseHeader(cdata.trq, contp, status) != TS_SUCCESS) {
+        if (WriteResponseHeader(cdata.trq, status) != TS_SUCCESS) {
           VERROR("failure writing response");
           return TS_EVENT_ERROR;
         }

--- a/plugins/experimental/http_stats/http_stats.cc
+++ b/plugins/experimental/http_stats/http_stats.cc
@@ -244,7 +244,7 @@ HeaderFieldStringSet(const HTTPStatsHttpHeader &http, const char *field_name, in
 }
 
 static TSReturnCode
-WriteResponseHeader(HTTPStatsRequest *trq, TSCont contp, TSHttpStatus status)
+WriteResponseHeader(HTTPStatsRequest *trq, TSCont /* contp ATS_UNUSED */, TSHttpStatus status)
 {
   HTTPStatsHttpHeader response;
 
@@ -568,7 +568,7 @@ TSRemapInit(TSRemapInterface * /* api_info */, char * /* errbuf */, int /* errbu
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   const TSHttpStatus txnstat = TSHttpTxnStatusGet(rh);
   if (txnstat != TS_HTTP_STATUS_NONE && txnstat != TS_HTTP_STATUS_OK) {
@@ -704,7 +704,8 @@ HTTPStatsFormatter::wrap_unsigned_counter(uint64_t value)
   } while (0)
 
 static void
-json_out_stat(TSRecordType rec_type, void *edata, int registered, const char *name, TSRecordDataType data_type, TSRecordData *datum)
+json_out_stat(TSRecordType /* rec_type ATS_UNUSED */, void *edata, int /* registered ATS_UNUSED */, const char *name,
+              TSRecordDataType data_type, TSRecordData *datum)
 {
   HTTPStatsFormatter *fmtr = static_cast<HTTPStatsFormatter *>(edata);
 
@@ -728,7 +729,8 @@ json_out_stat(TSRecordType rec_type, void *edata, int registered, const char *na
 }
 
 static void
-csv_out_stat(TSRecordType rec_type, void *edata, int registered, const char *name, TSRecordDataType data_type, TSRecordData *datum)
+csv_out_stat(TSRecordType /* rec_type ATS_UNUSED */, void *edata, int /* registered ATS_UNUSED */, const char *name,
+             TSRecordDataType data_type, TSRecordData *datum)
 {
   HTTPStatsFormatter *fmtr = static_cast<HTTPStatsFormatter *>(edata);
 

--- a/plugins/experimental/icap/icap_plugin.cc
+++ b/plugins/experimental/icap/icap_plugin.cc
@@ -256,7 +256,7 @@ handle_invalid_icap_behavior(TSCont contp, TransformData *data, const char *msg)
  *              icap eaders from response of icap server.
  */
 static int
-handle_icap_headers(TSCont /* contp ATS_UNUSED */, TransformData *data)
+handle_icap_headers(TransformData *data)
 {
   int64_t     pos = data->icap_header.find("\r\n");
   std::string icap_status_line =
@@ -329,7 +329,7 @@ handle_icap_http_header(TransformData *data)
  *              downstream.
  */
 static int
-handle_read_http_body(TSCont /* contp ATS_UNUSED */, TransformData *data)
+handle_read_http_body(TransformData *data)
 {
   int64_t avail = TSIOBufferReaderAvail(data->icap_resp_reader);
 
@@ -465,7 +465,7 @@ transform_connect(TSCont contp, TransformData *data)
 }
 
 static int
-transform_write_body(TSCont /* contp ATS_UNUSED */, TransformData *data)
+transform_write_body(TransformData *data)
 {
   data->state = State::WRITE_BODY;
   /* If debug-mode enabled, allocate buffer to store origin response */
@@ -521,7 +521,7 @@ transform_read_http_body(TSCont contp, TransformData *data)
   }
 
   if (TSIOBufferReaderAvail(data->icap_resp_reader)) {
-    return handle_read_http_body(contp, data);
+    return handle_read_http_body(data);
   }
 
   return 0;
@@ -570,7 +570,7 @@ handle_write_header(TSCont contp, TransformData *data)
   TSHandleMLocRelease(bufp_c, TS_NULL_MLOC, req_loc);
   TSHandleMLocRelease(bufp_s, TS_NULL_MLOC, resp_loc);
 
-  return transform_write_body(contp, data);
+  return transform_write_body(data);
 }
 
 static int
@@ -707,7 +707,7 @@ transform_bypass(TSCont contp, TransformData *data)
  * Description: Buffer response body from origin server.
  */
 static int
-transform_buffer_os_resp(TSCont /* contp ATS_UNUSED */, TransformData *data)
+transform_buffer_os_resp(TransformData *data)
 {
   data->state = State::BUFFER_OS_RESP;
   Dbg(dbg_ctl, "Buffer os response.");
@@ -771,7 +771,7 @@ transform_write_header_event(TSCont contp, TransformData *data, TSEvent event, v
 {
   switch (event) {
   case TS_EVENT_VCONN_WRITE_COMPLETE:
-    return transform_write_body(contp, data);
+    return transform_write_body(data);
   case TS_EVENT_ERROR:
     return handle_invalid_icap_behavior(contp, data, "Error writing header to ICAP scanner");
   case TS_EVENT_IMMEDIATE:
@@ -798,7 +798,7 @@ transform_write_event(TSCont contp, TransformData *data, TSEvent event, void * /
      */
     if (debug_enabled) {
       setup_icap_status_header(data, "@ICAP-Status", "Cannot connect to ICAP server");
-      return transform_buffer_os_resp(contp, data);
+      return transform_buffer_os_resp(data);
     } else {
       return handle_invalid_icap_behavior(contp, data, "Error writing body to ICAP scanner");
     }
@@ -842,7 +842,7 @@ transform_read_icap_header_event(TSCont contp, TransformData *data, TSEvent even
         data->icap_header.resize(pos);
         consume = pos + token_length - consumed;
         TSIOBufferReaderConsume(reader, consume);
-        if (handle_icap_headers(contp, data)) {
+        if (handle_icap_headers(data)) {
           return transform_send_os_resp(contp, data);
         } else {
           return transform_read_http_header(contp, data);
@@ -942,7 +942,7 @@ transform_read_http_body_event(TSCont contp, TransformData *data, TSEvent event,
     data->eos_detected = true;
     break;
   case TS_EVENT_VCONN_READ_READY:
-    handle_read_http_body(contp, data);
+    handle_read_http_body(data);
     TSVIOReenable(data->output_vio);
     break;
   case TS_EVENT_VCONN_WRITE_COMPLETE:
@@ -950,7 +950,7 @@ transform_read_http_body_event(TSCont contp, TransformData *data, TSEvent event,
     break;
   case TS_EVENT_VCONN_WRITE_READY:
     TSVIOReenable(data->icap_vio);
-    handle_read_http_body(contp, data);
+    handle_read_http_body(data);
     break;
   default:
     break;

--- a/plugins/experimental/icap/icap_plugin.cc
+++ b/plugins/experimental/icap/icap_plugin.cc
@@ -256,7 +256,7 @@ handle_invalid_icap_behavior(TSCont contp, TransformData *data, const char *msg)
  *              icap eaders from response of icap server.
  */
 static int
-handle_icap_headers(TSCont contp, TransformData *data)
+handle_icap_headers(TSCont /* contp ATS_UNUSED */, TransformData *data)
 {
   int64_t     pos = data->icap_header.find("\r\n");
   std::string icap_status_line =
@@ -329,7 +329,7 @@ handle_icap_http_header(TransformData *data)
  *              downstream.
  */
 static int
-handle_read_http_body(TSCont contp, TransformData *data)
+handle_read_http_body(TSCont /* contp ATS_UNUSED */, TransformData *data)
 {
   int64_t avail = TSIOBufferReaderAvail(data->icap_resp_reader);
 
@@ -465,7 +465,7 @@ transform_connect(TSCont contp, TransformData *data)
 }
 
 static int
-transform_write_body(TSCont contp, TransformData *data)
+transform_write_body(TSCont /* contp ATS_UNUSED */, TransformData *data)
 {
   data->state = State::WRITE_BODY;
   /* If debug-mode enabled, allocate buffer to store origin response */
@@ -707,7 +707,7 @@ transform_bypass(TSCont contp, TransformData *data)
  * Description: Buffer response body from origin server.
  */
 static int
-transform_buffer_os_resp(TSCont contp, TransformData *data)
+transform_buffer_os_resp(TSCont /* contp ATS_UNUSED */, TransformData *data)
 {
   data->state = State::BUFFER_OS_RESP;
   Dbg(dbg_ctl, "Buffer os response.");
@@ -767,7 +767,7 @@ transform_connect_event(TSCont contp, TransformData *data, TSEvent event, void *
 }
 
 static int
-transform_write_header_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_write_header_event(TSCont contp, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_VCONN_WRITE_COMPLETE:
@@ -784,7 +784,7 @@ transform_write_header_event(TSCont contp, TransformData *data, TSEvent event, v
 }
 
 static int
-transform_write_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_write_event(TSCont contp, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_VCONN_WRITE_COMPLETE:
@@ -811,7 +811,7 @@ transform_write_event(TSCont contp, TransformData *data, TSEvent event, void *ed
 }
 
 static int
-transform_read_icap_header_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_read_icap_header_event(TSCont contp, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_ERROR:
@@ -867,7 +867,7 @@ transform_read_icap_header_event(TSCont contp, TransformData *data, TSEvent even
 }
 
 static int
-transform_read_http_header_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_read_http_header_event(TSCont contp, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_ERROR:
@@ -924,7 +924,7 @@ transform_read_http_header_event(TSCont contp, TransformData *data, TSEvent even
 }
 
 static int
-transform_read_http_body_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_read_http_body_event(TSCont contp, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_ERROR:
@@ -960,7 +960,7 @@ transform_read_http_body_event(TSCont contp, TransformData *data, TSEvent event,
 }
 
 static int
-transform_send_error_msg_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_send_error_msg_event(TSCont /* contp ATS_UNUSED */, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_VCONN_WRITE_COMPLETE:
@@ -976,7 +976,7 @@ transform_send_error_msg_event(TSCont contp, TransformData *data, TSEvent event,
 }
 
 static int
-transform_bypass_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_bypass_event(TSCont /* contp ATS_UNUSED */, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_VCONN_WRITE_COMPLETE:
@@ -992,7 +992,7 @@ transform_bypass_event(TSCont contp, TransformData *data, TSEvent event, void *e
 
 /* Used only for debug-mode */
 static int
-transform_buffer_os_resp_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_buffer_os_resp_event(TSCont contp, TransformData *data, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   TSVIO   write_vio;
   int64_t towrite;
@@ -1045,7 +1045,7 @@ transform_buffer_os_resp_event(TSCont contp, TransformData *data, TSEvent event,
 
 /* Used only for debug-mode */
 static int
-transform_send_os_resp_event(TSCont contp, TransformData *data, TSEvent event, void *edata)
+transform_send_os_resp_event(TSCont /* contp ATS_UNUSED */, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_VCONN_WRITE_COMPLETE:
@@ -1118,7 +1118,7 @@ transform_handler(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-request_ok(TSHttpTxn txnp)
+request_ok(TSHttpTxn /* txnp ATS_UNUSED */)
 {
   /* Is the initial client request OK for transformation. This is a
      good place to check accept headers to see if the client can
@@ -1190,7 +1190,7 @@ transform_plugin(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char *argv[])
 {
   TSPluginRegistrationInfo info;
   TSCont                   cont;

--- a/plugins/experimental/inliner/fetcher.h
+++ b/plugins/experimental/inliner/fetcher.h
@@ -198,7 +198,7 @@ template <class T> struct HttpTransaction {
   }
 
   static int
-  handle(TSCont c, TSEvent e, void *d)
+  handle(TSCont c, TSEvent e, void * /* d ATS_UNUSED */)
   {
     Self *const self = static_cast<Self *const>(TSContDataGet(c));
     assert(self != nullptr);

--- a/plugins/experimental/inliner/ts.cc
+++ b/plugins/experimental/inliner/ts.cc
@@ -151,7 +151,7 @@ namespace io
   }
 
   int
-  WriteOperation::Handle(const TSCont c, const TSEvent e, void *d)
+  WriteOperation::Handle(const TSCont c, const TSEvent e, [[maybe_unused]] void *d)
   {
     assert(c != nullptr);
     WriteOperationPointer *const p = static_cast<WriteOperationPointer *>(TSContDataGet(c));

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -291,7 +291,7 @@ MC::write_binary_error(protocol_binary_response_status err, int swallow)
 }
 
 int
-MC::swallow_then_read_event(int event, void *data)
+MC::swallow_then_read_event(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
   rvio->nbytes  = INT64_MAX;
   int64_t avail = reader->read_avail();
@@ -307,7 +307,7 @@ MC::swallow_then_read_event(int event, void *data)
 }
 
 int
-MC::swallow_cmd_then_read_from_client_event(int event, void *data)
+MC::swallow_cmd_then_read_from_client_event(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
   int64_t avail = reader->read_avail();
   if (avail) {
@@ -687,7 +687,7 @@ MC::get_ascii_input(int n, int *end)
 }
 
 int
-MC::ascii_get_event(int event, void *data)
+MC::ascii_get_event(int event, void * /* data ATS_UNUSED */)
 {
   switch (event) {
   case CACHE_EVENT_OPEN_READ_FAILED:
@@ -877,7 +877,7 @@ Lfail:
 }
 
 int
-MC::ascii_delete_event(int event, void *data)
+MC::ascii_delete_event(int event, void * /* data ATS_UNUSED */)
 {
   switch (event) {
   case CACHE_EVENT_REMOVE_FAILED:
@@ -1254,7 +1254,7 @@ is_noreply(char **pt, char *e)
 }
 
 int
-MC::read_ascii_from_client_event(int event, void *data)
+MC::read_ascii_from_client_event(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
   int   len = 0;
   char *c = get_ascii_input(TSMEMCACHE_TMP_CMD_BUFFER_SIZE, &len), *s = c;

--- a/plugins/experimental/memory_profile/memory_profile.cc
+++ b/plugins/experimental/memory_profile/memory_profile.cc
@@ -92,7 +92,7 @@ CallbackHandler(TSCont cont, TSEvent id, void *data)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
   TSCont                   cb;

--- a/plugins/experimental/money_trace/money_trace.cc
+++ b/plugins/experimental/money_trace/money_trace.cc
@@ -528,7 +528,7 @@ check_request_header(TSHttpTxn const txnp, Config const *const conf, PluginType 
 }
 
 int
-global_request_header_hook(TSCont const contp, TSEvent const event, void *const edata)
+global_request_header_hook(TSCont const contp, TSEvent const /* event ATS_UNUSED */, void *const edata)
 {
   TSHttpTxn const     txnp = static_cast<TSHttpTxn>(edata);
   Config const *const conf = static_cast<Config *>(TSContDataGet(contp));

--- a/plugins/experimental/rate_limit/rate_limit.cc
+++ b/plugins/experimental/rate_limit/rate_limit.cc
@@ -111,7 +111,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 // This is the main "entry" point for the plugin, called for every request.
 //
 TSRemapStatus
-TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   auto *limiter = static_cast<TxnRateLimiter *>(ih);
 

--- a/plugins/experimental/rate_limit/sni_selector.cc
+++ b/plugins/experimental/rate_limit/sni_selector.cc
@@ -176,7 +176,7 @@ SniSelector::yamlParser(const std::string &yaml_file)
 // This is the queue management continuation, which gets called periodically
 //
 static int
-sni_config_cont(TSCont cont, TSEvent event, void *edata)
+sni_config_cont(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   auto selector = SniSelector::instance(); // Also leases the instance
   auto old_sel  = static_cast<SniSelector *>(TSContDataGet(cont));
@@ -209,7 +209,7 @@ sni_config_cont(TSCont cont, TSEvent event, void *edata)
 // This is the queue management continuation, which gets called periodically
 //
 static int
-sni_queue_cont(TSCont cont, TSEvent event, void *edata)
+sni_queue_cont(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   auto *selector = static_cast<SniSelector *>(TSContDataGet(cont));
 

--- a/plugins/experimental/rate_limit/txn_limiter.cc
+++ b/plugins/experimental/rate_limit/txn_limiter.cc
@@ -68,7 +68,7 @@ txn_limit_cont(TSCont cont, TSEvent event, void *edata)
 }
 
 static int
-txn_queue_cont(TSCont cont, TSEvent event, void *edata)
+txn_queue_cont(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   auto     *limiter = static_cast<TxnRateLimiter *>(TSContDataGet(cont));
   QueueTime now     = std::chrono::system_clock::now(); // Only do this once per "loop"

--- a/plugins/experimental/stale_response/stale_response.cc
+++ b/plugins/experimental/stale_response/stale_response.cc
@@ -539,7 +539,7 @@ fetch_finish(StateInfo *state)
 
 /*-----------------------------------------------------------------------------------------------*/
 static int
-fetch_consume(TSCont contp, TSEvent event, void *edata)
+fetch_consume(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   StateInfo *state;
   state = static_cast<StateInfo *>(TSContDataGet(contp));
@@ -1016,7 +1016,7 @@ read_request_header_handler(TSHttpTxn const txnp, ConfigInfo *plugin_config)
 
 /*-----------------------------------------------------------------------------------------------*/
 static int
-global_request_header_hook(TSCont contp, TSEvent event, void *edata)
+global_request_header_hook(TSCont contp, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   ConfigInfo     *plugin_config = static_cast<ConfigInfo *>(TSContDataGet(contp));
   TSHttpTxn const txnp          = static_cast<TSHttpTxn>(edata);

--- a/plugins/experimental/stream_editor/stream_editor.cc
+++ b/plugins/experimental/stream_editor/stream_editor.cc
@@ -312,7 +312,8 @@ class rxmatch : public match_t
 
 public:
   bool
-  find(const char *buf, size_t len, size_t &found, size_t &found_len, const char *tmpl, std::string &repl) const override
+  find(const char *buf, size_t /* len ATS_UNUSED */, size_t &found, size_t &found_len, const char *tmpl,
+       std::string &repl) const override
   {
     regmatch_t pmatch[MAX_RX_MATCH];
     if (regexec(&rx, buf, MAX_RX_MATCH, pmatch, REG_NOTEOL) == 0) {
@@ -736,7 +737,7 @@ streamedit_process(TSCont contp)
   TSVIOReenable(contdata->out_vio);
 }
 static int
-streamedit_filter(TSCont contp, TSEvent event, void *edata)
+streamedit_filter(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   /* Our main function that does the work.
    * Called as a continuation for filtering.

--- a/plugins/experimental/system_stats/system_stats.cc
+++ b/plugins/experimental/system_stats/system_stats.cc
@@ -296,7 +296,7 @@ getStats(TSMutex stat_creation_mutex)
 }
 
 static int
-systemStatsContCB(TSCont cont, TSEvent event ATS_UNUSED, void *edata)
+systemStatsContCB(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   TSMutex stat_creation_mutex;
 
@@ -312,7 +312,7 @@ systemStatsContCB(TSCont cont, TSEvent event ATS_UNUSED, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* arg ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
   TSCont                   stats_cont;

--- a/plugins/experimental/tls_bridge/tls_bridge.cc
+++ b/plugins/experimental/tls_bridge/tls_bridge.cc
@@ -648,7 +648,7 @@ CB_Exec(TSCont contp, TSEvent ev_idx, void *data)
 
 // Handle a new transaction - check if it should be intercepted and if so do the intercept.
 int
-CB_Read_Request_Hdr(TSCont contp, TSEvent ev_idx, void *data)
+CB_Read_Request_Hdr(TSCont /* contp ATS_UNUSED */, TSEvent /* ev_idx ATS_UNUSED */, void *data)
 {
   auto      txn = static_cast<TSHttpTxn>(data);
   TSMBuffer mbuf;

--- a/plugins/experimental/txn_box/plugin/include/txn_box/accl_util.h
+++ b/plugins/experimental/txn_box/plugin/include/txn_box/accl_util.h
@@ -171,7 +171,7 @@ get_bit_from_byte(char key, std::size_t position) noexcept
 template <typename T>
 auto
 get_byte(typename T::const_pointer ptr, int byte_number,
-         typename std::enable_if_t<std::is_same_v<T, reversed_view<swoc::TextView>>> *val = 0)
+         typename std::enable_if_t<std::is_same_v<T, reversed_view<swoc::TextView>>> * /* val ATS_UNUSED */ = 0)
 {
   typename T::const_pointer byte = ptr - byte_number;
   return *byte;
@@ -179,7 +179,7 @@ get_byte(typename T::const_pointer ptr, int byte_number,
 template <typename T>
 auto
 get_byte(typename T::const_pointer ptr, int byte_number,
-         typename std::enable_if_t<!std::is_same_v<T, reversed_view<swoc::TextView>>> *val = 0)
+         typename std::enable_if_t<!std::is_same_v<T, reversed_view<swoc::TextView>>> * /* val ATS_UNUSED */ = 0)
 {
   typename T::const_pointer byte = ptr + byte_number;
   return *byte;
@@ -244,7 +244,7 @@ template <typename Key, typename Value> StringTree<Key, Value>::~StringTree()
 
 template <typename Key, typename Value>
 bool
-StringTree<Key, Value>::insert(Key const &key, Value const &value, Comparison *cmp)
+StringTree<Key, Value>::insert(Key const &key, Value const &value, Comparison * /* cmp ATS_UNUSED */)
 {
   node_type_ptr search_node = _head;
   std::size_t   idx{0};
@@ -295,7 +295,7 @@ StringTree<Key, Value>::insert(Key const &key, Value const &value, Comparison *c
 
 template <typename Key, typename Value>
 std::pair<bool, Value>
-StringTree<Key, Value>::full_match(Key const &key, Comparison *cmp) const noexcept
+StringTree<Key, Value>::full_match(Key const &key, Comparison * /* cmp ATS_UNUSED */) const noexcept
 {
   node_type_ptr search_node = _head->left;
   std::size_t   idx{0};
@@ -315,7 +315,7 @@ StringTree<Key, Value>::full_match(Key const &key, Comparison *cmp) const noexce
 
 template <typename Key, typename Value>
 std::vector<std::pair<Key, Value>>
-StringTree<Key, Value>::prefix_match(Key const &prefix, Comparison *cmp) const
+StringTree<Key, Value>::prefix_match(Key const &prefix, Comparison * /* cmp ATS_UNUSED */) const
 {
   // Nodes will help to follow, but basically we:
   // 1 - find the closest node.

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -337,7 +337,7 @@ GeneratorWriteFailureResponse(GeneratorRequest *grq, TSHttpStatus status)
 }
 
 static TSReturnCode
-GeneratorWriteResponse(GeneratorRequest *grq, TSCont /* contp ATS_UNUSED */)
+GeneratorWriteResponse(GeneratorRequest *grq)
 {
   GeneratorHttpHeader response;
   VDEBUG("writing GET response");
@@ -374,7 +374,7 @@ GeneratorWriteResponse(GeneratorRequest *grq, TSCont /* contp ATS_UNUSED */)
 }
 
 static TSReturnCode
-GeneratorPOSTResponse(GeneratorRequest *grq, TSCont /* contp ATS_UNUSED */)
+GeneratorPOSTResponse(GeneratorRequest *grq)
 {
   GeneratorHttpHeader response;
   VDEBUG("writing POST response");
@@ -559,7 +559,7 @@ GeneratorInterceptHook(TSCont contp, TSEvent event, void *edata)
           TSVIOReenable(input_vio);
 
         } else {
-          if (GeneratorPOSTResponse(cdata.grq, contp) != TS_SUCCESS) {
+          if (GeneratorPOSTResponse(cdata.grq) != TS_SUCCESS) {
             VERROR("failure writing response");
             return TS_EVENT_ERROR;
           }
@@ -635,7 +635,7 @@ GeneratorInterceptHook(TSCont contp, TSEvent event, void *edata)
           return TS_EVENT_NONE;
         }
 
-        if (GeneratorWriteResponse(cdata.grq, contp) != TS_SUCCESS) {
+        if (GeneratorWriteResponse(cdata.grq) != TS_SUCCESS) {
           VERROR("failure writing response");
           return TS_EVENT_ERROR;
         }
@@ -713,7 +713,7 @@ GeneratorInterceptHook(TSCont contp, TSEvent event, void *edata)
     // Our response delay expired, so write the headers now, which
     // will also trigger the read+write event flow.
     argument_type cdata = TSContDataGet(contp);
-    if (GeneratorWriteResponse(cdata.grq, contp) != TS_SUCCESS) {
+    if (GeneratorWriteResponse(cdata.grq) != TS_SUCCESS) {
       VERROR("failure writing response");
       return TS_EVENT_ERROR;
     }

--- a/plugins/generator/generator.cc
+++ b/plugins/generator/generator.cc
@@ -337,7 +337,7 @@ GeneratorWriteFailureResponse(GeneratorRequest *grq, TSHttpStatus status)
 }
 
 static TSReturnCode
-GeneratorWriteResponse(GeneratorRequest *grq, TSCont contp)
+GeneratorWriteResponse(GeneratorRequest *grq, TSCont /* contp ATS_UNUSED */)
 {
   GeneratorHttpHeader response;
   VDEBUG("writing GET response");
@@ -374,7 +374,7 @@ GeneratorWriteResponse(GeneratorRequest *grq, TSCont contp)
 }
 
 static TSReturnCode
-GeneratorPOSTResponse(GeneratorRequest *grq, TSCont contp)
+GeneratorPOSTResponse(GeneratorRequest *grq, TSCont /* contp ATS_UNUSED */)
 {
   GeneratorHttpHeader response;
   VDEBUG("writing POST response");

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -759,7 +759,7 @@ ConditionNow::append_value(std::string &s, const Resources & /* res ATS_UNUSED *
 }
 
 bool
-ConditionNow::eval(const Resources &res)
+ConditionNow::eval(const Resources & /* res ATS_UNUSED */)
 {
   int64_t now = get_now_qualified(_now_qual);
 
@@ -768,14 +768,14 @@ ConditionNow::eval(const Resources &res)
 }
 
 std::string
-ConditionGeo::get_geo_string(const sockaddr *addr) const
+ConditionGeo::get_geo_string(const sockaddr * /* addr ATS_UNUSED */) const
 {
   TSError("[%s] No Geo library available!", PLUGIN_NAME);
   return "";
 }
 
 int64_t
-ConditionGeo::get_geo_int(const sockaddr *addr) const
+ConditionGeo::get_geo_int(const sockaddr * /* addr ATS_UNUSED */) const
 {
   TSError("[%s] No Geo library available!", PLUGIN_NAME);
   return 0;
@@ -1210,14 +1210,14 @@ ConditionStringLiteral::ConditionStringLiteral(const std::string &v)
 }
 
 void
-ConditionStringLiteral::append_value(std::string &s, const Resources &res)
+ConditionStringLiteral::append_value(std::string &s, const Resources & /* res ATS_UNUSED */)
 {
   s += _literal;
   Dbg(pi_dbg_ctl, "Appending '%s' to evaluation value", _literal.c_str());
 }
 
 bool
-ConditionStringLiteral::eval(const Resources &res)
+ConditionStringLiteral::eval(const Resources & /* res ATS_UNUSED */)
 {
   Dbg(pi_dbg_ctl, "Evaluating StringLiteral");
 
@@ -1292,7 +1292,7 @@ ConditionTcpInfo::eval(const Resources &res)
 }
 
 void
-ConditionTcpInfo::append_value(std::string &s, Resources const &res)
+ConditionTcpInfo::append_value(std::string &s, Resources const & /* res ATS_UNUSED */)
 {
 #if defined(TCP_INFO) && defined(HAVE_STRUCT_TCP_INFO)
   if (TSHttpTxnIsInternal(res.txnp)) {

--- a/plugins/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/ja3_fingerprint/ja3_fingerprint.cc
@@ -164,7 +164,7 @@ append_to_field(TSMBuffer bufp, TSMLoc hdr_loc, const char *field, int field_len
 }
 
 static int
-client_hello_ja3_handler(TSCont contp, TSEvent event, void *edata)
+client_hello_ja3_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
   switch (event) {
@@ -342,7 +342,7 @@ TSPluginInit(int argc, const char *argv[])
 
 // Remap Part
 TSReturnCode
-TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+TSRemapInit(TSRemapInterface * /* api_info ATS_UNUSED */, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "JA3 Remap Plugin initializing..");
 

--- a/plugins/multiplexer/ats-multiplexer.cc
+++ b/plugins/multiplexer/ats-multiplexer.cc
@@ -175,7 +175,7 @@ DoRemap(const Instance &i, TSHttpTxn t)
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *i, TSHttpTxn t, TSRemapRequestInfo *r)
+TSRemapDoRemap(void *i, TSHttpTxn t, TSRemapRequestInfo * /* r ATS_UNUSED */)
 {
   assert(i != nullptr);
   assert(t != nullptr);

--- a/plugins/multiplexer/fetcher.h
+++ b/plugins/multiplexer/fetcher.h
@@ -173,7 +173,7 @@ template <class T> struct HttpTransaction {
   }
 
   static int
-  handle(TSCont c, TSEvent e, void *data)
+  handle(TSCont c, TSEvent e, void * /* data ATS_UNUSED */)
   {
     using multiplexer_ns::dbg_ctl;
 

--- a/plugins/multiplexer/post.cc
+++ b/plugins/multiplexer/post.cc
@@ -119,7 +119,7 @@ postTransform(const TSCont c, PostState &s)
 }
 
 int
-handlePost(TSCont c, TSEvent e, void *data)
+handlePost(TSCont c, TSEvent e, [[maybe_unused]] void *data)
 {
   assert(c != nullptr);
   // TODO(dmorilha): assert on possible events.

--- a/plugins/prefetch/fetch_policy_simple.cc
+++ b/plugins/prefetch/fetch_policy_simple.cc
@@ -24,7 +24,7 @@
 #include "fetch_policy_simple.h"
 
 bool
-FetchPolicySimple::init(const char *parameters)
+FetchPolicySimple::init(const char * /* parameters ATS_UNUSED */)
 {
   PrefetchDebug("initialized %s fetch policy", name());
   return true;

--- a/plugins/prefetch/plugin.cc
+++ b/plugins/prefetch/plugin.cc
@@ -108,7 +108,7 @@ getCacheLookupResultName(TSCacheLookupResult result)
  * @return always TS_SUCCESS.
  */
 TSReturnCode
-TSRemapInit(TSRemapInterface *apiInfo, char *errBuf, int erroBufSize)
+TSRemapInit(TSRemapInterface * /* apiInfo ATS_UNUSED */, char * /* errBuf ATS_UNUSED */, int /* erroBufSize ATS_UNUSED */)
 {
   return TS_SUCCESS;
 }
@@ -756,7 +756,7 @@ contHandleFetch(const TSCont contp, TSEvent event, void *edata)
  * @return TS_SUCCES if success or TS_ERROR if failure
  */
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **instance, char *errBuf, int errBufSize)
+TSRemapNewInstance(int argc, char *argv[], void **instance, char * /* errBuf ATS_UNUSED */, int /* errBufSize ATS_UNUSED */)
 {
   bool failed = true;
 

--- a/plugins/regex_revalidate/regex_revalidate.cc
+++ b/plugins/regex_revalidate/regex_revalidate.cc
@@ -543,7 +543,7 @@ list_config(plugin_state_t *pstate, invalidate_t *i)
 }
 
 static int
-free_handler(TSCont cont, TSEvent event, void *edata)
+free_handler(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   invalidate_t *iptr;
 
@@ -555,7 +555,7 @@ free_handler(TSCont cont, TSEvent event, void *edata)
 }
 
 static int
-config_handler(TSCont cont, TSEvent event, void *edata)
+config_handler(TSCont cont, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   plugin_state_t *pstate;
   invalidate_t   *i, *iptr;

--- a/plugins/remap_purge/remap_purge.cc
+++ b/plugins/remap_purge/remap_purge.cc
@@ -247,14 +247,14 @@ handle_purge(TSHttpTxn txnp, PurgeInstance *purge)
 }
 
 TSReturnCode
-TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+TSRemapInit(TSRemapInterface * /* api_info ATS_UNUSED */, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "initialized");
   return TS_SUCCESS;
 }
 
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char *errbuf, int errbuf_size)
+TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   char                      *id        = argv[0]; /* The ID is default to the "from" URL, so save it */
   auto                       purge     = TSRalloc<PurgeInstance>();
@@ -326,7 +326,7 @@ TSRemapDeleteInstance(void *ih)
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   PurgeInstance *purge = (PurgeInstance *)ih;
 

--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -599,8 +599,6 @@ getRegion(const StringMap &regionMap, const char *entryPoint, size_t entryPointL
  *
  * @see AWS spec: http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
 
- * @param entryPoint  entry-point name
- * @param entryPointLen entry-point name length
  * @param dateTime - ISO 8601 time
  * @param dateTimeLen - ISO 8601 time length
  * @param region AWS region name
@@ -612,9 +610,8 @@ getRegion(const StringMap &regionMap, const char *entryPoint, size_t entryPointL
  * @returns the string to sign
  */
 String
-getStringToSign(const char * /* entryPoint ATS_UNUSED */, size_t /* EntryPointLen ATS_UNUSED */, const char *dateTime,
-                size_t dateTimeLen, const char *region, size_t regionLen, const char *service, size_t serviceLen,
-                const char *sha256Hash, size_t sha256HashLen)
+getStringToSign(const char *dateTime, size_t dateTimeLen, const char *region, size_t regionLen, const char *service,
+                size_t serviceLen, const char *sha256Hash, size_t sha256HashLen)
 {
   String stringToSign;
 
@@ -739,8 +736,8 @@ AwsAuthV4::getAuthorizationHeader()
 
   String awsRegion = getRegion(_regionMap, host, hostLen);
 
-  String stringToSign = getStringToSign(host, hostLen, _dateTime, sizeof(_dateTime) - 1, awsRegion.c_str(), awsRegion.length(),
-                                        _awsService, _awsServiceLen, canonicalReq.c_str(), canonicalReq.length());
+  String stringToSign = getStringToSign(_dateTime, sizeof(_dateTime) - 1, awsRegion.c_str(), awsRegion.length(), _awsService,
+                                        _awsServiceLen, canonicalReq.c_str(), canonicalReq.length());
 #ifdef AWS_AUTH_V4_DETAILED_DEBUG_OUTPUT
   std::cout << "<StringToSign>" << stringToSign << "</StringToSign>" << std::endl;
 #endif

--- a/plugins/s3_auth/aws_auth_v4.cc
+++ b/plugins/s3_auth/aws_auth_v4.cc
@@ -612,8 +612,9 @@ getRegion(const StringMap &regionMap, const char *entryPoint, size_t entryPointL
  * @returns the string to sign
  */
 String
-getStringToSign(const char *entryPoint, size_t EntryPointLen, const char *dateTime, size_t dateTimeLen, const char *region,
-                size_t regionLen, const char *service, size_t serviceLen, const char *sha256Hash, size_t sha256HashLen)
+getStringToSign(const char * /* entryPoint ATS_UNUSED */, size_t /* EntryPointLen ATS_UNUSED */, const char *dateTime,
+                size_t dateTimeLen, const char *region, size_t regionLen, const char *service, size_t serviceLen,
+                const char *sha256Hash, size_t sha256HashLen)
 {
   String stringToSign;
 

--- a/plugins/s3_auth/s3_auth.cc
+++ b/plugins/s3_auth/s3_auth.cc
@@ -1050,7 +1050,7 @@ cal_reload_delay(long time_diff)
 }
 
 int
-config_reloader(TSCont cont, TSEvent event, void *edata)
+config_reloader(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   Dbg(dbg_ctl, "reloading configs");
   S3Config *s3 = static_cast<S3Config *>(TSContDataGet(cont));

--- a/plugins/s3_auth/unit_tests/test_aws_auth_v4.cc
+++ b/plugins/s3_auth/unit_tests/test_aws_auth_v4.cc
@@ -405,7 +405,7 @@ ValidateBench(TsInterface &api, bool signPayload, time_t *now, const char *bench
   String      awsRegion = getRegion(defaultDefaultRegionMap, host, hostLen);
 
   /* Test string to sign calculation */
-  String stringToSign = getStringToSign(host, hostLen, dateTime, dateTimeLen, awsRegion.c_str(), awsRegion.length(), awsService,
+  String stringToSign = getStringToSign(dateTime, dateTimeLen, awsRegion.c_str(), awsRegion.length(), awsService,
                                         strlen(awsService), canonicalReq.c_str(), canonicalReq.length());
   CAPTURE(stringToSign);
   CHECK_FALSE(stringToSign.compare(bench[3]));

--- a/plugins/s3_auth/unit_tests/test_aws_auth_v4.h
+++ b/plugins/s3_auth/unit_tests/test_aws_auth_v4.h
@@ -136,9 +136,8 @@ String getCanonicalRequestSha256Hash(TsInterface &api, bool signPayload, const S
                                      const StringSet &excludeHeaders, String &signedHeaders);
 String getStringToSign(TsInterface &api, const char *dateTime, size_t dateTimeLen, const char *canonicalRequestSha256Hash,
                        size_t canonicalRequestSha256HashLen);
-String getStringToSign(const char *host, size_t hostLen, const char *dateTime, size_t dateTimeLen, const char *region,
-                       size_t regionLen, const char *service, size_t serviceLen, const char *canonicalRequestSha256Hash,
-                       size_t canonicalRequestSha256HashLen);
+String getStringToSign(const char *dateTime, size_t dateTimeLen, const char *region, size_t regionLen, const char *service,
+                       size_t serviceLen, const char *canonicalRequestSha256Hash, size_t canonicalRequestSha256HashLen);
 String getRegion(const StringMap &regionMap, const char *host, size_t hostLen);
 size_t hmacSha256(const char *secret, size_t secretLen, const char *msg, size_t msgLen, char *hmac, size_t hmacLen);
 

--- a/plugins/server_push_preload/server_push_preload.cc
+++ b/plugins/server_push_preload/server_push_preload.cc
@@ -142,7 +142,8 @@ public:
   explicit ServerPushRemap(void **instance_handle) : RemapPlugin(instance_handle) {}
 
   Result
-  doRemap(const Url &map_from_url, const Url &map_to_url, Transaction &transaction, bool &redirect) override
+  doRemap(const Url & /* map_from_url ATS_UNUSED */, const Url & /* map_to_url ATS_UNUSED */, Transaction &transaction,
+          bool & /* redirect ATS_UNUSED */) override
   {
     transaction.addPlugin(new ServerPushTransaction(transaction));
     return RESULT_DID_REMAP;

--- a/plugins/slice/server.cc
+++ b/plugins/slice/server.cc
@@ -350,7 +350,7 @@ logSliceError(char const *const message, Data const *const data, HttpHeader cons
 }
 
 bool
-handleNextServerHeader(Data *const data, TSCont const contp)
+handleNextServerHeader(Data *const data, TSCont const /* contp ATS_UNUSED */)
 {
   // block response header
   HttpHeader header(data->m_resp_hdrmgr.m_buffer, data->m_resp_hdrmgr.m_lochdr);

--- a/plugins/slice/server.cc
+++ b/plugins/slice/server.cc
@@ -350,7 +350,7 @@ logSliceError(char const *const message, Data const *const data, HttpHeader cons
 }
 
 bool
-handleNextServerHeader(Data *const data, TSCont const /* contp ATS_UNUSED */)
+handleNextServerHeader(Data *const data)
 {
   // block response header
   HttpHeader header(data->m_resp_hdrmgr.m_buffer, data->m_resp_hdrmgr.m_lochdr);
@@ -554,7 +554,7 @@ handle_server_resp(TSCont contp, TSEvent event, Data *const data)
             break;
           }
         } else {
-          headerStat = handleNextServerHeader(data, contp);
+          headerStat = handleNextServerHeader(data);
         }
 
         data->m_server_block_header_parsed = true;

--- a/plugins/slice/slice.cc
+++ b/plugins/slice/slice.cc
@@ -214,7 +214,7 @@ DbgCtl dbg_ctl{PLUGIN_NAME};
 ///// remap plugin engine
 
 TSRemapStatus
-TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   Config *const config = static_cast<Config *>(ih);
 
@@ -227,7 +227,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
 ///// remap plugin setup and teardown
 void
-TSRemapOSResponse(void *ih, TSHttpTxn rh, int os_response_type)
+TSRemapOSResponse(void * /* ih ATS_UNUSED */, TSHttpTxn /* rh ATS_UNUSED */, int /* os_response_type ATS_UNUSED */)
 {
 }
 
@@ -250,7 +250,7 @@ TSRemapDeleteInstance(void *ih)
 }
 
 TSReturnCode
-TSRemapInit(TSRemapInterface *api_info, char *errbug, int errbuf_size)
+TSRemapInit(TSRemapInterface * /* api_info ATS_UNUSED */, char * /* errbug ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   DEBUG_LOG("slice remap initializing.");
   return TS_SUCCESS;

--- a/plugins/statichit/statichit.cc
+++ b/plugins/statichit/statichit.cc
@@ -296,7 +296,7 @@ HeaderFieldStringSet(const StaticHitHttpHeader &http, const char *field_name, in
 }
 
 static TSReturnCode
-WriteResponseHeader(StaticHitRequest *trq, TSCont contp, TSHttpStatus status)
+WriteResponseHeader(StaticHitRequest *trq, TSCont /* contp ATS_UNUSED */, TSHttpStatus status)
 {
   StaticHitHttpHeader response;
 

--- a/plugins/statichit/statichit.cc
+++ b/plugins/statichit/statichit.cc
@@ -296,7 +296,7 @@ HeaderFieldStringSet(const StaticHitHttpHeader &http, const char *field_name, in
 }
 
 static TSReturnCode
-WriteResponseHeader(StaticHitRequest *trq, TSCont /* contp ATS_UNUSED */, TSHttpStatus status)
+WriteResponseHeader(StaticHitRequest *trq, TSHttpStatus status)
 {
   StaticHitHttpHeader response;
 
@@ -455,7 +455,7 @@ StaticHitInterceptHook(TSCont contp, TSEvent event, void *edata)
         cdata.trq->writeio.write(TSVIOVConnGet(arg.vio), contp);
         TSVIONBytesSet(cdata.trq->writeio.vio, 0);
 
-        if (WriteResponseHeader(cdata.trq, contp, status) != TS_SUCCESS) {
+        if (WriteResponseHeader(cdata.trq, status) != TS_SUCCESS) {
           VERROR("failure writing response");
           return TS_EVENT_ERROR;
         }

--- a/plugins/stats_over_http/stats_over_http.cc
+++ b/plugins/stats_over_http/stats_over_http.cc
@@ -373,7 +373,8 @@ wrap_unsigned_counter(uint64_t value)
 }
 
 static void
-json_out_stat(TSRecordType rec_type, void *edata, int registered, const char *name, TSRecordDataType data_type, TSRecordData *datum)
+json_out_stat(TSRecordType /* rec_type ATS_UNUSED */, void *edata, int /* registered ATS_UNUSED */, const char *name,
+              TSRecordDataType data_type, TSRecordData *datum)
 {
   stats_state *my_state = static_cast<stats_state *>(edata);
 
@@ -397,7 +398,8 @@ json_out_stat(TSRecordType rec_type, void *edata, int registered, const char *na
 }
 
 static void
-csv_out_stat(TSRecordType rec_type, void *edata, int registered, const char *name, TSRecordDataType data_type, TSRecordData *datum)
+csv_out_stat(TSRecordType /* rec_type ATS_UNUSED */, void *edata, int /* registered ATS_UNUSED */, const char *name,
+             TSRecordDataType data_type, TSRecordData *datum)
 {
   stats_state *my_state = static_cast<stats_state *>(edata);
   switch (data_type) {
@@ -565,7 +567,7 @@ stats_dostuff(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-stats_origin(TSCont contp, TSEvent event, void *edata)
+stats_origin(TSCont contp, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSCont       icontp;
   stats_state *my_state;
@@ -932,7 +934,7 @@ new_config_holder(const char *path)
 }
 
 static int
-free_handler(TSCont cont, TSEvent event, void *edata)
+free_handler(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   config_t *config;
   config = (config_t *)TSContDataGet(cont);
@@ -942,7 +944,7 @@ free_handler(TSCont cont, TSEvent event, void *edata)
 }
 
 static int
-config_handler(TSCont cont, TSEvent event, void *edata)
+config_handler(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   config_holder_t *config_holder;
   config_holder = (config_holder_t *)TSContDataGet(cont);

--- a/plugins/traffic_dump/session_data.cc
+++ b/plugins/traffic_dump/session_data.cc
@@ -304,7 +304,7 @@ SessionData::get_server_protocol_description(TSHttpTxn server_txnp)
     [&server_txnp](int n, const char **result, int *actual) {
       return TSHttpTxnServerProtocolStackGet(server_txnp, n, result, actual);
     },
-    [&server_txnp]() { return get_server_tls_description(server_txnp); }, [](std::string_view http_version) {});
+    [&server_txnp]() { return get_server_tls_description(server_txnp); }, [](std::string_view /* http_version ATS_UNUSED */) {});
 }
 
 SessionData::SessionData()
@@ -451,7 +451,7 @@ SessionData::session_aio_handler(TSCont contp, TSEvent event, void *edata)
 
 // static
 int
-SessionData::global_session_handler(TSCont contp, TSEvent event, void *edata)
+SessionData::global_session_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpSsn ssnp = static_cast<TSHttpSsn>(edata);
 

--- a/plugins/traffic_dump/traffic_dump.cc
+++ b/plugins/traffic_dump/traffic_dump.cc
@@ -35,7 +35,7 @@ DbgCtl dbg_ctl{debug_tag};
 
 /// Handle LIFECYCLE_MSG from traffic_ctl.
 static int
-global_message_handler(TSCont contp, TSEvent event, void *edata)
+global_message_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   switch (event) {
   case TS_EVENT_LIFECYCLE_MSG: {

--- a/plugins/traffic_dump/transaction_data.cc
+++ b/plugins/traffic_dump/transaction_data.cc
@@ -49,7 +49,7 @@ sensitive_fields_t default_sensitive_fields = {
 };
 
 int
-TransactionData::response_buffer_handler(TSCont contp, TSEvent event, void *edata)
+TransactionData::response_buffer_handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   auto *txnData = reinterpret_cast<TransactionData *>(TSContDataGet(contp));
   // This should always have been set by the TransactionData creator of this Transform.
@@ -396,7 +396,7 @@ TransactionData::write_proxy_response_node(TSMBuffer &buffer, TSMLoc &hdr_loc)
 
 // Transaction handler: writes headers to the log file using AIO
 int
-TransactionData::global_transaction_handler(TSCont contp, TSEvent event, void *edata)
+TransactionData::global_transaction_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
 

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -447,7 +447,7 @@ InjectEffectiveURLHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 }
 
 static void
-InjectOriginalContentTypeHeader(TSHttpTxn /* txn ATS_UNUSED */, TSMBuffer buffer, TSMLoc hdr)
+InjectOriginalContentTypeHeader(TSMBuffer buffer, TSMLoc hdr)
 {
   TSMLoc ct_field = TSMimeHdrFieldFind(buffer, hdr, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE);
   if (TS_NULL_MLOC != ct_field) {
@@ -588,7 +588,7 @@ XInjectResponseHeaders(TSCont /* contp */, TSEvent event, void *edata)
   }
 
   if (xheaders & XHEADER_X_PROBE_HEADERS) {
-    InjectOriginalContentTypeHeader(txn, buffer, hdr);
+    InjectOriginalContentTypeHeader(buffer, hdr);
     BodyBuilder *data = AuxDataMgr::data(txn).body_builder.get();
     Dbg(dbg_ctl_xform, "XInjectResponseHeaders(): client resp header ready");
     if (data == nullptr) {

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -447,7 +447,7 @@ InjectEffectiveURLHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
 }
 
 static void
-InjectOriginalContentTypeHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
+InjectOriginalContentTypeHeader(TSHttpTxn /* txn ATS_UNUSED */, TSMBuffer buffer, TSMLoc hdr)
 {
   TSMLoc ct_field = TSMimeHdrFieldFind(buffer, hdr, TS_MIME_FIELD_CONTENT_TYPE, TS_MIME_LEN_CONTENT_TYPE);
   if (TS_NULL_MLOC != ct_field) {

--- a/plugins/xdebug/xdebug_headers.cc
+++ b/plugins/xdebug/xdebug_headers.cc
@@ -119,7 +119,7 @@ private:
 ///////////////////////////////////////////////////////////////////////////
 // Dump a header on stderr, useful together with Dbg().
 void
-print_headers(TSHttpTxn txn, TSMBuffer bufp, TSMLoc hdr_loc, std::stringstream &ss)
+print_headers(TSHttpTxn /* txn ATS_UNUSED */, TSMBuffer bufp, TSMLoc hdr_loc, std::stringstream &ss)
 {
   TSIOBuffer        output_buffer;
   TSIOBufferReader  reader;

--- a/plugins/xdebug/xdebug_headers.cc
+++ b/plugins/xdebug/xdebug_headers.cc
@@ -119,7 +119,7 @@ private:
 ///////////////////////////////////////////////////////////////////////////
 // Dump a header on stderr, useful together with Dbg().
 void
-print_headers(TSHttpTxn /* txn ATS_UNUSED */, TSMBuffer bufp, TSMLoc hdr_loc, std::stringstream &ss)
+print_headers(TSMBuffer bufp, TSMLoc hdr_loc, std::stringstream &ss)
 {
   TSIOBuffer        output_buffer;
   TSIOBufferReader  reader;
@@ -160,7 +160,7 @@ log_headers(TSHttpTxn txn, TSMBuffer bufp, TSMLoc hdr_loc, char const *type_msg)
 {
   if (dbg_ctl_hdrs.on()) {
     std::stringstream output;
-    print_headers(txn, bufp, hdr_loc, output);
+    print_headers(bufp, hdr_loc, output);
     Dbg(dbg_ctl_hdrs, "\n=============\n %s headers are... \n %s", type_msg, output.str().c_str());
   }
 }
@@ -172,13 +172,13 @@ print_request_headers(TSHttpTxn txn, std::stringstream &output)
   TSMLoc    hdr_loc;
   if (TSHttpTxnClientReqGet(txn, &buf_c, &hdr_loc) == TS_SUCCESS) {
     output << "{'type':'request', 'side':'client', 'headers': {\n";
-    print_headers(txn, buf_c, hdr_loc, output);
+    print_headers(buf_c, hdr_loc, output);
     output << "\n\t}}";
     TSHandleMLocRelease(buf_c, TS_NULL_MLOC, hdr_loc);
   }
   if (TSHttpTxnServerReqGet(txn, &buf_s, &hdr_loc) == TS_SUCCESS) {
     output << ",{'type':'request', 'side':'server', 'headers': {\n";
-    print_headers(txn, buf_s, hdr_loc, output);
+    print_headers(buf_s, hdr_loc, output);
     output << "\n\t}}";
     TSHandleMLocRelease(buf_s, TS_NULL_MLOC, hdr_loc);
   }
@@ -191,13 +191,13 @@ print_response_headers(TSHttpTxn txn, std::stringstream &output)
   TSMLoc    hdr_loc;
   if (TSHttpTxnServerRespGet(txn, &buf_s, &hdr_loc) == TS_SUCCESS) {
     output << "{'type':'response', 'side':'server', 'headers': {\n";
-    print_headers(txn, buf_s, hdr_loc, output);
+    print_headers(buf_s, hdr_loc, output);
     output << "\n\t}},";
     TSHandleMLocRelease(buf_s, TS_NULL_MLOC, hdr_loc);
   }
   if (TSHttpTxnClientRespGet(txn, &buf_c, &hdr_loc) == TS_SUCCESS) {
     output << "{'type':'response', 'side':'client', 'headers': {\n";
-    print_headers(txn, buf_c, hdr_loc, output);
+    print_headers(buf_c, hdr_loc, output);
     output << "\n\t}}";
     TSHandleMLocRelease(buf_c, TS_NULL_MLOC, hdr_loc);
   }

--- a/plugins/xdebug/xdebug_transforms.cc
+++ b/plugins/xdebug/xdebug_transforms.cc
@@ -66,7 +66,7 @@ writePostBody(TSHttpTxn txn, BodyBuilder *data)
 }
 
 static int
-body_transform(TSCont contp, TSEvent event, void *edata)
+body_transform(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   TSHttpTxn    txn  = static_cast<TSHttpTxn>(TSContDataGet(contp));
   BodyBuilder *data = AuxDataMgr::data(txn).body_builder.get();


### PR DESCRIPTION
Use `/* name ATS_UNUSED */` for fully unused parameters.
Use `[[maybe_unused]]` attribute for conditionally unused parameters used in asserts.

This pull request is part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377 ) the `-Wno-unused-parameter` warning suppression.