### PR TITLE
header_rewrite: Add set-plugin-cntl

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1073,6 +1073,22 @@ TXN_DEBUG        Enable transaction debugging (default: ``off``)
 SKIP_REMAP       Don't require a remap match for the transaction (default: ``off``)
 ================ ====================================================================
 
+set-plugin-cntl
+~~~~~~~~~~~~~~~
+::
+
+  set-plugin-cntl <controller> <value>
+
+This operator lets you control the fundamental behavior of this plugin for a particular transaction.
+The available controllers are:
+
+================== ===================== =============================================================================================
+Controller         Operators/Conditions  Description
+================== ===================== =============================================================================================
+TIMEZONE           ``NOW``               If ``GMT`` is passed, the operators and conditions use GMT regardles of the timezone setting
+                                         on your system. The default value is ``LOCAL``.
+================== ===================== =============================================================================================
+
 Operator Flags
 --------------
 

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -659,7 +659,7 @@ ConditionTransactCount::append_value(std::string &s, Resources const &res)
 // Time related functionality for statements. We return an int64_t here, to assure that
 // gettimeofday() / Epoch does not lose bits.
 int64_t
-ConditionNow::get_now_qualified(NowQualifiers qual) const
+ConditionNow::get_now_qualified(NowQualifiers qual, const Resources &resources) const
 {
   time_t now;
 
@@ -670,7 +670,14 @@ ConditionNow::get_now_qualified(NowQualifiers qual) const
   } else {
     struct tm res;
 
-    localtime_r(&now, &res);
+    PrivateSlotData private_data;
+    private_data.raw = reinterpret_cast<uint64_t>(TSUserArgGet(resources.txnp, _txn_private_slot));
+    if (private_data.timezone == 1) {
+      gmtime_r(&now, &res);
+    } else {
+      localtime_r(&now, &res);
+    }
+
     switch (qual) {
     case NOW_QUAL_YEAR:
       return static_cast<int64_t>(res.tm_year + 1900); // This makes more sense
@@ -741,16 +748,16 @@ ConditionNow::set_qualifier(const std::string &q)
 }
 
 void
-ConditionNow::append_value(std::string &s, const Resources & /* res ATS_UNUSED */)
+ConditionNow::append_value(std::string &s, const Resources &res)
 {
-  s += std::to_string(get_now_qualified(_now_qual));
+  s += std::to_string(get_now_qualified(_now_qual, res));
   Dbg(pi_dbg_ctl, "Appending NOW() to evaluation value -> %s", s.c_str());
 }
 
 bool
-ConditionNow::eval(const Resources & /* res ATS_UNUSED */)
+ConditionNow::eval(const Resources &res)
 {
-  int64_t now = get_now_qualified(_now_qual);
+  int64_t now = get_now_qualified(_now_qual, res);
 
   Dbg(pi_dbg_ctl, "Evaluating NOW()");
   return static_cast<const MatcherType *>(_matcher)->test(now);

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -404,8 +404,14 @@ public:
 protected:
   bool eval(const Resources &res) override;
 
+  bool
+  need_txn_private_slot() const override
+  {
+    return true;
+  }
+
 private:
-  int64_t       get_now_qualified(NowQualifiers qual) const;
+  int64_t       get_now_qualified(NowQualifiers qual, const Resources &res) const;
   NowQualifiers _now_qual = NOW_QUAL_EPOCH;
 };
 

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -75,6 +75,8 @@ operator_factory(const std::string &op)
     o = new OperatorSetBody();
   } else if (op == "set-http-cntl") {
     o = new OperatorSetHttpCntl();
+  } else if (op == "set-plugin-cntl") {
+    o = new OperatorSetPluginCntl();
   } else if (op == "run-plugin") {
     o = new OperatorRunPlugin();
   } else if (op == "set-body-from") {

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1194,6 +1194,57 @@ OperatorSetHttpCntl::exec(const Resources &res) const
 }
 
 void
