### PR TITLE
Cleanup - Use C++ style cast instead of the C style. Part 1.

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -641,7 +641,8 @@ dir_overwrite(const CacheKey *key, StripeSM *stripe, Dir *dir, Dir *overwrite, b
 #endif
   CHECK_DIR(d);
 
-  ink_assert((unsigned int)dir_approx_size(dir) <= (unsigned int)(MAX_FRAG_SIZE + sizeof(Doc))); // XXX - size should be unsigned
+  ink_assert(static_cast<unsigned int>(dir_approx_size(dir)) <=
+             static_cast<unsigned int>((MAX_FRAG_SIZE + sizeof(Doc)))); // XXX - size should be unsigned
 Lagain:
   // find entry to overwrite
   e = b;

--- a/src/iocore/cache/CacheWrite.cc
+++ b/src/iocore/cache/CacheWrite.cc
@@ -371,7 +371,7 @@ CacheVC::openWriteCloseHead(int event, Event *e)
   cancel_trigger();
   f.use_first_key = 1;
   if (io.ok()) {
-    ink_assert(fragment || (length == (int64_t)total_len));
+    ink_assert(fragment || (length == static_cast<int64_t>(total_len)));
   } else {
     return openWriteCloseDir(event, e);
   }

--- a/src/iocore/cache/unit_tests/test_RWW.cc
+++ b/src/iocore/cache/unit_tests/test_RWW.cc
@@ -296,7 +296,7 @@ public:
     case VC_EVENT_ERROR:
     case VC_EVENT_EOS:
       if (this->_size == LARGE_FILE) {
-        REQUIRE(base->vio->ndone >= int64_t(1 * 1024 * 1024 - sizeof(Doc)));
+        REQUIRE(base->vio->ndone >= static_cast<int64_t>(1 * 1024 * 1024 - sizeof(Doc)));
       } else {
         REQUIRE(base->vio->ndone == 0);
       }

--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -1562,7 +1562,7 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
   // Do we have an entry for this id?
   //
   if (!e || !e->written_flag) {
-    Dbg(dbg_ctl_dns, "unknown DNS id = %u", (uint16_t)ntohs(h->id));
+    Dbg(dbg_ctl_dns, "unknown DNS id = %u", static_cast<uint16_t>(ntohs(h->id)));
     return false; // cannot count this as a success
   }
   //

--- a/src/iocore/eventsystem/UnixSocket.cc
+++ b/src/iocore/eventsystem/UnixSocket.cc
@@ -83,8 +83,9 @@ accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags)
 
   do {
     fd = accept(sockfd, addr, addrlen);
-    if (likely(fd >= 0))
+    if (likely(fd >= 0)) {
       break;
+    }
   } while (transient_error());
 
   if ((fd >= 0) && (flags & SOCK_CLOEXEC) && (safe_fcntl(fd, F_SETFD, FD_CLOEXEC) < 0)) {

--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -1039,7 +1039,7 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
       if (hash.is_srv()) {
         char *pos = rr_info.rebind<char>().end();
         SRV  *q[valid_records];
-        ink_assert(valid_records <= (int)hostdb_round_robin_max_count);
+        ink_assert(valid_records <= static_cast<int>(hostdb_round_robin_max_count));
         for (int i = 0; i < valid_records; ++i) {
           q[i] = &e->srv_hosts.hosts[i];
         }

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -864,8 +864,8 @@ SSLConfigParams::updateCTX(const std::string &cert_secret_name) const
       //
       char const *s{expected};
       for (; *s && (static_cast<std::size_t>(s - expected) < cert_secret_name.size()); ++s) {}
-      DbgPrint(dbg_ctl_ssl_config_updateCTX, "Update cert, indirect recusive call caused by call for %.*s", int(s - expected),
-               expected);
+      DbgPrint(dbg_ctl_ssl_config_updateCTX, "Update cert, indirect recusive call caused by call for %.*s",
+               static_cast<int>(s - expected), expected);
     }
     return;
   }

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -170,7 +170,7 @@ debug_certificate_name(const char *msg, X509_NAME *name)
     long  len;
     char *ptr;
     len = BIO_get_mem_data(bio, &ptr);
-    Dbg(dbg_ctl_ssl, "%s %.*s", msg, (int)len, ptr);
+    Dbg(dbg_ctl_ssl, "%s %.*s", msg, static_cast<int>(len), ptr);
   }
 
   BIO_free(bio);

--- a/src/iocore/net/Socks.cc
+++ b/src/iocore/net/Socks.cc
@@ -353,7 +353,7 @@ SocksEntry::mainEvent(int event, void *data)
           break;
         default:
           reply_len = INT_MAX;
