### PR TITLE
cachekey doc: --include-headers matched case insensitively

### DIFF
--- a/doc/admin-guide/plugins/cachekey.en.rst
+++ b/doc/admin-guide/plugins/cachekey.en.rst
@@ -140,7 +140,7 @@ Cache key structure and related plugin parameters
   optional components      | └───────────────────┴───────────────────┘
   configured               |
 
-* ``--include-headers`` (default: empty list) - comma separated list of headers to be added to the `cache key`. The list of headers defined by ``--include-headers`` are always sorted before adding them to the `cache key`.
+* ``--include-headers`` (default: empty list) - comma separated list of headers to be added to the `cache key`. The list of headers defined by ``--include-headers`` are always sorted before adding them to the `cache key`. These header field names are matched case insensitively.
 
 * ``--capture-header=<headername>:<capture_definition>`` (default: empty) - captures elements from header <headername> using <capture_definition> and adds them to the `cache key`.
 


### PR DESCRIPTION
Update the cachekey doc to indicate that the HTTP field name list provided to --include-headers are matched case insensitively.