### PR TITLE
Pascal case

### DIFF
--- a/doc/developer-guide/cripts/cripts-bundles.en.rst
+++ b/doc/developer-guide/cripts/cripts-bundles.en.rst
@@ -56,16 +56,16 @@ This example shows how a Cript would enable both of these bundles with all featu
 
    do_create_instance()
    {
-     Bundle::Common::activate().dscp(10)
+     Bundle::Common::Activate().dscp(10)
                                .via_header("client", "basic")
                                .set_config({{"proxy.config.srv_enabled", 0},
                                             {"proxy.config.http.response_server_str", "ATS"});
 
-     Bundle::LogsMetrics::activate().logsample(100)
+     Bundle::LogsMetrics::Activate().logsample(100)
                                     .tcpinfo(true)
                                     .propstats("example.com");
 
-     Bundle::Caching::activate().cache_control("max-age=259200")
+     Bundle::Caching::Activate().cache_control("max-age=259200")
                                 .disable(true)
 
    }
@@ -123,7 +123,7 @@ operators from the ``header_rewrite`` plugin. For example:
 
    do_create_instance()
    {
-     Bundle::Headers::activate().rm_headers({"X-Header1", "X-Header2"})
+     Bundle::Headers::Activate().rm_headers({"X-Header1", "X-Header2"})
                                 .add_headers({{"X-Header3", "value3"},
                                               {"X-Header4", "%{FROM-URL:PATH}"},
                                               {"X-Header5", "%{ID:UNIQUE}"} });

--- a/doc/developer-guide/cripts/cripts-bundles.en.rst
+++ b/doc/developer-guide/cripts/cripts-bundles.en.rst
@@ -34,6 +34,11 @@ turning these common patterns into easily reusable components. A bundle
 must be activated in the ``do_create_instance()`` hook of a Cript. This
 does *not* exclude doing additional hooks in the Cript itself.
 
+.. note::
+   The member variables of a bundle are always lower case, and not
+   Pascal case like methods. This is because even though they technically
+   are functions, they act more like variables with a value.
+
 The following bundles are available in the core today:
 
 ============================   ====================================================================

--- a/doc/developer-guide/cripts/cripts-connections.en.rst
+++ b/doc/developer-guide/cripts/cripts-connections.en.rst
@@ -34,8 +34,8 @@ implies that access to these objects must be ``borrowed``.
    do_remap()
    {
      static Matcher::Range::IP ALLOW_LIST({"192.168.201.0/24", "10.0.0.0/8"});
-     borrow conn = Client::Connection::get();
-     auto client_ip = conn.ip();
+     borrow conn = Client::Connection::Get();
+     auto client_ip = conn.IP();
 
      if (!ALLOW_LIST.contains(client_ip)) {
        // Deny the request (see examples for details)
@@ -52,7 +52,7 @@ Connection Object           Description
 =======================   =========================================================================
 
 As usual, the ``Server::Connection`` object is only available assuming that the request
-is a forward proxy request, and you borrow it with the ``get()`` method. On cache misses,
+is a forward proxy request, and you borrow it with the ``Get()`` method. On cache misses,
 there is no such connection.
 
 .. _cripts-connections-methods:
@@ -66,14 +66,14 @@ connections. These are:
 =======================   =========================================================================
 Method                    Description
 =======================   =========================================================================
-``count()``               The number of transactions processed on the connection so far.
-``ip()``                  The IP address of the connection.
-``localIP()``             The server (ATS) IP address of the connection.
-``isInternal()``          Returns ``true`` or ``false`` if the connection is internal to ATS.
-``socket()``              Returns the raw socket structure for the connection (use with care).
+``Count()``               The number of transactions processed on the connection so far.
+``IP()``                  The IP address of the connection.
+``LocalIP()``             The server (ATS) IP address of the connection.
+``IsInternal()``          Returns ``true`` or ``false`` if the connection is internal to ATS.
+``Socket()``              Returns the raw socket structure for the connection (use with care).
 =======================   =========================================================================
 
-The ``ip()`` and ``localIP()`` methods return the IP address as an object. In addition to the
+The ``IP()`` and ``LocalIP()`` methods return the IP address as an object. In addition to the
 automatic string conversion, it also has a special semantic string conversion which takes
 IPv4 and IPv6 CIDR sizes. For example:
 
@@ -81,8 +81,8 @@ IPv4 and IPv6 CIDR sizes. For example:
 
    do_remap()
    {
-     borrow conn = Client::Connection::get();
-     auto ip = conn.ip();
+     borrow conn = Client::Connection::Get();
+     auto ip = conn.IP();
 
      CDebug("Client IP CIDR: {}", ip.string(24, 64));
 
@@ -104,7 +104,7 @@ Variable                   Description
 ``mark``                  Manage the Mark value for the connection socket.
 =======================   =========================================================================
 
-For other advanced features, a Cript has access to the socket file descriptor, via the ``fd()``
+For other advanced features, a Cript has access to the socket file descriptor, via the ``FD()``
 method of the connection object.
 
 .. note::
@@ -116,7 +116,7 @@ Lets show an example of how one could use these variables:
 
    do_remap()
    {
-     borrow conn = Client::Connection::get();
+     borrow conn = Client::Connection::Get();
 
      conn.congestion = "bbrv2";
      conn.pacing = 100;
@@ -143,7 +143,7 @@ Field                     Description
 
 In addition to these convenience fields, the ``tcpinfo`` object provides a method to access the raw
 TCP information as well in the ``info`` field. There's also a predefined log format, which can be
-accessed via the ``log()`` method. See the ``tcpinfo`` plugin in ATS for details.
+accessed via the ``Log()`` method. See the ``tcpinfo`` plugin in ATS for details.
 
 .. _cripts-connections-geo-ip:
 

--- a/doc/developer-guide/cripts/cripts-crypto.en.rst
+++ b/doc/developer-guide/cripts/cripts-crypto.en.rst
@@ -46,14 +46,14 @@ Object                              Description
 ``Crypto::HMAC::SHA256``            HMAC-SHA256 hashing.
 =================================   ===============================================================
 
-These objects all provide a ``encode()`` and ``decode()`` method, to hash and unhash strings.
+These objects all provide a ``Encode()`` and ``Decode()`` method, to hash and unhash strings.
 Examples:
 
 .. code-block:: cpp
 
    do_remap()
    {
-     CDebug("SHA256 = {}", Crypto::SHA256::encode("Hello World"));
+     CDebug("SHA256 = {}", Crypto::SHA256::Encode("Hello World"));
    }
 
 .. _cripts-misc-crypto-encryption:
@@ -62,8 +62,8 @@ Encryption
 ==========
 
 Currently only one encryption object is provides, for AES256. This object provides
-``encrypt()`` and ``decrypt()`` methods. A ``hex()`` method is also provided to retrieve
-the encrypted data as a hex string. For encrypting data in chunks, a ``finalize()`` method
+``Encrypt()`` and ``Decrypt()`` methods. A ``Hex()`` method is also provided to retrieve
+the encrypted data as a hex string. For encrypting data in chunks, a ``Finalize()`` method
 is provided to retrieve the final encrypted data.
 
 =================================   ===============================================================
@@ -87,4 +87,4 @@ Object                              Description
 ``Crypto::Escape``                  Methods for URL escaping.
 =================================   ===============================================================
 
-These objects all provide a ``encode()`` and ``decode()`` method, to encode and decode strings.
+These objects all provide a ``Encode()`` and ``Decode()`` method, to encode and decode strings.

--- a/doc/developer-guide/cripts/cripts-headers.en.rst
+++ b/doc/developer-guide/cripts/cripts-headers.en.rst
@@ -30,7 +30,7 @@ system, and must always be borrowed. The pattern for this is as follows:
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::get();
+  borrow req = Client::Request::Get();
 
   auto foo = req["X-Foo"];
 
@@ -55,18 +55,18 @@ Assigning the empty value (``""``) to a header will remove it from the header li
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::get();
+  borrow req = Client::Request::Get();
 
   req["X-Foo"] = "bar"; // Set the header
   req["X-Fie"] = "";    // Remove the header
 
-A header can also be removed by using the ``erase`` method, which is a little more explicit:
+A header can also be removed by using the ``Erase`` method, which is a little more explicit:
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::get();
+  borrow req = Client::Request::Get();
 
-  req.erase("X-Foo");
+  req.Erase("X-Foo");
 
 .. note:: There is also a Cripts Bundle for headers, see :ref:`Bundles <cripts-bundles-headers>`.
 
@@ -80,7 +80,7 @@ a pattern such as the following example:
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::get();
+  borrow req = Client::Request::Get();
 
   for (auto header : req) {
     CDebug("Header: {}: {}", header, req[header]); // This will print all headers and their values
@@ -117,7 +117,7 @@ These symbols can be used to compare against the method in the request object. F
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::get();
+  borrow req = Client::Request::Get();
 
   if (req.method == Cript::Method::GET) {
       // Do something
@@ -157,7 +157,7 @@ fresh or stale. Example usage of the cache status:
 .. code-block:: cpp
 
   do_read_response() {
-    borrow resp = Server::Response::get();
+    borrow resp = Server::Response::Get();
 
     if (resp.cache == "miss") {
       // Do something

--- a/doc/developer-guide/cripts/cripts-matcher.en.rst
+++ b/doc/developer-guide/cripts/cripts-matcher.en.rst
@@ -49,9 +49,9 @@ Here's an example using the regular expression matcher:
    {
      static Matcher::PCRE pcre({"^/([^/]+)/(.*)$", "^(.*)$"}); // Nonsensical ...
 
-     borrow url = Client::URL::get();
+     borrow url = Client::URL::Get();
 
-     if (pcre.match(url.path)) {
+     if (pcre.Match(url.path)) {
        // Do something with the match
      }
    }
@@ -72,9 +72,9 @@ All matchers have the following functions:
 ============================   ====================================================================
 Function                       Description
 ============================   ====================================================================
-``match()``                    Match the given string against the matcher.
-``contains()``                 Another name for ``match()``
-``add()``                      Add another element to the matcher (can not be used with ``static``)
+``Match()``                    Match the given string against the matcher.
+``Contains()``                 Another name for ``Match()``
+``Add()``                      Add another element to the matcher (can not be used with ``static``)
 ============================   ====================================================================
 
 .. _cripts-matchers-pcre:
@@ -89,9 +89,9 @@ to deal with the matched results and the capture groups:
 ============================   ====================================================================
 Function                       Description
 ============================   ====================================================================
-``matched()``                  A boolean indicating if a regex was matched.
-``count()``                    Returns the number of regex capture groups that are matched.
-``matchIX()``                  Returns the index of the matched regex capture group.
+``Matched()``                  A boolean indicating if a regex was matched.
+``Count()``                    Returns the number of regex capture groups that are matched.
+``MatchIX()``                  Returns the index of the matched regex capture group.
 [] Index                       Retrieves the matched string for the given capture group index.
 ============================   ====================================================================
 
@@ -103,11 +103,11 @@ Lets show an example:
    {
      static Matcher::PCRE allow({"^([a-c][^/]*)/?(.*)", "^([g-h][^/]*)/?(.*)"});
 
-     borrow url = Client::URL::get();
+     borrow url = Client::URL::Get();
 
-     auto res = allow.match(url.path);
+     auto res = allow.Match(url.path);
 
-     if (res.matched()) {
+     if (res.Matched()) {
        CDebug("Matched: {}", res[1]);
        CDebug("Matched: {}", res[2]);
        // Now do something with these URLs matching these paths

--- a/doc/developer-guide/cripts/cripts-misc.en.rst
+++ b/doc/developer-guide/cripts/cripts-misc.en.rst
@@ -45,9 +45,9 @@ making this easy.
 =========================   =======================================================================
 Function                    Description
 =========================   =======================================================================
-``Error::Status::set()``    Sets the response to the status code, and force the request to error.
-``Error::Status::get()``    Get the current response status for the request.
-``Error::Reason::set()``    Sets an explicit reason message with the status code. **TBD**
+``Error::Status::Set()``    Sets the response to the status code, and force the request to error.
+``Error::Status::Get()``    Get the current response status for the request.
+``Error::Reason::Set()``    Sets an explicit reason message with the status code. **TBD**
 =========================   =======================================================================
 
 Example:
@@ -59,11 +59,11 @@ Example:
      borrow req  = Client::Request::get();
 
      if (req["X-Header"] == "yes") {
-       Error::Status::set(403);
+       Error::Status::Set(403);
      }
      // Do more stuff here
 
-     if (Error::status::get() != 403) {
+     if (Error::status::Get() != 403) {
        // Do even more stuff here if we're not in error state
      }
    }
@@ -77,9 +77,9 @@ the following functions are available:
 =========================   =======================================================================
 Function                    Description
 =========================   =======================================================================
-``disableCallback()``       Disables a future callback in this Cript, for this transaction.
-``aborted()``               Has the transaction been aborted.
-``lookupStatus()``          Returns the cache lookup status for the transaction.
+``DisableCallback()``       Disables a future callback in this Cript, for this transaction.
+``Aborted()``               Has the transaction been aborted.
+``LookupStatus()``          Returns the cache lookup status for the transaction.
 =========================   =======================================================================
 
 When disabling a callback, use the following names:
@@ -116,7 +116,7 @@ Example usage to turn off a particular hook conditionally:
      static borrow req = Client::Request::get();
 
      if (req["X-Header"] == "yes") {
-       transaction.disableCallback(Cript::Callback::DO_READ_RESPONSE);
+       transaction.DisableCallback(Cript::Callback::DO_READ_RESPONSE);
      }
    }
 
@@ -129,24 +129,24 @@ Time
 
 Cripts has encapsulated some common time-related functions in the core.  At the
 moment only the localtime is available, via the ``Time::Local`` object and its
-``now()`` method. The ``now()`` method returns the current time as an object
+``Now()`` method. The ``Now()`` method returns the current time as an object
 with the following functions:
 
 =====================   ===========================================================================
 Function                Description
 =====================   ===========================================================================
-``epoch()``             Returns the number of seconds since the Unix epoch (00:00:00 UTC, January 1, 1970).
-``year()``              Returns the year.
-``month()``             Returns the month (1-12).
-``day()``               Returns the day of the month (1-31).
-``hour()``              Returns the hour (0-23).
-``minute()``            Returns the minute (0-59).
-``second()``            Returns the second (0-59).
-``weekday()``           Returns the day of the week (0-6, Sunday is 0).
-``yearday()``           Returns the day of the year (0-365).
+``Epoch()``             Returns the number of seconds since the Unix epoch (00:00:00 UTC, January 1, 1970).
+``Year()``              Returns the year.
+``Month()``             Returns the month (1-12).
+``Day()``               Returns the day of the month (1-31).
+``Hour()``              Returns the hour (0-23).
+``Minute()``            Returns the minute (0-59).
+``Second()``            Returns the second (0-59).
+``Weekday()``           Returns the day of the week (0-6, Sunday is 0).
+``Yearday()``           Returns the day of the year (0-365).
 =====================   ===========================================================================
 
-The time as returned by ``now()`` can also be used directly in comparisons with previous or future
+The time as returned by ``Now()`` can also be used directly in comparisons with previous or future
 times.
 
 .. _cripts-misc-plugins:
@@ -169,21 +169,21 @@ plugin based on the client request headers:
 
    do_create_instance()
    {
-     instance.addPlugin("my_ratelimit", "rate_limit.so", {"--limit=300", "--error=429"});
+     instance.AddPlugin("my_ratelimit", "rate_limit.so", {"--limit=300", "--error=429"});
    }
 
    do_remap()
    {
      static borrow plugin = instance.plugins["my_ratelimit"];
-     borrow        req    = Client::Request::get();
+     borrow        req    = Client::Request::Get();
 
      if (req["X-Header"] == "yes") {
-       plugin.runRemap();
+       plugin.RunRemap();
      }
    }
 
 .. note::
-   The name of the plugin instance, as specified to ``addPlugin()``, must be
+   The name of the plugin instance, as specified to ``AddPlugin()``, must be
    unique across all Cripts.
 
 .. _cripts-misc-files:
@@ -205,7 +205,7 @@ by the ``File::Line::Reader`` object. Some examples:
    {
      static const File::Path p1("/tmp/foo");
      static const File::Path p2("/tmp/secret.txt");
-     if (File::Status(p1).type() == File::Type::regular) {
+     if (File::Status(p1).Type() == File::Type::regular) {
        resp["X-Foo-Exists"] = "yes";
      } else {
        resp["X-Foo-Exists"] = "no";
@@ -230,13 +230,13 @@ Object                      Description
 ``UUID::Request``           Returns a unique id for this request.
 =========================   =======================================================================
 
-Using the ``UUID`` object is simple, via the ``::get()`` method. Here's an example:
+Using the ``UUID`` object is simple, via the ``Get()`` method. Here's an example:
 
 .. code-block:: cpp
 
    do_remap()
    {
-     static borrow req = Client::Request::get();
+     static borrow req = Client::Request::Get();
 
-     resp["X-UUID"] = UUID::Unique::get();
+     resp["X-UUID"] = UUID::Unique::Get();
    }

--- a/doc/developer-guide/cripts/cripts-misc.en.rst
+++ b/doc/developer-guide/cripts/cripts-misc.en.rst
@@ -240,3 +240,37 @@ Using the ``UUID`` object is simple, via the ``Get()`` method. Here's an example
 
      resp["X-UUID"] = UUID::Unique::Get();
    }
+
+.. _cripts-metrics
+
+Metrics
+=======
+
+Cripts metrics are built directly on top of the atomic core ATS metrics. As such, they not only
+work the same as the core metrics, but they are also as efficient. There are two types of metrics:
+
+=========================   =======================================================================
+Metric                      Description
+=========================   =======================================================================
+``Metric::Counter``         A simple counter, which can only be incremented.
+``Metric::Gauge``           A gauge, which can be incremented and decremented, and set to a value.
+=========================   =======================================================================
+
+Example:
+
+.. code-block:: cpp
+
+   do_create_instance()
+   {
+     instance.metrics[0] = Metrics::Counter::Create("cript.example1.instance_calls");
+   }
+
+   do_remap()
+   {
+     static auto plugin_metric = Metrics::Counter("cript.example1.plugin_calls");
+
+     plugin_metric.Increment();
+     instance.metrics[0]->Increment();
+   }
+
+A ``Metric::Gauge`` can also be set via the ``Setter()`` method.

--- a/doc/developer-guide/cripts/cripts-misc.en.rst
+++ b/doc/developer-guide/cripts/cripts-misc.en.rst
@@ -241,7 +241,7 @@ Using the ``UUID`` object is simple, via the ``Get()`` method. Here's an example
      resp["X-UUID"] = UUID::Unique::Get();
    }
 
-.. _cripts-metrics
+.. _cripts-metrics:
 
 Metrics
 =======

--- a/doc/developer-guide/cripts/cripts-overview.en.rst
+++ b/doc/developer-guide/cripts/cripts-overview.en.rst
@@ -162,7 +162,8 @@ convention, ``PascalCase``. Instance variables and members are always all lowerc
 .. note::
 
    This naming convention does not apply to ``string`` and ``string_view`` variables, which
-   follow the standard C++ conventions for method names.
+   follow the standard C++ conventions for the standard method names. Cripts specific Additions
+   do follow the ``PascalCase`` convention though.
 
 Hooks
 =====

--- a/doc/developer-guide/cripts/cripts-overview.en.rst
+++ b/doc/developer-guide/cripts/cripts-overview.en.rst
@@ -144,6 +144,19 @@ cache for the shared object files. This is useful for large setups with many Cri
 In fact, moving the compilation details to be separate from the ATS process is a good
 idea with a lot of flexibility for the user.
 
+.. _cripts-overview-names:
+
+Names
+=====
+
+All classes and class and instance methods in Cripts are following the same naming
+convention, ``PascalCase``. Instance variables and members are always all lowercase. For example:
+
+.. code-block:: cpp
+
+   auto url = Client::URL::Get();
+   url.query.Keep({"foo", "bar"});
+
 .. _cripts-overview-hooks:
 
 Hooks

--- a/doc/developer-guide/cripts/cripts-overview.en.rst
+++ b/doc/developer-guide/cripts/cripts-overview.en.rst
@@ -159,6 +159,11 @@ convention, ``PascalCase``. Instance variables and members are always all lowerc
 
 .. _cripts-overview-hooks:
 
+.. note::
+
+   This naming convention does not apply to ``string`` and ``string_view`` variables, which
+   follow the standard C++ conventions for method names.
+
 Hooks
 =====
 

--- a/doc/developer-guide/cripts/cripts-urls.en.rst
+++ b/doc/developer-guide/cripts/cripts-urls.en.rst
@@ -30,7 +30,7 @@ must always be borrowed. The pattern for this is as follows:
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::get();
+  borrow url = Client::URL::Get();
 
   auto path = url.path;
 
@@ -80,7 +80,7 @@ you can use the following:
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::get();
+  borrow url = Client::URL::Get();
 
   auto path = url.path; // This is the entire path
   auto first = url.path[0]; // This is the first part of the path
@@ -90,25 +90,25 @@ indexed in a list. To get the value of a specific query parameter, you can use t
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::get();
+  borrow url = Client::URL::Get();
 
   auto value = url.query["key"]; // This is the value of the key
 
-You can retrieve the size of the path or query using the ``size()`` method, and you can clear
-the path or query using the ``erase()`` method. To summarize the ``path`` and ``query`` components
+You can retrieve the size of the ``path`` or ``query`` using the ``Size()`` method, and you can clear
+the path or query using the ``Erase()`` method. To summarize the ``path`` and ``query`` components
 have the following methods available to them:
 
 =================   ===============================================================================
 Method / access     Description
 =================   ===============================================================================
 Index []            Access a specific part of the path or query.
-``size()``          Get the number of parts of the path or query.
-``erase()``         Clears the component. Also available as ``clear()``.
-``sort()``          Sorts the query parameters. **Note**: Only for query parameters.
-``flush()``         Flushes any changes. This is rarely used, since Cripts will manage flushing.
+``Size()``          Get the number of parts of the path or query.
+``Erase()``         Clears the component. Also available as ``Clear()``.
+``Sort()``          Sorts the query parameters. **Note**: Only for query parameters.
+``Flush()``         Flushes any changes. This is rarely used, since Cripts will manage flushing.
 =================   ===============================================================================
 
-In addition, the query parameters ``erase()`` method can take a single key, or a list of keys to
+In addition, the query parameters ``Erase()`` method can take a single key, or a list of keys to
 remove specific parameters. It also allows specify a list of keys to keep, and will remove all other
 keys. This is useful for filtering out unwanted query parameters.
 

--- a/doc/developer-guide/cripts/cripts-urls.en.rst
+++ b/doc/developer-guide/cripts/cripts-urls.en.rst
@@ -52,6 +52,14 @@ hooks and have different meanings. The ``Client::URL`` is the most commonly used
 which you will also modify in the traditional remapping use case; for example changing
 the ``path`` or ``host`` before further processing.
 
+The full URL string can be copied via the ``String()`` method, for example:
+
+.. code-block:: cpp
+
+  borrow url = Client::URL::Get();
+
+  auto full = url.String();
+
 .. _cripts-urls-components:
 
 Components

--- a/doc/developer-guide/cripts/cripts-variables.en.rst
+++ b/doc/developer-guide/cripts/cripts-variables.en.rst
@@ -59,7 +59,7 @@ get the length of a string, you can use the ``size()`` method:
 
 .. code-block:: cpp
 
-     borrow req  = Client::Request::get();
+     borrow req  = Client::Request::Get();
 
      if (req["Host"].size() > 3) {
          // Do something
@@ -113,10 +113,10 @@ Best way to understand this is to look at an example:
 
 .. code-block:: cpp
 
-   auto cache_on = proxy.config.http.cache.http.get();
+   auto cache_on = proxy.config.http.cache.http.Get();
 
    if (cache_on > 0) {
-     proxy.config.http.ignore_server_no_cache.set(1);
+     proxy.config.http.ignore_server_no_cache.Set(1);
    }
 
 This is a pretty artificial example, but shows the name space of these configurations, and how they
@@ -130,7 +130,7 @@ control planes with Cripts. This is done using the ``Records`` object, for examp
    do_remap() {
      auto http_cache = Cript::Records("proxy.config.http.cache.http");
 
-     if (AsInteger(http_cache.get()) > 0) {
+     if (AsInteger(http_cache.Get()) > 0) {
        CDebug("HTTP Cache is on");
      }
    }
@@ -157,14 +157,14 @@ Variable                       Description
 ============================   ====================================================================
 
 All of these are controlled via a boolean value, and can be set to either ``true`` or ``false``,
-using the same ``.get()`` and ``.set()`` as for configuration variables. As an example, lets randomly
+using the same ``Get()`` and ``Set()`` as for configuration variables. As an example, lets randomly
 turn off logging for some percentage of requests:
 
 .. code-block:: cpp
 
    do_remap() {
      if (Cript::random(1000) > 99) {
-       control.logging.set(false); // 10% log sampling
+       control.logging.Set(false); // 10% log sampling
      }
    }
 

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -125,7 +125,7 @@ do_send_response()
 
 do_remap()
 {
-  auto   now  = Time::Local::now();
+  auto   now  = Time::Local::Now();
   borrow req  = Client::Request::Get();
   borrow conn = Client::Connection::Get();
   auto   ip   = conn.IP();
@@ -134,12 +134,12 @@ do_remap()
     CDebug("Client IP allowed: {}", ip.string(24, 64));
   }
 
-  CDebug("Epoch time is {} (or via .epoch(), {}", now, now.epoch());
-  CDebug("Year is {}", now.year());
-  CDebug("Month is {}", now.month());
-  CDebug("Day is {}", now.day());
-  CDebug("Hour is {}", now.hour());
-  CDebug("Day number is {}", now.yearday());
+  CDebug("Epoch time is {} (or via .epoch(), {}", now, now.Epoch());
+  CDebug("Year is {}", now.Year());
+  CDebug("Month is {}", now.Month());
+  CDebug("Day is {}", now.Day());
+  CDebug("Hour is {}", now.Hour());
+  CDebug("Day number is {}", now.YearDay());
 
   CDebug("from_url = {}", instance.from_url.c_str());
   CDebug("to_url = {}", instance.to_url.c_str());

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -59,7 +59,7 @@ do_cache_lookup()
 {
   borrow url2 = Cache::URL::Get();
 
-  CDebug("Cache URL: {}", url2.Getter());
+  CDebug("Cache URL: {}", url2.String());
   CDebug("Cache Host: {}", url2.host);
 }
 

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -43,8 +43,8 @@ do_create_instance()
   instance.metrics[7] = Metrics::Counter::create("cript.example1.c7");
   instance.metrics[8] = Metrics::Counter::create("cript.example1.c8"); // This one should resize() the storage
 
-  Bundle::Common::activate().dscp(10);
-  Bundle::Caching::activate().cache_control("max-age=259200");
+  Bundle::Common::Activate().dscp(10);
+  Bundle::Caching::Activate().cache_control("max-age=259200");
 }
 
 do_txn_close()
@@ -87,7 +87,7 @@ do_send_response()
   resp["X-AMC"]          = msg;       // New header
   resp["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
   resp["X-UUID"]         = UUID::Unique::Get();
-  resp["X-tcpinfo"]      = conn.tcpinfo.log();
+  resp["X-tcpinfo"]      = conn.tcpinfo.Log();
   resp["X-Cache-Status"] = resp.cache;
   resp["X-Integer"]      = 666;
   resp["X-Data"]         = AsString(txn_data[2]);
@@ -120,7 +120,7 @@ do_send_response()
     resp.status = 222;
   }
 
-  CDebug("Txn count: {}", conn.count());
+  CDebug("Txn count: {}", conn.Count());
 }
 
 do_remap()
@@ -128,7 +128,7 @@ do_remap()
   auto   now  = Time::Local::now();
   borrow req  = Client::Request::Get();
   borrow conn = Client::Connection::Get();
-  auto   ip   = conn.ip();
+  auto   ip   = conn.IP();
 
   if (CRIPT_ALLOW.contains(ip)) {
     CDebug("Client IP allowed: {}", ip.string(24, 64));
@@ -150,7 +150,7 @@ do_remap()
 
   CDebug("Int config cache.http = {}", proxy.config.http.cache.http.Get());
   CDebug("Float config cache.heuristic_lm_factor = {}", proxy.config.http.cache.heuristic_lm_factor.Get());
-  CDebug("String config http.response_server_str = {}", proxy.config.http.response_server_str.getSV(context));
+  CDebug("String config http.response_server_str = {}", proxy.config.http.response_server_str.GetSV(context));
   CDebug("X-Miles = {}", req["X-Miles"]);
   CDebug("random(1000) = {}", Cript::random(1000));
 
@@ -205,8 +205,8 @@ do_remap()
 
   // Some Crypto::Base64 tests
   static auto base64_test = "VGltZSB3aWxsIG5vdCBzbG93IGRvd24gd2hlbiBzb21ldGhpbmcgdW5wbGVhc2FudCBsaWVzIGFoZWFkLg==";
-  auto        hp          = Crypto::Base64::decode(base64_test);
-  auto        hp2         = Crypto::Base64::encode(hp);
+  auto        hp          = Crypto::Base64::Decode(base64_test);
+  auto        hp2         = Crypto::Base64::Encode(hp);
 
   CDebug("HP quote: {}", hp);
   if (base64_test != hp2) {
@@ -217,8 +217,8 @@ do_remap()
 
   // Some Crypto::Escape (URL escaping) tests
   static auto escape_test = "Hello_World_!@%23$%25%5E&*()_%2B%3C%3E?%2C.%2F";
-  auto        uri         = Crypto::Escape::decode(escape_test);
-  auto        uri2        = Crypto::Escape::encode(uri);
+  auto        uri         = Crypto::Escape::Decode(escape_test);
+  auto        uri2        = Crypto::Escape::Encode(uri);
 
   CDebug("Unescaped URI: {}", uri);
   if (escape_test != uri2) {
@@ -228,7 +228,7 @@ do_remap()
   }
 
   // Testing Crypto SHA and encryption
-  auto hex = format("{}", Crypto::SHA256::encode("Hello World"));
+  auto hex = format("{}", Crypto::SHA256::Encode("Hello World"));
 
   CDebug("SHA256 = {}", hex);
 

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -59,7 +59,7 @@ do_cache_lookup()
 {
   borrow url2 = Cache::URL::Get();
 
-  CDebug("Cache URL: {}", url2.url());
+  CDebug("Cache URL: {}", url2.Getter());
   CDebug("Cache Host: {}", url2.host);
 }
 
@@ -152,7 +152,7 @@ do_remap()
   CDebug("Float config cache.heuristic_lm_factor = {}", proxy.config.http.cache.heuristic_lm_factor.Get());
   CDebug("String config http.response_server_str = {}", proxy.config.http.response_server_str.GetSV(context));
   CDebug("X-Miles = {}", req["X-Miles"]);
-  CDebug("random(1000) = {}", Cript::random(1000));
+  CDebug("random(1000) = {}", Cript::Random(1000));
 
   borrow url      = Client::URL::Get();
   auto   old_port = url.port;

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -33,15 +33,15 @@ do_init()
 
 do_create_instance()
 {
-  instance.metrics[0] = Metrics::Counter::create("cript.example1.c0");
-  instance.metrics[1] = Metrics::Counter::create("cript.example1.c1");
-  instance.metrics[2] = Metrics::Counter::create("cript.example1.c2");
-  instance.metrics[3] = Metrics::Counter::create("cript.example1.c3");
-  instance.metrics[4] = Metrics::Counter::create("cript.example1.c4");
-  instance.metrics[5] = Metrics::Counter::create("cript.example1.c5");
-  instance.metrics[6] = Metrics::Counter::create("cript.example1.c6");
-  instance.metrics[7] = Metrics::Counter::create("cript.example1.c7");
-  instance.metrics[8] = Metrics::Counter::create("cript.example1.c8"); // This one should resize() the storage
+  instance.metrics[0] = Metrics::Counter::Create("cript.example1.c0");
+  instance.metrics[1] = Metrics::Counter::Create("cript.example1.c1");
+  instance.metrics[2] = Metrics::Counter::Create("cript.example1.c2");
+  instance.metrics[3] = Metrics::Counter::Create("cript.example1.c3");
+  instance.metrics[4] = Metrics::Counter::Create("cript.example1.c4");
+  instance.metrics[5] = Metrics::Counter::Create("cript.example1.c5");
+  instance.metrics[6] = Metrics::Counter::Create("cript.example1.c6");
+  instance.metrics[7] = Metrics::Counter::Create("cript.example1.c7");
+  instance.metrics[8] = Metrics::Counter::Create("cript.example1.c8"); // This one should resize() the storage
 
   Bundle::Common::Activate().dscp(10);
   Bundle::Caching::Activate().cache_control("max-age=259200");
@@ -189,10 +189,10 @@ do_remap()
   // Regular expressions
   static Matcher::PCRE pcre("^/([^/]+)/(.*)$");
 
-  auto res = pcre.match("/foo/bench/bar"); // Can also call contains(), same thing
+  auto res = pcre.Match("/foo/bench/bar"); // Can also call contains(), same thing
 
   if (res) {
-    CDebug("Ovector count is {}", res.count());
+    CDebug("Ovector count is {}", res.Count());
     CDebug("First capture is {}", res[1]);
     CDebug("Second capture is {}", res[2]);
   } else {
@@ -244,12 +244,12 @@ do_remap()
   static auto m1 = Metrics::Gauge("cript.example1.m1");
   static auto m2 = Metrics::Counter("cript.example1.m2");
 
-  m1.increment(100);
-  m1.decrement(10);
-  m2.increment();
+  m1.Increment(100);
+  m1.Decrement(10);
+  m2.Increment();
 
-  instance.metrics[0]->increment();
-  instance.metrics[8]->increment();
+  instance.metrics[0]->Increment();
+  instance.metrics[8]->Increment();
 }
 
 #include <cripts/Epilogue.hpp>

--- a/include/cripts/Bundle.hpp
+++ b/include/cripts/Bundle.hpp
@@ -44,19 +44,19 @@ namespace Bundle
     }
 
     [[nodiscard]] Cript::string_view
-    message() const
+    Message() const
     {
       return {_message};
     }
 
     [[nodiscard]] Cript::string_view
-    bundle() const
+    Bundle() const
     {
       return {_bundle};
     }
 
     [[nodiscard]] Cript::string_view
-    option() const
+    Option() const
     {
       return {_option};
     }
@@ -77,22 +77,22 @@ namespace Bundle
     void operator=(const self_type &) = delete;
     virtual ~Base()                   = default;
 
-    [[nodiscard]] virtual const Cript::string &name() const = 0;
+    [[nodiscard]] virtual const Cript::string &Name() const = 0;
 
     void
-    needCallback(Cript::Callbacks cb)
+    NeedCallback(Cript::Callbacks cb)
     {
       _callbacks |= cb;
     }
 
     void
-    needCallback(unsigned cbs)
+    NeedCallback(unsigned cbs)
     {
       _callbacks |= cbs;
     }
 
     void
-    needCallback(std::initializer_list<unsigned> cb_list)
+    NeedCallback(std::initializer_list<unsigned> cb_list)
     {
       for (auto &it : cb_list) {
         _callbacks |= it;
@@ -100,13 +100,13 @@ namespace Bundle
     }
 
     [[nodiscard]] unsigned
-    callbacks() const
+    Callbacks() const
     {
       return _callbacks;
     }
 
     virtual bool
-    validate(std::vector<Cript::Bundle::Error> & /* errors ATS_UNUSED */) const
+    Validate(std::vector<Cript::Bundle::Error> & /* errors ATS_UNUSED */) const
     {
       return true;
     }

--- a/include/cripts/Bundles/Caching.hpp
+++ b/include/cripts/Bundles/Caching.hpp
@@ -41,7 +41,7 @@ public:
   {
     auto *entry = new self_type();
 
-    inst.addBundle(entry);
+    inst.AddBundle(entry);
 
     return *entry;
   }

--- a/include/cripts/Bundles/Caching.hpp
+++ b/include/cripts/Bundles/Caching.hpp
@@ -47,7 +47,7 @@ public:
   }
 
   [[nodiscard]] const Cript::string &
-  name() const override
+  Name() const override
   {
     return _name;
   }
@@ -55,7 +55,7 @@ public:
   self_type &
   cache_control(Cript::string_view cc, bool force = false)
   {
-    needCallback(Cript::Callbacks::DO_READ_RESPONSE);
+    NeedCallback(Cript::Callbacks::DO_READ_RESPONSE);
     _cc       = cc;
     _force_cc = force;
 
@@ -65,7 +65,7 @@ public:
   self_type &
   disable(bool disable = true)
   {
-    needCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(Cript::Callbacks::DO_REMAP);
     _disabled = disable;
 
     return *this;

--- a/include/cripts/Bundles/Common.hpp
+++ b/include/cripts/Bundles/Common.hpp
@@ -39,7 +39,7 @@ class Common : public Cript::Bundle::Base
 public:
   using super_type::Base;
 
-  bool validate(std::vector<Cript::Bundle::Error> &errors) const override;
+  bool Validate(std::vector<Cript::Bundle::Error> &errors) const override;
 
   // This is the factory to create an instance of this bundle
   static self_type &
@@ -53,7 +53,7 @@ public:
   }
 
   [[nodiscard]] const Cript::string &
-  name() const override
+  Name() const override
   {
     return _name;
   }
@@ -61,7 +61,7 @@ public:
   self_type &
   dscp(int val)
   {
-    needCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(Cript::Callbacks::DO_REMAP);
     _dscp = val;
 
     return *this;

--- a/include/cripts/Bundles/Common.hpp
+++ b/include/cripts/Bundles/Common.hpp
@@ -47,7 +47,7 @@ public:
   {
     auto *entry = new self_type();
 
-    inst.addBundle(entry);
+    inst.AddBundle(entry);
 
     return *entry;
   }

--- a/include/cripts/Bundles/Headers.hpp
+++ b/include/cripts/Bundles/Headers.hpp
@@ -101,12 +101,12 @@ public:
   }
 
   [[nodiscard]] const Cript::string &
-  name() const override
+  Name() const override
   {
     return _name;
   }
 
-  static detail::HRWBridge *bridgeFactory(const Cript::string &source);
+  static detail::HRWBridge *BridgeFactory(const Cript::string &source);
 
   self_type &rm_headers(const Cript::string_view target, const HeaderList &headers);
   self_type &set_headers(const Cript::string_view target, const HeaderValueList &headers);

--- a/include/cripts/Bundles/Headers.hpp
+++ b/include/cripts/Bundles/Headers.hpp
@@ -95,7 +95,7 @@ public:
   {
     auto *entry = new self_type();
 
-    inst.addBundle(entry);
+    inst.AddBundle(entry);
 
     return *entry;
   }

--- a/include/cripts/Bundles/LogsMetrics.hpp
+++ b/include/cripts/Bundles/LogsMetrics.hpp
@@ -41,7 +41,7 @@ public:
   {
     auto *entry = new self_type(&inst);
 
-    inst.addBundle(entry);
+    inst.AddBundle(entry);
 
     return *entry;
   }

--- a/include/cripts/Bundles/LogsMetrics.hpp
+++ b/include/cripts/Bundles/LogsMetrics.hpp
@@ -47,7 +47,7 @@ public:
   }
 
   [[nodiscard]] const Cript::string &
-  name() const override
+  Name() const override
   {
     return _name;
   }
@@ -57,7 +57,7 @@ public:
   self_type &
   logsample(int val)
   {
-    needCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(Cript::Callbacks::DO_REMAP);
     _log_sample = val;
 
     return *this;
@@ -67,7 +67,7 @@ public:
   tcpinfo(bool enable = true)
   {
     if (enable) {
-      needCallback({Cript::Callbacks::DO_REMAP, Cript::Callbacks::DO_SEND_RESPONSE, Cript::Callbacks::DO_TXN_CLOSE});
+      NeedCallback({Cript::Callbacks::DO_REMAP, Cript::Callbacks::DO_SEND_RESPONSE, Cript::Callbacks::DO_TXN_CLOSE});
     }
     _tcpinfo = enable;
 

--- a/include/cripts/ConfigsBase.hpp
+++ b/include/cripts/ConfigsBase.hpp
@@ -48,53 +48,53 @@ public:
 
   // Optimizations, we can't use string_view in the ValueType since we need persistent storage.
   // Be careful with the setSV() and make sure there's underlying storage!
-  const Cript::string_view getSV(const Cript::Context *context) const;
-  bool                     setSV(const Cript::Context *context, const Cript::string_view value) const;
+  const Cript::string_view GetSV(const Cript::Context *context) const;
+  bool                     SetSV(const Cript::Context *context, const Cript::string_view value) const;
 
   [[nodiscard]] TSOverridableConfigKey
-  key() const
+  Key() const
   {
     return _key;
   }
 
   [[nodiscard]] TSRecordDataType
-  type() const
+  Type() const
   {
     return _type;
   }
 
   [[nodiscard]] Cript::string_view
-  name() const
+  Name() const
   {
     return _name;
   }
 
   [[nodiscard]] bool
-  loaded() const
+  Loaded() const
   {
     return (_key != TS_CONFIG_NULL && _type != TS_RECORDDATATYPE_NULL);
   }
 
   [[nodiscard]] bool
-  isInteger() const
+  IsInteger() const
   {
     return _type == TS_RECORDDATATYPE_INT;
   }
 
   [[nodiscard]] bool
-  isFloat() const
+  IsFloat() const
   {
     return _type == TS_RECORDDATATYPE_FLOAT;
   }
 
   [[nodiscard]] bool
-  isString() const
+  IsString() const
   {
     return _type == TS_RECORDDATATYPE_STRING;
   }
 
-  static void           add(const Records *rec);
-  static const Records *lookup(const Cript::string_view name);
+  static void           Add(const Records *rec);
+  static const Records *Lookup(const Cript::string_view name);
 
 private:
   Cript::string          _name;
@@ -108,7 +108,7 @@ class IntConfig
 {
 public:
   IntConfig() = delete;
-  explicit IntConfig(const Cript::string_view name) : _record(name) { Records::add(&_record); }
+  explicit IntConfig(const Cript::string_view name) : _record(name) { Records::Add(&_record); }
 
   float
   _get(Cript::Context *context) const
@@ -130,7 +130,7 @@ class FloatConfig
 {
 public:
   FloatConfig() = delete;
-  explicit FloatConfig(const Cript::string_view name) : _record(name) { Records::add(&_record); }
+  explicit FloatConfig(const Cript::string_view name) : _record(name) { Records::Add(&_record); }
 
   float
   _get(Cript::Context *context) const
@@ -152,7 +152,7 @@ class StringConfig
 {
 public:
   StringConfig() = delete;
-  explicit StringConfig(const Cript::string_view name) : _record(name) { Records::add(&_record); }
+  explicit StringConfig(const Cript::string_view name) : _record(name) { Records::Add(&_record); }
 
   std::string
   _get(Cript::Context *context) const
@@ -163,13 +163,14 @@ public:
   void
   _set(Cript::Context *context, std::string &value)
   {
-    _record.setSV(context, value);
+    _record.SetSV(context, value);
   }
 
+  // Only for the string type!
   const std::string_view
-  getSV(Cript::Context *context) const
+  GetSV(Cript::Context *context) const
   {
-    return _record.getSV(context);
+    return _record.GetSV(context);
   }
 
 private:

--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -137,7 +137,7 @@ class ConnBase
     {
       TSAssert(_owner);
 #if defined(TCP_CONGESTION)
-      int connfd = _owner->fd();
+      int connfd = _owner->FD();
       int res    = setsockopt(connfd, IPPROTO_TCP, TCP_CONGESTION, str.data(), str.size());
 
       // EBADF indicates possible client abort

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -53,9 +53,9 @@ public:
   // Clear the cached header mloc's etc.
   void reset();
 
-  // Freelist management, a thread_local freelist of Context objects. These are implemented in Lulu.cc.
-  static self_type *factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst);
-  void              release();
+  // This uses the ProxyAllocator to create a new Context object.
+  static self_type *Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst);
+  void              Release();
 
   // These fields are preserving the parameters as setup in DoRemap()
   Cript::Transaction                       state;
@@ -102,12 +102,12 @@ private:
 // This may be weird, but oh well for now.
 #define Get()               _get(context)
 #define Set(_value)         _set(context, _value)
-#define update()            _update(context)
-#define runRemap()          _runRemap(context)
-#define activate()          _activate(context->p_instance)
-#define transaction         context->state
-#define txn_data            context->data
-#define instance            context->p_instance
+#define Update()            _update(context)
+#define RunRemap()          _runRemap(context)
+#define Activate()          _activate(context->p_instance)
 #define CDebug(...)         context->p_instance.debug(__VA_ARGS__)
 #define CDebugOn()          context->p_instance.debugOn()
 #define DisableCallback(cb) context->state.disableCallback(cb)
+#define transaction         context->state
+#define txn_data            context->data
+#define instance            context->p_instance

--- a/include/cripts/Crypto.hpp
+++ b/include/cripts/Crypto.hpp
@@ -42,8 +42,8 @@ public:
   Base64(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static Cript::string encode(Cript::string_view str);
-  static Cript::string decode(Cript::string_view str);
+  static Cript::string Encode(Cript::string_view str);
+  static Cript::string Decode(Cript::string_view str);
 
 }; // End class Crypto::Base64
 
@@ -56,8 +56,8 @@ public:
   Escape(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static Cript::string encode(Cript::string_view str);
-  static Cript::string decode(Cript::string_view str);
+  static Cript::string Encode(Cript::string_view str);
+  static Cript::string Decode(Cript::string_view str);
 
 }; // End class Crypto::Escape
 
@@ -76,27 +76,27 @@ namespace detail
     Digest(size_t len) : _length(len) { TSAssert(len <= EVP_MAX_MD_SIZE); }
 
     [[nodiscard]] Cript::string
-    hex() const
+    Hex() const
     {
       return ts::hex({reinterpret_cast<const char *>(_hash), _length});
     }
 
-    operator Cript::string() const { return hex(); }
+    operator Cript::string() const { return Hex(); }
 
     [[nodiscard]] Cript::string
-    string() const
+    String() const
     {
       return {reinterpret_cast<const char *>(_hash), _length};
     }
 
     [[nodiscard]] Cript::string
-    base64() const
+    Base64() const
     {
-      return Crypto::Base64::encode(Cript::string_view(reinterpret_cast<const char *>(_hash), _length));
+      return Crypto::Base64::Encode(Cript::string_view(reinterpret_cast<const char *>(_hash), _length));
     }
 
     [[nodiscard]] const unsigned char *
-    hash() const
+    Hash() const
     {
       return _hash;
     }
@@ -118,30 +118,30 @@ namespace detail
 
     ~Cipher() { EVP_CIPHER_CTX_free(_ctx); }
 
-    virtual void               encrypt(Cript::string_view str);
-    virtual Cript::string_view finalize();
+    virtual void               Encrypt(Cript::string_view str);
+    virtual Cript::string_view Finalize();
 
     operator Cript::string_view() const { return {_message}; }
 
     [[nodiscard]] Cript::string
-    message() const
+    Message() const
     {
       return _message;
     }
 
     [[nodiscard]] Cript::string
-    base64() const
+    Base64() const
     {
-      return Crypto::Base64::encode(_message);
+      return Crypto::Base64::Encode(_message);
     }
 
     [[nodiscard]] Cript::string
-    hex() const
+    Hex() const
     {
       return ts::hex(_message);
     }
 
-    operator Cript::string() const { return hex(); }
+    operator Cript::string() const { return Hex(); }
 
   protected:
     Cipher(const unsigned char *key, int len) : _key_len(len) { memcpy(_key, key, len); }
@@ -171,7 +171,7 @@ public:
   SHA256(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static self_type encode(Cript::string_view str);
+  static self_type Encode(Cript::string_view str);
 }; // End class SHA256
 
 class SHA512 : public detail::Digest
@@ -187,7 +187,7 @@ public:
   SHA512(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static self_type encode(Cript::string_view str);
+  static self_type Encode(Cript::string_view str);
 }; // End class SHA512
 
 class MD5 : public detail::Digest
@@ -203,7 +203,7 @@ public:
   MD5(const self_type &)            = delete;
   void operator=(const self_type &) = delete;
 
-  static self_type encode(Cript::string_view str);
+  static self_type Encode(Cript::string_view str);
 }; // End class MD5
 
 class AES256 : public detail::Cipher
@@ -215,21 +215,21 @@ class AES256 : public detail::Cipher
 
 public:
   using super_type::Cipher;
-  using super_type::encrypt;
+  using super_type::Encrypt;
 
-  AES256(const SHA256 &key) : super_type(key.hash(), SHA256_DIGEST_LENGTH) {}
+  AES256(const SHA256 &key) : super_type(key.Hash(), SHA256_DIGEST_LENGTH) {}
   AES256(const unsigned char *key) : super_type(key, SHA256_DIGEST_LENGTH) {}
 
   AES256(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
   // The key has to be 256-bit afaik
-  static self_type encrypt(Cript::string_view str, const unsigned char *key);
+  static self_type Encrypt(Cript::string_view str, const unsigned char *key);
 
   static self_type
-  encrypt(Cript::string_view str, SHA256 &key)
+  Encrypt(Cript::string_view str, SHA256 &key)
   {
-    return encrypt(str, key.hash());
+    return Encrypt(str, key.Hash());
   }
 
 private:
@@ -257,7 +257,7 @@ namespace HMAC
     SHA256(const self_type &)         = delete;
     void operator=(const self_type &) = delete;
 
-    static self_type encrypt(Cript::string_view str, const Cript::string &key);
+    static self_type Encrypt(Cript::string_view str, const Cript::string &key);
   }; // End class SHA256
 } // namespace HMAC
 
@@ -277,7 +277,7 @@ template <> struct formatter<Crypto::SHA256> {
   auto
   format(Crypto::SHA256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", sha.hex());
+    return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
 };
 
@@ -292,7 +292,7 @@ template <> struct formatter<Crypto::SHA512> {
   auto
   format(Crypto::SHA512 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", sha.hex());
+    return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
 };
 
@@ -307,7 +307,7 @@ template <> struct formatter<Crypto::AES256> {
   auto
   format(Crypto::AES256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", Crypto::Base64::encode(sha.message()));
+    return fmt::format_to(ctx.out(), "{}", Crypto::Base64::Encode(sha.Message()));
   }
 };
 

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -249,7 +249,7 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_send_request()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
         for (auto &bundle : context->p_instance.bundles) {
           if (bundle->Callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
             bundle->doSendRequest(context);
@@ -266,7 +266,7 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_read_response()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
         for (auto &bundle : context->p_instance.bundles) {
           if (bundle->Callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
             bundle->doReadResponse(context);
@@ -282,7 +282,7 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_send_response()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
         for (auto &bundle : context->p_instance.bundles) {
           if (bundle->Callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
             bundle->doSendResponse(context);
@@ -298,7 +298,7 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_txn_close()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
         for (auto &bundle : context->p_instance.bundles) {
           if (bundle->Callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
             bundle->doTxnClose(context);
@@ -317,7 +317,7 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_cache_lookup()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
         for (auto &bundle : context->p_instance.bundles) {
           if (bundle->Callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
             bundle->doCacheLookup(context);
@@ -332,7 +332,7 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     CDebug("Entering do_post_remap()");
 
     // Call any bundle callbacks that are registered for this hook
-    if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_POST_REMAP) {
+    if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_POST_REMAP) {
       for (auto &bundle : context->p_instance.bundles) {
         if (bundle->Callbacks() & Cript::Callbacks::DO_POST_REMAP) {
           bundle->doPostRemap(context);
@@ -404,13 +404,13 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     wrap_create_instance(&context, true, CaseArg);
   }
 
-  if (!inst->failed()) {
+  if (!inst->Failed()) {
     std::vector<Cript::Bundle::Error> errors;
 
     for (auto &bundle : inst->bundles) {
       // Collect all the callbacks needed from all bundles, and validate them
       if (bundle->Validate(errors)) {
-        inst->needCallback(bundle->Callbacks());
+        inst->NeedCallback(bundle->Callbacks());
       }
     }
 
@@ -472,7 +472,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   TSHttpSsn ssnp         = TSHttpTxnSsnGet(txnp);
   auto     *inst         = static_cast<Cript::Instance *>(ih);
-  auto      bundle_cbs   = inst->callbacks();
+  auto      bundle_cbs   = inst->Callbacks();
   auto     *context      = Cript::Context::Factory(txnp, ssnp, rri, *inst);
   bool      keep_context = false;
 

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -245,30 +245,30 @@ default_cont(TSCont contp, TSEvent event, void *edata)
   switch (event) {
   case TS_EVENT_HTTP_SEND_REQUEST_HDR:
     context->state.hook = TS_HTTP_SEND_REQUEST_HDR_HOOK;
-    if (!context->state.error.failed()) {
+    if (!context->state.error.Failed()) {
       CDebug("Entering do_send_request()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
+      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
+          if (bundle->Callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
             bundle->doSendRequest(context);
           }
         }
       }
       wrap_send_request(context, true, CaseArg);
-      Client::URL::_get(context).update(); // Make sure any changes to the request URL is updated
+      Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
     }
     break;
   case TS_EVENT_HTTP_READ_RESPONSE_HDR: // 60006
     context->state.hook = TS_HTTP_READ_RESPONSE_HDR_HOOK;
-    if (!context->state.error.failed()) {
+    if (!context->state.error.Failed()) {
       CDebug("Entering do_read_response()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
+      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
+          if (bundle->Callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
             bundle->doReadResponse(context);
           }
         }
@@ -278,13 +278,13 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     break;
   case TS_EVENT_HTTP_SEND_RESPONSE_HDR: // 60007
     context->state.hook = TS_HTTP_SEND_RESPONSE_HDR_HOOK;
-    if (!context->state.error.failed()) {
+    if (!context->state.error.Failed()) {
       CDebug("Entering do_send_response()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
+      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
+          if (bundle->Callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
             bundle->doSendResponse(context);
           }
         }
@@ -298,9 +298,9 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_txn_close()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
+      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
+          if (bundle->Callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
             bundle->doTxnClose(context);
           }
         }
@@ -309,17 +309,17 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     }
 
     TSContDestroy(contp);
-    context->release();
+    context->Release();
     break;
   case TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE: // 60015
     context->state.hook = TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK;
-    if (!context->state.error.failed()) {
+    if (!context->state.error.Failed()) {
       CDebug("Entering do_cache_lookup()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
+      if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
+          if (bundle->Callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
             bundle->doCacheLookup(context);
           }
         }
@@ -332,18 +332,18 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     CDebug("Entering do_post_remap()");
 
     // Call any bundle callbacks that are registered for this hook
-    if (!context->state.error.failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_POST_REMAP) {
+    if (!context->state.error.Failed() && context->p_instance.callbacks() & Cript::Callbacks::DO_POST_REMAP) {
       for (auto &bundle : context->p_instance.bundles) {
-        if (bundle->callbacks() & Cript::Callbacks::DO_POST_REMAP) {
+        if (bundle->Callbacks() & Cript::Callbacks::DO_POST_REMAP) {
           bundle->doPostRemap(context);
         }
       }
     }
     wrap_post_remap(context, true, CaseArg);
 
-    if (!context->state.error.failed()) {
-      Cache::URL::_get(context).update();  // Make sure the cache-key gets updated, if modified
-      Client::URL::_get(context).update(); // Make sure any changes to the request URL is updated
+    if (!context->state.error.Failed()) {
+      Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
+      Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
     }
     break;
     // This is for cleanup, and should always be called / wrapped
@@ -409,8 +409,8 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 
     for (auto &bundle : inst->bundles) {
       // Collect all the callbacks needed from all bundles, and validate them
-      if (bundle->validate(errors)) {
-        inst->needCallback(bundle->callbacks());
+      if (bundle->Validate(errors)) {
+        inst->needCallback(bundle->Callbacks());
       }
     }
 
@@ -419,10 +419,10 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 
       for (auto &err : errors) {
         TSError("[Cript: %s] \tIn Bundle %.*s, option %.*s()", inst->plugin_debug_tag.c_str(),
-                static_cast<int>(err.bundle().size()), err.bundle().data(), static_cast<int>(err.option().size()),
-                err.option().data());
-        TSError("[Cript: %s] \t\t-> %.*s", inst->plugin_debug_tag.c_str(), static_cast<int>(err.message().size()),
-                err.message().data());
+                static_cast<int>(err.Bundle().size()), err.Bundle().data(), static_cast<int>(err.Option().size()),
+                err.Option().data());
+        TSError("[Cript: %s] \t\t-> %.*s", inst->plugin_debug_tag.c_str(), static_cast<int>(err.Message().size()),
+                err.Message().data());
       }
       delete inst;
       return TS_ERROR;
@@ -473,7 +473,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   TSHttpSsn ssnp         = TSHttpTxnSsnGet(txnp);
   auto     *inst         = static_cast<Cript::Instance *>(ih);
   auto      bundle_cbs   = inst->callbacks();
-  auto     *context      = Cript::Context::factory(txnp, ssnp, rri, *inst);
+  auto     *context      = Cript::Context::Factory(txnp, ssnp, rri, *inst);
   bool      keep_context = false;
 
   context->state.hook          = TS_HTTP_READ_REQUEST_HDR_HOOK; // Not quite true
@@ -484,15 +484,15 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
     for (auto &bundle : context->p_instance.bundles) {
       bundle->doRemap(context);
     }
-    if (!context->state.error.failed()) {
+    if (!context->state.error.Failed()) {
       wrap_do_remap(context, true, CaseArg); // This can fail the context
     }
   }
 
   // Don't do the callbacks when we are in a failure state.
-  if (!context->state.error.failed()) {
-    Cache::URL::_get(context).update();  // Make sure the cache-key gets updated, if modified
-    Client::URL::_get(context).update(); // Make sure any changes to the request URL is updated
+  if (!context->state.error.Failed()) {
+    Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
+    Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
 
     if (context->state.enabled_hooks >= Cript::Callbacks::DO_POST_REMAP) {
       context->default_cont = TSContCreate(default_cont, nullptr);
@@ -530,12 +530,12 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   // Check and deal with any failures here. Failures here are considered
   // catastrophic, and should give an error. ToDo: Do we want to have different
   // levels of failure here? Non-fatal vs fatal?
-  context->state.error.execute(context);
+  context->state.error.Execute(context);
 
   // For now, we always allocate the context, but a possible future optimization
   // could be to use stack allocation when there is only a do_remap() callback.
   if (!keep_context) {
-    context->release();
+    context->Release();
   }
 
   // See if the Client URL was modified, which dicates the return code here.

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -539,7 +539,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   }
 
   // See if the Client URL was modified, which dicates the return code here.
-  if (Client::URL::_get(context).modified()) {
+  if (Client::URL::_get(context).Modified()) {
     context->p_instance.debug("Client::URL was modified, returning TSREMAP_DID_REMAP");
     return TSREMAP_DID_REMAP;
   } else {

--- a/include/cripts/Error.hpp
+++ b/include/cripts/Error.hpp
@@ -43,15 +43,17 @@ public:
 
     static void _set(Cript::Context *context, const Cript::string_view msg);
 
+  private:
+    friend class Error;
+
     [[nodiscard]] Cript::string_view
-    reason() const
+    _getter() const
     {
       return {_reason.c_str(), _reason.size()};
     }
 
-  private:
     void
-    setter(const Cript::string_view msg)
+    _setter(const Cript::string_view msg)
     {
       _reason = msg;
     }
@@ -80,23 +82,19 @@ public:
 
     static TSHttpStatus _get(Cript::Context *context);
 
+  private:
+    friend class Error;
+
     [[nodiscard]] TSHttpStatus
-    status() const
+    _getter() const
     {
       return _status;
     }
 
-  private:
     void
-    setter(TSHttpStatus status)
+    _setter(TSHttpStatus status)
     {
       _status = status;
-    }
-
-    [[nodiscard]] TSHttpStatus
-    getter() const
-    {
-      return _status;
     }
 
   private:
@@ -107,19 +105,19 @@ public:
   Error() = default;
 
   [[nodiscard]] bool
-  failed() const
+  Failed() const
   {
     return _failed;
   }
 
   void
-  fail()
+  Fail()
   {
     _failed = true;
   }
 
   // Check if we have an error, and set appropriate exit codes etc.
-  void execute(Cript::Context *context);
+  void Execute(Cript::Context *context);
 
 private:
   Reason _reason;

--- a/include/cripts/Files.hpp
+++ b/include/cripts/Files.hpp
@@ -33,7 +33,7 @@ class Path : public std::filesystem::path
 public:
   using super_type::super_type;
 
-  self_type &rebase();
+  self_type &Rebase();
 };
 
 using Type = std::filesystem::file_type;
@@ -54,10 +54,10 @@ namespace Line
     explicit Reader(const std::string &path) : _path(path), _stream{path} {}
     explicit Reader(const Cript::string_view path) : _path(path), _stream{_path} {}
 
-    operator Cript::string() { return line(); }
+    operator Cript::string() { return Line(); }
 
     Cript::string
-    line()
+    Line()
     {
       Cript::string line;
 

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -90,9 +90,9 @@ public:
 
     Method(Header *owner) : _owner(owner) {}
 
-    Cript::string_view getSV();
+    Cript::string_view GetSV();
 
-    operator Cript::string_view() { return getSV(); }
+    operator Cript::string_view() { return GetSV(); }
 
     // ToDo: This is a bit weird, but seems needed (for now) to allow for the
     // Header::Method::* constants.
@@ -106,31 +106,31 @@ public:
     Cript::string_view::const_pointer
     Data()
     {
-      return getSV().data();
+      return GetSV().data();
     }
 
     Cript::string_view::size_type
     Size()
     {
-      return getSV().size();
+      return GetSV().size();
     }
 
     Cript::string_view::size_type
     Length()
     {
-      return getSV().size();
+      return GetSV().size();
     }
 
     bool
     operator==(Method const &rhs)
     {
-      return getSV().data() == rhs.Data();
+      return GetSV().data() == rhs.Data();
     }
 
     bool
     operator!=(Method const &rhs)
     {
-      return getSV().data() != rhs.Data();
+      return GetSV().data() != rhs.Data();
     }
 
   private:
@@ -147,26 +147,26 @@ public:
     CacheStatus() = delete;
     CacheStatus(Header *owner) : _owner(owner) {}
 
-    Cript::string_view getSV();
+    Cript::string_view GetSV();
 
-    operator Cript::string_view() { return getSV(); }
+    operator Cript::string_view() { return GetSV(); }
 
     Cript::string_view::const_pointer
     Data()
     {
-      return getSV().data();
+      return GetSV().data();
     }
 
     Cript::string_view::size_type
     Size()
     {
-      return getSV().size();
+      return GetSV().size();
     }
 
     Cript::string_view::size_type
     Length()
     {
-      return getSV().size();
+      return GetSV().size();
     }
 
   private:
@@ -245,7 +245,7 @@ public:
     using self_type  = Name;
 
   public:
-    operator Cript::string_view() const { return getSV(); }
+    operator Cript::string_view() const { return GetSV(); }
 
     self_type &
     operator=(const Cript::string_view str) override
@@ -526,7 +526,7 @@ template <> struct formatter<Header::Method> {
   auto
   format(Header::Method &method, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", method.getSV());
+    return fmt::format_to(ctx.out(), "{}", method.GetSV());
   }
 };
 
@@ -541,7 +541,7 @@ template <> struct formatter<Header::String> {
   auto
   format(Header::String &str, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", str.getSV());
+    return fmt::format_to(ctx.out(), "{}", str.GetSV());
   }
 };
 
@@ -556,7 +556,7 @@ template <> struct formatter<Header::Name> {
   auto
   format(Header::Name &name, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", name.getSV());
+    return fmt::format_to(ctx.out(), "{}", name.GetSV());
   }
 };
 

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -38,17 +38,17 @@ public:
   public:
     Status() = default;
 
-    void
-    initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     operator integer(); // This should not be explicit, nor const
     self_type &operator=(int status);
 
   private:
     friend class Header;
+
+    void
+    _initialize(Header *owner)
+    {
+      _owner = owner;
+    }
 
     Header      *_owner  = nullptr;
     TSHttpStatus _status = TS_HTTP_STATUS_NONE;
@@ -62,16 +62,16 @@ public:
   public:
     Reason() = default;
 
-    void
-    initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     self_type &operator=(Cript::string_view reason);
 
   private:
     friend class Header;
+
+    void
+    _initialize(Header *owner)
+    {
+      _owner = owner;
+    }
 
     Header *_owner = nullptr;
   }; // End class Header::Reason
@@ -83,16 +83,16 @@ public:
   public:
     Body() = default;
 
-    void
-    initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     self_type &operator=(Cript::string_view body);
 
   private:
     friend class Header;
+
+    void
+    _initialize(Header *owner)
+    {
+      _owner = owner;
+    }
 
     Header *_owner = nullptr;
   }; // End class Header::Body
@@ -102,18 +102,14 @@ public:
     using self_type = Method;
 
   public:
-    Method() = default;
+    Method() = delete;
     Method(Cript::string_view const &method) : _method(method) {}
     Method(const char *const method, int len)
     {
       _method = Cript::string_view(method, static_cast<Cript::string_view::size_type>(len));
     }
 
-    void
-    initialize(Header *owner)
-    {
-      _owner = owner;
-    }
+    Method(Header *owner) : _owner(owner) {}
 
     Cript::string_view getSV();
 
@@ -173,12 +169,6 @@ public:
   public:
     CacheStatus() = default;
 
-    void
-    initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     Cript::string_view getSV();
 
     operator Cript::string_view() { return getSV(); }
@@ -202,6 +192,14 @@ public:
     }
 
   private:
+    friend class Header;
+
+    void
+    _initialize(Header *owner)
+    {
+      _owner = owner;
+    }
+
     Header            *_owner = nullptr;
     Cript::string_view _cache;
 
@@ -357,6 +355,8 @@ public:
     static const Iterator _end;
   }; // Class Header::iterator
 
+  Header() = default;
+
   ~Header() { reset(); }
 
   // Clear anything "cached" in the Url, this is rather draconian, but it's
@@ -377,10 +377,10 @@ public:
   {
     _state = state;
 
-    status.initialize(this);
-    reason.initialize(this);
-    body.initialize(this);
-    cache.initialize(this);
+    status._initialize(this);
+    reason._initialize(this);
+    body._initialize(this);
+    cache._initialize(this);
   }
 
   [[nodiscard]] TSMBuffer
@@ -438,17 +438,15 @@ class RequestHeader : public Header
   using self_type  = RequestHeader;
 
 public:
-  RequestHeader() = default;
+  RequestHeader() : method(this) {} // Special case since only this header has a method
 
   void
   initialize(Cript::Transaction *state) override
   {
     Header::initialize(state);
-    method.initialize(this);
   }
 
   Method method;
-
 }; // End class RequestHeader
 
 class ResponseHeader : public Header

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -36,20 +36,13 @@ public:
     using self_type = Status;
 
   public:
-    Status() = default;
+    Status() = delete;
+    Status(Header *owner) : _owner(owner) {}
 
     operator integer(); // This should not be explicit, nor const
     self_type &operator=(int status);
 
   private:
-    friend class Header;
-
-    void
-    _initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     Header      *_owner  = nullptr;
     TSHttpStatus _status = TS_HTTP_STATUS_NONE;
 
@@ -60,19 +53,12 @@ public:
     using self_type = Reason;
 
   public:
-    Reason() = default;
+    Reason() = delete;
+    Reason(Header *owner) : _owner(owner) {}
 
     self_type &operator=(Cript::string_view reason);
 
   private:
-    friend class Header;
-
-    void
-    _initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     Header *_owner = nullptr;
   }; // End class Header::Reason
 
@@ -81,19 +67,12 @@ public:
     using self_type = Body;
 
   public:
-    Body() = default;
+    Body() = delete;
+    Body(Header *owner) : _owner(owner) {}
 
     self_type &operator=(Cript::string_view body);
 
   private:
-    friend class Header;
-
-    void
-    _initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     Header *_owner = nullptr;
   }; // End class Header::Body
 
@@ -118,26 +97,26 @@ public:
     // ToDo: This is a bit weird, but seems needed (for now) to allow for the
     // Header::Method::* constants.
     [[nodiscard]] Cript::string_view::const_pointer
-    data() const
+    Data() const
     {
       CAssert(_method.size() > 0);
       return _method.data();
     }
 
     Cript::string_view::const_pointer
-    data()
+    Data()
     {
       return getSV().data();
     }
 
     Cript::string_view::size_type
-    size()
+    Size()
     {
       return getSV().size();
     }
 
     Cript::string_view::size_type
-    length()
+    Length()
     {
       return getSV().size();
     }
@@ -145,18 +124,16 @@ public:
     bool
     operator==(Method const &rhs)
     {
-      return getSV().data() == rhs.data();
+      return getSV().data() == rhs.Data();
     }
 
     bool
     operator!=(Method const &rhs)
     {
-      return getSV().data() != rhs.data();
+      return getSV().data() != rhs.Data();
     }
 
   private:
-    friend class Header;
-
     Header            *_owner = nullptr;
     Cript::string_view _method;
 
@@ -167,39 +144,32 @@ public:
     using self_type = CacheStatus;
 
   public:
-    CacheStatus() = default;
+    CacheStatus() = delete;
+    CacheStatus(Header *owner) : _owner(owner) {}
 
     Cript::string_view getSV();
 
     operator Cript::string_view() { return getSV(); }
 
     Cript::string_view::const_pointer
-    data()
+    Data()
     {
       return getSV().data();
     }
 
     Cript::string_view::size_type
-    size()
+    Size()
     {
       return getSV().size();
     }
 
     Cript::string_view::size_type
-    length()
+    Length()
     {
       return getSV().size();
     }
 
   private:
-    friend class Header;
-
-    void
-    _initialize(Header *owner)
-    {
-      _owner = owner;
-    }
-
     Header            *_owner = nullptr;
     Cript::string_view _cache;
 
@@ -219,15 +189,7 @@ public:
       }
     }
 
-    void
-    initialize(Cript::string_view name, Cript::string_view value, Header *owner, TSMLoc field_loc)
-    {
-      _setSV(value);
-      _name      = name;
-      _owner     = owner;
-      _field_loc = field_loc;
-    }
-
+  public:
     // Implemented in Headers.cc, they are pretty large
     self_type &operator=(const Cript::string_view str) override;
     self_type &operator=(integer val);
@@ -260,6 +222,17 @@ public:
     }
 
   private:
+    friend class Header;
+
+    void
+    _initialize(Cript::string_view name, Cript::string_view value, Header *owner, TSMLoc field_loc)
+    {
+      _setSV(value);
+      _name      = name;
+      _owner     = owner;
+      _field_loc = field_loc;
+    }
+
     Header            *_owner     = nullptr;
     TSMLoc             _field_loc = nullptr;
     Cript::string_view _name;
@@ -355,14 +328,14 @@ public:
     static const Iterator _end;
   }; // Class Header::iterator
 
-  Header() = default;
+  Header() : status(this), reason(this), body(this), cache(this) {}
 
-  ~Header() { reset(); }
+  ~Header() { Reset(); }
 
   // Clear anything "cached" in the Url, this is rather draconian, but it's
   // safe...
   void
-  reset()
+  Reset()
   {
     if (_bufp && _hdr_loc) {
       TSHandleMLocRelease(_bufp, TS_NULL_MLOC, _hdr_loc);
@@ -372,25 +345,14 @@ public:
     _state = nullptr;
   }
 
-  virtual void
-  initialize(Cript::Transaction *state)
-  {
-    _state = state;
-
-    status._initialize(this);
-    reason._initialize(this);
-    body._initialize(this);
-    cache._initialize(this);
-  }
-
   [[nodiscard]] TSMBuffer
-  bufp() const
+  BufP() const
   {
     return _bufp;
   }
 
   [[nodiscard]] TSMLoc
-  mloc() const
+  MLoc() const
   {
     return _hdr_loc;
   }
@@ -398,13 +360,13 @@ public:
   String operator[](const Cript::string_view str);
 
   [[nodiscard]] bool
-  initialized() const
+  Initialized() const
   {
     return (_state != nullptr);
   }
 
   void
-  erase(const Cript::string_view header)
+  Erase(const Cript::string_view header)
   {
     operator[](header) = "";
   }
@@ -424,6 +386,12 @@ public:
   CacheStatus cache;
 
 protected:
+  void
+  _initialize(Cript::Transaction *state)
+  {
+    _state = state;
+  }
+
   TSMBuffer           _bufp         = nullptr;
   TSMLoc              _hdr_loc      = nullptr;
   Cript::Transaction *_state        = nullptr; // Pointer into the owning Context's State
@@ -439,12 +407,6 @@ class RequestHeader : public Header
 
 public:
   RequestHeader() : method(this) {} // Special case since only this header has a method
-
-  void
-  initialize(Cript::Transaction *state) override
-  {
-    Header::initialize(state);
-  }
 
   Method method;
 }; // End class RequestHeader

--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -62,8 +62,8 @@ public:
   addBundle(Cript::Bundle::Base *bundle)
   {
     for (auto &it : bundles) {
-      if (it->name() == bundle->name()) {
-        CFatal("[Instance]: Duplicate bundle %s", bundle->name().c_str());
+      if (it->Name() == bundle->Name()) {
+        CFatal("[Instance]: Duplicate bundle %s", bundle->Name().c_str());
       }
     }
 

--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -44,7 +44,7 @@ public:
   void operator=(const self_type &) = delete;
 
   // This has to be in the .hpp file, otherwise we will not get the correct debug tag!
-  Instance(int argc, char *argv[]) { initialize(argc, argv, __BASE_FILE__); }
+  Instance(int argc, char *argv[]) { _initialize(argc, argv, __BASE_FILE__); }
   ~Instance()
   {
     plugins.clear();
@@ -54,61 +54,49 @@ public:
     }
   }
 
-  bool addPlugin(const Cript::string &tag, const Cript::string &plugin, const Plugin::Options &options);
-  bool deletePlugin(const Cript::string &tag);
-  void initialize(int argc, char *argv[], const char *filename);
-
-  void
-  addBundle(Cript::Bundle::Base *bundle)
-  {
-    for (auto &it : bundles) {
-      if (it->Name() == bundle->Name()) {
-        CFatal("[Instance]: Duplicate bundle %s", bundle->Name().c_str());
-      }
-    }
-
-    bundles.push_back(bundle);
-  }
+  bool AddPlugin(const Cript::string &tag, const Cript::string &plugin, const Plugin::Options &options);
+  bool DeletePlugin(const Cript::string &tag);
+  void AddBundle(Cript::Bundle::Base *bundle);
 
   // This allows Bundles to require hooks as well.
   void
-  needCallback(Cript::Callbacks cb)
+  NeedCallback(Cript::Callbacks cb)
   {
     _callbacks |= cb;
   }
 
   void
-  needCallback(unsigned cbs)
+  NeedCallback(unsigned cbs)
   {
     _callbacks |= cbs;
   }
 
   [[nodiscard]] unsigned
-  callbacks() const
+  Callbacks() const
   {
     return _callbacks;
   }
 
   [[nodiscard]] bool
-  debugOn() const
+  DebugOn() const
   {
     return dbg_ctl_cript.on();
   }
 
   void
-  fail()
+  Fail()
   {
     _failed = true;
   }
 
   [[nodiscard]] bool
-  failed() const
+  Failed() const
   {
     return _failed;
   }
 
   [[nodiscard]] size_t
-  size() const
+  Size() const
   {
     return _size;
   }
@@ -117,7 +105,7 @@ public:
   void
   debug(fmt::format_string<T...> fmt, T &&...args) const
   {
-    if (debugOn()) {
+    if (DebugOn()) {
       auto str = fmt::vformat(fmt, fmt::make_format_args(args...));
 
       Dbg(dbg_ctl_cript, "%s", str.c_str());
@@ -133,6 +121,8 @@ public:
   std::vector<Cript::Bundle::Base *>             bundles;
 
 private:
+  void _initialize(int argc, char *argv[], const char *filename);
+
   size_t   _size      = 0;
   bool     _failed    = false;
   unsigned _callbacks = 0;

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -59,7 +59,7 @@ using string_view = swoc::TextView;
 
 namespace details
 {
-  template <typename T> std::vector<T> splitter(T input, char delim);
+  template <typename T> std::vector<T> Splitter(T input, char delim);
 
 } // namespace details
 
@@ -87,43 +87,37 @@ public:
   operator integer() const { return integer_helper(_value); }
 
   [[nodiscard]] integer
-  toInteger() const
-  {
-    return integer(*this);
-  }
-
-  [[nodiscard]] integer
-  asInteger() const
+  ToInteger() const
   {
     return integer(*this);
   }
 
   [[nodiscard]] double
-  toFloat() const
+  ToFloat() const
   {
     return float(*this);
   }
 
   [[nodiscard]] bool
-  toBool() const
+  ToBool() const
   {
     return bool(*this);
   }
 
   std::vector<mixin_type>
-  splitter(mixin_type input, char delim)
+  Splitter(mixin_type input, char delim)
   {
-    return details::splitter<mixin_type>(input, delim);
+    return details::Splitter<mixin_type>(input, delim);
   }
 
   [[nodiscard]] std::vector<mixin_type>
   split(char delim)
   {
-    return splitter(_value, delim);
+    return Splitter(_value, delim);
   }
 
   [[nodiscard]] mixin_type
-  getSV() const
+  GetSV() const
   {
     return _value;
   }
@@ -381,48 +375,32 @@ public:
   operator float() const { return std::stod(*this); }
 
   [[nodiscard]] integer
-  toInteger() const
-  {
-    return integer(*this);
-  }
-
-  [[nodiscard]] integer
-  asInteger() const
+  ToInteger() const
   {
     return integer(*this);
   }
 
   [[nodiscard]] double
-  toFloat() const
+  ToFloat() const
   {
     return float(*this);
   }
 
   [[nodiscard]] bool
-  toBool() const
+  ToBool() const
   {
     return bool(*this);
   }
 
 }; // End class Cript::string
 
-// Helpers for deducting if a type is a static string
-template <typename T> struct isStatic : std::false_type {
-};
-
-template <std::size_t N> struct isStatic<const char[N]> : std::true_type {
-};
-
-template <std::size_t N> struct isStatic<char[N]> : std::true_type {
-};
-
 // Some helper functions, in the Cript:: generic namespace
-int                             random(int max);
-std::vector<Cript::string_view> splitter(Cript::string_view input, char delim);
-Cript::string                   hex(const Cript::string &str);
-Cript::string                   hex(Cript::string_view sv);
-Cript::string                   unhex(const Cript::string &str);
-Cript::string                   unhex(Cript::string_view sv);
+int                             Random(int max);
+std::vector<Cript::string_view> Splitter(Cript::string_view input, char delim);
+Cript::string                   Hex(const Cript::string &str);
+Cript::string                   Hex(Cript::string_view sv);
+Cript::string                   UnHex(const Cript::string &str);
+Cript::string                   UnHex(Cript::string_view sv);
 
 } // namespace Cript
 
@@ -477,36 +455,26 @@ public:
   Versions(const self_type &)       = delete;
   void operator=(const self_type &) = delete;
 
-  Cript::string_view
-  getSV()
-  {
-    if (_version.length() == 0) {
-      const char *ver = TSTrafficServerVersionGet();
+  Cript::string_view GetSV();
 
-      _version = Cript::string_view(ver, strlen(ver)); // ToDo: Annoyingly, we have ambiquity on the operator=
-    }
-
-    return _version;
-  }
-
-  operator Cript::string_view() { return getSV(); }
+  operator Cript::string_view() { return GetSV(); }
 
   Cript::string_view::const_pointer
-  data()
+  Data()
   {
-    return getSV().data();
+    return GetSV().data();
   }
 
   Cript::string_view::size_type
-  size()
+  Size()
   {
-    return getSV().size();
+    return GetSV().size();
   }
 
   Cript::string_view::size_type
-  length()
+  Length()
   {
-    return getSV().length();
+    return GetSV().length();
   }
 
 private:
@@ -584,7 +552,7 @@ template <> struct formatter<Versions> {
   auto
   format(Versions &version, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", version.getSV());
+    return fmt::format_to(ctx.out(), "{}", version.GetSV());
   }
 };
 

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -42,7 +42,7 @@ namespace Range
     IP()                              = delete;
     void operator=(const self_type &) = delete;
 
-    explicit IP(Cript::string_view ip) { add(ip); }
+    explicit IP(Cript::string_view ip) { Add(ip); }
 
     IP(self_type const &ip)
     {
@@ -63,24 +63,36 @@ namespace Range
     IP(std::initializer_list<Cript::string_view> list)
     {
       for (auto &it : list) {
-        add(it);
+        Add(it);
       }
     }
 
     bool
-    match(sockaddr const *target, void ** /* ptr ATS_UNUSED */) const
+    Match(sockaddr const *target, void ** /* ptr ATS_UNUSED */) const
     {
       return contains(swoc::IPAddr(target));
     }
 
     bool
-    match(in_addr_t target, void ** /* ptr ATS_UNUSED */) const
+    Match(in_addr_t target, void ** /* ptr ATS_UNUSED */) const
+    {
+      return contains(swoc::IPAddr(target));
+    }
+
+    bool
+    Contains(sockaddr const *target, void ** /* ptr ATS_UNUSED */) const
+    {
+      return contains(swoc::IPAddr(target));
+    }
+
+    bool
+    Contains(in_addr_t target, void ** /* ptr ATS_UNUSED */) const
     {
       return contains(swoc::IPAddr(target));
     }
 
     void
-    add(Cript::string_view str)
+    Add(Cript::string_view str)
     {
       if (swoc::IPRange r; r.load(str)) {
         mark(r);
@@ -125,7 +137,7 @@ namespace List
     // Make sure we only allow the Cript::Method::* constants
 
     [[nodiscard]] bool
-    contains(Header::Method method) const
+    Contains(Header::Method method) const
     {
       auto data = method.Data();
 
@@ -133,9 +145,9 @@ namespace List
     }
 
     [[nodiscard]] bool
-    match(Header::Method method) const
+    Match(Header::Method method) const
     {
-      return contains(method);
+      return Contains(method);
     }
 
   }; // End class Method
@@ -165,7 +177,7 @@ public:
     explicit
     operator bool() const
     {
-      return matched();
+      return Matched();
     }
 
     Cript::string_view
@@ -173,7 +185,7 @@ public:
     {
       Cript::string_view ret;
 
-      if ((count() > ix) && _ovector) {
+      if ((Count() > ix) && _ovector) {
         ret = {_subject.substr(_ovector[ix * 2], _ovector[ix * 2 + 1] - _ovector[ix * 2])};
       }
 
@@ -181,19 +193,19 @@ public:
     }
 
     [[nodiscard]] bool
-    matched() const
+    Matched() const
     {
       return _match != 0;
     }
 
     [[nodiscard]] RegexEntries::size_type
-    matchIX() const
+    MatchIX() const
     {
       return _match;
     }
 
     [[nodiscard]] uint32_t
-    count() const
+    Count() const
     {
       return _data ? pcre2_get_ovector_count(_data) : 0;
     }
@@ -214,24 +226,24 @@ public:
   PCRE(const self_type &)           = delete;
   void operator=(const self_type &) = delete;
 
-  PCRE(Cript::string_view regex, uint32_t options = 0) { add(regex, options); }
+  PCRE(Cript::string_view regex, uint32_t options = 0) { Add(regex, options); }
 
   PCRE(std::initializer_list<Cript::string_view> list, uint32_t options = 0)
   {
     for (auto &it : list) {
-      add(it, options);
+      Add(it, options);
     }
   }
 
   ~PCRE();
 
-  void   add(Cript::string_view regex, uint32_t options = 0, bool jit = true);
-  Result contains(Cript::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0);
+  void   Add(Cript::string_view regex, uint32_t options = 0, bool jit = true);
+  Result Contains(Cript::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0);
 
   Result
-  match(Cript::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0)
+  Match(Cript::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0)
   {
-    return contains(subject, offset, options);
+    return Contains(subject, offset, options);
   }
 
 private:

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -127,9 +127,9 @@ namespace List
     [[nodiscard]] bool
     contains(Header::Method method) const
     {
-      auto data = method.data();
+      auto data = method.Data();
 
-      return end() != std::find_if(begin(), end(), [&](const Header::Method &header) { return header.data() == data; });
+      return end() != std::find_if(begin(), end(), [&](const Header::Method &header) { return header.Data() == data; });
     }
 
     [[nodiscard]] bool

--- a/include/cripts/Metrics.hpp
+++ b/include/cripts/Metrics.hpp
@@ -44,6 +44,19 @@ public:
 
   BaseMetrics(const Cript::string_view &name) : _name(name) {}
 
+  void
+  operator=(int64_t val)
+  {
+    CAssert(_id != TS_ERROR);
+    _metric->store(val);
+  }
+
+  operator int64_t() const
+  {
+    CAssert(_id != TS_ERROR);
+    return _metric->load();
+  }
+
   [[nodiscard]] Cript::string_view
   Name() const
   {
@@ -80,20 +93,6 @@ public:
   Decrement() const
   {
     Decrement(1);
-  }
-
-  [[nodiscard]] int64_t
-  Getter() const
-  {
-    CAssert(_id != TS_ERROR);
-    return _metric->load();
-  }
-
-  void
-  Setter(int64_t val)
-  {
-    CAssert(_id != TS_ERROR);
-    _metric->store(val);
   }
 
 protected:

--- a/include/cripts/Metrics.hpp
+++ b/include/cripts/Metrics.hpp
@@ -45,52 +45,52 @@ public:
   BaseMetrics(const Cript::string_view &name) : _name(name) {}
 
   [[nodiscard]] Cript::string_view
-  name() const
+  Name() const
   {
     return {_name};
   }
 
   [[nodiscard]] detail::MetricID
-  id() const
+  Id() const
   {
     return _id;
   }
 
   void
-  increment(int64_t inc) const
+  Increment(int64_t inc) const
   {
     CAssert(_id != ts::Metrics::NOT_FOUND);
     _metric->increment(inc);
   }
 
   void
-  increment() const
+  Increment() const
   {
-    increment(1);
+    Increment(1);
   }
 
   void
-  decrement(int64_t dec) const
+  Decrement(int64_t dec) const
   {
     CAssert(_id != ts::Metrics::NOT_FOUND);
     _metric->decrement(dec);
   }
 
   void
-  decrement() const
+  Decrement() const
   {
-    decrement(1);
+    Decrement(1);
   }
 
   [[nodiscard]] int64_t
-  get() const
+  Getter() const
   {
     CAssert(_id != TS_ERROR);
     return _metric->load();
   }
 
   void
-  set(int64_t val)
+  Setter(int64_t val)
   {
     CAssert(_id != TS_ERROR);
     _metric->store(val);
@@ -125,25 +125,25 @@ public:
   Counter(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Counter::create(name)); }
 
   // Counters can only increment, so lets produce some nice compile time erorrs too
-  void decrement(int64_t) = delete;
-  void set(int64_t val)   = delete;
+  void Decrement(int64_t)  = delete;
+  void Setter(int64_t val) = delete;
 
   template <typename T>
   void
-  decrement(T)
+  Decrement(T)
   {
-    static_assert(std::is_same_v<T, int64_t>, "A Metric::Counter can only use decrement(), consider Metric::Gauge instead?");
+    static_assert(std::is_same_v<T, int64_t>, "A Metric::Counter can only use Increment(), consider Metric::Gauge instead?");
   }
 
   template <typename T>
   void
-  set(T)
+  Setter(T)
   {
     static_assert(std::is_same_v<T, int64_t>, "A Metric::Counter can not be set to a value), consider Metric::Gauge instead?");
   }
 
   static self_type *
-  create(const Cript::string_view &name)
+  Create(const Cript::string_view &name)
   {
     auto *ret = new self_type(name);
     auto  id  = ts::Metrics::Counter::create(name);
@@ -164,7 +164,7 @@ public:
   Gauge(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Gauge::create(name)); }
 
   static self_type *
-  create(const Cript::string_view &name)
+  Create(const Cript::string_view &name)
   {
     auto *ret = new self_type(name);
     auto  id  = ts::Metrics::Gauge::create(name);

--- a/include/cripts/Plugins.hpp
+++ b/include/cripts/Plugins.hpp
@@ -45,23 +45,23 @@ public:
     other._plugin = nullptr;
   }
 
-  ~Remap() { cleanup(); }
+  ~Remap() { Cleanup(); }
 
   void _runRemap(Cript::Context *context);
 
-  void cleanup();
+  void Cleanup();
 
   [[nodiscard]] bool
-  valid() const
+  Valid() const
   {
     return _valid;
   }
 
   // Factory, sort of
-  static Remap create(const std::string &tag, const std::string &plugin, const Cript::string &from_url, const Cript::string &to_url,
+  static Remap Create(const std::string &tag, const std::string &plugin, const Cript::string &from_url, const Cript::string &to_url,
                       const Options &options);
 
-  static void initialize();
+  static void Initialize();
 
 private:
   RemapPluginInst *_plugin = nullptr;

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -38,6 +38,7 @@
 #include "cripts/Transaction.hpp"
 
 // This makes it nice and clean when the user of the framework defines the handlers in the cript.
+// Having both of these for now, until we decide which we like better...
 #define do_remap()           void _do_remap(Cript::Context *context)
 #define do_post_remap()      void _do_post_remap(Cript::Context *context)
 #define do_send_response()   void _do_send_response(Cript::Context *context)
@@ -48,6 +49,17 @@
 #define do_init()            void _do_init(TSRemapInterface *api_info)
 #define do_create_instance() void _do_create_instance(Cript::InstanceContext *context)
 #define do_delete_instance() void _do_delete_instance(Cript::InstanceContext *context)
+
+#define DoRemap()          void _do_remap(Cript::Context *context)
+#define DoPostRemap()      void _do_post_remap(Cript::Context *context)
+#define DoSendResponse()   void _do_send_response(Cript::Context *context)
+#define DoCacheLookup()    void _do_cache_lookup(Cript::Context *context)
+#define DoSendRequest()    void _do_send_request(Cript::Context *context)
+#define DoReadResponse()   void _do_read_response(Cript::Context *context)
+#define DoTxnClose()       void _do_txn_close(Cript::Context *context)
+#define DoInit()           void _do_init(TSRemapInterface *api_info)
+#define DoCreateInstance() void _do_create_instance(Cript::InstanceContext *context)
+#define DoDeleteInstance() void _do_delete_instance(Cript::InstanceContext *context)
 
 #include "cripts/Headers.hpp"
 #include "cripts/Urls.hpp"

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -39,58 +39,58 @@ public:
   BaseTime(const self_type &)       = delete;
   void operator=(const self_type &) = delete;
 
-  operator integer() const { return epoch(); }
+  operator integer() const { return Epoch(); }
 
   [[nodiscard]] integer
-  epoch() const
+  Epoch() const
   {
     return static_cast<integer>(_now);
   }
 
   [[nodiscard]] integer
-  year() const
+  Year() const
   {
     return static_cast<integer>(_result.tm_year) + 1900;
   }
 
   [[nodiscard]] integer
-  month() const
+  Month() const
   {
     return static_cast<integer>(1 + _result.tm_mon);
   }
 
   [[nodiscard]] integer
-  day() const
+  Day() const
   {
     return static_cast<integer>(_result.tm_mday);
   }
 
   [[nodiscard]] integer
-  hour() const
+  Hour() const
   {
     return static_cast<integer>(_result.tm_hour);
   }
 
   [[nodiscard]] integer
-  minute() const
+  Minute() const
   {
     return static_cast<integer>(_result.tm_min);
   }
 
   [[nodiscard]] integer
-  second() const
+  Second() const
   {
     return static_cast<integer>(_result.tm_sec);
   }
 
   [[nodiscard]] integer
-  weekday() const
+  WeekDay() const
   {
     return static_cast<integer>(_result.tm_wday) + 1;
   }
 
   [[nodiscard]] integer
-  yearday() const
+  YearDay() const
   {
     return static_cast<integer>(_result.tm_yday) + 1;
   }
@@ -118,7 +118,7 @@ public:
 
   // Factory, for consistency with ::get()
   static Local
-  now()
+  Now()
   {
     return {};
   }
@@ -141,7 +141,7 @@ template <> struct formatter<Time::Local> {
   auto
   format(Time::Local &time, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", time.epoch());
+    return fmt::format_to(ctx.out(), "{}", time.Epoch());
   }
 };
 } // namespace fmt

--- a/include/cripts/Transaction.hpp
+++ b/include/cripts/Transaction.hpp
@@ -44,7 +44,7 @@ class Transaction
 {
 public:
   void
-  disableCallback(Callbacks cb)
+  DisableCallback(Callbacks cb)
   {
     enabled_hooks &= ~cb;
   }
@@ -61,7 +61,7 @@ public:
   unsigned     enabled_hooks = 0; // Which hooks are enabled, other than the mandatory ones
 
   [[nodiscard]] bool
-  aborted() const
+  Aborted() const
   {
     bool client_abort = false;
 
@@ -73,7 +73,7 @@ public:
   }
 
   [[nodiscard]] int
-  lookupStatus() const
+  LookupStatus() const
   {
     int status = 0;
 

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -83,6 +83,24 @@ class Url
       return GetSV().size();
     }
 
+    Cript::string_view::const_pointer
+    Data()
+    {
+      return GetSV().data();
+    }
+
+    Cript::string_view::size_type
+    Size()
+    {
+      return GetSV().size();
+    }
+
+    Cript::string_view::size_type
+    Length()
+    {
+      return GetSV().size();
+    }
+
     // This is not ideal, but best way I can think of for now to mixin the Cript::string_view mixin class
     // Remember to add things here when added to the Lulu.hpp file for the mixin class... :/
     [[nodiscard]] constexpr Cript::string_view

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -39,27 +39,28 @@ class Url
 
   public:
     Component() = default;
+    Component(Url *owner) : _owner(owner) {}
 
-    virtual Cript::string_view getSV() = 0;
+    virtual Cript::string_view GetSV() = 0;
 
-    std::vector<Cript::string_view> split(char delim);
+    std::vector<Cript::string_view> Split(char delim);
 
-    operator Cript::string_view() { return getSV(); } // Should not be explicit
+    operator Cript::string_view() { return GetSV(); } // Should not be explicit
 
     bool
     operator==(Cript::string_view const &rhs)
     {
-      return getSV() == rhs;
+      return GetSV() == rhs;
     }
 
     bool
     operator!=(Cript::string_view const &rhs)
     {
-      return getSV() != rhs;
+      return GetSV() != rhs;
     }
 
     virtual void
-    reset()
+    Reset()
     {
       _data.clear();
     }
@@ -67,19 +68,19 @@ class Url
     Cript::string_view::const_pointer
     data()
     {
-      return getSV().data();
+      return GetSV().data();
     }
 
     Cript::string_view::size_type
     size()
     {
-      return getSV().size();
+      return GetSV().size();
     }
 
     Cript::string_view::size_type
     length()
     {
-      return getSV().size();
+      return GetSV().size();
     }
 
     // This is not ideal, but best way I can think of for now to mixin the Cript::string_view mixin class
@@ -189,11 +190,10 @@ public:
     using super_type = Component;
     using self_type  = Scheme;
 
-    friend class Url;
-
   public:
-    Scheme() = default;
-    Cript::string_view getSV() override;
+    using Component::Component;
+
+    Cript::string_view GetSV() override;
     self_type          operator=(Cript::string_view scheme);
 
   }; // End class Url::Scheme
@@ -203,11 +203,10 @@ public:
     using super_type = Component;
     using self_type  = Host;
 
-    friend class Url;
-
   public:
-    Host() = default;
-    Cript::string_view getSV() override;
+    using Component::Component;
+
+    Cript::string_view GetSV() override;
     self_type          operator=(Cript::string_view host);
 
   }; // End class Url::Host
@@ -216,13 +215,11 @@ public:
   {
     using self_type = Port;
 
-    friend class Url;
-
   public:
-    Port() = default;
+    Port(Url *owner) : _owner(owner){};
 
     void
-    reset()
+    Reset()
     {
       _port = -1;
     }
@@ -256,8 +253,6 @@ public:
   private:
     using super_type = Component;
     using self_type  = Path;
-
-    friend class Url;
 
     class String : public Cript::StringViewMixin<String>
     {
@@ -315,17 +310,17 @@ public:
   public:
     friend struct fmt::formatter<Path::String>;
 
-    Path() = default;
+    using Component::Component;
 
-    void reset() override;
+    void Reset() override;
 
-    Cript::string_view getSV() override;
+    Cript::string_view GetSV() override;
     Cript::string      operator+=(Cript::string_view add);
     self_type          operator=(Cript::string_view path);
     String             operator[](Segments::size_type ix);
 
     void
-    erase(Segments::size_type ix)
+    Erase(Segments::size_type ix)
     {
       auto p = operator[](ix);
 
@@ -334,25 +329,25 @@ public:
     }
 
     void
-    erase()
+    Erase()
     {
       operator=("");
     }
 
     void
-    clear()
+    Clear()
     {
-      erase();
+      Erase();
     }
 
-    void push(Cript::string_view val);
-    void insert(Segments::size_type ix, Cript::string_view val);
+    void Push(Cript::string_view val);
+    void Insert(Segments::size_type ix, Cript::string_view val);
 
     void
-    flush()
+    Flush()
     {
       if (_modified) {
-        operator=(getSV());
+        operator=(GetSV());
       }
     }
 
@@ -371,8 +366,6 @@ public:
     using super_type = Component;
     using self_type  = Query;
 
-    friend class Url;
-
     using OrderedParams = std::vector<Cript::string_view>;                            // Ordered parameter nmes
     using HashParams    = std::unordered_map<Cript::string_view, Cript::string_view>; // Hash lookups
 
@@ -385,15 +378,15 @@ public:
       Parameter() = default;
 
       [[nodiscard]] Cript::string_view
-      name() const
+      Name() const
       {
         return _name;
       }
 
       void
-      erase()
+      Erase()
       {
-        _owner->erase(_name);
+        _owner->Erase(_name);
       }
 
       // Implemented in the Urls.cc file, bigger function
@@ -444,7 +437,7 @@ public:
   public:
     friend struct fmt::formatter<Query::Parameter>;
 
-    Query() = default;
+    using Component::Component;
 
     Query(Cript::string_view load)
     {
@@ -453,36 +446,36 @@ public:
       _loaded = true;
     }
 
-    void reset() override;
+    void Reset() override;
 
-    Cript::string_view getSV() override;
+    Cript::string_view GetSV() override;
     self_type          operator=(Cript::string_view query);
     Cript::string      operator+=(Cript::string_view add);
     Parameter          operator[](Cript::string_view param);
-    void               erase(Cript::string_view param);
-    void               erase(std::initializer_list<Cript::string_view> list, bool keep = false);
+    void               Erase(Cript::string_view param);
+    void               Erase(std::initializer_list<Cript::string_view> list, bool keep = false);
 
     void
-    erase()
+    Erase()
     {
       operator=("");
       _size = 0;
     }
 
     void
-    keep(std::initializer_list<Cript::string_view> list)
+    Keep(std::initializer_list<Cript::string_view> list)
     {
-      erase(list, true);
+      Erase(list, true);
     }
 
     void
-    clear()
+    Clear()
     {
-      return erase();
+      return Erase();
     }
 
     void
-    sort()
+    Sort()
     {
       // Make sure the hash and vector are populated
       _parser();
@@ -492,10 +485,10 @@ public:
     }
 
     void
-    flush()
+    Flush()
     {
       if (_modified) {
-        operator=(getSV());
+        operator=(GetSV());
       }
     }
 
@@ -516,59 +509,58 @@ public:
     using super_type = Component;
     using self_type  = Matrix;
 
-    friend class Url;
-
   public:
-    Matrix() = default;
-    Cript::string_view getSV() override;
+    using Component::Component;
+
+    Cript::string_view GetSV() override;
     self_type          operator=(Cript::string_view matrix);
 
   }; // End class Url::Matrix
 
 public:
-  Url() = default;
+  Url() : scheme(this), host(this), port(this), path(this), query(this), matrix(this) {}
 
   // Clear anything "cached" in the Url, this is rather draconian, but it's safe...
   virtual void
-  reset()
+  Reset()
   {
     if (_bufp && _urlp) {
       TSHandleMLocRelease(_bufp, TS_NULL_MLOC, _urlp);
       _urlp = nullptr;
       _bufp = nullptr;
 
-      query.reset();
-      path.reset();
+      query.Reset();
+      path.Reset();
     }
     _state = nullptr;
   }
 
   [[nodiscard]] bool
-  initialized() const
+  Initialized() const
   {
     return (_state != nullptr);
   }
 
   [[nodiscard]] bool
-  modified() const
+  Modified() const
   {
     return _modified;
   }
 
   [[nodiscard]] TSMLoc
-  urlp() const
+  UrlP() const
   {
     return _urlp;
   }
 
   [[nodiscard]] virtual bool
-  readOnly() const
+  ReadOnly() const
   {
     return false;
   }
 
   // Getters / setters for the full URL
-  [[nodiscard]] Cript::string url() const;
+  [[nodiscard]] Cript::string Getter() const;
 
   Scheme scheme;
   Host   host;
@@ -581,8 +573,7 @@ protected:
   void
   _initialize(Cript::Transaction *state)
   {
-    _state        = state;
-    scheme._owner = host._owner = port._owner = path._owner = query._owner = matrix._owner = this;
+    _state = state;
   }
 
   TSMBuffer           _bufp     = nullptr; // These two gets setup via initializing, to appropriate headers
@@ -611,7 +602,7 @@ public:
   static self_type &_get(Cript::Context *context);
 
   [[nodiscard]] bool
-  readOnly() const override
+  ReadOnly() const override
   {
     return true;
   }
@@ -634,7 +625,7 @@ public:
 
   // We must not release the bufp etc. since it comes from the RRI structure
   void
-  reset() override
+  Reset() override
   {
   }
 
@@ -664,12 +655,12 @@ namespace From
 
     // We must not release the bufp etc. since it comes from the RRI structure
     void
-    reset() override
+    Reset() override
     {
     }
 
     [[nodiscard]] bool
-    readOnly() const override
+    ReadOnly() const override
     {
       return true;
     }
@@ -698,12 +689,12 @@ namespace To
 
     // We must not release the bufp etc. since it comes from the RRI structure
     void
-    reset() override
+    Reset() override
     {
     }
 
     [[nodiscard]] bool
-    readOnly() const override
+    ReadOnly() const override
     {
       return true;
     }
@@ -792,7 +783,7 @@ template <> struct formatter<Cript::Url::Scheme> {
   auto
   format(Cript::Url::Scheme &scheme, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", scheme.getSV());
+    return fmt::format_to(ctx.out(), "{}", scheme.GetSV());
   }
 };
 
@@ -807,7 +798,7 @@ template <> struct formatter<Cript::Url::Host> {
   auto
   format(Cript::Url::Host &host, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", host.getSV());
+    return fmt::format_to(ctx.out(), "{}", host.GetSV());
   }
 };
 
@@ -837,7 +828,7 @@ template <> struct formatter<Cript::Url::Path::String> {
   auto
   format(Cript::Url::Path::String &path, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", path.getSV());
+    return fmt::format_to(ctx.out(), "{}", path.GetSV());
   }
 };
 
@@ -852,7 +843,7 @@ template <> struct formatter<Cript::Url::Path> {
   auto
   format(Cript::Url::Path &path, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", path.getSV());
+    return fmt::format_to(ctx.out(), "{}", path.GetSV());
   }
 };
 
@@ -867,7 +858,7 @@ template <> struct formatter<Cript::Url::Query::Parameter> {
   auto
   format(Cript::Url::Query::Parameter &param, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", param.getSV());
+    return fmt::format_to(ctx.out(), "{}", param.GetSV());
   }
 };
 
@@ -882,7 +873,7 @@ template <> struct formatter<Cript::Url::Query> {
   auto
   format(Cript::Url::Query &query, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", query.getSV());
+    return fmt::format_to(ctx.out(), "{}", query.GetSV());
   }
 };
 
@@ -897,7 +888,7 @@ template <> struct formatter<Cript::Url::Matrix> {
   auto
   format(Cript::Url::Matrix &matrix, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", matrix.getSV());
+    return fmt::format_to(ctx.out(), "{}", matrix.GetSV());
   }
 };
 

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -577,8 +577,8 @@ public:
     return false;
   }
 
-  // Getters / setters for the full URL
-  [[nodiscard]] Cript::string Getter() const;
+  // This is the full string for a URL, which needs allocations.
+  [[nodiscard]] Cript::string String() const;
 
   Scheme scheme;
   Host   host;

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -741,8 +741,8 @@ private:
   {
     Url::_initialize(state);
 
-    _bufp    = req->bufp();
-    _hdr_loc = req->mloc();
+    _bufp    = req->BufP();
+    _hdr_loc = req->MLoc();
   }
 
 }; // End class Cache::URL
@@ -770,8 +770,8 @@ private:
   {
     Url::_initialize(state);
 
-    _bufp    = req->bufp();
-    _hdr_loc = req->mloc();
+    _bufp    = req->BufP();
+    _hdr_loc = req->MLoc();
   }
 
 }; // End class Cache::URL

--- a/src/cripts/Bundles/Common.cc
+++ b/src/cripts/Bundles/Common.cc
@@ -24,46 +24,46 @@ namespace Bundle
 const Cript::string Common::_name = "Bundle::Common";
 
 bool
-Common::validate(std::vector<Cript::Bundle::Error> &errors) const
+Common::Validate(std::vector<Cript::Bundle::Error> &errors) const
 {
   bool good = true;
 
   // The .dscp() can only be 0 - 63
   if (_dscp < 0 || _dscp > 63) {
-    errors.emplace_back("dscp must be between 0 and 63", name(), "dscp");
+    errors.emplace_back("dscp must be between 0 and 63", Name(), "dscp");
     good = false;
   }
 
   // Make sure we didn't encounter an error setting up the via headers
   if (_client_via.first == 999 || _origin_via.first == 999) {
-    errors.emplace_back("via_header must be one of: disable, protocol, basic, detailed, full", name(), "via_header");
+    errors.emplace_back("via_header must be one of: disable, protocol, basic, detailed, full", Name(), "via_header");
     good = false;
   }
 
   // Make sure all configurations are of the correct type
   for (auto &[rec, value] : _configs) {
-    switch (rec->type()) {
+    switch (rec->Type()) {
     case TS_RECORDDATATYPE_INT:
       if (!std::holds_alternative<TSMgmtInt>(value)) {
-        errors.emplace_back("Invalid value for config, expecting an integer", name(), rec->name());
+        errors.emplace_back("Invalid value for config, expecting an integer", Name(), rec->Name());
         good = false;
       }
       break;
     case TS_RECORDDATATYPE_FLOAT:
       if (!std::holds_alternative<TSMgmtFloat>(value)) {
-        errors.emplace_back("Invalid value for config, expecting a float", name(), rec->name());
+        errors.emplace_back("Invalid value for config, expecting a float", Name(), rec->Name());
         good = false;
       }
       break;
     case TS_RECORDDATATYPE_STRING:
       if (!std::holds_alternative<std::string>(value)) {
-        errors.emplace_back("Invalid value for config, expecting an integer", name(), rec->name());
+        errors.emplace_back("Invalid value for config, expecting an integer", Name(), rec->Name());
         good = false;
       }
       break;
 
     default:
-      errors.emplace_back("Invalid configuration type", name(), rec->name());
+      errors.emplace_back("Invalid configuration type", Name(), rec->Name());
       good = false;
       break;
     }
@@ -84,7 +84,7 @@ Common::via_header(const Cript::string_view &destination, const Cript::string_vi
     {"none",     999}  // This is an error
   };
 
-  needCallback(Cript::Callbacks::DO_REMAP);
+  NeedCallback(Cript::Callbacks::DO_REMAP);
 
   int  val = 999;
   auto it  = SettingValues.find(value);
@@ -107,10 +107,10 @@ Common::via_header(const Cript::string_view &destination, const Cript::string_vi
 Common &
 Common::set_config(const Cript::string_view name, const Cript::Records::ValueType &value)
 {
-  auto rec = Cript::Records::lookup(name); // These should be loaded at startup
+  auto rec = Cript::Records::Lookup(name); // These should be loaded at startup
 
   if (rec) {
-    needCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(Cript::Callbacks::DO_REMAP);
     _configs.emplace_back(rec, value);
   } else {
     CFatal("[Common::set_config]: Unknown configuration '%.*s'", static_cast<int>(name.size()), name.data());

--- a/src/cripts/Bundles/HRWBridge.cc
+++ b/src/cripts/Bundles/HRWBridge.cc
@@ -121,19 +121,19 @@ IP::value(Cript::Context *context)
 {
   switch (_type) {
   case Type::CLIENT: {
-    auto ip = Client::Connection::Get().ip();
+    auto ip = Client::Connection::Get().IP();
     _value  = ip.string();
   } break;
   case Type::INBOUND: {
-    auto ip = Client::Connection::Get().localIP();
+    auto ip = Client::Connection::Get().LocalIP();
     _value  = ip.string();
   } break;
   case Type::SERVER: {
-    auto ip = Server::Connection::Get().ip();
+    auto ip = Server::Connection::Get().IP();
     _value  = ip.string();
   } break;
   case Type::OUTBOUND: {
-    auto ip = Server::Connection::Get().localIP();
+    auto ip = Server::Connection::Get().LocalIP();
     _value  = ip.string();
   } break;
   default:
@@ -186,7 +186,7 @@ CIDR::CIDR(Cript::string_view &cidr) : super_type(cidr)
 Cript::string_view
 CIDR::value(Cript::Context *context)
 {
-  auto ip = Client::Connection::Get().ip();
+  auto ip = Client::Connection::Get().IP();
 
   _value = ip.string(_ipv4_cidr, _ipv6_cidr);
 
@@ -330,7 +330,7 @@ URL::value(Cript::Context *context)
 } // namespace detail
 
 detail::HRWBridge *
-Bundle::Headers::bridgeFactory(const Cript::string &source)
+Bundle::Headers::BridgeFactory(const Cript::string &source)
 {
   Cript::string_view str = source;
 

--- a/src/cripts/Bundles/HRWBridge.cc
+++ b/src/cripts/Bundles/HRWBridge.cc
@@ -226,7 +226,7 @@ URL::_getComponent(Cript::Url &url)
 {
   switch (_comp) {
   case Component::HOST:
-    return url.host.getSV();
+    return url.host.GetSV();
     break;
 
   case Component::PATH:

--- a/src/cripts/Bundles/Headers.cc
+++ b/src/cripts/Bundles/Headers.cc
@@ -58,19 +58,19 @@ Headers::rm_headers(const Cript::string_view target, const HeaderList &headers)
   switch (header_target(target)) {
   case CLIENT_REQUEST:
     _client_request.rm_headers.insert(_client_request.rm_headers.end(), headers.begin(), headers.end());
-    needCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(Cript::Callbacks::DO_REMAP);
     break;
   case CLIENT_RESPONSE:
     _client_response.rm_headers.insert(_client_response.rm_headers.end(), headers.begin(), headers.end());
-    needCallback(Cript::Callbacks::DO_SEND_RESPONSE);
+    NeedCallback(Cript::Callbacks::DO_SEND_RESPONSE);
     break;
   case SERVER_REQUEST:
     _client_response.rm_headers.insert(_client_response.rm_headers.end(), headers.begin(), headers.end());
-    needCallback(Cript::Callbacks::DO_SEND_REQUEST);
+    NeedCallback(Cript::Callbacks::DO_SEND_REQUEST);
     break;
   case SERVER_RESPONSE:
     _client_response.rm_headers.insert(_client_response.rm_headers.end(), headers.begin(), headers.end());
-    needCallback(Cript::Callbacks::DO_READ_RESPONSE);
+    NeedCallback(Cript::Callbacks::DO_READ_RESPONSE);
     break;
   default:
     CFatal("[Cripts::Headers] Unknown header target: %s.", target.data());
@@ -87,19 +87,19 @@ Headers::set_headers(const Cript::string_view target, const HeaderValueList &hea
   switch (header_target(target)) {
   case CLIENT_REQUEST:
     hdrs = &_client_request.set_headers;
-    needCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(Cript::Callbacks::DO_REMAP);
     break;
   case CLIENT_RESPONSE:
     hdrs = &_client_response.set_headers;
-    needCallback(Cript::Callbacks::DO_SEND_RESPONSE);
+    NeedCallback(Cript::Callbacks::DO_SEND_RESPONSE);
     break;
   case SERVER_REQUEST:
     hdrs = &_server_request.set_headers;
-    needCallback(Cript::Callbacks::DO_SEND_REQUEST);
+    NeedCallback(Cript::Callbacks::DO_SEND_REQUEST);
     break;
   case SERVER_RESPONSE:
     hdrs = &_server_response.set_headers;
-    needCallback(Cript::Callbacks::DO_READ_RESPONSE);
+    NeedCallback(Cript::Callbacks::DO_READ_RESPONSE);
     break;
   default:
     CFatal("[Cripts::Headers] Unknown header target: %s.", target.data());
@@ -107,7 +107,7 @@ Headers::set_headers(const Cript::string_view target, const HeaderValueList &hea
 
   hdrs->reserve(headers.size());
   for (const auto &hdr : headers) {
-    hdrs->emplace_back(hdr.first, Headers::bridgeFactory(hdr.second));
+    hdrs->emplace_back(hdr.first, Headers::BridgeFactory(hdr.second));
   }
 
   return *this;

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -181,7 +181,7 @@ LogsMetrics::doRemap(Cript::Context *context)
 
   // .logsample(int)
   if (_log_sample > 0) {
-    if (Cript::random(_log_sample) != 1) {
+    if (Cript::Random(_log_sample) != 1) {
       control.logging.Set(false);
       sampled = false;
     }

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -136,7 +136,7 @@ LogsMetrics::doTxnClose(Cript::Context *context)
       instance.metrics[Bundle::PROPSTAT_RESPONSE_5xx]->Increment();
     }
 
-    if (transaction.aborted()) {
+    if (transaction.Aborted()) {
       instance.metrics[Bundle::PROPSTAT_CLIENT_ABORTED_REQUESTS]->Increment();
     } else {
       instance.metrics[Bundle::PROPSTAT_CLIENT_COMPLETED_REQUESTS]->Increment();
@@ -164,7 +164,7 @@ LogsMetrics::doSendResponse(Cript::Context *context)
 void
 LogsMetrics::doCacheLookup(Cript::Context *context)
 {
-  auto status = transaction.lookupStatus();
+  auto status = transaction.LookupStatus();
 
   // .label(str)
   if (_label.length() > 0) {

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -88,7 +88,7 @@ LogsMetrics::propstats(const Cript::string_view &label)
       auto name = fmt::format("{}.{}", _label, Bundle::PROPSTAT_SUFFIXES[ix]);
 
       _inst->debug("Creating metrics for: {}", name);
-      _inst->metrics[ix] = Metrics::Counter::create(name);
+      _inst->metrics[ix] = Metrics::Counter::Create(name);
     }
   }
 
@@ -109,37 +109,37 @@ LogsMetrics::doTxnClose(Cript::Context *context)
 
   // .label(str)
   if (_label.length() > 0) {
-    instance.metrics[Bundle::PROPSTAT_CLIENT_BYTES_IN]->increment(TSHttpTxnClientReqHdrBytesGet(transaction.txnp) +
+    instance.metrics[Bundle::PROPSTAT_CLIENT_BYTES_IN]->Increment(TSHttpTxnClientReqHdrBytesGet(transaction.txnp) +
                                                                   TSHttpTxnClientReqBodyBytesGet(transaction.txnp));
-    instance.metrics[Bundle::PROPSTAT_CLIENT_BYTES_OUT]->increment(TSHttpTxnClientRespHdrBytesGet(transaction.txnp) +
+    instance.metrics[Bundle::PROPSTAT_CLIENT_BYTES_OUT]->Increment(TSHttpTxnClientRespHdrBytesGet(transaction.txnp) +
                                                                    TSHttpTxnClientRespBodyBytesGet(transaction.txnp));
-    instance.metrics[Bundle::PROPSTAT_SERVER_BYTES_IN]->increment(TSHttpTxnServerReqHdrBytesGet(transaction.txnp) +
+    instance.metrics[Bundle::PROPSTAT_SERVER_BYTES_IN]->Increment(TSHttpTxnServerReqHdrBytesGet(transaction.txnp) +
                                                                   TSHttpTxnServerReqBodyBytesGet(transaction.txnp));
-    instance.metrics[Bundle::PROPSTAT_SERVER_BYTES_OUT]->increment(TSHttpTxnServerRespHdrBytesGet(transaction.txnp) +
+    instance.metrics[Bundle::PROPSTAT_SERVER_BYTES_OUT]->Increment(TSHttpTxnServerRespHdrBytesGet(transaction.txnp) +
                                                                    TSHttpTxnServerRespBodyBytesGet(transaction.txnp));
 
     if (resp.status == 200) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_200]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_200]->Increment();
     } else if (resp.status == 206) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_206]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_206]->Increment();
     } else if (resp.status == 404) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_404]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_404]->Increment();
     } else if (resp.status == 504) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_504]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_504]->Increment();
     } else if (resp.status >= 200 && resp.status < 300) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_2xx]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_2xx]->Increment();
     } else if (resp.status >= 300 && resp.status < 400) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_3xx]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_3xx]->Increment();
     } else if (resp.status >= 400 && resp.status < 500) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_4xx]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_4xx]->Increment();
     } else if (resp.status >= 500 && resp.status < 600) {
-      instance.metrics[Bundle::PROPSTAT_RESPONSE_5xx]->increment();
+      instance.metrics[Bundle::PROPSTAT_RESPONSE_5xx]->Increment();
     }
 
     if (transaction.aborted()) {
-      instance.metrics[Bundle::PROPSTAT_CLIENT_ABORTED_REQUESTS]->increment();
+      instance.metrics[Bundle::PROPSTAT_CLIENT_ABORTED_REQUESTS]->Increment();
     } else {
-      instance.metrics[Bundle::PROPSTAT_CLIENT_COMPLETED_REQUESTS]->increment();
+      instance.metrics[Bundle::PROPSTAT_CLIENT_COMPLETED_REQUESTS]->Increment();
     }
   }
 }
@@ -169,7 +169,7 @@ LogsMetrics::doCacheLookup(Cript::Context *context)
   // .label(str)
   if (_label.length() > 0) {
     if (status >= 0 && status <= 3) {
-      instance.metrics[status]->increment(); // This assumes the 4 cache stats are first
+      instance.metrics[status]->Increment(); // This assumes the 4 cache stats are first
     }
   }
 }

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -82,7 +82,7 @@ LogsMetrics::propstats(const Cript::string_view &label)
   _label = label;
 
   if (_label.length() > 0) {
-    needCallback({Cript::Callbacks::DO_CACHE_LOOKUP, Cript::Callbacks::DO_TXN_CLOSE});
+    NeedCallback({Cript::Callbacks::DO_CACHE_LOOKUP, Cript::Callbacks::DO_TXN_CLOSE});
 
     for (int ix = 0; ix < Bundle::PROPSTAT_MAX; ++ix) {
       auto name = fmt::format("{}.{}", _label, Bundle::PROPSTAT_SUFFIXES[ix]);
@@ -104,7 +104,7 @@ LogsMetrics::doTxnClose(Cript::Context *context)
   if (_tcpinfo && control.logging.Get()) {
     borrow conn = Client::Connection::Get();
 
-    resp["@TCPInfo"] += fmt::format(",TC; {}", conn.tcpinfo.log());
+    resp["@TCPInfo"] += fmt::format(",TC; {}", conn.tcpinfo.Log());
   }
 
   // .label(str)
@@ -157,7 +157,7 @@ LogsMetrics::doSendResponse(Cript::Context *context)
 
   // .tcpinfo(bool)
   if (_tcpinfo && control.logging.Get()) {
-    resp["@TCPInfo"] = fmt::format("SR; {}", conn.tcpinfo.log());
+    resp["@TCPInfo"] = fmt::format("SR; {}", conn.tcpinfo.Log());
   }
 }
 
@@ -192,7 +192,7 @@ LogsMetrics::doRemap(Cript::Context *context)
   if (_tcpinfo && sampled) {
     borrow req      = Client::Request::Get();
     borrow conn     = Client::Connection::Get();
-    req["@TCPInfo"] = fmt::format("TS; {}", conn.tcpinfo.log());
+    req["@TCPInfo"] = fmt::format("TS; {}", conn.tcpinfo.Log());
   }
 }
 

--- a/src/cripts/Configs.cc
+++ b/src/cripts/Configs.cc
@@ -84,7 +84,7 @@ Records::GetSV(const Cript::Context *context) const
     }
   } break;
   default:
-    CFatal("[Records]: Invalid configuration type for getSV()");
+    CFatal("[Records]: Invalid configuration type for GetSV()");
     break;
   }
 

--- a/src/cripts/Configs.cc
+++ b/src/cripts/Configs.cc
@@ -59,7 +59,7 @@ Records::_get(const Cript::Context *context) const
     }
   } break;
   case TS_RECORDDATATYPE_STRING: {
-    return std::string{getSV(context)};
+    return std::string{GetSV(context)};
   } break;
   default:
     CFatal("[Records]: Invalid configuration type");
@@ -70,7 +70,7 @@ Records::_get(const Cript::Context *context) const
 }
 
 const Cript::string_view
-Records::getSV(const Cript::Context *context) const
+Records::GetSV(const Cript::Context *context) const
 {
   TSAssert(context->state.txnp);
 
@@ -118,7 +118,7 @@ Records::_set(const Cript::Context *context, const ValueType &value) const
   case TS_RECORDDATATYPE_STRING: {
     auto &str = std::get<std::string>(value);
 
-    setSV(context, {str.data(), str.size()});
+    SetSV(context, {str.data(), str.size()});
   } break;
   default:
     CFatal("[Records]: Invalid configuration type");
@@ -129,7 +129,7 @@ Records::_set(const Cript::Context *context, const ValueType &value) const
 }
 
 bool
-Records::setSV(const Cript::Context *context, const Cript::string_view value) const
+Records::SetSV(const Cript::Context *context, const Cript::string_view value) const
 {
   TSAssert(context->state.txnp);
 
@@ -151,22 +151,22 @@ Records::setSV(const Cript::Context *context, const Cript::string_view value) co
 
 // Static members for the records "cache"
 void
-Records::add(const Records *rec)
+Records::Add(const Records *rec)
 {
-  CAssert(rec->loaded());
-  auto it = _gRecords.find(rec->name());
+  CAssert(rec->Loaded());
+  auto it = _gRecords.find(rec->Name());
 
   CAssert(it == _gRecords.end());
-  _gRecords[rec->name()] = rec;
+  _gRecords[rec->Name()] = rec;
 }
 
 const Records *
-Records::lookup(const Cript::string_view name)
+Records::Lookup(const Cript::string_view name)
 {
   auto it = _gRecords.find(name);
 
   if (it != _gRecords.end()) {
-    CAssert(it->second->loaded());
+    CAssert(it->second->Loaded());
     return it->second;
   }
 

--- a/src/cripts/Connections.cc
+++ b/src/cripts/Connections.cc
@@ -26,9 +26,12 @@ constexpr unsigned NORMALIZED_TIME_QUANTUM = 3600; // 1 hour
 const Matcher::Range::IP Cript::Net::Localhost({"127.0.0.1", "::1"});
 const Matcher::Range::IP Cript::Net::RFC1918({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"});
 
+namespace Cript
+{
+
 // This is mostly copied out of header_rewrite of course
 Cript::string_view
-Cript::IP::GetSV(unsigned ipv4_cidr, unsigned ipv6_cidr)
+IP::GetSV(unsigned ipv4_cidr, unsigned ipv6_cidr)
 {
   if (is_ip4()) {
     auto      addr = this->_addr._ip4.network_order();
@@ -63,7 +66,7 @@ Cript::IP::GetSV(unsigned ipv4_cidr, unsigned ipv6_cidr)
 }
 
 uint64_t
-Cript::IP::Hasher(unsigned ipv4_cidr, unsigned ipv6_cidr)
+IP::Hasher(unsigned ipv4_cidr, unsigned ipv6_cidr)
 {
   if (_hash == 0) {
     if (is_ip4()) {
@@ -94,7 +97,7 @@ Cript::IP::Hasher(unsigned ipv4_cidr, unsigned ipv6_cidr)
 }
 
 bool
-Cript::IP::Sample(double rate, uint32_t seed, unsigned ipv4_cidr, unsigned ipv6_cidr)
+IP::Sample(double rate, uint32_t seed, unsigned ipv4_cidr, unsigned ipv6_cidr)
 {
   CAssert(rate >= 0.0 && rate <= 1.0); // For detecting bugs in a Cript, 0.0 and 1.0 are valid though
 
@@ -137,6 +140,8 @@ Cript::IP::Sample(double rate, uint32_t seed, unsigned ipv4_cidr, unsigned ipv6_
   // To avoid picking sequential folded IPs bucketize them with a modulo of the sampler (just in case)
   return (_sampler % static_cast<uint16_t>(rate * UINT16_MAX)) == _sampler;
 }
+
+} // namespace Cript
 
 void
 detail::ConnBase::Pacing::operator=(uint32_t val)

--- a/src/cripts/Connections.cc
+++ b/src/cripts/Connections.cc
@@ -152,7 +152,7 @@ detail::ConnBase::Pacing::operator=(uint32_t val)
   }
 
 #ifdef SO_MAX_PACING_RATE
-  int connfd = _owner->fd();
+  int connfd = _owner->FD();
   int res    = setsockopt(connfd, SOL_SOCKET, SO_MAX_PACING_RATE, (char *)&val, sizeof(val));
 
   // EBADF indicates possible client abort
@@ -168,7 +168,7 @@ detail::ConnBase::TcpInfo::initialize()
 {
 #if defined(TCP_INFO) && defined(HAVE_STRUCT_TCP_INFO)
   if (!_ready) {
-    int connfd = _owner->fd();
+    int connfd = _owner->FD();
 
     TSAssert(_owner->_state->txnp);
     if (connfd < 0 || TSHttpTxnIsInternal(_owner->_state->txnp)) { // No TCPInfo for internal transactions

--- a/src/cripts/Connections.cc
+++ b/src/cripts/Connections.cc
@@ -103,7 +103,7 @@ IP::Sample(double rate, uint32_t seed, unsigned ipv4_cidr, unsigned ipv6_cidr)
 
   if (_sampler == 0) {
     // This only works until 2038
-    uint32_t now = (Time::Local::now().epoch() / NORMALIZED_TIME_QUANTUM) * NORMALIZED_TIME_QUANTUM;
+    uint32_t now = (Time::Local::Now().Epoch() / NORMALIZED_TIME_QUANTUM) * NORMALIZED_TIME_QUANTUM;
 
     if (is_ip4()) {
       auto      addr = this->_addr._ip4.network_order();

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -29,17 +29,17 @@ Cript::Context::reset()
   // Clear the initialized headers before calling next hook
   // Note: we don't clear the pristine URL, nor the Remap From/To URLs, they are static.
   //      We also don't clear the client URL, since it's from the RRI.
-  if (_client_resp_header.initialized()) {
-    _client_resp_header.reset();
+  if (_client_resp_header.Initialized()) {
+    _client_resp_header.Reset();
   }
-  if (_server_resp_header.initialized()) {
-    _server_resp_header.reset();
+  if (_server_resp_header.Initialized()) {
+    _server_resp_header.Reset();
   }
-  if (_client_req_header.initialized()) {
-    _client_req_header.reset();
+  if (_client_req_header.Initialized()) {
+    _client_req_header.Reset();
   }
-  if (_server_req_header.initialized()) {
-    _server_req_header.reset();
+  if (_server_req_header.Initialized()) {
+    _server_req_header.Reset();
   }
 
   // Clear the initialized URLs before calling next hook

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -49,14 +49,14 @@ Context::reset()
   }
 
   // Clear the initialized URLs before calling next hook
-  if (_pristine_url.initialized()) {
-    _pristine_url.reset();
+  if (_pristine_url.Initialized()) {
+    _pristine_url.Reset();
   }
-  if (_cache_url.initialized()) {
-    _cache_url.reset();
+  if (_cache_url.Initialized()) {
+    _cache_url.Reset();
   }
-  if (_parent_url.initialized()) {
-    _parent_url.reset();
+  if (_parent_url.Initialized()) {
+    _parent_url.Reset();
   }
 }
 

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -58,13 +58,13 @@ Cript::Context::reset()
 ClassAllocator<Cript::Context> criptContextAllocator("Cript::Context");
 
 Cript::Context *
-Cript::Context::factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst)
+Cript::Context::Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst)
 {
   return THREAD_ALLOC(criptContextAllocator, this_thread(), txn_ptr, ssn_ptr, rri_ptr, inst);
 }
 
 void
-Cript::Context::release()
+Cript::Context::Release()
 {
   THREAD_FREE(this, criptContextAllocator, this_thread());
 }

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -23,8 +23,14 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Context.hpp"
 
+// Freelist management. These are here to avoid polluting the Context includes with ATS core includes.
+ClassAllocator<Cript::Context> criptContextAllocator("Cript::Context");
+
+namespace Cript
+{
+
 void
-Cript::Context::reset()
+Context::reset()
 {
   // Clear the initialized headers before calling next hook
   // Note: we don't clear the pristine URL, nor the Remap From/To URLs, they are static.
@@ -54,17 +60,16 @@ Cript::Context::reset()
   }
 }
 
-// Freelist management. These are here to avoid polluting the Context includes with ATS core includes.
-ClassAllocator<Cript::Context> criptContextAllocator("Cript::Context");
-
-Cript::Context *
-Cript::Context::Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst)
+Context *
+Context::Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst)
 {
   return THREAD_ALLOC(criptContextAllocator, this_thread(), txn_ptr, ssn_ptr, rri_ptr, inst);
 }
 
 void
-Cript::Context::Release()
+Context::Release()
 {
   THREAD_FREE(this, criptContextAllocator, this_thread());
 }
+
+} // namespace Cript

--- a/src/cripts/Crypto.cc
+++ b/src/cripts/Crypto.cc
@@ -26,7 +26,7 @@
 #define DECODED_LEN(len) (((int)ceil((len) / 1.33 + 5)) + 1)
 
 Cript::string
-Crypto::Base64::encode(Cript::string_view str)
+Crypto::Base64::Encode(Cript::string_view str)
 {
   Cript::string ret;
   size_t        encoded_len = 0;
@@ -42,7 +42,7 @@ Crypto::Base64::encode(Cript::string_view str)
 }
 
 Cript::string
-Crypto::Base64::decode(Cript::string_view str)
+Crypto::Base64::Decode(Cript::string_view str)
 {
   Cript::string ret;
   size_t        decoded_len = 0;
@@ -59,7 +59,7 @@ Crypto::Base64::decode(Cript::string_view str)
 }
 
 Cript::string
-Crypto::Escape::encode(Cript::string_view str)
+Crypto::Escape::Encode(Cript::string_view str)
 {
   static const unsigned char map[32] = {
     0xFF, 0xFF, 0xFF,
@@ -94,7 +94,7 @@ Crypto::Escape::encode(Cript::string_view str)
 }
 
 Cript::string
-Crypto::Escape::decode(Cript::string_view str)
+Crypto::Escape::Decode(Cript::string_view str)
 {
   Cript::string ret;
   size_t        decoded_len = 0;
@@ -107,7 +107,7 @@ Crypto::Escape::decode(Cript::string_view str)
 }
 
 Crypto::SHA256
-Crypto::SHA256::encode(Cript::string_view str)
+Crypto::SHA256::Encode(Cript::string_view str)
 {
   SHA256_CTX     ctx;
   Crypto::SHA256 digest;
@@ -120,7 +120,7 @@ Crypto::SHA256::encode(Cript::string_view str)
 }
 
 Crypto::SHA512
-Crypto::SHA512::encode(Cript::string_view str)
+Crypto::SHA512::Encode(Cript::string_view str)
 {
   SHA512_CTX     ctx;
   Crypto::SHA512 digest;
@@ -133,7 +133,7 @@ Crypto::SHA512::encode(Cript::string_view str)
 }
 
 Crypto::MD5
-Crypto::MD5::encode(Cript::string_view str)
+Crypto::MD5::Encode(Cript::string_view str)
 {
   MD5_CTX     ctx;
   Crypto::MD5 digest;
@@ -161,7 +161,7 @@ Crypto::detail::Cipher::_initialize()
 }
 
 void
-Crypto::detail::Cipher::encrypt(Cript::string_view str)
+Crypto::detail::Cipher::Encrypt(Cript::string_view str)
 {
   int len = 0;
 
@@ -176,7 +176,7 @@ Crypto::detail::Cipher::encrypt(Cript::string_view str)
 }
 
 Cript::string_view
-Crypto::detail::Cipher::finalize()
+Crypto::detail::Cipher::Finalize()
 {
   int len = 0;
 
@@ -192,18 +192,18 @@ Crypto::detail::Cipher::finalize()
 }
 
 Crypto::AES256
-Crypto::AES256::encrypt(Cript::string_view str, const unsigned char *key)
+Crypto::AES256::Encrypt(Cript::string_view str, const unsigned char *key)
 {
   Crypto::AES256 crypt(key);
 
-  crypt.encrypt(str);
-  crypt.finalize();
+  crypt.Encrypt(str);
+  crypt.Finalize();
 
   return crypt;
 }
 
 Crypto::HMAC::SHA256
-Crypto::HMAC::SHA256::encrypt(Cript::string_view str, const Cript::string &key)
+Crypto::HMAC::SHA256::Encrypt(Cript::string_view str, const Cript::string &key)
 {
   Crypto::HMAC::SHA256 retval;
 

--- a/src/cripts/Error.cc
+++ b/src/cripts/Error.cc
@@ -20,10 +20,10 @@
 #include "cripts/Preamble.hpp"
 
 void
-Error::execute(Cript::Context *context)
+Error::Execute(Cript::Context *context)
 {
-  if (failed()) {
-    TSHttpTxnStatusSet(context->state.txnp, _status.status());
+  if (Failed()) {
+    TSHttpTxnStatusSet(context->state.txnp, _status._getter());
     // ToDo: So we can't set the reason phrase here, because ATS doesn't have that
     // as a transaction API, only on the response header...
   }
@@ -33,19 +33,19 @@ Error::execute(Cript::Context *context)
 void
 Error::Reason::_set(Cript::Context *context, const Cript::string_view msg)
 {
-  context->state.error.fail();
-  context->state.error._reason.setter(msg);
+  context->state.error.Fail();
+  context->state.error._reason._setter(msg);
 }
 
 void
 Error::Status::_set(Cript::Context *context, TSHttpStatus status)
 {
-  context->state.error.fail();
-  context->state.error._status.setter(status);
+  context->state.error.Fail();
+  context->state.error._status._setter(status);
 }
 
 TSHttpStatus
 Error::Status::_get(Cript::Context *context)
 {
-  return context->state.error._status.getter();
+  return context->state.error._status._getter();
 }

--- a/src/cripts/Files.cc
+++ b/src/cripts/Files.cc
@@ -19,7 +19,7 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
-// Our include depedenencies are unfortunate ...
+// Our include dependencies are unfortunate ...
 extern std::string RecConfigReadConfigDir();
 
 std::filesystem::file_status
@@ -29,7 +29,7 @@ File::Status(const File::Path &path)
 }
 
 File::Path &
-File::Path::rebase()
+File::Path::Rebase()
 {
   if (std::filesystem::status(*this).type() != std::filesystem::file_type::regular) {
     *this = RecConfigReadConfigDir() + "/" + this->string();

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -263,7 +263,7 @@ Client::Request::_get(Cript::Context *context)
   if (!request->initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnClientReqGet(context->state.txnp, &request->_bufp, &request->_hdr_loc) != TS_SUCCESS) {
-      context->state.error.fail();
+      context->state.error.Fail();
     } else {
       request->initialize(&context->state); // Don't initialize unless properly setup
     }
@@ -327,7 +327,7 @@ Client::Response::_get(Cript::Context *context)
   if (!response->initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnClientRespGet(context->state.txnp, &response->_bufp, &response->_hdr_loc) != TS_SUCCESS) {
-      context->state.error.fail();
+      context->state.error.Fail();
     } else {
       response->initialize(&context->state); // Don't initialize unless properly setup
     }
@@ -349,7 +349,7 @@ Server::Request::_get(Cript::Context *context)
   if (!request->initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnServerReqGet(context->state.txnp, &request->_bufp, &request->_hdr_loc) != TS_SUCCESS) {
-      context->state.error.fail();
+      context->state.error.Fail();
     } else {
       request->initialize(&context->state); // Don't initialize unless properly setup
     }
@@ -371,7 +371,7 @@ Server::Response::_get(Cript::Context *context)
   if (!response->initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnServerRespGet(context->state.txnp, &response->_bufp, &response->_hdr_loc) != TS_SUCCESS) {
-      context->state.error.fail();
+      context->state.error.Fail();
     } else {
       response->initialize(&context->state); // Don't initialize unless properly setup
     }

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -89,7 +89,7 @@ Header::Body::operator=(Cript::string_view body)
 }
 
 Cript::string_view
-Header::Method::getSV()
+Header::Method::GetSV()
 {
   if (_method.size() == 0) {
     int         len;
@@ -102,7 +102,7 @@ Header::Method::getSV()
 }
 
 Cript::string_view
-Header::CacheStatus::getSV()
+Header::CacheStatus::GetSV()
 {
   static std::array<Cript::string_view, 4> names{
     "miss",      // TS_CACHE_LOOKUP_MISS,

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -247,9 +247,9 @@ Header::operator[](const Cript::string_view str)
     int         len   = 0;
     const char *value = TSMimeHdrFieldValueStringGet(_bufp, _hdr_loc, field_loc, -1, &len);
 
-    ret.initialize(str, Cript::string_view(value, len), this, field_loc);
+    ret._initialize(str, Cript::string_view(value, len), this, field_loc);
   } else {
-    ret.initialize(str, {}, this, nullptr);
+    ret._initialize(str, {}, this, nullptr);
   }
 
   return ret;
@@ -260,12 +260,12 @@ Client::Request::_get(Cript::Context *context)
 {
   Client::Request *request = &context->_client_req_header;
 
-  if (!request->initialized()) {
+  if (!request->Initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnClientReqGet(context->state.txnp, &request->_bufp, &request->_hdr_loc) != TS_SUCCESS) {
       context->state.error.Fail();
     } else {
-      request->initialize(&context->state); // Don't initialize unless properly setup
+      request->_initialize(&context->state); // Don't initialize unless properly setup
     }
   }
 
@@ -324,12 +324,12 @@ Client::Response::_get(Cript::Context *context)
 
   Client::Response *response = &context->_client_resp_header;
 
-  if (!response->initialized()) {
+  if (!response->Initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnClientRespGet(context->state.txnp, &response->_bufp, &response->_hdr_loc) != TS_SUCCESS) {
       context->state.error.Fail();
     } else {
-      response->initialize(&context->state); // Don't initialize unless properly setup
+      response->_initialize(&context->state); // Don't initialize unless properly setup
     }
   }
 
@@ -346,12 +346,12 @@ Server::Request::_get(Cript::Context *context)
 
   Server::Request *request = &context->_server_req_header;
 
-  if (!request->initialized()) {
+  if (!request->Initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnServerReqGet(context->state.txnp, &request->_bufp, &request->_hdr_loc) != TS_SUCCESS) {
       context->state.error.Fail();
     } else {
-      request->initialize(&context->state); // Don't initialize unless properly setup
+      request->_initialize(&context->state); // Don't initialize unless properly setup
     }
   }
 
@@ -368,12 +368,12 @@ Server::Response::_get(Cript::Context *context)
 
   Server::Response *response = &context->_server_resp_header;
 
-  if (!response->initialized()) {
+  if (!response->Initialized()) {
     TSAssert(context->state.txnp);
     if (TSHttpTxnServerRespGet(context->state.txnp, &response->_bufp, &response->_hdr_loc) != TS_SUCCESS) {
       context->state.error.Fail();
     } else {
-      response->initialize(&context->state); // Don't initialize unless properly setup
+      response->_initialize(&context->state); // Don't initialize unless properly setup
     }
   }
 

--- a/src/cripts/Instance.cc
+++ b/src/cripts/Instance.cc
@@ -21,8 +21,11 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Instance.hpp"
 
+namespace Cript
+{
+
 void
-Cript::Instance::initialize(int argc, char *argv[], const char *filename)
+Instance::_initialize(int argc, char *argv[], const char *filename)
 {
   from_url = argv[0];
   to_url   = argv[1];
@@ -50,10 +53,10 @@ Cript::Instance::initialize(int argc, char *argv[], const char *filename)
   }
 
   dbg_ctl_cript.set(plugin_debug_tag.c_str());
-}
+} // namespace Instance::_initialize(intargc,char*argv[],constchar*filename)
 
 bool
-Cript::Instance::addPlugin(const Cript::string &tag, const Cript::string &plugin, const Plugin::Options &options)
+Instance::AddPlugin(const Cript::string &tag, const Cript::string &plugin, const Plugin::Options &options)
 {
   if (plugins.find(tag) != plugins.end()) {
     return false;
@@ -66,13 +69,13 @@ Cript::Instance::addPlugin(const Cript::string &tag, const Cript::string &plugin
 
     return true;
   } else {
-    fail();
+    Fail();
     return false;
   }
 }
 
 bool
-Cript::Instance::deletePlugin(const Cript::string &tag)
+Instance::DeletePlugin(const Cript::string &tag)
 {
   auto p = plugins.find(tag);
 
@@ -84,3 +87,17 @@ Cript::Instance::deletePlugin(const Cript::string &tag)
     return false;
   }
 }
+
+void
+Instance::AddBundle(Cript::Bundle::Base *bundle)
+{
+  for (auto &it : bundles) {
+    if (it->Name() == bundle->Name()) {
+      CFatal("[Instance]: Duplicate bundle %s", bundle->Name().c_str());
+    }
+  }
+
+  bundles.push_back(bundle);
+}
+
+} // namespace Cript

--- a/src/cripts/Instance.cc
+++ b/src/cripts/Instance.cc
@@ -62,9 +62,9 @@ Instance::AddPlugin(const Cript::string &tag, const Cript::string &plugin, const
     return false;
   }
 
-  auto p = Plugin::Remap::create(tag, plugin, from_url, to_url, options);
+  auto p = Plugin::Remap::Create(tag, plugin, from_url, to_url, options);
 
-  if (p.valid()) {
+  if (p.Valid()) {
     plugins.emplace(tag, std::move(p));
 
     return true;

--- a/src/cripts/Lulu.cc
+++ b/src/cripts/Lulu.cc
@@ -50,7 +50,7 @@ global_initialization()
 #endif
 
   // Initialize various sub modules
-  Plugin::Remap::initialize();
+  Plugin::Remap::Initialize();
 }
 
 integer

--- a/src/cripts/Lulu.cc
+++ b/src/cripts/Lulu.cc
@@ -67,7 +67,7 @@ integer_helper(std::string_view sv)
 }
 
 int
-Cript::random(int max)
+Cript::Random(int max)
 {
   static std::random_device          r;
   static std::default_random_engine  e1(r());
@@ -81,7 +81,7 @@ namespace Cript::details
 
 template <typename T>
 std::vector<T>
-splitter(T input, char delim)
+Splitter(T input, char delim)
 {
   std::vector<T> output;
   size_t         first = 0;
@@ -104,25 +104,25 @@ splitter(T input, char delim)
 } // namespace Cript::details
 
 Cript::string
-Cript::hex(const Cript::string &str)
+Cript::Hex(const Cript::string &str)
 {
   return ts::hex(str);
 }
 
 Cript::string
-Cript::hex(Cript::string_view sv)
+Cript::Hex(Cript::string_view sv)
 {
   return ts::hex(sv);
 }
 
 Cript::string
-Cript::unhex(const Cript::string &str)
+Cript::UnHex(const Cript::string &str)
 {
   return ts::unhex(str);
 }
 
 Cript::string
-Cript::unhex(Cript::string_view sv)
+Cript::UnHex(Cript::string_view sv)
 {
   return ts::unhex(sv);
 }
@@ -157,13 +157,13 @@ Cript::string::operator bool() const
 std::vector<Cript::string_view>
 Cript::string::split(char delim) const &
 {
-  return details::splitter<Cript::string_view>(*this, delim);
+  return details::Splitter<Cript::string_view>(*this, delim);
 }
 
 std::vector<Cript::string_view>
-Cript::splitter(Cript::string_view input, char delim)
+Cript::Splitter(Cript::string_view input, char delim)
 {
-  return details::splitter<Cript::string_view>(input, delim);
+  return details::Splitter<Cript::string_view>(input, delim);
 }
 
 bool
@@ -176,6 +176,18 @@ void
 Control::Base::_set(Cript::Context *context, bool value)
 {
   TSHttpTxnCntlSet(context->state.txnp, _ctrl, value);
+}
+
+Cript::string_view
+Versions::GetSV()
+{
+  if (_version.length() == 0) {
+    const char *ver = TSTrafficServerVersionGet();
+
+    _version = Cript::string_view(ver, strlen(ver)); // ToDo: Annoyingly, we have ambiquity on the operator=
+  }
+
+  return _version;
 }
 
 // Globals

--- a/src/cripts/Matcher.cc
+++ b/src/cripts/Matcher.cc
@@ -41,7 +41,7 @@ Matcher::PCRE::Result::malloc(PCRE2_SIZE size, void *context)
 }
 
 void
-Matcher::PCRE::add(Cript::string_view regex, uint32_t options, bool jit)
+Matcher::PCRE::Add(Cript::string_view regex, uint32_t options, bool jit)
 {
   int         errorcode   = 0;
   PCRE2_SIZE  erroroffset = 0;
@@ -64,7 +64,7 @@ Matcher::PCRE::add(Cript::string_view regex, uint32_t options, bool jit)
 }
 
 Matcher::PCRE::Result
-Matcher::PCRE::contains(Cript::string_view subject, PCRE2_SIZE offset, uint32_t options)
+Matcher::PCRE::Contains(Cript::string_view subject, PCRE2_SIZE offset, uint32_t options)
 {
   Matcher::PCRE::Result  res(subject);
   pcre2_general_context *ctx =

--- a/src/cripts/Plugins.cc
+++ b/src/cripts/Plugins.cc
@@ -25,13 +25,13 @@
 PluginFactory gPluginFactory;
 
 void
-Plugin::Remap::initialize()
+Plugin::Remap::Initialize()
 {
   gPluginFactory.setRuntimeDir(RecConfigReadRuntimeDir()).addSearchDir(RecConfigReadPluginDir());
 }
 
 Plugin::Remap
-Plugin::Remap::create(const std::string &tag, const std::string &plugin, const Cript::string &from_url, const Cript::string &to_url,
+Plugin::Remap::Create(const std::string &tag, const std::string &plugin, const Cript::string &from_url, const Cript::string &to_url,
                       const Plugin::Options &options)
 {
   Plugin::Remap          inst;
@@ -72,7 +72,7 @@ Plugin::Remap::create(const std::string &tag, const std::string &plugin, const C
 }
 
 void
-Plugin::Remap::cleanup()
+Plugin::Remap::Cleanup()
 {
   if (_plugin) {
     _plugin->done();

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -546,9 +546,9 @@ Cache::URL::_get(Cript::Context *context)
     case TS_HTTP_READ_RESPONSE_HDR_HOOK:
     case TS_HTTP_SEND_REQUEST_HDR_HOOK:
     case TS_HTTP_TXN_CLOSE_HOOK:
-      if (TSUrlCreate(req.bufp(), &url->_urlp) == TS_SUCCESS) {
+      if (TSUrlCreate(req.BufP(), &url->_urlp) == TS_SUCCESS) {
         TSAssert(context->state.txnp);
-        if (TSHttpTxnCacheLookupUrlGet(context->state.txnp, req.bufp(), url->_urlp) == TS_SUCCESS) {
+        if (TSHttpTxnCacheLookupUrlGet(context->state.txnp, req.BufP(), url->_urlp) == TS_SUCCESS) {
           url->_initialize(&context->state, &req);
         }
       } else {
@@ -558,7 +558,7 @@ Cache::URL::_get(Cript::Context *context)
     default: { // This means we have to clone. ToDo: For now, this is implicitly using Client::URL
       Client::URL &src = Client::URL::_get(context);
 
-      if (TSUrlClone(req.bufp(), req.bufp(), src.urlp(), &url->_urlp) == TS_SUCCESS) {
+      if (TSUrlClone(req.BufP(), req.BufP(), src.urlp(), &url->_urlp) == TS_SUCCESS) {
         url->_initialize(&context->state, &req);
       } else {
         context->state.error.Fail();
@@ -606,9 +606,9 @@ Parent::URL::_get(Cript::Context *context)
     Parent::URL     *url = &context->_parent_url;
     Client::Request &req = Client::Request::_get(context); // Repurpose / create the shared request object
 
-    if (TSUrlCreate(req.bufp(), &url->_urlp) == TS_SUCCESS) {
+    if (TSUrlCreate(req.BufP(), &url->_urlp) == TS_SUCCESS) {
       TSAssert(context->state.txnp);
-      if (TSHttpTxnParentSelectionUrlGet(context->state.txnp, req.bufp(), url->_urlp) == TS_SUCCESS) {
+      if (TSHttpTxnParentSelectionUrlGet(context->state.txnp, req.BufP(), url->_urlp) == TS_SUCCESS) {
         url->_initialize(&context->state, &req);
       }
     } else {

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -582,12 +582,12 @@ Cache::URL::_update(Cript::Context *context)
     TSAssert(context->state.txnp);
     _modified = false;
     if (TS_SUCCESS == TSHttpTxnCacheLookupUrlSet(context->state.txnp, _bufp, _urlp)) {
-      if (context->p_instance.debugOn()) {
+      if (context->p_instance.DebugOn()) {
         context->p_instance.debug("Successfully setting cache-key to {}", url());
       }
       return true;
     } else {
-      if (context->p_instance.debugOn()) {
+      if (context->p_instance.DebugOn()) {
         context->p_instance.debug("Could not set the cache key to {}", url());
       }
       context->state.error.Fail();

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -455,7 +455,7 @@ Pristine::URL::_get(Cript::Context *context)
 
     TSAssert(context->state.txnp);
     if (TSHttpTxnPristineUrlGet(context->state.txnp, &url->_bufp, &url->_urlp) != TS_SUCCESS) {
-      context->state.error.fail();
+      context->state.error.Fail();
     } else {
       url->_initialize(&context->state);
     }
@@ -552,7 +552,7 @@ Cache::URL::_get(Cript::Context *context)
           url->_initialize(&context->state, &req);
         }
       } else {
-        context->state.error.fail();
+        context->state.error.Fail();
       }
       break;
     default: { // This means we have to clone. ToDo: For now, this is implicitly using Client::URL
@@ -561,7 +561,7 @@ Cache::URL::_get(Cript::Context *context)
       if (TSUrlClone(req.bufp(), req.bufp(), src.urlp(), &url->_urlp) == TS_SUCCESS) {
         url->_initialize(&context->state, &req);
       } else {
-        context->state.error.fail();
+        context->state.error.Fail();
       }
     } break;
     }
@@ -590,7 +590,7 @@ Cache::URL::_update(Cript::Context *context)
       if (context->p_instance.debugOn()) {
         context->p_instance.debug("Could not set the cache key to {}", url());
       }
-      context->state.error.fail();
+      context->state.error.Fail();
       return false;
     }
   }
@@ -612,7 +612,7 @@ Parent::URL::_get(Cript::Context *context)
         url->_initialize(&context->state, &req);
       }
     } else {
-      context->state.error.fail();
+      context->state.error.Fail();
     }
   }
 

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -430,7 +430,7 @@ Cript::Url::Matrix::operator=(Cript::string_view matrix)
 }
 
 Cript::string
-Cript::Url::Getter() const
+Cript::Url::String() const
 {
   Cript::string ret;
 
@@ -583,12 +583,12 @@ Cache::URL::_update(Cript::Context *context)
     _modified = false;
     if (TS_SUCCESS == TSHttpTxnCacheLookupUrlSet(context->state.txnp, _bufp, _urlp)) {
       if (context->p_instance.DebugOn()) {
-        context->p_instance.debug("Successfully setting cache-key to {}", Getter());
+        context->p_instance.debug("Successfully setting cache-key to {}", String());
       }
       return true;
     } else {
       if (context->p_instance.DebugOn()) {
-        context->p_instance.debug("Could not set the cache key to {}", Getter());
+        context->p_instance.debug("Could not set the cache key to {}", String());
       }
       context->state.error.Fail();
       return false;

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -21,13 +21,13 @@
 #include "cripts/Preamble.hpp"
 
 std::vector<Cript::string_view>
-Cript::Url::Component::split(const char delim)
+Cript::Url::Component::Split(const char delim)
 {
-  return Cript::splitter(getSV(), delim);
+  return Cript::Splitter(GetSV(), delim);
 }
 
 Cript::string_view
-Cript::Url::Scheme::getSV()
+Cript::Url::Scheme::GetSV()
 {
   if (_owner && _data.empty()) {
     const char *value = nullptr;
@@ -43,17 +43,17 @@ Cript::Url::Scheme::getSV()
 Cript::Url::Scheme
 Cript::Url::Scheme::operator=(Cript::string_view scheme)
 {
-  CAssert(!_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlSchemeSet(_owner->_bufp, _owner->_urlp, scheme.data(), scheme.size());
   _owner->_modified = true;
-  reset();
+  Reset();
   _loaded = false;
 
   return *this;
 }
 
 Cript::string_view
-Cript::Url::Host::getSV()
+Cript::Url::Host::GetSV()
 {
   if (_owner && _data.empty()) {
     const char *value = nullptr;
@@ -70,10 +70,10 @@ Cript::Url::Host::getSV()
 Cript::Url::Host
 Cript::Url::Host::operator=(Cript::string_view host)
 {
-  CAssert(!_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHostSet(_owner->_bufp, _owner->_urlp, host.data(), host.size());
   _owner->_modified = true;
-  reset();
+  Reset();
   _loaded = false;
 
   return *this;
@@ -91,16 +91,16 @@ Cript::Url::Port::operator integer() // This should not be explicit
 Cript::Url::Port
 Cript::Url::Port::operator=(int port)
 {
-  CAssert(!_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlPortSet(_owner->_bufp, _owner->_urlp, port);
   _owner->_modified = true;
-  reset();
+  Reset();
 
   return *this;
 }
 
 Cript::string_view
-Cript::Url::Path::getSV()
+Cript::Url::Path::GetSV()
 {
   if (_segments.size() > 0) {
     std::ostringstream path;
@@ -142,10 +142,10 @@ Cript::Url::Path::operator[](Segments::size_type ix)
 Cript::Url::Path
 Cript::Url::Path::operator=(Cript::string_view path)
 {
-  CAssert(!_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlPathSet(_owner->_bufp, _owner->_urlp, path.data(), path.size());
   _owner->_modified = true;
-  reset();
+  Reset();
   _loaded = false;
 
   return *this;
@@ -157,7 +157,7 @@ Cript::Url::Path::operator+=(Cript::string_view add)
   Cript::string str;
 
   if (add.size() > 0) {
-    str.assign(getSV());
+    str.assign(GetSV());
     str += add;
     operator=(str);
   }
@@ -168,7 +168,7 @@ Cript::Url::Path::operator+=(Cript::string_view add)
 Cript::Url::Path::String &
 Cript::Url::Path::String::operator=(const Cript::string_view str)
 {
-  CAssert(!_owner->_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->_owner->ReadOnly()); // This can not be a read-only URL
   _owner->_size          -= _owner->_segments[_ix].size();
   _owner->_segments[_ix]  = str;
   _owner->_size          += str.size();
@@ -178,9 +178,9 @@ Cript::Url::Path::String::operator=(const Cript::string_view str)
 }
 
 void
-Cript::Url::Path::reset()
+Cript::Url::Path::Reset()
 {
-  Component::reset();
+  Component::Reset();
 
   _segments.clear();
   _storage  = "";
@@ -189,7 +189,7 @@ Cript::Url::Path::reset()
 }
 
 void
-Cript::Url::Path::push(Cript::string_view val)
+Cript::Url::Path::Push(Cript::string_view val)
 {
   _parser();
   _modified = true;
@@ -197,7 +197,7 @@ Cript::Url::Path::push(Cript::string_view val)
 }
 
 void
-Cript::Url::Path::insert(Segments::size_type ix, Cript::string_view val)
+Cript::Url::Path::Insert(Segments::size_type ix, Cript::string_view val)
 {
   _parser();
   _modified = true;
@@ -208,14 +208,14 @@ void
 Cript::Url::Path::_parser()
 {
   if (_segments.size() == 0) {
-    _segments = split('/');
+    _segments = Split('/');
   }
 }
 
 Cript::Url::Query::Parameter &
 Cript::Url::Query::Parameter::operator=(const Cript::string_view str)
 {
-  CAssert(!_owner->_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->_owner->ReadOnly()); // This can not be a read-only URL
   auto iter = _owner->_hashed.find(_name);
 
   if (iter != _owner->_hashed.end()) {
@@ -230,7 +230,7 @@ Cript::Url::Query::Parameter::operator=(const Cript::string_view str)
 }
 
 Cript::string_view
-Cript::Url::Query::getSV()
+Cript::Url::Query::GetSV()
 {
   if (_ordered.size() > 0) {
     _storage.clear();
@@ -275,10 +275,10 @@ Cript::Url::Query::getSV()
 Cript::Url::Query
 Cript::Url::Query::operator=(Cript::string_view query)
 {
-  CAssert(!_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHttpQuerySet(_owner->_bufp, _owner->_urlp, query.data(), query.size());
   _owner->_modified = true;
-  reset();
+  Reset();
   _loaded = false;
 
   return *this;
@@ -290,7 +290,7 @@ Cript::Url::Query::operator+=(Cript::string_view add)
   Cript::string str;
 
   if (add.size() > 0) {
-    str.assign(getSV());
+    str.assign(GetSV());
     str += add;
     operator=(str);
   }
@@ -317,7 +317,7 @@ Cript::Url::Query::operator[](Cript::string_view param)
 }
 
 void
-Cript::Url::Query::erase(Cript::string_view param)
+Cript::Url::Query::Erase(Cript::string_view param)
 {
   // Make sure the hash and vector are populated
   _parser();
@@ -334,14 +334,14 @@ Cript::Url::Query::erase(Cript::string_view param)
     _ordered.erase(viter);
 
     if (_ordered.size() == 0) {
-      reset();
+      Reset();
     }
     _modified = true; // Make sure to set this after we reset above ...
   }
 }
 
 void
-Cript::Url::Query::erase(std::initializer_list<Cript::string_view> list, bool keep)
+Cript::Url::Query::Erase(std::initializer_list<Cript::string_view> list, bool keep)
 {
   if (keep) {
     // Make sure the hash and vector are populated
@@ -362,19 +362,19 @@ Cript::Url::Query::erase(std::initializer_list<Cript::string_view> list, bool ke
       }
     }
     if (_ordered.size() == 0) {
-      reset();
+      Reset();
     }
   } else {
     for (auto &it : list) {
-      erase(it);
+      Erase(it);
     }
   }
 }
 
 void
-Cript::Url::Query::reset()
+Cript::Url::Query::Reset()
 {
-  Component::reset();
+  Component::Reset();
 
   _ordered.clear();
   _hashed.clear();
@@ -387,7 +387,7 @@ void
 Cript::Url::Query::_parser()
 {
   if (_ordered.size() == 0) {
-    for (const auto sv : split('&')) {
+    for (const auto sv : Split('&')) {
       const auto         eq  = sv.find_first_of('=');
       Cript::string_view key = sv.substr(0, eq);
       Cript::string_view val;
@@ -403,7 +403,7 @@ Cript::Url::Query::_parser()
 }
 
 Cript::string_view
-Cript::Url::Matrix::getSV()
+Cript::Url::Matrix::GetSV()
 {
   if (_owner && _data.empty()) {
     const char *value = nullptr;
@@ -420,17 +420,17 @@ Cript::Url::Matrix::getSV()
 Cript::Url::Matrix
 Cript::Url::Matrix::operator=(Cript::string_view matrix)
 {
-  CAssert(!_owner->readOnly()); // This can not be a read-only URL
+  CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHttpParamsSet(_owner->_bufp, _owner->_urlp, matrix.data(), matrix.size());
   _owner->_modified = true;
-  reset();
+  Reset();
   _loaded = false;
 
   return *this;
 }
 
 Cript::string
-Cript::Url::url() const
+Cript::Url::Getter() const
 {
   Cript::string ret;
 
@@ -450,7 +450,7 @@ Cript::Url::url() const
 Pristine::URL &
 Pristine::URL::_get(Cript::Context *context)
 {
-  if (!context->_pristine_url.initialized()) {
+  if (!context->_pristine_url.Initialized()) {
     Pristine::URL *url = &context->_pristine_url;
 
     TSAssert(context->state.txnp);
@@ -477,7 +477,7 @@ Client::URL::_initialize(Cript::Context *context)
 Client::URL &
 Client::URL::_get(Cript::Context *context)
 {
-  if (!context->_client_url.initialized()) {
+  if (!context->_client_url.Initialized()) {
     context->_client_url._initialize(context);
   }
 
@@ -487,8 +487,8 @@ Client::URL::_get(Cript::Context *context)
 bool
 Client::URL::_update(Cript::Context * /* context ATS_UNUSED */)
 {
-  path.flush();
-  query.flush();
+  path.Flush();
+  query.Flush();
 
   return _modified;
 }
@@ -506,7 +506,7 @@ Remap::From::URL::_initialize(Cript::Context *context)
 Remap::From::URL &
 Remap::From::URL::_get(Cript::Context *context)
 {
-  if (!context->_remap_from_url.initialized()) {
+  if (!context->_remap_from_url.Initialized()) {
     context->_remap_from_url._initialize(context);
   }
 
@@ -526,7 +526,7 @@ Remap::To::URL::_initialize(Cript::Context *context)
 Remap::To::URL &
 Remap::To::URL::_get(Cript::Context *context)
 {
-  if (!context->_remap_to_url.initialized()) {
+  if (!context->_remap_to_url.Initialized()) {
     context->_remap_to_url._initialize(context);
   }
 
@@ -536,7 +536,7 @@ Remap::To::URL::_get(Cript::Context *context)
 Cache::URL &
 Cache::URL::_get(Cript::Context *context)
 {
-  if (!context->_cache_url.initialized()) {
+  if (!context->_cache_url.Initialized()) {
     Cache::URL      *url = &context->_cache_url;
     Client::Request &req = Client::Request::_get(context); // Repurpose / create the shared request object
 
@@ -558,7 +558,7 @@ Cache::URL::_get(Cript::Context *context)
     default: { // This means we have to clone. ToDo: For now, this is implicitly using Client::URL
       Client::URL &src = Client::URL::_get(context);
 
-      if (TSUrlClone(req.BufP(), req.BufP(), src.urlp(), &url->_urlp) == TS_SUCCESS) {
+      if (TSUrlClone(req.BufP(), req.BufP(), src.UrlP(), &url->_urlp) == TS_SUCCESS) {
         url->_initialize(&context->state, &req);
       } else {
         context->state.error.Fail();
@@ -575,20 +575,20 @@ bool
 Cache::URL::_update(Cript::Context *context)
 {
   // For correctness, we will also make sure the Path and Query objects are flushed
-  path.flush();
-  query.flush();
+  path.Flush();
+  query.Flush();
 
   if (_modified) {
     TSAssert(context->state.txnp);
     _modified = false;
     if (TS_SUCCESS == TSHttpTxnCacheLookupUrlSet(context->state.txnp, _bufp, _urlp)) {
       if (context->p_instance.DebugOn()) {
-        context->p_instance.debug("Successfully setting cache-key to {}", url());
+        context->p_instance.debug("Successfully setting cache-key to {}", Getter());
       }
       return true;
     } else {
       if (context->p_instance.DebugOn()) {
-        context->p_instance.debug("Could not set the cache key to {}", url());
+        context->p_instance.debug("Could not set the cache key to {}", Getter());
       }
       context->state.error.Fail();
       return false;
@@ -602,7 +602,7 @@ Cache::URL::_update(Cript::Context *context)
 Parent::URL &
 Parent::URL::_get(Cript::Context *context)
 {
-  if (!context->_cache_url.initialized()) {
+  if (!context->_cache_url.Initialized()) {
     Parent::URL     *url = &context->_parent_url;
     Client::Request &req = Client::Request::_get(context); // Repurpose / create the shared request object
 


### PR DESCRIPTION
This changes all public methods to be Pascal Case, a change necessary to better avoid namespace conflicts.

It also cleans up a few things that were odd or poorly implemented before, discovered while refactoring.