### PR TITLE
[compress] Add an option to do not compress partial object

### DIFF
--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -108,19 +108,25 @@ range-request
 
 This config controls behavior of this plugin when a client send ``Range`` header and ``Accept-Encoding`` header in the same time.
 
-============== =================================================================
-Value          Description
-============== =================================================================
-ignore-range   Remove ``Range`` header if the request has both headers (Default)
-false          Same as ``ignore-range`` for compatiblity
-no-compression Remove ``Accept-Encoding`` header if the request has both headers
-none           Do nothing
-true           Same as ``none`` for compatibility
-============== =================================================================
+====================== =================================================================
+Value                  Description
+====================== =================================================================
+none                   Do nothing
+true                   Same as ``none`` for compatibility
+remove-range           Remove ``Range`` header if the request has both headers
+remove-accept-encoding Remove ``Accept-Encoding`` header if the request has both headers
+no-compression         Do NOT compress Partial Content (default)
+false                  Same as ``no-compression`` for compatiblity
+====================== =================================================================
 
 .. important::
 
    Do NOT set this to ``none`` (or ``true``) if the cache config is set to ``false``. This combination will deliver corrupted content.
+
+
+.. important::
+
+   Some plugins (like cache_range_request) remove ``Range`` header. If you set ``remove-range`` or ``remove-accept-encoding``, be careful with the order of plugins.
 
 compressible-content-type
 -------------------------

--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -270,16 +270,22 @@ HostConfiguration::compression_algorithms()
   return compression_algorithms_;
 }
 
+/**
+  "true" and "false" are compatibility with old version, will be removed
+ */
 void
 HostConfiguration::set_range_request(const std::string &token)
 {
-  // "true" and "false" are compatibility with old version, will be removed
-  if (token == "false" || token == "ignore-range") {
-    range_request_ctl_ = RangeRequestCtrl::IGNORE_RANGE;
-  } else if (token == "true" || token == "none") {
+  if (token == "true" || token == "none") {
     range_request_ctl_ = RangeRequestCtrl::NONE;
-  } else if (token == "no-compression") {
+  } else if (token == "false" || token == "no-compression") {
     range_request_ctl_ = RangeRequestCtrl::NO_COMPRESSION;
+  } else if (token == "remove-range") {
+    range_request_ctl_ = RangeRequestCtrl::REMOVE_RANGE;
+  } else if (token == "remove-accept-encoding") {
+    range_request_ctl_ = RangeRequestCtrl::REMOVE_ACCEPT_ENCODING;
+  } else {
+    error("invalid token for range_request: %s", token.c_str());
   }
 }
 

--- a/plugins/compress/configuration.h
+++ b/plugins/compress/configuration.h
@@ -42,9 +42,10 @@ enum CompressionAlgorithm {
 };
 
 enum class RangeRequestCtrl : int {
-  IGNORE_RANGE   = 0, ///< Ignore Range Header (default)
-  NO_COMPRESSION = 1, ///< Do NOT compress if it's a range request
-  NONE           = 2, ///< Do nothing
+  NONE                   = 0, ///< Do nothing
+  NO_COMPRESSION         = 1, ///< Do NOT compress Partial Content (default)
+  REMOVE_RANGE           = 2, ///< Remove Range Header
+  REMOVE_ACCEPT_ENCODING = 3, ///< Remove Accept-Encoding Header
 };
 
 class HostConfiguration : private atscppapi::noncopyable
@@ -148,7 +149,7 @@ private:
   int          compression_algorithms_;
   unsigned int minimum_content_length_;
 
-  RangeRequestCtrl range_request_ctl_{RangeRequestCtrl::IGNORE_RANGE};
+  RangeRequestCtrl range_request_ctl_ = RangeRequestCtrl::NO_COMPRESSION;
   StringContainer  compressible_content_types_;
   StringContainer  allows_;
   // maintain backwards compatibility/usability out of the box

--- a/tests/gold_tests/pluginTest/compress/compress-range.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress-range.test.py
@@ -42,13 +42,23 @@ class CompressPluginTest:
                 "proxy.config.http.insert_response_via_str": 2,
             })
 
