### PR TITLE
Add a constructor to `Stripe` to impose invariants early

### DIFF
--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -270,15 +270,13 @@ Cache::open(bool clear, bool /* fix ATS_UNUSED */)
           DiskStripeBlockQueue *q = cp->disk_stripes[i]->dpb_queue.head;
           for (; q; q = q->link.next) {
             blocks                         = q->b->len;
-            cp->stripes[vol_no]            = new StripeSM(blocks, q->b->offset);
             CacheDisk *d                   = cp->disk_stripes[i]->disk;
-            cp->stripes[vol_no]->disk      = d;
-            cp->stripes[vol_no]->fd        = d->fd;
+            cp->stripes[vol_no]            = new StripeSM(d, blocks, q->b->offset);
             cp->stripes[vol_no]->cache     = this;
             cp->stripes[vol_no]->cache_vol = cp;
 
             bool vol_clear = clear || d->cleared || q->new_block;
-            cp->stripes[vol_no]->init(d->path, blocks, q->b->offset, vol_clear);
+            cp->stripes[vol_no]->init(vol_clear);
             vol_no++;
             cache_size += blocks;
           }

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -269,13 +269,13 @@ Cache::open(bool clear, bool /* fix ATS_UNUSED */)
         if (cp->disk_stripes[i] && !DISK_BAD(cp->disk_stripes[i]->disk)) {
           DiskStripeBlockQueue *q = cp->disk_stripes[i]->dpb_queue.head;
           for (; q; q = q->link.next) {
-            cp->stripes[vol_no]            = new StripeSM();
+            blocks                         = q->b->len;
+            cp->stripes[vol_no]            = new StripeSM(blocks, q->b->offset);
             CacheDisk *d                   = cp->disk_stripes[i]->disk;
             cp->stripes[vol_no]->disk      = d;
             cp->stripes[vol_no]->fd        = d->fd;
             cp->stripes[vol_no]->cache     = this;
             cp->stripes[vol_no]->cache_vol = cp;
-            blocks                         = q->b->len;
 
             bool vol_clear = clear || d->cleared || q->new_block;
             cp->stripes[vol_no]->init(d->path, blocks, q->b->offset, vol_clear);

--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -450,7 +450,7 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   disk.num_errors = 0;
 
   for (int i = 0; i < MAX_VOLS; ++i) {
-    stripes[i]     = new StripeSM{&disk, static_cast<off_t>(DEFAULT_STRIPE_SIZE / BLOCK_SIZE), 0};
+    stripes[i]     = new StripeSM{&disk, static_cast<off_t>(DEFAULT_STRIPE_SIZE / STORE_BLOCK_SIZE), 0};
     stripe_ptrs[i] = stripes[i];
     snprintf(buff, sizeof(buff), "/dev/sd%c %" PRIu64 ":%" PRIu64, 'a' + i, DEFAULT_SKIP, stripes[i]->len);
     CryptoContext().hash_immediate(stripes[i]->hash_id, buff, strlen(buff));

--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -435,7 +435,7 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   CacheHostRecord  hr1, hr2;
   StripeSM        *sample;
   static int const sample_idx = 16;
-  StripeSM         stripes[MAX_VOLS];
+  StripeSM        *stripes[MAX_VOLS];
   StripeSM        *stripe_ptrs[MAX_VOLS]; // array of pointers.
   char             buff[2048];
 
@@ -450,11 +450,10 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   disk.num_errors = 0;
 
   for (int i = 0; i < MAX_VOLS; ++i) {
-    stripe_ptrs[i]  = stripes + i;
-    stripes[i].disk = &disk;
-    stripes[i].len  = DEFAULT_STRIPE_SIZE;
-    snprintf(buff, sizeof(buff), "/dev/sd%c %" PRIu64 ":%" PRIu64, 'a' + i, DEFAULT_SKIP, stripes[i].len);
-    CryptoContext().hash_immediate(stripes[i].hash_id, buff, strlen(buff));
+    stripes[i]     = new StripeSM{&disk, static_cast<off_t>(DEFAULT_STRIPE_SIZE / BLOCK_SIZE), 0};
+    stripe_ptrs[i] = stripes[i];
+    snprintf(buff, sizeof(buff), "/dev/sd%c %" PRIu64 ":%" PRIu64, 'a' + i, DEFAULT_SKIP, stripes[i]->len);
+    CryptoContext().hash_immediate(stripes[i]->hash_id, buff, strlen(buff));
   }
 
   hr1.vol_hash_table = nullptr;
@@ -466,7 +465,7 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
   hr2.stripes        = stripe_ptrs;
   hr2.num_vols       = MAX_VOLS;
 
-  sample      = stripes + sample_idx;
+  sample      = stripes[sample_idx];
   sample->len = 1024ULL * 1024 * 1024 * (1024 + 128); // 1.1 TB
   snprintf(buff, sizeof(buff), "/dev/sd%c %" PRIu64 ":%" PRIu64, 'a' + sample_idx, DEFAULT_SKIP, sample->len);
   CryptoContext().hash_immediate(sample->hash_id, buff, strlen(buff));
@@ -498,6 +497,9 @@ REGRESSION_TEST(cache_disk_replacement_stability)(RegressionTest *t, int level, 
 
   hr1.stripes = nullptr;
   hr2.stripes = nullptr;
+  for (StripeSM *stripe : stripes) {
+    delete stripe;
+  }
 }
 
 static double  zipf_alpha       = 1.2;

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -33,6 +33,7 @@
 #include "tscore/ink_align.h"
 #include "tscore/ink_memory.h"
 
+#include <cstddef>
 #include <cstdint>
 
 #define CACHE_BLOCK_SHIFT        9
@@ -102,6 +103,13 @@ public:
 
   CacheVol *cache_vol{};
 
+  /**
+   * Stripe constructor.
+   *
+   * @param blocks: Number of blocks. Must be at least 10.
+   */
+  Stripe(off_t blocks, off_t dir_skip);
+
   int dir_check();
 
   uint32_t round_to_approx_size(uint32_t l) const;
@@ -158,11 +166,12 @@ protected:
 
   void _clear_init();
   void _init_dir();
-  void _init_data(off_t blocks, off_t dir_skip);
   bool flush_aggregate_write_buffer();
 
 private:
+  void _init_data(off_t store_block_size);
   void _init_data_internal();
+  void _init_directory(std::size_t directory_size, int header_size, int footer_size);
 };
 
 inline uint32_t

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -106,9 +106,15 @@ public:
   /**
    * Stripe constructor.
    *
+   * @param disk: The disk object to associate with this stripe.
+   * The disk path must be non-null.
    * @param blocks: Number of blocks. Must be at least 10.
+   * @param dir_skip: Offset into the disk at which to start the stripe.
+   * If this value is less than START_POS, START_POS will be used instead.
+   *
+   * @see START_POS
    */
-  Stripe(off_t blocks, off_t dir_skip);
+  Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip);
 
   int dir_check();
 
@@ -169,6 +175,7 @@ protected:
   bool flush_aggregate_write_buffer();
 
 private:
+  void _init_hash_text(char const *seed, off_t blocks, off_t dir_skip);
   void _init_data(off_t store_block_size);
   void _init_data_internal();
   void _init_directory(std::size_t directory_size, int header_size, int footer_size);

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -109,6 +109,17 @@ struct StripeInitInfo {
   }
 };
 
