### PR TITLE
Fix unused parameters in `exemple/plugins/c-api`

### DIFF
--- a/example/plugins/c-api/cert_update/cert_update.cc
+++ b/example/plugins/c-api/cert_update/cert_update.cc
@@ -75,7 +75,7 @@ CB_cert_update(TSCont, TSEvent, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/c-api/client_context_dump/client_context_dump.cc
+++ b/example/plugins/c-api/client_context_dump/client_context_dump.cc
@@ -170,7 +170,7 @@ CB_context_dump(TSCont, TSEvent, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/c-api/disable_http2/disable_http2.cc
+++ b/example/plugins/c-api/disable_http2/disable_http2.cc
@@ -44,7 +44,7 @@ using DomainSet = std::unordered_set<std::string>;
 DomainSet Domains;
 
 int
-CB_SNI(TSCont contp, TSEvent, void *cb_data)
+CB_SNI(TSCont /* contp ATS_UNUSED */, TSEvent, void *cb_data)
 {
   auto            vc       = static_cast<TSVConn>(cb_data);
   TSSslConnection ssl_conn = TSVConnSslConnectionGet(vc);

--- a/example/plugins/c-api/hello/hello.cc
+++ b/example/plugins/c-api/hello/hello.cc
@@ -33,7 +33,7 @@ DbgCtl dbg_ctl{PLUGIN_NAME};
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/c-api/lifecycle_plugin/lifecycle_plugin.cc
+++ b/example/plugins/c-api/lifecycle_plugin/lifecycle_plugin.cc
@@ -67,7 +67,7 @@ CallbackHandler(TSCont, TSEvent id, void *data)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
   TSCont                   cb;

--- a/example/plugins/c-api/null_transform/null_transform.cc
+++ b/example/plugins/c-api/null_transform/null_transform.cc
@@ -185,7 +185,7 @@ handle_transform(TSCont contp)
 }
 
 static int
-null_transform(TSCont contp, TSEvent event, void *edata)
+null_transform(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   /* Check to see if the transformation has been closed by a call to
    * TSVConnClose.
@@ -277,7 +277,7 @@ transform_add(TSHttpTxn txnp)
 }
 
 static int
-transform_plugin(TSCont contp, TSEvent event, void *edata)
+transform_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
 
@@ -299,7 +299,7 @@ transform_plugin(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/c-api/protocol_stack/protocol_stack.cc
+++ b/example/plugins/c-api/protocol_stack/protocol_stack.cc
@@ -34,7 +34,7 @@ DbgCtl dbg_ctl{PLUGIN_NAME};
 }
 
 static int
-proto_stack_cb(TSCont contp ATS_UNUSED, TSEvent event, void *edata)
+proto_stack_cb(TSCont contp ATS_UNUSED, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSHttpTxn   txnp = static_cast<TSHttpTxn>(edata);
   const char *results[10];

--- a/example/plugins/c-api/session_hooks/session_hooks.cc
+++ b/example/plugins/c-api/session_hooks/session_hooks.cc
@@ -36,7 +36,7 @@ static int transaction_count_stat;
 static int session_count_stat;
 
 static void
-txn_handler(TSHttpTxn txnp, TSCont contp)
+txn_handler(TSHttpTxn /* txnp ATS_UNUSED */, TSCont /* contp ATS_UNUSED */)
 {
   TSMgmtInt num_txns = 0;
 
@@ -84,7 +84,7 @@ ssn_handler(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSCont                   contp;
   TSPluginRegistrationInfo info;

--- a/example/plugins/c-api/ssl_sni/ssl_sni.cc
+++ b/example/plugins/c-api/ssl_sni/ssl_sni.cc
@@ -91,7 +91,7 @@ CB_servername(TSCont /* contp */, TSEvent /* event */, void *edata)
 
 // Called by ATS as our initialization point
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   bool                     success = false;
   TSPluginRegistrationInfo info;

--- a/example/plugins/c-api/ssl_sni_allowlist/ssl_sni_allowlist.cc
+++ b/example/plugins/c-api/ssl_sni_allowlist/ssl_sni_allowlist.cc
@@ -72,7 +72,7 @@ CB_servername_allowlist(TSCont /* contp */, TSEvent /* event */, void *edata)
 
 // Called by ATS as our initialization point
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   bool                     success = false;
   TSPluginRegistrationInfo info;

--- a/example/plugins/c-api/txn_data_sink/txn_data_sink.cc
+++ b/example/plugins/c-api/txn_data_sink/txn_data_sink.cc
@@ -148,14 +148,14 @@ body_reader_helper(TSCont contp, TSEvent event, bool sync_response_body)
 
 /** The handler for transaction data sink for response bodies. */
 int
-response_body_reader(TSCont contp, TSEvent event, void *edata)
+response_body_reader(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   return body_reader_helper(contp, event, SINK_RESPONSE_BODY);
 }
 
 /** The handler for transaction data sink for request bodies. */
 int
-request_body_reader(TSCont contp, TSEvent event, void *edata)
+request_body_reader(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   return body_reader_helper(contp, event, SINK_REQUEST_BODY);
 }
@@ -211,7 +211,7 @@ response_sink_requested(TSHttpTxn txnp)
  * transaction data sink if X-Dump-Request or X-Dump-Response flags are used.
  */
 int
-main_hook(TSCont contp, TSEvent event, void *edata)
+main_hook(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = static_cast<TSHttpTxn>(edata);
 
@@ -242,7 +242,7 @@ main_hook(TSCont contp, TSEvent event, void *edata)
 } // anonymous namespace
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/example/plugins/c-api/vconn_args/vconn_args.cc
+++ b/example/plugins/c-api/vconn_args/vconn_args.cc
@@ -31,7 +31,7 @@ static DbgCtl dbg_ctl{PLUGIN_NAME};
 static int    last_arg = 0;
 
 static int
-vconn_arg_handler(TSCont contp, TSEvent event, void *edata)
+vconn_arg_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
   switch (event) {
@@ -86,7 +86,7 @@ vconn_arg_handler(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "Initializing plugin.");
   TSPluginRegistrationInfo info;

--- a/example/plugins/c-api/verify_cert/verify_cert.cc
+++ b/example/plugins/c-api/verify_cert/verify_cert.cc
@@ -86,7 +86,7 @@ CB_clientcert(TSCont /* contp */, TSEvent /* event */, void *edata)
 
 // Called by ATS as our initialization point
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   bool                     success = false;
   TSPluginRegistrationInfo info;


### PR DESCRIPTION
Fix unused parameters using `/* name ATS_UNUSED */`

This pull request is part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377) the `-Wno-unused-parameter` warning suppression.