### PR TITLE
Document 0 for max_conections_in disables it

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -508,6 +508,7 @@ Network
    and active requests that |TS| can handle at any given instant. The delta
    between `proxy.config.net.max_connections_in` and `proxy.config.net.max_requests_in`
    is the amount of maximum idle (keepalive) connections |TS| will maintain.
+   If this is set to 0, the throttling logic is disabled.
 
 .. ts:cv:: CONFIG proxy.config.net.per_client.max_connections_in INT 0
    :reloadable:


### PR DESCRIPTION
Document that setting proxy.config.net.max_connections_in to 0 disables the max_connections_in throttling.