### PR TITLE
slice/cache_range_requests plugin: avoid subsequent slice IMS requests

### DIFF
--- a/doc/admin-guide/plugins/cache_range_requests.en.rst
+++ b/doc/admin-guide/plugins/cache_range_requests.en.rst
@@ -112,7 +112,6 @@ which includes information about the partial content range.  In this mode,
 all requests (include partial content) will use consistent hashing method
 for parent selection.
 
-
 X-Crr-Ims header support
 ------------------------
 
@@ -143,6 +142,35 @@ When used with the :program:`slice` plugin its `--crr-ims-header`
 option must have the same value (or not be defined) in order to work.
 
 Presence of the `--ims-header` automatically sets the `--consider-ims` option.
+
+X-Crr-Ident header support
+--------------------------
+
+.. option:: --consider-ident
+.. option:: -d
+.. option:: --ident-header=[header name] (default: X-Crr-Ident)
+.. option:: -j
+
+This supports the slice plugin which makes multiple adjancent
+range requests.  The slice plugin will record the identifier
+of the first range request (Etag, or Last-Modified in that order)
+and will add the value of that to the this header.
+
+.. code::
+
+    X-Crr-Ident: Etag: "foo"
+    X-Crr-Ident: Last-Modified: Tue, 19 Nov 2019 13:26:45 GMT
+
+If during the cache lookup hook a range request is considered stale
+the identifier from this header will be compared to the stale cache
+response and if matches the response will be marked FRESH to bypass
+visiting a parent cache with an IMS request.
+
+When used with the :program:`slice` plugin its `--crr-ident-header`
+option must have the same value (or not be defined) in order to work.
+
+Presence of the `--ident-header` automatically sets the `--consider-ident`
+option.
 
 Don't modify the Cache Key
 --------------------------

--- a/doc/admin-guide/plugins/cache_range_requests.en.rst
+++ b/doc/admin-guide/plugins/cache_range_requests.en.rst
@@ -151,20 +151,20 @@ X-Crr-Ident header support
 .. option:: --ident-header=[header name] (default: X-Crr-Ident)
 .. option:: -j
 
-This supports the slice plugin which makes multiple adjancent
-range requests.  The slice plugin will record the identifier
-of the first range request (Etag, or Last-Modified in that order)
-and will add the value of that to the this header.
+This supports the slice plugin which makes multiple adjacent range
+requests. The slice plugin will record the identifier of the first range
+request (Etag, or Last-Modified in that order) and will add the value
+to this header.
 
 .. code::
 
     X-Crr-Ident: Etag: "foo"
     X-Crr-Ident: Last-Modified: Tue, 19 Nov 2019 13:26:45 GMT
 
-If during the cache lookup hook a range request is considered stale
+During the cache lookup hook if a range request is considered STALE
 the identifier from this header will be compared to the stale cache
-response and if matches the response will be marked FRESH to bypass
-visiting a parent cache with an IMS request.
+identifier. If the values match the response will be changed to FRESH,
+preventing the transaction from contacting a parent.
 
 When used with the :program:`slice` plugin its `--crr-ident-header`
 option must have the same value (or not be defined) in order to work.

--- a/doc/admin-guide/plugins/slice.en.rst
+++ b/doc/admin-guide/plugins/slice.en.rst
@@ -140,6 +140,14 @@ The slice plugin supports the following options::
         `cache_range_requests` plugin.
         -i for short
 
+    --crr-ident-header=<header name> (default: X-Crr-Ident)
+        Header name used by the slice plugin to tell the
+        `cache_range_requests` plugin the identifier of the
+        first/reference slice fetched.  First Etag is preferred
+        followed by Last-Modified. The `cache_range_requests`
+        can use this identifier to flip a STALE asset back to
+        FRESH in order to limit unnecessary IMS requests.
+
     --prefetch-count=<int> (optional)
         Default is 0
         Prefetches successive 'n' slice block requests in the background

--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -56,8 +56,8 @@ constexpr std::string_view SLICE_CRR_HEADER   = {"Slice-Crr-Status"};
 constexpr std::string_view SLICE_CRR_VAL      = "1";
 constexpr std::string_view SKIP_CRR_HDR_NAME  = {"X-Skip-Crr"};
 
