### PR TITLE
Fix unused parameters in `proxy/http3` functionality

### DIFF
--- a/src/proxy/http3/Http09App.cc
+++ b/src/proxy/http3/Http09App.cc
@@ -89,7 +89,7 @@ Http09App::on_stream_open(QUICStream &stream)
 }
 
 void
-Http09App::on_stream_close(QUICStream &stream)
+Http09App::on_stream_close(QUICStream & /* stream ATS_UNUSED */)
 {
 }
 

--- a/src/proxy/http3/Http3App.cc
+++ b/src/proxy/http3/Http3App.cc
@@ -382,13 +382,13 @@ Http3App::_handle_uni_stream_on_write_complete(int event, VIO *vio)
 }
 
 void
-Http3App::_handle_bidi_stream_on_eos(int /* event */, VIO *vio)
+Http3App::_handle_bidi_stream_on_eos(int /* event ATS_UNUSED */, VIO * /* vio ATS_UNUSED */)
 {
   // TODO: handle eos
 }
 
 void
-Http3App::_handle_uni_stream_on_eos(int /* event */, VIO *v)
+Http3App::_handle_uni_stream_on_eos(int /* event ATS_UNUSED */, VIO * /* v ATS_UNUSED */)
 {
   // TODO: handle eos
 }

--- a/src/proxy/http3/Http3FrameCounter.cc
+++ b/src/proxy/http3/Http3FrameCounter.cc
@@ -35,7 +35,8 @@ Http3FrameCounter::interests()
 }
 
 Http3ErrorUPtr
-Http3FrameCounter::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq, Http3StreamType s_type)
+Http3FrameCounter::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t /* frame_seq ATS_UNUSED */,
+                                Http3StreamType /* s_type ATS_UNUSED */)
 {
   Http3ErrorUPtr error  = Http3ErrorUPtr(nullptr);
   Http3FrameType f_type = frame->type();

--- a/src/proxy/http3/Http3HeaderVIOAdaptor.cc
+++ b/src/proxy/http3/Http3HeaderVIOAdaptor.cc
@@ -82,7 +82,7 @@ Http3HeaderVIOAdaptor::is_complete()
 }
 
 int
-Http3HeaderVIOAdaptor::event_handler(int event, Event *data)
+Http3HeaderVIOAdaptor::event_handler(int event, Event * /* data ATS_UNUSED */)
 {
   switch (event) {
   case QPACK_EVENT_DECODE_COMPLETE:

--- a/src/proxy/http3/Http3Session.cc
+++ b/src/proxy/http3/Http3Session.cc
@@ -91,28 +91,28 @@ HQSession::get_transaction(QUICStreamId id)
 }
 
 void
-HQSession::do_io_close(int lerrno)
+HQSession::do_io_close(int /* lerrno ATS_UNUSED */)
 {
   // TODO
   return;
 }
 
 void
-HQSession::do_io_shutdown(ShutdownHowTo_t howto)
+HQSession::do_io_shutdown(ShutdownHowTo_t /* howto ATS_UNUSED */)
 {
   ink_assert(false);
   return;
 }
 
 void
-HQSession::reenable(VIO *vio)
+HQSession::reenable(VIO * /* vio ATS_UNUSED */)
 {
   ink_assert(false);
   return;
 }
 
 void
-HQSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOBufferReader *reade)
+HQSession::new_connection(NetVConnection *new_vc, MIOBuffer * /* iobuf ATS_UNUSED */, IOBufferReader * /* reader ATS_UNUSED */)
 {
   this->con_id = new_vc->get_service<QUICSupport>()->get_quic_connection()->connection_id();
   this->_handle_if_ssl(new_vc);
@@ -142,7 +142,7 @@ HQSession::free()
 }
 
 void
-HQSession::release(ProxyTransaction *trans)
+HQSession::release(ProxyTransaction * /* trans ATS_UNUSED */)
 {
   return;
 }
@@ -192,7 +192,7 @@ Http3Session::~Http3Session()
 }
 
 HTTPVersion
