### PR TITLE
Fix build for clang 20

### DIFF
--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -46,7 +46,7 @@ union CryptoHash {
   uint8_t  u8[CRYPTO_HASH_SIZE / sizeof(uint8_t)];
 
   /// Default constructor - init to zero.
-  CryptoHash() { memset(this, 0, sizeof(*this)); }
+  CryptoHash() { memset(static_cast<void *>(this), 0, sizeof(*this)); }
   /// Copy constructor.
   CryptoHash(CryptoHash const &that) = default;
 
@@ -55,7 +55,7 @@ union CryptoHash {
   operator=(CryptoHash const &that)
   {
     if (this != &that) {
-      memcpy(this, &that, sizeof(*this));
+      memcpy(static_cast<void *>(this), &that, sizeof(*this));
     }
     return *this;
   }

--- a/lib/swoc/src/swoc_ip.cc
+++ b/lib/swoc/src/swoc_ip.cc
@@ -239,7 +239,7 @@ IPEndpoint::family_name(sa_family_t family) {
 
 IPEndpoint &
 IPEndpoint::set_to_any(int family) {
-  memset(this, 0, sizeof(*this));
+  memset(static_cast<void *>(this), 0, sizeof(*this));
   if (AF_INET == family) {
     sa4.sin_family      = family;
     sa4.sin_addr.s_addr = INADDR_ANY;
@@ -268,7 +268,7 @@ IPEndpoint::is_any() const {
 
 IPEndpoint &
 IPEndpoint::set_to_loopback(int family) {
-  memset(this, 0, sizeof(*this));
+  memset(static_cast<void *>(this), 0, sizeof(*this));
   if (AF_INET == family) {
     sa.sa_family        = family;
     sa4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);

--- a/src/proxy/HostStatus.cc
+++ b/src/proxy/HostStatus.cc
@@ -214,7 +214,7 @@ HostStatus::setHostStatus(const std::string_view name, TSHostStatus status, cons
       host_stat = it->second;
     } else {
       host_stat = static_cast<HostStatRec *>(ats_malloc(sizeof(HostStatRec)));
-      bzero(host_stat, sizeof(HostStatRec));
+      bzero(static_cast<void *>(host_stat), sizeof(HostStatRec));
       hosts_statuses.emplace(name, host_stat);
     }
     if (reason & Reason::ACTIVE) {


### PR DESCRIPTION
Fix these warnings:

```
lib/swoc/src/swoc_ip.cc:242:10: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'swoc::IPEndpoint' [-Werror,-Wnontrivial-memaccess]
  242 |   memset(this, 0, sizeof(*this));
      |          ^
```