### PR TITLE
Remove accept_fn from NetAccept

### DIFF
--- a/src/iocore/net/P_NetAccept.h
+++ b/src/iocore/net/P_NetAccept.h
@@ -91,9 +91,8 @@ struct NetAcceptAction : public Action, public RefCountObjInHeap {
 struct NetAccept : public Continuation {
   ink_hrtime             period = 0;
   Server                 server;
-  AcceptFunctionPtr      accept_fn = nullptr;
-  int                    ifd       = NO_FD;
-  int                    id        = -1;
+  int                    ifd = NO_FD;
+  int                    id  = -1;
   Ptr<NetAcceptAction>   action_;
   SSLNextProtocolAccept *snpa = nullptr;
   NetAcceptEventIO       ep;

--- a/src/iocore/net/QUICNetProcessor.cc
+++ b/src/iocore/net/QUICNetProcessor.cc
@@ -248,7 +248,6 @@ QUICNetProcessor::main_accept(Continuation *cont, SOCKET fd, AcceptOptions const
   ink_assert(0 < opt.local_port && opt.local_port < 65536);
   accept_ip.network_order_port() = htons(opt.local_port);
 
-  na->accept_fn   = net_accept;
   na->server.sock = UnixSocket{fd};
   ats_ip_copy(&na->server.accept_addr, &accept_ip);
 

--- a/src/iocore/net/UnixNetAccept.cc
+++ b/src/iocore/net/UnixNetAccept.cc
@@ -272,11 +272,7 @@ NetAccept::accept_per_thread(int /* event ATS_UNUSED */, void * /* ep ATS_UNUSED
     }
   }
 
-  if (accept_fn == net_accept) {
-    SET_HANDLER(&NetAccept::acceptFastEvent);
-  } else {
-    SET_HANDLER(&NetAccept::acceptEvent);
-  }
+  SET_HANDLER(&NetAccept::acceptFastEvent);
   PollDescriptor *pd = get_PollDescriptor(this_ethread());
   if (this->ep.start(pd, this, EVENTIO_READ) < 0) {
     Fatal("[NetAccept::accept_per_thread]:error starting EventIO");
@@ -483,7 +479,7 @@ NetAccept::acceptEvent(int event, void *ep)
     }
 
     int res;
-    if ((res = accept_fn(this, e, false)) < 0) {
+    if ((res = net_accept(this, e, false)) < 0) {
       Metrics::Gauge::decrement(net_rsb.accepts_currently_open);
       /* INKqa11179 */
       Warning("Accept on port %d failed with error no %d", ats_ip_port_host_order(&server.addr), res);

--- a/src/iocore/net/UnixNetProcessor.cc
+++ b/src/iocore/net/UnixNetProcessor.cc
@@ -118,7 +118,6 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   ink_assert(opt.ip_family == AF_UNIX || (0 < opt.local_port && opt.local_port < 65536));
   accept_ip.network_order_port() = htons(opt.local_port);
 
-  na->accept_fn   = net_accept; // All callers used this.
   na->server.sock = UnixSocket{fd};
   ats_ip_copy(&na->server.accept_addr, &accept_ip);
 


### PR DESCRIPTION
This function pointer always points to net_accept.  Remove the extra indirection to make the code easier to read.