### PR TITLE
header_rewrite: Allow Txn reenable to be deferred.

### DIFF
--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -44,7 +44,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   TSOverridableConfigKey _key  = TS_CONFIG_NULL;
@@ -67,7 +67,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value       _status;
@@ -88,7 +88,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _reason;
@@ -106,7 +106,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   UrlQualifiers _url_qual = URL_QUAL_NONE;
@@ -126,7 +126,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   UrlQualifiers                 _url_qual = URL_QUAL_NONE;
@@ -161,7 +161,7 @@ public:
 protected:
   void initialize_hooks() override;
 
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _status;
@@ -178,7 +178,11 @@ public:
   void operator=(const OperatorNoOp &) = delete;
 
 protected:
-  void exec(const Resources & /* res ATS_UNUSED */) const override {};
+  bool
+  exec(const Resources & /* res ATS_UNUSED */) const override
+  {
+    return true;
+  };
 };
 
 class OperatorSetTimeoutOut : public Operator
@@ -193,7 +197,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   enum TimeoutOutType {
@@ -220,7 +224,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   bool _skip_remap = false;
@@ -237,7 +241,7 @@ public:
   void operator=(const OperatorRMHeader &)   = delete;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 };
 
 class OperatorAddHeader : public OperatorHeaders
@@ -252,7 +256,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _value;
@@ -270,7 +274,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _value;
@@ -288,7 +292,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   std::string _counter_name;
@@ -305,7 +309,7 @@ public:
   void operator=(const OperatorRMCookie &)   = delete;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 };
 
 class OperatorAddCookie : public OperatorCookies
@@ -320,7 +324,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _value;
@@ -338,7 +342,7 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _value;
@@ -369,7 +373,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _ds_value;
@@ -388,7 +392,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _ds_value;
@@ -407,7 +411,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 };
 
 class OperatorSetBody : public Operator
@@ -423,7 +427,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _value;
@@ -442,7 +446,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   bool           _flag = false;
@@ -475,7 +479,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   RemapPluginInst *_plugin = nullptr;
@@ -496,7 +500,7 @@ public:
 
 protected:
   void initialize_hooks() override;
-  void exec(const Resources &res) const override;
+  bool exec(const Resources &res) const override;
 
 private:
   Value _value;

--- a/plugins/header_rewrite/ruleset.h
+++ b/plugins/header_rewrite/ruleset.h
@@ -23,6 +23,8 @@
 
 #include <string>
 
+#include <tscore/ink_assert.h>
+
 #include "matcher.h"
 #include "factory.h"
 #include "resources.h"
@@ -104,7 +106,11 @@ public:
   OperModifiers
   exec(const Resources &res) const
   {
-    _oper->do_exec(res);
+    auto no_reenable_count{_oper->do_exec(res)};
+    ink_assert(no_reenable_count < 2);
+    if (no_reenable_count) {
+      return static_cast<OperModifiers>(_opermods | OPER_NO_REENABLE);
+    }
     return _opermods;
   }
 


### PR DESCRIPTION
The SetBodyFrom operator needs to defer calling Txn reenable until the fetch of the URL providing the response body completes.