### PR TITLE
Static link opentelemetry-cpp libraries to otel_tracer plugin

### DIFF
--- a/cmake/Findopentelemetry.cmake
+++ b/cmake/Findopentelemetry.cmake
@@ -20,57 +20,240 @@
 # This will define the following variables
 #
 #     opentelemetry_FOUND
-#     opentelemetry_LIBRARY
+#     opentelemetry_common_LIBRARY
+#     opentelemetry_exporter_in_memory_LIBRARY
+#     opentelemetry_exporter_ostream_logs_LIBRARY
+#     opentelemetry_exporter_ostream_metrics_LIBRARY
+#     opentelemetry_exporter_ostream_span_LIBRARY
+#     opentelemetry_exporter_otlp_http_LIBRARY
+#     opentelemetry_exporter_otlp_http_client_LIBRARY
+#     opentelemetry_exporter_otlp_http_log_LIBRARY
+#     opentelemetry_exporter_otlp_http_metric_LIBRARY
+#     opentelemetry_http_client_curl_LIBRARY
+#     opentelemetry_logs_LIBRARY
+#     opentelemetry_metrics_LIBRARY
+#     opentelemetry_otlp_recordable_LIBRARY
+#     opentelemetry_proto_LIBRARY
+#     opentelemetry_resources_LIBRARY
+#     opentelemetry_trace_LIBRARY
+#     opentelemetry_version_LIBRARY
 #     opentelemetry_INCLUDE_DIRS
 #
 # and the following imported targets
 #
-#     opentelemetry::opentelemetry
+#     opentelemetry::opentelemetry_common
+#     opentelemetry::opentelemetry_exporter_in_memory
+#     opentelemetry::opentelemetry_exporter_ostream_logs
+#     opentelemetry::opentelemetry_exporter_ostream_metrics
+#     opentelemetry::opentelemetry_exporter_ostream_span
+#     opentelemetry::opentelemetry_exporter_otlp_http
+#     opentelemetry::opentelemetry_exporter_otlp_http_client
+#     opentelemetry::opentelemetry_exporter_otlp_http_log
+#     opentelemetry::opentelemetry_exporter_otlp_http_metric
+#     opentelemetry::opentelemetry_http_client_curl
+#     opentelemetry::opentelemetry_logs
+#     opentelemetry::opentelemetry_metrics
+#     opentelemetry::opentelemetry_otlp_recordable
+#     opentelemetry::opentelemetry_proto
+#     opentelemetry::opentelemetry_resources
+#     opentelemetry::opentelemetry_trace
+#     opentelemetry::opentelemetry_version
 #
 
