### PR TITLE
Coverity. `swoc` Make Name Binding global variables a singleton. 

### DIFF
--- a/lib/swoc/include/swoc/bwf_base.h
+++ b/lib/swoc/include/swoc/bwf_base.h
@@ -467,7 +467,7 @@ protected:
  * This nameset is used if no other is provided. Therefore bindings added to this nameset will be
  * available in the default formatting use.
  */
-extern ExternalNames Global_Names;
+extern ExternalNames& Global_Names();
 
 // --------------- Implementation --------------------
 /// --- Spec ---
@@ -919,25 +919,25 @@ BufferWriter::print_nfv(Binding &&names, Extractor &&ex, bwf::ArgPack const &arg
 template <typename... Args>
 BufferWriter &
 BufferWriter::print(const TextView &fmt, Args &&...args) {
-  return this->print_nfv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), bwf::ArgTuple{std::forward_as_tuple(args...)});
+  return this->print_nfv(bwf::Global_Names().bind(), bwf::Format::bind(fmt), bwf::ArgTuple{std::forward_as_tuple(args...)});
 }
 
 template <typename... Args>
 BufferWriter &
 BufferWriter::print(bwf::Format const &fmt, Args &&...args) {
-  return this->print_nfv(bwf::Global_Names.bind(), fmt.bind(), bwf::ArgTuple{std::forward_as_tuple(args...)});
+  return this->print_nfv(bwf::Global_Names().bind(), fmt.bind(), bwf::ArgTuple{std::forward_as_tuple(args...)});
 }
 
 template <typename... Args>
 BufferWriter &
 BufferWriter::print_v(TextView const &fmt, std::tuple<Args...> const &args) {
-  return this->print_nfv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), bwf::ArgTuple{args});
+  return this->print_nfv(bwf::Global_Names().bind(), bwf::Format::bind(fmt), bwf::ArgTuple{args});
 }
 
 template <typename... Args>
 BufferWriter &
 BufferWriter::print_v(const bwf::Format &fmt, const std::tuple<Args...> &args) {
-  return this->print_nfv(bwf::Global_Names.bind(), fmt.bind(), bwf::ArgTuple{args});
+  return this->print_nfv(bwf::Global_Names().bind(), fmt.bind(), bwf::ArgTuple{args});
 }
 
 template <typename Binding, typename Extractor>

--- a/lib/swoc/src/bw_format.cc
+++ b/lib/swoc/src/bw_format.cc
@@ -24,12 +24,16 @@
 using namespace std::literals;
 using namespace swoc::literals;
 
-swoc::bwf::ExternalNames swoc::bwf::Global_Names;
+
 using swoc::svto_radix;
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 
 namespace bwf {
+ExternalNames& Global_Names() {
+  static swoc::bwf::ExternalNames Global_Names;
+  return Global_Names;
+}
 
 const Spec Spec::DEFAULT;
 

--- a/lib/swoc/unit_tests/ex_bw_format.cc
+++ b/lib/swoc/unit_tests/ex_bw_format.cc
@@ -127,10 +127,10 @@ struct Context {
 
 void
 EX_BWF_Format_Init() {
-  swoc::bwf::Global_Names.assign("timestamp", &BWF_Timestamp);
-  swoc::bwf::Global_Names.assign("now", &BWF_Now);
-  swoc::bwf::Global_Names.assign("version", &BWF_Version);
-  swoc::bwf::Global_Names.assign("dave", &BWF_EvilDave);
+  swoc::bwf::Global_Names().assign("timestamp", &BWF_Timestamp);
+  swoc::bwf::Global_Names().assign("now", &BWF_Now);
+  swoc::bwf::Global_Names().assign("version", &BWF_Version);
+  swoc::bwf::Global_Names().assign("dave", &BWF_EvilDave);
 }
 
 // Work with external / global names.

--- a/src/proxy/http/HttpProxyServerMain.cc
+++ b/src/proxy/http/HttpProxyServerMain.cc
@@ -66,10 +66,10 @@ bool                    et_udp_threads_ready = false;
 
 // File / process scope initializations
 static bool HTTP_SERVER_INITIALIZED __attribute__((unused)) = []() -> bool {
-  swoc::bwf::Global_Names.assign("ts-thread", [](swoc::BufferWriter &w, swoc::bwf::Spec const &spec) -> swoc::BufferWriter & {
+  swoc::bwf::Global_Names().assign("ts-thread", [](swoc::BufferWriter &w, swoc::bwf::Spec const &spec) -> swoc::BufferWriter & {
     return bwformat(w, spec, this_thread());
   });
-  swoc::bwf::Global_Names.assign("ts-ethread", [](swoc::BufferWriter &w, swoc::bwf::Spec const &spec) -> swoc::BufferWriter & {
+  swoc::bwf::Global_Names().assign("ts-ethread", [](swoc::BufferWriter &w, swoc::bwf::Spec const &spec) -> swoc::BufferWriter & {
     return bwformat(w, spec, this_ethread());
   });
   return true;


### PR DESCRIPTION
This is an attempt to fix some ordering creation issues for some global variables within  lib swoc. 
The is to get `swoc::bwf::Global_Names` initialized first.

[#1534740](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1534740) and more...