### PR TITLE
doc: ssl.client.alpn_protocol h22o update

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -4294,10 +4294,9 @@ Client-Related Configuration
    ``"h2,http/1.1,http/1.0"``       HTTP/2 is preferred by |TS| over HTTP/1.1 and HTTP/1.0. Thus, if the
                                     origin supports HTTP/2, it will be used for the connection. If
                                     not, it will fall back to HTTP/1.1 or, if that is not supported,
-                                    HTTP/1.0. (HTTP/2 to origin is currently not supported by |TS|.)
+                                    HTTP/1.0.
    ``"h2"``                         |TS| only advertises HTTP/2 support. Thus, the origin will
-                                    either negotiate HTTP/2 or fail the handshake. (HTTP/2 to origin
-                                    is currently not supported by |TS|.)
+                                    either negotiate HTTP/2 or fail the handshake.
    ================================ ======================================================================
 
    Note that this is an overridable configuration, so the ALPN can be configured on a per-origin


### PR DESCRIPTION
ssl.client.alpn_protocol was added before HTTP/2 to origin was supported and the "h2" examples stated the lack of support. But now that we support HTTP/2 to origin since 10.x, the docs should be updated to remove the statement that HTTP/2 to origin is not supported.