### PR TITLE
Fix narrowing conversion of connection ID

### DIFF
--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -614,10 +614,10 @@ public:
   bool set_server_session_private(bool private_session);
   bool is_dying() const;
 
-  int client_connection_id() const;
-  int client_transaction_id() const;
-  int client_transaction_priority_weight() const;
-  int client_transaction_priority_dependence() const;
+  int64_t client_connection_id() const;
+  int     client_transaction_id() const;
+  int     client_transaction_priority_weight() const;
+  int     client_transaction_priority_dependence() const;
 
   ink_hrtime get_server_inactivity_timeout();
   ink_hrtime get_server_active_timeout();
@@ -672,7 +672,7 @@ HttpSM::is_dying() const
   return terminate_sm;
 }
 
-inline int
+inline int64_t
 HttpSM::client_connection_id() const
 {
   return _ua.get_client_connection_id();

--- a/include/proxy/http/HttpUserAgent.h
+++ b/include/proxy/http/HttpUserAgent.h
@@ -64,7 +64,7 @@ public:
   ProxyTransaction *get_txn() const;
   void              set_txn(ProxyTransaction *txn, TransactionMilestones &milestones);
 
-  int get_client_connection_id() const;
+  int64_t get_client_connection_id() const;
 
   int get_client_transaction_id() const;
 
@@ -95,7 +95,7 @@ private:
 
   ClientConnectionInfo m_conn_info{};
 
-  int                   m_client_connection_id{-1};
+  int64_t               m_client_connection_id{-1};
   ClientTransactionInfo m_txn_info{};
 
   void save_transaction_info();
@@ -188,7 +188,7 @@ HttpUserAgent::set_txn(ProxyTransaction *txn, TransactionMilestones &milestones)
   }
 }
 
-inline int
+inline int64_t
 HttpUserAgent::get_client_connection_id() const
 {
   return m_client_connection_id;


### PR DESCRIPTION
ProxySession stores the connection ID as an int64_t, but in the HttpSM and HttpUserAgent, it was stored and transferred as an int type (typically 32 bits). This resulted in unnecessary narrowing. This updates the state machine to use an 64 bit type to alleviate the narrowing.