### PR TITLE
Move defaulting install prefix before layout setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE -DATS_BUILD)
 
+# Setup default install directory
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX
+      /usr/local/trafficserver
+      CACHE PATH "Default install path" FORCE
+  )
+endif()
+
 include(layout)
 include(ClangTidy)
 
@@ -160,14 +168,6 @@ else()
   set(TS_PKGSYSGROUP ${WITH_GROUP})
 endif()
 set(TS_PKGSYSUSER ${WITH_USER})
-
-# Setup default install directory
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX
-      /usr/local/trafficserver
-      CACHE PATH "Default install path" FORCE
-  )
-endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(DEFAULT_POSIX_CAP ON)


### PR DESCRIPTION
If a build config defaults CMAKE_INSTALL_PREFIX and then installs as the root user, the build will have an error about LOGDIR not existing.  This PR fixes that by making sure that CMAKE_INSTALL_PREFIX is set to the default value before the layout cmake script sets up the install paths according to the layout.

replaces #12036 