### PR TITLE
Allow PACKAGE_VERSION override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,7 +614,11 @@ endif()
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/lib64")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-add_compile_definitions(${HOST_OS} PACKAGE_NAME="Apache Traffic Server" PACKAGE_VERSION="${TS_VERSION_STRING}")
+add_compile_definitions(${HOST_OS} PACKAGE_NAME="Apache Traffic Server")
+if(NOT DEFINED PACKAGE_VERSION)
+  set(PACKAGE_VERSION "${TS_VERSION_STRING}")
+endif()
+add_compile_definitions(PACKAGE_VERSION="${PACKAGE_VERSION}")
 add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
 
 # Enable fuzzing

--- a/rc/CMakeLists.txt
+++ b/rc/CMakeLists.txt
@@ -16,7 +16,9 @@
 #######################
 
 set(PACKAGE_NAME "Apache Traffic Server")
-set(PACKAGE_VERSION ${TS_VERSION_STRING})
+if(NOT DEFINED PACKAGE_VERSION)
+  set(PACKAGE_VERSION ${TS_VERSION_STRING})
+endif()
 set(PACKAGE_BUGREPORT "dev@trafficserver.apache.org")
 
 # TODO: Use layouts


### PR DESCRIPTION
Allow a user to override PACKAGE_VERSION via -DPACKAGE_VERSION= on the commandline.