### PR TITLE
[traffic_crashlog] Log full version info

### DIFF
--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -232,7 +232,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
 
   crashlog_write_procname(fp, target);
   crashlog_write_exename(fp, target);
-  fprintf(fp, LABELFMT "Traffic Server %s\n", "Version:", PACKAGE_VERSION);
+  fprintf(fp, LABELFMT "%s\n", "Version:", version.full_version());
   crashlog_write_uname(fp, target);
   crashlog_write_datime(fp, target);
 


### PR DESCRIPTION
Having build version in the crash log is helpful.

# Before 
```
Process:            51820
Version:            Traffic Server 10.1.0
System Version:     Darwin arm64 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:12 PST 2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6031 24.2.0
Date:               Fri, 10 Jan 2025 13:50:15 +0900
```

# After
```
Process:            15310
Version:            Apache Traffic Server - traffic_crashlog - 10.1.0 - (build # 0 on Jan  8 2025 at 08:09:45)
System Version:     Darwin arm64 Darwin Kernel Version 24.2.0: Fri Dec  6 19:02:12 PST 2024; root:xnu-11215.61.5~2/RELEASE_ARM64_T6031 24.2.0
Date:               Fri, 10 Jan 2025 13:51:02 +0900
```