### PR TITLE
Fix unused parameters in conditionally built experimental plugins

### DIFF
--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -481,7 +481,7 @@ Acl::loaddb(const YAML::Node &dbNode)
 }
 
 bool
-Acl::eval(TSRemapRequestInfo *rri, TSHttpTxn txnp)
+Acl::eval(TSRemapRequestInfo * /* rri ATS_UNUSED */, TSHttpTxn txnp)
 {
   bool ret = default_allow;
   int  mmdb_error;

--- a/plugins/experimental/otel_tracer/otel_tracer.cc
+++ b/plugins/experimental/otel_tracer/otel_tracer.cc
@@ -113,7 +113,7 @@ set_request_header(TSMBuffer buf, TSMLoc hdr_loc, const char *key, int key_len, 
 }
 
 static void
-read_request(TSHttpTxn txnp, TSCont contp)
+read_request(TSHttpTxn txnp, TSCont /* contp */)
 {
   TSMBuffer buf;
   TSMLoc    hdr_loc;

--- a/plugins/experimental/otel_tracer/otel_tracer.cc
+++ b/plugins/experimental/otel_tracer/otel_tracer.cc
@@ -113,7 +113,7 @@ set_request_header(TSMBuffer buf, TSMLoc hdr_loc, const char *key, int key_len, 
 }
 
 static void
-read_request(TSHttpTxn txnp, TSCont /* contp */)
+read_request(TSHttpTxn txnp, TSCont /* contp ATS_UNUSED */)
 {
   TSMBuffer buf;
   TSMLoc    hdr_loc;

--- a/plugins/experimental/stek_share/state_machine.h
+++ b/plugins/experimental/stek_share/state_machine.h
@@ -38,7 +38,7 @@ public:
   ~STEKShareSM() {}
 
   nuraft::ptr<nuraft::buffer>
-  pre_commit(const uint64_t log_idx, nuraft::buffer &data) override
+  pre_commit(const uint64_t /* log_idx ATS_UNUSED */, nuraft::buffer & /* data ATS_UNUSED */) override
   {
     return nullptr;
   }
@@ -89,21 +89,21 @@ public:
   }
 
   void
-  commit_config(const uint64_t log_idx, nuraft::ptr<nuraft::cluster_config> &new_conf) override
+  commit_config(const uint64_t log_idx, nuraft::ptr<nuraft::cluster_config> & /* new_conf ATS_UNUSED */) override
   {
     // Nothing to do with configuration change. Just update committed index.
     last_committed_idx_ = log_idx;
   }
 
   void
-  rollback(const uint64_t log_idx, nuraft::buffer &data) override
+  rollback(const uint64_t /* log_idx ATS_UNUSED */, nuraft::buffer & /* data ATS_UNUSED */) override
   {
     // Nothing to do here since we don't have pre-commit.
   }
 
   int
-  read_logical_snp_obj(nuraft::snapshot &s, void *&user_snp_ctx, uint64_t obj_id, nuraft::ptr<nuraft::buffer> &data_out,
-                       bool &is_last_obj) override
+  read_logical_snp_obj(nuraft::snapshot            &s, void            *&/* user_snp_ctx ATS_UNUSED */, uint64_t /* obj_id ATS_UNUSED */,
+                       nuraft::ptr<nuraft::buffer> &data_out, bool &is_last_obj) override
   {
     // Dbg(dbg_ctl, "read snapshot %lu term %lu object ID %lu", s.get_last_log_idx(), s.get_last_log_term(), obj_id);
 
@@ -124,7 +124,8 @@ public:
   }
 
   void
-  save_logical_snp_obj(nuraft::snapshot &s, uint64_t &obj_id, nuraft::buffer &data, bool is_first_obj, bool is_last_obj) override
+  save_logical_snp_obj(nuraft::snapshot &s, uint64_t &obj_id, nuraft::buffer &data, bool /* is_first_obj ATS_UNUSED */,
+                       bool /* is_last_obj ATS_UNUSED */) override
   {
     // Dbg(dbg_ctl, "save snapshot %lu term %lu object ID %lu", s.get_last_log_idx(), s.get_last_log_term(), obj_id);
 
@@ -150,7 +151,7 @@ public:
   }
 
   bool
-  apply_snapshot(nuraft::snapshot &s) override
+  apply_snapshot(nuraft::snapshot & /* s ATS_UNUSED */) override
   {
     // Dbg(dbg_ctl, "apply snapshot %lu term %lu", s.get_last_log_idx(), s.get_last_log_term());
 
@@ -168,7 +169,7 @@ public:
   }
 
   void
-  free_user_snp_ctx(void *&user_snp_ctx) override
+  free_user_snp_ctx(void *& /* user_snp_ctx ATS_UNUSED */) override
   {
   }
 

--- a/plugins/experimental/stek_share/state_manager.h
+++ b/plugins/experimental/stek_share/state_manager.h
@@ -82,7 +82,7 @@ public:
   }
 
   void
-  system_exit(const int exit_code) override
+  system_exit(const int /* exit_code ATS_UNUSED */) override
   {
   }
 

--- a/plugins/experimental/stek_share/stek_share.cc
+++ b/plugins/experimental/stek_share/stek_share.cc
@@ -89,7 +89,7 @@ restore_config(std::shared_ptr<PluginConfig> config)
 }
 
 static int
