### PR TITLE
Adds convenience APIs / definitions to Cripts

### DIFF
--- a/doc/developer-guide/cripts/cripts-convenience.en.rst
+++ b/doc/developer-guide/cripts/cripts-convenience.en.rst
@@ -1,0 +1,138 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+.. include:: ../../common.defs
+
+.. highlight:: cpp
+.. default-domain:: cpp
+
+.. _cripts-convenience:
+
+Convenience APIs
+****************
+
+To make Cripts even more approachable, a set of optional convenience APIs are added
+to the core and top level name space. These APIs are not required to be used, and
+are enabled by adding a define to your Cript file (or when compiling the Cript).
+Making this addition optional allows users to choose whether they want to use
+these convenience APIs or stick with the traditional Cripts API style.
+
+The convenience APIs carries a small (very small) overhead, due to how Cripts defers
+(or delays) initializations of objects until they are actually used. These new APIs
+are designed to be as efficient as possible, but they do introduce potential conflicts
+in the top level namespace. Here's a simple example of how to enable these APIs:
+
+.. code-block:: cpp
+
+   #define CRIPT_CONVENIENCE_APIS 1
+
+   #include <cripts/Preamble.hpp>
+
+   do_remap()
+   {
+     url.query.keep({"foo", "bar"});
+   }
+
+   #include <cripts/Epilogue.hpp>
+
+
+.. _cripts-convenience-toplevel:
+
+Top level API additions
+=======================
+
+For the most common patterns, the top level API additions are ``client``, ``server``, and
+``urls``. These all have sub-level API additions, as explained in the following table:
+
+===========================   =============================================
+Object                        Traditional API equivalent
+===========================   =============================================
+``client.request``            ``borrow cripts::Client::Request::Get()``
+``client.response``           ``borrow cripts::Client::Response::Get()``
+``client.connection``         ``borrow cripts::Client::Connection::Get()``
+``server.request``            ``borrow cripts::Server::Request::Get()``
+``server.response``           ``borrow cripts::Server::Response::Get()``
+``server.connection``         ``borrow cripts::Server::Connection::Get()``
+``urls.request``              ``borrow cripts::Client::URL::Get()``
+``urls.pristine``             ``borrow cripts::Pristine::URL::Get()``
+``urls.cache``                ``borrow cripts::Cache::URL::Get()``
+``urls.parent``               ``borrow cripts::Parent::URL::Get()``
+``urls.remap.to``             ``borrow cripts::Remap::To::URL::Get``
+``urls.remap.from``           ``borrow cripts::Remap::From::URL::Get``
+===========================   =============================================
+
+The use of these top-level objects are identical to how you would use them with the traditinoal
+APIs. The following code shows both the traditional Cripts API and the new APIs in a simple
+example:
+
+.. code-block:: cpp
+
+   // Traditional Cripts API
+   do_remap()
+   {
+     borrow req = cripts::Client::Request::Get();
+     borrow url = cripts::Client::URL::Get();
+
+     url.query.Keep({"foo", "bar"});
+     req["X-Foo"] = "bar"
+   }
+
+   // Convenience API, does not need the borrow statements
+   do_remap()
+   {
+     urls.request.query.Keep({"foo", "bar"});
+     client.request["X-Foo"] = "bar";
+   }
+
+.. note::
+   The name for the classic client URL will change to ``cripts::Request::URL`` in
+   a future version of ATS, to be inline with these new convenience APIs.
+
+.. _cripts-convenience-macros:
+
+Convenience macros
+==================
+
+In addition to the top-level APIs, a set of convenience macros are provided as well,
+enabled with the same ``#define`` as above. The following macros have been added,
+which again populates in the top level namespace:
+
+===========================   ====================================================================
+Macro                         Traditional API equivalent
+===========================   ====================================================================
+``Regex(name, ...)``          ``static cripts::Matcher::PCRE name(...)``
+``ACL(name, ...)``            ``static cripts::Matcher::Range::IP name(...)``
+``CreateCounter(id, name)``   ``instance.metrics[id] = cripts::Metrics::Counter::Create(name)``
+``CreateGauge(id, name)``     ``instance.metrics[id] = cripts::Metrics::Gauge::Create(name)``
+``FilePath(name, path)``      ``static const cripts::File::Path name(path)``
+``UniqueUUID()``              ``cripts::UUID::Unique::Get()``
+``TimeNow()``                 ``cripts::Time::Local::Now()``
+===========================   ====================================================================
+
+An example of using ACLs and regular expressions:
+
+.. code-block:: cpp
+
+   do_remap()
+   {
+     Regex(rex, "^/([^/]+)/(.*)$");
+     ACL(allow, {"192.168.201.0/24", "10.0.0.0/8"});
+
+     if (allow.Match(client.connection.IP()) && rex.Match(urls.request.path)) {
+       // do something
+     }
+   }

--- a/doc/developer-guide/cripts/cripts-convenience.en.rst
+++ b/doc/developer-guide/cripts/cripts-convenience.en.rst
@@ -38,13 +38,13 @@ in the top level namespace. Here's a simple example of how to enable these APIs:
 
 .. code-block:: cpp
 
-   #define CRIPT_CONVENIENCE_APIS 1
+   #define CRIPTS_CONVENIENCE_APIS 1
 
    #include <cripts/Preamble.hpp>
 
    do_remap()
    {
-     url.query.keep({"foo", "bar"});
+     urls.request.query.Keep({"foo", "bar"});
    }
 
    #include <cripts/Epilogue.hpp>

--- a/doc/developer-guide/cripts/cripts-convenience.en.rst
+++ b/doc/developer-guide/cripts/cripts-convenience.en.rst
@@ -64,6 +64,7 @@ Object                        Traditional API equivalent
 ``client.request``            ``borrow cripts::Client::Request::Get()``
 ``client.response``           ``borrow cripts::Client::Response::Get()``
 ``client.connection``         ``borrow cripts::Client::Connection::Get()``
+``client.url``                ``borrow cripts::Client::URL::Get()``
 ``server.request``            ``borrow cripts::Server::Request::Get()``
 ``server.response``           ``borrow cripts::Server::Response::Get()``
 ``server.connection``         ``borrow cripts::Server::Connection::Get()``
@@ -99,8 +100,9 @@ example:
    }
 
 .. note::
-   The name for the classic client URL will change to ``cripts::Request::URL`` in
-   a future version of ATS, to be inline with these new convenience APIs.
+   Both ``client.url`` and `` urls.request`` refer to the same underlying object, which is
+   ``cripts::Client::URL``. This means that any changes made to ``urls.request``
+   will also be reflected in ``client.url`` and vice versa.
 
 .. _cripts-convenience-macros:
 

--- a/doc/developer-guide/cripts/cripts-global.en.rst
+++ b/doc/developer-guide/cripts/cripts-global.en.rst
@@ -50,9 +50,9 @@ depending on your preference. The file must be readable by the ATS process. Exam
 
    glb_read_request()
    {
-     borrow url = cripts::Client::URL::get();
+     borrow url = cripts::Client::URL::Get();
 
-     url.query.keep({"foo", "bar"});
+     url.query.Keep({"foo", "bar"});
    }
 
    #include <cripts/Epilogue.hpp>

