### PR TITLE
Fix a build issue from iocore cleanup

### DIFF
--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -124,18 +124,32 @@ if(BUILD_TESTING)
   )
   if(CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED OR CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED)
     # Use link groups to solve circular dependency
+    set(LINK_GROUP_LIBS
+        ts::logging
+        ts::inknet
+        ts::inkhostdb
+        ts::proxy
+        ts::tsapibackend
+        ts::inkdns
+        ts::http2
+        ts::inkcache
+        ts::rpcpublichandlers
+        ts::overridable_txn_vars
+        ts::http
+        ts::http_remap
+    )
+    if(TS_USE_QUIC)
+      list(APPEND LINK_GROUP_LIBS quic http3)
+    endif()
+    string(JOIN "," LINK_GROUP_LIBS_CSV ${LINK_GROUP_LIBS})
     target_link_libraries(
-      test_net
-      PRIVATE
-        catch2::catch2
-        ts::tscore
-        "$<LINK_GROUP:RESCAN,ts::logging,ts::inknet,ts::inkhostdb,ts::proxy,ts::tsapibackend,ts::inkdns,ts::http2,ts::inkcache,ts::rpcpublichandlers,ts::overridable_txn_vars,ts::http,ts::http_remap>"
-        ts::tsutil
-        ts::inkevent
-        libswoc::libswoc
+      test_net PRIVATE catch2::catch2 ts::tscore "$<LINK_GROUP:RESCAN,${LINK_GROUP_LIBS_CSV}>" ts::tsutil ts::inkevent
+                       libswoc::libswoc
     )
   else()
     # These linkers already do the equivalent of RESCAN, so there's no support in cmake for it
+    # This case is mainly for macOS
+    # The reason that the list is different here, is because a careful ordering is necessary to prevent duplicate symbols, which are not allowed on macOS
     target_link_libraries(test_net PRIVATE catch2::catch2 ts::tscore ts::proxy ts::inknet ts::inkevent libswoc::libswoc)
   endif()
   if(NOT APPLE)

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -122,31 +122,22 @@ if(BUILD_TESTING)
     test_net libinknet_stub.cc NetVCTest.cc unit_tests/test_ProxyProtocol.cc unit_tests/test_SSLSNIConfig.cc
              unit_tests/test_YamlSNIConfig.cc unit_tests/unit_test_main.cc
   )
-  target_link_libraries(
-    test_net
-    PRIVATE catch2::catch2
-            ts::tscore
-            ts::overridable_txn_vars
-            ts::tsutil
-            ts::http_remap
-            ts::logging
-            ts::hdrs
-            ts::configmanager
-            ts::diagsconfig
-            ts::inkutils
-            ts::inkdns
-            ts::inkhostdb
-            ts::inkcache
-            ts::aio
-            ts::proxy
-            ts::inknet
-            ts::records
-            ts::inkevent
-            libswoc::libswoc
-            ts::jsonrpc_protocol
-            ts::jsonrpc_server
-            ts::rpcpublichandlers
-  )
+  if(CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED OR CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED)
+    # Use link groups to solve circular dependency
+    target_link_libraries(
+      test_net
+      PRIVATE
+        catch2::catch2
+        ts::tscore
+        "$<LINK_GROUP:RESCAN,ts::logging,ts::inknet,ts::inkhostdb,ts::proxy,ts::tsapibackend,ts::inkdns,ts::http2,ts::inkcache,ts::rpcpublichandlers,ts::overridable_txn_vars,ts::http,ts::http_remap>"
+        ts::tsutil
+        ts::inkevent
+        libswoc::libswoc
+    )
+  else()
+    # These linkers already do the equivalent of RESCAN, so there's no support in cmake for it
+    target_link_libraries(test_net PRIVATE catch2::catch2 ts::tscore ts::proxy ts::inknet ts::inkevent libswoc::libswoc)
+  endif()
   if(NOT APPLE)
     target_link_options(test_net PRIVATE -Wl,--allow-multiple-definition)
   endif()

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -122,7 +122,20 @@ if(BUILD_TESTING)
     test_net libinknet_stub.cc NetVCTest.cc unit_tests/test_ProxyProtocol.cc unit_tests/test_SSLSNIConfig.cc
              unit_tests/test_YamlSNIConfig.cc unit_tests/unit_test_main.cc
   )
