### PR TITLE
Add TLSEventSupport

### DIFF
--- a/include/iocore/net/NetVConnection.h
+++ b/include/iocore/net/NetVConnection.h
@@ -526,6 +526,7 @@ protected:
     TLS_ALPN,
     TLS_Basic,
     TLS_CertSwitch,
+    TLS_Event,
     TLS_EarlyData,
     TLS_SNI,
     TLS_SessionResumption,
@@ -617,6 +618,20 @@ inline void
 NetVConnection::_set_service(TLSBasicSupport *instance)
 {
   this->_set_service(NetVConnection::Service::TLS_Basic, instance);
+}
+
+class TLSEventSupport;
+template <>
+inline TLSEventSupport *
+NetVConnection::get_service() const
+{
+  return static_cast<TLSEventSupport *>(this->_get_service(NetVConnection::Service::TLS_Event));
+}
+template <>
+inline void
+NetVConnection::_set_service(TLSEventSupport *instance)
+{
+  this->_set_service(NetVConnection::Service::TLS_Event, instance);
 }
 
 class TLSEarlyDataSupport;

--- a/include/iocore/net/TLSEventSupport.h
+++ b/include/iocore/net/TLSEventSupport.h
@@ -1,0 +1,89 @@
+/** @file
+
+  TLSEventSupport implements common methods and members to
+  support TLS related events
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include "iocore/eventsystem/Lock.h"
+
+class Continuation;
+
+class TLSEventSupport
+{
+public:
+  enum class SSLHandshakeHookState {
+    HANDSHAKE_HOOKS_PRE,
+    HANDSHAKE_HOOKS_PRE_INVOKE,
+    HANDSHAKE_HOOKS_CLIENT_HELLO,
+    HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE,
+    HANDSHAKE_HOOKS_SNI,
+    HANDSHAKE_HOOKS_CERT,
+    HANDSHAKE_HOOKS_CERT_INVOKE,
+    HANDSHAKE_HOOKS_CLIENT_CERT,
+    HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE,
+    HANDSHAKE_HOOKS_OUTBOUND_PRE,
+    HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE,
+    HANDSHAKE_HOOKS_VERIFY_SERVER,
+    HANDSHAKE_HOOKS_DONE
+  };
+
+  static char const *get_ssl_handshake_hook_state_name(SSLHandshakeHookState state);
+
+  virtual ~TLSEventSupport() = default;
+
+  static void             initialize();
+  static TLSEventSupport *getInstance(SSL *ssl);
+  static void             bind(SSL *ssl, TLSEventSupport *es);
+  static void             unbind(SSL *ssl);
+
+  bool                    callHooks(TSEvent eventId);
+  bool                    calledHooks(TSEvent eventId) const;
+  virtual Continuation   *getContinuationForTLSEvents() = 0;
+  virtual EThread        *getThreadForTLSEvents()       = 0;
+  virtual Ptr<ProxyMutex> getMutexForTLSEvents()        = 0;
+  virtual void            reenable(int event)           = 0;
+
+protected:
+  void clear();
+
+  SSLHandshakeHookState get_handshake_hook_state();
+  void                  set_handshake_hook_state(SSLHandshakeHookState state);
+  bool                  is_invoked_state() const;
+  int                   invoke_tls_event();
+  void                  resume_tls_event();
+
+  virtual bool _is_tunneling_requested()   = 0;
+  virtual void _switch_to_tunneling_mode() = 0;
+
+private:
+  static int _ex_data_index;
+  SSL       *_ssl;
+
+  bool _first_handshake_hooks_pre          = true;
+  bool _first_handshake_hooks_outbound_pre = true;
+
+  /// The current hook.
+  /// @note For @C SSL_HOOKS_INVOKE, this is the hook to invoke.
+  class APIHook        *curHook               = nullptr;
+  SSLHandshakeHookState sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE;
+};

--- a/include/iocore/net/TLSEventSupport.h
+++ b/include/iocore/net/TLSEventSupport.h
@@ -72,8 +72,8 @@ protected:
   int                   invoke_tls_event();
   void                  resume_tls_event();
 
-  virtual bool _is_tunneling_requested()   = 0;
-  virtual void _switch_to_tunneling_mode() = 0;
+  virtual bool _is_tunneling_requested() const = 0;
+  virtual void _switch_to_tunneling_mode()     = 0;
 
 private:
   static int _ex_data_index;

--- a/include/iocore/net/TLSSNISupport.h
+++ b/include/iocore/net/TLSSNISupport.h
@@ -77,8 +77,6 @@ public:
   } hints_from_sni;
 
 protected:
-  virtual void _fire_ssl_servername_event() = 0;
-
   virtual in_port_t _get_local_port() = 0;
 
   void _clear();

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -7870,25 +7870,25 @@ TSHttpEventNameLookup(TSEvent event)
   return HttpDebugNames::get_event_name(static_cast<int>(event));
 }
 
-/// Re-enable SSL VC.
+/// Re-enable NetVC that has TLSEventSupport.
 class TSSslCallback : public Continuation
 {
 public:
-  TSSslCallback(SSLNetVConnection *vc, TSEvent event) : Continuation(vc->nh->mutex), m_vc(vc), m_event(event)
+  TSSslCallback(TLSEventSupport *tes, TSEvent event) : Continuation(tes->getMutexForTLSEvents().get()), m_tes(tes), m_event(event)
   {
     SET_HANDLER(&TSSslCallback::event_handler);
   }
   int
   event_handler(int /* event ATS_UNUSED */, void *)
   {
-    m_vc->reenable(m_vc->nh, m_event);
+    m_tes->reenable(m_event);
     delete this;
     return 0;
   }
 
 private:
-  SSLNetVConnection *m_vc;
-  TSEvent            m_event;
+  TLSEventSupport *m_tes;
+  TSEvent          m_event;
 };
 
 /// SSL Hooks
