### PR TITLE
Adds a HTTP-CNTL condition to header_rewrite

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1425,3 +1425,19 @@ ConditionNextHop::eval(const Resources &res)
 
   return static_cast<const Matchers<std::string> *>(_matcher)->test(s);
 }
+
+// ConditionHttpCntl: request header.
+void
+ConditionHttpCntl::initialize(Parser &p)
+{
+  Condition::initialize(p);
+}
+
+void
+ConditionHttpCntl::set_qualifier(const std::string &q)
+{
+  Condition::set_qualifier(q);
+
+  Dbg(pi_dbg_ctl, "\tParsing %%{HTTP-CNTL:%s}", q.c_str());
+  _http_cntl_qual = parse_http_cntl_qualifier(q);
+}

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -627,3 +627,35 @@ protected:
 private:
   NextHopQualifiers _next_hop_qual = NEXT_HOP_NONE;
 };
+
+// HTTP CNTL
+class ConditionHttpCntl : public Condition
+{
+public:
+  explicit ConditionHttpCntl() { Dbg(dbg_ctl, "Calling CTOR for ConditionHttpCntl"); }
+
+  // noncopyable
+  ConditionHttpCntl(const ConditionHttpCntl &) = delete;
+  void operator=(const ConditionHttpCntl &)    = delete;
+
+  void initialize(Parser &p) override;
+  void set_qualifier(const std::string &q) override;
+
+  void
+  append_value(std::string &s, const Resources &res) override
+  {
+    s += TSHttpTxnCntlGet(res.txnp, _http_cntl_qual) ? "TRUE" : "FALSE";
+    Dbg(pi_dbg_ctl, "Evaluating HTTP-CNTL(%s)", _qualifier.c_str());
+  }
+
+protected:
+  bool
+  eval(const Resources &res) override
+  {
+    Dbg(pi_dbg_ctl, "Evaluating HTTP-CNTL()");
+    return TSHttpTxnCntlGet(res.txnp, _http_cntl_qual);
+  }
+
+private:
+  TSHttpCntlType _http_cntl_qual = TS_HTTP_CNTL_LOGGING_MODE;
+};

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -162,6 +162,8 @@ condition_factory(const std::string &cond)
     c = new ConditionCache();
   } else if (c_name == "NEXT-HOP") { // This condition adapts to the hook
     c = new ConditionNextHop();
+  } else if (c_name == "HTTP-CNTL") { // This condition adapts to the hook
+    c = new ConditionHttpCntl();
   } else {
     TSError("[%s] Unknown condition %s", PLUGIN_NAME, c_name.c_str());
     return nullptr;

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1154,7 +1154,7 @@ void
 OperatorSetHttpCntl::initialize(Parser &p)
 {
   Operator::initialize(p);
-  _cntl_qual = parse_cntl_qualifier(p.get_arg());
+  _cntl_qual = parse_http_cntl_qualifier(p.get_arg());
 
   std::string flag = p.copy_value();
 

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1150,33 +1150,6 @@ OperatorSetDebug::exec(const Resources &res) const
   return true;
 }
 
-// OperatorSetHttpCntl
-TSHttpCntlType
-parse_cntl_qualifier(const std::string &q) // Helper function for parsing modifiers
-{
-  TSHttpCntlType qual = TS_HTTP_CNTL_LOGGING_MODE;
-
-  if (q == "LOGGING") {
-    qual = TS_HTTP_CNTL_LOGGING_MODE;
-  } else if (q == "INTERCEPT_RETRY") {
-    qual = TS_HTTP_CNTL_INTERCEPT_RETRY_MODE;
-  } else if (q == "RESP_CACHEABLE") {
-    qual = TS_HTTP_CNTL_RESPONSE_CACHEABLE;
-  } else if (q == "REQ_CACHEABLE") {
-    qual = TS_HTTP_CNTL_REQUEST_CACHEABLE;
-  } else if (q == "SERVER_NO_STORE") {
-    qual = TS_HTTP_CNTL_SERVER_NO_STORE;
-  } else if (q == "TXN_DEBUG") {
-    qual = TS_HTTP_CNTL_TXN_DEBUG;
-  } else if (q == "SKIP_REMAP") {
-    qual = TS_HTTP_CNTL_SKIP_REMAPPING;
-  } else {
-    TSError("[%s] Invalid HTTP-CNTL() qualifier: %s", PLUGIN_NAME, q.c_str());
-  }
-
-  return qual;
-}
-
 void
 OperatorSetHttpCntl::initialize(Parser &p)
 {

--- a/plugins/header_rewrite/statement.cc
+++ b/plugins/header_rewrite/statement.cc
@@ -114,3 +114,30 @@ Statement::parse_url_qualifier(const std::string &q) const
 
   return qual;
 }
+
+// Parse HTTP Ctrl qualifiers
+TSHttpCntlType
+Statement::parse_cntl_qualifier(const std::string &q) const
+{
+  TSHttpCntlType qual = TS_HTTP_CNTL_LOGGING_MODE;
+
+  if (q == "LOGGING") {
+    qual = TS_HTTP_CNTL_LOGGING_MODE;
+  } else if (q == "INTERCEPT_RETRY") {
+    qual = TS_HTTP_CNTL_INTERCEPT_RETRY_MODE;
+  } else if (q == "RESP_CACHEABLE") {
+    qual = TS_HTTP_CNTL_RESPONSE_CACHEABLE;
+  } else if (q == "REQ_CACHEABLE") {
+    qual = TS_HTTP_CNTL_REQUEST_CACHEABLE;
+  } else if (q == "SERVER_NO_STORE") {
+    qual = TS_HTTP_CNTL_SERVER_NO_STORE;
+  } else if (q == "TXN_DEBUG") {
+    qual = TS_HTTP_CNTL_TXN_DEBUG;
+  } else if (q == "SKIP_REMAP") {
+    qual = TS_HTTP_CNTL_SKIP_REMAPPING;
+  } else {
+    TSError("[%s] Invalid HTTP-CNTL() qualifier: %s", PLUGIN_NAME, q.c_str());
+  }
+
+  return qual;
+}

--- a/plugins/header_rewrite/statement.cc
+++ b/plugins/header_rewrite/statement.cc
@@ -115,9 +115,9 @@ Statement::parse_url_qualifier(const std::string &q) const
   return qual;
 }
 
