### PR TITLE
Fix a bug that PPv2 parser fails to read TLV

### DIFF
--- a/src/iocore/net/ProxyProtocol.cc
+++ b/src/iocore/net/ProxyProtocol.cc
@@ -291,7 +291,7 @@ proxy_protocol_v2_parse(ProxyProtocol *pp_info, const swoc::TextView &msg)
     }
 
     if (tlv_len > 0) {
-      if (pp_info->set_additional_data(msg.substr(msg.length() - tlv_len)) < 0) {
+      if (pp_info->set_additional_data(msg.substr(total_len - tlv_len, tlv_len)) < 0) {
         return 0;
       }
     }

--- a/src/iocore/net/unit_tests/test_ProxyProtocol.cc
+++ b/src/iocore/net/unit_tests/test_ProxyProtocol.cc
@@ -329,6 +329,40 @@ TEST_CASE("PROXY Protocol v2 Parser", "[ProxyProtocol][ProxyProtocolv2]")
     CHECK(pp_info.tlv[PP2_TYPE_AUTHORITY] == "abc");
   }
 
+  SECTION("TLVs with extra data")
+  {
+    uint8_t raw_data[] = {
+      0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, ///< preface
+      0x55, 0x49, 0x54, 0x0A,                         ///<
+      0x21,                                           ///< version & command
+      0x11,                                           ///< protocol & family
+      0x00, 0x17,                                     ///< len
+      0xC0, 0x00, 0x02, 0x01,                         ///< src_addr
+      0xC6, 0x33, 0x64, 0x01,                         ///< dst_addr
+      0xC3, 0x50,                                     ///< src_port
+      0x01, 0xBB,                                     ///< dst_port
+      0x01, 0x00, 0x02, 0x68, 0x32,                   /// PP2_TYPE_ALPN (h2)
+      0x02, 0x00, 0x03, 0x61, 0x62, 0x63,             /// PP2_TYPE_AUTHORITY (abc)
+      0x47, 0x45, 0x54, 0x20, 0x2F                    /// Extra data (GET /)
+    };
+
+    swoc::TextView tv(reinterpret_cast<char *>(raw_data), sizeof(raw_data));
+
+    ProxyProtocol pp_info;
+    REQUIRE(proxy_protocol_parse(&pp_info, tv) == tv.size() - 5); // The extra 5 bytes at the end should not be parsed
+
+    REQUIRE(ats_ip_pton("192.0.2.1:50000", src_addr) == 0);
+    REQUIRE(ats_ip_pton("198.51.100.1:443", dst_addr) == 0);
+
+    CHECK(pp_info.version == ProxyProtocolVersion::V2);
+    CHECK(pp_info.ip_family == AF_INET);
+    CHECK(pp_info.src_addr == src_addr);
+    CHECK(pp_info.dst_addr == dst_addr);
+
+    CHECK(pp_info.tlv[PP2_TYPE_ALPN] == "h2");
+    CHECK(pp_info.tlv[PP2_TYPE_AUTHORITY] == "abc");
+  }
+
   SECTION("Malformed Headers")
   {
     ProxyProtocol pp_info;


### PR DESCRIPTION
ATS fails to read PPv2 TLV fields if the head of HTTP request follows in the same buffer.