--- a/doc/developer-guide/cripts/cripts-misc.en.rst
+++ b/doc/developer-guide/cripts/cripts-misc.en.rst
@@ -56,7 +56,7 @@ Example:
 
    do_remap()
    {
-     borrow req  = cripts::Client::Request::get();
+     borrow req  = cripts::Client::Request::Get();
 
      if (req["X-Header"] == "yes") {
        cripts::Error::Status::Set(403);
@@ -119,7 +119,7 @@ Example usage to turn off a particular hook conditionally:
 
    do_remap()
    {
-     static borrow req = cripts::Client::Request::get();
+     static borrow req = cripts::Client::Request::Get();
 
      if (req["X-Header"] == "yes") {
        transaction.DisableCallback(cripts::Callback::DO_READ_RESPONSE);

--- a/doc/developer-guide/cripts/cripts-overview.en.rst
+++ b/doc/developer-guide/cripts/cripts-overview.en.rst
@@ -94,9 +94,9 @@ depending on your preference. The file must be readable by the ATS process. Exam
 
    do_remap()
    {
-     borrow url = cripts::Client::URL::get();
+     borrow url = cripts::Client::URL::Get();
 
-     url.query.keep({"foo", "bar"});
+     url.query.Keep({"foo", "bar"});
    }
 
    #include <cripts/Epilogue.hpp>

--- a/doc/developer-guide/cripts/cripts-urls.en.rst
+++ b/doc/developer-guide/cripts/cripts-urls.en.rst
@@ -124,7 +124,7 @@ For example:
 
 .. code-block:: cpp
 
-  borrow url = cripts::Client::URL::get();
+  borrow url = cripts::Client::URL::Get();
 
   url.query.Erase("key"); // Removes the key from the query
   url.query.Erase({"key1", "key2"}); // Removes both keys from the query

--- a/doc/developer-guide/cripts/index.en.rst
+++ b/doc/developer-guide/cripts/index.en.rst
@@ -35,4 +35,5 @@ Cripts
    cripts-crypto.en
    cripts-misc.en
    cripts-bundles.en
+   cripts-convenience.en
    cripts-examples.en

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -59,7 +59,7 @@ do_cache_lookup()
 {
   borrow url2 = cripts::Cache::URL::Get();
 
-  CDebug("Cache URL: {}", url2.String());
+  CDebug("Cache URL: {}", url2);
   CDebug("Cache Host: {}", url2.host);
 }
 

--- a/example/cripts/example2.cc
+++ b/example/cripts/example2.cc
@@ -16,7 +16,7 @@
   limitations under the License.
 */
 
-#define CRIPT_CONVENIENCE_APIS 1
+#define CRIPTS_CONVENIENCE_APIS 1
 
 // The primary include file, this has to always be included
 #include <cripts/Preamble.hpp>
@@ -57,10 +57,8 @@ do_txn_close()
 
 do_cache_lookup()
 {
-  borrow url2 = cripts::Cache::URL::Get();
-
-  CDebug("Cache URL: {}", url2.String());
-  CDebug("Cache Host: {}", url2.host);
+  CDebug("Cache URL: {}", urls.cache);
+  CDebug("Cache Host: {}", urls.cache.host);
 }
 
 do_send_request()
@@ -122,7 +120,7 @@ do_remap()
   auto ip  = client.connection.IP();
   auto now = TimeNow();
 
-  if (CRIPT_ALLOW.contains(ip)) {
+  if (CRIPT_ALLOW.Match(ip)) {
     CDebug("Client IP allowed: {}", ip.string(24, 64));
   }
 
@@ -146,32 +144,31 @@ do_remap()
   CDebug("X-Miles = {}", client.request["X-Miles"]);
   CDebug("random(1000) = {}", cripts::Random(1000));
 
-  borrow url      = cripts::Client::URL::Get();
-  auto   old_port = url.port;
+  auto old_port = urls.request.port;
 
   CDebug("Method is {}", client.request.method);
-  CDebug("Scheme is {}", url.scheme);
-  CDebug("Host is {}", url.host);
-  CDebug("Port is {}", url.port);
-  CDebug("Path is {}", url.path);
-  CDebug("Path[1] is {}", url.path[1]);
-  CDebug("Query is {}", url.query);
+  CDebug("Scheme is {}", urls.request.scheme);
+  CDebug("Host is {}", urls.request.host);
+  CDebug("Port is {}", urls.request.port);
+  CDebug("Path is {}", urls.request.path);
+  CDebug("Path[1] is {}", urls.request.path[1]);
+  CDebug("Query is {}", urls.request.query);
 
-  auto testing_trim = url.path.trim();
+  auto testing_trim = urls.request.path.trim();
 
   CDebug("Trimmed path is {}", testing_trim);
 
-  if (url.query["foo"] > 100) {
+  if (urls.request.query["foo"] > 100) {
     CDebug("Query[foo] is > 100");
   }
 
-  if (url.path == "some/url" || url.path[0] == "other") {
+  if (urls.request.path == "some/url" || urls.request.path[0] == "other") {
     CDebug("The path comparison triggered");
   }
 
-  url.host = "foobar.com";
-  url.port = "81";
-  url.port = old_port;
+  urls.request.host = "foobar.com";
+  urls.request.port = "81";
+  urls.request.port = old_port;
 
   // TXN data slots
   txn_data[0] = true;

--- a/example/cripts/example2.cc
+++ b/example/cripts/example2.cc
@@ -16,7 +16,7 @@
   limitations under the License.
 */
 
-#define CONVENIENT_APIS 1
+#define CRIPT_CONVENIENCE_APIS 1
 
 // The primary include file, this has to always be included
 #include <cripts/Preamble.hpp>
@@ -80,7 +80,7 @@ do_send_response()
   client.response["Server"]         = "";        // Deletes the Server header
   client.response["X-AMC"]          = msg;       // New header
   client.response["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
-  client.response["X-UUID"]         = UniqueUUID;
+  client.response["X-UUID"]         = UniqueUUID();
   client.response["X-tcpinfo"]      = client.connection.tcpinfo.Log();
   client.response["X-Cache-Status"] = client.response.cache;
   client.response["X-Integer"]      = 666;

--- a/example/cripts/example2.cc
+++ b/example/cripts/example2.cc
@@ -1,0 +1,247 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#define CONVENIENT_APIS 1
+
+// The primary include file, this has to always be included
+#include <cripts/Preamble.hpp>
+
+#include <cripts/Bundles/Common.hpp>
+#include <cripts/Bundles/Caching.hpp>
+
+// Globals for this Cript
+ACL(CRIPT_ALLOW, {"192.168.201.0/24", "10.0.0.0/8"});
+
+// This is called only when the plugin is initialized
+do_init()
+{
+  // TSDebug("Cript", "Hello, example1 plugin is being initialized");
+}
+
+do_create_instance()
+{
+  CreateCounter(0, "cript.example1.c0");
+  CreateCounter(1, "cript.example1.c1");
+  CreateCounter(2, "cript.example1.c2");
+  CreateCounter(3, "cript.example1.c3");
+  CreateCounter(4, "cript.example1.c4");
+  CreateCounter(5, "cript.example1.c5");
+  CreateCounter(6, "cript.example1.c6");
+  CreateCounter(7, "cript.example1.c7");
+  CreateCounter(8, "cript.example1.c8"); // This one should resize the storage
+
+  cripts::Bundle::Common::Activate().dscp(10);
+  cripts::Bundle::Caching::Activate().cache_control("max-age=259200");
+}
+
+do_txn_close()
+{
+  client.connection.pacing = cripts::Pacing::Off;
+  CDebug("Cool, TXN close also works");
+}
+
+do_cache_lookup()
+{
+  borrow url2 = cripts::Cache::URL::Get();
+
+  CDebug("Cache URL: {}", url2.String());
+  CDebug("Cache Host: {}", url2.host);
+}
+
+do_send_request()
+{
+  server.request["X-Leif"] = "Meh";
+}
+
+do_read_response()
+{
+  server.response["X-DBJ"] = "Vrooom!";
+}
+
+do_send_response()
+{
+  string msg = "Eliminate TSCPP";
+
+  client.response["Server"]         = "";        // Deletes the Server header
+  client.response["X-AMC"]          = msg;       // New header
+  client.response["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
+  client.response["X-UUID"]         = UniqueUUID;
+  client.response["X-tcpinfo"]      = client.connection.tcpinfo.Log();
+  client.response["X-Cache-Status"] = client.response.cache;
+  client.response["X-Integer"]      = 666;
+  client.response["X-Data"]         = AsString(txn_data[2]);
+
+  client.response["X-ASN"]         = client.connection.geo.ASN();
+  client.response["X-ASN-Name"]    = client.connection.geo.ASNName();
+  client.response["X-Country"]     = client.connection.geo.Country();
+  client.response["X-ISO-Country"] = client.connection.geo.CountryCode();
+
+  // Setup some connection parameters
+  client.connection.congestion = "bbr";
+  client.connection.dscp       = 8;
+  client.connection.pacing     = 100000;
+  client.connection.mark       = 17;
+
+  // Some file operations (note that the paths aren't required here, can just be strings, but it's a good practice)
+  FilePath(p1, "/tmp/foo");
+  FilePath(p2, "/tmp/secret.txt");
+
+  if (cripts::File::Status(p1).type() == cripts::File::Type::regular) {
+    client.response["X-Foo-Exists"] = "yes";
+  } else {
+    client.response["X-Foo-Exists"] = "no";
+  }
+
+  string secret = cripts::File::Line::Reader(p2);
+  CDebug("Read secret = {}", secret);
+
+  if (client.response.status == 200) {
+    client.response.status = 222;
+  }
+
+  CDebug("Txn count: {}", client.connection.Count());
+}
+
+do_remap()
+{
+  auto ip  = client.connection.IP();
+  auto now = TimeNow();
+
+  if (CRIPT_ALLOW.contains(ip)) {
+    CDebug("Client IP allowed: {}", ip.string(24, 64));
+  }
+
+  CDebug("Epoch time is {} (or via .epoch(), {}", now, now.Epoch());
+  CDebug("Year is {}", now.Year());
+  CDebug("Month is {}", now.Month());
+  CDebug("Day is {}", now.Day());
+  CDebug("Hour is {}", now.Hour());
+  CDebug("Day number is {}", now.YearDay());
+
+  CDebug("from_url = {}", instance.from_url.c_str());
+  CDebug("to_url = {}", instance.to_url.c_str());
+
+  // Turn off the cache for testing
+  // proxy.config.http.cache.http.set(1);
+  // control.cache.nostore.set(true);
+
+  CDebug("Int config cache.http = {}", proxy.config.http.cache.http.Get());
+  CDebug("Float config cache.heuristic_lm_factor = {}", proxy.config.http.cache.heuristic_lm_factor.Get());
+  CDebug("String config http.response_server_str = {}", proxy.config.http.response_server_str.GetSV(context));
+  CDebug("X-Miles = {}", client.request["X-Miles"]);
+  CDebug("random(1000) = {}", cripts::Random(1000));
+
+  borrow url      = cripts::Client::URL::Get();
+  auto   old_port = url.port;
+
+  CDebug("Method is {}", client.request.method);
+  CDebug("Scheme is {}", url.scheme);
+  CDebug("Host is {}", url.host);
+  CDebug("Port is {}", url.port);
+  CDebug("Path is {}", url.path);
+  CDebug("Path[1] is {}", url.path[1]);
+  CDebug("Query is {}", url.query);
+
+  auto testing_trim = url.path.trim();
+
+  CDebug("Trimmed path is {}", testing_trim);
+
+  if (url.query["foo"] > 100) {
+    CDebug("Query[foo] is > 100");
+  }
+
+  if (url.path == "some/url" || url.path[0] == "other") {
+    CDebug("The path comparison triggered");
+  }
+
+  url.host = "foobar.com";
+  url.port = "81";
+  url.port = old_port;
+
+  // TXN data slots
+  txn_data[0] = true;
+  txn_data[1] = 17;
+  txn_data[2] = "DBJ";
+
+  // Regular expressions
+  Regex(pcre, "^/([^/]+)/(.*)$");
+
+  auto res = pcre.Match("/foo/bench/bar"); // Can also call contains(), same thing
+
+  if (res) {
+    CDebug("Ovector count is {}", res.Count());
+    CDebug("First capture is {}", res[1]);
+    CDebug("Second capture is {}", res[2]);
+  } else {
+    CDebug("Regular expression did not match, that is not expected!");
+  }
+
+  // ATS versions
+  CDebug("ATS version = {}", version);
+  CDebug("ATS Major Version = {}", version.major);
+
+  // Some Crypto::Base64 tests
+  static auto base64_test = "VGltZSB3aWxsIG5vdCBzbG93IGRvd24gd2hlbiBzb21ldGhpbmcgdW5wbGVhc2FudCBsaWVzIGFoZWFkLg==";
+  auto        hp          = cripts::Crypto::Base64::Decode(base64_test);
+  auto        hp2         = cripts::Crypto::Base64::Encode(hp);
+
+  CDebug("HP quote: {}", hp);
+  if (base64_test != hp2) {
+    CDebug("Base64 failed: {}", hp2);
+  } else {
+    CDebug("Base64 encode reproduced the decoded HP string");
+  }
+
+  // Some Crypto::Escape (URL escaping) tests
+  static auto escape_test = "Hello_World_!@%23$%25%5E&*()_%2B%3C%3E?%2C.%2F";
+  auto        uri         = cripts::Crypto::Escape::Decode(escape_test);
+  auto        uri2        = cripts::Crypto::Escape::Encode(uri);
+
+  CDebug("Unescaped URI: {}", uri);
+  if (escape_test != uri2) {
+    CDebug("URL Escape failed: {}", uri2);
+  } else {
+    CDebug("Url Escape encode reproduced the decoded HP string");
+  }
+
+  // Testing Crypto SHA and encryption
+  auto hex = format("{}", cripts::Crypto::SHA256::Encode("Hello World"));
+
+  CDebug("SHA256 = {}", hex);
+
+  // Testing iterators
+  for (auto hdr : client.request) {
+    CDebug("Header: {} = {}", hdr, client.request[hdr]);
+    if (hdr.starts_with("AWS-")) {
+      client.request[hdr].clear();
+    }
+  }
+
+  // Testing some simple metrics
+  static auto m1 = cripts::Metrics::Gauge("cript.example1.m1");
+  static auto m2 = cripts::Metrics::Counter("cript.example1.m2");
+
+  m1.Increment(100);
+  m1.Decrement(10);
+  m2.Increment();
+
+  instance.metrics[0]->Increment();
+  instance.metrics[8]->Increment();
+}
+
+#include <cripts/Epilogue.hpp>

--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -82,6 +82,7 @@ namespace detail
 class ConnBase
 {
   using self_type = ConnBase;
+
   class Dscp
   {
     using self_type = Dscp;
@@ -99,7 +100,7 @@ class ConnBase
     void
     operator=(int val)
     {
-      TSAssert(_owner);
+      _ensure_initialized(_owner);
       _owner->SetDscp(val);
       _val = val;
     }
@@ -147,7 +148,7 @@ class ConnBase
     self_type &
     operator=([[maybe_unused]] cripts::string_view const &str)
     {
-      TSAssert(_owner);
+      _ensure_initialized(_owner);
 #if defined(TCP_CONGESTION)
       int connfd = _owner->FD();
       int res    = setsockopt(connfd, IPPROTO_TCP, TCP_CONGESTION, str.data(), str.size());
@@ -182,7 +183,7 @@ class ConnBase
     void
     operator=(int val)
     {
-      TSAssert(_owner);
+      _ensure_initialized(_owner);
       _owner->SetMark(val);
       _val = val;
     }
@@ -309,23 +310,23 @@ public:
   [[nodiscard]] virtual int FD() const = 0; // This needs the txnp from the Context
 
   [[nodiscard]] struct sockaddr const *
-  Socket() const
+  Socket()
   {
-    TSAssert(_vc);
+    _ensure_initialized(this);
     return TSNetVConnRemoteAddrGet(_vc);
   }
 
   [[nodiscard]] cripts::IP
-  IP() const
+  IP()
   {
-    TSAssert(Initialized());
+    _ensure_initialized(this);
     return cripts::IP{Socket()};
   }
 
   [[nodiscard]] bool
   Initialized() const
   {
-    return _state != nullptr;
+    return _initialized;
   }
 
   [[nodiscard]] bool
@@ -334,10 +335,17 @@ public:
     return TSHttpTxnIsInternal(_state->txnp);
   }
 
-  [[nodiscard]] virtual cripts::IP LocalIP() const  = 0;
-  [[nodiscard]] virtual int        Count() const    = 0;
-  virtual void                     SetDscp(int val) = 0;
-  virtual void                     SetMark(int val) = 0;
+  [[nodiscard]] virtual cripts::IP LocalIP() const        = 0;
+  [[nodiscard]] virtual int        Count() const          = 0;
+  virtual void                     SetDscp(int val) const = 0;
+  virtual void                     SetMark(int val) const = 0;
+
+  // This should only be called from the Context initializers!
+  void
+  set_state(cripts::Transaction *state)
+  {
+    _state = state;
+  }
 
   Dscp       dscp;
   Congestion congestion;
@@ -349,10 +357,25 @@ public:
   cripts::string_view string(unsigned ipv4_cidr = 32, unsigned ipv6_cidr = 128);
 
 protected:
+  static void
+  _ensure_initialized(self_type *ptr)
+  {
+    if (!ptr->Initialized()) [[unlikely]] {
+      ptr->_initialize(ptr->_state);
+    }
+  }
+
+  void virtual _initialize(cripts::Transaction *state)
+  {
+    CAssert(state == _state);
+    _initialized = true;
+  }
+
   cripts::Transaction   *_state  = nullptr;
   struct sockaddr const *_socket = nullptr;
   TSVConn                _vc     = nullptr;
   char                   _str[INET6_ADDRSTRLEN + 1];
+  bool                   _initialized = false;
 
 }; // End class ConnBase
 
@@ -365,8 +388,8 @@ namespace Client
 {
   class Connection : public detail::ConnBase
   {
-    using pe        = detail::ConnBase;
-    using self_type = Connection;
+    using super_type = detail::ConnBase;
+    using self_type  = Connection;
 
   public:
     Connection()                      = default;
@@ -376,15 +399,16 @@ namespace Client
     [[nodiscard]] int  FD() const override;
     [[nodiscard]] int  Count() const override;
     static Connection &_get(cripts::Context *context);
+    void               _initialize(cripts::Transaction *state) override;
 
     void
-    SetDscp(int val) override
+    SetDscp(int val) const override
     {
       TSHttpTxnClientPacketDscpSet(_state->txnp, val);
     }
 
     void
-    SetMark(int val) override
+    SetMark(int val) const override
     {
       TSHttpTxnClientPacketMarkSet(_state->txnp, val);
     }
@@ -403,8 +427,8 @@ namespace Server
 {
   class Connection : public detail::ConnBase
   {
-    using pe        = detail::ConnBase;
-    using self_type = Connection;
+    using super_type = detail::ConnBase;
+    using self_type  = Connection;
 
   public:
     Connection()                      = default;
@@ -414,15 +438,16 @@ namespace Server
     [[nodiscard]] int  FD() const override;
     [[nodiscard]] int  Count() const override;
     static Connection &_get(cripts::Context *context);
+    void               _initialize(cripts::Transaction *state) override;
 
     void
-    SetDscp(int val) override
+    SetDscp(int val) const override
     {
       TSHttpTxnServerPacketDscpSet(_state->txnp, val);
     }
 
     void
-    SetMark(int val) override
+    SetMark(int val) const override
     {
       TSHttpTxnServerPacketMarkSet(_state->txnp, val);
     }

--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -361,15 +361,11 @@ protected:
   _ensure_initialized(self_type *ptr)
   {
     if (!ptr->Initialized()) [[unlikely]] {
-      ptr->_initialize(ptr->_state);
+      ptr->_initialize();
     }
   }
 
-  void virtual _initialize(cripts::Transaction *state)
-  {
-    CAssert(state == _state);
-    _initialized = true;
-  }
+  void virtual _initialize() { _initialized = true; }
 
   cripts::Transaction   *_state  = nullptr;
   struct sockaddr const *_socket = nullptr;
@@ -399,7 +395,7 @@ namespace Client
     [[nodiscard]] int  FD() const override;
     [[nodiscard]] int  Count() const override;
     static Connection &_get(cripts::Context *context);
-    void               _initialize(cripts::Transaction *state) override;
+    void               _initialize() override;
 
     void
     SetDscp(int val) const override
@@ -438,7 +434,7 @@ namespace Server
     [[nodiscard]] int  FD() const override;
     [[nodiscard]] int  Count() const override;
     static Connection &_get(cripts::Context *context);
-    void               _initialize(cripts::Transaction *state) override;
+    void               _initialize() override;
 
     void
     SetDscp(int val) const override

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -44,7 +44,7 @@ public:
 
   // This will, and should, only be called via the ProxyAllocator as used in the factory.
   Context(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst)
-    : rri(rri_ptr), p_instance(inst), _client(this), _server(this)
+    : rri(rri_ptr), p_instance(inst), _client(this), _server(this), _urls(this)
   {
     state.txnp    = txn_ptr;
     state.ssnp    = ssn_ptr;
@@ -110,8 +110,8 @@ public:
 
   } _server;
 
-  struct {
-    cripts::Client::URL   client;
+  struct _UrlBlock {
+    cripts::Client::URL   request;
     cripts::Pristine::URL pristine;
     cripts::Cache::URL    cache;
     cripts::Parent::URL   parent;
@@ -120,6 +120,16 @@ public:
       cripts::Remap::From::URL from;
       cripts::Remap::To::URL   to;
     } remap;
+
+    _UrlBlock(Context *ctx)
+    {
+      request.set_context(ctx);
+      pristine.set_context(ctx);
+      cache.set_context(ctx);
+      parent.set_context(ctx);
+      remap.from.set_context(ctx);
+      remap.to.set_context(ctx);
+    }
 
   } _urls;
 }; // End class Context

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -44,7 +44,7 @@ public:
 
   // This will, and should, only be called via the ProxyAllocator as used in the factory.
   Context(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst)
-    : rri(rri_ptr), p_instance(inst), _client(this), _server(this), _urls(this)
+    : rri(rri_ptr), p_instance(inst), _client(this), _server(this), _urls(this, _client.url)
   {
     state.txnp    = txn_ptr;
     state.ssnp    = ssn_ptr;
@@ -87,6 +87,7 @@ public:
     cripts::Client::Response   response;
     cripts::Client::Request    request;
     cripts::Client::Connection connection;
+    cripts::Client::URL        url;
 
     _ClientBlock(Context *ctx)
     {
@@ -111,7 +112,7 @@ public:
   } _server;
 
   struct _UrlBlock {
-    cripts::Client::URL   request;
+    cripts::Client::URL  &request;
     cripts::Pristine::URL pristine;
     cripts::Cache::URL    cache;
     cripts::Parent::URL   parent;
@@ -121,7 +122,7 @@ public:
       cripts::Remap::To::URL   to;
     } remap;
 
-    _UrlBlock(Context *ctx)
+    _UrlBlock(Context *ctx, cripts::Client::URL &alias) : request(alias)
     {
       request.set_context(ctx);
       pristine.set_context(ctx);

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -44,7 +44,7 @@ public:
 
   // This will, and should, only be called via the ProxyAllocator as used in the factory.
   Context(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst)
-    : rri(rri_ptr), p_instance(inst)
+    : rri(rri_ptr), p_instance(inst), _client(this), _server(this)
   {
     state.txnp    = txn_ptr;
     state.ssnp    = ssn_ptr;
@@ -67,7 +67,6 @@ public:
 
   // These are private, but needs to be visible to our friend classes that
   // depends on the Context.
-private:
   friend class Client::Request;
   friend class Client::Response;
   friend class Client::Connection;
@@ -84,18 +83,45 @@ private:
 
   // These are "pre-allocated", but not initialized. They will be initialized
   // when used via a factory.
-  cripts::Client::Response   _client_resp_header;
-  cripts::Client::Request    _client_req_header;
-  cripts::Client::Connection _client_conn;
-  cripts::Client::URL        _client_url;
-  cripts::Remap::From::URL   _remap_from_url;
-  cripts::Remap::To::URL     _remap_to_url;
-  cripts::Pristine::URL      _pristine_url;
-  cripts::Server::Response   _server_resp_header;
-  cripts::Server::Request    _server_req_header;
-  cripts::Server::Connection _server_conn;
-  cripts::Cache::URL         _cache_url;
-  cripts::Parent::URL        _parent_url;
+  struct _ClientBlock {
+    cripts::Client::Response   response;
+    cripts::Client::Request    request;
+    cripts::Client::Connection connection;
+
+    _ClientBlock(Context *ctx)
+    {
+      response.set_state(&ctx->state);
+      request.set_state(&ctx->state);
+      connection.set_state(&ctx->state);
+    }
+  } _client;
+
+  struct _ServerBlock {
+    cripts::Server::Response   response;
+    cripts::Server::Request    request;
+    cripts::Server::Connection connection;
+
+    _ServerBlock(Context *ctx)
+    {
+      response.set_state(&ctx->state);
+      request.set_state(&ctx->state);
+      connection.set_state(&ctx->state);
+    }
+
+  } _server;
+
+  struct {
+    cripts::Client::URL   client;
+    cripts::Pristine::URL pristine;
+    cripts::Cache::URL    cache;
+    cripts::Parent::URL   parent;
+
+    struct {
+      cripts::Remap::From::URL from;
+      cripts::Remap::To::URL   to;
+    } remap;
+
+  } _urls;
 }; // End class Context
 
 } // namespace cripts

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -441,7 +441,9 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
       }
       CDebug("Entering glb_read_request()");
       wrap_glb_read_request(context, true, CaseArg);
-      cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      if (context->_urls.request.Modified()) {
+        context->_urls.request._update(); // Make sure any changes to the request URL is updated
+      }
     }
     break;
 
@@ -464,7 +466,9 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
         CDebug("Entering glb_send_request()");
         wrap_glb_send_request(context, true, CaseArg);
       }
-      cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      if (context->_urls.request.Modified()) {
+        context->_urls.request._update(); // Make sure any changes to the request URL is updated
+      }
     }
     break;
 
@@ -577,8 +581,12 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
     }
 
     if (!context->state.error.Failed()) {
-      cripts::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
-      cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      if (context->_urls.cache.Modified()) {
+        context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+      }
+      if (context->_urls.request.Modified()) {
+        context->_urls.request._update(); // Make sure any changes to the request URL is updated
+      }
     }
     break;
 
@@ -604,8 +612,12 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
     }
 
     if (!context->state.error.Failed()) {
-      cripts::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
-      cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+      if (context->_urls.cache.Modified()) {
+        context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+      }
+      if (context->_urls.request.Modified()) {
+        context->_urls.request._update(); // Make sure any changes to the request URL is updated
+      }
     }
     break;
 
@@ -887,8 +899,12 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   // Don't do the callbacks when we are in a failure state.
   if (!context->state.error.Failed()) {
-    cripts::Cache::URL::_get(context).Update();  // Make sure the cache-key gets updated, if modified
-    cripts::Client::URL::_get(context).Update(); // Make sure any changes to the request URL is updated
+    if (context->_urls.cache.Modified()) {
+      context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+    }
+    if (context->_urls.request.Modified()) {
+      context->_urls.request._update(); // Make sure any changes to the request URL is updated
+    }
 
     if (context->state.enabled_hooks >= cripts::Callbacks::DO_POST_REMAP) {
       context->contp = TSContCreate(http_txn_cont, nullptr);
@@ -935,7 +951,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
   }
 
   // See if the Client URL was modified, which dicates the return code here.
-  if (cripts::Client::URL::_get(context).Modified()) {
+  if (context->_urls.request.Modified()) {
     context->p_instance.debug("Client::URL was modified, returning TSREMAP_DID_REMAP");
     return TSREMAP_DID_REMAP;
   } else {

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -725,7 +725,7 @@ TSPluginInit(int argc, const char *argv[])
   }
 
   // ToDo: This InstanceContext should also be usabled / used by other non-HTTP hooks.
-  cripts::InstanceContext *context = new cripts::InstanceContext(*inst);
+  auto *context = new cripts::InstanceContext(*inst);
 
   pthread_once(&init_once_control, global_initialization);
   bool needs_glb_init = wrap_glb_init(context, false, CaseArg);
@@ -866,11 +866,11 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
     (wrap_txn_close(static_cast<cripts::Context *>(nullptr), false, CaseArg) ? cripts::Callbacks::DO_TXN_CLOSE :
                                                                                cripts::Callbacks::NONE);
 
-  TSHttpSsn ssnp         = TSHttpTxnSsnGet(txnp);
-  auto     *inst         = static_cast<cripts::Instance *>(ih);
-  auto      bundle_cbs   = inst->Callbacks();
-  auto     *context      = cripts::Context::Factory(txnp, ssnp, rri, *inst);
-  bool      keep_context = false;
+  auto  ssnp         = TSHttpTxnSsnGet(txnp);
+  auto *inst         = static_cast<cripts::Instance *>(ih);
+  auto  bundle_cbs   = inst->Callbacks();
+  auto *context      = cripts::Context::Factory(txnp, ssnp, rri, *inst);
+  bool  keep_context = false;
 
   context->state.hook          = TS_HTTP_READ_REQUEST_HDR_HOOK; // Not quite true
   context->state.enabled_hooks = (enabled_hooks | bundle_cbs);

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -403,15 +403,11 @@ protected:
   _ensure_initialized(self_type *ptr)
   {
     if (!ptr->Initialized()) [[unlikely]] {
-      ptr->_initialize(ptr->_state);
+      ptr->_initialize();
     }
   }
 
-  void virtual _initialize(cripts::Transaction *state)
-  {
-    CAssert(state == _state);
-    _initialized = true;
-  }
+  void virtual _initialize() { _initialized = true; }
 
   TSMBuffer            _bufp         = nullptr;
   TSMLoc               _hdr_loc      = nullptr;
@@ -459,7 +455,7 @@ namespace Client
 
     // Implemented later, because needs the context.
     static self_type &_get(cripts::Context *context);
-    void              _initialize(cripts::Transaction *state) override;
+    void              _initialize() override;
 
   }; // End class Client::Request
 
@@ -475,7 +471,7 @@ namespace Client
 
     // Implemented later, because needs the context.
     static self_type &_get(cripts::Context *context);
-    void              _initialize(cripts::Transaction *state) override;
+    void              _initialize() override;
 
   }; // End class Client::Response
 
@@ -495,7 +491,7 @@ namespace Server
 
     // Implemented later, because needs the context.
     static self_type &_get(cripts::Context *context);
-    void              _initialize(cripts::Transaction *state) override;
+    void              _initialize() override;
 
   }; // End class Server::Request
 
@@ -511,7 +507,7 @@ namespace Server
 
     // Implemented later, because needs the context.
     static self_type &_get(cripts::Context *context);
-    void              _initialize(cripts::Transaction *state) override;
+    void              _initialize() override;
 
   }; // End class Server::Response
 

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -345,18 +345,20 @@ public:
       _hdr_loc = nullptr;
       _bufp    = nullptr;
     }
-    _state = nullptr;
+    _initialized = false;
   }
 
   [[nodiscard]] TSMBuffer
-  BufP() const
+  BufP()
   {
+    _ensure_initialized(this);
     return _bufp;
   }
 
   [[nodiscard]] TSMLoc
-  MLoc() const
+  MLoc()
   {
+    _ensure_initialized(this);
     return _hdr_loc;
   }
 
@@ -365,12 +367,13 @@ public:
   [[nodiscard]] bool
   Initialized() const
   {
-    return (_state != nullptr);
+    return _initialized;
   }
 
   void
   Erase(const cripts::string_view header)
   {
+    _ensure_initialized(this);
     operator[](header) = "";
   }
 
@@ -383,16 +386,31 @@ public:
     return Iterator::end(); // Static end iterator. ToDo: Does this have any value over making a new one always?
   }
 
+  // This should only be called from the Context initializers!
+  void
+  set_state(cripts::Transaction *state)
+  {
+    _state = state;
+  }
+
   Status      status;
   Reason      reason;
   Body        body;
   CacheStatus cache;
 
 protected:
-  void
-  _initialize(cripts::Transaction *state)
+  static void
+  _ensure_initialized(self_type *ptr)
   {
-    _state = state;
+    if (!ptr->Initialized()) [[unlikely]] {
+      ptr->_initialize(ptr->_state);
+    }
+  }
+
+  void virtual _initialize(cripts::Transaction *state)
+  {
+    CAssert(state == _state);
+    _initialized = true;
   }
 
   TSMBuffer            _bufp         = nullptr;
@@ -400,6 +418,7 @@ protected:
   cripts::Transaction *_state        = nullptr; // Pointer into the owning Context's State
   TSMLoc               _iterator_loc = nullptr;
   uint32_t             _iterator_tag = 0; // This is used to assure that we don't have more than one active iterator on a header
+  bool                 _initialized  = false;
 
 }; // End class Header
 
@@ -440,6 +459,7 @@ namespace Client
 
     // Implemented later, because needs the context.
     static self_type &_get(cripts::Context *context);
+    void              _initialize(cripts::Transaction *state) override;
 
   }; // End class Client::Request
 
@@ -455,6 +475,7 @@ namespace Client
 
     // Implemented later, because needs the context.
     static self_type &_get(cripts::Context *context);
+    void              _initialize(cripts::Transaction *state) override;
 
   }; // End class Client::Response
 
