### PR TITLE
Fix libswoc compile with clang 20

### DIFF
--- a/lib/swoc/include/swoc/DiscreteRange.h
+++ b/lib/swoc/include/swoc/DiscreteRange.h
@@ -464,7 +464,7 @@ template <typename T>
 auto
 DiscreteRange<T>::relationship(self_type const &that) const -> Relation {
   Relation retval = Relation::NONE;
-  if (this->has_intersection(that)) {
+  if (this->has_intersection_with(that)) {
     if (*this == that)
       retval = Relation::EQUAL;
     else if (this->is_subset_of(that))
@@ -568,7 +568,7 @@ DiscreteRange<T>::max() const {
 template <typename T>
 bool
 DiscreteRange<T>::has_union(DiscreteRange::self_type const &that) const {
-  return this->has_intersection(that) || this->is_adjacent_to(that);
+  return this->has_intersection_with(that) || this->is_adjacent_to(that);
 }
 
 template <typename T>
@@ -644,7 +644,7 @@ operator!=(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
 template <typename T>
 bool
 operator^(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return lhs.has_intersection(rhs);
+  return lhs.has_intersection_with(rhs);
 }
 
 /** Containment ordering.

--- a/lib/swoc/include/swoc/Vectray.h
+++ b/lib/swoc/include/swoc/Vectray.h
@@ -248,7 +248,7 @@ template <typename T, size_t N, class A> template <size_t M> Vectray<T, N, A>::V
     if (span.size() > N) {
     } else {
       for (auto &&item : span) {
-        this->template emplace_back(std::move(item));
+        this->template emplace_back<T, N, A>(std::move(item));
       }
     }
   }
@@ -287,7 +287,7 @@ Vectray<T, N, A>::operator[](size_type idx) {
 template <typename T, size_t N, typename A>
 T const &
 Vectray<T, N, A>::operator[](size_type idx) const {
-  return this->items[idx];
+  return this->items()[idx];
 }
 
 template <typename T, size_t N, typename A>


### PR DESCRIPTION
- Fix incorrect method name has_intersection (should be has_intersection_with).
- template keyword on a method call causes a warning if template arguments are not supplied.