### PR TITLE
Fix crash by including remap files with named filters (#11997)

### DIFF
--- a/proxy/http/remap/RemapConfig.cc
+++ b/proxy/http/remap/RemapConfig.cc
@@ -91,14 +91,6 @@ BUILD_TABLE_INFO::BUILD_TABLE_INFO()
 BUILD_TABLE_INFO::~BUILD_TABLE_INFO()
 {
   this->reset();
-
-  // clean up any leftover named filter rules
-  auto *rp = rules_list;
-  while (rp != nullptr) {
-    auto *tmp = rp->next;
-    delete rp;
-    rp = tmp;
-  }
 }
 
 void
@@ -107,6 +99,18 @@ BUILD_TABLE_INFO::reset()
   this->paramc = this->argc = 0;
   clear_xstr_array(this->paramv, sizeof(this->paramv) / sizeof(char *));
   clear_xstr_array(this->argv, sizeof(this->argv) / sizeof(char *));
+}
+
+void
+BUILD_TABLE_INFO::clear_acl_rules_list()
+{
+  // clean up any leftover named filter rules
+  auto *rp = rules_list;
+  while (rp != nullptr) {
+    auto *tmp = rp->next;
+    delete rp;
+    rp = tmp;
+  }
 }
 
 static const char *
@@ -1380,6 +1384,8 @@ remap_parse_config(const char *path, UrlRewrite *rewrite)
   /* Now after we parsed the configuration and (re)loaded plugins and plugin instances
    * accordingly notify all plugins that we are done */
   rewrite->pluginFactory.indicatePostReload(status);
+
+  bti.clear_acl_rules_list();
 
   return status;
 }

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -61,6 +61,9 @@ struct BUILD_TABLE_INFO {
   // Clear the argument vector.
   void reset();
 
+  // Free acl_filter_rule in the list
+  void clear_acl_rules_list();
+  
   // noncopyable
   BUILD_TABLE_INFO(const BUILD_TABLE_INFO &) = delete;            // disabled
   BUILD_TABLE_INFO &operator=(const BUILD_TABLE_INFO &) = delete; // disabled

--- a/proxy/http/remap/RemapConfig.h
+++ b/proxy/http/remap/RemapConfig.h
@@ -63,7 +63,7 @@ struct BUILD_TABLE_INFO {
 
   // Free acl_filter_rule in the list
   void clear_acl_rules_list();
-  
+
   // noncopyable
   BUILD_TABLE_INFO(const BUILD_TABLE_INFO &) = delete;            // disabled
   BUILD_TABLE_INFO &operator=(const BUILD_TABLE_INFO &) = delete; // disabled


### PR DESCRIPTION
* Fix crash by including remap files with named filters

* Fix unit test

(cherry picked from commit 4c9c7c63dcddc60c473509f66a262a09593f9b2e)