### PR TITLE
Cleanup: Track HttpCacheSM read retry event

### DIFF
--- a/include/proxy/http/HttpCacheSM.h
+++ b/include/proxy/http/HttpCacheSM.h
@@ -75,6 +75,7 @@ public:
     captive_action.init(this);
   }
   void reset();
+  void destroy();
 
   Action *open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, const OverridableHttpConfigParams *params,
                     time_t pin_in_cache);
@@ -260,7 +261,9 @@ private:
     const OverridableHttpConfigParams *_params = nullptr;
   };
 
-  void    do_schedule_in();
+  void   _schedule_read_retry();
+  Event *_read_retry_event = nullptr;
+
   Action *do_cache_open_read(const HttpCacheKey &);
 
   bool write_retry_done() const;

--- a/src/proxy/http/HttpCacheSM.cc
+++ b/src/proxy/http/HttpCacheSM.cc
@@ -80,6 +80,14 @@ HttpCacheSM::reset()
   err_code = 0;
 }
 
+void
+HttpCacheSM::destroy()
+{
+  if (_read_retry_event != nullptr) {
+    _read_retry_event->cancel();
+  }
+}
+
 //////////////////////////////////////////////////////////////////////////
 //
 //  HttpCacheSM::state_cache_open_read()
@@ -142,7 +150,7 @@ HttpCacheSM::state_cache_open_read(int event, void *data)
       if (open_read_tries <= master_sm->t_state.txn_conf->max_cache_open_read_retries) {
         // Retry to read; maybe the update finishes in time
         open_read_cb = false;
-        do_schedule_in();
+        _schedule_read_retry();
       } else {
         // Give up; the update didn't finish in time
         // HttpSM will inform HttpTransact to 'proxy-only'
@@ -157,6 +165,10 @@ HttpCacheSM::state_cache_open_read(int event, void *data)
     break;
 
   case EVENT_INTERVAL:
+    if (_read_retry_event == static_cast<Event *>(data)) {
+      _read_retry_event = nullptr;
+    }
+
     // Retry the cache open read if the number retries is less
     // than or equal to the max number of open read retries,
     // else treat as a cache miss.
@@ -240,9 +252,9 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
     }
 
     if (read_retry_on_write_fail || !write_retry_done()) {
-      // Retry open write;
+      // Retry open read;
       open_write_cb = false;
-      do_schedule_in();
+      _schedule_read_retry();
     } else {
       // The cache is hosed or full or something.
       // Forward the failure to the main sm
@@ -257,6 +269,10 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
   } break;
 
   case EVENT_INTERVAL:
+    if (_read_retry_event == static_cast<Event *>(data)) {
+      _read_retry_event = nullptr;
+    }
+
     if (master_sm->t_state.txn_conf->cache_open_write_fail_action == CACHE_WL_FAIL_ACTION_READ_RETRY) {
       Dbg(dbg_ctl_http_cache,
           "[%" PRId64 "] [state_cache_open_write] cache open write failure %d. "
@@ -288,16 +304,19 @@ HttpCacheSM::state_cache_open_write(int event, void *data)
   return VC_EVENT_CONT;
 }
 
+/**
+  Schedule a read retry event to this HttpCacheSM continuation with cache_open_read_retry_time delay.
+  The scheduled event is tracked by `_read_retry_event`.
+ */
 void
-HttpCacheSM::do_schedule_in()
+HttpCacheSM::_schedule_read_retry()
 {
-  ink_assert(pending_action == nullptr);
-  Action *action_handle =
-    mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(master_sm->t_state.txn_conf->cache_open_read_retry_time));
-
-  if (action_handle != ACTION_RESULT_DONE) {
-    pending_action = action_handle;
+  if (_read_retry_event != nullptr && _read_retry_event->cancelled == false) {
+    _read_retry_event->cancel();
   }
+
+  _read_retry_event =
+    mutex->thread_holding->schedule_in(this, HRTIME_MSECONDS(master_sm->t_state.txn_conf->cache_open_read_retry_time));
 
   return;
 }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -258,6 +258,8 @@ HttpSM::cleanup()
   HttpConfig::release(t_state.http_config_param);
   m_remap->release();
 
+  cache_sm.destroy();
+
   mutex.clear();
   tunnel.mutex.clear();
   cache_sm.mutex.clear();


### PR DESCRIPTION
`HttpCacheSM::pending_action` is used in 3 ways.

1. Read Retry Event
https://github.com/apache/trafficserver/blob/561771b1bad4221631c655d9b443df849b1aeccf/src/proxy/http/HttpCacheSM.cc#L295-L300

2. Action from `cacheProcessor.open_read`
https://github.com/apache/trafficserver/blob/561771b1bad4221631c655d9b443df849b1aeccf/src/proxy/http/HttpCacheSM.cc#L313-L317

3. Action from `cacheProcessor.open_write` 
https://github.com/apache/trafficserver/blob/561771b1bad4221631c655d9b443df849b1aeccf/src/proxy/http/HttpCacheSM.cc#L409-L413

This PR decouples the 1. Read Retry Event from others because it schedules an event to `HttpCacheSM` itself, so it's better to track the event by `HttpCacheSM`.