@@ -473,7 +494,9 @@ namespace Server
     void operator=(const self_type &) = delete;
 
     // Implemented later, because needs the context.
-    static Request &_get(cripts::Context *context);
+    static self_type &_get(cripts::Context *context);
+    void              _initialize(cripts::Transaction *state) override;
+
   }; // End class Server::Request
 
   class Response : public ResponseHeader
@@ -488,6 +511,7 @@ namespace Server
 
     // Implemented later, because needs the context.
     static self_type &_get(cripts::Context *context);
+    void              _initialize(cripts::Transaction *state) override;
 
   }; // End class Server::Response
 

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -107,3 +107,17 @@ using fmt::format;
 extern cripts::Proxy    proxy;   // Access to all overridable configurations
 extern cripts::Control  control; // Access to the HTTP control mechanism
 extern cripts::Versions version; // Access to the ATS version information
+
+// These are not enabled by default, since they adds additional overhead
+// and pollution of the top level namespace.
+#if CONVENIENT_APIS
+#define client                      context->_client
+#define server                      context->_server
+#define Regex(_name_, ...)          static cripts::Matcher::PCRE _name_(__VA_ARGS__);
+#define ACL(_name_, ...)            static cripts::Matcher::Range::IP _name_(__VA_ARGS__);
+#define CreateCounter(_id_, _name_) instance.metrics[_id_] = cripts::Metrics::Counter::Create(_name_);
+#define CreateGauge(_id_, _name_)   instance.metrics[_id_] = cripts::Metrics::Gauge::Create(_name_);
+#define FilePath(_name_, _path_)    static const cripts::File::Path _name_(_path_);
+#define UniqueUUID                  cripts::UUID::Unique::Get();
+#define TimeNow()                   cripts::Time::Local::Now();
+#endif

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -110,14 +110,15 @@ extern cripts::Versions version; // Access to the ATS version information
 
 // These are not enabled by default, since they adds additional overhead
 // and pollution of the top level namespace.
