### PR TITLE
Refactor the read and write functions in Unix and SSL NetVC

### DIFF
--- a/include/iocore/net/NetEvent.h
+++ b/include/iocore/net/NetEvent.h
@@ -55,9 +55,9 @@ class NetEvent
 public:
   NetEvent() = default;
   virtual ~NetEvent() {}
-  virtual void net_read_io(NetHandler *nh, EThread *lthread)  = 0;
-  virtual void net_write_io(NetHandler *nh, EThread *lthread) = 0;
-  virtual void free_thread(EThread *t)                        = 0;
+  virtual void net_read_io(NetHandler *nh)  = 0;
+  virtual void net_write_io(NetHandler *nh) = 0;
+  virtual void free_thread(EThread *t)      = 0;
 
   // since we want this class to be independent from VConnection, Continutaion. There should be
   // a pure virtual function which connect sub class and NetHandler.

--- a/src/iocore/net/NetHandler.cc
+++ b/src/iocore/net/NetHandler.cc
@@ -283,7 +283,7 @@ NetHandler::process_ready_list()
     if (ne->closed) {
       free_netevent(ne);
     } else if (ne->read.enabled && ne->read.triggered) {
-      ne->net_read_io(this, this->thread);
+      ne->net_read_io(this);
     } else if (!ne->read.enabled) {
       read_ready_list.remove(ne);
     }
@@ -293,7 +293,7 @@ NetHandler::process_ready_list()
     if (ne->closed) {
       free_netevent(ne);
     } else if (ne->write.enabled && ne->write.triggered) {
-      ne->net_write_io(this, this->thread);
+      ne->net_write_io(this);
     } else if (!ne->write.enabled) {
       write_ready_list.remove(ne);
     }

--- a/src/iocore/net/P_QUICNetVConnection.h
+++ b/src/iocore/net/P_QUICNetVConnection.h
@@ -108,7 +108,7 @@ public:
   bool    getSSLHandShakeComplete() const override;
 
   // NetEvent
-  virtual void net_read_io(NetHandler *nh, EThread *lthread) override;
+  virtual void net_read_io(NetHandler *nh) override;
 
   // NetVConnection
   int         populate_protocol(std::string_view *results, int n) const override;

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -140,7 +140,7 @@ public:
 
   int     sslServerHandShakeEvent(int &err);
   int     sslClientHandShakeEvent(int &err);
-  void    net_read_io(NetHandler *nh, EThread *lthread) override;
+  void    net_read_io(NetHandler *nh) override;
   int64_t load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf, int64_t &total_written, int &needs) override;
   void    do_io_close(int lerrno = -1) override;
 
@@ -376,7 +376,7 @@ private:
   UnixNetVConnection *_migrateFromSSL();
   void                _propagateHandShakeBuffer(UnixNetVConnection *target, EThread *t);
 
-  int         _ssl_read_from_net(EThread *lthread, int64_t &ret);
+  int         _ssl_read_from_net(int64_t &ret);
   ssl_error_t _ssl_read_buffer(void *buf, int64_t nbytes, int64_t &nread);
   ssl_error_t _ssl_write_buffer(const void *buf, int64_t nbytes, int64_t &nwritten);
   ssl_error_t _ssl_connect();

--- a/src/iocore/net/P_UnixNetVConnection.h
+++ b/src/iocore/net/P_UnixNetVConnection.h
@@ -150,8 +150,8 @@ public:
   }
 
   // NetEvent
-  virtual void net_read_io(NetHandler *nh, EThread *lthread) override;
-  virtual void net_write_io(NetHandler *nh, EThread *lthread) override;
+  virtual void net_read_io(NetHandler *nh) override;
+  virtual void net_write_io(NetHandler *nh) override;
   virtual void free_thread(EThread *t) override;
   virtual int
   close() override
@@ -195,7 +195,7 @@ public:
   int             readSignalAndUpdate(int event);
   void            readReschedule(NetHandler *nh);
   void            writeReschedule(NetHandler *nh);
-  void            netActivity(EThread *lthread);
+  void            netActivity();
   /**
    * If the current object's thread does not match the t argument, create a new
    * NetVC in the thread t context based on the socket and ssl information in the
@@ -233,8 +233,6 @@ public:
   void         set_remote_addr(const sockaddr *) override;
   int          set_tcp_congestion_control(int side) override;
   void         apply_options() override;
-
-  friend void write_to_net_io(NetHandler *, UnixNetVConnection *, EThread *);
 
   // set_context() should be called before calling this member function.
   void mark_as_tunnel_endpoint() override;
@@ -376,9 +374,3 @@ UnixNetVConnection::get_action() const
 {
   return &action_;
 }
-
-// declarations for local use (within the net module)
-
-void write_to_net(NetHandler *nh, UnixNetVConnection *vc, EThread *thread);
-void write_to_net_io(NetHandler *nh, UnixNetVConnection *vc, EThread *thread);
-void net_activity(UnixNetVConnection *vc, EThread *thread);

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -401,7 +401,7 @@ QUICNetVConnection::handle_received_packet(UDPPacket *packet)
 {
   size_t   buf_len{0};
   uint8_t *buf = packet->get_entire_chain_buffer(&buf_len);
-  net_activity(this, this_ethread());
+  this->netActivity();
   quiche_recv_info recv_info = {
     &packet->from.sa,
     static_cast<socklen_t>(packet->from.isIp4() ? sizeof(packet->from.sin) : sizeof(packet->from.sin6)),
@@ -522,7 +522,7 @@ QUICNetVConnection::is_handshake_completed() const
 }
 
 void
-QUICNetVConnection::net_read_io(NetHandler * /* nh ATS_UNUSED */, EThread * /* lthread ATS_UNUSED */)
+QUICNetVConnection::net_read_io(NetHandler * /* nh ATS_UNUSED */)
 {
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
   this->handleEvent(QUIC_EVENT_PACKET_READ_READY, nullptr);
@@ -714,7 +714,7 @@ QUICNetVConnection::_handle_write_ready()
       segment_size = max_udp_payload_size;
     }
     this->_packet_handler->send_packet(this->_udp_con, this->con.addr, udp_payload, segment_size, &send_at_hint);
