### PR TITLE
[compress] Add range request control option

### DIFF
--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -106,8 +106,21 @@ by the origin. Enabled by default.
 range-request
 -------------
 
-When set to ``true``, causes |TS| to compress responses to Range Requests.
-Disabled by default. Setting this to true while setting cache to false leads to delivering corrupted content.
+This config controls behavior of this plugin when a client send ``Range`` header and ``Accept-Encoding`` header in the same time.
+
+============== =================================================================
+Value          Description
+============== =================================================================
+ignore-range   Remove ``Range`` header if the request has both headers (Default)
+false          Same as ``ignore-range`` for compatiblity
+no-compression Remove ``Accept-Encoding`` header if the request has both headers
+none           Do nothing
+true           Same as ``none`` for compatibility
+============== =================================================================
+
+.. important::
+
+   Do NOT set this to ``none`` (or ``true``) if the cache config is set to ``false``. This combination will deliver corrupted content.
 
 compressible-content-type
 -------------------------

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -94,7 +94,7 @@ handle_range_request(TSMBuffer req_buf, TSMLoc req_loc, HostConfiguration *hc)
     return;
   }
 
-  TSMLoc range_hdr_field = TSMimeHdrFieldFind(req_buf, req_loc, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
+  TSMLoc         range_hdr_field = TSMimeHdrFieldFind(req_buf, req_loc, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
   ts::PostScript range_defer([&]() -> void { TSHandleMLocRelease(req_buf, req_loc, range_hdr_field); });
   if (range_hdr_field == TS_NULL_MLOC) {
     return;

--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -27,6 +27,8 @@
 #include "ts/apidefs.h"
 #include "tscore/ink_config.h"
 
+#include <tsutil/PostScript.h>
+
 #if HAVE_BROTLI_ENCODE_H
 #include <brotli/encode.h>
 #endif
@@ -87,11 +89,13 @@ handle_range_request(TSMBuffer req_buf, TSMLoc req_loc, HostConfiguration *hc)
 {
   TSMLoc accept_encoding_hdr_field =
     TSMimeHdrFieldFind(req_buf, req_loc, TS_MIME_FIELD_ACCEPT_ENCODING, TS_MIME_LEN_ACCEPT_ENCODING);
+  ts::PostScript accept_encoding_defer([&]() -> void { TSHandleMLocRelease(req_buf, req_loc, accept_encoding_hdr_field); });
   if (accept_encoding_hdr_field == TS_NULL_MLOC) {
     return;
   }
 
   TSMLoc range_hdr_field = TSMimeHdrFieldFind(req_buf, req_loc, TS_MIME_FIELD_RANGE, TS_MIME_LEN_RANGE);
+  ts::PostScript range_defer([&]() -> void { TSHandleMLocRelease(req_buf, req_loc, range_hdr_field); });
   if (range_hdr_field == TS_NULL_MLOC) {
     return;
   }

--- a/plugins/compress/configuration.h
+++ b/plugins/compress/configuration.h
@@ -41,6 +41,12 @@ enum CompressionAlgorithm {
   ALGORITHM_BROTLI  = 4 // For bit manipulations
 };
 
+enum class RangeRequestCtrl : int {
+  IGNORE_RANGE   = 0, ///< Ignore Range Header (default)
+  NO_COMPRESSION = 1, ///< Do NOT compress if it's a range request
+  NONE           = 2, ///< Do nothing
+};
+
 class HostConfiguration : private atscppapi::noncopyable
 {
 public:
@@ -48,7 +54,6 @@ public:
     : host_(host),
       enabled_(true),
       cache_(true),
-      range_request_(false),
       remove_accept_encoding_(false),
       flush_(false),
       compression_algorithms_(ALGORITHM_GZIP),
@@ -66,15 +71,10 @@ public:
   {
     enabled_ = x;
   }
-  bool
-  range_request()
+  RangeRequestCtrl
+  range_request_ctl()
   {
-    return range_request_;
-  }
-  void
-  set_range_request(bool x)
-  {
-    range_request_ = x;
+    return range_request_ctl_;
   }
   bool
   cache()
@@ -137,19 +137,20 @@ public:
   bool is_status_code_compressible(const TSHttpStatus status_code) const;
   void add_compression_algorithms(std::string &algorithms);
   int  compression_algorithms();
+  void set_range_request(const std::string &token);
 
 private:
   std::string  host_;
   bool         enabled_;
   bool         cache_;
-  bool         range_request_;
   bool         remove_accept_encoding_;
   bool         flush_;
   int          compression_algorithms_;
   unsigned int minimum_content_length_;
 
-  StringContainer compressible_content_types_;
-  StringContainer allows_;
+  RangeRequestCtrl range_request_ctl_;
+  StringContainer  compressible_content_types_;
+  StringContainer  allows_;
   // maintain backwards compatibility/usability out of the box
   std::set<TSHttpStatus> compressible_status_codes_ = {TS_HTTP_STATUS_OK, TS_HTTP_STATUS_PARTIAL_CONTENT,
                                                        TS_HTTP_STATUS_NOT_MODIFIED};

--- a/tests/gold_tests/pluginTest/compress/compress-range.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress-range.test.py
@@ -1,0 +1,64 @@
+'''
+Test compress plugin with range request
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the #  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test compress plugin with range request
+'''
+
+Test.SkipUnless(Condition.PluginExists('compress.so'))
+
+
+class CompressPluginTest:
+    replayFile = "replay/compress-and-range.replay.yaml"
+
+    def __init__(self):
+        self.setupOriginServer()
+        self.setupTS()
+
+    def setupOriginServer(self):
+        self.server = Test.MakeVerifierServerProcess("verifier-server", self.replayFile)
+
+    def setupTS(self):
+        self.ts = Test.MakeATSProcess("ts")
+        self.ts.Disk.records_config.update(
+            {
+                "proxy.config.diags.debug.enabled": 1,
+                "proxy.config.diags.debug.tags": "http|compress",
+                "proxy.config.http.insert_response_via_str": 2,
+            })
+
+        self.ts.Setup.Copy("etc/cache-true-ignore-range.config")
+        self.ts.Setup.Copy("etc/cache-true-no-compression.config")
+
+        self.ts.Disk.remap_config.AddLines(
+            {
+                f"map /cache-true-ignore-range/ http://127.0.0.1:{self.server.Variables.http_port}/ @plugin=compress.so @pparam={Test.RunDirectory}/cache-true-ignore-range.config",
+                f"map /cache-true-no-compression/ http://127.0.0.1:{self.server.Variables.http_port}/ @plugin=compress.so @pparam={Test.RunDirectory}/cache-true-no-compression.config",
+            })
+
+    def run(self):
+        tr = Test.AddTestRun()
+        tr.AddVerifierClientProcess(
+            "verifier-client", self.replayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.Processes.Default.StartBefore(self.ts)
+        tr.Processes.Default.StartBefore(self.server)
+        tr.StillRunningAfter = self.ts
+        tr.StillRunningAfter = self.server
+
+
+CompressPluginTest().run()

--- a/tests/gold_tests/pluginTest/compress/etc/cache-true-ignore-range.config
+++ b/tests/gold_tests/pluginTest/compress/etc/cache-true-ignore-range.config
@@ -1,0 +1,5 @@
+cache true
+range-request ignore-range
+compressible-content-type application/json
+supported-algorithms gzip
+minimum-content-length 0

--- a/tests/gold_tests/pluginTest/compress/etc/cache-true-no-compression.config
+++ b/tests/gold_tests/pluginTest/compress/etc/cache-true-no-compression.config
@@ -1,0 +1,5 @@
+cache true
+range-request no-compression
+compressible-content-type application/json
+supported-algorithms gzip
+minimum-content-length 0

--- a/tests/gold_tests/pluginTest/compress/replay/compress-and-range.replay.yaml
+++ b/tests/gold_tests/pluginTest/compress/replay/compress-and-range.replay.yaml
@@ -1,0 +1,156 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+  blocks:
+  - origin-server-response-200: &origin-server-response-200
+      status: 200
+      headers:
+        fields:
+          - [ Cache-Control, public;max-age=3600 ]
+          - [ Content-Type, application/json ]
+          - [ Content-Length, 1024 ]
+        content:
+          encoding: plain
+          size: 1024
+
+  - origin-server-response-206: &origin-server-response-206
+      status: 206
+      headers:
+        fields:
+          - [ Cache-Control, public;max-age=3600 ]
+          - [ Content-Type, application/json ]
+          - [ Content-Length, 10 ]
+        content:
+          encoding: plain
+          size: 10
+
+sessions:
+- transactions:
+  # Test Case 1
+  #
+  # ```
+  # cache true
+  # range-request ignore-range
+  #```
+  #
+  # 1-1: Accept-Encoding only
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cache-true-ignore-range/
+      headers:
+        fields:
+          - [ uuid, 1-1]
+          - [ Host, example.com ]
+          - [ Accept-Encoding, gzip ]
+
+    server-response:
+      <<: *origin-server-response-200
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Encoding, { value: gzip, as: equal } ]
+          - [ Content-Length, { value: 223, as: equal } ]
+
+  # 1-2: Range only
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cache-true-ignore-range/
+      headers:
+        fields:
+          - [ uuid, 1-2]
+          - [ Host, example.com ]
+          - [ Range, 0-9 ]
+
+    proxy-request:
+      headers:
+        fields:
+          - [ Range, { as: present } ]
+
+    server-response:
+      <<: *origin-server-response-206
+
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: 10, as: equal } ]
+
+  # 1-3: Range and Accept-Encoding
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cache-true-ignore-range/
+      headers:
+        fields:
+          - [ uuid, 1-3]
+          - [ Host, example.com ]
+          - [ Range, 0-9 ]
+          - [ Accept-Encoding, gzip ]
+
+    proxy-request:
+      headers:
+        fields:
+          - [ Range, { as: absent } ]
+
+    server-response:
+      <<: *origin-server-response-200
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Encoding, { value: gzip, as: equal } ]
+          - [ Content-Length, { value: 223, as: equal } ]
+
+  # Test Case 2
+  #
+  # ```
+  # cache true
+  # range-request no-compression
+  #```
+  #
+  # 2-1: Range and Accept-Encoding
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cache-true-no-compression/
+      headers:
+        fields:
+          - [ uuid, 2-1]
+          - [ Host, example.com ]
+          - [ Range, 0-9 ]
+          - [ Accept-Encoding, gzip ]
+
+    proxy-request:
+      headers:
+        fields:
+          - [ Range, { as: present } ]
+
+    server-response:
+      <<: *origin-server-response-206
+
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: 10, as: equal } ]
+


### PR DESCRIPTION
Prior to the change, the `range-request` config controls compress plugin to skip compression if `Range` request. However, this makes unexpected behavior once the object is cached without `Range` request. 

~To fix the case, this removes `Range` header if client send both of `Accept-Encoding` and `Range`  header.~

Update: add new options to choose `Accept-Encoding` header or `Range` header if a client sends both headers.

- `ignore-range` (or `true`) : Remove `Range` header
- `no-compression`: Remove `Accept-Encoding` header
- `none` (or `false`): do nothing
