### PR TITLE
Fix an infinite loop in Histogram

### DIFF
--- a/include/tsutil/Histogram.h
+++ b/include/tsutil/Histogram.h
@@ -75,7 +75,7 @@ public:
   /// Samples less than this go in the underflow range.
   static constexpr raw_type UNDERFLOW_BOUND = static_cast<raw_type>(1) << N_SPAN_BITS;
   /// Sample equal or greater than this  go in the overflow bucket.
-  static constexpr raw_type OVERFLOW_BOUND = static_cast<raw_type>(1) << (N_RANGE_BITS + N_SPAN_BITS + 1);
+  static constexpr raw_type OVERFLOW_BOUND = static_cast<raw_type>(1) << (N_RANGE_BITS + N_SPAN_BITS);
 
   /** Add @sample to the histogram.
    *

--- a/src/tscore/unit_tests/test_Histogram.cc
+++ b/src/tscore/unit_tests/test_Histogram.cc
@@ -45,7 +45,7 @@ TEST_CASE("Histogram Basic", "[libts][histogram]")
   REQUIRE(h.min_for_bucket(16) == 32);
   REQUIRE(h.min_for_bucket(17) == 40);
 
-  for (auto x : {0, 1, 4, 6, 19, 27, 36, 409, 16000, 1097}) {
+  for (auto x : {0, 1, 4, 6, 19, 27, 36, 409, 16000, 1097, 512}) {
     h(x);
   }
   REQUIRE(h[0] == 1);


### PR DESCRIPTION
The loop in Histogram::operator() is infinite if R = 7, S = 2, and sample = 512.