### PR TITLE
Sever `PreservationTable` inheritance and add utility methods

### DIFF
--- a/src/iocore/cache/CacheEvacuateDocVC.cc
+++ b/src/iocore/cache/CacheEvacuateDocVC.cc
@@ -55,9 +55,8 @@ CacheEvacuateDocVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS
   DDbg(dbg_ctl_cache_evac, "evacuateDocDone %X o %d p %d new_o %d new_p %d", (int)key.slice32(0),
        (int)dir_offset(&this->overwrite_dir), (int)dir_phase(&this->overwrite_dir), (int)dir_offset(&this->dir),
        (int)dir_phase(&this->dir));
-  int i = dir_evac_bucket(&this->overwrite_dir);
   // nasty beeping race condition, need to have the EvacuationBlock here
-  EvacuationBlock *b = this->stripe->evac_bucket_valid(i) ? this->stripe->get_preserved_dirs().find(this->overwrite_dir) : nullptr;
+  EvacuationBlock *b = this->stripe->get_preserved_dirs().find(this->overwrite_dir);
   if (b) {
     // If the document is single fragment (although not tied to the vector),
     // then we don't have to put the directory entry in the lookaside
@@ -74,7 +73,7 @@ CacheEvacuateDocVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS
       }
       ink_assert(evac);
       if (!evac) {
-        goto RET;
+        return free_CacheEvacuateDocVC(this);
       }
       if (evac->earliest_key.fold()) {
         DDbg(dbg_ctl_cache_evac, "evacdocdone: evacuating key %X earliest %X", evac->key.slice32(0), evac->earliest_key.slice32(0));
@@ -134,7 +133,6 @@ CacheEvacuateDocVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS
       }
     }
   }
-RET:
   return free_CacheEvacuateDocVC(this);
 }
 

--- a/src/iocore/cache/CacheEvacuateDocVC.cc
+++ b/src/iocore/cache/CacheEvacuateDocVC.cc
@@ -57,88 +57,84 @@ CacheEvacuateDocVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS
        (int)dir_phase(&this->dir));
   int i = dir_evac_bucket(&this->overwrite_dir);
   // nasty beeping race condition, need to have the EvacuationBlock here
