### PR TITLE
Extend timeout from 5 to 10 in tunnel_transform test

### DIFF
--- a/tests/gold_tests/tunnel/tunnel_transform.test.py
+++ b/tests/gold_tests/tunnel/tunnel_transform.test.py
@@ -86,7 +86,7 @@ cmd_tunnel = 'curl -k --http1.1 -H "Connection: close" -vs --resolve "tunnel-tes
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.Command = cmd_tunnel
 tr.Processes.Default.ReturnCode = 0
-tr.TimeOut = 5
+tr.TimeOut = 10
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.SSL_Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(dumb_proxy)


### PR DESCRIPTION
Without this adjustment, the tunnel_transform test fails with timeout like below in my test environment:
```
   Run: Run dumb proxy and send tunnel request.: Failed
     Setting up : Copying 'dumb_proxy.py' to directory '/home/jenkins/autest_work/sandbox/tunnel_transform' as 'dumb_proxy.py'' - Passed
     Test : Checking that True == _isRunningAfter - Failed
        Reason: Returned Value True != _isRunningAfter
     Time-Out : TestRun finishes within expected time - Failed
        Reason: Returned value: 7.963896751403809 >= 5.0
```