### PR TITLE
Adds the %{GROUP} condition to HRW, and else clause

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -297,6 +297,36 @@ setting headers. For example::
         set-header ATS-Geo-ASN %{GEO:ASN}
         set-header ATS-Geo-ASN-NAME %{GEO:ASN-NAME}
 
+GROUP
+~~~~~
+;;
+    cond %{GROUP}
+    cond %{GROUP:END}
+
+This condition is a pseudo condition that is used to group conditions together.
+Using these groups, you can construct more complex expressions, that can mix and
+match AND, OR and NOT operators. These groups are the equivalent of parenthesis
+in expressions. The following example illustrates this::
+
+    cond %{SEND_REQUEST_HDR_HOOK} [AND]
+    cond %{GROUP} [OR]
+        cond %{CLIENT-HEADER:X-Bar} /foo/ [AND]
+        cond %{CLIENT-HEADER:User-Agent} /Chrome/
+    cond %{GROUP:END}
+    cond %{GROUP}
+        cond %{CLIENT-HEADER:X-Foo} /something/ [AND]
+        cond %{CLIENT-HEADER:User-Agent} /MSIE/
+    cond %{GROUP:END}
+        set-header X-My-Header "This is a test"
+
+Note that the ``GROUP`` and ``GROUP:END`` conditions do not take any operands per se,
+and you are still limited to operations after the last condition. Also, the ``GROUP:END``
+condition must match exactly with the last ``GROUP`` conditions, but they can be
+nested in one or several levels.
+
+When closing a group with ``GROUP::END``, the modifiers are not used, in fact that entire
+condition is discarded, being used only to close the group. Youy may still decorate it
+with the same modifier as the opening ``GROUP`` condition, but it is not necessary.
 
 HEADER
 ~~~~~~

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -694,7 +694,8 @@ public:
   void
   append_value(std::string & /* s ATS_UNUSED */, const Resources & /* res ATS_UNUSED */) override
   {
-    TSReleaseAssert(!"%{GROUP} should never be used as a condition value!");
+    TSAssert(!"%{GROUP} should never be used as a condition value!");
+    TSError("[%s] %%{GROUP} should never be used as a condition value!", PLUGIN_NAME);
   }
 
   void

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -162,8 +162,10 @@ condition_factory(const std::string &cond)
     c = new ConditionCache();
   } else if (c_name == "NEXT-HOP") { // This condition adapts to the hook
     c = new ConditionNextHop();
-  } else if (c_name == "HTTP-CNTL") { // This condition adapts to the hook
+  } else if (c_name == "HTTP-CNTL") {
     c = new ConditionHttpCntl();
+  } else if (c_name == "GROUP") {
+    c = new ConditionGroup();
   } else {
     TSError("[%s] Unknown condition %s", PLUGIN_NAME, c_name.c_str());
     return nullptr;

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -173,6 +173,11 @@ Parser::preprocess(std::vector<std::string> tokens)
   } else if (tokens[0] == "cond") {
     _cond = true;
     tokens.erase(tokens.begin());
+  } else if (tokens[0] == "else") {
+    _cond = false;
+    _else = true;
+
+    return true;
   }
 
   // Is it a condition or operator?

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -65,6 +65,12 @@ public:
     return _cond;
   }
 
+  bool
+  is_else() const
+  {
+    return _else;
+  }
+
   const std::string &
   get_op() const
   {
@@ -110,6 +116,7 @@ private:
   bool preprocess(std::vector<std::string> tokens);
 
   bool                     _cond     = false;
+  bool                     _else     = false;
   bool                     _empty    = false;
   char                    *_from_url = nullptr;
   char                    *_to_url   = nullptr;


### PR DESCRIPTION
The syntax may not be beautiful, but it's inline with how HRW works today, and this solves a significant problem with lack of ()'s in the syntax.

Note that there's an implicit GROUP  / () around the outermost conditions. This has no impact on performance, but it moves some of the evaluation logic into the `ConditionGroup` class.

This also adds an optional else clause to the conditions and operators.