### PR TITLE
Event loop sub-stats

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/eventloop.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/eventloop.en.rst
@@ -80,6 +80,21 @@ high then it is likely transactions are experiencing significant latency.
 
     The maximum amount of time spent in a single loop in the last 10 seconds.
 
+.. ts:stat:: global proxy.process.eventloop.drain.queue.max.10s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent draining the event queue in a single loop in the last 10 seconds.
+
+.. ts:stat:: global proxy.process.eventloop.io.wait.max.10s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent waiting for network IO in a single loop in the last 10 seconds.
+
+.. ts:stat:: global proxy.process.eventloop.io.work.max.10s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent processing network IO in a single loop in the last 10 seconds.
+
 .. rubric:: 100 Second Metrics
 
 .. ts:stat:: global proxy.process.eventloop.count.100s integer
@@ -113,6 +128,21 @@ high then it is likely transactions are experiencing significant latency.
 
     The maximum amount of time spent in a single loop in the last 100 seconds.
 
+.. ts:stat:: global proxy.process.eventloop.drain.queue.max.100s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent draining the event queue in a single loop in the last 100 seconds.
+
+.. ts:stat:: global proxy.process.eventloop.io.wait.max.100s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent waiting for network IO in a single loop in the last 100 seconds.
+
+.. ts:stat:: global proxy.process.eventloop.io.work.max.100s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent processing network IO in a single loop in the last 100 seconds.
+
 .. rubric:: 1000 Second Metrics
 
 .. ts:stat:: global proxy.process.eventloop.count.1000s integer
@@ -145,6 +175,21 @@ high then it is likely transactions are experiencing significant latency.
     :units: nanoseconds
 
     The maximum amount of time spent in a single loop in the last 1000 seconds.
+
+.. ts:stat:: global proxy.process.eventloop.drain.queue.max.1000s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent draining the event queue in a single loop in the last 1000 seconds.
+
+.. ts:stat:: global proxy.process.eventloop.io.wait.max.1000s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent waiting for network IO in a single loop in the last 1000 seconds.
+
+.. ts:stat:: global proxy.process.eventloop.io.work.max.1000s integer
+   :units: nanoseconds
+
+    The maximum amount of time spent processing network IO in a single loop in the last 1000 seconds.
 
 .. rubric:: Histogram Metrics
 

--- a/src/iocore/eventsystem/UnixEThread.cc
+++ b/src/iocore/eventsystem/UnixEThread.cc
@@ -45,9 +45,12 @@ struct AIOCallback;
 
 // !! THIS MUST BE IN THE ENUM ORDER !!
 char const *const EThread::Metrics::Slice::STAT_NAME[] = {
-  "proxy.process.eventloop.count",      "proxy.process.eventloop.events", "proxy.process.eventloop.events.min",
-  "proxy.process.eventloop.events.max", "proxy.process.eventloop.wait",   "proxy.process.eventloop.time.min",
-  "proxy.process.eventloop.time.max"};
+  "proxy.process.eventloop.count",       "proxy.process.eventloop.events",
+  "proxy.process.eventloop.events.min",  "proxy.process.eventloop.events.max",
+  "proxy.process.eventloop.wait",        "proxy.process.eventloop.time.min",
+  "proxy.process.eventloop.time.max",    "proxy.process.eventloop.drain.queue.max",
+  "proxy.process.eventloop.io.wait.max", "proxy.process.eventloop.io.work.max",
+};
 
 int thread_max_heartbeat_mseconds = THREAD_MAX_HEARTBEAT_MSECONDS;
 
@@ -297,6 +300,10 @@ EThread::execute_regular()
       sleep_time = 0;
     }
 
+    // drained the queue by this point
+    ink_hrtime post_drain  = ink_get_hrtime();
+    ink_hrtime drain_queue = post_drain - loop_start_time;
+
     tail_cb->waitForActivity(sleep_time);
 
     // loop cleanup
@@ -309,6 +316,7 @@ EThread::execute_regular()
     metrics.decay();
     metrics.record_loop_time(delta);
     current_slice->record_event_count(ev_count);
+    current_slice->record_drain_queue(drain_queue);
   }
 }
 
