### PR TITLE
Cleanup: Redundant definition of cache_bytes_used

### DIFF
--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -122,21 +122,6 @@ force_link_CacheTestCaller()
 }
 #endif
 
-// ToDo: This gets called as part of librecords collection continuation, probably change this later.
-inline int64_t
-cache_bytes_used(int index)
-{
-  if (!DISK_BAD(gstripes[index]->disk)) {
-    if (!gstripes[index]->header->cycle) {
-      return gstripes[index]->header->write_pos - gstripes[index]->start;
-    } else {
-      return gstripes[index]->len - gstripes[index]->dirlen() - EVACUATION_SIZE;
-    }
-  }
-
-  return 0;
-}
-
 static int
 validate_rww(int new_value)
 {


### PR DESCRIPTION
It looks like a piece of code dropped from https://github.com/apache/trafficserver/commit/74f1a5d2a1eec78f7b50ab5ad36c40931523196d.