### PR TITLE
Fix unused parameters in the `iocore` functionality (SSL and QUIC related code)

### DIFF
--- a/include/iocore/net/quic/Mock.h
+++ b/include/iocore/net/quic/Mock.h
@@ -234,21 +234,22 @@ class MockNetVConnection : public NetVConnection
 public:
   MockNetVConnection(NetVConnectionContext_t context = NET_VCONNECTION_OUT) : NetVConnection() { netvc_context = context; }
   VIO *
-  do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf) override
+  do_io_read(Continuation * /* c ATS_UNUSED */, int64_t /* nbytes ATS_UNUSED */, MIOBuffer * /* buf ATS_UNUSED */) override
   {
     return nullptr;
   };
   VIO *
-  do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner = false) override
+  do_io_write(Continuation * /* c ATS_UNUSED */, int64_t /* nbytes ATS_UNUSED */, IOBufferReader * /* buf ATS_UNUSED */,
+              bool /* owner  ATS_UNUSED */ = false) override
   {
     return nullptr;
   };
-  void do_io_close(int lerrno = -1) override {};
-  void do_io_shutdown(ShutdownHowTo_t howto) override {};
-  void reenable(VIO *vio) override {};
-  void reenable_re(VIO *vio) override {};
-  void set_active_timeout(ink_hrtime timeout_in) override {};
-  void set_inactivity_timeout(ink_hrtime timeout_in) override {};
+  void do_io_close(int /* lerrno  ATS_UNUSED */ = -1) override {};
+  void do_io_shutdown(ShutdownHowTo_t /* howto ATS_UNUSED */) override{};
+  void reenable(VIO * /* vio ATS_UNUSED */) override {};
+  void reenable_re(VIO * /* vio ATS_UNUSED */) override {};
+  void set_active_timeout(ink_hrtime /* timeout_in ATS_UNUSED */) override{};
+  void set_inactivity_timeout(ink_hrtime /* timeout_in ATS_UNUSED */) override{};
   void cancel_active_timeout() override {};
   void cancel_inactivity_timeout() override {};
   void add_to_keep_alive_queue() override {};
@@ -275,12 +276,12 @@ public:
   SOCKET
   get_socket() override { return 0; }
   int
-  set_tcp_init_cwnd(int init_cwnd)
+  set_tcp_init_cwnd(int /* init_cwnd ATS_UNUSED */)
   {
     return 0;
   }
   int
-  set_tcp_congestion_control(int side) override
+  set_tcp_congestion_control(int /* side ATS_UNUSED */) override
   {
     return 0;
   }
@@ -364,7 +365,7 @@ public:
   }
 
   void
-  close_quic_connection(QUICConnectionErrorUPtr error) override
+  close_quic_connection(QUICConnectionErrorUPtr /* error ATS_UNUSED */) override
   {
   }
 
@@ -468,14 +469,15 @@ public:
   MockQUICStreamAdapter(QUICStream &stream) : QUICStreamAdapter(stream) {}
 
   void
-  write_to_stream(const uint8_t *buf, size_t len)
+  write_to_stream(const uint8_t * /* buf ATS_UNUSED */, size_t len)
   {
     this->_total_sending_data_len += len;
     this->_sending_data_len       += len;
   }
 
   int64_t
-  write(QUICOffset offset, const uint8_t *data, uint64_t data_length, bool fin) override
+  write(QUICOffset /* offset ATS_UNUSED */, const uint8_t * /* data ATS_UNUSED */, uint64_t data_length,
+        bool /* fin ATS_UNUSED */) override
   {
     this->_total_receiving_data_len += data_length;
     this->_receiving_data_len       += data_length;
@@ -538,7 +540,7 @@ public:
   MockQUICApplication(QUICConnection *c) : QUICApplication(c) { SET_HANDLER(&MockQUICApplication::main_event_handler); }
 
   int
-  main_event_handler(int event, Event *data)
+  main_event_handler(int event, Event * /* data ATS_UNUSED */)
   {
     if (event == 12345) {}
     return EVENT_CONT;
@@ -553,7 +555,7 @@ public:
   }
 
   void
-  on_stream_close(QUICStream &stream) override
+  on_stream_close(QUICStream & /* stream ATS_UNUSED */) override
   {
   }
 
@@ -575,7 +577,7 @@ class MockContinuation : public Continuation
 public:
   MockContinuation(Ptr<ProxyMutex> m) : Continuation(m) { SET_HANDLER(&MockContinuation::event_handler); }
   int
-  event_handler(int event, Event *data)
+  event_handler(int /* event ATS_UNUSED */, Event * /* data ATS_UNUSED */)
   {
     return EVENT_CONT;
   }
@@ -602,7 +604,7 @@ class MockQUICRTTProvider : public QUICRTTProvider
   }
 
   ink_hrtime