-std::string_view Etag(TS_MIME_FIELD_ETAG, TS_MIME_LEN_ETAG);
-std::string_view LastModified(TS_MIME_FIELD_LAST_MODIFIED, TS_MIME_LEN_LAST_MODIFIED);
+std::string_view const Etag(TS_MIME_FIELD_ETAG, TS_MIME_LEN_ETAG);
+std::string_view const LastModified(TS_MIME_FIELD_LAST_MODIFIED, TS_MIME_LEN_LAST_MODIFIED);
 
 struct pluginconfig {
   parent_select_mode_t ps_mode{PS_DEFAULT};

--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -192,7 +192,7 @@ create_pluginconfig(int argc, char *const argv[])
 
   if (pc->consider_ident_header && pc->ident_header.empty()) {
     pc->ident_header = DefaultIdentHeader;
-    DEBUG_LOG("Plugin uses default ims header: %s", pc->ims_header.c_str());
+    DEBUG_LOG("Plugin uses default ident header: %s", pc->ident_header.c_str());
   }
 
   return pc;
@@ -643,10 +643,11 @@ handle_cache_lookup_complete(TSHttpTxn txnp, txndata *const txn_state)
         }
       }
     } else if (TS_CACHE_LOOKUP_HIT_STALE == cachestat && txn_state->ident_check) {
+      pluginconfig const *const pc = txn_state->config;
+      DEBUG_LOG("Stale asset ident check");
+
       TSMBuffer resp_buf = nullptr;
       TSMLoc    resp_loc = TS_NULL_MLOC;
-
-      pluginconfig const *const pc = txn_state->config;
 
       if (TS_SUCCESS == TSHttpTxnCachedRespGet(txnp, &resp_buf, &resp_loc)) {
         if (TS_HTTP_STATUS_OK == TSHttpHdrStatusGet(resp_buf, resp_loc)) {

--- a/plugins/cache_range_requests/cache_range_requests.cc
+++ b/plugins/cache_range_requests/cache_range_requests.cc
@@ -642,7 +642,6 @@ handle_cache_lookup_complete(TSHttpTxn txnp, txndata *const txn_state)
           }
         }
       }
