### PR TITLE
Adds Cache Groups concepts to Cripts

### DIFF
--- a/doc/developer-guide/cripts/cripts-convenience.en.rst
+++ b/doc/developer-guide/cripts/cripts-convenience.en.rst
@@ -68,9 +68,10 @@ Object                        Traditional API equivalent
 ``server.request``            ``borrow cripts::Server::Request::Get()``
 ``server.response``           ``borrow cripts::Server::Response::Get()``
 ``server.connection``         ``borrow cripts::Server::Connection::Get()``
+``cached.url``                ``borrow cripts::Cache::URL::Get()``
+``cached.response``           ``borrow cripts::Cache::Response::Get()``
 ``urls.request``              ``borrow cripts::Client::URL::Get()``
 ``urls.pristine``             ``borrow cripts::Pristine::URL::Get()``
-``urls.cache``                ``borrow cripts::Cache::URL::Get()``
 ``urls.parent``               ``borrow cripts::Parent::URL::Get()``
 ``urls.remap.to``             ``borrow cripts::Remap::To::URL::Get``
 ``urls.remap.from``           ``borrow cripts::Remap::From::URL::Get``

--- a/example/cripts/cache_groups.cc
+++ b/example/cripts/cache_groups.cc
@@ -1,0 +1,106 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#define CRIPTS_CONVENIENCE_APIS 1
+
+#include <cripts/CacheGroup.hpp>
+#include <cripts/Preamble.hpp>
+
+do_create_instance()
+{
+  // Create a cache-group for this site / remap rule(s). They can be shared.
+  instance.data[0] = cripts::Cache::Group::Manager::Factory("example");
+}
+
+do_delete_instance()
+{
+  void *ptr = AsPointer(instance.data[0]);
+
+  if (ptr) {
+    delete static_cast<std::shared_ptr<cripts::Cache::Group> *>(ptr);
+    instance.data[0] = nullptr;
+  }
+}
+
+do_cache_lookup()
+{
+  if (cached.response.lookupstatus != cripts::LookupStatus::MISS) {
+    void *ptr = AsPointer(instance.data[0]);
+
+    if (ptr) {
+      auto date = cached.response.AsDate("Date");
+
+      if (date > 0) {
+        auto cache_groups = cached.response["Cache-Groups"];
+
+        CDebug("Looking up {}", cache_groups);
+        if (!cache_groups.empty()) {
+          borrow cg = *static_cast<std::shared_ptr<cripts::Cache::Group> *>(ptr);
+
+          if (cg->Lookup(cache_groups.split(','), date)) {
+            CDebug("Cache Group hit, forcing revalidation for request");
+            cached.response.lookupstatus = cripts::LookupStatus::HIT_STALE;
+          }
+        }
+      }
+    }
+  }
+}
+
+do_read_response()
+{
+  void *ptr = AsPointer(instance.data[0]);
+
+  if (ptr) {
+    auto invalidation = client.request["Cache-Group-Invalidation"];
+
+    if (!invalidation.empty()) {
+      borrow cg = *static_cast<std::shared_ptr<cripts::Cache::Group> *>(ptr);
+
+      cg->Insert(invalidation.split(','));
+    }
+  }
+
+// This is just for simulating origin responses that would include cache-groups.
+#if 0
+  server.response["Cache-Groups"] = "\"foo\", \"bar\"";
+#endif
+}
+
+// The RFC draft does not support / provide definitions for this. It is useful,
+// but should be protected with appropriate ACLs / authentication.
+#if 0
+do_remap()
+{
+  void *ptr = AsPointer(instance.data[0]);
+
+  if (ptr && urls.pristine.path == ".well-known/Cache-Groups") {
+    auto invalidation = client.request["Cache-Group-Invalidation"];
+
+    if (!invalidation.empty()) {
+      borrow cg = *static_cast<std::shared_ptr<cripts::Cache::Group> *>(ptr);
+
+      cg->Insert(invalidation.split(','));
+      CDebug("Forcing a cache miss for cache-groups: {}", invalidation);
+      StatusCode(202);
+    }
+  }
+}
+#endif
+
+#include <cripts/Epilogue.hpp>

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -79,16 +79,17 @@ do_read_response()
 
 do_send_response()
 {
-  borrow resp = cripts::Client::Response::Get();
-  borrow conn = cripts::Client::Connection::Get();
-  string msg  = "Eliminate TSCPP";
+  borrow resp   = cripts::Client::Response::Get();
+  borrow conn   = cripts::Client::Connection::Get();
+  borrow cached = cripts::Cache::Response::Get();
+  string msg    = "Eliminate TSCPP";
 
   resp["Server"]         = "";        // Deletes the Server header
   resp["X-AMC"]          = msg;       // New header
   resp["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
   resp["X-UUID"]         = cripts::UUID::Unique::Get();
   resp["X-tcpinfo"]      = conn.tcpinfo.Log();
-  resp["X-Cache-Status"] = resp.cache;
+  resp["X-Cache-Status"] = cached.lookupstatus.GetSV();
   resp["X-Integer"]      = 666;
   resp["X-Data"]         = AsString(txn_data[2]);
 

--- a/example/cripts/example2.cc
+++ b/example/cripts/example2.cc
@@ -57,8 +57,8 @@ do_txn_close()
 
 do_cache_lookup()
 {
-  CDebug("Cache URL: {}", urls.cache);
-  CDebug("Cache Host: {}", urls.cache.host);
+  CDebug("Cache URL: {}", cached.url);
+  CDebug("Cache Host: {}", cached.url.host);
 }
 
 do_send_request()
@@ -80,7 +80,7 @@ do_send_response()
   client.response["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
   client.response["X-UUID"]         = UniqueUUID();
   client.response["X-tcpinfo"]      = client.connection.tcpinfo.Log();
-  client.response["X-Cache-Status"] = client.response.cache;
+  client.response["X-Cache-Status"] = cached.response.lookupstatus.GetSV();
   client.response["X-Integer"]      = 666;
   client.response["X-Data"]         = AsString(txn_data[2]);
 
@@ -118,7 +118,7 @@ do_send_response()
 do_remap()
 {
   auto ip  = client.connection.IP();
-  auto now = TimeNow();
+  auto now = LocalTimeNow();
 
   if (CRIPT_ALLOW.Match(ip)) {
     CDebug("Client IP allowed: {}", ip.string(24, 64));

--- a/include/cripts/CacheGroup.hpp
+++ b/include/cripts/CacheGroup.hpp
@@ -1,0 +1,195 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#pragma once
+
+#include <unordered_map>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <mutex>
+#include <shared_mutex>
+#include <fstream>
+#include <atomic>
+#include <memory>
+#include <cstdint>
+
+#include "cripts/Context.hpp"
+#include "cripts/Time.hpp"
+
+// Implemented in the .cc file
+int _cripts_cache_group_sync(TSCont cont, TSEvent event, void *edata);
+
+namespace cripts::Cache
+{
+
+class Group
+{
+private:
+  using self_type = Group;
+
+  struct _Entry {
+    cripts::Time::Point timestamp; // Timestamp of when the entry was created
+    size_t              length;    // Length of the group ID
+    uint32_t            prefix;    // First 4 characters of the group ID
+    uint64_t            hash;      // Hash value of the group ID, needed when writing to disk
+  };
+
+  using _MapType = std::unordered_map<uint64_t, _Entry>;
+
+  struct _MapSlot {
+    std::unique_ptr<_MapType> map;
+    std::string               path;
+    cripts::Time::Point       created;
+    cripts::Time::Point       last_write;
+    cripts::Time::Point       last_sync;
+  };
+
+public:
+  static constexpr uint64_t VERSION = (static_cast<uint64_t>('C') << 56) | (static_cast<uint64_t>('G') << 48) |
+                                      (static_cast<uint64_t>('M') << 40) | (static_cast<uint64_t>('A') << 32) |
+                                      (static_cast<uint64_t>('P') << 24) | (static_cast<uint64_t>('S') << 16) |
+                                      (static_cast<uint64_t>('0') << 8) | 0x00; // Change this on version bump
+
+  Group(const std::string &name, const std::string &base_dir, size_t max_entries = 1024, size_t num_maps = 3)
+  {
+    Initialize(name, base_dir, num_maps, max_entries, std::chrono::seconds{63072000});
+  }
+
+  // Not used at the moment.
+  Group() = default;
+
+  ~Group() { WriteToDisk(); }
+
+  Group(const self_type &)                = delete;
+  self_type &operator=(const self_type &) = delete;
+
+  void Initialize(const std::string &name, const std::string &base_dir, size_t num_maps = 3, size_t max_entries = 1024,
+                  std::chrono::seconds max_age = std::chrono::seconds{63072000});
+
+  void
+  SetMaxEntries(size_t max_entries)
+  {
+    std::unique_lock lock(_mutex);
+    _max_entries = max_entries;
+  }
+
+  void
+  SetMaxAge(std::chrono::seconds max_age)
+  {
+    std::unique_lock lock(_mutex);
+    _max_age = max_age;
+  }
+
+  void Insert(cripts::string_view key);
+  void Insert(const std::vector<cripts::string_view> &keys);
+  bool Lookup(cripts::string_view key, cripts::Time::Point age) const;
+  bool Lookup(const std::vector<cripts::string_view> &keys, cripts::Time::Point age) const;
+
+  bool
+  Lookup(cripts::string_view key, time_t age) const
+  {
+    return Lookup(key, cripts::Time::Clock::from_time_t(age));
+  }
+
+  bool
+  Lookup(const std::vector<cripts::string_view> &keys, time_t age) const
+  {
+    return Lookup(keys, cripts::Time::Clock::from_time_t(age));
+  }
+
+  cripts::Time::Point
+  LastSync() const
+  {
+    std::shared_lock lock(_mutex);
+    return _last_sync;
+  }
+
+  void WriteToDisk();
+  void LoadFromDisk();
+
+private:
+  mutable std::shared_mutex _mutex;
+  std::string               _name        = "CacheGroup";
+  size_t                    _num_maps    = 3;
+  size_t                    _max_entries = 1024;
+  std::chrono::seconds      _max_age     = std::chrono::seconds(63072000);
+  std::atomic<size_t>       _map_index   = 0;
+  cripts::Time::Point       _last_sync   = cripts::Time::Point{};
+
+  std::vector<_MapSlot> _slots;
+  std::ofstream         _txn_log;
+  std::string           _log_path;
+  std::string           _base_dir;
+
+  void appendLog(const _Entry &entry);
+  void clearLog();
+  void syncMap(size_t index);
+
+public:
+  class Manager
+  {
+    friend int ::_cripts_cache_group_sync(TSCont cont, TSEvent event, void *edata);
+    using self_type = Manager;
+
+  public:
+    static void *Factory(const std::string &name, size_t max_entries = 1024, size_t num_maps = 3);
+
+    Manager(const self_type &)              = delete;
+    self_type &operator=(const self_type &) = delete;
+
+  protected:
+    void _scheduleCont();
+
+    std::unordered_map<std::string, std::weak_ptr<Group>> _groups;
+    std::mutex                                            _mutex;
+
+  private:
+    Manager()
+    {
+      _base_dir = TSRuntimeDirGet();
+
+      if (std::filesystem::exists(_base_dir)) {
+        _base_dir += "/cache_groups";
+        if (!std::filesystem::exists(_base_dir)) {
+          std::filesystem::create_directories(_base_dir);
+          std::filesystem::permissions(_base_dir, std::filesystem::perms::group_write, std::filesystem::perm_options::add);
+        }
+      }
+      _scheduleCont(); // Kick it off
+    }
+
+    ~Manager()
+    {
+      if (_action) {
+        TSActionCancel(_action);
+        _action = nullptr;
+      }
+      if (_cont) {
+        TSContDestroy(_cont);
+        _cont = nullptr;
+      }
+    }
+
+    static self_type &_instance();
+
+    TSCont      _cont   = nullptr;
+    TSAction    _action = nullptr;
+    std::string _base_dir;
+  };
+};
+} // namespace cripts::Cache

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -44,7 +44,7 @@ public:
 
   // This will, and should, only be called via the ProxyAllocator as used in the factory.
   Context(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst)
-    : rri(rri_ptr), p_instance(inst), _client(this), _server(this), _urls(this, _client.url)
+    : rri(rri_ptr), p_instance(inst), _client(this), _server(this), _cache(this), _urls(this, _client.url)
   {
     state.txnp    = txn_ptr;
     state.ssnp    = ssn_ptr;
@@ -76,8 +76,10 @@ public:
   friend class Server::Request;
   friend class Server::Response;
   friend class Server::Connection;
-  friend class Pristine::URL;
+  friend class Server::Response;
+  friend class Cache::Response;
   friend class Cache::URL;
+  friend class Pristine::URL;
   friend class Parent::URL;
   friend class Plugin::Remap;
 
@@ -111,10 +113,21 @@ public:
 
   } _server;
 
+  struct _CacheBlock {
+    cripts::Cache::Response response;
+    cripts::Cache::URL      url;
+
+    _CacheBlock(Context *ctx)
+    {
+      response.set_state(&ctx->state);
+      url.set_context(ctx);
+    }
+
+  } _cache;
+
   struct _UrlBlock {
     cripts::Client::URL  &request;
     cripts::Pristine::URL pristine;
-    cripts::Cache::URL    cache;
     cripts::Parent::URL   parent;
 
     struct {
@@ -126,7 +139,6 @@ public:
     {
       request.set_context(ctx);
       pristine.set_context(ctx);
-      cache.set_context(ctx);
       parent.set_context(ctx);
       remap.from.set_context(ctx);
       remap.to.set_context(ctx);

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -581,8 +581,8 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
     }
 
     if (!context->state.error.Failed()) {
-      if (context->_urls.cache.Modified()) {
-        context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+      if (context->_cache.url.Modified()) {
+        context->_cache.url._update(); // Make sure the cache-key gets updated, if modified
       }
       if (context->_urls.request.Modified()) {
         context->_urls.request._update(); // Make sure any changes to the request URL is updated
@@ -612,8 +612,8 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
     }
 
     if (!context->state.error.Failed()) {
-      if (context->_urls.cache.Modified()) {
-        context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+      if (context->_cache.url.Modified()) {
+        context->_cache.url._update(); // Make sure the cache-key gets updated, if modified
       }
       if (context->_urls.request.Modified()) {
         context->_urls.request._update(); // Make sure any changes to the request URL is updated
@@ -899,8 +899,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   // Don't do the callbacks when we are in a failure state.
   if (!context->state.error.Failed()) {
-    if (context->_urls.cache.Modified()) {
-      context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+    if (context->_cache.url.Modified()) {
+      context->_cache.url._update(); // Make sure the cache-key gets updated, if modified
     }
     if (context->_urls.request.Modified()) {
       context->_urls.request._update(); // Make sure any changes to the request URL is updated

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -142,42 +142,6 @@ public:
 
   }; // End class cripts::Header::Method
 
-  class CacheStatus
-  {
-    using self_type = CacheStatus;
-
-  public:
-    CacheStatus() = delete;
-    CacheStatus(Header *owner) : _owner(owner) {}
-
-    cripts::string_view GetSV();
-
-    operator cripts::string_view() { return GetSV(); }
-
-    cripts::string_view::const_pointer
-    Data()
-    {
-      return GetSV().data();
-    }
-
-    cripts::string_view::size_type
-    Size()
-    {
-      return GetSV().size();
-    }
-
-    cripts::string_view::size_type
-    Length()
-    {
-      return GetSV().size();
-    }
-
-  private:
-    Header             *_owner = nullptr;
-    cripts::string_view _cache;
-
-  }; // Class cripts::Header::CacheStatus
-
   class String : public cripts::StringViewMixin<String>
   {
     using super_type = cripts::StringViewMixin<String>;
@@ -199,21 +163,17 @@ public:
     self_type &operator+=(const cripts::string_view str);
 
     // These specialized assignment operators all use the above
-    template <size_t N>
-    self_type &
-    operator=(const char (&str)[N])
-    {
-      return operator=(cripts::string_view(str, str[N - 1] ? N : N - 1));
-    }
+    // template <size_t N>
+    // self_type &
+    // operator=(const char (&str)[N])
+    //{
+    //  return operator=(cripts::string_view(str, str[N - 1] ? N : N - 1));
+    //}
+
+    self_type &operator=(std::nullptr_t) = delete;
 
     self_type &
-    operator=(char *&str)
-    {
-      return operator=(cripts::string_view(str, strlen(str)));
-    }
-
-    self_type &
-    operator=(char const *&str)
+    operator=(char const *str)
     {
       return operator=(cripts::string_view(str, strlen(str)));
     }
@@ -331,11 +291,11 @@ public:
     static const Iterator _end;
   }; // Class cripts::Header::iterator
 
-  Header() : status(this), reason(this), body(this), cache(this) {}
+  Header() : status(this), reason(this), body(this) {}
 
   ~Header() { Reset(); }
 
-  // Clear anything "cached" in the Url, this is rather draconian, but it's
+  // Clear anything "cached" in the Header, this is rather draconian, but it's
   // safe...
   void
   Reset()
@@ -363,6 +323,7 @@ public:
   }
 
   String operator[](const cripts::string_view str);
+  time_t AsDate(const cripts::string_view str);
 
   [[nodiscard]] bool
   Initialized() const
@@ -393,10 +354,9 @@ public:
     _state = state;
   }
 
-  Status      status;
-  Reason      reason;
-  Body        body;
-  CacheStatus cache;
+  Status status;
+  Reason reason;
+  Body   body;
 
 protected:
   static void
@@ -513,6 +473,48 @@ namespace Server
 
 } // namespace Server
 
+namespace Cache
+{
+  class Response : public ResponseHeader
+  {
+    using super_type = ResponseHeader;
+    using self_type  = Response;
+
+    class LookupStatus
+    {
+      using self_type = LookupStatus;
+
+    public:
+      LookupStatus() = delete;
+      LookupStatus(Response *owner) : _owner(owner) {}
+
+      cripts::string_view GetSV();
+      self_type          &operator=(int status);
+
+      operator integer();
+
+    private:
+      Response *_owner  = nullptr;
+      int       _lookup = -1; // Note set yet
+
+    }; // Class cripts::Cache::LookupStatus
+
+  public:
+    Response() : ResponseHeader(), lookupstatus(this){};
+
+    Response(const self_type &)       = delete;
+    void operator=(const self_type &) = delete;
+
+    // Implemented later, because needs the context.
+    static self_type &_get(cripts::Context *context);
+    void              _initialize() override;
+
+    LookupStatus lookupstatus;
+
+  }; // End class Cache::Response
+
+} // namespace Cache
+
 // Some static methods for the Method class
 namespace Method
 {
@@ -529,6 +531,16 @@ namespace Method
   // This is a special feature of ATS
   extern const cripts::Header::Method PURGE;
 } // namespace Method
+
+// Lookup status constants, these are used in the Cache::Response::lookupstatus
+namespace LookupStatus
+{
+  inline constexpr int NONE      = -1;
+  inline constexpr int MISS      = TS_CACHE_LOOKUP_MISS;
+  inline constexpr int HIT_STALE = TS_CACHE_LOOKUP_HIT_STALE;
+  inline constexpr int HIT_FRESH = TS_CACHE_LOOKUP_HIT_FRESH;
+  inline constexpr int SKIPPED   = TS_CACHE_LOOKUP_SKIPPED;
+} // namespace LookupStatus
 
 class Context;
 } // namespace cripts

--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -112,7 +112,7 @@ public:
     }
   }
 
-  std::array<DataType, 32>                       data;
+  std::array<DataType, 16>                       data;
   cripts::string                                 to_url;
   cripts::string                                 from_url;
   cripts::string                                 plugin_debug_tag;

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <charconv>
 #include <type_traits>
+#include <chrono>
 
 #include <fmt/core.h>
 
@@ -101,6 +102,12 @@ public:
   ToBool() const
   {
     return bool(*this);
+  }
+
+  [[nodiscard]] time_t
+  ToDate() const
+  {
+    return TSMimeParseDate(_value.data(), _value.size());
   }
 
   std::vector<mixin_type>

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -23,8 +23,10 @@
 // Setup for PCRE2
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
+#include <algorithm>
 #include <vector>
 #include <tuple>
+#include <algorithm>
 
 #include "ts/ts.h"
 #include "cripts/Lulu.hpp"
@@ -153,7 +155,8 @@ namespace List
     {
       auto data = method.Data();
 
-      return end() != std::find_if(begin(), end(), [&](const cripts::Header::Method &header) { return header.Data() == data; });
+      return end() !=
+             std::ranges::find_if(begin(), end(), [&](const cripts::Header::Method &header) { return header.Data() == data; });
     }
 
     [[nodiscard]] bool

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -114,12 +114,14 @@ extern cripts::Versions version; // Access to the ATS version information
 #define client                      context->_client
 #define server                      context->_server
 #define urls                        context->_urls
+#define cached                      context->_cache
 #define Regex(_name_, ...)          static cripts::Matcher::PCRE _name_(__VA_ARGS__);
 #define ACL(_name_, ...)            static cripts::Matcher::Range::IP _name_(__VA_ARGS__);
 #define StatusCode(_name_, ...)     cripts::Error::Status::Set(_name_, __VA_ARGS__);
 #define CreateCounter(_id_, _name_) instance.metrics[_id_] = cripts::Metrics::Counter::Create(_name_);
 #define CreateGauge(_id_, _name_)   instance.metrics[_id_] = cripts::Metrics::Gauge::Create(_name_);
 #define FilePath(_name_, _path_)    static const cripts::File::Path _name_(_path_);
-#define UniqueUUID()                cripts::UUID::Unique::Get();
-#define TimeNow()                   cripts::Time::Local::Now();
+#define UniqueUUID()                cripts::UUID::Unique::Get()
+#define LocalTimeNow()              cripts::Time::Local::Now()
+#define UTCTimeNow()                cripts::Time::UTC::Now()
 #endif

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -28,6 +28,12 @@
 // std::chrono :-/ Todo: Rewrite this with std::chrono when it has things like
 // std::chrono::year_month_day
 
+namespace cripts::Time
+{
+using Clock = std::chrono::system_clock;
+using Point = Clock::time_point;
+} // namespace cripts::Time
+
 namespace detail
 {
 class BaseTime
@@ -95,16 +101,24 @@ public:
     return static_cast<integer>(_result.tm_yday) + 1;
   }
 
+  [[nodiscard]] const cripts::string_view
+  ToDate()
+  {
+    int len = sizeof(_buffer);
+
+    TSMimeFormatDate(_now, _buffer, &len);
+    return {_buffer, len};
+  }
+
 protected:
-  std::time_t _now    = std::time(nullptr);
-  std::tm     _result = {};
+  char        _buffer[64] = {};
+  std::time_t _now        = std::time(nullptr);
+  std::tm     _result     = {};
 };
 } // namespace detail
 
 namespace cripts::Time
 {
-// ToDo: Right now, we only have localtime, but we should support e.g. UTC and
-// other time zone instances.
 class Local : public detail::BaseTime
 {
   using super_type = detail::BaseTime;
@@ -123,7 +137,37 @@ public:
     return {};
   }
 
+  explicit Local(Time::Point tp)
+  {
+    _now = Time::Clock::to_time_t(tp);
+    localtime_r(&_now, static_cast<struct tm *>(&_result));
+  }
+
 }; // End class Time::Local
+
+class UTC : public detail::BaseTime
+{
+  using super_type = detail::BaseTime;
+  using self_type  = UTC;
+
+public:
+  UTC(const self_type &)            = delete;
+  void operator=(const self_type &) = delete;
+
+  UTC() { gmtime_r(&_now, static_cast<struct tm *>(&_result)); }
+
+  explicit UTC(Time::Point tp)
+  {
+    _now = Time::Clock::to_time_t(tp);
+    gmtime_r(&_now, static_cast<struct tm *>(&_result));
+  }
+
+  static UTC
+  Now()
+  {
+    return {};
+  }
+};
 
 } // namespace cripts::Time
 
@@ -139,9 +183,25 @@ template <> struct formatter<cripts::Time::Local> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Time::Local &time, FormatContext &ctx) const -> decltype(ctx.out())
+  format(const cripts::Time::Local &time, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", time.Epoch());
   }
 };
+
+template <> struct formatter<cripts::Time::UTC> {
+  constexpr auto
+  parse(const format_parse_context &ctx) -> decltype(ctx.begin())
+  {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto
+  format(const cripts::Time::UTC &time, FormatContext &ctx) const -> decltype(ctx.out())
+  {
+    return fmt::format_to(ctx.out(), "{}", time.Epoch());
+  }
+};
+
 } // namespace fmt

--- a/include/cripts/Transaction.hpp
+++ b/include/cripts/Transaction.hpp
@@ -81,18 +81,6 @@ public:
     return false;
   }
 
-  [[nodiscard]] int
-  LookupStatus() const
-  {
-    int status = 0;
-
-    if (TSHttpTxnCacheLookupStatusGet(txnp, &status) != TS_SUCCESS) {
-      return -1;
-    }
-
-    return status;
-  }
-
 }; // class Transaction
 
 } // namespace cripts

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -17,10 +17,12 @@
 */
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+#include <concepts>
 
 #include "ts/ts.h"
 #include "ts/remap.h"
