### PR TITLE
Make more of the dir entry sync configurable

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -2475,6 +2475,25 @@ Cache Control
 
    Objects larger than the limit are not hit evacuated. A value of 0 disables the limit.
 
+.. ts:cv:: CONFIG proxy.config.cache.dir.sync_frequency INT 60
+   :units: seconds
+
+   How often we will sync the cache directory entries to disk. Note that this is
+   a minimum time, and the actual sync may be delayed if the disks are larger than
+   how fast we allow it to write to disk (see next options).
+
+.. ts:cv:: CONFIG proxy.config.cache.dir.sync_max_writes INT 2097152
+   :units: bytes
+
+   How much of a stripes cache directory we will write to disk in each write cycle.
+   Together with the sync_delay, this controls how fast we can sync the entire directory
+   structure to disk. The default is 2MB.
+
+.. ts:cv:: CONFIG proxy.config.cache.dir.sync_delay INT 500
+   :units: millisecond
+
+   How long to wait between each write cycle when syncing the cache directory to disk.
+
 .. ts:cv:: CONFIG proxy.config.cache.limits.http.max_alts INT 5
 
    The maximum number of alternates that are allowed for any given URL.

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -62,6 +62,8 @@ int     cache_config_ram_cache_use_seen_filter     = 1;
 int     cache_config_http_max_alts                 = 3;
 int     cache_config_log_alternate_eviction        = 0;
 int     cache_config_dir_sync_frequency            = 60;
+int     cache_config_dir_sync_delay                = 500;
+int     cache_config_dir_sync_max_write            = (2 * 1024 * 1024);
 int     cache_config_permit_pinning                = 0;
 int     cache_config_select_alternate              = 1;
 int     cache_config_max_doc_size                  = 0;
@@ -823,6 +825,12 @@ ink_cache_init(ts::ModuleVersion v)
 
   REC_EstablishStaticConfigInt32(cache_config_dir_sync_frequency, "proxy.config.cache.dir.sync_frequency");
   Dbg(dbg_ctl_cache_init, "proxy.config.cache.dir.sync_frequency = %d", cache_config_dir_sync_frequency);
+
+  REC_EstablishStaticConfigInt32(cache_config_dir_sync_delay, "proxy.config.cache.dir.sync_delay");
+  Dbg(dbg_ctl_cache_init, "proxy.config.cache.dir.sync_delay = %d", cache_config_dir_sync_delay);
+
+  REC_EstablishStaticConfigInt32(cache_config_dir_sync_max_write, "proxy.config.cache.dir.sync_max_write");
+  Dbg(dbg_ctl_cache_init, "proxy.config.cache.dir.sync_max_write = %d", cache_config_dir_sync_max_write);
 
   REC_EstablishStaticConfigInt32(cache_config_select_alternate, "proxy.config.cache.select_alternate");
   Dbg(dbg_ctl_cache_init, "proxy.config.cache.select_alternate = %d", cache_config_select_alternate);

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -966,7 +966,7 @@ Lrestart:
     }
     Metrics::Counter::increment(cache_rsb.directory_sync_bytes, io.aio_result);
     Metrics::Counter::increment(stripe->cache_vol->vol_rsb.directory_sync_bytes, io.aio_result);
-    trigger = eventProcessor.schedule_in(this, SYNC_DELAY);
+    trigger = eventProcessor.schedule_in(this, HRTIME_MSECONDS(cache_config_dir_sync_delay));
     return EVENT_CONT;
   }
   {
@@ -1046,7 +1046,7 @@ Lrestart:
       writepos += headerlen;
     } else if (writepos < static_cast<off_t>(dirlen) - headerlen) {
       // write part of body
-      int l = SYNC_MAX_WRITE;
+      int l = cache_config_dir_sync_max_write;
       if (writepos + l > static_cast<off_t>(dirlen) - headerlen) {
         l = dirlen - headerlen - writepos;
       }

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -64,8 +64,6 @@ class CacheEvacuateDocVC;
 #define DIR_OFFSET_BITS         40
 #define DIR_OFFSET_MAX          ((((off_t)1) << DIR_OFFSET_BITS) - 1)
 
-#define SYNC_MAX_WRITE     (2 * 1024 * 1024)
-#define SYNC_DELAY         HRTIME_MSECONDS(500)
 #define DO_NOT_REMOVE_THIS 0
 
 // Debugging Options

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -101,6 +101,8 @@ extern CacheStatsBlock cache_rsb;
 
 // Configuration
 extern int cache_config_dir_sync_frequency;
+extern int cache_config_dir_sync_delay;
+extern int cache_config_dir_sync_max_write;
 extern int cache_config_http_max_alts;
 extern int cache_config_log_alternate_eviction;
 extern int cache_config_permit_pinning;

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -824,6 +824,10 @@ static const RecordElement RecordsConfig[] =
   //  # how often should the directory be synced (seconds)
   {RECT_CONFIG, "proxy.config.cache.dir.sync_frequency", RECD_INT, "60", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.cache.dir.sync_delay", RECD_INT, "500", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+  {RECT_CONFIG, "proxy.config.cache.dir.sync_max_write", RECD_INT, "2097152", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.cache.hostdb.disable_reverse_lookup", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.cache.select_alternate", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}


### PR DESCRIPTION
The problem is that very large disks, with very large directory entries, can take a very long time to sync the dir entries to disk. Also, these defaults feels like they would be from the 1990's...