### PR TITLE
Remove deprecated ld_classic linker flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,7 +593,6 @@ endif(HOST_OS STREQUAL "linux")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
   set(CMAKE_MACOSX_RPATH 1)
-  link_libraries("-ld_classic")
 endif()
 
 if(HOST_OS STREQUAL "freebsd")


### PR DESCRIPTION
The linker bug was fixed in Xcode 15.1.

FB13097713 in https://developer.apple.com/documentation/xcode-release-notes/xcode-15_1-release-notes 