### PR TITLE
Cleanup: Move Stripe initialization to Stripe::_init_data

### DIFF
--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -154,7 +154,7 @@ protected:
 
   void _clear_init();
   void _init_dir();
-  void _init_data();
+  void _init_data(off_t blocks, off_t dir_skip);
   bool flush_aggregate_write_buffer();
 
 private:

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -48,7 +48,6 @@
 
 #include "tscore/InkErrno.h"
 #include "tscore/Diags.h"
-#include "tscore/hugepages.h"
 #include "tscore/ink_assert.h"
 #include "tscore/ink_hrtime.h"
 #include "tscore/List.h"
@@ -154,6 +153,7 @@ StripeSM::clear_dir()
 int
 StripeSM::init(char *s, off_t blocks, off_t dir_skip, bool clear)
 {
+  // Hash
   char        *seed_str       = disk->hash_base_string ? disk->hash_base_string : s;
   const size_t hash_seed_size = strlen(seed_str);
   const size_t hash_text_size = hash_seed_size + 32;
@@ -164,19 +164,15 @@ StripeSM::init(char *s, off_t blocks, off_t dir_skip, bool clear)
            static_cast<uint64_t>(dir_skip), static_cast<uint64_t>(blocks));
   CryptoContext().hash_immediate(hash_id, hash_text, strlen(hash_text));
 
-  dir_skip = ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip));
-  path     = ats_strdup(s);
-  len      = blocks * STORE_BLOCK_SIZE;
-  ink_assert(len <= MAX_STRIPE_SIZE);
-  skip             = dir_skip;
-  prev_recover_pos = 0;
+  path = ats_strdup(s);
 
-  // successive approximation, directory/meta data eats up some storage
-  start = dir_skip;
-  this->_init_data();
-  data_blocks         = (len - (start - skip)) / STORE_BLOCK_SIZE;
-  hit_evacuate_window = (data_blocks * cache_config_hit_evacuate_percent) / 100;
+  // Stripe
+  this->_init_data(blocks, dir_skip);
 
+  // Evacuation
+  this->hit_evacuate_window = (this->data_blocks * cache_config_hit_evacuate_percent) / 100;
+
+  // PreservationTable
   this->_preserved_dirs.evacuate_size = static_cast<int>(len / EVACUATION_BUCKET_SIZE) + 2;
   int evac_len                        = this->_preserved_dirs.evacuate_size * sizeof(DLL<EvacuationBlock>);
   this->_preserved_dirs.evacuate      = static_cast<DLL<EvacuationBlock> *>(ats_malloc(evac_len));
@@ -185,18 +181,7 @@ StripeSM::init(char *s, off_t blocks, off_t dir_skip, bool clear)
   Dbg(dbg_ctl_cache_init, "Vol %s: allocating %zu directory bytes for a %lld byte volume (%lf%%)", hash_text.get(), dirlen(),
       (long long)this->len, (double)dirlen() / (double)this->len * 100.0);
 
-  raw_dir = nullptr;
-  if (ats_hugepage_enabled()) {
-    raw_dir = static_cast<char *>(ats_alloc_hugepage(this->dirlen()));
-  }
-  if (raw_dir == nullptr) {
-    raw_dir = static_cast<char *>(ats_memalign(ats_pagesize(), this->dirlen()));
-  }
-
-  dir    = reinterpret_cast<Dir *>(raw_dir + this->headerlen());
-  header = reinterpret_cast<StripteHeaderFooter *>(raw_dir);
-  footer = reinterpret_cast<StripteHeaderFooter *>(raw_dir + this->dirlen() - ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter)));
-
+  // AIO
   if (clear) {
     Note("clearing cache directory '%s'", hash_text.get());
     return clear_dir_aio();


### PR DESCRIPTION
Two cosmetic changes of `Stripe` initialization.

~1. I noticed somehow `Stripe::_init_data_internal()` is called three times, but calling once seems enough.~

~The function was renamed and moved, but this comes from the initial commit.~
https://github.com/apache/trafficserver/blob/a1651345d11f228dfb392cc79169760e80d25f06/iocore/cache/Cache.cc#L981-L983

2. `StripeSM::init` has initialization of `StripeSM` and `Stripe`. This clarifies `Stripe::_init_data` initializes `Stripe` data. ( should be move to constructor later) 

----

Update: 1. is dropped from this PR as @JosiahWI pointed out.