### PR TITLE
Restore webp_transform to build

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -65,20 +65,10 @@ endif()
 # find_package() call to ensure the module doesn't try
 # to create the same target twice.
 if(NOT TARGET ImageMagick::Magick++)
-  auto_option(
-    WEBP_TRANSFORM
-    FEATURE_VAR
-    BUILD_WEBP_TRANSFORM
-    PACKAGE_DEPENDS
-    ImageMagick
-    COMPONENTS
-    Magick++
-  )
-
-  include(magick_target)
+  find_package(ImageMagick COMPONENTS Magick++)
 endif()
 
-if(BUILD_WEBP_TRANSFORM)
+if(TARGET ImageMagick::Magick++)
   add_subdirectory(webp_transform)
 endif()
 


### PR DESCRIPTION
A bug was introduced in #10967 causing us not to register the auto_option for webp_transform if the ImageMagick::Magick++ target already exists. None of the other non-experimental plugins have auto_options at this time, so this demotes webp_transform to be always build if its dependency is found, in line with those other plugins.