### PR TITLE
Fixed crash in XPACK when making space for a new entry

### DIFF
--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -496,24 +496,17 @@ XpackDynamicTable::_expand_storage_size(uint32_t new_storage_size)
 bool
 XpackDynamicTable::_make_space(uint64_t extra_space_needed)
 {
-  if (is_empty()) {
-    // If the table is empty, there's nothing to free.
-    return extra_space_needed == 0;
-  }
   uint32_t freed = 0;
   uint32_t tail  = this->_entries_tail;
 
-  while (extra_space_needed > freed) {
+  // Check to see if we need more space and that we have entries to evict
+  while (extra_space_needed > freed && this->_entries_head != tail) {
     tail = this->_calc_index(tail, 1); // Move to the next entry
 
     if (this->_entries[tail].ref_count) {
       break;
     }
     freed += this->_entries[tail].name_len + this->_entries[tail].value_len + ADDITIONAL_32_BYTES;
-    if (this->_entries_head == tail) {
-      // The table is empty
-      break;
-    }
   }
 
   // Evict

--- a/src/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/src/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -383,6 +383,15 @@ TEST_CASE("XPACK_String", "[xpack]")
     REQUIRE(dt.maximum_size() == 4096);
     REQUIRE(dt.is_empty());
     REQUIRE(dt.count() == 0);
+
+    // Test to insert 10k random size entries
+    for (int i = 0; i < 10000; i++) {
+      int         name_size  = rand() % 20000;
+      int         value_size = rand() % 20000;
+      std::string name       = get_long_string(name_size);
+      std::string value      = get_long_string(value_size);
+      dt.insert_entry(name, value);
+    }
   }
 }
 


### PR DESCRIPTION
Cleaned up how the tail index in the dynamic table advances and never have it go beyond the head.