### PR TITLE
Cleanup: Remove unused args from open_read and open_write

### DIFF
--- a/include/iocore/cache/Cache.h
+++ b/include/iocore/cache/Cache.h
@@ -83,9 +83,9 @@ struct CacheProcessor : public Processor {
   Action *scan(Continuation *cont, char *hostname = nullptr, int host_len = 0, int KB_per_second = SCAN_KB_PER_SECOND);
   Action *lookup(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   Action *open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request, const HttpConfigAccessor *params,
-                    time_t pin_in_cache = 0, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
-  Action *open_write(Continuation *cont, int expected_size, const HttpCacheKey *key, CacheHTTPHdr *request, CacheHTTPInfo *old_info,
-                     time_t pin_in_cache = 0, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
+                    CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
+  Action *open_write(Continuation *cont, const HttpCacheKey *key, CacheHTTPInfo *old_info, time_t pin_in_cache = 0,
+                     CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   Action *remove(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP);
   Action *link(Continuation *cont, CacheKey *from, CacheKey *to, CacheFragType frag_type = CACHE_FRAG_TYPE_HTTP,
                char *hostname = nullptr, int host_len = 0);

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -606,8 +606,8 @@ Lcallreturn:
 
 // main entry point for writing of http documents
 Action *
-Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, time_t apin_in_cache,
-                  const CacheKey * /* key1 ATS_UNUSED */, CacheFragType type, const char *hostname, int host_len) const
+Cache::open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *info, time_t apin_in_cache, CacheFragType type,
+                  const char *hostname, int host_len) const
 {
   if (!CacheProcessor::IsCacheReady(type)) {
     cont->handleEvent(CACHE_EVENT_OPEN_WRITE_FAILED, reinterpret_cast<void *>(-ECACHE_NOT_READY));

--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -405,21 +405,18 @@ CacheProcessor::lookup(Continuation *cont, const HttpCacheKey *key, CacheFragTyp
   return lookup(cont, &key->hash, frag_type, key->hostname, key->hostlen);
 }
 
-//----------------------------------------------------------------------------
 Action *
 CacheProcessor::open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request, const HttpConfigAccessor *params,
-                          time_t /* pin_in_cache ATS_UNUSED */, CacheFragType type)
+                          CacheFragType type)
 {
   return caches[type]->open_read(cont, &key->hash, request, params, type, key->hostname, key->hostlen);
 }
 
-//----------------------------------------------------------------------------
 Action *
-CacheProcessor::open_write(Continuation *cont, int /* expected_size ATS_UNUSED */, const HttpCacheKey *key,
-                           CacheHTTPHdr * /* request ATS_UNUSED */, CacheHTTPInfo *old_info, time_t pin_in_cache,
+CacheProcessor::open_write(Continuation *cont, const HttpCacheKey *key, CacheHTTPInfo *old_info, time_t pin_in_cache,
                            CacheFragType type)
 {
-  return caches[type]->open_write(cont, &key->hash, old_info, pin_in_cache, nullptr /* key1 */, type, key->hostname, key->hostlen);
+  return caches[type]->open_write(cont, &key->hash, old_info, pin_in_cache, type, key->hostname, key->hostlen);
 }
 
 //----------------------------------------------------------------------------

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -466,8 +466,7 @@ struct Cache {
   Action     *open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, const HttpConfigAccessor *params,
                         CacheFragType type, const char *hostname, int host_len) const;
   Action     *open_write(Continuation *cont, const CacheKey *key, CacheHTTPInfo *old_info, time_t pin_in_cache = 0,
-                         const CacheKey *key1 = nullptr, CacheFragType type = CACHE_FRAG_TYPE_HTTP, const char *hostname = nullptr,
-                         int host_len = 0) const;
+                         CacheFragType type = CACHE_FRAG_TYPE_HTTP, const char *hostname = nullptr, int host_len = 0) const;
   static void generate_key(CryptoHash *hash, CacheURL *url);
   static void generate_key(HttpCacheKey *hash, CacheURL *url, bool ignore_query = false, cache_generation_t generation = -1);
 

--- a/src/iocore/cache/unit_tests/main.cc
+++ b/src/iocore/cache/unit_tests/main.cc
@@ -299,7 +299,7 @@ CacheWriteTest::start_test(int /* event ATS_UNUSED */, void * /* e ATS_UNUSED */
   }
 
   SET_HANDLER(&CacheWriteTest::write_event);
-  cacheProcessor.open_write(this, 0, &key, static_cast<CacheHTTPHdr *>(this->info.request_get()), old_info);
+  cacheProcessor.open_write(this, &key, old_info);
   return 0;
 }
 


### PR DESCRIPTION
No logic change. Main change is getting rid of `ATS_UNUSED` arguments from `CacheProcessor::open_read`, `CacheProcessor::open_write` and `Cache::open_write`
https://github.com/apache/trafficserver/blob/b1e9327069fde8207c2d5ed6178addc4e237498e/src/iocore/cache/CacheProcessor.cc#L409-L411
https://github.com/apache/trafficserver/blob/b1e9327069fde8207c2d5ed6178addc4e237498e/src/iocore/cache/CacheProcessor.cc#L417-L420

https://github.com/apache/trafficserver/blob/b1e9327069fde8207c2d5ed6178addc4e237498e/src/iocore/cache/Cache.cc#L608-L610                