### PR TITLE
Handle VC_EVENT_EOS in more places (#11368)

### DIFF
--- a/iocore/net/QUICNextProtocolAccept.cc
+++ b/iocore/net/QUICNextProtocolAccept.cc
@@ -37,6 +37,7 @@ quic_netvc_cast(int event, void *edata)
     return dynamic_cast<QUICNetVConnection *>(ptr.vc);
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_READ_COMPLETE:
+  case VC_EVENT_EOS:
   case VC_EVENT_ERROR:
     ptr.vio = static_cast<VIO *>(edata);
     return dynamic_cast<QUICNetVConnection *>(ptr.vio->vc_server);

--- a/iocore/net/SSLNextProtocolAccept.cc
+++ b/iocore/net/SSLNextProtocolAccept.cc
@@ -48,6 +48,7 @@ ssl_netvc_cast(int event, void *edata)
     return dynamic_cast<SSLNetVConnection *>(ptr.vc);
   case VC_EVENT_INACTIVITY_TIMEOUT:
   case VC_EVENT_READ_COMPLETE:
+  case VC_EVENT_EOS:
   case VC_EVENT_ERROR:
     ptr.vio = static_cast<VIO *>(edata);
     return dynamic_cast<SSLNetVConnection *>(ptr.vio->vc_server);

--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -1389,6 +1389,7 @@ HttpSM::state_common_wait_for_transform_read(HttpTransformInfo *t_info, HttpSMHa
     }
   // FALLTHROUGH
   case VC_EVENT_ERROR:
+  case VC_EVENT_EOS:
     // Transform VC sends NULL on error conditions
     if (!c) {
       c = tunnel.get_consumer(t_info->vc);


### PR DESCRIPTION
This adds the handling of VC_EVENT_EOS to a few handlers that did handle VC_EVENT_ERROR but not EOS. This is a follow up from a review comment in #11346. See:

(cherry picked from commit abc4d5d3419a615e95b9c0775bef9c5f7d25042d)