### PR TITLE
Add metrics for negotiated group with client

### DIFF
--- a/src/iocore/net/SSLStats.h
+++ b/src/iocore/net/SSLStats.h
@@ -30,6 +30,8 @@
 
 #include "tsutil/Metrics.h"
 
+#include <openssl/ssl.h>
+
 using ts::Metrics;
 
 // For some odd reason, these have to be initialized with nullptr, because the order
@@ -99,6 +101,13 @@ struct SSLStatsBlock {
 
 extern SSLStatsBlock                                                   ssl_rsb;
 extern std::unordered_map<std::string, Metrics::Counter::AtomicType *> cipher_map;
+
+#if defined(OPENSSL_IS_BORINGSSL)
+extern std::unordered_map<std::string, Metrics::Counter::AtomicType *> tls_group_map;
+#elif defined(SSL_get_negotiated_group)
+extern std::unordered_map<int, Metrics::Counter::AtomicType *> tls_group_map;
+constexpr int                                                  SSL_GROUP_STAT_OTHER_KEY = 0;
+#endif
 
 // Initialize SSL statistics.
 void SSLInitializeStatistics();

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1086,6 +1086,28 @@ ssl_callback_info(const SSL *ssl, int where, int ret)
       }
       Metrics::Counter::increment(it->second);
     }
+
+#if defined(OPENSSL_IS_BORINGSSL)
+    uint16_t group_id = SSL_get_group_id(ssl);
+    if (group_id != 0) {
+      const char *group_name = SSL_get_group_name(group_id);
+      if (auto it = tls_group_map.find(group_name); it != tls_group_map.end()) {
+        Metrics::Counter::increment(it->second);
+      } else {
+        Warning("Unknown TLS Group");
+      }
+    }
+#elif defined(SSL_get_negotiated_group)
+    int nid = SSL_get_negotiated_group(const_cast<SSL *>(ssl));
+    if (nid != NID_undef) {
+      if (auto it = tls_group_map.find(nid); it != tls_group_map.end()) {
+        Metrics::Counter::increment(it->second);
+      } else {
+        auto other = tls_group_map.find(SSL_GROUP_STAT_OTHER_KEY);
+        Metrics::Counter::increment(other->second);
+      }
+    }
+#endif // OPENSSL_IS_BORINGSSL or SSL_get_negotiated_group
   }
 }
 


### PR DESCRIPTION
Like TLS ciphers.

```
proxy.process.ssl.group.user_agent.P-256
proxy.process.ssl.group.user_agent.P-384
proxy.process.ssl.group.user_agent.P-521
proxy.process.ssl.group.user_agent.X25519
proxy.process.ssl.group.user_agent.P-224
proxy.process.ssl.group.user_agent.X448
proxy.process.ssl.group.user_agent.X25519MLKEM768
```

The `SSL_get_negotiated_group` is introduced by OpenSSL 3.0.0 (and BoringSSL), so this doesn't work with OpenSSL 1.1.1 and older.