### PR TITLE
CID-1559185: Mute coverity.

### DIFF
--- a/include/shared/rpc/IPCSocketClient.h
+++ b/include/shared/rpc/IPCSocketClient.h
@@ -85,7 +85,7 @@ struct IPCSocketClient {
   }
 
 protected:
-  ssize_t            _safe_write(int fd, const char *buffer, int len);
+  std::int64_t       _safe_write(int fd, const char *buffer, int len);
   std::string        _path;
   struct sockaddr_un _server;
 

--- a/src/shared/rpc/IPCSocketClient.cc
+++ b/src/shared/rpc/IPCSocketClient.cc
@@ -154,12 +154,12 @@ IPCSocketClient::connect(std::chrono::milliseconds ms, int attempts)
   return *this;
 }
 
-ssize_t
+std::int64_t
 IPCSocketClient::_safe_write(int fd, const char *buffer, int len)
 {
-  ssize_t written{0};
+  std::int64_t written{0};
   while (written < len) {
-    const int ret = ::write(fd, buffer + written, len - written);
+    const ssize_t ret = ::write(fd, buffer + written, len - written);
     if (ret == -1) {
       if (errno == EAGAIN || errno == EINTR) {
         continue;

--- a/src/shared/rpc/IPCSocketClient.cc
+++ b/src/shared/rpc/IPCSocketClient.cc
@@ -35,7 +35,7 @@ namespace
 {
 /// @brief Simple buffer to store the jsonrpc server's response.
 ///
-///        With small content it will just use the LocalBufferWritter, if the
+///        With small content it will just use the LocalBufferWriter, if the
 ///        content gets bigger, then it will just save the buffer into a stream
 ///        and reuse the already created BufferWritter.
 template <size_t N> class BufferStream


### PR DESCRIPTION
The code was ok, in theory `ret` should not be bigger than `len` but I suspect it complains because of the `ssize_t`  as in some other places we get away with just an `int`, in any case this should mute it.