@@ -8369,19 +8369,19 @@ TSVConnReenable(TSVConn vconn)
 void
 TSVConnReenableEx(TSVConn vconn, TSEvent event)
 {
-  NetVConnection    *vc     = reinterpret_cast<NetVConnection *>(vconn);
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
-  // We really only deal with a SSLNetVConnection at the moment
-  if (ssl_vc != nullptr) {
+  NetVConnection *vc = reinterpret_cast<NetVConnection *>(vconn);
+
+  if (auto tes = vc->get_service<TLSEventSupport>(); tes) {
     EThread *eth = this_ethread();
 
     // We use the mutex of VC's NetHandler so we can put the VC into ready_list by reenable()
-    MUTEX_TRY_LOCK(trylock, ssl_vc->nh->mutex, eth);
+    Ptr<ProxyMutex> m = tes->getMutexForTLSEvents();
+    MUTEX_TRY_LOCK(trylock, m, eth);
     if (trylock.is_locked()) {
-      ssl_vc->reenable(ssl_vc->nh, event);
+      tes->reenable(event);
     } else {
       // We schedule the reenable to the home thread of ssl_vc.
-      ssl_vc->thread->schedule_imm(new TSSslCallback(ssl_vc, event));
+      tes->getThreadForTLSEvents()->schedule_imm(new TSSslCallback(tes, event));
     }
   }
 }

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(
   SSLUtils.cc
   OCSPStapling.cc
   TLSBasicSupport.cc
+  TLSEventSupport.cc
   TLSCertSwitchSupport.cc
   TLSEarlyDataSupport.cc
   TLSKeyLogger.cc

--- a/src/iocore/net/P_QUICNetVConnection.h
+++ b/src/iocore/net/P_QUICNetVConnection.h
@@ -43,6 +43,7 @@
 #include "P_UDPNet.h"
 #include "iocore/net/TLSALPNSupport.h"
 #include "iocore/net/TLSBasicSupport.h"
+#include "iocore/net/TLSEventSupport.h"
 #include "iocore/net/TLSSessionResumptionSupport.h"
 #include "iocore/net/TLSSNISupport.h"
 #include "iocore/net/TLSCertSwitchSupport.h"
@@ -59,6 +60,7 @@
 #include <netinet/in.h>
 #include <quiche.h>
 
+class EThread;
 class QUICPacketHandler;
 class QUICResetTokenTable;
 class QUICConnectionTable;
@@ -70,6 +72,7 @@ class QUICNetVConnection : public UnixNetVConnection,
                            public TLSSNISupport,
                            public TLSSessionResumptionSupport,
                            public TLSCertSwitchSupport,
+                           public TLSEventSupport,
                            public TLSBasicSupport,
                            public QUICSupport
 {
@@ -144,6 +147,12 @@ public:
   // QUICNetVConnection
   int in_closed_queue = 0;
 
+  // TLSEventSupport
+  void            reenable(int event) override;
+  Continuation   *getContinuationForTLSEvents() override;
+  EThread        *getThreadForTLSEvents() override;
+  Ptr<ProxyMutex> getMutexForTLSEvents() override;
+
   bool shouldDestroy();
   void destroy(EThread *t);
   void remove_connection_ids();
@@ -170,6 +179,19 @@ protected:
   bool           _isTryingRenegotiation() const override;
   shared_SSL_CTX _lookupContextByName(const std::string &servername, SSLCertContextType ctxType) override;
   shared_SSL_CTX _lookupContextByIP() override;
+
+  // TLSEventSupport
+  bool
+  _is_tunneling_requested() override
+  {
+    // FIXME Not Supported
+    return false;
+  }
+  void
+  _switch_to_tunneling_mode() override
+  {
+    // FIXME Not supported
+  }
 
 private:
   SSL                      *_ssl;

--- a/src/iocore/net/P_QUICNetVConnection.h
+++ b/src/iocore/net/P_QUICNetVConnection.h
@@ -169,7 +169,6 @@ protected:
   ssl_curve_id _get_tls_curve() const override;
 
   // TLSSNISupport
-  void      _fire_ssl_servername_event() override;
   in_port_t _get_local_port() override;
 
   // TLSSessionResumptionSupport

--- a/src/iocore/net/P_QUICNetVConnection.h
+++ b/src/iocore/net/P_QUICNetVConnection.h
@@ -181,7 +181,7 @@ protected:
 
   // TLSEventSupport
   bool
-  _is_tunneling_requested() override
+  _is_tunneling_requested() const override
   {
     // FIXME Not Supported
     return false;

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -43,6 +43,7 @@
 #include "iocore/net/TLSEarlyDataSupport.h"
 #include "iocore/net/TLSTunnelSupport.h"
 #include "iocore/net/TLSBasicSupport.h"
+#include "iocore/net/TLSEventSupport.h"
 #include "iocore/net/TLSCertSwitchSupport.h"
 #include "P_SSLUtils.h"
 #include "P_SSLConfig.h"
@@ -105,6 +106,7 @@ class SSLNetVConnection : public UnixNetVConnection,
                           public TLSEarlyDataSupport,
                           public TLSTunnelSupport,
                           public TLSCertSwitchSupport,
+                          public TLSEventSupport,
                           public TLSBasicSupport
 {
   typedef UnixNetVConnection super; ///< Parent type.
@@ -195,9 +197,6 @@ public:
   // Copy up here so we overload but don't override
   using super::reenable;
 
-  /// Reenable the VC after a pre-accept or SNI hook is called.
-  virtual void reenable(NetHandler *nh, int event = TS_EVENT_CONTINUE);
-
   int64_t read_raw_data();
 
   void
@@ -225,80 +224,6 @@ public:
     this->handShakeHolder    = nullptr;
     this->handShakeBuffer    = nullptr;
     this->handShakeBioStored = 0;
-  }
-
-  // Returns true if all the hooks reenabled
-  bool callHooks(TSEvent eventId);
-
-  // Returns true if we have already called at
-  // least some of the hooks
-  bool
-  calledHooks(TSEvent eventId) const
-  {
-    bool retval = false;
-    switch (this->sslHandshakeHookState) {
-    case HANDSHAKE_HOOKS_PRE:
-    case HANDSHAKE_HOOKS_PRE_INVOKE:
-      if (eventId == TS_EVENT_VCONN_START) {
-        if (curHook) {
-          retval = true;
-        }
-      }
-      break;
-    case HANDSHAKE_HOOKS_CLIENT_HELLO:
-    case HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE:
-      if (eventId == TS_EVENT_VCONN_START) {
-        retval = true;
-      } else if (eventId == TS_EVENT_SSL_CLIENT_HELLO) {
-        if (curHook) {
-          retval = true;
-        }
-      }
-      break;
-    case HANDSHAKE_HOOKS_SNI:
-      if (eventId == TS_EVENT_VCONN_START || eventId == TS_EVENT_SSL_CLIENT_HELLO) {
-        retval = true;
-      } else if (eventId == TS_EVENT_SSL_SERVERNAME) {
-        if (curHook) {
-          retval = true;
-        }
-      }
-      break;
-    case HANDSHAKE_HOOKS_CERT:
-    case HANDSHAKE_HOOKS_CERT_INVOKE:
-      if (eventId == TS_EVENT_VCONN_START || eventId == TS_EVENT_SSL_CLIENT_HELLO || eventId == TS_EVENT_SSL_SERVERNAME) {
-        retval = true;
-      } else if (eventId == TS_EVENT_SSL_CERT) {
-        if (curHook) {
-          retval = true;
-        }
-      }
-      break;
-    case HANDSHAKE_HOOKS_CLIENT_CERT:
-    case HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE:
-      if (eventId == TS_EVENT_SSL_VERIFY_CLIENT || eventId == TS_EVENT_VCONN_START) {
-        retval = true;
-      }
-      break;
-
-    case HANDSHAKE_HOOKS_OUTBOUND_PRE:
-    case HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE:
-      if (eventId == TS_EVENT_VCONN_OUTBOUND_START) {
-        if (curHook) {
-          retval = true;
-        }
-      }
-      break;
-
-    case HANDSHAKE_HOOKS_VERIFY_SERVER:
-      retval = (eventId == TS_EVENT_SSL_VERIFY_SERVER);
-      break;
-
-    case HANDSHAKE_HOOKS_DONE:
-      retval = true;
-      break;
-    }
-    return retval;
   }
 
   int         populate_protocol(std::string_view *results, int n) const override;
@@ -407,7 +332,15 @@ public:
     return _ca_cert_dir.get();
   }
 
+  // TLSEventSupport
+  /// Reenable the VC after a pre-accept or SNI hook is called.
+  void            reenable(int event = TS_EVENT_CONTINUE) override;
+  Continuation   *getContinuationForTLSEvents() override;
+  EThread        *getThreadForTLSEvents() override;
+  Ptr<ProxyMutex> getMutexForTLSEvents() override;
+
 protected:
+  // TLSBasicSupport
   SSL *
   _get_ssl_object() const override
   {
@@ -415,6 +348,7 @@ protected:
   }
   ssl_curve_id _get_tls_curve() const override;
 
+  // TLSSessionResumptionSupport
   const IpEndpoint &
   _getLocalEndpoint() override
   {
@@ -428,6 +362,18 @@ protected:
   bool           _isTryingRenegotiation() const override;
   shared_SSL_CTX _lookupContextByName(const std::string &servername, SSLCertContextType ctxType) override;
   shared_SSL_CTX _lookupContextByIP() override;
+
+  // TLSEventSupport
+  bool
+  _is_tunneling_requested() override
+  {
+    return SSL_HOOK_OP_TUNNEL == hookOpRequested;
+  }
+  void
+  _switch_to_tunneling_mode() override
+  {
+    this->attributes = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
+  }
 
 private:
   std::string_view map_tls_protocol_to_tag(const char *proto_string) const;
@@ -448,28 +394,6 @@ private:
   bool allowPlain             = false;
 
   int sent_cert = 0;
-
-  /// The current hook.
-  /// @note For @C SSL_HOOKS_INVOKE, this is the hook to invoke.
-  class APIHook *curHook = nullptr;
-
-  enum SSLHandshakeHookState {
-    HANDSHAKE_HOOKS_PRE,
-    HANDSHAKE_HOOKS_PRE_INVOKE,
-    HANDSHAKE_HOOKS_CLIENT_HELLO,
-    HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE,
-    HANDSHAKE_HOOKS_SNI,
-    HANDSHAKE_HOOKS_CERT,
-    HANDSHAKE_HOOKS_CERT_INVOKE,
-    HANDSHAKE_HOOKS_CLIENT_CERT,
-    HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE,
-    HANDSHAKE_HOOKS_OUTBOUND_PRE,
-    HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE,
-    HANDSHAKE_HOOKS_VERIFY_SERVER,
-    HANDSHAKE_HOOKS_DONE
-  } sslHandshakeHookState = HANDSHAKE_HOOKS_PRE;
-
-  static char const *get_ssl_handshake_hook_state_name(SSLHandshakeHookState state);
 
   int64_t redoWriteSize = 0;
 

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -356,7 +356,6 @@ protected:
   }
 
   // TLSSNISupport
-  void      _fire_ssl_servername_event() override;
   in_port_t _get_local_port() override;
 
   bool           _isTryingRenegotiation() const override;

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -364,7 +364,7 @@ protected:
 
   // TLSEventSupport
   bool
-  _is_tunneling_requested() override
+  _is_tunneling_requested() const override
   {
     return SSL_HOOK_OP_TUNNEL == hookOpRequested;
   }

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -819,11 +819,6 @@ QUICNetVConnection::_get_tls_curve() const
   }
 }
 
-void
-QUICNetVConnection::_fire_ssl_servername_event()
-{
-}
-
 in_port_t
 QUICNetVConnection::_get_local_port()
 {

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -24,9 +24,12 @@
 #include "P_SSLUtils.h"
 #include "P_QUICNetVConnection.h"
 #include "P_QUICPacketHandler.h"
+#include "api/APIHook.h"
+#include "iocore/eventsystem/EThread.h"
 #include "iocore/net/QUICMultiCertConfigLoader.h"
 #include "iocore/net/quic/QUICStream.h"
 #include "iocore/net/quic/QUICGlobals.h"
+#include "iocore/net/SSLAPIHooks.h"
 
 #include <netinet/in.h>
 #include <quiche.h>
@@ -49,6 +52,7 @@ QUICNetVConnection::QUICNetVConnection()
 {
   this->_set_service(static_cast<ALPNSupport *>(this));
   this->_set_service(static_cast<TLSBasicSupport *>(this));
+  this->_set_service(static_cast<TLSEventSupport *>(this));
   this->_set_service(static_cast<TLSCertSwitchSupport *>(this));
   this->_set_service(static_cast<TLSSNISupport *>(this));
   this->_set_service(static_cast<TLSSessionResumptionSupport *>(this));
@@ -142,6 +146,7 @@ QUICNetVConnection::free_thread(EThread * /* t ATS_UNUSED */)
   super::clear();
   ALPNSupport::clear();
   TLSBasicSupport::clear();
+  TLSEventSupport::clear();
   TLSCertSwitchSupport::_clear();
 
   this->_packet_handler->close_connection(this);
@@ -540,6 +545,7 @@ void
 QUICNetVConnection::_bindSSLObject()
 {
   TLSBasicSupport::bind(this->_ssl, this);
+  TLSEventSupport::bind(this->_ssl, this);
   ALPNSupport::bind(this->_ssl, this);
   TLSSessionResumptionSupport::bind(this->_ssl, this);
   TLSSNISupport::bind(this->_ssl, this);
@@ -551,6 +557,7 @@ void
 QUICNetVConnection::_unbindSSLObject()
 {
   TLSBasicSupport::unbind(this->_ssl);
+  TLSEventSupport::unbind(this->_ssl);
   ALPNSupport::unbind(this->_ssl);
   TLSSessionResumptionSupport::unbind(this->_ssl);
   TLSSNISupport::unbind(this->_ssl);
@@ -771,6 +778,29 @@ QUICConnection *
 QUICNetVConnection::get_quic_connection()
 {
   return static_cast<QUICConnection *>(this);
+}
+
+void
+QUICNetVConnection::reenable(int /* event ATS_UNUSED */)
+{
+}
+
+Continuation *
+QUICNetVConnection::getContinuationForTLSEvents()
+{
+  return this;
+}
+
+EThread *
+QUICNetVConnection::getThreadForTLSEvents()
+{
+  return this->thread;
+}
+
+Ptr<ProxyMutex>
+QUICNetVConnection::getMutexForTLSEvents()
+{
+  return this->nh->mutex;
 }
 
 SSL *

--- a/src/iocore/net/SSLClientUtils.cc
+++ b/src/iocore/net/SSLClientUtils.cc
@@ -132,7 +132,10 @@ verify_callback(int signature_ok, X509_STORE_CTX *ctx)
   }
   // If the previous configured checks passed, give the hook a try
   netvc->set_verify_cert(ctx);
-  netvc->callHooks(TS_EVENT_SSL_VERIFY_SERVER);
+  TLSEventSupport *tes = TLSEventSupport::getInstance(ssl);
+  if (tes) {
+    tes->callHooks(TS_EVENT_SSL_VERIFY_SERVER);
+  }
   netvc->set_verify_cert(nullptr);
 
   if (netvc->getSSLHandshakeStatus() == SSLHandshakeStatus::SSL_HANDSHAKE_ERROR) {

--- a/src/iocore/net/SSLClientUtils.cc
+++ b/src/iocore/net/SSLClientUtils.cc
@@ -132,9 +132,9 @@ verify_callback(int signature_ok, X509_STORE_CTX *ctx)
   }
   // If the previous configured checks passed, give the hook a try
   netvc->set_verify_cert(ctx);
-  TLSEventSupport *tes = TLSEventSupport::getInstance(ssl);
-  if (tes) {
-    tes->callHooks(TS_EVENT_SSL_VERIFY_SERVER);
+  TLSEventSupport *es = TLSEventSupport::getInstance(ssl);
+  if (es) {
+    es->callHooks(TS_EVENT_SSL_VERIFY_SERVER);
   }
   netvc->set_verify_cert(nullptr);
 

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -1771,12 +1771,6 @@ SSLNetVConnection::protocol_contains(std::string_view prefix) const
   return retval;
 }
 
-void
-SSLNetVConnection::_fire_ssl_servername_event()
-{
-  this->callHooks(TS_EVENT_SSL_SERVERNAME);
-}
-
 in_port_t
 SSLNetVConnection::_get_local_port()
 {

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -290,9 +290,9 @@ ssl_verify_client_callback(int preverify_ok, X509_STORE_CTX *ctx)
   }
 
   netvc->set_verify_cert(ctx);
-  TLSEventSupport *tes = TLSEventSupport::getInstance(ssl);
-  if (tes) {
-    tes->callHooks(TS_EVENT_SSL_VERIFY_CLIENT);
+  TLSEventSupport *es = TLSEventSupport::getInstance(ssl);
+  if (es) {
+    es->callHooks(TS_EVENT_SSL_VERIFY_CLIENT);
   }
   netvc->set_verify_cert(nullptr);
 
@@ -333,9 +333,9 @@ ssl_client_hello_callback(const SSL_CLIENT_HELLO *client_hello)
     return CLIENT_HELLO_ERROR;
   }
 
-  TLSEventSupport *tes = TLSEventSupport::getInstance(s);
-  if (tes) {
-    bool reenabled = tes->callHooks(TS_EVENT_SSL_CLIENT_HELLO);
+  TLSEventSupport *es = TLSEventSupport::getInstance(s);
+  if (es) {
+    bool reenabled = es->callHooks(TS_EVENT_SSL_CLIENT_HELLO);
     if (!reenabled) {
       return CLIENT_HELLO_RETRY;
     }
@@ -435,6 +435,9 @@ ssl_servername_callback(SSL *ssl, int *al, void *arg)
 {
   TLSSNISupport *snis = TLSSNISupport::getInstance(ssl);
   if (snis) {
+    if (TLSEventSupport *es = TLSEventSupport::getInstance(ssl); es) {
+      es->callHooks(TS_EVENT_SSL_SERVERNAME);
+    }
     snis->on_servername(ssl, al, arg);
 #if !TS_USE_HELLO_CB
     // Only call the SNI actions here if not already performed in the HELLO_CB

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -290,7 +290,10 @@ ssl_verify_client_callback(int preverify_ok, X509_STORE_CTX *ctx)
   }
 
   netvc->set_verify_cert(ctx);
-  netvc->callHooks(TS_EVENT_SSL_VERIFY_CLIENT);
+  TLSEventSupport *tes = TLSEventSupport::getInstance(ssl);
+  if (tes) {
+    tes->callHooks(TS_EVENT_SSL_VERIFY_CLIENT);
+  }
   netvc->set_verify_cert(nullptr);
 
   if (netvc->getSSLHandShakeComplete()) { // hook moved the handshake state to terminal
@@ -330,17 +333,15 @@ ssl_client_hello_callback(const SSL_CLIENT_HELLO *client_hello)
     return CLIENT_HELLO_ERROR;
   }
 
-  SSLNetVConnection *netvc = dynamic_cast<SSLNetVConnection *>(snis);
-  if (netvc) {
-    if (netvc->ssl != s) {
-      Dbg(dbg_ctl_ssl_error, "ssl_client_hello_callback call back on stale netvc");
-      return CLIENT_HELLO_ERROR;
-    }
-
-    bool reenabled = netvc->callHooks(TS_EVENT_SSL_CLIENT_HELLO);
+  TLSEventSupport *tes = TLSEventSupport::getInstance(s);
+  if (tes) {
+    bool reenabled = tes->callHooks(TS_EVENT_SSL_CLIENT_HELLO);
     if (!reenabled) {
       return CLIENT_HELLO_RETRY;
     }
+  } else {
+    Dbg(dbg_ctl_ssl_error, "ssl_client_hello_callback call back on stale netvc");
+    return CLIENT_HELLO_ERROR;
   }
 
   return CLIENT_HELLO_SUCCESS;
@@ -354,6 +355,7 @@ static int
 ssl_cert_callback(SSL *ssl, [[maybe_unused]] void *arg)
 {
   TLSCertSwitchSupport *tcss     = TLSCertSwitchSupport::getInstance(ssl);
+  TLSEventSupport      *tes      = TLSEventSupport::getInstance(ssl);
   SSLNetVConnection    *sslnetvc = dynamic_cast<SSLNetVConnection *>(tcss);
   bool                  reenabled;
   int                   retval = 1;
@@ -382,15 +384,15 @@ ssl_cert_callback(SSL *ssl, [[maybe_unused]] void *arg)
   if (sslnetvc) {
     // Do the common certificate lookup only once.  If we pause
     // and restart processing, do not execute the common logic again
-    if (!sslnetvc->calledHooks(TS_EVENT_SSL_CERT)) {
-      retval = sslnetvc->selectCertificate(ssl, ctxType);
+    if (tes && !tes->calledHooks(TS_EVENT_SSL_CERT)) {
+      retval = tcss->selectCertificate(ssl, ctxType);
       if (retval != 1) {
         return retval;
       }
     }
 
     // Call the plugin cert code
-    reenabled = sslnetvc->callHooks(TS_EVENT_SSL_CERT);
+    reenabled = tes->callHooks(TS_EVENT_SSL_CERT);
     // If it did not re-enable, return the code to
     // stop the accept processing
     if (!reenabled) {
@@ -900,6 +902,7 @@ SSLInitializeLibrary()
   ssl_vc_index = SSL_get_ex_new_index(0, (void *)"NetVC index", nullptr, nullptr, nullptr);
 
   TLSBasicSupport::initialize();
+  TLSEventSupport::initialize();
   ALPNSupport::initialize();
   TLSSessionResumptionSupport::initialize();
   TLSSNISupport::initialize();

--- a/src/iocore/net/TLSEventSupport.cc
+++ b/src/iocore/net/TLSEventSupport.cc
@@ -1,0 +1,553 @@
+/** @file
+
+  TLSSEventSupport.cc provides implementations for
+  TLSEventSupport methods
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include <openssl/ssl.h>
+#include "iocore/net/TLSEventSupport.h"
+#include "iocore/net/SSLAPIHooks.h"
+#include "tscore/Diags.h"
+#include "SSLStats.h"
+
+int TLSEventSupport::_ex_data_index = -1;
+
+namespace
+{
+DbgCtl dbg_ctl_ssl{"ssl"};
+
+/// Callback to get two locks.
+/// The lock for this continuation, and for the target continuation.
+class ContWrapper : public Continuation
+{
+public:
+  /** Constructor.
+      This takes the secondary @a mutex and the @a target continuation
+      to invoke, along with the arguments for that invocation.
+  */
+  ContWrapper(ProxyMutex   *mutex,                     ///< Mutex for this continuation (primary lock).
+              Continuation *target,                    ///< "Real" continuation we want to call.
+              int           eventId = EVENT_IMMEDIATE, ///< Event ID for invocation of @a target.
+              void         *edata   = nullptr          ///< Data for invocation of @a target.
+              )
+    : Continuation(mutex), _target(target), _eventId(eventId), _edata(edata)
+  {
+    SET_HANDLER(&ContWrapper::event_handler);
+  }
+
+  /// Required event handler method.
+  int
+  event_handler(int, void *)
+  {
+    EThread *eth = this_ethread();
+
+    MUTEX_TRY_LOCK(lock, _target->mutex, eth);
+    if (lock.is_locked()) { // got the target lock, we can proceed.
+      _target->handleEvent(_eventId, _edata);
+      delete this;
+    } else { // can't get both locks, try again.
+      eventProcessor.schedule_imm(this, ET_NET);
+    }
+    return 0;
+  }
+
+  /** Convenience static method.
+
+      This lets a client make one call and not have to (accurately)
+      copy the invocation logic embedded here. We duplicate it near
+      by textually so it is easier to keep in sync.
+
+      This takes the same arguments as the constructor but, if the
+      lock can be obtained immediately, does not construct an
+      instance but simply calls the @a target.
+  */
+  static void
+  wrap(ProxyMutex   *mutex,                     ///< Mutex for this continuation (primary lock).
+       Continuation *target,                    ///< "Real" continuation we want to call.
+       int           eventId = EVENT_IMMEDIATE, ///< Event ID for invocation of @a target.
+       void         *edata   = nullptr          ///< Data for invocation of @a target.
+  )
+  {
+    EThread *eth = this_ethread();
+    if (!target->mutex) {
+      // If there's no mutex, plugin doesn't care about locking so why should we?
+      target->handleEvent(eventId, edata);
+    } else {
+      MUTEX_TRY_LOCK(lock, target->mutex, eth);
+      if (lock.is_locked()) {
+        target->handleEvent(eventId, edata);
+      } else {
+        eventProcessor.schedule_imm(new ContWrapper(mutex, target, eventId, edata), ET_NET);
+      }
+    }
+  }
+
+private:
+  Continuation *_target;  ///< Continuation to invoke.
+  int           _eventId; ///< with this event
+  void         *_edata;   ///< and this data
+};
+
+} // end anonymous namespace
+
+void
+TLSEventSupport::initialize()
+{
+  ink_assert(_ex_data_index == -1);
+  if (_ex_data_index == -1) {
+    _ex_data_index = SSL_get_ex_new_index(0, (void *)"TLSEventSupport index", nullptr, nullptr, nullptr);
+  }
+}
+
+TLSEventSupport *
+TLSEventSupport::getInstance(SSL *ssl)
+{
+  return static_cast<TLSEventSupport *>(SSL_get_ex_data(ssl, _ex_data_index));
+}
+
+void
+TLSEventSupport::bind(SSL *ssl, TLSEventSupport *es)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, es);
+  es->_ssl = ssl;
+}
+
+void
+TLSEventSupport::unbind(SSL *ssl)
+{
+  SSL_set_ex_data(ssl, _ex_data_index, nullptr);
+}
+
+void
+TLSEventSupport::clear()
+{
+  curHook = nullptr;
+}
+
+bool
+TLSEventSupport::callHooks(TSEvent eventId)
+{
+  // Only dealing with the SNI/CERT hook so far.
+  ink_assert(eventId == TS_EVENT_SSL_CLIENT_HELLO || eventId == TS_EVENT_SSL_CERT || eventId == TS_EVENT_SSL_SERVERNAME ||
+             eventId == TS_EVENT_SSL_VERIFY_SERVER || eventId == TS_EVENT_SSL_VERIFY_CLIENT || eventId == TS_EVENT_VCONN_CLOSE ||
+             eventId == TS_EVENT_VCONN_OUTBOUND_CLOSE);
+  Dbg(dbg_ctl_ssl, "sslHandshakeHookState=%s eventID=%d", get_ssl_handshake_hook_state_name(this->sslHandshakeHookState), eventId);
+
+  // Move state if it is appropriate
+  if (eventId == TS_EVENT_VCONN_CLOSE) {
+    // Regardless of state, if the connection is closing, then transition to
+    // the DONE state. This will trigger us to call the appropriate cleanup
+    // routines.
+    this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE;
+  } else {
+    switch (this->sslHandshakeHookState) {
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE:
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE:
+      if (eventId == TS_EVENT_SSL_CLIENT_HELLO) {
+        this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO;
+      } else if (eventId == TS_EVENT_SSL_SERVERNAME) {
+        this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI;
+      } else if (eventId == TS_EVENT_SSL_VERIFY_SERVER) {
+        this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_VERIFY_SERVER;
+      } else if (eventId == TS_EVENT_SSL_CERT) {
+        this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT;
+      }
+      break;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO:
+      if (eventId == TS_EVENT_SSL_SERVERNAME) {
+        this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI;
+      } else if (eventId == TS_EVENT_SSL_CERT) {
+        this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT;
+      }
+      break;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI:
+      if (eventId == TS_EVENT_SSL_CERT) {
+        this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT;
+      }
+      break;
+    default:
+      break;
+    }
+  }
+
+  // Look for hooks associated with the event
+  switch (this->sslHandshakeHookState) {
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE:
+    if (!curHook) {
+      curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_SSL_CLIENT_HELLO_HOOK));
+    } else {
+      curHook = curHook->next();
+    }
+    if (curHook == nullptr) {
+      this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI;
+    } else {
+      this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE;
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_VERIFY_SERVER:
+    // The server verify event addresses ATS to origin handshake
+    // All the other events are for client to ATS
+    if (!curHook) {
+      curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_SSL_VERIFY_SERVER_HOOK));
+    } else {
+      curHook = curHook->next();
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI:
+    if (!curHook) {
+      curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_SSL_SERVERNAME_HOOK));
+    } else {
+      curHook = curHook->next();
+    }
+    if (!curHook) {
+      this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT;
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE:
+    if (!curHook) {
+      curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_SSL_CERT_HOOK));
+    } else {
+      curHook = curHook->next();
+    }
+    if (curHook == nullptr) {
+      this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT;
+    } else {
+      this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE;
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE:
+    if (!curHook) {
+      curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_SSL_VERIFY_CLIENT_HOOK));
+    } else {
+      curHook = curHook->next();
+    }
+    [[fallthrough]];
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE:
+    if (eventId == TS_EVENT_VCONN_CLOSE) {
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE;
+      if (curHook == nullptr) {
+        curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_VCONN_CLOSE_HOOK));
+      } else {
+        curHook = curHook->next();
+      }
+    } else if (eventId == TS_EVENT_VCONN_OUTBOUND_CLOSE) {
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE;
+      if (curHook == nullptr) {
+        curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_VCONN_OUTBOUND_CLOSE_HOOK));
+      } else {
+        curHook = curHook->next();
+      }
+    }
+    break;
+  default:
+    curHook                     = nullptr;
+    this->sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE;
+    return true;
+  }
+
+  Dbg(dbg_ctl_ssl, "iterated to curHook=%p", curHook);
+
+  bool reenabled = true;
+
+  if (this->_is_tunneling_requested()) {
+    this->_switch_to_tunneling_mode();
+    // Don't mark the handshake as complete yet,
+    // Will be checking for that flag not being set after
+    // we get out of this callback, and then will shuffle
+    // over the buffered handshake packets to the O.S.
+    // sslHandShakeComplete = 1;
+    return reenabled;
+  }
+
+  if (curHook != nullptr) {
+    WEAK_SCOPED_MUTEX_LOCK(lock, curHook->m_cont->mutex, this_ethread());
+    curHook->invoke(eventId, this->getContinuationForTLSEvents());
+    reenabled = (this->sslHandshakeHookState != SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE &&
+                 this->sslHandshakeHookState != SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE &&
+                 this->sslHandshakeHookState != SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE);
+    Dbg(dbg_ctl_ssl, "Called hook on state=%s reenabled=%d", get_ssl_handshake_hook_state_name(sslHandshakeHookState), reenabled);
+  }
+
+  return reenabled;
+}
+
+// Returns true if we have already called at
+// least some of the hooks
+bool
+TLSEventSupport::calledHooks(TSEvent eventId) const
+{
+  bool retval = false;
+  switch (this->sslHandshakeHookState) {
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE:
+    if (eventId == TS_EVENT_VCONN_START) {
+      if (curHook) {
+        retval = true;
+      }
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE:
+    if (eventId == TS_EVENT_VCONN_START) {
+      retval = true;
+    } else if (eventId == TS_EVENT_SSL_CLIENT_HELLO) {
+      if (curHook) {
+        retval = true;
+      }
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI:
+    if (eventId == TS_EVENT_VCONN_START || eventId == TS_EVENT_SSL_CLIENT_HELLO) {
+      retval = true;
+    } else if (eventId == TS_EVENT_SSL_SERVERNAME) {
+      if (curHook) {
+        retval = true;
+      }
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE:
+    if (eventId == TS_EVENT_VCONN_START || eventId == TS_EVENT_SSL_CLIENT_HELLO || eventId == TS_EVENT_SSL_SERVERNAME) {
+      retval = true;
+    } else if (eventId == TS_EVENT_SSL_CERT) {
+      if (curHook) {
+        retval = true;
+      }
+    }
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE:
+    if (eventId == TS_EVENT_SSL_VERIFY_CLIENT || eventId == TS_EVENT_VCONN_START) {
+      retval = true;
+    }
+    break;
+
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE:
+    if (eventId == TS_EVENT_VCONN_OUTBOUND_START) {
+      if (curHook) {
+        retval = true;
+      }
+    }
+    break;
+
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_VERIFY_SERVER:
+    retval = (eventId == TS_EVENT_SSL_VERIFY_SERVER);
+    break;
+
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE:
+    retval = true;
+    break;
+  }
+  return retval;
+}
+
+char const *
+TLSEventSupport::get_ssl_handshake_hook_state_name(SSLHandshakeHookState state)
+{
+  switch (state) {
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE:
+    return "TS_SSL_HOOK_PRE_ACCEPT";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE:
+    return "TS_SSL_HOOK_PRE_ACCEPT_INVOKE";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO:
+    return "TS_SSL_HOOK_CLIENT_HELLO";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE:
+    return "TS_SSL_HOOK_CLIENT_HELLO_INVOKE";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI:
+    return "TS_SSL_HOOK_SERVERNAME";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT:
+    return "TS_SSL_HOOK_CERT";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE:
+    return "TS_SSL_HOOK_CERT_INVOKE";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT:
+    return "TS_SSL_HOOK_CLIENT_CERT";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE:
+    return "TS_SSL_HOOK_CLIENT_CERT_INVOKE";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE:
+    return "TS_SSL_HOOK_PRE_CONNECT";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE:
+    return "TS_SSL_HOOK_PRE_CONNECT_INVOKE";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_VERIFY_SERVER:
+    return "TS_SSL_HOOK_VERIFY_SERVER";
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE:
+    return "TS_SSL_HOOKS_DONE";
+  }
+  return "unknown handshake hook name";
+}
+
+TLSEventSupport::SSLHandshakeHookState
+TLSEventSupport::get_handshake_hook_state()
+{
+  return this->sslHandshakeHookState;
+}
+
+void
+TLSEventSupport::set_handshake_hook_state(TLSEventSupport::SSLHandshakeHookState state)
+{
+  this->sslHandshakeHookState = state;
+}
+
+bool
+TLSEventSupport::is_invoked_state() const
+{
+  return sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE ||
+         sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE ||
+         sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE ||
+         sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE ||
+         sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE;
+}
+
+int
+TLSEventSupport::invoke_tls_event()
+{
+  if (curHook != nullptr) {
+    curHook = curHook->next();
+    Dbg(dbg_ctl_ssl, "iterate from reenable curHook=%p", curHook);
+  }
+  if (curHook != nullptr) {
+    // Invoke the hook and return, wait for next reenable
+    if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO) {
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE;
+      curHook->invoke(TS_EVENT_SSL_CLIENT_HELLO, this->getContinuationForTLSEvents());
+    } else if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT) {
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE;
+      curHook->invoke(TS_EVENT_SSL_VERIFY_CLIENT, this->getContinuationForTLSEvents());
+    } else if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT) {
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE;
+      curHook->invoke(TS_EVENT_SSL_CERT, this->getContinuationForTLSEvents());
+    } else if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI) {
+      curHook->invoke(TS_EVENT_SSL_SERVERNAME, this->getContinuationForTLSEvents());
+    } else if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE) {
+      Dbg(dbg_ctl_ssl, "Reenable preaccept");
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE;
+      ContWrapper::wrap(this->getMutexForTLSEvents().get(), curHook->m_cont, TS_EVENT_VCONN_START,
+                        this->getContinuationForTLSEvents());
+    } else if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE) {
+      Dbg(dbg_ctl_ssl, "Reenable outbound connect");
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE;
+      ContWrapper::wrap(this->getMutexForTLSEvents().get(), curHook->m_cont, TS_EVENT_VCONN_OUTBOUND_START,
+                        this->getContinuationForTLSEvents());
+    } else if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE) {
+      if (SSL_is_server(this->_ssl)) {
+        ContWrapper::wrap(this->getMutexForTLSEvents().get(), curHook->m_cont, TS_EVENT_VCONN_CLOSE,
+                          this->getContinuationForTLSEvents());
+      } else {
+        ContWrapper::wrap(this->getMutexForTLSEvents().get(), curHook->m_cont, TS_EVENT_VCONN_OUTBOUND_CLOSE,
+                          this->getContinuationForTLSEvents());
+      }
+    } else if (sslHandshakeHookState == SSLHandshakeHookState::HANDSHAKE_HOOKS_VERIFY_SERVER) {
+      Dbg(dbg_ctl_ssl, "ServerVerify");
+      ContWrapper::wrap(this->getMutexForTLSEvents().get(), curHook->m_cont, TS_EVENT_SSL_VERIFY_SERVER,
+                        this->getContinuationForTLSEvents());
+    }
+    return 1;
+  } else {
+    // Move onto the "next" state
+    switch (this->sslHandshakeHookState) {
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE:
+      if (this->_first_handshake_hooks_pre) {
+        this->_first_handshake_hooks_pre = false;
+        Metrics::Counter::increment(ssl_rsb.total_attempts_handshake_count_in);
+        Dbg(dbg_ctl_ssl, "Initialize preaccept curHook from NULL");
+        curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_VCONN_START_HOOK));
+        if (curHook) {
+          sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE;
+          ContWrapper::wrap(this->getMutexForTLSEvents().get(), curHook->m_cont, TS_EVENT_VCONN_START,
+                            this->getContinuationForTLSEvents());
+          return 1;
+        }
+      }
+      [[fallthrough]];
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE:
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO;
+      break;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO:
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE:
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI;
+      break;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_SNI:
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT;
+      break;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT:
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE:
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT;
+      break;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE:
+      if (this->_first_handshake_hooks_outbound_pre) {
+        this->_first_handshake_hooks_outbound_pre = false;
+        Metrics::Counter::increment(ssl_rsb.total_attempts_handshake_count_out);
+        Dbg(dbg_ctl_ssl, "Initialize outbound connect curHook from NULL");
+        curHook = SSLAPIHooks::instance()->get(TSSslHookInternalID(TS_VCONN_OUTBOUND_START_HOOK));
+        if (curHook) {
+          sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE;
+          ContWrapper::wrap(this->getMutexForTLSEvents().get(), curHook->m_cont, TS_EVENT_VCONN_OUTBOUND_START,
+                            this->getContinuationForTLSEvents());
+          return 1;
+        }
+      }
+      [[fallthrough]];
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE:
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE;
+      return 2;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT:
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT_INVOKE:
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE;
+      break;
+    case SSLHandshakeHookState::HANDSHAKE_HOOKS_VERIFY_SERVER:
+      sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_DONE;
+      break;
+    default:
+      break;
+    }
+    Dbg(dbg_ctl_ssl, "iterate from reenable curHook=%p %s", curHook,
+        TLSEventSupport::get_ssl_handshake_hook_state_name(sslHandshakeHookState));
+  }
+  return 0;
+}
+
+void
+TLSEventSupport::resume_tls_event()
+{
+  switch (this->sslHandshakeHookState) {
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE_INVOKE:
+    sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_PRE;
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE_INVOKE:
+    sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_OUTBOUND_PRE;
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO_INVOKE:
+    sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_HELLO;
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT_INVOKE:
+    sslHandshakeHookState = SSLHandshakeHookState::HANDSHAKE_HOOKS_CERT;
+    break;
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_VERIFY_SERVER:
+  case SSLHandshakeHookState::HANDSHAKE_HOOKS_CLIENT_CERT:
+    break;
+  default:
+    break;
+  }
+}

--- a/src/iocore/net/TLSSNISupport.cc
+++ b/src/iocore/net/TLSSNISupport.cc
@@ -127,8 +127,6 @@ TLSSNISupport::on_client_hello(ClientHello &client_hello)
 void
 TLSSNISupport::on_servername(SSL *ssl, int * /* al ATS_UNUSED */, void * /* arg ATS_UNUSED */)
 {
-  this->_fire_ssl_servername_event();
-
   const char *name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (name) {
     this->_set_sni_server_name(name);


### PR DESCRIPTION
This is preparation to support [TLS User Agent Hooks](https://docs.trafficserver.apache.org/en/latest/developer-guide/plugins/hooks-and-transactions/ssl-hooks.en.html) on QUIC connections. The goal on this PR is, like other TLS*Support mix-ins, to remove dynamic_casts to SSLNetVC. Wiring for QUICNetVC will be made later on another PR.

