### PR TITLE
Try TCP_FASTOPEN socket option with mptcp

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -5075,8 +5075,8 @@ Sockets
         TCP_NOTSENT_LOWAT (64)
         INCOMING_CPU (128)
 
-   Note: If MPTCP is enabled, TCP_NODELAY is only supported on Linux kernels 5.17+. TCP_FASTOPEN
-   and TCP_NOTSENT_LOWAT socket options are currently not supported.
+   Note: If MPTCP is enabled, TCP_NODELAY is only supported on Linux kernels 5.17+ and TCP_FASTOPEN is
+   only supported on Linux kernels 6.2+. TCP_NOTSENT_LOWAT socket option is currently not supported.
 
 .. note::
 

--- a/src/iocore/net/Connection.cc
+++ b/src/iocore/net/Connection.cc
@@ -245,6 +245,7 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
 #ifdef TCP_FASTOPEN
   if (opt.sockopt_flags & NetVCOptions::SOCK_OPT_TCP_FAST_OPEN) {
     if (safe_setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (char *)&opt.tfo_queue_length, sizeof(int))) {
+      // EOPNOTSUPP also checked for general safeguarding of unsupported operations of socket functions
       if (opt.f_mptcp && (errno == ENOPROTOOPT || errno == EOPNOTSUPP)) {
         Warning("[Server::listen] TCP_FASTOPEN socket option not valid on MPTCP socket level");
       } else {

--- a/src/iocore/net/Connection.cc
+++ b/src/iocore/net/Connection.cc
@@ -244,10 +244,12 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
 
 #ifdef TCP_FASTOPEN
   if (opt.sockopt_flags & NetVCOptions::SOCK_OPT_TCP_FAST_OPEN) {
-    if (opt.f_mptcp) {
-      Warning("[Server::listen] TCP_FASTOPEN socket option not valid on MPTCP socket level");
-    } else if (safe_setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (char *)&opt.tfo_queue_length, sizeof(int))) {
-      goto Lerror;
+    if (safe_setsockopt(fd, IPPROTO_TCP, TCP_FASTOPEN, (char *)&opt.tfo_queue_length, sizeof(int))) {
+      if (opt.f_mptcp && (errno == ENOPROTOOPT || errno == EOPNOTSUPP)) {
+        Warning("[Server::listen] TCP_FASTOPEN socket option not valid on MPTCP socket level");
+      } else {
+        goto Lerror;
+      }
     }
   }
 #endif


### PR DESCRIPTION
With support for TCP_FASTOPEN in newer kernels, allow ATS to try to use TCP_FASTOPEN with mptcp enabled