### PR TITLE
traffic_ctl: Support command options to enable/disable  debug logs at runtime in a single command.

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -3389,6 +3389,8 @@ Diagnostic Logging Configuration
 
    When set to 2, interprets the :ts:cv:`proxy.config.diags.debug.client_ip` setting determine whether diagnostic messages are logged.
 
+   See the :ref:`Enable debug using traffic_ctl<traffic-control-command-server-debug>` for a convenient way to handle this.
+
 .. ts:cv:: CONFIG proxy.config.diags.debug.client_ip STRING NULL
 
    if :ts:cv:`proxy.config.diags.debug.enabled` is set to 2, this value is tested against the source IP of the incoming connection.  If there is a match, all the diagnostic messages for that connection and the related outgoing connection will be logged.

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -380,10 +380,10 @@ traffic_ctl server
 
    Enables diagnostic messages at runtime. This is equivalent to
    manually setting the below records but this is done in one go.
-   
+
    Note that if you just set this to enable, the :ts:cv:`proxy.config.diags.debug.enabled`
    will be set to ``1`` unless you specify the ``--client_ip,-c`` option.
-    
+
    :ts:cv:`proxy.config.diags.debug.enabled`
 
    :ts:cv:`proxy.config.diags.debug.tags`

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -373,6 +373,50 @@ traffic_ctl server
 
    Option not yet available
 
+.. _traffic-control-command-server-debug:
+
+.. program:: traffic_ctl server
+.. option:: debug enable
+
+   Enables diagnostic messages at runtime. This is equivalent to
+   manually setting the below records but this is done in one go.
+   
+   Note that if you just set this to enable, the :ts:cv:`proxy.config.diags.debug.enabled`
+   will be set to ``1`` unless you specify the ``--client_ip,-c`` option.
+    
+   :ts:cv:`proxy.config.diags.debug.enabled`
+
+   :ts:cv:`proxy.config.diags.debug.tags`
+
+   :ts:cv:`proxy.config.diags.debug.client_ip`
+
+
+   Enables logging for diagnostic messages. See :ts:cv:`proxy.config.diags.debug.enabled` for information.
+
+   .. option:: --tags, -t  tags
+
+   This string should contain an anchored regular expression that filters the messages based on the debug tag tag.
+   Please refer to :ts:cv:`proxy.config.diags.debug.tags` for more information
+
+   .. option:: --client_ip, -c ip
+
+   Please see :ts:cv:`proxy.config.diags.debug.client_ip` for information.
+
+
+
+.. program:: traffic_ctl server
+.. option:: debug disable
+
+   Disables logging for diagnostic messages. Equivalent to set :ts:cv:`proxy.config.diags.debug.enabled` to ``0``.
+
+
+   Example:
+
+   .. code-block:: bash
+
+      $ traffic_ctl server debug enable --tags "quic|quiche"
+      ■ TS Runtime debug set to »ON(1)« - tags »"quic|quiche"«, client_ip »unchanged«
+
 .. _traffic-control-command-storage:
 
 traffic_ctl storage

--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -581,6 +581,9 @@ ServerCommand::ServerCommand(ts::Arguments *args) : CtrlCommand(args)
   if (get_parsed_arguments()->get(DRAIN_STR)) {
     _printer      = std::make_unique<GenericPrinter>(printOpts);
     _invoked_func = [&]() { server_drain(); };
+  } else if (get_parsed_arguments()->get(DEBUG_STR)) {
+    _printer      = std::make_unique<GenericPrinter>(printOpts);
+    _invoked_func = [&]() { server_debug(); };
   }
 }
 
@@ -600,6 +603,34 @@ ServerCommand::server_drain()
 
   _printer->write_output(response);
 }