-  target_link_libraries(test_net PRIVATE catch2::catch2 tscore ts::proxy ts::http_remap ts::inknet ts::inkevent)
+  target_link_libraries(
+    test_net
+    PRIVATE catch2::catch2
+            tscore
+            ts::tsapi
+            ts::configmanager
+            ts::hdrs
+            ts::proxy
+            ts::inkdns
+            ts::inkutils
+            ts::inknet
+            ts::inkevent
+            libswoc::libswoc
+  )
   if(NOT APPLE)
     target_link_options(test_net PRIVATE -Wl,--allow-multiple-definition)
   endif()

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -126,7 +126,6 @@ if(BUILD_TESTING)
     test_net
     PRIVATE catch2::catch2
             tscore
-            ts::tsapi
             ts::configmanager
             ts::hdrs
             ts::proxy

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -125,12 +125,27 @@ if(BUILD_TESTING)
   target_link_libraries(
     test_net
     PRIVATE catch2::catch2
-            tscore
+            ts::tscore
+            ts::overridable_txn_vars
+            ts::tsutil
             ts::http_remap
+            ts::logging
+            ts::hdrs
+            ts::configmanager
+            ts::diagsconfig
+            ts::inkutils
+            ts::inkdns
+            ts::inkhostdb
+            ts::inkcache
+            ts::aio
             ts::proxy
             ts::inknet
+            ts::records
             ts::inkevent
             libswoc::libswoc
+            ts::jsonrpc_protocol
+            ts::jsonrpc_server
+            ts::rpcpublichandlers
   )
   if(NOT APPLE)
     target_link_options(test_net PRIVATE -Wl,--allow-multiple-definition)

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -126,11 +126,8 @@ if(BUILD_TESTING)
     test_net
     PRIVATE catch2::catch2
             tscore
-            ts::configmanager
-            ts::hdrs
+            ts::http_remap
             ts::proxy
-            ts::inkdns
-            ts::inkutils
             ts::inknet
             ts::inkevent
             libswoc::libswoc

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -117,11 +117,12 @@ if(TS_USE_LINUX_IO_URING)
 endif()
 
 if(BUILD_TESTING)
+  # libinknet_stub.cc is need because GNU ld is sensitive to the order of static libraries on the command line, and we have a cyclic dependency between inknet and proxy
   add_executable(
     test_net libinknet_stub.cc NetVCTest.cc unit_tests/test_ProxyProtocol.cc unit_tests/test_SSLSNIConfig.cc
              unit_tests/test_YamlSNIConfig.cc unit_tests/unit_test_main.cc
   )
-  target_link_libraries(test_net PRIVATE ts::inknet catch2::catch2)
+  target_link_libraries(test_net PRIVATE catch2::catch2 tscore ts::proxy ts::inknet ts::inkevent)
   if(NOT APPLE)
     target_link_options(test_net PRIVATE -Wl,--allow-multiple-definition)
   endif()

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -122,7 +122,7 @@ if(BUILD_TESTING)
     test_net libinknet_stub.cc NetVCTest.cc unit_tests/test_ProxyProtocol.cc unit_tests/test_SSLSNIConfig.cc
              unit_tests/test_YamlSNIConfig.cc unit_tests/unit_test_main.cc
   )
-  target_link_libraries(test_net PRIVATE catch2::catch2 tscore ts::proxy ts::inknet ts::inkevent)
+  target_link_libraries(test_net PRIVATE catch2::catch2 tscore ts::proxy ts::http_remap ts::inknet ts::inkevent)
   if(NOT APPLE)
     target_link_options(test_net PRIVATE -Wl,--allow-multiple-definition)
   endif()


### PR DESCRIPTION
The build of test_net was broken on Mac when the build mode is set to release.

**Root cause:**

We support two kinds of linkers.  One kind will only search for symbols that are to the left of the object being linked.  Another kind will search the list of libraries repeatedly until the no new undefined references are created.  Both are sensitive to the order of libraries on the command line.

In order to work with both, we have to carefully order our dependencies in cmake.  See the build rule for traffic_server for a working list of dependencies.

In this case, libinknet_stub.cc provides some symbols that are also provided by ts::proxy, in order to fix an issue of cyclic dependency between ts::inknet and ts::proxy.  However, this causes the link to have duplicate symbols when libraries are not ordered correctly, on linkers that repeat through the list.

**References:**

https://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc