### PR TITLE
Restore speed bucket metrics with more buckets

### DIFF
--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -305,6 +305,28 @@ struct HttpStatsBlock {
   Metrics::Counter::AtomicType *user_agent_response_document_total_size;
   Metrics::Counter::AtomicType *user_agent_response_header_total_size;
   Metrics::Gauge::AtomicType   *websocket_current_active_client_connections;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_100;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_1k;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_10k;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_100k;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_1M;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_10M;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_100M;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_200M;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_400M;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_800M;
+  Metrics::Counter::AtomicType *user_agent_speed_bytes_per_sec_1G;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_100;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_1k;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_10k;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_100k;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_1M;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_10M;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_100M;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_200M;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_400M;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_800M;
+  Metrics::Counter::AtomicType *origin_server_speed_bytes_per_sec_1G;
 };
 
 enum CacheOpenWriteFailAction_t {

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -1141,6 +1141,8 @@ public:
   static void milestone_start_api_time(State *s);
   static void milestone_update_api_time(State *s);
   static void client_result_stat(State *s, ink_hrtime total_time, ink_hrtime request_process_time);
+  static void origin_server_connection_speed(ink_hrtime transfer_time, int64_t nbytes);
+  static void user_agent_connection_speed(ink_hrtime transfer_time, int64_t nbytes);
   static void delete_warning_value(HTTPHdr *to_warn, HTTPWarningCode warning_code);
   static bool is_connection_collapse_checks_success(State *s); // YTS Team, yamsat
   static void update_method_stat(int method);

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -548,6 +548,49 @@ register_stat_callbacks()
   http_rsb.websocket_current_active_client_connections =
     Metrics::Gauge::createPtr("proxy.process.http.websocket.current_active_client_connections");
 
+  // Speed bucket stats for client and origin
+  http_rsb.user_agent_speed_bytes_per_sec_100 =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_100");
+  http_rsb.user_agent_speed_bytes_per_sec_1k = Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_1K");
+  http_rsb.user_agent_speed_bytes_per_sec_10k =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_10K");
+  http_rsb.user_agent_speed_bytes_per_sec_100k =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_100K");
+  http_rsb.user_agent_speed_bytes_per_sec_1M = Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_1M");
+  http_rsb.user_agent_speed_bytes_per_sec_10M =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_10M");
+  http_rsb.user_agent_speed_bytes_per_sec_100M =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_100M");
+  http_rsb.user_agent_speed_bytes_per_sec_200M =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_200M");
+  http_rsb.user_agent_speed_bytes_per_sec_400M =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_400M");
+  http_rsb.user_agent_speed_bytes_per_sec_800M =
+    Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_800M");
+  http_rsb.user_agent_speed_bytes_per_sec_1G = Metrics::Counter::createPtr("proxy.process.http.user_agent_speed_bytes_per_sec_1G");
+  http_rsb.origin_server_speed_bytes_per_sec_100 =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_100");
+  http_rsb.origin_server_speed_bytes_per_sec_1k =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_1K");
+  http_rsb.origin_server_speed_bytes_per_sec_10k =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_10K");
+  http_rsb.origin_server_speed_bytes_per_sec_100k =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_100K");
+  http_rsb.origin_server_speed_bytes_per_sec_1M =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_1M");
+  http_rsb.origin_server_speed_bytes_per_sec_10M =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_10M");
+  http_rsb.origin_server_speed_bytes_per_sec_100M =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_100M");
+  http_rsb.origin_server_speed_bytes_per_sec_200M =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_200M");
+  http_rsb.origin_server_speed_bytes_per_sec_400M =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_400M");
+  http_rsb.origin_server_speed_bytes_per_sec_800M =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_800M");
+  http_rsb.origin_server_speed_bytes_per_sec_1G =
+    Metrics::Counter::createPtr("proxy.process.http.origin_server_speed_bytes_per_sec_1G");
+
   Metrics::Derived::derive({
     // Total bytes of client request body + headers
     {"proxy.process.http.user_agent_total_request_bytes",

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -8281,6 +8281,71 @@ HttpTransact::milestone_update_api_time(State *s)
   s->state_machine->milestone_update_api_time();
 }
 
+void
+HttpTransact::origin_server_connection_speed(ink_hrtime transfer_time, int64_t nbytes)
+{
+  float bytes_per_hrtime =
+    (transfer_time == 0) ? (nbytes) : (static_cast<float>(nbytes) / static_cast<float>(static_cast<int64_t>(transfer_time)));
+  int bytes_per_sec = static_cast<int>(bytes_per_hrtime * HRTIME_SECOND);
+
+  if (bytes_per_sec <= 100) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_100);
+  } else if (bytes_per_sec <= 1024) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_1k);
+  } else if (bytes_per_sec <= 10240) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_10k);
+  } else if (bytes_per_sec <= 102400) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_100k);
+  } else if (bytes_per_sec <= 1048576) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_1M);
+  } else if (bytes_per_sec <= 10485760) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_10M);
+  } else if (bytes_per_sec <= 104857600) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_100M);
+  } else if (bytes_per_sec <= 2 * 104857600) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_200M);
+  } else if (bytes_per_sec <= 4 * 104857600) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_400M);
+  } else if (bytes_per_sec <= 8 * 104857600) {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_800M);
+  } else {
+    Metrics::Counter::increment(http_rsb.user_agent_speed_bytes_per_sec_1G);
+  }
+  return;
+}
+
+void
+HttpTransact::user_agent_connection_speed(ink_hrtime transfer_time, int64_t nbytes)
+{
+  float bytes_per_hrtime =
+    (transfer_time == 0) ? (nbytes) : (static_cast<float>(nbytes) / static_cast<float>(static_cast<int64_t>(transfer_time)));
+  int64_t bytes_per_sec = static_cast<int64_t>(bytes_per_hrtime * HRTIME_SECOND);
+
+  if (bytes_per_sec <= 100) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_100);
+  } else if (bytes_per_sec <= 1024) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_1k);
+  } else if (bytes_per_sec <= 10240) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_10k);
+  } else if (bytes_per_sec <= 102400) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_100k);
+  } else if (bytes_per_sec <= 1048576) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_1M);
+  } else if (bytes_per_sec <= 10485760) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_10M);
+  } else if (bytes_per_sec <= 104857600) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_100M);
+  } else if (bytes_per_sec <= 2 * 104857600) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_200M);
+  } else if (bytes_per_sec <= 4 * 104857600) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_400M);
+  } else if (bytes_per_sec <= 8 * 104857600) {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_800M);
+  } else {
+    Metrics::Counter::increment(http_rsb.origin_server_speed_bytes_per_sec_1G);
+  }
+}
+
 /*
  * added request_process_time stat for loadshedding foo
  */
