### PR TITLE
Updates to allow verify plugin tests to run without install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ option(EXTERNAL_YAML_CPP "Use external yaml-cpp (default OFF)")
 option(EXTERNAL_LIBSWOC "Use external libswoc (default OFF)")
 option(LINK_PLUGINS "Link core libraries to plugins (default OFF)")
 option(ENABLE_PROBES "Enable ATS SystemTap probes (default OFF)")
+option(ENABLE_VERIFY_PLUGINS "Enable plugin verification tests (default ON)" ON)
 
 # Setup user
 # NOTE: this is the user trafficserver runs as

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,8 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF",
         "CMAKE_INSTALL_PREFIX": "/opt/ats",
-        "BUILD_EXPERIMENTAL_PLUGINS": "ON"
+        "BUILD_EXPERIMENTAL_PLUGINS": "ON",
+        "ENABLE_VERIFY_PLUGINS": "OFF"
       }
     },
     {

--- a/cmake/add_atsplugin.cmake
+++ b/cmake/add_atsplugin.cmake
@@ -38,19 +38,25 @@ function(add_atsplugin name)
 endfunction()
 
 function(verify_remap_plugin target)
-  add_test(NAME verify_remap_${target} COMMAND $<TARGET_FILE:traffic_server> -C
-                                               "verify_remap_plugin $<TARGET_FILE:${target}>"
-  )
+  if(ENABLE_VERIFY_PLUGINS)
+    add_test(NAME verify_remap_${target} COMMAND $<TARGET_FILE:traffic_server> -C
+                                                 "verify_remap_plugin $<TARGET_FILE:${target}>"
+    )
+  endif()
 endfunction()
 
 function(verify_global_plugin target)
-  add_test(NAME verify_global_${target} COMMAND $<TARGET_FILE:traffic_server> -C
-                                                "verify_global_plugin $<TARGET_FILE:${target}>"
-  )
-  # Process the optional suppression file parameter.
-  set(suppression_file ${ARGV1})
-  if(suppression_file)
-    set_tests_properties(verify_global_${target} PROPERTIES ENVIRONMENT "LSAN_OPTIONS=suppressions=${suppression_file}")
+  if(ENABLE_VERIFY_PLUGINS)
+    add_test(NAME verify_global_${target} COMMAND $<TARGET_FILE:traffic_server> -C
+                                                  "verify_global_plugin $<TARGET_FILE:${target}>"
+    )
+    # Process the optional suppression file parameter.
+    set(suppression_file ${ARGV1})
+    if(suppression_file)
+      set_tests_properties(
+        verify_global_${target} PROPERTIES ENVIRONMENT "LSAN_OPTIONS=suppressions=${suppression_file}"
+      )
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
- Add option to skip verify tests
- Add `preinit` flag option to `-C` command to run the command before TS fully initializes