### PR TITLE
Rename `Stripe` to `StripeSM`

### DIFF
--- a/doc/developer-guide/cache-architecture/architecture.en.rst
+++ b/doc/developer-guide/cache-architecture/architecture.en.rst
@@ -126,7 +126,7 @@ span of bytes. Internally each stripe is treated almost entirely independently.
 The data structures described in this section are duplicated for each stripe.
 
 Internally the term *volume* is used for these stripes and implemented primarily
-in :cpp:class:`Stripe`. What a user thinks of as a volume (and what this document
+in :cpp:class:`StripeSM`. What a user thinks of as a volume (and what this document
 calls a *cache volume*) is represented by :cpp:class:`CacheVol`.
 
 .. note::
@@ -280,11 +280,11 @@ start
    The offset for the start of the content, after the stripe metadata.
 
 length
-   Total number of bytes in the stripe. :cpp:member:`Stripe::len`.
+   Total number of bytes in the stripe. :cpp:member:`StripeSM::len`.
 
 data length
    Total number of blocks in the stripe available for content storage.
-   :cpp:member:`Stripe::data_blocks`.
+   :cpp:member:`StripeSM::data_blocks`.
 
 .. note::
 
@@ -505,7 +505,7 @@ Disk Failure
 
 The cache is designed to be relatively resistant to disk failures. Because each
 :term:`storage unit` in each :term:`cache volume` is mostly independent, the
-loss of a disk simply means that the corresponding :cpp:class:`Stripe` instances
+loss of a disk simply means that the corresponding :cpp:class:`StripeSM` instances
 (one per cache volume that uses the storage unit) becomes unusable. The primary
 issue is updating the volume assignment table to both preserve assignments for
 objects on still operational volumes while distributing the assignments from the
@@ -778,7 +778,7 @@ The basic steps to a cache lookup are:
 
 #. The cache stripe is determined (based on the cache key).
 
-   The :term:`cache key` is used as a hash key in to an array of :cpp:class:`Stripe` instances by
+   The :term:`cache key` is used as a hash key in to an array of :cpp:class:`StripeSM` instances by
    :func:`Cache::key_to_stripe`. The construction and arrangement of this array is the essence of how
    volumes are assigned.
 
@@ -939,7 +939,7 @@ Aggregation Buffer
 ------------------
 
 Disk writes to cache are handled through an *aggregation buffer*. There is one
-for each :cpp:class:`Stripe` instance. To minimize the number of system calls data
+for each :cpp:class:`StripeSM` instance. To minimize the number of system calls data
 is written to disk in units of roughly :ref:`target fragment size <target-fragment-size>`
 bytes. The algorithm used is simple: data is piled up in the aggregation buffer
 until no more will fit without going over the target fragment size, at which
@@ -974,11 +974,11 @@ In some cases this is not acceptable and the object is *evacuated* by reading
 it from the cache and then writing it back to cache which moves the physical
 storage of the object from in front of the write cursor to behind the write
 cursor. Objects that are evacuated are handled in this way based on data in
-stripe data structures (attached to the :cpp:class:`Stripe` instance).
+stripe data structures (attached to the :cpp:class:`StripeSM` instance).
 
 Evacuation data structures are defined by dividing up the volume content into
 a disjoint and contiguous set of regions of ``EVACUATION_BUCKET_SIZE`` bytes.
-The :cpp:member:`Stripe::evacuate` member is an array with an element for each
+The :cpp:member:`StripeSM::evacuate` member is an array with an element for each
 evacuation region. Each element is a doubly linked list of :cpp:class:`EvacuationBlock`
 instances. Each instance contains a :cpp:class:`Dir` that specifies the fragment
 to evacuate. It is assumed that an evacuation block is placed in the evacuation
@@ -1004,14 +1004,14 @@ if the count goes to zero. If the ``EvacuationBlock`` already exists with a
 count of zero, the count is not modified and the number of readers is not
 tracked, so the evacuation is valid as long as the object exists.
 
-Evacuation is driven by cache writes, essentially in :cpp:member:`Stripe::aggWrite`.
+Evacuation is driven by cache writes, essentially in :cpp:member:`StripeSM::aggWrite`.
 This method processes the pending cache virtual connections that are trying to
 write to the stripe. Some of these may be evacuation virtual connections. If so
 then the completion callback for that virtual connection is called as the data
 is put in to the aggregation buffer.
 
 When no more cache virtual connections can be processed (due to an empty queue
-or the aggregation buffer filling) then :cpp:member:`Stripe::evac_range` is called
+or the aggregation buffer filling) then :cpp:member:`StripeSM::evac_range` is called
 to clear the range to be overwritten plus an additional :c:macro:`EVACUATION_SIZE`
 range. The buckets covering that range are checked. If there are any items in
 the buckets a new cache virtual connection (a *doc evacuator*) is created and
@@ -1021,7 +1021,7 @@ the read completes it is checked for validity and if valid, the cache virtual
 connection for it is placed at the front of the write queue for the stripe and
 the write aggregation resumed.
 
-Before doing a write, the method :cpp:member:`Stripe::evac_range()` is called to
+Before doing a write, the method :cpp:member:`StripeSM::evac_range()` is called to
 start an evacuation. If any fragments are found in the buckets in the range the
 earliest such fragment (smallest offset, closest to the write cursor) is
 selected and read from disk and the aggregation buffer write is suspended. The

--- a/doc/developer-guide/cache-architecture/core-cache-functions.en.rst
+++ b/doc/developer-guide/cache-architecture/core-cache-functions.en.rst
@@ -96,7 +96,7 @@ Core Cache Types
 Core Cache Functions
 ====================
 
-.. cpp:function:: int dir_probe(const CacheKey * key, Stripe * d, Dir * result, Dir ** last_collision)
+.. cpp:function:: int dir_probe(const CacheKey * key, StripeSM * d, Dir * result, Dir ** last_collision)
 
   Probe the stripe directory for a candidate directory entry.
 

--- a/doc/developer-guide/cache-architecture/data-structures.en.rst
+++ b/doc/developer-guide/cache-architecture/data-structures.en.rst
@@ -27,9 +27,9 @@ Data Structures
 
    hide empty members
 
-   CacheHostRecord *-- "*" Stripe : stripe >
+   CacheHostRecord *-- "*" StripeSM : stripe >
    CacheHostRecord *-- "*" CacheVol : cp >
-   CacheVol *-- "*" Stripe : stripe >
+   CacheVol *-- "*" StripeSM : stripe >
 
 .. var:: size_t STORE_BLOCK_SIZE = 8192
 
@@ -58,7 +58,7 @@ Data Structures
 
       The cache volumes that are part of this cache host record.
 
-   .. member:: Stripe ** vols
+   .. member:: StripeSM ** vols
 
       The stripes that are part of the cache volumes. This is the union over the stripes of
       :member:`CacheHostRecord::cp`
@@ -133,7 +133,7 @@ Data Structures
 
    * Timestamps for request and response from :term:`origin server`.
 
-.. class:: Stripe
+.. class:: StripeSM
 
    This represents a :term:`storage unit` inside a :term:`cache volume`.
 
@@ -279,11 +279,11 @@ Data Structures
 
 .. class:: DiskStripeBlock
 
-   A description of a span stripe (Stripe) block . This is a serialized data structure.
+   A description of a span stripe (StripeSM) block . This is a serialized data structure.
 
    .. member:: uint64_t offset
 
-      Offset in the span of the start of the span stripe (Stripe) block, in bytes.
+      Offset in the span of the start of the span stripe (StripeSM) block, in bytes.
 
    .. member:: uint64_t len
 
@@ -356,7 +356,7 @@ Data Structures
 
    .. member:: int new_block
 
-      Indicates if this is a new stripe rather than an existing one. In case a stripe is new ATS decides to clear that stripe(:class:`Stripe`)
+      Indicates if this is a new stripe rather than an existing one. In case a stripe is new ATS decides to clear that stripe(:class:`StripeSM`)
 
    .. member:: LINK<DiskStripeBlockQueue> link
 
@@ -372,7 +372,7 @@ Data Structures
 
    .. member:: int vol_number
 
-      Identification number of the stripe (:class:`Stripe`)
+      Identification number of the stripe (:class:`StripeSM`)
 
    .. member:: uint64_t size
 
@@ -407,11 +407,11 @@ Data Structures
 
    .. member:: int num_vols
 
-      Number of stripes(:class:`Stripe`) contained in this volume
+      Number of stripes(:class:`StripeSM`) contained in this volume
 
-   .. member:: Stripe** vols
+   .. member:: StripeSM** vols
 
