### PR TITLE
Remove misleading log statement

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -493,8 +493,7 @@ incoming/outgoing ports, and network interfaces used during transactions.
 ===== ============== ==========================================================
 Field Source         Description
 ===== ============== ==========================================================
-chi   Client         IP address of the client's host. If :ref:`Proxy Protocol <proxy-protocol>`
-                     is used, this represents the IP address of the previous hop.
+chi   Client         IP address of the client's host.
 chih  Client         IP address of the client's host, in hexadecimal.
 hii   Proxy          IP address for the proxy's incoming interface (to which
                      the client connected).

--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -493,7 +493,9 @@ incoming/outgoing ports, and network interfaces used during transactions.
 ===== ============== ==========================================================
 Field Source         Description
 ===== ============== ==========================================================
-chi   Client         IP address of the client's host.
+chi   Client         IP address of the client's host. If :ref:`Proxy Protocol <proxy-protocol>`
+                     is used, this represents the IP address of the peer, rather than
+                     the client IP behind the peer.
 chih  Client         IP address of the client's host, in hexadecimal.
 hii   Proxy          IP address for the proxy's incoming interface (to which
                      the client connected).


### PR DESCRIPTION
[Doc change only] Documentation for `chi` seems to imply proxy protocol ip address is used if enabled, similar to `pps` but [code](https://github.com/apache/trafficserver/blob/master/src/proxy/logging/LogAccess.cc#L1419) only reads for client info.

Discussion in slack thread suggests better wording or removal of line. Open to ideas