### PR TITLE
Add mark_bulk() method to lib/swoc to rebuild the RBTree in one operation

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -89,6 +89,11 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   )
 endif()
 
+# if BUILD_TESTING, then add a cpp defines for BUILD_TESTING
+if (BUILD_TESTING)
+    target_compile_definitions(libswoc PRIVATE BUILD_TESTING)
+endif()
+
 add_library(libswoc-static STATIC ${CC_FILES})
 set_target_properties(
   libswoc-static PROPERTIES OUTPUT_NAME swoc-static-${LIBSWOC_VERSION} PUBLIC_HEADER "${HEADER_FILES}"
@@ -116,7 +121,7 @@ target_include_directories(
   libswoc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
 )
 
-# Alledgedly this makes the targets "importable from the build directory" but I see no evidence of that.
+# Allegedly this makes the targets "importable from the build directory" but I see no evidence of that.
 # AFAICT the file isn't created at all even with this enabled.
 #export(TARGETS libswoc FILE libswoc-config.cmake)
 

--- a/lib/swoc/include/swoc/DiscreteRange.h
+++ b/lib/swoc/include/swoc/DiscreteRange.h
@@ -836,21 +836,21 @@ public:
   ~DiscreteSpace();
 
   /** Mark ranges in one operation.
-   * 
+   *
    * @param marks Vector of ranges and payloads to mark.
-   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+   * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-   self_type &mark_bulk(std::vector<std::pair<range_type, PAYLOAD>> &marks, bool isSorted = false);
+   self_type &mark_bulk(std::vector<std::pair<range_type, PAYLOAD>> &marks, bool is_sorted = false);
 
    /** Mark ranges in one operation.
-    * 
+    *
     * @param start Pointer to the first range/payload pair.
     * @param n Number of pairs.
-    * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+    * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
     * @return @a this
     */
-   self_type &mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool isSorted = false);
+   self_type &mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool is_sorted = false);
 
   /** Set the @a payload for a @a range
    *
@@ -1357,16 +1357,16 @@ DiscreteSpace<METRIC, PAYLOAD>::erase(DiscreteSpace::range_type const &range) {
 
 template <typename METRIC, typename PAYLOAD>
 DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteSpace::range_type, PAYLOAD>> &ranges, bool isSorted) {
-  return this->mark_bulk(ranges.data(), ranges.size(), isSorted);
+DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteSpace::range_type, PAYLOAD>> &ranges, bool is_sorted) {
+  return this->mark_bulk(ranges.data(), ranges.size(), is_sorted);
 }
 
 template <typename METRIC, typename PAYLOAD>
 DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool isSorted)
+DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool is_sorted)
 {
   // Sort the input data in-place before processing, if applicable.
-  if (!isSorted)
+  if (!is_sorted)
   {
     // Stable sort allows for duplicate elements.
     std::stable_sort(start, start + n, [](const auto &lhs, const auto &rhs) {

--- a/lib/swoc/include/swoc/DiscreteRange.h
+++ b/lib/swoc/include/swoc/DiscreteRange.h
@@ -8,6 +8,7 @@
  */
 
 #pragma once
+#include <algorithm>
 #include <limits>
 #include <functional>
 

--- a/lib/swoc/include/swoc/DiscreteRange.h
+++ b/lib/swoc/include/swoc/DiscreteRange.h
@@ -836,14 +836,14 @@ public:
   ~DiscreteSpace();
 
   /** Mark ranges in one operation.
-   * 
+   *
    * @param marks Vector of ranges and payloads to mark.
    * @return @a this
    */
   self_type &mark_bulk(std::vector<std::pair<range_type, PAYLOAD>> const &marks);
 
   /** Mark ranges in one operation.
-   * 
+   *
    * @param start Pointer to the first range/payload pair.
    * @param n Number of pairs.
    * @return @a this
@@ -1254,7 +1254,7 @@ DiscreteSpace<METRIC, PAYLOAD>::prepend(DiscreteSpace::Node *node, bool update_t
 template <typename METRIC, typename PAYLOAD>
 void
 DiscreteSpace<METRIC, PAYLOAD>::append(DiscreteSpace::Node *node, bool update_tree) {
-  
+
   if (update_tree) {
     if (!_root) {
       _root = node;

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -1137,6 +1137,28 @@ public:
    */
   self_type &mark(IPRange const &range, PAYLOAD const &payload);
 