-      :class:`Stripe` represents a single stripe in the disk. vols contains all the stripes this volume is made up of
+      :class:`StripeSM` represents a single stripe in the disk. vols contains all the stripes this volume is made up of
 
    .. member:: DiskStripe** disk_vols
 
@@ -466,9 +466,9 @@ Data Structures
       A generic class:`CacheHostRecord` that contains all cache volumes that are not explicitly
       assigned in :file:`hosting.config`.
 
-   .. function:: Stripe * key_to_stripe(CryptoHash * key, const char * host, int host_len)
+   .. function:: StripeSM * key_to_stripe(CryptoHash * key, const char * host, int host_len)
 
-      Compute the stripe (:code:`Stripe *`) for a cache :arg:`key` and :arg:`host`. The :arg:`host` is
+      Compute the stripe (:code:`StripeSM *`) for a cache :arg:`key` and :arg:`host`. The :arg:`host` is
       used to find the appropriate :class:`CacheHostRecord` instance. From there the stripe
       assignment slot is determined by taking bits 64..83 (20 bits) of the cache :arg:`key` modulo
       the stripe assignment array count (:code:`STRIPE_HASH_TABLE_SIZE`). These bits are the third 32

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -260,7 +260,7 @@ struct CacheVC : public CacheVConnection {
   uint32_t                  write_len;    // for communicating with agg_copy
   uint32_t                  agg_len;      // for communicating with aggWrite
   uint32_t                  write_serial; // serial of the final write for SYNC
-  StripeSM                   *stripe;
+  StripeSM                 *stripe;
   Dir                      *last_collision;
   Event                    *trigger;
   CacheKey                 *read_key;

--- a/include/iocore/cache/CacheVC.h
+++ b/include/iocore/cache/CacheVC.h
@@ -260,7 +260,7 @@ struct CacheVC : public CacheVConnection {
   uint32_t                  write_len;    // for communicating with agg_copy
   uint32_t                  agg_len;      // for communicating with aggWrite
   uint32_t                  write_serial; // serial of the final write for SYNC
-  Stripe                   *stripe;
+  StripeSM                   *stripe;
   Dir                      *last_collision;
   Event                    *trigger;
   CacheKey                 *read_key;

--- a/src/iocore/cache/AggregateWriteBuffer.h
+++ b/src/iocore/cache/AggregateWriteBuffer.h
@@ -80,7 +80,7 @@ public:
    *   have a correct len field, and its headers and data must follow it. This
    *   requires a pointer to a full document buffer - not just the Doc struct.
    * @param approx_size The approximate size of all headers and data as
-   *   determined by Stripe::round_to_approx_size. The document may not need
+   *   determined by StripeSM::round_to_approx_size. The document may not need
    *   this much space.
    *
    */
@@ -100,7 +100,7 @@ public:
    * The new document will be uninitialized.
    *
    * @param approx_size The approximate size of all headers and data as
-   *   determined by Stripe::round_to_approx_size. The document may not need
+   *   determined by StripeSM::round_to_approx_size. The document may not need
    *   this much space.
    * @return Returns a non-owning pointer to the new document.
    */

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -230,7 +230,7 @@ CachePeriodicMetricsUpdate()
   if (cacheProcessor.initialized == CACHE_INITIALIZED) {
     for (int i = 0; i < gnstripes; ++i) {
       StripeSM *v    = gstripes[i];
-      int64_t used = cache_bytes_used(i);
+      int64_t   used = cache_bytes_used(i);
 
       Metrics::Gauge::increment(v->cache_vol->vol_rsb.bytes_used, used); // This assumes they start at zero
       total_sum += used;
@@ -690,7 +690,7 @@ CacheProcessor::cacheInitialized()
 
       for (int i = 0; i < gnstripes; i++) {
         StripeSM *stripe          = gstripes[i];
-        int64_t ram_cache_bytes = 0;
+        int64_t   ram_cache_bytes = 0;
 
         if (stripe->cache_vol->ramcache_enabled) {
           if (http_ram_cache_size == 0) {
@@ -873,7 +873,7 @@ build_vol_hash_table(CacheHostRecord *cp)
 {
   int           num_vols = cp->num_vols;
   unsigned int *mapping  = static_cast<unsigned int *>(ats_malloc(sizeof(unsigned int) * num_vols));
-  StripeSM      **p        = static_cast<StripeSM **>(ats_malloc(sizeof(StripeSM *) * num_vols));
+  StripeSM    **p        = static_cast<StripeSM **>(ats_malloc(sizeof(StripeSM *) * num_vols));
 
   memset(mapping, 0, num_vols * sizeof(unsigned int));
   memset(p, 0, num_vols * sizeof(StripeSM *));
@@ -1226,8 +1226,8 @@ Cache::lookup(Continuation *cont, const CacheKey *key, CacheFragType type, const
     return ACTION_RESULT_DONE;
   }
 
-  StripeSM  *stripe = key_to_stripe(key, hostname, host_len);
-  CacheVC *c      = new_CacheVC(cont);
+  StripeSM *stripe = key_to_stripe(key, hostname, host_len);
+  CacheVC  *c      = new_CacheVC(cont);
   SET_CONTINUATION_HANDLER(c, &CacheVC::openReadStartHead);
   c->vio.op  = VIO::READ;
   c->op_type = static_cast<int>(CacheOpType::Lookup);

--- a/src/iocore/cache/CacheHosting.cc
+++ b/src/iocore/cache/CacheHosting.cc
@@ -441,7 +441,7 @@ CacheHostRecord::Init(CacheType typ)
     Warning("error: No volumes found for Cache Type %d", type);
     return -1;
   }
-  stripes     = static_cast<Stripe **>(ats_malloc(num_vols * sizeof(Stripe *)));
+  stripes     = static_cast<StripeSM **>(ats_malloc(num_vols * sizeof(StripeSM *)));
   int counter = 0;
   for (i = 0; i < num_cachevols; i++) {
     CacheVol *cachep1 = cp[i];
@@ -563,7 +563,7 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
   if (!num_vols) {
     return -1;
   }
-  stripes     = static_cast<Stripe **>(ats_malloc(num_vols * sizeof(Stripe *)));
+  stripes     = static_cast<StripeSM **>(ats_malloc(num_vols * sizeof(StripeSM *)));
   int counter = 0;
   for (i = 0; i < num_cachevols; i++) {
     CacheVol *cachep = cp[i];

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -48,7 +48,7 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheFragType type, co
   }
   ink_assert(caches[type] == this);
 
-  Stripe       *stripe = key_to_stripe(key, hostname, host_len);
+  StripeSM       *stripe = key_to_stripe(key, hostname, host_len);
   Dir           result, *last_collision = nullptr;
   ProxyMutex   *mutex = cont->mutex.get();
   OpenDirEntry *od    = nullptr;
@@ -116,7 +116,7 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
   }
   ink_assert(caches[type] == this);
 
-  Stripe       *stripe = key_to_stripe(key, hostname, host_len);
+  StripeSM       *stripe = key_to_stripe(key, hostname, host_len);
   Dir           result, *last_collision = nullptr;
   ProxyMutex   *mutex = cont->mutex.get();
   OpenDirEntry *od    = nullptr;

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -48,7 +48,7 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheFragType type, co
   }
   ink_assert(caches[type] == this);
 
-  StripeSM       *stripe = key_to_stripe(key, hostname, host_len);
+  StripeSM     *stripe = key_to_stripe(key, hostname, host_len);
   Dir           result, *last_collision = nullptr;
   ProxyMutex   *mutex = cont->mutex.get();
   OpenDirEntry *od    = nullptr;
@@ -116,7 +116,7 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
   }
   ink_assert(caches[type] == this);
 
-  StripeSM       *stripe = key_to_stripe(key, hostname, host_len);
+  StripeSM     *stripe = key_to_stripe(key, hostname, host_len);
   Dir           result, *last_collision = nullptr;
   ProxyMutex   *mutex = cont->mutex.get();
   OpenDirEntry *od    = nullptr;

--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -432,10 +432,10 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   static uint64_t  DEFAULT_STRIPE_SIZE = 1024ULL * 1024 * 1024 * 911; // 911G
   CacheDisk        disk;                                              // Only need one because it's just checked for failure.
   CacheHostRecord  hr1, hr2;
-  StripeSM          *sample;
+  StripeSM        *sample;
   static int const sample_idx = 16;
-  StripeSM           stripes[MAX_VOLS];
-  StripeSM          *stripe_ptrs[MAX_VOLS]; // array of pointers.
+  StripeSM         stripes[MAX_VOLS];
+  StripeSM        *stripe_ptrs[MAX_VOLS]; // array of pointers.
   char             buff[2048];
 
   // Only run at the highest levels.
@@ -550,7 +550,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
 {
   bool                           pass = true;
   CacheKey                       key;
-  StripeSM                        *stripe = theCache->key_to_stripe(&key, "example.com", sizeof("example.com") - 1);
+  StripeSM                      *stripe = theCache->key_to_stripe(&key, "example.com", sizeof("example.com") - 1);
   std::vector<Ptr<IOBufferData>> data;
 
   cache->init(cache_size, stripe);

--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -432,10 +432,10 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   static uint64_t  DEFAULT_STRIPE_SIZE = 1024ULL * 1024 * 1024 * 911; // 911G
   CacheDisk        disk;                                              // Only need one because it's just checked for failure.
   CacheHostRecord  hr1, hr2;
-  Stripe          *sample;
+  StripeSM          *sample;
   static int const sample_idx = 16;
-  Stripe           stripes[MAX_VOLS];
-  Stripe          *stripe_ptrs[MAX_VOLS]; // array of pointers.
+  StripeSM           stripes[MAX_VOLS];
+  StripeSM          *stripe_ptrs[MAX_VOLS]; // array of pointers.
   char             buff[2048];
 
   // Only run at the highest levels.
@@ -550,7 +550,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
 {
   bool                           pass = true;
   CacheKey                       key;
-  Stripe                        *stripe = theCache->key_to_stripe(&key, "example.com", sizeof("example.com") - 1);
+  StripeSM                        *stripe = theCache->key_to_stripe(&key, "example.com", sizeof("example.com") - 1);
   std::vector<Ptr<IOBufferData>> data;
 
   cache->init(cache_size, stripe);

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -97,7 +97,7 @@ extern int64_t cache_config_ram_cache_cutoff;
  * vol_map - precalculated map
  * offset - offset to start looking at (and data at this location has not been read yet). */
 static off_t
-next_in_map(Stripe *stripe, char *vol_map, off_t offset)
+next_in_map(StripeSM *stripe, char *vol_map, off_t offset)
 {
   off_t start_offset = stripe->vol_offset_to_offset(0);
   off_t new_off      = (offset - start_offset);
@@ -113,16 +113,16 @@ next_in_map(Stripe *stripe, char *vol_map, off_t offset)
 }
 
 // Function in CacheDir.cc that we need for make_vol_map().
-int dir_bucket_loop_fix(Dir *start_dir, int s, Stripe *stripe);
+int dir_bucket_loop_fix(Dir *start_dir, int s, StripeSM *stripe);
 
 // TODO: If we used a bit vector, we could make a smaller map structure.
 // TODO: If we saved a high water mark we could have a smaller buf, and avoid searching it
 // when we are asked about the highest interesting offset.
 /* Make map of what blocks in partition are used.
  *
- * d - Stripe to make a map of. */
+ * d - StripeSM to make a map of. */
 static char *
-make_vol_map(Stripe *stripe)
+make_vol_map(StripeSM *stripe)
 {
   // Map will be one byte for each SCAN_BUF_SIZE bytes.
   off_t  start_offset = stripe->vol_offset_to_offset(0);

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -1384,9 +1384,9 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheFragType frag_ty
   intptr_t res = 0;
   CacheVC *c   = new_CacheVC(cont);
   SCOPED_MUTEX_LOCK(lock, c->mutex, this_ethread());
-  c->vio.op      = VIO::WRITE;
-  c->op_type     = static_cast<int>(CacheOpType::Write);
-  c->stripe      = key_to_stripe(key, hostname, host_len);
+  c->vio.op        = VIO::WRITE;
+  c->op_type       = static_cast<int>(CacheOpType::Write);
+  c->stripe        = key_to_stripe(key, hostname, host_len);
   StripeSM *stripe = c->stripe;
   Metrics::Gauge::increment(cache_rsb.status[c->op_type].active);
   Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.status[c->op_type].active);
@@ -1463,11 +1463,11 @@ Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, 
   do {
     rand_CacheKey(&c->key);
   } while (DIR_MASK_TAG(c->key.slice32(2)) == DIR_MASK_TAG(c->first_key.slice32(2)));
-  c->earliest_key = c->key;
-  c->frag_type    = CACHE_FRAG_TYPE_HTTP;
-  c->stripe       = key_to_stripe(key, hostname, host_len);
-  StripeSM *stripe  = c->stripe;
-  c->info         = info;
+  c->earliest_key  = c->key;
+  c->frag_type     = CACHE_FRAG_TYPE_HTTP;
+  c->stripe        = key_to_stripe(key, hostname, host_len);
+  StripeSM *stripe = c->stripe;
+  c->info          = info;
   if (c->info && (uintptr_t)info != CACHE_ALLOW_MULTIPLE_WRITES) {
     /*
        Update has the following code paths :

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -33,7 +33,7 @@
 // aio
 #include "iocore/aio/AIO.h"
 
-class Stripe;
+class StripeSM;
 struct InterimCacheVol;
 struct CacheVC;
 class CacheEvacuateDocVC;
@@ -205,7 +205,7 @@ struct Dir {
 // INKqa11166 - Cache can not store 2 HTTP alternates simultaneously.
 // To allow this, move the vector from the CacheVC to the OpenDirEntry.
 // Each CacheVC now maintains a pointer to this vector. Adding/Deleting
-// alternates from this vector is done under the Stripe::lock. The alternate
+// alternates from this vector is done under the StripeSM::lock. The alternate
 // is deleted/inserted into the vector just before writing the vector disk
 // (CacheVC::updateVector).
 LINK_FORWARD_DECLARATION(CacheVC, opendir_link) // forward declaration
@@ -266,29 +266,29 @@ struct CacheSync : public Continuation {
 
 // Global Functions
 
-int      dir_probe(const CacheKey *, Stripe *, Dir *, Dir **);
-int      dir_insert(const CacheKey *key, Stripe *stripe, Dir *to_part);
-int      dir_overwrite(const CacheKey *key, Stripe *stripe, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
-int      dir_delete(const CacheKey *key, Stripe *stripe, Dir *del);
-int      dir_lookaside_probe(const CacheKey *key, Stripe *stripe, Dir *result, EvacuationBlock **eblock);
-int      dir_lookaside_insert(EvacuationBlock *b, Stripe *stripe, Dir *to);
-int      dir_lookaside_fixup(const CacheKey *key, Stripe *stripe);
-void     dir_lookaside_cleanup(Stripe *stripe);
-void     dir_lookaside_remove(const CacheKey *key, Stripe *stripe);
-void     dir_free_entry(Dir *e, int s, Stripe *stripe);
+int      dir_probe(const CacheKey *, StripeSM *, Dir *, Dir **);
+int      dir_insert(const CacheKey *key, StripeSM *stripe, Dir *to_part);
+int      dir_overwrite(const CacheKey *key, StripeSM *stripe, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
+int      dir_delete(const CacheKey *key, StripeSM *stripe, Dir *del);
+int      dir_lookaside_probe(const CacheKey *key, StripeSM *stripe, Dir *result, EvacuationBlock **eblock);
+int      dir_lookaside_insert(EvacuationBlock *b, StripeSM *stripe, Dir *to);
+int      dir_lookaside_fixup(const CacheKey *key, StripeSM *stripe);
+void     dir_lookaside_cleanup(StripeSM *stripe);
+void     dir_lookaside_remove(const CacheKey *key, StripeSM *stripe);
+void     dir_free_entry(Dir *e, int s, StripeSM *stripe);
 void     dir_sync_init();
-int      check_dir(Stripe *stripe);
-void     dir_clean_vol(Stripe *stripe);
-void     dir_clear_range(off_t start, off_t end, Stripe *stripe);
-int      dir_segment_accounted(int s, Stripe *stripe, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
+int      check_dir(StripeSM *stripe);
+void     dir_clean_vol(StripeSM *stripe);
+void     dir_clear_range(off_t start, off_t end, StripeSM *stripe);
+int      dir_segment_accounted(int s, StripeSM *stripe, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
                                int *valid = nullptr, int *agg_valid = nullptr, int *avg_size = nullptr);
-uint64_t dir_entries_used(Stripe *stripe);
+uint64_t dir_entries_used(StripeSM *stripe);
 void     sync_cache_dir_on_shutdown();
-int      dir_freelist_length(Stripe *stripe, int s);
+int      dir_freelist_length(StripeSM *stripe, int s);
 
-int  dir_bucket_length(Dir *b, int s, Stripe *stripe);
-int  dir_freelist_length(Stripe *stripe, int s);
-void dir_clean_segment(int s, Stripe *stripe);
+int  dir_bucket_length(Dir *b, int s, StripeSM *stripe);
+int  dir_freelist_length(StripeSM *stripe, int s);
+void dir_clean_segment(int s, StripeSM *stripe);
 
 // Inline Functions
 

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -266,22 +266,22 @@ struct CacheSync : public Continuation {
 
 // Global Functions
 
-int      dir_probe(const CacheKey *, StripeSM *, Dir *, Dir **);
-int      dir_insert(const CacheKey *key, StripeSM *stripe, Dir *to_part);
-int      dir_overwrite(const CacheKey *key, StripeSM *stripe, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
-int      dir_delete(const CacheKey *key, StripeSM *stripe, Dir *del);
-int      dir_lookaside_probe(const CacheKey *key, StripeSM *stripe, Dir *result, EvacuationBlock **eblock);
-int      dir_lookaside_insert(EvacuationBlock *b, StripeSM *stripe, Dir *to);
-int      dir_lookaside_fixup(const CacheKey *key, StripeSM *stripe);
-void     dir_lookaside_cleanup(StripeSM *stripe);
-void     dir_lookaside_remove(const CacheKey *key, StripeSM *stripe);
-void     dir_free_entry(Dir *e, int s, StripeSM *stripe);
-void     dir_sync_init();
-int      check_dir(StripeSM *stripe);
-void     dir_clean_vol(StripeSM *stripe);
-void     dir_clear_range(off_t start, off_t end, StripeSM *stripe);
-int      dir_segment_accounted(int s, StripeSM *stripe, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
-                               int *valid = nullptr, int *agg_valid = nullptr, int *avg_size = nullptr);
+int  dir_probe(const CacheKey *, StripeSM *, Dir *, Dir **);
+int  dir_insert(const CacheKey *key, StripeSM *stripe, Dir *to_part);
+int  dir_overwrite(const CacheKey *key, StripeSM *stripe, Dir *to_part, Dir *overwrite, bool must_overwrite = true);
+int  dir_delete(const CacheKey *key, StripeSM *stripe, Dir *del);
+int  dir_lookaside_probe(const CacheKey *key, StripeSM *stripe, Dir *result, EvacuationBlock **eblock);
+int  dir_lookaside_insert(EvacuationBlock *b, StripeSM *stripe, Dir *to);
+int  dir_lookaside_fixup(const CacheKey *key, StripeSM *stripe);
+void dir_lookaside_cleanup(StripeSM *stripe);
+void dir_lookaside_remove(const CacheKey *key, StripeSM *stripe);
+void dir_free_entry(Dir *e, int s, StripeSM *stripe);
+void dir_sync_init();
+int  check_dir(StripeSM *stripe);
+void dir_clean_vol(StripeSM *stripe);
+void dir_clear_range(off_t start, off_t end, StripeSM *stripe);
+int  dir_segment_accounted(int s, StripeSM *stripe, int offby = 0, int *free = nullptr, int *used = nullptr, int *empty = nullptr,
+                           int *valid = nullptr, int *agg_valid = nullptr, int *avg_size = nullptr);
 uint64_t dir_entries_used(StripeSM *stripe);
 void     sync_cache_dir_on_shutdown();
 int      dir_freelist_length(StripeSM *stripe, int s);

--- a/src/iocore/cache/P_CacheDisk.h
+++ b/src/iocore/cache/P_CacheDisk.h
@@ -36,7 +36,7 @@ extern int cache_config_max_disk_errors;
 
 #define DISK_HEADER_MAGIC 0xABCD1237
 
-/* each disk vol block has a corresponding Stripe object */
+/* each disk vol block has a corresponding StripeSM object */
 struct CacheDisk;
 
 struct DiskStripeBlock {

--- a/src/iocore/cache/P_CacheHosting.h
+++ b/src/iocore/cache/P_CacheHosting.h
@@ -51,7 +51,7 @@ struct CacheHostRecord {
   }
 
   CacheType       type           = CACHE_NONE_TYPE;
-  StripeSM        **stripes        = nullptr;
+  StripeSM      **stripes        = nullptr;
   int             num_vols       = 0;
   unsigned short *vol_hash_table = nullptr;
   CacheVol      **cp             = nullptr;

--- a/src/iocore/cache/P_CacheHosting.h
+++ b/src/iocore/cache/P_CacheHosting.h
@@ -30,7 +30,7 @@
 
 #define CACHE_MEM_FREE_TIMEOUT HRTIME_SECONDS(1)
 
-class Stripe;
+class StripeSM;
 struct CacheVol;
 
 struct CacheHostResult;
@@ -51,7 +51,7 @@ struct CacheHostRecord {
   }
 
   CacheType       type           = CACHE_NONE_TYPE;
-  Stripe        **stripes        = nullptr;
+  StripeSM        **stripes        = nullptr;
   int             num_vols       = 0;
   unsigned short *vol_hash_table = nullptr;
   CacheVol      **cp             = nullptr;

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -149,7 +149,7 @@ extern CacheSync                         *cacheDirSync;
 // Function Prototypes
 int                 cache_write(CacheVC *, CacheHTTPInfoVector *);
 int                 get_alternate_index(CacheHTTPInfoVector *cache_vector, CacheKey key);
-CacheEvacuateDocVC *new_DocEvacuator(int nbytes, Stripe *stripe);
+CacheEvacuateDocVC *new_DocEvacuator(int nbytes, StripeSM *stripe);
 
 // inline Functions
 
@@ -176,7 +176,7 @@ free_CacheVCCommon(CacheVC *cont)
   static DbgCtl dbg_ctl{"cache_free"};
   Dbg(dbg_ctl, "free %p", cont);
   ProxyMutex *mutex  = cont->mutex.get();
-  Stripe     *stripe = cont->stripe;
+  StripeSM     *stripe = cont->stripe;
 
   if (stripe) {
     Metrics::Gauge::decrement(cache_rsb.status[cont->op_type].active);
@@ -377,16 +377,16 @@ CacheVC::writer_done()
 }
 
 inline int
-Stripe::close_write(CacheVC *cont)
+StripeSM::close_write(CacheVC *cont)
 {
   return open_dir.close_write(cont);
 }
 
 // Returns 0 on success or a positive error code on failure
 inline int
-Stripe::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
+StripeSM::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
 {
-  Stripe *stripe    = this;
+  StripeSM *stripe    = this;
   bool    agg_error = false;
   if (!cont->f.remove) {
     agg_error = (!cont->f.update && this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog);
@@ -409,7 +409,7 @@ Stripe::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
 }
 
 inline int
-Stripe::close_write_lock(CacheVC *cont)
+StripeSM::close_write_lock(CacheVC *cont)
 {
   EThread *t = cont->mutex->thread_holding;
   CACHE_TRY_LOCK(lock, mutex, t);
@@ -420,7 +420,7 @@ Stripe::close_write_lock(CacheVC *cont)
 }
 
 inline int
-Stripe::open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers)
+StripeSM::open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers)
 {
   EThread *t = cont->mutex->thread_holding;
   CACHE_TRY_LOCK(lock, mutex, t);
@@ -431,7 +431,7 @@ Stripe::open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers)
 }
 
 inline OpenDirEntry *
-Stripe::open_read_lock(CryptoHash *key, EThread *t)
+StripeSM::open_read_lock(CryptoHash *key, EThread *t)
 {
   CACHE_TRY_LOCK(lock, mutex, t);
   if (!lock.is_locked()) {
@@ -441,7 +441,7 @@ Stripe::open_read_lock(CryptoHash *key, EThread *t)
 }
 
 inline int
-Stripe::begin_read_lock(CacheVC *cont)
+StripeSM::begin_read_lock(CacheVC *cont)
 {
   // no need for evacuation as the entire document is already in memory
   if (cont->f.single_fragment) {
@@ -457,7 +457,7 @@ Stripe::begin_read_lock(CacheVC *cont)
 }
 
 inline int
-Stripe::close_read_lock(CacheVC *cont)
+StripeSM::close_read_lock(CacheVC *cont)
 {
   EThread *t = cont->mutex->thread_holding;
   CACHE_TRY_LOCK(lock, mutex, t);
@@ -468,7 +468,7 @@ Stripe::close_read_lock(CacheVC *cont)
 }
 
 inline int
-dir_delete_lock(CacheKey *key, Stripe *stripe, ProxyMutex *m, Dir *del)
+dir_delete_lock(CacheKey *key, StripeSM *stripe, ProxyMutex *m, Dir *del)
 {
   EThread *thread = m->thread_holding;
   CACHE_TRY_LOCK(lock, stripe->mutex, thread);
@@ -479,7 +479,7 @@ dir_delete_lock(CacheKey *key, Stripe *stripe, ProxyMutex *m, Dir *del)
 }
 
 inline int
-dir_insert_lock(CacheKey *key, Stripe *stripe, Dir *to_part, ProxyMutex *m)
+dir_insert_lock(CacheKey *key, StripeSM *stripe, Dir *to_part, ProxyMutex *m)
 {
   EThread *thread = m->thread_holding;
   CACHE_TRY_LOCK(lock, stripe->mutex, thread);
@@ -490,7 +490,7 @@ dir_insert_lock(CacheKey *key, Stripe *stripe, Dir *to_part, ProxyMutex *m)
 }
 
 inline int
-dir_overwrite_lock(CacheKey *key, Stripe *stripe, Dir *to_part, ProxyMutex *m, Dir *overwrite, bool must_overwrite = true)
+dir_overwrite_lock(CacheKey *key, StripeSM *stripe, Dir *to_part, ProxyMutex *m, Dir *overwrite, bool must_overwrite = true)
 {
   EThread *thread = m->thread_holding;
   CACHE_TRY_LOCK(lock, stripe->mutex, thread);
@@ -563,7 +563,7 @@ CacheRemoveCont::event_handler(int event, void *data)
 }
 
 struct CacheHostRecord;
-class Stripe;
+class StripeSM;
 class CacheHostTable;
 
 struct Cache {
@@ -600,7 +600,7 @@ struct Cache {
 
   int open_done();
 
-  Stripe *key_to_stripe(const CacheKey *key, const char *hostname, int host_len);
+  StripeSM *key_to_stripe(const CacheKey *key, const char *hostname, int host_len);
 
   Cache() {}
 };

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -176,7 +176,7 @@ free_CacheVCCommon(CacheVC *cont)
   static DbgCtl dbg_ctl{"cache_free"};
   Dbg(dbg_ctl, "free %p", cont);
   ProxyMutex *mutex  = cont->mutex.get();
-  StripeSM     *stripe = cont->stripe;
+  StripeSM   *stripe = cont->stripe;
 
   if (stripe) {
     Metrics::Gauge::decrement(cache_rsb.status[cont->op_type].active);
@@ -387,7 +387,7 @@ inline int
 StripeSM::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
 {
   StripeSM *stripe    = this;
-  bool    agg_error = false;
+  bool      agg_error = false;
   if (!cont->f.remove) {
     agg_error = (!cont->f.update && this->_write_buffer.get_bytes_pending_aggregation() > cache_config_agg_write_backlog);
 #ifdef CACHE_AGG_FAIL_RATE

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -349,7 +349,7 @@ struct CacheVol {
   off_t        size             = 0;
   int          num_vols         = 0;
   bool         ramcache_enabled = true;
-  StripeSM     **stripes          = nullptr;
+  StripeSM   **stripes          = nullptr;
   DiskStripe **disk_stripes     = nullptr;
   LINK(CacheVol, link);
   // per volume stats
@@ -360,7 +360,7 @@ struct CacheVol {
 
 // Global Data
 
-extern StripeSM                        **gstripes;
+extern StripeSM                      **gstripes;
 extern std::atomic<int>                gnstripes;
 extern ClassAllocator<OpenDirEntry>    openDirEntryAllocator;
 extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -73,7 +73,7 @@
 // Documents
 
 struct Cache;
-class Stripe;
+class StripeSM;
 struct CacheDisk;
 struct StripeInitInfo;
 struct DiskStripe;
@@ -125,7 +125,7 @@ struct EvacuationBlock {
   LINK(EvacuationBlock, link);
 };
 
-class Stripe : public Continuation
+class StripeSM : public Continuation
 {
 public:
   char          *path = nullptr;
@@ -269,10 +269,10 @@ public:
   off_t vol_offset_to_offset(off_t pos) const;
   off_t vol_relative_length(off_t start_offset) const;
 
-  Stripe() : Continuation(new_ProxyMutex())
+  StripeSM() : Continuation(new_ProxyMutex())
   {
     open_dir.mutex = mutex;
-    SET_HANDLER(&Stripe::aggWrite);
+    SET_HANDLER(&StripeSM::aggWrite);
   }
 
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
@@ -349,7 +349,7 @@ struct CacheVol {
   off_t        size             = 0;
   int          num_vols         = 0;
   bool         ramcache_enabled = true;
-  Stripe     **stripes          = nullptr;
+  StripeSM     **stripes          = nullptr;
   DiskStripe **disk_stripes     = nullptr;
   LINK(CacheVol, link);
   // per volume stats
@@ -360,7 +360,7 @@ struct CacheVol {
 
 // Global Data
 
-extern Stripe                        **gstripes;
+extern StripeSM                        **gstripes;
 extern std::atomic<int>                gnstripes;
 extern ClassAllocator<OpenDirEntry>    openDirEntryAllocator;
 extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;
@@ -370,74 +370,74 @@ extern unsigned short                 *vol_hash_table;
 // inline Functions
 
 inline int
-Stripe::headerlen() const
+StripeSM::headerlen() const
 {
   return ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter) + sizeof(uint16_t) * (this->segments - 1));
 }
 
 inline Dir *
-Stripe::dir_segment(int s) const
+StripeSM::dir_segment(int s) const
 {
   return (Dir *)(((char *)this->dir) + (s * this->buckets) * DIR_DEPTH * SIZEOF_DIR);
 }
 
 inline size_t
-Stripe::dirlen() const
+StripeSM::dirlen() const
 {
   return this->headerlen() + ROUND_TO_STORE_BLOCK(((size_t)this->buckets) * DIR_DEPTH * this->segments * SIZEOF_DIR) +
          ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
 }
 
 inline int
-Stripe::direntries() const
+StripeSM::direntries() const
 {
   return this->buckets * DIR_DEPTH * this->segments;
 }
 
 inline int
-Stripe::vol_out_of_phase_valid(Dir const *e) const
+StripeSM::vol_out_of_phase_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Stripe::vol_out_of_phase_agg_valid(Dir const *e) const
+StripeSM::vol_out_of_phase_agg_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start + AGG_SIZE) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Stripe::vol_out_of_phase_write_valid(Dir const *e) const
+StripeSM::vol_out_of_phase_write_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 >= ((this->header->write_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
-Stripe::vol_in_phase_valid(Dir const *e) const
+StripeSM::vol_in_phase_valid(Dir const *e) const
 {
   return (dir_offset(e) - 1 < ((this->header->write_pos + this->_write_buffer.get_buffer_pos() - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline off_t
-Stripe::vol_offset(Dir const *e) const
+StripeSM::vol_offset(Dir const *e) const
 {
   return this->start + (off_t)dir_offset(e) * CACHE_BLOCK_SIZE - CACHE_BLOCK_SIZE;
 }
 
 inline off_t
-Stripe::offset_to_vol_offset(off_t pos) const
+StripeSM::offset_to_vol_offset(off_t pos) const
 {
   return ((pos - this->start + CACHE_BLOCK_SIZE) / CACHE_BLOCK_SIZE);
 }
 
 inline off_t
-Stripe::vol_offset_to_offset(off_t pos) const
+StripeSM::vol_offset_to_offset(off_t pos) const
 {
   return this->start + pos * CACHE_BLOCK_SIZE - CACHE_BLOCK_SIZE;
 }
 
 inline int
-Stripe::vol_in_phase_agg_buf_valid(Dir const *e) const
+StripeSM::vol_in_phase_agg_buf_valid(Dir const *e) const
 {
   return (this->vol_offset(e) >= this->header->write_pos &&
           this->vol_offset(e) < (this->header->write_pos + this->_write_buffer.get_buffer_pos()));
@@ -445,7 +445,7 @@ Stripe::vol_in_phase_agg_buf_valid(Dir const *e) const
 
 // length of the partition not including the offset of location 0.
 inline off_t
-Stripe::vol_relative_length(off_t start_offset) const
+StripeSM::vol_relative_length(off_t start_offset) const
 {
   return (this->len + this->skip) - start_offset;
 }
@@ -453,7 +453,7 @@ Stripe::vol_relative_length(off_t start_offset) const
 // inline Functions
 
 inline EvacuationBlock *
-evacuation_block_exists(Dir const *dir, Stripe *stripe)
+evacuation_block_exists(Dir const *dir, StripeSM *stripe)
 {
   auto bucket = dir_evac_bucket(dir);
   if (stripe->evac_bucket_valid(bucket)) {
@@ -468,7 +468,7 @@ evacuation_block_exists(Dir const *dir, Stripe *stripe)
 }
 
 inline void
-Stripe::cancel_trigger()
+StripeSM::cancel_trigger()
 {
   if (trigger) {
     trigger->cancel_action();
@@ -500,13 +500,13 @@ free_EvacuationBlock(EvacuationBlock *b, EThread *t)
 }
 
 inline OpenDirEntry *
-Stripe::open_read(const CryptoHash *key) const
+StripeSM::open_read(const CryptoHash *key) const
 {
   return open_dir.open_read(key);
 }
 
 inline int
-Stripe::within_hit_evacuate_window(Dir const *xdir) const
+StripeSM::within_hit_evacuate_window(Dir const *xdir) const
 {
   off_t oft       = dir_offset(xdir) - 1;
   off_t write_off = (header->write_pos + AGG_SIZE - start) / CACHE_BLOCK_SIZE;
@@ -518,38 +518,38 @@ Stripe::within_hit_evacuate_window(Dir const *xdir) const
 }
 
 inline uint32_t
-Stripe::round_to_approx_size(uint32_t l) const
+StripeSM::round_to_approx_size(uint32_t l) const
 {
   uint32_t ll = round_to_approx_dir_size(l);
   return ROUND_TO_SECTOR(this, ll);
 }
 
 inline bool
-Stripe::evac_bucket_valid(off_t bucket) const
+StripeSM::evac_bucket_valid(off_t bucket) const
 {
   return (bucket >= 0 && bucket < evacuate_size);
 }
 
 inline int
-Stripe::is_io_in_progress() const
+StripeSM::is_io_in_progress() const
 {
   return io.aiocb.aio_fildes != AIO_NOT_IN_PROGRESS;
 }
 
 inline void
-Stripe::set_io_not_in_progress()
+StripeSM::set_io_not_in_progress()
 {
   io.aiocb.aio_fildes = AIO_NOT_IN_PROGRESS;
 }
 
 inline Queue<CacheVC, Continuation::Link_link> &
-Stripe::get_pending_writers()
+StripeSM::get_pending_writers()
 {
   return this->_write_buffer.get_pending_writers();
 }
 
 inline int
-Stripe::get_agg_buf_pos() const
+StripeSM::get_agg_buf_pos() const
 {
   return this->_write_buffer.get_buffer_pos();
 }

--- a/src/iocore/cache/P_RamCache.h
+++ b/src/iocore/cache/P_RamCache.h
@@ -36,7 +36,7 @@ public:
   virtual int     fixup(const CryptoHash *key, uint64_t old_auxkey, uint64_t new_auxkey)                         = 0;
   virtual int64_t size() const                                                                                   = 0;
 
-  virtual void init(int64_t max_bytes, Stripe *stripe) = 0;
+  virtual void init(int64_t max_bytes, StripeSM *stripe) = 0;
   virtual ~RamCache(){};
 };
 

--- a/src/iocore/cache/RamCacheCLFUS.cc
+++ b/src/iocore/cache/RamCacheCLFUS.cc
@@ -90,12 +90,12 @@ public:
   int     fixup(const CryptoHash *key, uint64_t old_auxkey, uint64_t new_auxkey) override;
   int64_t size() const override;
 
-  void init(int64_t max_bytes, Stripe *stripe) override;
+  void init(int64_t max_bytes, StripeSM *stripe) override;
 
   void compress_entries(EThread *thread, int do_at_most = INT_MAX);
 
   // TODO move it to private.
-  Stripe *stripe = nullptr; // for stats
+  StripeSM *stripe = nullptr; // for stats
 private:
   int64_t _max_bytes = 0;
   int64_t _bytes     = 0;
@@ -203,7 +203,7 @@ RamCacheCLFUS::_resize_hashtable()
 }
 
 void
-RamCacheCLFUS::init(int64_t abytes, Stripe *astripe)
+RamCacheCLFUS::init(int64_t abytes, StripeSM *astripe)
 {
   ink_assert(astripe != nullptr);
   stripe           = astripe;

--- a/src/iocore/cache/RamCacheLRU.cc
+++ b/src/iocore/cache/RamCacheLRU.cc
@@ -46,7 +46,7 @@ struct RamCacheLRU : public RamCache {
   int     fixup(const CryptoHash *key, uint64_t old_auxkey, uint64_t new_auxkey) override;
   int64_t size() const override;
 
-  void init(int64_t max_bytes, Stripe *stripe) override;
+  void init(int64_t max_bytes, StripeSM *stripe) override;
 
   // private
   std::vector<bool> *seen = nullptr;
@@ -54,7 +54,7 @@ struct RamCacheLRU : public RamCache {
   DList(RamCacheLRUEntry, hash_link) *bucket = nullptr;
   int     nbuckets                           = 0;
   int     ibuckets                           = 0;
-  Stripe *stripe                             = nullptr;
+  StripeSM *stripe                             = nullptr;
 
   void              resize_hashtable();
   RamCacheLRUEntry *remove(RamCacheLRUEntry *e);
@@ -120,7 +120,7 @@ RamCacheLRU::resize_hashtable()
 }
 
 void
-RamCacheLRU::init(int64_t abytes, Stripe *astripe)
+RamCacheLRU::init(int64_t abytes, StripeSM *astripe)
 {
   stripe    = astripe;
   max_bytes = abytes;

--- a/src/iocore/cache/RamCacheLRU.cc
+++ b/src/iocore/cache/RamCacheLRU.cc
@@ -52,9 +52,9 @@ struct RamCacheLRU : public RamCache {
   std::vector<bool> *seen = nullptr;
   Que(RamCacheLRUEntry, lru_link) lru;
   DList(RamCacheLRUEntry, hash_link) *bucket = nullptr;
-  int     nbuckets                           = 0;
-  int     ibuckets                           = 0;
-  StripeSM *stripe                             = nullptr;
+  int       nbuckets                         = 0;
+  int       ibuckets                         = 0;
+  StripeSM *stripe                           = nullptr;
 
   void              resize_hashtable();
   RamCacheLRUEntry *remove(RamCacheLRUEntry *e);

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -80,8 +80,8 @@ public:
     REQUIRE(CacheProcessor::IsCacheEnabled() == CACHE_INITIALIZED);
     REQUIRE(gnstripes >= 1);
 
-    StripeSM  *stripe = gstripes[0];
-    EThread *thread = this_ethread();
+    StripeSM *stripe = gstripes[0];
+    EThread  *thread = this_ethread();
     MUTEX_TRY_LOCK(lock, stripe->mutex, thread);
     if (!lock.is_locked()) {
       CONT_SCHED_LOCK_RETRY(this);

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -54,7 +54,7 @@ regress_rand_CacheKey(const CacheKey *key)
 }
 
 void
-dir_corrupt_bucket(Dir *b, int s, Stripe *stripe)
+dir_corrupt_bucket(Dir *b, int s, StripeSM *stripe)
 {
   int  l   = (static_cast<int>(dir_bucket_length(b, s, stripe) * ts::Random::drandom()));
   Dir *e   = b;
@@ -80,7 +80,7 @@ public:
     REQUIRE(CacheProcessor::IsCacheEnabled() == CACHE_INITIALIZED);
     REQUIRE(gnstripes >= 1);
 
-    Stripe  *stripe = gstripes[0];
+    StripeSM  *stripe = gstripes[0];
     EThread *thread = this_ethread();
     MUTEX_TRY_LOCK(lock, stripe->mutex, thread);
     if (!lock.is_locked()) {

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -81,18 +81,18 @@ std::array<AddWriterBranchTest, 32> add_writer_branch_test_cases = {
    }
 };
 
-/* Catch test helper to provide a Stripe with a valid file descriptor.
+/* Catch test helper to provide a StripeSM with a valid file descriptor.
  *
  * The file will be deleted automatically when the application ends normally.
- * If the Stripe already has a valid file descriptor, that file will NOT be
+ * If the StripeSM already has a valid file descriptor, that file will NOT be
  * closed.
  *
- * @param stripe: A Stripe object with no valid file descriptor.
+ * @param stripe: A StripeSM object with no valid file descriptor.
  * @return The std::FILE* stream if successful, otherwise the Catch test will
  *   be failed at the point of error.
  */
 static std::FILE *
-attach_tmpfile_to_stripe(Stripe &stripe)
+attach_tmpfile_to_stripe(StripeSM &stripe)
 {
   auto *file{std::tmpfile()};
   REQUIRE(file != nullptr);
@@ -105,7 +105,7 @@ attach_tmpfile_to_stripe(Stripe &stripe)
 // We can't return a stripe from this function because the copy
 // and move constructors are deleted.
 static std::FILE *
-init_stripe_for_writing(Stripe &stripe, StripteHeaderFooter &header, CacheVol &cache_vol)
+init_stripe_for_writing(StripeSM &stripe, StripteHeaderFooter &header, CacheVol &cache_vol)
 {
   stripe.cache_vol                             = &cache_vol;
   cache_rsb.write_bytes                        = Metrics::Counter::createPtr("unit_test.write.bytes");
@@ -135,10 +135,10 @@ init_stripe_for_writing(Stripe &stripe, StripteHeaderFooter &header, CacheVol &c
   return attach_tmpfile_to_stripe(stripe);
 }
 
-TEST_CASE("The behavior of Stripe::add_writer.")
+TEST_CASE("The behavior of StripeSM::add_writer.")
 {
   FakeVC vc;
-  Stripe stripe;
+  StripeSM stripe;
 
   SECTION("Branch tests.")
   {
@@ -189,12 +189,12 @@ TEST_CASE("The behavior of Stripe::add_writer.")
   }
 }
 
-// This test case demonstrates how to set up a Stripe and make
+// This test case demonstrates how to set up a StripeSM and make
 // a call to aggWrite without causing memory errors. It uses a
-// tmpfile for the Stripe to write to.
+// tmpfile for the StripeSM to write to.
 TEST_CASE("aggWrite behavior with f.evacuator unset")
 {
-  Stripe              stripe;
+  StripeSM              stripe;
   StripteHeaderFooter header;
   CacheVol            cache_vol;
   auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};
@@ -304,7 +304,7 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
 // only on the presence of the f.evacuator flag.
 TEST_CASE("aggWrite behavior with f.evacuator set")
 {
-  Stripe              stripe;
+  StripeSM              stripe;
   StripteHeaderFooter header;
   CacheVol            cache_vol;
   auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -137,7 +137,7 @@ init_stripe_for_writing(StripeSM &stripe, StripteHeaderFooter &header, CacheVol 
 
 TEST_CASE("The behavior of StripeSM::add_writer.")
 {
-  FakeVC vc;
+  FakeVC   vc;
   StripeSM stripe;
 
   SECTION("Branch tests.")
@@ -194,7 +194,7 @@ TEST_CASE("The behavior of StripeSM::add_writer.")
 // tmpfile for the StripeSM to write to.
 TEST_CASE("aggWrite behavior with f.evacuator unset")
 {
-  StripeSM              stripe;
+  StripeSM            stripe;
   StripteHeaderFooter header;
   CacheVol            cache_vol;
   auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};
@@ -304,7 +304,7 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
 // only on the presence of the f.evacuator flag.
 TEST_CASE("aggWrite behavior with f.evacuator set")
 {
-  StripeSM              stripe;
+  StripeSM            stripe;
   StripteHeaderFooter header;
   CacheVol            cache_vol;
   auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};

--- a/src/iocore/cache/unit_tests/test_doubles.h
+++ b/src/iocore/cache/unit_tests/test_doubles.h
@@ -94,7 +94,7 @@ public:
 class WaitingVC final : public FakeVC
 {
 public:
-  WaitingVC(Stripe *stripe)
+  WaitingVC(StripeSM *stripe)
   {
     SET_HANDLER(&WaitingVC::handle_call);
     this->stripe = stripe;

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -137,7 +137,7 @@ struct SpanHeader {
   CacheStripeDescriptor stripes[1];
 };
 
-/** Stripe data, serialized format.
+/** StripeSM data, serialized format.
 
     @internal StripeHeaderFooter
  */
@@ -441,7 +441,7 @@ dir_to_offset(const CacheDirEntry *d, const CacheDirEntry *seg)
 #endif
 }
 
-struct Stripe;
+struct StripeSM;
 struct Span {
   Span(swoc::file::path const &path) : _path(path) {}
   Errata load();
@@ -455,7 +455,7 @@ struct Span {
   /// This is broken and needs to be cleaned up.
   void clearPermanently();
 
-  swoc::Rv<Stripe *> allocStripe(int vol_idx, const CacheStripeBlocks &len);
+  swoc::Rv<StripeSM *> allocStripe(int vol_idx, const CacheStripeBlocks &len);
   Errata             updateHeader(); ///< Update serialized header and write to disk.
 
   swoc::file::path _path;        ///< File system location of span.
@@ -472,10 +472,10 @@ struct Span {
   std::unique_ptr<ts::SpanHeader> _header;
   /// Live information about stripes.
   /// Seeded from @a _header and potentially augmented with direct probing.
-  std::list<Stripe *> _stripes;
+  std::list<StripeSM *> _stripes;
 };
 /* --------------------------------------------------------------------------------------- */
-struct Stripe {
+struct StripeSM {
   /// Meta data is stored in 4 copies A/B and Header/Footer.
   enum Copy { A = 0, B = 1 };
   enum { HEAD = 0, FOOT = 1 };
@@ -496,7 +496,7 @@ struct Stripe {
   };
 
   /// Construct from span header data.
-  Stripe(Span *span, const Bytes &start, const CacheStoreBlocks &len);
+  StripeSM(Span *span, const Bytes &start, const CacheStoreBlocks &len);
 
   /// Is stripe unallocated?
   bool isFree() const;
@@ -532,8 +532,8 @@ struct Stripe {
   Bytes            _content;         ///< Start of content.
   CacheStoreBlocks _len;             ///< Length of stripe.
   uint8_t          _vol_idx    = 0;  ///< Volume index.
-  uint8_t          _type       = 0;  ///< Stripe type.
-  int8_t           _idx        = -1; ///< Stripe index in span.
+  uint8_t          _type       = 0;  ///< StripeSM type.
+  int8_t           _idx        = -1; ///< StripeSM index in span.
   int              agg_buf_pos = 0;
 
   int64_t _buckets  = 0; ///< Number of buckets per segment.

--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -456,7 +456,7 @@ struct Span {
   void clearPermanently();
 
   swoc::Rv<StripeSM *> allocStripe(int vol_idx, const CacheStripeBlocks &len);
-  Errata             updateHeader(); ///< Update serialized header and write to disk.
+  Errata               updateHeader(); ///< Update serialized header and write to disk.
 
   swoc::file::path _path;        ///< File system location of span.
   ats_scoped_fd    _fd;          ///< Open file descriptor for span.

--- a/src/traffic_cache_tool/CacheScan.h
+++ b/src/traffic_cache_tool/CacheScan.h
@@ -39,7 +39,7 @@ namespace ct
 {
 class CacheScan
 {
-  StripeSM      *stripe    = nullptr;
+  StripeSM    *stripe    = nullptr;
   url_matcher *u_matcher = nullptr;
 
 public:

--- a/src/traffic_cache_tool/CacheScan.h
+++ b/src/traffic_cache_tool/CacheScan.h
@@ -39,17 +39,17 @@ namespace ct
 {
 class CacheScan
 {
-  Stripe      *stripe    = nullptr;
+  StripeSM      *stripe    = nullptr;
   url_matcher *u_matcher = nullptr;
 
 public:
-  CacheScan(Stripe *str, swoc::file::path const &path) : stripe(str)
+  CacheScan(StripeSM *str, swoc::file::path const &path) : stripe(str)
   {
     if (!path.empty()) {
       u_matcher = new url_matcher(path);
     }
   };
-  CacheScan(Stripe *str) : stripe(str) {}
+  CacheScan(StripeSM *str) : stripe(str) {}
   ~CacheScan() { delete u_matcher; }
   Errata Scan(bool search = false);
   Errata get_alternates(const char *buf, int length, bool search);

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -77,7 +77,7 @@ namespace ct
 struct Volume {
   int                   _idx;  ///< Volume index.
   CacheStoreBlocks      _size; ///< Amount of storage allocated.
-  std::vector<Stripe *> _stripes;
+  std::vector<StripeSM *> _stripes;
 
   /// Remove all data related to @a span.
   //  void clearSpan(Span *span);
@@ -89,7 +89,7 @@ struct Volume {
 void
 Volume::clearSpan(Span* span)
 {
-  auto spot = std::remove_if(_stripes.begin(), _stripes.end(), [span,this](Stripe* stripe) { return stripe->_span == span ? ( this->_size -= stripe->_len , true ) : false; });
+  auto spot = std::remove_if(_stripes.begin(), _stripes.end(), [span,this](StripeSM* stripe) { return stripe->_span == span ? ( this->_size -= stripe->_len , true ) : false; });
   _stripes.erase(spot, _stripes.end());
 }
 #endif
@@ -200,13 +200,13 @@ struct Cache {
   void    dumpSpans(SpanDumpDepth depth);
   void    dumpVolumes();
   void    build_stripe_hash_table();
-  Stripe *key_to_stripe(CryptoHash *key, const char *hostname, int host_len);
+  StripeSM *key_to_stripe(CryptoHash *key, const char *hostname, int host_len);
   //  ts::CacheStripeBlocks calcTotalSpanPhysicalSize();
   ts::CacheStripeBlocks calcTotalSpanConfiguredSize();
 
   std::list<Span *>                  _spans;
   std::map<int, Volume>              _volumes;
-  std::vector<Stripe *>              globalVec_stripe;
+  std::vector<StripeSM *>              globalVec_stripe;
   std::unordered_set<ts::CacheURL *> URLset;
   unsigned short                    *stripes_hash_table;
 };
@@ -483,7 +483,7 @@ Cache::loadSpanDirect(swoc::file::path const &path, int vol_idx, [[maybe_unused]
       int nspb = span->_header->num_diskvol_blks;
       for (auto i = 0; i < nspb; ++i) {
         ts::CacheStripeDescriptor &raw    = span->_header->stripes[i];
-        Stripe                    *stripe = new Stripe(span.get(), raw.offset, raw.len);
+        StripeSM                    *stripe = new StripeSM(span.get(), raw.offset, raw.len);
         stripe->_idx                      = i;
         if (raw.free == 0) {
           stripe->_vol_idx = raw.vol_idx;
@@ -776,11 +776,11 @@ Span::loadDevice()
   return zret;
 }
 
-swoc::Rv<Stripe *>
+swoc::Rv<StripeSM *>
 Span::allocStripe(int vol_idx, const CacheStripeBlocks &len)
 {
   for (auto spot = _stripes.begin(), limit = _stripes.end(); spot != limit; ++spot) {
-    Stripe *stripe = *spot;
+    StripeSM *stripe = *spot;
     if (stripe->isFree()) {
       if (len < stripe->_len) {
         // If the remains would be less than a stripe block, just take it all.
@@ -789,7 +789,7 @@ Span::allocStripe(int vol_idx, const CacheStripeBlocks &len)
           stripe->_type    = 1;
           return stripe;
         } else {
-          Stripe *ns      = new Stripe(this, stripe->_start, len);
+          StripeSM *ns      = new StripeSM(this, stripe->_start, len);
           stripe->_start += len;
           stripe->_len   -= len;
           ns->_vol_idx    = vol_idx;
@@ -806,14 +806,14 @@ Span::allocStripe(int vol_idx, const CacheStripeBlocks &len)
 bool
 Span::isEmpty() const
 {
-  return std::all_of(_stripes.begin(), _stripes.end(), [](Stripe *s) { return s->_vol_idx == 0; });
+  return std::all_of(_stripes.begin(), _stripes.end(), [](StripeSM *s) { return s->_vol_idx == 0; });
 }
 
 Errata
 Span::clear()
 {
-  Stripe *stripe;
-  std::for_each(_stripes.begin(), _stripes.end(), [](Stripe *s) { delete s; });
+  StripeSM *stripe;
+  std::for_each(_stripes.begin(), _stripes.end(), [](StripeSM *s) { delete s; });
   _stripes.clear();
 
   // Gah, due to lack of anything better, TS depends on the number of usable blocks to be consistent
@@ -822,7 +822,7 @@ Span::clear()
   // The maximum number of volumes that can store stored, accounting for the space used to store the descriptors.
   int n   = (eff - sizeof(ts::SpanHeader)) / (CacheStripeBlocks::SCALE + sizeof(CacheStripeDescriptor));
   _offset = _base + round_up(sizeof(ts::SpanHeader) + (n - 1) * sizeof(CacheStripeDescriptor));
-  stripe  = new Stripe(this, _offset, _len - _offset);
+  stripe  = new StripeSM(this, _offset, _len - _offset);
   stripe->vol_init_data();
   stripe->InitializeMeta();
   _stripes.push_back(stripe);
@@ -1021,7 +1021,7 @@ Cache::build_stripe_hash_table()
   ats_free(rtable);
 }
 
-Stripe *
+StripeSM *
 Cache::key_to_stripe(CryptoHash *key, [[maybe_unused]] const char *hostname, [[maybe_unused]] int host_len)
 {
   uint32_t h = (key->slice32(2) >> DIR_TAG_WIDTH) % STRIPE_HASH_TABLE_SIZE;
@@ -1201,7 +1201,7 @@ Find_Stripe(swoc::file::path const &input_file_path)
       ctx.update(host->url.data(), host->url.size());
       ctx.update(&host->port, sizeof(host->port));
       ctx.finalize(hashT);
-      Stripe *stripe_ = cache.key_to_stripe(&hashT, host->url.data(), host->url.size());
+      StripeSM *stripe_ = cache.key_to_stripe(&hashT, host->url.data(), host->url.size());
       w.print("{}", hashT);
       printf("hash of %.*s is %.*s: Stripe  %s \n", static_cast<int>(host->url.size()), host->url.data(),
              static_cast<int>(w.size()), w.data(), stripe_->hashText.data());
@@ -1317,7 +1317,7 @@ Get_Response(swoc::file::path const &input_file_path)
       ctx.update(host->url.data(), host->url.size());
       ctx.update(&host->port, sizeof(host->port));
       ctx.finalize(hashT);
-      Stripe *stripe_ = cache.key_to_stripe(&hashT, host->url.data(), host->url.size());
+      StripeSM *stripe_ = cache.key_to_stripe(&hashT, host->url.data(), host->url.size());
       w.print("{}", hashT);
       printf("hash of %.*s is %.*s: Stripe  %s \n", static_cast<int>(host->url.size()), host->url.data(),
              static_cast<int>(w.size()), w.data(), stripe_->hashText.data());

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -75,8 +75,8 @@ namespace ct
 /// A live volume.
 /// Volume data based on data from loaded spans.
 struct Volume {
-  int                   _idx;  ///< Volume index.
-  CacheStoreBlocks      _size; ///< Amount of storage allocated.
+  int                     _idx;  ///< Volume index.
+  CacheStoreBlocks        _size; ///< Amount of storage allocated.
   std::vector<StripeSM *> _stripes;
 
   /// Remove all data related to @a span.
@@ -197,16 +197,16 @@ struct Cache {
   void clearAllocation();
 
   enum class SpanDumpDepth { SPAN, STRIPE, DIRECTORY };
-  void    dumpSpans(SpanDumpDepth depth);
-  void    dumpVolumes();
-  void    build_stripe_hash_table();
+  void      dumpSpans(SpanDumpDepth depth);
+  void      dumpVolumes();
+  void      build_stripe_hash_table();
   StripeSM *key_to_stripe(CryptoHash *key, const char *hostname, int host_len);
   //  ts::CacheStripeBlocks calcTotalSpanPhysicalSize();
   ts::CacheStripeBlocks calcTotalSpanConfiguredSize();
 
   std::list<Span *>                  _spans;
   std::map<int, Volume>              _volumes;
-  std::vector<StripeSM *>              globalVec_stripe;
+  std::vector<StripeSM *>            globalVec_stripe;
   std::unordered_set<ts::CacheURL *> URLset;
   unsigned short                    *stripes_hash_table;
 };
@@ -483,7 +483,7 @@ Cache::loadSpanDirect(swoc::file::path const &path, int vol_idx, [[maybe_unused]
       int nspb = span->_header->num_diskvol_blks;
       for (auto i = 0; i < nspb; ++i) {
         ts::CacheStripeDescriptor &raw    = span->_header->stripes[i];
-        StripeSM                    *stripe = new StripeSM(span.get(), raw.offset, raw.len);
+        StripeSM                  *stripe = new StripeSM(span.get(), raw.offset, raw.len);
         stripe->_idx                      = i;
         if (raw.free == 0) {
           stripe->_vol_idx = raw.vol_idx;
@@ -789,7 +789,7 @@ Span::allocStripe(int vol_idx, const CacheStripeBlocks &len)
           stripe->_type    = 1;
           return stripe;
         } else {
-          StripeSM *ns      = new StripeSM(this, stripe->_start, len);
+          StripeSM *ns    = new StripeSM(this, stripe->_start, len);
           stripe->_start += len;
           stripe->_len   -= len;
           ns->_vol_idx    = vol_idx;


### PR DESCRIPTION
The real goal here is to split the continuation logic out of `Stripe` into `StripeSM` to help with the re-partitioning of methods into smaller .cc files. I'm going to do this 'backwards', by changing the existing class to `StripeSM` and extracting logic back out into `Stripe`. This rename is quite large, so I'm doing it as its own PR first to make sure I don't miss anything. I will restore the `Stripe` class again, but many of the references in the code will still need to point to `StripeSM`.