### PR TITLE
Tools: JSON-RPC - Change the Unix Domain Socket client to retry and wait when connection to the server.

### DIFF
--- a/include/shared/rpc/IPCSocketClient.h
+++ b/include/shared/rpc/IPCSocketClient.h
@@ -31,6 +31,7 @@
 
 namespace shared::rpc
 {
+using namespace std::chrono_literals;
 /// The goal of this class is abstract the Unix Socket implementation and provide a JSONRPC Node client for Tests and client's
 /// applications like traffic_ctl and traffic_top.
 /// To make the usage easy and more readable this class provides a chained API, so you can do this like this:
@@ -50,7 +51,8 @@ struct IPCSocketClient {
   ~IPCSocketClient() { this->disconnect(); }
 
   /// Connect to the configured socket path.
-  self_reference connect();
+  /// Connection will retry every @c ms for @c attempts times if errno is EAGAIN
+  self_reference connect(std::chrono::milliseconds ms = 40ms, int attempts = 5);
 
   /// Send all the passed string to the socket.
   self_reference send(std::string_view data);

--- a/include/shared/rpc/RPCClient.h
+++ b/include/shared/rpc/RPCClient.h
@@ -68,7 +68,7 @@ public:
           ink_assert(!"Buffer full, not enough space to read the response.");
           break;
         case IPCSocketClient::ReadStatus::STREAM_ERROR:
-          err_text = "STREAM_ERROR: Error while reading response.";
+          err_text = swoc::bwprint(err_text, "STREAM_ERROR: Error while reading response. {}({})", std::strerror(errno), errno);
           break;
         default:
           err_text = "Something happened, we can't read the response. Unknown error.";

--- a/src/mgmt/rpc/server/IPCSocketServer.cc
+++ b/src/mgmt/rpc/server/IPCSocketServer.cc
@@ -44,6 +44,10 @@
 #include "mgmt/rpc/jsonrpc/JsonRPCManager.h"
 #include "mgmt/rpc/server/IPCSocketServer.h"
 
+#ifndef SOCK_NONBLOCK
+#define SOCK_NONBLOCK O_NONBLOCK
+#endif
+
 namespace
 {
 constexpr size_t MAX_REQUEST_BUFFER_SIZE{32000};

--- a/src/mgmt/rpc/server/IPCSocketServer.cc
+++ b/src/mgmt/rpc/server/IPCSocketServer.cc
@@ -44,10 +44,6 @@
 #include "mgmt/rpc/jsonrpc/JsonRPCManager.h"
 #include "mgmt/rpc/server/IPCSocketServer.h"
 
-#ifndef SOCK_NONBLOCK
-#define SOCK_NONBLOCK O_NONBLOCK
-#endif
-
 namespace
 {
 constexpr size_t MAX_REQUEST_BUFFER_SIZE{32000};

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -43,6 +43,7 @@
 #include "shared/rpc/IPCSocketClient.h"
 #include "iocore/eventsystem/EventSystem.h"
 #include "tscore/Layout.h"
+#include "tscore/ink_sock.h"
 #include "iocore/utils/diags.i"
 
 #define DEFINE_JSONRPC_PROTO_FUNCTION(fn) swoc::Rv<YAML::Node> fn(std::string_view const &, const YAML::Node &params)
@@ -158,7 +159,7 @@ struct ScopedLocalSocket : shared::rpc::IPCSocketClient {
     int  chunk_number{1};
     auto chunks = chunk<N>(data);
     for (auto &&part : chunks) {
-      if (::write(_sock, part.c_str(), part.size()) < 0) {
+      if (safe_write(_sock, part.c_str(), part.size()) < 0) {
         Debug(logTag, "error sending message :%s", std ::strerror(errno));
         break;
       }

--- a/src/shared/rpc/IPCSocketClient.cc
+++ b/src/shared/rpc/IPCSocketClient.cc
@@ -17,15 +17,19 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+#include <unistd.h>
+
 #include <stdexcept>
 #include <chrono>
 #include <sstream>
 #include <utility>
+#include <thread>
 
 #include "tsutil/ts_bw_format.h"
 
 #include "shared/rpc/IPCSocketClient.h"
 #include <tscore/ink_assert.h>
+#include <tscore/ink_sock.h>
 
 namespace
 {
@@ -93,29 +97,55 @@ public:
     return _written ? _written : _bw.size();
   }
 };
-
 } // namespace
 
 namespace shared::rpc
 {
+
 IPCSocketClient::self_reference
-IPCSocketClient::connect()
+IPCSocketClient::connect(std::chrono::milliseconds ms, int attempts)
 {
-  _sock = socket(AF_UNIX, SOCK_STREAM, 0);
+  std::string text;
+  int         err, tries{attempts};
+  bool        done{false};
+  _sock = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+
   if (this->is_closed()) {
-    std::string text;
-    swoc::bwprint(text, "connect: error creating new socket. Why?: {}\n", std::strerror(errno));
-    throw std::runtime_error{text};
-  }
-  _server.sun_family = AF_UNIX;
-  std::strncpy(_server.sun_path, _path.c_str(), sizeof(_server.sun_path) - 1);
-  if (::connect(_sock, (struct sockaddr *)&_server, sizeof(struct sockaddr_un)) < 0) {
-    this->close();
-    std::string text;
-    swoc::bwprint(text, "connect: Couldn't open connection with {}. Why?: {}\n", _path, std::strerror(errno));
-    throw std::runtime_error{text};
+    throw std::runtime_error(swoc::bwprint(text, "connect: error creating new socket. Reason: {}\n", std::strerror(errno)));
   }
 
+  _server.sun_family = AF_UNIX;
+  std::strncpy(_server.sun_path, _path.c_str(), sizeof(_server.sun_path) - 1);
+
+  // Very simple connect and retry. We will just try to connect to the Unix Domain
+  // Socket and if it tell us to retry we just wait for a few ms and try again for
+  // X times.
+  do {
+    --tries;
+    if (::connect(_sock, (struct sockaddr *)&_server, sizeof(struct sockaddr_un)) >= 0) {
+      done = true;
+      break;
+    }
+
+    if (errno == EAGAIN || errno == EINPROGRESS) {
+      // Connection cannot be completed immediately
+      // EAGAIN for UDS should suffice, but just in case.
+      std::this_thread::sleep_for(ms);
+      err = errno;
+      continue;
+    } else {
+      // No worth it.
+      err = errno;
+      break;
+    }
+  } while (tries != 0);
+
+  if ((tries == 0 && !done) || !done) {
+    this->close();
+    errno = err;
+    throw std::runtime_error(swoc::bwprint(text, "connect(attempts={}/{}): Couldn't open connection with {}. Last error: {}({})\n",
+                                           (attempts - tries), attempts, _path, std::strerror(errno), errno));
+  }
   return *this;
 }
 
@@ -123,10 +153,10 @@ IPCSocketClient::self_reference
 IPCSocketClient ::send(std::string_view data)
 {
   std::string msg{data};
-  if (::write(_sock, msg.c_str(), msg.size()) < 0) {
+  if (safe_write(_sock, msg.c_str(), msg.size()) < 0) {
     this->close();
     std::string text;
-    throw std::runtime_error{swoc::bwprint(text, "Error writing on stream socket {}", std ::strerror(errno))};
+    throw std::runtime_error{swoc::bwprint(text, "Error writing on stream socket {}({})", std::strerror(errno), errno)};
   }
 
   return *this;
@@ -144,9 +174,12 @@ IPCSocketClient::read_all(std::string &content)
 
   ReadStatus readStatus{ReadStatus::UNKNOWN};
   while (true) {
-    auto          buf     = bs.writable_data();
-    const auto    to_read = bs.available();
-    const ssize_t ret     = ::read(_sock, buf, to_read);
+    auto       buf     = bs.writable_data();
+    const auto to_read = bs.available();
+    ssize_t    ret{-1};
+    do {
+      ret = ::read(_sock, buf, to_read);
+    } while (ret < 0 && (errno == EAGAIN || errno == EINTR));
 
     if (ret > 0) {
       bs.save(ret);

--- a/src/shared/rpc/IPCSocketClient.cc
+++ b/src/shared/rpc/IPCSocketClient.cc
@@ -108,10 +108,15 @@ IPCSocketClient::connect(std::chrono::milliseconds ms, int attempts)
   std::string text;
   int         err, tries{attempts};
   bool        done{false};
-  _sock = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+  _sock = socket(AF_UNIX, SOCK_STREAM, 0);
 
   if (this->is_closed()) {
     throw std::runtime_error(swoc::bwprint(text, "connect: error creating new socket. Reason: {}\n", std::strerror(errno)));
+  }
+
+  if (safe_fcntl(_sock, F_SETFL, O_NONBLOCK) < 0) {
+    this->close();
+    throw std::runtime_error(swoc::bwprint(text, "connect: fcntl error. Reason: {}\n", std::strerror(errno)));
   }
 
   _server.sun_family = AF_UNIX;


### PR DESCRIPTION
Very simple mechanism to wait and retry when the connect to the server socket is temporarily unavailable.
This should not block on `connect`. This logic is simpler than adding a `select` to wait on the `fd` as most of the time it will tell us it's ready after the first `EAGAIN` by  the `connect` but it does not mean that we can just write to the unix domain socket as the enpoint may not be ready.

Eventually if needed I can add some polling on the `read` to avoid hangung up there, but it's unlikely to happen.

Fixes: https://github.com/apache/trafficserver/issues/11468