### PR TITLE
Extend lifetimes of `DbgCtl` instances in inkcache

### DIFF
--- a/include/tsutil/DbgCtl.h
+++ b/include/tsutil/DbgCtl.h
@@ -185,3 +185,15 @@ private:
       }                               \
     }                                 \
   } while (false)
+
+// Shorthand for creating a global DbgCtl instance with static lifetime. The
+// instance must be allocated on the heap so that its destructor isn't called;
+// thus it remains valid until the program is finished and the memory that we
+// allocated for it is counted as being in use at exit. This macro should be
+// used from a .cc file.
+#define DEF_DBG(name)                                 \
+  static DbgCtl &get_dbg_##name()                     \
+  {                                                   \
+    static DbgCtl *dbg_ctl_##name{new DbgCtl{#name}}; \
+    return *dbg_ctl_##name;                           \
+  }

--- a/src/iocore/cache/CacheEvacuateDocVC.h
+++ b/src/iocore/cache/CacheEvacuateDocVC.h
@@ -61,8 +61,8 @@ new_CacheEvacuateDocVC(Continuation *cont)
   c->start_time         = ink_get_hrtime();
   c->setThreadAffinity(t);
   ink_assert(c->trigger == nullptr);
-  static DbgCtl dbg_ctl{"cache_new"};
-  Dbg(dbg_ctl, "new %p", c);
+  static DbgCtl *dbg_ctl{new DbgCtl{"cache_new"}};
+  Dbg(*dbg_ctl, "new %p", c);
   dir_clear(&c->dir);
 
   return c;

--- a/src/iocore/cache/CacheHosting.cc
+++ b/src/iocore/cache/CacheHosting.cc
@@ -29,13 +29,8 @@
 #include "tscore/Tokenizer.h"
 #include "tscore/Filenames.h"
 
