### PR TITLE
Remove rest of cache inspector references

### DIFF
--- a/doc/admin-guide/interaction/index.en.rst
+++ b/doc/admin-guide/interaction/index.en.rst
@@ -30,6 +30,3 @@ Traffic Control
 
 Stats Over HTTP
 ===============
-
-Cache Inspector
-===============

--- a/doc/admin-guide/storage/index.en.rst
+++ b/doc/admin-guide/storage/index.en.rst
@@ -339,43 +339,6 @@ Then, to push the object, post the object using the PUSH method: ::
 
       $ curl -s -o /dev/null -X PUSH --data-binary @/path/to/file "http://example.com/push_me.html"
 
-.. _inspecting-the-cache:
-
-Using the Cache Inspector Utility
----------------------------------
-
-The Cache Inspector Utility provides several options that enable you to view and
-delete the contents of your cache.
-
-Lookup URL
-    Search for a particular URL in the cache. When Traffic Server finds the URL
-    in the cache, it will display details of the object that corresponds to the
-    URL (e.g. header length and number of alternates). The option to delete the
-    URL from the cache will be presented.
-
-Delete URL
-    Delete the object from the cache which corresponds to the given URL. Success
-    or failure will be indicated after a delete has been attempted.
-
-Regex Lookup
-    Search URLs within the cache using one or more regular expressions.
-
-Regex Delete
-    Deletes all objects from the cache which match the provided regular
-    expressions.
-
-Regex Invalidate
-    Marks any objects in the cache which match the given regular expressions as
-    stale. Traffic Server will contact the relevant origin server(s) to confirm
-    the validity and freshness of the cached object, updating the cached object
-    if necessary.
-
-.. note::
-
-    Only one administrator should delete and invalidate cache entries from the
-    Cache Inspector at any point in time. Changes made by multiple
-    administrators at the same time can lead to unpredictable results.
-
 If-Modified-Since/If-None-Match
 -------------------------------
 

--- a/doc/developer-guide/cache-architecture/consistency.en.rst
+++ b/doc/developer-guide/cache-architecture/consistency.en.rst
@@ -20,13 +20,6 @@
 
 .. _developer-cache-consistency:
 
-Cache Tools
-~~~~~~~~~~~
-
-Tools and techniques for cache monitoring and inspection.
-
-* :ref:`The cache inspector <inspecting-the-cache>`.
-
 Topics to be done
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/locale/ja/LC_MESSAGES/developer-guide/architecture/consistency.en.po
+++ b/doc/locale/ja/LC_MESSAGES/developer-guide/architecture/consistency.en.po
@@ -36,10 +36,6 @@ msgstr ""
 msgid "Tools and techniques for cache monitoring and inspection."
 msgstr ""
 
-#: ../../developer-guide/architecture/consistency.en.rst:27
-msgid ":ref:`The cache inspector <inspecting-the-cache>`."
-msgstr ""
-
 #: ../../developer-guide/architecture/consistency.en.rst:30
 msgid "Topics to be done"
 msgstr ""


### PR DESCRIPTION
This finishes up the removal of doc references to the cache inspector tool. This picks up from #10710.