-      // BNO
     } else if (TS_CACHE_LOOKUP_HIT_STALE == cachestat && txn_state->ident_check) {
       TSMBuffer resp_buf = nullptr;
       TSMLoc    resp_loc = TS_NULL_MLOC;
@@ -651,7 +650,7 @@ handle_cache_lookup_complete(TSHttpTxn txnp, txndata *const txn_state)
 
       if (TS_SUCCESS == TSHttpTxnCachedRespGet(txnp, &resp_buf, &resp_loc)) {
         if (TS_HTTP_STATUS_OK == TSHttpHdrStatusGet(resp_buf, resp_loc)) {
-          // get the client identifier
+          // get the request identifier
           TSMBuffer req_buf = nullptr;
           TSMLoc    req_loc = TS_NULL_MLOC;
           if (TS_SUCCESS == TSHttpTxnClientReqGet(txnp, &req_buf, &req_loc)) {

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -196,6 +196,7 @@ Parser::preprocess(std::vector<std::string> tokens)
       }
     } else {
       TSError("[%s] conditions must be embraced in %%{}", PLUGIN_NAME);
+      TSError("[%s] token: '%s'", PLUGIN_NAME, tokens[0].c_str());
       return false;
     }
   } else {

--- a/plugins/slice/Config.cc
+++ b/plugins/slice/Config.cc
@@ -29,6 +29,7 @@ namespace
 {
 constexpr std::string_view DefaultSliceSkipHeader = {"X-Slicer-Info"};
 constexpr std::string_view DefaultCrrImsHeader    = {"X-Crr-Ims"};
+constexpr std::string_view DefaultCrrIdentHeader  = {"X-Crr-Ident"};
 } // namespace
 
 Config::~Config()
@@ -116,6 +117,7 @@ Config::fromArgs(int const argc, char const *const argv[])
     {const_cast<char *>("crr-ims-header"),       required_argument, nullptr, 'c'},
     {const_cast<char *>("disable-errorlog"),     no_argument,       nullptr, 'd'},
     {const_cast<char *>("exclude-regex"),        required_argument, nullptr, 'e'},
+    {const_cast<char *>("crr-ident-header"),     required_argument, nullptr, 'g'},
     {const_cast<char *>("include-regex"),        required_argument, nullptr, 'i'},
     {const_cast<char *>("ref-relative"),         no_argument,       nullptr, 'l'},
     {const_cast<char *>("pace-errorlog"),        required_argument, nullptr, 'p'},
@@ -133,7 +135,7 @@ Config::fromArgs(int const argc, char const *const argv[])
   // getopt assumes args start at '1' so this hack is needed
   char *const *argvp = (const_cast<char *const *>(argv) - 1);
   for (;;) {
-    int const opt = getopt_long(argc + 1, argvp, "b:dc:e:i:lm:p:r:s:t:x:z:", longopts, nullptr);
+    int const opt = getopt_long(argc + 1, argvp, "b:dc:e:g:i:lm:p:r:s:t:x:z:", longopts, nullptr);
     if (-1 == opt) {
       break;
     }
@@ -174,6 +176,10 @@ Config::fromArgs(int const argc, char const *const argv[])
         m_regex_extra = pcre_study(m_regex, 0, &errptr);
         DEBUG_LOG("Using regex for url exclude: '%s'", m_regexstr.c_str());
       }
+    } break;
+    case 'g': {
+      m_crr_ident_header.assign(optarg);
+      DEBUG_LOG("Using override crr ident header %s", optarg);
     } break;
     case 'i': {
       if (None != m_regex_type) {
@@ -277,6 +283,10 @@ Config::fromArgs(int const argc, char const *const argv[])
   if (m_crr_ims_header.empty()) {
     m_crr_ims_header = DefaultCrrImsHeader;
     DEBUG_LOG("Using default crr ims header %s", m_crr_ims_header.c_str());
+  }
+  if (m_crr_ident_header.empty()) {
+    m_crr_ident_header = DefaultCrrIdentHeader;
+    DEBUG_LOG("Using default crr ident header %s", m_crr_ident_header.c_str());
   }
   if (m_skip_header.empty()) {
     m_skip_header = DefaultSliceSkipHeader;

--- a/plugins/slice/Config.h
+++ b/plugins/slice/Config.h
@@ -52,6 +52,7 @@ struct Config {
 
   std::string m_skip_header;
   std::string m_crr_ims_header;
+  std::string m_crr_ident_header;
 
   // Convert optarg to bytes
   static int64_t bytesFrom(char const *const valstr);

--- a/plugins/slice/slice.cc
+++ b/plugins/slice/slice.cc
@@ -52,7 +52,10 @@ should_skip_this_obj(TSHttpTxn txnp, Config *const config)
   int         len    = 0;
   char *const urlstr = TSHttpTxnEffectiveUrlStringGet(txnp, &len);
 
-  if (!config->isKnownLargeObj({urlstr, static_cast<size_t>(len)})) {
+  bool const known_large = config->isKnownLargeObj({urlstr, static_cast<size_t>(len)});
+  TSfree(urlstr);
+
+  if (!known_large) {
     DEBUG_LOG("Not a known large object, not slicing: %.*s", len, urlstr);
     return true;
   }

--- a/plugins/slice/util.cc
+++ b/plugins/slice/util.cc
@@ -104,11 +104,11 @@ request_block(TSCont contp, Data *const data)
     swoc::LocalBufferWriter<8192> idbuf;
     if (0 < data->m_etaglen) {
       idbuf.write(TS_MIME_FIELD_ETAG, TS_MIME_LEN_ETAG);
-      idbuf.write(' ');
+      idbuf.write(": ");
       idbuf.write(data->m_etag, data->m_etaglen);
     } else if (0 < data->m_lastmodifiedlen) {
       idbuf.write(TS_MIME_FIELD_LAST_MODIFIED, TS_MIME_LEN_LAST_MODIFIED);
-      idbuf.write(' ');
+      idbuf.write(": ");
       idbuf.write(data->m_lastmodified, data->m_lastmodifiedlen);
     }
 

--- a/plugins/slice/util.cc
+++ b/plugins/slice/util.cc
@@ -113,6 +113,7 @@ request_block(TSCont contp, Data *const data)
     }
 
     if (0 < idbuf.size()) {
+      DEBUG_LOG("Adding identity '%.*s'", (int)idbuf.size(), idbuf.data());
       header.setKeyVal(cfg->m_crr_ident_header.data(), cfg->m_crr_ident_header.size(), idbuf.data(), idbuf.size());
     }
   }

--- a/plugins/slice/util.cc
+++ b/plugins/slice/util.cc
@@ -98,6 +98,25 @@ request_block(TSCont contp, Data *const data)
     header.setKeyVal(SLICE_CRR_HEADER.data(), SLICE_CRR_HEADER.size(), SLICE_CRR_VAL.data(), SLICE_CRR_VAL.size());
   }
 
+  // Attach the identifier header
+  Config const *const cfg = data->m_config;
+  if (!cfg->m_crr_ident_header.empty() && !header.hasKey(cfg->m_crr_ident_header.data(), cfg->m_crr_ident_header.size())) {
+    swoc::LocalBufferWriter<8192> idbuf;
+    if (0 < data->m_etaglen) {
+      idbuf.write(TS_MIME_FIELD_ETAG, TS_MIME_LEN_ETAG);
+      idbuf.write(' ');
+      idbuf.write(data->m_etag, data->m_etaglen);
+    } else if (0 < data->m_lastmodifiedlen) {
+      idbuf.write(TS_MIME_FIELD_LAST_MODIFIED, TS_MIME_LEN_LAST_MODIFIED);
+      idbuf.write(' ');
+      idbuf.write(data->m_lastmodified, data->m_lastmodifiedlen);
+    }
+
+    if (0 < idbuf.size()) {
+      header.setKeyVal(cfg->m_crr_ident_header.data(), cfg->m_crr_ident_header.size(), idbuf.data(), idbuf.size());
+    }
+  }
+
   // create virtual connection back into ATS
   TSHttpConnectOptions options = TSHttpConnectOptionsGet(TS_CONNECT_PLUGIN);
   options.addr                 = reinterpret_cast<sockaddr *>(&data->m_client_ip);

--- a/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ident.test.py
+++ b/tests/gold_tests/pluginTest/cache_range_requests/cache_range_requests_ident.test.py
@@ -1,0 +1,152 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+cache_range_requests X-Crr-Ident plugin test
+'''
+
+# Test description:
+# Preload the cache with the entire asset to be range requested.
+# Ensure asset is stale and request with properly formed header.
+
+Test.SkipUnless(
+    Condition.PluginExists('cache_range_requests.so'),
+    Condition.PluginExists('xdebug.so'),
+)
+#Test.ContinueOnFail = False
+Test.ContinueOnFail = True
+Test.testName = "cache_range_requests_ident"
+
+# Define and configure ATS
+ts = Test.MakeATSProcess("ts")
+
+# Define and configure origin server
+server = Test.MakeOriginServer("server")
+
+# default root
+req_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "uuid: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+
+res_chk = {"headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
+
+server.addResponse("sessionlog.json", req_chk, res_chk)
+
+body = "lets go surfin now"
+bodylen = len(body)
+
+req_full = {
+    "headers": "GET /path HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*\r\n" + "Range: bytes=0-\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": ""
+}
+
+last_modified = "Fri, 07 Mar 2025 18:06:58 GMT"
+etag = '"772102f4-56f4bc1e6d417"'
+
+res_full = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=1\r\n" +
+        "Content-Range: bytes 0-{0}/{0}\r\n".format(bodylen) + "Connection: close\r\n" + 'Etag: ' + etag + '\r\n' +
+        'Last-Modified: ' + last_modified + '\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body
+}
+
+server.addResponse("sessionlog.json", req_full, res_full)
+
+# cache range requests plugin remap
+ts.Disk.remap_config.AddLines(
+    [
+        f'map http://ident http://127.0.0.1:{server.Variables.Port}' + ' @plugin=cache_range_requests.so @pparam=--consider-ident',
+        f'map http://identheader http://127.0.0.1:{server.Variables.Port}' +
+        ' @plugin=cache_range_requests.so @pparam=--consider-ident' + ' @pparam=--ident-header=CrrIdent',
+    ])
+
+# cache debug
+ts.Disk.plugin_config.AddLine('xdebug.so --enable=x-cache')
+
+# minimal configuration
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'cache_range_requests',
+})
+
+curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{} -H "x-debug: x-cache"'.format(ts.Variables.port)
+
+# 0 Test - Fetch whole asset into cache
+tr = Test.AddTestRun("0- range cache load")
+ps = tr.Processes.Default
+ps.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+ps.StartBefore(Test.Processes.ts)
+ps.Command = curl_and_args + ' http://ident/path -r 0-'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss for load")
+tr.StillRunningAfter = ts
+
+# test inner range
+# 1 Test - Fetch range into cache
+tr = Test.AddTestRun("0- cache hit check")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://ident/path -r 0-'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit", "expected cache hit")
+tr.StillRunningAfter = ts
+
+# set up the IMS date field (go in the future) RFC 2616
+#futuretime = time.time() + 100  # seconds
+#futurestr = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(futuretime))
+
+# These requests should flip from STALE to FRESH
+
+# 2 Test - Ensure X-Crr-Ident Etag header results in hit-stale
+tr = Test.AddTestRun("0- range X-Crr-Ident check")
+tr.DelayStart = 2
+ps = tr.Processes.Default
+ps.Command = curl_and_args + f" http://ident/path -r 0- -H 'X-Crr-Ident: Etag: {etag}'"
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit-fresh")
+tr.StillRunningAfter = ts
+
+# 3 Test - Ensure X-Crr-Ident Last-Modified header results in hit-fresh
+tr = Test.AddTestRun("0- range X-Crr-Ident check")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + f' http://ident/path -r 0- -H "X-Crr-Ident: Last-Modified: {last_modified}"'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit-fresh")
+tr.StillRunningAfter = ts
+
+# 4 Test - Provide a mismatch Etag force IMS request
+tr = Test.AddTestRun("0- range X-Crr-Ident check")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + f' http://ident/path -r 0- -H "X-Crr-Ident: Last-Modified: foo"'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-stale", "expected cache hit-stale")
+tr.StillRunningAfter = ts
+
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
+    """Checking cached '"772102f4-56f4bc1e6d417"' against request 'Etag: "772102f4-56f4bc1e6d417"'""",
+    "Etag is correctly considered")
+
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
+    """Checking cached 'Fri, 07 Mar 2025 18:06:58 GMT' against request 'Last-Modified: Fri, 07 Mar 2025 18:06:58 GMT'""",
+    "Last-Modified is correctly considered")

--- a/tests/gold_tests/pluginTest/slice/gold/slice_crr_ident.gold
+++ b/tests/gold_tests/pluginTest/slice/gold/slice_crr_ident.gold
@@ -1,0 +1,13 @@
+cpuup=/plain sssc=200 pssc=206 phr=DIRECT range=::bytes=0-2:: x-crr-ident=::-:: uid=::plain 0:: crc=TCP_MISS
+cpuup=/plain sssc=200 pssc=206 phr=DIRECT range=::bytes=3-5:: x-crr-ident=::Etag: "plain":: uid=::plain 1:: crc=TCP_MISS
+cpuup=/plain sssc=200 pssc=200 phr=DIRECT range=::-:: x-crr-ident=::-:: uid=::plain:: crc=TCP_MISS
+cpuup=/plain sssc=200 pssc=206 phr=DIRECT range=::bytes=0-2:: x-crr-ident=::-:: uid=::plain 0:: crc=TCP_REFRESH_MISS
+cpuup=/plain sssc=000 pssc=206 phr=NONE range=::bytes=3-5:: x-crr-ident=::Etag: "plain":: uid=::-:: crc=TCP_HIT
+cpuup=/plain sssc=200 pssc=200 phr=DIRECT range=::-:: x-crr-ident=::-:: uid=::plain:: crc=TCP_MISS
+cpuup=/plain sssc=200 pssc=206 phr=DIRECT range=::bytes=0-2:: x-crr-ident=::-:: uid=::chg 0:: crc=TCP_REFRESH_MISS
+cpuup=/plain sssc=200 pssc=206 phr=DIRECT range=::bytes=3-5:: x-crr-ident=::Etag: "chg":: uid=::chg 1:: crc=TCP_REFRESH_MISS
+cpuup=/plain sssc=200 pssc=200 phr=DIRECT range=::-:: x-crr-ident=::-:: uid=::chg:: crc=TCP_MISS
+cpuup=/plain sssc=000 pssc=206 phr=NONE range=::bytes=0-2:: x-crr-ident=::-:: uid=::-:: crc=TCP_HIT
+cpuup=/plain sssc=000 pssc=206 phr=NONE range=::bytes=3-5:: x-crr-ident=::Etag: "chg":: uid=::-:: crc=TCP_HIT
+cpuup=/plain sssc=200 pssc=200 phr=DIRECT range=::-:: x-crr-ident=::-:: uid=::chg:: crc=TCP_MISS
+cpuup=/404.txt sssc=404 pssc=404 phr=DIRECT range=::-:: x-crr-ident=::-:: uid=::-:: crc=TCP_MISS

--- a/tests/gold_tests/pluginTest/slice/gold/slice_ident.gold
+++ b/tests/gold_tests/pluginTest/slice/gold/slice_ident.gold
@@ -1,0 +1,15 @@
+/etag 200 200 range=::-:: x-crr-ident=::-:: crrident=::-::
+/lm 200 200 range=::-:: x-crr-ident=::-:: crrident=::-::
+/etag 000 206 range=::bytes=0-10:: x-crr-ident=::-:: crrident=::-::
+/etag 000 206 range=::bytes=11-21:: x-crr-ident=::Etag: "foo":: crrident=::-::
+/etag 200 200 range=::-:: x-crr-ident=::-:: crrident=::-::
+/etag 000 206 range=::bytes=0-10:: x-crr-ident=::-:: crrident=::-::
+/etag 000 206 range=::bytes=11-21:: x-crr-ident=::-:: crrident=::Etag: "foo"::
+/etag 200 200 range=::-:: x-crr-ident=::-:: crrident=::-::
+/lm 000 206 range=::bytes=0-10:: x-crr-ident=::-:: crrident=::-::
+/lm 000 206 range=::bytes=11-21:: x-crr-ident=::Last-Modified: Fri, 07 Mar 2025 18:06:58 GMT:: crrident=::-::
+/lm 200 200 range=::-:: x-crr-ident=::-:: crrident=::-::
+/lm 000 206 range=::bytes=0-10:: x-crr-ident=::-:: crrident=::-::
+/lm 000 206 range=::bytes=11-21:: x-crr-ident=::-:: crrident=::Last-Modified: Fri, 07 Mar 2025 18:06:58 GMT::
+/lm 200 200 range=::-:: x-crr-ident=::-:: crrident=::-::
+/404.txt 000 404 range=::-:: x-crr-ident=::-:: crrident=::-::

--- a/tests/gold_tests/pluginTest/slice/slice_crr_ident.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_crr_ident.test.py
@@ -1,0 +1,222 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+
+Test.Summary = '''
+Combined Slice/crr ident test
+'''
+
+# Test description:
+# Preload the cache with the entire asset to be range requested.
+# Reload remap rule with slice plugin
+# Request content through the slice plugin
+
+Test.SkipUnless(
+    Condition.PluginExists('cache_range_requests.so'),
+    Condition.PluginExists('header_rewrite.so'),
+    Condition.PluginExists('slice.so'),
+    Condition.PluginExists('xdebug.so'),
+)
+Test.ContinueOnFail = False
+
+# configure origin server
+server = Test.MakeOriginServer("server", lookup_key="{%UID}")
+
+# default root
+req_header_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "UID: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+res_header_chk = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+server.addResponse("sessionlog.json", req_header_chk, res_header_chk)
+
+# Define ATS and configure
+ts = Test.MakeATSProcess("ts")  #, command='traffic_server_valgrind.sh')
+
+# set up slice plugin with remap host into cache_range_requests
+ts.Disk.remap_config.AddLines(
+    [
+        f'map http://slice/ http://127.0.0.1:{server.Variables.Port}/' +
+        ' @plugin=slice.so @pparam=--blockbytes-test=3 @pparam=--remap-host=crr',
+        f'map http://crr/ http://127.0.0.1:{server.Variables.Port}/' +
+        '  @plugin=cache_range_requests.so @pparam=--consider-ims @pparam=--consider-ident' +
+        ' @plugin=header_rewrite.so @pparam=hdr_rw.conf',
+    ])
+
+ts.Disk.logging_yaml.AddLines(
+    '''
+logging:
+ formats:
+  - name: custom
+    format: 'cpuup=%<cquup> sssc=%<sssc> pssc=%<pssc> phr=%<phr> range=::%<{Range}cqh>:: x-crr-ident=::%<{X-Crr-Ident}cqh>:: uid=::%<{UID}pqh>:: crc=%<crc>'
+ logs:
+  - filename: transaction
+    format: custom
+'''.split("\n"))
+
+ts.Disk.plugin_config.AddLine('xdebug.so --enable=x-cache')
+
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'cache_range_requests|header_rewrite|slice|log',
+    })
+
+ts.Disk.MakeConfigFile("hdr_rw.conf").AddLines(
+    [
+        'cond %{SEND_REQUEST_HDR_HOOK}', 'cond %{HEADER:Range} ="bytes=0-2" [AND]', 'set-header UID %{CLIENT-HEADER:UID} 0'
+        '', 'cond %{SEND_REQUEST_HDR_HOOK}', 'cond %{HEADER:Range} ="bytes=3-5" [AND]', 'set-header UID %{CLIENT-HEADER:UID} 1'
+    ])
+
+# Test case: short lived asset. second slice should be HIT_FRESH
+
+req_header_plain_0 = {
+    "headers": "GET /plain HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "UID: plain 0\r\n" + "Range: bytes=0-2\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+res_header_plain_0 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" +
+        "Content-Range: bytes 0-2/5\r\n" + 'Etag: "plain"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "aaa"
+}
+
+server.addResponse("sessionlog.json", req_header_plain_0, res_header_plain_0)
+
+req_header_plain_1 = {
+    "headers": "GET /plain HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "UID: plain 1\r\n" + "Range: bytes=3-5\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+res_header_plain_1 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" +
+        "Content-Range: bytes 3-4/5\r\n" + 'Etag: "plain"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "BB"
+}
+
+server.addResponse("sessionlog.json", req_header_plain_1, res_header_plain_1)
+
+# curl helper
+curl_and_args = 'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{}'.format(ts.Variables.port) + ' -H "x-debug: x-cache"'
+
+# 0 Test - Preload plain asset
+tr = Test.AddTestRun("Preload plain")
+ps = tr.Processes.Default
+ps.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+ps.StartBefore(Test.Processes.ts)
+ps.Command = curl_and_args + ' http://slice/plain -H "UID: plain"'
+ps.ReturnCode = 0
+ps.Streams.stderr.Content = Testers.ContainsExpression("aaaBB", "expected aaaBB")
+ps.Streams.stdout.Content = Testers.ContainsExpression('Etag: "plain"', "expected etag plain")
+tr.StillRunningAfter = ts
+
+# 2 Test - Request again, should result in stale asset
+tr = Test.AddTestRun("Request 2nd slice (expect slice1 to be fresh)")
+tr.DelayStart = 2  # ensure its really stale
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slice/plain -H "UID: plain"'
+ps.ReturnCode = 0
+ps.Streams.stderr = Testers.ContainsExpression("aaaBB", "expected aaaBB")
+ps.Streams.stdout.Content = Testers.ContainsExpression('Etag: "plain"', "expected etag plain")
+tr.StillRunningAfter = ts
+
+# change out the asset
+
+req_header_chg_0 = {
+    "headers": "GET /plain HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "UID: chg 0\r\n" + "Range: bytes=0-2\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+res_header_chg_0 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=60\r\n" +
+        "Connection: close\r\n" + "Content-Range: bytes 0-2/5\r\n" + 'Etag: "chg"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "AAA"
+}
+
+server.addResponse("sessionlog.json", req_header_chg_0, res_header_chg_0)
+
+req_header_chg_1 = {
+    "headers": "GET /plain HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "UID: chg 1\r\n" + "Range: bytes=3-5\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+res_header_chg_1 = {
+    "headers":
+        "HTTP/1.1 206 Partial Content\r\n" + "Accept-Ranges: bytes\r\n" + "Cache-Control: max-age=60\r\n" +
+        "Connection: close\r\n" + "Content-Range: bytes 3-4/5\r\n" + 'Etag: "chg"\r\n' + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "bb"
+}
+
+server.addResponse("sessionlog.json", req_header_chg_1, res_header_chg_1)
+
+# 3 Test - Request again, should result in new asset
+tr = Test.AddTestRun("Request again, asset replaced")
+tr.DelayStart = 2  # ensure its really stale
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slice/plain -H "UID: chg"'
+ps.ReturnCode = 0
+ps.Streams.stderr = Testers.ContainsExpression("AAAbb", "expected AAAbb")
+ps.Streams.stdout.Content = Testers.ContainsExpression('Etag: "chg"', "expected etag chg")
+tr.StillRunningAfter = ts
+
+# 4 Test - Request again, should all be hit
+tr = Test.AddTestRun("Request again, asset replaced but hit")
+tr.DelayStart = 2  # ensure its really stale
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slice/plain -H "UID: chg"'
+ps.ReturnCode = 0
+ps.Streams.stderr = Testers.ContainsExpression("AAAbb", "expected AAAbb")
+ps.Streams.stdout.Content = Testers.ContainsExpression('Etag: "chg"', "expected etag chg")
+tr.StillRunningAfter = ts
+
+# 5 Test - add token to transaction log
+tr = Test.AddTestRun("Fetch 404.txt asset")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://crr/404.txt'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("404", "expected 404 Not Found response")
+tr.StillRunningAfter = ts
+
+condwaitpath = os.path.join(Test.Variables.AtsTestToolsDir, 'condwait')
+
+tslog = os.path.join(ts.Variables.LOGDIR, 'transaction.log')
+Test.AddAwaitFileContainsTestRun('Await ts transactions to finish logging.', tslog, '404.txt')
+
+# 6 Check logs
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = (f"cat {tslog}")
+tr.Streams.stdout = "gold/slice_crr_ident.gold"
+tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/slice/slice_crr_ident.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_crr_ident.test.py
@@ -53,7 +53,7 @@ res_header_chk = {
 server.addResponse("sessionlog.json", req_header_chk, res_header_chk)
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts")  #, command='traffic_server_valgrind.sh')
+ts = Test.MakeATSProcess("ts")
 
 # set up slice plugin with remap host into cache_range_requests
 ts.Disk.remap_config.AddLines(

--- a/tests/gold_tests/pluginTest/slice/slice_ident.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_ident.test.py
@@ -89,7 +89,7 @@ server.addResponse("sessionlog.json", request_lm, response_lm)
 # use this second ats instance to serve up the slices
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts")
+ts = Test.MakeATSProcess("ts", command='traffic_server_valgrind.sh')
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'slice',

--- a/tests/gold_tests/pluginTest/slice/slice_ident.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_ident.test.py
@@ -1,0 +1,188 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Slice plugin test for sending ident header
+'''
+
+# Test description:
+# Preload the cache with the entire asset to be range requested.
+# Reload remap rule with slice plugin
+# Request content through the slice plugin
+
+Test.SkipUnless(Condition.PluginExists('slice.so'),)
+Test.ContinueOnFail = False
+
+# configure origin server
+server = Test.MakeOriginServer("server")
+
+# default root
+request_header_chk = {
+    "headers": "GET / HTTP/1.1\r\n" + "Host: ats\r\n" + "Range: none\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+response_header_chk = {
+    "headers": "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+server.addResponse("sessionlog.json", request_header_chk, response_header_chk)
+
+block_bytes = 11
+body = "lets go surfin now"
+
+etag = '"foo"'
+last_modified = "Fri, 07 Mar 2025 18:06:58 GMT"
+
+request_etag = {
+    "headers": "GET /etag HTTP/1.1\r\n" + "Host: origin\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+response_etag = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + f'Etag: {etag}\r\n' + f'Last-Modified: {last_modified}\r\n' +
+        "Cache-Control: max-age=500\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body,
+}
+
+server.addResponse("sessionlog.json", request_etag, response_etag)
+
+request_lm = {
+    "headers": "GET /lm HTTP/1.1\r\n" + "Host: origin\r\n" + "\r\n",
+    "timestamp": "1469733493.993",
+    "body": "",
+}
+
+response_lm = {
+    "headers":
+        "HTTP/1.1 200 OK\r\n" + "Connection: close\r\n" + f'Last-Modified: {last_modified}\r\n' + "Cache-Control: max-age=500\r\n" +
+        "\r\n",
+    "timestamp": "1469733493.993",
+    "body": body,
+}
+
+server.addResponse("sessionlog.json", request_lm, response_lm)
+
+# use this second ats instance to serve up the slices
+
+# Define ATS and configure
+ts = Test.MakeATSProcess("ts")
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'slice',
+})
+
+ts.Disk.remap_config.AddLines(
+    [
+        f"map http://preload/ http://127.0.0.1:{server.Variables.Port}",
+        f'map http://slice/ http://127.0.0.1:{server.Variables.Port}' +
+        f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}',
+        f'map http://slicecustom/ http://127.0.0.1:{server.Variables.Port}' +
+        f' @plugin=slice.so @pparam=--blockbytes-test={block_bytes}' + ' @pparam=--crr-ident-header=CrrIdent',
+    ])
+
+ts.Disk.logging_yaml.AddLines(
+    '''
+logging:
+ formats:
+  - name: custom
+    format: '%<cquup> %<sssc> %<pssc> range=::%<{Range}cqh>:: x-crr-ident=::%<{X-Crr-Ident}cqh>:: crrident=::%<{CrrIdent}cqh>::'
+ logs:
+  - filename: transaction
+    format: custom
+'''.split("\n"))
+
+# helpers for curl
+curl_and_args = f'curl -s -D /dev/stdout -o /dev/stderr -x localhost:{ts.Variables.port}'
+
+# 0 Test - Preload etag asset
+tr = Test.AddTestRun("Preload etag asset")
+ps = tr.Processes.Default
+ps.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
+ps.StartBefore(Test.Processes.ts)
+ps.Command = curl_and_args + ' http://preload/etag'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 OK response")
+tr.StillRunningAfter = ts
+
+# 1 Test - Preload last-modified asset
+tr = Test.AddTestRun("Preload last-modified asset")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://preload/lm'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 OK response")
+tr.StillRunningAfter = ts
+
+# 2 Test - Fetch etag asset
+tr = Test.AddTestRun("Fetch etag asset")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slice/etag'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 OK response")
+tr.StillRunningAfter = ts
+
+# 3 Test - Fetch etag asset
+tr = Test.AddTestRun("Fetch etag asset, custom")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slicecustom/etag'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 OK response")
+tr.StillRunningAfter = ts
+
+# 4 Test - Fetch last-modified asset
+tr = Test.AddTestRun("Fetch last-modified asset, custom")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slice/lm'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 OK response")
+tr.StillRunningAfter = ts
+
+# 5 Test - Fetch last-modified asset, custom
+tr = Test.AddTestRun("Fetch last-modified asset")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://slicecustom/lm'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("200 OK", "expected 200 OK response")
+tr.StillRunningAfter = ts
+
+# 6 Test - add token to transaction log
+tr = Test.AddTestRun("Fetch last-modified asset")
+ps = tr.Processes.Default
+ps.Command = curl_and_args + ' http://prefetch/404.txt'
+ps.ReturnCode = 0
+ps.Streams.stdout.Content = Testers.ContainsExpression("404", "expected 404 Not Found response")
+tr.StillRunningAfter = ts
+
+condwaitpath = os.path.join(Test.Variables.AtsTestToolsDir, 'condwait')
+
+tslog = os.path.join(ts.Variables.LOGDIR, 'transaction.log')
+Test.AddAwaitFileContainsTestRun('Await ts transactions to finish logging.', tslog, '404.txt')
+
+# 6 Check logs
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = (f"cat {tslog}")
+tr.Streams.stdout = "gold/slice_ident.gold"
+tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/slice/slice_ident.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_ident.test.py
@@ -89,7 +89,7 @@ server.addResponse("sessionlog.json", request_lm, response_lm)
 # use this second ats instance to serve up the slices
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command='traffic_server_valgrind.sh')
+ts = Test.MakeATSProcess("ts")
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1,
     'proxy.config.diags.debug.tags': 'slice',

