### PR TITLE
Prioritize the library path for SSL library

### DIFF
--- a/doc/developer-guide/plugins/building-plugins.en.rst
+++ b/doc/developer-guide/plugins/building-plugins.en.rst
@@ -52,7 +52,8 @@ This example ``CMakeLists.txt`` finds the tsapi package which provides the
 plugins module .so.  The function takes the plugin target name and a list of
 source files that make up the project.  If the plugin requires additional
 libraries, those can be linked with the ``target_link_libraries`` cmake
-function.
+function. If your plugin links OpenSSL (or the alternatives), put it in the
+beginning part of the list to avoid link issues.
 
 After the plugin target is created, a verify test target can be created.  This
 will add a cmake test declaration and at test time, will run traffic_server in

--- a/plugins/experimental/access_control/CMakeLists.txt
+++ b/plugins/experimental/access_control/CMakeLists.txt
@@ -28,7 +28,7 @@ add_atsplugin(
   utils.cc
 )
 
-target_link_libraries(access_control PRIVATE PCRE::PCRE OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(access_control PRIVATE OpenSSL::SSL OpenSSL::Crypto PCRE::PCRE)
 
 verify_remap_plugin(access_control)
 

--- a/plugins/experimental/magick/CMakeLists.txt
+++ b/plugins/experimental/magick/CMakeLists.txt
@@ -20,7 +20,7 @@ add_atsplugin(magick magick.cc)
 # This creates the magic import target if necessary (older cmake)
 include(magick_target)
 
-target_link_libraries(magick PRIVATE ImageMagick::MagickWand ImageMagick::MagickCore ts::tscppapi OpenSSL::Crypto)
+target_link_libraries(magick PRIVATE OpenSSL::Crypto ImageMagick::MagickWand ImageMagick::MagickCore ts::tscppapi)
 
 # There is a periodic issue with asan errors and imagemagick so disable this test for asan builds to reduce noise
 if(NOT ENABLE_ASAN)

--- a/plugins/experimental/sslheaders/CMakeLists.txt
+++ b/plugins/experimental/sslheaders/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties(sslhdr PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(BUILD_TESTING)
   add_executable(test_sslhdr unit_tests/unit_test_main.cc unit_tests/test_sslheaders.cc)
-  target_link_libraries(test_sslhdr PRIVATE sslhdr catch2::catch2 OpenSSL::SSL libswoc::libswoc)
+  target_link_libraries(test_sslhdr PRIVATE sslhdr OpenSSL::SSL catch2::catch2 libswoc::libswoc)
 endif()
 
 add_atsplugin(sslheaders sslheaders.cc)

--- a/plugins/experimental/stek_share/CMakeLists.txt
+++ b/plugins/experimental/stek_share/CMakeLists.txt
@@ -18,7 +18,7 @@
 if(nuraft_FOUND)
   add_atsplugin(stek_share common.cc log_store.cc stek_share.cc stek_utils.cc)
 
-  target_link_libraries(stek_share PRIVATE nuraft::nuraft OpenSSL::SSL yaml-cpp::yaml-cpp)
+  target_link_libraries(stek_share PRIVATE OpenSSL::SSL nuraft::nuraft yaml-cpp::yaml-cpp)
 else()
   message(STATUS "skipping stek_share plugin (missing nuraft)")
 

--- a/plugins/experimental/txn_box/plugin/CMakeLists.txt
+++ b/plugins/experimental/txn_box/plugin/CMakeLists.txt
@@ -44,7 +44,7 @@ add_atsplugin(
   src/text_block.cc
 )
 
-target_link_libraries(txn_box PRIVATE libswoc::libswoc PkgConfig::PCRE2 OpenSSL::SSL yaml-cpp::yaml-cpp)
+target_link_libraries(txn_box PRIVATE libswoc::libswoc OpenSSL::SSL PkgConfig::PCRE2 yaml-cpp::yaml-cpp)
 
 target_include_directories(txn_box PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/plugins/experimental/txn_box/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/txn_box/unit_tests/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(test_txn_box unit_test_main.cc test_txn_box.cc test_accl_utils.cc
 set_target_properties(test_txn_box PROPERTIES CLANG_FORMAT_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${YAMLCPP_INCLUDE_DIR})
 
 target_link_libraries(
-  test_txn_box PUBLIC libswoc::libswoc PkgConfig::PCRE2 OpenSSL::SSL catch2::catch2 yaml-cpp::yaml-cpp
+  test_txn_box PUBLIC libswoc::libswoc OpenSSL::SSL PkgConfig::PCRE2 catch2::catch2 yaml-cpp::yaml-cpp
 )
 # After fighting with CMake over the include paths, it's just not worth it to be correct.
 # target_link_libraries should make this work but it doesn't. I can't figure out why.

--- a/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
@@ -32,7 +32,9 @@ target_compile_definitions(uri_signing_test PRIVATE UNITTEST)
 target_include_directories(uri_signing_test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(
   uri_signing_test
-  PRIVATE catch2::catch2
+  PRIVATE OpenSSL::SSL
+          OpenSSL::Crypto
+          catch2::catch2
           jansson::jansson
           cjose::cjose
           ts::tsapi
@@ -43,8 +45,6 @@ target_link_libraries(
           ts::logging
           ts::inknet
           ts::overridable_txn_vars
-          OpenSSL::SSL
-          OpenSSL::Crypto
 )
 add_test(NAME uri_signing_test COMMAND uri_signing_test)
 set_tests_properties(

--- a/plugins/s3_auth/unit_tests/CMakeLists.txt
+++ b/plugins/s3_auth/unit_tests/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 add_executable(test_s3_auth test_aws_auth_v4.cc "${PROJECT_SOURCE_DIR}/aws_auth_v4.cc")
 
-target_link_libraries(test_s3_auth PRIVATE catch2::catch2 OpenSSL::Crypto ts::tsutil)
+target_link_libraries(test_s3_auth PRIVATE OpenSSL::Crypto catch2::catch2 ts::tsutil)
 
 target_compile_definitions(test_s3_auth PRIVATE AWS_AUTH_V4_UNIT_TEST)
 

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TSAPI_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/ts/ts.h ${PROJECT_SOURCE_
                          ${PROJECT_SOURCE_DIR}/include/ts/TsException.h ${PROJECT_BINARY_DIR}/include/ts/apidefs.h
 )
 
+# OpenSSL needs to be listed in before PCRE and other libraries that can be found in the system default lib directory (See # #11511)
 target_link_libraries(tsapi PRIVATE libswoc::libswoc yaml-cpp::yaml-cpp OpenSSL::SSL PCRE::PCRE PkgConfig::PCRE2)
 set_target_properties(tsapi PROPERTIES PUBLIC_HEADER "${TSAPI_PUBLIC_HEADERS}")
 

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -23,7 +23,7 @@ set(TSAPI_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/ts/ts.h ${PROJECT_SOURCE_
                          ${PROJECT_SOURCE_DIR}/include/ts/TsException.h ${PROJECT_BINARY_DIR}/include/ts/apidefs.h
 )
 
-target_link_libraries(tsapi PRIVATE libswoc::libswoc yaml-cpp::yaml-cpp PCRE::PCRE PkgConfig::PCRE2 OpenSSL::SSL)
+target_link_libraries(tsapi PRIVATE libswoc::libswoc yaml-cpp::yaml-cpp OpenSSL::SSL PCRE::PCRE PkgConfig::PCRE2)
 set_target_properties(tsapi PROPERTIES PUBLIC_HEADER "${TSAPI_PUBLIC_HEADERS}")
 
 # Items common between api and other ts libraries

--- a/src/cripts/CMakeLists.txt
+++ b/src/cripts/CMakeLists.txt
@@ -59,7 +59,7 @@ set(CRIPTS_BUNDLE_HEADERS
 add_library(cripts SHARED ${CPP_FILES})
 add_library(ts::cripts ALIAS cripts)
 
-target_link_libraries(cripts PUBLIC libswoc::libswoc fmt::fmt PkgConfig::PCRE2 OpenSSL::Crypto)
+target_link_libraries(cripts PUBLIC libswoc::libswoc OpenSSL::Crypto fmt::fmt PkgConfig::PCRE2)
 set_target_properties(cripts PROPERTIES PUBLIC_HEADER "${CRIPTS_PUBLIC_HEADERS}")
 
 set_target_properties(


### PR DESCRIPTION
SSL library in `OPENSSL_ROOT_DIR` is not be used/linked if PCRE and another SSL library are in the system default directory, because the linker finds the one in the system default directory first. The change tweak the library path priority so that linker can pick the one in `OPENSSL_ROOT_DIR`.

This is not a perfect solution. If a user wants to use the SSL library in the system default directory and PCRE in somewhere else, the user will face the same issue but for PCRE. But using a custom PCRE for ATS is uncommon, so it wouldn't likely be an issue.