### PR TITLE
Update gcp documentation 

### DIFF
--- a/doc/admin-guide/plugins/origin_server_auth.en.rst
+++ b/doc/admin-guide/plugins/origin_server_auth.en.rst
@@ -184,7 +184,7 @@ Google Cloud Storage
 Configuration options::
 
     # Mandatory options
-    --access_key=<access_id>
+    --session_token=<session_token>
     --version=gcpv1
 
 If the following option is used then the options could be specified in a file::
@@ -196,5 +196,5 @@ The ``gcp_auth.config`` config file could look like this::
 
     # gcp_auth.config
 
-    access_key=<access_id>
+    session_token=<access_id>
     version=gcpv1


### PR DESCRIPTION
I noticed that the documentation for GCP was not updated with the correct mandatory configs. 

The mandatory token is `session_token` rather than `access_token`

https://github.com/apache/trafficserver/blame/master/plugins/origin_server_auth/origin_server_auth.cc#L231

