### PR TITLE
[BoringSSL] Add TLS 1.3 cipher metrics

### DIFF
--- a/src/iocore/net/SSLStats.cc
+++ b/src/iocore/net/SSLStats.cc
@@ -30,12 +30,18 @@
 #include "P_SSLUtils.h"
 #include "../../records/P_RecProcess.h"
 
+#include <string_view>
+
 SSLStatsBlock                                                   ssl_rsb;
 std::unordered_map<std::string, Metrics::Counter::AtomicType *> cipher_map;
 
 namespace
 {
 DbgCtl dbg_ctl_ssl{"ssl"};
+
+#if defined(OPENSSL_IS_BORINGSSL)
+constexpr std::string_view UNKNOWN_CIPHER{"(NONE)"};
+#endif
 
 } // end anonymous namespace
 
@@ -88,10 +94,6 @@ add_cipher_stat(const char *cipherName, const std::string &statName)
 void
 SSLInitializeStatistics()
 {
-  SSL_CTX *ctx;
-  SSL     *ssl;
-  STACK_OF(SSL_CIPHER) * ciphers;
-
   // For now, register with the librecords global sync.
   RecRegNewSyncStatSync(SSLPeriodicMetricsUpdate);
 
@@ -154,14 +156,28 @@ SSLInitializeStatistics()
   ssl_rsb.user_agent_unknown_cert            = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_unknown_cert");
   ssl_rsb.user_agent_wrong_version           = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_wrong_version");
 
+#if defined(OPENSSL_IS_BORINGSSL)
+  size_t                    n = SSL_get_all_cipher_names(nullptr, 0);
+  std::vector<const char *> cipher_list(n);
+  SSL_get_all_cipher_names(cipher_list.data(), cipher_list.size());
+  for (auto cipher_name : cipher_list) {
+    if (UNKNOWN_CIPHER.compare(cipher_name) == 0) {
+      continue;
+    }
+
+    std::string stat_name = "proxy.process.ssl.cipher.user_agent." + std::string(cipher_name);
+
+    add_cipher_stat(cipher_name, stat_name);
+  }
+#else
   // Get and register the SSL cipher stats. Note that we are using the default SSL context to obtain
   // the cipher list. This means that the set of ciphers is fixed by the build configuration and not
   // filtered by proxy.config.ssl.server.cipher_suite. This keeps the set of cipher suites stable across
   // configuration reloads and works for the case where we honor the client cipher preference.
   SSLMultiCertConfigLoader loader(nullptr);
-  ctx     = loader.default_server_ssl_ctx();
-  ssl     = SSL_new(ctx);
-  ciphers = SSL_get_ciphers(ssl);
+  SSL_CTX                 *ctx  = loader.default_server_ssl_ctx();
+  SSL                     *ssl  = SSL_new(ctx);
+  STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
 
   // BoringSSL has sk_SSL_CIPHER_num() return a size_t (well, sk_num() is)
   for (int index = 0; index < static_cast<int>(sk_SSL_CIPHER_num(ciphers)); index++) {
@@ -172,9 +188,10 @@ SSLInitializeStatistics()
     add_cipher_stat(cipherName, statName);
   }
 
-  // Add "OTHER" for ciphers not on the map
-  add_cipher_stat(SSL_CIPHER_STAT_OTHER.c_str(), "proxy.process.ssl.cipher.user_agent." + SSL_CIPHER_STAT_OTHER);
-
   SSL_free(ssl);
   SSLReleaseContext(ctx);
+#endif
+
+  // Add "OTHER" for ciphers not on the map
+  add_cipher_stat(SSL_CIPHER_STAT_OTHER.c_str(), "proxy.process.ssl.cipher.user_agent." + SSL_CIPHER_STAT_OTHER);
 }


### PR DESCRIPTION
With BoringSSL (`59f4cc4e90ec856504483a3125eccfe6c0a2b011`), ATS doesn't have metrics for TLS 1.3 ciphers. 
This PR adds metrics for all supported ciphers by the library using `SSL_get_all_cipher_names` API.

## Before

```
$ traffic_ctl metric match cipher | sort
proxy.process.ssl.cipher.user_agent.AES128-GCM-SHA256 0
proxy.process.ssl.cipher.user_agent.AES128-SHA 0
proxy.process.ssl.cipher.user_agent.AES256-GCM-SHA384 0
proxy.process.ssl.cipher.user_agent.AES256-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES128-GCM-SHA256 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES128-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES256-GCM-SHA384 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES256-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-CHACHA20-POLY1305 0
proxy.process.ssl.cipher.user_agent.ECDHE-PSK-AES128-CBC-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-PSK-AES256-CBC-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-PSK-CHACHA20-POLY1305 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES128-GCM-SHA256 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES128-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES256-GCM-SHA384 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES256-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-CHACHA20-POLY1305 0
proxy.process.ssl.cipher.user_agent.OTHER 0
proxy.process.ssl.cipher.user_agent.PSK-AES128-CBC-SHA 0
proxy.process.ssl.cipher.user_agent.PSK-AES256-CBC-SHA 0
```

## After
```
$ traffic_ctl metric match cipher | sort
proxy.process.ssl.cipher.user_agent.AES128-GCM-SHA256 0
proxy.process.ssl.cipher.user_agent.AES128-SHA 0
proxy.process.ssl.cipher.user_agent.AES256-GCM-SHA384 0
proxy.process.ssl.cipher.user_agent.AES256-SHA 0
proxy.process.ssl.cipher.user_agent.DES-CBC3-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES128-GCM-SHA256 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES128-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES256-GCM-SHA384 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-AES256-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-ECDSA-CHACHA20-POLY1305 0
proxy.process.ssl.cipher.user_agent.ECDHE-PSK-AES128-CBC-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-PSK-AES256-CBC-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-PSK-CHACHA20-POLY1305 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES128-GCM-SHA256 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES128-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES128-SHA256 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES256-GCM-SHA384 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-AES256-SHA 0
proxy.process.ssl.cipher.user_agent.ECDHE-RSA-CHACHA20-POLY1305 0
proxy.process.ssl.cipher.user_agent.OTHER 0
proxy.process.ssl.cipher.user_agent.PSK-AES128-CBC-SHA 0
proxy.process.ssl.cipher.user_agent.PSK-AES256-CBC-SHA 0
proxy.process.ssl.cipher.user_agent.TLS_AES_128_GCM_SHA256 0
proxy.process.ssl.cipher.user_agent.TLS_AES_256_GCM_SHA384 0
proxy.process.ssl.cipher.user_agent.TLS_CHACHA20_POLY1305_SHA256 0
```

# Ref.
- [RFC 8446 B.4. Cipher Suites](https://www.rfc-editor.org/rfc/rfc8446#appendix-B.4)