### PR TITLE
Updated testing and fixed bug in SSLSNIConfig

### DIFF
--- a/src/iocore/net/SSLSNIConfig.cc
+++ b/src/iocore/net/SSLSNIConfig.cc
@@ -77,6 +77,7 @@ NamedElement::operator=(NamedElement &&other)
   if (this != &other) {
     match               = std::move(other.match);
     inbound_port_ranges = std::move(other.inbound_port_ranges);
+    rank                = other.rank;
   }
   return *this;
 }

--- a/src/iocore/net/unit_tests/sni_conf_test.yaml
+++ b/src/iocore/net/unit_tests/sni_conf_test.yaml
@@ -36,3 +36,13 @@ sni:
   http2_buffer_water_mark: 256
 - fqdn: foo.bar.com
   http2: false
+
+# test with mixed-case
+- fqdn: "MiXeDcAsE.foo.com"
+  http2: true
+  http2_buffer_water_mark: 256
+  inbound_port_ranges: 31337
+
+# # test with mixed-case glob
+- fqdn: "*.MiXeDcAsE.com"
+  http2: false

--- a/src/iocore/net/unit_tests/test_SSLSNIConfig.cc
+++ b/src/iocore/net/unit_tests/test_SSLSNIConfig.cc
@@ -41,77 +41,104 @@ TEST_CASE("Test SSLSNIConfig")
 
   SECTION("The config does not match any SNIs for someport.com:577")
   {
-    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 577)};
+    auto const &actions{params.get("someport.com", 577)};
     CHECK(!actions.first);
   }
 
   SECTION("The config does not match any SNIs for someport.com:808")
   {
-    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 808)};
+    auto const &actions{params.get("someport.com", 808)};
     CHECK(!actions.first);
   }
 
   SECTION("The config does not match any SNIs for oneport.com:1")
   {
-    auto const &actions{params.get({"oneport.com", std::strlen("oneport.com")}, 1)};
+    auto const &actions{params.get("oneport.com", 1)};
     CHECK(!actions.first);
   }
 
   SECTION("The config does match an SNI for oneport.com:433")
   {
-    auto const &actions{params.get({"oneport.com", std::strlen("oneport.com")}, 433)};
+    auto const &actions{params.get("oneport.com", 433)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 2);
   }
 
   SECTION("The config matches an SNI for allports.com")
   {
-    auto const &actions{params.get({"allports.com", std::strlen("allports.com")}, 1)};
+    auto const &actions{params.get("allports.com", 1)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 2);
   }
 
   SECTION("The config matches an SNI for someport.com:1")
   {
-    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 1)};
+    auto const &actions{params.get("someport.com", 1)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 3);
   }
 
   SECTION("The config matches an SNI for someport.com:433")
   {
-    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 433)};
+    auto const &actions{params.get("someport.com", 433)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 3);
   }
 
   SECTION("The config matches an SNI for someport:8080")
   {
-    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 8080)};
+    auto const &actions{params.get("someport.com", 8080)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 2);
   }
 
   SECTION("The config matches an SNI for someport:65535")
   {
-    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 65535)};
+    auto const &actions{params.get("someport.com", 65535)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 2);
   }
 
   SECTION("The config matches an SNI for someport:482")
   {
-    auto const &actions{params.get({"someport.com", std::strlen("someport.com")}, 482)};
+    auto const &actions{params.get("someport.com", 482)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 3);
   }
 
   SECTION("Matching order")
   {
-    std::string_view target = "foo.bar.com";
-    auto const      &actions{params.get(target, 443)};
+    auto const &actions{params.get("foo.bar.com", 443)};
     REQUIRE(actions.first);
     REQUIRE(actions.first->size() == 5); ///< three H2 config + early data + fqdn
+  }
+
+  SECTION("Test mixed-case")
+  {
+    auto const &actions{params.get("SoMePoRt.CoM", 65535)};
+    REQUIRE(actions.first);
+    REQUIRE(actions.first->size() == 2);
+  }
+
+  SECTION("Test mixed-case with wildcard in yaml config")
+  {
+    auto const &actions{params.get("AnYtHiNg.BaR.CoM", 443)};
+    REQUIRE(actions.first);
+    REQUIRE(actions.first->size() == 4);
+  }
+
+  SECTION("Test mixed-case in yaml config")
+  {
+    auto const &actions{params.get("mixedcase.foo.com", 31337)};
+    REQUIRE(actions.first);
+    REQUIRE(actions.first->size() == 4);
+  }
+
+  SECTION("Test mixed-case glob in yaml config")
+  {
+    auto const &actions{params.get("FoO.mixedcase.com", 443)};
+    REQUIRE(actions.first);
+    REQUIRE(actions.first->size() == 3);
   }
 }
 

--- a/src/iocore/net/unit_tests/test_YamlSNIConfig.cc
+++ b/src/iocore/net/unit_tests/test_YamlSNIConfig.cc
@@ -55,7 +55,7 @@ TEST_CASE("YamlSNIConfig sets port ranges appropriately")
     FAIL(errorstream.str());
   }
   REQUIRE(zret.is_ok());
-  REQUIRE(conf.items.size() == 7);
+  REQUIRE(conf.items.size() == 9);
 
   SECTION("If no ports were specified, port range should contain all ports.")
   {


### PR DESCRIPTION
If the `sni.yaml` configuration file contained multiple wildcard entries, an incorrect wildcard entry could be matched instead of the exact match listed first in the file.

This issue occurred because the `rank` for wildcard entries was set to 0 (the default value) and was not updated in the move constructor when the list was resized to accommodate a new entry.

