### PR TITLE
put dummy_forced_read inside a SANITY ifdef

### DIFF
--- a/src/tscore/ink_queue.cc
+++ b/src/tscore/ink_queue.cc
@@ -101,11 +101,13 @@ const ink_freelist_ops *freelist_global_ops = default_ops;
 
 DbgCtl dbg_ctl_freelist_init{"freelist_init"};
 
+#ifdef SANITY
 inline void
 dummy_forced_read(void *mem)
 {
   static_cast<void>(*const_cast<int volatile *>(reinterpret_cast<int *>(mem)));
 }
+#endif /* SANITY */
 
 } // end anonymous namespace
 


### PR DESCRIPTION
branch builds are failing due to unused function dummy_forced_read.  Calls to this function are inside a SANITY ifdef.  This PR wraps the function definition inside a SANITY ifdef.