-#opentelemetry has a lot of libraries
-set(OTEL_LIBS
-    opentelemetry_exporter_ostream_span
-    opentelemetry_exporter_otlp_http
-    opentelemetry_exporter_otlp_http_client
-    opentelemetry_exporter_otlp_http_log
-    opentelemetry_exporter_otlp_http_metric
-    opentelemetry_http_client_curl
-    opentelemetry_metrics
-    opentelemetry_otlp_recordable
-    opentelemetry_proto
-    opentelemetry_resources
-    opentelemetry_trace
-    opentelemetry_version
-    opentelemetry_common
-    opentelemetry_metrics
-    opentelemetry_logs
-)
-
+find_library(opentelemetry_common_LIBRARY NAMES opentelemetry_common)
+find_library(opentelemetry_exporter_in_memory_LIBRARY NAMES opentelemetry_exporter_in_memory)
+find_library(opentelemetry_exporter_ostream_logs_LIBRARY NAMES opentelemetry_exporter_ostream_logs)
+find_library(opentelemetry_exporter_ostream_metrics_LIBRARY NAMES opentelemetry_exporter_ostream_metrics)
+find_library(opentelemetry_exporter_ostream_span_LIBRARY NAMES opentelemetry_exporter_ostream_span)
+find_library(opentelemetry_exporter_otlp_http_LIBRARY NAMES opentelemetry_exporter_otlp_http)
+find_library(opentelemetry_exporter_otlp_http_client_LIBRARY NAMES opentelemetry_exporter_otlp_http_client)
+find_library(opentelemetry_exporter_otlp_http_log_LIBRARY NAMES opentelemetry_exporter_otlp_http_log)
+find_library(opentelemetry_exporter_otlp_http_metric_LIBRARY NAMES opentelemetry_exporter_otlp_http_metric)
+find_library(opentelemetry_http_client_curl_LIBRARY NAMES opentelemetry_http_client_curl)
+find_library(opentelemetry_logs_LIBRARY NAMES opentelemetry_logs)
+find_library(opentelemetry_metrics_LIBRARY NAMES opentelemetry_metrics)
+find_library(opentelemetry_otlp_recordable_LIBRARY NAMES opentelemetry_otlp_recordable)
+find_library(opentelemetry_proto_LIBRARY NAMES opentelemetry_proto)
+find_library(opentelemetry_resources_LIBRARY NAMES opentelemetry_resources)
+find_library(opentelemetry_trace_LIBRARY NAMES opentelemetry_trace)
+find_library(opentelemetry_version_LIBRARY NAMES opentelemetry_version)
 find_path(opentelemetry_INCLUDE_DIR NAMES opentelemetry/version.h)
 
-foreach(OTLIB ${OTEL_LIBS})
-  set(OTLIB_NAME ${OTLIB}_LIBRARY)
-  find_library(${OTLIB_NAME} NAMES ${OTLIB})
-  list(APPEND OTEL_LIBRARIES ${OTLIB_NAME})
-endforeach()
+mark_as_advanced(
+  opentelemetry_FOUND
+  opentelemetry_common_LIBRARY
+  opentelemetry_exporter_in_memory_LIBRARY
+  opentelemetry_exporter_ostream_logs_LIBRARY
+  opentelemetry_exporter_ostream_metrics_LIBRARY
+  opentelemetry_exporter_ostream_span_LIBRARY
+  opentelemetry_exporter_otlp_http_LIBRARY
+  opentelemetry_exporter_otlp_http_client_LIBRARY
+  opentelemetry_exporter_otlp_http_log_LIBRARY
+  opentelemetry_exporter_otlp_http_metric_LIBRARY
+  opentelemetry_http_client_curl_LIBRARY
+  opentelemetry_logs_LIBRARY
+  opentelemetry_metrics_LIBRARY
+  opentelemetry_otlp_recordable_LIBRARY
+  opentelemetry_proto_LIBRARY
+  opentelemetry_resources_LIBRARY
+  opentelemetry_trace_LIBRARY
+  opentelemetry_version_LIBRARY
+  opentelemetry_INCLUDE_DIR
+)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(opentelemetry REQUIRED_VARS opentelemetry_INCLUDE_DIR ${OTEL_LIBRARIES})
+find_package_handle_standard_args(
+  opentelemetry
+  REQUIRED_VARS
+    opentelemetry_common_LIBRARY
+    opentelemetry_exporter_in_memory_LIBRARY
+    opentelemetry_exporter_ostream_logs_LIBRARY
+    opentelemetry_exporter_ostream_metrics_LIBRARY
+    opentelemetry_exporter_ostream_span_LIBRARY
+    opentelemetry_exporter_otlp_http_LIBRARY
+    opentelemetry_exporter_otlp_http_client_LIBRARY
+    opentelemetry_exporter_otlp_http_log_LIBRARY
+    opentelemetry_exporter_otlp_http_metric_LIBRARY
+    opentelemetry_http_client_curl_LIBRARY
+    opentelemetry_logs_LIBRARY
+    opentelemetry_metrics_LIBRARY
+    opentelemetry_otlp_recordable_LIBRARY
+    opentelemetry_proto_LIBRARY
+    opentelemetry_resources_LIBRARY
+    opentelemetry_trace_LIBRARY
+    opentelemetry_version_LIBRARY
+    opentelemetry_INCLUDE_DIR
+)
 
 if(opentelemetry_FOUND)
