### PR TITLE
ja3_fingerprint: add --preserve option

### DIFF
--- a/doc/admin-guide/plugins/ja3_fingerprint.en.rst
+++ b/doc/admin-guide/plugins/ja3_fingerprint.en.rst
@@ -75,6 +75,19 @@ or :file:`remap.config`.
    This option is only useful when the plugin is configured as a global plugin. By default this
    is not enabled.
 
+.. option:: --preserve
+
+   There may be situations in a network where there are multiple proxies handling the same requests.
+   In these situations, each proxy may be configured to add ja* header fields. By default, |TS| will
+   append the ``;`` separated signature values to the already existing header fields characteristic
+   of the client-side connection for the given proxy in the chain. However, it may be that only the
+   signatures for the proxy closest to the client are interesting for fingerprinting and no other
+   signatures are desired to be appended to the fields. In these situations, this option causes the
+   plugin to inspect the request to see whether the ja header field already exists, and, if so, no
+   further signatures are added to the field value.
+
+   By default this is not enabled.
+
 Requirement
 =============
 

--- a/plugins/ja3_fingerprint/README
+++ b/plugins/ja3_fingerprint/README
@@ -27,6 +27,11 @@ Add flag --modify-incoming if it is desired that the plugin modify the incoming
     plugin) not as a remap plugin.  This is because remap plugins by definition
     are enaged upon remap completion and by that point it is too late to
     meaningfully modify the client request headers.
+Add flag --preserve for situations where there may be multiple proxies
+    handling a request and the first one, the one closest to the client, is
+    the one whose ja value is the most useful. If --preserve is used, then ja
+    values are not appended to already existing values in the request. By
+    default, ja header field values are appened if one exists already.
 
 3. plugin.config
 In plugin.config, supply name of the plugin and any desired options. For example:

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_global.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_global.replay.yaml
@@ -80,6 +80,7 @@ sessions:
         - [ content-type, image/jpeg ]
         - [ uuid, http2-request ]
         - [ x-request, http2-request ]
+        - [ x-ja3-raw, first-signature ]
       content:
         size: 399
 

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-proxy.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-incoming-proxy.gold
@@ -1,9 +1,6 @@
 +++++++++ Proxy's Request after hooks +++++++++
 -- State Machine Id``
 POST /some/path/http2``
-Host: ``
-Content-Type: ``
-uuid: ``
-x-request: ``
+``
 x-ja3-sig: ``
 ``

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-proxy.gold
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/modify-sent-proxy.gold
@@ -1,13 +1,6 @@
 +++++++++ Proxy's Request after hooks +++++++++
 -- State Machine Id``
 POST /some/path/http2``
-Host: ``
-Content-Type: ``
-uuid: ``
-x-request: ``
-Client-ip: ``
-X-Forwarded-For: ``
-Via: ``
-Transfer-Encoding: ``
+``
 x-ja3-sig: ``
 ``


### PR DESCRIPTION
Add the --preserve option to ja3_fingerprint such that any ja* fields already existing are not appended with new values. This is useful in situations where there are multiple proxies adding ja headers and the one of greatest interest is the outermost edge proxy (presumably, the one closest to the client).