### PR TITLE
Remove unused VIO.op values

### DIFF
--- a/include/iocore/eventsystem/VIO.h
+++ b/include/iocore/eventsystem/VIO.h
@@ -50,16 +50,6 @@ class ProxyMutex;
     </tr>
     <tr><td>READ</td><td>The VIO represents a read operation</td></tr>
     <tr><td>WRITE</td><td>The VIO represents a write operation</td></tr>
-    <tr><td>CLOSE</td><td>The VIO represents the request to close the
-                          VConnection</td></tr>
-    <tr><td>ABORT</td><td></td></tr>
-    <tr><td>SHUTDOWN_READ</td><td></td></tr>
-    <tr><td>SHUTDOWN_WRITE</td><td></td></tr>
-    <tr><td>SHUTDOWN_READWRITE</td><td></td></tr>
-    <tr><td>SEEK</td><td></td></tr>
-    <tr><td>PREAD</td><td></td></tr>
-    <tr><td>PWRITE</td><td></td></tr>
-    <tr><td>STAT</td><td></td></tr>
   </table>
 
 */
@@ -142,15 +132,6 @@ public:
     NONE = 0,
     READ,
     WRITE,
-    CLOSE,
-    ABORT,
-    SHUTDOWN_READ,
-    SHUTDOWN_WRITE,
-    SHUTDOWN_READWRITE,
-    SEEK,
-    PREAD,
-    PWRITE,
-    STAT,
   };
 
   /**

--- a/include/iocore/net/NetVConnection.h
+++ b/include/iocore/net/NetVConnection.h
@@ -129,13 +129,10 @@ public:
     called, the VConnection and underlying processor must NOT send
     any more events related to this VConnection to the state machine.
     Likewise, state machine must not access the VConnection or
-    any returned VIOs after calling close. lerrno indicates whether
-    a close is a normal close or an abort. The difference between
-    a normal close and an abort depends on the underlying type of
-    the VConnection. Passing VIO::CLOSE for lerrno indicates a
-    normal close while passing VIO::ABORT indicates an abort.
+    any returned VIOs after calling close. lerrno indicates the last
+    error on the NetVConnection.
 
-    @param lerrno VIO:CLOSE for regular close or VIO::ABORT for aborts
+    @param lerrno Last error on the NetVConnection
 
   */
   void do_io_close(int lerrno = -1) override = 0;


### PR DESCRIPTION
These values are in the enum, but are not used anywhere in the code. Remove the unused values and the confusing documentation.