### PR TITLE
Cleanup: remove invalid option from traffic_ctl

### DIFF
--- a/src/traffic_ctl/CtrlPrinters.cc
+++ b/src/traffic_ctl/CtrlPrinters.cc
@@ -184,8 +184,7 @@ ConfigSetPrinter::write_output(YAML::Node const &result)
   static const TypeToStringMap Update_Type_To_String_Message = {
     {"0", "Set {}"                                                                                          }, // UNDEFINED
     {"1", "Set {}, please wait 10 seconds for traffic server to sync configuration, restart is not required"}, // DYNAMIC
-    {"2", "Set {}, restart required"                                                                        }, // RESTART_TS
-    {"3", "Set {}, restart required"                                                                        }  // RESTART TM, we take care of this in case we get it from TS.
+    {"2", "Set {}, restart required"                                                                        }  // RESTART_TS
   };
   std::string text;
   try {


### PR DESCRIPTION
A leftover from https://github.com/apache/trafficserver/pull/10994