### PR TITLE
quic: Enable quiche debug logging only if debug tag vv_quiche is set

### DIFF
--- a/src/iocore/net/QUICNetProcessor.cc
+++ b/src/iocore/net/QUICNetProcessor.cc
@@ -86,7 +86,9 @@ QUICNetProcessor::start(int, size_t /* stacksize ATS_UNUSED */)
   QUICCertConfig::startup();
   QUICConfig::scoped_config params;
 
-  quiche_enable_debug_logging(debug_log, NULL);
+  if (dbg_ctl_vv_quiche.tag_on()) {
+    quiche_enable_debug_logging(debug_log, NULL);
+  }
   this->_quiche_config = quiche_config_new(QUICHE_PROTOCOL_VERSION);
 
   std::string quic_app_protos = "\02h3\x05h3-29\x05h3-27";


### PR DESCRIPTION
Although current code prevents printing debug log if the debug tag, `vv_quiche`, is not set (or ATS debug log is disabled), quiche generates debug log internally anyway if `quiche_enable_debug_logging` is called.

ATS has to be restarted to enable quiche debug logging, but you'd never want to enable it where restarting is going to be a problem.