@@ -364,13 +372,16 @@ EThread::execute()
 EThread::Metrics::Slice &
 EThread::Metrics::Slice::operator+=(Slice const &that)
 {
-  this->_events._max    = std::max(this->_events._max, that._events._max);
-  this->_events._min    = std::min(this->_events._min, that._events._min);
-  this->_events._total += that._events._total;
-  this->_duration._min  = std::min(this->_duration._min, that._duration._min);
-  this->_duration._max  = std::max(this->_duration._max, that._duration._max);
-  this->_count         += that._count;
-  this->_wait          += that._wait;
+  this->_events._max                = std::max(this->_events._max, that._events._max);
+  this->_events._min                = std::min(this->_events._min, that._events._min);
+  this->_events._total             += that._events._total;
+  this->_duration._min              = std::min(this->_duration._min, that._duration._min);
+  this->_duration._max              = std::max(this->_duration._max, that._duration._max);
+  this->_count                     += that._count;
+  this->_wait                      += that._wait;
+  this->_duration._max_drain_queue  = std::max(this->_duration._max_drain_queue, that._duration._max_drain_queue);
+  this->_duration._max_io_wait      = std::max(this->_duration._max_io_wait, that._duration._max_io_wait);
+  this->_duration._max_io_work      = std::max(this->_duration._max_io_work, that._duration._max_io_work);
   return *this;
 }
 

--- a/src/iocore/eventsystem/UnixEventProcessor.cc
+++ b/src/iocore/eventsystem/UnixEventProcessor.cc
@@ -118,6 +118,9 @@ EventMetricStatSync(const char *, RecDataT, RecData *, RecRawStatBlock *rsb, int
     slice_stat_update(ID::LOOP_EVENTS, id, slice->_events._total);
     slice_stat_update(ID::LOOP_EVENTS_MIN, id, slice->_events._min);
     slice_stat_update(ID::LOOP_EVENTS_MAX, id, slice->_events._max);
+    slice_stat_update(ID::LOOP_DRAIN_QUEUE_MAX, id, slice->_duration._max_drain_queue);
+    slice_stat_update(ID::LOOP_IO_WAIT_MAX, id, slice->_duration._max_io_wait);
+    slice_stat_update(ID::LOOP_IO_WORK_MAX, id, slice->_duration._max_io_work);
   }
 
   // Next are the event loop histogram buckets.

--- a/src/iocore/net/NetHandler.cc
+++ b/src/iocore/net/NetHandler.cc
@@ -357,8 +357,11 @@ NetHandler::waitForActivity(ink_hrtime timeout)
 #endif
 
   // Polling event by PollCont
-  PollCont *p = get_PollCont(this->thread);
+  PollCont  *p        = get_PollCont(this->thread);
+  ink_hrtime pre_poll = ink_get_hrtime();
   p->do_poll(timeout);
+  ink_hrtime post_poll = ink_get_hrtime();
+  ink_hrtime poll_time = post_poll - pre_poll;
 
   // Get & Process polling result
   PollDescriptor *pd = get_PollDescriptor(this->thread);
@@ -372,6 +375,10 @@ NetHandler::waitForActivity(ink_hrtime timeout)
   pd->result = 0;
 
   process_ready_list();
+  ink_hrtime post_process = ink_get_hrtime();
+  ink_hrtime process_time = post_process - post_poll;
+  this->thread->metrics.current_slice.load(std::memory_order_acquire)->record_io_stats(poll_time, process_time);
+
 #if TS_USE_LINUX_IO_URING
   ur->service();
 #endif


### PR DESCRIPTION
Introduces additional tracking of the 3 major subsections of an event loop: draining the event queue, polling for io events, and processing the ready list once populated. Each referred to as drain_queue, io_wait, and io_work.

I've been tracking these stats on top of the base event loop time stat to get a better idea of the cause in the event of increasing loop times. Increasing time to drain the event queue, for instance, would have a different cause and potentially different action, compared with if there was an increase in the time spent processing io.

New Stats:
        `LOOP_DRAIN_QUEUE_MAX, ///< Max time Draining the event queue`
        `LOOP_IO_WAIT_MAX,     ///< Min time spent IO waiting`
        `LOOP_IO_WORK_MAX,     ///< Max time spent IO processing`