-namespace
-{
-
-DbgCtl dbg_ctl_cache_hosting{"cache_hosting"};
-DbgCtl dbg_ctl_matcher{"matcher"};
-
-} // end anonymous namespace
+DEF_DBG(cache_hosting)
+DEF_DBG(matcher)
 
 /*************************************************************
  *   Begin class HostMatcher
@@ -174,7 +169,7 @@ CacheHostMatcher::NewEntry(matcher_line *line_info)
     memset(static_cast<void *>(cur_d), 0, sizeof(CacheHostRecord));
     return;
   }
-  Dbg(dbg_ctl_cache_hosting, "hostname: %s, host record: %p", match_data, cur_d);
+  Dbg(get_dbg_cache_hosting(), "hostname: %s, host record: %p", match_data, cur_d);
   // Fill in the matching info
   host_lookup->NewEntry(match_data, (line_info->type == MATCH_DOMAIN) ? true : false, cur_d);
 
@@ -389,7 +384,7 @@ CacheHostTable::BuildTableFromString(const char *config_file_path, char *file_bu
 
   ink_assert(second_pass == numEntries);
 
-  if (dbg_ctl_matcher.on()) {
+  if (get_dbg_matcher().on()) {
     Print();
   }
   return numEntries;
@@ -431,7 +426,7 @@ CacheHostRecord::Init(CacheType typ)
   CacheVol *cachep = cp_list.head;
   for (; cachep; cachep = cachep->link.next) {
     if (cachep->scheme == type) {
-      Dbg(dbg_ctl_cache_hosting, "Host Record: %p, Volume: %d, size: %" PRId64, this, cachep->vol_number, (int64_t)cachep->size);
+      Dbg(get_dbg_cache_hosting(), "Host Record: %p, Volume: %d, size: %" PRId64, this, cachep->vol_number, (int64_t)cachep->size);
       cp[num_cachevols] = cachep;
       num_cachevols++;
       num_vols += cachep->num_vols;
@@ -522,7 +517,7 @@ CacheHostRecord::Init(matcher_line *line_info, CacheType typ)
             if (cachep->vol_number == volume_number) {
               is_vol_present = 1;
               if (cachep->scheme == type) {
-                Dbg(dbg_ctl_cache_hosting, "Host Record: %p, Volume: %d, size: %ld", this, volume_number,
+                Dbg(get_dbg_cache_hosting(), "Host Record: %p, Volume: %d, size: %ld", this, volume_number,
                     (long)(cachep->size * STORE_BLOCK_SIZE));
                 cp[num_cachevols] = cachep;
                 num_cachevols++;
@@ -785,8 +780,8 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
       } else {
         ink_release_assert(!"Unexpected non-HTTP cache volume");
       }
-      Dbg(dbg_ctl_cache_hosting, "added volume=%d, scheme=%d, size=%d percent=%d, ramcache enabled=%d", volume_number, scheme, size,
-          in_percent, ramcache_enabled);
+      Dbg(get_dbg_cache_hosting(), "added volume=%d, scheme=%d, size=%d percent=%d, ramcache enabled=%d", volume_number, scheme,
+          size, in_percent, ramcache_enabled);
     }
 
     tmp = bufTok.iterNext(&i_state);

--- a/src/iocore/cache/CacheVol.cc
+++ b/src/iocore/cache/CacheVol.cc
@@ -23,10 +23,7 @@
 
 #include "P_Cache.h"
 
-namespace
-{
-DbgCtl dbg_ctl_cache_scan_truss{"cache_scan_truss"};
-} // end anonymous namespace
+DEF_DBG(cache_scan_truss);
 
 #define SCAN_BUF_SIZE              RECOVERY_SIZE
 #define SCAN_WRITER_LOCK_MAX_RETRY 5
@@ -34,7 +31,7 @@ DbgCtl dbg_ctl_cache_scan_truss{"cache_scan_truss"};
 Action *
 Cache::scan(Continuation *cont, const char *hostname, int host_len, int KB_per_second)
 {
-  Dbg(dbg_ctl_cache_scan_truss, "inside scan");
+  Dbg(get_dbg_cache_scan_truss(), "inside scan");
   if (!CacheProcessor::IsCacheReady(CACHE_FRAG_TYPE_HTTP)) {
     cont->handleEvent(CACHE_EVENT_SCAN_FAILED, nullptr);
     return ACTION_RESULT_DONE;

--- a/src/iocore/cache/HttpTransactCache.cc
+++ b/src/iocore/cache/HttpTransactCache.cc
@@ -38,12 +38,6 @@
 
 namespace
 {
-DbgCtl dbg_ctl_http_match{"http_match"};
-DbgCtl dbg_ctl_http_seq{"http_seq"};
-DbgCtl dbg_ctl_http_alts{"http_alts"};
-DbgCtl dbg_ctl_http_alternate{"http_alternate"};
-DbgCtl dbg_ctl_http_age{"http_age"};
-
 /**
   Find the pointer and length of an etag, after stripping off any leading
   "W/" prefix, and surrounding double quotes.
@@ -165,6 +159,12 @@ is_empty(char *s)
 
 } // end anonymous namespace
 
+DEF_DBG(http_match)
+DEF_DBG(http_seq)
+DEF_DBG(http_alts)
+DEF_DBG(http_alternate)
+DEF_DBG(http_age)
+
 /**
   Given a set of alternates, select the best match.
 
@@ -192,9 +192,9 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
     return -1;
   }
 
-  Dbg(dbg_ctl_http_match, "[SelectFromAlternates] # alternates = %d", alt_count);
-  Dbg(dbg_ctl_http_seq, "[SelectFromAlternates] %d alternates for this cached doc", alt_count);
-  if (dbg_ctl_http_alts.on()) {
+  Dbg(get_dbg_http_match(), "[SelectFromAlternates] # alternates = %d", alt_count);
+  Dbg(get_dbg_http_seq(), "[SelectFromAlternates] %d alternates for this cached doc", alt_count);
+  if (get_dbg_http_alts().on()) {
     fprintf(stderr, "[alts] There are %d alternates for this request header.\n", alt_count);
   }
 
@@ -230,7 +230,7 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
         current_age = static_cast<time_t>(0);
       }
 
-      if (dbg_ctl_http_alts.on()) {
+      if (get_dbg_http_alts().on()) {
         fprintf(stderr, "[alts] ---- alternate #%d (Q = %g) has these request/response hdrs:\n", i + 1, Q);
         char b[4096];
         int  used, tmp, offset;
@@ -264,8 +264,8 @@ HttpTransactCache::SelectFromAlternates(CacheHTTPInfoVector *cache_vector, HTTPH
       }
     }
   }
-  Dbg(dbg_ctl_http_seq, "[SelectFromAlternates] Chosen alternate # %d", best_index);
-  if (dbg_ctl_http_alts.on()) {
+  Dbg(get_dbg_http_seq(), "[SelectFromAlternates] Chosen alternate # %d", best_index);
+  if (get_dbg_http_alts().on()) {
     fprintf(stderr, "[alts] and the winner is alternate number %d\n", best_index);
   }
 
@@ -357,7 +357,7 @@ HttpTransactCache::calculate_quality_of_match(const HttpConfigAccessor *http_con
 
       // absence in both requests counts as exact match
       if (accept_field == nullptr && cached_accept_field == nullptr) {
-        Dbg(dbg_ctl_http_alternate, "Exact match for ACCEPT CHARSET (not in request nor cache)");
+        Dbg(get_dbg_http_alternate(), "Exact match for ACCEPT CHARSET (not in request nor cache)");
         q[1] = 1.001; // slightly higher weight to this guy
       } else {
         q[1] = calculate_quality_of_accept_charset_match(accept_field, content_field, cached_accept_field);
@@ -376,7 +376,7 @@ HttpTransactCache::calculate_quality_of_match(const HttpConfigAccessor *http_con
 
         // absence in both requests counts as exact match
         if (accept_field == nullptr && cached_accept_field == nullptr) {
-          Dbg(dbg_ctl_http_alternate, "Exact match for ACCEPT ENCODING (not in request nor cache)");
+          Dbg(get_dbg_http_alternate(), "Exact match for ACCEPT ENCODING (not in request nor cache)");
           q[2] = 1.001; // slightly higher weight to this guy
         } else {
           q[2] = calculate_quality_of_accept_encoding_match(accept_field, content_field, cached_accept_field);
@@ -395,7 +395,7 @@ HttpTransactCache::calculate_quality_of_match(const HttpConfigAccessor *http_con
 
           // absence in both requests counts as exact match
           if (accept_field == nullptr && cached_accept_field == nullptr) {
-            Dbg(dbg_ctl_http_alternate, "Exact match for ACCEPT LANGUAGE (not in request nor cache)");
+            Dbg(get_dbg_http_alternate(), "Exact match for ACCEPT LANGUAGE (not in request nor cache)");
             q[3] = 1.001; // slightly higher weight to this guy
           } else {
             q[3] = calculate_quality_of_accept_language_match(accept_field, content_field, cached_accept_field);
@@ -408,24 +408,24 @@ HttpTransactCache::calculate_quality_of_match(const HttpConfigAccessor *http_con
   // final quality is minimum Q, or -1, if some match failed //
   Q = ((q[0] < 0) || (q[1] < 0) || (q[2] < 0) || (q[3] < 0)) ? -1.0 : q[0] * q[1] * q[2] * q[3];
 
-  Dbg(dbg_ctl_http_match, "    CalcQualityOfMatch: Accept match = %g", q[0]);
-  Dbg(dbg_ctl_http_seq, "    CalcQualityOfMatch: Accept match = %g", q[0]);
-  Dbg(dbg_ctl_http_alternate, "Content-Type and Accept %f", q[0]);
+  Dbg(get_dbg_http_match(), "    CalcQualityOfMatch: Accept match = %g", q[0]);
+  Dbg(get_dbg_http_seq(), "    CalcQualityOfMatch: Accept match = %g", q[0]);
+  Dbg(get_dbg_http_alternate(), "Content-Type and Accept %f", q[0]);
 
-  Dbg(dbg_ctl_http_match, "    CalcQualityOfMatch: AcceptCharset match = %g", q[1]);
-  Dbg(dbg_ctl_http_seq, "    CalcQualityOfMatch: AcceptCharset match = %g", q[1]);
-  Dbg(dbg_ctl_http_alternate, "Content-Type and Accept-Charset %f", q[1]);
+  Dbg(get_dbg_http_match(), "    CalcQualityOfMatch: AcceptCharset match = %g", q[1]);
+  Dbg(get_dbg_http_seq(), "    CalcQualityOfMatch: AcceptCharset match = %g", q[1]);
+  Dbg(get_dbg_http_alternate(), "Content-Type and Accept-Charset %f", q[1]);
 
-  Dbg(dbg_ctl_http_match, "    CalcQualityOfMatch: AcceptEncoding match = %g", q[2]);
-  Dbg(dbg_ctl_http_seq, "    CalcQualityOfMatch: AcceptEncoding match = %g", q[2]);
-  Dbg(dbg_ctl_http_alternate, "Content-Encoding and Accept-Encoding %f", q[2]);
+  Dbg(get_dbg_http_match(), "    CalcQualityOfMatch: AcceptEncoding match = %g", q[2]);
+  Dbg(get_dbg_http_seq(), "    CalcQualityOfMatch: AcceptEncoding match = %g", q[2]);
+  Dbg(get_dbg_http_alternate(), "Content-Encoding and Accept-Encoding %f", q[2]);
 
-  Dbg(dbg_ctl_http_match, "    CalcQualityOfMatch: AcceptLanguage match = %g", q[3]);
-  Dbg(dbg_ctl_http_seq, "    CalcQualityOfMatch: AcceptLanguage match = %g", q[3]);
-  Dbg(dbg_ctl_http_alternate, "Content-Language and Accept-Language %f", q[3]);
+  Dbg(get_dbg_http_match(), "    CalcQualityOfMatch: AcceptLanguage match = %g", q[3]);
+  Dbg(get_dbg_http_seq(), "    CalcQualityOfMatch: AcceptLanguage match = %g", q[3]);
+  Dbg(get_dbg_http_alternate(), "Content-Language and Accept-Language %f", q[3]);
 
-  Dbg(dbg_ctl_http_alternate, "Mult's Quality Factor: %f", Q);
-  Dbg(dbg_ctl_http_alternate, "----------End of Alternate----------");
+  Dbg(get_dbg_http_alternate(), "Mult's Quality Factor: %f", Q);
+  Dbg(get_dbg_http_alternate(), "----------End of Alternate----------");
 
   int force_alt = 0;
 
@@ -473,10 +473,10 @@ HttpTransactCache::calculate_quality_of_match(const HttpConfigAccessor *http_con
       Q = -1.0;
     }
 
-    Dbg(dbg_ctl_http_match, "    CalcQualityOfMatch: CalcVariability says variability = %d", (variability != VARIABILITY_NONE));
-    Dbg(dbg_ctl_http_seq, "    CalcQualityOfMatch: CalcVariability says variability = %d", (variability != VARIABILITY_NONE));
-    Dbg(dbg_ctl_http_match, "    CalcQualityOfMatch: Returning final Q = %g", Q);
-    Dbg(dbg_ctl_http_seq, "    CalcQualityOfMatch: Returning final Q = %g", Q);
+    Dbg(get_dbg_http_match(), "    CalcQualityOfMatch: CalcVariability says variability = %d", (variability != VARIABILITY_NONE));
+    Dbg(get_dbg_http_seq(), "    CalcQualityOfMatch: CalcVariability says variability = %d", (variability != VARIABILITY_NONE));
+    Dbg(get_dbg_http_match(), "    CalcQualityOfMatch: Returning final Q = %g", Q);
+    Dbg(get_dbg_http_seq(), "    CalcQualityOfMatch: Returning final Q = %g", Q);
   }
 
   return Q;
@@ -560,7 +560,7 @@ HttpTransactCache::calculate_quality_of_accept_match(MIMEField *accept_field, MI
     char a_type[32], a_subtype[32];
     HttpCompat::parse_mime_type(a_param->str, a_type, a_subtype, sizeof(a_type), sizeof(a_subtype));
 
-    Dbg(dbg_ctl_http_match, "matching Content-type; '%s/%s' with Accept value '%s/%s'\n", c_type, c_subtype, a_type, a_subtype);
+    Dbg(get_dbg_http_match(), "matching Content-type; '%s/%s' with Accept value '%s/%s'\n", c_type, c_subtype, a_type, a_subtype);
 
     bool wildcard_found = true;
     // Only do wildcard checks if the content type is not image/webp
@@ -656,17 +656,17 @@ HttpTransactCache::calculate_document_age(ink_time_t request_time, ink_time_t re
     current_age            = corrected_initial_age + resident_time;
   }
 
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] age_value:              %" PRId64, (int64_t)age_value);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] date_value:             %" PRId64, (int64_t)date_value);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] response_time:          %" PRId64, (int64_t)response_time);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] now:                    %" PRId64, (int64_t)now);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] now (fixed):            %" PRId64, (int64_t)now_value);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] apparent_age:           %" PRId64, (int64_t)apparent_age);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] corrected_received_age: %" PRId64, (int64_t)corrected_received_age);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] response_delay:         %" PRId64, (int64_t)response_delay);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] corrected_initial_age:  %" PRId64, (int64_t)corrected_initial_age);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] resident_time:          %" PRId64, (int64_t)resident_time);
-  Dbg(dbg_ctl_http_age, "[calculate_document_age] current_age:            %" PRId64, (int64_t)current_age);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] age_value:              %" PRId64, (int64_t)age_value);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] date_value:             %" PRId64, (int64_t)date_value);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] response_time:          %" PRId64, (int64_t)response_time);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] now:                    %" PRId64, (int64_t)now);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] now (fixed):            %" PRId64, (int64_t)now_value);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] apparent_age:           %" PRId64, (int64_t)apparent_age);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] corrected_received_age: %" PRId64, (int64_t)corrected_received_age);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] response_delay:         %" PRId64, (int64_t)response_delay);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] corrected_initial_age:  %" PRId64, (int64_t)corrected_initial_age);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] resident_time:          %" PRId64, (int64_t)resident_time);
+  Dbg(get_dbg_http_age(), "[calculate_document_age] current_age:            %" PRId64, (int64_t)current_age);
 
   return current_age;
 }
@@ -715,7 +715,7 @@ HttpTransactCache::calculate_quality_of_accept_charset_match(MIMEField *accept_f
     a_raw  = accept_field->value_get(&a_raw_len);
     ca_raw = cached_accept_field->value_get(&ca_raw_len);
     if (a_raw && ca_raw && a_raw_len == ca_raw_len && !strncmp(a_raw, ca_raw, a_raw_len)) {
-      Dbg(dbg_ctl_http_alternate, "Exact match for ACCEPT CHARSET");
+      Dbg(get_dbg_http_alternate(), "Exact match for ACCEPT CHARSET");
       return static_cast<float>(1.001); // slightly higher weight to this guy
     }
   }
@@ -927,7 +927,7 @@ HttpTransactCache::calculate_quality_of_accept_encoding_match(MIMEField *accept_
     a_raw  = accept_field->value_get(&a_raw_len);
     ca_raw = cached_accept_field->value_get(&ca_raw_len);
     if (a_raw && ca_raw && a_raw_len == ca_raw_len && !strncmp(a_raw, ca_raw, a_raw_len)) {
-      Dbg(dbg_ctl_http_alternate, "Exact match for ACCEPT ENCODING");
+      Dbg(get_dbg_http_alternate(), "Exact match for ACCEPT ENCODING");
       return static_cast<float>(1.001); // slightly higher weight to this guy
     }
   }
@@ -938,8 +938,8 @@ HttpTransactCache::calculate_quality_of_accept_encoding_match(MIMEField *accept_
   }
   // if no Content-Encoding, treat as "identity" //
   if (!content_field) {
-    Dbg(dbg_ctl_http_match, "[calculate_quality_accept_encoding_match]: "
-                            "response hdr does not have content-encoding.");
+    Dbg(get_dbg_http_match(), "[calculate_quality_accept_encoding_match]: "
+                              "response hdr does not have content-encoding.");
     is_identity_encoding = true;
   } else {
     // TODO: Should we check the return value (count) here?
@@ -1153,7 +1153,7 @@ HttpTransactCache::calculate_quality_of_accept_language_match(MIMEField *accept_
     a_raw  = accept_field->value_get(&a_raw_len);
     ca_raw = cached_accept_field->value_get(&ca_raw_len);
     if (a_raw && ca_raw && a_raw_len == ca_raw_len && !strncmp(a_raw, ca_raw, a_raw_len)) {
-      Dbg(dbg_ctl_http_alternate, "Exact match for ACCEPT LANGUAGE");
+      Dbg(get_dbg_http_alternate(), "Exact match for ACCEPT LANGUAGE");
       return static_cast<float>(1.001); // slightly higher weight to this guy
     }
   }
@@ -1169,8 +1169,8 @@ HttpTransactCache::calculate_quality_of_accept_language_match(MIMEField *accept_
     if (match_accept_content_language("identity", accept_field, &wildcard_present, &wildcard_q, &q, &a_range_length)) {
       goto language_wildcard;
     }
-    Dbg(dbg_ctl_http_match, "[calculate_quality_accept_language_match]: "
-                            "response hdr does not have content-language.");
+    Dbg(get_dbg_http_match(), "[calculate_quality_accept_language_match]: "
+                              "response hdr does not have content-language.");
     return (1.0);
   }
 
@@ -1223,8 +1223,8 @@ HttpTransactCache::CalcVariability(const HttpConfigAccessor *http_config_params,
     StrList vary_list;
 
     if (obj_origin_server_response->value_get_comma_list(MIME_FIELD_VARY, MIME_LEN_VARY, &vary_list) > 0) {
-      if (dbg_ctl_http_match.on() && vary_list.head) {
-        DbgPrint(dbg_ctl_http_match, "Vary list of %d elements", vary_list.count);
+      if (get_dbg_http_match().on() && vary_list.head) {
+        DbgPrint(get_dbg_http_match(), "Vary list of %d elements", vary_list.count);
         vary_list.dump(stderr);
       }
 
@@ -1240,9 +1240,9 @@ HttpTransactCache::CalcVariability(const HttpConfigAccessor *http_config_params,
         // but currently we just treat it equivalent to a '*'.     //
         /////////////////////////////////////////////////////////////
 
-        Dbg(dbg_ctl_http_match, "Vary: %s", field->str);
+        Dbg(get_dbg_http_match(), "Vary: %s", field->str);
         if (((field->str[0] == '*') && (field->str[1] == NUL))) {
-          Dbg(dbg_ctl_http_match, "Wildcard variability --- object not served from cache");
+          Dbg(get_dbg_http_match(), "Wildcard variability --- object not served from cache");
           variability = VARIABILITY_ALL;
           break;
         }

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -164,8 +164,8 @@ new_CacheVC(Continuation *cont)
   c->start_time       = ink_get_hrtime();
   c->setThreadAffinity(t);
   ink_assert(c->trigger == nullptr);
-  static DbgCtl dbg_ctl{"cache_new"};
-  Dbg(dbg_ctl, "new %p", c);
+  static DbgCtl *dbg_ctl{new DbgCtl{"cache_new"}};
+  Dbg(*dbg_ctl, "new %p", c);
   dir_clear(&c->dir);
   return c;
 }
@@ -173,8 +173,8 @@ new_CacheVC(Continuation *cont)
 inline int
 free_CacheVCCommon(CacheVC *cont)
 {
-  static DbgCtl dbg_ctl{"cache_free"};
-  Dbg(dbg_ctl, "free %p", cont);
+  static DbgCtl *dbg_ctl{new DbgCtl{"cache_free"}};
+  Dbg(*dbg_ctl, "free %p", cont);
   ProxyMutex *mutex  = cont->mutex.get();
   StripeSM   *stripe = cont->stripe;
 

--- a/src/iocore/cache/Store.cc
+++ b/src/iocore/cache/Store.cc
@@ -41,12 +41,7 @@
 const char Store::VOLUME_KEY[]           = "volume";
 const char Store::HASH_BASE_STRING_KEY[] = "id";
 
-namespace
-{
-
-DbgCtl dbg_ctl_cache_init{"cache_init"};
-
-} // end anonymous namespace
+DEF_DBG(cache_init)
 
 static span_error_t
 make_span_error(int error)
@@ -230,7 +225,7 @@ Store::read_config()
   ats_scoped_str storage_path(RecConfigReadConfigPath(nullptr, ts::filename::STORAGE));
 
   Note("%s loading ...", ts::filename::STORAGE);
-  Dbg(dbg_ctl_cache_init, "Store::read_config, fd = -1, \"%s\"", (const char *)storage_path);
+  Dbg(get_dbg_cache_init(), "Store::read_config, fd = -1, \"%s\"", (const char *)storage_path);
   fd = ::open(storage_path, O_RDONLY);
   if (fd < 0) {
     Error("%s failed to load", ts::filename::STORAGE);
@@ -259,7 +254,7 @@ Store::read_config()
     }
 
     // parse
-    Dbg(dbg_ctl_cache_init, "Store::read_config: \"%s\"", path);
+    Dbg(get_dbg_cache_init(), "Store::read_config: \"%s\"", path);
     ++n_spans_in_config;
 
     int64_t     size       = -1;
@@ -297,10 +292,10 @@ Store::read_config()
     std::string pp = Layout::get()->relative(path);
 
     ns = new Span;
-    Dbg(dbg_ctl_cache_init, "Store::read_config - ns = new Span; ns->init(\"%s\",%" PRId64 "), forced volume=%d%s%s", pp.c_str(),
+    Dbg(get_dbg_cache_init(), "Store::read_config - ns = new Span; ns->init(\"%s\",%" PRId64 "), forced volume=%d%s%s", pp.c_str(),
         size, volume_num, seed ? " id=" : "", seed ? seed : "");
     if ((err = ns->init(pp.c_str(), size))) {
-      Dbg(dbg_ctl_cache_init, "Store::read_config - could not initialize storage \"%s\" [%s]", pp.c_str(), err);
+      Dbg(get_dbg_cache_init(), "Store::read_config - could not initialize storage \"%s\" [%s]", pp.c_str(), err);
       delete ns;
       continue;
     }
@@ -487,8 +482,8 @@ Span::init(const char *path, int64_t size)
   // A directory span means we will end up with a file, otherwise, we get what we asked for.
   this->pathname = ats_strdup(path);
 
-  Dbg(dbg_ctl_cache_init, "initialized span '%s'", this->pathname.get());
-  Dbg(dbg_ctl_cache_init,
+  Dbg(get_dbg_cache_init(), "initialized span '%s'", this->pathname.get());
+  Dbg(get_dbg_cache_init(),
       "hw_sector_size=%d, size=%" PRId64 ", blocks=%" PRId64 ", disk_id=%" PRId64 "/%" PRId64 ", file_pathname=%d",
       this->hw_sector_size, this->size(), this->blocks, this->disk_id[0], this->disk_id[1], this->file_pathname);
 


### PR DESCRIPTION
This ensures that threads can access these instances safely at any time. It should help clean up TSan reports a little bit by preventing data races with the destructors, and use-after-free issues.