### PR TITLE
Add proxy.config.http.negative_revalidating_list

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -1928,6 +1928,12 @@ Negative Response Caching
 
    This configuration defaults to 1,800 seconds (30 minutes).
 
+.. ts:cv:: CONFIG proxy.config.http.negative_revalidating_list STRING 500 502 503 504
+   :reloadable:
+
+   The HTTP status code for negative revalidating. Default values are mentioned above. The unwanted status codes can be
+   taken out from the list. Other status codes can be added. The variable is a list but parsed as STRING.
+
 Proxy User Variables
 ====================
 

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -1931,8 +1931,8 @@ Negative Response Caching
 .. ts:cv:: CONFIG proxy.config.http.negative_revalidating_list STRING 500 502 503 504
    :reloadable:
 
-   The HTTP status code for negative revalidating. Default values are mentioned above. The unwanted status codes can be
-   taken out from the list. Other status codes can be added. The variable is a list but parsed as STRING.
+   The HTTP status codes for which the negative revalidating feature applies. Note that this is a
+   `STRING` configuration containing a space separated list of the desired HTTP status codes.
 
 Proxy User Variables
 ====================

--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -802,6 +802,9 @@ public:
   // bitset to hold the status codes that will BE cached with negative caching enabled
   HttpStatusBitset negative_caching_list;
 
+  // bitset to hold the status codes that will used by nagative revalidating enabled
+  HttpStatusBitset negative_revalidating_list;
+
   // All the overridable configurations goes into this class member, but they
   // are not copied over until needed ("lazy").
   OverridableHttpConfigParams oride;

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -4319,7 +4319,7 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
     SET_VIA_STRING(VIA_SERVER_RESULT, VIA_SERVER_SERVED);
     SET_VIA_STRING(VIA_PROXY_RESULT, VIA_PROXY_SERVED);
 
-    /* In default, if we receive a 500, 502, 503 or 504 while revalidating
+    /* By default, if we receive a 500, 502, 503 or 504 while revalidating
        a document, treat the response as a 304 and in effect revalidate the document for
        negative_revalidating_lifetime. (negative revalidating)
      */

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -4319,15 +4319,12 @@ HttpTransact::handle_cache_operation_on_forward_server_response(State *s)
     SET_VIA_STRING(VIA_SERVER_RESULT, VIA_SERVER_SERVED);
     SET_VIA_STRING(VIA_PROXY_RESULT, VIA_PROXY_SERVED);
 
-    /* if we receive a 500, 502, 503 or 504 while revalidating
+    /* In default, if we receive a 500, 502, 503 or 504 while revalidating
        a document, treat the response as a 304 and in effect revalidate the document for
        negative_revalidating_lifetime. (negative revalidating)
      */