-#if CONVENIENT_APIS
+#if CRIPT_CONVENIENCE_APIS
 #define client                      context->_client
 #define server                      context->_server
+#define urls                        context->_urls
 #define Regex(_name_, ...)          static cripts::Matcher::PCRE _name_(__VA_ARGS__);
 #define ACL(_name_, ...)            static cripts::Matcher::Range::IP _name_(__VA_ARGS__);
 #define CreateCounter(_id_, _name_) instance.metrics[_id_] = cripts::Metrics::Counter::Create(_name_);
 #define CreateGauge(_id_, _name_)   instance.metrics[_id_] = cripts::Metrics::Gauge::Create(_name_);
 #define FilePath(_name_, _path_)    static const cripts::File::Path _name_(_path_);
-#define UniqueUUID                  cripts::UUID::Unique::Get();
+#define UniqueUUID()                cripts::UUID::Unique::Get();
 #define TimeNow()                   cripts::Time::Local::Now();
 #endif

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -110,7 +110,7 @@ extern cripts::Versions version; // Access to the ATS version information
 
 // These are not enabled by default, since they adds additional overhead
 // and pollution of the top level namespace.
-#if CRIPT_CONVENIENCE_APIS
+#if CRIPTS_CONVENIENCE_APIS
 #define client                      context->_client
 #define server                      context->_server
 #define urls                        context->_urls

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -588,14 +588,13 @@ protected:
   _ensure_initialized(self_type *ptr)
   {
     if (!ptr->Initialized()) [[unlikely]] {
-      ptr->_initialize(ptr->_context);
+      ptr->_initialize();
     }
   }
 
   virtual void
