### PR TITLE
check if client response is still valid on txn close

### DIFF
--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -100,6 +100,12 @@ LogsMetrics::doTxnClose(cripts::Context *context)
 {
   borrow resp = cripts::Client::Response::Get();
 
+  // It's possible that the client response here is not valid, because the client went
+  // away prematurely.
+  if (!resp.Initialized()) {
+    return;
+  }
+
   // .tcpinfo(bool)
   if (_tcpinfo && control.logging.Get()) {
     borrow conn = cripts::Client::Connection::Get();


### PR DESCRIPTION
It's sometimes possible that the client may have gone away already before Cripts reaches the TxnClose hook. 

In the TxnClose hook, Cripts attempts to read the response status when determining which metric to increment, but if the client response object is already invalid, this will create a false assert/failure and subsequent ATS abort down the line in TSHttpHdrStatusGet.

This fix ensures that the response is still valid before completing the hook.