### PR TITLE
Docs: Make sure we use the right YAML root name when building records.yaml docs. `ts` -> `records`

### DIFF
--- a/doc/ext/traffic-server.cmake.in.py
+++ b/doc/ext/traffic-server.cmake.in.py
@@ -141,7 +141,7 @@ class TSConfVar(std.Target):
 
         # Build the object
         add_object(config, name, cv_default, cv_type)
-        ts['ts'] = config
+        ts['records'] = config
         code = get_code(ts)
         literal = nodes.literal_block(code, code)
         literal['linenos'] = True


### PR DESCRIPTION
Missed this one from https://github.com/apache/trafficserver/pull/11454.

Seems ok now -> [link](https://ci.trafficserver.apache.org/job/Github_Builds/job/docs/5594/artifact/output/11648/docbuild/html/admin-guide/files/records.yaml.en.html#proxy-config-output-logfile)

fixes https://github.com/apache/trafficserver/issues/11642