@@ -8599,8 +8664,8 @@ HttpTransact::client_result_stat(State *s, ink_hrtime total_time, ink_hrtime req
 }
 
 void
-HttpTransact::update_size_and_time_stats(State *s, ink_hrtime total_time, ink_hrtime /* user_agent_write_time ATS_UNUSED */,
-                                         ink_hrtime /* origin_server_read_time ATS_UNUSED */, int user_agent_request_header_size,
+HttpTransact::update_size_and_time_stats(State *s, ink_hrtime total_time, ink_hrtime user_agent_write_time,
+                                         ink_hrtime origin_server_read_time, int user_agent_request_header_size,
                                          int64_t user_agent_request_body_size, int user_agent_response_header_size,
                                          int64_t user_agent_response_body_size, int origin_server_request_header_size,
                                          int64_t origin_server_request_body_size, int origin_server_response_header_size,
@@ -8730,6 +8795,14 @@ HttpTransact::update_size_and_time_stats(State *s, ink_hrtime total_time, ink_hr
     Metrics::Counter::increment(http_rsb.origin_server_response_header_total_size, origin_server_response_header_size);
     Metrics::Counter::increment(http_rsb.origin_server_request_document_total_size, origin_server_request_body_size);
     Metrics::Counter::increment(http_rsb.origin_server_response_document_total_size, origin_server_response_body_size);
+  }
+
+  if (user_agent_write_time >= 0) {
+    user_agent_connection_speed(user_agent_write_time, user_agent_response_size);
+  }
+
+  if (origin_server_request_header_size > 0 && origin_server_read_time > 0) {
+    origin_server_connection_speed(origin_server_read_time, origin_server_response_size);
   }
 
   if (s->method == HTTP_WKSIDX_PUSH) {


### PR DESCRIPTION
This restores the origin server and user agent speed buckets that were removed in 10.0.0 but have been sorely missed.
The new buckets are 200M, 400M, 800M and the new catch all bucket is 1G