-          Dbg(dbg_ctl_Socks, "Illegal address type(%d) in Socks server", (int)p[3]);
+          Dbg(dbg_ctl_Socks, "Illegal address type(%d) in Socks server", static_cast<int>(p[3]));
         }
 
         if (vio->ndone >= reply_len) {
@@ -390,17 +390,17 @@ SocksEntry::mainEvent(int event, void *data)
       bool success;
       if (version == SOCKS5_VERSION) {
         success = (p[0] == SOCKS5_VERSION && p[1] == SOCKS5_REQ_GRANTED);
-        Dbg(dbg_ctl_Socks, "received reply of length %" PRId64 " addr type %d", ((VIO *)data)->ndone, (int)p[3]);
+        Dbg(dbg_ctl_Socks, "received reply of length %" PRId64 " addr type %d", ((VIO *)data)->ndone, static_cast<int>(p[3]));
       } else {
         success = (p[0] == 0 && p[1] == SOCKS4_REQ_GRANTED);
       }
 
       // ink_assert(*(p) == 0);
       if (!success) { // SOCKS request failed
-        Dbg(dbg_ctl_Socks, "Socks request denied %d", (int)*(p + 1));
+        Dbg(dbg_ctl_Socks, "Socks request denied %d", static_cast<int>(*(p + 1)));
         lerrno = ESOCK_DENIED;
       } else {
-        Dbg(dbg_ctl_Socks, "Socks request successful %d", (int)*(p + 1));
+        Dbg(dbg_ctl_Socks, "Socks request successful %d", static_cast<int>(*(p + 1)));
         lerrno = 0;
       }
       free();
@@ -625,12 +625,12 @@ socks5BasicAuthHandler(int event, unsigned char *p, void (**h_ptr)(void))
         break;
 
       default:
-        Dbg(dbg_ctl_Socks, "Unexpected Socks auth method (%d) from the server", (int)p[1]);
+        Dbg(dbg_ctl_Socks, "Unexpected Socks auth method (%d) from the server", static_cast<int>(p[1]));
         ret = -1;
         break;
       }
     } else {
-      Dbg(dbg_ctl_Socks, "authEvent got wrong version %d from the Socks server", (int)p[0]);
+      Dbg(dbg_ctl_Socks, "authEvent got wrong version %d from the Socks server", static_cast<int>(p[0]));
       ret = -1;
     }
 
@@ -679,7 +679,7 @@ socks5PasswdAuthHandler(int event, unsigned char *p, void (**h_ptr)(void))
       break;
 
     default:
-      Dbg(dbg_ctl_Socks, "Username/Passwd authentication failed ret_code: %d", (int)p[1]);
+      Dbg(dbg_ctl_Socks, "Username/Passwd authentication failed ret_code: %d", static_cast<int>(p[1]));
       ret = -1;
     }
 

--- a/src/proxy/hdrs/HdrToken.cc
+++ b/src/proxy/hdrs/HdrToken.cc
@@ -467,7 +467,7 @@ hdrtoken_tokenize_dfa(const char *string, int string_len, const char **wks_strin
 {
   int wks_idx;
 
-  wks_idx = hdrtoken_strs_dfa->match({string, size_t(string_len)});
+  wks_idx = hdrtoken_strs_dfa->match({string, static_cast<size_t>(string_len)});
 
   if (wks_idx < 0) {
     wks_idx = -1;

--- a/src/proxy/http/remap/RemapConfig.cc
+++ b/src/proxy/http/remap/RemapConfig.cc
@@ -869,7 +869,7 @@ remap_load_plugin(const char *const *argv, int argc, url_mapping *mp, char *errb
   memset(pargv, 0, sizeof(pargv));
   memset(new_argv, 0, sizeof(new_argv));
 
-  ink_assert((unsigned)argc < countof(new_argv));
+  ink_assert(static_cast<unsigned>(argc) < countof(new_argv));
 
   if (jump_to_argc != 0) {
     argc  -= jump_to_argc;
@@ -1341,7 +1341,7 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti)
     // the rest of the system assumes that trailing slashes have
     // been removed.
 
-    if (unlikely(fromHostLen >= (int)sizeof(fromHost_lower_buf))) {
+    if (unlikely(fromHostLen >= static_cast<int>(sizeof(fromHost_lower_buf)))) {
       fromHost_lower = (fromHost_lower_ptr = static_cast<char *>(ats_malloc(fromHostLen + 1)));
     } else {
       fromHost_lower = &fromHost_lower_buf[0];


### PR DESCRIPTION
Got some help from clang-tidy.
I have a few more, but to make small PRs let's go with this one first.