### PR TITLE
Deduplicate StripeSM evacuate hit window computation

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -980,8 +980,7 @@ Lrestart:
       start_time = ink_get_hrtime();
     }
 
-    // recompute hit_evacuate_window
-    stripe->hit_evacuate_window = (stripe->data_blocks * cache_config_hit_evacuate_percent) / 100;
+    stripe->recompute_hit_evacuate_window();
 
     if (DISK_BAD(stripe->disk)) {
       goto Ldone;

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -97,7 +97,6 @@ public:
   off_t                skip{};  // start of headers
   off_t                start{}; // start of data
   off_t                len{};
-  off_t                data_blocks{};
 
   uint32_t sector_size{};
 
@@ -168,6 +167,7 @@ public:
   bool copy_from_aggregate_write_buffer(char *dest, Dir const &dir, size_t nbytes) const;
 
 protected:
+  off_t                data_blocks{};
   AggregateWriteBuffer _write_buffer;
 
   void _clear_init(std::uint32_t hw_sector_size);

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -170,7 +170,7 @@ StripeSM::init(bool clear)
   CryptoContext().hash_immediate(hash_id, hash_text, strlen(hash_text));
 
   // Evacuation
-  this->hit_evacuate_window = (this->data_blocks * cache_config_hit_evacuate_percent) / 100;
+  this->recompute_hit_evacuate_window();
 
   // AIO
   if (clear) {
@@ -1332,8 +1332,7 @@ StripeSM::shutdown(EThread *shutdown_thread)
     Dbg(dbg_ctl_cache_dir_sync, "Dir %s: ignoring -- not dirty", this->hash_text.get());
     return;
   }
-  // recompute hit_evacuate_window
-  this->hit_evacuate_window = (this->data_blocks * cache_config_hit_evacuate_percent) / 100;
+  this->recompute_hit_evacuate_window();
 
   // check if we have data in the agg buffer
   // dont worry about the cachevc s in the agg queue
@@ -1400,4 +1399,10 @@ int
 StripeSM::close_write(CacheVC *cont)
 {
   return open_dir.close_write(cont);
+}
+
+void
+StripeSM::recompute_hit_evacuate_window()
+{
+  this->hit_evacuate_window = (this->data_blocks * cache_config_hit_evacuate_percent) / 100;
 }

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -158,7 +158,11 @@ public:
 
   int evac_range(off_t start, off_t end, int evac_phase);
 
-  int within_hit_evacuate_window(Dir const *dir) const;
+  /**
+   * Recompute the hit evacuate window after a config change.
+   */
+  void recompute_hit_evacuate_window();
+  int  within_hit_evacuate_window(Dir const *dir) const;
 
   /**
    * StripeSM constructor.


### PR DESCRIPTION
The same expression is duplicated in 3 places, and 2 of them have a comment which I borrowed the name from. This allows us to make `Stripe::data_blocks` protected.