### PR TITLE
Remove paramset in url_sig

### DIFF
--- a/plugins/experimental/url_sig/url_sig.cc
+++ b/plugins/experimental/url_sig/url_sig.cc
@@ -890,7 +890,6 @@ allow:
     if (*new_path) {
       TSUrlPathSet(rri->requestBufp, rri->requestUrl, new_path, strlen(new_path));
     }
-    TSUrlHttpParamsSet(rri->requestBufp, rri->requestUrl, nullptr, 0);
   }
 
   TSfree((void *)current_url);


### PR DESCRIPTION
This removes the ParamsSet call within url_sig which was just clearing out the ATS parsed params anyway