### PR TITLE
Assert safety of evacuate size type at compilation

### DIFF
--- a/src/iocore/cache/PreservationTable.cc
+++ b/src/iocore/cache/PreservationTable.cc
@@ -37,6 +37,7 @@
 
 #include <cinttypes>
 #include <cstring>
+#include <limits>
 
 namespace
 {
@@ -47,6 +48,7 @@ DbgCtl dbg_ctl_cache_evac{"cache_evac"};
 
 PreservationTable::PreservationTable(off_t size) : evacuate_size{static_cast<int>(size / EVACUATION_BUCKET_SIZE) + 2}
 {
+  static_assert(MAX_STRIPE_SIZE / EVACUATION_BUCKET_SIZE + 2 <= std::numeric_limits<decltype(evacuate_size)>::max());
   ink_assert(size > 0);
   int evac_len   = this->evacuate_size * sizeof(DLL<EvacuationBlock>);
   this->evacuate = static_cast<DLL<EvacuationBlock> *>(ats_malloc(evac_len));

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -43,6 +43,10 @@
 #define ROUND_TO_SECTOR(_p, _x)  INK_ALIGN((_x), _p->sector_size)
 #define ROUND_TO(_x, _y)         INK_ALIGN((_x), (_y))
 
+#define STRIPE_BLOCK_SIZE (1024 * 1024 * 128) // 128MB
+#define MIN_STRIPE_SIZE   STRIPE_BLOCK_SIZE
+#define MAX_STRIPE_SIZE   ((off_t)512 * 1024 * 1024 * 1024 * 1024) // 512TB
+
 // This is defined here so CacheVC can avoid including StripeSM.h.
 #define RECOVERY_SIZE EVACUATION_SIZE // 8MB
 

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -41,10 +41,7 @@
 #define STRIPE_MAGIC                 0xF1D0F00D
 #define START_BLOCKS                 16 // 8k, STORE_BLOCK_SIZE
 #define START_POS                    ((off_t)START_BLOCKS * CACHE_BLOCK_SIZE)
-#define STRIPE_BLOCK_SIZE            (1024 * 1024 * 128) // 128MB
-#define MIN_STRIPE_SIZE              STRIPE_BLOCK_SIZE
-#define MAX_STRIPE_SIZE              ((off_t)512 * 1024 * 1024 * 1024 * 1024) // 512TB
-#define MAX_FRAG_SIZE                (AGG_SIZE - sizeof(Doc))                 // true max
+#define MAX_FRAG_SIZE                (AGG_SIZE - sizeof(Doc)) // true max
 #define LEAVE_FREE                   DEFAULT_MAX_BUFFER_SIZE
 #define STRIPE_HASH_TABLE_SIZE       32707
 #define STRIPE_HASH_EMPTY            0xFFFF


### PR DESCRIPTION
This would not have caught #12124, but by drawing attention to the risk of the narrowing cast, it may prevent a regression. The point of this is moreso to document that the current cast is indeed safe.