-
-    if ((server_response_code == HTTP_STATUS_INTERNAL_SERVER_ERROR || server_response_code == HTTP_STATUS_GATEWAY_TIMEOUT ||
-         server_response_code == HTTP_STATUS_BAD_GATEWAY || server_response_code == HTTP_STATUS_SERVICE_UNAVAILABLE) &&
-        s->cache_info.action == CACHE_DO_UPDATE && s->txn_conf->negative_revalidating_enabled &&
-        is_stale_cache_response_returnable(s)) {
+    if (s->txn_conf->negative_revalidating_enabled && s->http_config_param->negative_revalidating_list[server_response_code] &&
+        s->cache_info.action == CACHE_DO_UPDATE && is_stale_cache_response_returnable(s)) {
       HTTPStatus cached_response_code = s->cache_info.object_read->response_get()->status_get();
       if (!(cached_response_code == HTTP_STATUS_INTERNAL_SERVER_ERROR || cached_response_code == HTTP_STATUS_GATEWAY_TIMEOUT ||
             cached_response_code == HTTP_STATUS_BAD_GATEWAY || cached_response_code == HTTP_STATUS_SERVICE_UNAVAILABLE)) {

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -488,6 +488,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.http.negative_caching_list", RECD_STRING, "204 305 403 404 414 500 501 502 503 504", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.http.negative_revalidating_list", RECD_STRING, "500 502 503 504", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
 
   //        #########################
   //        # proxy users variables #

--- a/tests/gold_tests/cache/negative-revalidating.test.py
+++ b/tests/gold_tests/cache/negative-revalidating.test.py
@@ -21,47 +21,78 @@ Test.Summary = '''
 Test the negative revalidating feature.
 '''
 
+
+class NegativeRevalidatingTest:
+    _test_num: int = 0
+
+    def __init__(self, name: str, records_config: dict, replay_file: str):
+        self._tr = Test.AddTestRun(name)
+        self._replay_file = replay_file
+
+        self.__setupOriginServer()
+        self.__setupTS(records_config)
+        self.__setupClient()
+
+        NegativeRevalidatingTest._test_num += 1
+
+    def __setupClient(self):
+        self._tr.AddVerifierClientProcess(
+            f"client-{NegativeRevalidatingTest._test_num}", self._replay_file, http_ports=[self._ts.Variables.port])
+
+    def __setupOriginServer(self):
+        self._server = self._tr.AddVerifierServerProcess(f"server-{NegativeRevalidatingTest._test_num}", self._replay_file)
+
+    def __setupTS(self, records_config):
+        self._ts = Test.MakeATSProcess(f"ts-{NegativeRevalidatingTest._test_num}")
+        self._ts.Disk.records_config.update(records_config)
+        self._ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(self._server.Variables.http_port))
+
+    def run(self):
+        self._tr.Processes.Default.StartBefore(self._ts)
+        self._tr.StillRunningAfter = self._ts
+
+
 #
 # Verify disabled negative_revalidating behavior.
 #
-ts = Test.MakeATSProcess("ts-negative-revalidating-disabled")
-ts.Disk.records_config.update(
-    {
+NegativeRevalidatingTest(
+    "Verify negative revalidating disabled", {
         'proxy.config.diags.debug.enabled': 1,
         'proxy.config.diags.debug.tags': 'http|cache',
         'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.insert_response_via_str': 2,
         'proxy.config.http.negative_revalidating_enabled': 0,
         'proxy.config.http.cache.max_stale_age': 6
-    })
-tr = Test.AddTestRun("Verify disabled negative revalidating behavior.")
-replay_file = "replay/negative-revalidating-disabled.replay.yaml"
-server = tr.AddVerifierServerProcess("server1", replay_file)
-server_port = server.Variables.http_port
-tr.AddVerifierClientProcess("client1", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
-tr.Processes.Default.StartBefore(ts)
-tr.StillRunningAfter = ts
+    }, "replay/negative-revalidating-disabled.replay.yaml").run()
 
 #
 # Verify enabled negative_revalidating behavior.
 #
-ts = Test.MakeATSProcess("ts-negative-revalidating-enabled")
-ts.Disk.records_config.update(
+NegativeRevalidatingTest(
+    "Verify negative revalidating enabled",
     {
         'proxy.config.diags.debug.enabled': 1,
         'proxy.config.diags.debug.tags': 'http|cache',
         'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.insert_response_via_str': 2,
 
         # Negative revalidating is on by default. Verify this by leaving out the
         # following line and expect negative_revalidating to be enabled.
         # 'proxy.config.http.negative_revalidating_enabled': 1,
         'proxy.config.http.cache.max_stale_age': 6
-    })
-tr = Test.AddTestRun("Verify negative revalidating behavior.")
-replay_file = "replay/negative-revalidating-enabled.replay.yaml"
-server = tr.AddVerifierServerProcess("server2", replay_file)
-server_port = server.Variables.http_port
-tr.AddVerifierClientProcess("client2", replay_file, http_ports=[ts.Variables.port])
-ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server_port))
-tr.Processes.Default.StartBefore(ts)
-tr.StillRunningAfter = ts
+    },
+    "replay/negative-revalidating-enabled.replay.yaml").run()
+
+#
+# Verify negative_revalidating list behavior.
+#
+NegativeRevalidatingTest(
+    "Verify negative_revalidating_list behavior", {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|cache',
+        'proxy.config.http.insert_age_in_response': 0,
+        'proxy.config.http.insert_response_via_str': 2,
+        'proxy.config.http.cache.max_stale_age': 6,
+        'proxy.config.http.negative_revalidating_enabled': 1,
+        'proxy.config.http.negative_revalidating_list': "403 404"
+    }, "replay/negative-revalidating-list.replay.yaml").run()

--- a/tests/gold_tests/cache/replay/negative-revalidating-list.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-revalidating-list.replay.yaml
@@ -32,7 +32,6 @@ sessions:
   - client-request:
       method: "GET"
       version: "1.1"
