### PR TITLE
Remove the `-Wno-unused-parameter` warning suppression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,7 @@ add_subdirectory(lib)
 # Keep this after lib because lib is made up of third party libraries, so if
 # there are warnings, we can't do anything about it.
 # Note: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON will turn warnings into errors.
-add_compile_options(-pipe -Wall -Wextra -Wno-unused-parameter)
+add_compile_options(-pipe -Wall -Wextra)
 add_compile_options(
   "$<$<COMPILE_LANGUAGE:CXX>:-Wno-noexcept-type;-Wsuggest-override;-Wno-vla-extension;-fno-strict-aliasing>"
 )


### PR DESCRIPTION
This removes the `-Wno-unused-parameter` warning suppression from the main `CMakeLists.txt` of the project.

I built the project with different presets: `ci-debian`, `ci-ubuntu`, `ci-rocky`, `ci-clang-analyzer` with `GCC 13.2`.
Also built it with `Clang 17`. Built it in both debug and release modes.

Seems like the warning is no longer needed. Let's see if I'm missing something.

This pull request is hopefully the final part of the effort for [removing](https://github.com/apache/trafficserver/issues/11377) the `-Wno-unused-parameter` warning suppression.