### PR TITLE
Add nullptr check in PluginVC read and write

### DIFF
--- a/src/proxy/PluginVC.cc
+++ b/src/proxy/PluginVC.cc
@@ -483,7 +483,7 @@ PluginVC::process_write_side()
   need_write_process = false;
 
   // Check write_state
-  if (write_state.vio.op != VIO::WRITE || closed || write_state.shutdown) {
+  if (write_state.vio.cont == nullptr || write_state.vio.op != VIO::WRITE || closed || write_state.shutdown) {
     return;
   }
 
@@ -493,9 +493,13 @@ PluginVC::process_write_side()
     return;
   }
 
-  IOBufferReader *reader      = write_state.vio.get_reader();
-  int64_t         bytes_avail = reader->read_avail();
-  int64_t         act_on      = std::min(bytes_avail, ntodo);
+  IOBufferReader *reader = write_state.vio.get_reader();
+  if (reader == nullptr) {
+    return;
+  }
+
+  int64_t bytes_avail = reader->read_avail();
+  int64_t act_on      = std::min(bytes_avail, ntodo);
 
   Dbg(dbg_ctl_pvc, "[%u] %s: process_write_side; act_on %" PRId64 "", core_obj->id, PVC_TYPE, act_on);
 
@@ -601,7 +605,8 @@ PluginVC::process_read_side()
   need_read_process = false;
 
   // Check read_state
-  if (read_state.vio.op != VIO::READ || closed || read_state.shutdown || !read_state.vio.ntodo()) {
+  if (read_state.vio.cont == nullptr || read_state.vio.op != VIO::READ || closed || read_state.shutdown ||
+      !read_state.vio.ntodo()) {
     return;
   }
 


### PR DESCRIPTION
We faced a crash in `PluginVC::process_write_side()` with ATS 10.0.2. The stack trace is below.
```
/lib64/libc.so.6(+0x3e6f0)[0x7f3945a3e6f0]
/opt/bin/traffic_server(_ZN8PluginVC18process_write_sideEv+0xe9)[0x562d1e9d90a9]
/opt/bin/traffic_server(_ZN8PluginVC12main_handlerEiPv+0x373)[0x562d1e9d8153]
/opt/bin/traffic_server(_ZN7EThread13process_eventEP5Eventi+0x375)[0x562d1ea982f5]
/opt/bin/traffic_server(_ZN7EThread13process_queueEP5QueueI5EventNS1_9Link_linkEEPiS5_+0x57)[0x562d1ea985a7]
/opt/bin/traffic_server(_ZN7EThread15execute_regularEv+0x1a9)[0x562d1ea98c19]
/opt/bin/traffic_server(_ZN7EThread7executeEv+0x178)[0x562d1ea99648]
/opt/bin/traffic_server(+0x5230d7)[0x562d1ea970d7]
/lib64/libc.so.6(+0x89c02)[0x7f3945a89c02]
/lib64/libc.so.6(+0x10ec40)[0x7f3945b0ec40]
```

We found that the `PluginVC::write_state` is in odd state by somehow.
```
(gdb) frame 1
#1  PluginVC::process_write_side (this=0x7f64258b0268) at /src/proxy/PluginVC.cc:497
497      int64_t         bytes_avail = reader->read_avail();
(gdb) p reader
$7 = (IOBufferReader *) 0x0
(gdb) p write_state
$8 = {vio = {cont = 0x0, nbytes = 9223372036854775807, ndone = 0, op = 2, _disabled = false, buffer = {mbuf = 0x0, entry = 0x0}, vc_server = 0x7f64258b0268, mutex = {m_ptr = 0x7f6754ab6bd0}}, shutdown = false}
```

A wild idea is some plugin accidentally called `TSVConnWrite` API with `nullptr` like this, `TSVConnWrite(X, nullptr, nullptr, INT64_MAX)`, but still not sure.

Anyway, we need `nullptr` checks in `PluginVC::process_write_side()`. Also, adding a similar check in `PluginVC::process_read_side()` for just in case.