### PR TITLE
Record the amount of early data correctly

### DIFF
--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -2062,6 +2062,7 @@ SSLNetVConnection::_ssl_accept()
           }
           block->fill(nread);
           this->_early_data_buf->append_block(block);
+          this->_increment_early_data_len(nread);
           Metrics::Counter::increment(ssl_rsb.early_data_received_count);
 
           if (dbg_ctl_ssl_early_data_show_received.on()) {

--- a/src/proxy/http2/Http2CommonSession.cc
+++ b/src/proxy/http2/Http2CommonSession.cc
@@ -274,8 +274,9 @@ Http2CommonSession::do_start_frame_read(Http2ErrorCode &ret_error)
     this->cur_frame_from_early_data  = true;
   }
 
-  Http2SsnDebug("frame header length=%u, type=%u, flags=0x%x, streamid=%u", (unsigned)this->current_hdr.length,
-                (unsigned)this->current_hdr.type, (unsigned)this->current_hdr.flags, this->current_hdr.streamid);
+  Http2SsnDebug("frame header length=%u, type=%u, flags=0x%x, streamid=%u, early_data=%d", (unsigned)this->current_hdr.length,
+                (unsigned)this->current_hdr.type, (unsigned)this->current_hdr.flags, this->current_hdr.streamid,
+                this->cur_frame_from_early_data);
 
   this->_read_buffer_reader->consume(nbytes);
 

--- a/tests/gold_tests/tls/test-0rtt-s_client.py
+++ b/tests/gold_tests/tls/test-0rtt-s_client.py
@@ -42,10 +42,15 @@ def main():
     else:
         sni_str = ''
 
+    if args.http_ver == 'h2':
+        alpn_str = '-alpn h2'
+    else:
+        alpn_str = ''
+
     s_client_cmd_1 = shlex.split(
-        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_out {sess_file_path} {sni_str}')
+        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_out {sess_file_path} {sni_str} {alpn_str}')
     s_client_cmd_2 = shlex.split(
-        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_in {sess_file_path} -early_data {early_data_file_path} {sni_str}'
+        f'openssl s_client -connect 127.0.0.1:{args.ats_port} -tls1_3 -quiet -sess_in {sess_file_path} -early_data {early_data_file_path} {sni_str} {alpn_str}'
     )
 
     create_sess_proc = subprocess.Popen(


### PR DESCRIPTION
I found two bugs around early data.

The first commit fixes a bug in autest tls_0rtt_server (more specifically, the test client, test-0rtt-s_client). The test does not use ALPN to use H2 on TLS a TLS connection (protocol violation). The violation was found on #11881 (the test fails with the fix on #11881). 


The second commit fixes the other bug in SSLNetVC. It increments the total amount of early data received only after TLS handshake is completed. The first commit revealed this bug because it slightly changes the timing of read operations.