### PR TITLE
Add proxy.process.http.total_client_connections_uds

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/http-connection.en.rst
@@ -127,6 +127,9 @@ HTTP Connection
 .. ts:stat:: global proxy.process.http.total_client_connections_ipv6 integer
    :type: counter
 
+.. ts:stat:: global proxy.process.http.total_client_connections_uds integer
+   :type: counter
+
 .. ts:stat:: global proxy.process.http.total_incoming_connections integer
    :type: counter
 

--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -258,6 +258,7 @@ struct HttpStatsBlock {
   Metrics::Counter::AtomicType *total_client_connections;
   Metrics::Counter::AtomicType *total_client_connections_ipv4;
   Metrics::Counter::AtomicType *total_client_connections_ipv6;
+  Metrics::Counter::AtomicType *total_client_connections_uds;
   Metrics::Counter::AtomicType *total_incoming_connections;
   Metrics::Counter::AtomicType *total_parent_marked_down_count;
   Metrics::Counter::AtomicType *total_parent_proxy_connections;

--- a/src/proxy/http/Http1ClientSession.cc
+++ b/src/proxy/http/Http1ClientSession.cc
@@ -183,8 +183,11 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   case AF_INET6:
     Metrics::Counter::increment(http_rsb.total_client_connections_ipv6);
     break;
+  case AF_UNIX:
+    Metrics::Counter::increment(http_rsb.total_client_connections_uds);
+    break;
   default:
-    // don't do anything if the address family is not ipv4 or ipv6
+    // don't do anything if the address family is not ipv4, ipv6, or unix domain socket
     // (there are many other address families in <sys/socket.h>
     // but we don't have a need to report on all the others today)
     break;

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -486,6 +486,7 @@ register_stat_callbacks()
   http_rsb.total_client_connections          = Metrics::Counter::createPtr("proxy.process.http.total_client_connections");
   http_rsb.total_client_connections_ipv4     = Metrics::Counter::createPtr("proxy.process.http.total_client_connections_ipv4");
   http_rsb.total_client_connections_ipv6     = Metrics::Counter::createPtr("proxy.process.http.total_client_connections_ipv6");
+  http_rsb.total_client_connections_uds      = Metrics::Counter::createPtr("proxy.process.http.total_client_connections_uds");
   http_rsb.total_incoming_connections        = Metrics::Counter::createPtr("proxy.process.http.total_incoming_connections");
   http_rsb.total_parent_marked_down_count    = Metrics::Counter::createPtr("proxy.process.http.total_parent_marked_down_count");
   http_rsb.total_parent_proxy_connections    = Metrics::Counter::createPtr("proxy.process.http.total_parent_proxy_connections");


### PR DESCRIPTION
We currently have `proxy.process.http.total_client_connections_ipv4` and `proxy.process.http.total_client_connections_ipv6`. The new metric is for Unix Domain Socket.