### PR TITLE
TransformTerminus::do_io_*: handle null buffer

### DIFF
--- a/include/proxy/TransformInternal.h
+++ b/include/proxy/TransformInternal.h
@@ -31,6 +31,7 @@ class TransformTerminus : public VConnection
 {
 public:
   TransformTerminus(TransformVConnection *tvc);
+  ~TransformTerminus() override;
 
   int handle_event(int event, void *edata);
 
@@ -49,6 +50,12 @@ public:
   int                   m_deletable;
   int                   m_closed;
   int                   m_called_user;
+
+private:
+  Event *_read_event     = nullptr;
+  bool   _read_disabled  = true;
+  Event *_write_event    = nullptr;
+  bool   _write_disabled = true;
 };
 
 class TransformVConnection : public TransformVCChain


### PR DESCRIPTION
This is a very similar change as #11789. With this patch, TransformTerminus properly supports a 0 byte read to cancel VIO. Without this patch, the logic naively scheduled an event which called the handler which would crash on what was often a canceled continuation or otherwise invalid continuation.