### PR TITLE
Coverity: fix for CID-1550449

### DIFF
--- a/src/tscore/lockfile.cc
+++ b/src/tscore/lockfile.cc
@@ -43,7 +43,7 @@ Lockfile::Open(pid_t *holding_pid)
 
   struct flock lock;
   char        *t;
-  int          size;
+  size_t       size;
 
   fd = -1;
 


### PR DESCRIPTION
[1550449](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1550449) Overflowed integer argument