### PR TITLE
[origin_server_auth] Fix race of config_reloader vs delete

### DIFF
--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -48,6 +48,7 @@
 #include <ts/remap.h>
 #include <ts/remap_version.h>
 #include <tsutil/TsSharedMutex.h>
+#include "ts/apidefs.h"
 #include "tscore/ink_config.h"
 #include "swoc/TextView.h"
 
@@ -552,6 +553,12 @@ public:
     if (_conf_rld_act == ((TSAction)((uintptr_t)edata | 0x1))) {
       _conf_rld_act = nullptr;
     }
+  }
+
+  TSMutex
+  config_reloader_mutex()
+  {
+    return TSContMutexGet(_conf_rld);
   }
 
   ts::shared_mutex reload_mutex;
@@ -1263,7 +1270,10 @@ void
 TSRemapDeleteInstance(void *ih)
 {
   S3Config *s3 = static_cast<S3Config *>(ih);
+  TSMutex   s3_mutex_ptr = s3->config_reloader_mutex();
+  TSMutexLock(s3_mutex_ptr);
   delete s3;
+  TSMutexUnlock(s3_mutex_ptr);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We faced below crash with ATS 9.2 and 10.0. This is possible fix for it.

```
(gdb) bt
#0  0x00007fcd0ea8ba6c in __pthread_kill_implementation () from /lib64/libc.so.6
#1  0x00007fcd0ea3e686 in raise () from /lib64/libc.so.6
#2  0x00007fcd0ea28833 in abort () from /lib64/libc.so.6
#3  0x0000564781b10fa4 in ink_abort (message_format=<optimized out>) at /src/tscore/ink_error.cc:99
#4  0x0000564781b0df85 in _ink_assert (expression=0x7fcd0ea8ba6c <__pthread_kill_implementation+284> "\211\305\367\335=", file=0x14c538 <error: Cannot access memory at address 0x14c538>, line=6) at /src/tscore/ink_assert.cc:35
#5  0x00007fcd0f6e06e9 in _TSReleaseAssert (text=0x14c50a <error: Cannot access memory at address 0x14c50a>, file=0x14c538 <error: Cannot access memory at address 0x14c538>, line=6) at /src/api/InkAPI.cc:288
#6  0x00007fcd0f6e7ba6 in TSContScheduleOnPool (contp=0x7fcb5b2cfb40, timeout=17382000, tp=TS_THREAD_POOL_TASK) at /src/api/InkAPI.cc:3375
#7  0x00007fcc19a8e1eb in config_reloader (cont=<optimized out>, edata=<optimized out>) at /plugins/origin_server_auth/origin_server_auth.cc:530
#8  0x0000564781e7a67f in INKContInternal::handle_event (this=0x7fcb5b2cfb40, event=2, edata=0x7f9786f85ac0) at /src/api/InkContInternal.cc:160
#9  0x0000564781e230a5 in Continuation::handleEvent (this=<optimized out>, event=2, data=0x7f9786f85ac0) at /include/iocore/eventsystem/Continuation.h:236
#10 EThread::process_event (this=0x7fccff741480, e=0x7f9786f85ac0, calling_code=2) at /src/iocore/eventsystem/UnixEThread.cc:162
#11 0x0000564781e23b5d in EThread::execute_regular (this=0x7fccff741480) at /src/iocore/eventsystem/UnixEThread.cc:269
#12 0x0000564781e243f8 in EThread::execute (this=0x7fccff741480) at /src/iocore/eventsystem/UnixEThread.cc:348
#13 0x0000564781e21e87 in spawn_thread_internal (a=0x7fcd0e7bb230) at /src/iocore/eventsystem/Thread.cc:75
#14 0x00007fcd0ea89d22 in start_thread () from /lib64/libc.so.6
#15 0x00007fcd0eb0ed40 in clone3 () from /lib64/libc.so.6
```

It looks like `S3Config` (has `_conf_rld`) are deleted by other thread while `config_reloader` is trying to schedule another task.

https://github.com/apache/trafficserver/blob/756c49ff52219e376bd60420e6081f64f8b5d3c7/plugins/origin_server_auth/origin_server_auth.cc#L536-L543

https://github.com/apache/trafficserver/blob/756c49ff52219e376bd60420e6081f64f8b5d3c7/plugins/origin_server_auth/origin_server_auth.cc#L1262-L1267