### PR TITLE
HRW: Allow sets to have quoted strings

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -739,6 +739,11 @@ The absence of an operand for conditions which accept them simply requires that
 a value exists (e.g. the content of the header is not an empty string) for the
 condition to be considered true.
 
+.. note::
+    Strings within a set can be quoted, but the quotes are not necessary. This
+    can be important if a matching string can include spaces or commas,
+    e.g. ``(foo,"bar,fie",baz)``.
+
 Condition Flags
 ---------------
 
@@ -764,9 +769,10 @@ EXT    The substring match only applies to the file extension following a dot.
        This is generally mostly useful for the ``URL:PATH`` part.
 ====== ========================================================================
 
-**Note**: At most, one of ``[PRE]``, ``[SUF]``, ``[MID]``, or ``[EXT]`` may be
-used at any time. They can however be used together with ``[NOCASE]`` and the
-other flags.
+.. note::
+    At most, one of ``[PRE]``, ``[SUF]``, ``[MID]``, or ``[EXT]`` may be
+    used at any time. They can however be used together with ``[NOCASE]`` and the
+    other flags.
 
 Operators
 ---------
@@ -898,7 +904,9 @@ Will call ``<URL>`` (see URL in `URL Parts`_) to retrieve a custom error respons
 and set the body with the result. Triggering this rule on an OK transaction will
 send a 500 status code to the client with the desired response. If this is triggered
 on any error status code, that original status code will be sent to the client.
-**Note**: This config should only be set using READ_RESPONSE_HDR_HOOK
+
+.. note::
+    This config should only be set using READ_RESPONSE_HDR_HOOK
 
 An example config would look like::
 
@@ -958,8 +966,9 @@ the appropriate logs even when the debug tag has not been enabled. For
 additional information on |TS| debugging statements, refer to
 :ref:`developer-debug-tags` in the developer's documentation.
 
-**Note**: This operator is deprecated, use the `set-http-cntl`_ operator instead,
-with the ``TXN_DEBUG`` control.
+.. note::
+    This operator is deprecated, use the `set-http-cntl`_ operator instead,
+    with the ``TXN_DEBUG`` control.
 
 set-destination
 ~~~~~~~~~~~~~~~
@@ -1074,8 +1083,9 @@ When invoked, and when ``<value>`` is any of ``1``, ``true``, or ``TRUE``, this
 operator causes |TS| to abort further request remapping. Any other value and
 the operator will effectively be a no-op.
 
-**Note**: This operator is deprecated, use the `set-http-cntl`_ operator instead,
-with the ``SKIP_REMAP`` control.
+.. note::
+    This operator is deprecated, use the `set-http-cntl`_ operator instead,
+    with the ``SKIP_REMAP`` control.
 
 set-cookie
 ~~~~~~~~~~

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -109,6 +109,7 @@ public:
 
   bool parse_line(const std::string &original_line);
 
+  // We chose to have this take a std::string, since some of these conversions can not take a TextView easily
   template <typename NumericT>
   static NumericT
   parseNumeric(const std::string &s)

--- a/tests/gold_tests/pluginTest/header_rewrite/gold/ext-sets.gold
+++ b/tests/gold_tests/pluginTest/header_rewrite/gold/ext-sets.gold
@@ -7,4 +7,5 @@
 < Date: ``
 ``
 < X-Extension: Yes
+< X-Testing: Yes
 ``

--- a/tests/gold_tests/pluginTest/header_rewrite/gold/header_rewrite-client.gold
+++ b/tests/gold_tests/pluginTest/header_rewrite/gold/header_rewrite-client.gold
@@ -10,4 +10,5 @@
 < Server: ATS/``
 < Cache-Control: no-store
 < X-Pre-Else: Yes
+< X-Testing: No
 ``

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
@@ -90,7 +90,8 @@ ts.Disk.traffic_out.Content = "gold/header_rewrite-tag.gold"
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '--proxy 127.0.0.1:{0} "http://www.example.com/from_path/hrw-sets.png" '
-    '-H "Proxy-Connection: keep-alive" --verbose'.format(ts.Variables.port))
+    '-H "Proxy-Connection: keep-alive" -H "X-Testing: foo,bar" '
+    '--verbose'.format(ts.Variables.port))
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/ext-sets.gold"
 tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/rule_client.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/rule_client.conf
@@ -30,3 +30,9 @@ cond %{CLIENT-URL:PATH} (hrw,foo) [MID,NOCASE]
   no-op
 else
   set-header X-Pre-Else "Yes"
+
+cond %{SEND_RESPONSE_HDR_HOOK}
+cond %{CLIENT-HEADER:X-Testing} (foo,bar,"foo,bar")
+  set-header X-Testing "Yes"
+else
+  set-header X-Testing "No"


### PR DESCRIPTION
This became particularly important with the new syntax for HRW4U, and some specific examples where commas can be inside a set string.