### PR TITLE
Coverity: Avoid order initalization issue - part 2.

### DIFF
--- a/lib/swoc/include/swoc/bwf_base.h
+++ b/lib/swoc/include/swoc/bwf_base.h
@@ -108,7 +108,7 @@ protected:
   bool is_sign(char c);
 
   /// Handrolled initialization the character syntactic property data.
-  static const struct Property {
+  struct Property {
     Property(); ///< Default constructor, creates initialized flag set.
     /// Flag storage, indexed by character value.
     uint8_t _data[0x100]{};
@@ -118,7 +118,13 @@ protected:
     static constexpr uint8_t UPPER_TYPE_CHAR   = 0x20; ///< Upper case flag.
     static constexpr uint8_t NUMERIC_TYPE_CHAR = 0x40; ///< Numeric output.
     static constexpr uint8_t SIGN_CHAR         = 0x80; ///< Is sign character.
-  } _prop;                                             ///< Character property map.
+  };
+  static const Property &
+  Get_Prop()
+  {
+    static const Property prop;
+    return prop;
+  } ///< Character property map.
 };
 
 /** Format string support.
@@ -474,37 +480,37 @@ extern ExternalNames& Global_Names();
 
 inline Spec::Align
 Spec::align_of(char c) {
-  return static_cast<Align>(_prop._data[static_cast<unsigned>(c)] & Property::ALIGN_MASK);
+  return static_cast<Align>(Get_Prop()._data[static_cast<unsigned>(c)] & Property::ALIGN_MASK);
 }
 
 inline bool
 Spec::is_sign(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::SIGN_CHAR;
+  return Get_Prop()._data[static_cast<unsigned>(c)] & Property::SIGN_CHAR;
 }
 
 inline bool
 Spec::is_type(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::TYPE_CHAR;
+  return Get_Prop()._data[static_cast<unsigned>(c)] & Property::TYPE_CHAR;
 }
 
 inline bool
 Spec::is_upper_case_type(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::UPPER_TYPE_CHAR;
+  return Get_Prop()._data[static_cast<unsigned>(c)] & Property::UPPER_TYPE_CHAR;
 }
 
 inline bool
 Spec::is_numeric_type(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::NUMERIC_TYPE_CHAR;
+  return Get_Prop()._data[static_cast<unsigned>(c)] & Property::NUMERIC_TYPE_CHAR;
 }
 
 inline bool
 Spec::has_numeric_type() const {
-  return _prop._data[static_cast<unsigned>(_type)] & Property::NUMERIC_TYPE_CHAR;
+  return Get_Prop()._data[static_cast<unsigned>(_type)] & Property::NUMERIC_TYPE_CHAR;
 }
 
 inline bool
 Spec::has_upper_case_type() const {
-  return _prop._data[static_cast<unsigned>(_type)] & Property::UPPER_TYPE_CHAR;
+  return Get_Prop()._data[static_cast<unsigned>(_type)] & Property::UPPER_TYPE_CHAR;
 }
 
 inline bool

--- a/lib/swoc/src/bw_format.cc
+++ b/lib/swoc/src/bw_format.cc
@@ -37,8 +37,6 @@ ExternalNames& Global_Names() {
 
 const Spec Spec::DEFAULT;
 
-const Spec::Property Spec::_prop;
-
 #pragma GCC diagnostic ignored "-Wchar-subscripts"
 
 Spec::Property::Property() {


### PR DESCRIPTION
First fix [11908](https://github.com/apache/trafficserver/pull/11908) solved a lot of issues, this is a bit different but still the same  logic applied.

Hopefully it will fix the following CID's

[CID-1528622](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1528622)
[CID-1591463](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591463)
[CID-1591462](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591462)
[CID-1591470](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591470)
[CID-1591474](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591474)
[CID-1591505](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591505)
[CID-1591519](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591519)
[CID-1591531](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591531)
[CID-1591556](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591556)
[CID-1591560](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591560)
[CID-1591561](https://scan6.scan.coverity.com/#/project-view/58063/10191?selectedIssue=1591561)