### PR TITLE
Include records.yaml line and column in the logs when error is found.

### DIFF
--- a/include/records/RecYAMLDefs.h
+++ b/include/records/RecYAMLDefs.h
@@ -83,6 +83,16 @@ struct CfgNode {
     }
   }
 
+  std::string
+  mark_as_view(swoc::TextView fmt = "Line: {}, Column: {}") const
+  {
+    swoc::LocalBufferWriter<128> lbw;
+    lbw.print(fmt, node.Mark().line + 1, node.Mark().column + 1);
+    std::string mark;
+    mark.reserve(lbw.view().size());
+    mark = std::string{lbw.view().data(), lbw.view().size()};
+    return mark;
+  }
   // public
   YAML::Node node;
   YAML::Node value_node;

--- a/src/records/RecYAMLDecoder.cc
+++ b/src/records/RecYAMLDecoder.cc
@@ -131,8 +131,8 @@ SetRecordFromYAMLNode(CfgNode const &field, swoc::Errata &errata)
     // we ignore it.
     auto [dtype, e] = detail::try_deduce_type(field.value_node);
     if (!e.empty()) {
-      errata.note(ERRATA_WARN, "Ignoring field '{}' [{}] at Line {}. Not registered and {}", field.node.as<std::string>(),
-                  field.get_record_name(), field.node.Mark().line + 1, e);
+      errata.note(ERRATA_WARN, "Ignoring field '{}' [{}] at {}. Not registered and {}", field.node.as<std::string>(),
+                  field.get_record_name(), field.mark_as_view("line={}, col={}"), e);
       // We can't continue without knowing the type.
       return;
     }
@@ -164,8 +164,8 @@ SetRecordFromYAMLNode(CfgNode const &field, swoc::Errata &errata)
   }
 
   if (!check_expr.empty() && RecordValidityCheck(value_str.c_str(), check_type, check_expr.c_str()) == false) {
-    errata.note(ERRATA_WARN, "{} - Validity Check failed. '{}' against '{}'. Default value will be used", record_name, check_expr,
-                value_str);
+    errata.note(ERRATA_WARN, "{} - Validity Check error {}. Pattern '{}' failed against '{}'. Default value will be used",
+                record_name, field.mark_as_view("at line={}, col={}"), check_expr, value_str);
     return;
   }
 


### PR DESCRIPTION
For instance, with the following config:

```yaml
records:
  http:
    per_server:
      connection:
        match: both*ioajs
        new:
          field: 11:
```

We will get a warning log with the line and the column from the records.yaml file exactly where the error was detected.

In the above example, match and new.field have different sort of errors but both now log the line+column.

```
WARNING: We have found the following issues when reading the records node:
 Warn:   Warn: proxy.config.http.per_server.connection.match - Validity Check error at line=37, col=9. Pattern '^(?:ip|host|both|none)$' failed against 'both*ioajs'. Default value will be used
  Warn: Ignoring field 'field' [proxy.config.http.per_server.connection.new.field] at line=39, col=11. Not registered and Unknown tag type '?
```