### PR TITLE
libswoc version update: 1.5.14

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(Lib-SWOC LANGUAGES CXX VERSION 1.5.12)
-set(LIBSWOC_VERSION "1.5.12")
+project(Lib-SWOC LANGUAGES CXX VERSION 1.5.14)
+set(LIBSWOC_VERSION "1.5.14")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_13
+#define SWOC_VERSION_NS _1_5_14
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 13;
+static constexpr unsigned POINT_VERSION = 14;
 }} // namespace swoc::SWOC_VERSION_NS


### PR DESCRIPTION
We cut a release of trafficserver-libswoc that has our latest ATS changes to lib/swoc. That release is 1.5.14. This updates our local swoc_version.h to reflect this new release.