### PR TITLE
Connection tracker: Add functions to query inbound groups.

### DIFF
--- a/include/iocore/net/ConnectionTracker.h
+++ b/include/iocore/net/ConnectionTracker.h
@@ -212,6 +212,14 @@ public:
    */
   static TxnState obtain_outbound(TxnConfig const &txn_cnf, std::string_view fqdn, IpEndpoint const &addr);
 
+  /** Get the currently existing inbound groups.
+   * @param [out] groups parameter - pointers to the groups are pushed in to this container.
+   *
+   * The groups are loaded in to @a groups, which is cleared before loading. Note the groups returned will remain valid
+   * although data inside the groups is volatile.
+   */
+  static void get_inbound_groups(std::vector<std::shared_ptr<Group const>> &groups);
+
   /** Get the currently existing outbound groups.
    * @param [out] groups parameter - pointers to the groups are pushed in to this container.
    *
@@ -219,6 +227,12 @@ public:
    * although data inside the groups is volatile.
    */
   static void get_outbound_groups(std::vector<std::shared_ptr<Group const>> &groups);
+
+  /** Write the inbound connection tracking data to JSON.
+   * @return string containing a JSON encoding of the table.
+   */
+  static std::string inbound_to_json_string();
+
   /** Write the outbound connection tracking data to JSON.
    * @return string containing a JSON encoding of the table.
    */
@@ -227,6 +241,15 @@ public:
    * @param f Output file.
    */
   static void dump(FILE *f);
+  /** Write the groups to @a f.
+   * @param f Output file.
+   */
+  static void dump_inbound(FILE *f);
+  /** Write the groups to @a f.
+   * @param f Output file.
+   */
+  static void dump_outbound(FILE *f);
+
   /** Do global initialization.
    *
    * This sets up the global configuration and any configuration update callbacks needed. It is presumed


### PR DESCRIPTION
This, as well as the outbound groups will be used to report its data using the jsonrpc handlers.(upcoming [PR](https://github.com/apache/trafficserver/pull/12260))
This also fixes an issue in the build of the output json stream(`outbound_to_json_string`).

Some output:

IN
```bash
[I] Peer Connection Tracking
Current | Block |                  Address |                     Hostname Hash |    Match |
  ------|-------|--------------------------|-----------------------------------|----------|
1       | 1     | 127.0.0.1:35204          | 00000000000000000000000000000000  | ip       |
  ------|-------|--------------------------|-----------------------------------|----------|
```
_Note: `hash=00000000000000000000000000000000` as the `fqdn` is empty._

OUT
```bash
[O] Peer Connection Tracking
Current | Block |                  Address |                     Hostname Hash |    Match |
  ------|-------|--------------------------|-----------------------------------|----------|
5       | 0     | 127.0.0.1:80             | f528764d624db129b32c21fbca0cb8d6  | both     |
  ------|-------|--------------------------|-----------------------------------|----------|
```