### PR TITLE
Fix merge issue from PR #11857

### DIFF
--- a/src/mgmt/rpc/server/IPCSocketServer.cc
+++ b/src/mgmt/rpc/server/IPCSocketServer.cc
@@ -46,8 +46,7 @@
 
 namespace
 {
-constexpr size_t MAX_REQUEST_BUFFER_SIZE{32000};
-DbgCtl           dbg_ctl{"rpc.net"};
+DbgCtl dbg_ctl{"rpc.net"};
 
 // Quick check for errors(base on the errno);
 bool check_for_transient_errors();


### PR DESCRIPTION
There was a leftover variable declaration that was causing unused variable errors on some builds.