### PR TITLE
Fix last left unused parameters in the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,7 +598,7 @@ add_subdirectory(lib)
 # Keep this after lib because lib is made up of third party libraries, so if
 # there are warnings, we can't do anything about it.
 # Note: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON will turn warnings into errors.
-add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter)
+add_compile_options(-pipe -Wall -Wextra)
 add_compile_options(
   "$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override;-Wno-vla-extension;-fno-strict-aliasing>"
 )

--- a/include/proxy/HostStatus.h
+++ b/include/proxy/HostStatus.h
@@ -208,7 +208,7 @@ public:
 
   // Deletes instance.
   int
-  mainEvent(int event, Event *e)
+  mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   {
     sync_task();
 

--- a/include/proxy/ParentRoundRobin.h
+++ b/include/proxy/ParentRoundRobin.h
@@ -42,7 +42,7 @@ public:
   ParentRoundRobin(ParentRecord *_parent_record, ParentRR_t _round_robin_type);
   ~ParentRoundRobin() override;
   pRecord *
-  getParents(ParentResult *result) override
+  getParents(ParentResult * /* result ATS_UNUSED */) override
   {
     return parents;
   }

--- a/include/proxy/http/remap/RemapPlugins.h
+++ b/include/proxy/http/remap/RemapPlugins.h
@@ -36,7 +36,10 @@
  **/
 struct RemapPlugins : public Continuation {
   RemapPlugins() = default;
-  RemapPlugins(HttpTransact::State *s, URL *u, HTTPHdr *h, host_hdr_info *hi) : _s(s), _request_url(u), _request_header(h) {}
+  RemapPlugins(HttpTransact::State *s, URL *u, HTTPHdr *h, host_hdr_info * /* hi ATS_UNUSED */)
+    : _s(s), _request_url(u), _request_header(h)
+  {
+  }
 
   // Some basic setters
   void

--- a/include/proxy/logging/LogFilter.h
+++ b/include/proxy/logging/LogFilter.h
@@ -414,7 +414,7 @@ findPatternFromParamName(const char *lookup_query_param, const char *pattern)
  * replace param value whose name contains pattern with same count 'X' of original value str length
 ---------------------------------------------------------------------------*/
 static void
-updatePatternForFieldValue(char **field, const char *pattern_str, int field_pos, char *buf_dest)
+updatePatternForFieldValue(char **field, const char *pattern_str, int /* field_pos ATS_UNUSED */, char *buf_dest)
 {
   int   buf_dest_len = strlen(buf_dest);
   char  buf_dest_to_field[buf_dest_len + 1];

--- a/plugins/experimental/icap/icap_plugin.cc
+++ b/plugins/experimental/icap/icap_plugin.cc
@@ -924,7 +924,7 @@ transform_read_http_header_event(TSCont contp, TransformData *data, TSEvent even
 }
 
 static int
-transform_read_http_body_event(TSCont contp, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
+transform_read_http_body_event(TSCont /* contp ATS_UNUSED */, TransformData *data, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   switch (event) {
   case TS_EVENT_ERROR:

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -187,7 +187,7 @@ private:
   }
 
   bool
-  test_reg(const std::string &t, bool nocase = false) const
+  test_reg(const std::string &t) const
   {
     int ovector[OVECCOUNT];
 

--- a/plugins/prefetch/fetch.cc
+++ b/plugins/prefetch/fetch.cc
@@ -94,8 +94,8 @@ getPrefetchMetricsNames(int metric)
 }
 
 static bool
-createStat(const String &prefix, const String &space, const char *module, const char *statName, TSRecordDataType statType,
-           int &statId)
+createStat(const String &prefix, const String &space, const char *module, const char *statName,
+           TSRecordDataType /* statType ATS_UNUSED */, int &statId)
 {
   String name(prefix);
   name.append(".").append(space);

--- a/plugins/xdebug/xdebug_headers.cc
+++ b/plugins/xdebug/xdebug_headers.cc
@@ -156,7 +156,7 @@ print_headers(TSMBuffer bufp, TSMLoc hdr_loc, std::stringstream &ss)
 }
 
 void
-log_headers(TSHttpTxn txn, TSMBuffer bufp, TSMLoc hdr_loc, char const *type_msg)
+log_headers(TSHttpTxn /* txn ATS_UNUSED */, TSMBuffer bufp, TSMLoc hdr_loc, char const *type_msg)
 {
   if (dbg_ctl_hdrs.on()) {
     std::stringstream output;

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -6223,7 +6223,8 @@ TSCacheScan(TSCont contp, TSCacheKey key, int KB_per_second)
 
 /************************   REC Stats API    **************************/
 int
-TSStatCreate(const char *the_name, TSRecordDataType the_type, TSStatPersistence persist, TSStatSync sync)
+TSStatCreate(const char *the_name, TSRecordDataType /* the_type ATS_UNUSED */, TSStatPersistence /* persist ATS_UNUSED */,
+             TSStatSync /* sync ATS_UNUSED */)
 {
   int id = Metrics::Gauge::create(the_name); // Gauges allows for all "int" operations
 
@@ -7887,7 +7888,7 @@ public:
     SET_HANDLER(&TSSslCallback::event_handler);
   }
   int
-  event_handler(int event, void *)
+  event_handler(int /* event ATS_UNUSED */, void *)
   {
     m_vc->reenable(m_vc->nh, m_event);
     delete this;
@@ -8663,7 +8664,7 @@ TSHttpTxnServerProtocolStackContains(TSHttpTxn txnp, const char *tag)
 }
 
 const char *
-TSRegisterProtocolTag(const char *tag)
+TSRegisterProtocolTag(const char * /* tag ATS_UNUSED */)
 {
   return nullptr;
 }

--- a/src/mgmt/config/FileManager.cc
+++ b/src/mgmt/config/FileManager.cc
@@ -336,7 +336,8 @@ FileManager::configFileChild(const char *parent, const char *child)
 }
 
 auto
-FileManager::get_files_registry_rpc_endpoint(std::string_view const &id, YAML::Node const &params) -> swoc::Rv<YAML::Node>
+FileManager::get_files_registry_rpc_endpoint(std::string_view const & /* id ATS_UNUSED */,
+                                             YAML::Node const & /* params ATS_UNUSED */) -> swoc::Rv<YAML::Node>
 {
   // If any error, the rpc manager will catch it and respond with it.
   YAML::Node configs{YAML::NodeType::Sequence};

--- a/src/mgmt/rpc/handlers/config/Configuration.cc
+++ b/src/mgmt/rpc/handlers/config/Configuration.cc
@@ -104,7 +104,7 @@ namespace
 } // namespace
 
 swoc::Rv<YAML::Node>
-set_config_records(std::string_view const &id, YAML::Node const &params)
+set_config_records(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> resp;
 
@@ -185,7 +185,7 @@ set_config_records(std::string_view const &id, YAML::Node const &params)
 }
 
 swoc::Rv<YAML::Node>
-reload_config(std::string_view const &id, YAML::Node const &params)
+reload_config(std::string_view const & /* id ATS_UNUSED */, YAML::Node const & /* params ATS_UNUSED */)
 {
   ts::Metrics         &metrics     = ts::Metrics::instance();
   static auto          reconf_time = metrics.lookup("proxy.process.proxy.reconfigure_time");

--- a/src/mgmt/rpc/handlers/plugins/Plugins.cc
+++ b/src/mgmt/rpc/handlers/plugins/Plugins.cc
@@ -57,7 +57,7 @@ namespace rpc::handlers::plugins
 namespace err = rpc::handlers::errors;
 
 swoc::Rv<YAML::Node>
-plugin_send_basic_msg(std::string_view const &id, YAML::Node const &params)
+plugin_send_basic_msg(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   // The rpc could be ready before plugins are initialized.
   // We make sure it is ready.

--- a/src/mgmt/rpc/handlers/records/Records.cc
+++ b/src/mgmt/rpc/handlers/records/Records.cc
@@ -205,7 +205,7 @@ namespace rpc::handlers::records
 namespace err = rpc::handlers::errors;
 
 swoc::Rv<YAML::Node>
-lookup_records(std::string_view const &id, YAML::Node const &params)
+lookup_records(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   // TODO: we may want to deal with our own object instead of a node here.
   YAML::Node recordList{YAML::NodeType::Sequence}, errorList{YAML::NodeType::Sequence};
@@ -248,7 +248,7 @@ lookup_records(std::string_view const &id, YAML::Node const &params)
 }
 
 swoc::Rv<YAML::Node>
-clear_all_metrics_records(std::string_view const &id, YAML::Node const &params)
+clear_all_metrics_records(std::string_view const & /* id ATS_UNUSED */, YAML::Node const & /* params ATS_UNUSED */)
 {
   using namespace rpc::handlers::records::utils;
   swoc::Rv<YAML::Node> resp;
@@ -260,7 +260,7 @@ clear_all_metrics_records(std::string_view const &id, YAML::Node const &params)
 }
 
 swoc::Rv<YAML::Node>
-clear_metrics_records(std::string_view const &id, YAML::Node const &params)
+clear_metrics_records(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   using namespace rpc::handlers::records::utils;
 

--- a/src/mgmt/rpc/handlers/server/Server.cc
+++ b/src/mgmt/rpc/handlers/server/Server.cc
@@ -80,7 +80,7 @@ set_server_drain(bool drain)
 }
 
 swoc::Rv<YAML::Node>
-server_start_drain(std::string_view const &id, YAML::Node const &params)
+server_start_drain(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> resp;
   try {
@@ -103,7 +103,7 @@ server_start_drain(std::string_view const &id, YAML::Node const &params)
 }
 
 swoc::Rv<YAML::Node>
-server_stop_drain(std::string_view const &id, [[maybe_unused]] YAML::Node const &params)
+server_stop_drain(std::string_view const & /* id ATS_UNUSED */, YAML::Node const & /* params ATS_UNUSED */)
 {
   swoc::Rv<YAML::Node> resp;
   if (is_server_draining()) {

--- a/src/mgmt/rpc/handlers/storage/Storage.cc
+++ b/src/mgmt/rpc/handlers/storage/Storage.cc
@@ -58,7 +58,7 @@ namespace rpc::handlers::storage
 namespace err = rpc::handlers::errors;
 
 swoc::Rv<YAML::Node>
-set_storage_offline(std::string_view const &id, YAML::Node const &params)
+set_storage_offline(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> resp;
 
@@ -84,7 +84,7 @@ set_storage_offline(std::string_view const &id, YAML::Node const &params)
 }
 
 swoc::Rv<YAML::Node>
-get_storage_status(std::string_view const &id, YAML::Node const &params)
+get_storage_status(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> resp;
 

--- a/src/mgmt/rpc/jsonrpc/unit_tests/test_basic_protocol.cc
+++ b/src/mgmt/rpc/jsonrpc/unit_tests/test_basic_protocol.cc
@@ -63,7 +63,7 @@ static const std::error_code ERR2{ts::make_errno_code(10000)};
 static std::string_view      err{"Just an error message to add more meaning to the failure"};
 
 inline swoc::Rv<YAML::Node>
-test_callback_ok_or_error(std::string_view const &id, YAML::Node const &params)
+test_callback_ok_or_error(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> resp;
 
@@ -81,7 +81,7 @@ test_callback_ok_or_error(std::string_view const &id, YAML::Node const &params)
 
 static int notificationCallCount{0};
 inline void
-test_nofitication(YAML::Node const &params)
+test_nofitication(YAML::Node const & /* params ATS_UNUSED */)
 {
   notificationCallCount++;
 }
@@ -339,7 +339,7 @@ TEST_CASE("Basic test with member functions(add, remove)", "[basic][member_funct
         [this](std::string_view const &id, const YAML::Node &req) -> swoc::Rv<YAML::Node> { return test(id, req); });
     }
     swoc::Rv<YAML::Node>
-    test(std::string_view const &id, const YAML::Node &req)
+    test(std::string_view const & /* id ATS_UNUSED */, const YAML::Node & /* req ATS_UNUSED */)
     {
       swoc::Rv<YAML::Node> resp;
       resp.result() = "grand!";
@@ -382,7 +382,7 @@ TEST_CASE("Test Dispatcher rpc method", "[dispatcher]")
 }
 
 [[maybe_unused]] static swoc::Rv<YAML::Node>
-subtract(std::string_view const &id, YAML::Node const &numbers)
+subtract(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &numbers)
 {
   swoc::Rv<YAML::Node> res;
 
@@ -405,7 +405,7 @@ subtract(std::string_view const &id, YAML::Node const &numbers)
 }
 
 [[maybe_unused]] static swoc::Rv<YAML::Node>
-sum(std::string_view const &id, YAML::Node const &params)
+sum(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> res;
   int                  total{0};
@@ -417,7 +417,7 @@ sum(std::string_view const &id, YAML::Node const &params)
 }
 
 [[maybe_unused]] static swoc::Rv<YAML::Node>
-get_data(std::string_view const &id, YAML::Node const &params)
+get_data(std::string_view const & /* id ATS_UNUSED */, YAML::Node const & /* params ATS_UNUSED */)
 {
   swoc::Rv<YAML::Node> res;
   res.result().push_back("hello");
@@ -426,15 +426,15 @@ get_data(std::string_view const &id, YAML::Node const &params)
 }
 
 [[maybe_unused]] static void
-update(YAML::Node const &params)
+update(YAML::Node const & /* params ATS_UNUSED */)
 {
 }
 [[maybe_unused]] static void
-foobar(YAML::Node const &params)
+foobar(YAML::Node const & /* params ATS_UNUSED */)
 {
 }
 [[maybe_unused]] static void
-notify_hello(YAML::Node const &params)
+notify_hello(YAML::Node const & /* params ATS_UNUSED */)
 {
 }
 
@@ -558,9 +558,8 @@ TEST_CASE("Handle un-handle handler's error", "[throw]")
   SECTION("Basic exception thrown")
   {
     REQUIRE(rpc.add_method_handler("oops_i_did_it_again",
-                                   [](std::string_view const &id, const YAML::Node &params) -> swoc::Rv<YAML::Node> {
-                                     throw std::runtime_error("Oops, I did it again");
-                                   }));
+                                   [](std::string_view const & /* id ATS_UNUSED */, const YAML::Node & /* params ATS_UNUSED */)
+                                     -> swoc::Rv<YAML::Node> { throw std::runtime_error("Oops, I did it again"); }));
     const auto       resp     = rpc.handle_call(R"({"jsonrpc": "2.0", "method": "oops_i_did_it_again", "id": "1"})");
     std::string_view expected = R"({"jsonrpc": "2.0", "error": {"code": 9, "message": "Error during execution"}, "id": "1"})";
     REQUIRE(*resp == expected);
@@ -573,9 +572,8 @@ TEST_CASE("Call registered method with no ID", "[no-id]")
   SECTION("Basic test, no id on method call")
   {
     REQUIRE(rpc.add_method_handler("call_me_with_no_id",
-                                   [](std::string_view const &id, const YAML::Node &params) -> swoc::Rv<YAML::Node> {
-                                     throw std::runtime_error("Oops, I did it again");
-                                   }));
+                                   [](std::string_view const & /* id ATS_UNUSED */, const YAML::Node & /* params ATS_UNUSED */)
+                                     -> swoc::Rv<YAML::Node> { throw std::runtime_error("Oops, I did it again"); }));
     const auto       resp     = rpc.handle_call(R"({"jsonrpc": "2.0", "method": "call_me_with_no_id"})");
     std::string_view expected = R"({"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}})";
     REQUIRE(*resp == expected);
@@ -587,8 +585,9 @@ TEST_CASE("Call registered notification with ID", "[notification_and_id]")
   JsonRpcUnitTest rpc;
   SECTION("Basic test, id on a notification call")
   {
-    REQUIRE(rpc.add_notification_handler(
-      "call_me_with_id", [](const YAML::Node &params) -> void { throw std::runtime_error("Oops, I did it again"); }));
+    REQUIRE(rpc.add_notification_handler("call_me_with_id", [](const YAML::Node & /* params ATS_UNUSED */) -> void {
+      throw std::runtime_error("Oops, I did it again");
+    }));
     const auto       resp     = rpc.handle_call(R"({"jsonrpc": "2.0", "method": "call_me_with_id", "id": "1"})");
     std::string_view expected = R"({"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": "1"})";
     REQUIRE(*resp == expected);

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -45,7 +45,7 @@
 #include "tscore/Layout.h"
 #include "iocore/utils/diags.i"
 
-#define DEFINE_JSONRPC_PROTO_FUNCTION(fn) swoc::Rv<YAML::Node> fn(std::string_view const &id, const YAML::Node &params)
+#define DEFINE_JSONRPC_PROTO_FUNCTION(fn) swoc::Rv<YAML::Node> fn(std::string_view const &, const YAML::Node &params)
 
 namespace fs = swoc::file;
 
@@ -76,7 +76,7 @@ struct RPCServerTestListener : Catch::TestEventListenerBase {
 
   // The whole test run starting
   void
-  testRunStarting(Catch::TestRunInfo const &testRunInfo) override
+  testRunStarting(Catch::TestRunInfo const & /* testRunInfo ATS_UNUSED */) override
   {
     Layout::create();
     init_diags("rpc|rpc.test", nullptr);
@@ -108,7 +108,7 @@ struct RPCServerTestListener : Catch::TestEventListenerBase {
 
   // The whole test run ending
   void
-  testRunEnded(Catch::TestRunStats const &testRunStats) override
+  testRunEnded(Catch::TestRunStats const & /* testRunStats ATS_UNUSED */) override
   {
     // jsonrpcServer->stop_thread();
     // delete main_thread;

--- a/src/proxy/HostStatus.cc
+++ b/src/proxy/HostStatus.cc
@@ -425,7 +425,7 @@ template <> struct convert<HostCmdInfo> {
 
 // JSON-RPC method to retrieve host status information.
 swoc::Rv<YAML::Node>
-server_get_status(std::string_view id, YAML::Node const &params)
+server_get_status(std::string_view /* id ATS_UNUSED */, YAML::Node const &params)
 {
   namespace err = rpc::handlers::errors;
   swoc::Rv<YAML::Node> resp;

--- a/src/proxy/IPAllow.cc
+++ b/src/proxy/IPAllow.cc
@@ -52,7 +52,7 @@ DbgCtl dbg_ctl_ip_allow("ip_allow");
 namespace swoc
 {
 BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IpAllow const *obj)
+bwformat(BufferWriter &w, Spec const & /* spec ATS_UNUSED */, IpAllow const *obj)
 {
   return w.print("{}[{}]", obj->MODULE_NAME, obj->get_config_file().c_str());
 }
@@ -204,7 +204,7 @@ IpAllow::IpAllow(const char *ip_allow_config_var, const char *ip_categories_conf
 }
 
 BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IpAllow::IpMap const &map)
+bwformat(BufferWriter &w, Spec const & /* spec ATS_UNUSED */, IpAllow::IpMap const &map)
 {
   w.print("{} entries", map.count());
   for (auto const &spot : map) {

--- a/src/proxy/ParentConsistentHash.cc
+++ b/src/proxy/ParentConsistentHash.cc
@@ -135,8 +135,8 @@ chash_lookup(ATSConsistentHash *fhash, uint64_t path_hash, ATSConsistentHashIter
 }
 
 void
-ParentConsistentHash::selectParent(bool first_call, ParentResult *result, RequestData *rdata, unsigned int fail_threshold,
-                                   unsigned int retry_time)
+ParentConsistentHash::selectParent(bool first_call, ParentResult *result, RequestData *rdata,
+                                   unsigned int /* fail_threshold ATS_UNUSED */, unsigned int retry_time)
 {
   ATSHash64Sip24     hash;
   ATSConsistentHash *fhash;

--- a/src/proxy/ParentRoundRobin.cc
+++ b/src/proxy/ParentRoundRobin.cc
@@ -200,7 +200,7 @@ ParentRoundRobin::selectParent(bool first_call, ParentResult *result, RequestDat
 }
 
 uint32_t
-ParentRoundRobin::numParents(ParentResult *result) const
+ParentRoundRobin::numParents(ParentResult * /* result ATS_UNUSED */) const
 {
   return num_parents;
 }

--- a/src/proxy/ProxySession.cc
+++ b/src/proxy/ProxySession.cc
@@ -188,7 +188,7 @@ ProxySession::is_chunked_encoding_supported() const
 
 // Override if your session protocol cares.
 void
-ProxySession::set_half_close_flag(bool flag)
+ProxySession::set_half_close_flag(bool /* flag ATS_UNUSED */)
 {
 }
 
@@ -205,7 +205,7 @@ ProxySession::connection_id() const
 }
 
 bool
-ProxySession::attach_server_session(PoolableSession *ssession, bool transaction_done)
+ProxySession::attach_server_session(PoolableSession * /* ssession ATS_UNUSED */, bool /* transaction_done ATS_UNUSED */)
 {
   return false;
 }
@@ -223,7 +223,7 @@ ProxySession::is_protocol_framed() const
 }
 
 uint64_t
-ProxySession::get_received_frame_count(uint64_t type) const
+ProxySession::get_received_frame_count(uint64_t /* type ATS_UNUSED */) const
 {
   return 0;
 }

--- a/src/proxy/ProxyTransaction.cc
+++ b/src/proxy/ProxyTransaction.cc
@@ -273,7 +273,7 @@ ProxyTransaction::allow_half_open() const
 // For H2 it will initiate the drain logic.  So we make do nothing
 // the default action.
 void
-ProxyTransaction::set_close_connection(HTTPHdr &hdr) const
+ProxyTransaction::set_close_connection(HTTPHdr & /* hdr ATS_UNUSED */) const
 {
 }
 

--- a/src/proxy/hdrs/VersionConverter.cc
+++ b/src/proxy/hdrs/VersionConverter.cc
@@ -61,7 +61,7 @@ VersionConverter::convert(HTTPHdr &header, int from, int to) const
 }
 
 int
-VersionConverter::_convert_nop(HTTPHdr &header) const
+VersionConverter::_convert_nop(HTTPHdr & /* header ATS_UNUSED */) const
 {
   return 0;
 }

--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -399,7 +399,7 @@ XpackDynamicTable::duplicate_entry(uint32_t current_index)
 }
 
 bool
-XpackDynamicTable::should_duplicate(uint32_t index)
+XpackDynamicTable::should_duplicate(uint32_t /* index ATS_UNUSED */)
 {
   // TODO: Check whether a specified entry should be duplicated
   // Just return false for now
@@ -553,7 +553,8 @@ XpackDynamicTableStorage::~XpackDynamicTableStorage()
 }
 
 void
-XpackDynamicTableStorage::read(uint32_t offset, const char **name, uint32_t name_len, const char **value, uint32_t value_len) const
+XpackDynamicTableStorage::read(uint32_t offset, const char **name, uint32_t name_len, const char **value,
+                               uint32_t /* value_len ATS_UNUSED */) const
 {
   *name  = reinterpret_cast<const char *>(this->_data + offset);
   *value = reinterpret_cast<const char *>(this->_data + offset + name_len);

--- a/src/proxy/http/Http1ServerSession.cc
+++ b/src/proxy/http/Http1ServerSession.cc
@@ -145,7 +145,7 @@ Http1ServerSession::do_io_close(int alerrno)
 //   Releases the session for K-A reuse
 //
 void
-Http1ServerSession::release(ProxyTransaction *trans)
+Http1ServerSession::release(ProxyTransaction * /* trans ATS_UNUSED */)
 {
   Dbg(dbg_ctl_http_ss, "[%" PRId64 "] Releasing session, private_session=%d, sharing_match=%d", con_id, this->is_private(),
       sharing_match);

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -336,7 +336,7 @@ HttpSM::do_api_callout()
 }
 
 int
-HttpSM::state_add_to_list(int event, void * /* data ATS_UNUSED */)
+HttpSM::state_add_to_list(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
   t_state.api_next_action = HttpTransact::SM_ACTION_API_SM_START;
   if (do_api_callout() < 0) {
@@ -353,7 +353,7 @@ HttpSM::state_add_to_list(int event, void * /* data ATS_UNUSED */)
 }
 
 int
-HttpSM::state_remove_from_list(int event, void * /* data ATS_UNUSED */)
+HttpSM::state_remove_from_list(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
   // We're now ready to finish off the state machine
   terminate_sm         = true;
@@ -1314,7 +1314,7 @@ HttpSM::state_api_callback(int event, void *data)
 }
 
 int
-HttpSM::state_api_callout(int event, void *data)
+HttpSM::state_api_callout(int event, void * /* data ATS_UNUSED */)
 {
   // enum and variable for figuring out what the next action is after
   //   after we've finished the api state
@@ -2301,7 +2301,7 @@ HttpSM::process_hostdb_info(HostDBRecord *record)
 }
 
 int
-HttpSM::state_pre_resolve(int event, void *data)
+HttpSM::state_pre_resolve(int event, void * /* data ATS_UNUSED */)
 {
   STATE_ENTER(&HttpSM::state_hostdb_lookup, event);
   return 0;
@@ -2979,7 +2979,7 @@ HttpSM::tunnel_handler_push(int event, void *data)
 }
 
 int
-HttpSM::tunnel_handler(int event, void *data)
+HttpSM::tunnel_handler(int event, void * /* data ATS_UNUSED */)
 {
   STATE_ENTER(&HttpSM::tunnel_handler, event);
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -8568,8 +8568,8 @@ HttpTransact::client_result_stat(State *s, ink_hrtime total_time, ink_hrtime req
 }
 
 void
-HttpTransact::update_size_and_time_stats(State *s, ink_hrtime total_time, ink_hrtime user_agent_write_time,
-                                         ink_hrtime origin_server_read_time, int user_agent_request_header_size,
+HttpTransact::update_size_and_time_stats(State *s, ink_hrtime total_time, ink_hrtime /* user_agent_write_time ATS_UNUSED */,
+                                         ink_hrtime /* origin_server_read_time ATS_UNUSED */, int user_agent_request_header_size,
                                          int64_t user_agent_request_body_size, int user_agent_response_header_size,
                                          int64_t user_agent_response_body_size, int origin_server_request_header_size,
                                          int64_t origin_server_request_body_size, int origin_server_response_header_size,

--- a/src/proxy/http/PreWarmManager.cc
+++ b/src/proxy/http/PreWarmManager.cc
@@ -484,7 +484,7 @@ PreWarmSM::state_open(int event, void *data)
 }
 
 int
-PreWarmSM::state_closed(int event, void *data)
+PreWarmSM::state_closed(int event, void * /* data ATS_UNUSED */)
 {
   switch (event) {
   default:
@@ -673,7 +673,7 @@ PreWarmQueue::~PreWarmQueue()
 }
 
 int
-PreWarmQueue::state_init(int event, void *data)
+PreWarmQueue::state_init(int event, void * /* data ATS_UNUSED */)
 {
   switch (event) {
   case EVENT_IMMEDIATE: {
@@ -699,7 +699,7 @@ PreWarmQueue::state_init(int event, void *data)
 }
 
 int
-PreWarmQueue::state_running(int event, void *data)
+PreWarmQueue::state_running(int event, void * /* data ATS_UNUSED */)
 {
   switch (event) {
   case EVENT_INTERVAL: {

--- a/src/proxy/http/remap/NextHopConsistentHash.cc
+++ b/src/proxy/http/remap/NextHopConsistentHash.cc
@@ -271,7 +271,7 @@ NextHopConsistentHash::getHashKey(uint64_t sm_id, const HttpRequestData &hrdata,
 }
 
 void
-NextHopConsistentHash::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
+NextHopConsistentHash::findNextHop(TSHttpTxn txnp, void * /* ih ATS_UNUSED */, time_t now)
 {
   uint32_t const NO_RING_USE_POST_REMAP = uint32_t(0) - 1;
 

--- a/src/proxy/http/remap/NextHopHealthStatus.cc
+++ b/src/proxy/http/remap/NextHopHealthStatus.cc
@@ -43,7 +43,7 @@ NextHopHealthStatus::insert(std::vector<std::shared_ptr<HostRecord>> &hosts)
  * check that hostname is available for use.
  */
 bool
-NextHopHealthStatus::isNextHopAvailable(TSHttpTxn txn, const char *hostname, const int port, void *ih)
+NextHopHealthStatus::isNextHopAvailable(TSHttpTxn txn, const char *hostname, const int port, void * /* ih ATS_UNUSED */)
 {
   HttpSM *sm    = reinterpret_cast<HttpSM *>(txn);
   int64_t sm_id = sm->sm_id;
@@ -64,8 +64,8 @@ NextHopHealthStatus::isNextHopAvailable(TSHttpTxn txn, const char *hostname, con
  * mark up or down the indicated host
  */
 void
-NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int port, const NHCmd status, void *ih,
-                                 const time_t now)
+NextHopHealthStatus::markNextHop(TSHttpTxn txn, const char *hostname, const int port, const NHCmd status,
+                                 void * /* ih ATS_UNUSED */, const time_t now)
 {
   time_t _now;
   now == 0 ? _now = time(nullptr) : _now = now;

--- a/src/proxy/http/remap/NextHopRoundRobin.cc
+++ b/src/proxy/http/remap/NextHopRoundRobin.cc
@@ -33,7 +33,7 @@ NextHopRoundRobin::~NextHopRoundRobin()
 }
 
 void
-NextHopRoundRobin::findNextHop(TSHttpTxn txnp, void *ih, time_t now)
+NextHopRoundRobin::findNextHop(TSHttpTxn txnp, void * /* ih ATS_UNUSED */, time_t now)
 {
   HttpSM                     *sm             = reinterpret_cast<HttpSM *>(txnp);
   ParentResult               *result         = &sm->t_state.parent_result;

--- a/src/proxy/http/remap/NextHopSelectionStrategy.cc
+++ b/src/proxy/http/remap/NextHopSelectionStrategy.cc
@@ -276,7 +276,7 @@ NextHopSelectionStrategy::setHostHeader(TSHttpTxn txnp, const char *hostname)
 }
 
 bool
-NextHopSelectionStrategy::nextHopExists(TSHttpTxn txnp, void *ih)
+NextHopSelectionStrategy::nextHopExists(TSHttpTxn txnp, void * /* ih ATS_UNUSED */)
 {
   HttpSM *sm    = reinterpret_cast<HttpSM *>(txnp);
   int64_t sm_id = sm->sm_id;

--- a/src/proxy/http/remap/PluginFactory.cc
+++ b/src/proxy/http/remap/PluginFactory.cc
@@ -328,7 +328,7 @@ PluginFactory::indicatePostReload(bool reloadSuccessful)
 }
 
 void
-PluginFactory::clean(std::string &error)
+PluginFactory::clean(std::string & /* error ATS_UNUSED */)
 {
   fs::remove_all(_runtimeDir, _ec);
 }

--- a/src/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
+++ b/src/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
@@ -56,7 +56,7 @@ HttpVCTable::HttpVCTable(HttpSM *smp)
 }
 HttpCacheAction::HttpCacheAction() {}
 void
-HttpCacheAction::cancel(Continuation *c)
+HttpCacheAction::cancel(Continuation * /* c ATS_UNUSED */)
 {
 }
 PostDataBuffers::~PostDataBuffers() {}

--- a/src/proxy/http/remap/unit-tests/test_PluginDso.cc
+++ b/src/proxy/http/remap/unit-tests/test_PluginDso.cc
@@ -73,11 +73,11 @@ public:
   {
   }
   virtual void
-  indicatePostReload(TSRemapReloadStatus reloadStatus) override
+  indicatePostReload(TSRemapReloadStatus /* reloadStatus ATS_UNUSED */) override
   {
   }
   virtual bool
-  init(std::string &error) override
+  init(std::string & /* error ATS_UNUSED */) override
   {
     return true;
   }

--- a/src/proxy/http/remap/unit-tests/test_PluginFactory.cc
+++ b/src/proxy/http/remap/unit-tests/test_PluginFactory.cc
@@ -44,7 +44,7 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase;
 
   void
-  testRunStarting(Catch::TestRunInfo const &testRunInfo) override
+  testRunStarting(Catch::TestRunInfo const & /* testRunInfo ATS_UNUSED */) override
   {
     Layout::create();
     init_diags("", nullptr);

--- a/src/proxy/http2/HTTP2.cc
+++ b/src/proxy/http2/HTTP2.cc
@@ -117,7 +117,7 @@ memcpy_and_advance(uint8_t(&dst), byte_pointer &src)
 }
 
 bool
-http2_frame_header_is_valid(const Http2FrameHeader &hdr, unsigned max_frame_size)
+http2_frame_header_is_valid(const Http2FrameHeader &hdr, unsigned /* max_frame_size ATS_UNUSED */)
 {
   // 6.1 If a DATA frame is received whose stream identifier field is 0x0, the recipient MUST
   // respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

--- a/src/proxy/http2/Http2ClientSession.cc
+++ b/src/proxy/http2/Http2ClientSession.cc
@@ -143,7 +143,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 // are scenarios where we would like to complete the outstanding streams.
 
 void
-Http2ClientSession::do_io_close(int alerrno)
+Http2ClientSession::do_io_close(int /* alerrno ATS_UNUSED */)
 {
   REMEMBER(NO_EVENT, this->recursion)
 
@@ -292,7 +292,7 @@ Http2ClientSession::get_protocol_string() const
 }
 
 void
-Http2ClientSession::release(ProxyTransaction *trans)
+Http2ClientSession::release(ProxyTransaction * /* trans ATS_UNUSED */)
 {
 }
 
@@ -338,7 +338,7 @@ Http2ClientSession::set_no_activity_timeout()
 }
 
 HTTPVersion
-Http2ClientSession::get_version(HTTPHdr &hdr) const
+Http2ClientSession::get_version(HTTPHdr & /* hdr ATS_UNUSED */) const
 {
   return HTTP_2_0;
 }

--- a/src/proxy/http2/Http2CommonSession.cc
+++ b/src/proxy/http2/Http2CommonSession.cc
@@ -351,7 +351,7 @@ Http2CommonSession::do_complete_frame_read()
 }
 
 int
-Http2CommonSession::do_process_frame_read(int event, VIO *vio, bool inside_frame)
+Http2CommonSession::do_process_frame_read(int /* event ATS_UNUSED */, VIO *vio, bool inside_frame)
 {
   Http2SsnDebug("do_process_frame_read %" PRId64 " bytes ready", this->_read_buffer_reader->read_avail());
 

--- a/src/proxy/http2/Http2Frame.cc
+++ b/src/proxy/http2/Http2Frame.cc
@@ -105,7 +105,7 @@ Http2HeadersFrame::write_to(MIOBuffer *iobuffer) const
 // PRIORITY Frame
 //
 int64_t
-Http2PriorityFrame::write_to(MIOBuffer *iobuffer) const
+Http2PriorityFrame::write_to(MIOBuffer * /* iobuffer ATS_UNUSED */) const
 {
   ink_abort("not supported yet");
 

--- a/src/proxy/http2/Http2ServerSession.cc
+++ b/src/proxy/http2/Http2ServerSession.cc
@@ -147,7 +147,7 @@ Http2ServerSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
 // are scenarios where we would like to complete the outstanding streams.
 
 void
-Http2ServerSession::do_io_close(int alerrno)
+Http2ServerSession::do_io_close(int /* alerrno ATS_UNUSED */)
 {
   REMEMBER(NO_EVENT, this->recursion)
 
@@ -280,7 +280,7 @@ Http2ServerSession::get_protocol_string() const
 }
 
 void
-Http2ServerSession::release(ProxyTransaction *trans)
+Http2ServerSession::release(ProxyTransaction * /* trans ATS_UNUSED */)
 {
 }
 
@@ -401,7 +401,7 @@ Http2ServerSession::set_no_activity_timeout()
 }
 
 HTTPVersion
-Http2ServerSession::get_version(HTTPHdr &hdr) const
+Http2ServerSession::get_version(HTTPHdr & /* hdr ATS_UNUSED */) const
 {
   return HTTP_2_0;
 }

--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -287,7 +287,7 @@ Http2Stream::decode_header_blocks(HpackHandle &hpack_handle, uint32_t maximum_ta
 }
 
 void
-Http2Stream::send_headers(Http2ConnectionState &cstate)
+Http2Stream::send_headers(Http2ConnectionState & /* cstate ATS_UNUSED */)
 {
   if (closed) {
     return;
@@ -519,7 +519,7 @@ Http2Stream::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 }
 
 VIO *
-Http2Stream::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool owner)
+Http2Stream::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, bool /* owner ATS_UNUSED */)
 {
   if (abuffer) {
     write_vio.buffer.reader_for(abuffer);
@@ -960,7 +960,7 @@ Http2Stream::push_promise(URL &url, const MIMEField *accept_encoding)
 }
 
 void
-Http2Stream::send_body(bool call_update)
+Http2Stream::send_body(bool /* call_update ATS_UNUSED */)
 {
   Http2ConnectionState &connection_state = this->get_connection_state();
   _timeout.update_inactivity();
@@ -1205,7 +1205,7 @@ Http2Stream::read_vio_read_avail()
 }
 
 bool
-Http2Stream::has_request_body(int64_t content_length, bool is_chunked_set) const
+Http2Stream::has_request_body(int64_t /* content_length ATS_UNUSED */, bool /* is_chunked_set ATS_UNUSED */) const
 {
   return has_body;
 }
@@ -1273,7 +1273,7 @@ Http2Stream::set_tx_error_code(ProxyError e)
 }
 
 HTTPVersion
-Http2Stream::get_version(HTTPHdr &hdr) const
+Http2Stream::get_version(HTTPHdr & /* hdr ATS_UNUSED */) const
 {
   return HTTP_2_0;
 }

--- a/src/proxy/logging/LogBuffer.cc
+++ b/src/proxy/logging/LogBuffer.cc
@@ -483,8 +483,9 @@ LogBuffer::max_entry_bytes()
   -------------------------------------------------------------------------*/
 int
 LogBuffer::resolve_custom_entry(LogFieldList *fieldlist, char *printf_str, char *read_from, char *write_to, int write_to_len,
-                                long timestamp, long timestamp_usec, unsigned buffer_version, LogFieldList *alt_fieldlist,
-                                char *alt_printf_str, LogEscapeType escape_type)
+                                long /* timestamp ATS_UNUSED */, long /* timestamp_usec ATS_UNUSED */,
+                                unsigned /* buffer_version ATS_UNUSED */, LogFieldList *alt_fieldlist, char *alt_printf_str,
+                                LogEscapeType escape_type)
 {
   if (fieldlist == nullptr || printf_str == nullptr) {
     return 0;

--- a/src/proxy/logging/LogObject.cc
+++ b/src/proxy/logging/LogObject.cc
@@ -102,8 +102,8 @@ LogBufferManager::preproc_buffers(LogBufferSink *sink)
 
 LogObject::LogObject(LogConfig *cfg, const LogFormat *format, const char *log_dir, const char *basename, LogFileFormat file_format,
                      const char *header, Log::RollingEnabledValues rolling_enabled, int flush_threads, int rolling_interval_sec,
-                     int rolling_offset_hr, int rolling_size_mb, bool auto_created, int rolling_max_count, int rolling_min_count,
-                     bool reopen_after_rolling, int pipe_buffer_size, bool fast)
+                     int rolling_offset_hr, int rolling_size_mb, bool /* auto_created ATS_UNUSED */, int rolling_max_count,
+                     int rolling_min_count, bool reopen_after_rolling, int pipe_buffer_size, bool fast)
   : m_alt_filename(nullptr),
     m_flags(0),
     m_signature(0),

--- a/src/records/RecCore.cc
+++ b/src/records/RecCore.cc
@@ -551,7 +551,8 @@ RecLookupRecord(const char *name, void (*callback)(const RecRecord *, void *), v
 }
 
 RecErrT
-RecLookupMatchingRecords(unsigned rec_type, const char *match, void (*callback)(const RecRecord *, void *), void *data, bool lock)
+RecLookupMatchingRecords(unsigned rec_type, const char *match, void (*callback)(const RecRecord *, void *), void *data,
+                         bool /* lock ATS_UNUSED */)
 {
   int num_records;
   DFA regex;

--- a/src/records/RecYAMLDecoder.cc
+++ b/src/records/RecYAMLDecoder.cc
@@ -223,12 +223,12 @@ flatten_node(CfgNode const &field, RecYAMLNodeHandler handler, swoc::Errata &err
 namespace swoc
 {
 BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, YAML::NodeType::value type)
+bwformat(BufferWriter &w, bwf::Spec const & /* spec ATS_UNUSED */, YAML::NodeType::value type)
 {
   return w.write(Node_Type_to_Str[type]);
 }
 BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, YAML::Node const &node)
+bwformat(BufferWriter &w, bwf::Spec const & /* spec ATS_UNUSED */, YAML::Node const &node)
 {
   return w.write(node.as<std::string>());
 }

--- a/src/records/unit_tests/test_Diags.h
+++ b/src/records/unit_tests/test_Diags.h
@@ -28,7 +28,8 @@ public:
   CatchDiags() : Diags("catch", "", "", nullptr) {}
 
   void
-  error_va(DiagsLevel diags_level, const SourceLocation *loc, const char *fmt, va_list ap) const override
+  error_va(DiagsLevel /* diags_level ATS_UNUSED */, const SourceLocation * /* loc ATS_UNUSED */, const char *fmt,
+           va_list ap) const override
   {
     char buff[32768];
     vsnprintf(buff, sizeof(buff), fmt, ap);

--- a/src/records/unit_tests/unit_test_main_on_eventsystem.cc
+++ b/src/records/unit_tests/unit_test_main_on_eventsystem.cc
@@ -38,7 +38,7 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase;
 
   void
-  testRunStarting(Catch::TestRunInfo const &testRunInfo) override
+  testRunStarting(Catch::TestRunInfo const & /* testRunInfo ATS_UNUSED */) override
   {
     Layout::create();
     init_diags("", nullptr);

--- a/src/traffic_layout/engine.cc
+++ b/src/traffic_layout/engine.cc
@@ -152,7 +152,7 @@ path_handler(const std::string &path, bool run_flag, const std::string &command)
 
 // check if there is any directory inside empty_check_directory to see if it is empty or not
 static int
-check_directory_empty(const char *path, [[maybe_unused]] const struct stat *s, int flag)
+check_directory_empty(const char *path, const struct stat * /* s ATS_UNUSED */, int /* flag ATS_UNUSED */)
 {
   return std::string(path) != empty_check_directory ? -1 : 0;
 }


### PR DESCRIPTION
Fix unused parameters, using /`* name ATS_UNUSED */`, in `mgmt` and `proxy` and few others left here and there.

This pull request is the last part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377) the `-Wno-unused-parameter` warning suppression.