### PR TITLE
-std=c++20: Remove TextView space before _sv/_tv literal

### DIFF
--- a/lib/swoc/include/swoc/TextView.h
+++ b/lib/swoc/include/swoc/TextView.h
@@ -2085,7 +2085,7 @@ namespace literals {
  * so hopefully someday this can be removed.
  */
 constexpr std::string_view
-operator"" _sv(const char *s, size_t n) {
+operator""_sv(const char *s, size_t n) {
   return {s, n};
 }
 
@@ -2100,7 +2100,7 @@ operator"" _sv(const char *s, size_t n) {
  * so hopefully someday this can be removed.
  */
 constexpr swoc::TextView
-operator"" _tv(const char *s, size_t n) {
+operator""_tv(const char *s, size_t n) {
   return {s, n};
 }
 } // namespace literals


### PR DESCRIPTION
Spaces before _sv literals in operator"" declarations are deprecated for -std=c++20. This removes those spaces in the TextView.h declarations.

This addresses the following warning:

```
include/swoc/TextView.h:2088:12: error: identifier '_sv' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
 2088 | operator"" _sv(const char *s, size_t n) {
      | ~~~~~~~~~~~^~~
      | operator""_sv
include/swoc/TextView.h:2103:12: error: identifier '_tv' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
 2103 | operator"" _tv(const char *s, size_t n) {
      | ~~~~~~~~~~~^~~
      | operator""_tv
```