### PR TITLE
header_rewrite: Fix condition parser

### DIFF
--- a/plugins/header_rewrite/condition.cc
+++ b/plugins/header_rewrite/condition.cc
@@ -43,13 +43,23 @@ parse_matcher_op(std::string &arg)
     break;
   case '/':
     arg.erase(0, 1);
-    arg.erase(arg.length() - 1, arg.length());
-    return MATCH_REGULAR_EXPRESSION;
+    // There should be a slash at the end
+    if (arg.length() >= 1 && arg[arg.length() - 1] == '/') {
+      arg.erase(arg.length() - 1, arg.length());
+      return MATCH_REGULAR_EXPRESSION;
+    } else {
+      return MATCH_ERROR;
+    }
     break;
   case '{':
     arg.erase(0, 1);
-    arg.erase(arg.length() - 1, arg.length());
-    return MATCH_IP_RANGES;
+    // There should be a right brace at the end
+    if (arg.length() >= 1 && arg[arg.length() - 1] == '}') {
+      arg.erase(arg.length() - 1, arg.length());
+      return MATCH_IP_RANGES;
+    } else {
+      return MATCH_ERROR;
+    }
   default:
     return MATCH_EQUAL;
     break;

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -236,6 +236,28 @@ test_parsing()
   }
 
   {
+    ParserTest p(R"(cond %{INBOUND:REMOTE-ADDR} {192.168.201.0/24,10.0.0.0/8})");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{INBOUND:REMOTE-ADDR}");
+    CHECK_EQ(p.getTokens()[2], "{192.168.201.0/24,10.0.0.0/8}");
+
+    END_TEST();
+  }
+
+  {
+    ParserTest p(R"(cond %{INBOUND:REMOTE-ADDR} { 192.168.201.0/24,10.0.0.0/8 })");
+
+    CHECK_EQ(p.getTokens().size(), 3UL);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{INBOUND:REMOTE-ADDR}");
+    CHECK_EQ(p.getTokens()[2], "{ 192.168.201.0/24,10.0.0.0/8 }");
+
+    END_TEST();
+  }
+
+  {
     ParserTest p("add-header X-HeaderRewriteApplied true");
 
     CHECK_EQ(p.getTokens().size(), 3UL);

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -39,6 +39,7 @@ enum MatcherOps {
   MATCH_GREATER_THEN,
   MATCH_REGULAR_EXPRESSION,
   MATCH_IP_RANGES,
+  MATCH_ERROR,
 };
 
 // Condition modifiers

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -88,7 +88,7 @@ Parser::parse_line(const std::string &original_line)
         _empty = true;
         return false;
       }
-    } else if ((state == PARSER_DEFAULT) && (line[i - 1] != '%' && line[i] == '{')) {
+    } else if ((state == PARSER_DEFAULT) && ((i == 0 || line[i - 1] != '%') && line[i] == '{')) {
       state            = PARSER_IN_BRACE;
       extracting_token = true;
       cur_token_start  = i;

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -28,7 +28,7 @@
 
 #include "parser.h"
 
-enum ParserState { PARSER_DEFAULT, PARSER_IN_QUOTE, PARSER_IN_REGEX, PARSER_IN_EXPANSION };
+enum ParserState { PARSER_DEFAULT, PARSER_IN_QUOTE, PARSER_IN_REGEX, PARSER_IN_EXPANSION, PARSER_IN_BRACE };
 
 bool
 Parser::parse_line(const std::string &original_line)
@@ -88,6 +88,15 @@ Parser::parse_line(const std::string &original_line)
         _empty = true;
         return false;
       }
+    } else if ((state == PARSER_DEFAULT) && (line[i - 1] != '%' && line[i] == '{')) {
+      state            = PARSER_IN_BRACE;
+      extracting_token = true;
+      cur_token_start  = i;
+    } else if ((state == PARSER_IN_BRACE) && (line[i] == '}')) {
+      cur_token_length = i - cur_token_start + 1;
+      _tokens.push_back(line.substr(cur_token_start, cur_token_length));
+      state            = PARSER_DEFAULT;
+      extracting_token = false;
     } else if (!extracting_token) {
       if (_tokens.empty() && line[i] == '#') {
         // this is a comment line (it may have had leading whitespace before the #)

--- a/plugins/header_rewrite/ruleset.cc
+++ b/plugins/header_rewrite/ruleset.cc
@@ -54,6 +54,11 @@ RuleSet::add_condition(Parser &p, const char *filename, int lineno)
               TSHttpHookNameLookup(_hook), p.get_op().c_str(), p.get_arg().c_str());
       return false;
     }
+    if (c->get_cond_op() == MATCH_ERROR) {
+      delete c;
+      TSError("[%s] in %s:%d: Invalid operator", PLUGIN_NAME, filename, lineno);
+      return false;
+    }
     if (nullptr == _cond) {
       _cond = c;
     } else {


### PR DESCRIPTION
This fixes #11776.

This change allows the spaces before/after the braces. It also prevents crashes even if there are syntax errors.