### PR TITLE
records.yaml: Error logs -   Include record name as part of the error description.

### DIFF
--- a/src/records/RecYAMLDecoder.cc
+++ b/src/records/RecYAMLDecoder.cc
@@ -94,8 +94,8 @@ SetRecordFromYAMLNode(CfgNode const &field, swoc::Errata &errata)
     // we ignore it.
     auto [dtype, e] = detail::try_deduce_type(field.value_node);
     if (!e.empty()) {
-      errata.note(ERRATA_WARN, "Ignoring field '{}' at Line {}. Not registered and {}", field.node.as<std::string>(),
-                  field.node.Mark().line + 1, e);
+      errata.note(ERRATA_WARN, "Ignoring field '{}' [{}] at Line {}. Not registered and {}", field.node.as<std::string>(),
+                  field.get_record_name(), field.node.Mark().line + 1, e);
       // We can't continue without knowing the type.
       return;
     }

--- a/tests/gold_tests/records/records_yaml.test.py
+++ b/tests/gold_tests/records/records_yaml.test.py
@@ -66,8 +66,10 @@ ts.Disk.diags_log.Content = Testers.ContainsExpression(f"Unrecognized configurat
 var2 = 'proxy.config.test.not_registered.field2'
 ts.Disk.diags_log.Content += Testers.ContainsExpression(f"Unrecognized configuration value '{var2}", "Field should be ignored")
 
-ts.Disk.traffic_out.Content += Testers.ContainsExpression(f"Ignoring field 'filenamee'", "Field should be ignored")
-ts.Disk.traffic_out.Content += Testers.ContainsExpression(f"Ignoring field 'filenam'", "Field should be ignored")
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+    f"Ignoring field 'filenamee' \\[proxy.config.ssl.client.cert.filenamee\\]", "Field should be ignored")
+ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+    f"Ignoring field 'filenam' \\[proxy.config.ssl.client.cert.filenam\\]", "Field should be ignored")
 
 # 1
 tr = Test.AddTestRun("Query unregistered records.")


### PR DESCRIPTION
It basically goes from:
```
 Warn:   Warn: Ignoring field 'x' at Line 17. Not registered and Unknown tag type '?'
```
To:
```
 Warn:   Warn: Ignoring field 'x' [proxy.config.some.field.x] at Line 17. Not registered and Unknown tag type '?'
```
Record name is now included. This helps in case of multiple fields with that belong to different maps but have the same name.