### PR TITLE
HRW: Allow using a request header for IP lookups

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -343,6 +343,16 @@ setting headers. For example::
         set-header ATS-Geo-ASN %{GEO:ASN}
         set-header ATS-Geo-ASN-NAME %{GEO:ASN-NAME}
 
+Additionally, you can specify a client request header to use to extract an IP address
+value from. This is specified as a second argument, separated with a second colon.
+For example::
+
+    cond %{GEO:COUNTRY:X-Client-IP} =US
+        set-status 403
+
+If there is no request header matching the condition, the condition will always return
+an empty string, as if the client IP was not found in the GEO-IP database.
+
 GROUP
 ~~~~~
 ::

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -851,10 +851,10 @@ ConditionGeo::set_qualifier(const std::string &q)
 }
 
 static const sockaddr *
-_geo_ip_helper(const std::string &header, const Resources &res, struct sockaddr &addr_buf)
+_geo_ip_helper(const std::string &header, const Resources &res, struct sockaddr &addr_buf, int txn_private_slot)
 {
   if (header.empty()) {
-    return TSHttpTxnClientAddrGet(res.txnp);
+    return getClientAddr(res.txnp, txn_private_slot);
   } else {
     int len = 0;
 
@@ -882,7 +882,7 @@ void
 ConditionGeo::append_value(std::string &s, const Resources &res)
 {
   struct sockaddr addr_buf;
-  const sockaddr *client_ip = _geo_ip_helper(_ip_header, res, addr_buf);
+  const sockaddr *client_ip = _geo_ip_helper(_ip_header, res, addr_buf, _txn_private_slot);
 
   if (client_ip != nullptr) {
     if (is_int_type()) {
@@ -902,7 +902,7 @@ ConditionGeo::eval(const Resources &res)
   Dbg(pi_dbg_ctl, "Evaluating GEO()");
   if (is_int_type()) {
     struct sockaddr addr_buf;
-    const sockaddr *client_ip = _geo_ip_helper(_ip_header, res, addr_buf);
+    const sockaddr *client_ip = _geo_ip_helper(_ip_header, res, addr_buf, _txn_private_slot);
 
     if (client_ip != nullptr) {
       int64_t geo = get_geo_int(client_ip);

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -486,6 +486,7 @@ protected:
 
   bool          eval(const Resources &res) override;
   GeoQualifiers _geo_qual = GEO_QUAL_COUNTRY;
+  std::string   _ip_header;
   bool          _int_type = false;
 };
 


### PR DESCRIPTION
Using this, you can optionally request for the GEO conditions to get the client IP from a client request header, e.g.

```
cond %{GEO:COUNTRY:X-Client-IP} =US [NOT]
    set-status 403
```