### PR TITLE
Update SNI for origin side connections

### DIFF
--- a/include/iocore/net/TLSSNISupport.h
+++ b/include/iocore/net/TLSSNISupport.h
@@ -58,8 +58,30 @@ public:
 
   int perform_sni_action(SSL &ssl);
   // Callback functions for OpenSSL libraries
+
+  /** Process a CLIENT_HELLO from a client.
+   *
+   * This is for client-side connections.
+   */
   void on_client_hello(ClientHello &client_hello);
+
+  /** Process the servername extension when a client uses one in the TLS handshake.
+   *
+   * This is for client-side connections.
+   */
   void on_servername(SSL *ssl, int *al, void *arg);
+
+  /** Set the servername extension for server-side connections.
+   *
+   * This is for server-side connections.
+   * This calls SSL_set_tlsext_host_name() to set the servername extension.
+   *
+   * @param ssl The SSL object upon which the servername extension is set.
+   * @param name The servername to set. This is assumed to be a non-empty,
+   *   null-terminated string.
+   * @return True if the servername was set successfully, false otherwise.
+   */
+  bool set_sni_server_name(SSL *ssl, char const *name);
 
   /**
    * Get the server name in SNI
@@ -92,5 +114,5 @@ private:
   // Null-terminated string, or nullptr if there is no SNI server name.
   std::unique_ptr<char[]> _sni_server_name;
 
-  void _set_sni_server_name(std::string_view name);
+  void _set_sni_server_name_buffer(std::string_view name);
 };

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -1146,7 +1146,7 @@ SSLNetVConnection::sslStartHandShake(int event, int &err)
       // SNI
       ats_scoped_str &tlsext_host_name = this->options.sni_hostname ? this->options.sni_hostname : this->options.sni_servername;
       if (tlsext_host_name) {
-        if (SSL_set_tlsext_host_name(this->ssl, tlsext_host_name)) {
+        if (this->set_sni_server_name(this->ssl, tlsext_host_name)) {
           Dbg(dbg_ctl_ssl, "using SNI name '%s' for client handshake", tlsext_host_name.get());
         } else {
           Dbg(dbg_ctl_ssl_error, "failed to set SNI name '%s' for client handshake", tlsext_host_name.get());


### PR DESCRIPTION
Origin side connection pooling was not able to access the appropriate SNI of those connections, resulting in those connections not being able to be reused appropriately. This addresses that issue by setting the internal SNI buffer for those connections to the appropriate SNI so that the origin conection pooling feature has access to the SNI value.

This also populates the SNI buffer when an SSLNetVConnection is bound to an SSL object.

Fixes: #12214

---

### For Review

Essentially, the problem with #12214 was that the `_sni_server_name` was not set in certain origin side connection situations. This address that by doing two things:

* Add `TLSSNISupport::set_sni_server_name` for callers instead of calling `SSL_set_tlsext_host_name` directly. This function both calls `SSL_set_tlsext_host_name` and updates `_sni_server_name`.
* On `TLSSNISupport::bind` (which is used when an SSL instead is being reused for a new SSLNetVConnection), update `_sni_server_name` from the SNI of the SSL instance.