### PR TITLE
Cleanup rc/trafficserver to use layout

### DIFF
--- a/cmake/layout.cmake
+++ b/cmake/layout.cmake
@@ -64,18 +64,35 @@ set(CMAKE_INSTALL_LOGDIR
 )
 # Since CMAKE_INSTALL_LOGDIR is custom, GNUInstallDirs doesn't know to creat a
 # FULL version of it automatically for us.
-set(CMAKE_INSTALL_FULL_LOGDIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LOGDIR}"
-    CACHE STRING "full logdir"
-)
+cmake_path(IS_ABSOLUTE CMAKE_INSTALL_LOGDIR isabs)
+if(isabs)
+  set(CMAKE_INSTALL_FULL_LOGDIR
+      "${CMAKE_INSTALL_LOGDIR}"
+      CACHE STRING "full logdir"
+  )
+else()
+  set(CMAKE_INSTALL_FULL_LOGDIR
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LOGDIR}"
+      CACHE STRING "full logdir"
+  )
+endif()
+
 set(CMAKE_INSTALL_CACHEDIR
     "${CMAKE_INSTALL_LOCALSTATEDIR}/trafficserver"
     CACHE STRING "cachedir"
 )
 # Since CMAKE_INSTALL_CACHEDIR is custom, GNUInstallDirs doesn't know to creat a
 # FULL version of it automatically for us.
-set(CMAKE_INSTALL_FULL_CACHEDIR
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_CACHEDIR}"
-    CACHE STRING "full cachedir"
-)
+cmake_path(IS_ABSOLUTE CMAKE_INSTALL_CACHEDIR isabs)
+if(isabs)
+  set(CMAKE_INSTALL_FULL_CACHEDIR
+      "${CMAKE_INSTALL_CACHEDIR}"
+      CACHE STRING "full cachedir"
+  )
+else()
+  set(CMAKE_INSTALL_FULL_CACHEDIR
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_CACHEDIR}"
+      CACHE STRING "full cachedir"
+  )
+endif()
 include(GNUInstallDirs)

--- a/rc/CMakeLists.txt
+++ b/rc/CMakeLists.txt
@@ -19,11 +19,10 @@ set(PACKAGE_NAME "Apache Traffic Server")
 set(PACKAGE_VERSION ${TS_VERSION_STRING})
 set(PACKAGE_BUGREPORT "dev@trafficserver.apache.org")
 
-# TODO: Use layouts
 set(prefix ${CMAKE_INSTALL_PREFIX})
-set(exp_bindir ${CMAKE_INSTALL_PREFIX}/bin)
-set(exp_runtimedir ${CMAKE_INSTALL_PREFIX}/var/trafficserver)
-set(exp_logdir ${CMAKE_INSTALL_PREFIX}/var/log/trafficserver)
+set(exp_bindir ${CMAKE_INSTALL_FULL_BINDIR})
+set(exp_runtimedir ${CMAKE_INSTALL_FULL_RUNSTATEDIR})
+set(exp_logdir ${CMAKE_INSTALL_FULL_LOGDIR})
 set(pkgsysuser ${TS_PKGSYSUSER})
 set(pkgsysgroup ${TS_PKGSYSGROUP})
 


### PR DESCRIPTION
Also fixes `CMAKE_INSTALL_FULL_LOGDIR` when logdir is an absolute path.