### PR TITLE
Fix whats-new links and remove redundant timeout

### DIFF
--- a/doc/release-notes/upgrading.en.rst
+++ b/doc/release-notes/upgrading.en.rst
@@ -147,9 +147,6 @@ The following :file:`records.yaml` changes have been made:
   from ``PERMISSIVE`` to ``STRICT``.
 - The records.yaml entry ``proxy.config.http.keepalive_internal_vc`` has been removed.  This entry
   was previously undocumented.
-- The records.yaml entries ``proxy.config.http.parent_proxy.connect_attempts_timeout`` and
-  ``proxy.config.http.post_connect_attempts_timeout`` were previously referenced in default config
-  files, but they did not have any effect.  These have been removed from default configs files.
 - The default values for :ts:cv:`proxy.config.http.request_header_max_size`, :ts:cv:`proxy.config.http.response_header_max_size`, and
   :ts:cv:`proxy.config.http.header_field_max_size` have been changed to 32KB.
 - The records.yaml entry :ts:cv:`proxy.config.http.server_ports` now also accepts the

--- a/doc/release-notes/whats-new.en.rst
+++ b/doc/release-notes/whats-new.en.rst
@@ -44,13 +44,6 @@ New Features
 New or modified Configurations
 ------------------------------
 
-Combined Connect Timeouts
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The configuration settings :ts:cv: `proxy.config.http.parent_proxy.connect_attempts_timeout` and :ts:cv: `proxy.config.http.post_connect_attempts_timeout` have been removed.
-All connect timeouts are controlled by :ts:cv: `proxy.config.http.connect_attempts_timeout`.
-
-
 ip_allow.yaml and remap.config ACL actions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -62,7 +55,6 @@ There are two new sets of actions for HTTP request method filtering introduced i
   and ``deny`` actions did for :file:`remap.config` ACLs pre |TS| 10.x.
 
 The details about the motivation and behavior of these actions are documented in :ref:`acl-filters`.
-
 
 Logging and Metrics
 -------------------


### PR DESCRIPTION
whats-new has malformed link references to non-existent links. This fixes that. Also connect_attempts_timeout changes are referenced twice in upgrading in a way that doesn't seem helpful: we say first that we removed them, then in a separate bullet we say that they are removed from default config. The latter is implied by the former.