-      scheme: "http"
       url: /path/reques_item
       headers:
         fields:
@@ -55,7 +54,6 @@ sessions:
   - client-request:
       method: "GET"
       version: "1.1"
-      scheme: "http"
       url: /path/reques_item
       headers:
         fields:
@@ -82,7 +80,6 @@ sessions:
   - client-request:
       method: "GET"
       version: "1.1"
-      scheme: "http"
       url: /path/reques_item
       headers:
         fields:
@@ -108,7 +105,6 @@ sessions:
   - client-request:
       method: "GET"
       version: "1.1"
-      scheme: "http"
       url: /path/reques_item
       headers:
         fields:
@@ -130,7 +126,6 @@ sessions:
   - client-request:
       method: "GET"
       version: "1.1"
-      scheme: "http"
       url: /path/reques_item
       headers:
         fields:

--- a/tests/gold_tests/cache/replay/negative-revalidating-list.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-revalidating-list.replay.yaml
@@ -1,0 +1,155 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# Verify negative_revalidating disabled behavior. This replay file assumes:
+#   * ATS is configured with negative_revalidating disabled.
+#   * max_stale_age is set to 6 seconds.
+#
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+
+  #
+  # Test 1: Negative revalidating for a cached content-length response.
+  #
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      scheme: "http"
+      url: /path/reques_item
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 31 ]
+
+    # Populate the cache with a 200 response.
+    server-response:
+      status: 200
+      reason: "OK"
+      headers:
+        fields:
+        - [ Content-Length, 32 ]
+        - [ Cache-Control, max-age=2 ]
+
+    proxy-response:
+      status: 200
+
+  # Verify we serve the 200 OK out of the cache if it is not stale.
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      scheme: "http"
+      url: /path/reques_item
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 32 ]
+
+      # Give cache IO enough time to finish.
+      delay: 100ms
+
+    # This should not reach the origin server.
+    server-response:
+      status: 503
+      reason: "Service Unavailable"
+      headers:
+        fields:
+        - [ Content-Length, 32 ]
+
+    # Again, we should serve this out of the cache.
+    proxy-response:
+      status: 200
+
+  # Verify that with negative_revalidating enabled, we serve the 200 OK out of
+  # the cache even though it is stale (but younger than max_stale_age) for configured status code.
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      scheme: "http"
+      url: /path/reques_item
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 33 ]
+
+      # Make sure the item is stale per it's 2 second max-age.
+      delay: 4s
+
+    server-response:
+      status: 403
+      reason: "Forbidden"
+      headers:
+        fields:
+        - [ Content-Length, 32 ]
+
+    # With negative_revalidating enabled, the cached response should be served
+    # even though it is stale.
+    proxy-response:
+      status: 200
+
+  # Verify that with negative_revalidating enabled, we serve the response from origin if it's not configured status code.
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      scheme: "http"
+      url: /path/reques_item
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 34 ]
+
+    server-response:
+      status: 503
+      reason: "Service Unavailable"
+      headers:
+        fields:
+        - [ Content-Length, 32 ]
+
+    # With negative_revalidating enabled, but status code is not configured one, return it directly
+    proxy-response:
+      status: 503
+
+  # Verify that max_stale_age is respected.
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      scheme: "http"
+      url: /path/reques_item
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 35 ]
+
+          # After this delay, the item is 8 seconds old. This makes it:
+          #  6 seconds beyond the server's max-age of 2 seconds and
+          #  2 seconds beyond ATS's max_stale_age of 6 seconds.
+      delay: 4s
+
+    server-response:
+      status: 503
+      reason: "Service Unavailable"
+      headers:
+        fields:
+        - [ Content-Length, 32 ]
+
+    # negative_revalidating is enabled, but now the cached item is older than
+    # max_stale_age.
+    proxy-response:
+      status: 503


### PR DESCRIPTION
Recently, I got a request to make negative revalidation feature more flexible. 

This makes HTTP status code list to do negative revalidation configurable. Prior to this change, it's hard coded in `HttpTransact::handle_cache_operation_on_forward_server_response`.

For now, this new config is not overridable. Ideally, it's should be overridable, but has the same issue with `proxy.config.http.negative_caching_list` (#12206).