+  /** Mark ranges of IP4Addr in the IPSpace in one operation.
+   * 
+   * @param range_payloads Array of range/payload pairs.
+   * @param size Number of elements in @a range_payloads.
+   * @return @a this
+   */
+  self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size);
+
+  //! vector-based interface for the previous function.
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads);
+
+  /** Mark ranges of IP6Addr in the IPSpace in one operation.
+   * 
+   * @param range_payloads Array of range/payload pairs.
+   * @param size Number of elements in @a range_payloads.
+   * @return @a this
+   */
+  self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size);
+
+  //! vector-based interface for the previous function.
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads);
+
   /** Fill the @a range with @a payload.
    *
    * @param range Destination range.
@@ -2463,6 +2485,34 @@ IPRange::NetSource::operator!=(self_type const &that) const {
 }
 
 // --- IPSpace
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
+  _ip4.mark_bulk(range_payloads, size);
+  return *this;
+}
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
+  _ip6.mark_bulk(range_payloads, size);
+  return *this;
+}
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads) -> self_type & {
+  _ip4.mark_bulk(range_payloads);
+  return *this;
+}
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads) -> self_type & {
+  _ip6.mark_bulk(range_payloads);
+  return *this;
+}
 
 template <typename PAYLOAD>
 auto

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -1138,26 +1138,28 @@ public:
   self_type &mark(IPRange const &range, PAYLOAD const &payload);
 
   /** Mark ranges of IP4Addr in the IPSpace in one operation.
-   *
+   * 
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
+   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-  self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size);
+   self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
 
-  //! vector-based interface for the previous function.
-  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads);
-
-  /** Mark ranges of IP6Addr in the IPSpace in one operation.
-   *
-   * @param range_payloads Array of range/payload pairs.
-   * @param size Number of elements in @a range_payloads.
-   * @return @a this
-   */
-  self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size);
-
-  //! vector-based interface for the previous function.
-  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads);
+   //! vector-based interface for the previous function.
+   self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
+ 
+   /** Mark ranges of IP6Addr in the IPSpace in one operation.
+    * 
+    * @param range_payloads Array of range/payload pairs.
+    * @param size Number of elements in @a range_payloads.
+    * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+    * @return @a this
+    */
+   self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
+ 
+   //! vector-based interface for the previous function.
+   self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
 
   /** Fill the @a range with @a payload.
    *
@@ -2488,29 +2490,29 @@ IPRange::NetSource::operator!=(self_type const &that) const {
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
-  _ip4.mark_bulk(range_payloads, size);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
+  _ip4.mark_bulk(range_payloads, size, isSorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
-  _ip6.mark_bulk(range_payloads, size);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
+  _ip6.mark_bulk(range_payloads, size, isSorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads) -> self_type & {
-  _ip4.mark_bulk(range_payloads);
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
+  _ip4.mark_bulk(range_payloads, isSorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads) -> self_type & {
-  _ip6.mark_bulk(range_payloads);
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
+  _ip6.mark_bulk(range_payloads, isSorted);
   return *this;
 }
 

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -1138,28 +1138,28 @@ public:
   self_type &mark(IPRange const &range, PAYLOAD const &payload);
 
   /** Mark ranges of IP4Addr in the IPSpace in one operation.
-   * 
+   *
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
-   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+   * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-   self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
+   self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted = false);
 
    //! vector-based interface for the previous function.
-   self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
- 
+   self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool is_sorted = false);
+
    /** Mark ranges of IP6Addr in the IPSpace in one operation.
-    * 
+    *
     * @param range_payloads Array of range/payload pairs.
     * @param size Number of elements in @a range_payloads.
-    * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+    * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
     * @return @a this
     */
-   self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
- 
+   self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted = false);
+
    //! vector-based interface for the previous function.
