### PR TITLE
Change the interpretation of cache fragment size

### DIFF
--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -860,8 +860,11 @@ ink_cache_init(ts::ModuleVersion v)
              REC_ERR_FAIL);
   REC_ReadConfigInt32(cache_config_target_fragment_size, "proxy.config.cache.target_fragment_size");
 
-  if (cache_config_target_fragment_size == 0 || cache_config_target_fragment_size - sizeof(Doc) > MAX_FRAG_SIZE) {
+  if (cache_config_target_fragment_size == 0) {
     cache_config_target_fragment_size = DEFAULT_TARGET_FRAGMENT_SIZE;
+  } else if (cache_config_target_fragment_size - sizeof(Doc) > MAX_FRAG_SIZE) {
+    Warning("The fragments size exceed the limitation, setting to MAX_FRAG_SIZE (%ld)", MAX_FRAG_SIZE + sizeof(Doc));
+    cache_config_target_fragment_size = MAX_FRAG_SIZE + sizeof(Doc);
   }
 
   REC_EstablishStaticConfigInt32(cache_config_max_disk_errors, "proxy.config.cache.max_disk_errors");

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -52,8 +52,8 @@
 #define LOOKASIDE_SIZE               256
 #define AIO_NOT_IN_PROGRESS          -1
 #define AIO_AGG_WRITE_IN_PROGRESS    -2
-#define AUTO_SIZE_RAM_CACHE          -1                      // 1-1 with directory size
-#define DEFAULT_TARGET_FRAGMENT_SIZE (1048576 - sizeof(Doc)) // 1MB
+#define AUTO_SIZE_RAM_CACHE          -1       // 1-1 with directory size
+#define DEFAULT_TARGET_FRAGMENT_SIZE 1048576; // 1MB. Note: Should not exclude sizeof(Doc)
 #define STORE_BLOCKS_PER_STRIPE      (STRIPE_BLOCK_SIZE / STORE_BLOCK_SIZE)
 
 // Documents


### PR DESCRIPTION
This shouldn't change any code, but it fixes two things:

1. When the setting was set to 0, we'd set the fragment size to 1MB - sizeof(Doc), which is 1MB-72. However, when we use the fragment size, we subtract sizeof(Doc) again, in `target_fragment_size().` The value returned by this helper function is what it ends up using when creating a fragment to write.
2. Also confusing is that if you try to set a too large fragment size, it reverts to 1MB, rather than the maximum (capped) value of 4MB.

I intentionally left MAX_FRAG_SIZE as it is (4MB - 72), because this constant is used all over the place and expects to be this adjusted value.