### PR TITLE
Reduce the number of calls for ERR_clear_error

### DIFF
--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -812,6 +812,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
 
   Dbg(dbg_ctl_ssl, "towrite=%" PRId64, towrite);
 
+  ERR_clear_error();
   do {
     // What is remaining left in the next block?
     l                   = buf.reader()->block_read_avail();
@@ -2491,7 +2492,6 @@ SSLNetVConnection::_ssl_write_buffer(const void *buf, int64_t nbytes, int64_t &n
   if (unlikely(nbytes == 0)) {
     return SSL_ERROR_NONE;
   }
-  ERR_clear_error();
 
   int ret;
   // If SSL_write_early_data is available, it's probably OpenSSL,


### PR DESCRIPTION
Since we check the error only after the loop, clearing error on each iteration does not make sense. Unlike the `errno`, the error variable in Open/BoringSSL is actually a queue so clearing it is not a trivial operation (`memset` and `free` are called inside).

I feel like we should check whether there was an error on each iteration and break out if necessary, but that's another issue. This is for (tiny) performance improvement.