-   self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
+   self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool is_sorted = false);
 
   /** Fill the @a range with @a payload.
    *
@@ -2490,29 +2490,29 @@ IPRange::NetSource::operator!=(self_type const &that) const {
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
-  _ip4.mark_bulk(range_payloads, size, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted) -> self_type & {
+  _ip4.mark_bulk(range_payloads, size, is_sorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
-  _ip6.mark_bulk(range_payloads, size, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted) -> self_type & {
+  _ip6.mark_bulk(range_payloads, size, is_sorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
-  _ip4.mark_bulk(range_payloads, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool is_sorted) -> self_type & {
+  _ip4.mark_bulk(range_payloads, is_sorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
-  _ip6.mark_bulk(range_payloads, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool is_sorted) -> self_type & {
+  _ip6.mark_bulk(range_payloads, is_sorted);
   return *this;
 }
 

--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -1138,7 +1138,7 @@ public:
   self_type &mark(IPRange const &range, PAYLOAD const &payload);
 
   /** Mark ranges of IP4Addr in the IPSpace in one operation.
-   * 
+   *
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
    * @return @a this
@@ -1149,7 +1149,7 @@ public:
   self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads);
 
   /** Mark ranges of IP6Addr in the IPSpace in one operation.
-   * 
+   *
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
    * @return @a this

--- a/lib/swoc/include/swoc/RBTree.h
+++ b/lib/swoc/include/swoc/RBTree.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveDList.h"
 

--- a/lib/swoc/include/swoc/RBTree.h
+++ b/lib/swoc/include/swoc/RBTree.h
@@ -6,6 +6,9 @@
 */
 
 #pragma once
+
+#include <iostream>
+
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveDList.h"
 
