### PR TITLE
HTTP/2: actively close stream in the half-closed(local) state

### DIFF
--- a/include/proxy/http2/Http2ConnectionState.h
+++ b/include/proxy/http2/Http2ConnectionState.h
@@ -281,6 +281,9 @@ private:
   Http2StreamId      latest_streamid_out = 0;
   std::atomic<int>   stream_requests     = 0;
 
+  // TODO: change to fixed size buffer
+  std::set<Http2StreamId> _actively_closed_streams;
+
   // Counter for current active streams which are started by the client.
   std::atomic<uint32_t> peer_streams_count_in = 0;
 


### PR DESCRIPTION
Alternative approach of https://github.com/apache/trafficserver/pull/12257.