### PR TITLE
autest updates for recent curl and nghttp2 versions (#12165)

### DIFF
--- a/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
@@ -71,7 +71,7 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(delay_server)
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("RST_STREAM", "Delayed chunk close should not cause reset")
-tr.Processes.Default.Streams.All += Testers.ExcludesExpression("content-length", "Should return chunked")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("< content-length", "Should return chunked")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(":status: 200", "Should get successful response")
 tr.StillRunningAfter = ts
 # No resets in the output
@@ -85,7 +85,7 @@ tr.Processes.Default.Command = 'curl --http2 -k https://127.0.0.1:{}/post-full -
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 200", "Request should succeed")
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("content-length:", "Response should include content length")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("< content-length:", "Response should include content length")
 server2_out = Testers.ContainsExpression("Transfer-Encoding: chunked", "Request should be chunked encoded")
 # No content-length in header
 # Transfer encoding to origin, but no content-length
@@ -99,7 +99,7 @@ tr.Processes.Default.Command = 'curl --http2 -k https://127.0.0.1:{}/post-chunke
     ts.Variables.ssl_port)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 200", "Request should succeed")
-tr.Processes.Default.Streams.All += Testers.ExcludesExpression("content-length:", "Response should not include content length")
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression("< content-length:", "Response should not include content length")
 server3_out = Testers.ContainsExpression("Transfer-Encoding: chunked", "Request should be chunked encoded")
 # No content length in header
 # Transfer encoding to origin, but no content-length

--- a/tests/gold_tests/connect/connect.test.py
+++ b/tests/gold_tests/connect/connect.test.py
@@ -87,6 +87,8 @@ logging:
         tr.Processes.Default.Command = f"curl -v --fail -s -p -x 127.0.0.1:{self.ts.Variables.port} 'http://foo.com/get'"
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stderr = "gold/connect_0_stderr.gold"
+        tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
+            f'Connected to 127.0.0.1.*{self.ts.Variables.port}', 'Curl should connect through the ATS proxy port.')
         tr.Processes.Default.TimeOut = 3
         self.__checkProcessAfter(tr)
 

--- a/tests/gold_tests/connect/gold/connect_0_stderr.gold
+++ b/tests/gold_tests/connect/gold/connect_0_stderr.gold
@@ -1,6 +1,4 @@
 ``
-* Connected to `` (127.0.0.1) port ``
-``
 * Establish HTTP proxy tunnel to foo.com:80
 > CONNECT foo.com:80 HTTP/1.1
 > Host: foo.com:80

--- a/tests/gold_tests/pluginTest/compress/compress.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress.test.py
@@ -261,8 +261,8 @@ tr.Processes.Default.Command = get_verify_command(out_path, "gunzip -k")
 tr = Test.AddTestRun()
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Command = (
-    r"tr -d '\r' < compress_long.log | sed 's/\(..*\)\([<>]\)/\1\n\2/' | {0}/greplog.sh > compress_short.log").format(
-        Test.TestDirectory)
+    r"tr -d '\r' < compress_long.log | sed 's/\(..*\)\([<>]\)/\1\n\2/' | {0}/greplog.sh > compress_short.log".format(
+        Test.TestDirectory))
 f = tr.Disk.File("compress_short.log")
 f.Content = "compress.gold"
 

--- a/tests/gold_tests/pluginTest/compress/greplog.sh
+++ b/tests/gold_tests/pluginTest/compress/greplog.sh
@@ -15,7 +15,9 @@
 #  limitations under the License.
 
 grep --text \
- -e 'HTTP/' \
+ -e '< HTTP/' \
+ -e '> GET' \
+ -e '> POST' \
  -e '^> X-Ats-Compress-Test:' \
  -e '^> Accept-Encoding:' \
  -e '^< Content-' \

--- a/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.test.py
+++ b/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.test.py
@@ -60,6 +60,8 @@ tr.Processes.Default.Command = (
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.Processes.Default.Command = "grep -F HTTP/ curl.txt"
+# Later versions of curl add a "using HTTP" line to the output, so we filter it
+# out to keep this test compatible with old and new versions.
+tr.Processes.Default.Command = "grep -F HTTP/ curl.txt | grep -v 'using HTTP'"
 tr.Processes.Default.Streams.stdout = "curl.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo.test.py
@@ -71,9 +71,11 @@ Test.Env["OUTPUT_FILE"] = log_path
 # ----
 
 # H2 SETTINGS, PRIORITY, HEADERS, CONTINUATION, DATA, GOAWAY
-tr = Test.AddTestRun()
+tr = Test.AddTestRun('HTTP/2 Test')
 tr.TimeOut = 10
-tr.Processes.Default.Command = f"nghttp -vn --continuation 'https://localhost:{ts.Variables.ssl_port}/httpbin/post' -d 'post_body'"
+# grep out the continuation lines because that significantly reduces the output
+# size which exponentially reduces the gold file processing time.
+tr.Processes.Default.Command = f"nghttp -vn --continuation 'https://localhost:{ts.Variables.ssl_port}/httpbin/post' -d 'post_body' | grep -v 'continuation-test'"
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -83,7 +85,7 @@ tr.StillRunningAfter = ts
 
 # H3
 if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
-    tr = Test.AddTestRun()
+    tr = Test.AddTestRun('HTTP/3 Test')
     tr.TimeOut = 10
     tr.Processes.Default.Command = f"curl -k --http3 'https://localhost:{ts.Variables.ssl_port}/httpbin/post' -d 'post_body'"
     tr.Processes.Default.ReturnCode = 0
@@ -91,13 +93,13 @@ if Condition.HasATSFeature('TS_USE_QUIC') and Condition.HasCurlFeature('http3'):
     tr.StillRunningAfter = httpbin
     tr.StillRunningAfter = ts
 
-tr = Test.AddTestRun()
+tr = Test.AddTestRun('Check the log output')
 tr.Processes.Default.Command = "echo check log"
 tr.Processes.Default.ReturnCode = 0
 f = tr.Disk.File(log_path)
 f.Content = "test_TSHttpSsnInfo_plugin_log.gold"
 f.Content += Testers.ContainsExpression(
-    "H2 Frames Received:D1,H1,PR5,RS0,S2,PP0,P0,G1,WU0,C1,U0", "Expected numbers of frames should be received")
+    "H2 Frames Received:D1,H1,PR.,RS0,S2,PP0,P0,G1,WU0,C1,U0", "Expected numbers of frames should be received")
 # We cannot test this on H3 now because the test plugin does not work on H3 sessions
 # f.Content += Testers.ContainsExpression("H3 Frames Received:D1,H1,Ra0,CP0,S1,PP0,Rb0,G0,Rc0,Rd0,UND0,UND0,UND0,MPI0,U0",
 #                                        "Expected numbers of frames should be received")

