### PR TITLE
wasm plugin: provide defaults for struct SanitizationConfig

### DIFF
--- a/plugins/experimental/wasm/lib/include/proxy-wasm/wasm.h
+++ b/plugins/experimental/wasm/lib/include/proxy-wasm/wasm.h
@@ -40,8 +40,8 @@ using WasmVmFactory = std::function<std::unique_ptr<WasmVm>()>;
 using CallOnThreadFunction = std::function<void(std::function<void()>)>;
 
 struct SanitizationConfig {
-  std::vector<std::string> argument_list;
-  bool is_allowlist;
+  std::vector<std::string> argument_list{};
+  bool is_allowlist{false};
 };
 using AllowedCapabilitiesMap = std::unordered_map<std::string, SanitizationConfig>;
 


### PR DESCRIPTION
This should resolve gcc release build warnings for fedora and rocky9.