### PR TITLE
GCC 15: Address mismatched-new-delete in MemArena::Block

### DIFF
--- a/lib/swoc/src/MemArena.cc
+++ b/lib/swoc/src/MemArena.cc
@@ -91,12 +91,10 @@ MemArena::make_block(size_t n) {
     n = QuarterPage{round_up(n)};
   }
 
-  // Allocate space for the Block instance and the request memory and construct a Block at the front.
-  // In theory this could use ::operator new(n) but this causes a size mismatch during ::operator delete.
-  // Easier to use malloc and override @c delete.
+  // Allocate space for the Block instance and the requested memory and construct a Block at the front.
   auto free_space   = n - sizeof(Block);
   _active_reserved += free_space;
-  return new (::malloc(n)) Block(free_space);
+  return new (n) Block(free_space);
 }
 
 MemSpan<void>


### PR DESCRIPTION
This addresses a GCC 15 compiler warning about mismatched std operator new and overridden operator delete in MemArena. This patch addresses the warning by also overriding operator new for the MemArena::Block.

This is the warning being addressed:

```
lib/swoc/src/MemArena.cc: In member function ‘swoc::_1_5_14::MemArena::Block* swoc::_1_5_14::MemArena::make_block(size_t)’:
lib/swoc/src/MemArena.cc:99:44: error: ‘static void swoc::_1_5_14::MemArena::Block::operator delete(void*, void*)’ called on pointer returned from a mismatched allocation function [-Werror=mism
atched-new-delete]
   99 |   return new (::malloc(n)) Block(free_space);
      |                                            ^
src/ts_asf_master_fix_builds_for_fedora_42/lib/swoc/src/MemArena.cc:99:23: note: returned from ‘void* malloc(size_t)’
   99 |   return new (::malloc(n)) Block(free_space);
      |               ~~~~~~~~^~~
```