### PR TITLE
Update boringssl in build-h3-tools script

### DIFF
--- a/tools/build_boringssl_h3_tools.sh
+++ b/tools/build_boringssl_h3_tools.sh
@@ -121,7 +121,7 @@ GO_BINARY_PATH=${BASE}/go/bin/go
 if [ ! -d boringssl ]; then
   git clone https://boringssl.googlesource.com/boringssl
   cd boringssl
-  git checkout a1843d660b47116207877614af53defa767be46a
+  git checkout 45b2464158379f48cec6e35a1ef503ddea1511a6
   cd ..
 fi
 cd boringssl
@@ -141,9 +141,6 @@ set -e
 # Note: -UBORINGSSL_HAVE_LIBUNWIND
 #   Disable related libunwind test builds, there are some version number issues
 #   with this pkg in Ubuntu 20.04, so disable this to make sure it builds.
-# Note: -Wno-error=stringop-overflow
-#   GCC 13 has a stringop-overflow false positive. It only affects the build
-#   of the static lib.
 cmake \
   -B build-shared \
   -DGO_EXECUTABLE=${GO_BINARY_PATH} \
@@ -158,7 +155,7 @@ cmake \
   -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_FLAGS='-Wno-error=ignored-attributes -UBORINGSSL_HAVE_LIBUNWIND' \
-  -DCMAKE_C_FLAGS="-Wno-error=stringop-overflow ${BSSL_C_FLAGS}" \
+  -DCMAKE_C_FLAGS="${BSSL_C_FLAGS}" \
   -DBUILD_SHARED_LIBS=0
 cmake --build build-shared -j ${num_threads}
 cmake --build build-static -j ${num_threads}


### PR DESCRIPTION
This updates boringssl to the commit that avoids the -Wstringop-overflow false positive.

See #11602.