### PR TITLE
QUIC: Fix a bug that ssl_multicert.config is not reloaded for QUIC

### DIFF
--- a/src/iocore/net/SSLClientCoordinator.cc
+++ b/src/iocore/net/SSLClientCoordinator.cc
@@ -24,6 +24,7 @@
 #include "P_SSLClientCoordinator.h"
 #include "P_SSLConfig.h"
 #include "iocore/net/SSLSNIConfig.h"
+#include "iocore/net/QUICMultiCertConfigLoader.h"
 
 std::unique_ptr<ConfigUpdateHandler<SSLClientCoordinator>> sslClientUpdate;
 
@@ -36,6 +37,7 @@ SSLClientCoordinator::reconfigure()
   SSLConfig::reconfigure();
   SNIConfig::reconfigure();
   SSLCertificateConfig::reconfigure();
+  QUICCertConfig::reconfigure();
 }
 
 void

--- a/src/iocore/net/SSLClientCoordinator.cc
+++ b/src/iocore/net/SSLClientCoordinator.cc
@@ -24,7 +24,9 @@
 #include "P_SSLClientCoordinator.h"
 #include "P_SSLConfig.h"
 #include "iocore/net/SSLSNIConfig.h"
+#if TS_USE_QUIC == 1
 #include "iocore/net/QUICMultiCertConfigLoader.h"
+#endif
 
 std::unique_ptr<ConfigUpdateHandler<SSLClientCoordinator>> sslClientUpdate;
 
@@ -37,7 +39,9 @@ SSLClientCoordinator::reconfigure()
   SSLConfig::reconfigure();
   SNIConfig::reconfigure();
   SSLCertificateConfig::reconfigure();
+#if TS_USE_QUIC == 1
   QUICCertConfig::reconfigure();
+#endif
 }
 
 void

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1938,7 +1938,7 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup)
 
   const matcher_tags sslCertTags = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false};
 
-  Note("%s loading ...", ts::filename::SSL_MULTICERT);
+  Note("(%s) %s loading ...", this->_debug_tag(), ts::filename::SSL_MULTICERT);
 
   std::error_code ec;
   std::string     content{swoc::file::load(swoc::file::path{params->configFilePath}, ec)};


### PR DESCRIPTION
The fix is in SSLClientCoordinator. It's simply lacks the line for QUIC.

The log output format is slightly changed because it'd look like same config file is reloaded twice if it doesn't have a tag name (The file is loaded twice for two contexts, Regular TLS (on TCP) and QUIC).