### PR TITLE
Provide a way to silence the warning about max_early_data

### DIFF
--- a/include/iocore/net/TLSEarlyDataSupport.h
+++ b/include/iocore/net/TLSEarlyDataSupport.h
@@ -29,6 +29,9 @@
 class TLSEarlyDataSupport
 {
 public:
+  // The default size on OpenSSL is 16384.
+  static constexpr uint32_t DEFAULT_MAX_EARLY_DATA_SIZE = 16384;
+
   virtual ~TLSEarlyDataSupport() = default;
 
   static void                 initialize();

--- a/src/iocore/net/SNIActionPerformer.cc
+++ b/src/iocore/net/SNIActionPerformer.cc
@@ -456,9 +456,8 @@ ServerMaxEarlyData::SNIAction([[maybe_unused]] SSL &ssl, const Context & /* ctx 
   }
 
   snis->hints_from_sni.server_max_early_data = server_max_early_data;
-  const uint32_t EARLY_DATA_DEFAULT_SIZE     = 16384;
   const uint32_t server_recv_max_early_data =
-    server_max_early_data > 0 ? std::max(server_max_early_data, EARLY_DATA_DEFAULT_SIZE) : 0;
+    server_max_early_data > 0 ? std::max(server_max_early_data, TLSEarlyDataSupport::DEFAULT_MAX_EARLY_DATA_SIZE) : 0;
   eds->update_early_data_config(&ssl, server_max_early_data, server_recv_max_early_data);
 #endif
   return SSL_TLSEXT_ERR_OK;

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -51,6 +51,7 @@
 #include "iocore/net/SSLDiags.h"
 #include "SSLSessionCache.h"
 #include "SSLSessionTicket.h"
+#include "iocore/net/TLSEarlyDataSupport.h"
 #include "iocore/net/YamlSNIConfig.h"
 
 int                SSLConfig::config_index                                = 0;
@@ -427,9 +428,8 @@ SSLConfigParams::initialize()
   REC_ReadConfigInteger(server_max_early_data, "proxy.config.ssl.server.max_early_data");
   REC_ReadConfigInt32(server_allow_early_data_params, "proxy.config.ssl.server.allow_early_data_params");
 
-  // According to OpenSSL the default value is 16384,
   // we keep it unless "server_max_early_data" is higher.
-  server_recv_max_early_data = std::max(server_max_early_data, EARLY_DATA_DEFAULT_SIZE);
+  server_recv_max_early_data = std::max(server_max_early_data, TLSEarlyDataSupport::DEFAULT_MAX_EARLY_DATA_SIZE);
 
   REC_ReadConfigStringAlloc(serverCertChainFilename, "proxy.config.ssl.server.cert_chain.filename");
   REC_ReadConfigStringAlloc(serverCertRelativePath, "proxy.config.ssl.server.cert.path");

--- a/src/iocore/net/TLSEarlyDataSupport.cc
+++ b/src/iocore/net/TLSEarlyDataSupport.cc
@@ -106,7 +106,12 @@ TLSEarlyDataSupport::update_early_data_config([[maybe_unused]] SSL *ssl, [[maybe
   // If SSL_set_max_early_data is unavailable, it's probably BoringSSL,
   // and SSL_set_early_data_enabled should be available.
   SSL_set_early_data_enabled(ssl, max_early_data > 0 ? 1 : 0);
-  Warning("max_early_data is not used due to library limitations");
+  if (max_early_data != 0 && max_early_data != DEFAULT_MAX_EARLY_DATA_SIZE) {
+    Warning(
+      "Early Data was enabled, but max_early_data_size is not configurable due to library limitations. Use %u to silence this "
+      "warning.",
+      DEFAULT_MAX_EARLY_DATA_SIZE);
+  }
 #endif
 #endif
 }


### PR DESCRIPTION
The warning about early data is printed even if early data is disabled, and there is no way to silence the warning.