+StripeSM::StripeSM(off_t blocks, off_t dir_skip) : Continuation(new_ProxyMutex()), Stripe{blocks, dir_skip}
+{
+  this->_preserved_dirs.evacuate_size = static_cast<int>(len / EVACUATION_BUCKET_SIZE) + 2;
+  int evac_len                        = this->_preserved_dirs.evacuate_size * sizeof(DLL<EvacuationBlock>);
+  this->_preserved_dirs.evacuate      = static_cast<DLL<EvacuationBlock> *>(ats_malloc(evac_len));
+  memset(static_cast<void *>(this->_preserved_dirs.evacuate), 0, evac_len);
+
+  open_dir.mutex = this->mutex;
+  SET_HANDLER(&StripeSM::aggWrite);
+}
+
 int
 StripeSM::begin_read(CacheVC *cont) const
 {
@@ -166,20 +177,8 @@ StripeSM::init(char *s, off_t blocks, off_t dir_skip, bool clear)
 
   path = ats_strdup(s);
 
-  // Stripe
-  this->_init_data(blocks, dir_skip);
-
   // Evacuation
   this->hit_evacuate_window = (this->data_blocks * cache_config_hit_evacuate_percent) / 100;
-
-  // PreservationTable
-  this->_preserved_dirs.evacuate_size = static_cast<int>(len / EVACUATION_BUCKET_SIZE) + 2;
-  int evac_len                        = this->_preserved_dirs.evacuate_size * sizeof(DLL<EvacuationBlock>);
-  this->_preserved_dirs.evacuate      = static_cast<DLL<EvacuationBlock> *>(ats_malloc(evac_len));
-  memset(static_cast<void *>(this->_preserved_dirs.evacuate), 0, evac_len);
-
-  Dbg(dbg_ctl_cache_init, "Vol %s: allocating %zu directory bytes for a %lld byte volume (%lf%%)", hash_text.get(), dirlen(),
-      static_cast<long long>(this->len), static_cast<double>(dirlen()) / static_cast<double>(this->len) * 100.0);
 
   // AIO
   if (clear) {

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -164,6 +164,8 @@ StripeSM::clear_dir()
 int
 StripeSM::init(bool clear)
 {
+  CryptoContext().hash_immediate(hash_id, hash_text, strlen(hash_text));
+
   // Evacuation
   this->hit_evacuate_window = (this->data_blocks * cache_config_hit_evacuate_percent) / 100;
 

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -156,11 +156,12 @@ public:
 
   int within_hit_evacuate_window(Dir const *dir) const;
 
-  StripeSM() : Continuation(new_ProxyMutex())
-  {
-    open_dir.mutex = mutex;
-    SET_HANDLER(&StripeSM::aggWrite);
-  }
+  /**
+   * StripeSM constructor.
+   *
+   * @param blocks: Number of blocks. Must be at least 10.
+   */
+  StripeSM(off_t blocks, off_t dir_skip);
 
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
 

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "P_CacheDir.h"
+#include "P_CacheDisk.h"
 #include "P_RamCache.h"
 #include "AggregateWriteBuffer.h"
 #include "PreservationTable.h"
@@ -111,7 +112,7 @@ public:
   int clear_dir_aio();
   int clear_dir();
 
-  int init(char *s, off_t blocks, off_t dir_skip, bool clear);
+  int init(bool clear);
 
   int handle_dir_clear(int event, void *data);
   int handle_dir_read(int event, void *data);
@@ -159,9 +160,15 @@ public:
   /**
    * StripeSM constructor.
    *
+   * @param disk: The disk object to associate with this stripe.
+   * The disk path must be non-null.
    * @param blocks: Number of blocks. Must be at least 10.
+   * @param dir_skip: Offset into the disk at which to start the stripe.
+   * If this value is less than START_POS, START_POS will be used instead.
+   *
+   * @see START_POS
    */
-  StripeSM(off_t blocks, off_t dir_skip);
+  StripeSM(CacheDisk *disk, off_t blocks, off_t dir_skip);
 
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
 

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -191,6 +191,10 @@ TEST_CASE("The behavior of StripeSM::add_writer.")
       CHECK(true == result);
     }
   }
+
+  ats_free(stripe.raw_dir);
+  ats_free(stripe.get_preserved_dirs().evacuate);
+  ats_free(stripe.path);
 }
 
 // This test case demonstrates how to set up a StripeSM and make
