### PR TITLE
Deprecate name_get() and value_get() function returns const char * (#10153)

### DIFF
--- a/include/proxy/hdrs/MIME.h
+++ b/include/proxy/hdrs/MIME.h
@@ -142,8 +142,7 @@ struct MIMEField {
   }
 
   /// @return The name of @a this field.
-  std::string_view                                                      name_get() const;
-  [[deprecated("Use name_get() returns std::string_view")]] const char *name_get(int *length) const;
+  std::string_view name_get() const;
 
   /** Find the index of the value in the multi-value field.
 
@@ -160,8 +159,7 @@ struct MIMEField {
   int value_get_index(const char *value, int length) const;
 
   /// @return The value of @a this field.
-  std::string_view                                                       value_get() const;
-  [[deprecated("Use value_get() returns std::string_view")]] const char *value_get(int *length) const;
+  std::string_view value_get() const;
 
   int32_t  value_get_int() const;
   uint32_t value_get_uint() const;
@@ -943,17 +941,6 @@ bool     mime_parse_integer(const char *&buf, const char *end, int *integer);
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 
-inline const char *
-MIMEField::name_get(int *length) const
-{
-  auto name{this->name_get()};
-  *length = int(name.size());
-  return name.data();
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
 inline void
 MIMEField::name_set(HdrHeap *heap, MIMEHdrImpl *mh, const char *name, int length)
 {
@@ -985,14 +972,6 @@ MIMEField::name_is_valid(uint32_t invalid_char_bits) const
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
-
-inline const char *
-MIMEField::value_get(int *length) const
-{
-  auto value{this->value_get()};
-  *length = static_cast<int>(value.length());
-  return value.data();
-}
 
 inline int32_t
 MIMEField::value_get_int() const

--- a/include/proxy/hdrs/MIME.h
+++ b/include/proxy/hdrs/MIME.h
@@ -962,7 +962,7 @@ inline bool
 MIMEField::name_is_valid(uint32_t invalid_char_bits) const
 {
   auto name{name_get()};
-  for (char c : name) {
+  for (auto c : name) {
     if (ParseRules::is_type(c, invalid_char_bits)) {
       return false;
     }
@@ -1061,7 +1061,7 @@ inline bool
 MIMEField::value_is_valid(uint32_t invalid_char_bits) const
 {
   auto value{value_get()};
-  for (char c : value) {
+  for (auto c : value) {
     if (ParseRules::is_type(c, invalid_char_bits)) {
       return false;
     }

--- a/include/proxy/http2/HPACK.h
+++ b/include/proxy/http2/HPACK.h
@@ -86,13 +86,17 @@ public:
   const char *
   name_get(int *length) const
   {
-    return _field->name_get(length);
+    auto name{_field->name_get()};
+    *length = static_cast<int>(name.length());
+    return name.data();
   }
 
   const char *
   value_get(int *length) const
   {
-    return _field->value_get(length);
+    auto value{_field->value_get()};
+    *length = static_cast<int>(value.length());
+    return value.data();
   }
 
   const MIMEField *

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -1613,7 +1613,9 @@ TSMimeFieldValueGet(TSMBuffer /* bufp ATS_UNUSED */, TSMLoc field_obj, int idx, 
   if (idx >= 0) {
     return mime_field_value_get_comma_val(handle->field_ptr, value_len_ptr, idx);
   } else {
-    return handle->field_ptr->value_get(value_len_ptr);
+    auto value{handle->field_ptr->value_get()};
+    *value_len_ptr = static_cast<int>(value.length());
+    return value.data();
   }
 }
 
@@ -2030,7 +2032,9 @@ TSMimeHdrFieldNameGet(TSMBuffer bufp, TSMLoc hdr, TSMLoc field, int *length)
   sdk_assert(sdk_sanity_check_null_ptr((void *)length) == TS_SUCCESS);
 
   MIMEFieldSDKHandle *handle = reinterpret_cast<MIMEFieldSDKHandle *>(field);
-  return handle->field_ptr->name_get(length);
+  auto                name{handle->field_ptr->name_get()};
+  *length = static_cast<int>(name.length());
+  return name.data();
 }
 
 TSReturnCode

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S.cc
@@ -29,6 +29,8 @@ bool reuse_existing_cache = false;
 
 #include "main.h"
 
+using namespace std::literals;
+
 class CacheAltReadAgain : public CacheTestHandler
 {
 public:
@@ -76,9 +78,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -156,9 +157,8 @@ private:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 };
 

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_L.cc
@@ -26,6 +26,8 @@
 
 #include "main.h"
 
+using namespace std::literals;
+
 int  cache_vols           = 1;
 bool reuse_existing_cache = false;
 
@@ -87,9 +89,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 };
 
@@ -133,9 +134,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -213,9 +213,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 
   void

--- a/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_L_to_S_remove_S.cc
@@ -26,6 +26,8 @@
 
 #include "main.h"
 
+using namespace std::literals;
+
 int  cache_vols           = 1;
 bool reuse_existing_cache = false;
 
@@ -80,9 +82,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -134,9 +135,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -214,9 +214,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 
   void

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L.cc
@@ -26,6 +26,8 @@
 
 #include "main.h"
 
+using namespace std::literals;
+
 int  cache_vols           = 1;
 bool reuse_existing_cache = false;
 
@@ -76,9 +78,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -158,9 +159,8 @@ private:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 };
 

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_L.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_L.cc
@@ -27,6 +27,8 @@
 #include "main.h"
 #include "../P_CacheInternal.h"
 
+using namespace std::literals;
+
 int  cache_vols           = 1;
 bool reuse_existing_cache = false;
 
@@ -81,9 +83,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -136,9 +137,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -218,9 +218,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 
   void

--- a/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_S.cc
+++ b/src/iocore/cache/unit_tests/test_Alternate_S_to_L_remove_S.cc
@@ -27,6 +27,8 @@
 #include "main.h"
 #include "../P_CacheInternal.h"
 
+using namespace std::literals;
+
 int  cache_vols           = 1;
 bool reuse_existing_cache = false;
 
@@ -88,9 +90,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 };
 
@@ -134,9 +135,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "text/html;charset=utf-8", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "text/html;charset=utf-8"sv);
   }
 };
 
@@ -216,9 +216,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 
   void

--- a/src/iocore/cache/unit_tests/test_Update_header.cc
+++ b/src/iocore/cache/unit_tests/test_Update_header.cc
@@ -26,6 +26,8 @@
 
 #include "main.h"
 
+using namespace std::literals;
+
 int  cache_vols           = 1;
 bool reuse_existing_cache = false;
 
@@ -83,9 +85,8 @@ public:
     REQUIRE(rt);
     MIMEField *field = rt->read_http_info->m_alt->m_response_hdr.field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     REQUIRE(field);
-    int         len;
-    const char *value = field->value_get(&len);
-    REQUIRE(memcmp(value, "application/x-javascript", len) == 0);
+    auto value{field->value_get()};
+    REQUIRE(value == "application/x-javascript"sv);
   }
 
   void

