### PR TITLE
Use `this_ethread()` for evacuation block alloc

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -833,7 +833,7 @@ dir_lookaside_insert(EvacuationBlock *eblock, StripeSM *stripe, Dir *to)
        (int)dir_phase(to));
   ink_assert(stripe->mutex->thread_holding == this_ethread());
   int              i         = key->slice32(3) % LOOKASIDE_SIZE;
-  EvacuationBlock *b         = new_EvacuationBlock(stripe->mutex->thread_holding);
+  EvacuationBlock *b         = new_EvacuationBlock();
   b->evac_frags.key          = *key;
   b->evac_frags.earliest_key = *key;
   b->earliest_evacuator      = eblock->earliest_evacuator;
@@ -858,7 +858,7 @@ dir_lookaside_fixup(const CacheKey *key, StripeSM *stripe)
       int64_t o = dir_offset(&b->dir), n = dir_offset(&b->new_dir);
       stripe->ram_cache->fixup(key, static_cast<uint64_t>(o), static_cast<uint64_t>(n));
       stripe->lookaside[i].remove(b);
-      free_EvacuationBlock(b, stripe->mutex->thread_holding);
+      free_EvacuationBlock(b);
       return res;
     }
     b = b->link.next;
@@ -880,7 +880,7 @@ dir_lookaside_cleanup(StripeSM *stripe)
              b->evac_frags.earliest_key.slice32(1));
         i.remove(b);
         free_CacheEvacuateDocVC(b->earliest_evacuator);
-        free_EvacuationBlock(b, stripe->mutex->thread_holding);
+        free_EvacuationBlock(b);
         b = nb;
         goto Lagain;
       }
@@ -901,7 +901,7 @@ dir_lookaside_remove(const CacheKey *key, StripeSM *stripe)
       DDbg(dbg_ctl_dir_lookaside, "remove %X %X offset %" PRId64 " phase %d", key->slice32(0), key->slice32(1),
            dir_offset(&b->new_dir), dir_phase(&b->new_dir));
       stripe->lookaside[i].remove(b);
-      free_EvacuationBlock(b, stripe->mutex->thread_holding);
+      free_EvacuationBlock(b);
       return;
     }
     b = b->link.next;

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -24,6 +24,10 @@
 #include "P_Cache.h"
 #include "P_CacheDoc.h"
 
+#ifdef DEBUG
+#include "iocore/eventsystem/EThread.h"
+#endif
+
 namespace
 {
 
@@ -559,6 +563,7 @@ CacheVC::openReadClose(int event, Event * /* e ATS_UNUSED */)
     VC_SCHED_LOCK_RETRY();
   }
   if (f.hit_evacuate && dir_valid(stripe, &first_dir) && closed > 0) {
+    ink_assert(stripe->mutex->thread_holding == this_ethread());
     if (f.single_fragment) {
       stripe->force_evacuate_head(&first_dir, dir_pinned(&first_dir));
     } else if (dir_valid(stripe, &earliest_dir)) {

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -330,9 +330,9 @@ StripeSM::cancel_trigger()
 }
 
 inline EvacuationBlock *
-new_EvacuationBlock(EThread *t)
+new_EvacuationBlock()
 {
-  EvacuationBlock *b      = THREAD_ALLOC(evacuationBlockAllocator, t);
+  EvacuationBlock *b      = THREAD_ALLOC(evacuationBlockAllocator, this_ethread());
   b->init                 = 0;
   b->readers              = 0;
   b->earliest_evacuator   = nullptr;
@@ -341,7 +341,7 @@ new_EvacuationBlock(EThread *t)
 }
 
 inline void
-free_EvacuationBlock(EvacuationBlock *b, EThread *t)
+free_EvacuationBlock(EvacuationBlock *b)
 {
   EvacuationKey *e = b->evac_frags.link.next;
   while (e) {
@@ -349,7 +349,7 @@ free_EvacuationBlock(EvacuationBlock *b, EThread *t)
     evacuationKeyAllocator.free(e);
     e = n;
   }
-  THREAD_FREE(b, evacuationBlockAllocator, t);
+  THREAD_FREE(b, evacuationBlockAllocator, this_ethread());
 }
 
 inline OpenDirEntry *

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -196,11 +196,31 @@ public:
   int evacuateWrite(CacheEvacuateDocVC *evacuator, int event, Event *e);
   int evacuateDocReadDone(int event, Event *e);
 
-  int              evac_range(off_t start, off_t end, int evac_phase);
-  void             periodic_scan();
-  void             scan_for_pinned_documents();
-  void             evacuate_cleanup_blocks(int i);
-  void             evacuate_cleanup();
+  int evac_range(off_t start, off_t end, int evac_phase);
+  /**
+   *
+   * The caller must hold the mutex.
+   */
+  void periodic_scan();
+  /**
+   *
+   * The caller must hold the mutex.
+   */
+  void scan_for_pinned_documents();
+  /**
+   *
+   * The caller must hold the mutex.
+   */
+  void evacuate_cleanup_blocks(int i);
+  /**
+   *
+   * The caller must hold the mutex.
+   */
+  void evacuate_cleanup();
+  /**
+   *
+   * The caller must hold the mutex.
+   */
   EvacuationBlock *force_evacuate_head(Dir const *dir, int pinned);
 
   int within_hit_evacuate_window(Dir const *dir) const;


### PR DESCRIPTION
I would like to extract a new class to handle the responsibility of document evacuation, but that is hard because the evacuation logic uses the thread holding the `StripeSM` mutex to do the `EvacuationBlock` allocation. I think this is a hacky way to get the current thread, so I want to switch the calls to `this_ethread()` which doesn't depend on the mutex's internal data and describes precisely what it does. I'm PRing this change all by itself because from the perspective of the `StripeSM` API it is a behavior change. I don't think there can be too many debug asserts for this change so I've added them to every call into the evacuation logic, although if any of these asserts were violated we'd probably already have seen horrendous damage to the unprotected doubly-linked `evacuate` list and more.