-  congestion_period(uint32_t threshold) const override
+  congestion_period(uint32_t /* threshold ATS_UNUSED */) const override
   {
     return HRTIME_MSECONDS(1);
   }

--- a/src/iocore/net/QUICClosedConCollector.cc
+++ b/src/iocore/net/QUICClosedConCollector.cc
@@ -24,7 +24,7 @@ QUICClosedConCollector::QUICClosedConCollector()
 }
 
 int
-QUICClosedConCollector::mainEvent(int event, Event *e)
+QUICClosedConCollector::mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
 {
   EThread *t = this->mutex->thread_holding;
   ink_assert(t == this_thread());

--- a/src/iocore/net/QUICMultiCertConfigLoader.cc
+++ b/src/iocore/net/QUICMultiCertConfigLoader.cc
@@ -77,7 +77,7 @@ QUICMultiCertConfigLoader::default_server_ssl_ctx()
 }
 
 bool
-QUICMultiCertConfigLoader::_setup_session_cache(SSL_CTX *ctx)
+QUICMultiCertConfigLoader::_setup_session_cache(SSL_CTX * /* ctx ATS_UNUSED */)
 {
   // Disabled for now
   // TODO Check if the logic in SSLMultiCertConfigLoader is reusable
@@ -85,14 +85,14 @@ QUICMultiCertConfigLoader::_setup_session_cache(SSL_CTX *ctx)
 }
 
 bool
-QUICMultiCertConfigLoader::_set_cipher_suites_for_legacy_versions(SSL_CTX *ctx)
+QUICMultiCertConfigLoader::_set_cipher_suites_for_legacy_versions(SSL_CTX * /* ctx ATS_UNUSED */)
 {
   // Do not set this since QUIC only uses TLS 1.3
   return true;
 }
 
 bool
-QUICMultiCertConfigLoader::_set_info_callback(SSL_CTX *ctx)
+QUICMultiCertConfigLoader::_set_info_callback(SSL_CTX * /* ctx ATS_UNUSED */)
 {
   // Disabled for now
   // TODO Check if we need this for QUIC
@@ -100,7 +100,7 @@ QUICMultiCertConfigLoader::_set_info_callback(SSL_CTX *ctx)
 }
 
 bool
-QUICMultiCertConfigLoader::_set_npn_callback(SSL_CTX *ctx)
+QUICMultiCertConfigLoader::_set_npn_callback(SSL_CTX * /* ctx ATS_UNUSED */)
 {
   // Do not set a callback for NPN since QUIC doesn't use it
   return true;

--- a/src/iocore/net/QUICNetProcessor.cc
+++ b/src/iocore/net/QUICNetProcessor.cc
@@ -50,7 +50,7 @@ DbgCtl dbg_ctl_iocore_net_processor{"iocore_net_processor"};
 } // end anonymous namespace
 
 static void
-debug_log(const char *line, void *argp)
+debug_log(const char *line, void * /* argp ATS_UNUSED */)
 {
   Dbg(dbg_ctl_vv_quiche, "%s\n", line);
 }
@@ -75,7 +75,7 @@ QUICNetProcessor::init()
 }
 
 int
-QUICNetProcessor::start(int, size_t stacksize)
+QUICNetProcessor::start(int, size_t /* stacksize ATS_UNUSED */)
 {
   QUIC::init();
   // This initialization order matters ...

--- a/src/iocore/net/QUICNetProcessor.cc
+++ b/src/iocore/net/QUICNetProcessor.cc
@@ -50,7 +50,7 @@ DbgCtl dbg_ctl_iocore_net_processor{"iocore_net_processor"};
 } // end anonymous namespace
 
 static void
-debug_log(const char *line)
+debug_log(const char *line, void * /* argp ATS_UNUSED */)
 {
   Dbg(dbg_ctl_vv_quiche, "%s\n", line);
 }

--- a/src/iocore/net/QUICNetProcessor.cc
+++ b/src/iocore/net/QUICNetProcessor.cc
@@ -50,7 +50,7 @@ DbgCtl dbg_ctl_iocore_net_processor{"iocore_net_processor"};
 } // end anonymous namespace
 
 static void
-debug_log(const char *line, void * /* argp ATS_UNUSED */)
+debug_log(const char *line)
 {
   Dbg(dbg_ctl_vv_quiche, "%s\n", line);
 }

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -58,14 +58,15 @@ QUICNetVConnection::QUICNetVConnection()
 QUICNetVConnection::~QUICNetVConnection() {}
 
 void
