### PR TITLE
Do not retry to open cache store on ENOMEM

### DIFF
--- a/include/iocore/eventsystem/SocketManager.h
+++ b/include/iocore/eventsystem/SocketManager.h
@@ -62,11 +62,6 @@ bool fastopen_supported();
 // result is the socket or -errno
 SOCKET socket(int domain = AF_INET, int type = SOCK_STREAM, int protocol = 0);
 
-const mode_t DEFAULT_OPEN_MODE{0644};
-
-// result is the fd or -errno
-int open(const char *path, int oflag = O_RDWR | O_NDELAY | O_CREAT, mode_t mode = DEFAULT_OPEN_MODE);
-
 // result is the number of bytes or -errno
 int64_t read(int fd, void *buf, int len, void *pOLP = nullptr);
 

--- a/include/tscore/ink_file.h
+++ b/include/tscore/ink_file.h
@@ -80,10 +80,7 @@
 //
 #define INK_FILEPATH_TRUENAME 0x20
 
-namespace
-{
 inline constexpr mode_t DEFAULT_OPEN_MODE{0644};
-} // end anonymous namespace
 
 int safe_open(char const *path, int oflag = O_RDWR | O_NDELAY | O_CREAT, mode_t mode = DEFAULT_OPEN_MODE);
 

--- a/include/tscore/ink_file.h
+++ b/include/tscore/ink_file.h
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include "tscore/ink_config.h"
+#include "tscore/ink_platform.h"
 
 #include <cstdio>
 #include <sys/types.h>
@@ -79,6 +79,13 @@
 // trailing slash if a directory
 //
 #define INK_FILEPATH_TRUENAME 0x20
+
+namespace
+{
+inline constexpr mode_t DEFAULT_OPEN_MODE{0644};
+} // end anonymous namespace
+
+int safe_open(char const *path, int oflag = O_RDWR | O_NDELAY | O_CREAT, mode_t mode = DEFAULT_OPEN_MODE);
 
 int ink_fputln(FILE *stream, const char *s);
 int ink_file_fd_readline(int fd, int bufsize, char *buf);

--- a/src/iocore/cache/Store.cc
+++ b/src/iocore/cache/Store.cc
@@ -367,7 +367,7 @@ Span::init(const char *path, int64_t size)
   span_error_t        serr;
   ink_device_geometry geometry;
 
-  ats_scoped_fd fd(SocketManager::open(path, O_RDONLY));
+  ats_scoped_fd fd(safe_open(path, O_RDONLY));
   if (fd < 0) {
     serr = make_span_error(errno);
     Warning("unable to open '%s': %s", path, strerror(errno));

--- a/src/iocore/eventsystem/P_UnixSocketManager.h
+++ b/src/iocore/eventsystem/P_UnixSocketManager.h
@@ -43,20 +43,6 @@
 // 1024 - stdin, stderr, stdout
 #define EPOLL_MAX_DESCRIPTOR_SIZE 32768
 
-TS_INLINE int
-SocketManager::open(const char *path, int oflag, mode_t mode)
-{
-  int s;
-  do {
-    s = ::open(path, oflag, mode);
-    if (likely(s >= 0)) {
-      break;
-    }
-    s = -errno;
-  } while (transient_error());
-  return s;
-}
-
 TS_INLINE int64_t
 SocketManager::read(int fd, void *buf, int size, void * /* pOLP ATS_UNUSED */)
 {

--- a/src/tscore/ink_file.cc
+++ b/src/tscore/ink_file.cc
@@ -42,6 +42,21 @@ using ioctl_arg_t = union {
   off_t    off;
 };
 
+/** Open and possibly create a file.
+ *
+ * This is a wrapper for the POSIX open() call that will retry the call if a
+ * transient error occurs.
+ */
+int
+safe_open(char const *path, int oflag, mode_t mode)
+{
+  int r{-1};
+  do {
+    r = open(path, oflag, mode);
+  } while ((r < 0) && (errno == EINTR));
+  return r;
+}
+
 int
 ink_fputln(FILE *stream, const char *s)
 {


### PR DESCRIPTION
This replaces the `SocketManager::open` function with a new `safe_open` function in tscore that retries the call if it is interrupted a signal, but does not retry it if the kernel runs out of memory or buffers for a FIFO cannot be allocated. The change is split into three commits with descriptive comments.