### PR TITLE
Enable TLS 1.0 and 1.1 internally

### DIFF
--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1231,6 +1231,7 @@ SSLMultiCertConfigLoader::init_server_ssl_ctx(CertLoadData const &data, const SS
     Dbg(dbg_ctl_ssl_load, "Creating new context %p cert_count=%ld initial: %s", ctx, cert_names_list.size(),
         cert_names_list[0].c_str());
 
+    SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
     SSL_CTX_set_options(ctx, _params->ssl_ctx_options);
 
     if (_params->server_tls_ver_min >= 0 || _params->server_tls_ver_max >= 0) {


### PR DESCRIPTION
BoringSSL bumped the default minimum TLS version to 1.2. ATS is affected by this change because it expects that TLS 1.0 and 1.1 are enabled by default. https://boringssl.googlesource.com/boringssl/+/e95b0cad901abd49755d2a2a2f1f6c3e87d12b94

Although this change enables the old versions internally, the default ATS setting disables those. Only users who enable the old versions and use newer BoringSSL are affected. It was found by autest tls_client_versions.