--- a/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
@@ -71,7 +71,7 @@ ts.Disk.remap_config.AddLines(
         f'map http://crr/ http://127.0.0.1:{server.Variables.Port}/' +
         '  @plugin=cache_range_requests.so @pparam=--consider-ims @pparam=--consider-ident',
         f'map http://slicehdr/ http://127.0.0.1:{server.Variables.Port}/' + ' @plugin=slice.so @pparam=--blockbytes-test=3' +
-        ' @pparam=--remap-host=crrhdr @pparam=--crr-ims-header=crr-foo @pparam=--consider-ident',
+        ' @pparam=--remap-host=crrhdr @pparam=--crr-ims-header=crr-foo',
         f'map http://crrhdr/ http://127.0.0.1:{server.Variables.Port}/'
         '  @plugin=cache_range_requests.so @pparam=--ims-header=crr-foo',
     ])

--- a/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_selfhealing.test.py
@@ -46,7 +46,7 @@ Test.ContinueOnFail = False
 server = Test.MakeOriginServer("server", lookup_key="{%uuid}")
 
 # Define ATS and configure
-ts = Test.MakeATSProcess("ts", command='traffic_server_valgrind.sh')
+ts = Test.MakeATSProcess("ts")
 
 # default root
 req_header_chk = {


### PR DESCRIPTION
relates to issue #12047

With the slice plugin when an asset goes stale in cache and an IMS request results in a 304, the slice plugin may end up causing each range request to perform an IMS request, get a 304 and write another header into the cache for each subsequent range.

To get around this the slice plugin will take the strongest identifier from the first range request response and attach an identifier header to the cache_range_requests plugin.  If during cache lookup the CRR plugin finds that the resulting asset is stale, it will check the provided identifier against the "stale" slice and will flip it to "fresh" if the identifiers match.

The identifier will be passed as header, with Etag being preferred over Last-Modified.
X-Crr-Ident: Etag: "etag"
or
X-Crr-Ident: Last-Modified: "last modified date"


It might be worthwhile to consider reworking the slice self healing functionality to use this new header instead of the X-Crr-Ims header -- will file a separate PR for this.

I enabled this flag in the slice_selfhealing autest just to ensure it doesn't interfere.
Also found a memory leak in slice.cc regarding the large asset check code path and added extra debug for header rewrite token parsing failures.