### PR TITLE
Have dummy_forced_read only if it's used

### DIFF
--- a/src/tscore/ink_queue.cc
+++ b/src/tscore/ink_queue.cc
@@ -101,11 +101,13 @@ const ink_freelist_ops *freelist_global_ops = default_ops;
 
 DbgCtl dbg_ctl_freelist_init{"freelist_init"};
 
+#ifdef SANITY
 inline void
 dummy_forced_read(void *mem)
 {
   static_cast<void>(*const_cast<int volatile *>(reinterpret_cast<int *>(mem)));
 }
+#endif
 
 } // end anonymous namespace
 


### PR DESCRIPTION
`dummy_forced_read` is unused if `SANITY` is not defined, and compilers warn unused function. The function is used like this (surrounded by ifdef SANITY): https://github.com/apache/trafficserver/blob/5ef103643f2913d9fc4aba15f7846c01ccc75b8e/src/tscore/ink_queue.cc#L268-L280