-Http3Session::get_version(HTTPHdr &hdr) const
+Http3Session::get_version(HTTPHdr & /* hdr ATS_UNUSED */) const
 {
   return HTTP_3_0;
 }
@@ -253,7 +253,7 @@ Http09Session::~Http09Session()
 }
 
 HTTPVersion
-Http09Session::get_version(HTTPHdr &hdr) const
+Http09Session::get_version(HTTPHdr & /* hdr ATS_UNUSED */) const
 {
   return HTTP_0_9;
 }

--- a/src/proxy/http3/Http3SessionAccept.cc
+++ b/src/proxy/http3/Http3SessionAccept.cc
@@ -46,7 +46,7 @@ Http3SessionAccept::Http3SessionAccept(const HttpSessionAccept::Options &_o) : S
 Http3SessionAccept::~Http3SessionAccept() {}
 
 bool
-Http3SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReader *reader)
+Http3SessionAccept::accept(NetVConnection *netvc, MIOBuffer * /* iobuf ATS_UNUSED */, IOBufferReader * /* reader ATS_UNUSED */)
 {
   sockaddr const *client_ip   = netvc->get_remote_addr();
   IpAllow::ACL    session_acl = IpAllow::match(client_ip, IpAllow::SRC_ADDR);

--- a/src/proxy/http3/Http3Transaction.cc
+++ b/src/proxy/http3/Http3Transaction.cc
@@ -139,7 +139,7 @@ HQTransaction::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 }
 
 VIO *
-HQTransaction::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
+HQTransaction::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool /* owner ATS_UNUSED */)
 {
   if (buf) {
     this->_write_vio.buffer.reader_for(buf);
@@ -164,7 +164,7 @@ HQTransaction::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf,
 }
 
 void
-HQTransaction::do_io_close(int lerrno)
+HQTransaction::do_io_close(int /* lerrno ATS_UNUSED */)
 {
   this->_read_vio.buffer.clear();
   this->_read_vio.nbytes = 0;
@@ -178,7 +178,7 @@ HQTransaction::do_io_close(int lerrno)
 }
 
 void
-HQTransaction::do_io_shutdown(ShutdownHowTo_t howto)
+HQTransaction::do_io_shutdown(ShutdownHowTo_t /* howto ATS_UNUSED */)
 {
   return;
 }
@@ -622,7 +622,7 @@ Http3Transaction::_process_write_vio()
 }
 
 bool
