### PR TITLE
prefetch autests: await log file content

### DIFF
--- a/tests/gold_tests/autest-site/when.test.ext
+++ b/tests/gold_tests/autest-site/when.test.ext
@@ -75,4 +75,27 @@ def FileContains(haystack, needle, desired_count=1):
         return False
 
 
+def AddAwaitFileContainsTestRun(test, name, file_path, needle, desired_count=1) -> 'TestRun':
+    '''Add a test run to await upon the presence of a string in a file.
+
+    :param test: The Test object to which the TestRun is added.
+    :param name: The name of the TestRun.
+    :param file_path: The path to the file to be inspected.
+    :param needle: The content to look for in the file. This can be a regular
+        expression which will be used in Python's re.search function.
+    :param desired_count: How many times the caller desires to see needle in
+        the file before considering the TestRun successful. The default is 1.
+    :return: The TestRun object that was added to the Test.
+    '''
+    tr = test.AddTestRun(name)
+    p = tr.Processes.Default
+    p.Command = f'echo waiting for {needle} in {file_path}'
+    await_process = tr.Processes.Process('await', 'sleep 60')
+    await_process.Ready = When.FileContains(file_path, needle, desired_count)
+    await_process.StartupTimeout = 30
+    p.StartBefore(await_process)
+    return tr
+
+
 AddWhenFunction(FileContains)
+ExtendTest(AddAwaitFileContainsTestRun, name="AddAwaitFileContainsTestRun")

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_bignum.test.py
@@ -45,7 +45,7 @@ for i in vals:
 
 dns = Test.MakeDNServer("dns")
 
-ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
+ts = Test.MakeATSProcess("ts")
 ts.Disk.records_config.update(
     {
         'proxy.config.diags.debug.enabled': 1,
@@ -71,7 +71,9 @@ tr.Processes.Default.Command = (
     f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-3842948374928374982374982374.txt')
 tr.Processes.Default.ReturnCode = 0
 
+Test.AddAwaitFileContainsTestRun('Await transactions to finish logging.', ts.Disk.traffic_out.Name, '3842948374928374982374982377')
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = ("grep 'GET http://domain.in' trace.log")
+tr.Processes.Default.Command = (f"grep 'GET http://domain.in' {ts.Disk.traffic_out.Name}")
 tr.Streams.stdout = "prefetch_bignum.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_cmcd.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_cmcd.test.py
@@ -279,17 +279,11 @@ tr.Processes.Default.ReturnCode = 0
 
 condwaitpath = os.path.join(Test.Variables.AtsTestToolsDir, 'condwait')
 
-# look for ts transaction log
 ts0log = os.path.join(ts0.Variables.LOGDIR, 'transaction.log')
-tr = Test.AddTestRun()
-ps = tr.Processes.Default
-ps.Command = (condwaitpath + ' 60 1 -f ' + ts0log)
+Test.AddAwaitFileContainsTestRun('Await ts transactions to finish logging.', ts0log, 'crr.txt')
 
-# look for ts1 transaction log
 ts1log = os.path.join(ts1.Variables.LOGDIR, 'transaction.log')
-tr = Test.AddTestRun()
-ps = tr.Processes.Default
-ps.Command = (condwaitpath + ' 60 1 -f ' + ts1log)
+Test.AddAwaitFileContainsTestRun('Await ts1 transactions to finish logging.', ts1log, 'crr.txt')
 
 tr = Test.AddTestRun()
 tr.Processes.Default.Command = (f"cat {ts0log}")

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_overflow.test.py
@@ -42,7 +42,7 @@ for i in list(range(3594967639391, 3594967639391 + 3)):
 
 dns = Test.MakeDNServer("dns")
 
-ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
+ts = Test.MakeATSProcess("ts")
 ts.Disk.records_config.update(
     {
         'proxy.config.diags.debug.enabled': 1,
@@ -68,7 +68,9 @@ tr.Processes.Default.Command = (
     f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-3594967639391.txt')
 tr.Processes.Default.ReturnCode = 0
 
+Test.AddAwaitFileContainsTestRun('Await transactions to finish logging.', ts.Disk.traffic_out.Name, '3594967639394')
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = ("grep 'GET http://domain.in' trace.log")
+tr.Processes.Default.Command = (f"grep 'GET http://domain.in' {ts.Disk.traffic_out.Name}")
 tr.Streams.stdout = "prefetch_overflow.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_simple.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_simple.test.py
@@ -42,7 +42,7 @@ for i in list(range(1, 1 + 3)):
 
 dns = Test.MakeDNServer("dns")
 
-ts = Test.MakeATSProcess("ts", use_traffic_out=False, command="traffic_server 2> trace.log")
+ts = Test.MakeATSProcess("ts")
 ts.Disk.records_config.update(
     {
         'proxy.config.diags.debug.enabled': 1,
@@ -67,7 +67,9 @@ tr = Test.AddTestRun()
 tr.Processes.Default.Command = (f'curl --verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1.txt')
 tr.Processes.Default.ReturnCode = 0
 
+Test.AddAwaitFileContainsTestRun('Await transactions to finish logging.', ts.Disk.traffic_out.Name, 'demo-4.txt')
+
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = ("grep 'GET http://domain.in' trace.log")
+tr.Processes.Default.Command = (f"grep 'GET http://domain.in' {ts.Disk.traffic_out.Name}")
 tr.Streams.stdout = "prefetch_simple.gold"
 tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
This updates the prefetch tests to await the final logged transaction content that they expect. With this patch, they now have a test run that polls for the expected content for up to a one minute timeout. This will fix some intermittent test failures for these prefetch tests which was caused by a race condition in which the checking of content was done while the log was being written. Generally the write was fast enough, but it wasn't always, resulting in an intermittent false failure due to the race.

Fixes #11610