### PR TITLE
ASan: Fix use-after-free of SDK_API_TSCache Regression Test

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1571,8 +1571,8 @@ struct RegressionCont : public Continuation {
 
     TSSystemState::shut_down_event_system();
     fprintf(stderr, "REGRESSION_TEST DONE: %s\n", regression_status_string(res));
-    ::exit(res == REGRESSION_TEST_PASSED ? 0 : 1);
-    return EVENT_CONT;
+
+    return EVENT_DONE;
   }
 
   RegressionCont() : Continuation(new_ProxyMutex()) { SET_HANDLER(&RegressionCont::mainEvent); }
@@ -2324,6 +2324,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   }
 
   delete main_thread;
+
+#if TS_HAS_TESTS
+  if (RegressionTest::check_status(regression_level) == REGRESSION_TEST_PASSED) {
+    std::exit(0);
+  } else {
+    std::exit(1);
+  }
+#endif
 }
 
 static void


### PR DESCRIPTION
Rocky build of https://github.com/apache/trafficserver/pull/11786 reported a head-use-after-free with `SDK_API_TSCache` regression test. There is a race of of thread local variable destructor and global variable destructor. 

It looks like this is made by `::exit()` in the `RegressionCont::mainEvent`. With this change, the ASan report is gone.

```
==7768==ERROR: AddressSanitizer: heap-use-after-free on address 0x61d00001fe90 at pc 0x0000009a1df1 bp 0x7f530e88ffc0 sp 0x7f530e88ffb0
WRITE of size 8 at 0x61d00001fe90 thread T2 ([ET_NET 0])
    #0 0x9a1df0 in DenseThreadId::_Id::~_Id() ../include/tsutil/DenseThreadId.h:96
    #1 0x7f531309b47e in __call_tls_dtors (/lib64/libc.so.6+0x5147e)
    #2 0x7f53134281d7 in start_thread (/lib64/libpthread.so.0+0x81d7)
    #3 0x7f53130838d2 in __GI___clone (/lib64/libc.so.6+0x398d2)

0x61d00001fe90 is located 16 bytes inside of 2048-byte region [0x61d00001fe80,0x61d000020680)
freed by thread T4 ([ET_NET 2]) here:
    #0 0x7f5315f1836f in operator delete(void*, unsigned long) (/lib64/libasan.so.6+0xb736f)
    #1 0x9adfca in __gnu_cxx::new_allocator<unsigned long>::deallocate(unsigned long*, unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/ext/new_allocator.h:145
    #2 0x9aa466 in std::allocator<unsigned long>::deallocate(unsigned long*, unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/allocator.h:199
    #3 0x9aa466 in std::allocator_traits<std::allocator<unsigned long> >::deallocate(std::allocator<unsigned long>&, unsigned long*, unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/alloc_traits.h:496
    #4 0x9a8165 in std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_M_deallocate(unsigned long*, unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/stl_vector.h:354
    #5 0x9a5ff3 in std::_Vector_base<unsigned long, std::allocator<unsigned long> >::~_Vector_base() (/tmp/ats-quiche/bin/traffic_server+0x9a5ff3)
    #6 0x9b1b6f in std::vector<unsigned long, std::allocator<unsigned long> >::~vector() /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/stl_vector.h:683
    #7 0x7f531309b1f6 in __cxa_finalize (/lib64/libc.so.6+0x511f6)

previously allocated by thread T4 ([ET_NET 2]) here:
    #0 0x7f5315f17307 in operator new(unsigned long) (/lib64/libasan.so.6+0xb6307)
    #1 0x9afa37 in __gnu_cxx::new_allocator<unsigned long>::allocate(unsigned long, void const*) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/ext/new_allocator.h:127
    #2 0x9ac74f in std::allocator<unsigned long>::allocate(unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/allocator.h:185
    #3 0x9ac74f in std::allocator_traits<std::allocator<unsigned long> >::allocate(std::allocator<unsigned long>&, unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/alloc_traits.h:464
    #4 0x9aa71d in std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_M_allocate(unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/stl_vector.h:346
    #5 0x9a82f0 in std::vector<unsigned long, std::allocator<unsigned long> >::_M_default_append(unsigned long) /opt/rh/gcc-toolset-11/root/usr/include/c++/11/bits/vector.tcc:635
    #6 0x9a6052 in std::vector<unsigned long, std::allocator<unsigned long> >::resize(unsigned long) (/tmp/ats-quiche/bin/traffic_server+0x9a6052)
    #7 0x9a191d in DenseThreadId::_init() ../include/tsutil/DenseThreadId.h:68
    #8 0x9a1a5e in DenseThreadId::_Id::_Id() ../include/tsutil/DenseThreadId.h:82
    #9 0x99f117 in __tls_init ../include/tsutil/DenseThreadId.h:103
    #10 0xec3e82 in TLS wrapper function for DenseThreadId::_id (/tmp/ats-quiche/bin/traffic_server+0xec3e82)
    #11 0xec3e9c in DenseThreadId::self() ../include/tsutil/DenseThreadId.h:50
    #12 0xec7832 in ts::bravo::shared_mutex_impl<std::shared_mutex, 256ul, 7>::lock_shared(unsigned long&) ../include/tsutil/Bravo.h:258
    #13 0xec65fd in ReplaceablePtr<CacheHostTable>::ScopedReader::ScopedReader(ReplaceablePtr<CacheHostTable>*) ../src/iocore/cache/P_CacheHosting.h:153
    #14 0xebf7ad in Cache::key_to_stripe(ts::CryptoHash const*, char const*, int) ../src/iocore/cache/Cache.cc:753
    #15 0xebbf42 in Cache::open_write(Continuation*, ts::CryptoHash const*, CacheFragType, int, long, char const*, int) ../src/iocore/cache/Cache.cc:415
    #16 0xeeb40e in CacheProcessor::open_write(Continuation*, ts::CryptoHash*, CacheFragType, int, int, long, char*, int) ../src/iocore/cache/CacheProcessor.cc:386
    #17 0x7f5315a561c3 in TSCacheWrite(tsapi_cont*, tsapi_cachekey*) ../src/api/InkAPI.cc:6177
    #18 0x7f5315ac9f92 in RegressionTest_SDK_API_TSCache(RegressionTest*, int, int*) ../src/api/InkAPITest.cc:1977
    #19 0x9cfdbc in start_test ../src/tscore/Regression.cc:82
    #20 0x9d0195 in RegressionTest::run(char const*, int) ../src/tscore/Regression.cc:105
    #21 0x9a511b in RegressionCont::mainEvent(int, Event*) (/tmp/ats-quiche/bin/traffic_server+0x9a511b)
    #22 0x979252 in Continuation::handleEvent(int, void*) ../include/iocore/eventsystem/Continuation.h:228
    #23 0x1271f59 in EThread::process_event(Event*, int) ../src/iocore/eventsystem/UnixEThread.cc:163
    #24 0x1272b60 in EThread::execute_regular() ../src/iocore/eventsystem/UnixEThread.cc:270
    #25 0x127342d in EThread::execute() ../src/iocore/eventsystem/UnixEThread.cc:350
    #26 0x12702da in spawn_thread_internal ../src/iocore/eventsystem/Thread.cc:75
    #27 0x7f53134281c9 in start_thread (/lib64/libpthread.so.0+0x81c9)

Thread T2 ([ET_NET 0]) created by T0 ([TS_MAIN]) here:
    #0 0x7f5315eb97c5 in pthread_create (/lib64/libasan.so.6+0x587c5)
    #1 0x126fd7f in ink_thread_create ../include/tscore/ink_thread.h:129
    #2 0x1270407 in Thread::start(char const*, void*, unsigned long, std::function<void ()> const&) ../src/iocore/eventsystem/Thread.cc:92
    #3 0x1279a7b in EventProcessor::spawn_event_threads(int, int, unsigned long) ../src/iocore/eventsystem/UnixEventProcessor.cc:469
    #4 0x127a35f in EventProcessor::start(int, unsigned long) ../src/iocore/eventsystem/UnixEventProcessor.cc:550
    #5 0x9974c7 in main ../src/traffic_server/traffic_server.cc:2110
    #6 0x7f53130847e4 in __libc_start_main (/lib64/libc.so.6+0x3a7e4)

Thread T4 ([ET_NET 2]) created by T0 ([TS_MAIN]) here:
    #0 0x7f5315eb97c5 in pthread_create (/lib64/libasan.so.6+0x587c5)
    #1 0x126fd7f in ink_thread_create ../include/tscore/ink_thread.h:129
    #2 0x1270407 in Thread::start(char const*, void*, unsigned long, std::function<void ()> const&) ../src/iocore/eventsystem/Thread.cc:92
    #3 0x1279a7b in EventProcessor::spawn_event_threads(int, int, unsigned long) ../src/iocore/eventsystem/UnixEventProcessor.cc:469
    #4 0x127a35f in EventProcessor::start(int, unsigned long) ../src/iocore/eventsystem/UnixEventProcessor.cc:550
    #5 0x9974c7 in main ../src/traffic_server/traffic_server.cc:2110
    #6 0x7f53130847e4 in __libc_start_main (/lib64/libc.so.6+0x3a7e4)

SUMMARY: AddressSanitizer: heap-use-after-free ../include/tsutil/DenseThreadId.h:96 in DenseThreadId::_Id::~_Id()
Shadow bytes around the buggy address:
  0x0c3a7fffbf80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3a7fffbf90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3a7fffbfa0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3a7fffbfb0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3a7fffbfc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c3a7fffbfd0: fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3a7fffbfe0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3a7fffbff0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3a7fffc000: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3a7fffc010: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c3a7fffc020: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==7768==ABORTING
```
https://ci.trafficserver.apache.org/job/Github_Builds/job/rocky/5923/console