### PR TITLE
Fix JA4 SNI type determination

### DIFF
--- a/plugins/experimental/ja4_fingerprint/ja4.cc
+++ b/plugins/experimental/ja4_fingerprint/ja4.cc
@@ -53,7 +53,7 @@ JA4::make_JA4_a_raw(TLSClientHelloSummary const &TLS_summary)
   result.reserve(9);
   result.push_back(convert_protocol_to_char(TLS_summary.protocol));
   result.append(convert_TLS_version_to_string(TLS_summary.TLS_version));
-  result.push_back(convert_SNI_to_char(TLS_summary.SNI_type));
+  result.push_back(convert_SNI_to_char(TLS_summary.get_SNI_type()));
   result.append(convert_count_to_two_digit_string(TLS_summary.get_cipher_count()));
   result.append(convert_count_to_two_digit_string(TLS_summary.get_extension_count()));
   result.append(convert_ALPN_to_two_char_string(TLS_summary.ALPN));

--- a/plugins/experimental/ja4_fingerprint/ja4.h
+++ b/plugins/experimental/ja4_fingerprint/ja4.h
@@ -54,7 +54,6 @@ public:
   using difference_type = std::iterator_traits<std::vector<std::uint16_t>::iterator>::difference_type;
 
   Protocol      protocol;
-  SNI           SNI_type;
   std::uint16_t TLS_version;
   std::string   ALPN;
 
@@ -78,10 +77,17 @@ public:
    */
   difference_type get_extension_count() const;
 
+  /** Get the SNI type, domain or IP.
+   *
+   * @return Returns SNI::to_domain or SNI::to_IP.
+   */
+  SNI get_SNI_type() const;
+
 private:
   std::vector<std::uint16_t> _ciphers;
   std::vector<std::uint16_t> _extensions;
   int                        _extension_count_including_sni_and_alpn{0};
+  SNI                        _SNI_type{SNI::to_IP};
 };
 
 /**

--- a/plugins/experimental/ja4_fingerprint/test_ja4.cc
+++ b/plugins/experimental/ja4_fingerprint/test_ja4.cc
@@ -97,20 +97,19 @@ TEST_CASE("JA4")
     }
   }
 
-  SECTION("Given the SNI is a domain name, "
+  SECTION("Given the SNI extension is present, "
           "when we create a JA4 fingerprint, "
           "then index 3 thereof should contain 'd'.")
   {
-    TLS_summary.SNI_type = JA4::SNI::to_domain;
-    INFO(call_JA4(TLS_summary));
+    TLS_summary.add_extension(0x0);
     CHECK("d" == call_JA4(TLS_summary).substr(3, 1));
   }
 
-  SECTION("Given the SNI is an IP, "
+  SECTION("Given the SNI extension is not present, "
           "when we create a JA4 fingerprint, "
           "then index 3 thereof should contain 'i'.")
   {
-    TLS_summary.SNI_type = JA4::SNI::to_IP;
+    TLS_summary.add_extension(0x31);
     CHECK("i" == call_JA4(TLS_summary).substr(3, 1));
   }
 

--- a/plugins/experimental/ja4_fingerprint/tls_client_hello_summary.cc
+++ b/plugins/experimental/ja4_fingerprint/tls_client_hello_summary.cc
@@ -72,6 +72,10 @@ JA4::TLSClientHelloSummary::add_extension(std::uint16_t extension)
     return;
   }
 
+  if (extension_SNI == extension) {
+    this->_SNI_type = SNI::to_domain;
+  }
+
   ++this->_extension_count_including_sni_and_alpn;
   if (!is_ignored_non_GREASE_extension(extension)) {
     this->_extensions.push_back(extension);
@@ -100,4 +104,10 @@ bool
 is_ignored_non_GREASE_extension(std::uint16_t extension)
 {
   return (extension_SNI == extension) || (extension_ALPN == extension);
+}
+
+JA4::SNI
+JA4::TLSClientHelloSummary::get_SNI_type() const
+{
+  return this->_SNI_type;
 }


### PR DESCRIPTION
> If the SNI extension (0x0000) exists, then the destination of the connection
> is a domain, or "d" in the fingerprint. If the SNI does not exist, then the
> destination is an IP address, or "i".