### PR TITLE
HTTP/2: Wait END_STREAM flag on half-closed(local) stream state

### DIFF
--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -175,9 +175,15 @@ Http2ConnectionState::rcv_data_frame(const Http2Frame &frame)
 
     // Pure END_STREAM
     if (payload_length == 0) {
+      if (stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
+        stream->initiating_close();
+        return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
+      }
+
       if (stream->is_read_enabled()) {
         stream->signal_read_event(VC_EVENT_READ_COMPLETE);
       }
+
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
     }
   } else {
@@ -2380,13 +2386,16 @@ Http2ConnectionState::send_data_frames(Http2Stream *stream)
 
     if (result == Http2SendDataFrameResult::DONE) {
       if (!stream->is_outbound_connection()) {
-        // Delete a stream immediately
-        // TODO its should not be deleted for a several time to handling
-        // RST_STREAM and WINDOW_UPDATE.
-        // See 'closed' state written at [RFC 7540] 5.1.
-        Http2StreamDebug(this->session, stream->get_id(), "Shutdown stream");
-        stream->signal_write_event(VC_EVENT_WRITE_COMPLETE);
-        stream->do_io_close();
+        if (stream->get_state() == Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
+          // Delete a stream immediately
+          Http2StreamDebug(this->session, stream->get_id(), "Shutdown stream");
+          stream->signal_write_event(VC_EVENT_WRITE_COMPLETE);
+          stream->do_io_close();
+        } else {
+          // This stream waits for the END_STREAM in half-closed (local) state until `http.transaction_no_activity_timeout_in`
+          // expires
+          Http2StreamDebug(this->session, stream->get_id(), "waiting END_STREAM");
+        }
       } else if (stream->is_outbound_connection() && stream->is_write_vio_done()) {
         stream->signal_write_event(VC_EVENT_WRITE_COMPLETE);
       } else {

--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -31,6 +31,7 @@
 #include "tscore/Diags.h"
 #include "tscore/HTTPVersion.h"
 #include "tscore/ink_assert.h"
+#include "tsutil/DbgCtl.h"
 
 #include <numeric>
 
@@ -590,7 +591,7 @@ Http2Stream::transaction_done()
   SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
   super::transaction_done();
 
-  if (!closed) {
+  if (!closed && _state == Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
     do_io_close(); // Make sure we've been closed.  If we didn't close the _proxy_ssn session better still be open
   }
   Http2ConnectionState &state = this->get_connection_state();
@@ -1081,11 +1082,20 @@ Http2Stream::clear_io_events()
   }
 }
 
-//  release and do_io_close are the same for the HTTP/2 protocol
+/**
+  Callback from HttpSM
+
+  release and do_io_close are the same for the HTTP/2 protocol
+ */
 void
 Http2Stream::release()
 {
-  this->do_io_close();
+  if (_state == Http2StreamState::HTTP2_STREAM_STATE_CLOSED) {
+    this->do_io_close();
+    return;
+  }
+
+  Http2StreamDebug("release is called, but this stream is not ready");
 }
 
 void


### PR DESCRIPTION
# Problem
Recently, we found that some clients send `HEADERS` frame followed by an empty `DATA` frame with the `END_STREAM` flag even for GET requests. 

- `HEADERS` frame with `END_HEADERS` flag
- zero-length `DATA` frame with `END_STREAM` flag

Sometimes ATS closes the stream immediately after it sends DATA frame to the client, right after handling the `HEADERS` frame. In this case, ATS treats the zero-length DATA frame as a stream error because the stream is already closed.

However, this appears to be a bug. The spec[*1] says that an endpoint should keep the stream in the `half-closed (local)` state after sending `END_STREAM` flag and wait to receive `END_STREAM` flag from the peer before closing it.

With this change, ATS waits for the `END_STREAM` flag until the `http.transaction_no_activity_timeout_in` expires.

[*1] https://datatracker.ietf.org/doc/html/rfc9113#name-stream-states


