### PR TITLE
Disable h2 prior knowledge on tls

### DIFF
--- a/src/proxy/ProtocolProbeSessionAccept.cc
+++ b/src/proxy/ProtocolProbeSessionAccept.cc
@@ -139,6 +139,7 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
       if (netvc->get_service<TLSBasicSupport>() == nullptr) {
         key = PROTO_HTTP2;
       } else {
+        // RFC 9113 Section 3.3: Prior knowledge is only permissible for HTTP/2 over plaintext (non-TLS) connections.
         Dbg(dbg_ctl_http, "HTTP/2 prior knowledge was used on a TLS connection (protocol violation). Selecting HTTP/1 instead.");
         key = PROTO_HTTP;
       }

--- a/src/proxy/ProtocolProbeSessionAccept.cc
+++ b/src/proxy/ProtocolProbeSessionAccept.cc
@@ -139,7 +139,7 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
       if (netvc->get_service<TLSBasicSupport>() == nullptr) {
         key = PROTO_HTTP2;
       } else {
-        Dbg(dbg_ctl_http, "HTTP/2 preface was received on a TLS connection (protocol violation). Using HTTP/1 instead.");
+        Dbg(dbg_ctl_http, "HTTP/2 prior knowledge was used on a TLS connection (protocol violation). Selecting HTTP/1 instead.");
         key = PROTO_HTTP;
       }
     } else {

--- a/src/proxy/ProtocolProbeSessionAccept.cc
+++ b/src/proxy/ProtocolProbeSessionAccept.cc
@@ -136,7 +136,12 @@ struct ProtocolProbeTrampoline : public Continuation, public ProtocolProbeSessio
     } // end of Proxy Protocol processing
 
     if (proto_is_http2(reader)) {
-      key = PROTO_HTTP2;
+      if (netvc->get_service<TLSBasicSupport>() == nullptr) {
+        key = PROTO_HTTP2;
+      } else {
+        Dbg(dbg_ctl_http, "HTTP/2 preface was received on a TLS connection (protocol violation). Using HTTP/1 instead.");
+        key = PROTO_HTTP;
+      }
     } else {
       key = PROTO_HTTP;
     }

--- a/tests/gold_tests/tls/test-0rtt-s_client.py
+++ b/tests/gold_tests/tls/test-0rtt-s_client.py
@@ -42,10 +42,15 @@ def main():
     else:
         sni_str = ''
 
+    if args.http_ver == 'h2':
+        alpn_str = '-alpn h2'
+    else:
+        alpn_str = ''
+
     s_client_cmd_1 = shlex.split(
-        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_out {sess_file_path} {sni_str}')
+        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_out {sess_file_path} {sni_str} {alpn_str}')
     s_client_cmd_2 = shlex.split(
-        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_in {sess_file_path} -early_data {early_data_file_path} {sni_str}'
+        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_in {sess_file_path} -early_data {early_data_file_path} {sni_str} {alpn_str}'
     )
 
     create_sess_proc = subprocess.Popen(


### PR DESCRIPTION
> HTTP/2 connections over TLS MUST use [protocol negotiation in TLS](https://datatracker.ietf.org/doc/html/rfc7301) [[TLS-ALPN](https://datatracker.ietf.org/doc/html/rfc7301)].

https://datatracker.ietf.org/doc/html/rfc9113#section-3.3-2