### PR TITLE
Restore returning string metrics from traffic_ctl match

### DIFF
--- a/src/records/RecCore.cc
+++ b/src/records/RecCore.cc
@@ -576,8 +576,7 @@ RecLookupMatchingRecords(unsigned rec_type, const char *match, void (*callback)(
         callback(&tmp, data);
       }
     }
-    // all done for metrics
-    return REC_ERR_OKAY;
+    // Fall through to return any matching string metrics
   }
 
   num_records = g_num_records;


### PR DESCRIPTION
PR #11127 prevented metrics being returned for config records, but removed returning string metrics.

This PR restores string metrics.