### PR TITLE
Only include TestBox.h if needed

### DIFF
--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -29,8 +29,6 @@
 #include "swoc/BufferWriter.h"
 #include "swoc/bwf_base.h"
 
-#include "tscore/TestBox.h"
-
 #include "tsutil/Convert.h"
 
 #include "P_SSLUtils.h"
@@ -527,6 +525,8 @@ SSLContextStorage::lookup(const std::string &name)
 }
 
 #if TS_HAS_TESTS
+
+#include "tscore/TestBox.h"
 
 static char *
 reverse_dns_name(const char *hostname, char (&reversed)[TS_MAX_HOST_NAME_LEN + 1])

--- a/src/proxy/logging/LogObject.cc
+++ b/src/proxy/logging/LogObject.cc
@@ -35,7 +35,6 @@
 #include "proxy/logging/LogConfig.h"
 #include "proxy/logging/LogAccess.h"
 #include "proxy/logging/Log.h"
-#include "tscore/TestBox.h"
 
 #include <algorithm>
 #include <vector>
@@ -1393,6 +1392,7 @@ LogObjectManager::flush_all_objects()
 }
 
 #if TS_HAS_TESTS
+#include "tscore/TestBox.h"
 
 static LogObject *
 MakeTestLogObject(const char *name)


### PR DESCRIPTION
This silences some linter warnings about unused includes when regression tests are disabled.