### PR TITLE
Enable receiving large H3 frames

### DIFF
--- a/include/proxy/http3/Http3Frame.h
+++ b/include/proxy/http3/Http3Frame.h
@@ -50,16 +50,16 @@ public:
   static Http3FrameType      type(const uint8_t *buf, size_t buf_len);
 
 protected:
-  IOBufferReader *_reader;
+  IOBufferReader *_reader           = nullptr;
   bool            _finished_reading = false;
   uint64_t        _length           = 0;
   Http3FrameType  _type             = Http3FrameType::UNKNOWN;
   size_t          _payload_offset   = 0;
+  bool            _is_valid         = true;
 
   virtual bool _parse();
 
 private:
-  bool _is_valid = true;
   bool _is_ready = false;
 };
 
@@ -149,7 +149,6 @@ public:
   Ptr<IOBufferBlock> to_io_buffer_block() const override;
   void               reset(IOBufferReader &reader) override;
 
-  bool           is_valid() const;
   Http3ErrorUPtr get_error() const;
 
   bool     contains(Http3SettingsId id) const;
@@ -162,10 +161,8 @@ protected:
 private:
   uint32_t                            _max_settings = 0;
   std::map<Http3SettingsId, uint64_t> _settings;
-  // TODO: make connection error with HTTP_MALFORMED_FRAME
-  bool           _valid = false;
-  Http3ErrorCode _error_code;
-  const char    *_error_reason = nullptr;
+  Http3ErrorCode                      _error_code;
+  const char                         *_error_reason = nullptr;
 };
 
 using Http3FrameDeleterFunc  = void (*)(Http3Frame *p);

--- a/include/proxy/http3/Http3Frame.h
+++ b/include/proxy/http3/Http3Frame.h
@@ -35,29 +35,39 @@ public:
   constexpr static size_t MAX_FRAM_HEADER_OVERHEAD = 128; ///< Type (i) + Length (i)
 
   Http3Frame() {}
-  Http3Frame(const uint8_t *buf, size_t len);
+  Http3Frame(IOBufferReader &reader);
   Http3Frame(Http3FrameType type);
-  virtual ~Http3Frame() {}
+  virtual ~Http3Frame();
 
+  bool                       is_valid() const;
   uint64_t                   total_length() const;
   uint64_t                   length() const;
   Http3FrameType             type() const;
+  bool                       update();
   virtual Ptr<IOBufferBlock> to_io_buffer_block() const;
-  virtual void               reset(const uint8_t *buf, size_t len);
+  virtual void               reset(IOBufferReader &reader);
   static int                 length(const uint8_t *buf, size_t buf_len, uint64_t &length);
   static Http3FrameType      type(const uint8_t *buf, size_t buf_len);
 
 protected:
