### PR TITLE
Allow `UnixNetVConnection` to be closed anytime

### DIFF
--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -117,8 +117,14 @@ endif()
 
 if(BUILD_TESTING)
   add_executable(
-    test_net libinknet_stub.cc NetVCTest.cc unit_tests/test_ProxyProtocol.cc unit_tests/test_SSLSNIConfig.cc
-             unit_tests/test_YamlSNIConfig.cc unit_tests/unit_test_main.cc
+    test_net
+    libinknet_stub.cc
+    NetVCTest.cc
+    unit_tests/test_ProxyProtocol.cc
+    unit_tests/test_SSLSNIConfig.cc
+    unit_tests/test_YamlSNIConfig.cc
+    unit_tests/unit_test_main.cc
+    unit_tests/test_Net.cc
   )
   target_link_libraries(test_net PRIVATE ts::inknet catch2::catch2)
   set(LIBINKNET_UNIT_TEST_DIR "${CMAKE_SOURCE_DIR}/src/iocore/net/unit_tests")

--- a/src/iocore/net/UnixNetVConnection.cc
+++ b/src/iocore/net/UnixNetVConnection.cc
@@ -654,9 +654,6 @@ UnixNetVConnection::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader 
 void
 UnixNetVConnection::do_io_close(int alerrno /* = -1 */)
 {
-  // FIXME: the nh must not nullptr.
-  ink_assert(nh);
-
   // The vio continuations will be cleared in ::clear called from ::free_thread
   read.enabled    = 0;
   write.enabled   = 0;

--- a/src/iocore/net/unit_tests/test_Net.cc
+++ b/src/iocore/net/unit_tests/test_Net.cc
@@ -1,0 +1,34 @@
+/** @file
+
+  Catch based unit tests for inknet
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "iocore/net/NetProcessor.h"
+#include "iocore/net/NetVConnection.h"
+
+#include <catch.hpp>
+
+TEST_CASE("When we allocate a VC, it should not have a server name yet.")
+{
+  NetVConnection *vc{netProcessor.allocate_vc(this_ethread())};
+  CHECK(nullptr == vc->get_server_name());
+  vc->do_io_close();
+}


### PR DESCRIPTION
A `UnixNetVConnection` only has a NetHandler when it is connected. Since it may be unconnected until `UnixNetVConnection::connectUp` is called, it is unreasonable to expect that it will always have a `NetHandler`. The unit test does fail before removing the `ink_assert`. After the patch, the unit test passes and valgrind does not detect any memory issues.