### PR TITLE
Remove H3 frame sequence number tracking

### DIFF
--- a/include/proxy/http3/Http3FrameCounter.h
+++ b/include/proxy/http3/Http3FrameCounter.h
@@ -33,8 +33,7 @@ public:
 
   // Http3FrameHandler
   std::vector<Http3FrameType> interests() override;
-  Http3ErrorUPtr              handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq = -1,
-                                           Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
+  Http3ErrorUPtr handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
 
   uint64_t get_count(uint64_t type) const;
 

--- a/include/proxy/http3/Http3FrameHandler.h
+++ b/include/proxy/http3/Http3FrameHandler.h
@@ -32,6 +32,6 @@ class Http3FrameHandler
 public:
   virtual ~Http3FrameHandler(){};
   virtual std::vector<Http3FrameType> interests()                                                     = 0;
-  virtual Http3ErrorUPtr              handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq = -1,
-                                                   Http3StreamType s_type = Http3StreamType::UNKNOWN) = 0;
+  virtual Http3ErrorUPtr              handle_frame(std::shared_ptr<const Http3Frame> frame,
+                                                   Http3StreamType                   s_type = Http3StreamType::UNKNOWN) = 0;
 };

--- a/include/proxy/http3/Http3HeaderVIOAdaptor.h
+++ b/include/proxy/http3/Http3HeaderVIOAdaptor.h
@@ -35,8 +35,7 @@ public:
 
   // Http3FrameHandler
   std::vector<Http3FrameType> interests() override;
-  Http3ErrorUPtr              handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq = -1,
-                                           Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
+  Http3ErrorUPtr handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
 
   bool is_complete();
   int  event_handler(int event, Event *data);

--- a/include/proxy/http3/Http3ProtocolEnforcer.h
+++ b/include/proxy/http3/Http3ProtocolEnforcer.h
@@ -33,6 +33,8 @@ public:
 
   // Http3FrameHandler
   std::vector<Http3FrameType> interests() override;
-  Http3ErrorUPtr              handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq = -1,
-                                           Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
+  Http3ErrorUPtr handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
+
+private:
+  bool _is_first_frame_received_on_control = false;
 };

--- a/include/proxy/http3/Http3SettingsHandler.h
+++ b/include/proxy/http3/Http3SettingsHandler.h
@@ -33,8 +33,7 @@ public:
 
   // Http3FrameHandler
   std::vector<Http3FrameType> interests() override;
-  Http3ErrorUPtr              handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq = -1,
-                                           Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
+  Http3ErrorUPtr handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
 
 private:
   // TODO: clarify Http3Session I/F for Http3SettingsHandler and Http3App

--- a/include/proxy/http3/Http3StreamDataVIOAdaptor.h
+++ b/include/proxy/http3/Http3StreamDataVIOAdaptor.h
@@ -35,8 +35,7 @@ public:
 
   // Http3FrameHandler
   std::vector<Http3FrameType> interests() override;
-  Http3ErrorUPtr              handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq = -1,
-                                           Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
+  Http3ErrorUPtr handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType s_type = Http3StreamType::UNKNOWN) override;
 
   // Http3StreamDataVIOAdaptor
   void finalize();

--- a/src/proxy/http3/Http3FrameCounter.cc
+++ b/src/proxy/http3/Http3FrameCounter.cc
@@ -35,8 +35,7 @@ Http3FrameCounter::interests()
 }
 
 Http3ErrorUPtr
