### PR TITLE
cripts: rename get/set macros to Get/Set

### DIFF
--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -49,7 +49,7 @@ do_create_instance()
 
 do_txn_close()
 {
-  borrow conn = Client::Connection::get();
+  borrow conn = Client::Connection::Get();
 
   conn.pacing = Cript::Pacing::Off;
   CDebug("Cool, TXN close also works");
@@ -57,7 +57,7 @@ do_txn_close()
 
 do_cache_lookup()
 {
-  borrow url2 = Cache::URL::get();
+  borrow url2 = Cache::URL::Get();
 
   CDebug("Cache URL: {}", url2.url());
   CDebug("Cache Host: {}", url2.host);
@@ -65,28 +65,28 @@ do_cache_lookup()
 
 do_send_request()
 {
-  borrow req = Server::Request::get();
+  borrow req = Server::Request::Get();
 
   req["X-Leif"] = "Meh";
 }
 
 do_read_response()
 {
-  borrow resp = Server::Response::get();
+  borrow resp = Server::Response::Get();
 
   resp["X-DBJ"] = "Vrooom!";
 }
 
 do_send_response()
 {
-  borrow resp = Client::Response::get();
-  borrow conn = Client::Connection::get();
+  borrow resp = Client::Response::Get();
+  borrow conn = Client::Connection::Get();
   string msg  = "Eliminate TSCPP";
 
   resp["Server"]         = "";        // Deletes the Server header
   resp["X-AMC"]          = msg;       // New header
   resp["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
-  resp["X-UUID"]         = UUID::Unique::get();
+  resp["X-UUID"]         = UUID::Unique::Get();
   resp["X-tcpinfo"]      = conn.tcpinfo.log();
   resp["X-Cache-Status"] = resp.cache;
   resp["X-Integer"]      = 666;
@@ -126,8 +126,8 @@ do_send_response()
 do_remap()
 {
   auto   now  = Time::Local::now();
-  borrow req  = Client::Request::get();
-  borrow conn = Client::Connection::get();
+  borrow req  = Client::Request::Get();
+  borrow conn = Client::Connection::Get();
   auto   ip   = conn.ip();
 
   if (CRIPT_ALLOW.contains(ip)) {
@@ -148,13 +148,13 @@ do_remap()
   // proxy.config.http.cache.http.set(1);
   // control.cache.nostore.set(true);
 
-  CDebug("Int config cache.http = {}", proxy.config.http.cache.http.get());
-  CDebug("Float config cache.heuristic_lm_factor = {}", proxy.config.http.cache.heuristic_lm_factor.get());
+  CDebug("Int config cache.http = {}", proxy.config.http.cache.http.Get());
+  CDebug("Float config cache.heuristic_lm_factor = {}", proxy.config.http.cache.heuristic_lm_factor.Get());
   CDebug("String config http.response_server_str = {}", proxy.config.http.response_server_str.getSV(context));
   CDebug("X-Miles = {}", req["X-Miles"]);
   CDebug("random(1000) = {}", Cript::random(1000));
 
-  borrow url      = Client::URL::get();
+  borrow url      = Client::URL::Get();
   auto   old_port = url.port;
 
   CDebug("Method is {}", req.method);

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -100,8 +100,8 @@ private:
 } // namespace Cript
 
 // This may be weird, but oh well for now.
-#define get()               _get(context)
-#define set(_value)         _set(context, _value)
+#define Get()               _get(context)
+#define Set(_value)         _set(context, _value)
 #define update()            _update(context)
 #define runRemap()          _runRemap(context)
 #define activate()          _activate(context->p_instance)

--- a/src/cripts/Bundles/Caching.cc
+++ b/src/cripts/Bundles/Caching.cc
@@ -28,7 +28,7 @@ Caching::doRemap(Cript::Context *context)
 {
   // .disable(bool)
   if (_disabled) {
-    proxy.config.http.cache.http.set(0);
+    proxy.config.http.cache.http.Set(0);
     CDebug("Caching disabled");
   }
 }
@@ -36,7 +36,7 @@ Caching::doRemap(Cript::Context *context)
 void
 Caching::doReadResponse(Cript::Context *context)
 {
-  borrow resp = Server::Response::get();
+  borrow resp = Server::Response::Get();
 
   // .cache_control(str)
   if (!_cc.empty() && (resp.status > 199) && (resp.status < 400) && (resp["Cache-Control"].empty() || _force_cc)) {

--- a/src/cripts/Bundles/Common.cc
+++ b/src/cripts/Bundles/Common.cc
@@ -134,7 +134,7 @@ Common::doRemap(Cript::Context *context)
 {
   // .dscp(int)
   if (_dscp > 0) {
-    borrow conn = Client::Connection::get();
+    borrow conn = Client::Connection::Get();
 
     CDebug("Setting DSCP = {}", _dscp);
     conn.dscp = _dscp;
@@ -143,11 +143,11 @@ Common::doRemap(Cript::Context *context)
   // .via_header()
   if (_client_via.second) {
     CDebug("Setting Client Via = {}", _client_via.first);
-    proxy.config.http.insert_response_via_str.set(_client_via.first);
+    proxy.config.http.insert_response_via_str.Set(_client_via.first);
   }
   if (_origin_via.second) {
     CDebug("Setting Origin Via = {}", _origin_via.first);
-    proxy.config.http.insert_request_via_str.set(_origin_via.first);
+    proxy.config.http.insert_request_via_str.Set(_origin_via.first);
   }
 
   // .set_config()

--- a/src/cripts/Bundles/HRWBridge.cc
+++ b/src/cripts/Bundles/HRWBridge.cc
@@ -121,19 +121,19 @@ IP::value(Cript::Context *context)
 {
   switch (_type) {
   case Type::CLIENT: {
-    auto ip = Client::Connection::get().ip();
+    auto ip = Client::Connection::Get().ip();
     _value  = ip.string();
   } break;
   case Type::INBOUND: {
-    auto ip = Client::Connection::get().localIP();
+    auto ip = Client::Connection::Get().localIP();
     _value  = ip.string();
   } break;
   case Type::SERVER: {
-    auto ip = Server::Connection::get().ip();
+    auto ip = Server::Connection::Get().ip();
     _value  = ip.string();
   } break;
   case Type::OUTBOUND: {
-    auto ip = Server::Connection::get().localIP();
+    auto ip = Server::Connection::Get().localIP();
     _value  = ip.string();
   } break;
   default:
@@ -186,7 +186,7 @@ CIDR::CIDR(Cript::string_view &cidr) : super_type(cidr)
 Cript::string_view
 CIDR::value(Cript::Context *context)
 {
-  auto ip = Client::Connection::get().ip();
+  auto ip = Client::Connection::Get().ip();
 
   _value = ip.string(_ipv4_cidr, _ipv6_cidr);
 
@@ -284,37 +284,37 @@ URL::value(Cript::Context *context)
 {
   switch (_type) {
   case Type::CLIENT: {
-    borrow url = Client::URL::get();
+    borrow url = Client::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::REMAP_FROM: {
-    borrow url = Remap::From::URL::get();
+    borrow url = Remap::From::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::REMAP_TO: {
-    borrow url = Remap::To::URL::get();
+    borrow url = Remap::To::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::PRISTINE: {
-    borrow url = Pristine::URL::get();
+    borrow url = Pristine::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::CACHE: {
-    borrow url = Cache::URL::get();
+    borrow url = Cache::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::PARENT: {
-    borrow url = Parent::URL::get();
+    borrow url = Parent::URL::Get();
 
     return _getComponent(url);
   } break;

--- a/src/cripts/Bundles/Headers.cc
+++ b/src/cripts/Bundles/Headers.cc
@@ -116,7 +116,7 @@ Headers::set_headers(const Cript::string_view target, const HeaderValueList &hea
 void
 Headers::doRemap(Cript::Context *context)
 {
-  borrow req = Client::Request::get();
+  borrow req = Client::Request::Get();
 
   for (auto &header : _client_request.rm_headers) {
     req[header] = "";
@@ -130,7 +130,7 @@ Headers::doRemap(Cript::Context *context)
 void
 Headers::doSendResponse(Cript::Context *context)
 {
-  borrow resp = Client::Response::get();
+  borrow resp = Client::Response::Get();
 
   for (auto &header : _client_response.rm_headers) {
     resp[header] = "";
@@ -144,7 +144,7 @@ Headers::doSendResponse(Cript::Context *context)
 void
 Headers::doSendRequest(Cript::Context *context)
 {
-  borrow req = Server::Request::get();
+  borrow req = Server::Request::Get();
 
   for (auto &header : _server_request.rm_headers) {
     req[header] = "";
@@ -158,7 +158,7 @@ Headers::doSendRequest(Cript::Context *context)
 void
 Headers::doReadResponse(Cript::Context *context)
 {
-  borrow resp = Server::Response::get();
+  borrow resp = Server::Response::Get();
 
   for (auto &header : _server_response.rm_headers) {
     resp[header] = "";

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -98,11 +98,11 @@ LogsMetrics::propstats(const Cript::string_view &label)
 void
 LogsMetrics::doTxnClose(Cript::Context *context)
 {
-  borrow resp = Client::Response::get();
+  borrow resp = Client::Response::Get();
 
   // .tcpinfo(bool)
-  if (_tcpinfo && control.logging.get()) {
-    borrow conn = Client::Connection::get();
+  if (_tcpinfo && control.logging.Get()) {
+    borrow conn = Client::Connection::Get();
 
     resp["@TCPInfo"] += fmt::format(",TC; {}", conn.tcpinfo.log());
   }
@@ -147,8 +147,8 @@ LogsMetrics::doTxnClose(Cript::Context *context)
 void
 LogsMetrics::doSendResponse(Cript::Context *context)
 {
-  borrow resp = Client::Response::get();
-  borrow conn = Client::Connection::get();
+  borrow resp = Client::Response::Get();
+  borrow conn = Client::Connection::Get();
 
   // .sample(int)
   if (_log_sample > 0) {
@@ -156,7 +156,7 @@ LogsMetrics::doSendResponse(Cript::Context *context)
   }
 
   // .tcpinfo(bool)
-  if (_tcpinfo && control.logging.get()) {
+  if (_tcpinfo && control.logging.Get()) {
     resp["@TCPInfo"] = fmt::format("SR; {}", conn.tcpinfo.log());
   }
 }
@@ -182,7 +182,7 @@ LogsMetrics::doRemap(Cript::Context *context)
   // .logsample(int)
   if (_log_sample > 0) {
     if (Cript::random(_log_sample) != 1) {
-      control.logging.set(false);
+      control.logging.Set(false);
       sampled = false;
     }
     CDebug("Log sampling: 1 in {} -> {}", _log_sample, sampled);
@@ -190,8 +190,8 @@ LogsMetrics::doRemap(Cript::Context *context)
 
   // .tcpinfo(bool)
   if (_tcpinfo && sampled) {
-    borrow req      = Client::Request::get();
-    borrow conn     = Client::Connection::get();
+    borrow req      = Client::Request::Get();
+    borrow conn     = Client::Connection::Get();
     req["@TCPInfo"] = fmt::format("TS; {}", conn.tcpinfo.log());
   }
 }


### PR DESCRIPTION
The lowercase macros interfere with boringssl headers when used in the build.