### PR TITLE
Use a separate libctx for each TLS thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,7 @@ check_symbol_exists(BIO_meth_get_destroy "openssl/bio.h" HAVE_BIO_METH_GET_DESTR
 check_symbol_exists(CRYPTO_set_ex_data "openssl/bio.h" HAVE_CRYPTO_SET_EX_DATA)
 check_symbol_exists(DH_get_2048_256 "openssl/dh.h" TS_USE_GET_DH_2048_256)
 check_symbol_exists(OPENSSL_NO_TLS_3 "openssl/ssl.h" TS_NO_USE_TLS12)
+check_symbol_exists(SSL_CTX_new_ex "openssl/ssl.h" HAVE_SSL_CTX_NEW_EX)
 check_symbol_exists(SSL_CTX_set_client_hello_cb "openssl/ssl.h" HAVE_SSL_CTX_SET_CLIENT_HELLO_CB)
 check_symbol_exists(SSL_CTX_set_select_certificate_cb "openssl/ssl.h" HAVE_SSL_CTX_SET_SELECT_CERTIFICATE_CB)
 check_symbol_exists(SSL_set1_verify_cert_store "openssl/ssl.h" TS_HAS_VERIFY_CERT_STORE)

--- a/include/iocore/net/SSLMultiCertConfigLoader.h
+++ b/include/iocore/net/SSLMultiCertConfigLoader.h
@@ -51,7 +51,7 @@ public:
   SSLMultiCertConfigLoader(const SSLConfigParams *p) : _params(p) {}
   virtual ~SSLMultiCertConfigLoader(){};
 
-  swoc::Errata load(SSLCertLookup *lookup);
+  swoc::Errata load(SSLCertLookup *lookup, int nthreads);
 
   virtual SSL_CTX *default_server_ssl_ctx();
 
@@ -74,18 +74,18 @@ public:
   static int  check_server_cert_now(X509 *cert, const char *certname);
   static void clear_pw_references(SSL_CTX *ssl_ctx);
 
-  bool update_ssl_ctx(const std::string &secret_name);
+  bool update_ssl_ctx(const std::string &secret_name, int nthreads);
 
 protected:
   const SSLConfigParams *_params;
 
   bool _store_single_ssl_ctx(SSLCertLookup *lookup, const shared_SSLMultiCertConfigParams &sslMultCertSettings, shared_SSL_CTX ctx,
-                             SSLCertContextType ctx_type, std::set<std::string> &names);
+                             SSLCertContextType ctx_type, std::set<std::string> &names, int threadIndex);
 
 private:
   virtual const char   *_debug_tag() const;
   virtual const DbgCtl &_dbg_ctl() const;
-  virtual bool          _store_ssl_ctx(SSLCertLookup *lookup, const shared_SSLMultiCertConfigParams &ssl_multi_cert_params);
+  virtual bool _store_ssl_ctx(SSLCertLookup *lookup, const shared_SSLMultiCertConfigParams &ssl_multi_cert_params, int nthreads);
   bool _prep_ssl_ctx(const shared_SSLMultiCertConfigParams &sslMultCertSettings, SSLMultiCertConfigLoader::CertLoadData &data,
                      std::set<std::string> &common_names, std::unordered_map<int, std::set<std::string>> &unique_names);
   virtual void _set_handshake_callbacks(SSL_CTX *ctx);

--- a/include/tscore/ink_config.h.cmake.in
+++ b/include/tscore/ink_config.h.cmake.in
@@ -171,6 +171,7 @@ const int DEFAULT_STACKSIZE = @DEFAULT_STACK_SIZE@;
 // TODO(cmcfarlen): Verify use of below in iocore/net/SSLNetVConnection (redunant)
 #cmakedefine01 HAVE_SSL_READ_EARLY_DATA
 #cmakedefine HAVE_SSL_SET_MAX_EARLY_DATA
+#cmakedefine01 HAVE_SSL_CTX_NEW_EX
 #cmakedefine01 HAVE_SSL_CTX_SET_CLIENT_HELLO_CB
 #cmakedefine01 HAVE_SSL_CTX_SET_SELECT_CERTIFICATE_CB
 #cmakedefine01 HAVE_SSL_GET_SHARED_CURVE

