### PR TITLE
http3: Remove an unnecessary copy

### DIFF
--- a/include/proxy/http3/Http3Frame.h
+++ b/include/proxy/http3/Http3Frame.h
@@ -85,20 +85,19 @@ class Http3DataFrame : public Http3Frame
 public:
   Http3DataFrame() : Http3Frame() {}
   Http3DataFrame(IOBufferReader &reader);
-  Http3DataFrame(ats_unique_buf payload, size_t payload_len);
+  Http3DataFrame(IOBufferReader &reader, size_t payload_len);
 
   Ptr<IOBufferBlock> to_io_buffer_block() const override;
   void               reset(IOBufferReader &reader) override;
 
-  const uint8_t *payload() const;
-  uint64_t       payload_length() const;
+  uint64_t payload_length() const;
 
   IOBufferReader *data() const;
 
 private:
-  const uint8_t *_payload      = nullptr;
-  ats_unique_buf _payload_uptr = {nullptr};
-  size_t         _payload_len  = 0;
+  // Head of IOBufferBlock chain to send
+  Ptr<IOBufferBlock> _whole_frame;
+  uint64_t           _payload_len = 0;
 };
 
 //
@@ -251,7 +250,6 @@ public:
   /*
    * Creates a DATA frame.
    */
-  static Http3DataFrameUPtr create_data_frame(const uint8_t *data, size_t data_len);
   static Http3DataFrameUPtr create_data_frame(IOBufferReader *reader, size_t data_len);
 
 private:

--- a/src/proxy/http3/test/test_Http3Frame.cc
+++ b/src/proxy/http3/test/test_Http3Frame.cc
@@ -75,11 +75,12 @@ TEST_CASE("Store DATA Frame", "[http3]")
       0x11, 0x22, 0x33, 0x44, // Payload
     };
 
-    uint8_t        raw1[]   = "\x11\x22\x33\x44";
-    ats_unique_buf payload1 = ats_unique_malloc(4);
-    memcpy(payload1.get(), raw1, 4);
-
-    Http3DataFrame data_frame(std::move(payload1), 4);
+    uint8_t    raw1[]   = "\x11\x22\x33\x44";
+    MIOBuffer *payload1 = new_MIOBuffer(BUFFER_SIZE_INDEX_8K);
+    payload1->set(raw1, 4);
+    IOBufferReader *payload1_reader = payload1->alloc_reader();
+    Http3DataFrame  data_frame(*payload1_reader, 4);
+    free_MIOBuffer(payload1);
     CHECK(data_frame.length() == 4);
 
     auto           ibb = data_frame.to_io_buffer_block();


### PR DESCRIPTION
This uses more IOBufferBlocks, but it wouldn't be problematic unlike H2 because the size of Data frame is much larger than H2.