-Http3Transaction::has_request_body(int64_t content_length, bool is_chunked_set) const
+Http3Transaction::has_request_body(int64_t content_length, bool /* is_chunked_set ATS_UNUSED */) const
 {
   // Has body if Content-Length != 0 (content_length can be -1 if it's undefined)
   if (content_length > 0) {

--- a/src/proxy/http3/QPACK.cc
+++ b/src/proxy/http3/QPACK.cc
@@ -187,7 +187,7 @@ QPACK::on_stream_open(QUICStream &stream)
 }
 
 void
-QPACK::on_stream_close(QUICStream &stream)
+QPACK::on_stream_close(QUICStream & /* stream ATS_UNUSED */)
 {
 }
 
@@ -543,7 +543,7 @@ QPACK::_encode_indexed_header_field(uint16_t index, uint16_t base_index, bool dy
 }
 
 int
-QPACK::_encode_indexed_header_field_with_postbase_index(uint16_t index, uint16_t base_index, bool never_index,
+QPACK::_encode_indexed_header_field_with_postbase_index(uint16_t index, uint16_t base_index, bool /* never_index ATS_UNUSED */,
                                                         IOBufferBlock *compressed_header)
 {
   char *buf     = compressed_header->end();
@@ -1204,7 +1204,7 @@ QPACK::_on_encoder_write_ready(MIOBuffer &writer)
 }
 
 size_t
-QPACK::estimate_header_block_size(const HTTPHdr &hdr)
+QPACK::estimate_header_block_size(const HTTPHdr & /* hdr ATS_UNUSED */)
 {
   // FIXME Estimate it
   return 128 * 1024 * 1024;
@@ -1273,7 +1273,8 @@ QPACK::_calc_postbase_index_from_absolute_index(uint16_t base_index, uint16_t ab
 }
 
 void
-QPACK::_attach_header(HTTPHdr &hdr, const char *name, int name_len, const char *value, int value_len, bool never_index)
+QPACK::_attach_header(HTTPHdr &hdr, const char *name, int name_len, const char *value, int value_len,
+                      bool /* never_index ATS_UNUSED */)
 {
   // TODO If never_index is true, we need to mark this header as sensitive to not index the header when passing it to the other side
   MIMEField *new_field = hdr.field_create(name, name_len);

--- a/src/proxy/http3/test/Mock.h
+++ b/src/proxy/http3/test/Mock.h
@@ -39,7 +39,8 @@ public:
   }
 
   Http3ErrorUPtr
-  handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t /* frame_seq */, Http3StreamType /* s_type */) override
+  handle_frame(std::shared_ptr<const Http3Frame> /* frame ATS_UNUSED */, int32_t /* frame_seq */,
+               Http3StreamType /* s_type */) override
   {
     this->total_frame_received++;
     return Http3ErrorUPtr(nullptr);

--- a/src/proxy/http3/test/stub.cc
+++ b/src/proxy/http3/test/stub.cc
@@ -23,17 +23,17 @@
 
 #include "proxy/http3/QPACK.h"
 void
-QPACK::update_max_field_section_size(uint32_t max_field_section_size)
+QPACK::update_max_field_section_size(uint32_t /* max_field_section_size ATS_UNUSED */)
 {
 }
 
 void
-QPACK::update_max_table_size(uint16_t max_table_size)
+QPACK::update_max_table_size(uint16_t /* max_table_size ATS_UNUSED */)
 {
 }
 
 void
-QPACK::update_max_blocking_streams(uint16_t max_blocking_streams)
+QPACK::update_max_blocking_streams(uint16_t /* max_blocking_streams ATS_UNUSED */)
 {
 }
 

--- a/src/proxy/http3/test/test_QPACK.cc
+++ b/src/proxy/http3/test/test_QPACK.cc
@@ -95,7 +95,7 @@ public:
   TestQPACKEventHandler() : Continuation() { SET_HANDLER(&TestQPACKEventHandler::event_handler); }
 
   int
-  event_handler(int event, Event *data)
+  event_handler(int event, Event * /* data ATS_UNUSED */)
   {
     this->_event = event;
     return 0;
@@ -329,7 +329,8 @@ test_encode(const char *qif_file, const char *out_file, int dts, int mbs, int am
 }
 
 static int
-test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int am, const char *app_name)
+test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int /* am ATS_UNUSED */,
+            const char * /* app_name ATS_UNUSED */)
 {
   int ret = 0;
 

--- a/src/proxy/http3/test/test_QPACK.cc
+++ b/src/proxy/http3/test/test_QPACK.cc
@@ -467,7 +467,7 @@ TEST_CASE("Decoding", "[qpack-decode]")
       stat(enc_file, &st);
       if (S_ISREG(st.st_mode) && strstr(d->d_name, pattern)) {
         snprintf(out_file + strlen(decdir), sizeof(out_file) - strlen(decdir), "/%s/%s.decoded", appname, d->d_name);
-        CHECK(test_decode(enc_file, out_file, tablesize, streams, ackmode, appname) == 0);
+        CHECK(test_decode(enc_file, out_file, tablesize, streams) == 0);
       }
     }
   }

--- a/src/proxy/http3/test/test_QPACK.cc
+++ b/src/proxy/http3/test/test_QPACK.cc
@@ -329,8 +329,7 @@ test_encode(const char *qif_file, const char *out_file, int dts, int mbs, int am
 }
 
 static int
-test_decode(const char *enc_file, const char *out_file, int dts, int mbs, int /* am ATS_UNUSED */,
-            const char * /* app_name ATS_UNUSED */)
+test_decode(const char *enc_file, const char *out_file, int dts, int mbs)
 {
   int ret = 0;
 


### PR DESCRIPTION
Fix unused parameters using `/* name ATS_UNUSED */`

This pull request is part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377) the `-Wno-unused-parameter` warning suppression.