### PR TITLE
Revert "First cut at header heap genIDs and new API (#11780)"

### DIFF
--- a/include/proxy/hdrs/HdrHeap.h
+++ b/include/proxy/hdrs/HdrHeap.h
@@ -274,7 +274,6 @@ public:
   char    *m_free_start;
   char    *m_data_start;
   uint32_t m_size;
-  uint32_t m_genid;
 
   bool m_writeable;
 
@@ -485,8 +484,7 @@ public:
   void        set(const HdrHeapSDKHandle *from);
   const char *make_sdk_string(const char *raw_str, int raw_str_len);
 
-  HdrHeap *m_heap  = nullptr;
-  uint32_t m_genid = 0;
+  HdrHeap *m_heap = nullptr;
 
   // In order to prevent gratitous refcounting,
   //  automatic C++ copies are disabled!

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -332,12 +332,6 @@ TSMBuffer TSMBufferCreate(void);
  */
 TSReturnCode TSMBufferDestroy(TSMBuffer bufp);
 
-/**
-   Check to see if an MBuffer is still valid, from since the time
-   it was acquired.
- */
-bool TSMBufferIsValid(TSMBuffer bufp);
-
 /* --------------------------------------------------------------------------
    URLs */
 /**

--- a/src/proxy/hdrs/HdrHeap.cc
+++ b/src/proxy/hdrs/HdrHeap.cc
@@ -92,7 +92,6 @@ HdrHeap::init()
 {
   m_data_start = m_free_start = (reinterpret_cast<char *>(this)) + HDR_HEAP_HDR_SIZE;
   m_magic                     = HDR_BUF_MAGIC_ALIVE;
-  m_genid                     = 0;
   m_writeable                 = true;
 
   m_next      = nullptr;
@@ -370,8 +369,6 @@ HdrHeap::coalesce_str_heaps(int incoming_size)
   int new_heap_size = incoming_size;
   ink_assert(incoming_size >= 0);
   ink_assert(m_writeable);
-
-  ++m_genid;
 
   new_heap_size += required_space_for_evacuation();
 


### PR DESCRIPTION
This reverts commit 8ecad69415a51d07c4b73f839b9b142fa536ca73.

Cache compatibility issues. /Chris McFarlen.

