### PR TITLE
Clean up some linter warnings in SSLNetVConnection

### DIFF
--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -7916,7 +7916,7 @@ TSVConnTunnel(TSVConn sslp)
   SSLNetVConnection *ssl_vc = dynamic_cast<SSLNetVConnection *>(vc);
   TSReturnCode       zret   = TS_SUCCESS;
   if (nullptr != ssl_vc) {
-    ssl_vc->hookOpRequested = SSL_HOOK_OP_TUNNEL;
+    ssl_vc->hookOpRequested = SslVConnOp::SSL_HOOK_OP_TUNNEL;
   } else {
     zret = TS_ERROR;
   }

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -66,7 +66,7 @@
 #define SSL_TLSEXT_ERR_NOACK 3
 #endif
 
-#define SSL_OP_HANDSHAKE 0x16
+constexpr char SSL_OP_HANDSHAKE = 0x16;
 
 // TS-2503: dynamic TLS record sizing
 // For smaller records, we should also reserve space for various TCP options
@@ -74,18 +74,17 @@
 // (another 20-60 bytes on average, depending on the negotiated ciphersuite [2]).
 // All in all: 1500 - 40 (IP) - 20 (TCP) - 40 (TCP options) - TLS overhead (60-100)
 // For larger records, the size is determined by TLS protocol record size
-#define SSL_DEF_TLS_RECORD_SIZE           1300  // 1500 - 40 (IP) - 20 (TCP) - 40 (TCP options) - TLS overhead (60-100)
-#define SSL_MAX_TLS_RECORD_SIZE           16383 // 2^14 - 1
-#define SSL_DEF_TLS_RECORD_BYTE_THRESHOLD 1000000
-#define SSL_DEF_TLS_RECORD_MSEC_THRESHOLD 1000
+constexpr uint32_t SSL_DEF_TLS_RECORD_SIZE           = 1300; // 1500 - 40 (IP) - 20 (TCP) - 40 (TCP options) - TLS overhead (60-100)
+constexpr uint32_t SSL_MAX_TLS_RECORD_SIZE           = 16383; // 2^14 - 1
+constexpr int64_t  SSL_DEF_TLS_RECORD_BYTE_THRESHOLD = 1000000;
+constexpr int      SSL_DEF_TLS_RECORD_MSEC_THRESHOLD = 1000;
 
 struct SSLCertLookup;
 
-using SslVConnOp = enum {
-  SSL_HOOK_OP_DEFAULT,                     ///< Null / initialization value. Do normal processing.
-  SSL_HOOK_OP_TUNNEL,                      ///< Switch to blind tunnel
-  SSL_HOOK_OP_TERMINATE,                   ///< Termination connection / transaction.
-  SSL_HOOK_OP_LAST = SSL_HOOK_OP_TERMINATE ///< End marker value.
+enum class SslVConnOp {
+  SSL_HOOK_OP_DEFAULT,  ///< Null / initialization value. Do normal processing.
+  SSL_HOOK_OP_TUNNEL,   ///< Switch to blind tunnel
+  SSL_HOOK_OP_TERMINATE ///< Termination connection / transaction.
 };
 
 enum class SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHAKE_ERROR };
@@ -235,7 +234,7 @@ public:
   std::shared_ptr<SSL_SESSION> client_sess = nullptr;
 
   /// Set by asynchronous hooks to request a specific operation.
-  SslVConnOp hookOpRequested = SSL_HOOK_OP_DEFAULT;
+  SslVConnOp hookOpRequested = SslVConnOp::SSL_HOOK_OP_DEFAULT;
 
   // noncopyable
   SSLNetVConnection(const SSLNetVConnection &)            = delete;
@@ -324,7 +323,7 @@ protected:
   bool
   _is_tunneling_requested() const override
   {
-    return SSL_HOOK_OP_TUNNEL == hookOpRequested;
+    return SslVConnOp::SSL_HOOK_OP_TUNNEL == hookOpRequested;
   }
   void
   _switch_to_tunneling_mode() override

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -31,10 +31,8 @@
  ****************************************************************************/
 #pragma once
 
-#include "tscore/ink_platform.h"
 #include "ts/apidefs.h"
 
-#include "../eventsystem/P_EventSystem.h"
 #include "P_UnixNetVConnection.h"
 #include "P_UnixNet.h"
 #include "iocore/net/TLSALPNSupport.h"
@@ -83,12 +81,12 @@
 
 struct SSLCertLookup;
 
