### PR TITLE
Turn off ccache for coverity build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -387,7 +387,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "BUILD_EXPERIMENTAL_PLUGINS": "ON",
-        "ENABLE_EXAMPLE": "ON"
+        "ENABLE_EXAMPLE": "ON",
+        "ENABLE_CCACHE": "OFF"
       }
     },
     {


### PR DESCRIPTION
I think ccache might be messing with coverity results/building so want to disable it for those runs