### PR TITLE
ci-ubuntu preset: use clang

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -226,7 +226,11 @@
       "name": "ci-ubuntu",
       "displayName": "CI Ubuntu Hardened Build",
       "description": "CI Pipeline config for Ubuntu with hardening flags",
-      "inherits": ["ci", "hardened"]
+      "inherits": ["ci", "hardened"],
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
     },
     {
       "name": "ci-clang-analyzer",


### PR DESCRIPTION
Update the ci-ubuntu preset to explicitly use clang. Currently CI configures clang via setting CC and CXX environment variables. This will configure clang across other environments more consistently.