### PR TITLE
jsonrpc: Wait for the socket to be ready to read.

### DIFF
--- a/include/shared/rpc/IPCSocketClient.h
+++ b/include/shared/rpc/IPCSocketClient.h
@@ -43,7 +43,7 @@ using namespace std::chrono_literals;
 ///
 /// Error handling: Enclose this inside a try/catch because if any error is detected functions will throw.
 struct IPCSocketClient {
-  enum class ReadStatus { NO_ERROR = 0, BUFFER_FULL, STREAM_ERROR, UNKNOWN };
+  enum class ReadStatus { NO_ERROR = 0, BUFFER_FULL, READ_ERROR, TIMEOUT, UNKNOWN };
   using self_reference = IPCSocketClient &;
 
   IPCSocketClient(std::string path = "/tmp/jsonrpc20.sock") : _path{std::move(path)} { memset(&_server, 0, sizeof(_server)); }
@@ -52,13 +52,13 @@ struct IPCSocketClient {
 
   /// Connect to the configured socket path.
   /// Connection will retry every @c ms for @c attempts times if errno is EAGAIN
-  self_reference connect(std::chrono::milliseconds ms = 40ms, int attempts = 5);
+  self_reference connect(std::chrono::milliseconds wait_ms = 40ms, int attempts = 5);
 
   /// Send all the passed string to the socket.
   self_reference send(std::string_view data);
 
-  /// Read all the content from the socket till the message is complete.
-  ReadStatus read_all(std::string &content);
+  /// Read all the content from the socket till the message is complete or it times out.
+  ReadStatus read_all(std::string &content, std::chrono::milliseconds timeout_ms = 1000ms, int attempts = 10);
 
   /// Closes the socket.
   void

--- a/include/shared/rpc/IPCSocketClient.h
+++ b/include/shared/rpc/IPCSocketClient.h
@@ -57,7 +57,8 @@ struct IPCSocketClient {
   /// Send all the passed string to the socket.
   self_reference send(std::string_view data);
 
-  /// Read all the content from the socket till the message is complete or it times out.
+  /// Read all the content until the fd closes or timeout( @c timeout_ms * @c attempts) has passed.
+  /// @return @c ReadStatus will be set accordingly with the operation result.
   ReadStatus read_all(std::string &content, std::chrono::milliseconds timeout_ms = 1000ms, int attempts = 10);
 
   /// Closes the socket.

--- a/include/shared/rpc/RPCClient.h
+++ b/include/shared/rpc/RPCClient.h
@@ -67,8 +67,11 @@ public:
           // responses.
           ink_assert(!"Buffer full, not enough space to read the response.");
           break;
-        case IPCSocketClient::ReadStatus::STREAM_ERROR:
-          err_text = swoc::bwprint(err_text, "STREAM_ERROR: Error while reading response. {}({})", std::strerror(errno), errno);
+        case IPCSocketClient::ReadStatus::READ_ERROR:
+          err_text = swoc::bwprint(err_text, "READ_ERROR: Error while reading response. {}({})", std::strerror(errno), errno);
+          break;
+        case IPCSocketClient::ReadStatus::TIMEOUT:
+          err_text = swoc::bwprint(err_text, "TIMEOUT: Couldn't get the response. {}({})", std::strerror(errno), errno);
           break;
         default:
           err_text = "Something happened, we can't read the response. Unknown error.";


### PR DESCRIPTION
We found out that sometimes we hit a busy loop here, so adding a timeout to make sure we do not hangup forever here.