### PR TITLE
Fix crash by including remap files with named filters

### DIFF
--- a/include/proxy/http/remap/RemapConfig.h
+++ b/include/proxy/http/remap/RemapConfig.h
@@ -70,6 +70,9 @@ struct BUILD_TABLE_INFO {
   // Clear the argument vector.
   void reset();
 
+  // Free acl_filter_rule in the list
+  void clear_acl_rules_list();
+
   // noncopyable
   BUILD_TABLE_INFO(const BUILD_TABLE_INFO &)            = delete; // disabled
   BUILD_TABLE_INFO &operator=(const BUILD_TABLE_INFO &) = delete; // disabled

--- a/src/proxy/http/remap/RemapConfig.cc
+++ b/src/proxy/http/remap/RemapConfig.cc
@@ -97,14 +97,6 @@ BUILD_TABLE_INFO::BUILD_TABLE_INFO()
 BUILD_TABLE_INFO::~BUILD_TABLE_INFO()
 {
   this->reset();
-
-  // clean up any leftover named filter rules
-  auto *rp = rules_list;
-  while (rp != nullptr) {
-    auto *tmp = rp->next;
-    delete rp;
-    rp = tmp;
-  }
 }
 
 void
@@ -113,6 +105,18 @@ BUILD_TABLE_INFO::reset()
   this->paramc = this->argc = 0;
   clear_xstr_array(this->paramv, sizeof(this->paramv) / sizeof(char *));
   clear_xstr_array(this->argv, sizeof(this->argv) / sizeof(char *));
+}
+
+void
+BUILD_TABLE_INFO::clear_acl_rules_list()
+{
+  // clean up any leftover named filter rules
+  auto *rp = rules_list;
+  while (rp != nullptr) {
+    auto *tmp = rp->next;
+    delete rp;
+    rp = tmp;
+  }
 }
 
 static const char *
@@ -1489,6 +1493,8 @@ remap_parse_config(const char *path, UrlRewrite *rewrite)
   /* Now after we parsed the configuration and (re)loaded plugins and plugin instances
    * accordingly notify all plugins that we are done */
   rewrite->pluginFactory.indicatePostReload(status);
+
+  bti.clear_acl_rules_list();
 
   return status;
 }

--- a/src/proxy/http/remap/unit-tests/test_RemapRules.cc
+++ b/src/proxy/http/remap/unit-tests/test_RemapRules.cc
@@ -35,6 +35,8 @@
 #include "swoc/swoc_file.h"
 #include "ts/apidefs.h"
 #include "tscore/BaseLogFile.h"
+#include "tsutil/PostScript.h"
+
 #include <memory>
 
 #define CATCH_CONFIG_MAIN /* include main function */
@@ -83,6 +85,7 @@ SCENARIO("Parsing ACL named filters", "[proxy][remap]")
   GIVEN("Named filter definitions with multiple actions")
   {
     BUILD_TABLE_INFO bti{};
+    ts::PostScript   acl_rules_defer([&]() -> void { bti.clear_acl_rules_list(); });
     UrlRewrite       rewrite{};
 
     bti.rewrite = &rewrite;


### PR DESCRIPTION
# Symptom

When remap.config includes some files and if they have named filter, it'll be crashed.

## Repro

- remap.config
```
.include remap_a.config
.include remap_b.config
```

- remap_a.config
```
.definefilter filter_a @action=deny @method=CONNECT
```

- remap_b.config
```
.definefilter filter_b @action=deny @method=CONNECT
```

## Stack Trace

```
traffic_server: received signal 11 (Segmentation fault: 11)
traffic_server - STACK TRACE: 
0   traffic_server                      0x00000001008f6768 _Z19crash_logger_invokeiP9__siginfoPv + 172
1   libsystem_platform.dylib            0x000000018a5e2e04 _sigtramp + 56
2   traffic_server                      0x0000000100a78ea4 _ZN15acl_filter_rule11find_bynameEPS_PKc + 156
3   traffic_server                      0x0000000100a78ea4 _ZN15acl_filter_rule11find_bynameEPS_PKc + 156
4   traffic_server                      0x0000000100aafcf0 _ZL22parse_define_directivePKcP16BUILD_TABLE_INFOPcm + 360
5   traffic_server                      0x0000000100aa9d48 _Z21remap_parse_directiveP16BUILD_TABLE_INFOPcm + 372
6   traffic_server                      0x0000000100aad08c _Z22remap_parse_config_btiPKcP16BUILD_TABLE_INFO + 2324
7   traffic_server                      0x0000000100ab0abc _ZL20parse_remap_fragmentPKcP16BUILD_TABLE_INFOPcm + 416
8   traffic_server                      0x0000000100ab07d0 _ZL23parse_include_directivePKcP16BUILD_TABLE_INFOPcm + 1172
9   traffic_server                      0x0000000100aa9d48 _Z21remap_parse_directiveP16BUILD_TABLE_INFOPcm + 372
10  traffic_server                      0x0000000100aad08c _Z22remap_parse_config_btiPKcP16BUILD_TABLE_INFO + 2324
11  traffic_server                      0x0000000100aafb10 _Z18remap_parse_configPKcP10UrlRewrite + 92
12  traffic_server                      0x0000000100ac9fc0 _ZN10UrlRewrite10BuildTableEPKc + 700
13  traffic_server                      0x0000000100ac98f8 _ZN10UrlRewrite4loadEv + 2516
14  traffic_server                      0x0000000100ccad68 _Z18init_reverse_proxyv + 380
15  traffic_server                      0x00000001009c8fd0 _Z27init_accept_HttpProxyServeri + 32
16  traffic_server                      0x0000000100906a34 main + 8872
17  dyld                                0x000000018a22c274 start + 2840
```

# Root Cause 

https://github.com/apache/trafficserver/pull/11951 add a code to clear the `rules_list` in the destructor of `BUILD_TABLE_INFO` to fix a memory leak.

https://github.com/apache/trafficserver/blob/d543c8a30e4447a422bf688cb0299cf3074ece51/src/proxy/http/remap/RemapConfig.cc#L101-L108

However, when `.include` directive is used, `parse_remap_fragment()` is called and it has own `BUILD_TABLE_INFO nbti` on stack and copy the `rules_list` pointer. So, when `parse_remap_fragment()` call is done, the `bti` has freed pointer.

https://github.com/apache/trafficserver/blob/d543c8a30e4447a422bf688cb0299cf3074ece51/src/proxy/http/remap/RemapConfig.cc#L330-L331

# Approach

Clear the `rules_list` at the end of `remap_parse_config()`, it's end of scope of `BUILD_TABLE_INFO bti;`. 
( Yes, I do agree with we need refactoring around ACL Named Filters )