### PR TITLE
Update cmake minimum version to 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "In source builds are disabled.  Use a preset, -B or run from a different directory")
 endif()
 
-cmake_minimum_required(VERSION 3.20..3.27)
+cmake_minimum_required(VERSION 3.24..3.27)
 project(ats VERSION 10.1.0)
 
 set(TS_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 2,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 20,
+    "minor": 24,
     "patch": 0
   },
   "configurePresets": [


### PR DESCRIPTION
* `LINK_GROUP` `RESCAN` is used in `src/iocore/net/CMakeLists.txt`. It was [added in CMake version 3.24](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:LINK_GROUP).
* `CMAKE_COMPILE_WARNING_AS_ERROR` is used in `CMakePresets.json`. It was [added in CMake version 3.24](https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILE_WARNING_AS_ERROR.html).

CMake 3.22.1 on Ubuntu 22.04 causes the following link error for `src/iocore/net/test_net`.
```
FAILED: src/iocore/net/test_net                                                                                                                                                                                     : && /usr/bin/c++ -pthread -g -Wl,--allow-multiple-definition src/iocore/net/CMakeFiles/test_net.dir/libinknet_stub.cc.o src/iocore/net/CMakeFiles/test_net.dir/NetVCTest.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/test_ProxyProtocol.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/test_SSLSNIConfig.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/test_YamlSNIConfig.cc.o src/iocore/net/CMakeFiles/test_net.dir/unit_tests/unit_test_main.cc.o -o src/iocore/net/test_net  -Wl,-rpath,/root/trafficserver/build-default/lib/swoc:/root/trafficserver/build-default/lib/yamlcpp  -ldl  src/tscore/libtscore.a  src/proxy/libproxy.a  src/iocore/net/libinknet.a  src/iocore/eventsystem/libinkevent.a  src/iocore/cache/libinkcache.a  src/mgmt/rpc/librpcpublichandlers.a  src/api/libtsapibackend.a  src/shared/liboverridable_txn_vars.a  src/proxy/http/libhttp.a  src/iocore/hostdb/libinkhostdb.a  src/proxy/http2/libhttp2.a  src/proxy/http/remap/libhttp_remap.a  src/proxy/logging/liblogging.a  src/iocore/dns/libinkdns.a  src/proxy/libproxy.a  src/iocore/net/libinknet.a  src/iocore/cache/libinkcache.a  src/mgmt/rpc/librpcpublichandlers.a  src/api/libtsapibackend.a  src/shared/liboverridable_txn_vars.a  src/proxy/http/libhttp.a  src/iocore/hostdb/libinkhostdb.a  src/proxy/http2/libhttp2.a  src/proxy/http/remap/libhttp_remap.a  src/proxy/logging/liblogging.a  src/iocore/dns/libinkdns.a  src/mgmt/rpc/libjsonrpc_protocol.a  /usr/lib/x86_64-linux-gnu/libssl.so  src/iocore/aio/libaio.a  lib/fastlz/libfastlz.a  /usr/lib/x86_64-linux-gnu/libz.so  /usr/lib/x86_64-linux-gnu/liblzma.so  src/iocore/utils/libinkutils.a  src/proxy/hdrs/libhdrs.a  src/iocore/eventsystem/libinkevent.a  src/records/librecords.a  src/tscore/libtscore.a  /usr/lib/x86_64-linux-gnu/libcrypto.so  /usr/lib/x86_64-linux-gnu/libpcre.so  /usr/lib/x86_64-linux-gnu/libresolv.so  /usr/lib/x86_64-linux-gnu/libcap.so  /usr/lib/x86_64-linux-gnu/libhwloc.so  src/tsutil/libtsutil.a  lib/swoc/libswoc-1.5.12.so  lib/yamlcpp/libyaml-cppd.so.0.8.0  -ldl  /usr/lib/x86_64-linux-gnu/libpcre2-8.so && :                                             /usr/bin/ld: src/proxy/http/remap/libhttp_remap.a(RemapConfig.cc.o): warning: relocation against `_ZN7IpAllow14accept_check_pE' in read-only section `.text._ZN7IpAllow17enableAcceptCheckEb[_ZN7IpAllow17enableAcceptCheckEb]'                                                                                                                                                                                                         /usr/bin/ld: src/proxy/http/remap/libhttp_remap.a(AclFiltering.cc.o): in function `src_ip_category_info_t::ask_ip_allow_about_category(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, swoc::_1_5_13::IPAddr const&) const':                                                                                                                                                                    /root/trafficserver/src/proxy/http/remap/AclFiltering.cc:36: undefined reference to `IpAllow::ip_category_contains_addr(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, swoc::_1_5_13::IPAddr const&)'
/usr/bin/ld: src/proxy/http/remap/libhttp_remap.a(RemapConfig.cc.o): in function `remap_load_plugin(char const* const*, int, url_mapping*, char*, int, int, int*, UrlRewrite*)':
/root/trafficserver/src/proxy/http/remap/RemapConfig.cc:949: undefined reference to `isPluginDynamicReloadEnabled()'
/usr/bin/ld: src/proxy/http/remap/libhttp_remap.a(RemapConfig.cc.o): in function `IpAllow::enableAcceptCheck(bool)':
/root/trafficserver/include/proxy/IPAllow.h:398: undefined reference to `IpAllow::accept_check_p'
/usr/bin/ld: /root/trafficserver/include/proxy/IPAllow.h:399: undefined reference to `IpAllow::accept_check_p'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
collect2: error: ld returned 1 exit status
```

CMake 3.22.1 on Ubuntu 22.04 causes the following warning when running `cmake --preset default`:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_COMPILE_WARNING_AS_ERROR
```

CMake 3.24 does not cause the above problems.