### PR TITLE
Fix FreeBSD Raw Cache Disk Support

### DIFF
--- a/src/tscore/ink_file.cc
+++ b/src/tscore/ink_file.cc
@@ -36,6 +36,10 @@
 #include <sys/mount.h> /* for BLKGETSIZE */
 #endif
 
+#if __has_include(<sys/disk.h>)
+#include <sys/disk.h> /* for DIOCGMEDIASIZE on FreeBSD */
+#endif
+
 using ioctl_arg_t = union {
   uint64_t u64;
   uint32_t u32;


### PR DESCRIPTION
When we use a raw cache disk, we must obtain the disk's geometry using ioctl.  At some point it became necessary to include <sys/disk.h> in order to have these ioctl numbers in FreeBSD.