### PR TITLE
[9.2.x] Fix setting TLS groups with BoringSSL

### DIFF
--- a/iocore/net/SSLUtils.cc
+++ b/iocore/net/SSLUtils.cc
@@ -1578,7 +1578,6 @@ SSLMultiCertConfigLoader::_set_cipher_suites(SSL_CTX *ctx)
 bool
 SSLMultiCertConfigLoader::_set_curves(SSL_CTX *ctx)
 {
-#if defined(SSL_CTX_set1_groups_list) || defined(SSL_CTX_set1_curves_list)
   if (this->_params->server_groups_list != nullptr) {
 #ifdef SSL_CTX_set1_groups_list
     if (!SSL_CTX_set1_groups_list(ctx, this->_params->server_groups_list)) {
@@ -1589,7 +1588,7 @@ SSLMultiCertConfigLoader::_set_curves(SSL_CTX *ctx)
       return false;
     }
   }
-#endif
+
   return true;
 }
 


### PR DESCRIPTION
Backport #11840 to 9.2.x branch.

`SSL_CTX_set1_curves_list` is introduced by OpenSSL 1.0.2, it's the minimum supported version of ATS 9.2.x. BoringSSL also have it and it's an alias of `SSL_CTX_set1_groups_list`.