### PR TITLE
Add nullptr check in HttpTransact::is_stale_cache_response_returnable

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -5944,6 +5944,10 @@ HttpTransact::is_cache_response_returnable(State *s)
 bool
 HttpTransact::is_stale_cache_response_returnable(State *s)
 {
+  if (s->cache_info.object_read == nullptr) {
+    return false;
+  }
+
   HTTPHdr *cached_response = s->cache_info.object_read->response_get();
 
   // First check if client allows cached response


### PR DESCRIPTION
We faced a crash in the `HttpTransact::is_stale_cache_response_returnable`.

```
(gdb) bt
#0  0x000055ab30944655 in HttpTransact::is_stale_cache_response_returnable (s=0x7f4c475fc108) at /src/proxy/http/HttpTransact.cc:5948
#1  0x000055ab30945e58 in HttpTransact::OSDNSLookup (s=0x7f4c475fc108) at /src/proxy/http/HttpTransact.cc:1919
#2  0x000055ab309074a7 in HttpSM::call_transact_and_set_next_state (this=0x7f4c475fc000, f=<optimized out>) at /src/proxy/http/HttpSM.cc:7825
#3  0x000055ab30920942 in HttpSM::do_hostdb_lookup (this=0x7f4c475fc000) at /src/proxy/http/HttpSM.cc:4450
#4  0x000055ab3090d839 in HttpSM::state_api_callout (this=0x7f4c475fc000, event=<optimized out>) at /src/proxy/http/HttpSM.cc:1488
#5  0x000055ab3090c9a1 in HttpSM::state_api_callback (this=0x7f4c475fc000, event=60000, data=<optimized out>) at /src/proxy/http/HttpSM.cc:1295
#6  0x00007f6cb7b4b3b4 in TSHttpTxnReenable (txnp=0x7f4c475fc000, event=TS_EVENT_HTTP_CONTINUE) at /src/api/InkAPI.cc:4949
...
(gdb) p s->cache_info.object_read
$1 = (HTTPInfo *) 0x0
```

- version: 10.0.4
