### PR TITLE
Cleanup: Move dir_valid macros to Stripe

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -364,7 +364,7 @@ dir_clean_bucket(Dir *b, int s, Stripe *stripe)
         return;
     }
 #endif
-    if (!dir_valid(stripe, e) || !dir_offset(e)) {
+    if (!stripe->dir_valid(e) || !dir_offset(e)) {
       if (dbg_ctl_dir_clean.on()) {
         Dbg(dbg_ctl_dir_clean, "cleaning Stripe:%s: %p tag %X boffset %" PRId64 " b %p p %p bucket len %d", stripe->hash_text.get(),
             e, dir_tag(e), dir_offset(e), b, p, dir_bucket_length(b, s, stripe));
@@ -522,7 +522,7 @@ Lagain:
           }
           goto Lcont;
         }
-        if (dir_valid(stripe, e)) {
+        if (stripe->dir_valid(e)) {
           DDbg(dbg_ctl_dir_probe_hit, "found %X %X vol %d bucket %d boffset %" PRId64 "", key->slice32(0), key->slice32(1),
                stripe->fd, b, dir_offset(e));
           dir_assign(result, e);
@@ -758,7 +758,7 @@ dir_lookaside_probe(const CacheKey *key, StripeSM *stripe, Dir *result, Evacuati
   EvacuationBlock *b = stripe->lookaside[i].head;
   while (b) {
     if (b->evac_frags.key == *key) {
-      if (dir_valid(stripe, &b->new_dir)) {
+      if (stripe->dir_valid(&b->new_dir)) {
         *result = b->new_dir;
         DDbg(dbg_ctl_dir_lookaside, "probe %X success", key->slice32(0));
         if (eblock) {
@@ -822,7 +822,7 @@ dir_lookaside_cleanup(StripeSM *stripe)
   for (auto &i : stripe->lookaside) {
     EvacuationBlock *b = i.head;
     while (b) {
-      if (!dir_valid(stripe, &b->new_dir)) {
+      if (!stripe->dir_valid(&b->new_dir)) {
         EvacuationBlock *nb = b->link.next;
         DDbg(dbg_ctl_dir_lookaside, "cleanup %X %X cleaned up", b->evac_frags.earliest_key.slice32(0),
              b->evac_frags.earliest_key.slice32(1));

--- a/src/iocore/cache/CacheEvacuateDocVC.cc
+++ b/src/iocore/cache/CacheEvacuateDocVC.cc
@@ -148,7 +148,7 @@ CacheEvacuateDocVC::evacuateReadHead(int /* event ATS_UNUSED */, Event * /* e AT
     goto Ldone;
   }
   // a directory entry which is no longer valid may have been overwritten
-  if (!dir_valid(this->stripe, &this->dir)) {
+  if (!this->stripe->dir_valid(&this->dir)) {
     last_collision = nullptr;
     goto Lcollision;
   }

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -421,11 +421,11 @@ CacheVC::openReadClose(int event, Event * /* e ATS_UNUSED */)
   if (!lock.is_locked()) {
     VC_SCHED_LOCK_RETRY();
   }
-  if (f.hit_evacuate && dir_valid(stripe, &first_dir) && closed > 0) {
+  if (f.hit_evacuate && stripe->dir_valid(&first_dir) && closed > 0) {
     ink_assert(stripe->mutex->thread_holding == this_ethread());
     if (f.single_fragment) {
       stripe->force_evacuate_head(&first_dir, dir_pinned(&first_dir));
-    } else if (dir_valid(stripe, &earliest_dir)) {
+    } else if (stripe->dir_valid(&earliest_dir)) {
       stripe->force_evacuate_head(&first_dir, dir_pinned(&first_dir));
       stripe->force_evacuate_head(&earliest_dir, dir_pinned(&earliest_dir));
     }
@@ -453,7 +453,7 @@ CacheVC::openReadReadDone(int event, Event *e)
       goto Lerror;
     }
     if (last_collision &&        // no missed lock
-        dir_valid(stripe, &dir)) // object still valid
+        stripe->dir_valid(&dir)) // object still valid
     {
       doc = reinterpret_cast<Doc *>(buf->data());
       if (doc->magic != DOC_MAGIC) {
@@ -765,9 +765,9 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
     }
     // an object needs to be outside the aggregation window in order to be
     // be evacuated as it is read
-    if (!dir_agg_valid(stripe, &dir)) {
+    if (!stripe->dir_agg_valid(&dir)) {
       // a directory entry which is no longer valid may have been overwritten
-      if (!dir_valid(stripe, &dir)) {
+      if (!stripe->dir_valid(&dir)) {
         last_collision = nullptr;
       }
       goto Lread;
@@ -972,9 +972,9 @@ CacheVC::openReadStartHead(int event, Event *e)
     }
     // an object needs to be outside the aggregation window in order to be
     // be evacuated as it is read
-    if (!dir_agg_valid(stripe, &dir)) {
+    if (!stripe->dir_agg_valid(&dir)) {
       // a directory entry which is no longer valid may have been overwritten
-      if (!dir_valid(stripe, &dir)) {
+      if (!stripe->dir_valid(&dir)) {
         last_collision = nullptr;
       }
       goto Lread;

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -142,7 +142,7 @@ make_vol_map(Stripe *stripe)
         break;
       }
       while (e) {
-        if (dir_offset(e) && dir_valid(stripe, e) && dir_agg_valid(stripe, e) && dir_head(e)) {
+        if (dir_offset(e) && stripe->dir_valid(e) && stripe->dir_agg_valid(e) && dir_head(e)) {
           off_t offset = stripe->vol_offset(e) - start_offset;
           if (offset <= vol_len) {
             vol_map[offset / SCAN_BUF_SIZE] = 1;
@@ -357,7 +357,7 @@ CacheVC::handleReadDone(int event, Event *e)
     if (!lock.is_locked()) {
       VC_SCHED_LOCK_RETRY();
     }
-    if ((!dir_valid(stripe, &dir)) || (!io.ok())) {
+    if ((!stripe->dir_valid(&dir)) || (!io.ok())) {
       if (!io.ok()) {
         Dbg(dbg_ctl_cache_disk_error, "Read error on disk %s\n \
 	    read range : [%" PRIu64 " - %" PRIu64 " bytes]  [%" PRIu64 " - %" PRIu64 " blocks] \n",
@@ -529,7 +529,7 @@ CacheVC::load_from_last_open_read_call()
 bool
 CacheVC::load_from_aggregation_buffer()
 {
-  if (!dir_agg_buf_valid(this->stripe, &this->dir)) {
+  if (!this->stripe->dir_agg_buf_valid(&this->dir)) {
     return false;
   }
 
@@ -575,7 +575,7 @@ CacheVC::removeEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     if (!buf) {
       goto Lcollision;
     }
-    if (!dir_valid(stripe, &dir)) {
+    if (!stripe->dir_valid(&dir)) {
       last_collision = nullptr;
       goto Lcollision;
     }
@@ -746,7 +746,7 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       if (!dir_probe(&doc->first_key, stripe, &dir, &last_collision)) {
         goto Lskip;
       }
-      if (!dir_agg_valid(stripe, &dir) || !dir_head(&dir) ||
+      if (!stripe->dir_agg_valid(&dir) || !dir_head(&dir) ||
           (stripe->vol_offset(&dir) != io.aiocb.aio_offset + (reinterpret_cast<char *>(doc) - buf->data()))) {
         continue;
       }

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -338,7 +338,7 @@ CacheVC::openWriteCloseHeadDone(int event, Event *e)
         dir_overwrite(&first_key, stripe, &dir, &od->first_dir, false);
         // insert moved resident alternate
         if (od->move_resident_alt) {
-          if (dir_valid(stripe, &od->single_doc_dir)) {
+          if (stripe->dir_valid(&od->single_doc_dir)) {
             dir_insert(&od->single_doc_key, stripe, &od->single_doc_dir);
           }
           od->move_resident_alt = false;
@@ -689,7 +689,7 @@ CacheVC::openWriteStartDone(int event, Event *e)
          We need to start afresh from the beginning by setting last_collision
          to nullptr.
        */
-      if (!dir_valid(stripe, &dir)) {
+      if (!stripe->dir_valid(&dir)) {
         DDbg(dbg_ctl_cache_write, "OpenReadStartDone: Dir not valid: Write Head: %" PRId64 ", Dir: %" PRId64,
              (int64_t)stripe->offset_to_vol_offset(stripe->header->write_pos), dir_offset(&dir));
         last_collision = nullptr;

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -97,15 +97,7 @@ class CacheEvacuateDocVC;
     dir_assign(_e, _x);                 \
     dir_set_next(_e, next);             \
   } while (0)
-// entry is valid
-#define dir_valid(_d, _e) (_d->header->phase == dir_phase(_e) ? _d->vol_in_phase_valid(_e) : _d->vol_out_of_phase_valid(_e))
-// entry is valid and outside of write aggregation region
-#define dir_agg_valid(_d, _e) (_d->header->phase == dir_phase(_e) ? _d->vol_in_phase_valid(_e) : _d->vol_out_of_phase_agg_valid(_e))
-// entry may be valid or overwritten in the last aggregated write
-#define dir_write_valid(_d, _e) \
-  (_d->header->phase == dir_phase(_e) ? vol_in_phase_valid(_d, _e) : vol_out_of_phase_write_valid(_d, _e))
-#define dir_agg_buf_valid(_d, _e) (_d->header->phase == dir_phase(_e) && _d->vol_in_phase_agg_buf_valid(_e))
-#define dir_is_empty(_e)          (!dir_offset(_e))
+#define dir_is_empty(_e) (!dir_offset(_e))
 #define dir_clear(_e) \
   do {                \
     (_e)->w[0] = 0;   \

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -134,7 +134,7 @@ Stripe::dir_check()
             chain_mark[e_idx] = mark;
           }
 
-          if (!dir_valid(this, e)) {
+          if (!this->dir_valid(e)) {
             ++seg_stale;
           } else {
             uint64_t size = dir_approx_size(e);
@@ -305,7 +305,7 @@ Stripe::flush_aggregate_write_buffer()
 bool
 Stripe::copy_from_aggregate_write_buffer(char *dest, Dir const &dir, size_t nbytes) const
 {
-  if (!dir_agg_buf_valid(this, &dir)) {
+  if (!this->dir_agg_buf_valid(&dir)) {
     return false;
   }
 

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -119,8 +119,12 @@ public:
   /* Calculates the total length of the header, directories and footer.
    */
   size_t dirlen() const;
-  int    vol_out_of_phase_valid(Dir const *e) const;
 
+  bool dir_valid(const Dir *dir) const;
+  bool dir_agg_valid(const Dir *dir) const;
+  bool dir_agg_buf_valid(const Dir *dir) const;
+
+  int vol_out_of_phase_valid(Dir const *e) const;
   int vol_out_of_phase_agg_valid(Dir const *e) const;
   int vol_out_of_phase_write_valid(Dir const *e) const;
   int vol_in_phase_valid(Dir const *e) const;
@@ -191,6 +195,30 @@ Stripe::dirlen() const
 {
   return this->headerlen() + ROUND_TO_STORE_BLOCK(((size_t)this->buckets) * DIR_DEPTH * this->segments * SIZEOF_DIR) +
          ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
+}
+
+/**
+  entry is valid
+ */
+inline bool
+Stripe::dir_valid(const Dir *dir) const
+{
+  return (this->header->phase == dir_phase(dir) ? this->vol_in_phase_valid(dir) : this->vol_out_of_phase_valid(dir));
+}
+
+/**
+  entry is valid and outside of write aggregation region
+ */
+inline bool
+Stripe::dir_agg_valid(const Dir *dir) const
+{
+  return (this->header->phase == dir_phase(dir) ? this->vol_in_phase_valid(dir) : this->vol_out_of_phase_agg_valid(dir));
+}
+
+inline bool
+Stripe::dir_agg_buf_valid(const Dir *dir) const
+{
+  return (this->header->phase == dir_phase(dir) && this->vol_in_phase_agg_buf_valid(dir));
 }
 
 inline int


### PR DESCRIPTION
1. Move below macros into Stripe member function.
```
#define dir_valid(_d, _e)
#define dir_agg_valid(_d, _e)
#define dir_agg_buf_valid(_d, _e)
```

2. Remove below macro because it's dead code.
```
#define dir_write_valid(_d, _e)
```

