### PR TITLE
Add missing packages to Dockerfile

### DIFF
--- a/contrib/docker/ubuntu/noble/Dockerfile
+++ b/contrib/docker/ubuntu/noble/Dockerfile
@@ -223,6 +223,9 @@ RUN apt update \
     libbrotli1 \
     luajit \
     libcap2 \
+    libevent-2.1-7t64 \
+    libev4t64 \
+    libcares2 \
     libmagick++-6.q16-9t64 \
     libmagickcore-6.q16-7t64 \
     libmagickwand-6.q16-7t64 \


### PR DESCRIPTION
These are needed to run the provided h2load, which is super handy