### PR TITLE
Group directory related `Stripe` fields into struct

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -403,7 +403,7 @@ dir_clean_vol(Stripe *stripe)
 void
 dir_clear_range(off_t start, off_t end, Stripe *stripe)
 {
-  for (off_t i = 0; i < stripe->directory.buckets * DIR_DEPTH * stripe->directory.segments; i++) {
+  for (off_t i = 0; i < stripe->directory.entries(); i++) {
     Dir *e = dir_index(stripe, i);
     if (dir_offset(e) >= static_cast<int64_t>(start) && dir_offset(e) < static_cast<int64_t>(end)) {
       Metrics::Gauge::decrement(cache_rsb.direntries_used);

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -219,7 +219,7 @@ void
 dir_init_segment(int s, Stripe *stripe)
 {
   stripe->directory.header->freelist[s] = 0;
-  Dir *seg                              = stripe->dir_segment(s);
+  Dir *seg                              = stripe->directory.get_segment(s);
   int  l, b;
   memset(static_cast<void *>(seg), 0, SIZEOF_DIR * DIR_DEPTH * stripe->directory.buckets);
   for (l = 1; l < DIR_DEPTH; l++) {
@@ -235,7 +235,7 @@ dir_init_segment(int s, Stripe *stripe)
 int
 dir_bucket_loop_fix(Dir *start_dir, int s, Stripe *stripe)
 {
-  if (!dir_bucket_loop_check(start_dir, stripe->dir_segment(s))) {
+  if (!dir_bucket_loop_check(start_dir, stripe->directory.get_segment(s))) {
     Warning("Dir loop exists, clearing segment %d", s);
     dir_init_segment(s, stripe);
     return 1;
@@ -247,7 +247,7 @@ int
 dir_freelist_length(Stripe *stripe, int s)
 {
   int  free = 0;
-  Dir *seg  = stripe->dir_segment(s);
+  Dir *seg  = stripe->directory.get_segment(s);
   Dir *e    = dir_from_offset(stripe->directory.header->freelist[s], seg);
   if (dir_bucket_loop_fix(e, s, stripe)) {
     return (DIR_DEPTH - 1) * stripe->directory.buckets;
@@ -264,7 +264,7 @@ dir_bucket_length(Dir *b, int s, Stripe *stripe)
 {
   Dir *e   = b;
   int  i   = 0;
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
 #ifdef LOOP_CHECK_MODE
   if (dir_bucket_loop_fix(b, s, vol))
     return 1;
@@ -285,7 +285,7 @@ check_dir(Stripe *stripe)
   int i, s;
   Dbg(dbg_ctl_cache_check_dir, "inside check dir");
   for (s = 0; s < stripe->directory.segments; s++) {
-    Dir *seg = stripe->dir_segment(s);
+    Dir *seg = stripe->directory.get_segment(s);
     for (i = 0; i < stripe->directory.buckets; i++) {
       Dir *b = dir_bucket(i, seg);
       if (!(dir_bucket_length(b, s, stripe) >= 0)) {
@@ -305,7 +305,7 @@ check_dir(Stripe *stripe)
 inline void
 unlink_from_freelist(Dir *e, int s, Stripe *stripe)
 {
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
   Dir *p   = dir_from_offset(dir_prev(e), seg);
   if (p) {
     dir_set_next(p, dir_next(e));
@@ -321,7 +321,7 @@ unlink_from_freelist(Dir *e, int s, Stripe *stripe)
 inline Dir *
 dir_delete_entry(Dir *e, Dir *p, int s, Stripe *stripe)
 {
-  Dir *seg                        = stripe->dir_segment(s);
+  Dir *seg                        = stripe->directory.get_segment(s);
   int  no                         = dir_next(e);
   stripe->directory.header->dirty = 1;
   if (p) {
@@ -352,7 +352,7 @@ inline void
 dir_clean_bucket(Dir *b, int s, Stripe *stripe)
 {
   Dir *e = b, *p = nullptr;
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
 #ifdef LOOP_CHECK_MODE
   int loop_count = 0;
 #endif
@@ -384,7 +384,7 @@ dir_clean_bucket(Dir *b, int s, Stripe *stripe)
 void
 dir_clean_segment(int s, Stripe *stripe)
 {
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
   for (int64_t i = 0; i < stripe->directory.buckets; i++) {
     dir_clean_bucket(dir_bucket(i, seg), s, stripe);
     ink_assert(!dir_next(dir_bucket(i, seg)) || dir_offset(dir_bucket(i, seg)));
@@ -436,7 +436,7 @@ freelist_clean(int s, StripeSM *stripe)
   }
   Warning("cache directory overflow on '%s' segment %d, purging...", stripe->disk->path, s);
   int  n   = 0;
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
   for (int bi = 0; bi < stripe->directory.buckets; bi++) {
     Dir *b = dir_bucket(bi, seg);
     for (int l = 0; l < DIR_DEPTH; l++) {
@@ -454,7 +454,7 @@ freelist_clean(int s, StripeSM *stripe)
 inline Dir *
 freelist_pop(int s, StripeSM *stripe)
 {
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
   Dir *e   = dir_from_offset(stripe->directory.header->freelist[s], seg);
   if (!e) {
     freelist_clean(s, stripe);
@@ -476,7 +476,7 @@ freelist_pop(int s, StripeSM *stripe)
 void
 dir_free_entry(Dir *e, int s, Stripe *stripe)
 {
-  Dir         *seg = stripe->dir_segment(s);
+  Dir         *seg = stripe->directory.get_segment(s);
   unsigned int fo  = stripe->directory.header->freelist[s];
   unsigned int eo  = dir_to_offset(e, seg);
   dir_set_next(e, fo);
@@ -492,7 +492,7 @@ dir_probe(const CacheKey *key, StripeSM *stripe, Dir *result, Dir **last_collisi
   ink_assert(stripe->mutex->thread_holding == this_ethread());
   int  s   = key->slice32(0) % stripe->directory.segments;
   int  b   = key->slice32(1) % stripe->directory.buckets;
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
   Dir *e = nullptr, *p = nullptr, *collision = *last_collision;
   CHECK_DIR(d);
 #ifdef LOOP_CHECK_MODE
@@ -562,7 +562,7 @@ dir_insert(const CacheKey *key, StripeSM *stripe, Dir *to_part)
   int s  = key->slice32(0) % stripe->directory.segments, l;
   int bi = key->slice32(1) % stripe->directory.buckets;
   ink_assert(dir_approx_size(to_part) <= MAX_FRAG_SIZE + sizeof(Doc));
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
   Dir *e   = nullptr;
   Dir *b   = dir_bucket(bi, seg);
 #if defined(DEBUG) && defined(DO_CHECK_DIR_FAST)
@@ -629,7 +629,7 @@ dir_overwrite(const CacheKey *key, StripeSM *stripe, Dir *dir, Dir *overwrite, b
   ink_assert(stripe->mutex->thread_holding == this_ethread());
   int          s   = key->slice32(0) % stripe->directory.segments, l;
   int          bi  = key->slice32(1) % stripe->directory.buckets;
-  Dir         *seg = stripe->dir_segment(s);
+  Dir         *seg = stripe->directory.get_segment(s);
   Dir         *e   = nullptr;
   Dir         *b   = dir_bucket(bi, seg);
   unsigned int t   = DIR_MASK_TAG(key->slice32(2));
@@ -716,7 +716,7 @@ dir_delete(const CacheKey *key, StripeSM *stripe, Dir *del)
   ink_assert(stripe->mutex->thread_holding == this_ethread());
   int  s   = key->slice32(0) % stripe->directory.segments;
   int  b   = key->slice32(1) % stripe->directory.buckets;
-  Dir *seg = stripe->dir_segment(s);
+  Dir *seg = stripe->directory.get_segment(s);
   Dir *e = nullptr, *p = nullptr;
 #ifdef LOOP_CHECK_MODE
   int loop_count = 0;
@@ -886,7 +886,7 @@ dir_entries_used(Stripe *stripe)
   uint64_t full  = 0;
   uint64_t sfull = 0;
   for (int s = 0; s < stripe->directory.segments; full += sfull, s++) {
-    Dir *seg = stripe->dir_segment(s);
+    Dir *seg = stripe->directory.get_segment(s);
     sfull    = 0;
     for (int b = 0; b < stripe->directory.buckets; b++) {
       Dir *e = dir_bucket(b, seg);

--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -456,7 +456,7 @@ CacheProcessor::mark_storage_offline(CacheDisk *d, ///< Target disk
 
   for (p = 0; p < gnstripes; p++) {
     if (d->fd == gstripes[p]->fd) {
-      total_dir_delete   += gstripes[p]->directory.buckets * gstripes[p]->directory.segments * DIR_DEPTH;
+      total_dir_delete   += gstripes[p]->directory.entries();
       used_dir_delete    += dir_entries_used(gstripes[p]);
       total_bytes_delete += gstripes[p]->len - gstripes[p]->dirlen();
     }
@@ -1514,7 +1514,7 @@ CacheProcessor::cacheInitialized()
         Dbg(dbg_ctl_cache_init, "total_cache_bytes = %" PRId64 " = %" PRId64 "Mb", total_cache_bytes,
             total_cache_bytes / (1024 * 1024));
 
-        uint64_t vol_total_direntries  = stripe->directory.buckets * stripe->directory.segments * DIR_DEPTH;
+        uint64_t vol_total_direntries  = stripe->directory.entries();
         total_direntries              += vol_total_direntries;
         Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.direntries_total, vol_total_direntries);
 

--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -159,8 +159,8 @@ inline int64_t
 cache_bytes_used(int index)
 {
   if (!DISK_BAD(gstripes[index]->disk)) {
-    if (!gstripes[index]->header->cycle) {
-      return gstripes[index]->header->write_pos - gstripes[index]->start;
+    if (!gstripes[index]->directory.header->cycle) {
+      return gstripes[index]->directory.header->write_pos - gstripes[index]->start;
     } else {
       return gstripes[index]->len - gstripes[index]->dirlen() - EVACUATION_SIZE;
     }
@@ -456,7 +456,7 @@ CacheProcessor::mark_storage_offline(CacheDisk *d, ///< Target disk
 
   for (p = 0; p < gnstripes; p++) {
     if (d->fd == gstripes[p]->fd) {
-      total_dir_delete   += gstripes[p]->buckets * gstripes[p]->segments * DIR_DEPTH;
+      total_dir_delete   += gstripes[p]->directory.buckets * gstripes[p]->directory.segments * DIR_DEPTH;
       used_dir_delete    += dir_entries_used(gstripes[p]);
       total_bytes_delete += gstripes[p]->len - gstripes[p]->dirlen();
     }
@@ -1420,16 +1420,16 @@ CacheProcessor::cacheInitialized()
 
   // Update stripe version data.
   if (gnstripes) { // start with whatever the first stripe is.
-    cacheProcessor.min_stripe_version = cacheProcessor.max_stripe_version = gstripes[0]->header->version;
+    cacheProcessor.min_stripe_version = cacheProcessor.max_stripe_version = gstripes[0]->directory.header->version;
   }
   // scan the rest of the stripes.
   for (int i = 1; i < gnstripes; i++) {
     StripeSM *v = gstripes[i];
-    if (v->header->version < cacheProcessor.min_stripe_version) {
-      cacheProcessor.min_stripe_version = v->header->version;
+    if (v->directory.header->version < cacheProcessor.min_stripe_version) {
+      cacheProcessor.min_stripe_version = v->directory.header->version;
     }
-    if (cacheProcessor.max_stripe_version < v->header->version) {
-      cacheProcessor.max_stripe_version = v->header->version;
+    if (cacheProcessor.max_stripe_version < v->directory.header->version) {
+      cacheProcessor.max_stripe_version = v->directory.header->version;
     }
   }
 
@@ -1514,7 +1514,7 @@ CacheProcessor::cacheInitialized()
         Dbg(dbg_ctl_cache_init, "total_cache_bytes = %" PRId64 " = %" PRId64 "Mb", total_cache_bytes,
             total_cache_bytes / (1024 * 1024));
 
-        uint64_t vol_total_direntries  = stripe->buckets * stripe->segments * DIR_DEPTH;
+        uint64_t vol_total_direntries  = stripe->directory.buckets * stripe->directory.segments * DIR_DEPTH;
         total_direntries              += vol_total_direntries;
         Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.direntries_total, vol_total_direntries);
 

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -803,7 +803,7 @@ CacheVC::openReadStartEarliest(int /* event ATS_UNUSED */, Event * /* e ATS_UNUS
     if (stripe->within_hit_evacuate_window(&earliest_dir) &&
         (!cache_config_hit_evacuate_size_limit || doc_len <= static_cast<uint64_t>(cache_config_hit_evacuate_size_limit))) {
       DDbg(dbg_ctl_cache_hit_evac, "dir: %" PRId64 ", write: %" PRId64 ", phase: %d", dir_offset(&earliest_dir),
-           stripe->offset_to_vol_offset(stripe->header->write_pos), stripe->header->phase);
+           stripe->offset_to_vol_offset(stripe->directory.header->write_pos), stripe->directory.header->phase);
       f.hit_evacuate = 1;
     }
     goto Lsuccess;
@@ -1107,7 +1107,7 @@ CacheVC::openReadStartHead(int event, Event *e)
     if (stripe->within_hit_evacuate_window(&dir) &&
         (!cache_config_hit_evacuate_size_limit || doc_len <= static_cast<uint64_t>(cache_config_hit_evacuate_size_limit))) {
       DDbg(dbg_ctl_cache_hit_evac, "dir: %" PRId64 ", write: %" PRId64 ", phase: %d", dir_offset(&dir),
-           stripe->offset_to_vol_offset(stripe->header->write_pos), stripe->header->phase);
+           stripe->offset_to_vol_offset(stripe->directory.header->write_pos), stripe->directory.header->phase);
       f.hit_evacuate = 1;
     }
 

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -135,7 +135,7 @@ make_vol_map(Stripe *stripe)
   // Scan directories.
   // Copied from dir_entries_used() and modified to fill in the map instead.
   for (int s = 0; s < stripe->directory.segments; s++) {
-    Dir *seg = stripe->dir_segment(s);
+    Dir *seg = stripe->directory.get_segment(s);
     for (int b = 0; b < stripe->directory.buckets; b++) {
       Dir *e = dir_bucket(b, seg);
       if (dir_bucket_loop_fix(e, s, stripe)) {

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -134,9 +134,9 @@ make_vol_map(Stripe *stripe)
 
   // Scan directories.
   // Copied from dir_entries_used() and modified to fill in the map instead.
-  for (int s = 0; s < stripe->segments; s++) {
+  for (int s = 0; s < stripe->directory.segments; s++) {
     Dir *seg = stripe->dir_segment(s);
-    for (int b = 0; b < stripe->buckets; b++) {
+    for (int b = 0; b < stripe->directory.buckets; b++) {
       Dir *e = dir_bucket(b, seg);
       if (dir_bucket_loop_fix(e, s, stripe)) {
         break;

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -694,7 +694,7 @@ CacheVC::openWriteStartDone(int event, Event *e)
        */
       if (!stripe->dir_valid(&dir)) {
         DDbg(dbg_ctl_cache_write, "OpenReadStartDone: Dir not valid: Write Head: %" PRId64 ", Dir: %" PRId64,
-             (int64_t)stripe->offset_to_vol_offset(stripe->header->write_pos), dir_offset(&dir));
+             (int64_t)stripe->offset_to_vol_offset(stripe->directory.header->write_pos), dir_offset(&dir));
         last_collision = nullptr;
         goto Lcollision;
       }

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -286,7 +286,17 @@ struct Directory {
   StripteHeaderFooter *footer{};
   int                  segments{};
   off_t                buckets{};
+
+  /* Total number of dir entries.
+   */
+  int entries() const;
 };
+
+inline int
+Directory::entries() const
+{
+  return this->buckets * DIR_DEPTH * this->segments;
+}
 
 // Global Functions
 

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -79,7 +79,7 @@ class CacheEvacuateDocVC;
 #define CHECK_DIR(_d) ((void)0)
 #endif
 
-#define dir_index(_e, _i) ((Dir *)((char *)(_e)->dir + (SIZEOF_DIR * (_i))))
+#define dir_index(_e, _i) ((Dir *)((char *)(_e)->directory.dir + (SIZEOF_DIR * (_i))))
 #define dir_assign(_e, _x)   \
   do {                       \
     (_e)->w[0] = (_x)->w[0]; \

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -290,12 +290,22 @@ struct Directory {
   /* Total number of dir entries.
    */
   int entries() const;
+
+  /* Returns the first dir in segment @a s.
+   */
+  Dir *get_segment(int s) const;
 };
 
 inline int
 Directory::entries() const
 {
   return this->buckets * DIR_DEPTH * this->segments;
+}
+
+inline Dir *
+Directory::get_segment(int s) const
+{
+  return reinterpret_cast<Dir *>((reinterpret_cast<char *>(this->dir)) + (s * this->buckets) * DIR_DEPTH * SIZEOF_DIR);
 }
 
 // Global Functions

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -33,6 +33,12 @@
 // aio
 #include "iocore/aio/AIO.h"
 
+#include "tscore/ink_platform.h"
+#include "tscore/Version.h"
+
+#include <cstdint>
+#include <ctime>
+
 class Stripe;
 class StripeSM;
 struct InterimCacheVol;
@@ -253,6 +259,33 @@ struct CacheSync : public Continuation {
   void        aio_write(int fd, char *b, int n, off_t o);
 
   CacheSync() : Continuation(new_ProxyMutex()) { SET_HANDLER(&CacheSync::mainEvent); }
+};
+
+struct StripteHeaderFooter {
+  unsigned int      magic;
+  ts::VersionNumber version;
+  time_t            create_time;
+  off_t             write_pos;
+  off_t             last_write_pos;
+  off_t             agg_pos;
+  uint32_t          generation; // token generation (vary), this cannot be 0
+  uint32_t          phase;
+  uint32_t          cycle;
+  uint32_t          sync_serial;
+  uint32_t          write_serial;
+  uint32_t          dirty;
+  uint32_t          sector_size;
+  uint32_t          unused; // pad out to 8 byte boundary
+  uint16_t          freelist[1];
+};
+
+struct Directory {
+  char                *raw_dir{nullptr};
+  Dir                 *dir{};
+  StripteHeaderFooter *header{};
+  StripteHeaderFooter *footer{};
+  int                  segments{};
+  off_t                buckets{};
 };
 
 // Global Functions

--- a/src/iocore/cache/PreservationTable.cc
+++ b/src/iocore/cache/PreservationTable.cc
@@ -173,7 +173,7 @@ PreservationTable::scan_for_pinned_documents(Stripe const *stripe)
     int vol_end_offset    = stripe->offset_to_vol_offset(stripe->len + stripe->skip);
     int before_end_of_vol = pe < vol_end_offset;
     DDbg(dbg_ctl_cache_evac, "scan %d %d", ps, pe);
-    for (int i = 0; i < stripe->direntries(); i++) {
+    for (int i = 0; i < stripe->directory.entries(); i++) {
       // is it a valid pinned object?
       if (!dir_is_empty(&stripe->directory.dir[i]) && dir_pinned(&stripe->directory.dir[i]) &&
           dir_head(&stripe->directory.dir[i])) {

--- a/src/iocore/cache/PreservationTable.cc
+++ b/src/iocore/cache/PreservationTable.cc
@@ -155,7 +155,7 @@ PreservationTable::periodic_scan(Stripe *stripe)
 {
   cleanup(stripe);
   scan_for_pinned_documents(stripe);
-  if (stripe->header->write_pos == stripe->start) {
+  if (stripe->directory.header->write_pos == stripe->start) {
     stripe->scan_pos = stripe->start;
   }
   stripe->scan_pos += stripe->len / PIN_SCAN_EVERY;
@@ -167,17 +167,19 @@ PreservationTable::scan_for_pinned_documents(Stripe const *stripe)
   if (cache_config_permit_pinning) {
     // we can't evacuate anything between header->write_pos and
     // header->write_pos + AGG_SIZE.
-    int ps = stripe->offset_to_vol_offset(stripe->header->write_pos + AGG_SIZE);
-    int pe = stripe->offset_to_vol_offset(stripe->header->write_pos + 2 * EVACUATION_SIZE + (stripe->len / PIN_SCAN_EVERY));
+    int ps = stripe->offset_to_vol_offset(stripe->directory.header->write_pos + AGG_SIZE);
+    int pe =
+      stripe->offset_to_vol_offset(stripe->directory.header->write_pos + 2 * EVACUATION_SIZE + (stripe->len / PIN_SCAN_EVERY));
     int vol_end_offset    = stripe->offset_to_vol_offset(stripe->len + stripe->skip);
     int before_end_of_vol = pe < vol_end_offset;
     DDbg(dbg_ctl_cache_evac, "scan %d %d", ps, pe);
     for (int i = 0; i < stripe->direntries(); i++) {
       // is it a valid pinned object?
-      if (!dir_is_empty(&stripe->dir[i]) && dir_pinned(&stripe->dir[i]) && dir_head(&stripe->dir[i])) {
+      if (!dir_is_empty(&stripe->directory.dir[i]) && dir_pinned(&stripe->directory.dir[i]) &&
+          dir_head(&stripe->directory.dir[i])) {
         // select objects only within this PIN_SCAN region
-        int o = dir_offset(&stripe->dir[i]);
-        if (dir_phase(&stripe->dir[i]) == stripe->header->phase) {
+        int o = dir_offset(&stripe->directory.dir[i]);
+        if (dir_phase(&stripe->directory.dir[i]) == stripe->directory.header->phase) {
           if (before_end_of_vol || o >= (pe - vol_end_offset)) {
             continue;
           }
@@ -186,7 +188,7 @@ PreservationTable::scan_for_pinned_documents(Stripe const *stripe)
             continue;
           }
         }
-        force_evacuate_head(&stripe->dir[i], 1);
+        force_evacuate_head(&stripe->directory.dir[i], 1);
       }
     }
   }
@@ -195,7 +197,7 @@ PreservationTable::scan_for_pinned_documents(Stripe const *stripe)
 void
 PreservationTable::cleanup(Stripe const *stripe)
 {
-  int64_t eo = ((stripe->header->write_pos - stripe->start) / CACHE_BLOCK_SIZE) + 1;
+  int64_t eo = ((stripe->directory.header->write_pos - stripe->start) / CACHE_BLOCK_SIZE) + 1;
   int64_t e  = dir_offset_evac_bucket(eo);
   int64_t sx = e - (evacuate_size / PIN_SCAN_EVERY) - 1;
   int64_t s  = sx;
@@ -228,8 +230,10 @@ PreservationTable::remove_finished_blocks(Stripe const *stripe, int bucket)
 {
   EvacuationBlock *b = evac_bucket_valid(bucket) ? evacuate[bucket].head : nullptr;
   while (b) {
-    if (b->f.done && ((stripe->header->phase != dir_phase(&b->dir) && stripe->header->write_pos > stripe->vol_offset(&b->dir)) ||
-                      (stripe->header->phase == dir_phase(&b->dir) && stripe->header->write_pos <= stripe->vol_offset(&b->dir)))) {
+    if (b->f.done && ((stripe->directory.header->phase != dir_phase(&b->dir) &&
+                       stripe->directory.header->write_pos > stripe->vol_offset(&b->dir)) ||
+                      (stripe->directory.header->phase == dir_phase(&b->dir) &&
+                       stripe->directory.header->write_pos <= stripe->vol_offset(&b->dir)))) {
       EvacuationBlock *x = b;
       DDbg(dbg_ctl_cache_evac, "evacuate cleanup free %X offset %" PRId64, b->evac_frags.key.slice32(0), dir_offset(&b->dir));
       b = b->link.next;

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -191,7 +191,7 @@ Stripe::dir_check()
   printf("  Entries:   %" PRIu64 "\n", total_entries);
 
   for (int s = 0; s < directory.segments; s++) {
-    Dir *seg                = this->dir_segment(s);
+    Dir *seg                = this->directory.get_segment(s);
     int  seg_chain_max      = 0;
     int  seg_empty          = 0;
     int  seg_in_use         = 0;
@@ -346,7 +346,7 @@ Stripe::_init_dir()
 
   for (s = 0; s < this->directory.segments; s++) {
     this->directory.header->freelist[s] = 0;
-    Dir *seg                            = this->dir_segment(s);
+    Dir *seg                            = this->directory.get_segment(s);
     for (l = 1; l < DIR_DEPTH; l++) {
       for (b = 0; b < this->directory.buckets; b++) {
         Dir *bucket = dir_bucket(b, seg);

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -133,9 +133,9 @@ Stripe::_init_data_internal(int avg_obj_size)
   // step2: calculate the number of buckets
   off_t total_buckets = total_entries / DIR_DEPTH;
   // step3: calculate the number of segments, no segment has more than 16384 buckets
-  this->segments = (total_buckets + (((1 << 16) - 1) / DIR_DEPTH)) / ((1 << 16) / DIR_DEPTH);
+  this->directory.segments = (total_buckets + (((1 << 16) - 1) / DIR_DEPTH)) / ((1 << 16) / DIR_DEPTH);
   // step4: divide total_buckets into segments on average.
-  this->buckets = (total_buckets + this->segments - 1) / this->segments;
+  this->directory.buckets = (total_buckets + this->directory.segments - 1) / this->directory.segments;
   // step5: set the start pointer.
   this->start = this->skip + 2 * this->dirlen();
 }
@@ -153,15 +153,15 @@ Stripe::_init_directory(std::size_t directory_size, int header_size, int footer_
   Dbg(dbg_ctl_cache_init, "Stripe %s: allocating %zu directory bytes for a %lld byte volume (%lf%%)", hash_text.get(),
       directory_size, (long long)this->len, percent(directory_size, this->len));
   if (ats_hugepage_enabled()) {
-    this->raw_dir = static_cast<char *>(ats_alloc_hugepage(directory_size));
+    this->directory.raw_dir = static_cast<char *>(ats_alloc_hugepage(directory_size));
   }
-  if (nullptr == this->raw_dir) {
-    this->raw_dir = static_cast<char *>(ats_memalign(ats_pagesize(), directory_size));
+  if (nullptr == this->directory.raw_dir) {
+    this->directory.raw_dir = static_cast<char *>(ats_memalign(ats_pagesize(), directory_size));
   }
-  this->dir    = reinterpret_cast<Dir *>(this->raw_dir + header_size);
-  this->header = reinterpret_cast<StripteHeaderFooter *>(this->raw_dir);
+  this->directory.dir    = reinterpret_cast<Dir *>(this->directory.raw_dir + header_size);
+  this->directory.header = reinterpret_cast<StripteHeaderFooter *>(this->directory.raw_dir);
   std::size_t const footer_offset{directory_size - static_cast<std::size_t>(footer_size)};
-  this->footer = reinterpret_cast<StripteHeaderFooter *>(this->raw_dir + footer_offset);
+  this->directory.footer = reinterpret_cast<StripteHeaderFooter *>(this->directory.raw_dir + footer_offset);
 }
 
 int
@@ -171,7 +171,7 @@ Stripe::dir_check()
   int              hist[SEGMENT_HISTOGRAM_WIDTH + 1] = {0};
   unsigned short   chain_tag[MAX_ENTRIES_PER_SEGMENT];
   int32_t          chain_mark[MAX_ENTRIES_PER_SEGMENT];
-  uint64_t         total_buckets = buckets * segments;
+  uint64_t         total_buckets = directory.buckets * directory.segments;
   uint64_t         total_entries = total_buckets * DIR_DEPTH;
   int              frag_demographics[1 << DIR_SIZE_WIDTH][DIR_BLOCK_SIZES];
 
@@ -186,11 +186,11 @@ Stripe::dir_check()
 
   printf("Stripe '[%s]'\n", hash_text.get());
   printf("  Directory Bytes: %" PRIu64 "\n", total_buckets * SIZEOF_DIR);
-  printf("  Segments:  %d\n", segments);
-  printf("  Buckets per segment:   %" PRIu64 "\n", buckets);
+  printf("  Segments:  %d\n", directory.segments);
+  printf("  Buckets per segment:   %" PRIu64 "\n", directory.buckets);
   printf("  Entries:   %" PRIu64 "\n", total_entries);
 
-  for (int s = 0; s < segments; s++) {
+  for (int s = 0; s < directory.segments; s++) {
     Dir *seg                = this->dir_segment(s);
     int  seg_chain_max      = 0;
     int  seg_empty          = 0;
@@ -203,7 +203,7 @@ Stripe::dir_check()
     ink_zero(chain_tag);
     memset(chain_mark, -1, sizeof(chain_mark));
 
-    for (int b = 0; b < buckets; b++) {
+    for (int b = 0; b < directory.buckets; b++) {
       Dir *root = dir_bucket(b, seg);
       int  h    = 0; // chain length starting in this bucket
 
@@ -289,13 +289,13 @@ Stripe::dir_check()
   printf("    Objects:         %d\n", head);
   printf("    Average Size:    %" PRIu64 "\n", head ? (bytes_in_use / head) : 0);
   printf("    Average Frags:   %.2f\n", head ? static_cast<float>(in_use) / head : 0);
-  printf("    Write Position:  %" PRIu64 "\n", header->write_pos - start);
-  printf("    Wrap Count:      %d\n", header->cycle);
-  printf("    Phase:           %s\n", header->phase ? "true" : "false");
-  ink_ctime_r(&header->create_time, tt);
+  printf("    Write Position:  %" PRIu64 "\n", directory.header->write_pos - start);
+  printf("    Wrap Count:      %d\n", directory.header->cycle);
+  printf("    Phase:           %s\n", directory.header->phase ? "true" : "false");
+  ink_ctime_r(&directory.header->create_time, tt);
   tt[strlen(tt) - 1] = 0;
-  printf("    Sync Serial:     %u\n", header->sync_serial);
-  printf("    Write Serial:    %u\n", header->write_serial);
+  printf("    Sync Serial:     %u\n", directory.header->sync_serial);
+  printf("    Write Serial:    %u\n", directory.header->write_serial);
   printf("    Create Time:     %s\n", tt);
   printf("\n");
   printf("  Fragment size demographics\n");
@@ -324,19 +324,19 @@ void
 Stripe::_clear_init(std::uint32_t hw_sector_size)
 {
   size_t dir_len = this->dirlen();
-  memset(this->raw_dir, 0, dir_len);
+  memset(this->directory.raw_dir, 0, dir_len);
   this->_init_dir();
-  this->header->magic          = STRIPE_MAGIC;
-  this->header->version._major = CACHE_DB_MAJOR_VERSION;
-  this->header->version._minor = CACHE_DB_MINOR_VERSION;
-  this->scan_pos = this->header->agg_pos = this->header->write_pos = this->start;
-  this->header->last_write_pos                                     = this->header->write_pos;
-  this->header->phase                                              = 0;
-  this->header->cycle                                              = 0;
-  this->header->create_time                                        = time(nullptr);
-  this->header->dirty                                              = 0;
-  this->sector_size = this->header->sector_size = hw_sector_size;
-  *this->footer                                 = *this->header;
+  this->directory.header->magic          = STRIPE_MAGIC;
+  this->directory.header->version._major = CACHE_DB_MAJOR_VERSION;
+  this->directory.header->version._minor = CACHE_DB_MINOR_VERSION;
+  this->scan_pos = this->directory.header->agg_pos = this->directory.header->write_pos = this->start;
+  this->directory.header->last_write_pos                                               = this->directory.header->write_pos;
+  this->directory.header->phase                                                        = 0;
+  this->directory.header->cycle                                                        = 0;
+  this->directory.header->create_time                                                  = time(nullptr);
+  this->directory.header->dirty                                                        = 0;
+  this->sector_size = this->directory.header->sector_size = hw_sector_size;
+  *this->directory.footer                                 = *this->directory.header;
 }
 
 void
@@ -344,11 +344,11 @@ Stripe::_init_dir()
 {
   int b, s, l;
 
-  for (s = 0; s < this->segments; s++) {
-    this->header->freelist[s] = 0;
-    Dir *seg                  = this->dir_segment(s);
+  for (s = 0; s < this->directory.segments; s++) {
+    this->directory.header->freelist[s] = 0;
+    Dir *seg                            = this->dir_segment(s);
     for (l = 1; l < DIR_DEPTH; l++) {
-      for (b = 0; b < this->buckets; b++) {
+      for (b = 0; b < this->directory.buckets; b++) {
         Dir *bucket = dir_bucket(b, seg);
         dir_free_entry(dir_bucket_row(bucket, l), s, this);
       }
@@ -360,16 +360,16 @@ bool
 Stripe::flush_aggregate_write_buffer(int fd)
 {
   // set write limit
-  this->header->agg_pos = this->header->write_pos + this->_write_buffer.get_buffer_pos();
+  this->directory.header->agg_pos = this->directory.header->write_pos + this->_write_buffer.get_buffer_pos();
 
-  if (!this->_write_buffer.flush(fd, this->header->write_pos)) {
+  if (!this->_write_buffer.flush(fd, this->directory.header->write_pos)) {
     return false;
   }
-  this->header->last_write_pos  = this->header->write_pos;
-  this->header->write_pos      += this->_write_buffer.get_buffer_pos();
-  ink_assert(this->header->write_pos == this->header->agg_pos);
+  this->directory.header->last_write_pos  = this->directory.header->write_pos;
+  this->directory.header->write_pos      += this->_write_buffer.get_buffer_pos();
+  ink_assert(this->directory.header->write_pos == this->directory.header->agg_pos);
   this->_write_buffer.reset_buffer_pos();
-  this->header->write_serial++;
+  this->directory.header->write_serial++;
 
   return true;
 }
@@ -381,7 +381,7 @@ Stripe::copy_from_aggregate_write_buffer(char *dest, Dir const &dir, size_t nbyt
     return false;
   }
 
-  int agg_offset = this->vol_offset(&dir) - this->header->write_pos;
+  int agg_offset = this->vol_offset(&dir) - this->directory.header->write_pos;
   this->_write_buffer.copy_from(dest, agg_offset, nbytes);
   return true;
 }

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -81,22 +81,26 @@ struct StripteHeaderFooter {
   uint16_t          freelist[1];
 };
 
-class Stripe
-{
-public:
-  ats_scoped_str hash_text;
-  int            frag_size{-1};
-
+struct Directory {
   char                *raw_dir{nullptr};
   Dir                 *dir{};
   StripteHeaderFooter *header{};
   StripteHeaderFooter *footer{};
   int                  segments{};
   off_t                buckets{};
-  off_t                scan_pos{};
-  off_t                skip{};  // start of headers
-  off_t                start{}; // start of data
-  off_t                len{};
+};
+
+class Stripe
+{
+public:
+  ats_scoped_str hash_text;
+  int            frag_size{-1};
+
+  Directory directory;
+  off_t     scan_pos{};
+  off_t     skip{};  // start of headers
+  off_t     start{}; // start of data
+  off_t     len{};
 
   uint32_t sector_size{};
 
@@ -191,25 +195,27 @@ Stripe::round_to_approx_size(uint32_t l) const
 inline int
 Stripe::headerlen() const
 {
-  return ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter) + sizeof(uint16_t) * (this->segments - 1));
+  return ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter) + sizeof(uint16_t) * (this->directory.segments - 1));
 }
 
 inline int
 Stripe::direntries() const
 {
-  return this->buckets * DIR_DEPTH * this->segments;
+  return this->directory.buckets * DIR_DEPTH * this->directory.segments;
 }
 
 inline Dir *
 Stripe::dir_segment(int s) const
 {
-  return reinterpret_cast<Dir *>((reinterpret_cast<char *>(this->dir)) + (s * this->buckets) * DIR_DEPTH * SIZEOF_DIR);
+  return reinterpret_cast<Dir *>((reinterpret_cast<char *>(this->directory.dir)) +
+                                 (s * this->directory.buckets) * DIR_DEPTH * SIZEOF_DIR);
 }
 
 inline size_t
 Stripe::dirlen() const
 {
-  return this->headerlen() + ROUND_TO_STORE_BLOCK(((size_t)this->buckets) * DIR_DEPTH * this->segments * SIZEOF_DIR) +
+  return this->headerlen() +
+         ROUND_TO_STORE_BLOCK(((size_t)this->directory.buckets) * DIR_DEPTH * this->directory.segments * SIZEOF_DIR) +
          ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
 }
 
@@ -219,7 +225,7 @@ Stripe::dirlen() const
 inline bool
 Stripe::dir_valid(const Dir *dir) const
 {
-  return (this->header->phase == dir_phase(dir) ? this->vol_in_phase_valid(dir) : this->vol_out_of_phase_valid(dir));
+  return (this->directory.header->phase == dir_phase(dir) ? this->vol_in_phase_valid(dir) : this->vol_out_of_phase_valid(dir));
 }
 
 /**
@@ -228,44 +234,45 @@ Stripe::dir_valid(const Dir *dir) const
 inline bool
 Stripe::dir_agg_valid(const Dir *dir) const
 {
-  return (this->header->phase == dir_phase(dir) ? this->vol_in_phase_valid(dir) : this->vol_out_of_phase_agg_valid(dir));
+  return (this->directory.header->phase == dir_phase(dir) ? this->vol_in_phase_valid(dir) : this->vol_out_of_phase_agg_valid(dir));
 }
 
 inline bool
 Stripe::dir_agg_buf_valid(const Dir *dir) const
 {
-  return (this->header->phase == dir_phase(dir) && this->vol_in_phase_agg_buf_valid(dir));
+  return (this->directory.header->phase == dir_phase(dir) && this->vol_in_phase_agg_buf_valid(dir));
 }
 
 inline int
 Stripe::vol_out_of_phase_valid(Dir const *e) const
 {
-  return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start) / CACHE_BLOCK_SIZE));
+  return (dir_offset(e) - 1 >= ((this->directory.header->agg_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
 Stripe::vol_out_of_phase_agg_valid(Dir const *e) const
 {
-  return (dir_offset(e) - 1 >= ((this->header->agg_pos - this->start + AGG_SIZE) / CACHE_BLOCK_SIZE));
+  return (dir_offset(e) - 1 >= ((this->directory.header->agg_pos - this->start + AGG_SIZE) / CACHE_BLOCK_SIZE));
 }
 
 inline int
 Stripe::vol_out_of_phase_write_valid(Dir const *e) const
 {
-  return (dir_offset(e) - 1 >= ((this->header->write_pos - this->start) / CACHE_BLOCK_SIZE));
+  return (dir_offset(e) - 1 >= ((this->directory.header->write_pos - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
 Stripe::vol_in_phase_valid(Dir const *e) const
 {
-  return (dir_offset(e) - 1 < ((this->header->write_pos + this->_write_buffer.get_buffer_pos() - this->start) / CACHE_BLOCK_SIZE));
+  return (dir_offset(e) - 1 <
+          ((this->directory.header->write_pos + this->_write_buffer.get_buffer_pos() - this->start) / CACHE_BLOCK_SIZE));
 }
 
 inline int
 Stripe::vol_in_phase_agg_buf_valid(Dir const *e) const
 {
-  return (this->vol_offset(e) >= this->header->write_pos &&
-          this->vol_offset(e) < (this->header->write_pos + this->_write_buffer.get_buffer_pos()));
+  return (this->vol_offset(e) >= this->directory.header->write_pos &&
+          this->vol_offset(e) < (this->directory.header->write_pos + this->_write_buffer.get_buffer_pos()));
 }
 
 inline off_t

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -63,33 +63,6 @@ struct CacheVol {
   CacheVol() {}
 };
 
-struct StripteHeaderFooter {
-  unsigned int      magic;
-  ts::VersionNumber version;
-  time_t            create_time;
-  off_t             write_pos;
-  off_t             last_write_pos;
-  off_t             agg_pos;
-  uint32_t          generation; // token generation (vary), this cannot be 0
-  uint32_t          phase;
-  uint32_t          cycle;
-  uint32_t          sync_serial;
-  uint32_t          write_serial;
-  uint32_t          dirty;
-  uint32_t          sector_size;
-  uint32_t          unused; // pad out to 8 byte boundary
-  uint16_t          freelist[1];
-};
-
-struct Directory {
-  char                *raw_dir{nullptr};
-  Dir                 *dir{};
-  StripteHeaderFooter *header{};
-  StripteHeaderFooter *footer{};
-  int                  segments{};
-  off_t                buckets{};
-};
-
 class Stripe
 {
 public:

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -100,9 +100,6 @@ public:
   /* Calculates the total length of the vol header and the freelist.
    */
   int headerlen() const;
-  /* Returns the first dir in segment @a s.
-   */
-  Dir *dir_segment(int s) const;
   /* Calculates the total length of the header, directories and footer.
    */
   size_t dirlen() const;
@@ -166,13 +163,6 @@ inline int
 Stripe::headerlen() const
 {
   return ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter) + sizeof(uint16_t) * (this->directory.segments - 1));
-}
-
-inline Dir *
-Stripe::dir_segment(int s) const
-{
-  return reinterpret_cast<Dir *>((reinterpret_cast<char *>(this->directory.dir)) +
-                                 (s * this->directory.buckets) * DIR_DEPTH * SIZEOF_DIR);
 }
 
 inline size_t

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -100,9 +100,6 @@ public:
   /* Calculates the total length of the vol header and the freelist.
    */
   int headerlen() const;
-  /* Total number of dir entries.
-   */
-  int direntries() const;
   /* Returns the first dir in segment @a s.
    */
   Dir *dir_segment(int s) const;
@@ -169,12 +166,6 @@ inline int
 Stripe::headerlen() const
 {
   return ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter) + sizeof(uint16_t) * (this->directory.segments - 1));
-}
-
-inline int
-Stripe::direntries() const
-{
-  return this->directory.buckets * DIR_DEPTH * this->directory.segments;
 }
 
 inline Dir *

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -293,7 +293,7 @@ inline int
 StripeSM::within_hit_evacuate_window(Dir const *xdir) const
 {
   off_t oft       = dir_offset(xdir) - 1;
-  off_t write_off = (header->write_pos + AGG_SIZE - start) / CACHE_BLOCK_SIZE;
+  off_t write_off = (directory.header->write_pos + AGG_SIZE - start) / CACHE_BLOCK_SIZE;
   off_t delta     = oft - write_off;
   if (delta >= 0) {
     return delta < hit_evacuate_window;

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -97,12 +97,12 @@ public:
     dir_set_head(&dir, true);
     dir_set_offset(&dir, 1);
 
-    stripe->header->agg_pos = stripe->header->write_pos += 1024;
+    stripe->directory.header->agg_pos = stripe->directory.header->write_pos += 1024;
 
     CacheKey key;
     rand_CacheKey(&key);
 
-    int  s   = key.slice32(0) % stripe->segments, i, j;
+    int  s   = key.slice32(0) % stripe->directory.segments, i, j;
     Dir *seg = stripe->dir_segment(s);
 
     // test insert
@@ -118,7 +118,7 @@ public:
     CHECK(static_cast<unsigned int>(inserted - free) <= 1);
 
     // test delete
-    for (i = 0; i < stripe->buckets; i++) {
+    for (i = 0; i < stripe->directory.buckets; i++) {
       for (j = 0; j < DIR_DEPTH; j++) {
         dir_set_offset(dir_bucket_row(dir_bucket(i, seg), j), 0); // delete
       }
@@ -223,8 +223,8 @@ public:
 #else
       // test corruption detection
       rand_CacheKey(&key);
-      s1 = key.slice32(0) % stripe->segments;
-      b1 = key.slice32(1) % stripe->buckets;
+      s1 = key.slice32(0) % stripe->directory.segments;
+      b1 = key.slice32(1) % stripe->directory.buckets;
 
       dir_insert(&key, stripe, &dir1);
       dir_insert(&key, stripe, &dir1);

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -154,7 +154,7 @@ public:
       Dbg(dbg_ctl_cache_dir_test, "probe rate = %d / second", static_cast<int>((newfree * static_cast<uint64_t>(1000000)) / us));
     }
 
-    for (int c = 0; c < stripe->direntries() * 0.75; c++) {
+    for (int c = 0; c < stripe->directory.entries() * 0.75; c++) {
       regress_rand_CacheKey(&key);
       dir_insert(&key, stripe, &dir);
     }

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -130,10 +130,10 @@ init_stripe_for_writing(StripeSM &stripe, StripteHeaderFooter &header, CacheVol 
   // based on the distance of the write_pos from this point. If we ever move
   // the write head before the start of the stripe data section, we will
   // underflow offset calculations and end up in big trouble.
-  header.write_pos = stripe.start;
-  header.agg_pos   = 1;
-  header.phase     = 0;
-  stripe.header    = &header;
+  header.write_pos        = stripe.start;
+  header.agg_pos          = 1;
+  header.phase            = 0;
+  stripe.directory.header = &header;
   return attach_tmpfile_to_stripe(stripe);
 }
 
@@ -192,7 +192,7 @@ TEST_CASE("The behavior of StripeSM::add_writer.")
     }
   }
 
-  ats_free(stripe.raw_dir);
+  ats_free(stripe.directory.raw_dir);
 }
 
 // This test case demonstrates how to set up a StripeSM and make
@@ -302,7 +302,7 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
     cache_config_enable_checksum = false;
   }
 
-  ats_free(stripe.raw_dir);
+  ats_free(stripe.directory.raw_dir);
 }
 
 // When f.evacuator is set, vc.buf must contain a Doc object including headers
@@ -400,5 +400,5 @@ TEST_CASE("aggWrite behavior with f.evacuator set")
   }
 
   delete[] source;
-  ats_free(stripe.raw_dir);
+  ats_free(stripe.directory.raw_dir);
 }

--- a/src/iocore/cache/unit_tests/test_doubles.h
+++ b/src/iocore/cache/unit_tests/test_doubles.h
@@ -104,7 +104,7 @@ public:
   {
     SET_HANDLER(&WaitingVC::handle_call);
     this->stripe = stripe;
-    this->dir    = *stripe->dir;
+    this->dir    = *stripe->directory.dir;
   }
 
   void


### PR DESCRIPTION
This is all a mechanical cleanup change, broken into four individual commits. I intend to follow this up with another PR to make all the directory operations methods on this struct instead of standalone functions, with the objective of breaking the cyclic dependency between the directory functions and the stripe.

It is interesting to note that the `Stripe::direntries` method existed, but the expression it computed was used inline in multiple places where the method could have been called. I went ahead and changed those places to call the method, since the use of the method clarifies what quantity is being computed.

I did not move the `Stripe::headerlen` and `Stripe::dirlen` methods because the concept of rounding to a store block seems to be specific to the stripe, and the directory functions do not depend on those methods.