### PR TITLE
Fix Unsigned difference expression compared to zero IPCSocketServer

### DIFF
--- a/src/mgmt/rpc/server/IPCSocketServer.cc
+++ b/src/mgmt/rpc/server/IPCSocketServer.cc
@@ -413,7 +413,7 @@ IPCSocketServer::Client::read_all(Buffer &bw) const
       return {false, swoc::bwprint(buff, "Peer disconnected. EOF")};
     }
     bw.save(ret);
-    if (_max_req_size - bw.stored() > 0) { // we can still read more.
+    if (bw.stored() < _max_req_size) { // we can still read more.
       using namespace std::chrono_literals;
       if (!this->poll_for_data(1ms)) {
         return {true, buff};


### PR DESCRIPTION
https://github.com/apache/trafficserver/blob/28710feefbcd5f10ce5def123f6fbd3e09fc1b79/src/mgmt/rpc/server/IPCSocketServer.cc#L416-L416

Fix the issue need to ensure that the comparison logic does not rely on unsigned subtraction, which can underflow. Instead, we can directly compare `bw.stored()` with `_max_req_size` to determine if there is still space available in the buffer. Specifically:
- Replace `_max_req_size - bw.stored() > 0` with `bw.stored() < _max_req_size`.
- This avoids the unsigned subtraction entirely and achieves the same logical result in a safer and clearer manner.

The fix will be applied to line 416 in the file `src/mgmt/rpc/server/IPCSocketServer.cc`.

---

[INT02-C. Understand integer conversion rules](https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules)

```cc
uint32_t limit = get_limit();
uint32_t total = 0;

while (limit - total > 0) { // BAD: if `total` is greater than `limit` this will underflow and continue executing the loop.
  total += get_data();
}

while (total < limit) { // GOOD: never underflows here because there is no arithmetic.
  total += get_data();
}

while ((int64_t)limit - total > 0) { // GOOD: never underflows here because the result always fits in an `int64_t`.
  total += get_data();
}
```
