### PR TITLE
Add const to cripts formatter format functions

### DIFF
--- a/include/cripts/Crypto.hpp
+++ b/include/cripts/Crypto.hpp
@@ -275,7 +275,7 @@ template <> struct formatter<cripts::Crypto::SHA256> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Crypto::SHA256 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Crypto::SHA256 &sha, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
@@ -290,7 +290,7 @@ template <> struct formatter<cripts::Crypto::SHA512> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Crypto::SHA512 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Crypto::SHA512 &sha, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", sha.Hex());
   }
@@ -305,7 +305,7 @@ template <> struct formatter<cripts::Crypto::AES256> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Crypto::AES256 &sha, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Crypto::AES256 &sha, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", cripts::Crypto::Base64::Encode(sha.Message()));
   }

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -525,7 +525,7 @@ template <> struct formatter<cripts::Header::Method> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Header::Method &method, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Header::Method &method, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", method.GetSV());
   }
@@ -540,7 +540,7 @@ template <> struct formatter<cripts::Header::String> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Header::String &str, FormatContext &ctx) -> decltype(ctx.out())
+  format(const cripts::Header::String &str, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", str.GetSV());
   }
@@ -555,7 +555,7 @@ template <> struct formatter<cripts::Header::Name> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Header::Name &name, FormatContext &ctx) -> decltype(ctx.out())
+  format(const cripts::Header::Name &name, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", name.GetSV());
   }

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -549,7 +549,7 @@ template <> struct formatter<cripts::Versions> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Versions &version, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions &version, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", version.GetSV());
   }
@@ -564,7 +564,7 @@ template <> struct formatter<cripts::Versions::Major> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Versions::Major &major, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions::Major &major, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(major));
   }
@@ -579,7 +579,7 @@ template <> struct formatter<cripts::Versions::Minor> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Versions::Minor &minor, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions::Minor &minor, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(minor));
   }
@@ -594,7 +594,7 @@ template <> struct formatter<cripts::Versions::Patch> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Versions::Patch &patch, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Versions::Patch &patch, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(patch));
   }
@@ -609,7 +609,7 @@ template <> struct formatter<TSHttpStatus> {
 
   template <typename FormatContext>
   auto
-  format(const TSHttpStatus &stat, FormatContext &ctx) -> decltype(ctx.out())
+  format(const TSHttpStatus &stat, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", static_cast<int>(stat));
   }

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -139,7 +139,7 @@ template <> struct formatter<cripts::Time::Local> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Time::Local &time, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Time::Local &time, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", time.Epoch());
   }

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -785,7 +785,7 @@ template <> struct formatter<cripts::Url::Scheme> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Url::Scheme &scheme, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Scheme &scheme, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", scheme.GetSV());
   }
@@ -800,7 +800,7 @@ template <> struct formatter<cripts::Url::Host> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Url::Host &host, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Host &host, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", host.GetSV());
   }
@@ -815,7 +815,7 @@ template <> struct formatter<cripts::Url::Port> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Url::Port &port, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Port &port, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", integer(port));
   }
@@ -830,7 +830,7 @@ template <> struct formatter<cripts::Url::Path::String> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Url::Path::String &path, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Path::String &path, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", path.GetSV());
   }
@@ -845,7 +845,7 @@ template <> struct formatter<cripts::Url::Path> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Url::Path &path, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Path &path, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", path.GetSV());
   }
@@ -860,7 +860,7 @@ template <> struct formatter<cripts::Url::Query::Parameter> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Url::Query::Parameter &param, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Query::Parameter &param, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", param.GetSV());
   }
@@ -875,7 +875,7 @@ template <> struct formatter<cripts::Url::Query> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Url::Query &query, FormatContext &ctx) -> decltype(ctx.out())
+  format(cripts::Url::Query &query, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", query.GetSV());
   }


### PR DESCRIPTION
This is needed to support newer libfmt