+
+void
+ServerCommand::server_debug()
+{
+  // Set ATS to enable or disable debug at runtime.
+  const bool enable = get_parsed_arguments()->get(ENABLE_STR);
+
+  // If the following is not passed as options then the request will ignore them as default values
+  // will be set.
+  const std::string tags      = get_parsed_arguments()->get(TAGS_STR).value();
+  const std::string client_ip = get_parsed_arguments()->get(CLIENT_IP_STR).value();
+
+  const SetDebugServerRequest         request{enable, tags, client_ip};
+  shared::rpc::JSONRPCResponse const &response = invoke_rpc(request);
+
+  swoc::LocalBufferWriter<512> bw;
+
+  bw.print("■ TS Runtime debug set to »{}({})«", enable ? "ON" : "OFF", enable ? (!client_ip.empty() ? "2" : "1") : "0");
+  if (enable) {
+    bw.print(" - tags »\"{}\"«, client_ip »{}«", !tags.empty() ? tags : "unchanged", !client_ip.empty() ? client_ip : "unchanged");
+  }
+  if (response.is_error()) {
+    _printer->write_output(response);
+  } else {
+    _printer->write_output(bw.view());
+  }
+}
+
 // //------------------------------------------------------------------------------------------------------------------------------------
 StorageCommand::StorageCommand(ts::Arguments *args) : CtrlCommand(args)
 {

--- a/src/traffic_ctl/CtrlCommands.h
+++ b/src/traffic_ctl/CtrlCommands.h
@@ -218,7 +218,14 @@ private:
   static inline const std::string UNDO_STR{"undo"};
   static inline const std::string NO_NEW_CONN_STR{"no-new-connection"};
 
+  static inline const std::string DEBUG_STR{"debug"};
+  static inline const std::string ENABLE_STR{"enable"};
+  static inline const std::string DISABLE_STR{"disable"};
+  static inline const std::string TAGS_STR{"tags"};
+  static inline const std::string CLIENT_IP_STR{"client_ip"};
+
   void server_drain();
+  void server_debug();
 };
 //
 // -----------------------------------------------------------------------------------------------------------------------------------

--- a/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
@@ -92,7 +92,8 @@ struct ConfigSetRecordRequest : shared::rpc::ClientRequest {
     std::string recName;
     std::string recValue;
   };
-  using super = shared::rpc::ClientRequest;
+  using super              = shared::rpc::ClientRequest;
+  ConfigSetRecordRequest() = default;
   ConfigSetRecordRequest(Params d) { super::params.push_back(d); }
   std::string
   get_method() const override
@@ -249,5 +250,22 @@ struct ConfigStatusRequest : shared::rpc::RecordLookupRequest {
     for (auto &&recordName : statusFieldsNames) {
       super::emplace_rec(recordName, shared::rpc::NOT_REGEX, shared::rpc::METRIC_REC_TYPES);
     }
+  }
+};
+//------------------------------------------------------------------------------------------------------------------------------------
+struct SetDebugServerRequest : ConfigSetRecordRequest {
+  SetDebugServerRequest(bool enabled, std::string tags, std::string client_ip)
+  {
+    std::string enable_value{(enabled ? "1" : "0")};
+    if (!client_ip.empty()) {
+      super::params.push_back(Params{"proxy.config.diags.debug.client_ip", client_ip});
+      // proxy.config.diags.debug.enabled needs to be set to 2 if client_ip is used.
+      enable_value = "2";
+    }
+    if (!tags.empty()) {
+      super::params.push_back(Params{"proxy.config.diags.debug.tags", tags});
+    }
+
+    super::params.push_back(Params{"proxy.config.diags.debug.enabled", enable_value});
   }
 };

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -186,6 +186,15 @@ main([[maybe_unused]] int argc, const char **argv)
     .add_option("--no-new-connection", "-N", "Wait for new connections down to threshold before starting draining")
     .add_option("--undo", "-U", "Recover server from the drain mode");
 
+  auto &debug_command =
+    server_command.add_command("debug", "Enable/Disable ATS for diagnostic messages at runtime").require_commands();
+  debug_command.add_command("enable", "Enables logging for diagnostic messages at runtime", [&]() { command->execute(); })
+    .add_option("--tags", "-t", "Debug tags", "TS_DEBUG_TAGS", 1)
+    .add_option("--client_ip", "-c", "Client's ip", "", 1, "")
+    .add_example_usage("traffic_ctl server debug enable -t my_tags -c X.X.X.X");
+  debug_command.add_command("disable", "Disables logging for diagnostic messages at runtime", [&]() { command->execute(); })
+    .add_example_usage("traffic_ctl server debug disable");
+
   // storage commands
   storage_command
     .add_command("offline", "Take one or more storage volumes offline", "", MORE_THAN_ONE_ARG_N, [&]() { command->execute(); })


### PR DESCRIPTION
We can now set a debug mode at runtime by using a single traffic_ctl command and without the need to set all the records individually. 

Example:

Enable  and leave the tags unchanged

```
traffic_ctl server debug enable 
```
Enable debug  for the following tags
```
traffic_ctl server debug enable --tags quiche
```

Enable debug for the specified ip
```
traffic_ctl server debug enable -c 1.1.1.1
```

Disable logging.

```
traffic_ctl server debug disable
```

Before you needed to set up three different records to achieve what you do now in a single line.


