### PR TITLE
libswoc version update: 1.5.13

### DIFF
--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_12
+#define SWOC_VERSION_NS _1_5_13
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 12;
+static constexpr unsigned POINT_VERSION = 13;
 }} // namespace swoc::SWOC_VERSION_NS


### PR DESCRIPTION
We cut a release of trafficserver-libswoc that has our latest ATS changes to lib/swoc. That release is 1.5.13. This updates our local swoc_version.h to reflect this new release.

---

## libswoc workflow

Just as a reminder, all development on libswoc is now done in our ATS repo. So our ATS repo has the latest source code already. Frequently, these changes are ported to https://github.com/apache/trafficserver-libswoc for those who want to interact with libswoc as a separate library for build purposes or to use it as a library for other projects. Then a release is cut against apachet/trafficserver-libswoc, and we update our ATS libswoc to demonstrate that we are in sync with that release. This PR is for this final step, updating our ATS libswoc version to demonstrate what trafficserver-libswoc release we are in sync with.