-typedef enum {
+using SslVConnOp = enum {
   SSL_HOOK_OP_DEFAULT,                     ///< Null / initialization value. Do normal processing.
   SSL_HOOK_OP_TUNNEL,                      ///< Switch to blind tunnel
   SSL_HOOK_OP_TERMINATE,                   ///< Termination connection / transaction.
   SSL_HOOK_OP_LAST = SSL_HOOK_OP_TERMINATE ///< End marker value.
-} SslVConnOp;
+};
 
 enum class SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHAKE_ERROR };
 
@@ -109,7 +107,7 @@ class SSLNetVConnection : public UnixNetVConnection,
                           public TLSEventSupport,
                           public TLSBasicSupport
 {
-  typedef UnixNetVConnection super; ///< Parent type.
+  using super = UnixNetVConnection; ///< Parent type.
 
 public:
   int  sslStartHandShake(int event, int &err) override;
@@ -386,6 +384,6 @@ private:
   void _out_context_tunnel() override;
 };
 
-typedef int (SSLNetVConnection::*SSLNetVConnHandler)(int, void *);
+using SSLNetVConnHandler = int (SSLNetVConnection::*)(int, void *);
 
 extern ClassAllocator<SSLNetVConnection> sslNetVCAllocator;

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -23,7 +23,6 @@
 
 #include "iocore/net/NetVConnection.h"
 #include "tscore/ink_config.h"
-#include "tscore/EventNotify.h"
 #include "tscore/Layout.h"
 #include "tscore/InkErrno.h"
 #include "tscore/TSSystemState.h"

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -27,7 +27,6 @@
 #include "tscore/InkErrno.h"
 #include "tscore/TSSystemState.h"
 
-#include "api/InkAPIInternal.h" // Added to include the ssl_hook definitions
 #include "iocore/net/ProxyProtocol.h"
 #include "iocore/net/SSLSNIConfig.h"
 
@@ -917,7 +916,7 @@ SSLNetVConnection::clear()
   sslTotalBytesSent           = 0;
   sslClientRenegotiationAbort = false;
 
-  hookOpRequested = SSL_HOOK_OP_DEFAULT;
+  hookOpRequested = SslVConnOp::SSL_HOOK_OP_DEFAULT;
   free_handshake_buffers();
 
   super::clear();
@@ -1033,7 +1032,7 @@ SSLNetVConnection::sslStartHandShake(int event, int &err)
           this->ssl = nullptr;
           return EVENT_DONE;
         } else {
-          hookOpRequested = SSL_HOOK_OP_TUNNEL;
+          hookOpRequested = SslVConnOp::SSL_HOOK_OP_TUNNEL;
         }
       }
 
@@ -1193,7 +1192,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
   // without data replay.
   // Note we can't arrive here if a hook is active.
 
-  if (SSL_HOOK_OP_TUNNEL == hookOpRequested) {
+  if (SslVConnOp::SSL_HOOK_OP_TUNNEL == hookOpRequested) {
     this->attributes = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
     SSL_free(this->ssl);
     this->ssl = nullptr;
@@ -1202,7 +1201,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
     // we get out of this callback, and then will shuffle
     // over the buffered handshake packets to the O.S.
     return EVENT_DONE;
-  } else if (SSL_HOOK_OP_TERMINATE == hookOpRequested) {
+  } else if (SslVConnOp::SSL_HOOK_OP_TERMINATE == hookOpRequested) {
     sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
     return EVENT_DONE;
   }
@@ -1394,7 +1393,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
   case SSL_ERROR_PENDING_CERTIFICATE:
 #endif
 #if defined(SSL_ERROR_WANT_SNI_RESOLVE) || defined(SSL_ERROR_WANT_X509_LOOKUP) || defined(SSL_ERROR_PENDING_CERTIFICATE)
-    if (this->attributes == HttpProxyPort::TRANSPORT_BLIND_TUNNEL || SSL_HOOK_OP_TUNNEL == hookOpRequested) {
+    if (this->attributes == HttpProxyPort::TRANSPORT_BLIND_TUNNEL || SslVConnOp::SSL_HOOK_OP_TUNNEL == hookOpRequested) {
       this->attributes   = HttpProxyPort::TRANSPORT_BLIND_TUNNEL;
       sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_ONGOING;
       return EVENT_CONT;


### PR DESCRIPTION
* Remove unused #includes
* Use C++20 instead of C typedefs