### PR TITLE
NetHandler - Use the right type to hold `additional_accepts` config value.

### DIFF
--- a/include/iocore/net/NetHandler.h
+++ b/include/iocore/net/NetHandler.h
@@ -236,7 +236,7 @@ private:
   // TS_EVENT_MGMT_UPDATE event like with the Config settings above because
   // accept threads are not always on a standard NET thread with a NetHandler
   // that has TS_EVENT_MGMT_UPDATE handling logic.
-  static std::atomic<uint32_t> additional_accepts;
+  static std::atomic<int32_t>  additional_accepts;
   static std::atomic<uint32_t> per_client_max_connections_in;
 
   void _close_ne(NetEvent *ne, ink_hrtime now, int &handle_event, int &closed, int &total_idle_time, int &total_idle_count);

--- a/src/iocore/net/NetHandler.cc
+++ b/src/iocore/net/NetHandler.cc
@@ -42,7 +42,7 @@ DbgCtl dbg_ctl_v_net_queue{"v_net_queue"};
 
 } // end anonymous namespace
 
-std::atomic<uint32_t> NetHandler::additional_accepts{0};
+std::atomic<int32_t>  NetHandler::additional_accepts{0};
 std::atomic<uint32_t> NetHandler::per_client_max_connections_in{0};
 
 // NetHandler method definitions
@@ -185,13 +185,16 @@ NetHandler::init_for_process()
   REC_ReadConfigInt32(global_config.default_inactivity_timeout, "proxy.config.net.default_inactivity_timeout");
 
   // Atomic configurations.
-  uint32_t val = 0;
-
-  REC_ReadConfigInt32(val, "proxy.config.net.additional_accepts");
-  additional_accepts.store(val, std::memory_order_relaxed);
-
-  REC_ReadConfigInt32(val, "proxy.config.net.per_client.max_connections_in");
-  per_client_max_connections_in.store(val, std::memory_order_relaxed);
+  {
+    int32_t val = 0;
+    REC_ReadConfigInt32(val, "proxy.config.net.additional_accepts");
+    additional_accepts.store(val, std::memory_order_relaxed);
+  }
+  {
+    uint32_t val = 0;
+    REC_ReadConfigInt32(val, "proxy.config.net.per_client.max_connections_in");
+    per_client_max_connections_in.store(val, std::memory_order_relaxed);
+  }
 
   RecRegisterConfigUpdateCb("proxy.config.net.max_connections_in", update_nethandler_config, nullptr);
   RecRegisterConfigUpdateCb("proxy.config.net.max_requests_in", update_nethandler_config, nullptr);

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -720,7 +720,7 @@ static const RecordElement RecordsConfig[] =
   //#
   //##############################################################################
 
-  {RECT_CONFIG, "proxy.config.net.additional_accepts", RECD_INT, "-1", RECU_DYNAMIC, RR_NULL, RECC_INT, "^-1|[0-9]+$", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.net.additional_accepts", RECD_INT, "-1", RECU_DYNAMIC, RR_NULL, RECC_STR, "^-1|[0-9]+$", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.net.connections_throttle", RECD_INT, "30000", RECU_RESTART_TS, RR_REQUIRED, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,


### PR DESCRIPTION
[proxy.config.net.additional_accepts ](https://ci.trafficserver.apache.org/job/Github_Builds/job/docs/5594/artifact/output/11648/docbuild/html/admin-guide/files/records.yaml.en.html#proxy-config-net-additional-accepts) is expected to  use `-1`  but the code wasn't storing the value into a signed type, so changed from `unsigned` to `signed` as this is what's expected. 

This PR also makes sure the records validity check passes.

Original PR -> https://github.com/apache/trafficserver/pull/10098

Part of a fix for https://github.com/apache/trafficserver/issues/11649