### PR TITLE
Do not touch fd from StripeSM::handle_dir_clear (#11906)

### DIFF
--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -268,7 +268,6 @@ Stripe::handle_dir_clear(int event, void *data)
     if (!op->ok()) {
       Warning("unable to clear cache directory '%s'", hash_text.get());
       disk->incrErrors(op);
-      fd = -1;
     }
 
     if (op->aiocb.aio_nbytes == dir_len) {


### PR DESCRIPTION
Backport https://github.com/apache/trafficserver/pull/11906 to 10.0.x branch.

----

(cherry picked from commit 669cfcc1b97b1031ed5f4c1a5619456c84b11456)

Conflicts:
	src/iocore/cache/StripeSM.cc