### PR TITLE
Errata: Make sure the initialization of the errata members are in place.

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -694,6 +694,8 @@ initialize_process_manager()
 
 extern void initializeRegistry();
 
+extern void Initialize_Errata_Settings();
+
 static void
 initialize_file_manager()
 {
@@ -1778,6 +1780,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 #if defined(DEBUG) && defined(HAVE_MCHECK_PEDANTIC)
   mcheck_pedantic(NULL);
 #endif
+
+  // Override default swoc::Errata settings.
+  Initialize_Errata_Settings();
 
   pcre_malloc = ats_malloc;
   pcre_free   = ats_free;

--- a/src/tsutil/ts_diags.cc
+++ b/src/tsutil/ts_diags.cc
@@ -25,9 +25,10 @@
 #include "tsutil/ts_diag_levels.h"
 #include "tsutil/ts_errata.h"
 
-static const bool INITIALIZED = []() -> bool {
+void
+Initialize_Errata_Settings()
+{
   swoc::Errata::DEFAULT_SEVERITY = ERRATA_ERROR;
   swoc::Errata::FAILURE_SEVERITY = ERRATA_WARN;
   swoc::Errata::SEVERITY_NAMES   = swoc::MemSpan<swoc::TextView const>(Severity_Names.data(), Severity_Names.size());
-  return true;
-}();
+}


### PR DESCRIPTION
It seems the compiler/linker can omit a unit(in a static lib) if none of the functions in they are actually called. 
This commit adds a function call to initialize the `swoc::Errata` settings.
Without this the Errata is not properly initialized and runs with the defaults values.

with the change:
```
[Jul 16 16:06:30.658] traffic_server WARNING: We have found the following issues when reading the records node:
 Error:   'records' root key not present or no fields to read.
  'records' root key not present or no fields to read.
  'records' root key not present or no fields to read.
  'records' root key not present or no fields to read.
  Warn: Ignoring field 'invalid_record' at Line 114. Not registered and Unknown tag type '?'
 

```
Check the issue and the details before this patch:

fixes: https://github.com/apache/trafficserver/issues/11553