-// Parse HTTP Ctrl qualifiers
+// Parse HTTP CNTL qualifiers
 TSHttpCntlType
-Statement::parse_cntl_qualifier(const std::string &q) const
+Statement::parse_http_cntl_qualifier(const std::string &q) const
 {
   TSHttpCntlType qual = TS_HTTP_CNTL_LOGGING_MODE;
 

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -152,6 +152,7 @@ protected:
 
   UrlQualifiers     parse_url_qualifier(const std::string &q) const;
   NextHopQualifiers parse_next_hop_qualifier(const std::string &q) const;
+  TSHttpCntlType    parse_cntl_qualifier(const std::string &q) const;
 
   void
   require_resources(const ResourceIDs ids)

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -152,7 +152,7 @@ protected:
 
   UrlQualifiers     parse_url_qualifier(const std::string &q) const;
   NextHopQualifiers parse_next_hop_qualifier(const std::string &q) const;
-  TSHttpCntlType    parse_cntl_qualifier(const std::string &q) const;
+  TSHttpCntlType    parse_http_cntl_qualifier(const std::string &q) const;
 
   void
   require_resources(const ResourceIDs ids)


### PR DESCRIPTION
For example, this can be useful to avoid doing computationally expensive HRW rules if logging is turned off, if the computation is only used when producing logs.

```
cond %{SEND_RESPONSE_HDR_HOOK} [AND]
cond %{HTTP-CNTL:LOGGING}
   # Do expensive stuff here
```

I also cleaned up docs a bit, the operators and conditions are supposed to be in alphabetic order.