### PR TITLE
autest target: PYTHONPATH for remap_acl.test.py

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,9 +54,11 @@ add_custom_target(
   autest
   COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target install
   COMMAND ${RUNPIPENV} install
-  COMMAND ${RUNPIPENV} run env autest --directory ${CMAKE_CURRENT_SOURCE_DIR}/gold_tests
-          --ats-bin=${CMAKE_INSTALL_PREFIX}/bin --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root
-          ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX} ${AUTEST_OPTIONS}
+  COMMAND
+    ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/remap:$ENV{PYTHONPATH} ${RUNPIPENV} run
+    env autest --directory ${CMAKE_CURRENT_SOURCE_DIR}/gold_tests --ats-bin=${CMAKE_INSTALL_PREFIX}/bin
+    --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX}
+    ${AUTEST_OPTIONS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   USES_TERMINAL
 )
@@ -64,9 +66,11 @@ add_custom_target(
 add_custom_target(
   autest_no_install
   COMMAND ${RUNPIPENV} install
-  COMMAND ${RUNPIPENV} run env autest --directory ${CMAKE_CURRENT_SOURCE_DIR}/gold_tests
-          --ats-bin=${CMAKE_INSTALL_PREFIX}/bin --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root
-          ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX} ${AUTEST_OPTIONS}
+  COMMAND
+    ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/remap:$ENV{PYTHONPATH} ${RUNPIPENV} run
+    env autest --directory ${CMAKE_CURRENT_SOURCE_DIR}/gold_tests --ats-bin=${CMAKE_INSTALL_PREFIX}/bin
+    --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX}
+    ${AUTEST_OPTIONS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   USES_TERMINAL
 )


### PR DESCRIPTION
The autest.sh has updates for the PYTHONPATH to find the deactivate_ip_allow.py and all_acl_combinations.py files, but the cmake targets were not updated for these. This updates the cmake targets to set the PYTHONPATH to find these files.