### PR TITLE
cppcheck - Fix some some errors and warnings.

### DIFF
--- a/example/plugins/c-api/client_context_dump/client_context_dump.cc
+++ b/example/plugins/c-api/client_context_dump/client_context_dump.cc
@@ -110,7 +110,7 @@ dump_context(const char *ca_path, const char *ck_path)
               san_s.push_back(',');
             }
           }
-          if (san_s.back() == ',') {
+          if (!san_s.empty() && san_s.back() == ',') {
             san_s.pop_back();
           }
         }

--- a/plugins/compress/misc.cc
+++ b/plugins/compress/misc.cc
@@ -161,7 +161,7 @@ restore_accept_encoding(TSHttpTxn /* txnp ATS_UNUSED */, TSMBuffer reqp, TSMLoc 
 const char *
 init_hidden_header_name()
 {
-  char        *hidden_header_name;
+  char        *hidden_header_name{nullptr};
   const char  *var_name = "proxy.config.proxy_name";
   TSMgmtString result;
 

--- a/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
+++ b/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
@@ -109,7 +109,7 @@ dump_context(const char *ca_path, const char *ck_path)
               san_s.push_back(',');
             }
           }
-          if (san_s.back() == ',') {
+          if (!san_s.empty() && san_s.back() == ',') {
             san_s.pop_back();
           }
         }


### PR DESCRIPTION
Make sure we do not fall into UB when checking for string.back. 
Initialize `char*` to `nullptr`, cppcheck was complaining about this not being initialized depending on the branch taken.