### PR TITLE
multiplexer: support request bodies from non-POST/PUT

### DIFF
--- a/plugins/multiplexer/ats-multiplexer.cc
+++ b/plugins/multiplexer/ats-multiplexer.cc
@@ -158,7 +158,7 @@ DoRemap(const Instance &i, TSHttpTxn t)
     generateRequests(i.origins, buffer, location, requests);
     assert(requests.size() == i.origins.size());
 
-    if (is_post_or_put) {
+    if (is_post_or_put || content_length > 0) {
       const TSVConn vconnection = TSTransformCreate(handlePost, t);
       assert(vconnection != nullptr);
       PostState *state = new PostState(requests, content_length);

--- a/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
+++ b/tests/gold_tests/pluginTest/multiplexer/multiplexer.test.py
@@ -99,6 +99,18 @@ class MultiplexerTestBase:
         self.server_https.Streams.All += Testers.ExcludesExpression(
             'uuid: CHUNKED_POST', 'We do not expect a multiplexed chunked POST.')
 
+        # Verify that the CUSTOM_METHOD is sent to all servers.
+        self.server_origin.Streams.All += Testers.ContainsExpression(
+            'uuid: MYCUSTOMMETHOD', "Verify the client's original target received the MYCUSTOMMETHOD transaction.")
+        self.server_http.Streams.All += Testers.ContainsExpression(
+            'uuid: MYCUSTOMMETHOD', "Verify the HTTP server received the MYCUSTOMMETHOD request.")
+        self.server_http.Streams.All += Testers.ContainsExpression(
+            'x-response: fifth', "Verify the HTTP server sent the MYCUSTOMMETHOD response.")
+        self.server_https.Streams.All += Testers.ContainsExpression(
+            'uuid: MYCUSTOMMETHOD', "Verify the HTTPS server received the MYCUSTOMMETHOD request.")
+        self.server_https.Streams.All += Testers.ContainsExpression(
+            'x-response: fifth', "Verify the HTTPS server sent the MYCUSTOMMETHOD response.")
+
         # Verify that the HTTPS server receives a TLS connection.
         self.server_https.Streams.All += Testers.ContainsExpression(
             'Finished accept using TLSSession', "Verify the HTTPS was indeed used by the HTTPS server.")
@@ -172,11 +184,19 @@ class MultiplexerTest(MultiplexerTestBase):
             'x-response: second', "Verify the HTTP server sent the POST response.")
         self.server_https.Streams.All += Testers.ContainsExpression(
             'x-response: second', "Verify the HTTPS server sent the POST response.")
+        self.server_https.Streams.All += Testers.ContainsExpression(
+            'x-response: fifth', "Verify the HTTPS server sent the custom method response.")
 
         # Same with PUT
         self.server_http.Streams.All += Testers.ContainsExpression('uuid: PUT', "Verify the HTTP server received the PUT request.")
         self.server_https.Streams.All += Testers.ContainsExpression(
             'uuid: PUT', "Verify the HTTPS server received the PUT request.")
+
+        # Same with MYCUSTOMMETHOD
+        self.server_http.Streams.All += Testers.ContainsExpression(
+            'uuid: MYCUSTOMMETHOD', "Verify the HTTP server received the custom method request.")
+        self.server_https.Streams.All += Testers.ContainsExpression(
+            'uuid: MYCUSTOMMETHOD', "Verify the HTTPS server received the custom method request.")
 
 
 class MultiplexerSkipPostTest(MultiplexerTestBase):

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy.replay.yaml
@@ -111,3 +111,32 @@ sessions:
 
     # There is no client since this response terminates at ATS, so no need for
     # proxy-response.
+
+  - client-request:
+      method: "MYCUSTOMMETHOD"
+      version: "1.1"
+      url: /path/mycustommethod
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 8 ]
+        - [ X-Request, second ]
+        - [ uuid, MYCUSTOMMETHOD ]
+
+    proxy-request:
+      method: "MYCUSTOMMETHOD"
+      headers:
+        fields:
+        - [ X-Request, { value: fifth, as: equal } ]
+        - [ X-Multiplexer, { value: copy, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, fifth ]
+
+    # There is no client since this response terminates at ATS, so no need for
+    # proxy-response.

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy_skip_post.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy_skip_post.replay.yaml
@@ -53,3 +53,32 @@ sessions:
 
     # Since POST and POST requests are skipped, the multiplexed hosts should
     # not receive them.
+
+  - client-request:
+      method: "MYCUSTOMMETHOD"
+      version: "1.1"
+      url: /path/mycustommethod
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 8 ]
+        - [ X-Request, second ]
+        - [ uuid, MYCUSTOMMETHOD ]
+
+    proxy-request:
+      method: "MYCUSTOMMETHOD"
+      headers:
+        fields:
+        - [ X-Request, { value: fifth, as: equal } ]
+        - [ X-Multiplexer, { value: copy, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, fifth ]
+
+    # There is no client since this response terminates at ATS, so no need for
+    # proxy-response.

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original.replay.yaml
@@ -156,3 +156,36 @@ sessions:
       headers:
         fields:
         - [ X-Response, { value: fourth, as: equal } ]
+
+  # Custom method with body.
+  - client-request:
+      method: "MYCUSTOMMETHOD"
+      version: "1.1"
+      url: /path/mycustommethod
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 320000 ]
+        - [ X-Request, fifth ]
+        - [ uuid, MYCUSTOMMETHOD ]
+
+    proxy-request:
+      method: "MYCUSTOMMETHOD"
+      headers:
+        fields:
+        - [ X-Request, { value: fifth, as: equal } ]
+        - [ X-Multiplexer, { value: original, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, fifth ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, { value: fifth, as: equal } ]

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original_skip_post.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original_skip_post.replay.yaml
@@ -156,3 +156,36 @@ sessions:
       headers:
         fields:
         - [ X-Response, { value: fourth, as: equal } ]
+
+ # Custom method with body. Should not be skipped because it is neither a PUT or POST.
+  - client-request:
+      method: "MYCUSTOMMETHOD"
+      version: "1.1"
+      url: /path/mycustommethod
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 320000 ]
+        - [ X-Request, fifth ]
+        - [ uuid, MYCUSTOMMETHOD ]
+
+    proxy-request:
+      method: "MYCUSTOMMETHOD"
+      headers:
+        fields:
+        - [ X-Request, { value: fifth, as: equal } ]
+        - [ X-Multiplexer, { value: original, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, fifth ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, { value: fifth, as: equal } ]


### PR DESCRIPTION
This updates the multiplexer plugin to support request bodies from non-POST and PUT methods. As long as they are Content-Length requests.