### PR TITLE
Disable mptcp if proper header files are not available

### DIFF
--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -98,11 +98,13 @@ mptcp_supported()
   ats_scoped_fd fd(::open("/proc/sys/net/mptcp/enabled", O_RDONLY));
   int           value = 0;
 
+#if defined(HAVE_STRUCT_MPTCP_INFO_SUBFLOWS) && defined(MPTCP_INFO) && MPTCP_INFO == 1
   if (fd > 0) {
     TextBuffer buffer(16);
     buffer.slurp(fd.get());
     value = atoi(buffer.bufPtr());
   }
+#endif
 
   return value != 0;
 }

--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -95,10 +95,9 @@ SessionProtocolSet DEFAULT_QUIC_SESSION_PROTOCOL_SET;
 static bool
 mptcp_supported()
 {
-  ats_scoped_fd fd(::open("/proc/sys/net/mptcp/enabled", O_RDONLY));
-  int           value = 0;
-
+  int value = 0;
 #if defined(HAVE_STRUCT_MPTCP_INFO_SUBFLOWS) && defined(MPTCP_INFO) && MPTCP_INFO == 1
+  ats_scoped_fd fd(::open("/proc/sys/net/mptcp/enabled", O_RDONLY));
   if (fd > 0) {
     TextBuffer buffer(16);
     buffer.slurp(fd.get());


### PR DESCRIPTION
Currently, to log whether a connection used mptcp, we [check the socket option](https://github.com/apache/trafficserver/blob/2adc60f98bf49553c41245b260cf0a1cb44aae65/src/iocore/net/P_UnixNetVConnection.h#L306), which requires specific libraries to be available. This is not done when enabling mptcp in our configurations. Therefore, it is possible that we enable mptcp but our logging says we are not using mptcp so that leads to confusion