### PR TITLE
add max_open_write_retry_timeout to recordsconfig

### DIFF
--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -580,6 +580,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.cache.max_open_write_retries", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http.cache.max_open_write_retry_timeout", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   //       #  open_write_fail_action has 3 options:
   //       #
   //       #  0 - default. disable cache and goto origin


### PR DESCRIPTION
This is needed so that proxy.config.http.cache.max_open_write_retry_timeout shows up and can be set with the traffic_ctl utility.