### PR TITLE
Promote write_bytes and gc_frags_evacuated metrics

### DIFF
--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -734,10 +734,8 @@ Stripe::_agg_copy(CacheVC *vc)
         ProxyMutex *mutex ATS_UNUSED = this->mutex.get();
         ink_assert(mutex->thread_holding == this_ethread());
 
-#ifdef DEBUG
         Metrics::Counter::increment(cache_rsb.write_bytes, vc->write_len);
         Metrics::Counter::increment(this->cache_vol->vol_rsb.write_bytes, vc->write_len);
-#endif
       }
       if (vc->f.rewrite_resident_alt) {
         iobufferblock_memcpy(doc->data(), vc->write_len, res_alt_blk, 0);
@@ -776,10 +774,8 @@ Stripe::_agg_copy(CacheVC *vc)
     Doc *doc = reinterpret_cast<Doc *>(vc->buf->data());
     int  l   = this->round_to_approx_size(doc->len);
 
-#ifdef DEBUG
     Metrics::Counter::increment(cache_rsb.gc_frags_evacuated);
     Metrics::Counter::increment(this->cache_vol->vol_rsb.gc_frags_evacuated);
-#endif
 
     doc->sync_serial  = this->header->sync_serial;
     doc->write_serial = this->header->write_serial;


### PR DESCRIPTION
These metrics will now show up in release builds. As these were the only metrics that are debug-only, everything will now be more consistent and mistakes and unexpected behavior will be less likely.

The per stripe write_bytes metric counts the number of non-evacuated bytes written to the aggregation buffer. The number of bytes written to the stripe on disk may be larger because it includes evacuated documents. The volume metric counts the total across all stripes.

The gc_frags_evacuated metric behaves similarly to the above, but counts the number of evacuated documents written to the aggregation buffer.