### PR TITLE
Fixes to HostDB marking IPs up/down

### DIFF
--- a/include/iocore/hostdb/HostDBProcessor.h
+++ b/include/iocore/hostdb/HostDBProcessor.h
@@ -151,7 +151,7 @@ struct HostDBInfo {
    * If a zombie is selected the failure time is updated to make it appear down to other threads in a thread safe
    * manner. The caller should check @c last_fail_time to see if a zombie was selected.
    */
-  bool select(ts_time now, ts_seconds fail_window);
+  bool select(ts_time now, ts_seconds fail_window) const;
 
   /// Check if this info is valid.
   bool is_valid() const;
@@ -273,7 +273,7 @@ HostDBInfo::increment_fail_count(ts_time now, uint8_t max_retries)
 }
 
 inline bool
-HostDBInfo::select(ts_time now, ts_seconds fail_window)
+HostDBInfo::select(ts_time now, ts_seconds fail_window) const
 {
   auto t0 = this->last_fail_time();
   if (t0 == TS_TIME_ZERO) {

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4581,12 +4581,14 @@ HttpSM::do_hostdb_update_if_necessary()
     this->mark_host_failure(&t_state.dns_info, ts_clock::from_time_t(t_state.client_request_time));
   } else {
     if (t_state.dns_info.mark_active_server_alive()) {
+      char addrbuf[INET6_ADDRPORTSTRLEN];
+      ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf));
+      ATS_PROBE2(mark_active_server_alive, sm_id, addrbuf);
       if (t_state.dns_info.record->is_srv()) {
-        SMDbg(dbg_ctl_http, "[%" PRId64 "] hostdb update marking SRV: %s as up", sm_id, t_state.dns_info.record->name());
+        SMDbg(dbg_ctl_http, "[%" PRId64 "] hostdb update marking SRV: %s(%s) as up", sm_id, t_state.dns_info.record->name(),
+              addrbuf);
       } else {
-        char addrbuf[INET6_ADDRPORTSTRLEN];
-        SMDbg(dbg_ctl_http, "[%" PRId64 "] hostdb update marking IP: %s as up", sm_id,
-              ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
+        SMDbg(dbg_ctl_http, "[%" PRId64 "] hostdb update marking IP: %s as up", sm_id, addrbuf);
       }
     }
   }
@@ -5806,30 +5808,26 @@ HttpSM::mark_host_failure(ResolveInfo *info, ts_time time_down)
 
   if (info->active) {
     if (time_down != TS_TIME_ZERO) {
+      ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf));
       // Increment the fail_count
-      if (++info->active->fail_count >= t_state.txn_conf->connect_attempts_rr_retries) {
-        if (info->active) {
-          if (info->active->last_failure.load() == TS_TIME_ZERO) {
-            char            *url_str = t_state.hdr_info.client_request.url_string_get_ref(nullptr);
-            int              host_len;
-            const char      *host_name_ptr = t_state.unmapped_url.host_get(&host_len);
-            std::string_view host_name{host_name_ptr, size_t(host_len)};
-            swoc::bwprint(error_bw_buffer, "CONNECT : {::s} connecting to {} for host='{}' url='{}' marking down",
-                          swoc::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr, host_name,
-                          swoc::bwf::FirstOf(url_str, "<none>"));
-            Log::error("%s", error_bw_buffer.c_str());
-          }
-          info->active->last_failure = time_down;
-          SMDbg(dbg_ctl_http, "hostdb update marking IP: %s as down",
-                ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)));
-        } else {
-          SMDbg(dbg_ctl_http, "hostdb increment IP failcount %s to %d",
-                ats_ip_nptop(&t_state.current.server->dst_addr.sa, addrbuf, sizeof(addrbuf)), info->active->fail_count.load());
-        }
+      if (auto [down, fail_count] = info->active->increment_fail_count(time_down, t_state.txn_conf->connect_attempts_rr_retries);
+          down) {
+        char            *url_str = t_state.hdr_info.client_request.url_string_get_ref(nullptr);
+        int              host_len;
+        const char      *host_name_ptr = t_state.unmapped_url.host_get(&host_len);
+        std::string_view host_name{host_name_ptr, static_cast<size_t>(host_len)};
+        swoc::bwprint(error_bw_buffer, "CONNECT : {::s} connecting to {} for host='{}' url='{}' fail_count='{}' marking down",
+                      swoc::bwf::Errno(t_state.current.server->connect_result), t_state.current.server->dst_addr, host_name,
+                      swoc::bwf::FirstOf(url_str, "<none>"), fail_count);
+        Log::error("%s", error_bw_buffer.c_str());
+        SMDbg(dbg_ctl_http, "hostdb update marking IP: %s as down", addrbuf);
+        ATS_PROBE2(hostdb_mark_ip_as_down, sm_id, addrbuf);
+      } else {
+        ATS_PROBE3(hostdb_inc_ip_failcount, sm_id, addrbuf, fail_count);
+        SMDbg(dbg_ctl_http, "hostdb increment IP failcount %s to %d", addrbuf, fail_count);
       }
     } else { // Clear the failure
-      info->active->fail_count   = 0;
-      info->active->last_failure = time_down;
+      info->active->mark_up();
     }
   }
 #ifdef DEBUG
