### PR TITLE
Fix initialization issue in cache unit tests

### DIFF
--- a/src/iocore/cache/unit_tests/main.cc
+++ b/src/iocore/cache/unit_tests/main.cc
@@ -121,10 +121,8 @@ struct EventProcessorListener : Catch::TestEventListenerBase {
   using TestEventListenerBase::TestEventListenerBase; // inherit constructor
 
   void
-  testRunStarting(Catch::TestRunInfo const &testRunInfo) override
+  testRunStarting(Catch::TestRunInfo const & /* testRunInfo ATS_UNUSED */) override
   {
-    BaseLogFile *base_log_file = new BaseLogFile("stderr");
-    DiagsPtr::set(new Diags(testRunInfo.name, "*" /* tags */, "" /* actions */, base_log_file));
     diags()->activate_taglist("cache.*|agg.*|locks", DiagsTagType_Debug);
     diags()->config.enabled(DiagsTagType_Debug, 1);
     diags()->show_location = SHOW_LOCATION_DEBUG;

--- a/src/iocore/cache/unit_tests/stub.cc
+++ b/src/iocore/cache/unit_tests/stub.cc
@@ -27,6 +27,29 @@
 
 #include "proxy/HttpAPIHooks.h"
 
+#include "tscore/BaseLogFile.h"
+#include "tscore/Diags.h"
+
+class InitDiags
+{
+public:
+  InitDiags() : base_log_file{new BaseLogFile("stderr")}
+  {
+    DiagsPtr::set(new Diags("cache unit test", "*" /* tags */, "" /* actions */, this->base_log_file));
+  }
+
+  ~InitDiags() { delete this->base_log_file; }
+
+private:
+  BaseLogFile *base_log_file;
+};
+
+// The FetchSM class allocator below uses the diags in its constructor, so we
+// force them to be initialized prior to that. This gets "leaked" at shutdown
+// to ensure that the log file remains valid if accessed by other threads
+// during static object destruction.
+InitDiags const *g_init_diags_dummy = new InitDiags{};
+
 void
 HttpHookState::init(TSHttpHookID /* id ATS_UNUSED */, HttpAPIHooks const * /* global ATS_UNUSED */,
                     HttpAPIHooks const * /* ssn ATS_UNUSED */, HttpAPIHooks const * /* txn ATS_UNUSED */)


### PR DESCRIPTION
This fixes a segfault that is likely the same one seen in CI. The diags may be accessed by the global FetchSM allocator, so we have to initialize them before that global is constructed. The name for the diags has been changed because we no longer have access to the unit test metadata at initialization.