### PR TITLE
Cleanup: Remove fd copy from Strip

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -434,7 +434,7 @@ freelist_clean(int s, Stripe *stripe)
   if (stripe->header->freelist[s]) {
     return;
   }
-  Warning("cache directory overflow on '%s' segment %d, purging...", stripe->path, s);
+  Warning("cache directory overflow on '%s' segment %d, purging...", stripe->disk->path, s);
   int  n   = 0;
   Dir *seg = stripe->dir_segment(s);
   for (int bi = 0; bi < stripe->buckets; bi++) {

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -524,7 +524,7 @@ Lagain:
         }
         if (stripe->dir_valid(e)) {
           DDbg(dbg_ctl_dir_probe_hit, "found %X %X vol %d bucket %d boffset %" PRId64 "", key->slice32(0), key->slice32(1),
-               stripe->fd, b, dir_offset(e));
+               stripe->disk->fd, b, dir_offset(e));
           dir_assign(result, e);
           *last_collision = e;
           ink_assert(dir_offset(e) * CACHE_BLOCK_SIZE < stripe->len);
@@ -550,7 +550,8 @@ Lagain:
     collision = nullptr;
     goto Lagain;
   }
-  DDbg(dbg_ctl_dir_probe_miss, "missed %X %X on vol %d bucket %d at %p", key->slice32(0), key->slice32(1), stripe->fd, b, seg);
+  DDbg(dbg_ctl_dir_probe_miss, "missed %X %X on vol %d bucket %d at %p", key->slice32(0), key->slice32(1), stripe->disk->fd, b,
+       seg);
   CHECK_DIR(d);
   return 0;
 }
@@ -613,8 +614,8 @@ Lfill:
   dir_assign_data(e, to_part);
   dir_set_tag(e, key->slice32(2));
   ink_assert(stripe->vol_offset(e) < (stripe->skip + stripe->len));
-  DDbg(dbg_ctl_dir_insert, "insert %p %X into vol %d bucket %d at %p tag %X %X boffset %" PRId64 "", e, key->slice32(0), stripe->fd,
-       bi, e, key->slice32(1), dir_tag(e), dir_offset(e));
+  DDbg(dbg_ctl_dir_insert, "insert %p %X into vol %d bucket %d at %p tag %X %X boffset %" PRId64 "", e, key->slice32(0),
+       stripe->disk->fd, bi, e, key->slice32(1), dir_tag(e), dir_offset(e));
   CHECK_DIR(d);
   stripe->header->dirty = 1;
   Metrics::Gauge::increment(cache_rsb.direntries_used);

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -400,7 +400,7 @@ CacheVC::handleReadDone(int event, Event * /* e ATS_UNUSED */)
         ink_assert(checksum == doc->checksum);
         if (checksum != doc->checksum) {
           Note("cache: checksum error for [%" PRIu64 " %" PRIu64 "] len %d, hlen %d, disk %s, offset %" PRIu64 " size %zu",
-               doc->first_key.b[0], doc->first_key.b[1], doc->len, doc->hlen, stripe->path, (uint64_t)io.aiocb.aio_offset,
+               doc->first_key.b[0], doc->first_key.b[1], doc->len, doc->hlen, stripe->disk->path, (uint64_t)io.aiocb.aio_offset,
                (size_t)io.aiocb.aio_nbytes);
           doc->magic = DOC_CORRUPT;
           okay       = 0;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -85,8 +85,7 @@ struct StripeInitInfo {
 //
 
 Stripe::Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size, int fragment_size)
-  : path{ats_strdup(disk->path)},
-    fd{disk->fd},
+  : fd{disk->fd},
     frag_size{fragment_size},
     skip{ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip))},
     start{skip},

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -85,8 +85,7 @@ struct StripeInitInfo {
 //
 
 Stripe::Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size, int fragment_size)
-  : fd{disk->fd},
-    frag_size{fragment_size},
+  : frag_size{fragment_size},
     skip{ROUND_TO_STORE_BLOCK((dir_skip < START_POS ? START_POS : dir_skip))},
     start{skip},
     len{blocks * STORE_BLOCK_SIZE},

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -85,7 +85,6 @@ class Stripe
 {
 public:
   ats_scoped_str hash_text;
-  char          *path = nullptr;
   int            fd{-1};
   int            frag_size{-1};
 
@@ -101,8 +100,8 @@ public:
   off_t                len{};
   off_t                data_blocks{};
 
-  CacheDisk *disk{};
-  uint32_t   sector_size{};
+  CacheDisk *const disk{};
+  uint32_t         sector_size{};
 
   CacheVol *cache_vol{};
 

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -154,7 +154,7 @@ StripeSM::clear_dir()
   size_t dir_len = this->dirlen();
   this->_clear_init();
 
-  if (pwrite(this->fd, this->raw_dir, dir_len, this->skip) < 0) {
+  if (pwrite(this->disk->fd, this->raw_dir, dir_len, this->skip) < 0) {
     Warning("unable to clear cache directory '%s'", this->hash_text.get());
     return -1;
   }
@@ -192,7 +192,7 @@ StripeSM::init(bool clear)
 
   for (unsigned i = 0; i < countof(init_info->vol_aio); i++) {
     AIOCallback *aio      = &(init_info->vol_aio[i]);
-    aio->aiocb.aio_fildes = fd;
+    aio->aiocb.aio_fildes = disk->fd;
     aio->aiocb.aio_buf    = &(init_info->vol_h_f[i * STORE_BLOCK_SIZE]);
     aio->aiocb.aio_nbytes = footerlen;
     aio->action           = this;
@@ -214,7 +214,7 @@ StripeSM::handle_dir_clear(int event, void *data)
     if (!op->ok()) {
       Warning("unable to clear cache directory '%s'", hash_text.get());
       disk->incrErrors(op);
-      fd = -1;
+      disk->fd = -1;
     }
 
     if (op->aiocb.aio_nbytes == dir_len) {

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -193,7 +193,6 @@ TEST_CASE("The behavior of StripeSM::add_writer.")
   }
 
   ats_free(stripe.raw_dir);
-  ats_free(stripe.path);
 }
 
 // This test case demonstrates how to set up a StripeSM and make
@@ -304,7 +303,6 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
   }
 
   ats_free(stripe.raw_dir);
-  ats_free(stripe.path);
 }
 
 // When f.evacuator is set, vc.buf must contain a Doc object including headers
@@ -403,5 +401,4 @@ TEST_CASE("aggWrite behavior with f.evacuator set")
 
   delete[] source;
   ats_free(stripe.raw_dir);
-  ats_free(stripe.path);
 }

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -109,7 +109,7 @@ attach_tmpfile_to_stripe(StripeSM &stripe)
   REQUIRE(file != nullptr);
   int fd{fileno(file)};
   REQUIRE(fd != -1);
-  stripe.fd = fd;
+  stripe.disk->fd = fd;
   return file;
 }
 


### PR DESCRIPTION
Pretty similar change to the #11895 but for `fd`.