### PR TITLE
Invoke initgroups() iff we got enough privileges (#11869)

### DIFF
--- a/src/tscore/ink_cap.cc
+++ b/src/tscore/ink_cap.cc
@@ -156,8 +156,10 @@ impersonate(const struct passwd *pwd, ImpersonationLevel level)
 #endif
 
   // Always repopulate the supplementary group list for the new user.
-  if (initgroups(pwd->pw_name, pwd->pw_gid) != 0) {
-    Fatal("switching to user %s, failed to initialize supplementary groups ID %ld", pwd->pw_name, (long)pwd->pw_gid);
+  if (geteuid() == 0) { // check that we have enough rights to call initgroups()
+    if (initgroups(pwd->pw_name, pwd->pw_gid) != 0) {
+      Fatal("switching to user %s, failed to initialize supplementary groups ID %ld", pwd->pw_name, (long)pwd->pw_gid);
+    }
   }
 
   switch (level) {


### PR DESCRIPTION
Follow up of https://github.com/apache/trafficserver/pull/11855, that rendered unusable ATS as root when spawned via traffic_manager. As mentioned on #11869, traffic_manager drops privileges when spawned as root and as consequence by the time that traffic_server attempts to call initgroups() it gets an EPERM error. 

Fixes #11869