### PR TITLE
Fix unused parameters in cripts, experimental plugins and iocore

### DIFF
--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -63,7 +63,7 @@ wrap_do_remap(T *context, bool execute, CaseTag<1>) -> decltype(_do_remap(contex
 
 template <typename T>
 auto
-wrap_do_remap(T *context, bool execute, CaseTag<0>) -> bool
+wrap_do_remap(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -81,7 +81,7 @@ wrap_post_remap(T *context, bool execute, CaseTag<1>) -> decltype(_do_post_remap
 
 template <typename T>
 auto
-wrap_post_remap(T *context, bool execute, CaseTag<0>) -> bool
+wrap_post_remap(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -99,7 +99,7 @@ wrap_send_response(T *context, bool execute, CaseTag<1>) -> decltype(_do_send_re
 
 template <typename T>
 auto
-wrap_send_response(T *context, bool execute, CaseTag<0>) -> bool
+wrap_send_response(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -117,7 +117,7 @@ wrap_send_request(T *context, bool execute, CaseTag<1>) -> decltype(_do_send_req
 
 template <typename T>
 auto
-wrap_send_request(T *context, bool execute, CaseTag<0>) -> bool
+wrap_send_request(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -135,7 +135,7 @@ wrap_read_response(T *context, bool execute, CaseTag<1>) -> decltype(_do_read_re
 
 template <typename T>
 auto
-wrap_read_response(T *context, bool execute, CaseTag<0>) -> bool
+wrap_read_response(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -153,7 +153,7 @@ wrap_cache_lookup(T *context, bool execute, CaseTag<1>) -> decltype(_do_cache_lo
 
 template <typename T>
 auto
-wrap_cache_lookup(T *context, bool execute, CaseTag<0>) -> bool
+wrap_cache_lookup(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -171,7 +171,7 @@ wrap_txn_close(T *context, bool execute, CaseTag<1>) -> decltype(_do_txn_close(c
 
 template <typename T>
 auto
-wrap_txn_close(T *context, bool execute, CaseTag<0>) -> bool
+wrap_txn_close(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -191,7 +191,7 @@ wrap_plugin_init(T *context, bool execute, CaseTag<1>) -> decltype(_do_init(cont
 
 template <typename T>
 auto
-wrap_plugin_init(T *context, bool execute, CaseTag<0>) -> bool
+wrap_plugin_init(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -211,7 +211,7 @@ wrap_create_instance(T *context, bool execute, CaseTag<1>) -> decltype(_do_creat
 
 template <typename T>
 auto
-wrap_create_instance(T *context, bool execute, CaseTag<0>) -> bool
+wrap_create_instance(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }
@@ -228,7 +228,7 @@ wrap_delete_instance(T *context, bool execute, CaseTag<1>) -> decltype(_do_delet
 
 template <typename T>
 auto
-wrap_delete_instance(T *context, bool execute, CaseTag<0>) -> bool
+wrap_delete_instance(T * /* context ATS_UNUSED */, bool /* execute ATS_UNUSED */, CaseTag<0>) -> bool
 {
   return false;
 }

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -46,7 +46,7 @@
 #define do_send_request()    void _do_send_request(Cript::Context *context)
 #define do_read_response()   void _do_read_response(Cript::Context *context)
 #define do_txn_close()       void _do_txn_close(Cript::Context *context)
-#define do_init()            void _do_init(TSRemapInterface *api_info)
+#define do_init()            void _do_init(TSRemapInterface *)
 #define do_create_instance() void _do_create_instance(Cript::InstanceContext *context)
 #define do_delete_instance() void _do_delete_instance(Cript::InstanceContext *context)
 
@@ -57,7 +57,7 @@
 #define DoSendRequest()    void _do_send_request(Cript::Context *context)
 #define DoReadResponse()   void _do_read_response(Cript::Context *context)
 #define DoTxnClose()       void _do_txn_close(Cript::Context *context)
-#define DoInit()           void _do_init(TSRemapInterface *api_info)
+#define DoInit()           void _do_init(TSRemapInterface *)
 #define DoCreateInstance() void _do_create_instance(Cript::InstanceContext *context)
 #define DoDeleteInstance() void _do_delete_instance(Cript::InstanceContext *context)
 

--- a/plugins/experimental/fq_pacing/fq_pacing.cc
+++ b/plugins/experimental/fq_pacing/fq_pacing.cc
@@ -197,7 +197,7 @@ reset_pacing_cont(TSCont contp, TSEvent /* event ATS_UNUSED */, void *edata)
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *instance, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
+TSRemapDoRemap([[maybe_unused]] void *instance, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   if (TSHttpTxnClientProtocolStackContains(txnp, TS_PROTO_TAG_HTTP_2_0) != nullptr) {
     Dbg(dbg_ctl, "Skipping plugin execution for HTTP/2 requests");

--- a/src/iocore/net/UnixUDPNet.cc
+++ b/src/iocore/net/UnixUDPNet.cc
@@ -84,7 +84,7 @@ UDPPacket::new_UDPPacket()
 
 UDPPacket *
 UDPPacket::new_UDPPacket(struct sockaddr const *to, ink_hrtime when, Ptr<IOBufferBlock> &buf, uint16_t segment_size,
-                         struct timespec *send_at_hint)
+                         [[maybe_unused]] struct timespec *send_at_hint)
 {
   UDPPacket *p = udpPacketAllocator.alloc();
 

--- a/src/iocore/net/quic/QUICStreamManager.cc
+++ b/src/iocore/net/quic/QUICStreamManager.cc
@@ -102,7 +102,7 @@ QUICStreamManager::find_stream(QUICStreamId stream_id)
 }
 
 QUICStream *
-QUICStreamManager::create_stream(QUICStreamId stream_id, QUICConnectionError &err)
+QUICStreamManager::create_stream(QUICStreamId stream_id, QUICConnectionError & /* err ATS_UNUSED */)
 {
   QUICStream *stream = new QUICStream(this->_context->connection_info(), stream_id);
   this->stream_list.push(stream);


### PR DESCRIPTION
- Use `/* name ATS_UNUSED */` for full unused parameters
- Use `[[maybe_unused]]` for conditionally unused parameters
- Remove unused parameter name inside macro defines