-  mark_as_advanced(opentelemetry_FOUND ${OTEL_LIBRARIES})
   set(opentelemetry_INCLUDE_DIRS "${opentelemetry_INCLUDE_DIR}")
-
-  foreach(OTELLIB ${OTEL_LIBRARIES})
-    list(APPEND opentelemetry_LIBRARIES ${${OTELLIB}})
-  endforeach()
-  message(STATUS "Opentelemetry found: ${opentelemetry_LIBRARIES}")
-  message(STATUS "Opentelemetry include: ${opentelemetry_INCLUDE_DIRS}")
-
-  if(NOT TARGET opentelemetry::opentelemetry)
-    add_library(opentelemetry::opentelemetry INTERFACE IMPORTED)
-    target_include_directories(opentelemetry::opentelemetry INTERFACE ${opentelemetry_INCLUDE_DIRS})
-    target_link_libraries(opentelemetry::opentelemetry INTERFACE ${opentelemetry_LIBRARIES})
-  endif()
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_common)
+  add_library(opentelemetry::opentelemetry_common STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_common PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                                   IMPORTED_LOCATION "${opentelemetry_common_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_in_memory)
+  add_library(opentelemetry::opentelemetry_exporter_in_memory STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_in_memory
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_in_memory_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_ostream_logs)
+  add_library(opentelemetry::opentelemetry_exporter_ostream_logs STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_ostream_logs
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_ostream_logs_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_ostream_metrics)
+  add_library(opentelemetry::opentelemetry_exporter_ostream_metrics STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_ostream_metrics
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_ostream_metrics_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_ostream_span)
+  add_library(opentelemetry::opentelemetry_exporter_ostream_span STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_ostream_span
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_ostream_span_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http)
+  add_library(opentelemetry::opentelemetry_exporter_otlp_http STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_otlp_http
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http_client)
+  add_library(opentelemetry::opentelemetry_exporter_otlp_http_client STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_otlp_http_client
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_client_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http_log)
+  add_library(opentelemetry::opentelemetry_exporter_otlp_http_log STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_otlp_http_log
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_log_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http_metric)
+  add_library(opentelemetry::opentelemetry_exporter_otlp_http_metric STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_exporter_otlp_http_metric
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_metric_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_http_client_curl)
+  add_library(opentelemetry::opentelemetry_http_client_curl STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_http_client_curl
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}" IMPORTED_LOCATION
+                                                                            "${opentelemetry_http_client_curl_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_logs)
+  add_library(opentelemetry::opentelemetry_logs STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_logs PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                                 IMPORTED_LOCATION "${opentelemetry_logs_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_metrics)
+  add_library(opentelemetry::opentelemetry_metrics STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_metrics PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                                    IMPORTED_LOCATION "${opentelemetry_metrics_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_otlp_recordable)
+  add_library(opentelemetry::opentelemetry_otlp_recordable STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_otlp_recordable
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}" IMPORTED_LOCATION
+                                                                            "${opentelemetry_otlp_recordable_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_proto)
+  add_library(opentelemetry::opentelemetry_proto STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_proto PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                                  IMPORTED_LOCATION "${opentelemetry_proto_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_resources)
+  add_library(opentelemetry::opentelemetry_resources STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_resources PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                                      IMPORTED_LOCATION "${opentelemetry_resources_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_trace)
+  add_library(opentelemetry::opentelemetry_trace STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_trace PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                                  IMPORTED_LOCATION "${opentelemetry_trace_LIBRARY}"
+  )
+endif()
+if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_version)
+  add_library(opentelemetry::opentelemetry_version STATIC IMPORTED)
+  set_target_properties(
+    opentelemetry::opentelemetry_version PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                                    IMPORTED_LOCATION "${opentelemetry_version_LIBRARY}"
+  )
 endif()

--- a/cmake/Findopentelemetry.cmake
+++ b/cmake/Findopentelemetry.cmake
@@ -20,240 +20,103 @@
 # This will define the following variables
 #
 #     opentelemetry_FOUND
-#     opentelemetry_common_LIBRARY
-#     opentelemetry_exporter_in_memory_LIBRARY
-#     opentelemetry_exporter_ostream_logs_LIBRARY
-#     opentelemetry_exporter_ostream_metrics_LIBRARY
 #     opentelemetry_exporter_ostream_span_LIBRARY
 #     opentelemetry_exporter_otlp_http_LIBRARY
 #     opentelemetry_exporter_otlp_http_client_LIBRARY
 #     opentelemetry_exporter_otlp_http_log_LIBRARY
 #     opentelemetry_exporter_otlp_http_metric_LIBRARY
 #     opentelemetry_http_client_curl_LIBRARY
-#     opentelemetry_logs_LIBRARY
 #     opentelemetry_metrics_LIBRARY
 #     opentelemetry_otlp_recordable_LIBRARY
 #     opentelemetry_proto_LIBRARY
 #     opentelemetry_resources_LIBRARY
 #     opentelemetry_trace_LIBRARY
 #     opentelemetry_version_LIBRARY
+#     opentelemetry_common_LIBRARY
+#     opentelemetry_metrics_LIBRARY
+#     opentelemetry_logs_LIBRARY
 #     opentelemetry_INCLUDE_DIRS
 #
 # and the following imported targets
 #
-#     opentelemetry::opentelemetry_common
-#     opentelemetry::opentelemetry_exporter_in_memory
-#     opentelemetry::opentelemetry_exporter_ostream_logs
-#     opentelemetry::opentelemetry_exporter_ostream_metrics
+#   on macOS
+#     opentelemetry::opentelemetry
+#
+#   on other OSes
 #     opentelemetry::opentelemetry_exporter_ostream_span
 #     opentelemetry::opentelemetry_exporter_otlp_http
 #     opentelemetry::opentelemetry_exporter_otlp_http_client
 #     opentelemetry::opentelemetry_exporter_otlp_http_log
 #     opentelemetry::opentelemetry_exporter_otlp_http_metric
 #     opentelemetry::opentelemetry_http_client_curl
-#     opentelemetry::opentelemetry_logs
 #     opentelemetry::opentelemetry_metrics
 #     opentelemetry::opentelemetry_otlp_recordable
 #     opentelemetry::opentelemetry_proto
 #     opentelemetry::opentelemetry_resources
 #     opentelemetry::opentelemetry_trace
 #     opentelemetry::opentelemetry_version
+#     opentelemetry::opentelemetry_common
+#     opentelemetry::opentelemetry_metrics
+#     opentelemetry::opentelemetry_logs
 #
 
-find_library(opentelemetry_common_LIBRARY NAMES opentelemetry_common)
-find_library(opentelemetry_exporter_in_memory_LIBRARY NAMES opentelemetry_exporter_in_memory)
-find_library(opentelemetry_exporter_ostream_logs_LIBRARY NAMES opentelemetry_exporter_ostream_logs)
-find_library(opentelemetry_exporter_ostream_metrics_LIBRARY NAMES opentelemetry_exporter_ostream_metrics)
-find_library(opentelemetry_exporter_ostream_span_LIBRARY NAMES opentelemetry_exporter_ostream_span)
-find_library(opentelemetry_exporter_otlp_http_LIBRARY NAMES opentelemetry_exporter_otlp_http)
-find_library(opentelemetry_exporter_otlp_http_client_LIBRARY NAMES opentelemetry_exporter_otlp_http_client)
-find_library(opentelemetry_exporter_otlp_http_log_LIBRARY NAMES opentelemetry_exporter_otlp_http_log)
-find_library(opentelemetry_exporter_otlp_http_metric_LIBRARY NAMES opentelemetry_exporter_otlp_http_metric)
-find_library(opentelemetry_http_client_curl_LIBRARY NAMES opentelemetry_http_client_curl)
-find_library(opentelemetry_logs_LIBRARY NAMES opentelemetry_logs)
-find_library(opentelemetry_metrics_LIBRARY NAMES opentelemetry_metrics)
-find_library(opentelemetry_otlp_recordable_LIBRARY NAMES opentelemetry_otlp_recordable)
-find_library(opentelemetry_proto_LIBRARY NAMES opentelemetry_proto)
-find_library(opentelemetry_resources_LIBRARY NAMES opentelemetry_resources)
-find_library(opentelemetry_trace_LIBRARY NAMES opentelemetry_trace)
-find_library(opentelemetry_version_LIBRARY NAMES opentelemetry_version)
+#opentelemetry has a lot of libraries
+set(OTEL_LIBS
+    opentelemetry_exporter_ostream_span
+    opentelemetry_exporter_otlp_http
+    opentelemetry_exporter_otlp_http_client
+    opentelemetry_exporter_otlp_http_log
+    opentelemetry_exporter_otlp_http_metric
+    opentelemetry_http_client_curl
+    opentelemetry_metrics
+    opentelemetry_otlp_recordable
+    opentelemetry_proto
+    opentelemetry_resources
+    opentelemetry_trace
+    opentelemetry_version
+    opentelemetry_common
+    opentelemetry_metrics
+    opentelemetry_logs
+)
+
 find_path(opentelemetry_INCLUDE_DIR NAMES opentelemetry/version.h)
 
-mark_as_advanced(
-  opentelemetry_FOUND
-  opentelemetry_common_LIBRARY
-  opentelemetry_exporter_in_memory_LIBRARY
-  opentelemetry_exporter_ostream_logs_LIBRARY
-  opentelemetry_exporter_ostream_metrics_LIBRARY
-  opentelemetry_exporter_ostream_span_LIBRARY
-  opentelemetry_exporter_otlp_http_LIBRARY
-  opentelemetry_exporter_otlp_http_client_LIBRARY
-  opentelemetry_exporter_otlp_http_log_LIBRARY
-  opentelemetry_exporter_otlp_http_metric_LIBRARY
-  opentelemetry_http_client_curl_LIBRARY
-  opentelemetry_logs_LIBRARY
-  opentelemetry_metrics_LIBRARY
-  opentelemetry_otlp_recordable_LIBRARY
-  opentelemetry_proto_LIBRARY
-  opentelemetry_resources_LIBRARY
-  opentelemetry_trace_LIBRARY
-  opentelemetry_version_LIBRARY
-  opentelemetry_INCLUDE_DIR
-)
+foreach(OTLIB ${OTEL_LIBS})
+  set(OTLIB_NAME ${OTLIB}_LIBRARY)
+  find_library(${OTLIB_NAME} NAMES ${OTLIB})
+  list(APPEND OTEL_LIBRARIES ${OTLIB_NAME})
+endforeach()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  opentelemetry
-  REQUIRED_VARS
-    opentelemetry_common_LIBRARY
-    opentelemetry_exporter_in_memory_LIBRARY
-    opentelemetry_exporter_ostream_logs_LIBRARY
-    opentelemetry_exporter_ostream_metrics_LIBRARY
-    opentelemetry_exporter_ostream_span_LIBRARY
-    opentelemetry_exporter_otlp_http_LIBRARY
-    opentelemetry_exporter_otlp_http_client_LIBRARY
-    opentelemetry_exporter_otlp_http_log_LIBRARY
-    opentelemetry_exporter_otlp_http_metric_LIBRARY
-    opentelemetry_http_client_curl_LIBRARY
-    opentelemetry_logs_LIBRARY
-    opentelemetry_metrics_LIBRARY
-    opentelemetry_otlp_recordable_LIBRARY
-    opentelemetry_proto_LIBRARY
-    opentelemetry_resources_LIBRARY
-    opentelemetry_trace_LIBRARY
-    opentelemetry_version_LIBRARY
-    opentelemetry_INCLUDE_DIR
-)
+find_package_handle_standard_args(opentelemetry REQUIRED_VARS opentelemetry_INCLUDE_DIR ${OTEL_LIBRARIES})
 
 if(opentelemetry_FOUND)
   set(opentelemetry_INCLUDE_DIRS "${opentelemetry_INCLUDE_DIR}")
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_common)
-  add_library(opentelemetry::opentelemetry_common STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_common PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-                                                   IMPORTED_LOCATION "${opentelemetry_common_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_in_memory)
-  add_library(opentelemetry::opentelemetry_exporter_in_memory STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_in_memory
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_in_memory_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_ostream_logs)
-  add_library(opentelemetry::opentelemetry_exporter_ostream_logs STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_ostream_logs
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_ostream_logs_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_ostream_metrics)
-  add_library(opentelemetry::opentelemetry_exporter_ostream_metrics STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_ostream_metrics
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_ostream_metrics_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_ostream_span)
-  add_library(opentelemetry::opentelemetry_exporter_ostream_span STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_ostream_span
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_ostream_span_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http)
-  add_library(opentelemetry::opentelemetry_exporter_otlp_http STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_otlp_http
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http_client)
-  add_library(opentelemetry::opentelemetry_exporter_otlp_http_client STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_otlp_http_client
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_client_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http_log)
-  add_library(opentelemetry::opentelemetry_exporter_otlp_http_log STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_otlp_http_log
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_log_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_exporter_otlp_http_metric)
-  add_library(opentelemetry::opentelemetry_exporter_otlp_http_metric STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_exporter_otlp_http_metric
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-               IMPORTED_LOCATION "${opentelemetry_exporter_otlp_http_metric_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_http_client_curl)
-  add_library(opentelemetry::opentelemetry_http_client_curl STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_http_client_curl
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}" IMPORTED_LOCATION
-                                                                            "${opentelemetry_http_client_curl_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_logs)
-  add_library(opentelemetry::opentelemetry_logs STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_logs PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-                                                 IMPORTED_LOCATION "${opentelemetry_logs_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_metrics)
-  add_library(opentelemetry::opentelemetry_metrics STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_metrics PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-                                                    IMPORTED_LOCATION "${opentelemetry_metrics_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_otlp_recordable)
-  add_library(opentelemetry::opentelemetry_otlp_recordable STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_otlp_recordable
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}" IMPORTED_LOCATION
-                                                                            "${opentelemetry_otlp_recordable_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_proto)
-  add_library(opentelemetry::opentelemetry_proto STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_proto PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-                                                  IMPORTED_LOCATION "${opentelemetry_proto_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_resources)
-  add_library(opentelemetry::opentelemetry_resources STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_resources PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-                                                      IMPORTED_LOCATION "${opentelemetry_resources_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_trace)
-  add_library(opentelemetry::opentelemetry_trace STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_trace PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-                                                  IMPORTED_LOCATION "${opentelemetry_trace_LIBRARY}"
-  )
-endif()
-if(opentelemetry_FOUND AND NOT TARGET opentelemetry::opentelemetry_version)
-  add_library(opentelemetry::opentelemetry_version STATIC IMPORTED)
-  set_target_properties(
-    opentelemetry::opentelemetry_version PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
-                                                    IMPORTED_LOCATION "${opentelemetry_version_LIBRARY}"
-  )
+  mark_as_advanced(opentelemetry_FOUND opentelemetry_INCLUDE_DIR ${OTEL_LIBRARIES})
+
+  foreach(OTELLIB ${OTEL_LIBRARIES})
+    list(APPEND opentelemetry_found_LIBRARIES ${${OTELLIB}})
+  endforeach()
+  message(STATUS "Opentelemetry found: ${opentelemetry_found_LIBRARIES}")
+  message(STATUS "Opentelemetry include: ${opentelemetry_INCLUDE_DIRS}")
+
+  if(APPLE)
+    if(NOT TARGET opentelemetry::opentelemetry)
+      add_library(opentelemetry::opentelemetry INTERFACE IMPORTED)
+      target_include_directories(opentelemetry::opentelemetry INTERFACE ${opentelemetry_INCLUDE_DIRS})
+      target_link_libraries(opentelemetry::opentelemetry INTERFACE ${opentelemetry_found_LIBRARIES})
+      list(APPEND opentelemetry_LIBRARIES opentelemetry::opentelemetry)
+    endif()
+  else()
+    foreach(OTLIB ${OTEL_LIBS})
+      if(NOT TARGET opentelemetry::${OTLIB})
+        add_library(opentelemetry::${OTLIB} STATIC IMPORTED)
+        set_target_properties(
+          opentelemetry::${OTLIB} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${opentelemetry_INCLUDE_DIR}"
+                                             IMPORTED_LOCATION "${${OTLIB}_LIBRARY}"
+        )
+        list(APPEND opentelemetry_LIBRARIES opentelemetry::${OTLIB})
+      endif()
+    endforeach()
+  endif()
 endif()

--- a/doc/admin-guide/plugins/otel_tracer.en.rst
+++ b/doc/admin-guide/plugins/otel_tracer.en.rst
@@ -50,6 +50,17 @@ Compiling the Plugin
 
 To compile this plugin, we need nlohmann-json, protobuf and opentelemetry-cpp
 
+nlohmann-json:
+
+::
+
+  wget https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+  tar zxvf v3.11.3.tar.gz
+  cd json-3.11.3
+  cmake -B build -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
+  cmake --build build --config Release --parallel --verbose
+  sudo cmake --install build --prefix /usr/local/
+
 protobuf:
 
 ::
@@ -58,24 +69,21 @@ protobuf:
   wget https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.21.12.tar.gz
   tar zxvf v3.21.12.tar.gz
   cd protobuf-3.21.12
-  ./autogen.sh
-  ./configure --enable-shared=no --enable-static=yes CXXFLAGS="-std=c++17 -fPIC" CFLAGS="-fPIC"
-  make
-  make install
+  cmake -B build -Dprotobuf_BUILD_SHARED_LIBS=OFF -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+  cmake --build build --config Release --parallel --verbose
+  sudo cmake --install build --prefix /usr/local/
 
 opentelemetry-cpp
 
 ::
 
   cd
-  wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.11.0.tar.gz
-  tar zxvf v1.11.0.tar.gz
-  cd opentelemetry-cpp-1.11.0
-  mkdir build
-  cd build
-  cmake .. -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_JAEGER=OFF -DWITH_OTLP_GRPC=OFF -DWITH_OTLP_HTTP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DWITH_ABSEIL=OFF
-  cmake --build . --target all
-  cmake --install . --config Debug --prefix /usr/local/
+  wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz
+  tar zxvf v1.19.0.tar.gz
+  cd opentelemetry-cpp-1.19.0
+  cmake -B build -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_OTLP_GRPC=OFF -DWITH_OTLP_HTTP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DWITH_ABSEIL=OFF
+  cmake --build build --config Release --parallel --verbose
+  sudo cmake --install build --prefix /usr/local/
 
 Installation
 ============

--- a/plugins/experimental/otel_tracer/CMakeLists.txt
+++ b/plugins/experimental/otel_tracer/CMakeLists.txt
@@ -16,5 +16,9 @@
 #######################
 
 add_atsplugin(otel_tracer otel_tracer.cc)
-target_link_libraries(otel_tracer PRIVATE opentelemetry::opentelemetry protobuf::libprotobuf CURL::libcurl)
+target_link_libraries(
+  otel_tracer
+  PRIVATE
+    "$<LINK_GROUP:RESCAN,opentelemetry::opentelemetry_common,opentelemetry::opentelemetry_exporter_in_memory,opentelemetry::opentelemetry_exporter_ostream_logs,opentelemetry::opentelemetry_exporter_ostream_metrics,opentelemetry::opentelemetry_exporter_ostream_span,opentelemetry::opentelemetry_exporter_otlp_http,opentelemetry::opentelemetry_exporter_otlp_http_client,opentelemetry::opentelemetry_exporter_otlp_http_log,opentelemetry::opentelemetry_exporter_otlp_http_metric,opentelemetry::opentelemetry_http_client_curl,opentelemetry::opentelemetry_logs,opentelemetry::opentelemetry_metrics,opentelemetry::opentelemetry_otlp_recordable,opentelemetry::opentelemetry_proto,opentelemetry::opentelemetry_resources,opentelemetry::opentelemetry_trace,opentelemetry::opentelemetry_version,protobuf::libprotobuf,CURL::libcurl>"
+)
 verify_global_plugin(otel_tracer)

--- a/plugins/experimental/otel_tracer/CMakeLists.txt
+++ b/plugins/experimental/otel_tracer/CMakeLists.txt
@@ -16,9 +16,17 @@
 #######################
 
 add_atsplugin(otel_tracer otel_tracer.cc)
-target_link_libraries(
-  otel_tracer
-  PRIVATE
-    "$<LINK_GROUP:RESCAN,opentelemetry::opentelemetry_common,opentelemetry::opentelemetry_exporter_in_memory,opentelemetry::opentelemetry_exporter_ostream_logs,opentelemetry::opentelemetry_exporter_ostream_metrics,opentelemetry::opentelemetry_exporter_ostream_span,opentelemetry::opentelemetry_exporter_otlp_http,opentelemetry::opentelemetry_exporter_otlp_http_client,opentelemetry::opentelemetry_exporter_otlp_http_log,opentelemetry::opentelemetry_exporter_otlp_http_metric,opentelemetry::opentelemetry_http_client_curl,opentelemetry::opentelemetry_logs,opentelemetry::opentelemetry_metrics,opentelemetry::opentelemetry_otlp_recordable,opentelemetry::opentelemetry_proto,opentelemetry::opentelemetry_resources,opentelemetry::opentelemetry_trace,opentelemetry::opentelemetry_version,protobuf::libprotobuf,CURL::libcurl>"
-)
+if(CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED OR CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED)
+  string(JOIN "," opentelemetry_LIBRARIES_CSV ${opentelemetry_LIBRARIES})
+  target_link_libraries(
+    otel_tracer PRIVATE "$<LINK_GROUP:RESCAN,${opentelemetry_LIBRARIES_CSV},protobuf::libprotobuf,CURL::libcurl>"
+  )
+elseif(APPLE)
+  target_link_libraries(otel_tracer PRIVATE ${opentelemetry_LIBRARIES} protobuf::libprotobuf CURL::libcurl)
+else()
+  target_link_libraries(
+    otel_tracer PRIVATE -Wl,--start-group ${opentelemetry_LIBRARIES} protobuf::libprotobuf CURL::libcurl
+                        -Wl,--end-group
+  )
+endif()
 verify_global_plugin(otel_tracer)


### PR DESCRIPTION
Without this, `cmake --build build --target test` causes an error that failes to load otel_tracer.so because of undefined symbol `_ZN6google8protobuf7Message19CopyWithSourceCheckERS1_RKS1_`.

Also update instructions for building and installing dependency libraries using CMake.

Also update opentelemetry-cpp version to v1.19.0.