@@ -302,6 +306,7 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
 
   ats_free(stripe.raw_dir);
   ats_free(stripe.get_preserved_dirs().evacuate);
+  ats_free(stripe.path);
 }
 
 // When f.evacuator is set, vc.buf must contain a Doc object including headers
@@ -401,4 +406,5 @@ TEST_CASE("aggWrite behavior with f.evacuator set")
   delete[] source;
   ats_free(stripe.raw_dir);
   ats_free(stripe.get_preserved_dirs().evacuate);
+  ats_free(stripe.path);
 }

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -81,6 +81,17 @@ std::array<AddWriterBranchTest, 32> add_writer_branch_test_cases = {
    }
 };
 
+static void
+init_disk(CacheDisk &disk)
+{
+  disk.path                = static_cast<char *>(ats_malloc(1));
+  disk.path[0]             = '\0';
+  disk.disk_stripes        = static_cast<DiskStripe **>(ats_malloc(sizeof(DiskStripe *)));
+  disk.disk_stripes[0]     = nullptr;
+  disk.header              = static_cast<DiskHeader *>(ats_malloc(sizeof(DiskHeader)));
+  disk.header->num_volumes = 0;
+}
+
 /* Catch test helper to provide a StripeSM with a valid file descriptor.
  *
  * The file will be deleted automatically when the application ends normally.
@@ -124,8 +135,10 @@ init_stripe_for_writing(StripeSM &stripe, StripteHeaderFooter &header, CacheVol 
 
 TEST_CASE("The behavior of StripeSM::add_writer.")
 {
-  FakeVC   vc;
-  StripeSM stripe{10, 0};
+  FakeVC    vc;
+  CacheDisk disk;
+  init_disk(disk);
+  StripeSM stripe{&disk, 10, 0};
 
   SECTION("Branch tests.")
   {
@@ -181,7 +194,9 @@ TEST_CASE("The behavior of StripeSM::add_writer.")
 // tmpfile for the StripeSM to write to.
 TEST_CASE("aggWrite behavior with f.evacuator unset")
 {
-  StripeSM            stripe{10, 0};
+  CacheDisk disk;
+  init_disk(disk);
+  StripeSM            stripe{&disk, 10, 0};
   StripteHeaderFooter header;
   CacheVol            cache_vol;
   auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};
@@ -291,7 +306,9 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
 // only on the presence of the f.evacuator flag.
 TEST_CASE("aggWrite behavior with f.evacuator set")
 {
-  StripeSM            stripe{10, 0};
+  CacheDisk disk;
+  init_disk(disk);
+  StripeSM            stripe{&disk, 10, 0};
   StripteHeaderFooter header;
   CacheVol            cache_vol;
   auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -126,7 +126,11 @@ init_stripe_for_writing(StripeSM &stripe, StripteHeaderFooter &header, CacheVol 
 
   stripe.sector_size = 256;
 
-  header.write_pos = 50000;
+  // This is the minimum value for header.write_pos. Offsets are calculated
+  // based on the distance of the write_pos from this point. If we ever move
+  // the write head before the start of the stripe data section, we will
+  // underflow offset calculations and end up in big trouble.
+  header.write_pos = stripe.start;
   header.agg_pos   = 1;
   header.phase     = 0;
   stripe.header    = &header;


### PR DESCRIPTION
The recent commits are not signed because gpg broke on WSL after an update.

This change also revealed an issue with the `Stripe` unit tests. The write head was pointing to a hardcoded value that happened to be valid instead of the start of the document blocks. This also fixes that issue - see c39be53.