### PR TITLE
Update url_m_loc variable to the newly generated one in set-destination

### DIFF
--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -344,7 +344,7 @@ OperatorSetDestination::exec(const Resources &res) const
         if (TSUrlCreate(bufp, &new_url_loc) == TS_SUCCESS && TSUrlParse(bufp, new_url_loc, &start, end) == TS_PARSE_DONE &&
             TSHttpHdrUrlSet(bufp, res.hdr_loc, new_url_loc) == TS_SUCCESS) {
           // This case creates a new_url_loc which should be used for any other set-destination case
-          res._rri->requestUrl = reinterpret_cast<TSMLoc>(new_url_loc);
+          res._rri->requestUrl = new_url_loc;
           Dbg(pi_dbg_ctl, "Set destination URL to %s", value.c_str());
         } else {
           Dbg(pi_dbg_ctl, "Failed to set URL %s", value.c_str());

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -356,6 +356,7 @@ OperatorSetDestination::exec(const Resources &res) const
         Dbg(pi_dbg_ctl, "Would set destination SCHEME to an empty value, skipping");
       } else {
         TSUrlSchemeSet(bufp, url_m_loc, value.c_str(), value.length());
+        const_cast<Resources &>(res).changed_url = true;
         Dbg(pi_dbg_ctl, "OperatorSetDestination::exec() invoked with SCHEME: %s", value.c_str());
       }
       break;

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -268,7 +268,7 @@ OperatorSetDestination::exec(const Resources &res) const
     // Determine which TSMBuffer and TSMLoc to use
     TSMBuffer bufp;
     TSMLoc    url_m_loc;
-    if (res._rri) {
+    if (res._rri && !res.changed_url) {
       bufp      = res._rri->requestBufp;
       url_m_loc = res._rri->requestUrl;
     } else {
@@ -343,8 +343,7 @@ OperatorSetDestination::exec(const Resources &res) const
         TSMLoc      new_url_loc;
         if (TSUrlCreate(bufp, &new_url_loc) == TS_SUCCESS && TSUrlParse(bufp, new_url_loc, &start, end) == TS_PARSE_DONE &&
             TSHttpHdrUrlSet(bufp, res.hdr_loc, new_url_loc) == TS_SUCCESS) {
-          // This case creates a new_url_loc which should be used for any other set-destination case
-          res._rri->requestUrl = new_url_loc;
+          const_cast<Resources &>(res).changed_url = true;
           Dbg(pi_dbg_ctl, "Set destination URL to %s", value.c_str());
         } else {
           Dbg(pi_dbg_ctl, "Failed to set URL %s", value.c_str());

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -343,6 +343,8 @@ OperatorSetDestination::exec(const Resources &res) const
         TSMLoc      new_url_loc;
         if (TSUrlCreate(bufp, &new_url_loc) == TS_SUCCESS && TSUrlParse(bufp, new_url_loc, &start, end) == TS_PARSE_DONE &&
             TSHttpHdrUrlSet(bufp, res.hdr_loc, new_url_loc) == TS_SUCCESS) {
+          // This case creates a new_url_loc which should be used for any other set-destination case
+          res._rri->requestUrl = reinterpret_cast<TSMLoc>(new_url_loc);
           Dbg(pi_dbg_ctl, "Set destination URL to %s", value.c_str());
         } else {
           Dbg(pi_dbg_ctl, "Failed to set URL %s", value.c_str());


### PR DESCRIPTION
When `set-destination URL` is called, it creates a new url_m_loc with the new url and assigns that to the buffer. The requestUrl is never updated therefore any subsequent set-destination call will use the incorrect url_m_loc. This change tracks if the url has been changed, if so it will get the url_m_loc from the http hdr which has the updated loc.
This issue is also present in 9.2