-QUICNetVConnection::init(QUICVersion version, QUICConnectionId peer_cid, QUICConnectionId original_cid, UDPConnection *,
-                         QUICPacketHandler *)
+QUICNetVConnection::init(QUICVersion /* version ATS_UNUSED */, QUICConnectionId /* peer_cid ATS_UNUSED */,
+                         QUICConnectionId /* original_cid ATS_UNUSED */, UDPConnection *, QUICPacketHandler *)
 {
 }
 
 void
-QUICNetVConnection::init(QUICVersion version, QUICConnectionId peer_cid, QUICConnectionId original_cid, QUICConnectionId first_cid,
-                         QUICConnectionId retry_cid, UDPConnection *udp_con, quiche_conn *quiche_con,
+QUICNetVConnection::init(QUICVersion /* version ATS_UNUSED */, QUICConnectionId /* peer_cid ATS_UNUSED */,
+                         QUICConnectionId original_cid, QUICConnectionId /* first_cid ATS_UNUSED */,
+                         QUICConnectionId /* retry_cid ATS_UNUSED */, UDPConnection *udp_con, quiche_conn *quiche_con,
                          QUICPacketHandler *packet_handler, QUICConnectionTable *ctable, SSL *ssl)
 {
   SET_HANDLER((NetVConnHandler)&QUICNetVConnection::acceptEvent);
@@ -121,7 +122,7 @@ QUICNetVConnection::set_local_addr()
 }
 
 void
-QUICNetVConnection::free_thread(EThread *t)
+QUICNetVConnection::free_thread(EThread * /* t ATS_UNUSED */)
 {
   QUICConDebug("Free connection");
 
@@ -148,7 +149,7 @@ QUICNetVConnection::free_thread(EThread *t)
 }
 
 void
-QUICNetVConnection::reenable(VIO *vio)
+QUICNetVConnection::reenable(VIO * /* vio ATS_UNUSED */)
 {
 }
 
@@ -302,7 +303,7 @@ QUICNetVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 }
 
 VIO *
-QUICNetVConnection::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
+QUICNetVConnection::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool /* owner ATS_UNUSED */)
 {
   auto vio            = super::do_io_write(c, nbytes, buf);
   this->write.enabled = 1;
@@ -369,7 +370,7 @@ QUICNetVConnection::acceptEvent(int event, Event *e)
 }
 
 int
-QUICNetVConnection::connectUp(EThread *t, int fd)
+QUICNetVConnection::connectUp(EThread * /* t ATS_UNUSED */, int /* fd ATS_UNUSED */)
 {
   return 0;
 }
@@ -381,7 +382,7 @@ QUICNetVConnection::stream_manager()
 }
 
 void
-QUICNetVConnection::close_quic_connection(QUICConnectionErrorUPtr error)
+QUICNetVConnection::close_quic_connection(QUICConnectionErrorUPtr /* error ATS_UNUSED */)
 {
 }
 
@@ -516,14 +517,15 @@ QUICNetVConnection::is_handshake_completed() const
 }
 
 void
-QUICNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
+QUICNetVConnection::net_read_io(NetHandler * /* nh ATS_UNUSED */, EThread * /* lthread ATS_UNUSED */)
 {
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
   this->handleEvent(QUIC_EVENT_PACKET_READ_READY, nullptr);
 }
 
 int64_t
-QUICNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf, int64_t &total_written, int &needs)
+QUICNetVConnection::load_buffer_and_write(int64_t /* towrite ATS_UNUSED */, MIOBufferAccessor & /* buf ATS_UNUSED */,
+                                          int64_t & /* total_written ATS_UNUSED */, int & /* needs ATS_UNUSED */)
 {
   return 0;
 }

--- a/src/iocore/net/QUICPacketHandler.cc
+++ b/src/iocore/net/QUICPacketHandler.cc
@@ -174,7 +174,7 @@ QUICPacketHandlerIn::acceptEvent(int event, void *data)
 }
 
 void
-QUICPacketHandlerIn::init_accept(EThread *t = nullptr)
+QUICPacketHandlerIn::init_accept(EThread * /* t  ATS_UNUSED */ = nullptr)
 {
   int i, n;
 
@@ -196,7 +196,7 @@ QUICPacketHandlerIn::_get_continuation()
 }
 
 void
-QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
+QUICPacketHandlerIn::_recv_packet(int /* event ATS_UNUSED */, UDPPacket *udp_packet)
 {
   size_t   buf_len{0};
   uint8_t *buf = udp_packet->get_entire_chain_buffer(&buf_len);
@@ -340,7 +340,7 @@ QUICPacketHandlerIn::_recv_packet(int event, UDPPacket *udp_packet)
 }
 
 void
