### PR TITLE
Coverity: Fix for CID-1587277

### DIFF
--- a/plugins/experimental/ja4_fingerprint/ja4.h
+++ b/plugins/experimental/ja4_fingerprint/ja4.h
@@ -54,7 +54,7 @@ public:
   using difference_type = std::iterator_traits<std::vector<std::uint16_t>::iterator>::difference_type;
 
   Protocol      protocol;
-  std::uint16_t TLS_version;
+  std::uint16_t TLS_version{0}; // 0 is not the default, this is only to not have it un-initialized.
   std::string   ALPN;
 
   std::vector<std::uint16_t> const &get_ciphers() const;


### PR DESCRIPTION
JA4, zero initialization for TLS version member variable.