### PR TITLE
multiplexer: fix consume of too many bytes (#11499)

### DIFF
--- a/iocore/eventsystem/P_IOBuffer.h
+++ b/iocore/eventsystem/P_IOBuffer.h
@@ -551,6 +551,7 @@ IOBufferReader::is_read_avail_more_than(int64_t size)
 TS_INLINE void
 IOBufferReader::consume(int64_t n)
 {
+  ink_assert(read_avail() >= n);
   start_offset += n;
   if (size_limit != INT64_MAX) {
     size_limit -= n;

--- a/plugins/multiplexer/fetcher.h
+++ b/plugins/multiplexer/fetcher.h
@@ -211,6 +211,8 @@ template <class T> struct HttpTransaction {
             self->t_.header(self->parser_.buffer_, self->parser_.location_);
             self->parsingHeaders_ = false;
           }
+          // Parsing headers will indirectly read from our reader. Update available accordingly.
+          available = TSIOBufferReaderAvail(self->in_->reader);
         }
         if (!self->parsingHeaders_) {
           if (self->chunkDecoder_ != NULL) {


### PR DESCRIPTION
IOBufferReader::consume contractually assumes that all callers of it will not consume more bytes than read_avail for the buffer chain. This adds a debug assertion for this and fixes multiplexer so that it doesn't violate this invariant.

(cherry picked from commit 6774984a3f71f7473092d1af7ba99a004e8890d9)