### PR TITLE
Add support to retrieve request header block to lua plugin (#11893)

### DIFF
--- a/doc/admin-guide/plugins/lua.en.rst
+++ b/doc/admin-guide/plugins/lua.en.rst
@@ -998,6 +998,25 @@ Then ``GET /st HTTP/1.1\r\nHost: b.tb.cn\r\nUser-Aget: Mozilla/5.0\r\nAccept: */
 
 :ref:`TOP <admin-plugins-ts-lua>`
 
+ts.client_request.get_header_block
+----------------------------------
+**syntax:** *ts.client_request.get_header_block()*
+
+**context:** do_remap/do_os_response or do_global_* or later
+
+**description:** Returns a string holding all the headers for the current client request.
+
+Here is an example:
+
+::
+
+    function do_global_read_request()
+        block = ts.client_request.get_header_block()
+        ts.debug(block)
+    end
+
+:ref:`TOP <admin-plugins-ts-lua>`
+
 ts.client_request.client_addr.get_addr
 --------------------------------------
 **syntax:** *ts.client_request.client_addr.get_addr()*

--- a/plugins/lua/ts_lua_client_request.c
+++ b/plugins/lua/ts_lua_client_request.c
@@ -28,6 +28,7 @@ static int ts_lua_client_request_header_set(lua_State *L);
 static int ts_lua_client_request_header_table_get(lua_State *L);
 static int ts_lua_client_request_header_table_set(lua_State *L);
 static int ts_lua_client_request_get_headers(lua_State *L);
+static int ts_lua_client_request_get_header_block(lua_State *L);
 static int ts_lua_client_request_get_url(lua_State *L);
 static int ts_lua_client_request_get_pristine_url(lua_State *L);
 static int ts_lua_client_request_get_url_host(lua_State *L);
@@ -340,6 +341,9 @@ ts_lua_inject_client_request_headers_api(lua_State *L)
 {
   lua_pushcfunction(L, ts_lua_client_request_get_headers);
   lua_setfield(L, -2, "get_headers");
+
+  lua_pushcfunction(L, ts_lua_client_request_get_header_block);
+  lua_setfield(L, -2, "get_header_block");
 }
 
 static int
@@ -396,6 +400,65 @@ ts_lua_client_request_get_headers(lua_State *L)
     field_loc = next_field_loc;
   }
 
+  return 1;
+}
+
+static int
+ts_lua_client_request_get_header_block(lua_State *L)
+{
+  TSIOBuffer       output_buffer;
+  TSIOBufferReader reader;
+  int              total_avail;
+
+  TSIOBufferBlock block;
+  const char     *block_start;
+  int64_t         block_avail;
+
+  char   *output_string;
+  int64_t output_len;
+
+  ts_lua_http_ctx *http_ctx;
+
+  GET_HTTP_CONTEXT(http_ctx, L);
+
+  output_buffer = TSIOBufferCreate();
+  reader        = TSIOBufferReaderAlloc(output_buffer);
+
+  TSMimeHdrPrint(http_ctx->client_request_hdrp, output_buffer);
+
+  total_avail = TSIOBufferReaderAvail(reader);
+
+  output_string = static_cast<char *>(TSmalloc(total_avail + 1));
+  output_len    = 0;
+
+  block = TSIOBufferReaderStart(reader);
+  while (block) {
+    block_start = TSIOBufferBlockReadStart(block, reader, &block_avail);
+
+    if (block_avail == 0) {
+      break;
+    }
+
+    memcpy(output_string + output_len, block_start, block_avail);
+    output_len += block_avail;
+
+    TSIOBufferReaderConsume(reader, block_avail);
+    block = TSIOBufferReaderStart(reader);
+  }
+
+  output_string[output_len] = '\0';
+  output_len++;
+
+  TSIOBufferReaderFree(reader);
+  TSIOBufferDestroy(output_buffer);
+
+  if (output_string && output_len) {
+    lua_pushlstring(L, output_string, output_len);
+  } else {
+    lua_pushnil(L);
+  }
+
+  TSfree(output_string);
   return 1;
 }
 

--- a/plugins/lua/ts_lua_client_request.c
+++ b/plugins/lua/ts_lua_client_request.c
@@ -406,15 +406,15 @@ ts_lua_client_request_get_headers(lua_State *L)
 static int
 ts_lua_client_request_get_header_block(lua_State *L)
 {
-  TSIOBuffer       output_buffer;
+  TSIOBuffer output_buffer;
   TSIOBufferReader reader;
-  int              total_avail;
+  int total_avail;
 
   TSIOBufferBlock block;
-  const char     *block_start;
-  int64_t         block_avail;
+  const char *block_start;
+  int64_t block_avail;
 
-  char   *output_string;
+  char *output_string;
   int64_t output_len;
 
   ts_lua_http_ctx *http_ctx;
@@ -424,11 +424,11 @@ ts_lua_client_request_get_header_block(lua_State *L)
   output_buffer = TSIOBufferCreate();
   reader        = TSIOBufferReaderAlloc(output_buffer);
 
-  TSMimeHdrPrint(http_ctx->client_request_hdrp, output_buffer);
+  TSMimeHdrPrint(http_ctx->client_request_bufp, http_ctx->client_request_hdrp, output_buffer);
 
   total_avail = TSIOBufferReaderAvail(reader);
 
-  output_string = static_cast<char *>(TSmalloc(total_avail + 1));
+  output_string = (char *)(TSmalloc(total_avail + 1));
   output_len    = 0;
 
   block = TSIOBufferReaderStart(reader);


### PR DESCRIPTION
* Update ts_lua_client_request.cc

* Update lua.en.rst

* Update lua.en.rst

(cherry picked from commit 04b5fe33a5c9a40adfcb001f2fa626c3cfa7e681)