### PR TITLE
Fix openDirEntry leak

### DIFF
--- a/src/proxy/http/HttpCacheSM.cc
+++ b/src/proxy/http/HttpCacheSM.cc
@@ -69,15 +69,6 @@ void
 HttpCacheSM::reset()
 {
   captive_action.reset();
-
-  open_read_tries  = 0;
-  open_write_tries = 0;
-  open_write_start = 0;
-
-  lookup_max_recursive = 0;
-  current_lookup_level = 0;
-
-  err_code = 0;
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Workaround fix for #12204. 

I haven't found how resetting counters makes openDirEntry leak. However, this leak is serious on production so we need to revert the suspicious change.

- Leave the resetting `captive_action` for the active connection leak,
- Get rid of the resetting counters for the openDirEntry leak.

We tested this patch over a week, we haven't seen any leak so far.

