### PR TITLE
ATS 10 upgrading documentation updates

### DIFF
--- a/doc/release-notes/upgrading.en.rst
+++ b/doc/release-notes/upgrading.en.rst
@@ -23,13 +23,34 @@ Upgrading to ATS v10.x
 ======================
 
 .. toctree::
-   :maxdepth: 1
 
-Deprecated or Removed Features
-------------------------------
+Feature Changes
+---------------
+
+Removed and Deprecated Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following features, configurations and plugins are either removed or deprecated in this
 version of ATS. Deprecated features should be avoided, with the expectation that they will be
 removed in the next major release of ATS.
+
+* Removed NPN support
+
+  The Next Protocol Negotiation (NPN) support has been removed from ATS. This is due to the fact that
+  NPN has been deprecated in favor of ALPN.
+
+Changes to Features
+~~~~~~~~~~~~~~~~~~~
+The following features have been changed in this version of ATS.
+
+* Remap ACLs
+
+   Fixes with @action=allow to deny transactions that are not explicitly allowed.  Changed in-line ACLs to match before activated ACL rules.
+   For detail refer to: https://github.com/apache/trafficserver/pull/11033
+
+
+API Changes
+-----------
+The following APIs have changed, either in semantics, interfaces, or both.
 
 * Removed TS API
 
@@ -49,10 +70,19 @@ removed in the next major release of ATS.
   * TSVConnArgIndexNameLookup
   * TSVConnArgIndexLookup
 
+* Removed INK UDP API
 
-API Changes
------------
-The following APIs have changed, either in semantics, interfaces, or both.
+  * INKUDPBind
+  * INKUDPSendTo
+  * INKUDPRecvFrom
+  * INKUDPConnFdGet
+  * INKUDPPacketCreate
+  * INKUDPPacketBufferBlockGet
+  * INKUDPPacketFromAddressGet
+  * INKUDPPacketFromPortGet
+  * INKUDPPacketConnGet
+  * INKUDPPacketDestroy
+  * INKUDPPacketGet
 
 
 Cache
@@ -60,7 +90,7 @@ Cache
 The cache in this releases of ATS is compatible with previous versions of ATS. You would not expect
 to lose your cache, or have to reinitialize the cache when upgrading.
 
-Configuration changes
+Configuration Changes
 ---------------------
 The following incompatible changes to the configurations have been made in this version of ATS.
 
@@ -85,11 +115,11 @@ TS_LUA_CONFIG_HTTP_CONNECT_ATTEMPTS_MAX_RETRIES_DEAD_SERVER has been renamed to 
 TS_LUA_CONFIG_HTTP_CONNECT_DEAD_POLICY has been renamed to TS_LUA_CONFIG_HTTP_CONNECT_DOWN_POLICY.
 
 Metrics
-------------------
+-------
 
 The HTTP connection metric proxy.process.http.dead_server.no_requests has been renamed to proxy.process.http.down_server.no_requests.
 
 Logging
-------------------
+-------
 
 The ``cqtx`` log field has been removed, but can be replaced by ``cqhm pqu cqpv``.

--- a/doc/release-notes/whats-new.en.rst
+++ b/doc/release-notes/whats-new.en.rst
@@ -41,17 +41,20 @@ Combined Connect Timeouts
 The configuration settings :ts:cv: `proxy.config.http.parent_proxy.connect_attempts_timeout` and :ts:cv: `proxy.config.http.post_connect_attempts_timeout` have been removed.
 All connect timeouts are controlled by :ts:cv: `proxy.config.http.connect_attempts_timeout`.
 
+
+
+
 Logging and Metrics
 -------------------
 
 Plugins
 -------
 
-Switch to C++17
+Switch to C++20
 ^^^^^^^^^^^^^^^
 
 Plugins are now required to be compiled as C++ code, rather than straight C.
-The API is tested with C++17, so code compatible with this version is preferred.
+The API is tested with C++20, so code compatible with this version is preferred.
 ``TSDebug`` and related functions are removed.  Debug tracing should now be done
 using cpp:func:`Dbg` and related functions, as in |TS| core code.
 


### PR DESCRIPTION
Documentation for these PRs:

 #10910 - Change default C++ standard to 20
 #11033 - Remap ACL changes for 10
 #11045 - Deprecate the support for NPN
 #11171 - Remove symbols with prefix INKUDP from plugin API