### PR TITLE
Fix CID 1523641 - unchecked error return

### DIFF
--- a/src/proxy/http2/unit_tests/test_Http2Frame.cc
+++ b/src/proxy/http2/unit_tests/test_Http2Frame.cc
@@ -41,6 +41,7 @@ TEST_CASE("Http2Frame", "[http2][Http2Frame]")
     Http2PushPromiseFrame frame(id, flags, pp, hdr_block, hdr_block_len);
     int64_t               written = frame.write_to(miob);
 
+    REQUIRE(written != -1);
     CHECK(written == static_cast<int64_t>(HTTP2_FRAME_HEADER_LEN + sizeof(Http2StreamId) + hdr_block_len));
     CHECK(written == miob_r->read_avail());
 


### PR DESCRIPTION
We should abort the test if `written` indicates an error, otherwise we will call `memcmp` later with the value we didn't intend to be negative. This is already done correctly in all the other tests.