### PR TITLE
CMakePresets: build for autest in Debug

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,6 +54,7 @@
       "inherits": ["default"],
       "binaryDir": "${sourceDir}/build-autest",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_AUTEST": "ON",
         "CMAKE_INSTALL_PREFIX": "/tmp/ts-autest",
         "BUILD_EXPERIMENTAL_PLUGINS": "ON",


### PR DESCRIPTION
Build ATS for autests using debug mode so debug-level assert checking is done. This can also help with debugging autest cores too since optimization will be off.