### PR TITLE
traffic_crashlog: use SIGCONT for parent death

### DIFF
--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -156,7 +156,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   process_args(&version, argument_descriptions, countof(argument_descriptions), argv);
 
   if (wait_mode) {
-    EnableDeathSignal(SIGKILL);
+    EnableDeathSignal(SIGCONT);
     kill(getpid(), SIGSTOP);
   }
 


### PR DESCRIPTION
With PDEATHSIG set to SIGKILL, the traffic_crashlog was not exiting when traffic_server exited (normally).  Changing the signal to SIGCONT is a little nicer and allows traffic_crashlog to realize that traffic_server has exited and then terminate normally.

I'm not sure why SIGKILL wasn't working