### PR TITLE
Fix fuzz build 

### DIFF
--- a/tests/fuzzing/CMakeLists.txt
+++ b/tests/fuzzing/CMakeLists.txt
@@ -29,14 +29,15 @@ add_executable(fuzz_rec_http fuzz_rec_http.cc)
 add_executable(fuzz_yamlcpp fuzz_yamlcpp.cc)
 add_executable(fuzz_http3frame fuzz_http3frame.cc)
 
-target_link_libraries(fuzz_esi PRIVATE esi-common esicore)
+target_link_libraries(fuzz_esi PRIVATE esi-common esicore ts::tscore ts::tsutil ts::tsapi ts::inkevent)
+target_link_options(fuzz_esi PRIVATE "-fuse-ld=lld")
 target_link_libraries(fuzz_hpack PRIVATE records tscore hdrs inkevent)
 target_link_libraries(fuzz_http PRIVATE ts::hdrs ts::tscore ts::inkevent)
 target_link_libraries(fuzz_json PRIVATE libswoc::libswoc yaml-cpp ts::jsonrpc_protocol)
 target_link_libraries(fuzz_proxy_protocol PRIVATE inknet inkevent ts::tscore yaml-cpp libswoc::libswoc)
 target_link_libraries(fuzz_rec_http PRIVATE records tscore libswoc::libswoc)
 target_link_libraries(fuzz_yamlcpp PRIVATE yaml-cpp)
-target_link_libraries(fuzz_http3frame PRIVATE ts::http3 ts::tscore)
+target_link_libraries(fuzz_http3frame PRIVATE ts::tscore ts::quic ts::records ts::tsutil ts::hdrs)
 target_link_options(fuzz_http3frame PRIVATE "-fuse-ld=lld")
 
 target_sources(

--- a/tests/fuzzing/fuzz_esi.cc
+++ b/tests/fuzzing/fuzz_esi.cc
@@ -22,20 +22,10 @@
  */
 
 #include "EsiParser.h"
-#include "mgmt/rpc/handlers/common/Utils.h"
 #include "DocNode.h"
 
 #define kMinInputLength 10
 #define kMaxInputLength 1024
-
-void
-Debug(const char *tag, const char *fmt, ...)
-{
-}
-void
-Error(const char *fmt, ...)
-{
-}
 
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t *input_data, size_t size_data)
@@ -46,8 +36,7 @@ LLVMFuzzerTestOneInput(const uint8_t *input_data, size_t size_data)
 
   std::string input(reinterpret_cast<const char *>(input_data), size_data);
 
-  EsiLib::Utils::init(&Debug, &Error);
-  EsiParser parser("parser_fuzzing", &Debug, &Error);
+  EsiParser parser{1024 * 1024};
 
   EsiLib::DocNodeList node_list;
   bool                ret = parser.completeParse(node_list, input);

--- a/tests/fuzzing/fuzz_http3frame.cc
+++ b/tests/fuzzing/fuzz_http3frame.cc
@@ -20,8 +20,6 @@
 
 #include "proxy/http3/Http3Frame.h"
 #include "proxy/http3/Http3Config.h"
-#include "proxy/http3/Http3FrameDispatcher.h"
-#include "proxy/http3/Http3SettingsHandler.h"
 
 #include "records/RecordsConfig.h"
 #include "tscore/Layout.h"


### PR DESCRIPTION
fuzz build is failing because the fuzz tests for esi parser and http3frame need to be updated