### PR TITLE
OCSP: FetchSM initialization check

### DIFF
--- a/include/proxy/FetchSM.h
+++ b/include/proxy/FetchSM.h
@@ -38,6 +38,12 @@ class FetchSM : public Continuation
 {
 public:
   FetchSM() {}
+
+  /** Indicate whether FetchSM dependencies have been initialized by ATS.
+   * @return True if FetchSM dependencies have been initialized, false otherwise.
+   */
+  static bool is_initialized();
+
   void
   init_comm()
   {

--- a/include/proxy/PluginHttpConnect.h
+++ b/include/proxy/PluginHttpConnect.h
@@ -25,4 +25,5 @@
 
 #include "proxy/PluginVC.h"
 
+bool      PluginHttpConnectIsInitialized();
 PluginVC *PluginHttpConnectInternal(TSHttpConnectOptions *options);

--- a/src/iocore/cache/unit_tests/stub.cc
+++ b/src/iocore/cache/unit_tests/stub.cc
@@ -57,6 +57,11 @@ TSIOBufferReaderConsume(TSIOBufferReader /* readerp ATS_UNUSED */, int64_t /* nb
 
 #include "proxy/FetchSM.h"
 ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+bool
+FetchSM::is_initialized()
+{
+  return true;
+}
 void
 FetchSM::ext_launch()
 {

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -1284,12 +1284,18 @@ done:
   return rv;
 }
 
-void
+OCSPStatus
 ocsp_update()
 {
+  if (!FetchSM::is_initialized()) {
+    Dbg(dbg_ctl_ssl_ocsp, "FetchSM is not yet initialized. Skipping OCSP update.");
+    return OCSPStatus::OCSP_FETCHSM_NOT_INITIALIZED;
+  }
   shared_SSL_CTX    ctx;
   TS_OCSP_RESPONSE *resp = nullptr;
   time_t            current_time;
+
+  Note("OCSP refresh started");
 
   SSLCertificateConfig::scoped_config certLookup;
 
@@ -1332,6 +1338,8 @@ ocsp_update()
       }
     }
   }
+  Note("OCSP refresh finished");
+  return OCSPStatus::OCSP_OK;
 }
 
 // RFC 6066 Section-8: Certificate Status Request

--- a/src/iocore/net/P_OCSPStapling.h
+++ b/src/iocore/net/P_OCSPStapling.h
@@ -25,6 +25,11 @@
 
 void ssl_stapling_ex_init();
 bool ssl_stapling_init_cert(SSL_CTX *ctx, X509 *cert, const char *certname, const char *rsp_file);
-void ocsp_update();
+
+enum class OCSPStatus {
+  OCSP_OK,
+  OCSP_FETCHSM_NOT_INITIALIZED,
+};
+OCSPStatus ocsp_update();
 
 int ssl_callback_ocsp_stapling(SSL *, void *);

--- a/src/iocore/net/SSLNetProcessor.cc
+++ b/src/iocore/net/SSLNetProcessor.cc
@@ -38,9 +38,11 @@ struct OCSPContinuation : public Continuation {
   int
   mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   {
-    Note("OCSP refresh started");
-    ocsp_update();
-    Note("OCSP refresh finished");
+    if (ocsp_update() == OCSPStatus::OCSP_FETCHSM_NOT_INITIALIZED) {
+      Note("Delaying OCSP fetching until FetchSM is initialized.");
+      this_ethread()->schedule_in(this, HRTIME_SECONDS(1));
+      return EVENT_CONT;
+    }
     return EVENT_CONT;
   }
 

--- a/src/iocore/net/libinknet_stub.cc
+++ b/src/iocore/net/libinknet_stub.cc
@@ -27,6 +27,11 @@ AppVersionInfo appVersionInfo;
 
 #include "proxy/FetchSM.h"
 ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+bool
+FetchSM::is_initialized()
+{
+  return true;
+}
 void
 FetchSM::ext_launch()
 {

--- a/src/proxy/FetchSM.cc
+++ b/src/proxy/FetchSM.cc
@@ -40,6 +40,12 @@ DbgCtl dbg_ctl{DEBUG_TAG};
 
 } // end anonymous namespace
 
+bool
+FetchSM::is_initialized()
+{
+  return PluginHttpConnectIsInitialized();
+}
+
 void
 FetchSM::cleanUp()
 {

--- a/src/proxy/PluginHttpConnect.cc
+++ b/src/proxy/PluginHttpConnect.cc
@@ -26,6 +26,12 @@
 
 extern HttpSessionAccept *plugin_http_accept;
 
+bool
+PluginHttpConnectIsInitialized()
+{
+  return plugin_http_accept != nullptr;
+}
+
 PluginVC *
 PluginHttpConnectInternal(TSHttpConnectOptions *options)
 {

--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -347,6 +347,11 @@ PreWarmManager prewarmManager;
 
 #include "proxy/FetchSM.h"
 ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+bool
+FetchSM::is_initialized()
+{
+  return true;
+}
 void
 FetchSM::ext_launch()
 {


### PR DESCRIPTION
Delay OCSP fetch until FetchSM is initialized. This avoids noisy OCSP error messages on ATS initialization that result when the FetchSM calls fail each attempted OCSP cert fetch.

Fixes: #9819