### PR TITLE
Fix incorrect metric for agg_copy bytes written

### DIFF
--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -731,10 +731,9 @@ agg_copy(char *p, CacheVC *vc)
         ProxyMutex *mutex ATS_UNUSED = vc->stripe->mutex.get();
         ink_assert(mutex->thread_holding == this_ethread());
 
-// ToDo: Why are these for debug only ?
 #ifdef DEBUG
-        Metrics::Counter::increment(cache_rsb.write_backlog_failure);
-        Metrics::Counter::increment(stripe->cache_vol->vol_rsb.write_backlog_failure);
+        Metrics::Counter::increment(cache_rsb.write_bytes, vc->write_len);
+        Metrics::Counter::increment(stripe->cache_vol->vol_rsb.write_bytes, vc->write_len);
 #endif
       }
       if (vc->f.rewrite_resident_alt) {


### PR DESCRIPTION
This is a cherry-pick of #11508.

We introduced an issue in f23826d where we count backlog failures when copying bytes to the aggregation buffer. The original, intended behavior, was to count the number of bytes copied. This restores the original behavior.

Fixes #11457.