### PR TITLE
Make chunk size parsing more strict

### DIFF
--- a/src/proxy/http/HttpTunnel.cc
+++ b/src/proxy/http/HttpTunnel.cc
@@ -183,9 +183,10 @@ ChunkedHandler::read_size()
           }
         } else {
           // We are done parsing size
-          if ((num_digits == 0 || running_sum < 0) ||       /* Bogus chunk size */
-              (!ParseRules::is_wslfcr(*tmp) && *tmp != ';') /* Unexpected character */
-          ) {
+          const auto is_bogus_chunk_size   = (num_digits == 0 || running_sum < 0);
+          const auto is_rfc_compliant_char = (ParseRules::is_ws(*tmp) || ParseRules::is_cr(*tmp) || *tmp == ';');
+          const auto is_acceptable_lf      = (ParseRules::is_lf(*tmp) && !strict_chunk_parsing);
+          if (is_bogus_chunk_size || (!is_rfc_compliant_char && !is_acceptable_lf)) {
             state = CHUNK_READ_ERROR;
             done  = true;
             break;

--- a/tests/gold_tests/chunked_encoding/replays/malformed_chunked_header.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/malformed_chunked_header.replay.yaml
@@ -236,3 +236,49 @@ sessions:
         encoding: uri
         # Chunk header must end with a sequence of CRLF.
         data: 3;x%0Adef%0D%0A0%0D%0A%0D%0A
+
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /response/malformed/chunk/size2
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 106 ]
+
+    # The connection will be dropped and this response will not go out.
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+      content:
+        transfer: plain
+        encoding: uri
+        # Chunk header must end with a sequence of CRLF.
+        data: 3%0Ddef%0D%0A0%0D%0A%0D%0A
+
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /response/malformed/chunk/size2
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 107 ]
+
+    # The connection will be dropped and this response will not go out.
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+      content:
+        transfer: plain
+        encoding: uri
+        # Chunk header must end with a sequence of CRLF.
+        data: 3%0Adef%0D%0A0%0D%0A%0D%0A


### PR DESCRIPTION
# Problem
There are cases where chunked requests that do not comply with RFC 9112 are forwarded to the origin server even when `proxy.config.http.strict_chunk_parsing` is set to 1.
For example, when sending an invalid chunked body like the one below, the request, including the chunked body, was forwarded to the origin server.

```
POST /post HTTP/1.1\r\n
Host: example.com\r\n
User-Agent: test\r\n
Transfer-Encoding: chunked\r\n
\r\n
4\n
test\r\n
0\r\n
\r\n
```

# Cause
The bug is caused by `ChunkedHandler::read_size()`. When the aforementioned chunked request is sent, `ChunkedHandler::read_size()` should be able to determine that the chunked body is invalid when it encounters the '\n' following '4'. However, `ChunkedHandler::read_size()` does not recognize it as invalid and continues processing.
Therefore, @maskit and I have fixed it to detect an invalid chunked body when it encounters the '\n' following '4'.