### PR TITLE
Remove unused defines from P_Connection.h

### DIFF
--- a/src/iocore/dns/P_DNSConnection.h
+++ b/src/iocore/dns/P_DNSConnection.h
@@ -103,11 +103,7 @@ struct DNSConnection {
     }
   } tcp_data;
 
-  int connect(sockaddr const *addr, Options const &opt = DEFAULT_OPTIONS);
-  /*
-                bool non_blocking_connect = NON_BLOCKING_CONNECT,
-                bool use_tcp = CONNECT_WITH_TCP, bool non_blocking = NON_BLOCKING, bool bind_random_port = BIND_ANY_PORT);
-  */
+  int  connect(sockaddr const *addr, Options const &opt = DEFAULT_OPTIONS);
   int  close();
   void trigger();
 

--- a/src/iocore/net/Connection.cc
+++ b/src/iocore/net/Connection.cc
@@ -46,8 +46,6 @@
 // set in the OS
 // #define RECV_BUF_SIZE            (1024*64)
 // #define SEND_BUF_SIZE            (1024*64)
-#define FIRST_RANDOM_PORT 16000
-#define LAST_RANDOM_PORT  32000
 
 namespace
 {

--- a/src/iocore/net/Connection.cc
+++ b/src/iocore/net/Connection.cc
@@ -43,10 +43,6 @@
 #include <sys/linker.h>
 #endif
 
-// set in the OS
-// #define RECV_BUF_SIZE            (1024*64)
-// #define SEND_BUF_SIZE            (1024*64)
-
 namespace
 {
 DbgCtl dbg_ctl_http_tproxy{"http_tproxy"};
@@ -101,10 +97,6 @@ Server::accept(Connection *c)
     DbgPrint(dbg_ctl_iocore_net_server, "Connection accepted [Server]. %s -> %s", ats_ip_nptop(&c->addr, ipb2, sizeof(ipb2)),
              ats_ip_nptop(&addr, ipb1, sizeof(ipb1)));
   }
-
-#ifdef SEND_BUF_SIZE
-  SocketManager::set_sndbuf_size(c->fd, SEND_BUF_SIZE);
-#endif
 
   return 0;
 }
@@ -163,24 +155,6 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
     http_accept_filter = true;
     add_http_filter(fd);
   }
