### PR TITLE
Added option for proxy.config.http.auth_server_session_private

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -1053,12 +1053,22 @@ allow-plain
    to use the client HTTP version for upstream requests.
 
 .. ts:cv:: CONFIG proxy.config.http.auth_server_session_private INT 1
+   :reloadable:
    :overridable:
 
-   If enabled (``1``) anytime a request contains a ``Authorization``,
-   ``Proxy-Authorization``, or ``Www-Authenticate`` header the connection will
-   be closed and not reused. This marks the connection as private. When disabled
-   (``0``) the connection will be available for reuse.
+   Specifies whether |TS| should close the origin connection and not reuse it if the request contains an
+   ``Authorization``, ``Proxy-Authorization``, or ``Www-Authenticate`` header.  Private connections are
+   associated with a single client connection and are not shared with other client connections.
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``0`` The origin connection will be available for reuse.
+   ``1`` The origin connection will be closed after the client is done with it and if the request contains an
+         ``Authorization``, ``Proxy-Authorization``, or ``Www-Authenticate`` header.
+   ``2`` The origin connection will be closed after the client is done with it and if the request contains a
+         ``Proxy-Authorization`` or ``Www-Authenticate`` header.
+   ===== ======================================================================
 
 .. ts:cv:: CONFIG proxy.config.http.server_session_sharing.match STRING both
    :overridable:

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -1124,7 +1124,7 @@ HttpConfig::reconfigure()
   params->oride.keep_alive_enabled_out      = INT_TO_BOOL(m_master.oride.keep_alive_enabled_out);
   params->oride.chunking_enabled            = INT_TO_BOOL(m_master.oride.chunking_enabled);
   params->oride.http_drop_chunked_trailers  = m_master.oride.http_drop_chunked_trailers;
-  params->oride.auth_server_session_private = INT_TO_BOOL(m_master.oride.auth_server_session_private);
+  params->oride.auth_server_session_private = m_master.oride.auth_server_session_private;
 
   params->oride.http_chunking_size = m_master.oride.http_chunking_size;
 

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -5393,9 +5393,13 @@ HttpSM::do_http_server_open(bool raw, bool only_direct)
   // know that the session will be private. This is overridable meaning that if a plugin later decides
   // it shouldn't be private it can still be returned to a shared pool.
   //
-  if (t_state.txn_conf->auth_server_session_private == 1 &&
-      t_state.hdr_info.server_request.presence(MIME_PRESENCE_AUTHORIZATION | MIME_PRESENCE_PROXY_AUTHORIZATION |
-                                               MIME_PRESENCE_WWW_AUTHENTICATE)) {
+  if (t_state.txn_conf->auth_server_session_private == 2 &&
+      t_state.hdr_info.server_request.presence(MIME_PRESENCE_PROXY_AUTHORIZATION | MIME_PRESENCE_WWW_AUTHENTICATE)) {
+    SMDbg(dbg_ctl_http_ss_auth, "Setting server session to private for Proxy-Authorization or WWW-Authenticate header");
+    will_be_private_ss = true;
+  } else if (t_state.txn_conf->auth_server_session_private == 1 &&
+             t_state.hdr_info.server_request.presence(MIME_PRESENCE_AUTHORIZATION | MIME_PRESENCE_PROXY_AUTHORIZATION |
+                                                      MIME_PRESENCE_WWW_AUTHENTICATE)) {
     SMDbg(dbg_ctl_http_ss_auth, "Setting server session to private for authorization header");
     will_be_private_ss = true;
   }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -5392,12 +5392,10 @@ HttpSM::do_http_server_open(bool raw, bool only_direct)
   // We do this here because it means that we will not waste a connection from the pool if we already
   // know that the session will be private. This is overridable meaning that if a plugin later decides
   // it shouldn't be private it can still be returned to a shared pool.
-  //
-
   if (t_state.txn_conf->auth_server_session_private == 1 &&
       t_state.hdr_info.server_request.presence(MIME_PRESENCE_AUTHORIZATION | MIME_PRESENCE_PROXY_AUTHORIZATION |
                                                MIME_PRESENCE_WWW_AUTHENTICATE)) {
-    SMDbg(dbg_ctl_http_ss_auth, "Setting server session to private for authorization header");
+    SMDbg(dbg_ctl_http_ss_auth, "Setting server session to private for authorization headers");
     will_be_private_ss = true;
   } else if (t_state.txn_conf->auth_server_session_private == 2 &&
              t_state.hdr_info.server_request.presence(MIME_PRESENCE_PROXY_AUTHORIZATION | MIME_PRESENCE_WWW_AUTHENTICATE)) {

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -5393,14 +5393,15 @@ HttpSM::do_http_server_open(bool raw, bool only_direct)
   // know that the session will be private. This is overridable meaning that if a plugin later decides
   // it shouldn't be private it can still be returned to a shared pool.
   //
-  if (t_state.txn_conf->auth_server_session_private == 2 &&
-      t_state.hdr_info.server_request.presence(MIME_PRESENCE_PROXY_AUTHORIZATION | MIME_PRESENCE_WWW_AUTHENTICATE)) {
-    SMDbg(dbg_ctl_http_ss_auth, "Setting server session to private for Proxy-Authorization or WWW-Authenticate header");
-    will_be_private_ss = true;
-  } else if (t_state.txn_conf->auth_server_session_private == 1 &&
-             t_state.hdr_info.server_request.presence(MIME_PRESENCE_AUTHORIZATION | MIME_PRESENCE_PROXY_AUTHORIZATION |
-                                                      MIME_PRESENCE_WWW_AUTHENTICATE)) {
+
+  if (t_state.txn_conf->auth_server_session_private == 1 &&
+      t_state.hdr_info.server_request.presence(MIME_PRESENCE_AUTHORIZATION | MIME_PRESENCE_PROXY_AUTHORIZATION |
+                                               MIME_PRESENCE_WWW_AUTHENTICATE)) {
     SMDbg(dbg_ctl_http_ss_auth, "Setting server session to private for authorization header");
+    will_be_private_ss = true;
+  } else if (t_state.txn_conf->auth_server_session_private == 2 &&
+             t_state.hdr_info.server_request.presence(MIME_PRESENCE_PROXY_AUTHORIZATION | MIME_PRESENCE_WWW_AUTHENTICATE)) {
+    SMDbg(dbg_ctl_http_ss_auth, "Setting server session to private for Proxy-Authorization or WWW-Authenticate header");
     will_be_private_ss = true;
   }
 

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -393,7 +393,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.referer_default_redirect", RECD_STRING, "http://www.example.com/", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.http.auth_server_session_private", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.http.auth_server_session_private", RECD_INT, "1", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.http.max_post_size", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "^[0-9]+$", RECA_NULL}
   ,


### PR DESCRIPTION
Added option for proxy.config.http.auth_server_session_private to only mark the connection private if Proxy-Authorization or Www-Authenticate headers are present.