--- a/src/iocore/net/P_SSLConfig.h
+++ b/src/iocore/net/P_SSLConfig.h
@@ -111,7 +111,8 @@ struct SSLConfigParams : public ConfigInfo {
 
   char *keylog_file;
 
-  static bool ssl_ktls_enabled;
+  static bool   ssl_ktls_enabled;
+  static size_t number_of_ssl_threads;
 
   static uint32_t server_max_early_data;
   static uint32_t server_recv_max_early_data;

--- a/src/iocore/net/QUICMultiCertConfigLoader.cc
+++ b/src/iocore/net/QUICMultiCertConfigLoader.cc
@@ -41,10 +41,10 @@ void
 QUICCertConfig::reconfigure()
 {
   SSLConfig::scoped_config params;
-  SSLCertLookup           *lookup = new SSLCertLookup();
+  SSLCertLookup           *lookup = new SSLCertLookup(SSLConfigParams::number_of_ssl_threads);
 
   QUICMultiCertConfigLoader loader(params);
-  loader.load(lookup);
+  loader.load(lookup, SSLConfigParams::number_of_ssl_threads);
 
   _config_id = configProcessor.set(_config_id, lookup);
 }

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -70,6 +70,7 @@ init_ssl_ctx_func  SSLConfigParams::init_ssl_ctx_cb                       = null
 load_ssl_file_func SSLConfigParams::load_ssl_file_cb                      = nullptr;
 swoc::IPRangeSet  *SSLConfigParams::proxy_protocol_ip_addrs               = nullptr;
 bool               SSLConfigParams::ssl_ktls_enabled                      = false;
+size_t             SSLConfigParams::number_of_ssl_threads                 = 0;
 
 const uint32_t EARLY_DATA_DEFAULT_SIZE                         = 16384;
 uint32_t       SSLConfigParams::server_max_early_data          = 0;
@@ -678,7 +679,11 @@ SSLCertificateConfig::reconfigure()
 {
   bool                     retStatus = true;
   SSLConfig::scoped_config params;
-  SSLCertLookup           *lookup = new SSLCertLookup();
+
+  // If this assert fails, the call to update this has to be moved earlier in the
+  // main() function.
+  ink_release_assert(SSLConfigParams::number_of_ssl_threads > 0);
+  SSLCertLookup *lookup = new SSLCertLookup(SSLConfigParams::number_of_ssl_threads);
 
   // Test SSL certificate loading startup. With large numbers of certificates, reloading can take time, so delay
   // twice the healthcheck period to simulate a loading a large certificate set.
@@ -688,7 +693,7 @@ SSLCertificateConfig::reconfigure()
     ink_hrtime_sleep(HRTIME_SECONDS(secs));
   }
 
-  auto errata = SSLMultiCertConfigLoader(params).load(lookup);
+  auto errata = SSLMultiCertConfigLoader(params).load(lookup, SSLConfigParams::number_of_ssl_threads);
   if (!lookup->is_valid || (errata.has_severity() && errata.severity() >= ERRATA_ERROR)) {
     retStatus = false;
   }
@@ -902,7 +907,10 @@ SSLConfigParams::updateCTX(const std::string &cert_secret_name) const
 
   // Update the server cert
   SSLMultiCertConfigLoader loader(this);
-  loader.update_ssl_ctx(cert_secret_name);
+  // If this assert fails, the call to update this has to be moved earlier in the
+  // main() function.
+  ink_release_assert(SSLConfigParams::number_of_ssl_threads > 0);
+  loader.update_ssl_ctx(cert_secret_name, SSLConfigParams::number_of_ssl_threads);
 
   secret_for_updateCTX = nullptr;
 }

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2061,6 +2061,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   num_of_net_threads = ink_number_of_processors();
   Dbg(dbg_ctl_threads, "number of processors: %d", num_of_net_threads);
   num_of_net_threads = adjust_num_of_net_threads(num_of_net_threads);
+  Dbg(dbg_ctl_threads, "number of net threads: %d", num_of_net_threads);
+  SSLConfigParams::number_of_ssl_threads = num_of_net_threads;
 
   size_t stacksize;
   stacksize = RecGetRecordInt("proxy.config.thread.default.stacksize").value_or(0);

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -48,7 +48,7 @@ ports.get_port(ts, 's_server_port')
 ts.Disk.records_config.update(
     {
         'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'cert_update',
+        'proxy.config.diags.debug.tags': 'ssl.cert_update|cert_update',
         'proxy.config.ssl.server.cert.path': '{0}'.format(ts.Variables.SSLDir),
         'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
         'proxy.config.ssl.client.cert.path': '{0}'.format(ts.Variables.SSLDir),


### PR DESCRIPTION
This should reduce lock contention by making a single libctx per thread, rather than sharing an SSL_CTX across all threads.