### PR TITLE
Reset HttpCacheSM on following redirect

### DIFF
--- a/include/proxy/http/HttpCacheSM.h
+++ b/include/proxy/http/HttpCacheSM.h
@@ -49,6 +49,12 @@ struct HttpCacheAction : public Action {
   {
     sm = sm_arg;
   };
+  void
+  reset()
+  {
+    cancelled = false;
+  }
+
   HttpCacheSM *sm = nullptr;
 };
 
@@ -64,6 +70,7 @@ public:
     mutex     = amutex;
     captive_action.init(this);
   }
+  void reset();
 
   Action *open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, const OverridableHttpConfigParams *params,
                     time_t pin_in_cache);

--- a/src/proxy/http/HttpCacheSM.cc
+++ b/src/proxy/http/HttpCacheSM.cc
@@ -73,6 +73,25 @@ HttpCacheSM::HttpCacheSM()
 {
 }
 
+/**
+  Reset captive_action and counters for another cache operations.
+  - e.g. following redirect starts over from cache lookup
+ */
+void
+HttpCacheSM::reset()
+{
+  captive_action.reset();
+
+  open_read_tries  = 0;
+  open_write_tries = 0;
+  open_write_start = 0;
+
+  lookup_max_recursive = 0;
+  current_lookup_level = 0;
+
+  err_code = 0;
+}
+
 //////////////////////////////////////////////////////////////////////////
 //
 //  HttpCacheSM::state_cache_open_read()

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -8540,6 +8540,9 @@ HttpSM::redirect_request(const char *arg_redirect_url, const int arg_redirect_le
   }
 
   dump_header(dbg_ctl_http_hdrs, &t_state.hdr_info.client_request, sm_id, "Framed Client Request..checking");
+
+  // Reset HttpCacheSM for new cache operations
+  cache_sm.reset();
 }
 
 void


### PR DESCRIPTION
We face an issue that `http.current_active_client_connections` metrics keep increasing. After investigation with @cmcfarlen and @moonchen, we found `HttpSM` hangs on `state_cache_open_read` when it follows redirect and `HttpCacheSM::captive_action` was cancelled. Because `HttpCacheSM::state_cache_open_read` does nothing.

https://github.com/apache/trafficserver/blob/b1e9327069fde8207c2d5ed6178addc4e237498e/src/proxy/http/HttpCacheSM.cc#L106-L112

To fix the issue, this PR does reset `captive_action.cancelled` and other counters of `HttpCacheSM` on following redirect.

From our testing, this patch seems working, however, `captive_action` and `pending_action` related code seems pretty odd. They should be fixed.