### PR TITLE
Cleanup: Remove disk path copy from Stripe

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -434,7 +434,7 @@ freelist_clean(int s, Stripe *stripe)
   if (stripe->header->freelist[s]) {
     return;
   }
-  Warning("cache directory overflow on '%s' segment %d, purging...", stripe->path, s);
+  Warning("cache directory overflow on '%s' segment %d, purging...", stripe->disk->path, s);
   int  n   = 0;
   Dir *seg = stripe->dir_segment(s);
   for (int bi = 0; bi < stripe->buckets; bi++) {

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -400,7 +400,7 @@ CacheVC::handleReadDone(int event, Event * /* e ATS_UNUSED */)
         ink_assert(checksum == doc->checksum);
         if (checksum != doc->checksum) {
           Note("cache: checksum error for [%" PRIu64 " %" PRIu64 "] len %d, hlen %d, disk %s, offset %" PRIu64 " size %zu",
-               doc->first_key.b[0], doc->first_key.b[1], doc->len, doc->hlen, stripe->path, (uint64_t)io.aiocb.aio_offset,
+               doc->first_key.b[0], doc->first_key.b[1], doc->len, doc->hlen, stripe->disk->path, (uint64_t)io.aiocb.aio_offset,
                (size_t)io.aiocb.aio_nbytes);
           doc->magic = DOC_CORRUPT;
           okay       = 0;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -85,8 +85,7 @@ struct StripeInitInfo {
 //
 
 Stripe::Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size, int fragment_size)
-  : path{ats_strdup(disk->path)},
-    fd{disk->fd},
+  : fd{disk->fd},
     frag_size{fragment_size},
     skip{ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip))},
     start{skip},

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -85,7 +85,6 @@ class Stripe
 {
 public:
   ats_scoped_str hash_text;
-  char          *path = nullptr;
   int            fd{-1};
   int            frag_size{-1};
 
@@ -101,8 +100,8 @@ public:
   off_t                len{};
   off_t                data_blocks{};
 
-  CacheDisk *disk{};
-  uint32_t   sector_size{};
+  CacheDisk *const disk{};
+  uint32_t         sector_size{};
 
   CacheVol *cache_vol{};
 

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -193,7 +193,6 @@ TEST_CASE("The behavior of StripeSM::add_writer.")
   }
 
   ats_free(stripe.raw_dir);
-  ats_free(stripe.path);
 }
 
 // This test case demonstrates how to set up a StripeSM and make
@@ -304,7 +303,6 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
   }
 
   ats_free(stripe.raw_dir);
-  ats_free(stripe.path);
 }
 
 // When f.evacuator is set, vc.buf must contain a Doc object including headers
@@ -403,5 +401,4 @@ TEST_CASE("aggWrite behavior with f.evacuator set")
 
   delete[] source;
   ats_free(stripe.raw_dir);
-  ats_free(stripe.path);
 }


### PR DESCRIPTION
`Stripe::path` has copy of `CacheDisk::path`, but `Stripe` has pointer of `CacheDisk` and it doesn't change. 

This is part of making `Stripe` smaller and copyable.