### PR TITLE
Clean up NetAccept

### DIFF
--- a/src/iocore/net/P_NetAccept.h
+++ b/src/iocore/net/P_NetAccept.h
@@ -102,8 +102,8 @@ struct NetAccept : public Continuation {
 
   virtual NetProcessor *getNetProcessor() const;
 
-  virtual void       init_accept(EThread *t = nullptr);
-  void               init_accept_loop();
+  virtual void       init_accept_periodic(EThread *t = nullptr);
+  void               init_accept_dedicated_threads();
   void               init_accept_per_thread();
   virtual void       stop_accept();
   virtual NetAccept *clone() const;
@@ -114,21 +114,23 @@ struct NetAccept : public Continuation {
    *
    * @see do_blocking_listen
    */
-  int do_listen();
+  int do_nonblocking_listen();
   int do_blocking_listen();
   int do_blocking_accept(EThread *t);
+  int do_accept_periodic(void *ep, bool blockable);
 
-  virtual int acceptEvent(int event, void *e);
-  virtual int acceptFastEvent(int event, void *e);
-  virtual int accept_per_thread(int event, void *e);
-  int         acceptLoopEvent(int event, Event *e);
-  void        cancel();
+  int  acceptEventPeriodic(int event, void *e);
+  int  acceptEventPerThread(int event, void *e);
+  int  listenEventPerThread(int event, void *e);
+  int  acceptEventDedicatedThread(int event, Event *e);
+  void cancel();
 
   explicit NetAccept(const NetProcessor::AcceptOptions &);
   ~NetAccept() override { action_ = nullptr; }
 
 private:
-  int do_listen_impl(bool non_blocking);
+  int                 do_listen_impl(bool non_blocking);
+  UnixNetVConnection *initialize_vc_from_con(Connection &con, NetAcceptAction *action, EThread *ethread);
 };
 
 extern Ptr<ProxyMutex>          naVecMutex;

--- a/src/iocore/net/P_QUICPacketHandler.h
+++ b/src/iocore/net/P_QUICPacketHandler.h
@@ -60,8 +60,8 @@ public:
   // NetAccept
   NetProcessor *getNetProcessor() const override;
   NetAccept    *clone() const override;
-  int           acceptEvent(int event, void *e) override;
-  void          init_accept(EThread *t) override;
+  int           acceptEventQUIC(int event, void *e);
+  void          init_accept_quic();
 
 protected:
   // QUICPacketHandler

--- a/src/iocore/net/QUICNetProcessor.cc
+++ b/src/iocore/net/QUICNetProcessor.cc
@@ -251,10 +251,11 @@ QUICNetProcessor::main_accept(Continuation *cont, SOCKET fd, AcceptOptions const
   na->server.sock = UnixSocket{fd};
   ats_ip_copy(&na->server.accept_addr, &accept_ip);
 
-  na->action_         = new NetAcceptAction();
-  *na->action_        = cont;
-  na->action_->server = &na->server;
-  na->init_accept();
+  na->action_                         = new NetAcceptAction();
+  *na->action_                        = cont;
+  na->action_->server                 = &na->server;
+  QUICPacketHandlerIn *packet_handler = static_cast<QUICPacketHandlerIn *>(na);
+  packet_handler->init_accept_quic();
 
   return na->action_.get();
 }

--- a/src/iocore/net/QUICPacketHandler.cc
+++ b/src/iocore/net/QUICPacketHandler.cc
@@ -136,7 +136,7 @@ QUICPacketHandlerIn::clone() const
 }
 
 int
-QUICPacketHandlerIn::acceptEvent(int event, void *data)
+QUICPacketHandlerIn::acceptEventQUIC(int event, void *data)
 {
   // NetVConnection *netvc;
   ink_release_assert(event == EVENT_IMMEDIATE || event == NET_EVENT_DATAGRAM_OPEN || event == NET_EVENT_DATAGRAM_READ_READY ||
@@ -175,11 +175,11 @@ QUICPacketHandlerIn::acceptEvent(int event, void *data)
 }
 
 void
-QUICPacketHandlerIn::init_accept(EThread * /* t  ATS_UNUSED */ = nullptr)
+QUICPacketHandlerIn::init_accept_quic()
 {
   int i, n;
 
-  SET_HANDLER(&QUICPacketHandlerIn::acceptEvent);
+  SET_HANDLER(&QUICPacketHandlerIn::acceptEventQUIC);
 
   n = eventProcessor.thread_group[ET_UDP]._count;
   for (i = 0; i < n; i++) {

--- a/src/iocore/net/UnixNetProcessor.cc
+++ b/src/iocore/net/UnixNetProcessor.cc
@@ -139,7 +139,7 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
 
   if (opt.frequent_accept) { // true
     if (accept_threads > 0 && listen_per_thread == 0) {
-      na->init_accept_loop();
+      na->init_accept_dedicated_threads();
     } else {
       na->init_accept_per_thread();
     }
@@ -154,7 +154,7 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
     }
 #endif // TS_USE_POSIX_CAP
   } else {
-    na->init_accept(nullptr);
+    na->init_accept_periodic(nullptr);
   }
 
   {


### PR DESCRIPTION
* Give sensible names to the three different accept code paths (dedicated, per-thread, periodic)
* Put common code into functions - vc initialization, send/recv buf settings
* Make QUIC UDP code path separate from TCP