-  _initialize(cripts::Context *context)
+  _initialize()
   {
-    CAssert(context == _context); // This is initialized in the Context
     _initialized = true;
     _modified    = false;
   }
@@ -632,7 +631,7 @@ namespace Pristine
     }
 
   protected:
-    void _initialize(cripts::Context *context) override;
+    void _initialize() override;
 
   }; // End class Pristine::URL
 
@@ -660,7 +659,7 @@ namespace Client
     bool              _update();
 
   protected:
-    void _initialize(cripts::Context *context) override;
+    void _initialize() override;
 
   }; // End class Client::URL
 
@@ -696,7 +695,7 @@ namespace Remap
       bool              Update();
 
     private:
-      void _initialize(cripts::Context *context) override;
+      void _initialize() override;
 
     }; // End class Client::URL
 
@@ -730,7 +729,7 @@ namespace Remap
       bool              Update();
 
     private:
-      void _initialize(cripts::Context *context) override;
+      void _initialize() override;
 
     }; // End class Client::URL
 
@@ -754,7 +753,7 @@ namespace Cache
     bool              _update();
 
   protected:
-    void _initialize(cripts::Context *context) override;
+    void _initialize() override;
 
   }; // End class Cache::URL
 
@@ -776,7 +775,7 @@ namespace Parent
     bool              Update();
 
   protected:
