### PR TITLE
Update otel_tracer plugin

### DIFF
--- a/cmake/Findopentelemetry.cmake
+++ b/cmake/Findopentelemetry.cmake
@@ -33,6 +33,8 @@ set(OTEL_LIBS
     opentelemetry_exporter_ostream_span
     opentelemetry_exporter_otlp_http
     opentelemetry_exporter_otlp_http_client
+    opentelemetry_exporter_otlp_http_log
+    opentelemetry_exporter_otlp_http_metric
     opentelemetry_http_client_curl
     opentelemetry_metrics
     opentelemetry_otlp_recordable
@@ -41,6 +43,8 @@ set(OTEL_LIBS
     opentelemetry_trace
     opentelemetry_version
     opentelemetry_common
+    opentelemetry_metrics
+    opentelemetry_logs
 )
 
 find_path(opentelemetry_INCLUDE_DIR NAMES opentelemetry/version.h)

--- a/doc/admin-guide/plugins/otel_tracer.en.rst
+++ b/doc/admin-guide/plugins/otel_tracer.en.rst
@@ -50,28 +50,14 @@ Compiling the Plugin
 
 To compile this plugin, we need nlohmann-json, protobuf and opentelemetry-cpp
 
-nlohmann-json:
-
-::
-
-  cd
-  wget https://github.com/nlohmann/json/archive/refs/tags/v3.9.1.tar.gz
-  tar zxvf v3.9.1.tar.gz
-  cd json-3.9.1
-  mkdir build
-  cd build
-  cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
-  make
-  make install
-
 protobuf:
 
 ::
 
   cd
-  wget https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.4.tar.gz
-  tar zxvf v3.19.4.tar.gz
-  cd protobuf-3.19.4
+  wget https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.12.tar.gz
+  tar zxvf v3.21.12.tar.gz
+  cd protobuf-3.21.12
   ./autogen.sh
   ./configure --enable-shared=no --enable-static=yes CXXFLAGS="-std=c++17 -fPIC" CFLAGS="-fPIC"
   make
@@ -82,12 +68,12 @@ opentelemetry-cpp
 ::
 
   cd
-  wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.3.0.tar.gz
-  tar zxvf v1.3.0.tar.gz
-  cd opentelemetry-cpp-1.3.0
+  wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.11.0.tar.gz
+  tar zxvf v1.11.0.tar.gz
+  cd opentelemetry-cpp-1.11.0
   mkdir build
   cd build
-  cmake .. -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_JAEGER=OFF -DWITH_OTLP=ON -DWITH_OTLP_GRPC=OFF -DWITH_OTLP_HTTP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
+  cmake .. -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_JAEGER=OFF -DWITH_OTLP_GRPC=OFF -DWITH_OTLP_HTTP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DWITH_ABSEIL=OFF
   cmake --build . --target all
   cmake --install . --config Debug --prefix /usr/local/
 
@@ -112,3 +98,15 @@ This is the service name that will be sent as part of the information to the OTL
 * ``-r=[sampling rate]`` (default: ``1.0``)
 
 The value can be between 0.0 to 1.0. It controls the sampling rate of the trace information.
+
+* ``-q=[queue size]`` (default: ``25``)
+
+The size of the batch processor queue.
+
+* ``-d=[delay]`` (default: ``3000``)
+
+The time interval between two consecutive exports in milliseconds.
+
+* ``-b=[batch size]`` (default: ``10``)
+
+The maximum batch size of every export. Should be smaller than queue size.

--- a/plugins/experimental/otel_tracer/otel_tracer.cc
+++ b/plugins/experimental/otel_tracer/otel_tracer.cc
@@ -334,17 +334,23 @@ TSPluginInit(int argc, const char *argv[])
   std::string url          = "";
   std::string service_name = "otel_tracer";
   double      rate         = 1.0;
+  int qsize                = 25;
+  int delay                = 3000;
+  int bsize                = 10;
   if (argc > 1) {
     int                        c;
     static const struct option longopts[] = {
       {const_cast<char *>("url"),           required_argument, nullptr, 'u'},
       {const_cast<char *>("service-name"),  required_argument, nullptr, 's'},
       {const_cast<char *>("sampling-rate"), required_argument, nullptr, 'r'},
+      {const_cast<char *>("queue-size"),    required_argument, nullptr, 'q'},
+      {const_cast<char *>("delay"),         required_argument, nullptr, 'd'},
+      {const_cast<char *>("batch-size"),    required_argument, nullptr, 'b'},
       {nullptr,                             0,                 nullptr, 0  },
     };
 
     int longindex = 0;
-    while ((c = getopt_long(argc, const_cast<char *const *>(argv), "u:s:r:", longopts, &longindex)) != -1) {
+    while ((c = getopt_long(argc, const_cast<char *const *>(argv), "u:s:r:q:d:b:", longopts, &longindex)) != -1) {
       switch (c) {
       case 'u':
         url = optarg;
@@ -354,13 +360,26 @@ TSPluginInit(int argc, const char *argv[])
         break;
       case 'r':
         rate = atof(optarg);
+        if (rate < 0) { TSEmergency("[otel_tracer][%s] Invalid rate parameter", __FUNCTION__); }
+        break;
+      case 'q':
+        qsize = atoi(optarg);
+        if (qsize < 0) { TSEmergency("[otel_tracer][%s] Invalid queue size parameter", __FUNCTION__); }
+        break;
+      case 'd':
+        delay = atoi(optarg);
+        if (delay < 0) { TSEmergency("[otel_tracer][%s] Invalid delay parameter", __FUNCTION__); }
+        break;
+      case 'b':
+        bsize = atoi(optarg);
+        if (bsize < 0) { TSEmergency("[otel_tracer][%s] Invalid batch size parameter", __FUNCTION__); }
         break;
       default:
         break;
       }
     }
   }
-  InitTracer(url, service_name, rate);
+  InitTracer(url, service_name, rate, qsize, delay, bsize);
 
   if (TSPluginRegister(&info) != TS_SUCCESS) {
     TSError("[%s] Plugin registration failed", PLUGIN_NAME);


### PR DESCRIPTION
Fixes #9961 

Update the use of opentelemetry to 1.11.0 which is the latest stable version and use batch processor to have better control of export frequency.