-
-#ifdef SEND_BUF_SIZE
-  {
-    int send_buf_size = SEND_BUF_SIZE;
-    if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (char *)&send_buf_size, sizeof(int)) < 0)) {
-      goto Lerror;
-    }
-  }
-#endif
-
-#ifdef RECV_BUF_SIZE
-  {
-    int recv_buf_size = RECV_BUF_SIZE;
-    if ((res = safe_setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (char *)&recv_buf_size, sizeof(int))) < 0) {
-      goto Lerror;
-    }
-  }
-#endif
 
   if (opt.recv_bufsize) {
     if (SocketManager::set_rcvbuf_size(fd, opt.recv_bufsize)) {

--- a/src/iocore/net/P_Connection.h
+++ b/src/iocore/net/P_Connection.h
@@ -54,13 +54,6 @@
 
 struct NetVCOptions;
 
-//
-// Defines
-//
-
-#define NON_BLOCKING true
-#define BLOCKING     false
-
 ///////////////////////////////////////////////////////////////////////
 //
 // Connection

--- a/src/iocore/net/P_Connection.h
+++ b/src/iocore/net/P_Connection.h
@@ -58,20 +58,8 @@ struct NetVCOptions;
 // Defines
 //
 
-#define NON_BLOCKING_CONNECT true
-#define BLOCKING_CONNECT     false
-#define CONNECT_WITH_TCP     true
-#define CONNECT_WITH_UDP     false
-#define NON_BLOCKING         true
-#define BLOCKING             false
-#define BIND_RANDOM_PORT     true
-#define BIND_ANY_PORT        false
-#define ENABLE_MC_LOOPBACK   true
-#define DISABLE_MC_LOOPBACK  false
-#define BC_NO_CONNECT        true
-#define BC_CONNECT           false
-#define BC_NO_BIND           true
-#define BC_BIND              false
+#define NON_BLOCKING true
+#define BLOCKING     false
 
 ///////////////////////////////////////////////////////////////////////
 //

--- a/src/iocore/net/P_NetAccept.h
+++ b/src/iocore/net/P_NetAccept.h
@@ -108,8 +108,14 @@ struct NetAccept : public Continuation {
   virtual void       stop_accept();
   virtual NetAccept *clone() const;
 
-  // 0 == success
-  int do_listen(bool non_blocking);
+  /** Listen without blocking.
+   *
+   * For a blocking listen, use do_blocking_listen.
+   *
+   * @see do_blocking_listen
+   */
+  int do_listen();
+  int do_blocking_listen();
   int do_blocking_accept(EThread *t);
 
   virtual int acceptEvent(int event, void *e);
@@ -120,6 +126,9 @@ struct NetAccept : public Continuation {
 
   explicit NetAccept(const NetProcessor::AcceptOptions &);
   ~NetAccept() override { action_ = nullptr; }
+
+private:
+  int do_listen_impl(bool non_blocking);
 };
 
 extern Ptr<ProxyMutex>          naVecMutex;

--- a/src/iocore/net/UnixConnection.cc
+++ b/src/iocore/net/UnixConnection.cc
@@ -30,9 +30,6 @@
 #include "tscore/ink_sock.h"
 
 #define SET_NO_LINGER
-// set in the OS
-// #define RECV_BUF_SIZE            (1024*64)
-// #define SEND_BUF_SIZE            (1024*64)
 #define FIRST_RANDOM_PORT 16000
 #define LAST_RANDOM_PORT  32000
 
@@ -99,9 +96,8 @@ template <typename T> struct cleaner {
     @c nullptr which meant that the defaults had to be encoded in any
     methods that used it as well as the @c NetVCOptions
     constructor. Now they are controlled only in the latter and not in
-    any of the methods. This makes handling global default values
-    (such as @c RECV_BUF_SIZE) more robust. It doesn't have to be
-    checked in the method, only in the @c NetVCOptions constructor.
+    any of the methods. It doesn't have to be checked in the method,
+    only in the @c NetVCOptions constructor.
 
     The methods are simpler because they never have to check for the
     presence of the options, yet the clients aren't inconvenienced

--- a/src/iocore/net/UnixNetAccept.cc
+++ b/src/iocore/net/UnixNetAccept.cc
@@ -202,7 +202,7 @@ NetAccept::init_accept_loop()
   int    i, n;
   char   thr_name[MAX_THREAD_NAME_LENGTH];
   size_t stacksize;
-  if (do_listen(BLOCKING)) {
+  if (do_blocking_listen()) {
     return;
   }
   REC_ReadConfigInteger(stacksize, "proxy.config.thread.default.stacksize");
@@ -242,7 +242,7 @@ NetAccept::init_accept(EThread *t)
     action_->mutex               = t->mutex;
   }
 
-  if (do_listen(NON_BLOCKING)) {
+  if (do_listen()) {
     return;
   }
 
@@ -258,7 +258,7 @@ NetAccept::accept_per_thread(int /* event ATS_UNUSED */, void * /* ep ATS_UNUSED
   REC_ReadConfigInteger(listen_per_thread, "proxy.config.exec_thread.listen");
 
   if (listen_per_thread == 1) {
-    if (do_listen(NON_BLOCKING)) {
+    if (do_listen()) {
       Fatal("[NetAccept::accept_per_thread]:error listenting on ports");
       return -1;
     }
@@ -286,7 +286,7 @@ NetAccept::init_accept_per_thread()
   REC_ReadConfigInteger(listen_per_thread, "proxy.config.exec_thread.listen");
 
   if (listen_per_thread == 0) {
-    if (do_listen(NON_BLOCKING)) {
+    if (do_listen()) {
       Fatal("[NetAccept::accept_per_thread]:error listenting on ports");
       return;
     }
@@ -313,7 +313,20 @@ NetAccept::stop_accept()
 }
 
 int
-NetAccept::do_listen(bool non_blocking)
+NetAccept::do_listen()
+{
+  // non-blocking
+  this->do_listen_impl(true);
+}
+
+int
+NetAccept::do_blocking_listen()
+{
+  this->do_listen_impl(false);
+}
+
+int
+NetAccept::do_listen_impl(bool non_blocking)
 {
   int res = 0;
 

--- a/src/iocore/net/UnixNetAccept.cc
+++ b/src/iocore/net/UnixNetAccept.cc
@@ -322,7 +322,7 @@ NetAccept::do_listen()
 int
 NetAccept::do_blocking_listen()
 {
-  this->do_listen_impl(false);
+  return this->do_listen_impl(false);
 }
 
 int

--- a/src/iocore/net/UnixNetAccept.cc
+++ b/src/iocore/net/UnixNetAccept.cc
@@ -316,7 +316,7 @@ int
 NetAccept::do_listen()
 {
   // non-blocking
-  this->do_listen_impl(true);
+  return this->do_listen_impl(true);
 }
 
 int


### PR DESCRIPTION
It seems these have been superceded by NetVCOptions. Having them in the source code is confusing, since they no longer have any effect.