### PR TITLE
Fix quick_server autest to verify server response (#11512)

### DIFF
--- a/tests/gold_tests/slow_post/quick_server.py
+++ b/tests/gold_tests/slow_post/quick_server.py
@@ -67,9 +67,9 @@ def send_response(sock: socket.socket, abort_early: bool) -> None:
     if abort_early:
         response = "HTTP/1."
     else:
-        response = (r"HTTP/1.1 200 OK\r\n"
-                    r"Content-Length: 0\r\n"
-                    r"\r\n")
+        response = ("HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n")
     print(f'Sending:\n{response}')
     sock.sendall(response.encode("utf-8"))
 
@@ -92,7 +92,7 @@ def main() -> int:
                     sock.close()
                     continue
 
-                # Send a response now, before headers are read. This implements
+                # Send a response now, before the body is read. This implements
                 # the "quick" attribute of this quick_server.
                 send_response(sock, args.abort_response_headers)
 


### PR DESCRIPTION
The quick_server.test.py autest incorrectly sent a literal '\r\n' four bytes instead of the expected 2 bytes. The test still largely functioned as needed, but didn't verify that the expected respone made it to the client. This updates the test to verify that the 200 OK response makes it to the client as expected. ATS behaves as expected, so there is no production change needed.

(cherry picked from commit 168e23ac22b9dd614aeb009d78a0e2e2f6a66b7b)