### PR TITLE
Coverity. CID-1559195: Fix for  uninitialized scalar field.

### DIFF
--- a/include/proxy/http/remap/RemapConfig.h
+++ b/include/proxy/http/remap/RemapConfig.h
@@ -26,7 +26,6 @@
 #include "proxy/http/remap/AclFiltering.h"
 
 class UrlRewrite;
-enum class ACLBehaviorPolicy;
 
 #define BUILD_TABLE_MAX_ARGS 2048
 
@@ -46,6 +45,11 @@ enum class ACLBehaviorPolicy;
 #define REMAP_OPTFLG_ALL_FILTERS \
   (REMAP_OPTFLG_METHOD | REMAP_OPTFLG_SRC_IP | REMAP_OPTFLG_SRC_IP_CATEGORY | REMAP_OPTFLG_ACTION | REMAP_OPTFLG_INTERNAL)
 
+enum class ACLBehaviorPolicy {
+  ACL_BEHAVIOR_LEGACY = 0,
+  ACL_BEHAVIOR_MODERN,
+};
+
 struct BUILD_TABLE_INFO {
   BUILD_TABLE_INFO();
   ~BUILD_TABLE_INFO();
@@ -56,7 +60,7 @@ struct BUILD_TABLE_INFO {
   char         *paramv[BUILD_TABLE_MAX_ARGS];
   char         *argv[BUILD_TABLE_MAX_ARGS];
 
-  ACLBehaviorPolicy behavior_policy;
+  ACLBehaviorPolicy behavior_policy{ACLBehaviorPolicy::ACL_BEHAVIOR_LEGACY}; // Default 0.
   bool              ip_allow_check_enabled_p = true;
   bool              accept_check_p           = true;
 

--- a/include/proxy/http/remap/UrlRewrite.h
+++ b/include/proxy/http/remap/UrlRewrite.h
@@ -32,6 +32,7 @@
 #include "tsutil/Regex.h"
 #include "proxy/http/remap/PluginFactory.h"
 #include "proxy/http/remap/NextHopStrategyFactory.h"
+#include "proxy/http/remap/RemapConfig.h"
 
 #include <memory>
 
@@ -52,11 +53,6 @@ enum mapping_type {
   FORWARD_MAP_REFERER,
   FORWARD_MAP_WITH_RECV_PORT,
   NONE
-};
-
-enum class ACLBehaviorPolicy {
-  ACL_BEHAVIOR_LEGACY = 0,
-  ACL_BEHAVIOR_MODERN,
 };
 
 /**

--- a/src/proxy/http/remap/UrlRewrite.cc
+++ b/src/proxy/http/remap/UrlRewrite.cc
@@ -25,7 +25,6 @@
 #include "proxy/http/remap/UrlRewrite.h"
 #include "iocore/eventsystem/ConfigProcessor.h"
 #include "proxy/ReverseProxy.h"
-#include "proxy/http/remap/RemapConfig.h"
 #include "tscore/Layout.h"
 #include "tscore/Filenames.h"
 #include "proxy/http/HttpSM.h"


### PR DESCRIPTION
Moved from `UrlRemap.h` to `RemapConfig.h` which was anyways included in the `cc` file.