### PR TITLE
Configure autests to use microserver 1.0.8

### DIFF
--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -43,7 +43,7 @@ psutil = "*"
 charset-normalizer = "*"
 
 # Keep init.cli.ext updated with this required microserver version.
-microserver = ">=1.0.6"
+microserver = ">=1.0.8"
 
 jsonschema = "*"
 python-jose = "*"

--- a/tests/gold_tests/autest-site/init.cli.ext
+++ b/tests/gold_tests/autest-site/init.cli.ext
@@ -30,7 +30,7 @@ if AuTestVersion() < needed_autest_version:
         "Please update AuTest:\n  pipenv --rm && pipenv install\n",
         show_stack=False)
 
-needed_microserver_version = "1.0.6"
+needed_microserver_version = "1.0.8"
 found_microserver_version = microserver.__version__
 if found_microserver_version < needed_microserver_version:
     host.WriteError(


### PR DESCRIPTION
microserver 1.0.8 has updates to run with Python 3.13 while still being backwards compatible.