-shutdown_handler(TSCont contp, TSEvent event, void *edata)
+shutdown_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   if (event == TS_EVENT_LIFECYCLE_SHUTDOWN) {
     stek_share_server.raft_launcher.shutdown();
@@ -100,7 +100,7 @@ shutdown_handler(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-message_handler(TSCont contp, TSEvent event, void *edata)
+message_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   if (event == TS_EVENT_LIFECYCLE_MSG) {
     TSPluginMsg *msg = static_cast<TSPluginMsg *>(edata);
@@ -354,7 +354,7 @@ load_config_from_file()
 }
 
 void
-handle_result(raft_result &result, nuraft::ptr<std::exception> &err)
+handle_result(raft_result &result, nuraft::ptr<std::exception> & /* err ATS_UNUSED */)
 {
   if (result.get_result_code() != nuraft::cmd_result_code::OK) {
     // Something went wrong.
@@ -416,7 +416,7 @@ print_status()
 }
 
 static void *
-stek_updater(void *arg)
+stek_updater(void * /* arg ATS_UNUSED */)
 {
   plugin_threads.store(::pthread_self());
   ::pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr);

--- a/plugins/experimental/uri_signing/match.cc
+++ b/plugins/experimental/uri_signing/match.cc
@@ -22,7 +22,7 @@
 #include <cstring>
 
 bool
-match_hash(const char *needle, const char *haystack)
+match_hash(const char * /* needle ATS_UNUSED */, const char * /* haystack ATS_UNUSED */)
 {
   return false;
 }

--- a/plugins/experimental/uri_signing/parse.cc
+++ b/plugins/experimental/uri_signing/parse.cc
@@ -149,7 +149,7 @@ get_jws_from_cookie(const char **cookie, size_t *cookie_ct, const char *paramNam
 }
 
 struct jwt *
-validate_jws(cjose_jws_t *jws, struct config *cfg, const char *uri, size_t uri_ct)
+validate_jws(cjose_jws_t *jws, struct config *cfg, const char *uri, size_t /* uri_ct ATS_UNUSED */)
 {
   struct timer t;
   int64_t      last_mark = 0;

--- a/plugins/experimental/uri_signing/uri_signing.cc
+++ b/plugins/experimental/uri_signing/uri_signing.cc
@@ -90,7 +90,7 @@ TSRemapDeleteInstance(void *ih)
 }
 
 int
-add_cookie(TSCont cont, TSEvent event, void *edata)
+add_cookie(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   struct timer t;
   start_timer(&t);

--- a/plugins/experimental/wasm/ats_context.cc
+++ b/plugins/experimental/wasm/ats_context.cc
@@ -535,8 +535,8 @@ Context::getBuffer(WasmBufferType type)
 }
 
 WasmResult
-Context::httpCall(std::string_view target, const Pairs &request_headers, std::string_view request_body,
-                  const Pairs &request_trailers, int timeout_millisconds, uint32_t *token_ptr)
+Context::httpCall(std::string_view /* target ATS_UNUSED */, const Pairs &request_headers, std::string_view             request_body,
+                  const Pairs & /* request_trailers ATS_UNUSED */, int /* timeout_millisconds ATS_UNUSED */, uint32_t *token_ptr)
 {
   Wasm    *wasm         = this->wasm();
   Context *root_context = this->root_context();

--- a/plugins/experimental/wasm/ats_wasm.cc
+++ b/plugins/experimental/wasm/ats_wasm.cc
@@ -46,8 +46,9 @@ ATSWasmVmIntegration::trace(std::string_view message)
 }
 
 bool
-ATSWasmVmIntegration::getNullVmFunction(std::string_view function_name, bool returns_word, int number_of_arguments,
-                                        proxy_wasm::NullPlugin *plugin, void *ptr_to_function_return)
+ATSWasmVmIntegration::getNullVmFunction(std::string_view /* function_name ATS_UNUSED */, bool /* returns_word ATS_UNUSED */,
+                                        int /* number_of_arguments ATS_UNUSED */, proxy_wasm::NullPlugin * /* plugin ATS_UNUSED */,
+                                        void * /* ptr_to_function_return ATS_UNUSED */)
 {
   return false;
 }

--- a/plugins/experimental/wasm/lib/src/signature_util.cc
+++ b/plugins/experimental/wasm/lib/src/signature_util.cc
@@ -55,7 +55,7 @@ template <size_t N> constexpr std::array<uint8_t, N> hex2pubkey(const char (&hex
 
 namespace proxy_wasm {
 
-bool SignatureUtil::verifySignature(std::string_view bytecode, std::string &message) {
+bool SignatureUtil::verifySignature([[maybe_unused]] std::string_view bytecode, [[maybe_unused]] std::string &message) {
 
 #ifdef PROXY_WASM_VERIFY_WITH_ED25519_PUBKEY
 

--- a/plugins/experimental/wasm/lib/src/signature_util.cc
+++ b/plugins/experimental/wasm/lib/src/signature_util.cc
@@ -55,7 +55,7 @@ template <size_t N> constexpr std::array<uint8_t, N> hex2pubkey(const char (&hex
 
 namespace proxy_wasm {
 
-bool SignatureUtil::verifySignature([[maybe_unused]] std::string_view bytecode, [[maybe_unused]] std::string &message) {
+bool SignatureUtil::verifySignature(std::string_view bytecode, std::string &message) {
 
 #ifdef PROXY_WASM_VERIFY_WITH_ED25519_PUBKEY
 

--- a/plugins/experimental/wasm/wasm_main.cc
+++ b/plugins/experimental/wasm/wasm_main.cc
@@ -256,7 +256,7 @@ transform_handler(TSCont contp, ats_wasm::TransformInfo *ti)
 }
 
 static int
-transform_entry(TSCont contp, TSEvent ev, void *edata)
+transform_entry(TSCont contp, TSEvent ev, void * /* edata ATS_UNUSED */)
 {
   int                      event;
   TSVIO                    input_vio;


### PR DESCRIPTION
Fix the warnings for unused parameters when all of the conditionally compiled plugins are enabled.

Clang-format did a bit weird formatting in two places.