@@ -500,7 +502,7 @@ public:
       // Make sure the hash and vector are populated
       _parser();
 
-      std::sort(_ordered.begin(), _ordered.end());
+      std::ranges::sort(_ordered);
       _modified = true;
     }
 

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -113,7 +113,7 @@ LogsMetrics::doTxnClose(cripts::Context *context)
     resp["@TCPInfo"] += fmt::format(",TC; {}", conn.tcpinfo.Log());
   }
 
-  // .label(str)
+  // .propstats(str)
   if (_label.length() > 0) {
     instance.metrics[Bundle::PROPSTAT_CLIENT_BYTES_IN]->Increment(TSHttpTxnClientReqHdrBytesGet(transaction.txnp) +
                                                                   TSHttpTxnClientReqBodyBytesGet(transaction.txnp));
@@ -170,12 +170,12 @@ LogsMetrics::doSendResponse(cripts::Context *context)
 void
 LogsMetrics::doCacheLookup(cripts::Context *context)
 {
-  auto status = transaction.LookupStatus();
+  borrow cached = cripts::Cache::Response::Get();
 
-  // .label(str)
+  // .propstats(str)
   if (_label.length() > 0) {
-    if (status >= 0 && status <= 3) {
-      instance.metrics[status]->Increment(); // This assumes the 4 cache stats are first
+    if (cached.lookupstatus >= LookupStatus::MISS && cached.lookupstatus <= LookupStatus::SKIPPED) {
+      instance.metrics[cached.lookupstatus]->Increment(); // This assumes the 4 cache stats are first
     }
   }
 }
@@ -196,8 +196,9 @@ LogsMetrics::doRemap(cripts::Context *context)
 
   // .tcpinfo(bool)
   if (_tcpinfo && sampled) {
-    borrow req      = cripts::Client::Request::Get();
-    borrow conn     = cripts::Client::Connection::Get();
+    borrow req  = cripts::Client::Request::Get();
+    borrow conn = cripts::Client::Connection::Get();
+
     req["@TCPInfo"] = fmt::format("TS; {}", conn.tcpinfo.Log());
   }
 }

--- a/src/cripts/CMakeLists.txt
+++ b/src/cripts/CMakeLists.txt
@@ -28,6 +28,7 @@ list(REMOVE_ITEM CPP_FILES ${TEST_CPP_FILES})
 
 set(CRIPTS_PUBLIC_HEADERS
     ${PROJECT_SOURCE_DIR}/include/cripts/Bundle.hpp
+    ${PROJECT_SOURCE_DIR}/include/cripts/CacheGroup.hpp
     ${PROJECT_SOURCE_DIR}/include/cripts/Configs.hpp
     ${PROJECT_SOURCE_DIR}/include/cripts/ConfigsBase.hpp
     ${PROJECT_SOURCE_DIR}/include/cripts/Connections.hpp

--- a/src/cripts/CacheGroup.cc
+++ b/src/cripts/CacheGroup.cc
@@ -1,0 +1,419 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <algorithm>
+#include <iostream>
+#include <filesystem>
+
+#include "ts/ts.h"
+#include "cripts/CacheGroup.hpp"
+
+inline static uint32_t
+_make_prefix_int(cripts::string_view key)
+{
+  uint32_t prefix = 0;
+
+  std::memcpy(&prefix, key.data(), std::min<size_t>(4, key.size()));
+  return prefix;
+}
+
+// Stuff around the disk sync contination
+constexpr auto _CONT_SYNC_INTERVAL = 10; // How often to run the continuation
+constexpr int  _SYNC_GROUP_EVERY   = 60; // Sync each group every 60s
+
+int
+_cripts_cache_group_sync(TSCont cont, TSEvent /* event */, void * /* edata */)
+{
+  auto           *mgr = static_cast<cripts::Cache::Group::Manager *>(TSContDataGet(cont));
+  std::lock_guard lock(mgr->_mutex);
+  auto           &groups = mgr->_groups;
+
+  const size_t max_to_process = (groups.size() + (_SYNC_GROUP_EVERY - 1)) / _SYNC_GROUP_EVERY;
+  size_t       processed      = 0;
+  auto         now            = cripts::Time::Clock::now();
+
+  for (auto it = groups.begin(); it != groups.end() && processed < max_to_process; ++it) {
+    if (auto group = it->second.lock()) {
+      if (group->LastSync() + std::chrono::seconds{_SYNC_GROUP_EVERY} < now) {
+        group->WriteToDisk();
+        ++processed;
+      }
+    } else {
+      // The group has been deleted, remove it from the map ??
+      it = groups.erase(it);
+    }
+  }
+
+  return TS_SUCCESS;
+}
+
+namespace cripts
+{
+
+void
+Cache::Group::Initialize(const std::string &name, const std::string &base_dir, size_t num_maps, size_t max_entries,
+                         std::chrono::seconds max_age)
+{
+  cripts::Time::Point zero = cripts::Time::Point{};
+  cripts::Time::Point now  = cripts::Time::Clock::now();
+
+  _name        = name;
+  _num_maps    = num_maps;
+  _max_entries = max_entries;
+  _max_age     = max_age;
+
+  _base_dir = base_dir + "/" + _name;
+  _log_path = _base_dir + "/" + "txn.log";
+
+  if (!std::filesystem::exists(_base_dir)) {
+    std::filesystem::create_directories(_base_dir);
+    std::filesystem::permissions(_base_dir, std::filesystem::perms::group_write, std::filesystem::perm_options::add);
+  }
+
+  for (size_t ix = 0; ix < _num_maps; ++ix) {
+    _slots.emplace_back(_MapSlot{.map        = std::make_unique<_MapType>(),
+                                 .path       = _base_dir + "/map_" + std::to_string(ix) + ".bin",
+                                 .created    = zero,
+                                 .last_write = zero,
+                                 .last_sync  = zero});
+  }
+
+  _slots[0].created    = now;
+  _slots[0].last_write = now;
+
+  LoadFromDisk();
+  _last_sync = now;
+}
+
+void
+Cache::Group::Insert(cripts::string_view key)
+{
+  static const std::hash<cripts::string_view> hasher;
+
+  // Trim any "'s and white spaces from the key
+  key.trim_if(&isspace).trim('"');
+
+  auto     now    = cripts::Time::Clock::now();
+  auto     hash   = static_cast<uint64_t>(hasher(key));
+  uint32_t prefix = _make_prefix_int(key);
+
+  std::unique_lock lock(_mutex);
+
+  auto &slot = _slots[_map_index];
+  auto  it   = slot.map->find(hash);
+
+  if (it != slot.map->end() && it->second.length == key.size() && it->second.prefix == prefix) {
+    it->second.timestamp = now;
+    slot.last_write      = now;
+    appendLog(it->second);
+
+    return;
+  }
+
+  Cache::Group::_Entry entry{.timestamp = now, .length = key.size(), .prefix = prefix, .hash = hash};
+
+  slot.map->insert_or_assign(hash, entry);
+  slot.last_write = now;
+  appendLog(entry);
+
+  if (slot.map->size() > _max_entries || (now - slot.created) > _max_age) {
+    _map_index = (_map_index + 1) % _slots.size();
+
+    auto &next_slot = _slots[_map_index];
+
+    if (next_slot.last_write > next_slot.last_sync) {
+      TSWarning("cripts::Cache::Group: Rotating unsynced map for `%s'! This may lead to data loss.", _name.c_str());
+    }
+    next_slot.map->clear();
+    next_slot.created    = now;
+    next_slot.last_write = now;
+    syncMap(_map_index); // Sync to disk will make sure it's empty on disk
+  }
+}
+
+void
+Cache::Group::Insert(const std::vector<cripts::string_view> &keys)
+{
+  for (auto &key : keys) {
+    Insert(key);
+  }
+}
+
+bool
+Cache::Group::Lookup(cripts::string_view key, cripts::Time::Point age) const
+{
+  // Trim any "'s and whitespaces from the key
+  key.trim_if(&isspace).trim('"');
+
+  uint64_t         hash = static_cast<uint64_t>(std::hash<cripts::string_view>{}(key));
+  std::shared_lock lock(_mutex);
+
+  for (size_t i = 0; i < _slots.size(); ++i) {
+    size_t      map_index = (_map_index + _slots.size() - i) % _slots.size();
+    const auto &slot      = _slots[map_index];
+
+    if (slot.last_write < age) {
+      continue; // Skip maps that haven't been written to since this time
+    }
+
+    const auto &map = *slot.map;
+    auto        it  = map.find(hash);
+
+    if (it != map.end()) {
+      const Cache::Group::_Entry &entry = it->second;
+
+      if (entry.timestamp < age || entry.length != key.size() || entry.prefix != _make_prefix_int(key)) {
+        continue;
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool
+Cache::Group::Lookup(const std::vector<cripts::string_view> &keys, cripts::Time::Point age) const
+{
+  for (auto &key : keys) {
+    if (Lookup(key, age)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void
+Cache::Group::LoadFromDisk()
+{
+  std::unique_lock lock(_mutex);
+  std::ifstream    log(_log_path, std::ios::binary);
+
+  for (size_t slot_ix = 0; slot_ix < _slots.size(); ++slot_ix) {
+    auto         &slot          = _slots[slot_ix];
+    uint64_t      version_id    = 0;
+    size_t        count         = 0;
+    time_t        created_ts    = 0;
+    time_t        last_write_ts = 0;
+    time_t        last_sync_ts  = 0;
+    std::ifstream file(slot.path, std::ios::binary);
+
+    if (!file) {
+      continue;
+    }
+
+    file.read(reinterpret_cast<char *>(&version_id), sizeof(version_id));
+    if (version_id != VERSION) {
+      TSWarning("cripts::Cache::Group: Version mismatch for map file: %s, expected %llu, got %llu. Skipping this map.",
+                slot.path.c_str(), static_cast<unsigned long long>(VERSION), static_cast<unsigned long long>(version_id));
+      continue;
+    }
+
+    file.read(reinterpret_cast<char *>(&created_ts), sizeof(created_ts));
+    file.read(reinterpret_cast<char *>(&last_write_ts), sizeof(last_write_ts));
+    file.read(reinterpret_cast<char *>(&last_sync_ts), sizeof(last_sync_ts));
+    file.read(reinterpret_cast<char *>(&count), sizeof(count));
+
+    slot.created    = cripts::Time::Clock::from_time_t(created_ts);
+    slot.last_write = cripts::Time::Clock::from_time_t(last_write_ts);
+    slot.last_sync  = cripts::Time::Clock::from_time_t(last_sync_ts);
+
+    for (size_t i = 0; i < count; ++i) {
+      Cache::Group::_Entry entry;
+
+      file.read(reinterpret_cast<char *>(&entry), sizeof(entry));
+      if (!std::ranges::any_of(_slots, [&](const auto &slot) { return slot.map->find(entry.hash) != slot.map->end(); })) {
+        slot.map->insert_or_assign(entry.hash, entry);
+      }
+    }
+  }
+
+  // Sort the slots by creation time, newest first, since we'll start with index 0 upon loading
+  std::ranges::sort(_slots, [](const _MapSlot &a, const _MapSlot &b) { return a.created > b.created; });
+
+  // Replay any entries from the transaction log, and then truncate it
+  if (log) {
+    Cache::Group::_Entry entry;
+    auto                 last_write = cripts::Time::Clock::from_time_t(0);
+
+    while (log.read(reinterpret_cast<char *>(&entry), sizeof(entry))) {
+      _slots[0].map->insert_or_assign(entry.hash, entry);
+      last_write = std::max(last_write, entry.timestamp);
+    }
+    _slots[0].last_write = last_write;
+    clearLog();
+  }
+}
+
+void
+Cache::Group::WriteToDisk()
+{
+  std::unique_lock unique_lock(_mutex);
+
+  _last_sync = cripts::Time::Clock::now();
+  for (size_t ix = 0; ix < _slots.size(); ++ix) {
+    bool need_sync = false;
+
+    if (_slots[ix].last_write > _slots[ix].last_sync) {
+      _slots[ix].last_sync = _last_sync;
+      need_sync            = true;
+    }
+
+    if (need_sync) {
+      syncMap(ix);
+    }
+  }
+
+  clearLog();
+}
+
+//
+// Here comes the private member methods, these must never be called without
+// already hodling an exclusive lock on the mutex.
+//
+
+void
+Cache::Group::appendLog(const Cache::Group::_Entry &entry)
+{
+  if (!_txn_log.is_open() || !_txn_log.good()) {
+    _txn_log.open(_log_path, std::ios::app | std::ios::out);
+    if (!_txn_log) {
+      TSWarning("cripts::Cache::Group: Failed to open transaction log `%s'.", _log_path.c_str());
+      return;
+    }
+  }
+
+  _txn_log.write(reinterpret_cast<const char *>(&entry), sizeof(entry));
+  _txn_log.flush();
+}
+
+void
+Cache::Group::syncMap(size_t index)
+{
+  constexpr size_t                   BUFFER_SIZE = 64 * 1024;
+  std::array<std::byte, BUFFER_SIZE> buffer;
+  size_t                             buf_pos  = 0;
+  const auto                        &slot     = _slots[index];
+  const std::string                  tmp_path = slot.path + ".tmp";
+  std::ofstream                      o_file(tmp_path, std::ios::binary | std::ios::trunc);
+
+  if (!o_file) {
+    std::cerr << "Failed to open temp file for sync: " << tmp_path << "\n";
+    return;
+  }
+
+  // Helper lambda to append data to the write buffer
+  auto _AppendToBuffer = [&](const void *data, size_t size) {
+    if (buf_pos + size > buffer.size()) {
+      o_file.write(reinterpret_cast<const char *>(buffer.data()), buf_pos);
+      buf_pos = 0;
+    }
+    std::memcpy(buffer.data() + buf_pos, static_cast<const std::byte *>(data), size);
+    buf_pos += size;
+  };
+
+  time_t created_ts    = cripts::Time::Clock::to_time_t(slot.created);
+  time_t last_write_ts = cripts::Time::Clock::to_time_t(slot.last_write);
+  time_t last_sync_ts  = cripts::Time::Clock::to_time_t(slot.last_sync);
+  size_t count         = slot.map->size();
+
+  _AppendToBuffer(&VERSION, sizeof(VERSION));
+  _AppendToBuffer(&created_ts, sizeof(created_ts));
+  _AppendToBuffer(&last_write_ts, sizeof(last_write_ts));
+  _AppendToBuffer(&last_sync_ts, sizeof(last_sync_ts));
+  _AppendToBuffer(&count, sizeof(count));
+
+  // Write entries
+  for (const auto &[_, entry] : *slot.map) {
+    _AppendToBuffer(&entry, sizeof(entry));
+  }
+
+  if (buf_pos > 0) {
+    o_file.write(reinterpret_cast<const char *>(buffer.data()), buf_pos);
+  }
+  o_file.flush();
+  o_file.close();
+
+  if (std::rename(tmp_path.c_str(), slot.path.c_str()) != 0) {
+    TSWarning("cripts::Cache::Group: Failed to rename temp file `%s' to `%s'.", tmp_path.c_str(), slot.path.c_str());
+    std::filesystem::remove(tmp_path);
+  }
+}
+
+void
+Cache::Group::clearLog()
+{
+  std::error_code ec;
+
+  _txn_log.close();
+  std::filesystem::remove(_log_path, ec);
+  if (ec) {
+    TSWarning("cripts::Cache::Group: Failed to clear transaction log `%s': %s", _log_path.c_str(), ec.message().c_str());
+  }
+}
+
+// Singleton instance for the Cache::Group::Manager
+Cache::Group::Manager &
+Cache::Group::Manager::_instance()
+{
+  static Cache::Group::Manager inst;
+  return inst;
+}
+
+void *
+Cache::Group::Manager::Factory(const std::string &name, size_t max_entries, size_t num_maps)
+{
+  std::lock_guard lock(_instance()._mutex);
+  auto           &groups = _instance()._groups;
+
+  if (auto it = groups.find(name); it != groups.end()) {
+    if (auto group = it->second.lock()) {
+      return new std::shared_ptr<Group>(std::move(group));
+    }
+  }
+
+  if (!_instance()._base_dir.empty()) {
+    auto group = std::make_shared<Group>(name, _instance()._base_dir, max_entries, num_maps);
+
+    groups[name] = group;
+    return new std::shared_ptr<Group>(std::move(group));
+  } else {
+    TSError("cripts::Cache::Group: Failed to get runtime directory for initialization.");
+    return nullptr;
+  }
+}
+
+void
+Cache::Group::Manager::_scheduleCont()
+{
+  if (!_cont) {
+    _cont = TSContCreate(_cripts_cache_group_sync, TSMutexCreate());
+    TSContDataSet(_cont, this);
+  }
+
+  if (_action) {
+    TSActionCancel(_action); // Can this even happen ?
+    _action = nullptr;
+  }
+
+  _action = TSContScheduleEveryOnPool(_cont, _CONT_SYNC_INTERVAL * 1000, TS_THREAD_POOL_TASK);
+}
+
+} // namespace cripts

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -52,11 +52,11 @@ Context::reset()
   if (_urls.pristine.Initialized()) {
     _urls.pristine.Reset();
   }
-  if (_urls.cache.Initialized()) {
-    _urls.cache.Reset();
-  }
   if (_urls.parent.Initialized()) {
     _urls.parent.Reset();
+  }
+  if (_cache.url.Initialized()) {
+    _cache.url.Reset();
   }
 }
 

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -110,30 +110,6 @@ Header::Method::GetSV()
   return _method;
 }
 
-cripts::string_view
-Header::CacheStatus::GetSV()
-{
-  static std::array<cripts::string_view, 4> names{
-    "miss",      // TS_CACHE_LOOKUP_MISS,
-    "hit-stale", // TS_CACHE_LOOKUP_HIT_STALE,
-    "hit-fresh", // TS_CACHE_LOOKUP_HIT_FRESH,
-    "skipped"    // TS_CACHE_LOOKUP_SKIPPED
-  };
-  int status;
-
-  _ensure_initialized(_owner);
-  if (_cache.size() == 0) {
-    TSAssert(_owner->_state->txnp);
-    if (TSHttpTxnCacheLookupStatusGet(_owner->_state->txnp, &status) == TS_ERROR || status < 0 || status >= 4) {
-      _cache = "none";
-    } else {
-      _cache = names[status];
-    }
-  }
-
-  return _cache;
-}
-
 Header::String &
 Header::String::operator=(const cripts::string_view str)
 {
@@ -264,6 +240,24 @@ Header::operator[](const cripts::string_view str)
     ret._initialize(str, cripts::string_view(value, len), this, field_loc);
   } else {
     ret._initialize(str, {}, this, nullptr);
+  }
+
+  return ret;
+}
+
+time_t
+Header::AsDate(const cripts::string_view str)
+{
+  _ensure_initialized(this);
+  TSAssert(_bufp && _hdr_loc);
+
+  time_t ret       = 0;
+  TSMLoc field_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, str.data(), str.size());
+
+  if (field_loc) {
+    ret = TSMimeHdrFieldValueDateGet(_bufp, _hdr_loc, field_loc);
+    // Since this is not owned by a Header::String, we have to release it now
+    TSHandleMLocRelease(_bufp, _hdr_loc, field_loc);
   }
 
   return ret;
@@ -403,6 +397,74 @@ Server::Response::_initialize()
   } else {
     super_type::_initialize(); // Don't initialize unless properly setup
   }
+}
+
+Cache::Response &
+Cache::Response::_get(cripts::Context *context)
+{
+  _ensure_initialized(&context->_cache.response);
+  return context->_cache.response;
+}
+
+void
+Cache::Response::_initialize()
+{
+  CAssert(_state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_POST_REMAP_HOOK);
+  CAssert(_state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
+
+  TSAssert(_state->txnp);
+
+  if (TSHttpTxnCachedRespGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
+    _state->error.Fail();
+  } else {
+    super_type::_initialize(); // Don't initialize unless properly setup
+  }
+}
+
+Cache::Response::LookupStatus::operator integer()
+{
+  if (_lookup == -1) {
+    TSAssert(_owner->_state->txnp);
+
+    if (TSHttpTxnCacheLookupStatusGet(_owner->_state->txnp, &_lookup) == TS_ERROR || _lookup < 0 || _lookup >= 4) {
+      _lookup = -1;
+    }
+  }
+
+  return _lookup;
+}
+
+cripts::string_view
+Cache::Response::LookupStatus::GetSV()
+{
+  static std::array<cripts::string_view, 4> names{
+    "miss",      // TS_CACHE_LOOKUP_MISS,
+    "hit-stale", // TS_CACHE_LOOKUP_HIT_STALE,
+    "hit-fresh", // TS_CACHE_LOOKUP_HIT_FRESH,
+    "skipped"    // TS_CACHE_LOOKUP_SKIPPED
+  };
+
+  int status = operator integer();
+
+  if (status == -1) {
+    return "none";
+  } else {
+    return names[status];
+  }
+}
+
+Cache::Response::LookupStatus &
+Cache::Response::LookupStatus::operator=(int lookup)
+{
+  if (TSHttpTxnCacheLookupStatusSet(_owner->_state->txnp, lookup) == TS_SUCCESS) {
+    _owner->_state->context->p_instance.debug("Setting LookupStatus = {}", lookup);
+  } else {
+    // ToDo: Should we fail here?
+    // _owner->_state->error.Fail();
+  }
+
+  return *this;
 }
 
 } // namespace cripts


### PR DESCRIPTION
The goal here is to provide some cache management functionality to Cripts, allowing for a prototype implementation of the cache-groups RFC draft. In addition,t this

- cleans up the notion around cached URLs and headers, and cache keys.
- adds APIs to set the lookup status as well

The implementation adds a Cache::Groups object type to Cripts, which deals with all the details around lookups and inserts. In addition, it assures that the meta data is persistent across restarts and crashes. This is achieved with a combination of periodic disk syncs, and transaction logs. Upon startup, the synced files are loaded, following by replaying the transaction log (of any).