### PR TITLE
[compress] Fix compressible-status-code config

### DIFF
--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -248,6 +248,8 @@ HostConfiguration::add_compression_algorithms(string &line)
 void
 HostConfiguration::add_compressible_status_codes(string &line)
 {
+  compressible_status_codes_.clear();
+
   for (;;) {
     string token = extractFirstToken(line, isCommaOrSpace);
     if (token.empty()) {


### PR DESCRIPTION
The [`compressible-status-code`](https://docs.trafficserver.apache.org/en/10.0.x/admin-guide/plugins/compress.en.html#compressible-status-code) config of compress plugin doesn't work as expected. Because the set of status code has default value but it's not cleared before insert. So setting like `compressible-status-code 200,304` doesn't update the set.

https://github.com/apache/trafficserver/blob/07888c0aa85523871a9adb39b11e1075cc0a4d62/plugins/compress/configuration.h#L155-L156