### PR TITLE
[9.2.x] Backport: Fix ordering Via response header values (#9239)

### DIFF
--- a/proxy/http/HttpTransact.h
+++ b/proxy/http/HttpTransact.h
@@ -44,6 +44,8 @@
 #include "ProxySession.h"
 #include "MgmtDefs.h"
 
+#define HTTP_OUR_VIA_MAX_LENGTH 1024 // 512-bytes for hostname+via string, 512-bytes for the debug info
+
 #define HTTP_RELEASE_ASSERT(X) ink_release_assert(X)
 
 #define DUMP_HEADER(T, H, I, S)                                 \

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -837,7 +837,7 @@ HttpTransactHeaders::insert_hsts_header_in_response(HttpTransact::State *s, HTTP
 void
 HttpTransactHeaders::insert_via_header_in_response(HttpTransact::State *s, HTTPHdr *header)
 {
-  char new_via_string[1024]; // 512-bytes for hostname+via string, 512-bytes for the debug info
+  char new_via_string[HTTP_OUR_VIA_MAX_LENGTH];
   char *via_string = new_via_string;
   char *via_limit  = via_string + sizeof(new_via_string);
 


### PR DESCRIPTION
Backport https://github.com/apache/trafficserver/pull/9239 to 9.2.x.

Currently, when upstream returns 304 response, the order of Via response header values is wrong.

```
Expected order: upstream's Via, our Via
Actual order: our Via, upstream's Via
```

This pull request fixes this.

(cherry picked from commit https://github.com/apache/trafficserver/commit/e34ec503bb3ff767245acc72d7da951fee84f1b8)