### PR TITLE
x-ja3-via and x-ja4-via

### DIFF
--- a/doc/admin-guide/plugins/ja3_fingerprint.en.rst
+++ b/doc/admin-guide/plugins/ja3_fingerprint.en.rst
@@ -38,6 +38,9 @@ JA3 is available `here <https://github.com/salesforce/ja3>`__.
 The calculated JA3 fingerprints are then appended to upstream request in the field ``X-JA3-Sig``
 (to be processed at upstream). If multiple duplicates exist for the field name, it will append to the last
 occurrence; if none exists, it will add such a field to the headers. The signatures can also be logged locally.
+To help identify what proxy is adding what signature when there are multiple proxies in a chain, the plugin
+also adds a ``x-ja3-via`` header with a ``;`` separated list of :ts:cv:`proxy.config.proxy_name` values for
+each proxy in the chain that adds a signature.
 
 Plugin Configuration
 ====================

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint.test.py
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint.test.py
@@ -53,7 +53,7 @@ class JA3FingerprintTest:
 
         self._modify_incoming = modify_incoming
 
-        tr = Test.AddTestRun('Testing ja3_fingerprint plugin.')
+        tr = Test.AddTestRun(f'test_remap: {test_remap}, modify_incoming: {modify_incoming}')
         self._configure_dns(tr)
         self._configure_server(tr)
         self._configure_trafficserver()
@@ -87,6 +87,7 @@ class JA3FingerprintTest:
                 "x-ja3-raw: first-signature", "Verify the already-existing raw header was preserved.")
             self._server.Streams.All += Testers.ExcludesExpression(
                 "x-ja3-raw: first-signature;", "Verify no extra values were added due to preserve.")
+            self._server.Streams.All += Testers.ContainsExpression("x-ja3-via: test.proxy.com", "The x-ja3-via string was added.")
 
     def _configure_trafficserver(self) -> None:
         """Configure Traffic Server to be used in the test."""
@@ -117,6 +118,7 @@ class JA3FingerprintTest:
                 'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
                 'proxy.config.dns.nameservers': f"127.0.0.1:{self._dns.Variables.Port}",
                 'proxy.config.dns.resolv_conf': 'NULL',
+                'proxy.config.proxy_name': 'test.proxy.com',
                 'proxy.config.diags.debug.enabled': 1,
                 'proxy.config.diags.debug.tags': 'http|ja3_fingerprint',
             })

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_global.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_global.replay.yaml
@@ -42,6 +42,7 @@ sessions:
       headers:
         fields:
         - [ X-Request, { value: 'https-request', as: equal } ]
+        - [ x-ja3-via, { value: 'test.proxy.com', as: equal } ]
         - [ X-JA3-Sig, { as: present } ]
         - [ X-JA3-Raw, { as: present } ]
 
@@ -81,6 +82,7 @@ sessions:
         - [ uuid, http2-request ]
         - [ x-request, http2-request ]
         - [ x-ja3-raw, first-signature ]
+        - [ x-ja3-via, first-via ]
       content:
         size: 399
 
@@ -88,6 +90,7 @@ sessions:
       headers:
         fields:
         - [ x-request, { value: 'http2-request', as: equal } ]
+        - [ x-ja3-via, { value: 'first-via', as: equal } ]
         - [ X-JA3-Sig, { as: present } ]
         - [ X-JA3-Raw, { as: present } ]
 

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_remap.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_remap.replay.yaml
@@ -44,6 +44,7 @@ sessions:
       headers:
         fields:
         - [ X-Request, { value: 'https-request', as: equal } ]
+        - [ x-ja3-via, { as: absent } ]
         - [ X-JA3-Sig, { as: absent } ]
         - [ X-JA3-Raw, { as: absent } ]
 
@@ -82,6 +83,8 @@ sessions:
         - [ content-type, image/jpeg ]
         - [ uuid, http2-request ]
         - [ x-request, http2-request ]
+        - [ x-ja3-sig, first-signature ]
+        - [ x-ja3-via, first-via ]
       content:
         size: 399
 
@@ -91,6 +94,7 @@ sessions:
       headers:
         fields:
         - [ x-request, { value: 'http2-request', as: equal } ]
+        - [ x-ja3-via, { value: 'first-via, test.proxy.com', as: equal } ]
         - [ X-JA3-Sig, { as: present } ]
         - [ X-JA3-Raw, { as: absent } ]
 

--- a/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.replay.yaml
@@ -38,6 +38,7 @@ sessions:
       headers:
         fields:
         - [ ja4, { as: contains } ]
+        - [ x-ja4-via, { value: 'test.proxy.com', as: equal } ]
 
     server-response:
       status: 200

--- a/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.test.py
+++ b/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.test.py
@@ -117,6 +117,7 @@ class TestJA4Fingerprint:
                 'proxy.config.ssl.server.cert.path': f'{ts.Variables.SSLDir}',
                 'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
                 'proxy.config.http.server_ports': f'{self._port_one}:ssl',
+                'proxy.config.proxy_name': 'test.proxy.com',
                 'proxy.config.diags.debug.enabled': 1,
                 'proxy.config.diags.debug.tags': 'ja4_fingerprint|http',
             })


### PR DESCRIPTION
Add via strings for the JA* fingerprints. This can be helpful in situations where multiple layers of proxies can add these and it may not be obvious what host added what fingerprint.