### PR TITLE
Deprecate two functions of the MIMEField

### DIFF
--- a/include/proxy/hdrs/MIME.h
+++ b/include/proxy/hdrs/MIME.h
@@ -143,7 +143,8 @@ struct MIMEField {
 
   /// @return The name of @a this field.
   std::string_view name_get() const;
-  const char      *name_get(int *length) const;
+  [[deprecated("Use std::string_view name_get() or value_get() instead")]]
+  const char *name_get(int *length) const;
 
   /** Find the index of the value in the multi-value field.
 
@@ -161,7 +162,8 @@ struct MIMEField {
 
   /// @return The value of @a this field.
   std::string_view value_get() const;
-  const char      *value_get(int *length) const;
+  [[deprecated("Use std::string_view name_get() or value_get() instead")]]
+  const char *value_get(int *length) const;
 
   int32_t  value_get_int() const;
   uint32_t value_get_uint() const;


### PR DESCRIPTION
## Deprecate below two functions of the MIMEField:
<pre>
const char *name_get(int *length) const;
const char *value_get(int *length) const;
</pre>

## Update documentation to:
Highlight the benefits of using **std::string_view** (e.g., safer memory handling).
Provide migration guides for developers transitioning to the **std::string_view** versions.

## Advantages of Solution:
Encourages modern practices using **std::string_view** frequently.
Benchmarking performance is optimal.