### PR TITLE
Fix memory leak in ink_event_system_init

### DIFF
--- a/src/iocore/eventsystem/EventSystem.cc
+++ b/src/iocore/eventsystem/EventSystem.cc
@@ -50,6 +50,7 @@ ink_event_system_init(ts::ModuleVersion v)
     // If we can't parse the string then we can't be sure of the chunk sizes so just exit
     Fatal("Failed to parse proxy.config.allocator.iobuf_chunk_sizes");
   }
+  ats_free(chunk_sizes_string);
 
   bool use_hugepages = ats_hugepage_enabled();
 


### PR DESCRIPTION
The memory for chunk_sizes_string is allocated in
REC_ConfigReadString
RecGetRecordString_Xmalloc
RecGetRecord_Xmalloc
RecDataSet
ats_strdup
_xstrdup
ats_malloc

So it must be freed with ats_free.