### PR TITLE
Doc updates to prepare for Sphinx 8

### DIFF
--- a/doc/admin-guide/plugins/txn_box/dev/dev-guide.en.rst
+++ b/doc/admin-guide/plugins/txn_box/dev/dev-guide.en.rst
@@ -33,11 +33,3 @@ This section is for C++ developers working on or with |TxB|.
    memory-management.en
    dev-extractor.en
    dev-directive.en
-
-Reference
-*********
-
-.. toctree::
-   :maxdepth: 1
-
-   class-reference.en

--- a/doc/admin-guide/plugins/txn_box/misc.en.rst
+++ b/doc/admin-guide/plugins/txn_box/misc.en.rst
@@ -386,11 +386,3 @@ Mutual TLS
 
 Control remapping based on whether the user agent provided a TLS certificate, whether the
 certificate was verified, and whether the SNI name is in a whitelist.
-
-.. rubric:: Footnotes
-
-.. [*]
-
-   Literals are treated internally as extractors that "extract" the literal string. In practice every
-   feature string is an array of extractors.
-

--- a/doc/developer-guide/cache-architecture/architecture.en.rst
+++ b/doc/developer-guide/cache-architecture/architecture.en.rst
@@ -390,7 +390,7 @@ if needed to store the object.
    ``Doc`` layout 3.2.0
 
 This had the problem that with only one fragment table it could not be reliable
-for objects with more than one alternate[#multiple-alternates]_. Therefore, the
+for objects with more than one alternate [#multiple-alternates]_. Therefore, the
 fragment data was moved from being a separate variable length section of the
 metadata to being directly incorporated in to the :cpp:class:`CacheHTTPInfoVector`,
 yielding a layout of the following form.
@@ -720,7 +720,7 @@ The set of things which can affect cacheability are:
 * Plugin operations.
 
 The initial internal checks, along with their :file:`records.yaml`
-overrides[#cacheability-overrides]_, are done in ``HttpTransact::is_request_cache_lookupable``.
+overrides [#cacheability-overrides]_, are done in ``HttpTransact::is_request_cache_lookupable``.
 
 The checks that are done are:
 


### PR DESCRIPTION
This fixes issues that Sphinx 8 highlights with our footnotes and references. This patch is in preparation of updating to Sphinx 8, which will be in a separate PR.

This patch addresses:

* The txn-box class-reference.en was referenced from multiple layers of the txn-box toc tree, which Sphinx 8 allerted to being a problem. Sphinx assumes a single parent for each entry in a toc. Before I assume it silently choose one over the other. It seems not needed in dev-guide to me, so I simply removed it from there.
* txn_box/misc.en.rst had an unreferenced footnote which this patch removes.
* cache-architecture/architecture.en.rst had two broken footnote references because there wasn't a space between the previous word and the footnote. Sphinx requires this space for the footnote to work.