### PR TITLE
Add an autest for s-maxage Cache-Control response directive

### DIFF
--- a/tests/gold_tests/cache/cache-control.test.py
+++ b/tests/gold_tests/cache/cache-control.test.py
@@ -138,6 +138,24 @@ tr.Processes.Default.StartBefore(ts)
 tr.AddVerifierClientProcess("proxy-verifier-client", replay_file, http_ports=[ts.Variables.port])
 
 #
+# Verify correct handling of various s-maxage directives in responses.
+#
+ts = Test.MakeATSProcess("ts-s-maxage")
+replay_file = "replay/cache-control-s-maxage.replay.yaml"
+server = Test.MakeVerifierServerProcess("s-maxage-server", replay_file)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http',
+        'proxy.config.http.insert_age_in_response': 0,
+    })
+ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variables.http_port))
+tr = Test.AddTestRun("Verify correct max-age cache-control behavior.")
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(ts)
+tr.AddVerifierClientProcess("s-maxage-client", replay_file, http_ports=[ts.Variables.port])
+
+#
 # Verify correct interaction between cache-control no-cache and pragma header
 #
 ts = Test.MakeATSProcess("ts-cache-control-pragma")

--- a/tests/gold_tests/cache/replay/cache-control-s-maxage.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-s-maxage.replay.yaml
@@ -1,0 +1,232 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# This replay file assumes that caching is enabled.
+#
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - request_for_positive_s_maxage: &request_for_positive_s_maxage
+      client-request:
+        method: "GET"
+        version: "1.1"
+        scheme: "http"
+        url: /path/200_positive_s_maxage
+        headers:
+          fields:
+          - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 100ms
+
+  - request_for_zero_s_maxage: &request_for_zero_s_maxage
+      client-request:
+        method: "GET"
+        version: "1.1"
+        scheme: "http"
+        url: /path/200_zero_s_maxage
+        headers:
+          fields:
+          - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 100ms
+
+  - request_for_negative_s_maxage: &request_for_negative_s_maxage
+      client-request:
+        method: "GET"
+        version: "1.1"
+        scheme: "http"
+        url: /path/200_negative_s_maxage
+        headers:
+          fields:
+          - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 100ms
+
+  - request_for_non_number_s_maxage: &request_for_non_number_s_maxage
+      client-request:
+        method: "GET"
+        version: "1.1"
+        scheme: "http"
+        url: /path/200_non_number_s_maxage
+        headers:
+          fields:
+          - [ Host, example.com ]
+
+        # Add a delay so ATS has time to finish any caching IO for the previous
+        # transaction.
+        delay: 100ms
+
+  - 200_ok_response: &200_ok_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 16 ]
+          - [ Cache-Control, s-maxage=300 ]
+
+sessions:
+- transactions:
+
+  #
+  # Test 1: Verify that a 200 response with a positive s-maxage is cached.
+  #
+  - all: { headers: { fields: [[ uuid, 1 ]]}}
+    <<: *request_for_positive_s_maxage
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Cache-Control, s-maxage=300 ]
+
+    proxy-response:
+      status: 200
+
+  - all: { headers: { fields: [[ uuid, 2 ]]}}
+    <<: *request_for_positive_s_maxage
+
+    # This should not go through to the server. Return a non-200 response to
+    # verify it is served from cache.
+    server-response:
+      status: 400
+      reason: "Bad Request"
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    # Expect the cached 200 response.
+    proxy-response:
+      status: 200
+
+  #
+  # Test 2: Verify that a 200 response with a 0 s-maxage is considered stale.
+  #
+  - all: { headers: { fields: [[ uuid, 3 ]]}}
+    <<: *request_for_zero_s_maxage
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        # Note that ATS as a shared caching proxy should treat s-maxage with
+        # priority over max-age.
+        - [ Cache-Control, "s-maxage=0,public,max-age=300" ]
+
+    proxy-response:
+      status: 200
+
+  - all: { headers: { fields: [[ uuid, 4 ]]}}
+    <<: *request_for_zero_s_maxage
+
+    # This should go through to the server because the response's s-maxage was 0
+    # and therefore object should be considered stale.
+    server-response:
+      status: 400
+      reason: "Bad Request"
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    # Expect the 400 response from the server because the 200 response should
+    # be considered stale.
+    proxy-response:
+      status: 400
+
+  #
+  # Test 3: Verify that a 200 response with a negative max age is not served
+  # from the cache. Since it is invalid, the item should be considered stale.
+  #
+  - all: { headers: { fields: [[ uuid, 5 ]]}}
+    <<: *request_for_negative_s_maxage
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        # Notice the negative s-maxage.
+        - [ Cache-Control, s-maxage=-300 ]
+
+    proxy-response:
+      status: 200
+
+  - all: { headers: { fields: [[ uuid, 6 ]]}}
+    <<: *request_for_negative_s_maxage
+
+    # This should go through to the server because the above should not be
+    # served from the cache.
+    server-response:
+      status: 400
+      reason: "Bad Request"
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    # Expect the 400 response from the server because the 200 response should
+    # not be served from the cache.
+    proxy-response:
+      status: 400
+
+  #
+  # Test 4: Verify that a 200 response with a non-integer s-maxage is not served
+  # from the cache. Since it is invalid, it should be considered stale.
+  #
+  - all: { headers: { fields: [[ uuid, 7 ]]}}
+    <<: *request_for_non_number_s_maxage
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        # Notice the invalid, non-integer s-maxage value.
+        - [ Cache-Control, s-maxage=not_a_number ]
+
+    proxy-response:
+      status: 200
+
+  - all: { headers: { fields: [[ uuid, 8 ]]}}
+    <<: *request_for_non_number_s_maxage
+
+    # This should go through to the server because the above should not be
+    # cached.
+    server-response:
+      status: 400
+      reason: "Bad Request"
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    # Expect the 400 response from the server because the 200 response should
+    # not be cached.
+    proxy-response:
+      status: 400


### PR DESCRIPTION
This adds an autest to verify that ATS caching funcionality behaves correctly when handling the s-maxage Cache-Control response directive. No production changes are needed because ATS passes all the added tests.