### PR TITLE
Update `UnixSocket` API for inkdns

### DIFF
--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -56,14 +56,14 @@ struct UnixSocket {
 
   /** Get a new socket.
    *
-   * Call ok() to determine whether this call succeeded. If the call
+   * Call is_ok() to determine whether this call succeeded. If the call
    * failed, errno will be set to indicate the error.
    *
-   * @see ok
+   * @see s_ok
    */
   UnixSocket(int domain, int ctype, int protocol);
 
-  bool ok() const;
+  bool is_ok() const;
 
   int set_nonblocking();
 
@@ -111,7 +111,7 @@ inline UnixSocket::UnixSocket(int domain, int type, int protocol)
 }
 
 inline bool
-UnixSocket::ok() const
+UnixSocket::is_ok() const
 {
   return NO_SOCK != this->fd;
 }

--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -49,9 +49,9 @@
 
 bool transient_error();
 
-struct UnixSocket {
-  int fd{NO_SOCK};
-
+class UnixSocket
+{
+public:
   UnixSocket(int fd);
 
   /** Get a new socket.
@@ -62,6 +62,8 @@ struct UnixSocket {
    * @see s_ok
    */
   UnixSocket(int domain, int ctype, int protocol);
+
+  int get_fd() const;
 
   bool is_ok() const;
 
@@ -101,6 +103,9 @@ struct UnixSocket {
   int shutdown(int how);
 
   static bool client_fastopen_supported();
+
+private:
+  int fd{NO_SOCK};
 };
 
 inline UnixSocket::UnixSocket(int fd) : fd{fd} {}
@@ -108,6 +113,12 @@ inline UnixSocket::UnixSocket(int fd) : fd{fd} {}
 inline UnixSocket::UnixSocket(int domain, int type, int protocol)
 {
   this->fd = socket(domain, type, protocol);
+}
+
+inline int
+UnixSocket::get_fd() const
+{
+  return this->fd;
 }
 
 inline bool

--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -59,7 +59,7 @@ public:
    * Call is_ok() to determine whether this call succeeded. If the call
    * failed, errno will be set to indicate the error.
    *
-   * @see s_ok
+   * @see is_ok
    */
   UnixSocket(int domain, int ctype, int protocol);
 

--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -65,6 +65,8 @@ public:
 
   bool ok() const;
 
+  int set_nonblocking();
+
   int bind(struct sockaddr const *name, int namelen);
   int accept4(struct sockaddr *addr, socklen_t *addrlen, int flags) const;
 

--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -69,6 +69,7 @@ public:
 
   int bind(struct sockaddr const *name, int namelen);
   int accept4(struct sockaddr *addr, socklen_t *addrlen, int flags) const;
+  int connect(struct sockaddr const *addr, socklen_t addrlen);
 
   std::int64_t read(void *buf, int size) const;
 

--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -56,14 +56,14 @@ public:
 
   /** Get a new socket.
    *
-   * Call has_socket() to determine whether this call succeeded. If the call
+   * Call ok() to determine whether this call succeeded. If the call
    * failed, errno will be set to indicate the error.
    *
-   * @see has_socket
+   * @see ok
    */
   UnixSocket(int domain, int ctype, int protocol);
 
-  bool has_socket() const;
+  bool ok() const;
 
   int bind(struct sockaddr const *name, int namelen);
   int accept4(struct sockaddr *addr, socklen_t *addrlen, int flags) const;
@@ -109,7 +109,7 @@ inline UnixSocket::UnixSocket(int domain, int type, int protocol)
 }
 
 inline bool
-UnixSocket::has_socket() const
+UnixSocket::ok() const
 {
   return NO_SOCK != this->sock_fd;
 }

--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -49,9 +49,9 @@
 
 bool transient_error();
 
-class UnixSocket
-{
-public:
+struct UnixSocket {
+  int sock_fd{NO_SOCK};
+
   UnixSocket(int fd);
 
   /** Get a new socket.
@@ -101,9 +101,6 @@ public:
   int shutdown(int how);
 
   static bool client_fastopen_supported();
-
-private:
-  int sock_fd{NO_SOCK};
 };
 
 inline UnixSocket::UnixSocket(int fd) : sock_fd{fd} {}

--- a/include/iocore/eventsystem/UnixSocket.h
+++ b/include/iocore/eventsystem/UnixSocket.h
@@ -94,6 +94,8 @@ public:
   int set_sndbuf_size(int bsz);
   int set_rcvbuf_size(int bsz);
 
+  int enable_option(int level, int optname);
+
   int close();
   int shutdown(int how);
 

--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -26,6 +26,8 @@
 
 #include "iocore/dns/SplitDNS.h"
 
+#include "iocore/eventsystem/UnixSocket.h"
+
 #define SRV_COST    (RRFIXEDSZ + 0)
 #define SRV_WEIGHT  (RRFIXEDSZ + 2)
 #define SRV_PORT    (RRFIXEDSZ + 4)
@@ -507,7 +509,7 @@ DNSHandler::open_con(sockaddr const *target, bool failed, int icon, bool over_tc
 
   Dbg(dbg_ctl_dns, "open_con: opening connection %s", ats_ip_nptop(target, ip_text, sizeof ip_text));
 
-  if (cur_con.fd != NO_FD) { // Remove old FD from epoll fd
+  if (!cur_con.sock.ok()) { // Remove old FD from epoll fd
     cur_con.close();
   }
 
@@ -528,12 +530,12 @@ DNSHandler::open_con(sockaddr const *target, bool failed, int icon, bool over_tc
     }
     return false;
   } else {
-    if (cur_con.eio.start(pd, cur_con.fd, EVENTIO_READ) < 0) {
+    if (cur_con.eio.start(pd, cur_con.sock.fd, EVENTIO_READ) < 0) {
       Error("[iocore_dns] open_con: Failed to add %d server to epoll list\n", icon);
     } else {
       cur_con.num   = icon;
       ns_down[icon] = 0;
-      Dbg(dbg_ctl_dns, "opening connection %s on fd %d SUCCEEDED for %d", ip_text, cur_con.fd, icon);
+      Dbg(dbg_ctl_dns, "opening connection %s on fd %d SUCCEEDED for %d", ip_text, cur_con.sock.fd, icon);
     }
     ret = true;
   }
@@ -677,14 +679,14 @@ DNSHandler::retry_named(int ndx, ink_hrtime t, bool reopen)
     open_cons(&m_res->nsaddr_list[ndx].sa, true, ndx);
   }
   bool          over_tcp = dns_conn_mode == DNS_CONN_MODE::TCP_ONLY;
-  int           con_fd   = over_tcp ? tcpcon[ndx].fd : udpcon[ndx].fd;
+  UnixSocket    con_sock = over_tcp ? tcpcon[ndx].sock : udpcon[ndx].sock;
   unsigned char buffer[MAX_DNS_REQUEST_LEN];
   Dbg(dbg_ctl_dns, "trying to resolve '%s' from DNS connection, ndx %d", try_server_names[try_servers], ndx);
   int r       = _ink_res_mkquery(m_res, try_server_names[try_servers], T_A, buffer, over_tcp);
   try_servers = (try_servers + 1) % countof(try_server_names);
   ink_assert(r >= 0);
   if (r >= 0) { // looking for a bounce
-    int res = SocketManager::send(con_fd, buffer, r, 0);
+    int res = con_sock.send(buffer, r, 0);
     Dbg(dbg_ctl_dns, "ping result = %d", res);
   }
 }
@@ -701,7 +703,7 @@ DNSHandler::try_primary_named(bool reopen)
   if ((t - last_primary_retry) > DNS_PRIMARY_RETRY_PERIOD) {
     unsigned char buffer[MAX_DNS_REQUEST_LEN];
     bool          over_tcp = dns_conn_mode == DNS_CONN_MODE::TCP_ONLY;
-    int           con_fd   = over_tcp ? tcpcon[0].fd : udpcon[0].fd;
+    UnixSocket    con_sock = over_tcp ? tcpcon[0].sock : udpcon[0].sock;
     last_primary_retry     = t;
     Dbg(dbg_ctl_dns, "trying to resolve '%s' from primary DNS connection", try_server_names[try_servers]);
     int r = _ink_res_mkquery(m_res, try_server_names[try_servers], T_A, buffer, over_tcp);
@@ -714,7 +716,7 @@ DNSHandler::try_primary_named(bool reopen)
     }
     ink_assert(r >= 0);
     if (r >= 0) { // looking for a bounce
-      int res = SocketManager::send(con_fd, buffer, r, 0);
+      int res = con_sock.send(buffer, r, 0);
       Dbg(dbg_ctl_dns, "ping result = %d", res);
     }
   }
@@ -866,7 +868,7 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         if (dnsc->tcp_data.total_length == 0) {
           // see if TS gets a two-byte size
           uint16_t tmp = 0;
-          res          = SocketManager::recv(dnsc->fd, &tmp, sizeof(tmp), MSG_PEEK);
+          res          = dnsc->sock.recv(&tmp, sizeof(tmp), MSG_PEEK);
           if (res == -EAGAIN || res == 1) {
             break;
           }
@@ -874,7 +876,7 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
             goto Lerror;
           }
           // reading total size
-          res = SocketManager::recv(dnsc->fd, &(dnsc->tcp_data.total_length), sizeof(dnsc->tcp_data.total_length), 0);
+          res = dnsc->sock.recv(&(dnsc->tcp_data.total_length), sizeof(dnsc->tcp_data.total_length), 0);
           if (res == -EAGAIN) {
             break;
           }
@@ -888,7 +890,7 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         }
         // continue reading data
         void *buf_start = (char *)dnsc->tcp_data.buf_ptr->buf + dnsc->tcp_data.done_reading;
-        res             = SocketManager::recv(dnsc->fd, buf_start, dnsc->tcp_data.total_length - dnsc->tcp_data.done_reading, 0);
+        res             = dnsc->sock.recv(buf_start, dnsc->tcp_data.total_length - dnsc->tcp_data.done_reading, 0);
         if (res == -EAGAIN) {
           break;
         }
@@ -910,7 +912,7 @@ DNSHandler::recv_dns(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
         hostent_cache = dnsBufAllocator.alloc();
       }
 
-      res = SocketManager::recvfrom(dnsc->fd, hostent_cache->buf, MAX_DNS_RESPONSE_LEN, 0, &from_ip.sa, &from_length);
+      res = dnsc->sock.recvfrom(hostent_cache->buf, MAX_DNS_RESPONSE_LEN, 0, &from_ip.sa, &from_length);
       Dbg(dbg_ctl_dns, "DNSHandler::recv_dns res = [%d]", res);
       if (res == -EAGAIN) {
         break;
@@ -1181,10 +1183,10 @@ write_dns_event(DNSHandler *h, DNSEntry *e, bool over_tcp)
     h->release_query_id(e->id[dns_retries - e->retries]);
   }
   e->id[dns_retries - e->retries] = i;
-  int con_fd                      = over_tcp ? h->tcpcon[h->name_server].fd : h->udpcon[h->name_server].fd;
-  Dbg(dbg_ctl_dns, "send query (qtype=%d) for %s to fd %d", e->qtype, e->qname, con_fd);
+  UnixSocket con_sock             = over_tcp ? h->tcpcon[h->name_server].sock : h->udpcon[h->name_server].sock;
+  Dbg(dbg_ctl_dns, "send query (qtype=%d) for %s to fd %d", e->qtype, e->qname, con_sock.fd);
 
-  int s = SocketManager::send(con_fd, buffer, r, 0);
+  int s = con_sock.send(buffer, r, 0);
   if (s != r) {
     Dbg(dbg_ctl_dns, "send() failed: qname = %s, %d != %d, nameserver= %d", e->qname, s, r, h->name_server);
 

--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -530,12 +530,12 @@ DNSHandler::open_con(sockaddr const *target, bool failed, int icon, bool over_tc
     }
     return false;
   } else {
-    if (cur_con.eio.start(pd, cur_con.sock.fd, EVENTIO_READ) < 0) {
+    if (cur_con.eio.start(pd, cur_con.sock.get_fd(), EVENTIO_READ) < 0) {
       Error("[iocore_dns] open_con: Failed to add %d server to epoll list\n", icon);
     } else {
       cur_con.num   = icon;
       ns_down[icon] = 0;
-      Dbg(dbg_ctl_dns, "opening connection %s on fd %d SUCCEEDED for %d", ip_text, cur_con.sock.fd, icon);
+      Dbg(dbg_ctl_dns, "opening connection %s on fd %d SUCCEEDED for %d", ip_text, cur_con.sock.get_fd(), icon);
     }
     ret = true;
   }
@@ -1184,7 +1184,7 @@ write_dns_event(DNSHandler *h, DNSEntry *e, bool over_tcp)
   }
   e->id[dns_retries - e->retries] = i;
   UnixSocket con_sock             = over_tcp ? h->tcpcon[h->name_server].sock : h->udpcon[h->name_server].sock;
-  Dbg(dbg_ctl_dns, "send query (qtype=%d) for %s to fd %d", e->qtype, e->qname, con_sock.fd);
+  Dbg(dbg_ctl_dns, "send query (qtype=%d) for %s to fd %d", e->qtype, e->qname, con_sock.get_fd());
 
   int s = con_sock.send(buffer, r, 0);
   if (s != r) {

--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -509,7 +509,7 @@ DNSHandler::open_con(sockaddr const *target, bool failed, int icon, bool over_tc
 
   Dbg(dbg_ctl_dns, "open_con: opening connection %s", ats_ip_nptop(target, ip_text, sizeof ip_text));
 
-  if (!cur_con.sock.ok()) { // Remove old FD from epoll fd
+  if (!cur_con.sock.is_ok()) { // Remove old FD from epoll fd
     cur_con.close();
   }
 

--- a/src/iocore/dns/DNSConnection.cc
+++ b/src/iocore/dns/DNSConnection.cc
@@ -36,9 +36,6 @@
 #define SET_TCP_NO_DELAY
 #define SET_NO_LINGER
 #define SET_SO_KEEPALIVE
-// set in the OS
-// #define RECV_BUF_SIZE            (1024*64)
-// #define SEND_BUF_SIZE            (1024*64)
 #define FIRST_RANDOM_PORT (16000)
 #define LAST_RANDOM_PORT  (60000)
 
@@ -180,9 +177,6 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
       goto Lerror;
     }
   }
-#endif
-#ifdef RECV_BUF_SIZE
-  SocketManager::set_rcvbuf_size(fd, RECV_BUF_SIZE);
 #endif
 #ifdef SET_SO_KEEPALIVE
   // enables 2 hour inactivity probes, also may fix IRIX FIN_WAIT_2 leak

--- a/src/iocore/dns/DNSConnection.cc
+++ b/src/iocore/dns/DNSConnection.cc
@@ -87,7 +87,7 @@ DNSConnection::trigger()
 int
 DNSConnection::connect(sockaddr const *addr, Options const &opt)
 {
-  ink_assert(!this->sock.ok());
+  ink_assert(!this->sock.is_ok());
   ink_assert(ats_is_ip(addr));
   this->opt = opt;
   this->tcp_data.reset();
@@ -103,7 +103,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
     this->sock = UnixSocket{af, SOCK_DGRAM, 0};
   }
 
-  if (!this->sock.ok()) {
+  if (!this->sock.is_ok()) {
     goto Lerror;
   }
 
@@ -190,7 +190,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
   return 0;
 
 Lerror:
-  if (this->sock.ok()) {
+  if (this->sock.is_ok()) {
     close();
   }
   return res;

--- a/src/iocore/dns/DNSConnection.cc
+++ b/src/iocore/dns/DNSConnection.cc
@@ -190,7 +190,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
   return 0;
 
 Lerror:
-  if (!this->sock.ok()) {
+  if (this->sock.ok()) {
     close();
   }
   return res;

--- a/src/iocore/dns/DNSConnection.cc
+++ b/src/iocore/dns/DNSConnection.cc
@@ -190,7 +190,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
   return 0;
 
 Lerror:
-  if (this->sock.ok()) {
+  if (!this->sock.ok()) {
     close();
   }
   return res;

--- a/src/iocore/dns/DNSConnection.cc
+++ b/src/iocore/dns/DNSConnection.cc
@@ -31,7 +31,8 @@
 #include "P_DNS.h"
 #include "P_DNSConnection.h"
 #include "P_DNSProcessor.h"
-#include "tscore/ink_sock.h"
+
+#include "iocore/eventsystem/UnixSocket.h"
 
 #define SET_TCP_NO_DELAY
 #define SET_NO_LINGER
@@ -52,8 +53,7 @@ DbgCtl dbg_ctl_dns{"dns"};
 // Functions
 //
 
-DNSConnection::DNSConnection()
-  : fd(NO_FD), generator(static_cast<uint32_t>(static_cast<uintptr_t>(time(nullptr)) ^ (uintptr_t)this))
+DNSConnection::DNSConnection() : generator(static_cast<uint32_t>(static_cast<uintptr_t>(time(nullptr)) ^ (uintptr_t)this))
 {
   memset(&ip, 0, sizeof(ip));
 }
@@ -67,15 +67,7 @@ int
 DNSConnection::close()
 {
   eio.stop();
-  // don't close any of the standards
-  if (fd >= 2) {
-    int fd_save = fd;
-    fd          = NO_FD;
-    return SocketManager::close(fd_save);
-  } else {
-    fd = NO_FD;
-    return -EBADF;
-  }
+  return this->sock.close();
 }
 
 void
@@ -95,30 +87,25 @@ DNSConnection::trigger()
 int
 DNSConnection::connect(sockaddr const *addr, Options const &opt)
 {
-  ink_assert(fd == NO_FD);
+  ink_assert(!this->sock.ok());
   ink_assert(ats_is_ip(addr));
   this->opt = opt;
   this->tcp_data.reset();
 
   int        res = 0;
-  short      Proto;
-  uint8_t    af = addr->sa_family;
+  uint8_t    af  = addr->sa_family;
   IpEndpoint bind_addr;
   size_t     bind_size = 0;
 
   if (opt._use_tcp) {
-    Proto = IPPROTO_TCP;
-    if ((res = SocketManager::socket(af, SOCK_STREAM, 0)) < 0) {
-      goto Lerror;
-    }
+    this->sock = UnixSocket{af, SOCK_STREAM, 0};
   } else {
-    Proto = IPPROTO_UDP;
-    if ((res = SocketManager::socket(af, SOCK_DGRAM, 0)) < 0) {
-      goto Lerror;
-    }
+    this->sock = UnixSocket{af, SOCK_DGRAM, 0};
   }
 
-  fd = res;
+  if (!this->sock.ok()) {
+    goto Lerror;
+  }
 
   memset(&bind_addr, 0, sizeof bind_addr);
   bind_addr.sa.sa_family = af;
@@ -149,7 +136,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
       p                               = static_cast<uint16_t>((p % (LAST_RANDOM_PORT - FIRST_RANDOM_PORT)) + FIRST_RANDOM_PORT);
       ats_ip_port_cast(&bind_addr.sa) = htons(p); // stuff port in sockaddr.
       Dbg(dbg_ctl_dns, "random port = %s", ats_ip_nptop(&bind_addr.sa, b, sizeof b));
-      if (SocketManager::ink_bind(fd, &bind_addr.sa, bind_size, Proto) < 0) {
+      if (this->sock.bind(&bind_addr.sa, bind_size) < 0) {
         continue;
       }
       goto Lok;
@@ -158,14 +145,14 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
   Lok:;
   } else if (ats_is_ip(&bind_addr.sa)) {
     ip_text_buffer b;
-    res = SocketManager::ink_bind(fd, &bind_addr.sa, bind_size, Proto);
+    res = this->sock.bind(&bind_addr.sa, bind_size);
     if (res < 0) {
       Warning("Unable to bind local address to %s.", ats_ip_ntop(&bind_addr.sa, b, sizeof b));
     }
   }
 
   if (opt._non_blocking_connect) {
-    if ((res = safe_nonblocking(fd)) < 0) {
+    if ((res = this->sock.set_nonblocking()) < 0) {
       goto Lerror;
     }
   }
@@ -173,24 +160,24 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
 // cannot do this after connection on non-blocking connect
 #ifdef SET_TCP_NO_DELAY
   if (opt._use_tcp) {
-    if ((res = setsockopt_on(fd, IPPROTO_TCP, TCP_NODELAY)) < 0) {
+    if ((res = this->sock.enable_option(IPPROTO_TCP, TCP_NODELAY)) < 0) {
       goto Lerror;
     }
   }
 #endif
 #ifdef SET_SO_KEEPALIVE
   // enables 2 hour inactivity probes, also may fix IRIX FIN_WAIT_2 leak
-  if ((res = setsockopt_on(fd, SOL_SOCKET, SO_KEEPALIVE)) < 0) {
+  if ((res = this->sock.enable_option(SOL_SOCKET, SO_KEEPALIVE)) < 0) {
     goto Lerror;
   }
 #endif
 
   ats_ip_copy(&ip.sa, addr);
-  res = ::connect(fd, addr, ats_ip_size(addr));
+  res = this->sock.connect(addr, ats_ip_size(addr));
 
   if (!res || ((res < 0) && (errno == EINPROGRESS || errno == EWOULDBLOCK))) {
     if (!opt._non_blocking_connect && opt._non_blocking_io) {
-      if ((res = safe_nonblocking(fd)) < 0) {
+      if ((res = this->sock.set_nonblocking()) < 0) {
         goto Lerror;
       }
     }
@@ -203,7 +190,7 @@ DNSConnection::connect(sockaddr const *addr, Options const &opt)
   return 0;
 
 Lerror:
-  if (fd != NO_FD) {
+  if (this->sock.ok()) {
     close();
   }
   return res;

--- a/src/iocore/dns/P_DNSConnection.h
+++ b/src/iocore/dns/P_DNSConnection.h
@@ -33,6 +33,8 @@
 #include "iocore/dns/DNSEventIO.h"
 #include "iocore/dns/DNSProcessor.h"
 
+#include "iocore/eventsystem/UnixSocket.h"
+
 #include "tscore/ink_platform.h"
 #include "tscore/ink_rand.h"
 #include "tscore/List.h"
@@ -80,7 +82,7 @@ struct DNSConnection {
     self &setLocalIpv4(sockaddr const *addr);
   };
 
-  int        fd;
+  UnixSocket sock{NO_SOCK};
   IpEndpoint ip;
   int        num = 0;
   Options    opt;

--- a/src/iocore/eventsystem/UnixSocket.cc
+++ b/src/iocore/eventsystem/UnixSocket.cc
@@ -53,20 +53,20 @@ static unsigned int read_uint_from_fd(int fd);
 int
 UnixSocket::set_nonblocking()
 {
-  return safe_set_fl(this->sock_fd, O_NONBLOCK);
+  return safe_set_fl(this->fd, O_NONBLOCK);
 }
 
 int
 UnixSocket::bind(struct sockaddr const *name, int namelen)
 {
-  return safe_bind(this->sock_fd, name, namelen);
+  return safe_bind(this->fd, name, namelen);
 }
 
 int
 UnixSocket::accept4(struct sockaddr *addr, socklen_t *addrlen, int flags) const
 {
   do {
-    int fd = ::accept4(this->sock_fd, addr, addrlen, flags);
+    int fd = ::accept4(this->fd, addr, addrlen, flags);
     if (likely(fd >= 0)) {
       return fd;
     }
@@ -108,14 +108,14 @@ accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags)
 int
 UnixSocket::connect(struct sockaddr const *addr, socklen_t addrlen)
 {
-  return ::connect(this->sock_fd, addr, addrlen);
+  return ::connect(this->fd, addr, addrlen);
 }
 
 int
 UnixSocket::enable_option(int level, int optname)
 {
   int on = 1;
-  return safe_setsockopt(this->sock_fd, level, optname, &on, sizeof(on));
+  return safe_setsockopt(this->fd, level, optname, &on, sizeof(on));
 }
 
 int
@@ -123,14 +123,14 @@ UnixSocket::close()
 {
   int res;
 
-  if (this->sock_fd == 0) {
+  if (this->fd == 0) {
     return -EACCES;
-  } else if (this->sock_fd < 0) {
+  } else if (this->fd < 0) {
     return -EINVAL;
   }
 
   do {
-    res = ::close(this->sock_fd);
+    res = ::close(this->fd);
     if (res == -1) {
       res = -errno;
     }

--- a/src/iocore/eventsystem/UnixSocket.cc
+++ b/src/iocore/eventsystem/UnixSocket.cc
@@ -134,7 +134,7 @@ UnixSocket::close()
     if (res == -1) {
       res = -errno;
     } else {
-      this->fd = -1;
+      this->fd = NO_SOCK;
     }
   } while (res == -EINTR);
 

--- a/src/iocore/eventsystem/UnixSocket.cc
+++ b/src/iocore/eventsystem/UnixSocket.cc
@@ -106,6 +106,13 @@ accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags)
 #endif // !HAVE_ACCEPT4
 
 int
+UnixSocket::enable_option(int level, int optname)
+{
+  int on = 1;
+  return safe_setsockopt(this->sock_fd, level, optname, &on, sizeof(on));
+}
+
+int
 UnixSocket::close()
 {
   int res;

--- a/src/iocore/eventsystem/UnixSocket.cc
+++ b/src/iocore/eventsystem/UnixSocket.cc
@@ -106,6 +106,12 @@ accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags)
 #endif // !HAVE_ACCEPT4
 
 int
+UnixSocket::connect(struct sockaddr const *addr, socklen_t addrlen)
+{
+  return ::connect(this->sock_fd, addr, addrlen);
+}
+
+int
 UnixSocket::enable_option(int level, int optname)
 {
   int on = 1;

--- a/src/iocore/eventsystem/UnixSocket.cc
+++ b/src/iocore/eventsystem/UnixSocket.cc
@@ -121,7 +121,7 @@ UnixSocket::enable_option(int level, int optname)
 int
 UnixSocket::close()
 {
-  int res;
+  int res{};
 
   if (this->fd == 0) {
     return -EACCES;
@@ -133,8 +133,11 @@ UnixSocket::close()
     res = ::close(this->fd);
     if (res == -1) {
       res = -errno;
+    } else {
+      this->fd = -1;
     }
   } while (res == -EINTR);
+
   return res;
 }
 

--- a/src/iocore/eventsystem/UnixSocket.cc
+++ b/src/iocore/eventsystem/UnixSocket.cc
@@ -51,6 +51,12 @@ static int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int fl
 static unsigned int read_uint_from_fd(int fd);
 
 int
+UnixSocket::set_nonblocking()
+{
+  return safe_set_fl(this->sock_fd, O_NONBLOCK);
+}
+
+int
 UnixSocket::bind(struct sockaddr const *name, int namelen)
 {
   return safe_bind(this->sock_fd, name, namelen);


### PR DESCRIPTION
This includes a number of updates to `UnixSocket` to make the API easier to use and more encompassing, with the goal of replacing `SocketManager`, and properly abstracting on top of ink_sock.h. The first and last commit refactor inkdns to depend on the new API, and remove its dependencies on both `SocketManager` and ink_sock.h.