-    void _initialize(cripts::Context *context) override;
+    void _initialize() override;
 
   }; // End class Cache::URL
 

--- a/src/cripts/Connections.cc
+++ b/src/cripts/Connections.cc
@@ -30,7 +30,7 @@ const cripts::Matcher::Range::IP cripts::Net::RFC1918({"10.0.0.0/8", "172.16.0.0
 void
 detail::ConnBase::Pacing::operator=(uint32_t val)
 {
-  TSAssert(_owner);
+  _ensure_initialized(_owner);
   if (val == 0) {
     val = Off;
   }
@@ -51,6 +51,7 @@ void
 detail::ConnBase::TcpInfo::initialize()
 {
 #if defined(TCP_INFO) && defined(HAVE_STRUCT_TCP_INFO)
+  _ensure_initialized(_owner);
   if (!_ready) {
     int connfd = _owner->FD();
 
@@ -70,6 +71,7 @@ detail::ConnBase::TcpInfo::initialize()
 cripts::string_view
 detail::ConnBase::TcpInfo::Log()
 {
+  _ensure_initialized(_owner);
   initialize();
   // We intentionally do not use the old tcpinfo that may be stored, since we may
   // request this numerous times (measurements). Also make sure there's always a value.
@@ -205,18 +207,19 @@ IP::Sample(double rate, uint32_t seed, unsigned ipv4_cidr, unsigned ipv6_cidr)
 Client::Connection &
 Client::Connection::_get(cripts::Context *context)
 {
-  Client::Connection *conn = &context->_client_conn;
+  _ensure_initialized(&context->_client.connection);
+  return context->_client.connection;
+}
 
-  if (!conn->Initialized()) {
-    TSAssert(context->state.ssnp);
-    TSAssert(context->state.txnp);
+void
+Client::Connection::_initialize(cripts::Transaction *state)
+{
+  TSAssert(state->ssnp);
+  TSAssert(state->txnp);
 
-    conn->_state  = &context->state;
-    conn->_vc     = TSHttpSsnClientVConnGet(context->state.ssnp);
-    conn->_socket = TSHttpTxnClientAddrGet(context->state.txnp);
-  }
-
-  return context->_client_conn;
+  _vc     = TSHttpSsnClientVConnGet(state->ssnp);
+  _socket = TSHttpTxnClientAddrGet(state->txnp);
+  super_type::_initialize(state);
 }
 
 int
@@ -233,27 +236,25 @@ Client::Connection::FD() const
 int
 Client::Connection::Count() const
 {
-  TSHttpSsn ssn = TSHttpTxnSsnGet(_state->txnp);
-
-  TSAssert(_state->txnp);
-
-  return ssn ? TSHttpSsnTransactionCount(ssn) : -1;
+  TSAssert(_state->ssnp);
+  return TSHttpSsnTransactionCount(_state->ssnp);
 }
 
 Server::Connection &
 Server::Connection::_get(cripts::Context *context)
 {
-  cripts::Server::Connection *conn = &context->_server_conn;
+  _ensure_initialized(&context->_server.connection);
+  return context->_server.connection;
+}
 
-  if (!conn->Initialized()) {
-    TSAssert(context->state.ssnp);
+void
+Server::Connection::_initialize(cripts::Transaction *state)
+{
+  TSAssert(state->ssnp);
 
-    conn->_state  = &context->state;
-    conn->_vc     = TSHttpSsnServerVConnGet(context->state.ssnp);
-    conn->_socket = TSHttpTxnServerAddrGet(context->state.txnp);
-  }
-
-  return context->_server_conn;
+  _vc     = TSHttpSsnServerVConnGet(state->ssnp);
+  _socket = TSHttpTxnServerAddrGet(state->txnp);
+  super_type::_initialize(state);
 }
 
 int
@@ -270,6 +271,7 @@ Server::Connection::FD() const
 int
 Server::Connection::Count() const
 {
+  TSAssert(_state->txnp);
   return TSHttpTxnServerSsnTransactionCount(_state->txnp);
 }
 

--- a/src/cripts/Connections.cc
+++ b/src/cripts/Connections.cc
@@ -212,14 +212,14 @@ Client::Connection::_get(cripts::Context *context)
 }
 
 void
-Client::Connection::_initialize(cripts::Transaction *state)
+Client::Connection::_initialize()
 {
-  TSAssert(state->ssnp);
-  TSAssert(state->txnp);
+  TSAssert(_state->ssnp);
+  TSAssert(_state->txnp);
 
-  _vc     = TSHttpSsnClientVConnGet(state->ssnp);
-  _socket = TSHttpTxnClientAddrGet(state->txnp);
-  super_type::_initialize(state);
+  _vc     = TSHttpSsnClientVConnGet(_state->ssnp);
+  _socket = TSHttpTxnClientAddrGet(_state->txnp);
+  super_type::_initialize();
 }
 
 int
@@ -248,13 +248,13 @@ Server::Connection::_get(cripts::Context *context)
 }
 
 void
-Server::Connection::_initialize(cripts::Transaction *state)
+Server::Connection::_initialize()
 {
-  TSAssert(state->ssnp);
+  TSAssert(_state->ssnp);
 
-  _vc     = TSHttpSsnServerVConnGet(state->ssnp);
-  _socket = TSHttpTxnServerAddrGet(state->txnp);
-  super_type::_initialize(state);
+  _vc     = TSHttpSsnServerVConnGet(_state->ssnp);
+  _socket = TSHttpTxnServerAddrGet(_state->txnp);
+  super_type::_initialize();
 }
 
 int

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -35,28 +35,28 @@ Context::reset()
   // Clear the initialized headers before calling next hook
   // Note: we don't clear the pristine URL, nor the Remap From/To URLs, they are static.
   //      We also don't clear the client URL, since it's from the RRI.
-  if (_client_resp_header.Initialized()) {
-    _client_resp_header.Reset();
+  if (_client.response.Initialized()) {
+    _client.response.Reset();
   }
-  if (_server_resp_header.Initialized()) {
-    _server_resp_header.Reset();
+  if (_server.response.Initialized()) {
+    _server.response.Reset();
   }
-  if (_client_req_header.Initialized()) {
-    _client_req_header.Reset();
+  if (_client.request.Initialized()) {
+    _client.request.Reset();
   }
-  if (_server_req_header.Initialized()) {
-    _server_req_header.Reset();
+  if (_server.request.Initialized()) {
+    _server.request.Reset();
   }
 
   // Clear the initialized URLs before calling next hook
-  if (_pristine_url.Initialized()) {
-    _pristine_url.Reset();
+  if (_urls.pristine.Initialized()) {
+    _urls.pristine.Reset();
   }
-  if (_cache_url.Initialized()) {
-    _cache_url.Reset();
+  if (_urls.cache.Initialized()) {
+    _urls.cache.Reset();
   }
-  if (_parent_url.Initialized()) {
-    _parent_url.Reset();
+  if (_urls.parent.Initialized()) {
+    _urls.parent.Reset();
   }
 }
 

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -277,15 +277,15 @@ Client::Request::_get(cripts::Context *context)
 }
 
 void
-Client::Request::_initialize(cripts::Transaction *state)
+Client::Request::_initialize()
 {
-  TSAssert(state->txnp);
+  TSAssert(_state->txnp);
   TSAssert(!Initialized());
 
-  if (TSHttpTxnClientReqGet(state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
-    state->error.Fail();
+  if (TSHttpTxnClientReqGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
+    _state->error.Fail();
   } else {
-    super_type::_initialize(state); // Don't initialize unless properly setup
+    super_type::_initialize(); // Don't initialize unless properly setup
   }
 }
 
@@ -342,19 +342,19 @@ Client::Response::_get(cripts::Context *context)
 }
 
 void
-Client::Response::_initialize(cripts::Transaction *state)
+Client::Response::_initialize()
 {
-  CAssert(state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
-  CAssert(state->hook != TS_HTTP_POST_REMAP_HOOK);
-  CAssert(state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_POST_REMAP_HOOK);
+  CAssert(_state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
 
-  TSAssert(state->txnp);
+  TSAssert(_state->txnp);
   TSAssert(!Initialized());
 
-  if (TSHttpTxnClientRespGet(state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
-    state->error.Fail();
+  if (TSHttpTxnClientRespGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
+    _state->error.Fail();
   } else {
-    super_type::_initialize(state); // Don't initialize unless properly setup
+    super_type::_initialize(); // Don't initialize unless properly setup
   }
 }
 
@@ -366,19 +366,19 @@ Server::Request::_get(cripts::Context *context)
 }
 
 void
-Server::Request::_initialize(cripts::Transaction *state)
+Server::Request::_initialize()
 {
-  CAssert(state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
-  CAssert(state->hook != TS_HTTP_POST_REMAP_HOOK);
-  CAssert(state->hook != TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK);
-  CAssert(state->hook != TS_HTTP_READ_RESPONSE_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_POST_REMAP_HOOK);
+  CAssert(_state->hook != TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK);
+  CAssert(_state->hook != TS_HTTP_READ_RESPONSE_HDR_HOOK);
 
   if (!Initialized()) {
-    TSAssert(state->txnp);
-    if (TSHttpTxnServerReqGet(state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
-      state->error.Fail();
+    TSAssert(_state->txnp);
+    if (TSHttpTxnServerReqGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
+      _state->error.Fail();
     } else {
-      super_type::_initialize(state); // Don't initialize unless properly setup
+      super_type::_initialize(); // Don't initialize unless properly setup
     }
   }
 }
@@ -391,20 +391,20 @@ Server::Response::_get(cripts::Context *context)
 }
 
 void
-Server::Response::_initialize(cripts::Transaction *state)
+Server::Response::_initialize()
 {
-  CAssert(state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
-  CAssert(state->hook != TS_HTTP_POST_REMAP_HOOK);
-  CAssert(state->hook != TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK);
-  CAssert(state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_POST_REMAP_HOOK);
+  CAssert(_state->hook != TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK);
+  CAssert(_state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
 
-  TSAssert(state->txnp);
+  TSAssert(_state->txnp);
   TSAssert(!Initialized());
 
-  if (TSHttpTxnServerRespGet(state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
-    state->error.Fail();
+  if (TSHttpTxnServerRespGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
+    _state->error.Fail();
   } else {
-    super_type::_initialize(state); // Don't initialize unless properly setup
+    super_type::_initialize(); // Don't initialize unless properly setup
   }
 }
 

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -280,7 +280,6 @@ void
 Client::Request::_initialize()
 {
   TSAssert(_state->txnp);
-  TSAssert(!Initialized());
 
   if (TSHttpTxnClientReqGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
     _state->error.Fail();
@@ -349,7 +348,6 @@ Client::Response::_initialize()
   CAssert(_state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
 
   TSAssert(_state->txnp);
-  TSAssert(!Initialized());
 
   if (TSHttpTxnClientRespGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
     _state->error.Fail();
@@ -399,7 +397,6 @@ Server::Response::_initialize()
   CAssert(_state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
 
   TSAssert(_state->txnp);
-  TSAssert(!Initialized());
 
   if (TSHttpTxnServerRespGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
     _state->error.Fail();

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -426,8 +426,8 @@ Url::String() const
 Pristine::URL &
 Pristine::URL::_get(cripts::Context *context)
 {
-  if (!context->_pristine_url.Initialized()) {
-    Pristine::URL *url = &context->_pristine_url;
+  if (!context->_urls.pristine.Initialized()) {
+    Pristine::URL *url = &context->_urls.pristine;
 
     TSAssert(context->state.txnp);
     if (TSHttpTxnPristineUrlGet(context->state.txnp, &url->_bufp, &url->_urlp) != TS_SUCCESS) {
@@ -437,7 +437,7 @@ Pristine::URL::_get(cripts::Context *context)
     }
   }
 
-  return context->_pristine_url;
+  return context->_urls.pristine;
 }
 
 void
@@ -464,11 +464,11 @@ Client::URL::_initialize(cripts::Context *context)
 Client::URL &
 Client::URL::_get(cripts::Context *context)
 {
-  if (!context->_client_url.Initialized()) {
-    context->_client_url._initialize(context);
+  if (!context->_urls.client.Initialized()) {
+    context->_urls.client._initialize(context);
   }
 
-  return context->_client_url;
+  return context->_urls.client;
 }
 
 bool
@@ -493,11 +493,11 @@ Remap::From::URL::_initialize(cripts::Context *context)
 Remap::From::URL &
 Remap::From::URL::_get(cripts::Context *context)
 {
-  if (!context->_remap_from_url.Initialized()) {
-    context->_remap_from_url._initialize(context);
+  if (!context->_urls.remap.from.Initialized()) {
+    context->_urls.remap.from._initialize(context);
   }
 
-  return context->_remap_from_url;
+  return context->_urls.remap.from;
 }
 
 void
@@ -513,18 +513,17 @@ Remap::To::URL::_initialize(cripts::Context *context)
 Remap::To::URL &
 Remap::To::URL::_get(cripts::Context *context)
 {
-  if (!context->_remap_to_url.Initialized()) {
-    context->_remap_to_url._initialize(context);
+  if (!context->_urls.remap.to.Initialized()) {
+    context->_urls.remap.to._initialize(context);
   }
-
-  return context->_remap_to_url;
+  return context->_urls.remap.to;
 }
 
 Cache::URL &
 Cache::URL::_get(cripts::Context *context)
 {
-  if (!context->_cache_url.Initialized()) {
-    Cache::URL      *url = &context->_cache_url;
+  if (!context->_urls.cache.Initialized()) {
+    Cache::URL      *url = &context->_urls.cache;
     Client::Request &req = Client::Request::_get(context); // Repurpose / create the shared request object
 
     switch (context->state.hook) {
@@ -554,7 +553,7 @@ Cache::URL::_get(cripts::Context *context)
     }
   }
 
-  return context->_cache_url;
+  return context->_urls.cache;
 }
 
 // This has to be implemented here, since the cripts::Context is not complete yet
@@ -589,8 +588,8 @@ Cache::URL::_update(cripts::Context *context)
 Parent::URL &
 Parent::URL::_get(cripts::Context *context)
 {
-  if (!context->_cache_url.Initialized()) {
-    Parent::URL     *url = &context->_parent_url;
+  if (!context->_urls.cache.Initialized()) {
+    Parent::URL     *url = &context->_urls.parent;
     Client::Request &req = Client::Request::_get(context); // Repurpose / create the shared request object
 
     if (TSUrlCreate(req.BufP(), &url->_urlp) == TS_SUCCESS) {
@@ -603,7 +602,7 @@ Parent::URL::_get(cripts::Context *context)
     }
   }
 
-  return context->_parent_url;
+  return context->_urls.parent;
 }
 
 } // namespace cripts


### PR DESCRIPTION
This does a few things:

1. It adds a few top level symbols, polluting the name space with client, server and urls.
2. Adds a few convenience macros, again populated in the top level name space
3. Cleans up some code as needed.

These new symbols and macros are not in the normal name space, for now at least. They are instead activated by adding this to the absolute beginning of any Cripts that wants to use them:

```
#define CRIPT_CONVENIENCE_APIS 1
```