--- a/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo_nghttp0.gold
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo_nghttp0.gold
@@ -1,21 +1,11 @@
 ``
-[``] send PRIORITY frame <length=5, flags=0x00, stream_id=3>
-          (dep_stream_id=0, weight=201, exclusive=0)
-[``] send PRIORITY frame <length=5, flags=0x00, stream_id=5>
-          (dep_stream_id=0, weight=101, exclusive=0)
-[``] send PRIORITY frame <length=5, flags=0x00, stream_id=7>
-          (dep_stream_id=0, weight=1, exclusive=0)
-[``] send PRIORITY frame <length=5, flags=0x00, stream_id=9>
-          (dep_stream_id=7, weight=1, exclusive=0)
-[``] send PRIORITY frame <length=5, flags=0x00, stream_id=11>
-          (dep_stream_id=3, weight=1, exclusive=0)
-[``] send HEADERS frame <length=``, flags=0x24, stream_id=13>
-          ; END_HEADERS | PRIORITY
+[``] send HEADERS frame <length=``, flags=0x``, stream_id=``>
+          ; END_HEADER``
 ``
-[``] send DATA frame <length=``, flags=0x01, stream_id=13>
+[``] send DATA frame <length=``, flags=0x``, stream_id=``>
 ``; END_STREAM
 ``
-[``] recv (stream_id=13) :status: 431
+[``] recv (stream_id=``) :status: 431
 ``
 ``; END_STREAM
 ``

--- a/tests/gold_tests/redirect/number_of_redirects.test.py
+++ b/tests/gold_tests/redirect/number_of_redirects.test.py
@@ -83,8 +83,7 @@ class NumberOfRedirectionsTest:
         self._tr.Processes.Default.StartBefore(self._srv3)
         self._tr.Processes.Default.StartBefore(self._dns)
         self._tr.Processes.Default.StartBefore(self._ts)
-        self._tr.Command = "curl -L -vvv a.test/ping --proxy 127.0.0.1:{0} -H 'uuid: redirect_test_1'".format(
-            self._ts.Variables.port)
+        self._tr.Command = "curl -L -v a.test/ping --proxy 127.0.0.1:{0} -H 'uuid: redirect_test_1'".format(self._ts.Variables.port)
         self._tr.Processes.Default.Streams.All = f"gold/number_of_redirections_{self._numberOfRedirections}.gold"
         self._tr.ReturnCode = 0
         self._tr.StillRunningAfter = self._ts


### PR DESCRIPTION
* number_of_redirects.test.py: curl verbosity change

Change curl verbosity of number_of_redirects.test.py to -v from -vvv since in later versions of curl, the output of -vvv no longer matches the gold file.

* chunked_encoding_h2: make content-length search specific

Later versions of nghttp2 now include content-length headers in the request generated by chunked_encoding_h2. Therefore the search strings for the responses have to be more specific to look in server responses only otherwise they see the content-length in the request and incorrectly fail.

* compress.test.py: update for recent curl output

Recent versions of curl add a 'using HTTP/2' string to the output that the compress.test.py test has to filter out.

* connect.test.py: accommodate curl output order changes

Recent versions of curl switch the order of the "Connected to" CONNECT information with respect to the rest of the verbose output content. This updates the test expectations to accommodate that.

* cripts autests updates

This allows the cripts.test.py file to work in generic environments rather than just those that install into /tmp/ats.

* polite_hook_wait.test.py: update for recent curl output

Update the polite_hook_wait.test.py so that it can handle recent curl output that adds a 'using HTTP/1.x' or similar strings to the output.

* test_TSHttpSsnInfo.test.py: accommodate nghttp

The latest version of nghttp2 has different output that the test_TSHttpSsnInfo.test.py gold file has to be updated to accommodate. This updates it so that it can work for newer and older versions of the tool.

(cherry picked from commit 73670a3c6cf83c3eb01b9d62e15e37b3698075f7)