-  EvacuationBlock *b = this->stripe->evac_bucket_valid(i) ? this->stripe->get_evac_bucket(i).head : nullptr;
-  for (; b; b = b->link.next) {
-    if (dir_offset(&b->dir) == dir_offset(&this->overwrite_dir)) {
-      // If the document is single fragment (although not tied to the vector),
-      // then we don't have to put the directory entry in the lookaside
-      // buffer. But, we have no way of finding out if the document is
-      // single fragment. doc->single_fragment() can be true for a multiple
-      // fragment document since total_len and doc->len could be equal at
-      // the time we write the fragment down. To be on the safe side, we
-      // only overwrite the entry in the directory if its not a head.
-      if (!dir_head(&this->overwrite_dir)) {
-        // find the earliest key
-        EvacuationKey *evac = &b->evac_frags;
-        for (; evac && !(evac->key == doc->key); evac = evac->link.next) {
-          ;
-        }
-        ink_assert(evac);
-        if (!evac) {
-          break;
-        }
-        if (evac->earliest_key.fold()) {
-          DDbg(dbg_ctl_cache_evac, "evacdocdone: evacuating key %X earliest %X", evac->key.slice32(0),
-               evac->earliest_key.slice32(0));
-          EvacuationBlock *eblock = nullptr;
-          Dir              dir_tmp;
-          dir_lookaside_probe(&evac->earliest_key, this->stripe, &dir_tmp, &eblock);
-          if (eblock) {
-            CacheEvacuateDocVC *earliest_evac  = eblock->earliest_evacuator;
-            earliest_evac->total_len          += doc->data_len();
-            if (earliest_evac->total_len == earliest_evac->doc_len) {
-              dir_lookaside_fixup(&evac->earliest_key, this->stripe);
-              free_CacheEvacuateDocVC(earliest_evac);
-            }
+  EvacuationBlock *b = this->stripe->evac_bucket_valid(i) ? this->stripe->get_preserved_dirs().find(this->overwrite_dir) : nullptr;
+  if (b) {
+    // If the document is single fragment (although not tied to the vector),
+    // then we don't have to put the directory entry in the lookaside
+    // buffer. But, we have no way of finding out if the document is
+    // single fragment. doc->single_fragment() can be true for a multiple
+    // fragment document since total_len and doc->len could be equal at
+    // the time we write the fragment down. To be on the safe side, we
+    // only overwrite the entry in the directory if its not a head.
+    if (!dir_head(&this->overwrite_dir)) {
+      // find the earliest key
+      EvacuationKey *evac = &b->evac_frags;
+      for (; evac && !(evac->key == doc->key); evac = evac->link.next) {
+        ;
+      }
+      ink_assert(evac);
+      if (!evac) {
+        goto RET;
+      }
+      if (evac->earliest_key.fold()) {
+        DDbg(dbg_ctl_cache_evac, "evacdocdone: evacuating key %X earliest %X", evac->key.slice32(0), evac->earliest_key.slice32(0));
+        EvacuationBlock *eblock = nullptr;
+        Dir              dir_tmp;
+        dir_lookaside_probe(&evac->earliest_key, this->stripe, &dir_tmp, &eblock);
+        if (eblock) {
+          CacheEvacuateDocVC *earliest_evac  = eblock->earliest_evacuator;
+          earliest_evac->total_len          += doc->data_len();
+          if (earliest_evac->total_len == earliest_evac->doc_len) {
+            dir_lookaside_fixup(&evac->earliest_key, this->stripe);
+            free_CacheEvacuateDocVC(earliest_evac);
           }
         }
-        dir_overwrite(&doc->key, this->stripe, &this->dir, &this->overwrite_dir);
       }
-      // if the tag in the overwrite_dir matches the first_key in the
-      // document, then it has to be the vector. We guarantee that
-      // the first_key and the earliest_key will never collide (see
-      // Cache::open_write). Once we know its the vector, we can
-      // safely overwrite the first_key in the directory.
-      if (dir_head(&this->overwrite_dir) && b->f.evacuate_head) {
-        DDbg(dbg_ctl_cache_evac, "evacuateDocDone evacuate_head %X %X hlen %d offset %d", (int)key.slice32(0),
-             (int)doc->key.slice32(0), doc->hlen, (int)dir_offset(&this->overwrite_dir));
+      dir_overwrite(&doc->key, this->stripe, &this->dir, &this->overwrite_dir);
+    }
+    // if the tag in the overwrite_dir matches the first_key in the
+    // document, then it has to be the vector. We guarantee that
+    // the first_key and the earliest_key will never collide (see
+    // Cache::open_write). Once we know its the vector, we can
+    // safely overwrite the first_key in the directory.
+    if (dir_head(&this->overwrite_dir) && b->f.evacuate_head) {
+      DDbg(dbg_ctl_cache_evac, "evacuateDocDone evacuate_head %X %X hlen %d offset %d", (int)key.slice32(0),
+           (int)doc->key.slice32(0), doc->hlen, (int)dir_offset(&this->overwrite_dir));
 
-        if (dir_compare_tag(&this->overwrite_dir, &doc->first_key)) {
-          OpenDirEntry *cod;
-          DDbg(dbg_ctl_cache_evac, "evacuating vector: %X %d", (int)doc->first_key.slice32(0),
-               (int)dir_offset(&this->overwrite_dir));
-          if ((cod = this->stripe->open_read(&doc->first_key))) {
-            // writer  exists
-            DDbg(dbg_ctl_cache_evac, "overwriting the open directory %X %d %d", (int)doc->first_key.slice32(0),
-                 (int)dir_offset(&cod->first_dir), (int)dir_offset(&this->dir));
-            cod->first_dir = this->dir;
+      if (dir_compare_tag(&this->overwrite_dir, &doc->first_key)) {
+        OpenDirEntry *cod;
+        DDbg(dbg_ctl_cache_evac, "evacuating vector: %X %d", (int)doc->first_key.slice32(0), (int)dir_offset(&this->overwrite_dir));
+        if ((cod = this->stripe->open_read(&doc->first_key))) {
+          // writer  exists
+          DDbg(dbg_ctl_cache_evac, "overwriting the open directory %X %d %d", (int)doc->first_key.slice32(0),
+               (int)dir_offset(&cod->first_dir), (int)dir_offset(&this->dir));
+          cod->first_dir = this->dir;
+        }
+        if (dir_overwrite(&doc->first_key, this->stripe, &this->dir, &this->overwrite_dir)) {
+          int64_t o = dir_offset(&this->overwrite_dir), n = dir_offset(&this->dir);
+          this->stripe->ram_cache->fixup(&doc->first_key, static_cast<uint64_t>(o), static_cast<uint64_t>(n));
+        }
+      } else {
+        DDbg(dbg_ctl_cache_evac, "evacuating earliest: %X %d", (int)doc->key.slice32(0), (int)dir_offset(&this->overwrite_dir));
+        ink_assert(dir_compare_tag(&this->overwrite_dir, &doc->key));
+        ink_assert(b->earliest_evacuator == this);
+        this->total_len    += doc->data_len();
+        this->first_key     = doc->first_key;
+        this->earliest_dir  = this->dir;
+        if (dir_probe(&this->first_key, this->stripe, &this->dir, &last_collision) > 0) {
+          dir_lookaside_insert(b, this->stripe, &this->earliest_dir);
+          // read the vector
+          SET_HANDLER(&CacheEvacuateDocVC::evacuateReadHead);
+          int ret = do_read_call(&this->first_key);
+          if (ret == EVENT_RETURN) {
+            return handleEvent(AIO_EVENT_DONE, nullptr);
           }
-          if (dir_overwrite(&doc->first_key, this->stripe, &this->dir, &this->overwrite_dir)) {
-            int64_t o = dir_offset(&this->overwrite_dir), n = dir_offset(&this->dir);
-            this->stripe->ram_cache->fixup(&doc->first_key, static_cast<uint64_t>(o), static_cast<uint64_t>(n));
-          }
-        } else {
-          DDbg(dbg_ctl_cache_evac, "evacuating earliest: %X %d", (int)doc->key.slice32(0), (int)dir_offset(&this->overwrite_dir));
-          ink_assert(dir_compare_tag(&this->overwrite_dir, &doc->key));
-          ink_assert(b->earliest_evacuator == this);
-          this->total_len    += doc->data_len();
-          this->first_key     = doc->first_key;
-          this->earliest_dir  = this->dir;
-          if (dir_probe(&this->first_key, this->stripe, &this->dir, &last_collision) > 0) {
-            dir_lookaside_insert(b, this->stripe, &this->earliest_dir);
-            // read the vector
-            SET_HANDLER(&CacheEvacuateDocVC::evacuateReadHead);
-            int ret = do_read_call(&this->first_key);
-            if (ret == EVENT_RETURN) {
-              return handleEvent(AIO_EVENT_DONE, nullptr);
-            }
-            return ret;
-          }
+          return ret;
         }
       }
-      break;
     }
   }
+RET:
   return free_CacheEvacuateDocVC(this);
 }
 

--- a/src/iocore/cache/CacheEvacuateDocVC.cc
+++ b/src/iocore/cache/CacheEvacuateDocVC.cc
@@ -57,7 +57,7 @@ CacheEvacuateDocVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS
        (int)dir_phase(&this->dir));
   int i = dir_evac_bucket(&this->overwrite_dir);
   // nasty beeping race condition, need to have the EvacuationBlock here
-  EvacuationBlock *b = this->stripe->evac_bucket_valid(i) ? this->stripe->evacuate[i].head : nullptr;
+  EvacuationBlock *b = this->stripe->evac_bucket_valid(i) ? this->stripe->get_evac_bucket(i).head : nullptr;
   for (; b; b = b->link.next) {
     if (dir_offset(&b->dir) == dir_offset(&this->overwrite_dir)) {
       // If the document is single fragment (although not tied to the vector),

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -209,29 +209,29 @@ public:
   bool
   evac_bucket_valid(off_t bucket) const
   {
-    return this->preserved_dirs.evac_bucket_valid(bucket);
+    return this->_preserved_dirs.evac_bucket_valid(bucket);
   }
 
   DLL<EvacuationBlock>
   get_evac_bucket(off_t bucket) const
   {
-    return this->preserved_dirs.evacuate[bucket];
+    return this->_preserved_dirs.evacuate[bucket];
   }
 
   void
   force_evacuate_head(Dir const *evac_dir, int pinned)
   {
-    return this->preserved_dirs.force_evacuate_head(evac_dir, pinned);
+    return this->_preserved_dirs.force_evacuate_head(evac_dir, pinned);
   }
 
   PreservationTable &
   get_preserved_dirs()
   {
-    return this->preserved_dirs;
+    return this->_preserved_dirs;
   }
 
 private:
-  mutable PreservationTable preserved_dirs;
+  mutable PreservationTable _preserved_dirs;
 
   int _agg_copy(CacheVC *vc);
   int _copy_writer_to_aggregation(CacheVC *vc);

--- a/src/iocore/cache/P_CacheVol.h
+++ b/src/iocore/cache/P_CacheVol.h
@@ -34,6 +34,7 @@
 #include "iocore/eventsystem/EThread.h"
 
 #include "tscore/CryptoHash.h"
+#include "tscore/List.h"
 
 #include <atomic>
 
@@ -66,7 +67,7 @@ struct DiskStripe;
 struct CacheVol;
 class CacheEvacuateDocVC;
 
-class StripeSM : public Continuation, public Stripe, public PreservationTable
+class StripeSM : public Continuation, public Stripe
 {
 public:
   CryptoHash hash_id;
@@ -205,7 +206,33 @@ public:
    */
   void shutdown(EThread *shutdown_thread);
 
+  bool
+  evac_bucket_valid(off_t bucket) const
+  {
+    return this->preserved_dirs.evac_bucket_valid(bucket);
+  }
+
+  DLL<EvacuationBlock>
+  get_evac_bucket(off_t bucket) const
+  {
+    return this->preserved_dirs.evacuate[bucket];
+  }
+
+  void
+  force_evacuate_head(Dir const *evac_dir, int pinned)
+  {
+    return this->preserved_dirs.force_evacuate_head(evac_dir, pinned);
+  }
+
+  PreservationTable &
+  get_preserved_dirs()
+  {
+    return this->preserved_dirs;
+  }
+
 private:
+  mutable PreservationTable preserved_dirs;
+
   int _agg_copy(CacheVC *vc);
   int _copy_writer_to_aggregation(CacheVC *vc);
   int _copy_evacuator_to_aggregation(CacheVC *vc);

--- a/src/iocore/cache/PreservationTable.cc
+++ b/src/iocore/cache/PreservationTable.cc
@@ -40,6 +40,12 @@ DbgCtl dbg_ctl_cache_evac{"cache_evac"};
 
 } // namespace
 
+EvacuationBlock *
+PreservationTable::find(Dir const &dir) const
+{
+  return this->find(dir, dir_evac_bucket(&dir));
+}
+
 void
 PreservationTable::force_evacuate_head(Dir const *evac_dir, int pinned)
 {
@@ -51,7 +57,7 @@ PreservationTable::force_evacuate_head(Dir const *evac_dir, int pinned)
   }
 
   // build an evacuation block for the object
-  EvacuationBlock *b = evacuation_block_exists(evac_dir, this);
+  EvacuationBlock *b = this->find(*evac_dir);
   // if we have already started evacuating this document, its too late
   // to evacuate the head...bad luck
   if (b && b->f.done) {

--- a/src/iocore/cache/PreservationTable.cc
+++ b/src/iocore/cache/PreservationTable.cc
@@ -43,7 +43,12 @@ DbgCtl dbg_ctl_cache_evac{"cache_evac"};
 EvacuationBlock *
 PreservationTable::find(Dir const &dir) const
 {
-  return this->find(dir, dir_evac_bucket(&dir));
+  int bucket{dir_evac_bucket(&dir)};
+  if (this->evac_bucket_valid(bucket)) {
+    return this->find(dir, bucket);
+  } else {
+    return nullptr;
+  }
 }
 
 void

--- a/src/iocore/cache/PreservationTable.cc
+++ b/src/iocore/cache/PreservationTable.cc
@@ -43,7 +43,7 @@ DbgCtl dbg_ctl_cache_evac{"cache_evac"};
 EvacuationBlock *
 PreservationTable::find(Dir const &dir) const
 {
-  int bucket{dir_evac_bucket(&dir)};
+  auto bucket{dir_evac_bucket(&dir)};
   if (this->evac_bucket_valid(bucket)) {
     return this->find(dir, bucket);
   } else {

--- a/src/iocore/cache/PreservationTable.cc
+++ b/src/iocore/cache/PreservationTable.cc
@@ -71,7 +71,7 @@ PreservationTable::force_evacuate_head(Dir const *evac_dir, int pinned)
 }
 
 int
-PreservationTable::acquire(Dir const &dir, CacheKey const &key) const
+PreservationTable::acquire(Dir const &dir, CacheKey const &key)
 {
   int bucket = dir_evac_bucket(&dir);
   if (EvacuationBlock * b{this->find(dir, bucket)}; nullptr != b) {
@@ -91,7 +91,7 @@ PreservationTable::acquire(Dir const &dir, CacheKey const &key) const
 }
 
 void
-PreservationTable::release(Dir const &dir) const
+PreservationTable::release(Dir const &dir)
 {
   int bucket = dir_evac_bucket(&dir);
   if (EvacuationBlock * b{this->find(dir, bucket)}; nullptr != b) {

--- a/src/iocore/cache/PreservationTable.h
+++ b/src/iocore/cache/PreservationTable.h
@@ -116,6 +116,14 @@ public:
   void force_evacuate_head(Dir const *evac_dir, int pinned);
 
   /**
+   * Find the evacuation block corresponding to @a dir.
+   *
+   * @param dir The directory entry to search for.
+   * @return Returns the corresponding block if it exists, nullptr otherwise.
+   */
+  EvacuationBlock *find(Dir const &dir) const;
+
+  /**
    * Acquire the evacuation block for @a dir.
    *
    * Any number of readers may acquire the block at a time to prevent the
@@ -170,21 +178,6 @@ PreservationTable::evac_bucket_valid(off_t bucket) const
 
 extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;
 extern ClassAllocator<EvacuationKey>   evacuationKeyAllocator;
-
-inline EvacuationBlock *
-evacuation_block_exists(Dir const *dir, PreservationTable *stripe)
-{
-  auto bucket = dir_evac_bucket(dir);
-  if (stripe->evac_bucket_valid(bucket)) {
-    EvacuationBlock *b = stripe->evacuate[bucket].head;
-    for (; b; b = b->link.next) {
-      if (dir_offset(&b->dir) == dir_offset(dir)) {
-        return b;
-      }
-    }
-  }
-  return nullptr;
-}
 
 inline EvacuationBlock *
 new_EvacuationBlock()

--- a/src/iocore/cache/PreservationTable.h
+++ b/src/iocore/cache/PreservationTable.h
@@ -129,6 +129,22 @@ protected:
    */
   int acquire(Dir const &dir, CacheKey const &key) const;
 
+  /** Release the evacuation block for @a dir.
+   *
+   * When a block has been released once for every time it was acquired, it
+   * may be removed from the table, invalidating all pointers to it. Note that
+   * releasing more than once from the same reader may cause the block to be
+   * removed from the table while other readers that acquired it think it's
+   * valid. Be careful.
+   *
+   * A block that was evacuated with force_evacuate_head will not be removed
+   * from the table when it is released.
+   *
+   * @param dir The directory entry to release.
+   * @see force_evacuate_head
+   */
+  void release(Dir const &dir) const;
+
   /**
    * Remove completed documents from the table and add pinned documents.
    *

--- a/src/iocore/cache/PreservationTable.h
+++ b/src/iocore/cache/PreservationTable.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "AggregateWriteBuffer.h"
+#include "iocore/cache/CacheDefs.h"
 #include "P_CacheDir.h"
 #include "Stripe.h"
 
@@ -116,7 +117,23 @@ protected:
   int evacuate_size{};
 
   /**
+   * Acquire the evacuation block for @a dir.
+   *
+   * Any number of readers may acquire the block at a time to prevent the
+   * block from being removed from the table. If no block for the directory
+   * entry is in the table yet, one will be added with @a key.
+   *
+   * @param dir The directory entry to acquire.
+   * @param key The key for the directory entry.
+   * @return Returns 1 if a new block was created, otherwise 0.
+   */
+  int acquire(Dir const &dir, CacheKey const &key) const;
+
+  /**
    * Remove completed documents from the table and add pinned documents.
+   *
+   * Documents that were acquired by a reader and not released are not removed.
+   * Invalidates pointers to evacuation blocks unless they have been acquired.
    *
    * @param Stripe The stripe to scan for pinned documents to preserve.
    */

--- a/src/iocore/cache/PreservationTable.h
+++ b/src/iocore/cache/PreservationTable.h
@@ -90,6 +90,8 @@ struct EvacuationBlock {
 class PreservationTable
 {
 public:
+  int evacuate_size{};
+
   /**
    * The table of preserved documents.
    *
@@ -113,9 +115,6 @@ public:
    */
   void force_evacuate_head(Dir const *evac_dir, int pinned);
 
-protected:
-  int evacuate_size{};
-
   /**
    * Acquire the evacuation block for @a dir.
    *
@@ -127,7 +126,7 @@ protected:
    * @param key The key for the directory entry.
    * @return Returns 1 if a new block was created, otherwise 0.
    */
-  int acquire(Dir const &dir, CacheKey const &key) const;
+  int acquire(Dir const &dir, CacheKey const &key);
 
   /** Release the evacuation block for @a dir.
    *
@@ -143,7 +142,7 @@ protected:
    * @param dir The directory entry to release.
    * @see force_evacuate_head
    */
-  void release(Dir const &dir) const;
+  void release(Dir const &dir);
 
   /**
    * Remove completed documents from the table and add pinned documents.

--- a/src/iocore/cache/PreservationTable.h
+++ b/src/iocore/cache/PreservationTable.h
@@ -159,6 +159,8 @@ private:
   void cleanup(Stripe const *stripe);
   void remove_finished_blocks(Stripe const *stripe, int bucket);
   void scan_for_pinned_documents(Stripe const *stripe);
+
+  EvacuationBlock *find(Dir const &dir, int bucket) const;
 };
 
 inline bool

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -1261,7 +1261,7 @@ evacuate_fragments(CacheKey *key, CacheKey *earliest_key, int force, StripeSM *s
     if (dir_head(&dir)) {
       continue;
     }
-    EvacuationBlock *b = evacuation_block_exists(&dir, &stripe->get_preserved_dirs());
+    EvacuationBlock *b = stripe->get_preserved_dirs().find(dir);
     if (!b) {
       b                          = new_EvacuationBlock();
       b->dir                     = dir;

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -130,25 +130,9 @@ StripeSM::close_read(CacheVC *cont) const
   EThread *t = cont->mutex->thread_holding;
   ink_assert(t == this_ethread());
   ink_assert(t == mutex->thread_holding);
-  if (dir_is_empty(&cont->earliest_dir)) {
-    return 1;
+  if (!dir_is_empty(&cont->earliest_dir)) {
+    release(cont->earliest_dir);
   }
-  int              i = dir_evac_bucket(&cont->earliest_dir);
-  EvacuationBlock *b;
-  for (b = evacuate[i].head; b;) {
-    EvacuationBlock *next = b->link.next;
-    if (dir_offset(&b->dir) != dir_offset(&cont->earliest_dir)) {
-      b = next;
-      continue;
-    }
-    if (b->readers && !--b->readers) {
-      evacuate[i].remove(b);
-      free_EvacuationBlock(b);
-      break;
-    }
-    b = next;
-  }
-
   return 1;
 }
 

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -121,7 +121,7 @@ StripeSM::begin_read(CacheVC *cont) const
   if (cont->f.single_fragment) {
     return 0;
   }
-  return acquire(cont->earliest_dir, cont->earliest_key);
+  return this->preserved_dirs.acquire(cont->earliest_dir, cont->earliest_key);
 }
 
 int
@@ -131,7 +131,7 @@ StripeSM::close_read(CacheVC *cont) const
   ink_assert(t == this_ethread());
   ink_assert(t == mutex->thread_holding);
   if (!dir_is_empty(&cont->earliest_dir)) {
-    release(cont->earliest_dir);
+    this->preserved_dirs.release(cont->earliest_dir);
   }
   return 1;
 }
@@ -179,10 +179,10 @@ StripeSM::init(char *s, off_t blocks, off_t dir_skip, bool clear)
   data_blocks         = (len - (start - skip)) / STORE_BLOCK_SIZE;
   hit_evacuate_window = (data_blocks * cache_config_hit_evacuate_percent) / 100;
 
-  evacuate_size = static_cast<int>(len / EVACUATION_BUCKET_SIZE) + 2;
-  int evac_len  = evacuate_size * sizeof(DLL<EvacuationBlock>);
-  evacuate      = static_cast<DLL<EvacuationBlock> *>(ats_malloc(evac_len));
-  memset(static_cast<void *>(evacuate), 0, evac_len);
+  this->preserved_dirs.evacuate_size = static_cast<int>(len / EVACUATION_BUCKET_SIZE) + 2;
+  int evac_len                       = this->preserved_dirs.evacuate_size * sizeof(DLL<EvacuationBlock>);
+  this->preserved_dirs.evacuate      = static_cast<DLL<EvacuationBlock> *>(ats_malloc(evac_len));
+  memset(static_cast<void *>(this->preserved_dirs.evacuate), 0, evac_len);
 
   Dbg(dbg_ctl_cache_init, "Vol %s: allocating %zu directory bytes for a %lld byte volume (%lf%%)", hash_text.get(), dirlen(),
       (long long)this->len, (double)dirlen() / (double)this->len * 100.0);
@@ -630,7 +630,7 @@ StripeSM::handle_recover_write_dir(int /* event ATS_UNUSED */, void * /* data AT
   set_io_not_in_progress();
   scan_pos = header->write_pos;
   ink_assert(this->mutex->thread_holding == this_ethread());
-  periodic_scan(this);
+  this->preserved_dirs.periodic_scan(this);
   SET_HANDLER(&StripeSM::dir_init_done);
   return dir_init_done(EVENT_IMMEDIATE, nullptr);
 }
@@ -750,7 +750,7 @@ StripeSM::aggWriteDone(int event, Event *e)
     ink_assert(header->write_pos == header->agg_pos);
     if (header->write_pos + EVACUATION_SIZE > scan_pos) {
       ink_assert(this->mutex->thread_holding == this_ethread());
-      periodic_scan(this);
+      this->preserved_dirs.periodic_scan(this);
     }
     this->_write_buffer.reset_buffer_pos();
     header->write_serial++;
@@ -1107,7 +1107,7 @@ StripeSM::agg_wrap()
     Note("Cache volume %d on disk '%s' wraps around", stripe->cache_vol->vol_number, stripe->hash_text.get());
   }
   ink_assert(this->mutex->thread_holding == this_ethread());
-  periodic_scan(this);
+  this->preserved_dirs.periodic_scan(this);
 }
 
 int
@@ -1119,7 +1119,7 @@ StripeSM::evac_range(off_t low, off_t high, int evac_phase)
   int   ei = dir_offset_evac_bucket(e);
 
   for (int i = si; i <= ei; i++) {
-    EvacuationBlock *b            = evacuate[i].head;
+    EvacuationBlock *b            = this->preserved_dirs.evacuate[i].head;
     EvacuationBlock *first        = nullptr;
     int64_t          first_offset = INT64_MAX;
     for (; b; b = b->link.next) {
@@ -1179,7 +1179,7 @@ StripeSM::evacuateDocReadDone(int event, Event *e)
        (int)dir_offset(&doc_evacuator->overwrite_dir));
 
   if (evac_bucket_valid(bucket)) {
-    b = evacuate[bucket].head;
+    b = this->preserved_dirs.evacuate[bucket].head;
   }
   while (b) {
     if (dir_offset(&b->dir) == dir_offset(&doc_evacuator->overwrite_dir)) {
@@ -1261,13 +1261,13 @@ evacuate_fragments(CacheKey *key, CacheKey *earliest_key, int force, StripeSM *s
     if (dir_head(&dir)) {
       continue;
     }
-    EvacuationBlock *b = evacuation_block_exists(&dir, stripe);
+    EvacuationBlock *b = evacuation_block_exists(&dir, &stripe->get_preserved_dirs());
     if (!b) {
       b                          = new_EvacuationBlock();
       b->dir                     = dir;
       b->evac_frags.key          = *key;
       b->evac_frags.earliest_key = *earliest_key;
-      stripe->evacuate[dir_evac_bucket(&dir)].push(b);
+      stripe->get_evac_bucket(dir_evac_bucket(&dir)).push(b);
       i++;
     } else {
       ink_assert(dir_offset(&dir) == dir_offset(&b->dir));

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -121,25 +121,7 @@ StripeSM::begin_read(CacheVC *cont) const
   if (cont->f.single_fragment) {
     return 0;
   }
-  int              i = dir_evac_bucket(&cont->earliest_dir);
-  EvacuationBlock *b;
-  for (b = evacuate[i].head; b; b = b->link.next) {
-    if (dir_offset(&b->dir) != dir_offset(&cont->earliest_dir)) {
-      continue;
-    }
-    if (b->readers) {
-      b->readers = b->readers + 1;
-    }
-    return 0;
-  }
-  // we don't actually need to preserve this block as it is already in
-  // memory, but this is easier, and evacuations are rare
-  b                 = new_EvacuationBlock();
-  b->readers        = 1;
-  b->dir            = cont->earliest_dir;
-  b->evac_frags.key = cont->earliest_key;
-  evacuate[i].push(b);
-  return 1;
+  return acquire(cont->earliest_dir, cont->earliest_key);
 }
 
 int

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -125,8 +125,8 @@ init_stripe_for_writing(StripeSM &stripe, StripteHeaderFooter &header, CacheVol 
   stripe.raw_dir     = static_cast<char *>(ats_memalign(ats_pagesize(), stripe.dirlen()));
   stripe.dir         = reinterpret_cast<Dir *>(stripe.raw_dir + stripe.headerlen());
 
-  stripe.evacuate = static_cast<DLL<EvacuationBlock> *>(ats_malloc(2024));
-  memset(static_cast<void *>(stripe.evacuate), 0, 2024);
+  stripe.get_preserved_dirs().evacuate = static_cast<DLL<EvacuationBlock> *>(ats_malloc(2024));
+  memset(static_cast<void *>(stripe.get_preserved_dirs().evacuate), 0, 2024);
 
   header.write_pos = 50000;
   header.agg_pos   = 1;
@@ -295,7 +295,7 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
   }
 
   ats_free(stripe.raw_dir);
-  ats_free(stripe.evacuate);
+  ats_free(stripe.get_preserved_dirs().evacuate);
 }
 
 // When f.evacuator is set, vc.buf must contain a Doc object including headers
@@ -392,5 +392,5 @@ TEST_CASE("aggWrite behavior with f.evacuator set")
 
   delete[] source;
   ats_free(stripe.raw_dir);
-  ats_free(stripe.evacuate);
+  ats_free(stripe.get_preserved_dirs().evacuate);
 }


### PR DESCRIPTION
This adds the following methods:

* find(Dir const &)
* acquire(Dir const&, CacheKey const&)
* release(Dir const&)

The latter two are used for reference counting readers of documents so that the documents will be preserved while they're open for reading.