### PR TITLE
9.2.x backport: chunked body autests: avoid UUID colision (#11843)

### DIFF
--- a/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
@@ -135,9 +135,9 @@ class MalformedChunkHeaderTest:
         self.server.Streams.stdout += Testers.ContainsExpression(
             "Unexpected chunked content for key 3: too small", "Verify that writing the third response failed.")
 
-        # ATS should close the connection before any body gets through. "abc"
+        # ATS should close the connection before any body gets through. "abcwxyz"
         # is the body sent by the client for each of these chunked cases.
-        self.server.Streams.stdout += Testers.ExcludesExpression("abc", "Verify that the body never got through.")
+        self.server.Streams.stdout += Testers.ExcludesExpression("abcwxyz", "Verify that the body never got through.")
 
     def setupTS(self):
         self.ts = Test.MakeATSProcess("ts3", enable_tls=True, enable_cache=False)

--- a/tests/gold_tests/chunked_encoding/replays/chunked_trailer_dropped.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/chunked_trailer_dropped.replay.yaml
@@ -34,16 +34,16 @@ sessions:
       content:
         transfer: plain
         encoding: uri
-        # 3-byte chunk, abc.
+        # 7-byte chunk, abcwxyz.
         # Then chunked trailers between 0\r\n and a final \r\n (per specification).
-        data: 3%0D%0Aabc%0D%0A0%0D%0AClient%3A%20ATS%0D%0AETag%3A%20%22abc%22%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0AClient%3A%20ATS%0D%0AETag%3A%20%22abc%22%0D%0A%0D%0A
 
     proxy-request:
       content:
         transfer: plain
         encoding: uri
         # Note: same as client-request, but the trailer is dropped.
-        data: 3%0D%0Aabc%0D%0A0%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0A%0D%0A
         verify: { as: equal }
 
     server-response:
@@ -57,12 +57,12 @@ sessions:
         transfer: plain
         encoding: uri
         # Note: same content as the client-request.
-        data: 3%0D%0Aabc%0D%0A0%0D%0ASever%3A%20ATS%0D%0AETag%3A%20%22def%22%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0ASever%3A%20ATS%0D%0AETag%3A%20%22def%22%0D%0A%0D%0A
 
     proxy-request:
       content:
         transfer: plain
         encoding: uri
         # Note: same as server-response, but the trailer is dropped.
-        data: 3%0D%0Aabc%0D%0A0%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0A%0D%0A
         verify: { as: equal }

--- a/tests/gold_tests/chunked_encoding/replays/chunked_trailer_proxied.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/chunked_trailer_proxied.replay.yaml
@@ -34,16 +34,16 @@ sessions:
       content:
         transfer: plain
         encoding: uri
-        # 3-byte chunk, abc.
+        # 7-byte chunk, abcwxyz.
         # Then chunked trailers between 0\r\n and a final \r\n (per specification).
-        data: 3%0D%0Aabc%0D%0A0%0D%0AClient%3A%20ATS%0D%0AETag%3A%20%22abc%22%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0AClient%3A%20ATS%0D%0AETag%3A%20%22abc%22%0D%0A%0D%0A
 
     proxy-request:
       content:
         transfer: plain
         encoding: uri
         # Same content as client-request above.
-        data: 3%0D%0Aabc%0D%0A0%0D%0AClient%3A%20ATS%0D%0AETag%3A%20%22abc%22%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0AClient%3A%20ATS%0D%0AETag%3A%20%22abc%22%0D%0A%0D%0A
         verify: { as: equal }
 
     server-response:
@@ -57,12 +57,12 @@ sessions:
         transfer: plain
         encoding: uri
         # Note: same content as the client-request.
-        data: 3%0D%0Aabc%0D%0A0%0D%0ASever%3A%20ATS%0D%0AETag%3A%20%22def%22%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0ASever%3A%20ATS%0D%0AETag%3A%20%22def%22%0D%0A%0D%0A
 
     proxy-request:
       content:
         transfer: plain
         encoding: uri
         # Same content as server-response above.
-        data: 3%0D%0Aabc%0D%0A0%0D%0ASever%3A%20ATS%0D%0AETag%3A%20%22def%22%0D%0A%0D%0A
+        data: 7%0D%0Aabcwxyz%0D%0A0%0D%0ASever%3A%20ATS%0D%0AETag%3A%20%22def%22%0D%0A%0D%0A
         verify: { as: equal }

--- a/tests/gold_tests/chunked_encoding/replays/malformed_chunked_header.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/malformed_chunked_header.replay.yaml
@@ -32,7 +32,7 @@ sessions:
         transfer: plain
         encoding: uri
         # Chunk header sizes are in hex, so a size of `z` is malformed.
-        data: z%0D%0Aabc%0D%0A0%0D%0A%0D%0A
+        data: z%0D%0Aabcwxyz%0D%0A0%0D%0A%0D%0A
 
     # The connection will be dropped and this response will not go out.
     server-response:
@@ -52,7 +52,7 @@ sessions:
         transfer: plain
         encoding: uri
         # Chunk header sizes are in hex, so a size of `3z` is malformed.
-        data: 3z%0D%0Aabc%0D%0A0%0D%0A%0D%0A
+        data: 3z%0D%0Aabcwxyz%0D%0A0%0D%0A%0D%0A
 
     # The connection will be dropped and this response will not go out.
     server-response:
@@ -72,7 +72,7 @@ sessions:
         transfer: plain
         encoding: uri
         # Super large chunk header, larger than will fit in an int.
-        data: 111111113%0D%0Aabc%0D%0A0%0D%0A%0D%0A
+        data: 111111113%0D%0Aabcwxyz%0D%0A0%0D%0A%0D%0A
 
     # The connection will be dropped and this response will not go out.
     server-response:


### PR DESCRIPTION
The ATS via header string contains a UUID which is a set of hex values. Since some of the chunked encoding tests used a chunked body of abc, this would sometimes coincidentally cause a failure when the autest found abc, not from the body, but from the UUID. This avoids that by including non-hex values in the test body.

Fixes #11841

(cherry picked from commit 13abab64f7beb74227789621eadbd150b2af6694)

---

Backport of: https://github.com/apache/trafficserver/pull/11843