### PR TITLE
Use VIO reader and writer APIs

### DIFF
--- a/src/api/InkVConnInternal.cc
+++ b/src/api/InkVConnInternal.cc
@@ -70,7 +70,7 @@ INKVConnInternal::destroy()
 VIO *
 INKVConnInternal::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  m_read_vio.buffer.writer_for(buf);
+  m_read_vio.set_writer(buf);
   m_read_vio.op = VIO::READ;
   m_read_vio.set_continuation(c);
   m_read_vio.nbytes    = nbytes;
@@ -89,14 +89,14 @@ VIO *
 INKVConnInternal::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
 {
   ink_assert(!owner);
-  m_write_vio.buffer.reader_for(buf);
+  m_write_vio.set_reader(buf);
   m_write_vio.op = VIO::WRITE;
   m_write_vio.set_continuation(c);
   m_write_vio.nbytes    = nbytes;
   m_write_vio.ndone     = 0;
   m_write_vio.vc_server = this;
 
-  if (m_write_vio.buffer.reader()->read_avail() > 0) {
+  if (m_write_vio.get_reader()->read_avail() > 0) {
     if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
       ink_assert(!"not reached");
     }

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -535,7 +535,7 @@ CacheVC::openReadFromWriterMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNU
   }
   b          = iobufferblock_clone(writer_buf.get(), writer_offset, bytes);
   writer_buf = iobufferblock_skip(writer_buf.get(), &writer_offset, &length, bytes);
-  vio.buffer.writer()->append_block(b);
+  vio.get_writer()->append_block(b);
   vio.ndone += bytes;
   if (vio.ntodo() <= 0) {
     return calluser(VC_EVENT_READ_COMPLETE);
@@ -790,7 +790,7 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   if (ntodo <= 0) {
     return EVENT_CONT;
   }
-  if (vio.buffer.writer()->max_read_avail() > vio.buffer.writer()->water_mark && vio.ndone) { // initiate read of first block
+  if (vio.get_writer()->max_read_avail() > vio.get_writer()->water_mark && vio.ndone) { // initiate read of first block
     return EVENT_CONT;
   }
   if ((bytes <= 0) && vio.ntodo() >= 0) {
@@ -801,7 +801,7 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   }
   b           = new_IOBufferBlock(buf, bytes, doc_pos);
   b->_buf_end = b->_end;
-  vio.buffer.writer()->append_block(b);
+  vio.get_writer()->append_block(b);
   vio.ndone += bytes;
   doc_pos   += bytes;
   if (vio.ntodo() <= 0) {
@@ -812,7 +812,7 @@ CacheVC::openReadMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     }
     // we have to keep reading until we give the user all the
     // bytes it wanted or we hit the watermark.
-    if (vio.ntodo() > 0 && !vio.buffer.writer()->high_water()) {
+    if (vio.ntodo() > 0 && !vio.get_writer()->high_water()) {
       goto Lread;
     }
     return EVENT_CONT;

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -170,7 +170,7 @@ VIO *
 CacheVC::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *abuf)
 {
   ink_assert(vio.op == VIO::READ);
-  vio.buffer.writer_for(abuf);
+  vio.set_writer(abuf);
   vio.set_continuation(c);
   vio.ndone     = 0;
   vio.nbytes    = nbytes;
@@ -188,7 +188,7 @@ VIO *
 CacheVC::do_io_pread(Continuation *c, int64_t nbytes, MIOBuffer *abuf, int64_t offset)
 {
   ink_assert(vio.op == VIO::READ);
-  vio.buffer.writer_for(abuf);
+  vio.set_writer(abuf);
   vio.set_continuation(c);
   vio.ndone     = 0;
   vio.nbytes    = nbytes;
@@ -208,7 +208,7 @@ CacheVC::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuf, bool
 {
   ink_assert(vio.op == VIO::WRITE);
   ink_assert(!owner);
-  vio.buffer.reader_for(abuf);
+  vio.set_reader(abuf);
   vio.set_continuation(c);
   vio.ndone     = 0;
   vio.nbytes    = nbytes;
@@ -245,9 +245,9 @@ CacheVC::reenable(VIO *avio)
   if (!trigger) {
 #ifndef USELESS_REENABLES
     if (vio.op == VIO::READ) {
-      if (vio.buffer.mbuf->max_read_avail() > vio.buffer.writer()->water_mark)
+      if (vio.buffer.mbuf->max_read_avail() > vio.get_writer->water_mark)
         ink_assert(!"useless reenable of cache read");
-    } else if (!vio.buffer.reader()->read_avail())
+    } else if (!vio.get_reader()->read_avail())
       ink_assert(!"useless reenable of cache write");
 #endif
     trigger = avio->mutex->thread_holding->schedule_imm_local(this);

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -1113,11 +1113,11 @@ CacheVC::openWriteMain(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   int called_user = 0;
   ink_assert(!is_io_in_progress());
 Lagain:
-  if (!vio.buffer.writer()) {
+  if (!vio.get_writer()) {
     if (calluser(VC_EVENT_WRITE_READY) == EVENT_DONE) {
       return EVENT_DONE;
     }
-    if (!vio.buffer.writer()) {
+    if (!vio.get_writer()) {
       return EVENT_CONT;
     }
   }
@@ -1132,7 +1132,7 @@ Lagain:
     }
   }
   int64_t ntodo       = static_cast<int64_t>(vio.ntodo() + length);
-  int64_t total_avail = vio.buffer.reader()->read_avail();
+  int64_t total_avail = vio.get_reader()->read_avail();
   int64_t avail       = total_avail;
   int64_t towrite     = avail + length;
   if (towrite > ntodo) {
@@ -1144,11 +1144,11 @@ Lagain:
     towrite  = MAX_FRAG_SIZE;
   }
   if (!blocks && towrite) {
-    blocks = vio.buffer.reader()->block;
-    offset = vio.buffer.reader()->start_offset;
+    blocks = vio.get_reader()->block;
+    offset = vio.get_reader()->start_offset;
   }
   if (avail > 0) {
-    vio.buffer.reader()->consume(avail);
+    vio.get_reader()->consume(avail);
     vio.ndone += avail;
     total_len += avail;
   }

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -1556,7 +1556,7 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
       // Outbound PROXY Protocol
       VIO    &vio     = this->write.vio;
       int64_t ntodo   = vio.ntodo();
-      int64_t towrite = vio.buffer.reader()->read_avail();
+      int64_t towrite = vio.get_reader()->read_avail();
 
       if (ntodo > 0 && towrite > 0) {
         MIOBufferAccessor &buf           = vio.buffer;
@@ -2240,7 +2240,7 @@ SSLNetVConnection::_propagateHandShakeBuffer(UnixNetVConnection *target, EThread
   // Take ownership of the handShake buffer
   this->sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
   NetState *s              = &target->read;
-  s->vio.buffer.writer_for(this->handShakeBuffer);
+  s->vio.set_writer(this->handShakeBuffer);
   s->vio.set_reader(this->handShakeHolder);
   this->handShakeHolder = nullptr;
   this->handShakeBuffer = nullptr;

--- a/src/iocore/net/UnixNetVConnection.cc
+++ b/src/iocore/net/UnixNetVConnection.cc
@@ -609,7 +609,7 @@ UnixNetVConnection::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
   read.vio.ndone     = 0;
   read.vio.vc_server = (VConnection *)this;
   if (buf) {
-    read.vio.buffer.writer_for(buf);
+    read.vio.set_writer(buf);
     if (!read.enabled) {
       read.vio.reenable();
     }
@@ -635,7 +635,7 @@ UnixNetVConnection::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader 
   write.vio.vc_server = (VConnection *)this;
   if (reader) {
     ink_assert(!owner);
-    write.vio.buffer.reader_for(reader);
+    write.vio.set_reader(reader);
     if (nbytes && !write.enabled) {
       write.vio.reenable();
     }

--- a/src/iocore/net/quic/QUICStreamVCAdapter.cc
+++ b/src/iocore/net/quic/QUICStreamVCAdapter.cc
@@ -261,7 +261,7 @@ VIO *
 QUICStreamVCAdapter::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
   if (buf) {
-    this->_read_vio.buffer.writer_for(buf);
+    this->_read_vio.set_writer(buf);
   } else {
     this->_read_vio.buffer.clear();
   }
@@ -280,7 +280,7 @@ VIO *
 QUICStreamVCAdapter::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool /* owner ATS_UNUSED */)
 {
   if (buf) {
-    this->_write_vio.buffer.reader_for(buf);
+    this->_write_vio.set_reader(buf);
   } else {
     this->_write_vio.buffer.clear();
   }

--- a/src/proxy/PluginVC.cc
+++ b/src/proxy/PluginVC.cc
@@ -255,7 +255,7 @@ PluginVC::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
   ink_assert(magic == PLUGIN_VC_MAGIC_ALIVE);
 
   if (buf) {
-    read_state.vio.buffer.writer_for(buf);
+    read_state.vio.set_writer(buf);
   } else {
     read_state.vio.buffer.clear();
   }
@@ -287,7 +287,7 @@ PluginVC::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *abuffer, 
 
   if (abuffer) {
     ink_assert(!owner);
-    write_state.vio.buffer.reader_for(abuffer);
+    write_state.vio.set_reader(abuffer);
   } else {
     write_state.vio.buffer.clear();
   }

--- a/src/proxy/Transform.cc
+++ b/src/proxy/Transform.cc
@@ -275,7 +275,7 @@ TransformTerminus::handle_event(int event, void * /* edata ATS_UNUSED */)
 VIO *
 TransformTerminus::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  m_read_vio.buffer.writer_for(buf);
+  m_read_vio.set_writer(buf);
   m_read_vio.op = VIO::READ;
   m_read_vio.set_continuation(c);
   m_read_vio.nbytes    = nbytes;
@@ -300,7 +300,7 @@ TransformTerminus::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *
 {
   // In the process of eliminating 'owner' mode so asserting against it
   ink_assert(!owner);
-  m_write_vio.buffer.reader_for(buf);
+  m_write_vio.set_reader(buf);
   m_write_vio.op = VIO::WRITE;
   m_write_vio.set_continuation(c);
   m_write_vio.nbytes    = nbytes;
@@ -506,7 +506,7 @@ TransformVConnection::backlog(uint64_t limit)
   MIOBuffer   *w;
   while (raw_vc && raw_vc != &m_terminus) {
     INKVConnInternal *vc = static_cast<INKVConnInternal *>(raw_vc);
-    if (nullptr != (w = vc->m_read_vio.buffer.writer())) {
+    if (nullptr != (w = vc->m_read_vio.get_writer())) {
       b += w->max_read_avail();
     }
     if (b >= limit) {
@@ -514,7 +514,7 @@ TransformVConnection::backlog(uint64_t limit)
     }
     raw_vc = vc->m_output_vc;
   }
-  if (nullptr != (w = m_terminus.m_read_vio.buffer.writer())) {
+  if (nullptr != (w = m_terminus.m_read_vio.get_writer())) {
     b += w->max_read_avail();
   }
   if (b >= limit) {

--- a/src/proxy/http3/Http3Transaction.cc
+++ b/src/proxy/http3/Http3Transaction.cc
@@ -118,7 +118,7 @@ VIO *
 HQTransaction::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
   if (buf) {
-    this->_read_vio.buffer.writer_for(buf);
+    this->_read_vio.set_writer(buf);
   } else {
     this->_read_vio.buffer.clear();
   }
@@ -142,7 +142,7 @@ VIO *
 HQTransaction::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool /* owner ATS_UNUSED */)
 {
   if (buf) {
-    this->_write_vio.buffer.reader_for(buf);
+    this->_write_vio.set_reader(buf);
   } else {
     this->_write_vio.buffer.clear();
   }


### PR DESCRIPTION
These APIs are already provided and make the code more succinct. This updates the code everywhere to consistently use these convenience APIs. The continuation API usage is not changed because `VIO::set_continuation` has some additional behavior, so the usage is not as straightforward.