-  uint64_t       _length         = 0;
-  Http3FrameType _type           = Http3FrameType::UNKNOWN;
-  size_t         _payload_offset = 0;
+  IOBufferReader *_reader;
+  bool            _finished_reading = false;
+  uint64_t        _length           = 0;
+  Http3FrameType  _type             = Http3FrameType::UNKNOWN;
+  size_t          _payload_offset   = 0;
+
+  virtual bool _parse();
+
+private:
+  bool _is_valid = true;
+  bool _is_ready = false;
 };
 
 class Http3UnknownFrame : public Http3Frame
 {
 public:
   Http3UnknownFrame() : Http3Frame() {}
-  Http3UnknownFrame(const uint8_t *buf, size_t len);
+  Http3UnknownFrame(IOBufferReader &reader);
 
   Ptr<IOBufferBlock> to_io_buffer_block() const override;
 
@@ -74,14 +84,16 @@ class Http3DataFrame : public Http3Frame
 {
 public:
   Http3DataFrame() : Http3Frame() {}
-  Http3DataFrame(const uint8_t *buf, size_t len);
+  Http3DataFrame(IOBufferReader &reader);
   Http3DataFrame(ats_unique_buf payload, size_t payload_len);
 
   Ptr<IOBufferBlock> to_io_buffer_block() const override;
-  void               reset(const uint8_t *buf, size_t len) override;
+  void               reset(IOBufferReader &reader) override;
 
   const uint8_t *payload() const;
   uint64_t       payload_length() const;
+
+  IOBufferReader *data() const;
 
 private:
   const uint8_t *_payload      = nullptr;
@@ -97,17 +109,21 @@ class Http3HeadersFrame : public Http3Frame
 {
 public:
   Http3HeadersFrame() : Http3Frame() {}
-  Http3HeadersFrame(const uint8_t *buf, size_t len);
+  Http3HeadersFrame(IOBufferReader &reader);
   Http3HeadersFrame(ats_unique_buf header_block, size_t header_block_len);
+  ~Http3HeadersFrame();
 
   Ptr<IOBufferBlock> to_io_buffer_block() const override;
-  void               reset(const uint8_t *buf, size_t len) override;
+  void               reset(IOBufferReader &reader) override;
 
   const uint8_t *header_block() const;
   uint64_t       header_block_length() const;
 
+protected:
+  bool _parse() override;
+
 private:
-  const uint8_t *_header_block      = nullptr;
+  uint8_t       *_header_block      = nullptr;
   ats_unique_buf _header_block_uptr = {nullptr};
   size_t         _header_block_len  = 0;
 };
@@ -120,7 +136,7 @@ class Http3SettingsFrame : public Http3Frame
 {
 public:
   Http3SettingsFrame() : Http3Frame(Http3FrameType::SETTINGS) {}
-  Http3SettingsFrame(const uint8_t *buf, size_t len, uint32_t max_settings = 0);
+  Http3SettingsFrame(IOBufferReader &reader, uint32_t max_settings = 0);
 
   static constexpr size_t                         MAX_PAYLOAD_SIZE = 60;
   static constexpr std::array<Http3SettingsId, 4> VALID_SETTINGS_IDS{
@@ -131,7 +147,7 @@ public:
   };
 
   Ptr<IOBufferBlock> to_io_buffer_block() const override;
-  void               reset(const uint8_t *buf, size_t len) override;
+  void               reset(IOBufferReader &reader) override;
 
   bool           is_valid() const;
   Http3ErrorUPtr get_error() const;
@@ -140,7 +156,11 @@ public:
   uint64_t get(Http3SettingsId id) const;
   void     set(Http3SettingsId id, uint64_t value);
 
+protected:
+  bool _parse() override;
+
 private:
+  uint32_t                            _max_settings = 0;
   std::map<Http3SettingsId, uint64_t> _settings;
   // TODO: make connection error with HTTP_MALFORMED_FRAME
   bool           _valid = false;
@@ -217,14 +237,13 @@ public:
   /*
    * This is used for creating a Http3Frame object based on received data.
    */
-  static Http3FrameUPtr create(const uint8_t *buf, size_t len);
+  static Http3FrameUPtr create(IOBufferReader &reader);
 
   /*
    * This works almost the same as create() but it reuses created objects for performance.
    * If you create a frame object which has the same frame type that you created before, the object will be reset by new data.
    */
-  std::shared_ptr<const Http3Frame> fast_create(IOBufferReader &reader, size_t frame_len);
-  std::shared_ptr<const Http3Frame> fast_create(const uint8_t *buf, size_t len);
+  std::shared_ptr<Http3Frame> fast_create(IOBufferReader &reader);
 
   /*
    * Creates a HEADERS frame.

--- a/include/proxy/http3/Http3FrameDispatcher.h
+++ b/include/proxy/http3/Http3FrameDispatcher.h
@@ -47,6 +47,8 @@ private:
   int64_t                          _reading_frame_type_len;
   int64_t                          _reading_frame_length_len;
   uint64_t                         _reading_frame_payload_len;
+  uint64_t                         _bytes_to_skip;
   Http3FrameFactory                _frame_factory;
+  std::shared_ptr<Http3Frame>      _current_frame = nullptr;
   std::vector<Http3FrameHandler *> _handlers[256];
 };

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -328,7 +328,7 @@ Http3HeadersFrame::_parse()
 
   this->_header_block_len = this->_length;
   this->_header_block     = static_cast<uint8_t *>(ats_malloc(this->_header_block_len));
-  this->_reader->memcpy(this->_header_block);
+  this->_reader->memcpy(this->_header_block, this->_header_block_len);
 
   return true;
 }
@@ -432,7 +432,7 @@ Http3SettingsFrame::_parse()
   }
 
   uint8_t *buf = static_cast<uint8_t *>(ats_malloc(this->_length));
-  this->_reader->memcpy(buf);
+  this->_reader->memcpy(buf, this->_length);
 
   size_t   len       = 0;
   uint32_t nsettings = 0;

--- a/src/proxy/http3/Http3StreamDataVIOAdaptor.cc
+++ b/src/proxy/http3/Http3StreamDataVIOAdaptor.cc
@@ -45,8 +45,8 @@ Http3StreamDataVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame,
   const Http3DataFrame *dframe = dynamic_cast<const Http3DataFrame *>(frame.get());
 
   // Need to wait for headers to be written
-  this->_buffer->write(dframe->payload(), dframe->payload_length());
-  this->_total_data_length += dframe->payload_length();
+  int64_t written           = this->_buffer->write(dframe->data());
+  this->_total_data_length += written;
 
   return Http3ErrorUPtr(nullptr);
 }


### PR DESCRIPTION
This closes #9797.

The fundamental issue is that an array is passed when `Http3Frame` instances are created for receiving frames. This means that we have to store a whole frame data in an array and the size is 64k on current code. Since the size of an H3 frame can be tera bytes, this does not work. Also, there was a bug that the array to store frame data is on stack and it was used from out of the scope. This caused autest failure on some environments.

The main change on this PR is to change the constructor of `Http3Frame` from `Http3Frame(const uint8_t *buf, size_t len)` to  `Http3Frame(IOBufferReader &reader)`. The one for sending frames remains as is for now.

`H3FrameDispatcher` creates a frame only when it receives a frame header, and invokes frame handlers with the same frame if new data for the frame arrives, until it receives the last chunk of the frame.

The frame parsers could be optimized for `IOBufferReader`, but I'd like to remove the limitation and the bug on this PR.