### PR TITLE
Suppress CID 1523641 - dead code in XPACK

### DIFF
--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -179,8 +179,8 @@ xpack_encode_integer(uint8_t *buf_start, const uint8_t *buf_end, uint64_t value,
 int64_t
 xpack_encode_string(uint8_t *buf_start, const uint8_t *buf_end, const char *value, uint64_t value_len, uint8_t n)
 {
-  uint8_t *p           = buf_start;
-  bool     use_huffman = true;
+  uint8_t       *p           = buf_start;
+  constexpr bool use_huffman = true;
 
   ts::LocalBuffer<uint8_t, 4096> local_buffer(value_len * 4);
   uint8_t                       *data     = local_buffer.data();


### PR DESCRIPTION
The variable `use_huffman` is used to decide which branch to take, but is hardcoded to `true`. This has already been suppressed for cppcheck, and Coverity says we can suppress it by declaring the variable with `const`. I think `constexpr` should also work, but I couldn't confirm this.