### PR TITLE
No remap rules matched metric

### DIFF
--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -125,7 +125,7 @@ struct HttpStatsBlock {
   Metrics::Counter::AtomicType *misc_origin_server_bytes;
   Metrics::Counter::AtomicType *misc_user_agent_bytes;
   Metrics::Counter::AtomicType *missing_host_hdr;
-  Metrics::Counter::AtomicType *no_remap_404;
+  Metrics::Counter::AtomicType *no_remap_matched;
   Metrics::Counter::AtomicType *options_requests;
   Metrics::Counter::AtomicType *origin_body;
   Metrics::Counter::AtomicType *origin_close_private;

--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -125,6 +125,7 @@ struct HttpStatsBlock {
   Metrics::Counter::AtomicType *misc_origin_server_bytes;
   Metrics::Counter::AtomicType *misc_user_agent_bytes;
   Metrics::Counter::AtomicType *missing_host_hdr;
+  Metrics::Counter::AtomicType *no_remap_404;
   Metrics::Counter::AtomicType *options_requests;
   Metrics::Counter::AtomicType *origin_body;
   Metrics::Counter::AtomicType *origin_close_private;

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -335,7 +335,7 @@ register_stat_callbacks()
   http_rsb.misc_origin_server_bytes          = Metrics::Counter::createPtr("proxy.process.http.http_misc_origin_server_bytes");
   http_rsb.misc_user_agent_bytes             = Metrics::Counter::createPtr("proxy.process.http.misc_user_agent_bytes");
   http_rsb.missing_host_hdr                  = Metrics::Counter::createPtr("proxy.process.http.missing_host_hdr");
-  http_rsb.no_remap_404                      = Metrics::Counter::createPtr("proxy.process.http.no_remap_matched_404");
+  http_rsb.no_remap_matched                  = Metrics::Counter::createPtr("proxy.process.http.no_remap_matched");
   http_rsb.options_requests                  = Metrics::Counter::createPtr("proxy.process.http.options_requests");
   http_rsb.origin_body                       = Metrics::Counter::createPtr("proxy.process.http.origin.body");
   http_rsb.origin_close_private              = Metrics::Counter::createPtr("proxy.process.http.origin.close_private");

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -335,6 +335,7 @@ register_stat_callbacks()
   http_rsb.misc_origin_server_bytes          = Metrics::Counter::createPtr("proxy.process.http.http_misc_origin_server_bytes");
   http_rsb.misc_user_agent_bytes             = Metrics::Counter::createPtr("proxy.process.http.misc_user_agent_bytes");
   http_rsb.missing_host_hdr                  = Metrics::Counter::createPtr("proxy.process.http.missing_host_hdr");
+  http_rsb.no_remap_404                      = Metrics::Counter::createPtr("proxy.process.http.no_remap_matched_404");
   http_rsb.options_requests                  = Metrics::Counter::createPtr("proxy.process.http.options_requests");
   http_rsb.origin_body                       = Metrics::Counter::createPtr("proxy.process.http.origin.body");
   http_rsb.origin_close_private              = Metrics::Counter::createPtr("proxy.process.http.origin.close_private");

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4404,7 +4404,7 @@ HttpSM::do_remap_request(bool run_inline)
 
   if (!ret) {
     SMDbg(dbg_ctl_url_rewrite, "Could not find a valid remapping entry for this request");
-    Metrics::Counter::increment(http_rsb.no_remap_404);
+    Metrics::Counter::increment(http_rsb.no_remap_matched);
     if (!run_inline) {
       handleEvent(EVENT_REMAP_COMPLETE, nullptr);
     }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4404,6 +4404,7 @@ HttpSM::do_remap_request(bool run_inline)
 
   if (!ret) {
     SMDbg(dbg_ctl_url_rewrite, "Could not find a valid remapping entry for this request");
+    Metrics::Counter::increment(http_rsb.no_remap_404);
     if (!run_inline) {
       handleEvent(EVENT_REMAP_COMPLETE, nullptr);
     }


### PR DESCRIPTION
Add metric when none of the remap rules matched to client request and ATS returns 404