-QUICPacketHandlerOut::init(QUICNetVConnection *vc)
+QUICPacketHandlerOut::init(QUICNetVConnection * /* vc ATS_UNUSED */)
 {
 }
 
@@ -351,6 +351,6 @@ QUICPacketHandlerOut::_get_continuation()
 }
 
 void
-QUICPacketHandlerOut::_recv_packet(int event, UDPPacket *udp_packet)
+QUICPacketHandlerOut::_recv_packet(int /* event ATS_UNUSED */, UDPPacket * /* udp_packet ATS_UNUSED */)
 {
 }

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -562,7 +562,7 @@ DH_get_2048_256()
 #endif
 
 bool
-SSLMultiCertConfigLoader::_enable_ktls(SSL_CTX *ctx)
+SSLMultiCertConfigLoader::_enable_ktls([[maybe_unused]] SSL_CTX *ctx)
 {
 #ifdef SSL_OP_ENABLE_KTLS
   if (SSLConfigParams::ssl_ktls_enabled) {
@@ -1542,7 +1542,7 @@ SSLMultiCertConfigLoader::_set_cipher_suites_for_legacy_versions(SSL_CTX *ctx)
 }
 
 bool
-SSLMultiCertConfigLoader::_set_cipher_suites(SSL_CTX *ctx)
+SSLMultiCertConfigLoader::_set_cipher_suites([[maybe_unused]] SSL_CTX *ctx)
 {
 #if TS_USE_TLS_SET_CIPHERSUITES
   if (this->_params->server_tls13_cipher_suites != nullptr) {
@@ -1556,7 +1556,7 @@ SSLMultiCertConfigLoader::_set_cipher_suites(SSL_CTX *ctx)
 }
 
 bool
-SSLMultiCertConfigLoader::_set_curves(SSL_CTX *ctx)
+SSLMultiCertConfigLoader::_set_curves([[maybe_unused]] SSL_CTX *ctx)
 {
 #if defined(SSL_CTX_set1_groups_list) || defined(SSL_CTX_set1_curves_list)
   if (this->_params->server_groups_list != nullptr) {

--- a/src/iocore/net/TLSEarlyDataSupport.cc
+++ b/src/iocore/net/TLSEarlyDataSupport.cc
@@ -70,7 +70,8 @@ TLSEarlyDataSupport::get_early_data_len() const
 }
 
 void
-TLSEarlyDataSupport::update_early_data_config(SSL *ssl, uint32_t max_early_data, uint32_t recv_max_early_data)
+TLSEarlyDataSupport::update_early_data_config([[maybe_unused]] SSL *ssl, [[maybe_unused]] uint32_t max_early_data,
+                                              [[maybe_unused]] uint32_t recv_max_early_data)
 {
 #if TS_HAS_TLS_EARLY_DATA
   // Must disable OpenSSL's internal anti-replay if external cache is used with

--- a/src/iocore/net/quic/QUICGlobals.cc
+++ b/src/iocore/net/quic/QUICGlobals.cc
@@ -56,7 +56,7 @@ QUIC::init()
 }
 
 int
-QUIC::ssl_client_new_session(SSL *ssl, SSL_SESSION *session)
+QUIC::ssl_client_new_session([[maybe_unused]] SSL *ssl, [[maybe_unused]] SSL_SESSION *session)
 {
 #if TS_HAS_QUICHE
 #else

--- a/src/iocore/net/quic/QUICStream.cc
+++ b/src/iocore/net/quic/QUICStream.cc
@@ -74,12 +74,12 @@ QUICStream::final_offset() const
 }
 
 void
-QUICStream::stop_sending(QUICStreamErrorUPtr error)
+QUICStream::stop_sending(QUICStreamErrorUPtr /* error ATS_UNUSED */)
 {
 }
 
 void
-QUICStream::reset(QUICStreamErrorUPtr error)
+QUICStream::reset(QUICStreamErrorUPtr /* error ATS_UNUSED */)
 {
 }
 

--- a/src/iocore/net/quic/QUICStreamManager.cc
+++ b/src/iocore/net/quic/QUICStreamManager.cc
@@ -39,18 +39,18 @@ QUICStreamManager::set_default_application(QUICApplication *app)
 }
 
 void
-QUICStreamManager::init_flow_control_params(const std::shared_ptr<const QUICTransportParameters> &local_tp,
-                                            const std::shared_ptr<const QUICTransportParameters> &remote_tp)
+QUICStreamManager::init_flow_control_params(const std::shared_ptr<const QUICTransportParameters> & /* local_tp ATS_UNUSED */,
+                                            const std::shared_ptr<const QUICTransportParameters> & /* remote_tp ATS_UNUSED */)
 {
 }
 
 void
-QUICStreamManager::set_max_streams_bidi(uint64_t max_streams)
+QUICStreamManager::set_max_streams_bidi(uint64_t /* max_streams ATS_UNUSED */)
 {
 }
 
 void
-QUICStreamManager::set_max_streams_uni(uint64_t max_streams)
+QUICStreamManager::set_max_streams_uni(uint64_t /* max_streams ATS_UNUSED */)
 {
 }
 
@@ -101,13 +101,13 @@ QUICStreamManager::create_stream(QUICStreamId stream_id)
 }
 
 QUICConnectionErrorUPtr
-QUICStreamManager::create_uni_stream(QUICStreamId new_stream_id)
+QUICStreamManager::create_uni_stream(QUICStreamId /* new_stream_id ATS_UNUSED */)
 {
   return nullptr;
 }
 
 QUICConnectionErrorUPtr
-QUICStreamManager::create_bidi_stream(QUICStreamId new_stream_id)
+QUICStreamManager::create_bidi_stream(QUICStreamId /* new_stream_id ATS_UNUSED */)
 {
   return nullptr;
 }
@@ -128,11 +128,11 @@ QUICStreamManager::delete_stream(QUICStreamId stream_id)
 }
 
 void
