### PR TITLE
[Doc] Add deprecated plugins list for 10.0.0

### DIFF
--- a/doc/release-notes/upgrading.en.rst
+++ b/doc/release-notes/upgrading.en.rst
@@ -197,6 +197,13 @@ The following changes have been made to the :file:`sni.yaml` file:
 Plugins
 -------
 
+Deprecated Plugins
+~~~~~~~~~~~~~~~~~~
+The following plugins have been deprecated.
+
+  * healthchecks - please use the statichit plugin instead
+  * icap
+
 Removed Plugins
 ~~~~~~~~~~~~~~~
 The following plugins have been removed from the ATS source code in this version of ATS:


### PR DESCRIPTION
It looks like doc is missing list of deprecated plugins

- https://docs.trafficserver.apache.org/en/10.0.x/admin-guide/plugins/healthchecks.en.html
- https://docs.trafficserver.apache.org/en/10.0.x/admin-guide/plugins/icap.en.html