### PR TITLE
11-Dev: SSLUtils.cc address unused ctx parameter

### DIFF
--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1281,7 +1281,7 @@ fail:
 }
 
 bool
-SSLMultiCertConfigLoader::_setup_session_cache(SSL_CTX *ctx)
+SSLMultiCertConfigLoader::_setup_session_cache(SSL_CTX * /* ctx ATS_UNUSED */)
 {
   return true;
 }


### PR DESCRIPTION
```
FAILED: src/iocore/net/CMakeFiles/inknet.dir/SSLUtils.cc.o
/Library/Developer/CommandLineTools/usr/bin/clang++ -DDEBUG -DOPENSSL_API_COMPAT=10002 -DOPENSSL_IS_OPENSSL3 -DPACKAGE_NAME="\"Apache Traffic Server\"" -DPACKAGE_VERSION=\"11.0.0\" -D_DEBUG -Ddarwin -I/Users/bneradt/project_not_synced/repos/ts_os/include -I/Users/bneradt/project_not_synced/repos/ts_os/build/include -I/Users/bneradt/project_not_synced/repos/ts_os/lib/swoc/include -I/Users/bneradt/project_not_synced/repos/ts_os/lib/yamlcpp/include -isystem /opt/ats_h3_tools/openssl-quic/include -isystem /opt/homebrew/include -isystem /Users/bneradt/project_not_synced/repos/ts_os/lib/systemtap -isystem /opt/homebrew/Cellar/pcre2/10.44/include -Qunused-arguments -g -std=c++20 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk -Wno-invalid-offsetof -pipe -Wall -Wextra -Wno-noexcept-type -Wsuggest-override -Wno-vla-extension -fno-strict-aliasing -Wno-deprecated-declarations -Werror -MD -MT src/iocore/net/CMakeFiles/inknet.dir/SSLUtils.cc.o -MF src/iocore/net/CMakeFiles/inknet.dir/SSLUtils.cc.o.d -o src/iocore/net/CMakeFiles/inknet.dir/SSLUtils.cc.o -c /Users/bneradt/project_not_synced/repos/ts_os/src/iocore/net/SSLUtils.cc
/Users/bneradt/project_not_synced/repos/ts_os/src/iocore/net/SSLUtils.cc:1284:57: error: unused parameter 'ctx' [-Werror,-Wunused-parameter]
 1284 | SSLMultiCertConfigLoader::_setup_session_cache(SSL_CTX *ctx)
      |                                                         ^
1 error generated.
```