### PR TITLE
Fix incorrect metric for agg_copy bytes written

### DIFF
--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -734,10 +734,9 @@ Stripe::_agg_copy(CacheVC *vc)
         ProxyMutex *mutex ATS_UNUSED = this->mutex.get();
         ink_assert(mutex->thread_holding == this_ethread());
 
-// ToDo: Why are these for debug only ?
 #ifdef DEBUG
-        Metrics::Counter::increment(cache_rsb.write_backlog_failure);
-        Metrics::Counter::increment(this->cache_vol->vol_rsb.write_backlog_failure);
+        Metrics::Counter::increment(cache_rsb.write_bytes, vc->write_len);
+        Metrics::Counter::increment(this->cache_vol->vol_rsb.write_bytes, vc->write_len);
 #endif
       }
       if (vc->f.rewrite_resident_alt) {

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -107,11 +107,11 @@ attach_tmpfile_to_stripe(Stripe &stripe)
 static std::FILE *
 init_stripe_for_writing(Stripe &stripe, StripteHeaderFooter &header, CacheVol &cache_vol)
 {
-  stripe.cache_vol                                = &cache_vol;
-  cache_rsb.write_backlog_failure                 = Metrics::Counter::createPtr("unit_test.write.backlog.failure");
-  stripe.cache_vol->vol_rsb.write_backlog_failure = Metrics::Counter::createPtr("unit_test.write.backlog.failure");
-  cache_rsb.gc_frags_evacuated                    = Metrics::Counter::createPtr("unit_test.gc.frags.evacuated");
-  stripe.cache_vol->vol_rsb.gc_frags_evacuated    = Metrics::Counter::createPtr("unit_test.gc.frags.evacuated");
+  stripe.cache_vol                             = &cache_vol;
+  cache_rsb.write_bytes                        = Metrics::Counter::createPtr("unit_test.write.bytes");
+  stripe.cache_vol->vol_rsb.write_bytes        = Metrics::Counter::createPtr("unit_test.write.bytes");
+  cache_rsb.gc_frags_evacuated                 = Metrics::Counter::createPtr("unit_test.gc.frags.evacuated");
+  stripe.cache_vol->vol_rsb.gc_frags_evacuated = Metrics::Counter::createPtr("unit_test.gc.frags.evacuated");
 
   // A number of things must be initialized in a certain way for Stripe
   // not to segfault, hit an assertion, or exhibit zero-division.


### PR DESCRIPTION
We introduced an issue in f23826d where we count backlog failures when copying bytes to the aggregation buffer. The original, intended behavior, was to count the number of bytes copied. This restores the original behavior.

Fixes #11457.