### PR TITLE
Add support for parsing Proxy protocol v2 TLV fields

### DIFF
--- a/include/iocore/net/ProxyProtocol.h
+++ b/include/iocore/net/ProxyProtocol.h
@@ -27,6 +27,8 @@
 
 #include <tscore/ink_inet.h>
 #include <swoc/TextView.h>
+#include <unordered_map>
+#include <cstdlib>
 
 enum class ProxyProtocolVersion {
   UNDEFINED,
@@ -40,11 +42,38 @@ enum class ProxyProtocolData {
   DST,
 };
 
-struct ProxyProtocol {
-  ProxyProtocolVersion version   = ProxyProtocolVersion::UNDEFINED;
-  uint16_t             ip_family = AF_UNSPEC;
-  IpEndpoint           src_addr  = {};
-  IpEndpoint           dst_addr  = {};
+constexpr uint8_t PP2_TYPE_ALPN           = 0x01;
+constexpr uint8_t PP2_TYPE_AUTHORITY      = 0x02;
+constexpr uint8_t PP2_TYPE_CRC32C         = 0x03;
+constexpr uint8_t PP2_TYPE_NOOP           = 0x04;
+constexpr uint8_t PP2_TYPE_UNIQUE_ID      = 0x05;
+constexpr uint8_t PP2_TYPE_SSL            = 0x20;
+constexpr uint8_t PP2_SUBTYPE_SSL_VERSION = 0x21;
+constexpr uint8_t PP2_SUBTYPE_SSL_CN      = 0x22;
+constexpr uint8_t PP2_SUBTYPE_SSL_CIPHER  = 0x23;
+constexpr uint8_t PP2_SUBTYPE_SSL_SIG_ALG = 0x24;
+constexpr uint8_t PP2_SUBTYPE_SSL_KEY_ALG = 0x25;
+constexpr uint8_t PP2_TYPE_NETNS          = 0x30;
+
+class ProxyProtocol
+{
+public:
+  ProxyProtocol() {}
+  ProxyProtocol(ProxyProtocolVersion pp_ver, uint16_t family, IpEndpoint src, IpEndpoint dst)
+    : version(pp_ver), ip_family(family), src_addr(src), dst_addr(dst)
+  {
+  }
+  ~ProxyProtocol() { ats_free(additional_data); }
+  int set_additional_data(std::string_view data);
+
+  ProxyProtocolVersion                          version   = ProxyProtocolVersion::UNDEFINED;
+  uint16_t                                      ip_family = AF_UNSPEC;
+  IpEndpoint                                    src_addr  = {};
+  IpEndpoint                                    dst_addr  = {};
+  std::unordered_map<uint8_t, std::string_view> tlv;
+
+private:
+  char *additional_data = nullptr;
 };
 
 const size_t PPv1_CONNECTION_HEADER_LEN_MAX = 108;

--- a/src/iocore/net/unit_tests/test_ProxyProtocol.cc
+++ b/src/iocore/net/unit_tests/test_ProxyProtocol.cc
@@ -234,7 +234,6 @@ TEST_CASE("PROXY Protocol v2 Parser", "[ProxyProtocol][ProxyProtocolv2]")
     CHECK(pp_info.ip_family == AF_UNSPEC);
   }
 
-  // TLVs are not supported yet. Checking TLVs are skipped as expected for now.
   SECTION("TLVs")
   {
     uint8_t raw_data[] = {
@@ -242,12 +241,13 @@ TEST_CASE("PROXY Protocol v2 Parser", "[ProxyProtocol][ProxyProtocolv2]")
       0x55, 0x49, 0x54, 0x0A,                         ///<
       0x21,                                           ///< version & command
       0x11,                                           ///< protocol & family
-      0x00, 0x11,                                     ///< len
+      0x00, 0x17,                                     ///< len
       0xC0, 0x00, 0x02, 0x01,                         ///< src_addr
       0xC6, 0x33, 0x64, 0x01,                         ///< dst_addr
       0xC3, 0x50,                                     ///< src_port
       0x01, 0xBB,                                     ///< dst_port
       0x01, 0x00, 0x02, 0x68, 0x32,                   /// PP2_TYPE_ALPN (h2)
+      0x02, 0x00, 0x03, 0x61, 0x62, 0x63              /// PP2_TYPE_AUTHORITY (abc)
     };
 
     swoc::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
@@ -262,6 +262,9 @@ TEST_CASE("PROXY Protocol v2 Parser", "[ProxyProtocol][ProxyProtocolv2]")
     CHECK(pp_info.ip_family == AF_INET);
     CHECK(pp_info.src_addr == src_addr);
     CHECK(pp_info.dst_addr == dst_addr);
+
+    CHECK(pp_info.tlv[PP2_TYPE_ALPN] == "h2");
+    CHECK(pp_info.tlv[PP2_TYPE_AUTHORITY] == "abc");
   }
 
   SECTION("Malformed Headers")


### PR DESCRIPTION
The values are not used at anywhere yet, but ready to access. I didn't add parsers for specific TLV types because each type has different value format and an TLV field can have application specific value. I think we should add TS API to access information from Proxy protocol (incl. TLV fields).

Proxy protocol specification:
https://www.haproxy.org/download/2.1/doc/proxy-protocol.txt