@@ -8124,6 +8122,7 @@ HttpSM::set_next_state()
 
   case HttpTransact::SM_ACTION_ORIGIN_SERVER_RR_MARK_DOWN: {
     HTTP_SM_SET_DEFAULT_HANDLER(&HttpSM::state_mark_os_down);
+    ATS_PROBE(next_state_SM_ACTION_ORIGIN_SERVER_RR_MARK_DOWN);
 
     ink_assert(t_state.dns_info.looking_up == ResolveInfo::ORIGIN_SERVER);
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -47,6 +47,7 @@
 #include "proxy/http/HttpBodyFactory.h"
 #include "proxy/IPAllow.h"
 #include "iocore/utils/Machine.h"
+#include "ts/ats_probe.h"
 
 DbgCtl HttpTransact::State::_dbg_ctl{"http"};
 
@@ -521,8 +522,7 @@ HttpTransact::is_server_negative_cached(State *s)
     //   down to 2*down_server_timeout
     if (s->dns_info.active &&
         ts_clock::from_time_t(s->client_request_time) + s->txn_conf->down_server_timeout < s->dns_info.active->last_fail_time()) {
-      s->dns_info.active->last_failure = TS_TIME_ZERO;
-      s->dns_info.active->fail_count   = 0;
+      s->dns_info.active->mark_up();
       ink_assert(!"extreme clock skew");
       return true;
     }

--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -81,9 +81,8 @@ class DownCachedOriginServerTest:
             os.path.join(Test.Variables.AtsTestToolsDir, 'condwait') + ' 60 1 -f ' +
             os.path.join(self._ts.Variables.LOGDIR, 'error.log'))
 
-        self._ts.Disk.error_log.Content = Testers.ContainsExpression("/dns/mark/down' marking down", "host should be marked down")
         self._ts.Disk.error_log.Content = Testers.ContainsExpression(
-            "DNS Error: no valid server http://resolve.this.com", "DNS lookup should fail")
+            "/dns/mark/down' fail_count='1' marking down", "host should be marked down")
 
     def run(self):
         self._test_host_mark_down()

--- a/tests/gold_tests/dns/replay/server_down.replay.yaml
+++ b/tests/gold_tests/dns/replay/server_down.replay.yaml
@@ -55,7 +55,5 @@ sessions:
     server-response:
       status: 200
 
-    # Previous request marked host down so DNS lookup returns unsuccessful
-    # 500 response indicates no valid server
     proxy-response:
-      status: 500
+      status: 502


### PR DESCRIPTION
We have been troubleshooting and issue where ATS10 was returning more 500s than a nearby ATS9 host.  This PR fixes several related HostDB issues:

 * Set the fail count to 0 when marking an IP up
 * Restore the fail count from an old entry when migrating due to updates from DNS
 * Combine incrementing the fail count and marking the IP down to avoid a race condition
 * Cleanup to encapsulate failure state from HostDB users (i.e. don't increment fail_count directly)
 * HostDBInfo::select is now const and does not update the fail_time.  This was causing IPs to never be marked up.
 * If a HostDB record only has one IP, always select that for use/retry regardless of fail status (This restores the ATS9 behavior)
 * Add some ATS_PROBE calls to aid in troubleshooting.

Co-authors: @moonchen @maskit 