### PR TITLE
Coverity: txn_box, fix a few copy instead of move warnings.

### DIFF
--- a/plugins/experimental/txn_box/plugin/src/Config.cc
+++ b/plugins/experimental/txn_box/plugin/src/Config.cc
@@ -758,7 +758,7 @@ Config::load_cli_args(Handle handle, const std::vector<std::string> &args, int a
   for (auto const &arg : args) {
     argv[idx++] = arg.c_str();
   }
-  return this->load_cli_args(handle, argv, arg_idx, cache);
+  return this->load_cli_args(std::move(handle), argv, arg_idx, cache);
 }
 
 Errata

--- a/plugins/experimental/txn_box/plugin/src/Modifier.cc
+++ b/plugins/experimental/txn_box/plugin/src/Modifier.cc
@@ -991,9 +991,9 @@ Mod_as_integer::operator()(Context &ctx, Feature &feature)
   if (errata.is_ok()) {
     return Feature{value};
   }
-  auto invalid{ctx.extract(_value)};
+
   if (errata.is_ok()) {
-    return Feature{invalid};
+    return Feature{ctx.extract(_value)};
   }
   return feature;
 }

--- a/plugins/experimental/txn_box/plugin/src/text_block.cc
+++ b/plugins/experimental/txn_box/plugin/src/text_block.cc
@@ -304,7 +304,7 @@ Do_text_block_define::Updater::operator()()
     if (!ec) { // swap in updated content.
       {
         std::unique_lock lock(_block->_content_mutex);
-        _block->_content       = content;
+        _block->_content       = std::move(content);
         _block->_last_modified = mtime;
       }
       if (_block->_notify_idx != FeatureGroup::INVALID_IDX) {

--- a/plugins/experimental/txn_box/plugin/src/txn_box.cc
+++ b/plugins/experimental/txn_box/plugin/src/txn_box.cc
@@ -127,7 +127,7 @@ Task_ConfigReload()
     auto            errata = cfg->load_cli_args(cfg, G._args, 1);
     if (errata.is_ok()) {
       std::unique_lock lock(Plugin_Config_Mutex);
-      Plugin_Config = cfg;
+      Plugin_Config = std::move(cfg);
     } else {
       std::string err_str;
       swoc::bwprint(err_str, "{}: Failed to reload configuration.\n{}", Config::PLUGIN_NAME, errata);


### PR DESCRIPTION
CID-1534703
CID-1534707
CID-1534708
CID-1534713

This avoids a few extra copies of the `std::shared_ptr`