### PR TITLE
TS API: TSVConnSslSniGet sets 0 as length if it returns nullptr

### DIFF
--- a/doc/developer-guide/api/functions/TSVConnSslSniGet.en.rst
+++ b/doc/developer-guide/api/functions/TSVConnSslSniGet.en.rst
@@ -32,3 +32,5 @@ Synopsis
 Description
 -----------
 Get the SNI (Server Name Indication) that corresponds to SSL connection :arg:`sslp`.
+
+If :arg:`length` is not null, the length of the returned string (or 0 if this function returns null) will be stored.

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -7929,6 +7929,9 @@ const char *
 TSVConnSslSniGet(TSVConn sslp, int *length)
 {
   if (sslp == nullptr) {
+    if (length) {
+      *length = 0;
+    }
     return nullptr;
   }
 


### PR DESCRIPTION
The change was suggested on #11745.