### PR TITLE
hostdb: remove latency with cache misses

### DIFF
--- a/src/iocore/hostdb/P_HostDBProcessor.h
+++ b/src/iocore/hostdb/P_HostDBProcessor.h
@@ -197,6 +197,24 @@ struct HostDBHash {
   {
     return this->set_host(swoc::TextView{name, strlen(name)});
   }
+
+  bool
+  is_byname() const
+  {
+    return db_mark == HOSTDB_MARK_IPV4 || db_mark == HOSTDB_MARK_IPV6;
+  }
+
+  bool
+  is_srv() const
+  {
+    return db_mark == HOSTDB_MARK_SRV;
+  }
+
+  bool
+  is_reverse() const
+  {
+    return !is_byname() && !is_srv();
+  }
 };
 
 //
@@ -239,23 +257,6 @@ struct HostDBContinuation : public Continuation {
   /// Recompute the hash and update ancillary values.
   void refresh_hash();
   void do_dns();
-  bool
-  is_byname()
-  {
-    return hash.db_mark == HOSTDB_MARK_IPV4 || hash.db_mark == HOSTDB_MARK_IPV6;
-  }
-  bool
-  is_srv()
-  {
-    return hash.db_mark == HOSTDB_MARK_SRV;
-  }
-
-  bool
-  is_reverse()
-  {
-    return !is_byname() && !is_srv();
-  }
-
   Ptr<HostDBRecord>
   lookup_done(const char *query_name, ts_seconds answer_ttl, SRVHosts *s = nullptr, Ptr<HostDBRecord> record = Ptr<HostDBRecord>{})
   {


### PR DESCRIPTION
If hostdb suffers a cache miss, it would schedule a continuation to process the dns lookup.  Unfortunately, at some point in time, this event was scheduled with a delay instead of immediately.  This PR restores that and saves 20ms on a dns lookup.

Also, if the probe request could be fulfilled by parsing an IP or the hostfile, this was also delayed by the same 20ms.  This PR also moves those two checks to probe-time rather than dns lookup time (neither require IO).

coauthored by: @moonchen 
