### PR TITLE
Fix setting TLS groups with BoringSSL

### DIFF
--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1529,9 +1529,8 @@ SSLMultiCertConfigLoader::_set_cipher_suites([[maybe_unused]] SSL_CTX *ctx)
 }
 
 bool
-SSLMultiCertConfigLoader::_set_curves([[maybe_unused]] SSL_CTX *ctx)
+SSLMultiCertConfigLoader::_set_curves(SSL_CTX *ctx)
 {
-#ifdef OPENSSL_IS_BORINGSSL
   if (this->_params->server_groups_list != nullptr) {
     if (!SSL_CTX_set1_groups_list(ctx, this->_params->server_groups_list)) {
       SSLError("invalid groups list for server in %s", ts::filename::RECORDS);
@@ -1539,20 +1538,6 @@ SSLMultiCertConfigLoader::_set_curves([[maybe_unused]] SSL_CTX *ctx)
     }
   }
 
-#else
-#if defined(SSL_CTX_set1_groups_list) || defined(SSL_CTX_set1_curves_list)
-  if (this->_params->server_groups_list != nullptr) {
-#ifdef SSL_CTX_set1_groups_list
-    if (!SSL_CTX_set1_groups_list(ctx, this->_params->server_groups_list)) {
-#else
-    if (!SSL_CTX_set1_curves_list(ctx, this->_params->server_groups_list)) {
-#endif
-      SSLError("invalid groups list for server in %s", ts::filename::RECORDS);
-      return false;
-    }
-  }
-#endif
-#endif // OPENSSL_IS_BORINGSSL
   return true;
 }
 

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1531,6 +1531,15 @@ SSLMultiCertConfigLoader::_set_cipher_suites([[maybe_unused]] SSL_CTX *ctx)
 bool
 SSLMultiCertConfigLoader::_set_curves([[maybe_unused]] SSL_CTX *ctx)
 {
+#ifdef OPENSSL_IS_BORINGSSL
+  if (this->_params->server_groups_list != nullptr) {
+    if (!SSL_CTX_set1_groups_list(ctx, this->_params->server_groups_list)) {
+      SSLError("invalid groups list for server in %s", ts::filename::RECORDS);
+      return false;
+    }
+  }
+
+#else
 #if defined(SSL_CTX_set1_groups_list) || defined(SSL_CTX_set1_curves_list)
   if (this->_params->server_groups_list != nullptr) {
 #ifdef SSL_CTX_set1_groups_list
@@ -1543,6 +1552,7 @@ SSLMultiCertConfigLoader::_set_curves([[maybe_unused]] SSL_CTX *ctx)
     }
   }
 #endif
+#endif // OPENSSL_IS_BORINGSSL
   return true;
 }
 


### PR DESCRIPTION
I found that `SSLMultiCertConfigLoader::_set_curves` function is not working as expected with BoringSSL. Because this check doesn't work with BoringSSL, because it's defined as a function instead of macro.
```
#if defined(SSL_CTX_set1_groups_list) || defined(SSL_CTX_set1_curves_list)
```