### PR TITLE
Changes all of Cripts to be in cripts:: namespace

### DIFF
--- a/doc/developer-guide/cripts/cripts-bundles.en.rst
+++ b/doc/developer-guide/cripts/cripts-bundles.en.rst
@@ -41,14 +41,14 @@ does *not* exclude doing additional hooks in the Cript itself.
 
 The following bundles are available in the core today:
 
-============================   ====================================================================
-Bundle                         Description
-============================   ====================================================================
-``Bundle::Common``             For DSCP and an overridable Cache-Control header.
-``Bundle::LogsMetrics``        Log sampling, TCPInfo  and per-remap metrics.
-``Bundle::Headers``            For removing or adding headers.
-``Bundle::Caching``            Various cache controlling behavior.
-============================   ====================================================================
+===================================   ====================================================================
+Bundle                                Description
+===================================   ====================================================================
+``Cript::Bundle::Common``             For DSCP and an overridable Cache-Control header.
+``Cript::Bundle::LogsMetrics``        Log sampling, TCPInfo  and per-remap metrics.
+``Cript::Bundle::Headers``            For removing or adding headers.
+``Cript::Bundle::Caching``            Various cache controlling behavior.
+===================================   ====================================================================
 
 This example shows how a Cript would enable both of these bundles with all features:
 
@@ -61,17 +61,17 @@ This example shows how a Cript would enable both of these bundles with all featu
 
    do_create_instance()
    {
-     Bundle::Common::Activate().dscp(10)
-                               .via_header("client", "basic")
-                               .set_config({{"proxy.config.srv_enabled", 0},
-                                            {"proxy.config.http.response_server_str", "ATS"});
+     Cript::Bundle::Common::Activate().dscp(10)
+                                      .via_header("client", "basic")
+                                      .set_config({{"proxy.config.srv_enabled", 0},
+                                                   {"proxy.config.http.response_server_str", "ATS"});
 
-     Bundle::LogsMetrics::Activate().logsample(100)
-                                    .tcpinfo(true)
-                                    .propstats("example.com");
+     Cript::Bundle::LogsMetrics::Activate().logsample(100)
+                                           .tcpinfo(true)
+                                           .propstats("example.com");
 
-     Bundle::Caching::Activate().cache_control("max-age=259200")
-                                .disable(true)
+     Cript::Bundle::Caching::Activate().cache_control("max-age=259200")
+                                       .disable(true)
 
    }
 
@@ -91,7 +91,7 @@ to make a list.
 Via Header
 ==========
 
-The ``Bundle::Common`` bundle has a function called ``via_header()`` that adds a Via header to the
+The ``Cript::Bundle::Common`` bundle has a function called ``via_header()`` that adds a Via header to the
 client response or the origin request. The first argument is ``client`` or ``origin``, and the second
 argument is the type of Via header to be used:
 
@@ -110,9 +110,9 @@ Type                           Description
 Headers
 =======
 
-Even though adding or removing headers in Cripts is very straight forward, we've added the ``Bundle::Headers``
-for not only convenience, but also for easier integration and migratino with existing configurations. There
-are two main functions in this bundle:
+Even though adding or removing headers in Cripts is very straight forward, we've added the
+``Cript::Bundle::Headers`` for not only convenience, but also for easier integration and
+migration with existing configurations. There are two main functions in this bundle:
 
 - ``rm_headers()``: Add a header to the request or response.
 - ``add_headers()``: Remove a header from the request or response.
@@ -128,8 +128,8 @@ operators from the ``header_rewrite`` plugin. For example:
 
    do_create_instance()
    {
-     Bundle::Headers::Activate().rm_headers({"X-Header1", "X-Header2"})
-                                .add_headers({{"X-Header3", "value3"},
-                                              {"X-Header4", "%{FROM-URL:PATH}"},
-                                              {"X-Header5", "%{ID:UNIQUE}"} });
+     Cript::Bundle::Headers::Activate().rm_headers({"X-Header1", "X-Header2"})
+                                       .add_headers({{"X-Header3", "value3"},
+                                                     {"X-Header4", "%{FROM-URL:PATH}"},
+                                                     {"X-Header5", "%{ID:UNIQUE}"} });
    }

--- a/doc/developer-guide/cripts/cripts-bundles.en.rst
+++ b/doc/developer-guide/cripts/cripts-bundles.en.rst
@@ -44,10 +44,10 @@ The following bundles are available in the core today:
 ===================================   ====================================================================
 Bundle                                Description
 ===================================   ====================================================================
-``Cript::Bundle::Common``             For DSCP and an overridable Cache-Control header.
-``Cript::Bundle::LogsMetrics``        Log sampling, TCPInfo  and per-remap metrics.
-``Cript::Bundle::Headers``            For removing or adding headers.
-``Cript::Bundle::Caching``            Various cache controlling behavior.
+``cripts::Bundle::Common``            For DSCP and an overridable Cache-Control header.
+``cripts::Bundle::LogsMetrics``       Log sampling, TCPInfo  and per-remap metrics.
+``cripts::Bundle::Headers``           For removing or adding headers.
+``cripts::Bundle::Caching``           Various cache controlling behavior.
 ===================================   ====================================================================
 
 This example shows how a Cript would enable both of these bundles with all features:
@@ -61,17 +61,17 @@ This example shows how a Cript would enable both of these bundles with all featu
 
    do_create_instance()
    {
-     Cript::Bundle::Common::Activate().dscp(10)
-                                      .via_header("client", "basic")
-                                      .set_config({{"proxy.config.srv_enabled", 0},
-                                                   {"proxy.config.http.response_server_str", "ATS"});
+     cripts::Bundle::Common::Activate().dscp(10)
+                                       .via_header("client", "basic")
+                                       .set_config({{"proxy.config.srv_enabled", 0},
+                                                    {"proxy.config.http.response_server_str", "ATS"});
 
-     Cript::Bundle::LogsMetrics::Activate().logsample(100)
-                                           .tcpinfo(true)
-                                           .propstats("example.com");
+     cripts::Bundle::LogsMetrics::Activate().logsample(100)
+                                            .tcpinfo(true)
+                                            .propstats("example.com");
 
-     Cript::Bundle::Caching::Activate().cache_control("max-age=259200")
-                                       .disable(true)
+     cripts::Bundle::Caching::Activate().cache_control("max-age=259200")
+                                        .disable(true)
 
    }
 
@@ -91,7 +91,7 @@ to make a list.
 Via Header
 ==========
 
-The ``Cript::Bundle::Common`` bundle has a function called ``via_header()`` that adds a Via header to the
+The ``cripts::Bundle::Common`` bundle has a function called ``via_header()`` that adds a Via header to the
 client response or the origin request. The first argument is ``client`` or ``origin``, and the second
 argument is the type of Via header to be used:
 
@@ -111,7 +111,7 @@ Headers
 =======
 
 Even though adding or removing headers in Cripts is very straight forward, we've added the
-``Cript::Bundle::Headers`` for not only convenience, but also for easier integration and
+``cripts::Bundle::Headers`` for not only convenience, but also for easier integration and
 migration with existing configurations. There are two main functions in this bundle:
 
 - ``rm_headers()``: Add a header to the request or response.
@@ -128,8 +128,8 @@ operators from the ``header_rewrite`` plugin. For example:
 
    do_create_instance()
    {
-     Cript::Bundle::Headers::Activate().rm_headers({"X-Header1", "X-Header2"})
-                                       .add_headers({{"X-Header3", "value3"},
-                                                     {"X-Header4", "%{FROM-URL:PATH}"},
-                                                     {"X-Header5", "%{ID:UNIQUE}"} });
+     cripts::Bundle::Headers::Activate().rm_headers({"X-Header1", "X-Header2"})
+                                        .add_headers({{"X-Header3", "value3"},
+                                                      {"X-Header4", "%{FROM-URL:PATH}"},
+                                                      {"X-Header5", "%{ID:UNIQUE}"} });
    }

--- a/doc/developer-guide/cripts/cripts-connections.en.rst
+++ b/doc/developer-guide/cripts/cripts-connections.en.rst
@@ -33,8 +33,8 @@ implies that access to these objects must be ``borrowed``.
 
    do_remap()
    {
-     static Cript::Matcher::Range::IP ALLOW_LIST({"192.168.201.0/24", "10.0.0.0/8"});
-     borrow conn = Cript::Client::Connection::Get();
+     static cripts::Matcher::Range::IP ALLOW_LIST({"192.168.201.0/24", "10.0.0.0/8"});
+     borrow conn = cripts::Client::Connection::Get();
      auto client_ip = conn.IP();
 
      if (!ALLOW_LIST.contains(client_ip)) {
@@ -44,14 +44,14 @@ implies that access to these objects must be ``borrowed``.
 
 There are two kinds of connections provided by the run-time system:
 
-==============================   =========================================================================
-Connection Object                Description
-==============================   =========================================================================
-``Cript::Client::Connection``    The connection from the client to the ATS server.
-``Cript::Server::Connection``    The connection from ATS to parent or origin server.
-==============================   =========================================================================
+================================   =========================================================================
+Connection Object                  Description
+================================   =========================================================================
+``cripts::Client::Connection``     The connection from the client to the ATS server.
+``cripts::Server::Connection``     The connection from ATS to parent or origin server.
+================================   =========================================================================
 
-As usual, the ``Cript::Server::Connection`` object is only available assuming that the request
+As usual, the ``cripts::Server::Connection`` object is only available assuming that the request
 is a forward proxy request, and you borrow it with the ``Get()`` method. On cache misses,
 there is no such connection.
 
@@ -81,7 +81,7 @@ IPv4 and IPv6 CIDR sizes. For example:
 
    do_remap()
    {
-     borrow conn = Cript::Client::Connection::Get();
+     borrow conn = cripts::Client::Connection::Get();
      auto ip = conn.IP();
 
      CDebug("Client IP CIDR: {}", ip.string(24, 64));
@@ -108,7 +108,7 @@ For other advanced features, a Cript has access to the socket file descriptor, v
 method of the connection object.
 
 .. note::
-   For pacing, the special value ``Cript::Pacing::Off`` can be used to disable pacing.
+   For pacing, the special value ``cripts::Pacing::Off`` can be used to disable pacing.
 
 Lets show an example of how one could use these variables:
 
@@ -116,7 +116,7 @@ Lets show an example of how one could use these variables:
 
    do_remap()
    {
-     borrow conn = Cript::Client::Connection::Get();
+     borrow conn = cripts::Client::Connection::Get();
 
      conn.congestion = "bbrv2";
      conn.pacing = 100;

--- a/doc/developer-guide/cripts/cripts-connections.en.rst
+++ b/doc/developer-guide/cripts/cripts-connections.en.rst
@@ -33,8 +33,8 @@ implies that access to these objects must be ``borrowed``.
 
    do_remap()
    {
-     static Matcher::Range::IP ALLOW_LIST({"192.168.201.0/24", "10.0.0.0/8"});
-     borrow conn = Client::Connection::Get();
+     static Cript::Matcher::Range::IP ALLOW_LIST({"192.168.201.0/24", "10.0.0.0/8"});
+     borrow conn = Cript::Client::Connection::Get();
      auto client_ip = conn.IP();
 
      if (!ALLOW_LIST.contains(client_ip)) {
@@ -44,14 +44,14 @@ implies that access to these objects must be ``borrowed``.
 
 There are two kinds of connections provided by the run-time system:
 
-=======================   =========================================================================
-Connection Object           Description
-=======================   =========================================================================
-``Client::Connection``    The connection from the client to the ATS server.
-``Server::Connection``    The connection from ATS to parent or origin server.
-=======================   =========================================================================
+==============================   =========================================================================
+Connection Object                Description
+==============================   =========================================================================
+``Cript::Client::Connection``    The connection from the client to the ATS server.
+``Cript::Server::Connection``    The connection from ATS to parent or origin server.
+==============================   =========================================================================
 
-As usual, the ``Server::Connection`` object is only available assuming that the request
+As usual, the ``Cript::Server::Connection`` object is only available assuming that the request
 is a forward proxy request, and you borrow it with the ``Get()`` method. On cache misses,
 there is no such connection.
 
@@ -81,7 +81,7 @@ IPv4 and IPv6 CIDR sizes. For example:
 
    do_remap()
    {
-     borrow conn = Client::Connection::Get();
+     borrow conn = Cript::Client::Connection::Get();
      auto ip = conn.IP();
 
      CDebug("Client IP CIDR: {}", ip.string(24, 64));
@@ -116,7 +116,7 @@ Lets show an example of how one could use these variables:
 
    do_remap()
    {
-     borrow conn = Client::Connection::Get();
+     borrow conn = Cript::Client::Connection::Get();
 
      conn.congestion = "bbrv2";
      conn.pacing = 100;

--- a/doc/developer-guide/cripts/cripts-crypto.en.rst
+++ b/doc/developer-guide/cripts/cripts-crypto.en.rst
@@ -40,10 +40,10 @@ Hash
 =================================   ===============================================================
 Object                              Description
 =================================   ===============================================================
-``Crypto::MD5``                     MD5 hashing.
-``Crypto::SHA256``                  SHA256 hashing.
-``Crypto::SHA512``                  SHA512 hashing.
-``Crypto::HMAC::SHA256``            HMAC-SHA256 hashing.
+``Cript::Crypto::MD5``              MD5 hashing.
+``Cript::Crypto::SHA256``           SHA256 hashing.
+``Cript::Crypto::SHA512``           SHA512 hashing.
+``Cript::Crypto::HMAC::SHA256``     HMAC-SHA256 hashing.
 =================================   ===============================================================
 
 These objects all provide a ``Encode()`` and ``Decode()`` method, to hash and unhash strings.
@@ -53,7 +53,7 @@ Examples:
 
    do_remap()
    {
-     CDebug("SHA256 = {}", Crypto::SHA256::Encode("Hello World"));
+     CDebug("SHA256 = {}", Cript::Crypto::SHA256::Encode("Hello World"));
    }
 
 .. _cripts-misc-crypto-encryption:
@@ -69,7 +69,7 @@ is provided to retrieve the final encrypted data.
 =================================   ===============================================================
 Object                              Description
 =================================   ===============================================================
-``Crypto::AES256``                  AES256 encryption and decryption.
+``Cript::Crypto::AES256``           AES256 encryption and decryption.
 =================================   ===============================================================
 
 .. _cripts-misc-crypto-encoding:
@@ -83,8 +83,8 @@ as a URL escaping object, ``Escape``.
 =================================   ===============================================================
 Object                              Description
 =================================   ===============================================================
-``Crypto::Base64``                  Methods for Base64 encoding.
-``Crypto::Escape``                  Methods for URL escaping.
+``Cript::Crypto::Base64``           Methods for Base64 encoding.
+``Cript::Crypto::Escape``           Methods for URL escaping.
 =================================   ===============================================================
 
 These objects all provide a ``Encode()`` and ``Decode()`` method, to encode and decode strings.

--- a/doc/developer-guide/cripts/cripts-crypto.en.rst
+++ b/doc/developer-guide/cripts/cripts-crypto.en.rst
@@ -40,10 +40,10 @@ Hash
 =================================   ===============================================================
 Object                              Description
 =================================   ===============================================================
-``Cript::Crypto::MD5``              MD5 hashing.
-``Cript::Crypto::SHA256``           SHA256 hashing.
-``Cript::Crypto::SHA512``           SHA512 hashing.
-``Cript::Crypto::HMAC::SHA256``     HMAC-SHA256 hashing.
+``cripts::Crypto::MD5``             MD5 hashing.
+``cripts::Crypto::SHA256``          SHA256 hashing.
+``cripts::Crypto::SHA512``          SHA512 hashing.
+``cripts::Crypto::HMAC::SHA256``    HMAC-SHA256 hashing.
 =================================   ===============================================================
 
 These objects all provide a ``Encode()`` and ``Decode()`` method, to hash and unhash strings.
@@ -53,7 +53,7 @@ Examples:
 
    do_remap()
    {
-     CDebug("SHA256 = {}", Cript::Crypto::SHA256::Encode("Hello World"));
+     CDebug("SHA256 = {}", cripts::Crypto::SHA256::Encode("Hello World"));
    }
 
 .. _cripts-misc-crypto-encryption:
@@ -69,7 +69,7 @@ is provided to retrieve the final encrypted data.
 =================================   ===============================================================
 Object                              Description
 =================================   ===============================================================
-``Cript::Crypto::AES256``           AES256 encryption and decryption.
+``cripts::Crypto::AES256``          AES256 encryption and decryption.
 =================================   ===============================================================
 
 .. _cripts-misc-crypto-encoding:
@@ -83,8 +83,8 @@ as a URL escaping object, ``Escape``.
 =================================   ===============================================================
 Object                              Description
 =================================   ===============================================================
-``Cript::Crypto::Base64``           Methods for Base64 encoding.
-``Cript::Crypto::Escape``           Methods for URL escaping.
+``cripts::Crypto::Base64``          Methods for Base64 encoding.
+``cripts::Crypto::Escape``          Methods for URL escaping.
 =================================   ===============================================================
 
 These objects all provide a ``Encode()`` and ``Decode()`` method, to encode and decode strings.

--- a/doc/developer-guide/cripts/cripts-headers.en.rst
+++ b/doc/developer-guide/cripts/cripts-headers.en.rst
@@ -30,32 +30,32 @@ system, and must always be borrowed. The pattern for this is as follows:
 
 .. code-block:: cpp
 
-  borrow req = Cript::Client::Request::Get();
+  borrow req = cripts::Client::Request::Get();
 
   auto foo = req["X-Foo"];
 
 There are four types of headers that can be borrowed:
 
-============================   ===========================================================================
-Header Object                  Description
-============================   ===========================================================================
-``Cript::Client::Request``     The client request headers. Always available.
-``Cript::Client::Response``    The client response headers.
-``Cript::Server::Request``     The server request headers.
-``Cript::Server::Response``    The server response headers.
-============================   ===========================================================================
+=============================   ===========================================================================
+Header Object                   Description
+=============================   ===========================================================================
+``cripts::Client::Request``     The client request headers. Always available.
+``cripts::Client::Response``    The client response headers.
+``cripts::Server::Request``     The server request headers.
+``cripts::Server::Response``    The server response headers.
+=============================   ===========================================================================
 
 .. note::
 
-   For all of these headers, except the ``Cript::Client::Request``, the headers are not
-   available until the respective hook is called. For example, the ``Cript::Client::Response`` headers
+   For all of these headers, except the ``cripts::Client::Request``, the headers are not
+   available until the respective hook is called. For example, the ``cripts::Client::Response`` headers
    are not available until the response headers are received from the origin server or cache lookup.
 
 Assigning the empty value (``""``) to a header will remove it from the header list. For example:
 
 .. code-block:: cpp
 
-  borrow req = Cript::Client::Request::Get();
+  borrow req = cripts::Client::Request::Get();
 
   req["X-Foo"] = "bar"; // Set the header
   req["X-Fie"] = "";    // Remove the header
@@ -64,7 +64,7 @@ A header can also be removed by using the ``Erase`` method, which is a little mo
 
 .. code-block:: cpp
 
-  borrow req = Cript::Client::Request::Get();
+  borrow req = cripts::Client::Request::Get();
 
   req.Erase("X-Foo");
 
@@ -80,7 +80,7 @@ a pattern such as the following example:
 
 .. code-block:: cpp
 
-  borrow req = Cript::Client::Request::Get();
+  borrow req = cripts::Client::Request::Get();
 
   for (auto header : req) {
     CDebug("Header: {}: {}", header, req[header]); // This will print all headers and their values
@@ -95,31 +95,31 @@ Methods
 -------
 
 In addition to holding all the request headers, the request objects also holds the ``method`` verb.
-For the ``Cript::Client::Request`` object, this is the client request method (GET, POST, etc.). For the
-``Cript::Server::Request`` object, this is the method that will be sent to the origin server (GET, POST, etc.).
+For the ``cripts::Client::Request`` object, this is the client request method (GET, POST, etc.). For the
+``cripts::Server::Request`` object, this is the method that will be sent to the origin server (GET, POST, etc.).
 
 Cripts provides the following convenience symbols for common methods (and performance):
 
-==========================   ======================================================================
-Method                       Description
-==========================   ======================================================================
-``Cript::Method::GET``       The GET method.
-``Cript::Method::POST``      The POST method.
-``Cript::Method::PUT``       The PUT method.
-``Cript::Method::DELETE``    The DELETE method.
-``Cript::Method::HEAD``      The HEAD method.
-``Cript::Method::OPTIONS``   The OPTIONS method.
-``Cript::Method::CONNECT``   The CONNECT method.
-``Cript::Method::TRACE``     The TRACE method.
-==========================   ======================================================================
+============================   ======================================================================
+Method                         Description
+============================   ======================================================================
+``cripts::Method::GET``        The GET method.
+``cripts::Method::POST``       The POST method.
+``cripts::Method::PUT``        The PUT method.
+``cripts::Method::DELETE``     The DELETE method.
+``cripts::Method::HEAD``       The HEAD method.
+``cripts::Method::OPTIONS``    The OPTIONS method.
+``cripts::Method::CONNECT``    The CONNECT method.
+``cripts::Method::TRACE``      The TRACE method.
+============================   ======================================================================
 
 These symbols can be used to compare against the method in the request object. For example:
 
 .. code-block:: cpp
 
-  borrow req = Cript::Client::Request::Get();
+  borrow req = cripts::Client::Request::Get();
 
-  if (req.method == Cript::Method::GET) {
+  if (req.method == cripts::Method::GET) {
       // Do something
   }
 
@@ -157,7 +157,7 @@ fresh or stale. Example usage of the cache status:
 .. code-block:: cpp
 
   do_read_response() {
-    borrow resp = Cript::Server::Response::Get();
+    borrow resp = cripts::Server::Response::Get();
 
     if (resp.cache == "miss") {
       // Do something

--- a/doc/developer-guide/cripts/cripts-headers.en.rst
+++ b/doc/developer-guide/cripts/cripts-headers.en.rst
@@ -30,32 +30,32 @@ system, and must always be borrowed. The pattern for this is as follows:
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::Get();
+  borrow req = Cript::Client::Request::Get();
 
   auto foo = req["X-Foo"];
 
 There are four types of headers that can be borrowed:
 
-=====================   ===========================================================================
-Header Object           Description
-=====================   ===========================================================================
-``Client::Request``     The client request headers. Always available.
-``Client::Response``    The client response headers.
-``Server::Request``     The server request headers.
-``Server::Response``    The server response headers.
-=====================   ===========================================================================
+============================   ===========================================================================
+Header Object                  Description
+============================   ===========================================================================
+``Cript::Client::Request``     The client request headers. Always available.
+``Cript::Client::Response``    The client response headers.
+``Cript::Server::Request``     The server request headers.
+``Cript::Server::Response``    The server response headers.
+============================   ===========================================================================
 
 .. note::
 
-   For all of these headers, except the ``Client::Request``, the headers are not
-   available until the respective hook is called. For example, the ``Client::Response`` headers
+   For all of these headers, except the ``Cript::Client::Request``, the headers are not
+   available until the respective hook is called. For example, the ``Cript::Client::Response`` headers
    are not available until the response headers are received from the origin server or cache lookup.
 
 Assigning the empty value (``""``) to a header will remove it from the header list. For example:
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::Get();
+  borrow req = Cript::Client::Request::Get();
 
   req["X-Foo"] = "bar"; // Set the header
   req["X-Fie"] = "";    // Remove the header
@@ -64,7 +64,7 @@ A header can also be removed by using the ``Erase`` method, which is a little mo
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::Get();
+  borrow req = Cript::Client::Request::Get();
 
   req.Erase("X-Foo");
 
@@ -80,7 +80,7 @@ a pattern such as the following example:
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::Get();
+  borrow req = Cript::Client::Request::Get();
 
   for (auto header : req) {
     CDebug("Header: {}: {}", header, req[header]); // This will print all headers and their values
@@ -95,8 +95,8 @@ Methods
 -------
 
 In addition to holding all the request headers, the request objects also holds the ``method`` verb.
-For the ``Client::Request`` object, this is the client request method (GET, POST, etc.). For the
-``Server::Request`` object, this is the method that will be sent to the origin server (GET, POST, etc.).
+For the ``Cript::Client::Request`` object, this is the client request method (GET, POST, etc.). For the
+``Cript::Server::Request`` object, this is the method that will be sent to the origin server (GET, POST, etc.).
 
 Cripts provides the following convenience symbols for common methods (and performance):
 
@@ -117,7 +117,7 @@ These symbols can be used to compare against the method in the request object. F
 
 .. code-block:: cpp
 
-  borrow req = Client::Request::Get();
+  borrow req = Cript::Client::Request::Get();
 
   if (req.method == Cript::Method::GET) {
       // Do something
@@ -157,7 +157,7 @@ fresh or stale. Example usage of the cache status:
 .. code-block:: cpp
 
   do_read_response() {
-    borrow resp = Server::Response::Get();
+    borrow resp = Cript::Server::Response::Get();
 
     if (resp.cache == "miss") {
       // Do something

--- a/doc/developer-guide/cripts/cripts-matcher.en.rst
+++ b/doc/developer-guide/cripts/cripts-matcher.en.rst
@@ -30,13 +30,13 @@ strings and variables that it provides. However, this is sometimes not adequate
 for all use cases, so Cripts provides a way to define custom matchers. There are
 currently three types of matchers:
 
-============================   ====================================================================
-Matcher                        Description
-============================   ====================================================================
-``Matcher::Range``             Matching IP addresses against one or many IP ranges.
-``Matcher::PCRE``              Matching strings against one or many regular expressions.
-``Matcher::List::Method``      Match a request method against a list of methods.
-============================   ====================================================================
+===================================   ====================================================================
+Matcher                               Description
+===================================   ====================================================================
+``Cript::Matcher::Range``             Matching IP addresses against one or many IP ranges.
+``Cript::Matcher::PCRE``              Matching strings against one or many regular expressions.
+``Cript::Matcher::List::Method``      Match a request method against a list of methods.
+===================================   ====================================================================
 
 Often you will declare these ranges once, and then use them over and over again. For this purpose,
 Cripts allows ranges to be declared ``static``, which means it can optimize the code around the matches.
@@ -47,9 +47,9 @@ Here's an example using the regular expression matcher:
 
    do_remap()
    {
-     static Matcher::PCRE pcre({"^/([^/]+)/(.*)$", "^(.*)$"}); // Nonsensical ...
+     static Cript::Matcher::PCRE pcre({"^/([^/]+)/(.*)$", "^(.*)$"}); // Nonsensical ...
 
-     borrow url = Client::URL::Get();
+     borrow url = Cript::Client::URL::Get();
 
      if (pcre.Match(url.path)) {
        // Do something with the match
@@ -83,7 +83,7 @@ Matcher::PCRE
 =============
 
 The PCRE matcher is used to match strings against one or many regular expressions. When a match
-is found, a ``Matcher::PCRE::Result`` object is returned. This object has the following functions
+is found, a ``Cript::Matcher::PCRE::Result`` object is returned. This object has the following functions
 to deal with the matched results and the capture groups:
 
 ============================   ====================================================================
@@ -101,9 +101,9 @@ Lets show an example:
 
    do_remap()
    {
-     static Matcher::PCRE allow({"^([a-c][^/]*)/?(.*)", "^([g-h][^/]*)/?(.*)"});
+     static Cript::Matcher::PCRE allow({"^([a-c][^/]*)/?(.*)", "^([g-h][^/]*)/?(.*)"});
 
-     borrow url = Client::URL::Get();
+     borrow url = Cript::Client::URL::Get();
 
      auto res = allow.Match(url.path);
 

--- a/doc/developer-guide/cripts/cripts-matcher.en.rst
+++ b/doc/developer-guide/cripts/cripts-matcher.en.rst
@@ -33,9 +33,9 @@ currently three types of matchers:
 ===================================   ====================================================================
 Matcher                               Description
 ===================================   ====================================================================
-``Cript::Matcher::Range``             Matching IP addresses against one or many IP ranges.
-``Cript::Matcher::PCRE``              Matching strings against one or many regular expressions.
-``Cript::Matcher::List::Method``      Match a request method against a list of methods.
+``cripts::Matcher::Range``            Matching IP addresses against one or many IP ranges.
+``cripts::Matcher::PCRE``             Matching strings against one or many regular expressions.
+``cripts::Matcher::List::Method``     Match a request method against a list of methods.
 ===================================   ====================================================================
 
 Often you will declare these ranges once, and then use them over and over again. For this purpose,
@@ -47,9 +47,9 @@ Here's an example using the regular expression matcher:
 
    do_remap()
    {
-     static Cript::Matcher::PCRE pcre({"^/([^/]+)/(.*)$", "^(.*)$"}); // Nonsensical ...
+     static cripts::Matcher::PCRE pcre({"^/([^/]+)/(.*)$", "^(.*)$"}); // Nonsensical ...
 
-     borrow url = Cript::Client::URL::Get();
+     borrow url = cripts::Client::URL::Get();
 
      if (pcre.Match(url.path)) {
        // Do something with the match
@@ -83,7 +83,7 @@ Matcher::PCRE
 =============
 
 The PCRE matcher is used to match strings against one or many regular expressions. When a match
-is found, a ``Cript::Matcher::PCRE::Result`` object is returned. This object has the following functions
+is found, a ``cripts::Matcher::PCRE::Result`` object is returned. This object has the following functions
 to deal with the matched results and the capture groups:
 
 ============================   ====================================================================
@@ -101,9 +101,9 @@ Lets show an example:
 
    do_remap()
    {
-     static Cript::Matcher::PCRE allow({"^([a-c][^/]*)/?(.*)", "^([g-h][^/]*)/?(.*)"});
+     static cripts::Matcher::PCRE allow({"^([a-c][^/]*)/?(.*)", "^([g-h][^/]*)/?(.*)"});
 
-     borrow url = Cript::Client::URL::Get();
+     borrow url = cripts::Client::URL::Get();
 
      auto res = allow.Match(url.path);
 

--- a/doc/developer-guide/cripts/cripts-misc.en.rst
+++ b/doc/developer-guide/cripts/cripts-misc.en.rst
@@ -42,13 +42,13 @@ making this easy.
 .. note::
     Explicitly forcing an HTTP error overrides any other response status that may have been set.
 
-=========================   =======================================================================
-Function                    Description
-=========================   =======================================================================
-``Error::Status::Set()``    Sets the response to the status code, and force the request to error.
-``Error::Status::Get()``    Get the current response status for the request.
-``Error::Reason::Set()``    Sets an explicit reason message with the status code. **TBD**
-=========================   =======================================================================
+================================   =======================================================================
+Function                           Description
+================================   =======================================================================
+``Cript::Error::Status::Set()``    Sets the response to the status code, and force the request to error.
+``Cript::Error::Status::Get()``    Get the current response status for the request.
+``Cript::Error::Reason::Set()``    Sets an explicit reason message with the status code. **TBD**
+================================   =======================================================================
 
 Example:
 
@@ -56,14 +56,14 @@ Example:
 
    do_remap()
    {
-     borrow req  = Client::Request::get();
+     borrow req  = Cript::Client::Request::get();
 
      if (req["X-Header"] == "yes") {
-       Error::Status::Set(403);
+       Cript::Error::Status::Set(403);
      }
      // Do more stuff here
 
-     if (Error::status::Get() != 403) {
+     if (Cript::Error::status::Get() != 403) {
        // Do even more stuff here if we're not in error state
      }
    }
@@ -113,7 +113,7 @@ Example usage to turn off a particular hook conditionally:
 
    do_remap()
    {
-     static borrow req = Client::Request::get();
+     static borrow req = Cript::Client::Request::get();
 
      if (req["X-Header"] == "yes") {
        transaction.DisableCallback(Cript::Callback::DO_READ_RESPONSE);
@@ -128,7 +128,7 @@ Time
 ====
 
 Cripts has encapsulated some common time-related functions in the core.  At the
-moment only the localtime is available, via the ``Time::Local`` object and its
+moment only the localtime is available, via the ``Cript::Time::Local`` object and its
 ``Now()`` method. The ``Now()`` method returns the current time as an object
 with the following functions:
 
@@ -175,7 +175,7 @@ plugin based on the client request headers:
    do_remap()
    {
      static borrow plugin = instance.plugins["my_ratelimit"];
-     borrow        req    = Client::Request::Get();
+     borrow        req    = Cript::Client::Request::Get();
 
      if (req["X-Header"] == "yes") {
        plugin.RunRemap();
@@ -195,22 +195,23 @@ In same cases, albeit not likely, you may need to read lines of text from A
 file. Cripts of course allows this to be done with C or C++ standard file APIs,
 but we also provide a few convenience functions to make this easier.
 
-The ``File`` object encapsulates the common C++ files operations. For convenience,
+The ``Cript::File`` object encapsulates the common C++ files operations. For convenience,
 and being such a common use case, reading a single line from a file is provided
-by the ``File::Line::Reader`` object. Some examples:
+by the ``Cript::File::Line::Reader`` object. Some examples:
 
 .. code-block:: cpp
 
    do_remap()
    {
-     static const File::Path p1("/tmp/foo");
-     static const File::Path p2("/tmp/secret.txt");
-     if (File::Status(p1).Type() == File::Type::regular) {
+     static const Cript::File::Path p1("/tmp/foo");
+     static const Cript::File::Path p2("/tmp/secret.txt");
+
+     if (Cript::File::Status(p1).Type() == Cript::File::Type::regular) {
        resp["X-Foo-Exists"] = "yes";
      } else {
        resp["X-Foo-Exists"] = "no";
      }
-     string secret = File::Line::Reader(p2);
+     string secret = Cript::File::Line::Reader(p2);
      CDebug("Read secret = {}", secret);
    }
 
@@ -225,9 +226,9 @@ different purposes. The ``UUID`` class provides the following objects:
 =========================   =======================================================================
 Object                      Description
 =========================   =======================================================================
-``UUID::Process``           Returns a UUID for the running process (changes on ATS startup).
-``UUID::Unique``            Returns a completely unique UUID for the server and transacion.
-``UUID::Request``           Returns a unique id for this request.
+``Cript::UUID::Process``    Returns a UUID for the running process (changes on ATS startup).
+``Cript::UUID::Unique``     Returns a completely unique UUID for the server and transacion.
+``Cript::UUID::Request``    Returns a unique id for this request.
 =========================   =======================================================================
 
 Using the ``UUID`` object is simple, via the ``Get()`` method. Here's an example:
@@ -236,9 +237,9 @@ Using the ``UUID`` object is simple, via the ``Get()`` method. Here's an example
 
    do_remap()
    {
-     static borrow req = Client::Request::Get();
+     static borrow req = Cript::Client::Request::Get();
 
-     resp["X-UUID"] = UUID::Unique::Get();
+     resp["X-UUID"] = Cript::UUID::Unique::Get();
    }
 
 .. _cripts-metrics:
@@ -249,12 +250,12 @@ Metrics
 Cripts metrics are built directly on top of the atomic core ATS metrics. As such, they not only
 work the same as the core metrics, but they are also as efficient. There are two types of metrics:
 
-=========================   =======================================================================
-Metric                      Description
-=========================   =======================================================================
-``Metric::Counter``         A simple counter, which can only be incremented.
-``Metric::Gauge``           A gauge, which can be incremented and decremented, and set to a value.
-=========================   =======================================================================
+================================   =======================================================================
+Metric                             Description
+================================   =======================================================================
+``Cript::Metric::Counter``         A simple counter, which can only be incremented.
+``Cript::Metric::Gauge``           A gauge, which can be incremented and decremented, and set to a value.
+================================   =======================================================================
 
 Example:
 
@@ -262,15 +263,15 @@ Example:
 
    do_create_instance()
    {
-     instance.metrics[0] = Metrics::Counter::Create("cript.example1.instance_calls");
+     instance.metrics[0] = Cript::Metrics::Counter::Create("cript.example1.instance_calls");
    }
 
    do_remap()
    {
-     static auto plugin_metric = Metrics::Counter("cript.example1.plugin_calls");
+     static auto plugin_metric = Cript::Metrics::Counter("cript.example1.plugin_calls");
 
      plugin_metric.Increment();
      instance.metrics[0]->Increment();
    }
 
-A ``Metric::Gauge`` can also be set via the ``Setter()`` method.
+A ``Cript::Metric::Gauge`` can also be set via the ``Setter()`` method.

--- a/doc/developer-guide/cripts/cripts-misc.en.rst
+++ b/doc/developer-guide/cripts/cripts-misc.en.rst
@@ -42,13 +42,13 @@ making this easy.
 .. note::
     Explicitly forcing an HTTP error overrides any other response status that may have been set.
 
-================================   =======================================================================
-Function                           Description
-================================   =======================================================================
-``Cript::Error::Status::Set()``    Sets the response to the status code, and force the request to error.
-``Cript::Error::Status::Get()``    Get the current response status for the request.
-``Cript::Error::Reason::Set()``    Sets an explicit reason message with the status code. **TBD**
-================================   =======================================================================
+==================================   =======================================================================
+Function                             Description
+==================================   =======================================================================
+``cripts::Error::Status::Set()``     Sets the response to the status code, and force the request to error.
+``cripts::Error::Status::Get()``     Get the current response status for the request.
+``cripts::Error::Reason::Set()``     Sets an explicit reason message with the status code. **TBD**
+==================================   =======================================================================
 
 Example:
 
@@ -56,14 +56,14 @@ Example:
 
    do_remap()
    {
-     borrow req  = Cript::Client::Request::get();
+     borrow req  = cripts::Client::Request::get();
 
      if (req["X-Header"] == "yes") {
-       Cript::Error::Status::Set(403);
+       cripts::Error::Status::Set(403);
      }
      // Do more stuff here
 
-     if (Cript::Error::status::Get() != 403) {
+     if (cripts::Error::status::Get() != 403) {
        // Do even more stuff here if we're not in error state
      }
    }
@@ -84,17 +84,17 @@ Function                    Description
 
 When disabling a callback, use the following names:
 
-=======================================   =========================================================
-Callback                                  Description
-=======================================   =========================================================
-``Cript::Callback::DO_REMAP``             The ``do_remap()`` hook.
-``Cript::Callback::DO_POST_REMAP``        The ``do_post_remap()`` hook.
-``Cript::Callback::DO_SEND_RESPONSE``     The ``do_send_response()`` hook.
-``Cript::Callback::DO_CACHE_LOOKUP``      The ``do_cache_lookup()`` hook.
-``Cript::Callback::DO_SEND_REQUEST``      The ``do_send_request()`` hook.
-``Cript::Callback::DO_READ_RESPONSE``     The ``do_read_response()`` hook.
-``Cript::Callback::DO_TXN_CLOSE``         The ``do_txn_close()`` hook.
-=======================================   =========================================================
+========================================   =========================================================
+Callback                                   Description
+========================================   =========================================================
+``cripts::Callback::DO_REMAP``             The ``do_remap()`` hook.
+``cripts::Callback::DO_POST_REMAP``        The ``do_post_remap()`` hook.
+``cripts::Callback::DO_SEND_RESPONSE``     The ``do_send_response()`` hook.
+``cripts::Callback::DO_CACHE_LOOKUP``      The ``do_cache_lookup()`` hook.
+``cripts::Callback::DO_SEND_REQUEST``      The ``do_send_request()`` hook.
+``cripts::Callback::DO_READ_RESPONSE``     The ``do_read_response()`` hook.
+``cripts::Callback::DO_TXN_CLOSE``         The ``do_txn_close()`` hook.
+========================================   =========================================================
 
 Finally, the ``transaction`` object also provides access to these ATS objects, which can be used
 with the lower level ATS APIs:
@@ -113,10 +113,10 @@ Example usage to turn off a particular hook conditionally:
 
    do_remap()
    {
-     static borrow req = Cript::Client::Request::get();
+     static borrow req = cripts::Client::Request::get();
 
      if (req["X-Header"] == "yes") {
-       transaction.DisableCallback(Cript::Callback::DO_READ_RESPONSE);
+       transaction.DisableCallback(cripts::Callback::DO_READ_RESPONSE);
      }
    }
 
@@ -128,7 +128,7 @@ Time
 ====
 
 Cripts has encapsulated some common time-related functions in the core.  At the
-moment only the localtime is available, via the ``Cript::Time::Local`` object and its
+moment only the localtime is available, via the ``cripts::Time::Local`` object and its
 ``Now()`` method. The ``Now()`` method returns the current time as an object
 with the following functions:
 
@@ -175,7 +175,7 @@ plugin based on the client request headers:
    do_remap()
    {
      static borrow plugin = instance.plugins["my_ratelimit"];
-     borrow        req    = Cript::Client::Request::Get();
+     borrow        req    = cripts::Client::Request::Get();
 
      if (req["X-Header"] == "yes") {
        plugin.RunRemap();
@@ -195,23 +195,23 @@ In same cases, albeit not likely, you may need to read lines of text from A
 file. Cripts of course allows this to be done with C or C++ standard file APIs,
 but we also provide a few convenience functions to make this easier.
 
-The ``Cript::File`` object encapsulates the common C++ files operations. For convenience,
+The ``cripts::File`` object encapsulates the common C++ files operations. For convenience,
 and being such a common use case, reading a single line from a file is provided
-by the ``Cript::File::Line::Reader`` object. Some examples:
+by the ``cripts::File::Line::Reader`` object. Some examples:
 
 .. code-block:: cpp
 
    do_remap()
    {
-     static const Cript::File::Path p1("/tmp/foo");
-     static const Cript::File::Path p2("/tmp/secret.txt");
+     static const cripts::File::Path p1("/tmp/foo");
+     static const cripts::File::Path p2("/tmp/secret.txt");
 
-     if (Cript::File::Status(p1).Type() == Cript::File::Type::regular) {
+     if (cripts::File::Status(p1).Type() == cripts::File::Type::regular) {
        resp["X-Foo-Exists"] = "yes";
      } else {
        resp["X-Foo-Exists"] = "no";
      }
-     string secret = Cript::File::Line::Reader(p2);
+     string secret = cripts::File::Line::Reader(p2);
      CDebug("Read secret = {}", secret);
    }
 
@@ -223,13 +223,13 @@ UUID
 Cripts supports generating a few different UUID (Universally Unique Identifier), for
 different purposes. The ``UUID`` class provides the following objects:
 
-=========================   =======================================================================
-Object                      Description
-=========================   =======================================================================
-``Cript::UUID::Process``    Returns a UUID for the running process (changes on ATS startup).
-``Cript::UUID::Unique``     Returns a completely unique UUID for the server and transacion.
-``Cript::UUID::Request``    Returns a unique id for this request.
-=========================   =======================================================================
+==========================   =======================================================================
+Object                       Description
+==========================   =======================================================================
+``cripts::UUID::Process``    Returns a UUID for the running process (changes on ATS startup).
+``cripts::UUID::Unique``     Returns a completely unique UUID for the server and transacion.
+``cripts::UUID::Request``    Returns a unique id for this request.
+==========================   =======================================================================
 
 Using the ``UUID`` object is simple, via the ``Get()`` method. Here's an example:
 
@@ -237,9 +237,9 @@ Using the ``UUID`` object is simple, via the ``Get()`` method. Here's an example
 
    do_remap()
    {
-     static borrow req = Cript::Client::Request::Get();
+     static borrow req = cripts::Client::Request::Get();
 
-     resp["X-UUID"] = Cript::UUID::Unique::Get();
+     resp["X-UUID"] = cripts::UUID::Unique::Get();
    }
 
 .. _cripts-metrics:
@@ -253,8 +253,8 @@ work the same as the core metrics, but they are also as efficient. There are two
 ================================   =======================================================================
 Metric                             Description
 ================================   =======================================================================
-``Cript::Metric::Counter``         A simple counter, which can only be incremented.
-``Cript::Metric::Gauge``           A gauge, which can be incremented and decremented, and set to a value.
+``cripts::Metric::Counter``        A simple counter, which can only be incremented.
+``cripts::Metric::Gauge``          A gauge, which can be incremented and decremented, and set to a value.
 ================================   =======================================================================
 
 Example:
@@ -263,15 +263,15 @@ Example:
 
    do_create_instance()
    {
-     instance.metrics[0] = Cript::Metrics::Counter::Create("cript.example1.instance_calls");
+     instance.metrics[0] = cripts::Metrics::Counter::Create("cript.example1.instance_calls");
    }
 
    do_remap()
    {
-     static auto plugin_metric = Cript::Metrics::Counter("cript.example1.plugin_calls");
+     static auto plugin_metric = cripts::Metrics::Counter("cript.example1.plugin_calls");
 
      plugin_metric.Increment();
      instance.metrics[0]->Increment();
    }
 
-A ``Cript::Metric::Gauge`` can also be set via the ``Setter()`` method.
+A ``cripts::Metric::Gauge`` can also be set via the ``Setter()`` method.

--- a/doc/developer-guide/cripts/cripts-overview.en.rst
+++ b/doc/developer-guide/cripts/cripts-overview.en.rst
@@ -94,7 +94,7 @@ depending on your preference. The file must be readable by the ATS process. Exam
 
    do_remap()
    {
-     borrow url = Cript::Client::URL::get();
+     borrow url = cripts::Client::URL::get();
 
      url.query.keep({"foo", "bar"});
    }
@@ -154,7 +154,7 @@ convention, ``PascalCase``. Instance variables and members are always all lowerc
 
 .. code-block:: cpp
 
-   auto url = Cript::Client::URL::Get();
+   auto url = cripts::Client::URL::Get();
    url.query.Keep({"foo", "bar"});
 
 .. _cripts-overview-hooks:

--- a/doc/developer-guide/cripts/cripts-overview.en.rst
+++ b/doc/developer-guide/cripts/cripts-overview.en.rst
@@ -94,7 +94,7 @@ depending on your preference. The file must be readable by the ATS process. Exam
 
    do_remap()
    {
-     borrow url = Client::URL::get();
+     borrow url = Cript::Client::URL::get();
 
      url.query.keep({"foo", "bar"});
    }
@@ -154,7 +154,7 @@ convention, ``PascalCase``. Instance variables and members are always all lowerc
 
 .. code-block:: cpp
 
-   auto url = Client::URL::Get();
+   auto url = Cript::Client::URL::Get();
    url.query.Keep({"foo", "bar"});
 
 .. _cripts-overview-hooks:

--- a/doc/developer-guide/cripts/cripts-urls.en.rst
+++ b/doc/developer-guide/cripts/cripts-urls.en.rst
@@ -30,25 +30,25 @@ must always be borrowed. The pattern for this is as follows:
 
 .. code-block:: cpp
 
-  borrow url = Cript::Client::URL::Get();
+  borrow url = cripts::Client::URL::Get();
 
   auto path = url.path;
 
 There are four types of URLs that can be borrowed:
 
-============================   =============================================================================
-URL Object                     Description
-============================   =============================================================================
-``Cript::Client::URL``         The client request URL, as it currently stands (may be modified).
-``Cript::Pristine:URL``        The pristine client request URL, as it was coming into the ATS server.
-``Cript::Parent::URL``         The outgoing server URL, as sent to the next server (parent or origin).
-``Cript::Cache::URL``          The cache URL, which will be used for the cache lookups.
-``Cript::Remap::From::URL``    The remap ``from`` URL, from :file:`remap.config`.
-``Cript::Remap::To::URL``      The remap ``to`` URL, from :file:`remap.config`.
-============================   =============================================================================
+==============================   =============================================================================
+URL Object                       Description
+==============================   =============================================================================
+``cripts::Client::URL``          The client request URL, as it currently stands (may be modified).
+``cripts::Pristine:URL``         The pristine client request URL, as it was coming into the ATS server.
+``cripts::Parent::URL``          The outgoing server URL, as sent to the next server (parent or origin).
+``cripts::Cache::URL``           The cache URL, which will be used for the cache lookups.
+``cripts::Remap::From::URL``     The remap ``from`` URL, from :file:`remap.config`.
+``cripts::Remap::To::URL``       The remap ``to`` URL, from :file:`remap.config`.
+==============================   =============================================================================
 
 These URLs all have the same methods and properties, but they are used in different
-hooks and have different meanings. The ``Cript::Client::URL`` is the most commonly used URL,
+hooks and have different meanings. The ``cripts::Client::URL`` is the most commonly used URL,
 which you will also modify in the traditional remapping use case; for example changing
 the ``path`` or ``host`` before further processing.
 
@@ -56,7 +56,7 @@ The full URL string can be copied via the ``String()`` method, for example:
 
 .. code-block:: cpp
 
-  borrow url = Cript::Client::URL::Get();
+  borrow url = cripts::Client::URL::Get();
 
   auto full = url.String();
 
@@ -87,7 +87,7 @@ you can use the following:
 
 .. code-block:: cpp
 
-  borrow url = Cript::Client::URL::Get();
+  borrow url = cripts::Client::URL::Get();
 
   auto path = url.path; // This is the entire path
   auto first = url.path[0]; // This is the first part of the path
@@ -97,7 +97,7 @@ indexed in a list. To get the value of a specific query parameter, you can use t
 
 .. code-block:: cpp
 
-  borrow url = Cript::Client::URL::Get();
+  borrow url = cripts::Client::URL::Get();
 
   auto value = url.query["key"]; // This is the value of the key
 
@@ -123,7 +123,7 @@ For example:
 
 .. code-block:: cpp
 
-  borrow url = Cript::Client::URL::get();
+  borrow url = cripts::Client::URL::get();
 
   url.query.erase("key"); // Removes the key from the query
   url.query.erase({"key1", "key2"}); // Removes both keys from the query

--- a/doc/developer-guide/cripts/cripts-urls.en.rst
+++ b/doc/developer-guide/cripts/cripts-urls.en.rst
@@ -30,25 +30,25 @@ must always be borrowed. The pattern for this is as follows:
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::Get();
+  borrow url = Cript::Client::URL::Get();
 
   auto path = url.path;
 
 There are four types of URLs that can be borrowed:
 
-=====================   =============================================================================
-URL Object              Description
-=====================   =============================================================================
-``Client::URL``         The client request URL, as it currently stands (may be modified).
-``Pristine:URL``        The pristine client request URL, as it was coming into the ATS server.
-``Parent::URL``         The outgoing server URL, as sent to the next server (parent or origin).
-``Cache::URL``          The cache URL, which will be used for the cache lookups.
-``Remap::From::URL``    The remap ``from`` URL, from :file:`remap.config`.
-``Remap::To::URL``      The remap ``to`` URL, from :file:`remap.config`.
-=====================   =============================================================================
+============================   =============================================================================
+URL Object                     Description
+============================   =============================================================================
+``Cript::Client::URL``         The client request URL, as it currently stands (may be modified).
+``Cript::Pristine:URL``        The pristine client request URL, as it was coming into the ATS server.
+``Cript::Parent::URL``         The outgoing server URL, as sent to the next server (parent or origin).
+``Cript::Cache::URL``          The cache URL, which will be used for the cache lookups.
+``Cript::Remap::From::URL``    The remap ``from`` URL, from :file:`remap.config`.
+``Cript::Remap::To::URL``      The remap ``to`` URL, from :file:`remap.config`.
+============================   =============================================================================
 
 These URLs all have the same methods and properties, but they are used in different
-hooks and have different meanings. The ``Client::URL`` is the most commonly used URL,
+hooks and have different meanings. The ``Cript::Client::URL`` is the most commonly used URL,
 which you will also modify in the traditional remapping use case; for example changing
 the ``path`` or ``host`` before further processing.
 
@@ -56,7 +56,7 @@ The full URL string can be copied via the ``String()`` method, for example:
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::Get();
+  borrow url = Cript::Client::URL::Get();
 
   auto full = url.String();
 
@@ -87,7 +87,7 @@ you can use the following:
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::Get();
+  borrow url = Cript::Client::URL::Get();
 
   auto path = url.path; // This is the entire path
   auto first = url.path[0]; // This is the first part of the path
@@ -97,7 +97,7 @@ indexed in a list. To get the value of a specific query parameter, you can use t
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::Get();
+  borrow url = Cript::Client::URL::Get();
 
   auto value = url.query["key"]; // This is the value of the key
 
@@ -123,7 +123,7 @@ For example:
 
 .. code-block:: cpp
 
-  borrow url = Client::URL::get();
+  borrow url = Cript::Client::URL::get();
 
   url.query.erase("key"); // Removes the key from the query
   url.query.erase({"key1", "key2"}); // Removes both keys from the query

--- a/doc/developer-guide/cripts/cripts-variables.en.rst
+++ b/doc/developer-guide/cripts/cripts-variables.en.rst
@@ -59,7 +59,7 @@ get the length of a string, you can use the ``size()`` method:
 
 .. code-block:: cpp
 
-     borrow req  = Cript::Client::Request::Get();
+     borrow req  = cripts::Client::Request::Get();
 
      if (req["Host"].size() > 3) {
          // Do something
@@ -97,7 +97,7 @@ regular comparisons such as ``==`` and ``!=`` are also available.
 
 .. note::
    The ``find()`` and ``rfind()`` methods return the position of the string within the string, or
-   ``Cript::string_view::npos`` if the string is not found.
+   ``cripts::string_view::npos`` if the string is not found.
 
 .. _cripts-variables-configuration:
 
@@ -128,7 +128,7 @@ control planes with Cripts. This is done using the ``Records`` object, for examp
 .. code-block:: cpp
 
    do_remap() {
-     auto http_cache = Cript::Cript::Records("proxy.config.http.cache.http");
+     auto http_cache = cripts::cripts::Records("proxy.config.http.cache.http");
 
      if (AsInteger(http_cache.Get()) > 0) {
        CDebug("HTTP Cache is on");
@@ -163,7 +163,7 @@ turn off logging for some percentage of requests:
 .. code-block:: cpp
 
    do_remap() {
-     if (Cript::random(1000) > 99) {
+     if (cripts::random(1000) > 99) {
        control.logging.Set(false); // 10% log sampling
      }
    }

--- a/doc/developer-guide/cripts/cripts-variables.en.rst
+++ b/doc/developer-guide/cripts/cripts-variables.en.rst
@@ -59,7 +59,7 @@ get the length of a string, you can use the ``size()`` method:
 
 .. code-block:: cpp
 
-     borrow req  = Client::Request::Get();
+     borrow req  = Cript::Client::Request::Get();
 
      if (req["Host"].size() > 3) {
          // Do something
@@ -128,7 +128,7 @@ control planes with Cripts. This is done using the ``Records`` object, for examp
 .. code-block:: cpp
 
    do_remap() {
-     auto http_cache = Cript::Records("proxy.config.http.cache.http");
+     auto http_cache = Cript::Cript::Records("proxy.config.http.cache.http");
 
      if (AsInteger(http_cache.Get()) > 0) {
        CDebug("HTTP Cache is on");

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -23,7 +23,7 @@
 #include <cripts/Bundles/Caching.hpp>
 
 // Globals for this Cript
-static Cript::Matcher::Range::IP CRIPT_ALLOW({"192.168.201.0/24", "10.0.0.0/8"});
+static cripts::Matcher::Range::IP CRIPT_ALLOW({"192.168.201.0/24", "10.0.0.0/8"});
 
 // This is called only when the plugin is initialized
 do_init()
@@ -33,31 +33,31 @@ do_init()
 
 do_create_instance()
 {
-  instance.metrics[0] = Cript::Metrics::Counter::Create("cript.example1.c0");
-  instance.metrics[1] = Cript::Metrics::Counter::Create("cript.example1.c1");
-  instance.metrics[2] = Cript::Metrics::Counter::Create("cript.example1.c2");
-  instance.metrics[3] = Cript::Metrics::Counter::Create("cript.example1.c3");
-  instance.metrics[4] = Cript::Metrics::Counter::Create("cript.example1.c4");
-  instance.metrics[5] = Cript::Metrics::Counter::Create("cript.example1.c5");
-  instance.metrics[6] = Cript::Metrics::Counter::Create("cript.example1.c6");
-  instance.metrics[7] = Cript::Metrics::Counter::Create("cript.example1.c7");
-  instance.metrics[8] = Cript::Metrics::Counter::Create("cript.example1.c8"); // This one should resize() the storage
+  instance.metrics[0] = cripts::Metrics::Counter::Create("cript.example1.c0");
+  instance.metrics[1] = cripts::Metrics::Counter::Create("cript.example1.c1");
+  instance.metrics[2] = cripts::Metrics::Counter::Create("cript.example1.c2");
+  instance.metrics[3] = cripts::Metrics::Counter::Create("cript.example1.c3");
+  instance.metrics[4] = cripts::Metrics::Counter::Create("cript.example1.c4");
+  instance.metrics[5] = cripts::Metrics::Counter::Create("cript.example1.c5");
+  instance.metrics[6] = cripts::Metrics::Counter::Create("cript.example1.c6");
+  instance.metrics[7] = cripts::Metrics::Counter::Create("cript.example1.c7");
+  instance.metrics[8] = cripts::Metrics::Counter::Create("cript.example1.c8"); // This one should resize() the storage
 
-  Cript::Bundle::Common::Activate().dscp(10);
-  Cript::Bundle::Caching::Activate().cache_control("max-age=259200");
+  cripts::Bundle::Common::Activate().dscp(10);
+  cripts::Bundle::Caching::Activate().cache_control("max-age=259200");
 }
 
 do_txn_close()
 {
-  borrow conn = Cript::Client::Connection::Get();
+  borrow conn = cripts::Client::Connection::Get();
 
-  conn.pacing = Cript::Pacing::Off;
+  conn.pacing = cripts::Pacing::Off;
   CDebug("Cool, TXN close also works");
 }
 
 do_cache_lookup()
 {
-  borrow url2 = Cript::Cache::URL::Get();
+  borrow url2 = cripts::Cache::URL::Get();
 
   CDebug("Cache URL: {}", url2.String());
   CDebug("Cache Host: {}", url2.host);
@@ -65,28 +65,28 @@ do_cache_lookup()
 
 do_send_request()
 {
-  borrow req = Cript::Server::Request::Get();
+  borrow req = cripts::Server::Request::Get();
 
   req["X-Leif"] = "Meh";
 }
 
 do_read_response()
 {
-  borrow resp = Cript::Server::Response::Get();
+  borrow resp = cripts::Server::Response::Get();
 
   resp["X-DBJ"] = "Vrooom!";
 }
 
 do_send_response()
 {
-  borrow resp = Cript::Client::Response::Get();
-  borrow conn = Cript::Client::Connection::Get();
+  borrow resp = cripts::Client::Response::Get();
+  borrow conn = cripts::Client::Connection::Get();
   string msg  = "Eliminate TSCPP";
 
   resp["Server"]         = "";        // Deletes the Server header
   resp["X-AMC"]          = msg;       // New header
   resp["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
-  resp["X-UUID"]         = Cript::UUID::Unique::Get();
+  resp["X-UUID"]         = cripts::UUID::Unique::Get();
   resp["X-tcpinfo"]      = conn.tcpinfo.Log();
   resp["X-Cache-Status"] = resp.cache;
   resp["X-Integer"]      = 666;
@@ -104,16 +104,16 @@ do_send_response()
   conn.mark       = 17;
 
   // Some file operations (note that the paths aren't required here, can just be strings, but it's a good practice)
-  static const Cript::File::Path p1("/tmp/foo");
-  static const Cript::File::Path p2("/tmp/secret.txt");
+  static const cripts::File::Path p1("/tmp/foo");
+  static const cripts::File::Path p2("/tmp/secret.txt");
 
-  if (Cript::File::Status(p1).type() == Cript::File::Type::regular) {
+  if (cripts::File::Status(p1).type() == cripts::File::Type::regular) {
     resp["X-Foo-Exists"] = "yes";
   } else {
     resp["X-Foo-Exists"] = "no";
   }
 
-  string secret = Cript::File::Line::Reader(p2);
+  string secret = cripts::File::Line::Reader(p2);
   CDebug("Read secret = {}", secret);
 
   if (resp.status == 200) {
@@ -125,9 +125,9 @@ do_send_response()
 
 do_remap()
 {
-  auto   now  = Cript::Time::Local::Now();
-  borrow req  = Cript::Client::Request::Get();
-  borrow conn = Cript::Client::Connection::Get();
+  auto   now  = cripts::Time::Local::Now();
+  borrow req  = cripts::Client::Request::Get();
+  borrow conn = cripts::Client::Connection::Get();
   auto   ip   = conn.IP();
 
   if (CRIPT_ALLOW.contains(ip)) {
@@ -152,9 +152,9 @@ do_remap()
   CDebug("Float config cache.heuristic_lm_factor = {}", proxy.config.http.cache.heuristic_lm_factor.Get());
   CDebug("String config http.response_server_str = {}", proxy.config.http.response_server_str.GetSV(context));
   CDebug("X-Miles = {}", req["X-Miles"]);
-  CDebug("random(1000) = {}", Cript::Random(1000));
+  CDebug("random(1000) = {}", cripts::Random(1000));
 
-  borrow url      = Cript::Client::URL::Get();
+  borrow url      = cripts::Client::URL::Get();
   auto   old_port = url.port;
 
   CDebug("Method is {}", req.method);
@@ -187,7 +187,7 @@ do_remap()
   txn_data[2] = "DBJ";
 
   // Regular expressions
-  static Cript::Matcher::PCRE pcre("^/([^/]+)/(.*)$");
+  static cripts::Matcher::PCRE pcre("^/([^/]+)/(.*)$");
 
   auto res = pcre.Match("/foo/bench/bar"); // Can also call contains(), same thing
 
@@ -205,8 +205,8 @@ do_remap()
 
   // Some Crypto::Base64 tests
   static auto base64_test = "VGltZSB3aWxsIG5vdCBzbG93IGRvd24gd2hlbiBzb21ldGhpbmcgdW5wbGVhc2FudCBsaWVzIGFoZWFkLg==";
-  auto        hp          = Cript::Crypto::Base64::Decode(base64_test);
-  auto        hp2         = Cript::Crypto::Base64::Encode(hp);
+  auto        hp          = cripts::Crypto::Base64::Decode(base64_test);
+  auto        hp2         = cripts::Crypto::Base64::Encode(hp);
 
   CDebug("HP quote: {}", hp);
   if (base64_test != hp2) {
@@ -217,8 +217,8 @@ do_remap()
 
   // Some Crypto::Escape (URL escaping) tests
   static auto escape_test = "Hello_World_!@%23$%25%5E&*()_%2B%3C%3E?%2C.%2F";
-  auto        uri         = Cript::Crypto::Escape::Decode(escape_test);
-  auto        uri2        = Cript::Crypto::Escape::Encode(uri);
+  auto        uri         = cripts::Crypto::Escape::Decode(escape_test);
+  auto        uri2        = cripts::Crypto::Escape::Encode(uri);
 
   CDebug("Unescaped URI: {}", uri);
   if (escape_test != uri2) {
@@ -228,7 +228,7 @@ do_remap()
   }
 
   // Testing Crypto SHA and encryption
-  auto hex = format("{}", Cript::Crypto::SHA256::Encode("Hello World"));
+  auto hex = format("{}", cripts::Crypto::SHA256::Encode("Hello World"));
 
   CDebug("SHA256 = {}", hex);
 
@@ -241,8 +241,8 @@ do_remap()
   }
 
   // Testing some simple metrics
-  static auto m1 = Cript::Metrics::Gauge("cript.example1.m1");
-  static auto m2 = Cript::Metrics::Counter("cript.example1.m2");
+  static auto m1 = cripts::Metrics::Gauge("cript.example1.m1");
+  static auto m2 = cripts::Metrics::Counter("cript.example1.m2");
 
   m1.Increment(100);
   m1.Decrement(10);

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -23,7 +23,7 @@
 #include <cripts/Bundles/Caching.hpp>
 
 // Globals for this Cript
-static Matcher::Range::IP CRIPT_ALLOW({"192.168.201.0/24", "10.0.0.0/8"});
+static Cript::Matcher::Range::IP CRIPT_ALLOW({"192.168.201.0/24", "10.0.0.0/8"});
 
 // This is called only when the plugin is initialized
 do_init()
@@ -33,23 +33,23 @@ do_init()
 
 do_create_instance()
 {
-  instance.metrics[0] = Metrics::Counter::Create("cript.example1.c0");
-  instance.metrics[1] = Metrics::Counter::Create("cript.example1.c1");
-  instance.metrics[2] = Metrics::Counter::Create("cript.example1.c2");
-  instance.metrics[3] = Metrics::Counter::Create("cript.example1.c3");
-  instance.metrics[4] = Metrics::Counter::Create("cript.example1.c4");
-  instance.metrics[5] = Metrics::Counter::Create("cript.example1.c5");
-  instance.metrics[6] = Metrics::Counter::Create("cript.example1.c6");
-  instance.metrics[7] = Metrics::Counter::Create("cript.example1.c7");
-  instance.metrics[8] = Metrics::Counter::Create("cript.example1.c8"); // This one should resize() the storage
+  instance.metrics[0] = Cript::Metrics::Counter::Create("cript.example1.c0");
+  instance.metrics[1] = Cript::Metrics::Counter::Create("cript.example1.c1");
+  instance.metrics[2] = Cript::Metrics::Counter::Create("cript.example1.c2");
+  instance.metrics[3] = Cript::Metrics::Counter::Create("cript.example1.c3");
+  instance.metrics[4] = Cript::Metrics::Counter::Create("cript.example1.c4");
+  instance.metrics[5] = Cript::Metrics::Counter::Create("cript.example1.c5");
+  instance.metrics[6] = Cript::Metrics::Counter::Create("cript.example1.c6");
+  instance.metrics[7] = Cript::Metrics::Counter::Create("cript.example1.c7");
+  instance.metrics[8] = Cript::Metrics::Counter::Create("cript.example1.c8"); // This one should resize() the storage
 
-  Bundle::Common::Activate().dscp(10);
-  Bundle::Caching::Activate().cache_control("max-age=259200");
+  Cript::Bundle::Common::Activate().dscp(10);
+  Cript::Bundle::Caching::Activate().cache_control("max-age=259200");
 }
 
 do_txn_close()
 {
-  borrow conn = Client::Connection::Get();
+  borrow conn = Cript::Client::Connection::Get();
 
   conn.pacing = Cript::Pacing::Off;
   CDebug("Cool, TXN close also works");
@@ -57,7 +57,7 @@ do_txn_close()
 
 do_cache_lookup()
 {
-  borrow url2 = Cache::URL::Get();
+  borrow url2 = Cript::Cache::URL::Get();
 
   CDebug("Cache URL: {}", url2.String());
   CDebug("Cache Host: {}", url2.host);
@@ -65,28 +65,28 @@ do_cache_lookup()
 
 do_send_request()
 {
-  borrow req = Server::Request::Get();
+  borrow req = Cript::Server::Request::Get();
 
   req["X-Leif"] = "Meh";
 }
 
 do_read_response()
 {
-  borrow resp = Server::Response::Get();
+  borrow resp = Cript::Server::Response::Get();
 
   resp["X-DBJ"] = "Vrooom!";
 }
 
 do_send_response()
 {
-  borrow resp = Client::Response::Get();
-  borrow conn = Client::Connection::Get();
+  borrow resp = Cript::Client::Response::Get();
+  borrow conn = Cript::Client::Connection::Get();
   string msg  = "Eliminate TSCPP";
 
   resp["Server"]         = "";        // Deletes the Server header
   resp["X-AMC"]          = msg;       // New header
   resp["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
-  resp["X-UUID"]         = UUID::Unique::Get();
+  resp["X-UUID"]         = Cript::UUID::Unique::Get();
   resp["X-tcpinfo"]      = conn.tcpinfo.Log();
   resp["X-Cache-Status"] = resp.cache;
   resp["X-Integer"]      = 666;
@@ -104,16 +104,16 @@ do_send_response()
   conn.mark       = 17;
 
   // Some file operations (note that the paths aren't required here, can just be strings, but it's a good practice)
-  static const File::Path p1("/tmp/foo");
-  static const File::Path p2("/tmp/secret.txt");
+  static const Cript::File::Path p1("/tmp/foo");
+  static const Cript::File::Path p2("/tmp/secret.txt");
 
-  if (File::Status(p1).type() == File::Type::regular) {
+  if (Cript::File::Status(p1).type() == Cript::File::Type::regular) {
     resp["X-Foo-Exists"] = "yes";
   } else {
     resp["X-Foo-Exists"] = "no";
   }
 
-  string secret = File::Line::Reader(p2);
+  string secret = Cript::File::Line::Reader(p2);
   CDebug("Read secret = {}", secret);
 
   if (resp.status == 200) {
@@ -125,9 +125,9 @@ do_send_response()
 
 do_remap()
 {
-  auto   now  = Time::Local::Now();
-  borrow req  = Client::Request::Get();
-  borrow conn = Client::Connection::Get();
+  auto   now  = Cript::Time::Local::Now();
+  borrow req  = Cript::Client::Request::Get();
+  borrow conn = Cript::Client::Connection::Get();
   auto   ip   = conn.IP();
 
   if (CRIPT_ALLOW.contains(ip)) {
@@ -154,7 +154,7 @@ do_remap()
   CDebug("X-Miles = {}", req["X-Miles"]);
   CDebug("random(1000) = {}", Cript::Random(1000));
 
-  borrow url      = Client::URL::Get();
+  borrow url      = Cript::Client::URL::Get();
   auto   old_port = url.port;
 
   CDebug("Method is {}", req.method);
@@ -187,7 +187,7 @@ do_remap()
   txn_data[2] = "DBJ";
 
   // Regular expressions
-  static Matcher::PCRE pcre("^/([^/]+)/(.*)$");
+  static Cript::Matcher::PCRE pcre("^/([^/]+)/(.*)$");
 
   auto res = pcre.Match("/foo/bench/bar"); // Can also call contains(), same thing
 
@@ -205,8 +205,8 @@ do_remap()
 
   // Some Crypto::Base64 tests
   static auto base64_test = "VGltZSB3aWxsIG5vdCBzbG93IGRvd24gd2hlbiBzb21ldGhpbmcgdW5wbGVhc2FudCBsaWVzIGFoZWFkLg==";
-  auto        hp          = Crypto::Base64::Decode(base64_test);
-  auto        hp2         = Crypto::Base64::Encode(hp);
+  auto        hp          = Cript::Crypto::Base64::Decode(base64_test);
+  auto        hp2         = Cript::Crypto::Base64::Encode(hp);
 
   CDebug("HP quote: {}", hp);
   if (base64_test != hp2) {
@@ -217,8 +217,8 @@ do_remap()
 
   // Some Crypto::Escape (URL escaping) tests
   static auto escape_test = "Hello_World_!@%23$%25%5E&*()_%2B%3C%3E?%2C.%2F";
-  auto        uri         = Crypto::Escape::Decode(escape_test);
-  auto        uri2        = Crypto::Escape::Encode(uri);
+  auto        uri         = Cript::Crypto::Escape::Decode(escape_test);
+  auto        uri2        = Cript::Crypto::Escape::Encode(uri);
 
   CDebug("Unescaped URI: {}", uri);
   if (escape_test != uri2) {
@@ -228,7 +228,7 @@ do_remap()
   }
 
   // Testing Crypto SHA and encryption
-  auto hex = format("{}", Crypto::SHA256::Encode("Hello World"));
+  auto hex = format("{}", Cript::Crypto::SHA256::Encode("Hello World"));
 
   CDebug("SHA256 = {}", hex);
 
@@ -241,8 +241,8 @@ do_remap()
   }
 
   // Testing some simple metrics
-  static auto m1 = Metrics::Gauge("cript.example1.m1");
-  static auto m2 = Metrics::Counter("cript.example1.m2");
+  static auto m1 = Cript::Metrics::Gauge("cript.example1.m1");
+  static auto m2 = Cript::Metrics::Counter("cript.example1.m2");
 
   m1.Increment(100);
   m1.Decrement(10);

--- a/include/cripts/Bundle.hpp
+++ b/include/cripts/Bundle.hpp
@@ -22,7 +22,7 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Transaction.hpp"
 
-namespace Cript
+namespace cripts
 {
 // We have to forward declare this, to avoid some circular dependencies
 class Context;
@@ -38,33 +38,33 @@ namespace Bundle
     void operator=(const self_type &) = delete;
     virtual ~Error()                  = default;
 
-    Error(const Cript::string &message, Cript::string_view bundle, Cript::string_view option)
+    Error(const cripts::string &message, cripts::string_view bundle, cripts::string_view option)
       : _message(message), _bundle(bundle), _option(option)
     {
     }
 
-    [[nodiscard]] Cript::string_view
+    [[nodiscard]] cripts::string_view
     Message() const
     {
       return {_message};
     }
 
-    [[nodiscard]] Cript::string_view
+    [[nodiscard]] cripts::string_view
     Bundle() const
     {
       return {_bundle};
     }
 
-    [[nodiscard]] Cript::string_view
+    [[nodiscard]] cripts::string_view
     Option() const
     {
       return {_option};
     }
 
   private:
-    std::string        _message;
-    Cript::string_view _bundle;
-    Cript::string_view _option;
+    std::string         _message;
+    cripts::string_view _bundle;
+    cripts::string_view _option;
   };
 
   class Base
@@ -77,10 +77,10 @@ namespace Bundle
     void operator=(const self_type &) = delete;
     virtual ~Base()                   = default;
 
-    [[nodiscard]] virtual const Cript::string &Name() const = 0;
+    [[nodiscard]] virtual const cripts::string &Name() const = 0;
 
     void
-    NeedCallback(Cript::Callbacks cb)
+    NeedCallback(cripts::Callbacks cb)
     {
       _callbacks |= cb;
     }
@@ -106,43 +106,43 @@ namespace Bundle
     }
 
     virtual bool
-    Validate(std::vector<Cript::Bundle::Error> & /* errors ATS_UNUSED */) const
+    Validate(std::vector<cripts::Bundle::Error> & /* errors ATS_UNUSED */) const
     {
       return true;
     }
 
     virtual void
-    doRemap(Cript::Context * /* context ATS_UNUSED */)
+    doRemap(cripts::Context * /* context ATS_UNUSED */)
     {
     }
 
     virtual void
-    doPostRemap(Cript::Context * /* context ATS_UNUSED */)
+    doPostRemap(cripts::Context * /* context ATS_UNUSED */)
     {
     }
 
     virtual void
-    doSendResponse(Cript::Context * /* context ATS_UNUSED */)
+    doSendResponse(cripts::Context * /* context ATS_UNUSED */)
     {
     }
 
     virtual void
-    doCacheLookup(Cript::Context * /* context ATS_UNUSED */)
+    doCacheLookup(cripts::Context * /* context ATS_UNUSED */)
     {
     }
 
     virtual void
-    doSendRequest(Cript::Context * /* context ATS_UNUSED */)
+    doSendRequest(cripts::Context * /* context ATS_UNUSED */)
     {
     }
 
     virtual void
-    doReadResponse(Cript::Context * /* context ATS_UNUSED */)
+    doReadResponse(cripts::Context * /* context ATS_UNUSED */)
     {
     }
 
     virtual void
-    doTxnClose(Cript::Context * /* context ATS_UNUSED */)
+    doTxnClose(cripts::Context * /* context ATS_UNUSED */)
     {
     }
 
@@ -152,4 +152,4 @@ namespace Bundle
 
 } // namespace Bundle
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/Bundles/Caching.hpp
+++ b/include/cripts/Bundles/Caching.hpp
@@ -25,11 +25,11 @@
 #include "cripts/Instance.hpp"
 #include "cripts/Bundle.hpp"
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-class Caching : public Cript::Bundle::Base
+class Caching : public cripts::Bundle::Base
 {
-  using super_type = Cript::Bundle::Base;
+  using super_type = cripts::Bundle::Base;
   using self_type  = Caching;
 
 public:
@@ -37,7 +37,7 @@ public:
 
   // This is the factory to create an instance of this bundle
   static self_type &
-  _activate(Cript::Instance &inst)
+  _activate(cripts::Instance &inst)
   {
     auto *entry = new self_type();
 
@@ -46,16 +46,16 @@ public:
     return *entry;
   }
 
-  [[nodiscard]] const Cript::string &
+  [[nodiscard]] const cripts::string &
   Name() const override
   {
     return _name;
   }
 
   self_type &
-  cache_control(Cript::string_view cc, bool force = false)
+  cache_control(cripts::string_view cc, bool force = false)
   {
-    NeedCallback(Cript::Callbacks::DO_READ_RESPONSE);
+    NeedCallback(cripts::Callbacks::DO_READ_RESPONSE);
     _cc       = cc;
     _force_cc = force;
 
@@ -65,20 +65,20 @@ public:
   self_type &
   disable(bool disable = true)
   {
-    NeedCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(cripts::Callbacks::DO_REMAP);
     _disabled = disable;
 
     return *this;
   }
 
-  void doReadResponse(Cript::Context *context) override;
-  void doRemap(Cript::Context *context) override;
+  void doReadResponse(cripts::Context *context) override;
+  void doRemap(cripts::Context *context) override;
 
 private:
-  static const Cript::string _name;
-  Cript::string              _cc       = "";
-  bool                       _force_cc = false;
-  bool                       _disabled = false;
+  static const cripts::string _name;
+  cripts::string              _cc       = "";
+  bool                        _force_cc = false;
+  bool                        _disabled = false;
 };
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/include/cripts/Bundles/Caching.hpp
+++ b/include/cripts/Bundles/Caching.hpp
@@ -25,7 +25,7 @@
 #include "cripts/Instance.hpp"
 #include "cripts/Bundle.hpp"
 
-namespace Bundle
+namespace Cript::Bundle
 {
 class Caching : public Cript::Bundle::Base
 {
@@ -81,4 +81,4 @@ private:
   bool                       _disabled = false;
 };
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/include/cripts/Bundles/Common.hpp
+++ b/include/cripts/Bundles/Common.hpp
@@ -27,23 +27,23 @@
 #include "cripts/Bundle.hpp"
 #include <cripts/ConfigsBase.hpp>
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-class Common : public Cript::Bundle::Base
+class Common : public cripts::Bundle::Base
 {
-  using super_type = Cript::Bundle::Base;
+  using super_type = cripts::Bundle::Base;
   using self_type  = Common;
 
-  using RecordsList = std::vector<std::pair<const Cript::Records *, const Cript::Records::ValueType>>;
+  using RecordsList = std::vector<std::pair<const cripts::Records *, const cripts::Records::ValueType>>;
 
 public:
   using super_type::Base;
 
-  bool Validate(std::vector<Cript::Bundle::Error> &errors) const override;
+  bool Validate(std::vector<cripts::Bundle::Error> &errors) const override;
 
   // This is the factory to create an instance of this bundle
   static self_type &
-  _activate(Cript::Instance &inst)
+  _activate(cripts::Instance &inst)
   {
     auto *entry = new self_type();
 
@@ -52,7 +52,7 @@ public:
     return *entry;
   }
 
-  [[nodiscard]] const Cript::string &
+  [[nodiscard]] const cripts::string &
   Name() const override
   {
     return _name;
@@ -61,24 +61,24 @@ public:
   self_type &
   dscp(int val)
   {
-    NeedCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(cripts::Callbacks::DO_REMAP);
     _dscp = val;
 
     return *this;
   }
 
-  self_type &via_header(const Cript::string_view &destination, const Cript::string_view &value);
-  self_type &set_config(const Cript::string_view name, const Cript::Records::ValueType &value);
-  self_type &set_config(const std::vector<std::pair<const Cript::string_view, const Cript::Records::ValueType>> &configs);
+  self_type &via_header(const cripts::string_view &destination, const cripts::string_view &value);
+  self_type &set_config(const cripts::string_view name, const cripts::Records::ValueType &value);
+  self_type &set_config(const std::vector<std::pair<const cripts::string_view, const cripts::Records::ValueType>> &configs);
 
-  void doRemap(Cript::Context *context) override;
+  void doRemap(cripts::Context *context) override;
 
 private:
-  static const Cript::string _name;
-  int                        _dscp       = 0;
-  std::pair<int, bool>       _client_via = {0, false}; // Flag indicates if it's been set at all
-  std::pair<int, bool>       _origin_via = {0, false};
-  RecordsList                _configs;
+  static const cripts::string _name;
+  int                         _dscp       = 0;
+  std::pair<int, bool>        _client_via = {0, false}; // Flag indicates if it's been set at all
+  std::pair<int, bool>        _origin_via = {0, false};
+  RecordsList                 _configs;
 };
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/include/cripts/Bundles/Common.hpp
+++ b/include/cripts/Bundles/Common.hpp
@@ -27,7 +27,7 @@
 #include "cripts/Bundle.hpp"
 #include <cripts/ConfigsBase.hpp>
 
-namespace Bundle
+namespace Cript::Bundle
 {
 class Common : public Cript::Bundle::Base
 {
@@ -81,4 +81,4 @@ private:
   RecordsList                _configs;
 };
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/include/cripts/Bundles/Headers.hpp
+++ b/include/cripts/Bundles/Headers.hpp
@@ -36,18 +36,18 @@ public:
   HRWBridge(const self_type &)      = delete;
   void operator=(const self_type &) = delete;
 
-  HRWBridge(const Cript::string_view &str) : _value(str) {}
+  HRWBridge(const cripts::string_view &str) : _value(str) {}
 
   virtual ~HRWBridge() = default;
 
-  virtual Cript::string_view
-  value(Cript::Context * /* context ATS_UNUSED */)
+  virtual cripts::string_view
+  value(cripts::Context * /* context ATS_UNUSED */)
   {
     return _value;
   }
 
 protected:
-  Cript::string _value;
+  cripts::string _value;
 
 }; // class HRWBridge
 
@@ -57,8 +57,8 @@ class HeadersType
   using self_type = HeadersType;
 
 public:
-  using HeaderList      = std::vector<Cript::string>;
-  using HeaderValueList = std::vector<std::pair<const Cript::string, detail::HRWBridge *>>;
+  using HeaderList      = std::vector<cripts::string>;
+  using HeaderValueList = std::vector<std::pair<const cripts::string, detail::HRWBridge *>>;
 
   HeadersType()                     = default;
   HeadersType(const self_type &)    = delete;
@@ -76,22 +76,22 @@ public:
 };
 } // namespace detail
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-class Headers : public Cript::Bundle::Base
+class Headers : public cripts::Bundle::Base
 {
-  using super_type = Cript::Bundle::Base;
+  using super_type = cripts::Bundle::Base;
   using self_type  = Headers;
 
 public:
-  using HeaderList      = std::vector<Cript::string>;
-  using HeaderValueList = std::vector<std::pair<const Cript::string, const Cript::string>>;
+  using HeaderList      = std::vector<cripts::string>;
+  using HeaderValueList = std::vector<std::pair<const cripts::string, const cripts::string>>;
 
   using super_type::Base;
 
   // This is the factory to create an instance of this bundle
   static self_type &
-  _activate(Cript::Instance &inst)
+  _activate(cripts::Instance &inst)
   {
     auto *entry = new self_type();
 
@@ -100,24 +100,24 @@ public:
     return *entry;
   }
 
-  [[nodiscard]] const Cript::string &
+  [[nodiscard]] const cripts::string &
   Name() const override
   {
     return _name;
   }
 
-  static detail::HRWBridge *BridgeFactory(const Cript::string &source);
+  static detail::HRWBridge *BridgeFactory(const cripts::string &source);
 
-  self_type &rm_headers(const Cript::string_view target, const HeaderList &headers);
-  self_type &set_headers(const Cript::string_view target, const HeaderValueList &headers);
+  self_type &rm_headers(const cripts::string_view target, const HeaderList &headers);
+  self_type &set_headers(const cripts::string_view target, const HeaderValueList &headers);
 
-  void doRemap(Cript::Context *context) override;
-  void doSendResponse(Cript::Context *context) override;
-  void doSendRequest(Cript::Context *context) override;
-  void doReadResponse(Cript::Context *context) override;
+  void doRemap(cripts::Context *context) override;
+  void doSendResponse(cripts::Context *context) override;
+  void doSendRequest(cripts::Context *context) override;
+  void doReadResponse(cripts::Context *context) override;
 
 private:
-  static const Cript::string _name;
+  static const cripts::string _name;
 
   detail::HeadersType _client_request;
   detail::HeadersType _client_response;
@@ -125,4 +125,4 @@ private:
   detail::HeadersType _server_response;
 };
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/include/cripts/Bundles/Headers.hpp
+++ b/include/cripts/Bundles/Headers.hpp
@@ -76,7 +76,7 @@ public:
 };
 } // namespace detail
 
-namespace Bundle
+namespace Cript::Bundle
 {
 class Headers : public Cript::Bundle::Base
 {
@@ -125,4 +125,4 @@ private:
   detail::HeadersType _server_response;
 };
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/include/cripts/Bundles/LogsMetrics.hpp
+++ b/include/cripts/Bundles/LogsMetrics.hpp
@@ -26,7 +26,7 @@
 #include "cripts/Instance.hpp"
 #include "cripts/Bundle.hpp"
 
-namespace Bundle
+namespace Cript::Bundle
 {
 class LogsMetrics : public Cript::Bundle::Base
 {
@@ -87,4 +87,4 @@ private:
   bool                       _tcpinfo    = false; // Turn on TCP info logging
 };
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/include/cripts/Bundles/LogsMetrics.hpp
+++ b/include/cripts/Bundles/LogsMetrics.hpp
@@ -26,18 +26,18 @@
 #include "cripts/Instance.hpp"
 #include "cripts/Bundle.hpp"
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-class LogsMetrics : public Cript::Bundle::Base
+class LogsMetrics : public cripts::Bundle::Base
 {
-  using super_type = Cript::Bundle::Base;
+  using super_type = cripts::Bundle::Base;
   using self_type  = LogsMetrics;
 
 public:
-  LogsMetrics(Cript::Instance *inst) : _inst(inst) {}
+  LogsMetrics(cripts::Instance *inst) : _inst(inst) {}
 
   static self_type &
-  _activate(Cript::Instance &inst)
+  _activate(cripts::Instance &inst)
   {
     auto *entry = new self_type(&inst);
 
@@ -46,18 +46,18 @@ public:
     return *entry;
   }
 
-  [[nodiscard]] const Cript::string &
+  [[nodiscard]] const cripts::string &
   Name() const override
   {
     return _name;
   }
 
-  self_type &propstats(const Cript::string_view &label); // In LogsMetrics.cc
+  self_type &propstats(const cripts::string_view &label); // In LogsMetrics.cc
 
   self_type &
   logsample(int val)
   {
-    NeedCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(cripts::Callbacks::DO_REMAP);
     _log_sample = val;
 
     return *this;
@@ -67,24 +67,24 @@ public:
   tcpinfo(bool enable = true)
   {
     if (enable) {
-      NeedCallback({Cript::Callbacks::DO_REMAP, Cript::Callbacks::DO_SEND_RESPONSE, Cript::Callbacks::DO_TXN_CLOSE});
+      NeedCallback({cripts::Callbacks::DO_REMAP, cripts::Callbacks::DO_SEND_RESPONSE, cripts::Callbacks::DO_TXN_CLOSE});
     }
     _tcpinfo = enable;
 
     return *this;
   }
 
-  void doCacheLookup(Cript::Context *context) override;
-  void doSendResponse(Cript::Context *context) override;
-  void doTxnClose(Cript::Context *context) override;
-  void doRemap(Cript::Context *context) override;
+  void doCacheLookup(cripts::Context *context) override;
+  void doSendResponse(cripts::Context *context) override;
+  void doTxnClose(cripts::Context *context) override;
+  void doRemap(cripts::Context *context) override;
 
 private:
-  static const Cript::string _name;
-  Cript::Instance           *_inst;               // This Bundle needs the instance for access to the instance metrics
-  Cript::string              _label      = "";    // Propstats label
-  int                        _log_sample = 0;     // Log sampling
-  bool                       _tcpinfo    = false; // Turn on TCP info logging
+  static const cripts::string _name;
+  cripts::Instance           *_inst;               // This Bundle needs the instance for access to the instance metrics
+  cripts::string              _label      = "";    // Propstats label
+  int                         _log_sample = 0;     // Log sampling
+  bool                        _tcpinfo    = false; // Turn on TCP info logging
 };
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/include/cripts/Configs.hpp
+++ b/include/cripts/Configs.hpp
@@ -27,13 +27,13 @@
 
 #include "cripts/ConfigsBase.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 class Proxy
 {
 private:
-  friend class Cript::Context; // Needed to set the state
+  friend class cripts::Context; // Needed to set the state
 
   class Config
   {
@@ -41,8 +41,8 @@ private:
     class Body_Factory
     {
     public:
-      Cript::IntConfig    response_suppression_mode{"proxy.config.body_factory.response_suppression_mode"};
-      Cript::StringConfig template_base{"proxy.config.body_factory.template_base"};
+      cripts::IntConfig    response_suppression_mode{"proxy.config.body_factory.response_suppression_mode"};
+      cripts::StringConfig template_base{"proxy.config.body_factory.template_base"};
     }; // End class Body_Factory
 
   public:
@@ -52,7 +52,7 @@ private:
     class Hostdb
     {
     public:
-      Cript::StringConfig ip_resolve{"proxy.config.hostdb.ip_resolve"};
+      cripts::StringConfig ip_resolve{"proxy.config.hostdb.ip_resolve"};
     }; // End class Hostdb
 
   public:
@@ -62,61 +62,61 @@ private:
     class Http
     {
     public:
-      Cript::IntConfig   allow_half_open{"proxy.config.http.allow_half_open"};
-      Cript::IntConfig   allow_multi_range{"proxy.config.http.allow_multi_range"};
-      Cript::IntConfig   anonymize_remove_client_ip{"proxy.config.http.anonymize_remove_client_ip"};
-      Cript::IntConfig   anonymize_remove_cookie{"proxy.config.http.anonymize_remove_cookie"};
-      Cript::IntConfig   anonymize_remove_from{"proxy.config.http.anonymize_remove_from"};
-      Cript::IntConfig   anonymize_remove_referer{"proxy.config.http.anonymize_remove_referer"};
-      Cript::IntConfig   anonymize_remove_user_agent{"proxy.config.http.anonymize_remove_user_agent"};
-      Cript::IntConfig   attach_server_session_to_client{"proxy.config.http.attach_server_session_to_client"};
-      Cript::IntConfig   auth_server_session_private{"proxy.config.http.auth_server_session_private"};
-      Cript::IntConfig   background_fill_active_timeout{"proxy.config.http.background_fill_active_timeout"};
-      Cript::FloatConfig background_fill_completed_threshold{"proxy.config.http.background_fill_completed_threshold"};
+      cripts::IntConfig   allow_half_open{"proxy.config.http.allow_half_open"};
+      cripts::IntConfig   allow_multi_range{"proxy.config.http.allow_multi_range"};
+      cripts::IntConfig   anonymize_remove_client_ip{"proxy.config.http.anonymize_remove_client_ip"};
+      cripts::IntConfig   anonymize_remove_cookie{"proxy.config.http.anonymize_remove_cookie"};
+      cripts::IntConfig   anonymize_remove_from{"proxy.config.http.anonymize_remove_from"};
+      cripts::IntConfig   anonymize_remove_referer{"proxy.config.http.anonymize_remove_referer"};
+      cripts::IntConfig   anonymize_remove_user_agent{"proxy.config.http.anonymize_remove_user_agent"};
+      cripts::IntConfig   attach_server_session_to_client{"proxy.config.http.attach_server_session_to_client"};
+      cripts::IntConfig   auth_server_session_private{"proxy.config.http.auth_server_session_private"};
+      cripts::IntConfig   background_fill_active_timeout{"proxy.config.http.background_fill_active_timeout"};
+      cripts::FloatConfig background_fill_completed_threshold{"proxy.config.http.background_fill_completed_threshold"};
 
     private:
       class Cache
       {
       public:
-        Cript::IntConfig   cache_responses_to_cookies{"proxy.config.http.cache.cache_responses_to_cookies"};
-        Cript::IntConfig   cache_urls_that_look_dynamic{"proxy.config.http.cache.cache_urls_that_look_dynamic"};
-        Cript::IntConfig   generation{"proxy.config.http.cache.generation"};
-        Cript::IntConfig   guaranteed_max_lifetime{"proxy.config.http.cache.guaranteed_max_lifetime"};
-        Cript::IntConfig   guaranteed_min_lifetime{"proxy.config.http.cache.guaranteed_min_lifetime"};
-        Cript::FloatConfig heuristic_lm_factor{"proxy.config.http.cache.heuristic_lm_factor"};
-        Cript::IntConfig   heuristic_max_lifetime{"proxy.config.http.cache.heuristic_max_lifetime"};
-        Cript::IntConfig   heuristic_min_lifetime{"proxy.config.http.cache.heuristic_min_lifetime"};
-        Cript::IntConfig   http{"proxy.config.http.cache.http"};
-        Cript::IntConfig   ignore_accept_charset_mismatch{"proxy.config.http.cache.ignore_accept_charset_mismatch"};
-        Cript::IntConfig   ignore_accept_encoding_mismatch{"proxy.config.http.cache.ignore_accept_encoding_mismatch"};
-        Cript::IntConfig   ignore_accept_language_mismatch{"proxy.config.http.cache.ignore_accept_language_mismatch"};
-        Cript::IntConfig   ignore_accept_mismatch{"proxy.config.http.cache.ignore_accept_mismatch"};
-        Cript::IntConfig   ignore_authentication{"proxy.config.http.cache.ignore_authentication"};
-        Cript::IntConfig   ignore_client_cc_max_age{"proxy.config.http.cache.ignore_client_cc_max_age"};
-        Cript::IntConfig   ignore_client_no_cache{"proxy.config.http.cache.ignore_client_no_cache"};
-        Cript::IntConfig   ignore_query{"proxy.config.http.cache.ignore_query"};
-        Cript::IntConfig   ignore_server_no_cache{"proxy.config.http.cache.ignore_server_no_cache"};
-        Cript::IntConfig   ims_on_client_no_cache{"proxy.config.http.cache.ims_on_client_no_cache"};
-        Cript::IntConfig   max_open_read_retries{"proxy.config.http.cache.max_open_read_retries"};
-        Cript::IntConfig   max_open_write_retries{"proxy.config.http.cache.max_open_write_retries"};
-        Cript::IntConfig   max_open_write_retry_timeout{"proxy.config.http.cache.max_open_write_retry_timeout"};
-        Cript::IntConfig   max_stale_age{"proxy.config.http.cache.max_stale_age"};
-        Cript::IntConfig   open_read_retry_time{"proxy.config.http.cache.open_read_retry_time"};
-        Cript::IntConfig   open_write_fail_action{"proxy.config.http.cache.open_write_fail_action"};
+        cripts::IntConfig   cache_responses_to_cookies{"proxy.config.http.cache.cache_responses_to_cookies"};
+        cripts::IntConfig   cache_urls_that_look_dynamic{"proxy.config.http.cache.cache_urls_that_look_dynamic"};
+        cripts::IntConfig   generation{"proxy.config.http.cache.generation"};
+        cripts::IntConfig   guaranteed_max_lifetime{"proxy.config.http.cache.guaranteed_max_lifetime"};
+        cripts::IntConfig   guaranteed_min_lifetime{"proxy.config.http.cache.guaranteed_min_lifetime"};
+        cripts::FloatConfig heuristic_lm_factor{"proxy.config.http.cache.heuristic_lm_factor"};
+        cripts::IntConfig   heuristic_max_lifetime{"proxy.config.http.cache.heuristic_max_lifetime"};
+        cripts::IntConfig   heuristic_min_lifetime{"proxy.config.http.cache.heuristic_min_lifetime"};
+        cripts::IntConfig   http{"proxy.config.http.cache.http"};
+        cripts::IntConfig   ignore_accept_charset_mismatch{"proxy.config.http.cache.ignore_accept_charset_mismatch"};
+        cripts::IntConfig   ignore_accept_encoding_mismatch{"proxy.config.http.cache.ignore_accept_encoding_mismatch"};
+        cripts::IntConfig   ignore_accept_language_mismatch{"proxy.config.http.cache.ignore_accept_language_mismatch"};
+        cripts::IntConfig   ignore_accept_mismatch{"proxy.config.http.cache.ignore_accept_mismatch"};
+        cripts::IntConfig   ignore_authentication{"proxy.config.http.cache.ignore_authentication"};
+        cripts::IntConfig   ignore_client_cc_max_age{"proxy.config.http.cache.ignore_client_cc_max_age"};
+        cripts::IntConfig   ignore_client_no_cache{"proxy.config.http.cache.ignore_client_no_cache"};
+        cripts::IntConfig   ignore_query{"proxy.config.http.cache.ignore_query"};
+        cripts::IntConfig   ignore_server_no_cache{"proxy.config.http.cache.ignore_server_no_cache"};
+        cripts::IntConfig   ims_on_client_no_cache{"proxy.config.http.cache.ims_on_client_no_cache"};
+        cripts::IntConfig   max_open_read_retries{"proxy.config.http.cache.max_open_read_retries"};
+        cripts::IntConfig   max_open_write_retries{"proxy.config.http.cache.max_open_write_retries"};
+        cripts::IntConfig   max_open_write_retry_timeout{"proxy.config.http.cache.max_open_write_retry_timeout"};
+        cripts::IntConfig   max_stale_age{"proxy.config.http.cache.max_stale_age"};
+        cripts::IntConfig   open_read_retry_time{"proxy.config.http.cache.open_read_retry_time"};
+        cripts::IntConfig   open_write_fail_action{"proxy.config.http.cache.open_write_fail_action"};
 
       private:
         class Range
         {
         public:
-          Cript::IntConfig lookup{"proxy.config.http.cache.range.lookup"};
-          Cript::IntConfig write{"proxy.config.http.cache.range.write"};
+          cripts::IntConfig lookup{"proxy.config.http.cache.range.lookup"};
+          cripts::IntConfig write{"proxy.config.http.cache.range.write"};
         }; // End class Range
 
       public:
         Range range;
 
-        Cript::IntConfig required_headers{"proxy.config.http.cache.required_headers"};
-        Cript::IntConfig when_to_revalidate{"proxy.config.http.cache.when_to_revalidate"};
+        cripts::IntConfig required_headers{"proxy.config.http.cache.required_headers"};
+        cripts::IntConfig when_to_revalidate{"proxy.config.http.cache.when_to_revalidate"};
       }; // End class Cache
 
     public:
@@ -126,13 +126,13 @@ private:
       class Chunking
       {
       public:
-        Cript::IntConfig size{"proxy.config.http.chunking.size"};
+        cripts::IntConfig size{"proxy.config.http.chunking.size"};
       }; // End class Chunking
 
     public:
       Chunking chunking;
 
-      Cript::IntConfig chunking_enabled{"proxy.config.http.chunking_enabled"};
+      cripts::IntConfig chunking_enabled{"proxy.config.http.chunking_enabled"};
 
     private:
       class Connect
@@ -141,7 +141,7 @@ private:
         class Down
         {
         public:
-          Cript::IntConfig policy{"proxy.config.http.connect.down.policy"};
+          cripts::IntConfig policy{"proxy.config.http.connect.down.policy"};
         }; // End class Down
 
       public:
@@ -152,33 +152,33 @@ private:
     public:
       Connect connect;
 
-      Cript::IntConfig connect_attempts_max_retries{"proxy.config.http.connect_attempts_max_retries"};
-      Cript::IntConfig connect_attempts_max_retries_down_server{"proxy.config.http.connect_attempts_max_retries_down_server"};
-      Cript::IntConfig connect_attempts_rr_retries{"proxy.config.http.connect_attempts_rr_retries"};
-      Cript::IntConfig connect_attempts_timeout{"proxy.config.http.connect_attempts_timeout"};
-      Cript::IntConfig default_buffer_size{"proxy.config.http.default_buffer_size"};
-      Cript::IntConfig default_buffer_water_mark{"proxy.config.http.default_buffer_water_mark"};
-      Cript::IntConfig doc_in_cache_skip_dns{"proxy.config.http.doc_in_cache_skip_dns"};
+      cripts::IntConfig connect_attempts_max_retries{"proxy.config.http.connect_attempts_max_retries"};
+      cripts::IntConfig connect_attempts_max_retries_down_server{"proxy.config.http.connect_attempts_max_retries_down_server"};
+      cripts::IntConfig connect_attempts_rr_retries{"proxy.config.http.connect_attempts_rr_retries"};
+      cripts::IntConfig connect_attempts_timeout{"proxy.config.http.connect_attempts_timeout"};
+      cripts::IntConfig default_buffer_size{"proxy.config.http.default_buffer_size"};
+      cripts::IntConfig default_buffer_water_mark{"proxy.config.http.default_buffer_water_mark"};
+      cripts::IntConfig doc_in_cache_skip_dns{"proxy.config.http.doc_in_cache_skip_dns"};
 
     private:
       class Down_Server
       {
       public:
-        Cript::IntConfig cache_time{"proxy.config.http.down_server.cache_time"};
+        cripts::IntConfig cache_time{"proxy.config.http.down_server.cache_time"};
       }; // End class Down_Server
 
     public:
       Down_Server down_server;
 
-      Cript::IntConfig drop_chunked_trailers{"proxy.config.http.drop_chunked_trailers"};
+      cripts::IntConfig drop_chunked_trailers{"proxy.config.http.drop_chunked_trailers"};
 
     private:
       class Flow_Control
       {
       public:
-        Cript::IntConfig enabled{"proxy.config.http.flow_control.enabled"};
-        Cript::IntConfig high_water{"proxy.config.http.flow_control.high_water"};
-        Cript::IntConfig low_water{"proxy.config.http.flow_control.low_water"};
+        cripts::IntConfig enabled{"proxy.config.http.flow_control.enabled"};
+        cripts::IntConfig high_water{"proxy.config.http.flow_control.high_water"};
+        cripts::IntConfig low_water{"proxy.config.http.flow_control.low_water"};
       }; // End class Flow_Control
 
     public:
@@ -188,45 +188,45 @@ private:
       class Forward
       {
       public:
-        Cript::IntConfig proxy_auth_to_parent{"proxy.config.http.forward.proxy_auth_to_parent"};
+        cripts::IntConfig proxy_auth_to_parent{"proxy.config.http.forward.proxy_auth_to_parent"};
       }; // End class Forward
 
     public:
       Forward forward;
 
-      Cript::IntConfig    forward_connect_method{"proxy.config.http.forward_connect_method"};
-      Cript::StringConfig global_user_agent_header{"proxy.config.http.global_user_agent_header"};
-      Cript::IntConfig    insert_age_in_response{"proxy.config.http.insert_age_in_response"};
-      Cript::IntConfig    insert_client_ip{"proxy.config.http.insert_client_ip"};
-      Cript::StringConfig insert_forwarded{"proxy.config.http.insert_forwarded"};
-      Cript::IntConfig    insert_request_via_str{"proxy.config.http.insert_request_via_str"};
-      Cript::IntConfig    insert_response_via_str{"proxy.config.http.insert_response_via_str"};
-      Cript::IntConfig    insert_squid_x_forwarded_for{"proxy.config.http.insert_squid_x_forwarded_for"};
-      Cript::IntConfig    keep_alive_enabled_in{"proxy.config.http.keep_alive_enabled_in"};
-      Cript::IntConfig    keep_alive_enabled_out{"proxy.config.http.keep_alive_enabled_out"};
-      Cript::IntConfig    keep_alive_no_activity_timeout_in{"proxy.config.http.keep_alive_no_activity_timeout_in"};
-      Cript::IntConfig    keep_alive_no_activity_timeout_out{"proxy.config.http.keep_alive_no_activity_timeout_out"};
-      Cript::IntConfig    keep_alive_post_out{"proxy.config.http.keep_alive_post_out"};
-      Cript::IntConfig    max_proxy_cycles{"proxy.config.http.max_proxy_cycles"};
-      Cript::IntConfig    negative_caching_enabled{"proxy.config.http.negative_caching_enabled"};
-      Cript::IntConfig    negative_caching_lifetime{"proxy.config.http.negative_caching_lifetime"};
-      Cript::IntConfig    negative_revalidating_enabled{"proxy.config.http.negative_revalidating_enabled"};
-      Cript::IntConfig    negative_revalidating_lifetime{"proxy.config.http.negative_revalidating_lifetime"};
-      Cript::IntConfig    no_dns_just_forward_to_parent{"proxy.config.http.no_dns_just_forward_to_parent"};
-      Cript::IntConfig    normalize_ae{"proxy.config.http.normalize_ae"};
-      Cript::IntConfig    number_of_redirections{"proxy.config.http.number_of_redirections"};
+      cripts::IntConfig    forward_connect_method{"proxy.config.http.forward_connect_method"};
+      cripts::StringConfig global_user_agent_header{"proxy.config.http.global_user_agent_header"};
+      cripts::IntConfig    insert_age_in_response{"proxy.config.http.insert_age_in_response"};
+      cripts::IntConfig    insert_client_ip{"proxy.config.http.insert_client_ip"};
+      cripts::StringConfig insert_forwarded{"proxy.config.http.insert_forwarded"};
+      cripts::IntConfig    insert_request_via_str{"proxy.config.http.insert_request_via_str"};
+      cripts::IntConfig    insert_response_via_str{"proxy.config.http.insert_response_via_str"};
+      cripts::IntConfig    insert_squid_x_forwarded_for{"proxy.config.http.insert_squid_x_forwarded_for"};
+      cripts::IntConfig    keep_alive_enabled_in{"proxy.config.http.keep_alive_enabled_in"};
+      cripts::IntConfig    keep_alive_enabled_out{"proxy.config.http.keep_alive_enabled_out"};
+      cripts::IntConfig    keep_alive_no_activity_timeout_in{"proxy.config.http.keep_alive_no_activity_timeout_in"};
+      cripts::IntConfig    keep_alive_no_activity_timeout_out{"proxy.config.http.keep_alive_no_activity_timeout_out"};
+      cripts::IntConfig    keep_alive_post_out{"proxy.config.http.keep_alive_post_out"};
+      cripts::IntConfig    max_proxy_cycles{"proxy.config.http.max_proxy_cycles"};
+      cripts::IntConfig    negative_caching_enabled{"proxy.config.http.negative_caching_enabled"};
+      cripts::IntConfig    negative_caching_lifetime{"proxy.config.http.negative_caching_lifetime"};
+      cripts::IntConfig    negative_revalidating_enabled{"proxy.config.http.negative_revalidating_enabled"};
+      cripts::IntConfig    negative_revalidating_lifetime{"proxy.config.http.negative_revalidating_lifetime"};
+      cripts::IntConfig    no_dns_just_forward_to_parent{"proxy.config.http.no_dns_just_forward_to_parent"};
+      cripts::IntConfig    normalize_ae{"proxy.config.http.normalize_ae"};
+      cripts::IntConfig    number_of_redirections{"proxy.config.http.number_of_redirections"};
 
     private:
       class Parent_Proxy
       {
       public:
-        Cript::IntConfig disable_parent_markdowns{"proxy.config.http.parent_proxy.disable_parent_markdowns"};
-        Cript::IntConfig enable_parent_timeout_markdowns{"proxy.config.http.parent_proxy.enable_parent_timeout_markdowns"};
-        Cript::IntConfig fail_threshold{"proxy.config.http.parent_proxy.fail_threshold"};
-        Cript::IntConfig mark_down_hostdb{"proxy.config.http.parent_proxy.mark_down_hostdb"};
-        Cript::IntConfig per_parent_connect_attempts{"proxy.config.http.parent_proxy.per_parent_connect_attempts"};
-        Cript::IntConfig retry_time{"proxy.config.http.parent_proxy.retry_time"};
-        Cript::IntConfig total_connect_attempts{"proxy.config.http.parent_proxy.total_connect_attempts"};
+        cripts::IntConfig disable_parent_markdowns{"proxy.config.http.parent_proxy.disable_parent_markdowns"};
+        cripts::IntConfig enable_parent_timeout_markdowns{"proxy.config.http.parent_proxy.enable_parent_timeout_markdowns"};
+        cripts::IntConfig fail_threshold{"proxy.config.http.parent_proxy.fail_threshold"};
+        cripts::IntConfig mark_down_hostdb{"proxy.config.http.parent_proxy.mark_down_hostdb"};
+        cripts::IntConfig per_parent_connect_attempts{"proxy.config.http.parent_proxy.per_parent_connect_attempts"};
+        cripts::IntConfig retry_time{"proxy.config.http.parent_proxy.retry_time"};
+        cripts::IntConfig total_connect_attempts{"proxy.config.http.parent_proxy.total_connect_attempts"};
       }; // End class Parent_Proxy
 
     public:
@@ -242,7 +242,7 @@ private:
           class Content_Length
           {
           public:
-            Cript::IntConfig enabled{"proxy.config.http.post.check.content_length.enabled"};
+            cripts::IntConfig enabled{"proxy.config.http.post.check.content_length.enabled"};
           }; // End class Content_Length
 
         public:
@@ -258,20 +258,20 @@ private:
     public:
       Post post;
 
-      Cript::IntConfig    proxy_protocol_out{"proxy.config.http.proxy_protocol_out"};
-      Cript::IntConfig    redirect_use_orig_cache_key{"proxy.config.http.redirect_use_orig_cache_key"};
-      Cript::IntConfig    request_buffer_enabled{"proxy.config.http.request_buffer_enabled"};
-      Cript::IntConfig    request_header_max_size{"proxy.config.http.request_header_max_size"};
-      Cript::IntConfig    response_header_max_size{"proxy.config.http.response_header_max_size"};
-      Cript::IntConfig    response_server_enabled{"proxy.config.http.response_server_enabled"};
-      Cript::StringConfig response_server_str{"proxy.config.http.response_server_str"};
-      Cript::IntConfig    send_http11_requests{"proxy.config.http.send_http11_requests"};
+      cripts::IntConfig    proxy_protocol_out{"proxy.config.http.proxy_protocol_out"};
+      cripts::IntConfig    redirect_use_orig_cache_key{"proxy.config.http.redirect_use_orig_cache_key"};
+      cripts::IntConfig    request_buffer_enabled{"proxy.config.http.request_buffer_enabled"};
+      cripts::IntConfig    request_header_max_size{"proxy.config.http.request_header_max_size"};
+      cripts::IntConfig    response_header_max_size{"proxy.config.http.response_header_max_size"};
+      cripts::IntConfig    response_server_enabled{"proxy.config.http.response_server_enabled"};
+      cripts::StringConfig response_server_str{"proxy.config.http.response_server_str"};
+      cripts::IntConfig    send_http11_requests{"proxy.config.http.send_http11_requests"};
 
     private:
       class Server_Session_Sharing
       {
       public:
-        Cript::StringConfig match{"proxy.config.http.server_session_sharing.match"};
+        cripts::StringConfig match{"proxy.config.http.server_session_sharing.match"};
       }; // End class Server_Session_Sharing
 
     public:
@@ -284,7 +284,7 @@ private:
         class Log
         {
         public:
-          Cript::IntConfig threshold{"proxy.config.http.slow.log.threshold"};
+          cripts::IntConfig threshold{"proxy.config.http.slow.log.threshold"};
         }; // End class Log
 
       public:
@@ -295,11 +295,11 @@ private:
     public:
       Slow slow;
 
-      Cript::IntConfig transaction_active_timeout_in{"proxy.config.http.transaction_active_timeout_in"};
-      Cript::IntConfig transaction_active_timeout_out{"proxy.config.http.transaction_active_timeout_out"};
-      Cript::IntConfig transaction_no_activity_timeout_in{"proxy.config.http.transaction_no_activity_timeout_in"};
-      Cript::IntConfig transaction_no_activity_timeout_out{"proxy.config.http.transaction_no_activity_timeout_out"};
-      Cript::IntConfig uncacheable_requests_bypass_parent{"proxy.config.http.uncacheable_requests_bypass_parent"};
+      cripts::IntConfig transaction_active_timeout_in{"proxy.config.http.transaction_active_timeout_in"};
+      cripts::IntConfig transaction_active_timeout_out{"proxy.config.http.transaction_active_timeout_out"};
+      cripts::IntConfig transaction_no_activity_timeout_in{"proxy.config.http.transaction_no_activity_timeout_in"};
+      cripts::IntConfig transaction_no_activity_timeout_out{"proxy.config.http.transaction_no_activity_timeout_out"};
+      cripts::IntConfig uncacheable_requests_bypass_parent{"proxy.config.http.uncacheable_requests_bypass_parent"};
     }; // End class Http
 
   public:
@@ -309,13 +309,13 @@ private:
     class Net
     {
     public:
-      Cript::IntConfig default_inactivity_timeout{"proxy.config.net.default_inactivity_timeout"};
-      Cript::IntConfig sock_notsent_lowat{"proxy.config.net.sock_notsent_lowat"};
-      Cript::IntConfig sock_option_flag_out{"proxy.config.net.sock_option_flag_out"};
-      Cript::IntConfig sock_packet_mark_out{"proxy.config.net.sock_packet_mark_out"};
-      Cript::IntConfig sock_packet_tos_out{"proxy.config.net.sock_packet_tos_out"};
-      Cript::IntConfig sock_recv_buffer_size_out{"proxy.config.net.sock_recv_buffer_size_out"};
-      Cript::IntConfig sock_send_buffer_size_out{"proxy.config.net.sock_send_buffer_size_out"};
+      cripts::IntConfig default_inactivity_timeout{"proxy.config.net.default_inactivity_timeout"};
+      cripts::IntConfig sock_notsent_lowat{"proxy.config.net.sock_notsent_lowat"};
+      cripts::IntConfig sock_option_flag_out{"proxy.config.net.sock_option_flag_out"};
+      cripts::IntConfig sock_packet_mark_out{"proxy.config.net.sock_packet_mark_out"};
+      cripts::IntConfig sock_packet_tos_out{"proxy.config.net.sock_packet_tos_out"};
+      cripts::IntConfig sock_recv_buffer_size_out{"proxy.config.net.sock_recv_buffer_size_out"};
+      cripts::IntConfig sock_send_buffer_size_out{"proxy.config.net.sock_send_buffer_size_out"};
     }; // End class Net
 
   public:
@@ -328,8 +328,8 @@ private:
       class Vc
       {
       public:
-        Cript::IntConfig default_buffer_index{"proxy.config.plugin.vc.default_buffer_index"};
-        Cript::IntConfig default_buffer_water_mark{"proxy.config.plugin.vc.default_buffer_water_mark"};
+        cripts::IntConfig default_buffer_index{"proxy.config.plugin.vc.default_buffer_index"};
+        cripts::IntConfig default_buffer_water_mark{"proxy.config.plugin.vc.default_buffer_water_mark"};
       }; // End class Vc
 
     public:
@@ -341,7 +341,7 @@ private:
     Plugin plugin;
 
   public:
-    Cript::IntConfig srv_enabled{"proxy.config.srv_enabled"};
+    cripts::IntConfig srv_enabled{"proxy.config.srv_enabled"};
 
   private:
     class Ssl
@@ -356,7 +356,7 @@ private:
           class Cert
           {
           public:
-            Cript::StringConfig filename{"proxy.config.ssl.client.CA.cert.filename"};
+            cripts::StringConfig filename{"proxy.config.ssl.client.CA.cert.filename"};
           }; // End class Cert
 
         public:
@@ -368,14 +368,14 @@ private:
         Ca CA;
 
       public:
-        Cript::StringConfig alpn_protocols{"proxy.config.ssl.client.alpn_protocols"};
+        cripts::StringConfig alpn_protocols{"proxy.config.ssl.client.alpn_protocols"};
 
       private:
         class Cert
         {
         public:
-          Cript::StringConfig filename{"proxy.config.ssl.client.cert.filename"};
-          Cript::StringConfig path{"proxy.config.ssl.client.cert.path"};
+          cripts::StringConfig filename{"proxy.config.ssl.client.cert.filename"};
+          cripts::StringConfig path{"proxy.config.ssl.client.cert.path"};
         }; // End class Cert
 
       public:
@@ -385,13 +385,13 @@ private:
         class Private_Key
         {
         public:
-          Cript::StringConfig filename{"proxy.config.ssl.client.private_key.filename"};
+          cripts::StringConfig filename{"proxy.config.ssl.client.private_key.filename"};
         }; // End class Private_Key
 
       public:
         Private_Key private_key;
 
-        Cript::StringConfig sni_policy{"proxy.config.ssl.client.sni_policy"};
+        cripts::StringConfig sni_policy{"proxy.config.ssl.client.sni_policy"};
 
       private:
         class Verify
@@ -400,8 +400,8 @@ private:
           class Server
           {
           public:
-            Cript::StringConfig policy{"proxy.config.ssl.client.verify.server.policy"};
-            Cript::StringConfig properties{"proxy.config.ssl.client.verify.server.properties"};
+            cripts::StringConfig policy{"proxy.config.ssl.client.verify.server.policy"};
+            cripts::StringConfig properties{"proxy.config.ssl.client.verify.server.properties"};
           }; // End class Server
 
         public:
@@ -418,8 +418,8 @@ private:
       Client client;
 
     public:
-      Cript::IntConfig hsts_include_subdomains{"proxy.config.ssl.hsts_include_subdomains"};
-      Cript::IntConfig hsts_max_age{"proxy.config.ssl.hsts_max_age"};
+      cripts::IntConfig hsts_include_subdomains{"proxy.config.ssl.hsts_include_subdomains"};
+      cripts::IntConfig hsts_max_age{"proxy.config.ssl.hsts_max_age"};
     }; // End class Ssl
 
   public:
@@ -429,7 +429,7 @@ private:
     class Url_Remap
     {
     public:
-      Cript::IntConfig pristine_host_hdr{"proxy.config.url_remap.pristine_host_hdr"};
+      cripts::IntConfig pristine_host_hdr{"proxy.config.url_remap.pristine_host_hdr"};
     }; // End class Url_Remap
 
   public:
@@ -439,8 +439,8 @@ private:
     class Websocket
     {
     public:
-      Cript::IntConfig active_timeout{"proxy.config.websocket.active_timeout"};
-      Cript::IntConfig no_activity_timeout{"proxy.config.websocket.no_activity_timeout"};
+      cripts::IntConfig active_timeout{"proxy.config.websocket.active_timeout"};
+      cripts::IntConfig no_activity_timeout{"proxy.config.websocket.no_activity_timeout"};
     }; // End class Websocket
 
   public:
@@ -453,4 +453,4 @@ public:
 
 }; // End class Proxy
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/Configs.hpp
+++ b/include/cripts/Configs.hpp
@@ -27,6 +27,9 @@
 
 #include "cripts/ConfigsBase.hpp"
 
+namespace Cript
+{
+
 class Proxy
 {
 private:
@@ -166,6 +169,8 @@ private:
 
     public:
       Down_Server down_server;
+
+      Cript::IntConfig drop_chunked_trailers{"proxy.config.http.drop_chunked_trailers"};
 
     private:
       class Flow_Control
@@ -447,3 +452,5 @@ public:
   Config config;
 
 }; // End class Proxy
+
+} // namespace Cript

--- a/include/cripts/ConfigsBase.hpp
+++ b/include/cripts/ConfigsBase.hpp
@@ -25,7 +25,7 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Context.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 class Records
@@ -41,15 +41,15 @@ public:
 
   Records(self_type &&that) = default;
 
-  explicit Records(const Cript::string_view name);
+  explicit Records(const cripts::string_view name);
 
-  ValueType _get(const Cript::Context *context) const;
-  bool      _set(const Cript::Context *context, const ValueType &value) const;
+  ValueType _get(const cripts::Context *context) const;
+  bool      _set(const cripts::Context *context, const ValueType &value) const;
 
   // Optimizations, we can't use string_view in the ValueType since we need persistent storage.
   // Be careful with the setSV() and make sure there's underlying storage!
-  const Cript::string_view GetSV(const Cript::Context *context) const;
-  bool                     SetSV(const Cript::Context *context, const Cript::string_view value) const;
+  const cripts::string_view GetSV(const cripts::Context *context) const;
+  bool                      SetSV(const cripts::Context *context, const cripts::string_view value) const;
 
   [[nodiscard]] TSOverridableConfigKey
   Key() const
@@ -63,7 +63,7 @@ public:
     return _type;
   }
 
-  [[nodiscard]] Cript::string_view
+  [[nodiscard]] cripts::string_view
   Name() const
   {
     return _name;
@@ -94,30 +94,30 @@ public:
   }
 
   static void           Add(const Records *rec);
-  static const Records *Lookup(const Cript::string_view name);
+  static const Records *Lookup(const cripts::string_view name);
 
 private:
-  Cript::string          _name;
+  cripts::string         _name;
   TSOverridableConfigKey _key  = TS_CONFIG_NULL;
   TSRecordDataType       _type = TS_RECORDDATATYPE_NULL;
 
-  static std::unordered_map<Cript::string_view, const Records *> _gRecords;
+  static std::unordered_map<cripts::string_view, const Records *> _gRecords;
 }; // class Records
 
 class IntConfig
 {
 public:
   IntConfig() = delete;
-  explicit IntConfig(const Cript::string_view name) : _record(name) { Records::Add(&_record); }
+  explicit IntConfig(const cripts::string_view name) : _record(name) { Records::Add(&_record); }
 
   float
-  _get(Cript::Context *context) const
+  _get(cripts::Context *context) const
   {
     return std::get<TSMgmtInt>(_record._get(context));
   }
 
   void
-  _set(Cript::Context *context, integer value)
+  _set(cripts::Context *context, integer value)
   {
     _record._set(context, value);
   }
@@ -130,16 +130,16 @@ class FloatConfig
 {
 public:
   FloatConfig() = delete;
-  explicit FloatConfig(const Cript::string_view name) : _record(name) { Records::Add(&_record); }
+  explicit FloatConfig(const cripts::string_view name) : _record(name) { Records::Add(&_record); }
 
   float
-  _get(Cript::Context *context) const
+  _get(cripts::Context *context) const
   {
     return std::get<TSMgmtFloat>(_record._get(context));
   }
 
   void
-  _set(Cript::Context *context, float value)
+  _set(cripts::Context *context, float value)
   {
     _record._set(context, value);
   }
@@ -152,23 +152,23 @@ class StringConfig
 {
 public:
   StringConfig() = delete;
-  explicit StringConfig(const Cript::string_view name) : _record(name) { Records::Add(&_record); }
+  explicit StringConfig(const cripts::string_view name) : _record(name) { Records::Add(&_record); }
 
   std::string
-  _get(Cript::Context *context) const
+  _get(cripts::Context *context) const
   {
     return std::get<std::string>(_record._get(context));
   }
 
   void
-  _set(Cript::Context *context, std::string &value)
+  _set(cripts::Context *context, std::string &value)
   {
     _record.SetSV(context, value);
   }
 
   // Only for the string type!
   const std::string_view
-  GetSV(Cript::Context *context) const
+  GetSV(cripts::Context *context) const
   {
     return _record.GetSV(context);
   }
@@ -177,4 +177,4 @@ private:
   const Records _record;
 }; // class StringConfig
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -346,81 +346,86 @@ protected:
 
 } // namespace detail
 
+namespace Cript
+{
+
 namespace Client
 {
-class Connection : public detail::ConnBase
-{
-  using pe        = detail::ConnBase;
-  using self_type = Connection;
-
-public:
-  Connection()                      = default;
-  Connection(const self_type &)     = delete;
-  void operator=(const self_type &) = delete;
-
-  [[nodiscard]] int  FD() const override;
-  [[nodiscard]] int  Count() const override;
-  static Connection &_get(Cript::Context *context);
-
-  void
-  SetDscp(int val) override
+  class Connection : public detail::ConnBase
   {
-    TSHttpTxnClientPacketDscpSet(_state->txnp, val);
-  }
+    using pe        = detail::ConnBase;
+    using self_type = Connection;
 
-  void
-  SetMark(int val) override
-  {
-    TSHttpTxnClientPacketMarkSet(_state->txnp, val);
-  }
+  public:
+    Connection()                      = default;
+    Connection(const self_type &)     = delete;
+    void operator=(const self_type &) = delete;
 
-  [[nodiscard]] Cript::IP
-  LocalIP() const override
-  {
-    return Cript::IP{TSHttpTxnIncomingAddrGet(_state->txnp)};
-  }
+    [[nodiscard]] int  FD() const override;
+    [[nodiscard]] int  Count() const override;
+    static Connection &_get(Cript::Context *context);
 
-}; // End class Client::Connection
+    void
+    SetDscp(int val) override
+    {
+      TSHttpTxnClientPacketDscpSet(_state->txnp, val);
+    }
+
+    void
+    SetMark(int val) override
+    {
+      TSHttpTxnClientPacketMarkSet(_state->txnp, val);
+    }
+
+    [[nodiscard]] Cript::IP
+    LocalIP() const override
+    {
+      return Cript::IP{TSHttpTxnIncomingAddrGet(_state->txnp)};
+    }
+
+  }; // End class Client::Connection
 
 } // namespace Client
 
 namespace Server
 {
-class Connection : public detail::ConnBase
-{
-  using pe        = detail::ConnBase;
-  using self_type = Connection;
-
-public:
-  Connection()                      = default;
-  Connection(const self_type &)     = delete;
-  void operator=(const self_type &) = delete;
-
-  [[nodiscard]] int  FD() const override;
-  [[nodiscard]] int  Count() const override;
-  static Connection &_get(Cript::Context *context);
-
-  void
-  SetDscp(int val) override
+  class Connection : public detail::ConnBase
   {
-    TSHttpTxnServerPacketDscpSet(_state->txnp, val);
-  }
+    using pe        = detail::ConnBase;
+    using self_type = Connection;
 
-  void
-  SetMark(int val) override
-  {
-    TSHttpTxnServerPacketMarkSet(_state->txnp, val);
-  }
+  public:
+    Connection()                      = default;
+    Connection(const self_type &)     = delete;
+    void operator=(const self_type &) = delete;
 
-  [[nodiscard]] Cript::IP
-  LocalIP() const override
-  {
-    return Cript::IP{TSHttpTxnOutgoingAddrGet(_state->txnp)};
-  }
+    [[nodiscard]] int  FD() const override;
+    [[nodiscard]] int  Count() const override;
+    static Connection &_get(Cript::Context *context);
 
-}; // End class Server::Connection
+    void
+    SetDscp(int val) override
+    {
+      TSHttpTxnServerPacketDscpSet(_state->txnp, val);
+    }
+
+    void
+    SetMark(int val) override
+    {
+      TSHttpTxnServerPacketMarkSet(_state->txnp, val);
+    }
+
+    [[nodiscard]] Cript::IP
+    LocalIP() const override
+    {
+      return Cript::IP{TSHttpTxnOutgoingAddrGet(_state->txnp)};
+    }
+
+  }; // End class Server::Connection
 
 } // namespace Server
+
+} // namespace Cript
 
 // Formatters for {fmt}
 namespace fmt

--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -17,7 +17,7 @@
 */
 #pragma once
 
-namespace Cript
+namespace cripts
 {
 class Context;
 }
@@ -28,7 +28,7 @@ class Context;
 #include "cripts/Lulu.hpp"
 #include "cripts/Matcher.hpp"
 
-namespace Cript
+namespace cripts
 {
 namespace Net
 {
@@ -46,8 +46,8 @@ public:
   IP(const self_type &)             = delete;
   void operator=(const self_type &) = delete;
 
-  Cript::string_view GetSV(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
-  Cript::string_view
+  cripts::string_view GetSV(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
+  cripts::string_view
   string(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128)
   {
     return GetSV(ipv4_cidr, ipv6_cidr);
@@ -62,7 +62,7 @@ private:
   uint16_t _sampler = 0;
 };
 
-} // namespace Cript
+} // namespace cripts
 
 namespace detail
 {
@@ -133,7 +133,7 @@ class ConnBase
     void operator=(const self_type &) = delete;
 
     self_type &
-    operator=([[maybe_unused]] Cript::string_view const &str)
+    operator=([[maybe_unused]] cripts::string_view const &str)
     {
       TSAssert(_owner);
 #if defined(TCP_CONGESTION)
@@ -191,10 +191,10 @@ class ConnBase
     Geo()                             = default;
     void operator=(const self_type &) = delete;
 
-    [[nodiscard]] Cript::string ASN() const;
-    [[nodiscard]] Cript::string ASNName() const;
-    [[nodiscard]] Cript::string Country() const;
-    [[nodiscard]] Cript::string CountryCode() const;
+    [[nodiscard]] cripts::string ASN() const;
+    [[nodiscard]] cripts::string ASNName() const;
+    [[nodiscard]] cripts::string Country() const;
+    [[nodiscard]] cripts::string CountryCode() const;
 
   private:
     ConnBase *_owner = nullptr;
@@ -211,7 +211,7 @@ class ConnBase
     TcpInfo(const self_type &)        = delete;
     void operator=(const self_type &) = delete;
 
-    Cript::string_view Log();
+    cripts::string_view Log();
 
     [[nodiscard]] bool
     Ready() const
@@ -282,9 +282,9 @@ class ConnBase
   private:
     void initialize();
 
-    ConnBase     *_owner = nullptr;
-    bool          _ready = false;
-    Cript::string _logging; // Storage for the logformat of the tcpinfo
+    ConnBase      *_owner = nullptr;
+    bool           _ready = false;
+    cripts::string _logging; // Storage for the logformat of the tcpinfo
 
   }; // End class ConnBase::TcpInfo
 
@@ -303,11 +303,11 @@ public:
     return TSNetVConnRemoteAddrGet(_vc);
   }
 
-  [[nodiscard]] Cript::IP
+  [[nodiscard]] cripts::IP
   IP() const
   {
     TSAssert(Initialized());
-    return Cript::IP{Socket()};
+    return cripts::IP{Socket()};
   }
 
   [[nodiscard]] bool
@@ -322,10 +322,10 @@ public:
     return TSHttpTxnIsInternal(_state->txnp);
   }
 
-  [[nodiscard]] virtual Cript::IP LocalIP() const  = 0;
-  [[nodiscard]] virtual int       Count() const    = 0;
-  virtual void                    SetDscp(int val) = 0;
-  virtual void                    SetMark(int val) = 0;
+  [[nodiscard]] virtual cripts::IP LocalIP() const  = 0;
+  [[nodiscard]] virtual int        Count() const    = 0;
+  virtual void                     SetDscp(int val) = 0;
+  virtual void                     SetMark(int val) = 0;
 
   Dscp       dscp;
   Congestion congestion;
@@ -334,10 +334,10 @@ public:
   Pacing     pacing;
   Mark       mark;
 
-  Cript::string_view string(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
+  cripts::string_view string(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
 
 protected:
-  Cript::Transaction    *_state  = nullptr;
+  cripts::Transaction   *_state  = nullptr;
   struct sockaddr const *_socket = nullptr;
   TSVConn                _vc     = nullptr;
   char                   _str[INET6_ADDRSTRLEN + 1];
@@ -346,7 +346,7 @@ protected:
 
 } // namespace detail
 
-namespace Cript
+namespace cripts
 {
 
 namespace Client
@@ -363,7 +363,7 @@ namespace Client
 
     [[nodiscard]] int  FD() const override;
     [[nodiscard]] int  Count() const override;
-    static Connection &_get(Cript::Context *context);
+    static Connection &_get(cripts::Context *context);
 
     void
     SetDscp(int val) override
@@ -377,10 +377,10 @@ namespace Client
       TSHttpTxnClientPacketMarkSet(_state->txnp, val);
     }
 
-    [[nodiscard]] Cript::IP
+    [[nodiscard]] cripts::IP
     LocalIP() const override
     {
-      return Cript::IP{TSHttpTxnIncomingAddrGet(_state->txnp)};
+      return cripts::IP{TSHttpTxnIncomingAddrGet(_state->txnp)};
     }
 
   }; // End class Client::Connection
@@ -401,7 +401,7 @@ namespace Server
 
     [[nodiscard]] int  FD() const override;
     [[nodiscard]] int  Count() const override;
-    static Connection &_get(Cript::Context *context);
+    static Connection &_get(cripts::Context *context);
 
     void
     SetDscp(int val) override
@@ -415,22 +415,22 @@ namespace Server
       TSHttpTxnServerPacketMarkSet(_state->txnp, val);
     }
 
-    [[nodiscard]] Cript::IP
+    [[nodiscard]] cripts::IP
     LocalIP() const override
     {
-      return Cript::IP{TSHttpTxnOutgoingAddrGet(_state->txnp)};
+      return cripts::IP{TSHttpTxnOutgoingAddrGet(_state->txnp)};
     }
 
   }; // End class Server::Connection
 
 } // namespace Server
 
-} // namespace Cript
+} // namespace cripts
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Cript::IP> {
+template <> struct formatter<cripts::IP> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -439,7 +439,7 @@ template <> struct formatter<Cript::IP> {
 
   template <typename FormatContext>
   auto
-  format(Cript::IP &ip, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::IP &ip, FormatContext &ctx) -> decltype(ctx.out())
   {
     return format_to(ctx.out(), "{}", ip.GetSV());
   }

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -83,18 +83,18 @@ private:
 
   // These are "pre-allocated", but not initialized. They will be initialized
   // when used via a factory.
-  Client::Response   _client_resp_header;
-  Client::Request    _client_req_header;
-  Client::Connection _client_conn;
-  Client::URL        _client_url;
-  Remap::From::URL   _remap_from_url;
-  Remap::To::URL     _remap_to_url;
-  Pristine::URL      _pristine_url;
-  Server::Response   _server_resp_header;
-  Server::Request    _server_req_header;
-  Server::Connection _server_conn;
-  Cache::URL         _cache_url;
-  Parent::URL        _parent_url;
+  Cript::Client::Response   _client_resp_header;
+  Cript::Client::Request    _client_req_header;
+  Cript::Client::Connection _client_conn;
+  Cript::Client::URL        _client_url;
+  Cript::Remap::From::URL   _remap_from_url;
+  Cript::Remap::To::URL     _remap_to_url;
+  Cript::Pristine::URL      _pristine_url;
+  Cript::Server::Response   _server_resp_header;
+  Cript::Server::Request    _server_req_header;
+  Cript::Server::Connection _server_conn;
+  Cript::Cache::URL         _cache_url;
+  Cript::Parent::URL        _parent_url;
 }; // End class Context
 
 } // namespace Cript

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -30,12 +30,12 @@
 // These are pretty arbitrary for now
 constexpr int CONTEXT_DATA_SLOTS = 4;
 
-namespace Cript
+namespace cripts
 {
 class Context
 {
   using self_type = Context;
-  using DataType  = std::variant<integer, double, boolean, void *, Cript::string>;
+  using DataType  = std::variant<integer, double, boolean, void *, cripts::string>;
 
 public:
   Context()                         = delete;
@@ -43,7 +43,8 @@ public:
   void operator=(const self_type &) = delete;
 
   // This will, and should, only be called via the ProxyAllocator as used in the factory.
-  Context(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst) : rri(rri_ptr), p_instance(inst)
+  Context(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst)
+    : rri(rri_ptr), p_instance(inst)
   {
     state.txnp    = txn_ptr;
     state.ssnp    = ssn_ptr;
@@ -54,15 +55,15 @@ public:
   void reset();
 
   // This uses the ProxyAllocator to create a new Context object.
-  static self_type *Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst);
+  static self_type *Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst);
   void              Release();
 
   // These fields are preserving the parameters as setup in DoRemap()
-  Cript::Transaction                       state;
+  cripts::Transaction                      state;
   std::array<DataType, CONTEXT_DATA_SLOTS> data;
   TSCont                                   default_cont = nullptr;
   TSRemapRequestInfo                      *rri          = nullptr;
-  Cript::Instance                         &p_instance; // p_ == public_, since we can't use "instance"
+  cripts::Instance                        &p_instance; // p_ == public_, since we can't use "instance"
 
   // These are private, but needs to be visible to our friend classes that
   // depends on the Context.
@@ -83,21 +84,21 @@ private:
 
   // These are "pre-allocated", but not initialized. They will be initialized
   // when used via a factory.
-  Cript::Client::Response   _client_resp_header;
-  Cript::Client::Request    _client_req_header;
-  Cript::Client::Connection _client_conn;
-  Cript::Client::URL        _client_url;
-  Cript::Remap::From::URL   _remap_from_url;
-  Cript::Remap::To::URL     _remap_to_url;
-  Cript::Pristine::URL      _pristine_url;
-  Cript::Server::Response   _server_resp_header;
-  Cript::Server::Request    _server_req_header;
-  Cript::Server::Connection _server_conn;
-  Cript::Cache::URL         _cache_url;
-  Cript::Parent::URL        _parent_url;
+  cripts::Client::Response   _client_resp_header;
+  cripts::Client::Request    _client_req_header;
+  cripts::Client::Connection _client_conn;
+  cripts::Client::URL        _client_url;
+  cripts::Remap::From::URL   _remap_from_url;
+  cripts::Remap::To::URL     _remap_to_url;
+  cripts::Pristine::URL      _pristine_url;
+  cripts::Server::Response   _server_resp_header;
+  cripts::Server::Request    _server_req_header;
+  cripts::Server::Connection _server_conn;
+  cripts::Cache::URL         _cache_url;
+  cripts::Parent::URL        _parent_url;
 }; // End class Context
 
-} // namespace Cript
+} // namespace cripts
 
 // This may be weird, but oh well for now.
 #define Get()               _get(context)

--- a/include/cripts/Crypto.hpp
+++ b/include/cripts/Crypto.hpp
@@ -31,7 +31,7 @@
 
 #include "cripts/Lulu.hpp"
 
-namespace Cript::Crypto
+namespace cripts::Crypto
 {
 class Base64
 {
@@ -42,8 +42,8 @@ public:
   Base64(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static Cript::string Encode(Cript::string_view str);
-  static Cript::string Decode(Cript::string_view str);
+  static cripts::string Encode(cripts::string_view str);
+  static cripts::string Decode(cripts::string_view str);
 
 }; // End class Crypto::Base64
 
@@ -56,8 +56,8 @@ public:
   Escape(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static Cript::string Encode(Cript::string_view str);
-  static Cript::string Decode(Cript::string_view str);
+  static cripts::string Encode(cripts::string_view str);
+  static cripts::string Decode(cripts::string_view str);
 
 }; // End class Crypto::Escape
 
@@ -75,24 +75,24 @@ namespace detail
 
     Digest(size_t len) : _length(len) { TSAssert(len <= EVP_MAX_MD_SIZE); }
 
-    [[nodiscard]] Cript::string
+    [[nodiscard]] cripts::string
     Hex() const
     {
       return ts::hex({reinterpret_cast<const char *>(_hash), _length});
     }
 
-    operator Cript::string() const { return Hex(); }
+    operator cripts::string() const { return Hex(); }
 
-    [[nodiscard]] Cript::string
+    [[nodiscard]] cripts::string
     String() const
     {
       return {reinterpret_cast<const char *>(_hash), _length};
     }
 
-    [[nodiscard]] Cript::string
+    [[nodiscard]] cripts::string
     Base64() const
     {
-      return Crypto::Base64::Encode(Cript::string_view(reinterpret_cast<const char *>(_hash), _length));
+      return Crypto::Base64::Encode(cripts::string_view(reinterpret_cast<const char *>(_hash), _length));
     }
 
     [[nodiscard]] const unsigned char *
@@ -118,36 +118,36 @@ namespace detail
 
     ~Cipher() { EVP_CIPHER_CTX_free(_ctx); }
 
-    virtual void               Encrypt(Cript::string_view str);
-    virtual Cript::string_view Finalize();
+    virtual void                Encrypt(cripts::string_view str);
+    virtual cripts::string_view Finalize();
 
-    operator Cript::string_view() const { return {_message}; }
+    operator cripts::string_view() const { return {_message}; }
 
-    [[nodiscard]] Cript::string
+    [[nodiscard]] cripts::string
     Message() const
     {
       return _message;
     }
 
-    [[nodiscard]] Cript::string
+    [[nodiscard]] cripts::string
     Base64() const
     {
       return Crypto::Base64::Encode(_message);
     }
 
-    [[nodiscard]] Cript::string
+    [[nodiscard]] cripts::string
     Hex() const
     {
       return ts::hex(_message);
     }
 
-    operator Cript::string() const { return Hex(); }
+    operator cripts::string() const { return Hex(); }
 
   protected:
     Cipher(const unsigned char *key, int len) : _key_len(len) { memcpy(_key, key, len); }
     virtual void _initialize();
 
-    Cript::string     _message;
+    cripts::string    _message;
     unsigned char     _key[EVP_MAX_KEY_LENGTH];
     int               _key_len = 0;
     int               _length  = 0;
@@ -171,7 +171,7 @@ public:
   SHA256(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static self_type Encode(Cript::string_view str);
+  static self_type Encode(cripts::string_view str);
 }; // End class SHA256
 
 class SHA512 : public detail::Digest
@@ -187,7 +187,7 @@ public:
   SHA512(const self_type &)         = delete;
   void operator=(const self_type &) = delete;
 
-  static self_type Encode(Cript::string_view str);
+  static self_type Encode(cripts::string_view str);
 }; // End class SHA512
 
 class MD5 : public detail::Digest
@@ -203,7 +203,7 @@ public:
   MD5(const self_type &)            = delete;
   void operator=(const self_type &) = delete;
 
-  static self_type Encode(Cript::string_view str);
+  static self_type Encode(cripts::string_view str);
 }; // End class MD5
 
 class AES256 : public detail::Cipher
@@ -224,10 +224,10 @@ public:
   void operator=(const self_type &) = delete;
 
   // The key has to be 256-bit afaik
-  static self_type Encrypt(Cript::string_view str, const unsigned char *key);
+  static self_type Encrypt(cripts::string_view str, const unsigned char *key);
 
   static self_type
-  Encrypt(Cript::string_view str, SHA256 &key)
+  Encrypt(cripts::string_view str, SHA256 &key)
   {
     return Encrypt(str, key.Hash());
   }
@@ -257,16 +257,16 @@ namespace HMAC
     SHA256(const self_type &)         = delete;
     void operator=(const self_type &) = delete;
 
-    static self_type Encrypt(Cript::string_view str, const Cript::string &key);
+    static self_type Encrypt(cripts::string_view str, const cripts::string &key);
   }; // End class SHA256
 } // namespace HMAC
 
-} // namespace Cript::Crypto
+} // namespace cripts::Crypto
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Cript::Crypto::SHA256> {
+template <> struct formatter<cripts::Crypto::SHA256> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -275,13 +275,13 @@ template <> struct formatter<Cript::Crypto::SHA256> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Crypto::SHA256 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Crypto::SHA256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
 };
 
-template <> struct formatter<Cript::Crypto::SHA512> {
+template <> struct formatter<cripts::Crypto::SHA512> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -290,13 +290,13 @@ template <> struct formatter<Cript::Crypto::SHA512> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Crypto::SHA512 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Crypto::SHA512 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
 };
 
-template <> struct formatter<Cript::Crypto::AES256> {
+template <> struct formatter<cripts::Crypto::AES256> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -305,9 +305,9 @@ template <> struct formatter<Cript::Crypto::AES256> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Crypto::AES256 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Crypto::AES256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", Cript::Crypto::Base64::Encode(sha.Message()));
+    return fmt::format_to(ctx.out(), "{}", cripts::Crypto::Base64::Encode(sha.Message()));
   }
 };
 

--- a/include/cripts/Crypto.hpp
+++ b/include/cripts/Crypto.hpp
@@ -31,7 +31,7 @@
 
 #include "cripts/Lulu.hpp"
 
-namespace Crypto
+namespace Cript::Crypto
 {
 class Base64
 {
@@ -261,12 +261,12 @@ namespace HMAC
   }; // End class SHA256
 } // namespace HMAC
 
-} // namespace Crypto
+} // namespace Cript::Crypto
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Crypto::SHA256> {
+template <> struct formatter<Cript::Crypto::SHA256> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -275,13 +275,13 @@ template <> struct formatter<Crypto::SHA256> {
 
   template <typename FormatContext>
   auto
-  format(Crypto::SHA256 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Crypto::SHA256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
 };
 
-template <> struct formatter<Crypto::SHA512> {
+template <> struct formatter<Cript::Crypto::SHA512> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -290,13 +290,13 @@ template <> struct formatter<Crypto::SHA512> {
 
   template <typename FormatContext>
   auto
-  format(Crypto::SHA512 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Crypto::SHA512 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
 };
 
-template <> struct formatter<Crypto::AES256> {
+template <> struct formatter<Cript::Crypto::AES256> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -305,9 +305,9 @@ template <> struct formatter<Crypto::AES256> {
 
   template <typename FormatContext>
   auto
-  format(Crypto::AES256 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Crypto::AES256 &sha, FormatContext &ctx) -> decltype(ctx.out())
   {
-    return fmt::format_to(ctx.out(), "{}", Crypto::Base64::Encode(sha.Message()));
+    return fmt::format_to(ctx.out(), "{}", Cript::Crypto::Base64::Encode(sha.Message()));
   }
 };
 

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -238,7 +238,7 @@ int
 default_cont(TSCont contp, TSEvent event, void *edata)
 {
   auto  txnp    = static_cast<TSHttpTxn>(edata);
-  auto *context = static_cast<Cript::Context *>(TSContDataGet(contp));
+  auto *context = static_cast<cripts::Context *>(TSContDataGet(contp));
 
   context->reset(); // Clears the cached handles to internal ATS data (mloc's etc.)
 
@@ -249,15 +249,15 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_send_request()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & cripts::Callbacks::DO_SEND_REQUEST) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->Callbacks() & Cript::Callbacks::DO_SEND_REQUEST) {
+          if (bundle->Callbacks() & cripts::Callbacks::DO_SEND_REQUEST) {
             bundle->doSendRequest(context);
           }
         }
       }
       wrap_send_request(context, true, CaseArg);
-      Cript::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
     }
     break;
   case TS_EVENT_HTTP_READ_RESPONSE_HDR: // 60006
@@ -266,9 +266,9 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_read_response()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & cripts::Callbacks::DO_READ_RESPONSE) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->Callbacks() & Cript::Callbacks::DO_READ_RESPONSE) {
+          if (bundle->Callbacks() & cripts::Callbacks::DO_READ_RESPONSE) {
             bundle->doReadResponse(context);
           }
         }
@@ -282,9 +282,9 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_send_response()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & cripts::Callbacks::DO_SEND_RESPONSE) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->Callbacks() & Cript::Callbacks::DO_SEND_RESPONSE) {
+          if (bundle->Callbacks() & cripts::Callbacks::DO_SEND_RESPONSE) {
             bundle->doSendResponse(context);
           }
         }
@@ -294,13 +294,13 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     break;
   case TS_EVENT_HTTP_TXN_CLOSE: // 60012
     context->state.hook = TS_HTTP_TXN_CLOSE_HOOK;
-    if (context->state.enabled_hooks & Cript::Callbacks::DO_TXN_CLOSE) {
+    if (context->state.enabled_hooks & cripts::Callbacks::DO_TXN_CLOSE) {
       CDebug("Entering do_txn_close()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & cripts::Callbacks::DO_TXN_CLOSE) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->Callbacks() & Cript::Callbacks::DO_TXN_CLOSE) {
+          if (bundle->Callbacks() & cripts::Callbacks::DO_TXN_CLOSE) {
             bundle->doTxnClose(context);
           }
         }
@@ -317,9 +317,9 @@ default_cont(TSCont contp, TSEvent event, void *edata)
       CDebug("Entering do_cache_lookup()");
 
       // Call any bundle callbacks that are registered for this hook
-      if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
+      if (!context->state.error.Failed() && context->p_instance.Callbacks() & cripts::Callbacks::DO_CACHE_LOOKUP) {
         for (auto &bundle : context->p_instance.bundles) {
-          if (bundle->Callbacks() & Cript::Callbacks::DO_CACHE_LOOKUP) {
+          if (bundle->Callbacks() & cripts::Callbacks::DO_CACHE_LOOKUP) {
             bundle->doCacheLookup(context);
           }
         }
@@ -332,9 +332,9 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     CDebug("Entering do_post_remap()");
 
     // Call any bundle callbacks that are registered for this hook
-    if (!context->state.error.Failed() && context->p_instance.Callbacks() & Cript::Callbacks::DO_POST_REMAP) {
+    if (!context->state.error.Failed() && context->p_instance.Callbacks() & cripts::Callbacks::DO_POST_REMAP) {
       for (auto &bundle : context->p_instance.bundles) {
-        if (bundle->Callbacks() & Cript::Callbacks::DO_POST_REMAP) {
+        if (bundle->Callbacks() & cripts::Callbacks::DO_POST_REMAP) {
           bundle->doPostRemap(context);
         }
       }
@@ -342,8 +342,8 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     wrap_post_remap(context, true, CaseArg);
 
     if (!context->state.error.Failed()) {
-      Cript::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
-      Cript::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      cripts::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
+      cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
     }
     break;
     // This is for cleanup, and should always be called / wrapped
@@ -396,16 +396,16 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
-  auto                  *inst = new Cript::Instance(argc, argv);
-  Cript::InstanceContext context(*inst);
-  bool                   needs_create_instance = wrap_create_instance(&context, false, CaseArg);
+  auto                   *inst = new cripts::Instance(argc, argv);
+  cripts::InstanceContext context(*inst);
+  bool                    needs_create_instance = wrap_create_instance(&context, false, CaseArg);
 
   if (needs_create_instance) {
     wrap_create_instance(&context, true, CaseArg);
   }
 
   if (!inst->Failed()) {
-    std::vector<Cript::Bundle::Error> errors;
+    std::vector<cripts::Bundle::Error> errors;
 
     for (auto &bundle : inst->bundles) {
       // Collect all the callbacks needed from all bundles, and validate them
@@ -431,7 +431,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     *ih = static_cast<void *>(inst);
 
     inst->debug("Created a new instance for Cript = {}", inst->plugin_debug_tag);
-    inst->debug("The context data size = {}", sizeof(Cript::Context));
+    inst->debug("The context data size = {}", sizeof(cripts::Context));
 
     return TS_SUCCESS;
   } else {
@@ -443,9 +443,9 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 void
 TSRemapDeleteInstance(void *ih)
 {
-  auto                   inst = static_cast<Cript::Instance *>(ih);
-  Cript::InstanceContext context(*inst);
-  bool                   needs_delete_instance = wrap_delete_instance(&context, false, CaseArg);
+  auto                    inst = static_cast<cripts::Instance *>(ih);
+  cripts::InstanceContext context(*inst);
+  bool                    needs_delete_instance = wrap_delete_instance(&context, false, CaseArg);
 
   if (needs_delete_instance) {
     wrap_delete_instance(&context, true, CaseArg);
@@ -461,25 +461,25 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 {
   // Check to see if we need to setup future hooks with a continuation. This
   // should only happen once.
-  static bool     cript_needs_do_remap = wrap_do_remap(static_cast<Cript::Context *>(nullptr), false, CaseArg);
+  static bool     cript_needs_do_remap = wrap_do_remap(static_cast<cripts::Context *>(nullptr), false, CaseArg);
   static unsigned cript_enabled_hooks =
-    (wrap_post_remap(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_POST_REMAP : 0) |
-    (wrap_send_response(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_SEND_RESPONSE : 0) |
-    (wrap_send_request(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_SEND_REQUEST : 0) |
-    (wrap_read_response(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_READ_RESPONSE : 0) |
-    (wrap_cache_lookup(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_CACHE_LOOKUP : 0) |
-    (wrap_txn_close(static_cast<Cript::Context *>(nullptr), false, CaseArg) ? Cript::Callbacks::DO_TXN_CLOSE : 0);
+    (wrap_post_remap(static_cast<cripts::Context *>(nullptr), false, CaseArg) ? cripts::Callbacks::DO_POST_REMAP : 0) |
+    (wrap_send_response(static_cast<cripts::Context *>(nullptr), false, CaseArg) ? cripts::Callbacks::DO_SEND_RESPONSE : 0) |
+    (wrap_send_request(static_cast<cripts::Context *>(nullptr), false, CaseArg) ? cripts::Callbacks::DO_SEND_REQUEST : 0) |
+    (wrap_read_response(static_cast<cripts::Context *>(nullptr), false, CaseArg) ? cripts::Callbacks::DO_READ_RESPONSE : 0) |
+    (wrap_cache_lookup(static_cast<cripts::Context *>(nullptr), false, CaseArg) ? cripts::Callbacks::DO_CACHE_LOOKUP : 0) |
+    (wrap_txn_close(static_cast<cripts::Context *>(nullptr), false, CaseArg) ? cripts::Callbacks::DO_TXN_CLOSE : 0);
 
   TSHttpSsn ssnp         = TSHttpTxnSsnGet(txnp);
-  auto     *inst         = static_cast<Cript::Instance *>(ih);
+  auto     *inst         = static_cast<cripts::Instance *>(ih);
   auto      bundle_cbs   = inst->Callbacks();
-  auto     *context      = Cript::Context::Factory(txnp, ssnp, rri, *inst);
+  auto     *context      = cripts::Context::Factory(txnp, ssnp, rri, *inst);
   bool      keep_context = false;
 
   context->state.hook          = TS_HTTP_READ_REQUEST_HDR_HOOK; // Not quite true
   context->state.enabled_hooks = (cript_enabled_hooks | bundle_cbs);
 
-  if (cript_needs_do_remap || bundle_cbs & Cript::Callbacks::DO_REMAP) {
+  if (cript_needs_do_remap || bundle_cbs & cripts::Callbacks::DO_REMAP) {
     CDebug("Entering do_remap()");
     for (auto &bundle : context->p_instance.bundles) {
       bundle->doRemap(context);
@@ -491,30 +491,30 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   // Don't do the callbacks when we are in a failure state.
   if (!context->state.error.Failed()) {
-    Cript::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
-    Cript::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+    cripts::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
+    cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
 
-    if (context->state.enabled_hooks >= Cript::Callbacks::DO_POST_REMAP) {
+    if (context->state.enabled_hooks >= cripts::Callbacks::DO_POST_REMAP) {
       context->default_cont = TSContCreate(default_cont, nullptr);
       TSContDataSet(context->default_cont, context);
 
-      if (context->state.enabled_hooks & Cript::Callbacks::DO_POST_REMAP) {
+      if (context->state.enabled_hooks & cripts::Callbacks::DO_POST_REMAP) {
         TSHttpTxnHookAdd(txnp, TS_HTTP_POST_REMAP_HOOK, context->default_cont);
       }
 
-      if (context->state.enabled_hooks & Cript::Callbacks::DO_SEND_RESPONSE) {
+      if (context->state.enabled_hooks & cripts::Callbacks::DO_SEND_RESPONSE) {
         TSHttpTxnHookAdd(txnp, TS_HTTP_SEND_RESPONSE_HDR_HOOK, context->default_cont);
       }
 
-      if (context->state.enabled_hooks & Cript::Callbacks::DO_SEND_REQUEST) {
+      if (context->state.enabled_hooks & cripts::Callbacks::DO_SEND_REQUEST) {
         TSHttpTxnHookAdd(txnp, TS_HTTP_SEND_REQUEST_HDR_HOOK, context->default_cont);
       }
 
-      if (context->state.enabled_hooks & Cript::Callbacks::DO_READ_RESPONSE) {
+      if (context->state.enabled_hooks & cripts::Callbacks::DO_READ_RESPONSE) {
         TSHttpTxnHookAdd(txnp, TS_HTTP_READ_RESPONSE_HDR_HOOK, context->default_cont);
       }
 
-      if (context->state.enabled_hooks & Cript::Callbacks::DO_CACHE_LOOKUP) {
+      if (context->state.enabled_hooks & cripts::Callbacks::DO_CACHE_LOOKUP) {
         TSHttpTxnHookAdd(txnp, TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK, context->default_cont);
       }
 
@@ -539,7 +539,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   }
 
   // See if the Client URL was modified, which dicates the return code here.
-  if (Cript::Client::URL::_get(context).Modified()) {
+  if (cripts::Client::URL::_get(context).Modified()) {
     context->p_instance.debug("Client::URL was modified, returning TSREMAP_DID_REMAP");
     return TSREMAP_DID_REMAP;
   } else {

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -257,7 +257,7 @@ default_cont(TSCont contp, TSEvent event, void *edata)
         }
       }
       wrap_send_request(context, true, CaseArg);
-      Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      Cript::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
     }
     break;
   case TS_EVENT_HTTP_READ_RESPONSE_HDR: // 60006
@@ -342,8 +342,8 @@ default_cont(TSCont contp, TSEvent event, void *edata)
     wrap_post_remap(context, true, CaseArg);
 
     if (!context->state.error.Failed()) {
-      Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
-      Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      Cript::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
+      Cript::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
     }
     break;
     // This is for cleanup, and should always be called / wrapped
@@ -491,8 +491,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   // Don't do the callbacks when we are in a failure state.
   if (!context->state.error.Failed()) {
-    Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
-    Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+    Cript::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
+    Cript::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
 
     if (context->state.enabled_hooks >= Cript::Callbacks::DO_POST_REMAP) {
       context->default_cont = TSContCreate(default_cont, nullptr);
@@ -539,7 +539,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   }
 
   // See if the Client URL was modified, which dicates the return code here.
-  if (Client::URL::_get(context).Modified()) {
+  if (Cript::Client::URL::_get(context).Modified()) {
     context->p_instance.debug("Client::URL was modified, returning TSREMAP_DID_REMAP");
     return TSREMAP_DID_REMAP;
   } else {

--- a/include/cripts/Error.hpp
+++ b/include/cripts/Error.hpp
@@ -24,7 +24,7 @@
 
 #include "cripts/Lulu.hpp"
 
-namespace Cript
+namespace cripts
 {
 class Context;
 
@@ -40,24 +40,24 @@ public:
     Reason(const self_type &)         = delete;
     void operator=(const self_type &) = delete;
 
-    static void _set(Cript::Context *context, const Cript::string_view msg);
+    static void _set(cripts::Context *context, const cripts::string_view msg);
 
   private:
     friend class Error;
 
-    [[nodiscard]] Cript::string_view
+    [[nodiscard]] cripts::string_view
     _getter() const
     {
       return {_reason.c_str(), _reason.size()};
     }
 
     void
-    _setter(const Cript::string_view msg)
+    _setter(const cripts::string_view msg)
     {
       _reason = msg;
     }
 
-    Cript::string _reason;
+    cripts::string _reason;
   };
 
 #undef Status
@@ -71,15 +71,15 @@ public:
     Status(const self_type &)         = delete;
     void operator=(const self_type &) = delete;
 
-    static void _set(Cript::Context *context, TSHttpStatus _status);
+    static void _set(cripts::Context *context, TSHttpStatus _status);
 
     static void
-    _set(Cript::Context *context, int _status)
+    _set(cripts::Context *context, int _status)
     {
       _set(context, static_cast<TSHttpStatus>(_status));
     }
 
-    static TSHttpStatus _get(Cript::Context *context);
+    static TSHttpStatus _get(cripts::Context *context);
 
   private:
     friend class Error;
@@ -116,7 +116,7 @@ public:
   }
 
   // Check if we have an error, and set appropriate exit codes etc.
-  void Execute(Cript::Context *context);
+  void Execute(cripts::Context *context);
 
 private:
   Reason _reason;
@@ -124,4 +124,4 @@ private:
   bool   _failed = false;
 };
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/Error.hpp
+++ b/include/cripts/Error.hpp
@@ -27,7 +27,6 @@
 namespace Cript
 {
 class Context;
-}
 
 class Error
 {
@@ -124,3 +123,5 @@ private:
   Status _status;
   bool   _failed = false;
 };
+
+} // namespace Cript

--- a/include/cripts/Files.hpp
+++ b/include/cripts/Files.hpp
@@ -22,7 +22,7 @@
 
 #include "cripts/Lulu.hpp"
 
-namespace Cript::File
+namespace cripts::File
 {
 
 class Path : public std::filesystem::path
@@ -52,14 +52,14 @@ namespace Line
     void operator=(const self_type &) = delete;
 
     explicit Reader(const std::string &path) : _path(path), _stream{path} {}
-    explicit Reader(const Cript::string_view path) : _path(path), _stream{_path} {}
+    explicit Reader(const cripts::string_view path) : _path(path), _stream{_path} {}
 
-    operator Cript::string() { return Line(); }
+    operator cripts::string() { return Line(); }
 
-    Cript::string
+    cripts::string
     Line()
     {
-      Cript::string line;
+      cripts::string line;
 
       if (_stream) {
         std::getline(_stream, line);
@@ -75,4 +75,4 @@ namespace Line
 
 } // namespace Line
 
-} // namespace Cript::File
+} // namespace cripts::File

--- a/include/cripts/Files.hpp
+++ b/include/cripts/Files.hpp
@@ -22,7 +22,7 @@
 
 #include "cripts/Lulu.hpp"
 
-namespace File
+namespace Cript::File
 {
 
 class Path : public std::filesystem::path
@@ -75,4 +75,4 @@ namespace Line
 
 } // namespace Line
 
-} // namespace File
+} // namespace Cript::File

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -26,6 +26,9 @@
 #include "cripts/Transaction.hpp"
 #include "cripts/Lulu.hpp"
 
+namespace Cript
+{
+
 class Header
 {
   using self_type = Header;
@@ -46,7 +49,7 @@ public:
     Header      *_owner  = nullptr;
     TSHttpStatus _status = TS_HTTP_STATUS_NONE;
 
-  }; // End class Header::Status
+  }; // End class Cript::Header::Status
 
   class Reason
   {
@@ -60,7 +63,7 @@ public:
 
   private:
     Header *_owner = nullptr;
-  }; // End class Header::Reason
+  }; // End class Cript::Header::Reason
 
   class Body
   {
@@ -74,7 +77,7 @@ public:
 
   private:
     Header *_owner = nullptr;
-  }; // End class Header::Body
+  }; // End class Cript::Header::Body
 
   class Method
   {
@@ -95,7 +98,7 @@ public:
     operator Cript::string_view() { return GetSV(); }
 
     // ToDo: This is a bit weird, but seems needed (for now) to allow for the
-    // Header::Method::* constants.
+    // Cript::Header::Method::* constants.
     [[nodiscard]] Cript::string_view::const_pointer
     Data() const
     {
@@ -137,7 +140,7 @@ public:
     Header            *_owner = nullptr;
     Cript::string_view _method;
 
-  }; // End class Header::Method
+  }; // End class Cript::Header::Method
 
   class CacheStatus
   {
@@ -173,7 +176,7 @@ public:
     Header            *_owner = nullptr;
     Cript::string_view _cache;
 
-  }; // Class Header::CacheStatus
+  }; // Class Cript::Header::CacheStatus
 
   class String : public Cript::StringViewMixin<String>
   {
@@ -237,7 +240,7 @@ public:
     TSMLoc             _field_loc = nullptr;
     Cript::string_view _name;
 
-  }; // Class Header::String
+  }; // Class Cript::Header::String
 
   class Name : public Cript::StringViewMixin<Name>
   {
@@ -257,7 +260,7 @@ public:
 
     using super_type::StringViewMixin;
 
-  }; // Class Header::Name
+  }; // Class Cript::Header::Name
 
 public:
   class Iterator
@@ -326,7 +329,7 @@ public:
     Header  *_owner = nullptr;
 
     static const Iterator _end;
-  }; // Class Header::iterator
+  }; // Class Cript::Header::iterator
 
   Header() : status(this), reason(this), body(this), cache(this) {}
 
@@ -424,89 +427,87 @@ public:
 
 namespace Client
 {
-class URL;
-class Request : public RequestHeader
-{
-  using super_type = RequestHeader;
-  using self_type  = Request;
+  class URL;
+  class Request : public RequestHeader
+  {
+    using super_type = RequestHeader;
+    using self_type  = Request;
 
-public:
-  Request()                         = default;
-  Request(const self_type &)        = delete;
-  void operator=(const self_type &) = delete;
+  public:
+    Request()                         = default;
+    Request(const self_type &)        = delete;
+    void operator=(const self_type &) = delete;
 
-  // Implemented later, because needs the context.
-  static self_type &_get(Cript::Context *context);
+    // Implemented later, because needs the context.
+    static self_type &_get(Cript::Context *context);
 
-}; // End class Client::Request
+  }; // End class Client::Request
 
-class Response : public ResponseHeader
-{
-  using super_type = ResponseHeader;
-  using self_type  = Response;
+  class Response : public ResponseHeader
+  {
+    using super_type = ResponseHeader;
+    using self_type  = Response;
 
-public:
-  Response()                        = default;
-  Response(const self_type &)       = delete;
-  void operator=(const self_type &) = delete;
+  public:
+    Response()                        = default;
+    Response(const self_type &)       = delete;
+    void operator=(const self_type &) = delete;
 
-  // Implemented later, because needs the context.
-  static self_type &_get(Cript::Context *context);
+    // Implemented later, because needs the context.
+    static self_type &_get(Cript::Context *context);
 
-}; // End class Client::Response
+  }; // End class Client::Response
 
 } // namespace Client
 
 namespace Server
 {
-class Request : public RequestHeader
-{
-  using super_type = RequestHeader;
-  using self_type  = Request;
+  class Request : public RequestHeader
+  {
+    using super_type = RequestHeader;
+    using self_type  = Request;
 
-public:
-  Request()                         = default;
-  Request(const self_type &)        = delete;
-  void operator=(const self_type &) = delete;
+  public:
+    Request()                         = default;
+    Request(const self_type &)        = delete;
+    void operator=(const self_type &) = delete;
 
-  // Implemented later, because needs the context.
-  static Request &_get(Cript::Context *context);
-}; // End class Server::Request
+    // Implemented later, because needs the context.
+    static Request &_get(Cript::Context *context);
+  }; // End class Server::Request
 
-class Response : public ResponseHeader
-{
-  using super_type = ResponseHeader;
-  using self_type  = Response;
+  class Response : public ResponseHeader
+  {
+    using super_type = ResponseHeader;
+    using self_type  = Response;
 
-public:
-  Response()                        = default;
-  Response(const self_type &)       = delete;
-  void operator=(const self_type &) = delete;
+  public:
+    Response()                        = default;
+    Response(const self_type &)       = delete;
+    void operator=(const self_type &) = delete;
 
-  // Implemented later, because needs the context.
-  static self_type &_get(Cript::Context *context);
+    // Implemented later, because needs the context.
+    static self_type &_get(Cript::Context *context);
 
-}; // End class Server::Response
+  }; // End class Server::Response
 
 } // namespace Server
 
 // Some static methods for the Method class
-namespace Cript
-{
 namespace Method
 {
 #undef DELETE // ToDo: macOS shenanigans here, defining DELETE as a macro
-  extern const Header::Method GET;
-  extern const Header::Method HEAD;
-  extern const Header::Method POST;
-  extern const Header::Method PUT;
-  extern const Header::Method PUSH;
-  extern const Header::Method DELETE;
-  extern const Header::Method OPTIONS;
-  extern const Header::Method CONNECT;
-  extern const Header::Method TRACE;
+  extern const Cript::Header::Method GET;
+  extern const Cript::Header::Method HEAD;
+  extern const Cript::Header::Method POST;
+  extern const Cript::Header::Method PUT;
+  extern const Cript::Header::Method PUSH;
+  extern const Cript::Header::Method DELETE;
+  extern const Cript::Header::Method OPTIONS;
+  extern const Cript::Header::Method CONNECT;
+  extern const Cript::Header::Method TRACE;
   // This is a special feature of ATS
-  extern const Header::Method PURGE;
+  extern const Cript::Header::Method PURGE;
 } // namespace Method
 
 class Context;
@@ -515,7 +516,7 @@ class Context;
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Header::Method> {
+template <> struct formatter<Cript::Header::Method> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -524,13 +525,13 @@ template <> struct formatter<Header::Method> {
 
   template <typename FormatContext>
   auto
-  format(Header::Method &method, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Header::Method &method, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", method.GetSV());
   }
 };
 
-template <> struct formatter<Header::String> {
+template <> struct formatter<Cript::Header::String> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -539,13 +540,13 @@ template <> struct formatter<Header::String> {
 
   template <typename FormatContext>
   auto
-  format(Header::String &str, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Header::String &str, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", str.GetSV());
   }
 };
 
-template <> struct formatter<Header::Name> {
+template <> struct formatter<Cript::Header::Name> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -554,7 +555,7 @@ template <> struct formatter<Header::Name> {
 
   template <typename FormatContext>
   auto
-  format(Header::Name &name, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Header::Name &name, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", name.GetSV());
   }

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -26,7 +26,7 @@
 #include "cripts/Transaction.hpp"
 #include "cripts/Lulu.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 class Header
@@ -49,7 +49,7 @@ public:
     Header      *_owner  = nullptr;
     TSHttpStatus _status = TS_HTTP_STATUS_NONE;
 
-  }; // End class Cript::Header::Status
+  }; // End class cripts::Header::Status
 
   class Reason
   {
@@ -59,11 +59,11 @@ public:
     Reason() = delete;
     Reason(Header *owner) : _owner(owner) {}
 
-    self_type &operator=(Cript::string_view reason);
+    self_type &operator=(cripts::string_view reason);
 
   private:
     Header *_owner = nullptr;
-  }; // End class Cript::Header::Reason
+  }; // End class cripts::Header::Reason
 
   class Body
   {
@@ -73,11 +73,11 @@ public:
     Body() = delete;
     Body(Header *owner) : _owner(owner) {}
 
-    self_type &operator=(Cript::string_view body);
+    self_type &operator=(cripts::string_view body);
 
   private:
     Header *_owner = nullptr;
-  }; // End class Cript::Header::Body
+  }; // End class cripts::Header::Body
 
   class Method
   {
@@ -85,40 +85,40 @@ public:
 
   public:
     Method() = delete;
-    Method(Cript::string_view const &method) : _method(method) {}
+    Method(cripts::string_view const &method) : _method(method) {}
     Method(const char *const method, int len)
     {
-      _method = Cript::string_view(method, static_cast<Cript::string_view::size_type>(len));
+      _method = cripts::string_view(method, static_cast<cripts::string_view::size_type>(len));
     }
 
     Method(Header *owner) : _owner(owner) {}
 
-    Cript::string_view GetSV();
+    cripts::string_view GetSV();
 
-    operator Cript::string_view() { return GetSV(); }
+    operator cripts::string_view() { return GetSV(); }
 
     // ToDo: This is a bit weird, but seems needed (for now) to allow for the
-    // Cript::Header::Method::* constants.
-    [[nodiscard]] Cript::string_view::const_pointer
+    // cripts::Header::Method::* constants.
+    [[nodiscard]] cripts::string_view::const_pointer
     Data() const
     {
       CAssert(_method.size() > 0);
       return _method.data();
     }
 
-    Cript::string_view::const_pointer
+    cripts::string_view::const_pointer
     Data()
     {
       return GetSV().data();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     Size()
     {
       return GetSV().size();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     Length()
     {
       return GetSV().size();
@@ -137,10 +137,10 @@ public:
     }
 
   private:
-    Header            *_owner = nullptr;
-    Cript::string_view _method;
+    Header             *_owner = nullptr;
+    cripts::string_view _method;
 
-  }; // End class Cript::Header::Method
+  }; // End class cripts::Header::Method
 
   class CacheStatus
   {
@@ -150,37 +150,37 @@ public:
     CacheStatus() = delete;
     CacheStatus(Header *owner) : _owner(owner) {}
 
-    Cript::string_view GetSV();
+    cripts::string_view GetSV();
 
-    operator Cript::string_view() { return GetSV(); }
+    operator cripts::string_view() { return GetSV(); }
 
-    Cript::string_view::const_pointer
+    cripts::string_view::const_pointer
     Data()
     {
       return GetSV().data();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     Size()
     {
       return GetSV().size();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     Length()
     {
       return GetSV().size();
     }
 
   private:
-    Header            *_owner = nullptr;
-    Cript::string_view _cache;
+    Header             *_owner = nullptr;
+    cripts::string_view _cache;
 
-  }; // Class Cript::Header::CacheStatus
+  }; // Class cripts::Header::CacheStatus
 
-  class String : public Cript::StringViewMixin<String>
+  class String : public cripts::StringViewMixin<String>
   {
-    using super_type = Cript::StringViewMixin<String>;
+    using super_type = cripts::StringViewMixin<String>;
     using self_type  = String;
 
   public:
@@ -194,41 +194,41 @@ public:
 
   public:
     // Implemented in Headers.cc, they are pretty large
-    self_type &operator=(const Cript::string_view str) override;
+    self_type &operator=(const cripts::string_view str) override;
     self_type &operator=(integer val);
-    self_type &operator+=(const Cript::string_view str);
+    self_type &operator+=(const cripts::string_view str);
 
     // These specialized assignment operators all use the above
     template <size_t N>
     self_type &
     operator=(const char (&str)[N])
     {
-      return operator=(Cript::string_view(str, str[N - 1] ? N : N - 1));
+      return operator=(cripts::string_view(str, str[N - 1] ? N : N - 1));
     }
 
     self_type &
     operator=(char *&str)
     {
-      return operator=(Cript::string_view(str, strlen(str)));
+      return operator=(cripts::string_view(str, strlen(str)));
     }
 
     self_type &
     operator=(char const *&str)
     {
-      return operator=(Cript::string_view(str, strlen(str)));
+      return operator=(cripts::string_view(str, strlen(str)));
     }
 
     self_type &
     operator=(const std::string &str)
     {
-      return operator=(Cript::string_view(str));
+      return operator=(cripts::string_view(str));
     }
 
   private:
     friend class Header;
 
     void
-    _initialize(Cript::string_view name, Cript::string_view value, Header *owner, TSMLoc field_loc)
+    _initialize(cripts::string_view name, cripts::string_view value, Header *owner, TSMLoc field_loc)
     {
       _setSV(value);
       _name      = name;
@@ -236,22 +236,22 @@ public:
       _field_loc = field_loc;
     }
 
-    Header            *_owner     = nullptr;
-    TSMLoc             _field_loc = nullptr;
-    Cript::string_view _name;
+    Header             *_owner     = nullptr;
+    TSMLoc              _field_loc = nullptr;
+    cripts::string_view _name;
 
-  }; // Class Cript::Header::String
+  }; // Class cripts::Header::String
 
-  class Name : public Cript::StringViewMixin<Name>
+  class Name : public cripts::StringViewMixin<Name>
   {
-    using super_type = Cript::StringViewMixin<Name>;
+    using super_type = cripts::StringViewMixin<Name>;
     using self_type  = Name;
 
   public:
-    operator Cript::string_view() const { return GetSV(); }
+    operator cripts::string_view() const { return GetSV(); }
 
     self_type &
-    operator=(const Cript::string_view str) override
+    operator=(const cripts::string_view str) override
     {
       _setSV(str);
 
@@ -260,7 +260,7 @@ public:
 
     using super_type::StringViewMixin;
 
-  }; // Class Cript::Header::Name
+  }; // Class cripts::Header::Name
 
 public:
   class Iterator
@@ -329,7 +329,7 @@ public:
     Header  *_owner = nullptr;
 
     static const Iterator _end;
-  }; // Class Cript::Header::iterator
+  }; // Class cripts::Header::iterator
 
   Header() : status(this), reason(this), body(this), cache(this) {}
 
@@ -360,7 +360,7 @@ public:
     return _hdr_loc;
   }
 
-  String operator[](const Cript::string_view str);
+  String operator[](const cripts::string_view str);
 
   [[nodiscard]] bool
   Initialized() const
@@ -369,13 +369,13 @@ public:
   }
 
   void
-  Erase(const Cript::string_view header)
+  Erase(const cripts::string_view header)
   {
     operator[](header) = "";
   }
 
-  Iterator           begin();
-  Cript::string_view iterate(); // This is a little helper for the iterators
+  Iterator            begin();
+  cripts::string_view iterate(); // This is a little helper for the iterators
 
   [[nodiscard]] Iterator
   end() const
@@ -390,16 +390,16 @@ public:
 
 protected:
   void
-  _initialize(Cript::Transaction *state)
+  _initialize(cripts::Transaction *state)
   {
     _state = state;
   }
 
-  TSMBuffer           _bufp         = nullptr;
-  TSMLoc              _hdr_loc      = nullptr;
-  Cript::Transaction *_state        = nullptr; // Pointer into the owning Context's State
-  TSMLoc              _iterator_loc = nullptr;
-  uint32_t            _iterator_tag = 0; // This is used to assure that we don't have more than one active iterator on a header
+  TSMBuffer            _bufp         = nullptr;
+  TSMLoc               _hdr_loc      = nullptr;
+  cripts::Transaction *_state        = nullptr; // Pointer into the owning Context's State
+  TSMLoc               _iterator_loc = nullptr;
+  uint32_t             _iterator_tag = 0; // This is used to assure that we don't have more than one active iterator on a header
 
 }; // End class Header
 
@@ -439,7 +439,7 @@ namespace Client
     void operator=(const self_type &) = delete;
 
     // Implemented later, because needs the context.
-    static self_type &_get(Cript::Context *context);
+    static self_type &_get(cripts::Context *context);
 
   }; // End class Client::Request
 
@@ -454,7 +454,7 @@ namespace Client
     void operator=(const self_type &) = delete;
 
     // Implemented later, because needs the context.
-    static self_type &_get(Cript::Context *context);
+    static self_type &_get(cripts::Context *context);
 
   }; // End class Client::Response
 
@@ -473,7 +473,7 @@ namespace Server
     void operator=(const self_type &) = delete;
 
     // Implemented later, because needs the context.
-    static Request &_get(Cript::Context *context);
+    static Request &_get(cripts::Context *context);
   }; // End class Server::Request
 
   class Response : public ResponseHeader
@@ -487,7 +487,7 @@ namespace Server
     void operator=(const self_type &) = delete;
 
     // Implemented later, because needs the context.
-    static self_type &_get(Cript::Context *context);
+    static self_type &_get(cripts::Context *context);
 
   }; // End class Server::Response
 
@@ -497,26 +497,26 @@ namespace Server
 namespace Method
 {
 #undef DELETE // ToDo: macOS shenanigans here, defining DELETE as a macro
-  extern const Cript::Header::Method GET;
-  extern const Cript::Header::Method HEAD;
-  extern const Cript::Header::Method POST;
-  extern const Cript::Header::Method PUT;
-  extern const Cript::Header::Method PUSH;
-  extern const Cript::Header::Method DELETE;
-  extern const Cript::Header::Method OPTIONS;
-  extern const Cript::Header::Method CONNECT;
-  extern const Cript::Header::Method TRACE;
+  extern const cripts::Header::Method GET;
+  extern const cripts::Header::Method HEAD;
+  extern const cripts::Header::Method POST;
+  extern const cripts::Header::Method PUT;
+  extern const cripts::Header::Method PUSH;
+  extern const cripts::Header::Method DELETE;
+  extern const cripts::Header::Method OPTIONS;
+  extern const cripts::Header::Method CONNECT;
+  extern const cripts::Header::Method TRACE;
   // This is a special feature of ATS
-  extern const Cript::Header::Method PURGE;
+  extern const cripts::Header::Method PURGE;
 } // namespace Method
 
 class Context;
-} // namespace Cript
+} // namespace cripts
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Cript::Header::Method> {
+template <> struct formatter<cripts::Header::Method> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -525,13 +525,13 @@ template <> struct formatter<Cript::Header::Method> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Header::Method &method, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Header::Method &method, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", method.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Header::String> {
+template <> struct formatter<cripts::Header::String> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -540,13 +540,13 @@ template <> struct formatter<Cript::Header::String> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Header::String &str, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Header::String &str, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", str.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Header::Name> {
+template <> struct formatter<cripts::Header::Name> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -555,7 +555,7 @@ template <> struct formatter<Cript::Header::Name> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Header::Name &name, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Header::Name &name, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", name.GetSV());
   }

--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -29,7 +29,7 @@
 #include "cripts/Transaction.hpp"
 #include "cripts/Bundle.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 class Instance
@@ -37,7 +37,7 @@ class Instance
   using self_type = Instance;
 
 public:
-  using DataType = std::variant<integer, double, boolean, void *, Cript::string>;
+  using DataType = std::variant<integer, double, boolean, void *, cripts::string>;
 
   Instance()                        = delete;
   Instance(const self_type &)       = delete;
@@ -54,13 +54,13 @@ public:
     }
   }
 
-  bool AddPlugin(const Cript::string &tag, const Cript::string &plugin, const Plugin::Options &options);
-  bool DeletePlugin(const Cript::string &tag);
-  void AddBundle(Cript::Bundle::Base *bundle);
+  bool AddPlugin(const cripts::string &tag, const cripts::string &plugin, const Plugin::Options &options);
+  bool DeletePlugin(const cripts::string &tag);
+  void AddBundle(cripts::Bundle::Base *bundle);
 
   // This allows Bundles to require hooks as well.
   void
-  NeedCallback(Cript::Callbacks cb)
+  NeedCallback(cripts::Callbacks cb)
   {
     _callbacks |= cb;
   }
@@ -113,12 +113,12 @@ public:
   }
 
   std::array<DataType, 32>                       data;
-  Cript::string                                  to_url;
-  Cript::string                                  from_url;
-  Cript::string                                  plugin_debug_tag;
+  cripts::string                                 to_url;
+  cripts::string                                 from_url;
+  cripts::string                                 plugin_debug_tag;
   std::unordered_map<std::string, Plugin::Remap> plugins;
-  Cript::MetricStorage                           metrics{8};
-  std::vector<Cript::Bundle::Base *>             bundles;
+  cripts::MetricStorage                          metrics{8};
+  std::vector<cripts::Bundle::Base *>            bundles;
 
 private:
   void _initialize(int argc, char *argv[], const char *filename);
@@ -138,9 +138,9 @@ struct InstanceContext {
   InstanceContext(const self_type &) = delete;
   void operator=(const self_type &)  = delete;
 
-  InstanceContext(Cript::Instance &inst) : p_instance(inst) {}
+  InstanceContext(cripts::Instance &inst) : p_instance(inst) {}
 
-  Cript::Instance &p_instance;
+  cripts::Instance &p_instance;
 }; // End struct InstanceContext
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -402,8 +402,6 @@ Cript::string                   Hex(Cript::string_view sv);
 Cript::string                   UnHex(const Cript::string &str);
 Cript::string                   UnHex(Cript::string_view sv);
 
-} // namespace Cript
-
 class Control
 {
   class Base
@@ -538,10 +536,12 @@ public:
   Patch patch;
 }; // End class Versions
 
+} // namespace Cript
+
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Versions> {
+template <> struct formatter<Cript::Versions> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -550,13 +550,13 @@ template <> struct formatter<Versions> {
 
   template <typename FormatContext>
   auto
-  format(Versions &version, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Versions &version, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", version.GetSV());
   }
 };
 
-template <> struct formatter<Versions::Major> {
+template <> struct formatter<Cript::Versions::Major> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -565,13 +565,13 @@ template <> struct formatter<Versions::Major> {
 
   template <typename FormatContext>
   auto
-  format(Versions::Major &major, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Versions::Major &major, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(major));
   }
 };
 
-template <> struct formatter<Versions::Minor> {
+template <> struct formatter<Cript::Versions::Minor> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -580,13 +580,13 @@ template <> struct formatter<Versions::Minor> {
 
   template <typename FormatContext>
   auto
-  format(Versions::Minor &minor, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Versions::Minor &minor, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(minor));
   }
 };
 
-template <> struct formatter<Versions::Patch> {
+template <> struct formatter<Cript::Versions::Patch> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -595,7 +595,7 @@ template <> struct formatter<Versions::Patch> {
 
   template <typename FormatContext>
   auto
-  format(Versions::Patch &patch, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Versions::Patch &patch, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(patch));
   }

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -47,14 +47,14 @@ integer integer_helper(std::string_view sv);
 #define CAssert(...)   TSReleaseAssert(__VA_ARGS__)
 #define CFatal(...)    TSFatal(__VA_ARGS__)
 #define AsBoolean(arg) std::get<boolean>(arg)
-#define AsString(arg)  std::get<Cript::string>(arg)
+#define AsString(arg)  std::get<cripts::string>(arg)
 #define AsInteger(arg) std::get<integer>(arg)
 #define AsFloat(arg)   std::get<double>(arg)
 #define AsPointer(arg) std::get<void *>(arg)
 
-namespace Cript
+namespace cripts
 {
-// Use Cript::string_view consistently, so that it's a one-stop shop for all string_view needs.
+// Use cripts::string_view consistently, so that it's a one-stop shop for all string_view needs.
 using string_view = swoc::TextView;
 
 namespace details
@@ -74,13 +74,13 @@ class Context;
 template <typename ChildT> class StringViewMixin
 {
   using self_type  = StringViewMixin;
-  using mixin_type = Cript::string_view;
+  using mixin_type = cripts::string_view;
 
 public:
   constexpr StringViewMixin() = default;
   constexpr StringViewMixin(const char *s) { _value = mixin_type(s, strlen(s)); }
   constexpr StringViewMixin(const char *s, mixin_type::size_type count) { _value = mixin_type(s, count); }
-  constexpr StringViewMixin(const Cript::string_view &str) { _value = str; }
+  constexpr StringViewMixin(const cripts::string_view &str) { _value = str; }
 
   virtual self_type &operator=(const mixin_type str) = 0;
 
@@ -125,7 +125,7 @@ public:
   self_type &
   clear()
   {
-    _value = Cript::string_view();
+    _value = cripts::string_view();
     return *this;
   }
 
@@ -240,31 +240,31 @@ public:
   }
 
   [[nodiscard]] constexpr bool
-  ends_with(Cript::string_view const suffix) const
+  ends_with(cripts::string_view const suffix) const
   {
     return _value.ends_with(suffix);
   }
 
   [[nodiscard]] constexpr bool
-  starts_with(Cript::string_view const prefix) const
+  starts_with(cripts::string_view const prefix) const
   {
     return _value.starts_with(prefix);
   }
 
   [[nodiscard]] constexpr mixin_type::size_type
-  find(Cript::string_view const substr, mixin_type::size_type pos = 0) const
+  find(cripts::string_view const substr, mixin_type::size_type pos = 0) const
   {
     return _value.find(substr, pos);
   }
 
   [[nodiscard]] constexpr mixin_type::size_type
-  rfind(Cript::string_view const substr, mixin_type::size_type pos = 0) const
+  rfind(cripts::string_view const substr, mixin_type::size_type pos = 0) const
   {
     return _value.rfind(substr, pos);
   }
 
   [[nodiscard]] constexpr bool
-  contains(Cript::string_view const substr) const
+  contains(cripts::string_view const substr) const
   {
     return (_value.find(substr) != _value.npos);
   }
@@ -278,7 +278,7 @@ protected:
 
 private:
   mixin_type _value;
-}; // End class Cript::StringViewMixin
+}; // End class cripts::StringViewMixin
 
 class string : public std::string
 {
@@ -289,7 +289,7 @@ public:
   using std::string::string;
 
   // ToDo: This broke when switching to swoc::TextView
-  // using std::string::operator Cript::string_view;
+  // using std::string::operator cripts::string_view;
   using super_type::operator+=;
   using super_type::operator[];
 
@@ -301,7 +301,7 @@ public:
   }
 
   self_type &
-  operator=(const Cript::string_view &str)
+  operator=(const cripts::string_view &str)
   {
     super_type::operator=(str);
     return *this;
@@ -316,11 +316,11 @@ public:
 
   string(const self_type &that) : super_type(that) {}
 
-  // This allows for a std::string to be moved to a Cript::string
+  // This allows for a std::string to be moved to a cripts::string
   string(super_type &&that) : super_type(std::move(that)) {}
   string(self_type &&that) noexcept : super_type(that) {}
 
-  operator Cript::string_view() const { return {this->c_str(), this->size()}; }
+  operator cripts::string_view() const { return {this->c_str(), this->size()}; }
 
   // Make sure to keep these updated with C++20 ...
   self_type &
@@ -363,12 +363,12 @@ public:
     return this->ltrim(chars).rtrim(chars);
   }
 
-  [[nodiscard]] std::vector<Cript::string_view> split(char delim) const &;
+  [[nodiscard]] std::vector<cripts::string_view> split(char delim) const &;
 
   // delete the rvalue ref overload to prevent dangling string_views
-  // If you are getting an error here, you need to assign a variable to the Cript::string before calling split
+  // If you are getting an error here, you need to assign a variable to the cripts::string before calling split
   // and make sure its lifetime is longer than the returned vector
-  [[nodiscard]] std::vector<Cript::string_view> split(char delim) const && = delete;
+  [[nodiscard]] std::vector<cripts::string_view> split(char delim) const && = delete;
 
   operator integer() const;
   operator bool() const;
@@ -392,15 +392,15 @@ public:
     return bool(*this);
   }
 
-}; // End class Cript::string
+}; // End class cripts::string
 
-// Some helper functions, in the Cript:: generic namespace
-int                             Random(int max);
-std::vector<Cript::string_view> Splitter(Cript::string_view input, char delim);
-Cript::string                   Hex(const Cript::string &str);
-Cript::string                   Hex(Cript::string_view sv);
-Cript::string                   UnHex(const Cript::string &str);
-Cript::string                   UnHex(Cript::string_view sv);
+// Some helper functions, in the cripts:: generic namespace
+int                              Random(int max);
+std::vector<cripts::string_view> Splitter(cripts::string_view input, char delim);
+cripts::string                   Hex(const cripts::string &str);
+cripts::string                   Hex(cripts::string_view sv);
+cripts::string                   UnHex(const cripts::string &str);
+cripts::string                   UnHex(cripts::string_view sv);
 
 class Control
 {
@@ -414,8 +414,8 @@ class Control
     void operator=(const self_type &) = delete;
 
     explicit Base(TSHttpCntlType ctrl) : _ctrl(ctrl) {}
-    bool _get(Cript::Context *context) const;
-    void _set(Cript::Context *context, bool flag);
+    bool _get(cripts::Context *context) const;
+    void _set(cripts::Context *context, bool flag);
 
   protected:
     TSHttpCntlType _ctrl;
@@ -453,23 +453,23 @@ public:
   Versions(const self_type &)       = delete;
   void operator=(const self_type &) = delete;
 
-  Cript::string_view GetSV();
+  cripts::string_view GetSV();
 
-  operator Cript::string_view() { return GetSV(); }
+  operator cripts::string_view() { return GetSV(); }
 
-  Cript::string_view::const_pointer
+  cripts::string_view::const_pointer
   Data()
   {
     return GetSV().data();
   }
 
-  Cript::string_view::size_type
+  cripts::string_view::size_type
   Size()
   {
     return GetSV().size();
   }
 
-  Cript::string_view::size_type
+  cripts::string_view::size_type
   Length()
   {
     return GetSV().length();
@@ -528,7 +528,7 @@ private:
   friend struct fmt::formatter<Versions::Minor>;
   friend struct fmt::formatter<Versions::Patch>;
 
-  Cript::string_view _version;
+  cripts::string_view _version;
 
 public:
   Major major;
@@ -536,12 +536,12 @@ public:
   Patch patch;
 }; // End class Versions
 
-} // namespace Cript
+} // namespace cripts
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Cript::Versions> {
+template <> struct formatter<cripts::Versions> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -550,13 +550,13 @@ template <> struct formatter<Cript::Versions> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Versions &version, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions &version, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", version.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Versions::Major> {
+template <> struct formatter<cripts::Versions::Major> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -565,13 +565,13 @@ template <> struct formatter<Cript::Versions::Major> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Versions::Major &major, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions::Major &major, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(major));
   }
 };
 
-template <> struct formatter<Cript::Versions::Minor> {
+template <> struct formatter<cripts::Versions::Minor> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -580,13 +580,13 @@ template <> struct formatter<Cript::Versions::Minor> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Versions::Minor &minor, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions::Minor &minor, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(minor));
   }
 };
 
-template <> struct formatter<Cript::Versions::Patch> {
+template <> struct formatter<cripts::Versions::Patch> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -595,7 +595,7 @@ template <> struct formatter<Cript::Versions::Patch> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Versions::Patch &patch, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions::Patch &patch, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(patch));
   }

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -29,7 +29,7 @@
 #include "ts/ts.h"
 #include "cripts/Lulu.hpp"
 
-namespace Matcher
+namespace Cript::Matcher
 {
 namespace Range
 {
@@ -73,19 +73,19 @@ namespace Range
       return contains(swoc::IPAddr(target));
     }
 
-    bool
+    [[nodiscard]] bool
     Match(in_addr_t target) const
     {
       return contains(swoc::IPAddr(target));
     }
 
-    bool
+    [[nodiscard]] bool
     Match(swoc::IPAddr const &target) const
     {
       return contains(target);
     }
 
-    bool
+    [[nodiscard]] bool
     Contains(swoc::IPAddr const &target) const
     {
       return contains(target);
@@ -97,7 +97,7 @@ namespace Range
       return contains(swoc::IPAddr(target));
     }
 
-    bool
+    [[nodiscard]] bool
     Contains(in_addr_t target) const
     {
       return contains(swoc::IPAddr(target));
@@ -118,19 +118,19 @@ namespace Range
 
 namespace List
 {
-  class Method : public std::vector<Header::Method>
+  class Method : public std::vector<Cript::Header::Method>
   {
 #undef DELETE // ToDo: macOS shenanigans here, defining DELETE as a macro
 
-    using super_type = std::vector<Header::Method>;
+    using super_type = std::vector<Cript::Header::Method>;
     using self_type  = Method;
 
   public:
     Method() = delete;
-    explicit Method(Header::Method method) : std::vector<Header::Method>() { push_back(method); }
+    explicit Method(Cript::Header::Method method) : std::vector<Cript::Header::Method>() { push_back(method); }
     void operator=(const self_type &) = delete;
 
-    Method(self_type const &method) : std::vector<Header::Method>() { insert(end(), std::begin(method), std::end(method)); }
+    Method(self_type const &method) : std::vector<Cript::Header::Method>() { insert(end(), std::begin(method), std::end(method)); }
 
     Method(const std::initializer_list<self_type> &list)
     {
@@ -139,7 +139,7 @@ namespace List
       }
     }
 
-    Method(std::initializer_list<Header::Method> list)
+    Method(std::initializer_list<Cript::Header::Method> list)
     {
       for (auto &it : list) {
         push_back(it);
@@ -149,15 +149,15 @@ namespace List
     // Make sure we only allow the Cript::Method::* constants
 
     [[nodiscard]] bool
-    Contains(Header::Method method) const
+    Contains(Cript::Header::Method method) const
     {
       auto data = method.Data();
 
-      return end() != std::find_if(begin(), end(), [&](const Header::Method &header) { return header.Data() == data; });
+      return end() != std::find_if(begin(), end(), [&](const Cript::Header::Method &header) { return header.Data() == data; });
     }
 
     [[nodiscard]] bool
-    Match(Header::Method method) const
+    Match(Cript::Header::Method method) const
     {
       return Contains(method);
     }
@@ -262,4 +262,4 @@ private:
   RegexEntries _regexes;
 };
 
-} // namespace Matcher
+} // namespace Cript::Matcher

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -29,7 +29,7 @@
 #include "ts/ts.h"
 #include "cripts/Lulu.hpp"
 
-namespace Cript::Matcher
+namespace cripts::Matcher
 {
 namespace Range
 {
@@ -42,7 +42,7 @@ namespace Range
     IP()                              = delete;
     void operator=(const self_type &) = delete;
 
-    explicit IP(Cript::string_view ip) { Add(ip); }
+    explicit IP(cripts::string_view ip) { Add(ip); }
 
     IP(self_type const &ip)
     {
@@ -60,7 +60,7 @@ namespace Range
       }
     }
 
-    IP(std::initializer_list<Cript::string_view> list)
+    IP(std::initializer_list<cripts::string_view> list)
     {
       for (auto &it : list) {
         Add(it);
@@ -104,7 +104,7 @@ namespace Range
     }
 
     void
-    Add(Cript::string_view str)
+    Add(cripts::string_view str)
     {
       if (swoc::IPRange r; r.load(str)) {
         mark(r);
@@ -118,19 +118,19 @@ namespace Range
 
 namespace List
 {
-  class Method : public std::vector<Cript::Header::Method>
+  class Method : public std::vector<cripts::Header::Method>
   {
 #undef DELETE // ToDo: macOS shenanigans here, defining DELETE as a macro
 
-    using super_type = std::vector<Cript::Header::Method>;
+    using super_type = std::vector<cripts::Header::Method>;
     using self_type  = Method;
 
   public:
     Method() = delete;
-    explicit Method(Cript::Header::Method method) : std::vector<Cript::Header::Method>() { push_back(method); }
+    explicit Method(cripts::Header::Method method) : std::vector<cripts::Header::Method>() { push_back(method); }
     void operator=(const self_type &) = delete;
 
-    Method(self_type const &method) : std::vector<Cript::Header::Method>() { insert(end(), std::begin(method), std::end(method)); }
+    Method(self_type const &method) : std::vector<cripts::Header::Method>() { insert(end(), std::begin(method), std::end(method)); }
 
     Method(const std::initializer_list<self_type> &list)
     {
@@ -139,25 +139,25 @@ namespace List
       }
     }
 
-    Method(std::initializer_list<Cript::Header::Method> list)
+    Method(std::initializer_list<cripts::Header::Method> list)
     {
       for (auto &it : list) {
         push_back(it);
       }
     }
 
-    // Make sure we only allow the Cript::Method::* constants
+    // Make sure we only allow the cripts::Method::* constants
 
     [[nodiscard]] bool
-    Contains(Cript::Header::Method method) const
+    Contains(cripts::Header::Method method) const
     {
       auto data = method.Data();
 
-      return end() != std::find_if(begin(), end(), [&](const Cript::Header::Method &header) { return header.Data() == data; });
+      return end() != std::find_if(begin(), end(), [&](const cripts::Header::Method &header) { return header.Data() == data; });
     }
 
     [[nodiscard]] bool
-    Match(Cript::Header::Method method) const
+    Match(cripts::Header::Method method) const
     {
       return Contains(method);
     }
@@ -171,7 +171,7 @@ class PCRE
 public:
   static constexpr size_t MAX_CAPTURES = 32;
 
-  using Regex        = std::tuple<Cript::string, pcre2_code *>;
+  using Regex        = std::tuple<cripts::string, pcre2_code *>;
   using RegexEntries = std::vector<Regex>;
 
   using self_type = PCRE;
@@ -182,7 +182,7 @@ public:
     friend class PCRE;
 
     Result() = delete;
-    Result(Cript::string_view subject) : _subject(subject) {}
+    Result(cripts::string_view subject) : _subject(subject) {}
 
     ~Result() { pcre2_match_data_free(_data); }
 
@@ -192,10 +192,10 @@ public:
       return Matched();
     }
 
-    Cript::string_view
+    cripts::string_view
     operator[](size_t ix) const
     {
-      Cript::string_view ret;
+      cripts::string_view ret;
 
       if ((Count() > ix) && _ovector) {
         ret = {_subject.substr(_ovector[ix * 2], _ovector[ix * 2 + 1] - _ovector[ix * 2])};
@@ -231,16 +231,16 @@ public:
     PCRE2_SIZE             *_ovector = nullptr;
     PCRE2_SIZE              _ctx_ix  = 0;
     std::byte               _ctx_data[24 * 2 + 96 + 16 * MAX_CAPTURES];
-    Cript::string_view      _subject;
+    cripts::string_view     _subject;
   };
 
   PCRE()                            = default;
   PCRE(const self_type &)           = delete;
   void operator=(const self_type &) = delete;
 
-  PCRE(Cript::string_view regex, uint32_t options = 0) { Add(regex, options); }
+  PCRE(cripts::string_view regex, uint32_t options = 0) { Add(regex, options); }
 
-  PCRE(std::initializer_list<Cript::string_view> list, uint32_t options = 0)
+  PCRE(std::initializer_list<cripts::string_view> list, uint32_t options = 0)
   {
     for (auto &it : list) {
       Add(it, options);
@@ -249,11 +249,11 @@ public:
 
   ~PCRE();
 
-  void   Add(Cript::string_view regex, uint32_t options = 0, bool jit = true);
-  Result Contains(Cript::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0);
+  void   Add(cripts::string_view regex, uint32_t options = 0, bool jit = true);
+  Result Contains(cripts::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0);
 
   Result
-  Match(Cript::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0)
+  Match(cripts::string_view subject, PCRE2_SIZE offset = 0, uint32_t options = 0)
   {
     return Contains(subject, offset, options);
   }
@@ -262,4 +262,4 @@ private:
   RegexEntries _regexes;
 };
 
-} // namespace Cript::Matcher
+} // namespace cripts::Matcher

--- a/include/cripts/Metrics.hpp
+++ b/include/cripts/Metrics.hpp
@@ -42,7 +42,7 @@ public:
   void operator=(const self_type &) = delete;
   virtual ~BaseMetrics()            = default;
 
-  BaseMetrics(const Cript::string_view &name) : _name(name) {}
+  BaseMetrics(const cripts::string_view &name) : _name(name) {}
 
   void
   operator=(int64_t val)
@@ -57,7 +57,7 @@ public:
     return _metric->load();
   }
 
-  [[nodiscard]] Cript::string_view
+  [[nodiscard]] cripts::string_view
   Name() const
   {
     return {_name};
@@ -107,13 +107,13 @@ protected:
 
 private:
   ts::Metrics::AtomicType *_metric = nullptr;
-  Cript::string            _name   = "unknown";
+  cripts::string           _name   = "unknown";
   detail::MetricID         _id     = ts::Metrics::NOT_FOUND;
 }; // class BaseMetrics
 
 } // namespace detail
 
-namespace Cript
+namespace cripts
 {
 
 namespace Metrics
@@ -124,7 +124,7 @@ namespace Metrics
     using self_type  = Counter;
 
   public:
-    Counter(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Counter::create(name)); }
+    Counter(const cripts::string_view &name) : super_type(name) { _initialize(ts::Metrics::Counter::create(name)); }
 
     // Counters can only increment, so lets produce some nice compile time erorrs too
     void Decrement(int64_t)  = delete;
@@ -145,7 +145,7 @@ namespace Metrics
     }
 
     static self_type *
-    Create(const Cript::string_view &name)
+    Create(const cripts::string_view &name)
     {
       auto *ret = new self_type(name);
       auto  id  = ts::Metrics::Counter::create(name);
@@ -163,10 +163,10 @@ namespace Metrics
     using self_type  = Gauge;
 
   public:
-    Gauge(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Gauge::create(name)); }
+    Gauge(const cripts::string_view &name) : super_type(name) { _initialize(ts::Metrics::Gauge::create(name)); }
 
     static self_type *
-    Create(const Cript::string_view &name)
+    Create(const cripts::string_view &name)
     {
       auto *ret = new self_type(name);
       auto  id  = ts::Metrics::Gauge::create(name);
@@ -213,4 +213,4 @@ private:
 
 }; // class MetricStorage
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/Metrics.hpp
+++ b/include/cripts/Metrics.hpp
@@ -113,72 +113,73 @@ private:
 
 } // namespace detail
 
+namespace Cript
+{
+
 namespace Metrics
 {
-class Counter : public detail::BaseMetrics
-{
-  using super_type = detail::BaseMetrics;
-  using self_type  = Counter;
-
-public:
-  Counter(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Counter::create(name)); }
-
-  // Counters can only increment, so lets produce some nice compile time erorrs too
-  void Decrement(int64_t)  = delete;
-  void Setter(int64_t val) = delete;
-
-  template <typename T>
-  void
-  Decrement(T)
+  class Counter : public detail::BaseMetrics
   {
-    static_assert(std::is_same_v<T, int64_t>, "A Metric::Counter can only use Increment(), consider Metric::Gauge instead?");
-  }
+    using super_type = detail::BaseMetrics;
+    using self_type  = Counter;
 
-  template <typename T>
-  void
-  Setter(T)
+  public:
+    Counter(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Counter::create(name)); }
+
+    // Counters can only increment, so lets produce some nice compile time erorrs too
+    void Decrement(int64_t)  = delete;
+    void Setter(int64_t val) = delete;
+
+    template <typename T>
+    void
+    Decrement(T)
+    {
+      static_assert(std::is_same_v<T, int64_t>, "A Metric::Counter can only use Increment(), consider Metric::Gauge instead?");
+    }
+
+    template <typename T>
+    void
+    Setter(T)
+    {
+      static_assert(std::is_same_v<T, int64_t>, "A Metric::Counter can not be set to a value), consider Metric::Gauge instead?");
+    }
+
+    static self_type *
+    Create(const Cript::string_view &name)
+    {
+      auto *ret = new self_type(name);
+      auto  id  = ts::Metrics::Counter::create(name);
+
+      ret->_initialize(id);
+
+      return ret;
+    }
+
+  }; // class Counter
+
+  class Gauge : public detail::BaseMetrics
   {
-    static_assert(std::is_same_v<T, int64_t>, "A Metric::Counter can not be set to a value), consider Metric::Gauge instead?");
-  }
+    using super_type = detail::BaseMetrics;
+    using self_type  = Gauge;
 
-  static self_type *
-  Create(const Cript::string_view &name)
-  {
-    auto *ret = new self_type(name);
-    auto  id  = ts::Metrics::Counter::create(name);
+  public:
+    Gauge(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Gauge::create(name)); }
 
-    ret->_initialize(id);
+    static self_type *
+    Create(const Cript::string_view &name)
+    {
+      auto *ret = new self_type(name);
+      auto  id  = ts::Metrics::Gauge::create(name);
 
-    return ret;
-  }
+      ret->_initialize(id);
 
-}; // class Counter
+      return ret;
+    }
 
-class Gauge : public detail::BaseMetrics
-{
-  using super_type = detail::BaseMetrics;
-  using self_type  = Gauge;
-
-public:
-  Gauge(const Cript::string_view &name) : super_type(name) { _initialize(ts::Metrics::Gauge::create(name)); }
-
-  static self_type *
-  Create(const Cript::string_view &name)
-  {
-    auto *ret = new self_type(name);
-    auto  id  = ts::Metrics::Gauge::create(name);
-
-    ret->_initialize(id);
-
-    return ret;
-  }
-
-}; // class Counter
+  }; // class Counter
 
 } // namespace Metrics
 
-namespace Cript
-{
 class MetricStorage
 {
   using self_type = MetricStorage;

--- a/include/cripts/Plugins.hpp
+++ b/include/cripts/Plugins.hpp
@@ -24,7 +24,7 @@
 
 class RemapPluginInst; // Opaque to the Cripts, but needed in the implementation.
 
-namespace Plugin
+namespace Cript::Plugin
 {
 using Options = std::vector<Cript::string>;
 
@@ -68,4 +68,4 @@ private:
   bool             _valid  = false;
 }; // End class Plugin::Remap
 
-} // namespace Plugin
+} // namespace Cript::Plugin

--- a/include/cripts/Plugins.hpp
+++ b/include/cripts/Plugins.hpp
@@ -24,9 +24,9 @@
 
 class RemapPluginInst; // Opaque to the Cripts, but needed in the implementation.
 
-namespace Cript::Plugin
+namespace cripts::Plugin
 {
-using Options = std::vector<Cript::string>;
+using Options = std::vector<cripts::string>;
 
 class Remap
 {
@@ -47,7 +47,7 @@ public:
 
   ~Remap() { Cleanup(); }
 
-  void _runRemap(Cript::Context *context);
+  void _runRemap(cripts::Context *context);
 
   void Cleanup();
 
@@ -58,8 +58,8 @@ public:
   }
 
   // Factory, sort of
-  static Remap Create(const std::string &tag, const std::string &plugin, const Cript::string &from_url, const Cript::string &to_url,
-                      const Options &options);
+  static Remap Create(const std::string &tag, const std::string &plugin, const cripts::string &from_url,
+                      const cripts::string &to_url, const Options &options);
 
   static void Initialize();
 
@@ -68,4 +68,4 @@ private:
   bool             _valid  = false;
 }; // End class Plugin::Remap
 
-} // namespace Cript::Plugin
+} // namespace cripts::Plugin

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -39,27 +39,27 @@
 
 // This makes it nice and clean when the user of the framework defines the handlers in the cript.
 // Having both of these for now, until we decide which we like better...
-#define do_remap()           void _do_remap(Cript::Context *context)
-#define do_post_remap()      void _do_post_remap(Cript::Context *context)
-#define do_send_response()   void _do_send_response(Cript::Context *context)
-#define do_cache_lookup()    void _do_cache_lookup(Cript::Context *context)
-#define do_send_request()    void _do_send_request(Cript::Context *context)
-#define do_read_response()   void _do_read_response(Cript::Context *context)
-#define do_txn_close()       void _do_txn_close(Cript::Context *context)
+#define do_remap()           void _do_remap(cripts::Context *context)
+#define do_post_remap()      void _do_post_remap(cripts::Context *context)
+#define do_send_response()   void _do_send_response(cripts::Context *context)
+#define do_cache_lookup()    void _do_cache_lookup(cripts::Context *context)
+#define do_send_request()    void _do_send_request(cripts::Context *context)
+#define do_read_response()   void _do_read_response(cripts::Context *context)
+#define do_txn_close()       void _do_txn_close(cripts::Context *context)
 #define do_init()            void _do_init(TSRemapInterface *)
-#define do_create_instance() void _do_create_instance(Cript::InstanceContext *context)
-#define do_delete_instance() void _do_delete_instance(Cript::InstanceContext *context)
+#define do_create_instance() void _do_create_instance(cripts::InstanceContext *context)
+#define do_delete_instance() void _do_delete_instance(cripts::InstanceContext *context)
 
-#define DoRemap()          void _do_remap(Cript::Context *context)
-#define DoPostRemap()      void _do_post_remap(Cript::Context *context)
-#define DoSendResponse()   void _do_send_response(Cript::Context *context)
-#define DoCacheLookup()    void _do_cache_lookup(Cript::Context *context)
-#define DoSendRequest()    void _do_send_request(Cript::Context *context)
-#define DoReadResponse()   void _do_read_response(Cript::Context *context)
-#define DoTxnClose()       void _do_txn_close(Cript::Context *context)
+#define DoRemap()          void _do_remap(cripts::Context *context)
+#define DoPostRemap()      void _do_post_remap(cripts::Context *context)
+#define DoSendResponse()   void _do_send_response(cripts::Context *context)
+#define DoCacheLookup()    void _do_cache_lookup(cripts::Context *context)
+#define DoSendRequest()    void _do_send_request(cripts::Context *context)
+#define DoReadResponse()   void _do_read_response(cripts::Context *context)
+#define DoTxnClose()       void _do_txn_close(cripts::Context *context)
 #define DoInit()           void _do_init(TSRemapInterface *)
-#define DoCreateInstance() void _do_create_instance(Cript::InstanceContext *context)
-#define DoDeleteInstance() void _do_delete_instance(Cript::InstanceContext *context)
+#define DoCreateInstance() void _do_create_instance(cripts::InstanceContext *context)
+#define DoDeleteInstance() void _do_delete_instance(cripts::InstanceContext *context)
 
 #include "cripts/Headers.hpp"
 #include "cripts/Urls.hpp"
@@ -75,13 +75,13 @@
 #include "cripts/Plugins.hpp"
 
 // This is to make using these more convenient
-using Cript::string;
+using cripts::string;
 using fmt::format;
 
 // This needs to be last
 #include "cripts/Context.hpp"
 
 // These are globals, making certain operations nice and convenient, without wasting plugin space
-extern Cript::Proxy    proxy;   // Access to all overridable configurations
-extern Cript::Control  control; // Access to the HTTP control mechanism
-extern Cript::Versions version; // Access to the ATS version information
+extern cripts::Proxy    proxy;   // Access to all overridable configurations
+extern cripts::Control  control; // Access to the HTTP control mechanism
+extern cripts::Versions version; // Access to the ATS version information

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -82,6 +82,6 @@ using fmt::format;
 #include "cripts/Context.hpp"
 
 // These are globals, making certain operations nice and convenient, without wasting plugin space
-extern Proxy    proxy;   // Access to all overridable configurations
-extern Control  control; // Access to the HTTP control mechanism
-extern Versions version; // Access to the ATS version information
+extern Cript::Proxy    proxy;   // Access to all overridable configurations
+extern Cript::Control  control; // Access to the HTTP control mechanism
+extern Cript::Versions version; // Access to the ATS version information

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -101,7 +101,7 @@ protected:
 };
 } // namespace detail
 
-namespace Time
+namespace Cript::Time
 {
 // ToDo: Right now, we only have localtime, but we should support e.g. UTC and
 // other time zone instances.
@@ -125,12 +125,12 @@ public:
 
 }; // End class Time::Local
 
-} // namespace Time
+} // namespace Cript::Time
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Time::Local> {
+template <> struct formatter<Cript::Time::Local> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -139,7 +139,7 @@ template <> struct formatter<Time::Local> {
 
   template <typename FormatContext>
   auto
-  format(Time::Local &time, FormatContext &ctx) -> decltype(ctx.out())
+  format(Cript::Time::Local &time, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", time.Epoch());
   }

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -101,7 +101,7 @@ protected:
 };
 } // namespace detail
 
-namespace Cript::Time
+namespace cripts::Time
 {
 // ToDo: Right now, we only have localtime, but we should support e.g. UTC and
 // other time zone instances.
@@ -125,12 +125,12 @@ public:
 
 }; // End class Time::Local
 
-} // namespace Cript::Time
+} // namespace cripts::Time
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Cript::Time::Local> {
+template <> struct formatter<cripts::Time::Local> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -139,7 +139,7 @@ template <> struct formatter<Cript::Time::Local> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Time::Local &time, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Time::Local &time, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", time.Epoch());
   }

--- a/include/cripts/Transaction.hpp
+++ b/include/cripts/Transaction.hpp
@@ -26,7 +26,7 @@
 // This had to be extraced out of the CriptContex class, to avoid the circular references. And
 // doing this lets us have the various headers, URLs etc. as uninitialized members of the Context.
 
-namespace Cript
+namespace cripts
 {
 // This is a bitfield, used to disable a particular callback from a previous hook
 enum Callbacks : std::uint8_t {
@@ -86,4 +86,4 @@ public:
 
 }; // class Transaction
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/UUID.hpp
+++ b/include/cripts/UUID.hpp
@@ -18,60 +18,61 @@
 #pragma once
 
 #include "cripts/Lulu.hpp"
-namespace Cript
-{
-class Context;
-}
-
 #include "ts/ts.h"
 #include "ts/remap.h"
 
+namespace Cript
+{
+class Context;
+
 namespace UUID
 {
-class Process
-{
-  using self_type = Process;
-
-public:
-  Process()                         = delete;
-  Process(const self_type &)        = delete;
-  void operator=(const self_type &) = delete;
-
-  // This doesn't use the context so we can implement it here
-  static Cript::string
-  _get(Cript::Context * /* context ATS_UNUSED */)
+  class Process
   {
-    TSUuid process = TSProcessUuidGet();
+    using self_type = Process;
 
-    return TSUuidStringGet(process);
-  }
+  public:
+    Process()                         = delete;
+    Process(const self_type &)        = delete;
+    void operator=(const self_type &) = delete;
 
-}; // End class UUID::Process
+    // This doesn't use the context so we can implement it here
+    static Cript::string
+    _get(Cript::Context * /* context ATS_UNUSED */)
+    {
+      TSUuid process = TSProcessUuidGet();
 
-class Unique
-{
-  using self_type = Unique;
+      return TSUuidStringGet(process);
+    }
 
-public:
-  Unique()                          = delete;
-  Unique(const self_type &)         = delete;
-  void operator=(const self_type &) = delete;
+  }; // End class UUID::Process
 
-  static Cript::string _get(Cript::Context *context);
+  class Unique
+  {
+    using self_type = Unique;
 
-}; // End class UUID::Unique
+  public:
+    Unique()                          = delete;
+    Unique(const self_type &)         = delete;
+    void operator=(const self_type &) = delete;
 
-class Request
-{
-  using self_type = Request;
+    static Cript::string _get(Cript::Context *context);
 
-public:
-  Request()                         = delete;
-  Request(const self_type &)        = delete;
-  void operator=(const self_type &) = delete;
+  }; // End class UUID::Unique
 
-  static Cript::string _get(Cript::Context *context);
+  class Request
+  {
+    using self_type = Request;
 
-}; // End class UUID::Request
+  public:
+    Request()                         = delete;
+    Request(const self_type &)        = delete;
+    void operator=(const self_type &) = delete;
+
+    static Cript::string _get(Cript::Context *context);
+
+  }; // End class UUID::Request
 
 } // namespace UUID
+
+} // namespace Cript

--- a/include/cripts/UUID.hpp
+++ b/include/cripts/UUID.hpp
@@ -21,7 +21,7 @@
 #include "ts/ts.h"
 #include "ts/remap.h"
 
-namespace Cript
+namespace cripts
 {
 class Context;
 
@@ -37,8 +37,8 @@ namespace UUID
     void operator=(const self_type &) = delete;
 
     // This doesn't use the context so we can implement it here
-    static Cript::string
-    _get(Cript::Context * /* context ATS_UNUSED */)
+    static cripts::string
+    _get(cripts::Context * /* context ATS_UNUSED */)
     {
       TSUuid process = TSProcessUuidGet();
 
@@ -56,7 +56,7 @@ namespace UUID
     Unique(const self_type &)         = delete;
     void operator=(const self_type &) = delete;
 
-    static Cript::string _get(Cript::Context *context);
+    static cripts::string _get(cripts::Context *context);
 
   }; // End class UUID::Unique
 
@@ -69,10 +69,10 @@ namespace UUID
     Request(const self_type &)        = delete;
     void operator=(const self_type &) = delete;
 
-    static Cript::string _get(Cript::Context *context);
+    static cripts::string _get(cripts::Context *context);
 
   }; // End class UUID::Request
 
 } // namespace UUID
 
-} // namespace Cript
+} // namespace cripts

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -27,7 +27,7 @@
 
 #include "cripts/Headers.hpp"
 
-namespace Cript
+namespace cripts
 {
 class Context;
 
@@ -41,20 +41,20 @@ class Url
     Component() = default;
     Component(Url *owner) : _owner(owner) {}
 
-    virtual Cript::string_view GetSV() = 0;
+    virtual cripts::string_view GetSV() = 0;
 
-    std::vector<Cript::string_view> Split(char delim);
+    std::vector<cripts::string_view> Split(char delim);
 
-    operator Cript::string_view() { return GetSV(); } // Should not be explicit
+    operator cripts::string_view() { return GetSV(); } // Should not be explicit
 
     bool
-    operator==(Cript::string_view const &rhs)
+    operator==(cripts::string_view const &rhs)
     {
       return GetSV() == rhs;
     }
 
     bool
-    operator!=(Cript::string_view const &rhs)
+    operator!=(cripts::string_view const &rhs)
     {
       return GetSV() != rhs;
     }
@@ -65,93 +65,93 @@ class Url
       _data.clear();
     }
 
-    Cript::string_view::const_pointer
+    cripts::string_view::const_pointer
     data()
     {
       return GetSV().data();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     size()
     {
       return GetSV().size();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     length()
     {
       return GetSV().size();
     }
 
-    Cript::string_view::const_pointer
+    cripts::string_view::const_pointer
     Data()
     {
       return GetSV().data();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     Size()
     {
       return GetSV().size();
     }
 
-    Cript::string_view::size_type
+    cripts::string_view::size_type
     Length()
     {
       return GetSV().size();
     }
 
-    // This is not ideal, but best way I can think of for now to mixin the Cript::string_view mixin class
+    // This is not ideal, but best way I can think of for now to mixin the cripts::string_view mixin class
     // Remember to add things here when added to the Lulu.hpp file for the mixin class... :/
-    [[nodiscard]] constexpr Cript::string_view
-    substr(Cript::string_view::size_type pos = 0, Cript::string_view::size_type count = Cript::string_view::npos) const
+    [[nodiscard]] constexpr cripts::string_view
+    substr(cripts::string_view::size_type pos = 0, cripts::string_view::size_type count = cripts::string_view::npos) const
     {
       return _data.substr(pos, count);
     }
 
     void
-    remove_prefix(Cript::string_view::size_type n)
+    remove_prefix(cripts::string_view::size_type n)
     {
       _data.remove_prefix(n);
     }
 
     void
-    remove_suffix(Cript::string_view::size_type n)
+    remove_suffix(cripts::string_view::size_type n)
     {
       _data.remove_suffix(n);
     }
 
-    Cript::string_view &
+    cripts::string_view &
     ltrim(char c)
     {
       return _data.ltrim(c);
     }
 
-    Cript::string_view &
+    cripts::string_view &
     rtrim(char c)
     {
       return _data.rtrim(c);
     }
 
-    Cript::string_view &
+    cripts::string_view &
     trim(char c)
     {
       return _data.trim(c);
     }
 
-    Cript::string_view &
+    cripts::string_view &
     ltrim(const char *chars = " \t\r\n")
     {
       return _data.ltrim(chars);
     }
 
-    Cript::string_view &
+    cripts::string_view &
     rtrim(const char *chars = " \t\r\n")
     {
       return _data.rtrim(chars);
     }
 
-    Cript::string_view &
+    cripts::string_view &
     trim(const char *chars = " \t")
     {
       return _data.trim(chars);
@@ -164,39 +164,39 @@ class Url
     }
 
     [[nodiscard]] bool
-    ends_with(Cript::string_view suffix) const
+    ends_with(cripts::string_view suffix) const
     {
       return _data.ends_with(suffix);
     }
 
     [[nodiscard]] bool
-    starts_with(Cript::string_view const prefix) const
+    starts_with(cripts::string_view const prefix) const
     {
       return _data.starts_with(prefix);
     }
 
-    [[nodiscard]] constexpr Cript::string_view::size_type
-    find(Cript::string_view const substr, Cript::string_view::size_type pos = 0) const
+    [[nodiscard]] constexpr cripts::string_view::size_type
+    find(cripts::string_view const substr, cripts::string_view::size_type pos = 0) const
     {
       return _data.find(substr, pos);
     }
 
-    [[nodiscard]] constexpr Cript::string_view::size_type
-    rfind(Cript::string_view const substr, Cript::string_view::size_type pos = 0) const
+    [[nodiscard]] constexpr cripts::string_view::size_type
+    rfind(cripts::string_view const substr, cripts::string_view::size_type pos = 0) const
     {
       return _data.rfind(substr, pos);
     }
 
     [[nodiscard]] constexpr bool
-    contains(Cript::string_view const substr) const
+    contains(cripts::string_view const substr) const
     {
       return (_data.find(substr) != _data.npos);
     }
 
   protected:
-    mutable Cript::string_view _data;
-    Url                       *_owner  = nullptr;
-    bool                       _loaded = false;
+    mutable cripts::string_view _data;
+    Url                        *_owner  = nullptr;
+    bool                        _loaded = false;
 
   }; // End class Url::Component
 
@@ -211,8 +211,8 @@ public:
   public:
     using Component::Component;
 
-    Cript::string_view GetSV() override;
-    self_type          operator=(Cript::string_view scheme);
+    cripts::string_view GetSV() override;
+    self_type           operator=(cripts::string_view scheme);
 
   }; // End class Url::Scheme
 
@@ -224,8 +224,8 @@ public:
   public:
     using Component::Component;
 
-    Cript::string_view GetSV() override;
-    self_type          operator=(Cript::string_view host);
+    cripts::string_view GetSV() override;
+    self_type           operator=(cripts::string_view host);
 
   }; // End class Url::Host
 
@@ -246,7 +246,7 @@ public:
     self_type operator=(int port);
 
     self_type
-    operator=(Cript::string_view str)
+    operator=(cripts::string_view str)
     {
       uint32_t port   = 80;
       auto     result = std::from_chars(str.data(), str.data() + str.size(), port);
@@ -266,54 +266,54 @@ public:
   class Path : public Component
   {
   public:
-    using Segments = std::vector<Cript::string_view>;
+    using Segments = std::vector<cripts::string_view>;
 
   private:
     using super_type = Component;
     using self_type  = Path;
 
-    class String : public Cript::StringViewMixin<String>
+    class String : public cripts::StringViewMixin<String>
     {
-      using super_type = Cript::StringViewMixin<String>;
+      using super_type = cripts::StringViewMixin<String>;
       using self_type  = String;
 
     public:
       String() = default;
 
       // Implemented in the Urls.cc file, bigger function
-      self_type &operator=(const Cript::string_view str) override;
+      self_type &operator=(const cripts::string_view str) override;
 
       // These specialized assignment operators all use the above
       template <size_t N>
       self_type &
       operator=(const char (&str)[N])
       {
-        return operator=(Cript::string_view(str, str[N - 1] ? N : N - 1));
+        return operator=(cripts::string_view(str, str[N - 1] ? N : N - 1));
       }
 
       self_type &
       operator=(char *&str)
       {
-        return operator=(Cript::string_view(str, strlen(str)));
+        return operator=(cripts::string_view(str, strlen(str)));
       }
 
       self_type &
       operator=(char const *&str)
       {
-        return operator=(Cript::string_view(str, strlen(str)));
+        return operator=(cripts::string_view(str, strlen(str)));
       }
 
       self_type &
       operator=(const std::string &str)
       {
-        return operator=(Cript::string_view(str));
+        return operator=(cripts::string_view(str));
       }
 
     private:
       friend class Path;
 
       void
-      _initialize(Cript::string_view source, Path *owner, Segments::size_type ix)
+      _initialize(cripts::string_view source, Path *owner, Segments::size_type ix)
       {
         _setSV(source);
         _owner = owner;
@@ -332,10 +332,10 @@ public:
 
     void Reset() override;
 
-    Cript::string_view GetSV() override;
-    Cript::string      operator+=(Cript::string_view add);
-    self_type          operator=(Cript::string_view path);
-    String             operator[](Segments::size_type ix);
+    cripts::string_view GetSV() override;
+    cripts::string      operator+=(cripts::string_view add);
+    self_type           operator=(cripts::string_view path);
+    String              operator[](Segments::size_type ix);
 
     void
     Erase(Segments::size_type ix)
@@ -358,8 +358,8 @@ public:
       Erase();
     }
 
-    void Push(Cript::string_view val);
-    void Insert(Segments::size_type ix, Cript::string_view val);
+    void Push(cripts::string_view val);
+    void Insert(Segments::size_type ix, cripts::string_view val);
 
     void
     Flush()
@@ -372,10 +372,10 @@ public:
   private:
     void _parser();
 
-    bool                     _modified = false;
-    Segments                 _segments; // Lazy loading on this
-    Cript::string            _storage;  // Used when recombining the segments into a full path
-    Cript::string::size_type _size = 0; // Mostly a guestimate for managing _storage
+    bool                      _modified = false;
+    Segments                  _segments; // Lazy loading on this
+    cripts::string            _storage;  // Used when recombining the segments into a full path
+    cripts::string::size_type _size = 0; // Mostly a guestimate for managing _storage
 
   }; // End class Url::Path
 
@@ -384,18 +384,18 @@ public:
     using super_type = Component;
     using self_type  = Query;
 
-    using OrderedParams = std::vector<Cript::string_view>;                            // Ordered parameter nmes
-    using HashParams    = std::unordered_map<Cript::string_view, Cript::string_view>; // Hash lookups
+    using OrderedParams = std::vector<cripts::string_view>;                             // Ordered parameter nmes
+    using HashParams    = std::unordered_map<cripts::string_view, cripts::string_view>; // Hash lookups
 
-    class Parameter : public Cript::StringViewMixin<Parameter>
+    class Parameter : public cripts::StringViewMixin<Parameter>
     {
-      using super_type = Cript::StringViewMixin<Parameter>;
+      using super_type = cripts::StringViewMixin<Parameter>;
       using self_type  = Parameter;
 
     public:
       Parameter() = default;
 
-      [[nodiscard]] Cript::string_view
+      [[nodiscard]] cripts::string_view
       Name() const
       {
         return _name;
@@ -408,47 +408,47 @@ public:
       }
 
       // Implemented in the Urls.cc file, bigger function
-      self_type &operator=(const Cript::string_view str) override;
+      self_type &operator=(const cripts::string_view str) override;
 
       // These specialized assignment operators all use the above
       template <size_t N>
       self_type &
       operator=(const char (&str)[N])
       {
-        return operator=(Cript::string_view(str, str[N - 1] ? N : N - 1));
+        return operator=(cripts::string_view(str, str[N - 1] ? N : N - 1));
       }
 
       self_type &
       operator=(char *&str)
       {
-        return operator=(Cript::string_view(str, strlen(str)));
+        return operator=(cripts::string_view(str, strlen(str)));
       }
 
       self_type &
       operator=(char const *&str)
       {
-        return operator=(Cript::string_view(str, strlen(str)));
+        return operator=(cripts::string_view(str, strlen(str)));
       }
 
       self_type &
       operator=(const std::string &str)
       {
-        return operator=(Cript::string_view(str));
+        return operator=(cripts::string_view(str));
       }
 
     private:
       friend class Query;
 
       void
-      _initialize(Cript::string_view name, Cript::string_view source, Query *owner)
+      _initialize(cripts::string_view name, cripts::string_view source, Query *owner)
       {
         _setSV(source);
         _name  = name;
         _owner = owner;
       }
 
-      Query             *_owner = nullptr;
-      Cript::string_view _name;
+      Query              *_owner = nullptr;
+      cripts::string_view _name;
 
     }; // End class Url::Query::Parameter
 
@@ -457,7 +457,7 @@ public:
 
     using Component::Component;
 
-    Query(Cript::string_view load)
+    Query(cripts::string_view load)
     {
       _data   = load;
       _size   = load.size();
@@ -466,12 +466,12 @@ public:
 
     void Reset() override;
 
-    Cript::string_view GetSV() override;
-    self_type          operator=(Cript::string_view query);
-    Cript::string      operator+=(Cript::string_view add);
-    Parameter          operator[](Cript::string_view param);
-    void               Erase(Cript::string_view param);
-    void               Erase(std::initializer_list<Cript::string_view> list, bool keep = false);
+    cripts::string_view GetSV() override;
+    self_type           operator=(cripts::string_view query);
+    cripts::string      operator+=(cripts::string_view add);
+    Parameter           operator[](cripts::string_view param);
+    void                Erase(cripts::string_view param);
+    void                Erase(std::initializer_list<cripts::string_view> list, bool keep = false);
 
     void
     Erase()
@@ -481,7 +481,7 @@ public:
     }
 
     void
-    Keep(std::initializer_list<Cript::string_view> list)
+    Keep(std::initializer_list<cripts::string_view> list)
     {
       Erase(list, true);
     }
@@ -513,12 +513,12 @@ public:
   private:
     void _parser();
 
-    bool          _modified = false;
-    OrderedParams _ordered;             // Ordered vector of all parameters, can be sorted etc.
-    HashParams    _hashed;              // Unordered map to go from "name" to the query parameter
-    Cript::string _storage;             // Used when recombining the query params into a
-                                        // full query string
-    Cript::string::size_type _size = 0; // Mostly a guesttimate
+    bool           _modified = false;
+    OrderedParams  _ordered;             // Ordered vector of all parameters, can be sorted etc.
+    HashParams     _hashed;              // Unordered map to go from "name" to the query parameter
+    cripts::string _storage;             // Used when recombining the query params into a
+                                         // full query string
+    cripts::string::size_type _size = 0; // Mostly a guesttimate
 
   }; // End class Url::Query
 
@@ -565,7 +565,7 @@ public:
   }
 
   // This is the full string for a URL, which needs allocations.
-  [[nodiscard]] Cript::string String() const;
+  [[nodiscard]] cripts::string String() const;
 
   Scheme scheme;
   Host   host;
@@ -575,25 +575,25 @@ public:
 
 protected:
   void
-  _initialize(Cript::Transaction *state)
+  _initialize(cripts::Transaction *state)
   {
     _state = state;
   }
 
-  TSMBuffer           _bufp     = nullptr; // These two gets setup via initializing, to appropriate headers
-  TSMLoc              _hdr_loc  = nullptr; // Do not release any of this within the URL classes!
-  TSMLoc              _urlp     = nullptr; // This is owned by us.
-  Cript::Transaction *_state    = nullptr; // Pointer into the owning Context's State
-  bool                _modified = false;   // We have pending changes on the path/query components
+  TSMBuffer            _bufp     = nullptr; // These two gets setup via initializing, to appropriate headers
+  TSMLoc               _hdr_loc  = nullptr; // Do not release any of this within the URL classes!
+  TSMLoc               _urlp     = nullptr; // This is owned by us.
+  cripts::Transaction *_state    = nullptr; // Pointer into the owning Context's State
+  bool                 _modified = false;   // We have pending changes on the path/query components
 
 }; // End class Url
 
 // The Pristine URL is immutable, we should "delete" the operator= methods
 namespace Pristine
 {
-  class URL : public Cript::Url
+  class URL : public cripts::Url
   {
-    using super_type = Cript::Url;
+    using super_type = cripts::Url;
     using self_type  = URL;
 
   public:
@@ -601,7 +601,7 @@ namespace Pristine
     URL(const self_type &)            = delete;
     void operator=(const self_type &) = delete;
 
-    static self_type &_get(Cript::Context *context);
+    static self_type &_get(cripts::Context *context);
 
     [[nodiscard]] bool
     ReadOnly() const override
@@ -615,9 +615,9 @@ namespace Pristine
 
 namespace Client
 {
-  class URL : public Cript::Url
+  class URL : public cripts::Url
   {
-    using super_type = Cript::Url;
+    using super_type = cripts::Url;
     using self_type  = URL;
 
   public:
@@ -631,11 +631,11 @@ namespace Client
     {
     }
 
-    static self_type &_get(Cript::Context *context);
-    bool              _update(Cript::Context *context);
+    static self_type &_get(cripts::Context *context);
+    bool              _update(cripts::Context *context);
 
   private:
-    void _initialize(Cript::Context *context);
+    void _initialize(cripts::Context *context);
 
   }; // End class Client::URL
 
@@ -645,9 +645,9 @@ namespace Remap
 {
   namespace From
   {
-    class URL : public Cript::Url
+    class URL : public cripts::Url
     {
-      using super_type = Cript::Url;
+      using super_type = cripts::Url;
       using self_type  = URL;
 
     public:
@@ -667,11 +667,11 @@ namespace Remap
         return true;
       }
 
-      static self_type &_get(Cript::Context *context);
-      bool              _update(Cript::Context *context);
+      static self_type &_get(cripts::Context *context);
+      bool              _update(cripts::Context *context);
 
     private:
-      void _initialize(Cript::Context *context);
+      void _initialize(cripts::Context *context);
 
     }; // End class Client::URL
 
@@ -679,9 +679,9 @@ namespace Remap
 
   namespace To
   {
-    class URL : public Cript::Url
+    class URL : public cripts::Url
     {
-      using super_type = Cript::Url;
+      using super_type = cripts::Url;
       using self_type  = URL;
 
     public:
@@ -701,11 +701,11 @@ namespace Remap
         return true;
       }
 
-      static self_type &_get(Cript::Context *context);
-      bool              _update(Cript::Context *context);
+      static self_type &_get(cripts::Context *context);
+      bool              _update(cripts::Context *context);
 
     private:
-      void _initialize(Cript::Context *context);
+      void _initialize(cripts::Context *context);
 
     }; // End class Client::URL
 
@@ -715,9 +715,9 @@ namespace Remap
 
 namespace Cache
 {
-  class URL : public Cript::Url // ToDo: This can maybe be a subclass of Client::URL ?
+  class URL : public cripts::Url // ToDo: This can maybe be a subclass of Client::URL ?
   {
-    using super_type = Cript::Url;
+    using super_type = cripts::Url;
     using self_type  = URL;
 
   public:
@@ -725,12 +725,12 @@ namespace Cache
     URL(const self_type &)            = delete;
     void operator=(const self_type &) = delete;
 
-    static self_type &_get(Cript::Context *context);
-    bool              _update(Cript::Context *context);
+    static self_type &_get(cripts::Context *context);
+    bool              _update(cripts::Context *context);
 
   private:
     void
-    _initialize(Cript::Transaction *state, Client::Request *req)
+    _initialize(cripts::Transaction *state, Client::Request *req)
     {
       Url::_initialize(state);
 
@@ -744,9 +744,9 @@ namespace Cache
 
 namespace Parent
 {
-  class URL : public Cript::Url
+  class URL : public cripts::Url
   {
-    using super_type = Cript::Url;
+    using super_type = cripts::Url;
     using self_type  = URL;
 
   public:
@@ -754,12 +754,12 @@ namespace Parent
     URL(const self_type &)            = delete;
     void operator=(const self_type &) = delete;
 
-    static self_type &_get(Cript::Context *context);
-    bool              _update(Cript::Context *context);
+    static self_type &_get(cripts::Context *context);
+    bool              _update(cripts::Context *context);
 
   private:
     void
-    _initialize(Cript::Transaction *state, Client::Request *req)
+    _initialize(cripts::Transaction *state, Client::Request *req)
     {
       Url::_initialize(state);
 
@@ -771,12 +771,12 @@ namespace Parent
 
 } // namespace Parent
 
-} // namespace Cript
+} // namespace cripts
 
 // Formatters for {fmt}
 namespace fmt
 {
-template <> struct formatter<Cript::Url::Scheme> {
+template <> struct formatter<cripts::Url::Scheme> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -785,13 +785,13 @@ template <> struct formatter<Cript::Url::Scheme> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Url::Scheme &scheme, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Scheme &scheme, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", scheme.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Url::Host> {
+template <> struct formatter<cripts::Url::Host> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -800,13 +800,13 @@ template <> struct formatter<Cript::Url::Host> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Url::Host &host, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Host &host, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", host.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Url::Port> {
+template <> struct formatter<cripts::Url::Port> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -815,13 +815,13 @@ template <> struct formatter<Cript::Url::Port> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Url::Port &port, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Port &port, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(port));
   }
 };
 
-template <> struct formatter<Cript::Url::Path::String> {
+template <> struct formatter<cripts::Url::Path::String> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -830,13 +830,13 @@ template <> struct formatter<Cript::Url::Path::String> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Url::Path::String &path, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Path::String &path, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", path.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Url::Path> {
+template <> struct formatter<cripts::Url::Path> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -845,13 +845,13 @@ template <> struct formatter<Cript::Url::Path> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Url::Path &path, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Path &path, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", path.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Url::Query::Parameter> {
+template <> struct formatter<cripts::Url::Query::Parameter> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -860,13 +860,13 @@ template <> struct formatter<Cript::Url::Query::Parameter> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Url::Query::Parameter &param, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Query::Parameter &param, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", param.GetSV());
   }
 };
 
-template <> struct formatter<Cript::Url::Query> {
+template <> struct formatter<cripts::Url::Query> {
   constexpr auto
   parse(format_parse_context &ctx) -> decltype(ctx.begin())
   {
@@ -875,7 +875,7 @@ template <> struct formatter<Cript::Url::Query> {
 
   template <typename FormatContext>
   auto
-  format(Cript::Url::Query &query, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Query &query, FormatContext &ctx) -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", query.GetSV());
   }

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -588,190 +588,190 @@ protected:
 
 }; // End class Url
 
-} // namespace Cript
-
 // The Pristine URL is immutable, we should "delete" the operator= methods
 namespace Pristine
 {
-class URL : public Cript::Url
-{
-  using super_type = Cript::Url;
-  using self_type  = URL;
-
-public:
-  URL()                             = default;
-  URL(const self_type &)            = delete;
-  void operator=(const self_type &) = delete;
-
-  static self_type &_get(Cript::Context *context);
-
-  [[nodiscard]] bool
-  ReadOnly() const override
+  class URL : public Cript::Url
   {
-    return true;
-  }
+    using super_type = Cript::Url;
+    using self_type  = URL;
 
-}; // End class Pristine::URL
+  public:
+    URL()                             = default;
+    URL(const self_type &)            = delete;
+    void operator=(const self_type &) = delete;
+
+    static self_type &_get(Cript::Context *context);
+
+    [[nodiscard]] bool
+    ReadOnly() const override
+    {
+      return true;
+    }
+
+  }; // End class Pristine::URL
 
 } // namespace Pristine
 
 namespace Client
 {
-class URL : public Cript::Url
-{
-  using super_type = Cript::Url;
-  using self_type  = URL;
-
-public:
-  URL()                             = default;
-  URL(const self_type &)            = delete;
-  void operator=(const self_type &) = delete;
-
-  // We must not release the bufp etc. since it comes from the RRI structure
-  void
-  Reset() override
+  class URL : public Cript::Url
   {
-  }
+    using super_type = Cript::Url;
+    using self_type  = URL;
 
-  static self_type &_get(Cript::Context *context);
-  bool              _update(Cript::Context *context);
+  public:
+    URL()                             = default;
+    URL(const self_type &)            = delete;
+    void operator=(const self_type &) = delete;
 
-private:
-  void _initialize(Cript::Context *context);
+    // We must not release the bufp etc. since it comes from the RRI structure
+    void
+    Reset() override
+    {
+    }
 
-}; // End class Client::URL
+    static self_type &_get(Cript::Context *context);
+    bool              _update(Cript::Context *context);
+
+  private:
+    void _initialize(Cript::Context *context);
+
+  }; // End class Client::URL
 
 } // namespace Client
 
 namespace Remap
 {
-namespace From
-{
-  class URL : public Cript::Url
+  namespace From
   {
-    using super_type = Cript::Url;
-    using self_type  = URL;
-
-  public:
-    URL()                             = default;
-    URL(const self_type &)            = delete;
-    void operator=(const self_type &) = delete;
-
-    // We must not release the bufp etc. since it comes from the RRI structure
-    void
-    Reset() override
+    class URL : public Cript::Url
     {
-    }
+      using super_type = Cript::Url;
+      using self_type  = URL;
 
-    [[nodiscard]] bool
-    ReadOnly() const override
-    {
-      return true;
-    }
+    public:
+      URL()                             = default;
+      URL(const self_type &)            = delete;
+      void operator=(const self_type &) = delete;
 
-    static self_type &_get(Cript::Context *context);
-    bool              _update(Cript::Context *context);
+      // We must not release the bufp etc. since it comes from the RRI structure
+      void
+      Reset() override
+      {
+      }
 
-  private:
-    void _initialize(Cript::Context *context);
+      [[nodiscard]] bool
+      ReadOnly() const override
+      {
+        return true;
+      }
 
-  }; // End class Client::URL
+      static self_type &_get(Cript::Context *context);
+      bool              _update(Cript::Context *context);
 
-} // namespace From
+    private:
+      void _initialize(Cript::Context *context);
 
-namespace To
-{
-  class URL : public Cript::Url
+    }; // End class Client::URL
+
+  } // namespace From
+
+  namespace To
   {
-    using super_type = Cript::Url;
-    using self_type  = URL;
-
-  public:
-    URL()                             = default;
-    URL(const self_type &)            = delete;
-    void operator=(const self_type &) = delete;
-
-    // We must not release the bufp etc. since it comes from the RRI structure
-    void
-    Reset() override
+    class URL : public Cript::Url
     {
-    }
+      using super_type = Cript::Url;
+      using self_type  = URL;
 
-    [[nodiscard]] bool
-    ReadOnly() const override
-    {
-      return true;
-    }
+    public:
+      URL()                             = default;
+      URL(const self_type &)            = delete;
+      void operator=(const self_type &) = delete;
 
-    static self_type &_get(Cript::Context *context);
-    bool              _update(Cript::Context *context);
+      // We must not release the bufp etc. since it comes from the RRI structure
+      void
+      Reset() override
+      {
+      }
 
-  private:
-    void _initialize(Cript::Context *context);
+      [[nodiscard]] bool
+      ReadOnly() const override
+      {
+        return true;
+      }
 
-  }; // End class Client::URL
+      static self_type &_get(Cript::Context *context);
+      bool              _update(Cript::Context *context);
 
-} // namespace To
+    private:
+      void _initialize(Cript::Context *context);
+
+    }; // End class Client::URL
+
+  } // namespace To
 
 } // namespace Remap
 
 namespace Cache
 {
-class URL : public Cript::Url // ToDo: This can maybe be a subclass of Client::URL ?
-{
-  using super_type = Cript::Url;
-  using self_type  = URL;
-
-public:
-  URL()                             = default;
-  URL(const self_type &)            = delete;
-  void operator=(const self_type &) = delete;
-
-  static self_type &_get(Cript::Context *context);
-  bool              _update(Cript::Context *context);
-
-private:
-  void
-  _initialize(Cript::Transaction *state, Client::Request *req)
+  class URL : public Cript::Url // ToDo: This can maybe be a subclass of Client::URL ?
   {
-    Url::_initialize(state);
+    using super_type = Cript::Url;
+    using self_type  = URL;
 
-    _bufp    = req->BufP();
-    _hdr_loc = req->MLoc();
-  }
+  public:
+    URL()                             = default;
+    URL(const self_type &)            = delete;
+    void operator=(const self_type &) = delete;
 
-}; // End class Cache::URL
+    static self_type &_get(Cript::Context *context);
+    bool              _update(Cript::Context *context);
+
+  private:
+    void
+    _initialize(Cript::Transaction *state, Client::Request *req)
+    {
+      Url::_initialize(state);
+
+      _bufp    = req->BufP();
+      _hdr_loc = req->MLoc();
+    }
+
+  }; // End class Cache::URL
 
 } // namespace Cache
 
 namespace Parent
 {
-class URL : public Cript::Url
-{
-  using super_type = Cript::Url;
-  using self_type  = URL;
-
-public:
-  URL()                             = default;
-  URL(const self_type &)            = delete;
-  void operator=(const self_type &) = delete;
-
-  static self_type &_get(Cript::Context *context);
-  bool              _update(Cript::Context *context);
-
-private:
-  void
-  _initialize(Cript::Transaction *state, Client::Request *req)
+  class URL : public Cript::Url
   {
-    Url::_initialize(state);
+    using super_type = Cript::Url;
+    using self_type  = URL;
 
-    _bufp    = req->BufP();
-    _hdr_loc = req->MLoc();
-  }
+  public:
+    URL()                             = default;
+    URL(const self_type &)            = delete;
+    void operator=(const self_type &) = delete;
 
-}; // End class Cache::URL
+    static self_type &_get(Cript::Context *context);
+    bool              _update(Cript::Context *context);
+
+  private:
+    void
+    _initialize(Cript::Transaction *state, Client::Request *req)
+    {
+      Url::_initialize(state);
+
+      _bufp    = req->BufP();
+      _hdr_loc = req->MLoc();
+    }
+
+  }; // End class Cache::URL
 
 } // namespace Parent
+
+} // namespace Cript
 
 // Formatters for {fmt}
 namespace fmt

--- a/src/cripts/Bundles/Caching.cc
+++ b/src/cripts/Bundles/Caching.cc
@@ -19,12 +19,12 @@
 #include "cripts/Preamble.hpp"
 #include "cripts/Bundles/Caching.hpp"
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-const Cript::string Caching::_name = "Bundle::Caching";
+const cripts::string Caching::_name = "Bundle::Caching";
 
 void
-Caching::doRemap(Cript::Context *context)
+Caching::doRemap(cripts::Context *context)
 {
   // .disable(bool)
   if (_disabled) {
@@ -34,9 +34,9 @@ Caching::doRemap(Cript::Context *context)
 }
 
 void
-Caching::doReadResponse(Cript::Context *context)
+Caching::doReadResponse(cripts::Context *context)
 {
-  borrow resp = Cript::Server::Response::Get();
+  borrow resp = cripts::Server::Response::Get();
 
   // .cache_control(str)
   if (!_cc.empty() && (resp.status > 199) && (resp.status < 400) && (resp["Cache-Control"].empty() || _force_cc)) {
@@ -44,4 +44,4 @@ Caching::doReadResponse(Cript::Context *context)
   }
 }
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/src/cripts/Bundles/Caching.cc
+++ b/src/cripts/Bundles/Caching.cc
@@ -19,7 +19,7 @@
 #include "cripts/Preamble.hpp"
 #include "cripts/Bundles/Caching.hpp"
 
-namespace Bundle
+namespace Cript::Bundle
 {
 const Cript::string Caching::_name = "Bundle::Caching";
 
@@ -36,7 +36,7 @@ Caching::doRemap(Cript::Context *context)
 void
 Caching::doReadResponse(Cript::Context *context)
 {
-  borrow resp = Server::Response::Get();
+  borrow resp = Cript::Server::Response::Get();
 
   // .cache_control(str)
   if (!_cc.empty() && (resp.status > 199) && (resp.status < 400) && (resp["Cache-Control"].empty() || _force_cc)) {
@@ -44,4 +44,4 @@ Caching::doReadResponse(Cript::Context *context)
   }
 }
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/src/cripts/Bundles/Common.cc
+++ b/src/cripts/Bundles/Common.cc
@@ -19,7 +19,7 @@
 #include "cripts/Preamble.hpp"
 #include "cripts/Bundles/Common.hpp"
 
-namespace Bundle
+namespace Cript::Bundle
 {
 const Cript::string Common::_name = "Bundle::Common";
 
@@ -134,7 +134,7 @@ Common::doRemap(Cript::Context *context)
 {
   // .dscp(int)
   if (_dscp > 0) {
-    borrow conn = Client::Connection::Get();
+    borrow conn = Cript::Client::Connection::Get();
 
     CDebug("Setting DSCP = {}", _dscp);
     conn.dscp = _dscp;
@@ -156,4 +156,4 @@ Common::doRemap(Cript::Context *context)
   }
 }
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/src/cripts/Bundles/Common.cc
+++ b/src/cripts/Bundles/Common.cc
@@ -19,12 +19,12 @@
 #include "cripts/Preamble.hpp"
 #include "cripts/Bundles/Common.hpp"
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-const Cript::string Common::_name = "Bundle::Common";
+const cripts::string Common::_name = "Bundle::Common";
 
 bool
-Common::Validate(std::vector<Cript::Bundle::Error> &errors) const
+Common::Validate(std::vector<cripts::Bundle::Error> &errors) const
 {
   bool good = true;
 
@@ -73,9 +73,9 @@ Common::Validate(std::vector<Cript::Bundle::Error> &errors) const
 }
 
 Common::self_type &
-Common::via_header(const Cript::string_view &destination, const Cript::string_view &value)
+Common::via_header(const cripts::string_view &destination, const cripts::string_view &value)
 {
-  static const std::unordered_map<Cript::string_view, int> SettingValues = {
+  static const std::unordered_map<cripts::string_view, int> SettingValues = {
     {"disable",  0  },
     {"protocol", 1  },
     {"basic",    2  },
@@ -84,7 +84,7 @@ Common::via_header(const Cript::string_view &destination, const Cript::string_vi
     {"none",     999}  // This is an error
   };
 
-  NeedCallback(Cript::Callbacks::DO_REMAP);
+  NeedCallback(cripts::Callbacks::DO_REMAP);
 
   int  val = 999;
   auto it  = SettingValues.find(value);
@@ -105,12 +105,12 @@ Common::via_header(const Cript::string_view &destination, const Cript::string_vi
 }
 
 Common &
-Common::set_config(const Cript::string_view name, const Cript::Records::ValueType &value)
+Common::set_config(const cripts::string_view name, const cripts::Records::ValueType &value)
 {
-  auto rec = Cript::Records::Lookup(name); // These should be loaded at startup
+  auto rec = cripts::Records::Lookup(name); // These should be loaded at startup
 
   if (rec) {
-    NeedCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(cripts::Callbacks::DO_REMAP);
     _configs.emplace_back(rec, value);
   } else {
     CFatal("[Common::set_config]: Unknown configuration '%.*s'", static_cast<int>(name.size()), name.data());
@@ -120,7 +120,7 @@ Common::set_config(const Cript::string_view name, const Cript::Records::ValueTyp
 }
 
 Common &
-Common::set_config(const std::vector<std::pair<const Cript::string_view, const Cript::Records::ValueType>> &configs)
+Common::set_config(const std::vector<std::pair<const cripts::string_view, const cripts::Records::ValueType>> &configs)
 {
   for (auto &[name, value] : configs) {
     set_config(name, value);
@@ -130,11 +130,11 @@ Common::set_config(const std::vector<std::pair<const Cript::string_view, const C
 }
 
 void
-Common::doRemap(Cript::Context *context)
+Common::doRemap(cripts::Context *context)
 {
   // .dscp(int)
   if (_dscp > 0) {
-    borrow conn = Cript::Client::Connection::Get();
+    borrow conn = cripts::Client::Connection::Get();
 
     CDebug("Setting DSCP = {}", _dscp);
     conn.dscp = _dscp;
@@ -156,4 +156,4 @@ Common::doRemap(Cript::Context *context)
   }
 }
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/src/cripts/Bundles/HRWBridge.cc
+++ b/src/cripts/Bundles/HRWBridge.cc
@@ -36,16 +36,16 @@ public:
   ID(const self_type &)             = delete;
   void operator=(const self_type &) = delete;
 
-  ID(const Cript::string_view &id);
+  ID(const cripts::string_view &id);
   ~ID() override = default;
 
-  Cript::string_view value(Cript::Context *context) override;
+  cripts::string_view value(cripts::Context *context) override;
 
 private:
   Type _type = Type::none;
 };
 
-ID::ID(const Cript::string_view &id) : super_type(id)
+ID::ID(const cripts::string_view &id) : super_type(id)
 {
   if (id == "REQUEST") {
     _type = Type::REQUEST;
@@ -58,18 +58,18 @@ ID::ID(const Cript::string_view &id) : super_type(id)
   }
 }
 
-Cript::string_view
-ID::value(Cript::Context *context)
+cripts::string_view
+ID::value(cripts::Context *context)
 {
   switch (_type) {
   case Type::REQUEST:
-    _value = Cript::UUID::Request::_get(context);
+    _value = cripts::UUID::Request::_get(context);
     break;
   case Type::PROCESS:
-    _value = Cript::UUID::Process::_get(context);
+    _value = cripts::UUID::Process::_get(context);
     break;
   case Type::UNIQUE:
-    _value = Cript::UUID::Unique::_get(context);
+    _value = cripts::UUID::Unique::_get(context);
     break;
   default:
     _value = "";
@@ -92,16 +92,16 @@ public:
   IP(const self_type &)             = delete;
   void operator=(const self_type &) = delete;
 
-  IP(const Cript::string_view &ip);
+  IP(const cripts::string_view &ip);
   ~IP() override = default;
 
-  Cript::string_view value(Cript::Context *context) override;
+  cripts::string_view value(cripts::Context *context) override;
 
 private:
   Type _type = Type::none;
 };
 
-IP::IP(const Cript::string_view &type) : super_type(type)
+IP::IP(const cripts::string_view &type) : super_type(type)
 {
   if (type == "CLIENT") {
     _type = Type::CLIENT;
@@ -116,24 +116,24 @@ IP::IP(const Cript::string_view &type) : super_type(type)
   }
 }
 
-Cript::string_view
-IP::value(Cript::Context *context)
+cripts::string_view
+IP::value(cripts::Context *context)
 {
   switch (_type) {
   case Type::CLIENT: {
-    auto ip = Cript::Client::Connection::Get().IP();
+    auto ip = cripts::Client::Connection::Get().IP();
     _value  = ip.string();
   } break;
   case Type::INBOUND: {
-    auto ip = Cript::Client::Connection::Get().LocalIP();
+    auto ip = cripts::Client::Connection::Get().LocalIP();
     _value  = ip.string();
   } break;
   case Type::SERVER: {
-    auto ip = Cript::Server::Connection::Get().IP();
+    auto ip = cripts::Server::Connection::Get().IP();
     _value  = ip.string();
   } break;
   case Type::OUTBOUND: {
-    auto ip = Cript::Server::Connection::Get().LocalIP();
+    auto ip = cripts::Server::Connection::Get().LocalIP();
     _value  = ip.string();
   } break;
   default:
@@ -155,17 +155,17 @@ public:
   CIDR(const self_type &)           = delete;
   void operator=(const self_type &) = delete;
 
-  CIDR(Cript::string_view &cidr);
+  CIDR(cripts::string_view &cidr);
   ~CIDR() override = default;
 
-  Cript::string_view value(Cript::Context *context) override;
+  cripts::string_view value(cripts::Context *context) override;
 
 private:
   unsigned int _ipv4_cidr = 32;
   unsigned int _ipv6_cidr = 128;
 };
 
-CIDR::CIDR(Cript::string_view &cidr) : super_type(cidr)
+CIDR::CIDR(cripts::string_view &cidr) : super_type(cidr)
 {
   auto ipv4 = cidr.split_prefix_at(',');
 
@@ -183,10 +183,10 @@ CIDR::CIDR(Cript::string_view &cidr) : super_type(cidr)
   }
 }
 
-Cript::string_view
-CIDR::value(Cript::Context *context)
+cripts::string_view
+CIDR::value(cripts::Context *context)
 {
-  auto ip = Cript::Client::Connection::Get().IP();
+  auto ip = cripts::Client::Connection::Get().IP();
 
   _value = ip.string(_ipv4_cidr, _ipv6_cidr);
 
@@ -208,21 +208,21 @@ public:
   URL(const self_type &)           = delete;
   URL operator=(const self_type &) = delete;
 
-  URL(const Cript::string_view &) = delete;
-  URL(Type utype, const Cript::string_view &comp);
+  URL(const cripts::string_view &) = delete;
+  URL(Type utype, const cripts::string_view &comp);
   ~URL() override = default;
 
-  Cript::string_view value(Cript::Context *context) override;
+  cripts::string_view value(cripts::Context *context) override;
 
 private:
-  Cript::string_view _getComponent(Cript::Url &url);
+  cripts::string_view _getComponent(cripts::Url &url);
 
   Type      _type = Type::none;
   Component _comp = Component::none;
 };
 
-Cript::string_view
-URL::_getComponent(Cript::Url &url)
+cripts::string_view
+URL::_getComponent(cripts::Url &url)
 {
   switch (_comp) {
   case Component::HOST:
@@ -234,7 +234,7 @@ URL::_getComponent(Cript::Url &url)
     break;
 
   case Component::PORT:
-    _value = Cript::string(std::to_string(url.port));
+    _value = cripts::string(std::to_string(url.port));
     break;
 
   case Component::QUERY:
@@ -258,7 +258,7 @@ URL::_getComponent(Cript::Url &url)
   return ""; // Should never happen
 }
 
-URL::URL(Type utype, const Cript::string_view &comp) : super_type("")
+URL::URL(Type utype, const cripts::string_view &comp) : super_type("")
 {
   _type = utype;
 
@@ -279,42 +279,42 @@ URL::URL(Type utype, const Cript::string_view &comp) : super_type("")
   }
 }
 
-Cript::string_view
-URL::value(Cript::Context *context)
+cripts::string_view
+URL::value(cripts::Context *context)
 {
   switch (_type) {
   case Type::CLIENT: {
-    borrow url = Cript::Client::URL::Get();
+    borrow url = cripts::Client::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::REMAP_FROM: {
-    borrow url = Cript::Remap::From::URL::Get();
+    borrow url = cripts::Remap::From::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::REMAP_TO: {
-    borrow url = Cript::Remap::To::URL::Get();
+    borrow url = cripts::Remap::To::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::PRISTINE: {
-    borrow url = Cript::Pristine::URL::Get();
+    borrow url = cripts::Pristine::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::CACHE: {
-    borrow url = Cript::Cache::URL::Get();
+    borrow url = cripts::Cache::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::PARENT: {
-    borrow url = Cript::Parent::URL::Get();
+    borrow url = cripts::Parent::URL::Get();
 
     return _getComponent(url);
   } break;
@@ -330,9 +330,9 @@ URL::value(Cript::Context *context)
 } // namespace detail
 
 detail::HRWBridge *
-Cript::Bundle::Headers::BridgeFactory(const Cript::string &source)
+cripts::Bundle::Headers::BridgeFactory(const cripts::string &source)
 {
-  Cript::string_view str = source;
+  cripts::string_view str = source;
 
   str.trim_if([](char c) { return std::isspace(c) || c == '"' || c == '\''; });
 

--- a/src/cripts/Bundles/HRWBridge.cc
+++ b/src/cripts/Bundles/HRWBridge.cc
@@ -63,13 +63,13 @@ ID::value(Cript::Context *context)
 {
   switch (_type) {
   case Type::REQUEST:
-    _value = UUID::Request::_get(context);
+    _value = Cript::UUID::Request::_get(context);
     break;
   case Type::PROCESS:
-    _value = UUID::Process::_get(context);
+    _value = Cript::UUID::Process::_get(context);
     break;
   case Type::UNIQUE:
-    _value = UUID::Unique::_get(context);
+    _value = Cript::UUID::Unique::_get(context);
     break;
   default:
     _value = "";
@@ -121,19 +121,19 @@ IP::value(Cript::Context *context)
 {
   switch (_type) {
   case Type::CLIENT: {
-    auto ip = Client::Connection::Get().IP();
+    auto ip = Cript::Client::Connection::Get().IP();
     _value  = ip.string();
   } break;
   case Type::INBOUND: {
-    auto ip = Client::Connection::Get().LocalIP();
+    auto ip = Cript::Client::Connection::Get().LocalIP();
     _value  = ip.string();
   } break;
   case Type::SERVER: {
-    auto ip = Server::Connection::Get().IP();
+    auto ip = Cript::Server::Connection::Get().IP();
     _value  = ip.string();
   } break;
   case Type::OUTBOUND: {
-    auto ip = Server::Connection::Get().LocalIP();
+    auto ip = Cript::Server::Connection::Get().LocalIP();
     _value  = ip.string();
   } break;
   default:
@@ -186,7 +186,7 @@ CIDR::CIDR(Cript::string_view &cidr) : super_type(cidr)
 Cript::string_view
 CIDR::value(Cript::Context *context)
 {
-  auto ip = Client::Connection::Get().IP();
+  auto ip = Cript::Client::Connection::Get().IP();
 
   _value = ip.string(_ipv4_cidr, _ipv6_cidr);
 
@@ -284,37 +284,37 @@ URL::value(Cript::Context *context)
 {
   switch (_type) {
   case Type::CLIENT: {
-    borrow url = Client::URL::Get();
+    borrow url = Cript::Client::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::REMAP_FROM: {
-    borrow url = Remap::From::URL::Get();
+    borrow url = Cript::Remap::From::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::REMAP_TO: {
-    borrow url = Remap::To::URL::Get();
+    borrow url = Cript::Remap::To::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::PRISTINE: {
-    borrow url = Pristine::URL::Get();
+    borrow url = Cript::Pristine::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::CACHE: {
-    borrow url = Cache::URL::Get();
+    borrow url = Cript::Cache::URL::Get();
 
     return _getComponent(url);
   } break;
 
   case Type::PARENT: {
-    borrow url = Parent::URL::Get();
+    borrow url = Cript::Parent::URL::Get();
 
     return _getComponent(url);
   } break;
@@ -330,7 +330,7 @@ URL::value(Cript::Context *context)
 } // namespace detail
 
 detail::HRWBridge *
-Bundle::Headers::BridgeFactory(const Cript::string &source)
+Cript::Bundle::Headers::BridgeFactory(const Cript::string &source)
 {
   Cript::string_view str = source;
 

--- a/src/cripts/Bundles/Headers.cc
+++ b/src/cripts/Bundles/Headers.cc
@@ -31,7 +31,7 @@ enum HeaderTargets : uint8_t {
 };
 
 HeaderTargets
-header_target(const Cript::string_view &target)
+header_target(const cripts::string_view &target)
 {
   if (target == "Client::Request") {
     return CLIENT_REQUEST;
@@ -48,29 +48,29 @@ header_target(const Cript::string_view &target)
 
 } // namespace
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-const Cript::string Headers::_name = "Bundle::Headers";
+const cripts::string Headers::_name = "Bundle::Headers";
 
 Headers::self_type &
-Headers::rm_headers(const Cript::string_view target, const HeaderList &headers)
+Headers::rm_headers(const cripts::string_view target, const HeaderList &headers)
 {
   switch (header_target(target)) {
   case CLIENT_REQUEST:
     _client_request.rm_headers.insert(_client_request.rm_headers.end(), headers.begin(), headers.end());
-    NeedCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(cripts::Callbacks::DO_REMAP);
     break;
   case CLIENT_RESPONSE:
     _client_response.rm_headers.insert(_client_response.rm_headers.end(), headers.begin(), headers.end());
-    NeedCallback(Cript::Callbacks::DO_SEND_RESPONSE);
+    NeedCallback(cripts::Callbacks::DO_SEND_RESPONSE);
     break;
   case SERVER_REQUEST:
     _client_response.rm_headers.insert(_client_response.rm_headers.end(), headers.begin(), headers.end());
-    NeedCallback(Cript::Callbacks::DO_SEND_REQUEST);
+    NeedCallback(cripts::Callbacks::DO_SEND_REQUEST);
     break;
   case SERVER_RESPONSE:
     _client_response.rm_headers.insert(_client_response.rm_headers.end(), headers.begin(), headers.end());
-    NeedCallback(Cript::Callbacks::DO_READ_RESPONSE);
+    NeedCallback(cripts::Callbacks::DO_READ_RESPONSE);
     break;
   default:
     CFatal("[Cripts::Headers] Unknown header target: %s.", target.data());
@@ -80,26 +80,26 @@ Headers::rm_headers(const Cript::string_view target, const HeaderList &headers)
 }
 
 Headers::self_type &
-Headers::set_headers(const Cript::string_view target, const HeaderValueList &headers)
+Headers::set_headers(const cripts::string_view target, const HeaderValueList &headers)
 {
   detail::HeadersType::HeaderValueList *hdrs = nullptr;
 
   switch (header_target(target)) {
   case CLIENT_REQUEST:
     hdrs = &_client_request.set_headers;
-    NeedCallback(Cript::Callbacks::DO_REMAP);
+    NeedCallback(cripts::Callbacks::DO_REMAP);
     break;
   case CLIENT_RESPONSE:
     hdrs = &_client_response.set_headers;
-    NeedCallback(Cript::Callbacks::DO_SEND_RESPONSE);
+    NeedCallback(cripts::Callbacks::DO_SEND_RESPONSE);
     break;
   case SERVER_REQUEST:
     hdrs = &_server_request.set_headers;
-    NeedCallback(Cript::Callbacks::DO_SEND_REQUEST);
+    NeedCallback(cripts::Callbacks::DO_SEND_REQUEST);
     break;
   case SERVER_RESPONSE:
     hdrs = &_server_response.set_headers;
-    NeedCallback(Cript::Callbacks::DO_READ_RESPONSE);
+    NeedCallback(cripts::Callbacks::DO_READ_RESPONSE);
     break;
   default:
     CFatal("[Cripts::Headers] Unknown header target: %s.", target.data());
@@ -114,9 +114,9 @@ Headers::set_headers(const Cript::string_view target, const HeaderValueList &hea
 }
 
 void
-Headers::doRemap(Cript::Context *context)
+Headers::doRemap(cripts::Context *context)
 {
-  borrow req = Cript::Client::Request::Get();
+  borrow req = cripts::Client::Request::Get();
 
   for (auto &header : _client_request.rm_headers) {
     req[header] = "";
@@ -128,9 +128,9 @@ Headers::doRemap(Cript::Context *context)
 }
 
 void
-Headers::doSendResponse(Cript::Context *context)
+Headers::doSendResponse(cripts::Context *context)
 {
-  borrow resp = Cript::Client::Response::Get();
+  borrow resp = cripts::Client::Response::Get();
 
   for (auto &header : _client_response.rm_headers) {
     resp[header] = "";
@@ -142,9 +142,9 @@ Headers::doSendResponse(Cript::Context *context)
 }
 
 void
-Headers::doSendRequest(Cript::Context *context)
+Headers::doSendRequest(cripts::Context *context)
 {
-  borrow req = Cript::Server::Request::Get();
+  borrow req = cripts::Server::Request::Get();
 
   for (auto &header : _server_request.rm_headers) {
     req[header] = "";
@@ -156,9 +156,9 @@ Headers::doSendRequest(Cript::Context *context)
 }
 
 void
-Headers::doReadResponse(Cript::Context *context)
+Headers::doReadResponse(cripts::Context *context)
 {
-  borrow resp = Cript::Server::Response::Get();
+  borrow resp = cripts::Server::Response::Get();
 
   for (auto &header : _server_response.rm_headers) {
     resp[header] = "";
@@ -169,4 +169,4 @@ Headers::doReadResponse(Cript::Context *context)
   }
 }
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/src/cripts/Bundles/Headers.cc
+++ b/src/cripts/Bundles/Headers.cc
@@ -48,7 +48,7 @@ header_target(const Cript::string_view &target)
 
 } // namespace
 
-namespace Bundle
+namespace Cript::Bundle
 {
 const Cript::string Headers::_name = "Bundle::Headers";
 
@@ -116,7 +116,7 @@ Headers::set_headers(const Cript::string_view target, const HeaderValueList &hea
 void
 Headers::doRemap(Cript::Context *context)
 {
-  borrow req = Client::Request::Get();
+  borrow req = Cript::Client::Request::Get();
 
   for (auto &header : _client_request.rm_headers) {
     req[header] = "";
@@ -130,7 +130,7 @@ Headers::doRemap(Cript::Context *context)
 void
 Headers::doSendResponse(Cript::Context *context)
 {
-  borrow resp = Client::Response::Get();
+  borrow resp = Cript::Client::Response::Get();
 
   for (auto &header : _client_response.rm_headers) {
     resp[header] = "";
@@ -144,7 +144,7 @@ Headers::doSendResponse(Cript::Context *context)
 void
 Headers::doSendRequest(Cript::Context *context)
 {
-  borrow req = Server::Request::Get();
+  borrow req = Cript::Server::Request::Get();
 
   for (auto &header : _server_request.rm_headers) {
     req[header] = "";
@@ -158,7 +158,7 @@ Headers::doSendRequest(Cript::Context *context)
 void
 Headers::doReadResponse(Cript::Context *context)
 {
-  borrow resp = Server::Response::Get();
+  borrow resp = Cript::Server::Response::Get();
 
   for (auto &header : _server_response.rm_headers) {
     resp[header] = "";
@@ -169,4 +169,4 @@ Headers::doReadResponse(Cript::Context *context)
   }
 }
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -20,7 +20,7 @@
 #include "cripts/Preamble.hpp"
 #include "cripts/Bundles/LogsMetrics.hpp"
 
-namespace Bundle
+namespace Cript::Bundle
 {
 const Cript::string LogsMetrics::_name = "Bundle::LogsMetrics";
 
@@ -88,7 +88,7 @@ LogsMetrics::propstats(const Cript::string_view &label)
       auto name = fmt::format("{}.{}", _label, Bundle::PROPSTAT_SUFFIXES[ix]);
 
       _inst->debug("Creating metrics for: {}", name);
-      _inst->metrics[ix] = Metrics::Counter::Create(name);
+      _inst->metrics[ix] = Cript::Metrics::Counter::Create(name);
     }
   }
 
@@ -98,11 +98,11 @@ LogsMetrics::propstats(const Cript::string_view &label)
 void
 LogsMetrics::doTxnClose(Cript::Context *context)
 {
-  borrow resp = Client::Response::Get();
+  borrow resp = Cript::Client::Response::Get();
 
   // .tcpinfo(bool)
   if (_tcpinfo && control.logging.Get()) {
-    borrow conn = Client::Connection::Get();
+    borrow conn = Cript::Client::Connection::Get();
 
     resp["@TCPInfo"] += fmt::format(",TC; {}", conn.tcpinfo.Log());
   }
@@ -147,8 +147,8 @@ LogsMetrics::doTxnClose(Cript::Context *context)
 void
 LogsMetrics::doSendResponse(Cript::Context *context)
 {
-  borrow resp = Client::Response::Get();
-  borrow conn = Client::Connection::Get();
+  borrow resp = Cript::Client::Response::Get();
+  borrow conn = Cript::Client::Connection::Get();
 
   // .sample(int)
   if (_log_sample > 0) {
@@ -190,10 +190,10 @@ LogsMetrics::doRemap(Cript::Context *context)
 
   // .tcpinfo(bool)
   if (_tcpinfo && sampled) {
-    borrow req      = Client::Request::Get();
-    borrow conn     = Client::Connection::Get();
+    borrow req      = Cript::Client::Request::Get();
+    borrow conn     = Cript::Client::Connection::Get();
     req["@TCPInfo"] = fmt::format("TS; {}", conn.tcpinfo.Log());
   }
 }
 
-} // namespace Bundle
+} // namespace Cript::Bundle

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -20,9 +20,9 @@
 #include "cripts/Preamble.hpp"
 #include "cripts/Bundles/LogsMetrics.hpp"
 
-namespace Cript::Bundle
+namespace cripts::Bundle
 {
-const Cript::string LogsMetrics::_name = "Bundle::LogsMetrics";
+const cripts::string LogsMetrics::_name = "Bundle::LogsMetrics";
 
 namespace
 {
@@ -50,7 +50,7 @@ namespace
   };
 
   // This has to align with the enum above!!
-  static constexpr Cript::string_view PROPSTAT_SUFFIXES[] = {
+  static constexpr cripts::string_view PROPSTAT_SUFFIXES[] = {
     // clang-format off
     "cache.miss",
     "cache.hit_stale",
@@ -77,18 +77,18 @@ namespace
 
 // The .propstats(str) is particularly complicated, since it has to create all the metrics
 LogsMetrics::self_type &
-LogsMetrics::propstats(const Cript::string_view &label)
+LogsMetrics::propstats(const cripts::string_view &label)
 {
   _label = label;
 
   if (_label.length() > 0) {
-    NeedCallback({Cript::Callbacks::DO_CACHE_LOOKUP, Cript::Callbacks::DO_TXN_CLOSE});
+    NeedCallback({cripts::Callbacks::DO_CACHE_LOOKUP, cripts::Callbacks::DO_TXN_CLOSE});
 
     for (int ix = 0; ix < Bundle::PROPSTAT_MAX; ++ix) {
       auto name = fmt::format("{}.{}", _label, Bundle::PROPSTAT_SUFFIXES[ix]);
 
       _inst->debug("Creating metrics for: {}", name);
-      _inst->metrics[ix] = Cript::Metrics::Counter::Create(name);
+      _inst->metrics[ix] = cripts::Metrics::Counter::Create(name);
     }
   }
 
@@ -96,13 +96,13 @@ LogsMetrics::propstats(const Cript::string_view &label)
 }
 
 void
-LogsMetrics::doTxnClose(Cript::Context *context)
+LogsMetrics::doTxnClose(cripts::Context *context)
 {
-  borrow resp = Cript::Client::Response::Get();
+  borrow resp = cripts::Client::Response::Get();
 
   // .tcpinfo(bool)
   if (_tcpinfo && control.logging.Get()) {
-    borrow conn = Cript::Client::Connection::Get();
+    borrow conn = cripts::Client::Connection::Get();
 
     resp["@TCPInfo"] += fmt::format(",TC; {}", conn.tcpinfo.Log());
   }
@@ -145,10 +145,10 @@ LogsMetrics::doTxnClose(Cript::Context *context)
 }
 
 void
-LogsMetrics::doSendResponse(Cript::Context *context)
+LogsMetrics::doSendResponse(cripts::Context *context)
 {
-  borrow resp = Cript::Client::Response::Get();
-  borrow conn = Cript::Client::Connection::Get();
+  borrow resp = cripts::Client::Response::Get();
+  borrow conn = cripts::Client::Connection::Get();
 
   // .sample(int)
   if (_log_sample > 0) {
@@ -162,7 +162,7 @@ LogsMetrics::doSendResponse(Cript::Context *context)
 }
 
 void
-LogsMetrics::doCacheLookup(Cript::Context *context)
+LogsMetrics::doCacheLookup(cripts::Context *context)
 {
   auto status = transaction.LookupStatus();
 
@@ -175,13 +175,13 @@ LogsMetrics::doCacheLookup(Cript::Context *context)
 }
 
 void
-LogsMetrics::doRemap(Cript::Context *context)
+LogsMetrics::doRemap(cripts::Context *context)
 {
   bool sampled = true;
 
   // .logsample(int)
   if (_log_sample > 0) {
-    if (Cript::Random(_log_sample) != 1) {
+    if (cripts::Random(_log_sample) != 1) {
       control.logging.Set(false);
       sampled = false;
     }
@@ -190,10 +190,10 @@ LogsMetrics::doRemap(Cript::Context *context)
 
   // .tcpinfo(bool)
   if (_tcpinfo && sampled) {
-    borrow req      = Cript::Client::Request::Get();
-    borrow conn     = Cript::Client::Connection::Get();
+    borrow req      = cripts::Client::Request::Get();
+    borrow conn     = cripts::Client::Connection::Get();
     req["@TCPInfo"] = fmt::format("TS; {}", conn.tcpinfo.Log());
   }
 }
 
-} // namespace Cript::Bundle
+} // namespace cripts::Bundle

--- a/src/cripts/Configs.cc
+++ b/src/cripts/Configs.cc
@@ -19,12 +19,12 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
-namespace Cript
+namespace cripts
 {
 
-std::unordered_map<Cript::string_view, const Records *> Records::_gRecords;
+std::unordered_map<cripts::string_view, const Records *> Records::_gRecords;
 
-Records::Records(const Cript::string_view name)
+Records::Records(const cripts::string_view name)
 {
   TSOverridableConfigKey key;
   TSRecordDataType       type;
@@ -39,7 +39,7 @@ Records::Records(const Cript::string_view name)
 }
 
 Records::ValueType
-Records::_get(const Cript::Context *context) const
+Records::_get(const cripts::Context *context) const
 {
   TSAssert(context->state.txnp);
 
@@ -69,8 +69,8 @@ Records::_get(const Cript::Context *context) const
   return 0;
 }
 
-const Cript::string_view
-Records::GetSV(const Cript::Context *context) const
+const cripts::string_view
+Records::GetSV(const cripts::Context *context) const
 {
   TSAssert(context->state.txnp);
 
@@ -92,7 +92,7 @@ Records::GetSV(const Cript::Context *context) const
 }
 
 bool
-Records::_set(const Cript::Context *context, const ValueType &value) const
+Records::_set(const cripts::Context *context, const ValueType &value) const
 {
   TSAssert(context->state.txnp);
 
@@ -129,7 +129,7 @@ Records::_set(const Cript::Context *context, const ValueType &value) const
 }
 
 bool
-Records::SetSV(const Cript::Context *context, const Cript::string_view value) const
+Records::SetSV(const cripts::Context *context, const cripts::string_view value) const
 {
   TSAssert(context->state.txnp);
 
@@ -161,7 +161,7 @@ Records::Add(const Records *rec)
 }
 
 const Records *
-Records::Lookup(const Cript::string_view name)
+Records::Lookup(const cripts::string_view name)
 {
   auto it = _gRecords.find(name);
 
@@ -173,4 +173,4 @@ Records::Lookup(const Cript::string_view name)
   return nullptr;
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Connections.cc
+++ b/src/cripts/Connections.cc
@@ -23,8 +23,68 @@
 constexpr unsigned NORMALIZED_TIME_QUANTUM = 3600; // 1 hour
 
 // Some common network ranges
-const Matcher::Range::IP Cript::Net::Localhost({"127.0.0.1", "::1"});
-const Matcher::Range::IP Cript::Net::RFC1918({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"});
+const Cript::Matcher::Range::IP Cript::Net::Localhost({"127.0.0.1", "::1"});
+const Cript::Matcher::Range::IP Cript::Net::RFC1918({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"});
+
+void
+detail::ConnBase::Pacing::operator=(uint32_t val)
+{
+  TSAssert(_owner);
+  if (val == 0) {
+    val = Off;
+  }
+
+#ifdef SO_MAX_PACING_RATE
+  int connfd = _owner->FD();
+  int res    = setsockopt(connfd, SOL_SOCKET, SO_MAX_PACING_RATE, (char *)&val, sizeof(val));
+
+  // EBADF indicates possible client abort
+  if ((res < 0) && (errno != EBADF)) {
+    TSError("[fq_pacing] Error setting SO_MAX_PACING_RATE, errno=%d", errno);
+  }
+#endif
+  _val = val;
+}
+
+void
+detail::ConnBase::TcpInfo::initialize()
+{
+#if defined(TCP_INFO) && defined(HAVE_STRUCT_TCP_INFO)
+  if (!_ready) {
+    int connfd = _owner->FD();
+
+    TSAssert(_owner->_state->txnp);
+    if (connfd < 0 || TSHttpTxnIsInternal(_owner->_state->txnp)) { // No TCPInfo for internal transactions
+      _ready = false;
+      // ToDo: Deal with errors?
+    } else {
+      if (getsockopt(connfd, IPPROTO_TCP, TCP_INFO, &info, &info_len) == 0) {
+        _ready = (info_len > 0);
+      }
+    }
+  }
+#endif
+}
+
+Cript::string_view
+detail::ConnBase::TcpInfo::Log()
+{
+  initialize();
+  // We intentionally do not use the old tcpinfo that may be stored, since we may
+  // request this numerous times (measurements). Also make sure there's always a value.
+  _logging = "-";
+
+  if (_ready) {
+    // A lot of this is taken verbatim from header_rewrite, may want to rewrite this with sstreams
+#if HAVE_STRUCT_TCP_INFO_TCPI_TOTAL_RETRANS
+    _logging = fmt::format("{};{};{};{}", info.tcpi_rtt, info.tcpi_rto, info.tcpi_snd_cwnd, info.tcpi_retrans);
+#elif HAVE_STRUCT_TCP_INFO___TCPI_RETRANS
+    _logging = fmt::format("{};{};{};{}", info.tcpi_rtt, info.tcpi_rto, info.tcpi_snd_cwnd, info.__tcpi_retrans);
+#endif
+  }
+
+  return _logging;
+}
 
 namespace Cript
 {
@@ -141,68 +201,6 @@ IP::Sample(double rate, uint32_t seed, unsigned ipv4_cidr, unsigned ipv6_cidr)
   return (_sampler % static_cast<uint16_t>(rate * UINT16_MAX)) == _sampler;
 }
 
-} // namespace Cript
-
-void
-detail::ConnBase::Pacing::operator=(uint32_t val)
-{
-  TSAssert(_owner);
-  if (val == 0) {
-    val = Off;
-  }
-
-#ifdef SO_MAX_PACING_RATE
-  int connfd = _owner->FD();
-  int res    = setsockopt(connfd, SOL_SOCKET, SO_MAX_PACING_RATE, (char *)&val, sizeof(val));
-
-  // EBADF indicates possible client abort
-  if ((res < 0) && (errno != EBADF)) {
-    TSError("[fq_pacing] Error setting SO_MAX_PACING_RATE, errno=%d", errno);
-  }
-#endif
-  _val = val;
-}
-
-void
-detail::ConnBase::TcpInfo::initialize()
-{
-#if defined(TCP_INFO) && defined(HAVE_STRUCT_TCP_INFO)
-  if (!_ready) {
-    int connfd = _owner->FD();
-
-    TSAssert(_owner->_state->txnp);
-    if (connfd < 0 || TSHttpTxnIsInternal(_owner->_state->txnp)) { // No TCPInfo for internal transactions
-      _ready = false;
-      // ToDo: Deal with errors?
-    } else {
-      if (getsockopt(connfd, IPPROTO_TCP, TCP_INFO, &info, &info_len) == 0) {
-        _ready = (info_len > 0);
-      }
-    }
-  }
-#endif
-}
-
-Cript::string_view
-detail::ConnBase::TcpInfo::Log()
-{
-  initialize();
-  // We intentionally do not use the old tcpinfo that may be stored, since we may
-  // request this numerous times (measurements). Also make sure there's always a value.
-  _logging = "-";
-
-  if (_ready) {
-    // A lot of this is taken verbatim from header_rewrite, may want to rewrite this with sstreams
-#if HAVE_STRUCT_TCP_INFO_TCPI_TOTAL_RETRANS
-    _logging = fmt::format("{};{};{};{}", info.tcpi_rtt, info.tcpi_rto, info.tcpi_snd_cwnd, info.tcpi_retrans);
-#elif HAVE_STRUCT_TCP_INFO___TCPI_RETRANS
-    _logging = fmt::format("{};{};{};{}", info.tcpi_rtt, info.tcpi_rto, info.tcpi_snd_cwnd, info.__tcpi_retrans);
-#endif
-  }
-
-  return _logging;
-}
-
 Client::Connection &
 Client::Connection::_get(Cript::Context *context)
 {
@@ -244,7 +242,7 @@ Client::Connection::Count() const
 Server::Connection &
 Server::Connection::_get(Cript::Context *context)
 {
-  Server::Connection *conn = &context->_server_conn;
+  Cript::Server::Connection *conn = &context->_server_conn;
 
   if (!conn->Initialized()) {
     TSAssert(context->state.ssnp);
@@ -273,3 +271,5 @@ Server::Connection::Count() const
 {
   return TSHttpTxnServerSsnTransactionCount(_state->txnp);
 }
+
+} // namespace Cript

--- a/src/cripts/Connections.cc
+++ b/src/cripts/Connections.cc
@@ -23,8 +23,8 @@
 constexpr unsigned NORMALIZED_TIME_QUANTUM = 3600; // 1 hour
 
 // Some common network ranges
-const Cript::Matcher::Range::IP Cript::Net::Localhost({"127.0.0.1", "::1"});
-const Cript::Matcher::Range::IP Cript::Net::RFC1918({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"});
+const cripts::Matcher::Range::IP cripts::Net::Localhost({"127.0.0.1", "::1"});
+const cripts::Matcher::Range::IP cripts::Net::RFC1918({"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"});
 
 void
 detail::ConnBase::Pacing::operator=(uint32_t val)
@@ -66,7 +66,7 @@ detail::ConnBase::TcpInfo::initialize()
 #endif
 }
 
-Cript::string_view
+cripts::string_view
 detail::ConnBase::TcpInfo::Log()
 {
   initialize();
@@ -86,11 +86,11 @@ detail::ConnBase::TcpInfo::Log()
   return _logging;
 }
 
-namespace Cript
+namespace cripts
 {
 
 // This is mostly copied out of header_rewrite of course
-Cript::string_view
+cripts::string_view
 IP::GetSV(unsigned ipv4_cidr, unsigned ipv6_cidr)
 {
   if (is_ip4()) {
@@ -202,7 +202,7 @@ IP::Sample(double rate, uint32_t seed, unsigned ipv4_cidr, unsigned ipv6_cidr)
 }
 
 Client::Connection &
-Client::Connection::_get(Cript::Context *context)
+Client::Connection::_get(cripts::Context *context)
 {
   Client::Connection *conn = &context->_client_conn;
 
@@ -240,9 +240,9 @@ Client::Connection::Count() const
 }
 
 Server::Connection &
-Server::Connection::_get(Cript::Context *context)
+Server::Connection::_get(cripts::Context *context)
 {
-  Cript::Server::Connection *conn = &context->_server_conn;
+  cripts::Server::Connection *conn = &context->_server_conn;
 
   if (!conn->Initialized()) {
     TSAssert(context->state.ssnp);
@@ -272,4 +272,4 @@ Server::Connection::Count() const
   return TSHttpTxnServerSsnTransactionCount(_state->txnp);
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -24,9 +24,9 @@
 #include "cripts/Context.hpp"
 
 // Freelist management. These are here to avoid polluting the Context includes with ATS core includes.
-ClassAllocator<Cript::Context> criptContextAllocator("Cript::Context");
+ClassAllocator<cripts::Context> criptContextAllocator("cripts::Context");
 
-namespace Cript
+namespace cripts
 {
 
 void
@@ -61,7 +61,7 @@ Context::reset()
 }
 
 Context *
-Context::Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, Cript::Instance &inst)
+Context::Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst)
 {
   return THREAD_ALLOC(criptContextAllocator, this_thread(), txn_ptr, ssn_ptr, rri_ptr, inst);
 }
@@ -72,4 +72,4 @@ Context::Release()
   THREAD_FREE(this, criptContextAllocator, this_thread());
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Crypto.cc
+++ b/src/cripts/Crypto.cc
@@ -25,6 +25,9 @@
 #define ENCODED_LEN(len) (((int)ceil(1.34 * (len) + 5)) + 1)
 #define DECODED_LEN(len) (((int)ceil((len) / 1.33 + 5)) + 1)
 
+namespace Cript
+{
+
 Cript::string
 Crypto::Base64::Encode(Cript::string_view str)
 {
@@ -212,3 +215,5 @@ Crypto::HMAC::SHA256::Encrypt(Cript::string_view str, const Cript::string &key)
 
   return retval;
 }
+
+} // namespace Cript

--- a/src/cripts/Crypto.cc
+++ b/src/cripts/Crypto.cc
@@ -25,14 +25,14 @@
 #define ENCODED_LEN(len) (((int)ceil(1.34 * (len) + 5)) + 1)
 #define DECODED_LEN(len) (((int)ceil((len) / 1.33 + 5)) + 1)
 
-namespace Cript
+namespace cripts
 {
 
-Cript::string
-Crypto::Base64::Encode(Cript::string_view str)
+cripts::string
+Crypto::Base64::Encode(cripts::string_view str)
 {
-  Cript::string ret;
-  size_t        encoded_len = 0;
+  cripts::string ret;
+  size_t         encoded_len = 0;
 
   ret.resize(ENCODED_LEN(str.size())); // Don't use reserve() here, or bad things happens.
   if (TS_SUCCESS != TSBase64Encode(str.data(), str.size(), ret.data(), ret.capacity(), &encoded_len)) {
@@ -44,11 +44,11 @@ Crypto::Base64::Encode(Cript::string_view str)
   return ret; // RVO
 }
 
-Cript::string
-Crypto::Base64::Decode(Cript::string_view str)
+cripts::string
+Crypto::Base64::Decode(cripts::string_view str)
 {
-  Cript::string ret;
-  size_t        decoded_len = 0;
+  cripts::string ret;
+  size_t         decoded_len = 0;
 
   ret.resize(DECODED_LEN(str.size())); // Don't use reserve() here, or bad things happens.
   if (TS_SUCCESS !=
@@ -61,8 +61,8 @@ Crypto::Base64::Decode(Cript::string_view str)
   return ret; // RVO
 }
 
-Cript::string
-Crypto::Escape::Encode(Cript::string_view str)
+cripts::string
+Crypto::Escape::Encode(cripts::string_view str)
 {
   static const unsigned char map[32] = {
     0xFF, 0xFF, 0xFF,
@@ -86,8 +86,8 @@ Crypto::Escape::Encode(Cript::string_view str)
     0x00 //               .
   };
 
-  Cript::string ret;
-  size_t        encoded_len = 0;
+  cripts::string ret;
+  size_t         encoded_len = 0;
 
   ret.resize(str.size() * 3 + 1); // Don't use reserve() here, or bad things happens.
   TSStringPercentEncode(str.data(), str.size(), ret.data(), ret.capacity(), &encoded_len, map);
@@ -96,11 +96,11 @@ Crypto::Escape::Encode(Cript::string_view str)
   return ret; // RVO
 }
 
-Cript::string
-Crypto::Escape::Decode(Cript::string_view str)
+cripts::string
+Crypto::Escape::Decode(cripts::string_view str)
 {
-  Cript::string ret;
-  size_t        decoded_len = 0;
+  cripts::string ret;
+  size_t         decoded_len = 0;
 
   ret.resize(str.size() + 1); // Don't use reserve() here, or bad things happens.
   TSStringPercentDecode(str.data(), str.size(), ret.data(), ret.capacity(), &decoded_len);
@@ -110,7 +110,7 @@ Crypto::Escape::Decode(Cript::string_view str)
 }
 
 Crypto::SHA256
-Crypto::SHA256::Encode(Cript::string_view str)
+Crypto::SHA256::Encode(cripts::string_view str)
 {
   SHA256_CTX     ctx;
   Crypto::SHA256 digest;
@@ -123,7 +123,7 @@ Crypto::SHA256::Encode(Cript::string_view str)
 }
 
 Crypto::SHA512
-Crypto::SHA512::Encode(Cript::string_view str)
+Crypto::SHA512::Encode(cripts::string_view str)
 {
   SHA512_CTX     ctx;
   Crypto::SHA512 digest;
@@ -136,7 +136,7 @@ Crypto::SHA512::Encode(Cript::string_view str)
 }
 
 Crypto::MD5
-Crypto::MD5::Encode(Cript::string_view str)
+Crypto::MD5::Encode(cripts::string_view str)
 {
   MD5_CTX     ctx;
   Crypto::MD5 digest;
@@ -164,7 +164,7 @@ Crypto::detail::Cipher::_initialize()
 }
 
 void
-Crypto::detail::Cipher::Encrypt(Cript::string_view str)
+Crypto::detail::Cipher::Encrypt(cripts::string_view str)
 {
   int len = 0;
 
@@ -178,7 +178,7 @@ Crypto::detail::Cipher::Encrypt(Cript::string_view str)
   _length += len;
 }
 
-Cript::string_view
+cripts::string_view
 Crypto::detail::Cipher::Finalize()
 {
   int len = 0;
@@ -195,7 +195,7 @@ Crypto::detail::Cipher::Finalize()
 }
 
 Crypto::AES256
-Crypto::AES256::Encrypt(Cript::string_view str, const unsigned char *key)
+Crypto::AES256::Encrypt(cripts::string_view str, const unsigned char *key)
 {
   Crypto::AES256 crypt(key);
 
@@ -206,7 +206,7 @@ Crypto::AES256::Encrypt(Cript::string_view str, const unsigned char *key)
 }
 
 Crypto::HMAC::SHA256
-Crypto::HMAC::SHA256::Encrypt(Cript::string_view str, const Cript::string &key)
+Crypto::HMAC::SHA256::Encrypt(cripts::string_view str, const cripts::string &key)
 {
   Crypto::HMAC::SHA256 retval;
 
@@ -216,4 +216,4 @@ Crypto::HMAC::SHA256::Encrypt(Cript::string_view str, const Cript::string &key)
   return retval;
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Error.cc
+++ b/src/cripts/Error.cc
@@ -19,6 +19,9 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
+namespace Cript
+{
+
 void
 Error::Execute(Cript::Context *context)
 {
@@ -49,3 +52,5 @@ Error::Status::_get(Cript::Context *context)
 {
   return context->state.error._status._getter();
 }
+
+} // namespace Cript

--- a/src/cripts/Error.cc
+++ b/src/cripts/Error.cc
@@ -19,11 +19,11 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 void
-Error::Execute(Cript::Context *context)
+Error::Execute(cripts::Context *context)
 {
   if (Failed()) {
     TSHttpTxnStatusSet(context->state.txnp, _status._getter());
@@ -34,23 +34,23 @@ Error::Execute(Cript::Context *context)
 
 // These are static, to be used with the set() wrapper define
 void
-Error::Reason::_set(Cript::Context *context, const Cript::string_view msg)
+Error::Reason::_set(cripts::Context *context, const cripts::string_view msg)
 {
   context->state.error.Fail();
   context->state.error._reason._setter(msg);
 }
 
 void
-Error::Status::_set(Cript::Context *context, TSHttpStatus status)
+Error::Status::_set(cripts::Context *context, TSHttpStatus status)
 {
   context->state.error.Fail();
   context->state.error._status._setter(status);
 }
 
 TSHttpStatus
-Error::Status::_get(Cript::Context *context)
+Error::Status::_get(cripts::Context *context)
 {
   return context->state.error._status._getter();
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Files.cc
+++ b/src/cripts/Files.cc
@@ -22,7 +22,7 @@
 // Our include dependencies are unfortunate ...
 extern std::string RecConfigReadConfigDir();
 
-namespace Cript
+namespace cripts
 {
 
 std::filesystem::file_status
@@ -41,4 +41,4 @@ File::Path::Rebase()
   return *this;
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Files.cc
+++ b/src/cripts/Files.cc
@@ -22,6 +22,9 @@
 // Our include dependencies are unfortunate ...
 extern std::string RecConfigReadConfigDir();
 
+namespace Cript
+{
+
 std::filesystem::file_status
 File::Status(const File::Path &path)
 {
@@ -37,3 +40,5 @@ File::Path::Rebase()
 
   return *this;
 }
+
+} // namespace Cript

--- a/src/cripts/Geo.cc
+++ b/src/cripts/Geo.cc
@@ -30,14 +30,14 @@ enum Qualifiers {
   GEO_QUAL_ASN_NAME,
 };
 
-Cript::string
+cripts::string
 get_geo_string(const sockaddr *addr, Qualifiers q)
 {
   ink_release_assert(gMaxMindDB != nullptr);
   ink_release_assert(addr != nullptr);
 
-  Cript::string ret = "(unknown)";
-  int           mmdb_error;
+  cripts::string ret = "(unknown)";
+  int            mmdb_error;
 
   MMDB_lookup_result_s result = MMDB_lookup_sockaddr(gMaxMindDB, addr, &mmdb_error);
 
@@ -79,7 +79,7 @@ get_geo_string(const sockaddr *addr, Qualifiers q)
   if (MMDB_SUCCESS != status) {
     return ret;
   }
-  ret = Cript::string(entry_data.utf8_string, entry_data.data_size);
+  ret = cripts::string(entry_data.utf8_string, entry_data.data_size);
 
   if (nullptr != entry_data_list) {
     MMDB_free_entry_data_list(entry_data_list);
@@ -88,34 +88,34 @@ get_geo_string(const sockaddr *addr, Qualifiers q)
   return ret;
 }
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::ASN() const
 {
   return get_geo_string(this->_owner->socket(), GEO_QUAL_ASN);
 }
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::ASNName() const
 {
-  Cript::string ret;
+  cripts::string ret;
   ret = get_geo_string(this->_owner->socket(), GEO_QUAL_ASN_NAME);
 
   return ret; // RVO
 }
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::Country() const
 {
-  Cript::string ret;
+  cripts::string ret;
   ret = get_geo_string(this->_owner->socket(), GEO_QUAL_COUNTRY);
 
   return ret; // RVO
 }
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::CountryCode() const
 {
-  Cript::string ret;
+  cripts::string ret;
   ret = get_geo_string(this->_owner->socket(), GEO_QUAL_COUNTRY_ISO);
 
   return ret; // RVO
@@ -123,25 +123,25 @@ detail::ConnBase::Geo::CountryCode() const
 
 #else
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::ASN() const
 {
   return "(unavailable)";
 }
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::ASNName() const
 {
   return "(unavailable)";
 }
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::Country() const
 {
   return "(unavailable)";
 }
 
-Cript::string
+cripts::string
 detail::ConnBase::Geo::CountryCode() const
 {
   return "(unavailable)";

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -20,23 +20,26 @@
 #include "cripts/Preamble.hpp"
 
 // Constants
-const Header::Iterator Header::Iterator::_end = Header::Iterator("__END__", Header::Iterator::END_TAG);
+const Cript::Header::Iterator Cript::Header::Iterator::_end = Cript::Header::Iterator("__END__", Cript::Header::Iterator::END_TAG);
 
-namespace Cript::Method
+namespace Cript
+{
+
+namespace Method
 {
 #undef DELETE // ToDo: macOS shenanigans here, defining DELETE as a macro
-const Header::Method GET(TS_HTTP_METHOD_GET, TS_HTTP_LEN_GET);
-const Header::Method HEAD(TS_HTTP_METHOD_HEAD, TS_HTTP_LEN_HEAD);
-const Header::Method POST(TS_HTTP_METHOD_POST, TS_HTTP_LEN_POST);
-const Header::Method PUT(TS_HTTP_METHOD_PUT, TS_HTTP_LEN_PUT);
-const Header::Method PUSH(TS_HTTP_METHOD_PUSH, TS_HTTP_LEN_PUSH);
-const Header::Method DELETE(TS_HTTP_METHOD_DELETE, TS_HTTP_LEN_DELETE);
-const Header::Method OPTIONS(TS_HTTP_METHOD_OPTIONS, TS_HTTP_LEN_OPTIONS);
-const Header::Method CONNECT(TS_HTTP_METHOD_CONNECT, TS_HTTP_LEN_CONNECT);
-const Header::Method TRACE(TS_HTTP_METHOD_TRACE, TS_HTTP_LEN_TRACE);
-// This is a special feature of ATS
-const Header::Method PURGE(TS_HTTP_METHOD_PURGE, TS_HTTP_LEN_PURGE);
-} // namespace Cript::Method
+  const Cript::Header::Method GET(TS_HTTP_METHOD_GET, TS_HTTP_LEN_GET);
+  const Cript::Header::Method HEAD(TS_HTTP_METHOD_HEAD, TS_HTTP_LEN_HEAD);
+  const Cript::Header::Method POST(TS_HTTP_METHOD_POST, TS_HTTP_LEN_POST);
+  const Cript::Header::Method PUT(TS_HTTP_METHOD_PUT, TS_HTTP_LEN_PUT);
+  const Cript::Header::Method PUSH(TS_HTTP_METHOD_PUSH, TS_HTTP_LEN_PUSH);
+  const Cript::Header::Method DELETE(TS_HTTP_METHOD_DELETE, TS_HTTP_LEN_DELETE);
+  const Cript::Header::Method OPTIONS(TS_HTTP_METHOD_OPTIONS, TS_HTTP_LEN_OPTIONS);
+  const Cript::Header::Method CONNECT(TS_HTTP_METHOD_CONNECT, TS_HTTP_LEN_CONNECT);
+  const Cript::Header::Method TRACE(TS_HTTP_METHOD_TRACE, TS_HTTP_LEN_TRACE);
+  // This is a special feature of ATS
+  const Cript::Header::Method PURGE(TS_HTTP_METHOD_PURGE, TS_HTTP_LEN_PURGE);
+} // namespace Method
 
 Header::Status &
 Header::Status::operator=(int status)
@@ -315,7 +318,7 @@ Header::iterate()
   }
 }
 
-Client::Response &
+Cript::Client::Response &
 Client::Response::_get(Cript::Context *context)
 {
   CAssert(context->state.hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
@@ -379,3 +382,5 @@ Server::Response::_get(Cript::Context *context)
 
   return context->_server_resp_header;
 }
+
+} // namespace Cript

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -20,25 +20,26 @@
 #include "cripts/Preamble.hpp"
 
 // Constants
-const Cript::Header::Iterator Cript::Header::Iterator::_end = Cript::Header::Iterator("__END__", Cript::Header::Iterator::END_TAG);
+const cripts::Header::Iterator cripts::Header::Iterator::_end =
+  cripts::Header::Iterator("__END__", cripts::Header::Iterator::END_TAG);
 
-namespace Cript
+namespace cripts
 {
 
 namespace Method
 {
 #undef DELETE // ToDo: macOS shenanigans here, defining DELETE as a macro
-  const Cript::Header::Method GET(TS_HTTP_METHOD_GET, TS_HTTP_LEN_GET);
-  const Cript::Header::Method HEAD(TS_HTTP_METHOD_HEAD, TS_HTTP_LEN_HEAD);
-  const Cript::Header::Method POST(TS_HTTP_METHOD_POST, TS_HTTP_LEN_POST);
-  const Cript::Header::Method PUT(TS_HTTP_METHOD_PUT, TS_HTTP_LEN_PUT);
-  const Cript::Header::Method PUSH(TS_HTTP_METHOD_PUSH, TS_HTTP_LEN_PUSH);
-  const Cript::Header::Method DELETE(TS_HTTP_METHOD_DELETE, TS_HTTP_LEN_DELETE);
-  const Cript::Header::Method OPTIONS(TS_HTTP_METHOD_OPTIONS, TS_HTTP_LEN_OPTIONS);
-  const Cript::Header::Method CONNECT(TS_HTTP_METHOD_CONNECT, TS_HTTP_LEN_CONNECT);
-  const Cript::Header::Method TRACE(TS_HTTP_METHOD_TRACE, TS_HTTP_LEN_TRACE);
+  const cripts::Header::Method GET(TS_HTTP_METHOD_GET, TS_HTTP_LEN_GET);
+  const cripts::Header::Method HEAD(TS_HTTP_METHOD_HEAD, TS_HTTP_LEN_HEAD);
+  const cripts::Header::Method POST(TS_HTTP_METHOD_POST, TS_HTTP_LEN_POST);
+  const cripts::Header::Method PUT(TS_HTTP_METHOD_PUT, TS_HTTP_LEN_PUT);
+  const cripts::Header::Method PUSH(TS_HTTP_METHOD_PUSH, TS_HTTP_LEN_PUSH);
+  const cripts::Header::Method DELETE(TS_HTTP_METHOD_DELETE, TS_HTTP_LEN_DELETE);
+  const cripts::Header::Method OPTIONS(TS_HTTP_METHOD_OPTIONS, TS_HTTP_LEN_OPTIONS);
+  const cripts::Header::Method CONNECT(TS_HTTP_METHOD_CONNECT, TS_HTTP_LEN_CONNECT);
+  const cripts::Header::Method TRACE(TS_HTTP_METHOD_TRACE, TS_HTTP_LEN_TRACE);
   // This is a special feature of ATS
-  const Cript::Header::Method PURGE(TS_HTTP_METHOD_PURGE, TS_HTTP_LEN_PURGE);
+  const cripts::Header::Method PURGE(TS_HTTP_METHOD_PURGE, TS_HTTP_LEN_PURGE);
 } // namespace Method
 
 Header::Status &
@@ -71,7 +72,7 @@ Header::Status::operator integer()
 }
 
 Header::Reason &
-Header::Reason::operator=(Cript::string_view reason)
+Header::Reason::operator=(cripts::string_view reason)
 {
   TSHttpHdrReasonSet(_owner->_bufp, _owner->_hdr_loc, reason.data(), reason.size());
   _owner->_state->context->p_instance.debug("Setting reason = {}", reason);
@@ -80,7 +81,7 @@ Header::Reason::operator=(Cript::string_view reason)
 }
 
 Header::Body &
-Header::Body::operator=(Cript::string_view body)
+Header::Body::operator=(cripts::string_view body)
 {
   auto b = static_cast<char *>(TSmalloc(body.size() + 1));
 
@@ -91,23 +92,23 @@ Header::Body::operator=(Cript::string_view body)
   return *this;
 }
 
-Cript::string_view
+cripts::string_view
 Header::Method::GetSV()
 {
   if (_method.size() == 0) {
     int         len;
     const char *value = TSHttpHdrMethodGet(_owner->_bufp, _owner->_hdr_loc, &len);
 
-    _method = Cript::string_view(value, static_cast<Cript::string_view::size_type>(len));
+    _method = cripts::string_view(value, static_cast<cripts::string_view::size_type>(len));
   }
 
   return _method;
 }
 
-Cript::string_view
+cripts::string_view
 Header::CacheStatus::GetSV()
 {
-  static std::array<Cript::string_view, 4> names{
+  static std::array<cripts::string_view, 4> names{
     "miss",      // TS_CACHE_LOOKUP_MISS,
     "hit-stale", // TS_CACHE_LOOKUP_HIT_STALE,
     "hit-fresh", // TS_CACHE_LOOKUP_HIT_FRESH,
@@ -128,7 +129,7 @@ Header::CacheStatus::GetSV()
 }
 
 Header::String &
-Header::String::operator=(const Cript::string_view str)
+Header::String::operator=(const cripts::string_view str)
 {
   if (_field_loc) {
     if (str.empty()) {
@@ -215,7 +216,7 @@ Header::String::operator=(integer val)
 }
 
 Header::String &
-Header::String::operator+=(const Cript::string_view str)
+Header::String::operator+=(const cripts::string_view str)
 {
   if (_field_loc) {
     if (!str.empty()) {
@@ -239,7 +240,7 @@ Header::String::operator+=(const Cript::string_view str)
 }
 
 Header::String
-Header::operator[](const Cript::string_view str)
+Header::operator[](const cripts::string_view str)
 {
   TSAssert(_bufp && _hdr_loc);
 
@@ -250,7 +251,7 @@ Header::operator[](const Cript::string_view str)
     int         len   = 0;
     const char *value = TSMimeHdrFieldValueStringGet(_bufp, _hdr_loc, field_loc, -1, &len);
 
-    ret._initialize(str, Cript::string_view(value, len), this, field_loc);
+    ret._initialize(str, cripts::string_view(value, len), this, field_loc);
   } else {
     ret._initialize(str, {}, this, nullptr);
   }
@@ -259,7 +260,7 @@ Header::operator[](const Cript::string_view str)
 }
 
 Client::Request &
-Client::Request::_get(Cript::Context *context)
+Client::Request::_get(cripts::Context *context)
 {
   Client::Request *request = &context->_client_req_header;
 
@@ -289,9 +290,9 @@ Header::begin()
   _iterator_loc = TSMimeHdrFieldGet(_bufp, _hdr_loc, 0);
 
   if (_iterator_loc) {
-    int                name_len;
-    const char        *name = TSMimeHdrFieldNameGet(_bufp, _hdr_loc, _iterator_loc, &name_len);
-    Cript::string_view name_view(name, name_len);
+    int                 name_len;
+    const char         *name = TSMimeHdrFieldNameGet(_bufp, _hdr_loc, _iterator_loc, &name_len);
+    cripts::string_view name_view(name, name_len);
 
     return {name_view, _iterator_tag, this};
 
@@ -300,7 +301,7 @@ Header::begin()
   }
 }
 
-Cript::string_view
+cripts::string_view
 Header::iterate()
 {
   TSMLoc next_loc = TSMimeHdrFieldNext(_bufp, _hdr_loc, _iterator_loc);
@@ -312,14 +313,14 @@ Header::iterate()
     int         name_len;
     const char *name = TSMimeHdrFieldNameGet(_bufp, _hdr_loc, _iterator_loc, &name_len);
 
-    return {name, static_cast<Cript::string_view::size_type>(name_len)};
+    return {name, static_cast<cripts::string_view::size_type>(name_len)};
   } else {
     return "";
   }
 }
 
-Cript::Client::Response &
-Client::Response::_get(Cript::Context *context)
+cripts::Client::Response &
+Client::Response::_get(cripts::Context *context)
 {
   CAssert(context->state.hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
   CAssert(context->state.hook != TS_HTTP_POST_REMAP_HOOK);
@@ -340,7 +341,7 @@ Client::Response::_get(Cript::Context *context)
 }
 
 Server::Request &
-Server::Request::_get(Cript::Context *context)
+Server::Request::_get(cripts::Context *context)
 {
   CAssert(context->state.hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
   CAssert(context->state.hook != TS_HTTP_POST_REMAP_HOOK);
@@ -362,7 +363,7 @@ Server::Request::_get(Cript::Context *context)
 }
 
 Server::Response &
-Server::Response::_get(Cript::Context *context)
+Server::Response::_get(cripts::Context *context)
 {
   CAssert(context->state.hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
   CAssert(context->state.hook != TS_HTTP_POST_REMAP_HOOK);
@@ -383,4 +384,4 @@ Server::Response::_get(Cript::Context *context)
   return context->_server_resp_header;
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Instance.cc
+++ b/src/cripts/Instance.cc
@@ -21,7 +21,7 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Instance.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 void
@@ -30,7 +30,7 @@ Instance::_initialize(int argc, char *argv[], const char *filename)
   from_url = argv[0];
   to_url   = argv[1];
   for (int i = 2; i < argc; i++) {
-    auto s = Cript::string(argv[i]);
+    auto s = cripts::string(argv[i]);
 
     s.trim("\"\'");
     data[i - 2] = s;
@@ -44,11 +44,11 @@ Instance::_initialize(int argc, char *argv[], const char *filename)
   auto slash       = plugin_debug_tag.find_last_of('/');
   auto period      = plugin_debug_tag.find_last_of('.');
 
-  if (slash == Cript::string::npos) {
+  if (slash == cripts::string::npos) {
     slash = 0;
   }
 
-  if (period != Cript::string::npos) {
+  if (period != cripts::string::npos) {
     plugin_debug_tag = std::string_view(plugin_debug_tag.substr(slash + 1, period - slash - 1));
   }
 
@@ -56,7 +56,7 @@ Instance::_initialize(int argc, char *argv[], const char *filename)
 } // namespace Instance::_initialize(intargc,char*argv[],constchar*filename)
 
 bool
-Instance::AddPlugin(const Cript::string &tag, const Cript::string &plugin, const Plugin::Options &options)
+Instance::AddPlugin(const cripts::string &tag, const cripts::string &plugin, const Plugin::Options &options)
 {
   if (plugins.find(tag) != plugins.end()) {
     return false;
@@ -75,7 +75,7 @@ Instance::AddPlugin(const Cript::string &tag, const Cript::string &plugin, const
 }
 
 bool
-Instance::DeletePlugin(const Cript::string &tag)
+Instance::DeletePlugin(const cripts::string &tag)
 {
   auto p = plugins.find(tag);
 
@@ -89,7 +89,7 @@ Instance::DeletePlugin(const Cript::string &tag)
 }
 
 void
-Instance::AddBundle(Cript::Bundle::Base *bundle)
+Instance::AddBundle(cripts::Bundle::Base *bundle)
 {
   for (auto &it : bundles) {
     if (it->Name() == bundle->Name()) {
@@ -100,4 +100,4 @@ Instance::AddBundle(Cript::Bundle::Base *bundle)
   bundles.push_back(bundle);
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Lulu.cc
+++ b/src/cripts/Lulu.cc
@@ -28,8 +28,8 @@
 #if CRIPTS_HAS_MAXMIND
 #include <maxminddb.h>
 
-MMDB_s             *gMaxMindDB    = nullptr;
-const Cript::string maxMindDBPath = CRIPTS_MAXMIND_DB;
+MMDB_s              *gMaxMindDB    = nullptr;
+const cripts::string maxMindDBPath = CRIPTS_MAXMIND_DB;
 #endif
 
 void
@@ -50,7 +50,7 @@ global_initialization()
 #endif
 
   // Initialize various sub modules
-  Cript::Plugin::Remap::Initialize();
+  cripts::Plugin::Remap::Initialize();
 }
 
 integer
@@ -67,7 +67,7 @@ integer_helper(std::string_view sv)
 }
 
 int
-Cript::Random(int max)
+cripts::Random(int max)
 {
   static std::random_device          r;
   static std::default_random_engine  e1(r());
@@ -76,7 +76,7 @@ Cript::Random(int max)
   return uniform_dist(e1);
 }
 
-namespace Cript::details
+namespace cripts::details
 {
 
 template <typename T>
@@ -92,7 +92,7 @@ Splitter(T input, char delim)
     if (first != second) {
       output.emplace_back(input.substr(first, second - first));
     }
-    if (second == Cript::string_view::npos) {
+    if (second == cripts::string_view::npos) {
       break;
     }
     first = second + 1;
@@ -101,39 +101,39 @@ Splitter(T input, char delim)
   return output; // RVO
 }
 
-} // namespace Cript::details
+} // namespace cripts::details
 
-Cript::string
-Cript::Hex(const Cript::string &str)
+cripts::string
+cripts::Hex(const cripts::string &str)
 {
   return ts::hex(str);
 }
 
-Cript::string
-Cript::Hex(Cript::string_view sv)
+cripts::string
+cripts::Hex(cripts::string_view sv)
 {
   return ts::hex(sv);
 }
 
-Cript::string
-Cript::UnHex(const Cript::string &str)
+cripts::string
+cripts::UnHex(const cripts::string &str)
 {
   return ts::unhex(str);
 }
 
-Cript::string
-Cript::UnHex(Cript::string_view sv)
+cripts::string
+cripts::UnHex(cripts::string_view sv)
 {
   return ts::unhex(sv);
 }
 
-Cript::string::operator integer() const
+cripts::string::operator integer() const
 {
   return swoc::svtoi(*this);
 }
 
 // This doesn't deal with upper/lower case
-Cript::string::operator bool() const
+cripts::string::operator bool() const
 {
   if (empty()) {
     return false;
@@ -154,46 +154,46 @@ Cript::string::operator bool() const
   return false;
 }
 
-std::vector<Cript::string_view>
-Cript::string::split(char delim) const &
+std::vector<cripts::string_view>
+cripts::string::split(char delim) const &
 {
-  return details::Splitter<Cript::string_view>(*this, delim);
+  return details::Splitter<cripts::string_view>(*this, delim);
 }
 
-std::vector<Cript::string_view>
-Cript::Splitter(Cript::string_view input, char delim)
+std::vector<cripts::string_view>
+cripts::Splitter(cripts::string_view input, char delim)
 {
-  return details::Splitter<Cript::string_view>(input, delim);
+  return details::Splitter<cripts::string_view>(input, delim);
 }
 
 bool
-Cript::Control::Base::_get(Cript::Context *context) const
+cripts::Control::Base::_get(cripts::Context *context) const
 {
   return TSHttpTxnCntlGet(context->state.txnp, _ctrl);
 }
 
 void
-Cript::Control::Base::_set(Cript::Context *context, bool value)
+cripts::Control::Base::_set(cripts::Context *context, bool value)
 {
   TSHttpTxnCntlSet(context->state.txnp, _ctrl, value);
 }
 
-Cript::string_view
-Cript::Versions::GetSV()
+cripts::string_view
+cripts::Versions::GetSV()
 {
   if (_version.length() == 0) {
     const char *ver = TSTrafficServerVersionGet();
 
-    _version = Cript::string_view(ver, strlen(ver)); // ToDo: Annoyingly, we have ambiquity on the operator=
+    _version = cripts::string_view(ver, strlen(ver)); // ToDo: Annoyingly, we have ambiquity on the operator=
   }
 
   return _version;
 }
 
 // Globals
-Cript::Proxy    proxy;
-Cript::Control  control;
-Cript::Versions version;
+cripts::Proxy    proxy;
+cripts::Control  control;
+cripts::Versions version;
 
 std::string plugin_debug_tag;
 

--- a/src/cripts/Lulu.cc
+++ b/src/cripts/Lulu.cc
@@ -50,7 +50,7 @@ global_initialization()
 #endif
 
   // Initialize various sub modules
-  Plugin::Remap::Initialize();
+  Cript::Plugin::Remap::Initialize();
 }
 
 integer
@@ -167,19 +167,19 @@ Cript::Splitter(Cript::string_view input, char delim)
 }
 
 bool
-Control::Base::_get(Cript::Context *context) const
+Cript::Control::Base::_get(Cript::Context *context) const
 {
   return TSHttpTxnCntlGet(context->state.txnp, _ctrl);
 }
 
 void
-Control::Base::_set(Cript::Context *context, bool value)
+Cript::Control::Base::_set(Cript::Context *context, bool value)
 {
   TSHttpTxnCntlSet(context->state.txnp, _ctrl, value);
 }
 
 Cript::string_view
-Versions::GetSV()
+Cript::Versions::GetSV()
 {
   if (_version.length() == 0) {
     const char *ver = TSTrafficServerVersionGet();
@@ -191,9 +191,9 @@ Versions::GetSV()
 }
 
 // Globals
-Proxy    proxy;
-Control  control;
-Versions version;
+Cript::Proxy    proxy;
+Cript::Control  control;
+Cript::Versions version;
 
 std::string plugin_debug_tag;
 

--- a/src/cripts/Matcher.cc
+++ b/src/cripts/Matcher.cc
@@ -19,7 +19,7 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 Matcher::PCRE::~PCRE()
@@ -44,7 +44,7 @@ Matcher::PCRE::Result::malloc(PCRE2_SIZE size, void *context)
 }
 
 void
-Matcher::PCRE::Add(Cript::string_view regex, uint32_t options, bool jit)
+Matcher::PCRE::Add(cripts::string_view regex, uint32_t options, bool jit)
 {
   int         errorcode   = 0;
   PCRE2_SIZE  erroroffset = 0;
@@ -67,7 +67,7 @@ Matcher::PCRE::Add(Cript::string_view regex, uint32_t options, bool jit)
 }
 
 Matcher::PCRE::Result
-Matcher::PCRE::Contains(Cript::string_view subject, PCRE2_SIZE offset, uint32_t options)
+Matcher::PCRE::Contains(cripts::string_view subject, PCRE2_SIZE offset, uint32_t options)
 {
   Matcher::PCRE::Result  res(subject);
   pcre2_general_context *ctx =
@@ -88,4 +88,4 @@ Matcher::PCRE::Contains(Cript::string_view subject, PCRE2_SIZE offset, uint32_t 
   return res;
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Matcher.cc
+++ b/src/cripts/Matcher.cc
@@ -19,6 +19,9 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
+namespace Cript
+{
+
 Matcher::PCRE::~PCRE()
 {
   for (auto &it : _regexes) {
@@ -84,3 +87,5 @@ Matcher::PCRE::Contains(Cript::string_view subject, PCRE2_SIZE offset, uint32_t 
 
   return res;
 }
+
+} // namespace Cript

--- a/src/cripts/Plugins.cc
+++ b/src/cripts/Plugins.cc
@@ -21,7 +21,7 @@
 
 #include "cripts/Preamble.hpp"
 
-namespace Cript
+namespace cripts
 {
 
 // This is global for all Cripts, and it will not get reloaded on a config reload.
@@ -34,8 +34,8 @@ Plugin::Remap::Initialize()
 }
 
 Plugin::Remap
-Plugin::Remap::Create(const std::string &tag, const std::string &plugin, const Cript::string &from_url, const Cript::string &to_url,
-                      const Plugin::Options &options)
+Plugin::Remap::Create(const std::string &tag, const std::string &plugin, const cripts::string &from_url,
+                      const cripts::string &to_url, const Plugin::Options &options)
 {
   Plugin::Remap          inst;
   int                    argc = options.size() + 1;
@@ -84,9 +84,9 @@ Plugin::Remap::Cleanup()
 }
 
 void
-Plugin::Remap::_runRemap(Cript::Context *context)
+Plugin::Remap::_runRemap(cripts::Context *context)
 {
   _plugin->doRemap(context->state.txnp, context->rri);
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Plugins.cc
+++ b/src/cripts/Plugins.cc
@@ -21,6 +21,9 @@
 
 #include "cripts/Preamble.hpp"
 
+namespace Cript
+{
+
 // This is global for all Cripts, and it will not get reloaded on a config reload.
 PluginFactory gPluginFactory;
 
@@ -85,3 +88,5 @@ Plugin::Remap::_runRemap(Cript::Context *context)
 {
   _plugin->doRemap(context->state.txnp, context->rri);
 }
+
+} // namespace Cript

--- a/src/cripts/UUID.cc
+++ b/src/cripts/UUID.cc
@@ -19,14 +19,14 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
-namespace Cript
+namespace cripts
 {
 
-Cript::string
-UUID::Unique::_get(Cript::Context *context)
+cripts::string
+UUID::Unique::_get(cripts::Context *context)
 {
-  Cript::string ret;
-  char          uuid[TS_CRUUID_STRING_LEN + 1];
+  cripts::string ret;
+  char           uuid[TS_CRUUID_STRING_LEN + 1];
 
   if (TS_SUCCESS == TSClientRequestUuidGet(context->state.txnp, uuid)) {
     ret = uuid;
@@ -34,13 +34,13 @@ UUID::Unique::_get(Cript::Context *context)
   return ret; // RVO
 }
 
-Cript::string
-UUID::Request::_get(Cript::Context *context)
+cripts::string
+UUID::Request::_get(cripts::Context *context)
 {
-  uint64_t      uuid = TSHttpTxnIdGet(context->state.txnp);
-  Cript::string ret  = std::to_string(uuid);
+  uint64_t       uuid = TSHttpTxnIdGet(context->state.txnp);
+  cripts::string ret  = std::to_string(uuid);
 
   return ret;
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/UUID.cc
+++ b/src/cripts/UUID.cc
@@ -19,6 +19,9 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
+namespace Cript
+{
+
 Cript::string
 UUID::Unique::_get(Cript::Context *context)
 {
@@ -39,3 +42,5 @@ UUID::Request::_get(Cript::Context *context)
 
   return ret;
 }
+
+} // namespace Cript

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -20,16 +20,16 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
-namespace Cript
+namespace cripts
 {
 
-std::vector<Cript::string_view>
+std::vector<cripts::string_view>
 Url::Component::Split(const char delim)
 {
-  return Cript::Splitter(GetSV(), delim);
+  return cripts::Splitter(GetSV(), delim);
 }
 
-Cript::string_view
+cripts::string_view
 Url::Scheme::GetSV()
 {
   if (_owner && _data.empty()) {
@@ -37,14 +37,14 @@ Url::Scheme::GetSV()
     int         len   = 0;
 
     value = TSUrlSchemeGet(_owner->_bufp, _owner->_urlp, &len);
-    _data = Cript::string_view(value, len);
+    _data = cripts::string_view(value, len);
   }
 
   return _data;
 }
 
 Url::Scheme
-Url::Scheme::operator=(Cript::string_view scheme)
+Url::Scheme::operator=(cripts::string_view scheme)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlSchemeSet(_owner->_bufp, _owner->_urlp, scheme.data(), scheme.size());
@@ -55,7 +55,7 @@ Url::Scheme::operator=(Cript::string_view scheme)
   return *this;
 }
 
-Cript::string_view
+cripts::string_view
 Url::Host::GetSV()
 {
   if (_owner && _data.empty()) {
@@ -63,7 +63,7 @@ Url::Host::GetSV()
     int         len   = 0;
 
     value   = TSUrlHostGet(_owner->_bufp, _owner->_urlp, &len);
-    _data   = Cript::string_view(value, len);
+    _data   = cripts::string_view(value, len);
     _loaded = true;
   }
 
@@ -71,7 +71,7 @@ Url::Host::GetSV()
 }
 
 Url::Host
-Url::Host::operator=(Cript::string_view host)
+Url::Host::operator=(cripts::string_view host)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHostSet(_owner->_bufp, _owner->_urlp, host.data(), host.size());
@@ -102,13 +102,13 @@ Url::Port::operator=(int port)
   return *this;
 }
 
-Cript::string_view
+cripts::string_view
 Url::Path::GetSV()
 {
   if (_segments.size() > 0) {
     std::ostringstream path;
 
-    std::copy(_segments.begin(), _segments.end(), std::ostream_iterator<Cript::string_view>(path, "/"));
+    std::copy(_segments.begin(), _segments.end(), std::ostream_iterator<cripts::string_view>(path, "/"));
     _storage.reserve(_size);
     _storage = std::string_view(path.str());
     if (_storage.size() > 0) {
@@ -121,7 +121,7 @@ Url::Path::GetSV()
     int         len   = 0;
 
     value   = TSUrlPathGet(_owner->_bufp, _owner->_urlp, &len);
-    _data   = Cript::string_view(value, len);
+    _data   = cripts::string_view(value, len);
     _size   = len;
     _loaded = true;
   }
@@ -143,7 +143,7 @@ Url::Path::operator[](Segments::size_type ix)
 }
 
 Url::Path
-Url::Path::operator=(Cript::string_view path)
+Url::Path::operator=(cripts::string_view path)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlPathSet(_owner->_bufp, _owner->_urlp, path.data(), path.size());
@@ -154,10 +154,10 @@ Url::Path::operator=(Cript::string_view path)
   return *this;
 }
 
-Cript::string
-Url::Path::operator+=(Cript::string_view add)
+cripts::string
+Url::Path::operator+=(cripts::string_view add)
 {
-  Cript::string str;
+  cripts::string str;
 
   if (add.size() > 0) {
     str.assign(GetSV());
@@ -169,7 +169,7 @@ Url::Path::operator+=(Cript::string_view add)
 }
 
 Url::Path::String &
-Url::Path::String::operator=(const Cript::string_view str)
+Url::Path::String::operator=(const cripts::string_view str)
 {
   CAssert(!_owner->_owner->ReadOnly()); // This can not be a read-only URL
   _owner->_size          -= _owner->_segments[_ix].size();
@@ -192,7 +192,7 @@ Url::Path::Reset()
 }
 
 void
-Url::Path::Push(Cript::string_view val)
+Url::Path::Push(cripts::string_view val)
 {
   _parser();
   _modified = true;
@@ -200,7 +200,7 @@ Url::Path::Push(Cript::string_view val)
 }
 
 void
-Url::Path::Insert(Segments::size_type ix, Cript::string_view val)
+Url::Path::Insert(Segments::size_type ix, cripts::string_view val)
 {
   _parser();
   _modified = true;
@@ -216,7 +216,7 @@ Url::Path::_parser()
 }
 
 Url::Query::Parameter &
-Url::Query::Parameter::operator=(const Cript::string_view str)
+Url::Query::Parameter::operator=(const cripts::string_view str)
 {
   CAssert(!_owner->_owner->ReadOnly()); // This can not be a read-only URL
   auto iter = _owner->_hashed.find(_name);
@@ -232,7 +232,7 @@ Url::Query::Parameter::operator=(const Cript::string_view str)
   return *this;
 }
 
-Cript::string_view
+cripts::string_view
 Url::Query::GetSV()
 {
   if (_ordered.size() > 0) {
@@ -267,7 +267,7 @@ Url::Query::GetSV()
     int         len   = 0;
 
     value   = TSUrlHttpQueryGet(_owner->_bufp, _owner->_urlp, &len);
-    _data   = Cript::string_view(value, len);
+    _data   = cripts::string_view(value, len);
     _size   = len;
     _loaded = true;
   }
@@ -276,7 +276,7 @@ Url::Query::GetSV()
 }
 
 Url::Query
-Url::Query::operator=(Cript::string_view query)
+Url::Query::operator=(cripts::string_view query)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHttpQuerySet(_owner->_bufp, _owner->_urlp, query.data(), query.size());
@@ -287,10 +287,10 @@ Url::Query::operator=(Cript::string_view query)
   return *this;
 }
 
-Cript::string
-Url::Query::operator+=(Cript::string_view add)
+cripts::string
+Url::Query::operator+=(cripts::string_view add)
 {
-  Cript::string str;
+  cripts::string str;
 
   if (add.size() > 0) {
     str.assign(GetSV());
@@ -302,7 +302,7 @@ Url::Query::operator+=(Cript::string_view add)
 }
 
 Url::Query::Parameter
-Url::Query::operator[](Cript::string_view param)
+Url::Query::operator[](cripts::string_view param)
 {
   // Make sure the hash and vector are populated
   _parser();
@@ -320,7 +320,7 @@ Url::Query::operator[](Cript::string_view param)
 }
 
 void
-Url::Query::Erase(Cript::string_view param)
+Url::Query::Erase(cripts::string_view param)
 {
   // Make sure the hash and vector are populated
   _parser();
@@ -344,7 +344,7 @@ Url::Query::Erase(Cript::string_view param)
 }
 
 void
-Url::Query::Erase(std::initializer_list<Cript::string_view> list, bool keep)
+Url::Query::Erase(std::initializer_list<cripts::string_view> list, bool keep)
 {
   if (keep) {
     // Make sure the hash and vector are populated
@@ -391,11 +391,11 @@ Url::Query::_parser()
 {
   if (_ordered.size() == 0) {
     for (const auto sv : Split('&')) {
-      const auto         eq  = sv.find_first_of('=');
-      Cript::string_view key = sv.substr(0, eq);
-      Cript::string_view val;
+      const auto          eq  = sv.find_first_of('=');
+      cripts::string_view key = sv.substr(0, eq);
+      cripts::string_view val;
 
-      if (eq != Cript::string_view::npos) {
+      if (eq != cripts::string_view::npos) {
         val = sv.substr(eq + 1);
       }
 
@@ -405,10 +405,10 @@ Url::Query::_parser()
   }
 }
 
-Cript::string
+cripts::string
 Url::String() const
 {
-  Cript::string ret;
+  cripts::string ret;
 
   if (_state) {
     int   full_len = 0;
@@ -424,7 +424,7 @@ Url::String() const
 }
 
 Pristine::URL &
-Pristine::URL::_get(Cript::Context *context)
+Pristine::URL::_get(cripts::Context *context)
 {
   if (!context->_pristine_url.Initialized()) {
     Pristine::URL *url = &context->_pristine_url;
@@ -441,7 +441,7 @@ Pristine::URL::_get(Cript::Context *context)
 }
 
 void
-Client::URL::_initialize(Cript::Context *context)
+Client::URL::_initialize(cripts::Context *context)
 {
   Url::_initialize(&context->state);
 
@@ -451,7 +451,7 @@ Client::URL::_initialize(Cript::Context *context)
 }
 
 Client::URL &
-Client::URL::_get(Cript::Context *context)
+Client::URL::_get(cripts::Context *context)
 {
   if (!context->_client_url.Initialized()) {
     context->_client_url._initialize(context);
@@ -461,7 +461,7 @@ Client::URL::_get(Cript::Context *context)
 }
 
 bool
-Client::URL::_update(Cript::Context * /* context ATS_UNUSED */)
+Client::URL::_update(cripts::Context * /* context ATS_UNUSED */)
 {
   path.Flush();
   query.Flush();
@@ -470,7 +470,7 @@ Client::URL::_update(Cript::Context * /* context ATS_UNUSED */)
 }
 
 void
-Remap::From::URL::_initialize(Cript::Context *context)
+Remap::From::URL::_initialize(cripts::Context *context)
 {
   Url::_initialize(&context->state);
 
@@ -480,7 +480,7 @@ Remap::From::URL::_initialize(Cript::Context *context)
 }
 
 Remap::From::URL &
-Remap::From::URL::_get(Cript::Context *context)
+Remap::From::URL::_get(cripts::Context *context)
 {
   if (!context->_remap_from_url.Initialized()) {
     context->_remap_from_url._initialize(context);
@@ -490,7 +490,7 @@ Remap::From::URL::_get(Cript::Context *context)
 }
 
 void
-Remap::To::URL::_initialize(Cript::Context *context)
+Remap::To::URL::_initialize(cripts::Context *context)
 {
   Url::_initialize(&context->state);
 
@@ -500,7 +500,7 @@ Remap::To::URL::_initialize(Cript::Context *context)
 }
 
 Remap::To::URL &
-Remap::To::URL::_get(Cript::Context *context)
+Remap::To::URL::_get(cripts::Context *context)
 {
   if (!context->_remap_to_url.Initialized()) {
     context->_remap_to_url._initialize(context);
@@ -510,7 +510,7 @@ Remap::To::URL::_get(Cript::Context *context)
 }
 
 Cache::URL &
-Cache::URL::_get(Cript::Context *context)
+Cache::URL::_get(cripts::Context *context)
 {
   if (!context->_cache_url.Initialized()) {
     Cache::URL      *url = &context->_cache_url;
@@ -546,9 +546,9 @@ Cache::URL::_get(Cript::Context *context)
   return context->_cache_url;
 }
 
-// This has to be implemented here, since the Cript::Context is not complete yet
+// This has to be implemented here, since the cripts::Context is not complete yet
 bool
-Cache::URL::_update(Cript::Context *context)
+Cache::URL::_update(cripts::Context *context)
 {
   // For correctness, we will also make sure the Path and Query objects are flushed
   path.Flush();
@@ -576,7 +576,7 @@ Cache::URL::_update(Cript::Context *context)
 
 // ToDo: This may need more work, to understand which hooks the parent URL is actually available
 Parent::URL &
-Parent::URL::_get(Cript::Context *context)
+Parent::URL::_get(cripts::Context *context)
 {
   if (!context->_cache_url.Initialized()) {
     Parent::URL     *url = &context->_parent_url;
@@ -595,4 +595,4 @@ Parent::URL::_get(Cript::Context *context)
   return context->_parent_url;
 }
 
-} // namespace Cript
+} // namespace cripts

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -20,14 +20,17 @@
 #include "cripts/Lulu.hpp"
 #include "cripts/Preamble.hpp"
 
+namespace Cript
+{
+
 std::vector<Cript::string_view>
-Cript::Url::Component::Split(const char delim)
+Url::Component::Split(const char delim)
 {
   return Cript::Splitter(GetSV(), delim);
 }
 
 Cript::string_view
-Cript::Url::Scheme::GetSV()
+Url::Scheme::GetSV()
 {
   if (_owner && _data.empty()) {
     const char *value = nullptr;
@@ -40,8 +43,8 @@ Cript::Url::Scheme::GetSV()
   return _data;
 }
 
-Cript::Url::Scheme
-Cript::Url::Scheme::operator=(Cript::string_view scheme)
+Url::Scheme
+Url::Scheme::operator=(Cript::string_view scheme)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlSchemeSet(_owner->_bufp, _owner->_urlp, scheme.data(), scheme.size());
@@ -53,7 +56,7 @@ Cript::Url::Scheme::operator=(Cript::string_view scheme)
 }
 
 Cript::string_view
-Cript::Url::Host::GetSV()
+Url::Host::GetSV()
 {
   if (_owner && _data.empty()) {
     const char *value = nullptr;
@@ -67,8 +70,8 @@ Cript::Url::Host::GetSV()
   return _data;
 }
 
-Cript::Url::Host
-Cript::Url::Host::operator=(Cript::string_view host)
+Url::Host
+Url::Host::operator=(Cript::string_view host)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHostSet(_owner->_bufp, _owner->_urlp, host.data(), host.size());
@@ -79,7 +82,7 @@ Cript::Url::Host::operator=(Cript::string_view host)
   return *this;
 }
 
-Cript::Url::Port::operator integer() // This should not be explicit
+Url::Port::operator integer() // This should not be explicit
 {
   if (_owner && _port < 0) {
     _port = TSUrlPortGet(_owner->_bufp, _owner->_urlp);
@@ -88,8 +91,8 @@ Cript::Url::Port::operator integer() // This should not be explicit
   return _port;
 }
 
-Cript::Url::Port
-Cript::Url::Port::operator=(int port)
+Url::Port
+Url::Port::operator=(int port)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlPortSet(_owner->_bufp, _owner->_urlp, port);
@@ -100,7 +103,7 @@ Cript::Url::Port::operator=(int port)
 }
 
 Cript::string_view
-Cript::Url::Path::GetSV()
+Url::Path::GetSV()
 {
   if (_segments.size() > 0) {
     std::ostringstream path;
@@ -126,8 +129,8 @@ Cript::Url::Path::GetSV()
   return _data;
 }
 
-Cript::Url::Path::String
-Cript::Url::Path::operator[](Segments::size_type ix)
+Url::Path::String
+Url::Path::operator[](Segments::size_type ix)
 {
   Url::Path::String ret;
 
@@ -139,8 +142,8 @@ Cript::Url::Path::operator[](Segments::size_type ix)
   return ret; // RVO
 }
 
-Cript::Url::Path
-Cript::Url::Path::operator=(Cript::string_view path)
+Url::Path
+Url::Path::operator=(Cript::string_view path)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlPathSet(_owner->_bufp, _owner->_urlp, path.data(), path.size());
@@ -152,7 +155,7 @@ Cript::Url::Path::operator=(Cript::string_view path)
 }
 
 Cript::string
-Cript::Url::Path::operator+=(Cript::string_view add)
+Url::Path::operator+=(Cript::string_view add)
 {
   Cript::string str;
 
@@ -165,8 +168,8 @@ Cript::Url::Path::operator+=(Cript::string_view add)
   return str; // RVO
 }
 
-Cript::Url::Path::String &
-Cript::Url::Path::String::operator=(const Cript::string_view str)
+Url::Path::String &
+Url::Path::String::operator=(const Cript::string_view str)
 {
   CAssert(!_owner->_owner->ReadOnly()); // This can not be a read-only URL
   _owner->_size          -= _owner->_segments[_ix].size();
@@ -178,7 +181,7 @@ Cript::Url::Path::String::operator=(const Cript::string_view str)
 }
 
 void
-Cript::Url::Path::Reset()
+Url::Path::Reset()
 {
   Component::Reset();
 
@@ -189,7 +192,7 @@ Cript::Url::Path::Reset()
 }
 
 void
-Cript::Url::Path::Push(Cript::string_view val)
+Url::Path::Push(Cript::string_view val)
 {
   _parser();
   _modified = true;
@@ -197,7 +200,7 @@ Cript::Url::Path::Push(Cript::string_view val)
 }
 
 void
-Cript::Url::Path::Insert(Segments::size_type ix, Cript::string_view val)
+Url::Path::Insert(Segments::size_type ix, Cript::string_view val)
 {
   _parser();
   _modified = true;
@@ -205,15 +208,15 @@ Cript::Url::Path::Insert(Segments::size_type ix, Cript::string_view val)
 }
 
 void
-Cript::Url::Path::_parser()
+Url::Path::_parser()
 {
   if (_segments.size() == 0) {
     _segments = Split('/');
   }
 }
 
-Cript::Url::Query::Parameter &
-Cript::Url::Query::Parameter::operator=(const Cript::string_view str)
+Url::Query::Parameter &
+Url::Query::Parameter::operator=(const Cript::string_view str)
 {
   CAssert(!_owner->_owner->ReadOnly()); // This can not be a read-only URL
   auto iter = _owner->_hashed.find(_name);
@@ -230,7 +233,7 @@ Cript::Url::Query::Parameter::operator=(const Cript::string_view str)
 }
 
 Cript::string_view
-Cript::Url::Query::GetSV()
+Url::Query::GetSV()
 {
   if (_ordered.size() > 0) {
     _storage.clear();
@@ -272,8 +275,8 @@ Cript::Url::Query::GetSV()
   return _data;
 }
 
-Cript::Url::Query
-Cript::Url::Query::operator=(Cript::string_view query)
+Url::Query
+Url::Query::operator=(Cript::string_view query)
 {
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHttpQuerySet(_owner->_bufp, _owner->_urlp, query.data(), query.size());
@@ -285,7 +288,7 @@ Cript::Url::Query::operator=(Cript::string_view query)
 }
 
 Cript::string
-Cript::Url::Query::operator+=(Cript::string_view add)
+Url::Query::operator+=(Cript::string_view add)
 {
   Cript::string str;
 
@@ -298,8 +301,8 @@ Cript::Url::Query::operator+=(Cript::string_view add)
   return str; // RVO
 }
 
-Cript::Url::Query::Parameter
-Cript::Url::Query::operator[](Cript::string_view param)
+Url::Query::Parameter
+Url::Query::operator[](Cript::string_view param)
 {
   // Make sure the hash and vector are populated
   _parser();
@@ -317,7 +320,7 @@ Cript::Url::Query::operator[](Cript::string_view param)
 }
 
 void
-Cript::Url::Query::Erase(Cript::string_view param)
+Url::Query::Erase(Cript::string_view param)
 {
   // Make sure the hash and vector are populated
   _parser();
@@ -341,7 +344,7 @@ Cript::Url::Query::Erase(Cript::string_view param)
 }
 
 void
-Cript::Url::Query::Erase(std::initializer_list<Cript::string_view> list, bool keep)
+Url::Query::Erase(std::initializer_list<Cript::string_view> list, bool keep)
 {
   if (keep) {
     // Make sure the hash and vector are populated
@@ -372,7 +375,7 @@ Cript::Url::Query::Erase(std::initializer_list<Cript::string_view> list, bool ke
 }
 
 void
-Cript::Url::Query::Reset()
+Url::Query::Reset()
 {
   Component::Reset();
 
@@ -384,7 +387,7 @@ Cript::Url::Query::Reset()
 }
 
 void
-Cript::Url::Query::_parser()
+Url::Query::_parser()
 {
   if (_ordered.size() == 0) {
     for (const auto sv : Split('&')) {
@@ -403,7 +406,7 @@ Cript::Url::Query::_parser()
 }
 
 Cript::string
-Cript::Url::String() const
+Url::String() const
 {
   Cript::string ret;
 
@@ -591,3 +594,5 @@ Parent::URL::_get(Cript::Context *context)
 
   return context->_parent_url;
 }
+
+} // namespace Cript

--- a/tools/cripts/genconfig.py
+++ b/tools/cripts/genconfig.py
@@ -59,7 +59,7 @@ def print_header():
 
 #include "cripts/ConfigsBase.hpp"
 
-namespace Cript
+namespace cripts
 {
 """)
 
@@ -67,7 +67,7 @@ namespace Cript
 def print_footer():
     print("""
 
-} // namespace Cript
+} // namespace cripts
 """)
 
 
@@ -78,7 +78,7 @@ def print_class(tree, cur="", indent=0):
             if indent > 0:
                 indentp("private:", indent - 1)
                 if cur == "proxy":
-                    indentp("friend class Cript::Context; // Needed to set the state", indent)
+                    indentp("friend class cripts::Context; // Needed to set the state", indent)
                     print()
             indentp("class {}".format(k.title()), indent)
             indentp("{", indent)
@@ -88,11 +88,11 @@ def print_class(tree, cur="", indent=0):
                 indentp("public:", indent - 1)
                 firstInstance = False
             if tree[k][1] == "TS_RECORDDATATYPE_INT":
-                indentp("Cript::IntConfig {}{{\"{}\"}};".format(k, tree[k][2]), indent)
+                indentp("cripts::IntConfig {}{{\"{}\"}};".format(k, tree[k][2]), indent)
             elif tree[k][1] == "TS_RECORDDATATYPE_FLOAT":
-                indentp("Cript::FloatConfig {}{{\"{}\"}};".format(k, tree[k][2]), indent)
+                indentp("cripts::FloatConfig {}{{\"{}\"}};".format(k, tree[k][2]), indent)
             elif tree[k][1] == "TS_RECORDDATATYPE_STRING":
-                indentp("Cript::StringConfig {}{{\"{}\"}};".format(k, tree[k][2]), indent)
+                indentp("cripts::StringConfig {}{{\"{}\"}};".format(k, tree[k][2]), indent)
             else:
                 print("The source file has a bad configuration data type: {}".format(tree[k][1]))
     if cur:

--- a/tools/cripts/genconfig.py
+++ b/tools/cripts/genconfig.py
@@ -59,6 +59,15 @@ def print_header():
 
 #include "cripts/ConfigsBase.hpp"
 
+namespace Cript
+{
+""")
+
+
+def print_footer():
+    print("""
+
+} // namespace Cript
 """)
 
 
@@ -133,5 +142,6 @@ for elem in elements:
 
 print_header()
 print_class(tree)
+print_footer()
 # pp = pprint.PrettyPrinter(indent=4)
 # pp.pprint(tree)


### PR DESCRIPTION
This turns out to be required, for Cripts to be able to include core include files (like HttpSM.h) directly. I would like to do that later, bypassing InkAPI in Cripts directly.

This also feels more consistent within all of Cripts.