### PR TITLE
cppcheck - records. Fix few warnings, nothing major.

### DIFF
--- a/include/records/RecYAMLDefs.h
+++ b/include/records/RecYAMLDefs.h
@@ -73,7 +73,7 @@ struct CfgNode {
 
   /// @brief Append field name in order to build up the record name.
   void
-  append_field_name() const
+  append_field_name()
   {
     if (!_legacy.record_name.empty()) {
       _legacy.record_name.append(".");

--- a/src/traffic_ctl/FileConfigCommand.cc
+++ b/src/traffic_ctl/FileConfigCommand.cc
@@ -234,8 +234,7 @@ FileConfigCommand::config_get()
     FlatYAMLAccessor::load(YAML::LoadAllFromFile(filename));
 
     for (auto const &var : data) { // we support multiple get's
-      std::string variable = amend_variable_name(var);
-      auto [found, search] = find_node(variable);
+      auto [found, search] = find_node(amend_variable_name(var));
 
       if (found) {
         _printer->write_output(swoc::bwprint(text, "{}: {}", var, search.as<std::string>()));


### PR DESCRIPTION
- No logic change, re-arrange some function signature and code location.
- Make some functions signatures more meanful, removing `const` from a function that is supposed to modify the object.
