### PR TITLE
Sphinx 8.x and sphinx-rtd-theme 3.x

### DIFF
--- a/doc/Pipfile
+++ b/doc/Pipfile
@@ -27,9 +27,9 @@ verify_ssl = true
 # If not, we will often face issues when Sphinx updates their version before
 # sphinx-rtd-theme has had time to update their component for the new sphinx
 # version.
-sphinx = "==6.1.3"
+sphinx = "==8.2.3"
 
-sphinx-rtd-theme = "==1.*"
+sphinx-rtd-theme = "==3.*"
 sphinxcontrib-jquery = "*"
 sphinxcontrib-plantuml = "*"
 # i18n

--- a/doc/conf.cmake.in.py
+++ b/doc/conf.cmake.in.py
@@ -141,7 +141,6 @@ else:
     try:
         import sphinx_rtd_theme
         html_theme = 'sphinx_rtd_theme'
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     except Exception:
         pass
 # End of HACK

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -145,7 +145,6 @@ else:
     try:
         import sphinx_rtd_theme
         html_theme = 'sphinx_rtd_theme'
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     except Exception:
         pass
 # End of HACK


### PR DESCRIPTION
This updates Sphinx to version 8 and sphinx-rtd-theme to 3.x. This has the advantage of additional warnings that can catch some of our mistakes and adds support for building on Python 3.13.

When considering backporting, note that this requires the docs fixes from #12132.