-        self.ts.Setup.Copy("etc/cache-true-ignore-range.config")
+        self.ts.Setup.Copy("etc/cache-true-remove-range.config")
+        self.ts.Setup.Copy("etc/cache-true-remove-accept-encoding.config")
         self.ts.Setup.Copy("etc/cache-true-no-compression.config")
 
         self.ts.Disk.remap_config.AddLines(
             {
-                f"map /cache-true-ignore-range/ http://127.0.0.1:{self.server.Variables.http_port}/ @plugin=compress.so @pparam={Test.RunDirectory}/cache-true-ignore-range.config",
-                f"map /cache-true-no-compression/ http://127.0.0.1:{self.server.Variables.http_port}/ @plugin=compress.so @pparam={Test.RunDirectory}/cache-true-no-compression.config",
+                f"""
+map /cache-true-remove-range/ http://127.0.0.1:{self.server.Variables.http_port}/ \
+    @plugin=compress.so \
+    @pparam={Test.RunDirectory}/cache-true-remove-range.config
+map /cache-true-remove-accept-encoding/ http://127.0.0.1:{self.server.Variables.http_port}/ \
+    @plugin=compress.so \
+    @pparam={Test.RunDirectory}/cache-true-remove-accept-encoding.config
+map /cache-true-no-compression/ http://127.0.0.1:{self.server.Variables.http_port}/ \
+    @plugin=compress.so \
+    @pparam={Test.RunDirectory}/cache-true-no-compression.config
+"""
             })
 
     def run(self):

--- a/tests/gold_tests/pluginTest/compress/etc/cache-true-remove-accept-encoding.config
+++ b/tests/gold_tests/pluginTest/compress/etc/cache-true-remove-accept-encoding.config
@@ -1,5 +1,5 @@
 cache true
-range-request ignore-range
+range-request remove-accept-encoding
 compressible-content-type application/json
 supported-algorithms gzip
 minimum-content-length 0

--- a/tests/gold_tests/pluginTest/compress/etc/cache-true-remove-range.config
+++ b/tests/gold_tests/pluginTest/compress/etc/cache-true-remove-range.config
@@ -1,0 +1,5 @@
+cache true
+range-request remove-range
+compressible-content-type application/json
+supported-algorithms gzip
+minimum-content-length 0

--- a/tests/gold_tests/pluginTest/compress/replay/compress-and-range.replay.yaml
+++ b/tests/gold_tests/pluginTest/compress/replay/compress-and-range.replay.yaml
@@ -45,14 +45,14 @@ sessions:
   #
   # ```
   # cache true
-  # range-request ignore-range
+  # range-request remove-range
   #```
   #
   # 1-1: Accept-Encoding only
   - client-request:
       method: "GET"
       version: "1.1"
-      url: /cache-true-ignore-range/
+      url: /cache-true-remove-range/
       headers:
         fields:
           - [ uuid, 1-1]
@@ -73,7 +73,7 @@ sessions:
   - client-request:
       method: "GET"
       version: "1.1"
-      url: /cache-true-ignore-range/
+      url: /cache-true-remove-range/
       headers:
         fields:
           - [ uuid, 1-2]
@@ -98,7 +98,7 @@ sessions:
   - client-request:
       method: "GET"
       version: "1.1"
-      url: /cache-true-ignore-range/
+      url: /cache-true-remove-range/
       headers:
         fields:
           - [ uuid, 1-3]
@@ -125,14 +125,14 @@ sessions:
   #
   # ```
   # cache true
-  # range-request no-compression
+  # range-request remove-accept-encoding
   #```
   #
   # 2-1: Range and Accept-Encoding
   - client-request:
       method: "GET"
       version: "1.1"
-      url: /cache-true-no-compression/
+      url: /cache-true-remove-accept-encoding/
       headers:
         fields:
           - [ uuid, 2-1]
@@ -144,6 +144,40 @@ sessions:
       headers:
         fields:
           - [ Range, { as: present } ]
+
+    server-response:
+      <<: *origin-server-response-206
+
+    proxy-response:
+      status: 206
+      headers:
+        fields:
+          - [ Content-Length, { value: 10, as: equal } ]
+
+  # Test Case 3
+  #
+  # ```
+  # cache true
+  # range-request no-compression
+  #```
+  #
+  # 3-1: Range and Accept-Encoding
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /cache-true-no-compression/
+      headers:
+        fields:
+          - [ uuid, 3-1]
+          - [ Host, example.com ]
+          - [ Range, 0-9 ]
+          - [ Accept-Encoding, gzip ]
+
+    proxy-request:
+      headers:
+        fields:
+          - [ Range, { as: present } ]
+          - [ Accept-Encoding, { as: present } ]
 
     server-response:
       <<: *origin-server-response-206


### PR DESCRIPTION
During https://github.com/apache/trafficserver/pull/11975 test, we found that new configs doesn't work as expected if other plugins (like `cache_range_request`) run first and remove `Range` header from client request.

Also, @vmamidi wants to send both of `Range` and `Accept-Encoding` headers to allow origin server to return "partial content of compressed content".

This PR clarify name of current options and add a new option to do not compress partial object.