### PR TITLE
Add a dir-entry setting to volumes.config

### DIFF
--- a/doc/admin-guide/files/volume.config.en.rst
+++ b/doc/admin-guide/files/volume.config.en.rst
@@ -68,6 +68,15 @@ sits in front of a volume.  This may be desirable if you are using something lik
 ramdisks, to avoid wasting RAM and cpu time on double caching objects.
 
 
+Optional directory entry sizing
+-------------------------------
+
+You can also add an option ``avg_obj_size=<size>`` to the volume configuration
+line. This overrides the global :ts:cv:`proxy.config.cache.min_average_object_size`
+configuration for this volume. This is useful if you have a volume that is dedicated
+for say very small objects, and you need a lot of directory entries to store them.
+
+
 Exclusive spans and volume sizes
 ================================
 
@@ -106,5 +115,5 @@ ramcache has been disabled.::
     volume=1 scheme=http size=20%
     volume=2 scheme=http size=20%
     volume=3 scheme=http size=20%
-    volume=4 scheme=http size=20%
+    volume=4 scheme=http size=20% avg_obj_size=4096
     volume=5 scheme=http size=20% ramcache=false

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -273,7 +273,7 @@ Cache::open(bool clear, bool /* fix ATS_UNUSED */)
           for (; q; q = q->link.next) {
             blocks                         = q->b->len;
             CacheDisk *d                   = cp->disk_stripes[i]->disk;
-            cp->stripes[vol_no]            = new StripeSM(d, blocks, q->b->offset);
+            cp->stripes[vol_no]            = new StripeSM(d, blocks, q->b->offset, cp->avg_obj_size);
             cp->stripes[vol_no]->cache     = this;
             cp->stripes[vol_no]->cache_vol = cp;
 

--- a/src/iocore/cache/CacheHosting.cc
+++ b/src/iocore/cache/CacheHosting.cc
@@ -654,6 +654,7 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
     int         size             = 0;
     int         in_percent       = 0;
     bool        ramcache_enabled = true;
+    int         avg_obj_size     = -1; // Defaults
 
     while (true) {
       // skip all blank spaces at beginning of line
@@ -741,6 +742,13 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
         } else {
           in_percent = 0;
         }
+      } else if (strcasecmp(tmp, "avg_obj_size") == 0) { // match avg_obj_size
+        tmp          += 13;
+        avg_obj_size  = atoi(tmp);
+
+        while (ParseRules::is_digit(*tmp)) {
+          tmp++;
+        }
       } else if (strcasecmp(tmp, "ramcache") == 0) { // match ramcache
         tmp += 9;
         if (!strcasecmp(tmp, "false")) {
@@ -767,7 +775,8 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
       /* add the config */
 
       ConfigVol *configp = new ConfigVol();
-      configp->number    = volume_number;
+
+      configp->number = volume_number;
       if (in_percent) {
         configp->percent    = size;
         configp->in_percent = true;
@@ -776,6 +785,7 @@ ConfigVolumes::BuildListFromString(char *config_file_path, char *file_buf)
       }
       configp->scheme           = scheme;
       configp->size             = size;
+      configp->avg_obj_size     = avg_obj_size;
       configp->cachep           = nullptr;
       configp->ramcache_enabled = ramcache_enabled;
       cp_queue.enqueue(configp);

--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -1177,6 +1177,7 @@ cplist_update()
       if (config_vol->number == cp->vol_number) {
         if (cp->scheme == config_vol->scheme) {
           cp->ramcache_enabled = config_vol->ramcache_enabled;
+          cp->avg_obj_size     = config_vol->avg_obj_size;
           config_vol->cachep   = cp;
         } else {
           /* delete this volume from all the disks */

--- a/src/iocore/cache/P_CacheHosting.h
+++ b/src/iocore/cache/P_CacheHosting.h
@@ -296,6 +296,7 @@ struct ConfigVol {
   bool      in_percent;
   bool      ramcache_enabled;
   int       percent;
+  int       avg_obj_size;
   CacheVol *cachep;
   LINK(ConfigVol, link);
 };

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -51,6 +51,7 @@ struct CacheVol {
   int          scheme           = 0;
   off_t        size             = 0;
   int          num_vols         = 0;
+  int          avg_obj_size     = -1; // Defer to the records.config if not overriden
   bool         ramcache_enabled = true;
   StripeSM   **stripes          = nullptr;
   DiskStripe **disk_stripes     = nullptr;
@@ -114,7 +115,7 @@ public:
    *
    * @see START_POS
    */
-  Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip);
+  Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size = -1);
 
   int dir_check();
 
@@ -176,8 +177,8 @@ protected:
 
 private:
   void _init_hash_text(char const *seed, off_t blocks, off_t dir_skip);
-  void _init_data(off_t store_block_size);
-  void _init_data_internal();
+  void _init_data(off_t store_block_size, int avg_obj_size = -1);
+  void _init_data_internal(int avg_obj_size = -1); // Defaults to cache_config_min_average_object_size;
   void _init_directory(std::size_t directory_size, int header_size, int footer_size);
 };
 

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -112,8 +112,8 @@ struct StripeInitInfo {
 // This is weird: the len passed to the constructor for _preserved_dirs is
 // initialized in the superclasse's constructor. This is safe because the
 // superclass should always be initialized first.
-StripeSM::StripeSM(CacheDisk *disk, off_t blocks, off_t dir_skip)
-  : Continuation(new_ProxyMutex()), Stripe{disk, blocks, dir_skip}, _preserved_dirs{static_cast<int>(len)}
+StripeSM::StripeSM(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size)
+  : Continuation(new_ProxyMutex()), Stripe{disk, blocks, dir_skip, avg_obj_size}, _preserved_dirs{static_cast<int>(len)}
 {
   open_dir.mutex = this->mutex;
   SET_HANDLER(&StripeSM::aggWrite);

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -168,7 +168,7 @@ public:
    *
    * @see START_POS
    */
-  StripeSM(CacheDisk *disk, off_t blocks, off_t dir_skip);
+  StripeSM(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size = -1);
 
   Queue<CacheVC, Continuation::Link_link> &get_pending_writers();
 


### PR DESCRIPTION
The idea / purpose of this is to allow for creating a volume which has a different configuration for the number of directory entries. The use case would be in a mixed environment where you have a mix of very large and very small objects, and don't want to waste a lot of memory for unused directory entries.

Example use:

```
volume=1 scheme=http size=20%
volume=2 scheme=http size=20%
volume=3 scheme=http size=20%
volume=4 scheme=http size=20%
volume=5 scheme=http size=20% avg_obj_size=1024

```

And then assign volume5 to one or many hosts / domains via hosting.config.

Before using avg_obj_size, we'd get the same number of directories per volume:

```
root@frigg:/opt/ats-10# ./bin/traffic_ctl  metric match 'direntries.total'
proxy.process.cache.direntries.total 4183592
proxy.process.cache.direntries.used 0
proxy.process.cache.volume_1.direntries.total 835072
proxy.process.cache.volume_2.direntries.total 835072
proxy.process.cache.volume_3.direntries.total 835072
proxy.process.cache.volume_4.direntries.total 839188
proxy.process.cache.volume_5.direntries.total 839188
```

after enabling the new configuration on volume5:

```
root@frigg:/opt/ats-10# ./bin/traffic_ctl  metric match 'direntries.total'
proxy.process.cache.direntries.total 29700544
proxy.process.cache.volume_1.direntries.total 835072
proxy.process.cache.volume_2.direntries.total 835072
proxy.process.cache.volume_3.direntries.total 835072
proxy.process.cache.volume_4.direntries.total 839188
proxy.process.cache.volume_5.direntries.total 26356140
```

