### PR TITLE
Lowercase the headers appended by ja3_fingerprint

### DIFF
--- a/plugins/ja3_fingerprint/ja3_fingerprint.cc
+++ b/plugins/ja3_fingerprint/ja3_fingerprint.cc
@@ -252,11 +252,11 @@ modify_ja3_headers(TSCont contp, TSHttpTxn txnp, ja3_data const *ja3_vconn_data)
   }
 
   // Add JA3 md5 fingerprints
-  append_to_field(bufp, hdr_loc, "X-JA3-Sig", 9, ja3_vconn_data->md5_string, 32);
+  append_to_field(bufp, hdr_loc, "x-ja3-sig", 9, ja3_vconn_data->md5_string, 32);
 
   // If raw string is configured, added JA3 raw string to header as well
   if (raw_flag) {
-    append_to_field(bufp, hdr_loc, "x-JA3-RAW", 9, ja3_vconn_data->ja3_string.data(), ja3_vconn_data->ja3_string.size());
+    append_to_field(bufp, hdr_loc, "x-ja3-raw", 9, ja3_vconn_data->ja3_string.data(), ja3_vconn_data->ja3_string.size());
   }
   TSHandleMLocRelease(bufp, TS_NULL_MLOC, hdr_loc);
 

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-client.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-client.gold
@@ -5,6 +5,6 @@ host: ``
 content-length: ``
 x-request: ``
 uuid: ``
-X-JA3-Sig: ``
-x-JA3-RAW: ``
+x-ja3-sig: ``
+x-ja3-raw: ``
 ``

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-proxy.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-proxy.gold
@@ -5,5 +5,5 @@ Host: ``
 Content-Type: ``
 uuid: ``
 x-request: ``
-X-JA3-Sig: ``
+x-ja3-sig: ``
 ``

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-proxy.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-proxy.gold
@@ -9,5 +9,5 @@ Client-ip: ``
 X-Forwarded-For: ``
 Via: ``
 Transfer-Encoding: ``
-X-JA3-Sig: ``
+x-ja3-sig: ``
 ``


### PR DESCRIPTION
The headers should already be lowercased by ATS as is required for HTTP/2, and comparisons should be case-insensitive; this is purely a cosmetic change.