### PR TITLE
Decouple disk from stripe

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -428,7 +428,7 @@ check_bucket_not_contains(Dir *b, Dir *e, Dir *seg)
 }
 
 void
-freelist_clean(int s, Stripe *stripe)
+freelist_clean(int s, StripeSM *stripe)
 {
   dir_clean_segment(s, stripe);
   if (stripe->header->freelist[s]) {
@@ -452,7 +452,7 @@ freelist_clean(int s, Stripe *stripe)
 }
 
 inline Dir *
-freelist_pop(int s, Stripe *stripe)
+freelist_pop(int s, StripeSM *stripe)
 {
   Dir *seg = stripe->dir_segment(s);
   Dir *e   = dir_from_offset(stripe->header->freelist[s], seg);

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -359,12 +359,12 @@ Stripe::_init_dir()
 }
 
 bool
-Stripe::flush_aggregate_write_buffer()
+Stripe::flush_aggregate_write_buffer(int fd)
 {
   // set write limit
   this->header->agg_pos = this->header->write_pos + this->_write_buffer.get_buffer_pos();
 
-  if (!this->_write_buffer.flush(this->fd, this->header->write_pos)) {
+  if (!this->_write_buffer.flush(fd, this->header->write_pos)) {
     return false;
   }
   this->header->last_write_pos  = this->header->write_pos;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -322,7 +322,7 @@ Stripe::dir_check()
 }
 
 void
-Stripe::_clear_init()
+Stripe::_clear_init(std::uint32_t hw_sector_size)
 {
   size_t dir_len = this->dirlen();
   memset(this->raw_dir, 0, dir_len);
@@ -336,7 +336,7 @@ Stripe::_clear_init()
   this->header->cycle                                              = 0;
   this->header->create_time                                        = time(nullptr);
   this->header->dirty                                              = 0;
-  this->sector_size = this->header->sector_size = this->disk->hw_sector_size;
+  this->sector_size = this->header->sector_size = hw_sector_size;
   *this->footer                                 = *this->header;
 }
 

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -85,8 +85,7 @@ struct StripeInitInfo {
 //
 
 Stripe::Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size, int fragment_size)
-  : fd{disk->fd},
-    frag_size{fragment_size},
+  : frag_size{fragment_size},
     skip{ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip))},
     start{skip},
     len{blocks * STORE_BLOCK_SIZE},

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -88,20 +88,19 @@ Stripe::Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size, 
   : frag_size{fragment_size},
     skip{ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip))},
     start{skip},
-    len{blocks * STORE_BLOCK_SIZE},
-    disk{disk}
+    len{blocks * STORE_BLOCK_SIZE}
 {
   ink_assert(this->len < MAX_STRIPE_SIZE);
 
-  this->_init_hash_text(disk->path, blocks, dir_skip);
+  this->_init_hash_text(disk, blocks, dir_skip);
   this->_init_data(STORE_BLOCK_SIZE, avg_obj_size);
   this->_init_directory(this->dirlen(), this->headerlen(), DIRECTORY_FOOTER_SIZE);
 }
 
 void
