### PR TITLE
Coverity: Fix a few copy instead of move warnings.

### DIFF
--- a/src/proxy/http/remap/unit-tests/test_RemapPlugin.cc
+++ b/src/proxy/http/remap/unit-tests/test_RemapPlugin.cc
@@ -83,7 +83,7 @@ public:
 };
 
 RemapPluginUnitTest *
-setupSandBox(const fs::path configPath)
+setupSandBox(const fs::path &configPath)
 {
   std::string error;
   clean();


### PR DESCRIPTION
not using `std::move`, instead we pass it as `const ref`. 

CID-1544426
CID-1544432
CID-1544445