### PR TITLE
s3_auth does not retry after a file read error

### DIFF
--- a/doc/admin-guide/plugins/origin_server_auth.en.rst
+++ b/doc/admin-guide/plugins/origin_server_auth.en.rst
@@ -198,3 +198,10 @@ The ``gcp_auth.config`` config file could look like this::
 
     session_token=<access_id>
     version=gcpv1
+
+Retrying config loading
+=======================
+
+If the specified configuration file cannot be opened or is missing required options, ATS will attempt to reload the file repeatedly with exponential backoff.
+
+If the configuration file includes an `expiration` parameter and the file has exceeded its expiration time, ATS will retry loading the file every minute for a duration of 10 minutes. After 10 minutes, the file must be manually reloaded.

--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -30,6 +30,7 @@
 #include <cstdlib>
 #include <climits>
 #include <cctype>
+#include <cmath>
 
 #include <fstream> /* std::ifstream */
 #include <string>

--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -420,6 +420,12 @@ public:
     return _conf_reload_count++;
   }
 
+  int
+  incr_invalid_file_count()
+  {
+    return _invalid_file_count++;
+  }
+
   // Setters
   void
   set_secret(const char *s)
@@ -510,6 +516,12 @@ public:
     _conf_reload_count = 0;
   }
 
+  void
+  reset_invalid_file_count()
+  {
+    _invalid_file_count = 0;
+  }
+
   // Parse configs from an external file
   bool parse_config(const std::string &filename);
 
@@ -568,6 +580,7 @@ private:
   long      _expiration          = 0;
   char     *_conf_fname          = nullptr;
   int       _conf_reload_count   = 0;
+  int       _invalid_file_count  = 0;
 };
 
 bool
@@ -1087,9 +1100,12 @@ config_reloader(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
   S3Config *file_config = gConfCache.get(s3->conf_fname());
 
   if (!file_config || !file_config->valid()) {
-    TSError("[%s] invalid configuration. Check mandatory fields.", PLUGIN_NAME);
+    TSError("[%s] invalid configuration. Check mandatory fields. Scheduling reload", PLUGIN_NAME);
+    long delay = pow(s3->incr_invalid_file_count(), 2);
+    s3->schedule_conf_reload(delay);
     return TS_ERROR;
   }
+  s3->reset_invalid_file_count();
 
   {
     std::unique_lock lock(s3->reload_mutex);

--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -30,7 +30,6 @@
 #include <cstdlib>
 #include <climits>
 #include <cctype>
-#include <cmath>
 
 #include <fstream> /* std::ifstream */
 #include <string>
@@ -1102,7 +1101,7 @@ config_reloader(TSCont cont, TSEvent /* event ATS_UNUSED */, void *edata)
 
   if (!file_config || !file_config->valid()) {
     TSError("[%s] invalid configuration. Check mandatory fields. Scheduling reload", PLUGIN_NAME);
-    long delay = pow(s3->incr_invalid_file_count(), 2);
+    long delay = 1 << s3->incr_invalid_file_count();
     s3->schedule_conf_reload(delay);
     return TS_ERROR;
   }


### PR DESCRIPTION
Currently, if a config file is invalid or cannot be opened/read, ATS does not retry loading the config. As a result, if there is something wrong, ATS will not retry which can lead to 400 errors until there is manual intervention.

This adds an exponential retry to loading and validating the config. 

This fixes #11831 