### PR TITLE
Use the specified `length` characters of the key in `Headers::count` (#11405)

### DIFF
--- a/src/tscpp/api/Headers.cc
+++ b/src/tscpp/api/Headers.cc
@@ -594,7 +594,7 @@ Headers::size_type
 Headers::count(const char *key, int length)
 {
   size_type ret_count = 0;
-  size_t    len       = (length < 0) ? strlen(key) : length;
+  size_t len          = (length < 0) ? strlen(key) : length;
   for (header_field_iterator it = begin(); it != end(); ++it) {
     HeaderFieldName nm = (*it).name();
     if ((nm.length() == len) && (::strncasecmp(nm.c_str(), key, len) == 0)) {

--- a/src/tscpp/api/Headers.cc
+++ b/src/tscpp/api/Headers.cc
@@ -594,8 +594,10 @@ Headers::size_type
 Headers::count(const char *key, int length)
 {
   size_type ret_count = 0;
+  size_t    len       = (length < 0) ? strlen(key) : length;
   for (header_field_iterator it = begin(); it != end(); ++it) {
-    if ((*it).name() == key) {
+    HeaderFieldName nm = (*it).name();
+    if ((nm.length() == len) && (::strncasecmp(nm.c_str(), key, len) == 0)) {
       ret_count++;
     }
   }


### PR DESCRIPTION
* Use the specified `length` characters of the key in `Headers::count`

* Remove the additional operator== with std::string_view from tscpp APIs

(cherry picked from commit eb40c5b300a46086e608ae6d3350dad6c7941025)