### PR TITLE
Dispatch WRITE_COMPLETE when TLS handshake completes

### DIFF
--- a/src/iocore/net/UnixNetVConnection.cc
+++ b/src/iocore/net/UnixNetVConnection.cc
@@ -418,6 +418,12 @@ write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread)
       if (vc->write.enabled) {
         nh->write_ready_list.in_or_enqueue(vc);
       }
+      // If this was driven by a zero length read, signal complete when
+      // the handshake is complete. Otherwise set up for continuing read
+      // operations.
+      if (s->vio.ntodo() <= 0) {
+        vc->readSignalDone(VC_EVENT_WRITE_COMPLETE, nh);
+      }
     } else {
       write_reschedule(nh, vc);
     }


### PR DESCRIPTION
The SSLNetVConnection.cc logic already does this, so this is a port over
of that event dispatch functionality when ntodo is 0 for
UnixNetVConnection.cc. @josiahwi and I investigated a periodic failure
in proxy_protocol.test.py and we noticed that the issue was due to the
handshake completing within a single call of sslStartHandshake. In those
cases, the ConnectingEntry handler wasn't called back and the connection
would hang without progressing with the rest of the request after the
handshake completed. This ensures that the ConnectingEntry handler is
called in these circumstances.

---

# Review Comments

## SSLNetVConnection Reference
For reference, here is the corresponding dispatch from SSLNetVConnection that does this callback as well:

https://github.com/apache/trafficserver/blob/5f29d55f3cff865f2178d597199d72eb747ac80b/src/iocore/net/SSLNetVConnection.cc#L690-L694

This patch simply pulls in that callback for UnixNetVConnection's TLS handshake handling logic.

## Testing

The proxy_protocol.test.py test demonstrates this infrequently in ASF CI. I have never seen this locally on my mac. I've run this test in CI using my access to the CI vms dozens of times and have not seen a failure. I have been able to reproduce the error fairly consistently before this patch, so I feel this addresses the issue well.