### PR TITLE
Do not touch fd from StripeSM::handle_dir_clear

### DIFF
--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -216,7 +216,6 @@ StripeSM::handle_dir_clear(int event, void *data)
     if (!op->ok()) {
       Warning("unable to clear cache directory '%s'", hash_text.get());
       disk->incrErrors(op);
-      fd = -1;
     }
 
     if (op->aiocb.aio_nbytes == dir_len) {


### PR DESCRIPTION
Prior to the change, when `StripeSM::handle_dir_clear` faced an error, it set `fd = -1`. However, when  `CacheProcessor::mark_storage_offline` makes a bad `CacheDisk` offline, it's comparing `CacheDisk::fd` and `StripeSM::fd`.

https://github.com/apache/trafficserver/blob/dc59c4c1fc8243f60601127442ea6835c434ffdd/src/iocore/cache/CacheProcessor.cc#L457-L463

This might mess below metrics

- `proxy.process.cache.direntries.total`
- `proxy.process.cache.direntries.used`
- `proxy.process.cache.bytes_total`

FWIW, rebuilding Stripe Hash Table seems not affected by this.
