### PR TITLE
ja3_fingerprint.test.py: address race condition

### DIFF
--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint.test.py
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint.test.py
@@ -134,7 +134,11 @@ class JA3FingerprintTest:
         """
         name = f'client{self._client_counter}'
         p = tr.AddVerifierClientProcess(
-            name, self._replay_file, http_ports=[self._ts.Variables.port], https_ports=[self._ts.Variables.ssl_port])
+            name,
+            self._replay_file,
+            http_ports=[self._ts.Variables.port],
+            https_ports=[self._ts.Variables.ssl_port],
+            other_args='--thread-limit 1')
         JA3FingerprintTest._client_counter += 1
 
         p.StartBefore(self._dns)


### PR DESCRIPTION
ja3_fingerprint.test.py uses the Proxy Verifier client and configures it with two sessions/connections. By default, Proxy Verifier will run the transactions for those two connections in parallel. Generally the first HTTP/1 session will finish before the second HTTP/2 session, but sometimes the second session finished first. That causes the test to fail because the gold file expects the other order. This patch addresses this race condition issue by simply configuring the client to run the sessions in serial rather than in parallel.