### PR TITLE
Remove unused `alloc` parameter in swoc/Vectray functionality

### DIFF
--- a/lib/swoc/include/swoc/Vectray.h
+++ b/lib/swoc/include/swoc/Vectray.h
@@ -232,7 +232,7 @@ protected:
 
 template <typename T, size_t N, typename A> Vectray<T, N, A>::Vectray() {}
 
-template <typename T, size_t N, class A> Vectray<T, N, A>::Vectray(Vectray::size_type n, allocator_type const &alloc) : Vectray() {
+template <typename T, size_t N, class A> Vectray<T, N, A>::Vectray(Vectray::size_type n, allocator_type const &) : Vectray() {
   this->reserve(n);
   while (n-- > 0) {
     this->emplace_back();


### PR DESCRIPTION
This pull request is part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377 ) the `-Wno-unused-parameter` warning suppression.

I was told to not change code in the lib directory because it contains 3rdparty libraries.
However, this was the only error reported from there and I don't think it could have been silenced via `CMakeLists.txt` configuration because this is a template class which is not built in the library but directly included and used from outside.
I think, it was either changing this piece of code or leaving the warning suppression at the highest level (in the main `CMakeLists.txt`).

This warning is reported only by Clang but not by GCC according to my build tests.