### PR TITLE
setup_server_read_response_header: remove assertion

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -6669,7 +6669,6 @@ HttpSM::setup_server_read_response_header()
   if (server_txn->get_remote_reader()->read_avail() > 0) {
     state_read_server_response_header((server_entry->eos) ? VC_EVENT_EOS : VC_EVENT_READ_READY, server_entry->read_vio);
   }
-  ink_assert(server_entry->vc != nullptr);
 }
 
 HttpTunnelProducer *


### PR DESCRIPTION
This addresses an intermittent assertion failure associated with Expect:
100-Continue via the h2origin.test.py autest introduced via #11536.
Since the 100 Continue is followed immediately by 200 OK, it is possible
that both are processed at once if the Expect: 100-Continue request has
no body. In these cases, the assertion will fail because
state_read_server_response_header will have processed the entire
response. Since that is now possible, we might as well just remove the
assertion. In theory, it can be kept for the case when there is no
response bytes available to read, but in those situations the assertion
isn't really doing anything because there will be no complicated logic
from state_read_server_response_header and we set the server_entry->vc
earlier in the function.