@@ -174,6 +177,31 @@ struct RBNode {
    */
   self_type *ripple_structure_fixup();
 
+  /**
+   * @brief  Recursively build a balanced RB tree from a sorted linked list.
+   * 
+   * Constraints:
+   *  - The list is sorted in ascending order.
+   *  - A copy (not reference) of the head pointer is passed in.
+   * 
+   * @param head         Copy of the head pointer of the list.
+   * @param n            Number of nodes being processed at the current level.
+   * @return self_type*  The root node of the tree.
+   */
+  static self_type * buildTree(self_type*& head, int n);
+
+  //! Called by buildTree above.
+  static self_type * buildTree(self_type*& head, int n, bool isBlack);
+
+  /**
+   * @brief Recursively print the tree in a human-readable format.
+   *
+   * @param root   Root node of the tree.
+   * @param indent Indentation string.
+   * @param last   Flag to indicate if the node is the last node.
+   */
+  static void printTree(self_type* root, std::string indent = "", bool last = true);
+
   Color _color{Color::RED};    ///< node color
   self_type *_parent{nullptr}; ///< parent node (needed for rotations)
   self_type *_left{nullptr};   ///< left child
@@ -188,7 +216,7 @@ struct RBNode {
     next_ptr(self_type *t) {
       return swoc::ptr_ref_cast<self_type>(t->_next);
     }
-    /// @return Reference to the internal pointer to the previoius element.
+    /// @return Reference to the internal pointer to the previous element.
     static self_type *&
     prev_ptr(self_type *t) {
       return swoc::ptr_ref_cast<self_type>(t->_prev);

--- a/lib/swoc/include/swoc/RBTree.h
+++ b/lib/swoc/include/swoc/RBTree.h
@@ -10,6 +10,8 @@
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveDList.h"
 
+#include <string>
+
 namespace swoc { inline namespace SWOC_VERSION_NS { namespace detail {
 /** A node in a red/black tree.
 

--- a/lib/swoc/include/swoc/RBTree.h
+++ b/lib/swoc/include/swoc/RBTree.h
@@ -179,11 +179,11 @@ struct RBNode {
 
   /**
    * @brief  Recursively build a balanced RB tree from a sorted linked list.
-   * 
+   *
    * Constraints:
    *  - The list is sorted in ascending order.
    *  - A copy (not reference) of the head pointer is passed in.
-   * 
+   *
    * @param head         Copy of the head pointer of the list.
    * @param n            Number of nodes being processed at the current level.
    * @return self_type*  The root node of the tree.

--- a/lib/swoc/src/RBTree.cc
+++ b/lib/swoc/src/RBTree.cc
@@ -7,6 +7,8 @@
 
 #include "swoc/RBTree.h"
 
+#include <iostream>
+
 namespace swoc { inline namespace SWOC_VERSION_NS { namespace detail {
 // These equality operators are only used in this file.
 

--- a/lib/swoc/src/RBTree.cc
+++ b/lib/swoc/src/RBTree.cc
@@ -293,7 +293,7 @@ RBNode::rebalance_after_remove(Color c,    //!< The color of the removed node
   return root;
 }
 
-RBNode * 
+RBNode *
 RBNode::buildTree(RBNode*& head, int n)
 {
   if (!head || n <= 0)
@@ -319,7 +319,7 @@ RBNode::buildTree(RBNode*& head, int n, bool isBlack)
       currNode->structure_fixup();
       return currNode;
     }
-  
+
     // Always handle the even number of nodes first because it is guaranteed to contain an n == 2 case.
     int left_n = n / 2;
     int right_n = n - left_n - 1;
@@ -327,17 +327,17 @@ RBNode::buildTree(RBNode*& head, int n, bool isBlack)
     {
         std::swap(left_n, right_n);
     }
-  
+
     // Recursively construct the left subtree.
     RBNode* leftBranch = buildTree(head, left_n, !isBlack);
-  
+
     // Assign the left branch to the current node (head).
     RBNode* currNode = head;
     currNode->_left = leftBranch;
-  
+
     // This can be nullptr if we are at the end.
     head = head->_next;
-  
+
     // If this is currently processing 2 nodes, then don't make a right branch
     // because the left branch has already been made.
     // No need to check for head == nullptr here because n > 2 inside the block.

--- a/lib/swoc/unit_tests/test_ip.cc
+++ b/lib/swoc/unit_tests/test_ip.cc
@@ -2276,7 +2276,7 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
     insert4.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.2.10"},
         IP4Addr{"1.1.2.20"}},
                          currPayload++);
-                         
+
     insert6.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::1:10"},
             IP6Addr{"::1:20"}},
     currPayload++);

--- a/lib/swoc/unit_tests/test_ip.cc
+++ b/lib/swoc/unit_tests/test_ip.cc
@@ -2183,3 +2183,149 @@ TEST_CASE("IPRangeSet", "[libswoc][iprangeset]") {
   REQUIRE(n == addrs.count());
   REQUIRE(valid_p);
 }
+
+TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
+    using PAYLOAD = unsigned;
+    using Space   = swoc::IPSpace<PAYLOAD>;
+
+    Space space;
+
+    // #1 mark_bulk() onto an empty space
+    // Verify that it collapses ranges with the same payload
+    // Use (currPayload++) / 2 as the payload value in order to collapse every-other ip range.
+
+    unsigned currPayload = 0;
+    std::vector<std::pair<swoc::DiscreteRange<IP4Addr>, PAYLOAD>> addrs4;
+    std::vector<std::pair<swoc::DiscreteRange<IP6Addr>, PAYLOAD>> addrs6;
+
+    // 1.1.1.1 - 1.1.1.254, each range is length 1
+    for (int i = 1; i < 128; i += 2) {
+        addrs4.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.1." + std::to_string(i)},
+                                                         IP4Addr{"1.1.1." + std::to_string(i + 1)}},
+                            (currPayload++) / 2);
+    }
+
+    // ::1 - ::254, each range is length 1
+    for (int i = 1; i < 128; i += 2) {
+        addrs6.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::" + std::to_string(i)},
+                                                         IP6Addr{"::" + std::to_string(i + 1)}},
+                            (currPayload++) / 2);
+    }
+
+    // Verify successful mark_bulk
+    space.mark_bulk(addrs4.data(), addrs4.size());
+    space.mark_bulk(addrs6.data(), addrs6.size());
+
+    // Verify that the count is correct
+    REQUIRE(space.count() == (addrs4.size() + addrs6.size()) / 2);
+
+    // Verify that the payloads are correct
+    for (auto const& [range, payload] : addrs4) {
+        IP4Addr ip4 = range.min();
+        auto [r, p] = *(space.find(ip4));
+        REQUIRE(r.contains(ip4));
+        REQUIRE(p == payload);
+    }
+
+    for (auto const& [range, payload] : addrs6) {
+        IP6Addr ip6 = range.min();
+        auto [r, p] = *(space.find(ip6));
+        REQUIRE(r.contains(ip6));
+        REQUIRE(p == payload);
+    }
+
+    // #2 mark_bulk() onto the end of the existing space
+    addrs4.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.2.1"},
+                                                     IP4Addr{"1.1.2.255"}},
+                        currPayload++);
+    addrs4.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.3.1"},
+                                                     IP4Addr{"1.1.3.255"}},
+                        currPayload++);
+
+    addrs6.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::1:1"},
+                                                     IP6Addr{"::1:255"}},
+                        currPayload++);
+    addrs6.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::2:1"},
+                                                     IP6Addr{"::2:255"}},
+                        currPayload++);
+
+    // Verify successful mark_bulk
+    space.mark_bulk(addrs4.data(), addrs4.size());
+    space.mark_bulk(addrs6.data(), addrs6.size());
+
+    // Verify that the payloads are correct
+    for (auto const& [range, payload] : addrs4) {
+        IP4Addr ip4 = range.min();
+        auto [r, p] = *(space.find(ip4));
+        REQUIRE(r.contains(ip4));
+        REQUIRE(p == payload);
+    }
+
+    for (auto const& [range, payload] : addrs6) {
+        IP6Addr ip6 = range.min();
+        auto [r, p] = *(space.find(ip6));
+        REQUIRE(r.contains(ip6));
+        REQUIRE(p == payload);
+    }
+
+    // #3 Insert ranges into the middle of an existing range
+
+    std::vector<std::pair<swoc::DiscreteRange<IP4Addr>, PAYLOAD>> insert4;
+    std::vector<std::pair<swoc::DiscreteRange<IP6Addr>, PAYLOAD>> insert6;
+
+    insert4.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.2.10"},
+        IP4Addr{"1.1.2.20"}},
+                         currPayload++);
+                         
+    insert6.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::1:10"},
+            IP6Addr{"::1:20"}},
+    currPayload++);
+
+    space.mark_bulk(insert4.data(), insert4.size());
+    space.mark_bulk(insert6.data(), insert6.size());
+
+    // Verify that the ranges were split up.
+    {
+        auto [range, payload] = addrs4[addrs4.size() - 2];
+        IP4Addr ip4 = range.min();
+        auto [r, p] = *(space.find(ip4));
+        REQUIRE(r.contains(ip4));
+        REQUIRE(p == payload);
+    }
+    {
+        auto [range, payload] = insert4[0];
+        IP4Addr ip4 = range.min();
+        auto [r, p] = *(space.find(ip4));
+        REQUIRE(r.contains(ip4));
+        REQUIRE(p == payload);
+    }
+    {
+        auto [range, payload] = addrs4[addrs4.size() - 1];
+        IP4Addr ip4 = range.min();
+        auto [r, p] = *(space.find(range.min()));
+        REQUIRE(r.contains(ip4));
+        REQUIRE(p == payload);
+    }
+    {
+        auto [range, payload] = addrs6[addrs6.size() - 2];
+        IP6Addr ip6 = range.min();
+        auto [r, p] = *(space.find(ip6));
+        REQUIRE(r.contains(ip6));
+        REQUIRE(p == payload);
+    }
+    {
+        auto [range, payload] = insert6[0];
+        IP6Addr ip6 = range.min();
+        auto [r, p] = *(space.find(range.min()));
+        REQUIRE(r.contains(ip6));
+        REQUIRE(p == payload);
+    }
+    {
+        auto [range, payload] = addrs6[addrs6.size() - 1];
+        IP6Addr ip6 = range.min();
+        auto [r, p] = *(space.find(range.min()));
+        REQUIRE(r.contains(ip6));
+        REQUIRE(p == payload);
+    }
+
+}

--- a/lib/swoc/unit_tests/test_ip.cc
+++ b/lib/swoc/unit_tests/test_ip.cc
@@ -2276,7 +2276,7 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
   insert4.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.2.10"},
       IP4Addr{"1.1.2.20"}},
                        currPayload++);
-                       
+
   insert6.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::1:10"},
           IP6Addr{"::1:20"}},
   currPayload++);
@@ -2371,7 +2371,7 @@ TEST_CASE("IPSpace mark_bulk randomized", "[libswoc][ipspace][mark_bulk][randomi
   // Verify that the count is correct
   size_t size1 = (addrs4.size() + addrs6.size()) / 2;
   REQUIRE(space.count() == size1);
-  
+
   // Verify that the payloads are correct
   for (auto const& [range, payload] : addrs4) {
       IP4Addr ip4 = range.min();
@@ -2431,8 +2431,6 @@ TEST_CASE("IPSpace mark_bulk randomized", "[libswoc][ipspace][mark_bulk][randomi
       REQUIRE(r.contains(ip6));
       REQUIRE(p == payload);
   }
-
-  
 
   // Create another ip range before the previous two
   std::vector<std::pair<swoc::DiscreteRange<IP4Addr>, PAYLOAD>> addrs4_3;


### PR DESCRIPTION
Improves performance when many ip ranges need to be added to IPSpace at once.

Also results in a better-balanced RB tree whenever many append operations happen in succession.