### PR TITLE
Update code and build scripts to use latest quiche(0.22.0) release.

### DIFF
--- a/include/iocore/net/quic/QUICStream.h
+++ b/include/iocore/net/quic/QUICStream.h
@@ -42,6 +42,8 @@ class QUICStreamStateListener;
 class QUICStream
 {
 public:
+  using ErrorCode = uint64_t; //!<  recv/send stream application error codes.
+
   QUICStream() {}
   QUICStream(QUICConnectionInfoProvider *cinfo, QUICStreamId sid);
   ~QUICStream();

--- a/tools/build_boringssl_h3_tools.sh
+++ b/tools/build_boringssl_h3_tools.sh
@@ -168,12 +168,14 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone  https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.21.0
+git checkout 0.22.0
 QUICHE_BSSL_PATH=${BORINGSSL_LIB_PATH} QUICHE_BSSL_LINK_KIND=dylib cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
 sudo mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 sudo mkdir -p ${QUICHE_BASE}/include
 sudo cp target/release/libquiche.a ${QUICHE_BASE}/lib/
 [ -f target/release/libquiche.so ] && sudo cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+# Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+sudo ln -s ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
 sudo cp quiche/include/quiche.h ${QUICHE_BASE}/include/
 sudo cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
 sudo chmod -R a+rX ${BASE}

--- a/tools/build_openssl_h3_tools.sh
+++ b/tools/build_openssl_h3_tools.sh
@@ -120,7 +120,7 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.21.0
+git checkout 0.22.0
 
 PKG_CONFIG_PATH="$OPENSSL_LIB"/pkgconfig LD_LIBRARY_PATH="$OPENSSL_LIB" \
   cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog,openssl
@@ -129,6 +129,8 @@ sudo mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 sudo mkdir -p ${QUICHE_BASE}/include
 sudo cp target/release/libquiche.a ${QUICHE_BASE}/lib/
 [ -f target/release/libquiche.so ] && sudo cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+# Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+sudo ln -s ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
 sudo cp quiche/include/quiche.h ${QUICHE_BASE}/include/
 sudo cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
 sudo chmod -R a+rX ${BASE}


### PR DESCRIPTION
This bumps the quiche version from the build deps scripts and update the code to use latest quiche version which changed some of their API:

- `quiche_conn_stream_recv`
- `quiche_conn_stream_send`

which now takes an extra param to get the  stream application error codes(if any).

Note:
`error_code` is not used for now. A new PR should add logic to deal with this outcome.

PS: **: This needs CI to update quiche to 0.22.0**. CI will fail till then.


fixes: https://github.com/apache/trafficserver/issues/11486