### PR TITLE
Use ats_free instead of free in LogFlushData destructor

### DIFF
--- a/include/proxy/logging/Log.h
+++ b/include/proxy/logging/Log.h
@@ -92,7 +92,7 @@ public:
       break;
     case LOG_FILE_ASCII:
     case LOG_FILE_PIPE:
-      free(m_data);
+      ats_free(m_data);
       break;
     case N_LOGFILE_TYPES:
     default:


### PR DESCRIPTION
When m_logfile->m_file_format in LogData is LOG_FILE_ASCII or LOG_FILE_PIPE, m_data in LogData is allocated with ats_malloc in LogFile::write_ascii_logbuffer3.