--- a/src/proxy/hdrs/HTTP.cc
+++ b/src/proxy/hdrs/HTTP.cc
@@ -1216,9 +1216,8 @@ validate_hdr_host(HTTPHdrImpl *hh)
     if (host_field->has_dups()) {
       ret = PARSE_RESULT_ERROR; // can't have more than 1 host field.
     } else {
-      int              host_len = 0;
-      const char      *host_val = host_field->value_get(&host_len);
-      std::string_view addr, port, rest, host(host_val, host_len);
+      auto             host{host_field->value_get()};
+      std::string_view addr, port, rest;
       if (0 == ats_ip_parse(host, &addr, &port, &rest)) {
         if (!port.empty()) {
           if (port.size() > 5) {
@@ -1893,11 +1892,9 @@ HTTPHdr::check_hdr_implements()
   MIMEField *transfer_encode =
     mime_hdr_field_find(this->m_http->m_fields_impl, MIME_FIELD_TRANSFER_ENCODING, MIME_LEN_TRANSFER_ENCODING);
   if (transfer_encode) {
-    int         len;
-    const char *val;
     do {
-      val = transfer_encode->value_get(&len);
-      if (len != 7 || 0 != strncasecmp(val, "chunked", len)) {
+      auto val{transfer_encode->value_get()};
+      if (val.length() != 7 || 0 != strncasecmp(val.data(), "chunked", val.length())) {
         retval = false;
       }
       transfer_encode = transfer_encode->m_next_dup;

--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -1870,7 +1870,9 @@ mime_field_value_get_comma_val(const MIMEField *field, int *length, int idx)
   // some fields (like Date) contain commas but should not be ripped apart
   if (!field->supports_commas()) {
     if (idx == 0) {
-      return field->value_get(length);
+      auto value{field->value_get()};
+      *length = static_cast<int>(value.size());
+      return value.data();
     }
     return nullptr;
   } else {
@@ -3874,11 +3876,11 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
       // try pathpaths first -- unlike most other fastpaths, this one
       // is probably more useful for polygraph than for the real world
       if (!field->has_dups()) {
-        s = field->value_get(&len);
-        if (ptr_len_casecmp(s, len, "public", 6) == 0) {
+        auto val{field->value_get()};
+        if (ptr_len_casecmp(val.data(), val.length(), "public", 6) == 0) {
           mask                                   = MIME_COOKED_MASK_CC_PUBLIC;
           m_cooked_stuff.m_cache_control.m_mask |= mask;
-        } else if (ptr_len_casecmp(s, len, "private,no-cache", 16) == 0) {
+        } else if (ptr_len_casecmp(val.data(), val.length(), "private,no-cache", 16) == 0) {
           mask                                   = MIME_COOKED_MASK_CC_PRIVATE | MIME_COOKED_MASK_CC_NO_CACHE;
           m_cooked_stuff.m_cache_control.m_mask |= mask;
         }
@@ -3947,8 +3949,8 @@ MIMEHdrImpl::recompute_cooked_stuff(MIMEField *changing_field_or_null)
     field = mime_hdr_field_find(this, MIME_FIELD_PRAGMA, MIME_LEN_PRAGMA);
     if (field) {
       if (!field->has_dups()) { // try fastpath first
-        s = field->value_get(&len);
-        if (ptr_len_casecmp(s, len, "no-cache", 8) == 0) {
+        auto val{field->value_get()};
+        if (ptr_len_casecmp(val.data(), val.length(), "no-cache", 8) == 0) {
           m_cooked_stuff.m_pragma.m_no_cache = true;
           return;
         }

--- a/src/proxy/hdrs/VersionConverter.cc
+++ b/src/proxy/hdrs/VersionConverter.cc
@@ -21,6 +21,10 @@
   limitations under the License.
  */
 
+#include <string_view>
+
+using namespace std::literals;
+
 #include "proxy/hdrs/VersionConverter.h"
 #include "proxy/hdrs/HTTP.h"
 #include "tsutil/LocalBuffer.h"
@@ -231,8 +235,8 @@ VersionConverter::_convert_req_from_2_to_1(HTTPHdr &header) const
       auto path{field->value_get()};
 
       // cut first '/' if there, because `url_print()` add '/' before printing path
-      if (path.length() >= 1 && path[0] == '/') {
-        path = path.substr(1);
+      if (path.starts_with("/"sv)) {
+        path.remove_prefix(1);
       }
 
       header.m_http->u.req.m_url_impl->set_path(header.m_heap, path.data(), path.length(), true);

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4389,40 +4389,38 @@ HttpSM::do_remap_request(bool run_inline)
   if (!t_state.unmapped_url.m_url_impl->m_ptr_host) {
     MIMEField *host_field = t_state.hdr_info.client_request.field_find(MIME_FIELD_HOST, MIME_LEN_HOST);
     if (host_field) {
-      int         host_len  = 0;
-      const char *host_name = host_field->value_get(&host_len);
-      if (host_name && host_len) {
+      auto host_name = host_field->value_get();
+      if (host_name.data() && host_name.length()) {
         int port = -1;
         // Host header can contain port number, and if it does we need to set host and port separately to unmapped_url.
         // If header value starts with '[', the value must contain an IPv6 address, and it may contain a port number as well.
-        if (host_name[0] == '[') {   // IPv6
-          host_name = host_name + 1; // Skip '['
-          host_len--;
+        if (host_name[0] == '[') {         // IPv6
+          host_name = host_name.substr(1); // Skip '['
           // If header value ends with ']', the value must only contain an IPv6 address (no port number).
-          if (host_name[host_len - 1] == ']') { // Without port number
-            host_len--;                         // Exclude ']'
-          } else {                              // With port number
-            for (int idx = host_len - 1; idx > 0; idx--) {
+          if (host_name[host_name.length() - 1] == ']') {            // Without port number
+            host_name = host_name.substr(0, host_name.length() - 1); // Exclude ']'
+          } else {                                                   // With port number
+            for (int idx = host_name.length() - 1; idx > 0; idx--) {
               if (host_name[idx] == ':') {
-                port     = ink_atoi(host_name + idx + 1, host_len - (idx + 1));
-                host_len = idx;
+                port      = ink_atoi(host_name.data() + idx + 1, host_name.length() - (idx + 1));
+                host_name = host_name.substr(0, idx);
                 break;
               }
             }
           }
         } else { // Anything else (Hostname or IPv4 address)
           // If the value contains ':' where it does not have IPv6 address, there must be port number
-          if (const char *colon = static_cast<const char *>(memchr(host_name, ':', host_len));
+          if (const char *colon = static_cast<const char *>(memchr(host_name.data(), ':', host_name.length()));
               colon == nullptr) { // Without port number
             // Nothing to adjust. Entire value should be used as hostname.
           } else { // With port number
-            port     = ink_atoi(colon + 1, host_len - ((colon + 1) - host_name));
-            host_len = colon - host_name;
+            port      = ink_atoi(colon + 1, host_name.length() - ((colon + 1) - host_name.data()));
+            host_name = host_name.substr(0, colon - host_name.data());
           }
         }
 
         // Set values
-        t_state.unmapped_url.host_set(host_name, host_len);
+        t_state.unmapped_url.host_set(host_name.data(), host_name.length());
         if (port >= 0) {
           t_state.unmapped_url.port_set(port);
         }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4389,7 +4389,7 @@ HttpSM::do_remap_request(bool run_inline)
   if (!t_state.unmapped_url.m_url_impl->m_ptr_host) {
     MIMEField *host_field = t_state.hdr_info.client_request.field_find(MIME_FIELD_HOST, MIME_LEN_HOST);
     if (host_field) {
-      auto host_name = host_field->value_get();
+      auto host_name{host_field->value_get()};
       if (host_name.data() && host_name.length()) {
         int port = -1;
         // Host header can contain port number, and if it does we need to set host and port separately to unmapped_url.

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1251,12 +1251,11 @@ HttpTransact::handle_upgrade_request(State *s)
   MIMEField *upgrade_hdr    = s->hdr_info.client_request.field_find(MIME_FIELD_UPGRADE, MIME_LEN_UPGRADE);
   MIMEField *connection_hdr = s->hdr_info.client_request.field_find(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION);
 
-  StrList     connection_hdr_vals;
-  const char *upgrade_hdr_val     = nullptr;
-  int         upgrade_hdr_val_len = 0;
+  StrList          connection_hdr_vals;
+  std::string_view upgrade_hdr_val;
 
   if (!upgrade_hdr || !connection_hdr || connection_hdr->value_get_comma_list(&connection_hdr_vals) == 0 ||
-      (upgrade_hdr_val = upgrade_hdr->value_get(&upgrade_hdr_val_len)) == nullptr) {
+      (upgrade_hdr_val = upgrade_hdr->value_get()).data() == nullptr) {
     TxnDbg(dbg_ctl_http_trans_upgrade, "Transaction wasn't a valid upgrade request, proceeding as a normal HTTP request.");
     return false;
   }
@@ -1297,7 +1296,7 @@ HttpTransact::handle_upgrade_request(State *s)
         |Sec-WebSocket-Version|.  The value of this header field MUST be
         13.
    */
-  if (hdrtoken_tokenize(upgrade_hdr_val, upgrade_hdr_val_len, &s->upgrade_token_wks) >= 0) {
+  if (hdrtoken_tokenize(upgrade_hdr_val.data(), upgrade_hdr_val.length(), &s->upgrade_token_wks) >= 0) {
     if (s->upgrade_token_wks == MIME_VALUE_WEBSOCKET) {
       MIMEField *sec_websocket_key =
         s->hdr_info.client_request.field_find(MIME_FIELD_SEC_WEBSOCKET_KEY, MIME_LEN_SEC_WEBSOCKET_KEY);
@@ -1318,7 +1317,7 @@ HttpTransact::handle_upgrade_request(State *s)
       return false;
     }
   } else {
-    TxnDbg(dbg_ctl_http_trans_upgrade, "Transaction requested upgrade for unknown protocol: %s", upgrade_hdr_val);
+    TxnDbg(dbg_ctl_http_trans_upgrade, "Transaction requested upgrade for unknown protocol: %s", upgrade_hdr_val.data());
   }
 
   build_error_response(s, HTTP_STATUS_BAD_REQUEST, "Invalid Upgrade Request", "request#syntax_error");
@@ -1376,11 +1375,10 @@ HttpTransact::handle_websocket_connection(State *s)
 static bool
 mimefield_value_equal(MIMEField *field, const char *value, const int value_len)
 {
-  int         field_value_len = 0;
-  const char *field_value     = field->value_get(&field_value_len);
+  auto field_value = field->value_get();
 
-  if (field_value != nullptr && field_value_len == value_len) {
-    return !strncasecmp(field_value, value, value_len);
+  if (field_value.data() != nullptr && static_cast<int>(field_value.length()) == value_len) {
+    return !strncasecmp(field_value.data(), value, value_len);
   }
 
   return false;
@@ -1563,10 +1561,8 @@ HttpTransact::HandleRequest(State *s)
       MIMEField *expect = s->hdr_info.client_request.field_find(MIME_FIELD_EXPECT, MIME_LEN_EXPECT);
 
       if (expect != nullptr) {
-        const char *expect_hdr_val     = nullptr;
-        int         expect_hdr_val_len = 0;
-        expect_hdr_val                 = expect->value_get(&expect_hdr_val_len);
-        if (ptr_len_casecmp(expect_hdr_val, expect_hdr_val_len, HTTP_VALUE_100_CONTINUE, HTTP_LEN_100_CONTINUE) == 0) {
+        auto expect_hdr_val{expect->value_get()};
+        if (ptr_len_casecmp(expect_hdr_val.data(), expect_hdr_val.length(), HTTP_VALUE_100_CONTINUE, HTTP_LEN_100_CONTINUE) == 0) {
           // Let's error out this request.
           TxnDbg(dbg_ctl_http_trans, "Client sent a post expect: 100-continue, sending 405.");
           Metrics::Counter::increment(http_rsb.disallowed_post_100_continue);
@@ -3212,14 +3208,12 @@ HttpTransact::handle_cache_write_lock(State *s)
     MIMEField *c_inm = s->hdr_info.client_request.field_find(MIME_FIELD_IF_NONE_MATCH, MIME_LEN_IF_NONE_MATCH);
 
     if (c_ims) {
-      int         len;
-      const char *value = c_ims->value_get(&len);
-      s->hdr_info.server_request.value_set(MIME_FIELD_IF_MODIFIED_SINCE, MIME_LEN_IF_MODIFIED_SINCE, value, len);
+      auto value = c_ims->value_get();
+      s->hdr_info.server_request.value_set(MIME_FIELD_IF_MODIFIED_SINCE, MIME_LEN_IF_MODIFIED_SINCE, value.data(), value.length());
     }
     if (c_inm) {
-      int         len;
-      const char *value = c_inm->value_get(&len);
-      s->hdr_info.server_request.value_set(MIME_FIELD_IF_NONE_MATCH, MIME_LEN_IF_NONE_MATCH, value, len);
+      auto value = c_inm->value_get();
+      s->hdr_info.server_request.value_set(MIME_FIELD_IF_NONE_MATCH, MIME_LEN_IF_NONE_MATCH, value.data(), value.length());
     }
   }
 
@@ -4606,7 +4600,6 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
     //  the order of the fields
     MIMEField *resp_via = s->hdr_info.server_response.field_find(MIME_FIELD_VIA, MIME_LEN_VIA);
     if (resp_via) {
-      int                                              saved_via_len = 0;
       swoc::LocalBufferWriter<HTTP_OUR_VIA_MAX_LENGTH> saved_via_w;
       MIMEField                                       *our_via;
       our_via = s->hdr_info.client_response.field_find(MIME_FIELD_VIA, MIME_LEN_VIA);
@@ -4614,15 +4607,14 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
         our_via = s->hdr_info.client_response.field_create(MIME_FIELD_VIA, MIME_LEN_VIA);
         s->hdr_info.client_response.field_attach(our_via);
       } else {
-        const char *src = our_via->value_get(&saved_via_len);
-        saved_via_w.write(src, saved_via_len);
+        auto src{our_via->value_get()};
+        saved_via_w.write(src.data(), src.length());
         s->hdr_info.client_response.field_value_set(our_via, "", 0, true);
       }
       // HDR FIX ME - Multiple appends are VERY slow
       while (resp_via) {
-        int         clen;
-        const char *cfield = resp_via->value_get(&clen);
-        s->hdr_info.client_response.field_value_append(our_via, cfield, clen, true);
+        auto cfield = resp_via->value_get();
+        s->hdr_info.client_response.field_value_append(our_via, cfield.data(), cfield.length(), true);
         resp_via = resp_via->m_next_dup;
       }
       if (saved_via_w.size()) {
@@ -4972,31 +4964,29 @@ HttpTransact::set_headers_for_cache_write(State *s, HTTPInfo *cache_info, HTTPHd
 void
 HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, HTTPHdr *response_header)
 {
-  MIMEField  *new_field;
-  const char *name;
-  bool        dups_seen = false;
+  MIMEField *new_field;
+  bool       dups_seen = false;
 
   for (auto spot = response_header->begin(), limit = response_header->end(); spot != limit; ++spot) {
     MIMEField &field{*spot};
-    int        name_len;
-    name = field.name_get(&name_len);
+    auto       name{field.name_get()};
 
     ///////////////////////////
     // is hop-by-hop header? //
     ///////////////////////////
-    if (HttpTransactHeaders::is_this_a_hop_by_hop_header(name)) {
+    if (HttpTransactHeaders::is_this_a_hop_by_hop_header(name.data())) {
       continue;
     }
     /////////////////////////////////////
     // dont cache content-length field  and transfer encoding //
     /////////////////////////////////////
-    if (name == MIME_FIELD_CONTENT_LENGTH || name == MIME_FIELD_TRANSFER_ENCODING) {
+    if (name.data() == MIME_FIELD_CONTENT_LENGTH || name.data() == MIME_FIELD_TRANSFER_ENCODING) {
       continue;
     }
     /////////////////////////////////////
     // dont cache Set-Cookie headers   //
     /////////////////////////////////////
-    if (name == MIME_FIELD_SET_COOKIE) {
+    if (name.data() == MIME_FIELD_SET_COOKIE) {
       continue;
     }
     /////////////////////////////////////////
@@ -5004,7 +4994,7 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
     //   type as this wreaks havoc with    //
     //   transformed content               //
     /////////////////////////////////////////
-    if (name == MIME_FIELD_CONTENT_TYPE) {
+    if (name.data() == MIME_FIELD_CONTENT_TYPE) {
       continue;
     }
     /////////////////////////////////////
@@ -5012,7 +5002,7 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
     //  functions merges the two in a  //
     //  complex manner                 //
     /////////////////////////////////////
-    if (name == MIME_FIELD_WARNING) {
+    if (name.data() == MIME_FIELD_WARNING) {
       continue;
     }
     // Copy all remaining headers with replacement
@@ -5031,15 +5021,12 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
     //
     if (field.m_next_dup) {
       if (dups_seen == false) {
-        const char *name2;
-        int         name_len2;
-
         // use a second iterator to delete the
         // remaining response headers in the cached response,
         // so that they will be added in the next iterations.
         for (auto spot2 = spot; spot2 != limit; ++spot2) {
           MIMEField &field2{*spot2};
-          name2 = field2.name_get(&name_len2);
+          auto       name2 = field2.name_get();
 
           // It is specified above that content type should not
           // be altered here however when a duplicate header
@@ -5049,24 +5036,23 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
           // content type in the client response.
           // This ensures that it is not altered when duplicate
           // headers are present.
-          if (name2 == MIME_FIELD_CONTENT_TYPE) {
+          if (name2.data() == MIME_FIELD_CONTENT_TYPE) {
             continue;
           }
-          cached_header->field_delete(name2, name_len2);
+          cached_header->field_delete(name2.data(), name2.length());
         }
         dups_seen = true;
       }
     }
 
-    int         value_len;
-    const char *value = field.value_get(&value_len);
+    auto value{field.value_get()};
 
     if (dups_seen == false) {
-      cached_header->value_set(name, name_len, value, value_len);
+      cached_header->value_set(name.data(), name.length(), value.data(), value.length());
     } else {
-      new_field = cached_header->field_create(name, name_len);
+      new_field = cached_header->field_create(name.data(), name.length());
       cached_header->field_attach(new_field);
-      cached_header->field_value_set(new_field, value, value_len);
+      cached_header->field_value_set(new_field, value.data(), value.length());
     }
   }
 
@@ -5133,14 +5119,14 @@ HttpTransact::merge_warning_header(HTTPHdr *cached_header, HTTPHdr *response_hea
   // Loop over all the dups in the response warning header and append
   //  them one by one on to the cached warning header
   while (r_warn) {
-    move_warn = r_warn->value_get(&move_warn_len);
+    auto move_warn_sv{r_warn->value_get()};
 
     if (new_cwarn) {
-      cached_header->field_value_append(new_cwarn, move_warn, move_warn_len, true);
+      cached_header->field_value_append(new_cwarn, move_warn_sv.data(), move_warn_sv.length(), true);
     } else {
       new_cwarn = cached_header->field_create(MIME_FIELD_WARNING, MIME_LEN_WARNING);
       cached_header->field_attach(new_cwarn);
-      cached_header->field_value_set(new_cwarn, move_warn, move_warn_len);
+      cached_header->field_value_set(new_cwarn, move_warn_sv.data(), move_warn_sv.length());
     }
 
     r_warn = r_warn->m_next_dup;
@@ -6613,14 +6599,14 @@ HttpTransact::will_this_request_self_loop(State *s)
     while (via_field) {
       // No need to waste cycles comma separating the via values since we want to do a match anywhere in the
       // in the string.  We can just loop over the dup hdr fields
-      int         via_len;
-      const char *via_string = via_field->value_get(&via_len);
+      auto via_string{via_field->value_get()};
 
-      if ((count <= max_proxy_cycles) && via_string) {
+      if ((count <= max_proxy_cycles) && via_string.data()) {
         std::string_view            current{via_field->value_get()};
         std::string_view::size_type offset;
-        TxnDbg(dbg_ctl_http_transact, "Incoming via: \"%.*s\" --has-- (%s[%s] (%s))", via_len, via_string,
-               s->http_config_param->proxy_hostname, uuid.data(), s->http_config_param->proxy_request_via_string);
+        TxnDbg(dbg_ctl_http_transact, "Incoming via: \"%.*s\" --has-- (%s[%s] (%s))", static_cast<int>(via_string.length()),
+               via_string.data(), s->http_config_param->proxy_hostname, uuid.data(),
+               s->http_config_param->proxy_request_via_string);
         while ((count <= max_proxy_cycles) && (std::string_view::npos != (offset = current.find(uuid)))) {
           current.remove_prefix(offset + TS_UUID_STRING_LEN);
           count++;
@@ -7889,19 +7875,17 @@ HttpTransact::build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing
 
           for (size_t i = 0; i < countof(fields); i++) {
             if (base_response->presence(fields[i].presence)) {
-              MIMEField  *field;
-              int         len;
-              const char *value;
+              MIMEField *field;
 
               field = base_response->field_find(fields[i].name, fields[i].len);
               ink_assert(field != nullptr);
-              value = field->value_get(&len);
-              outgoing_response->value_append(fields[i].name, fields[i].len, value, len, false);
+              auto value{field->value_get()};
+              outgoing_response->value_append(fields[i].name, fields[i].len, value.data(), value.length(), false);
               if (field->has_dups()) {
                 field = field->m_next_dup;
                 while (field) {
-                  value = field->value_get(&len);
-                  outgoing_response->value_append(fields[i].name, fields[i].len, value, len, true);
+                  value = field->value_get();
+                  outgoing_response->value_append(fields[i].name, fields[i].len, value.data(), value.length(), true);
                   field = field->m_next_dup;
                 }
               }

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1375,7 +1375,7 @@ HttpTransact::handle_websocket_connection(State *s)
 static bool
 mimefield_value_equal(MIMEField *field, const char *value, const int value_len)
 {
-  auto field_value = field->value_get();
+  auto field_value{field->value_get()};
 
   if (field_value.data() != nullptr && static_cast<int>(field_value.length()) == value_len) {
     return !strncasecmp(field_value.data(), value, value_len);
@@ -3208,11 +3208,11 @@ HttpTransact::handle_cache_write_lock(State *s)
     MIMEField *c_inm = s->hdr_info.client_request.field_find(MIME_FIELD_IF_NONE_MATCH, MIME_LEN_IF_NONE_MATCH);
 
     if (c_ims) {
-      auto value = c_ims->value_get();
+      auto value{c_ims->value_get()};
       s->hdr_info.server_request.value_set(MIME_FIELD_IF_MODIFIED_SINCE, MIME_LEN_IF_MODIFIED_SINCE, value.data(), value.length());
     }
     if (c_inm) {
-      auto value = c_inm->value_get();
+      auto value{c_inm->value_get()};
       s->hdr_info.server_request.value_set(MIME_FIELD_IF_NONE_MATCH, MIME_LEN_IF_NONE_MATCH, value.data(), value.length());
     }
   }
@@ -4613,7 +4613,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
       }
       // HDR FIX ME - Multiple appends are VERY slow
       while (resp_via) {
-        auto cfield = resp_via->value_get();
+        auto cfield{resp_via->value_get()};
         s->hdr_info.client_response.field_value_append(our_via, cfield.data(), cfield.length(), true);
         resp_via = resp_via->m_next_dup;
       }
@@ -5026,7 +5026,7 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
         // so that they will be added in the next iterations.
         for (auto spot2 = spot; spot2 != limit; ++spot2) {
           MIMEField &field2{*spot2};
-          auto       name2 = field2.name_get();
+          auto       name2{field2.name_get()};
 
           // It is specified above that content type should not
           // be altered here however when a duplicate header

--- a/src/proxy/http/unit_tests/test_HttpTransact.cc
+++ b/src/proxy/http/unit_tests/test_HttpTransact.cc
@@ -22,6 +22,7 @@
  */
 
 #include <string_view>
+using namespace std::string_view_literals;
 
 #include "tscore/Diags.h"
 #include "tsutil/PostScript.h"
@@ -46,9 +47,7 @@ TEST_CASE("HttpTransact", "[http]")
       ts::PostScript hdr1_defer([&]() -> void { hdr1.destroy(); });
       ts::PostScript hdr2_defer([&]() -> void { hdr2.destroy(); });
 
-      MIMEField  *field;
-      const char *str;
-      int         len;
+      MIMEField *field;
 
       struct header {
         std::string_view name;
@@ -86,44 +85,38 @@ TEST_CASE("HttpTransact", "[http]")
 
       field = hdr1.field_find("AAA", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "111", len) == 0);
+      auto str{field->value_get()};
+      CHECK(str == "111"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("BBB", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "222", len) == 0);
+      str = field->value_get();
+      CHECK(str == "222"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("CCC", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "333", len) == 0);
+      str = field->value_get();
+      CHECK(str == "333"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("DDD", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "444", len) == 0);
+      str = field->value_get();
+      CHECK(str == "444"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("EEE", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "555", len) == 0);
+      str = field->value_get();
+      CHECK(str == "555"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("FFF", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "666", len) == 0);
+      str = field->value_get();
+      CHECK(str == "666"sv);
       CHECK(field->has_dups() == false);
     }
 
@@ -134,9 +127,7 @@ TEST_CASE("HttpTransact", "[http]")
       ts::PostScript hdr1_defer([&]() -> void { hdr1.destroy(); });
       ts::PostScript hdr2_defer([&]() -> void { hdr2.destroy(); });
 
-      MIMEField  *field;
-      const char *str;
-      int         len;
+      MIMEField *field;
 
       struct header {
         std::string_view name;
@@ -174,37 +165,32 @@ TEST_CASE("HttpTransact", "[http]")
 
       field = hdr1.field_find("AAA", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "111", len) == 0);
+      auto str{field->value_get()};
+      CHECK(str == "111"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("BBB", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "555", len) == 0);
+      str = field->value_get();
+      CHECK(str == "555"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("CCC", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "333", len) == 0);
+      str = field->value_get();
+      CHECK(str == "333"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("DDD", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "444", len) == 0);
+      str = field->value_get();
+      CHECK(str == "444"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("FFF", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "666", len) == 0);
+      str = field->value_get();
+      CHECK(str == "666"sv);
       CHECK(field->has_dups() == false);
     }
 
@@ -215,9 +201,7 @@ TEST_CASE("HttpTransact", "[http]")
       ts::PostScript hdr1_defer([&]() -> void { hdr1.destroy(); });
       ts::PostScript hdr2_defer([&]() -> void { hdr2.destroy(); });
 
-      MIMEField  *field;
-      const char *str;
-      int         len;
+      MIMEField *field;
 
       struct header {
         std::string_view name;
@@ -255,37 +239,32 @@ TEST_CASE("HttpTransact", "[http]")
 
       field = hdr1.field_find("AAA", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "111", len) == 0);
+      auto str{field->value_get()};
+      CHECK(str == "111"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("BBB", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "222", len) == 0);
+      str = field->value_get();
+      CHECK(str == "222"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("CCC", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "333", len) == 0);
+      str = field->value_get();
+      CHECK(str == "333"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("DDD", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "444", len) == 0);
+      str = field->value_get();
+      CHECK(str == "444"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("EEE", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "555", len) == 0);
+      str = field->value_get();
+      CHECK(str == "555"sv);
       CHECK(field->has_dups() == true);
     }
 
@@ -296,9 +275,7 @@ TEST_CASE("HttpTransact", "[http]")
       ts::PostScript hdr1_defer([&]() -> void { hdr1.destroy(); });
       ts::PostScript hdr2_defer([&]() -> void { hdr2.destroy(); });
 
-      MIMEField  *field;
-      const char *str;
-      int         len;
+      MIMEField *field;
 
       struct header {
         std::string_view name;
@@ -336,37 +313,32 @@ TEST_CASE("HttpTransact", "[http]")
 
       field = hdr1.field_find("AAA", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "111", len) == 0);
+      auto str{field->value_get()};
+      CHECK(str == "111"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("BBB", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "222", len) == 0);
+      str = field->value_get();
+      CHECK(str == "222"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("CCC", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "333", len) == 0);
+      str = field->value_get();
+      CHECK(str == "333"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("DDD", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "444", len) == 0);
+      str = field->value_get();
+      CHECK(str == "444"sv);
       CHECK(field->has_dups() == true);
 
       field = hdr1.field_find("FFF", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "666", len) == 0);
+      str = field->value_get();
+      CHECK(str == "666"sv);
       CHECK(field->has_dups() == false);
     }
 
@@ -377,9 +349,7 @@ TEST_CASE("HttpTransact", "[http]")
       ts::PostScript hdr1_defer([&]() -> void { hdr1.destroy(); });
       ts::PostScript hdr2_defer([&]() -> void { hdr2.destroy(); });
 
-      MIMEField  *field;
-      const char *str;
-      int         len;
+      MIMEField *field;
 
       struct header {
         std::string_view name;
@@ -420,45 +390,39 @@ TEST_CASE("HttpTransact", "[http]")
 
       field = hdr1.field_find("AAA", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "555", len) == 0);
+      auto str{field->value_get()};
+      CHECK(str == "555"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("BBB", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "666", len) == 0);
+      str = field->value_get();
+      CHECK(str == "666"sv);
       CHECK(field->has_dups() == true);
 
       ///////////// Dup //////////////////////////
       field = field->m_next_dup;
-      str   = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "777", len) == 0);
+      str   = field->value_get();
+      CHECK(str == "777"sv);
       CHECK(field->has_dups() == false);
       ///////////////////////////////////////
 
       field = hdr1.field_find("CCC", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "888", len) == 0);
+      str = field->value_get();
+      CHECK(str == "888"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("DDD", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "444", len) == 0);
+      str = field->value_get();
+      CHECK(str == "444"sv);
       CHECK(field->has_dups() == false);
 
       field = hdr1.field_find("EEE", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "999", len) == 0);
+      str = field->value_get();
+      CHECK(str == "999"sv);
       CHECK(field->has_dups() == false);
     }
     SECTION("Response has superset")
@@ -468,9 +432,7 @@ TEST_CASE("HttpTransact", "[http]")
       ts::PostScript cached_headers_defer([&]() -> void { cached_headers.destroy(); });
       ts::PostScript response_headers_defer([&]() -> void { response_headers.destroy(); });
 
-      MIMEField  *field;
-      const char *str;
-      int         len;
+      MIMEField *field;
 
       struct header {
         std::string_view name;
@@ -521,68 +483,59 @@ TEST_CASE("HttpTransact", "[http]")
 
       field = cached_headers.field_find("Foo", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "111", len) == 0);
+      auto str{field->value_get()};
+      CHECK(str == "111"sv);
       CHECK(field->has_dups() == false);
 
       field = cached_headers.field_find("Fizz", 4);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "555", len) == 0);
+      str = field->value_get();
+      CHECK(str == "555"sv);
       CHECK(field->has_dups() == false);
 
       field = cached_headers.field_find("Bop", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "666", len) == 0);
+      str = field->value_get();
+      CHECK(str == "666"sv);
       CHECK(field->has_dups() == false);
 
       field = cached_headers.field_find("X-Foo", 5);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "aaa", len) == 0);
+      str = field->value_get();
+      CHECK(str == "aaa"sv);
       CHECK(field->has_dups() == false);
 
       field = cached_headers.field_find("Eat", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "444", len) == 0);
+      str = field->value_get();
+      CHECK(str == "444"sv);
       CHECK(field->has_dups() == false);
 
       field = cached_headers.field_find("Bar", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "333", len) == 0);
+      str = field->value_get();
+      CHECK(str == "333"sv);
       CHECK(field->has_dups() == true);
 
       ///////////// Dup //////////////////////////
       field = field->m_next_dup;
-      str   = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "222", len) == 0);
+      str   = field->value_get();
+      CHECK(str == "222"sv);
       CHECK(field->has_dups() == false);
       ///////////////////////////////////////
 
       field = cached_headers.field_find("Zip", 3);
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "888", len) == 0);
+      str = field->value_get();
+      CHECK(str == "888"sv);
       CHECK(field->has_dups() == true);
 
       ///////////// Dup //////////////////////////
       REQUIRE(field->m_next_dup != nullptr);
       field = field->m_next_dup;
       REQUIRE(field != nullptr);
-      str = field->value_get(&len);
-      CHECK(len == 3);
-      CHECK(strncmp(str, "999", len) == 0);
+      str = field->value_get();
+      CHECK(str == "999"sv);
       CHECK(field->has_dups() == false);
       ///////////////////////////////////////
     }

--- a/src/proxy/http2/HPACK.cc
+++ b/src/proxy/http2/HPACK.cc
@@ -742,16 +742,13 @@ hpack_decode_header_block(HpackIndexingTable &indexing_table, HTTPHdr *hdr, cons
       continue;
     }
 
-    int name_len  = 0;
-    int value_len = 0;
-
-    field->name_get(&name_len);
-    field->value_get(&value_len);
+    auto name{field->name_get()};
+    auto value{field->value_get()};
 
     // [RFC 7540] 6.5.2. SETTINGS_MAX_HEADER_LIST_SIZE:
     // The value is based on the uncompressed size of header fields, including the length of the name and value in octets plus an
     // overhead of 32 octets for each header field.
-    total_header_size += name_len + value_len + ADDITIONAL_OCTETS;
+    total_header_size += name.length() + value.length() + ADDITIONAL_OCTETS;
 
     if (total_header_size > max_header_size) {
       return HPACK_ERROR_SIZE_EXCEEDED_ERROR;

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -2539,10 +2539,10 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   hdr.method_set(HTTP_METHOD_GET, HTTP_LEN_GET);
 
   if (accept_encoding != nullptr) {
-    auto       name = accept_encoding->name_get();
-    MIMEField *f    = hdr.field_create(name.data(), name.length());
+    auto       name{accept_encoding->name_get()};
+    MIMEField *f = hdr.field_create(name.data(), name.length());
 
-    auto value = accept_encoding->value_get();
+    auto value{accept_encoding->value_get()};
     f->value_set(hdr.m_heap, hdr.m_mime, value.data(), value.length());
 
     hdr.field_attach(f);

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -2539,13 +2539,11 @@ Http2ConnectionState::send_push_promise_frame(Http2Stream *stream, URL &url, con
   hdr.method_set(HTTP_METHOD_GET, HTTP_LEN_GET);
 
   if (accept_encoding != nullptr) {
-    int         name_len;
-    const char *name = accept_encoding->name_get(&name_len);
-    MIMEField  *f    = hdr.field_create(name, name_len);
+    auto       name = accept_encoding->name_get();
+    MIMEField *f    = hdr.field_create(name.data(), name.length());
 
-    int         value_len;
-    const char *value = accept_encoding->value_get(&value_len);
-    f->value_set(hdr.m_heap, hdr.m_mime, value, value_len);
+    auto value = accept_encoding->value_get();
+    f->value_set(hdr.m_heap, hdr.m_mime, value.data(), value.length());
 
     hdr.field_attach(f);
   }

--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -842,7 +842,7 @@ Http2Stream::update_write_request(bool call_update)
       // Schedule session shutdown if response header has "Connection: close"
       MIMEField *field = this->_send_header.field_find(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION);
       if (field) {
-        auto value = field->value_get();
+        auto value{field->value_get()};
         if (value == std::string_view{HTTP_VALUE_CLOSE, static_cast<std::string_view::size_type>(HTTP_LEN_CLOSE)}) {
           SCOPED_MUTEX_LOCK(lock, _proxy_ssn->mutex, this_ethread());
           if (connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {

--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -842,9 +842,8 @@ Http2Stream::update_write_request(bool call_update)
       // Schedule session shutdown if response header has "Connection: close"
       MIMEField *field = this->_send_header.field_find(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION);
       if (field) {
-        int         len;
-        const char *value = field->value_get(&len);
-        if (memcmp(HTTP_VALUE_CLOSE, value, HTTP_LEN_CLOSE) == 0) {
+        auto value = field->value_get();
+        if (value == std::string_view{HTTP_VALUE_CLOSE, static_cast<std::string_view::size_type>(HTTP_LEN_CLOSE)}) {
           SCOPED_MUTEX_LOCK(lock, _proxy_ssn->mutex, this_ethread());
           if (connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
             connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED, Http2ErrorCode::HTTP2_ERROR_NO_ERROR);

--- a/src/proxy/http2/test_HPACK.cc
+++ b/src/proxy/http2/test_HPACK.cc
@@ -137,24 +137,19 @@ compare_header_fields(HTTPHdr *a, HTTPHdr *b)
   auto b_spot = b->begin(), b_limit = b->end();
 
   while (a_spot != a_limit && b_spot != b_limit) {
-    int a_str_len, b_str_len;
     // compare header name
-    const char *a_str = a_spot->name_get(&a_str_len);
-    const char *b_str = b_spot->name_get(&b_str_len);
-    if (a_str_len != b_str_len) {
-      if (memcmp(a_str, b_str, a_str_len) != 0) {
-        print_difference(a_str, a_str_len, b_str, b_str_len);
-        return -1;
-      }
+    auto a_str{a_spot->name_get()};
+    auto b_str{b_spot->name_get()};
+    if (a_str != b_str) {
+      print_difference(a_str.data(), a_str.length(), b_str.data(), b_str.length());
+      return -1;
     }
     // compare header value
-    a_str = a_spot->value_get(&a_str_len);
-    b_str = b_spot->value_get(&b_str_len);
-    if (a_str_len != b_str_len) {
-      if (memcmp(a_str, b_str, a_str_len) != 0) {
-        print_difference(a_str, a_str_len, b_str, b_str_len);
-        return -1;
-      }
+    a_str = a_spot->value_get();
+    b_str = b_spot->value_get();
+    if (a_str != b_str) {
+      print_difference(a_str.data(), a_str.length(), b_str.data(), b_str.length());
+      return -1;
     }
     ++a_spot;
     ++b_spot;

--- a/src/proxy/http2/unit_tests/test_HpackIndexingTable.cc
+++ b/src/proxy/http2/unit_tests/test_HpackIndexingTable.cc
@@ -463,9 +463,8 @@ TEST_CASE("HPACK high level APIs", "[hpack]")
         CHECK(field != nullptr);
 
         if (field) {
-          int         actual_value_len;
-          const char *actual_value = field->value_get(&actual_value_len);
-          CHECK(strncmp(expected_value, actual_value, actual_value_len) == 0);
+          auto actual_value{field->value_get()};
+          CHECK(actual_value == std::string_view{expected_value});
         }
       }
     }

--- a/src/proxy/http3/test/test_QPACK.cc
+++ b/src/proxy/http3/test/test_QPACK.cc
@@ -222,16 +222,14 @@ output_decoded_headers(FILE *fd, HTTPHdr **headers, uint64_t n)
     fprintf(fd, "# stream %" PRIu64 "\n", i + 1);
     MIMEFieldIter field_iter;
     for (auto const &field : *header_set) {
-      int         name_len  = 0;
-      int         value_len = 0;
-      Arena       arena;
-      const char *name         = field.name_get(&name_len);
-      char       *lowered_name = arena.str_store(name, name_len);
-      for (int i = 0; i < name_len; i++) {
+      Arena arena;
+      auto  name{field.name_get()};
+      char *lowered_name = arena.str_store(name.data(), name.length());
+      for (size_t i = 0; i < name.length(); i++) {
         lowered_name[i] = ParseRules::ink_tolower(lowered_name[i]);
       }
-      const char *value = field.value_get(&value_len);
-      fprintf(fd, "%.*s\t%.*s\n", name_len, lowered_name, value_len, value);
+      auto value{field.value_get()};
+      fprintf(fd, "%.*s\t%.*s\n", static_cast<int>(name.length()), lowered_name, static_cast<int>(value.length()), value.data());
     }
     fprintf(fd, "\n");
   }

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -95,14 +95,17 @@ LogAccess::init()
     m_proxy_response = &(hdr->client_response);
     MIMEField *field = m_proxy_response->field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     if (field) {
-      m_proxy_resp_content_type_str = const_cast<char *>(field->value_get(&m_proxy_resp_content_type_len));
-
+      auto proxy_resp_content_type  = field->value_get();
+      m_proxy_resp_content_type_str = const_cast<char *>(proxy_resp_content_type.data());
+      m_proxy_resp_content_type_len = proxy_resp_content_type.length();
       LogUtils::remove_content_type_attributes(m_proxy_resp_content_type_str, &m_proxy_resp_content_type_len);
     } else {
       // If Content-Type field is missing, check for @Content-Type
       field = m_proxy_response->field_find(HIDDEN_CONTENT_TYPE, HIDDEN_CONTENT_TYPE_LEN);
       if (field) {
-        m_proxy_resp_content_type_str = const_cast<char *>(field->value_get(&m_proxy_resp_content_type_len));
+        auto proxy_resp_content_type  = field->value_get();
+        m_proxy_resp_content_type_str = const_cast<char *>(proxy_resp_content_type.data());
+        m_proxy_resp_content_type_len = proxy_resp_content_type.length();
         LogUtils::remove_content_type_attributes(m_proxy_resp_content_type_str, &m_proxy_resp_content_type_len);
       }
     }
@@ -2903,9 +2906,10 @@ LogAccess::marshal_file_size(char *buf)
     HTTPHdr   *hdr = m_server_response ? m_server_response : m_cache_response;
 
     if (hdr && (fld = hdr->field_find(MIME_FIELD_CONTENT_RANGE, MIME_LEN_CONTENT_RANGE))) {
-      int   len;
-      char *str = const_cast<char *>(fld->value_get(&len));
-      char *pos = static_cast<char *>(memchr(str, '/', len)); // Find the /
+      auto  value = fld->value_get();
+      int   len   = value.length();
+      char *str   = const_cast<char *>(value.data());
+      char *pos   = static_cast<char *>(memchr(str, '/', len)); // Find the /
 
       // If the size is not /* (which means unknown) use it as the file_size.
       if (pos && !memchr(pos + 1, '*', len - (pos + 1 - str))) {
@@ -3093,7 +3097,9 @@ LogAccess::marshal_http_header_field(LogField::Container container, char *field,
       //
       int running_len = 0;
       while (fld) {
-        str = const_cast<char *>(fld->value_get(&actual_len));
+        auto value = fld->value_get();
+        actual_len = value.length();
+        str        = const_cast<char *>(value.data());
         if (buf) {
           memcpy(buf, str, actual_len);
           buf += actual_len;
@@ -3194,8 +3200,10 @@ LogAccess::marshal_http_header_field_escapify(LogField::Container container, cha
       //
       int running_len = 0;
       while (fld) {
-        str     = const_cast<char *>(fld->value_get(&actual_len));
-        new_str = Encoding::escapify_url(&m_arena, str, actual_len, &new_len);
+        auto value = fld->value_get();
+        actual_len = value.length();
+        str        = const_cast<char *>(value.data());
+        new_str    = Encoding::escapify_url(&m_arena, str, actual_len, &new_len);
         if (buf) {
           memcpy(buf, new_str, new_len);
           buf += new_len;

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -95,7 +95,7 @@ LogAccess::init()
     m_proxy_response = &(hdr->client_response);
     MIMEField *field = m_proxy_response->field_find(MIME_FIELD_CONTENT_TYPE, MIME_LEN_CONTENT_TYPE);
     if (field) {
-      auto proxy_resp_content_type  = field->value_get();
+      auto proxy_resp_content_type{field->value_get()};
       m_proxy_resp_content_type_str = const_cast<char *>(proxy_resp_content_type.data());
       m_proxy_resp_content_type_len = proxy_resp_content_type.length();
       LogUtils::remove_content_type_attributes(m_proxy_resp_content_type_str, &m_proxy_resp_content_type_len);
@@ -103,7 +103,7 @@ LogAccess::init()
       // If Content-Type field is missing, check for @Content-Type
       field = m_proxy_response->field_find(HIDDEN_CONTENT_TYPE, HIDDEN_CONTENT_TYPE_LEN);
       if (field) {
-        auto proxy_resp_content_type  = field->value_get();
+        auto proxy_resp_content_type{field->value_get()};
         m_proxy_resp_content_type_str = const_cast<char *>(proxy_resp_content_type.data());
         m_proxy_resp_content_type_len = proxy_resp_content_type.length();
         LogUtils::remove_content_type_attributes(m_proxy_resp_content_type_str, &m_proxy_resp_content_type_len);
@@ -2906,10 +2906,10 @@ LogAccess::marshal_file_size(char *buf)
     HTTPHdr   *hdr = m_server_response ? m_server_response : m_cache_response;
 
     if (hdr && (fld = hdr->field_find(MIME_FIELD_CONTENT_RANGE, MIME_LEN_CONTENT_RANGE))) {
-      auto  value = fld->value_get();
-      int   len   = value.length();
-      char *str   = const_cast<char *>(value.data());
-      char *pos   = static_cast<char *>(memchr(str, '/', len)); // Find the /
+      auto  value{fld->value_get()};
+      int   len = value.length();
+      char *str = const_cast<char *>(value.data());
+      char *pos = static_cast<char *>(memchr(str, '/', len)); // Find the /
 
       // If the size is not /* (which means unknown) use it as the file_size.
       if (pos && !memchr(pos + 1, '*', len - (pos + 1 - str))) {
@@ -3097,7 +3097,7 @@ LogAccess::marshal_http_header_field(LogField::Container container, char *field,
       //
       int running_len = 0;
       while (fld) {
-        auto value = fld->value_get();
+        auto value{fld->value_get()};
         actual_len = value.length();
         str        = const_cast<char *>(value.data());
         if (buf) {
@@ -3200,7 +3200,7 @@ LogAccess::marshal_http_header_field_escapify(LogField::Container container, cha
       //
       int running_len = 0;
       while (fld) {
-        auto value = fld->value_get();
+        auto value{fld->value_get()};
         actual_len = value.length();
         str        = const_cast<char *>(value.data());
         new_str    = Encoding::escapify_url(&m_arena, str, actual_len, &new_len);

--- a/src/proxy/logging/LogUtils.cc
+++ b/src/proxy/logging/LogUtils.cc
@@ -48,6 +48,8 @@
 #include <string_view>
 #include <cstdint>
 
+using namespace std::literals;
+
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -423,21 +425,17 @@ namespace
 // Get a string out of a MIMEField using one of its member functions, and put it into a buffer writer, terminated with a nul.
 //
 void
-marshalStr(swoc::FixedBufferWriter &bw, const MIMEField &mf, const char *(MIMEField::*get_func)(int *length) const)
+marshalStr(swoc::FixedBufferWriter &bw, const MIMEField &mf, std::string_view (MIMEField::*get_func)() const)
 {
-  int         length;
-  const char *data = (mf.*get_func)(&length);
+  auto data = (mf.*get_func)();
 
-  if (!data or (*data == '\0')) {
+  if (!data.data() or (*data.data() == '\0')) {
     // Empty string.  This is a problem, since it would result in two successive nul characters, which indicates the end of the
     // marshaled hearer.  Change the string to a single blank character.
-
-    static const char Blank[] = " ";
-    data                      = Blank;
-    length                    = 1;
+    data = " "sv;
   }
 
-  bw << std::string_view(data, length) << '\0';
+  bw << data << '\0';
 }
 
 void

--- a/src/proxy/logging/LogUtils.cc
+++ b/src/proxy/logging/LogUtils.cc
@@ -427,7 +427,7 @@ namespace
 void
 marshalStr(swoc::FixedBufferWriter &bw, const MIMEField &mf, std::string_view (MIMEField::*get_func)() const)
 {
-  auto data = (mf.*get_func)();
+  auto data{(mf.*get_func)()};
 
   if (!data.data() or (*data.data() == '\0')) {
     // Empty string.  This is a problem, since it would result in two successive nul characters, which indicates the end of the

--- a/src/proxy/logging/unit-tests/test_LogUtils.h
+++ b/src/proxy/logging/unit-tests/test_LogUtils.h
@@ -29,17 +29,15 @@
 struct MIMEField {
   const char *tag, *value;
 
-  const char *
-  name_get(int *length) const
+  std::string_view
+  name_get() const
   {
-    *length = strlen(tag);
-    return tag;
+    return {tag, strlen(tag)};
   }
-  const char *
-  value_get(int *length) const
+  std::string_view
+  value_get() const
   {
-    *length = strlen(value);
-    return value;
+    return {value, strlen(value)};
   }
 };
 

--- a/src/proxy/logging/unit-tests/test_LogUtils.h
+++ b/src/proxy/logging/unit-tests/test_LogUtils.h
@@ -32,12 +32,12 @@ struct MIMEField {
   std::string_view
   name_get() const
   {
-    return {tag, strlen(tag)};
+    return {tag};
   }
   std::string_view
   value_get() const
   {
-    return {value, strlen(value)};
+    return {value};
   }
 };
 


### PR DESCRIPTION
Confirmed that `cmake --build build --target test` passes with the modification of [Static link opentelemetry-cpp libraries to otel_tracer plugin by hnakamur · Pull Request #12026 · apache/trafficserver](https://github.com/apache/trafficserver/pull/12026).