### PR TITLE
Revert "HttpSM::tunnel_handler: Handle WRITE events (#11242)"

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -3011,12 +3011,6 @@ HttpSM::tunnel_handler(int event, void * /* data ATS_UNUSED */)
 {
   STATE_ENTER(&HttpSM::tunnel_handler, event);
 
-  // If we had already received EOS, just go away. We would sometimes see
-  // a WRITE event appear after receiving EOS from the server connection
-  if ((event == VC_EVENT_WRITE_READY || event == VC_EVENT_WRITE_COMPLETE) && server_entry->eos) {
-    return 0;
-  }
-
   ink_assert(event == HTTP_TUNNEL_EVENT_DONE || event == VC_EVENT_INACTIVITY_TIMEOUT);
   // The tunnel calls this when it is done
   terminate_sm = true;


### PR DESCRIPTION
This reverts commit ed29bf7bed9e62f75bdc088a58a845a5b9689a2b.

To check which AuTest made the crash.