-Stripe::_init_hash_text(char const *seed, off_t blocks, off_t dir_skip)
+Stripe::_init_hash_text(CacheDisk const *disk, off_t blocks, off_t dir_skip)
 {
-  char const  *seed_str       = this->disk->hash_base_string ? this->disk->hash_base_string : seed;
+  char const  *seed_str       = disk->hash_base_string ? disk->hash_base_string : disk->path;
   const size_t hash_seed_size = strlen(seed_str);
   const size_t hash_text_size = hash_seed_size + 32;
 

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -174,7 +174,7 @@ protected:
 
   void _clear_init();
   void _init_dir();
-  bool flush_aggregate_write_buffer();
+  bool flush_aggregate_write_buffer(int fd);
 
 private:
   void _init_hash_text(char const *seed, off_t blocks, off_t dir_skip);

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -171,7 +171,7 @@ public:
 protected:
   AggregateWriteBuffer _write_buffer;
 
-  void _clear_init();
+  void _clear_init(std::uint32_t hw_sector_size);
   void _init_dir();
   bool flush_aggregate_write_buffer(int fd);
 

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -99,8 +99,7 @@ public:
   off_t                len{};
   off_t                data_blocks{};
 
-  CacheDisk *const disk{};
-  uint32_t         sector_size{};
+  uint32_t sector_size{};
 
   CacheVol *cache_vol{};
 
@@ -176,7 +175,7 @@ protected:
   bool flush_aggregate_write_buffer(int fd);
 
 private:
-  void _init_hash_text(char const *seed, off_t blocks, off_t dir_skip);
+  void _init_hash_text(CacheDisk const *disk, off_t blocks, off_t dir_skip);
   void _init_data(off_t store_block_size, int avg_obj_size = -1);
   void _init_data_internal(int avg_obj_size = -1); // Defaults to cache_config_min_average_object_size;
   void _init_directory(std::size_t directory_size, int header_size, int footer_size);

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -85,7 +85,6 @@ class Stripe
 {
 public:
   ats_scoped_str hash_text;
-  int            fd{-1};
   int            frag_size{-1};
 
   char                *raw_dir{nullptr};

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -1339,7 +1339,7 @@ StripeSM::shutdown(EThread *shutdown_thread)
   // directories have not been inserted for these writes
   if (!this->_write_buffer.is_empty()) {
     Dbg(dbg_ctl_cache_dir_sync, "Dir %s: flushing agg buffer first", this->hash_text.get());
-    this->flush_aggregate_write_buffer();
+    this->flush_aggregate_write_buffer(this->fd);
   }
 
   // We already asserted that dirlen > 0.

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -153,7 +153,7 @@ int
 StripeSM::clear_dir()
 {
   size_t dir_len = this->dirlen();
-  this->_clear_init();
+  this->_clear_init(this->disk->hw_sector_size);
 
   if (pwrite(this->fd, this->raw_dir, dir_len, this->skip) < 0) {
     Warning("unable to clear cache directory '%s'", this->hash_text.get());
@@ -273,7 +273,7 @@ int
 StripeSM::clear_dir_aio()
 {
   size_t dir_len = this->dirlen();
-  this->_clear_init();
+  this->_clear_init(this->disk->hw_sector_size);
 
   SET_HANDLER(&StripeSM::handle_dir_clear);
 

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -115,6 +115,7 @@ struct StripeInitInfo {
 StripeSM::StripeSM(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size, int fragment_size)
   : Continuation(new_ProxyMutex()),
     Stripe{disk, blocks, dir_skip, avg_obj_size, fragment_size},
+    fd{disk->fd},
     _preserved_dirs{static_cast<int>(len)}
 {
   open_dir.mutex = this->mutex;

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -116,6 +116,7 @@ StripeSM::StripeSM(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_si
   : Continuation(new_ProxyMutex()),
     Stripe{disk, blocks, dir_skip, avg_obj_size, fragment_size},
     fd{disk->fd},
+    disk{disk},
     _preserved_dirs{static_cast<int>(len)}
 {
   open_dir.mutex = this->mutex;

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -78,6 +78,8 @@ public:
 
   Event *trigger = nullptr;
 
+  CacheDisk *disk{};
+
   OpenDir              open_dir;
   RamCache            *ram_cache = nullptr;
   DLL<EvacuationBlock> lookaside[LOOKASIDE_SIZE];

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -66,6 +66,7 @@ class StripeSM : public Continuation, public Stripe
 {
 public:
   CryptoHash hash_id;
+  int        fd{-1};
 
   int hit_evacuate_window{};
 


### PR DESCRIPTION
This moves the following variables out of `Stripe`:

- [x] `fd`
- [x] `path`
- [x] `disk`
- [ ] ~~`hash_text`~~

The `hash_text` is used for some logging, so it might take some more design changes or possibly changes to the logging to easily move it.