-    net_activity(this, this_ethread());
+    this->netActivity();
   }
 }
 

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -178,7 +178,7 @@ debug_certificate_name(const char *msg, X509_NAME *name)
 }
 
 int
-SSLNetVConnection::_ssl_read_from_net(EThread *lthread, int64_t &ret)
+SSLNetVConnection::_ssl_read_from_net(int64_t &ret)
 {
   NetState          *s          = &this->read;
   MIOBufferAccessor &buf        = s->vio.buffer;
@@ -221,7 +221,7 @@ SSLNetVConnection::_ssl_read_from_net(EThread *lthread, int64_t &ret)
       bytes_read += nread;
       if (nread > 0) {
         buf.writer()->fill(nread); // Tell the buffer, we've used the bytes
-        this->netActivity(lthread);
+        this->netActivity();
       }
       break;
     case SSL_ERROR_WANT_WRITE:
@@ -275,7 +275,7 @@ SSLNetVConnection::_ssl_read_from_net(EThread *lthread, int64_t &ret)
     Dbg(dbg_ctl_ssl, "bytes_read=%" PRId64, bytes_read);
 
     s->vio.ndone += bytes_read;
-    this->netActivity(lthread);
+    this->netActivity();
 
     ret = bytes_read;
 
@@ -454,7 +454,7 @@ SSLNetVConnection::update_rbio(bool move_to_socket)
 
 // changed by YTS Team, yamsat
 void
-SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
+SSLNetVConnection::net_read_io(NetHandler *nh)
 {
   int       ret;
   int64_t   r     = 0;
@@ -462,11 +462,11 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
   NetState *s     = &this->read;
 
   if (HttpProxyPort::TRANSPORT_BLIND_TUNNEL == this->attributes) {
-    this->super::net_read_io(nh, lthread);
+    this->super::net_read_io(nh);
     return;
   }
 
-  MUTEX_TRY_LOCK(lock, s->vio.mutex, lthread);
+  MUTEX_TRY_LOCK(lock, s->vio.mutex, nh->thread);
   if (!lock.is_locked()) {
     readReschedule(nh);
     return;
@@ -475,7 +475,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
   // The closed flag should be stable once we get the s->vio.mutex in that case
   // (the global session pool mutex).
   if (this->closed) {
-    this->super::net_read_io(nh, lthread);
+    this->super::net_read_io(nh);
     return;
   }
   // If the key renegotiation failed it's over, just signal the error and finish.
@@ -614,7 +614,7 @@ SSLNetVConnection::net_read_io(NetHandler *nh, EThread *lthread)
   // this comment if you know
   int ssl_read_errno = 0;
   do {
-    ret = this->_ssl_read_from_net(lthread, r);
+    ret = this->_ssl_read_from_net(r);
     if (ret == SSL_READ_READY || ret == SSL_READ_ERROR_NONE) {
       bytes += r;
     }


### PR DESCRIPTION
There are redundant wrapper functions in UnixNetVC and the design is inconstant between read and write, and also between UnixNetVC and SSLNetVC.

This PR is a first step for further refactoring/abstraction. It removes those redundant functions and aligns the design. I also removed a few parameters that don't need to be passed around. There should be no change in the flow.

With this change, we should be able to move the TLS related code into SSLNetVC from UnixNetVC like `load_buffer_and_write`.

Before

UnixNetVConnection
```
UnixNetVConnection::net_read_io -> ::read_from_net
UnixNetVConnection::net_write_io -> ::write_to_net -> ::write_to_net_io -> UnixNetVConnection::load_buffer_and_write
UnixNetVConnection::netActivity -> ::net_activity
```
SSLNetVConnection
```
SSLNetVConnection::net_read_io
UnixNetVConnection::net_write_io -> ::write_to_net -> ::write_to_net_io -> SSLNetVConnection::load_buffer_and_write
```

After

UnixNetVConnection
```
UnixNetVConnection::net_read_io
UnixNetVConnection::net_write_io -> UnixNetVConnection::load_buffer_and_write
UnixNetVConnection::netActivity
```

SSLNetVConnection
```
SSLNetVConnection::net_read_io
UnixNetVConnection::net_write_io -> SSLNetVConnection::load_buffer_and_write
```