+OperatorSetPluginCntl::initialize(Parser &p)
+{
+  Operator::initialize(p);
+  const std::string &name  = p.get_arg();
+  const std::string &value = p.get_value();
+
+  if (name == "TIMEZONE") {
+    _name = PluginCtrl::TIMEZONE;
+    if (value == "LOCAL") {
+      _value = TIMEZONE_LOCAL;
+    } else if (value == "GMT") {
+      _value = TIMEZONE_GMT;
+    } else {
+      TSError("[%s] Unknown value for TIMZEONE control: %s", PLUGIN_NAME, value.c_str());
+    }
+  }
+}
+
+// This operator should be allowed everywhere
+void
+OperatorSetPluginCntl::initialize_hooks()
+{
+  add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
+  add_allowed_hook(TS_HTTP_READ_RESPONSE_HDR_HOOK);
+  add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
+  add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
+  add_allowed_hook(TS_HTTP_PRE_REMAP_HOOK);
+  add_allowed_hook(TS_HTTP_SEND_REQUEST_HDR_HOOK);
+  add_allowed_hook(TS_HTTP_TXN_CLOSE_HOOK);
+  add_allowed_hook(TS_HTTP_TXN_START_HOOK);
+}
+
+bool
+OperatorSetPluginCntl::exec(const Resources &res) const
+{
+  PrivateSlotData private_data;
+  private_data.raw = reinterpret_cast<uint64_t>(TSUserArgGet(res.txnp, _txn_private_slot));
+
+  switch (_name) {
+  case PluginCtrl::TIMEZONE:
+    private_data.timezone = _value;
+    break;
+  }
+
+  Dbg(pi_dbg_ctl, "   Setting plugin control %d to %d", _name, _value);
+  TSUserArgSet(res.txnp, _txn_private_slot, reinterpret_cast<void *>(private_data.raw));
+
+  return true;
+}
+
+void
 OperatorRunPlugin::initialize(Parser &p)
 {
   Operator::initialize(p);

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1238,7 +1238,7 @@ OperatorSetPluginCntl::exec(const Resources &res) const
     break;
   }
 
-  Dbg(pi_dbg_ctl, "   Setting plugin control %d to %d", _name, _value);
+  Dbg(pi_dbg_ctl, "   Setting plugin control %d to %d", static_cast<int>(_name), _value);
   TSUserArgSet(res.txnp, _txn_private_slot, reinterpret_cast<void *>(private_data.raw));
 
   return true;

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -453,6 +453,36 @@ private:
   TSHttpCntlType _cntl_qual;
 };
 
+class OperatorSetPluginCntl : public Operator
+{
+public:
+  OperatorSetPluginCntl() { Dbg(dbg_ctl, "Calling CTOR for OperatorSetPluginCntl"); }
+
+  // noncopyable
+  OperatorSetPluginCntl(const OperatorSetPluginCntl &) = delete;
+  void operator=(const OperatorSetPluginCntl &)        = delete;
+
+  void initialize(Parser &p) override;
+
+  enum class PluginCtrl {
+    TIMEZONE,
+  };
+
+protected:
+  void initialize_hooks() override;
+  bool exec(const Resources &res) const override;
+
+  bool
+  need_txn_private_slot() const override
+  {
+    return true;
+  }
+
+private:
+  PluginCtrl _name;
+  int        _value;
+};
+
 class RemapPluginInst; // Opaque to the HRW operator, but needed in the implementation.
 
 class OperatorRunPlugin : public Operator

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -155,6 +155,7 @@ public:
     TSReleaseAssert(_initialized == false);
     initialize_hooks();
     acquire_txn_slot();
+    acquire_txn_private_slot();
 
     _initialized = true;
   }
@@ -184,14 +185,31 @@ protected:
     return false;
   }
 
-  Statement *_next     = nullptr; // Linked list
-  int        _txn_slot = -1;
+  virtual bool
+  need_txn_private_slot() const
+  {
+    return false;
+  }
+
+  Statement *_next             = nullptr; // Linked list
+  int        _txn_slot         = -1;
+  int        _txn_private_slot = -1;
 
 private:
   void acquire_txn_slot();
+  void acquire_txn_private_slot();
 
   ResourceIDs               _rsrc = RSRC_NONE;
   TSHttpHookID              _hook = TS_HTTP_READ_RESPONSE_HDR_HOOK;
   std::vector<TSHttpHookID> _allowed_hooks;
   bool                      _initialized = false;
 };
+
+union PrivateSlotData {
+  uint64_t raw;
+  struct {
+    uint64_t timezone : 1; // TIMEZONE_LOCAL, or TIMEZONE_GMT
+  };
+};
+
+enum { TIMEZONE_LOCAL, TIMEZONE_GMT };


### PR DESCRIPTION
I was surprised that `%{NOW}` in header rewrite rules does not always use GMT.
https://github.com/apache/trafficserver/blob/ce7287b906b07fdfebdce13b91a92b4e13fa7d59/doc/admin-guide/plugins/header_rewrite.en.rst?plain=1#L560-L565

The new operator, `set-plugin-cntl`, enables users to change fundamental behavior of header_rewrite plugin. I added `TIMEZONE` controller for now. You can use it like below to use GMT regardless of system setting.

```
cond %{SEND_RESPONSE_HDR_HOOK}
  set-plugin-cntl TIMEZONE GMT
  set-header hour %{NOW:HOUR}
```

I made this new operator applicable for other things because there's at least one more thing I want to change.