### PR TITLE
http2: use exponential backoff for restarting streams when going past watermark

### DIFF
--- a/include/proxy/http2/Http2ConnectionState.h
+++ b/include/proxy/http2/Http2ConnectionState.h
@@ -388,6 +388,9 @@ private:
    * acknowledged by the peer. */
   std::queue<OutstandingSettingsFrame> _outstanding_settings_frames;
 
+  static constexpr const int DATA_EVENT_BACKOFF_START = 10;
+  static constexpr const int DATA_EVENT_BACKOFF_MAX   = 1000;
+
   // NOTE: Id of stream which MUST receive CONTINUATION frame.
   //   - [RFC 7540] 6.2 HEADERS
   //     "A HEADERS frame without the END_HEADERS flag set MUST be followed by a
@@ -399,6 +402,8 @@ private:
   bool               fini_received       = false;
   bool               in_destroy          = false;
   int                recursion           = 0;
+  int                _data_event_backoff = DATA_EVENT_BACKOFF_START;
+  bool               _data_event_retry   = false;
   Http2ShutdownState shutdown_state      = HTTP2_SHUTDOWN_NONE;
   Http2ErrorCode     shutdown_reason     = Http2ErrorCode::HTTP2_ERROR_MAX;
   Event             *shutdown_cont_event = nullptr;


### PR DESCRIPTION
In production we were seeing a huge increase in the number of events processed and tracked it down to this
`HTTP2_SESSION_EVENT_DATA` event.  This PR adds an exponential backoff to the retries to try to find a retry period that matches the read rate of the client.  The adjusted backoff will remain for the life of the connection.