-QUICStreamManager::reset_stream(QUICStreamId stream_id, QUICStreamErrorUPtr error)
+QUICStreamManager::reset_stream(QUICStreamId /* stream_id ATS_UNUSED */, QUICStreamErrorUPtr /* error ATS_UNUSED */)
 {
 }
 
 void
-QUICStreamManager::on_stream_state_close(const QUICStream *stream)
+QUICStreamManager::on_stream_state_close(const QUICStream * /* stream ATS_UNUSED */)
 {
 }

--- a/src/iocore/net/quic/QUICStreamVCAdapter.cc
+++ b/src/iocore/net/quic/QUICStreamVCAdapter.cc
@@ -277,7 +277,7 @@ QUICStreamVCAdapter::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 }
 
 VIO *
-QUICStreamVCAdapter::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
+QUICStreamVCAdapter::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool /* owner ATS_UNUSED */)
 {
   if (buf) {
     this->_write_vio.buffer.reader_for(buf);
@@ -296,7 +296,7 @@ QUICStreamVCAdapter::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader
 }
 
 void
-QUICStreamVCAdapter::do_io_close(int lerrno)
+QUICStreamVCAdapter::do_io_close(int /* lerrno ATS_UNUSED */)
 {
   SET_HANDLER(&QUICStreamVCAdapter::state_stream_closed);
 
@@ -314,14 +314,14 @@ QUICStreamVCAdapter::do_io_close(int lerrno)
 }
 
 void
-QUICStreamVCAdapter::do_io_shutdown(ShutdownHowTo_t howto)
+QUICStreamVCAdapter::do_io_shutdown(ShutdownHowTo_t /* howto ATS_UNUSED */)
 {
   ink_assert(false); // unimplemented yet
   return;
 }
 
 void
-QUICStreamVCAdapter::reenable(VIO *vio)
+QUICStreamVCAdapter::reenable(VIO * /* vio ATS_UNUSED */)
 {
   // TODO We probably need to tell QUICStream that the application consumed received data
   // to update receive window here. In other words, we should not update receive window
@@ -341,7 +341,7 @@ QUICStreamVCAdapter::is_writable()
 }
 
 int
-QUICStreamVCAdapter::state_stream_open(int event, void *data)
+QUICStreamVCAdapter::state_stream_open(int event, void * /* data ATS_UNUSED */)
 {
   QUICErrorUPtr error = nullptr;
 
@@ -372,7 +372,7 @@ QUICStreamVCAdapter::state_stream_open(int event, void *data)
 }
 
 int
-QUICStreamVCAdapter::state_stream_closed(int event, void *data)
+QUICStreamVCAdapter::state_stream_closed(int event, void * /* data ATS_UNUSED */)
 {
   switch (event) {
   case VC_EVENT_READ_READY:


### PR DESCRIPTION
Fix unused parameters using `/* name ATS_UNUSED */` for totally unused parameters.
Fix unused parameters using `[[maybe_unused]]` for conditionally unused parameters.

This pull request is part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377) the `-Wno-unused-parameter` warning suppression.