### PR TITLE
[cache_range_requests] Cleanup debug log

### DIFF
--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -38,7 +38,7 @@
 #include <string_view>
 
 #define PLUGIN_NAME         "cache_range_requests"
-#define DEBUG_LOG(fmt, ...) Dbg(dbg_ctl, "[%s:%d] %s(): " fmt, __FILE__, __LINE__, __func__, ##__VA_ARGS__)
+#define DEBUG_LOG(fmt, ...) Dbg(dbg_ctl, fmt, ##__VA_ARGS__)
 #define ERROR_LOG(fmt, ...) TSError("[%s:%d] %s(): " fmt, __FILE__, __LINE__, __func__, ##__VA_ARGS__)
 
 namespace


### PR DESCRIPTION
Debug log of cache_range_requests is redundant. File name, line number, and functions are already in the beginning.
```
[Feb 18 13:00:48.482]  DIAG: <cache_range_requests.cc:658 (TSRemapInit)> (cache_range_requests) [/Users/masaori/src/github.com/apache/trafficserver-asf-master-work-5/plugins/cache_range_requests/cache_range_requests.cc:658] TSRemapInit(): cache_range_requests remap is successfully initialized.
```