### PR TITLE
Add support for cert verification to QUIC

### DIFF
--- a/include/iocore/net/TLSBasicSupport.h
+++ b/include/iocore/net/TLSBasicSupport.h
@@ -48,9 +48,9 @@ public:
   ink_hrtime  get_tls_handshake_begin_time() const;
   ink_hrtime  get_tls_handshake_end_time() const;
   /**
-   * Returns a certificate that neeed to be verified.
+   * Returns a certificate that need to be verified.
    *
-   * Note: This function is only available during verify_certification is being called.
+   * Note: This function is only available when verify_certification is being called.
    * This function is probably just for TSVConnSslVerifyCTXGet.
    * We could (and probably should) pass a cert to verify as an argument of TS_EVENT_SSL_VERIFY_CLIENT/SERVER event.
    */

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -7950,10 +7950,10 @@ TSVConnSslSniGet(TSVConn sslp, int *length)
 TSSslVerifyCTX
 TSVConnSslVerifyCTXGet(TSVConn sslp)
 {
-  NetVConnection    *vc     = reinterpret_cast<NetVConnection *>(sslp);
-  SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
-  if (ssl_vc != nullptr) {
-    return reinterpret_cast<TSSslVerifyCTX>(ssl_vc->get_verify_cert());
+  NetVConnection  *vc    = reinterpret_cast<NetVConnection *>(sslp);
+  TLSBasicSupport *tlsbs = vc->get_service<TLSBasicSupport>();
+  if (tlsbs != nullptr) {
+    return reinterpret_cast<TSSslVerifyCTX>(tlsbs->get_tls_cert_to_verify());
   }
   return nullptr;
 }

--- a/src/iocore/net/P_QUICNetVConnection.h
+++ b/src/iocore/net/P_QUICNetVConnection.h
@@ -165,6 +165,7 @@ protected:
   // TLSBasicSupport
   SSL         *_get_ssl_object() const override;
   ssl_curve_id _get_tls_curve() const override;
+  int          _verify_certificate(X509_STORE_CTX *ctx) override;
 
   // TLSSNISupport
   in_port_t _get_local_port() override;
@@ -235,6 +236,9 @@ private:
 
   QUICStreamManager  *_stream_manager  = nullptr;
   QUICApplicationMap *_application_map = nullptr;
+
+  bool _is_verifying_cert = false;
+  bool _is_cert_verified  = false;
 };
 
 extern ClassAllocator<QUICNetVConnection> quicNetVCAllocator;

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -126,12 +126,6 @@ public:
     return retval;
   }
 
-  SSLHandshakeStatus
-  getSSLHandshakeStatus() const
-  {
-    return sslHandshakeStatus;
-  }
-
   bool
   getSSLHandShakeComplete() const override
   {
@@ -252,21 +246,6 @@ public:
   bool          protocol_mask_set = false;
   unsigned long protocol_mask     = 0;
 
-  // Only applies during the VERIFY certificate hooks (client and server side)
-  // Means to give the plugin access to the data structure passed in during the underlying
-  // openssl callback so the plugin can make more detailed decisions about the
-  // validity of the certificate in their cases
-  X509_STORE_CTX *
-  get_verify_cert()
-  {
-    return verify_cert;
-  }
-  void
-  set_verify_cert(X509_STORE_CTX *ctx)
-  {
-    verify_cert = ctx;
-  }
-
   bool
   peer_provided_cert() const override
   {
@@ -327,6 +306,7 @@ protected:
     return this->ssl;
   }
   ssl_curve_id _get_tls_curve() const override;
+  int          _verify_certificate(X509_STORE_CTX *ctx) override;
 
   // TLSSessionResumptionSupport
   const IpEndpoint &
@@ -375,8 +355,6 @@ private:
   int sent_cert = 0;
 
   int64_t redoWriteSize = 0;
-
-  X509_STORE_CTX *verify_cert = nullptr;
 
   // Null-terminated string, or nullptr if there is no SNI server name.
   std::unique_ptr<char[]> _ca_cert_file;

--- a/src/iocore/net/TLSBasicSupport.cc
+++ b/src/iocore/net/TLSBasicSupport.cc
@@ -166,6 +166,23 @@ TLSBasicSupport::set_valid_tls_version_max(int max)
   SSL_set_max_proto_version(ssl, ver);
 }
 
+int
+TLSBasicSupport::verify_certificate(X509_STORE_CTX *ctx)
+{
+  // See comments in SSLNetVConnection::_verify_certificate
+  this->_cert_to_verify = ctx;
+  int ret               = this->_verify_certificate(ctx);
+  this->_cert_to_verify = nullptr;
+
+  return ret;
+}
+
+X509_STORE_CTX *
+TLSBasicSupport::get_tls_cert_to_verify() const
+{
+  return this->_cert_to_verify;
+}
+
 void
 TLSBasicSupport::_record_tls_handshake_begin_time()
 {


### PR DESCRIPTION
This extends `TLSBasicSupport` to add the ability to verify certificates.

With this change, QUICNetVC supports the verification and we have one less dynamic_cast to SSLNetVC.