### PR TITLE
Fix unused parameters in the test plugins (#11524)

### DIFF
--- a/src/tscore/hugepages.cc
+++ b/src/tscore/hugepages.cc
@@ -61,7 +61,7 @@ ats_hugepage_enabled()
 }
 
 void
-ats_hugepage_init(int enabled)
+ats_hugepage_init([[maybe_unused]] int enabled)
 {
 #ifdef MAP_HUGETLB
   FILE *fp;
@@ -110,7 +110,7 @@ ats_hugepage_init(int enabled)
 }
 
 void *
-ats_alloc_hugepage(size_t s)
+ats_alloc_hugepage([[maybe_unused]] size_t s)
 {
 #ifdef MAP_HUGETLB
   size_t size;
@@ -128,14 +128,13 @@ ats_alloc_hugepage(size_t s)
   Debug(DEBUG_TAG, "Request/Allocation (%zu/%zu) {%p}", s, size, mem);
   return mem;
 #else
-  (void)s;
   Debug(DEBUG_TAG, "MAP_HUGETLB not defined");
   return nullptr;
 #endif
 }
 
 bool
-ats_free_hugepage(void *ptr, size_t s)
+ats_free_hugepage([[maybe_unused]] void *ptr, [[maybe_unused]] size_t s)
 {
 #ifdef MAP_HUGETLB
   size_t size;
@@ -143,8 +142,6 @@ ats_free_hugepage(void *ptr, size_t s)
   size = INK_ALIGN(s, ats_hugepage_size());
   return (munmap(ptr, size) == 0);
 #else
-  (void)ptr;
-  (void)s;
   Debug(DEBUG_TAG, "MAP_HUGETLB not defined");
   return false;
 #endif

--- a/tests/gold_tests/continuations/plugins/session_id_verify.cc
+++ b/tests/gold_tests/continuations/plugins/session_id_verify.cc
@@ -34,7 +34,7 @@ static char support_email[] = "bneradt@apache.org";
 static DbgCtl dbg_ctl{plugin_name};
 
 int
-global_handler(TSCont continuation, TSEvent event, void *data)
+global_handler(TSCont /* continuation ATS_UNUSED */, TSEvent event, void *data)
 {
   TSHttpSsn session = static_cast<TSHttpSsn>(data);
 
@@ -62,7 +62,7 @@ global_handler(TSCont continuation, TSEvent event, void *data)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "initializing plugin");
 

--- a/tests/gold_tests/jsonrpc/plugins/jsonrpc_plugin_handler_test.cc
+++ b/tests/gold_tests/jsonrpc/plugins/jsonrpc_plugin_handler_test.cc
@@ -118,7 +118,7 @@ struct HostItem {
 };
 
 int
-CB_handle_rpc_io_call(TSCont contp, TSEvent event, void *data)
+CB_handle_rpc_io_call(TSCont contp, TSEvent /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
 {
   namespace fs = swoc::file;
 
@@ -251,7 +251,7 @@ CB_handle_rpc_io_call(TSCont contp, TSEvent event, void *data)
 
 // Perform a field updated on a yaml file. Host will be added or updated
 void
-test_io_on_et_task(const char *id, TSYaml p)
+test_io_on_et_task(const char * /* id ATS_UNUSED */, TSYaml p)
 {
   // A possible scenario would be that a handler needs to perform a "heavy" operation or that the handler
   // is not yet ready to perform the operation when is called, under this scenarios(and some others)
@@ -263,7 +263,7 @@ test_io_on_et_task(const char *id, TSYaml p)
 } // namespace
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/gold_tests/pluginTest/TSVConnFd/TSVConnFd.cc
+++ b/tests/gold_tests/pluginTest/TSVConnFd/TSVConnFd.cc
@@ -417,7 +417,7 @@ Send_to_vconn::send(void const *data, int64_t n_bytes)
 }
 
 int
-Send_to_vconn::_cont_func(TSCont cont, TSEvent event, void *edata)
+Send_to_vconn::_cont_func(TSCont cont, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   auto stv = static_cast<Send_to_vconn *>(nonNullPtrDbg(TSContDataGet(nonNullPtrDbg(cont))));
 

--- a/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.cc
+++ b/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.cc
@@ -242,7 +242,7 @@ Blocking_action::_txn_cont_func(TSCont, TSEvent event, void *eventData)
 } // end anonymous namespace
 
 void
-TSPluginInit(int n_arg, char const *arg[])
+TSPluginInit(int /* n_arg ATS_UNUSED */, char const ** /* arg ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "initializing plugin");
 

--- a/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo.cc
@@ -103,7 +103,7 @@ TSCont gCont;
 } // end anonymous namespace
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/gold_tests/pluginTest/tsapi/test_TSHttpTxnServerAddrSet.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSHttpTxnServerAddrSet.cc
@@ -134,7 +134,7 @@ parse_arguments(int argc, char const *argv[])
 
 /** The handler which sets the user-specified origin. */
 int
-set_origin(TSCont cont, TSEvent event, void *edata)
+set_origin(TSCont /* cont ATS_UNUSED */, TSEvent event, void *edata)
 {
   if (event != TS_EVENT_HTTP_CACHE_LOOKUP_COMPLETE) {
     TSError("Unexpected event: %d", event);

--- a/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
+++ b/tests/gold_tests/pluginTest/tsapi/test_tsapi.cc
@@ -251,7 +251,7 @@ globalContFunc(TSCont, TSEvent event, void *eventData)
 } // end anonymous namespace
 
 TSReturnCode
-TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+TSRemapInit(TSRemapInterface *api_info, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "TSRemapInit()");
 

--- a/tests/gold_tests/timeout/ssl-delay-server.cc
+++ b/tests/gold_tests/timeout/ssl-delay-server.cc
@@ -55,7 +55,7 @@ struct thread_info {
 };
 
 void
-SSL_locking_callback(int mode, int type, const char *file, int line)
+SSL_locking_callback(int mode, int type, const char * /* file ATS_UNUSED */, int /* line ATS_UNUSED */)
 {
   if (mode & CRYPTO_LOCK) {
     pthread_mutex_lock(&mutex_buf[type]);
@@ -67,7 +67,7 @@ SSL_locking_callback(int mode, int type, const char *file, int line)
 }
 
 void
-SSL_pthreads_thread_id(CRYPTO_THREADID *id)
+SSL_pthreads_thread_id([[maybe_unused]] CRYPTO_THREADID *id)
 {
   CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
 }

--- a/tests/gold_tests/tls/ssl-post.c
+++ b/tests/gold_tests/tls/ssl-post.c
@@ -35,6 +35,8 @@
 #include <netinet/tcp.h>
 #include <pthread.h>
 
+#include "tscore/ink_defs.h"
+
 #define NUM_THREADS 10
 
 char req_buf[10000];
@@ -48,7 +50,7 @@ struct thread_info {
 };
 
 void
-SSL_locking_callback(int mode, int type, const char *file, int line)
+SSL_locking_callback(int mode, int type, const char *file ATS_UNUSED, int line ATS_UNUSED)
 {
   if (mode & CRYPTO_LOCK) {
     pthread_mutex_lock(&mutex_buf[type]);

--- a/tests/tools/plugins/async_engine.c
+++ b/tests/tools/plugins/async_engine.c
@@ -30,6 +30,7 @@
 
 /* TLS_USE_TLS_ASYNC defined in ink_config.h */
 #include "tscore/ink_config.h"
+#include "tscore/ink_defs.h"
 #if TS_USE_TLS_ASYNC
 
 #include <stdio.h>
@@ -70,7 +71,7 @@ static int async_rsa_finish(RSA *rsa);
 static RSA_METHOD *async_rsa_method = NULL;
 
 EVP_PKEY *
-async_load_privkey(ENGINE *e, const char *s_key_id, UI_METHOD *ui_method, void *callback_data)
+async_load_privkey(ENGINE *e ATS_UNUSED, const char *s_key_id, UI_METHOD *ui_method ATS_UNUSED, void *callback_data ATS_UNUSED)
 {
   fprintf(stderr, "Loading key %s\n", s_key_id);
   FILE *f = fopen(s_key_id, "r");
@@ -151,26 +152,26 @@ engine_load_async_int(void)
 }
 
 static int
-engine_async_init(ENGINE *e)
+engine_async_init(ENGINE *e ATS_UNUSED)
 {
   return 1;
 }
 
 static int
-async_finish(ENGINE *e)
+async_finish(ENGINE *e ATS_UNUSED)
 {
   return 1;
 }
 
 static int
-async_destroy(ENGINE *e)
+async_destroy(ENGINE *e ATS_UNUSED)
 {
   RSA_meth_free(async_rsa_method);
   return 1;
 }
 
 static void
-wait_cleanup(ASYNC_WAIT_CTX *ctx, const void *key, OSSL_ASYNC_FD readfd, void *pvwritefd)
+wait_cleanup(ASYNC_WAIT_CTX *ctx ATS_UNUSED, const void *key ATS_UNUSED, OSSL_ASYNC_FD readfd, void *pvwritefd)
 {
   OSSL_ASYNC_FD *pwritefd = (OSSL_ASYNC_FD *)pvwritefd;
   close(readfd);

--- a/tests/tools/plugins/conf_remap_stripped.cc
+++ b/tests/tools/plugins/conf_remap_stripped.cc
@@ -23,19 +23,20 @@
 // Initialize the plugin as a remap plugin.
 //
 TSReturnCode
-TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+TSRemapInit(TSRemapInterface * /* api_info ATS_UNUSED */, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   return TS_SUCCESS; /* success */
 }
 
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
+TSRemapNewInstance(int /* argc ATS_UNUSED */, char ** /* argv ATS_UNUSED */, void ** /* ih ATS_UNUSED */,
+                   char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   return TS_ERROR;
 }
 
 void
-TSRemapDeleteInstance(void *ih)
+TSRemapDeleteInstance(void * /* ih ATS_UNUSED */)
 {
 }
 
@@ -43,7 +44,7 @@ TSRemapDeleteInstance(void *ih)
 // Main entry point when used as a remap plugin.
 //
 TSRemapStatus
-TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo * /* rri ATS_UNUSED */)
+TSRemapDoRemap(void * /* ih ATS_UNUSED */, TSHttpTxn /* rh ATS_UNUSED */, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   return TSREMAP_NO_REMAP;
 }

--- a/tests/tools/plugins/cont_schedule.cc
+++ b/tests/tools/plugins/cont_schedule.cc
@@ -54,7 +54,7 @@ static int TSContScheduleOnThread_handler_2(TSCont contp, TSEvent event, void *e
 static int TSContThreadAffinity_handler(TSCont contp, TSEvent event, void *edata);
 
 static int
-TSContScheduleOnPool_handler_1(TSCont contp, TSEvent event, void *edata)
+TSContScheduleOnPool_handler_1(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   // This runs on ET_NET threads.
   Dbg(dbg_ctl_hdl, "TSContScheduleOnPool handler 1 thread [%p]", TSThreadSelf());
@@ -73,7 +73,7 @@ TSContScheduleOnPool_handler_1(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-TSContScheduleOnPool_handler_2(TSCont contp, TSEvent event, void *edata)
+TSContScheduleOnPool_handler_2(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   // This runs on ET_TASK threads.
   Dbg(dbg_ctl_hdl, "TSContScheduleOnPool handler 2 thread [%p]", TSThreadSelf());
@@ -116,7 +116,7 @@ TSContScheduleOnPool_test()
 }
 
 static int
-TSContScheduleOnThread_handler_1(TSCont contp, TSEvent event, void *edata)
+TSContScheduleOnThread_handler_1(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   // Mostly same as TSContScheduleOnPool_handler_1, no need to set affinity
   // since we are scheduling directly on to a thread.
@@ -140,7 +140,7 @@ TSContScheduleOnThread_handler_1(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-TSContScheduleOnThread_handler_2(TSCont contp, TSEvent event, void *edata)
+TSContScheduleOnThread_handler_2(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   Dbg(dbg_ctl_hdl, "TSContScheduleOnThread handler 2 thread [%p]", TSThreadSelf());
   if (thread_2 == nullptr) {
@@ -213,7 +213,7 @@ TSContThreadAffinity_test()
 }
 
 static int
-LifecycleHookTracer(TSCont contp, TSEvent event, void *edata)
+LifecycleHookTracer(TSCont /* contp ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   if (event == TS_EVENT_LIFECYCLE_TASK_THREADS_READY) {
     switch (test_flag) {

--- a/tests/tools/plugins/continuations_verify.cc
+++ b/tests/tools/plugins/continuations_verify.cc
@@ -51,7 +51,7 @@ static int stat_txn_close_2 = 0; // number of TS_HTTP_TXN_CLOSE hooks caught by 
 static int stat_test_done   = 0; // Incremented when receiving a traffic_ctl message
 
 static int
-handle_msg(TSCont contp, TSEvent event, void *edata)
+handle_msg(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   if (event == TS_EVENT_LIFECYCLE_MSG) { // External trigger, such as traffic_ctl
     Dbg(dbg_ctl_msg, "event TS_EVENT_LIFECYCLE_MSG");
@@ -74,7 +74,7 @@ handle_msg(TSCont contp, TSEvent event, void *edata)
     to the corresponding events. Return value is irrelevant.
 */
 static int
-handle_order_1(TSCont contp, TSEvent event, void *edata)
+handle_order_1(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpSsn ssnp; // session data
   TSHttpTxn txnp; // transaction data
@@ -104,7 +104,7 @@ handle_order_1(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-handle_order_2(TSCont contp, TSEvent event, void *edata)
+handle_order_2(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpSsn ssnp; // session data
   TSHttpTxn txnp; // transaction data
@@ -141,7 +141,7 @@ handle_order_2(TSCont contp, TSEvent event, void *edata)
         - Initializes all statistics as described in the README
 */
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   Dbg(dbg_ctl_init, "initializing plugin");
 

--- a/tests/tools/plugins/custom204plugin.cc
+++ b/tests/tools/plugins/custom204plugin.cc
@@ -119,7 +119,7 @@ done:
 }
 
 static int
-global_handler(TSCont contp, TSEvent event, void *edata)
+global_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp      = static_cast<TSHttpTxn>(edata);
   TSCont    txn_contp = nullptr;
@@ -140,7 +140,7 @@ global_handler(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/tools/plugins/emergency_shutdown.cc
+++ b/tests/tools/plugins/emergency_shutdown.cc
@@ -33,14 +33,14 @@ static char vendor_name[]   = "apache";
 static char support_email[] = "duke8253@apache.org";
 
 static int
-test_handler(TSCont contp, TSEvent event, void *edata)
+test_handler(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "failed to shutdown");
   return 0;
 }
 
 static int
-LifecycleHookTracer(TSCont contp, TSEvent event, void *edata)
+LifecycleHookTracer(TSCont /* contp ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   if (event == TS_EVENT_LIFECYCLE_TASK_THREADS_READY) {
     TSCont contp = TSContCreate(test_handler, TSMutexCreate());
@@ -51,7 +51,7 @@ LifecycleHookTracer(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/tools/plugins/fatal_shutdown.cc
+++ b/tests/tools/plugins/fatal_shutdown.cc
@@ -33,14 +33,14 @@ static char vendor_name[]   = "apache";
 static char support_email[] = "duke8253@apache.org";
 
 static int
-test_handler(TSCont contp, TSEvent event, void *edata)
+test_handler(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "failed to shutdown");
   return 0;
 }
 
 static int
-LifecycleHookTracer(TSCont contp, TSEvent event, void *edata)
+LifecycleHookTracer(TSCont /* contp ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   if (event == TS_EVENT_LIFECYCLE_TASK_THREADS_READY) {
     TSCont contp = TSContCreate(test_handler, TSMutexCreate());
@@ -51,7 +51,7 @@ LifecycleHookTracer(TSCont contp, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/tools/plugins/hook_add_plugin.cc
+++ b/tests/tools/plugins/hook_add_plugin.cc
@@ -104,7 +104,7 @@ sessionHandler(TSCont continuation, TSEvent event, void *d)
 }
 
 int
-globalHandler(TSCont continuation, TSEvent event, void *data)
+globalHandler(TSCont /* continuation ATS_UNUSED */, TSEvent event, void *data)
 {
   if (event == TS_EVENT_HTTP_SSN_START) {
     TSHttpSsn session = static_cast<TSHttpSsn>(data);

--- a/tests/tools/plugins/hook_tunnel_plugin.cc
+++ b/tests/tools/plugins/hook_tunnel_plugin.cc
@@ -34,7 +34,7 @@ static const char PLUGIN_TAG[] = PLUGIN_NAME;
 static DbgCtl     plugin_ctl{PLUGIN_TAG};
 
 static int
-tunnelStart(TSCont cont, TSEvent event, void *edata)
+tunnelStart(TSCont /* cont ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp   = reinterpret_cast<TSHttpTxn>(edata);
   TSTxnType retval = TSHttpTxnTypeGet(txnp);
@@ -52,7 +52,7 @@ tunnelStart(TSCont cont, TSEvent event, void *edata)
 }
 
 static int
-transactionStart(TSCont cont, TSEvent event, void *edata)
+transactionStart(TSCont /* cont ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp   = reinterpret_cast<TSHttpTxn>(edata);
   TSTxnType retval = TSHttpTxnTypeGet(txnp);
@@ -68,7 +68,7 @@ transactionStart(TSCont cont, TSEvent event, void *edata)
 }
 
 static int
-handleMsg(TSCont cont, TSEvent event, void *edata)
+handleMsg(TSCont /* cont ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   Dbg(plugin_ctl, "handleMsg event=%d", event);
   TSStatIntIncrement(stat_test_done, 1);
@@ -76,7 +76,7 @@ handleMsg(TSCont cont, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char **argv)
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/tools/plugins/missing_mangled_definition_c.c
+++ b/tests/tools/plugins/missing_mangled_definition_c.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include "tscore/ink_defs.h"
 #include "missing_mangled_definition.h"
 
 void
@@ -25,7 +26,7 @@ foo()
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int argc ATS_UNUSED, const char *argv[] ATS_UNUSED)
 {
   foo();
 }

--- a/tests/tools/plugins/missing_mangled_definition_cpp.cc
+++ b/tests/tools/plugins/missing_mangled_definition_cpp.cc
@@ -27,7 +27,7 @@
  */
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   foo();
 }

--- a/tests/tools/plugins/ssl_hook_test.cc
+++ b/tests/tools/plugins/ssl_hook_test.cc
@@ -39,7 +39,7 @@ static DbgCtl dbg_ctl{PN};
 static bool   was_conn_closed;
 
 int
-ReenableSSL(TSCont cont, TSEvent event, void *edata)
+ReenableSSL(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   if (was_conn_closed) {
     TSContDestroy(cont);
@@ -155,7 +155,7 @@ CB_out_close(TSCont cont, TSEvent event, void *edata)
   return TS_SUCCESS;
 }
 int
-CB_Client_Hello_Immediate(TSCont cont, TSEvent event, void *edata)
+CB_Client_Hello_Immediate(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
 
@@ -169,7 +169,7 @@ CB_Client_Hello_Immediate(TSCont cont, TSEvent event, void *edata)
 }
 
 int
-CB_Client_Hello(TSCont cont, TSEvent event, void *edata)
+CB_Client_Hello(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
 
@@ -189,7 +189,7 @@ CB_Client_Hello(TSCont cont, TSEvent event, void *edata)
 }
 
 int
-CB_SNI(TSCont cont, TSEvent event, void *edata)
+CB_SNI(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
 
@@ -203,7 +203,7 @@ CB_SNI(TSCont cont, TSEvent event, void *edata)
 }
 
 int
-CB_Cert_Immediate(TSCont cont, TSEvent event, void *edata)
+CB_Cert_Immediate(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
 
@@ -216,7 +216,7 @@ CB_Cert_Immediate(TSCont cont, TSEvent event, void *edata)
 }
 
 int
-CB_Cert(TSCont cont, TSEvent event, void *edata)
+CB_Cert(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSVConn ssl_vc = reinterpret_cast<TSVConn>(edata);
 

--- a/tests/tools/plugins/ssl_secret_load_test.cc
+++ b/tests/tools/plugins/ssl_secret_load_test.cc
@@ -92,7 +92,7 @@ load_file(const std::string &newname, struct stat *statdata, std::string &data_i
 }
 
 int
-CB_Load_Secret(TSCont cont, TSEvent event, void *edata)
+CB_Load_Secret(TSCont /* cont ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSSecretID *id = reinterpret_cast<TSSecretID *>(edata);
 
@@ -133,7 +133,7 @@ CB_Load_Secret(TSCont cont, TSEvent event, void *edata)
 }
 
 int
-CB_Update_Secret(TSCont cont, TSEvent event, void *edata)
+CB_Update_Secret(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_UNUSED */)
 {
   std::vector<std::string> updates;
   for (auto iter = secret_versions.begin(); iter != secret_versions.end(); ++iter) {
@@ -168,7 +168,7 @@ CB_Update_Secret(TSCont cont, TSEvent event, void *edata)
 
 // Called by ATS as our initialization point
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
   info.plugin_name   = const_cast<char *>("SSL secret load test");

--- a/tests/tools/plugins/ssntxnorder_verify.cc
+++ b/tests/tools/plugins/ssntxnorder_verify.cc
@@ -301,7 +301,7 @@ handle_order(TSCont contp, TSEvent event, void *edata)
         - Initializes all statistics as described in the README
 */
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   Dbg(dbg_ctl_init, "initializing plugin");
 

--- a/tests/tools/plugins/test_hooks.cc
+++ b/tests/tools/plugins/test_hooks.cc
@@ -282,7 +282,7 @@ TSCont gCont;
 } // end anonymous namespace
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/tools/plugins/test_log_interface.cc
+++ b/tests/tools/plugins/test_log_interface.cc
@@ -49,7 +49,7 @@ is_get_request(TSHttpTxn transaction)
 }
 
 int
-global_handler(TSCont continuation, TSEvent event, void *data)
+global_handler(TSCont /* continuation ATS_UNUSED */, TSEvent event, void *data)
 {
   TSHttpSsn session     = static_cast<TSHttpSsn>(data);
   TSHttpTxn transaction = static_cast<TSHttpTxn>(data);
@@ -73,7 +73,7 @@ global_handler(TSCont continuation, TSEvent event, void *data)
 }
 
 void
-TSPluginInit(int argc, const char **argv)
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/tools/plugins/tunnel_transform.cc
+++ b/tests/tools/plugins/tunnel_transform.cc
@@ -192,7 +192,7 @@ handle_transform(TSCont contp, bool forward)
 }
 
 static int
-null_transform(TSCont contp, TSEvent event, void *edata, bool forward)
+null_transform(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */, bool forward)
 {
   /* Check to see if the transformation has been closed by a call to
    * TSVConnClose.
@@ -274,7 +274,7 @@ transform_add(TSHttpTxn txnp)
 }
 
 static int
-transform_plugin(TSCont contp, TSEvent event, void *edata)
+transform_plugin(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 {
   TSHttpTxn txnp = (TSHttpTxn)edata;
 
@@ -293,7 +293,7 @@ transform_plugin(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-handleMsg(TSCont cont, TSEvent event, void *edata)
+handleMsg(TSCont /* cont ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
 {
   Dbg(plugin_ctl, "handleMsg event=%d", event);
   TSStatIntIncrement(stat_test_done, 1);
@@ -301,7 +301,7 @@ handleMsg(TSCont cont, TSEvent event, void *edata)
 }
 
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
 

--- a/tests/tools/plugins/user_args.cc
+++ b/tests/tools/plugins/user_args.cc
@@ -57,7 +57,7 @@ set_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, const char *val)
 }
 
 static int
-cont_global(TSCont contp, TSEvent event, void *edata)
+cont_global(TSCont /* contp ATS_UNUSED */, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSHttpTxn txnp   = static_cast<TSHttpTxn>(edata);
   TSHttpSsn ssnp   = TSHttpTxnSsnGet(txnp);
@@ -73,7 +73,7 @@ cont_global(TSCont contp, TSEvent event, void *edata)
 }
 
 static int
-cont_remap(TSCont contp, TSEvent event, void *edata)
+cont_remap(TSCont contp, TSEvent /* event ATS_UNUSED */, void *edata)
 {
   TSMBuffer   bufp;
   TSMLoc      hdrs;
@@ -96,7 +96,7 @@ cont_remap(TSCont contp, TSEvent event, void *edata)
 
 // Called by ATS as our initialization point
 void
-TSPluginInit(int argc, const char *argv[])
+TSPluginInit(int /* argc ATS_UNUSED */, const char ** /* argv ATS_UNUSED */)
 {
   TSPluginRegistrationInfo info;
   info.plugin_name   = const_cast<char *>("user_args");
@@ -128,7 +128,7 @@ TSPluginInit(int argc, const char *argv[])
 }
 
 TSReturnCode
-TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
+TSRemapInit(TSRemapInterface *api_info, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   TSReleaseAssert(api_info != nullptr);
   TSReleaseAssert(api_info->size == sizeof(TSRemapInterface));
@@ -138,7 +138,8 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 }
 
 TSReturnCode
-TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
+TSRemapNewInstance(int /* argc ATS_UNUSED */, char ** /* argv ATS_UNUSED */, void **ih, char * /* errbuf ATS_UNUSED */,
+                   int /* errbuf_size ATS_UNUSED */)
 {
   ArgIndexes *ix = new ArgIndexes;
 
@@ -173,7 +174,7 @@ TSRemapDeleteInstance(void *ih)
 }
 
 TSRemapStatus
-TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
+TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo * /* rri ATS_UNUSED */)
 {
   ArgIndexes *ix = static_cast<ArgIndexes *>(ih);
 


### PR DESCRIPTION
This is a cherry-pick of #11524.

Use `/* name ATS_UNUSED */` for fully unused parameters in C++ files Use `[[maybe_unused]]` for conditionally unused parameters in C++ files Use `name ATS_UNUSED` for unused parameters in C files