-Http3FrameCounter::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t /* frame_seq ATS_UNUSED */,
-                                Http3StreamType /* s_type ATS_UNUSED */)
+Http3FrameCounter::handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType /* s_type ATS_UNUSED */)
 {
   Http3ErrorUPtr error  = Http3ErrorUPtr(nullptr);
   Http3FrameType f_type = frame->type();

--- a/src/proxy/http3/Http3FrameDispatcher.cc
+++ b/src/proxy/http3/Http3FrameDispatcher.cc
@@ -52,7 +52,6 @@ Http3FrameDispatcher::on_read_ready(QUICStreamId stream_id, Http3StreamType stre
 {
   Http3ErrorUPtr error = Http3ErrorUPtr(nullptr);
   nread                = 0;
-  uint32_t frame_count = 0;
 
   while (true) {
     // Read a length of Type field and hopefully a length of Length field too
@@ -110,7 +109,6 @@ Http3FrameDispatcher::on_read_ready(QUICStreamId stream_id, Http3StreamType stre
           break;
         }
         this->_bytes_to_skip = this->_current_frame->total_length();
-        ++frame_count;
       }
 
       auto skip = std::min(static_cast<uint64_t>(reader.read_avail()), this->_bytes_to_skip);
@@ -125,7 +123,7 @@ Http3FrameDispatcher::on_read_ready(QUICStreamId stream_id, Http3StreamType stre
               this->_current_frame->total_length() - _bytes_to_skip, this->_current_frame->total_length());
         std::vector<Http3FrameHandler *> handlers = this->_handlers[static_cast<uint8_t>(type)];
         for (auto h : handlers) {
-          error = h->handle_frame(this->_current_frame, frame_count - 1, stream_type);
+          error = h->handle_frame(this->_current_frame, stream_type);
           if (error && error->cls != Http3ErrorClass::UNDEFINED) {
             return error;
           }

--- a/src/proxy/http3/Http3HeaderVIOAdaptor.cc
+++ b/src/proxy/http3/Http3HeaderVIOAdaptor.cc
@@ -54,7 +54,7 @@ Http3HeaderVIOAdaptor::interests()
 }
 
 Http3ErrorUPtr
-Http3HeaderVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t /* frame_seq */, Http3StreamType /* s_type */)
+Http3HeaderVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType /* s_type */)
 {
   ink_assert(frame->type() == Http3FrameType::HEADERS);
   const Http3HeadersFrame *hframe = dynamic_cast<const Http3HeadersFrame *>(frame.get());

--- a/src/proxy/http3/Http3ProtocolEnforcer.cc
+++ b/src/proxy/http3/Http3ProtocolEnforcer.cc
@@ -34,15 +34,15 @@ Http3ProtocolEnforcer::interests()
 }
 
 Http3ErrorUPtr
-Http3ProtocolEnforcer::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t frame_seq, Http3StreamType s_type)
+Http3ProtocolEnforcer::handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType s_type)
 {
   Http3ErrorUPtr error  = Http3ErrorUPtr(nullptr);
   Http3FrameType f_type = frame->type();
   if (s_type == Http3StreamType::CONTROL) {
-    if (frame_seq == 0 && f_type != Http3FrameType::SETTINGS) {
+    if (!this->_is_first_frame_received_on_control && f_type != Http3FrameType::SETTINGS) {
       error = std::make_unique<Http3Error>(Http3ErrorClass::CONNECTION, Http3ErrorCode::H3_MISSING_SETTINGS,
                                            "first frame of the control stream must be SETTINGS frame");
-    } else if (frame_seq != 0 && f_type == Http3FrameType::SETTINGS) {
+    } else if (this->_is_first_frame_received_on_control && f_type == Http3FrameType::SETTINGS) {
       error = std::make_unique<Http3Error>(Http3ErrorClass::CONNECTION, Http3ErrorCode::H3_FRAME_UNEXPECTED,
                                            "only one SETTINGS frame is allowed per the control stream");
     } else if (f_type == Http3FrameType::DATA || f_type == Http3FrameType::HEADERS || f_type == Http3FrameType::X_RESERVED_1 ||
@@ -50,6 +50,9 @@ Http3ProtocolEnforcer::handle_frame(std::shared_ptr<const Http3Frame> frame, int
       std::string error_msg = Http3DebugNames::frame_type(f_type);
       error_msg.append(" frame is not allowed on control stream");
       error = std::make_unique<Http3Error>(Http3ErrorClass::CONNECTION, Http3ErrorCode::H3_FRAME_UNEXPECTED, error_msg.c_str());
+    }
+    if (!this->_is_first_frame_received_on_control) {
+      this->_is_first_frame_received_on_control = true;
     }
   } else {
     if (f_type == Http3FrameType::X_RESERVED_1 || f_type == Http3FrameType::X_RESERVED_2 ||

--- a/src/proxy/http3/Http3SettingsHandler.cc
+++ b/src/proxy/http3/Http3SettingsHandler.cc
@@ -39,7 +39,7 @@ Http3SettingsHandler::interests()
 }
 
 Http3ErrorUPtr
-Http3SettingsHandler::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t /* frame_seq */, Http3StreamType /* s_type */)
+Http3SettingsHandler::handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType /* s_type */)
 {
   ink_assert(frame->type() == Http3FrameType::SETTINGS);
 

--- a/src/proxy/http3/Http3StreamDataVIOAdaptor.cc
+++ b/src/proxy/http3/Http3StreamDataVIOAdaptor.cc
@@ -38,8 +38,7 @@ Http3StreamDataVIOAdaptor::interests()
 }
 
 Http3ErrorUPtr
-Http3StreamDataVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame, int32_t /* frame_seq */,
-                                        Http3StreamType /* s_type */)
+Http3StreamDataVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame, Http3StreamType /* s_type */)
 {
   ink_assert(frame->type() == Http3FrameType::DATA);
   const Http3DataFrame *dframe = dynamic_cast<const Http3DataFrame *>(frame.get());

--- a/src/proxy/http3/test/Mock.h
+++ b/src/proxy/http3/test/Mock.h
@@ -39,8 +39,7 @@ public:
   }
 
   Http3ErrorUPtr
-  handle_frame(std::shared_ptr<const Http3Frame> /* frame ATS_UNUSED */, int32_t /* frame_seq */,
-               Http3StreamType /* s_type */) override
+  handle_frame(std::shared_ptr<const Http3Frame> /* frame ATS_UNUSED */, Http3StreamType /* s_type */) override
   {
     this->total_frame_received++;
     return Http3ErrorUPtr(nullptr);

--- a/src/proxy/http3/test/test_Http3FrameDispatcher.cc
+++ b/src/proxy/http3/test/test_Http3FrameDispatcher.cc
@@ -281,8 +281,6 @@ TEST_CASE("control stream tests", "[http3]")
 
     CHECK(handler.total_frame_received == 1);
     CHECK(total_nread == 6);
-
-    free_MIOBuffer(buf);
   }
 
   free_MIOBuffer(buf);


### PR DESCRIPTION
This closes #11622.

The frame sequence was only used for `ProtocolEnforcer` and there is no other use case planned. This PR removes the sequence number tracking, which was reset on every READ_READY, and use a private flag in ProtocolEnforcer to do the same check for SETTINGS frame.